### PR TITLE
ci: speed up Windows release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,6 +71,13 @@ jobs:
           shared-key: release-cli-${{ matrix.settings.target }}
           cache-workspace-crates: "true"
 
+      - name: Tune Windows release profile
+        if: runner.os == 'Windows'
+        shell: bash
+        run: |
+          echo "CARGO_PROFILE_RELEASE_LTO=thin" >> "$GITHUB_ENV"
+          echo "CARGO_PROFILE_RELEASE_CODEGEN_UNITS=16" >> "$GITHUB_ENV"
+
       - name: Build CLI
         shell: bash
         env:
@@ -343,6 +350,13 @@ jobs:
         with:
           shared-key: release-native-${{ matrix.settings.target }}
           cache-workspace-crates: "true"
+
+      - name: Tune Windows release profile
+        if: runner.os == 'Windows'
+        shell: bash
+        run: |
+          echo "CARGO_PROFILE_RELEASE_LTO=thin" >> "$GITHUB_ENV"
+          echo "CARGO_PROFILE_RELEASE_CODEGEN_UNITS=16" >> "$GITHUB_ENV"
 
       - name: Setup Zig
         if: matrix.settings.cross_compile

--- a/tests/tooling/github-workflows.test.ts
+++ b/tests/tooling/github-workflows.test.ts
@@ -356,6 +356,29 @@ test("cargo config forces the bundled Rust linker for Windows MSVC targets", () 
   assert.match(cargoConfig, /\[target\.aarch64-pc-windows-msvc\]\s*linker = "rust-lld"/);
 });
 
+test("release workflow tunes Windows production Rust builds for cold runners", () => {
+  const workflow = readRepoFile(".github", "workflows", "release.yml");
+  const profileSteps = [...workflow.matchAll(/- name: Tune Windows release profile/g)];
+
+  assert.equal(profileSteps.length, 2);
+  assert.match(
+    workflow,
+    /Tune Windows release profile[\s\S]*if: runner\.os == 'Windows'[\s\S]*CARGO_PROFILE_RELEASE_LTO=thin/,
+  );
+  assert.match(
+    workflow,
+    /Tune Windows release profile[\s\S]*CARGO_PROFILE_RELEASE_CODEGEN_UNITS=16/,
+  );
+  assert.match(
+    workflow,
+    /Tune Windows release profile[\s\S]*Build CLI[\s\S]*cargo build --release -p vize --target \$\{\{ matrix\.settings\.target \}\}/,
+  );
+  assert.match(
+    workflow,
+    /Tune Windows release profile[\s\S]*Build vize-native[\s\S]*tools\/moon\/scripts\/github\/build_napi_package\.mbtx/,
+  );
+});
+
 test("release workflow runs GitHub helper scripts with the native target on every runner", () => {
   const workflow = readRepoFile(".github", "workflows", "release.yml");
 


### PR DESCRIPTION
## Summary
- tune Windows release Rust builds to use thin LTO and multiple codegen units
- apply the setting to both CLI and native binding release jobs
- add workflow coverage so the release profile tuning stays in place

## Notes
Recent tag release runs were cold on Windows: the x64 CLI job reported no Rust cache and spent 13m51s in `cargo build --release`. This keeps Linux and macOS release settings unchanged while reducing the MSVC cold-build cost.