### PR TITLE
fix(type): detect nested template promises

### DIFF
--- a/crates/vize_patina/src/linter/native_type_aware/template_queries/calls.rs
+++ b/crates/vize_patina/src/linter/native_type_aware/template_queries/calls.rs
@@ -74,11 +74,11 @@ pub(super) fn collect_floating_promise_ranges(
         "patina.type_aware.template_floating.parse_expression",
         OxcParser::new(&allocator, source, source_type).parse_expression()
     ) {
-        if expression.span().end as usize == source.trim_end().len()
-            && !is_explicitly_handled(&expression)
-        {
-            if let Some(range) = floating_promise_range_for_expression(&expression) {
-                return vec![range];
+        if expression.span().end as usize == source.trim_end().len() {
+            let mut ranges = Vec::new();
+            collect_floating_promise_ranges_for_expression(&expression, &mut ranges);
+            if !ranges.is_empty() {
+                return ranges;
             }
         }
     }
@@ -100,17 +100,17 @@ pub(super) fn collect_floating_promise_ranges(
         let Statement::ExpressionStatement(expression_statement) = statement else {
             continue;
         };
-        let expression = &expression_statement.expression;
-        if is_explicitly_handled(expression) {
-            continue;
+        let mut statement_ranges = Vec::new();
+        collect_floating_promise_ranges_for_expression(
+            &expression_statement.expression,
+            &mut statement_ranges,
+        );
+        for range in statement_ranges {
+            if range.end <= range.start || range.end as usize > source.len() {
+                continue;
+            }
+            ranges.push(range);
         }
-        let Some(range) = floating_promise_range_for_expression(expression) else {
-            continue;
-        };
-        if range.end <= range.start || range.end as usize > source.len() {
-            continue;
-        }
-        ranges.push(range);
     }
     ranges
 }
@@ -200,6 +200,37 @@ fn floating_promise_range_for_expression(
             floating_promise_range_for_expression(&ts_non_null.expression)
         }
         _ => None,
+    }
+}
+
+fn collect_floating_promise_ranges_for_expression(
+    expression: &Expression<'_>,
+    ranges: &mut Vec<FloatingPromiseRange>,
+) {
+    if is_explicitly_handled(expression) {
+        return;
+    }
+    if let Some(range) = floating_promise_range_for_expression(expression) {
+        ranges.push(range);
+        return;
+    }
+
+    match expression {
+        Expression::LogicalExpression(logical) => {
+            collect_floating_promise_ranges_for_expression(&logical.left, ranges);
+            collect_floating_promise_ranges_for_expression(&logical.right, ranges);
+        }
+        Expression::ConditionalExpression(conditional) => {
+            collect_floating_promise_ranges_for_expression(&conditional.test, ranges);
+            collect_floating_promise_ranges_for_expression(&conditional.consequent, ranges);
+            collect_floating_promise_ranges_for_expression(&conditional.alternate, ranges);
+        }
+        Expression::SequenceExpression(sequence) => {
+            for expression in &sequence.expressions {
+                collect_floating_promise_ranges_for_expression(expression, ranges);
+            }
+        }
+        _ => {}
     }
 }
 

--- a/crates/vize_patina/src/linter/native_type_aware/tests.rs
+++ b/crates/vize_patina/src/linter/native_type_aware/tests.rs
@@ -195,6 +195,52 @@ async function loadLabel(): Promise<string> {
 }
 
 #[test]
+fn no_floating_promises_reports_nested_template_event_calls() {
+    if !corsa_available() {
+        return;
+    }
+
+    let linter = Linter::with_preset(LintPreset::Opinionated);
+    let source = r#"<script setup lang="ts">
+const enabled = true
+async function save(): Promise<void> {}
+</script>
+
+<template>
+  <button @click="enabled && save()">Save</button>
+</template>"#;
+    let result = lint_sfc_with_corsa(&linter, source, "Component.vue");
+    assert!(result.diagnostics.iter().any(|diag| {
+        diag.rule_name == RULE_NO_FLOATING_PROMISES
+            && diag.message.contains("Template event handler")
+    }));
+}
+
+#[test]
+fn no_floating_promises_reports_nested_template_interpolations() {
+    if !corsa_available() {
+        return;
+    }
+
+    let linter = Linter::with_preset(LintPreset::Opinionated);
+    let source = r#"<script setup lang="ts">
+const enabled = true
+async function loadLabel(): Promise<string> {
+  return 'ready'
+}
+</script>
+
+<template>
+  <p>{{ enabled ? loadLabel() : 'idle' }}</p>
+</template>"#;
+    let result = lint_sfc_with_corsa(&linter, source, "Component.vue");
+    assert!(result.diagnostics.iter().any(|diag| {
+        diag.rule_name == RULE_NO_FLOATING_PROMISES
+            && diag.message.contains("Template interpolation")
+    }));
+}
+
+#[test]
 fn no_floating_promises_reports_template_finally_only_calls() {
     if !corsa_available() {
         return;
@@ -211,6 +257,31 @@ function cleanup() {}
 </template>"#;
     let result = lint_sfc_with_corsa(&linter, source, "Component.vue");
     assert!(result
+        .diagnostics
+        .iter()
+        .any(|diag| diag.rule_name == RULE_NO_FLOATING_PROMISES));
+}
+
+#[test]
+fn handled_nested_template_promises_are_ignored() {
+    if !corsa_available() {
+        return;
+    }
+
+    let linter = Linter::with_preset(LintPreset::Opinionated);
+    let source = r#"<script setup lang="ts">
+const enabled = true
+async function save(): Promise<void> {}
+function report(error: unknown) {
+  console.error(error)
+}
+</script>
+
+<template>
+  <button @click="enabled && save().catch(report)">Save</button>
+</template>"#;
+    let result = lint_sfc_with_corsa(&linter, source, "Component.vue");
+    assert!(!result
         .diagnostics
         .iter()
         .any(|diag| diag.rule_name == RULE_NO_FLOATING_PROMISES));


### PR DESCRIPTION
## Summary
- Collect floating Promise candidates inside template logical, conditional, and sequence expressions
- Preserve handling for nested chains that already call `.catch(...)` or `.then(...)`
- Add regression coverage for nested template event handlers and interpolations

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p vize_patina nested_template -- --nocapture`
- `cargo test -p vize_patina no_floating_promises -- --nocapture`
- `cargo test -p vize_patina native_type_aware -- --nocapture`
- `cargo clippy -p vize_patina -- -D warnings`
- `cargo test -p vize_patina --lib`