### PR TITLE
perf: speed up profiled SFC builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2518,12 +2518,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex-lite"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
-
-[[package]]
 name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3462,7 +3456,6 @@ dependencies = [
  "oxc_span",
  "oxc_transformer",
  "rayon",
- "regex-lite",
  "rpkl",
  "serde",
  "serde_json",

--- a/crates/vize/Cargo.toml
+++ b/crates/vize/Cargo.toml
@@ -64,9 +64,6 @@ oxc_semantic = { workspace = true }
 oxc_span = { workspace = true }
 oxc_transformer = { workspace = true }
 
-# Regex for script language detection
-regex-lite.workspace = true
-
 # PKL configuration language
 rpkl.workspace = true
 

--- a/crates/vize/src/commands/build/config.rs
+++ b/crates/vize/src/commands/build/config.rs
@@ -7,7 +7,7 @@
 
 use std::{
     path::PathBuf,
-    sync::{atomic::AtomicUsize, Mutex},
+    sync::atomic::{AtomicU64, AtomicUsize, Ordering},
     time::Duration,
 };
 
@@ -23,8 +23,8 @@ pub(crate) struct CompileStats {
     pub failed: AtomicUsize,
     pub total_bytes: AtomicUsize,
     pub output_bytes: AtomicUsize,
-    pub total_parse_time: Mutex<Duration>,
-    pub total_compile_time: Mutex<Duration>,
+    pub total_parse_nanos: AtomicU64,
+    pub total_compile_nanos: AtomicU64,
 }
 
 impl CompileStats {
@@ -35,21 +35,31 @@ impl CompileStats {
             failed: AtomicUsize::new(0),
             total_bytes: AtomicUsize::new(0),
             output_bytes: AtomicUsize::new(0),
-            total_parse_time: Mutex::new(Duration::ZERO),
-            total_compile_time: Mutex::new(Duration::ZERO),
+            total_parse_nanos: AtomicU64::new(0),
+            total_compile_nanos: AtomicU64::new(0),
         }
     }
 
     pub fn add_parse_time(&self, duration: Duration) {
-        if let Ok(mut total) = self.total_parse_time.lock() {
-            *total += duration;
-        }
+        self.total_parse_nanos.fetch_add(
+            duration.as_nanos().try_into().unwrap_or(u64::MAX),
+            Ordering::Relaxed,
+        );
     }
 
     pub fn add_compile_time(&self, duration: Duration) {
-        if let Ok(mut total) = self.total_compile_time.lock() {
-            *total += duration;
-        }
+        self.total_compile_nanos.fetch_add(
+            duration.as_nanos().try_into().unwrap_or(u64::MAX),
+            Ordering::Relaxed,
+        );
+    }
+
+    pub fn total_parse_time(&self) -> Duration {
+        Duration::from_nanos(self.total_parse_nanos.load(Ordering::Relaxed))
+    }
+
+    pub fn total_compile_time(&self) -> Duration {
+        Duration::from_nanos(self.total_compile_nanos.load(Ordering::Relaxed))
     }
 }
 

--- a/crates/vize/src/commands/build/runner.rs
+++ b/crates/vize/src/commands/build/runner.rs
@@ -79,10 +79,7 @@ pub(crate) fn run(args: BuildArgs) {
     let results: Vec<_> = files
         .par_iter()
         .map(|path| {
-            let source_size = fs::metadata(path).map(|m| m.len() as usize).unwrap_or(0);
-            stats.total_bytes.fetch_add(source_size, Ordering::Relaxed);
-
-            match compile_file_with_profile(path, args.ssr, args.script_ext, &stats) {
+            match compile_file_with_profile(path, args.ssr, args.script_ext, &stats, args.profile) {
                 Ok((output, profile)) => {
                     stats.success.fetch_add(1, Ordering::Relaxed);
                     stats
@@ -263,16 +260,8 @@ pub(crate) fn run(args: BuildArgs) {
         let profiler = global_profiler();
         let operation_summary = profiler.summary();
         profiler.disable();
-        let total_parse = stats
-            .total_parse_time
-            .lock()
-            .map(|d| *d)
-            .unwrap_or(Duration::ZERO);
-        let total_compile = stats
-            .total_compile_time
-            .lock()
-            .map(|d| *d)
-            .unwrap_or(Duration::ZERO);
+        let total_parse = stats.total_parse_time();
+        let total_compile = stats.total_compile_time();
 
         let mut all_profiles = profiles.into_inner().unwrap_or_default();
         all_profiles.sort_by_key(|profile| std::cmp::Reverse(profile.total_time));
@@ -490,26 +479,13 @@ fn pattern_matches(path: &std::path::Path, pattern: &str) -> bool {
     path_str.ends_with(".vue")
 }
 
-/// Detect the script language from `<script lang="...">` in the SFC source.
-fn detect_script_lang(source: &str) -> String {
-    let script_pattern = regex_lite::Regex::new(r#"<script[^>]*\blang\s*=\s*["']([^"']+)["']"#)
-        .expect("Invalid regex");
-
-    if let Some(captures) = script_pattern.captures(source) {
-        if let Some(lang) = captures.get(1) {
-            return lang.as_str().to_compact_string();
-        }
-    }
-
-    "js".into()
-}
-
 /// Compile a single `.vue` file with profiling information.
 fn compile_file_with_profile(
     path: &PathBuf,
     ssr: bool,
     script_ext: ScriptExtension,
     stats: &CompileStats,
+    record_profile_totals: bool,
 ) -> Result<(CompileOutput, FileProfile), CompileError> {
     let file_start = Instant::now();
 
@@ -521,14 +497,13 @@ fn compile_file_with_profile(
     })?;
 
     let file_size = source.len();
+    stats.total_bytes.fetch_add(file_size, Ordering::Relaxed);
 
     let filename: String = path
         .file_name()
         .and_then(|n| n.to_str())
         .unwrap_or("anonymous.vue")
         .into();
-
-    let script_lang = detect_script_lang(&source);
 
     // Parse
     let parse_start = Instant::now();
@@ -546,7 +521,17 @@ fn compile_file_with_profile(
             }
         })?;
     let parse_time = parse_start.elapsed();
-    stats.add_parse_time(parse_time);
+    if record_profile_totals {
+        stats.add_parse_time(parse_time);
+    }
+
+    let script_lang = descriptor
+        .script_setup
+        .as_ref()
+        .and_then(|s| s.lang.as_deref())
+        .or_else(|| descriptor.script.as_ref().and_then(|s| s.lang.as_deref()))
+        .unwrap_or("js")
+        .to_compact_string();
 
     // Calculate sizes
     let template_size = descriptor
@@ -606,7 +591,9 @@ fn compile_file_with_profile(
         phase: ErrorPhase::Compile,
     })?;
     let compile_time = compile_start.elapsed();
-    stats.add_compile_time(compile_time);
+    if record_profile_totals {
+        stats.add_compile_time(compile_time);
+    }
 
     let total_time = file_start.elapsed();
 

--- a/crates/vize_atelier_core/src/transform/element.rs
+++ b/crates/vize_atelier_core/src/transform/element.rs
@@ -1,6 +1,6 @@
 //! Element transformation functions.
 
-use vize_carton::{capitalize, is_builtin_directive, Box, String, Vec};
+use vize_carton::{capitalize, is_builtin_directive, is_native_tag, Box, String, Vec};
 
 use crate::ast::*;
 use crate::transforms::transform_expression::process_inline_handler;
@@ -66,12 +66,26 @@ fn maybe_promote_element_to_component(
         return;
     }
 
-    if is_dynamic_component_tag(&el.tag)
-        || has_is_attribute(el)
-        || is_registered_component(ctx, &el.tag)
+    let looks_like_component = is_dynamic_component_tag(&el.tag)
         || el.tag.chars().next().is_some_and(|c| c.is_uppercase())
-        || el.tag.contains('-')
-    {
+        || el.tag.contains('-');
+
+    if looks_like_component {
+        el.tag_type = ElementType::Component;
+        return;
+    }
+
+    let has_is = has_is_attribute(el);
+    if has_is {
+        el.tag_type = ElementType::Component;
+        return;
+    }
+
+    if is_native_tag(&el.tag) {
+        return;
+    }
+
+    if is_registered_component(ctx, &el.tag) {
         el.tag_type = ElementType::Component;
     }
 }
@@ -88,12 +102,17 @@ fn is_registered_component(ctx: &TransformContext<'_>, tag: &str) -> bool {
         return true;
     }
 
-    let camel = vize_carton::camelize(tag);
-    if ctx.is_component_registered(camel.as_str()) {
-        return true;
+    if tag.contains('-') || tag.contains('_') {
+        let camel = vize_carton::camelize(tag);
+        if ctx.is_component_registered(camel.as_str()) {
+            return true;
+        }
+
+        let pascal = capitalize(&camel);
+        return ctx.is_component_registered(pascal.as_str());
     }
 
-    let pascal = capitalize(&camel);
+    let pascal = capitalize(tag);
     ctx.is_component_registered(pascal.as_str())
 }
 
@@ -158,6 +177,15 @@ fn process_directive_expressions<'a>(
 
 /// Process element properties and directives
 fn process_element_props<'a>(ctx: &mut TransformContext<'a>, el: &mut Box<'a, ElementNode<'a>>) {
+    if el.props.is_empty()
+        || !el
+            .props
+            .iter()
+            .any(|prop| matches!(prop, PropNode::Directive(_)))
+    {
+        return;
+    }
+
     let allocator = ctx.allocator;
     let is_component = el.tag_type == ElementType::Component;
 

--- a/crates/vize_atelier_core/src/transform/structural.rs
+++ b/crates/vize_atelier_core/src/transform/structural.rs
@@ -16,62 +16,79 @@ pub struct SimpleExpressionContent {
     pub loc: SourceLocation,
 }
 
-/// Check if element has a structural directive.
-/// In Vue 3, v-if has higher priority than v-for when both are on the same element.
-/// So we check for v-if/v-else-if/v-else first, then v-for.
-pub fn check_structural_directive<'a>(
-    el: &ElementNode<'a>,
-) -> Option<(
-    String,
-    Option<SimpleExpressionContent>,
-    Option<SourceLocation>,
-)> {
-    // First pass: check for v-if/v-else-if/v-else (higher priority)
-    for prop in el.props.iter() {
+#[derive(Clone, Copy)]
+pub enum StructuralDirectiveKind {
+    If,
+    ElseIf,
+    Else,
+    For,
+}
+
+fn directive_expression_to_content(exp: ExpressionNode<'_>) -> SimpleExpressionContent {
+    match exp {
+        ExpressionNode::Simple(s) => {
+            let s = Box::into_inner(s);
+            SimpleExpressionContent {
+                content: s.content,
+                is_static: s.is_static,
+                loc: s.loc,
+            }
+        }
+        ExpressionNode::Compound(c) => {
+            let c = Box::into_inner(c);
+            let loc = c.loc;
+            SimpleExpressionContent {
+                content: loc.source.clone(),
+                is_static: false,
+                loc,
+            }
+        }
+    }
+}
+
+/// Take the highest-priority structural directive from an element.
+///
+/// In Vue 3, v-if has higher priority than v-for when both are present on the same element.
+/// This removes the selected directive from the element in the same pass we discover it.
+pub fn take_structural_directive<'a>(
+    el: &mut Box<'a, ElementNode<'a>>,
+) -> Option<(StructuralDirectiveKind, Option<SimpleExpressionContent>)> {
+    let mut selected_if = None;
+    let mut selected_for = None;
+
+    for (idx, prop) in el.props.iter().enumerate() {
         if let PropNode::Directive(dir) = prop {
             match dir.name.as_str() {
-                "if" | "else-if" | "else" => {
-                    let exp_content = dir.exp.as_ref().map(|e| match e {
-                        ExpressionNode::Simple(s) => SimpleExpressionContent {
-                            content: s.content.clone(),
-                            is_static: s.is_static,
-                            loc: s.loc.clone(),
-                        },
-                        ExpressionNode::Compound(c) => SimpleExpressionContent {
-                            content: c.loc.source.clone(),
-                            is_static: false,
-                            loc: c.loc.clone(),
-                        },
-                    });
-                    let exp_loc = dir.exp.as_ref().map(|e| e.loc().clone());
-                    return Some((dir.name.clone(), exp_content, exp_loc));
+                "if" => {
+                    selected_if = Some((idx, StructuralDirectiveKind::If));
+                    break;
+                }
+                "else-if" => {
+                    selected_if = Some((idx, StructuralDirectiveKind::ElseIf));
+                    break;
+                }
+                "else" => {
+                    selected_if = Some((idx, StructuralDirectiveKind::Else));
+                    break;
+                }
+                "for" if selected_for.is_none() => {
+                    selected_for = Some((idx, StructuralDirectiveKind::For));
                 }
                 _ => {}
             }
         }
     }
-    // Second pass: check for v-for (lower priority)
-    for prop in el.props.iter() {
-        if let PropNode::Directive(dir) = prop {
-            if dir.name.as_str() == "for" {
-                let exp_content = dir.exp.as_ref().map(|e| match e {
-                    ExpressionNode::Simple(s) => SimpleExpressionContent {
-                        content: s.content.clone(),
-                        is_static: s.is_static,
-                        loc: s.loc.clone(),
-                    },
-                    ExpressionNode::Compound(c) => SimpleExpressionContent {
-                        content: c.loc.source.clone(),
-                        is_static: false,
-                        loc: c.loc.clone(),
-                    },
-                });
-                let exp_loc = dir.exp.as_ref().map(|e| e.loc().clone());
-                return Some((dir.name.clone(), exp_content, exp_loc));
-            }
-        }
-    }
-    None
+
+    let (directive_idx, directive_kind) = selected_if.or(selected_for)?;
+    let directive = match el.props.remove(directive_idx) {
+        PropNode::Directive(dir) => Box::into_inner(dir),
+        PropNode::Attribute(_) => unreachable!("structural directives are always directive props"),
+    };
+
+    Some((
+        directive_kind,
+        directive.exp.map(directive_expression_to_content),
+    ))
 }
 
 /// Extract and remove key prop from element
@@ -97,25 +114,10 @@ pub fn extract_key_prop<'a>(el: &mut ElementNode<'a>) -> Option<PropNode<'a>> {
     key_index.map(|i| el.props.remove(i))
 }
 
-/// Remove structural directive from element props
-pub fn remove_structural_directive<'a>(el: &mut Box<'a, ElementNode<'a>>, dir_name: &str) {
-    let mut i = 0;
-    while i < el.props.len() {
-        if let PropNode::Directive(dir) = &el.props[i] {
-            if dir.name.as_str() == dir_name {
-                el.props.remove(i);
-                return;
-            }
-        }
-        i += 1;
-    }
-}
-
 /// Transform v-if directive
 pub fn transform_v_if<'a>(
     ctx: &mut TransformContext<'a>,
     exp: Option<&SimpleExpressionContent>,
-    _exp_loc: Option<SourceLocation>,
     is_root: bool,
 ) -> Option<std::vec::Vec<ExitFn<'a>>> {
     let allocator = ctx.allocator;
@@ -387,7 +389,6 @@ pub fn transform_v_if<'a>(
 pub fn transform_v_for<'a>(
     ctx: &mut TransformContext<'a>,
     exp: Option<&SimpleExpressionContent>,
-    _exp_loc: Option<SourceLocation>,
 ) -> Option<std::vec::Vec<ExitFn<'a>>> {
     let allocator = ctx.allocator;
 

--- a/crates/vize_atelier_core/src/transform/traverse.rs
+++ b/crates/vize_atelier_core/src/transform/traverse.rs
@@ -6,11 +6,17 @@ use vize_carton::profile;
 
 use super::element::{transform_element, transform_interpolation};
 use super::structural::{
-    check_structural_directive, remove_structural_directive, transform_v_for, transform_v_if,
+    take_structural_directive, transform_v_for, transform_v_if, StructuralDirectiveKind,
 };
 use super::{ExitFn, ParentNode, TransformContext};
 
 fn enter_v_slot_scope_if_needed<'a>(ctx: &mut TransformContext<'a>, el: &ElementNode<'a>) -> bool {
+    if el.children.is_empty()
+        || (el.tag_type != ElementType::Component && el.tag.as_str() != "template")
+    {
+        return false;
+    }
+
     for prop in el.props.iter() {
         if let PropNode::Directive(dir) = prop {
             if dir.name != "slot" {
@@ -72,40 +78,36 @@ pub fn traverse_node<'a>(ctx: &mut TransformContext<'a>, node: &mut TemplateChil
             // Check for structural directives first
             let structural_result = profile!(
                 "atelier.transform.check_structural",
-                check_structural_directive(el)
+                take_structural_directive(el)
             );
 
-            if let Some((dir_name, exp, exp_loc)) = structural_result {
-                // Remove the directive from props
-                remove_structural_directive(el, &dir_name);
-
+            if let Some((directive_kind, exp)) = structural_result {
                 // Handle the structural directive
-                match dir_name.as_str() {
-                    "if" => {
+                match directive_kind {
+                    StructuralDirectiveKind::If => {
                         if let Some(exits) = profile!(
                             "atelier.transform.v_if",
-                            transform_v_if(ctx, exp.as_ref(), exp_loc, true)
+                            transform_v_if(ctx, exp.as_ref(), true)
                         ) {
                             exit_fns.extend(exits);
                         }
                     }
-                    "else-if" | "else" => {
+                    StructuralDirectiveKind::ElseIf | StructuralDirectiveKind::Else => {
                         if let Some(exits) = profile!(
                             "atelier.transform.v_if",
-                            transform_v_if(ctx, exp.as_ref(), exp_loc, false)
+                            transform_v_if(ctx, exp.as_ref(), false)
                         ) {
                             exit_fns.extend(exits);
                         }
                     }
-                    "for" => {
+                    StructuralDirectiveKind::For => {
                         if let Some(exits) = profile!(
                             "atelier.transform.v_for",
-                            transform_v_for(ctx, exp.as_ref(), exp_loc)
+                            transform_v_for(ctx, exp.as_ref())
                         ) {
                             exit_fns.extend(exits);
                         }
                     }
-                    _ => {}
                 }
 
                 // If node was replaced (e.g., by v-if transform), we need to traverse the new node
@@ -269,14 +271,16 @@ pub fn traverse_node<'a>(ctx: &mut TransformContext<'a>, node: &mut TemplateChil
 
     // Traverse children for element nodes
     if let TemplateChildNode::Element(el) = node {
-        let entered_slot_scope = enter_v_slot_scope_if_needed(ctx, el);
-        let el_ptr = el.as_mut() as *mut ElementNode<'a>;
-        profile!(
-            "atelier.transform.traverse_element_children",
-            traverse_children(ctx, ParentNode::Element(el_ptr))
-        );
-        if entered_slot_scope {
-            ctx.exit_scope();
+        if !el.children.is_empty() {
+            let entered_slot_scope = enter_v_slot_scope_if_needed(ctx, el);
+            let el_ptr = el.as_mut() as *mut ElementNode<'a>;
+            profile!(
+                "atelier.transform.traverse_element_children",
+                traverse_children(ctx, ParentNode::Element(el_ptr))
+            );
+            if entered_slot_scope {
+                ctx.exit_scope();
+            }
         }
     }
 

--- a/crates/vize_atelier_sfc/Cargo.toml
+++ b/crates/vize_atelier_sfc/Cargo.toml
@@ -44,3 +44,7 @@ toml = { workspace = true }
 [[bench]]
 name = "sfc_parse"
 harness = false
+
+[[bench]]
+name = "sfc_compile"
+harness = false

--- a/crates/vize_atelier_sfc/benches/sfc_compile.rs
+++ b/crates/vize_atelier_sfc/benches/sfc_compile.rs
@@ -1,0 +1,315 @@
+//! Native Rust benchmarks for SFC compilation performance.
+//!
+//! Run with: cargo bench -p vize_atelier_sfc --bench sfc_compile
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
+use vize_atelier_sfc::{
+    compile_sfc, parse_sfc, ScriptCompileOptions, SfcCompileOptions, SfcParseOptions,
+    StyleCompileOptions, TemplateCompileOptions,
+};
+
+const SIMPLE_TEMPLATE_ONLY: &str = r#"<template>
+  <section class="hero">
+    <h1>{{ title }}</h1>
+    <p>{{ subtitle }}</p>
+  </section>
+</template>
+
+<style scoped>
+.hero {
+  padding: 24px;
+}
+</style>
+"#;
+
+const MEDIUM_SCRIPT_SETUP: &str = r#"<template>
+  <div class="app-shell">
+    <header class="topbar">
+      <button @click="toggleMenu" class="menu-trigger">{{ menuLabel }}</button>
+      <nav class="tabs">
+        <button
+          v-for="tab in tabs"
+          :key="tab.id"
+          :class="{ active: tab.id === activeTab }"
+          @click="activeTab = tab.id"
+        >
+          {{ tab.label }}
+        </button>
+      </nav>
+    </header>
+    <main class="content">
+      <article v-if="activePanel" class="panel">
+        <h2>{{ activePanel.title }}</h2>
+        <p>{{ activePanel.description }}</p>
+        <ul>
+          <li v-for="item in activePanel.items" :key="item.id">{{ item.label }}</li>
+        </ul>
+      </article>
+    </main>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+
+type PanelItem = { id: number; label: string }
+type Panel = { id: string; title: string; description: string; items: PanelItem[] }
+
+const menuLabel = ref('Open menu')
+const activeTab = ref('overview')
+const tabs = ref([
+  { id: 'overview', label: 'Overview' },
+  { id: 'usage', label: 'Usage' },
+  { id: 'api', label: 'API' },
+])
+
+const panels = ref<Panel[]>([
+  {
+    id: 'overview',
+    title: 'Overview',
+    description: 'A compact compile benchmark for script setup.',
+    items: [
+      { id: 1, label: 'Fast parsing' },
+      { id: 2, label: 'Inline template output' },
+    ],
+  },
+  {
+    id: 'usage',
+    title: 'Usage',
+    description: 'Exercises v-for, v-if, and event handlers.',
+    items: [
+      { id: 3, label: 'Stateful tabs' },
+      { id: 4, label: 'Computed panel lookup' },
+    ],
+  },
+])
+
+const activePanel = computed(() => panels.value.find((panel) => panel.id === activeTab.value))
+
+function toggleMenu() {
+  menuLabel.value = menuLabel.value === 'Open menu' ? 'Close menu' : 'Open menu'
+}
+</script>
+
+<style scoped>
+.app-shell {
+  display: grid;
+  gap: 16px;
+}
+
+.tabs {
+  display: flex;
+  gap: 8px;
+}
+
+.panel {
+  border: 1px solid #ddd;
+  padding: 16px;
+}
+</style>
+"#;
+
+const COMPLEX_SCRIPT_SETUP: &str = r#"<template>
+  <section class="dashboard">
+    <header class="dashboard-header">
+      <div>
+        <p class="eyebrow">{{ eyebrow }}</p>
+        <h1>{{ title }}</h1>
+      </div>
+      <button @click="refresh" :disabled="loading" class="refresh">
+        {{ loading ? 'Refreshing…' : 'Refresh' }}
+      </button>
+    </header>
+
+    <div class="summary-grid">
+      <article
+        v-for="metric in metrics"
+        :key="metric.id"
+        class="metric-card"
+        :style="{ borderColor: metric.color }"
+      >
+        <span class="metric-label">{{ metric.label }}</span>
+        <strong class="metric-value">{{ metric.value }}</strong>
+        <em class="metric-change">{{ metric.change }}</em>
+      </article>
+    </div>
+
+    <section v-if="visibleProjects.length" class="projects">
+      <article v-for="project in visibleProjects" :key="project.id" class="project-card">
+        <header>
+          <h2>{{ project.name }}</h2>
+          <span>{{ project.owner }}</span>
+        </header>
+        <p>{{ project.summary }}</p>
+        <ul>
+          <li v-for="tag in project.tags" :key="tag">{{ tag }}</li>
+        </ul>
+      </article>
+    </section>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+
+interface Metric {
+  id: number
+  label: string
+  value: string
+  change: string
+  color: string
+}
+
+interface Project {
+  id: number
+  name: string
+  owner: string
+  summary: string
+  tags: string[]
+  featured: boolean
+}
+
+const eyebrow = ref('Operations')
+const title = ref('System overview')
+const loading = ref(false)
+const showFeaturedOnly = ref(false)
+
+const metrics = ref<Metric[]>([
+  { id: 1, label: 'Deployments', value: '128', change: '+12%', color: '#22c55e' },
+  { id: 2, label: 'Latency', value: '84ms', change: '-9%', color: '#3b82f6' },
+  { id: 3, label: 'Errors', value: '3', change: '-42%', color: '#ef4444' },
+])
+
+const projects = ref<Project[]>([
+  {
+    id: 1,
+    name: 'Atlas',
+    owner: 'Platform',
+    summary: 'Core dashboard application',
+    tags: ['dashboard', 'vue', 'rust'],
+    featured: true,
+  },
+  {
+    id: 2,
+    name: 'Comet',
+    owner: 'Growth',
+    summary: 'Acquisition experiments and reporting',
+    tags: ['growth', 'analytics'],
+    featured: false,
+  },
+  {
+    id: 3,
+    name: 'Beacon',
+    owner: 'Infra',
+    summary: 'Realtime service health explorer',
+    tags: ['infra', 'realtime'],
+    featured: true,
+  },
+])
+
+const visibleProjects = computed(() =>
+  showFeaturedOnly.value
+    ? projects.value.filter((project) => project.featured)
+    : projects.value,
+)
+
+function refresh() {
+  loading.value = !loading.value
+}
+</script>
+
+<style scoped>
+.dashboard {
+  display: grid;
+  gap: 20px;
+}
+
+.summary-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.metric-card,
+.project-card {
+  border: 1px solid #d4d4d8;
+  border-radius: 16px;
+  padding: 16px;
+}
+</style>
+"#;
+
+fn compile_options(filename: &'static str) -> SfcCompileOptions {
+    SfcCompileOptions {
+        parse: SfcParseOptions {
+            filename: filename.into(),
+            ..Default::default()
+        },
+        script: ScriptCompileOptions {
+            id: Some(filename.into()),
+            ..Default::default()
+        },
+        template: TemplateCompileOptions {
+            id: Some(filename.into()),
+            ..Default::default()
+        },
+        style: StyleCompileOptions {
+            id: filename.into(),
+            ..Default::default()
+        },
+        ..Default::default()
+    }
+}
+
+fn benchmark_compile_case(c: &mut Criterion, name: &str, filename: &'static str, source: &str) {
+    let descriptor = parse_sfc(
+        source,
+        SfcParseOptions {
+            filename: filename.into(),
+            ..Default::default()
+        },
+    )
+    .expect("failed to parse benchmark SFC");
+
+    let source_len = source.len() as u64;
+    let mut group = c.benchmark_group("sfc_compile");
+    group.throughput(Throughput::Bytes(source_len));
+    group.bench_function(name, |b| {
+        b.iter(|| {
+            let result = compile_sfc(black_box(&descriptor), black_box(compile_options(filename)))
+                .expect("failed to compile benchmark SFC");
+            black_box(result);
+        });
+    });
+    group.finish();
+}
+
+fn bench_compile_template_only(c: &mut Criterion) {
+    benchmark_compile_case(c, "template_only", "TemplateOnly.vue", SIMPLE_TEMPLATE_ONLY);
+}
+
+fn bench_compile_medium_script_setup(c: &mut Criterion) {
+    benchmark_compile_case(
+        c,
+        "script_setup_medium",
+        "MediumScriptSetup.vue",
+        MEDIUM_SCRIPT_SETUP,
+    );
+}
+
+fn bench_compile_complex_script_setup(c: &mut Criterion) {
+    benchmark_compile_case(
+        c,
+        "script_setup_complex",
+        "ComplexScriptSetup.vue",
+        COMPLEX_SCRIPT_SETUP,
+    );
+}
+
+criterion_group!(
+    benches,
+    bench_compile_template_only,
+    bench_compile_medium_script_setup,
+    bench_compile_complex_script_setup,
+);
+criterion_main!(benches);

--- a/crates/vize_atelier_sfc/src/compile_template/extraction.rs
+++ b/crates/vize_atelier_sfc/src/compile_template/extraction.rs
@@ -22,6 +22,16 @@ fn detect_render_export_name(trimmed: &str) -> Option<&'static str> {
     }
 }
 
+fn finalize_render_body(render_body: &mut String) {
+    while render_body.ends_with([' ', '\t', '\n', '\r']) {
+        render_body.pop();
+    }
+
+    if render_body.ends_with(';') {
+        render_body.pop();
+    }
+}
+
 /// Extract imports, hoisted consts, and render function from compiled template code
 /// Returns (imports, hoisted, render_function, render_function_name)
 /// where render_function is the full function definition.
@@ -90,11 +100,9 @@ pub(crate) fn extract_template_parts(
     let mut brace_state = StringTrackState::default();
     let mut paren_state = StringTrackState::default();
     let mut return_paren_depth = 0;
+    let mut pending_ternary_continuation = false;
 
-    // Collect all lines for look-ahead
-    let lines: Vec<&str> = template_code.lines().collect();
-
-    for (i, line) in lines.iter().enumerate() {
+    for line in template_code.lines() {
         let trimmed = line.trim();
 
         if trimmed.starts_with("import ") {
@@ -135,6 +143,16 @@ pub(crate) fn extract_template_parts(
 
             brace_depth = next_brace_depth;
 
+            if pending_ternary_continuation && !trimmed.is_empty() {
+                if trimmed.starts_with('?') || trimmed.starts_with(':') {
+                    pending_ternary_continuation = false;
+                } else {
+                    pending_ternary_continuation = false;
+                    in_return = false;
+                    finalize_render_body(&mut render_body);
+                }
+            }
+
             // Extract the return statement inside the render function (may span multiple lines)
             if in_return {
                 // Continue collecting return body
@@ -142,27 +160,8 @@ pub(crate) fn extract_template_parts(
                 render_body.push_str(line);
                 return_paren_depth += count_parens_with_state(line, &mut paren_state);
 
-                // Check if return statement is complete:
-                // - Parentheses must be balanced (return_paren_depth <= 0)
-                // - Next non-empty line must NOT be a ternary continuation (? or :)
                 if return_paren_depth <= 0 {
-                    // Look ahead to check for ternary continuation
-                    let next_continues_ternary = lines
-                        .iter()
-                        .skip(i + 1)
-                        .map(|l| l.trim())
-                        .find(|l| !l.is_empty())
-                        .map(|l| l.starts_with('?') || l.starts_with(':'))
-                        .unwrap_or(false);
-
-                    if !next_continues_ternary {
-                        in_return = false;
-                        // Remove trailing semicolon if present
-                        let trimmed_body = render_body.trim_end();
-                        if let Some(stripped) = trimmed_body.strip_suffix(';') {
-                            render_body = stripped.to_compact_string();
-                        }
-                    }
+                    pending_ternary_continuation = true;
                 }
             } else if let Some(stripped) = trimmed.strip_prefix("return ") {
                 render_body = stripped.to_compact_string();
@@ -172,23 +171,8 @@ pub(crate) fn extract_template_parts(
                 if return_paren_depth > 0 {
                     in_return = true;
                 } else {
-                    // Check if next non-empty line is a ternary continuation
-                    let next_continues_ternary = lines
-                        .iter()
-                        .skip(i + 1)
-                        .map(|l| l.trim())
-                        .find(|l| !l.is_empty())
-                        .map(|l| l.starts_with('?') || l.starts_with(':'))
-                        .unwrap_or(false);
-
-                    if next_continues_ternary {
-                        in_return = true;
-                    } else {
-                        // Single line return - remove trailing semicolon if present
-                        if render_body.ends_with(';') {
-                            render_body.pop();
-                        }
-                    }
+                    in_return = true;
+                    pending_ternary_continuation = true;
                 }
             } else if trimmed.starts_with("const _component_")
                 || trimmed.starts_with("const _directive_")
@@ -202,6 +186,10 @@ pub(crate) fn extract_template_parts(
                 in_render = false;
             }
         }
+    }
+
+    if in_return {
+        finalize_render_body(&mut render_body);
     }
 
     // Compact VDOM-style return expressions, but keep Vapor statement blocks intact.

--- a/crates/vize_atelier_sfc/src/compile_template/string_tracking.rs
+++ b/crates/vize_atelier_sfc/src/compile_template/string_tracking.rs
@@ -15,7 +15,7 @@ pub(super) struct StringTrackState {
     /// Whether we're inside a string literal (regular or template literal text portion)
     pub(super) in_string: bool,
     /// The quote character of the current string ('\'' | '"' | '`')
-    string_char: char,
+    string_char: u8,
     /// Whether the last character was a backslash escape
     escape: bool,
     /// Stack for nested template literal `${...}` expressions.
@@ -33,7 +33,7 @@ impl Default for StringTrackState {
     fn default() -> Self {
         Self {
             in_string: false,
-            string_char: '\0',
+            string_char: b'\0',
             escape: false,
             template_expr_brace_stack: Vec::new(),
             in_block_comment: false,
@@ -46,12 +46,12 @@ impl Default for StringTrackState {
 /// State is carried across lines to handle multiline template literals and comments.
 pub(super) fn count_braces_with_state(line: &str, state: &mut StringTrackState) -> i32 {
     let mut count: i32 = 0;
-    let chars: Vec<char> = line.chars().collect();
-    let len = chars.len();
+    let bytes = line.as_bytes();
+    let len = bytes.len();
     let mut i = 0;
 
     while i < len {
-        let ch = chars[i];
+        let ch = bytes[i];
 
         if state.escape {
             state.escape = false;
@@ -61,7 +61,7 @@ pub(super) fn count_braces_with_state(line: &str, state: &mut StringTrackState) 
 
         // Inside a block comment: skip everything until */
         if state.in_block_comment {
-            if ch == '*' && i + 1 < len && chars[i + 1] == '/' {
+            if ch == b'*' && i + 1 < len && bytes[i + 1] == b'/' {
                 state.in_block_comment = false;
                 i += 2; // Skip both * and /
                 continue;
@@ -71,17 +71,17 @@ pub(super) fn count_braces_with_state(line: &str, state: &mut StringTrackState) 
         }
 
         if state.in_string {
-            if ch == '\\' {
+            if ch == b'\\' {
                 state.escape = true;
                 i += 1;
                 continue;
             }
 
-            if state.string_char == '`' {
-                if ch == '`' {
+            if state.string_char == b'`' {
+                if ch == b'`' {
                     // Close template literal
                     state.in_string = false;
-                } else if ch == '$' && i + 1 < len && chars[i + 1] == '{' {
+                } else if ch == b'$' && i + 1 < len && bytes[i + 1] == b'{' {
                     // Enter template expression ${...}
                     // The ${ is template syntax, not a code brace
                     state.in_string = false;
@@ -96,37 +96,37 @@ pub(super) fn count_braces_with_state(line: &str, state: &mut StringTrackState) 
         } else {
             // Not in string - we're in code mode
             match ch {
-                '/' if i + 1 < len && chars[i + 1] == '*' => {
+                b'/' if i + 1 < len && bytes[i + 1] == b'*' => {
                     // Enter block comment /*
                     state.in_block_comment = true;
                     i += 2; // Skip both / and *
                     continue;
                 }
-                '/' if i + 1 < len && chars[i + 1] == '/' => {
+                b'/' if i + 1 < len && bytes[i + 1] == b'/' => {
                     // Line comment // -- skip rest of line
                     break;
                 }
-                '\'' | '"' => {
+                b'\'' | b'"' => {
                     state.in_string = true;
                     state.string_char = ch;
                 }
-                '`' => {
+                b'`' => {
                     state.in_string = true;
-                    state.string_char = '`';
+                    state.string_char = b'`';
                 }
-                '{' => {
+                b'{' => {
                     if let Some(depth) = state.template_expr_brace_stack.last_mut() {
                         *depth += 1;
                     }
                     count += 1;
                 }
-                '}' => {
+                b'}' => {
                     if let Some(&depth) = state.template_expr_brace_stack.last() {
                         if depth == 0 {
                             // This } closes the ${...} expression, not a code brace
                             state.template_expr_brace_stack.pop();
                             state.in_string = true;
-                            state.string_char = '`';
+                            state.string_char = b'`';
                             i += 1;
                             continue;
                         } else {
@@ -162,12 +162,12 @@ pub(super) fn count_braces_outside_strings(line: &str) -> i32 {
 /// State is carried across lines to handle multiline template literals and comments.
 pub(super) fn count_parens_with_state(line: &str, state: &mut StringTrackState) -> i32 {
     let mut count: i32 = 0;
-    let chars: Vec<char> = line.chars().collect();
-    let len = chars.len();
+    let bytes = line.as_bytes();
+    let len = bytes.len();
     let mut i = 0;
 
     while i < len {
-        let ch = chars[i];
+        let ch = bytes[i];
 
         if state.escape {
             state.escape = false;
@@ -177,7 +177,7 @@ pub(super) fn count_parens_with_state(line: &str, state: &mut StringTrackState) 
 
         // Inside a block comment: skip everything until */
         if state.in_block_comment {
-            if ch == '*' && i + 1 < len && chars[i + 1] == '/' {
+            if ch == b'*' && i + 1 < len && bytes[i + 1] == b'/' {
                 state.in_block_comment = false;
                 i += 2; // Skip both * and /
                 continue;
@@ -187,16 +187,16 @@ pub(super) fn count_parens_with_state(line: &str, state: &mut StringTrackState) 
         }
 
         if state.in_string {
-            if ch == '\\' {
+            if ch == b'\\' {
                 state.escape = true;
                 i += 1;
                 continue;
             }
 
-            if state.string_char == '`' {
-                if ch == '`' {
+            if state.string_char == b'`' {
+                if ch == b'`' {
                     state.in_string = false;
-                } else if ch == '$' && i + 1 < len && chars[i + 1] == '{' {
+                } else if ch == b'$' && i + 1 < len && bytes[i + 1] == b'{' {
                     state.in_string = false;
                     state.template_expr_brace_stack.push(0);
                     i += 2;
@@ -208,36 +208,36 @@ pub(super) fn count_parens_with_state(line: &str, state: &mut StringTrackState) 
         } else {
             // Not in string - we're in code mode
             match ch {
-                '/' if i + 1 < len && chars[i + 1] == '*' => {
+                b'/' if i + 1 < len && bytes[i + 1] == b'*' => {
                     // Enter block comment /*
                     state.in_block_comment = true;
                     i += 2; // Skip both / and *
                     continue;
                 }
-                '/' if i + 1 < len && chars[i + 1] == '/' => {
+                b'/' if i + 1 < len && bytes[i + 1] == b'/' => {
                     // Line comment // -- skip rest of line
                     break;
                 }
-                '\'' | '"' => {
+                b'\'' | b'"' => {
                     state.in_string = true;
                     state.string_char = ch;
                 }
-                '`' => {
+                b'`' => {
                     state.in_string = true;
-                    state.string_char = '`';
+                    state.string_char = b'`';
                 }
-                '{' => {
+                b'{' => {
                     // Track braces for template expression depth even though we're counting parens
                     if let Some(depth) = state.template_expr_brace_stack.last_mut() {
                         *depth += 1;
                     }
                 }
-                '}' => {
+                b'}' => {
                     if let Some(&depth) = state.template_expr_brace_stack.last() {
                         if depth == 0 {
                             state.template_expr_brace_stack.pop();
                             state.in_string = true;
-                            state.string_char = '`';
+                            state.string_char = b'`';
                             i += 1;
                             continue;
                         } else {
@@ -245,10 +245,10 @@ pub(super) fn count_parens_with_state(line: &str, state: &mut StringTrackState) 
                         }
                     }
                 }
-                '(' => {
+                b'(' => {
                     count += 1;
                 }
-                ')' => {
+                b')' => {
                     count -= 1;
                 }
                 _ => {}

--- a/npm/vscode-vize/package.json
+++ b/npm/vscode-vize/package.json
@@ -24,7 +24,6 @@
     "type": "git",
     "url": "https://github.com/ubugeeei/vize"
   },
-  "icon": "icons/logo.png",
   "publisher": "ubugeeei",
   "main": "./dist/extension.cjs",
   "scripts": {


### PR DESCRIPTION
## Summary
- reduce `build --profile` overhead by switching aggregate timing to atomics, deriving script language from the parsed SFC descriptor, and avoiding per-file metadata and regex scans
- speed up SFC template extraction and transform hot paths by removing extra passes, skipping unnecessary child traversal, and short-circuiting native/component checks
- add a native Criterion benchmark for template-only, medium, and complex `script setup` SFC compile cases

## Why
Profiling on a 5,000-file synthetic SFC corpus showed that we were still spending time on work that did not contribute to actual compilation throughput:
- `atelier.sfc.template.extract_parts` was rescanning lines with look-ahead and extra allocations
- `atelier.transform.traverse_element_children` and element/component detection were doing avoidable work for leaf and native elements
- build stats collection was paying mutex, regex, and metadata costs even when the needed information was already available

## Impact
On `target/release/vize build bench/__in__ --format stats --profile --threads 1`:
- total wall time improved from `895.10ms` to `628.40ms`
- `atelier.sfc.compile` dropped from `637.82ms` to `529.45ms`
- `atelier.sfc.template.extract_parts` dropped from `229.95ms` to `160.58ms`

On `target/release/vize build bench/__in__ --format stats --profile`:
- wall time measured `223.28ms` on this machine while cumulative hot-op cost in the profiled pipeline stayed lower than the original baseline

Updated Criterion benchmark snapshot:
- `sfc_compile/template_only`: `4.50µs`
- `sfc_compile/script_setup_medium`: `73.50µs`
- `sfc_compile/script_setup_complex`: `89.60µs`

## Validation
- `cargo fmt --all`
- `cargo test -p vize_atelier_sfc compile_template --quiet`
- `cargo test -p vize_atelier_core transform --quiet`
- `cargo build -p vize --release --quiet`
- `cargo bench -p vize_atelier_sfc --bench sfc_compile -- --noplot`
- `target/release/vize build bench/__in__ --format stats --profile --threads 1`
- `target/release/vize build bench/__in__ --format stats --profile`
