### PR TITLE
fix: sanitize component asset identifiers

### DIFF
--- a/crates/vize_atelier_core/src/codegen.rs
+++ b/crates/vize_atelier_core/src/codegen.rs
@@ -183,6 +183,35 @@ mod tests {
     }
 
     #[test]
+    fn test_codegen_component_name_with_colon_uses_valid_identifier() {
+        let allocator = bumpalo::Bump::new();
+        let parser_opts = crate::ParserOptions {
+            is_native_tag: Some(vize_carton::is_native_tag),
+            ..Default::default()
+        };
+        let (mut root, errors) = crate::parse_with_options(
+            &allocator,
+            r#"<global:head title="Page Title" />"#,
+            parser_opts,
+        );
+        assert!(errors.is_empty(), "Parse errors: {:?}", errors);
+
+        crate::transform::transform(
+            &allocator,
+            &mut root,
+            crate::TransformOptions::default(),
+            None,
+        );
+        let output = result_output(&super::generate(&root, crate::CodegenOptions::default()));
+
+        assert!(
+            output.contains(r#"const _component_global_head = _resolveComponent("global:head")"#)
+        );
+        assert!(output.contains("_createBlock(_component_global_head"));
+        assert!(!output.contains("_component_global:head"));
+    }
+
+    #[test]
     fn test_root_directive_comment_does_not_create_fragment_hole() {
         let result =
             compile!("<!-- @vize:forget sections are labeled by their headings --><section />");

--- a/crates/vize_atelier_core/src/codegen/element/block.rs
+++ b/crates/vize_atelier_core/src/codegen/element/block.rs
@@ -13,7 +13,7 @@ use super::{
         children::{generate_children, generate_children_force_array, is_directive_comment},
         context::CodegenContext,
         expression::generate_expression,
-        helpers::is_builtin_component,
+        helpers::{is_builtin_component, to_valid_asset_identifier},
         node::generate_node,
         patch_flag::{
             calculate_element_patch_info, calculate_element_patch_info_skip_is, patch_flag_name,
@@ -310,8 +310,7 @@ pub fn generate_element_block(ctx: &mut CodegenContext, el: &ElementNode<'_>) {
                 }
                 ctx.push(&el.tag);
             } else {
-                ctx.push("_component_");
-                ctx.push(&el.tag.replace('-', "_"));
+                ctx.push(&to_valid_asset_identifier("component", &el.tag));
             }
 
             // Calculate patch flag and dynamic props for component

--- a/crates/vize_atelier_core/src/codegen/element/directives.rs
+++ b/crates/vize_atelier_core/src/codegen/element/directives.rs
@@ -10,6 +10,7 @@ use crate::{
 
 use super::super::{context::CodegenContext, expression::generate_expression};
 use super::helpers::{get_custom_directives, get_vmodel_directive, has_vshow_directive};
+use crate::codegen::helpers::to_valid_asset_identifier;
 
 /// Generate v-model directive closing
 pub fn generate_vmodel_closing(ctx: &mut CodegenContext, el: &ElementNode<'_>) {
@@ -125,8 +126,8 @@ pub fn generate_custom_directives_closing(ctx: &mut CodegenContext, el: &Element
             ctx.push(",");
             ctx.newline();
         }
-        ctx.push("  [_directive_");
-        ctx.push(&dir.name.replace('-', "_"));
+        ctx.push("  [");
+        ctx.push(&to_valid_asset_identifier("directive", &dir.name));
 
         // Add value if present
         if let Some(exp) = &dir.exp {

--- a/crates/vize_atelier_core/src/codegen/element/inline.rs
+++ b/crates/vize_atelier_core/src/codegen/element/inline.rs
@@ -13,7 +13,7 @@ use super::{
         children::{generate_children, is_directive_comment},
         context::CodegenContext,
         expression::generate_expression,
-        helpers::is_builtin_component,
+        helpers::{is_builtin_component, to_valid_asset_identifier},
         node::generate_node,
         patch_flag::{
             calculate_element_patch_info, calculate_element_patch_info_skip_is, patch_flag_name,
@@ -215,8 +215,7 @@ pub fn generate_element(ctx: &mut CodegenContext, el: &ElementNode<'_>) {
                 }
                 ctx.push(&el.tag);
             } else {
-                ctx.push("_component_");
-                ctx.push(&el.tag.replace('-', "_"));
+                ctx.push(&to_valid_asset_identifier("component", &el.tag));
             }
 
             // Calculate patch flag and dynamic props for component

--- a/crates/vize_atelier_core/src/codegen/element/v_once.rs
+++ b/crates/vize_atelier_core/src/codegen/element/v_once.rs
@@ -10,7 +10,7 @@ use crate::ast::{
 use super::super::{
     context::CodegenContext,
     expression::generate_expression,
-    helpers::escape_js_string,
+    helpers::{escape_js_string, to_valid_asset_identifier},
     node::generate_node,
     patch_flag::{calculate_element_patch_info, patch_flag_name},
     props::is_supported_directive,
@@ -45,8 +45,8 @@ pub fn generate_v_once_element(ctx: &mut CodegenContext, el: &ElementNode<'_>) {
         ctx.use_helper(RuntimeHelper::CreateVNode);
         ctx.use_helper(RuntimeHelper::ResolveComponent);
         ctx.push(ctx.helper(RuntimeHelper::CreateVNode));
-        ctx.push("(_component_");
-        ctx.push(&el.tag.replace('-', "_"));
+        ctx.push("(");
+        ctx.push(&to_valid_asset_identifier("component", &el.tag));
         ctx.push(")");
     } else {
         ctx.use_helper(RuntimeHelper::CreateElementVNode);

--- a/crates/vize_atelier_core/src/codegen/helpers.rs
+++ b/crates/vize_atelier_core/src/codegen/helpers.rs
@@ -122,6 +122,24 @@ pub fn is_valid_js_identifier(s: &str) -> bool {
     chars.all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '$')
 }
 
+/// Convert a component/directive asset name into a valid JavaScript identifier.
+pub fn to_valid_asset_identifier(kind: &str, name: &str) -> String {
+    let mut ident = String::with_capacity(kind.len() + name.len() + 2);
+    ident.push('_');
+    ident.push_str(kind);
+    ident.push('_');
+
+    for c in name.chars() {
+        if c.is_ascii_alphanumeric() || c == '_' {
+            ident.push(c);
+        } else {
+            ident.push('_');
+        }
+    }
+
+    ident
+}
+
 /// Default helper alias function
 pub fn default_helper_alias(helper: RuntimeHelper) -> &'static str {
     match helper {

--- a/crates/vize_atelier_core/src/codegen/root.rs
+++ b/crates/vize_atelier_core/src/codegen/root.rs
@@ -7,6 +7,7 @@ use crate::ast::{RootNode, RuntimeHelper, TemplateChildNode};
 
 use super::context::CodegenContext;
 use super::element::helpers::is_dynamic_component_tag;
+use super::helpers::to_valid_asset_identifier;
 use vize_carton::{camelize, capitalize, String};
 
 /// Check if a root-level text node is ignorable whitespace.
@@ -121,8 +122,8 @@ pub(super) fn generate_assets(ctx: &mut CodegenContext, root: &RootNode<'_>) {
         }
 
         ctx.use_helper(RuntimeHelper::ResolveComponent);
-        ctx.push("const _component_");
-        ctx.push(&component.replace('-', "_"));
+        ctx.push("const ");
+        ctx.push(&to_valid_asset_identifier("component", component));
         ctx.push(" = ");
         ctx.push(ctx.helper(RuntimeHelper::ResolveComponent));
         ctx.push("(\"");
@@ -134,8 +135,8 @@ pub(super) fn generate_assets(ctx: &mut CodegenContext, root: &RootNode<'_>) {
 
     // Resolve directives
     for directive in root.directives.iter() {
-        ctx.push("const _directive_");
-        ctx.push(&directive.replace('-', "_"));
+        ctx.push("const ");
+        ctx.push(&to_valid_asset_identifier("directive", directive));
         ctx.push(" = ");
         let binding_name = imported_directive_binding_name(directive);
         let uses_imported_binding = ctx

--- a/crates/vize_atelier_core/src/codegen/v_for/generate.rs
+++ b/crates/vize_atelier_core/src/codegen/v_for/generate.rs
@@ -17,7 +17,7 @@ use super::super::{
         has_custom_directives, has_vmodel_directive, has_vshow_directive,
     },
     expression::generate_expression,
-    helpers::{escape_js_string, is_builtin_component},
+    helpers::{escape_js_string, is_builtin_component, to_valid_asset_identifier},
     node::generate_node,
     patch_flag::{
         calculate_element_patch_info, calculate_element_patch_info_skip_is, patch_flag_name,
@@ -182,8 +182,7 @@ pub fn generate_for_item(ctx: &mut CodegenContext, node: &TemplateChildNode<'_>,
                         }
                         ctx.push(&el.tag);
                     } else {
-                        ctx.push("_component_");
-                        ctx.push(&el.tag.replace('-', "_"));
+                        ctx.push(&to_valid_asset_identifier("component", &el.tag));
                     }
                 } else if gen_is_template {
                     // Template with multiple children: use Fragment

--- a/crates/vize_atelier_core/src/codegen/v_if/branch.rs
+++ b/crates/vize_atelier_core/src/codegen/v_if/branch.rs
@@ -19,7 +19,7 @@ use super::{
             has_custom_directives, has_vmodel_directive, has_vshow_directive,
         },
         expression::generate_expression,
-        helpers::{escape_js_string, is_builtin_component},
+        helpers::{escape_js_string, is_builtin_component, to_valid_asset_identifier},
         node::generate_node,
         patch_flag::{
             calculate_element_patch_info, calculate_element_patch_info_skip_is, patch_flag_name,
@@ -203,8 +203,7 @@ fn generate_if_branch_component(
         }
         ctx.push(el.tag.as_str());
     } else {
-        ctx.push("_component_");
-        ctx.push(&el.tag.replace('-', "_"));
+        ctx.push(&to_valid_asset_identifier("component", &el.tag));
     }
 
     let (mut patch_flag, dynamic_props) = if is_dynamic_component {

--- a/tests/expected/vdom/component.snap
+++ b/tests/expected/vdom/component.snap
@@ -74,6 +74,20 @@ export function render(_ctx, _cache) {
 }
 
 ===
+name: component name with colon
+options: default
+--- INPUT ---
+<global:head title="Page Title" />
+--- OUTPUT ---
+import { resolveComponent as _resolveComponent, openBlock as _openBlock, createBlock as _createBlock } from "vue"
+
+export function render(_ctx, _cache) {
+  const _component_global_head = _resolveComponent("global:head")
+
+  return (_openBlock(), _createBlock(_component_global_head, { title: "Page Title" }))
+}
+
+===
 name: static prop
 options: default
 --- INPUT ---

--- a/tests/fixtures/vdom/component.toml
+++ b/tests/fixtures/vdom/component.toml
@@ -26,6 +26,10 @@ input = "<MyComponent />"
 name = "kebab-case component"
 input = "<my-component />"
 
+[[cases]]
+name = "component name with colon"
+input = '<global:head title="Page Title" />'
+
 # =============================================================================
 # Component props
 # =============================================================================


### PR DESCRIPTION
Fixes #156

## Summary

- Sanitize generated component asset identifiers so component names such as `global:head` compile to valid JavaScript bindings.
- Reuse the same asset identifier helper across root asset resolution and component call sites.
- Add a regression case for colon-containing component names.



## Verification

- `cargo fmt`
- `cargo test -p vize_atelier_core codegen`
- `cargo test -p vize_test_runner tests::vdom_component -- --ignored --exact`

Note: `vdom_component` still fails on 8 existing built-in component snapshot mismatches; the new `component name with colon` case is not among the failures.
