### PR TITLE
fix(sfc): preserve imported definePage calls

### DIFF
--- a/crates/vize_atelier_sfc/src/compile/tests.rs
+++ b/crates/vize_atelier_sfc/src/compile/tests.rs
@@ -120,6 +120,40 @@ const msg = 'ready'
 }
 
 #[test]
+fn test_script_setup_imported_define_page_stays_runtime() {
+    let source = r#"<script setup lang="ts">
+import { definePage } from '@/page.js'
+
+definePage(() => ({
+  title: 'runtime page',
+}))
+
+const msg = 'ready'
+</script>
+<template>
+  <div>{{ msg }}</div>
+</template>"#;
+
+    let descriptor = parse_sfc(source, SfcParseOptions::default()).expect("Failed to parse SFC");
+    let opts = SfcCompileOptions::default();
+    let result = compile_sfc(&descriptor, opts).expect("Failed to compile SFC");
+
+    assert!(
+        result
+            .code
+            .contains("import { definePage } from \"@/page.js\";"),
+        "runtime definePage import should be preserved:\n{}",
+        result.code
+    );
+    assert!(
+        result.code.contains("definePage(() =>"),
+        "runtime definePage call should be preserved:\n{}",
+        result.code
+    );
+    assert!(result.macro_artifacts.is_empty());
+}
+
+#[test]
 fn test_script_setup_define_page_meta_is_compile_time_only() {
     let source = r#"<script setup lang="ts">
 definePageMeta({

--- a/crates/vize_atelier_sfc/src/compile_script.rs
+++ b/crates/vize_atelier_sfc/src/compile_script.rs
@@ -10,6 +10,7 @@ pub mod inline;
 pub(crate) mod lazy_hydration;
 pub mod macros;
 pub mod props;
+pub(crate) mod runtime_bindings;
 pub mod statement_sections;
 #[cfg(test)]
 mod tests;

--- a/crates/vize_atelier_sfc/src/compile_script/artifacts.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/artifacts.rs
@@ -13,6 +13,8 @@ use vize_croquis::macros::{artifact_macro_names, macro_artifact_kind};
 
 use crate::types::SfcMacroArtifact;
 
+use super::runtime_bindings::collect_runtime_bindings;
+
 pub(crate) fn extract_macro_artifacts(
     content: &str,
     absolute_offset: usize,
@@ -30,6 +32,7 @@ pub(crate) fn extract_macro_artifacts(
     }
 
     let static_imports = collect_static_imports(ret.program.body.iter(), content);
+    let runtime_bindings = collect_runtime_bindings(ret.program.body.iter());
     let mut artifacts = Vec::new();
 
     for stmt in ret.program.body.iter() {
@@ -39,6 +42,9 @@ pub(crate) fn extract_macro_artifacts(
         let Some(name) = call_name(call) else {
             continue;
         };
+        if runtime_bindings.contains(name) {
+            continue;
+        }
         let Some(kind) = macro_artifact_kind(name) else {
             continue;
         };
@@ -85,6 +91,7 @@ pub(crate) fn erase_artifact_macro_statements(content: &str) -> Option<String> {
         return None;
     }
 
+    let runtime_bindings = collect_runtime_bindings(ret.program.body.iter());
     let mut ranges = Vec::new();
     for stmt in ret.program.body.iter() {
         let Some(call) = artifact_call_from_statement(stmt) else {
@@ -93,6 +100,9 @@ pub(crate) fn erase_artifact_macro_statements(content: &str) -> Option<String> {
         let Some(name) = call_name(call) else {
             continue;
         };
+        if runtime_bindings.contains(name) {
+            continue;
+        }
         if macro_artifact_kind(name).is_none() {
             continue;
         }
@@ -300,6 +310,21 @@ const LazyHydrationMyComponent = defineLazyHydrationComponent(
   'visible',
   () => import('./components/MyComponent.vue'),
 )
+"#;
+
+        assert!(extract_macro_artifacts(content, 0).is_empty());
+        assert!(erase_artifact_macro_statements(content).is_none());
+    }
+
+    #[test]
+    fn preserves_imported_define_page_runtime_call() {
+        let content = r#"import { definePage } from '@/page.js'
+
+definePage(() => ({
+  title: 'runtime page',
+}))
+
+const msg = 'ready'
 "#;
 
         assert!(extract_macro_artifacts(content, 0).is_empty());

--- a/crates/vize_atelier_sfc/src/compile_script/runtime_bindings.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/runtime_bindings.rs
@@ -1,0 +1,125 @@
+//! Runtime binding collection for script-level macro disambiguation.
+
+use oxc_ast::ast::{
+    BindingPattern, Declaration, ImportDeclarationSpecifier, Statement, VariableDeclaration,
+};
+use vize_carton::{FxHashSet, String};
+
+pub(super) fn collect_runtime_bindings<'a>(
+    statements: impl Iterator<Item = &'a Statement<'a>>,
+) -> FxHashSet<String> {
+    let mut bindings = FxHashSet::default();
+
+    for stmt in statements {
+        collect_runtime_bindings_from_statement(stmt, &mut bindings);
+    }
+
+    bindings
+}
+
+fn collect_runtime_bindings_from_statement(stmt: &Statement<'_>, bindings: &mut FxHashSet<String>) {
+    match stmt {
+        Statement::ImportDeclaration(import_decl) => {
+            if import_decl.import_kind.is_type() {
+                return;
+            }
+            if let Some(specifiers) = import_decl.specifiers.as_ref() {
+                for specifier in specifiers {
+                    match specifier {
+                        ImportDeclarationSpecifier::ImportSpecifier(spec) => {
+                            if !spec.import_kind.is_type() {
+                                bindings.insert(spec.local.name.as_str().into());
+                            }
+                        }
+                        ImportDeclarationSpecifier::ImportDefaultSpecifier(spec) => {
+                            bindings.insert(spec.local.name.as_str().into());
+                        }
+                        ImportDeclarationSpecifier::ImportNamespaceSpecifier(spec) => {
+                            bindings.insert(spec.local.name.as_str().into());
+                        }
+                    }
+                }
+            }
+        }
+        Statement::VariableDeclaration(var_decl) => {
+            collect_variable_declaration_bindings(var_decl, bindings);
+        }
+        Statement::FunctionDeclaration(func) => {
+            if let Some(id) = func.id.as_ref() {
+                bindings.insert(id.name.as_str().into());
+            }
+        }
+        Statement::ClassDeclaration(class) => {
+            if let Some(id) = class.id.as_ref() {
+                bindings.insert(id.name.as_str().into());
+            }
+        }
+        Statement::ExportNamedDeclaration(export_decl) => {
+            if export_decl.export_kind.is_type() {
+                return;
+            }
+            if let Some(declaration) = export_decl.declaration.as_ref() {
+                collect_runtime_bindings_from_declaration(declaration, bindings);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn collect_runtime_bindings_from_declaration(
+    declaration: &Declaration<'_>,
+    bindings: &mut FxHashSet<String>,
+) {
+    match declaration {
+        Declaration::VariableDeclaration(var_decl) => {
+            collect_variable_declaration_bindings(var_decl, bindings);
+        }
+        Declaration::FunctionDeclaration(func) => {
+            if let Some(id) = func.id.as_ref() {
+                bindings.insert(id.name.as_str().into());
+            }
+        }
+        Declaration::ClassDeclaration(class) => {
+            if let Some(id) = class.id.as_ref() {
+                bindings.insert(id.name.as_str().into());
+            }
+        }
+        _ => {}
+    }
+}
+
+fn collect_variable_declaration_bindings(
+    var_decl: &VariableDeclaration<'_>,
+    bindings: &mut FxHashSet<String>,
+) {
+    for declarator in var_decl.declarations.iter() {
+        collect_binding_pattern_names(&declarator.id, bindings);
+    }
+}
+
+fn collect_binding_pattern_names(pattern: &BindingPattern<'_>, bindings: &mut FxHashSet<String>) {
+    match pattern {
+        BindingPattern::BindingIdentifier(id) => {
+            bindings.insert(id.name.as_str().into());
+        }
+        BindingPattern::ObjectPattern(obj) => {
+            for prop in obj.properties.iter() {
+                collect_binding_pattern_names(&prop.value, bindings);
+            }
+            if let Some(rest) = obj.rest.as_ref() {
+                collect_binding_pattern_names(&rest.argument, bindings);
+            }
+        }
+        BindingPattern::ArrayPattern(arr) => {
+            for element in arr.elements.iter().flatten() {
+                collect_binding_pattern_names(element, bindings);
+            }
+            if let Some(rest) = arr.rest.as_ref() {
+                collect_binding_pattern_names(&rest.argument, bindings);
+            }
+        }
+        BindingPattern::AssignmentPattern(assign) => {
+            collect_binding_pattern_names(&assign.left, bindings);
+        }
+    }
+}

--- a/crates/vize_atelier_sfc/src/compile_script/statement_sections.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/statement_sections.rs
@@ -8,8 +8,10 @@ use oxc_ast::ast::{Declaration, Expression, Statement};
 use oxc_parser::Parser;
 use oxc_span::{GetSpan, SourceType};
 
-use vize_carton::{String, ToCompactString};
-use vize_croquis::macros::is_runtime_erased_macro;
+use vize_carton::{FxHashSet, String, ToCompactString};
+use vize_croquis::macros::{is_builtin_macro, is_runtime_erased_macro};
+
+use super::runtime_bindings::collect_runtime_bindings;
 
 enum StatementBucket {
     Import,
@@ -36,6 +38,7 @@ pub(crate) fn extract_script_sections(
 
     let mut prev_end = 0usize;
     let mut pending_gap = String::default();
+    let runtime_bindings = collect_runtime_bindings(ret.program.body.iter());
 
     for stmt in ret.program.body.iter() {
         let span = stmt.span();
@@ -49,7 +52,7 @@ pub(crate) fn extract_script_sections(
         pending_gap.push_str(&content[prev_end..start]);
 
         let slice = &content[start..end];
-        match classify_statement(stmt, slice) {
+        match classify_statement(stmt, slice, &runtime_bindings) {
             StatementBucket::Import => {
                 let mut segment = std::mem::take(&mut pending_gap);
                 segment.push_str(slice);
@@ -81,7 +84,11 @@ pub(crate) fn extract_script_sections(
     Some((user_imports, setup_lines, ts_declarations))
 }
 
-fn classify_statement(stmt: &Statement<'_>, slice: &str) -> StatementBucket {
+fn classify_statement(
+    stmt: &Statement<'_>,
+    slice: &str,
+    runtime_bindings: &FxHashSet<String>,
+) -> StatementBucket {
     let trimmed = slice.trim_start();
 
     if trimmed.starts_with("declare ") {
@@ -111,7 +118,9 @@ fn classify_statement(stmt: &Statement<'_>, slice: &str) -> StatementBucket {
             }
         }
         Statement::ExpressionStatement(expr_stmt) => {
-            if unwrap_call_expression(&expr_stmt.expression).is_some_and(is_macro_call) {
+            if unwrap_call_expression(&expr_stmt.expression)
+                .is_some_and(|call| is_macro_call(call, runtime_bindings))
+            {
                 StatementBucket::Macro
             } else {
                 StatementBucket::Setup
@@ -122,7 +131,7 @@ fn classify_statement(stmt: &Statement<'_>, slice: &str) -> StatementBucket {
                 decl.init
                     .as_ref()
                     .and_then(unwrap_call_expression)
-                    .is_some_and(is_macro_call)
+                    .is_some_and(|call| is_macro_call(call, runtime_bindings))
             }) {
                 StatementBucket::Macro
             } else {
@@ -150,9 +159,16 @@ fn unwrap_call_expression<'a>(
     }
 }
 
-fn is_macro_call(call: &oxc_ast::ast::CallExpression<'_>) -> bool {
+fn is_macro_call(
+    call: &oxc_ast::ast::CallExpression<'_>,
+    runtime_bindings: &FxHashSet<String>,
+) -> bool {
     match &call.callee {
-        Expression::Identifier(id) => is_runtime_erased_macro(id.name.as_str()),
+        Expression::Identifier(id) => {
+            let name = id.name.as_str();
+            is_builtin_macro(name)
+                || (is_runtime_erased_macro(name) && !runtime_bindings.contains(name))
+        }
         _ => false,
     }
 }
@@ -237,6 +253,26 @@ const msg = 'ready'
 
         assert_eq!(setup_lines.len(), 1);
         assert_eq!(setup_lines[0].as_str(), "const msg = 'ready'");
+        assert!(ts_declarations.is_empty());
+    }
+
+    #[test]
+    fn test_extract_script_sections_preserves_imported_define_page() {
+        let content = r#"import { definePage } from '@/page.js'
+
+definePage(() => ({
+  title: 'runtime page',
+}))
+
+const msg = 'ready'
+"#;
+
+        let (imports, setup_lines, ts_declarations) =
+            extract_script_sections(content, true).expect("sections should parse");
+
+        assert_eq!(imports.len(), 1);
+        assert!(setup_lines.iter().any(|line| line.contains("definePage")));
+        assert!(setup_lines.iter().any(|line| line.contains("const msg")));
         assert!(ts_declarations.is_empty());
     }
 


### PR DESCRIPTION
## Summary
- Preserve runtime-bound ecosystem macro names, including imported definePage calls, during SFC script compilation
- Keep compile-time artifact extraction and erasure for unbound macro calls
- Add regression coverage for imported definePage

## Validation
- cargo fmt --check
- cargo test -p vize_atelier_sfc

Refs https://github.com/ubugeeei/vize/discussions/71#discussioncomment-16752957