### PR TITLE
fix(lsp): handle UTF-16 document positions

### DIFF
--- a/crates/vize_maestro/src/document/store.rs
+++ b/crates/vize_maestro/src/document/store.rs
@@ -242,6 +242,31 @@ mod tests {
     }
 
     #[test]
+    fn test_incremental_change_uses_utf16_positions() {
+        let mut doc = Document::new(test_uri(), "a😀b".to_string(), 1, "vue".to_string());
+
+        let change = TextDocumentContentChangeEvent {
+            range: Some(Range {
+                start: Position {
+                    line: 0,
+                    character: 3,
+                },
+                end: Position {
+                    line: 0,
+                    character: 4,
+                },
+            }),
+            range_length: None,
+            text: "c".to_string(),
+        };
+
+        doc.apply_change(&change, 2);
+
+        assert_eq!(doc.text(), "a😀c");
+        assert_eq!(doc.version, 2);
+    }
+
+    #[test]
     fn test_full_content_change() {
         let mut doc = Document::new(test_uri(), "hello world".to_string(), 1, "vue".to_string());
 

--- a/crates/vize_maestro/src/utils/position.rs
+++ b/crates/vize_maestro/src/utils/position.rs
@@ -13,7 +13,11 @@ pub fn offset_to_position(rope: &Rope, offset: usize) -> Option<Position> {
     let char_idx = rope.try_byte_to_char(offset).ok()?;
     let line = rope.char_to_line(char_idx);
     let line_start_char = rope.line_to_char(line);
-    let character = char_idx - line_start_char;
+    let character = rope
+        .slice(line_start_char..char_idx)
+        .chars()
+        .map(|ch| ch.len_utf16())
+        .sum::<usize>();
 
     Some(Position {
         line: line as u32,
@@ -31,10 +35,18 @@ pub fn position_to_offset(rope: &Rope, position: Position) -> Option<usize> {
     }
 
     let line_start_char = rope.line_to_char(line);
-    let line_len = rope.line(line).len_chars();
+    let mut utf16_units = 0usize;
+    let mut char_in_line = 0usize;
 
-    // Clamp character to line length
-    let char_in_line = character.min(line_len);
+    for ch in rope.line(line).chars() {
+        if utf16_units >= character || ch == '\n' {
+            break;
+        }
+
+        utf16_units += ch.len_utf16();
+        char_in_line += 1;
+    }
+
     let char_idx = line_start_char + char_in_line;
 
     rope.try_char_to_byte(char_idx).ok()
@@ -81,13 +93,15 @@ pub fn position_to_offset_str(content: &str, line: u32, character: u32) -> usize
 
     for (i, ch) in content.char_indices() {
         if current_line == line {
-            // We're on the target line, count characters
+            // We're on the target line, count UTF-16 code units
             let line_start = current_offset;
+            let mut utf16_units = 0u32;
 
-            for (char_count, (j, c)) in content[line_start..].char_indices().enumerate() {
-                if c == '\n' || char_count as u32 == character {
+            for (j, c) in content[line_start..].char_indices() {
+                if c == '\n' || utf16_units >= character {
                     return line_start + j;
                 }
+                utf16_units += c.len_utf16() as u32;
             }
             // End of file reached
             return content.len();
@@ -126,7 +140,9 @@ pub fn line_range(rope: &Rope, line: usize) -> Option<Range> {
 
 #[cfg(test)]
 mod tests {
-    use super::{internal_to_lsp_position, offset_to_position, position_to_offset};
+    use super::{
+        internal_to_lsp_position, offset_to_position, position_to_offset, position_to_offset_str,
+    };
     use ropey::Rope;
     use tower_lsp::lsp_types::Position;
 
@@ -210,6 +226,61 @@ mod tests {
             ),
             Some(6)
         );
+    }
+
+    #[test]
+    fn test_offset_to_position_counts_utf16_code_units() {
+        let rope = Rope::from_str("a😀b\nc");
+
+        assert_eq!(
+            offset_to_position(&rope, "a😀".len()),
+            Some(Position {
+                line: 0,
+                character: 3,
+            })
+        );
+        assert_eq!(
+            offset_to_position(&rope, "a😀b\nc".len()),
+            Some(Position {
+                line: 1,
+                character: 1,
+            })
+        );
+    }
+
+    #[test]
+    fn test_position_to_offset_counts_utf16_code_units() {
+        let rope = Rope::from_str("a😀b\nc");
+
+        assert_eq!(
+            position_to_offset(
+                &rope,
+                Position {
+                    line: 0,
+                    character: 3,
+                }
+            ),
+            Some("a😀".len())
+        );
+        assert_eq!(
+            position_to_offset(
+                &rope,
+                Position {
+                    line: 0,
+                    character: 4,
+                }
+            ),
+            Some("a😀b".len())
+        );
+    }
+
+    #[test]
+    fn test_position_to_offset_str_counts_utf16_code_units() {
+        let content = "a😀b\nc";
+
+        assert_eq!(position_to_offset_str(content, 0, 3), "a😀".len());
+        assert_eq!(position_to_offset_str(content, 0, 4), "a😀b".len());
+        assert_eq!(position_to_offset_str(content, 1, 1), content.len());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- make LSP position conversion count UTF-16 code units instead of Rust scalar chars
- apply UTF-16 range handling to incremental document changes
- add focused emoji/astral-plane coverage for shared position utilities and document store edits

## Validation
- cargo fmt -p vize_maestro
- cargo test -p vize_maestro utf16
- cargo test -p vize_maestro utils::position
- cargo test -p vize_maestro document::store
- git diff --check