### PR TITLE
test: add workspace e2e tasks

### DIFF
--- a/tests/tooling/e2e-tasks.test.ts
+++ b/tests/tooling/e2e-tasks.test.ts
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+
+function readRepoFile(...segments: string[]): string {
+  return fs.readFileSync(path.join(root, ...segments), "utf8");
+}
+
+test("workspace exposes app e2e task aliases with scoped cache inputs", () => {
+  const config = readRepoFile("vite.config.ts");
+
+  assert.match(config, /e2e:\s*\[/);
+  assert.match(config, /"tests\/app\/\*\*"/);
+  assert.match(config, /"tests\/_helpers\/\*\*"/);
+  assert.match(
+    config,
+    /"test:e2e":\s*noCacheTask\(runTasks\("test:e2e:dev", "test:e2e:preview"\)\)/,
+  );
+  assert.match(config, /"test:e2e:dev":\s*task\(runInPackages\("test:dev", \["\.\/tests"\]\)/);
+  assert.match(
+    config,
+    /"test:e2e:preview":\s*task\(runInPackages\("test:preview", \["\.\/tests"\]\)/,
+  );
+  assert.match(config, /input:\s*cacheInputs\.e2e/);
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -83,6 +83,21 @@ const cacheInputs = {
     "tests/**",
     "tools/**",
   ],
+  e2e: [
+    ".node-version",
+    "package.json",
+    "vite.config.ts",
+    "pnpm-lock.yaml",
+    "pnpm-workspace.yaml",
+    "tests/package.json",
+    "tests/app/**",
+    "tests/_helpers/**",
+    "npm/vize*/**",
+    "npm/vite-plugin-vize/**",
+    "npm/nuxt/**",
+    "npm/vite-plugin-musea/**",
+    "npm/musea-nuxt/**",
+  ],
 };
 
 const localVp = "./node_modules/.bin/vp";
@@ -261,6 +276,11 @@ const testTasks = {
   }),
   "test:playground": task(runInPackages("test:browser", ["./playground"]), {
     input: cacheInputs.jsChecks,
+  }),
+  "test:e2e": noCacheTask(runTasks("test:e2e:dev", "test:e2e:preview")),
+  "test:e2e:dev": task(runInPackages("test:dev", ["./tests"]), { input: cacheInputs.e2e }),
+  "test:e2e:preview": task(runInPackages("test:preview", ["./tests"]), {
+    input: cacheInputs.e2e,
   }),
   "test:vue": task("cargo test -p vize_test_runner", { input: cacheInputs.rust }),
   coverage: task("cargo run -p vize_test_runner --bin coverage", { input: cacheInputs.rust }),


### PR DESCRIPTION
## Summary

- Adds workspace-level `test:e2e`, `test:e2e:dev`, and `test:e2e:preview` tasks.
- Scopes e2e cache inputs to the app tests, helpers, and runtime packages they exercise.
- Adds a tooling test to keep the task entrypoints present.

## Validation

- `node --test tests/tooling/e2e-tasks.test.ts`
- `vp check vite.config.ts tests/tooling/e2e-tasks.test.ts`
- `vp run --workspace-root --help`
