### PR TITLE
fix(type-aware): collect event statement callees

### DIFF
--- a/crates/vize_maestro/src/server/capabilities.rs
+++ b/crates/vize_maestro/src/server/capabilities.rs
@@ -82,12 +82,8 @@ pub fn server_capabilities(features: LspFeatureConfig) -> ServerCapabilities {
         // Range formatting
         document_range_formatting_provider: features.formatting.then_some(OneOf::Left(true)),
 
-        // Signature help
-        signature_help_provider: features.completion.then_some(SignatureHelpOptions {
-            trigger_characters: Some(vec!["(".to_string(), ",".to_string()]),
-            retrigger_characters: None,
-            work_done_progress_options: WorkDoneProgressOptions::default(),
-        }),
+        // Signature help is not implemented yet.
+        signature_help_provider: None,
 
         // Code lens
         code_lens_provider: features.code_lens.then_some(CodeLensOptions {
@@ -144,7 +140,7 @@ pub fn server_capabilities(features: LspFeatureConfig) -> ServerCapabilities {
 
         // Document links
         document_link_provider: features.document_links.then_some(DocumentLinkOptions {
-            resolve_provider: Some(true),
+            resolve_provider: Some(false),
             work_done_progress_options: WorkDoneProgressOptions::default(),
         }),
 
@@ -153,10 +149,8 @@ pub fn server_capabilities(features: LspFeatureConfig) -> ServerCapabilities {
             .folding_ranges
             .then_some(FoldingRangeProviderCapability::Simple(true)),
 
-        // Selection ranges
-        selection_range_provider: features
-            .folding_ranges
-            .then_some(SelectionRangeProviderCapability::Simple(true)),
+        // Selection ranges are not implemented yet.
+        selection_range_provider: None,
 
         // Inlay hints
         inlay_hint_provider: features.inlay_hints.then_some(OneOf::Left(true)),
@@ -216,5 +210,76 @@ fn file_rename_registration_options() -> FileOperationRegistrationOptions {
                 },
             },
         ],
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn all_features() -> LspFeatureConfig {
+        LspFeatureConfig {
+            lint: true,
+            typecheck: true,
+            completion: true,
+            hover: true,
+            definition: true,
+            references: true,
+            document_symbols: true,
+            workspace_symbols: true,
+            code_actions: true,
+            rename: true,
+            formatting: true,
+            code_lens: true,
+            semantic_tokens: true,
+            document_links: true,
+            folding_ranges: true,
+            inlay_hints: true,
+            file_rename: true,
+        }
+    }
+
+    #[test]
+    fn default_features_do_not_advertise_unimplemented_providers() {
+        let capabilities = server_capabilities(LspFeatureConfig::default());
+
+        assert!(capabilities.signature_help_provider.is_none());
+        assert!(capabilities.selection_range_provider.is_none());
+        assert!(capabilities.document_link_provider.is_none());
+    }
+
+    #[test]
+    fn all_features_skip_unimplemented_providers_and_keep_implemented_ones() {
+        let capabilities = server_capabilities(all_features());
+
+        assert!(capabilities.signature_help_provider.is_none());
+        assert!(capabilities.selection_range_provider.is_none());
+        assert_eq!(
+            capabilities
+                .document_link_provider
+                .as_ref()
+                .and_then(|provider| provider.resolve_provider),
+            Some(false)
+        );
+
+        assert!(capabilities.completion_provider.is_some());
+        assert!(capabilities.hover_provider.is_some());
+        assert!(capabilities.definition_provider.is_some());
+        assert!(capabilities.references_provider.is_some());
+        assert!(capabilities.document_symbol_provider.is_some());
+        assert!(capabilities.workspace_symbol_provider.is_some());
+        assert!(capabilities.code_action_provider.is_some());
+        assert!(capabilities.rename_provider.is_some());
+        assert!(capabilities.document_formatting_provider.is_some());
+        assert!(capabilities.document_range_formatting_provider.is_some());
+        assert!(capabilities.code_lens_provider.is_some());
+        assert!(capabilities.semantic_tokens_provider.is_some());
+        assert!(capabilities.document_link_provider.is_some());
+        assert!(capabilities.folding_range_provider.is_some());
+        assert!(capabilities.inlay_hint_provider.is_some());
+        assert!(capabilities
+            .workspace
+            .and_then(|workspace| workspace.file_operations)
+            .is_some());
     }
 }

--- a/crates/vize_patina/src/linter/native_type_aware/template_queries/calls.rs
+++ b/crates/vize_patina/src/linter/native_type_aware/template_queries/calls.rs
@@ -57,13 +57,32 @@ pub(super) fn collect_template_call_ranges(
         OxcParser::new(&allocator, source, source_type).parse_expression()
     ) {
         ranges.probe_expression_binding = expression_prefers_binding_probe(&expression);
-        if include_callees {
-            let mut collector = CallCalleeCollector::default();
-            profile!(
-                "patina.type_aware.template_calls.visit_expression",
-                collector.visit_expression(&expression)
+        let expression_consumes_source = expression.span().end as usize == source.trim_end().len();
+        if allow_statement_fallback && !expression_consumes_source {
+            let statement_ranges = collect_statement_template_call_ranges(
+                &allocator,
+                source_type,
+                source,
+                include_callees,
+                include_floating_promises,
             );
-            ranges.callees = collector.into_relative_ranges(0, source.len() as u32);
+            if include_callees {
+                ranges.callees = if statement_ranges.callees.is_empty() {
+                    collect_expression_call_callee_ranges(&expression, source.len() as u32)
+                } else {
+                    statement_ranges.callees
+                };
+            }
+            if include_floating_promises {
+                ranges.floating_promises = statement_ranges.floating_promises;
+            }
+
+            return ranges;
+        }
+
+        if include_callees {
+            ranges.callees =
+                collect_expression_call_callee_ranges(&expression, source.len() as u32);
         }
         if include_floating_promises {
             if allow_statement_fallback {
@@ -71,18 +90,13 @@ pub(super) fn collect_template_call_ranges(
                     ranges.floating_promises.push(range);
                 }
             }
-            if expression.span().end as usize == source.trim_end().len() {
-                profile!(
-                    "patina.type_aware.template_floating.visit_expression",
-                    collect_floating_promise_ranges_for_expression(
-                        &expression,
-                        &mut ranges.floating_promises
-                    )
-                );
-            } else if allow_statement_fallback {
-                ranges.floating_promises =
-                    collect_statement_floating_promise_ranges(&allocator, source_type, source);
-            }
+            profile!(
+                "patina.type_aware.template_floating.visit_expression",
+                collect_floating_promise_ranges_for_expression(
+                    &expression,
+                    &mut ranges.floating_promises
+                )
+            );
         }
         return ranges;
     }
@@ -91,15 +105,13 @@ pub(super) fn collect_template_call_ranges(
         return ranges;
     }
 
-    if include_callees {
-        ranges.callees = collect_statement_call_callee_ranges(&allocator, source_type, source);
-    }
-    if include_floating_promises {
-        ranges.floating_promises =
-            collect_statement_floating_promise_ranges(&allocator, source_type, source);
-    }
-
-    ranges
+    collect_statement_template_call_ranges(
+        &allocator,
+        source_type,
+        source,
+        include_callees,
+        include_floating_promises,
+    )
 }
 
 fn expression_prefers_binding_probe(expression: &Expression<'_>) -> bool {
@@ -219,11 +231,25 @@ fn floating_promise_range_from_span_with_target(
     }
 }
 
-fn collect_statement_call_callee_ranges(
+fn collect_expression_call_callee_ranges(
+    expression: &Expression<'_>,
+    source_len: u32,
+) -> Vec<RelativeRange> {
+    let mut collector = CallCalleeCollector::default();
+    profile!(
+        "patina.type_aware.template_calls.visit_expression",
+        collector.visit_expression(expression)
+    );
+    collector.into_relative_ranges(0, source_len)
+}
+
+fn collect_statement_template_call_ranges(
     allocator: &OxcAllocator,
     source_type: SourceType,
     source: &str,
-) -> Vec<RelativeRange> {
+    include_callees: bool,
+    include_floating_promises: bool,
+) -> TemplateCallRanges {
     let mut wrapped = String::with_capacity(TEMPLATE_HANDLER_PREFIX.len() + source.len() + 4);
     wrapped.push_str(TEMPLATE_HANDLER_PREFIX);
     wrapped.push_str(source);
@@ -234,41 +260,30 @@ fn collect_statement_call_callee_ranges(
         OxcParser::new(allocator, wrapped.as_str(), source_type).parse()
     );
     if parsed.panicked || !parsed.errors.is_empty() {
-        return Vec::new();
+        return TemplateCallRanges::default();
     }
 
-    let mut collector = CallCalleeCollector::default();
-    profile!(
-        "patina.type_aware.template_calls.visit_program",
-        collector.visit_program(&parsed.program)
-    );
-    collector.into_relative_ranges(TEMPLATE_HANDLER_PREFIX.len() as u32, source.len() as u32)
-}
-
-fn collect_statement_floating_promise_ranges(
-    allocator: &OxcAllocator,
-    source_type: SourceType,
-    source: &str,
-) -> Vec<FloatingPromiseRange> {
-    let mut wrapped = String::with_capacity(TEMPLATE_HANDLER_PREFIX.len() + source.len() + 4);
-    wrapped.push_str(TEMPLATE_HANDLER_PREFIX);
-    wrapped.push_str(source);
-    wrapped.push_str("\n}");
-
-    let parsed = profile!(
-        "patina.type_aware.template_floating.parse_statement",
-        OxcParser::new(allocator, wrapped.as_str(), source_type).parse()
-    );
-    if parsed.panicked || !parsed.errors.is_empty() {
-        return Vec::new();
+    let mut ranges = TemplateCallRanges::default();
+    if include_callees {
+        let mut collector = CallCalleeCollector::default();
+        profile!(
+            "patina.type_aware.template_calls.visit_program",
+            collector.visit_program(&parsed.program)
+        );
+        ranges.callees = collector
+            .into_relative_ranges(TEMPLATE_HANDLER_PREFIX.len() as u32, source.len() as u32);
+    }
+    if include_floating_promises {
+        let mut collector = FloatingPromiseCollector::default();
+        profile!(
+            "patina.type_aware.template_floating.visit_program",
+            collector.visit_program(&parsed.program)
+        );
+        ranges.floating_promises = collector
+            .into_relative_ranges(TEMPLATE_HANDLER_PREFIX.len() as u32, source.len() as u32);
     }
 
-    let mut collector = FloatingPromiseCollector::default();
-    profile!(
-        "patina.type_aware.template_floating.visit_program",
-        collector.visit_program(&parsed.program)
-    );
-    collector.into_relative_ranges(TEMPLATE_HANDLER_PREFIX.len() as u32, source.len() as u32)
+    ranges
 }
 
 #[derive(Default)]
@@ -559,6 +574,18 @@ mod tests {
         let ranges = collect_template_call_ranges(source, true, true, false);
 
         assert_eq!(range_slices(source, &ranges.callees), vec!["save", "track"]);
+        assert!(ranges.floating_promises.is_empty());
+    }
+
+    #[test]
+    fn collects_statement_fallback_callees_after_expression_prefix() {
+        let source = "safe(); anyHandler()";
+        let ranges = collect_template_call_ranges(source, true, true, false);
+
+        assert_eq!(
+            range_slices(source, &ranges.callees),
+            vec!["safe", "anyHandler"]
+        );
         assert!(ranges.floating_promises.is_empty());
     }
 

--- a/crates/vize_patina/src/linter/native_type_aware/tests.rs
+++ b/crates/vize_patina/src/linter/native_type_aware/tests.rs
@@ -567,6 +567,29 @@ const anyHandler: any = () => {}
 }
 
 #[test]
+fn no_unsafe_template_binding_reports_event_statement_calls_after_prefix() {
+    if !corsa_available() {
+        return;
+    }
+
+    let linter = Linter::with_preset(LintPreset::Opinionated);
+    let source = r#"<script setup lang="ts">
+const safe = () => {}
+const anyHandler: any = () => {}
+</script>
+
+<template>
+  <button @click="safe(); anyHandler()">Save</button>
+</template>"#;
+    let result = lint_sfc_with_corsa(&linter, source, "TypeAwareFixture.vue");
+
+    assert!(result
+        .diagnostics
+        .iter()
+        .any(|diag| diag.rule_name == RULE_NO_UNSAFE_TEMPLATE_BINDING));
+}
+
+#[test]
 fn no_unsafe_template_binding_reports_computed_member_template_bindings() {
     if !corsa_available() {
         return;


### PR DESCRIPTION
## Summary
- fall back to statement parsing for event handler expressions that only parse a leading expression prefix
- collect unsafe-template call probes and floating-promise probes from the same statement parse
- add coverage for unsafe calls after an earlier event statement

## Validation
- TMPDIR=$PWD/__agent_only/tmp cargo test -p vize_patina template_queries::calls -- --nocapture
- TMPDIR=$PWD/__agent_only/tmp cargo test -p vize_patina no_unsafe_template_binding_reports_event_statement_calls_after_prefix -- --nocapture
- TMPDIR=$PWD/__agent_only/tmp cargo clippy -p vize_patina -- -D warnings
- ./node_modules/.bin/vp lint
- git diff --check