### PR TITLE
docs(blog): add descriptions and link underlines

### DIFF
--- a/docs/content/blog/index.md
+++ b/docs/content/blog/index.md
@@ -36,17 +36,61 @@ The Vize docs now have two writing lanes:
 
 ## Latest Posts
 
-- [Tooling Compare](./notes/2026-05-16-comparing-vize-with-official-vue-oxc-golar-verter-flint-and-tsslint.md)
-- [Performance Tuning](./notes/2026-05-16-performance-tuning-notes-for-a-vue-toolchain.md)
-- [Testing & Agents](./notes/2026-05-16-testing-agentic-coding-and-trust.md)
-- [Vapor Mode](./notes/2026-05-16-vapor-mode-and-the-next-vue-compiler-surface.md)
-- [Vue as Language](./notes/2026-05-16-vue-as-a-language-and-the-strongest-frontend-environment.md)
-- [Musea & AI](./notes/2026-05-16-why-musea-and-design-systems-matter-in-the-ai-era.md)
-- [Production Ready](./notes/2026-05-16-real-world-feedback-and-the-road-to-production-ready.md)
-- [Personal Speed](./notes/2026-05-16-unofficial-personal-tooling-and-development-speed.md)
-- [Vertical Toolchains](./notes/2026-03-26-the-advantages-and-beauty-of-toolchains-and-vertical-integration.md)
-- [Static Analysis for AI](./notes/2026-03-26-why-ai-needs-deterministic-fast-static-analysis.md)
-- [Vue Tooling Map](./notes/2026-03-26-where-vize-fits-in-the-vue-tooling-landscape.md)
-- [`oxlint-plugin-vize` Alpha](./releases/2026-03-26-oxlint-plugin-vize-alpha.md)
-- [Docs Blog](./releases/2026-03-26-docs-blog-support.md)
-- [Notes Lane](./notes/2026-03-26-why-vize-needs-notes.md)
+<div class="blog-post-list">
+  <a class="blog-post-list-item" href="./notes/2026-05-16-comparing-vize-with-official-vue-oxc-golar-verter-flint-and-tsslint.md">
+    <strong>Tooling Compare</strong>
+    <span>A practical comparison of Vize and nearby projects across official Vue tooling, Oxc, Golar, Verter, Flint, and TSSLint.</span>
+  </a>
+  <a class="blog-post-list-item" href="./notes/2026-05-16-performance-tuning-notes-for-a-vue-toolchain.md">
+    <strong>Performance Tuning</strong>
+    <span>Practical performance lessons from building a Vue toolchain where parsing, allocation, parallelism, and feedback loops all matter.</span>
+  </a>
+  <a class="blog-post-list-item" href="./notes/2026-05-16-testing-agentic-coding-and-trust.md">
+    <strong>Testing & Agents</strong>
+    <span>Why snapshot-heavy tests, real-world fixtures, and deterministic checks matter more when agents are part of the development loop.</span>
+  </a>
+  <a class="blog-post-list-item" href="./notes/2026-05-16-vapor-mode-and-the-next-vue-compiler-surface.md">
+    <strong>Vapor Mode</strong>
+    <span>Why Vapor Mode matters for Vize, and why a direct fine-grained compiler path changes more than runtime performance.</span>
+  </a>
+  <a class="blog-post-list-item" href="./notes/2026-05-16-vue-as-a-language-and-the-strongest-frontend-environment.md">
+    <strong>Vue as Language</strong>
+    <span>Building on the idea that Vue is a language for UI, this note explains why frontend development needs a coherent environment rather than scattered tools.</span>
+  </a>
+  <a class="blog-post-list-item" href="./notes/2026-05-16-why-musea-and-design-systems-matter-in-the-ai-era.md">
+    <strong>Musea & AI</strong>
+    <span>AI can generate UI quickly, but Musea and design systems make the intent, constraints, accessibility, and review workflow durable.</span>
+  </a>
+  <a class="blog-post-list-item" href="./notes/2026-05-16-real-world-feedback-and-the-road-to-production-ready.md">
+    <strong>Production Ready</strong>
+    <span>Why exhaustive real-world validation and community feedback are the path from experimental project to production-ready toolchain.</span>
+  </a>
+  <a class="blog-post-list-item" href="./notes/2026-05-16-unofficial-personal-tooling-and-development-speed.md">
+    <strong>Personal Speed</strong>
+    <span>Why Vize being unofficial and personal can be an advantage for exploration, speed, and ambitious toolchain design.</span>
+  </a>
+  <a class="blog-post-list-item" href="./notes/2026-03-26-the-advantages-and-beauty-of-toolchains-and-vertical-integration.md">
+    <strong>Vertical Toolchains</strong>
+    <span>Why owning more of the stack can improve speed, coherence, and even the aesthetic quality of developer tools.</span>
+  </a>
+  <a class="blog-post-list-item" href="./notes/2026-03-26-why-ai-needs-deterministic-fast-static-analysis.md">
+    <strong>Static Analysis for AI</strong>
+    <span>As AI writes more code, we need faster and more reliable static feedback, not less.</span>
+  </a>
+  <a class="blog-post-list-item" href="./notes/2026-03-26-where-vize-fits-in-the-vue-tooling-landscape.md">
+    <strong>Vue Tooling Map</strong>
+    <span>A map of where Vize sits in the current Vue tooling landscape, and how it differs from adjacent projects.</span>
+  </a>
+  <a class="blog-post-list-item" href="./releases/2026-03-26-oxlint-plugin-vize-alpha.md">
+    <strong><code>oxlint-plugin-vize</code> Alpha</strong>
+    <span>A new Oxlint JS plugin bridge brings Vize Patina diagnostics into a single Oxlint run for Vue SFCs.</span>
+  </a>
+  <a class="blog-post-list-item" href="./releases/2026-03-26-docs-blog-support.md">
+    <strong>Docs Blog</strong>
+    <span>The Vize docs can now host both release notes and irregular notes.</span>
+  </a>
+  <a class="blog-post-list-item" href="./notes/2026-03-26-why-vize-needs-notes.md">
+    <strong>Notes Lane</strong>
+    <span>Some project updates need room for context, not just a changelog entry.</span>
+  </a>
+</div>

--- a/docs/content/blog/notes/index.md
+++ b/docs/content/blog/notes/index.md
@@ -16,15 +16,53 @@ Use this section for writing that does not fit a release announcement: architect
 
 ## Posts
 
-- [Tooling Compare](./2026-05-16-comparing-vize-with-official-vue-oxc-golar-verter-flint-and-tsslint.md)
-- [Performance Tuning](./2026-05-16-performance-tuning-notes-for-a-vue-toolchain.md)
-- [Testing & Agents](./2026-05-16-testing-agentic-coding-and-trust.md)
-- [Vapor Mode](./2026-05-16-vapor-mode-and-the-next-vue-compiler-surface.md)
-- [Vue as Language](./2026-05-16-vue-as-a-language-and-the-strongest-frontend-environment.md)
-- [Musea & AI](./2026-05-16-why-musea-and-design-systems-matter-in-the-ai-era.md)
-- [Production Ready](./2026-05-16-real-world-feedback-and-the-road-to-production-ready.md)
-- [Personal Speed](./2026-05-16-unofficial-personal-tooling-and-development-speed.md)
-- [Vertical Toolchains](./2026-03-26-the-advantages-and-beauty-of-toolchains-and-vertical-integration.md)
-- [Static Analysis for AI](./2026-03-26-why-ai-needs-deterministic-fast-static-analysis.md)
-- [Vue Tooling Map](./2026-03-26-where-vize-fits-in-the-vue-tooling-landscape.md)
-- [Notes Lane](./2026-03-26-why-vize-needs-notes.md)
+<div class="blog-post-list">
+  <a class="blog-post-list-item" href="./2026-05-16-comparing-vize-with-official-vue-oxc-golar-verter-flint-and-tsslint.md">
+    <strong>Tooling Compare</strong>
+    <span>A practical comparison of Vize and nearby projects across official Vue tooling, Oxc, Golar, Verter, Flint, and TSSLint.</span>
+  </a>
+  <a class="blog-post-list-item" href="./2026-05-16-performance-tuning-notes-for-a-vue-toolchain.md">
+    <strong>Performance Tuning</strong>
+    <span>Practical performance lessons from building a Vue toolchain where parsing, allocation, parallelism, and feedback loops all matter.</span>
+  </a>
+  <a class="blog-post-list-item" href="./2026-05-16-testing-agentic-coding-and-trust.md">
+    <strong>Testing & Agents</strong>
+    <span>Why snapshot-heavy tests, real-world fixtures, and deterministic checks matter more when agents are part of the development loop.</span>
+  </a>
+  <a class="blog-post-list-item" href="./2026-05-16-vapor-mode-and-the-next-vue-compiler-surface.md">
+    <strong>Vapor Mode</strong>
+    <span>Why Vapor Mode matters for Vize, and why a direct fine-grained compiler path changes more than runtime performance.</span>
+  </a>
+  <a class="blog-post-list-item" href="./2026-05-16-vue-as-a-language-and-the-strongest-frontend-environment.md">
+    <strong>Vue as Language</strong>
+    <span>Building on the idea that Vue is a language for UI, this note explains why frontend development needs a coherent environment rather than scattered tools.</span>
+  </a>
+  <a class="blog-post-list-item" href="./2026-05-16-why-musea-and-design-systems-matter-in-the-ai-era.md">
+    <strong>Musea & AI</strong>
+    <span>AI can generate UI quickly, but Musea and design systems make the intent, constraints, accessibility, and review workflow durable.</span>
+  </a>
+  <a class="blog-post-list-item" href="./2026-05-16-real-world-feedback-and-the-road-to-production-ready.md">
+    <strong>Production Ready</strong>
+    <span>Why exhaustive real-world validation and community feedback are the path from experimental project to production-ready toolchain.</span>
+  </a>
+  <a class="blog-post-list-item" href="./2026-05-16-unofficial-personal-tooling-and-development-speed.md">
+    <strong>Personal Speed</strong>
+    <span>Why Vize being unofficial and personal can be an advantage for exploration, speed, and ambitious toolchain design.</span>
+  </a>
+  <a class="blog-post-list-item" href="./2026-03-26-the-advantages-and-beauty-of-toolchains-and-vertical-integration.md">
+    <strong>Vertical Toolchains</strong>
+    <span>Why owning more of the stack can improve speed, coherence, and even the aesthetic quality of developer tools.</span>
+  </a>
+  <a class="blog-post-list-item" href="./2026-03-26-why-ai-needs-deterministic-fast-static-analysis.md">
+    <strong>Static Analysis for AI</strong>
+    <span>As AI writes more code, we need faster and more reliable static feedback, not less.</span>
+  </a>
+  <a class="blog-post-list-item" href="./2026-03-26-where-vize-fits-in-the-vue-tooling-landscape.md">
+    <strong>Vue Tooling Map</strong>
+    <span>A map of where Vize sits in the current Vue tooling landscape, and how it differs from adjacent projects.</span>
+  </a>
+  <a class="blog-post-list-item" href="./2026-03-26-why-vize-needs-notes.md">
+    <strong>Notes Lane</strong>
+    <span>Some project updates need room for context, not just a changelog entry.</span>
+  </a>
+</div>

--- a/docs/content/blog/releases/index.md
+++ b/docs/content/blog/releases/index.md
@@ -16,5 +16,13 @@ Use this section for shipped changes: new versions, notable fixes, migrations, d
 
 ## Posts
 
-- [`oxlint-plugin-vize` Alpha](./2026-03-26-oxlint-plugin-vize-alpha.md)
-- [Docs Blog](./2026-03-26-docs-blog-support.md)
+<div class="blog-post-list">
+  <a class="blog-post-list-item" href="./2026-03-26-oxlint-plugin-vize-alpha.md">
+    <strong><code>oxlint-plugin-vize</code> Alpha</strong>
+    <span>A new Oxlint JS plugin bridge brings Vize Patina diagnostics into a single Oxlint run for Vue SFCs.</span>
+  </a>
+  <a class="blog-post-list-item" href="./2026-03-26-docs-blog-support.md">
+    <strong>Docs Blog</strong>
+    <span>The Vize docs can now host both release notes and irregular notes.</span>
+  </a>
+</div>

--- a/docs/theme/style.css
+++ b/docs/theme/style.css
@@ -985,6 +985,12 @@ body.entry-page .entry-content .content > h2 + p > img {
 /* ================================================
    BLOG
    ================================================ */
+.content a:not(.blog-card):not(.blog-author-card):not(.blog-post-list-item) {
+  text-decoration: underline;
+  text-underline-offset: 0.16em;
+  text-decoration-thickness: 0.08em;
+}
+
 .blog-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
@@ -1031,6 +1037,44 @@ body.entry-page .entry-content .content > h2 + p > img {
   letter-spacing: 0.08em;
   text-transform: uppercase;
   color: var(--octc-color-text-muted);
+}
+
+.blog-post-list {
+  display: grid;
+  gap: 0;
+  margin: 1.25rem 0 2rem;
+  border-top: 1px solid color-mix(in srgb, var(--octc-color-border) 78%, transparent);
+}
+
+.blog-post-list-item {
+  display: grid;
+  gap: 0.35rem;
+  padding: 1rem 0;
+  border-bottom: 1px solid color-mix(in srgb, var(--octc-color-border) 62%, transparent);
+  color: var(--octc-color-text) !important;
+  text-decoration: none;
+}
+
+.blog-post-list-item:hover strong {
+  color: var(--octc-color-text);
+  text-decoration-thickness: 0.12em;
+}
+
+.blog-post-list-item strong {
+  width: fit-content;
+  font-size: 1rem;
+  letter-spacing: -0.01em;
+  line-height: 1.35;
+  text-decoration: underline;
+  text-underline-offset: 0.16em;
+  text-decoration-thickness: 0.08em;
+}
+
+.blog-post-list-item span {
+  max-width: 68ch;
+  color: var(--octc-color-text-muted);
+  font-size: 0.92rem;
+  line-height: 1.55;
 }
 
 .content img[src^="/blog/"],


### PR DESCRIPTION
## Summary
- show post descriptions on the blog, notes, and release listing pages
- underline readable content links while keeping blog cards visually clean

## Verification
- pnpm --dir docs build