### PR TITLE
fix(type-aware): catch member event promise handlers

### DIFF
--- a/crates/vize_croquis/src/virtual_ts/generator/template.rs
+++ b/crates/vize_croquis/src/virtual_ts/generator/template.rs
@@ -69,7 +69,8 @@ impl VirtualTsGenerator {
     pub(crate) fn emit_template_scope(&mut self, ast: &RootNode, bindings: &BindingMetadata) {
         self.emit_line("");
         self.emit_line("// Template scope (inherits from setup)");
-        self.emit_line("(function __template() {");
+        // Keep the template IIFE from being parsed as a call on the last setup expression.
+        self.emit_line(";(function __template() {");
         self.indent_level += 1;
 
         // Declare refs for template ref access

--- a/crates/vize_croquis/src/virtual_ts/snapshots/vize_croquis__virtual_ts__tests__snapshot_full_sfc.snap
+++ b/crates/vize_croquis/src/virtual_ts/snapshots/vize_croquis__virtual_ts__tests__snapshot_full_sfc.snap
@@ -46,7 +46,7 @@ function __setup() {
   const increment = () => count.value++
   
   // Template scope (inherits from setup)
-  (function __template() {
+  ;(function __template() {
     // Template refs (auto-unwrapped)
     const __unwrapped_count = count.value;
     

--- a/crates/vize_patina/src/linter/native_type_aware/template_queries/calls.rs
+++ b/crates/vize_patina/src/linter/native_type_aware/template_queries/calls.rs
@@ -97,14 +97,10 @@ fn bare_handler_reference_range_for_expression(
     expression: &Expression<'_>,
 ) -> Option<FloatingPromiseRange> {
     match expression {
-        Expression::Identifier(_) => {
-            let span = expression.span();
-            Some(FloatingPromiseRange {
-                start: span.start,
-                end: span.end,
-                probe_start: span.start,
-                probe_end: span.end,
-            })
+        Expression::Identifier(_) => Some(floating_promise_range_from_span(expression.span())),
+        Expression::StaticMemberExpression(member) => {
+            is_static_member_handler_reference(&member.object)
+                .then(|| floating_promise_range_from_span(expression.span()))
         }
         Expression::ParenthesizedExpression(paren) => {
             bare_handler_reference_range_for_expression(&paren.expression)
@@ -119,6 +115,25 @@ fn bare_handler_reference_range_for_expression(
             bare_handler_reference_range_for_expression(&ts_non_null.expression)
         }
         _ => None,
+    }
+}
+
+fn is_static_member_handler_reference(expression: &Expression<'_>) -> bool {
+    match expression {
+        Expression::Identifier(_) | Expression::ThisExpression(_) => true,
+        Expression::StaticMemberExpression(member) => {
+            is_static_member_handler_reference(&member.object)
+        }
+        _ => false,
+    }
+}
+
+fn floating_promise_range_from_span(span: Span) -> FloatingPromiseRange {
+    FloatingPromiseRange {
+        start: span.start,
+        end: span.end,
+        probe_start: span.start,
+        probe_end: span.end,
     }
 }
 
@@ -486,6 +501,17 @@ mod tests {
         assert_eq!(
             promise_slices(source, &ranges.floating_promises),
             vec!["save"]
+        );
+    }
+
+    #[test]
+    fn collects_member_event_handler_references_as_floating_candidates() {
+        let source = "actions.save";
+        let ranges = collect_template_call_ranges(source, true, false, true);
+
+        assert_eq!(
+            promise_slices(source, &ranges.floating_promises),
+            vec!["actions.save"]
         );
     }
 

--- a/crates/vize_patina/src/linter/native_type_aware/tests.rs
+++ b/crates/vize_patina/src/linter/native_type_aware/tests.rs
@@ -259,6 +259,52 @@ async function save(): Promise<void> {}
 }
 
 #[test]
+fn no_floating_promises_reports_member_template_event_handlers() {
+    if !corsa_available() {
+        return;
+    }
+
+    let linter = Linter::with_preset(LintPreset::Opinionated);
+    let source = r#"<script setup lang="ts">
+const actions = {
+  async save(): Promise<void> {}
+}
+</script>
+
+<template>
+  <button @click="actions.save">Save</button>
+</template>"#;
+    let result = lint_sfc_with_corsa(&linter, source, "Component.vue");
+    assert!(result.diagnostics.iter().any(|diag| {
+        diag.rule_name == RULE_NO_FLOATING_PROMISES
+            && diag.message.contains("Template event handler")
+    }));
+}
+
+#[test]
+fn no_floating_promises_ignores_sync_member_template_event_handlers() {
+    if !corsa_available() {
+        return;
+    }
+
+    let linter = Linter::with_preset(LintPreset::Opinionated);
+    let source = r#"<script setup lang="ts">
+const actions = {
+  save(): void {}
+}
+</script>
+
+<template>
+  <button @click="actions.save">Save</button>
+</template>"#;
+    let result = lint_sfc_with_corsa(&linter, source, "Component.vue");
+    assert!(!result
+        .diagnostics
+        .iter()
+        .any(|diag| diag.rule_name == RULE_NO_FLOATING_PROMISES));
+}
+
+#[test]
 fn no_floating_promises_reports_template_interpolations() {
     if !corsa_available() {
         return;


### PR DESCRIPTION
## Summary
- keep the generated template IIFE behind a statement boundary so trailing setup expressions do not swallow it through ASI
- collect static member event handler references as floating-promise candidates
- add async and sync member-handler coverage for the template rule

## Validation
- TMPDIR=$PWD/__agent_only/tmp cargo test -p vize_patina linter::native_type_aware -- --nocapture
- TMPDIR=$PWD/__agent_only/tmp cargo test -p vize_croquis virtual_ts::tests::test_snapshot_full_sfc -- --nocapture
- TMPDIR=$PWD/__agent_only/tmp cargo clippy -p vize_patina -p vize_croquis -- -D warnings
- ./node_modules/.bin/vp lint
- git diff --check