### PR TITLE
feat(npm): expose vize check command

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 - Rust workspace crates for parsing, semantic analysis, compilation, linting, formatting, type checking, LSP, Musea art tooling, and bindings
 - A full Rust CLI via the `vize` crate (`build`, `fmt`, `lint`, `check`, `musea`, `lsp`, `ide`)
 - npm packages including `@vizejs/vite-plugin`, `@vizejs/native`, `@vizejs/wasm`, `@vizejs/unplugin`, `@vizejs/rspack-plugin`, `@vizejs/nuxt`, `@vizejs/vite-plugin-musea`, `@vizejs/musea-mcp-server`, and `oxlint-plugin-vize`
-- The `vize` npm package for shared config utilities and the native `lint` command
+- The `vize` npm package for shared config utilities and the native `lint` / `check` commands
 
 ## Quick Start
 
@@ -69,12 +69,14 @@ export default defineConfig({
 
 ### npm CLI
 
-The npm `vize` package currently exposes the native lint command plus shared config helpers:
+The npm `vize` package exposes native lint/check commands plus shared config helpers:
 
 ```bash
 vp install -D vize
 vp exec vize lint src
 vp exec vize lint --preset opinionated --help-level short src
+vp exec vize check
+vp exec vize check src
 ```
 
 ### Full Rust CLI

--- a/docs/content/getting-started.md
+++ b/docs/content/getting-started.md
@@ -53,14 +53,17 @@ export default defineConfig({
 
 ### 2. npm CLI + Shared Config
 
-Use the `vize` npm package when you want shared config utilities and the native lint command.
+Use the `vize` npm package when you want shared config utilities and native lint/check commands
+available in package scripts.
 
 ```bash
 vp install -D vize
 vp exec vize lint src
+vp exec vize check
 ```
 
-The npm package currently focuses on config loading plus `lint`.
+The npm `vize check` command uses the packaged NAPI checker. Use the Rust CLI when you need the
+Corsa-backed project diagnostics path across Vue, TS, TSX, and `.d.ts` inputs.
 
 ### 3. Full Rust CLI
 

--- a/docs/content/guide/cli.md
+++ b/docs/content/guide/cli.md
@@ -7,8 +7,9 @@ title: CLI
 > **⚠️ Work in Progress:** Vize is under active development and the CLI surface is still evolving.
 
 This page describes the Rust-native `vize` binary.
-The npm `vize` package currently exposes shared config helpers plus `vize lint`; for the full CLI,
-install the Rust binary with `cargo install vize`.
+The npm `vize` package exposes shared config helpers plus `vize lint` and an NAPI-backed
+`vize check`; for the full CLI and Corsa project diagnostics, install the Rust binary with
+`cargo install vize`.
 
 ## Installation
 

--- a/npm/vize/README.md
+++ b/npm/vize/README.md
@@ -4,10 +4,11 @@ The `vize` npm package provides:
 
 - shared config utilities (`defineConfig`, `loadConfig`)
 - the native `vize lint` command
+- the native `vize check` command for package scripts
 
 For Vite integration, pair it with `@vizejs/vite-plugin`.
-For the full Rust-native CLI (`build`, `fmt`, `check`, `lsp`, `ide`), install the Rust `vize`
-binary with `cargo install vize`.
+For the full Rust-native CLI (`build`, `fmt`, project-backed `check`, `lsp`, `ide`), install the
+Rust `vize` binary with `cargo install vize`.
 
 Need `vp` first? Install Vite+ once from the [Vite+ install guide](https://viteplus.dev/guide/install).
 
@@ -19,11 +20,13 @@ vp install -D vize
 
 ## CLI
 
-The npm CLI currently exposes `lint`:
+The npm CLI exposes `lint` and `check`:
 
 ```bash
 vp exec vize lint src
 vp exec vize lint --preset opinionated --help-level short src
+vp exec vize check
+vp exec vize check src
 ```
 
 Shared config discovery is supported for the npm CLI:
@@ -41,10 +44,17 @@ export default defineConfig({
   linter: {
     preset: "opinionated",
   },
+  typeChecker: {
+    strict: true,
+  },
 });
 ```
 
 Override config discovery with `--config`, or disable it with `--no-config`.
+
+`vize check` in the npm package uses the packaged NAPI checker so it can run from `package.json`
+scripts after installing `vize`. Use the Rust CLI when you need Corsa project diagnostics across
+Vue, TS, TSX, and `.d.ts` inputs.
 
 ## Programmatic Config Helpers
 

--- a/npm/vize/src/cli.ts
+++ b/npm/vize/src/cli.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
 import { spawnSync } from "node:child_process";
 import * as path from "node:path";
 import { createRequire } from "node:module";
@@ -63,6 +63,7 @@ function getBindingPackageName(): string {
 }
 
 interface NativeBinding {
+  typeCheck: (source: string, options?: NativeTypeCheckOptions) => TypeCheckResult;
   lint: (
     patterns: string[],
     options?: {
@@ -76,15 +77,15 @@ interface NativeBinding {
   ) => LintResult;
 }
 
-function loadNative(): NativeBinding {
+function loadNative(command: "check" | "lint"): NativeBinding {
   const attemptedPackages = getAttemptedPackages();
   let lastError: unknown = null;
 
   for (const packageName of attemptedPackages) {
     try {
       const binding = require(packageName) as Partial<NativeBinding>;
-      if (typeof binding.lint !== "function") {
-        throw new Error(`${packageName} does not expose the lint binding.`);
+      if (typeof binding[command === "check" ? "typeCheck" : "lint"] !== "function") {
+        throw new Error(`${packageName} does not expose the ${command} binding.`);
       }
       return binding as NativeBinding;
     } catch (error) {
@@ -161,7 +162,23 @@ interface ParsedLintCommand {
 
 function printUsage(): void {
   console.error("Usage: vize <command> [options]");
-  console.error("Commands: lint, musea");
+  console.error("Commands: check, lint, musea");
+}
+
+function printCheckUsage(): void {
+  console.error("Usage: vize check [options] [files-or-directories]");
+  console.error("Options:");
+  console.error("  -f, --format <text|json>       Output format");
+  console.error("  -q, --quiet                    Show summary only");
+  console.error("      --strict                   Enable strict checks");
+  console.error("      --show-virtual-ts          Print generated Virtual TS");
+  console.error("      --max-warnings <number>    Fail when warnings exceed the limit");
+  console.error("  -c, --config <path>            Use a specific vize config file");
+  console.error("      --no-config                Disable config discovery");
+  console.error("");
+  console.error(
+    "Note: npm `vize check` uses the packaged NAPI checker. Install the Rust CLI for project-backed Corsa diagnostics.",
+  );
 }
 
 function resolvePackageBinaryFromCwd(packageName: string, binName: string = packageName): string {
@@ -242,6 +259,471 @@ function parseLintCommand(args: string[]): ParsedLintCommand {
   return { patterns, options, sharedConfig };
 }
 
+// ============================================================================
+// Check command
+// ============================================================================
+
+interface NativeTypeCheckOptions {
+  filename?: string;
+  strict?: boolean;
+  includeVirtualTs?: boolean;
+  include_virtual_ts?: boolean;
+  checkProps?: boolean;
+  check_props?: boolean;
+  checkEmits?: boolean;
+  check_emits?: boolean;
+  checkTemplateBindings?: boolean;
+  check_template_bindings?: boolean;
+  checkReactivity?: boolean;
+  check_reactivity?: boolean;
+  checkSetupContext?: boolean;
+  check_setup_context?: boolean;
+  checkInvalidExports?: boolean;
+  check_invalid_exports?: boolean;
+  checkFallthroughAttrs?: boolean;
+  check_fallthrough_attrs?: boolean;
+}
+
+interface TypeDiagnostic {
+  severity: string;
+  message: string;
+  start: number;
+  end: number;
+  code?: string;
+  help?: string;
+  related?: Array<{
+    message: string;
+    start: number;
+    end: number;
+    filename?: string;
+  }>;
+}
+
+interface TypeCheckResult {
+  diagnostics: TypeDiagnostic[];
+  virtualTs?: string;
+  errorCount: number;
+  warningCount: number;
+  analysisTimeMs?: number;
+}
+
+interface CheckOptions {
+  format?: string;
+  quiet?: boolean;
+  strict?: boolean;
+  includeVirtualTs?: boolean;
+  maxWarnings?: number;
+  checkProps?: boolean;
+  checkEmits?: boolean;
+  checkTemplateBindings?: boolean;
+  checkReactivity?: boolean;
+  checkSetupContext?: boolean;
+  checkInvalidExports?: boolean;
+  checkFallthroughAttrs?: boolean;
+  help?: boolean;
+}
+
+interface ParsedCheckCommand {
+  patterns: string[];
+  options: CheckOptions;
+  sharedConfig: SharedConfigOptions;
+}
+
+interface CheckedFileResult {
+  file: string;
+  source: string;
+  result: TypeCheckResult;
+}
+
+function parseCheckCommand(args: string[]): ParsedCheckCommand {
+  const patterns: string[] = [];
+  const options: CheckOptions = {};
+  const sharedConfig: SharedConfigOptions = {
+    configMode: "root",
+  };
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === "--format" || arg === "-f") {
+      options.format = args[++i];
+    } else if (arg === "--quiet" || arg === "-q") {
+      options.quiet = true;
+    } else if (arg === "--strict") {
+      options.strict = true;
+    } else if (arg === "--no-strict") {
+      options.strict = false;
+    } else if (arg === "--show-virtual-ts" || arg === "--include-virtual-ts") {
+      options.includeVirtualTs = true;
+    } else if (arg === "--max-warnings") {
+      options.maxWarnings = Number.parseInt(args[++i], 10);
+    } else if (arg === "--no-check-props") {
+      options.checkProps = false;
+    } else if (arg === "--no-check-emits") {
+      options.checkEmits = false;
+    } else if (arg === "--no-check-template-bindings") {
+      options.checkTemplateBindings = false;
+    } else if (arg === "--no-check-reactivity") {
+      options.checkReactivity = false;
+    } else if (arg === "--no-check-setup-context") {
+      options.checkSetupContext = false;
+    } else if (arg === "--no-check-invalid-exports") {
+      options.checkInvalidExports = false;
+    } else if (arg === "--no-check-fallthrough-attrs") {
+      options.checkFallthroughAttrs = false;
+    } else if (arg === "--config" || arg === "-c") {
+      const configFile = args[++i];
+      if (!configFile) {
+        throw new Error("Missing path after --config");
+      }
+      sharedConfig.configFile = configFile;
+    } else if (arg === "--no-config") {
+      sharedConfig.configMode = "none";
+    } else if (arg === "--help" || arg === "-h") {
+      options.help = true;
+    } else if (arg === "--tsconfig" || arg === "--corsa-path" || arg === "--servers") {
+      i++;
+    } else if (arg === "--socket" || arg === "-s" || arg === "--declaration-dir") {
+      i++;
+    } else if (arg === "--profile" || arg === "--declaration") {
+      // Accepted for package-script compatibility with the Rust CLI. The npm
+      // checker does not currently emit project profiles or declarations.
+    } else if (!arg.startsWith("-")) {
+      patterns.push(arg);
+    }
+  }
+
+  return { patterns, options, sharedConfig };
+}
+
+function hasGlobSyntax(pattern: string): boolean {
+  return pattern.includes("*") || pattern.includes("?") || pattern.includes("[");
+}
+
+function normalizePath(filePath: string): string {
+  return filePath.split(path.sep).join("/");
+}
+
+function displayPath(filePath: string): string {
+  const relative = path.relative(process.cwd(), filePath);
+  if (relative && !relative.startsWith("..") && !path.isAbsolute(relative)) {
+    return normalizePath(relative);
+  }
+  return normalizePath(filePath);
+}
+
+function isVueFile(filePath: string): boolean {
+  return path.extname(filePath) === ".vue";
+}
+
+function collectVueFilesFromDirectory(directory: string, recursive: boolean): string[] {
+  const files: string[] = [];
+  const entries = readdirSync(directory, { withFileTypes: true });
+
+  for (const entry of entries) {
+    const entryPath = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === "node_modules" || entry.name === ".git") {
+        continue;
+      }
+      if (recursive) {
+        files.push(...collectVueFilesFromDirectory(entryPath, true));
+      }
+    } else if (entry.isFile() && isVueFile(entryPath)) {
+      files.push(entryPath);
+    }
+  }
+
+  return files;
+}
+
+function globBase(pattern: string): string {
+  const normalized = normalizePath(pattern);
+  const globIndex = normalized.search(/[*?[]/);
+  if (globIndex === -1) {
+    return normalized;
+  }
+
+  const beforeGlob = normalized.slice(0, globIndex);
+  const slashIndex = beforeGlob.lastIndexOf("/");
+  if (slashIndex === -1) {
+    return ".";
+  }
+  return beforeGlob.slice(0, slashIndex) || "/";
+}
+
+function globToRegExp(pattern: string): RegExp {
+  const normalized = normalizePath(pattern);
+  let source = "";
+
+  for (let i = 0; i < normalized.length; i++) {
+    const char = normalized[i];
+    const next = normalized[i + 1];
+    const afterNext = normalized[i + 2];
+
+    if (char === "*" && next === "*" && afterNext === "/") {
+      source += "(?:.*/)?";
+      i += 2;
+    } else if (char === "*" && next === "*") {
+      source += ".*";
+      i++;
+    } else if (char === "*") {
+      source += "[^/]*";
+    } else if (char === "?") {
+      source += "[^/]";
+    } else if ("\\^$+?.()|{}[]".includes(char)) {
+      source += `\\${char}`;
+    } else {
+      source += char;
+    }
+  }
+
+  return new RegExp(`^${source}$`);
+}
+
+function shouldRecurseGlob(pattern: string, base: string): boolean {
+  const normalizedPattern = normalizePath(pattern);
+  const normalizedBase = normalizePath(base);
+  const rest =
+    normalizedBase === "."
+      ? normalizedPattern
+      : normalizedPattern.slice(normalizedBase.length).replace(/^\/+/, "");
+  return rest.includes("/");
+}
+
+function collectVueFilesFromGlob(pattern: string): string[] {
+  const basePattern = globBase(pattern);
+  const base = path.resolve(process.cwd(), basePattern);
+  if (!existsSync(base)) {
+    return [];
+  }
+
+  const isAbsolutePattern = path.isAbsolute(pattern);
+  const normalizedPattern = normalizePath(isAbsolutePattern ? path.resolve(pattern) : pattern);
+  const regex = globToRegExp(normalizedPattern);
+  const candidates = collectVueFilesFromDirectory(base, shouldRecurseGlob(pattern, basePattern));
+
+  return candidates.filter((file) => {
+    const comparable = isAbsolutePattern
+      ? normalizePath(file)
+      : normalizePath(path.relative(process.cwd(), file));
+    return regex.test(comparable);
+  });
+}
+
+function collectCheckFiles(patterns: string[]): string[] {
+  const files = new Set<string>();
+  const inputs = patterns.length === 0 ? ["."] : patterns;
+
+  for (const input of inputs) {
+    if (hasGlobSyntax(input)) {
+      for (const file of collectVueFilesFromGlob(input)) {
+        files.add(path.resolve(file));
+      }
+      continue;
+    }
+
+    const resolved = path.resolve(process.cwd(), input);
+    if (!existsSync(resolved)) {
+      continue;
+    }
+
+    const stats = statSync(resolved);
+    if (stats.isDirectory()) {
+      for (const file of collectVueFilesFromDirectory(resolved, true)) {
+        files.add(path.resolve(file));
+      }
+    } else if (stats.isFile() && isVueFile(resolved)) {
+      files.add(resolved);
+    }
+  }
+
+  return Array.from(files).sort();
+}
+
+function lineStarts(source: string): number[] {
+  const starts = [0];
+  for (let i = 0; i < source.length; i++) {
+    if (source.charCodeAt(i) === 10) {
+      starts.push(i + 1);
+    }
+  }
+  return starts;
+}
+
+function offsetToLineColumn(starts: number[], offset: number): { line: number; column: number } {
+  let low = 0;
+  let high = starts.length - 1;
+  while (low <= high) {
+    const mid = Math.floor((low + high) / 2);
+    if (starts[mid] <= offset) {
+      low = mid + 1;
+    } else {
+      high = mid - 1;
+    }
+  }
+
+  const lineIndex = Math.max(0, high);
+  return {
+    line: lineIndex + 1,
+    column: offset - starts[lineIndex] + 1,
+  };
+}
+
+function toNativeTypeCheckOptions(file: string, options: CheckOptions): NativeTypeCheckOptions {
+  return {
+    filename: file,
+    strict: options.strict,
+    includeVirtualTs: options.includeVirtualTs,
+    include_virtual_ts: options.includeVirtualTs,
+    checkProps: options.checkProps,
+    check_props: options.checkProps,
+    checkEmits: options.checkEmits,
+    check_emits: options.checkEmits,
+    checkTemplateBindings: options.checkTemplateBindings,
+    check_template_bindings: options.checkTemplateBindings,
+    checkReactivity: options.checkReactivity,
+    check_reactivity: options.checkReactivity,
+    checkSetupContext: options.checkSetupContext,
+    check_setup_context: options.checkSetupContext,
+    checkInvalidExports: options.checkInvalidExports,
+    check_invalid_exports: options.checkInvalidExports,
+    checkFallthroughAttrs: options.checkFallthroughAttrs,
+    check_fallthrough_attrs: options.checkFallthroughAttrs,
+  };
+}
+
+function renderCheckText(
+  results: CheckedFileResult[],
+  options: CheckOptions,
+  timeMs: number,
+): void {
+  let totalErrors = 0;
+  let totalWarnings = 0;
+
+  for (const { file, source, result } of results) {
+    totalErrors += result.errorCount;
+    totalWarnings += result.warningCount;
+
+    if (options.includeVirtualTs && result.virtualTs) {
+      process.stderr.write(`\n=== ${displayPath(file)} ===\n${result.virtualTs}\n`);
+    }
+
+    if (options.quiet || result.diagnostics.length === 0) {
+      continue;
+    }
+
+    const starts = lineStarts(source);
+    process.stdout.write(`\n\x1b[4m${displayPath(file)}\x1b[0m\n`);
+    for (const diagnostic of result.diagnostics) {
+      const color = diagnostic.severity === "error" ? "\x1b[31m" : "\x1b[33m";
+      const location = offsetToLineColumn(starts, diagnostic.start);
+      const code = diagnostic.code ? ` [${diagnostic.code}]` : "";
+      process.stdout.write(
+        `  ${color}${diagnostic.severity}:${location.line}:${location.column}\x1b[0m${code} ${diagnostic.message}\n`,
+      );
+      if (diagnostic.help) {
+        process.stdout.write(`    help: ${diagnostic.help}\n`);
+      }
+    }
+  }
+
+  const status = totalErrors > 0 ? "\x1b[31mERR\x1b[0m" : "\x1b[32mOK\x1b[0m";
+  process.stdout.write(
+    `\n${status} Type checked ${results.length} Vue files in ${timeMs.toFixed(2)}ms\n`,
+  );
+  if (totalErrors > 0) {
+    process.stdout.write(`  \x1b[31m${totalErrors} error(s)\x1b[0m\n`);
+  } else {
+    process.stdout.write("  \x1b[32mNo type errors found!\x1b[0m\n");
+  }
+  if (totalWarnings > 0) {
+    process.stdout.write(`  \x1b[33m${totalWarnings} warning(s)\x1b[0m\n`);
+  }
+}
+
+async function runCheck(args: string[]): Promise<void> {
+  const { patterns, options, sharedConfig } = parseCheckCommand(args);
+  if (options.help) {
+    printCheckUsage();
+    return;
+  }
+
+  const config = await loadConfig(process.cwd(), {
+    mode: sharedConfig.configMode,
+    configFile: sharedConfig.configFile,
+    env: {
+      mode: process.env.NODE_ENV ?? "development",
+      command: "check",
+    },
+  });
+
+  if (sharedConfig.configFile && !config) {
+    throw new Error(`Could not find config file: ${sharedConfig.configFile}`);
+  }
+
+  if (config?.typeChecker?.enabled === false) {
+    process.stderr.write(
+      "[vize] Skipping check because typeChecker.enabled is false in vize.config.\n",
+    );
+    return;
+  }
+
+  options.strict ??= config?.typeChecker?.strict;
+  options.checkProps ??= config?.typeChecker?.checkProps;
+  options.checkEmits ??= config?.typeChecker?.checkEmits;
+  options.checkTemplateBindings ??= config?.typeChecker?.checkTemplateBindings;
+
+  const files = collectCheckFiles(patterns);
+  if (files.length === 0) {
+    process.stderr.write(`No Vue files found matching inputs: ${JSON.stringify(patterns)}\n`);
+    return;
+  }
+
+  const native = loadNative("check");
+  const start = performance.now();
+  const results = files.map((file) => {
+    const source = readFileSync(file, "utf8");
+    return {
+      file,
+      source,
+      result: native.typeCheck(source, toNativeTypeCheckOptions(file, options)),
+    };
+  });
+  const timeMs = performance.now() - start;
+  const totalErrors = results.reduce((sum, { result }) => sum + result.errorCount, 0);
+  const totalWarnings = results.reduce((sum, { result }) => sum + result.warningCount, 0);
+
+  if (options.format === "json") {
+    process.stdout.write(
+      `${JSON.stringify(
+        {
+          files: results.map(({ file, result }) => ({
+            file: displayPath(file),
+            diagnostics: result.diagnostics,
+            virtualTs: result.virtualTs,
+          })),
+          errorCount: totalErrors,
+          warningCount: totalWarnings,
+          fileCount: results.length,
+        },
+        null,
+        2,
+      )}\n`,
+    );
+  } else {
+    renderCheckText(results, options, timeMs);
+  }
+
+  if (totalErrors > 0) {
+    process.exit(1);
+  }
+
+  if (options.maxWarnings !== undefined && totalWarnings > options.maxWarnings) {
+    process.stderr.write(`\nToo many warnings (${totalWarnings} > max ${options.maxWarnings})\n`);
+    process.exit(1);
+  }
+}
+
 async function runLint(args: string[]): Promise<void> {
   const { patterns, options, sharedConfig } = parseLintCommand(args);
   const config = await loadConfig(process.cwd(), {
@@ -268,7 +750,7 @@ async function runLint(args: string[]): Promise<void> {
     patterns.push(".");
   }
 
-  const native = loadNative();
+  const native = loadNative("lint");
   const result = native.lint(patterns, {
     format: options.format,
     max_warnings: options.maxWarnings,
@@ -305,7 +787,7 @@ async function runLint(args: string[]): Promise<void> {
 // Command router
 // ============================================================================
 
-const NAPI_COMMANDS = new Set(["lint"]);
+const NAPI_COMMANDS = new Set(["check", "lint"]);
 const JS_COMMANDS = new Set(["musea"]);
 
 async function main(): Promise<void> {
@@ -320,6 +802,9 @@ async function main(): Promise<void> {
   if (NAPI_COMMANDS.has(command)) {
     const commandArgs = args.slice(1);
     switch (command) {
+      case "check":
+        await runCheck(commandArgs);
+        break;
       case "lint":
         await runLint(commandArgs);
         break;


### PR DESCRIPTION
## Summary

- add `vize check` to the npm package CLI so it can be used from package scripts
- wire the command to the packaged NAPI type checker with text and JSON output
- update README and docs to describe the npm CLI check path and when to use the Rust CLI

## Validation

- `pnpm --dir npm/vize check`
- `pnpm --dir npm/vize build`
- `node npm/vize/dist/cli.mjs check --help`
- `node npm/vize/dist/cli.mjs check --no-config --quiet tests/_fixtures/_projects/typecheck-errors/src`
- `node npm/vize/dist/cli.mjs check --no-config --format json tests/_fixtures/_projects/typecheck-errors/src/UndefinedVariable.vue`
- `git diff --check`
