### PR TITLE
fix(vite-plus): normalize task shell locale

### DIFF
--- a/tests/tooling/task-shell.test.ts
+++ b/tests/tooling/task-shell.test.ts
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  getTaskShellLocaleAssignments,
+  normalizeTaskShellLocale,
+  shellCommand,
+} from "../../tools/vite-plus/task-shell.ts";
+
+test("macOS task shells fall back from C.UTF-8 to an installed UTF-8 locale", () => {
+  assert.deepEqual(
+    getTaskShellLocaleAssignments("darwin", {
+      LC_ALL: "C.UTF-8",
+      LC_CTYPE: "C.UTF-8",
+      LANG: "C.UTF-8",
+    }),
+    ["LC_ALL='en_US.UTF-8'", "LC_CTYPE='en_US.UTF-8'", "LANG='en_US.UTF-8'"],
+  );
+});
+
+test("non-macOS task shells do not rewrite C.UTF-8", () => {
+  assert.deepEqual(
+    getTaskShellLocaleAssignments("linux", {
+      LC_ALL: "C.UTF-8",
+      LC_CTYPE: "C.UTF-8",
+      LANG: "C.UTF-8",
+    }),
+    [],
+  );
+});
+
+test("task shell commands apply locale before sh starts", () => {
+  assert.equal(
+    shellCommand("cd examples/vite-musea && pnpm run check", ["LC_ALL='en_US.UTF-8'"]),
+    "env LC_ALL='en_US.UTF-8' sh -c 'cd examples/vite-musea && pnpm run check'",
+  );
+});
+
+test("normalizing a macOS C.UTF-8 environment updates child-process locale variables", () => {
+  const env: NodeJS.ProcessEnv = {
+    LC_ALL: "C.UTF-8",
+    LC_CTYPE: "C.UTF-8",
+    LANG: "C.UTF-8",
+  };
+
+  normalizeTaskShellLocale("darwin", env);
+
+  assert.equal(env.LC_ALL, "en_US.UTF-8");
+  assert.equal(env.LC_CTYPE, "en_US.UTF-8");
+  assert.equal(env.LANG, "en_US.UTF-8");
+});

--- a/tools/vite-plus/task-commands.ts
+++ b/tools/vite-plus/task-commands.ts
@@ -1,5 +1,5 @@
 import type { PackagePath } from "./task-types.ts";
-import { shellQuote } from "./task-shell.ts";
+import { shellCommand } from "./task-shell.ts";
 
 export const localVp = "./node_modules/.bin/vp";
 
@@ -10,7 +10,7 @@ export const localVp = "./node_modules/.bin/vp";
  * package-manager scripts directly instead of going through `vp run --filter`.
  */
 export const runInDirectory = (cwd: string, command: string) =>
-  `sh -c ${shellQuote(`cd ${cwd} && ${command}`)}`;
+  shellCommand(`cd ${cwd} && ${command}`);
 
 export const runPackageScriptDirectly = (taskName: string, packages: readonly PackagePath[]) =>
   packages.map((pkg) => runInDirectory(pkg, `pnpm run ${taskName}`)).join(" && ");

--- a/tools/vite-plus/task-helpers.ts
+++ b/tools/vite-plus/task-helpers.ts
@@ -12,6 +12,6 @@ export {
   runTasks,
 } from "./task-commands.ts";
 export { noCacheTask, task } from "./task-definition.ts";
-export { shellQuote, withRustTaskEnvironment } from "./task-shell.ts";
+export { shellCommand, shellQuote, withRustTaskEnvironment } from "./task-shell.ts";
 export { defineTasks } from "./task-types.ts";
 export type { PackagePath, TaskInput } from "./task-types.ts";

--- a/tools/vite-plus/task-shell.ts
+++ b/tools/vite-plus/task-shell.ts
@@ -8,6 +8,45 @@
  */
 export const shellQuote = (command: string) => `'${command.replaceAll("'", `'"'"'`)}'`;
 
+const darwinUnsupportedUtf8Locale = "C.UTF-8";
+const darwinFallbackUtf8Locale = "en_US.UTF-8";
+const taskShellLocaleVariables = ["LC_ALL", "LC_CTYPE", "LANG"] as const;
+
+const needsDarwinLocaleFallback = (platform: NodeJS.Platform, env: NodeJS.ProcessEnv) =>
+  platform === "darwin" &&
+  taskShellLocaleVariables.some((name) => env[name] === darwinUnsupportedUtf8Locale);
+
+export const getTaskShellLocaleAssignments = (
+  platform: NodeJS.Platform = process.platform,
+  env: NodeJS.ProcessEnv = process.env,
+) =>
+  needsDarwinLocaleFallback(platform, env)
+    ? taskShellLocaleVariables.map((name) => `${name}=${shellQuote(darwinFallbackUtf8Locale)}`)
+    : [];
+
+export const normalizeTaskShellLocale = (
+  platform: NodeJS.Platform = process.platform,
+  env: NodeJS.ProcessEnv = process.env,
+) => {
+  if (!needsDarwinLocaleFallback(platform, env)) {
+    return;
+  }
+
+  for (const name of taskShellLocaleVariables) {
+    env[name] = darwinFallbackUtf8Locale;
+  }
+};
+
+const taskShellLocaleAssignments = getTaskShellLocaleAssignments();
+// macOS does not ship C.UTF-8, but Nix shells often export it by default.
+normalizeTaskShellLocale();
+
+export const shellCommand = (
+  command: string,
+  environmentAssignments: readonly string[] = taskShellLocaleAssignments,
+) =>
+  `${environmentAssignments.length === 0 ? "" : `env ${environmentAssignments.join(" ")} `}sh -c ${shellQuote(command)}`;
+
 const darwinLibiconvLibraryPath = process.env.VIZE_DARWIN_LIBICONV_LIB;
 const rustTaskEnvironment =
   darwinLibiconvLibraryPath == null
@@ -29,4 +68,4 @@ const rustTaskEnvironment =
 export const withRustTaskEnvironment = (command: string) =>
   rustTaskEnvironment.length === 0
     ? command
-    : `sh -c ${shellQuote(`${rustTaskEnvironment.join("; ")}; ${command}`)}`;
+    : shellCommand(`${rustTaskEnvironment.join("; ")}; ${command}`);

--- a/tools/vite-plus/tasks/generation-cli.ts
+++ b/tools/vite-plus/tasks/generation-cli.ts
@@ -1,4 +1,4 @@
-import { defineTasks, moonScript, noCacheTask, runTask } from "../task-helpers.ts";
+import { defineTasks, moonScript, noCacheTask, runTask, shellCommand } from "../task-helpers.ts";
 
 /**
  * Code generation tasks and local CLI smoke commands.
@@ -18,7 +18,7 @@ export const generationAndCliTasks = defineTasks({
   ),
   gen: noCacheTask(runTask("gen:types")),
   cli: noCacheTask(
-    'sh -c \'if [ "${usage_debug:-$1}" = "true" ] || [ "$1" = "--debug" ]; then cargo install --path crates/vize --force --locked --debug && echo "Installed vize CLI (debug build)"; else cargo install --path crates/vize --force --locked && echo "Installed vize CLI (release build)"; fi\' --',
+    `${shellCommand('if [ "${usage_debug:-$1}" = "true" ] || [ "$1" = "--debug" ]; then cargo install --path crates/vize --force --locked --debug && echo "Installed vize CLI (debug build)"; else cargo install --path crates/vize --force --locked && echo "Installed vize CLI (release build)"; fi')} --`,
   ),
   "cli:help": noCacheTask("vize --help"),
   "cli:example": noCacheTask("vize './**/*.vue' -o . -v"),


### PR DESCRIPTION
## Summary
- normalize macOS task-shell locale when inherited Nix-style C.UTF-8 is unavailable
- route explicit sh -c helpers through a shared shellCommand wrapper so locale is applied before sh starts
- cover locale fallback and shell command generation in tooling tests

## Validation
- ./node_modules/.bin/vp lint
- ./node_modules/.bin/vp check tools/vite-plus/task-shell.ts tools/vite-plus/task-commands.ts tools/vite-plus/task-helpers.ts tools/vite-plus/tasks/generation-cli.ts tests/tooling/task-shell.test.ts
- node --test --test-concurrency=1 tests/tooling/*.test.ts
- env LC_ALL=C.UTF-8 LC_CTYPE=C.UTF-8 LANG=C.UTF-8 ./node_modules/.bin/vp run cli:help

Note: pnpm exec tsgo --noEmit -p tsconfig.node.json still fails on pre-existing tooling type gaps around DOM globals and JS module declarations.