### PR TITLE
perf: tighten bench and profile workflows

### DIFF
--- a/bench/check.ts
+++ b/bench/check.ts
@@ -7,7 +7,7 @@
  *   3. Run benchmark: node bench/check.ts
  */
 
-import { existsSync, mkdirSync, readdirSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { copyFileSync, existsSync, mkdirSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, join, relative } from "node:path";
 import { execSync } from "node:child_process";
@@ -57,7 +57,7 @@ function prepareBenchInputDir(selectedVueFiles: string[], totalVueFileCount: num
   mkdirSync(subsetDir, { recursive: true });
 
   for (const vueFile of selectedVueFiles) {
-    symlinkSync(join(INPUT_DIR, vueFile), join(subsetDir, vueFile));
+    copyFileSync(join(INPUT_DIR, vueFile), join(subsetDir, vueFile));
   }
 
   const tsconfigPath = join(subsetDir, "tsconfig.json");

--- a/bench/lint.ts
+++ b/bench/lint.ts
@@ -49,8 +49,29 @@ function formatThroughput(fileCount: number, ms: number): string {
   return `${filesPerSec.toFixed(0)} files/s`;
 }
 
+let eslintAvailability: boolean | undefined;
+
+async function hasEslintPackage(): Promise<boolean> {
+  if (eslintAvailability != null) {
+    return eslintAvailability;
+  }
+
+  try {
+    await import("eslint");
+    eslintAvailability = true;
+  } catch {
+    eslintAvailability = false;
+  }
+
+  return eslintAvailability;
+}
+
 // ESLint single-thread: use Node.js API
 async function runEslintSingleThread(): Promise<number> {
+  if (!(await hasEslintPackage())) {
+    return -1;
+  }
+
   const { ESLint } = await import("eslint");
   const eslint = new ESLint({
     overrideConfigFile: join(INPUT_DIR, "eslint.config.mjs"),
@@ -69,6 +90,10 @@ async function runEslintSingleThread(): Promise<number> {
 
 // ESLint multi-thread: worker threads
 async function runEslintMultiThread(): Promise<number> {
+  if (!(await hasEslintPackage())) {
+    return -1;
+  }
+
   const workerCount = CPU_COUNT;
   const chunkSize = Math.ceil(vueFiles.length / workerCount);
 
@@ -128,11 +153,11 @@ function execIgnoreExit(cmd: string): void {
 function runVizeLintSingleThread(): number {
   // Warmup
   for (let i = 0; i < 3; i++) {
-    execIgnoreExit(`RAYON_NUM_THREADS=1 ${VIZE_BIN} lint '${GLOB_PATTERN}'`);
+    execIgnoreExit(`RAYON_NUM_THREADS=1 ${VIZE_BIN} lint '${GLOB_PATTERN}' --quiet`);
   }
 
   const start = performance.now();
-  execIgnoreExit(`RAYON_NUM_THREADS=1 ${VIZE_BIN} lint '${GLOB_PATTERN}'`);
+  execIgnoreExit(`RAYON_NUM_THREADS=1 ${VIZE_BIN} lint '${GLOB_PATTERN}' --quiet`);
   return performance.now() - start;
 }
 
@@ -140,11 +165,11 @@ function runVizeLintSingleThread(): number {
 function runVizeLintMultiThread(): number {
   // Warmup
   for (let i = 0; i < 3; i++) {
-    execIgnoreExit(`${VIZE_BIN} lint '${GLOB_PATTERN}'`);
+    execIgnoreExit(`${VIZE_BIN} lint '${GLOB_PATTERN}' --quiet`);
   }
 
   const start = performance.now();
-  execIgnoreExit(`${VIZE_BIN} lint '${GLOB_PATTERN}'`);
+  execIgnoreExit(`${VIZE_BIN} lint '${GLOB_PATTERN}' --quiet`);
   return performance.now() - start;
 }
 
@@ -166,17 +191,27 @@ console.log(" Single Thread:");
 console.log();
 
 const eslintSingle = await runEslintSingleThread();
-console.log(
-  `   eslint-plugin-vue : ${formatTime(eslintSingle).padStart(8)}  (${formatThroughput(vueFiles.length, eslintSingle)})`,
-);
+if (eslintSingle >= 0) {
+  console.log(
+    `   eslint-plugin-vue : ${formatTime(eslintSingle).padStart(8)}  (${formatThroughput(vueFiles.length, eslintSingle)})`,
+  );
+} else {
+  console.log("   eslint-plugin-vue : SKIPPED (eslint not found)");
+}
 
 let vizeSingle = 0;
 if (existsSync(VIZE_BIN)) {
   vizeSingle = runVizeLintSingleThread();
-  const speedup = (eslintSingle / vizeSingle).toFixed(1);
-  console.log(
-    `   Vize (patina)     : ${formatTime(vizeSingle).padStart(8)}  (${formatThroughput(vueFiles.length, vizeSingle)})  ${speedup}x faster`,
-  );
+  if (eslintSingle >= 0) {
+    const speedup = (eslintSingle / vizeSingle).toFixed(1);
+    console.log(
+      `   Vize (patina)     : ${formatTime(vizeSingle).padStart(8)}  (${formatThroughput(vueFiles.length, vizeSingle)})  ${speedup}x faster`,
+    );
+  } else {
+    console.log(
+      `   Vize (patina)     : ${formatTime(vizeSingle).padStart(8)}  (${formatThroughput(vueFiles.length, vizeSingle)})`,
+    );
+  }
 } else {
   console.log("   Vize (patina)     : SKIPPED (vize CLI not found)");
 }
@@ -187,23 +222,33 @@ console.log(` Multi Thread (${CPU_COUNT} workers):`);
 console.log();
 
 const eslintMulti = await runEslintMultiThread();
-console.log(
-  `   eslint-plugin-vue : ${formatTime(eslintMulti).padStart(8)}  (${formatThroughput(vueFiles.length, eslintMulti)})`,
-);
+if (eslintMulti >= 0) {
+  console.log(
+    `   eslint-plugin-vue : ${formatTime(eslintMulti).padStart(8)}  (${formatThroughput(vueFiles.length, eslintMulti)})`,
+  );
+} else {
+  console.log("   eslint-plugin-vue : SKIPPED (eslint not found)");
+}
 
 let vizeMulti = 0;
 if (existsSync(VIZE_BIN)) {
   vizeMulti = runVizeLintMultiThread();
-  const speedup = (eslintMulti / vizeMulti).toFixed(1);
-  console.log(
-    `   Vize (patina)     : ${formatTime(vizeMulti).padStart(8)}  (${formatThroughput(vueFiles.length, vizeMulti)})  ${speedup}x faster`,
-  );
+  if (eslintMulti >= 0) {
+    const speedup = (eslintMulti / vizeMulti).toFixed(1);
+    console.log(
+      `   Vize (patina)     : ${formatTime(vizeMulti).padStart(8)}  (${formatThroughput(vueFiles.length, vizeMulti)})  ${speedup}x faster`,
+    );
+  } else {
+    console.log(
+      `   Vize (patina)     : ${formatTime(vizeMulti).padStart(8)}  (${formatThroughput(vueFiles.length, vizeMulti)})`,
+    );
+  }
 } else {
   console.log("   Vize (patina)     : SKIPPED (vize CLI not found)");
 }
 
 // Summary
-if (vizeSingle > 0 && vizeMulti > 0) {
+if (eslintSingle >= 0 && eslintMulti >= 0 && vizeSingle > 0 && vizeMulti > 0) {
   console.log();
   console.log("-".repeat(65));
   console.log();

--- a/crates/vize/src/commands/lint.rs
+++ b/crates/vize/src/commands/lint.rs
@@ -63,6 +63,11 @@ pub struct LintArgs {
 
 pub fn run(args: LintArgs) {
     let start = Instant::now();
+    let format = match args.format.as_str() {
+        "json" => OutputFormat::Json,
+        _ => OutputFormat::Text,
+    };
+    let render_details = should_render_lint_details(format, args.quiet);
 
     // Collect .vue files using glob patterns or directory walking
     let collect_start = Instant::now();
@@ -180,15 +185,9 @@ pub fn run(args: LintArgs) {
     let total_errors = error_count.load(Ordering::Relaxed);
     let total_warnings = warning_count.load(Ordering::Relaxed);
 
-    // Determine output format
-    let format = match args.format.as_str() {
-        "json" => OutputFormat::Json,
-        _ => OutputFormat::Text,
-    };
-
     // Format and print results
     let output_start = Instant::now();
-    if !args.quiet || total_errors > 0 || total_warnings > 0 {
+    if render_details {
         let lint_results: Vec<_> = results.iter().map(|(_, _, r)| r).cloned().collect();
         let sources: Vec<_> = results
             .iter()
@@ -322,5 +321,26 @@ pub fn run(args: LintArgs) {
             eprintln!("\nToo many warnings ({} > max {})", total_warnings, max);
             std::process::exit(1);
         }
+    }
+}
+
+#[inline]
+fn should_render_lint_details(format: OutputFormat, quiet: bool) -> bool {
+    matches!(format, OutputFormat::Json) || !quiet
+}
+
+#[cfg(test)]
+mod tests {
+    use super::should_render_lint_details;
+    use vize_patina::OutputFormat;
+
+    #[test]
+    fn quiet_text_output_skips_detailed_diagnostics() {
+        assert!(!should_render_lint_details(OutputFormat::Text, true));
+    }
+
+    #[test]
+    fn json_output_remains_machine_readable_in_quiet_mode() {
+        assert!(should_render_lint_details(OutputFormat::Json, true));
     }
 }

--- a/crates/vize_canon/src/lsp_client/diagnostics.rs
+++ b/crates/vize_canon/src/lsp_client/diagnostics.rs
@@ -22,6 +22,7 @@ use std::{
 use vize_carton::{cstr, FxHashMap, String};
 
 type DiagnosticBatch = Vec<(String, Vec<LspDiagnostic>)>;
+const LSP_DIAGNOSTICS_BATCH_CHUNK_SIZE: usize = 128;
 
 impl CorsaProjectClient {
     /// Get cached diagnostics for a URI.
@@ -365,6 +366,30 @@ impl CorsaProjectClient {
     }
 
     fn request_diagnostics_batch_via_lsp(
+        &mut self,
+        uris: &[String],
+    ) -> Result<Option<DiagnosticBatch>, String> {
+        if uris.is_empty() {
+            return Ok(Some(Vec::new()));
+        }
+
+        if uris.len() > LSP_DIAGNOSTICS_BATCH_CHUNK_SIZE {
+            let mut results = Vec::with_capacity(uris.len());
+            for chunk in uris.chunks(LSP_DIAGNOSTICS_BATCH_CHUNK_SIZE) {
+                let Some(mut chunk_results) =
+                    self.request_diagnostics_batch_via_lsp_chunk(chunk)?
+                else {
+                    return Ok(None);
+                };
+                results.append(&mut chunk_results);
+            }
+            return Ok(Some(results));
+        }
+
+        self.request_diagnostics_batch_via_lsp_chunk(uris)
+    }
+
+    fn request_diagnostics_batch_via_lsp_chunk(
         &mut self,
         uris: &[String],
     ) -> Result<Option<DiagnosticBatch>, String> {


### PR DESCRIPTION
## Summary
- make `lint --quiet` skip detailed text rendering while keeping JSON output machine-readable
- harden the benchmark harnesses so missing `eslint` and subset inputs do not produce misleading results
- chunk LSP diagnostic fallback requests to avoid queue saturation during large `check` profiling runs

## Why
The tuning work exposed two sources of noise and instability:
- quiet text lint runs were still paying the full diagnostic rendering cost
- large type-check profiling runs could fail when the fallback LSP path opened too many overlays at once

These changes make the benchmark and profile numbers more trustworthy and keep larger `check` runs from failing early.

## Impact
- faster user-facing `lint --quiet` runs
- more reliable local benchmark output for `bench/lint.ts` and `bench/check.ts`
- more stable `check --profile` behavior on larger file sets

## Validation
- `cargo test -p vize --bin vize commands::lint::tests`
- `node bench/lint.ts`
- `node bench/check.ts 1000`
- `node bench/check.ts`
