### PR TITLE
fix(vite): support regexp aliases in virtual resolution

### DIFF
--- a/npm/vite-plugin-vize/src/plugin/resolve.test.ts
+++ b/npm/vite-plugin-vize/src/plugin/resolve.test.ts
@@ -209,6 +209,57 @@ function expectResolvedId(resolved: Awaited<ReturnType<typeof resolveIdHook>>): 
 }
 
 {
+  const tempRoot = createTempRoot("regexp-bare-alias");
+  const viteRoot = path.join(tempRoot, "app");
+  const importer = path.join(tempRoot, "app", "src", "App.vue");
+  const packageName = "vize-regexp-alias-fixture";
+  const packageRoot = path.join(
+    tempRoot,
+    "node_modules",
+    ".pnpm",
+    `${packageName}@0.0.0`,
+    "node_modules",
+    packageName,
+  );
+  const pnpmHoistRoot = path.join(tempRoot, "node_modules", ".pnpm", "node_modules");
+  const entry = path.join(packageRoot, "esm", "vs", "editor", "editor.main.js");
+
+  fs.mkdirSync(path.dirname(importer), { recursive: true });
+  fs.mkdirSync(path.dirname(entry), { recursive: true });
+  fs.mkdirSync(pnpmHoistRoot, { recursive: true });
+  fs.writeFileSync(importer, "<template><div /></template>");
+  fs.writeFileSync(
+    path.join(packageRoot, "package.json"),
+    `{"name":"${packageName}","version":"0.0.0"}`,
+  );
+  fs.writeFileSync(entry, "export const editor = {};");
+  fs.symlinkSync(packageRoot, path.join(pnpmHoistRoot, packageName), "dir");
+
+  const state = createState(viteRoot);
+  state.server = null;
+  state.cssAliasRules = [
+    {
+      find: /^vize-regexp-alias-fixture$/,
+      replacement: "vize-regexp-alias-fixture/esm/vs/editor/editor.main.js",
+    },
+  ];
+
+  const resolved = await resolveIdHook(
+    nullResolveContext,
+    state,
+    packageName,
+    toVirtualId(importer),
+    undefined,
+  );
+
+  assert.equal(
+    expectResolvedId(resolved),
+    entry,
+    "RegExp package aliases from virtual modules should resolve to loadable files",
+  );
+}
+
+{
   const projectRoot = path.join(workspaceRoot, "tests", "_fixtures", "_git", "npmx.dev");
   if (hasFixtureProject(projectRoot)) {
     const importer = toVirtualId(path.join(projectRoot, "app", "pages", "index.vue"));

--- a/npm/vite-plugin-vize/src/plugin/resolve.ts
+++ b/npm/vite-plugin-vize/src/plugin/resolve.ts
@@ -108,6 +108,14 @@ function resolveAliasRequest(
 ): string | null {
   const [request, querySuffix] = splitIdQuery(id);
   for (const rule of state.cssAliasRules) {
+    if (rule.find instanceof RegExp) {
+      const pattern = stableAliasPattern(rule.find);
+      if (pattern.test(request)) {
+        return request.replace(pattern, rule.replacement) + querySuffix;
+      }
+      continue;
+    }
+
     if (request === rule.find) {
       return rule.replacement + querySuffix;
     }
@@ -121,6 +129,10 @@ function resolveAliasRequest(
     }
   }
   return null;
+}
+
+function stableAliasPattern(pattern: RegExp): RegExp {
+  return new RegExp(pattern.source, pattern.flags.replace(/[gy]/g, ""));
 }
 
 function pushPnpmHoistBases(

--- a/npm/vize/package.json
+++ b/npm/vize/package.json
@@ -73,6 +73,6 @@
     "@vizejs/native-win32-x64-msvc": "catalog:native-binaries"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=22"
   }
 }

--- a/tests/tooling/package-manifests.test.ts
+++ b/tests/tooling/package-manifests.test.ts
@@ -142,9 +142,11 @@ test("vize package delegates rule type generation to the workspace MoonBit task"
   const vizePackage = JSON.parse(
     fs.readFileSync(path.join(root, "npm/vize/package.json"), "utf-8"),
   ) as {
+    engines?: Record<string, string>;
     scripts?: Record<string, string>;
   };
 
+  assert.equal(vizePackage.engines?.node, ">=22");
   assert.equal(
     vizePackage.scripts?.["generate:rule-types"],
     "vp run --workspace-root generate:rule-types",


### PR DESCRIPTION
## Summary

- Support RegExp aliases when resolving bare imports from Vize virtual modules.
- Add a pnpm-hoist fixture test for RegExp package aliases.
- Raise the published CLI Node engine to `>=22` so Node 20 is excluded.

## Verification

- `cargo fmt --all -- --check`
- `pnpm exec vp run --workspace-root --no-cache check:ci`
- `cargo clippy --workspace -- -D warnings`
- `pnpm exec vp run --workspace-root --no-cache test`
- `pnpm exec vp run --workspace-root --no-cache bench:quick`
- `pnpm exec vp run --filter './npm/vite-plugin-vize' --no-cache build`
- `pnpm exec vp run --filter './playground' --no-cache build`
- `pnpm exec vp run --filter './playground' --no-cache test:browser`
