### PR TITLE
fix(type): flag promises handled only by finally

### DIFF
--- a/crates/vize_patina/src/linter/native_type_aware/parsing.rs
+++ b/crates/vize_patina/src/linter/native_type_aware/parsing.rs
@@ -170,10 +170,37 @@ fn is_explicitly_handled(expression: &Expression<'_>) -> bool {
 }
 
 fn is_handled_call(call: &CallExpression<'_>) -> bool {
-    call.callee
-        .as_member_expression()
-        .and_then(|member| member.static_property_name())
-        .is_some_and(|name| matches!(name, "then" | "catch" | "finally"))
+    let Some(member) = call.callee.as_member_expression() else {
+        return false;
+    };
+
+    match member.static_property_name() {
+        Some("then" | "catch") => true,
+        Some("finally") => is_handled_promise_chain(member.object()),
+        _ => false,
+    }
+}
+
+fn is_handled_promise_chain(expression: &Expression<'_>) -> bool {
+    match expression {
+        Expression::ParenthesizedExpression(paren) => is_handled_promise_chain(&paren.expression),
+        Expression::TSAsExpression(ts_as) => is_handled_promise_chain(&ts_as.expression),
+        Expression::TSSatisfiesExpression(ts_satisfies) => {
+            is_handled_promise_chain(&ts_satisfies.expression)
+        }
+        Expression::TSNonNullExpression(ts_non_null) => {
+            is_handled_promise_chain(&ts_non_null.expression)
+        }
+        Expression::ChainExpression(chain) => match &chain.expression {
+            ChainElement::CallExpression(call) => is_handled_call(call),
+            ChainElement::TSNonNullExpression(non_null) => {
+                is_handled_promise_chain(&non_null.expression)
+            }
+            _ => false,
+        },
+        Expression::CallExpression(call) => is_handled_call(call),
+        _ => false,
+    }
 }
 
 fn is_macro_call_expression(expression: &Expression<'_>) -> bool {

--- a/crates/vize_patina/src/linter/native_type_aware/template_queries/calls.rs
+++ b/crates/vize_patina/src/linter/native_type_aware/template_queries/calls.rs
@@ -228,8 +228,35 @@ fn is_explicitly_handled(expression: &Expression<'_>) -> bool {
 }
 
 fn is_handled_call(call: &CallExpression<'_>) -> bool {
-    call.callee
-        .as_member_expression()
-        .and_then(|member| member.static_property_name())
-        .is_some_and(|name| matches!(name, "then" | "catch" | "finally"))
+    let Some(member) = call.callee.as_member_expression() else {
+        return false;
+    };
+
+    match member.static_property_name() {
+        Some("then" | "catch") => true,
+        Some("finally") => is_handled_promise_chain(member.object()),
+        _ => false,
+    }
+}
+
+fn is_handled_promise_chain(expression: &Expression<'_>) -> bool {
+    match expression {
+        Expression::ParenthesizedExpression(paren) => is_handled_promise_chain(&paren.expression),
+        Expression::TSAsExpression(ts_as) => is_handled_promise_chain(&ts_as.expression),
+        Expression::TSSatisfiesExpression(ts_satisfies) => {
+            is_handled_promise_chain(&ts_satisfies.expression)
+        }
+        Expression::TSNonNullExpression(ts_non_null) => {
+            is_handled_promise_chain(&ts_non_null.expression)
+        }
+        Expression::ChainExpression(chain) => match &chain.expression {
+            ChainElement::CallExpression(call) => is_handled_call(call),
+            ChainElement::TSNonNullExpression(non_null) => {
+                is_handled_promise_chain(&non_null.expression)
+            }
+            _ => false,
+        },
+        Expression::CallExpression(call) => is_handled_call(call),
+        _ => false,
+    }
 }

--- a/crates/vize_patina/src/linter/native_type_aware/tests.rs
+++ b/crates/vize_patina/src/linter/native_type_aware/tests.rs
@@ -104,6 +104,53 @@ if (enabled) {
 }
 
 #[test]
+fn no_floating_promises_reports_finally_only_calls() {
+    if !corsa_available() {
+        return;
+    }
+
+    let linter = Linter::with_preset(LintPreset::Opinionated);
+    let source = r#"<script setup lang="ts">
+async function loadData(): Promise<number> {
+  return 1
+}
+function cleanup() {}
+
+loadData().finally(cleanup)
+</script>"#;
+    let result = lint_sfc_with_corsa(&linter, source, "Component.vue");
+    assert!(result
+        .diagnostics
+        .iter()
+        .any(|diag| diag.rule_name == RULE_NO_FLOATING_PROMISES));
+}
+
+#[test]
+fn handled_finally_chains_are_ignored() {
+    if !corsa_available() {
+        return;
+    }
+
+    let linter = Linter::with_preset(LintPreset::Opinionated);
+    let source = r#"<script setup lang="ts">
+async function loadData(): Promise<number> {
+  return 1
+}
+function cleanup() {}
+function report(error: unknown) {
+  console.error(error)
+}
+
+loadData().catch(report).finally(cleanup)
+</script>"#;
+    let result = lint_sfc_with_corsa(&linter, source, "Component.vue");
+    assert!(!result
+        .diagnostics
+        .iter()
+        .any(|diag| diag.rule_name == RULE_NO_FLOATING_PROMISES));
+}
+
+#[test]
 fn no_floating_promises_reports_template_event_calls() {
     if !corsa_available() {
         return;
@@ -145,6 +192,28 @@ async function loadLabel(): Promise<string> {
         diag.rule_name == RULE_NO_FLOATING_PROMISES
             && diag.message.contains("Template interpolation")
     }));
+}
+
+#[test]
+fn no_floating_promises_reports_template_finally_only_calls() {
+    if !corsa_available() {
+        return;
+    }
+
+    let linter = Linter::with_preset(LintPreset::Opinionated);
+    let source = r#"<script setup lang="ts">
+async function save(): Promise<void> {}
+function cleanup() {}
+</script>
+
+<template>
+  <button @click="save().finally(cleanup)">Save</button>
+</template>"#;
+    let result = lint_sfc_with_corsa(&linter, source, "Component.vue");
+    assert!(result
+        .diagnostics
+        .iter()
+        .any(|diag| diag.rule_name == RULE_NO_FLOATING_PROMISES));
 }
 
 #[test]
@@ -379,6 +448,31 @@ function report(error: unknown) {
 
 <template>
   <button @click="save().catch(report)">Save</button>
+</template>"#;
+    let result = lint_sfc_with_corsa(&linter, source, "Component.vue");
+    assert!(!result
+        .diagnostics
+        .iter()
+        .any(|diag| diag.rule_name == RULE_NO_FLOATING_PROMISES));
+}
+
+#[test]
+fn handled_template_finally_chains_are_ignored() {
+    if !corsa_available() {
+        return;
+    }
+
+    let linter = Linter::with_preset(LintPreset::Opinionated);
+    let source = r#"<script setup lang="ts">
+async function save(): Promise<void> {}
+function cleanup() {}
+function report(error: unknown) {
+  console.error(error)
+}
+</script>
+
+<template>
+  <button @click="save().catch(report).finally(cleanup)">Save</button>
 </template>"#;
     let result = lint_sfc_with_corsa(&linter, source, "Component.vue");
     assert!(!result


### PR DESCRIPTION
## Summary
- Treat `.finally(...)` as handled only when an earlier `.then(...)` or `.catch(...)` already handles the chain
- Report script and template Promise calls that only attach `finally` callbacks
- Keep caught chains like `.catch(...).finally(...)` quiet

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p vize_patina finally -- --nocapture`
- `cargo test -p vize_patina no_floating_promises -- --nocapture`
- `cargo test -p vize_patina native_type_aware -- --nocapture`
- `cargo clippy -p vize_patina -- -D warnings`
- `cargo test -p vize_patina --lib`