### PR TITLE
fix(release): install matrix Rust targets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,6 +61,9 @@ jobs:
         with:
           targets: ${{ matrix.settings.target }}
 
+      - name: Install Rust target
+        run: rustup target add ${{ matrix.settings.target }}
+
       - name: Install cross-compilation tools (Linux ARM64)
         if: matrix.settings.target == 'aarch64-unknown-linux-gnu'
         run: moon run --target native - -- < tools/moon/scripts/github/install_cross_compile_tools.mbtx
@@ -344,6 +347,9 @@ jobs:
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           targets: ${{ matrix.settings.target }}
+
+      - name: Install Rust target
+        run: rustup target add ${{ matrix.settings.target }}
 
       - name: Cache Rust
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2

--- a/tests/tooling/github-workflows.test.ts
+++ b/tests/tooling/github-workflows.test.ts
@@ -121,6 +121,30 @@ test("PR CI jobs cap runtime with explicit timeouts", () => {
   }
 });
 
+test("release workflow explicitly installs matrix Rust targets", () => {
+  const workflow = readRepoFile(".github", "workflows", "release.yml");
+
+  for (const jobName of ["build-cli", "build-native-all"]) {
+    const job = workflowJobBody(workflow, jobName);
+    const setupRust = job.indexOf("name: Setup Rust");
+    const installTarget = job.indexOf("name: Install Rust target");
+    const cacheRust = job.indexOf("name: Cache Rust");
+
+    assert.notEqual(setupRust, -1, `${jobName} is missing Setup Rust`);
+    assert.notEqual(installTarget, -1, `${jobName} is missing Install Rust target`);
+    assert.notEqual(cacheRust, -1, `${jobName} is missing Cache Rust`);
+    assert.ok(
+      setupRust < installTarget && installTarget < cacheRust,
+      `${jobName} must install the matrix Rust target before caching/building`,
+    );
+    assert.match(
+      job,
+      /run:\s*rustup target add \$\{\{\s*matrix\.settings\.target\s*\}\}/,
+      `${jobName} must install the matrix Rust target explicitly`,
+    );
+  }
+});
+
 test("benchmark workflow comments from trusted code after a read-only benchmark run", () => {
   const workflow = readRepoFile(".github", "workflows", "benchmark.yml");
   const benchmarkJob = workflowJobBody(workflow, "pr-benchmark");


### PR DESCRIPTION
## Summary
- install the release matrix Rust target explicitly before caching/building CLI binaries
- do the same for native package builds so napi targets have std/core available
- cover the release workflow shape with a tooling test

## Verification
- env TMPDIR=/Users/ubugeeei/Source/github.com/ubugeeei/vize/__agent_only/tmp node --test tests/tooling/github-workflows.test.ts
- pnpm exec oxlint tests/tooling/github-workflows.test.ts
- pnpm exec tsgo --noEmit
- git diff --check