### PR TITLE
fix(docs): restore mobile menu navigation

### DIFF
--- a/docs/theme/style.css
+++ b/docs/theme/style.css
@@ -47,6 +47,10 @@ body:not(.entry-page) #vein-canvas {
 
 .layout {
   position: relative;
+}
+
+.main {
+  position: relative;
   z-index: 1;
 }
 


### PR DESCRIPTION
## Summary

- move the docs page stacking context from `.layout` to `.main`
- keep the mobile sidebar above the overlay so sidebar links receive taps

## Validation

- `pnpm --dir docs build`
- mobile browser check at 390px width: opened Menu from `/getting-started/` and navigated to `/philosophy/index.html`

## Notes

- The docs build completed, but the existing OG image batch logged that `@vizejs/vite-plugin` was unavailable for the `vizejs` Vue plugin path in this fresh worktree.
