### PR TITLE
fix(musea): normalize input rendering and paths

### DIFF
--- a/npm/musea-mcp-server/src/musea.ts
+++ b/npm/musea-mcp-server/src/musea.ts
@@ -93,15 +93,34 @@ function tokenize(query: string): string[] {
 }
 
 function toProjectPath(projectRoot: string, absolutePath: string): string {
-  const root = path.resolve(projectRoot);
-  const resolved = path.resolve(absolutePath);
+  const root = realpathNearest(projectRoot);
+  const resolved = realpathNearest(absolutePath);
   const relativePath = path.relative(root, resolved);
   return isProjectPath(root, resolved) ? relativePath || "." : resolved;
 }
 
+function realpathNearest(targetPath: string): string {
+  let current = path.resolve(targetPath);
+  const missingParts: string[] = [];
+
+  while (true) {
+    try {
+      const real = fs.realpathSync.native(current);
+      return missingParts.length > 0 ? path.join(real, ...missingParts.reverse()) : real;
+    } catch {
+      const parent = path.dirname(current);
+      if (parent === current) {
+        return path.resolve(targetPath);
+      }
+      missingParts.push(path.basename(current));
+      current = parent;
+    }
+  }
+}
+
 export function isProjectPath(projectRoot: string, candidatePath: string): boolean {
-  const root = path.resolve(projectRoot);
-  const candidate = path.resolve(candidatePath);
+  const root = realpathNearest(projectRoot);
+  const candidate = realpathNearest(candidatePath);
   const relativePath = path.relative(root, candidate);
   return relativePath === "" || (!relativePath.startsWith("..") && !path.isAbsolute(relativePath));
 }

--- a/npm/vite-plugin-musea/gallery/components/DocumentationPanel.vue
+++ b/npm/vite-plugin-musea/gallery/components/DocumentationPanel.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ref, computed, watch } from "vue";
-import { Marked } from "marked";
+import { Marked, type Tokens } from "marked";
 import { markedHighlight } from "marked-highlight";
 import hljs from "highlight.js/lib/core";
 import xml from "highlight.js/lib/languages/xml";
@@ -21,13 +21,71 @@ hljs.registerLanguage("css", css);
 hljs.registerLanguage("bash", bash);
 hljs.registerLanguage("sh", bash);
 
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#x27;");
+}
+
+const URL_SCHEME_RE = /^[a-z][a-z\d+.-]*:/i;
+const ALLOWED_URL_PROTOCOLS = new Set(["http:", "https:", "mailto:", "tel:"]);
+
+function cleanUrl(value: string): string | null {
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+
+  if (
+    trimmed.startsWith("#") ||
+    trimmed.startsWith("/") ||
+    trimmed.startsWith("./") ||
+    trimmed.startsWith("../")
+  ) {
+    return trimmed;
+  }
+
+  if (trimmed.startsWith("//")) return null;
+  if (!URL_SCHEME_RE.test(trimmed)) return trimmed;
+
+  try {
+    const url = new URL(trimmed, window.location.href);
+    return ALLOWED_URL_PROTOCOLS.has(url.protocol) ? trimmed : null;
+  } catch {
+    return null;
+  }
+}
+
 const markedInstance = new Marked(
+  {
+    renderer: {
+      html({ text }: Tokens.HTML | Tokens.Tag) {
+        return escapeHtml(text);
+      },
+      link({ href, title, tokens }: Tokens.Link) {
+        const cleanHref = cleanUrl(href);
+        const label = this.parser.parseInline(tokens);
+        if (!cleanHref) return label;
+
+        const titleAttr = title ? ` title="${escapeHtml(title)}"` : "";
+        return `<a href="${escapeHtml(cleanHref)}"${titleAttr} rel="noreferrer">${label}</a>`;
+      },
+      image({ href, title, text }: Tokens.Image) {
+        const cleanHref = cleanUrl(href);
+        if (!cleanHref) return escapeHtml(text);
+
+        const titleAttr = title ? ` title="${escapeHtml(title)}"` : "";
+        return `<img src="${escapeHtml(cleanHref)}" alt="${escapeHtml(text)}"${titleAttr}>`;
+      },
+    },
+  },
   markedHighlight({
     highlight(code: string, lang: string) {
       if (lang && hljs.getLanguage(lang)) {
         return hljs.highlight(code, { language: lang }).value;
       }
-      return code;
+      return escapeHtml(code);
     },
   }),
 );

--- a/npm/vite-plugin-musea/src/api-routes/handler-palette.ts
+++ b/npm/vite-plugin-musea/src/api-routes/handler-palette.ts
@@ -5,9 +5,9 @@
  */
 
 import fs from "node:fs";
-import path from "node:path";
 
 import type { ApiRoutesContext, SendJson, SendError } from "./index.js";
+import { allowedSourceRoots, resolveComponentSourcePath } from "../component-source.js";
 import { loadNative, analyzeSfcFallback } from "../native-loader.js";
 
 /** GET /api/arts/:path/palette */
@@ -59,9 +59,16 @@ export async function handleArtPalette(
 
     // If the native palette returned no controls, try JS-based SFC analysis
     if (palette.controls.length === 0 && art.metadata.component) {
-      const resolvedComponentPath = path.isAbsolute(art.metadata.component)
-        ? art.metadata.component
-        : path.resolve(path.dirname(artPath), art.metadata.component);
+      const resolvedComponentPath = resolveComponentSourcePath(
+        art,
+        artPath,
+        allowedSourceRoots(ctx.config.root, ctx.scanRoots),
+      );
+      if (!resolvedComponentPath) {
+        sendJson(palette);
+        return;
+      }
+
       try {
         const componentSource = await fs.promises.readFile(resolvedComponentPath, "utf-8");
         const analysis = binding.analyzeSfc

--- a/npm/vite-plugin-musea/src/api-routes/handlers.ts
+++ b/npm/vite-plugin-musea/src/api-routes/handlers.ts
@@ -6,9 +6,9 @@
  */
 
 import fs from "node:fs";
-import path from "node:path";
 
 import type { ApiRoutesContext, SendJson, SendError } from "./index.js";
+import { allowedSourceRoots, resolveComponentSourcePath } from "../component-source.js";
 import { loadNative, analyzeSfcFallback } from "../native-loader.js";
 
 export { handleArtPalette } from "./handler-palette.js";
@@ -50,14 +50,11 @@ export async function handleArtAnalysis(
   }
 
   try {
-    const resolvedComponentPath =
-      art.isInline && art.componentPath
-        ? art.componentPath
-        : art.metadata.component
-          ? path.isAbsolute(art.metadata.component)
-            ? art.metadata.component
-            : path.resolve(path.dirname(artPath), art.metadata.component)
-          : null;
+    const resolvedComponentPath = resolveComponentSourcePath(
+      art,
+      artPath,
+      allowedSourceRoots(ctx.config.root, ctx.scanRoots),
+    );
 
     if (resolvedComponentPath) {
       const source = await fs.promises.readFile(resolvedComponentPath, "utf-8");

--- a/npm/vite-plugin-musea/src/api-routes/index.ts
+++ b/npm/vite-plugin-musea/src/api-routes/index.ts
@@ -42,6 +42,7 @@ import {
 export interface ApiRoutesContext {
   config: ResolvedConfig;
   artFiles: Map<string, ArtFileInfo>;
+  scanRoots: string[];
   tokensPath: string | undefined;
   basePath: string;
   resolvedPreviewCss: string[];

--- a/npm/vite-plugin-musea/src/art-module.test.ts
+++ b/npm/vite-plugin-musea/src/art-module.test.ts
@@ -93,3 +93,41 @@ void test("generatePreviewModule injects art-scoped styles from the virtual art 
   assert.match(code, /ensureArtStyles\(artModule\.__styles__\);/);
   assert.match(code, /document\.createElement\('style'\)/);
 });
+
+void test("generated modules quote dynamic specifiers", () => {
+  const art: ArtFileInfo = {
+    path: `/repo/components/MfCard';sideEffect().art.vue`,
+    metadata: {
+      title: "Card",
+      tags: [],
+      status: "ready",
+      component: `./MfCard';sideEffect().vue`,
+    },
+    variants: [
+      {
+        name: `default';sideEffect()`,
+        template: "<Self />",
+        isDefault: true,
+        skipVrt: false,
+      },
+    ],
+    hasScriptSetup: false,
+    hasScript: false,
+    styleCount: 0,
+  };
+
+  const artCode = generateArtModule(art, art.path);
+  const previewCode = generatePreviewModule(art, "Default", art.variants[0].name, [
+    `/repo/theme';sideEffect().css`,
+  ]);
+
+  assert.match(
+    artCode,
+    /import __MuseaComponent from "\/repo\/components\/MfCard';sideEffect\(\)\.vue";/,
+  );
+  assert.match(previewCode, /import "\/repo\/theme';sideEffect\(\)\.css";/);
+  assert.match(
+    previewCode,
+    /import \* as artModule from "virtual:musea-art:\/repo\/components\/MfCard';sideEffect\(\)\.art\.vue";/,
+  );
+});

--- a/npm/vite-plugin-musea/src/art-module.ts
+++ b/npm/vite-plugin-musea/src/art-module.ts
@@ -7,8 +7,9 @@
 
 import path from "node:path";
 
+import { allowedSourceRoots, resolveComponentSourcePath } from "./component-source.js";
 import type { ArtFileInfo } from "./types/index.js";
-import { toPascalCase } from "./utils.js";
+import { escapeHtml, toPascalCase } from "./utils.js";
 
 /**
  * Extract the content of the first <script setup> block from a Vue SFC source.
@@ -38,6 +39,10 @@ function rewriteRelativeImportStatement(statement: string, artDir: string): stri
     (_match, prefix: string, quote: string, specifier: string, suffix: string) =>
       `${prefix}${quote}${resolveRelativeSpecifier(specifier, artDir)}${quote}${suffix}`,
   );
+}
+
+function escapeTemplateLiteral(str: string): string {
+  return str.replace(/\\/g, "\\\\").replace(/`/g, "\\`").replace(/\$/g, "\\$");
 }
 
 function countCharBalance(source: string, openChar: string, closeChar: string): number {
@@ -340,19 +345,42 @@ export function parseScriptSetupForArt(content: string): {
   };
 }
 
-export function generateArtModule(art: ArtFileInfo, filePath: string): string {
+interface GenerateArtModuleOptions {
+  root?: string;
+  scanRoots?: string[];
+}
+
+export function generateArtModule(
+  art: ArtFileInfo,
+  filePath: string,
+  options: GenerateArtModuleOptions = {},
+): string {
   let componentImportPath: string | undefined;
-  let componentName: string | undefined;
+  let componentTagName: string | undefined;
+  const componentBindingName = "__MuseaComponent";
 
   if (art.isInline && art.componentPath) {
     // Inline art: import the host .vue file itself as the component
-    componentImportPath = art.componentPath;
-    componentName = path.basename(art.componentPath, ".vue");
+    componentImportPath = options.root
+      ? (resolveComponentSourcePath(
+          art,
+          filePath,
+          allowedSourceRoots(options.root, options.scanRoots ?? []),
+        ) ?? undefined)
+      : art.componentPath;
+    componentTagName = "MuseaComponent";
   } else if (art.metadata.component) {
     // Traditional .art.vue: resolve component from the component attribute
-    const comp = art.metadata.component;
-    componentImportPath = path.isAbsolute(comp) ? comp : path.resolve(path.dirname(filePath), comp);
-    componentName = path.basename(comp, ".vue");
+    componentImportPath = options.root
+      ? (resolveComponentSourcePath(
+          art,
+          filePath,
+          allowedSourceRoots(options.root, options.scanRoots ?? []),
+        ) ?? undefined)
+      : path.isAbsolute(art.metadata.component)
+        ? art.metadata.component
+        : path.resolve(path.dirname(filePath), art.metadata.component);
+    componentTagName = "MuseaComponent";
   }
 
   // Parse script setup if present
@@ -375,22 +403,15 @@ import { defineComponent, h } from 'vue';
     }
   }
 
-  if (componentImportPath && componentName) {
+  if (componentImportPath && componentTagName) {
     // Only add component import if not already imported by script setup
-    const alreadyImported = scriptSetup?.imports.some((imp) => {
-      // Check against the original relative path and the resolved absolute path
-      if (
-        imp.includes(`from '${componentImportPath}'`) ||
-        imp.includes(`from "${componentImportPath}"`)
-      )
-        return true;
-      // Also check by component name as default import (handles relative vs absolute path mismatch)
-      return new RegExp(`^import\\s+${componentName}[\\s,]`).test(imp.trim());
-    });
+    const alreadyImported = scriptSetup?.imports.some((imp) =>
+      new RegExp(`^import\\s+${componentBindingName}[\\s,]`).test(imp.trim()),
+    );
     if (!alreadyImported) {
-      code += `import ${componentName} from '${componentImportPath}';\n`;
+      code += `import ${componentBindingName} from ${JSON.stringify(componentImportPath)};\n`;
     }
-    code += `export const __component__ = ${componentName};\n`;
+    code += `export const __component__ = ${componentBindingName};\n`;
   }
 
   code += `
@@ -406,35 +427,37 @@ export const __styles__ = ${JSON.stringify(art.styleBlocks ?? [])};
     let template = variant.template;
 
     // Replace <Self> with the actual component name (for inline art)
-    if (componentName) {
+    if (componentTagName) {
       template = template
-        .replace(/<Self/g, `<${componentName}`)
-        .replace(/<\/Self>/g, `</${componentName}>`);
+        .replace(/<Self/g, `<${componentTagName}`)
+        .replace(/<\/Self>/g, `</${componentTagName}>`);
     }
 
     // Escape the template for use in a JS string
-    const escapedTemplate = template
-      .replace(/\\/g, "\\\\")
-      .replace(/`/g, "\\`")
-      .replace(/\$/g, "\\$");
+    const escapedTemplate = escapeTemplateLiteral(template);
+    const escapedVariantName = escapeTemplateLiteral(escapeHtml(variant.name));
 
     // Wrap template with the variant container (no .musea-variant class -- the
     // outer mount container already carries it; duplicating causes double padding)
-    const fullTemplate = `<div data-variant="${variant.name}">${escapedTemplate}</div>`;
+    const fullTemplate = `<div data-variant="${escapedVariantName}">${escapedTemplate}</div>`;
 
     // Collect component names for the `components` option.
     // Runtime-compiled templates use resolveComponent() which checks the
     // `components` option, NOT setup return values.
-    const componentNames = new Set<string>();
-    if (componentName) componentNames.add(componentName);
+    const componentNames = new Map<string, string>();
+    if (componentTagName) componentNames.set(componentTagName, componentBindingName);
     if (scriptSetup) {
       for (const name of scriptSetup.returnNames) {
         // PascalCase names starting with uppercase are likely components
-        if (/^[A-Z]/.test(name)) componentNames.add(name);
+        if (/^[A-Z]/.test(name)) componentNames.set(name, name);
       }
     }
     const components =
-      componentNames.size > 0 ? `  components: { ${[...componentNames].join(", ")} },\n` : "";
+      componentNames.size > 0
+        ? `  components: { ${[...componentNames]
+            .map(([name, value]) => `${JSON.stringify(name)}: ${value}`)
+            .join(", ")} },\n`
+        : "";
 
     const hasSetupBody = scriptSetup?.setupBody.some((line) => line.trim().length > 0) ?? false;
 
@@ -450,7 +473,7 @@ ${scriptSetup.setupBody.map((l) => `    ${l}`).join("\n")}
   template: \`${fullTemplate}\`,
 });
 `;
-    } else if (componentName) {
+    } else if (componentTagName) {
       code += `
 export const ${variantComponentName} = {
   name: '${variantComponentName}',

--- a/npm/vite-plugin-musea/src/component-source.ts
+++ b/npm/vite-plugin-musea/src/component-source.ts
@@ -1,0 +1,25 @@
+import path from "node:path";
+
+import { resolveInsideAny } from "./security.js";
+import type { ArtFileInfo } from "./types/index.js";
+
+export function allowedSourceRoots(root: string, scanRoots: string[] = []): string[] {
+  return [...new Set([root, ...scanRoots].map((sourceRoot) => path.resolve(sourceRoot)))];
+}
+
+export function resolveComponentSourcePath(
+  art: ArtFileInfo,
+  artPath: string,
+  sourceRoots: string[],
+): string | null {
+  const componentPath =
+    art.isInline && art.componentPath
+      ? art.componentPath
+      : art.metadata.component
+        ? path.isAbsolute(art.metadata.component)
+          ? art.metadata.component
+          : path.resolve(path.dirname(artPath), art.metadata.component)
+        : null;
+
+  return componentPath ? resolveInsideAny(sourceRoots, componentPath, "component path") : null;
+}

--- a/npm/vite-plugin-musea/src/gallery/template.ts
+++ b/npm/vite-plugin-musea/src/gallery/template.ts
@@ -107,17 +107,18 @@ export function generateGalleryScript(basePath: string): string {
 
       let html = '';
       for (const [category, items] of Object.entries(categories)) {
+        const escapedCategory = escapeHtml(category);
         html += '<div class="sidebar-section">';
-        html += '<div class="category-header" data-category="' + category + '">';
+        html += '<div class="category-header" data-category="' + escapedCategory + '">';
         html += '<svg class="category-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="m9 18 6-6-6-6"/></svg>';
-        html += '<span>' + category + '</span>';
+        html += '<span>' + escapedCategory + '</span>';
         html += '<span class="category-count">' + items.length + '</span>';
         html += '</div>';
-        html += '<ul class="art-list" data-category="' + category + '">';
+        html += '<ul class="art-list" data-category="' + escapedCategory + '">';
         for (const art of items) {
           const active = selectedArt?.path === art.path ? 'active' : '';
           const variantCount = art.variants?.length || 0;
-          html += '<li class="art-item ' + active + '" data-path="' + art.path + '">';
+          html += '<li class="art-item ' + active + '" data-path="' + escapeHtml(art.path) + '">';
           html += '<span>' + escapeHtml(art.metadata.title) + '</span>';
           html += '<span class="art-variant-count">' + variantCount + ' variant' + (variantCount !== 1 ? 's' : '') + '</span>';
           html += '</li>';
@@ -140,7 +141,7 @@ export function generateGalleryScript(basePath: string): string {
       sidebar.querySelectorAll('.category-header').forEach(header => {
         header.addEventListener('click', () => {
           header.classList.toggle('collapsed');
-          const list = sidebar.querySelector('.art-list[data-category="' + header.dataset.category + '"]');
+          const list = header.parentElement?.querySelector('.art-list');
           if (list) list.style.display = header.classList.contains('collapsed') ? 'none' : 'block';
         });
       });

--- a/npm/vite-plugin-musea/src/plugin/index.ts
+++ b/npm/vite-plugin-musea/src/plugin/index.ts
@@ -135,6 +135,7 @@ export function musea(options: MuseaOptions = {}): Plugin[] {
     resolvedPreviewCss,
     resolvedPreviewSetup,
     getConfigRoot: () => config.root,
+    getScanRoots: () => scanRoots,
     getServer: () => server,
     processArtFile,
   };
@@ -208,6 +209,7 @@ export function musea(options: MuseaOptions = {}): Plugin[] {
         devSessionToken,
         themeConfig,
         artFiles,
+        scanRoots,
         resolvedPreviewCss,
         resolvedPreviewSetup,
       });
@@ -218,6 +220,7 @@ export function musea(options: MuseaOptions = {}): Plugin[] {
         createApiMiddleware({
           config,
           artFiles,
+          scanRoots,
           tokensPath,
           basePath,
           resolvedPreviewCss,

--- a/npm/vite-plugin-musea/src/plugin/virtual.ts
+++ b/npm/vite-plugin-musea/src/plugin/virtual.ts
@@ -33,6 +33,7 @@ export interface VirtualModuleState {
   resolvedPreviewCss: string[];
   resolvedPreviewSetup: string | null;
   getConfigRoot: () => string;
+  getScanRoots: () => string[];
   getServer: () => {
     moduleGraph: { getModulesByFile(id: string): Set<ModuleNode> | undefined };
   } | null;
@@ -112,14 +113,20 @@ export function createLoad(state: VirtualModuleState) {
       const artPath = id.slice("\0musea-art:".length).replace(/\?musea-virtual$/, "");
       const art = state.artFiles.get(artPath);
       if (art) {
-        return generateArtModule(art, artPath);
+        return generateArtModule(art, artPath, {
+          root: state.getConfigRoot(),
+          scanRoots: state.getScanRoots(),
+        });
       }
     }
     if (id.startsWith(VIRTUAL_MUSEA_PREFIX)) {
       const realPath = id.slice(VIRTUAL_MUSEA_PREFIX.length).replace(/\?musea-virtual$/, "");
       const art = state.artFiles.get(realPath);
       if (art) {
-        return generateArtModule(art, realPath);
+        return generateArtModule(art, realPath, {
+          root: state.getConfigRoot(),
+          scanRoots: state.getScanRoots(),
+        });
       }
     }
     return null;

--- a/npm/vite-plugin-musea/src/preview/index.ts
+++ b/npm/vite-plugin-musea/src/preview/index.ts
@@ -6,7 +6,6 @@
  */
 
 import type { ArtFileInfo } from "../types/index.js";
-import { escapeTemplate } from "../utils.js";
 import { MUSEA_ADDONS_INIT_CODE } from "./addons.js";
 
 export { generatePreviewHtml } from "./html.js";
@@ -19,18 +18,25 @@ export function generatePreviewModule(
   previewSetup: string | null = null,
 ): string {
   const artModuleId = `virtual:musea-art:${art.path}`;
-  const escapedVariantName = escapeTemplate(variantName);
-  const cssImportStatements = cssImports.map((cssPath) => `import '${cssPath}';`).join("\n");
-  const setupImport = previewSetup ? `import __museaPreviewSetup from '${previewSetup}';` : "";
+  const artModuleIdLiteral = JSON.stringify(artModuleId);
+  const variantNameLiteral = JSON.stringify(variantName);
+  const variantComponentNameLiteral = JSON.stringify(variantComponentName);
+  const cssImportStatements = cssImports
+    .map((cssPath) => `import ${JSON.stringify(cssPath)};`)
+    .join("\n");
+  const setupImport = previewSetup
+    ? `import __museaPreviewSetup from ${JSON.stringify(previewSetup)};`
+    : "";
   const setupCall = previewSetup ? "await __museaPreviewSetup(app);" : "";
   const actionEvents = JSON.stringify(art.metadata.actionEvents ?? []);
   const artStyleId = `musea-art-styles-${art.path.replace(/[^\w-]+/g, "_")}`;
+  const artStyleIdLiteral = JSON.stringify(artStyleId);
 
   return `
 ${cssImportStatements}
 ${setupImport}
 import { createApp, reactive, h } from 'vue';
-import * as artModule from '${artModuleId}';
+import * as artModule from ${artModuleIdLiteral};
 
 const container = document.getElementById('app');
 
@@ -41,7 +47,7 @@ const propsOverride = reactive({});
 const slotsOverride = reactive({ default: '' });
 
 function ensureArtStyles(styles) {
-  const styleId = '${artStyleId}';
+  const styleId = ${artStyleIdLiteral};
   const existing = document.getElementById(styleId);
 
   if (!Array.isArray(styles) || styles.length === 0) {
@@ -100,11 +106,11 @@ window.__museaSetSlots = (slots) => {
 async function mount() {
   try {
     // Get the specific variant component
-    const VariantComponent = artModule['${variantComponentName}'];
+    const VariantComponent = artModule[${variantComponentNameLiteral}];
     const RawComponent = artModule.__component__;
 
     if (!VariantComponent) {
-      throw new Error('Variant component "${variantComponentName}" not found in art module');
+      throw new Error('Variant component ' + ${variantComponentNameLiteral} + ' not found in art module');
     }
 
     // Create and mount the app
@@ -116,8 +122,8 @@ async function mount() {
     app.mount(container);
     currentApp = app;
 
-    console.log('[musea-preview] Mounted variant: ${escapedVariantName}');
-    __museaInitAddons(container, '${escapedVariantName}', ${actionEvents});
+    console.log('[musea-preview] Mounted variant:', ${variantNameLiteral});
+    __museaInitAddons(container, ${variantNameLiteral}, ${actionEvents});
 
     // Override set-props to remount with raw component + props
     const TargetComponent = RawComponent || VariantComponent;
@@ -176,19 +182,26 @@ export function generatePreviewModuleWithProps(
   previewSetup: string | null = null,
 ): string {
   const artModuleId = `virtual:musea-art:${art.path}`;
-  const escapedVariantName = escapeTemplate(variantName);
+  const artModuleIdLiteral = JSON.stringify(artModuleId);
+  const variantNameLiteral = JSON.stringify(variantName);
+  const variantComponentNameLiteral = JSON.stringify(variantComponentName);
   const propsJson = JSON.stringify(propsOverride);
-  const cssImportStatements = cssImports.map((cssPath) => `import '${cssPath}';`).join("\n");
-  const setupImport = previewSetup ? `import __museaPreviewSetup from '${previewSetup}';` : "";
+  const cssImportStatements = cssImports
+    .map((cssPath) => `import ${JSON.stringify(cssPath)};`)
+    .join("\n");
+  const setupImport = previewSetup
+    ? `import __museaPreviewSetup from ${JSON.stringify(previewSetup)};`
+    : "";
   const setupCall = previewSetup ? "await __museaPreviewSetup(app);" : "";
   const actionEvents = JSON.stringify(art.metadata.actionEvents ?? []);
   const artStyleId = `musea-art-styles-${art.path.replace(/[^\w-]+/g, "_")}`;
+  const artStyleIdLiteral = JSON.stringify(artStyleId);
 
   return `
 ${cssImportStatements}
 ${setupImport}
 import { createApp, h } from 'vue';
-import * as artModule from '${artModuleId}';
+import * as artModule from ${artModuleIdLiteral};
 
 const container = document.getElementById('app');
 const propsOverride = ${propsJson};
@@ -196,7 +209,7 @@ const propsOverride = ${propsJson};
 ${MUSEA_ADDONS_INIT_CODE}
 
 function ensureArtStyles(styles) {
-  const styleId = '${artStyleId}';
+  const styleId = ${artStyleIdLiteral};
   const existing = document.getElementById(styleId);
 
   if (!Array.isArray(styles) || styles.length === 0) {
@@ -232,9 +245,9 @@ function renderError(title, error) {
 
 async function mount() {
   try {
-    const VariantComponent = artModule['${variantComponentName}'];
+    const VariantComponent = artModule[${variantComponentNameLiteral}];
     if (!VariantComponent) {
-      throw new Error('Variant component "${variantComponentName}" not found');
+      throw new Error('Variant component ' + ${variantComponentNameLiteral} + ' not found');
     }
 
     const WrappedComponent = {
@@ -249,8 +262,8 @@ async function mount() {
     container.innerHTML = '';
     container.className = 'musea-variant';
     app.mount(container);
-    console.log('[musea-preview] Mounted variant: ${escapedVariantName} with props override');
-    __museaInitAddons(container, '${escapedVariantName}', ${actionEvents});
+    console.log('[musea-preview] Mounted variant with props override:', ${variantNameLiteral});
+    __museaInitAddons(container, ${variantNameLiteral}, ${actionEvents});
   } catch (error) {
     console.error('[musea-preview] Failed to mount:', error);
     renderError('Failed to render', error);

--- a/npm/vite-plugin-musea/src/security.test.ts
+++ b/npm/vite-plugin-musea/src/security.test.ts
@@ -1,6 +1,8 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import fs from "node:fs";
 import type { IncomingMessage } from "node:http";
+import os from "node:os";
 import path from "node:path";
 
 import {
@@ -21,6 +23,22 @@ void test("resolveInside keeps filesystem reads under the allowed directory", ()
   assert.equal(resolveInside(root, "src/Button.vue"), path.join(root, "src/Button.vue"));
   assert.throws(() => resolveInside(root, "../outside.txt"), HttpError);
   assert.throws(() => resolveUrlPathInside(root, "/assets/../../outside.txt"), HttpError);
+});
+
+void test("resolveInside follows links before accepting a path", async () => {
+  const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "musea-path-"));
+  const root = path.join(tempDir, "root");
+  const outside = path.join(tempDir, "outside");
+
+  try {
+    await fs.promises.mkdir(root);
+    await fs.promises.mkdir(outside);
+    await fs.promises.symlink(outside, path.join(root, "linked"), "dir");
+
+    assert.throws(() => resolveInside(root, "linked/file.txt"), HttpError);
+  } finally {
+    await fs.promises.rm(tempDir, { recursive: true, force: true });
+  }
 });
 
 void test("validateDevApiRequest requires same-origin JSON mutations with the session token", () => {

--- a/npm/vite-plugin-musea/src/security.ts
+++ b/npm/vite-plugin-musea/src/security.ts
@@ -1,4 +1,5 @@
 import { randomBytes, timingSafeEqual } from "node:crypto";
+import fs from "node:fs";
 import type { IncomingMessage } from "node:http";
 import path from "node:path";
 
@@ -18,24 +19,66 @@ export function createDevSessionToken(): string {
   return randomBytes(32).toString("base64url");
 }
 
-export function isPathInside(parentDir: string, candidatePath: string): boolean {
+function realpathNearest(targetPath: string): string {
+  let current = path.resolve(targetPath);
+  const missingParts: string[] = [];
+
+  while (true) {
+    try {
+      const real = fs.realpathSync.native(current);
+      return missingParts.length > 0 ? path.join(real, ...missingParts.reverse()) : real;
+    } catch {
+      const parent = path.dirname(current);
+      if (parent === current) {
+        return path.resolve(targetPath);
+      }
+      missingParts.push(path.basename(current));
+      current = parent;
+    }
+  }
+}
+
+function isResolvedPathInside(parentDir: string, candidatePath: string): boolean {
   const parent = path.resolve(parentDir);
   const candidate = path.resolve(candidatePath);
   const relative = path.relative(parent, candidate);
   return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
 }
 
+export function isPathInside(parentDir: string, candidatePath: string): boolean {
+  return isResolvedPathInside(realpathNearest(parentDir), realpathNearest(candidatePath));
+}
+
+export function isPathInsideAny(parentDirs: string[], candidatePath: string): boolean {
+  const candidate = realpathNearest(candidatePath);
+  return parentDirs.some((parentDir) =>
+    isResolvedPathInside(realpathNearest(parentDir), candidate),
+  );
+}
+
 export function resolveInside(parentDir: string, candidatePath: string, label = "path"): string {
+  return resolveInsideAny([parentDir], candidatePath, label);
+}
+
+export function resolveInsideAny(
+  parentDirs: string[],
+  candidatePath: string,
+  label = "path",
+): string {
   if (candidatePath.includes("\0")) {
     throw new HttpError(`${label} contains an invalid character`, 400);
   }
 
-  const parent = path.resolve(parentDir);
+  if (parentDirs.length === 0) {
+    throw new HttpError(`No allowed directories configured for ${label}`, 500);
+  }
+
+  const parent = path.resolve(parentDirs[0] ?? ".");
   const resolved = path.isAbsolute(candidatePath)
     ? path.resolve(candidatePath)
     : path.resolve(parent, candidatePath);
 
-  if (!isPathInside(parent, resolved)) {
+  if (!isPathInsideAny(parentDirs, resolved)) {
     throw new HttpError(`${label} escapes the allowed directory`, 400);
   }
 

--- a/npm/vite-plugin-musea/src/server-middleware.ts
+++ b/npm/vite-plugin-musea/src/server-middleware.ts
@@ -78,6 +78,7 @@ export interface MiddlewareContext {
   devSessionToken: string;
   themeConfig: { default: string; custom?: Record<string, unknown> } | undefined;
   artFiles: Map<string, ArtFileInfo>;
+  scanRoots: string[];
   resolvedPreviewCss: string[];
   resolvedPreviewSetup: string | null;
 }
@@ -303,13 +304,19 @@ export function registerMiddleware(devServer: ViteDevServer, ctx: MiddlewareCont
         res.setHeader("Cache-Control", "no-cache");
         res.end(result.code);
       } else {
-        const moduleCode = generateArtModule(art, artPath);
+        const moduleCode = generateArtModule(art, artPath, {
+          root: devServer.config.root,
+          scanRoots: ctx.scanRoots,
+        });
         res.setHeader("Content-Type", "application/javascript");
         res.end(moduleCode);
       }
     } catch (err) {
       console.error("[musea] Failed to transform art module:", err);
-      const moduleCode = generateArtModule(art, artPath);
+      const moduleCode = generateArtModule(art, artPath, {
+        root: devServer.config.root,
+        scanRoots: ctx.scanRoots,
+      });
       res.setHeader("Content-Type", "application/javascript");
       res.end(moduleCode);
     }


### PR DESCRIPTION
## Summary
- escape generated docs output and fallback gallery labels before rendering
- normalize component source resolution through shared roots
- quote generated module specifiers and variant labels
- add regression coverage for linked paths and generated imports

## Checks
- pnpm --filter @vizejs/vite-plugin-musea check
- pnpm --filter @vizejs/musea-mcp-server check
- pnpm exec tsx --test npm/vite-plugin-musea/src/security.test.ts npm/vite-plugin-musea/src/art-module.test.ts npm/vite-plugin-musea/src/utils.test.ts
- pnpm --filter @vizejs/vite-plugin-musea exec vp build --config gallery-vite.config.ts --outDir /tmp/vize-musea-gallery-build --emptyOutDir
