### PR TITLE
fix(ssr): skip regex literal browser names

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,8 @@ diagnostics back to the original source files.
 
 Use `vize lint --profile src` when tuning rule cost. Type-aware lint profile rows include template
 query collection and Corsa probe phases so expensive cross-rule work can be spotted quickly.
+SSR browser-global diagnostics also avoid common literal-boundary false positives such as strings,
+regexes, comments, and direct `typeof window` guards.
 
 ## Compiler Configuration
 

--- a/crates/vize_patina/src/rules/ssr/no_browser_globals_in_ssr.rs
+++ b/crates/vize_patina/src/rules/ssr/no_browser_globals_in_ssr.rs
@@ -179,6 +179,7 @@ impl NoBrowserGlobalsInSsr {
     ///
     /// This method is aware of JavaScript syntax to avoid false positives:
     /// - Skips content inside string literals ('...', "...", `...`)
+    /// - Skips content inside comments and regex literals (`/window/`)
     /// - Skips property access after `.` (e.g., `obj.top` → only `obj`)
     /// - Skips object property keys (e.g., `{ top: 0 }` → skips `top`)
     /// - Skips direct `typeof window` guards that are safe in SSR
@@ -190,9 +191,63 @@ impl NoBrowserGlobalsInSsr {
         // Track whether the previous token was a `.` (property access)
         let mut after_dot = false;
         let mut after_typeof = false;
+        let mut can_start_regex = true;
 
         while i < len {
             let b = bytes[i];
+
+            // Skip comments without changing the surrounding expression state.
+            if b == b'/' && i + 1 < len && bytes[i + 1] == b'/' {
+                i += 2;
+                while i < len && !matches!(bytes[i], b'\n' | b'\r') {
+                    i += 1;
+                }
+                continue;
+            }
+            if b == b'/' && i + 1 < len && bytes[i + 1] == b'*' {
+                i += 2;
+                while i + 1 < len {
+                    if bytes[i] == b'*' && bytes[i + 1] == b'/' {
+                        i += 2;
+                        break;
+                    }
+                    i += 1;
+                }
+                continue;
+            }
+
+            if b == b'/' && can_start_regex {
+                i += 1;
+                let mut in_character_class = false;
+                while i < len {
+                    if bytes[i] == b'\\' {
+                        i += 2;
+                        continue;
+                    }
+                    if bytes[i] == b'[' {
+                        in_character_class = true;
+                        i += 1;
+                        continue;
+                    }
+                    if bytes[i] == b']' {
+                        in_character_class = false;
+                        i += 1;
+                        continue;
+                    }
+                    if bytes[i] == b'/' && !in_character_class {
+                        i += 1;
+                        while i < len && bytes[i].is_ascii_alphabetic() {
+                            i += 1;
+                        }
+                        break;
+                    }
+                    i += 1;
+                }
+                after_dot = false;
+                after_typeof = false;
+                can_start_regex = false;
+                continue;
+            }
 
             // Skip string literals
             if b == b'\'' || b == b'"' || b == b'`' {
@@ -211,12 +266,14 @@ impl NoBrowserGlobalsInSsr {
                     i += 1;
                 }
                 after_dot = false;
+                can_start_regex = false;
                 continue;
             }
 
             // Track dot for property access
             if b == b'.' {
                 after_dot = true;
+                can_start_regex = false;
                 i += 1;
                 continue;
             }
@@ -236,6 +293,7 @@ impl NoBrowserGlobalsInSsr {
                 if after_dot {
                     after_dot = false;
                     after_typeof = false;
+                    can_start_regex = false;
                     continue;
                 }
 
@@ -249,12 +307,14 @@ impl NoBrowserGlobalsInSsr {
                     // This is an object key like `{ top: 0 }`, skip it
                     after_dot = false;
                     after_typeof = false;
+                    can_start_regex = true;
                     continue;
                 }
 
                 if ident == "typeof" {
                     after_typeof = true;
                     after_dot = false;
+                    can_start_regex = true;
                     continue;
                 }
 
@@ -266,12 +326,14 @@ impl NoBrowserGlobalsInSsr {
                     }
                     if next >= len || !matches!(bytes[next], b'.' | b'[') {
                         after_dot = false;
+                        can_start_regex = false;
                         continue;
                     }
                 }
 
                 identifiers.push(ident);
                 after_dot = false;
+                can_start_regex = false;
                 continue;
             }
 
@@ -283,6 +345,7 @@ impl NoBrowserGlobalsInSsr {
                     i += 1;
                 }
                 after_dot = false;
+                can_start_regex = false;
                 continue;
             }
 
@@ -292,6 +355,27 @@ impl NoBrowserGlobalsInSsr {
                 if !matches!(b, b'(' | b')') {
                     after_typeof = false;
                 }
+                can_start_regex = matches!(
+                    b,
+                    b'(' | b'['
+                        | b'{'
+                        | b','
+                        | b':'
+                        | b';'
+                        | b'?'
+                        | b'='
+                        | b'!'
+                        | b'&'
+                        | b'|'
+                        | b'+'
+                        | b'-'
+                        | b'*'
+                        | b'%'
+                        | b'~'
+                        | b'^'
+                        | b'<'
+                        | b'>'
+                );
             }
             i += 1;
         }
@@ -517,6 +601,32 @@ mod tests {
     #[test]
     fn test_detects_typeof_member_access() {
         let result = lint_with_ssr(r#"<div>{{ typeof window.innerWidth }}</div>"#);
+        assert_eq!(result.len(), 1);
+    }
+
+    #[test]
+    fn test_ignores_regex_literal_with_browser_global_name() {
+        let result = lint_with_ssr(r#"<div>{{ /window|document/.test(name) }}</div>"#);
+        assert!(
+            result.is_empty(),
+            "Should not flag browser global names inside regex literals, got: {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_ignores_block_comment_with_browser_global_name() {
+        let result = lint_with_ssr(r#"<div>{{ value /* window */ }}</div>"#);
+        assert!(
+            result.is_empty(),
+            "Should not flag browser global names inside comments, got: {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_detects_division_by_browser_global() {
+        let result = lint_with_ssr(r#"<div>{{ width / window.innerWidth }}</div>"#);
         assert_eq!(result.len(), 1);
     }
 }

--- a/docs/content/rules/ssr.md
+++ b/docs/content/rules/ssr.md
@@ -36,8 +36,9 @@ onMounted(() => {
 ```
 
 Guard checks such as `typeof window === "undefined"` are allowed because the direct `typeof`
-identifier form is safe during server rendering. Accessing a member such as `typeof window.innerWidth`
-still reports, because it evaluates the browser global.
+identifier form is safe during server rendering. Strings, comments, and regex literals are also
+ignored when they contain names like `window` or `document`. Accessing a member such as
+`typeof window.innerWidth` still reports, because it evaluates the browser global.
 
 ## `ssr/no-hydration-mismatch`
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -82,6 +82,7 @@ vize lint examples/cli/src/*.vue --profile
 
 `src/HasErrors.vue` intentionally includes missing `v-for` keys, a `v-if`/`v-for` conflict, and a
 static unsafe URL so the linter output demonstrates correctness and security diagnostics together.
+The SSR rule docs include extra boundary examples for `typeof window`, comments, and regex literals.
 
 **Options:**
 


### PR DESCRIPTION
## Summary
- skip comments and regex literals when scanning SSR template expressions for browser globals
- preserve detection for real division/member access such as width / window.innerWidth
- document the literal-boundary behavior in README, SSR docs, and examples

## Validation
- cargo test -p vize_patina no_browser_globals_in_ssr -- --nocapture
- cargo fmt --all -- --check
- git diff --check
- vp check --fix README.md docs/content/rules/ssr.md examples/README.md