### PR TITLE
fix(unplugin): stabilize regexp filters

### DIFF
--- a/npm/unplugin-vize/src/filter.test.ts
+++ b/npm/unplugin-vize/src/filter.test.ts
@@ -1,0 +1,24 @@
+import { test } from "node:test";
+import { createFilter } from "./filter.ts";
+
+void test("global include regex stays stable across repeated calls", (t) => {
+  const filter = createFilter(/\.vue$/g);
+
+  t.assert.equal(filter("/project/src/App.vue"), true);
+  t.assert.equal(filter("/project/src/App.vue"), true);
+});
+
+void test("global exclude regex stays stable across repeated calls", (t) => {
+  const filter = createFilter(undefined, /node_modules/g);
+
+  t.assert.equal(filter("/project/node_modules/pkg/App.vue"), false);
+  t.assert.equal(filter("/project/node_modules/pkg/App.vue"), false);
+});
+
+void test("regex matcher does not leak lastIndex back to callers", (t) => {
+  const include = /\.vue$/g;
+  const filter = createFilter(include);
+
+  t.assert.equal(filter("/project/src/App.vue"), true);
+  t.assert.equal(include.lastIndex, 0);
+});

--- a/npm/unplugin-vize/src/filter.ts
+++ b/npm/unplugin-vize/src/filter.ts
@@ -10,12 +10,19 @@ export function createFilter(
     : [/node_modules/];
 
   return (id: string) => {
-    const matchInclude = includePatterns.some((pattern) =>
-      typeof pattern === "string" ? id.includes(pattern) : pattern.test(id),
-    );
-    const matchExclude = excludePatterns.some((pattern) =>
-      typeof pattern === "string" ? id.includes(pattern) : pattern.test(id),
-    );
+    const matchInclude = includePatterns.some((pattern) => matchesPattern(pattern, id));
+    const matchExclude = excludePatterns.some((pattern) => matchesPattern(pattern, id));
     return matchInclude && !matchExclude;
   };
+}
+
+function matchesPattern(pattern: string | RegExp, id: string): boolean {
+  if (typeof pattern === "string") {
+    return id.includes(pattern);
+  }
+
+  pattern.lastIndex = 0;
+  const matches = pattern.test(id);
+  pattern.lastIndex = 0;
+  return matches;
 }


### PR DESCRIPTION
## Summary

- Reset RegExp filter state before and after every include/exclude match.
- Add focused coverage for global include and exclude patterns so repeated filter calls stay deterministic.

## Stack

- Depends on #237 for the async type-stripping test fix.

## Validation

- pnpm --dir npm/unplugin-vize test
- pnpm --dir npm/unplugin-vize check
