### PR TITLE
docs: improve navigation and code highlighting

### DIFF
--- a/docs/content/rules/cross-file.md
+++ b/docs/content/rules/cross-file.md
@@ -1,8 +1,8 @@
 ---
-title: Cross-File Analyzer Rules
+title: Cross-file Analyzer Rules
 ---
 
-# Cross-File Analyzer Rules
+# Cross-file Analyzer Rules
 
 Cross-file diagnostics are emitted by `vize lint --cross-file`. They use
 `vize:croquis/cf/*` diagnostic codes because they analyze a project graph rather than one isolated

--- a/docs/content/rules/index.md
+++ b/docs/content/rules/index.md
@@ -12,16 +12,16 @@ manual.
 
 - [Vue rules](./vue.md): SFC template structure, Vue directives, component conventions, and
   single-file Vue correctness checks.
-- [Accessibility rules](./accessibility.md): ARIA, keyboard interaction, labels, landmarks, and
-  accessible media checks.
 - [Type and script rules](./type-and-script.md): TypeScript checker-backed diagnostics and Vapor
   script restrictions.
 - [HTML rules](./html.md): HTML validity and semantic markup checks.
+- [Accessibility rules](./accessibility.md): ARIA, keyboard interaction, labels, landmarks, and
+  accessible media checks.
 - [SSR rules](./ssr.md): server rendering and hydration hazards.
 - [Vapor rules](./vapor.md): Vapor-only template constraints.
+- [Musea and CSS rules](./musea-and-css.md): Musea art-block checks and style diagnostics.
 - [Cross-file analyzer rules](./cross-file.md): project-graph diagnostics emitted by
   `vize lint --cross-file`.
-- [Musea and CSS rules](./musea-and-css.md): Musea art-block checks and style diagnostics.
 
 ## Presets
 

--- a/docs/content/rules/musea-and-css.md
+++ b/docs/content/rules/musea-and-css.md
@@ -1,8 +1,8 @@
 ---
-title: Musea And CSS Rules
+title: Musea & CSS Rules
 ---
 
-# Musea And CSS Rules
+# Musea & CSS Rules
 
 Musea rules validate `<art>` and `<variant>` blocks. CSS rules inspect style content and recommend
 patterns that keep component styles themeable, predictable, and compatible with Vue and Vapor.

--- a/docs/content/rules/type-and-script.md
+++ b/docs/content/rules/type-and-script.md
@@ -1,8 +1,8 @@
 ---
-title: Type And Script Rules
+title: Type & Script Rules
 ---
 
-# Type And Script Rules
+# Type & Script Rules
 
 Type rules use the TypeScript checker when semantic information is needed. Vize reads the same
 project shape that TypeScript reads from `tsconfig.json`, so shared ambient names should come from

--- a/docs/theme/background.ts
+++ b/docs/theme/background.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 
-const SCRIPT_BASENAMES = ["vein", "syntax-highlight"];
+const SCRIPT_BASENAMES = ["vein", "navigation", "syntax-highlight"];
 const VERTEX_SHADER_PLACEHOLDER = "__VERT_SRC__";
 const FRAGMENT_SHADER_PLACEHOLDER = "__FRAG_SRC__";
 

--- a/docs/theme/navigation.js
+++ b/docs/theme/navigation.js
@@ -1,0 +1,185 @@
+const vizeDocsNavigation = (() => {
+  const labelByPath = new Map([
+    ["/", "Overview"],
+    ["/getting-started", "Getting Started"],
+    ["/guide/configuration", "Configuration"],
+    ["/guide/cli", "CLI"],
+    ["/guide/vite-plugin", "Vite Plugin"],
+    ["/guide/unplugin", "Bundler Integrations"],
+    ["/guide/wasm", "WASM Bindings"],
+    ["/guide/static-analysis", "Static Analysis"],
+    ["/guide/analysis-diagnostics", "Diagnostics"],
+    ["/guide/oxlint", "Oxlint Plugin"],
+    ["/guide/comment-annotations", "Comment Annotations"],
+    ["/rules", "Rules Overview"],
+    ["/rules/vue", "Vue"],
+    ["/rules/type-and-script", "Type & Script"],
+    ["/rules/html", "HTML"],
+    ["/rules/accessibility", "Accessibility"],
+    ["/rules/ssr", "SSR"],
+    ["/rules/vapor", "Vapor"],
+    ["/rules/musea-and-css", "Musea & CSS"],
+    ["/rules/cross-file", "Cross-file Analyzer"],
+    ["/guide/musea", "Musea"],
+    ["/integrations/nuxt", "Nuxt"],
+    ["/integrations/vscode", "VS Code"],
+    ["/integrations/mcp", "MCP Server"],
+    ["/architecture/overview", "Architecture Overview"],
+    ["/architecture/crates", "Crates"],
+    ["/architecture/performance", "Performance"],
+    ["/philosophy", "Philosophy"],
+  ]);
+
+  const navGroups = [
+    {
+      title: "Start",
+      paths: ["/", "/getting-started"],
+    },
+    {
+      title: "Use",
+      paths: [
+        "/guide/configuration",
+        "/guide/cli",
+        "/guide/vite-plugin",
+        "/guide/unplugin",
+        "/guide/wasm",
+      ],
+    },
+    {
+      title: "Analyze",
+      paths: [
+        "/guide/static-analysis",
+        "/guide/analysis-diagnostics",
+        "/guide/oxlint",
+        "/guide/comment-annotations",
+      ],
+    },
+    {
+      title: "Rules",
+      paths: [
+        "/rules",
+        "/rules/vue",
+        "/rules/type-and-script",
+        "/rules/html",
+        "/rules/accessibility",
+        "/rules/ssr",
+        "/rules/vapor",
+        "/rules/musea-and-css",
+        "/rules/cross-file",
+      ],
+    },
+    {
+      title: "Integrations",
+      paths: ["/guide/musea", "/integrations/nuxt", "/integrations/vscode", "/integrations/mcp"],
+    },
+    {
+      title: "Architecture",
+      paths: [
+        "/architecture/overview",
+        "/architecture/crates",
+        "/architecture/performance",
+        "/philosophy",
+      ],
+    },
+  ];
+
+  function canonicalPath(href) {
+    const url = new URL(href, window.location.origin);
+    const path = url.pathname.replace(/\/index\.html$/, "").replace(/\/$/, "");
+    return path || "/";
+  }
+
+  function createSection(title, items) {
+    const section = document.createElement("div");
+    section.className = "nav-section";
+
+    const heading = document.createElement("div");
+    heading.className = "nav-title";
+    heading.textContent = title;
+    section.append(heading);
+
+    const list = document.createElement("ul");
+    list.className = "nav-list";
+    for (const item of items) {
+      list.append(item);
+    }
+    section.append(list);
+
+    return section;
+  }
+
+  function applyNavigationOrder(root = document) {
+    const nav = root.querySelector?.(".sidebar nav");
+    if (!nav || nav.dataset.vizeNavigation === "structured") {
+      return;
+    }
+
+    const itemsByPath = new Map();
+    const unusedItems = [];
+    for (const item of nav.querySelectorAll(".nav-item")) {
+      const link = item.querySelector(".nav-link[href]");
+      if (!link) {
+        unusedItems.push(item);
+        continue;
+      }
+
+      const path = canonicalPath(link.getAttribute("href"));
+      link.textContent = labelByPath.get(path) ?? link.textContent.trim();
+      if (itemsByPath.has(path)) {
+        unusedItems.push(item);
+        continue;
+      }
+      itemsByPath.set(path, item);
+    }
+
+    const nextNav = document.createDocumentFragment();
+    const used = new Set();
+    for (const group of navGroups) {
+      const items = group.paths
+        .map((path) => {
+          used.add(path);
+          return itemsByPath.get(path);
+        })
+        .filter(Boolean);
+
+      if (items.length > 0) {
+        nextNav.append(createSection(group.title, items));
+      }
+    }
+
+    const remainingItems = [...itemsByPath]
+      .filter(([path]) => !used.has(path))
+      .map(([, item]) => item)
+      .concat(unusedItems);
+    if (remainingItems.length > 0) {
+      nextNav.append(createSection("More", remainingItems));
+    }
+
+    nav.replaceChildren(nextNav);
+    nav.dataset.vizeNavigation = "structured";
+  }
+
+  return {
+    applyNavigationOrder,
+    canonicalPath,
+  };
+})();
+
+if (typeof globalThis !== "undefined") {
+  globalThis.__vizeDocsNavigation = vizeDocsNavigation;
+}
+
+(() => {
+  if (typeof document === "undefined") {
+    return;
+  }
+
+  const start = () => vizeDocsNavigation.applyNavigationOrder(document);
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", start, { once: true });
+    return;
+  }
+
+  start();
+})();

--- a/docs/theme/syntax-highlight.js
+++ b/docs/theme/syntax-highlight.js
@@ -243,8 +243,14 @@ const vizeDocsSyntax = (() => {
       "v-code__string",
       store,
     );
-    result = replaceWithClass(result, /<\/?[\w:-]+/g, "v-code__tag", store);
+    result = replaceWithCallback(
+      result,
+      /(^|[^\w$])(<\/?[\w:-]+)/g,
+      (_, prefix, tag) => `${escapeHtml(prefix)}${wrapToken("v-code__tag", tag)}`,
+      store,
+    );
     result = replaceWithClass(result, /\{\{|\}\}/g, "v-code__delimiter", store);
+    result = replaceWithClass(result, /\/?>/g, "v-code__delimiter", store);
     result = replaceWithClass(
       result,
       /\b(v-[\w:-]+|@[\w.-]+|:[\w.-]+|#[\w.-]+)\b/g,
@@ -258,6 +264,38 @@ const vizeDocsSyntax = (() => {
       store,
     );
 
+    return result;
+  }
+
+  function highlightVue(source, store) {
+    const blockPattern = /<(script|template|style)\b[^>]*>[\s\S]*?<\/\1>/gi;
+    let result = "";
+    let lastIndex = 0;
+
+    for (const match of source.matchAll(blockPattern)) {
+      const block = match[0];
+      const blockName = match[1].toLowerCase();
+      const start = match.index ?? 0;
+      const openEnd = block.indexOf(">") + 1;
+      const closeStart = block.toLowerCase().lastIndexOf(`</${blockName}`);
+      const openTag = block.slice(0, openEnd);
+      const body = block.slice(openEnd, closeStart);
+      const closeTag = block.slice(closeStart);
+
+      result += highlightMarkup(source.slice(lastIndex, start), store);
+      result += highlightMarkup(openTag, store);
+      if (blockName === "script") {
+        result += highlightScriptLike(body, store, { highlightVariables: true });
+      } else if (blockName === "template") {
+        result += highlightMarkup(body, store);
+      } else {
+        result += highlightConfig(body, store);
+      }
+      result += highlightMarkup(closeTag, store);
+      lastIndex = start + block.length;
+    }
+
+    result += highlightMarkup(source.slice(lastIndex), store);
     return result;
   }
 
@@ -452,8 +490,7 @@ const vizeDocsSyntax = (() => {
     switch (normalizedLanguage) {
       case "art-vue":
       case "vue":
-        result = highlightMarkup(result, store);
-        result = highlightScriptLike(result, store, { highlightVariables: true });
+        result = highlightVue(result, store);
         break;
       case "javascript":
       case "typescript":

--- a/docs/theme/syntax-highlight.test.js
+++ b/docs/theme/syntax-highlight.test.js
@@ -38,6 +38,20 @@ void test("createHighlightedHtml highlights vue directives and strings", () => {
   assert.match(html, /v-code__directive/);
   assert.match(html, /v-code__string/);
   assert.match(html, /v-code__delimiter/);
+  assert.match(html, /v-code__delimiter">&gt;/);
+});
+
+void test("createHighlightedHtml does not treat TypeScript generics in Vue scripts as tags", () => {
+  const html = syntax.createHighlightedHtml(
+    '<script setup lang="ts">\nconst key: InjectionKey<Ref<Theme>> = Symbol("theme");\n</script>',
+    "vue",
+  );
+
+  assert.match(html, /&lt;script/);
+  assert.match(html, /&lt;\/script/);
+  assert.match(html, /InjectionKey&lt;Ref&lt;Theme&gt;&gt;/);
+  assert.doesNotMatch(html, /v-code__tag[^>]*>&lt;Ref/);
+  assert.doesNotMatch(html, /v-code__tag[^>]*>&lt;Theme/);
 });
 
 void test("createHighlightedHtml highlights bash commands and flags", () => {


### PR DESCRIPTION
## Summary

- make Vue code highlighting split SFC blocks so TypeScript generics are not treated as tags
- highlight closing tag delimiters in Vue code blocks
- restructure the docs sidebar into Start, Use, Analyze, Rules, Integrations, and Architecture groups
- align rule labels and the Rules overview ordering with the sidebar flow

## Validation

- `vp run --workspace-root check:ci`
- `vp run --filter ./docs build`
- `node docs/theme/syntax-highlight.test.js`
- `node --test docs/theme/background.test.ts`
- checked the cross-file rules page locally for sidebar order and Vue code highlighting