### PR TITLE
test: retain VRT failure media

### DIFF
--- a/examples/vite-musea/playwright.config.ts
+++ b/examples/vite-musea/playwright.config.ts
@@ -9,10 +9,12 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
   workers: process.env.CI ? 1 : undefined,
-  reporter: "html",
+  reporter: [["list"], ["html", { open: "never" }]],
   use: {
     baseURL: "http://localhost:5173",
+    screenshot: "only-on-failure",
     trace: "on-first-retry",
+    video: "retain-on-failure",
   },
   projects: [
     {

--- a/playground/playwright.config.ts
+++ b/playground/playwright.config.ts
@@ -9,10 +9,12 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
   workers: process.env.CI ? 1 : undefined,
-  reporter: "html",
+  reporter: [["list"], ["html", { open: "never" }]],
   use: {
     baseURL: "http://localhost:5180",
+    screenshot: "only-on-failure",
     trace: "on-first-retry",
+    video: "retain-on-failure",
   },
   projects: [
     {

--- a/tests/tooling/playwright-vrt-config.test.ts
+++ b/tests/tooling/playwright-vrt-config.test.ts
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+
+function readRepoFile(...segments: string[]): string {
+  return fs.readFileSync(path.join(root, ...segments), "utf8");
+}
+
+test("VRT Playwright configs keep failure artifacts and CI-readable output", () => {
+  for (const configPath of [
+    ["playground", "playwright.config.ts"],
+    ["examples", "vite-musea", "playwright.config.ts"],
+  ]) {
+    const config = readRepoFile(...configPath);
+
+    assert.match(config, /reporter:\s*\[\["list"\], \["html", \{ open: "never" \}\]\]/);
+    assert.match(config, /screenshot:\s*"only-on-failure"/);
+    assert.match(config, /trace:\s*"on-first-retry"/);
+    assert.match(config, /video:\s*"retain-on-failure"/);
+  }
+});


### PR DESCRIPTION
## Summary

- Adds list output alongside the HTML reporter for VRT runs.
- Keeps the HTML report closed in CI.
- Retains screenshots, traces, and videos when visual tests fail.

## Validation

- `node --test tests/tooling/playwright-vrt-config.test.ts`
- `vp check playground/playwright.config.ts examples/vite-musea/playwright.config.ts tests/tooling/playwright-vrt-config.test.ts`
- `pnpm --dir playground exec playwright test --list`
- `pnpm --dir examples/vite-musea exec playwright test --list`
