### PR TITLE
fix(vite-plugin): source style metadata from native sfc

### DIFF
--- a/crates/vize_vitrine/src/napi/sfc.rs
+++ b/crates/vize_vitrine/src/napi/sfc.rs
@@ -22,6 +22,16 @@ use std::{
 use vize_carton::cstr;
 
 #[napi(object)]
+pub struct StyleBlockNapi {
+    pub content: String,
+    pub lang: Option<String>,
+    pub scoped: bool,
+    pub module: bool,
+    pub module_name: Option<String>,
+    pub index: u32,
+}
+
+#[napi(object)]
 pub struct MacroArtifactNapi {
     pub kind: String,
     pub name: String,
@@ -45,6 +55,33 @@ fn macro_artifacts_to_napi(
             module_code: artifact.module_code.map(Into::into),
             start: artifact.start as u32,
             end: artifact.end as u32,
+        })
+        .collect()
+}
+
+fn style_blocks_to_napi(styles: &[vize_atelier_sfc::SfcStyleBlock]) -> Vec<StyleBlockNapi> {
+    styles
+        .iter()
+        .enumerate()
+        .map(|(index, style)| {
+            let module_attr = style.attrs.get("module");
+            let module_name = module_attr.and_then(|value| {
+                let value = value.as_ref();
+                if value.is_empty() {
+                    None
+                } else {
+                    Some(value.into())
+                }
+            });
+
+            StyleBlockNapi {
+                content: style.content.as_ref().into(),
+                lang: style.lang.as_deref().map(Into::into),
+                scoped: style.scoped,
+                module: module_attr.is_some(),
+                module_name,
+                index: index as u32,
+            }
         })
         .collect()
 }
@@ -88,6 +125,10 @@ pub struct SfcCompileResultNapi {
     pub style_hash: Option<String>,
     /// Hash of script content (for HMR)
     pub script_hash: Option<String>,
+    /// Whether the file has scoped styles
+    pub has_scoped: bool,
+    /// Per-block style metadata
+    pub styles: Vec<StyleBlockNapi>,
     /// Compile-time macro artifacts
     pub macro_artifacts: Vec<MacroArtifactNapi>,
 }
@@ -151,6 +192,8 @@ pub struct BatchFileResultNapi {
     pub style_hash: Option<String>,
     /// Hash of script content (for HMR)
     pub script_hash: Option<String>,
+    /// Per-block style metadata
+    pub styles: Vec<StyleBlockNapi>,
     /// Compile-time macro artifacts
     pub macro_artifacts: Vec<MacroArtifactNapi>,
 }
@@ -284,6 +327,8 @@ pub fn compile_sfc(
                 template_hash: None,
                 style_hash: None,
                 script_hash: None,
+                has_scoped: false,
+                styles: vec![],
                 macro_artifacts: vec![],
             });
         }
@@ -292,6 +337,7 @@ pub fn compile_sfc(
     let template_hash: Option<String> = descriptor.template_hash().map(Into::into);
     let style_hash: Option<String> = descriptor.style_hash().map(Into::into);
     let script_hash: Option<String> = descriptor.script_hash().map(Into::into);
+    let styles = style_blocks_to_napi(&descriptor.styles);
 
     // Compile
     let has_scoped = descriptor.styles.iter().any(|s| s.scoped);
@@ -363,6 +409,8 @@ pub fn compile_sfc(
                 template_hash: template_hash.clone(),
                 style_hash: style_hash.clone(),
                 script_hash: script_hash.clone(),
+                has_scoped,
+                styles,
                 macro_artifacts,
             })
         }
@@ -374,6 +422,8 @@ pub fn compile_sfc(
             template_hash,
             style_hash,
             script_hash,
+            has_scoped,
+            styles,
             macro_artifacts: vec![],
         }),
     }
@@ -592,8 +642,6 @@ pub fn compile_sfc_batch_with_results(
             )
         };
 
-        let has_scoped = source.contains("<style") && source.contains("scoped");
-
         let filename_cs: vize_carton::CompactString = filename.clone().into();
 
         // Parse
@@ -612,12 +660,13 @@ pub fn compile_sfc_batch_with_results(
                     code: String::new(),
                     css: None,
                     scope_id: scope_id.clone().into(),
-                    has_scoped,
+                    has_scoped: false,
                     errors: vec![e.message.into()],
                     warnings: vec![],
                     template_hash: None,
                     style_hash: None,
                     script_hash: None,
+                    styles: vec![],
                     macro_artifacts: vec![],
                 });
                 return;
@@ -628,6 +677,7 @@ pub fn compile_sfc_batch_with_results(
         let template_hash: Option<String> = descriptor.template_hash().map(Into::into);
         let style_hash: Option<String> = descriptor.style_hash().map(Into::into);
         let script_hash: Option<String> = descriptor.script_hash().map(Into::into);
+        let styles = style_blocks_to_napi(&descriptor.styles);
 
         // Compile
         // Preserve TypeScript in output - let Vite/esbuild handle TS transformation
@@ -694,6 +744,7 @@ pub fn compile_sfc_batch_with_results(
                     template_hash: template_hash.clone(),
                     style_hash: style_hash.clone(),
                     script_hash: script_hash.clone(),
+                    styles,
                     macro_artifacts,
                 });
             }
@@ -711,6 +762,7 @@ pub fn compile_sfc_batch_with_results(
                     template_hash,
                     style_hash,
                     script_hash,
+                    styles,
                     macro_artifacts: vec![],
                 });
             }

--- a/npm/vite-plugin-vize/src/compile-options.ts
+++ b/npm/vite-plugin-vize/src/compile-options.ts
@@ -16,20 +16,15 @@ export interface CompileBatchOptions {
 
 export function buildCompileFileOptions(
   filePath: string,
-  source: string,
   options: CompileFileOptions,
 ): SfcCompileOptionsNapi {
-  const scopeId = /<style[^>]*\bscoped\b/.test(source)
-    ? `data-v-${generateScopeId(filePath)}`
-    : undefined;
-
   return {
     filename: filePath,
     sourceMap: options.sourceMap,
     ssr: options.ssr,
     vapor: options.vapor,
     customRenderer: options.customRenderer ?? false,
-    scopeId,
+    scopeId: `data-v-${generateScopeId(filePath)}`,
   };
 }
 

--- a/npm/vite-plugin-vize/src/compiler.test.ts
+++ b/npm/vite-plugin-vize/src/compiler.test.ts
@@ -91,6 +91,62 @@ assert.doesNotMatch(
   "Batch SSR compilation should also drop the Vapor marker when falling back to VDOM",
 );
 
+const styleMetadataSource = `<template><div class="root">Styled</div></template>
+<style scoped module lang="scss">
+.root { color: red; }
+</style>
+<style module="tokens">
+.token { color: blue; }
+</style>`;
+
+const styleMetadataCompiled = compileFile(
+  "/src/Styled.vue",
+  new Map(),
+  { sourceMap: false, ssr: false, vapor: false },
+  styleMetadataSource,
+);
+
+assert.equal(
+  styleMetadataCompiled.hasScoped,
+  true,
+  "Single-file compilation should use native scoped style metadata",
+);
+assert.deepEqual(
+  styleMetadataCompiled.styles?.map(({ lang, scoped, module, index }) => ({
+    lang,
+    scoped,
+    module,
+    index,
+  })),
+  [
+    { lang: "scss", scoped: true, module: true, index: 0 },
+    { lang: null, scoped: false, module: "tokens", index: 1 },
+  ],
+  "Single-file compilation should normalize native style metadata for delegated CSS imports",
+);
+
+const styleBatchCache = new Map();
+const styleBatchResult = compileBatch(
+  [{ path: "/src/Styled.vue", source: styleMetadataSource }],
+  styleBatchCache,
+  { ssr: false, vapor: false },
+);
+
+assert.equal(styleBatchResult.failedCount, 0, "Batch style metadata compilation should succeed");
+assert.deepEqual(
+  styleBatchCache.get("/src/Styled.vue")?.styles?.map(({ lang, scoped, module, index }) => ({
+    lang,
+    scoped,
+    module,
+    index,
+  })),
+  [
+    { lang: "scss", scoped: true, module: true, index: 0 },
+    { lang: null, scoped: false, module: "tokens", index: 1 },
+  ],
+  "Batch compilation should cache style metadata emitted by native SFC parsing",
+);
+
 const definePageSource = `<script setup lang="ts">
 definePage({
   name: "home",

--- a/npm/vite-plugin-vize/src/compiler.ts
+++ b/npm/vite-plugin-vize/src/compiler.ts
@@ -4,6 +4,7 @@ import type {
   CompiledModule,
   BatchFileInput,
   BatchCompileResultWithFiles,
+  NativeStyleBlockInfo,
   StyleBlockInfo,
 } from "./types.ts";
 import {
@@ -16,26 +17,18 @@ import { generateScopeId } from "./utils/index.ts";
 
 const { compileSfc, compileSfcBatchWithResults } = native;
 
-/**
- * Extract style block metadata from a Vue SFC source string.
- * Parses `<style>` tags to determine lang, scoped, and module attributes.
- */
-export function extractStyleBlocks(source: string): StyleBlockInfo[] {
-  const blocks: StyleBlockInfo[] = [];
-  const styleRegex = /<style([^>]*)>([\s\S]*?)<\/style>/gi;
-  let match;
-  let index = 0;
-  while ((match = styleRegex.exec(source)) !== null) {
-    const attrs = match[1];
-    const content = match[2];
-    const lang = attrs.match(/\blang=["']([^"']+)["']/)?.[1] ?? null;
-    const scoped = /\bscoped\b/.test(attrs);
-    const moduleMatch = attrs.match(/\bmodule(?:=["']([^"']+)["'])?/);
-    const isModule = moduleMatch ? moduleMatch[1] || true : false;
-    blocks.push({ content, lang, scoped, module: isModule, index });
-    index++;
+function normalizeStyleBlocks(styles: NativeStyleBlockInfo[] | undefined): StyleBlockInfo[] {
+  if (!styles) {
+    return [];
   }
-  return blocks;
+
+  return styles.map((block) => ({
+    content: block.content,
+    lang: block.lang ?? null,
+    scoped: block.scoped,
+    module: block.module ? (block.moduleName ?? true) : false,
+    index: block.index,
+  }));
 }
 
 export function compileFile(
@@ -46,9 +39,8 @@ export function compileFile(
 ): CompiledModule {
   const content = source ?? fs.readFileSync(filePath, "utf-8");
   const scopeId = generateScopeId(filePath);
-  const hasScoped = /<style[^>]*\bscoped\b/.test(content);
 
-  const result = compileSfc(content, buildCompileFileOptions(filePath, content, options));
+  const result = compileSfc(content, buildCompileFileOptions(filePath, options));
 
   if (result.errors.length > 0) {
     const errorMsg = result.errors.join("\n");
@@ -61,18 +53,16 @@ export function compileFile(
     });
   }
 
-  const styles = extractStyleBlocks(content);
-
   const compiled: CompiledModule = {
     code: result.code,
     css: result.css,
     scopeId,
-    hasScoped,
+    hasScoped: result.hasScoped,
     templateHash: result.templateHash,
     styleHash: result.styleHash,
     scriptHash: result.scriptHash,
     macroArtifacts: result.macroArtifacts ?? [],
-    styles,
+    styles: normalizeStyleBlocks(result.styles),
   };
 
   cache.set(filePath, compiled);
@@ -95,17 +85,9 @@ export function compileBatch(
 
   const result = compileSfcBatchWithResults(inputs, buildCompileBatchOptions(options));
 
-  // Build a map from path -> source for style block extraction
-  const sourceMap = new Map<string, string>();
-  for (const f of files) {
-    sourceMap.set(f.path, f.source);
-  }
-
   // Update cache with results
   for (const fileResult of result.results) {
     if (fileResult.errors.length === 0) {
-      const source = sourceMap.get(fileResult.path);
-      const styles = source ? extractStyleBlocks(source) : undefined;
       cache.set(fileResult.path, {
         code: fileResult.code,
         css: fileResult.css,
@@ -115,7 +97,7 @@ export function compileBatch(
         styleHash: fileResult.styleHash,
         scriptHash: fileResult.scriptHash,
         macroArtifacts: fileResult.macroArtifacts ?? [],
-        styles,
+        styles: normalizeStyleBlocks(fileResult.styles),
       });
     }
 

--- a/npm/vite-plugin-vize/src/types.ts
+++ b/npm/vite-plugin-vize/src/types.ts
@@ -32,6 +32,8 @@ export interface SfcCompileResultNapi {
   templateHash?: string;
   styleHash?: string;
   scriptHash?: string;
+  hasScoped: boolean;
+  styles: NativeStyleBlockInfo[];
   macroArtifacts?: MacroArtifact[];
 }
 
@@ -158,6 +160,21 @@ export interface StyleBlockInfo {
   index: number;
 }
 
+export interface NativeStyleBlockInfo {
+  /** Raw style content (uncompiled for preprocessor langs) */
+  content: string;
+  /** Language of the style block (e.g., "css", "scss", "less", "sass", "stylus") */
+  lang?: string | null;
+  /** Whether the style block has the scoped attribute */
+  scoped: boolean;
+  /** Whether the style block has the module attribute */
+  module: boolean;
+  /** CSS Modules binding name for named module attributes */
+  moduleName?: string | null;
+  /** Index of this style block in the SFC */
+  index: number;
+}
+
 export interface CompiledModule {
   code: string;
   css?: string;
@@ -191,7 +208,7 @@ export interface BatchFileResult {
   /** Compile-time macro artifacts extracted from the source SFC */
   macroArtifacts?: MacroArtifact[];
   /** Per-block style metadata extracted from the source SFC */
-  styles?: StyleBlockInfo[];
+  styles?: NativeStyleBlockInfo[];
 }
 
 export interface BatchCompileOptionsNapi {

--- a/npm/vize-native/index.d.ts
+++ b/npm/vize-native/index.d.ts
@@ -99,6 +99,15 @@ export interface BatchFileInputNapi {
   source: string;
 }
 
+export interface StyleBlockNapi {
+  content: string;
+  lang?: string;
+  scoped: boolean;
+  module: boolean;
+  moduleName?: string;
+  index: number;
+}
+
 /** Per-file result from batch compilation */
 export interface BatchFileResultNapi {
   /** File path */
@@ -121,6 +130,8 @@ export interface BatchFileResultNapi {
   styleHash?: string;
   /** Hash of script content (for HMR) */
   scriptHash?: string;
+  /** Per-block style metadata */
+  styles: Array<StyleBlockNapi>;
   /** Compile-time macro artifacts */
   macroArtifacts: Array<MacroArtifactNapi>;
 }
@@ -569,6 +580,10 @@ export interface SfcCompileResultNapi {
   styleHash?: string;
   /** Hash of script content (for HMR) */
   scriptHash?: string;
+  /** Whether the file has scoped styles */
+  hasScoped: boolean;
+  /** Per-block style metadata */
+  styles: Array<StyleBlockNapi>;
   /** Compile-time macro artifacts */
   macroArtifacts: Array<MacroArtifactNapi>;
 }


### PR DESCRIPTION
## Summary

- return SFC style block metadata and scoped-style presence from the native compiler binding
- remove vite-plugin's JS regex pass for style block extraction and scoped detection
- cover single-file and batch compile cache behavior for native style metadata

## Why

The vite plugin was reparsing Vue SFC style blocks in JavaScript to decide when to delegate work back into Vite's CSS pipeline. That made the adapter fatter and risked diverging from the native SFC parser. Keeping this metadata at the Rust boundary gives the plugin one parsed source of truth while preserving downstream CSS transforms for preprocessors, CSS Modules, and PostCSS-style handling.

Closes #207.

## Validation

- `TMPDIR=$PWD/__agent_only/tmp cargo fmt --all -- --check`
- `TMPDIR=$PWD/__agent_only/tmp pnpm exec vp check --fix npm/vite-plugin-vize/src/compiler.ts npm/vite-plugin-vize/src/compile-options.ts npm/vite-plugin-vize/src/types.ts npm/vite-plugin-vize/src/compiler.test.ts npm/vize-native/index.d.ts`
- `TMPDIR=$PWD/__agent_only/tmp cargo check -p vize_vitrine --features napi`
- `TMPDIR=$PWD/__agent_only/tmp cargo clippy -p vize_vitrine -- -D warnings`

Full workspace test, bench, and playground coverage are left to PR CI.
