### PR TITLE
fix(release): forward vp run release arguments

### DIFF
--- a/tests/tooling/task-shell.test.ts
+++ b/tests/tooling/task-shell.test.ts
@@ -41,24 +41,36 @@ test("task shell commands apply locale before sh starts", () => {
 
 test("task shell commands can forward Vite+ task arguments", () => {
   assert.equal(
-    shellCommandForwardingArguments("moon run -q --target native - -- \"$@\" < tools/moon/scripts/release.mbtx", []),
-    'sh -c \'moon run -q --target native - -- "$@" < tools/moon/scripts/release.mbtx\' --',
+    shellCommandForwardingArguments(
+      'moon run -q --target native - -- "$@" < tools/moon/scripts/release.mbtx',
+      [],
+    ),
+    "sh -c 'moon run -q --target native - -- \"$@\" < tools/moon/scripts/release.mbtx' --",
   );
 });
 
 test("Rust task environments preserve forwarded arguments", () => {
-  const command = withRustTaskEnvironment("moon run -q --target native - -- \"$@\" < tools/moon/scripts/release.mbtx", {
-    forwardArguments: true,
-  });
+  const command = withRustTaskEnvironment(
+    'moon run -q --target native - -- "$@" < tools/moon/scripts/release.mbtx',
+    {
+      forwardArguments: true,
+    },
+  );
 
-  assert.match(command, /sh -c .*moon run -q --target native - -- "\$@" < tools\/moon\/scripts\/release\.mbtx/);
+  assert.match(
+    command,
+    /sh -c .*moon run -q --target native - -- "\$@" < tools\/moon\/scripts\/release\.mbtx/,
+  );
   assert.match(command, / --$/);
 });
 
 test("release task forwards extra vp run arguments into the MoonBit script", () => {
   const command = (releaseTasks.release as { command: string }).command;
 
-  assert.match(command, /moon run -q --target native - -- "\$@" < tools\/moon\/scripts\/release\.mbtx/);
+  assert.match(
+    command,
+    /moon run -q --target native - -- "\$@" < tools\/moon\/scripts\/release\.mbtx/,
+  );
   assert.match(command, / --$/);
 });
 

--- a/tests/tooling/task-shell.test.ts
+++ b/tests/tooling/task-shell.test.ts
@@ -5,7 +5,10 @@ import {
   getTaskShellLocaleAssignments,
   normalizeTaskShellLocale,
   shellCommand,
+  shellCommandForwardingArguments,
+  withRustTaskEnvironment,
 } from "../../tools/vite-plus/task-shell.ts";
+import { releaseTasks } from "../../tools/vite-plus/tasks/release.ts";
 
 test("macOS task shells fall back from C.UTF-8 to an installed UTF-8 locale", () => {
   assert.deepEqual(
@@ -34,6 +37,29 @@ test("task shell commands apply locale before sh starts", () => {
     shellCommand("cd examples/vite-musea && pnpm run check", ["LC_ALL='en_US.UTF-8'"]),
     "env LC_ALL='en_US.UTF-8' sh -c 'cd examples/vite-musea && pnpm run check'",
   );
+});
+
+test("task shell commands can forward Vite+ task arguments", () => {
+  assert.equal(
+    shellCommandForwardingArguments("moon run -q --target native - -- \"$@\" < tools/moon/scripts/release.mbtx", []),
+    'sh -c \'moon run -q --target native - -- "$@" < tools/moon/scripts/release.mbtx\' --',
+  );
+});
+
+test("Rust task environments preserve forwarded arguments", () => {
+  const command = withRustTaskEnvironment("moon run -q --target native - -- \"$@\" < tools/moon/scripts/release.mbtx", {
+    forwardArguments: true,
+  });
+
+  assert.match(command, /sh -c .*moon run -q --target native - -- "\$@" < tools\/moon\/scripts\/release\.mbtx/);
+  assert.match(command, / --$/);
+});
+
+test("release task forwards extra vp run arguments into the MoonBit script", () => {
+  const command = (releaseTasks.release as { command: string }).command;
+
+  assert.match(command, /moon run -q --target native - -- "\$@" < tools\/moon\/scripts\/release\.mbtx/);
+  assert.match(command, / --$/);
 });
 
 test("normalizing a macOS C.UTF-8 environment updates child-process locale variables", () => {

--- a/tools/vite-plus/task-definition.ts
+++ b/tools/vite-plus/task-definition.ts
@@ -8,18 +8,28 @@ import { withRustTaskEnvironment } from "./task-shell.ts";
 export const task = (
   command: string,
   options: {
+    forwardArguments?: boolean;
     input?: TaskInput;
   } = {},
 ): TaskConfig => ({
-  command: withRustTaskEnvironment(command),
-  ...options,
+  command: withRustTaskEnvironment(command, {
+    forwardArguments: options.forwardArguments,
+  }),
+  ...(options.input == null ? {} : { input: options.input }),
 });
 
 /**
  * Creates an uncached task for commands whose effects are too broad or too
  * stateful to be represented by a stable input list.
  */
-export const noCacheTask = (command: string): TaskConfig => ({
+export const noCacheTask = (
+  command: string,
+  options: {
+    forwardArguments?: boolean;
+  } = {},
+): TaskConfig => ({
   cache: false as const,
-  command: withRustTaskEnvironment(command),
+  command: withRustTaskEnvironment(command, {
+    forwardArguments: options.forwardArguments,
+  }),
 });

--- a/tools/vite-plus/task-shell.ts
+++ b/tools/vite-plus/task-shell.ts
@@ -47,6 +47,11 @@ export const shellCommand = (
 ) =>
   `${environmentAssignments.length === 0 ? "" : `env ${environmentAssignments.join(" ")} `}sh -c ${shellQuote(command)}`;
 
+export const shellCommandForwardingArguments = (
+  command: string,
+  environmentAssignments: readonly string[] = taskShellLocaleAssignments,
+) => `${shellCommand(command, environmentAssignments)} --`;
+
 const darwinLibiconvLibraryPath = process.env.VIZE_DARWIN_LIBICONV_LIB;
 const rustTaskEnvironment =
   darwinLibiconvLibraryPath == null
@@ -65,7 +70,18 @@ const rustTaskEnvironment =
  * variable is present, both Cargo and any nested Rust build script see the same
  * library search path.
  */
-export const withRustTaskEnvironment = (command: string) =>
-  rustTaskEnvironment.length === 0
-    ? command
-    : shellCommand(`${rustTaskEnvironment.join("; ")}; ${command}`);
+export const withRustTaskEnvironment = (
+  command: string,
+  options: {
+    forwardArguments?: boolean;
+  } = {},
+) => {
+  const commandWithEnvironment =
+    rustTaskEnvironment.length === 0 ? command : `${rustTaskEnvironment.join("; ")}; ${command}`;
+
+  return options.forwardArguments
+    ? shellCommandForwardingArguments(commandWithEnvironment)
+    : rustTaskEnvironment.length === 0
+      ? command
+      : shellCommand(commandWithEnvironment);
+};

--- a/tools/vite-plus/tasks/release.ts
+++ b/tools/vite-plus/tasks/release.ts
@@ -17,7 +17,7 @@ import {
  * catalog readable even as the repository gains more package families.
  */
 export const releaseTasks = defineTasks({
-  release: noCacheTask(moonScript("release")),
+  release: noCacheTask(moonScript("release", '"$@"'), { forwardArguments: true }),
   "publish:wasm": noCacheTask(
     `${moonScript("build_vize_wasm_package")} && ${moonScript("publish_npm_package", "npm/vize-wasm")}`,
   ),


### PR DESCRIPTION
## Summary
- forward extra Vite+ task arguments into the MoonBit release script
- keep the Rust task environment wrapper from swallowing `sh -c` positional parameters
- cover the release task command with focused tooling tests

## Verification
- node --test tests/tooling/task-shell.test.ts
- node --test tests/tooling/moonbit-helper.test.ts tests/tooling/github-workflows.test.ts
- pnpm exec tsgo --noEmit
- pnpm exec oxlint tools/vite-plus/task-shell.ts tools/vite-plus/task-definition.ts tools/vite-plus/tasks/release.ts tests/tooling/task-shell.test.ts
- git diff --check