### PR TITLE
fix(type-aware): probe computed template bindings

### DIFF
--- a/crates/vize_patina/src/linter/native_type_aware/template_queries/calls.rs
+++ b/crates/vize_patina/src/linter/native_type_aware/template_queries/calls.rs
@@ -34,6 +34,7 @@ pub(super) enum FloatingPromiseProbeTarget {
 pub(super) struct TemplateCallRanges {
     pub callees: Vec<RelativeRange>,
     pub floating_promises: Vec<FloatingPromiseRange>,
+    pub probe_expression_binding: bool,
 }
 
 const TEMPLATE_HANDLER_PREFIX: &str = "function __vize_template_handler(){\n";
@@ -55,6 +56,7 @@ pub(super) fn collect_template_call_ranges(
         "patina.type_aware.template_queries.parse_expression",
         OxcParser::new(&allocator, source, source_type).parse_expression()
     ) {
+        ranges.probe_expression_binding = expression_prefers_binding_probe(&expression);
         if include_callees {
             let mut collector = CallCalleeCollector::default();
             profile!(
@@ -98,6 +100,30 @@ pub(super) fn collect_template_call_ranges(
     }
 
     ranges
+}
+
+fn expression_prefers_binding_probe(expression: &Expression<'_>) -> bool {
+    match expression {
+        Expression::ComputedMemberExpression(_) => true,
+        Expression::ChainExpression(chain) => match &chain.expression {
+            ChainElement::ComputedMemberExpression(_) => true,
+            ChainElement::TSNonNullExpression(non_null) => {
+                expression_prefers_binding_probe(&non_null.expression)
+            }
+            _ => false,
+        },
+        Expression::ParenthesizedExpression(paren) => {
+            expression_prefers_binding_probe(&paren.expression)
+        }
+        Expression::TSAsExpression(ts_as) => expression_prefers_binding_probe(&ts_as.expression),
+        Expression::TSSatisfiesExpression(ts_satisfies) => {
+            expression_prefers_binding_probe(&ts_satisfies.expression)
+        }
+        Expression::TSNonNullExpression(ts_non_null) => {
+            expression_prefers_binding_probe(&ts_non_null.expression)
+        }
+        _ => false,
+    }
 }
 
 fn bare_handler_reference_range_for_expression(
@@ -613,6 +639,19 @@ mod tests {
             promise_slices(source, &ranges.floating_promises),
             vec!["actions?.[method]"]
         );
+    }
+
+    #[test]
+    fn computed_member_expressions_prefer_binding_probes() {
+        let computed = collect_template_call_ranges("payload[key]", false, true, false);
+        let optional = collect_template_call_ranges("payload?.[key]", false, true, false);
+        let call = collect_template_call_ranges("payload[key]()", false, true, false);
+        let static_member = collect_template_call_ranges("payload.key", false, true, false);
+
+        assert!(computed.probe_expression_binding);
+        assert!(optional.probe_expression_binding);
+        assert!(!call.probe_expression_binding);
+        assert!(!static_member.probe_expression_binding);
     }
 
     #[test]

--- a/crates/vize_patina/src/linter/native_type_aware/template_queries/collector.rs
+++ b/crates/vize_patina/src/linter/native_type_aware/template_queries/collector.rs
@@ -305,6 +305,12 @@ fn collect_expression_query_sets(
         sinks.template_queries.as_deref_mut(),
         expression_generated_offset,
     ) {
+        let generated_offset = if call_ranges.probe_expression_binding {
+            expression_binding_generated_offset(&virtual_ts.content, generated_offset)
+                .unwrap_or(generated_offset)
+        } else {
+            generated_offset
+        };
         queries.push(TemplateQuery {
             kind: TemplateQueryKind::Expression,
             context,

--- a/crates/vize_patina/src/linter/native_type_aware/tests.rs
+++ b/crates/vize_patina/src/linter/native_type_aware/tests.rs
@@ -567,6 +567,52 @@ const anyHandler: any = () => {}
 }
 
 #[test]
+fn no_unsafe_template_binding_reports_computed_member_template_bindings() {
+    if !corsa_available() {
+        return;
+    }
+
+    let linter = Linter::with_preset(LintPreset::Opinionated);
+    let source = r#"<script setup lang="ts">
+const key = 'label' as const
+const payload: Record<string, any> = { label: 'unsafe' }
+</script>
+
+<template>
+  <div>{{ payload[key] }}</div>
+</template>"#;
+    let result = lint_sfc_with_corsa(&linter, source, "TypeAwareFixture.vue");
+
+    assert!(result
+        .diagnostics
+        .iter()
+        .any(|diag| diag.rule_name == RULE_NO_UNSAFE_TEMPLATE_BINDING));
+}
+
+#[test]
+fn typed_computed_template_members_are_ignored() {
+    if !corsa_available() {
+        return;
+    }
+
+    let linter = Linter::with_preset(LintPreset::Opinionated);
+    let source = r#"<script setup lang="ts">
+const key = 'label' as const
+const payload: { label: string } = { label: 'safe' }
+</script>
+
+<template>
+  <div :title="payload[key]" />
+</template>"#;
+    let result = lint_sfc_with_corsa(&linter, source, "TypeAwareFixture.vue");
+
+    assert!(!result
+        .diagnostics
+        .iter()
+        .any(|diag| diag.rule_name == RULE_NO_UNSAFE_TEMPLATE_BINDING));
+}
+
+#[test]
 fn no_reactivity_loss_tracks_props_calls_and_getter_returns() {
     if !corsa_available() {
         return;


### PR DESCRIPTION
## Summary
- probe top-level computed template member expressions through their generated expression binding
- keep call-callee probes on their existing source offsets
- add unsafe and typed computed member coverage for template bindings

## Validation
- TMPDIR=$PWD/__agent_only/tmp cargo test -p vize_patina computed -- --nocapture
- TMPDIR=$PWD/__agent_only/tmp cargo test -p vize_patina linter::native_type_aware -- --nocapture
- TMPDIR=$PWD/__agent_only/tmp cargo clippy -p vize_patina -- -D warnings
- ./node_modules/.bin/vp lint
- git diff --check