### PR TITLE
fix: harden workflows and local dev surfaces

### DIFF
--- a/.github/actions/setup-moonbit/install-moonbit.mjs
+++ b/.github/actions/setup-moonbit/install-moonbit.mjs
@@ -144,12 +144,16 @@ if (!hasExistingMoonInstall()) {
       MOON_HOME: moonHome,
     });
   } else {
-    run("curl", ["-fsSL", "https://cli.moonbitlang.com/install/unix.sh", "-o", moonInstallerUnixScript], {
-      ...process.env,
-      HOME: runnerTemp,
-      MOON_HOME: moonHome,
-      SHELL: process.env.SHELL ?? "/bin/bash",
-    });
+    run(
+      "curl",
+      ["-fsSL", "https://cli.moonbitlang.com/install/unix.sh", "-o", moonInstallerUnixScript],
+      {
+        ...process.env,
+        HOME: runnerTemp,
+        MOON_HOME: moonHome,
+        SHELL: process.env.SHELL ?? "/bin/bash",
+      },
+    );
     verifyInstaller(moonInstallerUnixScript, moonInstallerSha256.unix);
     run("bash", [moonInstallerUnixScript], {
       ...process.env,

--- a/.github/actions/setup-moonbit/install-moonbit.mjs
+++ b/.github/actions/setup-moonbit/install-moonbit.mjs
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import process from "node:process";
 import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
 
 const runnerTemp = process.env.RUNNER_TEMP;
 const githubPath = process.env.GITHUB_PATH;
@@ -21,6 +22,11 @@ const shimMoonCmd = path.join(shimDir, "moon.cmd");
 const shimMoonShell = path.join(shimDir, "moon");
 const shimMoon = os.type() === "Windows_NT" ? shimMoonCmd : shimMoonShell;
 const moonInstallerScript = path.join(runnerTemp, "moonbit-install.ps1");
+const moonInstallerUnixScript = path.join(runnerTemp, "moonbit-install.sh");
+const moonInstallerSha256 = {
+  unix: "802ea2310c13e2a6b447050a2c82e60b4d5f222ec7c6a8e55b77df09d4b4da7d",
+  windows: "e1b22bd41363ca8cdb1480b523a8c61ce57ffcb4a581375369ff16c5afd5c5b7",
+};
 
 function run(command, args, env) {
   const result = spawnSync(command, args, {
@@ -30,6 +36,20 @@ function run(command, args, env) {
 
   if ((result.status ?? 1) !== 0) {
     process.exit(result.status ?? 1);
+  }
+}
+
+function sha256File(filePath) {
+  return createHash("sha256").update(fs.readFileSync(filePath)).digest("hex");
+}
+
+function verifyInstaller(filePath, expectedHash) {
+  const actualHash = sha256File(filePath);
+  if (actualHash !== expectedHash) {
+    console.error(`MoonBit installer hash mismatch for ${filePath}`);
+    console.error(`Expected: ${expectedHash}`);
+    console.error(`Actual:   ${actualHash}`);
+    process.exit(1);
   }
 }
 
@@ -118,12 +138,20 @@ if (!hasExistingMoonInstall()) {
         MOON_HOME: moonHome,
       },
     );
+    verifyInstaller(moonInstallerScript, moonInstallerSha256.windows);
     run("pwsh", ["-NoProfile", "-ExecutionPolicy", "Bypass", "-File", moonInstallerScript], {
       ...process.env,
       MOON_HOME: moonHome,
     });
   } else {
-    run("bash", ["-lc", "curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash"], {
+    run("curl", ["-fsSL", "https://cli.moonbitlang.com/install/unix.sh", "-o", moonInstallerUnixScript], {
+      ...process.env,
+      HOME: runnerTemp,
+      MOON_HOME: moonHome,
+      SHELL: process.env.SHELL ?? "/bin/bash",
+    });
+    verifyInstaller(moonInstallerUnixScript, moonInstallerSha256.unix);
+    run("bash", [moonInstallerUnixScript], {
       ...process.env,
       HOME: runnerTemp,
       MOON_HOME: moonHome,

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -94,4 +94,4 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           BENCHMARK_COMMENT_KEY: ${{ github.event.pull_request.head.sha }}
-        run: node head/bench/comment-pr.mjs --body benchmark-summary.md --comment-key "$BENCHMARK_COMMENT_KEY"
+        run: node base/bench/comment-pr.mjs --body benchmark-summary.md --comment-key "$BENCHMARK_COMMENT_KEY"

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -10,6 +10,9 @@ concurrency:
   group: check-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -106,12 +109,9 @@ jobs:
   playground-test:
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
     steps:
       - uses: actions/checkout@v6
-        with:
-          ref: ${{ github.head_ref }}
-          token: ${{ github.token }}
 
       # Rust is always needed for @vizejs/native (used by vite-plugin-vize)
       - name: Setup Rust
@@ -189,12 +189,8 @@ jobs:
         if: steps.vrt.outcome == 'failure'
         run: vp run --filter './playground' test:vrt:update
 
-      - name: Commit updated snapshots
-        if: steps.vrt.outcome == 'failure' && github.event_name == 'pull_request'
-        run: moon run --target native - -- ${{ github.head_ref }} < tools/moon/scripts/github/commit_vrt_snapshots.mbtx
-
-      - name: Fail if VRT failed and no auto-update
-        if: steps.vrt.outcome == 'failure' && github.event_name != 'pull_request'
+      - name: Fail if VRT failed
+        if: steps.vrt.outcome == 'failure'
         run: exit 1
 
       - name: Upload VRT diff artifacts

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -11,8 +11,6 @@ env:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 concurrency:
   group: pages-${{ github.ref }}
@@ -129,6 +127,10 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     needs: [build-docs, build-playground]
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,8 +10,7 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
-  contents: write
-  id-token: write
+  contents: read
 
 env:
   CARGO_INCREMENTAL: 0
@@ -147,6 +146,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-editor-extensions
     environment: vscode-marketplace
+    permissions:
+      contents: read
     env:
       VSCE_PAT: ${{ secrets.VSCE_PAT }}
     steps:
@@ -846,6 +847,9 @@ jobs:
     name: Release crates to crates.io
     runs-on: ubuntu-latest
     environment: crates-io
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-moonbit
@@ -873,6 +877,8 @@ jobs:
     name: Create GitHub Release
     runs-on: ubuntu-latest
     needs: [build-cli, build-editor-extensions]
+    permissions:
+      contents: write
     steps:
       - name: Download CLI artifacts
         uses: actions/download-artifact@v4

--- a/npm/musea-mcp-server/src/index.ts
+++ b/npm/musea-mcp-server/src/index.ts
@@ -23,6 +23,7 @@ import { loadNative } from "./native.js";
 import { findArtFiles } from "./scanner.js";
 import { toolDefinitions, handleToolCall } from "./tools.js";
 import { listResources, readResource } from "./resources.js";
+import { resolveProjectPath } from "./musea.js";
 
 export function createMuseaServer(config: {
   projectRoot: string;
@@ -35,7 +36,7 @@ export function createMuseaServer(config: {
     { capabilities: { resources: {}, tools: {} } },
   );
 
-  const projectRoot = config.projectRoot;
+  const projectRoot = path.resolve(config.projectRoot);
   const include = config.include ?? ["**/*.art.vue"];
   const exclude = config.exclude ?? ["node_modules/**", "dist/**"];
   const tokensPath = config.tokensPath;
@@ -80,7 +81,7 @@ export function createMuseaServer(config: {
   }
 
   async function resolveTokensPath(): Promise<string | null> {
-    if (tokensPath) return path.resolve(projectRoot, tokensPath);
+    if (tokensPath) return resolveProjectPath(projectRoot, tokensPath, "tokensPath");
 
     const candidates = ["tokens", "design-tokens", "style-dictionary"];
     for (const dir of candidates) {

--- a/npm/musea-mcp-server/src/musea.ts
+++ b/npm/musea-mcp-server/src/musea.ts
@@ -93,11 +93,34 @@ function tokenize(query: string): string[] {
 }
 
 function toProjectPath(projectRoot: string, absolutePath: string): string {
-  const relativePath = path.relative(projectRoot, absolutePath);
-  if (!relativePath || relativePath.startsWith("..") || path.isAbsolute(relativePath)) {
-    return absolutePath;
+  const root = path.resolve(projectRoot);
+  const resolved = path.resolve(absolutePath);
+  const relativePath = path.relative(root, resolved);
+  return isProjectPath(root, resolved) ? relativePath || "." : resolved;
+}
+
+export function isProjectPath(projectRoot: string, candidatePath: string): boolean {
+  const root = path.resolve(projectRoot);
+  const candidate = path.resolve(candidatePath);
+  const relativePath = path.relative(root, candidate);
+  return relativePath === "" || (!relativePath.startsWith("..") && !path.isAbsolute(relativePath));
+}
+
+export function resolveProjectPath(projectRoot: string, inputPath: string, label = "path"): string {
+  if (inputPath.includes("\0")) {
+    throw new McpError(ErrorCode.InvalidParams, `${label} contains an invalid character`);
   }
-  return relativePath;
+
+  const root = path.resolve(projectRoot);
+  const resolvedPath = path.isAbsolute(inputPath)
+    ? path.resolve(inputPath)
+    : path.resolve(root, inputPath);
+
+  if (!isProjectPath(root, resolvedPath)) {
+    throw new McpError(ErrorCode.InvalidParams, `${label} must stay inside the project root`);
+  }
+
+  return resolvedPath;
 }
 
 function buildResourceUris(
@@ -316,9 +339,7 @@ export async function resolveArtReference(
   const refArg = typeof args?.ref === "string" ? args.ref : undefined;
 
   if (pathArg) {
-    const resolvedPath = path.isAbsolute(pathArg)
-      ? pathArg
-      : path.resolve(ctx.projectRoot, pathArg);
+    const resolvedPath = resolveProjectPath(ctx.projectRoot, pathArg, "path");
     const normalizedResolvedPath = normalizePathLike(resolvedPath);
     const normalizedRelativePath = normalizePathLike(path.relative(ctx.projectRoot, resolvedPath));
     const directMatch = arts.find((info) => {
@@ -448,6 +469,16 @@ async function getComponentSourceDescriptor(
       reference: resolved.info.component,
       exists: false,
       error: "This art file does not declare a component source.",
+    };
+  }
+
+  if (!isProjectPath(ctx.projectRoot, componentPath)) {
+    return {
+      reference: resolved.info.component,
+      absolutePath: componentPath,
+      path: componentPath,
+      exists: false,
+      error: "Component source is outside the project root.",
     };
   }
 

--- a/npm/musea-mcp-server/src/resources.ts
+++ b/npm/musea-mcp-server/src/resources.ts
@@ -8,6 +8,7 @@ import {
   buildIndexSummary,
   getProjectPath,
   resolveArtReference,
+  resolveProjectPath,
 } from "./musea.js";
 import { flattenTokenCategories, generateTokensMarkdown, parseTokensFromPath } from "./tokens.js";
 import type { ServerContext } from "./types.js";
@@ -193,7 +194,7 @@ export async function readResource(ctx: ServerContext, uri: string) {
 
   if (uri.startsWith("musea://source/")) {
     const relativePath = decodeURIComponent(uri.slice("musea://source/".length));
-    const absolutePath = path.resolve(ctx.projectRoot, relativePath);
+    const absolutePath = resolveProjectPath(ctx.projectRoot, relativePath, "source path");
     const source = await fs.promises.readFile(absolutePath, "utf-8");
 
     return {
@@ -225,7 +226,11 @@ export async function readResource(ctx: ServerContext, uri: string) {
       );
     }
 
-    const absolutePath = path.resolve(ctx.projectRoot, componentSource.path);
+    const absolutePath = resolveProjectPath(
+      ctx.projectRoot,
+      componentSource.path,
+      "component source path",
+    );
     const source = await fs.promises.readFile(absolutePath, "utf-8");
     return {
       contents: [{ uri, mimeType: "text/plain", text: source }],

--- a/npm/musea-mcp-server/src/tools/handler/analysis.ts
+++ b/npm/musea-mcp-server/src/tools/handler/analysis.ts
@@ -5,9 +5,13 @@
  */
 
 import fs from "node:fs";
-import path from "node:path";
 import { ErrorCode, McpError } from "@modelcontextprotocol/sdk/types.js";
-import { analyzeResolvedComponent, buildPalette, resolveArtReference } from "../../musea.js";
+import {
+  analyzeResolvedComponent,
+  buildPalette,
+  resolveArtReference,
+  resolveProjectPath,
+} from "../../musea.js";
 import type { ServerContext, ToolResult } from "./types.js";
 
 export async function handleAnalyzeComponent(
@@ -21,7 +25,7 @@ export async function handleAnalyzeComponent(
       throw new McpError(ErrorCode.InternalError, "analyzeSfc not available in native binding");
     }
 
-    const absolutePath = path.resolve(ctx.projectRoot, directPath);
+    const absolutePath = resolveProjectPath(ctx.projectRoot, directPath, "path");
     const source = await fs.promises.readFile(absolutePath, "utf-8");
     const analysis = binding.analyzeSfc(source, { filename: absolutePath });
 

--- a/npm/musea-mcp-server/src/tools/handler/generation.ts
+++ b/npm/musea-mcp-server/src/tools/handler/generation.ts
@@ -8,7 +8,12 @@
 import fs from "node:fs";
 import path from "node:path";
 import { ErrorCode, McpError } from "@modelcontextprotocol/sdk/types.js";
-import { buildCatalogMarkdown, buildDocumentation, resolveArtReference } from "../../musea.js";
+import {
+  buildCatalogMarkdown,
+  buildDocumentation,
+  resolveArtReference,
+  resolveProjectPath,
+} from "../../musea.js";
 import {
   flattenTokenCategories,
   generateTokensMarkdown,
@@ -32,7 +37,7 @@ export async function handleGenerateVariants(
     throw new McpError(ErrorCode.InternalError, "generateVariants not available in native binding");
   }
 
-  const absolutePath = path.resolve(ctx.projectRoot, componentRelPath);
+  const absolutePath = resolveProjectPath(ctx.projectRoot, componentRelPath, "componentPath");
   const source = await fs.promises.readFile(absolutePath, "utf-8");
 
   const analysis = binding.analyzeSfc(source, { filename: absolutePath });
@@ -236,7 +241,7 @@ export async function handleGetTokens(
 
   let resolvedPath: string | null;
   if (inputPath) {
-    resolvedPath = path.resolve(ctx.projectRoot, inputPath);
+    resolvedPath = resolveProjectPath(ctx.projectRoot, inputPath, "tokensPath");
   } else {
     resolvedPath = await ctx.resolveTokensPath();
   }
@@ -294,7 +299,7 @@ export async function handleSearchTokens(
   const typeFilter = typeof args?.type === "string" ? args.type.toLowerCase() : undefined;
   const limit = typeof args?.limit === "number" ? args.limit : 20;
   const resolvedPath = inputPath
-    ? path.resolve(ctx.projectRoot, inputPath)
+    ? resolveProjectPath(ctx.projectRoot, inputPath, "tokensPath")
     : await ctx.resolveTokensPath();
 
   if (!resolvedPath) {

--- a/npm/vite-plugin-musea/gallery/api.ts
+++ b/npm/vite-plugin-musea/gallery/api.ts
@@ -52,6 +52,17 @@ export interface A11yApiResponse {
 
 const basePath =
   (window as unknown as { __MUSEA_BASE_PATH__: string }).__MUSEA_BASE_PATH__ ?? "/__musea__";
+const sessionToken =
+  (window as unknown as { __MUSEA_SESSION_TOKEN__?: string }).__MUSEA_SESSION_TOKEN__ ?? "";
+
+function mutationHeaders(): HeadersInit {
+  const headers = new Headers();
+  headers.set("Content-Type", "application/json");
+  if (sessionToken) {
+    headers.set("X-Musea-Session", sessionToken);
+  }
+  return headers;
+}
 
 async function fetchJson<T>(url: string): Promise<T> {
   const res = await fetch(basePath + url);
@@ -176,7 +187,7 @@ export async function createToken(
 ): Promise<TokenMutationResponse> {
   const res = await fetch(basePath + "/api/tokens", {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: mutationHeaders(),
     body: JSON.stringify({ path: tokenPath, token }),
   });
   if (!res.ok) {
@@ -192,7 +203,7 @@ export async function updateToken(
 ): Promise<TokenMutationResponse> {
   const res = await fetch(basePath + "/api/tokens", {
     method: "PUT",
-    headers: { "Content-Type": "application/json" },
+    headers: mutationHeaders(),
     body: JSON.stringify({ path: tokenPath, token }),
   });
   if (!res.ok) {
@@ -205,7 +216,7 @@ export async function updateToken(
 export async function deleteToken(tokenPath: string): Promise<TokenMutationResponse> {
   const res = await fetch(basePath + "/api/tokens", {
     method: "DELETE",
-    headers: { "Content-Type": "application/json" },
+    headers: mutationHeaders(),
     body: JSON.stringify({ path: tokenPath }),
   });
   if (!res.ok) {
@@ -250,7 +261,7 @@ export async function updateArtSource(
 ): Promise<{ success: boolean }> {
   const res = await fetch(basePath + `/api/arts/${encodeURIComponent(artPath)}/source`, {
     method: "PUT",
-    headers: { "Content-Type": "application/json" },
+    headers: mutationHeaders(),
     body: JSON.stringify({ source }),
   });
   if (!res.ok) {
@@ -263,7 +274,7 @@ export async function updateArtSource(
 export async function runVrt(artPath?: string, updateSnapshots?: boolean): Promise<VrtApiResponse> {
   const res = await fetch(basePath + "/api/run-vrt", {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: mutationHeaders(),
     body: JSON.stringify({ artPath, updateSnapshots }),
   });
   if (!res.ok) {

--- a/npm/vite-plugin-musea/src/api-routes/index.ts
+++ b/npm/vite-plugin-musea/src/api-routes/index.ts
@@ -30,6 +30,13 @@ import {
   handleArtA11y,
 } from "./handlers.js";
 import { handlePreviewWithProps, handleGenerate, handleRunVrt } from "./post-handlers.js";
+import {
+  collectRequestBody,
+  DEFAULT_API_BODY_LIMIT_BYTES,
+  HttpError,
+  resolveInside,
+  validateDevApiRequest,
+} from "../security.js";
 
 /** Dependencies injected from the plugin closure. */
 export interface ApiRoutesContext {
@@ -39,6 +46,8 @@ export interface ApiRoutesContext {
   basePath: string;
   resolvedPreviewCss: string[];
   resolvedPreviewSetup: string | null;
+  devSessionToken: string;
+  apiBodyLimit?: number;
   processArtFile: (filePath: string) => Promise<void>;
   /** Reference to the dev server for VRT port resolution */
   getDevServerPort: () => number;
@@ -49,17 +58,6 @@ export type SendError = (message: string, status?: number) => void;
 export type ReadBody = () => Promise<string>;
 
 type NextFn = () => void;
-
-/** Helper to read the full request body as a string. */
-function collectBody(req: IncomingMessage): Promise<string> {
-  return new Promise((resolve) => {
-    let body = "";
-    req.on("data", (chunk) => {
-      body += chunk;
-    });
-    req.on("end", () => resolve(body));
-  });
-}
 
 /**
  * Create the API middleware handler for the Musea gallery.
@@ -79,135 +77,147 @@ export function createApiMiddleware(ctx: ApiRoutesContext) {
       sendJson({ error: message }, status);
     };
 
-    const readBody: ReadBody = () => collectBody(req);
+    const readBody: ReadBody = () =>
+      collectRequestBody(req, ctx.apiBodyLimit ?? DEFAULT_API_BODY_LIMIT_BYTES);
 
     const url = req.url || "/";
 
-    // --- GET /api/arts ---
-    if (url === "/arts" && req.method === "GET") {
-      sendJson(Array.from(ctx.artFiles.values()));
-      return;
-    }
+    try {
+      const requestError = validateDevApiRequest(req, ctx.devSessionToken);
+      if (requestError) {
+        sendError(requestError.message, requestError.status);
+        return;
+      }
 
-    // --- Token routes (delegated to api-tokens.ts) ---
-    if (url === "/tokens/usage" && req.method === "GET") {
-      await handleTokensUsage(ctx, sendJson);
-      return;
-    }
-    if (url === "/tokens" && req.method === "GET") {
-      await handleTokensGet(ctx, sendJson);
-      return;
-    }
-    if (url === "/tokens" && req.method === "POST") {
-      await handleTokensCreate(ctx, readBody, sendJson, sendError);
-      return;
-    }
-    if (url === "/tokens" && req.method === "PUT") {
-      await handleTokensUpdate(ctx, readBody, sendJson, sendError);
-      return;
-    }
-    if (url === "/tokens" && req.method === "DELETE") {
-      await handleTokensDelete(ctx, readBody, sendJson, sendError);
-      return;
-    }
+      // --- GET /api/arts ---
+      if (url === "/arts" && req.method === "GET") {
+        sendJson(Array.from(ctx.artFiles.values()));
+        return;
+      }
 
-    // --- PUT /api/arts/:path/source (update art source) ---
-    if (url?.startsWith("/arts/") && req.method === "PUT") {
-      const rest = url.slice(6);
-      const sourceMatch = rest.match(/^(.+)\/source$/);
-      if (sourceMatch) {
-        const artPath = decodeURIComponent(sourceMatch[1]);
-        const art = ctx.artFiles.get(artPath);
-        if (!art) {
-          sendError("Art not found", 404);
-          return;
-        }
+      // --- Token routes (delegated to api-tokens.ts) ---
+      if (url === "/tokens/usage" && req.method === "GET") {
+        await handleTokensUsage(ctx, sendJson);
+        return;
+      }
+      if (url === "/tokens" && req.method === "GET") {
+        await handleTokensGet(ctx, sendJson);
+        return;
+      }
+      if (url === "/tokens" && req.method === "POST") {
+        await handleTokensCreate(ctx, readBody, sendJson, sendError);
+        return;
+      }
+      if (url === "/tokens" && req.method === "PUT") {
+        await handleTokensUpdate(ctx, readBody, sendJson, sendError);
+        return;
+      }
+      if (url === "/tokens" && req.method === "DELETE") {
+        await handleTokensDelete(ctx, readBody, sendJson, sendError);
+        return;
+      }
 
-        const body = await collectBody(req);
-        try {
+      // --- PUT /api/arts/:path/source (update art source) ---
+      if (url?.startsWith("/arts/") && req.method === "PUT") {
+        const rest = url.slice(6);
+        const sourceMatch = rest.match(/^(.+)\/source$/);
+        if (sourceMatch) {
+          const artPath = decodeURIComponent(sourceMatch[1]);
+          const art = ctx.artFiles.get(artPath);
+          if (!art) {
+            sendError("Art not found", 404);
+            return;
+          }
+
+          const safeArtPath = resolveInside(ctx.config.root, artPath, "art path");
+          const body = await readBody();
           const { source } = JSON.parse(body) as { source: string };
           if (typeof source !== "string") {
             sendError("Missing required field: source", 400);
             return;
           }
-          await fs.promises.writeFile(artPath, source, "utf-8");
-          await ctx.processArtFile(artPath);
+          await fs.promises.writeFile(safeArtPath, source, "utf-8");
+          await ctx.processArtFile(safeArtPath);
           sendJson({ success: true });
-        } catch (e) {
-          sendError(e instanceof Error ? e.message : String(e));
+          return;
+        }
+        next();
+        return;
+      }
+
+      // --- GET /api/arts/:path/... sub-routes ---
+      if (url?.startsWith("/arts/") && req.method === "GET") {
+        const rest = url.slice(6);
+
+        const sourceMatch = rest.match(/^(.+)\/source$/);
+        const paletteMatch = rest.match(/^(.+)\/palette$/);
+        const analysisMatch = rest.match(/^(.+)\/analysis$/);
+        const docsMatch = rest.match(/^(.+)\/docs$/);
+        const a11yMatch = rest.match(/^(.+)\/variants\/([^/]+)\/a11y$/);
+
+        if (sourceMatch) {
+          await handleArtSource(ctx, sourceMatch, sendJson, sendError);
+          return;
+        }
+
+        if (paletteMatch) {
+          await handleArtPalette(ctx, paletteMatch, sendJson, sendError);
+          return;
+        }
+
+        if (analysisMatch) {
+          await handleArtAnalysis(ctx, analysisMatch, sendJson, sendError);
+          return;
+        }
+
+        if (docsMatch) {
+          await handleArtDocs(ctx, docsMatch, sendJson, sendError);
+          return;
+        }
+
+        if (a11yMatch) {
+          handleArtA11y(ctx, a11yMatch, sendJson, sendError);
+          return;
+        }
+
+        // GET /api/arts/:path (no sub-resource)
+        const artPath = decodeURIComponent(rest);
+        const art = ctx.artFiles.get(artPath);
+        if (art) {
+          sendJson(art);
+        } else {
+          sendError("Art not found", 404);
         }
         return;
       }
+
+      // --- POST routes (delegated to post-handlers.ts) ---
+      if (req.method === "POST") {
+        const body = await readBody();
+
+        if (url === "/preview-with-props") {
+          handlePreviewWithProps(ctx, body, res, sendJson, sendError);
+          return;
+        }
+
+        if (url === "/generate") {
+          await handleGenerate(ctx, body, sendJson, sendError);
+          return;
+        }
+
+        if (url === "/run-vrt") {
+          await handleRunVrt(ctx, body, sendJson, sendError);
+          return;
+        }
+      }
+
       next();
-      return;
+    } catch (e) {
+      if (e instanceof HttpError) {
+        sendError(e.message, e.status);
+        return;
+      }
+      sendError(e instanceof Error ? e.message : String(e));
     }
-
-    // --- GET /api/arts/:path/... sub-routes ---
-    if (url?.startsWith("/arts/") && req.method === "GET") {
-      const rest = url.slice(6);
-
-      const sourceMatch = rest.match(/^(.+)\/source$/);
-      const paletteMatch = rest.match(/^(.+)\/palette$/);
-      const analysisMatch = rest.match(/^(.+)\/analysis$/);
-      const docsMatch = rest.match(/^(.+)\/docs$/);
-      const a11yMatch = rest.match(/^(.+)\/variants\/([^/]+)\/a11y$/);
-
-      if (sourceMatch) {
-        await handleArtSource(ctx, sourceMatch, sendJson, sendError);
-        return;
-      }
-
-      if (paletteMatch) {
-        await handleArtPalette(ctx, paletteMatch, sendJson, sendError);
-        return;
-      }
-
-      if (analysisMatch) {
-        await handleArtAnalysis(ctx, analysisMatch, sendJson, sendError);
-        return;
-      }
-
-      if (docsMatch) {
-        await handleArtDocs(ctx, docsMatch, sendJson, sendError);
-        return;
-      }
-
-      if (a11yMatch) {
-        handleArtA11y(ctx, a11yMatch, sendJson, sendError);
-        return;
-      }
-
-      // GET /api/arts/:path (no sub-resource)
-      const artPath = decodeURIComponent(rest);
-      const art = ctx.artFiles.get(artPath);
-      if (art) {
-        sendJson(art);
-      } else {
-        sendError("Art not found", 404);
-      }
-      return;
-    }
-
-    // --- POST routes (delegated to post-handlers.ts) ---
-    if (req.method === "POST") {
-      const body = await collectBody(req);
-
-      if (url === "/preview-with-props") {
-        handlePreviewWithProps(ctx, body, res, sendJson, sendError);
-        return;
-      }
-
-      if (url === "/generate") {
-        await handleGenerate(body, sendJson, sendError);
-        return;
-      }
-
-      if (url === "/run-vrt") {
-        await handleRunVrt(ctx, body, sendJson, sendError);
-        return;
-      }
-    }
-
-    next();
   };
 }

--- a/npm/vite-plugin-musea/src/api-routes/post-handlers.ts
+++ b/npm/vite-plugin-musea/src/api-routes/post-handlers.ts
@@ -10,6 +10,7 @@ import path from "node:path";
 
 import type { ApiRoutesContext, SendJson, SendError } from "./index.js";
 import { generatePreviewModuleWithProps } from "../preview/index.js";
+import { HttpError, resolveInside } from "../security.js";
 import { toPascalCase } from "../utils.js";
 
 /** POST /api/preview-with-props */
@@ -46,20 +47,30 @@ export function handlePreviewWithProps(
     res.setHeader("Content-Type", "application/javascript");
     res.end(moduleCode);
   } catch (e) {
+    if (e instanceof HttpError) {
+      sendError(e.message, e.status);
+      return;
+    }
     sendError(e instanceof Error ? e.message : String(e));
   }
 }
 
 /** POST /api/generate */
 export async function handleGenerate(
+  ctx: ApiRoutesContext,
   body: string,
   sendJson: SendJson,
   sendError: SendError,
 ): Promise<void> {
   try {
     const { componentPath: reqComponentPath, options: autogenOptions } = JSON.parse(body);
+    if (typeof reqComponentPath !== "string") {
+      sendError("Missing required field: componentPath", 400);
+      return;
+    }
     const { generateArtFile: genArt } = await import("../autogen/index.js");
-    const result = await genArt(reqComponentPath, autogenOptions);
+    const componentPath = resolveInside(ctx.config.root, reqComponentPath, "componentPath");
+    const result = await genArt(componentPath, autogenOptions);
     sendJson({
       generated: true,
       componentName: result.componentName,
@@ -67,6 +78,10 @@ export async function handleGenerate(
       artFileContent: result.artFileContent,
     });
   } catch (e) {
+    if (e instanceof HttpError) {
+      sendError(e.message, e.status);
+      return;
+    }
     sendError(e instanceof Error ? e.message : String(e));
   }
 }

--- a/npm/vite-plugin-musea/src/api-tokens.ts
+++ b/npm/vite-plugin-musea/src/api-tokens.ts
@@ -9,9 +9,8 @@
  * - DELETE /tokens    -- delete a token
  */
 
-import path from "node:path";
-
 import type { ApiRoutesContext, SendJson, SendError, ReadBody } from "./api-routes/index.js";
+import { HttpError, resolveInside } from "./security.js";
 import {
   parseTokens,
   buildTokenMap,
@@ -27,6 +26,24 @@ import {
   type TokenUsageMap,
 } from "./style-dictionary.js";
 
+function resolveTokensPath(ctx: ApiRoutesContext): string {
+  return resolveInside(ctx.config.root, ctx.tokensPath!, "tokensPath");
+}
+
+function sendTokenMutationError(e: unknown, sendError: SendError): void {
+  if (e instanceof HttpError) {
+    sendError(e.message, e.status);
+    return;
+  }
+
+  if (e instanceof Error && /token path/i.test(e.message)) {
+    sendError(e.message, 400);
+    return;
+  }
+
+  sendError(e instanceof Error ? e.message : String(e));
+}
+
 /** GET /api/tokens/usage */
 export async function handleTokensUsage(ctx: ApiRoutesContext, sendJson: SendJson): Promise<void> {
   if (!ctx.tokensPath) {
@@ -35,7 +52,7 @@ export async function handleTokensUsage(ctx: ApiRoutesContext, sendJson: SendJso
   }
 
   try {
-    const absoluteTokensPath = path.resolve(ctx.config.root, ctx.tokensPath);
+    const absoluteTokensPath = resolveTokensPath(ctx);
     const categories = await parseTokens(absoluteTokensPath);
     const tokenMap = buildTokenMap(categories);
     resolveReferences(categories, tokenMap);
@@ -65,7 +82,7 @@ export async function handleTokensGet(ctx: ApiRoutesContext, sendJson: SendJson)
   }
 
   try {
-    const absoluteTokensPath = path.resolve(ctx.config.root, ctx.tokensPath);
+    const absoluteTokensPath = resolveTokensPath(ctx);
     const categories = await parseTokens(absoluteTokensPath);
     const tokenMap = buildTokenMap(categories);
     resolveReferences(categories, tokenMap);
@@ -114,7 +131,7 @@ export async function handleTokensCreate(
       sendError("Missing required fields: path, token.value", 400);
       return;
     }
-    const absoluteTokensPath = path.resolve(ctx.config.root, ctx.tokensPath!);
+    const absoluteTokensPath = resolveTokensPath(ctx);
     const rawData = await readRawTokenFile(absoluteTokensPath);
 
     const currentCategories = await parseTokens(absoluteTokensPath);
@@ -143,7 +160,7 @@ export async function handleTokensCreate(
     const resolvedTokenMap = buildTokenMap(categories);
     sendJson({ categories, tokenMap: resolvedTokenMap }, 201);
   } catch (e) {
-    sendError(e instanceof Error ? e.message : String(e));
+    sendTokenMutationError(e, sendError);
   }
 }
 
@@ -169,7 +186,7 @@ export async function handleTokensUpdate(
       sendError("Missing required fields: path, token.value", 400);
       return;
     }
-    const absoluteTokensPath = path.resolve(ctx.config.root, ctx.tokensPath!);
+    const absoluteTokensPath = resolveTokensPath(ctx);
 
     if (token.$reference) {
       const currentCategories = await parseTokens(absoluteTokensPath);
@@ -193,7 +210,7 @@ export async function handleTokensUpdate(
     const resolvedTokenMap = buildTokenMap(categories);
     sendJson({ categories, tokenMap: resolvedTokenMap });
   } catch (e) {
-    sendError(e instanceof Error ? e.message : String(e));
+    sendTokenMutationError(e, sendError);
   }
 }
 
@@ -216,7 +233,7 @@ export async function handleTokensDelete(
       sendError("Missing required field: path", 400);
       return;
     }
-    const absoluteTokensPath = path.resolve(ctx.config.root, ctx.tokensPath!);
+    const absoluteTokensPath = resolveTokensPath(ctx);
 
     const currentCategories = await parseTokens(absoluteTokensPath);
     const currentMap = buildTokenMap(currentCategories);
@@ -240,6 +257,6 @@ export async function handleTokensDelete(
       dependentsWarning: dependents.length > 0 ? dependents : undefined,
     });
   } catch (e) {
-    sendError(e instanceof Error ? e.message : String(e));
+    sendTokenMutationError(e, sendError);
   }
 }

--- a/npm/vite-plugin-musea/src/gallery/index.ts
+++ b/npm/vite-plugin-musea/src/gallery/index.ts
@@ -7,16 +7,18 @@
 
 import { generateGalleryStyles } from "./styles.js";
 import { generateGalleryBody, generateGalleryScript } from "./template.js";
+import { serializeScriptValue } from "../security.js";
 
 /**
  * Generate the inline gallery HTML page.
  */
 export function generateGalleryHtml(
   basePath: string,
+  devSessionToken: string,
   themeConfig?: { default: string; custom?: Record<string, unknown> },
 ): string {
   const themeScript = themeConfig
-    ? `window.__MUSEA_THEME_CONFIG__=${JSON.stringify(themeConfig)};`
+    ? `window.__MUSEA_THEME_CONFIG__=${serializeScriptValue(themeConfig)};`
     : "";
   return `<!DOCTYPE html>
 <html lang="en">
@@ -24,7 +26,7 @@ export function generateGalleryHtml(
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Musea - Component Gallery</title>
-  <script>window.__MUSEA_BASE_PATH__='${basePath}';${themeScript}${"<"}/script>
+  <script>window.__MUSEA_BASE_PATH__=${serializeScriptValue(basePath)};window.__MUSEA_SESSION_TOKEN__=${serializeScriptValue(devSessionToken)};${themeScript}${"<"}/script>
   <style>${generateGalleryStyles()}
   </style>
 </head>
@@ -41,7 +43,7 @@ export function generateGalleryHtml(
  */
 export function generateGalleryModule(basePath: string): string {
   return `
-export const basePath = '${basePath}';
+export const basePath = ${serializeScriptValue(basePath)};
 export async function loadArts() {
   const res = await fetch(basePath + '/api/arts');
   return res.json();

--- a/npm/vite-plugin-musea/src/gallery/template.ts
+++ b/npm/vite-plugin-musea/src/gallery/template.ts
@@ -4,6 +4,8 @@
  * Extracted from gallery.ts to keep file sizes manageable.
  */
 
+import { serializeScriptValue } from "../security.js";
+
 /**
  * Generate the gallery HTML body (header, sidebar, content, and inline script).
  */
@@ -68,7 +70,7 @@ export function generateGalleryBody(basePath: string): string {
  */
 export function generateGalleryScript(basePath: string): string {
   return `
-    const basePath = '${basePath}';
+    const basePath = ${serializeScriptValue(basePath)};
     let arts = [];
     let selectedArt = null;
     let searchQuery = '';

--- a/npm/vite-plugin-musea/src/plugin/index.ts
+++ b/npm/vite-plugin-musea/src/plugin/index.ts
@@ -31,6 +31,7 @@ import {
 } from "../utils.js";
 import { registerMiddleware } from "../server-middleware.js";
 import { createApiMiddleware } from "../api-routes/index.js";
+import { createDevSessionToken } from "../security.js";
 import {
   createResolveId,
   createLoad,
@@ -115,6 +116,7 @@ export function musea(options: MuseaOptions = {}): Plugin[] {
   const themeConfig = buildThemeConfig(options.theme);
   const previewCss = options.previewCss ?? [];
   const previewSetup = options.previewSetup;
+  const devSessionToken = createDevSessionToken();
 
   let config: ResolvedConfig;
   let server: ViteDevServer | null = null;
@@ -203,6 +205,7 @@ export function musea(options: MuseaOptions = {}): Plugin[] {
       // Register gallery SPA, preview, and art module middleware
       registerMiddleware(devServer, {
         basePath,
+        devSessionToken,
         themeConfig,
         artFiles,
         resolvedPreviewCss,
@@ -219,6 +222,7 @@ export function musea(options: MuseaOptions = {}): Plugin[] {
           basePath,
           resolvedPreviewCss,
           resolvedPreviewSetup,
+          devSessionToken,
           processArtFile,
           getDevServerPort: () => devServer.config.server.port || 5173,
         }),

--- a/npm/vite-plugin-musea/src/preview/index.ts
+++ b/npm/vite-plugin-musea/src/preview/index.ts
@@ -58,6 +58,30 @@ function ensureArtStyles(styles) {
   }
 }
 
+function renderError(title, error) {
+  container.textContent = '';
+  const root = document.createElement('div');
+  root.className = 'musea-error';
+
+  const titleEl = document.createElement('div');
+  titleEl.className = 'musea-error-title';
+  titleEl.textContent = title;
+  root.appendChild(titleEl);
+
+  const messageEl = document.createElement('div');
+  messageEl.textContent = error instanceof Error ? error.message : String(error);
+  root.appendChild(messageEl);
+
+  const stack = error instanceof Error ? error.stack : '';
+  if (stack) {
+    const stackEl = document.createElement('pre');
+    stackEl.textContent = stack;
+    root.appendChild(stackEl);
+  }
+
+  container.appendChild(root);
+}
+
 window.__museaSetProps = (props) => {
   // Clear old keys
   for (const key of Object.keys(propsOverride)) {
@@ -113,13 +137,7 @@ async function mount() {
     };
   } catch (error) {
     console.error('[musea-preview] Failed to mount:', error);
-    container.innerHTML = \`
-      <div class="musea-error">
-        <div class="musea-error-title">Failed to render component</div>
-        <div>\${error.message}</div>
-        <pre>\${error.stack || ''}</pre>
-      </div>
-    \`;
+    renderError('Failed to render component', error);
   }
 }
 
@@ -132,7 +150,7 @@ async function remountWithProps(Component) {
       return () => {
         const slotFns = {};
         for (const [name, content] of Object.entries(slotsOverride)) {
-          if (content) slotFns[name] = () => h('span', { innerHTML: content });
+          if (content) slotFns[name] = () => h('span', String(content));
         }
         return h(Component, { ...propsOverride }, slotFns);
       };
@@ -195,6 +213,23 @@ function ensureArtStyles(styles) {
   }
 }
 
+function renderError(title, error) {
+  container.textContent = '';
+  const root = document.createElement('div');
+  root.className = 'musea-error';
+
+  const titleEl = document.createElement('div');
+  titleEl.className = 'musea-error-title';
+  titleEl.textContent = title;
+  root.appendChild(titleEl);
+
+  const messageEl = document.createElement('div');
+  messageEl.textContent = error instanceof Error ? error.message : String(error);
+  root.appendChild(messageEl);
+
+  container.appendChild(root);
+}
+
 async function mount() {
   try {
     const VariantComponent = artModule['${variantComponentName}'];
@@ -218,7 +253,7 @@ async function mount() {
     __museaInitAddons(container, '${escapedVariantName}', ${actionEvents});
   } catch (error) {
     console.error('[musea-preview] Failed to mount:', error);
-    container.innerHTML = '<div class="musea-error"><div class="musea-error-title">Failed to render</div><div>' + error.message + '</div></div>';
+    renderError('Failed to render', error);
   }
 }
 

--- a/npm/vite-plugin-musea/src/security.test.ts
+++ b/npm/vite-plugin-musea/src/security.test.ts
@@ -1,0 +1,86 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import type { IncomingMessage } from "node:http";
+import path from "node:path";
+
+import {
+  HttpError,
+  resolveInside,
+  resolveUrlPathInside,
+  serializeScriptValue,
+  validateDevApiRequest,
+} from "./security.ts";
+
+function request(method: string, headers: IncomingMessage["headers"]): IncomingMessage {
+  return { method, headers } as IncomingMessage;
+}
+
+void test("resolveInside keeps filesystem reads under the allowed directory", () => {
+  const root = path.resolve("/tmp/musea-root");
+
+  assert.equal(resolveInside(root, "src/Button.vue"), path.join(root, "src/Button.vue"));
+  assert.throws(() => resolveInside(root, "../outside.txt"), HttpError);
+  assert.throws(() => resolveUrlPathInside(root, "/assets/../../outside.txt"), HttpError);
+});
+
+void test("validateDevApiRequest requires same-origin JSON mutations with the session token", () => {
+  const token = "session-token";
+
+  assert.equal(
+    validateDevApiRequest(
+      request("PUT", {
+        host: "localhost:5173",
+        origin: "http://localhost:5173",
+        "content-type": "application/json",
+        "x-musea-session": token,
+      }),
+      token,
+    ),
+    null,
+  );
+
+  assert.equal(
+    validateDevApiRequest(
+      request("PUT", {
+        host: "localhost:5173",
+        origin: "http://evil.test",
+        "content-type": "application/json",
+        "x-musea-session": token,
+      }),
+      token,
+    )?.status,
+    403,
+  );
+
+  assert.equal(
+    validateDevApiRequest(
+      request("POST", {
+        host: "localhost:5173",
+        origin: "http://localhost:5173",
+        "content-type": "text/plain",
+        "x-musea-session": token,
+      }),
+      token,
+    )?.status,
+    415,
+  );
+
+  assert.equal(
+    validateDevApiRequest(
+      request("DELETE", {
+        host: "localhost:5173",
+        origin: "http://localhost:5173",
+        "content-type": "application/json",
+      }),
+      token,
+    )?.status,
+    403,
+  );
+});
+
+void test("serializeScriptValue cannot close the surrounding script tag", () => {
+  assert.equal(
+    serializeScriptValue("</script><script>alert(1)</script>"),
+    `"\\u003C/script\\u003E\\u003Cscript\\u003Ealert(1)\\u003C/script\\u003E"`,
+  );
+});

--- a/npm/vite-plugin-musea/src/security.ts
+++ b/npm/vite-plugin-musea/src/security.ts
@@ -1,0 +1,195 @@
+import { randomBytes, timingSafeEqual } from "node:crypto";
+import type { IncomingMessage } from "node:http";
+import path from "node:path";
+
+export const DEFAULT_API_BODY_LIMIT_BYTES = 1024 * 1024;
+
+export class HttpError extends Error {
+  readonly status: number;
+
+  constructor(message: string, status: number) {
+    super(message);
+    this.name = "HttpError";
+    this.status = status;
+  }
+}
+
+export function createDevSessionToken(): string {
+  return randomBytes(32).toString("base64url");
+}
+
+export function isPathInside(parentDir: string, candidatePath: string): boolean {
+  const parent = path.resolve(parentDir);
+  const candidate = path.resolve(candidatePath);
+  const relative = path.relative(parent, candidate);
+  return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+}
+
+export function resolveInside(parentDir: string, candidatePath: string, label = "path"): string {
+  if (candidatePath.includes("\0")) {
+    throw new HttpError(`${label} contains an invalid character`, 400);
+  }
+
+  const parent = path.resolve(parentDir);
+  const resolved = path.isAbsolute(candidatePath)
+    ? path.resolve(candidatePath)
+    : path.resolve(parent, candidatePath);
+
+  if (!isPathInside(parent, resolved)) {
+    throw new HttpError(`${label} escapes the allowed directory`, 400);
+  }
+
+  return resolved;
+}
+
+export function resolveUrlPathInside(
+  parentDir: string,
+  requestUrl: string,
+  label = "path",
+): string {
+  const rawPath = requestUrl.split(/[?#]/, 1)[0] || "/";
+  let pathname: string;
+  try {
+    pathname = decodeURIComponent(rawPath);
+  } catch {
+    throw new HttpError(`${label} is not valid URL encoding`, 400);
+  }
+
+  pathname = pathname.replaceAll("\\", "/");
+  if (pathname.split("/").includes("..")) {
+    throw new HttpError(`${label} must not contain parent directory segments`, 400);
+  }
+
+  const relativePath = `.${pathname}`;
+  return resolveInside(parentDir, relativePath, label);
+}
+
+export function collectRequestBody(
+  req: IncomingMessage,
+  limit = DEFAULT_API_BODY_LIMIT_BYTES,
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let body = "";
+    let size = 0;
+    let completed = false;
+
+    req.on("data", (chunk: Buffer | string) => {
+      if (completed) return;
+
+      const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+      size += buffer.byteLength;
+      if (size > limit) {
+        completed = true;
+        reject(new HttpError(`Request body exceeds ${limit} bytes`, 413));
+        return;
+      }
+
+      body += buffer.toString("utf-8");
+    });
+
+    req.on("end", () => {
+      if (!completed) {
+        completed = true;
+        resolve(body);
+      }
+    });
+
+    req.on("error", (error) => {
+      if (!completed) {
+        completed = true;
+        reject(error);
+      }
+    });
+  });
+}
+
+export function validateDevApiRequest(
+  req: IncomingMessage,
+  sessionToken: string,
+): HttpError | null {
+  const originError = validateOrigin(req);
+  if (originError) return originError;
+
+  if (!isUnsafeMethod(req.method)) {
+    return null;
+  }
+
+  if (!hasValidSessionToken(req, sessionToken)) {
+    return new HttpError("Invalid Musea dev session token", 403);
+  }
+
+  if (!isJsonRequest(req)) {
+    return new HttpError("Content-Type must be application/json", 415);
+  }
+
+  return null;
+}
+
+export function serializeScriptValue(value: unknown): string {
+  return (JSON.stringify(value) ?? "undefined").replace(/[<>&\u2028\u2029]/g, (char) => {
+    switch (char) {
+      case "<":
+        return "\\u003C";
+      case ">":
+        return "\\u003E";
+      case "&":
+        return "\\u0026";
+      case "\u2028":
+        return "\\u2028";
+      case "\u2029":
+        return "\\u2029";
+      default:
+        return char;
+    }
+  });
+}
+
+function isUnsafeMethod(method: string | undefined): boolean {
+  return method === "POST" || method === "PUT" || method === "PATCH" || method === "DELETE";
+}
+
+function isJsonRequest(req: IncomingMessage): boolean {
+  const contentType = getHeader(req, "content-type");
+  return contentType?.split(";")[0]?.trim().toLowerCase() === "application/json";
+}
+
+function validateOrigin(req: IncomingMessage): HttpError | null {
+  const secFetchSite = getHeader(req, "sec-fetch-site");
+  if (secFetchSite === "cross-site") {
+    return new HttpError("Cross-origin Musea API requests are not allowed", 403);
+  }
+
+  const origin = getHeader(req, "origin");
+  if (!origin) return null;
+
+  const host = getHeader(req, "host");
+  if (!host) {
+    return new HttpError("Missing Host header", 400);
+  }
+
+  try {
+    const originUrl = new URL(origin);
+    if (originUrl.host !== host) {
+      return new HttpError("Cross-origin Musea API requests are not allowed", 403);
+    }
+  } catch {
+    return new HttpError("Invalid Origin header", 400);
+  }
+
+  return null;
+}
+
+function hasValidSessionToken(req: IncomingMessage, expectedToken: string): boolean {
+  const actualToken = getHeader(req, "x-musea-session");
+  if (!actualToken) return false;
+
+  const actual = Buffer.from(actualToken);
+  const expected = Buffer.from(expectedToken);
+  return actual.length === expected.length && timingSafeEqual(actual, expected);
+}
+
+function getHeader(req: IncomingMessage, name: string): string | undefined {
+  const value = req.headers[name];
+  if (Array.isArray(value)) return value[0];
+  return value;
+}

--- a/npm/vite-plugin-musea/src/server-middleware.ts
+++ b/npm/vite-plugin-musea/src/server-middleware.ts
@@ -16,6 +16,7 @@ import type { ArtFileInfo } from "./types/index.js";
 import { generateGalleryHtml } from "./gallery/index.js";
 import { generatePreviewModule, generatePreviewHtml } from "./preview/index.js";
 import { generateArtModule } from "./art-module.js";
+import { HttpError, resolveUrlPathInside, serializeScriptValue } from "./security.js";
 import { toPascalCase } from "./utils.js";
 
 const moduleDir = path.dirname(fileURLToPath(import.meta.url));
@@ -32,10 +33,22 @@ function toViteFsPath(filePath: string): string {
   return encodeURI(`/@fs${filePath.split(path.sep).join("/")}`);
 }
 
+function generateDevGlobalsScript(
+  basePath: string,
+  devSessionToken: string,
+  themeConfig?: { default: string; custom?: Record<string, unknown> },
+): string {
+  const themeScript = themeConfig
+    ? `window.__MUSEA_THEME_CONFIG__=${serializeScriptValue(themeConfig)};`
+    : "";
+  return `window.__MUSEA_BASE_PATH__=${serializeScriptValue(basePath)};window.__MUSEA_SESSION_TOKEN__=${serializeScriptValue(devSessionToken)};${themeScript}`;
+}
+
 async function tryLoadSourceGalleryHtml(
   devServer: ViteDevServer,
   url: string,
   basePath: string,
+  devSessionToken: string,
   themeConfig?: { default: string; custom?: Record<string, unknown> },
 ): Promise<string | null> {
   const gallerySourceDir = resolveGallerySourceDir();
@@ -48,15 +61,12 @@ async function tryLoadSourceGalleryHtml(
   }
 
   const sourceEntryPath = toViteFsPath(path.join(gallerySourceDir, "main.ts"));
-  const themeScript = themeConfig
-    ? `window.__MUSEA_THEME_CONFIG__=${JSON.stringify(themeConfig)};`
-    : "";
 
   let html = await fs.promises.readFile(indexHtmlPath, "utf-8");
   html = html.replace('src="./main.ts"', `src="${sourceEntryPath}"`);
   html = html.replace(
     "</head>",
-    `<script>window.__MUSEA_BASE_PATH__='${basePath}';${themeScript}</script></head>`,
+    `<script>${generateDevGlobalsScript(basePath, devSessionToken, themeConfig)}</script></head>`,
   );
 
   return devServer.transformIndexHtml(url, html);
@@ -65,6 +75,7 @@ async function tryLoadSourceGalleryHtml(
 /** Dependencies injected from the plugin closure. */
 export interface MiddlewareContext {
   basePath: string;
+  devSessionToken: string;
   themeConfig: { default: string; custom?: Record<string, unknown> } | undefined;
   artFiles: Map<string, ArtFileInfo>;
   resolvedPreviewCss: string[];
@@ -83,7 +94,7 @@ export interface MiddlewareContext {
  * - Art module route
  */
 export function registerMiddleware(devServer: ViteDevServer, ctx: MiddlewareContext): void {
-  const { basePath, themeConfig, artFiles } = ctx;
+  const { basePath, devSessionToken, themeConfig, artFiles } = ctx;
 
   // --- Gallery SPA route ---
   devServer.middlewares.use(basePath, async (req, res, next) => {
@@ -102,25 +113,28 @@ export function registerMiddleware(devServer: ViteDevServer, ctx: MiddlewareCont
       try {
         await fs.promises.access(indexHtmlPath);
         let html = await fs.promises.readFile(indexHtmlPath, "utf-8");
-        const themeScript = themeConfig
-          ? `window.__MUSEA_THEME_CONFIG__=${JSON.stringify(themeConfig)};`
-          : "";
         html = html.replace(
           "</head>",
-          `<script>window.__MUSEA_BASE_PATH__='${basePath}';${themeScript}</script></head>`,
+          `<script>${generateDevGlobalsScript(basePath, devSessionToken, themeConfig)}</script></head>`,
         );
         res.setHeader("Content-Type", "text/html");
         res.end(html);
         return;
       } catch {
-        const sourceHtml = await tryLoadSourceGalleryHtml(devServer, url, basePath, themeConfig);
+        const sourceHtml = await tryLoadSourceGalleryHtml(
+          devServer,
+          url,
+          basePath,
+          devSessionToken,
+          themeConfig,
+        );
         if (sourceHtml) {
           res.setHeader("Content-Type", "text/html");
           res.end(sourceHtml);
           return;
         }
 
-        const html = generateGalleryHtml(basePath, themeConfig);
+        const html = generateGalleryHtml(basePath, devSessionToken, themeConfig);
         res.setHeader("Content-Type", "text/html");
         res.end(html);
         return;
@@ -130,8 +144,8 @@ export function registerMiddleware(devServer: ViteDevServer, ctx: MiddlewareCont
     // Serve gallery static assets (JS, CSS) from built SPA
     if (url.startsWith("/assets/")) {
       const galleryDistDir = resolveGalleryDistDir();
-      const filePath = path.join(galleryDistDir, url);
       try {
+        const filePath = resolveUrlPathInside(galleryDistDir, url, "asset path");
         const stat = await fs.promises.stat(filePath);
         if (stat.isFile()) {
           const content = await fs.promises.readFile(filePath);
@@ -150,7 +164,12 @@ export function registerMiddleware(devServer: ViteDevServer, ctx: MiddlewareCont
           res.end(content);
           return;
         }
-      } catch {
+      } catch (error) {
+        if (error instanceof HttpError) {
+          res.statusCode = error.status;
+          res.end(error.message);
+          return;
+        }
         // File not found, fall through
       }
     }

--- a/npm/vite-plugin-musea/src/tokens.test.ts
+++ b/npm/vite-plugin-musea/src/tokens.test.ts
@@ -4,8 +4,14 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
+import { generateTokensHtml } from "./tokens/generator.ts";
 import { parseTokens } from "./tokens/parser.ts";
-import { buildTokenMap, resolveReferences } from "./tokens/resolver.ts";
+import {
+  buildTokenMap,
+  deleteTokenAtPath,
+  resolveReferences,
+  setTokenAtPath,
+} from "./tokens/resolver.ts";
 
 void test("parseTokens merges token directories into canonical reference paths", async () => {
   const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "musea-tokens-"));
@@ -45,4 +51,33 @@ void test("parseTokens merges token directories into canonical reference paths",
   assert.equal(resolvedTokenMap["color.semantic.surface"]?.$resolvedValue, "#f7f7f7");
 
   await fs.promises.rm(tempDir, { recursive: true, force: true });
+});
+
+void test("token mutations reject prototype-polluting paths", () => {
+  const data: Record<string, unknown> = {};
+
+  assert.throws(() => setTokenAtPath(data, "__proto__.polluted", { value: "yes" }), /not allowed/);
+  assert.throws(() => deleteTokenAtPath(data, "constructor.prototype"), /not allowed/);
+  assert.equal(({} as Record<string, unknown>).polluted, undefined);
+});
+
+void test("generateTokensHtml escapes untrusted token text and filters unsafe color styles", () => {
+  const html = generateTokensHtml([
+    {
+      name: `Colors <img src=x onerror=alert(1)>`,
+      tokens: {
+        [`bad"><script>alert(1)</script>`]: {
+          value: `url(javascript:alert(1)); color:red`,
+          type: "color",
+          description: `<b onclick=alert(1)>owned</b>`,
+        },
+      },
+    },
+  ]);
+
+  assert.match(html, /Colors &lt;img src=x onerror=alert\(1\)&gt;/);
+  assert.match(html, /bad&quot;&gt;&lt;script&gt;alert\(1\)&lt;\/script&gt;/);
+  assert.match(html, /&lt;b onclick=alert\(1\)&gt;owned&lt;\/b&gt;/);
+  assert.doesNotMatch(html, /<script>|<b onclick=|javascript:/);
+  assert.doesNotMatch(html, /color-swatch/);
 });

--- a/npm/vite-plugin-musea/src/tokens/generator.ts
+++ b/npm/vite-plugin-musea/src/tokens/generator.ts
@@ -10,6 +10,22 @@ import path from "node:path";
 
 import type { TokenCategory, StyleDictionaryConfig, StyleDictionaryOutput } from "./parser.js";
 import { parseTokens } from "./parser.js";
+import { escapeHtml } from "../utils.js";
+
+const SAFE_CSS_COLOR_PATTERN = /^(?:#[0-9a-fA-F]{3,8}|(?:rgb|hsl)a?\(\s*[-+.\d,%\s]+\))$/;
+
+function safeCssColor(value: string | number, type?: string): string | null {
+  if (typeof value !== "string") return null;
+
+  const trimmed = value.trim();
+  const looksLikeColor =
+    type === "color" ||
+    trimmed.startsWith("#") ||
+    trimmed.startsWith("rgb") ||
+    trimmed.startsWith("hsl");
+
+  return looksLikeColor && SAFE_CSS_COLOR_PATTERN.test(trimmed) ? trimmed : null;
+}
 
 /**
  * Generate HTML documentation for tokens.
@@ -19,22 +35,17 @@ export function generateTokensHtml(categories: TokenCategory[]): string {
     name: string,
     token: { value: string | number; type?: string; description?: string },
   ): string => {
-    const isColor =
-      typeof token.value === "string" &&
-      (token.value.startsWith("#") ||
-        token.value.startsWith("rgb") ||
-        token.value.startsWith("hsl") ||
-        token.type === "color");
+    const color = safeCssColor(token.value, token.type);
 
     return `
       <div class="token">
         <div class="token-preview">
-          ${isColor ? `<div class="color-swatch" style="background: ${token.value}"></div>` : ""}
+          ${color ? `<div class="color-swatch" style="background: ${color}"></div>` : ""}
         </div>
         <div class="token-info">
-          <div class="token-name">${name}</div>
-          <div class="token-value">${token.value}</div>
-          ${token.description ? `<div class="token-description">${token.description}</div>` : ""}
+          <div class="token-name">${escapeHtml(name)}</div>
+          <div class="token-value">${escapeHtml(String(token.value))}</div>
+          ${token.description ? `<div class="token-description">${escapeHtml(token.description)}</div>` : ""}
         </div>
       </div>
     `;
@@ -42,7 +53,7 @@ export function generateTokensHtml(categories: TokenCategory[]): string {
 
   const renderCategory = (category: TokenCategory, level: number = 2): string => {
     const heading = `h${Math.min(level, 6)}`;
-    let html = `<${heading}>${category.name}</${heading}>`;
+    let html = `<${heading}>${escapeHtml(category.name)}</${heading}>`;
     html += '<div class="tokens-grid">';
 
     for (const [name, token] of Object.entries(category.tokens)) {

--- a/npm/vite-plugin-musea/src/tokens/resolver.ts
+++ b/npm/vite-plugin-musea/src/tokens/resolver.ts
@@ -38,6 +38,21 @@ export type TokenUsageMap = Record<string, TokenUsageEntry[]>;
 
 const REFERENCE_PATTERN = /^\{(.+)\}$/;
 const MAX_RESOLVE_DEPTH = 10;
+const UNSAFE_TOKEN_PATH_SEGMENTS = new Set(["__proto__", "prototype", "constructor"]);
+
+function parseTokenPath(dotPath: string): string[] {
+  const parts = dotPath.split(".");
+  if (parts.length === 0 || parts.some((part) => part.trim() === "")) {
+    throw new Error(`Invalid token path "${dotPath}"`);
+  }
+
+  const unsafeSegment = parts.find((part) => UNSAFE_TOKEN_PATH_SEGMENTS.has(part));
+  if (unsafeSegment) {
+    throw new Error(`Token path segment "${unsafeSegment}" is not allowed`);
+  }
+
+  return parts;
+}
 
 /**
  * Flatten nested categories into a flat map keyed by dot-path.
@@ -145,7 +160,7 @@ export function setTokenAtPath(
   dotPath: string,
   token: Omit<DesignToken, "$resolvedValue">,
 ): void {
-  const parts = dotPath.split(".");
+  const parts = parseTokenPath(dotPath);
   let current: Record<string, unknown> = data;
 
   for (let i = 0; i < parts.length - 1; i++) {
@@ -170,7 +185,7 @@ export function setTokenAtPath(
  * Delete a token at a dot-separated path, cleaning empty parents.
  */
 export function deleteTokenAtPath(data: Record<string, unknown>, dotPath: string): boolean {
-  const parts = dotPath.split(".");
+  const parts = parseTokenPath(dotPath);
   const parents: Array<{ obj: Record<string, unknown>; key: string }> = [];
   let current: Record<string, unknown> = data;
 


### PR DESCRIPTION
## Summary
- reduce workflow token permissions, remove PR snapshot auto-commit, run benchmark commenting from the trusted base checkout, and verify MoonBit installer hashes before execution
- add Musea dev API same-origin checks, session-token protection for mutations, JSON/body-size enforcement, and safe static asset path resolution
- constrain Musea MCP filesystem reads to the project root, reject unsafe token path segments, and escape generated token/preview HTML

## Verification
- `vp run --filter './npm/vite-plugin-musea' check`
- `node --test npm/vite-plugin-musea/src/security.test.ts`
- `vp run --filter './npm/vite-plugin-musea' build`
- `vp run --filter './npm/musea-mcp-server' check`
- `vp run --filter './npm/musea-mcp-server' build`
- `node --test tests/tooling/github-workflows.test.ts`
