### PR TITLE
fix: wrong package name on `vize` (CLI)

### DIFF
--- a/npm/vite-plugin-vize/example/package.json
+++ b/npm/vite-plugin-vize/example/package.json
@@ -13,7 +13,7 @@
   "devDependencies": {
     "vite": "^8.0.0-beta.0",
     "@vizejs/vite-plugin": "workspace:*",
-    "vizejs": "workspace:*",
+    "vize": "workspace:*",
     "vite-plugin-inspect": "^11.0.1",
     "typescript": "^5.8.3"
   }

--- a/npm/vite-plugin-vize/package.json
+++ b/npm/vite-plugin-vize/package.json
@@ -52,7 +52,7 @@
   },
   "dependencies": {
     "@vizejs/native": "workspace:*",
-    "vizejs": "workspace:*",
+    "vize": "workspace:*",
     "tinyglobby": "^0.2.0"
   }
 }

--- a/npm/vite-plugin-vize/src/index.ts
+++ b/npm/vite-plugin-vize/src/index.ts
@@ -11,8 +11,8 @@ import { detectHmrUpdateType, type HmrUpdateType } from "./hmr.js";
 export type { VizeOptions, CompiledModule };
 
 // Re-export config utilities from vizejs
-export { defineConfig, loadConfig } from "vizejs";
-export type { VizeConfig, LoadConfigOptions } from "vizejs";
+export { defineConfig, loadConfig } from "vize";
+export type { VizeConfig, LoadConfigOptions } from "vize";
 
 const VIRTUAL_PREFIX = "\0vize:";
 const VIRTUAL_CSS_MODULE = "virtual:vize-styles";
@@ -156,7 +156,7 @@ export function vize(options: VizeOptions = {}): Plugin {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       let fileConfig: any = null;
       if (options.configMode !== false) {
-        const { loadConfig } = await import("vizejs");
+        const { loadConfig } = await import("vize");
         fileConfig = await loadConfig(root, {
           mode: options.configMode ?? "root",
           configFile: options.configFile,

--- a/npm/vize/package.json
+++ b/npm/vize/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "vizejs",
+  "name": "vize",
   "version": "0.0.1-alpha.50",
   "description": "Vize - High-performance Vue.js toolchain in Rust",
   "publishConfig": {


### PR DESCRIPTION
CLI は `vizejs` ではなく https://www.npmjs.com/package/vize で公開されていそうなので、パッケージ名をそちらに合わせました。