### PR TITLE
ci: use Node 24 artifact downloads

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -171,7 +171,7 @@ jobs:
           ref: ${{ github.event.pull_request.base.sha }}
 
       - name: Download benchmark results
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: pr-benchmark
 

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -256,7 +256,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.base.sha }}
       - name: Download test inventory
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: test-inventory
       - name: Comment detailed test report

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -138,7 +138,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Download all artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: artifacts
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -179,7 +179,7 @@ jobs:
             ${{ runner.os }}-pnpm-vscode-release-
 
       - name: Download editor extension artifact
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: editor-extensions
           path: editor-extension-artifacts
@@ -433,7 +433,7 @@ jobs:
         run: vp install --frozen-lockfile --prefer-offline --filter './npm/vize-native...'
 
       - name: Download all artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: bindings-*
           path: npm/vize-native/artifacts
@@ -488,7 +488,7 @@ jobs:
         run: vp install --frozen-lockfile --prefer-offline --filter './npm/fresco-native...'
 
       - name: Download all artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: fresco-bindings-*
           path: npm/fresco-native/artifacts
@@ -581,7 +581,7 @@ jobs:
         run: moon run --target native - -- < tools/moon/scripts/github/configure_npm_auth.mbtx
 
       - name: Download prebuilt packages
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: release-package-vite-plugin-vize
           path: npm/vite-plugin-vize
@@ -614,7 +614,7 @@ jobs:
         run: moon run --target native - -- < tools/moon/scripts/github/configure_npm_auth.mbtx
 
       - name: Download prebuilt packages
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: release-package-oxlint-plugin-vize
           path: npm/oxlint-plugin-vize
@@ -650,7 +650,7 @@ jobs:
         run: moon run --target native - -- < tools/moon/scripts/github/configure_npm_auth.mbtx
 
       - name: Download prebuilt packages
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: release-package-unplugin-vize
           path: npm/unplugin-vize
@@ -683,7 +683,7 @@ jobs:
         run: moon run --target native - -- < tools/moon/scripts/github/configure_npm_auth.mbtx
 
       - name: Download prebuilt packages
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: release-package-fresco
           path: npm/fresco
@@ -716,7 +716,7 @@ jobs:
         run: moon run --target native - -- < tools/moon/scripts/github/configure_npm_auth.mbtx
 
       - name: Download prebuilt packages
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: release-package-musea-mcp-server
           path: npm/musea-mcp-server
@@ -749,7 +749,7 @@ jobs:
         run: moon run --target native - -- < tools/moon/scripts/github/configure_npm_auth.mbtx
 
       - name: Download prebuilt packages
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: release-package-vite-plugin-musea
           path: npm/vite-plugin-musea
@@ -782,7 +782,7 @@ jobs:
         run: moon run --target native - -- < tools/moon/scripts/github/configure_npm_auth.mbtx
 
       - name: Download prebuilt packages
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: release-package-rspack-vize-plugin
           path: npm/rspack-vize-plugin
@@ -815,7 +815,7 @@ jobs:
         run: moon run --target native - -- < tools/moon/scripts/github/configure_npm_auth.mbtx
 
       - name: Download prebuilt packages
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: release-package-musea-nuxt
           path: npm/musea-nuxt
@@ -854,7 +854,7 @@ jobs:
         run: moon run --target native - -- < tools/moon/scripts/github/configure_npm_auth.mbtx
 
       - name: Download prebuilt packages
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: release-package-nuxt
           path: npm/nuxt
@@ -901,14 +901,14 @@ jobs:
       contents: write
     steps:
       - name: Download CLI artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: cli-*
           path: cli-artifacts
           merge-multiple: true
 
       - name: Download editor extension artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: editor-extensions
           path: editor-extension-artifacts
@@ -958,7 +958,7 @@ jobs:
         run: moon run --target native - -- < tools/moon/scripts/github/configure_npm_auth.mbtx
 
       - name: Download prebuilt packages
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: release-package-vize
           path: npm/vize

--- a/tests/tooling/github-workflows.test.ts
+++ b/tests/tooling/github-workflows.test.ts
@@ -65,6 +65,18 @@ test("GitHub workflows use the current cache action", () => {
   }
 });
 
+test("GitHub workflows use Node 24-compatible artifact downloads", () => {
+  const violations: string[] = [];
+
+  for (const { relativePath, content } of readGithubYamlFiles()) {
+    if (/uses:\s*actions\/download-artifact@[0-9a-f]{40}\s*#\s*v[1-6](?:\b|\.)/.test(content)) {
+      violations.push(`${relativePath} still uses a Node 20 artifact downloader`);
+    }
+  }
+
+  assert.deepEqual(violations, []);
+});
+
 test("GitHub workflow actions are pinned by full commit SHA", () => {
   const violations: string[] = [];
   const usePattern = /^(\s*-?\s*uses:\s*)(["']?)([^\s"']+)\2\s*(?:#.*)?$/gm;
@@ -171,7 +183,7 @@ test("benchmark workflow comments from trusted code after a read-only benchmark 
   assert.match(commentJob, /issues:\s*write/);
   assert.match(commentJob, /pull-requests:\s*write/);
   assert.match(commentJob, /ref:\s*\$\{\{\s*github\.event\.pull_request\.base\.sha\s*\}\}/);
-  assert.match(commentJob, /uses:\s*actions\/download-artifact@[0-9a-f]{40}\s*# v4/);
+  assert.match(commentJob, /uses:\s*actions\/download-artifact@[0-9a-f]{40}\s*# v8\.0\.1/);
   assert.match(commentJob, /name:\s*pr-benchmark/);
   assert.match(
     commentJob,
@@ -219,7 +231,7 @@ test("check workflow comments a detailed PR test report for each head push", () 
   assert.match(commentJob, /issues:\s*write/);
   assert.match(commentJob, /pull-requests:\s*write/);
   assert.match(commentJob, /ref:\s*\$\{\{\s*github\.event\.pull_request\.base\.sha\s*\}\}/);
-  assert.match(commentJob, /uses:\s*actions\/download-artifact@[0-9a-f]{40}\s*# v4/);
+  assert.match(commentJob, /uses:\s*actions\/download-artifact@[0-9a-f]{40}\s*# v8\.0\.1/);
   assert.match(commentJob, /name:\s*test-inventory/);
   assert.match(
     commentJob,


### PR DESCRIPTION
## Summary
- update actions/download-artifact pins to v8.0.1, which runs on Node.js 24
- keep workflow action pinning on full commit SHAs
- add a tooling test that rejects old download-artifact pins

## Verification
- pnpm exec vp check --fix tests/tooling/github-workflows.test.ts
- node --test --test-concurrency=1 tests/tooling/github-workflows.test.ts
- git diff --check