### PR TITLE
fix(tooling): clear MoonBit script warnings

### DIFF
--- a/tests/tooling/_helpers/moonbit.ts
+++ b/tests/tooling/_helpers/moonbit.ts
@@ -4,6 +4,13 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 export const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..");
+const workspaceMoonHome = path.join(repoRoot, ".cache", "moonbit");
+const workspaceMoonCommand = path.join(
+  workspaceMoonHome,
+  "bin",
+  process.platform === "win32" ? "moon.cmd" : "moon",
+);
+const agentTempDir = path.join(repoRoot, "__agent_only", "moonbit-tmp");
 
 export function moonScriptPath(name: string): string {
   return path.join(repoRoot, "tools", "moon", "scripts", `${name}.mbtx`);
@@ -30,6 +37,9 @@ function resolveMoonCommand(env: NodeJS.ProcessEnv): string {
   if (runnerShim) {
     return runnerShim;
   }
+  if (fs.existsSync(workspaceMoonCommand)) {
+    return workspaceMoonCommand;
+  }
   return "moon";
 }
 
@@ -37,20 +47,53 @@ function stripMoonCacheLogs(output: string): string {
   return output.replace(/^(Using cached|Downloading) .*\n/gm, "");
 }
 
+function hasExplicitEnvValue(env: NodeJS.ProcessEnv | undefined, name: string): boolean {
+  return Object.prototype.hasOwnProperty.call(env ?? {}, name);
+}
+
 export function runMoonScript(
   name: string,
   args: string[] = [],
   options: {
+    buildOnly?: boolean;
     cwd?: string;
+    denyWarn?: boolean;
     env?: NodeJS.ProcessEnv;
   } = {},
 ) {
+  fs.mkdirSync(agentTempDir, { recursive: true });
   const env = {
     ...process.env,
     ...options.env,
   };
+  if (!hasExplicitEnvValue(options.env, "TMPDIR")) {
+    env.TMPDIR = agentTempDir;
+  }
+  if (!hasExplicitEnvValue(options.env, "TEMP")) {
+    env.TEMP = agentTempDir;
+  }
+  if (!hasExplicitEnvValue(options.env, "TMP")) {
+    env.TMP = agentTempDir;
+  }
   const moonCommand = resolveMoonCommand(env);
-  const result = spawnSync(moonCommand, ["run", "-q", "--target", "native", "-", "--", ...args], {
+  if (moonCommand === workspaceMoonCommand && !hasExplicitEnvValue(options.env, "MOON_HOME")) {
+    env.MOON_HOME = workspaceMoonHome;
+  }
+  if (moonCommand === workspaceMoonCommand && !hasExplicitEnvValue(options.env, "MOON_BIN")) {
+    env.MOON_BIN = workspaceMoonCommand;
+  }
+  const runArgs = [
+    "run",
+    "-q",
+    ...(options.buildOnly ? ["--build-only"] : []),
+    ...(options.denyWarn ? ["--deny-warn"] : []),
+    "--target",
+    "native",
+    "-",
+    "--",
+    ...args,
+  ];
+  const result = spawnSync(moonCommand, runArgs, {
     cwd: options.cwd ?? repoRoot,
     env,
     encoding: "utf8",

--- a/tests/tooling/moonbit-warnings.test.ts
+++ b/tests/tooling/moonbit-warnings.test.ts
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+
+import { repoRoot, runMoonScript } from "./_helpers/moonbit.ts";
+
+const scriptsRoot = path.join(repoRoot, "tools", "moon", "scripts");
+
+function collectMoonScriptNames(directory: string): string[] {
+  const names: string[] = [];
+  for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+    const fullPath = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      names.push(...collectMoonScriptNames(fullPath));
+      continue;
+    }
+    if (!entry.name.endsWith(".mbtx")) {
+      continue;
+    }
+    names.push(
+      path
+        .relative(scriptsRoot, fullPath)
+        .replace(/\.mbtx$/, "")
+        .split(path.sep)
+        .join("/"),
+    );
+  }
+  return names.sort();
+}
+
+test("all MoonBit scripts compile without warnings", () => {
+  const scriptNames = collectMoonScriptNames(scriptsRoot);
+  assert.ok(scriptNames.length > 0, "expected repository MoonBit scripts");
+
+  for (const scriptName of scriptNames) {
+    const result = runMoonScript(scriptName, [], {
+      buildOnly: true,
+      denyWarn: true,
+    });
+
+    assert.equal(
+      result.status,
+      0,
+      [
+        `${scriptName} failed to compile with --deny-warn`,
+        result.stderr.trim(),
+        result.stdout.trim(),
+      ]
+        .filter(Boolean)
+        .join("\n\n"),
+    );
+  }
+});

--- a/tests/tooling/task-shell.test.ts
+++ b/tests/tooling/task-shell.test.ts
@@ -68,7 +68,7 @@ test("Rust task environments preserve forwarded arguments", () => {
 test("MoonBit task commands prefer the workspace toolchain cache", () => {
   assert.equal(
     moonCommandForEnvironment({}, (candidate) => candidate === ".cache/moonbit/bin/moon"),
-    "env MOON_HOME=.cache/moonbit .cache/moonbit/bin/moon",
+    "env MOON_HOME=.cache/moonbit MOON_BIN=.cache/moonbit/bin/moon .cache/moonbit/bin/moon",
   );
 });
 

--- a/tools/moon/scripts/build_vitrine_wasm.mbtx
+++ b/tools/moon/scripts/build_vitrine_wasm.mbtx
@@ -53,7 +53,7 @@ async fn command_stdout(
   if body == "" {
     return None
   }
-  Some(body.to_string())
+  Some(body.to_owned())
 }
 
 ///|

--- a/tools/moon/scripts/generate_rule_types.mbtx
+++ b/tools/moon/scripts/generate_rule_types.mbtx
@@ -58,7 +58,7 @@ fn snapshot_json_body(snapshot : String) -> String? {
   guard snapshot.has_prefix("---\n") else { return None }
   let parts : Array[String] = snapshot
     .split("\n---\n")
-    .map(StringView::to_string)
+    .map(view => view.to_owned())
     .collect()
   guard parts.length() >= 2 else { return None }
   let body : Array[String] = []

--- a/tools/moon/scripts/github/build_napi_package.mbtx
+++ b/tools/moon/scripts/github/build_napi_package.mbtx
@@ -103,7 +103,12 @@ async fn build_apple_package(
     package_dir,
     "\{binary_name(crate_name)}.\{platform_tag}.node",
   )
-  @afs.write_file(output_path, @afs.read_file(built_library), create=0o755)
+  @afs.write_file(
+    output_path,
+    @afs.read_file(built_library),
+    create_mode=CreateOrTruncate,
+    permission=0o755,
+  )
   0
 }
 

--- a/tools/moon/scripts/github/collect_native_artifacts.mbtx
+++ b/tools/moon/scripts/github/collect_native_artifacts.mbtx
@@ -27,7 +27,7 @@ fn join_path(base : String, child : String) -> String {
 ///|
 fn basename(path_string : String) -> String {
   let path : @path.Path = path_string
-  path.basename().to_string()
+  path.basename().to_owned()
 }
 
 ///|
@@ -105,7 +105,12 @@ async fn run_app() -> Int {
   let copied = []
   for file in collected {
     let destination = join_path(args[1], basename(file))
-    @afs.write_file(destination, @afs.read_file(file), create=0o644)
+    @afs.write_file(
+      destination,
+      @afs.read_file(file),
+      create_mode=CreateOrTruncate,
+      permission=0o644,
+    )
     copied.push(destination)
   }
   copied.sort()

--- a/tools/moon/scripts/github/configure_npm_auth.mbtx
+++ b/tools/moon/scripts/github/configure_npm_auth.mbtx
@@ -58,7 +58,7 @@ async fn run_app() -> Int {
   let registry_line = "registry=https://registry.npmjs.org/"
   let lines = []
   if existing.trim() != "" {
-    let existing_lines : Array[String] = existing.split("\n").map(StringView::to_string).collect()
+    let existing_lines : Array[String] = existing.split("\n").map(view => view.to_owned()).collect()
     for line in existing_lines {
       let trimmed = line.trim()
       if trimmed == "" {

--- a/tools/moon/scripts/github/create_cli_archive.mbtx
+++ b/tools/moon/scripts/github/create_cli_archive.mbtx
@@ -40,7 +40,7 @@ async fn run_app() -> Int {
   }
   let cwd = release_dir(args[0])
   let archive_path = resolve_path(args[1])
-  if args[1].ends_with(".zip") {
+  if args[1].has_suffix(".zip") {
     return @process.run("7z", ["a", archive_path, args[2]], cwd=cwd)
   }
   @process.run("tar", ["-czvf", archive_path, args[2]], cwd=cwd)

--- a/tools/moon/scripts/github/create_site_structure.mbtx
+++ b/tools/moon/scripts/github/create_site_structure.mbtx
@@ -23,7 +23,12 @@ async fn copy_tree(source : String, destination : String) -> Unit {
     if @xfs.is_dir(source_path) {
       copy_tree(source_path, destination_path)
     } else {
-      @afs.write_file(destination_path, @afs.read_file(source_path), create=0o644)
+      @afs.write_file(
+        destination_path,
+        @afs.read_file(source_path),
+        create_mode=CreateOrTruncate,
+        permission=0o644,
+      )
     }
   }
 }
@@ -36,7 +41,8 @@ async fn main {
   @afs.write_file(
     "site/CNAME",
     @afs.read_file("playground/public/CNAME"),
-    create=0o644,
+    create_mode=CreateOrTruncate,
+    permission=0o644,
   )
   @sys.exit(0)
 }

--- a/tools/moon/scripts/github/write_coverage_summary.mbtx
+++ b/tools/moon/scripts/github/write_coverage_summary.mbtx
@@ -13,7 +13,7 @@ fn last_lines(text : String, count : Int) -> String {
   if trimmed == "" {
     return ""
   }
-  let lines : Array[String] = trimmed.split("\n").map(StringView::to_string).collect()
+  let lines : Array[String] = trimmed.split("\n").map(view => view.to_owned()).collect()
   let start = if lines.length() > count { lines.length() - count } else { 0 }
   let summary_lines : Array[String] = []
   for i in start..<lines.length() {
@@ -46,7 +46,12 @@ async fn run_app() -> Int {
   if exit_code != 0 {
     return exit_code
   }
-  @afs.write_file("coverage-report.txt", stdout, create=0o644)
+  @afs.write_file(
+    "coverage-report.txt",
+    stdout,
+    create_mode=CreateOrTruncate,
+    permission=0o644,
+  )
   let summary = last_lines(stdout, 7)
   let summary_text = if summary == "" {
     "### Coverage Summary\n\n"
@@ -57,8 +62,8 @@ async fn run_app() -> Int {
     summary_path,
     summary_text,
     append=true,
-    create=0o644,
-    truncate=false,
+    create_mode=OpenOrCreate,
+    permission=0o644,
   )
   0
 }

--- a/tools/moon/scripts/inject_native_optional_deps.mbtx
+++ b/tools/moon/scripts/inject_native_optional_deps.mbtx
@@ -108,7 +108,7 @@ async fn run_app() -> Int {
   if package_obj.get("optionalDependencies") is Some(Object(optional_dependencies)) {
     for dependency_name, dependency_value in optional_dependencies {
       ignore(dependency_value)
-      if dependency_name.starts_with("@vizejs/native-") {
+      if dependency_name.has_prefix("@vizejs/native-") {
         optional_dependencies[dependency_name] = Json::string(version)
       }
     }

--- a/tools/moon/scripts/prepare_npm_publish_manifest.mbtx
+++ b/tools/moon/scripts/prepare_npm_publish_manifest.mbtx
@@ -111,7 +111,7 @@ fn package_version(json : Json) -> String? {
 
 ///|
 fn yaml_scalar(value : String) -> String {
-  value.trim().to_string().replace_all(old="\"", new="")
+  value.trim().to_owned().replace_all(old="\"", new="")
 }
 
 ///|
@@ -164,7 +164,7 @@ fn parse_catalog_versions(content : String) -> Map[String, String] {
   let versions : Map[String, String] = {}
   let mut in_catalogs = false
   let mut current_catalog = ""
-  let lines : Array[String] = content.split("\n").map(StringView::to_string).collect()
+  let lines : Array[String] = content.split("\n").map(view => view.to_owned()).collect()
   for line in lines {
     let trimmed = line.trim()
     if trimmed == "" || trimmed.has_prefix("#") {
@@ -180,13 +180,13 @@ fn parse_catalog_versions(content : String) -> Map[String, String] {
       break
     }
     if line.has_prefix("  ") && !line.has_prefix("    ") && trimmed.has_suffix(":") {
-      current_catalog = trimmed.to_string().replace(old=":", new="")
+      current_catalog = trimmed.to_owned().replace(old=":", new="")
       continue
     }
     if current_catalog == "" || !line.has_prefix("    ") {
       continue
     }
-    let parts : Array[String] = trimmed.split(": ").map(StringView::to_string).collect()
+    let parts : Array[String] = trimmed.split(": ").map(view => view.to_owned()).collect()
     guard parts.length() >= 2 else { continue }
     let key = yaml_scalar(parts[0])
     let value = yaml_scalar(parts[1])

--- a/tools/moon/scripts/publish_crates.mbtx
+++ b/tools/moon/scripts/publish_crates.mbtx
@@ -9,7 +9,7 @@
 import {
   "moonbitlang/core/env",
   "moonbitlang/core/json",
-  "moonbitlang/core/strconv",
+  "moonbitlang/core/string",
   "moonbitlang/async@0.19.0",
   "moonbitlang/async@0.19.0/process",
   "moonbitlang/async@0.19.0/stdio",
@@ -43,7 +43,7 @@ let published_crates : Array[String] = [
 /// Parses a positive integer from a string and falls back on invalid input.
 fn positive_int_or(value : String, fallback : Int) -> Int {
   try {
-    let parsed = @strconv.parse_int(value)
+    let parsed = @string.parse_int(value)
     if parsed > 0 {
       parsed
     } else {
@@ -80,11 +80,11 @@ fn read_file_to_string(path : String) -> String? {
 /// scanner is more predictable than shelling out to another TOML parser.
 fn workspace_version_from_content(content : String) -> String? {
   let mut section = ""
-  let lines : Array[String] = content.split("\n").map(StringView::to_string).collect()
+  let lines : Array[String] = content.split("\n").map(view => view.to_owned()).collect()
   for line in lines {
     let trimmed = line.trim()
     if trimmed.has_prefix("[") && trimmed.has_suffix("]") {
-      section = trimmed.to_string()
+      section = trimmed.to_owned()
       continue
     }
     if section == "[workspace.package]" &&
@@ -92,7 +92,7 @@ fn workspace_version_from_content(content : String) -> String? {
       trimmed.has_suffix("\"") {
       return Some(
         trimmed
-          .to_string()
+          .to_owned()
           .replace(old="version = \"", new="")
           .replace_all(old="\"", new=""),
       )

--- a/tools/moon/scripts/publish_npm_package.mbtx
+++ b/tools/moon/scripts/publish_npm_package.mbtx
@@ -21,7 +21,7 @@
 import {
   "moonbitlang/core/env",
   "moonbitlang/core/json",
-  "moonbitlang/core/strconv",
+  "moonbitlang/core/string",
   "moonbitlang/async@0.19.0",
   "moonbitlang/async@0.19.0/process",
   "moonbitlang/async@0.19.0/stdio",
@@ -80,7 +80,7 @@ fn safe_path_exists(path : String) -> Bool {
 
 ///|
 fn normalize_manifest_path(value : String) -> String? {
-  let path = value.trim().to_string()
+  let path = value.trim().to_owned()
   if path == "" {
     return None
   }
@@ -209,7 +209,7 @@ fn package_version(json : Json) -> String? {
 /// safe default instead of aborting on malformed values.
 fn positive_int_or(value : String, fallback : Int) -> Int {
   try {
-    let parsed = @strconv.parse_int(value)
+    let parsed = @string.parse_int(value)
     if parsed > 0 {
       parsed
     } else {

--- a/tools/moon/scripts/release.mbtx
+++ b/tools/moon/scripts/release.mbtx
@@ -9,7 +9,7 @@
 /// and only then creates and pushes the release commit and tag.
 import {
   "moonbitlang/core/env",
-  "moonbitlang/core/strconv",
+  "moonbitlang/core/string",
   "moonbitlang/async@0.19.0",
   "moonbitlang/async@0.19.0/process",
   "moonbitlang/async@0.19.0/stdio",
@@ -104,7 +104,7 @@ fn write_string_to_file(path : String, content : String) -> Bool {
 /// Parses an integer but keeps the caller in control of error handling.
 fn parse_int(value : String) -> Int? {
   try {
-    Some(@strconv.parse_int(value))
+    Some(@string.parse_int(value))
   } catch {
     _ => None
   }
@@ -122,10 +122,10 @@ fn parse_int(value : String) -> Int? {
 /// The parser is intentionally strict so release automation never guesses when
 /// the current version format has drifted unexpectedly.
 fn parse_version(value : String) -> Version? {
-  let parts : Array[String] = value.split("-").map(StringView::to_string).collect()
+  let parts : Array[String] = value.split("-").map(view => view.to_owned()).collect()
   guard parts.length() >= 1 && parts.length() <= 2 else { return None }
 
-  let base_parts : Array[String] = parts[0].split(".").map(StringView::to_string).collect()
+  let base_parts : Array[String] = parts[0].split(".").map(view => view.to_owned()).collect()
   guard base_parts.length() == 3 else { return None }
   let major = match parse_int(base_parts[0]) {
     Some(value) => value
@@ -145,7 +145,7 @@ fn parse_version(value : String) -> Version? {
   if parts.length() == 2 {
     let prerelease_parts : Array[String] = parts[1]
       .split(".")
-      .map(StringView::to_string)
+      .map(view => view.to_owned())
       .collect()
     guard prerelease_parts.length() >= 1 && prerelease_parts.length() <= 2 else {
       return None
@@ -266,11 +266,11 @@ fn bump_version(current : String, bump : String) -> String? {
 /// Extracts the current workspace version from the root `Cargo.toml`.
 fn workspace_version_from_content(content : String) -> String? {
   let mut section = ""
-  let lines : Array[String] = content.split("\n").map(StringView::to_string).collect()
+  let lines : Array[String] = content.split("\n").map(view => view.to_owned()).collect()
   for line in lines {
     let trimmed = line.trim()
     if trimmed.has_prefix("[") && trimmed.has_suffix("]") {
-      section = trimmed.to_string()
+      section = trimmed.to_owned()
       continue
     }
     if section == "[workspace.package]" &&
@@ -278,7 +278,7 @@ fn workspace_version_from_content(content : String) -> String? {
       trimmed.has_suffix("\"") {
       return Some(
         trimmed
-          .to_string()
+          .to_owned()
           .replace(old="version = \"", new="")
           .replace_all(old="\"", new=""),
       )
@@ -299,11 +299,11 @@ fn update_workspace_manifest_versions(
 ) -> String {
   let mut section = ""
   let updated : Array[String] = []
-  let lines : Array[String] = content.split("\n").map(StringView::to_string).collect()
+  let lines : Array[String] = content.split("\n").map(view => view.to_owned()).collect()
   for line in lines {
     let trimmed = line.trim()
     if trimmed.has_prefix("[") && trimmed.has_suffix("]") {
-      section = trimmed.to_string()
+      section = trimmed.to_owned()
       updated.push(line)
       continue
     }
@@ -333,7 +333,7 @@ fn replace_package_json_version(
 ) -> String {
   let updated : Array[String] = []
   let mut replaced = false
-  let lines : Array[String] = content.split("\n").map(StringView::to_string).collect()
+  let lines : Array[String] = content.split("\n").map(view => view.to_owned()).collect()
   for line in lines {
     if !replaced {
       let trimmed = line.trim()
@@ -360,7 +360,7 @@ fn replace_first_version_line(
 ) -> String {
   let updated : Array[String] = []
   let mut replaced = false
-  let lines : Array[String] = content.split("\n").map(StringView::to_string).collect()
+  let lines : Array[String] = content.split("\n").map(view => view.to_owned()).collect()
   for line in lines {
     if !replaced {
       let trimmed = line.trim()

--- a/tools/vite-plus/task-commands.ts
+++ b/tools/vite-plus/task-commands.ts
@@ -75,7 +75,7 @@ export const moonCommandForEnvironment = (
   }
 
   if (pathExists(workspaceMoonBin)) {
-    return `env MOON_HOME=${workspaceMoonHome} ${workspaceMoonBin}`;
+    return `env MOON_HOME=${workspaceMoonHome} MOON_BIN=${workspaceMoonBin} ${workspaceMoonBin}`;
   }
 
   return "moon";


### PR DESCRIPTION
## Summary
- Replace deprecated MoonBit APIs in release/publish/GitHub helper scripts so they build warning-free on the current toolchain.
- Propagate the workspace MOON_BIN fallback into nested MoonBit script calls so child moon run executions do not fall back to an older user-local toolchain.
- Add a tooling test that compiles every repository .mbtx script with --build-only --deny-warn.

## Checks
- pnpm exec vp check --fix tools/vite-plus/task-commands.ts tests/tooling/_helpers/moonbit.ts tests/tooling/task-shell.test.ts tests/tooling/moonbit-warnings.test.ts
- node --test --test-concurrency=1 tests/tooling/moonbit-publish.test.ts tests/tooling/task-shell.test.ts tests/tooling/moonbit-warnings.test.ts
- cargo fmt --all -- --check
- git diff --check