### PR TITLE
fix(lsp): count UTF-16 units in diagnostics

### DIFF
--- a/crates/vize_maestro/src/ide/diagnostics/mod.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/mod.rs
@@ -320,7 +320,7 @@ pub(super) fn offset_to_line_col(source: &str, offset: usize) -> (u32, u32) {
             line += 1;
             col = 0;
         } else {
-            col += 1;
+            col += ch.len_utf16() as u32;
         }
         current_offset += ch.len_utf8();
     }
@@ -330,7 +330,7 @@ pub(super) fn offset_to_line_col(source: &str, offset: usize) -> (u32, u32) {
 
 #[cfg(test)]
 mod tests {
-    use super::{sources, DiagnosticBuilder, DiagnosticService, Severity};
+    use super::{offset_to_line_col, sources, DiagnosticBuilder, DiagnosticService, Severity};
     use crate::server::ServerState;
     use tower_lsp::lsp_types::{DiagnosticSeverity, NumberOrString, Url};
 
@@ -375,6 +375,14 @@ mod tests {
             DiagnosticSeverity::from(Severity::Hint),
             DiagnosticSeverity::HINT
         );
+    }
+
+    #[test]
+    fn offset_to_line_col_counts_utf16_code_units() {
+        let source = "const icon = \"😀\"; missing";
+        let offset = source.find("missing").unwrap();
+
+        assert_eq!(offset_to_line_col(source, offset), (0, 19));
     }
 
     #[test]

--- a/crates/vize_maestro/src/ide/type_service/diagnostics.rs
+++ b/crates/vize_maestro/src/ide/type_service/diagnostics.rs
@@ -292,7 +292,7 @@ pub(super) fn offset_to_line_col(source: &str, offset: usize) -> (u32, u32) {
             line += 1;
             col = 0;
         } else {
-            col += 1;
+            col += ch.len_utf16() as u32;
         }
         current_offset += ch.len_utf8();
     }
@@ -311,6 +311,14 @@ mod diagnostics_tests {
         assert_eq!(offset_to_line_col("one\ntwo", 0), (0, 0));
         assert_eq!(offset_to_line_col("one\ntwo", 4), (1, 0));
         assert_eq!(offset_to_line_col("one\ntwo", 6), (1, 2));
+    }
+
+    #[test]
+    fn offset_to_line_col_counts_utf16_code_units() {
+        let source = "const icon = \"😀\"; missing";
+        let offset = source.find("missing").unwrap();
+
+        assert_eq!(offset_to_line_col(source, offset), (0, 19));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- count UTF-16 code units when converting diagnostic byte offsets to LSP columns
- apply the same conversion to type-service diagnostic ranges
- add focused emoji coverage for both diagnostic conversion paths

## Validation
- cargo fmt -p vize_maestro
- TMPDIR=$PWD/__agent_only/tmp cargo test -p vize_maestro offset_to_line_col_counts_utf16_code_units -- --nocapture
- TMPDIR=$PWD/__agent_only/tmp cargo clippy -p vize_maestro -- -D warnings
- git diff --check