### PR TITLE
fix(check): support tsconfig extends arrays

### DIFF
--- a/crates/vize/src/commands/check/tsconfig_inputs.rs
+++ b/crates/vize/src/commands/check/tsconfig_inputs.rs
@@ -26,6 +26,23 @@ struct TsconfigInputSpec {
     has_excludes: bool,
 }
 
+impl TsconfigInputSpec {
+    fn apply_extended(&mut self, extended: Self) {
+        if extended.has_files {
+            self.files = extended.files;
+            self.has_files = true;
+        }
+        if extended.has_includes {
+            self.includes = extended.includes;
+            self.has_includes = true;
+        }
+        if extended.has_excludes {
+            self.excludes = extended.excludes;
+            self.has_excludes = true;
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 struct RelativePathSpec {
     base_dir: PathBuf,
@@ -189,13 +206,14 @@ fn load_tsconfig_inputs_inner(
     let value = parse_jsonc_value(&content).unwrap_or(Value::Null);
     let dir = resolved.parent().unwrap_or(Path::new("."));
 
-    let mut merged = value
-        .get("extends")
-        .and_then(Value::as_str)
-        .and_then(|extends| resolve_extended_tsconfig(&resolved, extends))
-        .map(|extends_path| load_tsconfig_inputs_inner(&extends_path, seen))
-        .transpose()?
-        .unwrap_or_default();
+    let mut merged = TsconfigInputSpec::default();
+    for extends in read_extends_entries(&value) {
+        let Some(extends_path) = resolve_extended_tsconfig(&resolved, &extends) else {
+            continue;
+        };
+        let extended = load_tsconfig_inputs_inner(&extends_path, seen)?;
+        merged.apply_extended(extended);
+    }
 
     if let Some(files) = read_string_array(&value, "files") {
         merged.has_files = true;
@@ -259,6 +277,17 @@ fn read_string_array(value: &Value, key: &str) -> Option<Vec<std::string::String
             .filter_map(|item| item.as_str().map(std::string::String::from))
             .collect()
     })
+}
+
+fn read_extends_entries(value: &Value) -> Vec<std::string::String> {
+    match value.get("extends") {
+        Some(Value::String(extends)) => vec![extends.clone()],
+        Some(Value::Array(extends)) => extends
+            .iter()
+            .filter_map(|item| item.as_str().map(std::string::String::from))
+            .collect(),
+        _ => Vec::new(),
+    }
 }
 
 fn normalize_tsconfig_glob(value: &str) -> std::string::String {
@@ -535,6 +564,45 @@ mod tests {
         let files = collect_default_check_files(&case_dir, Some(&case_dir.join("tsconfig.json")));
 
         assert_eq!(files, vec![case_dir.join("src/App.vue")]);
+
+        let _ = fs::remove_dir_all(&case_dir);
+    }
+
+    #[test]
+    fn default_collection_applies_extends_array_in_order() {
+        let case_dir = unique_case_dir("tsconfig-extends-array");
+        let _ = fs::remove_dir_all(&case_dir);
+        fs::create_dir_all(case_dir.join("src/one")).unwrap();
+        fs::create_dir_all(case_dir.join("src/two")).unwrap();
+        fs::write(case_dir.join("src/one/One.vue"), "<template />").unwrap();
+        fs::write(case_dir.join("src/two/App.vue"), "<template />").unwrap();
+        fs::write(case_dir.join("src/two/Skip.vue"), "<template />").unwrap();
+        fs::write(
+            case_dir.join("tsconfig.one.json"),
+            r#"{
+  "include": ["src/one/**/*.vue"],
+  "exclude": ["src/two/Skip.vue"]
+}"#,
+        )
+        .unwrap();
+        fs::write(
+            case_dir.join("tsconfig.two.json"),
+            r#"{
+  "include": ["src/two/**/*.vue"]
+}"#,
+        )
+        .unwrap();
+        fs::write(
+            case_dir.join("tsconfig.json"),
+            r#"{
+  "extends": ["./tsconfig.one.json", "./tsconfig.two.json"]
+}"#,
+        )
+        .unwrap();
+
+        let files = collect_default_check_files(&case_dir, Some(&case_dir.join("tsconfig.json")));
+
+        assert_eq!(files, vec![case_dir.join("src/two/App.vue")]);
 
         let _ = fs::remove_dir_all(&case_dir);
     }


### PR DESCRIPTION
## Summary
- allow `vize check` default input collection to read TypeScript 5.0-style `extends` arrays
- merge inherited input specs in declaration order so later configs override `files` / `include` / `exclude` while earlier non-conflicting fields remain
- add coverage for array inheritance order and preserved excludes

Reference: https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-0.html#supporting-multiple-configuration-files-in-extends

## Validation
- `cargo fmt --check`
- `cargo test -p vize default_collection_applies_extends_array_in_order`
- `cargo test -p vize`
- `cargo clippy -p vize -- -D warnings`
- `pnpm exec vp run --workspace-root check:ci`