### PR TITLE
fix(a11y): normalize javascript anchor hrefs

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,9 @@ vize check --declaration --declaration-dir dist/types
 `vize lint` runs Patina rules for Vue templates, scripts, CSS, a11y, SSR, Vapor, Musea, cross-file,
 and type-aware checks. Security-oriented Vue rules include `vue/no-unsafe-url`, which checks dynamic
 URL bindings and static URL attributes for executable schemes such as `javascript:`, `vbscript:`,
-and active `data:` payloads. `vize check` generates virtual TypeScript for Vue SFCs and maps project
+and active `data:` payloads. Anchor accessibility checks share the same scheme normalization for
+static `href` values, so case changes or HTML-decoded control characters do not hide
+`javascript:` links. `vize check` generates virtual TypeScript for Vue SFCs and maps project
 diagnostics back to the original source files.
 
 Use `vize lint --profile src` when tuning rule cost. Type-aware lint profile rows include template

--- a/crates/vize_patina/src/rules/a11y/anchor_is_valid.rs
+++ b/crates/vize_patina/src/rules/a11y/anchor_is_valid.rs
@@ -23,6 +23,7 @@
 use crate::context::LintContext;
 use crate::diagnostic::Severity;
 use crate::rule::{Rule, RuleCategory, RuleMeta};
+use crate::rules::url::has_javascript_scheme;
 use vize_relief::ast::{ElementNode, ElementType, ExpressionNode, PropNode};
 
 static META: RuleMeta = RuleMeta {
@@ -73,7 +74,7 @@ impl Rule for AnchorIsValid {
                             &attr.loc,
                             ctx.t("a11y/anchor-is-valid.help"),
                         );
-                    } else if trimmed.starts_with("javascript:") {
+                    } else if has_javascript_scheme(trimmed) {
                         ctx.warn_with_help(
                             ctx.t("a11y/anchor-is-valid.message_javascript"),
                             &attr.loc,
@@ -149,6 +150,28 @@ mod tests {
         let linter = create_linter();
         let result = linter.lint_template(r#"<a href="javascript:void(0)">Link</a>"#, "test.vue");
         assert_eq!(result.warning_count, 1);
+    }
+
+    #[test]
+    fn test_invalid_mixed_case_javascript_href() {
+        let linter = create_linter();
+        let result = linter.lint_template(r#"<a href="JaVaScRiPt:void(0)">Link</a>"#, "test.vue");
+        assert_eq!(result.warning_count, 1);
+    }
+
+    #[test]
+    fn test_invalid_obfuscated_javascript_href() {
+        let linter = create_linter();
+        let result =
+            linter.lint_template(r#"<a href="java&#x0A;script:void(0)">Link</a>"#, "test.vue");
+        assert_eq!(result.warning_count, 1);
+    }
+
+    #[test]
+    fn test_valid_similar_javascript_scheme() {
+        let linter = create_linter();
+        let result = linter.lint_template(r#"<a href="javascriptx:void(0)">Link</a>"#, "test.vue");
+        assert_eq!(result.warning_count, 0);
     }
 
     #[test]

--- a/crates/vize_patina/src/rules/mod.rs
+++ b/crates/vize_patina/src/rules/mod.rs
@@ -8,5 +8,6 @@ pub mod opinionated;
 pub mod script;
 pub mod ssr;
 pub mod type_aware;
+pub(crate) mod url;
 pub mod vapor;
 pub mod vue;

--- a/crates/vize_patina/src/rules/url.rs
+++ b/crates/vize_patina/src/rules/url.rs
@@ -1,0 +1,64 @@
+use vize_carton::String;
+
+pub(crate) fn normalized_scheme(value: &str) -> Option<(String, &str)> {
+    let mut scheme = String::default();
+    let mut saw_scheme_char = false;
+
+    for (index, ch) in value.char_indices() {
+        if ch == ':' {
+            return saw_scheme_char.then(|| (scheme, &value[index + 1..]));
+        }
+
+        if ch.is_ascii_whitespace() || ch.is_ascii_control() {
+            continue;
+        }
+
+        if matches!(ch, '/' | '#' | '?') {
+            return None;
+        }
+
+        if ch.is_ascii_alphanumeric() || matches!(ch, '+' | '-' | '.') {
+            saw_scheme_char = true;
+            scheme.push(ch.to_ascii_lowercase());
+            continue;
+        }
+
+        return None;
+    }
+
+    None
+}
+
+pub(crate) fn has_javascript_scheme(value: &str) -> bool {
+    normalized_scheme(value).is_some_and(|(scheme, _)| scheme.as_str() == "javascript")
+}
+
+pub(crate) fn is_executable_data_url(rest: &str) -> bool {
+    let media_type = rest
+        .trim_start_matches(|ch: char| ch.is_ascii_whitespace() || ch.is_ascii_control())
+        .split(',')
+        .next()
+        .unwrap_or("")
+        .split(';')
+        .next()
+        .unwrap_or("")
+        .trim()
+        .to_ascii_lowercase();
+
+    matches!(
+        media_type.as_str(),
+        "text/html" | "application/xhtml+xml" | "image/svg+xml" | "text/xml" | "application/xml"
+    )
+}
+
+pub(crate) fn is_unsafe_url(value: &str) -> bool {
+    let Some((scheme, rest)) = normalized_scheme(value) else {
+        return false;
+    };
+
+    match scheme.as_str() {
+        "javascript" | "vbscript" => true,
+        "data" => is_executable_data_url(rest),
+        _ => false,
+    }
+}

--- a/crates/vize_patina/src/rules/vue/no_unsafe_url.rs
+++ b/crates/vize_patina/src/rules/vue/no_unsafe_url.rs
@@ -42,7 +42,7 @@
 use crate::context::LintContext;
 use crate::diagnostic::Severity;
 use crate::rule::{Rule, RuleCategory, RuleMeta};
-use vize_carton::String;
+use crate::rules::url::is_unsafe_url;
 use vize_relief::ast::{DirectiveNode, ElementNode, ExpressionNode, PropNode};
 
 static META: RuleMeta = RuleMeta {
@@ -76,65 +76,6 @@ fn is_url_attr(name: &str) -> bool {
 
 fn is_router_link_tag(tag: &str) -> bool {
     tag == "router-link" || tag == "RouterLink" || tag == "nuxt-link" || tag == "NuxtLink"
-}
-
-fn normalized_scheme(value: &str) -> Option<(String, &str)> {
-    let mut scheme = String::default();
-    let mut saw_scheme_char = false;
-
-    for (index, ch) in value.char_indices() {
-        if ch == ':' {
-            return saw_scheme_char.then(|| (scheme, &value[index + 1..]));
-        }
-
-        if ch.is_ascii_whitespace() || ch.is_ascii_control() {
-            continue;
-        }
-
-        if matches!(ch, '/' | '#' | '?') {
-            return None;
-        }
-
-        if ch.is_ascii_alphanumeric() || matches!(ch, '+' | '-' | '.') {
-            saw_scheme_char = true;
-            scheme.push(ch.to_ascii_lowercase());
-            continue;
-        }
-
-        return None;
-    }
-
-    None
-}
-
-fn is_executable_data_url(rest: &str) -> bool {
-    let media_type = rest
-        .trim_start_matches(|ch: char| ch.is_ascii_whitespace() || ch.is_ascii_control())
-        .split(',')
-        .next()
-        .unwrap_or("")
-        .split(';')
-        .next()
-        .unwrap_or("")
-        .trim()
-        .to_ascii_lowercase();
-
-    matches!(
-        media_type.as_str(),
-        "text/html" | "application/xhtml+xml" | "image/svg+xml" | "text/xml" | "application/xml"
-    )
-}
-
-fn is_unsafe_url(value: &str) -> bool {
-    let Some((scheme, rest)) = normalized_scheme(value) else {
-        return false;
-    };
-
-    match scheme.as_str() {
-        "javascript" | "vbscript" => true,
-        "data" => is_executable_data_url(rest),
-        _ => false,
-    }
 }
 
 fn is_unsafe_static_attr_value(attr_name: &str, value: &str) -> bool {

--- a/docs/content/rules/accessibility.md
+++ b/docs/content/rules/accessibility.md
@@ -222,6 +222,9 @@ Good:
 ## `a11y/anchor-is-valid`
 
 Requires anchors to have valid link targets.
+Static `href` values are checked after scheme normalization, so `JaVaScRiPt:` and HTML-decoded
+control characters inside `java&#x0A;script:` are still reported while similar non-matching schemes
+stay allowed.
 
 Default severity: `warning`  
 Presets: `happy-path`, `nuxt`, `opinionated`
@@ -231,6 +234,7 @@ Bad:
 ```vue
 <template>
   <a href="#" @click="open">Open</a>
+  <a href="JaVaScRiPt:void(0)">Open</a>
 </template>
 ```
 
@@ -239,6 +243,7 @@ Good:
 ```vue
 <template>
   <button type="button" @click="open">Open</button>
+  <a href="/docs/javascript:void">Docs</a>
 </template>
 ```
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -80,8 +80,9 @@ vize lint examples/cli/src/*.vue --quiet
 vize lint examples/cli/src/*.vue --profile
 ```
 
-`src/HasErrors.vue` intentionally includes missing `v-for` keys, a `v-if`/`v-for` conflict, and a
-static unsafe URL so the linter output demonstrates correctness and security diagnostics together.
+`src/HasErrors.vue` intentionally includes missing `v-for` keys, a `v-if`/`v-for` conflict, a
+static unsafe URL, and an obfuscated invalid anchor so the linter output demonstrates correctness,
+accessibility, and security diagnostics together.
 The SSR rule docs include extra boundary examples for `typeof window`, comments, and regex literals.
 
 **Options:**

--- a/examples/cli/src/HasErrors.vue
+++ b/examples/cli/src/HasErrors.vue
@@ -33,6 +33,9 @@ const users = ref([
 
     <!-- vue/no-unsafe-url: executable scheme in a static URL attribute -->
     <iframe src="javascript:alert(1)" title="Unsafe embedded content"></iframe>
+
+    <!-- a11y/anchor-is-valid: invalid anchor with normalized executable scheme -->
+    <a href="JaVaScRiPt:void(0)">Unsafe action link</a>
   </div>
 </template>
 


### PR DESCRIPTION
## Summary
- share static URL scheme normalization between unsafe URL checks and anchor validity checks
- report static anchor hrefs that hide `javascript:` with case changes or HTML-decoded control characters
- keep similar non-matching schemes allowed and document the boundary in README, docs, and examples

## Validation
- `cargo test -p vize_patina anchor_is_valid -- --nocapture`
- `cargo test -p vize_patina no_unsafe_url -- --nocapture`
- `cargo fmt --all -- --check`
- `git diff --check`
- `vp check --fix README.md docs/content/rules/accessibility.md examples/README.md examples/cli/src/HasErrors.vue`