### PR TITLE
fix: reduce unsafe and panic paths

### DIFF
--- a/crates/vize/src/commands/build/runner.rs
+++ b/crates/vize/src/commands/build/runner.rs
@@ -41,10 +41,13 @@ pub(crate) fn run(args: BuildArgs) {
     let slow_threshold = Duration::from_millis(args.slow_threshold);
 
     if let Some(threads) = args.threads {
-        rayon::ThreadPoolBuilder::new()
+        if let Err(error) = rayon::ThreadPoolBuilder::new()
             .num_threads(threads)
             .build_global()
-            .expect("Failed to configure thread pool");
+        {
+            eprintln!("Failed to configure thread pool: {error}");
+            std::process::exit(1);
+        }
     }
 
     let files = collect_files(&args.patterns);
@@ -119,7 +122,13 @@ pub(crate) fn run(args: BuildArgs) {
     match args.format {
         OutputFormat::Stats => {}
         OutputFormat::Js | OutputFormat::Json => {
-            fs::create_dir_all(&args.output).expect("Failed to create output directory");
+            if let Err(error) = fs::create_dir_all(&args.output) {
+                eprintln!(
+                    "Failed to create output directory {}: {error}",
+                    args.output.display()
+                );
+                std::process::exit(1);
+            }
 
             for (path, output) in results.into_iter().flatten() {
                 let ext = match args.format {
@@ -135,7 +144,13 @@ pub(crate) fn run(args: BuildArgs) {
                 let out_path = args.output.join(filename);
 
                 if let Some(parent) = out_path.parent() {
-                    fs::create_dir_all(parent).expect("Failed to create output subdirectory");
+                    if let Err(error) = fs::create_dir_all(parent) {
+                        eprintln!(
+                            "Failed to create output subdirectory {}: {error}",
+                            parent.display()
+                        );
+                        continue;
+                    }
                 }
 
                 let content: String = match args.format {

--- a/crates/vize/src/commands/build/runner.rs
+++ b/crates/vize/src/commands/build/runner.rs
@@ -40,14 +40,13 @@ pub(crate) fn run(args: BuildArgs) {
     let start = Instant::now();
     let slow_threshold = Duration::from_millis(args.slow_threshold);
 
-    if let Some(threads) = args.threads {
-        if let Err(error) = rayon::ThreadPoolBuilder::new()
+    if let Some(threads) = args.threads
+        && let Err(error) = rayon::ThreadPoolBuilder::new()
             .num_threads(threads)
             .build_global()
-        {
-            eprintln!("Failed to configure thread pool: {error}");
-            std::process::exit(1);
-        }
+    {
+        eprintln!("Failed to configure thread pool: {error}");
+        std::process::exit(1);
     }
 
     let files = collect_files(&args.patterns);
@@ -143,14 +142,14 @@ pub(crate) fn run(args: BuildArgs) {
                     .unwrap_or_else(|| PathBuf::from("output").with_extension(ext));
                 let out_path = args.output.join(filename);
 
-                if let Some(parent) = out_path.parent() {
-                    if let Err(error) = fs::create_dir_all(parent) {
-                        eprintln!(
-                            "Failed to create output subdirectory {}: {error}",
-                            parent.display()
-                        );
-                        continue;
-                    }
+                if let Some(parent) = out_path.parent()
+                    && let Err(error) = fs::create_dir_all(parent)
+                {
+                    eprintln!(
+                        "Failed to create output subdirectory {}: {error}",
+                        parent.display()
+                    );
+                    continue;
                 }
 
                 let content: String = match args.format {

--- a/crates/vize/src/commands/check/dts.rs
+++ b/crates/vize/src/commands/check/dts.rs
@@ -164,9 +164,10 @@ fn append_pending_member(
     current_type.push_str(trimmed.trim_end_matches(';'));
 
     if is_type_complete(current_type.as_str()) {
-        let name = current_name.take().unwrap();
-        members.push((name, normalize_type(current_type.as_str())));
-        current_type.clear();
+        if let Some(name) = current_name.take() {
+            members.push((name, normalize_type(current_type.as_str())));
+            current_type.clear();
+        }
     }
 
     true
@@ -187,12 +188,13 @@ fn append_pending_global(
     current_type.push_str(trimmed.trim_end_matches(';'));
 
     if is_type_complete(current_type.as_str()) {
-        let name = current_name.take().unwrap();
-        values.push((
-            name,
-            normalize_rewritten_type(current_type.as_str(), source_dir),
-        ));
-        current_type.clear();
+        if let Some(name) = current_name.take() {
+            values.push((
+                name,
+                normalize_rewritten_type(current_type.as_str(), source_dir),
+            ));
+            current_type.clear();
+        }
     }
 
     true

--- a/crates/vize/src/commands/check/dts.rs
+++ b/crates/vize/src/commands/check/dts.rs
@@ -163,11 +163,11 @@ fn append_pending_member(
     current_type.push(' ');
     current_type.push_str(trimmed.trim_end_matches(';'));
 
-    if is_type_complete(current_type.as_str()) {
-        if let Some(name) = current_name.take() {
-            members.push((name, normalize_type(current_type.as_str())));
-            current_type.clear();
-        }
+    if is_type_complete(current_type.as_str())
+        && let Some(name) = current_name.take()
+    {
+        members.push((name, normalize_type(current_type.as_str())));
+        current_type.clear();
     }
 
     true
@@ -187,14 +187,14 @@ fn append_pending_global(
     current_type.push(' ');
     current_type.push_str(trimmed.trim_end_matches(';'));
 
-    if is_type_complete(current_type.as_str()) {
-        if let Some(name) = current_name.take() {
-            values.push((
-                name,
-                normalize_rewritten_type(current_type.as_str(), source_dir),
-            ));
-            current_type.clear();
-        }
+    if is_type_complete(current_type.as_str())
+        && let Some(name) = current_name.take()
+    {
+        values.push((
+            name,
+            normalize_rewritten_type(current_type.as_str(), source_dir),
+        ));
+        current_type.clear();
     }
 
     true

--- a/crates/vize/src/commands/check/runner.rs
+++ b/crates/vize/src/commands/check/runner.rs
@@ -284,7 +284,13 @@ pub(crate) fn run_direct(args: &CheckArgs) {
             file_count: virtual_files.len(),
             declarations,
         };
-        println!("{}", serde_json::to_string_pretty(&json_output).unwrap());
+        match serde_json::to_string_pretty(&json_output) {
+            Ok(output) => println!("{output}"),
+            Err(error) => {
+                eprintln!("Failed to serialize check output: {error}");
+                std::process::exit(1);
+            }
+        }
         if total_errors > 0 {
             std::process::exit(1);
         }

--- a/crates/vize/src/commands/ide.rs
+++ b/crates/vize/src/commands/ide.rs
@@ -59,7 +59,13 @@ pub fn run(args: IdeArgs) {
 
 /// Run LSP server (default behavior)
 fn run_lsp(args: IdeArgs) {
-    let runtime = tokio::runtime::Runtime::new().expect("Failed to create tokio runtime");
+    let runtime = match tokio::runtime::Runtime::new() {
+        Ok(runtime) => runtime,
+        Err(error) => {
+            eprintln!("Failed to create tokio runtime: {error}");
+            std::process::exit(1);
+        }
+    };
 
     runtime.block_on(async {
         let result = if let Some(port) = args.port {

--- a/crates/vize/src/commands/lsp.rs
+++ b/crates/vize/src/commands/lsp.rs
@@ -19,7 +19,13 @@ pub struct LspArgs {
 
 pub fn run(args: LspArgs) {
     // Create tokio runtime for async LSP server
-    let runtime = tokio::runtime::Runtime::new().expect("Failed to create tokio runtime");
+    let runtime = match tokio::runtime::Runtime::new() {
+        Ok(runtime) => runtime,
+        Err(error) => {
+            eprintln!("Failed to create tokio runtime: {error}");
+            std::process::exit(1);
+        }
+    };
 
     runtime.block_on(async {
         let result = if let Some(port) = args.port {

--- a/crates/vize_armature/src/parser/attribute.rs
+++ b/crates/vize_armature/src/parser/attribute.rs
@@ -4,9 +4,12 @@
 //! attribute data (values), and finalization of attribute and directive nodes.
 
 use vize_carton::{Box, String, Vec};
-use vize_relief::ast::{
-    AttributeNode, ConstantType, DirectiveNode, ExpressionNode, PropNode, SimpleExpressionNode,
-    TextNode,
+use vize_relief::{
+    ast::{
+        AttributeNode, ConstantType, DirectiveNode, ExpressionNode, PropNode, SimpleExpressionNode,
+        TextNode,
+    },
+    errors::{CompilerError, ErrorCode},
 };
 
 use crate::tokenizer::QuoteType;
@@ -70,6 +73,15 @@ impl<'a> Parser<'a> {
 
     /// Process directive modifier
     pub(super) fn on_dir_modifier_impl(&mut self, start: usize, end: usize) {
+        if start >= end {
+            let loc = self.create_loc(start, end);
+            self.errors.push(CompilerError::new(
+                ErrorCode::MissingDirectiveModifier,
+                Some(loc),
+            ));
+            return;
+        }
+
         let modifier: String = self.get_source(start, end).into();
         if let Some(ref mut dir) = self.current_dir {
             dir.modifiers.push((modifier, start, end));
@@ -155,11 +167,30 @@ impl<'a> Parser<'a> {
         }
     }
 
+    fn has_duplicate_attribute(&self, name: &str) -> bool {
+        self.current_element.as_ref().is_some_and(|current| {
+            current.props.iter().any(|prop| {
+                matches!(prop, PropNode::Attribute(existing) if existing.name.as_str() == name)
+            })
+        })
+    }
+
     /// Finish building an attribute node
     fn finish_attribute(&mut self, attr: CurrentAttribute<'a>, quote: QuoteType, end: usize) {
         let loc_end = self.prop_loc_end(quote, end, attr.name_end);
         let loc = self.create_loc(attr.name_start, loc_end);
         let name_loc = self.create_loc(attr.name_start, attr.name_end);
+
+        if self.has_duplicate_attribute(attr.name.as_str()) {
+            self.errors.push(CompilerError::with_message(
+                ErrorCode::DuplicateAttribute,
+                format!(
+                    "Duplicate attribute `{}`. Keeping the repeated attribute so parsing can continue.",
+                    attr.name
+                ),
+                Some(name_loc.clone()),
+            ));
+        }
 
         let mut attr_node = AttributeNode::new(attr.name.clone(), loc);
         attr_node.name_loc = name_loc;
@@ -186,6 +217,18 @@ impl<'a> Parser<'a> {
     fn finish_directive(&mut self, dir: CurrentDirective<'a>, quote: QuoteType, end: usize) {
         let loc_end = self.prop_loc_end(quote, end, dir.name_end);
         let loc = self.create_loc(dir.name_start, loc_end);
+
+        if dir.name.is_empty() {
+            self.errors.push(CompilerError::with_message(
+                ErrorCode::MissingDirectiveName,
+                format!(
+                    "Directive `{}` is missing a name. Ignoring it so the rest of the tag can be parsed.",
+                    dir.raw_name
+                ),
+                Some(loc),
+            ));
+            return;
+        }
 
         let mut dir_node = DirectiveNode::new(self.allocator, dir.name.clone(), loc);
         dir_node.raw_name = Some(dir.raw_name);

--- a/crates/vize_armature/src/parser/attribute.rs
+++ b/crates/vize_armature/src/parser/attribute.rs
@@ -184,7 +184,7 @@ impl<'a> Parser<'a> {
         if self.has_duplicate_attribute(attr.name.as_str()) {
             self.errors.push(CompilerError::with_message(
                 ErrorCode::DuplicateAttribute,
-                format!(
+                vize_carton::cstr!(
                     "Duplicate attribute `{}`. Keeping the repeated attribute so parsing can continue.",
                     attr.name
                 ),
@@ -221,7 +221,7 @@ impl<'a> Parser<'a> {
         if dir.name.is_empty() {
             self.errors.push(CompilerError::with_message(
                 ErrorCode::MissingDirectiveName,
-                format!(
+                vize_carton::cstr!(
                     "Directive `{}` is missing a name. Ignoring it so the rest of the tag can be parsed.",
                     dir.raw_name
                 ),

--- a/crates/vize_armature/src/parser/element.rs
+++ b/crates/vize_armature/src/parser/element.rs
@@ -3,7 +3,7 @@
 //! Handles text, interpolation, open/close tags, element type determination,
 //! comments, and error reporting.
 
-use vize_carton::{Box, directive::parse_vize_directive};
+use vize_carton::{Box, String, directive::parse_vize_directive};
 use vize_relief::{
     ast::*,
     errors::{CompilerError, ErrorCode},
@@ -391,19 +391,19 @@ impl<'a> Parser<'a> {
         self.errors.push(error);
     }
 
-    fn recovery_error_message(&self, code: ErrorCode) -> Option<std::string::String> {
+    fn recovery_error_message(&self, code: ErrorCode) -> Option<String> {
         match code {
             ErrorCode::EofBeforeTagName => Some(
                 "Unexpected end of input after `<`; treating it as text so parsing can continue."
-                    .to_string(),
+                    .into(),
             ),
             ErrorCode::EofInTag => Some(
                 "Unexpected end of input inside a tag; inferred the missing tag close so parsing can continue."
-                    .to_string(),
+                    .into(),
             ),
             ErrorCode::InvalidFirstCharacterOfTagName => Some(
                 "Tag name starts with an invalid character; treating the malformed tag as text."
-                    .to_string(),
+                    .into(),
             ),
             ErrorCode::MissingAttributeValue => {
                 let name = self
@@ -412,41 +412,41 @@ impl<'a> Parser<'a> {
                     .map(|attr| attr.name.as_str())
                     .or_else(|| self.current_dir.as_ref().map(|dir| dir.raw_name.as_str()))
                     .unwrap_or("attribute");
-                Some(format!(
+                Some(vize_carton::cstr!(
                     "Attribute `{name}` is missing a value after `=`; continuing without the value."
                 ))
             }
             ErrorCode::MissingDynamicDirectiveArgumentEnd => Some(
                 "Dynamic directive argument is missing its closing `]`; inferred the argument end at the next tag boundary."
-                    .to_string(),
+                    .into(),
             ),
-            ErrorCode::MissingInterpolationEnd => Some(format!(
+            ErrorCode::MissingInterpolationEnd => Some(vize_carton::cstr!(
                 "Interpolation is missing its closing delimiter `{}`; treating the unfinished interpolation as text.",
                 self.options.delimiters.1
             )),
             ErrorCode::UnexpectedCharacterInAttributeName => Some(
                 "Attribute name contains an invalid character; inferred the nearest attribute boundary and continued."
-                    .to_string(),
+                    .into(),
             ),
             ErrorCode::UnexpectedCharacterInUnquotedAttributeValue => Some(
                 "Unquoted attribute value contains a character that should be quoted; keeping it in the value and continuing."
-                    .to_string(),
+                    .into(),
             ),
             ErrorCode::UnexpectedEqualsSignBeforeAttributeName => Some(
                 "Unexpected `=` before an attribute name; skipping it and continuing with the next attribute."
-                    .to_string(),
+                    .into(),
             ),
             ErrorCode::MissingWhitespaceBetweenAttributes => Some(
                 "Missing whitespace between attributes; inferred a new attribute boundary."
-                    .to_string(),
+                    .into(),
             ),
             ErrorCode::IncorrectlyClosedComment => Some(
                 "Comment was closed as `--!>`; treating it as `-->` so parsing can continue."
-                    .to_string(),
+                    .into(),
             ),
             ErrorCode::IncorrectlyOpenedComment => Some(
                 "Declaration or comment syntax is malformed; skipping it until the next `>`."
-                    .to_string(),
+                    .into(),
             ),
             _ => None,
         }

--- a/crates/vize_armature/src/parser/element.rs
+++ b/crates/vize_armature/src/parser/element.rs
@@ -214,7 +214,11 @@ impl<'a> Parser<'a> {
                 let mut elements: vize_carton::Vec<'a, ParserStackEntry<'a>> =
                     vize_carton::Vec::new_in(self.allocator);
                 while self.stack.len() > i {
-                    elements.push(self.stack.pop().unwrap());
+                    if let Some(entry) = self.stack.pop() {
+                        elements.push(entry);
+                    } else {
+                        break;
+                    }
                 }
 
                 // Report errors for unclosed elements (except the matching one)

--- a/crates/vize_armature/src/parser/element.rs
+++ b/crates/vize_armature/src/parser/element.rs
@@ -383,6 +383,72 @@ impl<'a> Parser<'a> {
         let start = index.min(len);
         let end = (index + 1).min(len);
         let loc = self.create_loc(start, end);
-        self.errors.push(CompilerError::new(code, Some(loc)));
+        let error = if let Some(message) = self.recovery_error_message(code) {
+            CompilerError::with_message(code, message, Some(loc))
+        } else {
+            CompilerError::new(code, Some(loc))
+        };
+        self.errors.push(error);
+    }
+
+    fn recovery_error_message(&self, code: ErrorCode) -> Option<std::string::String> {
+        match code {
+            ErrorCode::EofBeforeTagName => Some(
+                "Unexpected end of input after `<`; treating it as text so parsing can continue."
+                    .to_string(),
+            ),
+            ErrorCode::EofInTag => Some(
+                "Unexpected end of input inside a tag; inferred the missing tag close so parsing can continue."
+                    .to_string(),
+            ),
+            ErrorCode::InvalidFirstCharacterOfTagName => Some(
+                "Tag name starts with an invalid character; treating the malformed tag as text."
+                    .to_string(),
+            ),
+            ErrorCode::MissingAttributeValue => {
+                let name = self
+                    .current_attr
+                    .as_ref()
+                    .map(|attr| attr.name.as_str())
+                    .or_else(|| self.current_dir.as_ref().map(|dir| dir.raw_name.as_str()))
+                    .unwrap_or("attribute");
+                Some(format!(
+                    "Attribute `{name}` is missing a value after `=`; continuing without the value."
+                ))
+            }
+            ErrorCode::MissingDynamicDirectiveArgumentEnd => Some(
+                "Dynamic directive argument is missing its closing `]`; inferred the argument end at the next tag boundary."
+                    .to_string(),
+            ),
+            ErrorCode::MissingInterpolationEnd => Some(format!(
+                "Interpolation is missing its closing delimiter `{}`; treating the unfinished interpolation as text.",
+                self.options.delimiters.1
+            )),
+            ErrorCode::UnexpectedCharacterInAttributeName => Some(
+                "Attribute name contains an invalid character; inferred the nearest attribute boundary and continued."
+                    .to_string(),
+            ),
+            ErrorCode::UnexpectedCharacterInUnquotedAttributeValue => Some(
+                "Unquoted attribute value contains a character that should be quoted; keeping it in the value and continuing."
+                    .to_string(),
+            ),
+            ErrorCode::UnexpectedEqualsSignBeforeAttributeName => Some(
+                "Unexpected `=` before an attribute name; skipping it and continuing with the next attribute."
+                    .to_string(),
+            ),
+            ErrorCode::MissingWhitespaceBetweenAttributes => Some(
+                "Missing whitespace between attributes; inferred a new attribute boundary."
+                    .to_string(),
+            ),
+            ErrorCode::IncorrectlyClosedComment => Some(
+                "Comment was closed as `--!>`; treating it as `-->` so parsing can continue."
+                    .to_string(),
+            ),
+            ErrorCode::IncorrectlyOpenedComment => Some(
+                "Declaration or comment syntax is malformed; skipping it until the next `>`."
+                    .to_string(),
+            ),
+            _ => None,
+        }
     }
 }

--- a/crates/vize_armature/src/parser/mod.rs
+++ b/crates/vize_armature/src/parser/mod.rs
@@ -156,7 +156,10 @@ impl<'a> Parser<'a> {
             condense_whitespace(&mut root.children, self.options.is_pre_tag);
         }
 
-        let root = self.root.take().unwrap();
+        let root = match self.root.take() {
+            Some(root) => root,
+            None => RootNode::new(self.allocator, self.source),
+        };
         (root, self.errors)
     }
 

--- a/crates/vize_armature/src/parser/tests.rs
+++ b/crates/vize_armature/src/parser/tests.rs
@@ -589,12 +589,14 @@ fn test_parse_error_missing_end_tag() {
 fn test_parse_error_duplicate_attribute() {
     let allocator = Bump::new();
     let (root, errors) = parse(&allocator, r#"<div id="a" id="b"></div>"#);
-    // Parser doesn't error on duplicate attrs, it just adds both
-    // Verify both are present
+    assert!(
+        errors
+            .iter()
+            .any(|e| e.code == ErrorCode::DuplicateAttribute)
+    );
     if let TemplateChildNode::Element(el) = &root.children[0] {
         assert_eq!(el.props.len(), 2);
     }
-    let _ = errors;
 }
 
 #[test]
@@ -705,6 +707,190 @@ fn test_parse_open_tag_at_eof_does_not_panic() {
     let (_root, errors) = parse(&allocator, "<template>\n  <div>\n  <div\n");
     // Should return errors (EofInTag / MissingEndTag), not panic.
     assert!(!errors.is_empty());
+}
+
+#[test]
+fn test_parse_recovers_open_tag_at_eof() {
+    let allocator = Bump::new();
+    let (root, errors) = parse(&allocator, r#"<div class="a""#);
+
+    assert!(errors.iter().any(|e| e.code == ErrorCode::EofInTag));
+    assert!(errors.iter().any(|e| e.code == ErrorCode::MissingEndTag));
+    assert_eq!(root.children.len(), 1);
+
+    if let TemplateChildNode::Element(el) = &root.children[0] {
+        assert_eq!(el.tag.as_str(), "div");
+        if let PropNode::Attribute(attr) = &el.props[0] {
+            assert_eq!(attr.name.as_str(), "class");
+            assert_eq!(attr.value.as_ref().unwrap().content.as_str(), "a");
+        } else {
+            panic!("Expected recovered attribute");
+        }
+    } else {
+        panic!("Expected recovered element");
+    }
+}
+
+#[test]
+fn test_parse_recovers_missing_attribute_value() {
+    let allocator = Bump::new();
+    let (root, errors) = parse(&allocator, "<div id=></div>");
+
+    assert!(
+        errors
+            .iter()
+            .any(|e| e.code == ErrorCode::MissingAttributeValue)
+    );
+    if let TemplateChildNode::Element(el) = &root.children[0] {
+        if let PropNode::Attribute(attr) = &el.props[0] {
+            assert_eq!(attr.name.as_str(), "id");
+            assert!(attr.value.is_none());
+        } else {
+            panic!("Expected recovered attribute");
+        }
+    } else {
+        panic!("Expected element");
+    }
+}
+
+#[test]
+fn test_parse_recovers_missing_equals_before_quoted_attribute_value() {
+    let allocator = Bump::new();
+    let (root, errors) = parse(&allocator, r#"<div id"foo"></div>"#);
+
+    assert!(
+        errors
+            .iter()
+            .any(|e| e.code == ErrorCode::UnexpectedCharacterInAttributeName)
+    );
+    if let TemplateChildNode::Element(el) = &root.children[0] {
+        if let PropNode::Attribute(attr) = &el.props[0] {
+            assert_eq!(attr.name.as_str(), "id");
+            assert_eq!(attr.value.as_ref().unwrap().content.as_str(), "foo");
+        } else {
+            panic!("Expected recovered attribute");
+        }
+    } else {
+        panic!("Expected element");
+    }
+}
+
+#[test]
+fn test_parse_reports_missing_whitespace_between_attributes_and_continues() {
+    let allocator = Bump::new();
+    let (root, errors) = parse(&allocator, r#"<div id="a"class="b"></div>"#);
+
+    assert!(
+        errors
+            .iter()
+            .any(|e| e.code == ErrorCode::MissingWhitespaceBetweenAttributes)
+    );
+    if let TemplateChildNode::Element(el) = &root.children[0] {
+        assert_eq!(el.props.len(), 2);
+        if let PropNode::Attribute(attr) = &el.props[1] {
+            assert_eq!(attr.name.as_str(), "class");
+            assert_eq!(attr.value.as_ref().unwrap().content.as_str(), "b");
+        } else {
+            panic!("Expected recovered second attribute");
+        }
+    } else {
+        panic!("Expected element");
+    }
+}
+
+#[test]
+fn test_parse_recovers_missing_dynamic_directive_argument_end() {
+    let allocator = Bump::new();
+    let (root, errors) = parse(&allocator, r#"<div :[foo="bar"></div>"#);
+
+    assert!(
+        errors
+            .iter()
+            .any(|e| e.code == ErrorCode::MissingDynamicDirectiveArgumentEnd)
+    );
+    if let TemplateChildNode::Element(el) = &root.children[0] {
+        if let PropNode::Directive(dir) = &el.props[0] {
+            assert_eq!(dir.name.as_str(), "bind");
+            if let Some(ExpressionNode::Simple(arg)) = &dir.arg {
+                assert_eq!(arg.content.as_str(), "foo");
+                assert!(!arg.is_static);
+            } else {
+                panic!("Expected recovered directive argument");
+            }
+        } else {
+            panic!("Expected recovered directive");
+        }
+    } else {
+        panic!("Expected element");
+    }
+}
+
+#[test]
+fn test_parse_reports_missing_directive_name_and_continues() {
+    let allocator = Bump::new();
+    let (root, errors) = parse(&allocator, "<div v->ok</div>");
+
+    assert!(
+        errors
+            .iter()
+            .any(|e| e.code == ErrorCode::MissingDirectiveName)
+    );
+    if let TemplateChildNode::Element(el) = &root.children[0] {
+        assert!(el.props.is_empty());
+        assert_eq!(el.children.len(), 1);
+    } else {
+        panic!("Expected element");
+    }
+}
+
+#[test]
+fn test_parse_unfinished_interpolation_reports_error_but_keeps_text() {
+    let allocator = Bump::new();
+    let (root, errors) = parse(&allocator, "{{ unfinished");
+
+    assert!(
+        errors
+            .iter()
+            .any(|e| e.code == ErrorCode::MissingInterpolationEnd)
+    );
+    assert_eq!(root.children.len(), 1);
+    if let TemplateChildNode::Text(text) = &root.children[0] {
+        assert_eq!(text.content.as_str(), "{{ unfinished");
+    } else {
+        panic!("Expected recovered text");
+    }
+}
+
+#[test]
+fn test_parse_invalid_tag_name_reports_error_and_continues() {
+    let allocator = Bump::new();
+    let (root, errors) = parse(&allocator, "<1div></1div><span></span>");
+
+    assert!(
+        errors
+            .iter()
+            .any(|e| e.code == ErrorCode::InvalidFirstCharacterOfTagName)
+    );
+    assert!(
+        root.children.iter().any(
+            |child| matches!(child, TemplateChildNode::Element(el) if el.tag.as_str() == "span")
+        )
+    );
+}
+
+#[test]
+fn test_parse_incorrectly_closed_comment_reports_error_and_continues() {
+    let allocator = Bump::new();
+    let (root, errors) = parse(&allocator, "<!-- note --!><div></div>");
+
+    assert!(
+        errors
+            .iter()
+            .any(|e| e.code == ErrorCode::IncorrectlyClosedComment)
+    );
+    assert_eq!(root.children.len(), 2);
+    assert!(matches!(&root.children[0], TemplateChildNode::Comment(_)));
+    assert!(matches!(&root.children[1], TemplateChildNode::Element(_)));
 }
 
 #[test]

--- a/crates/vize_armature/src/tokenizer/mod.rs
+++ b/crates/vize_armature/src/tokenizer/mod.rs
@@ -50,6 +50,12 @@ pub struct Tokenizer<'a, C: Callbacks> {
 
     /// For special parsing behavior inside of script and style tags.
     in_rcdata: bool,
+
+    /// True immediately after a quoted attribute value ended.
+    ///
+    /// The tokenizer needs this one-token memory to report `<div a="b"c>` as
+    /// recoverable missing whitespace instead of silently starting `c`.
+    after_quoted_attr_value: bool,
 }
 
 impl<'a, C: Callbacks> Tokenizer<'a, C> {
@@ -81,6 +87,7 @@ impl<'a, C: Callbacks> Tokenizer<'a, C> {
             current_sequence: None,
             sequence_index: 0,
             in_rcdata: false,
+            after_quoted_attr_value: false,
         }
     }
 

--- a/crates/vize_armature/src/tokenizer/states.rs
+++ b/crates/vize_armature/src/tokenizer/states.rs
@@ -6,8 +6,8 @@ use crate::tokenizer::sequences::Sequence;
 use super::{
     Tokenizer,
     char_codes::{
-        AT, COLON, DASH, DOT, DOUBLE_QUOTE, EQ, EXCLAMATION_MARK, GT, LEFT_SQUARE, LOWER_V, LT,
-        NUMBER, QUESTION_MARK, RIGHT_SQUARE, SINGLE_QUOTE, SLASH,
+        AT, COLON, DASH, DOT, DOUBLE_QUOTE, EQ, EXCLAMATION_MARK, GRAVE_ACCENT, GT, LEFT_SQUARE,
+        LOWER_V, LT, NUMBER, QUESTION_MARK, RIGHT_SQUARE, SINGLE_QUOTE, SLASH,
     },
     types::{Callbacks, QuoteType, State, is_end_of_tag_section, is_tag_start_char, is_whitespace},
 };
@@ -19,30 +19,44 @@ impl<'a, C: Callbacks> Tokenizer<'a, C> {
     pub(super) fn cleanup(&mut self) {
         let has_section = self.section_start < self.index;
 
-        if has_section {
-            match self.state {
-                State::Text | State::Interpolation => {
-                    self.callbacks.on_text(self.section_start, self.index);
-                }
-                State::InTagName
-                | State::InSFCRootTagName
-                | State::BeforeClosingTagName
-                | State::InClosingTagName
-                | State::BeforeAttrName
-                | State::InAttrName
-                | State::InDirName
-                | State::InDirArg
-                | State::InDirDynamicArg
-                | State::InDirModifier
-                | State::AfterAttrName
-                | State::BeforeAttrValue
-                | State::InAttrValueDq
-                | State::InAttrValueSq
-                | State::InAttrValueNq => {
-                    self.callbacks.on_error(ErrorCode::EofInTag, self.index);
-                }
-                _ => {}
+        match self.state {
+            State::Text if has_section => {
+                self.callbacks.on_text(self.section_start, self.index);
             }
+            State::Interpolation | State::InterpolationClose if has_section => {
+                self.callbacks
+                    .on_error(ErrorCode::MissingInterpolationEnd, self.index);
+                let start = self.section_start.saturating_sub(self.delimiter_open.len());
+                self.callbacks.on_text(start, self.index);
+            }
+            State::BeforeTagName if has_section => {
+                self.callbacks
+                    .on_error(ErrorCode::EofBeforeTagName, self.index);
+                self.callbacks.on_text(self.section_start, self.index);
+            }
+            State::InTagName
+            | State::InSFCRootTagName
+            | State::BeforeSpecialS
+            | State::BeforeSpecialT
+            | State::SpecialStartSequence
+            | State::BeforeClosingTagName
+            | State::InClosingTagName
+            | State::AfterClosingTagName
+            | State::BeforeAttrName
+            | State::InAttrName
+            | State::InDirName
+            | State::InDirArg
+            | State::InDirDynamicArg
+            | State::InDirModifier
+            | State::AfterAttrName
+            | State::BeforeAttrValue
+            | State::InAttrValueDq
+            | State::InAttrValueSq
+            | State::InAttrValueNq => {
+                self.callbacks.on_error(ErrorCode::EofInTag, self.index);
+                self.recover_incomplete_tag_at_eof();
+            }
+            _ => {}
         }
 
         if self.state == State::InCommentLike {
@@ -60,6 +74,103 @@ impl<'a, C: Callbacks> Tokenizer<'a, C> {
                 }
             }
         }
+    }
+
+    fn recover_incomplete_tag_at_eof(&mut self) {
+        let inferred_tag_end = self.index.saturating_sub(1);
+
+        match self.state {
+            State::InTagName
+            | State::InSFCRootTagName
+            | State::BeforeSpecialS
+            | State::BeforeSpecialT
+            | State::SpecialStartSequence => {
+                self.callbacks
+                    .on_open_tag_name(self.section_start, self.index);
+                self.callbacks.on_open_tag_end(inferred_tag_end);
+            }
+            State::BeforeAttrName => {
+                self.callbacks.on_open_tag_end(inferred_tag_end);
+            }
+            State::InAttrName => {
+                self.callbacks
+                    .on_attrib_name(self.section_start, self.index);
+                self.callbacks.on_attrib_name_end(self.index);
+                self.callbacks.on_attrib_end(QuoteType::NoValue, self.index);
+                self.callbacks.on_open_tag_end(inferred_tag_end);
+            }
+            State::InDirName => {
+                self.callbacks.on_dir_name(self.section_start, self.index);
+                self.callbacks.on_attrib_name_end(self.index);
+                self.callbacks.on_attrib_end(QuoteType::NoValue, self.index);
+                self.callbacks.on_open_tag_end(inferred_tag_end);
+            }
+            State::InDirArg => {
+                if self.section_start < self.index {
+                    self.callbacks.on_dir_arg(self.section_start, self.index);
+                }
+                self.callbacks.on_attrib_name_end(self.index);
+                self.callbacks.on_attrib_end(QuoteType::NoValue, self.index);
+                self.callbacks.on_open_tag_end(inferred_tag_end);
+            }
+            State::InDirDynamicArg => {
+                self.callbacks
+                    .on_error(ErrorCode::MissingDynamicDirectiveArgumentEnd, self.index);
+                if self.section_start < self.index {
+                    self.callbacks.on_dir_arg(self.section_start, self.index);
+                }
+                self.callbacks.on_attrib_name_end(self.index);
+                self.callbacks.on_attrib_end(QuoteType::NoValue, self.index);
+                self.callbacks.on_open_tag_end(inferred_tag_end);
+            }
+            State::InDirModifier => {
+                self.callbacks
+                    .on_dir_modifier(self.section_start, self.index);
+                self.callbacks.on_attrib_name_end(self.index);
+                self.callbacks.on_attrib_end(QuoteType::NoValue, self.index);
+                self.callbacks.on_open_tag_end(inferred_tag_end);
+            }
+            State::AfterAttrName => {
+                self.callbacks.on_attrib_end(QuoteType::NoValue, self.index);
+                self.callbacks.on_open_tag_end(inferred_tag_end);
+            }
+            State::BeforeAttrValue => {
+                self.callbacks
+                    .on_error(ErrorCode::MissingAttributeValue, self.index);
+                self.callbacks.on_attrib_end(QuoteType::NoValue, self.index);
+                self.callbacks.on_open_tag_end(inferred_tag_end);
+            }
+            State::InAttrValueDq => {
+                self.emit_unclosed_attr_value(QuoteType::Double);
+                self.callbacks.on_open_tag_end(inferred_tag_end);
+            }
+            State::InAttrValueSq => {
+                self.emit_unclosed_attr_value(QuoteType::Single);
+                self.callbacks.on_open_tag_end(inferred_tag_end);
+            }
+            State::InAttrValueNq => {
+                self.emit_unclosed_attr_value(QuoteType::Unquoted);
+                self.callbacks.on_open_tag_end(inferred_tag_end);
+            }
+            State::InClosingTagName => {
+                if self.section_start < self.index {
+                    self.callbacks.on_close_tag(self.section_start, self.index);
+                }
+            }
+            State::BeforeClosingTagName | State::AfterClosingTagName => {}
+            _ => {}
+        }
+
+        self.state = State::Text;
+        self.section_start = self.index;
+    }
+
+    fn emit_unclosed_attr_value(&mut self, quote: QuoteType) {
+        if self.section_start < self.index {
+            self.callbacks
+                .on_attrib_data(self.section_start, self.index);
+        }
+        self.callbacks.on_attrib_end(quote, self.index);
     }
 
     // ========== State handlers ==========
@@ -149,6 +260,8 @@ impl<'a, C: Callbacks> Tokenizer<'a, C> {
         } else if c == SLASH {
             self.state = State::BeforeClosingTagName;
         } else {
+            self.callbacks
+                .on_error(ErrorCode::InvalidFirstCharacterOfTagName, self.index);
             self.state = State::Text;
             self.state_text(c);
         }
@@ -186,6 +299,11 @@ impl<'a, C: Callbacks> Tokenizer<'a, C> {
                 .on_error(ErrorCode::MissingEndTagName, self.index);
             self.state = State::Text;
             self.section_start = self.index + 1;
+        } else if !is_tag_start_char(c) {
+            self.callbacks
+                .on_error(ErrorCode::InvalidFirstCharacterOfTagName, self.index);
+            self.state = State::InClosingTagName;
+            self.section_start = self.index;
         } else {
             self.state = State::InClosingTagName;
             self.section_start = self.index;
@@ -208,11 +326,18 @@ impl<'a, C: Callbacks> Tokenizer<'a, C> {
         if c == GT {
             self.state = State::Text;
             self.section_start = self.index + 1;
+        } else if c == SLASH {
+            self.callbacks
+                .on_error(ErrorCode::EndTagWithTrailingSolidus, self.index);
+        } else if !is_whitespace(c) {
+            self.callbacks
+                .on_error(ErrorCode::EndTagWithAttributes, self.index);
         }
     }
 
     pub(super) fn state_before_attr_name(&mut self, c: u8) {
         if c == GT {
+            self.after_quoted_attr_value = false;
             self.callbacks.on_open_tag_end(self.index);
             if self.in_rcdata {
                 self.state = State::InRCDATA;
@@ -221,8 +346,22 @@ impl<'a, C: Callbacks> Tokenizer<'a, C> {
             }
             self.section_start = self.index + 1;
         } else if c == SLASH {
+            self.after_quoted_attr_value = false;
             self.state = State::InSelfClosingTag;
+        } else if is_whitespace(c) {
+            self.after_quoted_attr_value = false;
+        } else if c == EQ {
+            self.after_quoted_attr_value = false;
+            self.callbacks.on_error(
+                ErrorCode::UnexpectedEqualsSignBeforeAttributeName,
+                self.index,
+            );
         } else if !is_whitespace(c) {
+            if self.after_quoted_attr_value {
+                self.callbacks
+                    .on_error(ErrorCode::MissingWhitespaceBetweenAttributes, self.index);
+            }
+            self.after_quoted_attr_value = false;
             self.handle_attr_start(c);
         }
     }
@@ -254,6 +393,21 @@ impl<'a, C: Callbacks> Tokenizer<'a, C> {
             self.section_start = self.index;
             self.state = State::AfterAttrName;
             self.state_after_attr_name(c);
+        } else if c == DOUBLE_QUOTE || c == SINGLE_QUOTE {
+            self.callbacks
+                .on_error(ErrorCode::UnexpectedCharacterInAttributeName, self.index);
+            self.callbacks
+                .on_attrib_name(self.section_start, self.index);
+            self.callbacks.on_attrib_name_end(self.index);
+            self.section_start = self.index + 1;
+            self.state = if c == DOUBLE_QUOTE {
+                State::InAttrValueDq
+            } else {
+                State::InAttrValueSq
+            };
+        } else if c == LT {
+            self.callbacks
+                .on_error(ErrorCode::UnexpectedCharacterInAttributeName, self.index);
         }
     }
 
@@ -308,6 +462,16 @@ impl<'a, C: Callbacks> Tokenizer<'a, C> {
             self.callbacks.on_dir_arg(self.section_start, self.index);
             self.state = State::InDirArg;
             self.section_start = self.index + 1;
+        } else if c == EQ || is_end_of_tag_section(c) {
+            self.callbacks
+                .on_error(ErrorCode::MissingDynamicDirectiveArgumentEnd, self.index);
+            if self.section_start < self.index {
+                self.callbacks.on_dir_arg(self.section_start, self.index);
+            }
+            self.callbacks.on_attrib_name_end(self.index);
+            self.section_start = self.index;
+            self.state = State::AfterAttrName;
+            self.state_after_attr_name(c);
         }
     }
 
@@ -346,6 +510,17 @@ impl<'a, C: Callbacks> Tokenizer<'a, C> {
         } else if c == SINGLE_QUOTE {
             self.state = State::InAttrValueSq;
             self.section_start = self.index + 1;
+        } else if c == EQ {
+            self.callbacks.on_error(
+                ErrorCode::UnexpectedEqualsSignBeforeAttributeName,
+                self.index,
+            );
+        } else if c == GT || c == SLASH {
+            self.callbacks
+                .on_error(ErrorCode::MissingAttributeValue, self.index);
+            self.callbacks.on_attrib_end(QuoteType::NoValue, self.index);
+            self.state = State::BeforeAttrName;
+            self.state_before_attr_name(c);
         } else if !is_whitespace(c) {
             self.section_start = self.index;
             self.state = State::InAttrValueNq;
@@ -377,6 +552,11 @@ impl<'a, C: Callbacks> Tokenizer<'a, C> {
             self.emit_attr_value(QuoteType::Unquoted);
         } else if c == AMP {
             self.start_entity();
+        } else if matches!(c, DOUBLE_QUOTE | SINGLE_QUOTE | LT | EQ | GRAVE_ACCENT) {
+            self.callbacks.on_error(
+                ErrorCode::UnexpectedCharacterInUnquotedAttributeValue,
+                self.index,
+            );
         }
     }
 
@@ -388,6 +568,7 @@ impl<'a, C: Callbacks> Tokenizer<'a, C> {
         self.callbacks.on_attrib_end(quote, self.index);
         self.section_start = self.index + 1;
         self.state = State::BeforeAttrName;
+        self.after_quoted_attr_value = matches!(quote, QuoteType::Double | QuoteType::Single);
     }
 
     pub(super) fn state_before_declaration(&mut self, c: u8) {
@@ -399,6 +580,10 @@ impl<'a, C: Callbacks> Tokenizer<'a, C> {
             self.state = State::CDATASequence;
             self.section_start = self.index + 1;
         } else {
+            self.callbacks.on_error(
+                ErrorCode::IncorrectlyOpenedComment,
+                self.section_start.saturating_sub(2),
+            );
             self.state = State::InDeclaration;
         }
     }
@@ -491,6 +676,12 @@ impl<'a, C: Callbacks> Tokenizer<'a, C> {
             if self.fast_forward_to(sequence_bytes[0]) {
                 self.sequence_index = 1;
             }
+        } else if sequence == Sequence::CommentEnd
+            && self.sequence_index == 2
+            && c == EXCLAMATION_MARK
+        {
+            self.callbacks
+                .on_error(ErrorCode::IncorrectlyClosedComment, self.index);
         } else if c != sequence_bytes[self.sequence_index - 1] {
             // Allow long sequences, eg. --->, ]]]>
             self.sequence_index = 0;

--- a/crates/vize_armature/src/tokenizer/states.rs
+++ b/crates/vize_armature/src/tokenizer/states.rs
@@ -470,15 +470,16 @@ impl<'a, C: Callbacks> Tokenizer<'a, C> {
     }
 
     #[inline]
-    fn current_sequence_with_bytes(&self) -> (Sequence, &'static [u8]) {
-        let sequence = self
-            .current_sequence
-            .expect("current_sequence must be set in this state");
-        (sequence, sequence.bytes())
+    fn current_sequence_with_bytes(&self) -> Option<(Sequence, &'static [u8])> {
+        self.current_sequence
+            .map(|sequence| (sequence, sequence.bytes()))
     }
 
     pub(super) fn state_in_comment_like(&mut self, c: u8) {
-        let (sequence, sequence_bytes) = self.current_sequence_with_bytes();
+        let Some((sequence, sequence_bytes)) = self.current_sequence_with_bytes() else {
+            self.state = State::Text;
+            return;
+        };
 
         if c == sequence_bytes[self.sequence_index] {
             self.sequence_index += 1;
@@ -534,7 +535,11 @@ impl<'a, C: Callbacks> Tokenizer<'a, C> {
     }
 
     pub(super) fn state_special_start_sequence(&mut self, c: u8) {
-        let (_, sequence_bytes) = self.current_sequence_with_bytes();
+        let Some((_, sequence_bytes)) = self.current_sequence_with_bytes() else {
+            self.state = State::InTagName;
+            self.state_in_tag_name(c);
+            return;
+        };
 
         let is_end = self.sequence_index == sequence_bytes.len();
         let is_match = if is_end {
@@ -558,7 +563,11 @@ impl<'a, C: Callbacks> Tokenizer<'a, C> {
     // Look for an end tag. For `<title>` and `<textarea>`, also decode entities and handle
     // interpolation
     pub(super) fn state_in_rcdata(&mut self, c: u8) {
-        let (sequence, sequence_bytes) = self.current_sequence_with_bytes();
+        let Some((sequence, sequence_bytes)) = self.current_sequence_with_bytes() else {
+            self.state = State::Text;
+            self.state_text(c);
+            return;
+        };
 
         if self.sequence_index == sequence_bytes.len() {
             if c == GT || is_whitespace(c) {

--- a/crates/vize_armature/src/tokenizer/states.rs
+++ b/crates/vize_armature/src/tokenizer/states.rs
@@ -152,12 +152,10 @@ impl<'a, C: Callbacks> Tokenizer<'a, C> {
                 self.emit_unclosed_attr_value(QuoteType::Unquoted);
                 self.callbacks.on_open_tag_end(inferred_tag_end);
             }
-            State::InClosingTagName => {
-                if self.section_start < self.index {
-                    self.callbacks.on_close_tag(self.section_start, self.index);
-                }
+            State::InClosingTagName if self.section_start < self.index => {
+                self.callbacks.on_close_tag(self.section_start, self.index);
             }
-            State::BeforeClosingTagName | State::AfterClosingTagName => {}
+            State::InClosingTagName | State::BeforeClosingTagName | State::AfterClosingTagName => {}
             _ => {}
         }
 

--- a/crates/vize_atelier_core/src/codegen/context.rs
+++ b/crates/vize_atelier_core/src/codegen/context.rs
@@ -4,7 +4,6 @@ use crate::ast::RuntimeHelper;
 use crate::options::CodegenOptions;
 
 use super::helpers::default_helper_alias;
-use std::string::String as StdString;
 use vize_carton::FxHashSet;
 use vize_carton::String;
 use vize_carton::ToCompactString;
@@ -14,7 +13,7 @@ use vize_carton::capitalize;
 /// Code generation context using a UTF-8 string buffer for performance.
 pub struct CodegenContext {
     /// Generated code buffer
-    pub(super) code: StdString,
+    pub(super) code: String,
     /// Current indentation level
     pub(super) indent_level: u32,
     /// Whether we're in SSR mode
@@ -63,7 +62,7 @@ impl CodegenContext {
     /// Create a new codegen context
     pub fn new(options: CodegenOptions) -> Self {
         Self {
-            code: StdString::with_capacity(4096),
+            code: String::with_capacity(4096),
             indent_level: 0,
             ssr: options.ssr,
             helper_alias: default_helper_alias,
@@ -234,7 +233,7 @@ impl CodegenContext {
 
     /// Get the generated code as a String
     pub fn into_code(self) -> String {
-        self.code.into()
+        self.code
     }
 
     /// Get the generated code as a reference (for temporary use)

--- a/crates/vize_atelier_core/src/codegen/context.rs
+++ b/crates/vize_atelier_core/src/codegen/context.rs
@@ -4,16 +4,17 @@ use crate::ast::RuntimeHelper;
 use crate::options::CodegenOptions;
 
 use super::helpers::default_helper_alias;
+use std::string::String as StdString;
 use vize_carton::FxHashSet;
 use vize_carton::String;
 use vize_carton::ToCompactString;
 use vize_carton::camelize;
 use vize_carton::capitalize;
 
-/// Code generation context using byte buffer for performance
+/// Code generation context using a UTF-8 string buffer for performance.
 pub struct CodegenContext {
-    /// Generated code buffer (bytes)
-    pub(super) code: Vec<u8>,
+    /// Generated code buffer
+    pub(super) code: StdString,
     /// Current indentation level
     pub(super) indent_level: u32,
     /// Whether we're in SSR mode
@@ -62,7 +63,7 @@ impl CodegenContext {
     /// Create a new codegen context
     pub fn new(options: CodegenOptions) -> Self {
         Self {
-            code: Vec::with_capacity(4096),
+            code: StdString::with_capacity(4096),
             indent_level: 0,
             ssr: options.ssr,
             helper_alias: default_helper_alias,
@@ -120,16 +121,10 @@ impl CodegenContext {
         index
     }
 
-    /// Push bytes to buffer
-    #[inline]
-    pub fn push_bytes(&mut self, bytes: &[u8]) {
-        self.code.extend_from_slice(bytes);
-    }
-
     /// Push string to buffer
     #[inline]
     pub fn push(&mut self, code: &str) {
-        self.code.extend_from_slice(code.as_bytes());
+        self.code.push_str(code);
     }
 
     /// Push code with newline
@@ -142,9 +137,9 @@ impl CodegenContext {
     /// Add newline with proper indentation
     #[inline]
     pub fn newline(&mut self) {
-        self.code.push(b'\n');
+        self.code.push('\n');
         for _ in 0..self.indent_level {
-            self.code.extend_from_slice(b"  ");
+            self.code.push_str("  ");
         }
     }
 
@@ -166,7 +161,7 @@ impl CodegenContext {
     #[inline]
     pub fn push_pure(&mut self) {
         if self.pure {
-            self.code.extend_from_slice(b"/*#__PURE__*/ ");
+            self.code.push_str("/*#__PURE__*/ ");
         }
     }
 
@@ -225,7 +220,7 @@ impl CodegenContext {
     #[inline]
     #[allow(dead_code)]
     pub fn push_str(&mut self, code: &str) {
-        self.code.extend_from_slice(code.as_bytes());
+        self.code.push_str(code);
     }
 
     /// Push formatted line (format_args! + newline with indentation)
@@ -233,27 +228,25 @@ impl CodegenContext {
     #[allow(dead_code)]
     pub fn push_line_fmt(&mut self, args: std::fmt::Arguments<'_>) {
         use std::fmt::Write as _;
-        self.write_fmt(args).unwrap();
+        let _ = self.write_fmt(args);
         self.newline();
     }
 
     /// Get the generated code as a String
     pub fn into_code(self) -> String {
-        // SAFETY: We only push valid UTF-8 strings
-        unsafe { String::from_utf8_unchecked(self.code) }
+        self.code.into()
     }
 
     /// Get the generated code as a reference (for temporary use)
     pub fn code_as_str(&self) -> &str {
-        // SAFETY: We only push valid UTF-8 strings
-        unsafe { std::str::from_utf8_unchecked(&self.code) }
+        &self.code
     }
 }
 
 impl std::fmt::Write for CodegenContext {
     #[inline]
     fn write_str(&mut self, s: &str) -> std::fmt::Result {
-        self.code.extend_from_slice(s.as_bytes());
+        self.code.push_str(s);
         Ok(())
     }
 }

--- a/crates/vize_atelier_core/src/codegen/generate.rs
+++ b/crates/vize_atelier_core/src/codegen/generate.rs
@@ -9,13 +9,12 @@ use crate::ast::{
 };
 
 use super::{context::CodegenContext, helpers::escape_js_string};
-use std::string::String as StdString;
 use vize_carton::String;
 use vize_carton::ToCompactString;
 
 /// Generate hoisted variable declarations.
 pub(super) fn generate_hoists(ctx: &CodegenContext, root: &RootNode<'_>) -> String {
-    let mut hoists_code = StdString::new();
+    let mut hoists_code = String::default();
 
     for (i, hoist) in root.hoists.iter().enumerate() {
         if let Some(node) = hoist {
@@ -31,7 +30,7 @@ pub(super) fn generate_hoists(ctx: &CodegenContext, root: &RootNode<'_>) -> Stri
         }
     }
 
-    hoists_code.into()
+    hoists_code
 }
 
 /// Collect runtime helpers needed by hoisted nodes.
@@ -91,11 +90,7 @@ fn collect_helpers_from_props(props: &PropsExpression<'_>, helpers: &mut Vec<Run
 }
 
 /// Generate `JsChildNode` to bytes.
-fn generate_js_child_node_to_bytes(
-    ctx: &CodegenContext,
-    node: &JsChildNode<'_>,
-    out: &mut StdString,
-) {
+fn generate_js_child_node_to_bytes(ctx: &CodegenContext, node: &JsChildNode<'_>, out: &mut String) {
     match node {
         JsChildNode::VNodeCall(vnode) => generate_vnode_call_to_bytes(ctx, vnode, out),
         JsChildNode::SimpleExpression(exp) => {
@@ -142,7 +137,7 @@ fn generate_js_child_node_to_bytes(
 }
 
 /// Generate `VNodeCall` to bytes.
-fn generate_vnode_call_to_bytes(ctx: &CodegenContext, vnode: &VNodeCall<'_>, out: &mut StdString) {
+fn generate_vnode_call_to_bytes(ctx: &CodegenContext, vnode: &VNodeCall<'_>, out: &mut String) {
     // Block nodes use openBlock + createBlock/createElementBlock
     if vnode.is_block {
         out.push('(');
@@ -224,7 +219,7 @@ fn generate_vnode_call_to_bytes(ctx: &CodegenContext, vnode: &VNodeCall<'_>, out
 fn generate_props_expression_to_bytes(
     ctx: &CodegenContext,
     props: &PropsExpression<'_>,
-    out: &mut StdString,
+    out: &mut String,
 ) {
     match props {
         PropsExpression::Object(obj) => {
@@ -272,7 +267,7 @@ fn generate_props_expression_to_bytes(
 fn generate_vnode_children_to_bytes(
     _ctx: &CodegenContext,
     children: &VNodeChildren<'_>,
-    out: &mut StdString,
+    out: &mut String,
 ) {
     match children {
         VNodeChildren::Single(text_child) => match text_child {

--- a/crates/vize_atelier_core/src/codegen/generate.rs
+++ b/crates/vize_atelier_core/src/codegen/generate.rs
@@ -9,29 +9,29 @@ use crate::ast::{
 };
 
 use super::{context::CodegenContext, helpers::escape_js_string};
+use std::string::String as StdString;
 use vize_carton::String;
 use vize_carton::ToCompactString;
 
 /// Generate hoisted variable declarations.
 pub(super) fn generate_hoists(ctx: &CodegenContext, root: &RootNode<'_>) -> String {
-    let mut hoists_code: Vec<u8> = Vec::new();
+    let mut hoists_code = StdString::new();
 
     for (i, hoist) in root.hoists.iter().enumerate() {
         if let Some(node) = hoist {
-            hoists_code.extend_from_slice(b"const _hoisted_");
-            hoists_code.extend_from_slice((i + 1).to_compact_string().as_bytes());
-            hoists_code.extend_from_slice(b" = ");
+            hoists_code.push_str("const _hoisted_");
+            hoists_code.push_str((i + 1).to_compact_string().as_str());
+            hoists_code.push_str(" = ");
             // Only add /*#__PURE__*/ for VNodeCall (createElementVNode calls)
             if matches!(node, JsChildNode::VNodeCall(_)) {
-                hoists_code.extend_from_slice(b"/*#__PURE__*/ ");
+                hoists_code.push_str("/*#__PURE__*/ ");
             }
             generate_js_child_node_to_bytes(ctx, node, &mut hoists_code);
-            hoists_code.push(b'\n');
+            hoists_code.push('\n');
         }
     }
 
-    // SAFETY: We only push valid UTF-8 strings
-    unsafe { String::from_utf8_unchecked(hoists_code) }
+    hoists_code.into()
 }
 
 /// Collect runtime helpers needed by hoisted nodes.
@@ -94,27 +94,27 @@ fn collect_helpers_from_props(props: &PropsExpression<'_>, helpers: &mut Vec<Run
 fn generate_js_child_node_to_bytes(
     ctx: &CodegenContext,
     node: &JsChildNode<'_>,
-    out: &mut Vec<u8>,
+    out: &mut StdString,
 ) {
     match node {
         JsChildNode::VNodeCall(vnode) => generate_vnode_call_to_bytes(ctx, vnode, out),
         JsChildNode::SimpleExpression(exp) => {
             if exp.is_static {
-                out.push(b'"');
+                out.push('"');
                 // Escape special characters in static string values (newlines, quotes, etc.)
                 let escaped = escape_js_string(&exp.content);
-                out.extend_from_slice(escaped.as_bytes());
-                out.push(b'"');
+                out.push_str(escaped.as_str());
+                out.push('"');
             } else {
                 // Expression should already be processed by transform
-                out.extend_from_slice(exp.content.as_bytes());
+                out.push_str(exp.content.as_str());
             }
         }
         JsChildNode::Object(obj) => {
-            out.extend_from_slice(b"{ ");
+            out.push_str("{ ");
             for (i, prop) in obj.properties.iter().enumerate() {
                 if i > 0 {
-                    out.extend_from_slice(b", ");
+                    out.push_str(", ");
                 }
                 // Key - quote if contains special characters like hyphens
                 match &prop.key {
@@ -122,101 +122,101 @@ fn generate_js_child_node_to_bytes(
                         let key = &exp.content;
                         let needs_quote = !crate::codegen::helpers::is_valid_js_identifier(key);
                         if needs_quote {
-                            out.push(b'"');
-                            out.extend_from_slice(key.as_bytes());
-                            out.push(b'"');
+                            out.push('"');
+                            out.push_str(key.as_str());
+                            out.push('"');
                         } else {
-                            out.extend_from_slice(key.as_bytes());
+                            out.push_str(key.as_str());
                         }
-                        out.extend_from_slice(b": ");
+                        out.push_str(": ");
                     }
-                    ExpressionNode::Compound(_) => out.extend_from_slice(b"null: "),
+                    ExpressionNode::Compound(_) => out.push_str("null: "),
                 }
                 // Value
                 generate_js_child_node_to_bytes(ctx, &prop.value, out);
             }
-            out.extend_from_slice(b" }");
+            out.push_str(" }");
         }
-        _ => out.extend_from_slice(b"null /* unsupported */"),
+        _ => out.push_str("null /* unsupported */"),
     }
 }
 
 /// Generate `VNodeCall` to bytes.
-fn generate_vnode_call_to_bytes(ctx: &CodegenContext, vnode: &VNodeCall<'_>, out: &mut Vec<u8>) {
+fn generate_vnode_call_to_bytes(ctx: &CodegenContext, vnode: &VNodeCall<'_>, out: &mut StdString) {
     // Block nodes use openBlock + createBlock/createElementBlock
     if vnode.is_block {
-        out.push(b'(');
-        out.extend_from_slice(ctx.helper(RuntimeHelper::OpenBlock).as_bytes());
-        out.extend_from_slice(b"(), ");
+        out.push('(');
+        out.push_str(ctx.helper(RuntimeHelper::OpenBlock));
+        out.push_str("(), ");
         if vnode.is_component {
-            out.extend_from_slice(ctx.helper(RuntimeHelper::CreateBlock).as_bytes());
+            out.push_str(ctx.helper(RuntimeHelper::CreateBlock));
         } else {
-            out.extend_from_slice(ctx.helper(RuntimeHelper::CreateElementBlock).as_bytes());
+            out.push_str(ctx.helper(RuntimeHelper::CreateElementBlock));
         }
     } else if vnode.is_component {
-        out.extend_from_slice(ctx.helper(RuntimeHelper::CreateVNode).as_bytes());
+        out.push_str(ctx.helper(RuntimeHelper::CreateVNode));
     } else {
-        out.extend_from_slice(ctx.helper(RuntimeHelper::CreateElementVNode).as_bytes());
+        out.push_str(ctx.helper(RuntimeHelper::CreateElementVNode));
     }
-    out.push(b'(');
+    out.push('(');
 
     // Tag
     match &vnode.tag {
         VNodeTag::String(s) => {
-            out.push(b'"');
-            out.extend_from_slice(s.as_bytes());
-            out.push(b'"');
+            out.push('"');
+            out.push_str(s.as_str());
+            out.push('"');
         }
-        VNodeTag::Symbol(helper) => out.extend_from_slice(ctx.helper(*helper).as_bytes()),
-        VNodeTag::Call(_) => out.extend_from_slice(b"null"),
+        VNodeTag::Symbol(helper) => out.push_str(ctx.helper(*helper)),
+        VNodeTag::Call(_) => out.push_str("null"),
     }
 
     // Props
     if let Some(props) = &vnode.props {
-        out.extend_from_slice(b", ");
+        out.push_str(", ");
         generate_props_expression_to_bytes(ctx, props, out);
     } else if vnode.children.is_some() || vnode.patch_flag.is_some() {
-        out.extend_from_slice(b", null");
+        out.push_str(", null");
     }
 
     // Children
     if let Some(children) = &vnode.children {
-        out.extend_from_slice(b", ");
+        out.push_str(", ");
         generate_vnode_children_to_bytes(ctx, children, out);
     } else if vnode.patch_flag.is_some() {
-        out.extend_from_slice(b", null");
+        out.push_str(", null");
     }
 
     // Patch flag
     if let Some(patch_flag) = &vnode.patch_flag {
-        out.extend_from_slice(b", ");
-        out.extend_from_slice(patch_flag.bits().to_compact_string().as_bytes());
-        out.extend_from_slice(b" /* ");
+        out.push_str(", ");
+        out.push_str(patch_flag.bits().to_compact_string().as_str());
+        out.push_str(" /* ");
         let mut debug = String::default();
         use std::fmt::Write as _;
         let _ = write!(&mut debug, "{:?}", patch_flag);
-        out.extend_from_slice(debug.as_bytes());
-        out.extend_from_slice(b" */");
+        out.push_str(debug.as_str());
+        out.push_str(" */");
     }
 
     // Dynamic props
     if let Some(dynamic_props) = &vnode.dynamic_props {
-        out.extend_from_slice(b", ");
+        out.push_str(", ");
         match dynamic_props {
             DynamicProps::String(s) => {
-                out.extend_from_slice(s.as_bytes());
+                out.push_str(s.as_str());
             }
             DynamicProps::Simple(exp) => {
-                out.extend_from_slice(exp.content.as_bytes());
+                out.push_str(exp.content.as_str());
             }
         }
     }
 
-    out.push(b')');
+    out.push(')');
 
     // Close block wrapper
     if vnode.is_block {
-        out.push(b')');
+        out.push(')');
     }
 }
 
@@ -224,14 +224,14 @@ fn generate_vnode_call_to_bytes(ctx: &CodegenContext, vnode: &VNodeCall<'_>, out
 fn generate_props_expression_to_bytes(
     ctx: &CodegenContext,
     props: &PropsExpression<'_>,
-    out: &mut Vec<u8>,
+    out: &mut StdString,
 ) {
     match props {
         PropsExpression::Object(obj) => {
-            out.extend_from_slice(b"{ ");
+            out.push_str("{ ");
             for (i, prop) in obj.properties.iter().enumerate() {
                 if i > 0 {
-                    out.extend_from_slice(b", ");
+                    out.push_str(", ");
                 }
                 // Key - quote if contains special characters like hyphens
                 match &prop.key {
@@ -239,32 +239,32 @@ fn generate_props_expression_to_bytes(
                         let key = &exp.content;
                         let needs_quote = !crate::codegen::helpers::is_valid_js_identifier(key);
                         if needs_quote {
-                            out.push(b'"');
-                            out.extend_from_slice(key.as_bytes());
-                            out.push(b'"');
+                            out.push('"');
+                            out.push_str(key.as_str());
+                            out.push('"');
                         } else {
-                            out.extend_from_slice(key.as_bytes());
+                            out.push_str(key.as_str());
                         }
-                        out.extend_from_slice(b": ");
+                        out.push_str(": ");
                     }
-                    ExpressionNode::Compound(_) => out.extend_from_slice(b"null: "),
+                    ExpressionNode::Compound(_) => out.push_str("null: "),
                 }
                 // Value
                 generate_js_child_node_to_bytes(ctx, &prop.value, out);
             }
-            out.extend_from_slice(b" }");
+            out.push_str(" }");
         }
         PropsExpression::Simple(exp) => {
             if exp.is_static {
-                out.push(b'"');
-                out.extend_from_slice(exp.content.as_bytes());
-                out.push(b'"');
+                out.push('"');
+                out.push_str(exp.content.as_str());
+                out.push('"');
             } else {
                 // Expression should already be processed by transform
-                out.extend_from_slice(exp.content.as_bytes());
+                out.push_str(exp.content.as_str());
             }
         }
-        PropsExpression::Call(_) => out.extend_from_slice(b"null"),
+        PropsExpression::Call(_) => out.push_str("null"),
     }
 }
 
@@ -272,28 +272,28 @@ fn generate_props_expression_to_bytes(
 fn generate_vnode_children_to_bytes(
     _ctx: &CodegenContext,
     children: &VNodeChildren<'_>,
-    out: &mut Vec<u8>,
+    out: &mut StdString,
 ) {
     match children {
         VNodeChildren::Single(text_child) => match text_child {
             TemplateTextChildNode::Text(text) => {
-                out.push(b'"');
-                out.extend_from_slice(escape_js_string(&text.content).as_bytes());
-                out.push(b'"');
+                out.push('"');
+                out.push_str(escape_js_string(&text.content).as_str());
+                out.push('"');
             }
-            TemplateTextChildNode::Interpolation(_) => out.extend_from_slice(b"null"),
-            TemplateTextChildNode::Compound(_) => out.extend_from_slice(b"null"),
+            TemplateTextChildNode::Interpolation(_) => out.push_str("null"),
+            TemplateTextChildNode::Compound(_) => out.push_str("null"),
         },
         VNodeChildren::Simple(exp) => {
             if exp.is_static {
-                out.push(b'"');
-                out.extend_from_slice(escape_js_string(&exp.content).as_bytes());
-                out.push(b'"');
+                out.push('"');
+                out.push_str(escape_js_string(&exp.content).as_str());
+                out.push('"');
             } else {
                 // Expression should already be processed by transform
-                out.extend_from_slice(exp.content.as_bytes());
+                out.push_str(exp.content.as_str());
             }
         }
-        _ => out.extend_from_slice(b"null"),
+        _ => out.push_str("null"),
     }
 }

--- a/crates/vize_atelier_core/src/codegen/props/generate.rs
+++ b/crates/vize_atelier_core/src/codegen/props/generate.rs
@@ -328,13 +328,16 @@ fn generate_props_object_inner(
                 first = false;
 
                 // Check if this is a ref attribute that needs ref_key generation
-                let ref_binding_type = if attr.name == "ref" && ctx.options.inline {
-                    attr.value.as_ref().and_then(|v| {
-                        ctx.options
-                            .binding_metadata
-                            .as_ref()
-                            .and_then(|m| m.bindings.get(v.content.as_str()).copied())
-                    })
+                let ref_value = if attr.name == "ref" && ctx.options.inline {
+                    attr.value.as_ref()
+                } else {
+                    None
+                };
+                let ref_binding_type = if let Some(value) = ref_value {
+                    ctx.options
+                        .binding_metadata
+                        .as_ref()
+                        .and_then(|m| m.bindings.get(value.content.as_str()).copied())
                 } else {
                     None
                 };
@@ -345,11 +348,11 @@ fn generate_props_object_inner(
                     )
                 );
 
-                if needs_ref_key {
+                if let (true, Some(ref_value)) = (needs_ref_key, ref_value) {
                     // Emit ref_key + ref pair for setup-let/ref/maybe-ref bindings.
                     // Vue's runtime setRef() needs ref_key to write to instance.refs,
                     // which is essential for useTemplateRef to receive the element.
-                    let ref_name = &attr.value.as_ref().unwrap().content;
+                    let ref_name = &ref_value.content;
                     ctx.push("ref_key: \"");
                     ctx.push(ref_name);
                     ctx.push("\", ref: ");

--- a/crates/vize_atelier_core/src/codegen/props/scan.rs
+++ b/crates/vize_atelier_core/src/codegen/props/scan.rs
@@ -35,18 +35,19 @@ impl EventNameCounts {
             return;
         }
 
-        if let Some(first_key) = &self.first_key {
+        if let Some(first_key) = self.first_key.as_ref() {
             if first_key.as_str() == key.as_str() {
                 self.first_count += 1;
                 return;
             }
 
-            let first_key = self.first_key.take().expect("first event key");
-            let mut counts = FxHashMap::default();
-            counts.insert(first_key, self.first_count);
-            counts.insert(key, 1);
-            self.first_count = 0;
-            self.many = Some(counts);
+            if let Some(first_key) = self.first_key.take() {
+                let mut counts = FxHashMap::default();
+                counts.insert(first_key, self.first_count);
+                counts.insert(key, 1);
+                self.first_count = 0;
+                self.many = Some(counts);
+            }
             return;
         }
 

--- a/crates/vize_atelier_core/src/codegen/root.rs
+++ b/crates/vize_atelier_core/src/codegen/root.rs
@@ -45,43 +45,42 @@ pub(super) fn generate_preamble_from_helpers(
 
     // Pre-calculate capacity: each helper needs ~20 chars on average
     let estimated_capacity = 32 + helpers.len() * 24;
-    let mut preamble = Vec::with_capacity(estimated_capacity);
+    let mut preamble = String::with_capacity(estimated_capacity);
 
     match ctx.options.mode {
         crate::options::CodegenMode::Module => {
             // ES module imports - build string directly without intermediate Vec
-            preamble.extend_from_slice(b"import { ");
+            preamble.push_str("import { ");
             for (i, h) in helpers.iter().enumerate() {
                 if i > 0 {
-                    preamble.extend_from_slice(b", ");
+                    preamble.push_str(", ");
                 }
-                preamble.extend_from_slice(h.name().as_bytes());
-                preamble.extend_from_slice(b" as ");
-                preamble.extend_from_slice(ctx.helper(*h).as_bytes());
+                preamble.push_str(h.name());
+                preamble.push_str(" as ");
+                preamble.push_str(ctx.helper(*h));
             }
-            preamble.extend_from_slice(b" } from \"");
-            preamble.extend_from_slice(ctx.runtime_module_name.as_bytes());
-            preamble.extend_from_slice(b"\"\n");
+            preamble.push_str(" } from \"");
+            preamble.push_str(ctx.runtime_module_name.as_str());
+            preamble.push_str("\"\n");
         }
         crate::options::CodegenMode::Function => {
             // Destructuring from global - build string directly without intermediate Vec
-            preamble.extend_from_slice(b"const { ");
+            preamble.push_str("const { ");
             for (i, h) in helpers.iter().enumerate() {
                 if i > 0 {
-                    preamble.extend_from_slice(b", ");
+                    preamble.push_str(", ");
                 }
-                preamble.extend_from_slice(h.name().as_bytes());
-                preamble.extend_from_slice(b": ");
-                preamble.extend_from_slice(ctx.helper(*h).as_bytes());
+                preamble.push_str(h.name());
+                preamble.push_str(": ");
+                preamble.push_str(ctx.helper(*h));
             }
-            preamble.extend_from_slice(b" } = ");
-            preamble.extend_from_slice(ctx.runtime_global_name.as_bytes());
-            preamble.push(b'\n');
+            preamble.push_str(" } = ");
+            preamble.push_str(ctx.runtime_global_name.as_str());
+            preamble.push('\n');
         }
     }
 
-    // SAFETY: We only push valid UTF-8 strings
-    unsafe { String::from_utf8_unchecked(preamble) }
+    preamble
 }
 
 /// Generate function signature.

--- a/crates/vize_atelier_core/src/codegen/v_if/generate.rs
+++ b/crates/vize_atelier_core/src/codegen/v_if/generate.rs
@@ -106,16 +106,17 @@ pub(super) fn generate_single_prop_for_if(
 ) {
     match prop {
         PropNode::Attribute(attr) => {
-            let ref_binding_type = if attr.name == "ref" && ctx.options.inline {
-                attr.value.as_ref().and_then(|v| {
-                    ctx.options
-                        .binding_metadata
-                        .as_ref()
-                        .and_then(|m| m.bindings.get(v.content.as_str()).copied())
-                })
+            let ref_value = if attr.name == "ref" && ctx.options.inline {
+                attr.value.as_ref()
             } else {
                 None
             };
+            let ref_binding_type = ref_value.and_then(|v| {
+                ctx.options
+                    .binding_metadata
+                    .as_ref()
+                    .and_then(|m| m.bindings.get(v.content.as_str()).copied())
+            });
             let needs_ref_key = matches!(
                 ref_binding_type,
                 Some(
@@ -125,8 +126,8 @@ pub(super) fn generate_single_prop_for_if(
                 )
             );
 
-            if needs_ref_key {
-                let ref_name = &attr.value.as_ref().unwrap().content;
+            if let (true, Some(ref_value)) = (needs_ref_key, ref_value) {
+                let ref_name = &ref_value.content;
                 ctx.push("ref_key: \"");
                 ctx.push(ref_name);
                 ctx.push("\", ref: ");

--- a/crates/vize_atelier_core/src/transforms/transform_expression/inline_handler.rs
+++ b/crates/vize_atelier_core/src/transforms/transform_expression/inline_handler.rs
@@ -69,11 +69,11 @@ pub fn process_inline_handler<'a>(
                 },
                 allocator,
             ));
-        } else if ctx.options.is_ts {
+        } else if let Some(ts_stripped_content) = &ts_stripped_content {
             // Strip TypeScript type annotations even without prefix_identifiers
             return ExpressionNode::Simple(Box::new_in(
                 SimpleExpressionNode {
-                    content: String::new(ts_stripped_content.as_ref().unwrap()),
+                    content: String::new(ts_stripped_content),
                     is_static: false,
                     const_type: ConstantType::NotConstant,
                     loc: normalized.loc.clone(),

--- a/crates/vize_atelier_core/src/transforms/transform_expression/prefix.rs
+++ b/crates/vize_atelier_core/src/transforms/transform_expression/prefix.rs
@@ -87,7 +87,9 @@ pub fn is_simple_identifier(s: &str) -> bool {
     }
 
     let mut chars = s.chars();
-    let first = chars.next().unwrap();
+    let Some(first) = chars.next() else {
+        return false;
+    };
 
     if !first.is_alphabetic() && first != '_' && first != '$' {
         return false;

--- a/crates/vize_atelier_sfc/src/compile_script/function_mode/compiler.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/function_mode/compiler.rs
@@ -326,9 +326,9 @@ fn emit_props_definition(
     needs_prop_type: bool,
     _is_ts: bool,
 ) {
-    if has_props_destructure {
-        let destructure = ctx.macros.props_destructure.as_ref().unwrap();
-
+    if let (true, Some(destructure)) =
+        (has_props_destructure, ctx.macros.props_destructure.as_ref())
+    {
         // Check if there are any defaults
         let has_defaults = destructure.bindings.values().any(|b| b.default.is_some());
 
@@ -446,7 +446,7 @@ fn collect_model_names(ctx: &ScriptCompileContext) -> Vec<String> {
             } else {
                 let args_trimmed = m.args.trim();
                 if args_trimmed.starts_with('\'') || args_trimmed.starts_with('"') {
-                    let quote_char = args_trimmed.chars().next().unwrap();
+                    let quote_char = args_trimmed.as_bytes()[0] as char;
                     if let Some(end_pos) = args_trimmed[1..].find(quote_char) {
                         String::from(&args_trimmed[1..end_pos + 1])
                     } else {
@@ -543,7 +543,7 @@ fn emit_model_bindings(
                 let args_trimmed = model_call.args.trim();
                 if args_trimmed.starts_with('\'') || args_trimmed.starts_with('"') {
                     // Extract string content
-                    let quote_char = args_trimmed.chars().next().unwrap();
+                    let quote_char = args_trimmed.as_bytes()[0] as char;
                     if let Some(end_pos) = args_trimmed[1..].find(quote_char) {
                         String::from(&args_trimmed[1..end_pos + 1])
                     } else {

--- a/crates/vize_atelier_sfc/src/compile_script/inline/compiler/component_output.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/inline/compiler/component_output.rs
@@ -35,7 +35,7 @@ pub(super) fn emit_component_definition(
         .is_some_and(|emits| emits.binding_name.is_some());
     let has_expose = ctx.macros.define_expose.is_some();
 
-    if has_options {
+    if let (true, Some(define_options)) = (has_options, ctx.macros.define_options.as_ref()) {
         // Use Object.assign for defineOptions
         if is_vapor {
             output.extend_from_slice(
@@ -44,7 +44,7 @@ pub(super) fn emit_component_definition(
         } else {
             output.extend_from_slice(b"export default /*@__PURE__*/Object.assign(");
         }
-        let options_args = ctx.macros.define_options.as_ref().unwrap().args.trim();
+        let options_args = define_options.args.trim();
         output.extend_from_slice(options_args.as_bytes());
         output.extend_from_slice(b", {\n");
     } else if has_default_export {

--- a/crates/vize_atelier_sfc/src/compile_script/inline/compiler/props.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/inline/compiler/props.rs
@@ -115,8 +115,9 @@ pub(super) fn build_props_emits(
                 props_emits_buf.extend_from_slice(b"  },\n");
             }
         } else if !props_macro.args.is_empty() {
-            if needs_merge_defaults {
-                let destructure = ctx.macros.props_destructure.as_ref().unwrap();
+            if let (true, Some(destructure)) =
+                (needs_merge_defaults, ctx.macros.props_destructure.as_ref())
+            {
                 props_emits_buf.extend_from_slice(b"  props: /*@__PURE__*/_mergeDefaults(");
                 props_emits_buf.extend_from_slice(props_macro.args.as_bytes());
                 props_emits_buf.extend_from_slice(b", {\n");

--- a/crates/vize_atelier_sfc/src/compile_script/inline/compiler/render.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/inline/compiler/render.rs
@@ -169,8 +169,9 @@ fn append_usize(target: &mut String, value: usize) {
         }
     }
 
-    let digits = std::str::from_utf8(&buffer[index..]).expect("usize digits should be ASCII");
-    target.push_str(digits);
+    for digit in &buffer[index..] {
+        target.push(*digit as char);
+    }
 }
 
 fn collect_setup_bindings(

--- a/crates/vize_atelier_sfc/src/compile_script/props.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/props.rs
@@ -329,8 +329,8 @@ fn ts_type_to_js_type(ts_type: &str) -> String {
     let ts_type = ts_type.trim();
 
     // Strip `readonly` prefix: `readonly T[]` → `T[]`
-    let ts_type = if ts_type.starts_with("readonly ") {
-        ts_type.strip_prefix("readonly ").unwrap().trim()
+    let ts_type = if let Some(rest) = ts_type.strip_prefix("readonly ") {
+        rest.trim()
     } else {
         ts_type
     };
@@ -385,8 +385,10 @@ fn ts_type_to_js_type(ts_type: &str) -> String {
                 }
             }
 
-            if js_types.len() == 1 {
-                return js_types.into_iter().next().unwrap();
+            if js_types.len() == 1
+                && let Some(only) = js_types.pop()
+            {
+                return only;
             }
 
             // Multiple distinct types → array form: [String, Number]

--- a/crates/vize_atelier_sfc/src/compile_template/string_tracking.rs
+++ b/crates/vize_atelier_sfc/src/compile_template/string_tracking.rs
@@ -131,7 +131,9 @@ pub(super) fn count_braces_with_state(line: &str, state: &mut StringTrackState) 
                             continue;
                         } else {
                             // Nested brace inside ${...} expression
-                            *state.template_expr_brace_stack.last_mut().unwrap() -= 1;
+                            if let Some(depth) = state.template_expr_brace_stack.last_mut() {
+                                *depth -= 1;
+                            }
                             count -= 1;
                         }
                     } else {
@@ -241,7 +243,9 @@ pub(super) fn count_parens_with_state(line: &str, state: &mut StringTrackState) 
                             i += 1;
                             continue;
                         } else {
-                            *state.template_expr_brace_stack.last_mut().unwrap() -= 1;
+                            if let Some(depth) = state.template_expr_brace_stack.last_mut() {
+                                *depth -= 1;
+                            }
                         }
                     }
                 }

--- a/crates/vize_atelier_sfc/src/css/scoped.rs
+++ b/crates/vize_atelier_sfc/src/css/scoped.rs
@@ -92,9 +92,9 @@ pub(crate) fn apply_scoped_css<'a>(bump: &'a Bump, css: &str, scope_id: &str) ->
             ';' if in_at_rule => {
                 // Statement at-rule (e.g., @import, @charset, @namespace)
                 // Flush the entire at-rule including the semicolon
-                let stmt = &css_bytes[last_selector_end..=i];
-                let stmt_str = unsafe { std::str::from_utf8_unchecked(stmt) }.trim();
-                output.extend_from_slice(stmt_str.as_bytes());
+                if let Some(stmt_str) = css.get(last_selector_end..=i).map(str::trim) {
+                    output.extend_from_slice(stmt_str.as_bytes());
+                }
                 output.push(b'\n');
                 in_at_rule = false;
                 in_selector = true;
@@ -106,10 +106,9 @@ pub(crate) fn apply_scoped_css<'a>(bump: &'a Bump, css: &str, scope_id: &str) ->
                 if in_at_rule {
                     in_at_rule = false;
                     // Flush the buffered at-rule header (e.g., "@media (--mobile)")
-                    let at_rule_header = &css_bytes[last_selector_end..i];
-                    let at_rule_str =
-                        unsafe { std::str::from_utf8_unchecked(at_rule_header) }.trim();
-                    output.extend_from_slice(at_rule_str.as_bytes());
+                    if let Some(at_rule_str) = css.get(last_selector_end..i).map(str::trim) {
+                        output.extend_from_slice(at_rule_str.as_bytes());
+                    }
                     output.push(b'{');
                     if pending_keyframes {
                         saved_at_rule_depth = Some(at_rule_depth);
@@ -121,9 +120,9 @@ pub(crate) fn apply_scoped_css<'a>(bump: &'a Bump, css: &str, scope_id: &str) ->
                     last_selector_end = i + 1;
                 } else if keyframes_brace_depth.is_some_and(|d| brace_depth > d) {
                     // Inside @keyframes: output the stop name (from/to/0%/100%)
-                    let kf_part = &css_bytes[last_selector_end..i];
-                    let kf_str = unsafe { std::str::from_utf8_unchecked(kf_part) }.trim();
-                    output.extend_from_slice(kf_str.as_bytes());
+                    if let Some(kf_str) = css.get(last_selector_end..i).map(str::trim) {
+                        output.extend_from_slice(kf_str.as_bytes());
+                    }
                     output.push(b'{');
                     in_selector = false;
                     last_selector_end = i + 1;
@@ -131,10 +130,9 @@ pub(crate) fn apply_scoped_css<'a>(bump: &'a Bump, css: &str, scope_id: &str) ->
                     && (brace_depth == 1 || (at_rule_depth > 0 && brace_depth > at_rule_depth))
                 {
                     // End of selector, apply scope
-                    let selector_bytes = &css_bytes[last_selector_end..i];
-                    let selector_str =
-                        unsafe { std::str::from_utf8_unchecked(selector_bytes) }.trim();
-                    scope_selector(&mut output, selector_str, attr_selector);
+                    if let Some(selector_str) = css.get(last_selector_end..i).map(str::trim) {
+                        scope_selector(&mut output, selector_str, attr_selector);
+                    }
                     output.push(b'{');
                     in_selector = false;
                     last_selector_end = i + 1;

--- a/crates/vize_atelier_sfc/src/css/tests.rs
+++ b/crates/vize_atelier_sfc/src/css/tests.rs
@@ -13,6 +13,13 @@ use super::scoped::{
 use super::transform::extract_and_transform_v_bind;
 use super::{CssCompileOptions, bundle_css, compile_css};
 
+fn test_utf8(bytes: &[u8]) -> &str {
+    match std::str::from_utf8(bytes) {
+        Ok(value) => value,
+        Err(error) => panic!("CSS helper emitted invalid UTF-8: {error}"),
+    }
+}
+
 #[test]
 fn test_compile_simple_css() {
     let css = ".foo { color: red; }";
@@ -67,7 +74,7 @@ fn test_scope_deep() {
     let bump = Bump::new();
     let mut out = BumpVec::new_in(&bump);
     transform_deep(&mut out, ":deep(.child)", 0, b"[data-v-123]");
-    let result = unsafe { std::str::from_utf8_unchecked(&out) };
+    let result = test_utf8(&out);
     assert_eq!(result, "[data-v-123] .child");
 }
 
@@ -76,7 +83,7 @@ fn test_scope_global() {
     let bump = Bump::new();
     let mut out = BumpVec::new_in(&bump);
     transform_global(&mut out, ":global(.foo)", 0);
-    let result = unsafe { std::str::from_utf8_unchecked(&out) };
+    let result = test_utf8(&out);
     assert_eq!(result, ".foo");
 }
 
@@ -85,7 +92,7 @@ fn test_scope_slotted() {
     let bump = Bump::new();
     let mut out = BumpVec::new_in(&bump);
     transform_slotted(&mut out, ":slotted(.child)", 0, b"[data-v-123]");
-    let result = unsafe { std::str::from_utf8_unchecked(&out) };
+    let result = test_utf8(&out);
     assert_eq!(result, ".child[data-v-123-s]");
 }
 
@@ -94,7 +101,7 @@ fn test_scope_slotted_with_pseudo() {
     let bump = Bump::new();
     let mut out = BumpVec::new_in(&bump);
     transform_slotted(&mut out, ":slotted(.child):hover", 0, b"[data-v-abc]");
-    let result = unsafe { std::str::from_utf8_unchecked(&out) };
+    let result = test_utf8(&out);
     assert_eq!(result, ".child[data-v-abc-s]:hover");
 }
 
@@ -103,7 +110,7 @@ fn test_scope_slotted_complex() {
     let bump = Bump::new();
     let mut out = BumpVec::new_in(&bump);
     transform_slotted(&mut out, ":slotted(div.foo)", 0, b"[data-v-12345678]");
-    let result = unsafe { std::str::from_utf8_unchecked(&out) };
+    let result = test_utf8(&out);
     assert_eq!(result, "div.foo[data-v-12345678-s]");
 }
 
@@ -112,7 +119,7 @@ fn test_scope_with_pseudo_element() {
     let bump = Bump::new();
     let mut out = BumpVec::new_in(&bump);
     add_scope_to_element(&mut out, ".foo::before", b"[data-v-123]");
-    let result = unsafe { std::str::from_utf8_unchecked(&out) };
+    let result = test_utf8(&out);
     assert_eq!(result, ".foo[data-v-123]::before");
 }
 
@@ -121,7 +128,7 @@ fn test_scope_with_pseudo_class() {
     let bump = Bump::new();
     let mut out = BumpVec::new_in(&bump);
     add_scope_to_element(&mut out, ".foo:hover", b"[data-v-123]");
-    let result = unsafe { std::str::from_utf8_unchecked(&out) };
+    let result = test_utf8(&out);
     assert_eq!(result, ".foo[data-v-123]:hover");
 }
 

--- a/crates/vize_atelier_sfc/src/css/transform.rs
+++ b/crates/vize_atelier_sfc/src/css/transform.rs
@@ -26,8 +26,11 @@ pub(crate) fn extract_and_transform_v_bind<'a>(
                 result.extend_from_slice(&css_bytes[pos..actual_pos]);
 
                 // Extract expression
-                let expr_bytes = &css_bytes[start..start + end];
-                let expr_str = unsafe { std::str::from_utf8_unchecked(expr_bytes) }.trim();
+                let Some(expr_str) = css.get(start..start + end).map(str::trim) else {
+                    pos = start + end + 1;
+                    result.extend_from_slice(&css_bytes[actual_pos..pos]);
+                    continue;
+                };
                 let expr_str = expr_str.trim_matches(|c| c == '"' || c == '\'');
                 vars.push(expr_str.to_compact_string());
 

--- a/crates/vize_atelier_sfc/src/parse/parse_sfc.rs
+++ b/crates/vize_atelier_sfc/src/parse/parse_sfc.rs
@@ -192,13 +192,14 @@ pub fn parse_sfc<'a>(
                     });
                 } else {
                     // Custom block - use borrowed tag name
-                    let tag_str = unsafe { std::str::from_utf8_unchecked(tag_name) };
-                    descriptor.custom_blocks.push(SfcCustomBlock {
-                        block_type: Cow::Borrowed(tag_str),
-                        content,
-                        loc,
-                        attrs,
-                    });
+                    if let Ok(tag_str) = std::str::from_utf8(tag_name) {
+                        descriptor.custom_blocks.push(SfcCustomBlock {
+                            block_type: Cow::Borrowed(tag_str),
+                            content,
+                            loc,
+                            attrs,
+                        });
+                    }
                 }
 
                 pos = end_pos;

--- a/crates/vize_atelier_sfc/src/parse/tests.rs
+++ b/crates/vize_atelier_sfc/src/parse/tests.rs
@@ -82,8 +82,10 @@ fn test_zero_copy_content() {
     match &template.content {
         Cow::Borrowed(s) => {
             // The string should be a slice of the original source
-            let ptr = s.as_ptr();
-            assert!(source.as_ptr_range().contains(&ptr));
+            let start = source.as_ptr() as usize;
+            let end = start + source.len();
+            let ptr = s.as_ptr() as usize;
+            assert!((start..end).contains(&ptr));
         }
         Cow::Owned(_) => panic!("Expected Cow::Borrowed, got Cow::Owned"),
     }

--- a/crates/vize_atelier_sfc/src/parse/tests.rs
+++ b/crates/vize_atelier_sfc/src/parse/tests.rs
@@ -83,8 +83,7 @@ fn test_zero_copy_content() {
         Cow::Borrowed(s) => {
             // The string should be a slice of the original source
             let ptr = s.as_ptr();
-            let source_ptr = source.as_ptr();
-            assert!(ptr >= source_ptr && ptr < unsafe { source_ptr.add(source.len()) });
+            assert!(source.as_ptr_range().contains(&ptr));
         }
         Cow::Owned(_) => panic!("Expected Cow::Borrowed, got Cow::Owned"),
     }

--- a/crates/vize_atelier_sfc/src/script/context/props.rs
+++ b/crates/vize_atelier_sfc/src/script/context/props.rs
@@ -17,7 +17,9 @@ fn is_valid_identifier(s: &str) -> bool {
         return false;
     }
     let mut chars = s.chars();
-    let first = chars.next().unwrap();
+    let Some(first) = chars.next() else {
+        return false;
+    };
     if !first.is_ascii_alphabetic() && first != '_' && first != '$' {
         return false;
     }

--- a/crates/vize_atelier_sfc/src/script/define_emits.rs
+++ b/crates/vize_atelier_sfc/src/script/define_emits.rs
@@ -9,6 +9,7 @@ use vize_carton::{FxHashSet, String, ToCompactString};
 
 use oxc_ast::ast::{CallExpression, Expression, TSSignature, TSType, TSTypeLiteral};
 use oxc_span::GetSpan;
+use std::sync::LazyLock;
 
 use super::context::ScriptCompileContext;
 
@@ -197,24 +198,31 @@ fn extract_event_name_from_function_type(type_str: &str) -> Option<String> {
 
 /// Extract events from a type literal (object type)
 fn extract_events_from_type_literal(type_str: &str, emits: &mut FxHashSet<String>) {
+    static CALL_SIG_RE: LazyLock<Result<regex::Regex, regex::Error>> = LazyLock::new(|| {
+        regex::Regex::new(r#"\(\s*\w+\s*:\s*['"]([^'"]+)['"]\s*(?:,\s*[^)]+)?\)\s*:"#)
+    });
+    static PROP_RE: LazyLock<Result<regex::Regex, regex::Error>> =
+        LazyLock::new(|| regex::Regex::new(r#"(?:^|[{;,])\s*([a-zA-Z_$][a-zA-Z0-9_$]*)\s*:"#));
+
     // Handle call signatures: { (e: 'click'): void; (e: 'update'): void }
-    let call_sig_re =
-        regex::Regex::new(r#"\(\s*\w+\s*:\s*['"]([^'"]+)['"]\s*(?:,\s*[^)]+)?\)\s*:"#).unwrap();
-    for cap in call_sig_re.captures_iter(type_str) {
-        if let Some(event_name) = cap.get(1) {
-            emits.insert(event_name.as_str().to_compact_string());
+    if let Ok(call_sig_re) = &*CALL_SIG_RE {
+        for cap in call_sig_re.captures_iter(type_str) {
+            if let Some(event_name) = cap.get(1) {
+                emits.insert(event_name.as_str().to_compact_string());
+            }
         }
     }
 
     // Handle property syntax: { click: [...], update: [...] }
     // This is for the newer emit type syntax
-    let prop_re = regex::Regex::new(r#"(?:^|[{;,])\s*([a-zA-Z_$][a-zA-Z0-9_$]*)\s*:"#).unwrap();
-    for cap in prop_re.captures_iter(type_str) {
-        if let Some(prop_name) = cap.get(1) {
-            let name = prop_name.as_str();
-            // Skip common type keywords
-            if !matches!(name, "type" | "required" | "default" | "validator") {
-                emits.insert(name.to_compact_string());
+    if let Ok(prop_re) = &*PROP_RE {
+        for cap in prop_re.captures_iter(type_str) {
+            if let Some(prop_name) = cap.get(1) {
+                let name = prop_name.as_str();
+                // Skip common type keywords
+                if !matches!(name, "type" | "required" | "default" | "validator") {
+                    emits.insert(name.to_compact_string());
+                }
             }
         }
     }

--- a/crates/vize_atelier_sfc/src/style.rs
+++ b/crates/vize_atelier_sfc/src/style.rs
@@ -50,7 +50,9 @@ pub fn apply_scoped_css(css: &str, scope_id: &str) -> String {
 
         if in_comment {
             if c == '*' && chars.peek() == Some(&'/') {
-                current.push(chars.next().unwrap());
+                if let Some(next) = chars.next() {
+                    current.push(next);
+                }
                 in_comment = false;
             }
             continue;
@@ -75,7 +77,9 @@ pub fn apply_scoped_css(css: &str, scope_id: &str) -> String {
                 }
             }
             '/' if chars.peek() == Some(&'*') => {
-                current.push(chars.next().unwrap());
+                if let Some(next) = chars.next() {
+                    current.push(next);
+                }
                 in_comment = true;
             }
             '{' => {

--- a/crates/vize_atelier_vapor/src/generate/context.rs
+++ b/crates/vize_atelier_vapor/src/generate/context.rs
@@ -378,7 +378,7 @@ impl<'a> GenerateContext<'a> {
     pub(crate) fn push_line_fmt(&mut self, args: std::fmt::Arguments<'_>) {
         self.push_indent();
         use std::fmt::Write as _;
-        self.write_fmt(args).unwrap();
+        let _ = self.write_fmt(args);
         self.code.push('\n');
     }
 

--- a/crates/vize_atelier_vapor/src/generators/block.rs
+++ b/crates/vize_atelier_vapor/src/generators/block.rs
@@ -64,7 +64,7 @@ impl GenerateContext {
     pub fn push_line_fmt(&mut self, args: std::fmt::Arguments<'_>) {
         self.push_indent();
         use std::fmt::Write as _;
-        self.write_fmt(args).unwrap();
+        let _ = self.write_fmt(args);
         self.code.push('\n');
     }
 }

--- a/crates/vize_canon/src/checker/reporting.rs
+++ b/crates/vize_canon/src/checker/reporting.rs
@@ -235,7 +235,9 @@ impl TypeChecker {
         }
 
         let mut chars = s.chars();
-        let first = chars.next().expect("non-empty string checked above");
+        let Some(first) = chars.next() else {
+            return false;
+        };
 
         if !Self::is_ident_start(first) {
             return false;

--- a/crates/vize_canon/src/virtual_ts/generator.rs
+++ b/crates/vize_canon/src/virtual_ts/generator.rs
@@ -262,10 +262,12 @@ pub fn generate_virtual_ts_with_offsets(
                     && !trimmed_line.starts_with("export interface ")
                 {
                     let leading_ws = &output_line[..output_line.len() - trimmed_line.len()];
-                    let rest = trimmed_line.strip_prefix("export ").unwrap();
-                    #[allow(clippy::disallowed_types)]
-                    {
-                        output_line = std::borrow::Cow::Owned(cstr!("{leading_ws}{rest}").into());
+                    if let Some(rest) = trimmed_line.strip_prefix("export ") {
+                        #[allow(clippy::disallowed_types)]
+                        {
+                            output_line =
+                                std::borrow::Cow::Owned(cstr!("{leading_ws}{rest}").into());
+                        }
                     }
                 }
 
@@ -503,18 +505,10 @@ pub fn generate_virtual_ts_with_offsets(
 
     // Return exposed object from __setup() so its type can be extracted at module level.
     // This keeps the runtime args expression in scope (where the bindings are defined).
-    let has_runtime_expose = summary
-        .macros
-        .define_expose()
-        .is_some_and(|e| e.type_args.is_none() && e.runtime_args.is_some());
-    if has_runtime_expose {
-        let runtime_args = summary
-            .macros
-            .define_expose()
-            .unwrap()
-            .runtime_args
-            .as_ref()
-            .unwrap();
+    if let Some(expose) = summary.macros.define_expose()
+        && expose.type_args.is_none()
+        && let Some(runtime_args) = expose.runtime_args.as_ref()
+    {
         append!(ts, "\n  return ({runtime_args});\n");
     }
 

--- a/crates/vize_carton/src/general.rs
+++ b/crates/vize_carton/src/general.rs
@@ -4,7 +4,7 @@ use crate::String;
 use once_cell::sync::Lazy;
 use phf::phf_set;
 use rustc_hash::FxHashMap;
-use std::sync::RwLock;
+use std::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 
 /// Reserved props that should not be passed to components
 pub static RESERVED_PROPS: phf::Set<&'static str> = phf_set! {
@@ -73,12 +73,32 @@ static HYPHENATE_CACHE: Lazy<RwLock<FxHashMap<String, String>>> =
 static CAPITALIZE_CACHE: Lazy<RwLock<FxHashMap<String, String>>> =
     Lazy::new(|| RwLock::new(FxHashMap::default()));
 
+#[inline]
+fn read_cache(
+    cache: &RwLock<FxHashMap<String, String>>,
+) -> RwLockReadGuard<'_, FxHashMap<String, String>> {
+    match cache.read() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    }
+}
+
+#[inline]
+fn write_cache(
+    cache: &RwLock<FxHashMap<String, String>>,
+) -> RwLockWriteGuard<'_, FxHashMap<String, String>> {
+    match cache.write() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    }
+}
+
 /// Convert kebab-case to camelCase
 /// Example: "foo-bar" -> "fooBar"
 pub fn camelize(s: &str) -> String {
     // Check cache first
     {
-        let cache = CAMELIZE_CACHE.read().unwrap();
+        let cache = read_cache(&CAMELIZE_CACHE);
         if let Some(cached) = cache.get(s) {
             return cached.clone();
         }
@@ -88,7 +108,7 @@ pub fn camelize(s: &str) -> String {
 
     // Store in cache
     {
-        let mut cache = CAMELIZE_CACHE.write().unwrap();
+        let mut cache = write_cache(&CAMELIZE_CACHE);
         cache.insert(String::from(s), result.clone());
     }
 
@@ -118,7 +138,7 @@ fn camelize_uncached(s: &str) -> String {
 pub fn hyphenate(s: &str) -> String {
     // Check cache first
     {
-        let cache = HYPHENATE_CACHE.read().unwrap();
+        let cache = read_cache(&HYPHENATE_CACHE);
         if let Some(cached) = cache.get(s) {
             return cached.clone();
         }
@@ -128,7 +148,7 @@ pub fn hyphenate(s: &str) -> String {
 
     // Store in cache
     {
-        let mut cache = HYPHENATE_CACHE.write().unwrap();
+        let mut cache = write_cache(&HYPHENATE_CACHE);
         cache.insert(String::from(s), result.clone());
     }
 
@@ -159,7 +179,7 @@ pub fn capitalize(s: &str) -> String {
 
     // Check cache first
     {
-        let cache = CAPITALIZE_CACHE.read().unwrap();
+        let cache = read_cache(&CAPITALIZE_CACHE);
         if let Some(cached) = cache.get(s) {
             return cached.clone();
         }
@@ -169,7 +189,7 @@ pub fn capitalize(s: &str) -> String {
 
     // Store in cache
     {
-        let mut cache = CAPITALIZE_CACHE.write().unwrap();
+        let mut cache = write_cache(&CAPITALIZE_CACHE);
         cache.insert(String::from(s), result.clone());
     }
 
@@ -236,11 +256,46 @@ pub fn is_simple_identifier(s: &str) -> bool {
 /// Generate a props access expression
 pub fn gen_props_access_exp(name: &str) -> String {
     if is_simple_identifier(name) {
-        crate::cstr!("__props.{name}")
+        let mut result = String::with_capacity("__props.".len() + name.len());
+        result.push_str("__props.");
+        result.push_str(name);
+        result
     } else {
-        let key = serde_json::to_string(name).unwrap();
-        crate::cstr!("__props[{key}]")
+        let mut result = String::with_capacity("__props[]".len() + name.len() + 2);
+        result.push_str("__props[");
+        push_json_string_literal(&mut result, name);
+        result.push(']');
+        result
     }
+}
+
+#[inline]
+fn push_hex_digit(out: &mut String, value: u8) {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    out.push(HEX[value as usize] as char);
+}
+
+fn push_json_string_literal(out: &mut String, value: &str) {
+    out.push('"');
+    for ch in value.chars() {
+        match ch {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            '\u{08}' => out.push_str("\\b"),
+            '\u{0c}' => out.push_str("\\f"),
+            ch if (ch as u32) < 0x20 => {
+                let byte = ch as u8;
+                out.push_str("\\u00");
+                push_hex_digit(out, byte >> 4);
+                push_hex_digit(out, byte & 0x0f);
+            }
+            ch => out.push(ch),
+        }
+    }
+    out.push('"');
 }
 
 /// Check if a tag can have its value set directly
@@ -250,7 +305,10 @@ pub fn can_set_value_directly(tag_name: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::{camelize, capitalize, hyphenate, is_on, is_simple_identifier, to_handler_key};
+    use super::{
+        camelize, capitalize, gen_props_access_exp, hyphenate, is_on, is_simple_identifier,
+        to_handler_key,
+    };
 
     #[test]
     fn test_is_on() {
@@ -297,5 +355,15 @@ mod tests {
         assert!(!is_simple_identifier("123foo"));
         assert!(!is_simple_identifier("foo-bar"));
         assert!(!is_simple_identifier(""));
+    }
+
+    #[test]
+    fn test_gen_props_access_exp_escapes_keys() {
+        assert_eq!(gen_props_access_exp("foo"), "__props.foo");
+        assert_eq!(gen_props_access_exp("foo-bar"), "__props[\"foo-bar\"]");
+        assert_eq!(
+            gen_props_access_exp("quote\"slash\\line\n"),
+            "__props[\"quote\\\"slash\\\\line\\n\"]"
+        );
     }
 }

--- a/crates/vize_carton/src/hash.rs
+++ b/crates/vize_carton/src/hash.rs
@@ -25,14 +25,12 @@ pub fn hash_str(data: &str) -> u64 {
 #[inline]
 pub fn hash_to_hex(hash: u64) -> String {
     const HEX: &[u8; 16] = b"0123456789abcdef";
-    let mut bytes = [0u8; 16];
-    for (index, byte) in bytes.iter_mut().enumerate() {
+    let mut out = String::with_capacity(16);
+    for index in 0..16 {
         let shift = (15 - index) * 4;
-        *byte = HEX[((hash >> shift) & 0xF) as usize];
+        out.push(HEX[((hash >> shift) & 0xF) as usize] as char);
     }
-
-    // SAFETY: `HEX` only contains ASCII hex digits.
-    String::from(unsafe { std::str::from_utf8_unchecked(&bytes) })
+    out
 }
 
 /// Compute hash of a string and return as hex.

--- a/crates/vize_carton/src/lsp.rs
+++ b/crates/vize_carton/src/lsp.rs
@@ -68,7 +68,7 @@ fn lsp_message_from_json(content: String) -> String {
 
     let mut message = String::with_capacity("Content-Length: ".len() + 20 + 4 + content.len());
     message.push_str("Content-Length: ");
-    write!(&mut message, "{}", content.len()).expect("writing to String cannot fail");
+    let _ = write!(&mut message, "{}", content.len());
     message.push_str("\r\n\r\n");
     message.push_str(&content);
     message

--- a/crates/vize_carton/src/string_builder.rs
+++ b/crates/vize_carton/src/string_builder.rs
@@ -126,7 +126,7 @@ macro_rules! cstr {
 macro_rules! append {
     ($dst:expr, $($arg:tt)*) => {{
         use ::std::fmt::Write as _;
-        ::std::fmt::Write::write_fmt(&mut $dst, format_args!($($arg)*)).unwrap()
+        let _ = ::std::fmt::Write::write_fmt(&mut $dst, format_args!($($arg)*));
     }};
 }
 

--- a/crates/vize_croquis/src/analyzer/helpers/slots.rs
+++ b/crates/vize_croquis/src/analyzer/helpers/slots.rs
@@ -79,12 +79,13 @@ fn extract_slot_props_with_oxc(pattern: &str) -> SmallVec<[CompactString; 4]> {
     buffer[prefix.len()..prefix.len() + pattern.len()].copy_from_slice(pattern.as_bytes());
     buffer[prefix.len() + pattern.len()..total_len].copy_from_slice(suffix);
 
-    // SAFETY: we only copy ASCII bytes
-    let pattern_str = unsafe { std::str::from_utf8_unchecked(&buffer[..total_len]) };
-    profile!(
-        "croquis.helpers.slot_props.parse_pattern",
-        parse_slot_pattern(pattern_str)
-    )
+    match std::str::from_utf8(&buffer[..total_len]) {
+        Ok(pattern_str) => profile!(
+            "croquis.helpers.slot_props.parse_pattern",
+            parse_slot_pattern(pattern_str)
+        ),
+        Err(_) => SmallVec::new(),
+    }
 }
 
 /// Parse slot pattern using OXC

--- a/crates/vize_croquis/src/analyzer/helpers/v_for.rs
+++ b/crates/vize_croquis/src/analyzer/helpers/v_for.rs
@@ -238,12 +238,13 @@ fn parse_v_for_with_oxc(
     buffer[prefix.len()..prefix.len() + inner.len()].copy_from_slice(inner.as_bytes());
     buffer[prefix.len() + inner.len()..total_len].copy_from_slice(suffix);
 
-    // SAFETY: we only copy ASCII bytes
-    let pattern_str = unsafe { std::str::from_utf8_unchecked(&buffer[..total_len]) };
-    profile!(
-        "croquis.helpers.v_for.parse_pattern",
-        parse_v_for_pattern(pattern_str, source)
-    )
+    match std::str::from_utf8(&buffer[..total_len]) {
+        Ok(pattern_str) => profile!(
+            "croquis.helpers.v_for.parse_pattern",
+            parse_v_for_pattern(pattern_str, source)
+        ),
+        Err(_) => (SmallVec::new(), source),
+    }
 }
 
 /// Parse v-for pattern using OXC

--- a/crates/vize_croquis/src/cross_file/analyzer/core.rs
+++ b/crates/vize_croquis/src/cross_file/analyzer/core.rs
@@ -215,17 +215,16 @@ impl CrossFileAnalyzer {
         }
 
         if self.options.provide_inject {
-            let index = provide_inject_index
-                .as_ref()
-                .expect("provide/inject index should be initialized when enabled");
-            let (matches, diags) = analyzers::analyze_provide_inject_with_index(index);
-            result.provide_inject_tree = Some(analyzers::build_provide_inject_tree_with_index(
-                &self.registry,
-                index,
-                &matches,
-            ));
-            result.provide_inject_matches = matches;
-            result.diagnostics.extend(diags);
+            if let Some(index) = provide_inject_index.as_ref() {
+                let (matches, diags) = analyzers::analyze_provide_inject_with_index(index);
+                result.provide_inject_tree = Some(analyzers::build_provide_inject_tree_with_index(
+                    &self.registry,
+                    index,
+                    &matches,
+                ));
+                result.provide_inject_matches = matches;
+                result.diagnostics.extend(diags);
+            }
         }
 
         if self.options.unique_ids {

--- a/crates/vize_croquis/src/cross_file/analyzer/core.rs
+++ b/crates/vize_croquis/src/cross_file/analyzer/core.rs
@@ -214,17 +214,17 @@ impl CrossFileAnalyzer {
             result.diagnostics.extend(diags);
         }
 
-        if self.options.provide_inject {
-            if let Some(index) = provide_inject_index.as_ref() {
-                let (matches, diags) = analyzers::analyze_provide_inject_with_index(index);
-                result.provide_inject_tree = Some(analyzers::build_provide_inject_tree_with_index(
-                    &self.registry,
-                    index,
-                    &matches,
-                ));
-                result.provide_inject_matches = matches;
-                result.diagnostics.extend(diags);
-            }
+        if self.options.provide_inject
+            && let Some(index) = provide_inject_index.as_ref()
+        {
+            let (matches, diags) = analyzers::analyze_provide_inject_with_index(index);
+            result.provide_inject_tree = Some(analyzers::build_provide_inject_tree_with_index(
+                &self.registry,
+                index,
+                &matches,
+            ));
+            result.provide_inject_matches = matches;
+            result.diagnostics.extend(diags);
         }
 
         if self.options.unique_ids {

--- a/crates/vize_croquis/src/display/formatters.rs
+++ b/crates/vize_croquis/src/display/formatters.rs
@@ -211,7 +211,9 @@ impl Croquis {
             }
 
             for scope in &self.scopes {
-                let (prefix, display_id) = display_id_map.get(&scope.id).unwrap();
+                let Some((prefix, display_id)) = display_id_map.get(&scope.id) else {
+                    continue;
+                };
                 // Format: prefix+display_id kind @start:end {bindings} $ parent_refs
                 append!(
                     output,

--- a/crates/vize_croquis/src/naming.rs
+++ b/crates/vize_croquis/src/naming.rs
@@ -10,7 +10,7 @@ pub use vize_carton::{String, camelize, capitalize, hyphenate, is_simple_identif
 
 use once_cell::sync::Lazy;
 use rustc_hash::FxHashMap;
-use std::sync::RwLock;
+use std::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 use vize_carton::CompactString;
 
 // =============================================================================
@@ -20,6 +20,22 @@ use vize_carton::CompactString;
 /// Cache for to_pascal_case conversions
 static PASCAL_CASE_CACHE: Lazy<RwLock<FxHashMap<CompactString, CompactString>>> =
     Lazy::new(|| RwLock::new(FxHashMap::default()));
+
+#[inline]
+fn read_pascal_case_cache() -> RwLockReadGuard<'static, FxHashMap<CompactString, CompactString>> {
+    match PASCAL_CASE_CACHE.read() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    }
+}
+
+#[inline]
+fn write_pascal_case_cache() -> RwLockWriteGuard<'static, FxHashMap<CompactString, CompactString>> {
+    match PASCAL_CASE_CACHE.write() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    }
+}
 
 /// Convert kebab-case or camelCase to PascalCase
 ///
@@ -38,7 +54,7 @@ pub fn to_pascal_case(s: &str) -> CompactString {
 
     // Check cache first
     {
-        let cache = PASCAL_CASE_CACHE.read().unwrap();
+        let cache = read_pascal_case_cache();
         if let Some(cached) = cache.get(s) {
             return cached.clone();
         }
@@ -48,7 +64,7 @@ pub fn to_pascal_case(s: &str) -> CompactString {
 
     // Store in cache
     {
-        let mut cache = PASCAL_CASE_CACHE.write().unwrap();
+        let mut cache = write_pascal_case_cache();
         cache.insert(CompactString::new(s), result.clone());
     }
 
@@ -99,7 +115,9 @@ pub fn is_camel_case(s: &str) -> bool {
     }
 
     let mut chars = s.chars();
-    let first = chars.next().unwrap();
+    let Some(first) = chars.next() else {
+        return false;
+    };
 
     // Must start with lowercase
     if !first.is_ascii_lowercase() {
@@ -140,7 +158,9 @@ pub fn is_camel_case_loose(s: &str) -> bool {
         return false;
     }
 
-    let first = s.chars().next().unwrap();
+    let Some(first) = s.chars().next() else {
+        return false;
+    };
 
     // Must start with lowercase
     if !first.is_ascii_lowercase() {
@@ -171,7 +191,9 @@ pub fn is_pascal_case(s: &str) -> bool {
         return false;
     }
 
-    let first = s.chars().next().unwrap();
+    let Some(first) = s.chars().next() else {
+        return false;
+    };
 
     // Must start with uppercase
     if !first.is_ascii_uppercase() {

--- a/crates/vize_croquis/src/types.rs
+++ b/crates/vize_croquis/src/types.rs
@@ -324,7 +324,9 @@ fn is_valid_identifier(s: &str) -> bool {
         return false;
     }
     let mut chars = s.chars();
-    let first = chars.next().unwrap();
+    let Some(first) = chars.next() else {
+        return false;
+    };
     if !first.is_ascii_alphabetic() && first != '_' && first != '$' {
         return false;
     }

--- a/crates/vize_maestro/src/ide/definition/bindings.rs
+++ b/crates/vize_maestro/src/ide/definition/bindings.rs
@@ -138,7 +138,9 @@ pub(crate) fn is_valid_identifier(s: &str) -> bool {
         return false;
     }
     let mut chars = s.chars();
-    let first = chars.next().unwrap();
+    let Some(first) = chars.next() else {
+        return false;
+    };
     if !first.is_alphabetic() && first != '_' && first != '$' {
         return false;
     }

--- a/crates/vize_maestro/src/ide/inlay_hint/template.rs
+++ b/crates/vize_maestro/src/ide/inlay_hint/template.rs
@@ -152,8 +152,9 @@ impl InlayHintService {
                                 let quote = remaining.as_bytes()[quote_pos] as char;
                                 if quote == '"' || quote == '\'' {
                                     let new_match = (found, quote_pos + 1, quote);
-                                    if next_match.is_none()
-                                        || new_match.0 < next_match.as_ref().unwrap().0
+                                    if next_match
+                                        .as_ref()
+                                        .is_none_or(|current| new_match.0 < current.0)
                                     {
                                         next_match = Some(new_match);
                                     }
@@ -162,9 +163,12 @@ impl InlayHintService {
                         }
                     } else {
                         // v-if=", etc. - pattern already includes the quote
-                        let quote = pattern.chars().last().unwrap();
+                        let quote = pattern.as_bytes()[pattern.len() - 1] as char;
                         let new_match = (found, pattern_end, quote);
-                        if next_match.is_none() || new_match.0 < next_match.as_ref().unwrap().0 {
+                        if next_match
+                            .as_ref()
+                            .is_none_or(|current| new_match.0 < current.0)
+                        {
                             next_match = Some(new_match);
                         }
                     }

--- a/crates/vize_maestro/src/ide/mod.rs
+++ b/crates/vize_maestro/src/ide/mod.rs
@@ -161,7 +161,9 @@ pub fn is_component_tag(name: &str) -> bool {
     if name.is_empty() {
         return false;
     }
-    let first = name.chars().next().unwrap();
+    let Some(first) = name.chars().next() else {
+        return false;
+    };
     first.is_ascii_uppercase() || name.contains('-')
 }
 

--- a/crates/vize_maestro/src/ide/rename.rs
+++ b/crates/vize_maestro/src/ide/rename.rs
@@ -518,7 +518,9 @@ impl RenameService {
         }
 
         let mut chars = s.chars();
-        let first = chars.next().unwrap();
+        let Some(first) = chars.next() else {
+            return false;
+        };
 
         if !Self::is_ident_start(first) {
             return false;

--- a/crates/vize_patina/src/linter/native_type_aware/driver.rs
+++ b/crates/vize_patina/src/linter/native_type_aware/driver.rs
@@ -42,11 +42,9 @@ pub(super) fn lint_with_descriptor<'a>(
         )
     });
 
-    let mut result = if let Some((root, offset)) = template_ast.as_ref() {
-        let template = descriptor
-            .template
-            .as_ref()
-            .expect("template AST requires a template block");
+    let mut result = if let (Some((root, offset)), Some(template)) =
+        (template_ast.as_ref(), descriptor.template.as_ref())
+    {
         profile!(
             "patina.type_aware.template_rules",
             linter.lint_sfc_template_root(

--- a/crates/vize_patina/src/rules/opinionated/vapor/prefer_static_class.rs
+++ b/crates/vize_patina/src/rules/opinionated/vapor/prefer_static_class.rs
@@ -122,14 +122,15 @@ fn is_string_literal(s: &str) -> bool {
         return false;
     }
 
-    let first = s.chars().next().unwrap();
-    let last = s.chars().last().unwrap();
+    let bytes = s.as_bytes();
+    let first = bytes[0];
+    let last = bytes[bytes.len() - 1];
 
     // Check for 'string', "string", or `string`
     // But not template literals with expressions like `${foo}`
     match (first, last) {
-        ('\'', '\'') | ('"', '"') => true,
-        ('`', '`') => !s.contains("${"),
+        (b'\'', b'\'') | (b'"', b'"') => true,
+        (b'`', b'`') => !s.contains("${"),
         _ => false,
     }
 }

--- a/crates/vize_patina/src/rules/script/prefer_import_from_vue.rs
+++ b/crates/vize_patina/src/rules/script/prefer_import_from_vue.rs
@@ -88,11 +88,13 @@ impl ScriptRule for PreferImportFromVue {
                 continue;
             };
 
-            let module_specifier = &after_from[specifier_start..specifier_start + quote_end];
-
             // Check if it matches any internal package
-            // SAFETY: module_specifier comes from source which is valid UTF-8
-            let specifier_str = unsafe { std::str::from_utf8_unchecked(module_specifier) };
+            let specifier_abs_start = abs_from_pos + 4 + specifier_start;
+            let specifier_abs_end = specifier_abs_start + quote_end;
+            let Some(specifier_str) = source.get(specifier_abs_start..specifier_abs_end) else {
+                search_start = abs_from_pos + 4 + specifier_start + quote_end;
+                continue;
+            };
 
             for pkg in INTERNAL_PACKAGES {
                 if specifier_str == *pkg {

--- a/crates/vize_patina/src/rules/type_aware/require_typed_emits.rs
+++ b/crates/vize_patina/src/rules/type_aware/require_typed_emits.rs
@@ -90,7 +90,9 @@ impl Rule for RequireTypedEmits {
             return;
         }
 
-        let analysis = ctx.analysis().unwrap();
+        let Some(analysis) = ctx.analysis() else {
+            return;
+        };
         let emits = analysis.macros.emits();
 
         // Check if there are any emits

--- a/crates/vize_patina/src/rules/type_aware/require_typed_props.rs
+++ b/crates/vize_patina/src/rules/type_aware/require_typed_props.rs
@@ -93,7 +93,9 @@ impl Rule for RequireTypedProps {
             return;
         }
 
-        let analysis = ctx.analysis().unwrap();
+        let Some(analysis) = ctx.analysis() else {
+            return;
+        };
         let props = analysis.macros.props();
 
         // Check if there are any props

--- a/crates/vize_patina/src/rules/vue/component_definition_name_casing.rs
+++ b/crates/vize_patina/src/rules/vue/component_definition_name_casing.rs
@@ -41,7 +41,9 @@ fn is_pascal_case(s: &str) -> bool {
     if s.is_empty() {
         return false;
     }
-    let first = s.chars().next().unwrap();
+    let Some(first) = s.chars().next() else {
+        return false;
+    };
     if !first.is_ascii_uppercase() {
         return false;
     }

--- a/crates/vize_patina/src/rules/vue/no_mutating_props.rs
+++ b/crates/vize_patina/src/rules/vue/no_mutating_props.rs
@@ -169,7 +169,9 @@ impl Rule for NoMutatingProps {
 
         // Collect prop names first (to avoid borrow conflicts)
         let (prop_names, has_props_object_binding): (FxHashSet<String>, bool) = {
-            let analysis = ctx.analysis().unwrap();
+            let Some(analysis) = ctx.analysis() else {
+                return;
+            };
 
             let mut names: FxHashSet<String> = FxHashSet::default();
 

--- a/crates/vize_patina/src/rules/vue/no_unused_components.rs
+++ b/crates/vize_patina/src/rules/vue/no_unused_components.rs
@@ -138,7 +138,9 @@ impl Rule for NoUnusedComponents {
 
         // Collect unused components first (to avoid borrow conflicts)
         let unused_components: Vec<String> = {
-            let analysis = ctx.analysis().unwrap();
+            let Some(analysis) = ctx.analysis() else {
+                return;
+            };
 
             let registered_components = Self::imported_component_names(analysis);
 

--- a/crates/vize_patina/src/rules/vue/no_unused_properties.rs
+++ b/crates/vize_patina/src/rules/vue/no_unused_properties.rs
@@ -98,7 +98,9 @@ impl Rule for NoUnusedProperties {
 
         // Collect unused props first (to avoid borrow conflicts)
         let (unused_props, define_props_loc): (Vec<String>, (u32, u32)) = {
-            let analysis = ctx.analysis().unwrap();
+            let Some(analysis) = ctx.analysis() else {
+                return;
+            };
 
             if !self.check_props {
                 return;

--- a/crates/vize_patina/src/rules/vue/no_unused_vars.rs
+++ b/crates/vize_patina/src/rules/vue/no_unused_vars.rs
@@ -101,7 +101,9 @@ impl Rule for NoUnusedVars {
             return;
         }
 
-        let analysis = ctx.analysis().unwrap();
+        let Some(analysis) = ctx.analysis() else {
+            return;
+        };
         let unused_vars = analysis.unused_template_vars();
 
         for unused in unused_vars {

--- a/crates/vize_patina/src/rules/vue/valid_v_for.rs
+++ b/crates/vize_patina/src/rules/vue/valid_v_for.rs
@@ -117,11 +117,25 @@ impl Rule for ValidVFor {
 
                 // Validate alias part (left side of in/of)
                 let (alias_part, source_part) = if has_in {
-                    let idx = trimmed.find(" in ").unwrap();
+                    if let Some(idx) = trimmed.find(" in ") {
+                        (&trimmed[..idx], &trimmed[idx + 4..])
+                    } else {
+                        ctx.error_with_help(
+                            ctx.t("vue/valid-v-for.invalid_syntax"),
+                            &directive.loc,
+                            ctx.t("vue/valid-v-for.help"),
+                        );
+                        return;
+                    }
+                } else if let Some(idx) = trimmed.find(" of ") {
                     (&trimmed[..idx], &trimmed[idx + 4..])
                 } else {
-                    let idx = trimmed.find(" of ").unwrap();
-                    (&trimmed[..idx], &trimmed[idx + 4..])
+                    ctx.error_with_help(
+                        ctx.t("vue/valid-v-for.invalid_syntax"),
+                        &directive.loc,
+                        ctx.t("vue/valid-v-for.help"),
+                    );
+                    return;
                 };
 
                 let alias = alias_part.trim();


### PR DESCRIPTION
## Summary
- move hot codegen buffers from raw bytes to UTF-8 string buffers to remove unchecked conversions without adding final validation passes
- replace low-risk unwrap/expect paths with explicit fallbacks across parser, lint, IDE, and compiler helpers
- keep remaining unsafe blocks where replacing them would add output-size validation or require a deeper ownership redesign

## Verification
- cargo fmt --all
- cargo check -p vize_carton -p vize_armature -p vize_atelier_core -p vize_atelier_sfc -p vize_atelier_vapor -p vize_canon -p vize_croquis -p vize_patina -p vize_maestro -p vize