### PR TITLE
feat(croquis): use Croquis as compiler infrastructure with ReactivityTracker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3001,7 +3001,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vize"
-version = "0.0.1-alpha.77"
+version = "0.0.1-alpha.78"
 dependencies = [
  "clap",
  "dirs",
@@ -3036,7 +3036,7 @@ dependencies = [
 
 [[package]]
 name = "vize_armature"
-version = "0.0.1-alpha.77"
+version = "0.0.1-alpha.78"
 dependencies = [
  "compact_str",
  "serde",
@@ -3047,7 +3047,7 @@ dependencies = [
 
 [[package]]
 name = "vize_atelier_core"
-version = "0.0.1-alpha.77"
+version = "0.0.1-alpha.78"
 dependencies = [
  "bumpalo",
  "compact_str",
@@ -3073,7 +3073,7 @@ dependencies = [
 
 [[package]]
 name = "vize_atelier_dom"
-version = "0.0.1-alpha.77"
+version = "0.0.1-alpha.78"
 dependencies = [
  "insta",
  "phf",
@@ -3081,11 +3081,12 @@ dependencies = [
  "thiserror 2.0.18",
  "vize_atelier_core",
  "vize_carton",
+ "vize_croquis",
 ]
 
 [[package]]
 name = "vize_atelier_sfc"
-version = "0.0.1-alpha.77"
+version = "0.0.1-alpha.78"
 dependencies = [
  "criterion",
  "insta",
@@ -3113,7 +3114,7 @@ dependencies = [
 
 [[package]]
 name = "vize_atelier_ssr"
-version = "0.0.1-alpha.77"
+version = "0.0.1-alpha.78"
 dependencies = [
  "insta",
  "serde",
@@ -3125,7 +3126,7 @@ dependencies = [
 
 [[package]]
 name = "vize_atelier_vapor"
-version = "0.0.1-alpha.77"
+version = "0.0.1-alpha.78"
 dependencies = [
  "insta",
  "serde",
@@ -3136,7 +3137,7 @@ dependencies = [
 
 [[package]]
 name = "vize_canon"
-version = "0.0.1-alpha.77"
+version = "0.0.1-alpha.78"
 dependencies = [
  "dashmap 6.1.0",
  "dirs",
@@ -3164,7 +3165,7 @@ dependencies = [
 
 [[package]]
 name = "vize_carton"
-version = "0.0.1-alpha.77"
+version = "0.0.1-alpha.78"
 dependencies = [
  "bitflags 2.10.0",
  "bumpalo",
@@ -3180,7 +3181,7 @@ dependencies = [
 
 [[package]]
 name = "vize_croquis"
-version = "0.0.1-alpha.77"
+version = "0.0.1-alpha.78"
 dependencies = [
  "dashmap 6.1.0",
  "insta",
@@ -3202,7 +3203,7 @@ dependencies = [
 
 [[package]]
 name = "vize_fresco"
-version = "0.0.1-alpha.77"
+version = "0.0.1-alpha.78"
 dependencies = [
  "compact_str",
  "criterion",
@@ -3224,7 +3225,7 @@ dependencies = [
 
 [[package]]
 name = "vize_glyph"
-version = "0.0.1-alpha.77"
+version = "0.0.1-alpha.78"
 dependencies = [
  "criterion",
  "memchr",
@@ -3241,7 +3242,7 @@ dependencies = [
 
 [[package]]
 name = "vize_maestro"
-version = "0.0.1-alpha.77"
+version = "0.0.1-alpha.78"
 dependencies = [
  "async-trait",
  "dashmap 6.1.0",
@@ -3267,7 +3268,7 @@ dependencies = [
 
 [[package]]
 name = "vize_musea"
-version = "0.0.1-alpha.77"
+version = "0.0.1-alpha.78"
 dependencies = [
  "criterion",
  "insta",
@@ -3282,7 +3283,7 @@ dependencies = [
 
 [[package]]
 name = "vize_patina"
-version = "0.0.1-alpha.77"
+version = "0.0.1-alpha.78"
 dependencies = [
  "criterion",
  "insta",
@@ -3305,7 +3306,7 @@ dependencies = [
 
 [[package]]
 name = "vize_relief"
-version = "0.0.1-alpha.77"
+version = "0.0.1-alpha.78"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
@@ -3314,7 +3315,7 @@ dependencies = [
 
 [[package]]
 name = "vize_test_runner"
-version = "0.0.1-alpha.77"
+version = "0.0.1-alpha.78"
 dependencies = [
  "serde",
  "toml",
@@ -3326,7 +3327,7 @@ dependencies = [
 
 [[package]]
 name = "vize_vitrine"
-version = "0.0.1-alpha.77"
+version = "0.0.1-alpha.78"
 dependencies = [
  "getrandom 0.3.4",
  "glob",

--- a/crates/vize_atelier_core/src/test_macros.rs
+++ b/crates/vize_atelier_core/src/test_macros.rs
@@ -209,7 +209,7 @@ macro_rules! assert_transform {
         let allocator = bumpalo::Bump::new();
         let (mut root, errors) = $crate::parser::parse(&allocator, $input);
         assert!(errors.is_empty(), "Parse errors: {:?}", errors);
-        $crate::transform::transform(&allocator, &mut root, $crate::options::TransformOptions::default());
+        $crate::transform::transform(&allocator, &mut root, $crate::options::TransformOptions::default(), None);
         assert!(root.transformed, "Expected root to be transformed");
         $(
             assert!(
@@ -223,7 +223,7 @@ macro_rules! assert_transform {
         let allocator = bumpalo::Bump::new();
         let (mut root, errors) = $crate::parser::parse(&allocator, $input);
         assert!(errors.is_empty(), "Parse errors: {:?}", errors);
-        $crate::transform::transform(&allocator, &mut root, $crate::options::TransformOptions::default());
+        $crate::transform::transform(&allocator, &mut root, $crate::options::TransformOptions::default(), None);
         $(
             assert!(
                 root.components.iter().any(|c| c.as_str() == $comp),
@@ -271,7 +271,7 @@ macro_rules! assert_codegen {
         let allocator = bumpalo::Bump::new();
         let (mut root, errors) = $crate::parser::parse(&allocator, $input);
         assert!(errors.is_empty(), "Parse errors: {:?}", errors);
-        $crate::transform::transform(&allocator, &mut root, $crate::options::TransformOptions::default());
+        $crate::transform::transform(&allocator, &mut root, $crate::options::TransformOptions::default(), None);
         let result = $crate::codegen::generate(&root, $crate::options::CodegenOptions::default());
         $(
             assert!(
@@ -286,7 +286,7 @@ macro_rules! assert_codegen {
         let allocator = bumpalo::Bump::new();
         let (mut root, errors) = $crate::parser::parse(&allocator, $input);
         assert!(errors.is_empty(), "Parse errors: {:?}", errors);
-        $crate::transform::transform(&allocator, &mut root, $crate::options::TransformOptions::default());
+        $crate::transform::transform(&allocator, &mut root, $crate::options::TransformOptions::default(), None);
         let result = $crate::codegen::generate(&root, $crate::options::CodegenOptions::default());
         assert!(
             result.code.contains($pattern),
@@ -307,6 +307,7 @@ macro_rules! compile {
             &allocator,
             &mut root,
             $crate::options::TransformOptions::default(),
+            None,
         );
         $crate::codegen::generate(&root, $crate::options::CodegenOptions::default())
     }};
@@ -319,6 +320,7 @@ macro_rules! compile {
             &allocator,
             &mut root,
             $crate::options::TransformOptions::default(),
+            None,
         );
         $crate::codegen::generate(&root, $options)
     }};

--- a/crates/vize_atelier_core/src/transform/context.rs
+++ b/crates/vize_atelier_core/src/transform/context.rs
@@ -1,6 +1,7 @@
 //! TransformContext implementation.
 
 use vize_carton::{Box, Bump, CompactString, String};
+use vize_croquis::reactivity::ReactiveKind;
 use vize_croquis::{BindingType, Croquis, ScopeBinding, ScopeKind, VForScopeData};
 
 use crate::ast::*;
@@ -157,6 +158,21 @@ impl<'a> TransformContext<'a> {
                 Some(BindingType::Props | BindingType::PropsAliased)
             )
         }
+    }
+
+    /// Get the ReactiveKind for a name (from Croquis ReactivityTracker)
+    pub fn get_reactive_kind(&self, name: &str) -> Option<ReactiveKind> {
+        self.analysis?.reactivity.lookup(name).map(|s| s.kind)
+    }
+
+    /// Check if a binding is read-only (Computed, Readonly, ShallowReadonly)
+    pub fn is_readonly_binding(&self, name: &str) -> bool {
+        self.get_reactive_kind(name).is_some_and(|k| {
+            matches!(
+                k,
+                ReactiveKind::Computed | ReactiveKind::Readonly | ReactiveKind::ShallowReadonly
+            )
+        })
     }
 
     /// Check if a component is registered (from analysis or binding metadata)

--- a/crates/vize_atelier_dom/Cargo.toml
+++ b/crates/vize_atelier_dom/Cargo.toml
@@ -9,6 +9,7 @@ description = "Atelier DOM - The DOM compiler workshop for Vize"
 [dependencies]
 vize_carton = { workspace = true }
 vize_atelier_core = { workspace = true }
+vize_croquis = { workspace = true }
 
 phf = { workspace = true }
 serde = { workspace = true }

--- a/crates/vize_atelier_dom/src/options.rs
+++ b/crates/vize_atelier_dom/src/options.rs
@@ -1,11 +1,12 @@
 //! DOM compiler options.
 
 use serde::{Deserialize, Serialize};
-use vize_atelier_core::options::CodegenMode;
-use vize_carton::{FxHashMap, String};
+use vize_atelier_core::options::{BindingMetadata, CodegenMode};
+use vize_carton::String;
+use vize_croquis::Croquis;
 
 /// DOM compiler options
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct DomCompilerOptions {
     /// Output mode: function or module
@@ -45,12 +46,36 @@ pub struct DomCompilerOptions {
     pub inline: bool,
 
     /// Binding metadata from script setup
-    #[serde(default)]
-    pub binding_metadata: Option<BindingMetadataMap>,
+    #[serde(skip)]
+    pub binding_metadata: Option<BindingMetadata>,
 
     /// Whether is TypeScript
     #[serde(default)]
     pub is_ts: bool,
+
+    /// Semantic analysis data from Croquis (optional, enhances transforms)
+    #[serde(skip)]
+    pub croquis: Option<Box<Croquis>>,
+}
+
+impl Clone for DomCompilerOptions {
+    fn clone(&self) -> Self {
+        Self {
+            mode: self.mode,
+            prefix_identifiers: self.prefix_identifiers,
+            hoist_static: self.hoist_static,
+            cache_handlers: self.cache_handlers,
+            scope_id: self.scope_id.clone(),
+            ssr: self.ssr,
+            source_map: self.source_map,
+            comments: self.comments,
+            inline: self.inline,
+            binding_metadata: self.binding_metadata.clone(),
+            is_ts: self.is_ts,
+            // Croquis is not cloneable; it will be consumed when passed to the compiler
+            croquis: None,
+        }
+    }
 }
 
 impl Default for DomCompilerOptions {
@@ -67,15 +92,9 @@ impl Default for DomCompilerOptions {
             inline: false,
             binding_metadata: None,
             is_ts: false,
+            croquis: None,
         }
     }
-}
-
-/// Binding metadata map from script setup
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(transparent)]
-pub struct BindingMetadataMap {
-    pub bindings: FxHashMap<String, String>,
 }
 
 /// DOM-specific element checks

--- a/crates/vize_atelier_sfc/src/compile.rs
+++ b/crates/vize_atelier_sfc/src/compile.rs
@@ -80,7 +80,7 @@ pub fn compile_sfc(
         dom_opts.hoist_static = true;
         template_opts.compiler_options = Some(dom_opts);
         let template_result =
-            compile_template_block(template, &template_opts, &scope_id, has_scoped, is_ts, None);
+            compile_template_block(template, &template_opts, &scope_id, has_scoped, is_ts, None, None);
 
         match template_result {
             Ok(template_code) => {
@@ -142,6 +142,7 @@ pub fn compile_sfc(
                 has_scoped,
                 is_ts,
                 None, // No bindings for normal scripts
+                None, // No Croquis for normal scripts
             );
 
             match template_result {
@@ -240,6 +241,9 @@ pub fn compile_sfc(
     ctx.analyze();
     let mut script_bindings = ctx.bindings.clone();
 
+    // Generate Croquis from the already-analyzed context (no additional OXC parse)
+    let croquis = ctx.to_analysis_summary();
+
     // Also register exported bindings from normal script (e.g., export const n = 1)
     // These are accessible in the template without _ctx. prefix
     if has_script {
@@ -284,6 +288,7 @@ pub fn compile_sfc(
                 has_scoped,
                 is_ts,
                 Some(&script_bindings), // Pass bindings for proper ref handling
+                Some(croquis),          // Pass Croquis for enhanced transforms
             ))
         }
     } else {

--- a/crates/vize_atelier_sfc/src/compile.rs
+++ b/crates/vize_atelier_sfc/src/compile.rs
@@ -79,8 +79,15 @@ pub fn compile_sfc(
         let mut dom_opts = template_opts.compiler_options.take().unwrap_or_default();
         dom_opts.hoist_static = true;
         template_opts.compiler_options = Some(dom_opts);
-        let template_result =
-            compile_template_block(template, &template_opts, &scope_id, has_scoped, is_ts, None, None);
+        let template_result = compile_template_block(
+            template,
+            &template_opts,
+            &scope_id,
+            has_scoped,
+            is_ts,
+            None,
+            None,
+        );
 
         match template_result {
             Ok(template_code) => {
@@ -249,10 +256,7 @@ pub fn compile_sfc(
     //    Croquis can't resolve interface references, so we take Props from the legacy analyzer
     for (name, bt) in &ctx.bindings.bindings {
         if matches!(bt, BindingType::Props | BindingType::PropsAliased) {
-            script_bindings
-                .bindings
-                .entry(name.clone())
-                .or_insert(*bt);
+            script_bindings.bindings.entry(name.clone()).or_insert(*bt);
         }
     }
 
@@ -554,17 +558,14 @@ fn extract_normal_script_content(content: &str, source_is_ts: bool, output_is_ts
 }
 
 /// Convert Croquis BindingMetadata (CompactString keys) to legacy BindingMetadata (String keys)
-fn croquis_to_legacy_bindings(
-    src: &vize_croquis::analysis::BindingMetadata,
-) -> BindingMetadata {
+fn croquis_to_legacy_bindings(src: &vize_croquis::analysis::BindingMetadata) -> BindingMetadata {
     let mut dst = BindingMetadata::default();
     dst.is_script_setup = src.is_script_setup;
     for (name, bt) in src.iter() {
         dst.bindings.insert(name.to_string(), bt);
     }
     for (local, key) in &src.props_aliases {
-        dst.props_aliases
-            .insert(local.to_string(), key.to_string());
+        dst.props_aliases.insert(local.to_string(), key.to_string());
     }
     dst
 }

--- a/crates/vize_atelier_sfc/src/script/context.rs
+++ b/crates/vize_atelier_sfc/src/script/context.rs
@@ -95,6 +95,8 @@ impl ScriptCompileContext {
         let source = std::mem::take(&mut self.source);
         self.parse_with_oxc(&source);
         self.source = source;
+        // ScriptCompileContext is always used for <script setup>
+        self.bindings.is_script_setup = true;
     }
 
     /// Convert to an Croquis for use in transforms and linting.

--- a/crates/vize_atelier_ssr/src/lib.rs
+++ b/crates/vize_atelier_ssr/src/lib.rs
@@ -85,7 +85,7 @@ pub fn compile_ssr_with_options<'a>(
         inline: options.inline,
         ..Default::default()
     };
-    do_transform(allocator, &mut root, transform_opts);
+    do_transform(allocator, &mut root, transform_opts, None);
 
     // SSR codegen
     let codegen_ctx = SsrCodegenContext::new(allocator, &options);

--- a/crates/vize_atelier_vapor/src/lib.rs
+++ b/crates/vize_atelier_vapor/src/lib.rs
@@ -74,7 +74,7 @@ pub fn compile_vapor<'a>(
         inline: options.inline,
         ..Default::default()
     };
-    transform(allocator, &mut root, transform_opts);
+    transform(allocator, &mut root, transform_opts, None);
 
     // Transform to Vapor IR
     let ir = transform_to_ir(allocator, &root);

--- a/crates/vize_croquis/src/analyzer/snapshots/vize_croquis__analyzer__tests__full_analysis_snapshot.snap
+++ b/crates/vize_croquis/src/analyzer/snapshots/vize_croquis__analyzer__tests__full_analysis_snapshot.snap
@@ -1,18 +1,19 @@
 ---
 source: crates/vize_croquis/src/analyzer/mod.rs
+assertion_line: 487
 expression: output
 ---
 === Bindings ===
-  model: SetupConst
+  model: SetupRef
   emit: SetupConst
   count: Props
   theme: SetupConst
-  props: SetupConst
-  provide: SetupConst
-  inject: SetupConst
+  props: SetupReactiveConst
+  provide: SetupMaybeRef
+  inject: SetupMaybeRef
   msg: Props
-  computed: SetupConst
-  ref: SetupConst
+  computed: SetupMaybeRef
+  ref: SetupMaybeRef
   MyComponent: SetupConst
   doubled: SetupRef
   increment: SetupConst
@@ -24,6 +25,7 @@ expression: output
   models: 1
 
 === Reactivity ===
+  model: kind=Ref, needs_value=true
   counter: kind=Ref, needs_value=true
   doubled: kind=Computed, needs_value=true
 

--- a/crates/vize_croquis/src/script_parser/extract.rs
+++ b/crates/vize_croquis/src/script_parser/extract.rs
@@ -43,10 +43,7 @@ pub fn process_call_expression(
         _ => return None,
     };
 
-    let macro_kind = match MacroKind::from_name(callee_name) {
-        Some(kind) => kind,
-        None => return None,
-    };
+    let macro_kind = MacroKind::from_name(callee_name)?;
 
     let span = call.span;
 
@@ -309,7 +306,10 @@ pub fn detect_reactivity_call(
         "toRefs" => Some((ReactiveKind::ToRefs, BindingType::SetupRef)),
         "customRef" => Some((ReactiveKind::Ref, BindingType::SetupRef)),
         "readonly" => Some((ReactiveKind::Readonly, BindingType::SetupReactiveConst)),
-        "shallowReadonly" => Some((ReactiveKind::ShallowReadonly, BindingType::SetupReactiveConst)),
+        "shallowReadonly" => Some((
+            ReactiveKind::ShallowReadonly,
+            BindingType::SetupReactiveConst,
+        )),
         _ => None,
     }
 }

--- a/crates/vize_croquis/src/script_parser/extract.rs
+++ b/crates/vize_croquis/src/script_parser/extract.rs
@@ -32,20 +32,20 @@ pub fn extract_call_expression<'a>(expr: &'a Expression<'a>) -> Option<&'a CallE
     }
 }
 
-/// Process a call expression, returns true if it was a macro call
+/// Process a call expression, returns the MacroKind if it was a macro call
 pub fn process_call_expression(
     result: &mut ScriptParseResult,
     call: &CallExpression<'_>,
     source: &str,
-) -> bool {
+) -> Option<MacroKind> {
     let callee_name = match &call.callee {
         Expression::Identifier(id) => id.name.as_str(),
-        _ => return false,
+        _ => return None,
     };
 
     let macro_kind = match MacroKind::from_name(callee_name) {
         Some(kind) => kind,
-        None => return false,
+        None => return None,
     };
 
     let span = call.span;
@@ -140,7 +140,7 @@ pub fn process_call_expression(
         _ => {}
     }
 
-    true
+    Some(macro_kind)
 }
 
 /// Extract props from TypeScript type parameters
@@ -305,7 +305,11 @@ pub fn detect_reactivity_call(
         "reactive" | "shallowReactive" => {
             Some((ReactiveKind::Reactive, BindingType::SetupReactiveConst))
         }
-        "toRef" | "toRefs" => Some((ReactiveKind::Ref, BindingType::SetupMaybeRef)),
+        "toRef" => Some((ReactiveKind::ToRef, BindingType::SetupRef)),
+        "toRefs" => Some((ReactiveKind::ToRefs, BindingType::SetupRef)),
+        "customRef" => Some((ReactiveKind::Ref, BindingType::SetupRef)),
+        "readonly" => Some((ReactiveKind::Readonly, BindingType::SetupReactiveConst)),
+        "shallowReadonly" => Some((ReactiveKind::ShallowReadonly, BindingType::SetupReactiveConst)),
         _ => None,
     }
 }

--- a/crates/vize_croquis/src/script_parser/snapshots/vize_croquis__script_parser__tests__parse_result_snapshot.snap
+++ b/crates/vize_croquis/src/script_parser/snapshots/vize_croquis__script_parser__tests__parse_result_snapshot.snap
@@ -3,18 +3,18 @@ source: crates/vize_croquis/src/script_parser/mod.rs
 expression: output
 ---
 === Bindings ===
-MyAlias: SetupConst
+MyAlias: SetupMaybeRef
 MyComponent: SetupConst
-computed: SetupConst
+computed: SetupMaybeRef
 count: Props
 counter: SetupRef
 doubled: SetupRef
 emit: SetupConst
 increment: SetupConst
 msg: Props
-props: SetupConst
-ref: SetupConst
-watch: SetupConst
+props: SetupReactiveConst
+ref: SetupMaybeRef
+watch: SetupMaybeRef
 
 === Macros ===
 Props count: 2

--- a/crates/vize_vitrine/src/napi.rs
+++ b/crates/vize_vitrine/src/napi.rs
@@ -50,7 +50,7 @@ pub fn compile(template: String, options: Option<CompilerOptions>) -> Result<Com
         ssr: opts.ssr.unwrap_or(false),
         ..Default::default()
     };
-    transform(&allocator, &mut root, transform_opts);
+    transform(&allocator, &mut root, transform_opts, None);
 
     // Codegen
     let codegen_opts = CodegenOptions {

--- a/tests/snapshots/sfc/ts/script_setup__defineemits_with_typed_function_signatures.snap
+++ b/tests/snapshots/sfc/ts/script_setup__defineemits_with_typed_function_signatures.snap
@@ -4,7 +4,7 @@ assertion_line: 150
 expression: ts_output
 ---
 import { defineComponent as _defineComponent } from 'vue'
-import { openBlock as _openBlock, createElementBlock as _createElementBlock, unref as _unref } from "vue"
+import { openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 
 
 export default /*@__PURE__*/_defineComponent({
@@ -15,7 +15,7 @@ export default /*@__PURE__*/_defineComponent({
 const emit = __emit
 
 return (_ctx: any,_cache: any) => {
-  return (_openBlock(), _createElementBlock("button", { onClick: _cache[0] || (_cache[0] = ($event: any) => (_unref(emit)('submit'))) }, "Submit"))
+  return (_openBlock(), _createElementBlock("button", { onClick: _cache[0] || (_cache[0] = ($event: any) => (emit('submit'))) }, "Submit"))
 }
 }
 

--- a/tests/snapshots/sfc/ts/script_setup__defineemits_with_vue_33_shorthand.snap
+++ b/tests/snapshots/sfc/ts/script_setup__defineemits_with_vue_33_shorthand.snap
@@ -4,7 +4,7 @@ assertion_line: 150
 expression: ts_output
 ---
 import { defineComponent as _defineComponent } from 'vue'
-import { openBlock as _openBlock, createElementBlock as _createElementBlock, unref as _unref } from "vue"
+import { openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 
 
 export default /*@__PURE__*/_defineComponent({
@@ -14,7 +14,7 @@ export default /*@__PURE__*/_defineComponent({
 const emit = __emit
 
 return (_ctx: any,_cache: any) => {
-  return (_openBlock(), _createElementBlock("button", { onClick: _cache[0] || (_cache[0] = ($event: any) => (_unref(emit)('submit'))) }, "Submit"))
+  return (_openBlock(), _createElementBlock("button", { onClick: _cache[0] || (_cache[0] = ($event: any) => (emit('submit'))) }, "Submit"))
 }
 }
 

--- a/tests/vize_test_runner/src/lib.rs
+++ b/tests/vize_test_runner/src/lib.rs
@@ -171,7 +171,7 @@ pub fn compile_vdom(input: &str, options: &TestOptions) -> String {
         ssr: options.ssr.unwrap_or(false),
         ..Default::default()
     };
-    transform(&allocator, &mut root, transform_opts);
+    transform(&allocator, &mut root, transform_opts, None);
 
     let codegen_opts = CodegenOptions {
         mode: CodegenMode::Module,


### PR DESCRIPTION
## Summary

- **Integrate Croquis as primary script analysis in `compile_sfc`**, replacing `ScriptCompileContext` as the main source of binding metadata. Croquis now provides `ReactivityTracker` data alongside `BindingMetadata`, enabling richer type information to flow into the template compiler.
- **Fix Croquis script_parser binding types** to match Vue's `ScriptCompileContext` semantics: named imports → `SetupMaybeRef`, `defineProps` → `SetupReactiveConst`, `defineModel` → `SetupRef`, literal constants → `LiteralConst`, and correct types for `toRef`/`toRefs`/`customRef`/`readonly`/`shallowReadonly`.
- **Leverage `ReactiveKind` in template expression transforms** (`is_ref_binding`, `needs_unref`, `is_ref_binding_simple`) to make precise `.value` / `_unref()` decisions based on actual reactivity analysis, with graceful fallback to `binding_metadata` when Croquis data is unavailable.
- **Simplify the `DomCompilerOptions` API**: `binding_metadata` is now `Option<BindingMetadata>` directly (no more `BindingMetadataMap` string conversion), and `Croquis` is arena-allocated and passed through `transform()` as `Option<&'a Croquis>`.

## Details

### Phase 1: Croquis script_parser binding type fixes
- `process_call_expression` now returns `Option<MacroKind>` instead of `bool`, enabling macro-specific binding type assignment
- Named import specifiers produce `SetupMaybeRef` (default/namespace imports remain `SetupConst`)
- Regular `const` declarations detect literal expressions (`LiteralConst`) and function expressions (`SetupConst`)
- `detect_reactivity_call` correctly maps `toRef` → `SetupRef`, `readonly` → `SetupReactiveConst`, etc.
- `defineModel` variables are registered in `ReactivityTracker` as `ReactiveKind::Ref`

### Phase 2: compile_sfc switches to Croquis parser
- `analyze_script_setup_to_summary()` is now the primary analysis path (provides `ReactivityTracker`)
- `ScriptCompileContext` is retained for macro span info and TypeScript type resolution (Props interface fallback)
- Props bindings from `ScriptCompileContext` are merged as fallback for TypeScript `defineProps<Props>()` patterns

### Phase 3: TransformContext ReactivityTracker access
- Added `get_reactive_kind()` and `is_readonly_binding()` methods to `TransformContext`
- These consult `Croquis.reactivity` when available

### Phase 4: Expression transforms use ReactiveKind
- `is_ref_binding`: Croquis-first check via `ReactiveKind::needs_value_access()`, fallback to `BindingType::SetupRef`
- `needs_unref`: If `ReactiveKind` is known, type is certain — skip `_unref()`. Only emit `_unref()` for `SetupLet`/`SetupMaybeRef` with unknown reactivity.
- `is_ref_binding_simple`: Same Croquis-first pattern

### Bug fix
- Removed unnecessary `_unref(emit)` for `defineEmits` — `emit` is `SetupConst` and never needed unwrapping

## Test plan

- [x] All 1,659+ workspace tests pass (`cargo test --workspace`)
- [x] Updated snapshots for binding type changes in `vize_croquis`
- [x] Updated snapshots for `defineEmits` `_unref` removal in `vize_atelier_sfc`
- [x] Verified `withDefaults` + `defineProps<Props>()` still resolves props correctly via ScriptCompileContext fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)