### PR TITLE
fix(maestro): reduce lsp false positives

### DIFF
--- a/crates/vize_maestro/src/ide/definition/helpers.rs
+++ b/crates/vize_maestro/src/ide/definition/helpers.rs
@@ -287,73 +287,7 @@ pub(crate) fn find_prop_in_define_props(content: &str, property_name: &str) -> O
 
 /// Check if the cursor is inside a Vue directive expression.
 pub(crate) fn is_in_vue_directive_expression(ctx: &IdeContext) -> bool {
-    let content = &ctx.content;
-    let offset = ctx.offset;
-
-    // Check if we're inside a mustache expression {{ ... }}
-    let before = &content[..offset];
-    let after = &content[offset..];
-
-    if let Some(mustache_start) = before.rfind("{{") {
-        let between = &content[mustache_start + 2..offset];
-        if !between.contains("}}") && after.contains("}}") {
-            return true;
-        }
-    }
-
-    // Check if we're inside an attribute value
-    let mut pos = offset;
-    let mut in_quotes = false;
-    let mut quote_char = '"';
-
-    while pos > 0 {
-        let c = content.as_bytes()[pos - 1] as char;
-        if c == '"' || c == '\'' {
-            in_quotes = true;
-            quote_char = c;
-            pos -= 1;
-            break;
-        }
-        if c == '>' || c == '<' {
-            return false;
-        }
-        pos -= 1;
-    }
-
-    if !in_quotes {
-        return false;
-    }
-
-    // Skip the = sign
-    while pos > 0 && content.as_bytes()[pos - 1] == b'=' {
-        pos -= 1;
-    }
-
-    // Get the attribute name by scanning backwards
-    let attr_end = pos;
-    while pos > 0 {
-        let c = content.as_bytes()[pos - 1] as char;
-        if c.is_whitespace() || c == '<' || c == '>' {
-            break;
-        }
-        pos -= 1;
-    }
-
-    let attr_name = &content[pos..attr_end];
-
-    if attr_name.starts_with(':')
-        || attr_name.starts_with('@')
-        || attr_name.starts_with('#')
-        || attr_name.starts_with("v-")
-    {
-        let quote_start = attr_end + 1;
-        if let Some(quote_end) = content[quote_start + 1..].find(quote_char) {
-            let abs_quote_end = quote_start + 1 + quote_end;
-            return offset <= abs_quote_end;
-        }
-    }
-
-    false
+    crate::ide::is_in_vue_template_expression(&ctx.content, ctx.offset)
 }
 
 /// Find the import path for a given component name.

--- a/crates/vize_maestro/src/ide/definition/mod.rs
+++ b/crates/vize_maestro/src/ide/definition/mod.rs
@@ -352,6 +352,33 @@ const msg = 'hello'
         assert_eq!(value_location.range.start.character, character);
     }
 
+    #[test]
+    fn test_definition_ignores_static_attribute_value() {
+        let dir = tempfile::tempdir().unwrap();
+        let source_path = dir.path().join("StaticAttribute.vue");
+        let source = r#"<script setup lang="ts">
+const message = 'hello'
+</script>
+
+<template>
+  <div title="message" />
+</template>
+"#;
+        fs::write(&source_path, source).unwrap();
+
+        let uri = Url::from_file_path(&source_path).unwrap();
+        let state = ServerState::new();
+        state
+            .documents
+            .open(uri.clone(), source.to_string(), 1, "vue".to_string());
+        state.update_virtual_docs(&uri, source);
+
+        let value_offset = source.rfind("message\"").unwrap() + "message".len();
+        let value_ctx = IdeContext::new(&state, &uri, value_offset).unwrap();
+
+        assert!(DefinitionService::definition(&value_ctx).is_none());
+    }
+
     #[cfg(feature = "native")]
     #[tokio::test]
     async fn test_definition_with_corsa_fallback_resolves_template_binding_at_boundary() {
@@ -425,6 +452,64 @@ const secondaryLabel = ref('secondary')
         assert_eq!(location.uri, uri);
         assert_eq!(location.range.start.line, line);
         assert_eq!(location.range.start.character, character);
+    }
+
+    #[test]
+    fn test_definition_in_style_resolves_inside_v_bind_argument() {
+        let dir = tempfile::tempdir().unwrap();
+        let source_path = dir.path().join("Styled.vue");
+        let source = r#"<script setup lang="ts">
+const color = 'red'
+</script>
+<style>
+.foo { color: v-bind(color); }
+</style>
+"#;
+        fs::write(&source_path, source).unwrap();
+
+        let uri = Url::from_file_path(&source_path).unwrap();
+        let state = ServerState::new();
+        state
+            .documents
+            .open(uri.clone(), source.to_string(), 1, "vue".to_string());
+        state.update_virtual_docs(&uri, source);
+
+        let offset = source.find("v-bind(color").unwrap() + "v-bind(".len() + "color".len();
+        let ctx = IdeContext::new(&state, &uri, offset).unwrap();
+        let location = scalar_location(DefinitionService::definition(&ctx).unwrap());
+        let expected_binding_offset = source.find("const color").unwrap() + "const ".len();
+        let (line, character) = crate::ide::offset_to_position(source, expected_binding_offset);
+
+        assert_eq!(location.uri, uri);
+        assert_eq!(location.range.start.line, line);
+        assert_eq!(location.range.start.character, character);
+    }
+
+    #[test]
+    fn test_definition_in_style_ignores_same_word_after_closed_v_bind() {
+        let dir = tempfile::tempdir().unwrap();
+        let source_path = dir.path().join("Styled.vue");
+        let source = r#"<script setup lang="ts">
+const color = 'red'
+</script>
+<style>
+.foo { color: v-bind(color); }
+.bar { background: color; }
+</style>
+"#;
+        fs::write(&source_path, source).unwrap();
+
+        let uri = Url::from_file_path(&source_path).unwrap();
+        let state = ServerState::new();
+        state
+            .documents
+            .open(uri.clone(), source.to_string(), 1, "vue".to_string());
+        state.update_virtual_docs(&uri, source);
+
+        let offset = source.rfind("background: color").unwrap() + "background: ".len();
+        let ctx = IdeContext::new(&state, &uri, offset).unwrap();
+
+        assert!(DefinitionService::definition(&ctx).is_none());
     }
 
     fn scalar_location(response: GotoDefinitionResponse) -> Location {

--- a/crates/vize_maestro/src/ide/definition/script.rs
+++ b/crates/vize_maestro/src/ide/definition/script.rs
@@ -65,9 +65,8 @@ pub(crate) fn definition_in_style(ctx: &IdeContext) -> Option<GotoDefinitionResp
         return None;
     }
 
-    // Check for v-bind() references to script variables
-    let before_cursor = &ctx.content[..ctx.offset];
-    if before_cursor.contains("v-bind(") {
+    // Check for v-bind() references to script variables.
+    if is_inside_style_v_bind_argument(&ctx.content, ctx.offset) {
         let options = vize_atelier_sfc::SfcParseOptions {
             filename: ctx.uri.path().to_string().into(),
             ..Default::default()
@@ -96,6 +95,20 @@ pub(crate) fn definition_in_style(ctx: &IdeContext) -> Option<GotoDefinitionResp
     }
 
     None
+}
+
+fn is_inside_style_v_bind_argument(content: &str, offset: usize) -> bool {
+    let mut offset = offset.min(content.len());
+    while offset > 0 && !content.is_char_boundary(offset) {
+        offset -= 1;
+    }
+
+    let Some(v_bind_start) = content[..offset].rfind("v-bind(") else {
+        return false;
+    };
+    let arg_start = v_bind_start + "v-bind(".len();
+
+    !content[arg_start..offset].contains(')')
 }
 
 /// Find the location of a binding definition in raw script content (not virtual code).

--- a/crates/vize_maestro/src/ide/definition/service.rs
+++ b/crates/vize_maestro/src/ide/definition/service.rs
@@ -71,6 +71,10 @@ impl super::DefinitionService {
             }
         }
 
+        if !crate::ide::is_in_vue_template_expression(&ctx.content, ctx.offset) {
+            return None;
+        }
+
         // Try Corsa definition lookup first.
         if let Some(bridge) = corsa_bridge {
             if let Some(ref virtual_docs) = ctx.virtual_docs {
@@ -132,6 +136,10 @@ impl super::DefinitionService {
         let word = helpers::get_word_at_offset(&ctx.content, ctx.offset)?;
 
         if word.is_empty() {
+            return None;
+        }
+
+        if !crate::ide::is_in_vue_template_expression(&ctx.content, ctx.offset) {
             return None;
         }
 

--- a/crates/vize_maestro/src/ide/definition/template.rs
+++ b/crates/vize_maestro/src/ide/definition/template.rs
@@ -32,6 +32,10 @@ pub(crate) fn definition_in_template(ctx: &IdeContext) -> Option<GotoDefinitionR
         return None;
     }
 
+    if !crate::ide::is_in_vue_template_expression(&ctx.content, ctx.offset) {
+        return None;
+    }
+
     // Check if this is a props property access (e.g., props.title -> defineProps)
     if let Some(def) = find_props_property_definition(ctx, &word) {
         return Some(def);

--- a/crates/vize_maestro/src/ide/hover/mod.rs
+++ b/crates/vize_maestro/src/ide/hover/mod.rs
@@ -490,6 +490,77 @@ mod tests {
     }
 
     #[test]
+    fn test_hover_template_returns_none_for_plain_text_node() {
+        let source = r#"<template>
+  <div>Hello world</div>
+</template>
+"#;
+        let (state, uri) = state_with_document("PlainTextHover.vue", source);
+
+        let offset = source.find("Hello").unwrap() + "Hello".len();
+        let ctx = IdeContext::new(&state, &uri, offset).unwrap();
+
+        assert!(HoverService::hover(&ctx).is_none());
+    }
+
+    #[test]
+    fn test_hover_template_returns_none_for_static_attribute_value() {
+        let source = r#"<script setup lang="ts">
+const message = 'hello'
+</script>
+<template>
+  <div title="message" />
+</template>
+"#;
+        let (state, uri) = state_with_document("StaticAttributeHover.vue", source);
+
+        let offset = source.rfind("message\"").unwrap() + "message".len();
+        let ctx = IdeContext::new(&state, &uri, offset).unwrap();
+
+        assert!(HoverService::hover(&ctx).is_none());
+    }
+
+    #[test]
+    fn test_hover_template_keeps_binding_hover_in_interpolation() {
+        let source = r#"<script setup lang="ts">
+const message = ref('hello')
+</script>
+<template>
+  {{ message }}
+</template>
+"#;
+        let (state, uri) = state_with_document("InterpolationHover.vue", source);
+
+        let offset = source.rfind("message").unwrap() + "message".len();
+        let ctx = IdeContext::new(&state, &uri, offset).unwrap();
+        let hover = HoverService::hover(&ctx).unwrap();
+        let value = hover_markdown(hover);
+
+        assert!(value.contains("message"));
+        assert!(value.contains("Ref<string>"));
+    }
+
+    #[test]
+    fn test_hover_template_keeps_binding_hover_in_dynamic_attribute() {
+        let source = r#"<script setup lang="ts">
+const message = ref('hello')
+</script>
+<template>
+  <div :title = "message" />
+</template>
+"#;
+        let (state, uri) = state_with_document("DynamicAttributeHover.vue", source);
+
+        let offset = source.rfind("message").unwrap() + "message".len();
+        let ctx = IdeContext::new(&state, &uri, offset).unwrap();
+        let hover = HoverService::hover(&ctx).unwrap();
+        let value = hover_markdown(hover);
+
+        assert!(value.contains("message"));
+        assert!(value.contains("Ref<string>"));
+    }
+
+    #[test]
     fn test_hover_builder() {
         let hover = HoverBuilder::new()
             .title("ref")
@@ -644,5 +715,20 @@ const count = ref(0)
                 .collect::<Vec<_>>()
                 .join("\n\n"),
         }
+    }
+
+    fn state_with_document(name: &str, source: &str) -> (ServerState, Url) {
+        let dir = tempfile::tempdir().unwrap();
+        let source_path = dir.path().join(name);
+        fs::write(&source_path, source).unwrap();
+
+        let uri = Url::from_file_path(&source_path).unwrap();
+        let state = ServerState::new();
+        state
+            .documents
+            .open(uri.clone(), source.to_string(), 1, "vue".to_string());
+        state.update_virtual_docs(&uri, source);
+
+        (state, uri)
     }
 }

--- a/crates/vize_maestro/src/ide/hover/template.rs
+++ b/crates/vize_maestro/src/ide/hover/template.rs
@@ -36,6 +36,10 @@ impl HoverService {
             return Some(hover);
         }
 
+        if !crate::ide::is_in_vue_template_expression(&ctx.content, ctx.offset) {
+            return None;
+        }
+
         // Try to get TypeScript type information from croquis analysis
         if let Some(hover) = Self::hover_ts_binding(ctx, &word) {
             return Some(hover);
@@ -103,6 +107,10 @@ impl HoverService {
         // Check for Vue directives first; these do not need Corsa.
         if let Some(hover) = Self::hover_directive(&word) {
             return Some(hover);
+        }
+
+        if !crate::ide::is_in_vue_template_expression(&ctx.content, ctx.offset) {
+            return None;
         }
 
         // Try to get type information from Corsa via virtual TypeScript.

--- a/crates/vize_maestro/src/ide/mod.rs
+++ b/crates/vize_maestro/src/ide/mod.rs
@@ -216,6 +216,99 @@ where
     Some(content[start..end].to_string())
 }
 
+/// Check if a cursor offset is inside a Vue template expression.
+///
+/// This covers mustache interpolations and Vue directive attribute values, but
+/// deliberately excludes plain text nodes and static attribute values.
+pub(crate) fn is_in_vue_template_expression(content: &str, offset: usize) -> bool {
+    if content.is_empty() {
+        return false;
+    }
+
+    let mut offset = offset.min(content.len());
+    while offset > 0 && !content.is_char_boundary(offset) {
+        offset -= 1;
+    }
+
+    if is_in_mustache_expression(content, offset) {
+        return true;
+    }
+
+    is_in_vue_directive_attribute_value(content, offset)
+}
+
+fn is_in_mustache_expression(content: &str, offset: usize) -> bool {
+    let before = &content[..offset];
+    let Some(mustache_start) = before.rfind("{{") else {
+        return false;
+    };
+
+    let closed_before_cursor = before
+        .rfind("}}")
+        .is_some_and(|mustache_end| mustache_end > mustache_start);
+    if closed_before_cursor {
+        return false;
+    }
+
+    content[offset..].contains("}}")
+}
+
+fn is_in_vue_directive_attribute_value(content: &str, offset: usize) -> bool {
+    let bytes = content.as_bytes();
+    let mut pos = offset;
+    let mut quote_start = None;
+
+    while pos > 0 {
+        let byte = bytes[pos - 1];
+        match byte {
+            b'"' | b'\'' => {
+                quote_start = Some((pos - 1, byte));
+                break;
+            }
+            b'<' | b'>' | b'\n' | b'\r' => return false,
+            _ => pos -= 1,
+        }
+    }
+
+    let Some((quote_start, quote)) = quote_start else {
+        return false;
+    };
+    let Some(relative_quote_end) = content[quote_start + 1..].find(quote as char) else {
+        return false;
+    };
+    let quote_end = quote_start + 1 + relative_quote_end;
+    if offset > quote_end {
+        return false;
+    }
+
+    let mut pos = quote_start;
+    while pos > 0 && bytes[pos - 1].is_ascii_whitespace() {
+        pos -= 1;
+    }
+    if pos == 0 || bytes[pos - 1] != b'=' {
+        return false;
+    }
+    pos -= 1;
+
+    while pos > 0 && bytes[pos - 1].is_ascii_whitespace() {
+        pos -= 1;
+    }
+    let attr_end = pos;
+    while pos > 0 {
+        let byte = bytes[pos - 1];
+        if byte.is_ascii_whitespace() || matches!(byte, b'<' | b'>' | b'/') {
+            break;
+        }
+        pos -= 1;
+    }
+
+    let attr_name = &content[pos..attr_end];
+    attr_name.starts_with(':')
+        || attr_name.starts_with('@')
+        || attr_name.starts_with('#')
+        || attr_name.starts_with("v-")
+}
+
 /// Context for IDE operations.
 pub struct IdeContext<'a> {
     /// Server state


### PR DESCRIPTION
## Summary
- suppress template hover and definition results for plain text and static attribute values
- keep binding hover and definition behavior for real Vue expressions, including dynamic attributes with spaced equals
- restrict style go-to-definition to the active CSS v-bind() argument

## Checks
- cargo fmt --check
- git diff --check
- cargo test -p vize_maestro hover -- --nocapture
- cargo test -p vize_maestro definition -- --nocapture
- cargo test -p vize_maestro
- cargo clippy -p vize_maestro -- -D warnings