### PR TITLE
fix(type): detect floating promises in control flow

### DIFF
--- a/crates/vize_patina/src/linter/native_type_aware/parsing.rs
+++ b/crates/vize_patina/src/linter/native_type_aware/parsing.rs
@@ -1,8 +1,9 @@
 use oxc_allocator::Allocator as OxcAllocator;
 use oxc_ast::ast::{
-    CallExpression, ChainElement, Expression, ObjectExpression, ObjectPropertyKind, PropertyKey,
-    Statement,
+    CallExpression, ChainElement, Expression, ExpressionStatement, ObjectExpression,
+    ObjectPropertyKind, PropertyKey, Statement,
 };
+use oxc_ast_visit::{walk::walk_expression_statement, Visit};
 use oxc_parser::Parser as OxcParser;
 use oxc_span::{GetSpan, SourceType};
 use oxc_syntax::operator::UnaryOperator;
@@ -89,20 +90,30 @@ pub(super) fn collect_floating_candidates(source: &str) -> Vec<FloatingCandidate
         return Vec::new();
     }
 
-    let mut candidates = Vec::new();
-    for statement in parsed.program.body.iter() {
-        if let Statement::ExpressionStatement(expression_statement) = statement {
-            if is_explicitly_handled(&expression_statement.expression) {
-                continue;
+    let mut collector = FloatingCandidateCollector::default();
+    collector.visit_program(&parsed.program);
+    collector.candidates
+}
+
+#[derive(Default)]
+struct FloatingCandidateCollector {
+    candidates: Vec<FloatingCandidate>,
+}
+
+impl<'a> Visit<'a> for FloatingCandidateCollector {
+    fn visit_expression_statement(&mut self, statement: &ExpressionStatement<'a>) {
+        if !is_explicitly_handled(&statement.expression) {
+            let span = statement.expression.span();
+            if span.end > span.start {
+                self.candidates.push(FloatingCandidate {
+                    start: span.start,
+                    end: span.end,
+                });
             }
-            let span = expression_statement.expression.span();
-            candidates.push(FloatingCandidate {
-                start: span.start,
-                end: span.end,
-            });
         }
+
+        walk_expression_statement(self, statement);
     }
-    candidates
 }
 
 fn unwrap_object_expression<'a>(

--- a/crates/vize_patina/src/linter/native_type_aware/tests.rs
+++ b/crates/vize_patina/src/linter/native_type_aware/tests.rs
@@ -80,6 +80,30 @@ loadData()
 }
 
 #[test]
+fn no_floating_promises_reports_control_flow_calls() {
+    if !corsa_available() {
+        return;
+    }
+
+    let linter = Linter::with_preset(LintPreset::Opinionated);
+    let source = r#"<script setup lang="ts">
+async function loadData(): Promise<number> {
+  return 1
+}
+
+const enabled = true
+if (enabled) {
+  loadData()
+}
+</script>"#;
+    let result = lint_sfc_with_corsa(&linter, source, "Component.vue");
+    assert!(result
+        .diagnostics
+        .iter()
+        .any(|diag| diag.rule_name == RULE_NO_FLOATING_PROMISES));
+}
+
+#[test]
 fn no_floating_promises_reports_template_event_calls() {
     if !corsa_available() {
         return;


### PR DESCRIPTION
## Summary
- Walk script expression statements recursively when collecting floating Promise candidates
- Detect unhandled Promise calls inside control-flow blocks instead of only top-level statements
- Add regression coverage for an `if` block containing an unhandled async call

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p vize_patina no_floating_promises_reports_control_flow_calls -- --nocapture`
- `cargo test -p vize_patina no_floating_promises -- --nocapture`
- `cargo test -p vize_patina native_type_aware -- --nocapture`
- `cargo clippy -p vize_patina -- -D warnings`
- `cargo test -p vize_patina --lib`