### PR TITLE
fix(cross-file): skip kebab-case built-ins

### DIFF
--- a/crates/vize_croquis/src/cross_file/analyzer/mod.rs
+++ b/crates/vize_croquis/src/cross_file/analyzer/mod.rs
@@ -210,6 +210,29 @@ mod tests {
         )));
     }
 
+    #[test]
+    fn test_component_resolution_skips_kebab_case_builtins() {
+        let mut analyzer = CrossFileAnalyzer::new(CrossFileOptions::strict());
+
+        let mut parent_analyzer = crate::Analyzer::with_options(AnalyzerOptions::full());
+        for component in ["router-view", "router-link", "nuxt-link", "client-only"] {
+            parent_analyzer
+                .croquis_mut()
+                .used_components
+                .insert(CompactString::new(component));
+        }
+        analyzer.add_file_with_analysis(Path::new("Parent.vue"), "", parent_analyzer.finish());
+
+        let result = analyzer.analyze();
+        assert!(
+            result.diagnostics.iter().all(|diagnostic| !matches!(
+                diagnostic.kind,
+                CrossFileDiagnosticKind::UnregisteredComponent { .. }
+            )),
+            "kebab-case framework built-ins should not require local registration"
+        );
+    }
+
     // === Provide/Inject Tests ===
     // NOTE: CrossFileAnalyzer.analyze_single_file doesn't parse SFC tags,
     // so we use .ts extension to pass raw script content

--- a/crates/vize_croquis/src/cross_file/analyzers/component_resolution.rs
+++ b/crates/vize_croquis/src/cross_file/analyzers/component_resolution.rs
@@ -166,16 +166,17 @@ pub fn analyze_component_resolution(
 /// Check if a component name is a Vue built-in component.
 #[inline]
 fn is_builtin_component(name: &str) -> bool {
+    let normalized = to_pascal_case(name);
     matches!(
-        name,
+        normalized.as_str(),
         "Transition"
             | "TransitionGroup"
             | "KeepAlive"
             | "Suspense"
             | "Teleport"
-            | "component"
-            | "slot"
-            | "template"
+            | "Component"
+            | "Slot"
+            | "Template"
             // Nuxt built-ins
             | "NuxtPage"
             | "NuxtLayout"
@@ -302,9 +303,17 @@ mod tests {
     #[test]
     fn test_is_builtin_component() {
         assert!(is_builtin_component("Transition"));
+        assert!(is_builtin_component("transition"));
+        assert!(is_builtin_component("transition-group"));
         assert!(is_builtin_component("KeepAlive"));
+        assert!(is_builtin_component("keep-alive"));
         assert!(is_builtin_component("RouterView"));
+        assert!(is_builtin_component("router-view"));
         assert!(is_builtin_component("NuxtPage"));
+        assert!(is_builtin_component("nuxt-page"));
+        assert!(is_builtin_component("nuxt-link"));
+        assert!(is_builtin_component("client-only"));
+        assert!(is_builtin_component("slot"));
         assert!(!is_builtin_component("MyComponent"));
         assert!(!is_builtin_component("UserCard"));
     }


### PR DESCRIPTION
## Summary

Normalizes component names before the cross-file component-resolution built-in check. This avoids reporting framework/Vue built-ins as unregistered when templates use kebab-case names such as `router-view`, `nuxt-link`, or `client-only`.

## Impact

Reduces false-positive `UnregisteredComponent` diagnostics for common Vue Router and Nuxt built-ins without weakening local registration checks for user components.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p vize_croquis component_resolution -- --nocapture`
- `cargo clippy -p vize_croquis -- -D warnings`