### PR TITLE
fix(a11y): honor bound literal input types

### DIFF
--- a/crates/vize_patina/src/rules/a11y/form_control_has_label.rs
+++ b/crates/vize_patina/src/rules/a11y/form_control_has_label.rs
@@ -13,6 +13,8 @@ use crate::diagnostic::Severity;
 use crate::rule::{Rule, RuleCategory, RuleMeta};
 use vize_relief::ast::{ElementNode, ExpressionNode, PropNode};
 
+use super::helpers::get_static_or_bound_literal_attribute_value;
+
 static META: RuleMeta = RuleMeta {
     name: "a11y/form-control-has-label",
     description: "Require form controls to have associated labels",
@@ -37,19 +39,14 @@ impl FormControlHasLabel {
             return false;
         }
 
-        for prop in &element.props {
-            if let PropNode::Attribute(attr) = prop {
-                if attr.name == "type" {
-                    if let Some(value) = &attr.value {
-                        return matches!(
-                            value.content.as_ref(),
-                            "hidden" | "submit" | "reset" | "button" | "image"
-                        );
-                    }
-                }
-            }
-        }
-        false
+        let Some(input_type) = get_static_or_bound_literal_attribute_value(element, "type") else {
+            return false;
+        };
+
+        matches!(
+            input_type,
+            "hidden" | "submit" | "reset" | "button" | "image"
+        )
     }
 
     /// Check if element has aria-label or aria-labelledby
@@ -213,6 +210,14 @@ mod tests {
     fn test_valid_hidden_input() {
         let linter = create_linter();
         let result = linter.lint_template(r#"<input type="hidden" value="token" />"#, "test.vue");
+        assert_eq!(result.warning_count, 0);
+    }
+
+    #[test]
+    fn test_valid_bound_literal_hidden_input() {
+        let linter = create_linter();
+        let result =
+            linter.lint_template(r#"<input :type="'hidden'" value="token" />"#, "test.vue");
         assert_eq!(result.warning_count, 0);
     }
 

--- a/crates/vize_patina/src/rules/a11y/helpers.rs
+++ b/crates/vize_patina/src/rules/a11y/helpers.rs
@@ -98,6 +98,52 @@ pub fn get_static_attribute_value<'a>(element: &'a ElementNode, name: &str) -> O
     None
 }
 
+/// Get a static attribute value, including v-bind expressions that are string literals.
+///
+/// This is useful for rules that need exact attribute values but should not warn when
+/// Vue's bind syntax is only wrapping a literal value, e.g. `:type="'hidden'"`.
+pub fn get_static_or_bound_literal_attribute_value<'a>(
+    element: &'a ElementNode,
+    name: &str,
+) -> Option<&'a str> {
+    for prop in &element.props {
+        match prop {
+            PropNode::Attribute(attr) if attr.name == name => {
+                return attr.value.as_ref().map(|v| v.content.as_ref());
+            }
+            PropNode::Directive(dir) if dir.name == "bind" => {
+                let Some(ExpressionNode::Simple(arg)) = &dir.arg else {
+                    continue;
+                };
+                if arg.content != name {
+                    continue;
+                }
+                let Some(ExpressionNode::Simple(exp)) = &dir.exp else {
+                    continue;
+                };
+                if let Some(value) = string_literal_value(exp.content.as_ref()) {
+                    return Some(value);
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+fn string_literal_value(content: &str) -> Option<&str> {
+    let content = content.trim();
+    let quote = content.as_bytes().first()?;
+    if content.len() < 2
+        || !matches!(quote, b'\'' | b'"')
+        || content.as_bytes().last() != Some(quote)
+    {
+        return None;
+    }
+
+    Some(&content[1..content.len() - 1])
+}
+
 /// Check if an element has a specific event handler (v-on directive)
 pub fn has_event_handler(element: &ElementNode, event_name: &str) -> bool {
     for prop in &element.props {


### PR DESCRIPTION
## Summary
- Treat literal v-bind values like `:type="'hidden'"` as static for exact attribute checks
- Avoid false positives from `a11y/form-control-has-label` on exempt input types
- Add regression coverage for bound literal hidden inputs

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p vize_patina form_control_has_label -- --nocapture`
- `cargo clippy -p vize_patina -- -D warnings`
- `cargo test -p vize_patina --lib`