### PR TITLE
fix(musea): preserve prototype-like token keys

### DIFF
--- a/npm/vite-plugin-musea/src/tokens.test.ts
+++ b/npm/vite-plugin-musea/src/tokens.test.ts
@@ -61,6 +61,30 @@ void test("token mutations reject prototype-polluting paths", () => {
   assert.equal(({} as Record<string, unknown>).polluted, undefined);
 });
 
+void test("token parsing keeps prototype-like token names as data", async () => {
+  const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "musea-tokens-"));
+
+  try {
+    await fs.promises.writeFile(
+      path.join(tempDir, "colors.tokens.json"),
+      '{"color":{"__proto__":{"value":"#fff","type":"color"}}}',
+      "utf-8",
+    );
+
+    const categories = await parseTokens(tempDir);
+    const tokenMap = buildTokenMap(categories);
+    const colorCategory = categories[0];
+
+    assert.ok(colorCategory);
+    assert.equal(Object.getPrototypeOf(colorCategory.tokens), null);
+    assert.equal(Object.getPrototypeOf(tokenMap), null);
+    assert.equal(tokenMap["color.__proto__"]?.value, "#fff");
+    assert.equal(({} as Record<string, unknown>).value, undefined);
+  } finally {
+    await fs.promises.rm(tempDir, { recursive: true, force: true });
+  }
+});
+
 void test("generateTokensHtml escapes untrusted token text and filters unsafe color styles", () => {
   const html = generateTokensHtml([
     {

--- a/npm/vite-plugin-musea/src/tokens/parser.ts
+++ b/npm/vite-plugin-musea/src/tokens/parser.ts
@@ -94,7 +94,7 @@ export async function parseTokens(tokensPath: string): Promise<TokenCategory[]> 
  * Parse tokens from a directory.
  */
 async function parseTokenDirectory(dirPath: string): Promise<TokenCategory[]> {
-  const mergedTokens: Record<string, unknown> = {};
+  const mergedTokens = createRecord<unknown>();
   await mergeTokenDirectory(mergedTokens, dirPath);
   return flattenTokens(mergedTokens);
 }
@@ -143,7 +143,7 @@ function deepMergeTokenTrees(
       continue;
     }
 
-    target[key] = value;
+    target[key] = cloneTokenTree(value);
   }
 }
 
@@ -180,7 +180,7 @@ function flattenTokens(tokens: Record<string, unknown>, prefix: string[] = []): 
  * Extract token values from an object.
  */
 function extractTokens(obj: Record<string, unknown>): Record<string, DesignToken> {
-  const tokens: Record<string, DesignToken> = {};
+  const tokens = createRecord<DesignToken>();
 
   for (const [key, value] of Object.entries(obj)) {
     if (isTokenValue(value)) {
@@ -189,6 +189,22 @@ function extractTokens(obj: Record<string, unknown>): Record<string, DesignToken
   }
 
   return tokens;
+}
+
+function cloneTokenTree(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(cloneTokenTree);
+  }
+
+  if (isPlainObject(value)) {
+    const cloned = createRecord<unknown>();
+    for (const [key, child] of Object.entries(value)) {
+      cloned[key] = cloneTokenTree(child);
+    }
+    return cloned;
+  }
+
+  return value;
 }
 
 /**
@@ -206,6 +222,10 @@ function isTokenValue(value: unknown): boolean {
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function createRecord<T>(): Record<string, T> {
+  return Object.create(null) as Record<string, T>;
 }
 
 /**

--- a/npm/vite-plugin-musea/src/tokens/resolver.ts
+++ b/npm/vite-plugin-musea/src/tokens/resolver.ts
@@ -61,7 +61,7 @@ export function buildTokenMap(
   categories: TokenCategory[],
   prefix: string[] = [],
 ): Record<string, DesignToken> {
-  const map: Record<string, DesignToken> = {};
+  const map = Object.create(null) as Record<string, DesignToken>;
 
   for (const cat of categories) {
     const catKey = cat.name.toLowerCase().replace(/\s+/g, "-");


### PR DESCRIPTION
## Summary

- Use null-prototype records while merging and flattening Musea token trees.
- Preserve prototype-like token keys such as `__proto__` as normal token data.
- Add regression coverage for prototype-like token names not being lost or applied as object prototypes.

## Validation

- pnpm --dir npm/vite-plugin-musea check
- pnpm exec vp check
- pnpm exec vp run --workspace-root check:ci

## Notes

- Direct `node --test npm/vite-plugin-musea/src/*.test.ts` is not currently usable for the existing Musea tests because source files import sibling TypeScript modules through `.js` specifiers.
