### PR TITLE
ci: upload VRT report artifacts

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -174,6 +174,15 @@ jobs:
         continue-on-error: true
         id: vrt
 
+      - name: Upload VRT report
+        if: steps.vrt.outcome == 'failure'
+        uses: actions/upload-artifact@v4
+        with:
+          name: playground-vrt-report
+          path: playground/playwright-report/
+          if-no-files-found: ignore
+          retention-days: 7
+
       - name: Update VRT snapshots
         if: steps.vrt.outcome == 'failure'
         run: vp run --filter './playground' test:vrt:update

--- a/tests/tooling/github-workflows.test.ts
+++ b/tests/tooling/github-workflows.test.ts
@@ -222,6 +222,15 @@ test("check workflow only installs Playwright browsers on cache misses", () => {
   );
 });
 
+test("check workflow uploads the VRT HTML report when snapshots fail", () => {
+  const workflow = readRepoFile(".github", "workflows", "check.yml");
+
+  assert.match(workflow, /- name: Upload VRT report\s+if: steps\.vrt\.outcome == 'failure'/);
+  assert.match(workflow, /name:\s*playground-vrt-report/);
+  assert.match(workflow, /path:\s*playground\/playwright-report\//);
+  assert.match(workflow, /if-no-files-found:\s*ignore/);
+});
+
 test("check and docs workflows use the CI Rust profile for non-release native builds", () => {
   const checkWorkflow = readRepoFile(".github", "workflows", "check.yml");
   const deployDocsWorkflow = readRepoFile(".github", "workflows", "deploy-docs.yml");


### PR DESCRIPTION
## Summary

- Uploads the Playwright HTML report when playground VRT fails.
- Keeps the existing VRT diff artifact unchanged.
- Ignores missing report files so cleanup paths do not fail the job.

## Validation

- `node --test tests/tooling/github-workflows.test.ts`
- `vp check .github/workflows/check.yml tests/tooling/github-workflows.test.ts`
