### PR TITLE
fix(croquis): ignore regex literal identifiers

### DIFF
--- a/crates/vize_croquis/src/analyzer/helpers/identifiers.rs
+++ b/crates/vize_croquis/src/analyzer/helpers/identifiers.rs
@@ -129,7 +129,8 @@ pub fn extract_identifiers_oxc(expr: &str) -> Vec<CompactString> {
     // - Object literals: { }
     // - Type assertions: as Type
     // - Arrow functions: () =>
-    if expr.contains('{') || expr.contains(" as ") || expr.contains("=>") {
+    // - Regex literals and division: /
+    if expr.contains('{') || expr.contains(" as ") || expr.contains("=>") || expr.contains('/') {
         return profile!(
             "croquis.helpers.identifiers.slow",
             extract_identifiers_oxc_slow(expr)
@@ -592,5 +593,24 @@ mod tests {
             "/** comment words should disappear */ disabled ? true : undefined",
         ));
         assert_eq!(ids, vec!["disabled", "true", "undefined"]);
+    }
+
+    #[test]
+    fn test_extract_identifiers_ignores_regex_literals() {
+        fn to_strings(ids: Vec<CompactString>) -> Vec<CompactString> {
+            ids
+        }
+
+        let ids = to_strings(extract_identifiers_oxc("message.match(/foo/)"));
+        assert_eq!(ids, vec!["message"]);
+
+        let ids = to_strings(extract_identifiers_oxc("/foo/.test(message)"));
+        assert_eq!(ids, vec!["message"]);
+
+        let ids = to_strings(extract_identifiers_oxc("message.replace(/foo/g, bar)"));
+        assert_eq!(ids, vec!["message", "bar"]);
+
+        let ids = to_strings(extract_identifiers_oxc("count / divisor"));
+        assert_eq!(ids, vec!["count", "divisor"]);
     }
 }

--- a/crates/vize_maestro/src/ide/type_service/diagnostics.rs
+++ b/crates/vize_maestro/src/ide/type_service/diagnostics.rs
@@ -304,7 +304,7 @@ pub(super) fn offset_to_line_col(source: &str, offset: usize) -> (u32, u32) {
 mod diagnostics_tests {
     use super::{offset_to_line_col, TypeService};
     use crate::server::ServerState;
-    use tower_lsp::lsp_types::{DiagnosticSeverity, Url};
+    use tower_lsp::lsp_types::{DiagnosticSeverity, NumberOrString, Url};
 
     #[test]
     fn offset_to_line_col_is_zero_indexed_for_lsp() {
@@ -335,5 +335,40 @@ mod diagnostics_tests {
 
         assert_eq!(diagnostic.range.start.line, 1);
         assert_eq!(diagnostic.severity, Some(DiagnosticSeverity::WARNING));
+    }
+
+    #[test]
+    fn collect_diagnostics_does_not_report_regex_literals_as_undefined_bindings() {
+        let state = ServerState::new();
+        let uri = Url::parse("file:///RegexLiteral.vue").unwrap();
+        state.documents.open(
+            uri.clone(),
+            r#"<script setup lang="ts">
+const message = 'hello'
+const bar = 'baz'
+</script>
+<template>
+  {{ message.match(/foo/) }}
+  {{ /foo/.test(message) }}
+  {{ message.replace(/foo/g, bar) }}
+</template>"#
+                .to_string(),
+            1,
+            "vue".to_string(),
+        );
+
+        let diagnostics = TypeService::collect_diagnostics(&state, &uri);
+
+        assert!(
+            diagnostics
+                .iter()
+                .filter(|diagnostic| matches!(
+                    diagnostic.code,
+                    Some(NumberOrString::String(ref code)) if code == "undefined-binding"
+                ))
+                .collect::<Vec<_>>()
+                .is_empty(),
+            "regex literals should not produce undefined-binding diagnostics: {diagnostics:#?}"
+        );
     }
 }


### PR DESCRIPTION
## Summary
- route template expressions containing slash syntax through the OXC identifier extractor
- ignore identifiers inside regex literals while preserving division-expression references
- add LSP type-diagnostic regression coverage for regex literals in template expressions

## Checks
- cargo fmt --check
- git diff --check
- cargo test -p vize_croquis extract_identifiers -- --nocapture
- cargo test -p vize_maestro regex_literals -- --nocapture
- cargo test -p vize_croquis -p vize_maestro
- cargo clippy -p vize_croquis -p vize_maestro -- -D warnings