### PR TITLE
fix(type-aware): catch optional event promise handlers

### DIFF
--- a/crates/vize_patina/src/linter/native_type_aware/template_queries/calls.rs
+++ b/crates/vize_patina/src/linter/native_type_aware/template_queries/calls.rs
@@ -98,9 +98,10 @@ fn bare_handler_reference_range_for_expression(
 ) -> Option<FloatingPromiseRange> {
     match expression {
         Expression::Identifier(_) => Some(floating_promise_range_from_span(expression.span())),
-        Expression::StaticMemberExpression(member) => {
-            is_static_member_handler_reference(&member.object)
-                .then(|| floating_promise_range_from_span(expression.span()))
+        Expression::StaticMemberExpression(member) => is_member_handler_reference(&member.object)
+            .then(|| floating_promise_range_from_span(expression.span())),
+        Expression::ChainExpression(chain) => {
+            chain_member_handler_reference_range(chain, expression.span())
         }
         Expression::ParenthesizedExpression(paren) => {
             bare_handler_reference_range_for_expression(&paren.expression)
@@ -118,12 +119,33 @@ fn bare_handler_reference_range_for_expression(
     }
 }
 
-fn is_static_member_handler_reference(expression: &Expression<'_>) -> bool {
+fn chain_member_handler_reference_range(
+    chain: &oxc_ast::ast::ChainExpression<'_>,
+    span: Span,
+) -> Option<FloatingPromiseRange> {
+    match &chain.expression {
+        ChainElement::StaticMemberExpression(member) => is_member_handler_reference(&member.object)
+            .then(|| floating_promise_range_from_span(span)),
+        ChainElement::TSNonNullExpression(non_null) => {
+            bare_handler_reference_range_for_expression(&non_null.expression)
+        }
+        _ => None,
+    }
+}
+
+fn is_member_handler_reference(expression: &Expression<'_>) -> bool {
     match expression {
         Expression::Identifier(_) | Expression::ThisExpression(_) => true,
-        Expression::StaticMemberExpression(member) => {
-            is_static_member_handler_reference(&member.object)
-        }
+        Expression::StaticMemberExpression(member) => is_member_handler_reference(&member.object),
+        Expression::ChainExpression(chain) => match &chain.expression {
+            ChainElement::StaticMemberExpression(member) => {
+                is_member_handler_reference(&member.object)
+            }
+            ChainElement::TSNonNullExpression(non_null) => {
+                is_member_handler_reference(&non_null.expression)
+            }
+            _ => false,
+        },
         _ => false,
     }
 }
@@ -512,6 +534,17 @@ mod tests {
         assert_eq!(
             promise_slices(source, &ranges.floating_promises),
             vec!["actions.save"]
+        );
+    }
+
+    #[test]
+    fn collects_optional_member_event_handler_references_as_floating_candidates() {
+        let source = "actions?.save";
+        let ranges = collect_template_call_ranges(source, true, false, true);
+
+        assert_eq!(
+            promise_slices(source, &ranges.floating_promises),
+            vec!["actions?.save"]
         );
     }
 

--- a/crates/vize_patina/src/linter/native_type_aware/tests.rs
+++ b/crates/vize_patina/src/linter/native_type_aware/tests.rs
@@ -305,6 +305,32 @@ const actions = {
 }
 
 #[test]
+fn no_floating_promises_reports_optional_member_template_event_handlers() {
+    if !corsa_available() {
+        return;
+    }
+
+    let linter = Linter::with_preset(LintPreset::Opinionated);
+    let source = r#"<script setup lang="ts">
+type Actions = {
+  save(): Promise<void>
+}
+const actions: Actions | undefined = {
+  async save(): Promise<void> {}
+}
+</script>
+
+<template>
+  <button @click="actions?.save">Save</button>
+</template>"#;
+    let result = lint_sfc_with_corsa(&linter, source, "Component.vue");
+    assert!(result.diagnostics.iter().any(|diag| {
+        diag.rule_name == RULE_NO_FLOATING_PROMISES
+            && diag.message.contains("Template event handler")
+    }));
+}
+
+#[test]
 fn no_floating_promises_reports_template_interpolations() {
     if !corsa_available() {
         return;


### PR DESCRIPTION
## Summary
- treat optional static member event handler references as floating-promise candidates
- keep the Corsa return-type check as the final async/sync gate
- add focused parser and type-aware integration coverage for `@click="actions?.save"`

## Validation
- TMPDIR=$PWD/__agent_only/tmp cargo test -p vize_patina linter::native_type_aware -- --nocapture
- TMPDIR=$PWD/__agent_only/tmp cargo clippy -p vize_patina -- -D warnings
- ./node_modules/.bin/vp lint
- git diff --check