### PR TITLE
fix(typecheck): recognize runtime emits validators

### DIFF
--- a/crates/vize_canon/src/sfc_typecheck/mod.rs
+++ b/crates/vize_canon/src/sfc_typecheck/mod.rs
@@ -199,6 +199,50 @@ const emit = defineEmits<{
     }
 
     #[test]
+    fn test_type_check_with_runtime_emits_object_validators() {
+        let source = r#"<script setup lang="ts">
+interface SavePayload {
+    id: number;
+}
+const emit = defineEmits({
+    save: (payload: SavePayload) => payload.id > 0,
+    close() { return true },
+});
+</script>
+<template>
+    <button @click="emit('close')">Close</button>
+</template>"#;
+        let options = SfcTypeCheckOptions::new("test.vue");
+        let result = type_check_sfc(source, &options);
+        assert!(!result
+            .diagnostics
+            .iter()
+            .any(|d| matches!(d.code.as_deref(), Some("untyped-emits" | "untyped-emit"))));
+    }
+
+    #[test]
+    fn test_type_check_with_untyped_runtime_emits_object_value() {
+        let source = r#"<script setup lang="ts">
+const emit = defineEmits({
+    save: null,
+});
+</script>
+<template>
+    <button @click="emit('save')">Save</button>
+</template>"#;
+        let options = SfcTypeCheckOptions::new("test.vue");
+        let result = type_check_sfc(source, &options);
+        assert!(result
+            .diagnostics
+            .iter()
+            .any(|d| d.code.as_deref() == Some("untyped-emit")));
+        assert!(!result
+            .diagnostics
+            .iter()
+            .any(|d| d.code.as_deref() == Some("untyped-emits")));
+    }
+
+    #[test]
     fn test_type_check_disabled_props_check() {
         let source = r#"<script setup>
 const props = defineProps(['count']);

--- a/crates/vize_croquis/src/script_parser/extract.rs
+++ b/crates/vize_croquis/src/script_parser/extract.rs
@@ -1,8 +1,9 @@
 //! Extraction functions for props, emits, and reactivity detection.
 
 use oxc_ast::ast::{
-    Argument, AssignmentTarget, CallExpression, Declaration, Expression, ObjectPropertyKind,
-    PropertyKey, SimpleAssignmentTarget, Statement, TSType, VariableDeclarationKind,
+    Argument, AssignmentTarget, CallExpression, Declaration, Expression, FormalParameters,
+    ObjectPropertyKind, PropertyKey, SimpleAssignmentTarget, Statement, TSType,
+    VariableDeclarationKind,
 };
 use oxc_span::{GetSpan, Span};
 
@@ -424,18 +425,180 @@ pub fn extract_emits_from_type(
 pub fn extract_emits_from_runtime(
     result: &mut ScriptParseResult,
     arg: &Argument<'_>,
-    _source: &str,
+    source: &str,
 ) {
-    if let Argument::ArrayExpression(arr) = arg {
-        for elem in arr.elements.iter() {
-            if let oxc_ast::ast::ArrayExpressionElement::StringLiteral(s) = elem {
-                result.macros.add_emit(EmitDefinition {
-                    name: CompactString::new(s.value.as_str()),
-                    payload_type: None,
-                });
-            }
+    match arg {
+        Argument::ArrayExpression(arr) => extract_emits_from_array(result, arr),
+        Argument::ObjectExpression(obj) => extract_emits_from_object(result, obj, source),
+        Argument::TSAsExpression(ts_as) => {
+            extract_emits_from_runtime_expression(result, &ts_as.expression, source);
+        }
+        Argument::TSSatisfiesExpression(ts_satisfies) => {
+            extract_emits_from_runtime_expression(result, &ts_satisfies.expression, source);
+        }
+        Argument::TSNonNullExpression(ts_non_null) => {
+            extract_emits_from_runtime_expression(result, &ts_non_null.expression, source);
+        }
+        Argument::ParenthesizedExpression(paren) => {
+            extract_emits_from_runtime_expression(result, &paren.expression, source);
+        }
+        _ => {}
+    }
+}
+
+fn extract_emits_from_runtime_expression(
+    result: &mut ScriptParseResult,
+    expr: &Expression<'_>,
+    source: &str,
+) {
+    match expr {
+        Expression::ArrayExpression(arr) => extract_emits_from_array(result, arr),
+        Expression::ObjectExpression(obj) => extract_emits_from_object(result, obj, source),
+        Expression::TSAsExpression(ts_as) => {
+            extract_emits_from_runtime_expression(result, &ts_as.expression, source);
+        }
+        Expression::TSSatisfiesExpression(ts_satisfies) => {
+            extract_emits_from_runtime_expression(result, &ts_satisfies.expression, source);
+        }
+        Expression::TSNonNullExpression(ts_non_null) => {
+            extract_emits_from_runtime_expression(result, &ts_non_null.expression, source);
+        }
+        Expression::ParenthesizedExpression(paren) => {
+            extract_emits_from_runtime_expression(result, &paren.expression, source);
+        }
+        _ => {}
+    }
+}
+
+fn extract_emits_from_array(
+    result: &mut ScriptParseResult,
+    arr: &oxc_ast::ast::ArrayExpression<'_>,
+) {
+    for elem in arr.elements.iter() {
+        if let oxc_ast::ast::ArrayExpressionElement::StringLiteral(s) = elem {
+            result.macros.add_emit(EmitDefinition {
+                name: CompactString::new(s.value.as_str()),
+                payload_type: None,
+            });
         }
     }
+}
+
+fn extract_emits_from_object(
+    result: &mut ScriptParseResult,
+    obj: &oxc_ast::ast::ObjectExpression<'_>,
+    source: &str,
+) {
+    for prop in obj.properties.iter() {
+        let ObjectPropertyKind::ObjectProperty(prop) = prop else {
+            continue;
+        };
+        let name = match &prop.key {
+            PropertyKey::StaticIdentifier(id) => id.name.as_str(),
+            PropertyKey::StringLiteral(s) => s.value.as_str(),
+            _ => continue,
+        };
+
+        result.macros.add_emit(EmitDefinition {
+            name: CompactString::new(name),
+            payload_type: extract_runtime_emit_payload_type(&prop.value, source),
+        });
+    }
+}
+
+fn extract_runtime_emit_payload_type(
+    value: &Expression<'_>,
+    source: &str,
+) -> Option<CompactString> {
+    match value {
+        Expression::ArrowFunctionExpression(func) => {
+            extract_emit_payload_tuple(&func.params, source)
+        }
+        Expression::FunctionExpression(func) => extract_emit_payload_tuple(&func.params, source),
+        Expression::TSAsExpression(ts_as) => {
+            extract_runtime_emit_payload_type(&ts_as.expression, source)
+        }
+        Expression::TSSatisfiesExpression(ts_satisfies) => {
+            extract_runtime_emit_payload_type(&ts_satisfies.expression, source)
+        }
+        Expression::TSNonNullExpression(ts_non_null) => {
+            extract_runtime_emit_payload_type(&ts_non_null.expression, source)
+        }
+        Expression::ParenthesizedExpression(paren) => {
+            extract_runtime_emit_payload_type(&paren.expression, source)
+        }
+        _ => None,
+    }
+}
+
+fn extract_emit_payload_tuple(
+    params: &FormalParameters<'_>,
+    source: &str,
+) -> Option<CompactString> {
+    let mut payload = String::from("[");
+    let mut first = true;
+
+    for param in params.items.iter() {
+        let type_annotation = param.type_annotation.as_ref()?;
+        let ty = type_annotation_source(source, type_annotation.span)?;
+
+        if !first {
+            payload.push_str(", ");
+        }
+        first = false;
+
+        if let Some(label) = simple_parameter_label(source, param.pattern.span()) {
+            payload.push_str(label.as_str());
+            if param.optional {
+                payload.push('?');
+            }
+            payload.push_str(": ");
+        }
+        payload.push_str(ty);
+    }
+
+    if let Some(rest) = params.rest.as_ref() {
+        let type_annotation = rest.type_annotation.as_ref()?;
+        let ty = type_annotation_source(source, type_annotation.span)?;
+
+        if !first {
+            payload.push_str(", ");
+        }
+
+        if let Some(label) = simple_parameter_label(source, rest.rest.argument.span()) {
+            payload.push_str("...");
+            payload.push_str(label.as_str());
+            payload.push_str(": ");
+        } else {
+            payload.push_str("...");
+        }
+        payload.push_str(ty);
+    }
+
+    payload.push(']');
+    Some(CompactString::new(payload.as_str()))
+}
+
+fn type_annotation_source(source: &str, span: Span) -> Option<&str> {
+    let ty = source
+        .get(span.start as usize..span.end as usize)?
+        .trim()
+        .trim_start_matches(':')
+        .trim();
+    (!ty.is_empty()).then_some(ty)
+}
+
+fn simple_parameter_label(source: &str, span: Span) -> Option<CompactString> {
+    let label = source.get(span.start as usize..span.end as usize)?.trim();
+    let mut chars = label.chars();
+    let first = chars.next()?;
+    if !(first.is_ascii_alphabetic() || first == '_' || first == '$') {
+        return None;
+    }
+    if !chars.all(|ch| ch.is_ascii_alphanumeric() || ch == '_' || ch == '$') {
+        return None;
+    }
+    Some(CompactString::new(label))
 }
 
 /// Detect reactivity wrappers (ref, computed, reactive, etc.)

--- a/crates/vize_croquis/src/script_parser/mod.rs
+++ b/crates/vize_croquis/src/script_parser/mod.rs
@@ -425,6 +425,47 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_define_emits_runtime_object() {
+        let result = parse_script_setup(
+            r#"
+            type SavePayload = { id: number }
+            const emit = defineEmits({
+                save: (payload: SavePayload) => payload.id > 0,
+                close() { return true },
+                cancel: null,
+            })
+        "#,
+        );
+
+        assert_eq!(result.macros.all_calls().len(), 1);
+        assert_eq!(result.macros.emits().len(), 3);
+
+        let save = result
+            .macros
+            .emits()
+            .iter()
+            .find(|emit| emit.name == "save")
+            .expect("save emit should be extracted");
+        assert_eq!(save.payload_type.as_deref(), Some("[payload: SavePayload]"));
+
+        let close = result
+            .macros
+            .emits()
+            .iter()
+            .find(|emit| emit.name == "close")
+            .expect("close emit should be extracted");
+        assert_eq!(close.payload_type.as_deref(), Some("[]"));
+
+        let cancel = result
+            .macros
+            .emits()
+            .iter()
+            .find(|emit| emit.name == "cancel")
+            .expect("cancel emit should be extracted");
+        assert_eq!(cancel.payload_type, None);
+    }
+
+    #[test]
     fn test_parse_reactivity() {
         let result = parse_script_setup(
             r#"


### PR DESCRIPTION
## Summary
- extract runtime object defineEmits declarations from Croquis script analysis
- preserve typed validator payloads as tuple payload metadata
- keep untyped runtime emit values reported as specific untyped-emit diagnostics

## Checks
- cargo fmt --check
- git diff --check
- cargo test -p vize_croquis script_parser -- --nocapture
- cargo test -p vize_canon sfc_typecheck -- --nocapture
- cargo clippy -p vize_croquis -p vize_canon -- -D warnings