### PR TITLE
fix(type-aware): preserve v-if template narrowing

### DIFF
--- a/crates/vize_croquis/src/virtual_ts/generator/template.rs
+++ b/crates/vize_croquis/src/virtual_ts/generator/template.rs
@@ -549,7 +549,7 @@ fn extract_var_names(vars_part: &str) -> Vec<String> {
 }
 
 fn push_unique_alias(aliases: &mut Vec<String>, alias: String) {
-    if !aliases.iter().any(|existing| existing == &alias) {
+    if !aliases.contains(&alias) {
         aliases.push(alias);
     }
 }

--- a/crates/vize_croquis/src/virtual_ts/generator/template.rs
+++ b/crates/vize_croquis/src/virtual_ts/generator/template.rs
@@ -149,6 +149,20 @@ impl VirtualTsGenerator {
 
     /// Visit an element node.
     fn visit_element(&mut self, element: &ElementNode) {
+        if let Some(condition) = element_control_flow_condition(element) {
+            if self.emit_mapped_expression_line(condition, "if (", ") {") {
+                self.indent_level += 1;
+                self.visit_element_inner(element);
+                self.indent_level = self.indent_level.saturating_sub(1);
+                self.emit_line("}");
+                return;
+            }
+        }
+
+        self.visit_element_inner(element);
+    }
+
+    fn visit_element_inner(&mut self, element: &ElementNode) {
         // Check if this element has a v-for directive
         let v_for_exp = element.props.iter().find_map(|prop| {
             if let PropNode::Directive(dir) = prop {
@@ -164,7 +178,7 @@ impl VirtualTsGenerator {
             self.emit_v_for_scope(exp, |this| {
                 for prop in &element.props {
                     if let PropNode::Directive(dir) = prop {
-                        if dir.name != "for" {
+                        if dir.name != "for" && !is_control_flow_directive(&dir.name) {
                             profile!(
                                 "croquis.virtual_ts.template.directive",
                                 this.visit_directive(dir)
@@ -180,10 +194,12 @@ impl VirtualTsGenerator {
         } else {
             for prop in &element.props {
                 if let PropNode::Directive(dir) = prop {
-                    profile!(
-                        "croquis.virtual_ts.template.directive",
-                        self.visit_directive(dir)
-                    );
+                    if !is_control_flow_directive(&dir.name) {
+                        profile!(
+                            "croquis.virtual_ts.template.directive",
+                            self.visit_directive(dir)
+                        );
+                    }
                 }
             }
             profile!(
@@ -256,11 +272,38 @@ impl VirtualTsGenerator {
 
     /// Visit an if node.
     fn visit_if(&mut self, if_node: &IfNode) {
+        let mut control_flow_open = false;
         for branch in &if_node.branches {
             if let Some(ref cond) = branch.condition {
-                self.emit_expression(cond, "v-if");
+                if control_flow_open {
+                    self.indent_level = self.indent_level.saturating_sub(1);
+                }
+
+                let prefix = if control_flow_open {
+                    "} else if ("
+                } else {
+                    "if ("
+                };
+                if self.emit_mapped_expression_line(cond, prefix, ") {") {
+                    control_flow_open = true;
+                    self.indent_level += 1;
+                } else {
+                    if control_flow_open {
+                        self.emit_line("}");
+                        control_flow_open = false;
+                    }
+                    self.emit_expression(cond, "v-if");
+                }
+            } else if control_flow_open {
+                self.indent_level = self.indent_level.saturating_sub(1);
+                self.emit_line("} else {");
+                self.indent_level += 1;
             }
             self.visit_children(&branch.children);
+        }
+        if control_flow_open {
+            self.indent_level = self.indent_level.saturating_sub(1);
+            self.emit_line("}");
         }
     }
 
@@ -414,6 +457,40 @@ impl VirtualTsGenerator {
             }
         });
     }
+
+    fn emit_mapped_expression_line(
+        &mut self,
+        expr: &ExpressionNode,
+        prefix: &str,
+        suffix: &str,
+    ) -> bool {
+        let ExpressionNode::Simple(simple) = expr else {
+            return false;
+        };
+        if simple.content.is_empty() {
+            return false;
+        }
+
+        let expr_start = self.gen_offset + (self.indent_level * 2 + prefix.len()) as u32;
+        let expr_end = expr_start + simple.content.len() as u32;
+        let source_start = simple.loc.start.offset + self.block_offset;
+        let source_end = simple.loc.end.offset + self.block_offset;
+
+        self.mappings.push(SourceMapping::with_data(
+            SourceRange::new(source_start, source_end),
+            SourceRange::new(expr_start, expr_end),
+            MappingData::Expression {
+                text: simple.content.to_compact_string(),
+            },
+        ));
+
+        self.emit_generated_line(|output| {
+            output.push_str(prefix);
+            output.push_str(simple.content.as_str());
+            output.push_str(suffix);
+        });
+        true
+    }
 }
 
 fn decimal_len(mut value: u32) -> usize {
@@ -423,4 +500,21 @@ fn decimal_len(mut value: u32) -> usize {
         len += 1;
     }
     len
+}
+
+fn element_control_flow_condition<'a>(
+    element: &'a ElementNode<'a>,
+) -> Option<&'a ExpressionNode<'a>> {
+    element.props.iter().find_map(|prop| {
+        let PropNode::Directive(dir) = prop else {
+            return None;
+        };
+        matches!(dir.name.as_str(), "if" | "else-if")
+            .then_some(dir.exp.as_ref())
+            .flatten()
+    })
+}
+
+fn is_control_flow_directive(name: &str) -> bool {
+    matches!(name, "if" | "else-if" | "else")
 }

--- a/crates/vize_croquis/src/virtual_ts/snapshots/vize_croquis__virtual_ts__tests__snapshot_template_with_v_if.snap
+++ b/crates/vize_croquis/src/virtual_ts/snapshots/vize_croquis__virtual_ts__tests__snapshot_template_with_v_if.snap
@@ -10,5 +10,7 @@ declare const __ctx: { isVisible: any, isAlternate: any };
 const { isVisible, isAlternate } = __ctx;
 
 // Template expressions
-const __expr_0 = isVisible;
-const __expr_1 = isAlternate;
+if (isVisible) {
+}
+if (isAlternate) {
+}

--- a/crates/vize_patina/src/linter/native_type_aware/template_queries/collector.rs
+++ b/crates/vize_patina/src/linter/native_type_aware/template_queries/collector.rs
@@ -305,12 +305,9 @@ fn collect_expression_query_sets(
         sinks.template_queries.as_deref_mut(),
         expression_generated_offset,
     ) {
-        let generated_offset = if call_ranges.probe_expression_binding {
+        let generated_offset =
             expression_binding_generated_offset(&virtual_ts.content, generated_offset)
-                .unwrap_or(generated_offset)
-        } else {
-            generated_offset
-        };
+                .unwrap_or(generated_offset);
         queries.push(TemplateQuery {
             kind: TemplateQueryKind::Expression,
             context,

--- a/crates/vize_patina/src/linter/native_type_aware/tests.rs
+++ b/crates/vize_patina/src/linter/native_type_aware/tests.rs
@@ -970,6 +970,32 @@ const actions = {
 }
 
 #[test]
+fn narrowed_template_bindings_inside_v_if_are_ignored() {
+    if !corsa_available() {
+        return;
+    }
+
+    let linter = Linter::with_preset(LintPreset::Opinionated);
+    let source = r#"<script setup lang="ts">
+const payload: unknown = 'safe'
+</script>
+
+<template>
+  <p v-if="typeof payload === 'string'">{{ payload.toUpperCase() }}</p>
+</template>"#;
+    let result = lint_sfc_with_corsa(&linter, source, "NarrowedTemplate.vue");
+
+    assert!(
+        !result
+            .diagnostics
+            .iter()
+            .any(|diag| diag.rule_name == RULE_NO_UNSAFE_TEMPLATE_BINDING),
+        "v-if narrowing should keep template binding safe: {:?}",
+        result.diagnostics
+    );
+}
+
+#[test]
 fn type_aware_diagnostics_snapshot() {
     if !corsa_available() {
         return;


### PR DESCRIPTION
## Summary
- emit v-if template conditions as generated TypeScript control flow so Corsa can apply narrowing
- probe template expression bindings instead of raw RHS positions for unsafe-template expression checks
- add coverage for narrowed unknown values used inside v-if templates
- keep v-for alias dedupe clippy-clean after integrating latest main

## Validation
- TMPDIR=$PWD/__agent_only/tmp cargo test -p vize_croquis snapshot_template_with_v_if -- --nocapture
- TMPDIR=$PWD/__agent_only/tmp cargo test -p vize_croquis snapshot_template_with_v_for -- --nocapture
- TMPDIR=$PWD/__agent_only/tmp cargo test -p vize_patina narrowed_template_bindings_inside_v_if_are_ignored -- --nocapture
- TMPDIR=$PWD/__agent_only/tmp cargo test -p vize_patina typed_v_for_alias_template_bindings_are_ignored -- --nocapture
- TMPDIR=$PWD/__agent_only/tmp cargo clippy -p vize_croquis -p vize_patina -- -D warnings
- ./node_modules/.bin/vp lint
- git diff --check