### PR TITLE
feat(cli): tighten profile diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,10 +132,13 @@ static `href` values, so case changes or HTML-decoded control characters do not 
 `javascript:` links. `vize check` generates virtual TypeScript for Vue SFCs and maps project
 diagnostics back to the original source files.
 
-Use `vize lint --profile src` when tuning rule cost. Type-aware lint profile rows include template
-query collection and Corsa probe phases so expensive cross-rule work can be spotted quickly. When
-template unsafe-binding and floating-Promise checks are both enabled, shared expression parsing keeps
-their query collection from doing duplicate OXC work.
+Use `vize lint --profile src` when tuning rule cost. Profile output now starts with a strict audit
+that calls out untracked wall time, slow-threshold hits, cumulative worker time, and captured
+internal spans. Hot-file rows include wall share, per-stage share, throughput, and slow-threshold
+status, while internal operation rows include wall share and max/avg spike detection. Type-aware
+lint profile rows include template query collection and Corsa probe phases so expensive cross-rule
+work can be spotted quickly. When template unsafe-binding and floating-Promise checks are both
+enabled, shared expression parsing keeps their query collection from doing duplicate OXC work.
 SSR browser-global diagnostics also avoid common literal-boundary false positives such as strings,
 regexes, comments, and direct `typeof window` guards.
 

--- a/crates/vize/src/commands/lint.rs
+++ b/crates/vize/src/commands/lint.rs
@@ -206,6 +206,7 @@ pub fn run(args: LintArgs) {
 
     let mut cross_file_tree = None;
     let cross_file_enabled = args.cross_file || args.cross_file_tree;
+    let cross_file_start = args.profile.then(Instant::now);
     if cross_file_enabled {
         let cross_file_inputs: Vec<_> = results
             .iter()
@@ -221,6 +222,9 @@ pub fn run(args: LintArgs) {
             }
         }
     }
+    let cross_file_time = cross_file_start
+        .map(|start| start.elapsed())
+        .unwrap_or(Duration::ZERO);
     let operation_summary = if args.profile {
         let profiler = global_profiler();
         let summary = profiler.summary();
@@ -288,7 +292,7 @@ pub fn run(args: LintArgs) {
             .iter()
             .fold(Duration::ZERO, |acc, row| acc + row.secondary);
         let total_bytes = file_rows.iter().fold(0usize, |acc, row| acc + row.bytes);
-        let phases = [
+        let mut phases = vec![
             ProfilePhase {
                 name: "collect files",
                 duration: collect_time,
@@ -313,13 +317,21 @@ pub fn run(args: LintArgs) {
                 kind: ProfilePhaseKind::Cumulative,
                 note: "sum across worker threads",
             },
-            ProfilePhase {
-                name: "render output",
-                duration: output_time,
-                kind: ProfilePhaseKind::Wall,
-                note: "diagnostic formatting",
-            },
         ];
+        if cross_file_enabled {
+            phases.push(ProfilePhase {
+                name: "cross-file lint",
+                duration: cross_file_time,
+                kind: ProfilePhaseKind::Wall,
+                note: "project graph diagnostics",
+            });
+        }
+        phases.push(ProfilePhase {
+            name: "render output",
+            duration: output_time,
+            kind: ProfilePhaseKind::Wall,
+            note: "diagnostic formatting",
+        });
         let slow_threshold = Duration::from_millis(args.slow_threshold);
         let mut recommendations: Vec<String> = Vec::new();
         if let Some(summary) = operation_summary.as_ref() {
@@ -360,7 +372,7 @@ pub fn run(args: LintArgs) {
             title: "lint",
             summary: summary.as_str(),
             total: elapsed,
-            phases: &phases,
+            phases: phases.as_slice(),
             files: &file_rows,
             slow_threshold,
             throughput_bytes: Some(total_bytes),

--- a/crates/vize/src/commands/profile.rs
+++ b/crates/vize/src/commands/profile.rs
@@ -11,6 +11,7 @@ const BOLD: &str = "\x1b[1m";
 const DIM: &str = "\x1b[90m";
 const GREEN: &str = "\x1b[32m";
 const YELLOW: &str = "\x1b[33m";
+const RED: &str = "\x1b[31m";
 const CYAN: &str = "\x1b[36m";
 
 #[derive(Debug, Clone, Copy)]
@@ -74,12 +75,118 @@ pub(crate) fn render_profile_report(report: &ProfileReport<'_>) -> String {
     }
     out.push('\n');
 
+    render_strict_audit(&mut out, report);
     render_phase_table(&mut out, report);
     render_file_table(&mut out, report);
-    render_operation_table(&mut out, report.operations);
+    render_operation_table(&mut out, report);
     render_recommendations(&mut out, report);
 
     out
+}
+
+fn render_strict_audit(out: &mut String, report: &ProfileReport<'_>) {
+    let wall_tracked = report
+        .phases
+        .iter()
+        .filter(|phase| matches!(phase.kind, ProfilePhaseKind::Wall))
+        .fold(Duration::ZERO, |acc, phase| acc + phase.duration);
+    let cumulative_tracked = report
+        .phases
+        .iter()
+        .filter(|phase| matches!(phase.kind, ProfilePhaseKind::Cumulative))
+        .fold(Duration::ZERO, |acc, phase| acc + phase.duration);
+    let untracked_wall = report.total.saturating_sub(wall_tracked);
+    let slow_file_count = report
+        .files
+        .iter()
+        .filter(|file| file.total > report.slow_threshold)
+        .count();
+    let (operation_count, operation_total) = report
+        .operations
+        .map(|summary| {
+            summary
+                .entries
+                .iter()
+                .fold((0u64, Duration::ZERO), |(count, total), entry| {
+                    (count + entry.count, total + entry.total)
+                })
+        })
+        .unwrap_or((0, Duration::ZERO));
+
+    appendln!(out);
+    appendln!(out, BOLD, "Strict audit", RESET);
+    appendln!(
+        out,
+        DIM,
+        "  metric                  value                  status",
+        RESET
+    );
+
+    let wall_share = percent_of(wall_tracked, report.total);
+    let mut value = String::default();
+    write_duration(&mut value, wall_tracked);
+    append!(value, " ({:.1}%)", wall_share);
+    let (status, color) = if wall_share < 80.0 {
+        ("profile gap", YELLOW)
+    } else if wall_share > 120.0 {
+        ("overlapping phases", CYAN)
+    } else {
+        ("covered", GREEN)
+    };
+    audit_row(out, "wall accounted", value.as_str(), status, color);
+
+    value.clear();
+    write_duration(&mut value, untracked_wall);
+    append!(value, " ({:.1}%)", percent_of(untracked_wall, report.total));
+    let (status, color) = if percent_of(untracked_wall, report.total) > 5.0 {
+        ("unprofiled work", YELLOW)
+    } else {
+        ("tight", GREEN)
+    };
+    audit_row(out, "untracked wall", value.as_str(), status, color);
+
+    value.clear();
+    write_duration(&mut value, cumulative_tracked);
+    append!(
+        value,
+        " ({:.1}x wall)",
+        duration_ratio(cumulative_tracked, report.total)
+    );
+    let (status, color) = if cumulative_tracked.is_zero() {
+        ("none", DIM)
+    } else {
+        ("parallel/nested", CYAN)
+    };
+    audit_row(out, "cumulative work", value.as_str(), status, color);
+
+    value.clear();
+    append!(value, "{} / {}", slow_file_count, report.files.len());
+    let (status, color) = if slow_file_count == 0 {
+        ("threshold clear", GREEN)
+    } else {
+        ("threshold hit", YELLOW)
+    };
+    audit_row(out, "slow files", value.as_str(), status, color);
+
+    value.clear();
+    append!(value, "{operation_count} call(s), ");
+    write_duration(&mut value, operation_total);
+    let (status, color) = if operation_count == 0 {
+        ("not captured", DIM)
+    } else {
+        ("captured", GREEN)
+    };
+    audit_row(out, "internal spans", value.as_str(), status, color);
+}
+
+fn audit_row(out: &mut String, metric: &str, value: &str, status: &str, color: &str) {
+    appends!(out, "  ");
+    append_padded(out, metric, 23);
+    appends!(out, " ");
+    append_padded(out, value, 22);
+    appends!(out, " ", color);
+    append_padded(out, status, 16);
+    appendln!(out, RESET);
 }
 
 fn render_phase_table(out: &mut String, report: &ProfileReport<'_>) {
@@ -136,32 +243,43 @@ fn render_file_table(mut out: &mut String, report: &ProfileReport<'_>) {
     appendln!(
         out,
         DIM,
-        "  total       breakdown                 size      file",
+        "  #  total       share   breakdown                          size      rate       status       file",
         RESET
     );
 
     let mut displayed = 0usize;
-    for file in report.files.iter().take(10) {
+    for (index, file) in report.files.iter().take(20).enumerate() {
         displayed += 1;
-        let color = if file.total > report.slow_threshold {
-            YELLOW
-        } else {
-            GREEN
-        };
+        let is_slow = file.total > report.slow_threshold;
+        let color = if is_slow { YELLOW } else { GREEN };
+        let status = file_status(file, report.slow_threshold);
 
+        appends!(out, "  ");
+        write_count_padded(out, (index + 1) as u64, 2);
         appends!(out, "  ", color);
         write_duration_padded(out, file.total, 10);
         appends!(out, RESET, "  ");
+        write_percent_padded(out, percent_of(file.total, report.total), 6);
+        appends!(out, "  ");
         append_padded(out, file.primary_label, 7);
         appends!(out, " ");
         write_duration_padded(out, file.primary, 9);
+        appends!(out, " ");
+        write_percent_padded(out, percent_of(file.primary, file.total), 6);
         appends!(out, "  ");
         append_padded(out, file.secondary_label, 7);
         appends!(out, " ");
         write_duration_padded(out, file.secondary, 9);
+        appends!(out, " ");
+        write_percent_padded(out, percent_of(file.secondary, file.total), 6);
         appends!(out, "  ");
         write_bytes(out, file.bytes);
         appends!(out, "  ");
+        write_rate_padded(out, file.bytes, file.total, 9);
+        appends!(out, "  ");
+        appends!(out, color);
+        append_padded(out, status.as_str(), 12);
+        appends!(out, RESET, " ");
         append!(out, "{}", file.path.display());
 
         if let Some(note) = file.note.as_ref() {
@@ -184,8 +302,8 @@ fn render_file_table(mut out: &mut String, report: &ProfileReport<'_>) {
     }
 }
 
-fn render_operation_table(out: &mut String, summary: Option<&ProfileSummary>) {
-    let Some(summary) = summary else {
+fn render_operation_table(out: &mut String, report: &ProfileReport<'_>) {
+    let Some(summary) = report.operations else {
         return;
     };
     if summary.entries.is_empty() {
@@ -197,12 +315,15 @@ fn render_operation_table(out: &mut String, summary: Option<&ProfileSummary>) {
     appendln!(
         out,
         DIM,
-        "  operation                         count   total       avg         min         max",
+        "  operation                         count   total       share   avg         min         max       max/avg  status",
         RESET
     );
 
-    let displayed = summary.entries.len().min(32);
+    let displayed = summary.entries.len().min(48);
     for entry in summary.entries.iter().take(displayed) {
+        let max_avg_ratio = duration_ratio(entry.max, entry.average);
+        let (status, color) = operation_status(entry, report.total, max_avg_ratio);
+
         appends!(out, "  ");
         append_padded(out, entry.name, 33);
         appends!(out, " ");
@@ -210,11 +331,18 @@ fn render_operation_table(out: &mut String, summary: Option<&ProfileSummary>) {
         appends!(out, "  ");
         write_duration_padded(out, entry.total, 10);
         appends!(out, "  ");
+        write_percent_padded(out, percent_of(entry.total, report.total), 6);
+        appends!(out, "  ");
         write_duration_padded(out, entry.average, 10);
         appends!(out, "  ");
         write_duration_padded(out, entry.min, 10);
         appends!(out, "  ");
         write_duration_padded(out, entry.max, 10);
+        appends!(out, "  ");
+        write_ratio_padded(out, max_avg_ratio, 7);
+        appends!(out, "  ", color);
+        append_padded(out, status, 8);
+        appends!(out, RESET);
         out.push('\n');
     }
 
@@ -227,6 +355,31 @@ fn render_operation_table(out: &mut String, summary: Option<&ProfileSummary>) {
             " more operation(s)",
             RESET
         );
+    }
+}
+
+fn file_status(file: &ProfileFileRow, slow_threshold: Duration) -> String {
+    if slow_threshold.is_zero() || file.total <= slow_threshold {
+        return String::from("ok");
+    }
+
+    let ratio = duration_ratio(file.total, slow_threshold);
+    let mut status = String::default();
+    append!(status, "SLOW x{ratio:.1}");
+    status
+}
+
+fn operation_status(
+    entry: &vize_carton::profiler::ProfileEntry,
+    total: Duration,
+    max_avg_ratio: f64,
+) -> (&'static str, &'static str) {
+    if percent_of(entry.total, total) >= 25.0 {
+        ("HOT", YELLOW)
+    } else if entry.count >= 3 && entry.max >= Duration::from_millis(1) && max_avg_ratio >= 8.0 {
+        ("SPIKE", RED)
+    } else {
+        ("ok", GREEN)
     }
 }
 
@@ -287,6 +440,10 @@ fn write_percent(mut out: &mut String, percent: f64) {
     append!(out, "{:>5.1}%", percent);
 }
 
+fn write_percent_padded(mut out: &mut String, percent: f64, width: usize) {
+    append!(out, "{percent:>width$.1}%");
+}
+
 fn write_throughput(mut out: &mut String, bytes: usize, duration: Duration) {
     let seconds = duration.as_secs_f64();
     if seconds <= f64::EPSILON {
@@ -295,6 +452,34 @@ fn write_throughput(mut out: &mut String, bytes: usize, duration: Duration) {
     }
     let kb_per_sec = bytes as f64 / 1024.0 / seconds;
     append!(out, "{:.2} KiB/s", kb_per_sec);
+}
+
+fn write_rate_padded(out: &mut String, bytes: usize, duration: Duration, width: usize) {
+    let before = out.len();
+    write_rate(out, bytes, duration);
+    let written = out.len() - before;
+    if written < width {
+        let value = out.split_off(before);
+        for _ in 0..(width - written) {
+            out.push(' ');
+        }
+        out.push_str(value.as_str());
+    }
+}
+
+fn write_rate(mut out: &mut String, bytes: usize, duration: Duration) {
+    let seconds = duration.as_secs_f64();
+    if seconds <= f64::EPSILON {
+        appends!(out, "n/a");
+        return;
+    }
+
+    let kib_per_sec = bytes as f64 / 1024.0 / seconds;
+    if kib_per_sec >= 1024.0 {
+        append!(out, "{:.2} MiB/s", kib_per_sec / 1024.0);
+    } else {
+        append!(out, "{:.2} KiB/s", kib_per_sec);
+    }
 }
 
 fn write_bytes(mut out: &mut String, bytes: usize) {
@@ -309,6 +494,10 @@ fn write_bytes(mut out: &mut String, bytes: usize) {
 
 fn write_count_padded(mut out: &mut String, count: u64, width: usize) {
     append!(out, "{count:>width$}");
+}
+
+fn write_ratio_padded(mut out: &mut String, ratio: f64, width: usize) {
+    append!(out, "{ratio:>width$.1}x");
 }
 
 fn write_bar(out: &mut String, percent: f64) {
@@ -327,6 +516,15 @@ fn percent_of(duration: Duration, total: Duration) -> f64 {
         0.0
     } else {
         duration.as_secs_f64() / total * 100.0
+    }
+}
+
+fn duration_ratio(duration: Duration, baseline: Duration) -> f64 {
+    let baseline = baseline.as_secs_f64();
+    if baseline <= f64::EPSILON {
+        0.0
+    } else {
+        duration.as_secs_f64() / baseline
     }
 }
 

--- a/crates/vize/src/commands/snapshots/vize__commands__profile__tests__profile_report_snapshot.snap
+++ b/crates/vize/src/commands/snapshots/vize__commands__profile__tests__profile_report_snapshot.snap
@@ -8,6 +8,14 @@ expression: render_profile_report(&report)
 
 [1mTotal wall time[0m: 50.000ms[90m  throughput 40.00 KiB/s[0m
 
+[1mStrict audit[0m
+[90m  metric                  value                  status[0m
+  wall accounted          10.000ms (20.0%)       [33mprofile gap     [0m
+  untracked wall          40.000ms (80.0%)       [33munprofiled work [0m
+  cumulative work         42.000ms (0.8x wall)   [36mparallel/nested [0m
+  slow files              1 / 1                  [33mthreshold hit   [0m
+  internal spans          25 call(s), 14.000ms   [32mcaptured        [0m
+
 [1mTiming breakdown[0m
 [90m  phase                         time        share  kind        note[0m
   collect files                  10.000ms   20.0%  wall        [####..............]  [90mwalked inputs[0m
@@ -15,13 +23,13 @@ expression: render_profile_report(&report)
 
 [1mHot files[0m
 [90m  slow threshold: 30.000ms[0m
-[90m  total       breakdown                 size      file[0m
-  [33m  31.000ms[0m  parse     8.000ms  compile  20.000ms     2.00 KiB  src/App.vue[90m  1 style block[0m
+[90m  #  total       share   breakdown                          size      rate       status       file[0m
+   1  [33m  31.000ms[0m    62.0%  parse     8.000ms   25.8%  compile  20.000ms   64.5%     2.00 KiB  64.52 KiB/s  [33mSLOW x1.0   [0m src/App.vue[90m  1 style block[0m
 
 [1mInternal operations[0m
-[90m  operation                         count   total       avg         min         max[0m
-  atelier.sfc.parse                     1     8.000ms     8.000ms     8.000ms     8.000ms
-  atelier.transform.element            24     6.000ms     0.250ms     0.100ms     0.600ms
+[90m  operation                         count   total       share   avg         min         max       max/avg  status[0m
+  atelier.sfc.parse                     1     8.000ms    16.0%     8.000ms     8.000ms     8.000ms      1.0x  [32mok      [0m
+  atelier.transform.element            24     6.000ms    12.0%     0.250ms     0.100ms     0.600ms      2.4x  [32mok      [0m
 
 [1mNotes[0m
   [36m- [0msrc/App.vue spent most of its time in compile; inspect template complexity.

--- a/crates/vize_carton/src/profiler.rs
+++ b/crates/vize_carton/src/profiler.rs
@@ -3,11 +3,13 @@
 //! Provides simple timing and metrics collection for tracking
 //! type checking and compilation performance.
 
-use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::{RwLockReadGuard, RwLockWriteGuard};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 use std::time::{Duration, Instant};
 
 use rustc_hash::FxHashMap;
+
+const PROFILER_SHARDS: usize = 32;
 
 /// A lightweight timer for measuring durations.
 #[derive(Debug)]
@@ -95,18 +97,22 @@ impl Default for Metrics {
 }
 
 /// Performance profiler for collecting metrics.
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct Profiler {
-    /// Metrics by operation name
-    metrics: std::sync::RwLock<FxHashMap<&'static str, Metrics>>,
+    /// Metrics by operation name, split into shards to keep parallel profile runs from
+    /// funnelling every span through the same lock.
+    metrics: [RwLock<FxHashMap<&'static str, Metrics>>; PROFILER_SHARDS],
     /// Whether profiling is enabled
-    enabled: std::sync::atomic::AtomicBool,
+    enabled: AtomicBool,
 }
 
 impl Profiler {
     /// Create a new profiler.
     pub fn new() -> Self {
-        Self::default()
+        Self {
+            metrics: std::array::from_fn(|_| RwLock::new(FxHashMap::default())),
+            enabled: AtomicBool::new(false),
+        }
     }
 
     /// Create an enabled profiler.
@@ -154,39 +160,60 @@ impl Profiler {
     /// Record a duration after the caller has already checked that profiling is enabled.
     #[doc(hidden)]
     pub fn record_enabled(&self, name: &'static str, duration: Duration) {
-        let mut metrics = self.metrics_write();
+        let mut metrics = self.metrics_write(Self::shard_index(name));
         metrics.entry(name).or_default().record(duration);
     }
 
     /// Get metrics for the given operation.
     pub fn get(&self, name: &str) -> Option<Metrics> {
-        self.metrics_read().get(name).cloned()
+        self.metrics_read(Self::shard_index(name))
+            .get(name)
+            .cloned()
     }
 
     /// Get all metrics.
     pub fn all(&self) -> FxHashMap<&'static str, Metrics> {
-        self.metrics_read().clone()
+        let mut all = FxHashMap::default();
+        for shard in &self.metrics {
+            let metrics = shard
+                .read()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            all.extend(
+                metrics
+                    .iter()
+                    .map(|(name, metrics)| (*name, metrics.clone())),
+            );
+        }
+        all
     }
 
     /// Clear all metrics.
     pub fn clear(&self) {
-        self.metrics_write().clear();
+        for shard in &self.metrics {
+            shard
+                .write()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .clear();
+        }
     }
 
     /// Generate a summary report.
     pub fn summary(&self) -> ProfileSummary {
-        let metrics = self.metrics_read();
-        let mut entries: Vec<_> = metrics
-            .iter()
-            .map(|(name, m)| ProfileEntry {
+        let mut entries = Vec::new();
+        for shard in &self.metrics {
+            let metrics = shard
+                .read()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            entries.reserve(metrics.len());
+            entries.extend(metrics.iter().map(|(name, m)| ProfileEntry {
                 name,
                 count: m.count,
                 total: m.total_duration,
                 average: m.average(),
                 min: m.min_duration,
                 max: m.max_duration,
-            })
-            .collect();
+            }));
+        }
 
         // Sort by total time descending
         entries.sort_by_key(|entry| std::cmp::Reverse(entry.total));
@@ -195,17 +222,38 @@ impl Profiler {
     }
 
     #[inline]
-    fn metrics_read(&self) -> RwLockReadGuard<'_, FxHashMap<&'static str, Metrics>> {
-        self.metrics
+    fn metrics_read(&self, shard: usize) -> RwLockReadGuard<'_, FxHashMap<&'static str, Metrics>> {
+        self.metrics[shard]
             .read()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
     }
 
     #[inline]
-    fn metrics_write(&self) -> RwLockWriteGuard<'_, FxHashMap<&'static str, Metrics>> {
-        self.metrics
+    fn metrics_write(
+        &self,
+        shard: usize,
+    ) -> RwLockWriteGuard<'_, FxHashMap<&'static str, Metrics>> {
+        self.metrics[shard]
             .write()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
+    #[inline]
+    fn shard_index(name: &str) -> usize {
+        debug_assert!(PROFILER_SHARDS.is_power_of_two());
+
+        let mut hash = 0xcbf2_9ce4_8422_2325u64;
+        for byte in name.as_bytes() {
+            hash ^= u64::from(*byte);
+            hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
+        }
+        (hash as usize) & (PROFILER_SHARDS - 1)
+    }
+}
+
+impl Default for Profiler {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -431,8 +479,9 @@ mod tests {
     fn profiler_recovers_from_poisoned_metrics_lock() {
         let profiler = Arc::new(Profiler::enabled());
         let cloned = Arc::clone(&profiler);
+        let shard = Profiler::shard_index("after_poison");
         let _ = std::thread::spawn(move || {
-            let _guard = cloned.metrics.write().unwrap();
+            let _guard = cloned.metrics[shard].write().unwrap();
             panic!("poison profiler metrics lock");
         })
         .join();
@@ -440,6 +489,30 @@ mod tests {
         profiler.record("after_poison", Duration::from_millis(1));
 
         assert_eq!(profiler.get("after_poison").unwrap().count, 1);
+    }
+
+    #[test]
+    fn profiler_summarizes_records_across_shards() {
+        let profiler = Profiler::enabled();
+        for index in 0..128 {
+            let name = match index % 4 {
+                0 => "profile.shard.a",
+                1 => "profile.shard.b",
+                2 => "profile.shard.c",
+                _ => "profile.shard.d",
+            };
+            profiler.record(name, Duration::from_micros(index + 1));
+        }
+
+        let all = profiler.all();
+        assert_eq!(all.len(), 4);
+
+        let summary = profiler.summary();
+        assert_eq!(summary.entries.len(), 4);
+        assert_eq!(
+            summary.entries.iter().map(|entry| entry.count).sum::<u64>(),
+            128
+        );
     }
 
     #[test]

--- a/docs/content/architecture/performance.md
+++ b/docs/content/architecture/performance.md
@@ -126,7 +126,11 @@ template Promise queries in one AST walk before the Corsa probe phase. Query col
 the OXC expression parse for unsafe-template and floating-Promise checks, so one template expression
 does not pay duplicate parse cost when both rules are enabled.
 
-Run `vize lint --profile --preset opinionated src` to see these rows in a local project.
+Run `vize lint --profile --preset opinionated src` to see these rows in a local project. The
+profile report also includes a strict audit section that checks wall-time coverage, cumulative
+worker time, slow-threshold hits, and captured internal spans before listing hot files and internal
+operations. Hot-file rows show per-stage share and throughput, and operation rows flag dominant
+spans or max/avg spikes.
 
 ## Benchmark: Formatter — glyph vs Prettier
 


### PR DESCRIPTION
## Summary

- add a strict audit section to CLI profile output for wall-time coverage, untracked wall time, cumulative worker time, slow-file hits, and captured internal spans
- expand hot-file and internal-operation tables with share, throughput, status, and max/avg spike context
- profile cross-file lint as an explicit wall phase and shard profiler metrics to reduce lock contention during parallel profile runs

## Why

Profiling mode was useful for broad timing, but it was too forgiving: gaps between total wall time and tracked phases were easy to miss, file rows did not show proportional cost, and all profile spans contended on one metrics lock during parallel workloads.

## Validation

- `cargo test -p vize`
- `cargo test -p vize_carton profiler`
- `cargo run -q -p vize -- lint --profile --quiet examples/vite-musea/src/components/Avatar.vue`

## Note

- `cargo test -p vize_carton` still fails in this local environment because the Pkl server executable is unavailable for existing Pkl loading snapshots; profiler-focused tests pass.
