### PR TITLE
fix(maestro): gate template binding completions

### DIFF
--- a/crates/vize_maestro/src/ide/completion/mod.rs
+++ b/crates/vize_maestro/src/ide/completion/mod.rs
@@ -204,6 +204,60 @@ mod tests {
     }
 
     #[test]
+    fn test_template_completion_skips_bindings_in_plain_text_node() {
+        let source = r#"<script setup lang="ts">
+const message = ref('hello')
+</script>
+<template>
+  <div>Hello </div>
+</template>
+"#;
+        let (state, uri) = state_with_document("PlainTextCompletion.vue", source);
+        let offset = source.find("Hello ").unwrap() + "Hello ".len();
+        let ctx = IdeContext::new(&state, &uri, offset).unwrap();
+        let labels = completion_labels(CompletionService::complete(&ctx).unwrap());
+
+        assert!(!has_label(&labels, "message"));
+        assert!(has_label(&labels, "v-if"));
+    }
+
+    #[test]
+    fn test_template_completion_skips_bindings_in_static_attribute_value() {
+        let source = r#"<script setup lang="ts">
+const message = ref('hello')
+</script>
+<template>
+  <div title="message" />
+</template>
+"#;
+        let (state, uri) = state_with_document("StaticAttributeCompletion.vue", source);
+        let offset = source.rfind("message\"").unwrap() + "message".len();
+        let ctx = IdeContext::new(&state, &uri, offset).unwrap();
+        let labels = completion_labels(CompletionService::complete(&ctx).unwrap());
+
+        assert!(!has_label(&labels, "message"));
+        assert!(has_label(&labels, "v-if"));
+    }
+
+    #[test]
+    fn test_template_completion_keeps_bindings_in_dynamic_attribute_value() {
+        let source = r#"<script setup lang="ts">
+const message = ref('hello')
+</script>
+<template>
+  <div :title = "message" />
+</template>
+"#;
+        let (state, uri) = state_with_document("DynamicAttributeCompletion.vue", source);
+        let offset = source.rfind("message").unwrap() + "message".len();
+        let ctx = IdeContext::new(&state, &uri, offset).unwrap();
+        let labels = completion_labels(CompletionService::complete(&ctx).unwrap());
+
+        assert!(has_label(&labels, "message"));
+        assert!(has_label(&labels, "v-if"));
+    }
+
+    #[test]
     fn test_art_variant_completion_includes_script_bindings_in_non_default_variant() {
         let dir = tempfile::tempdir().unwrap();
         let source_path = dir.path().join("Button.art.vue");
@@ -242,5 +296,33 @@ const secondaryLabel = ref('secondary')
         assert!(labels.contains(&"secondaryLabel"));
         assert!(labels.contains(&"primaryLabel"));
         assert!(labels.contains(&"v-if"));
+    }
+
+    fn completion_labels(response: CompletionResponse) -> Vec<String> {
+        let items = match response {
+            CompletionResponse::Array(items) => items,
+            CompletionResponse::List(list) => list.items,
+        };
+
+        items.into_iter().map(|item| item.label).collect()
+    }
+
+    fn has_label(labels: &[String], expected: &str) -> bool {
+        labels.iter().any(|label| label == expected)
+    }
+
+    fn state_with_document(name: &str, source: &str) -> (ServerState, Url) {
+        let dir = tempfile::tempdir().unwrap();
+        let source_path = dir.path().join(name);
+        fs::write(&source_path, source).unwrap();
+
+        let uri = Url::from_file_path(&source_path).unwrap();
+        let state = ServerState::new();
+        state
+            .documents
+            .open(uri.clone(), source.to_string(), 1, "vue".to_string());
+        state.update_virtual_docs(&uri, source);
+
+        (state, uri)
     }
 }

--- a/crates/vize_maestro/src/ide/completion/template.rs
+++ b/crates/vize_maestro/src/ide/completion/template.rs
@@ -35,6 +35,11 @@ pub(crate) fn complete_template(ctx: &IdeContext) -> Vec<CompletionItem> {
     // Add built-in components
     items_vec.extend(builtin_component_completions());
 
+    if !crate::ide::is_in_vue_template_expression(&ctx.content, ctx.offset) {
+        items_vec.extend(template_snippets());
+        return items_vec;
+    }
+
     // Use vize_croquis for accurate scope analysis and type information
     let options = vize_atelier_sfc::SfcParseOptions {
         filename: ctx.uri.path().to_string().into(),


### PR DESCRIPTION
## Summary
- keep structural template completions available everywhere in templates
- suppress script binding, prop, and reactive-source completions outside real Vue template expressions
- add regression coverage for plain text, static attributes, and dynamic attributes

## Checks
- cargo fmt --check
- git diff --check
- cargo test -p vize_maestro completion -- --nocapture
- cargo test -p vize_maestro
- cargo clippy -p vize_maestro -- -D warnings