### PR TITLE
fix(atelier_sfc): report errors for malformed tags

### DIFF
--- a/crates/vize_atelier_sfc/src/parse/block.rs
+++ b/crates/vize_atelier_sfc/src/parse/block.rs
@@ -2,10 +2,6 @@ use memchr::memchr;
 use std::borrow::Cow;
 use vize_carton::{cstr, FxHashMap, String};
 
-// Static closing tags for fast comparison (avoid format!)
-const CLOSING_SCRIPT: &[u8] = b"</script>";
-const CLOSING_STYLE: &[u8] = b"</style>";
-
 // Tag name bytes for fast comparison
 const TAG_TEMPLATE: &[u8] = b"template";
 const TAG_SCRIPT: &[u8] = b"script";
@@ -42,6 +38,32 @@ fn is_tag_name_char_fast(b: u8) -> bool {
 #[inline(always)]
 fn is_whitespace_fast(b: u8) -> bool {
     matches!(b, b' ' | b'\t' | b'\n' | b'\r')
+}
+
+/// Find the end of a closing tag `</tag_name` followed by optional whitespace and `>`.
+/// Returns the position immediately after `>`, or `None` if no valid closing tag at `pos`.
+#[inline]
+fn find_closing_tag_end(bytes: &[u8], pos: usize, len: usize, tag_name: &[u8]) -> Option<usize> {
+    // Need at least "</" + tag_name + ">"
+    if pos + 2 + tag_name.len() >= len {
+        return None;
+    }
+    if bytes[pos] != b'<' || bytes[pos + 1] != b'/' {
+        return None;
+    }
+    let name_start = pos + 2;
+    if !bytes[name_start..name_start + tag_name.len()].eq_ignore_ascii_case(tag_name) {
+        return None;
+    }
+    let mut check_pos = name_start + tag_name.len();
+    while check_pos < len {
+        match bytes[check_pos] {
+            b'>' => return Some(check_pos + 1),
+            b' ' | b'\t' | b'\n' | b'\r' => check_pos += 1,
+            _ => return None,
+        }
+    }
+    None
 }
 
 /// Parse a single block from the source using byte operations
@@ -321,13 +343,8 @@ pub(super) fn parse_block_fast<'a>(
         ));
     }
 
-    // Script/style blocks: use static closing tags
-    let closing_tag = if tag_name.eq_ignore_ascii_case(TAG_SCRIPT) {
-        CLOSING_SCRIPT
-    } else if tag_name.eq_ignore_ascii_case(TAG_STYLE) {
-        CLOSING_STYLE
-    } else {
-        // Custom block: need to find closing tag dynamically
+    // Custom block: need to find closing tag dynamically
+    if !tag_name.eq_ignore_ascii_case(TAG_SCRIPT) && !tag_name.eq_ignore_ascii_case(TAG_STYLE) {
         return find_custom_block_end(
             bytes,
             source,
@@ -337,7 +354,7 @@ pub(super) fn parse_block_fast<'a>(
             start_line,
             attrs,
         );
-    };
+    }
 
     // For script blocks, we need to be aware of string literals to avoid
     // matching closing tags inside strings like: const x = `</script>`
@@ -484,22 +501,23 @@ pub(super) fn parse_block_fast<'a>(
             }
         }
 
-        // Check for closing tag
-        if b == b'<' && starts_with_bytes(&bytes[pos..], closing_tag) {
-            let content_end = pos;
-            let end_pos = pos + closing_tag.len();
-            let col = pos - last_newline + closing_tag.len();
-            let content = Cow::Borrowed(&source[content_start..content_end]);
-            return Ok(Some((
-                tag_name,
-                attrs,
-                content,
-                content_start,
-                content_end,
-                end_pos,
-                line,
-                col,
-            )));
+        // Check for closing tag (allows optional whitespace before '>')
+        if b == b'<' {
+            if let Some(end_tag_pos) = find_closing_tag_end(bytes, pos, len, tag_name) {
+                let content_end = pos;
+                let col = pos - last_newline + (end_tag_pos - pos);
+                let content = Cow::Borrowed(&source[content_start..content_end]);
+                return Ok(Some((
+                    tag_name,
+                    attrs,
+                    content,
+                    content_start,
+                    content_end,
+                    end_tag_pos,
+                    line,
+                    col,
+                )));
+            }
         }
 
         prev_significant_char = b;
@@ -550,32 +568,22 @@ fn find_custom_block_end<'a>(
             }
             pos += lt_offset;
 
-            // Check for </
-            if pos + 2 < len && bytes[pos] == b'<' && bytes[pos + 1] == b'/' {
-                let close_tag_start = pos + 2;
-                // Check if tag name matches
-                if close_tag_start + tag_name.len() <= len
-                    && bytes[close_tag_start..close_tag_start + tag_name.len()]
-                        .eq_ignore_ascii_case(tag_name)
-                {
-                    // Check for closing >
-                    let after_name = close_tag_start + tag_name.len();
-                    if after_name < len && bytes[after_name] == b'>' {
-                        let content_end = pos;
-                        let end_pos = after_name + 1;
-                        let col = pos - last_newline + (end_pos - pos);
-                        let content = Cow::Borrowed(&source[content_start..content_end]);
-                        return Ok(Some((
-                            tag_name,
-                            attrs,
-                            content,
-                            content_start,
-                            content_end,
-                            end_pos,
-                            line,
-                            col,
-                        )));
-                    }
+            // Check for closing tag (allows optional whitespace before '>')
+            if bytes[pos] == b'<' {
+                if let Some(end_tag_pos) = find_closing_tag_end(bytes, pos, len, tag_name) {
+                    let content_end = pos;
+                    let col = pos - last_newline + (end_tag_pos - pos);
+                    let content = Cow::Borrowed(&source[content_start..content_end]);
+                    return Ok(Some((
+                        tag_name,
+                        attrs,
+                        content,
+                        content_start,
+                        content_end,
+                        end_tag_pos,
+                        line,
+                        col,
+                    )));
                 }
             }
             pos += 1;

--- a/crates/vize_atelier_sfc/src/parse/block.rs
+++ b/crates/vize_atelier_sfc/src/parse/block.rs
@@ -11,19 +11,14 @@ const TAG_TEMPLATE: &[u8] = b"template";
 const TAG_SCRIPT: &[u8] = b"script";
 const TAG_STYLE: &[u8] = b"style";
 
-/// Error codes and messages for malformed known blocks.
-const MALFORMED_TEMPLATE: (&str, &str) = (
-    "MALFORMED_TEMPLATE",
-    "Malformed <template> block: opening tag or closing tag is incomplete.",
-);
-const MALFORMED_SCRIPT: (&str, &str) = (
-    "MALFORMED_SCRIPT",
-    "Malformed <script> block: missing valid closing tag.",
-);
-const MALFORMED_STYLE: (&str, &str) = (
-    "MALFORMED_STYLE",
-    "Malformed <style> block: missing valid closing tag.",
-);
+/// Build a uniform `(code, message)` error for any malformed block.
+fn build_malformed_error(tag_name: &[u8], reason: &str) -> (&'static str, String) {
+    let tag_str = std::str::from_utf8(tag_name).unwrap_or("unknown");
+    (
+        "MALFORMED_BLOCK",
+        format!("Malformed <{tag_str}> block: {reason}."),
+    )
+}
 
 /// Fast tag name comparison using byte slices
 #[inline(always)]
@@ -54,7 +49,7 @@ fn is_whitespace_fast(b: u8) -> bool {
 ///
 /// - `Ok(Some(...))` — successfully parsed block.
 /// - `Ok(None)`      — can't find a block at this position (stray `<`, comment, etc.)
-/// - `Err((code, message))` — position starts a known invalid block (`<template>`, `<script>`, `<style>`)
+/// - `Err((code, message))` — position starts an invalid/incomplete block
 pub(super) fn parse_block_fast<'a>(
     bytes: &[u8],
     source: &'a str,
@@ -71,7 +66,7 @@ pub(super) fn parse_block_fast<'a>(
         usize,                                 // end line
         usize,                                 // end column
     )>,
-    (&'static str, &'static str), // (error_code, error_message)
+    (&'static str, String), // (error_code, error_message)
 > {
     let len = bytes.len();
 
@@ -92,18 +87,6 @@ pub(super) fn parse_block_fast<'a>(
     }
 
     let tag_name = &source.as_bytes()[tag_start..pos];
-
-    // Determine if this is a known block so we can return a structured error on failure.
-    let known_block_error: Option<(&'static str, &'static str)> =
-        if tag_name.eq_ignore_ascii_case(TAG_TEMPLATE) {
-            Some(MALFORMED_TEMPLATE)
-        } else if tag_name.eq_ignore_ascii_case(TAG_SCRIPT) {
-            Some(MALFORMED_SCRIPT)
-        } else if tag_name.eq_ignore_ascii_case(TAG_STYLE) {
-            Some(MALFORMED_STYLE)
-        } else {
-            None
-        };
 
     // Parse attributes with zero-copy
     let mut attrs: FxHashMap<Cow<'a, str>, Cow<'a, str>> = FxHashMap::default();
@@ -223,11 +206,11 @@ pub(super) fn parse_block_fast<'a>(
     if pos < len && bytes[pos] == b'>' {
         pos += 1;
     } else {
-        // Opening tag is not closed — error for known blocks, skip for others.
-        return match known_block_error {
-            Some(err) => Err(err),
-            None => Ok(None),
-        };
+        // Opening tag is not closed — error for any tag.
+        return Err(build_malformed_error(
+            tag_name,
+            "the opening tag is incomplete",
+        ));
     }
 
     let content_start = pos;
@@ -332,14 +315,17 @@ pub(super) fn parse_block_fast<'a>(
             pos += 1;
         }
         // Exhausted input without finding </template>
-        return Err(MALFORMED_TEMPLATE);
+        return Err(build_malformed_error(
+            tag_name,
+            "the closing tag is missing",
+        ));
     }
 
     // Script/style blocks: use static closing tags
-    let (closing_tag, block_error) = if tag_name.eq_ignore_ascii_case(TAG_SCRIPT) {
-        (CLOSING_SCRIPT, MALFORMED_SCRIPT)
+    let closing_tag = if tag_name.eq_ignore_ascii_case(TAG_SCRIPT) {
+        CLOSING_SCRIPT
     } else if tag_name.eq_ignore_ascii_case(TAG_STYLE) {
-        (CLOSING_STYLE, MALFORMED_STYLE)
+        CLOSING_STYLE
     } else {
         // Custom block: need to find closing tag dynamically
         return find_custom_block_end(
@@ -520,8 +506,11 @@ pub(super) fn parse_block_fast<'a>(
         pos += 1;
     }
 
-    // Exhausted input without finding the closing tag for a known block.
-    Err(block_error)
+    // Exhausted input without finding the closing tag.
+    Err(build_malformed_error(
+        tag_name,
+        "the closing tag is missing",
+    ))
 }
 
 /// Find the end of a custom block (non-template/script/style)
@@ -544,7 +533,7 @@ fn find_custom_block_end<'a>(
         usize,
         usize,
     )>,
-    (&'static str, &'static str),
+    (&'static str, String),
 > {
     let len = bytes.len();
     let mut line = start_line;
@@ -595,5 +584,9 @@ fn find_custom_block_end<'a>(
         }
     }
 
-    Ok(None)
+    // Exhausted input without finding the closing tag.
+    Err(build_malformed_error(
+        tag_name,
+        "the closing tag is missing",
+    ))
 }

--- a/crates/vize_atelier_sfc/src/parse/block.rs
+++ b/crates/vize_atelier_sfc/src/parse/block.rs
@@ -2,9 +2,9 @@ use memchr::memchr;
 use std::borrow::Cow;
 use vize_carton::{cstr, FxHashMap, String};
 
-// Static closing tag prefixes without '>' for fast comparison (avoid format!)
-const CLOSING_SCRIPT: &[u8] = b"</script";
-const CLOSING_STYLE: &[u8] = b"</style";
+// Static closing tags for fast comparison (avoid format!)
+const CLOSING_SCRIPT: &[u8] = b"</script>";
+const CLOSING_STYLE: &[u8] = b"</style>";
 
 // Tag name bytes for fast comparison
 const TAG_TEMPLATE: &[u8] = b"template";
@@ -486,33 +486,27 @@ pub(super) fn parse_block_fast<'a>(
 
         // Check for closing tag
         if b == b'<' && starts_with_bytes(&bytes[pos..], closing_tag) {
-            let after = pos + closing_tag.len();
-            if after < len && bytes[after] == b'>' {
-                let content_end = pos;
-                let end_pos = after + 1;
-                let col = pos - last_newline + closing_tag.len() + 1;
-                let content = Cow::Borrowed(&source[content_start..content_end]);
-                return Ok(Some((
-                    tag_name,
-                    attrs,
-                    content,
-                    content_start,
-                    content_end,
-                    end_pos,
-                    line,
-                    col,
-                )));
-            }
-            return Err(build_malformed_error(
+            let content_end = pos;
+            let end_pos = pos + closing_tag.len();
+            let col = pos - last_newline + closing_tag.len();
+            let content = Cow::Borrowed(&source[content_start..content_end]);
+            return Ok(Some((
                 tag_name,
-                "the closing tag is incomplete",
-            ));
+                attrs,
+                content,
+                content_start,
+                content_end,
+                end_pos,
+                line,
+                col,
+            )));
         }
 
         prev_significant_char = b;
         pos += 1;
     }
 
+    // Exhausted input without finding the closing tag.
     Err(build_malformed_error(
         tag_name,
         "the closing tag is missing",

--- a/crates/vize_atelier_sfc/src/parse/block.rs
+++ b/crates/vize_atelier_sfc/src/parse/block.rs
@@ -11,6 +11,20 @@ const TAG_TEMPLATE: &[u8] = b"template";
 const TAG_SCRIPT: &[u8] = b"script";
 const TAG_STYLE: &[u8] = b"style";
 
+/// Error codes and messages for malformed known blocks.
+const MALFORMED_TEMPLATE: (&str, &str) = (
+    "MALFORMED_TEMPLATE",
+    "Malformed <template> block: opening tag or closing tag is incomplete.",
+);
+const MALFORMED_SCRIPT: (&str, &str) = (
+    "MALFORMED_SCRIPT",
+    "Malformed <script> block: missing valid closing tag.",
+);
+const MALFORMED_STYLE: (&str, &str) = (
+    "MALFORMED_STYLE",
+    "Malformed <style> block: missing valid closing tag.",
+);
+
 /// Fast tag name comparison using byte slices
 #[inline(always)]
 pub(super) fn tag_name_eq(name: &[u8], expected: &[u8]) -> bool {
@@ -37,27 +51,34 @@ fn is_whitespace_fast(b: u8) -> bool {
 
 /// Parse a single block from the source using byte operations
 /// Returns borrowed strings using Cow for zero-copy
+///
+/// - `Ok(Some(...))` — successfully parsed block.
+/// - `Ok(None)`      — can't find a block at this position (stray `<`, comment, etc.)
+/// - `Err((code, message))` — position starts a known invalid block (`<template>`, `<script>`, `<style>`)
 pub(super) fn parse_block_fast<'a>(
     bytes: &[u8],
     source: &'a str,
     start: usize,
     start_line: usize,
-) -> Option<(
-    &'a [u8],                              // tag name as bytes
-    FxHashMap<Cow<'a, str>, Cow<'a, str>>, // attrs with borrowed strings
-    Cow<'a, str>,                          // content as borrowed string
-    usize,                                 // content start
-    usize,                                 // content end
-    usize,                                 // end position
-    usize,                                 // end line
-    usize,                                 // end column
-)> {
+) -> Result<
+    Option<(
+        &'a [u8],                              // tag name as bytes
+        FxHashMap<Cow<'a, str>, Cow<'a, str>>, // attrs with borrowed strings
+        Cow<'a, str>,                          // content as borrowed string
+        usize,                                 // content start
+        usize,                                 // content end
+        usize,                                 // end position
+        usize,                                 // end line
+        usize,                                 // end column
+    )>,
+    (&'static str, &'static str), // (error_code, error_message)
+> {
     let len = bytes.len();
 
     // Skip '<'
     let mut pos = start + 1;
     if pos >= len {
-        return None;
+        return Ok(None);
     }
 
     // Parse tag name - find end of tag name
@@ -67,10 +88,22 @@ pub(super) fn parse_block_fast<'a>(
     }
 
     if pos == tag_start {
-        return None;
+        return Ok(None);
     }
 
     let tag_name = &source.as_bytes()[tag_start..pos];
+
+    // Determine if this is a known block so we can return a structured error on failure.
+    let known_block_error: Option<(&'static str, &'static str)> =
+        if tag_name.eq_ignore_ascii_case(TAG_TEMPLATE) {
+            Some(MALFORMED_TEMPLATE)
+        } else if tag_name.eq_ignore_ascii_case(TAG_SCRIPT) {
+            Some(MALFORMED_SCRIPT)
+        } else if tag_name.eq_ignore_ascii_case(TAG_STYLE) {
+            Some(MALFORMED_STYLE)
+        } else {
+            None
+        };
 
     // Parse attributes with zero-copy
     let mut attrs: FxHashMap<Cow<'a, str>, Cow<'a, str>> = FxHashMap::default();
@@ -174,7 +207,7 @@ pub(super) fn parse_block_fast<'a>(
         if pos < len && bytes[pos] == b'>' {
             pos += 1;
         }
-        return Some((
+        return Ok(Some((
             tag_name,
             attrs,
             Cow::Borrowed(""),
@@ -183,14 +216,18 @@ pub(super) fn parse_block_fast<'a>(
             pos,
             start_line,
             pos - start,
-        ));
+        )));
     }
 
     // Skip '>'
     if pos < len && bytes[pos] == b'>' {
         pos += 1;
     } else {
-        return None;
+        // Opening tag is not closed — error for known blocks, skip for others.
+        return match known_block_error {
+            Some(err) => Err(err),
+            None => Ok(None),
+        };
     }
 
     let content_start = pos;
@@ -245,7 +282,7 @@ pub(super) fn parse_block_fast<'a>(
                         let end_pos = end_tag_pos;
                         let col = pos - last_newline + (end_pos - pos);
                         let content = Cow::Borrowed(&source[content_start..content_end]);
-                        return Some((
+                        return Ok(Some((
                             tag_name,
                             attrs,
                             content,
@@ -254,7 +291,7 @@ pub(super) fn parse_block_fast<'a>(
                             end_pos,
                             line,
                             col,
-                        ));
+                        )));
                     }
                     pos = end_tag_pos;
                     continue;
@@ -294,14 +331,15 @@ pub(super) fn parse_block_fast<'a>(
 
             pos += 1;
         }
-        return None;
+        // Exhausted input without finding </template>
+        return Err(MALFORMED_TEMPLATE);
     }
 
     // Script/style blocks: use static closing tags
-    let closing_tag = if tag_name.eq_ignore_ascii_case(TAG_SCRIPT) {
-        CLOSING_SCRIPT
+    let (closing_tag, block_error) = if tag_name.eq_ignore_ascii_case(TAG_SCRIPT) {
+        (CLOSING_SCRIPT, MALFORMED_SCRIPT)
     } else if tag_name.eq_ignore_ascii_case(TAG_STYLE) {
-        CLOSING_STYLE
+        (CLOSING_STYLE, MALFORMED_STYLE)
     } else {
         // Custom block: need to find closing tag dynamically
         return find_custom_block_end(
@@ -466,7 +504,7 @@ pub(super) fn parse_block_fast<'a>(
             let end_pos = pos + closing_tag.len();
             let col = pos - last_newline + closing_tag.len();
             let content = Cow::Borrowed(&source[content_start..content_end]);
-            return Some((
+            return Ok(Some((
                 tag_name,
                 attrs,
                 content,
@@ -475,14 +513,15 @@ pub(super) fn parse_block_fast<'a>(
                 end_pos,
                 line,
                 col,
-            ));
+            )));
         }
 
         prev_significant_char = b;
         pos += 1;
     }
 
-    None
+    // Exhausted input without finding the closing tag for a known block.
+    Err(block_error)
 }
 
 /// Find the end of a custom block (non-template/script/style)
@@ -494,16 +533,19 @@ fn find_custom_block_end<'a>(
     content_start: usize,
     start_line: usize,
     attrs: FxHashMap<Cow<'a, str>, Cow<'a, str>>,
-) -> Option<(
-    &'a [u8],
-    FxHashMap<Cow<'a, str>, Cow<'a, str>>,
-    Cow<'a, str>,
-    usize,
-    usize,
-    usize,
-    usize,
-    usize,
-)> {
+) -> Result<
+    Option<(
+        &'a [u8],
+        FxHashMap<Cow<'a, str>, Cow<'a, str>>,
+        Cow<'a, str>,
+        usize,
+        usize,
+        usize,
+        usize,
+        usize,
+    )>,
+    (&'static str, &'static str),
+> {
     let len = bytes.len();
     let mut line = start_line;
     let mut last_newline = content_start;
@@ -534,7 +576,7 @@ fn find_custom_block_end<'a>(
                         let end_pos = after_name + 1;
                         let col = pos - last_newline + (end_pos - pos);
                         let content = Cow::Borrowed(&source[content_start..content_end]);
-                        return Some((
+                        return Ok(Some((
                             tag_name,
                             attrs,
                             content,
@@ -543,7 +585,7 @@ fn find_custom_block_end<'a>(
                             end_pos,
                             line,
                             col,
-                        ));
+                        )));
                     }
                 }
             }
@@ -553,5 +595,5 @@ fn find_custom_block_end<'a>(
         }
     }
 
-    None
+    Ok(None)
 }

--- a/crates/vize_atelier_sfc/src/parse/block.rs
+++ b/crates/vize_atelier_sfc/src/parse/block.rs
@@ -2,9 +2,9 @@ use memchr::memchr;
 use std::borrow::Cow;
 use vize_carton::{cstr, FxHashMap, String};
 
-// Static closing tags for fast comparison (avoid format!)
-const CLOSING_SCRIPT: &[u8] = b"</script>";
-const CLOSING_STYLE: &[u8] = b"</style>";
+// Static closing tag prefixes without '>' for fast comparison (avoid format!)
+const CLOSING_SCRIPT: &[u8] = b"</script";
+const CLOSING_STYLE: &[u8] = b"</style";
 
 // Tag name bytes for fast comparison
 const TAG_TEMPLATE: &[u8] = b"template";
@@ -486,27 +486,33 @@ pub(super) fn parse_block_fast<'a>(
 
         // Check for closing tag
         if b == b'<' && starts_with_bytes(&bytes[pos..], closing_tag) {
-            let content_end = pos;
-            let end_pos = pos + closing_tag.len();
-            let col = pos - last_newline + closing_tag.len();
-            let content = Cow::Borrowed(&source[content_start..content_end]);
-            return Ok(Some((
+            let after = pos + closing_tag.len();
+            if after < len && bytes[after] == b'>' {
+                let content_end = pos;
+                let end_pos = after + 1;
+                let col = pos - last_newline + closing_tag.len() + 1;
+                let content = Cow::Borrowed(&source[content_start..content_end]);
+                return Ok(Some((
+                    tag_name,
+                    attrs,
+                    content,
+                    content_start,
+                    content_end,
+                    end_pos,
+                    line,
+                    col,
+                )));
+            }
+            return Err(build_malformed_error(
                 tag_name,
-                attrs,
-                content,
-                content_start,
-                content_end,
-                end_pos,
-                line,
-                col,
-            )));
+                "the closing tag is incomplete",
+            ));
         }
 
         prev_significant_char = b;
         pos += 1;
     }
 
-    // Exhausted input without finding the closing tag.
     Err(build_malformed_error(
         tag_name,
         "the closing tag is missing",

--- a/crates/vize_atelier_sfc/src/parse/block.rs
+++ b/crates/vize_atelier_sfc/src/parse/block.rs
@@ -1,6 +1,6 @@
 use memchr::memchr;
 use std::borrow::Cow;
-use vize_carton::FxHashMap;
+use vize_carton::{cstr, FxHashMap, String};
 
 // Static closing tags for fast comparison (avoid format!)
 const CLOSING_SCRIPT: &[u8] = b"</script>";
@@ -16,7 +16,7 @@ fn build_malformed_error(tag_name: &[u8], reason: &str) -> (&'static str, String
     let tag_str = std::str::from_utf8(tag_name).unwrap_or("unknown");
     (
         "MALFORMED_BLOCK",
-        format!("Malformed <{tag_str}> block: {reason}."),
+        cstr!("Malformed <{tag_str}> block: {reason}."),
     )
 }
 

--- a/crates/vize_atelier_sfc/src/parse/parse_sfc.rs
+++ b/crates/vize_atelier_sfc/src/parse/parse_sfc.rs
@@ -95,108 +95,135 @@ pub fn parse_sfc<'a>(
         }
 
         // Parse block starting at '<'
-        if let Some(block_result) = parse_block_fast(bytes, source, pos, line) {
-            let (tag_name, attrs, content, content_start, content_end, end_pos, end_line, end_col) =
-                block_result;
+        match parse_block_fast(bytes, source, pos, line) {
+            Ok(Some(block_result)) => {
+                let (
+                    tag_name,
+                    attrs,
+                    content,
+                    content_start,
+                    content_end,
+                    end_pos,
+                    end_line,
+                    end_col,
+                ) = block_result;
 
-            let loc = BlockLocation {
-                start: content_start,
-                end: content_end,
-                tag_start: pos,
-                tag_end: end_pos,
-                start_line: line,
-                start_column: column,
-                end_line,
-                end_column: end_col,
-            };
+                let loc = BlockLocation {
+                    start: content_start,
+                    end: content_end,
+                    tag_start: pos,
+                    tag_end: end_pos,
+                    start_line: line,
+                    start_column: column,
+                    end_line,
+                    end_column: end_col,
+                };
 
-            // Match tag name using byte comparison
-            if tag_name_eq(tag_name, TAG_TEMPLATE) {
-                if descriptor.template.is_some() {
-                    return Err(SfcError {
-                        message: "SFC can only contain one <template> block".into(),
-                        code: Some("DUPLICATE_TEMPLATE".into()),
-                        loc: Some(loc.clone()),
+                // Match tag name using byte comparison
+                if tag_name_eq(tag_name, TAG_TEMPLATE) {
+                    if descriptor.template.is_some() {
+                        return Err(SfcError {
+                            message: "SFC can only contain one <template> block".into(),
+                            code: Some("DUPLICATE_TEMPLATE".into()),
+                            loc: Some(loc.clone()),
+                        });
+                    }
+                    descriptor.template = Some(SfcTemplateBlock {
+                        content,
+                        loc,
+                        lang: attrs.get("lang").cloned(),
+                        src: attrs.get("src").cloned(),
+                        attrs,
+                    });
+                } else if tag_name_eq(tag_name, TAG_SCRIPT) {
+                    let is_setup = attrs.contains_key("setup");
+                    let script_block = SfcScriptBlock {
+                        content,
+                        loc,
+                        lang: attrs.get("lang").cloned(),
+                        src: attrs.get("src").cloned(),
+                        setup: is_setup,
+                        attrs,
+                        bindings: None,
+                    };
+
+                    if is_setup {
+                        if descriptor.script_setup.is_some() {
+                            return Err(SfcError {
+                                message: "SFC can only contain one <script setup> block".into(),
+                                code: Some("DUPLICATE_SCRIPT_SETUP".into()),
+                                loc: Some(script_block.loc),
+                            });
+                        }
+                        descriptor.script_setup = Some(script_block);
+                    } else {
+                        if descriptor.script.is_some() {
+                            return Err(SfcError {
+                                message: "SFC can only contain one <script> block".into(),
+                                code: Some("DUPLICATE_SCRIPT".into()),
+                                loc: Some(script_block.loc),
+                            });
+                        }
+                        descriptor.script = Some(script_block);
+                    }
+                } else if tag_name_eq(tag_name, TAG_STYLE) {
+                    let scoped = attrs.contains_key("scoped");
+                    let module = if attrs.contains_key("module") {
+                        Some(
+                            attrs
+                                .get("module")
+                                .filter(|v| !v.is_empty())
+                                .cloned()
+                                .unwrap_or_else(|| Cow::Borrowed("$style")),
+                        )
+                    } else {
+                        None
+                    };
+
+                    descriptor.styles.push(SfcStyleBlock {
+                        content,
+                        loc,
+                        lang: attrs.get("lang").cloned(),
+                        src: attrs.get("src").cloned(),
+                        scoped,
+                        module,
+                        attrs,
+                    });
+                } else {
+                    // Custom block - use borrowed tag name
+                    let tag_str = unsafe { std::str::from_utf8_unchecked(tag_name) };
+                    descriptor.custom_blocks.push(SfcCustomBlock {
+                        block_type: Cow::Borrowed(tag_str),
+                        content,
+                        loc,
+                        attrs,
                     });
                 }
-                descriptor.template = Some(SfcTemplateBlock {
-                    content,
-                    loc,
-                    lang: attrs.get("lang").cloned(),
-                    src: attrs.get("src").cloned(),
-                    attrs,
-                });
-            } else if tag_name_eq(tag_name, TAG_SCRIPT) {
-                let is_setup = attrs.contains_key("setup");
-                let script_block = SfcScriptBlock {
-                    content,
-                    loc,
-                    lang: attrs.get("lang").cloned(),
-                    src: attrs.get("src").cloned(),
-                    setup: is_setup,
-                    attrs,
-                    bindings: None,
-                };
 
-                if is_setup {
-                    if descriptor.script_setup.is_some() {
-                        return Err(SfcError {
-                            message: "SFC can only contain one <script setup> block".into(),
-                            code: Some("DUPLICATE_SCRIPT_SETUP".into()),
-                            loc: Some(script_block.loc),
-                        });
-                    }
-                    descriptor.script_setup = Some(script_block);
-                } else {
-                    if descriptor.script.is_some() {
-                        return Err(SfcError {
-                            message: "SFC can only contain one <script> block".into(),
-                            code: Some("DUPLICATE_SCRIPT".into()),
-                            loc: Some(script_block.loc),
-                        });
-                    }
-                    descriptor.script = Some(script_block);
-                }
-            } else if tag_name_eq(tag_name, TAG_STYLE) {
-                let scoped = attrs.contains_key("scoped");
-                let module = if attrs.contains_key("module") {
-                    Some(
-                        attrs
-                            .get("module")
-                            .filter(|v| !v.is_empty())
-                            .cloned()
-                            .unwrap_or_else(|| Cow::Borrowed("$style")),
-                    )
-                } else {
-                    None
-                };
-
-                descriptor.styles.push(SfcStyleBlock {
-                    content,
-                    loc,
-                    lang: attrs.get("lang").cloned(),
-                    src: attrs.get("src").cloned(),
-                    scoped,
-                    module,
-                    attrs,
-                });
-            } else {
-                // Custom block - use borrowed tag name
-                let tag_str = unsafe { std::str::from_utf8_unchecked(tag_name) };
-                descriptor.custom_blocks.push(SfcCustomBlock {
-                    block_type: Cow::Borrowed(tag_str),
-                    content,
-                    loc,
-                    attrs,
+                pos = end_pos;
+                line = end_line;
+                column = end_col;
+            }
+            Ok(None) => {
+                pos += 1;
+                column += 1;
+            }
+            Err((code, message)) => {
+                return Err(SfcError {
+                    message: message.into(),
+                    code: Some(code.into()),
+                    loc: Some(BlockLocation {
+                        start: pos,
+                        end: len,
+                        tag_start: pos,
+                        tag_end: len,
+                        start_line: line,
+                        start_column: column,
+                        end_line: line,
+                        end_column: column,
+                    }),
                 });
             }
-
-            pos = end_pos;
-            line = end_line;
-            column = end_col;
-        } else {
-            pos += 1;
-            column += 1;
         }
     }
 

--- a/crates/vize_atelier_sfc/src/parse/parse_sfc.rs
+++ b/crates/vize_atelier_sfc/src/parse/parse_sfc.rs
@@ -210,7 +210,7 @@ pub fn parse_sfc<'a>(
             }
             Err((code, message)) => {
                 return Err(SfcError {
-                    message: message.into(),
+                    message,
                     code: Some(code.into()),
                     loc: Some(BlockLocation {
                         start: pos,

--- a/crates/vize_atelier_sfc/src/parse/tests.rs
+++ b/crates/vize_atelier_sfc/src/parse/tests.rs
@@ -442,21 +442,10 @@ const x = 1
     assert!(result.script_setup.unwrap().content.contains("const x = 1"));
 }
 
-// ── Malformed block error tests ──────────────────────────────────────────────
-
-#[test]
-fn test_malformed_template_unclosed_open_tag() {
-    // <template without closing '>' on the opening tag
-    let source = "<template";
-    let err = parse_sfc(source, Default::default()).unwrap_err();
-    assert_eq!(err.code.as_deref(), Some("MALFORMED_TEMPLATE"));
-    assert!(err.message.contains("<template>"));
-}
-
 #[test]
 fn test_unclosed_tags() {
     // <template> block that never has </template>
-    let source = "<template><div></div";
+    let source = "<template><div></div>";
     let err = parse_sfc(source, Default::default()).unwrap_err();
     assert_eq!(err.code.as_deref(), Some("MALFORMED_TEMPLATE"));
     assert!(err.message.contains("<template>"));

--- a/crates/vize_atelier_sfc/src/parse/tests.rs
+++ b/crates/vize_atelier_sfc/src/parse/tests.rs
@@ -447,7 +447,7 @@ fn test_unclosed_tags() {
     // <template> block that never has </template>
     let source = "<template><div></div>";
     let err = parse_sfc(source, Default::default()).unwrap_err();
-    assert_eq!(err.code.as_deref(), Some("MALFORMED_TEMPLATE"));
+    assert_eq!(err.code.as_deref(), Some("MALFORMED_BLOCK"));
     assert!(err.message.contains("<template>"));
     // Location should point to the start of the malformed block
     let loc = err.loc.unwrap();
@@ -459,12 +459,12 @@ fn test_incomplete_opening_tags() {
     // <script but no closing '>' on the opening tag
     let source = r#"<script lang="ts""#;
     let err = parse_sfc(source, Default::default()).unwrap_err();
-    assert_eq!(err.code.as_deref(), Some("MALFORMED_SCRIPT"));
+    assert_eq!(err.code.as_deref(), Some("MALFORMED_BLOCK"));
 }
 
 #[test]
 fn test_incomplete_closing_tags() {
     let source = r#"<script lang="ts"></script"#;
     let err = parse_sfc(source, Default::default()).unwrap_err();
-    assert_eq!(err.code.as_deref(), Some("MALFORMED_SCRIPT"));
+    assert_eq!(err.code.as_deref(), Some("MALFORMED_BLOCK"));
 }

--- a/crates/vize_atelier_sfc/src/parse/tests.rs
+++ b/crates/vize_atelier_sfc/src/parse/tests.rs
@@ -468,3 +468,12 @@ fn test_incomplete_closing_tags() {
     let err = parse_sfc(source, Default::default()).unwrap_err();
     assert_eq!(err.code.as_deref(), Some("MALFORMED_BLOCK"));
 }
+
+#[test]
+fn test_closing_script_tag_with_whitespace() {
+    // </script   > and </style   > with trailing whitespace before '>' should be valid
+    let source = "<script>console.log(1)</script   >";
+    let result = parse_sfc(source, Default::default()).unwrap();
+    let script = result.script.unwrap();
+    assert!(script.content.contains("console.log(1)"));
+}

--- a/crates/vize_atelier_sfc/src/parse/tests.rs
+++ b/crates/vize_atelier_sfc/src/parse/tests.rs
@@ -441,3 +441,41 @@ const x = 1
     assert!(result.script_setup.is_some());
     assert!(result.script_setup.unwrap().content.contains("const x = 1"));
 }
+
+// ── Malformed block error tests ──────────────────────────────────────────────
+
+#[test]
+fn test_malformed_template_unclosed_open_tag() {
+    // <template without closing '>' on the opening tag
+    let source = "<template";
+    let err = parse_sfc(source, Default::default()).unwrap_err();
+    assert_eq!(err.code.as_deref(), Some("MALFORMED_TEMPLATE"));
+    assert!(err.message.contains("<template>"));
+}
+
+#[test]
+fn test_unclosed_tags() {
+    // <template> block that never has </template>
+    let source = "<template><div></div";
+    let err = parse_sfc(source, Default::default()).unwrap_err();
+    assert_eq!(err.code.as_deref(), Some("MALFORMED_TEMPLATE"));
+    assert!(err.message.contains("<template>"));
+    // Location should point to the start of the malformed block
+    let loc = err.loc.unwrap();
+    assert_eq!(loc.tag_start, 0);
+}
+
+#[test]
+fn test_incomplete_opening_tags() {
+    // <script but no closing '>' on the opening tag
+    let source = r#"<script lang="ts""#;
+    let err = parse_sfc(source, Default::default()).unwrap_err();
+    assert_eq!(err.code.as_deref(), Some("MALFORMED_SCRIPT"));
+}
+
+#[test]
+fn test_incomplete_closing_tags() {
+    let source = r#"<script lang="ts"></script"#;
+    let err = parse_sfc(source, Default::default()).unwrap_err();
+    assert_eq!(err.code.as_deref(), Some("MALFORMED_SCRIPT"));
+}


### PR DESCRIPTION
The current atelier won't report errors for malformed tags, like incomplete tags, and just skip them, may hide actually syntax errors in Vue SFCs

like

```vue
<template>
<div />
<!-- missing closing tag -->
```

```vue
<template
<!-- incomplte closing tag -->
```

This PR add errors processing logic for `parse_block_fast` to fix it up.

I'm not sure if this was a intentional behavior, but considering that it already throws an error for duplicate `<script>` tags, it's reasonable for it to throw an error for illegel code blocks as well

Generate with Claude Code partially