### PR TITLE
feat(canon): add new typechecker diagnostics with linter separation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3001,7 +3001,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vize"
-version = "0.0.1-alpha.84"
+version = "0.0.1-alpha.86"
 dependencies = [
  "clap",
  "dirs",
@@ -3036,7 +3036,7 @@ dependencies = [
 
 [[package]]
 name = "vize_armature"
-version = "0.0.1-alpha.84"
+version = "0.0.1-alpha.86"
 dependencies = [
  "compact_str",
  "serde",
@@ -3047,7 +3047,7 @@ dependencies = [
 
 [[package]]
 name = "vize_atelier_core"
-version = "0.0.1-alpha.84"
+version = "0.0.1-alpha.86"
 dependencies = [
  "bumpalo",
  "compact_str",
@@ -3073,7 +3073,7 @@ dependencies = [
 
 [[package]]
 name = "vize_atelier_dom"
-version = "0.0.1-alpha.84"
+version = "0.0.1-alpha.86"
 dependencies = [
  "insta",
  "phf",
@@ -3086,7 +3086,7 @@ dependencies = [
 
 [[package]]
 name = "vize_atelier_sfc"
-version = "0.0.1-alpha.84"
+version = "0.0.1-alpha.86"
 dependencies = [
  "criterion",
  "insta",
@@ -3114,7 +3114,7 @@ dependencies = [
 
 [[package]]
 name = "vize_atelier_ssr"
-version = "0.0.1-alpha.84"
+version = "0.0.1-alpha.86"
 dependencies = [
  "insta",
  "serde",
@@ -3126,7 +3126,7 @@ dependencies = [
 
 [[package]]
 name = "vize_atelier_vapor"
-version = "0.0.1-alpha.84"
+version = "0.0.1-alpha.86"
 dependencies = [
  "insta",
  "serde",
@@ -3137,7 +3137,7 @@ dependencies = [
 
 [[package]]
 name = "vize_canon"
-version = "0.0.1-alpha.84"
+version = "0.0.1-alpha.86"
 dependencies = [
  "dashmap 6.1.0",
  "dirs",
@@ -3165,7 +3165,7 @@ dependencies = [
 
 [[package]]
 name = "vize_carton"
-version = "0.0.1-alpha.84"
+version = "0.0.1-alpha.86"
 dependencies = [
  "bitflags 2.10.0",
  "bumpalo",
@@ -3181,7 +3181,7 @@ dependencies = [
 
 [[package]]
 name = "vize_croquis"
-version = "0.0.1-alpha.84"
+version = "0.0.1-alpha.86"
 dependencies = [
  "dashmap 6.1.0",
  "insta",
@@ -3203,7 +3203,7 @@ dependencies = [
 
 [[package]]
 name = "vize_fresco"
-version = "0.0.1-alpha.84"
+version = "0.0.1-alpha.86"
 dependencies = [
  "compact_str",
  "criterion",
@@ -3225,7 +3225,7 @@ dependencies = [
 
 [[package]]
 name = "vize_glyph"
-version = "0.0.1-alpha.84"
+version = "0.0.1-alpha.86"
 dependencies = [
  "criterion",
  "memchr",
@@ -3242,7 +3242,7 @@ dependencies = [
 
 [[package]]
 name = "vize_maestro"
-version = "0.0.1-alpha.84"
+version = "0.0.1-alpha.86"
 dependencies = [
  "async-trait",
  "dashmap 6.1.0",
@@ -3268,7 +3268,7 @@ dependencies = [
 
 [[package]]
 name = "vize_musea"
-version = "0.0.1-alpha.84"
+version = "0.0.1-alpha.86"
 dependencies = [
  "criterion",
  "insta",
@@ -3283,7 +3283,7 @@ dependencies = [
 
 [[package]]
 name = "vize_patina"
-version = "0.0.1-alpha.84"
+version = "0.0.1-alpha.86"
 dependencies = [
  "criterion",
  "insta",
@@ -3306,7 +3306,7 @@ dependencies = [
 
 [[package]]
 name = "vize_relief"
-version = "0.0.1-alpha.84"
+version = "0.0.1-alpha.86"
 dependencies = [
  "serde",
  "serde_json",
@@ -3316,7 +3316,7 @@ dependencies = [
 
 [[package]]
 name = "vize_test_runner"
-version = "0.0.1-alpha.84"
+version = "0.0.1-alpha.86"
 dependencies = [
  "serde",
  "toml",
@@ -3328,7 +3328,7 @@ dependencies = [
 
 [[package]]
 name = "vize_vitrine"
-version = "0.0.1-alpha.84"
+version = "0.0.1-alpha.86"
 dependencies = [
  "getrandom 0.3.4",
  "glob",

--- a/crates/vize_canon/src/sfc_typecheck/checks.rs
+++ b/crates/vize_canon/src/sfc_typecheck/checks.rs
@@ -320,4 +320,3 @@ pub fn check_fallthrough_attrs(
         related: Vec::new(),
     });
 }
-

--- a/crates/vize_canon/src/sfc_typecheck/checks.rs
+++ b/crates/vize_canon/src/sfc_typecheck/checks.rs
@@ -1,6 +1,9 @@
-//! Type checking functions for props, emits, and template bindings.
+//! Type checking functions for Vue SFC diagnostics.
 
 use super::{SfcTypeCheckResult, SfcTypeDiagnostic, SfcTypeSeverity};
+use vize_croquis::reactivity::ReactivityLossKind;
+use vize_croquis::setup_context::ViolationSeverity;
+use vize_croquis::{ScopeData, ScopeKind};
 
 /// Check props typing.
 pub fn check_props_typing(
@@ -179,6 +182,229 @@ pub fn check_template_bindings(
             help: Some(format!(
                 "Make sure '{}' is defined in script setup or imported",
                 undef_ref.name
+            )),
+            related: Vec::new(),
+        });
+    }
+}
+
+/// Check for reactivity loss patterns.
+pub fn check_reactivity(
+    summary: &vize_croquis::Croquis,
+    script_offset: u32,
+    result: &mut SfcTypeCheckResult,
+    strict: bool,
+) {
+    let severity = if strict {
+        SfcTypeSeverity::Error
+    } else {
+        SfcTypeSeverity::Warning
+    };
+
+    for loss in summary.reactivity.losses() {
+        let message = match &loss.kind {
+            ReactivityLossKind::ReactiveDestructure { source_name, .. } => {
+                format!(
+                    "Destructuring reactive object '{}' loses reactivity",
+                    source_name
+                )
+            }
+            ReactivityLossKind::RefValueDestructure { source_name, .. } => {
+                format!("Destructuring ref '{}' loses reactivity", source_name)
+            }
+            ReactivityLossKind::RefValueExtract {
+                source_name,
+                target_name,
+            } => {
+                format!(
+                    "Extracting '{}' from '{}.value' loses reactivity",
+                    target_name, source_name
+                )
+            }
+            ReactivityLossKind::ReactiveSpread { source_name } => {
+                format!(
+                    "Spreading reactive object '{}' loses reactivity",
+                    source_name
+                )
+            }
+            ReactivityLossKind::ReactiveReassign { source_name } => {
+                format!(
+                    "Reassigning reactive variable '{}' disconnects reactivity",
+                    source_name
+                )
+            }
+        };
+
+        result.add_diagnostic(SfcTypeDiagnostic {
+            severity,
+            message,
+            start: loss.start + script_offset,
+            end: loss.end + script_offset,
+            code: Some("reactivity-loss".to_string()),
+            help: None,
+            related: Vec::new(),
+        });
+    }
+}
+
+/// Check for setup context violations (CSRP / memory leaks).
+pub fn check_setup_context(
+    summary: &vize_croquis::Croquis,
+    script_offset: u32,
+    result: &mut SfcTypeCheckResult,
+) {
+    for violation in summary.setup_context.violations() {
+        let severity = match violation.kind.severity() {
+            ViolationSeverity::Error => SfcTypeSeverity::Error,
+            ViolationSeverity::Warning => SfcTypeSeverity::Warning,
+            ViolationSeverity::Info => SfcTypeSeverity::Info,
+        };
+
+        result.add_diagnostic(SfcTypeDiagnostic {
+            severity,
+            message: violation.kind.description().to_string(),
+            start: violation.start + script_offset,
+            end: violation.end + script_offset,
+            code: Some(violation.kind.to_display().to_string()),
+            help: None,
+            related: Vec::new(),
+        });
+    }
+}
+
+/// Check for invalid exports in `<script setup>`.
+pub fn check_invalid_exports(
+    summary: &vize_croquis::Croquis,
+    script_offset: u32,
+    result: &mut SfcTypeCheckResult,
+) {
+    for export in &summary.invalid_exports {
+        result.add_diagnostic(SfcTypeDiagnostic {
+            severity: SfcTypeSeverity::Error,
+            message: format!("Cannot export '{}' from <script setup>", export.name),
+            start: export.start + script_offset,
+            end: export.end + script_offset,
+            code: Some("invalid-export".to_string()),
+            help: Some(
+                "Only type exports are allowed in <script setup>. Use a separate <script> block for value exports.".to_string(),
+            ),
+            related: Vec::new(),
+        });
+    }
+}
+
+/// Check for v-for directives missing `:key`.
+pub fn check_vfor_keys(
+    summary: &vize_croquis::Croquis,
+    template_offset: u32,
+    result: &mut SfcTypeCheckResult,
+    strict: bool,
+) {
+    let severity = if strict {
+        SfcTypeSeverity::Error
+    } else {
+        SfcTypeSeverity::Warning
+    };
+
+    for scope in summary.scopes.iter() {
+        if scope.kind != ScopeKind::VFor {
+            continue;
+        }
+        if let ScopeData::VFor(ref data) = *scope.data() {
+            if data.key_expression.is_none() {
+                result.add_diagnostic(SfcTypeDiagnostic {
+                    severity,
+                    message: format!("v-for on '{}' is missing a :key binding", data.source),
+                    start: scope.span.start + template_offset,
+                    end: scope.span.end + template_offset,
+                    code: Some("vfor-missing-key".to_string()),
+                    help: Some(
+                        "Add a :key binding to help Vue track items efficiently".to_string(),
+                    ),
+                    related: Vec::new(),
+                });
+            }
+        }
+    }
+}
+
+/// Check for fallthrough attrs issues with multi-root components.
+pub fn check_fallthrough_attrs(
+    summary: &vize_croquis::Croquis,
+    result: &mut SfcTypeCheckResult,
+    strict: bool,
+) {
+    if !summary.template_info.may_lose_fallthrough_attrs() {
+        return;
+    }
+
+    let severity = if strict {
+        SfcTypeSeverity::Error
+    } else {
+        SfcTypeSeverity::Warning
+    };
+
+    result.add_diagnostic(SfcTypeDiagnostic {
+        severity,
+        message: "Multi-root component may lose fallthrough attributes".to_string(),
+        start: summary.template_info.content_start,
+        end: summary.template_info.content_end,
+        code: Some("fallthrough-attrs".to_string()),
+        help: Some(
+            "Bind $attrs explicitly to one root element or use inheritAttrs: false".to_string(),
+        ),
+        related: Vec::new(),
+    });
+}
+
+/// Check for unused template variables (v-for / v-slot).
+pub fn check_unused_template_vars(
+    summary: &vize_croquis::Croquis,
+    template_offset: u32,
+    result: &mut SfcTypeCheckResult,
+    strict: bool,
+) {
+    let severity = if strict {
+        SfcTypeSeverity::Warning
+    } else {
+        SfcTypeSeverity::Info
+    };
+
+    for unused in summary.unused_template_vars() {
+        let context_label = match &unused.context {
+            vize_croquis::UnusedVarContext::VForValue => "v-for value",
+            vize_croquis::UnusedVarContext::VForKey => "v-for key",
+            vize_croquis::UnusedVarContext::VForIndex => "v-for index",
+            vize_croquis::UnusedVarContext::VSlot { slot_name } => {
+                // Return early to include slot_name in message
+                result.add_diagnostic(SfcTypeDiagnostic {
+                    severity,
+                    message: format!(
+                        "Unused variable '{}' in v-slot '{}'",
+                        unused.name, slot_name
+                    ),
+                    start: unused.offset + template_offset,
+                    end: unused.offset + template_offset + unused.name.len() as u32,
+                    code: Some("unused-template-var".to_string()),
+                    help: Some(format!(
+                        "Remove '{}' or prefix with _ to indicate intentionally unused",
+                        unused.name
+                    )),
+                    related: Vec::new(),
+                });
+                continue;
+            }
+        };
+
+        result.add_diagnostic(SfcTypeDiagnostic {
+            severity,
+            message: format!("Unused variable '{}' in {}", unused.name, context_label),
+            start: unused.offset + template_offset,
+            end: unused.offset + template_offset + unused.name.len() as u32,
+            code: Some("unused-template-var".to_string()),
+            help: Some(format!(
+                "Remove '{}' or prefix with _ to indicate intentionally unused",
+                unused.name
             )),
             related: Vec::new(),
         });

--- a/crates/vize_canon/src/sfc_typecheck/mod.rs
+++ b/crates/vize_canon/src/sfc_typecheck/mod.rs
@@ -927,5 +927,4 @@ const msg = 'hello'
         });
         assert!(has_error, "Strict mode should report as Error");
     }
-
 }

--- a/crates/vize_croquis/src/analyzer/mod.rs
+++ b/crates/vize_croquis/src/analyzer/mod.rs
@@ -180,6 +180,7 @@ impl Analyzer {
         self.summary.scopes = result.scopes;
         self.summary.provide_inject = result.provide_inject;
         self.summary.binding_spans = result.binding_spans;
+        self.summary.setup_context = result.setup_context;
 
         self
     }
@@ -204,6 +205,7 @@ impl Analyzer {
         self.summary.scopes = result.scopes;
         self.summary.provide_inject = result.provide_inject;
         self.summary.binding_spans = result.binding_spans;
+        self.summary.setup_context = result.setup_context;
 
         self
     }

--- a/crates/vize_maestro/src/ide/type_service.rs
+++ b/crates/vize_maestro/src/ide/type_service.rs
@@ -38,6 +38,18 @@ pub struct LspTypeCheckOptions {
     pub check_emits: bool,
     /// Check template bindings
     pub check_template_bindings: bool,
+    /// Check reactivity loss patterns
+    pub check_reactivity: bool,
+    /// Check setup context violations
+    pub check_setup_context: bool,
+    /// Check invalid exports in `<script setup>`
+    pub check_invalid_exports: bool,
+    /// Check v-for missing :key
+    pub check_vfor_keys: bool,
+    /// Check fallthrough attrs with multi-root
+    pub check_fallthrough_attrs: bool,
+    /// Check unused template variables (opt-in)
+    pub check_unused_template_vars: bool,
 }
 
 impl Default for LspTypeCheckOptions {
@@ -47,6 +59,12 @@ impl Default for LspTypeCheckOptions {
             check_props: true,
             check_emits: true,
             check_template_bindings: true,
+            check_reactivity: true,
+            check_setup_context: true,
+            check_invalid_exports: true,
+            check_vfor_keys: true,
+            check_fallthrough_attrs: true,
+            check_unused_template_vars: false,
         }
     }
 }
@@ -79,6 +97,12 @@ impl TypeService {
             check_props: lsp_options.check_props,
             check_emits: lsp_options.check_emits,
             check_template_bindings: lsp_options.check_template_bindings,
+            check_reactivity: lsp_options.check_reactivity,
+            check_setup_context: lsp_options.check_setup_context,
+            check_invalid_exports: lsp_options.check_invalid_exports,
+            check_vfor_keys: lsp_options.check_vfor_keys,
+            check_fallthrough_attrs: lsp_options.check_fallthrough_attrs,
+            check_unused_template_vars: lsp_options.check_unused_template_vars,
             include_virtual_ts: false,
         };
 

--- a/crates/vize_maestro/src/ide/type_service.rs
+++ b/crates/vize_maestro/src/ide/type_service.rs
@@ -44,12 +44,8 @@ pub struct LspTypeCheckOptions {
     pub check_setup_context: bool,
     /// Check invalid exports in `<script setup>`
     pub check_invalid_exports: bool,
-    /// Check v-for missing :key
-    pub check_vfor_keys: bool,
     /// Check fallthrough attrs with multi-root
     pub check_fallthrough_attrs: bool,
-    /// Check unused template variables (opt-in)
-    pub check_unused_template_vars: bool,
 }
 
 impl Default for LspTypeCheckOptions {
@@ -62,9 +58,7 @@ impl Default for LspTypeCheckOptions {
             check_reactivity: true,
             check_setup_context: true,
             check_invalid_exports: true,
-            check_vfor_keys: true,
             check_fallthrough_attrs: true,
-            check_unused_template_vars: false,
         }
     }
 }
@@ -100,9 +94,7 @@ impl TypeService {
             check_reactivity: lsp_options.check_reactivity,
             check_setup_context: lsp_options.check_setup_context,
             check_invalid_exports: lsp_options.check_invalid_exports,
-            check_vfor_keys: lsp_options.check_vfor_keys,
             check_fallthrough_attrs: lsp_options.check_fallthrough_attrs,
-            check_unused_template_vars: lsp_options.check_unused_template_vars,
             include_virtual_ts: false,
         };
 

--- a/crates/vize_vitrine/src/napi_typecheck.rs
+++ b/crates/vize_vitrine/src/napi_typecheck.rs
@@ -75,9 +75,13 @@ pub fn type_check_napi(
     options: Option<TypeCheckOptionsNapi>,
 ) -> Result<TypeCheckResultNapi> {
     let opts = options.unwrap_or_default();
+    let filename = opts
+        .filename
+        .as_deref()
+        .unwrap_or("anonymous.vue")
+        .to_string();
 
-    let mut check_opts =
-        TypeCheckOptions::new(opts.filename.unwrap_or_else(|| "anonymous.vue".to_string()));
+    let mut check_opts = TypeCheckOptions::new(filename);
     apply_napi_options(&opts, &mut check_opts);
 
     let result = type_check_sfc(&source, &check_opts);
@@ -158,12 +162,15 @@ pub fn get_type_check_capabilities_napi() -> TypeCheckCapabilitiesNapi {
             },
             TypeCheckCapabilityNapi {
                 name: "reactivity-loss".to_string(),
-                description: "Detects patterns that lose reactivity (destructuring, spreading, reassigning)".to_string(),
+                description:
+                    "Detects patterns that lose reactivity (destructuring, spreading, reassigning)"
+                        .to_string(),
                 severity: "warning".to_string(),
             },
             TypeCheckCapabilityNapi {
                 name: "setup-context-violation".to_string(),
-                description: "Detects Vue APIs called outside setup context (CSRP, memory leaks)".to_string(),
+                description: "Detects Vue APIs called outside setup context (CSRP, memory leaks)"
+                    .to_string(),
                 severity: "warning/error".to_string(),
             },
             TypeCheckCapabilityNapi {
@@ -173,7 +180,8 @@ pub fn get_type_check_capabilities_napi() -> TypeCheckCapabilitiesNapi {
             },
             TypeCheckCapabilityNapi {
                 name: "fallthrough-attrs".to_string(),
-                description: "Detects multi-root components that may lose fallthrough attributes".to_string(),
+                description: "Detects multi-root components that may lose fallthrough attributes"
+                    .to_string(),
                 severity: "warning".to_string(),
             },
         ],

--- a/crates/vize_vitrine/src/napi_typecheck.rs
+++ b/crates/vize_vitrine/src/napi_typecheck.rs
@@ -18,9 +18,7 @@ pub struct TypeCheckOptionsNapi {
     pub check_reactivity: Option<bool>,
     pub check_setup_context: Option<bool>,
     pub check_invalid_exports: Option<bool>,
-    pub check_vfor_keys: Option<bool>,
     pub check_fallthrough_attrs: Option<bool>,
-    pub check_unused_template_vars: Option<bool>,
 }
 
 /// Related location for diagnostic (NAPI)
@@ -64,9 +62,7 @@ fn apply_napi_options(opts: &TypeCheckOptionsNapi, check_opts: &mut TypeCheckOpt
     check_opts.check_reactivity = opts.check_reactivity.unwrap_or(true);
     check_opts.check_setup_context = opts.check_setup_context.unwrap_or(true);
     check_opts.check_invalid_exports = opts.check_invalid_exports.unwrap_or(true);
-    check_opts.check_vfor_keys = opts.check_vfor_keys.unwrap_or(true);
     check_opts.check_fallthrough_attrs = opts.check_fallthrough_attrs.unwrap_or(true);
-    check_opts.check_unused_template_vars = opts.check_unused_template_vars.unwrap_or(false);
 }
 
 /// Perform type checking on a Vue SFC
@@ -176,19 +172,9 @@ pub fn get_type_check_capabilities_napi() -> TypeCheckCapabilitiesNapi {
                 severity: "error".to_string(),
             },
             TypeCheckCapabilityNapi {
-                name: "vfor-missing-key".to_string(),
-                description: "Detects v-for directives without :key binding".to_string(),
-                severity: "warning".to_string(),
-            },
-            TypeCheckCapabilityNapi {
                 name: "fallthrough-attrs".to_string(),
                 description: "Detects multi-root components that may lose fallthrough attributes".to_string(),
                 severity: "warning".to_string(),
-            },
-            TypeCheckCapabilityNapi {
-                name: "unused-template-var".to_string(),
-                description: "Detects unused variables in v-for/v-slot (opt-in)".to_string(),
-                severity: "info".to_string(),
             },
         ],
         notes: vec![


### PR DESCRIPTION
## Summary

Surface additional diagnostic checks from `vize_croquis` semantic analysis into the `vize_canon` typechecker. Only checks that belong in a **typechecker** (semantic errors, compile errors, runtime correctness) are included — lint-style checks (best practices, code quality) are left to `vize_patina`.

### New checks (typechecker)

| Check | Code | Default Severity | Strict Severity |
|---|---|---|---|
| Reactivity loss detection | `reactivity-loss` | Warning | Error |
| Setup context violations (CSRP/leaks) | `module-level-*` | Warning/Error | — |
| Invalid exports in `<script setup>` | `invalid-export` | Error | — |
| Multi-root fallthrough attrs | `fallthrough-attrs` | Warning | Error |

### Linter / typechecker separation

| Check | Owner | Rationale |
|---|---|---|
| v-for missing `:key` | **patina** (`vue/require-v-for-key`) | Best practice |
| Unused template vars | **patina** (`vue/no-unused-vars`) | Code quality |
| Reactivity loss | **canon** (`reactivity-loss`) | Semantic bug detection via Croquis (5 loss patterns) |
| Setup context violations | **canon** (`module-level-*`) | CSRP / memory leak detection |
| Invalid exports | **canon** (`invalid-export`) | Compile error |
| Fallthrough attrs | **canon** (`fallthrough-attrs`) | Runtime correctness warning |

### Bug fix

- Fixed `setup_context` not being transferred from `ScriptParseResult` to `Croquis` in both `analyze_script_setup()` and `analyze_script_plain()`

### Changes

- **`crates/vize_croquis/src/analyzer/mod.rs`** — Transfer `setup_context` from parse result to summary
- **`crates/vize_canon/src/sfc_typecheck/checks.rs`** — 4 new check functions (reactivity, setup_context, invalid_exports, fallthrough_attrs)
- **`crates/vize_canon/src/sfc_typecheck/mod.rs`** — New options on `SfcTypeCheckOptions` + wiring + 12 new tests
- **`crates/vize_maestro/src/ide/type_service.rs`** — Pass new options through `LspTypeCheckOptions`
- **`crates/vize_vitrine/src/napi_typecheck.rs`** — Expose new options in NAPI bindings + update capabilities

## Test plan

- [x] `cargo test -p vize_canon` — 131 tests pass
- [x] `cargo test -p vize_croquis` — 196 tests pass
- [x] `cargo clippy -p vize_canon` — clean
- [x] `cargo clippy -p vize_croquis` — clean
- [x] `cargo clippy -p vize_maestro` — clean
- [x] `cargo clippy -p vize_vitrine` — clean