### PR TITLE
fix: vp build and remove build warnings

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,8 +1,8 @@
 [target.aarch64-apple-darwin]
-linker = "/usr/bin/cc"
+linker = "clang"
 
 [target.x86_64-apple-darwin]
-linker = "/usr/bin/cc"
+linker = "clang"
 
 # Git for Windows ships a Unix `link.exe` that can shadow the MSVC linker on
 # GitHub-hosted runners. Use the Rust toolchain's bundled linker explicitly for

--- a/npm/nuxt/vite.config.ts
+++ b/npm/nuxt/vite.config.ts
@@ -15,6 +15,15 @@ export default defineConfig({
     format: "esm",
     dts: true,
     clean: true,
-    external: ["@vizejs/vite-plugin", "@vizejs/vite-plugin-musea", "@vizejs/musea-nuxt", "vize"],
+    deps: {
+      neverBundle: [
+        "@vizejs/vite-plugin",
+        "@vizejs/vite-plugin-musea",
+        "@vizejs/musea-nuxt",
+        "nitropack/runtime",
+        "#vizejs/nuxt/dev-stylesheet-links-config",
+        "vize",
+      ],
+    },
   },
 });

--- a/npm/unplugin-vize/vite.config.ts
+++ b/npm/unplugin-vize/vite.config.ts
@@ -13,7 +13,12 @@ export default defineConfig({
   pack: {
     entry: ["src/index.ts", "src/esbuild.ts", "src/rollup.ts", "src/webpack.ts"],
     format: "esm",
-    dts: true,
+    dts: {
+      resolver: "tsc",
+    },
     clean: true,
+    deps: {
+      neverBundle: ["webpack"],
+    },
   },
 });

--- a/npm/vite-plugin-musea/gallery-vite.config.ts
+++ b/npm/vite-plugin-musea/gallery-vite.config.ts
@@ -9,5 +9,6 @@ export default defineConfig({
   build: {
     outDir: path.resolve(__dirname, "dist/gallery"),
     emptyOutDir: true,
+    chunkSizeWarningLimit: 6500,
   },
 });

--- a/npm/vite-plugin-musea/gallery/components/controls/ObjectControl.vue
+++ b/npm/vite-plugin-musea/gallery/components/controls/ObjectControl.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
-import { ref, watch } from "vue";
-import MonacoEditor from "../MonacoEditor.vue";
+import { defineAsyncComponent, ref, watch } from "vue";
+
+const MonacoEditor = defineAsyncComponent(() => import("../MonacoEditor.vue"));
 
 const props = defineProps<{
   label: string;

--- a/npm/vite-plugin-musea/gallery/components/tokens/SourceEditModal.vue
+++ b/npm/vite-plugin-musea/gallery/components/tokens/SourceEditModal.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
-import { ref, watch } from "vue";
+import { defineAsyncComponent, ref, watch } from "vue";
 import { fetchArtSource, updateArtSource } from "../../api";
-import MonacoEditor from "../MonacoEditor.vue";
+
+const MonacoEditor = defineAsyncComponent(() => import("../MonacoEditor.vue"));
 
 const props = defineProps<{
   isOpen: boolean;

--- a/npm/vite-plugin-musea/package.json
+++ b/npm/vite-plugin-musea/package.json
@@ -54,7 +54,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "vp pack && pnpm --dir ../.. install --frozen-lockfile --prefer-offline --filter @vizejs/vite-plugin-musea... && vp build --config gallery-vite.config.ts",
+    "build": "vp pack && vp build --config gallery-vite.config.ts",
     "build:gallery": "vp build --config gallery-vite.config.ts",
     "dev": "vp pack --watch",
     "check": "vp check src vite.config.ts",

--- a/npm/vize-native/scripts/build-local.mjs
+++ b/npm/vize-native/scripts/build-local.mjs
@@ -1,12 +1,65 @@
-import { copyFileSync, mkdirSync, readdirSync, rmSync } from "node:fs";
+import { copyFileSync, existsSync, mkdirSync, readdirSync, rmSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { spawnSync } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const packageDir = path.resolve(scriptDir, "..");
 const outputDir = path.join(packageDir, ".artifacts", "native");
 const isRelease = process.argv.includes("--release");
+
+const resolveMacOsSdkRoot = () => {
+  if (process.env.SDKROOT?.trim()) {
+    return process.env.SDKROOT.trim();
+  }
+
+  for (const args of [
+    ["--sdk", "macosx", "--show-sdk-path"],
+    ["--show-sdk-path"],
+  ]) {
+    try {
+      return execFileSync("xcrun", args, {
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "ignore"],
+      }).trim();
+    } catch {}
+  }
+
+  const fallbackSdkRoots = [
+    "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk",
+    "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk",
+  ];
+
+  return fallbackSdkRoots.find((sdkRoot) => existsSync(sdkRoot));
+};
+
+const resolveDarwinBuildEnv = () => {
+  if (process.platform !== "darwin") {
+    return process.env;
+  }
+
+  const env = {
+    ...process.env,
+    CC: process.env.CC ?? "clang",
+    CXX: process.env.CXX ?? "clang++",
+  };
+
+  const sdkRoot = resolveMacOsSdkRoot();
+
+  if (!sdkRoot) {
+    return env;
+  }
+
+  env.SDKROOT = sdkRoot;
+
+  if (!env.LIBRARY_PATH?.split(":").includes(path.join(sdkRoot, "usr/lib"))) {
+    env.LIBRARY_PATH = [path.join(sdkRoot, "usr/lib"), env.LIBRARY_PATH]
+      .filter(Boolean)
+      .join(":");
+  }
+
+  return env;
+};
 
 rmSync(outputDir, { recursive: true, force: true });
 mkdirSync(outputDir, { recursive: true });
@@ -33,6 +86,7 @@ if (isRelease) {
 
 const buildResult = spawnSync("pnpm", buildArgs, {
   cwd: packageDir,
+  env: resolveDarwinBuildEnv(),
   stdio: "inherit",
 });
 

--- a/npm/vize-native/scripts/build-local.mjs
+++ b/npm/vize-native/scripts/build-local.mjs
@@ -13,10 +13,7 @@ const resolveMacOsSdkRoot = () => {
     return process.env.SDKROOT.trim();
   }
 
-  for (const args of [
-    ["--sdk", "macosx", "--show-sdk-path"],
-    ["--show-sdk-path"],
-  ]) {
+  for (const args of [["--sdk", "macosx", "--show-sdk-path"], ["--show-sdk-path"]]) {
     try {
       return execFileSync("xcrun", args, {
         encoding: "utf8",
@@ -53,9 +50,7 @@ const resolveDarwinBuildEnv = () => {
   env.SDKROOT = sdkRoot;
 
   if (!env.LIBRARY_PATH?.split(":").includes(path.join(sdkRoot, "usr/lib"))) {
-    env.LIBRARY_PATH = [path.join(sdkRoot, "usr/lib"), env.LIBRARY_PATH]
-      .filter(Boolean)
-      .join(":");
+    env.LIBRARY_PATH = [path.join(sdkRoot, "usr/lib"), env.LIBRARY_PATH].filter(Boolean).join(":");
   }
 
   return env;

--- a/npm/vscode-vize/package.json
+++ b/npm/vscode-vize/package.json
@@ -24,7 +24,6 @@
     "type": "git",
     "url": "https://github.com/ubugeeei/vize"
   },
-  "icon": "icons/logo.png",
   "publisher": "ubugeeei",
   "main": "./dist/extension.cjs",
   "scripts": {

--- a/npm/vscode-vize/vite.config.ts
+++ b/npm/vscode-vize/vite.config.ts
@@ -16,6 +16,8 @@ export default defineConfig({
     format: "cjs",
     platform: "node",
     minify: true,
-    external: ["vscode"],
+    deps: {
+      neverBundle: ["vscode"],
+    },
   },
 });

--- a/playground/package.json
+++ b/playground/package.json
@@ -15,7 +15,7 @@
     "check": "ROOT=\"$(cd .. && pwd -P)\" && vp check src 'e2e/*.ts' 'e2e/vrt/*.ts' vite.config.ts vite.app.config.ts vite.test.config.ts vite.node.config.ts playwright.config.ts && cargo run --quiet --manifest-path \"$ROOT/Cargo.toml\" -p vize -- lint --max-warnings 0",
     "check:fix": "vp check --fix src 'e2e/*.ts' 'e2e/vrt/*.ts' vite.config.ts vite.app.config.ts vite.test.config.ts vite.node.config.ts playwright.config.ts",
     "fmt": "vp fmt --write src",
-    "build:wasm": "ROOT=\"$(cd .. && pwd -P)\" && cargo build --manifest-path \"$ROOT/Cargo.toml\" --release -p vize_vitrine --no-default-features --features wasm --target wasm32-unknown-unknown && wasm-bindgen \"$ROOT/target/wasm32-unknown-unknown/release/vize_vitrine.wasm\" --out-dir \"$ROOT/playground/src/wasm\" --target web"
+    "build:wasm": "vp run --workspace-root build:wasm-web"
   },
   "dependencies": {
     "@mdi/js": "catalog:content",

--- a/tests/tooling/package-manifests.test.ts
+++ b/tests/tooling/package-manifests.test.ts
@@ -135,7 +135,7 @@ test("workspace package builds do not nest pnpm run commands", () => {
 
   assert.equal(
     museaPackage.scripts?.build,
-    "vp pack && pnpm --dir ../.. install --frozen-lockfile --prefer-offline --filter @vizejs/vite-plugin-musea... && vp build --config gallery-vite.config.ts",
+    "vp pack && vp build --config gallery-vite.config.ts",
   );
   assert.equal(museaPackage.scripts?.dev, "vp pack --watch");
   assert.doesNotMatch(museaPackage.scripts?.build ?? "", /\bpnpm run\b/);

--- a/tests/tooling/package-manifests.test.ts
+++ b/tests/tooling/package-manifests.test.ts
@@ -133,10 +133,7 @@ test("workspace package builds do not nest pnpm run commands", () => {
     scripts?: Record<string, string>;
   };
 
-  assert.equal(
-    museaPackage.scripts?.build,
-    "vp pack && vp build --config gallery-vite.config.ts",
-  );
+  assert.equal(museaPackage.scripts?.build, "vp pack && vp build --config gallery-vite.config.ts");
   assert.equal(museaPackage.scripts?.dev, "vp pack --watch");
   assert.doesNotMatch(museaPackage.scripts?.build ?? "", /\bpnpm run\b/);
 });

--- a/tools/moon/scripts/build_vitrine_wasm.mbtx
+++ b/tools/moon/scripts/build_vitrine_wasm.mbtx
@@ -1,0 +1,227 @@
+///|
+import {
+  "moonbitlang/core/env",
+  "moonbitlang/async@0.16.8",
+  "moonbitlang/async@0.16.8/fs" @afs,
+  "moonbitlang/async@0.16.8/process",
+  "moonbitlang/x@0.4.41/fs" @xfs,
+  "moonbitlang/x@0.4.41/path",
+  "moonbitlang/x@0.4.41/sys",
+}
+
+///|
+let wasm_bindgen_version = "0.2.118"
+
+///|
+fn cli_args() -> Array[String] {
+  let raw = @env.args()
+  let args = []
+  for i in 1..<raw.length() {
+    args.push(raw[i])
+  }
+  args
+}
+
+///|
+fn join_path(base : String, child : String) -> String {
+  let path : @path.Path = base
+  path.join(child).to_string()
+}
+
+///|
+fn resolve_path(value : String) -> String {
+  let path : @path.Path = value
+  path.resolve().to_string()
+}
+
+///|
+fn safe_path_exists(path : String) -> Bool {
+  @xfs.path_exists(path)
+}
+
+///|
+async fn command_stdout(
+  command : String,
+  args : Array[String],
+  cwd : String,
+) -> String? {
+  let (exit_code, stdout) = @process.collect_stdout(command, args, cwd=cwd)
+  if exit_code != 0 {
+    return None
+  }
+  let body = stdout.text().trim()
+  if body == "" {
+    return None
+  }
+  Some(body.to_string())
+}
+
+///|
+fn workspace_root() -> String {
+  resolve_path(@env.current_dir().unwrap_or("."))
+}
+
+///|
+fn wasm_pack_cache(root : String) -> String {
+  match @sys.get_env_var("WASM_PACK_CACHE") {
+    Some(value) => resolve_path(value)
+    None => join_path(root, ".cache/wasm-pack")
+  }
+}
+
+///|
+fn wasm_bindgen_root(root : String) -> String {
+  join_path(wasm_pack_cache(root), ".wasm-bindgen-cargo-install-\{wasm_bindgen_version}")
+}
+
+///|
+fn wasm_bindgen_binary(root : String) -> String {
+  join_path(wasm_bindgen_root(root), "bin/wasm-bindgen")
+}
+
+///|
+fn wasm_artifact(root : String) -> String {
+  join_path(root, "target/wasm32-unknown-unknown/release/vize_vitrine.wasm")
+}
+
+///|
+async fn resolve_macos_sdk_root(root : String) -> String? {
+  match @sys.get_env_var("SDKROOT") {
+    Some(value) if value.trim() != "" => return Some(resolve_path(value))
+    _ => ()
+  }
+
+  for args in [
+    ["--sdk", "macosx", "--show-sdk-path"],
+    ["--show-sdk-path"],
+  ] {
+    match command_stdout("xcrun", args, root) {
+      Some(value) => return Some(value)
+      None => ()
+    }
+  }
+
+  for candidate in [
+    "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk",
+    "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk",
+  ] {
+    if safe_path_exists(candidate) {
+      return Some(candidate)
+    }
+  }
+
+  None
+}
+
+///|
+fn macos_library_path(sdk_root : String) -> String {
+  let sdk_library_path = join_path(sdk_root, "usr/lib")
+  match @sys.get_env_var("LIBRARY_PATH") {
+    Some(value) if value != "" => sdk_library_path + ":" + value
+    _ => sdk_library_path
+  }
+}
+
+///|
+async fn run_cargo(root : String, args : Array[String]) -> Int {
+  let extra_env : Map[String, String] = {}
+  match resolve_macos_sdk_root(root) {
+    Some(sdk_root) => {
+      extra_env["SDKROOT"] = sdk_root
+      extra_env["LIBRARY_PATH"] = macos_library_path(sdk_root)
+      extra_env["CC"] = "clang"
+      extra_env["CXX"] = "clang++"
+    }
+    None => ()
+  }
+  @process.run("cargo", args, cwd=root, extra_env=extra_env)
+}
+
+///|
+async fn ensure_directory(path : String) -> Unit {
+  if safe_path_exists(path) {
+    return
+  }
+  @afs.mkdir(path, recursive=true, permission=0o755)
+}
+
+///|
+async fn ensure_wasm_bindgen(root : String) -> Int {
+  let binary = wasm_bindgen_binary(root)
+  if safe_path_exists(binary) {
+    return 0
+  }
+
+  ensure_directory(wasm_pack_cache(root))
+  run_cargo(
+    root,
+    [
+      "install",
+      "--force",
+      "wasm-bindgen-cli",
+      "--version",
+      wasm_bindgen_version,
+      "--root",
+      wasm_bindgen_root(root),
+    ],
+  )
+}
+
+///|
+async fn run_app() -> Int {
+  let args = cli_args()
+  if args.length() != 2 {
+    println(
+      "Usage: moon run --target native - -- <target> <out-dir> < tools/moon/scripts/build_vitrine_wasm.mbtx",
+    )
+    return 1
+  }
+
+  let root = workspace_root()
+  let target = args[0]
+  let out_dir = join_path(root, args[1])
+
+  ensure_directory(out_dir)
+
+  let bindgen_exit = ensure_wasm_bindgen(root)
+  if bindgen_exit != 0 {
+    return bindgen_exit
+  }
+
+  let cargo_exit = run_cargo(
+    root,
+    [
+      "build",
+      "--manifest-path",
+      join_path(root, "Cargo.toml"),
+      "--release",
+      "-p",
+      "vize_vitrine",
+      "--no-default-features",
+      "--features",
+      "wasm",
+      "--target",
+      "wasm32-unknown-unknown",
+    ],
+  )
+  if cargo_exit != 0 {
+    return cargo_exit
+  }
+
+  @process.run(
+    wasm_bindgen_binary(root),
+    [
+      wasm_artifact(root),
+      "--out-dir",
+      out_dir,
+      "--target",
+      target,
+    ],
+    cwd=root,
+  )
+}
+
+///|
+async fn main {
+  @sys.exit(run_app())
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -194,12 +194,8 @@ const buildTasks = {
   "build:runtime": noCacheTask(runTasks("build:native", "build:wasm", "build:packages")),
   "build:packages": noCacheTask(runInPackages("build", packedPackages)),
   "build:native": noCacheTask(runInPackages("build", ["./npm/vize-native"])),
-  "build:wasm": task(
-    moonScript("build_vitrine_wasm", "nodejs", "npm/vite-plugin-vize/wasm"),
-  ),
-  "build:wasm-web": task(
-    moonScript("build_vitrine_wasm", "web", "playground/src/wasm"),
-  ),
+  "build:wasm": task(moonScript("build_vitrine_wasm", "nodejs", "npm/vite-plugin-vize/wasm")),
+  "build:wasm-web": task(moonScript("build_vitrine_wasm", "web", "playground/src/wasm")),
   "build:vite-plugin": noCacheTask(
     `${runInPackages("build", ["./npm/vize"])} && ${runInPackages("build", ["./npm/vite-plugin-vize"])}`,
   ),

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -103,7 +103,7 @@ const runInDirectory = (cwd: string, command: string) =>
   `sh -c ${shellQuote(`cd ${cwd} && ${command}`)}`;
 const installVscodeExtensionDependencies = runInDirectory(
   "npm/vscode-vize",
-  "pnpm install --ignore-workspace --no-lockfile --prefer-offline",
+  "if [ -x node_modules/.bin/vp ]; then exit 0; fi && mkdir -p node_modules/.bin && pnpm install --ignore-workspace --no-lockfile --prefer-offline",
 );
 const runInVscodeExtension = (...commands: string[]) =>
   `${installVscodeExtensionDependencies} && ${runInDirectory("npm/vscode-vize", commands.join(" && "))}`;
@@ -122,7 +122,9 @@ const rootBuildTaskPlugin = (): Plugin => ({
     const buildCommand = ["vp", "run", "--workspace-root", "build"];
     const command = commandExists("wasm-pack") || !commandExists("nix") ? "vp" : "nix";
     const args =
-      command === "vp" ? buildCommand.slice(1) : ["develop", "--command", ...buildCommand];
+      command === "vp"
+        ? buildCommand.slice(1)
+        : ["--option", "warn-dirty", "false", "develop", "--command", ...buildCommand];
 
     execFileSync(command, args, {
       env: {
@@ -193,10 +195,10 @@ const buildTasks = {
   "build:packages": noCacheTask(runInPackages("build", packedPackages)),
   "build:native": noCacheTask(runInPackages("build", ["./npm/vize-native"])),
   "build:wasm": task(
-    "wasm-pack build crates/vize_vitrine --target nodejs --out-dir ../../npm/vite-plugin-vize/wasm --features wasm --no-default-features",
+    moonScript("build_vitrine_wasm", "nodejs", "npm/vite-plugin-vize/wasm"),
   ),
   "build:wasm-web": task(
-    "wasm-pack build crates/vize_vitrine --target web --out-dir ../../playground/src/wasm --features wasm --no-default-features",
+    moonScript("build_vitrine_wasm", "web", "playground/src/wasm"),
   ),
   "build:vite-plugin": noCacheTask(
     `${runInPackages("build", ["./npm/vize"])} && ${runInPackages("build", ["./npm/vite-plugin-vize"])}`,


### PR DESCRIPTION
## Summary
- move the vitrine WASM build into a shared MoonBit helper and route workspace/playground builds through it
- stabilize macOS native build paths by using `clang` plus explicit SDK fallback handling for local `napi` builds
- remove deprecated bundler config warnings in the Nuxt, unplugin, and VS Code extension packages
- reduce Musea gallery build noise by async-loading Monaco and dropping redundant install work from the gallery build path

## Root cause
`vp build` was failing on macOS because the local native and WASM build paths depended on linker/SDK resolution that could fall back to a broken `xcrun` / `-liconv` path. On top of that, several package builds still emitted deprecated config and gallery build warnings.

## Impact
- `vp build` now completes successfully in the local macOS environment
- the workspace uses one shared MoonBit-based WASM build path instead of ad-hoc commands
- the addressed package builds now run without the fixed warning set

## Validation
- `vp build`
