### PR TITLE
fix(lsp): surface sfc lint diagnostics

### DIFF
--- a/crates/vize_maestro/src/ide/diagnostics/collectors.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/collectors.rs
@@ -338,32 +338,23 @@ impl DiagnosticService {
             ..Default::default()
         };
 
-        let Ok(descriptor) = vize_atelier_sfc::parse_sfc(content, options) else {
+        if vize_atelier_sfc::parse_sfc(content, options).is_err() {
             return vec![];
-        };
+        }
 
-        let Some(ref template) = descriptor.template else {
-            return vec![];
-        };
-
-        // Create linter and lint the template content
+        // Create linter and lint the full SFC so editor diagnostics match the CLI.
         let linter = vize_patina::Linter::new();
-        let result = linter.lint_template(&template.content, uri.path());
+        let result = linter.lint_sfc(content, uri.path());
 
         // Convert lint diagnostics to LSP diagnostics
         result
             .diagnostics
             .into_iter()
             .map(|lint_diag| {
-                // Convert byte offset to line/column within template
-                let (start_line, start_col) =
-                    offset_to_line_col(&template.content, lint_diag.start as usize);
-                let (end_line, end_col) =
-                    offset_to_line_col(&template.content, lint_diag.end as usize);
-
-                // Adjust line numbers based on template block position in SFC
-                let sfc_start_line = template.loc.start_line as u32 + start_line;
-                let sfc_end_line = template.loc.start_line as u32 + end_line;
+                // Convert byte offsets directly in the SFC. vize_patina::lint_sfc
+                // already maps template diagnostics back to source coordinates.
+                let (start_line, start_col) = offset_to_line_col(content, lint_diag.start as usize);
+                let (end_line, end_col) = offset_to_line_col(content, lint_diag.end as usize);
 
                 // Build the diagnostic message with help text (render as plain text for LSP)
                 #[allow(clippy::disallowed_macros)]
@@ -381,11 +372,11 @@ impl DiagnosticService {
                 Diagnostic {
                     range: Range {
                         start: Position {
-                            line: sfc_start_line.saturating_sub(1),
+                            line: start_line,
                             character: start_col,
                         },
                         end: Position {
-                            line: sfc_end_line.saturating_sub(1),
+                            line: end_line,
                             character: end_col,
                         },
                     },

--- a/crates/vize_maestro/src/ide/diagnostics/mod.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/mod.rs
@@ -419,6 +419,31 @@ mod tests {
     }
 
     #[test]
+    fn collect_surfaces_sfc_level_lint_diagnostics() {
+        let state = state_with_lsp_diagnostics(true, false);
+        let uri = Url::parse("file:///OutOfOrder.vue").unwrap();
+        state.documents.open(
+            uri.clone(),
+            "<template><div /></template>\n<script setup>const count = 1</script>".to_string(),
+            1,
+            "vue".to_string(),
+        );
+
+        let diagnostics = DiagnosticService::collect(&state, &uri);
+        let diagnostic = diagnostics
+            .iter()
+            .find(|diagnostic| {
+                diagnostic.source.as_deref() == Some(sources::LINTER)
+                    && diagnostic.code
+                        == Some(NumberOrString::String("vue/sfc-element-order".to_string()))
+            })
+            .expect("SFC-level lint diagnostic");
+
+        assert_eq!(diagnostic.range.start.line, 1);
+        assert!(diagnostic.message.contains("<script> should come before"));
+    }
+
+    #[test]
     fn collect_short_circuits_dependent_diagnostics_after_script_parse_error() {
         let state = state_with_lsp_diagnostics(true, true);
         let uri = Url::parse("file:///BrokenScript.vue").unwrap();


### PR DESCRIPTION
## Summary
- route language-server lint collection through the full SFC linter
- preserve parser short-circuiting before dependent lint diagnostics
- add regression coverage for SFC-level lint diagnostics in editor output

## Validation
- TMPDIR=$PWD/__agent_only/tmp cargo test -p vize_maestro ide::diagnostics -- --nocapture
- TMPDIR=$PWD/__agent_only/tmp cargo clippy -p vize_maestro -- -D warnings
- ./node_modules/.bin/vp lint
- git diff --check