### PR TITLE
fix(rspack): stabilize regexp patterns

### DIFF
--- a/npm/rspack-vize-plugin/src/shared/utils.test.ts
+++ b/npm/rspack-vize-plugin/src/shared/utils.test.ts
@@ -5,6 +5,7 @@ import {
   extractStyleBlocks,
   collectTemplateAssetUrls,
   isImportableUrl,
+  matchesPattern,
   stripCssCommentsForScoped,
 } from "./utils.ts";
 
@@ -226,6 +227,24 @@ void describe("stripCssCommentsForScoped", () => {
     const output = stripCssCommentsForScoped(input);
 
     assert.equal(output.includes('content: "/* :deep(.x) */"'), true);
+  });
+});
+
+void describe("matchesPattern", () => {
+  void test("keeps global regexp patterns stable across calls", () => {
+    const pattern = /\.vue$/g;
+
+    assert.equal(matchesPattern("src/App.vue", pattern, false), true);
+    assert.equal(matchesPattern("src/App.vue", pattern, false), true);
+    assert.equal(pattern.lastIndex, 0);
+  });
+
+  void test("keeps sticky regexp patterns stable across calls", () => {
+    const pattern = /^src\/.*\.vue$/y;
+
+    assert.equal(matchesPattern("src/App.vue", pattern, false), true);
+    assert.equal(matchesPattern("src/App.vue", pattern, false), true);
+    assert.equal(pattern.lastIndex, 0);
   });
 });
 

--- a/npm/rspack-vize-plugin/src/shared/utils.ts
+++ b/npm/rspack-vize-plugin/src/shared/utils.ts
@@ -354,8 +354,15 @@ export function matchesPattern(
     if (typeof item === "string") {
       return normalizedFile.includes(item) || file.includes(item);
     }
-    return item.test(normalizedFile);
+    return testRegExp(item, normalizedFile);
   });
+}
+
+function testRegExp(pattern: RegExp, value: string): boolean {
+  pattern.lastIndex = 0;
+  const matches = pattern.test(value);
+  pattern.lastIndex = 0;
+  return matches;
 }
 
 // Template Asset URL Transformation


### PR DESCRIPTION
## Summary
- reset regexp state while matching rspack include/exclude patterns
- cover global and sticky patterns so repeated calls remain deterministic

## Validation
- pnpm --dir npm/rspack-vize-plugin check
- pnpm exec vp run --workspace-root check:ci
- pnpm --dir npm/rspack-vize-plugin build && cd npm/rspack-vize-plugin && node --test src/shared/utils.test.ts

## Notes
- pnpm --dir npm/rspack-vize-plugin test still fails on main with the same 8 existing rspack integration/snapshot failures; this branch adds only the new utils coverage, which passes.