### PR TITLE
style(docs): format nuxt integration guide

### DIFF
--- a/docs/content/integrations/nuxt.md
+++ b/docs/content/integrations/nuxt.md
@@ -19,7 +19,7 @@ vp install @vizejs/nuxt
 ```
 
 If you want to use `pkl` config with pnpm, you might need to install the `vize` package itself.
-`@vizejs/nuxt` installs `vize` which serves `vize.pkl` with default config, but the location of `vize.pkl` may differ when using pnpm. 
+`@vizejs/nuxt` installs `vize` which serves `vize.pkl` with default config, but the location of `vize.pkl` may differ when using pnpm.
 
 ```bash
 vp install vize


### PR DESCRIPTION
## Summary
- remove trailing whitespace from the Nuxt integration guide
- restore workspace formatting check on latest main

## Validation
- pnpm exec vp run --workspace-root check:ci