### PR TITLE
fix: resolve open issue regressions

### DIFF
--- a/crates/vize_atelier_core/src/codegen.rs
+++ b/crates/vize_atelier_core/src/codegen.rs
@@ -320,6 +320,35 @@ mod tests {
     }
 
     #[test]
+    fn test_codegen_conditional_named_slot_preserves_implicit_default_slot() {
+        let result = compile!(
+            r#"<Parent>
+  Not rendering!
+  <template v-if="showNamed" #named>
+    Named content
+  </template>
+</Parent>"#
+        );
+        let output = result_output(&result);
+
+        assert!(
+            output.contains("default: _withCtx(() => ["),
+            "implicit default slot should be generated when createSlots is used:\n{}",
+            output
+        );
+        assert!(
+            output.contains("Not rendering!"),
+            "default slot text should be preserved:\n{}",
+            output
+        );
+        assert!(
+            output.contains("name: \"named\""),
+            "conditional named slot should still be dynamic:\n{}",
+            output
+        );
+    }
+
+    #[test]
     fn test_codegen_default_slot_with_v_if_is_marked_dynamic() {
         let result = compile!(
             r#"<PageWithHeader>

--- a/crates/vize_atelier_core/src/codegen/slots.rs
+++ b/crates/vize_atelier_core/src/codegen/slots.rs
@@ -356,6 +356,37 @@ fn has_conditional_or_loop_slots(el: &ElementNode<'_>) -> bool {
     })
 }
 
+fn child_is_slot_template(child: &TemplateChildNode<'_>) -> bool {
+    match child {
+        TemplateChildNode::Element(el) => el.tag.as_str() == "template" && has_v_slot(el),
+        TemplateChildNode::If(if_node) => if_node.branches.iter().any(|branch| {
+            branch.children.iter().any(|child| {
+                matches!(
+                    child,
+                    TemplateChildNode::Element(el)
+                        if el.tag.as_str() == "template" && has_v_slot(el)
+                )
+            })
+        }),
+        TemplateChildNode::For(for_node) => for_node.children.iter().any(|child| {
+            matches!(
+                child,
+                TemplateChildNode::Element(el)
+                    if el.tag.as_str() == "template" && has_v_slot(el)
+            )
+        }),
+        _ => false,
+    }
+}
+
+fn slot_children_have_meaningful_content(children: &[&TemplateChildNode<'_>]) -> bool {
+    children.iter().any(|child| match child {
+        TemplateChildNode::Text(text) => !text.content.trim().is_empty(),
+        TemplateChildNode::Comment(_) => false,
+        _ => true,
+    })
+}
+
 /// Generate slots object for component
 pub fn generate_slots(ctx: &mut CodegenContext, el: &ElementNode<'_>) {
     // Note: WithCtx helper is registered at each _withCtx() output site,
@@ -569,7 +600,9 @@ pub fn generate_slots(ctx: &mut CodegenContext, el: &ElementNode<'_>) {
 fn generate_create_slots(ctx: &mut CodegenContext, el: &ElementNode<'_>) {
     ctx.use_helper(RuntimeHelper::CreateSlots);
     ctx.push(ctx.helper(RuntimeHelper::CreateSlots));
-    ctx.push("({ _: 2 /* DYNAMIC */ }, [");
+    ctx.push("(");
+    generate_create_slots_base(ctx, el);
+    ctx.push(", [");
     ctx.indent();
 
     let mut first = true;
@@ -612,6 +645,47 @@ fn generate_create_slots(ctx: &mut CodegenContext, el: &ElementNode<'_>) {
     ctx.deindent();
     ctx.newline();
     ctx.push("])");
+}
+
+fn generate_create_slots_base(ctx: &mut CodegenContext, el: &ElementNode<'_>) {
+    let default_children: Vec<_> = el
+        .children
+        .iter()
+        .filter(|child| !child_is_slot_template(child))
+        .collect();
+    let has_default_children = slot_children_have_meaningful_content(&default_children);
+
+    if !has_default_children {
+        ctx.push("{ _: 2 /* DYNAMIC */ }");
+        return;
+    }
+
+    ctx.push("{");
+    ctx.indent();
+
+    ctx.newline();
+    ctx.push("default: ");
+    ctx.use_helper(RuntimeHelper::WithCtx);
+    ctx.push(ctx.helper(RuntimeHelper::WithCtx));
+    ctx.push("(() => [");
+    ctx.indent();
+    for (i, child) in default_children.iter().enumerate() {
+        if i > 0 {
+            ctx.push(",");
+        }
+        ctx.newline();
+        generate_slot_child_node(ctx, child);
+    }
+    ctx.deindent();
+    ctx.newline();
+    ctx.push("]),");
+
+    ctx.newline();
+    ctx.push("_: 2 /* DYNAMIC */");
+
+    ctx.deindent();
+    ctx.newline();
+    ctx.push("}");
 }
 
 /// Generate a conditional slot entry (v-if on slot template)

--- a/crates/vize_atelier_sfc/src/parse/block.rs
+++ b/crates/vize_atelier_sfc/src/parse/block.rs
@@ -73,6 +73,86 @@ fn advance_line(bytes: &[u8], base: usize, line: &mut usize, last_newline: &mut 
     }
 }
 
+fn can_start_regex_literal(prev_significant_char: u8) -> bool {
+    matches!(
+        prev_significant_char,
+        b'=' | b'('
+            | b'['
+            | b','
+            | b':'
+            | b'{'
+            | b';'
+            | b'\n'
+            | b'?'
+            | b'&'
+            | b'|'
+            | b'+'
+            | b'-'
+            | b'*'
+            | b'!'
+            | b'>'
+            | b'<'
+            | b'%'
+            | b'^'
+    )
+}
+
+fn skip_regex_literal(
+    bytes: &[u8],
+    mut pos: usize,
+    len: usize,
+    line: &mut usize,
+    last_newline: &mut usize,
+) -> Option<usize> {
+    debug_assert_eq!(bytes[pos], b'/');
+    pos += 1;
+    let mut in_character_class = false;
+
+    while pos < len {
+        let c = bytes[pos];
+
+        if c == b'\n' {
+            // An unescaped newline terminates JavaScript regex literals. Stop
+            // treating this as regex so normal malformed-block handling wins.
+            return None;
+        }
+
+        if c == b'\\' {
+            if pos + 1 < len && bytes[pos + 1] == b'\n' {
+                *line += 1;
+                *last_newline = pos + 1;
+            }
+            pos = (pos + 2).min(len);
+            continue;
+        }
+
+        if in_character_class {
+            if c == b']' {
+                in_character_class = false;
+            }
+            pos += 1;
+            continue;
+        }
+
+        match c {
+            b'[' => {
+                in_character_class = true;
+                pos += 1;
+            }
+            b'/' => {
+                pos += 1;
+                while pos < len && (bytes[pos].is_ascii_alphanumeric() || bytes[pos] == b'_') {
+                    pos += 1;
+                }
+                return Some(pos);
+            }
+            _ => pos += 1,
+        }
+    }
+
+    None
+}
+
 /// Find the end of a closing tag `</tag_name` followed by optional whitespace and `>`.
 /// Returns the position immediately after `>`, or `None` if no valid closing tag at `pos`.
 #[inline]
@@ -449,6 +529,16 @@ pub(super) fn parse_block_fast<'a>(
                     pos = len;
                 }
                 continue;
+            }
+
+            if b == b'/' && can_start_regex_literal(prev_significant_char) {
+                if let Some(next_pos) =
+                    skip_regex_literal(bytes, pos, len, &mut line, &mut last_newline)
+                {
+                    prev_significant_char = b'/';
+                    pos = next_pos;
+                    continue;
+                }
             }
 
             // Check for string literals (', ", `)

--- a/crates/vize_atelier_sfc/src/parse/tests.rs
+++ b/crates/vize_atelier_sfc/src/parse/tests.rs
@@ -325,6 +325,20 @@ const e = 5
 }
 
 #[test]
+fn test_script_with_regex_character_class_containing_comment_start() {
+    let source = r#"<script>
+const regexp = /[/*]/g;
+</script>"#;
+    let result = parse_sfc(source, Default::default()).unwrap();
+
+    assert!(result.script.is_some());
+    assert_eq!(
+        result.script.unwrap().content.trim(),
+        "const regexp = /[/*]/g;"
+    );
+}
+
+#[test]
 fn test_script_with_division_operator() {
     // Test that division operator doesn't interfere with string detection
     let source = r#"<script setup>

--- a/docs/content/integrations/vscode.md
+++ b/docs/content/integrations/vscode.md
@@ -9,10 +9,13 @@ title: VS Code
 > **Important:** For day-to-day Vue editor support, keep using the official Vue language tools
 > (`vuejs/language-tools`) for now. Vize is designed for incremental opt-in evaluation.
 
-Vize currently ships two VS Code extensions:
+The repository contains two experimental VS Code extensions:
 
 - **Vize** — Vue language support backed by `vize lsp`
 - **Vize Art** — syntax highlighting for Musea `*.art.vue` files
+
+They are not published to the VS Code Marketplace yet. Install from a locally built VSIX or run the
+extension development host while the editor packages stabilize.
 
 Install both if you want `*.art.vue` to receive Vize hover, completion, go-to-definition, and
 reference support in addition to syntax highlighting.
@@ -68,7 +71,7 @@ vize lsp (vize_maestro)
   → vize_glyph
 ```
 
-### Installing from Source
+### Installing from Source or VSIX
 
 Install `vp` once from the [Vite+ install guide](https://viteplus.dev/guide/install), then:
 
@@ -78,6 +81,8 @@ cd vize
 cd npm/vscode-vize
 vp install --ignore-workspace
 vp build
+vp exec vsce package --no-dependencies --out dist/vize.vsix
+code --install-extension dist/vize.vsix
 ```
 
 ## Vize Art Extension
@@ -101,5 +106,13 @@ Example Neovim setup:
 require("lspconfig").vize.setup({
   cmd = { "vize", "lsp" },
   filetypes = { "vue" },
+  init_options = {
+    lint = true,
+    typecheck = false,
+    editor = false,
+  },
 })
 ```
+
+When another TypeScript server such as tsgo owns project diagnostics, keep `typecheck = false` and
+turn on only the Vue-specific capabilities you want to evaluate.

--- a/npm/vite-plugin-vize/src/compiler.test.ts
+++ b/npm/vite-plugin-vize/src/compiler.test.ts
@@ -155,6 +155,43 @@ assert.doesNotMatch(
   "Vapor builds must not leave dotted imported components to runtime resolution",
 );
 
+const antDesignScopedSlotSource = `<script setup lang="ts">
+import { Table } from "ant-design-vue";
+const columns = [{ key: "name" }, { key: "phone" }];
+const dataSource = [{ name: "Lin", phone: "123" }];
+</script>
+
+<template>
+  <Table :columns="columns" :data-source="dataSource">
+    <template #bodyCell="{ column, record }">
+      <template v-if="column.key === 'name'">
+        {{ record.name }}
+      </template>
+      <template v-else-if="column.key === 'phone'">
+        {{ record.phone }}
+      </template>
+    </template>
+  </Table>
+</template>`;
+
+const antDesignScopedSlotCompiled = compileFile(
+  "/src/AntDesignScopedSlot.vue",
+  new Map(),
+  { sourceMap: false, ssr: false, vapor: false },
+  antDesignScopedSlotSource,
+);
+
+assert.match(
+  antDesignScopedSlotCompiled.code,
+  /bodyCell: _withCtx\(\(\{ column, record \}\) => \[/,
+  "Ant Design table bodyCell slot should compile with scoped slot params",
+);
+assert.doesNotMatch(
+  antDesignScopedSlotCompiled.code,
+  /_ctx\.(?:column|record)\b/,
+  "Scoped slot params must stay local inside nested v-if templates",
+);
+
 const customRendererSource = `<script setup lang="ts">
 import { Primitive } from "@tresjs/core";
 const visible = true;

--- a/npm/vscode-art/README.md
+++ b/npm/vscode-art/README.md
@@ -33,6 +33,9 @@ import Button from "./Button.vue";
 
 ## Installation
 
+This extension is not published to the VS Code Marketplace yet. Use a locally built VSIX while the
+editor package stabilizes.
+
 ### From VSIX
 
 ```bash

--- a/npm/vscode-vize/README.md
+++ b/npm/vscode-vize/README.md
@@ -18,9 +18,8 @@ Vue Language Support powered by Vize - A high-performance language server for Vu
 
 ## Installation
 
-### From VS Code Marketplace
-
-Search "Vize" in VS Code Extensions.
+The extension is not published to the VS Code Marketplace yet. Use a locally built VSIX while the
+editor package stabilizes.
 
 ### From VSIX
 
@@ -36,6 +35,7 @@ Install `vp` once from the [Vite+ install guide](https://viteplus.dev/guide/inst
 cd npm/vscode-vize
 vp install --ignore-workspace
 vp build
+vp exec vsce package --no-dependencies --out dist/vize.vsix
 # Press F5 to launch Extension Development Host
 ```
 

--- a/tests/expected/vdom/v-slot.snap
+++ b/tests/expected/vdom/v-slot.snap
@@ -391,6 +391,35 @@ export function render(_ctx, _cache) {
 }
 
 ===
+name: conditional named slot with default
+options: default
+--- INPUT ---
+<MyComponent>Default content<template #header v-if="show">Header</template></MyComponent>
+--- OUTPUT ---
+import { createTextVNode as _createTextVNode, resolveComponent as _resolveComponent, withCtx as _withCtx, createSlots as _createSlots, openBlock as _openBlock, createBlock as _createBlock } from "vue"
+
+export function render(_ctx, _cache) {
+  const _component_MyComponent = _resolveComponent("MyComponent")
+
+  return (_openBlock(), _createBlock(_component_MyComponent, null, _createSlots({
+    default: _withCtx(() => [
+      _createTextVNode("Default content")
+    ]),
+    _: 2 /* DYNAMIC */
+  }, [
+    (_ctx.show)
+      ? {
+          name: "header",
+          fn: _withCtx(() => [
+            _createTextVNode("Header")
+          ]),
+          key: "0"
+        }
+      : undefined
+  ]), 1024 /* DYNAMIC_SLOTS */))
+}
+
+===
 name: slot with v-for
 options: default
 --- INPUT ---

--- a/tests/fixtures/vdom/v-slot.toml
+++ b/tests/fixtures/vdom/v-slot.toml
@@ -107,6 +107,10 @@ name = "slot with v-if"
 input = '<MyComponent><template #header v-if="show">Header</template></MyComponent>'
 
 [[cases]]
+name = "conditional named slot with default"
+input = '<MyComponent>Default content<template #header v-if="show">Header</template></MyComponent>'
+
+[[cases]]
 name = "slot with v-for"
 input = '<MyComponent><template #item v-for="item in items" :key="item.id">{{ item }}</template></MyComponent>'
 


### PR DESCRIPTION
## Summary
- Preserve implicit default slot children when conditional named slots require dynamic slot creation.
- Parse JavaScript regex literals in SFC script blocks so comment-like character classes do not hide closing tags.
- Add Ant Design Vue scoped-slot regression coverage and clarify local VSIX / tsgo editor docs.

## Validation
- `cargo fmt --all`
- `RUSTFLAGS='-C debuginfo=0' cargo test -p vize_atelier_core conditional`
- `RUSTFLAGS='-C debuginfo=0' cargo test -p vize_atelier_sfc regex_character_class`
- `RUSTFLAGS='-C debuginfo=0' pnpm --dir npm/vite-plugin-vize test`
- `RUSTFLAGS='-C debuginfo=0' cargo test -p vize_test_runner vdom_v_slot -- --ignored` still reports an existing `Transition slot` snapshot mismatch outside this patch.

## Issues
Closes #177
Closes #176
Closes #122
Closes #91
Closes #79
Refs #24
Refs #23
Refs #21
Refs #18
Refs #12
Refs #10
