### PR TITLE
fix(vite): avoid discarded oxc sourcemaps

### DIFF
--- a/docs/content/integrations/nuxt.md
+++ b/docs/content/integrations/nuxt.md
@@ -19,7 +19,7 @@ vp install @vizejs/nuxt
 ```
 
 If you want to use `pkl` config with pnpm, you might need to install the `vize` package itself.
-`@vizejs/nuxt` installs `vize` which serves `vize.pkl` with default config, but the location of `vize.pkl` may differ when using pnpm. 
+`@vizejs/nuxt` installs `vize` which serves `vize.pkl` with default config, but the location of `vize.pkl` may differ when using pnpm.
 
 ```bash
 vp install vize

--- a/npm/vite-plugin-vize/src/plugin/compat.test.ts
+++ b/npm/vite-plugin-vize/src/plugin/compat.test.ts
@@ -70,6 +70,11 @@ const msg = 'hello'
     /document\.createElement/,
     "SSR post-transforms should stay free of document-based side effects",
   );
+  assert.equal(
+    result.map,
+    null,
+    "SSR post-transforms should not allocate discarded OXC sourcemaps",
+  );
 }
 
 {

--- a/npm/vite-plugin-vize/src/plugin/compat.ts
+++ b/npm/vite-plugin-vize/src/plugin/compat.ts
@@ -77,7 +77,7 @@ export function createPostTransformPlugin(state: VizePluginState): Plugin {
             filePath: id,
           });
 
-          const result = await transformWithOxc(output, id, { lang: "ts" });
+          const result = await transformWithOxc(output, id, { lang: "ts", sourcemap: false });
           const defines = transformOptions?.ssr ? state.serverViteDefine : state.clientViteDefine;
           let transformed = result.code;
           if (Object.keys(defines).length > 0) {
@@ -85,7 +85,7 @@ export function createPostTransformPlugin(state: VizePluginState): Plugin {
           }
           return {
             code: transformed,
-            map: result.map as TransformResult["map"],
+            map: null,
           };
         } catch (e: unknown) {
           state.logger.error(`Virtual SFC compilation failed for ${id}:`, e);

--- a/npm/vite-plugin-vize/src/plugin/load.test.ts
+++ b/npm/vite-plugin-vize/src/plugin/load.test.ts
@@ -115,6 +115,11 @@ assert.match(
   /import\.meta\.hot/,
   "Virtual module transforms must leave import.meta.hot available for Vite HMR",
 );
+assert.equal(
+  virtualDefineTransform.map,
+  null,
+  "Virtual module OXC transforms should not allocate sourcemaps that Vize discards",
+);
 
 const definePageDir = fs.mkdtempSync(path.join(os.tmpdir(), "vize-define-page-"));
 const definePagePath = path.join(definePageDir, "Home.vue");

--- a/npm/vite-plugin-vize/src/plugin/load.ts
+++ b/npm/vite-plugin-vize/src/plugin/load.ts
@@ -353,12 +353,13 @@ export async function transformHook(
     try {
       const result = await transformWithOxc(code, realPath, {
         lang: "ts",
+        sourcemap: false,
       });
       const defines = getVirtualModuleDefines(state, options?.ssr ?? false);
       let transformed = result.code;
       transformed = applyDefineReplacements(transformed, defines);
 
-      return { code: transformed, map: result.map as TransformResult["map"] };
+      return { code: transformed, map: null };
     } catch (e: unknown) {
       state.logger.error(`transformWithOxc failed for ${realPath}:`, e);
       const dumpPath = getOxcDumpPath(state.root, realPath);


### PR DESCRIPTION
## Summary

- Disable discarded OXC sourcemap generation for Vize virtual Vue module transforms.
- Return `map: null` from the virtual transform paths and cover that behavior in tests.
- Trim a trailing space in the Nuxt integration docs so the repository-wide formatter check stays green.

Fixes #248.

## Root Cause

Vite Plus `transformWithOxc` defaults to `sourcemap: true`. Vize was using it only to strip TypeScript and apply define replacements for synthetic `\0...vue.ts` modules, then passing the generated map through even though the plugin otherwise treats those transforms as sourcemap-less. On Nuxt builds this made the Vite Plus native layer allocate and return extra sourcemap strings for every virtual Vue module, increasing V8 heap pressure.

## Reproduction Notes

- Cloned `frontend-phpcon-do/frontend-phpcon-do-website` under `./__agent_only/repro` and applied the issue's Vize/Nuxt config.
- Published `@vizejs/nuxt@0.86.0` now reaches Vize precompile on that repo, but the current upstream app fails earlier with `vue-i18n/dist/vue-i18n.esm-bundler.js` resolution before reproducing the full OOM.
- Direct `transformWithOxc` measurement on a synthetic large virtual module showed `sourcemap: true` returning an ~850 KB map and ~22 MB RSS delta, while `sourcemap: false` returned no map with ~6.6 MB RSS delta.

## Validation

- `pnpm --dir npm/vite-plugin-vize test`
- `pnpm --dir npm/vite-plugin-vize check`
- `pnpm --dir npm/vite-plugin-vize build`
- `cargo fmt --all -- --check`
- `pnpm exec vp run --workspace-root check:ci`
- `cargo clippy --workspace -- -D warnings`
- `cargo test --workspace`
- `pnpm exec vp run --workspace-root bench:quick`
