### PR TITLE
fix(lint): match options api component aliases

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -55,33 +55,55 @@ jobs:
         working-directory: head
         run: vp install --frozen-lockfile --prefer-offline
 
+      - name: Validate base metadata
+        id: validate-base
+        continue-on-error: true
+        run: cargo metadata --manifest-path base/Cargo.toml --format-version 1 --no-deps > /dev/null
+
+      - name: Skip benchmark when base metadata is invalid
+        if: steps.validate-base.outcome != 'success'
+        run: |
+          {
+            echo "## PR Benchmark"
+            echo
+            echo "Base metadata could not be parsed, so the benchmark was skipped for this PR."
+            echo
+            echo "| status | reason |"
+            echo "| --- | --- |"
+            echo "| skipped | base checkout is not buildable |"
+          } > benchmark-summary.md
+
       - name: Cache base CLI
         id: cache-base-cli
+        if: steps.validate-base.outcome == 'success'
         uses: actions/cache@v5
         with:
           path: base/target/ci/vize
           key: ${{ runner.os }}-benchmark-base-cli-${{ github.event.pull_request.base.sha }}
 
       - name: Build base CLI
-        if: steps.cache-base-cli.outputs.cache-hit != 'true'
+        if: steps.validate-base.outcome == 'success' && steps.cache-base-cli.outputs.cache-hit != 'true'
         run: cargo build --manifest-path base/Cargo.toml --profile ci -p vize
 
       - name: Cache head CLI
         id: cache-head-cli
+        if: steps.validate-base.outcome == 'success'
         uses: actions/cache@v5
         with:
           path: head/target/ci/vize
           key: ${{ runner.os }}-benchmark-head-cli-${{ github.event.pull_request.head.sha }}
 
       - name: Build head CLI
-        if: steps.cache-head-cli.outputs.cache-hit != 'true'
+        if: steps.validate-base.outcome == 'success' && steps.cache-head-cli.outputs.cache-hit != 'true'
         run: cargo build --manifest-path head/Cargo.toml --profile ci -p vize
 
       - name: Generate benchmark input
+        if: steps.validate-base.outcome == 'success'
         working-directory: head
         run: node bench/generate.mjs "$VIZE_BENCH_FILE_COUNT"
 
       - name: Compare base and head
+        if: steps.validate-base.outcome == 'success'
         run: |
           node head/bench/compare-pr.mjs \
             --input "$GITHUB_WORKSPACE/head/bench/__in__" \
@@ -104,6 +126,7 @@ jobs:
           path: |
             benchmark-summary.md
             benchmark-results.json
+          if-no-files-found: warn
           retention-days: 14
 
       - name: Comment on PR

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3372,11 +3372,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vize"
-<<<<<<< HEAD
-version = "0.70.0"
-=======
 version = "0.90.0"
->>>>>>> 4a1f8bd588428ec7a8e25028edfa1e75e255caab
 dependencies = [
  "clap",
  "dirs",
@@ -3413,11 +3409,7 @@ dependencies = [
 
 [[package]]
 name = "vize_armature"
-<<<<<<< HEAD
-version = "0.70.0"
-=======
 version = "0.90.0"
->>>>>>> 4a1f8bd588428ec7a8e25028edfa1e75e255caab
 dependencies = [
  "compact_str 0.9.0",
  "htmlize",
@@ -3429,11 +3421,7 @@ dependencies = [
 
 [[package]]
 name = "vize_atelier_core"
-<<<<<<< HEAD
-version = "0.70.0"
-=======
 version = "0.90.0"
->>>>>>> 4a1f8bd588428ec7a8e25028edfa1e75e255caab
 dependencies = [
  "bumpalo",
  "compact_str 0.9.0",
@@ -3460,11 +3448,7 @@ dependencies = [
 
 [[package]]
 name = "vize_atelier_dom"
-<<<<<<< HEAD
-version = "0.70.0"
-=======
 version = "0.90.0"
->>>>>>> 4a1f8bd588428ec7a8e25028edfa1e75e255caab
 dependencies = [
  "insta",
  "phf 0.13.1",
@@ -3477,11 +3461,7 @@ dependencies = [
 
 [[package]]
 name = "vize_atelier_sfc"
-<<<<<<< HEAD
-version = "0.70.0"
-=======
 version = "0.90.0"
->>>>>>> 4a1f8bd588428ec7a8e25028edfa1e75e255caab
 dependencies = [
  "criterion",
  "insta",
@@ -3511,11 +3491,7 @@ dependencies = [
 
 [[package]]
 name = "vize_atelier_ssr"
-<<<<<<< HEAD
-version = "0.70.0"
-=======
 version = "0.90.0"
->>>>>>> 4a1f8bd588428ec7a8e25028edfa1e75e255caab
 dependencies = [
  "insta",
  "serde",
@@ -3528,11 +3504,7 @@ dependencies = [
 
 [[package]]
 name = "vize_atelier_vapor"
-<<<<<<< HEAD
-version = "0.70.0"
-=======
 version = "0.90.0"
->>>>>>> 4a1f8bd588428ec7a8e25028edfa1e75e255caab
 dependencies = [
  "insta",
  "oxc_allocator",
@@ -3550,11 +3522,7 @@ dependencies = [
 
 [[package]]
 name = "vize_canon"
-<<<<<<< HEAD
-version = "0.70.0"
-=======
 version = "0.90.0"
->>>>>>> 4a1f8bd588428ec7a8e25028edfa1e75e255caab
 dependencies = [
  "corsa",
  "dashmap 6.1.0",
@@ -3585,11 +3553,7 @@ dependencies = [
 
 [[package]]
 name = "vize_carton"
-<<<<<<< HEAD
-version = "0.70.0"
-=======
 version = "0.90.0"
->>>>>>> 4a1f8bd588428ec7a8e25028edfa1e75e255caab
 dependencies = [
  "bitflags 2.11.1",
  "bumpalo",
@@ -3608,11 +3572,7 @@ dependencies = [
 
 [[package]]
 name = "vize_croquis"
-<<<<<<< HEAD
-version = "0.70.0"
-=======
 version = "0.90.0"
->>>>>>> 4a1f8bd588428ec7a8e25028edfa1e75e255caab
 dependencies = [
  "criterion",
  "dashmap 6.1.0",
@@ -3635,11 +3595,7 @@ dependencies = [
 
 [[package]]
 name = "vize_fresco"
-<<<<<<< HEAD
-version = "0.70.0"
-=======
 version = "0.90.0"
->>>>>>> 4a1f8bd588428ec7a8e25028edfa1e75e255caab
 dependencies = [
  "compact_str 0.9.0",
  "criterion",
@@ -3661,11 +3617,7 @@ dependencies = [
 
 [[package]]
 name = "vize_glyph"
-<<<<<<< HEAD
-version = "0.70.0"
-=======
 version = "0.90.0"
->>>>>>> 4a1f8bd588428ec7a8e25028edfa1e75e255caab
 dependencies = [
  "criterion",
  "insta",
@@ -3684,11 +3636,7 @@ dependencies = [
 
 [[package]]
 name = "vize_maestro"
-<<<<<<< HEAD
-version = "0.70.0"
-=======
 version = "0.90.0"
->>>>>>> 4a1f8bd588428ec7a8e25028edfa1e75e255caab
 dependencies = [
  "async-trait",
  "dashmap 6.1.0",
@@ -3722,11 +3670,7 @@ dependencies = [
 
 [[package]]
 name = "vize_musea"
-<<<<<<< HEAD
-version = "0.70.0"
-=======
 version = "0.90.0"
->>>>>>> 4a1f8bd588428ec7a8e25028edfa1e75e255caab
 dependencies = [
  "criterion",
  "insta",
@@ -3741,11 +3685,7 @@ dependencies = [
 
 [[package]]
 name = "vize_patina"
-<<<<<<< HEAD
-version = "0.70.0"
-=======
 version = "0.90.0"
->>>>>>> 4a1f8bd588428ec7a8e25028edfa1e75e255caab
 dependencies = [
  "corsa",
  "criterion",
@@ -3771,11 +3711,7 @@ dependencies = [
 
 [[package]]
 name = "vize_relief"
-<<<<<<< HEAD
-version = "0.70.0"
-=======
 version = "0.90.0"
->>>>>>> 4a1f8bd588428ec7a8e25028edfa1e75e255caab
 dependencies = [
  "serde",
  "serde_json",
@@ -3785,11 +3721,7 @@ dependencies = [
 
 [[package]]
 name = "vize_test_runner"
-<<<<<<< HEAD
-version = "0.70.0"
-=======
 version = "0.90.0"
->>>>>>> 4a1f8bd588428ec7a8e25028edfa1e75e255caab
 dependencies = [
  "serde",
  "toml",
@@ -3801,11 +3733,7 @@ dependencies = [
 
 [[package]]
 name = "vize_vitrine"
-<<<<<<< HEAD
-version = "0.70.0"
-=======
 version = "0.90.0"
->>>>>>> 4a1f8bd588428ec7a8e25028edfa1e75e255caab
 dependencies = [
  "getrandom 0.3.4",
  "glob",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,32 +22,13 @@ members = [
 ]
 
 [workspace.package]
-<<<<<<< HEAD
-version = "0.70.0"
-=======
 version = "0.90.0"
->>>>>>> 4a1f8bd588428ec7a8e25028edfa1e75e255caab
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/ubugeeei/vize"
 
 [workspace.dependencies]
 # Publishable internal crates (path for local dev, version fallback for crates.io)
-<<<<<<< HEAD
-vize_carton = { path = "crates/vize_carton", version = "=0.70.0" }
-vize_relief = { path = "crates/vize_relief", version = "=0.70.0" }
-vize_armature = { path = "crates/vize_armature", version = "=0.70.0" }
-vize_croquis = { path = "crates/vize_croquis", version = "=0.70.0" }
-vize_atelier_core = { path = "crates/vize_atelier_core", version = "=0.70.0" }
-vize_atelier_dom = { path = "crates/vize_atelier_dom", version = "=0.70.0" }
-vize_atelier_vapor = { path = "crates/vize_atelier_vapor", version = "=0.70.0" }
-vize_atelier_ssr = { path = "crates/vize_atelier_ssr", version = "=0.70.0" }
-vize_atelier_sfc = { path = "crates/vize_atelier_sfc", version = "=0.70.0", default-features = false }
-vize_musea = { path = "crates/vize_musea", version = "=0.70.0" }
-vize_patina = { path = "crates/vize_patina", version = "=0.70.0" }
-vize_canon = { path = "crates/vize_canon", version = "=0.70.0", default-features = false }
-vize_fresco = { path = "crates/vize_fresco", version = "=0.70.0", default-features = false }
-=======
 vize_carton = { path = "crates/vize_carton", version = "=0.90.0" }
 vize_relief = { path = "crates/vize_relief", version = "=0.90.0" }
 vize_armature = { path = "crates/vize_armature", version = "=0.90.0" }
@@ -61,7 +42,6 @@ vize_musea = { path = "crates/vize_musea", version = "=0.90.0" }
 vize_patina = { path = "crates/vize_patina", version = "=0.90.0" }
 vize_canon = { path = "crates/vize_canon", version = "=0.90.0", default-features = false }
 vize_fresco = { path = "crates/vize_fresco", version = "=0.90.0", default-features = false }
->>>>>>> 4a1f8bd588428ec7a8e25028edfa1e75e255caab
 
 # Workspace-only internal crates (always use the local path)
 vize_vitrine = { path = "crates/vize_vitrine", default-features = false }

--- a/crates/vize_croquis/src/analysis/mod.rs
+++ b/crates/vize_croquis/src/analysis/mod.rs
@@ -41,8 +41,8 @@ pub use bindings::{
 };
 pub use croquis::AnalysisStats;
 pub use template::{
-    ComponentUsage, ElementIdInfo, ElementIdKind, EventListener, PassedProp, SlotUsage,
-    TemplateExpression, TemplateExpressionKind, TemplateInfo,
+    ComponentRegistration, ComponentUsage, ElementIdInfo, ElementIdKind, EventListener, PassedProp,
+    SlotUsage, TemplateExpression, TemplateExpressionKind, TemplateInfo,
 };
 
 use crate::hoist::HoistTracker;
@@ -96,6 +96,9 @@ pub struct Croquis {
 
     /// Components used in template (names only, for quick lookup)
     pub used_components: FxHashSet<CompactString>,
+
+    /// Components registered through Options API `components`.
+    pub component_registrations: Vec<ComponentRegistration>,
 
     /// Detailed component usage information (props, events, slots)
     pub component_usages: Vec<ComponentUsage>,

--- a/crates/vize_croquis/src/analysis/template.rs
+++ b/crates/vize_croquis/src/analysis/template.rs
@@ -37,6 +37,15 @@ impl TemplateInfo {
     }
 }
 
+/// Component registration from an Options API `components` option.
+#[derive(Debug, Clone)]
+pub struct ComponentRegistration {
+    /// Public component name registered for template usage.
+    pub name: CompactString,
+    /// Local script binding referenced by the registration.
+    pub local_name: CompactString,
+}
+
 /// Information about element IDs in template (for cross-file uniqueness checking).
 #[derive(Debug, Clone)]
 pub struct ElementIdInfo {

--- a/crates/vize_croquis/src/analyzer/helpers/keywords.rs
+++ b/crates/vize_croquis/src/analyzer/helpers/keywords.rs
@@ -5,11 +5,16 @@
 //! - Whether a directive is built-in to Vue
 //! - Whether a string is a JavaScript keyword
 
+use crate::builtins::is_builtin_component;
 use vize_carton::is_native_tag;
 
 /// Check if a tag is a component or custom element.
 #[inline]
 pub fn is_component_tag(tag: &str) -> bool {
+    if is_builtin_component(tag) {
+        return false;
+    }
+
     tag.contains('-')
         || tag.chars().next().is_some_and(|c| c.is_ascii_uppercase())
         || !is_native_tag(tag)
@@ -94,6 +99,9 @@ mod tests {
         assert!(is_component_tag("MyComponent"));
         assert!(is_component_tag("my-component"));
         assert!(is_component_tag("basic"));
+        assert!(!is_component_tag("component"));
+        assert!(!is_component_tag("slot"));
+        assert!(!is_component_tag("transition-group"));
         assert!(!is_component_tag("div"));
         assert!(!is_component_tag("span"));
     }

--- a/crates/vize_croquis/src/analyzer/helpers/keywords.rs
+++ b/crates/vize_croquis/src/analyzer/helpers/keywords.rs
@@ -5,10 +5,14 @@
 //! - Whether a directive is built-in to Vue
 //! - Whether a string is a JavaScript keyword
 
-/// Check if a tag is a component (PascalCase or contains hyphen)
+use vize_carton::is_native_tag;
+
+/// Check if a tag is a component or custom element.
 #[inline]
 pub fn is_component_tag(tag: &str) -> bool {
-    tag.contains('-') || tag.chars().next().is_some_and(|c| c.is_ascii_uppercase())
+    tag.contains('-')
+        || tag.chars().next().is_some_and(|c| c.is_ascii_uppercase())
+        || !is_native_tag(tag)
 }
 
 /// Check if a directive is built-in
@@ -89,6 +93,7 @@ mod tests {
     fn test_is_component_tag() {
         assert!(is_component_tag("MyComponent"));
         assert!(is_component_tag("my-component"));
+        assert!(is_component_tag("basic"));
         assert!(!is_component_tag("div"));
         assert!(!is_component_tag("span"));
     }

--- a/crates/vize_croquis/src/analyzer/snapshots/vize_croquis__analyzer__tests__analyzer_script_bindings.snap
+++ b/crates/vize_croquis/src/analyzer/snapshots/vize_croquis__analyzer__tests__analyzer_script_bindings.snap
@@ -1276,6 +1276,7 @@ Croquis {
         content_end: 0,
     },
     used_components: {},
+    component_registrations: [],
     component_usages: [],
     used_directives: {},
     undefined_refs: [],

--- a/crates/vize_croquis/src/script_parser/mod.rs
+++ b/crates/vize_croquis/src/script_parser/mod.rs
@@ -22,7 +22,7 @@ use oxc_allocator::Allocator;
 use oxc_parser::Parser;
 use oxc_span::SourceType;
 
-use crate::analysis::{BindingMetadata, Croquis};
+use crate::analysis::{BindingMetadata, ComponentRegistration, Croquis};
 use crate::analysis::{ImportStatementInfo, InvalidExport, ReExportInfo, TypeExport};
 use crate::macros::MacroTracker;
 use crate::provide::ProvideInjectTracker;
@@ -105,6 +105,8 @@ pub struct ScriptParseResult {
     pub import_statements: Vec<ImportStatementInfo>,
     /// Re-export statement spans (`export { ... } from "..."`)
     pub re_exports: Vec<ReExportInfo>,
+    /// Components registered through Options API `components`.
+    pub component_registrations: Vec<ComponentRegistration>,
     /// Definition spans for bindings (name -> (start, end) offset in script)
     pub binding_spans: FxHashMap<CompactString, (u32, u32)>,
 }
@@ -126,6 +128,7 @@ impl ScriptParseResult {
         summary.setup_context = self.setup_context;
         summary.import_statements = self.import_statements;
         summary.re_exports = self.re_exports;
+        summary.component_registrations = self.component_registrations;
         summary.binding_spans = self.binding_spans;
     }
 
@@ -371,7 +374,7 @@ pub fn parse_script(source: &str) -> ScriptParseResult {
 
 #[cfg(test)]
 mod tests {
-    use super::parse_script_setup;
+    use super::{parse_script, parse_script_setup};
     use vize_carton::{append, cstr, CompactString};
 
     #[test]
@@ -447,6 +450,41 @@ mod tests {
         );
 
         insta::assert_debug_snapshot!(result);
+    }
+
+    #[test]
+    fn test_parse_options_api_component_registrations() {
+        let result = parse_script(
+            r#"
+            import Style from './style.vue'
+            import Basic from './basic.vue'
+            import { defineComponent } from 'vue'
+
+            export default defineComponent({
+                components: {
+                    FourStyle: Style,
+                    Basic,
+                    'string-name': Basic,
+                    Ignored: defineComponent({}),
+                },
+            })
+        "#,
+        );
+
+        let registrations: Vec<_> = result
+            .component_registrations
+            .iter()
+            .map(|registration| (registration.name.as_str(), registration.local_name.as_str()))
+            .collect();
+
+        assert_eq!(
+            registrations,
+            vec![
+                ("FourStyle", "Style"),
+                ("Basic", "Basic"),
+                ("string-name", "Basic")
+            ]
+        );
     }
 
     #[test]

--- a/crates/vize_croquis/src/script_parser/process/mod.rs
+++ b/crates/vize_croquis/src/script_parser/process/mod.rs
@@ -13,11 +13,15 @@
 mod bindings;
 mod macros;
 
-use oxc_ast::ast::{Declaration, Expression, Statement};
+use oxc_ast::ast::{
+    Argument, CallExpression, Declaration, ExportDefaultDeclarationKind, Expression,
+    ObjectExpression, ObjectPropertyKind, PropertyKey, Statement,
+};
 use oxc_span::GetSpan;
 
 use crate::analysis::{
-    ImportStatementInfo, InvalidExport, InvalidExportKind, ReExportInfo, TypeExport, TypeExportKind,
+    ComponentRegistration, ImportStatementInfo, InvalidExport, InvalidExportKind, ReExportInfo,
+    TypeExport, TypeExportKind,
 };
 use crate::scope::{BlockKind, BlockScopeData, ClosureScopeData, ExternalModuleScopeData};
 use crate::ScopeBinding;
@@ -222,6 +226,10 @@ pub fn process_statement(result: &mut ScriptParseResult, stmt: &Statement<'_>, s
         }
 
         Statement::ExportDefaultDeclaration(export) => {
+            if result.is_non_setup_script {
+                collect_options_api_component_registrations(result, &export.declaration);
+            }
+
             // Default exports are invalid in script setup
             result.invalid_exports.push(InvalidExport {
                 name: CompactString::new("default"),
@@ -272,6 +280,148 @@ pub fn process_statement(result: &mut ScriptParseResult, stmt: &Statement<'_>, s
         }
 
         _ => {}
+    }
+}
+
+fn collect_options_api_component_registrations(
+    result: &mut ScriptParseResult,
+    declaration: &ExportDefaultDeclarationKind<'_>,
+) {
+    let Some(options) = component_options_from_export(declaration) else {
+        return;
+    };
+
+    let Some(components) = option_object_property(options, "components") else {
+        return;
+    };
+
+    for property in &components.properties {
+        let ObjectPropertyKind::ObjectProperty(property) = property else {
+            continue;
+        };
+        if property.computed {
+            continue;
+        }
+
+        let Some(name) = property_key_name(&property.key) else {
+            continue;
+        };
+
+        let local_name = if property.shorthand {
+            name
+        } else {
+            let Expression::Identifier(identifier) = &property.value else {
+                continue;
+            };
+            identifier.name.as_str()
+        };
+
+        result.component_registrations.push(ComponentRegistration {
+            name: CompactString::new(name),
+            local_name: CompactString::new(local_name),
+        });
+    }
+}
+
+fn component_options_from_export<'a>(
+    declaration: &'a ExportDefaultDeclarationKind<'a>,
+) -> Option<&'a ObjectExpression<'a>> {
+    match declaration {
+        ExportDefaultDeclarationKind::ObjectExpression(object) => Some(object),
+        ExportDefaultDeclarationKind::CallExpression(call) => component_options_from_call(call),
+        ExportDefaultDeclarationKind::ParenthesizedExpression(parenthesized) => {
+            component_options_from_expression(&parenthesized.expression)
+        }
+        ExportDefaultDeclarationKind::TSAsExpression(ts_as) => {
+            component_options_from_expression(&ts_as.expression)
+        }
+        ExportDefaultDeclarationKind::TSSatisfiesExpression(ts_satisfies) => {
+            component_options_from_expression(&ts_satisfies.expression)
+        }
+        ExportDefaultDeclarationKind::TSNonNullExpression(ts_non_null) => {
+            component_options_from_expression(&ts_non_null.expression)
+        }
+        _ => None,
+    }
+}
+
+fn component_options_from_expression<'a>(
+    expression: &'a Expression<'a>,
+) -> Option<&'a ObjectExpression<'a>> {
+    match expression {
+        Expression::ObjectExpression(object) => Some(object),
+        Expression::CallExpression(call) => component_options_from_call(call),
+        Expression::ParenthesizedExpression(parenthesized) => {
+            component_options_from_expression(&parenthesized.expression)
+        }
+        Expression::TSAsExpression(ts_as) => component_options_from_expression(&ts_as.expression),
+        Expression::TSSatisfiesExpression(ts_satisfies) => {
+            component_options_from_expression(&ts_satisfies.expression)
+        }
+        Expression::TSNonNullExpression(ts_non_null) => {
+            component_options_from_expression(&ts_non_null.expression)
+        }
+        _ => None,
+    }
+}
+
+fn component_options_from_call<'a>(
+    call: &'a CallExpression<'a>,
+) -> Option<&'a ObjectExpression<'a>> {
+    let Expression::Identifier(callee) = &call.callee else {
+        return None;
+    };
+    if !matches!(callee.name.as_str(), "defineComponent" | "_defineComponent") {
+        return None;
+    }
+
+    let first_arg = call.arguments.first()?;
+    component_options_from_argument(first_arg)
+}
+
+fn component_options_from_argument<'a>(
+    argument: &'a Argument<'a>,
+) -> Option<&'a ObjectExpression<'a>> {
+    match argument {
+        Argument::ObjectExpression(object) => Some(object),
+        Argument::CallExpression(call) => component_options_from_call(call),
+        Argument::ParenthesizedExpression(parenthesized) => {
+            component_options_from_expression(&parenthesized.expression)
+        }
+        Argument::TSAsExpression(ts_as) => component_options_from_expression(&ts_as.expression),
+        Argument::TSSatisfiesExpression(ts_satisfies) => {
+            component_options_from_expression(&ts_satisfies.expression)
+        }
+        Argument::TSNonNullExpression(ts_non_null) => {
+            component_options_from_expression(&ts_non_null.expression)
+        }
+        _ => None,
+    }
+}
+
+fn option_object_property<'a>(
+    object: &'a ObjectExpression<'a>,
+    key_name: &str,
+) -> Option<&'a ObjectExpression<'a>> {
+    object.properties.iter().find_map(|property| {
+        let ObjectPropertyKind::ObjectProperty(property) = property else {
+            return None;
+        };
+        if property.computed || property_key_name(&property.key) != Some(key_name) {
+            return None;
+        }
+        match &property.value {
+            Expression::ObjectExpression(object) => Some(object.as_ref()),
+            _ => None,
+        }
+    })
+}
+
+fn property_key_name<'a>(key: &'a PropertyKey<'a>) -> Option<&'a str> {
+    match key {
+        PropertyKey::StaticIdentifier(identifier) => Some(identifier.name.as_str()),
+        PropertyKey::StringLiteral(string) => Some(string.value.as_str()),
+        _ => None,
     }
 }
 

--- a/crates/vize_croquis/src/script_parser/snapshots/vize_croquis__script_parser__tests__parse_imports.snap
+++ b/crates/vize_croquis/src/script_parser/snapshots/vize_croquis__script_parser__tests__parse_imports.snap
@@ -1296,6 +1296,7 @@ ScriptParseResult {
         },
     ],
     re_exports: [],
+    component_registrations: [],
     binding_spans: {
         "computed": (
             27,

--- a/crates/vize_croquis/src/script_parser/snapshots/vize_croquis__script_parser__tests__parse_reactivity.snap
+++ b/crates/vize_croquis/src/script_parser/snapshots/vize_croquis__script_parser__tests__parse_reactivity.snap
@@ -1284,6 +1284,7 @@ ScriptParseResult {
     is_non_setup_script: false,
     import_statements: [],
     re_exports: [],
+    component_registrations: [],
     binding_spans: {
         "doubled": (
             52,

--- a/crates/vize_patina/src/linter/engine.rs
+++ b/crates/vize_patina/src/linter/engine.rs
@@ -16,6 +16,7 @@ use super::config::{LintResult, Linter};
 
 const SEMANTIC_TEMPLATE_RULES: &[&str] = &[
     "vue/no-unused-vars",
+    "vue/no-unused-components",
     "vue/no-undefined-refs",
     "vue/no-mutating-props",
     "a11y/no-refer-to-non-existent-id",

--- a/crates/vize_patina/src/linter/tests/sfc.rs
+++ b/crates/vize_patina/src/linter/tests/sfc.rs
@@ -136,6 +136,58 @@ import MyButton from './MyButton.vue'
 }
 
 #[test]
+fn test_lint_sfc_no_unused_components_matches_options_api_component_alias() {
+    let linter = Linter::new().with_enabled_rules(Some(vec!["vue/no-unused-components".into()]));
+    let sfc = r#"<script lang="ts">
+import Style from './style.vue'
+import { defineComponent } from 'vue'
+
+export default defineComponent({
+  components: {
+    FourStyle: Style,
+  },
+})
+</script>
+
+<template>
+  <four-style />
+</template>
+"#;
+    let result = linter.lint_sfc(sfc, "test.vue");
+
+    assert!(
+        result.diagnostics.is_empty(),
+        "Options API component aliases should be matched by registered name: {:?}",
+        result.diagnostics
+    );
+}
+
+#[test]
+fn test_lint_sfc_no_unused_components_reports_unused_options_api_component_alias() {
+    let linter = Linter::new().with_enabled_rules(Some(vec!["vue/no-unused-components".into()]));
+    let sfc = r#"<script lang="ts">
+import Style from './style.vue'
+import { defineComponent } from 'vue'
+
+export default defineComponent({
+  components: {
+    FourStyle: Style,
+  },
+})
+</script>
+
+<template>
+  <div />
+</template>
+"#;
+    let result = linter.lint_sfc(sfc, "test.vue");
+
+    assert_eq!(result.warning_count, 1);
+    assert_eq!(result.diagnostics[0].rule_name, "vue/no-unused-components");
+    assert!(result.diagnostics[0].message.contains("Style"));
+}
+
+#[test]
 fn test_lint_sfc_offset_line_conversion() {
     let linter = Linter::new();
     let sfc = r#"<script setup lang="ts">

--- a/crates/vize_patina/src/linter/tests/sfc.rs
+++ b/crates/vize_patina/src/linter/tests/sfc.rs
@@ -77,6 +77,65 @@ defineProps<{ count: number }>()
 }
 
 #[test]
+fn test_lint_sfc_no_unused_components_reports_unused_vue_import() {
+    let linter = Linter::new().with_enabled_rules(Some(vec!["vue/no-unused-components".into()]));
+    let sfc = r#"<script setup>
+import MyButton from './MyButton.vue'
+</script>
+
+<template>
+  <div>Hello</div>
+</template>
+"#;
+    let result = linter.lint_sfc(sfc, "test.vue");
+
+    assert_eq!(result.warning_count, 1);
+    assert_eq!(result.diagnostics[0].rule_name, "vue/no-unused-components");
+    assert!(result.diagnostics[0].message.contains("MyButton"));
+}
+
+#[test]
+fn test_lint_sfc_no_unused_components_allows_local_pascal_case_constants() {
+    let linter = Linter::new().with_enabled_rules(Some(vec!["vue/no-unused-components".into()]));
+    let sfc = r#"<script setup lang="ts">
+const GapList = [4, 3, 2, 1]
+const gap = GapList[0]
+</script>
+
+<template>
+  <div :data-gap="gap" />
+</template>
+"#;
+    let result = linter.lint_sfc(sfc, "test.vue");
+
+    assert!(
+        result.diagnostics.is_empty(),
+        "local PascalCase constants are not component registrations: {:?}",
+        result.diagnostics
+    );
+}
+
+#[test]
+fn test_lint_sfc_no_unused_components_matches_kebab_case_vue_import() {
+    let linter = Linter::new().with_enabled_rules(Some(vec!["vue/no-unused-components".into()]));
+    let sfc = r#"<script setup>
+import MyButton from './MyButton.vue'
+</script>
+
+<template>
+  <my-button />
+</template>
+"#;
+    let result = linter.lint_sfc(sfc, "test.vue");
+
+    assert!(
+        result.diagnostics.is_empty(),
+        "kebab-case component usage should mark the import as used: {:?}",
+        result.diagnostics
+    );
+}
+
+#[test]
 fn test_lint_sfc_offset_line_conversion() {
     let linter = Linter::new();
     let sfc = r#"<script setup lang="ts">

--- a/crates/vize_patina/src/rules/vue/no_unused_components.rs
+++ b/crates/vize_patina/src/rules/vue/no_unused_components.rs
@@ -82,18 +82,17 @@ impl NoUnusedComponents {
         matches!(binding_type, BindingType::SetupConst)
     }
 
-    fn imported_component_names<'a>(analysis: &'a Croquis) -> Vec<&'a str> {
+    fn imported_component_names(analysis: &Croquis) -> Vec<&str> {
         let mut names: Vec<_> = analysis
             .scopes
             .iter()
-            .filter_map(|scope| match scope.data() {
-                ScopeData::ExternalModule(data)
-                    if !data.is_type_only
-                        && Self::is_component_import_source(data.source.as_str()) =>
-                {
-                    Some(scope)
-                }
-                _ => None,
+            .filter(|scope| {
+                matches!(
+                    scope.data(),
+                    ScopeData::ExternalModule(data)
+                        if !data.is_type_only
+                            && Self::is_component_import_source(data.source.as_str())
+                )
             })
             .flat_map(|scope| {
                 scope.bindings().filter_map(|(name, binding)| {

--- a/crates/vize_patina/src/rules/vue/no_unused_components.rs
+++ b/crates/vize_patina/src/rules/vue/no_unused_components.rs
@@ -109,6 +109,20 @@ impl NoUnusedComponents {
         names.dedup();
         names
     }
+
+    fn component_name_matches(used: &str, registered: &str) -> bool {
+        used == registered
+            || vize_croquis::naming::names_match(used, registered)
+            || to_pascal_case(used).as_str() == registered
+    }
+
+    fn matches_registered_alias(analysis: &Croquis, used: &str, local_name: &str) -> bool {
+        analysis
+            .component_registrations
+            .iter()
+            .filter(|registration| registration.local_name == local_name)
+            .any(|registration| Self::component_name_matches(used, registration.name.as_str()))
+    }
 }
 
 impl Rule for NoUnusedComponents {
@@ -138,11 +152,8 @@ impl Rule for NoUnusedComponents {
 
                     // Check if used in template (case-insensitive matching for kebab-case)
                     !analysis.used_components.iter().any(|used| {
-                        // Exact match
-                        used.as_str() == *name
-                            // kebab-case match (MyComponent -> my-component)
-                            || vize_croquis::naming::names_match(used.as_str(), name)
-                            || to_pascal_case(used.as_str()).as_str() == *name
+                        Self::component_name_matches(used.as_str(), name)
+                            || Self::matches_registered_alias(analysis, used.as_str(), name)
                     })
                 })
                 .map(|name| name.to_compact_string())

--- a/crates/vize_patina/src/rules/vue/no_unused_components.rs
+++ b/crates/vize_patina/src/rules/vue/no_unused_components.rs
@@ -33,7 +33,8 @@ use crate::diagnostic::Severity;
 use crate::rule::{Rule, RuleCategory, RuleMeta};
 use vize_carton::String;
 use vize_carton::ToCompactString;
-use vize_croquis::naming::is_pascal_case;
+use vize_croquis::naming::{is_pascal_case, to_pascal_case};
+use vize_croquis::{Croquis, ScopeData};
 use vize_relief::ast::RootNode;
 use vize_relief::BindingType;
 
@@ -70,12 +71,44 @@ impl NoUnusedComponents {
         false
     }
 
-    /// Check if a binding type indicates a component
-    fn is_component_binding(binding_type: &BindingType) -> bool {
-        matches!(
-            binding_type,
-            BindingType::SetupConst | BindingType::ExternalModule
-        )
+    /// Check if an import source should be treated as a Vue component module.
+    fn is_component_import_source(source: &str) -> bool {
+        let path = source.split(['?', '#']).next().unwrap_or(source);
+        path.ends_with(".vue")
+    }
+
+    /// Check if an imported binding type indicates a runtime component value.
+    fn is_component_binding(binding_type: BindingType) -> bool {
+        matches!(binding_type, BindingType::SetupConst)
+    }
+
+    fn imported_component_names<'a>(analysis: &'a Croquis) -> Vec<&'a str> {
+        let mut names: Vec<_> = analysis
+            .scopes
+            .iter()
+            .filter_map(|scope| match scope.data() {
+                ScopeData::ExternalModule(data)
+                    if !data.is_type_only
+                        && Self::is_component_import_source(data.source.as_str()) =>
+                {
+                    Some(scope)
+                }
+                _ => None,
+            })
+            .flat_map(|scope| {
+                scope.bindings().filter_map(|(name, binding)| {
+                    if Self::is_component_binding(binding.binding_type) && is_pascal_case(name) {
+                        Some(name)
+                    } else {
+                        None
+                    }
+                })
+            })
+            .collect();
+
+        names.sort_unstable();
+        names.dedup();
+        names
     }
 }
 
@@ -94,33 +127,26 @@ impl Rule for NoUnusedComponents {
         let unused_components: Vec<String> = {
             let analysis = ctx.analysis().unwrap();
 
-            // Collect registered components (PascalCase bindings that could be components)
-            let registered_components: Vec<_> = analysis
-                .bindings
-                .iter()
-                .filter(|(name, binding_type)| {
-                    // Must be a component-like binding type
-                    Self::is_component_binding(binding_type)
-                        // Must be PascalCase (component naming convention)
-                        && is_pascal_case(name)
-                        // Not ignored
-                        && !self.should_ignore(name)
-                })
-                .collect();
+            let registered_components = Self::imported_component_names(analysis);
 
             // Find unused components
             registered_components
                 .into_iter()
-                .filter(|(name, _)| {
+                .filter(|name| {
+                    if self.should_ignore(name) {
+                        return false;
+                    }
+
                     // Check if used in template (case-insensitive matching for kebab-case)
                     !analysis.used_components.iter().any(|used| {
                         // Exact match
                         used.as_str() == *name
                             // kebab-case match (MyComponent -> my-component)
                             || vize_croquis::naming::names_match(used.as_str(), name)
+                            || to_pascal_case(used.as_str()).as_str() == *name
                     })
                 })
-                .map(|(name, _)| name.to_compact_string())
+                .map(|name| name.to_compact_string())
                 .collect()
         };
 

--- a/npm/fresco-native/package.json
+++ b/npm/fresco-native/package.json
@@ -1,10 +1,6 @@
 {
   "name": "@vizejs/fresco-native",
-<<<<<<< HEAD
-  "version": "0.70.0",
-=======
   "version": "0.90.0",
->>>>>>> 4a1f8bd588428ec7a8e25028edfa1e75e255caab
   "description": "Vue TUI framework - Native bindings",
   "keywords": [
     "fresco",

--- a/npm/fresco/package.json
+++ b/npm/fresco/package.json
@@ -1,10 +1,6 @@
 {
   "name": "@vizejs/fresco",
-<<<<<<< HEAD
-  "version": "0.70.0",
-=======
   "version": "0.90.0",
->>>>>>> 4a1f8bd588428ec7a8e25028edfa1e75e255caab
   "description": "Vue TUI framework - Build terminal UIs with Vue.js",
   "keywords": [
     "cli",

--- a/npm/musea-mcp-server/package.json
+++ b/npm/musea-mcp-server/package.json
@@ -1,10 +1,6 @@
 {
   "name": "@vizejs/musea-mcp-server",
-<<<<<<< HEAD
-  "version": "0.70.0",
-=======
   "version": "0.90.0",
->>>>>>> 4a1f8bd588428ec7a8e25028edfa1e75e255caab
   "description": "MCP server for building Vue.js design systems - component analysis, documentation, variant generation, and design tokens",
   "keywords": [
     "ai",

--- a/npm/musea-nuxt/package.json
+++ b/npm/musea-nuxt/package.json
@@ -1,10 +1,6 @@
 {
   "name": "@vizejs/musea-nuxt",
-<<<<<<< HEAD
-  "version": "0.70.0",
-=======
   "version": "0.90.0",
->>>>>>> 4a1f8bd588428ec7a8e25028edfa1e75e255caab
   "description": "Nuxt mock layer for Musea - enables Nuxt component isolation in galleries",
   "keywords": [
     "component-gallery",

--- a/npm/nuxt/package.json
+++ b/npm/nuxt/package.json
@@ -1,10 +1,6 @@
 {
   "name": "@vizejs/nuxt",
-<<<<<<< HEAD
-  "version": "0.70.0",
-=======
   "version": "0.90.0",
->>>>>>> 4a1f8bd588428ec7a8e25028edfa1e75e255caab
   "description": "Nuxt module for Vize - compiler, musea gallery, linter, and type checker",
   "keywords": [
     "compiler",

--- a/npm/oxlint-plugin-vize/package.json
+++ b/npm/oxlint-plugin-vize/package.json
@@ -1,10 +1,6 @@
 {
   "name": "oxlint-plugin-vize",
-<<<<<<< HEAD
-  "version": "0.70.0",
-=======
   "version": "0.90.0",
->>>>>>> 4a1f8bd588428ec7a8e25028edfa1e75e255caab
   "description": "Oxlint JS plugin bridge for Vize Patina",
   "keywords": [
     "lint",

--- a/npm/rspack-vize-plugin/package.json
+++ b/npm/rspack-vize-plugin/package.json
@@ -1,10 +1,6 @@
 {
   "name": "@vizejs/rspack-plugin",
-<<<<<<< HEAD
-  "version": "0.70.0",
-=======
   "version": "0.90.0",
->>>>>>> 4a1f8bd588428ec7a8e25028edfa1e75e255caab
   "description": "High-performance Rspack plugin for Vue SFC compilation powered by Vize",
   "keywords": [
     "compiler",

--- a/npm/unplugin-vize/package.json
+++ b/npm/unplugin-vize/package.json
@@ -1,10 +1,6 @@
 {
   "name": "@vizejs/unplugin",
-<<<<<<< HEAD
-  "version": "0.70.0",
-=======
   "version": "0.90.0",
->>>>>>> 4a1f8bd588428ec7a8e25028edfa1e75e255caab
   "description": "Experimental unplugin-based Vue SFC integration for rollup, webpack, and esbuild powered by Vize",
   "keywords": [
     "compiler",

--- a/npm/vite-plugin-musea/package.json
+++ b/npm/vite-plugin-musea/package.json
@@ -1,10 +1,6 @@
 {
   "name": "@vizejs/vite-plugin-musea",
-<<<<<<< HEAD
-  "version": "0.70.0",
-=======
   "version": "0.90.0",
->>>>>>> 4a1f8bd588428ec7a8e25028edfa1e75e255caab
   "description": "Vite plugin for Musea - Component gallery for Vue components",
   "keywords": [
     "component-gallery",

--- a/npm/vite-plugin-vize/package.json
+++ b/npm/vite-plugin-vize/package.json
@@ -1,10 +1,6 @@
 {
   "name": "@vizejs/vite-plugin",
-<<<<<<< HEAD
-  "version": "0.70.0",
-=======
   "version": "0.90.0",
->>>>>>> 4a1f8bd588428ec7a8e25028edfa1e75e255caab
   "description": "High-performance native Vite plugin for Vue SFC compilation powered by Vize",
   "keywords": [
     "compiler",

--- a/npm/vize-native/package.json
+++ b/npm/vize-native/package.json
@@ -1,10 +1,6 @@
 {
   "name": "@vizejs/native",
-<<<<<<< HEAD
-  "version": "0.70.0",
-=======
   "version": "0.90.0",
->>>>>>> 4a1f8bd588428ec7a8e25028edfa1e75e255caab
   "description": "High-performance Vue.js compiler - Native bindings",
   "keywords": [
     "compiler",

--- a/npm/vize-wasm/package.json
+++ b/npm/vize-wasm/package.json
@@ -2,11 +2,7 @@
   "name": "@vizejs/wasm",
   "type": "module",
   "description": "Vize WASM bindings for browser environments",
-<<<<<<< HEAD
-  "version": "0.70.0",
-=======
   "version": "0.90.0",
->>>>>>> 4a1f8bd588428ec7a8e25028edfa1e75e255caab
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/npm/vize/package.json
+++ b/npm/vize/package.json
@@ -1,10 +1,6 @@
 {
   "name": "vize",
-<<<<<<< HEAD
-  "version": "0.70.0",
-=======
   "version": "0.90.0",
->>>>>>> 4a1f8bd588428ec7a8e25028edfa1e75e255caab
   "description": "Vize - High-performance Vue.js toolchain in Rust",
   "keywords": [
     "cli",

--- a/npm/vscode-art/package.json
+++ b/npm/vscode-art/package.json
@@ -1,11 +1,7 @@
 {
   "name": "vize-art",
   "displayName": "Vize Art",
-<<<<<<< HEAD
-  "version": "0.70.0",
-=======
   "version": "0.90.0",
->>>>>>> 4a1f8bd588428ec7a8e25028edfa1e75e255caab
   "description": "Syntax highlighting for Vize Art files (*.art.vue)",
   "categories": [
     "Programming Languages"

--- a/npm/vscode-vize/package.json
+++ b/npm/vscode-vize/package.json
@@ -1,11 +1,7 @@
 {
   "name": "vize",
   "displayName": "Vize",
-<<<<<<< HEAD
-  "version": "0.70.0",
-=======
   "version": "0.90.0",
->>>>>>> 4a1f8bd588428ec7a8e25028edfa1e75e255caab
   "description": "Vue Language Support powered by Vize - A high-performance language server for Vue SFC",
   "categories": [
     "Formatters",

--- a/npm/zed-vize/Cargo.lock
+++ b/npm/zed-vize/Cargo.lock
@@ -570,11 +570,7 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "vize-zed-extension"
-<<<<<<< HEAD
-version = "0.70.0"
-=======
 version = "0.90.0"
->>>>>>> 4a1f8bd588428ec7a8e25028edfa1e75e255caab
 dependencies = [
  "zed_extension_api",
 ]

--- a/npm/zed-vize/Cargo.toml
+++ b/npm/zed-vize/Cargo.toml
@@ -1,10 +1,6 @@
 [package]
 name = "vize-zed-extension"
-<<<<<<< HEAD
-version = "0.70.0"
-=======
 version = "0.90.0"
->>>>>>> 4a1f8bd588428ec7a8e25028edfa1e75e255caab
 edition = "2021"
 license = "MIT"
 publish = false

--- a/npm/zed-vize/extension.toml
+++ b/npm/zed-vize/extension.toml
@@ -1,10 +1,6 @@
 id = "vize"
 name = "Vize"
-<<<<<<< HEAD
-version = "0.70.0"
-=======
 version = "0.90.0"
->>>>>>> 4a1f8bd588428ec7a8e25028edfa1e75e255caab
 schema_version = 1
 authors = ["Vize contributors"]
 description = "Opt-in Vue diagnostics and language support powered by Vize"


### PR DESCRIPTION
## Summary

- record Options API `components` registrations in semantic analysis
- treat registered alias names as usages for `vue/no-unused-components`
- cover used and unused alias cases plus parser-level registration extraction

## Real-world check

- ant-design-vue default lint: `vue/no-unused-components` `14 -> 6`, warnings `1502 -> 1494`

## Validation

- `cargo fmt --all -- --check`
- `cargo +1.93.0 test -p vize_croquis script_parser --lib`
- `cargo +1.93.0 test -p vize_croquis analyzer --lib`
- `cargo +1.93.0 test -p vize_patina no_unused_components --lib`
- `cargo +1.93.0 test -p vize_patina linter --lib`
- `cargo +1.93.0 clippy -p vize_croquis -p vize_patina -- -D warnings`
- `git diff --check`
