### PR TITLE
fix(maestro): surface script parse diagnostics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3646,6 +3646,7 @@ dependencies = [
  "oxc_allocator",
  "oxc_ast",
  "oxc_ast_visit",
+ "oxc_diagnostics",
  "oxc_parser",
  "oxc_span",
  "parking_lot",

--- a/crates/vize_maestro/Cargo.toml
+++ b/crates/vize_maestro/Cargo.toml
@@ -41,6 +41,7 @@ oxc_ast.workspace = true
 oxc_ast_visit.workspace = true
 oxc_parser.workspace = true
 oxc_span.workspace = true
+oxc_diagnostics.workspace = true
 
 # Internal crates
 vize_carton.workspace = true

--- a/crates/vize_maestro/src/ide/diagnostics/collectors.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/collectors.rs
@@ -9,6 +9,9 @@ use tower_lsp::lsp_types::{
     CodeDescription, Diagnostic, DiagnosticSeverity, NumberOrString, Position, Range, Url,
 };
 
+use oxc_allocator::Allocator as OxcAllocator;
+use oxc_parser::Parser as OxcParser;
+use oxc_span::SourceType;
 use vize_patina::{render_help, HelpRenderTarget};
 
 use super::{offset_to_line_col, sources, DiagnosticService};
@@ -294,6 +297,40 @@ impl DiagnosticService {
             .collect()
     }
 
+    /// Collect script parser diagnostics.
+    pub(super) fn collect_script_diagnostics(uri: &Url, content: &str) -> Vec<Diagnostic> {
+        let options = vize_atelier_sfc::SfcParseOptions {
+            filename: uri.path().to_string().into(),
+            ..Default::default()
+        };
+
+        let Ok(descriptor) = vize_atelier_sfc::parse_sfc(content, options) else {
+            return vec![];
+        };
+
+        let mut diagnostics = Vec::new();
+
+        if let Some(ref script) = descriptor.script {
+            diagnostics.extend(collect_script_block_diagnostics(
+                content,
+                &script.content,
+                script.loc.start,
+                script.lang.as_deref(),
+            ));
+        }
+
+        if let Some(ref script_setup) = descriptor.script_setup {
+            diagnostics.extend(collect_script_block_diagnostics(
+                content,
+                &script_setup.content,
+                script_setup.loc.start,
+                script_setup.lang.as_deref(),
+            ));
+        }
+
+        diagnostics
+    }
+
     /// Collect linter diagnostics from vize_patina.
     pub(super) fn collect_lint_diagnostics(uri: &Url, content: &str) -> Vec<Diagnostic> {
         let options = vize_atelier_sfc::SfcParseOptions {
@@ -374,4 +411,78 @@ impl DiagnosticService {
             })
             .collect()
     }
+}
+
+fn collect_script_block_diagnostics(
+    sfc_content: &str,
+    script_content: &str,
+    script_offset: usize,
+    lang: Option<&str>,
+) -> Vec<Diagnostic> {
+    let Some(source_type) = script_source_type(lang) else {
+        return vec![];
+    };
+
+    let allocator = OxcAllocator::default();
+    let parsed = OxcParser::new(&allocator, script_content, source_type).parse();
+
+    parsed
+        .errors
+        .iter()
+        .map(|error| {
+            let (local_start, local_end) = diagnostic_span(error, script_content.len());
+            let start = script_offset + local_start;
+            let end = script_offset + local_end;
+            let (start_line, start_col) = offset_to_line_col(sfc_content, start);
+            let (end_line, end_col) = offset_to_line_col(sfc_content, end);
+
+            Diagnostic {
+                range: Range {
+                    start: Position {
+                        line: start_line,
+                        character: start_col,
+                    },
+                    end: Position {
+                        line: end_line,
+                        character: end_col,
+                    },
+                },
+                severity: Some(DiagnosticSeverity::ERROR),
+                code: Some(NumberOrString::String("script-parse-error".to_string())),
+                source: Some(sources::SCRIPT_PARSER.to_string()),
+                message: format!("Script parse error: {}", error),
+                ..Default::default()
+            }
+        })
+        .collect()
+}
+
+fn script_source_type(lang: Option<&str>) -> Option<SourceType> {
+    let extension = match lang.map(|value| value.trim().to_ascii_lowercase()) {
+        None => "js".to_string(),
+        Some(value) if value.is_empty() => "js".to_string(),
+        Some(value) if matches!(value.as_str(), "js" | "javascript") => "js".to_string(),
+        Some(value) if matches!(value.as_str(), "jsx") => "jsx".to_string(),
+        Some(value) if matches!(value.as_str(), "ts" | "typescript") => "ts".to_string(),
+        Some(value) if matches!(value.as_str(), "tsx") => "tsx".to_string(),
+        Some(_) => return None,
+    };
+
+    SourceType::from_path(format!("script.{extension}")).ok()
+}
+
+fn diagnostic_span(error: &oxc_diagnostics::OxcDiagnostic, source_len: usize) -> (usize, usize) {
+    let fallback_end = source_len.max(1);
+    let Some(label) = error.labels.as_ref().and_then(|labels| {
+        labels
+            .iter()
+            .find(|label| label.primary())
+            .or_else(|| labels.first())
+    }) else {
+        return (0, fallback_end);
+    };
+
+    let start = label.offset().min(source_len);
+    let end = start.saturating_add(label.len().max(1)).min(fallback_end);
+    (start, end.max(start + 1))
 }

--- a/crates/vize_maestro/src/ide/diagnostics/mod.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/mod.rs
@@ -114,13 +114,25 @@ impl DiagnosticService {
             return diagnostics;
         }
 
-        // Collect template parser diagnostics
+        // Collect parser diagnostics for script and template blocks before
+        // dependent analyzers, so broken blocks do not fan out into noisy
+        // lint/type/Corsa diagnostics.
+        let script_diags = Self::collect_script_diagnostics(uri, &content);
+        let has_script_parse_error = !script_diags.is_empty();
+        tracing::info!("collect: script parser diagnostics: {}", script_diags.len());
+        diagnostics.extend(script_diags);
+
         let template_diags = Self::collect_template_diagnostics(uri, &content);
+        let has_template_parse_error = !template_diags.is_empty();
         tracing::info!(
             "collect: template parser diagnostics: {}",
             template_diags.len()
         );
         diagnostics.extend(template_diags);
+        if has_script_parse_error || has_template_parse_error {
+            tracing::info!("collect: skipping dependent diagnostics after block parse error");
+            return diagnostics;
+        }
 
         if features.lint {
             // Collect linter diagnostics (vize_patina)
@@ -161,11 +173,8 @@ impl DiagnosticService {
         // Start with sync diagnostics (patina, etc.)
         let mut diagnostics = Self::collect(state, uri);
         tracing::info!("sync diagnostics count: {}", diagnostics.len());
-        if diagnostics.iter().any(|diagnostic| {
-            diagnostic.source.as_deref() == Some(sources::SFC_PARSER)
-                && diagnostic.severity == Some(DiagnosticSeverity::ERROR)
-        }) {
-            tracing::info!("collect_async: Corsa diagnostics skipped after SFC parse error");
+        if has_blocking_parser_error(&diagnostics) {
+            tracing::info!("collect_async: Corsa diagnostics skipped after parser error");
             return diagnostics;
         }
 
@@ -206,6 +215,16 @@ impl DiagnosticService {
             ..Default::default()
         }
     }
+}
+
+#[cfg(feature = "native")]
+fn has_blocking_parser_error(diagnostics: &[Diagnostic]) -> bool {
+    diagnostics.iter().any(|diagnostic| {
+        matches!(
+            diagnostic.source.as_deref(),
+            Some(sources::SFC_PARSER | sources::SCRIPT_PARSER | sources::TEMPLATE_PARSER)
+        ) && diagnostic.severity == Some(DiagnosticSeverity::ERROR)
+    })
 }
 
 /// Builder for creating diagnostics.
@@ -397,5 +416,108 @@ mod tests {
         assert!(!diagnostics
             .iter()
             .any(|diagnostic| diagnostic.source.as_deref() == Some(sources::SFC_PARSER)));
+    }
+
+    #[test]
+    fn collect_short_circuits_dependent_diagnostics_after_script_parse_error() {
+        let state = state_with_lsp_diagnostics(true, true);
+        let uri = Url::parse("file:///BrokenScript.vue").unwrap();
+        state.documents.open(
+            uri.clone(),
+            "<script setup lang=\"ts\">\nconst count =</script>\n<template>{{ count }}</template>"
+                .to_string(),
+            1,
+            "vue".to_string(),
+        );
+
+        let diagnostics = DiagnosticService::collect(&state, &uri);
+        let diagnostic_sources: Vec<_> = diagnostics
+            .iter()
+            .filter_map(|diagnostic| diagnostic.source.as_deref())
+            .collect();
+
+        assert_eq!(diagnostic_sources, vec![sources::SCRIPT_PARSER]);
+        assert_eq!(
+            diagnostics[0].code,
+            Some(NumberOrString::String("script-parse-error".to_string()))
+        );
+        assert_eq!(diagnostics[0].range.start.line, 1);
+    }
+
+    #[test]
+    fn collect_accepts_jsx_script_without_false_parse_diagnostic() {
+        let state = state_with_lsp_diagnostics(false, false);
+        let uri = Url::parse("file:///JsxScript.vue").unwrap();
+        state.documents.open(
+            uri.clone(),
+            "<script setup lang=\"jsx\">\nconst count = 1\nconst vnode = <button>{count}</button>\n</script>"
+                .to_string(),
+            1,
+            "vue".to_string(),
+        );
+
+        let diagnostics = DiagnosticService::collect(&state, &uri);
+
+        assert!(!diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.source.as_deref() == Some(sources::SCRIPT_PARSER)));
+    }
+
+    #[test]
+    fn collect_accepts_tsx_script_without_false_parse_diagnostic() {
+        let state = state_with_lsp_diagnostics(false, false);
+        let uri = Url::parse("file:///TsxScript.vue").unwrap();
+        state.documents.open(
+            uri.clone(),
+            "<script setup lang=\"tsx\">\nconst count = 1\nconst vnode = <button>{count}</button>\n</script>"
+                .to_string(),
+            1,
+            "vue".to_string(),
+        );
+
+        let diagnostics = DiagnosticService::collect(&state, &uri);
+
+        assert!(!diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.source.as_deref() == Some(sources::SCRIPT_PARSER)));
+    }
+
+    #[test]
+    fn collect_skips_unsupported_script_language() {
+        let state = state_with_lsp_diagnostics(false, false);
+        let uri = Url::parse("file:///CoffeeScript.vue").unwrap();
+        state.documents.open(
+            uri.clone(),
+            "<script setup lang=\"coffee\">\ncount = ->\n</script>".to_string(),
+            1,
+            "vue".to_string(),
+        );
+
+        let diagnostics = DiagnosticService::collect(&state, &uri);
+
+        assert!(!diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.source.as_deref() == Some(sources::SCRIPT_PARSER)));
+    }
+
+    #[test]
+    fn collect_short_circuits_dependent_diagnostics_after_template_parse_error() {
+        let state = state_with_lsp_diagnostics(true, true);
+        let uri = Url::parse("file:///BrokenTemplate.vue").unwrap();
+        state.documents.open(
+            uri.clone(),
+            "<script setup lang=\"ts\">const count = 1</script>\n<template><div>{{ count }}</template>"
+                .to_string(),
+            1,
+            "vue".to_string(),
+        );
+
+        let diagnostics = DiagnosticService::collect(&state, &uri);
+        let diagnostic_sources: Vec<_> = diagnostics
+            .iter()
+            .filter_map(|diagnostic| diagnostic.source.as_deref())
+            .collect();
+
+        assert_eq!(diagnostic_sources, vec![sources::TEMPLATE_PARSER]);
     }
 }

--- a/crates/vize_maestro/src/ide/type_service/diagnostics.rs
+++ b/crates/vize_maestro/src/ide/type_service/diagnostics.rs
@@ -208,11 +208,11 @@ impl TypeService {
                 Diagnostic {
                     range: Range {
                         start: Position {
-                            line: template_start_line + start_line - 1,
+                            line: template_start_line.saturating_sub(1) + start_line,
                             character: start_col,
                         },
                         end: Position {
-                            line: template_start_line + end_line - 1,
+                            line: template_start_line.saturating_sub(1) + end_line,
                             character: end_col,
                         },
                     },
@@ -278,9 +278,9 @@ impl TypeService {
     }
 }
 
-/// Convert byte offset to (line, column) - line is 1-indexed, column is 0-indexed.
+/// Convert byte offset to (line, column), both 0-indexed for LSP.
 pub(super) fn offset_to_line_col(source: &str, offset: usize) -> (u32, u32) {
-    let mut line = 1u32;
+    let mut line = 0u32;
     let mut col = 0u32;
     let mut current_offset = 0;
 
@@ -298,4 +298,42 @@ pub(super) fn offset_to_line_col(source: &str, offset: usize) -> (u32, u32) {
     }
 
     (line, col)
+}
+
+#[cfg(test)]
+mod diagnostics_tests {
+    use super::{offset_to_line_col, TypeService};
+    use crate::server::ServerState;
+    use tower_lsp::lsp_types::{DiagnosticSeverity, Url};
+
+    #[test]
+    fn offset_to_line_col_is_zero_indexed_for_lsp() {
+        assert_eq!(offset_to_line_col("one\ntwo", 0), (0, 0));
+        assert_eq!(offset_to_line_col("one\ntwo", 4), (1, 0));
+        assert_eq!(offset_to_line_col("one\ntwo", 6), (1, 2));
+    }
+
+    #[test]
+    fn collect_diagnostics_uses_zero_indexed_lsp_lines() {
+        let state = ServerState::new();
+        let uri = Url::parse("file:///Component.vue").unwrap();
+        state.documents.open(
+            uri.clone(),
+            "<script setup>\nconst props = defineProps(['count'])\n</script>\n<template>{{ props.count }}</template>"
+                .to_string(),
+            1,
+            "vue".to_string(),
+        );
+
+        let diagnostics = TypeService::collect_diagnostics(&state, &uri);
+        let diagnostic = diagnostics
+            .iter()
+            .find(|diagnostic| diagnostic.code.as_ref().is_some_and(|code| {
+                matches!(code, tower_lsp::lsp_types::NumberOrString::String(value) if value == "untyped-prop")
+            }))
+            .expect("untyped prop diagnostic should be present");
+
+        assert_eq!(diagnostic.range.start.line, 1);
+        assert_eq!(diagnostic.severity, Some(DiagnosticSeverity::WARNING));
+    }
 }


### PR DESCRIPTION
## Summary
- report script parser errors as Maestro diagnostics before dependent analyzers run
- stop lint/type/Corsa diagnostics after script or template parse errors to reduce noisy false positives
- map type-service diagnostics to zero-indexed LSP lines and cover JSX/TSX/unsupported script language edges

## Checks
- cargo fmt --check
- git diff --check
- cargo test -p vize_maestro diagnostics -- --nocapture
- cargo test -p vize_maestro
- cargo clippy --workspace -- -D warnings