### PR TITLE
fix(vite): support css regexp aliases

### DIFF
--- a/npm/vite-plugin-vize/src/plugin/index.ts
+++ b/npm/vite-plugin-vize/src/plugin/index.ts
@@ -33,6 +33,10 @@ import { patchUnoCssBridge } from "./unocss.ts";
 
 export type { VizePluginState } from "./state.ts";
 
+function aliasSortKey(find: string | RegExp): number {
+  return typeof find === "string" ? find.length : find.source.length;
+}
+
 export function vize(options: VizeOptions = {}): Plugin[] {
   const state: VizePluginState = {
     cache: new Map(),
@@ -207,7 +211,10 @@ export function vize(options: VizeOptions = {}): Plugin[] {
       // Build CSS alias rules for @import resolution (use filesystem paths, not browser paths)
       state.cssAliasRules = [];
       for (const alias of resolvedConfig.resolve.alias) {
-        if (typeof alias.find !== "string" || typeof alias.replacement !== "string") {
+        if (
+          !(typeof alias.find === "string" || alias.find instanceof RegExp) ||
+          typeof alias.replacement !== "string"
+        ) {
           continue;
         }
         state.cssAliasRules.push({
@@ -216,7 +223,7 @@ export function vize(options: VizeOptions = {}): Plugin[] {
         });
       }
       // Prefer longer alias keys first
-      state.cssAliasRules.sort((a, b) => b.find.length - a.find.length);
+      state.cssAliasRules.sort((a, b) => aliasSortKey(b.find) - aliasSortKey(a.find));
 
       state.filter = createFilter(state.mergedOptions.include, state.mergedOptions.exclude);
       state.scanPatterns = state.mergedOptions.scanPatterns ?? ["**/*.vue"];

--- a/npm/vite-plugin-vize/src/utils.test.ts
+++ b/npm/vite-plugin-vize/src/utils.test.ts
@@ -448,6 +448,26 @@ function resolveCssTransforms(css: string): string {
   );
 }
 
+// Test 22: CSS aliases should support RegExp find rules
+{
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "vize-css-regexp-alias-"));
+  const assetPath = path.join(tempDir, "src", "assets", "logo.svg");
+  fs.mkdirSync(path.dirname(assetPath), { recursive: true });
+  fs.writeFileSync(assetPath, "");
+
+  const result = resolveCssImports(
+    `.logo { background-image: url("@app/assets/logo.svg"); }`,
+    path.join(tempDir, "Component.vue"),
+    [{ find: /^@app\/(.+)$/, replacement: path.join(tempDir, "src", "$1") }],
+    true,
+  );
+
+  assert.ok(
+    result.includes(`url("/@fs${assetPath.replace(/\\/g, "/")}")`),
+    "CSS alias should resolve RegExp find rules",
+  );
+}
+
 // =============================================================================
 // Test: applyDefineReplacements
 // =============================================================================

--- a/npm/vite-plugin-vize/src/utils/css.ts
+++ b/npm/vite-plugin-vize/src/utils/css.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 
 export interface CssAliasRule {
-  find: string;
+  find: string | RegExp;
   replacement: string;
 }
 
@@ -401,9 +401,8 @@ function resolveCssPath(
 ): string | null {
   // Try alias resolution
   for (const rule of aliasRules) {
-    const suffix = matchedAliasSuffix(importPath, rule.find);
-    if (suffix !== null) {
-      const resolved = path.join(rule.replacement, suffix);
+    const resolved = resolveAliasPath(importPath, rule);
+    if (resolved !== null) {
       return path.resolve(resolved);
     }
   }
@@ -420,6 +419,24 @@ function resolveCssPath(
   }
 
   return null;
+}
+
+function resolveAliasPath(importPath: string, rule: CssAliasRule): string | null {
+  if (typeof rule.find !== "string") {
+    const pattern = stableAliasPattern(rule.find);
+    return pattern.test(importPath) ? importPath.replace(pattern, rule.replacement) : null;
+  }
+
+  const suffix = matchedAliasSuffix(importPath, rule.find);
+  if (suffix !== null) {
+    return path.join(rule.replacement, suffix);
+  }
+
+  return null;
+}
+
+function stableAliasPattern(pattern: RegExp): RegExp {
+  return new RegExp(pattern.source, pattern.flags.replace(/[gy]/g, ""));
 }
 
 function matchedAliasSuffix(importPath: string, find: string): string | null {


### PR DESCRIPTION
## Summary
- keep RegExp Vite aliases in CSS alias rules
- apply RegExp alias replacements while resolving SFC CSS imports and url() assets
- cover capture-group CSS alias rewrites with a focused utils test

## Validation
- node npm/vite-plugin-vize/src/utils.test.ts
- pnpm --dir npm/vite-plugin-vize check
- pnpm --dir npm/vite-plugin-vize test
- pnpm exec vp run --workspace-root check:ci