### PR TITLE
fix(lint): avoid local props v-model false positives

### DIFF
--- a/crates/vize_patina/src/linter/tests/sfc.rs
+++ b/crates/vize_patina/src/linter/tests/sfc.rs
@@ -140,6 +140,29 @@ const counter = reactive({ value: 0 })
 }
 
 #[test]
+fn test_lint_sfc_allows_local_props_object_v_model_member() {
+    let linter = Linter::new().with_enabled_rules(Some(vec!["vue/no-mutating-props".into()]));
+    let sfc = r#"<script setup lang="ts">
+import { reactive } from 'vue'
+
+defineProps<{ user: { name: string } }>()
+const props = reactive({ user: { name: '' } })
+</script>
+
+<template>
+  <input v-model="props.user.name" />
+</template>
+"#;
+    let result = linter.lint_sfc(sfc, "test.vue");
+
+    assert!(
+        result.diagnostics.is_empty(),
+        "local props object should not be treated as defineProps output: {:?}",
+        result.diagnostics
+    );
+}
+
+#[test]
 fn test_lint_sfc_no_unused_components_reports_unused_vue_import() {
     let linter = Linter::new().with_enabled_rules(Some(vec!["vue/no-unused-components".into()]));
     let sfc = r#"<script setup>

--- a/crates/vize_patina/src/rules/vue/no_mutating_props.rs
+++ b/crates/vize_patina/src/rules/vue/no_mutating_props.rs
@@ -48,6 +48,7 @@ use crate::rule::{Rule, RuleCategory, RuleMeta};
 use vize_carton::FxHashSet;
 use vize_carton::String;
 use vize_carton::ToCompactString;
+use vize_croquis::reactivity::ReactiveKind;
 use vize_relief::ast::{DirectiveNode, ElementNode, PropNode, RootNode, TemplateChildNode};
 use vize_relief::BindingType;
 
@@ -70,6 +71,7 @@ impl NoMutatingProps {
         ctx: &mut LintContext<'a>,
         directive: &DirectiveNode<'a>,
         prop_names: &FxHashSet<&str>,
+        has_props_object_binding: bool,
     ) {
         if directive.name.as_str() != "model" {
             return;
@@ -82,7 +84,7 @@ impl NoMutatingProps {
                 vize_relief::ast::ExpressionNode::Compound(c) => c.loc.source.as_str(),
             };
 
-            if is_prop_mutation_target(content, prop_names) {
+            if is_prop_mutation_target(content, prop_names, has_props_object_binding) {
                 ctx.report(
                     crate::diagnostic::LintDiagnostic::error(
                         ctx.current_rule,
@@ -104,19 +106,30 @@ impl NoMutatingProps {
         ctx: &mut LintContext<'a>,
         children: &[TemplateChildNode<'a>],
         prop_names: &FxHashSet<&str>,
+        has_props_object_binding: bool,
     ) {
         for child in children {
             match child {
                 TemplateChildNode::Element(el) => {
-                    self.check_element(ctx, el, prop_names);
+                    self.check_element(ctx, el, prop_names, has_props_object_binding);
                 }
                 TemplateChildNode::If(if_node) => {
                     for branch in if_node.branches.iter() {
-                        self.check_children(ctx, &branch.children, prop_names);
+                        self.check_children(
+                            ctx,
+                            &branch.children,
+                            prop_names,
+                            has_props_object_binding,
+                        );
                     }
                 }
                 TemplateChildNode::For(for_node) => {
-                    self.check_children(ctx, &for_node.children, prop_names);
+                    self.check_children(
+                        ctx,
+                        &for_node.children,
+                        prop_names,
+                        has_props_object_binding,
+                    );
                 }
                 _ => {}
             }
@@ -129,16 +142,17 @@ impl NoMutatingProps {
         ctx: &mut LintContext<'a>,
         element: &ElementNode<'a>,
         prop_names: &FxHashSet<&str>,
+        has_props_object_binding: bool,
     ) {
         // Check directives
         for prop in element.props.iter() {
             if let PropNode::Directive(dir) = prop {
-                self.check_v_model_mutation(ctx, dir, prop_names);
+                self.check_v_model_mutation(ctx, dir, prop_names, has_props_object_binding);
             }
         }
 
         // Check children
-        self.check_children(ctx, &element.children, prop_names);
+        self.check_children(ctx, &element.children, prop_names, has_props_object_binding);
     }
 }
 
@@ -154,7 +168,7 @@ impl Rule for NoMutatingProps {
         }
 
         // Collect prop names first (to avoid borrow conflicts)
-        let prop_names: FxHashSet<String> = {
+        let (prop_names, has_props_object_binding): (FxHashSet<String>, bool) = {
             let analysis = ctx.analysis().unwrap();
 
             let mut names: FxHashSet<String> = FxHashSet::default();
@@ -171,7 +185,12 @@ impl Rule for NoMutatingProps {
                 }
             }
 
-            names
+            let has_props_object_binding = analysis
+                .reactivity
+                .lookup("props")
+                .is_some_and(|source| matches!(source.kind, ReactiveKind::Readonly));
+
+            (names, has_props_object_binding)
         };
 
         // If no props, nothing to check
@@ -183,19 +202,30 @@ impl Rule for NoMutatingProps {
         let prop_names_ref: FxHashSet<&str> = prop_names.iter().map(|s| s.as_str()).collect();
 
         // Check template
-        self.check_children(ctx, &root.children, &prop_names_ref);
+        self.check_children(
+            ctx,
+            &root.children,
+            &prop_names_ref,
+            has_props_object_binding,
+        );
     }
 }
 
-fn is_prop_mutation_target(content: &str, prop_names: &FxHashSet<&str>) -> bool {
+fn is_prop_mutation_target(
+    content: &str,
+    prop_names: &FxHashSet<&str>,
+    has_props_object_binding: bool,
+) -> bool {
     let content = content.trim();
     if prop_names.contains(content) {
         return true;
     }
 
-    if content
-        .strip_prefix("props")
-        .is_some_and(is_member_access_suffix)
+    if has_props_object_binding
+        && content
+            .strip_prefix("props")
+            .and_then(props_member_root)
+            .is_some_and(|name| prop_names.contains(name))
     {
         return true;
     }
@@ -209,6 +239,41 @@ fn is_prop_mutation_target(content: &str, prop_names: &FxHashSet<&str>) -> bool 
 
 fn is_member_access_suffix(rest: &str) -> bool {
     rest.starts_with('.') || rest.starts_with('[') || rest.starts_with("?.")
+}
+
+fn props_member_root(rest: &str) -> Option<&str> {
+    let mut rest = rest.trim_start();
+    let mut consumed_optional = false;
+    if let Some(after_optional) = rest.strip_prefix("?.") {
+        rest = after_optional.trim_start();
+        consumed_optional = true;
+    }
+
+    if let Some(after_dot) = rest.strip_prefix('.') {
+        return identifier_root(after_dot);
+    }
+
+    if consumed_optional {
+        if let Some(name) = identifier_root(rest) {
+            return Some(name);
+        }
+    }
+
+    let after_bracket = rest.strip_prefix('[')?.trim_start();
+    let quote = after_bracket.chars().next()?;
+    if quote != '\'' && quote != '"' {
+        return None;
+    }
+    let name_start = quote.len_utf8();
+    let name_end = after_bracket[name_start..].find(quote)? + name_start;
+    (name_end > name_start).then_some(&after_bracket[name_start..name_end])
+}
+
+fn identifier_root(source: &str) -> Option<&str> {
+    let end = source
+        .find(|ch: char| !(ch == '_' || ch == '$' || ch.is_ascii_alphanumeric()))
+        .unwrap_or(source.len());
+    (end > 0).then_some(&source[..end])
 }
 
 #[cfg(test)]
@@ -230,13 +295,36 @@ mod tests {
     fn prop_mutation_target_matches_member_roots() {
         let prop_names = FxHashSet::from_iter(["count", "user"]);
 
-        assert!(is_prop_mutation_target("count", &prop_names));
-        assert!(is_prop_mutation_target("user.name", &prop_names));
-        assert!(is_prop_mutation_target("user?.name", &prop_names));
-        assert!(is_prop_mutation_target("props.count", &prop_names));
-        assert!(is_prop_mutation_target("props.user.name", &prop_names));
-        assert!(is_prop_mutation_target("props['count']", &prop_names));
-        assert!(!is_prop_mutation_target("counter.value", &prop_names));
-        assert!(!is_prop_mutation_target("propsState.count", &prop_names));
+        assert!(is_prop_mutation_target("count", &prop_names, false));
+        assert!(is_prop_mutation_target("user.name", &prop_names, false));
+        assert!(is_prop_mutation_target("user?.name", &prop_names, false));
+        assert!(is_prop_mutation_target("props.count", &prop_names, true));
+        assert!(is_prop_mutation_target(
+            "props.user.name",
+            &prop_names,
+            true
+        ));
+        assert!(is_prop_mutation_target("props['count']", &prop_names, true));
+        assert!(is_prop_mutation_target(
+            "props?.user.name",
+            &prop_names,
+            true
+        ));
+        assert!(!is_prop_mutation_target("props.extra", &prop_names, true));
+        assert!(!is_prop_mutation_target(
+            "props.user.name",
+            &prop_names,
+            false
+        ));
+        assert!(!is_prop_mutation_target(
+            "counter.value",
+            &prop_names,
+            false
+        ));
+        assert!(!is_prop_mutation_target(
+            "propsState.count",
+            &prop_names,
+            true
+        ));
     }
 }


### PR DESCRIPTION
## Summary
- only treat props.* v-model targets as prop mutations when props is the readonly defineProps binding
- keep nested props.user and bracket member detection for real prop objects
- add coverage for local reactive objects named props

## Validation
- TMPDIR=$PWD/__agent_only/tmp cargo test -p vize_patina no_mutating_props -- --nocapture
- TMPDIR=$PWD/__agent_only/tmp cargo test -p vize_patina v_model -- --nocapture
- TMPDIR=$PWD/__agent_only/tmp cargo clippy -p vize_patina -- -D warnings
- ./node_modules/.bin/vp lint
- git diff --check