### PR TITLE
fix: avoid compiling non-Vue macro imports

### DIFF
--- a/npm/vite-plugin-vize/src/plugin/load.test.ts
+++ b/npm/vite-plugin-vize/src/plugin/load.test.ts
@@ -192,6 +192,27 @@ assert.doesNotMatch(
   "Nuxt definePageMeta macro queries should not return the component setup body",
 );
 
+const jsMacroDir = fs.mkdtempSync(path.join(os.tmpdir(), "vize-js-macro-"));
+const jsMacroPath = path.join(jsMacroDir, "component-stub.js");
+fs.writeFileSync(jsMacroPath, "export default {};");
+
+const jsMacroLoad = loadHook(
+  { ...hmrState, cache: new Map(), ssrCache: new Map(), root: jsMacroDir },
+  `\0${jsMacroPath}?macro=true`,
+  { ssr: false },
+);
+
+assert.equal(
+  typeof jsMacroLoad,
+  "string",
+  "non-Vue macro virtual IDs should be proxied without SFC compilation",
+);
+assert.match(
+  jsMacroLoad as string,
+  /component-stub\.js\?macro=true/,
+  "non-Vue macro proxies should preserve the macro query for Vite",
+);
+
 const firstLoad = loadHook(hmrState, toVirtualId(realPath), { ssr: false });
 assert.ok(firstLoad && typeof firstLoad === "object", "Virtual module should load as code object");
 assert.match(

--- a/npm/vite-plugin-vize/src/plugin/load.ts
+++ b/npm/vite-plugin-vize/src/plugin/load.ts
@@ -76,6 +76,10 @@ function normalizeMacroRealPath(realPath: string): string {
   return realPath.endsWith(".vue.ts") ? realPath.slice(0, -3) : realPath;
 }
 
+function isVueSfcPath(realPath: string): boolean {
+  return normalizeMacroRealPath(realPath).endsWith(".vue");
+}
+
 function stripVirtualQuery(id: string): string {
   return normalizeMacroRealPath(id.slice(1).split("?")[0] ?? "");
 }
@@ -212,29 +216,34 @@ export function loadHook(
 
   // Handle Vue Router's ?definePage query through extracted artifacts.
   if (id.startsWith("\0") && hasQueryParam(id, "definePage")) {
-    return loadDefinePageArtifact(state, stripVirtualQuery(id), !!loadOptions?.ssr);
+    const realPath = stripVirtualQuery(id);
+    if (isVueSfcPath(realPath)) {
+      return loadDefinePageArtifact(state, realPath, !!loadOptions?.ssr);
+    }
   }
 
   // Handle ?macro=true queries
   if (id.startsWith("\0") && hasMacroQuery(id)) {
     const realPath = stripVirtualQuery(id);
-    const artifactLoad = loadDefinePageMetaArtifact(state, realPath, !!loadOptions?.ssr);
-    if (artifactLoad) {
-      return artifactLoad;
-    }
-
-    if (fs.existsSync(realPath)) {
-      const source = fs.readFileSync(realPath, "utf-8");
-      const setupMatch = source.match(/<script\s+setup[^>]*>([\s\S]*?)<\/script>/);
-      if (setupMatch) {
-        const scriptContent = setupMatch[1];
-        return {
-          code: `${scriptContent}\nexport default {}`,
-          map: null,
-        };
+    if (isVueSfcPath(realPath)) {
+      const artifactLoad = loadDefinePageMetaArtifact(state, realPath, !!loadOptions?.ssr);
+      if (artifactLoad) {
+        return artifactLoad;
       }
+
+      if (fs.existsSync(realPath)) {
+        const source = fs.readFileSync(realPath, "utf-8");
+        const setupMatch = source.match(/<script\s+setup[^>]*>([\s\S]*?)<\/script>/);
+        if (setupMatch) {
+          const scriptContent = setupMatch[1];
+          return {
+            code: `${scriptContent}\nexport default {}`,
+            map: null,
+          };
+        }
+      }
+      return { code: "export default {}", map: null };
     }
-    return { code: "export default {}", map: null };
   }
 
   // Handle vize virtual modules

--- a/npm/vite-plugin-vize/src/plugin/resolve.test.ts
+++ b/npm/vite-plugin-vize/src/plugin/resolve.test.ts
@@ -85,6 +85,28 @@ function expectResolvedId(resolved: Awaited<ReturnType<typeof resolveIdHook>>): 
 }
 
 {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "vize-resolve-js-macro-"));
+  const importer = path.join(tempRoot, "App.vue");
+  const stub = path.join(tempRoot, "component-stub.js");
+  fs.writeFileSync(importer, "<template><div /></template>");
+  fs.writeFileSync(stub, "export default {};");
+
+  const resolved = await resolveIdHook(
+    nullResolveContext,
+    createState(tempRoot),
+    "./component-stub.js?macro=true",
+    toVirtualId(importer),
+    undefined,
+  );
+
+  assert.equal(
+    expectResolvedId(resolved),
+    `${stub}?macro=true`,
+    "non-Vue macro imports should stay regular JavaScript modules",
+  );
+}
+
+{
   const projectRoot = path.join(workspaceRoot, "tests", "_fixtures", "_git", "npmx.dev");
   if (hasFixtureProject(projectRoot)) {
     const importer = toVirtualId(path.join(projectRoot, "app", "pages", "index.vue"));

--- a/npm/vite-plugin-vize/src/plugin/resolve.ts
+++ b/npm/vite-plugin-vize/src/plugin/resolve.ts
@@ -63,6 +63,10 @@ function isMacroVirtualId(id: string): boolean {
   return id.startsWith("\0") && (hasMacroQuery(id) || hasQueryParam(id, "definePage"));
 }
 
+function isVueSfcPath(id: string): boolean {
+  return (id.split("?")[0] ?? id).endsWith(".vue");
+}
+
 function normalizeRequireBase(importer?: string): string | null {
   if (!importer) {
     return null;
@@ -183,7 +187,7 @@ export async function resolveIdHook(
   // Nuxt's router generates `import { default } from "page.vue?macro=true"` to extract
   // route metadata. Without @vitejs/plugin-vue, Vize must resolve this query so the
   // load hook can return compile-time macro artifact modules.
-  if (hasMacroQuery(id) || hasQueryParam(id, "definePage")) {
+  if ((hasMacroQuery(id) || hasQueryParam(id, "definePage")) && isVueSfcPath(id)) {
     const filePath = id.split("?")[0];
     const querySuffix = id.slice(id.indexOf("?"));
     const resolved = resolveVuePath(state, filePath, importer);


### PR DESCRIPTION
## Summary
- restrict Vize macro virtual handling to Vue SFC paths
- let non-Vue `?macro=true` imports such as Nuxt `component-stub.js` pass through as regular JavaScript
- add resolve/load regression coverage for non-Vue macro imports

## Tests
- `pnpm --filter @vizejs/vite-plugin test`
- `pnpm --filter @vizejs/vite-plugin check`

Closes #219