### PR TITLE
feat(cli): add npm ready and upgrade entrypoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@
 ## What Ships Today
 
 - Rust workspace crates for parsing, semantic analysis, compilation, linting, formatting, type checking, LSP, Musea art tooling, and bindings
-- A full Rust CLI via the `vize` crate (`build`, `fmt`, `lint`, `check`, `musea`, `lsp`, `ide`)
+- A full Rust CLI via the `vize` crate (`build`, `fmt`, `lint`, `check`, `ready`, `upgrade`, `musea`, `lsp`, `ide`)
 - npm packages including `@vizejs/vite-plugin`, `@vizejs/native`, `@vizejs/wasm`, `@vizejs/unplugin`, `@vizejs/rspack-plugin`, `@vizejs/nuxt`, `@vizejs/vite-plugin-musea`, `@vizejs/musea-mcp-server`, and `oxlint-plugin-vize`
-- The `vize` npm package for shared config utilities and the native `lint` / `check` commands
+- The `vize` npm package for shared config utilities and native `build`, `fmt`, `lint`, `check`, `ready`, and `upgrade` commands
 
 ## Quick Start
 
@@ -69,14 +69,15 @@ export default defineConfig({
 
 ### npm CLI
 
-The npm `vize` package exposes native lint/check commands plus shared config helpers:
+The npm `vize` package exposes native CLI commands plus shared config helpers:
 
 ```bash
 vp install -D vize
+vp exec vize fmt --write src
 vp exec vize lint src
-vp exec vize lint --preset opinionated --help-level short src
 vp exec vize check
-vp exec vize check src
+vp exec vize build src
+vp exec vize ready src
 ```
 
 ### Full Rust CLI
@@ -92,6 +93,8 @@ vize build src/**/*.vue
 vize fmt --check src
 vize lint --profile src
 vize check --profile src
+vize ready src
+vize upgrade
 vize lsp
 ```
 

--- a/crates/vize/README.md
+++ b/crates/vize/README.md
@@ -4,7 +4,7 @@
 
 It provides:
 
-- the `vize` CLI binary (`build`, `fmt`, `lint`, `check`, `musea`, `lsp`, `ide`)
+- the `vize` CLI binary (`build`, `fmt`, `lint`, `check`, `ready`, `upgrade`, `musea`, `lsp`, `ide`)
 - a facade crate that re-exports the workspace crates for unified Rust docs
 
 ## Install
@@ -20,10 +20,14 @@ vize build src/**/*.vue
 vize fmt --check src
 vize lint --preset opinionated src
 vize check --profile src
+vize ready src
+vize upgrade
 vize lsp
 ```
 
 `vize` defaults to `build` when no subcommand is provided.
+`vize ready` runs `fmt --write`, `lint`, `check`, and `build` in order.
+`vize upgrade` updates the installed Rust CLI through Cargo.
 
 ## Re-exported Crates
 

--- a/crates/vize/src/commands/mod.rs
+++ b/crates/vize/src/commands/mod.rs
@@ -9,3 +9,6 @@ pub mod lint;
 pub mod lsp;
 pub mod musea;
 pub mod profile;
+#[cfg(feature = "glyph")]
+pub mod ready;
+pub mod upgrade;

--- a/crates/vize/src/commands/ready.rs
+++ b/crates/vize/src/commands/ready.rs
@@ -80,7 +80,7 @@ pub fn run(args: ReadyArgs) {
         #[cfg(unix)]
         socket: None,
         tsconfig: None,
-        format: "text".to_string(),
+        format: "text".into(),
         show_virtual_ts: false,
         quiet: false,
         profile: false,

--- a/crates/vize/src/commands/ready.rs
+++ b/crates/vize/src/commands/ready.rs
@@ -1,0 +1,105 @@
+//! Ready command - Run the standard pre-publish local checks.
+
+use clap::Args;
+use std::path::PathBuf;
+
+use crate::commands::{
+    build::{BuildArgs, OutputFormat, ScriptExtension},
+    check::CheckArgs,
+    lint::LintArgs,
+};
+use vize_carton::ToCompactString;
+
+#[cfg(feature = "glyph")]
+use crate::commands::fmt::FmtArgs;
+
+#[derive(Args)]
+#[allow(clippy::disallowed_types)]
+pub struct ReadyArgs {
+    /// Files or directories to process.
+    #[arg(default_value = "./**/*.vue")]
+    pub patterns: Vec<String>,
+
+    /// Output directory for the build step.
+    #[arg(short, long, default_value = "./dist")]
+    pub output: PathBuf,
+
+    /// Enable SSR mode for the build step.
+    #[arg(long)]
+    pub ssr: bool,
+
+    /// Script extension handling for the build step.
+    #[arg(long, value_enum, default_value = "downcompile")]
+    pub script_ext: ScriptExtension,
+}
+
+pub fn run(args: ReadyArgs) {
+    #[cfg(feature = "glyph")]
+    {
+        eprintln!("vize ready: fmt");
+        crate::commands::fmt::run(FmtArgs {
+            patterns: args.patterns.clone(),
+            check: false,
+            write: true,
+            config: None,
+            single_quote: None,
+            print_width: None,
+            tab_width: None,
+            use_tabs: None,
+            no_semi: false,
+            sort_attributes: None,
+            single_attribute_per_line: None,
+            max_attributes_per_line: None,
+            normalize_directive_shorthands: None,
+            profile: false,
+            slow_threshold: 100,
+        });
+    }
+
+    eprintln!("vize ready: lint");
+    crate::commands::lint::run(LintArgs {
+        patterns: args
+            .patterns
+            .iter()
+            .map(|pattern| pattern.to_compact_string())
+            .collect(),
+        fix: false,
+        config: None,
+        format: "text".into(),
+        max_warnings: None,
+        quiet: false,
+        help_level: "full".into(),
+        preset: "happy-path".into(),
+        profile: false,
+        slow_threshold: 100,
+    });
+
+    eprintln!("vize ready: check");
+    crate::commands::check::run(CheckArgs {
+        patterns: args.patterns.clone(),
+        #[cfg(unix)]
+        socket: None,
+        tsconfig: None,
+        format: "text".to_string(),
+        show_virtual_ts: false,
+        quiet: false,
+        profile: false,
+        corsa_path: None,
+        servers: None,
+        declaration: false,
+        declaration_dir: None,
+    });
+
+    eprintln!("vize ready: build");
+    crate::commands::build::run(BuildArgs {
+        patterns: args.patterns,
+        output: args.output,
+        format: OutputFormat::Js,
+        ssr: args.ssr,
+        script_ext: args.script_ext,
+        threads: None,
+        profile: false,
+        slow_threshold: 100,
+        continue_on_error: false,
+    });
+}

--- a/crates/vize/src/commands/upgrade.rs
+++ b/crates/vize/src/commands/upgrade.rs
@@ -37,9 +37,9 @@ pub fn run(args: UpgradeArgs) {
 }
 
 fn run_cargo_upgrade(args: UpgradeArgs) {
-    let mut command_args = vec!["install".to_string(), args.package, "--force".to_string()];
+    let mut command_args = vec!["install", args.package.as_str(), "--force"];
     if !args.no_locked {
-        command_args.push("--locked".to_string());
+        command_args.push("--locked");
     }
 
     if args.dry_run {

--- a/crates/vize/src/commands/upgrade.rs
+++ b/crates/vize/src/commands/upgrade.rs
@@ -1,0 +1,61 @@
+//! Upgrade command - Update the installed Vize CLI.
+
+use clap::{Args, ValueEnum};
+use std::process::Command;
+
+#[derive(Debug, Clone, Copy, ValueEnum, Default)]
+pub enum UpgradeSource {
+    /// Update the Rust CLI through Cargo.
+    #[default]
+    Cargo,
+}
+
+#[derive(Args)]
+#[allow(clippy::disallowed_types)]
+pub struct UpgradeArgs {
+    /// Update source.
+    #[arg(long, value_enum, default_value = "cargo")]
+    pub source: UpgradeSource,
+
+    /// Package to install.
+    #[arg(long, default_value = "vize")]
+    pub package: String,
+
+    /// Skip `--locked` when running Cargo.
+    #[arg(long)]
+    pub no_locked: bool,
+
+    /// Print the command without running it.
+    #[arg(long)]
+    pub dry_run: bool,
+}
+
+pub fn run(args: UpgradeArgs) {
+    match args.source {
+        UpgradeSource::Cargo => run_cargo_upgrade(args),
+    }
+}
+
+fn run_cargo_upgrade(args: UpgradeArgs) {
+    let mut command_args = vec!["install".to_string(), args.package, "--force".to_string()];
+    if !args.no_locked {
+        command_args.push("--locked".to_string());
+    }
+
+    if args.dry_run {
+        eprintln!("cargo {}", command_args.join(" "));
+        return;
+    }
+
+    let status = Command::new("cargo")
+        .args(&command_args)
+        .status()
+        .unwrap_or_else(|error| {
+            eprintln!("Failed to start cargo: {}", error);
+            std::process::exit(1);
+        });
+
+    if !status.success() {
+        std::process::exit(status.code().unwrap_or(1));
+    }
+}

--- a/crates/vize/src/main.rs
+++ b/crates/vize/src/main.rs
@@ -57,6 +57,14 @@ enum Commands {
 
     /// IDE integration - LSP server and editor extension management
     Ide(commands::ide::IdeArgs),
+
+    /// Update the installed Vize CLI
+    #[command(visible_alias = "self-update")]
+    Upgrade(commands::upgrade::UpgradeArgs),
+
+    /// Run fmt, lint, check, and build
+    #[cfg(feature = "glyph")]
+    Ready(commands::ready::ReadyArgs),
 }
 
 fn main() {
@@ -73,6 +81,9 @@ fn main() {
         Some(Commands::Musea(args)) => commands::musea::run(args),
         Some(Commands::Lsp(args)) => commands::lsp::run(args),
         Some(Commands::Ide(args)) => commands::ide::run(args),
+        Some(Commands::Upgrade(args)) => commands::upgrade::run(args),
+        #[cfg(feature = "glyph")]
+        Some(Commands::Ready(args)) => commands::ready::run(args),
         None => {
             // Default to build command with default args
             commands::build::run(commands::build::BuildArgs::default());

--- a/crates/vize_vitrine/src/napi/format.rs
+++ b/crates/vize_vitrine/src/napi/format.rs
@@ -1,0 +1,80 @@
+//! NAPI bindings for Vue SFC formatting.
+
+#![allow(clippy::disallowed_types)]
+
+use napi::bindgen_prelude::{Error, Result, Status};
+use napi_derive::napi;
+use vize_glyph::{format_sfc_with_allocator, Allocator, FormatOptions};
+
+/// Format options for NAPI.
+#[napi(object)]
+#[derive(Default)]
+pub struct FormatOptionsNapi {
+    pub print_width: Option<u32>,
+    pub tab_width: Option<u8>,
+    pub use_tabs: Option<bool>,
+    pub semi: Option<bool>,
+    pub single_quote: Option<bool>,
+    pub sort_attributes: Option<bool>,
+    pub single_attribute_per_line: Option<bool>,
+    pub max_attributes_per_line: Option<u32>,
+    pub normalize_directive_shorthands: Option<bool>,
+}
+
+/// Format result for NAPI.
+#[napi(object)]
+pub struct FormatResultNapi {
+    pub code: String,
+    pub changed: bool,
+}
+
+fn apply_options(opts: FormatOptionsNapi) -> FormatOptions {
+    let mut options = FormatOptions::default();
+
+    if let Some(value) = opts.print_width {
+        options.print_width = value;
+    }
+    if let Some(value) = opts.tab_width {
+        options.tab_width = value;
+    }
+    if let Some(value) = opts.use_tabs {
+        options.use_tabs = value;
+    }
+    if let Some(value) = opts.semi {
+        options.semi = value;
+    }
+    if let Some(value) = opts.single_quote {
+        options.single_quote = value;
+    }
+    if let Some(value) = opts.sort_attributes {
+        options.sort_attributes = value;
+    }
+    if let Some(value) = opts.single_attribute_per_line {
+        options.single_attribute_per_line = value;
+    }
+    if let Some(value) = opts.max_attributes_per_line {
+        options.max_attributes_per_line = Some(value);
+    }
+    if let Some(value) = opts.normalize_directive_shorthands {
+        options.normalize_directive_shorthands = value;
+    }
+
+    options
+}
+
+/// Format a Vue SFC source string.
+#[napi(js_name = "formatSfc")]
+pub fn format_sfc_napi(
+    source: String,
+    options: Option<FormatOptionsNapi>,
+) -> Result<FormatResultNapi> {
+    let options = apply_options(options.unwrap_or_default());
+    let allocator = Allocator::with_capacity(source.len() * 2);
+    let result = format_sfc_with_allocator(&source, &options, &allocator)
+        .map_err(|error| Error::new(Status::GenericFailure, error.to_string()))?;
+
+    Ok(FormatResultNapi {
+        code: result.code.into(),
+        changed: result.changed,
+    })
+}

--- a/crates/vize_vitrine/src/napi/mod.rs
+++ b/crates/vize_vitrine/src/napi/mod.rs
@@ -4,9 +4,11 @@
 //! - `template`: Template compilation (compile, compileVapor, parseTemplate)
 //! - `sfc`: SFC parsing, compilation, and batch processing
 //! - `art`: Art file parsing, CSF transform, docs, palette, and autogen
+//! - `format`: Vue SFC formatting
 //! - `lint`: Vue SFC linting
 
 mod art;
+mod format;
 mod lint;
 mod sfc;
 mod template;
@@ -16,6 +18,7 @@ mod napi_typecheck;
 pub use napi_typecheck::*;
 
 pub use art::*;
+pub use format::*;
 pub use lint::*;
 pub use sfc::*;
 pub use template::*;

--- a/docs/content/getting-started.md
+++ b/docs/content/getting-started.md
@@ -53,13 +53,16 @@ export default defineConfig({
 
 ### 2. npm CLI + Shared Config
 
-Use the `vize` npm package when you want shared config utilities and native lint/check commands
-available in package scripts.
+Use the `vize` npm package when you want shared config utilities and native CLI commands available
+in package scripts.
 
 ```bash
 vp install -D vize
+vp exec vize fmt --write src
 vp exec vize lint src
 vp exec vize check
+vp exec vize build src
+vp exec vize ready src
 ```
 
 The npm `vize check` command uses the packaged NAPI checker. Use the Rust CLI when you need the
@@ -78,6 +81,8 @@ vize build src/**/*.vue
 vize fmt --check src
 vize lint --profile src
 vize check --profile src
+vize ready src
+vize upgrade
 vize lsp
 ```
 

--- a/docs/content/guide/cli.md
+++ b/docs/content/guide/cli.md
@@ -7,9 +7,9 @@ title: CLI
 > **⚠️ Work in Progress:** Vize is under active development and the CLI surface is still evolving.
 
 This page describes the Rust-native `vize` binary.
-The npm `vize` package exposes shared config helpers plus `vize lint` and an NAPI-backed
-`vize check`; for the full CLI and Corsa project diagnostics, install the Rust binary with
-`cargo install vize`.
+The npm `vize` package exposes shared config helpers plus NAPI-backed `build`, `fmt`, `lint`,
+`check`, `ready`, and `upgrade` commands. Install the Rust binary when you need LSP, IDE,
+`check-server`, or Corsa project diagnostics.
 
 ## Installation
 
@@ -37,6 +37,8 @@ When invoked without a command, `vize` defaults to `build`.
 | `fmt`          | Format Vue SFC files                            |
 | `lint`         | Lint Vue SFC files                              |
 | `check`        | Type check Vue SFC, TS, TSX, and `.d.ts` inputs |
+| `ready`        | Run `fmt`, `lint`, `check`, and `build`         |
+| `upgrade`      | Update the installed CLI                        |
 | `check-server` | Start the Unix JSON-RPC typecheck server        |
 | `musea`        | Musea subcommands and scaffolding               |
 | `lsp`          | Start the language server                       |
@@ -136,6 +138,34 @@ Key options:
 | `--declaration-dir` | Output directory for emitted declarations          |
 
 Use `--corsa-path` when you want to pin a custom Corsa executable while developing Vize or testing a local `corsa-bind` checkout.
+
+## Ready
+
+```bash
+vize ready src
+vize ready --output dist src
+```
+
+`vize ready` runs `fmt --write`, `lint`, `check`, and `build` in order. The command stops at the
+first failing step.
+
+Key options:
+
+| Option         | Description                         |
+| -------------- | ----------------------------------- |
+| `-o, --output` | Output directory for the build step |
+| `--ssr`        | Enable SSR compilation for build    |
+| `--script-ext` | `preserve` or `downcompile`         |
+
+## Upgrade
+
+```bash
+vize upgrade
+vize upgrade --dry-run
+```
+
+The Rust CLI upgrades through Cargo by running `cargo install vize --force --locked`.
+The npm CLI upgrades the npm package through the detected package manager.
 
 ## Musea
 

--- a/npm/vize-native/index.js
+++ b/npm/vize-native/index.js
@@ -302,6 +302,7 @@ const {
   generateArtCatalog,
   generateArtDocsBatch,
   generateArtPalette,
+  formatSfc,
   lint,
   lintPatinaSfc,
   getPatinaRules,
@@ -324,6 +325,7 @@ module.exports.generateArtDoc = generateArtDoc;
 module.exports.generateArtCatalog = generateArtCatalog;
 module.exports.generateArtDocsBatch = generateArtDocsBatch;
 module.exports.generateArtPalette = generateArtPalette;
+module.exports.formatSfc = formatSfc;
 module.exports.lint = lint;
 module.exports.lintPatinaSfc = lintPatinaSfc;
 module.exports.getPatinaRules = getPatinaRules;

--- a/npm/vize/README.md
+++ b/npm/vize/README.md
@@ -3,12 +3,16 @@
 The `vize` npm package provides:
 
 - shared config utilities (`defineConfig`, `loadConfig`)
+- the native `vize build` command
+- the native `vize fmt` command
 - the native `vize lint` command
 - the native `vize check` command for package scripts
+- `vize ready` for `fmt --write -> lint -> check -> build`
+- `vize upgrade` for updating the npm package
 
 For Vite integration, pair it with `@vizejs/vite-plugin`.
-For the full Rust-native CLI (`build`, `fmt`, project-backed `check`, `lsp`, `ide`), install the
-Rust `vize` binary with `cargo install vize`.
+For the full Rust-native CLI (`lsp`, `ide`, project-backed `check`, and `check-server`), install
+the Rust `vize` binary with `cargo install vize`.
 
 Need `vp` first? Install Vite+ once from the [Vite+ install guide](https://viteplus.dev/guide/install).
 
@@ -20,13 +24,15 @@ vp install -D vize
 
 ## CLI
 
-The npm CLI exposes `lint` and `check`:
+The npm CLI exposes the common package-script commands:
 
 ```bash
+vp exec vize build src
+vp exec vize fmt --write src
 vp exec vize lint src
-vp exec vize lint --preset opinionated --help-level short src
 vp exec vize check
-vp exec vize check src
+vp exec vize ready src
+vp exec vize upgrade
 ```
 
 Shared config discovery is supported for the npm CLI:
@@ -55,6 +61,8 @@ Override config discovery with `--config`, or disable it with `--no-config`.
 `vize check` in the npm package uses the packaged NAPI checker so it can run from `package.json`
 scripts after installing `vize`. Use the Rust CLI when you need Corsa project diagnostics across
 Vue, TS, TSX, and `.d.ts` inputs.
+
+`vize ready` runs `fmt --write`, `lint`, `check`, and `build` in that order.
 
 ## Programmatic Config Helpers
 

--- a/npm/vize/src/cli.ts
+++ b/npm/vize/src/cli.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, readdirSync, statSync, writeFileSync } from "node:fs";
 import { spawnSync } from "node:child_process";
 import * as path from "node:path";
 import { createRequire } from "node:module";
@@ -63,6 +63,11 @@ function getBindingPackageName(): string {
 }
 
 interface NativeBinding {
+  compileSfcBatchWithResults: (
+    files: BatchFileInput[],
+    options?: NativeBuildOptions,
+  ) => BatchCompileResult;
+  formatSfc: (source: string, options?: NativeFormatOptions) => FormatResult;
   typeCheck: (source: string, options?: NativeTypeCheckOptions) => TypeCheckResult;
   lint: (
     patterns: string[],
@@ -77,14 +82,24 @@ interface NativeBinding {
   ) => LintResult;
 }
 
-function loadNative(command: "check" | "lint"): NativeBinding {
+type NativeCommand = "build" | "check" | "fmt" | "lint";
+
+const REQUIRED_BINDINGS: Record<NativeCommand, keyof NativeBinding> = {
+  build: "compileSfcBatchWithResults",
+  check: "typeCheck",
+  fmt: "formatSfc",
+  lint: "lint",
+};
+
+function loadNative(command: NativeCommand): NativeBinding {
   const attemptedPackages = getAttemptedPackages();
   let lastError: unknown = null;
+  const requiredBinding = REQUIRED_BINDINGS[command];
 
   for (const packageName of attemptedPackages) {
     try {
       const binding = require(packageName) as Partial<NativeBinding>;
-      if (typeof binding[command === "check" ? "typeCheck" : "lint"] !== "function") {
+      if (typeof binding[requiredBinding] !== "function") {
         throw new Error(`${packageName} does not expose the ${command} binding.`);
       }
       return binding as NativeBinding;
@@ -162,7 +177,29 @@ interface ParsedLintCommand {
 
 function printUsage(): void {
   console.error("Usage: vize <command> [options]");
-  console.error("Commands: check, lint, musea");
+  console.error("Commands: build, fmt, check, lint, upgrade, ready, musea");
+}
+
+function printBuildUsage(): void {
+  console.error("Usage: vize build [options] [files-or-directories]");
+  console.error("Options:");
+  console.error("  -o, --output <dir>             Output directory");
+  console.error("  -f, --format <js|json|stats>   Output format");
+  console.error("      --ssr                      Enable SSR compilation");
+  console.error("      --script-ext <mode>        preserve or downcompile");
+  console.error("  -j, --threads <number>         Worker thread count");
+}
+
+function printFmtUsage(): void {
+  console.error("Usage: vize fmt [options] [files-or-directories]");
+  console.error("Options:");
+  console.error("      --check                    Exit with an error if files need formatting");
+  console.error("  -w, --write                    Write formatted output");
+  console.error("      --single-quote             Use single quotes");
+  console.error("      --print-width <number>     Maximum line width");
+  console.error("      --tab-width <number>       Indentation width");
+  console.error("      --use-tabs                 Indent with tabs");
+  console.error("      --no-semi                  Omit semicolons");
 }
 
 function printCheckUsage(): void {
@@ -179,6 +216,23 @@ function printCheckUsage(): void {
   console.error(
     "Note: npm `vize check` uses the packaged NAPI checker. Install the Rust CLI for project-backed Corsa diagnostics.",
   );
+}
+
+function printUpgradeUsage(): void {
+  console.error("Usage: vize upgrade [options]");
+  console.error("Options:");
+  console.error("      --package-manager <name>   npm, pnpm, yarn, bun, or vp");
+  console.error("  -g, --global                   Upgrade the global installation");
+  console.error("      --dry-run                  Print the command without running it");
+}
+
+function printReadyUsage(): void {
+  console.error("Usage: vize ready [options] [files-or-directories]");
+  console.error("Runs: fmt --write -> lint -> check -> build");
+  console.error("Options:");
+  console.error("  -o, --output <dir>             Output directory for build");
+  console.error("      --ssr                      Enable SSR compilation for build");
+  console.error("      --script-ext <mode>        preserve or downcompile");
 }
 
 function resolvePackageBinaryFromCwd(packageName: string, binName: string = packageName): string {
@@ -257,6 +311,413 @@ function parseLintCommand(args: string[]): ParsedLintCommand {
   }
 
   return { patterns, options, sharedConfig };
+}
+
+// ============================================================================
+// Build command
+// ============================================================================
+
+interface NativeBuildOptions {
+  ssr?: boolean;
+  vapor?: boolean;
+  customRenderer?: boolean;
+  custom_renderer?: boolean;
+  isTs?: boolean;
+  is_ts?: boolean;
+  threads?: number;
+}
+
+interface BatchFileInput {
+  path: string;
+  source: string;
+}
+
+interface BatchFileResult {
+  path: string;
+  code: string;
+  css?: string;
+  errors: string[];
+  warnings: string[];
+  scopeId?: string;
+  scope_id?: string;
+  hasScoped?: boolean;
+  has_scoped?: boolean;
+}
+
+interface BatchCompileResult {
+  results: BatchFileResult[];
+  successCount?: number;
+  success_count?: number;
+  failedCount?: number;
+  failed_count?: number;
+  timeMs?: number;
+  time_ms?: number;
+}
+
+interface BuildOptions {
+  output: string;
+  format: "js" | "json" | "stats";
+  ssr?: boolean;
+  vapor?: boolean;
+  customRenderer?: boolean;
+  scriptExt: "preserve" | "downcompile";
+  threads?: number;
+  help?: boolean;
+}
+
+interface ParsedBuildCommand {
+  patterns: string[];
+  options: BuildOptions;
+  sharedConfig: SharedConfigOptions;
+}
+
+function parseBuildCommand(args: string[]): ParsedBuildCommand {
+  const patterns: string[] = [];
+  const options: BuildOptions = {
+    output: "./dist",
+    format: "js",
+    scriptExt: "downcompile",
+  };
+  const sharedConfig: SharedConfigOptions = {
+    configMode: "root",
+  };
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === "--output" || arg === "-o") {
+      options.output = args[++i] ?? options.output;
+    } else if (arg === "--format" || arg === "-f") {
+      const format = args[++i];
+      if (format === "js" || format === "json" || format === "stats") {
+        options.format = format;
+      }
+    } else if (arg === "--ssr") {
+      options.ssr = true;
+    } else if (arg === "--vapor") {
+      options.vapor = true;
+    } else if (arg === "--custom-renderer") {
+      options.customRenderer = true;
+    } else if (arg === "--script-ext") {
+      const scriptExt = args[++i];
+      if (scriptExt === "preserve" || scriptExt === "downcompile") {
+        options.scriptExt = scriptExt;
+      }
+    } else if (arg === "--threads" || arg === "-j") {
+      options.threads = Number.parseInt(args[++i], 10);
+    } else if (arg === "--config" || arg === "-c") {
+      const configFile = args[++i];
+      if (!configFile) {
+        throw new Error("Missing path after --config");
+      }
+      sharedConfig.configFile = configFile;
+    } else if (arg === "--no-config") {
+      sharedConfig.configMode = "none";
+    } else if (arg === "--profile" || arg === "--continue-on-error") {
+      // Accepted for command compatibility. The npm build path prints a compact summary.
+    } else if (arg === "--help" || arg === "-h") {
+      options.help = true;
+    } else if (!arg.startsWith("-")) {
+      patterns.push(arg);
+    }
+  }
+
+  return { patterns, options, sharedConfig };
+}
+
+function getScriptLang(source: string): string {
+  const match = source.match(/<script\b[^>]*\blang=["']([^"']+)["']/i);
+  return match?.[1] ?? "js";
+}
+
+function getOutputExtension(source: string, scriptExt: BuildOptions["scriptExt"]): string {
+  if (scriptExt === "downcompile") {
+    return "js";
+  }
+  const lang = getScriptLang(source);
+  return lang === "ts" || lang === "tsx" || lang === "jsx" ? lang : "js";
+}
+
+function outputFileName(file: string, extension: string): string {
+  return path.basename(file).replace(/\.vue$/i, `.${extension}`);
+}
+
+function toNativeBuildOptions(options: BuildOptions): NativeBuildOptions {
+  const isTs = options.scriptExt === "preserve";
+  return {
+    ssr: options.ssr,
+    vapor: options.vapor,
+    customRenderer: options.customRenderer,
+    custom_renderer: options.customRenderer,
+    isTs,
+    is_ts: isTs,
+    threads: options.threads,
+  };
+}
+
+async function runBuild(args: string[]): Promise<void> {
+  const { patterns, options, sharedConfig } = parseBuildCommand(args);
+  if (options.help) {
+    printBuildUsage();
+    return;
+  }
+
+  const config = await loadConfig(process.cwd(), {
+    mode: sharedConfig.configMode,
+    configFile: sharedConfig.configFile,
+    env: {
+      mode: process.env.NODE_ENV ?? "development",
+      command: "build",
+    },
+  });
+
+  if (sharedConfig.configFile && !config) {
+    throw new Error(`Could not find config file: ${sharedConfig.configFile}`);
+  }
+
+  options.ssr ??= config?.compiler?.ssr;
+  options.vapor ??= config?.compiler?.vapor;
+  options.customRenderer ??= config?.compiler?.customRenderer;
+  if (config?.compiler?.scriptExt === "ts") {
+    options.scriptExt = "preserve";
+  } else if (config?.compiler?.scriptExt === "js") {
+    options.scriptExt = "downcompile";
+  }
+
+  const files = collectVueFiles(patterns);
+  if (files.length === 0) {
+    process.stderr.write(`No Vue files found matching inputs: ${JSON.stringify(patterns)}\n`);
+    process.exit(1);
+  }
+
+  const inputs = files.map((file) => ({
+    path: file,
+    source: readFileSync(file, "utf8"),
+  }));
+  const native = loadNative("build");
+  const startedAt = performance.now();
+  const result = native.compileSfcBatchWithResults(inputs, toNativeBuildOptions(options));
+  const timeMs = result.timeMs ?? result.time_ms ?? performance.now() - startedAt;
+  const results = [...result.results].sort((left, right) => left.path.localeCompare(right.path));
+
+  if (options.format !== "stats") {
+    mkdirSync(options.output, { recursive: true });
+  }
+
+  for (const fileResult of results) {
+    const source = inputs.find((input) => input.path === fileResult.path)?.source ?? "";
+    for (const warning of fileResult.warnings) {
+      process.stderr.write(`warning: ${displayPath(fileResult.path)} ${warning}\n`);
+    }
+    for (const error of fileResult.errors) {
+      process.stderr.write(`error: ${displayPath(fileResult.path)} ${error}\n`);
+    }
+
+    if (fileResult.errors.length > 0 || options.format === "stats") {
+      continue;
+    }
+
+    const extension =
+      options.format === "json" ? "json" : getOutputExtension(source, options.scriptExt);
+    const outputPath = path.join(options.output, outputFileName(fileResult.path, extension));
+    const content =
+      options.format === "json" ? JSON.stringify(fileResult, null, 2) : fileResult.code;
+    writeFileSync(outputPath, content);
+  }
+
+  const failed =
+    result.failedCount ?? result.failed_count ?? results.filter((r) => r.errors.length).length;
+  const success = result.successCount ?? result.success_count ?? results.length - failed;
+  process.stderr.write(
+    `\x1b[32mOK\x1b[0m Built ${success} Vue file(s) in ${timeMs.toFixed(2)}ms\n`,
+  );
+
+  if (failed > 0) {
+    process.stderr.write(`\x1b[31mERR\x1b[0m ${failed} file(s) failed\n`);
+    process.exit(1);
+  }
+}
+
+// ============================================================================
+// Format command
+// ============================================================================
+
+interface NativeFormatOptions {
+  printWidth?: number;
+  print_width?: number;
+  tabWidth?: number;
+  tab_width?: number;
+  useTabs?: boolean;
+  use_tabs?: boolean;
+  semi?: boolean;
+  singleQuote?: boolean;
+  single_quote?: boolean;
+  sortAttributes?: boolean;
+  sort_attributes?: boolean;
+  singleAttributePerLine?: boolean;
+  single_attribute_per_line?: boolean;
+  maxAttributesPerLine?: number;
+  max_attributes_per_line?: number;
+  normalizeDirectiveShorthands?: boolean;
+  normalize_directive_shorthands?: boolean;
+}
+
+interface FormatResult {
+  code: string;
+  changed: boolean;
+}
+
+interface FmtOptions extends NativeFormatOptions {
+  check?: boolean;
+  write?: boolean;
+  help?: boolean;
+}
+
+interface ParsedFmtCommand {
+  patterns: string[];
+  options: FmtOptions;
+  sharedConfig: SharedConfigOptions;
+}
+
+function parseFmtCommand(args: string[]): ParsedFmtCommand {
+  const patterns: string[] = [];
+  const options: FmtOptions = {};
+  const sharedConfig: SharedConfigOptions = {
+    configMode: "root",
+  };
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === "--check") {
+      options.check = true;
+    } else if (arg === "--write" || arg === "-w") {
+      options.write = true;
+    } else if (arg === "--single-quote") {
+      options.singleQuote = true;
+    } else if (arg === "--print-width") {
+      options.printWidth = Number.parseInt(args[++i], 10);
+    } else if (arg === "--tab-width") {
+      options.tabWidth = Number.parseInt(args[++i], 10);
+    } else if (arg === "--use-tabs") {
+      options.useTabs = true;
+    } else if (arg === "--no-semi") {
+      options.semi = false;
+    } else if (arg === "--sort-attributes") {
+      options.sortAttributes = true;
+    } else if (arg === "--single-attribute-per-line") {
+      options.singleAttributePerLine = true;
+    } else if (arg === "--max-attributes-per-line") {
+      options.maxAttributesPerLine = Number.parseInt(args[++i], 10);
+    } else if (arg === "--normalize-directive-shorthands") {
+      options.normalizeDirectiveShorthands = true;
+    } else if (arg === "--config" || arg === "-c") {
+      const configFile = args[++i];
+      if (!configFile) {
+        throw new Error("Missing path after --config");
+      }
+      sharedConfig.configFile = configFile;
+    } else if (arg === "--no-config") {
+      sharedConfig.configMode = "none";
+    } else if (arg === "--profile") {
+      // Accepted for command compatibility. The npm fmt path prints a compact summary.
+    } else if (arg === "--help" || arg === "-h") {
+      options.help = true;
+    } else if (!arg.startsWith("-")) {
+      patterns.push(arg);
+    }
+  }
+
+  return { patterns, options, sharedConfig };
+}
+
+function toNativeFormatOptions(options: FmtOptions): NativeFormatOptions {
+  return {
+    printWidth: options.printWidth,
+    print_width: options.printWidth,
+    tabWidth: options.tabWidth,
+    tab_width: options.tabWidth,
+    useTabs: options.useTabs,
+    use_tabs: options.useTabs,
+    semi: options.semi,
+    singleQuote: options.singleQuote,
+    single_quote: options.singleQuote,
+    sortAttributes: options.sortAttributes,
+    sort_attributes: options.sortAttributes,
+    singleAttributePerLine: options.singleAttributePerLine,
+    single_attribute_per_line: options.singleAttributePerLine,
+    maxAttributesPerLine: options.maxAttributesPerLine,
+    max_attributes_per_line: options.maxAttributesPerLine,
+    normalizeDirectiveShorthands: options.normalizeDirectiveShorthands,
+    normalize_directive_shorthands: options.normalizeDirectiveShorthands,
+  };
+}
+
+async function runFmt(args: string[]): Promise<void> {
+  const { patterns, options, sharedConfig } = parseFmtCommand(args);
+  if (options.help) {
+    printFmtUsage();
+    return;
+  }
+
+  const config = await loadConfig(process.cwd(), {
+    mode: sharedConfig.configMode,
+    configFile: sharedConfig.configFile,
+    env: {
+      mode: process.env.NODE_ENV ?? "development",
+      command: "fmt",
+    },
+  });
+
+  if (sharedConfig.configFile && !config) {
+    throw new Error(`Could not find config file: ${sharedConfig.configFile}`);
+  }
+
+  options.printWidth ??= config?.formatter?.printWidth;
+  options.tabWidth ??= config?.formatter?.tabWidth;
+  options.useTabs ??= config?.formatter?.useTabs;
+  options.semi ??= config?.formatter?.semi;
+  options.singleQuote ??= config?.formatter?.singleQuote;
+
+  const files = collectVueFiles(patterns);
+  if (files.length === 0) {
+    process.stderr.write(`No Vue files found matching inputs: ${JSON.stringify(patterns)}\n`);
+    return;
+  }
+
+  const native = loadNative("fmt");
+  let changed = 0;
+  let errored = 0;
+
+  for (const file of files) {
+    const source = readFileSync(file, "utf8");
+    try {
+      const result = native.formatSfc(source, toNativeFormatOptions(options));
+      if (!result.changed) {
+        continue;
+      }
+      changed++;
+      if (options.check) {
+        process.stderr.write(`Would reformat: ${displayPath(file)}\n`);
+      } else if (options.write) {
+        writeFileSync(file, result.code);
+        process.stderr.write(`Reformatted: ${displayPath(file)}\n`);
+      } else {
+        process.stderr.write(`Would reformat: ${displayPath(file)}\n`);
+      }
+    } catch (error) {
+      errored++;
+      process.stderr.write(
+        `Error formatting ${displayPath(file)}: ${error instanceof Error ? error.message : String(error)}\n`,
+      );
+    }
+  }
+
+  process.stderr.write(
+    `\x1b[32mOK\x1b[0m Formatted ${files.length} Vue file(s), ${changed} changed\n`,
+  );
+
+  if (errored > 0 || (options.check && changed > 0)) {
+    process.exit(1);
+  }
 }
 
 // ============================================================================
@@ -510,7 +971,7 @@ function collectVueFilesFromGlob(pattern: string): string[] {
   });
 }
 
-function collectCheckFiles(patterns: string[]): string[] {
+function collectVueFiles(patterns: string[]): string[] {
   const files = new Set<string>();
   const inputs = patterns.length === 0 ? ["."] : patterns;
 
@@ -673,7 +1134,7 @@ async function runCheck(args: string[]): Promise<void> {
   options.checkEmits ??= config?.typeChecker?.checkEmits;
   options.checkTemplateBindings ??= config?.typeChecker?.checkTemplateBindings;
 
-  const files = collectCheckFiles(patterns);
+  const files = collectVueFiles(patterns);
   if (files.length === 0) {
     process.stderr.write(`No Vue files found matching inputs: ${JSON.stringify(patterns)}\n`);
     return;
@@ -784,11 +1245,235 @@ async function runLint(args: string[]): Promise<void> {
 }
 
 // ============================================================================
+// Upgrade command
+// ============================================================================
+
+type PackageManager = "bun" | "npm" | "pnpm" | "vp" | "yarn";
+
+interface UpgradeOptions {
+  packageManager?: PackageManager;
+  global?: boolean;
+  dryRun?: boolean;
+  help?: boolean;
+}
+
+function parseUpgradeCommand(args: string[]): UpgradeOptions {
+  const options: UpgradeOptions = {};
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === "--package-manager") {
+      const packageManager = args[++i];
+      if (
+        packageManager === "bun" ||
+        packageManager === "npm" ||
+        packageManager === "pnpm" ||
+        packageManager === "vp" ||
+        packageManager === "yarn"
+      ) {
+        options.packageManager = packageManager;
+      }
+    } else if (arg === "--global" || arg === "-g") {
+      options.global = true;
+    } else if (arg === "--dry-run") {
+      options.dryRun = true;
+    } else if (arg === "--help" || arg === "-h") {
+      options.help = true;
+    }
+  }
+
+  return options;
+}
+
+function readCwdPackageJson(): {
+  packageManager?: string;
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+} | null {
+  const packageJsonPath = path.join(process.cwd(), "package.json");
+  if (!existsSync(packageJsonPath)) {
+    return null;
+  }
+  return JSON.parse(readFileSync(packageJsonPath, "utf8"));
+}
+
+function detectPackageManager(explicit?: PackageManager): PackageManager {
+  if (explicit) {
+    return explicit;
+  }
+
+  const userAgent = process.env.npm_config_user_agent ?? "";
+  if (userAgent.startsWith("pnpm")) {
+    return "pnpm";
+  }
+  if (userAgent.startsWith("yarn")) {
+    return "yarn";
+  }
+  if (userAgent.startsWith("bun")) {
+    return "bun";
+  }
+  if (userAgent.startsWith("npm")) {
+    return "npm";
+  }
+
+  const packageManager = readCwdPackageJson()?.packageManager;
+  if (packageManager?.startsWith("pnpm")) {
+    return "pnpm";
+  }
+  if (packageManager?.startsWith("yarn")) {
+    return "yarn";
+  }
+  if (packageManager?.startsWith("bun")) {
+    return "bun";
+  }
+  return "npm";
+}
+
+function buildUpgradeCommand(
+  packageManager: PackageManager,
+  options: UpgradeOptions,
+): { command: string; args: string[] } {
+  const packageJson = readCwdPackageJson();
+  const saveDev = !packageJson?.dependencies?.vize;
+  const packageSpec = "vize@latest";
+
+  if (packageManager === "vp") {
+    return {
+      command: "vp",
+      args: ["install", ...(options.global ? ["-g"] : saveDev ? ["-D"] : []), packageSpec],
+    };
+  }
+  if (packageManager === "pnpm") {
+    return {
+      command: "pnpm",
+      args: ["add", ...(options.global ? ["-g"] : saveDev ? ["-D"] : []), packageSpec],
+    };
+  }
+  if (packageManager === "yarn") {
+    return {
+      command: "yarn",
+      args: options.global
+        ? ["global", "add", packageSpec]
+        : ["add", ...(saveDev ? ["-D"] : []), packageSpec],
+    };
+  }
+  if (packageManager === "bun") {
+    return {
+      command: "bun",
+      args: ["add", ...(options.global ? ["-g"] : saveDev ? ["-d"] : []), packageSpec],
+    };
+  }
+  return {
+    command: "npm",
+    args: ["install", ...(options.global ? ["-g"] : saveDev ? ["-D"] : []), packageSpec],
+  };
+}
+
+function runUpgrade(args: string[]): void {
+  const options = parseUpgradeCommand(args);
+  if (options.help) {
+    printUpgradeUsage();
+    return;
+  }
+
+  const packageManager = detectPackageManager(options.packageManager);
+  const command = buildUpgradeCommand(packageManager, options);
+
+  if (options.dryRun) {
+    process.stdout.write(`${command.command} ${command.args.join(" ")}\n`);
+    return;
+  }
+
+  const result = spawnSync(command.command, command.args, {
+    stdio: "inherit",
+    cwd: process.cwd(),
+    env: process.env,
+  });
+
+  if (result.error) {
+    throw result.error;
+  }
+
+  process.exit(result.status ?? 1);
+}
+
+// ============================================================================
+// Ready command
+// ============================================================================
+
+interface ReadyOptions {
+  output: string;
+  ssr?: boolean;
+  scriptExt: "preserve" | "downcompile";
+  help?: boolean;
+}
+
+interface ParsedReadyCommand {
+  patterns: string[];
+  options: ReadyOptions;
+}
+
+function parseReadyCommand(args: string[]): ParsedReadyCommand {
+  const patterns: string[] = [];
+  const options: ReadyOptions = {
+    output: "./dist",
+    scriptExt: "downcompile",
+  };
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === "--output" || arg === "-o") {
+      options.output = args[++i] ?? options.output;
+    } else if (arg === "--ssr") {
+      options.ssr = true;
+    } else if (arg === "--script-ext") {
+      const scriptExt = args[++i];
+      if (scriptExt === "preserve" || scriptExt === "downcompile") {
+        options.scriptExt = scriptExt;
+      }
+    } else if (arg === "--help" || arg === "-h") {
+      options.help = true;
+    } else if (!arg.startsWith("-")) {
+      patterns.push(arg);
+    }
+  }
+
+  return { patterns, options };
+}
+
+async function runReady(args: string[]): Promise<void> {
+  const { patterns, options } = parseReadyCommand(args);
+  if (options.help) {
+    printReadyUsage();
+    return;
+  }
+
+  process.stderr.write("vize ready: fmt\n");
+  await runFmt(["--write", ...patterns]);
+
+  process.stderr.write("vize ready: lint\n");
+  await runLint(patterns);
+
+  process.stderr.write("vize ready: check\n");
+  await runCheck(patterns);
+
+  process.stderr.write("vize ready: build\n");
+  await runBuild([
+    "--output",
+    options.output,
+    "--script-ext",
+    options.scriptExt,
+    ...(options.ssr ? ["--ssr"] : []),
+    ...patterns,
+  ]);
+}
+
+// ============================================================================
 // Command router
 // ============================================================================
 
-const NAPI_COMMANDS = new Set(["check", "lint"]);
-const JS_COMMANDS = new Set(["musea"]);
+const NAPI_COMMANDS = new Set(["build", "check", "fmt", "lint"]);
+const JS_COMMANDS = new Set(["musea", "ready", "upgrade"]);
 
 async function main(): Promise<void> {
   const args = process.argv.slice(2);
@@ -802,8 +1487,14 @@ async function main(): Promise<void> {
   if (NAPI_COMMANDS.has(command)) {
     const commandArgs = args.slice(1);
     switch (command) {
+      case "build":
+        await runBuild(commandArgs);
+        break;
       case "check":
         await runCheck(commandArgs);
+        break;
+      case "fmt":
+        await runFmt(commandArgs);
         break;
       case "lint":
         await runLint(commandArgs);
@@ -814,6 +1505,12 @@ async function main(): Promise<void> {
     switch (command) {
       case "musea":
         runMusea(commandArgs);
+        break;
+      case "ready":
+        await runReady(commandArgs);
+        break;
+      case "upgrade":
+        runUpgrade(commandArgs);
         break;
     }
   } else {


### PR DESCRIPTION
## Summary
- Expose npm `vize build`, `vize fmt`, `vize lint`, `vize check`, `vize ready`, and `vize upgrade` through the package CLI.
- Add Rust `ready` and `upgrade` commands, plus an NAPI `formatSfc` binding for npm formatting.
- Update README and docs for npm/Rust CLI usage, `ready`, and self-update flows.

## Validation
- `pnpm --dir npm/vize check`
- `pnpm --dir npm/vize build`
- `cargo fmt --check`
- `cargo check -p vize -p vize_vitrine --features vize_vitrine/napi`
- Node CLI fixture covering `build`, `fmt`, `lint`, `check`, `ready`, and `upgrade --dry-run`
