### PR TITLE
fix(patina): tighten floating promise handlers

### DIFF
--- a/crates/vize_patina/src/linter/native_type_aware/parsing.rs
+++ b/crates/vize_patina/src/linter/native_type_aware/parsing.rs
@@ -1,6 +1,6 @@
 use oxc_allocator::Allocator as OxcAllocator;
 use oxc_ast::ast::{
-    CallExpression, ChainElement, Expression, ExpressionStatement, ObjectExpression,
+    Argument, CallExpression, ChainElement, Expression, ExpressionStatement, ObjectExpression,
     ObjectPropertyKind, PropertyKey, Statement,
 };
 use oxc_ast_visit::{walk::walk_expression_statement, Visit};
@@ -175,8 +175,23 @@ fn is_handled_call(call: &CallExpression<'_>) -> bool {
     };
 
     match member.static_property_name() {
-        Some("then" | "catch") => true,
+        Some("then") => has_present_handler_argument(call, 1),
+        Some("catch") => has_present_handler_argument(call, 0),
         Some("finally") => is_handled_promise_chain(member.object()),
+        _ => false,
+    }
+}
+
+fn has_present_handler_argument(call: &CallExpression<'_>, index: usize) -> bool {
+    call.arguments
+        .get(index)
+        .is_some_and(|argument| !is_missing_handler_argument(argument))
+}
+
+fn is_missing_handler_argument(argument: &Argument<'_>) -> bool {
+    match argument {
+        Argument::Identifier(identifier) => identifier.name == "undefined",
+        Argument::NullLiteral(_) => true,
         _ => false,
     }
 }

--- a/crates/vize_patina/src/linter/native_type_aware/template_queries/calls.rs
+++ b/crates/vize_patina/src/linter/native_type_aware/template_queries/calls.rs
@@ -1,5 +1,5 @@
 use oxc_allocator::Allocator as OxcAllocator;
-use oxc_ast::ast::{CallExpression, ChainElement, Expression, ExpressionStatement};
+use oxc_ast::ast::{Argument, CallExpression, ChainElement, Expression, ExpressionStatement};
 use oxc_ast_visit::{
     walk::{walk_call_expression, walk_expression_statement},
     Visit,
@@ -57,6 +57,11 @@ pub(super) fn collect_template_call_ranges(
             ranges.callees = collector.into_relative_ranges(0, source.len() as u32);
         }
         if include_floating_promises {
+            if allow_statement_fallback {
+                if let Some(range) = bare_handler_reference_range_for_expression(&expression) {
+                    ranges.floating_promises.push(range);
+                }
+            }
             if expression.span().end as usize == source.trim_end().len() {
                 profile!(
                     "patina.type_aware.template_floating.visit_expression",
@@ -86,6 +91,35 @@ pub(super) fn collect_template_call_ranges(
     }
 
     ranges
+}
+
+fn bare_handler_reference_range_for_expression(
+    expression: &Expression<'_>,
+) -> Option<FloatingPromiseRange> {
+    match expression {
+        Expression::Identifier(_) => {
+            let span = expression.span();
+            Some(FloatingPromiseRange {
+                start: span.start,
+                end: span.end,
+                probe_start: span.start,
+                probe_end: span.end,
+            })
+        }
+        Expression::ParenthesizedExpression(paren) => {
+            bare_handler_reference_range_for_expression(&paren.expression)
+        }
+        Expression::TSAsExpression(ts_as) => {
+            bare_handler_reference_range_for_expression(&ts_as.expression)
+        }
+        Expression::TSSatisfiesExpression(ts_satisfies) => {
+            bare_handler_reference_range_for_expression(&ts_satisfies.expression)
+        }
+        Expression::TSNonNullExpression(ts_non_null) => {
+            bare_handler_reference_range_for_expression(&ts_non_null.expression)
+        }
+        _ => None,
+    }
 }
 
 fn collect_statement_call_callee_ranges(
@@ -338,8 +372,23 @@ fn is_handled_call(call: &CallExpression<'_>) -> bool {
     };
 
     match member.static_property_name() {
-        Some("then" | "catch") => true,
+        Some("then") => has_present_handler_argument(call, 1),
+        Some("catch") => has_present_handler_argument(call, 0),
         Some("finally") => is_handled_promise_chain(member.object()),
+        _ => false,
+    }
+}
+
+fn has_present_handler_argument(call: &CallExpression<'_>, index: usize) -> bool {
+    call.arguments
+        .get(index)
+        .is_some_and(|argument| !is_missing_handler_argument(argument))
+}
+
+fn is_missing_handler_argument(argument: &Argument<'_>) -> bool {
+    match argument {
+        Argument::Identifier(identifier) => identifier.name == "undefined",
+        Argument::NullLiteral(_) => true,
         _ => false,
     }
 }
@@ -426,6 +475,55 @@ mod tests {
         assert_eq!(
             promise_slices(source, &ranges.floating_promises),
             vec!["save()", "track()"]
+        );
+    }
+
+    #[test]
+    fn collects_bare_event_handler_references_as_floating_candidates() {
+        let source = "save";
+        let ranges = collect_template_call_ranges(source, true, false, true);
+
+        assert_eq!(
+            promise_slices(source, &ranges.floating_promises),
+            vec!["save"]
+        );
+    }
+
+    #[test]
+    fn ignores_bare_references_without_event_fallback() {
+        let source = "save";
+        let ranges = collect_template_call_ranges(source, false, false, true);
+
+        assert!(ranges.floating_promises.is_empty());
+    }
+
+    #[test]
+    fn reports_then_without_rejection_handler_as_floating() {
+        let source = "save().then(() => {})";
+        let ranges = collect_template_call_ranges(source, false, false, true);
+
+        assert_eq!(
+            promise_slices(source, &ranges.floating_promises),
+            vec!["save().then(() => {})"]
+        );
+    }
+
+    #[test]
+    fn ignores_then_with_rejection_handler() {
+        let source = "save().then(() => {}, report)";
+        let ranges = collect_template_call_ranges(source, false, false, true);
+
+        assert!(ranges.floating_promises.is_empty());
+    }
+
+    #[test]
+    fn reports_empty_catch_as_floating() {
+        let source = "save().catch()";
+        let ranges = collect_template_call_ranges(source, false, false, true);
+
+        assert_eq!(
+            promise_slices(source, &ranges.floating_promises),
+            vec!["save().catch()"]
         );
     }
 }

--- a/crates/vize_patina/src/linter/native_type_aware/tests.rs
+++ b/crates/vize_patina/src/linter/native_type_aware/tests.rs
@@ -151,6 +151,72 @@ loadData().catch(report).finally(cleanup)
 }
 
 #[test]
+fn then_without_rejection_handler_reports_floating_promise() {
+    if !corsa_available() {
+        return;
+    }
+
+    let linter = Linter::with_preset(LintPreset::Opinionated);
+    let source = r#"<script setup lang="ts">
+async function loadData(): Promise<number> {
+  return 1
+}
+
+loadData().then((value) => console.log(value))
+</script>"#;
+    let result = lint_sfc_with_corsa(&linter, source, "Component.vue");
+    assert!(result
+        .diagnostics
+        .iter()
+        .any(|diag| diag.rule_name == RULE_NO_FLOATING_PROMISES));
+}
+
+#[test]
+fn then_with_rejection_handler_is_ignored() {
+    if !corsa_available() {
+        return;
+    }
+
+    let linter = Linter::with_preset(LintPreset::Opinionated);
+    let source = r#"<script setup lang="ts">
+async function loadData(): Promise<number> {
+  return 1
+}
+function report(error: unknown) {
+  console.error(error)
+}
+
+loadData().then((value) => console.log(value), report)
+</script>"#;
+    let result = lint_sfc_with_corsa(&linter, source, "Component.vue");
+    assert!(!result
+        .diagnostics
+        .iter()
+        .any(|diag| diag.rule_name == RULE_NO_FLOATING_PROMISES));
+}
+
+#[test]
+fn catch_without_handler_reports_floating_promise() {
+    if !corsa_available() {
+        return;
+    }
+
+    let linter = Linter::with_preset(LintPreset::Opinionated);
+    let source = r#"<script setup lang="ts">
+async function loadData(): Promise<number> {
+  return 1
+}
+
+loadData().catch()
+</script>"#;
+    let result = lint_sfc_with_corsa(&linter, source, "Component.vue");
+    assert!(result
+        .diagnostics
+        .iter()
+        .any(|diag| diag.rule_name == RULE_NO_FLOATING_PROMISES));
+}
+
+#[test]
 fn no_floating_promises_reports_template_event_calls() {
     if !corsa_available() {
         return;
@@ -163,6 +229,27 @@ async function save(): Promise<void> {}
 
 <template>
   <button @click="save()">Save</button>
+</template>"#;
+    let result = lint_sfc_with_corsa(&linter, source, "Component.vue");
+    assert!(result.diagnostics.iter().any(|diag| {
+        diag.rule_name == RULE_NO_FLOATING_PROMISES
+            && diag.message.contains("Template event handler")
+    }));
+}
+
+#[test]
+fn no_floating_promises_reports_bare_template_event_handlers() {
+    if !corsa_available() {
+        return;
+    }
+
+    let linter = Linter::with_preset(LintPreset::Opinionated);
+    let source = r#"<script setup lang="ts">
+async function save(): Promise<void> {}
+</script>
+
+<template>
+  <button @click="save">Save</button>
 </template>"#;
     let result = lint_sfc_with_corsa(&linter, source, "Component.vue");
     assert!(result.diagnostics.iter().any(|diag| {
@@ -523,6 +610,27 @@ async function save(): Promise<void> {}
         .diagnostics
         .iter()
         .any(|diag| diag.rule_name == RULE_NO_FLOATING_PROMISES));
+}
+
+#[test]
+fn template_then_without_rejection_handler_reports_floating_promise() {
+    if !corsa_available() {
+        return;
+    }
+
+    let linter = Linter::with_preset(LintPreset::Opinionated);
+    let source = r#"<script setup lang="ts">
+async function save(): Promise<void> {}
+</script>
+
+<template>
+  <button @click="save().then(() => {})">Save</button>
+</template>"#;
+    let result = lint_sfc_with_corsa(&linter, source, "Component.vue");
+    assert!(result.diagnostics.iter().any(|diag| {
+        diag.rule_name == RULE_NO_FLOATING_PROMISES
+            && diag.message.contains("Template event handler")
+    }));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- treat `.then(...)` as handled only when it includes a rejection handler
- keep `.catch(...)` handled only when it receives a real handler, so empty/null/undefined catches still report
- report async bare Vue event handler references like `@click="save"` after Corsa confirms the handler returns a Promise
- add script/template regression coverage for these no-floating-promises edge cases

## Validation
- TMPDIR=$PWD/__agent_only/tmp cargo test -p vize_patina linter::native_type_aware -- --nocapture
- TMPDIR=$PWD/__agent_only/tmp cargo clippy -p vize_patina -- -D warnings
- ./node_modules/.bin/vp lint
- git diff --check
