### PR TITLE
ci: add timeouts to pr checks

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -20,6 +20,7 @@ jobs:
   pr-benchmark:
     name: pr-benchmark
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read
       issues: write

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -20,6 +20,7 @@ env:
 jobs:
   nix-flake:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
       - uses: cachix/install-nix-action@v31
@@ -33,6 +34,7 @@ jobs:
 
   fmt-rust:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
@@ -43,6 +45,7 @@ jobs:
 
   check-js:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     env:
       NODE_OPTIONS: "--disable-warning=DEP0040 --disable-warning=DEP0169"
     steps:
@@ -75,6 +78,7 @@ jobs:
 
   clippy-and-test:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
@@ -91,6 +95,7 @@ jobs:
 
   coverage:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
 
@@ -108,6 +113,7 @@ jobs:
 
   playground-test:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read
     steps:

--- a/tests/tooling/github-workflows.test.ts
+++ b/tests/tooling/github-workflows.test.ts
@@ -10,11 +10,40 @@ function readRepoFile(...segments: string[]): string {
   return fs.readFileSync(path.join(root, ...segments), "utf8");
 }
 
+function workflowJobBody(workflow: string, jobName: string): string {
+  const jobStart = workflow.indexOf(`\n  ${jobName}:\n`);
+  assert.notEqual(jobStart, -1, `missing job ${jobName}`);
+  const remaining = workflow.slice(jobStart + 1);
+  const nextJobMatch = /\n  [a-z0-9-]+:\n/g.exec(remaining.slice(1));
+  return remaining.slice(0, nextJobMatch ? nextJobMatch.index + 1 : undefined);
+}
+
 test("GitHub workflows opt JavaScript actions into Node 24", () => {
   for (const workflowName of ["check.yml", "deploy-docs.yml", "release.yml"]) {
     const workflow = readRepoFile(".github", "workflows", workflowName);
     assert.match(workflow, /FORCE_JAVASCRIPT_ACTIONS_TO_NODE24:\s*true/);
   }
+});
+
+test("PR CI jobs cap runtime with explicit timeouts", () => {
+  const checkWorkflow = readRepoFile(".github", "workflows", "check.yml");
+  const benchmarkWorkflow = readRepoFile(".github", "workflows", "benchmark.yml");
+
+  for (const [jobName, minutes] of [
+    ["nix-flake", 30],
+    ["fmt-rust", 10],
+    ["check-js", 30],
+    ["clippy-and-test", 30],
+    ["coverage", 10],
+    ["playground-test", 30],
+  ] as const) {
+    assert.match(
+      workflowJobBody(checkWorkflow, jobName),
+      new RegExp(`timeout-minutes:\\s*${minutes}\\b`),
+    );
+  }
+
+  assert.match(workflowJobBody(benchmarkWorkflow, "pr-benchmark"), /timeout-minutes:\s*30\b/);
 });
 
 test("deploy-docs deploy job installs MoonBit before running script-mode helpers", () => {


### PR DESCRIPTION
## Summary
- Add explicit timeouts to PR Check jobs so stalled runs stop consuming runner time
- Add the same cap to PR Benchmark
- Guard the workflow settings with a tooling test

## Validation
- `ruby -e 'require "yaml"; ARGV.each { |file| YAML.load_file(file); puts "ok #{file}" }' .github/workflows/check.yml .github/workflows/benchmark.yml`
- `node --test --test-concurrency=1 tests/tooling/github-workflows.test.ts`
- `vp check tests/tooling/github-workflows.test.ts vite.config.ts`

## Note
- `vp run --workspace-root test:scripts` still has unrelated local failures in existing LSP/production-readiness tests around local CLI/LSP behavior.