### PR TITLE
fix(lint): catch dynamic props v-model mutations

### DIFF
--- a/crates/vize_patina/src/linter/tests/sfc.rs
+++ b/crates/vize_patina/src/linter/tests/sfc.rs
@@ -98,6 +98,46 @@ const props = defineProps<{ user: { name: string }, count: number }>()
 }
 
 #[test]
+fn test_lint_sfc_reports_dynamic_props_object_v_model_mutation() {
+    let linter = Linter::new().with_enabled_rules(Some(vec!["vue/no-mutating-props".into()]));
+    let sfc = r#"<script setup lang="ts">
+const props = defineProps<{ user: { name: string } }>()
+const key = 'user' as keyof typeof props
+</script>
+
+<template>
+  <input v-model="props[key].name" />
+</template>
+"#;
+    let result = linter.lint_sfc(sfc, "test.vue");
+
+    assert_eq!(result.error_count, 1);
+    assert_eq!(result.diagnostics[0].rule_name, "vue/no-mutating-props");
+}
+
+#[test]
+fn test_lint_sfc_reports_unlisted_props_object_v_model_mutation() {
+    let linter = Linter::new().with_enabled_rules(Some(vec!["vue/no-mutating-props".into()]));
+    let sfc = r#"<script setup lang="ts">
+const props = defineProps<Record<string, string>>()
+const field = 'title'
+</script>
+
+<template>
+  <input v-model="props.title" />
+  <input v-model="props[field]" />
+</template>
+"#;
+    let result = linter.lint_sfc(sfc, "test.vue");
+
+    assert_eq!(result.error_count, 2);
+    assert!(result
+        .diagnostics
+        .iter()
+        .all(|diagnostic| diagnostic.rule_name == "vue/no-mutating-props"));
+}
+
+#[test]
 fn test_lint_sfc_reports_destructured_prop_member_v_model_mutation() {
     let linter = Linter::new().with_enabled_rules(Some(vec!["vue/no-mutating-props".into()]));
     let sfc = r#"<script setup lang="ts">

--- a/crates/vize_patina/src/rules/vue/no_mutating_props.rs
+++ b/crates/vize_patina/src/rules/vue/no_mutating_props.rs
@@ -193,8 +193,8 @@ impl Rule for NoMutatingProps {
             (names, has_props_object_binding)
         };
 
-        // If no props, nothing to check
-        if prop_names.is_empty() {
+        // If no props binding is visible, nothing to check.
+        if prop_names.is_empty() && !has_props_object_binding {
             return;
         }
 
@@ -224,8 +224,7 @@ fn is_prop_mutation_target(
     if has_props_object_binding
         && content
             .strip_prefix("props")
-            .and_then(props_member_root)
-            .is_some_and(|name| prop_names.contains(name))
+            .is_some_and(|rest| is_props_object_member_mutation(rest, prop_names))
     {
         return true;
     }
@@ -239,6 +238,27 @@ fn is_prop_mutation_target(
 
 fn is_member_access_suffix(rest: &str) -> bool {
     rest.starts_with('.') || rest.starts_with('[') || rest.starts_with("?.")
+}
+
+fn is_props_object_member_mutation(rest: &str, prop_names: &FxHashSet<&str>) -> bool {
+    if let Some(name) = props_member_root(rest) {
+        return prop_names.is_empty() || prop_names.contains(name);
+    }
+
+    is_dynamic_props_member_access(rest)
+}
+
+fn is_dynamic_props_member_access(rest: &str) -> bool {
+    let mut rest = rest.trim_start();
+    if let Some(after_optional) = rest.strip_prefix("?.") {
+        rest = after_optional.trim_start();
+    }
+
+    let Some(after_bracket) = rest.strip_prefix('[') else {
+        return false;
+    };
+    let after_bracket = after_bracket.trim_start();
+    !after_bracket.starts_with('\'') && !after_bracket.starts_with('"')
 }
 
 fn props_member_root(rest: &str) -> Option<&str> {
@@ -305,12 +325,23 @@ mod tests {
             true
         ));
         assert!(is_prop_mutation_target("props['count']", &prop_names, true));
+        assert!(is_prop_mutation_target("props[key]", &prop_names, true));
+        assert!(is_prop_mutation_target(
+            "props[key].name",
+            &prop_names,
+            true
+        ));
         assert!(is_prop_mutation_target(
             "props?.user.name",
             &prop_names,
             true
         ));
         assert!(!is_prop_mutation_target("props.extra", &prop_names, true));
+        assert!(!is_prop_mutation_target(
+            "props['extra']",
+            &prop_names,
+            true
+        ));
         assert!(!is_prop_mutation_target(
             "props.user.name",
             &prop_names,
@@ -324,6 +355,18 @@ mod tests {
         assert!(!is_prop_mutation_target(
             "propsState.count",
             &prop_names,
+            true
+        ));
+
+        let unknown_prop_names = FxHashSet::default();
+        assert!(is_prop_mutation_target(
+            "props.title",
+            &unknown_prop_names,
+            true
+        ));
+        assert!(is_prop_mutation_target(
+            "props[field]",
+            &unknown_prop_names,
             true
         ));
     }


### PR DESCRIPTION
## Summary
- treat dynamic props[key] v-model targets as prop mutations when props is the readonly defineProps binding
- keep static undeclared props['extra'] ignored when prop names are known
- report readonly props object mutations for Record-style props where names cannot be enumerated

## Validation
- TMPDIR=$PWD/__agent_only/tmp cargo test -p vize_patina no_mutating_props -- --nocapture
- TMPDIR=$PWD/__agent_only/tmp cargo test -p vize_patina v_model -- --nocapture
- TMPDIR=$PWD/__agent_only/tmp cargo clippy -p vize_patina -- -D warnings
- ./node_modules/.bin/vp lint
- git diff --check