### PR TITLE
perf(playground): scan offsets without slicing

### DIFF
--- a/playground/src/features/cross-file/utils.test.ts
+++ b/playground/src/features/cross-file/utils.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vite-plus/test";
+import {
+  buildSuppressionMap,
+  filterSuppressedIssues,
+  offsetToLineColumn,
+  parseSuppressions,
+} from "./utils";
+import type { CrossFileIssue } from "./types";
+
+function createIssue(file: string, line: number): CrossFileIssue {
+  return {
+    id: `${file}:${line}`,
+    type: "reactivity",
+    code: "cross-file",
+    severity: "warning",
+    message: "test issue",
+    file,
+    line,
+    column: 1,
+  };
+}
+
+describe("cross-file utils", () => {
+  it("reuses the shared offset mapper", () => {
+    expect(offsetToLineColumn("alpha\nbeta", 6)).toEqual({ line: 2, column: 1 });
+  });
+
+  it("maps forget comments to the next code line", () => {
+    const source = [
+      "// @vize forget: generated import",
+      "// explanatory comment",
+      "const generated = true",
+      "const kept = true",
+      "/* @vize forget: macro output */",
+      "defineProps<{ id: string }>()",
+    ].join("\n");
+
+    expect([...parseSuppressions(source)]).toEqual([3, 6]);
+  });
+
+  it("filters only issues on suppressed lines", () => {
+    const suppressionMap = buildSuppressionMap({
+      "App.vue": "// @vize forget: generated\nconst generated = true",
+    });
+    const issues = [
+      createIssue("App.vue", 2),
+      createIssue("App.vue", 3),
+      createIssue("Other.vue", 2),
+    ];
+
+    expect(filterSuppressedIssues(issues, suppressionMap)).toEqual([issues[1], issues[2]]);
+  });
+});

--- a/playground/src/features/cross-file/utils.ts
+++ b/playground/src/features/cross-file/utils.ts
@@ -1,21 +1,10 @@
 import type { CrossFileIssue } from "./types";
+export { offsetToLineColumn } from "../../utils/position";
 
 let _issueIdCounter = 0;
 
 export function resetIssueIdCounter() {
   _issueIdCounter = 0;
-}
-
-export function offsetToLineColumn(
-  source: string,
-  offset: number,
-): { line: number; column: number } {
-  const beforeOffset = source.substring(0, offset);
-  const lines = beforeOffset.split("\n");
-  return {
-    line: lines.length,
-    column: lines[lines.length - 1].length + 1,
-  };
 }
 
 export function parseSuppressions(source: string): Set<number> {

--- a/playground/src/utils/position.test.ts
+++ b/playground/src/utils/position.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vite-plus/test";
+import { offsetToLineColumn } from "./position";
+
+describe("offsetToLineColumn", () => {
+  it("maps offsets without allocating source slices", () => {
+    const source = "one\ntwo\n";
+
+    expect(offsetToLineColumn(source, 0)).toEqual({ line: 1, column: 1 });
+    expect(offsetToLineColumn(source, 3)).toEqual({ line: 1, column: 4 });
+    expect(offsetToLineColumn(source, 4)).toEqual({ line: 2, column: 1 });
+    expect(offsetToLineColumn(source, 7)).toEqual({ line: 2, column: 4 });
+    expect(offsetToLineColumn(source, 8)).toEqual({ line: 3, column: 1 });
+  });
+
+  it("clamps offsets outside the source range", () => {
+    expect(offsetToLineColumn("one\ntwo\n", -10)).toEqual({ line: 1, column: 1 });
+    expect(offsetToLineColumn("one\ntwo\n", 100)).toEqual({ line: 3, column: 1 });
+  });
+});

--- a/playground/src/utils/position.ts
+++ b/playground/src/utils/position.ts
@@ -3,10 +3,18 @@ export function offsetToLineColumn(
   source: string,
   offset: number,
 ): { line: number; column: number } {
-  const beforeOffset = source.substring(0, offset);
-  const lines = beforeOffset.split("\n");
-  return {
-    line: lines.length,
-    column: lines[lines.length - 1].length + 1,
-  };
+  const end = Math.max(0, Math.min(offset, source.length));
+  let line = 1;
+  let column = 1;
+
+  for (let index = 0; index < end; index++) {
+    if (source.charCodeAt(index) === 10) {
+      line++;
+      column = 1;
+    } else {
+      column++;
+    }
+  }
+
+  return { line, column };
 }


### PR DESCRIPTION
## Summary

- Replace substring/split based offset mapping with a single bounded scan.
- Reuse the shared playground offset mapper from cross-file utilities.
- Add coverage for offset mapping, suppression parsing, and suppression filtering.

## Validation

- pnpm --dir playground test:node
- pnpm --dir playground check
