### PR TITLE
fix(maestro): reject invalid LSP document positions

### DIFF
--- a/crates/vize_maestro/src/document/store.rs
+++ b/crates/vize_maestro/src/document/store.rs
@@ -111,6 +111,14 @@ impl DocumentStore {
 
     /// Rename an open document while preserving its content and version.
     pub fn rename(&self, old_uri: &Url, new_uri: Url) -> bool {
+        if old_uri == &new_uri {
+            return self.documents.contains_key(old_uri);
+        }
+
+        if self.documents.contains_key(&new_uri) {
+            return false;
+        }
+
         let Some((_, mut document)) = self.documents.remove(old_uri) else {
             return false;
         };
@@ -267,6 +275,31 @@ mod tests {
     }
 
     #[test]
+    fn test_incremental_change_rejects_utf16_surrogate_pair_interior() {
+        let mut doc = Document::new(test_uri(), "a😀b".to_string(), 1, "vue".to_string());
+
+        let change = TextDocumentContentChangeEvent {
+            range: Some(Range {
+                start: Position {
+                    line: 0,
+                    character: 2,
+                },
+                end: Position {
+                    line: 0,
+                    character: 3,
+                },
+            }),
+            range_length: None,
+            text: "x".to_string(),
+        };
+
+        doc.apply_change(&change, 2);
+
+        assert_eq!(doc.text(), "a😀b");
+        assert_eq!(doc.version, 2);
+    }
+
+    #[test]
     fn test_full_content_change() {
         let mut doc = Document::new(test_uri(), "hello world".to_string(), 1, "vue".to_string());
 
@@ -365,5 +398,26 @@ mod tests {
         let doc = store.get(&new_uri).unwrap();
         assert_eq!(doc.text(), "content");
         assert_eq!(doc.version, 3);
+    }
+
+    #[test]
+    fn test_document_store_rename_does_not_overwrite_open_target() {
+        let store = DocumentStore::new();
+        let old_uri = test_uri();
+        let new_uri = Url::parse("file:///renamed.vue").unwrap();
+
+        store.open(old_uri.clone(), "source".to_string(), 3, "vue".to_string());
+        store.open(new_uri.clone(), "target".to_string(), 7, "vue".to_string());
+
+        assert!(!store.rename(&old_uri, new_uri.clone()));
+
+        let source = store.get(&old_uri).unwrap();
+        assert_eq!(source.text(), "source");
+        assert_eq!(source.version, 3);
+        drop(source);
+
+        let target = store.get(&new_uri).unwrap();
+        assert_eq!(target.text(), "target");
+        assert_eq!(target.version, 7);
     }
 }

--- a/crates/vize_maestro/src/utils/position.rs
+++ b/crates/vize_maestro/src/utils/position.rs
@@ -39,12 +39,21 @@ pub fn position_to_offset(rope: &Rope, position: Position) -> Option<usize> {
     let mut char_in_line = 0usize;
 
     for ch in rope.line(line).chars() {
-        if utf16_units >= character || ch == '\n' {
+        if utf16_units == character || ch == '\n' {
             break;
         }
 
-        utf16_units += ch.len_utf16();
+        let next_utf16_units = utf16_units + ch.len_utf16();
+        if character < next_utf16_units {
+            return None;
+        }
+
+        utf16_units = next_utf16_units;
         char_in_line += 1;
+    }
+
+    if utf16_units != character {
+        return None;
     }
 
     let char_idx = line_start_char + char_in_line;
@@ -271,6 +280,22 @@ mod tests {
                 }
             ),
             Some("a😀b".len())
+        );
+    }
+
+    #[test]
+    fn test_position_to_offset_rejects_utf16_surrogate_pair_interior() {
+        let rope = Rope::from_str("a😀b");
+
+        assert_eq!(
+            position_to_offset(
+                &rope,
+                Position {
+                    line: 0,
+                    character: 2,
+                }
+            ),
+            None
         );
     }
 


### PR DESCRIPTION
## Summary
- reject LSP UTF-16 positions that land inside surrogate pairs
- ignore incremental document edits with invalid UTF-16 ranges
- prevent document rename collisions from overwriting already-open targets

## Validation
- cargo fmt -p vize_maestro
- cargo test -p vize_maestro
- cargo clippy -p vize_maestro --lib -- -D warnings

Note: cargo clippy -p vize_maestro --all-targets -- -D warnings currently fails on existing insta snapshot-test macro lints outside this change.