### PR TITLE
fix(musea):  dark button contrast

### DIFF
--- a/npm/vite-plugin-musea/gallery/components/A11yPanel.vue
+++ b/npm/vite-plugin-musea/gallery/components/A11yPanel.vue
@@ -243,7 +243,7 @@ watch(result, (nextResult) => {
   background: var(--musea-accent);
   border: none;
   border-radius: var(--musea-radius-sm);
-  color: #fff;
+  color: var(--musea-accent-contrast);
   font-size: 0.75rem;
   font-weight: 600;
   cursor: pointer;

--- a/npm/vite-plugin-musea/gallery/components/PropsPanel.vue
+++ b/npm/vite-plugin-musea/gallery/components/PropsPanel.vue
@@ -659,7 +659,7 @@ const controlKindOptions = [
 
 .props-mode-btn.active {
   background: var(--musea-accent);
-  color: #fff;
+  color: var(--musea-accent-contrast);
 }
 
 .props-mode-btn:not(.active):hover {
@@ -828,7 +828,7 @@ const controlKindOptions = [
   border: none;
   border-radius: var(--musea-radius-sm);
   background: var(--musea-accent);
-  color: #fff;
+  color: var(--musea-accent-contrast);
   font-size: 0.75rem;
   font-weight: 500;
   cursor: pointer;

--- a/npm/vite-plugin-musea/gallery/components/VrtPanel.vue
+++ b/npm/vite-plugin-musea/gallery/components/VrtPanel.vue
@@ -240,7 +240,7 @@ function getStatusColor(result: VrtResult): string {
   background: var(--musea-accent);
   border: none;
   border-radius: var(--musea-radius-sm);
-  color: #fff;
+  color: var(--musea-accent-contrast);
   font-size: 0.75rem;
   font-weight: 600;
   cursor: pointer;

--- a/npm/vite-plugin-musea/gallery/components/tokens/SourceEditModal.vue
+++ b/npm/vite-plugin-musea/gallery/components/tokens/SourceEditModal.vue
@@ -238,7 +238,7 @@ async function handleSave() {
 
 .btn--primary {
   background: var(--musea-accent);
-  color: #fff;
+  color: var(--musea-accent-contrast);
   border-color: var(--musea-accent);
 }
 

--- a/npm/vite-plugin-musea/gallery/components/tokens/TokenFormModal.vue
+++ b/npm/vite-plugin-musea/gallery/components/tokens/TokenFormModal.vue
@@ -427,7 +427,7 @@ function selectReference(path: string) {
 
 .btn--primary {
   background: var(--musea-accent);
-  color: #fff;
+  color: var(--musea-accent-contrast);
 }
 
 .btn--primary:hover {

--- a/npm/vite-plugin-musea/gallery/styles/variables.css
+++ b/npm/vite-plugin-musea/gallery/styles/variables.css
@@ -6,6 +6,7 @@
   --musea-bg-elevated: #e6e2d6;
   --musea-accent: #121212;
   --musea-accent-hover: #2a2a2a;
+  --musea-accent-contrast: #e6e2d6;
   --musea-accent-subtle: rgba(18, 18, 18, 0.08);
   --musea-text: #121212;
   --musea-text-secondary: #3a3a3a;
@@ -36,6 +37,7 @@
   --musea-bg-elevated: #e6e2d6;
   --musea-accent: #121212;
   --musea-accent-hover: #2a2a2a;
+  --musea-accent-contrast: #e6e2d6;
   --musea-accent-subtle: rgba(18, 18, 18, 0.08);
   --musea-text: #121212;
   --musea-text-secondary: #3a3a3a;
@@ -58,6 +60,7 @@
   --musea-bg-elevated: #2a2a2a;
   --musea-accent: #e6e2d6;
   --musea-accent-hover: #d4d0c4;
+  --musea-accent-contrast: #121212;
   --musea-accent-subtle: rgba(230, 226, 214, 0.1);
   --musea-text: #e6e2d6;
   --musea-text-secondary: #c4c1b6;
@@ -81,6 +84,7 @@
     --musea-bg-elevated: #2a2a2a;
     --musea-accent: #e6e2d6;
     --musea-accent-hover: #d4d0c4;
+    --musea-accent-contrast: #121212;
     --musea-accent-subtle: rgba(230, 226, 214, 0.1);
     --musea-text: #e6e2d6;
     --musea-text-secondary: #c4c1b6;

--- a/npm/vite-plugin-musea/gallery/themes/index.ts
+++ b/npm/vite-plugin-musea/gallery/themes/index.ts
@@ -12,6 +12,7 @@ export interface ThemeColors {
   bgElevated: string;
   accent: string;
   accentHover: string;
+  accentContrast: string;
   accentSubtle: string;
   text: string;
   textSecondary: string;
@@ -32,6 +33,7 @@ export const darkTheme: ThemeColors = {
   bgElevated: "#2a2a2a",
   accent: "#E6E2D6",
   accentHover: "#d4d0c4",
+  accentContrast: "#121212",
   accentSubtle: "rgba(230, 226, 214, 0.1)",
   text: "#E6E2D6",
   textSecondary: "#c4c1b6",
@@ -52,6 +54,7 @@ export const lightTheme: ThemeColors = {
   bgElevated: "#E6E2D6",
   accent: "#121212",
   accentHover: "#2a2a2a",
+  accentContrast: "#E6E2D6",
   accentSubtle: "rgba(18, 18, 18, 0.08)",
   text: "#121212",
   textSecondary: "#3a3a3a",

--- a/npm/vite-plugin-musea/gallery/views/ComponentView.vue
+++ b/npm/vite-plugin-musea/gallery/views/ComponentView.vue
@@ -542,7 +542,7 @@ onUnmounted(() => {
   padding: 0 0.375rem;
   border-radius: 9px;
   background: var(--musea-accent);
-  color: #fff;
+  color: var(--musea-accent-contrast);
   font-size: 0.625rem;
   font-weight: 700;
   line-height: 1;

--- a/npm/vite-plugin-musea/gallery/views/TestSummaryView.vue
+++ b/npm/vite-plugin-musea/gallery/views/TestSummaryView.vue
@@ -513,7 +513,7 @@ watch(
   background: var(--musea-accent);
   border: none;
   border-radius: var(--musea-radius-md);
-  color: var(--musea-bg-primary);
+  color: var(--musea-accent-contrast);
   font-size: 0.875rem;
   font-weight: 600;
   cursor: pointer;

--- a/npm/vite-plugin-musea/gallery/views/TokensView.vue
+++ b/npm/vite-plugin-musea/gallery/views/TokensView.vue
@@ -320,7 +320,7 @@ async function handleSourceSaved() {
   gap: 0.375rem;
   padding: 0.5rem 1rem;
   background: var(--musea-accent);
-  color: #fff;
+  color: var(--musea-accent-contrast);
   border: none;
   border-radius: var(--musea-radius-md);
   font-size: 0.8125rem;

--- a/npm/vite-plugin-musea/src/types/plugin.ts
+++ b/npm/vite-plugin-musea/src/types/plugin.ts
@@ -11,6 +11,7 @@ export interface MuseaThemeColors {
   bgElevated?: string;
   accent?: string;
   accentHover?: string;
+  accentContrast?: string;
   accentSubtle?: string;
   text?: string;
   textSecondary?: string;


### PR DESCRIPTION
## Summary
- Add an `accentContrast` theme color for text placed on accent backgrounds.
- Use that contrast color for musea gallery primary buttons, active segmented controls, and accent badges.
- Keep custom themes able to override the new contrast token while inheriting sensible light/dark defaults.

## Why
Dark theme uses a light accent color. Several accent-backed buttons still used fixed white text, which made the labels nearly invisible.

## Validation
- `pnpm --filter @vizejs/vite-plugin-musea check`
- `pnpm --filter @vizejs/vite-plugin-musea build:gallery`
- Playwright dark-theme smoke check: target buttons render with `rgb(18, 18, 18)` text on `rgb(230, 226, 214)` backgrounds, contrast ratio 14.46.
