### PR TITLE
fix(patina): ignore incomplete template type probes

### DIFF
--- a/crates/vize_patina/src/linter/native_type_aware/template_queries/calls.rs
+++ b/crates/vize_patina/src/linter/native_type_aware/template_queries/calls.rs
@@ -35,6 +35,7 @@ pub(super) struct TemplateCallRanges {
     pub callees: Vec<RelativeRange>,
     pub floating_promises: Vec<FloatingPromiseRange>,
     pub probe_expression_binding: bool,
+    pub expression_consumes_source: bool,
 }
 
 const TEMPLATE_HANDLER_PREFIX: &str = "function __vize_template_handler(){\n";
@@ -58,6 +59,7 @@ pub(super) fn collect_template_call_ranges(
     ) {
         ranges.probe_expression_binding = expression_prefers_binding_probe(&expression);
         let expression_consumes_source = expression.span().end as usize == source.trim_end().len();
+        ranges.expression_consumes_source = expression_consumes_source;
         if allow_statement_fallback && !expression_consumes_source {
             let statement_ranges = collect_statement_template_call_ranges(
                 &allocator,

--- a/crates/vize_patina/src/linter/native_type_aware/template_queries/collector.rs
+++ b/crates/vize_patina/src/linter/native_type_aware/template_queries/collector.rs
@@ -301,23 +301,23 @@ fn collect_expression_query_sets(
         )
     );
 
-    if let (Some(queries), Some(generated_offset)) = (
-        sinks.template_queries.as_deref_mut(),
-        expression_generated_offset,
-    ) {
-        let generated_offset =
-            expression_binding_generated_offset(&virtual_ts.content, generated_offset)
-                .unwrap_or(generated_offset);
-        queries.push(TemplateQuery {
-            kind: TemplateQueryKind::Expression,
-            context,
-            generated_offset,
-            source_start,
-            source_end,
-            owner_start: source_start,
-            owner_end: source_end,
-        });
-
+    if let Some(queries) = sinks.template_queries.as_deref_mut() {
+        if call_ranges.expression_consumes_source {
+            if let Some(generated_offset) = expression_generated_offset {
+                let generated_offset =
+                    expression_binding_generated_offset(&virtual_ts.content, generated_offset)
+                        .unwrap_or(generated_offset);
+                queries.push(TemplateQuery {
+                    kind: TemplateQueryKind::Expression,
+                    context,
+                    generated_offset,
+                    source_start,
+                    source_end,
+                    owner_start: source_start,
+                    owner_end: source_end,
+                });
+            }
+        }
         for callee in call_ranges.callees {
             let callee_start = source_start + callee.start;
             let callee_end = source_start + callee.end;

--- a/crates/vize_patina/src/linter/native_type_aware/tests.rs
+++ b/crates/vize_patina/src/linter/native_type_aware/tests.rs
@@ -238,6 +238,31 @@ async function save(): Promise<void> {}
 }
 
 #[test]
+fn malformed_template_event_expressions_skip_type_aware_noise() {
+    if !corsa_available() {
+        return;
+    }
+
+    let linter = Linter::with_preset(LintPreset::Opinionated);
+    let source = r#"<script setup lang="ts">
+async function save(): Promise<void> {}
+</script>
+
+<template>
+  <button @click="save(">Save</button>
+</template>"#;
+    let result = lint_sfc_with_corsa(&linter, source, "Component.vue");
+    assert!(
+        !result
+            .diagnostics
+            .iter()
+            .any(|diag| diag.rule_name == RULE_NO_FLOATING_PROMISES),
+        "malformed template event should not emit floating-promise noise: {:?}",
+        result.diagnostics
+    );
+}
+
+#[test]
 fn no_floating_promises_reports_bare_template_event_handlers() {
     if !corsa_available() {
         return;
@@ -610,6 +635,31 @@ const payload: Record<string, any> = { label: 'unsafe' }
         .diagnostics
         .iter()
         .any(|diag| diag.rule_name == RULE_NO_UNSAFE_TEMPLATE_BINDING));
+}
+
+#[test]
+fn malformed_template_interpolations_skip_type_aware_noise() {
+    if !corsa_available() {
+        return;
+    }
+
+    let linter = Linter::with_preset(LintPreset::Opinionated);
+    let source = r#"<script setup lang="ts">
+const payload: any = { label: 'unsafe' }
+</script>
+
+<template>
+  <div>{{ payload. }}</div>
+</template>"#;
+    let result = lint_sfc_with_corsa(&linter, source, "TypeAwareFixture.vue");
+    assert!(
+        !result
+            .diagnostics
+            .iter()
+            .any(|diag| diag.rule_name == RULE_NO_UNSAFE_TEMPLATE_BINDING),
+        "malformed interpolation should not emit unsafe-binding noise: {:?}",
+        result.diagnostics
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- skip native type-aware expression probes when the template expression parser only consumes a recovered prefix
- add regression coverage for malformed event handlers and interpolations avoiding type-aware noise

## Validation
- cargo fmt -p vize_patina
- cargo test -p vize_patina linter::native_type_aware::tests -- --nocapture
- cargo clippy -p vize_patina --lib -- -D warnings

Note: cargo clippy -p vize_patina --all-targets -- -D warnings still hits existing bench/test lint violations unrelated to this change.