### PR TITLE
perf: tune compiler and benchmark profiling

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,9 +132,9 @@ Benchmarks with **15,000 Vue SFC files** (36.9 MB). "User-facing speedup" = trad
 
 | Tool             | Traditional (ST)          | Vize (MT)                 | User-facing Speedup |
 | ---------------- | ------------------------- | ------------------------- | ------------------- |
-| **Compiler**     | @vue/compiler-sfc 10.43s  | 612ms                     | **16.7x**           |
+| **Compiler**     | @vue/compiler-sfc 9.28s   | 434ms                     | **20.9x**           |
 | **Linter**       | eslint-plugin-vue 65.30s  | patina 5.48s              | **11.9x**           |
-| **Formatter**    | Prettier 82.69s           | glyph 23ms                | **3,666x**          |
+| **Formatter**    | Prettier 104.08s          | glyph 1.32s               | **78.9x**           |
 | **Type Checker** | vue-tsc 22.13s            | canon 3.33s               | **6.6x** \*         |
 | **Vite Plugin**  | @vitejs/plugin-vue 16.98s | @vizejs/vite-plugin 6.90s | **2.5x** \*\*       |
 
@@ -143,8 +143,8 @@ Benchmarks with **15,000 Vue SFC files** (36.9 MB). "User-facing speedup" = trad
 
 |                   | @vue/compiler-sfc | Vize  | Speedup  |
 | ----------------- | ----------------- | ----- | -------- |
-| **Single Thread** | 10.43s            | 6.06s | **1.7x** |
-| **Multi Thread**  | 3.45s             | 612ms | **5.6x** |
+| **Single Thread** | 9.28s             | 3.30s | **2.8x** |
+| **Multi Thread**  | 3.35s             | 434ms | **7.7x** |
 
 </details>
 
@@ -153,6 +153,8 @@ Benchmarks with **15,000 Vue SFC files** (36.9 MB). "User-facing speedup" = trad
 \*\* Vite Plugin benchmark uses Vite v8.0.0 (Rolldown). The plugin replaces only the SFC compilation step; all other Vite internals are unchanged.
 
 Run `vp run --workspace-root bench:all` to reproduce all benchmarks.
+
+`bench:check` also includes the diagnostics-heavy `npmx.dev` e2e fixture when that fixture is present, so the Corsa diagnostic mapping path stays covered.
 
 ## Contributing
 

--- a/bench/check.ts
+++ b/bench/check.ts
@@ -3,7 +3,7 @@
  *
  * Usage:
  *   1. Generate test files: node generate.mjs [count]
- *   2. Build CLI: mise run build:cli
+ *   2. Build CLI: vp run --workspace-root build:cli
  *   3. Run benchmark: node --experimental-strip-types bench/check.ts
  */
 
@@ -15,6 +15,7 @@ import os from "node:os";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const INPUT_DIR = join(__dirname, "__in__");
+const E2E_NPMX_DIR = join(__dirname, "..", "tests", "_fixtures", "_git", "npmx.dev");
 const CPU_COUNT = os.cpus().length;
 const VIZE_BIN = join(__dirname, "..", "target", "release", "vize");
 const FILE_LIMIT = parseInt(process.argv[2] || "0", 10) || Infinity;
@@ -87,22 +88,22 @@ function formatThroughput(fileCount: number, ms: number): string {
   return `${filesPerSec.toFixed(0)} files/s`;
 }
 
-function runCommand(cmd: string): number {
+function runCommand(cmd: string, cwd: string = BENCH_INPUT_DIR): number {
   const start = performance.now();
   try {
-    execSync(cmd, { stdio: "ignore", cwd: BENCH_INPUT_DIR });
+    execSync(cmd, { stdio: "ignore", cwd });
   } catch {
     // vue-tsc may exit non-zero on type errors; still measure time
   }
   return performance.now() - start;
 }
 
-function benchmarkCommand(cmd: string, warmup: number = 0): number {
+function benchmarkCommand(cmd: string, warmup: number = 0, cwd: string = BENCH_INPUT_DIR): number {
   // Warmup
   for (let i = 0; i < warmup; i++) {
-    runCommand(cmd);
+    runCommand(cmd, cwd);
   }
-  return runCommand(cmd);
+  return runCommand(cmd, cwd);
 }
 
 function resolveVueTscBin(): string | null {
@@ -139,6 +140,28 @@ function runVizeCheckSingleThread(): number {
 function runVizeCheckMultiThread(): number {
   return benchmarkCommand(
     `${VIZE_BIN} check '${GLOB_PATTERN}' --quiet --tsconfig ${TSCONFIG_PATH}`,
+  );
+}
+
+function countVueFiles(dir: string): number {
+  if (!existsSync(dir)) return 0;
+
+  let count = 0;
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.isDirectory()) {
+      count += countVueFiles(join(dir, entry.name));
+    } else if (entry.name.endsWith(".vue")) {
+      count += 1;
+    }
+  }
+  return count;
+}
+
+function runVizeE2eNpmxCheck(): number {
+  return benchmarkCommand(
+    `${VIZE_BIN} check app --quiet --tsconfig tsconfig.json`,
+    1,
+    E2E_NPMX_DIR,
   );
 }
 
@@ -228,6 +251,26 @@ if (vueTscSingle >= 0 && vizeSingle > 0 && vizeMulti > 0) {
   console.log(`   vue-tsc ST vs Vize ST : ${stSpeedup}x`);
   console.log(`   vue-tsc MT vs Vize MT : ${mtSpeedup}x`);
   console.log(`   vue-tsc ST vs Vize MT : ${crossSpeedup}x  (user-facing speedup)`);
+}
+
+if (existsSync(VIZE_BIN) && existsSync(join(E2E_NPMX_DIR, "app"))) {
+  const e2eFileCount = countVueFiles(join(E2E_NPMX_DIR, "app"));
+  const e2eTime = runVizeE2eNpmxCheck();
+  console.log();
+  console.log("-".repeat(65));
+  console.log();
+  console.log(" Diagnostics-heavy e2e fixture:");
+  console.log();
+  console.log(
+    `   npmx.dev app  : ${formatTime(e2eTime).padStart(8)}  (${formatThroughput(e2eFileCount, e2eTime)}, ${e2eFileCount} SFC files, non-zero diagnostics ignored)`,
+  );
+} else {
+  console.log();
+  console.log("-".repeat(65));
+  console.log();
+  console.log(" Diagnostics-heavy e2e fixture:");
+  console.log();
+  console.log("   npmx.dev app  : SKIPPED (fixture or vize CLI not found)");
 }
 
 console.log();

--- a/bench/fmt.ts
+++ b/bench/fmt.ts
@@ -12,19 +12,24 @@
 import { existsSync, readdirSync, statSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
-import { execSync } from "node:child_process";
+import { spawnSync } from "node:child_process";
 import os from "node:os";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const INPUT_DIR = join(__dirname, "__in__");
 const CPU_COUNT = os.cpus().length;
 const VIZE_BIN = join(__dirname, "..", "target", "release", "vize");
-const GLOB_PATTERN = join(INPUT_DIR, "*.vue");
+const FORMAT_PATTERN = "*.vue";
 const GENERATE_SCRIPT = join(__dirname, "generate.mjs");
+const FILE_COUNT = parseInt(process.argv[2] || "15000", 10) || 15000;
+const PRETTIER_BIN_CANDIDATES = [
+  join(__dirname, "node_modules", ".bin", "prettier"),
+  join(__dirname, "..", "node_modules", ".bin", "prettier"),
+];
 
 // Regenerate input files (ensures fresh, unformatted state)
 function regenerateInput(): void {
-  execSync(`node ${GENERATE_SCRIPT}`, { stdio: "ignore" });
+  runCommand(`node ${shellQuote(GENERATE_SCRIPT)} ${FILE_COUNT}`, __dirname);
 }
 
 // Initial generation to get file metadata
@@ -57,58 +62,100 @@ function formatBytesPerSec(bytes: number, ms: number): string {
   return `${bps.toFixed(0)} B/s`;
 }
 
-// Run shell command, ignoring exit code (formatter may exit non-zero on diffs)
-function execIgnoreExit(cmd: string): void {
-  try {
-    execSync(cmd, { stdio: "ignore" });
-  } catch {
-    // ignore non-zero exit code
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", "'\\''")}'`;
+}
+
+function resolvePrettierBin(): string | null {
+  for (const candidate of PRETTIER_BIN_CANDIDATES) {
+    if (existsSync(candidate)) return candidate;
+  }
+  return null;
+}
+
+type CommandResult = {
+  ms: number;
+  output: string;
+};
+
+function runCommand(
+  cmd: string,
+  cwd: string = INPUT_DIR,
+  env: NodeJS.ProcessEnv = {},
+): CommandResult {
+  const start = performance.now();
+  const result = spawnSync(cmd, {
+    cwd,
+    encoding: "utf8",
+    env: { ...process.env, ...env },
+    shell: true,
+  });
+  const ms = performance.now() - start;
+  const output = `${result.stdout ?? ""}${result.stderr ?? ""}`;
+
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    const tail = output.trim().split("\n").slice(-20).join("\n");
+    throw new Error(`Command failed (${result.status}): ${cmd}\n${tail}`);
+  }
+
+  return { ms, output };
+}
+
+function benchmarkFormatter(
+  cmd: string,
+  validate: (result: CommandResult) => void = () => {},
+  env: NodeJS.ProcessEnv = {},
+): number {
+  regenerateInput();
+  for (let i = 0; i < 3; i++) {
+    validate(runCommand(cmd, INPUT_DIR, env));
+    regenerateInput();
+  }
+
+  regenerateInput();
+  const result = runCommand(cmd, INPUT_DIR, env);
+  validate(result);
+  return result.ms;
+}
+
+function assertVizeFileCount(result: CommandResult): void {
+  const match = result.output.match(/Found (\d+) \.vue file\(s\)/);
+  if (!match) {
+    throw new Error("Vize fmt output did not include the collected file count.");
+  }
+  const found = Number.parseInt(match[1], 10);
+  if (found !== vueFiles.length) {
+    throw new Error(`Vize fmt matched ${found} files, expected ${vueFiles.length}.`);
   }
 }
 
 // Prettier CLI (inherently single-threaded)
 function runPrettier(): number {
-  // Warmup
-  regenerateInput();
-  for (let i = 0; i < 3; i++) {
-    execIgnoreExit(`npx prettier --write '${GLOB_PATTERN}'`);
-    regenerateInput();
+  const prettierBin = resolvePrettierBin();
+  if (prettierBin == null) {
+    return -1;
   }
-
-  regenerateInput();
-  const start = performance.now();
-  execIgnoreExit(`npx prettier --write '${GLOB_PATTERN}'`);
-  return performance.now() - start;
+  return benchmarkFormatter(
+    `${shellQuote(prettierBin)} --write ${shellQuote(FORMAT_PATTERN)} --log-level error`,
+  );
 }
 
 // Vize (glyph) single-thread
 function runVizeFmtSingleThread(): number {
-  // Warmup
-  regenerateInput();
-  for (let i = 0; i < 3; i++) {
-    execIgnoreExit(`RAYON_NUM_THREADS=1 ${VIZE_BIN} fmt --write '${GLOB_PATTERN}'`);
-    regenerateInput();
-  }
-
-  regenerateInput();
-  const start = performance.now();
-  execIgnoreExit(`RAYON_NUM_THREADS=1 ${VIZE_BIN} fmt --write '${GLOB_PATTERN}'`);
-  return performance.now() - start;
+  return benchmarkFormatter(
+    `${shellQuote(VIZE_BIN)} fmt --write ${shellQuote(FORMAT_PATTERN)}`,
+    assertVizeFileCount,
+    { RAYON_NUM_THREADS: "1" },
+  );
 }
 
 // Vize (glyph) multi-thread
 function runVizeFmtMultiThread(): number {
-  // Warmup
-  regenerateInput();
-  for (let i = 0; i < 3; i++) {
-    execIgnoreExit(`${VIZE_BIN} fmt --write '${GLOB_PATTERN}'`);
-    regenerateInput();
-  }
-
-  regenerateInput();
-  const start = performance.now();
-  execIgnoreExit(`${VIZE_BIN} fmt --write '${GLOB_PATTERN}'`);
-  return performance.now() - start;
+  return benchmarkFormatter(
+    `${shellQuote(VIZE_BIN)} fmt --write ${shellQuote(FORMAT_PATTERN)}`,
+    assertVizeFileCount,
+  );
 }
 
 // Main
@@ -126,31 +173,47 @@ console.log("-".repeat(65));
 console.log();
 
 const prettierTime = runPrettier();
-console.log(
-  `   Prettier (CLI)      : ${formatTime(prettierTime).padStart(8)}  (${formatThroughput(vueFiles.length, prettierTime)}, ${formatBytesPerSec(totalSize, prettierTime)})`,
-);
+if (prettierTime >= 0) {
+  console.log(
+    `   Prettier (CLI)      : ${formatTime(prettierTime).padStart(8)}  (${formatThroughput(vueFiles.length, prettierTime)}, ${formatBytesPerSec(totalSize, prettierTime)})`,
+  );
+} else {
+  console.log("   Prettier (CLI)      : SKIPPED (not found)");
+}
 
 let vizeSingle = 0;
 let vizeMulti = 0;
 
 if (existsSync(VIZE_BIN)) {
   vizeSingle = runVizeFmtSingleThread();
-  const stSpeedup = (prettierTime / vizeSingle).toFixed(1);
-  console.log(
-    `   Vize glyph (1T)     : ${formatTime(vizeSingle).padStart(8)}  (${formatThroughput(vueFiles.length, vizeSingle)}, ${formatBytesPerSec(totalSize, vizeSingle)})  ${stSpeedup}x faster`,
-  );
+  if (prettierTime >= 0) {
+    const stSpeedup = (prettierTime / vizeSingle).toFixed(1);
+    console.log(
+      `   Vize glyph (1T)     : ${formatTime(vizeSingle).padStart(8)}  (${formatThroughput(vueFiles.length, vizeSingle)}, ${formatBytesPerSec(totalSize, vizeSingle)})  ${stSpeedup}x faster`,
+    );
+  } else {
+    console.log(
+      `   Vize glyph (1T)     : ${formatTime(vizeSingle).padStart(8)}  (${formatThroughput(vueFiles.length, vizeSingle)}, ${formatBytesPerSec(totalSize, vizeSingle)})`,
+    );
+  }
 
   vizeMulti = runVizeFmtMultiThread();
-  const mtSpeedup = (prettierTime / vizeMulti).toFixed(1);
-  console.log(
-    `   Vize glyph (${CPU_COUNT}T)    : ${formatTime(vizeMulti).padStart(8)}  (${formatThroughput(vueFiles.length, vizeMulti)}, ${formatBytesPerSec(totalSize, vizeMulti)})  ${mtSpeedup}x faster`,
-  );
+  if (prettierTime >= 0) {
+    const mtSpeedup = (prettierTime / vizeMulti).toFixed(1);
+    console.log(
+      `   Vize glyph (${CPU_COUNT}T)    : ${formatTime(vizeMulti).padStart(8)}  (${formatThroughput(vueFiles.length, vizeMulti)}, ${formatBytesPerSec(totalSize, vizeMulti)})  ${mtSpeedup}x faster`,
+    );
+  } else {
+    console.log(
+      `   Vize glyph (${CPU_COUNT}T)    : ${formatTime(vizeMulti).padStart(8)}  (${formatThroughput(vueFiles.length, vizeMulti)}, ${formatBytesPerSec(totalSize, vizeMulti)})`,
+    );
+  }
 } else {
   console.log("   Vize (glyph)  : SKIPPED (vize CLI not found)");
 }
 
 // Summary
-if (vizeSingle > 0 && vizeMulti > 0) {
+if (prettierTime >= 0 && vizeSingle > 0 && vizeMulti > 0) {
   console.log();
   console.log("-".repeat(65));
   console.log();

--- a/bench/generate.mjs
+++ b/bench/generate.mjs
@@ -3,7 +3,7 @@
  * Generate SFC files for benchmarking
  * Usage: node generate.mjs [count]
  */
-import { writeFileSync, mkdirSync, readdirSync, statSync } from "fs";
+import { writeFileSync, mkdirSync, readdirSync, rmSync, statSync } from "fs";
 import { join, dirname } from "path";
 import { fileURLToPath } from "url";
 
@@ -347,6 +347,12 @@ mkdirSync(benchDir, { recursive: true });
 
 console.log(`Generating ${FILE_COUNT} SFC files in ${benchDir}...`);
 
+for (const file of readdirSync(benchDir)) {
+  if (file.startsWith("Component") && file.endsWith(".vue")) {
+    rmSync(join(benchDir, file), { force: true });
+  }
+}
+
 for (let i = 0; i < FILE_COUNT; i++) {
   const template = templates[i % templates.length];
   const filename = `Component${String(i).padStart(4, "0")}.vue`;
@@ -428,7 +434,7 @@ const indexHtml = `<!DOCTYPE html>
 <head><title>Bench</title></head>
 <body>
   <div id="app"></div>
-  <script type="module" src="./main.ts"><\/script>
+  <script type="module" src="./main.ts"></script>
 </body>
 </html>
 `;

--- a/bench/run.ts
+++ b/bench/run.ts
@@ -5,7 +5,7 @@
  *
  * Usage:
  *   1. Generate test files: node generate.mjs [count]
- *   2. Build native bindings: mise run build
+ *   2. Build native bindings: vp run --filter './npm/vize-native' build
  *   3. Run benchmark: node --experimental-strip-types run.ts
  */
 
@@ -13,7 +13,7 @@ import { parse, compileScript, compileTemplate } from "@vue/compiler-sfc";
 import type { BindingMetadata } from "@vue/compiler-sfc";
 import { existsSync, readdirSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
 import { fileURLToPath } from "node:url";
-import { dirname, join, basename } from "node:path";
+import { dirname, join } from "node:path";
 import { createRequire } from "node:module";
 import { Worker } from "node:worker_threads";
 import os from "node:os";
@@ -27,6 +27,7 @@ const ORIGINAL_OUT_DIR = join(OUTPUT_DIR, "original");
 const NATIVE_OUT_DIR = join(OUTPUT_DIR, "native");
 const CPU_COUNT = os.cpus().length;
 const FILE_LIMIT = parseInt(process.argv[2] || "0", 10) || Infinity;
+const SAVE_OUTPUT = process.env.VIZE_BENCH_SAVE_OUTPUT === "1";
 
 // Types
 interface NativeBindings {
@@ -48,14 +49,10 @@ interface TestFile {
   source: string;
 }
 
-interface CompileResult {
-  filename: string;
-  code: string;
-}
-
 // Load Native (NAPI) bindings
 let native: NativeBindings | null = null;
 const nativePath = join(__dirname, "..", "npm", "vize-native");
+const compilerSfcPath = require.resolve("@vue/compiler-sfc");
 if (existsSync(nativePath)) {
   try {
     native = require(nativePath) as NativeBindings;
@@ -90,9 +87,10 @@ const files: TestFile[] = vueFiles.map((filename) => ({
 
 const totalSize = files.reduce((sum, f) => sum + Buffer.byteLength(f.source, "utf8"), 0);
 
-// Ensure output directories exist
-mkdirSync(ORIGINAL_OUT_DIR, { recursive: true });
-mkdirSync(NATIVE_OUT_DIR, { recursive: true });
+if (SAVE_OUTPUT) {
+  mkdirSync(ORIGINAL_OUT_DIR, { recursive: true });
+  mkdirSync(NATIVE_OUT_DIR, { recursive: true });
+}
 
 // Vue compiler-sfc full compile
 function vueCompileSfc(source: string, filename: string): string {
@@ -166,7 +164,7 @@ async function runOriginalMultiThread(): Promise<number> {
 
   const workerCode = `
     const { parentPort, workerData } = require('worker_threads');
-    const { parse, compileScript, compileTemplate } = require('@vue/compiler-sfc');
+    const { parse, compileScript, compileTemplate } = require(workerData.compilerSfcPath);
 
     for (const file of workerData.files) {
       const { descriptor } = parse(file.source, { filename: file.filename });
@@ -197,7 +195,7 @@ async function runOriginalMultiThread(): Promise<number> {
 
     const worker = new Worker(workerCode, {
       eval: true,
-      workerData: { files: chunk },
+      workerData: { files: chunk, compilerSfcPath },
     });
 
     workers.push(
@@ -234,7 +232,7 @@ console.log();
 console.log(` Files     : ${files.length.toLocaleString()} SFC files`);
 console.log(` Total Size: ${(totalSize / 1024 / 1024).toFixed(1)} MB`);
 console.log(` CPU Cores : ${CPU_COUNT}`);
-console.log(` Output    : ${OUTPUT_DIR}`);
+console.log(` Output    : ${SAVE_OUTPUT ? OUTPUT_DIR : "disabled"}`);
 console.log();
 console.log(" Compilers:");
 console.log(`   Original : @vue/compiler-sfc`);
@@ -247,15 +245,14 @@ console.log();
 console.log(" Single Thread:");
 console.log();
 
-// First run saves output (skip in quick mode)
-const saveOutput = FILE_LIMIT === Infinity;
-const originalSingle = runOriginalSingleThread(saveOutput);
+const originalSingle = runOriginalSingleThread(SAVE_OUTPUT);
 console.log(
   `   Original : ${formatTime(originalSingle).padStart(8)}  (${formatThroughput(files.length, originalSingle)})`,
 );
 
+let nativeSingle = 0;
 if (native) {
-  const nativeSingle = runNativeSingleThread(saveOutput);
+  nativeSingle = runNativeSingleThread(SAVE_OUTPUT);
   const speedup = (originalSingle / nativeSingle).toFixed(1);
   console.log(
     `   Native   : ${formatTime(nativeSingle).padStart(8)}  (${formatThroughput(files.length, nativeSingle)})  ${speedup}x faster`,
@@ -329,15 +326,13 @@ if (FILE_LIMIT === Infinity && native) {
   console.log();
   console.log(" Summary:");
   console.log();
-  console.log(
-    `   Original ST vs Native ST : ${(originalSingle / runNativeSingleThread(false)).toFixed(1)}x`,
-  );
+  console.log(`   Original ST vs Native ST : ${(originalSingle / nativeSingle).toFixed(1)}x`);
   console.log(`   Original ST vs Native MT : ${crossSpeedup}x  (user-facing speedup)`);
 }
 
 console.log();
 console.log("-".repeat(65));
-if (FILE_LIMIT === Infinity) {
+if (SAVE_OUTPUT) {
   console.log();
   console.log(` Output saved to:`);
   console.log(`   Original : ${ORIGINAL_OUT_DIR}`);

--- a/crates/vize/src/commands/fmt.rs
+++ b/crates/vize/src/commands/fmt.rs
@@ -3,10 +3,11 @@
 #![allow(clippy::disallowed_macros)]
 
 use clap::Args;
+use glob::{glob, MatchOptions, Pattern};
 use ignore::WalkBuilder;
 use rayon::prelude::*;
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Mutex;
 use std::time::{Duration, Instant};
@@ -329,23 +330,26 @@ fn build_format_options(args: &FmtArgs) -> FormatOptions {
 #[allow(clippy::disallowed_types)]
 fn collect_files(patterns: &[std::string::String]) -> Vec<PathBuf> {
     let mut files = Vec::new();
+    let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
 
     for pattern in patterns {
-        // Use ignore crate to walk directories respecting .gitignore
-        let walker = WalkBuilder::new(".")
-            .hidden(false)
-            .git_ignore(true)
-            .git_global(true)
-            .git_exclude(true)
-            .build();
-
-        for entry in walker.filter_map(Result::ok) {
-            let path = entry.path();
-            if path.extension().is_some_and(|ext| ext == "vue") {
-                // Check if path matches pattern (simple glob matching)
-                if matches_pattern(path, pattern) {
-                    files.push(path.to_path_buf());
+        let normalized = normalize_fmt_pattern(pattern);
+        if should_walk_with_gitignore(&normalized) {
+            if let Some(pattern) = FmtPattern::new(&normalized, &cwd) {
+                collect_walked_files(&pattern, &mut files);
+            }
+        } else if contains_glob_char(&normalized) {
+            if let Ok(paths) = glob(&normalized) {
+                for path in paths.flatten() {
+                    if path.extension().is_some_and(|ext| ext == "vue") {
+                        files.push(path);
+                    }
                 }
+            }
+        } else {
+            let path = PathBuf::from(&normalized);
+            if path.extension().is_some_and(|ext| ext == "vue") && path.is_file() {
+                files.push(path);
             }
         }
     }
@@ -357,25 +361,99 @@ fn collect_files(patterns: &[std::string::String]) -> Vec<PathBuf> {
     files
 }
 
+fn collect_walked_files(pattern: &FmtPattern, files: &mut Vec<PathBuf>) {
+    // Use ignore crate to walk directories respecting .gitignore
+    let walker = WalkBuilder::new(".")
+        .hidden(false)
+        .git_ignore(true)
+        .git_global(true)
+        .git_exclude(true)
+        .build();
+
+    for entry in walker.filter_map(Result::ok) {
+        let path = entry.path();
+        if path.extension().is_some_and(|ext| ext == "vue") && pattern.matches(path) {
+            files.push(path.to_path_buf());
+        }
+    }
+}
+
 #[inline]
-fn matches_pattern(path: &std::path::Path, pattern: &str) -> bool {
-    // Simple pattern matching - for now just check if it's a .vue file
-    if pattern == "./**/*.vue" {
-        return true;
+fn should_walk_with_gitignore(pattern: &str) -> bool {
+    matches!(pattern, "**/*.vue" | "./**/*.vue")
+}
+
+struct FmtPattern {
+    pattern: Pattern,
+    cwd: PathBuf,
+    absolute: bool,
+}
+
+impl FmtPattern {
+    fn new(pattern: &str, cwd: &Path) -> Option<Self> {
+        let normalized = normalize_fmt_pattern(pattern);
+        let absolute = Path::new(&normalized).is_absolute();
+        Pattern::new(&normalized).ok().map(|pattern| Self {
+            pattern,
+            cwd: cwd.to_path_buf(),
+            absolute,
+        })
     }
 
-    // Check if pattern matches the file path
-    let path_str = path.to_string_lossy();
+    fn matches(&self, path: &Path) -> bool {
+        let candidate = if self.absolute {
+            let relative = path.strip_prefix(".").unwrap_or(path);
+            let absolute = if relative.is_absolute() {
+                relative.to_path_buf()
+            } else {
+                self.cwd.join(relative)
+            };
+            normalize_path(&absolute)
+        } else {
+            normalize_path(path.strip_prefix(".").unwrap_or(path))
+        };
 
-    if pattern.contains('*') {
-        // Simple glob: **/*.vue matches any .vue file
-        if pattern.ends_with("*.vue") {
-            return path_str.ends_with(".vue");
+        self.pattern
+            .matches_with(candidate.as_str(), fmt_glob_match_options())
+    }
+}
+
+fn normalize_fmt_pattern(pattern: &str) -> vize_carton::String {
+    let mut normalized: vize_carton::String = pattern.replace('\\', "/").into();
+    while let Some(stripped) = normalized.strip_prefix("./") {
+        normalized = stripped.into();
+    }
+
+    if normalized.is_empty() || normalized == "." {
+        return "**/*.vue".into();
+    }
+
+    if !contains_glob_char(&normalized) && Path::new(&normalized).is_dir() {
+        if !normalized.ends_with('/') {
+            normalized.push('/');
         }
-        true
-    } else {
-        // Exact match
-        path_str.contains(pattern)
+        normalized.push_str("**/*.vue");
+    }
+
+    normalized
+}
+
+#[inline]
+fn normalize_path(path: &Path) -> vize_carton::String {
+    path.to_string_lossy().replace('\\', "/").into()
+}
+
+#[inline]
+fn contains_glob_char(pattern: &str) -> bool {
+    pattern.contains(['*', '?', '['])
+}
+
+#[inline]
+fn fmt_glob_match_options() -> MatchOptions {
+    MatchOptions {
+        case_sensitive: !cfg!(windows),
+        require_literal_separator: true,
+        require_literal_leading_dot: false,
     }
 }
 
@@ -463,4 +541,62 @@ struct FormatFileResult {
 struct FormatFileProfile {
     row: ProfileFileRow,
     read_time: Duration,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{collect_files, FmtPattern};
+    use std::{
+        fs,
+        path::{Path, PathBuf},
+        time::{SystemTime, UNIX_EPOCH},
+    };
+    use vize_carton::{String, ToCompactString};
+
+    #[test]
+    fn absolute_glob_only_matches_requested_directory() {
+        let root = unique_case_dir("absolute-glob");
+        let input_dir = root.join("bench-input");
+        let other_dir = root.join("other");
+        let _ = fs::remove_dir_all(&root);
+        fs::create_dir_all(&input_dir).unwrap();
+        fs::create_dir_all(&other_dir).unwrap();
+        fs::write(input_dir.join("A.vue"), "<template><div/></template>").unwrap();
+        fs::write(other_dir.join("B.vue"), "<template><div/></template>").unwrap();
+
+        let pattern = input_dir.join("*.vue").to_string_lossy().into_owned();
+        let files = collect_files(&[pattern]);
+        let _ = fs::remove_dir_all(&root);
+
+        assert_eq!(files, vec![input_dir.join("A.vue")]);
+    }
+
+    #[test]
+    fn relative_glob_does_not_match_every_vue_file() {
+        let cwd = std::env::current_dir().unwrap();
+        let pattern = FmtPattern::new("bench/__in__/*.vue", &cwd).unwrap();
+
+        assert!(pattern.matches(Path::new("./bench/__in__/Component0000.vue")));
+        assert!(!pattern.matches(Path::new("./examples/cli/src/App.vue")));
+    }
+
+    fn unique_case_dir(name: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let mut dir_name = String::from(name);
+        dir_name.push('-');
+        let pid = std::process::id().to_compact_string();
+        dir_name.push_str(pid.as_str());
+        dir_name.push('-');
+        let nanos = nanos.to_compact_string();
+        dir_name.push_str(nanos.as_str());
+        std::env::current_dir()
+            .unwrap()
+            .join("__agent_only")
+            .join("tests")
+            .join("fmt")
+            .join(dir_name.as_str())
+    }
 }

--- a/crates/vize_atelier_sfc/src/compile/mod.rs
+++ b/crates/vize_atelier_sfc/src/compile/mod.rs
@@ -11,7 +11,7 @@ mod styles;
 #[cfg(test)]
 mod tests;
 
-use crate::compile_script::{compile_script_setup_inline, TemplateParts};
+use crate::compile_script::{compile_script_setup_inline_with_context, TemplateParts};
 use crate::compile_template::{
     compile_template_block, compile_template_block_vapor, extract_template_parts,
     extract_template_parts_full,
@@ -41,13 +41,21 @@ pub fn compile_sfc(
 
     let filename = options.script.id.as_deref().unwrap_or("anonymous.vue");
 
+    let has_styles = !descriptor.styles.is_empty();
+    let has_scoped = descriptor.styles.iter().any(|s| s.scoped);
     // Use externally-provided scope ID if available, otherwise generate from filename.
     // The external scope ID ensures consistency with JS-side SHA-256 generation.
-    let scope_id = options
-        .scope_id
-        .clone()
-        .unwrap_or_else(|| generate_scope_id(filename));
-    let has_scoped = descriptor.styles.iter().any(|s| s.scoped);
+    // Template/script-only SFCs do not need the hash.
+    let needs_scope_id =
+        has_styles || !descriptor.css_vars.is_empty() || options.scope_id.is_some();
+    let scope_id = if needs_scope_id {
+        options
+            .scope_id
+            .clone()
+            .unwrap_or_else(|| generate_scope_id(filename))
+    } else {
+        String::default()
+    };
 
     // Vapor components currently render on the client. For SSR we fall back to
     // the standard VDOM compiler and let the client hydrate with Vapor output.
@@ -483,7 +491,8 @@ pub fn compile_sfc(
 
     let script_result = profile!(
         "atelier.sfc.script_setup.inline_compile",
-        compile_script_setup_inline(
+        compile_script_setup_inline_with_context(
+            ctx,
             &script_setup.content,
             &component_name,
             is_ts,
@@ -501,7 +510,6 @@ pub fn compile_sfc(
             normal_script_content.as_deref(),
             &descriptor.css_vars,
             &scope_id,
-            Some(filename),
         )
     )?;
 

--- a/crates/vize_atelier_sfc/src/compile/styles.rs
+++ b/crates/vize_atelier_sfc/src/compile/styles.rs
@@ -13,6 +13,10 @@ pub(super) fn compile_styles(
     base_opts: &StyleCompileOptions,
     warnings: &mut Vec<SfcError>,
 ) -> String {
+    if styles.is_empty() {
+        return String::default();
+    }
+
     let mut all_css = String::default();
     for style in styles {
         let style_opts = StyleCompileOptions {

--- a/crates/vize_atelier_sfc/src/compile_script.rs
+++ b/crates/vize_atelier_sfc/src/compile_script.rs
@@ -22,6 +22,7 @@ use self::typescript::transform_typescript_to_js;
 pub use self::function_mode::compile_script_setup as compile_script_setup_function_mode;
 pub use self::import_utils::{extract_import_identifiers, process_import_for_types};
 pub use self::inline::compile_script_setup_inline;
+pub(crate) use self::inline::compile_script_setup_inline_with_context;
 pub use self::macros::{
     is_macro_call_line, is_multiline_macro_start, is_paren_macro_start, is_props_destructure_line,
 };

--- a/crates/vize_atelier_sfc/src/compile_script/function_mode/helpers.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/function_mode/helpers.rs
@@ -97,6 +97,10 @@ pub(crate) fn collect_runtime_identifier_references(code: &str) -> FxHashSet<Str
 
 /// Detect top-level await in setup code (ignores awaits inside nested functions).
 pub fn contains_top_level_await(code: &str, is_ts: bool) -> bool {
+    if !code.contains("await") {
+        return false;
+    }
+
     let allocator = Allocator::default();
     let source_type = if is_ts {
         SourceType::ts()

--- a/crates/vize_atelier_sfc/src/compile_script/inline/compiler.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/inline/compiler.rs
@@ -44,36 +44,41 @@ pub fn compile_script_setup_inline(
     scope_id: &str,
     filename: Option<&str>,
 ) -> Result<ScriptCompileResult, SfcError> {
-    let mut ctx = profile!(
-        "atelier.script_inline.context.new",
-        ScriptCompileContext::new(content)
-    );
+    let ctx = build_script_setup_context(content, normal_script_content, filename);
+    compile_script_setup_inline_with_context(
+        ctx,
+        content,
+        component_name,
+        is_ts,
+        source_is_ts,
+        is_vapor,
+        template,
+        normal_script_content,
+        css_vars,
+        scope_id,
+    )
+}
 
-    // Merge type definitions from normal <script> block so that
-    // defineProps<TypeRef>() can resolve types defined there.
-    if let Some(normal_src) = normal_script_content {
-        if !normal_src.is_empty() {
-            profile!(
-                "atelier.script_inline.collect_normal_types",
-                ctx.collect_types_from(normal_src)
-            );
-        }
-    }
-    if let Some(path) = filename {
-        profile!(
-            "atelier.script_inline.collect_setup_import_types",
-            ctx.collect_imported_types_from_path(content, path)
-        );
-        if let Some(normal_src) = normal_script_content {
-            if !normal_src.is_empty() {
-                profile!(
-                    "atelier.script_inline.collect_normal_import_types",
-                    ctx.collect_imported_types_from_path(normal_src, path)
-                );
-            }
-        }
-    }
-    profile!("atelier.script_inline.context.analyze", ctx.analyze());
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn compile_script_setup_inline_with_context(
+    ctx: ScriptCompileContext,
+    content: &str,
+    component_name: &str,
+    is_ts: bool,
+    source_is_ts: bool,
+    is_vapor: bool,
+    template: TemplateParts<'_>,
+    normal_script_content: Option<&str>,
+    css_vars: &[Cow<'_, str>],
+    scope_id: &str,
+) -> Result<ScriptCompileResult, SfcError> {
+    // Extract user imports and setup lines from script content once; await detection
+    // and output assembly share the same split.
+    let (user_imports, setup_lines, ts_declarations) = profile!(
+        "atelier.script_inline.parse_sections",
+        parse_script_content(content, is_ts)
+    );
+    let setup_code: String = setup_lines.join("\n").into();
 
     // Use arena-allocated Vec for better performance
     let bump = vize_carton::Bump::new();
@@ -113,14 +118,7 @@ pub fn compile_script_setup_inline(
         .then(|| build_vapor_render_alias(content, normal_script_content, template.render_fn));
 
     // withAsyncContext import comes first if needed
-    let setup_code_for_await = {
-        let (_, slines, _) = profile!(
-            "atelier.script_inline.parse_for_await",
-            parse_script_content(content, is_ts)
-        );
-        slines.join("\n")
-    };
-    let is_async = contains_top_level_await(&setup_code_for_await, source_is_ts);
+    let is_async = contains_top_level_await(&setup_code, source_is_ts);
     if is_async {
         if is_vapor {
             if needs_vapor_setup_context {
@@ -143,6 +141,89 @@ pub fn compile_script_setup_inline(
         }
     }
 
+    compile_script_setup_inline_body(
+        ctx,
+        component_name,
+        is_ts,
+        source_is_ts,
+        is_vapor,
+        template,
+        css_vars,
+        scope_id,
+        user_imports,
+        ts_declarations,
+        setup_code,
+        output,
+        preserved_normal_script,
+        needs_merge_defaults,
+        has_define_model,
+        has_define_slots,
+        needs_vapor_setup_context,
+        vapor_render_alias,
+        is_async,
+    )
+}
+
+fn build_script_setup_context(
+    content: &str,
+    normal_script_content: Option<&str>,
+    filename: Option<&str>,
+) -> ScriptCompileContext {
+    let mut ctx = profile!(
+        "atelier.script_inline.context.new",
+        ScriptCompileContext::new(content)
+    );
+
+    // Merge type definitions from normal <script> block so that
+    // defineProps<TypeRef>() can resolve types defined there.
+    if let Some(normal_src) = normal_script_content {
+        if !normal_src.is_empty() {
+            profile!(
+                "atelier.script_inline.collect_normal_types",
+                ctx.collect_types_from(normal_src)
+            );
+        }
+    }
+    if let Some(path) = filename {
+        profile!(
+            "atelier.script_inline.collect_setup_import_types",
+            ctx.collect_imported_types_from_path(content, path)
+        );
+        if let Some(normal_src) = normal_script_content {
+            if !normal_src.is_empty() {
+                profile!(
+                    "atelier.script_inline.collect_normal_import_types",
+                    ctx.collect_imported_types_from_path(normal_src, path)
+                );
+            }
+        }
+    }
+    profile!("atelier.script_inline.context.analyze", ctx.analyze());
+    ctx
+}
+
+#[allow(clippy::too_many_arguments)]
+fn compile_script_setup_inline_body(
+    ctx: ScriptCompileContext,
+    component_name: &str,
+    is_ts: bool,
+    source_is_ts: bool,
+    is_vapor: bool,
+    template: TemplateParts<'_>,
+    css_vars: &[Cow<'_, str>],
+    scope_id: &str,
+    user_imports: Vec<String>,
+    ts_declarations: Vec<String>,
+    setup_code: String,
+    mut output: vize_carton::Vec<u8>,
+    preserved_normal_script: Option<String>,
+    needs_merge_defaults: bool,
+    has_define_model: bool,
+    has_define_slots: bool,
+    needs_vapor_setup_context: bool,
+    vapor_render_alias: Option<String>,
+    is_async: bool,
+) -> Result<ScriptCompileResult, SfcError> {
     // mergeDefaults import comes first if needed
     if needs_merge_defaults {
         output.extend_from_slice(b"import { mergeDefaults as _mergeDefaults } from 'vue'\n");
@@ -191,12 +272,6 @@ pub fn compile_script_setup_inline(
         // Blank line after template imports
         output.push(b'\n');
     }
-
-    // Extract user imports and setup lines from script content
-    let (user_imports, setup_lines, ts_declarations) = profile!(
-        "atelier.script_inline.parse_sections",
-        parse_script_content(content, is_ts)
-    );
 
     // Template hoisted consts (e.g., const _hoisted_1 = { class: "..." })
     // Must come BEFORE user imports to match Vue's output order
@@ -269,14 +344,13 @@ pub fn compile_script_setup_inline(
     );
 
     // Setup code body - transform props destructure references and separate hoisted/setup code
-    let setup_code = setup_lines.join("\n");
     let transformed_setup: String = if let Some(ref destructure) = ctx.macros.props_destructure {
         profile!(
             "atelier.script_inline.transform_props_destructure",
             transform_destructured_props(&setup_code, destructure)
         )
     } else {
-        setup_code.into()
+        setup_code
     };
 
     // Separate hoisted consts (literal consts that can be module-level) from setup code

--- a/crates/vize_atelier_sfc/src/compile_script/inline/mod.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/inline/mod.rs
@@ -10,3 +10,4 @@ mod tests;
 pub(crate) mod type_handling;
 
 pub use compiler::compile_script_setup_inline;
+pub(crate) use compiler::compile_script_setup_inline_with_context;

--- a/crates/vize_atelier_sfc/src/script/context/external_types.rs
+++ b/crates/vize_atelier_sfc/src/script/context/external_types.rs
@@ -28,6 +28,10 @@ const INDEX_CANDIDATES: &[&str] = &[
 
 impl ScriptCompileContext {
     pub fn collect_imported_types_from_path(&mut self, source: &str, filename: &str) {
+        if !source.contains("import") || !source.contains("type") {
+            return;
+        }
+
         let owned_base = canonicalize_or_original(PathBuf::from(filename))
             .unwrap_or_else(|| PathBuf::from(filename));
         let base_file = owned_base.as_path();

--- a/crates/vize_canon/src/batch/executor.rs
+++ b/crates/vize_canon/src/batch/executor.rs
@@ -15,6 +15,7 @@ use super::type_checker::{
 use super::virtual_project::VirtualProject;
 use crate::{
     corsa_client::CorsaProjectClient,
+    file_uri::path_to_file_uri,
     lsp_client::paths::{corsa_search_roots, find_corsa_in_search_roots},
 };
 use oxc_span::SourceType;
@@ -189,7 +190,7 @@ fn collect_virtual_file_uris(virtual_root: &Path) -> CorsaResult<Vec<String>> {
             continue;
         }
         if let Some("ts" | "tsx") = path.extension().and_then(|extension| extension.to_str()) {
-            uris.push(cstr!("file://{}", path.display()));
+            uris.push(path_to_file_uri(path));
         }
     }
 
@@ -282,6 +283,7 @@ fn should_fallback_to_cli(error: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::{collect_declaration_outputs, collect_virtual_file_uris, normalize_corsa_path};
+    use crate::file_uri::path_to_file_uri;
     use std::{
         fs,
         path::PathBuf,
@@ -319,10 +321,32 @@ mod tests {
         assert_eq!(
             uris,
             vec![
-                cstr!("file://{}", root.join("component.vue.ts").display()),
-                cstr!("file://{}", root.join("index.ts").display()),
+                path_to_file_uri(root.join("component.vue.ts").as_path()),
+                path_to_file_uri(root.join("index.ts").as_path()),
             ]
         );
+    }
+
+    #[test]
+    fn encodes_reserved_characters_in_virtual_file_uris() {
+        let root = unique_case_dir("reserved-uri");
+        let _ = fs::remove_dir_all(&root);
+        let route_dir = root.join("pages").join("[[org]]").join("[packageName]");
+        fs::create_dir_all(&route_dir).unwrap();
+        fs::write(route_dir.join("[versionRange].vue.ts"), "").unwrap();
+
+        let uris = collect_virtual_file_uris(root.as_path()).unwrap();
+        let _ = fs::remove_dir_all(&root);
+
+        assert_eq!(
+            uris,
+            vec![path_to_file_uri(
+                route_dir.join("[versionRange].vue.ts").as_path()
+            )]
+        );
+        assert!(uris[0].contains("%5B%5Borg%5D%5D"));
+        assert!(uris[0].contains("%5BpackageName%5D"));
+        assert!(uris[0].contains("%5BversionRange%5D.vue.ts"));
     }
 
     #[test]

--- a/crates/vize_canon/src/batch/executor/diagnostics.rs
+++ b/crates/vize_canon/src/batch/executor/diagnostics.rs
@@ -2,20 +2,25 @@ use std::path::{Path, PathBuf};
 
 use serde_json::Value;
 
-use super::super::{Diagnostic, VirtualProject};
+use super::super::{Diagnostic, OriginalPosition, VirtualFile, VirtualProject};
 use crate::corsa_client::LspDiagnostic;
-use vize_carton::String;
+use crate::file_uri::file_uri_to_path;
+use vize_carton::{FxHashMap, String};
 
 pub(super) fn map_batch_diagnostics(
     results: Vec<(String, Vec<LspDiagnostic>)>,
     project: &VirtualProject,
 ) -> Vec<Diagnostic> {
-    let mut diagnostics = Vec::new();
+    let diagnostic_count = results
+        .iter()
+        .fold(0usize, |acc, (_, diagnostics)| acc + diagnostics.len());
+    let mut diagnostics = Vec::with_capacity(diagnostic_count);
+    let mut mapper = DiagnosticMapper::new(project);
 
     for (uri, lsp_diagnostics) in results {
         let virtual_path = uri_to_path(uri.as_str());
         for diagnostic in lsp_diagnostics {
-            if let Some(diagnostic) = map_lsp_diagnostic(&virtual_path, diagnostic, project) {
+            if let Some(diagnostic) = mapper.map_lsp_diagnostic(&virtual_path, diagnostic) {
                 diagnostics.push(diagnostic);
             }
         }
@@ -24,38 +29,184 @@ pub(super) fn map_batch_diagnostics(
     diagnostics
 }
 
-fn map_lsp_diagnostic(
-    virtual_path: &Path,
-    diagnostic: LspDiagnostic,
-    project: &VirtualProject,
-) -> Option<Diagnostic> {
-    let code = parse_diagnostic_code(diagnostic.code.as_ref());
-    if should_skip_diagnostic(code) {
-        return None;
-    }
-    let original = project.map_to_original(
-        virtual_path,
-        diagnostic.range.start.line,
-        diagnostic.range.start.character,
-    );
+struct DiagnosticMapper<'a> {
+    project: &'a VirtualProject,
+    original_sources: FxHashMap<PathBuf, CachedSource>,
+    virtual_line_indexes: FxHashMap<PathBuf, LineIndex>,
+}
 
-    if let Some(original) = original {
-        return Some(Diagnostic {
-            file: original.path,
-            line: original.line,
-            column: original.column,
-            message: diagnostic.message,
-            code,
-            severity: parse_severity(diagnostic.severity),
-            block_type: original.block_type,
-        });
+impl<'a> DiagnosticMapper<'a> {
+    fn new(project: &'a VirtualProject) -> Self {
+        Self {
+            project,
+            original_sources: FxHashMap::default(),
+            virtual_line_indexes: FxHashMap::default(),
+        }
     }
 
-    None
+    fn map_lsp_diagnostic(
+        &mut self,
+        virtual_path: &Path,
+        diagnostic: LspDiagnostic,
+    ) -> Option<Diagnostic> {
+        let code = parse_diagnostic_code(diagnostic.code.as_ref());
+        if should_skip_diagnostic(code) {
+            return None;
+        }
+
+        let original = self.map_to_original(
+            virtual_path,
+            diagnostic.range.start.line,
+            diagnostic.range.start.character,
+        );
+
+        if let Some(original) = original {
+            return Some(Diagnostic {
+                file: original.path,
+                line: original.line,
+                column: original.column,
+                message: diagnostic.message,
+                code,
+                severity: parse_severity(diagnostic.severity),
+                block_type: original.block_type,
+            });
+        }
+
+        None
+    }
+
+    fn map_to_original(
+        &mut self,
+        virtual_path: &Path,
+        line: u32,
+        column: u32,
+    ) -> Option<OriginalPosition> {
+        let file = self.project.find_by_virtual(virtual_path)?;
+        let virtual_offset = self.virtual_offset(file, line, column)?;
+        let (original_offset, _, block_type) =
+            file.source_map.get_original_position(virtual_offset)?;
+        let cached = self.original_source(&file.original_path)?;
+        let (original_line, original_column) = cached
+            .line_index
+            .offset_to_line_col(&cached.content, original_offset)?;
+
+        Some(OriginalPosition {
+            path: file.original_path.clone(),
+            line: original_line,
+            column: original_column,
+            block_type,
+        })
+    }
+
+    fn virtual_offset(&mut self, file: &VirtualFile, line: u32, column: u32) -> Option<u32> {
+        if !self.virtual_line_indexes.contains_key(&file.virtual_path) {
+            self.virtual_line_indexes
+                .insert(file.virtual_path.clone(), LineIndex::new(&file.content));
+        }
+        let line_index = self.virtual_line_indexes.get(&file.virtual_path)?;
+        line_index.line_col_to_offset(&file.content, line, column)
+    }
+
+    fn original_source(&mut self, path: &Path) -> Option<&CachedSource> {
+        if !self.original_sources.contains_key(path) {
+            let content: String = std::fs::read_to_string(path).ok()?.into();
+            let line_index = LineIndex::new(&content);
+            self.original_sources.insert(
+                path.to_path_buf(),
+                CachedSource {
+                    content,
+                    line_index,
+                },
+            );
+        }
+
+        self.original_sources.get(path)
+    }
+}
+
+struct CachedSource {
+    content: String,
+    line_index: LineIndex,
+}
+
+struct LineIndex {
+    starts: Vec<usize>,
+    len: usize,
+}
+
+impl LineIndex {
+    fn new(content: &str) -> Self {
+        let mut starts = vec![0];
+        for (index, byte) in content.bytes().enumerate() {
+            if byte == b'\n' {
+                starts.push(index + 1);
+            }
+        }
+
+        Self {
+            starts,
+            len: content.len(),
+        }
+    }
+
+    fn line_col_to_offset(&self, content: &str, line: u32, col: u32) -> Option<u32> {
+        let line = usize::try_from(line).ok()?;
+        let start = *self.starts.get(line)?;
+        let end = self.line_end(line);
+        let mut current_col = 0u32;
+        let mut offset = start;
+
+        if col == 0 {
+            return u32::try_from(offset).ok();
+        }
+
+        for ch in content[start..end].chars() {
+            offset += ch.len_utf8();
+            current_col += 1;
+            if current_col == col {
+                return u32::try_from(offset).ok();
+            }
+        }
+
+        if current_col == col {
+            u32::try_from(offset).ok()
+        } else {
+            None
+        }
+    }
+
+    fn offset_to_line_col(&self, content: &str, offset: u32) -> Option<(u32, u32)> {
+        let offset = usize::try_from(offset).ok()?;
+        if offset > self.len {
+            return None;
+        }
+
+        let line = self.starts.partition_point(|start| *start <= offset);
+        let line = line.saturating_sub(1);
+        let start = *self.starts.get(line)?;
+        let end = self.line_end(line);
+        let mut col = 0usize;
+        let mut cursor = start;
+        for ch in content[start..end].chars() {
+            if cursor >= offset {
+                break;
+            }
+            col += 1;
+            cursor += ch.len_utf8();
+        }
+        Some((u32::try_from(line).ok()?, u32::try_from(col).ok()?))
+    }
+
+    fn line_end(&self, line: usize) -> usize {
+        self.starts
+            .get(line + 1)
+            .map(|next_start| next_start.saturating_sub(1))
+            .unwrap_or(self.len)
+    }
 }
 
 fn uri_to_path(uri: &str) -> PathBuf {
-    PathBuf::from(uri.strip_prefix("file://").unwrap_or(uri))
+    file_uri_to_path(uri).unwrap_or_else(|| PathBuf::from(uri))
 }
 
 fn parse_diagnostic_code(code: Option<&Value>) -> Option<u32> {
@@ -86,7 +237,9 @@ pub(super) fn should_skip_diagnostic(code: Option<u32>) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::{map_batch_diagnostics, parse_diagnostic_code, parse_severity, uri_to_path};
+    use super::{
+        map_batch_diagnostics, parse_diagnostic_code, parse_severity, uri_to_path, LineIndex,
+    };
     use crate::batch::VirtualProject;
     use serde_json::json;
     use std::path::PathBuf;
@@ -115,6 +268,30 @@ mod tests {
             uri_to_path("file:///workspace/src/App.vue.ts"),
             PathBuf::from("/workspace/src/App.vue.ts")
         );
+    }
+
+    #[test]
+    fn decodes_file_uri_path_bytes() {
+        assert_eq!(
+            uri_to_path("file:///workspace/pages/%5Bname%5D%20%231.vue.ts"),
+            PathBuf::from("/workspace/pages/[name] #1.vue.ts")
+        );
+    }
+
+    #[test]
+    fn line_index_matches_source_map_boundaries() {
+        let content = "a\nbeta\n";
+        let index = LineIndex::new(content);
+
+        assert_eq!(index.line_col_to_offset(content, 0, 1), Some(1));
+        assert_eq!(index.line_col_to_offset(content, 1, 4), Some(6));
+        assert_eq!(index.line_col_to_offset(content, 2, 0), Some(7));
+        assert_eq!(index.line_col_to_offset(content, 1, 5), None);
+        assert_eq!(index.offset_to_line_col(content, 7), Some((2, 0)));
+
+        let content = "é\n";
+        let index = LineIndex::new(content);
+        assert_eq!(index.offset_to_line_col(content, 1), Some((0, 1)));
     }
 
     #[test]

--- a/crates/vize_canon/src/batch/virtual_project.rs
+++ b/crates/vize_canon/src/batch/virtual_project.rs
@@ -269,6 +269,11 @@ impl VirtualProject {
             .find(|file| file.original_path == original_path)
     }
 
+    /// Find a virtual file by its materialized path.
+    pub fn find_by_virtual(&self, virtual_path: &Path) -> Option<&VirtualFile> {
+        self.virtual_files.get(virtual_path)
+    }
+
     /// Return virtual files sorted by original path for deterministic output.
     pub fn virtual_files_sorted(&self) -> Vec<&VirtualFile> {
         let mut files: Vec<_> = self.virtual_files.values().collect();

--- a/crates/vize_canon/src/file_uri.rs
+++ b/crates/vize_canon/src/file_uri.rs
@@ -1,0 +1,91 @@
+use std::path::{Path, PathBuf};
+
+use vize_carton::String;
+
+pub(crate) fn path_to_file_uri(path: &Path) -> String {
+    let path = path.to_string_lossy();
+    let mut uri = String::default();
+    uri.push_str("file://");
+    append_encoded_path(&mut uri, path.as_bytes());
+    uri
+}
+
+pub(crate) fn file_uri_to_path(uri: &str) -> Option<PathBuf> {
+    let path = uri.strip_prefix("file://")?;
+    let decoded = decode_path(path)?;
+    Some(PathBuf::from(decoded.as_str()))
+}
+
+fn append_encoded_path(uri: &mut String, path: &[u8]) {
+    for &byte in path {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'.' | b'_' | b'~' | b'/' | b':' => {
+                uri.push(byte as char)
+            }
+            _ => append_percent_encoded(uri, byte),
+        }
+    }
+}
+
+fn append_percent_encoded(uri: &mut String, byte: u8) {
+    const HEX: &[u8; 16] = b"0123456789ABCDEF";
+
+    uri.push('%');
+    uri.push(HEX[(byte >> 4) as usize] as char);
+    uri.push(HEX[(byte & 0x0f) as usize] as char);
+}
+
+fn decode_path(path: &str) -> Option<String> {
+    let bytes = path.as_bytes();
+    let mut decoded = std::vec::Vec::with_capacity(bytes.len());
+    let mut index = 0;
+
+    while index < bytes.len() {
+        if bytes[index] == b'%' && index + 2 < bytes.len() {
+            if let (Some(high), Some(low)) =
+                (hex_value(bytes[index + 1]), hex_value(bytes[index + 2]))
+            {
+                decoded.push((high << 4) | low);
+                index += 3;
+                continue;
+            }
+        }
+
+        decoded.push(bytes[index]);
+        index += 1;
+    }
+
+    let decoded = std::str::from_utf8(&decoded).ok()?;
+    Some(String::from(decoded))
+}
+
+fn hex_value(byte: u8) -> Option<u8> {
+    match byte {
+        b'0'..=b'9' => Some(byte - b'0'),
+        b'a'..=b'f' => Some(byte - b'a' + 10),
+        b'A'..=b'F' => Some(byte - b'A' + 10),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{file_uri_to_path, path_to_file_uri};
+    use std::path::{Path, PathBuf};
+
+    #[test]
+    fn encodes_reserved_file_uri_path_bytes() {
+        assert_eq!(
+            path_to_file_uri(Path::new("/workspace/pages/[[org]]/[name] #1.vue.ts")),
+            "file:///workspace/pages/%5B%5Borg%5D%5D/%5Bname%5D%20%231.vue.ts"
+        );
+    }
+
+    #[test]
+    fn decodes_file_uri_path_bytes() {
+        assert_eq!(
+            file_uri_to_path("file:///workspace/pages/%5B%5Borg%5D%5D/%5Bname%5D%20%231.vue.ts"),
+            Some(PathBuf::from("/workspace/pages/[[org]]/[name] #1.vue.ts"))
+        );
+    }
+}

--- a/crates/vize_canon/src/lib.rs
+++ b/crates/vize_canon/src/lib.rs
@@ -45,6 +45,8 @@
 mod checker;
 mod context;
 mod diagnostic;
+#[cfg(feature = "native")]
+mod file_uri;
 pub mod intelligence;
 pub mod sfc_typecheck;
 pub mod source_map;

--- a/crates/vize_canon/src/lsp_client/diagnostics.rs
+++ b/crates/vize_canon/src/lsp_client/diagnostics.rs
@@ -4,6 +4,7 @@ use super::{
     utils::convert_diagnostics,
     CorsaProjectClient, DiagnosticFetch, LspDiagnostic,
 };
+use crate::file_uri::{file_uri_to_path, path_to_file_uri};
 use corsa::{
     jsonrpc::InboundEvent,
     lsp::{LspClient, LspSpawnConfig, VirtualDocument},
@@ -463,7 +464,7 @@ fn initialize_lsp_client(client: &LspClient, project_root: &std::path::Path) -> 
         const METHOD: &'static str = "initialized";
     }
 
-    let root_uri = cstr!("file://{}", project_root.display());
+    let root_uri = path_to_file_uri(project_root);
     block_on(client.request::<InitializeRequest>(serde_json::json!({
         "processId": std::process::id(),
         "rootUri": root_uri,
@@ -599,7 +600,7 @@ fn json_code_to_lsp_code(code: serde_json::Value) -> lsp_types::NumberOrString {
 }
 
 fn read_file_uri(uri: &str) -> Option<String> {
-    let path = uri.strip_prefix("file://")?;
+    let path = file_uri_to_path(uri)?;
     std::fs::read_to_string(path).ok().map(Into::into)
 }
 

--- a/crates/vize_canon/src/lsp_client/diagnostics_api.rs
+++ b/crates/vize_canon/src/lsp_client/diagnostics_api.rs
@@ -1,7 +1,9 @@
 use super::{utils::convert_diagnostics, CorsaProjectClient, LspDiagnostic};
+use crate::file_uri::path_to_file_uri;
 use corsa::api::{DocumentIdentifier, FileDiagnosticsResponse, ProjectDiagnosticsResponse};
 use lsp_types::Diagnostic;
-use vize_carton::{cstr, FxHashMap, String};
+use std::path::Path;
+use vize_carton::{FxHashMap, String};
 
 pub(super) fn map_project_diagnostics(
     client: &mut CorsaProjectClient,
@@ -41,7 +43,7 @@ pub(super) fn document_identifier_uri(document: &DocumentIdentifier) -> String {
         DocumentIdentifier::FileName(path) if path.as_str().starts_with("file://") => {
             path.as_str().into()
         }
-        DocumentIdentifier::FileName(path) => cstr!("file://{}", path.as_str()),
+        DocumentIdentifier::FileName(path) => path_to_file_uri(Path::new(path.as_str())),
     }
 }
 
@@ -73,6 +75,14 @@ mod tests {
         assert_eq!(
             document_identifier_uri(&DocumentIdentifier::from("/workspace/App.vue.ts")),
             "file:///workspace/App.vue.ts"
+        );
+    }
+
+    #[test]
+    fn file_names_are_percent_encoded_when_normalized_to_uris() {
+        assert_eq!(
+            document_identifier_uri(&DocumentIdentifier::from("/workspace/pages/[id].vue.ts")),
+            "file:///workspace/pages/%5Bid%5D.vue.ts"
         );
     }
 

--- a/crates/vize_canon/src/lsp_client/session.rs
+++ b/crates/vize_canon/src/lsp_client/session.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::disallowed_types)]
 
 use super::{utils::remap_serialized_uris, CorsaProjectClient};
+use crate::file_uri::{file_uri_to_path, path_to_file_uri};
 use corsa::{
     api::{
         ApiMode, ApiSpawnConfig, CapabilitiesResponse, DocumentIdentifier, FileChangeSummary,
@@ -118,8 +119,9 @@ fn is_node_wrapper_executable(path: &Path) -> bool {
 }
 
 pub(super) fn uri_document_identifier(uri: &str) -> DocumentIdentifier {
-    if let Some(path) = uri.strip_prefix("file://") {
-        return DocumentIdentifier::FileName(path.into());
+    if let Some(path) = file_uri_to_path(uri) {
+        let path = path.to_string_lossy();
+        return DocumentIdentifier::FileName(CompactString::from(path.as_ref()));
     }
 
     DocumentIdentifier::Uri {
@@ -268,7 +270,7 @@ fn next_overlay_version(versions: &mut vize_carton::FxHashMap<String, i32>, uri:
 }
 
 fn load_file_text(uri: &str) -> Option<String> {
-    let path = uri.strip_prefix("file://")?;
+    let path = file_uri_to_path(uri)?;
     std::fs::read_to_string(path).ok().map(Into::into)
 }
 
@@ -278,7 +280,7 @@ fn build_session_document_uri(uri: &str, project_root: &Path) -> String {
     };
 
     if external_path.starts_with(project_root) && external_path.exists() {
-        return cstr!("file://{}", external_path.display());
+        return path_to_file_uri(&external_path);
     }
 
     let mut session_path = project_root.join("__agent_only").join("vize-corsa-overlay");
@@ -291,12 +293,12 @@ fn build_session_document_uri(uri: &str, project_root: &Path) -> String {
         }
     }
 
-    cstr!("file://{}", session_path.display())
+    path_to_file_uri(&session_path)
 }
 
 fn external_document_path(uri: &str) -> Option<PathBuf> {
-    if let Some(path) = uri.strip_prefix("file://") {
-        return Some(PathBuf::from(path));
+    if let Some(path) = file_uri_to_path(uri) {
+        return Some(path);
     }
 
     let (scheme, path) = uri.split_once("://")?;
@@ -315,8 +317,8 @@ pub(super) fn materialize_session_document(
         return None;
     }
 
-    let path = document_uri.strip_prefix("file://")?;
-    let path = Path::new(path);
+    let path = file_uri_to_path(document_uri)?;
+    let path = path.as_path();
     let parent = path.parent()?;
     let existed = path.exists();
     let _ = std::fs::create_dir_all(parent);
@@ -342,8 +344,8 @@ fn remove_session_document(external_uri: &str, document_uri: &str) -> Option<Fil
         return None;
     }
 
-    let path = document_uri.strip_prefix("file://")?;
-    let path = Path::new(path);
+    let path = file_uri_to_path(document_uri)?;
+    let path = path.as_path();
     if !path.exists() {
         return None;
     }

--- a/docs/content/architecture/performance.md
+++ b/docs/content/architecture/performance.md
@@ -24,22 +24,22 @@ Compiling **15,000 Vue SFC files** (36.9 MB total):
 
 |                                | @vue/compiler-sfc | Vize  | Speedup   |
 | ------------------------------ | ----------------- | ----- | --------- |
-| **Single Thread**              | 10.43s            | 6.06s | **1.7x**  |
-| **Multi Thread**               | 3.45s             | 612ms | **5.6x**  |
-| **compiler-sfc ST vs Vize MT** | 10.43s            | 612ms | **16.7x** |
+| **Single Thread**              | 9.28s             | 3.30s | **2.8x**  |
+| **Multi Thread**               | 3.35s             | 434ms | **7.7x**  |
+| **compiler-sfc ST vs Vize MT** | 9.28s             | 434ms | **20.9x** |
 
 The single-threaded improvement comes from Rust's zero-cost abstractions (no GC, no JIT warmup, cache-friendly memory layout). The multi-threaded improvement comes from Rayon's work-stealing thread pool, which scales near-linearly with CPU core count.
 
-### Scaling Behavior
+### Native Batch Scaling Behavior
 
-| Files  | Vize (1 thread) | Vize (8 threads) | Parallel Speedup |
-| ------ | --------------- | ---------------- | ---------------- |
-| 100    | 44ms            | 12ms             | 3.7x             |
-| 1,000  | 443ms           | 73ms             | 6.1x             |
-| 5,000  | 2.2s            | 198ms            | 11.1x            |
-| 15,000 | 6.65s           | 498ms            | 13.4x            |
+| Files  | Vize batch (1 thread) | Vize batch (12 threads) | Parallel Speedup |
+| ------ | --------------------- | ----------------------- | ---------------- |
+| 100    | 22ms                  | 3ms                     | 7.0x             |
+| 1,000  | 218ms                 | 25ms                    | 8.7x             |
+| 5,000  | 1.09s                 | 125ms                   | 8.7x             |
+| 15,000 | 3.65s                 | 432ms                   | 8.5x             |
 
-The super-linear scaling at higher file counts is due to better amortization of thread pool startup costs and improved CPU cache utilization when all cores are saturated.
+These native batch numbers include file reads. Small batches are dominated by fixed overhead; larger batches settle around 8.5x parallel speedup on this 12-core machine.
 
 ## Why Rust?
 
@@ -121,9 +121,9 @@ Run `vp run --workspace-root bench:lint` to reproduce.
 
 Formatting **15,000 Vue SFC files**:
 
-|          | Prettier (ST) | Vize glyph (ST) | Speedup    | Prettier (MT) | Vize glyph (MT) | Speedup  | **Prettier ST vs Vize MT** |
-| -------- | ------------- | --------------- | ---------- | ------------- | --------------- | -------- | -------------------------- |
-| **Time** | 82.69s        | 36ms            | **2,303x** | 19.66s        | 23ms            | **872x** | **3,666x**                 |
+|          | Prettier (CLI) | Vize glyph (ST) | Speedup   | Vize glyph (MT) | **Prettier CLI vs Vize MT** |
+| -------- | -------------- | --------------- | --------- | --------------- | --------------------------- |
+| **Time** | 104.08s        | 3.44s           | **30.3x** | 1.32s           | **78.9x**                   |
 
 Run `vp run --workspace-root bench:fmt` to reproduce.
 
@@ -138,6 +138,16 @@ Type checking **15,000 Vue SFC files**:
 > **Note:** Vize canon is still in early development and the Corsa-backed diagnostics path is still catching up with vue-tsc fidelity. These measurements reflect the current native project-session implementation with auto-tuned parallel Corsa sessions and will change as diagnostics coverage and parity improve.
 
 Run `vp run --workspace-root bench:check` to reproduce.
+
+### Diagnostics-heavy e2e fixture
+
+`bench/check.ts` also measures the `tests/_fixtures/_git/npmx.dev` app when the fixture is present. This catches the diagnostics mapping path that synthetic no-error SFCs do not stress:
+
+| Fixture      | Source SFC files | Virtual files | Diagnostics | Vize canon |
+| ------------ | ---------------- | ------------- | ----------- | ---------- |
+| npmx.dev app | 134              | 226           | 3,943       | ~2.9s      |
+
+The current profile for this fixture keeps `canon.corsa.map_diagnostics` at ~31ms; most time is now in Corsa project diagnostics.
 
 ## Benchmark: Vite Plugin — @vizejs/vite-plugin vs @vitejs/plugin-vue
 


### PR DESCRIPTION
## Summary
- tune SFC compiler hot paths and refresh compiler benchmark results
- fix the formatter benchmark target selection so the Prettier comparison is valid
- profile the diagnostics-heavy `npmx.dev` e2e fixture and speed up Corsa diagnostic mapping
- update benchmark scripts/docs with reproducible `vp`-based commands and measured results

## Optimization details

### SFC compiler
- Reuse the `ScriptCompileContext` created by `compile_sfc` when compiling inline `<script setup>`, avoiding a second context build/analyze pass.
- Parse script setup sections once and reuse the split result for top-level await detection and output assembly, removing the duplicate parse previously used for await detection.
- Add cheap prefilters before expensive OXC-backed analysis: skip imported-type collection when the source has no `import`/`type`, and skip top-level await parsing when the source has no `await`.
- Generate scope IDs lazily so template/script-only SFCs without CSS vars or explicit scope IDs skip filename hashing.
- Short-circuit style compilation for empty style lists.
- Update `bench/run.ts` so output writing is disabled by default, worker resolution uses the resolved `@vue/compiler-sfc` path, and the summary uses the measured native single-thread timing instead of a hidden rerun.

Measured compiler benchmark after this change, 15,000 SFC files / 36.9 MB:

| Mode | @vue/compiler-sfc | Vize | Speedup |
| --- | ---: | ---: | ---: |
| Single thread | 9.28s | 3.30s | 2.8x |
| Multi thread | 3.35s | 434ms | 7.7x |
| compiler-sfc ST vs Vize MT | 9.28s | 434ms | 20.9x |

`bench:quick` measured Native ST at 219ms for 1,000 files and Native MT throughput at 38.4k files/s, for 24.3x user-facing speedup.

### Formatter benchmark
- Fix `vize fmt` glob collection so `*.vue` and absolute globs only match the requested directory instead of degenerating into every `.vue` file in the repo.
- Keep the default ignore-aware `**/*.vue` walker path, while using real glob handling for explicit globs and exact-file handling for direct file inputs.
- Update `bench/fmt.ts` to run in `bench/__in__`, use the local Prettier binary instead of `npx`, check formatter exit codes, and assert Vize reports the expected `.vue` file count.
- Update `bench/generate.mjs` to clean stale generated `Component*.vue` files before regeneration so old files cannot poison benchmark counts.

Measured formatter benchmark after this change, 15,000 SFC files:

| Formatter | Time |
| --- | ---: |
| Prettier CLI | 104.08s |
| Vize glyph 1T | 3.44s |
| Vize glyph 12T | 1.32s |

This replaces the previous invalid `3,666x` number with `78.9x`.

### Canon diagnostics profiling
- Add percent-encoded `file://` URI conversion for paths with reserved characters, including Nuxt bracket routes.
- Cache original source reads and virtual file line indexes inside diagnostic mapping, and add direct virtual-file lookup to avoid repeated scans/work during diagnostic mapping.
- Add the diagnostics-heavy `tests/_fixtures/_git/npmx.dev` app to `bench/check.ts` so no-error synthetic fixtures do not hide diagnostic mapping costs.

Current `npmx.dev` profile: 134 source SFC files, 226 virtual files, 3,943 diagnostics, about 2.9s total with `canon.corsa.map_diagnostics` around 31ms. Most remaining time is now in Corsa project diagnostics.

## Validation
- `cargo check -p vize_atelier_sfc -p vize_vitrine -p vize`
- `cargo test -p vize_atelier_sfc`
- `vp run --workspace-root fmt:all`
- `vp run --workspace-root clippy`
- `vp run --workspace-root test`
- `vp run --workspace-root bench:quick`
- `vp run --workspace-root test:playground`
- `vp run --workspace-root build:cli`
- `node --experimental-strip-types bench/run.ts`
- `node --experimental-strip-types bench/fmt.ts`
- `vp check bench/check.ts bench/fmt.ts bench/generate.mjs bench/run.ts README.md docs/content/architecture/performance.md`
- `git diff --check`

## CI
- Check: https://github.com/ubugeeei/vize/actions/runs/24284879389