### PR TITLE
fix(type-aware): catch computed event promise handlers

### DIFF
--- a/crates/vize_patina/src/linter/native_type_aware/template_queries/calls.rs
+++ b/crates/vize_patina/src/linter/native_type_aware/template_queries/calls.rs
@@ -21,6 +21,13 @@ pub(super) struct FloatingPromiseRange {
     pub end: u32,
     pub probe_start: u32,
     pub probe_end: u32,
+    pub probe_target: FloatingPromiseProbeTarget,
+}
+
+#[derive(Clone, Copy, Eq, Ord, PartialEq, PartialOrd)]
+pub(super) enum FloatingPromiseProbeTarget {
+    SourceText,
+    ExpressionBinding,
 }
 
 #[derive(Default)]
@@ -100,6 +107,13 @@ fn bare_handler_reference_range_for_expression(
         Expression::Identifier(_) => Some(floating_promise_range_from_span(expression.span())),
         Expression::StaticMemberExpression(member) => is_member_handler_reference(&member.object)
             .then(|| floating_promise_range_from_span(expression.span())),
+        Expression::ComputedMemberExpression(member) => is_member_handler_reference(&member.object)
+            .then(|| {
+                floating_promise_range_from_span_with_target(
+                    expression.span(),
+                    FloatingPromiseProbeTarget::ExpressionBinding,
+                )
+            }),
         Expression::ChainExpression(chain) => {
             chain_member_handler_reference_range(chain, expression.span())
         }
@@ -126,6 +140,14 @@ fn chain_member_handler_reference_range(
     match &chain.expression {
         ChainElement::StaticMemberExpression(member) => is_member_handler_reference(&member.object)
             .then(|| floating_promise_range_from_span(span)),
+        ChainElement::ComputedMemberExpression(member) => {
+            is_member_handler_reference(&member.object).then(|| {
+                floating_promise_range_from_span_with_target(
+                    span,
+                    FloatingPromiseProbeTarget::ExpressionBinding,
+                )
+            })
+        }
         ChainElement::TSNonNullExpression(non_null) => {
             bare_handler_reference_range_for_expression(&non_null.expression)
         }
@@ -137,8 +159,12 @@ fn is_member_handler_reference(expression: &Expression<'_>) -> bool {
     match expression {
         Expression::Identifier(_) | Expression::ThisExpression(_) => true,
         Expression::StaticMemberExpression(member) => is_member_handler_reference(&member.object),
+        Expression::ComputedMemberExpression(member) => is_member_handler_reference(&member.object),
         Expression::ChainExpression(chain) => match &chain.expression {
             ChainElement::StaticMemberExpression(member) => {
+                is_member_handler_reference(&member.object)
+            }
+            ChainElement::ComputedMemberExpression(member) => {
                 is_member_handler_reference(&member.object)
             }
             ChainElement::TSNonNullExpression(non_null) => {
@@ -151,11 +177,19 @@ fn is_member_handler_reference(expression: &Expression<'_>) -> bool {
 }
 
 fn floating_promise_range_from_span(span: Span) -> FloatingPromiseRange {
+    floating_promise_range_from_span_with_target(span, FloatingPromiseProbeTarget::SourceText)
+}
+
+fn floating_promise_range_from_span_with_target(
+    span: Span,
+    probe_target: FloatingPromiseProbeTarget,
+) -> FloatingPromiseRange {
     FloatingPromiseRange {
         start: span.start,
         end: span.end,
         probe_start: span.start,
         probe_end: span.end,
+        probe_target,
     }
 }
 
@@ -257,13 +291,20 @@ impl FloatingPromiseCollector {
     ) -> Vec<FloatingPromiseRange> {
         let mut ranges = Vec::with_capacity(self.ranges.len());
         let limit = base_offset + source_len;
-        self.ranges
-            .sort_unstable_by_key(|range| (range.start, range.end, range.probe_start));
+        self.ranges.sort_unstable_by_key(|range| {
+            (
+                range.start,
+                range.end,
+                range.probe_start,
+                range.probe_target,
+            )
+        });
         self.ranges.dedup_by(|left, right| {
             left.start == right.start
                 && left.end == right.end
                 && left.probe_start == right.probe_start
                 && left.probe_end == right.probe_end
+                && left.probe_target == right.probe_target
         });
         for range in self.ranges {
             if range.end <= range.start
@@ -280,6 +321,7 @@ impl FloatingPromiseCollector {
                 end: range.end - base_offset,
                 probe_start: range.probe_start - base_offset,
                 probe_end: range.probe_end - base_offset,
+                probe_target: range.probe_target,
             });
         }
         ranges
@@ -305,6 +347,7 @@ fn floating_promise_range_for_expression(
                 end: span.end,
                 probe_start: probe.start,
                 probe_end: probe.end,
+                probe_target: FloatingPromiseProbeTarget::SourceText,
             })
         }
         Expression::NewExpression(_) => {
@@ -314,6 +357,7 @@ fn floating_promise_range_for_expression(
                 end: span.end,
                 probe_start: span.start,
                 probe_end: span.end,
+                probe_target: FloatingPromiseProbeTarget::SourceText,
             })
         }
         Expression::ChainExpression(chain) => match &chain.expression {
@@ -325,6 +369,7 @@ fn floating_promise_range_for_expression(
                     end: span.end,
                     probe_start: probe.start,
                     probe_end: probe.end,
+                    probe_target: FloatingPromiseProbeTarget::SourceText,
                 })
             }
             ChainElement::TSNonNullExpression(non_null) => {
@@ -545,6 +590,28 @@ mod tests {
         assert_eq!(
             promise_slices(source, &ranges.floating_promises),
             vec!["actions?.save"]
+        );
+    }
+
+    #[test]
+    fn collects_computed_member_event_handler_references_as_floating_candidates() {
+        let source = "actions[method]";
+        let ranges = collect_template_call_ranges(source, true, false, true);
+
+        assert_eq!(
+            promise_slices(source, &ranges.floating_promises),
+            vec!["actions[method]"]
+        );
+    }
+
+    #[test]
+    fn collects_optional_computed_member_event_handler_references_as_floating_candidates() {
+        let source = "actions?.[method]";
+        let ranges = collect_template_call_ranges(source, true, false, true);
+
+        assert_eq!(
+            promise_slices(source, &ranges.floating_promises),
+            vec!["actions?.[method]"]
         );
     }
 

--- a/crates/vize_patina/src/linter/native_type_aware/template_queries/collector.rs
+++ b/crates/vize_patina/src/linter/native_type_aware/template_queries/collector.rs
@@ -1,6 +1,8 @@
 use super::{
-    absolute_expression_range, calls::collect_template_call_ranges, generated_offset_for_text,
-    TemplateContext, TemplatePromiseQuery, TemplateQuery, TemplateQueryKind,
+    absolute_expression_range,
+    calls::{collect_template_call_ranges, FloatingPromiseProbeTarget},
+    generated_offset_for_text, TemplateContext, TemplatePromiseQuery, TemplateQuery,
+    TemplateQueryKind,
 };
 use vize_carton::profile;
 use vize_croquis::virtual_ts::VirtualTsOutput;
@@ -352,6 +354,17 @@ fn collect_expression_query_sets(
             else {
                 continue;
             };
+            let generated_offset = match candidate.probe_target {
+                FloatingPromiseProbeTarget::SourceText => generated_offset,
+                FloatingPromiseProbeTarget::ExpressionBinding => {
+                    let Some(binding_offset) =
+                        expression_binding_generated_offset(&virtual_ts.content, generated_offset)
+                    else {
+                        continue;
+                    };
+                    binding_offset
+                }
+            };
             queries.push(TemplatePromiseQuery {
                 context,
                 generated_offset,
@@ -359,5 +372,39 @@ fn collect_expression_query_sets(
                 source_end: candidate_end,
             });
         }
+    }
+}
+
+fn expression_binding_generated_offset(generated: &str, expression_offset: u32) -> Option<u32> {
+    let offset = usize::min(expression_offset as usize, generated.len());
+    let before_offset = generated.get(..offset)?;
+    let after_offset = generated.get(offset..)?;
+    let line_start = before_offset.rfind('\n').map_or(0, |index| index + 1);
+    let line_end = after_offset
+        .find('\n')
+        .map_or(generated.len(), |index| offset + index);
+    let line = generated.get(line_start..line_end)?;
+    let const_start = line.find("const __expr_")?;
+    let name_start = const_start + "const ".len();
+    let name_end = line.get(name_start..)?.find(" = ")? + name_start;
+    (name_end > name_start).then_some((line_start + name_end - 1) as u32)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::expression_binding_generated_offset;
+
+    #[test]
+    fn finds_expression_binding_offset_on_generated_line() {
+        let generated = "  const __expr_42 = actions[method];\n";
+        let expression_offset = generated.find("method").unwrap() as u32;
+
+        let binding_offset = expression_binding_generated_offset(generated, expression_offset)
+            .expect("binding offset");
+
+        assert_eq!(
+            &generated[binding_offset as usize..binding_offset as usize + 1],
+            "2"
+        );
     }
 }

--- a/crates/vize_patina/src/linter/native_type_aware/tests.rs
+++ b/crates/vize_patina/src/linter/native_type_aware/tests.rs
@@ -331,6 +331,81 @@ const actions: Actions | undefined = {
 }
 
 #[test]
+fn no_floating_promises_reports_computed_member_template_event_handlers() {
+    if !corsa_available() {
+        return;
+    }
+
+    let linter = Linter::with_preset(LintPreset::Opinionated);
+    let source = r#"<script setup lang="ts">
+const method = 'save' as const
+const actions = {
+  async save(): Promise<void> {}
+}
+</script>
+
+<template>
+  <button @click="actions[method]">Save</button>
+</template>"#;
+    let result = lint_sfc_with_corsa(&linter, source, "Component.vue");
+    assert!(result.diagnostics.iter().any(|diag| {
+        diag.rule_name == RULE_NO_FLOATING_PROMISES
+            && diag.message.contains("Template event handler")
+    }));
+}
+
+#[test]
+fn no_floating_promises_ignores_sync_computed_member_template_event_handlers() {
+    if !corsa_available() {
+        return;
+    }
+
+    let linter = Linter::with_preset(LintPreset::Opinionated);
+    let source = r#"<script setup lang="ts">
+const method = 'save' as const
+const actions = {
+  save(): void {}
+}
+</script>
+
+<template>
+  <button @click="actions[method]">Save</button>
+</template>"#;
+    let result = lint_sfc_with_corsa(&linter, source, "Component.vue");
+    assert!(!result
+        .diagnostics
+        .iter()
+        .any(|diag| diag.rule_name == RULE_NO_FLOATING_PROMISES));
+}
+
+#[test]
+fn no_floating_promises_reports_optional_computed_member_template_event_handlers() {
+    if !corsa_available() {
+        return;
+    }
+
+    let linter = Linter::with_preset(LintPreset::Opinionated);
+    let source = r#"<script setup lang="ts">
+type Actions = {
+  save(): Promise<void>
+}
+const method = 'save' as const
+const actions: Actions | undefined = {
+  async save(): Promise<void> {}
+}
+</script>
+
+<template>
+  <button @click="actions?.[method]">Save</button>
+</template>"#;
+    let result = lint_sfc_with_corsa(&linter, source, "Component.vue");
+    assert!(result.diagnostics.iter().any(|diag| {
+        diag.rule_name == RULE_NO_FLOATING_PROMISES
+            && diag.message.contains("Template event handler")
+    }));
+}
+
+#[test]
 fn no_floating_promises_reports_template_interpolations() {
     if !corsa_available() {
         return;


### PR DESCRIPTION
## Summary
- detect computed member template event handler references as floating-promise candidates
- probe generated expression bindings so Corsa sees the handler function type instead of the computed key type
- add parser and type-aware coverage for computed, optional computed, and sync computed handlers

## Validation
- TMPDIR=$PWD/__agent_only/tmp cargo test -p vize_patina linter::native_type_aware -- --nocapture
- TMPDIR=$PWD/__agent_only/tmp cargo clippy -p vize_patina -- -D warnings
- ./node_modules/.bin/vp lint
- git diff --check