### PR TITLE
test: guard app e2e CI runs

### DIFF
--- a/tests/app/playwright.config.ts
+++ b/tests/app/playwright.config.ts
@@ -7,13 +7,15 @@ export default defineConfig({
   timeout: 300_000,
   expect: { timeout: 30_000 },
   fullyParallel: false,
-  retries: 0,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
   workers: 1,
-  reporter: "list",
+  reporter: process.env.CI ? [["list"], ["html", { open: "never" }]] : "list",
   use: {
     headless: true,
     screenshot: "only-on-failure",
     trace: "retain-on-failure",
+    video: "retain-on-failure",
   },
   projects: [
     {

--- a/tests/tooling/playwright-app-config.test.ts
+++ b/tests/tooling/playwright-app-config.test.ts
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+
+function readRepoFile(...segments: string[]): string {
+  return fs.readFileSync(path.join(root, ...segments), "utf8");
+}
+
+test("app e2e Playwright config keeps CI runs guarded and debuggable", () => {
+  const config = readRepoFile("tests", "app", "playwright.config.ts");
+
+  assert.match(config, /forbidOnly:\s*!!process\.env\.CI/);
+  assert.match(config, /retries:\s*process\.env\.CI \? 2 : 0/);
+  assert.match(
+    config,
+    /reporter:\s*process\.env\.CI \? \[\["list"\], \["html", \{ open: "never" \}\]\] : "list"/,
+  );
+  assert.match(config, /screenshot:\s*"only-on-failure"/);
+  assert.match(config, /trace:\s*"retain-on-failure"/);
+  assert.match(config, /video:\s*"retain-on-failure"/);
+});


### PR DESCRIPTION
## Summary

- Adds CI-only `.only` protection and retries for the app e2e Playwright suite.
- Keeps list output locally while producing an HTML report in CI.
- Retains screenshots, traces, and video on failures for faster diagnosis.

## Validation

- `node --test tests/tooling/playwright-app-config.test.ts`
- `vp check tests/app/playwright.config.ts tests/tooling/playwright-app-config.test.ts`
