### PR TITLE
docs(nuxt): add getting started guide

### DIFF
--- a/docs/content/getting-started.md
+++ b/docs/content/getting-started.md
@@ -54,7 +54,31 @@ export default defineConfig({
 });
 ```
 
-### 2. npm CLI + Shared Config
+### 2. Nuxt Projects
+
+Use the Nuxt module when you want Vize to run inside Nuxt's own Vite pipeline.
+
+```bash
+vp install @vizejs/nuxt
+```
+
+Add the module to `nuxt.config.ts`:
+
+```ts
+export default defineNuxtConfig({
+  modules: ["@vizejs/nuxt"],
+  vize: {
+    compiler: true,
+  },
+});
+```
+
+Run your Nuxt dev server as usual. The module registers `@vizejs/vite-plugin` for Vue SFC
+compilation while preserving Nuxt auto-imports, components, middleware, and SSR transforms.
+
+See the [Nuxt Integration](./integrations/nuxt.md) guide for Musea setup and Nuxt-specific notes.
+
+### 3. npm CLI + Shared Config
 
 Use the `vize` npm package when you want shared config utilities and native CLI commands available
 in package scripts.
@@ -72,7 +96,7 @@ The npm `vize check` command uses the packaged NAPI checker and can emit Vue com
 with `--declaration --declaration-dir dist/types`. Use the Rust CLI when you need the Corsa-backed
 project diagnostics path across Vue, TS, TSX, and `.d.ts` inputs.
 
-### 3. Full Rust CLI
+### 4. Full Rust CLI
 
 Use the Rust binary when you want the full native CLI today.
 

--- a/docs/content/integrations/nuxt.md
+++ b/docs/content/integrations/nuxt.md
@@ -8,7 +8,9 @@ title: Nuxt
 
 Vize provides first-class Nuxt integration through the `@vizejs/nuxt` module. This replaces Nuxt's default Vue compiler with Vize's Rust-native compiler, providing the same speed improvements in Nuxt projects.
 
-## Installation
+## Getting Started
+
+### 1. Install the Module
 
 Install `vp` once from the [Vite+ install guide](https://viteplus.dev/guide/install), then add the module:
 
@@ -16,9 +18,7 @@ Install `vp` once from the [Vite+ install guide](https://viteplus.dev/guide/inst
 vp install @vizejs/nuxt
 ```
 
-## Setup
-
-### Using the Nuxt Module (Recommended)
+### 2. Register the Nuxt Module
 
 ```typescript
 // nuxt.config.ts
@@ -29,6 +29,20 @@ export default defineNuxtConfig({
   },
 });
 ```
+
+### 3. Start Nuxt
+
+Run the app with your existing Nuxt command:
+
+```bash
+vp dev
+```
+
+The module injects `@vizejs/vite-plugin` into Nuxt's Vite config and keeps Nuxt-specific transforms
+in the pipeline, so auto-imports, components, middleware, and SSR behavior continue to work through
+Nuxt.
+
+## Advanced Setup
 
 ### Using the Vite Plugin Directly
 


### PR DESCRIPTION
## Summary

- add a Nuxt Projects entry to the main Getting Started guide
- reorganize the Nuxt Integration page around install, module registration, and dev startup steps
- keep the direct Vite plugin path under Advanced Setup

## Validation

- `pnpm --dir docs build`
- checked generated HTML for the Nuxt section and Getting Started link resolution

## Notes

- The docs build completed, but the existing OG image batch logged that `@vizejs/vite-plugin` was unavailable for the `vizejs` Vue plugin path in this fresh worktree.
