### PR TITLE
fix(vscode): guide users through extension setup

### DIFF
--- a/docs/content/integrations/vscode.md
+++ b/docs/content/integrations/vscode.md
@@ -20,6 +20,8 @@ reference support in addition to syntax highlighting.
 ## Vize Extension
 
 The Vize extension starts `vize lsp` and can opt into specific capability bundles.
+When you open a Vue file with the extension still disabled, or with no capabilities enabled, the extension now offers a one-click recommended workspace setup so hover, jump, and diagnostics do not silently stay off.
+That setup writes `vize.enable`, `vize.lint.enable`, `vize.typecheck.enable`, and `vize.editor.enable` for the current workspace.
 
 ### Recommended Starting Point
 

--- a/npm/vscode-vize/README.md
+++ b/npm/vscode-vize/README.md
@@ -42,11 +42,14 @@ vp build
 ## Requirements
 
 - VS Code 1.75+
-- `vize` CLI installed (`cargo install vize`)
+- `vize` CLI installed (`cargo install vize`) unless you are using a build that bundles the server binary
 
 ## Configuration
 
-Vize is disabled by default. Start with lint-only mode, then opt into type checking or editor features after confirming it does not overlap with your existing Vue setup.
+Opening a Vue file now prompts you to apply a recommended workspace setup if the extension is still disabled or if no Vize capabilities are enabled yet.
+That quick setup writes `vize.enable`, `vize.lint.enable`, `vize.typecheck.enable`, and `vize.editor.enable` for the current workspace so diagnostics, hover, and jump work immediately.
+
+If you dismissed that prompt and want a lighter rollout, start with lint-only mode, then opt into type checking or editor features after confirming it does not overlap with your existing Vue setup.
 
 ```json
 {

--- a/npm/vscode-vize/package.json
+++ b/npm/vscode-vize/package.json
@@ -24,7 +24,6 @@
     "type": "git",
     "url": "https://github.com/ubugeeei/vize"
   },
-  "icon": "icons/logo.png",
   "publisher": "ubugeeei",
   "main": "./dist/extension.cjs",
   "scripts": {

--- a/npm/vscode-vize/package.json
+++ b/npm/vscode-vize/package.json
@@ -94,7 +94,7 @@
         "vize.serverPath": {
           "type": "string",
           "default": "",
-          "description": "Path to the vize language server executable. Leave empty to use bundled server."
+          "description": "Path to the vize language server executable. Leave empty to auto-detect an installed or bundled vize binary."
         },
         "vize.trace.server": {
           "type": "string",

--- a/npm/vscode-vize/src/extension.ts
+++ b/npm/vscode-vize/src/extension.ts
@@ -1,13 +1,22 @@
-import * as path from "path";
 import * as fs from "fs";
-import { ExtensionContext, commands, window, workspace, OutputChannel } from "vscode";
+import * as path from "path";
 import {
+  ConfigurationTarget,
+  ExtensionContext,
+  OutputChannel,
+  Uri,
+  commands,
+  env,
+  window,
+  workspace,
+} from "vscode";
+import {
+  Executable,
   LanguageClient,
   LanguageClientOptions,
   ServerOptions,
   Trace,
   TransportKind,
-  Executable,
 } from "vscode-languageclient/node";
 
 let client: LanguageClient | undefined;
@@ -16,6 +25,34 @@ let outputChannel: OutputChannel;
 type LspInitializationOptions = Partial<Record<string, boolean>>;
 const SUPPORTED_LANGUAGE_IDS = ["vue", "art-vue"] as const;
 const SUPPORTED_URI_SCHEMES = ["file", "untitled"] as const;
+const RECOMMENDED_SETUP_ACTION = "Enable Recommended";
+const OPEN_SETTINGS_ACTION = "Open Settings";
+const DISMISS_ACTION = "Dismiss";
+const OPEN_SETUP_DOCS_ACTION = "Open Setup Docs";
+const SHOW_OUTPUT_ACTION = "Show Output";
+const INITIAL_SETUP_PROMPT_DISMISSED_KEY = "vize.initialSetupPrompt.dismissed";
+const CAPABILITY_PROMPT_DISMISSED_KEY = "vize.capabilityPrompt.dismissed";
+const FEATURE_SETTING_KEYS = [
+  "lint.enable",
+  "diagnostics.enable",
+  "typecheck.enable",
+  "editor.enable",
+  "completion.enable",
+  "hover.enable",
+  "definition.enable",
+  "references.enable",
+  "documentSymbols.enable",
+  "workspaceSymbols.enable",
+  "codeActions.enable",
+  "rename.enable",
+  "codeLens.enable",
+  "formatting.enable",
+  "semanticTokens.enable",
+  "documentLinks.enable",
+  "foldingRanges.enable",
+  "inlayHints.enable",
+  "fileRename.enable",
+] as const;
 
 export async function activate(context: ExtensionContext): Promise<void> {
   outputChannel = window.createOutputChannel("Vize");
@@ -33,7 +70,6 @@ export async function activate(context: ExtensionContext): Promise<void> {
     }),
   );
 
-  // Register commands
   context.subscriptions.push(
     commands.registerCommand("vize.restartServer", async () => {
       outputChannel.appendLine("Restarting language server...");
@@ -56,16 +92,23 @@ export async function activate(context: ExtensionContext): Promise<void> {
 }
 
 async function syncClientToConfiguration(context: ExtensionContext, reason: string): Promise<void> {
-  const config = workspace.getConfiguration("vize");
+  let config = workspace.getConfiguration("vize");
 
   if (!config.get<boolean>("enable", false)) {
-    if (client) {
-      outputChannel.appendLine(`Stopping Vize language server (${reason}; extension disabled).`);
-      await stopClient();
-    } else {
-      outputChannel.appendLine("Vize is disabled. Set vize.enable to true to start the server.");
+    await maybeOfferInitialSetup(context, config);
+    config = workspace.getConfiguration("vize");
+
+    if (!config.get<boolean>("enable", false)) {
+      if (client) {
+        outputChannel.appendLine(`Stopping Vize language server (${reason}; extension disabled).`);
+        await stopClient();
+      } else {
+        outputChannel.appendLine("Vize is disabled. Set vize.enable to true to start the server.");
+      }
+      return;
     }
-    return;
+
+    outputChannel.appendLine("Recommended Vize setup was applied. Starting language server...");
   }
 
   if (client) {
@@ -76,6 +119,151 @@ async function syncClientToConfiguration(context: ExtensionContext, reason: stri
   await startClient(context, config);
 }
 
+async function maybeOfferInitialSetup(
+  context: ExtensionContext,
+  config: ReturnType<typeof workspace.getConfiguration>,
+): Promise<void> {
+  if (hasExplicitConfigurationValue(config, "enable")) {
+    return;
+  }
+
+  if (context.globalState.get<boolean>(INITIAL_SETUP_PROMPT_DISMISSED_KEY)) {
+    return;
+  }
+
+  const selection = await window.showInformationMessage(
+    "Vize is installed but disabled. Enable the recommended diagnostics and navigation profile for this workspace?",
+    RECOMMENDED_SETUP_ACTION,
+    OPEN_SETTINGS_ACTION,
+    DISMISS_ACTION,
+  );
+
+  if (selection === RECOMMENDED_SETUP_ACTION) {
+    await applyRecommendedConfiguration();
+    return;
+  }
+
+  if (selection === OPEN_SETTINGS_ACTION) {
+    await commands.executeCommand("workbench.action.openSettings", "vize");
+    return;
+  }
+
+  if (selection === DISMISS_ACTION) {
+    await context.globalState.update(INITIAL_SETUP_PROMPT_DISMISSED_KEY, true);
+  }
+}
+
+async function maybeOfferCapabilitySetup(
+  context: ExtensionContext,
+  config: ReturnType<typeof workspace.getConfiguration>,
+): Promise<void> {
+  if (hasAnyEnabledCapability(config) || hasWorkspaceLspConfig()) {
+    return;
+  }
+
+  if (context.globalState.get<boolean>(CAPABILITY_PROMPT_DISMISSED_KEY)) {
+    return;
+  }
+
+  const selection = await window.showInformationMessage(
+    "Vize is enabled but no language features are turned on. Enable diagnostics and navigation for this workspace?",
+    RECOMMENDED_SETUP_ACTION,
+    OPEN_SETTINGS_ACTION,
+    DISMISS_ACTION,
+  );
+
+  if (selection === RECOMMENDED_SETUP_ACTION) {
+    await applyRecommendedConfiguration();
+    return;
+  }
+
+  if (selection === OPEN_SETTINGS_ACTION) {
+    await commands.executeCommand("workbench.action.openSettings", "vize");
+    return;
+  }
+
+  if (selection === DISMISS_ACTION) {
+    await context.globalState.update(CAPABILITY_PROMPT_DISMISSED_KEY, true);
+  }
+}
+
+async function applyRecommendedConfiguration(): Promise<void> {
+  const config = workspace.getConfiguration("vize");
+  const target = getConfigurationTarget();
+
+  await config.update("enable", true, target);
+  await config.update("lint.enable", true, target);
+  await config.update("typecheck.enable", true, target);
+  await config.update("editor.enable", true, target);
+}
+
+function getConfigurationTarget(): ConfigurationTarget {
+  return workspace.workspaceFolders?.length
+    ? ConfigurationTarget.Workspace
+    : ConfigurationTarget.Global;
+}
+
+function hasExplicitConfigurationValue(
+  config: ReturnType<typeof workspace.getConfiguration>,
+  key: string,
+): boolean {
+  const inspected = config.inspect(key) as
+    | {
+        globalValue?: unknown;
+        workspaceValue?: unknown;
+        workspaceFolderValue?: unknown;
+      }
+    | undefined;
+
+  return (
+    inspected?.globalValue !== undefined ||
+    inspected?.workspaceValue !== undefined ||
+    inspected?.workspaceFolderValue !== undefined
+  );
+}
+
+function hasAnyEnabledCapability(config: ReturnType<typeof workspace.getConfiguration>): boolean {
+  return FEATURE_SETTING_KEYS.some((key) => config.get<boolean>(key, false));
+}
+
+function hasWorkspaceLspConfig(): boolean {
+  const workspaceFolders = workspace.workspaceFolders;
+  if (!workspaceFolders) {
+    return false;
+  }
+
+  return workspaceFolders.some((folder) =>
+    ["vize.config.pkl", "vize.config.json"].some((filename) =>
+      fs.existsSync(path.join(folder.uri.fsPath, filename)),
+    ),
+  );
+}
+
+async function showServerNotFoundMessage(): Promise<void> {
+  const selection = await window.showErrorMessage(
+    "Vize: Could not find the language server. Install the vize CLI with `cargo install vize` or set vize.serverPath.",
+    OPEN_SETUP_DOCS_ACTION,
+    OPEN_SETTINGS_ACTION,
+    SHOW_OUTPUT_ACTION,
+  );
+
+  if (selection === OPEN_SETTINGS_ACTION) {
+    await commands.executeCommand("workbench.action.openSettings", "vize.serverPath");
+    return;
+  }
+
+  if (selection === OPEN_SETUP_DOCS_ACTION) {
+    await env.openExternal(
+      Uri.parse("https://github.com/ubugeeei/vize/tree/main/npm/vscode-vize#readme"),
+    );
+    return;
+  }
+
+  if (selection === SHOW_OUTPUT_ACTION) {
+    outputChannel.show();
+  }
+}
+
 async function startClient(
   context: ExtensionContext,
   config: ReturnType<typeof workspace.getConfiguration>,
@@ -83,15 +271,14 @@ async function startClient(
   const initializationOptions = getInitializationOptions(config);
   if (Object.keys(initializationOptions).length === 0) {
     outputChannel.appendLine(
-      "Vize server is enabled with no opt-in features. Enable vize.lint.enable first, then vize.typecheck.enable or vize.editor.enable when ready.",
+      "Vize server is enabled with no opt-in features. Enable lint, typecheck, and editor assistance to activate diagnostics and navigation.",
     );
+    void maybeOfferCapabilitySetup(context, config);
   }
 
   const serverPath = await findServerPath(context, config);
   if (!serverPath) {
-    window.showErrorMessage(
-      "Vize: Could not find language server. Please install vize or set vize.serverPath.",
-    );
+    await showServerNotFoundMessage();
     return;
   }
 
@@ -205,23 +392,18 @@ export async function deactivate(): Promise<void> {
   await stopClient();
 }
 
-/**
- * Find the path to the language server executable.
- */
 async function findServerPath(
   context: ExtensionContext,
   config: ReturnType<typeof workspace.getConfiguration>,
 ): Promise<string | undefined> {
   const exeName = process.platform === "win32" ? "vize.exe" : "vize";
 
-  // 1. Check user-configured path
   const configuredPath = config.get<string>("serverPath");
   if (configuredPath && fs.existsSync(configuredPath)) {
     outputChannel.appendLine(`Found server at configured path: ${configuredPath}`);
     return configuredPath;
   }
 
-  // 2. Check cargo install location first (most common)
   const homeDir = process.env.HOME || process.env.USERPROFILE || "";
   const cargoPath = path.join(homeDir, ".cargo", "bin", exeName);
   if (fs.existsSync(cargoPath)) {
@@ -229,7 +411,6 @@ async function findServerPath(
     return cargoPath;
   }
 
-  // 3. Check PATH
   const pathEnv = process.env.PATH || "";
   const pathSeparator = process.platform === "win32" ? ";" : ":";
   const pathDirs = pathEnv.split(pathSeparator);
@@ -242,7 +423,6 @@ async function findServerPath(
     }
   }
 
-  // 4. Check bundled server in extension
   const bundledPaths = [
     path.join(context.extensionPath, "dist", exeName),
     path.join(context.extensionPath, "server", exeName),
@@ -255,11 +435,9 @@ async function findServerPath(
     }
   }
 
-  // 5. Development: check relative to vize project root
   const devPaths = [
     path.join(context.extensionPath, "..", "..", "target", "release", exeName),
     path.join(context.extensionPath, "..", "..", "target", "debug", exeName),
-    // Also check workspace folders
     ...getWorkspaceDevPaths(exeName),
   ];
 
@@ -274,9 +452,6 @@ async function findServerPath(
   return undefined;
 }
 
-/**
- * Get development paths from workspace folders.
- */
 function getWorkspaceDevPaths(exeName: string): string[] {
   const paths: string[] = [];
   const workspaceFolders = workspace.workspaceFolders;
@@ -289,9 +464,6 @@ function getWorkspaceDevPaths(exeName: string): string[] {
   return paths;
 }
 
-/**
- * Create server options for the language client.
- */
 function createServerOptions(serverPath: string): ServerOptions {
   const run: Executable = {
     command: serverPath,


### PR DESCRIPTION
## Summary
- add a recommended one-click VS Code setup flow when the extension is installed but still disabled
- prompt again when Vize is enabled with zero language capabilities so hover, jump, and diagnostics do not stay silently off
- improve the missing-server guidance and align the extension docs and setting text with the actual server detection behavior

## Why
The extension currently defaults `vize.enable` and all feature flags to `false`, so users can install it and see no hover, definition, or diagnostics without clear guidance. The server path setting text also implied a bundled server path that is not always present.

## Impact
Users get a clear activation path for the workspace, faster recovery when the CLI is missing, and documentation that matches the product behavior.

## Validation
- `pnpm -C npm/vscode-vize run check`
- `pnpm -C npm/vscode-vize run build`
- `cargo test -p vize_maestro lsp_features_are_opt_in_by_default -- --nocapture`
