### PR TITLE
perf: reduce compiler hot path allocations

### DIFF
--- a/bench/vite.ts
+++ b/bench/vite.ts
@@ -115,7 +115,7 @@ async function buildWithVizePlugin(): Promise<number> {
   let vizePlugin: any;
   try {
     vizePlugin = (
-      await import(join(__dirname, "..", "npm", "vite-plugin-vize", "dist", "index.js"))
+      await import(join(__dirname, "..", "npm", "vite-plugin-vize", "dist", "index.mjs"))
     ).default;
   } catch {
     return -1;
@@ -185,7 +185,7 @@ if (vizeTime >= 0) {
   );
 } else {
   console.log(
-    "   @vizejs/vite-plugin : SKIPPED (plugin not built, run 'mise run build:vite-plugin')",
+    "   @vizejs/vite-plugin : SKIPPED (plugin not built, run 'vp run --workspace-root build:vite-plugin')",
   );
 }
 

--- a/crates/vize_atelier_sfc/src/parse/block.rs
+++ b/crates/vize_atelier_sfc/src/parse/block.rs
@@ -1,4 +1,4 @@
-use memchr::memchr;
+use memchr::{memchr, memchr_iter, memmem};
 use std::borrow::Cow;
 use vize_carton::{cstr, FxHashMap, String};
 
@@ -20,6 +20,17 @@ type BlockParseOutput<'a> = (
 );
 type BlockParseError = (&'static str, String);
 type BlockParseResult<'a> = Result<Option<BlockParseOutput<'a>>, BlockParseError>;
+
+struct BlockEndSearch<'a> {
+    bytes: &'a [u8],
+    source: &'a str,
+    tag_name: &'a [u8],
+    pos: usize,
+    content_start: usize,
+    start_line: usize,
+    initial_last_newline: usize,
+    attrs: BlockAttrs<'a>,
+}
 
 /// Build a uniform `(code, message)` error for any malformed block.
 fn build_malformed_error(tag_name: &[u8], reason: &str) -> BlockParseError {
@@ -52,6 +63,14 @@ fn is_tag_name_char_fast(b: u8) -> bool {
 #[inline(always)]
 fn is_whitespace_fast(b: u8) -> bool {
     matches!(b, b' ' | b'\t' | b'\n' | b'\r')
+}
+
+#[inline]
+fn advance_line(bytes: &[u8], base: usize, line: &mut usize, last_newline: &mut usize) {
+    for offset in memchr_iter(b'\n', bytes) {
+        *line += 1;
+        *last_newline = base + offset;
+    }
 }
 
 /// Find the end of a closing tag `</tag_name` followed by optional whitespace and `>`.
@@ -87,7 +106,7 @@ fn find_closing_tag_end(bytes: &[u8], pos: usize, len: usize, tag_name: &[u8]) -
 /// - `Ok(None)` — no SFC block starts at this position.
 /// - `Err(...)` — a block starts here but is incomplete or malformed.
 pub(super) fn parse_block_fast<'a>(
-    bytes: &[u8],
+    bytes: &'a [u8],
     source: &'a str,
     start: usize,
     start_line: usize,
@@ -274,62 +293,68 @@ pub(super) fn parse_block_fast<'a>(
         }
 
         while pos < len {
-            if bytes[pos] == b'\n' {
-                line += 1;
-                last_newline = pos;
+            let Some(lt_offset) = memchr(b'<', &bytes[pos..]) else {
+                advance_line(&bytes[pos..], pos, &mut line, &mut last_newline);
+                break;
+            };
+
+            advance_line(
+                &bytes[pos..pos + lt_offset],
+                pos,
+                &mut line,
+                &mut last_newline,
+            );
+            pos += lt_offset;
+
+            // Check for closing tag using byte comparison
+            if let Some(end_tag_pos) = is_closing_template_tag(bytes, pos, len) {
+                depth -= 1;
+                if depth == 0 {
+                    let content_end = pos;
+                    let end_pos = end_tag_pos;
+                    let col = pos - last_newline + (end_pos - pos);
+                    let content = Cow::Borrowed(&source[content_start..content_end]);
+                    return Ok(Some((
+                        tag_name,
+                        attrs,
+                        content,
+                        content_start,
+                        content_end,
+                        end_pos,
+                        line,
+                        col,
+                    )));
+                }
+                pos = end_tag_pos;
+                continue;
             }
 
-            if bytes[pos] == b'<' {
-                // Check for closing tag using byte comparison
-                if let Some(end_tag_pos) = is_closing_template_tag(bytes, pos, len) {
-                    depth -= 1;
-                    if depth == 0 {
-                        let content_end = pos;
-                        let end_pos = end_tag_pos;
-                        let col = pos - last_newline + (end_pos - pos);
-                        let content = Cow::Borrowed(&source[content_start..content_end]);
-                        return Ok(Some((
-                            tag_name,
-                            attrs,
-                            content,
-                            content_start,
-                            content_end,
-                            end_pos,
-                            line,
-                            col,
-                        )));
-                    }
-                    pos = end_tag_pos;
-                    continue;
-                }
-
-                // Check for nested opening tag
-                if starts_with_bytes(&bytes[pos + 1..], TAG_TEMPLATE) {
-                    let tag_check_pos = pos + 1 + TAG_TEMPLATE.len();
-                    if tag_check_pos < len {
-                        let next_char = bytes[tag_check_pos];
-                        if next_char == b' '
-                            || next_char == b'>'
-                            || next_char == b'\n'
-                            || next_char == b'\t'
-                            || next_char == b'\r'
-                        {
-                            // Check if self-closing
-                            let mut check_pos = tag_check_pos;
-                            let mut is_self_closing_nested = false;
-                            while check_pos < len && bytes[check_pos] != b'>' {
-                                if bytes[check_pos] == b'/'
-                                    && check_pos + 1 < len
-                                    && bytes[check_pos + 1] == b'>'
-                                {
-                                    is_self_closing_nested = true;
-                                    break;
-                                }
-                                check_pos += 1;
+            // Check for nested opening tag
+            if starts_with_bytes(&bytes[pos + 1..], TAG_TEMPLATE) {
+                let tag_check_pos = pos + 1 + TAG_TEMPLATE.len();
+                if tag_check_pos < len {
+                    let next_char = bytes[tag_check_pos];
+                    if next_char == b' '
+                        || next_char == b'>'
+                        || next_char == b'\n'
+                        || next_char == b'\t'
+                        || next_char == b'\r'
+                    {
+                        // Check if self-closing
+                        let mut check_pos = tag_check_pos;
+                        let mut is_self_closing_nested = false;
+                        while check_pos < len && bytes[check_pos] != b'>' {
+                            if bytes[check_pos] == b'/'
+                                && check_pos + 1 < len
+                                && bytes[check_pos + 1] == b'>'
+                            {
+                                is_self_closing_nested = true;
+                                break;
                             }
-                            if !is_self_closing_nested {
-                                depth += 1;
-                            }
+                            check_pos += 1;
+                        }
+                        if !is_self_closing_nested {
+                            depth += 1;
                         }
                     }
                 }
@@ -343,17 +368,31 @@ pub(super) fn parse_block_fast<'a>(
         ));
     }
 
-    // Custom block: need to find closing tag dynamically
-    if !tag_name.eq_ignore_ascii_case(TAG_SCRIPT) && !tag_name.eq_ignore_ascii_case(TAG_STYLE) {
-        return find_custom_block_end(
+    if tag_name.eq_ignore_ascii_case(TAG_STYLE) {
+        return find_block_end(BlockEndSearch {
             bytes,
             source,
             tag_name,
             pos,
             content_start,
             start_line,
+            initial_last_newline: start,
             attrs,
-        );
+        });
+    }
+
+    // Custom block: need to find closing tag dynamically
+    if !tag_name.eq_ignore_ascii_case(TAG_SCRIPT) {
+        return find_block_end(BlockEndSearch {
+            bytes,
+            source,
+            tag_name,
+            pos,
+            content_start,
+            start_line,
+            initial_last_newline: content_start,
+            attrs,
+        });
     }
 
     // For script blocks, we need to be aware of string literals to avoid
@@ -386,8 +425,10 @@ pub(super) fn parse_block_fast<'a>(
             if b == b'/' && pos + 1 < len && bytes[pos + 1] == b'/' {
                 // Skip to end of line
                 pos += 2;
-                while pos < len && bytes[pos] != b'\n' {
-                    pos += 1;
+                if let Some(newline_offset) = memchr(b'\n', &bytes[pos..]) {
+                    pos += newline_offset;
+                } else {
+                    pos = len;
                 }
                 continue;
             }
@@ -395,16 +436,17 @@ pub(super) fn parse_block_fast<'a>(
             // Check for multi-line comment
             if b == b'/' && pos + 1 < len && bytes[pos + 1] == b'*' {
                 pos += 2;
-                while pos + 1 < len {
-                    if bytes[pos] == b'\n' {
-                        line += 1;
-                        last_newline = pos;
-                    }
-                    if bytes[pos] == b'*' && bytes[pos + 1] == b'/' {
-                        pos += 2;
-                        break;
-                    }
-                    pos += 1;
+                if let Some(end_offset) = memmem::find(&bytes[pos..], b"*/") {
+                    advance_line(
+                        &bytes[pos..pos + end_offset],
+                        pos,
+                        &mut line,
+                        &mut last_newline,
+                    );
+                    pos += end_offset + 2;
+                } else {
+                    advance_line(&bytes[pos..], pos, &mut line, &mut last_newline);
+                    pos = len;
                 }
                 continue;
             }
@@ -530,29 +572,31 @@ pub(super) fn parse_block_fast<'a>(
     ))
 }
 
-/// Find the end of a custom block (non-template/script/style)
-fn find_custom_block_end<'a>(
-    bytes: &[u8],
-    source: &'a str,
-    tag_name: &'a [u8],
-    mut pos: usize,
-    content_start: usize,
-    start_line: usize,
-    attrs: BlockAttrs<'a>,
-) -> BlockParseResult<'a> {
+/// Find the end of a raw block by jumping between `<` bytes.
+fn find_block_end<'a>(search: BlockEndSearch<'a>) -> BlockParseResult<'a> {
+    let BlockEndSearch {
+        bytes,
+        source,
+        tag_name,
+        mut pos,
+        content_start,
+        start_line,
+        initial_last_newline,
+        attrs,
+    } = search;
     let len = bytes.len();
     let mut line = start_line;
-    let mut last_newline = content_start;
+    let mut last_newline = initial_last_newline;
 
     while pos < len {
         if let Some(lt_offset) = memchr(b'<', &bytes[pos..]) {
             // Count newlines
-            for &b in &bytes[pos..pos + lt_offset] {
-                if b == b'\n' {
-                    line += 1;
-                    last_newline = pos + lt_offset;
-                }
-            }
+            advance_line(
+                &bytes[pos..pos + lt_offset],
+                pos,
+                &mut line,
+                &mut last_newline,
+            );
             pos += lt_offset;
 
             // Check for closing tag (allows optional whitespace before '>')

--- a/crates/vize_atelier_sfc/src/parse/parse_sfc.rs
+++ b/crates/vize_atelier_sfc/src/parse/parse_sfc.rs
@@ -2,7 +2,7 @@ use crate::types::{
     BlockLocation, SfcCustomBlock, SfcDescriptor, SfcError, SfcParseOptions, SfcScriptBlock,
     SfcStyleBlock, SfcTemplateBlock,
 };
-use memchr::{memchr, memmem::Finder};
+use memchr::{memchr, memchr_iter, memmem::Finder};
 use std::borrow::Cow;
 
 use super::block::{parse_block_fast, tag_name_eq};
@@ -11,6 +11,21 @@ use super::block::{parse_block_fast, tag_name_eq};
 const TAG_TEMPLATE: &[u8] = b"template";
 const TAG_SCRIPT: &[u8] = b"script";
 const TAG_STYLE: &[u8] = b"style";
+
+#[inline]
+fn advance_line_column(bytes: &[u8], line: &mut usize, column: &mut usize) {
+    let mut last_newline = None;
+    for offset in memchr_iter(b'\n', bytes) {
+        *line += 1;
+        last_newline = Some(offset);
+    }
+
+    if let Some(offset) = last_newline {
+        *column = bytes.len() - offset;
+    } else {
+        *column += bytes.len();
+    }
+}
 
 /// Parse a Vue SFC into a descriptor with zero-copy strings
 pub fn parse_sfc<'a>(
@@ -55,14 +70,7 @@ pub fn parse_sfc<'a>(
         if bytes[pos] != b'<' {
             if let Some(next_lt) = memchr(b'<', &bytes[pos..]) {
                 // Update line/column for skipped content
-                for &b in &bytes[pos..pos + next_lt] {
-                    if b == b'\n' {
-                        line += 1;
-                        column = 1;
-                    } else {
-                        column += 1;
-                    }
-                }
+                advance_line_column(&bytes[pos..pos + next_lt], &mut line, &mut column);
                 pos += next_lt;
             } else {
                 break;
@@ -82,14 +90,7 @@ pub fn parse_sfc<'a>(
                 .unwrap_or(len); // unclosed comment: skip to EOF
 
             // Update line/column for the skipped comment
-            for &b in &bytes[pos..end] {
-                if b == b'\n' {
-                    line += 1;
-                    column = 1;
-                } else {
-                    column += 1;
-                }
-            }
+            advance_line_column(&bytes[pos..end], &mut line, &mut column);
             pos = end;
             continue;
         }
@@ -211,14 +212,7 @@ pub fn parse_sfc<'a>(
             Err((code, message)) => {
                 let mut end_line = line;
                 let mut end_column = column;
-                for &b in &bytes[pos..len] {
-                    if b == b'\n' {
-                        end_line += 1;
-                        end_column = 1;
-                    } else {
-                        end_column += 1;
-                    }
-                }
+                advance_line_column(&bytes[pos..len], &mut end_line, &mut end_column);
                 return Err(SfcError {
                     message,
                     code: Some(code.into()),

--- a/crates/vize_atelier_ssr/src/codegen/mod.rs
+++ b/crates/vize_atelier_ssr/src/codegen/mod.rs
@@ -8,7 +8,7 @@ pub(crate) mod helpers;
 
 use crate::options::SsrCompilerOptions;
 use vize_atelier_core::ast::{RootNode, RuntimeHelper, TemplateChildNode};
-use vize_carton::{camelize, capitalize, cstr, Bump, FxHashSet, String, ToCompactString};
+use vize_carton::{camelize, capitalize, Bump, FxHashSet, SmallVec, String, ToCompactString};
 
 /// SSR codegen result
 #[derive(Debug, Default)]
@@ -42,7 +42,7 @@ pub struct SsrCodegenContext<'a> {
     /// Used core helpers (from vue)
     pub(crate) core_helpers: FxHashSet<RuntimeHelper>,
     /// Current template literal parts being accumulated
-    pub(crate) current_template_parts: Vec<TemplatePart>,
+    pub(crate) current_template_parts: SmallVec<[TemplatePart; 8]>,
     /// Whether we have an open _push call
     #[allow(dead_code)]
     pub(crate) has_open_push: bool,
@@ -62,7 +62,7 @@ impl<'a> SsrCodegenContext<'a> {
             indent_level: 0,
             ssr_helpers: FxHashSet::default(),
             core_helpers: FxHashSet::default(),
-            current_template_parts: Vec::new(),
+            current_template_parts: SmallVec::new(),
             has_open_push: false,
             with_slot_scope_id: false,
             scoped_params: std::vec::Vec::new(),
@@ -154,9 +154,7 @@ impl<'a> SsrCodegenContext<'a> {
         for part in &parts {
             match part {
                 TemplatePart::Static(s) => {
-                    // Escape backticks and ${
-                    let escaped = s.replace('`', "\\`").replace("${", "\\${");
-                    self.push(&escaped);
+                    self.push_template_static(s);
                 }
                 TemplatePart::Dynamic(expr) => {
                     self.push("${");
@@ -167,6 +165,34 @@ impl<'a> SsrCodegenContext<'a> {
         }
 
         self.push("`)\n");
+    }
+
+    fn push_template_static(&mut self, value: &str) {
+        let bytes = value.as_bytes();
+        let mut start = 0;
+        let mut index = 0;
+
+        while index < bytes.len() {
+            match bytes[index] {
+                b'`' => {
+                    self.code.extend_from_slice(&bytes[start..index]);
+                    self.code.extend_from_slice(b"\\`");
+                    index += 1;
+                    start = index;
+                }
+                b'$' if index + 1 < bytes.len() && bytes[index + 1] == b'{' => {
+                    self.code.extend_from_slice(&bytes[start..index]);
+                    self.code.extend_from_slice(b"\\${");
+                    index += 2;
+                    start = index;
+                }
+                _ => {
+                    index += 1;
+                }
+            }
+        }
+
+        self.code.extend_from_slice(&bytes[start..]);
     }
 
     /// Use an SSR helper
@@ -288,11 +314,7 @@ impl<'a> SsrCodegenContext<'a> {
             preamble.push_str("import { ");
             let mut ssr_helpers: Vec<_> = self.ssr_helpers.iter().copied().collect();
             ssr_helpers.sort();
-            let helpers: Vec<_> = ssr_helpers
-                .iter()
-                .map(|h| cstr!("{} as _{}", h.name(), h.name()))
-                .collect();
-            preamble.push_str(&helpers.join(", "));
+            push_helper_imports(&mut preamble, &ssr_helpers);
             preamble.push_str(" } from \"@vue/server-renderer\"\n");
         }
 
@@ -301,15 +323,23 @@ impl<'a> SsrCodegenContext<'a> {
             preamble.push_str("import { ");
             let mut core_helpers: Vec<_> = self.core_helpers.iter().copied().collect();
             core_helpers.sort();
-            let helpers: Vec<_> = core_helpers
-                .iter()
-                .map(|h| cstr!("{} as _{}", h.name(), h.name()))
-                .collect();
-            preamble.push_str(&helpers.join(", "));
+            push_helper_imports(&mut preamble, &core_helpers);
             preamble.push_str(" } from \"vue\"\n");
         }
 
         preamble
+    }
+}
+
+fn push_helper_imports(out: &mut String, helpers: &[RuntimeHelper]) {
+    for (index, helper) in helpers.iter().enumerate() {
+        if index > 0 {
+            out.push_str(", ");
+        }
+        let name = helper.name();
+        out.push_str(name);
+        out.push_str(" as _");
+        out.push_str(name);
     }
 }
 

--- a/crates/vize_carton/src/hash.rs
+++ b/crates/vize_carton/src/hash.rs
@@ -24,7 +24,15 @@ pub fn hash_str(data: &str) -> u64 {
 /// Convert a hash to a hex string (16 characters).
 #[inline]
 pub fn hash_to_hex(hash: u64) -> String {
-    crate::cstr!("{hash:016x}")
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut bytes = [0u8; 16];
+    for (index, byte) in bytes.iter_mut().enumerate() {
+        let shift = (15 - index) * 4;
+        *byte = HEX[((hash >> shift) & 0xF) as usize];
+    }
+
+    // SAFETY: `HEX` only contains ASCII hex digits.
+    String::from(unsafe { std::str::from_utf8_unchecked(&bytes) })
 }
 
 /// Compute hash of a string and return as hex.

--- a/crates/vize_carton/src/lsp.rs
+++ b/crates/vize_carton/src/lsp.rs
@@ -33,12 +33,7 @@ impl JsonRpcRequest {
     /// Serialize to LSP message format (with Content-Length header).
     pub fn to_lsp_message(&self) -> Result<String, serde_json::Error> {
         let content = serde_json::to_string(self)?;
-        #[allow(clippy::disallowed_macros)]
-        Ok(format!(
-            "Content-Length: {}\r\n\r\n{}",
-            content.len(),
-            content
-        ))
+        Ok(lsp_message_from_json(content))
     }
 }
 
@@ -64,13 +59,19 @@ impl JsonRpcNotification {
     /// Serialize to LSP message format (with Content-Length header).
     pub fn to_lsp_message(&self) -> Result<String, serde_json::Error> {
         let content = serde_json::to_string(self)?;
-        #[allow(clippy::disallowed_macros)]
-        Ok(format!(
-            "Content-Length: {}\r\n\r\n{}",
-            content.len(),
-            content
-        ))
+        Ok(lsp_message_from_json(content))
     }
+}
+
+fn lsp_message_from_json(content: String) -> String {
+    use std::fmt::Write as _;
+
+    let mut message = String::with_capacity("Content-Length: ".len() + 20 + 4 + content.len());
+    message.push_str("Content-Length: ");
+    write!(&mut message, "{}", content.len()).expect("writing to String cannot fail");
+    message.push_str("\r\n\r\n");
+    message.push_str(&content);
+    message
 }
 
 /// JSON-RPC response.

--- a/crates/vize_vitrine/src/napi/sfc.rs
+++ b/crates/vize_vitrine/src/napi/sfc.rs
@@ -275,7 +275,7 @@ pub fn compile_sfc(
         external_scope_id
             .as_ref()
             .map(|scope_id| vize_atelier_dom::DomCompilerOptions {
-                scope_id: Some(cstr!("data-v-{scope_id}").into()),
+                scope_id: Some(cstr!("data-v-{scope_id}")),
                 ..Default::default()
             })
     } else {
@@ -384,87 +384,120 @@ pub fn compile_sfc_batch(
         ));
     }
 
-    let success = AtomicUsize::new(0);
-    let failed = AtomicUsize::new(0);
-    let input_bytes = AtomicUsize::new(0);
-    let output_bytes = AtomicUsize::new(0);
+    #[derive(Default)]
+    struct BatchStats {
+        success: usize,
+        failed: usize,
+        input_bytes: usize,
+        output_bytes: usize,
+    }
+
+    impl BatchStats {
+        fn failed() -> Self {
+            Self {
+                failed: 1,
+                ..Default::default()
+            }
+        }
+
+        fn failed_with_input(input_bytes: usize) -> Self {
+            Self {
+                failed: 1,
+                input_bytes,
+                ..Default::default()
+            }
+        }
+
+        fn success(input_bytes: usize, output_bytes: usize) -> Self {
+            Self {
+                success: 1,
+                input_bytes,
+                output_bytes,
+                failed: 0,
+            }
+        }
+
+        fn add(mut self, other: Self) -> Self {
+            self.success += other.success;
+            self.failed += other.failed;
+            self.input_bytes += other.input_bytes;
+            self.output_bytes += other.output_bytes;
+            self
+        }
+    }
 
     let start = Instant::now();
 
     // Compile files in parallel using rayon
-    files.par_iter().for_each(|path| {
-        let source = match fs::read_to_string(path) {
-            Ok(s) => s,
-            Err(_) => {
-                failed.fetch_add(1, Ordering::Relaxed);
-                return;
-            }
-        };
+    let stats = files
+        .par_iter()
+        .map(|path| {
+            let source = match fs::read_to_string(path) {
+                Ok(s) => s,
+                Err(_) => {
+                    return BatchStats::failed();
+                }
+            };
 
-        input_bytes.fetch_add(source.len(), Ordering::Relaxed);
+            let source_len = source.len();
 
-        let filename: vize_carton::CompactString = path.to_string_lossy().as_ref().into();
+            let filename: vize_carton::CompactString = path.to_string_lossy().as_ref().into();
 
-        // Parse
-        let parse_opts = SfcParseOptions {
-            filename: filename.clone(),
-            ..Default::default()
-        };
-
-        let descriptor = match sfc_parse(&source, parse_opts) {
-            Ok(d) => d,
-            Err(_) => {
-                failed.fetch_add(1, Ordering::Relaxed);
-                return;
-            }
-        };
-
-        // Compile
-        let has_scoped = descriptor.styles.iter().any(|s| s.scoped);
-        let compile_opts = SfcCompileOptions {
-            parse: SfcParseOptions {
+            // Parse
+            let parse_opts = SfcParseOptions {
                 filename: filename.clone(),
                 ..Default::default()
-            },
-            script: ScriptCompileOptions {
-                id: Some(filename.clone()),
-                is_ts,
-                ..Default::default()
-            },
-            template: TemplateCompileOptions {
-                id: Some(filename.clone()),
-                scoped: has_scoped,
-                ssr,
-                is_ts,
-                ..Default::default()
-            },
-            style: StyleCompileOptions {
-                id: filename,
-                scoped: has_scoped,
-                ..Default::default()
-            },
-            vapor,
-            scope_id: None,
-        };
+            };
 
-        match sfc_compile(&descriptor, compile_opts) {
-            Ok(result) => {
-                success.fetch_add(1, Ordering::Relaxed);
-                output_bytes.fetch_add(result.code.len(), Ordering::Relaxed);
+            let descriptor = match sfc_parse(&source, parse_opts) {
+                Ok(d) => d,
+                Err(_) => {
+                    return BatchStats::failed_with_input(source_len);
+                }
+            };
+
+            // Compile
+            let has_scoped = descriptor.styles.iter().any(|s| s.scoped);
+            let compile_opts = SfcCompileOptions {
+                parse: SfcParseOptions {
+                    filename: filename.clone(),
+                    ..Default::default()
+                },
+                script: ScriptCompileOptions {
+                    id: Some(filename.clone()),
+                    is_ts,
+                    ..Default::default()
+                },
+                template: TemplateCompileOptions {
+                    id: Some(filename.clone()),
+                    scoped: has_scoped,
+                    ssr,
+                    is_ts,
+                    ..Default::default()
+                },
+                style: StyleCompileOptions {
+                    id: filename,
+                    scoped: has_scoped,
+                    ..Default::default()
+                },
+                vapor,
+                scope_id: None,
+            };
+
+            match sfc_compile(&descriptor, compile_opts) {
+                Ok(result) => BatchStats::success(source_len, result.code.len()),
+                Err(_) => BatchStats::failed_with_input(source_len),
             }
-            Err(_) => {
-                failed.fetch_add(1, Ordering::Relaxed);
-            }
-        }
-    });
+        })
+        .reduce(BatchStats::default, BatchStats::add);
 
     let elapsed = start.elapsed();
 
     Ok(BatchCompileResultNapi {
-        success: success.load(Ordering::Relaxed) as u32,
-        failed: failed.load(Ordering::Relaxed) as u32,
-        input_bytes: input_bytes.load(Ordering::Relaxed) as u32,
-        output_bytes: output_bytes.load(Ordering::Relaxed) as u32,
+        success: stats.success as u32,
+        failed: stats.failed as u32,
+        input_bytes: stats.input_bytes as u32,
+        output_bytes: stats.output_bytes as u32,
         time_ms: elapsed.as_secs_f64() * 1000.0,
     })
 }
@@ -562,7 +595,7 @@ pub fn compile_sfc_batch_with_results(
         // Create compiler options with scope_id for scoped CSS
         let template_compiler_options = if actual_has_scoped {
             Some(vize_atelier_dom::DomCompilerOptions {
-                scope_id: Some(cstr!("data-v-{scope_id}").into()),
+                scope_id: Some(cstr!("data-v-{scope_id}")),
                 ..Default::default()
             })
         } else {

--- a/docs/content/architecture/performance.md
+++ b/docs/content/architecture/performance.md
@@ -13,10 +13,10 @@ Vize achieves significant performance improvements over the standard JavaScript-
 |             |                                           |
 | ----------- | ----------------------------------------- |
 | **Machine** | MacBook Pro (M2 Max, 12 cores, 96 GB RAM) |
-| **OS**      | macOS (Darwin 24.3.0)                     |
-| **Node.js** | v24.13.0                                  |
+| **OS**      | macOS 15.3.2 (Darwin 24.3.0)              |
+| **Node.js** | v24.14.0                                  |
 | **Vite**    | v8.0.0 (Rolldown)                         |
-| **Vue**     | v3.6.0-beta.1                             |
+| **Vue**     | v3.6.0-beta.10                            |
 
 ## Benchmark: 15,000 SFC Files
 
@@ -24,9 +24,9 @@ Compiling **15,000 Vue SFC files** (36.9 MB total):
 
 |                                | @vue/compiler-sfc | Vize  | Speedup   |
 | ------------------------------ | ----------------- | ----- | --------- |
-| **Single Thread**              | 9.28s             | 3.30s | **2.8x**  |
-| **Multi Thread**               | 3.35s             | 434ms | **7.7x**  |
-| **compiler-sfc ST vs Vize MT** | 9.28s             | 434ms | **20.9x** |
+| **Single Thread**              | 9.35s             | 3.47s | **2.7x**  |
+| **Multi Thread**               | 4.08s             | 353ms | **11.6x** |
+| **compiler-sfc ST vs Vize MT** | 9.35s             | 353ms | **26.0x** |
 
 The single-threaded improvement comes from Rust's zero-cost abstractions (no GC, no JIT warmup, cache-friendly memory layout). The multi-threaded improvement comes from Rayon's work-stealing thread pool, which scales near-linearly with CPU core count.
 
@@ -34,12 +34,12 @@ The single-threaded improvement comes from Rust's zero-cost abstractions (no GC,
 
 | Files  | Vize batch (1 thread) | Vize batch (12 threads) | Parallel Speedup |
 | ------ | --------------------- | ----------------------- | ---------------- |
-| 100    | 22ms                  | 3ms                     | 7.0x             |
-| 1,000  | 218ms                 | 25ms                    | 8.7x             |
-| 5,000  | 1.09s                 | 125ms                   | 8.7x             |
-| 15,000 | 3.65s                 | 432ms                   | 8.5x             |
+| 100    | 25ms                  | 3ms                     | 8.5x             |
+| 1,000  | 243ms                 | 26ms                    | 9.4x             |
+| 5,000  | 1.25s                 | 128ms                   | 9.7x             |
+| 15,000 | 3.75s                 | 373ms                   | 10.1x            |
 
-These native batch numbers include file reads. Small batches are dominated by fixed overhead; larger batches settle around 8.5x parallel speedup on this 12-core machine.
+These native batch numbers include file reads. Small batches are dominated by fixed overhead; larger batches settle around 10x parallel speedup on this 12-core machine.
 
 ## Why Rust?
 
@@ -111,9 +111,9 @@ The Vite plugin (`@vizejs/vite-plugin`) uses file-level caching. Only modified f
 
 Linting **15,000 Vue SFC files**:
 
-|          | eslint-plugin-vue (ST) | Vize patina (ST) | Speedup   | eslint-plugin-vue (MT) | Vize patina (MT) | Speedup  | **eslint ST vs Vize MT** |
-| -------- | ---------------------- | ---------------- | --------- | ---------------------- | ---------------- | -------- | ------------------------ |
-| **Time** | 65.30s                 | 5.45s            | **12.0x** | 26.82s                 | 5.48s            | **4.9x** | **11.9x**                |
+|          | eslint-plugin-vue (ST) | Vize patina (ST) | Speedup   | eslint-plugin-vue (MT) | Vize patina (MT) | Speedup   | **eslint ST vs Vize MT** |
+| -------- | ---------------------- | ---------------- | --------- | ---------------------- | ---------------- | --------- | ------------------------ |
+| **Time** | 45.08s                 | 4.02s            | **11.2x** | 16.38s                 | 784ms            | **20.9x** | **57.5x**                |
 
 Run `vp run --workspace-root bench:lint` to reproduce.
 
@@ -123,7 +123,7 @@ Formatting **15,000 Vue SFC files**:
 
 |          | Prettier (CLI) | Vize glyph (ST) | Speedup   | Vize glyph (MT) | **Prettier CLI vs Vize MT** |
 | -------- | -------------- | --------------- | --------- | --------------- | --------------------------- |
-| **Time** | 104.08s        | 3.44s           | **30.3x** | 1.32s           | **78.9x**                   |
+| **Time** | 101.20s        | 2.97s           | **34.1x** | 835ms           | **121.2x**                  |
 
 Run `vp run --workspace-root bench:fmt` to reproduce.
 
@@ -151,11 +151,11 @@ The current profile for this fixture keeps `canon.corsa.map_diagnostics` at ~31m
 
 ## Benchmark: Vite Plugin — @vizejs/vite-plugin vs @vitejs/plugin-vue
 
-Vite build with **15,000 Vue SFC imports** (all imported in a single entry):
+Vite build with **1,000 Vue SFC imports** (all imported in a single entry):
 
 |                | @vitejs/plugin-vue | @vizejs/vite-plugin | Speedup  |
 | -------------- | ------------------ | ------------------- | -------- |
-| **Build Time** | 16.98s             | 6.90s               | **2.5x** |
+| **Build Time** | 957ms              | 479ms               | **2.0x** |
 
 > Note: `@vizejs/vite-plugin` replaces only the Vue SFC compilation step — the performance difference comes entirely from that part. Dependency resolution, module graph construction, bundling (Rolldown), and all other Vite internals are identical to `@vitejs/plugin-vue`. For pure compilation performance, see the [Compiler benchmark](#benchmark-15000-sfc-files) above. `@vizejs/vite-plugin` eagerly pre-compiles `.vue` files using native multi-threaded compilation, which also enables faster HMR.
 

--- a/npm/vite-plugin-vize/README.md
+++ b/npm/vite-plugin-vize/README.md
@@ -210,10 +210,10 @@ When a `.vue` file changes:
 
 Vize's native compiler is significantly faster than the official Vue compiler:
 
-| Benchmark (15,000 SFCs) | @vue/compiler-sfc | Vize  | Speedup  |
-| ----------------------- | ----------------- | ----- | -------- |
-| Single-threaded         | 10.43s            | 6.06s | **1.7x** |
-| Multi-threaded          | 3.45s             | 612ms | **5.6x** |
+| Benchmark (15,000 SFCs) | @vue/compiler-sfc | Vize  | Speedup   |
+| ----------------------- | ----------------- | ----- | --------- |
+| Single-threaded         | 9.35s             | 3.47s | **2.7x**  |
+| Multi-threaded          | 4.08s             | 353ms | **11.6x** |
 
 ## Comparison with vite-plugin-vize
 


### PR DESCRIPTION
## Summary

- speed up SFC block scans by jumping between delimiter bytes and using memchr/memmem for line accounting
- reduce SSR codegen allocations by using inline template parts and streaming static template escaping/import preambles
- remove small formatting and shared atomic overhead in carton helpers and native batch compilation
- refresh benchmark docs and the native Vite plugin README with current measurements
- fix the Vite plugin benchmark to load the current `dist/index.mjs` output

## Benchmark Refresh

- compiler, 15,000 SFCs: native MT 353ms vs @vue/compiler-sfc MT 4.08s; compiler ST vs native MT 26.0x
- native batch scaling, 15,000 SFCs: 3.75s on 1 thread vs 373ms on 12 threads; 10.1x parallel speedup
- lint, 15,000 SFCs: native MT 784ms vs eslint MT 16.38s; eslint ST vs native MT 57.5x
- format, 15,000 SFCs: native MT 835ms vs Prettier 101.20s; 121.2x
- Vite plugin, 1,000 imported SFCs: 479ms vs 957ms; 2.0x
- `bench:check` was attempted locally, but the native typecheck run exceeded 10 minutes in the Corsa/tsgo diagnostics path, so that table was left unchanged

## Validation

- cargo fmt --all -- --check
- cargo clippy --workspace -- -D warnings
- cargo test --workspace
- node --test --test-concurrency=1 tests/tooling/*.test.ts
- pnpm -C npm/vite-plugin-vize test
- pnpm -C npm/oxlint-plugin-vize test
- pnpm -C npm/unplugin-vize test
- pnpm -C npm/rspack-vize-plugin test
- pnpm -C playground test
- vp run --workspace-root lint
- vp run --workspace-root build:native
- vp run --workspace-root build:cli
- pnpm -C npm/vize build
- pnpm -C npm/vite-plugin-vize build
- vp run --workspace-root bench
- vp run --workspace-root bench:quick
- vp run --workspace-root bench:lint
- vp run --workspace-root bench:fmt
- vp run --workspace-root bench:vite
- cargo bench -p vize_atelier_sfc --bench sfc_parse -- --warm-up-time 1 --measurement-time 2
- cargo bench -p vize_atelier_sfc --bench sfc_compile -- --warm-up-time 1 --measurement-time 2

## Notes

- `pnpm -C playground test:vrt` was also tried locally. The runtime-clean checks passed, while 14 screenshot snapshots differed against the Linux baseline noted in the test comments.
