### PR TITLE
fix(typecheck): report broken sfc parse errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3533,6 +3533,7 @@ dependencies = [
  "oxc_allocator",
  "oxc_ast",
  "oxc_ast_visit",
+ "oxc_diagnostics",
  "oxc_parser",
  "oxc_span",
  "serde",

--- a/crates/vize/tests/check_cli.rs
+++ b/crates/vize/tests/check_cli.rs
@@ -116,6 +116,52 @@ void props
 }
 
 #[test]
+fn check_json_reports_broken_sfc_parse_errors_without_secondary_noise() {
+    let Some(corsa_path) = resolve_test_corsa_path() else {
+        return;
+    };
+    let project_root = create_cli_project(
+        "json-broken-sfc",
+        &[(
+            "src/App.vue",
+            r#"<script setup lang="ts">
+const count =
+</script>
+
+<template>
+  <div>{{ count }}</div>
+</template>
+"#,
+        )],
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(&project_root)
+        .env("CORSA_PATH", corsa_path)
+        .args(["check", ".", "--format", "json"])
+        .output()
+        .unwrap();
+
+    let stdout = std::string::String::from_utf8(output.stdout).unwrap();
+    let json: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    let diagnostics = json["files"][0]["diagnostics"].as_array().unwrap();
+
+    assert_eq!(output.status.code(), Some(1));
+    assert_eq!(json["errorCount"], 1);
+    assert_eq!(diagnostics.len(), 1);
+    assert!(diagnostics[0]
+        .as_str()
+        .unwrap()
+        .contains("Script parse error"));
+    assert!(!diagnostics[0]
+        .as_str()
+        .unwrap()
+        .contains("Cannot find name"));
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}
+
+#[test]
 fn check_can_emit_declarations() {
     let Some(corsa_path) = resolve_test_corsa_path() else {
         return;

--- a/crates/vize_canon/Cargo.toml
+++ b/crates/vize_canon/Cargo.toml
@@ -24,6 +24,7 @@ oxc_ast.workspace = true
 oxc_ast_visit.workspace = true
 oxc_span.workspace = true
 oxc_allocator.workspace = true
+oxc_diagnostics.workspace = true
 
 # File system walking (for batch type checking)
 walkdir = { workspace = true, optional = true }

--- a/crates/vize_canon/src/batch/type_checker.rs
+++ b/crates/vize_canon/src/batch/type_checker.rs
@@ -208,7 +208,15 @@ impl TypeChecker for BatchTypeChecker {
             return Err(CorsaError::NotInitialized);
         }
 
-        self.executor.check(&self.project)
+        let mut result = self.executor.check(&self.project)?;
+        result
+            .diagnostics
+            .extend(self.project.diagnostics().iter().cloned());
+        if result.has_errors() {
+            result.success = false;
+            result.exit_code = result.exit_code.max(1);
+        }
+        Ok(result)
     }
 
     fn check_file(&self, path: &Path, content: &str) -> CorsaResult<Vec<Diagnostic>> {
@@ -217,7 +225,10 @@ impl TypeChecker for BatchTypeChecker {
         let mut temp_project = VirtualProject::new(project_root)?;
         temp_project.register_path_with_content(path, content)?;
 
-        let result = self.executor.check(&temp_project)?;
+        let mut result = self.executor.check(&temp_project)?;
+        result
+            .diagnostics
+            .extend(temp_project.diagnostics().iter().cloned());
         Ok(result.diagnostics)
     }
 

--- a/crates/vize_canon/src/batch/virtual_project.rs
+++ b/crates/vize_canon/src/batch/virtual_project.rs
@@ -10,7 +10,8 @@ use super::error::{CorsaError, CorsaResult};
 use super::import_rewriter::ImportRewriter;
 use super::runtime_deps::materialize_runtime_dependencies;
 use super::source_map::{CompositeSourceMap, SfcBlockRange, SfcSourceMap};
-use super::SfcBlockType;
+use super::{Diagnostic, SfcBlockType};
+use crate::script_parse::collect_script_parse_diagnostics;
 use crate::virtual_ts::{generate_virtual_ts_with_offsets, VirtualTsOptions};
 use oxc_span::SourceType;
 use serde_json::{Map, Value};
@@ -76,6 +77,9 @@ pub struct VirtualProject {
     /// Virtual files keyed by materialized path.
     virtual_files: FxHashMap<PathBuf, VirtualFile>,
 
+    /// Parser diagnostics collected before Corsa runs.
+    diagnostics: Vec<Diagnostic>,
+
     /// Import rewriter for `.vue` specifiers inside TypeScript sources.
     rewriter: ImportRewriter,
 }
@@ -97,6 +101,7 @@ impl VirtualProject {
             tsconfig_path: None,
             virtual_ts_options: VirtualTsOptions::default(),
             virtual_files: FxHashMap::default(),
+            diagnostics: Vec::new(),
             rewriter: ImportRewriter::new(),
         })
     }
@@ -168,12 +173,18 @@ impl VirtualProject {
             "canon.vue.virtual_ts",
             generate_vue_virtual_ts(path, content, &descriptor, &effective_options)
         )?;
+        let GeneratedVueFile {
+            code,
+            mappings,
+            diagnostics,
+        } = generated;
+        self.diagnostics.extend(diagnostics);
         let rewritten = profile!(
             "canon.import.rewrite.vue",
-            self.rewriter.rewrite(&generated.code, SourceType::ts())
+            self.rewriter.rewrite(&code, SourceType::ts())
         );
         let source_map = CompositeSourceMap::new_vue(
-            SfcSourceMap::new(generated.mappings, collect_sfc_block_ranges(&descriptor)),
+            SfcSourceMap::new(mappings, collect_sfc_block_ranges(&descriptor)),
             rewritten.source_map,
         );
         let virtual_path = virtual_vue_path(&self.project_root, &self.virtual_root, path)?;
@@ -308,6 +319,11 @@ impl VirtualProject {
         let mut files: Vec<_> = self.virtual_files.values().collect();
         files.sort_by(|left, right| left.original_path.cmp(&right.original_path));
         files
+    }
+
+    /// Parser diagnostics collected while registering source files.
+    pub fn diagnostics(&self) -> &[Diagnostic] {
+        &self.diagnostics
     }
 
     /// Map a virtual position to the original position.
@@ -549,6 +565,7 @@ impl VirtualProject {
 struct GeneratedVueFile {
     code: CompactString,
     mappings: Vec<crate::virtual_ts::VizeMapping>,
+    diagnostics: Vec<Diagnostic>,
 }
 
 fn generate_vue_virtual_ts(
@@ -562,12 +579,27 @@ fn generate_vue_virtual_ts(
 
     let allocator = Bump::new();
     let mut analyzer = Analyzer::with_options(AnalyzerOptions::full());
+    let mut diagnostics = Vec::new();
     let has_both_scripts = descriptor.script.is_some() && descriptor.script_setup.is_some();
 
     if let Some(ref script) = descriptor.script {
-        profile!("canon.croquis.analyze_script", {
-            analyzer.analyze_script_plain(&script.content);
-        });
+        let script_diagnostics =
+            collect_script_parse_diagnostics(&script.content, script.loc.start as u32);
+        if script_diagnostics.is_empty() {
+            profile!("canon.croquis.analyze_script", {
+                analyzer.analyze_script_plain(&script.content);
+            });
+        } else {
+            diagnostics.extend(script_diagnostics.into_iter().map(|diagnostic| {
+                diagnostic_for_offset(
+                    path,
+                    source,
+                    diagnostic.start,
+                    cstr!("Script parse error: {}", diagnostic.message),
+                    SfcBlockType::Script,
+                )
+            }));
+        }
     }
 
     let plain_spans: Option<(Vec<ImportStatementInfo>, Vec<ReExportInfo>, Vec<TypeExport>)> =
@@ -586,9 +618,23 @@ fn generate_vue_virtual_ts(
             .attrs
             .get("generic")
             .map(|value| value.as_ref());
-        profile!("canon.croquis.analyze_script_setup", {
-            analyzer.analyze_script_setup_with_generic(&script_setup.content, generic);
-        });
+        let script_diagnostics =
+            collect_script_parse_diagnostics(&script_setup.content, script_setup.loc.start as u32);
+        if script_diagnostics.is_empty() {
+            profile!("canon.croquis.analyze_script_setup", {
+                analyzer.analyze_script_setup_with_generic(&script_setup.content, generic);
+            });
+        } else {
+            diagnostics.extend(script_diagnostics.into_iter().map(|diagnostic| {
+                diagnostic_for_offset(
+                    path,
+                    source,
+                    diagnostic.start,
+                    cstr!("Script parse error: {}", diagnostic.message),
+                    SfcBlockType::ScriptSetup,
+                )
+            }));
+        }
     }
 
     let template_offset = descriptor
@@ -596,13 +642,39 @@ fn generate_vue_virtual_ts(
         .as_ref()
         .map(|template| template.loc.start as u32)
         .unwrap_or(0);
-    let template_ast = descriptor.template.as_ref().map(|template| {
+    let template_ast = descriptor.template.as_ref().and_then(|template| {
         profile!("canon.template.parse_and_analyze", {
-            let (root, _) = parse(&allocator, &template.content);
-            analyzer.analyze_template(&root);
-            root
+            let (root, errors) = parse(&allocator, &template.content);
+            if errors.is_empty() {
+                analyzer.analyze_template(&root);
+                Some(root)
+            } else {
+                diagnostics.extend(errors.into_iter().map(|error| {
+                    let start = error
+                        .loc
+                        .as_ref()
+                        .map(|loc| template_offset + loc.start.offset)
+                        .unwrap_or(template_offset);
+                    diagnostic_for_offset(
+                        path,
+                        source,
+                        start,
+                        cstr!("Template parse error: {}", error.message),
+                        SfcBlockType::Template,
+                    )
+                }));
+                None
+            }
         })
     });
+
+    if !diagnostics.is_empty() {
+        return Ok(GeneratedVueFile {
+            code: invalid_sfc_fallback_virtual_ts(),
+            mappings: Vec::new(),
+            diagnostics,
+        });
+    }
 
     let mut summary = profile!("canon.croquis.finish", analyzer.finish());
 
@@ -636,7 +708,49 @@ fn generate_vue_virtual_ts(
     Ok(GeneratedVueFile {
         code: output.code,
         mappings: output.mappings,
+        diagnostics,
     })
+}
+
+fn invalid_sfc_fallback_virtual_ts() -> CompactString {
+    "declare const __vize_component: any;\nexport default __vize_component;\n".into()
+}
+
+fn diagnostic_for_offset(
+    path: &Path,
+    source: &str,
+    start: u32,
+    message: CompactString,
+    block_type: SfcBlockType,
+) -> Diagnostic {
+    let (line, column) = line_column_for_offset(source, start);
+    Diagnostic {
+        file: path.to_path_buf(),
+        line,
+        column,
+        message,
+        code: None,
+        severity: 1,
+        block_type: Some(block_type),
+    }
+}
+
+fn line_column_for_offset(source: &str, offset: u32) -> (u32, u32) {
+    let target = (offset as usize).min(source.len());
+    let mut line = 0;
+    let mut line_start = 0;
+
+    for (index, character) in source.char_indices() {
+        if index >= target {
+            break;
+        }
+        if character == '\n' {
+            line += 1;
+            line_start = index + 1;
+        }
+    }
+
+    (line, target.saturating_sub(line_start) as u32)
 }
 
 fn shift_module_spans<T>(items: &mut [T], delta: u32)
@@ -915,6 +1029,7 @@ fn strip_trailing_commas(content: &str) -> CompactString {
 #[cfg(test)]
 mod tests {
     use super::{parse_jsonc_value, source_type_for_path, strip_json_comments, VirtualProject};
+    use crate::batch::SfcBlockType;
     use crate::virtual_ts::VirtualTsOptions;
     use std::fs;
     use std::path::{Path, PathBuf};
@@ -967,6 +1082,70 @@ const count = 1
 
         let virtual_file = project.find_by_original(&vue_path).unwrap();
         insta::assert_snapshot!(virtual_file.content.as_str());
+
+        let _ = fs::remove_dir_all(&case_dir);
+    }
+
+    #[test]
+    fn test_register_vue_file_reports_script_parse_error_with_fallback() {
+        let case_dir = unique_case_dir("script-parse-error");
+        let _ = fs::remove_dir_all(&case_dir);
+        let src_dir = case_dir.join("src");
+        fs::create_dir_all(&src_dir).unwrap();
+        let vue_path = src_dir.join("Broken.vue");
+        let vue_content = r#"<script setup lang="ts">
+const count =
+</script>
+
+<template>
+  <div>{{ count }}</div>
+</template>
+"#;
+
+        let mut project = VirtualProject::new(&case_dir).unwrap();
+        project.register_vue_file(&vue_path, vue_content).unwrap();
+
+        let diagnostics = project.diagnostics();
+        assert_eq!(diagnostics.len(), 1);
+        assert!(diagnostics[0].message.contains("Script parse error"));
+        assert_eq!(diagnostics[0].block_type, Some(SfcBlockType::ScriptSetup));
+
+        let virtual_file = project.find_by_original(&vue_path).unwrap();
+        assert!(virtual_file
+            .content
+            .contains("export default __vize_component"));
+        assert!(!virtual_file.content.contains("const count ="));
+
+        let _ = fs::remove_dir_all(&case_dir);
+    }
+
+    #[test]
+    fn test_register_vue_file_reports_template_parse_error_with_fallback() {
+        let case_dir = unique_case_dir("template-parse-error");
+        let _ = fs::remove_dir_all(&case_dir);
+        let src_dir = case_dir.join("src");
+        fs::create_dir_all(&src_dir).unwrap();
+        let vue_path = src_dir.join("BrokenTemplate.vue");
+        let vue_content = r#"<script setup lang="ts">
+const count = 1
+</script>
+
+<template><div>{{ count }}</template>
+"#;
+
+        let mut project = VirtualProject::new(&case_dir).unwrap();
+        project.register_vue_file(&vue_path, vue_content).unwrap();
+
+        let diagnostics = project.diagnostics();
+        assert_eq!(diagnostics.len(), 1);
+        assert!(diagnostics[0].message.contains("Template parse error"));
+        assert_eq!(diagnostics[0].block_type, Some(SfcBlockType::Template));
+
+        let virtual_file = project.find_by_original(&vue_path).unwrap();
+        assert!(virtual_file
+            .content
+            .contains("export default __vize_component"));
+        assert!(!virtual_file.content.contains("__vize_check_template"));
 
         let _ = fs::remove_dir_all(&case_dir);
     }

--- a/crates/vize_canon/src/lib.rs
+++ b/crates/vize_canon/src/lib.rs
@@ -48,6 +48,7 @@ mod diagnostic;
 #[cfg(feature = "native")]
 mod file_uri;
 pub mod intelligence;
+mod script_parse;
 pub mod sfc_typecheck;
 pub mod source_map;
 mod types;

--- a/crates/vize_canon/src/script_parse.rs
+++ b/crates/vize_canon/src/script_parse.rs
@@ -1,0 +1,63 @@
+use oxc_allocator::Allocator as OxcAllocator;
+use oxc_parser::Parser as OxcParser;
+use oxc_span::SourceType;
+use vize_carton::{profile, String, ToCompactString};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ScriptParseDiagnostic {
+    pub message: String,
+    pub start: u32,
+    pub end: u32,
+}
+
+pub(crate) fn collect_script_parse_diagnostics(
+    source: &str,
+    source_offset: u32,
+) -> Vec<ScriptParseDiagnostic> {
+    let allocator = OxcAllocator::default();
+    let source_type = SourceType::from_path("script.ts").unwrap_or_default();
+    let parsed = profile!(
+        "canon.script.parse_errors",
+        OxcParser::new(&allocator, source, source_type).parse()
+    );
+
+    let mut diagnostics: Vec<ScriptParseDiagnostic> = parsed
+        .errors
+        .iter()
+        .map(|error| {
+            let (local_start, local_end) = diagnostic_span(error, source.len());
+            ScriptParseDiagnostic {
+                message: error.to_compact_string(),
+                start: source_offset + local_start,
+                end: source_offset + local_end,
+            }
+        })
+        .collect();
+
+    if parsed.panicked && diagnostics.is_empty() {
+        let fallback_end = source_offset + (source.len() as u32).max(1);
+        diagnostics.push(ScriptParseDiagnostic {
+            message: "Parser panicked while parsing script".into(),
+            start: source_offset,
+            end: fallback_end,
+        });
+    }
+
+    diagnostics
+}
+
+fn diagnostic_span(error: &oxc_diagnostics::OxcDiagnostic, source_len: usize) -> (u32, u32) {
+    let fallback_end = source_len.max(1);
+    let Some(label) = error.labels.as_ref().and_then(|labels| {
+        labels
+            .iter()
+            .find(|label| label.primary())
+            .or_else(|| labels.first())
+    }) else {
+        return (0, fallback_end as u32);
+    };
+
+    let start = label.offset().min(source_len);
+    let end = start.saturating_add(label.len().max(1)).min(fallback_end);
+    (start as u32, end.max(start + 1) as u32)
+}

--- a/crates/vize_canon/src/sfc_typecheck/mod.rs
+++ b/crates/vize_canon/src/sfc_typecheck/mod.rs
@@ -506,6 +506,74 @@ const count = 1
     }
 
     #[test]
+    fn test_type_check_malformed_script_setup_reports_parse_error_without_noise() {
+        let source = r#"<script setup lang="ts">
+const count =
+</script>
+<template><div>{{ count }}</div></template>"#;
+        let options = SfcTypeCheckOptions::new("test.vue").with_virtual_ts();
+        let result = type_check_sfc(source, &options);
+
+        assert!(result
+            .diagnostics
+            .iter()
+            .any(|d| d.code.as_deref() == Some("script-parse-error")));
+        assert!(result.has_errors());
+        assert!(result.virtual_ts.is_none());
+        assert!(!result
+            .diagnostics
+            .iter()
+            .any(|d| d.code.as_deref() == Some("undefined-binding")));
+    }
+
+    #[test]
+    fn test_type_check_malformed_plain_script_reports_parse_error_without_virtual_ts() {
+        let source = r#"<script lang="ts">
+export default {
+  setup() {
+    const count =
+  }
+}
+</script>
+<template><div>Hello</div></template>"#;
+        let options = SfcTypeCheckOptions::new("test.vue").with_virtual_ts();
+        let result = type_check_sfc(source, &options);
+
+        assert_eq!(
+            result
+                .diagnostics
+                .iter()
+                .filter(|d| d.code.as_deref() == Some("script-parse-error"))
+                .count(),
+            1
+        );
+        assert!(result.virtual_ts.is_none());
+    }
+
+    #[test]
+    fn test_type_check_malformed_plain_script_with_setup_reports_parse_error() {
+        let source = r#"<script lang="ts">
+export default {
+  setup() {
+    const broken =
+  }
+}
+</script>
+<script setup lang="ts">
+const count = 1
+</script>
+<template><div>{{ count }}</div></template>"#;
+        let options = SfcTypeCheckOptions::new("test.vue").with_virtual_ts();
+        let result = type_check_sfc(source, &options);
+
+        assert!(result
+            .diagnostics
+            .iter()
+            .any(|d| d.code.as_deref() == Some("script-parse-error")));
+        assert!(result.virtual_ts.is_none());
+    }
+
+    #[test]
     fn test_type_check_malformed_template_keeps_script_diagnostics() {
         let source = r#"<script setup>
 const props = defineProps(['count'])

--- a/crates/vize_canon/src/sfc_typecheck/runner.rs
+++ b/crates/vize_canon/src/sfc_typecheck/runner.rs
@@ -6,6 +6,8 @@
 use vize_carton::cstr;
 use vize_carton::Bump;
 
+use crate::script_parse::collect_script_parse_diagnostics;
+
 use super::{
     analysis::{SfcTypeCheckOptions, SfcTypeCheckResult, SfcTypeDiagnostic, SfcTypeSeverity},
     checks::{
@@ -71,15 +73,34 @@ pub fn type_check_sfc(source: &str, options: &SfcTypeCheckOptions) -> SfcTypeChe
     let mut analyzer = Analyzer::with_options(AnalyzerOptions::full());
 
     // Analyze script and get offset
-    let script_offset: u32 = if let Some(ref script_setup) = descriptor.script_setup {
-        analyzer.analyze_script_setup(&script_setup.content);
-        script_setup.loc.start as u32
-    } else if let Some(ref script) = descriptor.script {
-        analyzer.analyze_script_plain(&script.content);
-        script.loc.start as u32
-    } else {
-        0
-    };
+    let mut has_script_parse_errors = false;
+    let mut script_offset: u32 = 0;
+    if let Some(ref script) = descriptor.script {
+        if descriptor.script_setup.is_none() {
+            script_offset = script.loc.start as u32;
+        }
+        let script_diagnostics =
+            collect_script_parse_diagnostics(&script.content, script.loc.start as u32);
+        if script_diagnostics.is_empty() {
+            if descriptor.script_setup.is_none() {
+                analyzer.analyze_script_plain(&script.content);
+            }
+        } else {
+            has_script_parse_errors = true;
+            add_script_parse_diagnostics(script_diagnostics, &mut result);
+        }
+    }
+    if let Some(ref script_setup) = descriptor.script_setup {
+        script_offset = script_setup.loc.start as u32;
+        let script_diagnostics =
+            collect_script_parse_diagnostics(&script_setup.content, script_setup.loc.start as u32);
+        if script_diagnostics.is_empty() {
+            analyzer.analyze_script_setup(&script_setup.content);
+        } else {
+            has_script_parse_errors = true;
+            add_script_parse_diagnostics(script_diagnostics, &mut result);
+        }
+    }
 
     // Analyze template and get AST
     let mut has_template_parse_errors = false;
@@ -122,32 +143,32 @@ pub fn type_check_sfc(source: &str, options: &SfcTypeCheckOptions) -> SfcTypeChe
     let summary = analyzer.finish();
 
     // Check props typing
-    if options.check_props {
+    if options.check_props && !has_script_parse_errors {
         check_props_typing(&summary, script_offset, &mut result, options.strict);
     }
 
     // Check emits typing
-    if options.check_emits {
+    if options.check_emits && !has_script_parse_errors {
         check_emits_typing(&summary, script_offset, &mut result, options.strict);
     }
 
     // Check template bindings
-    if options.check_template_bindings && !has_template_parse_errors {
+    if options.check_template_bindings && !has_template_parse_errors && !has_script_parse_errors {
         check_template_bindings(&summary, template_offset, &mut result, options.strict);
     }
 
     // Check reactivity loss
-    if options.check_reactivity {
+    if options.check_reactivity && !has_script_parse_errors {
         check_reactivity(&summary, script_offset, &mut result, options.strict);
     }
 
     // Check setup context violations
-    if options.check_setup_context {
+    if options.check_setup_context && !has_script_parse_errors {
         check_setup_context(&summary, script_offset, &mut result);
     }
 
     // Check invalid exports in <script setup>
-    if options.check_invalid_exports {
+    if options.check_invalid_exports && !has_script_parse_errors {
         check_invalid_exports(&summary, script_offset, &mut result);
     }
 
@@ -157,7 +178,7 @@ pub fn type_check_sfc(source: &str, options: &SfcTypeCheckOptions) -> SfcTypeChe
     }
 
     // Generate virtual TypeScript with scope information if requested
-    if options.include_virtual_ts && !has_template_parse_errors {
+    if options.include_virtual_ts && !has_template_parse_errors && !has_script_parse_errors {
         result.virtual_ts = Some(generate_virtual_ts_with_scopes(
             &summary,
             script_content,
@@ -174,4 +195,21 @@ pub fn type_check_sfc(source: &str, options: &SfcTypeCheckOptions) -> SfcTypeChe
     }
 
     result
+}
+
+fn add_script_parse_diagnostics(
+    diagnostics: Vec<crate::script_parse::ScriptParseDiagnostic>,
+    result: &mut SfcTypeCheckResult,
+) {
+    for diagnostic in diagnostics {
+        result.add_diagnostic(SfcTypeDiagnostic {
+            severity: SfcTypeSeverity::Error,
+            message: cstr!("Script parse error: {}", diagnostic.message),
+            start: diagnostic.start,
+            end: diagnostic.end,
+            code: Some("script-parse-error".into()),
+            help: None,
+            related: Vec::new(),
+        });
+    }
 }

--- a/crates/vize_canon/src/typecheck_service.rs
+++ b/crates/vize_canon/src/typecheck_service.rs
@@ -4,6 +4,7 @@
 //! using Corsa as the TypeScript type checker backend.
 
 use crate::corsa_bridge::{CorsaBridge, CorsaBridgeError};
+use crate::script_parse::{collect_script_parse_diagnostics, ScriptParseDiagnostic};
 use crate::virtual_ts::{generate_virtual_ts_with_offsets, VirtualTsOptions, VirtualTsOutput};
 #[allow(clippy::disallowed_types)]
 use std::sync::Arc;
@@ -151,15 +152,36 @@ impl TypeCheckService {
         let mut analyzer = Analyzer::with_options(AnalyzerOptions::full());
 
         // Analyze script
-        let script_offset: u32 = if let Some(ref script_setup) = descriptor.script_setup {
-            analyzer.analyze_script_setup(&script_setup.content);
-            script_setup.loc.start as u32
-        } else if let Some(ref script) = descriptor.script {
-            analyzer.analyze_script_plain(&script.content);
-            script.loc.start as u32
-        } else {
-            0
-        };
+        let mut has_script_parse_errors = false;
+        let mut script_offset: u32 = 0;
+        if let Some(ref script) = descriptor.script {
+            if descriptor.script_setup.is_none() {
+                script_offset = script.loc.start as u32;
+            }
+            let script_diagnostics =
+                collect_script_parse_diagnostics(&script.content, script.loc.start as u32);
+            if script_diagnostics.is_empty() {
+                if descriptor.script_setup.is_none() {
+                    analyzer.analyze_script_plain(&script.content);
+                }
+            } else {
+                has_script_parse_errors = true;
+                add_script_parse_diagnostics(script_diagnostics, &mut result);
+            }
+        }
+        if let Some(ref script_setup) = descriptor.script_setup {
+            script_offset = script_setup.loc.start as u32;
+            let script_diagnostics = collect_script_parse_diagnostics(
+                &script_setup.content,
+                script_setup.loc.start as u32,
+            );
+            if script_diagnostics.is_empty() {
+                analyzer.analyze_script_setup(&script_setup.content);
+            } else {
+                has_script_parse_errors = true;
+                add_script_parse_diagnostics(script_diagnostics, &mut result);
+            }
+        }
 
         // Analyze template
         let mut has_template_parse_errors = false;
@@ -201,7 +223,7 @@ impl TypeCheckService {
 
         let summary = analyzer.finish();
 
-        if has_template_parse_errors {
+        if has_template_parse_errors || has_script_parse_errors {
             result.analysis_time_ms = Some(start_time.elapsed().as_secs_f64() * 1000.0);
             return Ok(result);
         }
@@ -318,6 +340,23 @@ fn line_col_to_offset(content: &str, line: u32, col: u32) -> u32 {
     }
 
     offset + col
+}
+
+fn add_script_parse_diagnostics(
+    diagnostics: Vec<ScriptParseDiagnostic>,
+    result: &mut SfcTypeCheckResult,
+) {
+    for diagnostic in diagnostics {
+        result.diagnostics.push(SfcDiagnostic {
+            message: cstr!("Script parse error: {}", diagnostic.message),
+            severity: SfcDiagnosticSeverity::Error,
+            start: diagnostic.start,
+            end: diagnostic.end,
+            code: Some("script-parse-error".into()),
+            related: Vec::new(),
+        });
+        result.error_count += 1;
+    }
 }
 
 /// Map position from virtual TypeScript to original SFC.


### PR DESCRIPTION
## Summary
- report script parser failures as first-class typecheck diagnostics
- stop virtual TS generation for broken script/template blocks and use a neutral fallback in batch mode
- add AST, batch, and CLI coverage for broken SFCs without secondary noise

## Checks
- cargo fmt --check
- cargo clippy --workspace -- -D warnings
- cargo test -p vize_canon
- cargo test -p vize --test check_cli