### PR TITLE
ci: use cache v5 across workflows

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -76,7 +76,7 @@ jobs:
 
       - name: Cache WASM build
         id: cache-wasm
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             npm/vize-wasm

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Cache Playwright browsers
         id: cache-playwright
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ hashFiles('**/pnpm-lock.yaml') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -161,7 +161,7 @@ jobs:
       - uses: ./.github/actions/setup-moonbit
 
       - name: Cache pnpm store for VS Code extension tooling
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.local/share/pnpm/store
           key: ${{ runner.os }}-pnpm-vscode-release-${{ hashFiles('.node-version') }}-v1
@@ -507,7 +507,7 @@ jobs:
 
       - name: Cache WASM package build
         id: cache-wasm
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: npm/vize-wasm
           key: ${{ runner.os }}-release-wasm-${{ hashFiles('crates/**/*.rs', 'Cargo.lock', 'npm/vize-wasm/package.json') }}

--- a/tests/tooling/github-workflows.test.ts
+++ b/tests/tooling/github-workflows.test.ts
@@ -25,6 +25,20 @@ test("GitHub workflows opt JavaScript actions into Node 24", () => {
   }
 });
 
+test("GitHub workflows use the current cache action", () => {
+  for (const relativePath of [
+    ".github/actions/setup-moonbit/action.yml",
+    ".github/workflows/benchmark.yml",
+    ".github/workflows/check.yml",
+    ".github/workflows/deploy-docs.yml",
+    ".github/workflows/e2e.yml",
+    ".github/workflows/release.yml",
+  ]) {
+    const file = readRepoFile(...relativePath.split("/"));
+    assert.doesNotMatch(file, /uses:\s*actions\/cache@v4/, `${relativePath} still uses cache v4`);
+  }
+});
+
 test("PR CI jobs cap runtime with explicit timeouts", () => {
   const checkWorkflow = readRepoFile(".github", "workflows", "check.yml");
   const benchmarkWorkflow = readRepoFile(".github", "workflows", "benchmark.yml");


### PR DESCRIPTION
## Summary
- Upgrade remaining workflow cache steps from actions/cache v4 to v5
- Keep E2E, docs, release, Check, Benchmark, and setup-moonbit on one cache action generation
- Add a tooling test to prevent cache v4 from returning

## Validation
- `ruby -e 'require "yaml"; ARGV.each { |file| YAML.load_file(file); puts "ok #{file}" }' .github/workflows/e2e.yml .github/workflows/deploy-docs.yml .github/workflows/release.yml`
- `node --test --test-concurrency=1 tests/tooling/github-workflows.test.ts`
- `vp check tests/tooling/github-workflows.test.ts vite.config.ts`