### PR TITLE
fix(vite): resolve aliased vue before filtering

### DIFF
--- a/npm/vite-plugin-vize/src/plugin/resolve.test.ts
+++ b/npm/vite-plugin-vize/src/plugin/resolve.test.ts
@@ -108,6 +108,44 @@ function expectResolvedId(resolved: Awaited<ReturnType<typeof resolveIdHook>>): 
 }
 
 {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "vize-resolve-alias-"));
+  const importer = path.join(tempRoot, "src", "App.vue");
+  const aliased = path.join(tempRoot, "src", "views", "Aliased.vue");
+  fs.mkdirSync(path.dirname(importer), { recursive: true });
+  fs.mkdirSync(path.dirname(aliased), { recursive: true });
+  fs.writeFileSync(importer, "<template><Aliased /></template>");
+  fs.writeFileSync(aliased, "<template><div /></template>");
+
+  const state = createState(tempRoot);
+  state.filter = (id) => id === aliased;
+
+  let resolverImporter: string | undefined;
+  const resolved = await resolveIdHook(
+    {
+      resolve: async (id, importer) => {
+        resolverImporter = importer;
+        return id === "@views/Aliased.vue" ? { id: `/@fs${aliased}` } : null;
+      },
+    },
+    state,
+    "@views/Aliased.vue",
+    toVirtualId(importer),
+    undefined,
+  );
+
+  assert.equal(
+    resolverImporter,
+    importer,
+    "Vite alias resolution should receive the real importer path",
+  );
+  assert.equal(
+    expectResolvedId(resolved),
+    toVirtualId(aliased),
+    "Aliased Vue imports should be filtered after Vite resolves the real file path",
+  );
+}
+
+{
   const projectRoot = path.join(workspaceRoot, "tests", "_fixtures", "_git", "npmx.dev");
   if (hasFixtureProject(projectRoot)) {
     const importer = toVirtualId(path.join(projectRoot, "app", "pages", "index.vue"));

--- a/npm/vite-plugin-vize/src/plugin/resolve.ts
+++ b/npm/vite-plugin-vize/src/plugin/resolve.ts
@@ -112,6 +112,52 @@ function resolveBareImportWithNode(
   return null;
 }
 
+function normalizeResolvedVuePath(id: string): string | null {
+  const pathPart = id.split("?")[0];
+  if (!pathPart?.endsWith(".vue")) {
+    return null;
+  }
+  return pathPart.startsWith("/@fs/") ? pathPart.slice(4) : pathPart;
+}
+
+async function resolveAliasedVueImport(
+  ctx: ResolveContext,
+  state: VizePluginState,
+  id: string,
+  importer: string | undefined,
+  isSsrRequest: boolean,
+  handleNodeModules: boolean,
+): Promise<string | null> {
+  if (path.isAbsolute(id)) {
+    return null;
+  }
+
+  const viteImporter = normalizeRequireBase(importer) ?? importer;
+  const viteResolved = await ctx.resolve(id, viteImporter, { skipSelf: true });
+  const realPath = viteResolved ? normalizeResolvedVuePath(viteResolved.id) : null;
+  if (!realPath) {
+    return null;
+  }
+
+  const isResolvedNodeModules = realPath.includes("node_modules");
+  if (!handleNodeModules && isResolvedNodeModules) {
+    state.logger.log(`resolveId: skipping resolved node_modules path ${realPath}`);
+    return null;
+  }
+
+  if (!isResolvedNodeModules && state.filter && !state.filter(realPath)) {
+    state.logger.log(`resolveId: skipping filtered resolved path ${realPath}`);
+    return null;
+  }
+
+  if (state.cache.has(realPath) || fs.existsSync(realPath)) {
+    state.logger.log(`resolveId: resolved via Vite fallback ${id} to ${realPath}`);
+    return toVirtualId(realPath, isSsrRequest);
+  }
+
+  return null;
+}
+
 export async function resolveIdHook(
   ctx: ResolveContext,
   state: VizePluginState,
@@ -320,6 +366,21 @@ export async function resolveIdHook(
     }
 
     const resolved = resolveVuePath(state, id, importer);
+    const fileExists = fs.existsSync(resolved);
+    if (!fileExists) {
+      const aliased = await resolveAliasedVueImport(
+        ctx,
+        state,
+        id,
+        importer,
+        isSsrRequest,
+        handleNodeModules,
+      );
+      if (aliased) {
+        return aliased;
+      }
+    }
+
     const isNodeModulesPath = resolved.includes("node_modules");
 
     if (!handleNodeModules && isNodeModulesPath) {
@@ -333,7 +394,6 @@ export async function resolveIdHook(
     }
 
     const hasCache = state.cache.has(resolved);
-    const fileExists = fs.existsSync(resolved);
     state.logger.log(
       `resolveId: id=${id}, resolved=${resolved}, hasCache=${hasCache}, fileExists=${fileExists}, importer=${importer ?? "none"}`,
     );
@@ -341,22 +401,6 @@ export async function resolveIdHook(
     // Return virtual module ID: \0/path/to/Component.vue.ts
     if (hasCache || fileExists) {
       return toVirtualId(resolved, isSsrRequest);
-    }
-
-    // Vite fallback for aliased imports
-    if (!fileExists && !path.isAbsolute(id)) {
-      const viteResolved = await ctx.resolve(id, importer, { skipSelf: true });
-      if (viteResolved && viteResolved.id.endsWith(".vue")) {
-        const realPath = viteResolved.id;
-        const isResolvedNodeModules = realPath.includes("node_modules");
-        if (
-          (isResolvedNodeModules ? handleNodeModules : state.filter(realPath)) &&
-          (state.cache.has(realPath) || fs.existsSync(realPath))
-        ) {
-          state.logger.log(`resolveId: resolved via Vite fallback ${id} to ${realPath}`);
-          return toVirtualId(realPath, isSsrRequest);
-        }
-      }
     }
   }
 


### PR DESCRIPTION
## Summary
- resolve non-absolute Vue imports through Vite before applying include filters when the direct filesystem path is missing
- normalize /@fs Vue resolver results back to real file paths before caching and virtualizing
- cover aliased Vue imports from virtual modules with a restrictive include filter

## Validation
- pnpm --dir npm/vite-plugin-vize check
- node npm/vite-plugin-vize/src/plugin/resolve.test.ts
- pnpm exec vp run --workspace-root check:ci