### PR TITLE
ci(e2e): harden compiler snapshot runs

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -29,20 +29,24 @@ jobs:
   app-e2e:
     runs-on: ubuntu-latest
     timeout-minutes: 90
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          submodules: recursive
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Cache Rust
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
         with:
           shared-key: "native"
           cache-workspace-crates: "true"
 
       - name: Setup Vite+ and Node.js
-        uses: voidzero-dev/setup-vp@v1
+        uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1
         with:
           node-version-file: ".node-version"
           cache: true
@@ -54,9 +58,12 @@ jobs:
       - name: Build native package
         run: vp run --filter './npm/vize-native' build:ci
 
+      - name: Build vize CLI
+        run: cargo build --release -p vize
+
       - name: Cache Playwright browsers
         id: cache-playwright
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -93,7 +100,7 @@ jobs:
 
       - name: Upload app e2e artifacts
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: app-e2e-artifacts-${{ inputs.suite }}
           path: |

--- a/tests/_helpers/apps.ts
+++ b/tests/_helpers/apps.ts
@@ -1143,7 +1143,34 @@ export const stylePreprocessorsApp: AppConfig = {
 };
 
 export const SCREENSHOT_DIR = path.resolve(TESTS_DIR, "app", "screenshots");
-export const VIZE_BIN = path.resolve(TESTS_DIR, "../target/release/vize");
+const VIZE_RELEASE_BIN = path.resolve(TESTS_DIR, "../target/release/vize");
+const VIZE_DEBUG_BIN = path.resolve(TESTS_DIR, "../target/debug/vize");
+const VIZE_BIN_OVERRIDE = process.env.VIZE_BIN;
+const VIZE_BIN_FALLBACKS = [VIZE_RELEASE_BIN, VIZE_DEBUG_BIN];
+export const VIZE_BIN =
+  VIZE_BIN_OVERRIDE && VIZE_BIN_OVERRIDE.length > 0
+    ? VIZE_BIN_OVERRIDE
+    : (VIZE_BIN_FALLBACKS.find((candidate) => fs.existsSync(candidate)) ?? VIZE_RELEASE_BIN);
 const CORSA_PRIMARY_BIN = path.resolve(TESTS_DIR, "../node_modules/.bin/corsa");
 const CORSA_LEGACY_BIN = path.resolve(TESTS_DIR, "../node_modules/.bin/tsgo");
 export const CORSA_BIN = fs.existsSync(CORSA_PRIMARY_BIN) ? CORSA_PRIMARY_BIN : CORSA_LEGACY_BIN;
+
+export function requireVizeBin(): void {
+  requireFile(VIZE_BIN, "vize CLI", "Build it with `cargo build --release -p vize`.");
+}
+
+export function requireVizeAndCorsaBins(): void {
+  requireVizeBin();
+  requireFile(
+    CORSA_BIN,
+    "Corsa/tsgo",
+    "Install JS dependencies with `vp install` so node_modules/.bin/corsa is available.",
+  );
+}
+
+function requireFile(filePath: string, label: string, hint: string): void {
+  if (fs.existsSync(filePath)) {
+    return;
+  }
+  throw new Error(`${label} binary not found at ${filePath}. ${hint}`);
+}

--- a/tests/_helpers/toolchain-parity.ts
+++ b/tests/_helpers/toolchain-parity.ts
@@ -4,7 +4,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import { compileScript, compileTemplate, parse as parseSfc } from "@vue/compiler-sfc";
-import { CORSA_BIN, VIZE_BIN, type AppConfig } from "./apps.ts";
+import { CORSA_BIN, VIZE_BIN, requireVizeAndCorsaBins, type AppConfig } from "./apps.ts";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -24,8 +24,12 @@ interface VizeCheckJson {
   }>;
 }
 
-export function hasToolchainParityBinaries(): boolean {
-  return fs.existsSync(VIZE_BIN) && fs.existsSync(CORSA_BIN) && resolveBin("vue-tsc") != null;
+export function requireToolchainParityBinaries(): void {
+  requireVizeAndCorsaBins();
+  assert.ok(
+    resolveBin("vue-tsc"),
+    "vue-tsc binary should exist. Install JS dependencies with `vp install`.",
+  );
 }
 
 export function assertOfficialCompilerAccepts(app: AppConfig): void {

--- a/tests/snapshots/build/elk.ts
+++ b/tests/snapshots/build/elk.ts
@@ -4,7 +4,7 @@ import { execSync } from "node:child_process";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
-import { elkApp, VIZE_BIN } from "../../_helpers/apps.ts";
+import { elkApp, VIZE_BIN, requireVizeBin } from "../../_helpers/apps.ts";
 import { assertParsesAsModule } from "../../_helpers/assertions.ts";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -12,10 +12,7 @@ const app = elkApp;
 
 describe(`${app.name} build (compiler)`, () => {
   before(() => {
-    if (!fs.existsSync(VIZE_BIN)) {
-      console.log(`Skipping: vize binary not found at ${VIZE_BIN}`);
-      process.exit(0);
-    }
+    requireVizeBin();
   });
 
   it("vize build compiles without errors", () => {

--- a/tests/snapshots/build/misskey.ts
+++ b/tests/snapshots/build/misskey.ts
@@ -4,7 +4,7 @@ import { execSync } from "node:child_process";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
-import { misskeyApp, VIZE_BIN } from "../../_helpers/apps.ts";
+import { misskeyApp, VIZE_BIN, requireVizeBin } from "../../_helpers/apps.ts";
 import { assertParsesAsModule } from "../../_helpers/assertions.ts";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -12,10 +12,7 @@ const app = misskeyApp;
 
 describe(`${app.name} build (compiler)`, () => {
   before(() => {
-    if (!fs.existsSync(VIZE_BIN)) {
-      console.log(`Skipping: vize binary not found at ${VIZE_BIN}`);
-      process.exit(0);
-    }
+    requireVizeBin();
     if (app.setup) app.setup();
   });
 

--- a/tests/snapshots/build/npmx.ts
+++ b/tests/snapshots/build/npmx.ts
@@ -4,7 +4,7 @@ import { execSync } from "node:child_process";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
-import { npmxApp, VIZE_BIN } from "../../_helpers/apps.ts";
+import { npmxApp, VIZE_BIN, requireVizeBin } from "../../_helpers/apps.ts";
 import { assertParsesAsModule } from "../../_helpers/assertions.ts";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -12,10 +12,7 @@ const app = npmxApp;
 
 describe(`${app.name} build (compiler)`, () => {
   before(() => {
-    if (!fs.existsSync(VIZE_BIN)) {
-      console.log(`Skipping: vize binary not found at ${VIZE_BIN}`);
-      process.exit(0);
-    }
+    requireVizeBin();
   });
 
   it("vize build compiles without errors", () => {

--- a/tests/snapshots/build/vuefes.ts
+++ b/tests/snapshots/build/vuefes.ts
@@ -4,7 +4,7 @@ import { execSync } from "node:child_process";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
-import { vuefesApp, VIZE_BIN } from "../../_helpers/apps.ts";
+import { vuefesApp, VIZE_BIN, requireVizeBin } from "../../_helpers/apps.ts";
 import { assertParsesAsModule } from "../../_helpers/assertions.ts";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -12,10 +12,7 @@ const app = vuefesApp;
 
 describe(`${app.name} build (compiler)`, () => {
   before(() => {
-    if (!fs.existsSync(VIZE_BIN)) {
-      console.log(`Skipping: vize binary not found at ${VIZE_BIN}`);
-      process.exit(0);
-    }
+    requireVizeBin();
   });
 
   it("vize build compiles without errors", () => {

--- a/tests/snapshots/check/ant-design-vue.ts
+++ b/tests/snapshots/check/ant-design-vue.ts
@@ -1,10 +1,14 @@
 import { describe, it, before } from "node:test";
 import assert from "node:assert/strict";
 import { execSync } from "node:child_process";
-import * as fs from "node:fs";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
-import { antDesignVueApp, CORSA_BIN, VIZE_BIN } from "../../_helpers/apps.ts";
+import {
+  antDesignVueApp,
+  CORSA_BIN,
+  VIZE_BIN,
+  requireVizeAndCorsaBins,
+} from "../../_helpers/apps.ts";
 import { assertSnapshot } from "../../_helpers/snapshot.ts";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -12,12 +16,7 @@ const SNAPSHOT_DIR = path.join(__dirname, "__snapshots__");
 const app = antDesignVueApp;
 
 describe(`${app.name} check (type checker)`, () => {
-  before(() => {
-    if (!fs.existsSync(VIZE_BIN) || !fs.existsSync(CORSA_BIN)) {
-      console.log(`Skipping: vize=${fs.existsSync(VIZE_BIN)}, corsa=${fs.existsSync(CORSA_BIN)}`);
-      process.exit(0);
-    }
-  });
+  before(requireVizeAndCorsaBins);
 
   // TODO: Corsa LSP deadlocks on ant-design-vue (731 files).
   // Unblock once the Corsa hang is fixed.

--- a/tests/snapshots/check/compiler-macros.ts
+++ b/tests/snapshots/check/compiler-macros.ts
@@ -1,10 +1,14 @@
 import { describe, it, before } from "node:test";
 import assert from "node:assert/strict";
 import { execSync } from "node:child_process";
-import * as fs from "node:fs";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
-import { compilerMacrosApp, CORSA_BIN, VIZE_BIN } from "../../_helpers/apps.ts";
+import {
+  compilerMacrosApp,
+  CORSA_BIN,
+  VIZE_BIN,
+  requireVizeAndCorsaBins,
+} from "../../_helpers/apps.ts";
 import { assertSnapshot } from "../../_helpers/snapshot.ts";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -12,12 +16,7 @@ const SNAPSHOT_DIR = path.join(__dirname, "__snapshots__");
 const app = compilerMacrosApp;
 
 describe(`${app.name} check (type checker)`, () => {
-  before(() => {
-    if (!fs.existsSync(VIZE_BIN) || !fs.existsSync(CORSA_BIN)) {
-      console.log(`Skipping: vize=${fs.existsSync(VIZE_BIN)}, corsa=${fs.existsSync(CORSA_BIN)}`);
-      process.exit(0);
-    }
-  });
+  before(requireVizeAndCorsaBins);
 
   it("vize check does not crash and snapshot matches", () => {
     const checkConfig = app.check!;

--- a/tests/snapshots/check/elk.ts
+++ b/tests/snapshots/check/elk.ts
@@ -1,10 +1,9 @@
 import { describe, it, before } from "node:test";
 import assert from "node:assert/strict";
 import { execSync } from "node:child_process";
-import * as fs from "node:fs";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
-import { elkApp, CORSA_BIN, VIZE_BIN } from "../../_helpers/apps.ts";
+import { elkApp, CORSA_BIN, VIZE_BIN, requireVizeAndCorsaBins } from "../../_helpers/apps.ts";
 import { assertSnapshot } from "../../_helpers/snapshot.ts";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -12,12 +11,7 @@ const SNAPSHOT_DIR = path.join(__dirname, "__snapshots__");
 const app = elkApp;
 
 describe(`${app.name} check (type checker)`, () => {
-  before(() => {
-    if (!fs.existsSync(VIZE_BIN) || !fs.existsSync(CORSA_BIN)) {
-      console.log(`Skipping: vize=${fs.existsSync(VIZE_BIN)}, corsa=${fs.existsSync(CORSA_BIN)}`);
-      process.exit(0);
-    }
-  });
+  before(requireVizeAndCorsaBins);
 
   it("vize check does not crash and snapshot matches", () => {
     const checkConfig = app.check!;

--- a/tests/snapshots/check/misskey.ts
+++ b/tests/snapshots/check/misskey.ts
@@ -1,10 +1,9 @@
 import { describe, it, before } from "node:test";
 import assert from "node:assert/strict";
 import { execSync } from "node:child_process";
-import * as fs from "node:fs";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
-import { misskeyApp, CORSA_BIN, VIZE_BIN } from "../../_helpers/apps.ts";
+import { misskeyApp, CORSA_BIN, VIZE_BIN, requireVizeAndCorsaBins } from "../../_helpers/apps.ts";
 import { assertSnapshot } from "../../_helpers/snapshot.ts";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -13,10 +12,7 @@ const app = misskeyApp;
 
 describe(`${app.name} check (type checker)`, () => {
   before(() => {
-    if (!fs.existsSync(VIZE_BIN) || !fs.existsSync(CORSA_BIN)) {
-      console.log(`Skipping: vize=${fs.existsSync(VIZE_BIN)}, corsa=${fs.existsSync(CORSA_BIN)}`);
-      process.exit(0);
-    }
+    requireVizeAndCorsaBins();
     if (app.setup) app.setup();
   });
 

--- a/tests/snapshots/check/npmx.ts
+++ b/tests/snapshots/check/npmx.ts
@@ -1,10 +1,9 @@
 import { describe, it, before } from "node:test";
 import assert from "node:assert/strict";
 import { execSync } from "node:child_process";
-import * as fs from "node:fs";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
-import { npmxApp, CORSA_BIN, VIZE_BIN } from "../../_helpers/apps.ts";
+import { npmxApp, CORSA_BIN, VIZE_BIN, requireVizeAndCorsaBins } from "../../_helpers/apps.ts";
 import { assertSnapshot } from "../../_helpers/snapshot.ts";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -12,12 +11,7 @@ const SNAPSHOT_DIR = path.join(__dirname, "__snapshots__");
 const app = npmxApp;
 
 describe(`${app.name} check (type checker)`, () => {
-  before(() => {
-    if (!fs.existsSync(VIZE_BIN) || !fs.existsSync(CORSA_BIN)) {
-      console.log(`Skipping: vize=${fs.existsSync(VIZE_BIN)}, corsa=${fs.existsSync(CORSA_BIN)}`);
-      process.exit(0);
-    }
-  });
+  before(requireVizeAndCorsaBins);
 
   it("vize check does not crash and snapshot matches", () => {
     const checkConfig = app.check!;

--- a/tests/snapshots/check/nuxt-ui.ts
+++ b/tests/snapshots/check/nuxt-ui.ts
@@ -1,10 +1,9 @@
 import { describe, it, before } from "node:test";
 import assert from "node:assert/strict";
 import { execSync } from "node:child_process";
-import * as fs from "node:fs";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
-import { nuxtUiApp, CORSA_BIN, VIZE_BIN } from "../../_helpers/apps.ts";
+import { nuxtUiApp, CORSA_BIN, VIZE_BIN, requireVizeAndCorsaBins } from "../../_helpers/apps.ts";
 import { assertSnapshot } from "../../_helpers/snapshot.ts";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -12,12 +11,7 @@ const SNAPSHOT_DIR = path.join(__dirname, "__snapshots__");
 const app = nuxtUiApp;
 
 describe(`${app.name} check (type checker)`, () => {
-  before(() => {
-    if (!fs.existsSync(VIZE_BIN) || !fs.existsSync(CORSA_BIN)) {
-      console.log(`Skipping: vize=${fs.existsSync(VIZE_BIN)}, corsa=${fs.existsSync(CORSA_BIN)}`);
-      process.exit(0);
-    }
-  });
+  before(requireVizeAndCorsaBins);
 
   it("vize check does not crash and snapshot matches", () => {
     const checkConfig = app.check!;

--- a/tests/snapshots/check/reka-ui.ts
+++ b/tests/snapshots/check/reka-ui.ts
@@ -1,10 +1,9 @@
 import { describe, it, before } from "node:test";
 import assert from "node:assert/strict";
 import { execSync } from "node:child_process";
-import * as fs from "node:fs";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
-import { rekaUiApp, CORSA_BIN, VIZE_BIN } from "../../_helpers/apps.ts";
+import { rekaUiApp, CORSA_BIN, VIZE_BIN, requireVizeAndCorsaBins } from "../../_helpers/apps.ts";
 import { assertSnapshot } from "../../_helpers/snapshot.ts";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -12,12 +11,7 @@ const SNAPSHOT_DIR = path.join(__dirname, "__snapshots__");
 const app = rekaUiApp;
 
 describe(`${app.name} check (type checker)`, () => {
-  before(() => {
-    if (!fs.existsSync(VIZE_BIN) || !fs.existsSync(CORSA_BIN)) {
-      console.log(`Skipping: vize=${fs.existsSync(VIZE_BIN)}, corsa=${fs.existsSync(CORSA_BIN)}`);
-      process.exit(0);
-    }
-  });
+  before(requireVizeAndCorsaBins);
 
   it("vize check does not crash and snapshot matches", () => {
     const checkConfig = app.check!;

--- a/tests/snapshots/check/style-preprocessors.ts
+++ b/tests/snapshots/check/style-preprocessors.ts
@@ -1,10 +1,14 @@
 import { describe, it, before } from "node:test";
 import assert from "node:assert/strict";
 import { execSync } from "node:child_process";
-import * as fs from "node:fs";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
-import { stylePreprocessorsApp, CORSA_BIN, VIZE_BIN } from "../../_helpers/apps.ts";
+import {
+  stylePreprocessorsApp,
+  CORSA_BIN,
+  VIZE_BIN,
+  requireVizeAndCorsaBins,
+} from "../../_helpers/apps.ts";
 import { assertSnapshot } from "../../_helpers/snapshot.ts";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -12,12 +16,7 @@ const SNAPSHOT_DIR = path.join(__dirname, "__snapshots__");
 const app = stylePreprocessorsApp;
 
 describe(`${app.name} check (type checker)`, () => {
-  before(() => {
-    if (!fs.existsSync(VIZE_BIN) || !fs.existsSync(CORSA_BIN)) {
-      console.log(`Skipping: vize=${fs.existsSync(VIZE_BIN)}, corsa=${fs.existsSync(CORSA_BIN)}`);
-      process.exit(0);
-    }
-  });
+  before(requireVizeAndCorsaBins);
 
   it("vize check passes with no errors for style preprocessors", () => {
     const checkConfig = app.check!;

--- a/tests/snapshots/check/toolchain-parity.ts
+++ b/tests/snapshots/check/toolchain-parity.ts
@@ -7,7 +7,7 @@ import {
 import {
   assertOfficialCompilerAccepts,
   assertVueTscDiagnosticSurface,
-  hasToolchainParityBinaries,
+  requireToolchainParityBinaries,
 } from "../../_helpers/toolchain-parity.ts";
 
 const fixtureApps = [
@@ -17,12 +17,7 @@ const fixtureApps = [
 ] as const;
 
 describe("check fixture parity with Vue toolchain", () => {
-  before(() => {
-    if (!hasToolchainParityBinaries()) {
-      console.log("Skipping: vize, checker, or vue-tsc binary was not found");
-      process.exit(0);
-    }
-  });
+  before(requireToolchainParityBinaries);
 
   for (const { app, expectErrors } of fixtureApps) {
     it(`${app.name} matches vue-tsc diagnostic surface`, () => {

--- a/tests/snapshots/check/typecheck-errors.ts
+++ b/tests/snapshots/check/typecheck-errors.ts
@@ -1,10 +1,14 @@
 import { describe, it, before } from "node:test";
 import assert from "node:assert/strict";
 import { execSync } from "node:child_process";
-import * as fs from "node:fs";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
-import { typecheckErrorsApp, CORSA_BIN, VIZE_BIN } from "../../_helpers/apps.ts";
+import {
+  typecheckErrorsApp,
+  CORSA_BIN,
+  VIZE_BIN,
+  requireVizeAndCorsaBins,
+} from "../../_helpers/apps.ts";
 import { assertSnapshot } from "../../_helpers/snapshot.ts";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -12,12 +16,7 @@ const SNAPSHOT_DIR = path.join(__dirname, "__snapshots__");
 const app = typecheckErrorsApp;
 
 describe(`${app.name} check (type checker)`, () => {
-  before(() => {
-    if (!fs.existsSync(VIZE_BIN) || !fs.existsSync(CORSA_BIN)) {
-      console.log(`Skipping: vize=${fs.existsSync(VIZE_BIN)}, corsa=${fs.existsSync(CORSA_BIN)}`);
-      process.exit(0);
-    }
-  });
+  before(requireVizeAndCorsaBins);
 
   it("vize check detects type errors", () => {
     const checkConfig = app.check!;

--- a/tests/snapshots/check/vuefes.ts
+++ b/tests/snapshots/check/vuefes.ts
@@ -1,10 +1,9 @@
 import { describe, it, before } from "node:test";
 import assert from "node:assert/strict";
 import { execSync } from "node:child_process";
-import * as fs from "node:fs";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
-import { vuefesApp, CORSA_BIN, VIZE_BIN } from "../../_helpers/apps.ts";
+import { vuefesApp, CORSA_BIN, VIZE_BIN, requireVizeAndCorsaBins } from "../../_helpers/apps.ts";
 import { assertSnapshot } from "../../_helpers/snapshot.ts";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -12,12 +11,7 @@ const SNAPSHOT_DIR = path.join(__dirname, "__snapshots__");
 const app = vuefesApp;
 
 describe(`${app.name} check (type checker)`, () => {
-  before(() => {
-    if (!fs.existsSync(VIZE_BIN) || !fs.existsSync(CORSA_BIN)) {
-      console.log(`Skipping: vize=${fs.existsSync(VIZE_BIN)}, corsa=${fs.existsSync(CORSA_BIN)}`);
-      process.exit(0);
-    }
-  });
+  before(requireVizeAndCorsaBins);
 
   it("vize check does not crash and snapshot matches", () => {
     const checkConfig = app.check!;

--- a/tests/snapshots/lint/ant-design-vue.ts
+++ b/tests/snapshots/lint/ant-design-vue.ts
@@ -1,10 +1,9 @@
 import { describe, it, before } from "node:test";
 import assert from "node:assert/strict";
 import { execSync } from "node:child_process";
-import * as fs from "node:fs";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
-import { antDesignVueApp, VIZE_BIN } from "../../_helpers/apps.ts";
+import { antDesignVueApp, VIZE_BIN, requireVizeBin } from "../../_helpers/apps.ts";
 import { assertSnapshot } from "../../_helpers/snapshot.ts";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -19,10 +18,7 @@ interface LintFileResult {
 
 describe(`${app.name} lint (linter)`, () => {
   before(() => {
-    if (!fs.existsSync(VIZE_BIN)) {
-      console.log(`Skipping: vize binary not found at ${VIZE_BIN}`);
-      process.exit(0);
-    }
+    requireVizeBin();
   });
 
   it("vize lint does not crash and snapshot matches", () => {

--- a/tests/snapshots/lint/elk.ts
+++ b/tests/snapshots/lint/elk.ts
@@ -1,10 +1,9 @@
 import { describe, it, before } from "node:test";
 import assert from "node:assert/strict";
 import { execSync } from "node:child_process";
-import * as fs from "node:fs";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
-import { elkApp, VIZE_BIN } from "../../_helpers/apps.ts";
+import { elkApp, VIZE_BIN, requireVizeBin } from "../../_helpers/apps.ts";
 import { assertSnapshot } from "../../_helpers/snapshot.ts";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -19,10 +18,7 @@ interface LintFileResult {
 
 describe(`${app.name} lint (linter)`, () => {
   before(() => {
-    if (!fs.existsSync(VIZE_BIN)) {
-      console.log(`Skipping: vize binary not found at ${VIZE_BIN}`);
-      process.exit(0);
-    }
+    requireVizeBin();
   });
 
   it("vize lint does not crash and snapshot matches", () => {

--- a/tests/snapshots/lint/misskey.ts
+++ b/tests/snapshots/lint/misskey.ts
@@ -1,10 +1,9 @@
 import { describe, it, before } from "node:test";
 import assert from "node:assert/strict";
 import { execSync } from "node:child_process";
-import * as fs from "node:fs";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
-import { misskeyApp, VIZE_BIN } from "../../_helpers/apps.ts";
+import { misskeyApp, VIZE_BIN, requireVizeBin } from "../../_helpers/apps.ts";
 import { assertSnapshot } from "../../_helpers/snapshot.ts";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -35,10 +34,7 @@ function compareStrings(left: string, right: string): number {
 
 describe(`${app.name} lint (linter)`, () => {
   before(() => {
-    if (!fs.existsSync(VIZE_BIN)) {
-      console.log(`Skipping: vize binary not found at ${VIZE_BIN}`);
-      process.exit(0);
-    }
+    requireVizeBin();
     if (app.setup) app.setup();
   });
 

--- a/tests/snapshots/lint/npmx.ts
+++ b/tests/snapshots/lint/npmx.ts
@@ -1,10 +1,9 @@
 import { describe, it, before } from "node:test";
 import assert from "node:assert/strict";
 import { execSync } from "node:child_process";
-import * as fs from "node:fs";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
-import { npmxApp, VIZE_BIN } from "../../_helpers/apps.ts";
+import { npmxApp, VIZE_BIN, requireVizeBin } from "../../_helpers/apps.ts";
 import { assertSnapshot } from "../../_helpers/snapshot.ts";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -19,10 +18,7 @@ interface LintFileResult {
 
 describe(`${app.name} lint (linter)`, () => {
   before(() => {
-    if (!fs.existsSync(VIZE_BIN)) {
-      console.log(`Skipping: vize binary not found at ${VIZE_BIN}`);
-      process.exit(0);
-    }
+    requireVizeBin();
   });
 
   it("vize lint does not crash and snapshot matches", () => {

--- a/tests/snapshots/lint/nuxt-ui.ts
+++ b/tests/snapshots/lint/nuxt-ui.ts
@@ -1,10 +1,9 @@
 import { describe, it, before } from "node:test";
 import assert from "node:assert/strict";
 import { execSync } from "node:child_process";
-import * as fs from "node:fs";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
-import { nuxtUiApp, VIZE_BIN } from "../../_helpers/apps.ts";
+import { nuxtUiApp, VIZE_BIN, requireVizeBin } from "../../_helpers/apps.ts";
 import { assertSnapshot } from "../../_helpers/snapshot.ts";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -19,10 +18,7 @@ interface LintFileResult {
 
 describe(`${app.name} lint (linter)`, () => {
   before(() => {
-    if (!fs.existsSync(VIZE_BIN)) {
-      console.log(`Skipping: vize binary not found at ${VIZE_BIN}`);
-      process.exit(0);
-    }
+    requireVizeBin();
   });
 
   it("vize lint does not crash and snapshot matches", () => {

--- a/tests/snapshots/lint/reka-ui.ts
+++ b/tests/snapshots/lint/reka-ui.ts
@@ -1,10 +1,9 @@
 import { describe, it, before } from "node:test";
 import assert from "node:assert/strict";
 import { execSync } from "node:child_process";
-import * as fs from "node:fs";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
-import { rekaUiApp, VIZE_BIN } from "../../_helpers/apps.ts";
+import { rekaUiApp, VIZE_BIN, requireVizeBin } from "../../_helpers/apps.ts";
 import { assertSnapshot } from "../../_helpers/snapshot.ts";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -19,10 +18,7 @@ interface LintFileResult {
 
 describe(`${app.name} lint (linter)`, () => {
   before(() => {
-    if (!fs.existsSync(VIZE_BIN)) {
-      console.log(`Skipping: vize binary not found at ${VIZE_BIN}`);
-      process.exit(0);
-    }
+    requireVizeBin();
   });
 
   it("vize lint does not crash and snapshot matches", () => {

--- a/tests/snapshots/lint/vuefes.ts
+++ b/tests/snapshots/lint/vuefes.ts
@@ -1,10 +1,9 @@
 import { describe, it, before } from "node:test";
 import assert from "node:assert/strict";
 import { execSync } from "node:child_process";
-import * as fs from "node:fs";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
-import { vuefesApp, VIZE_BIN } from "../../_helpers/apps.ts";
+import { vuefesApp, VIZE_BIN, requireVizeBin } from "../../_helpers/apps.ts";
 import { assertSnapshot } from "../../_helpers/snapshot.ts";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -19,10 +18,7 @@ interface LintFileResult {
 
 describe(`${app.name} lint (linter)`, () => {
   before(() => {
-    if (!fs.existsSync(VIZE_BIN)) {
-      console.log(`Skipping: vize binary not found at ${VIZE_BIN}`);
-      process.exit(0);
-    }
+    requireVizeBin();
   });
 
   it("vize lint does not crash and snapshot matches", () => {


### PR DESCRIPTION
## Summary
- Pin app e2e external actions by commit SHA and move checkout to the confirmed v6 SHA.
- Fetch submodules and build the release vize CLI before app e2e snapshot suites.
- Make compiler build/check/lint snapshot tests fail loudly when required binaries are missing, with VIZE_BIN override support.

## Verification
- vp check --fix tests/_helpers/apps.ts tests/_helpers/toolchain-parity.ts tests/snapshots/check/*.ts tests/snapshots/build/*.ts tests/snapshots/lint/*.ts
- git diff --check
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/e2e.yml"); puts ".github/workflows/e2e.yml: ok"'\n- VIZE_BIN=/definitely/missing/vize node --test tests/snapshots/build/elk.ts (fails as expected with the missing CLI guard)