### PR TITLE
fix(check): honor package tsconfig field

### DIFF
--- a/crates/vize/src/commands/check/tsconfig_inputs.rs
+++ b/crates/vize/src/commands/check/tsconfig_inputs.rs
@@ -256,10 +256,22 @@ fn resolve_extended_tsconfig(tsconfig_path: &Path, extends: &str) -> Option<Path
             },
         );
     } else {
-        push_tsconfig_candidates(&mut candidates, base_dir.join("node_modules").join(extends));
+        push_node_modules_tsconfig_candidates(&mut candidates, base_dir, extends);
     }
 
     candidates.into_iter().find(|candidate| candidate.exists())
+}
+
+fn push_node_modules_tsconfig_candidates(
+    candidates: &mut Vec<PathBuf>,
+    base_dir: &Path,
+    extends: &str,
+) {
+    let mut current = Some(base_dir);
+    while let Some(dir) = current {
+        push_tsconfig_candidates(candidates, dir.join("node_modules").join(extends));
+        current = dir.parent();
+    }
 }
 
 fn push_tsconfig_candidates(candidates: &mut Vec<PathBuf>, base: PathBuf) {
@@ -489,7 +501,7 @@ fn strip_trailing_commas(content: &str) -> std::string::String {
 
 #[cfg(test)]
 mod tests {
-    use super::collect_default_check_files;
+    use super::{collect_default_check_files, resolve_extended_tsconfig};
     use std::fs;
     use std::path::{Path, PathBuf};
     use vize_carton::cstr;
@@ -603,6 +615,35 @@ mod tests {
         let files = collect_default_check_files(&case_dir, Some(&case_dir.join("tsconfig.json")));
 
         assert_eq!(files, vec![case_dir.join("src/two/App.vue")]);
+
+        let _ = fs::remove_dir_all(&case_dir);
+    }
+
+    #[test]
+    fn extended_config_resolution_finds_ancestor_node_modules() {
+        let case_dir = unique_case_dir("tsconfig-package-extends");
+        let _ = fs::remove_dir_all(&case_dir);
+        let app_dir = case_dir.join("packages/app");
+        let package_dir = case_dir.join("node_modules/@scope/tsconfig");
+        fs::create_dir_all(&app_dir).unwrap();
+        fs::create_dir_all(&package_dir).unwrap();
+        fs::write(app_dir.join("tsconfig.json"), "{}").unwrap();
+        fs::write(
+            package_dir.join("tsconfig.vue.json"),
+            r#"{
+  "compilerOptions": {
+    "strict": true
+  }
+}"#,
+        )
+        .unwrap();
+
+        let resolved = resolve_extended_tsconfig(
+            &app_dir.join("tsconfig.json"),
+            "@scope/tsconfig/tsconfig.vue.json",
+        );
+
+        assert_eq!(resolved, Some(package_dir.join("tsconfig.vue.json")));
 
         let _ = fs::remove_dir_all(&case_dir);
     }

--- a/crates/vize/src/commands/check/tsconfig_inputs.rs
+++ b/crates/vize/src/commands/check/tsconfig_inputs.rs
@@ -259,7 +259,7 @@ fn resolve_extended_tsconfig(tsconfig_path: &Path, extends: &str) -> Option<Path
         push_node_modules_tsconfig_candidates(&mut candidates, base_dir, extends);
     }
 
-    candidates.into_iter().find(|candidate| candidate.exists())
+    candidates.into_iter().find(|candidate| candidate.is_file())
 }
 
 fn push_node_modules_tsconfig_candidates(
@@ -269,9 +269,63 @@ fn push_node_modules_tsconfig_candidates(
 ) {
     let mut current = Some(base_dir);
     while let Some(dir) = current {
-        push_tsconfig_candidates(candidates, dir.join("node_modules").join(extends));
+        let node_modules = dir.join("node_modules");
+        if let Some((package, subpath)) = split_package_specifier(extends) {
+            let package_root = node_modules.join(package);
+            if let Some(subpath) = subpath {
+                push_tsconfig_candidates(candidates, package_root.join(subpath));
+            } else {
+                push_package_json_tsconfig_candidates(candidates, &package_root);
+                candidates.push(package_root.join("tsconfig.json"));
+            }
+        } else {
+            push_tsconfig_candidates(candidates, node_modules.join(extends));
+        }
         current = dir.parent();
     }
+}
+
+fn split_package_specifier(extends: &str) -> Option<(&str, Option<&str>)> {
+    let mut parts = extends.split('/');
+    let first = parts.next()?;
+    if first.is_empty() {
+        return None;
+    }
+
+    if first.starts_with('@') {
+        let name = parts.next()?;
+        if name.is_empty() {
+            return None;
+        }
+        let package_len = first.len() + 1 + name.len();
+        let subpath = extends
+            .get(package_len + 1..)
+            .filter(|value| !value.is_empty());
+        return Some((&extends[..package_len], subpath));
+    }
+
+    let subpath = extends
+        .get(first.len() + 1..)
+        .filter(|value| !value.is_empty());
+    Some((first, subpath))
+}
+
+fn push_package_json_tsconfig_candidates(candidates: &mut Vec<PathBuf>, package_root: &Path) {
+    let package_json_path = package_root.join("package.json");
+    let Some(tsconfig) = fs::read_to_string(package_json_path)
+        .ok()
+        .and_then(|content| parse_jsonc_value(&content).ok())
+        .and_then(|value| {
+            value
+                .get("tsconfig")
+                .and_then(Value::as_str)
+                .map(str::to_owned)
+        })
+    else {
+        return;
+    };
+
+    push_tsconfig_candidates(candidates, package_root.join(tsconfig));
 }
 
 fn push_tsconfig_candidates(candidates: &mut Vec<PathBuf>, base: PathBuf) {
@@ -644,6 +698,41 @@ mod tests {
         );
 
         assert_eq!(resolved, Some(package_dir.join("tsconfig.vue.json")));
+
+        let _ = fs::remove_dir_all(&case_dir);
+    }
+
+    #[test]
+    fn extended_config_resolution_uses_package_json_tsconfig_field() {
+        let case_dir = unique_case_dir("tsconfig-package-json-field");
+        let _ = fs::remove_dir_all(&case_dir);
+        let app_dir = case_dir.join("packages/app");
+        let package_dir = case_dir.join("node_modules/@scope/tsconfig");
+        fs::create_dir_all(app_dir.join("src")).unwrap();
+        fs::create_dir_all(package_dir.join("configs")).unwrap();
+        fs::write(app_dir.join("tsconfig.json"), "{}").unwrap();
+        fs::write(
+            package_dir.join("package.json"),
+            r#"{
+  "name": "@scope/tsconfig",
+  "tsconfig": "configs/vue.json"
+}"#,
+        )
+        .unwrap();
+        fs::write(
+            package_dir.join("configs/vue.json"),
+            r#"{
+  "compilerOptions": {
+    "strict": true
+  }
+}"#,
+        )
+        .unwrap();
+        fs::write(package_dir.join("tsconfig.json"), "{}").unwrap();
+
+        let resolved = resolve_extended_tsconfig(&app_dir.join("tsconfig.json"), "@scope/tsconfig");
+
+        assert_eq!(resolved, Some(package_dir.join("configs/vue.json")));
 
         let _ = fs::remove_dir_all(&case_dir);
     }


### PR DESCRIPTION
## Summary
- read the `tsconfig` field from package `package.json` files when resolving bare `extends` entries
- prefer that package entrypoint before falling back to package-root `tsconfig.json`
- ignore directory candidates so resolution does not try to load package folders as config files

Reference: https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-2.html#tsconfigjson-inheritance-via-nodejs-packages

## Validation
- `cargo fmt --check`
- `cargo test -p vize extended_config_resolution_uses_package_json_tsconfig_field`
- `cargo test -p vize`
- `cargo clippy -p vize -- -D warnings`
- `pnpm exec vp run --workspace-root check:ci`