### PR TITLE
feat(tokenizer): implement HTML special tag parsing (RCDATA & RAWTEXT)

### DIFF
--- a/crates/vize_armature/src/tokenizer/mod.rs
+++ b/crates/vize_armature/src/tokenizer/mod.rs
@@ -47,6 +47,9 @@ pub struct Tokenizer<'a, C: Callbacks> {
     current_sequence: Option<Sequence>,
     /// Index of the next expected byte in that sequence.
     sequence_index: usize,
+
+    /// For special parsing behavior inside of script and style tags.
+    in_rcdata: bool,
 }
 
 impl<'a, C: Callbacks> Tokenizer<'a, C> {
@@ -77,6 +80,7 @@ impl<'a, C: Callbacks> Tokenizer<'a, C> {
             base_state: State::Text,
             current_sequence: None,
             sequence_index: 0,
+            in_rcdata: false,
         }
     }
 

--- a/crates/vize_armature/src/tokenizer/sequences.rs
+++ b/crates/vize_armature/src/tokenizer/sequences.rs
@@ -1,12 +1,20 @@
 const CDATA: &[u8] = b"CDATA[";
 const CDATA_END: &[u8] = b"]]>";
 const COMMENT_END: &[u8] = b"-->";
+const TITLE_END: &[u8] = b"</title";
+const TEXTAREA_END: &[u8] = b"</textarea";
+const SCRIPT_END: &[u8] = b"</script";
+const STYLE_END: &[u8] = b"</style";
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub(super) enum Sequence {
     Cdata,
     CdataEnd,
     CommentEnd,
+    TitleEnd,
+    TextareaEnd,
+    ScriptEnd,
+    StyleEnd,
 }
 
 impl Sequence {
@@ -16,6 +24,10 @@ impl Sequence {
             Self::Cdata => CDATA,
             Self::CdataEnd => CDATA_END,
             Self::CommentEnd => COMMENT_END,
+            Self::TitleEnd => TITLE_END,
+            Self::TextareaEnd => TEXTAREA_END,
+            Self::ScriptEnd => SCRIPT_END,
+            Self::StyleEnd => STYLE_END,
         }
     }
 }

--- a/crates/vize_armature/src/tokenizer/states.rs
+++ b/crates/vize_armature/src/tokenizer/states.rs
@@ -92,6 +92,9 @@ impl<'a, C: Callbacks> Tokenizer<'a, C> {
                 self.state = State::Interpolation;
                 self.delimiter_index = 0;
             }
+        } else if self.in_rcdata {
+            self.state = State::InRCDATA;
+            self.state_in_rcdata(c);
         } else {
             self.state = State::Text;
             self.state_text(c);
@@ -114,8 +117,12 @@ impl<'a, C: Callbacks> Tokenizer<'a, C> {
                     self.section_start,
                     self.index + 1 - self.delimiter_close.len(),
                 );
+                if self.in_rcdata {
+                    self.state = State::InRCDATA
+                } else {
+                    self.state = State::Text
+                }
                 self.section_start = self.index + 1;
-                self.state = State::Text;
             }
         } else {
             self.state = State::Interpolation;
@@ -132,7 +139,13 @@ impl<'a, C: Callbacks> Tokenizer<'a, C> {
             self.section_start = self.index + 1;
         } else if is_tag_start_char(c) {
             self.section_start = self.index;
-            self.state = State::InTagName;
+            if c == b't' {
+                self.state = State::BeforeSpecialT;
+            } else if c == b's' {
+                self.state = State::BeforeSpecialS;
+            } else {
+                self.state = State::InTagName;
+            }
         } else if c == SLASH {
             self.state = State::BeforeClosingTagName;
         } else {
@@ -198,7 +211,11 @@ impl<'a, C: Callbacks> Tokenizer<'a, C> {
     pub(super) fn state_before_attr_name(&mut self, c: u8) {
         if c == GT {
             self.callbacks.on_open_tag_end(self.index);
-            self.state = State::Text;
+            if self.in_rcdata {
+                self.state = State::InRCDATA;
+            } else {
+                self.state = State::Text;
+            }
             self.section_start = self.index + 1;
         } else if c == SLASH {
             self.state = State::InSelfClosingTag;
@@ -449,11 +466,16 @@ impl<'a, C: Callbacks> Tokenizer<'a, C> {
         self.state = State::Text;
     }
 
+    #[inline]
+    fn current_sequence_with_bytes(&self) -> (Sequence, &'static [u8]) {
+        let sequence = self
+            .current_sequence
+            .expect("current_sequence must be set in this state");
+        (sequence, sequence.bytes())
+    }
+
     pub(super) fn state_in_comment_like(&mut self, c: u8) {
-        let Some(sequence) = self.current_sequence else {
-            return;
-        };
-        let sequence_bytes = sequence.bytes();
+        let (sequence, sequence_bytes) = self.current_sequence_with_bytes();
 
         if c == sequence_bytes[self.sequence_index] {
             self.sequence_index += 1;
@@ -471,23 +493,108 @@ impl<'a, C: Callbacks> Tokenizer<'a, C> {
         }
     }
 
-    pub(super) fn state_before_special_s(&mut self, _c: u8) {
-        // TODO: Handle script/style
-        self.state = State::InTagName;
+    // </script
+    // </style
+    pub(super) fn state_before_special_s(&mut self, c: u8) {
+        if c == Sequence::ScriptEnd.bytes()[3] {
+            self.start_special(Sequence::ScriptEnd, 4);
+        } else if c == Sequence::StyleEnd.bytes()[3] {
+            self.start_special(Sequence::StyleEnd, 4);
+        } else {
+            self.state = State::InTagName;
+            self.state_in_tag_name(c);
+        }
     }
 
-    pub(super) fn state_before_special_t(&mut self, _c: u8) {
-        // TODO: Handle title/textarea
-        self.state = State::InTagName;
+    // </title>
+    // </textarea>
+    pub(super) fn state_before_special_t(&mut self, c: u8) {
+        if c == Sequence::TitleEnd.bytes()[3] {
+            self.start_special(Sequence::TitleEnd, 4);
+        } else if c == Sequence::TextareaEnd.bytes()[3] {
+            self.start_special(Sequence::TextareaEnd, 4);
+        } else {
+            self.state = State::InTagName;
+            self.state_in_tag_name(c);
+        }
     }
 
-    pub(super) fn state_special_start_sequence(&mut self, _c: u8) {
-        self.state = State::InTagName;
+    pub(super) fn enter_rcdata(&mut self, sequence: Sequence, offset: usize) {
+        self.in_rcdata = true;
+        self.current_sequence = Some(sequence);
+        self.sequence_index = offset;
     }
 
+    fn start_special(&mut self, sequence: Sequence, offset: usize) {
+        self.enter_rcdata(sequence, offset);
+        self.state = State::SpecialStartSequence;
+    }
+
+    pub(super) fn state_special_start_sequence(&mut self, c: u8) {
+        let (_, sequence_bytes) = self.current_sequence_with_bytes();
+
+        let is_end = self.sequence_index == sequence_bytes.len();
+        let is_match = if is_end {
+            is_end_of_tag_section(c)
+        } else {
+            (c | 0x20) == sequence_bytes[self.sequence_index]
+        };
+
+        if !is_match {
+            self.in_rcdata = false;
+        } else if !is_end {
+            self.sequence_index += 1;
+            return;
+        }
+
+        self.sequence_index = 0;
+        self.state = State::InTagName;
+        self.state_in_tag_name(c);
+    }
+
+    // Look for an end tag. For `<title>` and `<textarea>`, also decode entities and handle
+    // interpolation
     pub(super) fn state_in_rcdata(&mut self, c: u8) {
-        if c == LT {
-            self.state = State::BeforeTagName;
+        let (sequence, sequence_bytes) = self.current_sequence_with_bytes();
+
+        if self.sequence_index == sequence_bytes.len() {
+            if c == GT || is_whitespace(c) {
+                let end_of_text: usize = self.index - sequence_bytes.len();
+                if self.section_start < end_of_text {
+                    let actual_index = self.index;
+                    self.index = end_of_text;
+                    self.callbacks.on_text(self.section_start, end_of_text);
+                    self.index = actual_index;
+                }
+                self.section_start = end_of_text + 2; // Skip over the `</`
+                self.state_in_closing_tag_name(c);
+                self.in_rcdata = false;
+                return;
+            }
+
+            self.sequence_index = 0;
+        }
+
+        if (c | 0x20) == sequence_bytes[self.sequence_index] {
+            self.sequence_index += 1;
+        } else if self.sequence_index == 0 {
+            // TODO(SFC root): align with vue-core `(TextareaEnd && !inSFCRoot)` — `<textarea>` at SFC
+            // file root should behave as RAWTEXT (no `&`/interpolation here); not distinguished yet.
+            if matches!(sequence, Sequence::TitleEnd | Sequence::TextareaEnd) {
+                if c == AMP {
+                    self.start_entity();
+                } else if !self.callbacks.is_in_v_pre() && c == self.delimiter_open[0] {
+                    self.state = State::InterpolationOpen;
+                    self.delimiter_index = 0;
+                    self.state_interpolation_open(c);
+                }
+            } else if self.fast_forward_to(LT) {
+                // Outside of `<title>` / `<textarea>`, skip ahead to the next `<` (script/style RAWTEXT).
+                self.sequence_index = 1;
+            }
+        } else {
+            // If we see `<`, set the sequence index to 1; useful for e.g. `<</script>`.
+            self.sequence_index = if c == LT { 1 } else { 0 };
         }
     }
 

--- a/crates/vize_armature/src/tokenizer/tests.rs
+++ b/crates/vize_armature/src/tokenizer/tests.rs
@@ -418,7 +418,6 @@ fn test_entity_attr_single_quote_and_text() {
     let cb = tokenize("<div data='&amp;'>>&amp;</div>");
     assert!(cb.events.contains(&TokenEvent::AttribEntity('&', 11, 16)));
     assert!(cb.events.contains(&TokenEvent::TextEntity('&', 19, 24)));
-    println!("{:?}", cb.events);
 }
 
 #[test]
@@ -489,4 +488,174 @@ fn test_entity_in_unquoted_attr_value() {
     assert!(cb
         .events
         .contains(&TokenEvent::AttribEnd(QuoteType::Unquoted, 14)));
+}
+
+// ========================================================================
+// Special tags tests
+// ========================================================================
+
+#[test]
+fn test_special_opening_script_text_and_close() {
+    let cb = tokenize("<script>a</script>");
+    assert!(cb.errors.is_empty());
+    assert!(cb.events.contains(&TokenEvent::OpenTagName(1, 7)));
+    assert!(cb.events.contains(&TokenEvent::OpenTagEnd(7)));
+    assert!(cb.events.contains(&TokenEvent::Text(8, 9)));
+    assert!(cb.events.contains(&TokenEvent::CloseTag(11, 17)));
+    assert!(cb.events.contains(&TokenEvent::End));
+}
+
+#[test]
+fn test_special_opening_script_close_tag_uppercase() {
+    let cb = tokenize("<script>a</SCRIPT>");
+    assert!(cb.errors.is_empty());
+    assert!(cb.events.contains(&TokenEvent::Text(8, 9)));
+    assert!(cb.events.contains(&TokenEvent::CloseTag(11, 17)));
+}
+
+#[test]
+fn test_special_opening_style_and_close() {
+    let cb = tokenize("<style>.a{}</style>");
+    assert!(cb.errors.is_empty());
+    assert!(cb.events.contains(&TokenEvent::OpenTagName(1, 6)));
+    // `</style` is 7 bytes; `>` at 18, closing name starts at 13
+    assert!(cb.events.contains(&TokenEvent::CloseTag(13, 18)));
+}
+
+#[test]
+fn test_special_opening_textarea_text_and_close() {
+    let cb = tokenize("<textarea>hi</textarea>");
+    assert!(cb.errors.is_empty());
+    assert!(cb.events.contains(&TokenEvent::Text(10, 12)));
+    assert!(cb.events.contains(&TokenEvent::CloseTag(14, 22)));
+}
+
+#[test]
+fn test_special_opening_title_entity_in_plain_text() {
+    let cb = tokenize("<title>a&amp;b</title>");
+    assert!(cb.errors.is_empty());
+    assert!(cb.events.contains(&TokenEvent::Text(7, 8)));
+    assert!(cb.events.contains(&TokenEvent::TextEntity('&', 8, 13)));
+    assert!(cb.events.contains(&TokenEvent::Text(13, 14)));
+    assert!(cb.events.contains(&TokenEvent::CloseTag(16, 21)));
+}
+
+#[test]
+fn test_before_special_s_falls_back_to_in_tag_name() {
+    let cb = tokenize("<sfoo x></sfoo>");
+    assert!(cb.errors.is_empty());
+    assert!(cb.events.contains(&TokenEvent::OpenTagName(1, 5)));
+    assert!(cb
+        .events
+        .iter()
+        .any(|e| matches!(e, TokenEvent::CloseTag(_, _))));
+}
+
+#[test]
+fn test_before_special_t_falls_back_to_in_tag_name() {
+    let cb = tokenize("<tfoo></tfoo>");
+    assert!(cb.errors.is_empty());
+    assert!(cb.events.contains(&TokenEvent::OpenTagName(1, 5)));
+}
+
+#[test]
+fn test_opening_tag_span_past_before_special_s() {
+    let cb = tokenize("<span>a</span>");
+    assert!(cb.errors.is_empty());
+    assert!(cb.events.contains(&TokenEvent::OpenTagName(1, 5)));
+    assert!(cb.events.contains(&TokenEvent::Text(6, 7)));
+    // `</span` is 6 bytes; `>` at 13
+    assert!(cb.events.contains(&TokenEvent::CloseTag(9, 13)));
+}
+
+#[test]
+fn test_closing_tag_name_scr_prefix() {
+    let cb = tokenize("</scrfoo>");
+    assert!(cb.errors.is_empty());
+    assert!(cb.events.contains(&TokenEvent::CloseTag(2, 8)));
+}
+
+#[test]
+fn test_textarea_with_embedded_element() {
+    let cb = tokenize("<textarea><h1>hi</h1></textarea>");
+    assert!(cb.errors.is_empty());
+    assert!(cb.events.contains(&TokenEvent::OpenTagName(1, 9)));
+    assert!(cb.events.contains(&TokenEvent::OpenTagEnd(9)));
+    assert!(cb.events.contains(&TokenEvent::Text(10, 21)));
+    assert!(cb.events.contains(&TokenEvent::CloseTag(23, 31)));
+}
+
+#[test]
+fn test_script_with_less_than_sign() {
+    let cb = tokenize("<script>if(a<b)</script>");
+    assert!(cb.errors.is_empty());
+    assert!(cb.events.contains(&TokenEvent::OpenTagName(1, 7)));
+    assert!(cb.events.contains(&TokenEvent::OpenTagEnd(7)));
+    assert!(cb.events.contains(&TokenEvent::Text(8, 15)));
+    assert!(cb.events.contains(&TokenEvent::CloseTag(17, 23)));
+}
+
+#[test]
+fn test_textarea_interpolation_returns_to_rcdata() {
+    let cb = tokenize("<textarea>a{{x}}b</textarea>");
+    assert!(cb.errors.is_empty());
+    assert!(cb.events.contains(&TokenEvent::OpenTagName(1, 9)));
+    assert!(cb.events.contains(&TokenEvent::OpenTagEnd(9)));
+    assert!(cb.events.contains(&TokenEvent::Text(10, 11)));
+    assert!(cb.events.contains(&TokenEvent::Interpolation(13, 14)));
+    assert!(cb.events.contains(&TokenEvent::Text(16, 17)));
+    assert!(cb.events.contains(&TokenEvent::CloseTag(19, 27)));
+}
+
+#[test]
+fn test_textarea_partial_interpolation_open_falls_back_to_rcdata() {
+    let cb = tokenize("<textarea>a{b</textarea>");
+    assert!(cb.errors.is_empty());
+    assert!(cb.events.contains(&TokenEvent::OpenTagName(1, 9)));
+    assert!(cb.events.contains(&TokenEvent::OpenTagEnd(9)));
+    assert!(cb.events.contains(&TokenEvent::Text(10, 13)));
+    assert!(cb.events.contains(&TokenEvent::CloseTag(15, 23)));
+    assert!(!cb
+        .events
+        .iter()
+        .any(|e| matches!(e, TokenEvent::Interpolation(_, _))));
+}
+
+#[test]
+fn test_scriptx_is_not_treated_as_special_script_tag() {
+    let cb = tokenize("<scriptx>1</scriptx>");
+    assert!(cb.errors.is_empty());
+    assert!(cb.events.contains(&TokenEvent::OpenTagName(1, 8)));
+    assert!(cb.events.contains(&TokenEvent::OpenTagEnd(8)));
+    assert!(cb.events.contains(&TokenEvent::Text(9, 10)));
+    assert!(cb.events.contains(&TokenEvent::CloseTag(12, 19)));
+}
+
+#[test]
+fn test_titlex_is_not_treated_as_special_title_tag() {
+    let cb = tokenize("<titlex>1</titlex>");
+    assert!(cb.errors.is_empty());
+    assert!(cb.events.contains(&TokenEvent::OpenTagName(1, 7)));
+    assert!(cb.events.contains(&TokenEvent::OpenTagEnd(7)));
+    assert!(cb.events.contains(&TokenEvent::Text(8, 9)));
+    assert!(cb.events.contains(&TokenEvent::CloseTag(11, 17)));
+}
+
+#[test]
+fn test_script_close_tag_with_whitespace_before_gt() {
+    let cb = tokenize("<script>a</script   >");
+    assert!(cb.errors.is_empty());
+    assert!(cb.events.contains(&TokenEvent::OpenTagName(1, 7)));
+    assert!(cb.events.contains(&TokenEvent::Text(8, 9)));
+    assert!(cb.events.contains(&TokenEvent::CloseTag(11, 17)));
+}
+
+#[test]
+fn test_script_pseudo_close_kept_as_text_until_real_close() {
+    let cb = tokenize("<script>a</scriptx>b</script>");
+    assert!(cb.errors.is_empty());
+    assert!(cb.events.contains(&TokenEvent::OpenTagName(1, 7)));
+    assert!(cb.events.contains(&TokenEvent::OpenTagEnd(7)));
+    assert!(cb.events.contains(&TokenEvent::Text(8, 20)));
+    assert!(cb.events.contains(&TokenEvent::CloseTag(22, 28)));
 }


### PR DESCRIPTION
Add support for RCDATA (`<title>`, `<textarea>`) and RAWTEXT (`<script>`, `<style>`) modes to align with Vue core tokenizer behavior.