### PR TITLE
fix(nuxt): preserve encoded dev stylesheet assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@
 - A full Rust CLI via the `vize` crate (`build`, `fmt`, `lint`, `check`, `ready`, `upgrade`, `musea`, `lsp`, `ide`)
 - npm packages including `@vizejs/vite-plugin`, `@vizejs/native`, `@vizejs/wasm`, `@vizejs/unplugin`, `@vizejs/rspack-plugin`, `@vizejs/nuxt`, `@vizejs/vite-plugin-musea`, `@vizejs/musea-mcp-server`, and `oxlint-plugin-vize`
 - The `vize` npm package for shared config utilities and native `build`, `fmt`, `lint`, `check`, `ready`, and `upgrade` commands
+- Nuxt dev integration that preserves URL-encoded asset links while removing broken or unsafe stylesheet references from rendered HTML
 
 ## Quick Start
 

--- a/docs/content/integrations/nuxt.md
+++ b/docs/content/integrations/nuxt.md
@@ -48,6 +48,8 @@ vp run dev
 The module injects `@vizejs/vite-plugin` into Nuxt's Vite config and keeps Nuxt-specific transforms
 in the pipeline, so auto-imports, components, middleware, and SSR behavior continue to work through
 Nuxt.
+During development, the server response cleanup preserves valid URL-encoded Nuxt asset links such
+as `%40fs/` and encoded `assets/` paths while dropping decoded null-byte or traversal paths.
 
 ## Advanced Setup
 

--- a/npm/nuxt/src/dev-html.test.ts
+++ b/npm/nuxt/src/dev-html.test.ts
@@ -25,6 +25,22 @@ assert.equal(
 
 assert.equal(
   sanitizeNuxtDevStylesheetLinks(
+    `<link rel="stylesheet" href="/_nuxt/%40fs/Users/me/project/node_modules/pkg/style.css"><link rel="stylesheet" href="/_nuxt/assets%2Fentry.css">`,
+  ),
+  `<link rel="stylesheet" href="/_nuxt/%40fs/Users/me/project/node_modules/pkg/style.css"><link rel="stylesheet" href="/_nuxt/assets%2Fentry.css">`,
+  "URL-encoded valid Nuxt dev asset paths should be preserved",
+);
+
+assert.equal(
+  sanitizeNuxtDevStylesheetLinks(
+    `<link rel="stylesheet" href="/_nuxt/assets/%2e%2e/server.css"><link rel="stylesheet" href="/_nuxt/@fs/C:%5Cproject%5C..%5Csecret.css"><link rel="stylesheet" href="/_nuxt/assets/%00secret.css">`,
+  ),
+  "",
+  "decoded traversal and null-byte paths should be stripped",
+);
+
+assert.equal(
+  sanitizeNuxtDevStylesheetLinks(
     `<link rel="stylesheet" href="/docs/_nuxt/assets/main.css"><link rel="stylesheet" href="/docs/_nuxt/pkg/style.css">`,
     "/docs/_nuxt/",
   ),

--- a/npm/nuxt/src/dev-html.ts
+++ b/npm/nuxt/src/dev-html.ts
@@ -7,6 +7,29 @@ export function sanitizeNuxtDevStylesheetLinks(html: string, buildAssetsDir = "/
   const normalizedAssetsDir = normalizeUrlPrefix(buildAssetsDir);
   const seenHrefs = new Set<string>();
 
+  function decodePathPart(pathPart: string): string {
+    try {
+      return decodeURIComponent(pathPart);
+    } catch {
+      return pathPart;
+    }
+  }
+
+  function hasUnsafePathSegment(pathPart: string): boolean {
+    return pathPart.split(/[\\/]/).some((segment) => segment === "..");
+  }
+
+  function isAllowedNuxtDevStylesheetPath(pathPart: string): boolean {
+    return (
+      pathPart.startsWith("@fs/") ||
+      pathPart.startsWith("@id/") ||
+      pathPart.startsWith("assets/") ||
+      pathPart.startsWith("virtual:") ||
+      /^__[\w.-]+\.css$/i.test(pathPart) ||
+      /^[\w.-]+\.css$/i.test(pathPart)
+    );
+  }
+
   function shouldKeepHref(href: string): boolean {
     if (seenHrefs.has(href)) {
       return false;
@@ -18,26 +41,13 @@ export function sanitizeNuxtDevStylesheetLinks(html: string, buildAssetsDir = "/
     }
 
     const pathPart = href.slice(normalizedAssetsDir.length).split("?")[0].split("#")[0];
+    const decodedPath = decodePathPart(pathPart);
 
-    let decodedPath = pathPart;
-    try {
-      decodedPath = decodeURIComponent(pathPart);
-    } catch {
-      // Keep the raw path if decoding fails.
-    }
-
-    if (decodedPath.includes("\0")) {
+    if (decodedPath.includes("\0") || hasUnsafePathSegment(decodedPath)) {
       return false;
     }
 
-    return (
-      pathPart.startsWith("@fs/") ||
-      pathPart.startsWith("@id/") ||
-      pathPart.startsWith("assets/") ||
-      pathPart.startsWith("virtual:") ||
-      /^__[\w.-]+\.css$/i.test(pathPart) ||
-      /^[\w.-]+\.css$/i.test(pathPart)
-    );
+    return isAllowedNuxtDevStylesheetPath(decodedPath);
   }
 
   return html.replace(


### PR DESCRIPTION
## Summary
- decode Nuxt dev stylesheet asset paths before applying the allowlist
- preserve valid encoded `%40fs/` and `assets%2F...` links instead of stripping them
- reject decoded null-byte and traversal segments, including encoded Windows backslash traversal
- document the dev cleanup boundary in README and Nuxt integration docs

## Validation
- `node npm/nuxt/src/dev-html.test.ts`
- `vp check --fix README.md docs/content/integrations/nuxt.md npm/nuxt/src/dev-html.ts npm/nuxt/src/dev-html.test.ts`
- `git diff --check`