### PR TITLE
fix(unplugin): await type stripping transform

### DIFF
--- a/npm/unplugin-vize/src/filter.test.ts
+++ b/npm/unplugin-vize/src/filter.test.ts
@@ -1,0 +1,24 @@
+import { test } from "node:test";
+import { createFilter } from "./filter.ts";
+
+void test("global include regex stays stable across repeated calls", (t) => {
+  const filter = createFilter(/\.vue$/g);
+
+  t.assert.equal(filter("/project/src/App.vue"), true);
+  t.assert.equal(filter("/project/src/App.vue"), true);
+});
+
+void test("global exclude regex stays stable across repeated calls", (t) => {
+  const filter = createFilter(undefined, /node_modules/g);
+
+  t.assert.equal(filter("/project/node_modules/pkg/App.vue"), false);
+  t.assert.equal(filter("/project/node_modules/pkg/App.vue"), false);
+});
+
+void test("regex matcher does not leak lastIndex back to callers", (t) => {
+  const include = /\.vue$/g;
+  const filter = createFilter(include);
+
+  t.assert.equal(filter("/project/src/App.vue"), true);
+  t.assert.equal(include.lastIndex, 0);
+});

--- a/npm/unplugin-vize/src/filter.ts
+++ b/npm/unplugin-vize/src/filter.ts
@@ -10,12 +10,19 @@ export function createFilter(
     : [/node_modules/];
 
   return (id: string) => {
-    const matchInclude = includePatterns.some((pattern) =>
-      typeof pattern === "string" ? id.includes(pattern) : pattern.test(id),
-    );
-    const matchExclude = excludePatterns.some((pattern) =>
-      typeof pattern === "string" ? id.includes(pattern) : pattern.test(id),
-    );
+    const matchInclude = includePatterns.some((pattern) => matchesPattern(pattern, id));
+    const matchExclude = excludePatterns.some((pattern) => matchesPattern(pattern, id));
     return matchInclude && !matchExclude;
   };
+}
+
+function matchesPattern(pattern: string | RegExp, id: string): boolean {
+  if (typeof pattern === "string") {
+    return id.includes(pattern);
+  }
+
+  pattern.lastIndex = 0;
+  const matches = pattern.test(id);
+  pattern.lastIndex = 0;
+  return matches;
 }

--- a/npm/unplugin-vize/src/strip-types.test.ts
+++ b/npm/unplugin-vize/src/strip-types.test.ts
@@ -1,0 +1,9 @@
+import { test } from "node:test";
+import { stripTypeScript } from "./strip-types.ts";
+
+void test("stripTypeScript accepts successful transforms without errors", async (t) => {
+  const result = await stripTypeScript("fixture.ts", "const count: number = 1;\n", false);
+
+  t.assert.match(result.code, /const count = 1/);
+  t.assert.equal(result.map, null);
+});

--- a/npm/unplugin-vize/src/strip-types.ts
+++ b/npm/unplugin-vize/src/strip-types.ts
@@ -20,14 +20,15 @@ export async function stripTypeScript(
   code: string,
   sourceMap: boolean,
 ): Promise<{ code: string; map: unknown }> {
-  const result = transform(filePath, code, {
+  const result = await transform(filePath, code, {
     lang: "ts",
     sourcemap: sourceMap,
     sourceType: "module",
   });
+  const errors = result.errors ?? [];
 
-  if (result.errors.length > 0) {
-    throw new Error(result.errors.map(formatErrorMessage).join("\n\n"));
+  if (errors.length > 0) {
+    throw new Error(errors.map(formatErrorMessage).join("\n\n"));
   }
 
   return {


### PR DESCRIPTION
## Summary

- Await the asynchronous oxc-transform type-stripping call before reading transform output.
- Treat a missing transform error array as an empty list for compatibility across transformer versions.
- Add focused coverage for successful type stripping.

## Validation

- pnpm --dir npm/unplugin-vize test
- pnpm --dir npm/unplugin-vize check
