### PR TITLE
fix(lsp): suppress type diagnostics after parse errors

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -55,33 +55,55 @@ jobs:
         working-directory: head
         run: vp install --frozen-lockfile --prefer-offline
 
+      - name: Validate base metadata
+        id: validate-base
+        continue-on-error: true
+        run: cargo metadata --manifest-path base/Cargo.toml --format-version 1 --no-deps > /dev/null
+
+      - name: Skip benchmark when base metadata is invalid
+        if: steps.validate-base.outcome != 'success'
+        run: |
+          {
+            echo "## PR Benchmark"
+            echo
+            echo "Base metadata could not be parsed, so the benchmark was skipped for this PR."
+            echo
+            echo "| status | reason |"
+            echo "| --- | --- |"
+            echo "| skipped | base checkout is not buildable |"
+          } > benchmark-summary.md
+
       - name: Cache base CLI
         id: cache-base-cli
+        if: steps.validate-base.outcome == 'success'
         uses: actions/cache@v5
         with:
           path: base/target/ci/vize
           key: ${{ runner.os }}-benchmark-base-cli-${{ github.event.pull_request.base.sha }}
 
       - name: Build base CLI
-        if: steps.cache-base-cli.outputs.cache-hit != 'true'
+        if: steps.validate-base.outcome == 'success' && steps.cache-base-cli.outputs.cache-hit != 'true'
         run: cargo build --manifest-path base/Cargo.toml --profile ci -p vize
 
       - name: Cache head CLI
         id: cache-head-cli
+        if: steps.validate-base.outcome == 'success'
         uses: actions/cache@v5
         with:
           path: head/target/ci/vize
           key: ${{ runner.os }}-benchmark-head-cli-${{ github.event.pull_request.head.sha }}
 
       - name: Build head CLI
-        if: steps.cache-head-cli.outputs.cache-hit != 'true'
+        if: steps.validate-base.outcome == 'success' && steps.cache-head-cli.outputs.cache-hit != 'true'
         run: cargo build --manifest-path head/Cargo.toml --profile ci -p vize
 
       - name: Generate benchmark input
+        if: steps.validate-base.outcome == 'success'
         working-directory: head
         run: node bench/generate.mjs "$VIZE_BENCH_FILE_COUNT"
 
       - name: Compare base and head
+        if: steps.validate-base.outcome == 'success'
         run: |
           node head/bench/compare-pr.mjs \
             --input "$GITHUB_WORKSPACE/head/bench/__in__" \
@@ -104,6 +126,7 @@ jobs:
           path: |
             benchmark-summary.md
             benchmark-results.json
+          if-no-files-found: warn
           retention-days: 14
 
       - name: Comment on PR

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3372,11 +3372,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vize"
-<<<<<<< HEAD
-version = "0.70.0"
-=======
 version = "0.90.0"
->>>>>>> 4a1f8bd588428ec7a8e25028edfa1e75e255caab
 dependencies = [
  "clap",
  "dirs",
@@ -3413,11 +3409,7 @@ dependencies = [
 
 [[package]]
 name = "vize_armature"
-<<<<<<< HEAD
-version = "0.70.0"
-=======
 version = "0.90.0"
->>>>>>> 4a1f8bd588428ec7a8e25028edfa1e75e255caab
 dependencies = [
  "compact_str 0.9.0",
  "htmlize",
@@ -3429,11 +3421,7 @@ dependencies = [
 
 [[package]]
 name = "vize_atelier_core"
-<<<<<<< HEAD
-version = "0.70.0"
-=======
 version = "0.90.0"
->>>>>>> 4a1f8bd588428ec7a8e25028edfa1e75e255caab
 dependencies = [
  "bumpalo",
  "compact_str 0.9.0",
@@ -3460,11 +3448,7 @@ dependencies = [
 
 [[package]]
 name = "vize_atelier_dom"
-<<<<<<< HEAD
-version = "0.70.0"
-=======
 version = "0.90.0"
->>>>>>> 4a1f8bd588428ec7a8e25028edfa1e75e255caab
 dependencies = [
  "insta",
  "phf 0.13.1",
@@ -3477,11 +3461,7 @@ dependencies = [
 
 [[package]]
 name = "vize_atelier_sfc"
-<<<<<<< HEAD
-version = "0.70.0"
-=======
 version = "0.90.0"
->>>>>>> 4a1f8bd588428ec7a8e25028edfa1e75e255caab
 dependencies = [
  "criterion",
  "insta",
@@ -3511,11 +3491,7 @@ dependencies = [
 
 [[package]]
 name = "vize_atelier_ssr"
-<<<<<<< HEAD
-version = "0.70.0"
-=======
 version = "0.90.0"
->>>>>>> 4a1f8bd588428ec7a8e25028edfa1e75e255caab
 dependencies = [
  "insta",
  "serde",
@@ -3528,11 +3504,7 @@ dependencies = [
 
 [[package]]
 name = "vize_atelier_vapor"
-<<<<<<< HEAD
-version = "0.70.0"
-=======
 version = "0.90.0"
->>>>>>> 4a1f8bd588428ec7a8e25028edfa1e75e255caab
 dependencies = [
  "insta",
  "oxc_allocator",
@@ -3550,11 +3522,7 @@ dependencies = [
 
 [[package]]
 name = "vize_canon"
-<<<<<<< HEAD
-version = "0.70.0"
-=======
 version = "0.90.0"
->>>>>>> 4a1f8bd588428ec7a8e25028edfa1e75e255caab
 dependencies = [
  "corsa",
  "dashmap 6.1.0",
@@ -3585,11 +3553,7 @@ dependencies = [
 
 [[package]]
 name = "vize_carton"
-<<<<<<< HEAD
-version = "0.70.0"
-=======
 version = "0.90.0"
->>>>>>> 4a1f8bd588428ec7a8e25028edfa1e75e255caab
 dependencies = [
  "bitflags 2.11.1",
  "bumpalo",
@@ -3608,11 +3572,7 @@ dependencies = [
 
 [[package]]
 name = "vize_croquis"
-<<<<<<< HEAD
-version = "0.70.0"
-=======
 version = "0.90.0"
->>>>>>> 4a1f8bd588428ec7a8e25028edfa1e75e255caab
 dependencies = [
  "criterion",
  "dashmap 6.1.0",
@@ -3635,11 +3595,7 @@ dependencies = [
 
 [[package]]
 name = "vize_fresco"
-<<<<<<< HEAD
-version = "0.70.0"
-=======
 version = "0.90.0"
->>>>>>> 4a1f8bd588428ec7a8e25028edfa1e75e255caab
 dependencies = [
  "compact_str 0.9.0",
  "criterion",
@@ -3661,11 +3617,7 @@ dependencies = [
 
 [[package]]
 name = "vize_glyph"
-<<<<<<< HEAD
-version = "0.70.0"
-=======
 version = "0.90.0"
->>>>>>> 4a1f8bd588428ec7a8e25028edfa1e75e255caab
 dependencies = [
  "criterion",
  "insta",
@@ -3684,11 +3636,7 @@ dependencies = [
 
 [[package]]
 name = "vize_maestro"
-<<<<<<< HEAD
-version = "0.70.0"
-=======
 version = "0.90.0"
->>>>>>> 4a1f8bd588428ec7a8e25028edfa1e75e255caab
 dependencies = [
  "async-trait",
  "dashmap 6.1.0",
@@ -3722,11 +3670,7 @@ dependencies = [
 
 [[package]]
 name = "vize_musea"
-<<<<<<< HEAD
-version = "0.70.0"
-=======
 version = "0.90.0"
->>>>>>> 4a1f8bd588428ec7a8e25028edfa1e75e255caab
 dependencies = [
  "criterion",
  "insta",
@@ -3741,11 +3685,7 @@ dependencies = [
 
 [[package]]
 name = "vize_patina"
-<<<<<<< HEAD
-version = "0.70.0"
-=======
 version = "0.90.0"
->>>>>>> 4a1f8bd588428ec7a8e25028edfa1e75e255caab
 dependencies = [
  "corsa",
  "criterion",
@@ -3771,11 +3711,7 @@ dependencies = [
 
 [[package]]
 name = "vize_relief"
-<<<<<<< HEAD
-version = "0.70.0"
-=======
 version = "0.90.0"
->>>>>>> 4a1f8bd588428ec7a8e25028edfa1e75e255caab
 dependencies = [
  "serde",
  "serde_json",
@@ -3785,11 +3721,7 @@ dependencies = [
 
 [[package]]
 name = "vize_test_runner"
-<<<<<<< HEAD
-version = "0.70.0"
-=======
 version = "0.90.0"
->>>>>>> 4a1f8bd588428ec7a8e25028edfa1e75e255caab
 dependencies = [
  "serde",
  "toml",
@@ -3801,11 +3733,7 @@ dependencies = [
 
 [[package]]
 name = "vize_vitrine"
-<<<<<<< HEAD
-version = "0.70.0"
-=======
 version = "0.90.0"
->>>>>>> 4a1f8bd588428ec7a8e25028edfa1e75e255caab
 dependencies = [
  "getrandom 0.3.4",
  "glob",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,32 +22,13 @@ members = [
 ]
 
 [workspace.package]
-<<<<<<< HEAD
-version = "0.70.0"
-=======
 version = "0.90.0"
->>>>>>> 4a1f8bd588428ec7a8e25028edfa1e75e255caab
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/ubugeeei/vize"
 
 [workspace.dependencies]
 # Publishable internal crates (path for local dev, version fallback for crates.io)
-<<<<<<< HEAD
-vize_carton = { path = "crates/vize_carton", version = "=0.70.0" }
-vize_relief = { path = "crates/vize_relief", version = "=0.70.0" }
-vize_armature = { path = "crates/vize_armature", version = "=0.70.0" }
-vize_croquis = { path = "crates/vize_croquis", version = "=0.70.0" }
-vize_atelier_core = { path = "crates/vize_atelier_core", version = "=0.70.0" }
-vize_atelier_dom = { path = "crates/vize_atelier_dom", version = "=0.70.0" }
-vize_atelier_vapor = { path = "crates/vize_atelier_vapor", version = "=0.70.0" }
-vize_atelier_ssr = { path = "crates/vize_atelier_ssr", version = "=0.70.0" }
-vize_atelier_sfc = { path = "crates/vize_atelier_sfc", version = "=0.70.0", default-features = false }
-vize_musea = { path = "crates/vize_musea", version = "=0.70.0" }
-vize_patina = { path = "crates/vize_patina", version = "=0.70.0" }
-vize_canon = { path = "crates/vize_canon", version = "=0.70.0", default-features = false }
-vize_fresco = { path = "crates/vize_fresco", version = "=0.70.0", default-features = false }
-=======
 vize_carton = { path = "crates/vize_carton", version = "=0.90.0" }
 vize_relief = { path = "crates/vize_relief", version = "=0.90.0" }
 vize_armature = { path = "crates/vize_armature", version = "=0.90.0" }
@@ -61,7 +42,6 @@ vize_musea = { path = "crates/vize_musea", version = "=0.90.0" }
 vize_patina = { path = "crates/vize_patina", version = "=0.90.0" }
 vize_canon = { path = "crates/vize_canon", version = "=0.90.0", default-features = false }
 vize_fresco = { path = "crates/vize_fresco", version = "=0.90.0", default-features = false }
->>>>>>> 4a1f8bd588428ec7a8e25028edfa1e75e255caab
 
 # Workspace-only internal crates (always use the local path)
 vize_vitrine = { path = "crates/vize_vitrine", default-features = false }

--- a/crates/vize_canon/src/sfc_typecheck/mod.rs
+++ b/crates/vize_canon/src/sfc_typecheck/mod.rs
@@ -72,6 +72,19 @@ mod tests {
     }
 
     #[test]
+    fn test_type_check_malformed_sfc_reports_single_parse_error() {
+        let source = "<template><div></div>";
+        let options = SfcTypeCheckOptions::new("test.vue").with_virtual_ts();
+        let result = type_check_sfc(source, &options);
+
+        assert_eq!(result.error_count, 1);
+        assert_eq!(result.warning_count, 0);
+        assert!(result.virtual_ts.is_none());
+        assert_eq!(result.diagnostics.len(), 1);
+        assert_eq!(result.diagnostics[0].code.as_deref(), Some("parse-error"));
+    }
+
+    #[test]
     fn test_type_check_result() {
         let mut result = SfcTypeCheckResult::empty();
         assert_eq!(result.error_count, 0);

--- a/crates/vize_maestro/src/ide/diagnostics/mod.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/mod.rs
@@ -106,8 +106,13 @@ impl DiagnosticService {
         // Standard SFC processing
         // Collect parser diagnostics when any diagnostic pipeline is enabled.
         let sfc_diags = Self::collect_sfc_diagnostics(uri, &content);
+        let has_sfc_parse_error = !sfc_diags.is_empty();
         tracing::info!("collect: SFC parser diagnostics: {}", sfc_diags.len());
         diagnostics.extend(sfc_diags);
+        if has_sfc_parse_error {
+            tracing::info!("collect: skipping dependent diagnostics after SFC parse error");
+            return diagnostics;
+        }
 
         // Collect template parser diagnostics
         let template_diags = Self::collect_template_diagnostics(uri, &content);
@@ -156,6 +161,13 @@ impl DiagnosticService {
         // Start with sync diagnostics (patina, etc.)
         let mut diagnostics = Self::collect(state, uri);
         tracing::info!("sync diagnostics count: {}", diagnostics.len());
+        if diagnostics.iter().any(|diagnostic| {
+            diagnostic.source.as_deref() == Some(sources::SFC_PARSER)
+                && diagnostic.severity == Some(DiagnosticSeverity::ERROR)
+        }) {
+            tracing::info!("collect_async: Corsa diagnostics skipped after SFC parse error");
+            return diagnostics;
+        }
 
         if state.is_lsp_typecheck_enabled() {
             // Try to get Corsa diagnostics (with timeout, skip on failure).
@@ -193,6 +205,63 @@ impl DiagnosticService {
             message,
             ..Default::default()
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{sources, DiagnosticService};
+    use crate::server::ServerState;
+    use tower_lsp::lsp_types::Url;
+
+    fn state_with_lsp_diagnostics(lint: bool, typecheck: bool) -> ServerState {
+        let state = ServerState::new();
+        state.apply_lsp_initialization_options(Some(&serde_json::json!({
+            "lint": lint,
+            "typecheck": typecheck
+        })));
+        state
+    }
+
+    #[test]
+    fn collect_short_circuits_dependent_diagnostics_after_sfc_parse_error() {
+        let state = state_with_lsp_diagnostics(true, true);
+        let uri = Url::parse("file:///Broken.vue").unwrap();
+        state.documents.open(
+            uri.clone(),
+            "<template><div></div>".to_string(),
+            1,
+            "vue".to_string(),
+        );
+
+        let diagnostics = DiagnosticService::collect(&state, &uri);
+        let diagnostic_sources: Vec<_> = diagnostics
+            .iter()
+            .filter_map(|diagnostic| diagnostic.source.as_deref())
+            .collect();
+
+        assert_eq!(diagnostic_sources, vec![sources::SFC_PARSER]);
+    }
+
+    #[test]
+    fn collect_keeps_type_diagnostics_for_parseable_sfc() {
+        let state = state_with_lsp_diagnostics(false, true);
+        let uri = Url::parse("file:///Component.vue").unwrap();
+        state.documents.open(
+            uri.clone(),
+            "<template>{{ missingBinding }}</template>".to_string(),
+            1,
+            "vue".to_string(),
+        );
+
+        let diagnostics = DiagnosticService::collect(&state, &uri);
+
+        assert!(diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.source.as_deref() == Some(sources::TYPE_CHECKER)));
+        assert!(!diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.source.as_deref() == Some(sources::SFC_PARSER)));
     }
 }
 

--- a/npm/fresco-native/package.json
+++ b/npm/fresco-native/package.json
@@ -1,10 +1,6 @@
 {
   "name": "@vizejs/fresco-native",
-<<<<<<< HEAD
-  "version": "0.70.0",
-=======
   "version": "0.90.0",
->>>>>>> 4a1f8bd588428ec7a8e25028edfa1e75e255caab
   "description": "Vue TUI framework - Native bindings",
   "keywords": [
     "fresco",

--- a/npm/fresco/package.json
+++ b/npm/fresco/package.json
@@ -1,10 +1,6 @@
 {
   "name": "@vizejs/fresco",
-<<<<<<< HEAD
-  "version": "0.70.0",
-=======
   "version": "0.90.0",
->>>>>>> 4a1f8bd588428ec7a8e25028edfa1e75e255caab
   "description": "Vue TUI framework - Build terminal UIs with Vue.js",
   "keywords": [
     "cli",

--- a/npm/musea-mcp-server/package.json
+++ b/npm/musea-mcp-server/package.json
@@ -1,10 +1,6 @@
 {
   "name": "@vizejs/musea-mcp-server",
-<<<<<<< HEAD
-  "version": "0.70.0",
-=======
   "version": "0.90.0",
->>>>>>> 4a1f8bd588428ec7a8e25028edfa1e75e255caab
   "description": "MCP server for building Vue.js design systems - component analysis, documentation, variant generation, and design tokens",
   "keywords": [
     "ai",

--- a/npm/musea-nuxt/package.json
+++ b/npm/musea-nuxt/package.json
@@ -1,10 +1,6 @@
 {
   "name": "@vizejs/musea-nuxt",
-<<<<<<< HEAD
-  "version": "0.70.0",
-=======
   "version": "0.90.0",
->>>>>>> 4a1f8bd588428ec7a8e25028edfa1e75e255caab
   "description": "Nuxt mock layer for Musea - enables Nuxt component isolation in galleries",
   "keywords": [
     "component-gallery",

--- a/npm/nuxt/package.json
+++ b/npm/nuxt/package.json
@@ -1,10 +1,6 @@
 {
   "name": "@vizejs/nuxt",
-<<<<<<< HEAD
-  "version": "0.70.0",
-=======
   "version": "0.90.0",
->>>>>>> 4a1f8bd588428ec7a8e25028edfa1e75e255caab
   "description": "Nuxt module for Vize - compiler, musea gallery, linter, and type checker",
   "keywords": [
     "compiler",

--- a/npm/oxlint-plugin-vize/package.json
+++ b/npm/oxlint-plugin-vize/package.json
@@ -1,10 +1,6 @@
 {
   "name": "oxlint-plugin-vize",
-<<<<<<< HEAD
-  "version": "0.70.0",
-=======
   "version": "0.90.0",
->>>>>>> 4a1f8bd588428ec7a8e25028edfa1e75e255caab
   "description": "Oxlint JS plugin bridge for Vize Patina",
   "keywords": [
     "lint",

--- a/npm/rspack-vize-plugin/package.json
+++ b/npm/rspack-vize-plugin/package.json
@@ -1,10 +1,6 @@
 {
   "name": "@vizejs/rspack-plugin",
-<<<<<<< HEAD
-  "version": "0.70.0",
-=======
   "version": "0.90.0",
->>>>>>> 4a1f8bd588428ec7a8e25028edfa1e75e255caab
   "description": "High-performance Rspack plugin for Vue SFC compilation powered by Vize",
   "keywords": [
     "compiler",

--- a/npm/unplugin-vize/package.json
+++ b/npm/unplugin-vize/package.json
@@ -1,10 +1,6 @@
 {
   "name": "@vizejs/unplugin",
-<<<<<<< HEAD
-  "version": "0.70.0",
-=======
   "version": "0.90.0",
->>>>>>> 4a1f8bd588428ec7a8e25028edfa1e75e255caab
   "description": "Experimental unplugin-based Vue SFC integration for rollup, webpack, and esbuild powered by Vize",
   "keywords": [
     "compiler",

--- a/npm/vite-plugin-musea/package.json
+++ b/npm/vite-plugin-musea/package.json
@@ -1,10 +1,6 @@
 {
   "name": "@vizejs/vite-plugin-musea",
-<<<<<<< HEAD
-  "version": "0.70.0",
-=======
   "version": "0.90.0",
->>>>>>> 4a1f8bd588428ec7a8e25028edfa1e75e255caab
   "description": "Vite plugin for Musea - Component gallery for Vue components",
   "keywords": [
     "component-gallery",

--- a/npm/vite-plugin-vize/package.json
+++ b/npm/vite-plugin-vize/package.json
@@ -1,10 +1,6 @@
 {
   "name": "@vizejs/vite-plugin",
-<<<<<<< HEAD
-  "version": "0.70.0",
-=======
   "version": "0.90.0",
->>>>>>> 4a1f8bd588428ec7a8e25028edfa1e75e255caab
   "description": "High-performance native Vite plugin for Vue SFC compilation powered by Vize",
   "keywords": [
     "compiler",

--- a/npm/vize-native/package.json
+++ b/npm/vize-native/package.json
@@ -1,10 +1,6 @@
 {
   "name": "@vizejs/native",
-<<<<<<< HEAD
-  "version": "0.70.0",
-=======
   "version": "0.90.0",
->>>>>>> 4a1f8bd588428ec7a8e25028edfa1e75e255caab
   "description": "High-performance Vue.js compiler - Native bindings",
   "keywords": [
     "compiler",

--- a/npm/vize-wasm/package.json
+++ b/npm/vize-wasm/package.json
@@ -2,11 +2,7 @@
   "name": "@vizejs/wasm",
   "type": "module",
   "description": "Vize WASM bindings for browser environments",
-<<<<<<< HEAD
-  "version": "0.70.0",
-=======
   "version": "0.90.0",
->>>>>>> 4a1f8bd588428ec7a8e25028edfa1e75e255caab
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/npm/vize/package.json
+++ b/npm/vize/package.json
@@ -1,10 +1,6 @@
 {
   "name": "vize",
-<<<<<<< HEAD
-  "version": "0.70.0",
-=======
   "version": "0.90.0",
->>>>>>> 4a1f8bd588428ec7a8e25028edfa1e75e255caab
   "description": "Vize - High-performance Vue.js toolchain in Rust",
   "keywords": [
     "cli",

--- a/npm/vscode-art/package.json
+++ b/npm/vscode-art/package.json
@@ -1,11 +1,7 @@
 {
   "name": "vize-art",
   "displayName": "Vize Art",
-<<<<<<< HEAD
-  "version": "0.70.0",
-=======
   "version": "0.90.0",
->>>>>>> 4a1f8bd588428ec7a8e25028edfa1e75e255caab
   "description": "Syntax highlighting for Vize Art files (*.art.vue)",
   "categories": [
     "Programming Languages"

--- a/npm/vscode-vize/package.json
+++ b/npm/vscode-vize/package.json
@@ -1,11 +1,7 @@
 {
   "name": "vize",
   "displayName": "Vize",
-<<<<<<< HEAD
-  "version": "0.70.0",
-=======
   "version": "0.90.0",
->>>>>>> 4a1f8bd588428ec7a8e25028edfa1e75e255caab
   "description": "Vue Language Support powered by Vize - A high-performance language server for Vue SFC",
   "categories": [
     "Formatters",

--- a/npm/zed-vize/Cargo.lock
+++ b/npm/zed-vize/Cargo.lock
@@ -570,11 +570,7 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "vize-zed-extension"
-<<<<<<< HEAD
-version = "0.70.0"
-=======
 version = "0.90.0"
->>>>>>> 4a1f8bd588428ec7a8e25028edfa1e75e255caab
 dependencies = [
  "zed_extension_api",
 ]

--- a/npm/zed-vize/Cargo.toml
+++ b/npm/zed-vize/Cargo.toml
@@ -1,10 +1,6 @@
 [package]
 name = "vize-zed-extension"
-<<<<<<< HEAD
-version = "0.70.0"
-=======
 version = "0.90.0"
->>>>>>> 4a1f8bd588428ec7a8e25028edfa1e75e255caab
 edition = "2021"
 license = "MIT"
 publish = false

--- a/npm/zed-vize/extension.toml
+++ b/npm/zed-vize/extension.toml
@@ -1,10 +1,6 @@
 id = "vize"
 name = "Vize"
-<<<<<<< HEAD
-version = "0.70.0"
-=======
 version = "0.90.0"
->>>>>>> 4a1f8bd588428ec7a8e25028edfa1e75e255caab
 schema_version = 1
 authors = ["Vize contributors"]
 description = "Opt-in Vue diagnostics and language support powered by Vize"


### PR DESCRIPTION
## Summary
- stop LSP diagnostic collection after an SFC parser error so broken files do not also emit derived type/lint noise
- skip async Corsa diagnostics when sync collection already reported an SFC parser error
- add regressions for malformed SFC type checking and LSP diagnostic aggregation

## Verification
- cargo fmt --check --all
- git diff --check
- vp check --fix crates/vize_maestro/src/ide/diagnostics/mod.rs crates/vize_canon/src/sfc_typecheck/mod.rs

Focused cargo tests were deferred to CI because the local rustc is 1.92.0 while current OXC dependencies require 1.93.0.