### PR TITLE
(docs) some fixes in nuxt intregration document.

### DIFF
--- a/docs/content/integrations/nuxt.md
+++ b/docs/content/integrations/nuxt.md
@@ -18,6 +18,13 @@ Install `vp` once from the [Vite+ install guide](https://viteplus.dev/guide/inst
 vp install @vizejs/nuxt
 ```
 
+If you want to use `pkl` config with pnpm, you might need to install `vize` package itself.
+`@vizejs/nuxt` installs `vize` which serves `vize.pkl` with default config, but `vize.pkl` file position might be different in case of using pnpm. 
+
+```bash
+vp install vize
+```
+
 ### 2. Register the Nuxt Module
 
 ```typescript
@@ -32,10 +39,10 @@ export default defineNuxtConfig({
 
 ### 3. Start Nuxt
 
-Run the app with your existing Nuxt command:
+Start the dev server as usual:
 
 ```bash
-vp dev
+vp run dev 
 ```
 
 The module injects `@vizejs/vite-plugin` into Nuxt's Vite config and keeps Nuxt-specific transforms

--- a/docs/content/integrations/nuxt.md
+++ b/docs/content/integrations/nuxt.md
@@ -18,8 +18,8 @@ Install `vp` once from the [Vite+ install guide](https://viteplus.dev/guide/inst
 vp install @vizejs/nuxt
 ```
 
-If you want to use `pkl` config with pnpm, you might need to install `vize` package itself.
-`@vizejs/nuxt` installs `vize` which serves `vize.pkl` with default config, but `vize.pkl` file position might be different in case of using pnpm. 
+If you want to use `pkl` config with pnpm, you might need to install the `vize` package itself.
+`@vizejs/nuxt` installs `vize` which serves `vize.pkl` with default config, but the location of `vize.pkl` may differ when using pnpm. 
 
 ```bash
 vp install vize
@@ -42,7 +42,7 @@ export default defineNuxtConfig({
 Start the dev server as usual:
 
 ```bash
-vp run dev 
+vp run dev
 ```
 
 The module injects `@vizejs/vite-plugin` into Nuxt's Vite config and keeps Nuxt-specific transforms


### PR DESCRIPTION
Some document updates in Nuxt intergration.

# Fix 1: Need to install vize package directory when using pkl with pnpm

When using pkl config with pnpm, we need to specify pkl default file in vize package.
However, pnpm does not install `vize` in root node_modules, so we also need to install `vize` itself accoring to theconfiguration document.
https://vizejs.dev/guide/configuration/index.html

# Fix 2: We should use `vp run dev` instead of `vp dev`

`vp dev` launches vite server not nitro server, so we need to run `vp run dev` instead of that.