### PR TITLE
perf(type-aware): share template expression parse

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,9 @@ static `href` values, so case changes or HTML-decoded control characters do not 
 diagnostics back to the original source files.
 
 Use `vize lint --profile src` when tuning rule cost. Type-aware lint profile rows include template
-query collection and Corsa probe phases so expensive cross-rule work can be spotted quickly.
+query collection and Corsa probe phases so expensive cross-rule work can be spotted quickly. When
+template unsafe-binding and floating-Promise checks are both enabled, shared expression parsing keeps
+their query collection from doing duplicate OXC work.
 SSR browser-global diagnostics also avoid common literal-boundary false positives such as strings,
 regexes, comments, and direct `typeof window` guards.
 

--- a/crates/vize_patina/src/linter/native_type_aware/template_queries/calls.rs
+++ b/crates/vize_patina/src/linter/native_type_aware/template_queries/calls.rs
@@ -20,28 +20,74 @@ pub(super) struct FloatingPromiseRange {
     pub probe_end: u32,
 }
 
-pub(super) fn collect_call_callee_ranges(
+#[derive(Default)]
+pub(super) struct TemplateCallRanges {
+    pub callees: Vec<RelativeRange>,
+    pub floating_promises: Vec<FloatingPromiseRange>,
+}
+
+pub(super) fn collect_template_call_ranges(
     source: &str,
     allow_statement_fallback: bool,
-) -> Vec<RelativeRange> {
+    include_callees: bool,
+    include_floating_promises: bool,
+) -> TemplateCallRanges {
+    let mut ranges = TemplateCallRanges::default();
+    if !include_callees && !include_floating_promises {
+        return ranges;
+    }
+
     let allocator = OxcAllocator::default();
     let source_type = SourceType::from_path("template.ts").unwrap_or_default();
     if let Ok(expression) = profile!(
-        "patina.type_aware.template_calls.parse_expression",
+        "patina.type_aware.template_queries.parse_expression",
         OxcParser::new(&allocator, source, source_type).parse_expression()
     ) {
-        let mut collector = CallCalleeCollector::default();
-        profile!(
-            "patina.type_aware.template_calls.visit_expression",
-            collector.visit_expression(&expression)
-        );
-        return collector.into_relative_ranges(0, source.len() as u32);
+        if include_callees {
+            let mut collector = CallCalleeCollector::default();
+            profile!(
+                "patina.type_aware.template_calls.visit_expression",
+                collector.visit_expression(&expression)
+            );
+            ranges.callees = collector.into_relative_ranges(0, source.len() as u32);
+        }
+        if include_floating_promises {
+            if expression.span().end as usize == source.trim_end().len() {
+                profile!(
+                    "patina.type_aware.template_floating.visit_expression",
+                    collect_floating_promise_ranges_for_expression(
+                        &expression,
+                        &mut ranges.floating_promises
+                    )
+                );
+            } else if allow_statement_fallback {
+                ranges.floating_promises =
+                    collect_statement_floating_promise_ranges(&allocator, source_type, source);
+            }
+        }
+        return ranges;
     }
 
     if !allow_statement_fallback {
-        return Vec::new();
+        return ranges;
     }
 
+    if include_callees {
+        ranges.callees = collect_statement_call_callee_ranges(&allocator, source_type, source);
+    }
+    if include_floating_promises {
+        ranges.floating_promises =
+            collect_statement_floating_promise_ranges(&allocator, source_type, source);
+    }
+
+    ranges
+}
+
+fn collect_statement_call_callee_ranges(
+    allocator: &OxcAllocator,
+    source_type: SourceType,
+    source: &str,
+) -> Vec<RelativeRange> {
     const PREFIX: &str = "function __vize_template_handler(){\n";
     let mut wrapped = String::with_capacity(PREFIX.len() + source.len() + 4);
     wrapped.push_str(PREFIX);
@@ -50,7 +96,7 @@ pub(super) fn collect_call_callee_ranges(
 
     let parsed = profile!(
         "patina.type_aware.template_calls.parse_statement",
-        OxcParser::new(&allocator, wrapped.as_str(), source_type).parse()
+        OxcParser::new(allocator, wrapped.as_str(), source_type).parse()
     );
     if parsed.panicked || !parsed.errors.is_empty() {
         return Vec::new();
@@ -64,32 +110,14 @@ pub(super) fn collect_call_callee_ranges(
     collector.into_relative_ranges(PREFIX.len() as u32, source.len() as u32)
 }
 
-pub(super) fn collect_floating_promise_ranges(
+fn collect_statement_floating_promise_ranges(
+    allocator: &OxcAllocator,
+    source_type: SourceType,
     source: &str,
-    allow_statement_fallback: bool,
 ) -> Vec<FloatingPromiseRange> {
-    let allocator = OxcAllocator::default();
-    let source_type = SourceType::from_path("template.ts").unwrap_or_default();
-    if let Ok(expression) = profile!(
-        "patina.type_aware.template_floating.parse_expression",
-        OxcParser::new(&allocator, source, source_type).parse_expression()
-    ) {
-        if expression.span().end as usize == source.trim_end().len() {
-            let mut ranges = Vec::new();
-            collect_floating_promise_ranges_for_expression(&expression, &mut ranges);
-            if !ranges.is_empty() {
-                return ranges;
-            }
-        }
-    }
-
-    if !allow_statement_fallback {
-        return Vec::new();
-    }
-
     let parsed = profile!(
         "patina.type_aware.template_floating.parse_statement",
-        OxcParser::new(&allocator, source, source_type).parse()
+        OxcParser::new(allocator, source, source_type).parse()
     );
     if parsed.panicked || !parsed.errors.is_empty() {
         return Vec::new();
@@ -289,5 +317,57 @@ fn is_handled_promise_chain(expression: &Expression<'_>) -> bool {
         },
         Expression::CallExpression(call) => is_handled_call(call),
         _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{collect_template_call_ranges, FloatingPromiseRange, RelativeRange};
+
+    fn range_slices<'a>(source: &'a str, ranges: &[RelativeRange]) -> Vec<&'a str> {
+        ranges
+            .iter()
+            .map(|range| &source[range.start as usize..range.end as usize])
+            .collect()
+    }
+
+    fn promise_slices<'a>(source: &'a str, ranges: &[FloatingPromiseRange]) -> Vec<&'a str> {
+        ranges
+            .iter()
+            .map(|range| &source[range.start as usize..range.end as usize])
+            .collect()
+    }
+
+    #[test]
+    fn collects_callees_and_floating_promises_from_one_expression_parse() {
+        let source = "enabled && save()";
+        let ranges = collect_template_call_ranges(source, false, true, true);
+
+        assert_eq!(range_slices(source, &ranges.callees), vec!["save"]);
+        assert_eq!(
+            promise_slices(source, &ranges.floating_promises),
+            vec!["save()"]
+        );
+    }
+
+    #[test]
+    fn collects_statement_fallback_callees_for_event_handlers() {
+        let source = "if (enabled) { save(); track() }";
+        let ranges = collect_template_call_ranges(source, true, true, false);
+
+        assert_eq!(range_slices(source, &ranges.callees), vec!["save", "track"]);
+        assert!(ranges.floating_promises.is_empty());
+    }
+
+    #[test]
+    fn collects_statement_fallback_floating_promises() {
+        let source = "save(); track()";
+        let ranges = collect_template_call_ranges(source, true, false, true);
+
+        assert!(ranges.callees.is_empty());
+        assert_eq!(
+            promise_slices(source, &ranges.floating_promises),
+            vec!["save()", "track()"]
+        );
     }
 }

--- a/crates/vize_patina/src/linter/native_type_aware/template_queries/collector.rs
+++ b/crates/vize_patina/src/linter/native_type_aware/template_queries/collector.rs
@@ -1,8 +1,6 @@
 use super::{
-    absolute_expression_range,
-    calls::{collect_call_callee_ranges, collect_floating_promise_ranges},
-    generated_offset_for_text, TemplateContext, TemplatePromiseQuery, TemplateQuery,
-    TemplateQueryKind,
+    absolute_expression_range, calls::collect_template_call_ranges, generated_offset_for_text,
+    TemplateContext, TemplatePromiseQuery, TemplateQuery, TemplateQueryKind,
 };
 use vize_carton::profile;
 use vize_croquis::virtual_ts::VirtualTsOutput;
@@ -56,6 +54,12 @@ struct TemplateQuerySinks<'a> {
     template_promise_queries: Option<&'a mut Vec<TemplatePromiseQuery>>,
 }
 
+impl TemplateQuerySinks<'_> {
+    fn has_queries(&self) -> bool {
+        self.template_queries.is_some() || self.template_promise_queries.is_some()
+    }
+}
+
 fn dedupe_template_queries(queries: &mut Vec<TemplateQuery>) {
     queries.sort_unstable_by_key(|query| {
         (
@@ -106,21 +110,10 @@ fn collect_children(
                     let PropNode::Directive(directive) = prop else {
                         continue;
                     };
-                    if let Some(queries) = sinks.template_queries.as_deref_mut() {
+                    if sinks.has_queries() {
                         profile!(
-                            "patina.type_aware.template_queries.directive",
-                            collect_directive(virtual_ts, directive, template_offset, queries)
-                        );
-                    }
-                    if let Some(queries) = sinks.template_promise_queries.as_deref_mut() {
-                        profile!(
-                            "patina.type_aware.template_promise_queries.directive",
-                            collect_promise_directive(
-                                virtual_ts,
-                                directive,
-                                template_offset,
-                                queries
-                            )
+                            "patina.type_aware.template_query_sets.directive",
+                            collect_directive(virtual_ts, directive, template_offset, sinks)
                         );
                     }
                 }
@@ -236,29 +229,20 @@ fn collect_expression(
     allow_statement_fallback: bool,
     sinks: &mut TemplateQuerySinks<'_>,
 ) {
-    if let Some(queries) = sinks.template_queries.as_deref_mut() {
+    let include_template_queries = sinks.template_queries.is_some();
+    let include_template_promise_queries = sinks.template_promise_queries.is_some();
+    if include_template_queries || include_template_promise_queries {
         profile!(
-            "patina.type_aware.template_queries.expression",
-            collect_expression_queries(
+            "patina.type_aware.template_query_sets.expression",
+            collect_expression_query_sets(
                 virtual_ts,
                 expression,
                 template_offset,
                 context,
                 allow_statement_fallback,
-                queries,
-            )
-        );
-    }
-    if let Some(queries) = sinks.template_promise_queries.as_deref_mut() {
-        profile!(
-            "patina.type_aware.template_promise_queries.expression",
-            collect_promise_expression_queries(
-                virtual_ts,
-                expression,
-                template_offset,
-                context,
-                allow_statement_fallback,
-                queries,
+                include_template_queries,
+                include_template_promise_queries,
+                sinks,
             )
         );
     }
@@ -268,7 +252,7 @@ fn collect_directive(
     virtual_ts: &VirtualTsOutput,
     directive: &DirectiveNode<'_>,
     template_offset: u32,
-    queries: &mut Vec<TemplateQuery>,
+    sinks: &mut TemplateQuerySinks<'_>,
 ) {
     let Some(expression) = &directive.exp else {
         return;
@@ -278,135 +262,104 @@ fn collect_directive(
         "on" => TemplateContext::Event,
         _ => TemplateContext::Directive,
     };
-    profile!(
-        "patina.type_aware.template_queries.expression",
-        collect_expression_queries(
-            virtual_ts,
-            expression,
-            template_offset,
-            context,
-            matches!(context, TemplateContext::Event),
-            queries,
-        )
+    collect_expression(
+        virtual_ts,
+        expression,
+        template_offset,
+        context,
+        matches!(context, TemplateContext::Event),
+        sinks,
     );
 }
 
-fn collect_promise_directive(
-    virtual_ts: &VirtualTsOutput,
-    directive: &DirectiveNode<'_>,
-    template_offset: u32,
-    queries: &mut Vec<TemplatePromiseQuery>,
-) {
-    let Some(expression) = &directive.exp else {
-        return;
-    };
-    let context = match directive.name.as_str() {
-        "bind" => TemplateContext::Binding,
-        "on" => TemplateContext::Event,
-        _ => TemplateContext::Directive,
-    };
-    profile!(
-        "patina.type_aware.template_promise_queries.expression",
-        collect_promise_expression_queries(
-            virtual_ts,
-            expression,
-            template_offset,
-            context,
-            matches!(context, TemplateContext::Event),
-            queries,
-        )
-    );
-}
-
-fn collect_expression_queries(
+fn collect_expression_query_sets(
     virtual_ts: &VirtualTsOutput,
     expression: &ExpressionNode<'_>,
     template_offset: u32,
     context: TemplateContext,
     allow_statement_fallback: bool,
-    queries: &mut Vec<TemplateQuery>,
+    include_template_queries: bool,
+    include_template_promise_queries: bool,
+    sinks: &mut TemplateQuerySinks<'_>,
 ) {
     let Some((source_start, source_end)) = absolute_expression_range(expression, template_offset)
     else {
         return;
     };
     let source_text = expression.loc().source.as_str();
-    let Some(generated_offset) = generated_offset_for_text(virtual_ts, source_start, source_text)
-    else {
-        return;
-    };
-    queries.push(TemplateQuery {
-        kind: TemplateQueryKind::Expression,
-        context,
-        generated_offset,
-        source_start,
-        source_end,
-        owner_start: source_start,
-        owner_end: source_end,
-    });
+    let expression_generated_offset = include_template_queries
+        .then(|| generated_offset_for_text(virtual_ts, source_start, source_text))
+        .flatten();
+    let include_call_callees = expression_generated_offset.is_some();
+    let call_ranges = profile!(
+        "patina.type_aware.template_query_sets.call_ranges",
+        collect_template_call_ranges(
+            source_text,
+            allow_statement_fallback,
+            include_call_callees,
+            include_template_promise_queries,
+        )
+    );
 
-    for callee in profile!(
-        "patina.type_aware.template_queries.call_callees",
-        collect_call_callee_ranges(source_text, allow_statement_fallback)
+    if let (Some(queries), Some(generated_offset)) = (
+        sinks.template_queries.as_deref_mut(),
+        expression_generated_offset,
     ) {
-        let callee_start = source_start + callee.start;
-        let callee_end = source_start + callee.end;
-        let Some(callee_source) = source_text.get(callee.start as usize..callee.end as usize)
-        else {
-            continue;
-        };
-        let Some(generated_offset) =
-            generated_offset_for_text(virtual_ts, callee_start, callee_source)
-        else {
-            continue;
-        };
         queries.push(TemplateQuery {
-            kind: TemplateQueryKind::CallCallee,
+            kind: TemplateQueryKind::Expression,
             context,
             generated_offset,
-            source_start: callee_start,
-            source_end: callee_end,
+            source_start,
+            source_end,
             owner_start: source_start,
             owner_end: source_end,
         });
-    }
-}
 
-fn collect_promise_expression_queries(
-    virtual_ts: &VirtualTsOutput,
-    expression: &ExpressionNode<'_>,
-    template_offset: u32,
-    context: TemplateContext,
-    allow_statement_fallback: bool,
-    queries: &mut Vec<TemplatePromiseQuery>,
-) {
-    let Some((source_start, _source_end)) = absolute_expression_range(expression, template_offset)
-    else {
-        return;
-    };
-    let source_text = expression.loc().source.as_str();
-    for candidate in profile!(
-        "patina.type_aware.template_promise_queries.floating_ranges",
-        collect_floating_promise_ranges(source_text, allow_statement_fallback)
-    ) {
-        let candidate_start = source_start + candidate.start;
-        let candidate_end = source_start + candidate.end;
-        let probe_start = source_start + candidate.probe_start;
-        let Some(probe_source) =
-            source_text.get(candidate.probe_start as usize..candidate.probe_end as usize)
-        else {
-            continue;
-        };
-        let Some(generated_offset) =
-            generated_offset_for_text(virtual_ts, probe_start, probe_source)
-        else {
-            continue;
-        };
-        queries.push(TemplatePromiseQuery {
-            context,
-            generated_offset,
-            source_start: candidate_start,
-            source_end: candidate_end,
-        });
+        for callee in call_ranges.callees {
+            let callee_start = source_start + callee.start;
+            let callee_end = source_start + callee.end;
+            let Some(callee_source) = source_text.get(callee.start as usize..callee.end as usize)
+            else {
+                continue;
+            };
+            let Some(generated_offset) =
+                generated_offset_for_text(virtual_ts, callee_start, callee_source)
+            else {
+                continue;
+            };
+            queries.push(TemplateQuery {
+                kind: TemplateQueryKind::CallCallee,
+                context,
+                generated_offset,
+                source_start: callee_start,
+                source_end: callee_end,
+                owner_start: source_start,
+                owner_end: source_end,
+            });
+        }
+    }
+
+    if let Some(queries) = sinks.template_promise_queries.as_deref_mut() {
+        for candidate in call_ranges.floating_promises {
+            let candidate_start = source_start + candidate.start;
+            let candidate_end = source_start + candidate.end;
+            let probe_start = source_start + candidate.probe_start;
+            let Some(probe_source) =
+                source_text.get(candidate.probe_start as usize..candidate.probe_end as usize)
+            else {
+                continue;
+            };
+            let Some(generated_offset) =
+                generated_offset_for_text(virtual_ts, probe_start, probe_source)
+            else {
+                continue;
+            };
+            queries.push(TemplatePromiseQuery {
+                context,
+                generated_offset,
+                source_start: candidate_start,
+                source_end: candidate_end,
+            });
+        }
     }
 }

--- a/crates/vize_patina/src/linter/native_type_aware/template_queries/collector.rs
+++ b/crates/vize_patina/src/linter/native_type_aware/template_queries/collector.rs
@@ -240,8 +240,6 @@ fn collect_expression(
                 template_offset,
                 context,
                 allow_statement_fallback,
-                include_template_queries,
-                include_template_promise_queries,
                 sinks,
             )
         );
@@ -278,8 +276,6 @@ fn collect_expression_query_sets(
     template_offset: u32,
     context: TemplateContext,
     allow_statement_fallback: bool,
-    include_template_queries: bool,
-    include_template_promise_queries: bool,
     sinks: &mut TemplateQuerySinks<'_>,
 ) {
     let Some((source_start, source_end)) = absolute_expression_range(expression, template_offset)
@@ -287,6 +283,8 @@ fn collect_expression_query_sets(
         return;
     };
     let source_text = expression.loc().source.as_str();
+    let include_template_queries = sinks.template_queries.is_some();
+    let include_template_promise_queries = sinks.template_promise_queries.is_some();
     let expression_generated_offset = include_template_queries
         .then(|| generated_offset_for_text(virtual_ts, source_start, source_text))
         .flatten();

--- a/docs/content/architecture/performance.md
+++ b/docs/content/architecture/performance.md
@@ -122,7 +122,9 @@ Run `vp run --workspace-root bench:lint` to reproduce.
 Type-aware linting is intentionally profiled at the phases where cost tends to cluster: SFC parsing,
 Croquis analysis, virtual TypeScript generation, template query collection, and Corsa probes. When
 multiple template-backed type-aware rules are enabled, Patina collects template expression and
-template Promise queries in one AST walk before the Corsa probe phase.
+template Promise queries in one AST walk before the Corsa probe phase. Query collection also shares
+the OXC expression parse for unsafe-template and floating-Promise checks, so one template expression
+does not pay duplicate parse cost when both rules are enabled.
 
 Run `vize lint --profile --preset opinionated src` to see these rows in a local project.
 


### PR DESCRIPTION
## Summary
- collect unsafe-template and floating-Promise template query ranges from a shared expression parse
- keep statement fallback behavior for event handlers and partial expression parses
- add focused unit coverage for shared expression ranges and both fallback paths
- document the shared parse path in README and performance docs

## Validation
- `cargo test -p vize_patina template_queries::calls -- --nocapture`
- `cargo test -p vize_patina native_type_aware -- --nocapture`
- `cargo fmt --all -- --check`
- `vp check --fix README.md docs/content/architecture/performance.md`
- `git diff --check`