### PR TITLE
feat(musea): autocomplete and typecheck

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3468,6 +3468,7 @@ dependencies = [
  "vize_carton",
  "vize_croquis",
  "vize_glyph",
+ "vize_musea",
  "vize_patina",
  "vize_relief",
  "vize_vitrine",

--- a/crates/vize_maestro/Cargo.toml
+++ b/crates/vize_maestro/Cargo.toml
@@ -45,6 +45,7 @@ vize_glyph = { workspace = true, optional = true }
 vize_patina.workspace = true
 vize_canon = { workspace = true }
 vize_croquis.workspace = true
+vize_musea.workspace = true
 vize_vitrine = { workspace = true, default-features = false }
 
 [dev-dependencies]

--- a/crates/vize_maestro/src/ide/completion/service.rs
+++ b/crates/vize_maestro/src/ide/completion/service.rs
@@ -17,15 +17,42 @@ use vize_canon::{LspCompletionItem, LspDocumentation, TsgoBridge};
 
 use super::{is_inside_html_comment, script, style, template};
 use crate::ide::IdeContext;
-use crate::virtual_code::BlockType;
+use crate::virtual_code::{ArtCursorPosition, BlockType};
 use vize_carton::cstr;
 
 impl super::CompletionService {
     /// Get completions for the given context.
     pub fn complete(ctx: &IdeContext) -> Option<CompletionResponse> {
-        // Check if this is an Art file
+        // Art file: route by cursor position within art structure
         if ctx.uri.path().ends_with(".art.vue") {
-            return template::complete_art(ctx);
+            return match ctx.block_type {
+                Some(BlockType::Art(ArtCursorPosition::VariantTemplate(_))) => {
+                    // Inside variant template: provide template completions
+                    let items = template::complete_template(ctx);
+                    if items.is_empty() {
+                        template::complete_art(ctx)
+                    } else {
+                        Some(CompletionResponse::Array(items))
+                    }
+                }
+                Some(BlockType::ScriptSetup) => {
+                    let items = script::complete_script(ctx, true);
+                    if items.is_empty() {
+                        None
+                    } else {
+                        Some(CompletionResponse::Array(items))
+                    }
+                }
+                Some(BlockType::Script) => {
+                    let items = script::complete_script(ctx, false);
+                    if items.is_empty() {
+                        None
+                    } else {
+                        Some(CompletionResponse::Array(items))
+                    }
+                }
+                _ => template::complete_art(ctx),
+            };
         }
 
         // Check if cursor is inside <art> block in a regular .vue file
@@ -54,9 +81,49 @@ impl super::CompletionService {
         ctx: &IdeContext<'_>,
         tsgo_bridge: Option<Arc<TsgoBridge>>,
     ) -> Option<CompletionResponse> {
-        // Check if this is an Art file
+        // Art file: route by cursor position within art structure
         if ctx.uri.path().ends_with(".art.vue") {
-            return template::complete_art(ctx);
+            return match ctx.block_type {
+                Some(BlockType::Art(ArtCursorPosition::VariantTemplate(ref info))) => {
+                    // Try tsgo template completion for variant template
+                    if let Some(ref bridge) = tsgo_bridge {
+                        let items = Self::complete_art_variant_with_tsgo(ctx, info, bridge).await;
+                        if !items.is_empty() {
+                            let mut all = items;
+                            all.extend(template::directive_completions());
+                            return Some(CompletionResponse::Array(all));
+                        }
+                    }
+                    // Fallback to structural completions
+                    Self::complete(ctx)
+                }
+                Some(BlockType::ScriptSetup) => {
+                    // Script setup in art file: use normal script completion with tsgo
+                    if let Some(ref bridge) = tsgo_bridge {
+                        let items = Self::complete_script_with_tsgo(ctx, true, bridge).await;
+                        if !items.is_empty() {
+                            let mut all = items;
+                            let mut v = script::composition_api_completions();
+                            v.extend(script::macro_completions());
+                            all.extend(v);
+                            return Some(CompletionResponse::Array(all));
+                        }
+                    }
+                    Self::complete(ctx)
+                }
+                Some(BlockType::Script) => {
+                    if let Some(ref bridge) = tsgo_bridge {
+                        let items = Self::complete_script_with_tsgo(ctx, false, bridge).await;
+                        if !items.is_empty() {
+                            let mut all = items;
+                            all.extend(script::composition_api_completions());
+                            return Some(CompletionResponse::Array(all));
+                        }
+                    }
+                    Self::complete(ctx)
+                }
+                _ => Self::complete(ctx),
+            };
         }
 
         // Check if cursor is inside <art> block in a regular .vue file
@@ -85,7 +152,7 @@ impl super::CompletionService {
                 BlockType::Script => Self::complete_script_with_tsgo(ctx, false, &bridge).await,
                 BlockType::ScriptSetup => Self::complete_script_with_tsgo(ctx, true, &bridge).await,
                 BlockType::Style(_) => vec![],
-                BlockType::Art(_) => unreachable!(),
+                BlockType::Art(_) => vec![],
             };
 
             if !tsgo_items.is_empty() {
@@ -99,7 +166,7 @@ impl super::CompletionService {
                         v
                     }
                     BlockType::Style(_) => style::vue_css_completions(),
-                    BlockType::Art(_) => unreachable!(),
+                    BlockType::Art(_) => vec![],
                 });
 
                 return Some(CompletionResponse::Array(items));
@@ -108,6 +175,47 @@ impl super::CompletionService {
 
         // Fall back to synchronous completions
         Self::complete(ctx)
+    }
+
+    /// Get completions for an art variant template with tsgo.
+    #[cfg(feature = "native")]
+    async fn complete_art_variant_with_tsgo(
+        ctx: &IdeContext<'_>,
+        info: &crate::virtual_code::ArtVariantInfo,
+        bridge: &TsgoBridge,
+    ) -> Vec<CompletionItem> {
+        if let Some(ref virtual_docs) = ctx.virtual_docs {
+            if let Some(ref tmpl) = virtual_docs.template {
+                // Convert the art variant relative offset through the template source map
+                let relative_offset = info.relative_offset as u32;
+                let vts_offset = tmpl
+                    .source_map
+                    .to_generated(relative_offset)
+                    .map(|o| o as usize)
+                    .unwrap_or(relative_offset as usize);
+
+                let (line, character) = crate::ide::offset_to_position(&tmpl.content, vts_offset);
+                let uri = cstr!("vize-virtual://{}.template.ts", ctx.uri.path());
+
+                if bridge.is_initialized() {
+                    let _ = bridge
+                        .open_or_update_virtual_document(
+                            &cstr!("{}.template.ts", ctx.uri.path()),
+                            &tmpl.content,
+                        )
+                        .await;
+
+                    if let Ok(items) = bridge.completion(&uri, line, character).await {
+                        return items
+                            .into_iter()
+                            .map(Self::convert_lsp_completion)
+                            .collect();
+                    }
+                }
+            }
+        }
+
+        vec![]
     }
 
     /// Get completions for template with tsgo.

--- a/crates/vize_maestro/src/ide/definition/service.rs
+++ b/crates/vize_maestro/src/ide/definition/service.rs
@@ -21,7 +21,7 @@ use vize_canon::TsgoBridge;
 
 use super::{helpers, script, template, IdeContext};
 use crate::ide::is_component_tag;
-use crate::virtual_code::BlockType;
+use crate::virtual_code::{ArtCursorPosition, BlockType};
 
 impl super::DefinitionService {
     /// Get definition for the symbol at the current position.
@@ -30,6 +30,9 @@ impl super::DefinitionService {
             BlockType::Template => template::definition_in_template(ctx),
             BlockType::Script | BlockType::ScriptSetup => script::definition_in_script(ctx),
             BlockType::Style(_) => script::definition_in_style(ctx),
+            BlockType::Art(ArtCursorPosition::VariantTemplate(_)) => {
+                template::definition_in_template(ctx)
+            }
             BlockType::Art(_) => None,
         }
     }
@@ -46,8 +49,70 @@ impl super::DefinitionService {
                 Self::definition_in_script_with_tsgo(ctx, tsgo_bridge).await
             }
             BlockType::Style(_) => script::definition_in_style(ctx),
+            BlockType::Art(ArtCursorPosition::VariantTemplate(ref info)) => {
+                Self::definition_in_art_variant_with_tsgo(ctx, info, tsgo_bridge).await
+            }
             BlockType::Art(_) => None,
         }
+    }
+
+    /// Find definition in art variant template with tsgo.
+    #[cfg(feature = "native")]
+    async fn definition_in_art_variant_with_tsgo(
+        ctx: &IdeContext<'_>,
+        info: &crate::virtual_code::ArtVariantInfo,
+        tsgo_bridge: Option<Arc<TsgoBridge>>,
+    ) -> Option<GotoDefinitionResponse> {
+        let word = helpers::get_word_at_offset(&ctx.content, ctx.offset)?;
+
+        if word.is_empty() {
+            return None;
+        }
+
+        // Check if this is a component tag
+        if let Some(tag_name) = helpers::get_tag_at_offset(&ctx.content, ctx.offset) {
+            if is_component_tag(&tag_name) {
+                if let Some(def) = template::find_component_definition(ctx, &tag_name) {
+                    return Some(def);
+                }
+            }
+        }
+
+        // Try tsgo definition
+        if let Some(bridge) = tsgo_bridge {
+            if let Some(ref virtual_docs) = ctx.virtual_docs {
+                if let Some(ref tmpl) = virtual_docs.template {
+                    let relative_offset = info.relative_offset as u32;
+                    let vts_offset = tmpl
+                        .source_map
+                        .to_generated(relative_offset)
+                        .map(|o| o as usize)
+                        .unwrap_or(relative_offset as usize);
+
+                    let (line, character) =
+                        crate::ide::offset_to_position(&tmpl.content, vts_offset);
+                    #[allow(clippy::disallowed_macros)]
+                    let uri = format!("vize-virtual://{}.template.ts", ctx.uri.path());
+
+                    if bridge.is_initialized() {
+                        #[allow(clippy::disallowed_macros)]
+                        let vdoc_uri = format!("{}.template.ts", ctx.uri.path());
+                        let _ = bridge
+                            .open_or_update_virtual_document(&vdoc_uri, &tmpl.content)
+                            .await;
+
+                        if let Ok(locations) = bridge.definition(&uri, line, character).await {
+                            if !locations.is_empty() {
+                                return Some(Self::convert_lsp_locations(locations, ctx));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // Fall back to synchronous definition
+        template::definition_in_template(ctx)
     }
 
     /// Find definition in template with tsgo and component jump support.

--- a/crates/vize_maestro/src/ide/diagnostics/mod.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/mod.rs
@@ -90,8 +90,9 @@ impl DiagnosticService {
         // Check if this is an Art file (*.art.vue)
         let path = uri.path();
         if path.ends_with(".art.vue") {
-            // Use Musea-specific diagnostics for Art files
+            // Musea-specific diagnostics for Art files
             diagnostics.extend(Self::collect_musea_diagnostics(uri, &content));
+            // Don't return early - continue to collect tsgo diagnostics in collect_async()
             return diagnostics;
         }
 

--- a/crates/vize_maestro/src/ide/diagnostics/tsgo.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/tsgo.rs
@@ -41,7 +41,13 @@ impl DiagnosticService {
         tracing::info!("tsgo bridge acquired");
 
         // Generate virtual TypeScript
-        let Some(virtual_result) = Self::generate_virtual_ts(uri, &content) else {
+        let is_art_file = uri.path().ends_with(".art.vue");
+        let virtual_result = if is_art_file {
+            Self::generate_virtual_ts_for_art(uri, &content)
+        } else {
+            Self::generate_virtual_ts(uri, &content)
+        };
+        let Some(virtual_result) = virtual_result else {
             tracing::warn!("failed to generate virtual ts for {}", uri);
             return vec![];
         };
@@ -420,5 +426,105 @@ impl DiagnosticService {
 
         tracing::info!("parse_vize_map_comments: found {} mappings", found_count);
         mappings
+    }
+
+    /// Generate virtual TypeScript for an art file (*.art.vue).
+    ///
+    /// Uses the default variant's template as the synthetic template,
+    /// and the script_setup block from the SFC parse.
+    pub(super) fn generate_virtual_ts_for_art(uri: &Url, content: &str) -> Option<VirtualTsResult> {
+        use vize_atelier_sfc::{parse_sfc, SfcParseOptions};
+        use vize_canon::virtual_ts::generate_virtual_ts;
+        use vize_croquis::{Analyzer, AnalyzerOptions};
+
+        // Parse as art file to get variant templates
+        let art_allocator = vize_carton::Bump::new();
+        let art_desc = vize_musea::parse_art(
+            &art_allocator,
+            content,
+            vize_musea::ArtParseOptions::default(),
+        )
+        .ok()?;
+
+        // Get default variant's template
+        let variant = art_desc.default_variant()?;
+        let template_content = variant.template;
+        if template_content.trim().is_empty() {
+            return None;
+        }
+
+        // Calculate template offset in the original art file
+        let template_ptr = template_content.as_ptr() as usize;
+        let source_ptr = content.as_ptr() as usize;
+        let template_offset = (template_ptr - source_ptr) as u32;
+
+        // Parse SFC for script blocks
+        let sfc_options = SfcParseOptions {
+            filename: uri.path().to_string().into(),
+            ..Default::default()
+        };
+        let descriptor = parse_sfc(content, sfc_options).ok()?;
+
+        // Get script block info
+        let (script_content, sfc_script_start_line) = descriptor
+            .script_setup
+            .as_ref()
+            .map(|s| (s.content.as_ref(), s.loc.start_line as u32))
+            .or_else(|| {
+                descriptor
+                    .script
+                    .as_ref()
+                    .map(|s| (s.content.as_ref(), s.loc.start_line as u32))
+            })?;
+
+        // Parse template AST
+        let template_allocator = vize_carton::Bump::new();
+        let (template_ast, _) = vize_armature::parse(&template_allocator, template_content);
+
+        // Analyze script + template
+        let mut analyzer = Analyzer::with_options(AnalyzerOptions::full());
+        analyzer.analyze_script(script_content);
+        analyzer.analyze_template(&template_ast);
+
+        let summary = analyzer.finish();
+        let output = generate_virtual_ts(
+            &summary,
+            Some(script_content),
+            Some(&template_ast),
+            template_offset,
+        );
+        let code = output.code;
+
+        // Count import lines
+        let skipped_import_lines = Self::count_import_lines(script_content);
+
+        // Find where user code starts
+        let user_code_start_line = code
+            .lines()
+            .enumerate()
+            .find(|(_, line)| line.contains("// User setup code"))
+            .map(|(i, _)| i as u32 + 1)
+            .unwrap_or(0);
+
+        // Find where template scope starts
+        let template_scope_start_line = code
+            .lines()
+            .enumerate()
+            .find(|(_, line)| line.contains("Template Scope"))
+            .map(|(i, _)| i as u32)
+            .unwrap_or(u32::MAX);
+
+        // Parse @vize-map comments
+        let line_mappings = Self::parse_vize_map_comments(&code);
+
+        Some(VirtualTsResult {
+            #[allow(clippy::disallowed_methods)]
+            code: code.to_string(),
+            user_code_start_line,
+            sfc_script_start_line,
+            template_scope_start_line,
+            line_mappings,
+            skipped_import_lines,
+        })
     }
 }

--- a/crates/vize_maestro/src/ide/hover/mod.rs
+++ b/crates/vize_maestro/src/ide/hover/mod.rs
@@ -28,7 +28,7 @@ use vize_relief::BindingType;
 use vize_canon::TsgoBridge;
 
 use super::IdeContext;
-use crate::virtual_code::BlockType;
+use crate::virtual_code::{ArtCursorPosition, BlockType};
 
 /// Hover service for providing contextual information.
 pub struct HoverService;
@@ -41,6 +41,7 @@ impl HoverService {
             BlockType::Script => Self::hover_script(ctx, false),
             BlockType::ScriptSetup => Self::hover_script(ctx, true),
             BlockType::Style(index) => Self::hover_style(ctx, index),
+            BlockType::Art(ArtCursorPosition::VariantTemplate(_)) => Self::hover_template(ctx),
             BlockType::Art(_) => None,
         }
     }
@@ -59,6 +60,9 @@ impl HoverService {
             BlockType::Script => Self::hover_script_with_tsgo(ctx, false, tsgo_bridge).await,
             BlockType::ScriptSetup => Self::hover_script_with_tsgo(ctx, true, tsgo_bridge).await,
             BlockType::Style(index) => Self::hover_style(ctx, index),
+            BlockType::Art(ArtCursorPosition::VariantTemplate(ref info)) => {
+                Self::hover_art_variant_with_tsgo(ctx, info, tsgo_bridge).await
+            }
             BlockType::Art(_) => None,
         }
     }

--- a/crates/vize_maestro/src/ide/hover/tsgo.rs
+++ b/crates/vize_maestro/src/ide/hover/tsgo.rs
@@ -8,11 +8,14 @@
     clippy::disallowed_macros
 )]
 
+use std::sync::Arc;
+
 use tower_lsp::lsp_types::{Hover, HoverContents, MarkupContent, MarkupKind, Range};
-use vize_canon::{LspHover, LspHoverContents, LspMarkedString};
+use vize_canon::{LspHover, LspHoverContents, LspMarkedString, TsgoBridge};
 
 use super::HoverService;
 use crate::ide::IdeContext;
+use crate::virtual_code::ArtVariantInfo;
 
 impl HoverService {
     /// Convert SFC offset to virtual TS template offset.
@@ -94,6 +97,63 @@ impl HoverService {
         }
 
         None
+    }
+
+    /// Get hover for an art variant template with tsgo.
+    ///
+    /// Maps the art variant offset to the virtual TS offset and requests hover from tsgo.
+    pub(super) async fn hover_art_variant_with_tsgo(
+        ctx: &IdeContext<'_>,
+        info: &ArtVariantInfo,
+        tsgo_bridge: Option<Arc<TsgoBridge>>,
+    ) -> Option<Hover> {
+        let word = Self::get_word_at_offset(&ctx.content, ctx.offset);
+
+        if word.is_empty() {
+            return None;
+        }
+
+        // Check for Vue directives first (these don't need tsgo)
+        if let Some(hover) = Self::hover_directive(&word) {
+            return Some(hover);
+        }
+
+        // Try to get type information from tsgo via virtual TypeScript
+        if let Some(bridge) = tsgo_bridge {
+            if let Some(ref virtual_docs) = ctx.virtual_docs {
+                if let Some(ref template) = virtual_docs.template {
+                    // Convert the art variant relative offset through the template source map
+                    let relative_offset = info.relative_offset as u32;
+                    let vts_offset = template
+                        .source_map
+                        .to_generated(relative_offset)
+                        .map(|o| o as usize)
+                        .unwrap_or(relative_offset as usize);
+
+                    let (line, character) =
+                        crate::ide::offset_to_position(&template.content, vts_offset);
+                    #[allow(clippy::disallowed_macros)]
+                    let uri = format!("vize-virtual://{}.template.ts", ctx.uri.path());
+
+                    // Open/update virtual document
+                    if bridge.is_initialized() {
+                        #[allow(clippy::disallowed_macros)]
+                        let vdoc_uri = format!("{}.template.ts", ctx.uri.path());
+                        let _ = bridge
+                            .open_or_update_virtual_document(&vdoc_uri, &template.content)
+                            .await;
+
+                        // Request hover from tsgo
+                        if let Ok(Some(hover)) = bridge.hover(&uri, line, character).await {
+                            return Some(Self::convert_lsp_hover(hover));
+                        }
+                    }
+                }
+            }
+        }
+
+        // Fall back to template hover (croquis analysis)
+        Self::hover_template(ctx)
     }
 
     /// Convert tsgo LspHover to tower-lsp Hover.

--- a/crates/vize_maestro/src/ide/mod.rs
+++ b/crates/vize_maestro/src/ide/mod.rs
@@ -45,7 +45,9 @@ pub use workspace_symbols::WorkspaceSymbolsService;
 use tower_lsp::lsp_types::Url;
 
 use crate::server::ServerState;
-use crate::virtual_code::{find_block_at_offset, BlockType, VirtualDocuments};
+use crate::virtual_code::{
+    find_art_block_at_offset, find_block_at_offset, ArtCursorPosition, BlockType, VirtualDocuments,
+};
 
 // =============================================================================
 // Position conversion utilities
@@ -181,16 +183,21 @@ impl<'a> IdeContext<'a> {
         let doc = state.documents.get(uri)?;
         let content = doc.text();
 
-        // Parse SFC to determine block type
-        let options = vize_atelier_sfc::SfcParseOptions {
-            filename: uri.path().to_string().into(),
-            ..Default::default()
-        };
-
-        let block_type = if let Ok(descriptor) = vize_atelier_sfc::parse_sfc(&content, options) {
-            find_block_at_offset(&descriptor, offset)
+        // Determine block type
+        let block_type = if uri.path().ends_with(".art.vue") {
+            // For art files, use art-specific block detection
+            find_art_block_at_offset(&content, offset)
         } else {
-            None
+            // Parse SFC to determine block type
+            let options = vize_atelier_sfc::SfcParseOptions {
+                filename: uri.path().to_string().into(),
+                ..Default::default()
+            };
+            if let Ok(descriptor) = vize_atelier_sfc::parse_sfc(&content, options) {
+                find_block_at_offset(&descriptor, offset)
+            } else {
+                None
+            }
         };
 
         let virtual_docs = state.get_virtual_docs(uri);
@@ -230,6 +237,15 @@ impl<'a> IdeContext<'a> {
     #[inline]
     pub fn is_in_art(&self) -> bool {
         matches!(self.block_type, Some(BlockType::Art(_)))
+    }
+
+    /// Check if cursor is in an art variant template.
+    #[inline]
+    pub fn is_in_art_variant_template(&self) -> bool {
+        matches!(
+            self.block_type,
+            Some(BlockType::Art(ArtCursorPosition::VariantTemplate(_)))
+        )
     }
 }
 

--- a/crates/vize_maestro/src/server/state.rs
+++ b/crates/vize_maestro/src/server/state.rs
@@ -278,6 +278,11 @@ impl ServerState {
 
     /// Generate and cache virtual documents for a document.
     pub fn update_virtual_docs(&self, uri: &Url, content: &str) {
+        if uri.path().ends_with(".art.vue") {
+            self.update_art_virtual_docs(uri, content);
+            return;
+        }
+
         let options = vize_atelier_sfc::SfcParseOptions {
             filename: uri.path().to_string().into(),
             ..Default::default()
@@ -288,6 +293,67 @@ impl ServerState {
             let virtual_docs = self.virtual_gen.write().generate(&descriptor, base_uri);
             self.virtual_docs_cache.insert(uri.clone(), virtual_docs);
         }
+    }
+
+    /// Generate and cache virtual documents for an art file (*.art.vue).
+    ///
+    /// Uses the default variant's template as the synthetic template block,
+    /// and generates virtual docs for script_setup if present.
+    fn update_art_virtual_docs(&self, uri: &Url, content: &str) {
+        use crate::virtual_code::{ScriptCodeGenerator, TemplateCodeGenerator, VirtualDocuments};
+
+        let allocator = vize_carton::Bump::new();
+        let Ok(art_desc) =
+            vize_musea::parse_art(&allocator, content, vize_musea::ArtParseOptions::default())
+        else {
+            return;
+        };
+
+        let base_uri = uri.path();
+        let mut docs = VirtualDocuments::new();
+
+        // Generate template virtual doc from default variant's template
+        if let Some(variant) = art_desc.default_variant() {
+            let template_content = variant.template;
+            if !template_content.trim().is_empty() {
+                let template_allocator = vize_carton::Bump::new();
+                let (ast, _errors) = vize_armature::parse(&template_allocator, template_content);
+
+                // Calculate template offset in the original art file
+                let template_ptr = template_content.as_ptr() as usize;
+                let source_ptr = content.as_ptr() as usize;
+                let block_offset = (template_ptr - source_ptr) as u32;
+
+                let mut template_gen = TemplateCodeGenerator::new();
+                template_gen.set_block_offset(block_offset);
+                let mut template_doc = template_gen.generate(&ast, template_content);
+                template_doc.uri = vize_carton::cstr!("{base_uri}.__template.ts").to_string();
+                docs.template = Some(template_doc);
+            }
+        }
+
+        // Generate script_setup virtual doc using SFC parser
+        // (SFC parser handles script blocks even in art files)
+        let sfc_options = vize_atelier_sfc::SfcParseOptions {
+            filename: uri.path().to_string().into(),
+            ..Default::default()
+        };
+        if let Ok(descriptor) = vize_atelier_sfc::parse_sfc(content, sfc_options) {
+            if let Some(ref script_setup) = descriptor.script_setup {
+                let mut script_gen = ScriptCodeGenerator::new();
+                let mut script_doc = script_gen.generate(script_setup, true);
+                script_doc.uri = vize_carton::cstr!("{base_uri}.__script_setup.ts").to_string();
+                docs.script_setup = Some(script_doc);
+            }
+            if let Some(ref script) = descriptor.script {
+                let mut script_gen = ScriptCodeGenerator::new();
+                let mut script_doc = script_gen.generate(script, false);
+                script_doc.uri = vize_carton::cstr!("{base_uri}.__script.ts").to_string();
+                docs.script = Some(script_doc);
+            }
+        }
+
+        self.virtual_docs_cache.insert(uri.clone(), docs);
     }
 
     /// Get cached virtual documents for a document.

--- a/crates/vize_maestro/src/virtual_code/generator.rs
+++ b/crates/vize_maestro/src/virtual_code/generator.rs
@@ -247,6 +247,32 @@ impl Default for BatchVirtualCodeGenerator {
     }
 }
 
+/// Information about cursor position within an art variant template.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ArtVariantInfo {
+    /// Index of the variant in the art descriptor
+    pub variant_index: usize,
+    /// Byte offset where the variant template content starts in the art file
+    pub template_start: usize,
+    /// Byte offset where the variant template content ends in the art file
+    pub template_end: usize,
+    /// Cursor offset relative to the start of the variant template content
+    pub relative_offset: usize,
+}
+
+/// Where the cursor is within an art block.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ArtCursorPosition {
+    /// In `<art ...>` tag attributes
+    ArtTag,
+    /// In `<variant ...>` tag attributes (variant index)
+    VariantTag(usize),
+    /// Inside variant template content
+    VariantTemplate(ArtVariantInfo),
+    /// Between variants (art content area)
+    ArtContent,
+}
+
 /// Helper to determine the virtual language from a block position.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BlockType {
@@ -254,7 +280,7 @@ pub enum BlockType {
     Script,
     ScriptSetup,
     Style(usize),
-    Art(usize),
+    Art(ArtCursorPosition),
 }
 
 impl BlockType {
@@ -302,20 +328,88 @@ pub fn find_block_at_offset(descriptor: &SfcDescriptor, offset: usize) -> Option
     }
 
     // Check custom blocks (art, i18n, etc.)
-    for (i, custom) in descriptor.custom_blocks.iter().enumerate() {
+    for custom in descriptor.custom_blocks.iter() {
         if custom.block_type == "art" && offset >= custom.loc.start && offset < custom.loc.end {
-            return Some(BlockType::Art(i));
+            return Some(BlockType::Art(ArtCursorPosition::ArtContent));
         }
     }
 
     None
 }
 
+/// Find which block contains the given offset in an art file (*.art.vue).
+///
+/// Uses `vize_musea::parse_art()` to determine cursor position within art variant templates.
+pub fn find_art_block_at_offset(source: &str, offset: usize) -> Option<BlockType> {
+    // First check SFC blocks (script, style)
+    let options = vize_atelier_sfc::SfcParseOptions {
+        filename: Default::default(),
+        ..Default::default()
+    };
+
+    if let Ok(descriptor) = vize_atelier_sfc::parse_sfc(source, options) {
+        // Check script/script_setup/style blocks
+        if let Some(ref script) = descriptor.script {
+            if offset >= script.loc.start && offset < script.loc.end {
+                return Some(BlockType::Script);
+            }
+        }
+        if let Some(ref script_setup) = descriptor.script_setup {
+            if offset >= script_setup.loc.start && offset < script_setup.loc.end {
+                return Some(BlockType::ScriptSetup);
+            }
+        }
+        for (i, style) in descriptor.styles.iter().enumerate() {
+            if offset >= style.loc.start && offset < style.loc.end {
+                return Some(BlockType::Style(i));
+            }
+        }
+    }
+
+    // Parse as art file to determine variant position
+    let allocator = vize_carton::Bump::new();
+    let Ok(art_desc) =
+        vize_musea::parse_art(&allocator, source, vize_musea::ArtParseOptions::default())
+    else {
+        return None;
+    };
+
+    for (i, variant) in art_desc.variants.iter().enumerate() {
+        if let Some(ref loc) = variant.loc {
+            let variant_start = loc.start as usize;
+            let variant_end = loc.end as usize;
+
+            if offset >= variant_start && offset < variant_end {
+                // Determine template content position using pointer arithmetic
+                let template_ptr = variant.template.as_ptr() as usize;
+                let source_ptr = source.as_ptr() as usize;
+                let template_start = template_ptr - source_ptr;
+                let template_end = template_start + variant.template.len();
+
+                if offset >= template_start && offset < template_end {
+                    return Some(BlockType::Art(ArtCursorPosition::VariantTemplate(
+                        ArtVariantInfo {
+                            variant_index: i,
+                            template_start,
+                            template_end,
+                            relative_offset: offset - template_start,
+                        },
+                    )));
+                }
+
+                return Some(BlockType::Art(ArtCursorPosition::VariantTag(i)));
+            }
+        }
+    }
+
+    Some(BlockType::Art(ArtCursorPosition::ArtContent))
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
-        find_block_at_offset, BatchVirtualCodeGenerator, BlockType, VirtualCodeGenerator,
-        VirtualLanguage,
+        find_art_block_at_offset, find_block_at_offset, ArtCursorPosition,
+        BatchVirtualCodeGenerator, BlockType, VirtualCodeGenerator, VirtualLanguage,
     };
 
     #[test]
@@ -414,7 +508,7 @@ const x = 1
         let art_content_start = descriptor.custom_blocks[0].loc.start;
         assert_eq!(
             find_block_at_offset(&descriptor, art_content_start + 5),
-            Some(BlockType::Art(0))
+            Some(BlockType::Art(ArtCursorPosition::ArtContent))
         );
 
         // In template - should still be Template
@@ -429,6 +523,46 @@ const x = 1
 
     #[test]
     fn test_block_type_art_language() {
-        assert_eq!(BlockType::Art(0).language(), VirtualLanguage::Template);
+        assert_eq!(
+            BlockType::Art(ArtCursorPosition::ArtContent).language(),
+            VirtualLanguage::Template
+        );
+    }
+
+    #[test]
+    fn test_find_art_block_at_offset() {
+        let source = r#"<art title="Button" component="./Button.vue">
+  <variant name="Primary" default>
+    <Button>Click me</Button>
+  </variant>
+</art>
+
+<script setup lang="ts">
+import Button from './Button.vue'
+</script>"#;
+
+        // In script setup
+        let script_offset = source.find("import Button").unwrap();
+        assert_eq!(
+            find_art_block_at_offset(source, script_offset),
+            Some(BlockType::ScriptSetup)
+        );
+
+        // In variant template content
+        let template_offset = source.find("<Button>Click me</Button>").unwrap();
+        let result = find_art_block_at_offset(source, template_offset);
+        assert!(matches!(
+            result,
+            Some(BlockType::Art(ArtCursorPosition::VariantTemplate(_)))
+        ));
+
+        // In art content (between variants)
+        let art_content_offset = source.find("\n  <variant").unwrap() + 1;
+        // This offset is just before <variant, which is inside the <art> but before variant tag starts
+        // It should be ArtContent
+        assert!(matches!(
+            find_art_block_at_offset(source, 1),
+            Some(BlockType::Art(_))
+        ));
     }
 }

--- a/crates/vize_maestro/src/virtual_code/mod.rs
+++ b/crates/vize_maestro/src/virtual_code/mod.rs
@@ -35,7 +35,8 @@ mod style_code;
 mod template_code;
 
 pub use generator::{
-    find_block_at_offset, BatchVirtualCodeGenerator, BlockType, VirtualCodeGenerator,
+    find_art_block_at_offset, find_block_at_offset, ArtCursorPosition, ArtVariantInfo,
+    BatchVirtualCodeGenerator, BlockType, VirtualCodeGenerator,
 };
 pub use script_code::{extract_simple_bindings, ScriptCodeGenerator};
 pub use source_map::{MappingData, MappingFeatures, SourceMap, SourceMapping};


### PR DESCRIPTION
## Summary

Add full tsgo-powered IDE support (type checking, autocompletion, hover, go-to-definition) for art files (`*.art.vue`).

Previously, art files received zero type intelligence from tsgo — diagnostics early-returned with only musea linter checks, completion returned only static snippets, and hover/definition returned `None`. The root cause was that art files have no `<template>` block (templates live inside `<variant>` blocks), so the virtual TS generation pipeline produced nothing.

### Changes

- **`BlockType::Art` refinement**: Replaced `BlockType::Art(usize)` with `BlockType::Art(ArtCursorPosition)` to distinguish cursor positions: `ArtTag`, `VariantTag`, `VariantTemplate`, and `ArtContent`. Added `find_art_block_at_offset()` that uses `vize_musea::parse_art()` for precise variant-level cursor detection.

- **Virtual document generation for art files**: `update_virtual_docs()` now handles `.art.vue` files by synthesizing a template virtual doc from the default variant's template content, with correct `block_offset` for source mapping. Script setup/script virtual docs are generated via the existing SFC parser.

- **tsgo diagnostics**: Added `generate_virtual_ts_for_art()` that builds virtual TypeScript from the default variant's template + script setup, using the same `vize_canon` pipeline as regular SFC files. Art files no longer skip tsgo diagnostics.

- **Completion**: Art variant template cursors route to `complete_art_variant_with_tsgo()`, which maps the variant-relative offset through the template source map. Script setup in art files falls through to normal script completion with tsgo.

- **Hover**: Art variant template cursors route to `hover_art_variant_with_tsgo()`, with fallback to directive hover and croquis-based template hover.

- **Definition**: Art variant template cursors route to `definition_in_art_variant_with_tsgo()`, with component tag detection and tsgo fallback.

### Architecture

The approach reuses the entire existing `vize_canon` / `vize_croquis` / `vize_armature` pipeline by synthesizing a virtual template from the default variant's content. Pointer arithmetic calculates the template's byte offset in the original art file, ensuring source maps correctly link virtual TS positions back to art file locations. The `ArtVariantInfo.relative_offset` field carries the cursor's position within the variant template for offset conversion through the template source map.