### PR TITLE
fix(lint): catch nested prop v-model mutations

### DIFF
--- a/crates/vize_patina/src/linter/tests/sfc.rs
+++ b/crates/vize_patina/src/linter/tests/sfc.rs
@@ -77,6 +77,69 @@ defineProps<{ count: number }>()
 }
 
 #[test]
+fn test_lint_sfc_reports_nested_prop_v_model_mutation() {
+    let linter = Linter::new().with_enabled_rules(Some(vec!["vue/no-mutating-props".into()]));
+    let sfc = r#"<script setup lang="ts">
+const props = defineProps<{ user: { name: string }, count: number }>()
+</script>
+
+<template>
+  <input v-model="props.user.name" />
+  <input v-model="props['count']" />
+</template>
+"#;
+    let result = linter.lint_sfc(sfc, "test.vue");
+
+    assert_eq!(result.error_count, 2);
+    assert!(result
+        .diagnostics
+        .iter()
+        .all(|diagnostic| diagnostic.rule_name == "vue/no-mutating-props"));
+}
+
+#[test]
+fn test_lint_sfc_reports_destructured_prop_member_v_model_mutation() {
+    let linter = Linter::new().with_enabled_rules(Some(vec!["vue/no-mutating-props".into()]));
+    let sfc = r#"<script setup lang="ts">
+const { user } = defineProps<{ user: { name: string } }>()
+</script>
+
+<template>
+  <input v-model="user.name" />
+</template>
+"#;
+    let result = linter.lint_sfc(sfc, "test.vue");
+
+    assert_eq!(result.error_count, 1);
+    assert_eq!(result.diagnostics[0].rule_name, "vue/no-mutating-props");
+}
+
+#[test]
+fn test_lint_sfc_allows_local_v_model_names_that_start_like_props() {
+    let linter = Linter::new().with_enabled_rules(Some(vec!["vue/no-mutating-props".into()]));
+    let sfc = r#"<script setup lang="ts">
+import { reactive } from 'vue'
+
+defineProps<{ count: number }>()
+const propsState = reactive({ count: 0 })
+const counter = reactive({ value: 0 })
+</script>
+
+<template>
+  <input v-model="propsState.count" />
+  <input v-model="counter.value" />
+</template>
+"#;
+    let result = linter.lint_sfc(sfc, "test.vue");
+
+    assert!(
+        result.diagnostics.is_empty(),
+        "local state should not be treated as prop mutation: {:?}",
+        result.diagnostics
+    );
+}
+
+#[test]
 fn test_lint_sfc_no_unused_components_reports_unused_vue_import() {
     let linter = Linter::new().with_enabled_rules(Some(vec!["vue/no-unused-components".into()]));
     let sfc = r#"<script setup>

--- a/crates/vize_patina/src/rules/vue/no_mutating_props.rs
+++ b/crates/vize_patina/src/rules/vue/no_mutating_props.rs
@@ -82,12 +82,7 @@ impl NoMutatingProps {
                 vize_relief::ast::ExpressionNode::Compound(c) => c.loc.source.as_str(),
             };
 
-            // Check if the expression references a prop
-            // Simple check: v-model="propName" or v-model="props.propName"
-            let is_prop_mutation = prop_names.contains(content)
-                || content.starts_with("props.") && prop_names.contains(&content[6..]);
-
-            if is_prop_mutation {
+            if is_prop_mutation_target(content, prop_names) {
                 ctx.report(
                     crate::diagnostic::LintDiagnostic::error(
                         ctx.current_rule,
@@ -192,11 +187,36 @@ impl Rule for NoMutatingProps {
     }
 }
 
+fn is_prop_mutation_target(content: &str, prop_names: &FxHashSet<&str>) -> bool {
+    let content = content.trim();
+    if prop_names.contains(content) {
+        return true;
+    }
+
+    if content
+        .strip_prefix("props")
+        .is_some_and(is_member_access_suffix)
+    {
+        return true;
+    }
+
+    prop_names.iter().any(|name| {
+        content
+            .strip_prefix(*name)
+            .is_some_and(is_member_access_suffix)
+    })
+}
+
+fn is_member_access_suffix(rest: &str) -> bool {
+    rest.starts_with('.') || rest.starts_with('[') || rest.starts_with("?.")
+}
+
 #[cfg(test)]
 mod tests {
-    use super::NoMutatingProps;
+    use super::{is_prop_mutation_target, NoMutatingProps};
     use crate::diagnostic::Severity;
     use crate::rule::{Rule, RuleCategory};
+    use vize_carton::FxHashSet;
 
     #[test]
     fn test_meta() {
@@ -204,5 +224,19 @@ mod tests {
         assert_eq!(rule.meta().name, "vue/no-mutating-props");
         assert_eq!(rule.meta().category, RuleCategory::Essential);
         assert_eq!(rule.meta().default_severity, Severity::Error);
+    }
+
+    #[test]
+    fn prop_mutation_target_matches_member_roots() {
+        let prop_names = FxHashSet::from_iter(["count", "user"]);
+
+        assert!(is_prop_mutation_target("count", &prop_names));
+        assert!(is_prop_mutation_target("user.name", &prop_names));
+        assert!(is_prop_mutation_target("user?.name", &prop_names));
+        assert!(is_prop_mutation_target("props.count", &prop_names));
+        assert!(is_prop_mutation_target("props.user.name", &prop_names));
+        assert!(is_prop_mutation_target("props['count']", &prop_names));
+        assert!(!is_prop_mutation_target("counter.value", &prop_names));
+        assert!(!is_prop_mutation_target("propsState.count", &prop_names));
     }
 }


### PR DESCRIPTION
## Summary
- report v-model mutations on nested prop members such as props.user.name
- catch bracket and destructured prop member forms used in real-world components
- keep local state names such as propsState.count and counter.value out of the rule

## Validation
- TMPDIR=$PWD/__agent_only/tmp cargo test -p vize_patina no_mutating_props -- --nocapture
- TMPDIR=$PWD/__agent_only/tmp cargo test -p vize_patina v_model -- --nocapture
- TMPDIR=$PWD/__agent_only/tmp cargo clippy -p vize_patina -- -D warnings
- ./node_modules/.bin/vp lint
- git diff --check