### PR TITLE
fix(vite): guard css alias prefixes

### DIFF
--- a/npm/vite-plugin-vize/src/utils.test.ts
+++ b/npm/vite-plugin-vize/src/utils.test.ts
@@ -418,6 +418,36 @@ function resolveCssTransforms(css: string): string {
   );
 }
 
+// Test 21: CSS aliases should not match package prefixes
+{
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "vize-css-alias-"));
+  const srcAssetPath = path.join(tempDir, "src", "assets", "logo.svg");
+  const packageAssetPath = path.join(tempDir, "node_modules", "@scope", "icons", "logo.svg");
+  fs.mkdirSync(path.dirname(srcAssetPath), { recursive: true });
+  fs.mkdirSync(path.dirname(packageAssetPath), { recursive: true });
+  fs.writeFileSync(srcAssetPath, "");
+  fs.writeFileSync(packageAssetPath, "");
+
+  const result = resolveCssImports(
+    `
+.local { background-image: url("@/assets/logo.svg"); }
+.package { background-image: url("@scope/icons/logo.svg"); }
+`,
+    path.join(tempDir, "Component.vue"),
+    [{ find: "@", replacement: path.join(tempDir, "src") }],
+    true,
+  );
+
+  assert.ok(
+    result.includes(`url("/@fs${srcAssetPath.replace(/\\/g, "/")}")`),
+    "CSS alias should resolve @/ URLs",
+  );
+  assert.ok(
+    result.includes('url("@scope/icons/logo.svg")'),
+    "CSS alias should not rewrite package specifiers that only share the first character",
+  );
+}
+
 // =============================================================================
 // Test: applyDefineReplacements
 // =============================================================================

--- a/npm/vite-plugin-vize/src/utils/css.ts
+++ b/npm/vite-plugin-vize/src/utils/css.ts
@@ -401,8 +401,9 @@ function resolveCssPath(
 ): string | null {
   // Try alias resolution
   for (const rule of aliasRules) {
-    if (importPath.startsWith(rule.find)) {
-      const resolved = importPath.replace(rule.find, rule.replacement);
+    const suffix = matchedAliasSuffix(importPath, rule.find);
+    if (suffix !== null) {
+      const resolved = path.join(rule.replacement, suffix);
       return path.resolve(resolved);
     }
   }
@@ -419,4 +420,17 @@ function resolveCssPath(
   }
 
   return null;
+}
+
+function matchedAliasSuffix(importPath: string, find: string): string | null {
+  if (importPath === find) {
+    return "";
+  }
+
+  const prefix = find.endsWith("/") ? find : `${find}/`;
+  if (!importPath.startsWith(prefix)) {
+    return null;
+  }
+
+  return importPath.slice(prefix.length);
 }


### PR DESCRIPTION
## Summary
- prevent CSS alias resolution from matching package specifiers that merely share an alias prefix
- resolve matched aliases by suffix so `@` still handles `@/assets/...` but leaves `@scope/...` untouched
- add coverage for dev CSS asset URL rewriting with scoped package specifiers

## Validation
- `node npm/vite-plugin-vize/src/utils.test.ts`
- `pnpm --dir npm/vite-plugin-vize check`
- `pnpm --dir npm/vite-plugin-vize test`
- `pnpm exec vp run --workspace-root check:ci`