### PR TITLE
feat(musea-mcp-server): enrich MCP workflows

### DIFF
--- a/npm/musea-mcp-server/README.md
+++ b/npm/musea-mcp-server/README.md
@@ -42,10 +42,41 @@ vp dlx @vizejs/musea-mcp-server --project ./my-vue-app
 
 ## MCP Tools
 
-- `list_components` - List all components
-- `get_component` - Get component details
-- `get_variants` - Get component variants
-- `get_tokens` - Get design tokens
+- `analyze_component` - Extract props and emits from a Vue SFC or linked art component
+- `get_palette` - Derive an interactive props palette from an art file
+- `list_components` - List registered components with status, variants, and resource URIs
+- `get_component` - Get full component details, analysis, palette, and docs
+- `get_variant` - Get one specific variant
+- `search_components` - Search components by title, tags, category, component name, and variants
+- `recommend_components` - Rank components by user intent or UI task
+- `generate_variants` - Generate an `.art.vue` draft from a component
+- `generate_csf` - Convert an art file to Storybook CSF
+- `generate_docs` - Generate Markdown docs for a component
+- `generate_catalog` - Generate a catalog for the whole design system
+- `get_tokens` - Read design tokens
+- `search_tokens` - Search tokens without loading the full token tree
+
+## Reproducible Prompting
+
+Musea helps AI assistants stay grounded in real component data, but reusable prompts still need to
+be tuned for reproducibility.
+
+A practical loop is:
+
+1. Fix a few evaluation scenarios first.
+2. Run the prompt in fresh assistant sessions.
+3. Collect both self-reported ambiguity and tool/checklist traces.
+4. Fix one ambiguity per iteration.
+
+For Musea-specific workflows, check whether the assistant:
+
+- used real components from the registry
+- matched prop and variant names to MCP output
+- read tokens before suggesting visual values
+- reported missing metadata instead of guessing
+
+The full MCP guide includes a longer reproducibility workflow and prompt template:
+[docs/content/integrations/mcp.md](https://github.com/ubugeeei/vize/blob/main/docs/content/integrations/mcp.md)
 
 ## License
 

--- a/npm/musea-mcp-server/src/index.ts
+++ b/npm/musea-mcp-server/src/index.ts
@@ -64,7 +64,11 @@ export function createMuseaServer(config: {
           component: parsed.metadata.component,
           category: parsed.metadata.category,
           tags: parsed.metadata.tags,
+          status: parsed.metadata.status,
+          order: parsed.metadata.order,
           variantCount: parsed.variants.length,
+          variantNames: parsed.variants.map((variant) => variant.name),
+          defaultVariant: parsed.variants.find((variant) => variant.is_default)?.name,
         });
       } catch (e) {
         console.error(`Failed to parse ${file}:`, e);

--- a/npm/musea-mcp-server/src/musea.ts
+++ b/npm/musea-mcp-server/src/musea.ts
@@ -1,0 +1,814 @@
+import fs from "node:fs";
+import path from "node:path";
+import { ErrorCode, McpError } from "@modelcontextprotocol/sdk/types.js";
+import type { ArtInfo, NativeBinding, ServerContext } from "./types.js";
+
+type PaletteControl = {
+  name: string;
+  control: string;
+  defaultValue?: unknown;
+  description?: string;
+  required: boolean;
+  options: Array<{ label: string; value: unknown }>;
+  range?: { min: number; max: number; step?: number };
+  group?: string;
+};
+
+export interface ComponentAnalysisResult {
+  path: string;
+  props: Array<{
+    name: string;
+    type: string;
+    required: boolean;
+    defaultValue?: unknown;
+  }>;
+  emits: string[];
+}
+
+export interface PaletteResult {
+  title: string;
+  controls: PaletteControl[];
+  groups: string[];
+  json: string;
+  typescript: string;
+}
+
+export interface DocumentationResult {
+  markdown: string;
+  title: string;
+  category?: string;
+  variantCount: number;
+}
+
+export interface ArtSearchResult {
+  info: ArtInfo;
+  relativePath: string;
+  score: number;
+  reasons: string[];
+}
+
+export interface ResolvedArtReference {
+  info: ArtInfo;
+  absolutePath: string;
+  relativePath: string;
+  matchedBy: "path" | "title" | "component" | "query" | "ref";
+  matchValue: string;
+  score: number;
+  reasons: string[];
+  alternatives: Array<{
+    path: string;
+    title: string;
+    component?: string;
+    score: number;
+    reasons: string[];
+  }>;
+}
+
+interface ComponentSourceDescriptor {
+  reference?: string;
+  absolutePath?: string;
+  path?: string;
+  exists: boolean;
+  error?: string;
+}
+
+function normalize(value: string | undefined): string {
+  return value?.trim().toLowerCase() ?? "";
+}
+
+function normalizePathLike(value: string): string {
+  return value.replace(/\\/g, "/").toLowerCase();
+}
+
+function tokenize(query: string): string[] {
+  return Array.from(
+    new Set(
+      query
+        .toLowerCase()
+        .split(/[\s/,_-]+/)
+        .map((term) => term.trim())
+        .filter(Boolean),
+    ),
+  );
+}
+
+function toProjectPath(projectRoot: string, absolutePath: string): string {
+  const relativePath = path.relative(projectRoot, absolutePath);
+  if (!relativePath || relativePath.startsWith("..") || path.isAbsolute(relativePath)) {
+    return absolutePath;
+  }
+  return relativePath;
+}
+
+function buildResourceUris(
+  relativePath: string,
+  variantNames: string[],
+  hasComponentSource: boolean,
+) {
+  const encodedPath = encodeURIComponent(relativePath);
+  return {
+    component: `musea://component/${encodedPath}`,
+    docs: `musea://docs/${encodedPath}`,
+    source: `musea://source/${encodedPath}`,
+    componentSource: hasComponentSource ? `musea://component-source/${encodedPath}` : undefined,
+    variants: variantNames.map((variantName) => ({
+      name: variantName,
+      uri: `musea://variant/${encodedPath}/${encodeURIComponent(variantName)}`,
+    })),
+  };
+}
+
+function addScore(
+  reasons: Set<string>,
+  reason: string,
+  amount: number,
+  scoreRef: { value: number },
+): void {
+  reasons.add(reason);
+  scoreRef.value += amount;
+}
+
+function getComponentCandidates(info: ArtInfo): string[] {
+  const candidates = new Set<string>();
+  if (info.component) {
+    candidates.add(info.component);
+    candidates.add(path.basename(info.component));
+    candidates.add(path.basename(info.component, path.extname(info.component)));
+  }
+  return Array.from(candidates);
+}
+
+function scoreArtInfo(projectRoot: string, info: ArtInfo, query: string): ArtSearchResult | null {
+  const normalizedQuery = normalize(query);
+  if (!normalizedQuery) return null;
+
+  const relativePath = toProjectPath(projectRoot, info.path);
+  const relativePathNorm = normalizePathLike(relativePath);
+  const titleNorm = normalize(info.title);
+  const descriptionNorm = normalize(info.description);
+  const categoryNorm = normalize(info.category);
+  const tagNorms = info.tags.map((tag) => normalize(tag));
+  const variantNorms = info.variantNames.map((variantName) => normalize(variantName));
+  const componentCandidates = getComponentCandidates(info);
+  const componentNorms = componentCandidates.map((component) => normalizePathLike(component));
+  const reasons = new Set<string>();
+  const scoreRef = { value: 0 };
+
+  if (relativePathNorm === normalizePathLike(query)) {
+    addScore(reasons, "exact path match", 220, scoreRef);
+  } else if (relativePathNorm.includes(normalizePathLike(query))) {
+    addScore(reasons, "path match", 70, scoreRef);
+  }
+
+  if (titleNorm === normalizedQuery) {
+    addScore(reasons, "exact title match", 200, scoreRef);
+  } else if (titleNorm.startsWith(normalizedQuery)) {
+    addScore(reasons, "title prefix match", 140, scoreRef);
+  } else if (titleNorm.includes(normalizedQuery)) {
+    addScore(reasons, "title match", 110, scoreRef);
+  }
+
+  if (categoryNorm === normalizedQuery) {
+    addScore(reasons, "exact category match", 120, scoreRef);
+  } else if (categoryNorm.includes(normalizedQuery)) {
+    addScore(reasons, "category match", 55, scoreRef);
+  }
+
+  if (descriptionNorm.includes(normalizedQuery)) {
+    addScore(reasons, "description match", 60, scoreRef);
+  }
+
+  for (const tag of tagNorms) {
+    if (tag === normalizedQuery) {
+      addScore(reasons, "exact tag match", 130, scoreRef);
+      break;
+    }
+    if (tag.includes(normalizedQuery)) {
+      addScore(reasons, "tag match", 80, scoreRef);
+      break;
+    }
+  }
+
+  for (const variant of variantNorms) {
+    if (variant === normalizedQuery) {
+      addScore(reasons, "exact variant match", 130, scoreRef);
+      break;
+    }
+    if (variant.includes(normalizedQuery)) {
+      addScore(reasons, "variant match", 90, scoreRef);
+      break;
+    }
+  }
+
+  for (const component of componentNorms) {
+    if (component === normalizePathLike(query)) {
+      addScore(reasons, "exact component match", 180, scoreRef);
+      break;
+    }
+    if (component.includes(normalizePathLike(query))) {
+      addScore(reasons, "component match", 100, scoreRef);
+      break;
+    }
+  }
+
+  const terms = tokenize(query);
+  for (const term of terms) {
+    if (term === normalizedQuery) continue;
+    if (titleNorm.includes(term)) {
+      addScore(reasons, `title contains "${term}"`, 18, scoreRef);
+    }
+    if (descriptionNorm.includes(term)) {
+      addScore(reasons, `description contains "${term}"`, 10, scoreRef);
+    }
+    if (categoryNorm.includes(term)) {
+      addScore(reasons, `category contains "${term}"`, 10, scoreRef);
+    }
+    if (tagNorms.some((tag) => tag.includes(term))) {
+      addScore(reasons, `tag contains "${term}"`, 16, scoreRef);
+    }
+    if (variantNorms.some((variant) => variant.includes(term))) {
+      addScore(reasons, `variant contains "${term}"`, 14, scoreRef);
+    }
+    if (componentNorms.some((component) => component.includes(term))) {
+      addScore(reasons, `component contains "${term}"`, 14, scoreRef);
+    }
+  }
+
+  if (scoreRef.value <= 0) {
+    return null;
+  }
+
+  return {
+    info,
+    relativePath,
+    score: scoreRef.value,
+    reasons: Array.from(reasons).slice(0, 5),
+  };
+}
+
+function compareArtResults(left: ArtSearchResult, right: ArtSearchResult): number {
+  return (
+    right.score - left.score ||
+    (left.info.order ?? Number.MAX_SAFE_INTEGER) - (right.info.order ?? Number.MAX_SAFE_INTEGER) ||
+    left.info.title.localeCompare(right.info.title)
+  );
+}
+
+export async function searchArtInfos(
+  ctx: ServerContext,
+  query: string,
+  filters?: {
+    category?: string;
+    tag?: string;
+    status?: string;
+    component?: string;
+    limit?: number;
+  },
+): Promise<ArtSearchResult[]> {
+  const arts = Array.from((await ctx.scanArtFiles()).values());
+  const category = normalize(filters?.category);
+  const tag = normalize(filters?.tag);
+  const status = normalize(filters?.status);
+  const componentFilter = normalize(filters?.component);
+
+  const filtered = arts.filter((info) => {
+    if (category && normalize(info.category) !== category) return false;
+    if (tag && !info.tags.some((item) => normalize(item) === tag)) return false;
+    if (status && normalize(info.status) !== status) return false;
+    if (
+      componentFilter &&
+      !getComponentCandidates(info).some((candidate) =>
+        normalizePathLike(candidate).includes(componentFilter),
+      )
+    ) {
+      return false;
+    }
+    return true;
+  });
+
+  const results = filtered
+    .map((info) => scoreArtInfo(ctx.projectRoot, info, query))
+    .filter((result): result is ArtSearchResult => result != null)
+    .sort(compareArtResults);
+
+  return results.slice(0, filters?.limit ?? 10);
+}
+
+function buildAlternatives(results: ArtSearchResult[]): ResolvedArtReference["alternatives"] {
+  return results.slice(1, 4).map((result) => ({
+    path: result.relativePath,
+    title: result.info.title,
+    component: result.info.component,
+    score: result.score,
+    reasons: result.reasons,
+  }));
+}
+
+export async function resolveArtReference(
+  ctx: ServerContext,
+  args: Record<string, unknown> | undefined,
+): Promise<ResolvedArtReference> {
+  const arts = Array.from((await ctx.scanArtFiles()).values());
+  const pathArg = typeof args?.path === "string" ? args.path : undefined;
+  const titleArg = typeof args?.title === "string" ? args.title : undefined;
+  const componentArg = typeof args?.component === "string" ? args.component : undefined;
+  const queryArg = typeof args?.query === "string" ? args.query : undefined;
+  const refArg = typeof args?.ref === "string" ? args.ref : undefined;
+
+  if (pathArg) {
+    const resolvedPath = path.isAbsolute(pathArg)
+      ? pathArg
+      : path.resolve(ctx.projectRoot, pathArg);
+    const normalizedResolvedPath = normalizePathLike(resolvedPath);
+    const normalizedRelativePath = normalizePathLike(path.relative(ctx.projectRoot, resolvedPath));
+    const directMatch = arts.find((info) => {
+      const infoRelativePath = normalizePathLike(path.relative(ctx.projectRoot, info.path));
+      return (
+        normalizePathLike(info.path) === normalizedResolvedPath ||
+        infoRelativePath === normalizedRelativePath
+      );
+    });
+
+    if (directMatch) {
+      return {
+        info: directMatch,
+        absolutePath: directMatch.path,
+        relativePath: toProjectPath(ctx.projectRoot, directMatch.path),
+        matchedBy: "path",
+        matchValue: pathArg,
+        score: 999,
+        reasons: ["exact path match"],
+        alternatives: [],
+      };
+    }
+  }
+
+  if (titleArg) {
+    const matches = arts.filter((info) => normalize(info.title) === normalize(titleArg));
+    if (matches.length > 0) {
+      const primary = matches[0];
+      return {
+        info: primary,
+        absolutePath: primary.path,
+        relativePath: toProjectPath(ctx.projectRoot, primary.path),
+        matchedBy: "title",
+        matchValue: titleArg,
+        score: 950,
+        reasons: ["exact title match"],
+        alternatives: matches.slice(1, 4).map((info) => ({
+          path: toProjectPath(ctx.projectRoot, info.path),
+          title: info.title,
+          component: info.component,
+          score: 900,
+          reasons: ["exact title match"],
+        })),
+      };
+    }
+  }
+
+  if (componentArg) {
+    const normalizedComponent = normalizePathLike(componentArg);
+    const matches = arts.filter((info) =>
+      getComponentCandidates(info).some(
+        (candidate) => normalizePathLike(candidate) === normalizedComponent,
+      ),
+    );
+    if (matches.length > 0) {
+      const primary = matches[0];
+      return {
+        info: primary,
+        absolutePath: primary.path,
+        relativePath: toProjectPath(ctx.projectRoot, primary.path),
+        matchedBy: "component",
+        matchValue: componentArg,
+        score: 930,
+        reasons: ["exact component match"],
+        alternatives: matches.slice(1, 4).map((info) => ({
+          path: toProjectPath(ctx.projectRoot, info.path),
+          title: info.title,
+          component: info.component,
+          score: 880,
+          reasons: ["exact component match"],
+        })),
+      };
+    }
+  }
+
+  const queryValue = queryArg ?? refArg ?? pathArg ?? titleArg ?? componentArg;
+  if (!queryValue) {
+    throw new McpError(
+      ErrorCode.InvalidParams,
+      "Provide one of: path, title, component, query, or ref",
+    );
+  }
+
+  const results = await searchArtInfos(ctx, queryValue, { limit: 4 });
+  if (results.length === 0) {
+    throw new McpError(
+      ErrorCode.InvalidParams,
+      `No component matched "${queryValue}". Try list_components or search_components first.`,
+    );
+  }
+
+  const primary = results[0];
+  return {
+    info: primary.info,
+    absolutePath: primary.info.path,
+    relativePath: primary.relativePath,
+    matchedBy: queryArg ? "query" : "ref",
+    matchValue: queryValue,
+    score: primary.score,
+    reasons: primary.reasons,
+    alternatives: buildAlternatives(results),
+  };
+}
+
+export function resolveComponentSourcePath(
+  artAbsolutePath: string,
+  componentReference?: string,
+): string | null {
+  if (!componentReference) {
+    return null;
+  }
+
+  if (path.isAbsolute(componentReference)) {
+    return componentReference;
+  }
+
+  return path.resolve(path.dirname(artAbsolutePath), componentReference);
+}
+
+async function getComponentSourceDescriptor(
+  ctx: ServerContext,
+  resolved: ResolvedArtReference,
+): Promise<ComponentSourceDescriptor> {
+  const componentPath = resolveComponentSourcePath(resolved.absolutePath, resolved.info.component);
+  if (!componentPath) {
+    return {
+      reference: resolved.info.component,
+      exists: false,
+      error: "This art file does not declare a component source.",
+    };
+  }
+
+  try {
+    await fs.promises.access(componentPath, fs.constants.R_OK);
+    return {
+      reference: resolved.info.component,
+      absolutePath: componentPath,
+      path: toProjectPath(ctx.projectRoot, componentPath),
+      exists: true,
+    };
+  } catch {
+    return {
+      reference: resolved.info.component,
+      absolutePath: componentPath,
+      path: toProjectPath(ctx.projectRoot, componentPath),
+      exists: false,
+      error: `Component source not found: ${toProjectPath(ctx.projectRoot, componentPath)}`,
+    };
+  }
+}
+
+function normalizeDefaultValue(value: unknown): unknown {
+  if (value === "true") return true;
+  if (value === "false") return false;
+  if (
+    typeof value === "string" &&
+    ((value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'")))
+  ) {
+    return value.slice(1, -1);
+  }
+  return value;
+}
+
+function inferControlType(type: string): string {
+  const normalizedType = type.toLowerCase();
+  if (normalizedType === "boolean") return "boolean";
+  if (normalizedType === "number") return "number";
+  if (normalizedType.includes("|") && !normalizedType.includes("=>")) return "select";
+  return "text";
+}
+
+function extractOptionsFromType(type: string): Array<{ label: string; value: unknown }> {
+  const options: Array<{ label: string; value: unknown }> = [];
+  for (const match of type.matchAll(/["']([^"']+)["']/g)) {
+    options.push({ label: match[1], value: match[1] });
+  }
+  return options;
+}
+
+function buildPaletteFromAnalysis(title: string, analysis: ComponentAnalysisResult): PaletteResult {
+  const controls = analysis.props.map((prop) => {
+    const control = inferControlType(prop.type);
+    return {
+      name: prop.name,
+      control,
+      defaultValue: normalizeDefaultValue(prop.defaultValue),
+      description: undefined,
+      required: prop.required,
+      options: control === "select" ? extractOptionsFromType(prop.type) : [],
+      range: undefined,
+      group: undefined,
+    };
+  });
+
+  return {
+    title,
+    controls,
+    groups: [],
+    json: JSON.stringify({ title, controls }, null, 2),
+    typescript: `export interface ${title.replace(/\s+/g, "")}Props {\n${controls
+      .map((control) => {
+        const type =
+          control.control === "boolean"
+            ? "boolean"
+            : control.control === "number"
+              ? "number"
+              : control.control === "select" && control.options.length > 0
+                ? control.options.map((option) => `"${String(option.value)}"`).join(" | ")
+                : "string";
+        return `  ${control.name}${control.required ? "" : "?"}: ${type};`;
+      })
+      .join("\n")}\n}\n`,
+  };
+}
+
+export async function analyzeResolvedComponent(
+  ctx: ServerContext,
+  binding: NativeBinding,
+  resolved: ResolvedArtReference,
+): Promise<{ source: ComponentSourceDescriptor; analysis: ComponentAnalysisResult | null }> {
+  const sourceDescriptor = await getComponentSourceDescriptor(ctx, resolved);
+  if (!sourceDescriptor.exists || !sourceDescriptor.absolutePath) {
+    return { source: sourceDescriptor, analysis: null };
+  }
+
+  if (!binding.analyzeSfc) {
+    return {
+      source: {
+        ...sourceDescriptor,
+        error: "analyzeSfc is not available in the native binding.",
+      },
+      analysis: null,
+    };
+  }
+
+  const source = await fs.promises.readFile(sourceDescriptor.absolutePath, "utf-8");
+  const analysis = binding.analyzeSfc(source, { filename: sourceDescriptor.absolutePath });
+  return {
+    source: sourceDescriptor,
+    analysis: {
+      path: sourceDescriptor.path ?? sourceDescriptor.absolutePath,
+      props: analysis.props.map((prop) => ({
+        name: prop.name,
+        type: prop.type,
+        required: prop.required,
+        defaultValue: prop.default_value,
+      })),
+      emits: analysis.emits,
+    },
+  };
+}
+
+function formatGeneratedMarkdown(markdown: string, componentName: string): string {
+  let formatted = markdown
+    .replace(/<Self(\s|>|\/)/g, `<${componentName}$1`)
+    .replace(/<\/Self>/g, `</${componentName}>`);
+
+  formatted = formatted.replace(
+    /```(\w*)\n([\s\S]*?)```/g,
+    (_match: string, lang: string, code: string) => {
+      const lines = code.split("\n");
+      let minIndent = Infinity;
+
+      for (const line of lines) {
+        if (line.trim()) {
+          const indent = line.match(/^(\s*)/)?.[1].length ?? 0;
+          minIndent = Math.min(minIndent, indent);
+        }
+      }
+
+      if (minIndent === Infinity) {
+        minIndent = 0;
+      }
+
+      const normalizedLines = minIndent > 0 ? lines.map((line) => line.slice(minIndent)) : lines;
+
+      return `\`\`\`${lang}\n${normalizedLines.join("\n")}\`\`\``;
+    },
+  );
+
+  return formatted;
+}
+
+export async function buildPalette(
+  ctx: ServerContext,
+  binding: NativeBinding,
+  resolved: ResolvedArtReference,
+  source: string,
+): Promise<PaletteResult | null> {
+  let palette: PaletteResult | null = null;
+
+  if (binding.generateArtPalette) {
+    const generated = binding.generateArtPalette(source, { filename: resolved.absolutePath });
+    palette = {
+      title: generated.title,
+      controls: generated.controls.map((control) => ({
+        name: control.name,
+        control: control.control,
+        defaultValue: control.default_value,
+        description: control.description,
+        required: control.required,
+        options: control.options,
+        range: control.range,
+        group: control.group,
+      })),
+      groups: generated.groups,
+      json: generated.json,
+      typescript: generated.typescript,
+    };
+  }
+
+  if (palette && palette.controls.length > 0) {
+    return palette;
+  }
+
+  const { analysis } = await analyzeResolvedComponent(ctx, binding, resolved);
+  if (!analysis || analysis.props.length === 0) {
+    return palette;
+  }
+
+  return buildPaletteFromAnalysis(resolved.info.title, analysis);
+}
+
+export async function buildDocumentation(
+  binding: NativeBinding,
+  resolved: ResolvedArtReference,
+  source: string,
+  options?: {
+    includeSource?: boolean;
+    includeTemplates?: boolean;
+  },
+): Promise<DocumentationResult | null> {
+  if (!binding.generateArtDoc) {
+    return null;
+  }
+
+  const doc = binding.generateArtDoc(
+    source,
+    { filename: resolved.absolutePath },
+    {
+      include_source: options?.includeSource,
+      include_templates: options?.includeTemplates,
+      include_metadata: true,
+    },
+  );
+
+  return {
+    markdown: formatGeneratedMarkdown(doc.markdown, resolved.info.title || "Component"),
+    title: doc.title,
+    category: doc.category,
+    variantCount: doc.variant_count,
+  };
+}
+
+export async function buildComponentDetails(
+  ctx: ServerContext,
+  binding: NativeBinding,
+  resolved: ResolvedArtReference,
+  options?: {
+    includeAnalysis?: boolean;
+    includePalette?: boolean;
+    includeDocumentation?: boolean;
+  },
+): Promise<Record<string, unknown>> {
+  const source = await fs.promises.readFile(resolved.absolutePath, "utf-8");
+  const parsed = binding.parseArt(source, { filename: resolved.absolutePath });
+  const componentState = await analyzeResolvedComponent(ctx, binding, resolved);
+  const palette =
+    options?.includePalette === false ? null : await buildPalette(ctx, binding, resolved, source);
+  const documentation =
+    options?.includeDocumentation === true
+      ? await buildDocumentation(binding, resolved, source)
+      : null;
+  const resourceUris = buildResourceUris(
+    resolved.relativePath,
+    parsed.variants.map((variant) => variant.name),
+    Boolean(componentState.source.reference),
+  );
+
+  return {
+    path: resolved.relativePath,
+    match: {
+      matchedBy: resolved.matchedBy,
+      matchValue: resolved.matchValue,
+      score: resolved.score,
+      reasons: resolved.reasons,
+      alternatives: resolved.alternatives,
+    },
+    metadata: parsed.metadata,
+    variants: parsed.variants.map((variant) => ({
+      name: variant.name,
+      template: variant.template,
+      isDefault: variant.is_default,
+      skipVrt: variant.skip_vrt,
+    })),
+    defaultVariant: parsed.variants.find((variant) => variant.is_default)?.name,
+    variantNames: parsed.variants.map((variant) => variant.name),
+    hasScriptSetup: parsed.has_script_setup,
+    hasScript: parsed.has_script,
+    styleCount: parsed.style_count,
+    componentSource: componentState.source,
+    componentAnalysis:
+      options?.includeAnalysis === false
+        ? undefined
+        : (componentState.analysis ?? {
+            path: componentState.source.path,
+            props: [],
+            emits: [],
+            error: componentState.source.error,
+          }),
+    palette,
+    documentation,
+    resources: resourceUris,
+  };
+}
+
+export function buildCatalogMarkdown(arts: ArtInfo[], projectRoot: string): string {
+  const grouped = new Map<string, ArtInfo[]>();
+  for (const art of arts) {
+    const category = art.category || "Uncategorized";
+    const list = grouped.get(category) ?? [];
+    list.push(art);
+    grouped.set(category, list);
+  }
+
+  let markdown = "# Musea Component Catalog\n\n";
+  for (const [category, items] of Array.from(grouped.entries()).sort(([left], [right]) =>
+    left.localeCompare(right),
+  )) {
+    markdown += `## ${category}\n\n`;
+    for (const item of items.sort((left, right) => left.title.localeCompare(right.title))) {
+      const relativePath = toProjectPath(projectRoot, item.path);
+      markdown += `- **${item.title}** \`${relativePath}\``;
+      if (item.description) {
+        markdown += ` — ${item.description}`;
+      }
+      markdown += "\n";
+      if (item.variantNames.length > 0) {
+        markdown += `  Variants: ${item.variantNames.join(", ")}\n`;
+      }
+      if (item.tags.length > 0) {
+        markdown += `  Tags: ${item.tags.join(", ")}\n`;
+      }
+    }
+    markdown += "\n";
+  }
+  return markdown;
+}
+
+export function buildIndexSummary(ctx: ServerContext, arts: ArtInfo[]): Record<string, unknown> {
+  const categories = new Map<string, number>();
+  const tags = new Map<string, number>();
+
+  for (const art of arts) {
+    categories.set(
+      art.category || "Uncategorized",
+      (categories.get(art.category || "Uncategorized") ?? 0) + 1,
+    );
+    for (const tag of art.tags) {
+      tags.set(tag, (tags.get(tag) ?? 0) + 1);
+    }
+  }
+
+  return {
+    componentCount: arts.length,
+    categories: Array.from(categories.entries())
+      .map(([name, count]) => ({ name, count }))
+      .sort((left, right) => left.name.localeCompare(right.name)),
+    tags: Array.from(tags.entries())
+      .map(([name, count]) => ({ name, count }))
+      .sort((left, right) => right.count - left.count || left.name.localeCompare(right.name)),
+    components: arts
+      .slice()
+      .sort((left, right) => left.title.localeCompare(right.title))
+      .map((art) => ({
+        path: toProjectPath(ctx.projectRoot, art.path),
+        title: art.title,
+        description: art.description,
+        component: art.component,
+        category: art.category,
+        status: art.status,
+        tags: art.tags,
+        variantCount: art.variantCount,
+        variantNames: art.variantNames,
+        defaultVariant: art.defaultVariant,
+      })),
+  };
+}
+
+export function getProjectPath(projectRoot: string, absolutePath: string): string {
+  return toProjectPath(projectRoot, absolutePath);
+}

--- a/npm/musea-mcp-server/src/resources.ts
+++ b/npm/musea-mcp-server/src/resources.ts
@@ -1,30 +1,97 @@
 import fs from "node:fs";
 import path from "node:path";
 import { ErrorCode, McpError } from "@modelcontextprotocol/sdk/types.js";
+import {
+  buildCatalogMarkdown,
+  buildComponentDetails,
+  buildDocumentation,
+  buildIndexSummary,
+  getProjectPath,
+  resolveArtReference,
+} from "./musea.js";
+import { flattenTokenCategories, generateTokensMarkdown, parseTokensFromPath } from "./tokens.js";
 import type { ServerContext } from "./types.js";
-import { parseTokensFromPath } from "./tokens.js";
+
+function componentUri(relativePath: string): string {
+  return `musea://component/${encodeURIComponent(relativePath)}`;
+}
+
+function docsUri(relativePath: string): string {
+  return `musea://docs/${encodeURIComponent(relativePath)}`;
+}
+
+function sourceUri(relativePath: string): string {
+  return `musea://source/${encodeURIComponent(relativePath)}`;
+}
+
+function componentSourceUri(relativePath: string): string {
+  return `musea://component-source/${encodeURIComponent(relativePath)}`;
+}
+
+function variantUri(relativePath: string, variantName: string): string {
+  return `musea://variant/${encodeURIComponent(relativePath)}/${encodeURIComponent(variantName)}`;
+}
 
 export async function listResources(ctx: ServerContext) {
-  const arts = await ctx.scanArtFiles();
-  const resources = [];
+  const arts = Array.from((await ctx.scanArtFiles()).values());
+  const resources = [
+    {
+      uri: "musea://index",
+      name: "Component Index",
+      description: "JSON summary of the project component registry",
+      mimeType: "application/json",
+    },
+    {
+      uri: "musea://catalog",
+      name: "Component Catalog",
+      description: "Markdown catalog for the whole design system",
+      mimeType: "text/markdown",
+    },
+  ];
 
-  for (const [filePath, info] of arts) {
-    const relativePath = path.relative(ctx.projectRoot, filePath);
+  for (const info of arts) {
+    const relativePath = getProjectPath(ctx.projectRoot, info.path);
 
     resources.push({
-      uri: `musea://component/${encodeURIComponent(relativePath)}`,
+      uri: componentUri(relativePath),
       name: info.title,
       description:
-        info.description || `${info.category || "Component"} — ${info.variantCount} variant(s)`,
+        info.description ||
+        `${info.category || "Component"} • ${info.variantCount} variant(s) • ${info.status}`,
       mimeType: "application/json",
     });
 
     resources.push({
-      uri: `musea://docs/${encodeURIComponent(relativePath)}`,
+      uri: docsUri(relativePath),
       name: `${info.title} — Documentation`,
-      description: `Markdown docs for ${info.title}`,
+      description: `Generated Markdown docs for ${info.title}`,
       mimeType: "text/markdown",
     });
+
+    resources.push({
+      uri: sourceUri(relativePath),
+      name: `${info.title} — Art Source`,
+      description: `Raw .art.vue source for ${info.title}`,
+      mimeType: "text/plain",
+    });
+
+    if (info.component) {
+      resources.push({
+        uri: componentSourceUri(relativePath),
+        name: `${info.title} — Component Source`,
+        description: `Resolved Vue component source for ${info.title}`,
+        mimeType: "text/plain",
+      });
+    }
+
+    for (const variantName of info.variantNames) {
+      resources.push({
+        uri: variantUri(relativePath, variantName),
+        name: `${info.title} — ${variantName}`,
+        description: `Variant details for ${variantName}`,
+        mimeType: "application/json",
+      });
+    }
   }
 
   const resolvedTokensPath = await ctx.resolveTokensPath();
@@ -32,8 +99,14 @@ export async function listResources(ctx: ServerContext) {
     resources.push({
       uri: "musea://tokens",
       name: "Design Tokens",
-      description: "Project design tokens (colors, spacing, typography, …)",
+      description: "Project design tokens as JSON",
       mimeType: "application/json",
+    });
+    resources.push({
+      uri: "musea://tokens/markdown",
+      name: "Design Tokens — Markdown",
+      description: "Project design tokens as Markdown tables",
+      mimeType: "text/markdown",
     });
   }
 
@@ -41,91 +114,213 @@ export async function listResources(ctx: ServerContext) {
 }
 
 export async function readResource(ctx: ServerContext, uri: string) {
+  if (uri === "musea://index") {
+    const arts = Array.from((await ctx.scanArtFiles()).values());
+    return {
+      contents: [
+        {
+          uri,
+          mimeType: "application/json",
+          text: JSON.stringify(buildIndexSummary(ctx, arts), null, 2),
+        },
+      ],
+    };
+  }
+
+  if (uri === "musea://catalog") {
+    const binding = ctx.loadNative();
+    const arts = Array.from((await ctx.scanArtFiles()).values());
+
+    if (binding.generateArtCatalog) {
+      const sources = await Promise.all(arts.map((art) => fs.promises.readFile(art.path, "utf-8")));
+      const catalog = binding.generateArtCatalog(sources, { include_metadata: true });
+      return {
+        contents: [{ uri, mimeType: "text/markdown", text: catalog.markdown }],
+      };
+    }
+
+    return {
+      contents: [
+        {
+          uri,
+          mimeType: "text/markdown",
+          text: buildCatalogMarkdown(arts, ctx.projectRoot),
+        },
+      ],
+    };
+  }
+
   if (uri.startsWith("musea://component/")) {
     const relativePath = decodeURIComponent(uri.slice("musea://component/".length));
-    const absolutePath = path.resolve(ctx.projectRoot, relativePath);
+    const binding = ctx.loadNative();
+    const details = await buildComponentDetails(
+      ctx,
+      binding,
+      await resolveArtReference(ctx, { path: relativePath }),
+      {
+        includeAnalysis: true,
+        includePalette: true,
+        includeDocumentation: false,
+      },
+    );
 
-    try {
-      const source = await fs.promises.readFile(absolutePath, "utf-8");
-      const binding = ctx.loadNative();
-      const parsed = binding.parseArt(source, { filename: absolutePath });
-
-      return {
-        contents: [
-          {
-            uri,
-            mimeType: "application/json",
-            text: JSON.stringify(
-              {
-                path: relativePath,
-                metadata: parsed.metadata,
-                variants: parsed.variants.map((v) => ({
-                  name: v.name,
-                  template: v.template,
-                  isDefault: v.is_default,
-                  skipVrt: v.skip_vrt,
-                })),
-                hasScriptSetup: parsed.has_script_setup,
-                hasScript: parsed.has_script,
-                styleCount: parsed.style_count,
-              },
-              null,
-              2,
-            ),
-          },
-        ],
-      };
-    } catch (e) {
-      throw new McpError(ErrorCode.InternalError, `Failed to read component: ${String(e)}`);
-    }
+    return {
+      contents: [
+        {
+          uri,
+          mimeType: "application/json",
+          text: JSON.stringify(details, null, 2),
+        },
+      ],
+    };
   }
 
   if (uri.startsWith("musea://docs/")) {
     const relativePath = decodeURIComponent(uri.slice("musea://docs/".length));
-    const absolutePath = path.resolve(ctx.projectRoot, relativePath);
+    const binding = ctx.loadNative();
+    const resolved = await resolveArtReference(ctx, { path: relativePath });
+    const source = await fs.promises.readFile(resolved.absolutePath, "utf-8");
+    const documentation = await buildDocumentation(binding, resolved, source);
 
-    try {
-      const source = await fs.promises.readFile(absolutePath, "utf-8");
-      const binding = ctx.loadNative();
-
-      if (!binding.generateArtDoc) {
-        throw new McpError(
-          ErrorCode.InternalError,
-          "generateArtDoc not available in native binding",
-        );
-      }
-
-      const doc = binding.generateArtDoc(source, { filename: absolutePath });
-
-      return {
-        contents: [{ uri, mimeType: "text/markdown", text: doc.markdown }],
-      };
-    } catch (e) {
-      if (e instanceof McpError) throw e;
-      throw new McpError(ErrorCode.InternalError, `Failed to generate docs: ${String(e)}`);
+    if (!documentation) {
+      throw new McpError(ErrorCode.InternalError, "generateArtDoc not available in native binding");
     }
+
+    return {
+      contents: [{ uri, mimeType: "text/markdown", text: documentation.markdown }],
+    };
   }
 
-  if (uri === "musea://tokens") {
+  if (uri.startsWith("musea://source/")) {
+    const relativePath = decodeURIComponent(uri.slice("musea://source/".length));
+    const absolutePath = path.resolve(ctx.projectRoot, relativePath);
+    const source = await fs.promises.readFile(absolutePath, "utf-8");
+
+    return {
+      contents: [{ uri, mimeType: "text/plain", text: source }],
+    };
+  }
+
+  if (uri.startsWith("musea://component-source/")) {
+    const relativePath = decodeURIComponent(uri.slice("musea://component-source/".length));
+    const binding = ctx.loadNative();
+    const details = (await buildComponentDetails(
+      ctx,
+      binding,
+      await resolveArtReference(ctx, { path: relativePath }),
+      {
+        includeAnalysis: false,
+        includePalette: false,
+        includeDocumentation: false,
+      },
+    )) as {
+      componentSource?: { path?: string; exists?: boolean; error?: string };
+    };
+
+    const componentSource = details.componentSource;
+    if (!componentSource?.path || componentSource.exists !== true) {
+      throw new McpError(
+        ErrorCode.InvalidRequest,
+        componentSource?.error ?? "Component source not available for this art file",
+      );
+    }
+
+    const absolutePath = path.resolve(ctx.projectRoot, componentSource.path);
+    const source = await fs.promises.readFile(absolutePath, "utf-8");
+    return {
+      contents: [{ uri, mimeType: "text/plain", text: source }],
+    };
+  }
+
+  if (uri.startsWith("musea://variant/")) {
+    const rest = uri.slice("musea://variant/".length);
+    const separatorIndex = rest.indexOf("/");
+    if (separatorIndex === -1) {
+      throw new McpError(ErrorCode.InvalidRequest, `Unknown resource URI: ${uri}`);
+    }
+
+    const relativePath = decodeURIComponent(rest.slice(0, separatorIndex));
+    const variantName = decodeURIComponent(rest.slice(separatorIndex + 1));
+    const binding = ctx.loadNative();
+    const resolved = await resolveArtReference(ctx, { path: relativePath });
+    const source = await fs.promises.readFile(resolved.absolutePath, "utf-8");
+    const parsed = binding.parseArt(source, { filename: resolved.absolutePath });
+    const variant = parsed.variants.find(
+      (item) => item.name.toLowerCase() === variantName.toLowerCase(),
+    );
+
+    if (!variant) {
+      throw new McpError(
+        ErrorCode.InvalidRequest,
+        `Variant "${variantName}" not found in "${resolved.info.title}"`,
+      );
+    }
+
+    return {
+      contents: [
+        {
+          uri,
+          mimeType: "application/json",
+          text: JSON.stringify(
+            {
+              component: {
+                title: resolved.info.title,
+                path: resolved.relativePath,
+                componentReference: resolved.info.component,
+              },
+              variant: {
+                name: variant.name,
+                template: variant.template,
+                isDefault: variant.is_default,
+                skipVrt: variant.skip_vrt,
+              },
+              relatedVariants: parsed.variants.map((item) => item.name),
+            },
+            null,
+            2,
+          ),
+        },
+      ],
+    };
+  }
+
+  if (uri === "musea://tokens" || uri === "musea://tokens/markdown") {
     const resolvedTokensPath = await ctx.resolveTokensPath();
     if (!resolvedTokensPath) {
       throw new McpError(ErrorCode.InternalError, "No tokens path configured or auto-detected");
     }
 
-    try {
-      const categories = await parseTokensFromPath(resolvedTokensPath);
+    const categories = await parseTokensFromPath(resolvedTokensPath);
+    if (uri === "musea://tokens/markdown") {
       return {
         contents: [
           {
             uri,
-            mimeType: "application/json",
-            text: JSON.stringify({ categories }, null, 2),
+            mimeType: "text/markdown",
+            text: generateTokensMarkdown(categories),
           },
         ],
       };
-    } catch (e) {
-      throw new McpError(ErrorCode.InternalError, `Failed to read tokens: ${String(e)}`);
     }
+
+    return {
+      contents: [
+        {
+          uri,
+          mimeType: "application/json",
+          text: JSON.stringify(
+            {
+              source: path.relative(ctx.projectRoot, resolvedTokensPath),
+              categoryCount: categories.length,
+              tokenCount: flattenTokenCategories(categories).length,
+              categories,
+            },
+            null,
+            2,
+          ),
+        },
+      ],
+    };
   }
 
   throw new McpError(ErrorCode.InvalidRequest, `Unknown resource URI: ${uri}`);

--- a/npm/musea-mcp-server/src/tokens.ts
+++ b/npm/musea-mcp-server/src/tokens.ts
@@ -13,6 +13,15 @@ export interface TokenCategory {
   subcategories?: TokenCategory[];
 }
 
+export interface FlattenedToken {
+  name: string;
+  path: string;
+  categoryPath: string[];
+  value: string | number;
+  type?: string;
+  description?: string;
+}
+
 export async function parseTokensFromPath(tokensPath: string): Promise<TokenCategory[]> {
   const stat = await fs.promises.stat(tokensPath);
 
@@ -73,6 +82,33 @@ export function generateTokensMarkdown(categories: TokenCategory[]): string {
     markdown += renderCategory(category);
   }
   return markdown;
+}
+
+export function flattenTokenCategories(
+  categories: TokenCategory[],
+  parentPath: string[] = [],
+): FlattenedToken[] {
+  const flattened: FlattenedToken[] = [];
+
+  for (const category of categories) {
+    const categoryPath = [...parentPath, category.name];
+    for (const [name, token] of Object.entries(category.tokens)) {
+      flattened.push({
+        name,
+        path: [...categoryPath, name].join("."),
+        categoryPath,
+        value: token.value,
+        type: token.type,
+        description: token.description,
+      });
+    }
+
+    if (category.subcategories) {
+      flattened.push(...flattenTokenCategories(category.subcategories, categoryPath));
+    }
+  }
+
+  return flattened;
 }
 
 function isTokenLeaf(value: unknown): boolean {

--- a/npm/musea-mcp-server/src/tools/definitions.ts
+++ b/npm/musea-mcp-server/src/tools/definitions.ts
@@ -11,22 +11,41 @@ export const toolDefinitions = [
   {
     name: "analyze_component",
     description:
-      "Statically analyze a Vue SFC to extract its props and emits. Useful for understanding a component's public API when building or reviewing a design system.",
+      "Statically analyze a Vue SFC to extract its props and emits. Accepts a Vue component path directly, or an art-file reference that resolves to the linked component source.",
     inputSchema: {
       type: "object" as const,
       properties: {
         path: {
           type: "string",
-          description: "Path to the .vue component file (relative to project root)",
+          description:
+            "Path to the .vue component file or .art.vue file (relative to project root)",
+        },
+        title: {
+          type: "string",
+          description:
+            "Resolve an art file by its display title, then analyze its component source",
+        },
+        component: {
+          type: "string",
+          description:
+            "Resolve an art file by its component reference or component basename, then analyze it",
+        },
+        query: {
+          type: "string",
+          description: "Fuzzy-search an art file, then analyze the linked component source",
+        },
+        ref: {
+          type: "string",
+          description: "Generic art-file reference: path, title, component name, or search text",
         },
       },
-      required: ["path"],
+      required: [],
     },
   },
   {
     name: "get_palette",
     description:
-      "Derive an interactive props palette (control types, defaults, ranges, options) for a component described by an Art file. Helps to understand how props can be tweaked in a design system playground.",
+      "Derive an interactive props palette (control types, defaults, ranges, options) for a component described by an Art file. Falls back to SFC analysis when native palette inference is sparse.",
     inputSchema: {
       type: "object" as const,
       properties: {
@@ -34,8 +53,24 @@ export const toolDefinitions = [
           type: "string",
           description: "Path to the .art.vue file (relative to project root)",
         },
+        title: {
+          type: "string",
+          description: "Resolve an art file by title instead of path",
+        },
+        component: {
+          type: "string",
+          description: "Resolve an art file by component reference or component basename",
+        },
+        query: {
+          type: "string",
+          description: "Fuzzy-search an art file before generating the palette",
+        },
+        ref: {
+          type: "string",
+          description: "Generic art-file reference: path, title, component name, or search text",
+        },
       },
-      required: ["path"],
+      required: [],
     },
   },
 
@@ -43,19 +78,41 @@ export const toolDefinitions = [
   {
     name: "list_components",
     description:
-      "List components registered in the design system. Returns titles, categories, tags, and variant counts.",
+      "List components registered in the design system. Returns titles, categories, tags, status, variant names, and related resource URIs.",
     inputSchema: {
       type: "object" as const,
       properties: {
         category: { type: "string", description: "Filter by category" },
         tag: { type: "string", description: "Filter by tag" },
+        status: {
+          type: "string",
+          enum: ["draft", "ready", "deprecated"],
+          description: "Filter by status badge",
+        },
+        component: {
+          type: "string",
+          description: "Filter by component reference or component basename",
+        },
+        limit: {
+          type: "number",
+          description: "Maximum number of components to return (default: all)",
+        },
+        includeVariants: {
+          type: "boolean",
+          description: "Include per-variant metadata in the result (default: false)",
+        },
+        sortBy: {
+          type: "string",
+          enum: ["title", "category", "status", "variants"],
+          description: "Sort order for the result list (default: title)",
+        },
       },
     },
   },
   {
     name: "get_component",
     description:
-      "Get full details of a design-system component: metadata, variant list, and script/style information.",
+      "Get full details of a design-system component: metadata, variants, source-component analysis, palette data, documentation, and related resource URIs.",
     inputSchema: {
       type: "object" as const,
       properties: {
@@ -63,31 +120,120 @@ export const toolDefinitions = [
           type: "string",
           description: "Path to the .art.vue file (relative to project root)",
         },
+        title: {
+          type: "string",
+          description: "Resolve an art file by display title instead of path",
+        },
+        component: {
+          type: "string",
+          description: "Resolve an art file by component reference or component basename",
+        },
+        query: {
+          type: "string",
+          description: "Fuzzy-search an art file before loading details",
+        },
+        ref: {
+          type: "string",
+          description: "Generic art-file reference: path, title, component name, or search text",
+        },
+        includeAnalysis: {
+          type: "boolean",
+          description: "Include resolved component props/emits analysis (default: true)",
+        },
+        includePalette: {
+          type: "boolean",
+          description: "Include inferred palette data (default: true)",
+        },
+        includeDocumentation: {
+          type: "boolean",
+          description: "Include generated Markdown docs inline (default: false)",
+        },
       },
-      required: ["path"],
+      required: [],
     },
   },
   {
     name: "get_variant",
-    description: "Retrieve a single variant (template and metadata) from a component.",
+    description:
+      "Retrieve a single variant (template and metadata) from a component, resolving the component by path, title, component name, or fuzzy query.",
     inputSchema: {
       type: "object" as const,
       properties: {
         path: { type: "string", description: "Path to the .art.vue file" },
+        title: { type: "string", description: "Resolve an art file by title" },
+        component: {
+          type: "string",
+          description: "Resolve an art file by component reference or component basename",
+        },
+        query: {
+          type: "string",
+          description: "Fuzzy-search an art file before looking up the variant",
+        },
+        ref: {
+          type: "string",
+          description: "Generic art-file reference: path, title, component name, or search text",
+        },
         variant: { type: "string", description: "Variant name" },
+        includeAnalysis: {
+          type: "boolean",
+          description: "Include resolved component props/emits analysis (default: false)",
+        },
       },
-      required: ["path", "variant"],
+      required: ["variant"],
     },
   },
   {
     name: "search_components",
-    description: "Full-text search over component titles, descriptions, and tags.",
+    description:
+      "Ranked full-text search over component titles, descriptions, categories, tags, component names, and variant names.",
     inputSchema: {
       type: "object" as const,
       properties: {
         query: { type: "string", description: "Search query" },
+        category: { type: "string", description: "Restrict matches to one category" },
+        tag: { type: "string", description: "Restrict matches to one tag" },
+        status: {
+          type: "string",
+          enum: ["draft", "ready", "deprecated"],
+          description: "Restrict matches to one status",
+        },
+        component: {
+          type: "string",
+          description: "Restrict matches to a component reference/basename before searching",
+        },
+        limit: {
+          type: "number",
+          description: "Maximum number of results to return (default: 10)",
+        },
       },
       required: ["query"],
+    },
+  },
+  {
+    name: "recommend_components",
+    description:
+      "Intent-oriented component recommendation. Useful when the user describes a task or UX goal rather than knowing exact component names.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        task: { type: "string", description: "Intent or UI task to solve" },
+        category: { type: "string", description: "Optional category filter" },
+        tag: { type: "string", description: "Optional tag filter" },
+        status: {
+          type: "string",
+          enum: ["draft", "ready", "deprecated"],
+          description: "Optional status filter",
+        },
+        component: {
+          type: "string",
+          description: "Optional component reference/basename filter",
+        },
+        limit: {
+          type: "number",
+          description: "Maximum number of recommendations to return (default: 5)",
+        },
+      },
+      required: ["task"],
     },
   },
 
@@ -131,8 +277,21 @@ export const toolDefinitions = [
       type: "object" as const,
       properties: {
         path: { type: "string", description: "Path to the .art.vue file" },
+        title: { type: "string", description: "Resolve an art file by title" },
+        component: {
+          type: "string",
+          description: "Resolve an art file by component reference or component basename",
+        },
+        query: {
+          type: "string",
+          description: "Fuzzy-search an art file before converting to CSF",
+        },
+        ref: {
+          type: "string",
+          description: "Generic art-file reference: path, title, component name, or search text",
+        },
       },
-      required: ["path"],
+      required: [],
     },
   },
 
@@ -148,6 +307,19 @@ export const toolDefinitions = [
           type: "string",
           description: "Path to the .art.vue file (relative to project root)",
         },
+        title: { type: "string", description: "Resolve an art file by title" },
+        component: {
+          type: "string",
+          description: "Resolve an art file by component reference or component basename",
+        },
+        query: {
+          type: "string",
+          description: "Fuzzy-search an art file before generating docs",
+        },
+        ref: {
+          type: "string",
+          description: "Generic art-file reference: path, title, component name, or search text",
+        },
         includeSource: {
           type: "boolean",
           description: "Embed source code in the output (default: false)",
@@ -157,7 +329,7 @@ export const toolDefinitions = [
           description: "Embed variant templates in the output (default: false)",
         },
       },
-      required: ["path"],
+      required: [],
     },
   },
   {
@@ -183,7 +355,7 @@ export const toolDefinitions = [
   {
     name: "get_tokens",
     description:
-      "Read design tokens (colors, spacing, typography, etc.) from a Style Dictionary\u2013compatible JSON file or directory. Auto-detects common paths if not specified.",
+      "Read design tokens (colors, spacing, typography, etc.) from a Style Dictionary-compatible JSON file or directory. Auto-detects common paths if not specified.",
     inputSchema: {
       type: "object" as const,
       properties: {
@@ -198,6 +370,31 @@ export const toolDefinitions = [
           description: "Output format (default: json)",
         },
       },
+    },
+  },
+  {
+    name: "search_tokens",
+    description:
+      "Search flattened design tokens by token name, category path, value, or description. Much more practical than loading the full token tree for large systems.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        query: { type: "string", description: "Search query" },
+        tokensPath: {
+          type: "string",
+          description:
+            "Path to tokens JSON file or directory (relative to project root). Auto-detects common locations if omitted.",
+        },
+        type: {
+          type: "string",
+          description: "Optional token type filter, e.g. color, dimension, typography",
+        },
+        limit: {
+          type: "number",
+          description: "Maximum number of matches to return (default: 20)",
+        },
+      },
+      required: ["query"],
     },
   },
 ];

--- a/npm/musea-mcp-server/src/tools/handler/analysis.ts
+++ b/npm/musea-mcp-server/src/tools/handler/analysis.ts
@@ -7,6 +7,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { ErrorCode, McpError } from "@modelcontextprotocol/sdk/types.js";
+import { analyzeResolvedComponent, buildPalette, resolveArtReference } from "../../musea.js";
 import type { ServerContext, ToolResult } from "./types.js";
 
 export async function handleAnalyzeComponent(
@@ -14,15 +15,48 @@ export async function handleAnalyzeComponent(
   binding: ReturnType<ServerContext["loadNative"]>,
   args: Record<string, unknown> | undefined,
 ): Promise<ToolResult> {
-  const vuePath = args?.path as string;
-  if (!vuePath) throw new McpError(ErrorCode.InvalidParams, "path is required");
-  if (!binding.analyzeSfc) {
-    throw new McpError(ErrorCode.InternalError, "analyzeSfc not available in native binding");
+  const directPath = args?.path as string | undefined;
+  if (directPath?.endsWith(".vue") && !directPath.endsWith(".art.vue")) {
+    if (!binding.analyzeSfc) {
+      throw new McpError(ErrorCode.InternalError, "analyzeSfc not available in native binding");
+    }
+
+    const absolutePath = path.resolve(ctx.projectRoot, directPath);
+    const source = await fs.promises.readFile(absolutePath, "utf-8");
+    const analysis = binding.analyzeSfc(source, { filename: absolutePath });
+
+    return {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify(
+            {
+              path: directPath,
+              props: analysis.props.map((prop) => ({
+                name: prop.name,
+                type: prop.type,
+                required: prop.required,
+                defaultValue: prop.default_value,
+              })),
+              emits: analysis.emits,
+            },
+            null,
+            2,
+          ),
+        },
+      ],
+    };
   }
 
-  const absolutePath = path.resolve(ctx.projectRoot, vuePath);
-  const source = await fs.promises.readFile(absolutePath, "utf-8");
-  const analysis = binding.analyzeSfc(source, { filename: absolutePath });
+  const resolved = await resolveArtReference(ctx, args);
+  const { source, analysis } = await analyzeResolvedComponent(ctx, binding, resolved);
+
+  if (!analysis) {
+    throw new McpError(
+      ErrorCode.InvalidParams,
+      source.error ?? `Could not analyze component source for "${resolved.info.title}"`,
+    );
+  }
 
   return {
     content: [
@@ -30,12 +64,20 @@ export async function handleAnalyzeComponent(
         type: "text",
         text: JSON.stringify(
           {
-            props: analysis.props.map((p) => ({
-              name: p.name,
-              type: p.type,
-              required: p.required,
-              defaultValue: p.default_value,
-            })),
+            component: {
+              title: resolved.info.title,
+              artPath: resolved.relativePath,
+              componentReference: resolved.info.component,
+              componentPath: source.path,
+            },
+            match: {
+              matchedBy: resolved.matchedBy,
+              matchValue: resolved.matchValue,
+              score: resolved.score,
+              reasons: resolved.reasons,
+              alternatives: resolved.alternatives,
+            },
+            props: analysis.props,
             emits: analysis.emits,
           },
           null,
@@ -51,18 +93,16 @@ export async function handleGetPalette(
   binding: ReturnType<ServerContext["loadNative"]>,
   args: Record<string, unknown> | undefined,
 ): Promise<ToolResult> {
-  const artPath = args?.path as string;
-  if (!artPath) throw new McpError(ErrorCode.InvalidParams, "path is required");
-  if (!binding.generateArtPalette) {
+  const resolved = await resolveArtReference(ctx, args);
+  const source = await fs.promises.readFile(resolved.absolutePath, "utf-8");
+  const palette = await buildPalette(ctx, binding, resolved, source);
+
+  if (!palette) {
     throw new McpError(
-      ErrorCode.InternalError,
-      "generateArtPalette not available in native binding",
+      ErrorCode.InvalidParams,
+      `Could not infer a palette for "${resolved.info.title}"`,
     );
   }
-
-  const absolutePath = path.resolve(ctx.projectRoot, artPath);
-  const source = await fs.promises.readFile(absolutePath, "utf-8");
-  const palette = binding.generateArtPalette(source, { filename: absolutePath });
 
   return {
     content: [
@@ -70,17 +110,20 @@ export async function handleGetPalette(
         type: "text",
         text: JSON.stringify(
           {
+            component: {
+              title: resolved.info.title,
+              path: resolved.relativePath,
+              componentReference: resolved.info.component,
+            },
+            match: {
+              matchedBy: resolved.matchedBy,
+              matchValue: resolved.matchValue,
+              score: resolved.score,
+              reasons: resolved.reasons,
+              alternatives: resolved.alternatives,
+            },
             title: palette.title,
-            controls: palette.controls.map((c) => ({
-              name: c.name,
-              control: c.control,
-              defaultValue: c.default_value,
-              description: c.description,
-              required: c.required,
-              options: c.options,
-              range: c.range,
-              group: c.group,
-            })),
+            controls: palette.controls,
             groups: palette.groups,
             json: palette.json,
             typescript: palette.typescript,

--- a/npm/musea-mcp-server/src/tools/handler/generation.ts
+++ b/npm/musea-mcp-server/src/tools/handler/generation.ts
@@ -2,14 +2,19 @@
  * MCP tool handlers for code generation.
  *
  * Handles `generate_variants`, `generate_csf`, `generate_docs`,
- * `generate_catalog`, and `get_tokens` tool calls.
+ * `generate_catalog`, `get_tokens`, and `search_tokens` tool calls.
  */
 
 import fs from "node:fs";
 import path from "node:path";
 import { ErrorCode, McpError } from "@modelcontextprotocol/sdk/types.js";
+import { buildCatalogMarkdown, buildDocumentation, resolveArtReference } from "../../musea.js";
+import {
+  flattenTokenCategories,
+  generateTokensMarkdown,
+  parseTokensFromPath,
+} from "../../tokens.js";
 import type { ServerContext, ToolResult } from "./types.js";
-import { parseTokensFromPath, generateTokensMarkdown } from "../../tokens.js";
 
 export async function handleGenerateVariants(
   ctx: ServerContext,
@@ -31,11 +36,11 @@ export async function handleGenerateVariants(
   const source = await fs.promises.readFile(absolutePath, "utf-8");
 
   const analysis = binding.analyzeSfc(source, { filename: absolutePath });
-  const props = analysis.props.map((p) => ({
-    name: p.name,
-    prop_type: p.type,
-    required: p.required,
-    default_value: p.default_value,
+  const props = analysis.props.map((prop) => ({
+    name: prop.name,
+    prop_type: prop.type,
+    required: prop.required,
+    default_value: prop.default_value,
   }));
 
   const relPath = `./${path.basename(absolutePath)}`;
@@ -52,13 +57,14 @@ export async function handleGenerateVariants(
         type: "text",
         text: JSON.stringify(
           {
+            componentPath: componentRelPath,
             componentName: result.component_name,
             artFileContent: result.art_file_content,
-            variants: result.variants.map((v) => ({
-              name: v.name,
-              isDefault: v.is_default,
-              props: v.props,
-              description: v.description,
+            variants: result.variants.map((variant) => ({
+              name: variant.name,
+              isDefault: variant.is_default,
+              props: variant.props,
+              description: variant.description,
             })),
           },
           null,
@@ -74,38 +80,9 @@ export async function handleGenerateCsf(
   binding: ReturnType<ServerContext["loadNative"]>,
   args: Record<string, unknown> | undefined,
 ): Promise<ToolResult> {
-  const artPath = args?.path as string;
-  if (!artPath) throw new McpError(ErrorCode.InvalidParams, "path is required");
-
-  const absolutePath = path.resolve(ctx.projectRoot, artPath);
-  const source = await fs.promises.readFile(absolutePath, "utf-8");
-  const csf = binding.artToCsf(source, { filename: absolutePath });
-
-  return { content: [{ type: "text", text: csf.code }] };
-}
-
-export async function handleGenerateDocs(
-  ctx: ServerContext,
-  binding: ReturnType<ServerContext["loadNative"]>,
-  args: Record<string, unknown> | undefined,
-): Promise<ToolResult> {
-  const artPath = args?.path as string;
-  if (!artPath) throw new McpError(ErrorCode.InvalidParams, "path is required");
-  if (!binding.generateArtDoc) {
-    throw new McpError(ErrorCode.InternalError, "generateArtDoc not available in native binding");
-  }
-
-  const absolutePath = path.resolve(ctx.projectRoot, artPath);
-  const source = await fs.promises.readFile(absolutePath, "utf-8");
-  const doc = binding.generateArtDoc(
-    source,
-    { filename: absolutePath },
-    {
-      include_source: args?.includeSource as boolean | undefined,
-      include_templates: args?.includeTemplates as boolean | undefined,
-      include_metadata: true,
-    },
-  );
+  const resolved = await resolveArtReference(ctx, args);
+  const source = await fs.promises.readFile(resolved.absolutePath, "utf-8");
+  const csf = binding.artToCsf(source, { filename: resolved.absolutePath });
 
   return {
     content: [
@@ -113,7 +90,72 @@ export async function handleGenerateDocs(
         type: "text",
         text: JSON.stringify(
           {
-            markdown: doc.markdown,
+            component: {
+              title: resolved.info.title,
+              path: resolved.relativePath,
+            },
+            match: {
+              matchedBy: resolved.matchedBy,
+              matchValue: resolved.matchValue,
+              score: resolved.score,
+              reasons: resolved.reasons,
+              alternatives: resolved.alternatives,
+            },
+            filename: csf.filename,
+            code: csf.code,
+          },
+          null,
+          2,
+        ),
+      },
+    ],
+  };
+}
+
+export async function handleGenerateDocs(
+  ctx: ServerContext,
+  binding: ReturnType<ServerContext["loadNative"]>,
+  args: Record<string, unknown> | undefined,
+): Promise<ToolResult> {
+  const resolved = await resolveArtReference(ctx, args);
+  const source = await fs.promises.readFile(resolved.absolutePath, "utf-8");
+
+  if (!binding.generateArtDoc) {
+    throw new McpError(ErrorCode.InternalError, "generateArtDoc not available in native binding");
+  }
+
+  const doc = binding.generateArtDoc(
+    source,
+    { filename: resolved.absolutePath },
+    {
+      include_source: args?.includeSource as boolean | undefined,
+      include_templates: args?.includeTemplates as boolean | undefined,
+      include_metadata: true,
+    },
+  );
+  const formattedDoc = await buildDocumentation(binding, resolved, source, {
+    includeSource: args?.includeSource as boolean | undefined,
+    includeTemplates: args?.includeTemplates as boolean | undefined,
+  });
+
+  return {
+    content: [
+      {
+        type: "text",
+        text: JSON.stringify(
+          {
+            component: {
+              title: resolved.info.title,
+              path: resolved.relativePath,
+            },
+            match: {
+              matchedBy: resolved.matchedBy,
+              matchValue: resolved.matchValue,
+              score: resolved.score,
+              reasons: resolved.reasons,
+              alternatives: resolved.alternatives,
+            },
+            markdown: formattedDoc?.markdown ?? doc.markdown,
             title: doc.title,
             category: doc.category,
             variantCount: doc.variant_count,
@@ -131,36 +173,51 @@ export async function handleGenerateCatalog(
   binding: ReturnType<ServerContext["loadNative"]>,
   args: Record<string, unknown> | undefined,
 ): Promise<ToolResult> {
-  if (!binding.generateArtCatalog) {
-    throw new McpError(
-      ErrorCode.InternalError,
-      "generateArtCatalog not available in native binding",
-    );
-  }
-
   const arts = await ctx.scanArtFiles();
-  const sources: string[] = [];
-  for (const [filePath] of arts) {
-    const source = await fs.promises.readFile(filePath, "utf-8");
-    sources.push(source);
+
+  if (binding.generateArtCatalog) {
+    const sources: string[] = [];
+    for (const [filePath] of arts) {
+      const source = await fs.promises.readFile(filePath, "utf-8");
+      sources.push(source);
+    }
+
+    const catalog = binding.generateArtCatalog(sources, {
+      include_source: args?.includeSource as boolean | undefined,
+      include_templates: args?.includeTemplates as boolean | undefined,
+      include_metadata: true,
+    });
+
+    return {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify(
+            {
+              markdown: catalog.markdown,
+              componentCount: catalog.component_count,
+              categories: catalog.categories,
+              tags: catalog.tags,
+            },
+            null,
+            2,
+          ),
+        },
+      ],
+    };
   }
 
-  const catalog = binding.generateArtCatalog(sources, {
-    include_source: args?.includeSource as boolean | undefined,
-    include_templates: args?.includeTemplates as boolean | undefined,
-    include_metadata: true,
-  });
-
+  const allArts = Array.from(arts.values());
   return {
     content: [
       {
         type: "text",
         text: JSON.stringify(
           {
-            markdown: catalog.markdown,
-            componentCount: catalog.component_count,
-            categories: catalog.categories,
-            tags: catalog.tags,
+            markdown: buildCatalogMarkdown(allArts, ctx.projectRoot),
+            componentCount: allArts.length,
+            categories: Array.from(new Set(allArts.map((art) => art.category || "Uncategorized"))),
+            tags: Array.from(new Set(allArts.flatMap((art) => art.tags))),
           },
           null,
           2,
@@ -192,12 +249,93 @@ export async function handleGetTokens(
   }
 
   const categories = await parseTokensFromPath(resolvedPath);
+  const flattened = flattenTokenCategories(categories);
 
   if (format === "markdown") {
-    return { content: [{ type: "text", text: generateTokensMarkdown(categories) }] };
+    return {
+      content: [
+        {
+          type: "text",
+          text: generateTokensMarkdown(categories),
+        },
+      ],
+    };
   }
 
   return {
-    content: [{ type: "text", text: JSON.stringify({ categories }, null, 2) }],
+    content: [
+      {
+        type: "text",
+        text: JSON.stringify(
+          {
+            source: path.relative(ctx.projectRoot, resolvedPath),
+            categoryCount: categories.length,
+            tokenCount: flattened.length,
+            categories,
+          },
+          null,
+          2,
+        ),
+      },
+    ],
+  };
+}
+
+export async function handleSearchTokens(
+  ctx: ServerContext,
+  args: Record<string, unknown> | undefined,
+): Promise<ToolResult> {
+  const query = args?.query as string | undefined;
+  if (!query) {
+    throw new McpError(ErrorCode.InvalidParams, "query is required");
+  }
+
+  const inputPath = args?.tokensPath as string | undefined;
+  const typeFilter = typeof args?.type === "string" ? args.type.toLowerCase() : undefined;
+  const limit = typeof args?.limit === "number" ? args.limit : 20;
+  const resolvedPath = inputPath
+    ? path.resolve(ctx.projectRoot, inputPath)
+    : await ctx.resolveTokensPath();
+
+  if (!resolvedPath) {
+    throw new McpError(
+      ErrorCode.InvalidParams,
+      "No tokens path provided and none auto-detected. Looked for: tokens/, design-tokens/, style-dictionary/ directories.",
+    );
+  }
+
+  const flattened = flattenTokenCategories(await parseTokensFromPath(resolvedPath));
+  const normalizedQuery = query.toLowerCase();
+
+  const allMatches = flattened.filter((token) => {
+    if (typeFilter && token.type?.toLowerCase() !== typeFilter) {
+      return false;
+    }
+    return (
+      token.name.toLowerCase().includes(normalizedQuery) ||
+      token.path.toLowerCase().includes(normalizedQuery) ||
+      token.categoryPath.some((segment) => segment.toLowerCase().includes(normalizedQuery)) ||
+      String(token.value).toLowerCase().includes(normalizedQuery) ||
+      token.description?.toLowerCase().includes(normalizedQuery)
+    );
+  });
+  const matches = allMatches.slice(0, limit);
+
+  return {
+    content: [
+      {
+        type: "text",
+        text: JSON.stringify(
+          {
+            query,
+            source: path.relative(ctx.projectRoot, resolvedPath),
+            totalMatches: allMatches.length,
+            matches,
+          },
+          null,
+          2,
+        ),
+      },
+    ],
   };
 }

--- a/npm/musea-mcp-server/src/tools/handler/index.ts
+++ b/npm/musea-mcp-server/src/tools/handler/index.ts
@@ -14,6 +14,7 @@ import {
   handleGetComponent,
   handleGetVariant,
   handleSearchComponents,
+  handleRecommendComponents,
 } from "./registry.js";
 import {
   handleGenerateVariants,
@@ -21,6 +22,7 @@ import {
   handleGenerateDocs,
   handleGenerateCatalog,
   handleGetTokens,
+  handleSearchTokens,
 } from "./generation.js";
 
 export type { ToolResult };
@@ -48,6 +50,8 @@ export async function handleToolCall(
       return handleGetVariant(ctx, binding, args);
     case "search_components":
       return handleSearchComponents(ctx, args);
+    case "recommend_components":
+      return handleRecommendComponents(ctx, args);
 
     // --- Code generation / docs / tokens ------------------------------------
     case "generate_variants":
@@ -60,6 +64,8 @@ export async function handleToolCall(
       return handleGenerateCatalog(ctx, binding, args);
     case "get_tokens":
       return handleGetTokens(ctx, args);
+    case "search_tokens":
+      return handleSearchTokens(ctx, args);
 
     default:
       throw new McpError(ErrorCode.MethodNotFound, `Unknown tool: ${name}`);

--- a/npm/musea-mcp-server/src/tools/handler/registry.ts
+++ b/npm/musea-mcp-server/src/tools/handler/registry.ts
@@ -1,31 +1,90 @@
 /**
  * MCP tool handlers for the component registry.
  *
- * Handles `list_components`, `get_component`, `get_variant`, and
- * `search_components` tool calls.
+ * Handles `list_components`, `get_component`, `get_variant`, `search_components`,
+ * and `recommend_components` tool calls.
  */
 
 import fs from "node:fs";
-import path from "node:path";
 import { ErrorCode, McpError } from "@modelcontextprotocol/sdk/types.js";
+import {
+  analyzeResolvedComponent,
+  buildComponentDetails,
+  getProjectPath,
+  resolveArtReference,
+  searchArtInfos,
+} from "../../musea.js";
 import type { ServerContext, ToolResult } from "./types.js";
+
+function buildResourceUris(relativePath: string, variantNames: string[], hasComponent: boolean) {
+  const encodedPath = encodeURIComponent(relativePath);
+  return {
+    component: `musea://component/${encodedPath}`,
+    docs: `musea://docs/${encodedPath}`,
+    source: `musea://source/${encodedPath}`,
+    componentSource: hasComponent ? `musea://component-source/${encodedPath}` : undefined,
+    variants: variantNames.map((variantName) => ({
+      name: variantName,
+      uri: `musea://variant/${encodedPath}/${encodeURIComponent(variantName)}`,
+    })),
+  };
+}
 
 export async function handleListComponents(
   ctx: ServerContext,
   args: Record<string, unknown> | undefined,
 ): Promise<ToolResult> {
-  const arts = await ctx.scanArtFiles();
-  let results = Array.from(arts.values());
+  const arts = Array.from((await ctx.scanArtFiles()).values());
+  const category = typeof args?.category === "string" ? args.category.toLowerCase() : undefined;
+  const tag = typeof args?.tag === "string" ? args.tag.toLowerCase() : undefined;
+  const status = typeof args?.status === "string" ? args.status.toLowerCase() : undefined;
+  const component = typeof args?.component === "string" ? args.component.toLowerCase() : undefined;
+  const limit = typeof args?.limit === "number" ? args.limit : undefined;
+  const includeVariants = args?.includeVariants === true;
+  const sortBy = typeof args?.sortBy === "string" ? args.sortBy : "title";
 
-  if (args?.category) {
-    results = results.filter(
-      (a) => a.category?.toLowerCase() === (args.category as string).toLowerCase(),
-    );
-  }
-  if (args?.tag) {
-    results = results.filter((a) =>
-      a.tags.some((t) => t.toLowerCase() === (args.tag as string).toLowerCase()),
-    );
+  let results = arts.filter((info) => {
+    if (category && info.category?.toLowerCase() !== category) return false;
+    if (tag && !info.tags.some((item) => item.toLowerCase() === tag)) return false;
+    if (status && info.status.toLowerCase() !== status) return false;
+    if (
+      component &&
+      ![
+        info.component,
+        info.component ? info.component.split("/").at(-1) : undefined,
+        info.component
+          ? info.component
+              .split("/")
+              .at(-1)
+              ?.replace(/\.\w+$/, "")
+          : undefined,
+      ]
+        .filter((value): value is string => Boolean(value))
+        .some((value) => value.toLowerCase().includes(component))
+    ) {
+      return false;
+    }
+    return true;
+  });
+
+  results = results.sort((left, right) => {
+    if (sortBy === "category") {
+      return (
+        (left.category || "").localeCompare(right.category || "") ||
+        left.title.localeCompare(right.title)
+      );
+    }
+    if (sortBy === "status") {
+      return left.status.localeCompare(right.status) || left.title.localeCompare(right.title);
+    }
+    if (sortBy === "variants") {
+      return right.variantCount - left.variantCount || left.title.localeCompare(right.title);
+    }
+    return left.title.localeCompare(right.title);
+  });
+
+  if (typeof limit === "number") {
+    results = results.slice(0, limit);
   }
 
   return {
@@ -33,15 +92,36 @@ export async function handleListComponents(
       {
         type: "text",
         text: JSON.stringify(
-          results.map((r) => ({
-            path: path.relative(ctx.projectRoot, r.path),
-            title: r.title,
-            description: r.description,
-            component: r.component,
-            category: r.category,
-            tags: r.tags,
-            variantCount: r.variantCount,
-          })),
+          results.map((info) => {
+            const relativePath = getProjectPath(ctx.projectRoot, info.path);
+            return {
+              path: relativePath,
+              title: info.title,
+              description: info.description,
+              component: info.component,
+              category: info.category,
+              status: info.status,
+              order: info.order,
+              tags: info.tags,
+              variantCount: info.variantCount,
+              variantNames: info.variantNames,
+              defaultVariant: info.defaultVariant,
+              variants: includeVariants
+                ? info.variantNames.map((variantName) => ({
+                    name: variantName,
+                    isDefault: variantName === info.defaultVariant,
+                    uri: `musea://variant/${encodeURIComponent(relativePath)}/${encodeURIComponent(
+                      variantName,
+                    )}`,
+                  }))
+                : undefined,
+              resources: buildResourceUris(
+                relativePath,
+                info.variantNames,
+                Boolean(info.component),
+              ),
+            };
+          }),
           null,
           2,
         ),
@@ -55,35 +135,15 @@ export async function handleGetComponent(
   binding: ReturnType<ServerContext["loadNative"]>,
   args: Record<string, unknown> | undefined,
 ): Promise<ToolResult> {
-  const artPath = args?.path as string;
-  if (!artPath) throw new McpError(ErrorCode.InvalidParams, "path is required");
-
-  const absolutePath = path.resolve(ctx.projectRoot, artPath);
-  const source = await fs.promises.readFile(absolutePath, "utf-8");
-  const parsed = binding.parseArt(source, { filename: absolutePath });
+  const resolved = await resolveArtReference(ctx, args);
+  const details = await buildComponentDetails(ctx, binding, resolved, {
+    includeAnalysis: args?.includeAnalysis !== false,
+    includePalette: args?.includePalette !== false,
+    includeDocumentation: args?.includeDocumentation === true,
+  });
 
   return {
-    content: [
-      {
-        type: "text",
-        text: JSON.stringify(
-          {
-            metadata: parsed.metadata,
-            variants: parsed.variants.map((v) => ({
-              name: v.name,
-              template: v.template,
-              isDefault: v.is_default,
-              skipVrt: v.skip_vrt,
-            })),
-            hasScriptSetup: parsed.has_script_setup,
-            hasScript: parsed.has_script,
-            styleCount: parsed.style_count,
-          },
-          null,
-          2,
-        ),
-      },
-    ],
+    content: [{ type: "text", text: JSON.stringify(details, null, 2) }],
   };
 }
 
@@ -92,20 +152,27 @@ export async function handleGetVariant(
   binding: ReturnType<ServerContext["loadNative"]>,
   args: Record<string, unknown> | undefined,
 ): Promise<ToolResult> {
-  const artPath = args?.path as string;
-  const variantName = args?.variant as string;
-  if (!artPath || !variantName) {
-    throw new McpError(ErrorCode.InvalidParams, "path and variant are required");
+  const variantName = args?.variant as string | undefined;
+  if (!variantName) {
+    throw new McpError(ErrorCode.InvalidParams, "variant is required");
   }
 
-  const absolutePath = path.resolve(ctx.projectRoot, artPath);
-  const source = await fs.promises.readFile(absolutePath, "utf-8");
-  const parsed = binding.parseArt(source, { filename: absolutePath });
+  const resolved = await resolveArtReference(ctx, args);
+  const source = await fs.promises.readFile(resolved.absolutePath, "utf-8");
+  const parsed = binding.parseArt(source, { filename: resolved.absolutePath });
 
-  const variant = parsed.variants.find((v) => v.name.toLowerCase() === variantName.toLowerCase());
+  const variant = parsed.variants.find(
+    (item) => item.name.toLowerCase() === variantName.toLowerCase(),
+  );
   if (!variant) {
-    throw new McpError(ErrorCode.InvalidParams, `Variant "${variantName}" not found`);
+    throw new McpError(
+      ErrorCode.InvalidParams,
+      `Variant "${variantName}" not found in "${resolved.info.title}"`,
+    );
   }
+
+  const analysis =
+    args?.includeAnalysis === true ? await analyzeResolvedComponent(ctx, binding, resolved) : null;
 
   return {
     content: [
@@ -113,10 +180,33 @@ export async function handleGetVariant(
         type: "text",
         text: JSON.stringify(
           {
-            name: variant.name,
-            template: variant.template,
-            isDefault: variant.is_default,
-            skipVrt: variant.skip_vrt,
+            component: {
+              title: resolved.info.title,
+              path: resolved.relativePath,
+              componentReference: resolved.info.component,
+            },
+            match: {
+              matchedBy: resolved.matchedBy,
+              matchValue: resolved.matchValue,
+              score: resolved.score,
+              reasons: resolved.reasons,
+              alternatives: resolved.alternatives,
+            },
+            variant: {
+              name: variant.name,
+              template: variant.template,
+              isDefault: variant.is_default,
+              skipVrt: variant.skip_vrt,
+            },
+            relatedVariants: parsed.variants.map((item) => item.name),
+            componentAnalysis:
+              analysis?.analysis == null
+                ? undefined
+                : {
+                    path: analysis.analysis.path,
+                    props: analysis.analysis.props,
+                    emits: analysis.analysis.emits,
+                  },
           },
           null,
           2,
@@ -130,30 +220,93 @@ export async function handleSearchComponents(
   ctx: ServerContext,
   args: Record<string, unknown> | undefined,
 ): Promise<ToolResult> {
-  const query = (args?.query as string)?.toLowerCase();
-  if (!query) throw new McpError(ErrorCode.InvalidParams, "query is required");
+  const query = args?.query as string | undefined;
+  if (!query) {
+    throw new McpError(ErrorCode.InvalidParams, "query is required");
+  }
 
-  const arts = await ctx.scanArtFiles();
-  const results = Array.from(arts.values()).filter(
-    (a) =>
-      a.title.toLowerCase().includes(query) ||
-      a.description?.toLowerCase().includes(query) ||
-      a.tags.some((t) => t.toLowerCase().includes(query)),
-  );
+  const results = await searchArtInfos(ctx, query, {
+    category: args?.category as string | undefined,
+    tag: args?.tag as string | undefined,
+    status: args?.status as string | undefined,
+    component: args?.component as string | undefined,
+    limit: (args?.limit as number | undefined) ?? 10,
+  });
 
   return {
     content: [
       {
         type: "text",
         text: JSON.stringify(
-          results.map((r) => ({
-            path: path.relative(ctx.projectRoot, r.path),
-            title: r.title,
-            description: r.description,
-            component: r.component,
-            category: r.category,
-            tags: r.tags,
+          results.map((result) => ({
+            score: result.score,
+            reasons: result.reasons,
+            path: result.relativePath,
+            title: result.info.title,
+            description: result.info.description,
+            component: result.info.component,
+            category: result.info.category,
+            status: result.info.status,
+            tags: result.info.tags,
+            variantCount: result.info.variantCount,
+            variantNames: result.info.variantNames,
+            defaultVariant: result.info.defaultVariant,
+            resources: buildResourceUris(
+              result.relativePath,
+              result.info.variantNames,
+              Boolean(result.info.component),
+            ),
           })),
+          null,
+          2,
+        ),
+      },
+    ],
+  };
+}
+
+export async function handleRecommendComponents(
+  ctx: ServerContext,
+  args: Record<string, unknown> | undefined,
+): Promise<ToolResult> {
+  const task = args?.task as string | undefined;
+  if (!task) {
+    throw new McpError(ErrorCode.InvalidParams, "task is required");
+  }
+
+  const results = await searchArtInfos(ctx, task, {
+    category: args?.category as string | undefined,
+    tag: args?.tag as string | undefined,
+    status: args?.status as string | undefined,
+    component: args?.component as string | undefined,
+    limit: (args?.limit as number | undefined) ?? 5,
+  });
+
+  return {
+    content: [
+      {
+        type: "text",
+        text: JSON.stringify(
+          {
+            task,
+            recommendations: results.map((result) => ({
+              title: result.info.title,
+              path: result.relativePath,
+              component: result.info.component,
+              category: result.info.category,
+              status: result.info.status,
+              tags: result.info.tags,
+              variantNames: result.info.variantNames,
+              defaultVariant: result.info.defaultVariant,
+              score: result.score,
+              why: result.reasons,
+              resources: buildResourceUris(
+                result.relativePath,
+                result.info.variantNames,
+                Boolean(result.info.component),
+              ),
+            })),
+          },
           null,
           2,
         ),

--- a/npm/musea-mcp-server/src/types.ts
+++ b/npm/musea-mcp-server/src/types.ts
@@ -126,7 +126,11 @@ export interface ArtInfo {
   component?: string;
   category?: string;
   tags: string[];
+  status: string;
+  order?: number;
   variantCount: number;
+  variantNames: string[];
+  defaultVariant?: string;
 }
 
 export interface ServerContext {


### PR DESCRIPTION
## Summary

- enrich the Musea MCP server with richer component lookup and fuzzy reference resolution
- add practical MCP tools for recommendations and token search
- expose richer resources for component index, catalog, docs, variants, sources, and token markdown
- update the package README to reflect the expanded MCP surface area

## Why

The existing MCP server worked, but it was still too path-driven and sparse for day-to-day assistant workflows. These changes make it easier for an assistant to discover components, resolve intent, gather the right context, and answer with less back-and-forth.

## Validation

- `pnpm --filter @vizejs/musea-mcp-server run check`
- `pnpm --filter @vizejs/musea-mcp-server run build`
