### PR TITLE
refactor(vite-plugin): move request classification into rust

### DIFF
--- a/crates/vize_atelier_sfc/src/lib.rs
+++ b/crates/vize_atelier_sfc/src/lib.rs
@@ -47,6 +47,7 @@ pub mod rewrite_default;
 pub mod script;
 pub mod style;
 pub mod types;
+pub mod vite_plugin;
 
 // Re-exports for public API
 pub use compile::{compile_sfc, ScriptCompileResult};

--- a/crates/vize_atelier_sfc/src/vite_plugin/boundary.rs
+++ b/crates/vize_atelier_sfc/src/vite_plugin/boundary.rs
@@ -1,0 +1,13 @@
+/// Returns the Vue runtime boundary encoded by the SFC filename.
+///
+/// Boundary filenames are resolved before SFC compilation, so keeping this
+/// logic native gives every JS hook the same suffix interpretation.
+pub fn boundary_kind(path: &str) -> Option<&'static str> {
+    if path.ends_with(".client.vue") {
+        Some("client")
+    } else if path.ends_with(".server.vue") {
+        Some("server")
+    } else {
+        None
+    }
+}

--- a/crates/vize_atelier_sfc/src/vite_plugin/mod.rs
+++ b/crates/vize_atelier_sfc/src/vite_plugin/mod.rs
@@ -1,0 +1,16 @@
+//! Native request classification for the Vite plugin.
+//!
+//! Vite hook orchestration stays in TypeScript because it depends on Vite's
+//! async resolver and plugin context. This module owns the deterministic pieces
+//! that are easy to keep fast and strict in Rust: query parsing, virtual module
+//! normalization, style virtual suffixes, and Vue boundary detection.
+
+mod boundary;
+mod query;
+mod request;
+mod style;
+
+#[cfg(test)]
+mod tests;
+
+pub use request::{classify_vite_plugin_request, VitePluginRequest};

--- a/crates/vize_atelier_sfc/src/vite_plugin/query.rs
+++ b/crates/vize_atelier_sfc/src/vite_plugin/query.rs
@@ -1,0 +1,53 @@
+/// Borrowed view of a Vite module ID split at the first query marker.
+pub struct SplitRequest<'a> {
+    /// The path segment before `?`.
+    pub path: &'a str,
+    /// The query segment without the leading `?`.
+    pub query: &'a str,
+    /// The original query suffix including `?`, or an empty string.
+    pub query_suffix: &'a str,
+}
+
+/// Splits a Vite module ID without allocating.
+pub fn split_request(id: &str) -> SplitRequest<'_> {
+    if let Some(query_start) = id.find('?') {
+        SplitRequest {
+            path: &id[..query_start],
+            query: &id[query_start + 1..],
+            query_suffix: &id[query_start..],
+        }
+    } else {
+        SplitRequest {
+            path: id,
+            query: "",
+            query_suffix: "",
+        }
+    }
+}
+
+/// Returns true when the raw query contains `key` as a standalone key.
+pub fn query_has_key(query: &str, key: &str) -> bool {
+    query.split('&').any(|part| query_part_key(part) == key)
+}
+
+/// Returns the raw value for `key` in a Vite query string.
+pub fn query_value<'a>(query: &'a str, key: &str) -> Option<&'a str> {
+    query.split('&').find_map(|part| {
+        let (part_key, value) = part.split_once('=').unwrap_or((part, ""));
+        (part_key == key).then_some(value)
+    })
+}
+
+/// Returns true when `key` exists and exactly matches `expected`.
+pub fn query_value_is(query: &str, key: &str, expected: &str) -> bool {
+    query_value(query, key).is_some_and(|value| value == expected)
+}
+
+/// Parses an unsigned style block index.
+pub fn parse_u32(value: &str) -> Option<u32> {
+    value.parse().ok()
+}
+
+fn query_part_key(part: &str) -> &str {
+    part.split_once('=').map_or(part, |(key, _)| key)
+}

--- a/crates/vize_atelier_sfc/src/vite_plugin/request.rs
+++ b/crates/vize_atelier_sfc/src/vite_plugin/request.rs
@@ -1,0 +1,125 @@
+use vize_carton::String;
+
+use super::{
+    boundary::boundary_kind,
+    query::{query_has_key, query_value_is, split_request},
+    style::classify_style,
+};
+
+const VIZE_SSR_PREFIX: &str = "\0vize-ssr:";
+
+/// Native classification of a Vite plugin module request.
+///
+/// The TypeScript plugin calls this once per hook and then uses the resulting
+/// facts instead of repeatedly reparsing Vite's stringly module IDs.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct VitePluginRequest {
+    /// Path segment before the query string.
+    pub path: String,
+    /// Query suffix including the leading `?`, or an empty string.
+    pub query_suffix: String,
+    /// Path normalized for macro virtual modules (`.vue.ts` -> `.vue`).
+    pub normalized_vue_path: String,
+    /// For `\0...` virtual macro IDs, the real path without the virtual prefix.
+    pub stripped_virtual_path: Option<String>,
+    /// Whether this ID is a Vize-compiled virtual Vue module.
+    pub is_vize_virtual: bool,
+    /// Whether this ID is a Vize SSR virtual Vue module.
+    pub is_vize_ssr_virtual: bool,
+    /// Real `.vue` path extracted from a Vize virtual Vue module ID.
+    pub vize_virtual_path: Option<String>,
+    /// Build-safe ID with Vite's `/@fs` prefix removed when present.
+    pub normalized_fs_id: Option<String>,
+    /// Whether the query contains `macro=true`.
+    pub has_macro_query: bool,
+    /// Whether the query contains `definePage`.
+    pub has_define_page_query: bool,
+    /// Whether this is a `\0` virtual ID carrying a macro query.
+    pub is_macro_virtual_id: bool,
+    /// Whether the request points at a Vue SFC after macro normalization.
+    pub is_vue_sfc_path: bool,
+    /// Whether the request is a Vite Vue style virtual query.
+    pub is_vue_style_query: bool,
+    /// Style block language, defaulting to `css` for style virtual queries.
+    pub style_lang: Option<String>,
+    /// Style block index for style virtual queries.
+    pub style_index: Option<u32>,
+    /// Scoped attribute value for style virtual queries.
+    pub style_scoped: Option<String>,
+    /// Whether the style query carries a CSS modules marker.
+    pub has_style_module: bool,
+    /// Extension suffix Vite should see for the style pipeline.
+    pub style_virtual_suffix: Option<String>,
+    /// Vue boundary file kind: `client`, `server`, or undefined.
+    pub boundary_kind: Option<String>,
+}
+
+/// Classifies a Vite module ID into normalized native facts.
+pub fn classify_vite_plugin_request(id: &str) -> VitePluginRequest {
+    let split = split_request(id);
+    let normalized_vue_path = normalize_vue_path(split.path);
+    let has_macro_query = query_value_is(split.query, "macro", "true");
+    let has_define_page_query = query_has_key(split.query, "definePage");
+    let style = classify_style(split.query);
+    let is_vize_virtual = is_vize_virtual_vue_module_id(id);
+    let is_vize_ssr_virtual = id.starts_with(VIZE_SSR_PREFIX);
+
+    VitePluginRequest {
+        path: String::from(split.path),
+        query_suffix: String::from(split.query_suffix),
+        normalized_vue_path: String::from(normalized_vue_path),
+        stripped_virtual_path: stripped_virtual_query_path(id),
+        is_vize_virtual,
+        is_vize_ssr_virtual,
+        vize_virtual_path: is_vize_virtual.then(|| vize_virtual_path(id)),
+        normalized_fs_id: normalized_fs_id(id),
+        has_macro_query,
+        has_define_page_query,
+        is_macro_virtual_id: id.starts_with('\0') && (has_macro_query || has_define_page_query),
+        is_vue_sfc_path: normalized_vue_path.ends_with(".vue"),
+        is_vue_style_query: style.is_vue_style_query,
+        style_lang: style.lang,
+        style_index: style.index,
+        style_scoped: style.scoped,
+        has_style_module: style.has_module,
+        style_virtual_suffix: style.virtual_suffix,
+        boundary_kind: boundary_kind(normalized_vue_path).map(String::from),
+    }
+}
+
+fn normalize_vue_path(path: &str) -> &str {
+    path.strip_suffix(".ts")
+        .filter(|normalized| normalized.ends_with(".vue"))
+        .unwrap_or(path)
+}
+
+fn stripped_virtual_query_path(id: &str) -> Option<String> {
+    id.strip_prefix('\0').map(|without_prefix| {
+        let split = split_request(without_prefix);
+        String::from(normalize_vue_path(split.path))
+    })
+}
+
+fn is_vize_virtual_vue_module_id(id: &str) -> bool {
+    id.starts_with('\0') && split_request(id).path.ends_with(".vue.ts")
+}
+
+fn vize_virtual_path(id: &str) -> String {
+    let prefix_len = if id.starts_with(VIZE_SSR_PREFIX) {
+        VIZE_SSR_PREFIX.len()
+    } else {
+        1
+    };
+    let without_prefix = &id[prefix_len..];
+    let split = split_request(without_prefix);
+    String::from(normalize_vue_path(split.path))
+}
+
+fn normalized_fs_id(id: &str) -> Option<String> {
+    let split = split_request(id);
+    let path = split.path.strip_prefix("/@fs")?;
+    let mut normalized = String::with_capacity(path.len() + split.query_suffix.len());
+    normalized.push_str(path);
+    normalized.push_str(split.query_suffix);
+    Some(normalized)
+}

--- a/crates/vize_atelier_sfc/src/vite_plugin/style.rs
+++ b/crates/vize_atelier_sfc/src/vite_plugin/style.rs
@@ -1,0 +1,60 @@
+use vize_carton::String;
+
+use super::query::{parse_u32, query_has_key, query_value};
+
+/// Classification result for Vite's Vue style virtual query.
+pub struct StyleRequest {
+    /// Whether the request is a Vue style virtual module.
+    pub is_vue_style_query: bool,
+    /// Style language passed to downstream CSS plugins.
+    pub lang: Option<String>,
+    /// Original SFC style block index.
+    pub index: Option<u32>,
+    /// Scoped CSS id carried by Vue's virtual query.
+    pub scoped: Option<String>,
+    /// Whether the style block is a CSS modules request.
+    pub has_module: bool,
+    /// File extension suffix that lets Vite pick the right style pipeline.
+    pub virtual_suffix: Option<String>,
+}
+
+/// Classifies Vue style virtual query metadata without allocating on misses.
+pub fn classify_style(query: &str) -> StyleRequest {
+    let is_vue_style_query = query.contains("vue&type=style") || query.contains("vue=&type=style");
+    if !is_vue_style_query {
+        return StyleRequest {
+            is_vue_style_query,
+            lang: None,
+            index: None,
+            scoped: None,
+            has_module: false,
+            virtual_suffix: None,
+        };
+    }
+
+    let lang = query_value(query, "lang")
+        .filter(|value| !value.is_empty())
+        .unwrap_or("css");
+    let has_module = query_has_key(query, "module");
+
+    StyleRequest {
+        is_vue_style_query,
+        lang: Some(String::from(lang)),
+        index: query_value(query, "index").and_then(parse_u32),
+        scoped: query_value(query, "scoped")
+            .filter(|value| !value.is_empty())
+            .map(String::from),
+        has_module,
+        virtual_suffix: Some(build_virtual_suffix(lang, has_module)),
+    }
+}
+
+fn build_virtual_suffix(lang: &str, has_module: bool) -> String {
+    let mut suffix = String::with_capacity(lang.len() + if has_module { 9 } else { 1 });
+    suffix.push('.');
+    if has_module {
+        suffix.push_str("module.");
+    }
+    suffix.push_str(lang);
+    suffix
+}

--- a/crates/vize_atelier_sfc/src/vite_plugin/tests.rs
+++ b/crates/vize_atelier_sfc/src/vite_plugin/tests.rs
@@ -1,0 +1,133 @@
+use super::classify_vite_plugin_request;
+
+#[test]
+fn snapshots_macro_define_page_request() {
+    insta::assert_debug_snapshot!(
+        classify_vite_plugin_request("/src/pages/Home.vue?definePage"),
+        @r###"
+        VitePluginRequest {
+            path: "/src/pages/Home.vue",
+            query_suffix: "?definePage",
+            normalized_vue_path: "/src/pages/Home.vue",
+            stripped_virtual_path: None,
+            is_vize_virtual: false,
+            is_vize_ssr_virtual: false,
+            vize_virtual_path: None,
+            normalized_fs_id: None,
+            has_macro_query: false,
+            has_define_page_query: true,
+            is_macro_virtual_id: false,
+            is_vue_sfc_path: true,
+            is_vue_style_query: false,
+            style_lang: None,
+            style_index: None,
+            style_scoped: None,
+            has_style_module: false,
+            style_virtual_suffix: None,
+            boundary_kind: None,
+        }
+        "###
+    );
+}
+
+#[test]
+fn classifies_virtual_macro_paths() {
+    let request = classify_vite_plugin_request("\0/src/pages/Home.vue.ts?macro=true");
+
+    assert_eq!(
+        request.stripped_virtual_path.as_deref(),
+        Some("/src/pages/Home.vue")
+    );
+    assert_eq!(
+        request.normalized_vue_path.as_str(),
+        "\0/src/pages/Home.vue"
+    );
+    assert!(request.is_macro_virtual_id);
+    assert!(request.is_vue_sfc_path);
+    assert!(request.is_vize_virtual);
+    assert_eq!(
+        request.vize_virtual_path.as_deref(),
+        Some("/src/pages/Home.vue")
+    );
+}
+
+#[test]
+fn classifies_ssr_virtual_vue_modules() {
+    let request = classify_vite_plugin_request("\0vize-ssr:/src/pages/Home.vue.ts?used=true");
+
+    assert!(request.is_vize_virtual);
+    assert!(request.is_vize_ssr_virtual);
+    assert_eq!(
+        request.vize_virtual_path.as_deref(),
+        Some("/src/pages/Home.vue")
+    );
+}
+
+#[test]
+fn normalizes_fs_ids_for_build() {
+    let request = classify_vite_plugin_request("/@fs/src/entry.js?import");
+
+    assert_eq!(
+        request.normalized_fs_id.as_deref(),
+        Some("/src/entry.js?import")
+    );
+}
+
+#[test]
+fn snapshots_style_virtual_queries() {
+    insta::assert_debug_snapshot!(
+        classify_vite_plugin_request(
+            "/src/App.vue?vue&type=style&index=2&lang=scss&module&scoped=data-v-test",
+        ),
+        @r###"
+        VitePluginRequest {
+            path: "/src/App.vue",
+            query_suffix: "?vue&type=style&index=2&lang=scss&module&scoped=data-v-test",
+            normalized_vue_path: "/src/App.vue",
+            stripped_virtual_path: None,
+            is_vize_virtual: false,
+            is_vize_ssr_virtual: false,
+            vize_virtual_path: None,
+            normalized_fs_id: None,
+            has_macro_query: false,
+            has_define_page_query: false,
+            is_macro_virtual_id: false,
+            is_vue_sfc_path: true,
+            is_vue_style_query: true,
+            style_lang: Some(
+                "scss",
+            ),
+            style_index: Some(
+                2,
+            ),
+            style_scoped: Some(
+                "data-v-test",
+            ),
+            has_style_module: true,
+            style_virtual_suffix: Some(
+                ".module.scss",
+            ),
+            boundary_kind: None,
+        }
+        "###
+    );
+}
+
+#[test]
+fn classifies_vue_boundaries() {
+    assert_eq!(
+        classify_vite_plugin_request("/src/Foo.client.vue")
+            .boundary_kind
+            .as_deref(),
+        Some("client")
+    );
+    assert_eq!(
+        classify_vite_plugin_request("/src/Foo.server.vue")
+            .boundary_kind
+            .as_deref(),
+        Some("server")
+    );
+    assert!(classify_vite_plugin_request("/src/Foo.vue")
+        .boundary_kind
+        .is_none());
+}

--- a/crates/vize_vitrine/src/napi/mod.rs
+++ b/crates/vize_vitrine/src/napi/mod.rs
@@ -10,6 +10,7 @@
 mod art;
 mod format;
 mod lint;
+mod plugin;
 mod sfc;
 mod template;
 
@@ -20,5 +21,6 @@ pub use napi_typecheck::*;
 pub use art::*;
 pub use format::*;
 pub use lint::*;
+pub use plugin::*;
 pub use sfc::*;
 pub use template::*;

--- a/crates/vize_vitrine/src/napi/plugin/mod.rs
+++ b/crates/vize_vitrine/src/napi/plugin/mod.rs
@@ -1,0 +1,15 @@
+//! N-API bindings for native Vite plugin request classification.
+//!
+//! The actual classification model lives in `vize_atelier_sfc`; vitrine only
+//! converts that Rust shape into the JavaScript-facing N-API object.
+
+#![allow(clippy::disallowed_types)]
+
+mod request;
+
+pub use request::VitePluginRequestNapi;
+
+#[napi_derive::napi(js_name = "classifyVitePluginRequest")]
+pub fn classify_vite_plugin_request(id: String) -> VitePluginRequestNapi {
+    vize_atelier_sfc::vite_plugin::classify_vite_plugin_request(&id).into()
+}

--- a/crates/vize_vitrine/src/napi/plugin/request.rs
+++ b/crates/vize_vitrine/src/napi/plugin/request.rs
@@ -1,0 +1,72 @@
+#![allow(clippy::disallowed_macros)]
+
+use napi_derive::napi;
+use vize_atelier_sfc::vite_plugin::VitePluginRequest;
+
+#[napi(object)]
+pub struct VitePluginRequestNapi {
+    /// Path segment before the query string.
+    pub path: String,
+    /// Query suffix including the leading `?`, or an empty string.
+    pub query_suffix: String,
+    /// Path normalized for macro virtual modules (`.vue.ts` -> `.vue`).
+    pub normalized_vue_path: String,
+    /// For `\0...` virtual macro IDs, the real path without the virtual prefix.
+    pub stripped_virtual_path: Option<String>,
+    /// Whether this ID is a Vize-compiled virtual Vue module.
+    pub is_vize_virtual: bool,
+    /// Whether this ID is a Vize SSR virtual Vue module.
+    pub is_vize_ssr_virtual: bool,
+    /// Real `.vue` path extracted from a Vize virtual Vue module ID.
+    pub vize_virtual_path: Option<String>,
+    /// Build-safe ID with Vite's `/@fs` prefix removed when present.
+    pub normalized_fs_id: Option<String>,
+    /// Whether the query contains `macro=true`.
+    pub has_macro_query: bool,
+    /// Whether the query contains `definePage`.
+    pub has_define_page_query: bool,
+    /// Whether this is a `\0` virtual ID carrying a macro query.
+    pub is_macro_virtual_id: bool,
+    /// Whether the request points at a Vue SFC after macro normalization.
+    pub is_vue_sfc_path: bool,
+    /// Whether the request is a Vite Vue style virtual query.
+    pub is_vue_style_query: bool,
+    /// Style block language, defaulting to `css` for style virtual queries.
+    pub style_lang: Option<String>,
+    /// Style block index for style virtual queries.
+    pub style_index: Option<u32>,
+    /// Scoped attribute value for style virtual queries.
+    pub style_scoped: Option<String>,
+    /// Whether the style query carries a CSS modules marker.
+    pub has_style_module: bool,
+    /// Extension suffix Vite should see for the style pipeline.
+    pub style_virtual_suffix: Option<String>,
+    /// Vue boundary file kind: `client`, `server`, or undefined.
+    pub boundary_kind: Option<String>,
+}
+
+impl From<VitePluginRequest> for VitePluginRequestNapi {
+    fn from(request: VitePluginRequest) -> Self {
+        Self {
+            path: request.path.into(),
+            query_suffix: request.query_suffix.into(),
+            normalized_vue_path: request.normalized_vue_path.into(),
+            stripped_virtual_path: request.stripped_virtual_path.map(Into::into),
+            is_vize_virtual: request.is_vize_virtual,
+            is_vize_ssr_virtual: request.is_vize_ssr_virtual,
+            vize_virtual_path: request.vize_virtual_path.map(Into::into),
+            normalized_fs_id: request.normalized_fs_id.map(Into::into),
+            has_macro_query: request.has_macro_query,
+            has_define_page_query: request.has_define_page_query,
+            is_macro_virtual_id: request.is_macro_virtual_id,
+            is_vue_sfc_path: request.is_vue_sfc_path,
+            is_vue_style_query: request.is_vue_style_query,
+            style_lang: request.style_lang.map(Into::into),
+            style_index: request.style_index,
+            style_scoped: request.style_scoped.map(Into::into),
+            has_style_module: request.has_style_module,
+            style_virtual_suffix: request.style_virtual_suffix.map(Into::into),
+            boundary_kind: request.boundary_kind.map(Into::into),
+        }
+    }
+}

--- a/npm/vite-plugin-vize/src/plugin/load.ts
+++ b/npm/vite-plugin-vize/src/plugin/load.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
+import { classifyVitePluginRequest } from "@vizejs/native";
 import type { TransformResult } from "vite";
 import { transformWithOxc } from "vite";
 
@@ -14,9 +15,6 @@ import { compileFile } from "../compiler.ts";
 import { generateOutput, hasDelegatedStyles } from "../utils/index.ts";
 import { resolveCssImports, scopeCssForPipeline } from "../utils/css.ts";
 import {
-  isVizeVirtual,
-  isVizeSsrVirtual,
-  fromVirtualId,
   LEGACY_VIZE_PREFIX,
   RESOLVED_CSS_MODULE,
   rewriteDynamicTemplateImports,
@@ -33,10 +31,11 @@ export default defineComponent({
 `;
 
 export function getBoundaryPlaceholderCode(realPath: string, ssr: boolean): string | null {
-  if (ssr && realPath.endsWith(".client.vue")) {
+  const boundaryKind = classifyVitePluginRequest(realPath).boundaryKind;
+  if (ssr && boundaryKind === "client") {
     return SERVER_PLACEHOLDER_CODE;
   }
-  if (!ssr && realPath.endsWith(".server.vue")) {
+  if (!ssr && boundaryKind === "server") {
     return SERVER_PLACEHOLDER_CODE;
   }
   return null;
@@ -62,28 +61,6 @@ function getVirtualModuleDefines(
   };
 }
 
-function hasQueryParam(id: string, name: string): boolean {
-  const query = id.split("?")[1];
-  return query ? new URLSearchParams(query).has(name) : false;
-}
-
-function hasMacroQuery(id: string): boolean {
-  const query = id.split("?")[1];
-  return query ? new URLSearchParams(query).get("macro") === "true" : false;
-}
-
-function normalizeMacroRealPath(realPath: string): string {
-  return realPath.endsWith(".vue.ts") ? realPath.slice(0, -3) : realPath;
-}
-
-function isVueSfcPath(realPath: string): boolean {
-  return normalizeMacroRealPath(realPath).endsWith(".vue");
-}
-
-function stripVirtualQuery(id: string): string {
-  return normalizeMacroRealPath(id.slice(1).split("?")[0] ?? "");
-}
-
 function findMacroArtifactModule(
   state: VizePluginState,
   realPath: string,
@@ -91,7 +68,7 @@ function findMacroArtifactModule(
   kind: string,
 ): string | null {
   const cache = getEnvironmentCache(state, ssr);
-  realPath = normalizeMacroRealPath(realPath);
+  realPath = classifyVitePluginRequest(realPath).normalizedVuePath;
   let compiled = cache.get(realPath) ?? state.cache.get(realPath) ?? state.ssrCache.get(realPath);
 
   if (!compiled && fs.existsSync(realPath)) {
@@ -131,6 +108,7 @@ export function loadHook(
 ): string | { code: string; map: null } | null {
   // Pick the correct viteBase for URL resolution based on the build environment.
   const currentBase = loadOptions?.ssr ? state.serverViteBase : state.clientViteBase;
+  const request = classifyVitePluginRequest(id);
 
   // Handle virtual CSS module for production extraction
   if (id === RESOLVED_CSS_MODULE) {
@@ -147,18 +125,16 @@ export function loadHook(
       .replace(/\.\w+$/, ""); // strip .{lang}
   }
 
-  if (styleId.includes("?vue&type=style") || styleId.includes("?vue=&type=style")) {
-    const [filename, queryString] = styleId.split("?");
-    const realPath = isVizeVirtual(filename) ? fromVirtualId(filename) : filename;
-    const params = new URLSearchParams(queryString);
-    const indexStr = params.get("index");
-    const lang = params.get("lang");
-    const _hasModule = params.has("module");
-    const scoped = params.get("scoped");
+  const styleRequest = classifyVitePluginRequest(styleId);
+  if (styleRequest.isVueStyleQuery) {
+    const realPath =
+      classifyVitePluginRequest(styleRequest.path).vizeVirtualPath ?? styleRequest.path;
+    const lang = styleRequest.styleLang ?? null;
+    const scoped = styleRequest.styleScoped ?? null;
 
     const compiled = state.cache.get(realPath);
     const fallbackCompiled = compiled ?? state.ssrCache.get(realPath);
-    const blockIndex = indexStr !== null ? parseInt(indexStr, 10) : -1;
+    const blockIndex = styleRequest.styleIndex ?? -1;
 
     if (
       fallbackCompiled?.styles &&
@@ -215,17 +191,17 @@ export function loadHook(
   }
 
   // Handle Vue Router's ?definePage query through extracted artifacts.
-  if (id.startsWith("\0") && hasQueryParam(id, "definePage")) {
-    const realPath = stripVirtualQuery(id);
-    if (isVueSfcPath(realPath)) {
+  if (id.startsWith("\0") && request.hasDefinePageQuery) {
+    const realPath = request.strippedVirtualPath ?? "";
+    if (request.isVueSfcPath) {
       return loadDefinePageArtifact(state, realPath, !!loadOptions?.ssr);
     }
   }
 
   // Handle ?macro=true queries
-  if (id.startsWith("\0") && hasMacroQuery(id)) {
-    const realPath = stripVirtualQuery(id);
-    if (isVueSfcPath(realPath)) {
+  if (id.startsWith("\0") && request.hasMacroQuery) {
+    const realPath = request.strippedVirtualPath ?? "";
+    if (request.isVueSfcPath) {
       const artifactLoad = loadDefinePageMetaArtifact(state, realPath, !!loadOptions?.ssr);
       if (artifactLoad) {
         return artifactLoad;
@@ -247,9 +223,9 @@ export function loadHook(
   }
 
   // Handle vize virtual modules
-  if (isVizeVirtual(id)) {
-    const realPath = fromVirtualId(id);
-    const isSsr = isVizeSsrVirtual(id) || !!loadOptions?.ssr;
+  if (request.isVizeVirtual) {
+    const realPath = request.vizeVirtualPath ?? "";
+    const isSsr = request.isVizeSsrVirtual || !!loadOptions?.ssr;
 
     if (!realPath.endsWith(".vue")) {
       state.logger.log(`load: skipping non-vue virtual module ${realPath}`);
@@ -324,9 +300,11 @@ export function loadHook(
     if (afterPrefix.includes("?commonjs-")) {
       return null;
     }
-    const [pathPart, queryPart] = afterPrefix.split("?");
-    const querySuffix = queryPart ? `?${queryPart}` : "";
-    const fsPath = pathPart.startsWith("/@fs/") ? pathPart.slice(4) : pathPart;
+    const leakedRequest = classifyVitePluginRequest(afterPrefix);
+    const fsPath = leakedRequest.normalizedFsId
+      ? classifyVitePluginRequest(leakedRequest.normalizedFsId).path
+      : leakedRequest.path;
+    const querySuffix = leakedRequest.querySuffix;
     if (fsPath.startsWith("/") && fs.existsSync(fsPath) && fs.statSync(fsPath).isFile()) {
       const importPath =
         state.server === null
@@ -347,9 +325,11 @@ export async function transformHook(
   id: string,
   options?: { ssr?: boolean },
 ): Promise<TransformResult | null> {
-  const isMacro = id.startsWith("\0") && (hasMacroQuery(id) || hasQueryParam(id, "definePage"));
-  if (isVizeVirtual(id) || isMacro) {
-    const realPath = isMacro ? stripVirtualQuery(id) : fromVirtualId(id);
+  const request = classifyVitePluginRequest(id);
+  if (request.isVizeVirtual || request.isMacroVirtualId) {
+    const realPath = request.isMacroVirtualId
+      ? (request.strippedVirtualPath ?? "")
+      : (request.vizeVirtualPath ?? "");
     try {
       const result = await transformWithOxc(code, realPath, {
         lang: "ts",

--- a/npm/vite-plugin-vize/src/plugin/native.test.ts
+++ b/npm/vite-plugin-vize/src/plugin/native.test.ts
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import { classifyVitePluginRequest } from "@vizejs/native";
+
+{
+  const request = classifyVitePluginRequest("/src/pages/Home.vue?definePage");
+  assert.equal(request.path, "/src/pages/Home.vue");
+  assert.equal(request.querySuffix, "?definePage");
+  assert.equal(request.hasDefinePageQuery, true);
+  assert.equal(request.hasMacroQuery, false);
+  assert.equal(request.isVueSfcPath, true);
+}
+
+{
+  const request = classifyVitePluginRequest("\0/src/pages/Home.vue.ts?macro=true");
+  assert.equal(request.strippedVirtualPath, "/src/pages/Home.vue");
+  assert.equal(request.normalizedVuePath, "\0/src/pages/Home.vue");
+  assert.equal(request.isMacroVirtualId, true);
+  assert.equal(request.isVueSfcPath, true);
+  assert.equal(request.isVizeVirtual, true);
+  assert.equal(request.isVizeSsrVirtual, false);
+  assert.equal(request.vizeVirtualPath, "/src/pages/Home.vue");
+}
+
+{
+  const request = classifyVitePluginRequest("\0vize-ssr:/src/pages/Home.vue.ts?used=true");
+  assert.equal(request.isVizeVirtual, true);
+  assert.equal(request.isVizeSsrVirtual, true);
+  assert.equal(request.vizeVirtualPath, "/src/pages/Home.vue");
+}
+
+{
+  const request = classifyVitePluginRequest("/@fs/src/entry.js?import");
+  assert.equal(request.normalizedFsId, "/src/entry.js?import");
+}
+
+{
+  const request = classifyVitePluginRequest(
+    "/src/App.vue?vue&type=style&index=2&lang=scss&module&scoped=data-v-test",
+  );
+  assert.equal(request.isVueStyleQuery, true);
+  assert.equal(request.styleLang, "scss");
+  assert.equal(request.styleIndex, 2);
+  assert.equal(request.styleScoped, "data-v-test");
+  assert.equal(request.hasStyleModule, true);
+  assert.equal(request.styleVirtualSuffix, ".module.scss");
+}
+
+{
+  assert.equal(classifyVitePluginRequest("/src/Foo.client.vue").boundaryKind, "client");
+  assert.equal(classifyVitePluginRequest("/src/Foo.server.vue").boundaryKind, "server");
+  assert.equal(classifyVitePluginRequest("/src/Foo.vue").boundaryKind ?? undefined, undefined);
+}

--- a/npm/vite-plugin-vize/src/plugin/resolve.ts
+++ b/npm/vite-plugin-vize/src/plugin/resolve.ts
@@ -1,17 +1,14 @@
 import path from "node:path";
 import fs from "node:fs";
 import { createRequire } from "node:module";
+import { classifyVitePluginRequest } from "@vizejs/native";
 
 import type { VizePluginState } from "./state.ts";
 import {
   LEGACY_VIZE_PREFIX,
   VIRTUAL_CSS_MODULE,
   RESOLVED_CSS_MODULE,
-  isVizeVirtual,
-  isVizeSsrVirtual,
   toVirtualId,
-  fromVirtualId,
-  normalizeFsIdForBuild,
 } from "../virtual.ts";
 
 export function resolveVuePath(state: VizePluginState, id: string, importer?: string): string {
@@ -27,8 +24,9 @@ export function resolveVuePath(state: VizePluginState, id: string, importer?: st
   } else if (path.isAbsolute(id)) {
     resolved = id;
   } else if (importer) {
-    // If importer is a virtual module, extract the real path
-    const realImporter = isVizeVirtual(importer) ? fromVirtualId(importer) : importer;
+    const importerRequest = classifyVitePluginRequest(importer);
+    const realImporter =
+      importerRequest.vizeVirtualPath ?? importerRequest.strippedVirtualPath ?? importer;
     resolved = path.resolve(path.dirname(realImporter), id);
   } else {
     // Relative path without importer - resolve from root
@@ -49,34 +47,17 @@ interface ResolveContext {
   ): Promise<{ id: string } | null>;
 }
 
-function hasQueryParam(id: string, name: string): boolean {
-  const query = id.split("?")[1];
-  return query ? new URLSearchParams(query).has(name) : false;
-}
-
-function hasMacroQuery(id: string): boolean {
-  const query = id.split("?")[1];
-  return query ? new URLSearchParams(query).get("macro") === "true" : false;
-}
-
-function isMacroVirtualId(id: string): boolean {
-  return id.startsWith("\0") && (hasMacroQuery(id) || hasQueryParam(id, "definePage"));
-}
-
-function isVueSfcPath(id: string): boolean {
-  return (id.split("?")[0] ?? id).endsWith(".vue");
-}
-
 function normalizeRequireBase(importer?: string): string | null {
   if (!importer) {
     return null;
   }
 
   let normalized = importer;
-  if (isVizeVirtual(normalized)) {
-    normalized = fromVirtualId(normalized);
-  } else if (isMacroVirtualId(normalized)) {
-    normalized = normalized.slice(1).split("?")[0] ?? "";
+  const request = classifyVitePluginRequest(normalized);
+  if (request.vizeVirtualPath) {
+    normalized = request.vizeVirtualPath;
+  } else if (request.isMacroVirtualId) {
+    normalized = request.strippedVirtualPath ?? "";
   }
 
   return normalized.split("?")[0] ?? null;
@@ -271,14 +252,16 @@ export async function resolveIdHook(
   options?: { ssr?: boolean },
 ): Promise<string | { id: string } | null | undefined> {
   const isBuild = state.server === null;
-  const isSsrRequest = !!options?.ssr || (importer ? isVizeSsrVirtual(importer) : false);
+  const importerRequest = importer ? classifyVitePluginRequest(importer) : null;
+  const isSsrRequest = !!options?.ssr || (importerRequest?.isVizeSsrVirtual ?? false);
+  const request = classifyVitePluginRequest(id);
 
   // Skip all virtual module IDs
   if (id.startsWith("\0")) {
     // This is one of our .vue.ts virtual modules -- pass through
-    if (isVizeVirtual(id)) {
-      if (isSsrRequest && !isVizeSsrVirtual(id)) {
-        return toVirtualId(fromVirtualId(id), true);
+    if (request.isVizeVirtual) {
+      if (isSsrRequest && !request.isVizeSsrVirtual && request.vizeVirtualPath) {
+        return toVirtualId(request.vizeVirtualPath, true);
       }
       return null;
     }
@@ -304,7 +287,9 @@ export async function resolveIdHook(
         `resolveId: redirecting \0-prefixed non-vue ID to ${pathPart}${querySuffix}`,
       );
       const redirected = pathPart + querySuffix;
-      return isBuild ? normalizeFsIdForBuild(redirected) : redirected;
+      return isBuild
+        ? (classifyVitePluginRequest(redirected).normalizedFsId ?? redirected)
+        : redirected;
     }
     return null;
   }
@@ -317,8 +302,9 @@ export async function resolveIdHook(
     }
     state.logger.log(`resolveId: redirecting stale vize: ID to ${realPath}`);
     const resolved = await ctx.resolve(realPath, importer, { skipSelf: true });
-    if (resolved && isBuild && resolved.id.startsWith("/@fs/")) {
-      return { ...resolved, id: normalizeFsIdForBuild(resolved.id) };
+    const normalizedFsId = resolved ? classifyVitePluginRequest(resolved.id).normalizedFsId : null;
+    if (resolved && isBuild && normalizedFsId) {
+      return { ...resolved, id: normalizedFsId };
     }
     return resolved;
   }
@@ -328,8 +314,8 @@ export async function resolveIdHook(
     return RESOLVED_CSS_MODULE;
   }
 
-  if (isBuild && id.startsWith("/@fs/")) {
-    return normalizeFsIdForBuild(id);
+  if (isBuild && request.normalizedFsId) {
+    return request.normalizedFsId;
   }
 
   // Handle route macro queries.
@@ -338,37 +324,27 @@ export async function resolveIdHook(
   // Nuxt's router generates `import { default } from "page.vue?macro=true"` to extract
   // route metadata. Without @vitejs/plugin-vue, Vize must resolve this query so the
   // load hook can return compile-time macro artifact modules.
-  if ((hasMacroQuery(id) || hasQueryParam(id, "definePage")) && isVueSfcPath(id)) {
-    const filePath = id.split("?")[0];
-    const querySuffix = id.slice(id.indexOf("?"));
-    const resolved = resolveVuePath(state, filePath, importer);
+  if ((request.hasMacroQuery || request.hasDefinePageQuery) && request.isVueSfcPath) {
+    const resolved = resolveVuePath(state, request.path, importer);
     if (resolved && fs.existsSync(resolved)) {
-      return `\0${resolved}${querySuffix}`;
+      return `\0${resolved}${request.querySuffix}`;
     }
   }
 
   // Handle virtual style imports:
   //   Component.vue?vue&type=style&index=0&lang=scss
   //   Component.vue?vue&type=style&index=0&lang=scss&module
-  if (id.includes("?vue&type=style") || id.includes("?vue=&type=style")) {
-    const params = new URLSearchParams(id.split("?")[1]);
-    const lang = params.get("lang") || "css";
-    if (params.has("module")) {
-      // For CSS Modules, append .module.{lang} suffix so Vite's CSS pipeline
-      // automatically treats it as a CSS module and returns the class mapping.
-      return `\0${id}.module.${lang}`;
-    }
-    // Append .{lang} suffix so Vite's CSS pipeline recognizes the file type
-    // and applies the appropriate preprocessor (SCSS, Less, etc.).
-    return `\0${id}.${lang}`;
+  if (request.isVueStyleQuery && request.styleVirtualSuffix) {
+    return `\0${id}${request.styleVirtualSuffix}`;
   }
 
   // If importer is a vize virtual module or macro module, resolve imports against the real path
-  const isMacroImporter = importer ? isMacroVirtualId(importer) : false;
-  if (importer && (isVizeVirtual(importer) || isMacroImporter)) {
+  const isMacroImporter = importerRequest?.isMacroVirtualId ?? false;
+  const isVizeVirtualImporter = importerRequest?.isVizeVirtual ?? false;
+  if (importer && (isVizeVirtualImporter || isMacroImporter)) {
     const cleanImporter = isMacroImporter
-      ? importer.slice(1).split("?")[0]!
-      : fromVirtualId(importer);
+      ? (importerRequest?.strippedVirtualPath ?? "")
+      : (importerRequest?.vizeVirtualPath ?? "");
 
     state.logger.log(`resolveId from virtual: id=${id}, cleanImporter=${cleanImporter}`);
 
@@ -402,8 +378,9 @@ export async function resolveIdHook(
           const resolved = await ctx.resolve(id, cleanImporter, { skipSelf: true });
           if (resolved) {
             state.logger.log(`resolveId: resolved bare ${id} to ${resolved.id} via Vite resolver`);
-            if (isBuild && resolved.id.startsWith("/@fs/")) {
-              return { ...resolved, id: normalizeFsIdForBuild(resolved.id) };
+            const normalizedFsId = classifyVitePluginRequest(resolved.id).normalizedFsId;
+            if (isBuild && normalizedFsId) {
+              return { ...resolved, id: normalizedFsId };
             }
 
             const nodeResolved = resolveBareImportCandidatesWithNode(
@@ -440,8 +417,9 @@ export async function resolveIdHook(
               state.logger.log(
                 `resolveId: resolved aliased bare ${id} to ${resolved.id} via Vite resolver`,
               );
-              if (isBuild && resolved.id.startsWith("/@fs/")) {
-                return { ...resolved, id: normalizeFsIdForBuild(resolved.id) };
+              const normalizedFsId = classifyVitePluginRequest(resolved.id).normalizedFsId;
+              if (isBuild && normalizedFsId) {
+                return { ...resolved, id: normalizedFsId };
               }
 
               const nodeResolved = resolveBareImportCandidatesWithNode(
@@ -486,8 +464,9 @@ export async function resolveIdHook(
         const resolved = await ctx.resolve(id, cleanImporter, { skipSelf: true });
         if (resolved) {
           state.logger.log(`resolveId: resolved ${id} to ${resolved.id} via Vite resolver`);
-          if (isBuild && resolved.id.startsWith("/@fs/")) {
-            return { ...resolved, id: normalizeFsIdForBuild(resolved.id) };
+          const normalizedFsId = classifyVitePluginRequest(resolved.id).normalizedFsId;
+          if (isBuild && normalizedFsId) {
+            return { ...resolved, id: normalizedFsId };
           }
           return resolved;
         }

--- a/npm/vite-plugin-vize/src/test.ts
+++ b/npm/vite-plugin-vize/src/test.ts
@@ -3,6 +3,7 @@ import "./compiler.test.ts";
 import "./utils.test.ts";
 import "./plugin/compat.test.ts";
 import "./plugin/load.test.ts";
+import "./plugin/native.test.ts";
 import "./plugin/resolve.test.ts";
 import "./plugin/state.test.ts";
 import "./plugin/unocss.test.ts";

--- a/npm/vize-native/index.d.ts
+++ b/npm/vize-native/index.d.ts
@@ -166,6 +166,13 @@ export interface CatalogOutputNapi {
   tags: Array<string>;
 }
 
+/**
+ * Classify a Vite plugin module request using the native Vize request model.
+ * This keeps pure query parsing and virtual module categorization in Rust while
+ * JavaScript keeps Vite hook orchestration and filesystem interactions.
+ */
+export declare function classifyVitePluginRequest(id: string): VitePluginRequestNapi;
+
 /** Compile Vue template to VDom render function */
 export declare function compile(
   template: string,
@@ -646,6 +653,47 @@ export interface TypeCheckResultNapi {
   errorCount: number;
   warningCount: number;
   analysisTimeMs?: number;
+}
+
+export interface VitePluginRequestNapi {
+  /** Path segment before the query string. */
+  path: string;
+  /** Query suffix including the leading `?`, or an empty string. */
+  querySuffix: string;
+  /** Path normalized for macro virtual modules (`.vue.ts` -> `.vue`). */
+  normalizedVuePath: string;
+  /** For `\0...` virtual macro IDs, the real path without the virtual prefix. */
+  strippedVirtualPath?: string;
+  /** Whether this ID is a Vize-compiled virtual Vue module. */
+  isVizeVirtual: boolean;
+  /** Whether this ID is a Vize SSR virtual Vue module. */
+  isVizeSsrVirtual: boolean;
+  /** Real `.vue` path extracted from a Vize virtual Vue module ID. */
+  vizeVirtualPath?: string;
+  /** Build-safe ID with Vite's `/@fs` prefix removed when present. */
+  normalizedFsId?: string;
+  /** Whether the query contains `macro=true`. */
+  hasMacroQuery: boolean;
+  /** Whether the query contains `definePage`. */
+  hasDefinePageQuery: boolean;
+  /** Whether this is a `\0` virtual ID carrying a macro query. */
+  isMacroVirtualId: boolean;
+  /** Whether the request points at a Vue SFC after macro normalization. */
+  isVueSfcPath: boolean;
+  /** Whether the request is a Vite Vue style virtual query. */
+  isVueStyleQuery: boolean;
+  /** Style block language, defaulting to `css` for style virtual queries. */
+  styleLang?: string;
+  /** Style block index for style virtual queries. */
+  styleIndex?: number;
+  /** Scoped attribute value for style virtual queries. */
+  styleScoped?: string;
+  /** Whether the style query carries a CSS modules marker. */
+  hasStyleModule: boolean;
+  /** Extension suffix Vite should see for the style pipeline. */
+  styleVirtualSuffix?: string;
+  /** Vue boundary file kind: `client`, `server`, or undefined. */
+  boundaryKind?: string;
 }
 
 /** Type diagnostic for NAPI */


### PR DESCRIPTION
## Summary
- Add a `vize_atelier_sfc::vite_plugin` request classifier for Vite module IDs, split into small query/style/boundary/request modules.
- Keep `vize_vitrine` as the N-API binding layer by converting the Rust request model into the JS-facing object.
- Thin the Vite plugin hooks so virtual module, macro query, style query, boundary, and `/@fs` handling consume native classifier fields.

## Validation
- `cargo fmt --package vize_atelier_sfc --package vize_vitrine`
- `TMPDIR=$PWD/__agent_only/tmp cargo test -p vize_atelier_sfc vite_plugin::tests`
- `TMPDIR=$PWD/__agent_only/tmp cargo check -p vize_vitrine --features napi --lib`
- `TMPDIR=$PWD/__agent_only/tmp cargo clippy -p vize_atelier_sfc -p vize_vitrine --features vize_vitrine/napi --lib`
- `pnpm exec vp check --fix npm/vite-plugin-vize/src/plugin/load.ts npm/vite-plugin-vize/src/plugin/resolve.ts npm/vite-plugin-vize/src/plugin/native.test.ts npm/vite-plugin-vize/src/test.ts npm/vize-native/index.d.ts`
- `TMPDIR=$PWD/__agent_only/tmp pnpm exec tsgo --ignoreConfig --noEmit --target ES2022 --module NodeNext --moduleResolution NodeNext --types node --strict --skipLibCheck --isolatedModules --verbatimModuleSyntax --allowImportingTsExtensions npm/vite-plugin-vize/src/plugin/load.ts npm/vite-plugin-vize/src/plugin/resolve.ts npm/vite-plugin-vize/src/plugin/native.test.ts npm/vite-plugin-vize/src/compiler.ts npm/vite-plugin-vize/src/types.ts npm/vite-plugin-vize/src/virtual.ts npm/vite-plugin-vize/src/transform.ts npm/vite-plugin-vize/src/utils/index.ts npm/vite-plugin-vize/src/utils/css.ts`
- `git diff --check`
