### PR TITLE
fix(security): flag static unsafe urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,9 @@ vize check --declaration --declaration-dir dist/types
 ```
 
 `vize lint` runs Patina rules for Vue templates, scripts, CSS, a11y, SSR, Vapor, Musea, cross-file,
-and type-aware checks. `vize check` generates virtual TypeScript for Vue SFCs and maps project
+and type-aware checks. Security-oriented Vue rules include `vue/no-unsafe-url`, which checks dynamic
+URL bindings and static URL attributes for executable schemes such as `javascript:`, `vbscript:`,
+and active `data:` payloads. `vize check` generates virtual TypeScript for Vue SFCs and maps project
 diagnostics back to the original source files.
 
 ## Compiler Configuration

--- a/crates/vize_carton/src/i18n/en.json
+++ b/crates/vize_carton/src/i18n/en.json
@@ -91,6 +91,8 @@
   "vue/a11y-img-alt.help": "Add alt=\"description\" for informative images or alt=\"\" for decorative images",
   "vue/no-unsafe-url.description": "Warn about potentially unsafe URL bindings",
   "vue/no-unsafe-url.message": "Dynamic :{attr} binding may be vulnerable to XSS via javascript: protocol",
+  "vue/no-unsafe-url.static_message": "Static URL attribute uses a potentially unsafe protocol or active data URL",
+  "vue/no-unsafe-url.static_help": "Use http(s), relative URLs, or a non-executable data URL. Avoid javascript:, vbscript:, text/html data URLs, and SVG data URLs",
   "vue/no-unsafe-url.help_href": "Consider using <router-link :to=\"...\"> or sanitize URLs with @braintree/sanitize-url",
   "vue/no-unsafe-url.help_src": "Ensure URLs are sanitized before binding. Use @braintree/sanitize-url for validation",
   "vue/no-unsafe-url.help": "Ensure URLs are sanitized before binding to prevent XSS via javascript: protocol",

--- a/crates/vize_carton/src/i18n/ja.json
+++ b/crates/vize_carton/src/i18n/ja.json
@@ -91,6 +91,8 @@
   "vue/a11y-img-alt.help": "説明的な画像にはalt=\"説明\"を、装飾的な画像にはalt=\"\"を追加してください",
   "vue/no-unsafe-url.description": "安全でないURLバインディングについて警告する",
   "vue/no-unsafe-url.message": "動的な:{attr}バインディングはjavascript:プロトコル経由でXSSに脆弱な可能性があります",
+  "vue/no-unsafe-url.static_message": "静的URL属性に安全でない可能性のあるプロトコルまたは実行可能なdata URLが使われています",
+  "vue/no-unsafe-url.static_help": "http(s)、相対URL、または実行可能でないdata URLを使用してください。javascript:、vbscript:、text/html data URL、SVG data URLは避けてください",
   "vue/no-unsafe-url.help_href": "<router-link :to=\"...\">を使用するか、@braintree/sanitize-urlでURLをサニタイズすることを検討してください",
   "vue/no-unsafe-url.help_src": "バインディング前にURLがサニタイズされていることを確認してください。検証には@braintree/sanitize-urlを使用してください",
   "vue/no-unsafe-url.help": "javascript:プロトコルによるXSSを防ぐため、バインディング前にURLをサニタイズしてください",

--- a/crates/vize_carton/src/i18n/zh.json
+++ b/crates/vize_carton/src/i18n/zh.json
@@ -91,6 +91,8 @@
   "vue/a11y-img-alt.help": "为信息性图片添加alt=\"描述\"，为装饰性图片添加alt=\"\"",
   "vue/no-unsafe-url.description": "警告潜在的不安全URL绑定",
   "vue/no-unsafe-url.message": "动态:{attr}绑定可能通过javascript:协议导致XSS漏洞",
+  "vue/no-unsafe-url.static_message": "静态URL属性使用了潜在不安全协议或可执行data URL",
+  "vue/no-unsafe-url.static_help": "请使用http(s)、相对URL或不可执行的data URL。避免javascript:、vbscript:、text/html data URL和SVG data URL",
   "vue/no-unsafe-url.help_href": "考虑使用<router-link :to=\"...\">或使用@braintree/sanitize-url净化URL",
   "vue/no-unsafe-url.help_src": "确保在绑定前净化URL。使用@braintree/sanitize-url进行验证",
   "vue/no-unsafe-url.help": "在绑定前净化URL以防止通过javascript:协议的XSS攻击",

--- a/crates/vize_patina/src/rules/vue/no_unsafe_url.rs
+++ b/crates/vize_patina/src/rules/vue/no_unsafe_url.rs
@@ -23,7 +23,7 @@
 //!
 //! ### Safe Patterns
 //! ```vue
-//! <!-- Static URLs are safe -->
+//! <!-- Trusted static URLs are safe -->
 //! <a href="/about">About</a>
 //!
 //! <!-- Computed URLs with validation -->
@@ -42,7 +42,7 @@
 use crate::context::LintContext;
 use crate::diagnostic::Severity;
 use crate::rule::{Rule, RuleCategory, RuleMeta};
-use vize_relief::ast::{DirectiveNode, ElementNode, ExpressionNode};
+use vize_relief::ast::{DirectiveNode, ElementNode, ExpressionNode, PropNode};
 
 static META: RuleMeta = RuleMeta {
     name: "vue/no-unsafe-url",
@@ -57,11 +57,131 @@ static META: RuleMeta = RuleMeta {
 pub struct NoUnsafeUrl;
 
 /// Attributes that can be exploited with unsafe URLs
-const UNSAFE_URL_ATTRS: &[&str] = &["href", "src", "srcset", "action", "formaction"];
+const UNSAFE_URL_ATTRS: &[&str] = &[
+    "href",
+    "xlink:href",
+    "src",
+    "srcset",
+    "action",
+    "formaction",
+    "data",
+];
+
+fn is_url_attr(name: &str) -> bool {
+    UNSAFE_URL_ATTRS
+        .iter()
+        .any(|attr| name.eq_ignore_ascii_case(attr))
+}
+
+fn is_router_link_tag(tag: &str) -> bool {
+    tag == "router-link" || tag == "RouterLink" || tag == "nuxt-link" || tag == "NuxtLink"
+}
+
+fn normalized_scheme(value: &str) -> Option<(String, &str)> {
+    let mut scheme = String::new();
+    let mut saw_scheme_char = false;
+
+    for (index, ch) in value.char_indices() {
+        if ch == ':' {
+            return saw_scheme_char.then(|| (scheme, &value[index + 1..]));
+        }
+
+        if ch.is_ascii_whitespace() || ch.is_ascii_control() {
+            continue;
+        }
+
+        if matches!(ch, '/' | '#' | '?') {
+            return None;
+        }
+
+        if ch.is_ascii_alphanumeric() || matches!(ch, '+' | '-' | '.') {
+            saw_scheme_char = true;
+            scheme.push(ch.to_ascii_lowercase());
+            continue;
+        }
+
+        return None;
+    }
+
+    None
+}
+
+fn is_executable_data_url(rest: &str) -> bool {
+    let media_type = rest
+        .trim_start_matches(|ch: char| ch.is_ascii_whitespace() || ch.is_ascii_control())
+        .split(',')
+        .next()
+        .unwrap_or("")
+        .split(';')
+        .next()
+        .unwrap_or("")
+        .trim()
+        .to_ascii_lowercase();
+
+    matches!(
+        media_type.as_str(),
+        "text/html" | "application/xhtml+xml" | "image/svg+xml" | "text/xml" | "application/xml"
+    )
+}
+
+fn is_unsafe_url(value: &str) -> bool {
+    let Some((scheme, rest)) = normalized_scheme(value) else {
+        return false;
+    };
+
+    match scheme.as_str() {
+        "javascript" | "vbscript" => true,
+        "data" => is_executable_data_url(rest),
+        _ => false,
+    }
+}
+
+fn is_unsafe_static_attr_value(attr_name: &str, value: &str) -> bool {
+    if attr_name.eq_ignore_ascii_case("srcset") {
+        return value
+            .split(',')
+            .map(str::trim_start)
+            .filter_map(|candidate| candidate.split_ascii_whitespace().next())
+            .any(is_unsafe_url);
+    }
+
+    is_unsafe_url(value)
+}
 
 impl Rule for NoUnsafeUrl {
     fn meta(&self) -> &'static RuleMeta {
         &META
+    }
+
+    fn enter_element<'a>(&self, ctx: &mut LintContext<'a>, element: &ElementNode<'a>) {
+        if is_router_link_tag(element.tag.as_str()) {
+            return;
+        }
+
+        for prop in &element.props {
+            let PropNode::Attribute(attr) = prop else {
+                continue;
+            };
+
+            let attr_name = attr.name.as_str();
+            if !is_url_attr(attr_name) {
+                continue;
+            }
+
+            let Some(value) = &attr.value else {
+                continue;
+            };
+
+            if !is_unsafe_static_attr_value(attr_name, value.content.as_str()) {
+                continue;
+            }
+
+            ctx.warn_with_help(
+                ctx.t("vue/no-unsafe-url.static_message"),
+                &attr.loc,
+                ctx.t("vue/no-unsafe-url.static_help"),
+            );
+        }
     }
 
     fn check_directive<'a>(
@@ -82,13 +202,12 @@ impl Rule for NoUnsafeUrl {
         };
 
         // Check if this is a potentially unsafe attribute
-        if !UNSAFE_URL_ATTRS.contains(&attr_name) {
+        if !is_url_attr(attr_name) {
             return;
         }
 
         // Skip if the element is router-link (it handles routing safely)
-        let tag = element.tag.as_str();
-        if tag == "router-link" || tag == "RouterLink" || tag == "nuxt-link" || tag == "NuxtLink" {
+        if is_router_link_tag(element.tag.as_str()) {
             return;
         }
 
@@ -123,6 +242,64 @@ mod tests {
         let linter = create_linter();
         let result = linter.lint_template(r#"<a href="/about">About</a>"#, "test.vue");
         assert_eq!(result.warning_count, 0);
+    }
+
+    #[test]
+    fn test_warns_static_javascript_src() {
+        let linter = create_linter();
+        let result =
+            linter.lint_template(r#"<iframe src="javascript:alert(1)"></iframe>"#, "test.vue");
+        assert_eq!(result.warning_count, 1);
+    }
+
+    #[test]
+    fn test_warns_static_obfuscated_javascript_href() {
+        let linter = create_linter();
+        let result = linter.lint_template(
+            r#"<a href="java&#x0A;script:alert(1)">Link</a>"#,
+            "test.vue",
+        );
+        assert_eq!(result.warning_count, 1);
+    }
+
+    #[test]
+    fn test_warns_static_vbscript_formaction() {
+        let linter = create_linter();
+        let result = linter.lint_template(
+            r#"<button formaction="vbscript:msgbox(1)">Submit</button>"#,
+            "test.vue",
+        );
+        assert_eq!(result.warning_count, 1);
+    }
+
+    #[test]
+    fn test_warns_static_executable_data_url() {
+        let linter = create_linter();
+        let result = linter.lint_template(
+            r#"<iframe src="data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg=="></iframe>"#,
+            "test.vue",
+        );
+        assert_eq!(result.warning_count, 1);
+    }
+
+    #[test]
+    fn test_allows_static_image_data_url() {
+        let linter = create_linter();
+        let result = linter.lint_template(
+            r#"<img src="data:image/png;base64,iVBORw0KGgo=">"#,
+            "test.vue",
+        );
+        assert_eq!(result.warning_count, 0);
+    }
+
+    #[test]
+    fn test_warns_static_unsafe_srcset_candidate() {
+        let linter = create_linter();
+        let result = linter.lint_template(
+            r#"<img srcset="/safe.png 1x, javascript:alert(1) 2x">"#,
+            "test.vue",
+        );
+        assert_eq!(result.warning_count, 1);
     }
 
     #[test]

--- a/crates/vize_patina/src/rules/vue/no_unsafe_url.rs
+++ b/crates/vize_patina/src/rules/vue/no_unsafe_url.rs
@@ -42,6 +42,7 @@
 use crate::context::LintContext;
 use crate::diagnostic::Severity;
 use crate::rule::{Rule, RuleCategory, RuleMeta};
+use vize_carton::String;
 use vize_relief::ast::{DirectiveNode, ElementNode, ExpressionNode, PropNode};
 
 static META: RuleMeta = RuleMeta {
@@ -78,7 +79,7 @@ fn is_router_link_tag(tag: &str) -> bool {
 }
 
 fn normalized_scheme(value: &str) -> Option<(String, &str)> {
-    let mut scheme = String::new();
+    let mut scheme = String::default();
     let mut saw_scheme_char = false;
 
     for (index, ch) in value.char_indices() {

--- a/docs/content/guide/static-analysis.md
+++ b/docs/content/guide/static-analysis.md
@@ -65,6 +65,7 @@ registries that decide which rules are enabled together.
 | Area                | Example rules                                                                                | What they cover                                    |
 | ------------------- | -------------------------------------------------------------------------------------------- | -------------------------------------------------- |
 | Vue correctness     | `vue/require-v-for-key`, `vue/valid-v-model`, `vue/no-use-v-if-with-v-for`                   | Template semantics that are local to one component |
+| Vue security        | `vue/no-v-html`, `vue/no-unsafe-url`                                                         | XSS-prone HTML and URL sinks                        |
 | Vue structure       | `vue/sfc-element-order`, `vue/require-scoped-style`, `vue/no-unused-components`              | SFC shape, component usage, and maintainability    |
 | Script conventions  | `script/no-options-api`, `script/no-get-current-instance`, `script/prefer-import-from-vue`   | Vue Composition API and compiler macro conventions |
 | CSS                 | `css/no-important`, `css/no-hardcoded-values`, `css/prefer-logical-properties`               | Style blocks and design-system friendly CSS        |

--- a/docs/content/guide/static-analysis.md
+++ b/docs/content/guide/static-analysis.md
@@ -65,7 +65,7 @@ registries that decide which rules are enabled together.
 | Area                | Example rules                                                                                | What they cover                                    |
 | ------------------- | -------------------------------------------------------------------------------------------- | -------------------------------------------------- |
 | Vue correctness     | `vue/require-v-for-key`, `vue/valid-v-model`, `vue/no-use-v-if-with-v-for`                   | Template semantics that are local to one component |
-| Vue security        | `vue/no-v-html`, `vue/no-unsafe-url`                                                         | XSS-prone HTML and URL sinks                        |
+| Vue security        | `vue/no-v-html`, `vue/no-unsafe-url`                                                         | XSS-prone HTML and URL sinks                       |
 | Vue structure       | `vue/sfc-element-order`, `vue/require-scoped-style`, `vue/no-unused-components`              | SFC shape, component usage, and maintainability    |
 | Script conventions  | `script/no-options-api`, `script/no-get-current-instance`, `script/prefer-import-from-vue`   | Vue Composition API and compiler macro conventions |
 | CSS                 | `css/no-important`, `css/no-hardcoded-values`, `css/prefer-logical-properties`               | Style blocks and design-system friendly CSS        |

--- a/docs/content/rules/vue.md
+++ b/docs/content/rules/vue.md
@@ -222,7 +222,8 @@ const selectedItem = ref("selected");
 
 ## `vue/no-unsafe-url`
 
-Reports URL bindings that may resolve to unsafe schemes such as `javascript:`.
+Reports URL bindings and static URL attributes that may resolve to unsafe schemes such as
+`javascript:`, `vbscript:`, or executable `data:` payloads.
 
 Default severity: `warning`  
 Presets: `essential`, `happy-path`, `nuxt`, `opinionated`
@@ -231,6 +232,9 @@ Bad:
 
 ```vue
 <template>
+  <iframe src="javascript:alert(1)"></iframe>
+  <object data="data:text/html,<script>alert(1)</script>"></object>
+  <img srcset="/safe.png 1x, javascript:alert(1) 2x" />
   <a :href="nextUrl">Continue</a>
 </template>
 ```
@@ -246,6 +250,8 @@ const nextUrl = computed(() => {
 </script>
 
 <template>
+  <iframe src="/embedded/report" title="Report"></iframe>
+  <img srcset="/avatar.png 1x, /avatar@2x.png 2x" />
   <a :href="nextUrl">Continue</a>
 </template>
 ```

--- a/examples/README.md
+++ b/examples/README.md
@@ -31,7 +31,7 @@ The `examples/cli/` directory contains sample Vue files for trying the CLI tools
 | --------------------- | --------------------------------- |
 | `src/App.vue`         | A correctly formatted Vue file    |
 | `src/Unformatted.vue` | A Vue file that needs formatting  |
-| `src/HasErrors.vue`   | A Vue file containing lint errors |
+| `src/HasErrors.vue`   | A Vue file containing lint and security diagnostics |
 
 ### Formatter (`vize fmt`)
 
@@ -76,6 +76,9 @@ vize lint examples/cli/src/*.vue --max-warnings 5
 # Show only the summary
 vize lint examples/cli/src/*.vue --quiet
 ```
+
+`src/HasErrors.vue` intentionally includes missing `v-for` keys, a `v-if`/`v-for` conflict, and a
+static unsafe URL so the linter output demonstrates correctness and security diagnostics together.
 
 **Options:**
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -27,10 +27,10 @@ The `examples/cli/` directory contains sample Vue files for trying the CLI tools
 
 ### File Structure
 
-| File                  | Description                       |
-| --------------------- | --------------------------------- |
-| `src/App.vue`         | A correctly formatted Vue file    |
-| `src/Unformatted.vue` | A Vue file that needs formatting  |
+| File                  | Description                                         |
+| --------------------- | --------------------------------------------------- |
+| `src/App.vue`         | A correctly formatted Vue file                      |
+| `src/Unformatted.vue` | A Vue file that needs formatting                    |
 | `src/HasErrors.vue`   | A Vue file containing lint and security diagnostics |
 
 ### Formatter (`vize fmt`)

--- a/examples/cli/src/HasErrors.vue
+++ b/examples/cli/src/HasErrors.vue
@@ -30,6 +30,9 @@ const users = ref([
     <template v-for="product in items" :key="product.id">
       <div>{{ product.name }}</div>
     </template>
+
+    <!-- vue/no-unsafe-url: executable scheme in a static URL attribute -->
+    <iframe src="javascript:alert(1)" title="Unsafe embedded content"></iframe>
   </div>
 </template>
 


### PR DESCRIPTION
## Summary
- warn on static URL attributes using javascript:, vbscript:, or executable data: URLs
- cover xlink:href, data, srcset candidates, and obfuscated schemes
- add localized static diagnostics and focused no_unsafe_url tests
- document the security diagnostic in README/docs and add an example unsafe URL case

## Validation
- cargo test -p vize_patina no_unsafe_url -- --nocapture
- cargo clippy -p vize_patina --lib -- -D warnings
- cargo fmt --all -- --check
- git diff --check
- ruby -e 'require "json"; ARGV.each { |path| JSON.parse(File.read(path)); puts "ok #{path}" }' crates/vize_carton/src/i18n/en.json crates/vize_carton/src/i18n/ja.json crates/vize_carton/src/i18n/zh.json