### PR TITLE
fix(release): prefer workspace MoonBit toolchain

### DIFF
--- a/tests/tooling/task-shell.test.ts
+++ b/tests/tooling/task-shell.test.ts
@@ -8,6 +8,7 @@ import {
   shellCommandForwardingArguments,
   withRustTaskEnvironment,
 } from "../../tools/vite-plus/task-shell.ts";
+import { moonCommandForEnvironment } from "../../tools/vite-plus/task-commands.ts";
 import { releaseTasks } from "../../tools/vite-plus/tasks/release.ts";
 
 test("macOS task shells fall back from C.UTF-8 to an installed UTF-8 locale", () => {
@@ -64,6 +65,20 @@ test("Rust task environments preserve forwarded arguments", () => {
   assert.match(command, / --$/);
 });
 
+test("MoonBit task commands prefer the workspace toolchain cache", () => {
+  assert.equal(
+    moonCommandForEnvironment({}, (candidate) => candidate === ".cache/moonbit/bin/moon"),
+    "env MOON_HOME=.cache/moonbit .cache/moonbit/bin/moon",
+  );
+});
+
+test("MoonBit task commands preserve the GitHub runner shim", () => {
+  assert.equal(
+    moonCommandForEnvironment({ MOON_BIN: "/runner-temp/moonbit-shims/moon" }, () => true),
+    "/runner-temp/moonbit-shims/moon",
+  );
+});
+
 test("release task forwards extra vp run arguments into the MoonBit script", () => {
   const command = (releaseTasks.release as { command: string }).command;
 
@@ -71,6 +86,7 @@ test("release task forwards extra vp run arguments into the MoonBit script", () 
     command,
     /moon run -q --target native - -- "\$@" < tools\/moon\/scripts\/release\.mbtx/,
   );
+  assert.doesNotMatch(command, /env -u MOON_HOME/);
   assert.match(command, / --$/);
 });
 

--- a/tools/vite-plus/task-commands.ts
+++ b/tools/vite-plus/task-commands.ts
@@ -1,3 +1,5 @@
+import { existsSync } from "node:fs";
+
 import type { PackagePath } from "./task-types.ts";
 import { shellCommand } from "./task-shell.ts";
 
@@ -61,15 +63,33 @@ export const runInPackages = (
 export const runTask = (taskName: string) => `vp run --workspace-root ${taskName}`;
 export const runTasks = (...taskNames: string[]) => taskNames.map(runTask).join(" && ");
 
-const moonCommand = process.env.MOON_BIN ?? "env -u MOON_HOME moon";
+const workspaceMoonHome = ".cache/moonbit";
+const workspaceMoonBin = `${workspaceMoonHome}/bin/moon`;
+
+export const moonCommandForEnvironment = (
+  env: NodeJS.ProcessEnv = process.env,
+  pathExists: (path: string) => boolean = existsSync,
+) => {
+  if (env.MOON_BIN != null && env.MOON_BIN !== "") {
+    return env.MOON_BIN;
+  }
+
+  if (pathExists(workspaceMoonBin)) {
+    return `env MOON_HOME=${workspaceMoonHome} ${workspaceMoonBin}`;
+  }
+
+  return "moon";
+};
+
+const moonCommand = moonCommandForEnvironment();
 
 /**
  * Executes a repository MoonBit script through native script mode.
  *
  * The root task catalog treats MoonBit scripts as first-class automation. This
- * helper keeps the invocation uniform, clears inherited `MOON_HOME` by default,
- * and forwards script arguments after `--` so each script owns its own CLI
- * parsing.
+ * helper keeps the invocation uniform, prefers the workspace-local MoonBit
+ * toolchain installed by the Nix shell, and forwards script arguments after
+ * `--` so each script owns its own CLI parsing.
  */
 export const moonScript = (name: string, ...args: string[]) =>
   [


### PR DESCRIPTION
## Summary
- prefer the workspace .cache/moonbit toolchain for MoonBit-backed Vite+ tasks when MOON_BIN is absent
- keep the CI MOON_BIN shim path unchanged
- cover the release task command so it no longer unsets MOON_HOME and falls back to stale user MoonBit installs

## Verification
- env TMPDIR=/Users/ubugeeei/Source/github.com/ubugeeei/vize/__agent_only/tmp node --test tests/tooling/task-shell.test.ts tests/tooling/github-workflows.test.ts
- env TMPDIR=/Users/ubugeeei/Source/github.com/ubugeeei/vize/__agent_only/tmp node --test tests/tooling/task-shell.test.ts
- pnpm exec oxlint tools/vite-plus/task-commands.ts tests/tooling/task-shell.test.ts tests/tooling/github-workflows.test.ts
- pnpm exec vp check --fix tools/vite-plus/task-commands.ts tests/tooling/task-shell.test.ts tests/tooling/github-workflows.test.ts
- pnpm exec tsgo --noEmit
- git diff --check
- env MOON_HOME=.cache/moonbit .cache/moonbit/bin/moon version