### PR TITLE
perf: reduce props codegen scans

### DIFF
--- a/crates/vize_atelier_core/src/codegen/props/events.rs
+++ b/crates/vize_atelier_core/src/codegen/props/events.rs
@@ -5,7 +5,7 @@ use crate::ast::{DirectiveNode, ExpressionNode, PropNode, RuntimeHelper};
 use super::super::{
     context::CodegenContext, expression::generate_event_handler, helpers::camelize,
 };
-use vize_carton::{FxHashMap, String};
+use vize_carton::String;
 
 /// Get the event key for a v-on directive (e.g., "onClick", "onKeyupEnter")
 pub(super) fn get_von_event_key(dir: &DirectiveNode<'_>) -> Option<String> {
@@ -27,19 +27,6 @@ pub(super) fn get_von_event_key(dir: &DirectiveNode<'_>) -> Option<String> {
     } else {
         None
     }
-}
-
-/// Count occurrences of each event name across all v-on directives
-pub(super) fn count_event_names(props: &[PropNode<'_>]) -> FxHashMap<String, usize> {
-    let mut counts = FxHashMap::default();
-    for p in props {
-        if let PropNode::Directive(dir) = p {
-            if let Some(key) = get_von_event_key(dir) {
-                *counts.entry(key).or_insert(0) += 1;
-            }
-        }
-    }
-    counts
 }
 
 /// Generate merged event handlers for the same event name as array syntax

--- a/crates/vize_atelier_core/src/codegen/props/generate.rs
+++ b/crates/vize_atelier_core/src/codegen/props/generate.rs
@@ -9,9 +9,9 @@ use super::{
         helpers::{escape_js_string, is_valid_js_identifier},
     },
     directives::{generate_directive_prop_with_static, is_supported_directive},
-    events::{count_event_names, generate_merged_event_handlers, get_von_event_key},
-    generate_vbind_object_exp, generate_von_object_exp, has_dynamic_key, has_dynamic_vmodel,
-    has_other_props, has_vbind_object, has_von_object,
+    events::{generate_merged_event_handlers, get_von_event_key},
+    generate_vbind_object_exp, generate_von_object_exp,
+    scan::PropsScan,
 };
 use vize_carton::{FxHashSet, String};
 
@@ -37,14 +37,15 @@ pub fn generate_props(ctx: &mut CodegenContext, props: &[PropNode<'_>]) {
         return;
     }
 
-    // Check for v-bind object (v-bind="attrs") and v-on object (v-on="handlers")
-    let has_vbind_obj = has_vbind_object(props);
-    let has_von_obj = has_von_object(props);
-    let has_other = has_other_props(props);
+    if try_generate_static_attrs(ctx, props, scope_id.as_deref()) {
+        return;
+    }
+
+    let scan = PropsScan::new(ctx, props, ctx.skip_is_prop);
 
     // Handle cases with object spreads (v-bind="obj" or v-on="obj")
-    if has_vbind_obj || has_von_obj {
-        if has_other || (has_vbind_obj && has_von_obj) {
+    if scan.has_vbind_obj || scan.has_von_obj {
+        if scan.has_other || (scan.has_vbind_obj && scan.has_von_obj) {
             // Multiple spreads or spread with other props: _mergeProps(...)
             ctx.use_helper(RuntimeHelper::MergeProps);
             ctx.push(ctx.helper(RuntimeHelper::MergeProps));
@@ -53,13 +54,13 @@ pub fn generate_props(ctx: &mut CodegenContext, props: &[PropNode<'_>]) {
             let mut first_merge_arg = true;
 
             // Add v-bind object spread
-            if has_vbind_obj {
+            if scan.has_vbind_obj {
                 generate_vbind_object_exp(ctx, props);
                 first_merge_arg = false;
             }
 
             // Add v-on object spread (wrapped with toHandlers)
-            if has_von_obj {
+            if scan.has_von_obj {
                 if !first_merge_arg {
                     ctx.push(", ");
                 }
@@ -69,11 +70,11 @@ pub fn generate_props(ctx: &mut CodegenContext, props: &[PropNode<'_>]) {
 
             // Add other props as object (includes scope_id)
             // Inside mergeProps, skip normalizeClass/normalizeStyle - mergeProps handles it
-            if has_other {
+            if scan.has_other {
                 if !first_merge_arg {
                     ctx.push(", ");
                 }
-                generate_props_object_inner(ctx, props, true, true);
+                generate_props_object_inner(ctx, props, true, true, &scan);
             } else if let Some(ref sid) = scope_id {
                 // No other props but we have scope_id, add it as separate object
                 if !first_merge_arg {
@@ -85,7 +86,7 @@ pub fn generate_props(ctx: &mut CodegenContext, props: &[PropNode<'_>]) {
             }
 
             ctx.push(")");
-        } else if has_vbind_obj {
+        } else if scan.has_vbind_obj {
             // v-bind="attrs" alone
             // If we have scope_id, we need to merge it with the bound object
             if let Some(ref sid) = scope_id {
@@ -138,16 +139,14 @@ pub fn generate_props(ctx: &mut CodegenContext, props: &[PropNode<'_>]) {
     // - dynamic v-model argument
     // - dynamic v-bind key (:[attr])
     // - dynamic v-on key (@[event])
-    let has_dyn_vmodel = has_dynamic_vmodel(props);
-    let has_dyn_key = has_dynamic_key(props);
-    let needs_normalize = has_dyn_vmodel || has_dyn_key;
+    let needs_normalize = scan.needs_normalize();
     if needs_normalize {
         ctx.use_helper(RuntimeHelper::NormalizeProps);
         ctx.push(ctx.helper(RuntimeHelper::NormalizeProps));
         ctx.push("(");
     }
 
-    generate_props_object(ctx, props, false);
+    generate_props_object(ctx, props, false, &scan);
 
     // Close normalizeProps wrapper if needed
     if needs_normalize {
@@ -155,13 +154,96 @@ pub fn generate_props(ctx: &mut CodegenContext, props: &[PropNode<'_>]) {
     }
 }
 
+fn try_generate_static_attrs(
+    ctx: &mut CodegenContext,
+    props: &[PropNode<'_>],
+    scope_id: Option<&str>,
+) -> bool {
+    if ctx.skip_is_prop || ctx.options.inline {
+        return false;
+    }
+    if !props
+        .iter()
+        .all(|prop| matches!(prop, PropNode::Attribute(_)))
+    {
+        return false;
+    }
+
+    let multiline = props.len() + usize::from(scope_id.is_some()) > 1;
+    if multiline {
+        ctx.push("{");
+        ctx.indent();
+    } else {
+        ctx.push("{ ");
+    }
+
+    let mut first = true;
+    for prop in props {
+        let PropNode::Attribute(attr) = prop else {
+            unreachable!("checked above");
+        };
+
+        if !first {
+            ctx.push(",");
+        }
+        if multiline {
+            ctx.newline();
+        } else if !first {
+            ctx.push(" ");
+        }
+        first = false;
+
+        let needs_quotes = !is_valid_js_identifier(&attr.name);
+        if needs_quotes {
+            ctx.push("\"");
+        }
+        ctx.push(&attr.name);
+        if needs_quotes {
+            ctx.push("\"");
+        }
+        ctx.push(": ");
+        if let Some(value) = &attr.value {
+            ctx.push("\"");
+            ctx.push(&escape_js_string(&value.content));
+            ctx.push("\"");
+        } else {
+            ctx.push("\"\"");
+        }
+    }
+
+    if let Some(sid) = scope_id {
+        if !first {
+            ctx.push(",");
+        }
+        if multiline {
+            ctx.newline();
+        } else if !first {
+            ctx.push(" ");
+        }
+        ctx.push("\"");
+        ctx.push(sid);
+        ctx.push("\": \"\"");
+    }
+
+    if multiline {
+        ctx.deindent();
+        ctx.newline();
+        ctx.push("}");
+    } else {
+        ctx.push(" }");
+    }
+
+    true
+}
+
 /// Generate props as a regular object { key: value, ... }
 fn generate_props_object(
     ctx: &mut CodegenContext,
     props: &[PropNode<'_>],
     skip_object_spreads: bool,
+    scan: &PropsScan<'_>,
 ) {
-    generate_props_object_inner(ctx, props, skip_object_spreads, false);
+    generate_props_object_inner(ctx, props, skip_object_spreads, false, scan);
 }
 
 /// Generate the props object with optional class/style normalization skipping.
@@ -172,6 +254,7 @@ fn generate_props_object_inner(
     props: &[PropNode<'_>],
     skip_object_spreads: bool,
     inside_merge_props: bool,
+    scan: &PropsScan<'_>,
 ) {
     // When inside mergeProps, skip normalizeClass/normalizeStyle wrappers
     let prev_skip = ctx.skip_normalize;
@@ -187,155 +270,10 @@ fn generate_props_object_inner(
         ctx.options.scope_id.clone()
     };
 
-    // Check for static class/style that need to be merged with dynamic
-    let static_class = props.iter().find_map(|p| {
-        if let PropNode::Attribute(attr) = p {
-            if attr.name == "class" {
-                return attr.value.as_ref().map(|v| v.content.as_str());
-            }
-        }
-        None
-    });
-
-    let static_style = props.iter().find_map(|p| {
-        if let PropNode::Attribute(attr) = p {
-            if attr.name == "style" {
-                return attr.value.as_ref().map(|v| v.content.as_str());
-            }
-        }
-        None
-    });
-
-    let has_dynamic_class = props.iter().any(|p| {
-        if let PropNode::Directive(dir) = p {
-            if dir.name == "bind" {
-                if let Some(ExpressionNode::Simple(exp)) = &dir.arg {
-                    return exp.content == "class";
-                }
-            }
-        }
-        false
-    });
-
-    let has_dynamic_style = props.iter().any(|p| {
-        if let PropNode::Directive(dir) = p {
-            if dir.name == "bind" {
-                if let Some(ExpressionNode::Simple(exp)) = &dir.arg {
-                    return exp.content == "style";
-                }
-            }
-        }
-        false
-    });
-
     // Skip static class/style if we have dynamic version (will merge them)
-    let skip_static_class = static_class.is_some() && has_dynamic_class;
-    let skip_static_style = static_style.is_some() && has_dynamic_style;
-
-    // Count visible props (attributes + supported directives + scope_id if present)
-    let has_scope_id = scope_id.is_some();
-    let skip_is = ctx.skip_is_prop;
-    let visible_count = props
-        .iter()
-        .filter(|p| {
-            // Skip `is` prop for dynamic components
-            if skip_is {
-                match p {
-                    PropNode::Attribute(attr) if attr.name == "is" => return false,
-                    PropNode::Directive(dir)
-                        if dir.name == "bind"
-                            && matches!(&dir.arg, Some(ExpressionNode::Simple(exp)) if exp.content == "is") =>
-                    {
-                        return false
-                    }
-                    _ => {}
-                }
-            }
-            match p {
-                PropNode::Attribute(attr) => {
-                    if skip_static_class && attr.name == "class" {
-                        return false;
-                    }
-                    if skip_static_style && attr.name == "style" {
-                        return false;
-                    }
-                    true
-                }
-                PropNode::Directive(dir) => is_supported_directive(dir),
-            }
-        })
-        .count()
-        + if has_scope_id { 1 } else { 0 };
-
-    // Check if any prop requires a normalizer (class/style bindings) or uses helper functions (v-text)
-    let has_normalizer = props.iter().any(|p| {
-        if let PropNode::Directive(dir) = p {
-            // v-text uses _toDisplayString, which makes the output multiline
-            if dir.name == "text" {
-                return true;
-            }
-            if dir.name == "bind" {
-                if let Some(ExpressionNode::Simple(exp)) = &dir.arg {
-                    return exp.content == "class" || exp.content == "style";
-                }
-            }
-        }
-        false
-    });
-
-    // Check if any v-on has inline handler (not just identifier) or has runtime modifiers
-    // Also check for cached handlers which produce long expressions
-    let has_inline_handler = props.iter().any(|p| {
-        if let PropNode::Directive(dir) = p {
-            if dir.name == "on" {
-                // When cache_handlers is enabled, handlers produce long expressions
-                // that need multiline formatting (except setup-const which aren't cached)
-                if ctx.cache_handlers_in_current_scope() && dir.exp.is_some() {
-                    let is_const = dir.exp.as_ref().is_some_and(|exp| {
-                        if let ExpressionNode::Simple(simple) = exp {
-                            if !simple.is_static {
-                                let content = simple.content.trim();
-                                if crate::transforms::is_simple_identifier(content) {
-                                    if let Some(ref metadata) = ctx.options.binding_metadata {
-                                        return matches!(
-                                            metadata.bindings.get(content),
-                                            Some(crate::options::BindingType::SetupConst)
-                                        );
-                                    }
-                                }
-                            }
-                        }
-                        false
-                    });
-                    if !is_const {
-                        return true;
-                    }
-                }
-                // Check for modifiers that will use withModifiers or withKeys (not event option modifiers)
-                let has_runtime_modifier = dir.modifiers.iter().any(|m| {
-                    let n = m.content.as_str();
-                    // Event option modifiers (capture, once, passive) don't require multiline
-                    // because they just modify the event name, not wrap the handler
-                    !matches!(n, "capture" | "once" | "passive")
-                });
-                if has_runtime_modifier {
-                    return true;
-                }
-                if let Some(ExpressionNode::Simple(simple)) = &dir.exp {
-                    // Inline if contains operators, parens, or is not simple identifier
-                    let content = simple.content.as_str();
-                    return content.contains('(')
-                        || content.contains('+')
-                        || content.contains('-')
-                        || content.contains('=')
-                        || content.contains(' ');
-                }
-            }
-        }
-        false
-    });
-
-    let multiline = visible_count > 1 || has_normalizer || has_inline_handler;
+    let skip_static_class = scan.skip_static_class();
+    let skip_static_style = scan.skip_static_style();
+    let multiline = scan.multiline(scope_id.is_some());
 
     if multiline {
         ctx.push("{");
@@ -344,12 +282,9 @@ fn generate_props_object_inner(
         ctx.push("{ ");
     }
 
-    // Pre-scan: find duplicate v-on event names that need array merging
-    let event_counts = count_event_names(props);
-
     let mut first = true;
     // Track which event names have already been output (for array merging)
-    let mut emitted_events: FxHashSet<String> = FxHashSet::default();
+    let mut emitted_events: Option<FxHashSet<String>> = None;
 
     for prop in props {
         // Skip v-slot directive (handled separately in slots codegen)
@@ -458,8 +393,10 @@ fn generate_props_object_inner(
                     // Check for duplicate v-on events that should be merged into arrays
                     if dir.name == "on" {
                         if let Some(event_key) = get_von_event_key(dir) {
-                            let count = event_counts.get(&event_key).copied().unwrap_or(0);
+                            let count = scan.event_counts.count(&event_key);
                             if count > 1 {
+                                let emitted_events =
+                                    emitted_events.get_or_insert_with(FxHashSet::default);
                                 if emitted_events.contains(&event_key) {
                                     // Skip: already emitted as part of array
                                     continue;
@@ -479,8 +416,8 @@ fn generate_props_object_inner(
                                     ctx,
                                     props,
                                     &event_key,
-                                    static_class,
-                                    static_style,
+                                    scan.static_class,
+                                    scan.static_style,
                                 );
                                 continue;
                             }
@@ -496,7 +433,12 @@ fn generate_props_object_inner(
                         ctx.push(" ");
                     }
                     first = false;
-                    generate_directive_prop_with_static(ctx, dir, static_class, static_style);
+                    generate_directive_prop_with_static(
+                        ctx,
+                        dir,
+                        scan.static_class,
+                        scan.static_style,
+                    );
                 }
             }
         }

--- a/crates/vize_atelier_core/src/codegen/props/mod.rs
+++ b/crates/vize_atelier_core/src/codegen/props/mod.rs
@@ -3,8 +3,9 @@
 mod directives;
 mod events;
 mod generate;
+mod scan;
 
-use crate::ast::{ExpressionNode, PropNode, RuntimeHelper};
+use crate::ast::{PropNode, RuntimeHelper};
 
 use super::{context::CodegenContext, expression::generate_expression};
 
@@ -28,24 +29,6 @@ pub(crate) fn has_von_object(props: &[PropNode<'_>]) -> bool {
             return dir.name == "on" && dir.arg.is_none();
         }
         false
-    })
-}
-
-/// Check if there are other props besides v-bind/v-on object spreads
-fn has_other_props(props: &[PropNode<'_>]) -> bool {
-    props.iter().any(|p| match p {
-        PropNode::Attribute(_) => true,
-        PropNode::Directive(dir) => {
-            // v-bind without arg is the object spread, not a regular prop
-            if dir.name == "bind" && dir.arg.is_none() {
-                return false;
-            }
-            // v-on without arg is the event object spread, not a regular prop
-            if dir.name == "on" && dir.arg.is_none() {
-                return false;
-            }
-            is_supported_directive(dir)
-        }
     })
 }
 
@@ -80,34 +63,4 @@ pub(crate) fn generate_von_object_exp(ctx: &mut CodegenContext, props: &[PropNod
         }
     }
     ctx.push(")");
-}
-
-/// Check if any v-bind prop has a dynamic key (v-bind with dynamic arg)
-/// Note: v-on with dynamic arg uses _toHandlerKey() instead and doesn't need _normalizeProps
-fn has_dynamic_key(props: &[PropNode<'_>]) -> bool {
-    props.iter().any(|p| {
-        if let PropNode::Directive(dir) = p {
-            if dir.name == "bind" {
-                if let Some(ExpressionNode::Simple(exp)) = &dir.arg {
-                    return !exp.is_static;
-                }
-            }
-        }
-        false
-    })
-}
-
-/// Check if element has dynamic v-model (with dynamic argument)
-pub fn has_dynamic_vmodel(props: &[PropNode<'_>]) -> bool {
-    props.iter().any(|p| {
-        if let PropNode::Directive(dir) = p {
-            if dir.name == "model" {
-                return dir.arg.as_ref().is_some_and(|arg| match arg {
-                    ExpressionNode::Simple(exp) => !exp.is_static,
-                    ExpressionNode::Compound(_) => true,
-                });
-            }
-        }
-        false
-    })
 }

--- a/crates/vize_atelier_core/src/codegen/props/scan.rs
+++ b/crates/vize_atelier_core/src/codegen/props/scan.rs
@@ -1,0 +1,293 @@
+//! Single-pass prop metadata collection for code generation.
+
+use crate::ast::{DirectiveNode, ExpressionNode, PropNode};
+use crate::options::BindingType;
+
+use super::super::context::CodegenContext;
+use super::directives::is_supported_directive;
+use super::events::get_von_event_key;
+use vize_carton::{FxHashMap, String};
+
+#[derive(Default)]
+pub(super) struct EventNameCounts {
+    first_key: Option<String>,
+    first_count: usize,
+    many: Option<FxHashMap<String, usize>>,
+}
+
+impl EventNameCounts {
+    #[inline]
+    pub(super) fn count(&self, key: &str) -> usize {
+        if let Some(counts) = &self.many {
+            return counts.get(key).copied().unwrap_or(0);
+        }
+
+        if self.first_key.as_deref() == Some(key) {
+            self.first_count
+        } else {
+            0
+        }
+    }
+
+    fn observe(&mut self, key: String) {
+        if let Some(counts) = &mut self.many {
+            *counts.entry(key).or_insert(0) += 1;
+            return;
+        }
+
+        if let Some(first_key) = &self.first_key {
+            if first_key.as_str() == key.as_str() {
+                self.first_count += 1;
+                return;
+            }
+
+            let first_key = self.first_key.take().expect("first event key");
+            let mut counts = FxHashMap::default();
+            counts.insert(first_key, self.first_count);
+            counts.insert(key, 1);
+            self.first_count = 0;
+            self.many = Some(counts);
+            return;
+        }
+
+        self.first_key = Some(key);
+        self.first_count = 1;
+    }
+}
+
+pub(super) struct PropsScan<'props> {
+    pub(super) static_class: Option<&'props str>,
+    pub(super) static_style: Option<&'props str>,
+    pub(super) has_vbind_obj: bool,
+    pub(super) has_von_obj: bool,
+    pub(super) has_other: bool,
+    has_dynamic_key: bool,
+    has_dynamic_vmodel: bool,
+    has_dynamic_class: bool,
+    has_dynamic_style: bool,
+    visible_prop_count: usize,
+    visible_class_attrs: usize,
+    visible_style_attrs: usize,
+    has_normalizer: bool,
+    has_inline_handler: bool,
+    pub(super) event_counts: EventNameCounts,
+}
+
+impl<'props> PropsScan<'props> {
+    pub(super) fn new<'ast>(
+        ctx: &CodegenContext,
+        props: &'props [PropNode<'ast>],
+        skip_is: bool,
+    ) -> Self {
+        let mut scan = Self {
+            static_class: None,
+            static_style: None,
+            has_vbind_obj: false,
+            has_von_obj: false,
+            has_other: false,
+            has_dynamic_key: false,
+            has_dynamic_vmodel: false,
+            has_dynamic_class: false,
+            has_dynamic_style: false,
+            visible_prop_count: 0,
+            visible_class_attrs: 0,
+            visible_style_attrs: 0,
+            has_normalizer: false,
+            has_inline_handler: false,
+            event_counts: EventNameCounts::default(),
+        };
+
+        for prop in props {
+            scan.observe_other_prop(prop);
+
+            let visible = !skip_is || !is_is_prop(prop);
+            match prop {
+                PropNode::Attribute(attr) => {
+                    if attr.name == "class" {
+                        if scan.static_class.is_none() {
+                            scan.static_class = attr.value.as_ref().map(|v| v.content.as_str());
+                        }
+                        if visible {
+                            scan.visible_class_attrs += 1;
+                        }
+                    } else if attr.name == "style" {
+                        if scan.static_style.is_none() {
+                            scan.static_style = attr.value.as_ref().map(|v| v.content.as_str());
+                        }
+                        if visible {
+                            scan.visible_style_attrs += 1;
+                        }
+                    }
+
+                    if visible {
+                        scan.visible_prop_count += 1;
+                    }
+                }
+                PropNode::Directive(dir) => {
+                    scan.observe_directive(ctx, dir);
+                    if visible && is_supported_directive(dir) {
+                        scan.visible_prop_count += 1;
+                    }
+                }
+            }
+        }
+
+        scan
+    }
+
+    #[inline]
+    pub(super) fn needs_normalize(&self) -> bool {
+        self.has_dynamic_vmodel || self.has_dynamic_key
+    }
+
+    #[inline]
+    pub(super) fn skip_static_class(&self) -> bool {
+        self.static_class.is_some() && self.has_dynamic_class
+    }
+
+    #[inline]
+    pub(super) fn skip_static_style(&self) -> bool {
+        self.static_style.is_some() && self.has_dynamic_style
+    }
+
+    #[inline]
+    pub(super) fn visible_count(&self, has_scope_id: bool) -> usize {
+        let mut count = self.visible_prop_count;
+        if self.skip_static_class() {
+            count = count.saturating_sub(self.visible_class_attrs);
+        }
+        if self.skip_static_style() {
+            count = count.saturating_sub(self.visible_style_attrs);
+        }
+        if has_scope_id {
+            count += 1;
+        }
+        count
+    }
+
+    #[inline]
+    pub(super) fn multiline(&self, has_scope_id: bool) -> bool {
+        self.visible_count(has_scope_id) > 1 || self.has_normalizer || self.has_inline_handler
+    }
+
+    fn observe_other_prop<'ast>(&mut self, prop: &PropNode<'ast>) {
+        if self.has_other {
+            return;
+        }
+
+        self.has_other = match prop {
+            PropNode::Attribute(_) => true,
+            PropNode::Directive(dir) => {
+                if (dir.name == "bind" || dir.name == "on") && dir.arg.is_none() {
+                    false
+                } else {
+                    is_supported_directive(dir)
+                }
+            }
+        };
+    }
+
+    fn observe_directive(&mut self, ctx: &CodegenContext, dir: &DirectiveNode<'_>) {
+        match dir.name.as_str() {
+            "bind" => {
+                if dir.arg.is_none() {
+                    self.has_vbind_obj = true;
+                    return;
+                }
+
+                if let Some(ExpressionNode::Simple(exp)) = &dir.arg {
+                    if !exp.is_static {
+                        self.has_dynamic_key = true;
+                    }
+
+                    if exp.content == "class" {
+                        self.has_dynamic_class = true;
+                        self.has_normalizer = true;
+                    } else if exp.content == "style" {
+                        self.has_dynamic_style = true;
+                        self.has_normalizer = true;
+                    }
+                }
+            }
+            "on" => {
+                if dir.arg.is_none() {
+                    self.has_von_obj = true;
+                }
+                if !self.has_inline_handler && has_inline_handler(ctx, dir) {
+                    self.has_inline_handler = true;
+                }
+                if let Some(event_key) = get_von_event_key(dir) {
+                    self.event_counts.observe(event_key);
+                }
+            }
+            "model" => {
+                self.has_dynamic_vmodel |= dir.arg.as_ref().is_some_and(|arg| match arg {
+                    ExpressionNode::Simple(exp) => !exp.is_static,
+                    ExpressionNode::Compound(_) => true,
+                });
+            }
+            "text" => {
+                self.has_normalizer = true;
+            }
+            _ => {}
+        }
+    }
+}
+
+fn is_is_prop(prop: &PropNode<'_>) -> bool {
+    match prop {
+        PropNode::Attribute(attr) => attr.name == "is",
+        PropNode::Directive(dir) => {
+            dir.name == "bind"
+                && matches!(&dir.arg, Some(ExpressionNode::Simple(exp)) if exp.content == "is")
+        }
+    }
+}
+
+fn has_inline_handler(ctx: &CodegenContext, dir: &DirectiveNode<'_>) -> bool {
+    if ctx.cache_handlers_in_current_scope()
+        && dir.exp.is_some()
+        && !is_setup_const_handler(ctx, dir)
+    {
+        return true;
+    }
+
+    if dir.modifiers.iter().any(|m| {
+        let name = m.content.as_str();
+        !matches!(name, "capture" | "once" | "passive")
+    }) {
+        return true;
+    }
+
+    dir.exp.as_ref().is_some_and(|exp| {
+        if let ExpressionNode::Simple(simple) = exp {
+            let content = simple.content.as_str();
+            content.contains('(')
+                || content.contains('+')
+                || content.contains('-')
+                || content.contains('=')
+                || content.contains(' ')
+        } else {
+            false
+        }
+    })
+}
+
+fn is_setup_const_handler(ctx: &CodegenContext, dir: &DirectiveNode<'_>) -> bool {
+    dir.exp.as_ref().is_some_and(|exp| {
+        if let ExpressionNode::Simple(simple) = exp {
+            if !simple.is_static {
+                let content = simple.content.trim();
+                if crate::transforms::is_simple_identifier(content) {
+                    return ctx
+                        .options
+                        .binding_metadata
+                        .as_ref()
+                        .and_then(|metadata| metadata.bindings.get(content))
+                        .is_some_and(|binding| *binding == BindingType::SetupConst);
+                }
+            }
+        }
+        false
+    })
+}

--- a/crates/vize_atelier_sfc/benches/sfc_compile.rs
+++ b/crates/vize_atelier_sfc/benches/sfc_compile.rs
@@ -239,6 +239,68 @@ function refresh() {
 </style>
 "#;
 
+const PROP_HEAVY_LIST: &str = r#"<template>
+  <section class="catalog">
+    <ProductCard
+      v-for="product in products"
+      :key="product.id"
+      class="catalog-card"
+      style="--gap: 12px; --radius: 8px"
+      :class="{ active: product.id === activeId, featured: product.featured }"
+      :style="{ borderColor: product.color, opacity: product.disabled ? 0.5 : 1 }"
+      :id="`product-${product.id}`"
+      :title="product.title"
+      :aria-label="product.title"
+      :data-rank="product.rank"
+      :data-state="product.disabled ? 'disabled' : 'ready'"
+      @click="select(product)"
+      @click.stop="track(product.id)"
+      @keydown.enter="open(product)"
+      @mouseenter="hovered = product.id"
+      @mouseleave="hovered = null"
+    >
+      <template #meta="{ price, inventory }">
+        <span>{{ price }}</span>
+        <span>{{ inventory }}</span>
+      </template>
+    </ProductCard>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+
+interface Product {
+  id: number
+  title: string
+  rank: number
+  color: string
+  featured: boolean
+  disabled: boolean
+}
+
+const activeId = ref(1)
+const hovered = ref<number | null>(null)
+const products = ref<Product[]>([
+  { id: 1, title: 'Canvas', rank: 1, color: '#0ea5e9', featured: true, disabled: false },
+  { id: 2, title: 'Pigment', rank: 2, color: '#f97316', featured: false, disabled: false },
+  { id: 3, title: 'Frame', rank: 3, color: '#22c55e', featured: true, disabled: true },
+])
+
+function select(product: Product) {
+  activeId.value = product.id
+}
+
+function track(id: number) {
+  hovered.value = id
+}
+
+function open(product: Product) {
+  activeId.value = product.id
+}
+</script>
+"#;
+
 fn compile_options(filename: &'static str) -> SfcCompileOptions {
     SfcCompileOptions {
         parse: SfcParseOptions {
@@ -306,10 +368,15 @@ fn bench_compile_complex_script_setup(c: &mut Criterion) {
     );
 }
 
+fn bench_compile_prop_heavy_list(c: &mut Criterion) {
+    benchmark_compile_case(c, "prop_heavy_list", "PropHeavyList.vue", PROP_HEAVY_LIST);
+}
+
 criterion_group!(
     benches,
     bench_compile_template_only,
     bench_compile_medium_script_setup,
     bench_compile_complex_script_setup,
+    bench_compile_prop_heavy_list,
 );
 criterion_main!(benches);


### PR DESCRIPTION
## Summary

- Collapse props codegen metadata collection into a single scan for spread props, dynamic keys, class/style merging, multiline decisions, and duplicate event detection.
- Add a static-attribute fast path that skips the scan for common literal-only props.
- Add a prop-heavy SFC compile benchmark case to cover repeated attributes, dynamic bindings, and duplicate event handlers.

## Validation

- `vp run fmt`
- `vp run fmt:js`
- `cargo fmt --all --check`
- `cargo clippy --workspace -- -D warnings`
- `cargo test --workspace`
- `vp run test:js`
- `vp run check:ci`
- `vp run bench:quick` (native MT: 3.1k files/s, 2.6x vs original 1T)
- `cargo bench -p vize_atelier_sfc --bench sfc_compile -- --warm-up-time 1 --measurement-time 2`
- `vp run test:playground` (99 browser tests passed)

## Benchmark Notes

Short Criterion run after the change:

- `sfc_compile/template_only`: 8.0744 us
- `sfc_compile/script_setup_medium`: 161.85 us, improved in the local comparison
- `sfc_compile/script_setup_complex`: 221.85 us, no significant change
- `sfc_compile/prop_heavy_list`: 155.88 us
