### PR TITLE
ci: update upload artifact action

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -144,7 +144,7 @@ jobs:
         run: cat benchmark-summary.md >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload benchmark results
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: pr-benchmark
           path: |

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -190,7 +190,7 @@ jobs:
 
       - name: Upload VRT report
         if: steps.vrt.outcome == 'failure'
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: playground-vrt-report
           path: playground/playwright-report/
@@ -207,7 +207,7 @@ jobs:
 
       - name: Upload VRT diff artifacts
         if: steps.vrt.outcome == 'failure'
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: vrt-diff
           path: playground/e2e/vrt/test-results/
@@ -232,7 +232,7 @@ jobs:
       - name: Collect test inventory
         run: node bench/test-inventory.mjs --json test-inventory.json --markdown "$GITHUB_STEP_SUMMARY"
       - name: Upload test inventory
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: test-inventory
           path: test-inventory.json

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -50,7 +50,7 @@ jobs:
         run: vp run --filter './docs' build
 
       - name: Upload docs artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: docs
           path: docs/dist
@@ -113,13 +113,13 @@ jobs:
         run: vp run --filter './examples/vite-musea' build
 
       - name: Upload playground artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: playground
           path: playground/dist
 
       - name: Upload musea-examples artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: musea-examples
           path: examples/vite-musea/dist

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -110,7 +110,7 @@ jobs:
 
       - name: Upload app e2e artifacts
         if: failure()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: app-e2e-artifacts-${{ inputs.suite }}
           path: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,7 +95,7 @@ jobs:
         run: moon run --target native - -- ${{ matrix.settings.target }} ${{ matrix.settings.archive }} vize.exe < tools/moon/scripts/github/create_cli_archive.mbtx
 
       - name: Upload artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: cli-${{ matrix.settings.target }}
           path: ${{ matrix.settings.archive }}
@@ -138,7 +138,7 @@ jobs:
         run: vp run --workspace-root package:zed-extension
 
       - name: Upload artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: editor-extensions
           path: |
@@ -211,7 +211,7 @@ jobs:
         run: moon run --target native - -- vp run --filter './npm/vize' build -- vp run --filter './npm/vite-plugin-vize' build -- vp run --filter './npm/oxlint-plugin-vize' build -- vp run --filter './npm/unplugin-vize' build -- vp run --filter './npm/fresco' build -- vp run --filter './npm/musea-mcp-server' build -- vp run --filter './npm/vite-plugin-musea' build -- vp run --filter './npm/vite-plugin-musea' build:gallery -- vp run --filter './npm/rspack-vize-plugin' build -- vp run --filter './npm/musea-nuxt' build -- vp run --filter './npm/nuxt' build < tools/moon/scripts/github/run_many.mbtx
 
       - name: Upload vize CLI package artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: release-package-vize
           path: npm/vize
@@ -219,7 +219,7 @@ jobs:
           compression-level: 0
 
       - name: Upload Vite plugin artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: release-package-vite-plugin-vize
           path: npm/vite-plugin-vize
@@ -227,7 +227,7 @@ jobs:
           compression-level: 0
 
       - name: Upload Oxlint plugin artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: release-package-oxlint-plugin-vize
           path: npm/oxlint-plugin-vize
@@ -235,7 +235,7 @@ jobs:
           compression-level: 0
 
       - name: Upload unplugin artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: release-package-unplugin-vize
           path: npm/unplugin-vize
@@ -243,7 +243,7 @@ jobs:
           compression-level: 0
 
       - name: Upload Fresco artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: release-package-fresco
           path: npm/fresco
@@ -251,7 +251,7 @@ jobs:
           compression-level: 0
 
       - name: Upload Musea MCP server artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: release-package-musea-mcp-server
           path: npm/musea-mcp-server
@@ -259,7 +259,7 @@ jobs:
           compression-level: 0
 
       - name: Upload Musea Vite plugin artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: release-package-vite-plugin-musea
           path: npm/vite-plugin-musea
@@ -267,7 +267,7 @@ jobs:
           compression-level: 0
 
       - name: Upload Rspack plugin artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: release-package-rspack-vize-plugin
           path: npm/rspack-vize-plugin
@@ -275,7 +275,7 @@ jobs:
           compression-level: 0
 
       - name: Upload Musea Nuxt artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: release-package-musea-nuxt
           path: npm/musea-nuxt
@@ -283,7 +283,7 @@ jobs:
           compression-level: 0
 
       - name: Upload Nuxt artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: release-package-nuxt
           path: npm/nuxt
@@ -375,7 +375,7 @@ jobs:
         run: moon run --target native - -- npm/vize-native .artifacts/vize-native vize-native < tools/moon/scripts/github/collect_native_artifacts.mbtx
 
       - name: Upload vize-native artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: bindings-${{ matrix.settings.target }}
           path: .artifacts/vize-native/*.node
@@ -391,7 +391,7 @@ jobs:
         run: moon run --target native - -- npm/fresco-native .artifacts/fresco-native fresco-native < tools/moon/scripts/github/collect_native_artifacts.mbtx
 
       - name: Upload fresco-native artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: fresco-bindings-${{ matrix.settings.target }}
           path: .artifacts/fresco-native/*.node


### PR DESCRIPTION
## Summary
- update pinned actions/upload-artifact references from v4.6.2 to v7.0.1
- keep workflow action references pinned to the v7.0.1 commit SHA
- remove the Node.js 20 deprecation warning for artifact uploads

## Validation
- git diff --check
- yq parse of .github/workflows/*.yml
- gh workflow list --repo ubugeeei/vize --all
