### PR TITLE
feat(sfc): support compile-time macro artifacts

### DIFF
--- a/crates/vize/src/commands/build/config.rs
+++ b/crates/vize/src/commands/build/config.rs
@@ -12,6 +12,7 @@ use std::{
 };
 
 use super::ScriptExtension;
+use vize_atelier_sfc::SfcMacroArtifact;
 use vize_carton::cstr;
 use vize_carton::String;
 
@@ -72,6 +73,7 @@ pub(crate) struct CompileOutput {
     pub errors: Vec<String>,
     pub warnings: Vec<String>,
     pub script_lang: String,
+    pub macro_artifacts: Vec<SfcMacroArtifact>,
 }
 
 /// Detailed timing information for a single file.

--- a/crates/vize/src/commands/build/runner.rs
+++ b/crates/vize/src/commands/build/runner.rs
@@ -615,6 +615,7 @@ fn compile_file_with_profile(
         errors: result.errors.into_iter().map(|e| e.message).collect(),
         warnings: result.warnings.into_iter().map(|e| e.message).collect(),
         script_lang,
+        macro_artifacts: result.macro_artifacts,
     };
 
     Ok((output, profile))

--- a/crates/vize/src/commands/check/nuxt.rs
+++ b/crates/vize/src/commands/check/nuxt.rs
@@ -316,6 +316,7 @@ fn fallback_stub_strings() -> Vec<String> {
         "declare function useRouter(): any;".into(),
         "declare function useRoute(name?: string): any;".into(),
         "declare function definePageMeta(meta: any): void;".into(),
+        "declare function defineRouteRules(rules: any): void;".into(),
         "declare function useSeoMeta(meta: any): void;".into(),
         "declare function useFetch<T = any>(url: string | (() => string), options?: any): any;".into(),
         "declare function useAsyncData<T = any>(handler: (...args: any[]) => T | Promise<T>, options?: any): any;".into(),

--- a/crates/vize_atelier_sfc/src/compile/mod.rs
+++ b/crates/vize_atelier_sfc/src/compile/mod.rs
@@ -11,6 +11,8 @@ mod styles;
 #[cfg(test)]
 mod tests;
 
+use crate::compile_script::artifacts::{erase_artifact_macro_statements, extract_macro_artifacts};
+use crate::compile_script::lazy_hydration::transform_lazy_hydration_macros;
 use crate::compile_script::{compile_script_setup_inline_with_context, TemplateParts};
 use crate::compile_template::{
     compile_template_block, compile_template_block_vapor, extract_template_parts,
@@ -18,7 +20,9 @@ use crate::compile_template::{
 };
 use crate::rewrite_default::rewrite_default;
 use crate::script::ScriptCompileContext;
-use crate::types::{BindingType, SfcCompileOptions, SfcCompileResult, SfcDescriptor, SfcError};
+use crate::types::{
+    BindingType, SfcCompileOptions, SfcCompileResult, SfcDescriptor, SfcError, SfcMacroArtifact,
+};
 
 use self::bindings::{croquis_to_legacy_bindings, register_normal_script_bindings};
 use self::helpers::{
@@ -62,6 +66,23 @@ fn is_ts_lang(lang: Option<&str>) -> bool {
     matches!(lang, Some("ts" | "tsx"))
 }
 
+fn extract_descriptor_macro_artifacts(descriptor: &SfcDescriptor) -> Vec<SfcMacroArtifact> {
+    let mut artifacts = Vec::new();
+
+    if let Some(script) = descriptor.script.as_ref() {
+        artifacts.extend(extract_macro_artifacts(&script.content, script.loc.start));
+    }
+    if let Some(script_setup) = descriptor.script_setup.as_ref() {
+        artifacts.extend(extract_macro_artifacts(
+            &script_setup.content,
+            script_setup.loc.start,
+        ));
+    }
+
+    artifacts.sort_by_key(|artifact| artifact.start);
+    artifacts
+}
+
 /// Compile an SFC descriptor into JavaScript and CSS
 pub fn compile_sfc(
     descriptor: &SfcDescriptor,
@@ -71,6 +92,7 @@ pub fn compile_sfc(
     let mut warnings = Vec::new();
     let mut code = String::default();
     let mut css = None;
+    let macro_artifacts = extract_descriptor_macro_artifacts(descriptor);
 
     let filename = options.script.id.as_deref().unwrap_or("anonymous.vue");
 
@@ -204,12 +226,20 @@ pub fn compile_sfc(
             errors,
             warnings,
             bindings: None,
+            macro_artifacts,
         });
     }
 
     // Case 2: Script (non-setup) + Template - rewrite default and compile template
     if has_script && !has_script_setup {
         let script = descriptor.script.as_ref().unwrap();
+        let lazy_hydration_transform = transform_lazy_hydration_macros(&script.content);
+        let script_source = lazy_hydration_transform
+            .as_ref()
+            .map(|result| result.code.as_str())
+            .unwrap_or(&script.content);
+        let script_content = erase_artifact_macro_statements(script_source)
+            .unwrap_or_else(|| script_source.to_compact_string());
 
         // Check if source script is TypeScript
         let source_is_ts = script
@@ -221,11 +251,11 @@ pub fn compile_sfc(
         // Parse as TypeScript if source is TypeScript
         let (rewritten_script, _has_default) = profile!(
             "atelier.sfc.normal_script.rewrite_default",
-            rewrite_default(&script.content, "_sfc_main", source_is_ts)
+            rewrite_default(&script_content, "_sfc_main", source_is_ts)
         );
 
         // Transpile TypeScript to JavaScript if needed
-        let final_script = if source_is_ts && !is_ts {
+        let mut final_script = if source_is_ts && !is_ts {
             profile!(
                 "atelier.sfc.normal_script.ts_to_js",
                 crate::compile_script::typescript::transform_typescript_to_js(&rewritten_script)
@@ -233,6 +263,11 @@ pub fn compile_sfc(
         } else {
             rewritten_script
         };
+        if let Some(transform) = lazy_hydration_transform {
+            let mut script_with_preamble = transform.preamble;
+            script_with_preamble.push_str(&final_script);
+            final_script = script_with_preamble;
+        }
 
         // Compile template if present
         if has_template {
@@ -298,7 +333,7 @@ pub fn compile_sfc(
                 Err(e) => {
                     errors.push(e);
                     // Fall back to just the script
-                    code = script.content.to_compact_string();
+                    code = final_script.clone();
                     code.push('\n');
                 }
             }
@@ -327,6 +362,7 @@ pub fn compile_sfc(
             errors,
             warnings,
             bindings: None,
+            macro_artifacts,
         });
     }
 
@@ -363,19 +399,24 @@ pub fn compile_sfc(
         None
     };
 
+    let lazy_hydration_transform = transform_lazy_hydration_macros(&script_setup.content);
+    let mut script_setup_content = lazy_hydration_transform
+        .as_ref()
+        .map(|result| result.code.clone())
+        .unwrap_or_else(|| script_setup.content.to_compact_string());
+
     // 1. Croquis parser: rich analysis with ReactivityTracker
     let mut croquis = profile!(
         "atelier.sfc.script_setup.croquis",
-        crate::script::analyze_script_setup_to_summary(&script_setup.content)
+        crate::script::analyze_script_setup_to_summary(&script_setup_content)
     );
     let mut script_bindings = croquis_to_legacy_bindings(&croquis.bindings);
-    let mut script_setup_content = script_setup.content.to_compact_string();
 
     // 2. ScriptCompileContext: needed for macro span info and TypeScript type resolution
     //    (Croquis doesn't resolve type references like `defineProps<Props>()`)
     let mut ctx = profile!(
         "atelier.sfc.script_context.new",
-        ScriptCompileContext::new(&script_setup.content)
+        ScriptCompileContext::new(&script_setup_content)
     );
 
     // Merge type definitions from normal <script> block so that
@@ -389,7 +430,7 @@ pub fn compile_sfc(
     }
     profile!(
         "atelier.sfc.script_context.collect_setup_import_types",
-        ctx.collect_imported_types_from_path(&script_setup.content, filename)
+        ctx.collect_imported_types_from_path(&script_setup_content, filename)
     );
     if has_script {
         let script = descriptor.script.as_ref().unwrap();
@@ -592,6 +633,9 @@ pub fn compile_sfc(
 
     // The inline mode compile_script_setup_inline generates a complete output
     // including imports, hoisted vars, and `export default { ... }` with inline render
+    if let Some(transform) = lazy_hydration_transform {
+        code.push_str(&transform.preamble);
+    }
     code.push_str(&script_result.code);
 
     // Compile styles
@@ -610,5 +654,6 @@ pub fn compile_sfc(
         errors,
         warnings,
         bindings: script_result.bindings,
+        macro_artifacts,
     })
 }

--- a/crates/vize_atelier_sfc/src/compile/tests.rs
+++ b/crates/vize_atelier_sfc/src/compile/tests.rs
@@ -81,6 +81,185 @@ const items = [{ name: 'dist', children: [{ name: 'file.js', children: [] }] }]
 }
 
 #[test]
+fn test_script_setup_define_page_is_compile_time_only() {
+    let source = r#"<script setup lang="ts">
+definePage({
+  name: 'home',
+  meta: {
+    requiresAuth: true,
+  },
+})
+
+const msg = 'ready'
+</script>
+<template>
+  <div>{{ msg }}</div>
+</template>"#;
+
+    let descriptor = parse_sfc(source, SfcParseOptions::default()).expect("Failed to parse SFC");
+    let opts = SfcCompileOptions::default();
+    let result = compile_sfc(&descriptor, opts).expect("Failed to compile SFC");
+
+    assert!(
+        !result.code.contains("definePage"),
+        "definePage should be removed from runtime output:\n{}",
+        result.code
+    );
+    assert!(result.code.contains("ready"));
+    assert_eq!(result.macro_artifacts.len(), 1);
+
+    let artifact = &result.macro_artifacts[0];
+    assert_eq!(artifact.kind.as_str(), "vue-router.definePage");
+    assert_eq!(artifact.name.as_str(), "definePage");
+    assert!(artifact.source.contains("definePage"));
+    assert!(artifact.content.contains("requiresAuth"));
+    assert!(artifact
+        .module_code
+        .as_ref()
+        .is_some_and(|code| code.starts_with("export default {")));
+}
+
+#[test]
+fn test_script_setup_define_page_meta_is_compile_time_only() {
+    let source = r#"<script setup lang="ts">
+definePageMeta({
+  name: 'docs',
+  meta: {
+    scrollMargin: 180,
+  },
+})
+
+const msg = 'ready'
+</script>
+<template>
+  <div>{{ msg }}</div>
+</template>"#;
+
+    let descriptor = parse_sfc(source, SfcParseOptions::default()).expect("Failed to parse SFC");
+    let opts = SfcCompileOptions::default();
+    let result = compile_sfc(&descriptor, opts).expect("Failed to compile SFC");
+
+    assert!(
+        !result.code.contains("definePageMeta"),
+        "definePageMeta should be removed from runtime output:\n{}",
+        result.code
+    );
+    assert!(result.code.contains("ready"));
+    assert_eq!(result.macro_artifacts.len(), 1);
+
+    let artifact = &result.macro_artifacts[0];
+    assert_eq!(artifact.kind.as_str(), "nuxt.definePageMeta");
+    assert_eq!(artifact.name.as_str(), "definePageMeta");
+    assert!(artifact.source.contains("definePageMeta"));
+    assert!(artifact.content.contains("scrollMargin"));
+    assert!(artifact
+        .module_code
+        .as_ref()
+        .is_some_and(|code| code.starts_with("export default {")));
+}
+
+#[test]
+fn test_script_setup_define_route_rules_is_compile_time_only() {
+    let source = r#"<script setup lang="ts">
+defineRouteRules({
+  prerender: true,
+  cache: {
+    maxAge: 60,
+  },
+})
+
+const msg = 'ready'
+</script>
+<template>
+  <div>{{ msg }}</div>
+</template>"#;
+
+    let descriptor = parse_sfc(source, SfcParseOptions::default()).expect("Failed to parse SFC");
+    let opts = SfcCompileOptions::default();
+    let result = compile_sfc(&descriptor, opts).expect("Failed to compile SFC");
+
+    assert!(
+        !result.code.contains("defineRouteRules"),
+        "defineRouteRules should be removed from runtime output:\n{}",
+        result.code
+    );
+    assert!(result.code.contains("ready"));
+    assert_eq!(result.macro_artifacts.len(), 1);
+
+    let artifact = &result.macro_artifacts[0];
+    assert_eq!(artifact.kind.as_str(), "nuxt.defineRouteRules");
+    assert_eq!(artifact.name.as_str(), "defineRouteRules");
+    assert!(artifact.source.contains("defineRouteRules"));
+    assert!(artifact.content.contains("prerender"));
+    assert!(artifact
+        .module_code
+        .as_ref()
+        .is_some_and(|code| code.starts_with("export default {")));
+}
+
+#[test]
+fn test_script_setup_define_lazy_hydration_component_expands() {
+    let source = r#"<script setup lang="ts">
+const LazyHydrationMyComponent = defineLazyHydrationComponent(
+  'visible',
+  () => import('./components/MyComponent.vue'),
+)
+</script>
+<template>
+  <LazyHydrationMyComponent :hydrate-on-visible="{ rootMargin: '100px' }" />
+</template>"#;
+
+    let descriptor = parse_sfc(source, SfcParseOptions::default()).expect("Failed to parse SFC");
+    let mut opts = SfcCompileOptions::default();
+    opts.script.id = Some("/src/pages/Home.vue".into());
+    let result = compile_sfc(&descriptor, opts).expect("Failed to compile SFC");
+
+    assert!(
+        !result.code.contains("defineLazyHydrationComponent"),
+        "defineLazyHydrationComponent should be expanded from runtime output:\n{}",
+        result.code
+    );
+    assert!(result.code.contains("__vizeCreateLazyVisibleComponent"));
+    assert!(result.code.contains("useNuxtApp as __vizeUseNuxtApp"));
+    assert!(result.code.contains("./components/MyComponent.vue"));
+    assert!(result.code.contains("LazyHydrationMyComponent"));
+}
+
+#[test]
+fn test_normal_script_define_page_outputs_artifact_and_is_erased() {
+    let source = r#"<script>
+definePage({
+  name: 'legacy-page',
+})
+
+export default {
+  data() {
+    return { msg: 'ready' }
+  },
+}
+</script>
+<template>
+  <div>{{ msg }}</div>
+</template>"#;
+
+    let descriptor = parse_sfc(source, SfcParseOptions::default()).expect("Failed to parse SFC");
+    let opts = SfcCompileOptions::default();
+    let result = compile_sfc(&descriptor, opts).expect("Failed to compile SFC");
+
+    assert!(
+        !result.code.contains("definePage"),
+        "definePage should be removed from normal script runtime output:\n{}",
+        result.code
+    );
+    assert_eq!(result.macro_artifacts.len(), 1);
+    assert_eq!(
+        result.macro_artifacts[0].kind.as_str(),
+        "vue-router.definePage"
+    );
+    assert!(result.macro_artifacts[0].content.contains("legacy-page"));
+}
+
+#[test]
 fn test_bindings_passed_to_template() {
     let source = r#"<script setup lang="ts">
 import { ref } from 'vue';

--- a/crates/vize_atelier_sfc/src/compile_script.rs
+++ b/crates/vize_atelier_sfc/src/compile_script.rs
@@ -3,9 +3,11 @@
 //! This module handles compilation of `<script>` and `<script setup>` blocks,
 //! following the Vue.js core output format.
 
+pub(crate) mod artifacts;
 pub mod function_mode;
 pub mod import_utils;
 pub mod inline;
+pub(crate) mod lazy_hydration;
 pub mod macros;
 pub mod props;
 pub mod statement_sections;
@@ -16,6 +18,7 @@ pub mod typescript;
 use crate::types::{BindingMetadata, ScriptCompileOptions, SfcDescriptor, SfcError};
 
 use self::function_mode::compile_script_setup;
+use self::lazy_hydration::transform_lazy_hydration_macros;
 use self::typescript::transform_typescript_to_js;
 
 // Re-export commonly used items
@@ -63,13 +66,24 @@ pub fn compile_script(
     // Handle script setup
     if let Some(script_setup) = &descriptor.script_setup {
         let template_content = descriptor.template.as_ref().map(|t| t.content.as_ref());
-        compile_script_setup(
-            &script_setup.content,
+        let transformed = transform_lazy_hydration_macros(&script_setup.content);
+        let script_content = transformed
+            .as_ref()
+            .map(|result| result.code.as_str())
+            .unwrap_or(&script_setup.content);
+        let mut result = compile_script_setup(
+            script_content,
             component_name,
             is_vapor,
             is_ts,
             template_content,
-        )
+        )?;
+        if let Some(transformed) = transformed {
+            let mut code = transformed.preamble;
+            code.push_str(&result.code);
+            result.code = code;
+        }
+        Ok(result)
     } else if let Some(script) = &descriptor.script {
         // Use regular script, wrapped in __sfc__
         let mut code = String::default();

--- a/crates/vize_atelier_sfc/src/compile_script/artifacts.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/artifacts.rs
@@ -1,0 +1,344 @@
+//! Compile-time macro artifact extraction.
+//!
+//! These helpers keep ecosystem macro output independent from any specific
+//! bundler hook. The SFC compiler can erase the runtime call while still
+//! returning a loadable artifact for tools such as file-based routers.
+
+use oxc_allocator::Allocator;
+use oxc_ast::ast::{Argument, CallExpression, Expression, Statement};
+use oxc_parser::Parser;
+use oxc_span::{GetSpan, SourceType};
+use vize_carton::{String, ToCompactString};
+use vize_croquis::macros::{artifact_macro_names, macro_artifact_kind};
+
+use crate::types::SfcMacroArtifact;
+
+pub(crate) fn extract_macro_artifacts(
+    content: &str,
+    absolute_offset: usize,
+) -> Vec<SfcMacroArtifact> {
+    if !contains_artifact_macro_candidate(content) {
+        return Vec::new();
+    }
+
+    let allocator = Allocator::default();
+    let source_type = SourceType::from_path("script.ts").unwrap_or_default();
+    let ret = Parser::new(&allocator, content, source_type).parse();
+
+    if ret.panicked {
+        return Vec::new();
+    }
+
+    let static_imports = collect_static_imports(ret.program.body.iter(), content);
+    let mut artifacts = Vec::new();
+
+    for stmt in ret.program.body.iter() {
+        let Some(call) = artifact_call_from_statement(stmt) else {
+            continue;
+        };
+        let Some(name) = call_name(call) else {
+            continue;
+        };
+        let Some(kind) = macro_artifact_kind(name) else {
+            continue;
+        };
+
+        let start = call.span.start as usize;
+        let end = call.span.end as usize;
+        if start > end || end > content.len() {
+            continue;
+        }
+
+        let source = (&content[start..end]).to_compact_string();
+        let payload = call
+            .arguments
+            .first()
+            .map(|arg| argument_source(arg, content))
+            .filter(|source| !source.trim().is_empty())
+            .unwrap_or_else(|| "{}".into());
+        let module_code = build_artifact_module(kind, &payload, &static_imports);
+
+        artifacts.push(SfcMacroArtifact {
+            kind: kind.into(),
+            name: name.into(),
+            source,
+            content: payload,
+            module_code: Some(module_code),
+            start: absolute_offset + start,
+            end: absolute_offset + end,
+        });
+    }
+
+    artifacts
+}
+
+pub(crate) fn erase_artifact_macro_statements(content: &str) -> Option<String> {
+    if !contains_artifact_macro_candidate(content) {
+        return None;
+    }
+
+    let allocator = Allocator::default();
+    let source_type = SourceType::from_path("script.ts").unwrap_or_default();
+    let ret = Parser::new(&allocator, content, source_type).parse();
+
+    if ret.panicked {
+        return None;
+    }
+
+    let mut ranges = Vec::new();
+    for stmt in ret.program.body.iter() {
+        let Some(call) = artifact_call_from_statement(stmt) else {
+            continue;
+        };
+        let Some(name) = call_name(call) else {
+            continue;
+        };
+        if macro_artifact_kind(name).is_none() {
+            continue;
+        }
+
+        let span = stmt.span();
+        let start = span.start as usize;
+        let end = span.end as usize;
+        if start <= end && end <= content.len() {
+            ranges.push((start, end));
+        }
+    }
+
+    if ranges.is_empty() {
+        return None;
+    }
+
+    let mut erased = String::with_capacity(content.len());
+    let mut cursor = 0usize;
+    for (start, end) in ranges {
+        if start < cursor {
+            continue;
+        }
+        erased.push_str(&content[cursor..start]);
+        cursor = end;
+    }
+    erased.push_str(&content[cursor..]);
+    Some(erased)
+}
+
+fn contains_artifact_macro_candidate(content: &str) -> bool {
+    artifact_macro_names().any(|name| content.contains(name))
+}
+
+fn artifact_call_from_statement<'a>(stmt: &'a Statement<'a>) -> Option<&'a CallExpression<'a>> {
+    match stmt {
+        Statement::ExpressionStatement(expr_stmt) => unwrap_call_expression(&expr_stmt.expression),
+        _ => None,
+    }
+}
+
+fn unwrap_call_expression<'a>(expr: &'a Expression<'a>) -> Option<&'a CallExpression<'a>> {
+    match expr {
+        Expression::CallExpression(call) => Some(call),
+        Expression::TSAsExpression(ts_as) => unwrap_call_expression(&ts_as.expression),
+        Expression::TSSatisfiesExpression(ts_satisfies) => {
+            unwrap_call_expression(&ts_satisfies.expression)
+        }
+        Expression::TSNonNullExpression(ts_non_null) => {
+            unwrap_call_expression(&ts_non_null.expression)
+        }
+        Expression::ParenthesizedExpression(paren) => unwrap_call_expression(&paren.expression),
+        _ => None,
+    }
+}
+
+fn call_name<'a>(call: &'a CallExpression<'a>) -> Option<&'a str> {
+    match &call.callee {
+        Expression::Identifier(id) => Some(id.name.as_str()),
+        _ => None,
+    }
+}
+
+fn argument_source(arg: &Argument<'_>, source: &str) -> String {
+    let span = arg.span();
+    let start = span.start as usize;
+    let end = span.end as usize;
+    if start > end || end > source.len() {
+        return String::default();
+    }
+    (&source[start..end]).to_compact_string()
+}
+
+fn collect_static_imports<'a>(
+    statements: impl Iterator<Item = &'a Statement<'a>>,
+    content: &str,
+) -> String {
+    let mut imports = String::default();
+
+    for stmt in statements {
+        if !matches!(stmt, Statement::ImportDeclaration(_)) {
+            continue;
+        }
+
+        let span = stmt.span();
+        let start = span.start as usize;
+        let end = span.end as usize;
+        if start > end || end > content.len() {
+            continue;
+        }
+
+        imports.push_str(content[start..end].trim());
+        imports.push('\n');
+    }
+
+    imports
+}
+
+fn build_artifact_module(_kind: &str, payload: &str, static_imports: &str) -> String {
+    let mut module_code = String::default();
+    module_code.push_str(static_imports);
+    module_code.push_str("export default ");
+    module_code.push_str(payload.trim());
+    module_code.push('\n');
+    module_code
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{erase_artifact_macro_statements, extract_macro_artifacts};
+
+    #[test]
+    fn extracts_define_page_artifact_module() {
+        let content = r#"import { routeMeta } from './route'
+
+definePage({
+  name: 'home',
+  meta: routeMeta,
+})
+
+const msg = 'ready'
+"#;
+
+        let artifacts = extract_macro_artifacts(content, 10);
+
+        assert_eq!(artifacts.len(), 1);
+        assert_eq!(artifacts[0].kind.as_str(), "vue-router.definePage");
+        assert_eq!(artifacts[0].name.as_str(), "definePage");
+        assert!(artifacts[0].source.contains("definePage"));
+        assert!(artifacts[0].content.contains("routeMeta"));
+        assert_eq!(artifacts[0].start, 10 + content.find("definePage").unwrap());
+        assert!(artifacts[0]
+            .module_code
+            .as_ref()
+            .unwrap()
+            .contains("import { routeMeta } from './route'\nexport default {"));
+    }
+
+    #[test]
+    fn extracts_define_page_meta_artifact_module() {
+        let content = r#"import { pageAlias } from './route'
+
+definePageMeta({
+  name: 'docs',
+  alias: pageAlias,
+  meta: {
+    scrollMargin: 180,
+  },
+})
+
+const msg = 'ready'
+"#;
+
+        let artifacts = extract_macro_artifacts(content, 4);
+
+        assert_eq!(artifacts.len(), 1);
+        assert_eq!(artifacts[0].kind.as_str(), "nuxt.definePageMeta");
+        assert_eq!(artifacts[0].name.as_str(), "definePageMeta");
+        assert!(artifacts[0].source.contains("definePageMeta"));
+        assert!(artifacts[0].content.contains("scrollMargin"));
+        assert_eq!(
+            artifacts[0].start,
+            4 + content.find("definePageMeta").unwrap()
+        );
+        assert!(artifacts[0]
+            .module_code
+            .as_ref()
+            .unwrap()
+            .contains("import { pageAlias } from './route'\nexport default {"));
+    }
+
+    #[test]
+    fn extracts_define_route_rules_artifact_module() {
+        let content = r#"defineRouteRules({
+  prerender: true,
+  cache: {
+    maxAge: 60,
+  },
+})
+
+const msg = 'ready'
+"#;
+
+        let artifacts = extract_macro_artifacts(content, 2);
+
+        assert_eq!(artifacts.len(), 1);
+        assert_eq!(artifacts[0].kind.as_str(), "nuxt.defineRouteRules");
+        assert_eq!(artifacts[0].name.as_str(), "defineRouteRules");
+        assert!(artifacts[0].source.contains("defineRouteRules"));
+        assert!(artifacts[0].content.contains("prerender"));
+        assert_eq!(
+            artifacts[0].start,
+            2 + content.find("defineRouteRules").unwrap()
+        );
+        assert!(artifacts[0]
+            .module_code
+            .as_ref()
+            .unwrap()
+            .starts_with("export default {"));
+    }
+
+    #[test]
+    fn ignores_content_without_artifact_macro_candidates() {
+        let content = r#"const msg = 'ready'
+const LazyHydrationMyComponent = defineLazyHydrationComponent(
+  'visible',
+  () => import('./components/MyComponent.vue'),
+)
+"#;
+
+        assert!(extract_macro_artifacts(content, 0).is_empty());
+        assert!(erase_artifact_macro_statements(content).is_none());
+    }
+
+    #[test]
+    fn erases_define_page_top_level_statement() {
+        let content = r#"definePage({ name: 'home' })
+const msg = 'ready'
+"#;
+
+        let erased = erase_artifact_macro_statements(content).expect("macro should be erased");
+
+        assert!(!erased.contains("definePage"));
+        assert!(erased.contains("const msg = 'ready'"));
+    }
+
+    #[test]
+    fn erases_define_page_meta_top_level_statement() {
+        let content = r#"definePageMeta({ name: 'docs' })
+const msg = 'ready'
+"#;
+
+        let erased = erase_artifact_macro_statements(content).expect("macro should be erased");
+
+        assert!(!erased.contains("definePageMeta"));
+        assert!(erased.contains("const msg = 'ready'"));
+    }
+
+    #[test]
+    fn erases_define_route_rules_top_level_statement() {
+        let content = r#"defineRouteRules({ prerender: true })
+const msg = 'ready'
+"#;
+
+        let erased = erase_artifact_macro_statements(content).expect("macro should be erased");
+
+        assert!(!erased.contains("defineRouteRules"));
+        assert!(erased.contains("const msg = 'ready'"));
+    }
+}

--- a/crates/vize_atelier_sfc/src/compile_script/function_mode/compiler.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/function_mode/compiler.rs
@@ -5,6 +5,7 @@
 //! render function.
 
 use vize_carton::{Bump, FxHashSet, String, ToCompactString};
+use vize_croquis::macros::runtime_erased_macro_names;
 
 use crate::script::{
     resolve_template_used_identifiers, transform_destructured_props, ScriptCompileContext,
@@ -13,6 +14,7 @@ use crate::script::{
 use crate::types::{BindingType, SfcError};
 
 use super::super::import_utils::extract_import_identifiers;
+use super::super::lazy_hydration::transform_lazy_hydration_macros;
 use super::super::props::{
     add_null_to_runtime_type, extract_emit_names_from_type, extract_prop_types_from_type,
 };
@@ -31,6 +33,12 @@ pub fn compile_script_setup(
     is_ts: bool,
     template_content: Option<&str>,
 ) -> Result<ScriptCompileResult, SfcError> {
+    let lazy_hydration_transform = transform_lazy_hydration_macros(content);
+    let content = lazy_hydration_transform
+        .as_ref()
+        .map(|result| result.code.as_str())
+        .unwrap_or(content);
+
     let mut ctx = ScriptCompileContext::new(content);
     ctx.analyze();
 
@@ -292,11 +300,16 @@ pub fn compile_script_setup(
         unsafe { std::string::String::from_utf8_unchecked(output.into_iter().collect()) };
 
     // Transform TypeScript to JavaScript only when output is not TS.
-    let final_code: String = if is_ts {
+    let mut final_code: String = if is_ts {
         output_str.into()
     } else {
         transform_typescript_to_js(&output_str)
     };
+    if let Some(transform) = lazy_hydration_transform {
+        let mut code = transform.preamble;
+        code.push_str(&final_code);
+        final_code = code;
+    }
 
     Ok(ScriptCompileResult {
         code: final_code,
@@ -572,17 +585,7 @@ fn build_returned_bindings(
     _model_binding_names: &[String],
 ) -> Vec<String> {
     // Compiler macros preset - these are compile-time only and should not be in __returned__
-    let compiler_macros: FxHashSet<&str> = [
-        "defineProps",
-        "defineEmits",
-        "defineExpose",
-        "defineOptions",
-        "defineSlots",
-        "defineModel",
-        "withDefaults",
-    ]
-    .into_iter()
-    .collect();
+    let compiler_macros: FxHashSet<&str> = runtime_erased_macro_names().collect();
 
     // Collect destructured prop local names to exclude from __returned__
     let destructured_prop_locals: FxHashSet<String> = ctx

--- a/crates/vize_atelier_sfc/src/compile_script/inline/compiler.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/inline/compiler.rs
@@ -22,6 +22,7 @@ use crate::script::ScriptCompileContext;
 use crate::types::SfcError;
 
 use super::super::function_mode::contains_top_level_await;
+use super::super::lazy_hydration::transform_lazy_hydration_macros;
 use super::super::{ScriptCompileResult, TemplateParts};
 use body::compile_script_setup_inline_body;
 use parser::parse_script_content;
@@ -41,8 +42,13 @@ pub fn compile_script_setup_inline(
     scope_id: &str,
     filename: Option<&str>,
 ) -> Result<ScriptCompileResult, SfcError> {
+    let transformed = transform_lazy_hydration_macros(content);
+    let content = transformed
+        .as_ref()
+        .map(|result| result.code.as_str())
+        .unwrap_or(content);
     let ctx = build_script_setup_context(content, normal_script_content, filename);
-    compile_script_setup_inline_with_context(
+    let mut result = compile_script_setup_inline_with_context(
         ctx,
         content,
         component_name,
@@ -53,7 +59,13 @@ pub fn compile_script_setup_inline(
         normal_script_content,
         css_vars,
         scope_id,
-    )
+    )?;
+    if let Some(transformed) = transformed {
+        let mut code = transformed.preamble;
+        code.push_str(&result.code);
+        result.code = code;
+    }
+    Ok(result)
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/crates/vize_atelier_sfc/src/compile_script/lazy_hydration.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/lazy_hydration.rs
@@ -1,0 +1,376 @@
+//! Nuxt lazy hydration macro expansion.
+//!
+//! Nuxt exposes `defineLazyHydrationComponent` as a compiler macro. Expanding it
+//! in the SFC compiler keeps the behavior independent from a specific bundler
+//! transform and prevents the empty runtime stub from leaking into output.
+
+use oxc_allocator::Allocator;
+use oxc_ast::ast::{
+    Argument, ArrowFunctionExpression, BindingPattern, Declaration, Expression, Statement,
+    VariableDeclaration,
+};
+use oxc_parser::Parser;
+use oxc_span::{GetSpan, SourceType};
+use vize_carton::{String, ToCompactString};
+
+/// A rewritten script and the module preamble it needs.
+#[derive(Debug, Clone)]
+pub(crate) struct LazyHydrationTransform {
+    pub code: String,
+    pub preamble: String,
+}
+
+#[derive(Debug)]
+struct Edit {
+    start: usize,
+    end: usize,
+    replacement: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum LazyHydrationStrategy {
+    Visible,
+    Idle,
+    Interaction,
+    MediaQuery,
+    If,
+    Time,
+    Never,
+}
+
+impl LazyHydrationStrategy {
+    fn from_name(name: &str) -> Option<Self> {
+        match name {
+            "visible" => Some(Self::Visible),
+            "idle" => Some(Self::Idle),
+            "interaction" => Some(Self::Interaction),
+            "mediaQuery" => Some(Self::MediaQuery),
+            "if" => Some(Self::If),
+            "time" => Some(Self::Time),
+            "never" => Some(Self::Never),
+            _ => None,
+        }
+    }
+
+    const fn factory_name(self) -> &'static str {
+        match self {
+            Self::Visible => "__vizeCreateLazyVisibleComponent",
+            Self::Idle => "__vizeCreateLazyIdleComponent",
+            Self::Interaction => "__vizeCreateLazyInteractionComponent",
+            Self::MediaQuery => "__vizeCreateLazyMediaQueryComponent",
+            Self::If => "__vizeCreateLazyIfComponent",
+            Self::Time => "__vizeCreateLazyTimeComponent",
+            Self::Never => "__vizeCreateLazyNeverComponent",
+        }
+    }
+}
+
+/// Expand Nuxt `defineLazyHydrationComponent(strategy, loader)` calls.
+pub(crate) fn transform_lazy_hydration_macros(content: &str) -> Option<LazyHydrationTransform> {
+    if !content.contains("defineLazyHydrationComponent") {
+        return None;
+    }
+
+    let allocator = Allocator::default();
+    let source_type = SourceType::from_path("script.ts").unwrap_or_default();
+    let ret = Parser::new(&allocator, content, source_type).parse();
+    if ret.panicked {
+        return None;
+    }
+
+    let mut edits = Vec::new();
+    let mut strategies = Vec::new();
+
+    for stmt in ret.program.body.iter() {
+        match stmt {
+            Statement::VariableDeclaration(var_decl) => {
+                collect_lazy_hydration_edits(var_decl, content, &mut edits, &mut strategies)?;
+            }
+            Statement::ExportNamedDeclaration(export_decl) => {
+                if let Some(Declaration::VariableDeclaration(var_decl)) =
+                    export_decl.declaration.as_ref()
+                {
+                    collect_lazy_hydration_edits(var_decl, content, &mut edits, &mut strategies)?;
+                }
+            }
+            _ => {}
+        }
+    }
+
+    if edits.is_empty() {
+        return None;
+    }
+
+    edits.sort_by_key(|edit| edit.start);
+    let mut code = String::with_capacity(
+        content.len() + edits.iter().map(|e| e.replacement.len()).sum::<usize>(),
+    );
+    let mut cursor = 0usize;
+    for edit in edits {
+        if edit.start < cursor {
+            continue;
+        }
+        code.push_str(&content[cursor..edit.start]);
+        code.push_str(&edit.replacement);
+        cursor = edit.end;
+    }
+    code.push_str(&content[cursor..]);
+
+    Some(LazyHydrationTransform {
+        code,
+        preamble: build_lazy_hydration_preamble(&strategies),
+    })
+}
+
+fn collect_lazy_hydration_edits(
+    var_decl: &VariableDeclaration<'_>,
+    content: &str,
+    edits: &mut Vec<Edit>,
+    strategies: &mut Vec<LazyHydrationStrategy>,
+) -> Option<()> {
+    for declarator in var_decl.declarations.iter() {
+        let BindingPattern::BindingIdentifier(_) = &declarator.id else {
+            continue;
+        };
+        let Some(Expression::CallExpression(call)) = declarator.init.as_ref() else {
+            continue;
+        };
+        let Expression::Identifier(callee) = &call.callee else {
+            continue;
+        };
+        if callee.name.as_str() != "defineLazyHydrationComponent" {
+            continue;
+        }
+        if call.arguments.len() < 2 {
+            continue;
+        }
+
+        let Some(strategy) = strategy_from_argument(&call.arguments[0]) else {
+            continue;
+        };
+        let Some(import_id) = import_id_from_loader(&call.arguments[1]) else {
+            continue;
+        };
+        let Some(loader_source) = argument_source(&call.arguments[1], content) else {
+            continue;
+        };
+
+        let start = call.span.start as usize;
+        let end = call.span.end as usize;
+        if start > end || end > content.len() {
+            continue;
+        }
+
+        let import_id = serde_json::to_string(import_id).ok()?;
+        let mut replacement =
+            String::with_capacity(strategy.factory_name().len() + import_id.len() + 8);
+        replacement.push_str(strategy.factory_name());
+        replacement.push('(');
+        replacement.push_str(&import_id);
+        replacement.push_str(", ");
+        replacement.push_str(&loader_source);
+        replacement.push(')');
+
+        edits.push(Edit {
+            start,
+            end,
+            replacement,
+        });
+        if !strategies.contains(&strategy) {
+            strategies.push(strategy);
+        }
+    }
+
+    Some(())
+}
+
+fn strategy_from_argument(arg: &Argument<'_>) -> Option<LazyHydrationStrategy> {
+    let Argument::StringLiteral(lit) = arg else {
+        return None;
+    };
+    LazyHydrationStrategy::from_name(lit.value.as_str())
+}
+
+fn import_id_from_loader<'a>(arg: &'a Argument<'a>) -> Option<&'a str> {
+    let Argument::ArrowFunctionExpression(arrow) = arg else {
+        return None;
+    };
+    import_literal_from_arrow(arrow)
+}
+
+fn import_literal_from_arrow<'a>(arrow: &'a ArrowFunctionExpression<'a>) -> Option<&'a str> {
+    if arrow.expression {
+        let Some(Statement::ExpressionStatement(expr_stmt)) = arrow.body.statements.first() else {
+            return None;
+        };
+        return import_literal_from_expression(&expr_stmt.expression);
+    }
+
+    for stmt in arrow.body.statements.iter() {
+        let Statement::ReturnStatement(return_stmt) = stmt else {
+            continue;
+        };
+        let Some(argument) = return_stmt.argument.as_ref() else {
+            continue;
+        };
+        if let Some(literal) = import_literal_from_expression(argument) {
+            return Some(literal);
+        }
+    }
+
+    None
+}
+
+fn import_literal_from_expression<'a>(expr: &'a Expression<'a>) -> Option<&'a str> {
+    match expr {
+        Expression::ImportExpression(import_expr) => match &import_expr.source {
+            Expression::StringLiteral(lit) => Some(lit.value.as_str()),
+            _ => None,
+        },
+        Expression::ParenthesizedExpression(paren) => {
+            import_literal_from_expression(&paren.expression)
+        }
+        Expression::AwaitExpression(await_expr) => {
+            import_literal_from_expression(&await_expr.argument)
+        }
+        Expression::ConditionalExpression(conditional) => {
+            import_literal_from_expression(&conditional.consequent)
+                .or_else(|| import_literal_from_expression(&conditional.alternate))
+        }
+        Expression::StaticMemberExpression(member) => {
+            import_literal_from_expression(&member.object)
+        }
+        Expression::ComputedMemberExpression(member) => {
+            import_literal_from_expression(&member.object)
+        }
+        Expression::PrivateFieldExpression(member) => {
+            import_literal_from_expression(&member.object)
+        }
+        Expression::CallExpression(call) => import_literal_from_expression(&call.callee),
+        _ => None,
+    }
+}
+
+fn argument_source(arg: &Argument<'_>, source: &str) -> Option<String> {
+    let span = arg.span();
+    let start = span.start as usize;
+    let end = span.end as usize;
+    if start > end || end > source.len() {
+        return None;
+    }
+    Some((&source[start..end]).to_compact_string())
+}
+
+fn build_lazy_hydration_preamble(strategies: &[LazyHydrationStrategy]) -> String {
+    let mut preamble = String::from(
+        "import { defineAsyncComponent as __vizeDefineAsyncComponent, defineComponent as __vizeDefineComponent, h as __vizeH, hydrateOnIdle as __vizeHydrateOnIdle, hydrateOnInteraction as __vizeHydrateOnInteraction, hydrateOnMediaQuery as __vizeHydrateOnMediaQuery, hydrateOnVisible as __vizeHydrateOnVisible, mergeProps as __vizeMergeProps } from 'vue'\n",
+    );
+    preamble.push_str("import { useNuxtApp as __vizeUseNuxtApp } from '#app/nuxt'\n");
+    preamble.push_str("const __vizeDefineLazyHydrationComponent = (props, defineStrategy) => (id, loader) => __vizeDefineComponent({\n");
+    preamble.push_str("  inheritAttrs: false,\n");
+    preamble.push_str("  props,\n");
+    preamble.push_str("  emits: ['hydrated'],\n");
+    preamble.push_str("  setup(props2, ctx) {\n");
+    preamble.push_str("    if (import.meta.server) {\n");
+    preamble.push_str("      const nuxtApp = __vizeUseNuxtApp()\n");
+    preamble.push_str("      nuxtApp.hook('app:rendered', ({ ssrContext }) => {\n");
+    preamble.push_str("        ssrContext['~lazyHydratedModules'] ||= new Set()\n");
+    preamble.push_str("        ssrContext['~lazyHydratedModules'].add(id)\n");
+    preamble.push_str("      })\n");
+    preamble.push_str("    }\n");
+    preamble.push_str("    const child = __vizeDefineAsyncComponent({ loader })\n");
+    preamble.push_str("    const comp = __vizeDefineAsyncComponent({ hydrate: defineStrategy(props2), loader: () => Promise.resolve(child) })\n");
+    preamble.push_str("    const onVnodeMounted = () => { ctx.emit('hydrated') }\n");
+    preamble.push_str("    return () => __vizeH(comp, __vizeMergeProps(ctx.attrs, { onVnodeMounted }), ctx.slots)\n");
+    preamble.push_str("  },\n");
+    preamble.push_str("})\n");
+
+    if strategies.contains(&LazyHydrationStrategy::Visible) {
+        preamble.push_str("const __vizeCreateLazyVisibleComponent = __vizeDefineLazyHydrationComponent({ hydrateOnVisible: { type: [Object, Boolean], required: false, default: true } }, (props) => __vizeHydrateOnVisible(props.hydrateOnVisible === true ? void 0 : props.hydrateOnVisible))\n");
+    }
+    if strategies.contains(&LazyHydrationStrategy::Idle) {
+        preamble.push_str("const __vizeCreateLazyIdleComponent = __vizeDefineLazyHydrationComponent({ hydrateOnIdle: { type: [Number, Boolean], required: false, default: true } }, (props) => props.hydrateOnIdle === 0 ? void 0 : __vizeHydrateOnIdle(props.hydrateOnIdle === true ? void 0 : props.hydrateOnIdle))\n");
+    }
+    if strategies.contains(&LazyHydrationStrategy::Interaction) {
+        preamble.push_str(
+            "const __vizeDefaultInteractionEvents = ['pointerenter', 'click', 'focus']\n",
+        );
+        preamble.push_str("const __vizeCreateLazyInteractionComponent = __vizeDefineLazyHydrationComponent({ hydrateOnInteraction: { type: [String, Array], required: false, default: __vizeDefaultInteractionEvents } }, (props) => __vizeHydrateOnInteraction(props.hydrateOnInteraction === true ? __vizeDefaultInteractionEvents : props.hydrateOnInteraction || __vizeDefaultInteractionEvents))\n");
+    }
+    if strategies.contains(&LazyHydrationStrategy::MediaQuery) {
+        preamble.push_str("const __vizeCreateLazyMediaQueryComponent = __vizeDefineLazyHydrationComponent({ hydrateOnMediaQuery: { type: String, required: true } }, (props) => __vizeHydrateOnMediaQuery(props.hydrateOnMediaQuery))\n");
+    }
+    if strategies.contains(&LazyHydrationStrategy::If) {
+        preamble.push_str("const __vizeCreateLazyIfComponent = __vizeDefineLazyHydrationComponent({ hydrateWhen: { type: Boolean, default: true } }, (props) => props.hydrateWhen ? void 0 : () => {})\n");
+    }
+    if strategies.contains(&LazyHydrationStrategy::Time) {
+        preamble.push_str("const __vizeCreateLazyTimeComponent = __vizeDefineLazyHydrationComponent({ hydrateAfter: { type: Number, required: true } }, (props) => props.hydrateAfter === 0 ? void 0 : (hydrate) => { const id = setTimeout(hydrate, props.hydrateAfter); return () => clearTimeout(id) })\n");
+    }
+    if strategies.contains(&LazyHydrationStrategy::Never) {
+        preamble.push_str("const __vizeHydrateNever = () => {}\n");
+        preamble.push_str("const __vizeCreateLazyNeverComponent = __vizeDefineLazyHydrationComponent({ hydrateNever: { type: Boolean, required: false, default: true } }, () => __vizeHydrateNever)\n");
+    }
+    preamble.push('\n');
+    preamble
+}
+
+#[cfg(test)]
+mod tests {
+    use super::transform_lazy_hydration_macros;
+
+    #[test]
+    fn transforms_define_lazy_hydration_component() {
+        let content = r#"const LazyHydrationMyComponent = defineLazyHydrationComponent(
+  'visible',
+  () => import('./components/MyComponent.vue'),
+)
+"#;
+
+        let transformed =
+            transform_lazy_hydration_macros(content).expect("macro should be transformed");
+
+        assert!(!transformed.code.contains("defineLazyHydrationComponent"));
+        assert!(transformed
+            .code
+            .contains("__vizeCreateLazyVisibleComponent"));
+        assert!(transformed
+            .code
+            .contains("\"./components/MyComponent.vue\", () => import"));
+        assert!(transformed
+            .preamble
+            .contains("hydrateOnVisible as __vizeHydrateOnVisible"));
+        assert!(transformed
+            .preamble
+            .contains("const __vizeCreateLazyVisibleComponent"));
+    }
+
+    #[test]
+    fn ignores_dynamic_strategy_or_loader() {
+        let content = r#"const strategy = 'visible'
+const LazyHydrationMyComponent = defineLazyHydrationComponent(
+  strategy,
+  source,
+)
+"#;
+
+        assert!(transform_lazy_hydration_macros(content).is_none());
+    }
+
+    #[test]
+    fn transforms_exported_variable_declarations() {
+        let content = r#"export const LazyHydrationMyComponent = defineLazyHydrationComponent(
+  'time',
+  () => import('./components/MyComponent.vue'),
+)
+"#;
+
+        let transformed =
+            transform_lazy_hydration_macros(content).expect("macro should be transformed");
+
+        assert!(!transformed.code.contains("defineLazyHydrationComponent"));
+        assert!(transformed.code.contains("__vizeCreateLazyTimeComponent"));
+        assert!(transformed
+            .preamble
+            .contains("const __vizeCreateLazyTimeComponent"));
+    }
+}

--- a/crates/vize_atelier_sfc/src/compile_script/macros.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/macros.rs
@@ -3,7 +3,7 @@
 //! This module provides utilities for detecting Vue compiler macro calls
 //! in script setup code.
 
-use vize_croquis::macros::BUILTIN_MACROS;
+use vize_croquis::macros::runtime_erased_macro_names;
 
 /// Check if a line is a compiler macro call (not just containing the macro name as a string)
 pub fn is_macro_call_line(line: &str) -> bool {
@@ -14,7 +14,7 @@ pub fn is_macro_call_line(line: &str) -> bool {
     }
 
     // Check if line contains a macro that is being called (not just mentioned in a string)
-    for macro_name in BUILTIN_MACROS {
+    for macro_name in runtime_erased_macro_names() {
         if let Some(pos) = line.find(macro_name) {
             // Check that this is an actual call, not just a substring or string literal
             // 1. Check that macro is followed by '(' or '<' (with optional whitespace)
@@ -70,7 +70,7 @@ pub fn is_paren_macro_start(line: &str) -> bool {
     }
 
     // Check if line contains a macro call that isn't complete on the same line
-    for macro_name in BUILTIN_MACROS {
+    for macro_name in runtime_erased_macro_names() {
         if let Some(pos) = line.find(macro_name) {
             // Check that this is an actual call, not a string literal
             let after = &line[pos + macro_name.len()..];
@@ -111,7 +111,7 @@ pub fn is_multiline_macro_start(line: &str) -> bool {
     }
 
     // Check if line contains a macro with type args that spans multiple lines
-    for macro_name in BUILTIN_MACROS {
+    for macro_name in runtime_erased_macro_names() {
         if let Some(pos) = line.find(macro_name) {
             // Check that this is an actual call, not a string literal
             let after = &line[pos + macro_name.len()..];
@@ -217,6 +217,8 @@ mod tests {
             "const layer = defineModel<Layer>('layer', { required: true });"
         ));
         assert!(is_macro_call_line("defineExpose({})"));
+        assert!(is_macro_call_line("definePage({ name: 'home' })"));
+        assert!(is_macro_call_line("defineRouteRules({ prerender: true })"));
         assert!(!is_macro_call_line("import { defineModel } from 'vue'"));
         assert!(!is_macro_call_line("const fx = FXS[layer.value.fxId];"));
         // Note: string-embedded macro names ARE detected (pre-existing limitation)

--- a/crates/vize_atelier_sfc/src/compile_script/statement_sections.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/statement_sections.rs
@@ -9,7 +9,7 @@ use oxc_parser::Parser;
 use oxc_span::{GetSpan, SourceType};
 
 use vize_carton::{String, ToCompactString};
-use vize_croquis::macros::is_builtin_macro;
+use vize_croquis::macros::is_runtime_erased_macro;
 
 enum StatementBucket {
     Import,
@@ -152,7 +152,7 @@ fn unwrap_call_expression<'a>(
 
 fn is_macro_call(call: &oxc_ast::ast::CallExpression<'_>) -> bool {
     match &call.callee {
-        Expression::Identifier(id) => is_builtin_macro(id.name.as_str()),
+        Expression::Identifier(id) => is_runtime_erased_macro(id.name.as_str()),
         _ => false,
     }
 }
@@ -218,5 +218,65 @@ const store = useStore<RootState>()
             ts_declarations[0].as_str(),
             "interface RootState {\n  count: number\n}"
         );
+    }
+
+    #[test]
+    fn test_extract_script_sections_skips_ecosystem_compile_time_macro() {
+        let content = r#"definePage({
+  name: 'home',
+  meta: {
+    requiresAuth: true,
+  },
+})
+
+const msg = 'ready'
+"#;
+
+        let (_, setup_lines, ts_declarations) =
+            extract_script_sections(content, true).expect("sections should parse");
+
+        assert_eq!(setup_lines.len(), 1);
+        assert_eq!(setup_lines[0].as_str(), "const msg = 'ready'");
+        assert!(ts_declarations.is_empty());
+    }
+
+    #[test]
+    fn test_extract_script_sections_skips_define_page_meta() {
+        let content = r#"definePageMeta({
+  name: 'docs',
+  meta: {
+    scrollMargin: 180,
+  },
+})
+
+const msg = 'ready'
+"#;
+
+        let (_, setup_lines, ts_declarations) =
+            extract_script_sections(content, true).expect("sections should parse");
+
+        assert_eq!(setup_lines.len(), 1);
+        assert_eq!(setup_lines[0].as_str(), "const msg = 'ready'");
+        assert!(ts_declarations.is_empty());
+    }
+
+    #[test]
+    fn test_extract_script_sections_skips_define_route_rules() {
+        let content = r#"defineRouteRules({
+  prerender: true,
+  cache: {
+    maxAge: 60,
+  },
+})
+
+const msg = 'ready'
+"#;
+
+        let (_, setup_lines, ts_declarations) =
+            extract_script_sections(content, true).expect("sections should parse");
+
+        assert_eq!(setup_lines.len(), 1);
+        assert_eq!(setup_lines[0].as_str(), "const msg = 'ready'");
+        assert!(ts_declarations.is_empty());
     }
 }

--- a/crates/vize_atelier_sfc/src/compile_script/tests.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/tests.rs
@@ -295,6 +295,104 @@ const msg = ref('hello')
     }
 
     #[test]
+    fn test_compile_script_setup_strips_ecosystem_compile_time_macro() {
+        let content = r#"
+definePage({
+  name: 'home',
+  meta: {
+    requiresAuth: true,
+  },
+})
+
+const msg = 'ready'
+"#;
+        let result =
+            compile_script_setup(content, "Test", false, false, Some("<div>{{ msg }}</div>"))
+                .unwrap();
+
+        assert!(
+            !result.code.contains("definePage"),
+            "definePage should be removed from runtime output:\n{}",
+            result.code
+        );
+        assert!(result.code.contains("ready"));
+    }
+
+    #[test]
+    fn test_compile_script_setup_strips_define_page_meta() {
+        let content = r#"
+definePageMeta({
+  name: 'docs',
+  meta: {
+    scrollMargin: 180,
+  },
+})
+
+const msg = 'ready'
+"#;
+        let result =
+            compile_script_setup(content, "Test", false, false, Some("<div>{{ msg }}</div>"))
+                .unwrap();
+
+        assert!(
+            !result.code.contains("definePageMeta"),
+            "definePageMeta should be removed from runtime output:\n{}",
+            result.code
+        );
+        assert!(result.code.contains("ready"));
+    }
+
+    #[test]
+    fn test_compile_script_setup_strips_define_route_rules() {
+        let content = r#"
+defineRouteRules({
+  prerender: true,
+  cache: {
+    maxAge: 60,
+  },
+})
+
+const msg = 'ready'
+"#;
+        let result =
+            compile_script_setup(content, "Test", false, false, Some("<div>{{ msg }}</div>"))
+                .unwrap();
+
+        assert!(
+            !result.code.contains("defineRouteRules"),
+            "defineRouteRules should be removed from runtime output:\n{}",
+            result.code
+        );
+        assert!(result.code.contains("ready"));
+    }
+
+    #[test]
+    fn test_compile_script_setup_expands_define_lazy_hydration_component() {
+        let content = r#"
+const LazyHydrationMyComponent = defineLazyHydrationComponent(
+  'idle',
+  () => import('./components/MyComponent.vue'),
+)
+"#;
+        let result = compile_script_setup(
+            content,
+            "Test",
+            false,
+            false,
+            Some("<LazyHydrationMyComponent />"),
+        )
+        .unwrap();
+
+        assert!(
+            !result.code.contains("defineLazyHydrationComponent"),
+            "defineLazyHydrationComponent should be expanded from runtime output:\n{}",
+            result.code
+        );
+        assert!(result.code.contains("__vizeCreateLazyIdleComponent"));
+        assert!(result.code.contains("./components/MyComponent.vue"));
+    }
+
+    #[test]
     fn test_compile_script_setup_with_props_destructure() {
         let content = r#"
 import { computed } from 'vue'

--- a/crates/vize_atelier_sfc/src/lib.rs
+++ b/crates/vize_atelier_sfc/src/lib.rs
@@ -56,8 +56,9 @@ pub use css::{
 pub use parse::parse_sfc;
 pub use types::{
     BindingMetadata, BindingType, BlockLocation, PadOption, PropsDestructure, ScriptCompileOptions,
-    SfcCompileOptions, SfcCompileResult, SfcCustomBlock, SfcDescriptor, SfcError, SfcParseOptions,
-    SfcScriptBlock, SfcStyleBlock, SfcTemplateBlock, StyleCompileOptions, TemplateCompileOptions,
+    SfcCompileOptions, SfcCompileResult, SfcCustomBlock, SfcDescriptor, SfcError, SfcMacroArtifact,
+    SfcParseOptions, SfcScriptBlock, SfcStyleBlock, SfcTemplateBlock, StyleCompileOptions,
+    TemplateCompileOptions,
 };
 
 // Re-export key types from dependencies

--- a/crates/vize_atelier_sfc/src/script/utils.rs
+++ b/crates/vize_atelier_sfc/src/script/utils.rs
@@ -6,6 +6,7 @@
 //! parsing in production. They are marked with `#[allow(dead_code)]`.
 
 use vize_carton::{String, ToCompactString};
+use vize_croquis::macros::runtime_erased_macro_names;
 
 /// Macro definitions found in script setup
 #[derive(Debug, Default)]
@@ -151,16 +152,7 @@ pub fn extract_type_args(before_call: &str) -> Option<String> {
 
 /// Check if a line contains a compiler macro call
 pub fn is_compiler_macro_line(line: &str) -> bool {
-    let macros = [
-        "defineProps",
-        "defineEmits",
-        "defineExpose",
-        "defineOptions",
-        "defineSlots",
-        "defineModel",
-        "withDefaults",
-    ];
-    macros.iter().any(|m| line.contains(m))
+    runtime_erased_macro_names().any(|macro_name| line.contains(macro_name))
 }
 
 /// Check if string is valid JS identifier

--- a/crates/vize_atelier_sfc/src/types.rs
+++ b/crates/vize_atelier_sfc/src/types.rs
@@ -504,6 +504,37 @@ pub struct SfcCompileResult {
 
     /// Binding metadata
     pub bindings: Option<BindingMetadata>,
+
+    /// Compile-time macro artifacts extracted from script blocks.
+    #[serde(default)]
+    pub macro_artifacts: Vec<SfcMacroArtifact>,
+}
+
+/// Compile-time macro artifact extracted from an SFC.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SfcMacroArtifact {
+    /// Stable artifact kind.
+    pub kind: String,
+
+    /// Macro call name.
+    pub name: String,
+
+    /// Full macro call source.
+    pub source: String,
+
+    /// Extracted macro payload source.
+    pub content: String,
+
+    /// Ready-to-load virtual module code, when applicable.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub module_code: Option<String>,
+
+    /// Absolute start offset in the original SFC source.
+    pub start: usize,
+
+    /// Absolute end offset in the original SFC source.
+    pub end: usize,
 }
 
 /// SFC error/warning

--- a/crates/vize_croquis/src/macros.rs
+++ b/crates/vize_croquis/src/macros.rs
@@ -5,6 +5,43 @@
 
 use vize_carton::{CompactString, FxHashMap};
 
+/// How a macro participates in the script setup compilation lifecycle.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MacroLifecycle {
+    /// The SFC compiler analyzes the call and emits the matching runtime code.
+    AnalyzeAndErase,
+    /// The SFC compiler rewrites the macro call into runtime code.
+    Expand,
+    /// The SFC compiler extracts the call as a separate artifact, then removes
+    /// the top-level call from runtime output.
+    ExtractAndErase,
+}
+
+impl MacroLifecycle {
+    /// Whether calls with this lifecycle should be removed from setup runtime code.
+    #[inline]
+    pub const fn erases_from_runtime(self) -> bool {
+        matches!(self, Self::AnalyzeAndErase | Self::ExtractAndErase)
+    }
+
+    /// Whether calls with this lifecycle produce a compiler artifact.
+    #[inline]
+    pub const fn produces_artifact(self) -> bool {
+        matches!(self, Self::ExtractAndErase)
+    }
+}
+
+/// Static metadata for a known compiler macro.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MacroDefinition {
+    /// Macro call name.
+    pub name: &'static str,
+    /// How the macro participates in compilation.
+    pub lifecycle: MacroLifecycle,
+    /// Optional artifact kind emitted by the SFC compiler.
+    pub artifact_kind: Option<&'static str>,
+}
+
 /// Built-in Vue compiler macros
 pub static BUILTIN_MACROS: &[&str] = &[
     "defineProps",
@@ -16,10 +53,106 @@ pub static BUILTIN_MACROS: &[&str] = &[
     "withDefaults",
 ];
 
+/// Known ecosystem macros that are compile-time only.
+///
+/// These are intentionally separate from Vue's built-in compiler macros:
+/// Vize does not expand them into component runtime itself, but it may extract
+/// artifacts for surrounding tooling before removing top-level calls.
+pub static ECOSYSTEM_COMPILE_TIME_MACROS: &[MacroDefinition] = &[
+    MacroDefinition {
+        name: "definePage",
+        lifecycle: MacroLifecycle::ExtractAndErase,
+        artifact_kind: Some("vue-router.definePage"),
+    },
+    MacroDefinition {
+        name: "definePageMeta",
+        lifecycle: MacroLifecycle::ExtractAndErase,
+        artifact_kind: Some("nuxt.definePageMeta"),
+    },
+    MacroDefinition {
+        name: "defineRouteRules",
+        lifecycle: MacroLifecycle::ExtractAndErase,
+        artifact_kind: Some("nuxt.defineRouteRules"),
+    },
+    MacroDefinition {
+        name: "defineLazyHydrationComponent",
+        lifecycle: MacroLifecycle::Expand,
+        artifact_kind: None,
+    },
+];
+
 /// Check if a name is a built-in compiler macro
 #[inline]
 pub fn is_builtin_macro(name: &str) -> bool {
     BUILTIN_MACROS.contains(&name)
+}
+
+/// Return the ecosystem macro definition for a name.
+#[inline]
+pub fn ecosystem_macro_definition(name: &str) -> Option<&'static MacroDefinition> {
+    ECOSYSTEM_COMPILE_TIME_MACROS
+        .iter()
+        .find(|definition| definition.name == name)
+}
+
+/// Check if a name is a known ecosystem compile-time macro.
+#[inline]
+pub fn is_ecosystem_compile_time_macro(name: &str) -> bool {
+    ecosystem_macro_definition(name).is_some()
+}
+
+/// Return the compile-time macro lifecycle for a name.
+#[inline]
+pub fn macro_lifecycle(name: &str) -> Option<MacroLifecycle> {
+    if is_builtin_macro(name) {
+        Some(MacroLifecycle::AnalyzeAndErase)
+    } else {
+        ecosystem_macro_definition(name).map(|definition| definition.lifecycle)
+    }
+}
+
+/// Check if a name is compile-time only in script setup.
+#[inline]
+pub fn is_compile_time_macro(name: &str) -> bool {
+    macro_lifecycle(name).is_some()
+}
+
+/// Check if a macro call should be removed from setup runtime output.
+#[inline]
+pub fn is_runtime_erased_macro(name: &str) -> bool {
+    macro_lifecycle(name).is_some_and(MacroLifecycle::erases_from_runtime)
+}
+
+/// Return the artifact kind emitted for a macro name, when any.
+#[inline]
+pub fn macro_artifact_kind(name: &str) -> Option<&'static str> {
+    ecosystem_macro_definition(name).and_then(|definition| definition.artifact_kind)
+}
+
+/// Check if a macro call should produce a compiler artifact.
+#[inline]
+pub fn is_artifact_macro(name: &str) -> bool {
+    macro_lifecycle(name).is_some_and(MacroLifecycle::produces_artifact)
+}
+
+/// Names of macros that should not remain in setup runtime code.
+#[inline]
+pub fn runtime_erased_macro_names() -> impl Iterator<Item = &'static str> {
+    BUILTIN_MACROS.iter().copied().chain(
+        ECOSYSTEM_COMPILE_TIME_MACROS
+            .iter()
+            .filter(|definition| definition.lifecycle.erases_from_runtime())
+            .map(|definition| definition.name),
+    )
+}
+
+/// Names of macros that should produce compiler artifacts.
+#[inline]
+pub fn artifact_macro_names() -> impl Iterator<Item = &'static str> {
+    ECOSYSTEM_COMPILE_TIME_MACROS
+        .iter()
+        .filter(|definition| definition.lifecycle.produces_artifact())
+        .map(|definition| definition.name)
 }
 
 /// Unique identifier for a macro call
@@ -434,8 +567,77 @@ impl MacroTracker {
 
 #[cfg(test)]
 mod tests {
-    use super::{MacroKind, MacroTracker};
+    use super::{
+        artifact_macro_names, is_artifact_macro, is_compile_time_macro,
+        is_ecosystem_compile_time_macro, is_runtime_erased_macro, macro_artifact_kind,
+        macro_lifecycle, runtime_erased_macro_names, MacroKind, MacroLifecycle, MacroTracker,
+    };
     use vize_carton::CompactString;
+
+    #[test]
+    fn test_macro_lifecycle_classifies_builtin_and_ecosystem_macros() {
+        assert_eq!(
+            macro_lifecycle("defineProps"),
+            Some(MacroLifecycle::AnalyzeAndErase)
+        );
+        assert_eq!(
+            macro_lifecycle("definePage"),
+            Some(MacroLifecycle::ExtractAndErase)
+        );
+        assert_eq!(
+            macro_lifecycle("definePageMeta"),
+            Some(MacroLifecycle::ExtractAndErase)
+        );
+        assert_eq!(
+            macro_lifecycle("defineRouteRules"),
+            Some(MacroLifecycle::ExtractAndErase)
+        );
+        assert_eq!(
+            macro_lifecycle("defineLazyHydrationComponent"),
+            Some(MacroLifecycle::Expand)
+        );
+        assert_eq!(macro_lifecycle("notAMacro"), None);
+
+        assert!(is_compile_time_macro("definePage"));
+        assert!(is_ecosystem_compile_time_macro("definePage"));
+        assert!(is_runtime_erased_macro("definePage"));
+        assert!(is_artifact_macro("definePage"));
+        assert_eq!(
+            macro_artifact_kind("definePage"),
+            Some("vue-router.definePage")
+        );
+        assert!(is_compile_time_macro("definePageMeta"));
+        assert!(is_ecosystem_compile_time_macro("definePageMeta"));
+        assert!(is_runtime_erased_macro("definePageMeta"));
+        assert!(is_artifact_macro("definePageMeta"));
+        assert_eq!(
+            macro_artifact_kind("definePageMeta"),
+            Some("nuxt.definePageMeta")
+        );
+        assert!(is_compile_time_macro("defineRouteRules"));
+        assert!(is_ecosystem_compile_time_macro("defineRouteRules"));
+        assert!(is_runtime_erased_macro("defineRouteRules"));
+        assert!(is_artifact_macro("defineRouteRules"));
+        assert_eq!(
+            macro_artifact_kind("defineRouteRules"),
+            Some("nuxt.defineRouteRules")
+        );
+        assert!(is_compile_time_macro("defineLazyHydrationComponent"));
+        assert!(is_ecosystem_compile_time_macro(
+            "defineLazyHydrationComponent"
+        ));
+        assert!(!is_runtime_erased_macro("defineLazyHydrationComponent"));
+        assert!(!is_artifact_macro("defineLazyHydrationComponent"));
+        assert_eq!(macro_artifact_kind("defineLazyHydrationComponent"), None);
+        assert!(runtime_erased_macro_names().any(|name| name == "definePage"));
+        assert!(runtime_erased_macro_names().any(|name| name == "definePageMeta"));
+        assert!(runtime_erased_macro_names().any(|name| name == "defineRouteRules"));
+        assert!(!runtime_erased_macro_names().any(|name| name == "defineLazyHydrationComponent"));
+        assert!(artifact_macro_names().any(|name| name == "definePage"));
+        assert!(artifact_macro_names().any(|name| name == "definePageMeta"));
+        assert!(artifact_macro_names().any(|name| name == "defineRouteRules"));
+        assert!(!artifact_macro_names().any(|name| name == "defineLazyHydrationComponent"));
+    }
 
     #[test]
     fn test_macro_tracker() {

--- a/crates/vize_vitrine/src/napi/sfc.rs
+++ b/crates/vize_vitrine/src/napi/sfc.rs
@@ -20,6 +20,34 @@ use std::{
 };
 use vize_carton::cstr;
 
+#[napi(object)]
+pub struct MacroArtifactNapi {
+    pub kind: String,
+    pub name: String,
+    pub source: String,
+    pub content: String,
+    pub module_code: Option<String>,
+    pub start: u32,
+    pub end: u32,
+}
+
+fn macro_artifacts_to_napi(
+    artifacts: Vec<vize_atelier_sfc::SfcMacroArtifact>,
+) -> Vec<MacroArtifactNapi> {
+    artifacts
+        .into_iter()
+        .map(|artifact| MacroArtifactNapi {
+            kind: artifact.kind.into(),
+            name: artifact.name.into(),
+            source: artifact.source.into(),
+            content: artifact.content.into(),
+            module_code: artifact.module_code.map(Into::into),
+            start: artifact.start as u32,
+            end: artifact.end as u32,
+        })
+        .collect()
+}
+
 /// SFC parse options for NAPI
 #[napi(object)]
 #[derive(Default)]
@@ -59,6 +87,8 @@ pub struct SfcCompileResultNapi {
     pub style_hash: Option<String>,
     /// Hash of script content (for HMR)
     pub script_hash: Option<String>,
+    /// Compile-time macro artifacts
+    pub macro_artifacts: Vec<MacroArtifactNapi>,
 }
 
 /// Batch compile options for NAPI
@@ -120,6 +150,8 @@ pub struct BatchFileResultNapi {
     pub style_hash: Option<String>,
     /// Hash of script content (for HMR)
     pub script_hash: Option<String>,
+    /// Compile-time macro artifacts
+    pub macro_artifacts: Vec<MacroArtifactNapi>,
 }
 
 /// Batch compile result with per-file results
@@ -251,6 +283,7 @@ pub fn compile_sfc(
                 template_hash: None,
                 style_hash: None,
                 script_hash: None,
+                macro_artifacts: vec![],
             });
         }
     };
@@ -311,23 +344,27 @@ pub fn compile_sfc(
     };
 
     match sfc_compile(&descriptor, compile_opts) {
-        Ok(result) => Ok(SfcCompileResultNapi {
-            code: result.code.into(),
-            css: result.css.map(Into::into),
-            errors: result
-                .errors
-                .into_iter()
-                .map(|e| e.message.into())
-                .collect(),
-            warnings: result
-                .warnings
-                .into_iter()
-                .map(|e| e.message.into())
-                .collect(),
-            template_hash: template_hash.clone(),
-            style_hash: style_hash.clone(),
-            script_hash: script_hash.clone(),
-        }),
+        Ok(result) => {
+            let macro_artifacts = macro_artifacts_to_napi(result.macro_artifacts);
+            Ok(SfcCompileResultNapi {
+                code: result.code.into(),
+                css: result.css.map(Into::into),
+                errors: result
+                    .errors
+                    .into_iter()
+                    .map(|e| e.message.into())
+                    .collect(),
+                warnings: result
+                    .warnings
+                    .into_iter()
+                    .map(|e| e.message.into())
+                    .collect(),
+                template_hash: template_hash.clone(),
+                style_hash: style_hash.clone(),
+                script_hash: script_hash.clone(),
+                macro_artifacts,
+            })
+        }
         Err(e) => Ok(SfcCompileResultNapi {
             code: String::new(),
             css: None,
@@ -336,6 +373,7 @@ pub fn compile_sfc(
             template_hash,
             style_hash,
             script_hash,
+            macro_artifacts: vec![],
         }),
     }
 }
@@ -579,6 +617,7 @@ pub fn compile_sfc_batch_with_results(
                     template_hash: None,
                     style_hash: None,
                     script_hash: None,
+                    macro_artifacts: vec![],
                 });
                 return;
             }
@@ -632,6 +671,7 @@ pub fn compile_sfc_batch_with_results(
 
         match sfc_compile(&descriptor, compile_opts) {
             Ok(result) => {
+                let macro_artifacts = macro_artifacts_to_napi(result.macro_artifacts);
                 success_count.fetch_add(1, Ordering::Relaxed);
                 let mut guard = results.lock().unwrap();
                 guard.push(BatchFileResultNapi {
@@ -653,6 +693,7 @@ pub fn compile_sfc_batch_with_results(
                     template_hash: template_hash.clone(),
                     style_hash: style_hash.clone(),
                     script_hash: script_hash.clone(),
+                    macro_artifacts,
                 });
             }
             Err(e) => {
@@ -669,6 +710,7 @@ pub fn compile_sfc_batch_with_results(
                     template_hash,
                     style_hash,
                     script_hash,
+                    macro_artifacts: vec![],
                 });
             }
         }

--- a/crates/vize_vitrine/src/wasm/mod.rs
+++ b/crates/vize_vitrine/src/wasm/mod.rs
@@ -39,7 +39,8 @@ use vize_atelier_dom::{compile_template_with_options, DomCompilerOptions};
 use vize_atelier_sfc::compile_script::typescript::transform_typescript_to_js;
 use vize_atelier_sfc::{
     compile_sfc as sfc_compile, parse_sfc, CssCompileOptions, CssTargets, ScriptCompileOptions,
-    SfcCompileOptions, SfcDescriptor, SfcParseOptions, StyleCompileOptions, TemplateCompileOptions,
+    SfcCompileOptions, SfcDescriptor, SfcMacroArtifact, SfcParseOptions, StyleCompileOptions,
+    TemplateCompileOptions,
 };
 use vize_atelier_ssr::compile_ssr as ssr_compile;
 use vize_atelier_vapor::{compile_vapor as vapor_compile, VaporCompilerOptions};
@@ -232,6 +233,8 @@ pub struct SfcWasmResult {
     pub warnings: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none", rename = "bindingMetadata")]
     pub binding_metadata: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Vec::is_empty", rename = "macroArtifacts")]
+    pub macro_artifacts: Vec<SfcMacroArtifactWasm>,
 }
 
 /// Script compilation result
@@ -240,6 +243,19 @@ pub struct SfcScriptResult {
     pub code: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bindings: Option<serde_json::Value>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SfcMacroArtifactWasm {
+    pub kind: String,
+    pub name: String,
+    pub source: String,
+    pub content: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub module_code: Option<String>,
+    pub start: usize,
+    pub end: usize,
 }
 
 #[derive(Serialize)]
@@ -404,6 +420,18 @@ fn descriptor_to_wasm(descriptor: &SfcDescriptor<'_>) -> SfcDescriptorWasm {
             .collect(),
         slotted: descriptor.slotted,
         should_force_reload: descriptor.should_force_reload,
+    }
+}
+
+fn macro_artifact_to_wasm(artifact: &SfcMacroArtifact) -> SfcMacroArtifactWasm {
+    SfcMacroArtifactWasm {
+        kind: artifact.kind.to_string(),
+        name: artifact.name.to_string(),
+        source: artifact.source.to_string(),
+        content: artifact.content.to_string(),
+        module_code: artifact.module_code.as_ref().map(ToString::to_string),
+        start: artifact.start,
+        end: artifact.end,
     }
 }
 
@@ -613,6 +641,11 @@ impl Compiler {
             .bindings
             .as_ref()
             .and_then(|b| serde_json::to_value(&b.bindings).ok());
+        let macro_artifacts = sfc_result
+            .macro_artifacts
+            .iter()
+            .map(macro_artifact_to_wasm)
+            .collect();
 
         let result = SfcWasmResult {
             descriptor: descriptor_to_wasm(&descriptor),
@@ -635,6 +668,7 @@ impl Compiler {
                 .map(|e| e.message.into())
                 .collect(),
             binding_metadata,
+            macro_artifacts,
         };
 
         to_json_js_value(&result)

--- a/npm/rspack-vize-plugin/src/index.ts
+++ b/npm/rspack-vize-plugin/src/index.ts
@@ -30,6 +30,7 @@ export { compileFile, generateOutput, clearCompilationCache } from "./shared/com
 // Types
 export type {
   CompiledModule,
+  MacroArtifact,
   StyleBlockInfo,
   CustomBlockInfo,
   SfcSrcInfo,

--- a/npm/rspack-vize-plugin/src/shared/compiler.ts
+++ b/npm/rspack-vize-plugin/src/shared/compiler.ts
@@ -105,6 +105,7 @@ export function compileFile(
     customBlocks,
     isCustomElement,
     templateAssetUrls,
+    macroArtifacts: result.macroArtifacts ?? [],
   };
 
   // Only cache successful compilations

--- a/npm/rspack-vize-plugin/src/types/index.ts
+++ b/npm/rspack-vize-plugin/src/types/index.ts
@@ -14,6 +14,16 @@ export interface SfcCompileOptionsNapi {
   scopeId?: string;
 }
 
+export interface MacroArtifact {
+  kind: string;
+  name: string;
+  source: string;
+  content: string;
+  moduleCode?: string;
+  start: number;
+  end: number;
+}
+
 export interface SfcCompileResultNapi {
   code: string;
   css?: string;
@@ -21,6 +31,7 @@ export interface SfcCompileResultNapi {
   map?: string;
   errors: string[];
   warnings: string[];
+  macroArtifacts?: MacroArtifact[];
 }
 
 // CSS Compile API Types
@@ -134,6 +145,8 @@ export interface CompiledModule {
   isCustomElement: boolean;
   /** Static asset URLs needing import rewrite. Empty when transformAssetUrls is false. */
   templateAssetUrls: TemplateAssetUrl[];
+  /** Compile-time macro artifacts extracted from the source SFC. */
+  macroArtifacts?: MacroArtifact[];
 }
 
 // Loader Options Types

--- a/npm/unplugin-vize/src/compiler.ts
+++ b/npm/unplugin-vize/src/compiler.ts
@@ -64,6 +64,7 @@ export function compileVueModule(
     templateHash: result.templateHash,
     styleHash: result.styleHash,
     scriptHash: result.scriptHash,
+    macroArtifacts: result.macroArtifacts ?? [],
     styles: extractStyleBlocks(source),
   };
 

--- a/npm/unplugin-vize/src/index.ts
+++ b/npm/unplugin-vize/src/index.ts
@@ -1,2 +1,2 @@
 export { vizeUnplugin as default, vizeUnplugin } from "./unplugin.ts";
-export type { VizeUnpluginOptions } from "./types.ts";
+export type { MacroArtifact, VizeUnpluginOptions } from "./types.ts";

--- a/npm/unplugin-vize/src/types.ts
+++ b/npm/unplugin-vize/src/types.ts
@@ -7,6 +7,16 @@ export interface SfcCompileOptionsNapi {
   scopeId?: string;
 }
 
+export interface MacroArtifact {
+  kind: string;
+  name: string;
+  source: string;
+  content: string;
+  moduleCode?: string;
+  start: number;
+  end: number;
+}
+
 export interface SfcCompileResultNapi {
   code: string;
   css?: string;
@@ -15,6 +25,7 @@ export interface SfcCompileResultNapi {
   templateHash?: string;
   styleHash?: string;
   scriptHash?: string;
+  macroArtifacts?: MacroArtifact[];
 }
 
 export interface VizeUnpluginOptions {
@@ -46,6 +57,7 @@ export interface CompiledModule {
   templateHash?: string;
   styleHash?: string;
   scriptHash?: string;
+  macroArtifacts?: MacroArtifact[];
   styles: StyleBlockInfo[];
 }
 

--- a/npm/vite-plugin-vize/src/compiler.test.ts
+++ b/npm/vite-plugin-vize/src/compiler.test.ts
@@ -91,6 +91,154 @@ assert.doesNotMatch(
   "Batch SSR compilation should also drop the Vapor marker when falling back to VDOM",
 );
 
+const definePageSource = `<script setup lang="ts">
+definePage({
+  name: "home",
+  meta: {
+    requiresAuth: true,
+  },
+});
+
+const msg = "hello";
+</script>
+
+<template>
+  <div>{{ msg }}</div>
+</template>`;
+
+const definePageCompiled = compileFile(
+  "/src/pages/Home.vue",
+  new Map(),
+  { sourceMap: false, ssr: false, vapor: false },
+  definePageSource,
+);
+
+assert.doesNotMatch(
+  definePageCompiled.code,
+  /definePage/,
+  "definePage should not stay in component runtime output",
+);
+assert.equal(
+  definePageCompiled.macroArtifacts?.[0]?.kind,
+  "vue-router.definePage",
+  "definePage should be exposed as a Vue Router macro artifact",
+);
+assert.match(
+  definePageCompiled.macroArtifacts?.[0]?.moduleCode ?? "",
+  /export default \{/,
+  "definePage artifacts should include loadable module code",
+);
+
+const definePageMetaSource = `<script setup lang="ts">
+definePageMeta({
+  name: "docs",
+  meta: {
+    scrollMargin: 180,
+  },
+});
+
+const msg = "hello";
+</script>
+
+<template>
+  <div>{{ msg }}</div>
+</template>`;
+
+const definePageMetaCompiled = compileFile(
+  "/src/pages/docs.vue",
+  new Map(),
+  { sourceMap: false, ssr: false, vapor: false },
+  definePageMetaSource,
+);
+
+assert.doesNotMatch(
+  definePageMetaCompiled.code,
+  /definePageMeta/,
+  "definePageMeta should not stay in component runtime output",
+);
+assert.equal(
+  definePageMetaCompiled.macroArtifacts?.[0]?.kind,
+  "nuxt.definePageMeta",
+  "definePageMeta should be exposed as a Nuxt page macro artifact",
+);
+assert.match(
+  definePageMetaCompiled.macroArtifacts?.[0]?.moduleCode ?? "",
+  /export default \{/,
+  "definePageMeta artifacts should include loadable module code",
+);
+
+const defineRouteRulesSource = `<script setup lang="ts">
+defineRouteRules({
+  prerender: true,
+  cache: {
+    maxAge: 60,
+  },
+});
+
+const msg = "hello";
+</script>
+
+<template>
+  <div>{{ msg }}</div>
+</template>`;
+
+const defineRouteRulesCompiled = compileFile(
+  "/src/pages/docs.vue",
+  new Map(),
+  { sourceMap: false, ssr: false, vapor: false },
+  defineRouteRulesSource,
+);
+
+assert.doesNotMatch(
+  defineRouteRulesCompiled.code,
+  /defineRouteRules/,
+  "defineRouteRules should not stay in component runtime output",
+);
+assert.equal(
+  defineRouteRulesCompiled.macroArtifacts?.[0]?.kind,
+  "nuxt.defineRouteRules",
+  "defineRouteRules should be exposed as a Nuxt route rules macro artifact",
+);
+assert.match(
+  defineRouteRulesCompiled.macroArtifacts?.[0]?.moduleCode ?? "",
+  /prerender/,
+  "defineRouteRules artifacts should include loadable route rules module code",
+);
+
+const defineLazyHydrationSource = `<script setup lang="ts">
+const LazyHydrationMyComponent = defineLazyHydrationComponent(
+  "visible",
+  () => import("./components/MyComponent.vue"),
+);
+</script>
+
+<template>
+  <LazyHydrationMyComponent :hydrate-on-visible="{ rootMargin: '100px' }" />
+</template>`;
+
+const defineLazyHydrationCompiled = compileFile(
+  "/src/pages/lazy.vue",
+  new Map(),
+  { sourceMap: false, ssr: false, vapor: false },
+  defineLazyHydrationSource,
+);
+
+assert.doesNotMatch(
+  defineLazyHydrationCompiled.code,
+  /defineLazyHydrationComponent/,
+  "defineLazyHydrationComponent should not stay in component runtime output",
+);
+assert.match(
+  defineLazyHydrationCompiled.code,
+  /__vizeCreateLazyVisibleComponent/,
+  "defineLazyHydrationComponent should expand to a lazy hydration factory",
+);
+assert.match(
+  defineLazyHydrationCompiled.code,
+  /useNuxtApp as __vizeUseNuxtApp/,
+  "defineLazyHydrationComponent should include Nuxt lazy hydration runtime support",
+);
+
 const antDesignSource = `<script setup lang="ts">
 import { Form, Input } from "ant-design-vue";
 </script>

--- a/npm/vite-plugin-vize/src/compiler.ts
+++ b/npm/vite-plugin-vize/src/compiler.ts
@@ -71,6 +71,7 @@ export function compileFile(
     templateHash: result.templateHash,
     styleHash: result.styleHash,
     scriptHash: result.scriptHash,
+    macroArtifacts: result.macroArtifacts ?? [],
     styles,
   };
 
@@ -113,6 +114,7 @@ export function compileBatch(
         templateHash: fileResult.templateHash,
         styleHash: fileResult.styleHash,
         scriptHash: fileResult.scriptHash,
+        macroArtifacts: fileResult.macroArtifacts ?? [],
         styles,
       });
     }

--- a/npm/vite-plugin-vize/src/hmr.test.ts
+++ b/npm/vite-plugin-vize/src/hmr.test.ts
@@ -10,6 +10,7 @@ const baseModule: CompiledModule = {
   templateHash: "template-a",
   styleHash: "style-a",
   scriptHash: "script-a",
+  macroArtifacts: [],
   styles: [],
 };
 

--- a/npm/vite-plugin-vize/src/index.ts
+++ b/npm/vite-plugin-vize/src/index.ts
@@ -5,7 +5,13 @@
 export { vize } from "./plugin/index.ts";
 export { defineConfig, loadConfig, vizeConfigStore } from "./config.ts";
 export { rewriteStaticAssetUrls as __internal_rewriteStaticAssetUrls } from "./transform.ts";
-export type { VizeOptions, CompiledModule, VizeConfig, LoadConfigOptions } from "./types.ts";
+export type {
+  VizeOptions,
+  CompiledModule,
+  MacroArtifact,
+  VizeConfig,
+  LoadConfigOptions,
+} from "./types.ts";
 
 // Test-only export for snapshot coverage (re-exported for backward compat).
 import { rewriteStaticAssetUrls } from "./transform.ts";

--- a/npm/vite-plugin-vize/src/plugin/load.test.ts
+++ b/npm/vite-plugin-vize/src/plugin/load.test.ts
@@ -115,6 +115,83 @@ assert.match(
   "Virtual module transforms must leave import.meta.hot available for Vite HMR",
 );
 
+const definePageDir = fs.mkdtempSync(path.join(os.tmpdir(), "vize-define-page-"));
+const definePagePath = path.join(definePageDir, "Home.vue");
+fs.writeFileSync(
+  definePagePath,
+  `<script setup lang="ts">
+definePage({
+  name: "home",
+  meta: { requiresAuth: true },
+})
+
+const msg = "ready"
+</script>
+<template><div>{{ msg }}</div></template>`,
+);
+
+const definePageLoad = loadHook(
+  { ...hmrState, cache: new Map(), ssrCache: new Map(), root: definePageDir },
+  `\0${definePagePath}?definePage`,
+  { ssr: false },
+);
+
+assert.ok(
+  definePageLoad && typeof definePageLoad === "object",
+  "Vue Router definePage queries should load as code objects",
+);
+assert.match(
+  definePageLoad.code,
+  /export default \{/,
+  "Vue Router definePage queries should return the extracted route record module",
+);
+assert.doesNotMatch(
+  definePageLoad.code,
+  /const msg/,
+  "Vue Router definePage queries should not return the component setup body",
+);
+
+const definePageMetaDir = fs.mkdtempSync(path.join(os.tmpdir(), "vize-define-page-meta-"));
+const definePageMetaPath = path.join(definePageMetaDir, "Docs.vue");
+fs.writeFileSync(
+  definePageMetaPath,
+  `<script setup lang="ts">
+definePageMeta({
+  name: "docs",
+  meta: { scrollMargin: 180 },
+})
+
+const msg = "ready"
+</script>
+<template><div>{{ msg }}</div></template>`,
+);
+
+const definePageMetaLoad = loadHook(
+  { ...hmrState, cache: new Map(), ssrCache: new Map(), root: definePageMetaDir },
+  `\0${definePageMetaPath}?macro=true`,
+  { ssr: false },
+);
+
+assert.ok(
+  definePageMetaLoad && typeof definePageMetaLoad === "object",
+  "Nuxt definePageMeta macro queries should load as code objects",
+);
+assert.match(
+  definePageMetaLoad.code,
+  /export default \{/,
+  "Nuxt definePageMeta macro queries should return the extracted page metadata module",
+);
+assert.match(
+  definePageMetaLoad.code,
+  /scrollMargin/,
+  "Nuxt definePageMeta macro queries should preserve page metadata",
+);
+assert.doesNotMatch(
+  definePageMetaLoad.code,
+  /const msg/,
+  "Nuxt definePageMeta macro queries should not return the component setup body",
+);
+
 const firstLoad = loadHook(hmrState, toVirtualId(realPath), { ssr: false });
 assert.ok(firstLoad && typeof firstLoad === "object", "Virtual module should load as code object");
 assert.match(

--- a/npm/vite-plugin-vize/src/plugin/load.ts
+++ b/npm/vite-plugin-vize/src/plugin/load.ts
@@ -62,6 +62,64 @@ function getVirtualModuleDefines(
   };
 }
 
+function hasQueryParam(id: string, name: string): boolean {
+  const query = id.split("?")[1];
+  return query ? new URLSearchParams(query).has(name) : false;
+}
+
+function hasMacroQuery(id: string): boolean {
+  const query = id.split("?")[1];
+  return query ? new URLSearchParams(query).get("macro") === "true" : false;
+}
+
+function normalizeMacroRealPath(realPath: string): string {
+  return realPath.endsWith(".vue.ts") ? realPath.slice(0, -3) : realPath;
+}
+
+function stripVirtualQuery(id: string): string {
+  return normalizeMacroRealPath(id.slice(1).split("?")[0] ?? "");
+}
+
+function findMacroArtifactModule(
+  state: VizePluginState,
+  realPath: string,
+  ssr: boolean,
+  kind: string,
+): string | null {
+  const cache = getEnvironmentCache(state, ssr);
+  realPath = normalizeMacroRealPath(realPath);
+  let compiled = cache.get(realPath) ?? state.cache.get(realPath) ?? state.ssrCache.get(realPath);
+
+  if (!compiled && fs.existsSync(realPath)) {
+    const source = fs.readFileSync(realPath, "utf-8");
+    compiled = compileFile(realPath, cache, getCompileOptionsForRequest(state, ssr), source);
+    syncCollectedCssForFile(state, realPath, compiled);
+  }
+
+  return compiled?.macroArtifacts?.find((artifact) => artifact.kind === kind)?.moduleCode ?? null;
+}
+
+function loadDefinePageArtifact(
+  state: VizePluginState,
+  realPath: string,
+  ssr: boolean,
+): { code: string; map: null } {
+  return {
+    code:
+      findMacroArtifactModule(state, realPath, ssr, "vue-router.definePage") ?? "export default {}",
+    map: null,
+  };
+}
+
+function loadDefinePageMetaArtifact(
+  state: VizePluginState,
+  realPath: string,
+  ssr: boolean,
+): { code: string; map: null } | null {
+  const code = findMacroArtifactModule(state, realPath, ssr, "nuxt.definePageMeta");
+  return code ? { code, map: null } : null;
+}
+
 export function loadHook(
   state: VizePluginState,
   id: string,
@@ -152,9 +210,19 @@ export function loadHook(
     return "";
   }
 
+  // Handle Vue Router's ?definePage query through extracted artifacts.
+  if (id.startsWith("\0") && hasQueryParam(id, "definePage")) {
+    return loadDefinePageArtifact(state, stripVirtualQuery(id), !!loadOptions?.ssr);
+  }
+
   // Handle ?macro=true queries
-  if (id.startsWith("\0") && id.endsWith("?macro=true")) {
-    const realPath = id.slice(1).replace("?macro=true", "");
+  if (id.startsWith("\0") && hasMacroQuery(id)) {
+    const realPath = stripVirtualQuery(id);
+    const artifactLoad = loadDefinePageMetaArtifact(state, realPath, !!loadOptions?.ssr);
+    if (artifactLoad) {
+      return artifactLoad;
+    }
+
     if (fs.existsSync(realPath)) {
       const source = fs.readFileSync(realPath, "utf-8");
       const setupMatch = source.match(/<script\s+setup[^>]*>([\s\S]*?)<\/script>/);
@@ -270,9 +338,9 @@ export async function transformHook(
   id: string,
   options?: { ssr?: boolean },
 ): Promise<TransformResult | null> {
-  const isMacro = id.startsWith("\0") && id.endsWith("?macro=true");
+  const isMacro = id.startsWith("\0") && (hasMacroQuery(id) || hasQueryParam(id, "definePage"));
   if (isVizeVirtual(id) || isMacro) {
-    const realPath = isMacro ? id.slice(1).replace("?macro=true", "") : fromVirtualId(id);
+    const realPath = isMacro ? stripVirtualQuery(id) : fromVirtualId(id);
     try {
       const result = await transformWithOxc(code, realPath, {
         lang: "ts",

--- a/npm/vite-plugin-vize/src/plugin/resolve.test.ts
+++ b/npm/vite-plugin-vize/src/plugin/resolve.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -61,6 +62,26 @@ function expectResolvedId(resolved: Awaited<ReturnType<typeof resolveIdHook>>): 
   assert.equal(typeof resolved, "object");
   assert.equal(typeof resolved.id, "string");
   return resolved.id;
+}
+
+{
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "vize-resolve-define-page-"));
+  const source = path.join(tempRoot, "Home.vue");
+  fs.writeFileSync(source, "<script setup>definePage({})</script>");
+
+  const resolved = await resolveIdHook(
+    nullResolveContext,
+    createState(tempRoot),
+    `${source}?definePage`,
+    undefined,
+    undefined,
+  );
+
+  assert.equal(
+    expectResolvedId(resolved),
+    `\0${source}?definePage`,
+    "Vue Router definePage queries should resolve to a virtual macro module",
+  );
 }
 
 {

--- a/npm/vite-plugin-vize/src/plugin/resolve.ts
+++ b/npm/vite-plugin-vize/src/plugin/resolve.ts
@@ -49,6 +49,20 @@ interface ResolveContext {
   ): Promise<{ id: string } | null>;
 }
 
+function hasQueryParam(id: string, name: string): boolean {
+  const query = id.split("?")[1];
+  return query ? new URLSearchParams(query).has(name) : false;
+}
+
+function hasMacroQuery(id: string): boolean {
+  const query = id.split("?")[1];
+  return query ? new URLSearchParams(query).get("macro") === "true" : false;
+}
+
+function isMacroVirtualId(id: string): boolean {
+  return id.startsWith("\0") && (hasMacroQuery(id) || hasQueryParam(id, "definePage"));
+}
+
 function normalizeRequireBase(importer?: string): string | null {
   if (!importer) {
     return null;
@@ -57,8 +71,8 @@ function normalizeRequireBase(importer?: string): string | null {
   let normalized = importer;
   if (isVizeVirtual(normalized)) {
     normalized = fromVirtualId(normalized);
-  } else if (normalized.startsWith("\0") && normalized.endsWith("?macro=true")) {
-    normalized = normalized.slice(1).replace("?macro=true", "");
+  } else if (isMacroVirtualId(normalized)) {
+    normalized = normalized.slice(1).split("?")[0] ?? "";
   }
 
   return normalized.split("?")[0] ?? null;
@@ -163,15 +177,18 @@ export async function resolveIdHook(
     return normalizeFsIdForBuild(id);
   }
 
-  // Handle ?macro=true queries (Nuxt page macros: defineRouteRules, definePageMeta, etc.)
+  // Handle route macro queries.
+  // - ?macro=true is used by Nuxt page macros.
+  // - ?definePage is used by Vue Router file-based routing.
   // Nuxt's router generates `import { default } from "page.vue?macro=true"` to extract
-  // route metadata. Without @vitejs/plugin-vue, Vize must handle this query and return
-  // the compiled script output so Vite's OXC transform can process it as JS.
-  if (id.includes("?macro=true")) {
+  // route metadata. Without @vitejs/plugin-vue, Vize must resolve this query so the
+  // load hook can return compile-time macro artifact modules.
+  if (hasMacroQuery(id) || hasQueryParam(id, "definePage")) {
     const filePath = id.split("?")[0];
+    const querySuffix = id.slice(id.indexOf("?"));
     const resolved = resolveVuePath(state, filePath, importer);
     if (resolved && fs.existsSync(resolved)) {
-      return `\0${resolved}?macro=true`;
+      return `\0${resolved}${querySuffix}`;
     }
   }
 
@@ -192,10 +209,10 @@ export async function resolveIdHook(
   }
 
   // If importer is a vize virtual module or macro module, resolve imports against the real path
-  const isMacroImporter = importer?.startsWith("\0") && importer?.endsWith("?macro=true");
+  const isMacroImporter = importer ? isMacroVirtualId(importer) : false;
   if (importer && (isVizeVirtual(importer) || isMacroImporter)) {
     const cleanImporter = isMacroImporter
-      ? importer.slice(1).replace("?macro=true", "")
+      ? importer.slice(1).split("?")[0]!
       : fromVirtualId(importer);
 
     state.logger.log(`resolveId from virtual: id=${id}, cleanImporter=${cleanImporter}`);

--- a/npm/vite-plugin-vize/src/plugin/state.test.ts
+++ b/npm/vite-plugin-vize/src/plugin/state.test.ts
@@ -90,6 +90,7 @@ const plainCssModule: CompiledModule = {
   css: ".card { color: tomato; }",
   scopeId: "plaincss",
   hasScoped: false,
+  macroArtifacts: [],
   styles: [
     {
       content: ".card { color: tomato; }",
@@ -113,6 +114,7 @@ const delegatedCssModule: CompiledModule = {
   css: ".button { color: red; }",
   scopeId: "delegatedcss",
   hasScoped: false,
+  macroArtifacts: [],
   styles: [
     {
       content: ".button { color: red; }",

--- a/npm/vite-plugin-vize/src/types.ts
+++ b/npm/vite-plugin-vize/src/types.ts
@@ -14,6 +14,16 @@ export interface SfcCompileOptionsNapi {
   scopeId?: string;
 }
 
+export interface MacroArtifact {
+  kind: string;
+  name: string;
+  source: string;
+  content: string;
+  moduleCode?: string;
+  start: number;
+  end: number;
+}
+
 export interface SfcCompileResultNapi {
   code: string;
   css?: string;
@@ -22,6 +32,7 @@ export interface SfcCompileResultNapi {
   templateHash?: string;
   styleHash?: string;
   scriptHash?: string;
+  macroArtifacts?: MacroArtifact[];
 }
 
 export type CompileSfcFn = (
@@ -148,6 +159,8 @@ export interface CompiledModule {
   templateHash?: string;
   styleHash?: string;
   scriptHash?: string;
+  /** Compile-time macro artifacts extracted from the source SFC */
+  macroArtifacts?: MacroArtifact[];
   /** Per-block style metadata extracted from the source SFC */
   styles?: StyleBlockInfo[];
 }
@@ -168,6 +181,8 @@ export interface BatchFileResult {
   templateHash?: string;
   styleHash?: string;
   scriptHash?: string;
+  /** Compile-time macro artifacts extracted from the source SFC */
+  macroArtifacts?: MacroArtifact[];
   /** Per-block style metadata extracted from the source SFC */
   styles?: StyleBlockInfo[];
 }

--- a/npm/vize-wasm/index.d.ts
+++ b/npm/vize-wasm/index.d.ts
@@ -72,6 +72,24 @@ export interface SfcStyleBlock extends SfcBlock {
   module?: string | true;
 }
 
+/** Compile-time macro artifact extracted from an SFC */
+export interface MacroArtifact {
+  /** Stable artifact kind */
+  kind: string;
+  /** Macro call name */
+  name: string;
+  /** Full macro call source */
+  source: string;
+  /** Extracted macro payload source */
+  content: string;
+  /** Ready-to-load virtual module code */
+  moduleCode?: string;
+  /** Absolute start offset in the SFC source */
+  start: number;
+  /** Absolute end offset in the SFC source */
+  end: number;
+}
+
 /** SFC descriptor (parsed .vue file) */
 export interface SfcDescriptor {
   /** Filename */
@@ -125,6 +143,8 @@ export interface SfcCompileResult {
   errors: string[];
   /** Compilation warnings */
   warnings: string[];
+  /** Compile-time macro artifacts */
+  macroArtifacts?: MacroArtifact[];
 }
 
 /** CSS compile options */

--- a/npm/vize/src/cli.ts
+++ b/npm/vize/src/cli.ts
@@ -335,6 +335,16 @@ interface BatchFileInput {
   source: string;
 }
 
+interface MacroArtifact {
+  kind: string;
+  name: string;
+  source: string;
+  content: string;
+  moduleCode?: string;
+  start: number;
+  end: number;
+}
+
 interface BatchFileResult {
   path: string;
   code: string;
@@ -345,6 +355,8 @@ interface BatchFileResult {
   scope_id?: string;
   hasScoped?: boolean;
   has_scoped?: boolean;
+  macroArtifacts?: MacroArtifact[];
+  macro_artifacts?: MacroArtifact[];
 }
 
 interface BatchCompileResult {


### PR DESCRIPTION
## Summary
- Add croquis macro lifecycle metadata for macros that emit compile-time artifacts or expand into runtime helpers before runtime output.
- Extract `definePage`, Nuxt `definePageMeta`, and Nuxt `defineRouteRules` into `macroArtifacts` with `source`, `content`, and loadable `moduleCode`, while removing top-level calls from component runtime output.
- Expand Nuxt `defineLazyHydrationComponent` in the Rust SFC compiler into lazy hydration factory calls with a bundler-agnostic runtime preamble.
- Keep the artifact macro path cheap for ordinary SFCs by skipping OXC parsing unless an artifact macro candidate is present.
- Expose artifacts through Rust SFC results, N-API, WASM, CLI JSON output, Vite, unplugin, and Rspack types.
- Serve Vue Router `?definePage` requests and Nuxt `?macro=true` page metadata requests from extracted artifact modules, keeping the previous Nuxt fallback for pages without an extracted artifact.

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p vize_croquis macro_lifecycle -- --nocapture`
- `cargo test -p vize_atelier_sfc artifacts -- --nocapture`
- `cargo test -p vize_atelier_sfc define_page_meta -- --nocapture`
- `cargo test -p vize_atelier_sfc define_route_rules -- --nocapture`
- `cargo test -p vize_atelier_sfc lazy_hydration -- --nocapture`
- `cargo clippy --workspace -- -D warnings`
- `cargo test --workspace`
- `vp run --workspace-root check:ci`
- `pnpm --dir npm/vite-plugin-vize check`
- `pnpm --dir npm/vite-plugin-vize test`