### PR TITLE
chore: remove moonbit script deprecation warnings

### DIFF
--- a/tools/moon/scripts/build_vitrine_wasm.mbtx
+++ b/tools/moon/scripts/build_vitrine_wasm.mbtx
@@ -53,7 +53,7 @@ async fn command_stdout(
   if body == "" {
     return None
   }
-  Some(body.to_string())
+  Some(body.to_owned())
 }
 
 ///|

--- a/tools/moon/scripts/generate_rule_types.mbtx
+++ b/tools/moon/scripts/generate_rule_types.mbtx
@@ -58,7 +58,7 @@ fn snapshot_json_body(snapshot : String) -> String? {
   guard snapshot.has_prefix("---\n") else { return None }
   let parts : Array[String] = snapshot
     .split("\n---\n")
-    .map(StringView::to_string)
+    .map(StringView::to_owned)
     .collect()
   guard parts.length() >= 2 else { return None }
   let body : Array[String] = []

--- a/tools/moon/scripts/github/configure_npm_auth.mbtx
+++ b/tools/moon/scripts/github/configure_npm_auth.mbtx
@@ -58,7 +58,7 @@ async fn run_app() -> Int {
   let registry_line = "registry=https://registry.npmjs.org/"
   let lines = []
   if existing.trim() != "" {
-    let existing_lines : Array[String] = existing.split("\n").map(StringView::to_string).collect()
+    let existing_lines : Array[String] = existing.split("\n").map(StringView::to_owned).collect()
     for line in existing_lines {
       let trimmed = line.trim()
       if trimmed == "" {

--- a/tools/moon/scripts/github/write_coverage_summary.mbtx
+++ b/tools/moon/scripts/github/write_coverage_summary.mbtx
@@ -13,7 +13,7 @@ fn last_lines(text : String, count : Int) -> String {
   if trimmed == "" {
     return ""
   }
-  let lines : Array[String] = trimmed.split("\n").map(StringView::to_string).collect()
+  let lines : Array[String] = trimmed.split("\n").map(StringView::to_owned).collect()
   let start = if lines.length() > count { lines.length() - count } else { 0 }
   let summary_lines : Array[String] = []
   for i in start..<lines.length() {

--- a/tools/moon/scripts/prepare_npm_publish_manifest.mbtx
+++ b/tools/moon/scripts/prepare_npm_publish_manifest.mbtx
@@ -111,7 +111,7 @@ fn package_version(json : Json) -> String? {
 
 ///|
 fn yaml_scalar(value : String) -> String {
-  value.trim().to_string().replace_all(old="\"", new="")
+  value.trim().to_owned().replace_all(old="\"", new="")
 }
 
 ///|
@@ -164,7 +164,7 @@ fn parse_catalog_versions(content : String) -> Map[String, String] {
   let versions : Map[String, String] = {}
   let mut in_catalogs = false
   let mut current_catalog = ""
-  let lines : Array[String] = content.split("\n").map(StringView::to_string).collect()
+  let lines : Array[String] = content.split("\n").map(StringView::to_owned).collect()
   for line in lines {
     let trimmed = line.trim()
     if trimmed == "" || trimmed.has_prefix("#") {
@@ -180,13 +180,13 @@ fn parse_catalog_versions(content : String) -> Map[String, String] {
       break
     }
     if line.has_prefix("  ") && !line.has_prefix("    ") && trimmed.has_suffix(":") {
-      current_catalog = trimmed.to_string().replace(old=":", new="")
+      current_catalog = trimmed.to_owned().replace(old=":", new="")
       continue
     }
     if current_catalog == "" || !line.has_prefix("    ") {
       continue
     }
-    let parts : Array[String] = trimmed.split(": ").map(StringView::to_string).collect()
+    let parts : Array[String] = trimmed.split(": ").map(StringView::to_owned).collect()
     guard parts.length() >= 2 else { continue }
     let key = yaml_scalar(parts[0])
     let value = yaml_scalar(parts[1])

--- a/tools/moon/scripts/publish_crates.mbtx
+++ b/tools/moon/scripts/publish_crates.mbtx
@@ -9,7 +9,7 @@
 import {
   "moonbitlang/core/env",
   "moonbitlang/core/json",
-  "moonbitlang/core/strconv",
+  "moonbitlang/core/string",
   "moonbitlang/async@0.16.8",
   "moonbitlang/async@0.16.8/process",
   "moonbitlang/async@0.16.8/stdio",
@@ -43,7 +43,7 @@ let published_crates : Array[String] = [
 /// Parses a positive integer from a string and falls back on invalid input.
 fn positive_int_or(value : String, fallback : Int) -> Int {
   try {
-    let parsed = @strconv.parse_int(value)
+    let parsed = @string.parse_int(value)
     if parsed > 0 {
       parsed
     } else {
@@ -80,11 +80,11 @@ fn read_file_to_string(path : String) -> String? {
 /// scanner is more predictable than shelling out to another TOML parser.
 fn workspace_version_from_content(content : String) -> String? {
   let mut section = ""
-  let lines : Array[String] = content.split("\n").map(StringView::to_string).collect()
+  let lines : Array[String] = content.split("\n").map(StringView::to_owned).collect()
   for line in lines {
     let trimmed = line.trim()
     if trimmed.has_prefix("[") && trimmed.has_suffix("]") {
-      section = trimmed.to_string()
+      section = trimmed.to_owned()
       continue
     }
     if section == "[workspace.package]" &&
@@ -92,7 +92,7 @@ fn workspace_version_from_content(content : String) -> String? {
       trimmed.has_suffix("\"") {
       return Some(
         trimmed
-          .to_string()
+          .to_owned()
           .replace(old="version = \"", new="")
           .replace_all(old="\"", new=""),
       )

--- a/tools/moon/scripts/publish_npm_package.mbtx
+++ b/tools/moon/scripts/publish_npm_package.mbtx
@@ -21,7 +21,7 @@
 import {
   "moonbitlang/core/env",
   "moonbitlang/core/json",
-  "moonbitlang/core/strconv",
+  "moonbitlang/core/string",
   "moonbitlang/async@0.16.8",
   "moonbitlang/async@0.16.8/process",
   "moonbitlang/async@0.16.8/stdio",
@@ -80,7 +80,7 @@ fn safe_path_exists(path : String) -> Bool {
 
 ///|
 fn normalize_manifest_path(value : String) -> String? {
-  let path = value.trim().to_string()
+  let path = value.trim().to_owned()
   if path == "" {
     return None
   }
@@ -209,7 +209,7 @@ fn package_version(json : Json) -> String? {
 /// safe default instead of aborting on malformed values.
 fn positive_int_or(value : String, fallback : Int) -> Int {
   try {
-    let parsed = @strconv.parse_int(value)
+    let parsed = @string.parse_int(value)
     if parsed > 0 {
       parsed
     } else {

--- a/tools/moon/scripts/release.mbtx
+++ b/tools/moon/scripts/release.mbtx
@@ -9,7 +9,7 @@
 /// and only then creates and pushes the release commit and tag.
 import {
   "moonbitlang/core/env",
-  "moonbitlang/core/strconv",
+  "moonbitlang/core/string",
   "moonbitlang/async@0.16.8",
   "moonbitlang/async@0.16.8/process",
   "moonbitlang/async@0.16.8/stdio",
@@ -104,7 +104,7 @@ fn write_string_to_file(path : String, content : String) -> Bool {
 /// Parses an integer but keeps the caller in control of error handling.
 fn parse_int(value : String) -> Int? {
   try {
-    Some(@strconv.parse_int(value))
+    Some(@string.parse_int(value))
   } catch {
     _ => None
   }
@@ -122,10 +122,10 @@ fn parse_int(value : String) -> Int? {
 /// The parser is intentionally strict so release automation never guesses when
 /// the current version format has drifted unexpectedly.
 fn parse_version(value : String) -> Version? {
-  let parts : Array[String] = value.split("-").map(StringView::to_string).collect()
+  let parts : Array[String] = value.split("-").map(StringView::to_owned).collect()
   guard parts.length() >= 1 && parts.length() <= 2 else { return None }
 
-  let base_parts : Array[String] = parts[0].split(".").map(StringView::to_string).collect()
+  let base_parts : Array[String] = parts[0].split(".").map(StringView::to_owned).collect()
   guard base_parts.length() == 3 else { return None }
   let major = match parse_int(base_parts[0]) {
     Some(value) => value
@@ -145,7 +145,7 @@ fn parse_version(value : String) -> Version? {
   if parts.length() == 2 {
     let prerelease_parts : Array[String] = parts[1]
       .split(".")
-      .map(StringView::to_string)
+      .map(StringView::to_owned)
       .collect()
     guard prerelease_parts.length() >= 1 && prerelease_parts.length() <= 2 else {
       return None
@@ -266,11 +266,11 @@ fn bump_version(current : String, bump : String) -> String? {
 /// Extracts the current workspace version from the root `Cargo.toml`.
 fn workspace_version_from_content(content : String) -> String? {
   let mut section = ""
-  let lines : Array[String] = content.split("\n").map(StringView::to_string).collect()
+  let lines : Array[String] = content.split("\n").map(StringView::to_owned).collect()
   for line in lines {
     let trimmed = line.trim()
     if trimmed.has_prefix("[") && trimmed.has_suffix("]") {
-      section = trimmed.to_string()
+      section = trimmed.to_owned()
       continue
     }
     if section == "[workspace.package]" &&
@@ -278,7 +278,7 @@ fn workspace_version_from_content(content : String) -> String? {
       trimmed.has_suffix("\"") {
       return Some(
         trimmed
-          .to_string()
+          .to_owned()
           .replace(old="version = \"", new="")
           .replace_all(old="\"", new=""),
       )
@@ -299,11 +299,11 @@ fn update_workspace_manifest_versions(
 ) -> String {
   let mut section = ""
   let updated : Array[String] = []
-  let lines : Array[String] = content.split("\n").map(StringView::to_string).collect()
+  let lines : Array[String] = content.split("\n").map(StringView::to_owned).collect()
   for line in lines {
     let trimmed = line.trim()
     if trimmed.has_prefix("[") && trimmed.has_suffix("]") {
-      section = trimmed.to_string()
+      section = trimmed.to_owned()
       updated.push(line)
       continue
     }
@@ -333,7 +333,7 @@ fn replace_package_json_version(
 ) -> String {
   let updated : Array[String] = []
   let mut replaced = false
-  let lines : Array[String] = content.split("\n").map(StringView::to_string).collect()
+  let lines : Array[String] = content.split("\n").map(StringView::to_owned).collect()
   for line in lines {
     if !replaced {
       let trimmed = line.trim()
@@ -360,7 +360,7 @@ fn replace_first_version_line(
 ) -> String {
   let updated : Array[String] = []
   let mut replaced = false
-  let lines : Array[String] = content.split("\n").map(StringView::to_string).collect()
+  let lines : Array[String] = content.split("\n").map(StringView::to_owned).collect()
   for line in lines {
     if !replaced {
       let trimmed = line.trim()


### PR DESCRIPTION
## Summary
- replace deprecated MoonBit integer parsing helpers with current core/string APIs
- use StringView::to_owned when scripts allocate owned strings
- clean up release, package build, and publish helper scripts that run in CI

## Verification
- cargo build --profile ci -p vize
- vp run --workspace-root test:scripts
- vp run --workspace-root build:packages
- env -u MOON_HOME moon run -q --target native - -- < tools/moon/scripts/release.mbtx
- env -u MOON_HOME moon run -q --target native - -- minor < tools/moon/scripts/release.mbtx
- moon run -q --target native - -- < tools/moon/scripts/generate_rule_types.mbtx