### PR TITLE
fix: correct Vue prop source spans

### DIFF
--- a/crates/vize_armature/src/parser/attribute.rs
+++ b/crates/vize_armature/src/parser/attribute.rs
@@ -28,6 +28,17 @@ impl<'a> Parser<'a> {
         });
     }
 
+    /// Process the end of a full attribute or directive head.
+    pub(super) fn on_attrib_name_end_impl(&mut self, end: usize) {
+        if let Some(ref mut attr) = self.current_attr {
+            attr.name_end = end;
+        }
+
+        if let Some(ref mut dir) = self.current_dir {
+            dir.name_end = end;
+        }
+    }
+
     /// Process directive name
     pub(super) fn on_dir_name_impl(&mut self, start: usize, end: usize) {
         let raw_name = self.get_source(start, end);
@@ -136,9 +147,18 @@ impl<'a> Parser<'a> {
         }
     }
 
+    fn prop_loc_end(&self, quote: QuoteType, end: usize, name_end: usize) -> usize {
+        match quote {
+            QuoteType::NoValue => name_end,
+            QuoteType::Double | QuoteType::Single => (end + 1).min(self.source.len()),
+            QuoteType::Unquoted => end,
+        }
+    }
+
     /// Finish building an attribute node
     fn finish_attribute(&mut self, attr: CurrentAttribute<'a>, quote: QuoteType, end: usize) {
-        let loc = self.create_loc(attr.name_start, end);
+        let loc_end = self.prop_loc_end(quote, end, attr.name_end);
+        let loc = self.create_loc(attr.name_start, loc_end);
         let name_loc = self.create_loc(attr.name_start, attr.name_end);
 
         let mut attr_node = AttributeNode::new(attr.name.clone(), loc);
@@ -163,8 +183,9 @@ impl<'a> Parser<'a> {
     }
 
     /// Finish building a directive node
-    fn finish_directive(&mut self, dir: CurrentDirective<'a>, _quote: QuoteType, end: usize) {
-        let loc = self.create_loc(dir.name_start, end);
+    fn finish_directive(&mut self, dir: CurrentDirective<'a>, quote: QuoteType, end: usize) {
+        let loc_end = self.prop_loc_end(quote, end, dir.name_end);
+        let loc = self.create_loc(dir.name_start, loc_end);
 
         let mut dir_node = DirectiveNode::new(self.allocator, dir.name.clone(), loc);
         dir_node.raw_name = Some(dir.raw_name);

--- a/crates/vize_armature/src/parser/callbacks.rs
+++ b/crates/vize_armature/src/parser/callbacks.rs
@@ -80,8 +80,8 @@ impl<'a, 'p> Callbacks for ParserCallbacks<'a, 'p> {
         self.parser.on_attrib_name_impl(start, end);
     }
 
-    fn on_attrib_name_end(&mut self, _end: usize) {
-        // No-op for now
+    fn on_attrib_name_end(&mut self, end: usize) {
+        self.parser.on_attrib_name_end_impl(end);
     }
 
     fn on_dir_name(&mut self, start: usize, end: usize) {

--- a/crates/vize_armature/src/parser/tests.rs
+++ b/crates/vize_armature/src/parser/tests.rs
@@ -452,6 +452,59 @@ fn test_parse_v_for() {
 }
 
 #[test]
+fn test_no_value_directive_loc_excludes_trailing_whitespace() {
+    let allocator = Bump::new();
+    let (root, errors) = parse(&allocator, "<div v-if />");
+    assert!(errors.is_empty());
+
+    if let TemplateChildNode::Element(el) = &root.children[0] {
+        if let PropNode::Directive(dir) = &el.props[0] {
+            assert_eq!(dir.loc.source.as_str(), "v-if");
+        } else {
+            panic!("Expected directive");
+        }
+    }
+}
+
+#[test]
+fn test_quoted_attribute_loc_includes_closing_quote_with_spaced_equals() {
+    let allocator = Bump::new();
+    let (root, errors) = parse(&allocator, r#"<div class ="w-100" />"#);
+    assert!(errors.is_empty());
+
+    if let TemplateChildNode::Element(el) = &root.children[0] {
+        if let PropNode::Attribute(attr) = &el.props[0] {
+            assert_eq!(attr.loc.source.as_str(), r#"class ="w-100""#);
+            assert_eq!(attr.value.as_ref().unwrap().content.as_str(), "w-100");
+            assert_eq!(attr.value.as_ref().unwrap().loc.source.as_str(), "w-100");
+        } else {
+            panic!("Expected attribute");
+        }
+    }
+}
+
+#[test]
+fn test_quoted_directive_loc_includes_closing_quote_with_spaced_equals() {
+    let allocator = Bump::new();
+    let (root, errors) = parse(&allocator, r#"<div v-if ="ok" />"#);
+    assert!(errors.is_empty());
+
+    if let TemplateChildNode::Element(el) = &root.children[0] {
+        if let PropNode::Directive(dir) = &el.props[0] {
+            assert_eq!(dir.loc.source.as_str(), r#"v-if ="ok""#);
+            if let Some(ExpressionNode::Simple(exp)) = &dir.exp {
+                assert_eq!(exp.content.as_str(), "ok");
+                assert_eq!(exp.loc.source.as_str(), "ok");
+            } else {
+                panic!("Expected expression");
+            }
+        } else {
+            panic!("Expected directive");
+        }
+    }
+}
+
+#[test]
 fn test_parse_mixed_children() {
     let allocator = Bump::new();
     let (root, errors) = parse(&allocator, "<div>text<span></span>{{ msg }}</div>");

--- a/crates/vize_canon/src/batch/snapshots/vize_canon__batch__virtual_project__tests__register_vue_file_rewrites_child_imports.snap
+++ b/crates/vize_canon/src/batch/snapshots/vize_canon__batch__virtual_project__tests__register_vue_file_rewrites_child_imports.snap
@@ -89,7 +89,7 @@ function __setup() {
   type __Child_0_prop_count = __Child_Props_0 extends { 'count'?: infer T } ? T : __Child_Props_0 extends { 'count': infer T } ? T : unknown;
 
   // Component props value checks (template scope)
-  // @vize-map: prop -> 104:117
+  // @vize-map: prop -> 104:118
   const __vize_prop_check_0_count: __Child_0_prop_count = count;
   void __vize_prop_check_0_count;
 

--- a/crates/vize_canon/src/sfc_typecheck/snapshots/vize_canon__sfc_typecheck__tests__type_check_component_with_props_and_events.snap
+++ b/crates/vize_canon/src/sfc_typecheck/snapshots/vize_canon__sfc_typecheck__tests__type_check_component_with_props_and_events.snap
@@ -101,7 +101,7 @@ function __setup() {
   void (props.disabled); // VBind
   // @vize-map: expr -> 319:333
   void (emit('submit')); // VOn
-  // @vize-map: expr -> 335:357
+  // @vize-map: expr -> 335:358
 
   // Reference setup bindings (used in template/CSS v-bind)
   void props; void emit;

--- a/crates/vize_canon/src/snapshots/vize_canon__tests__virtual_ts_tests__virtual_ts_complex_component.snap
+++ b/crates/vize_canon/src/snapshots/vize_canon__tests__virtual_ts_tests__virtual_ts_complex_component.snap
@@ -132,7 +132,7 @@ function __setup() {
   (($event: MouseEvent) => {
     const __vize_handler_10_132 = ((handler: ($event: MouseEvent) => unknown) => handler)((increment));
     __vize_handler_10_132($event);  // handler expression
-    // @vize-map: handler -> 678:695
+    // @vize-map: handler -> 678:696
   })({} as MouseEvent);
 
   // Reference setup bindings (used in template/CSS v-bind)

--- a/crates/vize_canon/src/snapshots/vize_canon__tests__virtual_ts_tests__virtual_ts_dynamic_component.snap
+++ b/crates/vize_canon/src/snapshots/vize_canon__tests__virtual_ts_tests__virtual_ts_dynamic_component.snap
@@ -99,7 +99,7 @@ function __setup() {
   (($event: MouseEvent) => {
     const __vize_handler_10_62 = ((handler: ($event: MouseEvent) => unknown) => handler)((switchComponent));
     __vize_handler_10_62($event);  // handler expression
-    // @vize-map: handler -> 379:402
+    // @vize-map: handler -> 379:403
   })({} as MouseEvent);
 
   // Reference setup bindings (used in template/CSS v-bind)

--- a/crates/vize_canon/src/snapshots/vize_canon__tests__virtual_ts_tests__virtual_ts_scoped_slots.snap
+++ b/crates/vize_canon/src/snapshots/vize_canon__tests__virtual_ts_tests__virtual_ts_scoped_slots.snap
@@ -113,7 +113,7 @@ function __setup() {
   type __MyList_0_prop_items = __MyList_Props_0 extends { 'items'?: infer T } ? T : __MyList_Props_0 extends { 'items': infer T } ? T : unknown;
 
   // Component props value checks (template scope)
-  // @vize-map: prop -> 153:166
+  // @vize-map: prop -> 153:167
   const __vize_prop_check_0_items: __MyList_0_prop_items = items;
   void __vize_prop_check_0_items;
 

--- a/crates/vize_canon/src/snapshots/vize_canon__tests__virtual_ts_tests__virtual_ts_simple_component.snap
+++ b/crates/vize_canon/src/snapshots/vize_canon__tests__virtual_ts_tests__virtual_ts_simple_component.snap
@@ -102,7 +102,7 @@ function __setup() {
   (($event: MouseEvent) => {
     const __vize_handler_8_76 = ((handler: ($event: MouseEvent) => unknown) => handler)((increment));
     __vize_handler_8_76($event);  // handler expression
-    // @vize-map: handler -> 241:258
+    // @vize-map: handler -> 241:259
   })({} as MouseEvent);
 
   // Reference setup bindings (used in template/CSS v-bind)

--- a/crates/vize_canon/src/snapshots/vize_canon__tests__virtual_ts_tests__virtual_ts_with_emits.snap
+++ b/crates/vize_canon/src/snapshots/vize_canon__tests__virtual_ts_tests__virtual_ts_with_emits.snap
@@ -89,13 +89,13 @@ function __setup() {
     void __ctx; void $attrs; void $slots; void $refs; void $emit;
 
   void (emit('close')); // VOn
-  // @vize-map: expr -> 266:287
+  // @vize-map: expr -> 266:288
 
   // @click handler
   (($event: MouseEvent) => {
     const __vize_handler_7_11 = ((handler: ($event: MouseEvent) => unknown) => handler)((handleClick));
     __vize_handler_7_11($event);  // handler expression
-    // @vize-map: handler -> 219:238
+    // @vize-map: handler -> 219:239
   })({} as MouseEvent);
 
   // Reference setup bindings (used in template/CSS v-bind)

--- a/crates/vize_canon/src/snapshots/vize_canon__virtual_ts__tests__virtual_ts_component_prop_checks_respect_same_element_vif_guard.snap
+++ b/crates/vize_canon/src/snapshots/vize_canon__virtual_ts__tests__virtual_ts_component_prop_checks_respect_same_element_vif_guard.snap
@@ -101,7 +101,7 @@ function __setup() {
   type __LinkComp_0_prop_to = __LinkComp_Props_0 extends { 'to'?: infer T } ? T : __LinkComp_Props_0 extends { 'to': infer T } ? T : unknown;
 
   // Component props value checks (template scope)
-  // @vize-map: prop -> 22:36
+  // @vize-map: prop -> 22:37
   if (item) {
     const __vize_prop_check_0_to: __LinkComp_0_prop_to = item.name;
     void __vize_prop_check_0_to;

--- a/crates/vize_canon/src/snapshots/vize_canon__virtual_ts__tests__virtual_ts_multiple_event_handlers.snap
+++ b/crates/vize_canon/src/snapshots/vize_canon__virtual_ts__tests__virtual_ts_multiple_event_handlers.snap
@@ -93,14 +93,14 @@ function __setup() {
   (($event: MouseEvent) => {
     const __vize_handler_9_16 = ((handler: ($event: MouseEvent) => unknown) => handler)((handleClick));
     __vize_handler_9_16($event);  // handler expression
-    // @vize-map: handler -> 16:35
+    // @vize-map: handler -> 16:36
   })({} as MouseEvent);
 
   // @mouseenter handler
   (($event: MouseEvent) => {
     const __vize_handler_10_37 = ((handler: ($event: MouseEvent) => unknown) => handler)((handleHover));
     __vize_handler_10_37($event);  // handler expression
-    // @vize-map: handler -> 37:61
+    // @vize-map: handler -> 37:62
   })({} as MouseEvent);
 
   // Reference setup bindings (used in template/CSS v-bind)

--- a/crates/vize_canon/src/snapshots/vize_canon__virtual_ts__tests__virtual_ts_reserved_prop_and_hyphenated_slot_names.snap
+++ b/crates/vize_canon/src/snapshots/vize_canon__virtual_ts__tests__virtual_ts_reserved_prop_and_hyphenated_slot_names.snap
@@ -106,7 +106,7 @@ function __setup() {
   type __TrendChart_0_prop_class = __TrendChart_Props_0 extends { 'class'?: infer T } ? T : __TrendChart_Props_0 extends { 'class': infer T } ? T : unknown;
 
   // Component props value checks (template scope)
-  // @vize-map: prop -> 12:25
+  // @vize-map: prop -> 12:26
   const __vize_prop_check_0_class: __TrendChart_0_prop_class = props["class"];
   void __vize_prop_check_0_class;
 

--- a/crates/vize_canon/src/snapshots/vize_canon__virtual_ts__tests__virtual_ts_scoped_slot_expressions.snap
+++ b/crates/vize_canon/src/snapshots/vize_canon__virtual_ts__tests__virtual_ts_scoped_slot_expressions.snap
@@ -95,7 +95,7 @@ function __setup() {
   type __MyList_0_prop_items = __MyList_Props_0 extends { 'items'?: infer T } ? T : __MyList_Props_0 extends { 'items': infer T } ? T : unknown;
 
   // Component props value checks (template scope)
-  // @vize-map: prop -> 8:21
+  // @vize-map: prop -> 8:22
   const __vize_prop_check_0_items: __MyList_0_prop_items = items;
   void __vize_prop_check_0_items;
 

--- a/crates/vize_canon/src/snapshots/vize_canon__virtual_ts__tests__virtual_ts_vfor_component_props_in_scope.snap
+++ b/crates/vize_canon/src/snapshots/vize_canon__virtual_ts__tests__virtual_ts_vfor_component_props_in_scope.snap
@@ -106,7 +106,7 @@ function __setup() {
   // Component props in v-for scope: todo in todos
   (todos).forEach((todo: typeof todos[number]) => {
     void todo;
-    // @vize-map: prop -> 55:66
+    // @vize-map: prop -> 55:67
     const __vize_prop_check_0_item: __TodoItem_0_prop_item = todo;
     void __vize_prop_check_0_item;
   });

--- a/crates/vize_patina/src/rules/opinionated/vapor/snapshots/vize_patina__rules__opinionated__vapor__prefer_static_class__tests__invalid_string_literal_class.snap
+++ b/crates/vize_patina/src/rules/opinionated/vapor/snapshots/vize_patina__rules__opinionated__vapor__prefer_static_class__tests__invalid_string_literal_class.snap
@@ -8,7 +8,7 @@ expression: result.diagnostics
         severity: Warning,
         message: "Prefer static class attribute over dynamic :class binding for constant values",
         start: 6,
-        end: 27,
+        end: 28,
         help: None,
         labels: [],
         fix: Some(
@@ -17,7 +17,7 @@ expression: result.diagnostics
                 edits: [
                     TextEdit {
                         start: 5,
-                        end: 28,
+                        end: 29,
                         new_text: "class=\"static-class\"",
                     },
                 ],

--- a/crates/vize_patina/src/rules/opinionated/vue/snapshots/vize_patina__rules__opinionated__vue__no_template_shadow__tests__invalid_nested_shadow.snap
+++ b/crates/vize_patina/src/rules/opinionated/vue/snapshots/vize_patina__rules__opinionated__vue__no_template_shadow__tests__invalid_nested_shadow.snap
@@ -8,7 +8,7 @@ expression: result.diagnostics
         severity: Warning,
         message: "Variable 'item' shadows a variable in an outer scope",
         start: 48,
-        end: 76,
+        end: 77,
         help: Some(
             "Rename the variable to avoid shadowing",
         ),

--- a/crates/vize_patina/src/rules/opinionated/vue/snapshots/vize_patina__rules__opinionated__vue__prefer_props_shorthand__tests__invalid_same_name.snap
+++ b/crates/vize_patina/src/rules/opinionated/vue/snapshots/vize_patina__rules__opinionated__vue__prefer_props_shorthand__tests__invalid_same_name.snap
@@ -8,7 +8,7 @@ expression: result.diagnostics
         severity: Warning,
         message: "Use shorthand syntax for same-name prop binding",
         start: 13,
-        end: 22,
+        end: 23,
         help: Some(
             "Use shorthand prop syntax",
         ),

--- a/crates/vize_patina/src/rules/opinionated/vue/snapshots/vize_patina__rules__opinionated__vue__scoped_event_names__tests__warn_unscoped_event_with_suffix.snap
+++ b/crates/vize_patina/src/rules/opinionated/vue/snapshots/vize_patina__rules__opinionated__vue__scoped_event_names__tests__warn_unscoped_event_with_suffix.snap
@@ -8,7 +8,7 @@ expression: result.diagnostics
         severity: Warning,
         message: "Consider using scoped event name for better organization",
         start: 8,
-        end: 30,
+        end: 31,
         help: Some(
             "Use scoped event names like 'update:modelValue' instead of generic names",
         ),

--- a/crates/vize_patina/src/rules/vapor/snapshots/vize_patina__rules__vapor__no_vue_lifecycle_events__tests__invalid_vue_mounted.snap
+++ b/crates/vize_patina/src/rules/vapor/snapshots/vize_patina__rules__vapor__no_vue_lifecycle_events__tests__invalid_vue_mounted.snap
@@ -8,7 +8,7 @@ expression: result.diagnostics
         severity: Error,
         message: "@vue:mounted lifecycle events are not supported in Vapor",
         start: 5,
-        end: 28,
+        end: 29,
         help: Some(
             "Use component lifecycle hooks instead",
         ),

--- a/crates/vize_patina/src/rules/vapor/snapshots/vize_patina__rules__vapor__no_vue_lifecycle_events__tests__invalid_vue_updated.snap
+++ b/crates/vize_patina/src/rules/vapor/snapshots/vize_patina__rules__vapor__no_vue_lifecycle_events__tests__invalid_vue_updated.snap
@@ -8,7 +8,7 @@ expression: result.diagnostics
         severity: Error,
         message: "@vue:updated lifecycle events are not supported in Vapor",
         start: 5,
-        end: 28,
+        end: 29,
         help: Some(
             "Use component lifecycle hooks instead",
         ),

--- a/crates/vize_patina/src/rules/vue/snapshots/vize_patina__rules__vue__no_duplicate_attributes__tests__invalid_duplicate_event_same_modifiers.snap
+++ b/crates/vize_patina/src/rules/vue/snapshots/vize_patina__rules__vue__no_duplicate_attributes__tests__invalid_duplicate_event_same_modifiers.snap
@@ -8,7 +8,7 @@ expression: result.diagnostics
         severity: Error,
         message: "Duplicate attribute 'v-on:click.stop'",
         start: 21,
-        end: 35,
+        end: 36,
         help: Some(
             "Remove the duplicate attribute",
         ),

--- a/crates/vize_patina/src/rules/vue/snapshots/vize_patina__rules__vue__no_duplicate_attributes__tests__invalid_duplicate_id.snap
+++ b/crates/vize_patina/src/rules/vue/snapshots/vize_patina__rules__vue__no_duplicate_attributes__tests__invalid_duplicate_id.snap
@@ -8,7 +8,7 @@ expression: result.diagnostics
         severity: Error,
         message: "Duplicate attribute 'id'",
         start: 14,
-        end: 21,
+        end: 22,
         help: Some(
             "Remove the duplicate attribute",
         ),

--- a/crates/vize_patina/src/rules/vue/snapshots/vize_patina__rules__vue__no_use_v_if_with_v_for__tests__invalid_v_if_not_using_v_for_var.snap
+++ b/crates/vize_patina/src/rules/vue/snapshots/vize_patina__rules__vue__no_use_v_if_with_v_for__tests__invalid_v_if_not_using_v_for_var.snap
@@ -8,7 +8,7 @@ expression: result.diagnostics
         severity: Warning,
         message: "Avoid using v-if with v-for on the same element. The v-if condition does not have access to v-for scope variables",
         start: 27,
-        end: 40,
+        end: 41,
         help: Some(
             "**Problem:** `v-for` has higher priority than `v-if`, causing the entire list to iterate before filtering.\n\n**Solution 1:** Use a computed property:\n```vue\n<script setup>\nconst activeUsers = computed(() => \n  users.filter(u => u.isActive)\n)\n</script>\n<template>\n  <li v-for=\"user in activeUsers\" :key=\"user.id\">\n</template>\n```\n\n**Solution 2:** Wrap with `<template>`:\n```vue\n<template v-for=\"user in users\" :key=\"user.id\">\n  <li v-if=\"user.isActive\">{{ user.name }}</li>\n</template>\n```",
         ),
@@ -16,7 +16,7 @@ expression: result.diagnostics
             Label {
                 message: "v-for is here",
                 start: 5,
-                end: 25,
+                end: 26,
             },
         ],
         fix: None,

--- a/crates/vize_patina/src/rules/vue/snapshots/vize_patina__rules__vue__no_use_v_if_with_v_for__tests__invalid_v_if_with_v_for_same_element.snap
+++ b/crates/vize_patina/src/rules/vue/snapshots/vize_patina__rules__vue__no_use_v_if_with_v_for__tests__invalid_v_if_with_v_for_same_element.snap
@@ -8,7 +8,7 @@ expression: result.diagnostics
         severity: Warning,
         message: "Avoid using v-if with v-for on the same element. Use a computed property to filter the list first",
         start: 27,
-        end: 44,
+        end: 45,
         help: Some(
             "**Problem:** `v-for` has higher priority than `v-if`, causing the entire list to iterate before filtering.\n\n**Solution 1:** Use a computed property:\n```vue\n<script setup>\nconst activeUsers = computed(() => \n  users.filter(u => u.isActive)\n)\n</script>\n<template>\n  <li v-for=\"user in activeUsers\" :key=\"user.id\">\n</template>\n```\n\n**Solution 2:** Wrap with `<template>`:\n```vue\n<template v-for=\"user in users\" :key=\"user.id\">\n  <li v-if=\"user.isActive\">{{ user.name }}</li>\n</template>\n```",
         ),
@@ -16,7 +16,7 @@ expression: result.diagnostics
             Label {
                 message: "v-for is here",
                 start: 5,
-                end: 25,
+                end: 26,
             },
         ],
         fix: None,

--- a/crates/vize_patina/src/rules/vue/snapshots/vize_patina__rules__vue__no_v_html__tests__invalid_v_html.snap
+++ b/crates/vize_patina/src/rules/vue/snapshots/vize_patina__rules__vue__no_v_html__tests__invalid_v_html.snap
@@ -8,7 +8,7 @@ expression: result.diagnostics
         severity: Warning,
         message: "v-html can lead to XSS attacks. Avoid using it with user-provided content",
         start: 5,
-        end: 20,
+        end: 21,
         help: Some(
             "**Security Risk:** `v-html` renders raw HTML and can execute malicious scripts from user input.\n\n**Alternatives:**\n\n1. Use text interpolation (auto-escaped):\n```vue\n<p>{{ userContent }}</p>\n```\n\n2. Use a sanitization library:\n```ts\nimport DOMPurify from 'dompurify'\nconst safeHtml = DOMPurify.sanitize(userInput)\n```\n\n3. Use a markdown renderer with XSS protection\n\n**If you must use v-html:**\n- Never use with user-provided content\n- Only use with trusted, static content",
         ),

--- a/crates/vize_patina/src/rules/vue/snapshots/vize_patina__rules__vue__require_v_for_key__tests__invalid_v_for_without_key.snap
+++ b/crates/vize_patina/src/rules/vue/snapshots/vize_patina__rules__vue__require_v_for_key__tests__invalid_v_for_without_key.snap
@@ -8,7 +8,7 @@ expression: result.diagnostics
         severity: Error,
         message: "Elements in iteration expect to have 'v-bind:key' directives. Element: <li>",
         start: 8,
-        end: 28,
+        end: 29,
         help: Some(
             "**Why:** The `:key` attribute helps Vue's virtual DOM efficiently track and update list items.\n\n**Fix:** Add a unique identifier as the key:\n```vue\n<li v-for=\"item in items\" :key=\"item.id\">\n  {{ item.name }}\n</li>\n```\n\n**Best practices:**\n- Use unique, stable identifiers (like database IDs)\n- Avoid using array index as key when list order may change\n- Keys must be primitive values (string or number)",
         ),

--- a/crates/vize_patina/src/rules/vue/snapshots/vize_patina__rules__vue__valid_v_else__tests__invalid_v_else_with_expression.snap
+++ b/crates/vize_patina/src/rules/vue/snapshots/vize_patina__rules__vue__valid_v_else__tests__invalid_v_else_with_expression.snap
@@ -8,7 +8,7 @@ expression: result.diagnostics
         severity: Error,
         message: "v-else directives require no expression",
         start: 27,
-        end: 38,
+        end: 39,
         help: Some(
             "**Correct usage:**\n```vue\n<div v-if=\"type === 'A'\">A</div>\n<div v-else-if=\"type === 'B'\">B</div>\n<div v-else>Other</div>\n```\n\n**Rules:**\n- `v-else` takes no expression\n- Must immediately follow `v-if` or `v-else-if`\n- No other elements between them",
         ),
@@ -19,7 +19,7 @@ expression: result.diagnostics
                 edits: [
                     TextEdit {
                         start: 27,
-                        end: 38,
+                        end: 39,
                         new_text: "",
                     },
                 ],

--- a/crates/vize_patina/src/rules/vue/snapshots/vize_patina__rules__vue__valid_v_show__tests__invalid_v_show_on_template.snap
+++ b/crates/vize_patina/src/rules/vue/snapshots/vize_patina__rules__vue__valid_v_show__tests__invalid_v_show_on_template.snap
@@ -8,7 +8,7 @@ expression: result.diagnostics
         severity: Error,
         message: "v-show cannot be used on <template> element",
         start: 10,
-        end: 21,
+        end: 22,
         help: Some(
             "Add an expression to the v-show directive",
         ),


### PR DESCRIPTION
## Summary
- Correct parser prop source locations so no-value directives stop at the directive head instead of including trailing whitespace.
- Include the closing quote in quoted attribute and directive full locations, including spaced equals.
- Update diagnostics snapshots that use the corrected prop spans.

## Tests
- `cargo test -p vize_armature`
- `cargo test -p vize_patina`

Closes #206