### PR TITLE
feat(armature): recover malformed template parse errors

### DIFF
--- a/crates/vize_armature/src/parser/attribute.rs
+++ b/crates/vize_armature/src/parser/attribute.rs
@@ -4,9 +4,12 @@
 //! attribute data (values), and finalization of attribute and directive nodes.
 
 use vize_carton::{Box, String, Vec};
-use vize_relief::ast::{
-    AttributeNode, ConstantType, DirectiveNode, ExpressionNode, PropNode, SimpleExpressionNode,
-    TextNode,
+use vize_relief::{
+    ast::{
+        AttributeNode, ConstantType, DirectiveNode, ExpressionNode, PropNode, SimpleExpressionNode,
+        TextNode,
+    },
+    errors::{CompilerError, ErrorCode},
 };
 
 use crate::tokenizer::QuoteType;
@@ -70,6 +73,15 @@ impl<'a> Parser<'a> {
 
     /// Process directive modifier
     pub(super) fn on_dir_modifier_impl(&mut self, start: usize, end: usize) {
+        if start >= end {
+            let loc = self.create_loc(start, end);
+            self.errors.push(CompilerError::new(
+                ErrorCode::MissingDirectiveModifier,
+                Some(loc),
+            ));
+            return;
+        }
+
         let modifier: String = self.get_source(start, end).into();
         if let Some(ref mut dir) = self.current_dir {
             dir.modifiers.push((modifier, start, end));
@@ -155,11 +167,30 @@ impl<'a> Parser<'a> {
         }
     }
 
+    fn has_duplicate_attribute(&self, name: &str) -> bool {
+        self.current_element.as_ref().is_some_and(|current| {
+            current.props.iter().any(|prop| {
+                matches!(prop, PropNode::Attribute(existing) if existing.name.as_str() == name)
+            })
+        })
+    }
+
     /// Finish building an attribute node
     fn finish_attribute(&mut self, attr: CurrentAttribute<'a>, quote: QuoteType, end: usize) {
         let loc_end = self.prop_loc_end(quote, end, attr.name_end);
         let loc = self.create_loc(attr.name_start, loc_end);
         let name_loc = self.create_loc(attr.name_start, attr.name_end);
+
+        if self.has_duplicate_attribute(attr.name.as_str()) {
+            self.errors.push(CompilerError::with_message(
+                ErrorCode::DuplicateAttribute,
+                format!(
+                    "Duplicate attribute `{}`. Keeping the repeated attribute so parsing can continue.",
+                    attr.name
+                ),
+                Some(name_loc.clone()),
+            ));
+        }
 
         let mut attr_node = AttributeNode::new(attr.name.clone(), loc);
         attr_node.name_loc = name_loc;
@@ -186,6 +217,18 @@ impl<'a> Parser<'a> {
     fn finish_directive(&mut self, dir: CurrentDirective<'a>, quote: QuoteType, end: usize) {
         let loc_end = self.prop_loc_end(quote, end, dir.name_end);
         let loc = self.create_loc(dir.name_start, loc_end);
+
+        if dir.name.is_empty() {
+            self.errors.push(CompilerError::with_message(
+                ErrorCode::MissingDirectiveName,
+                format!(
+                    "Directive `{}` is missing a name. Ignoring it so the rest of the tag can be parsed.",
+                    dir.raw_name
+                ),
+                Some(loc),
+            ));
+            return;
+        }
 
         let mut dir_node = DirectiveNode::new(self.allocator, dir.name.clone(), loc);
         dir_node.raw_name = Some(dir.raw_name);

--- a/crates/vize_armature/src/parser/element.rs
+++ b/crates/vize_armature/src/parser/element.rs
@@ -383,6 +383,72 @@ impl<'a> Parser<'a> {
         let start = index.min(len);
         let end = (index + 1).min(len);
         let loc = self.create_loc(start, end);
-        self.errors.push(CompilerError::new(code, Some(loc)));
+        let error = if let Some(message) = self.recovery_error_message(code) {
+            CompilerError::with_message(code, message, Some(loc))
+        } else {
+            CompilerError::new(code, Some(loc))
+        };
+        self.errors.push(error);
+    }
+
+    fn recovery_error_message(&self, code: ErrorCode) -> Option<std::string::String> {
+        match code {
+            ErrorCode::EofBeforeTagName => Some(
+                "Unexpected end of input after `<`; treating it as text so parsing can continue."
+                    .to_string(),
+            ),
+            ErrorCode::EofInTag => Some(
+                "Unexpected end of input inside a tag; inferred the missing tag close so parsing can continue."
+                    .to_string(),
+            ),
+            ErrorCode::InvalidFirstCharacterOfTagName => Some(
+                "Tag name starts with an invalid character; treating the malformed tag as text."
+                    .to_string(),
+            ),
+            ErrorCode::MissingAttributeValue => {
+                let name = self
+                    .current_attr
+                    .as_ref()
+                    .map(|attr| attr.name.as_str())
+                    .or_else(|| self.current_dir.as_ref().map(|dir| dir.raw_name.as_str()))
+                    .unwrap_or("attribute");
+                Some(format!(
+                    "Attribute `{name}` is missing a value after `=`; continuing without the value."
+                ))
+            }
+            ErrorCode::MissingDynamicDirectiveArgumentEnd => Some(
+                "Dynamic directive argument is missing its closing `]`; inferred the argument end at the next tag boundary."
+                    .to_string(),
+            ),
+            ErrorCode::MissingInterpolationEnd => Some(format!(
+                "Interpolation is missing its closing delimiter `{}`; treating the unfinished interpolation as text.",
+                self.options.delimiters.1
+            )),
+            ErrorCode::UnexpectedCharacterInAttributeName => Some(
+                "Attribute name contains an invalid character; inferred the nearest attribute boundary and continued."
+                    .to_string(),
+            ),
+            ErrorCode::UnexpectedCharacterInUnquotedAttributeValue => Some(
+                "Unquoted attribute value contains a character that should be quoted; keeping it in the value and continuing."
+                    .to_string(),
+            ),
+            ErrorCode::UnexpectedEqualsSignBeforeAttributeName => Some(
+                "Unexpected `=` before an attribute name; skipping it and continuing with the next attribute."
+                    .to_string(),
+            ),
+            ErrorCode::MissingWhitespaceBetweenAttributes => Some(
+                "Missing whitespace between attributes; inferred a new attribute boundary."
+                    .to_string(),
+            ),
+            ErrorCode::IncorrectlyClosedComment => Some(
+                "Comment was closed as `--!>`; treating it as `-->` so parsing can continue."
+                    .to_string(),
+            ),
+            ErrorCode::IncorrectlyOpenedComment => Some(
+                "Declaration or comment syntax is malformed; skipping it until the next `>`."
+                    .to_string(),
+            ),
+            _ => None,
+        }
     }
 }

--- a/crates/vize_armature/src/parser/tests.rs
+++ b/crates/vize_armature/src/parser/tests.rs
@@ -589,12 +589,14 @@ fn test_parse_error_missing_end_tag() {
 fn test_parse_error_duplicate_attribute() {
     let allocator = Bump::new();
     let (root, errors) = parse(&allocator, r#"<div id="a" id="b"></div>"#);
-    // Parser doesn't error on duplicate attrs, it just adds both
-    // Verify both are present
+    assert!(
+        errors
+            .iter()
+            .any(|e| e.code == ErrorCode::DuplicateAttribute)
+    );
     if let TemplateChildNode::Element(el) = &root.children[0] {
         assert_eq!(el.props.len(), 2);
     }
-    let _ = errors;
 }
 
 #[test]
@@ -705,6 +707,190 @@ fn test_parse_open_tag_at_eof_does_not_panic() {
     let (_root, errors) = parse(&allocator, "<template>\n  <div>\n  <div\n");
     // Should return errors (EofInTag / MissingEndTag), not panic.
     assert!(!errors.is_empty());
+}
+
+#[test]
+fn test_parse_recovers_open_tag_at_eof() {
+    let allocator = Bump::new();
+    let (root, errors) = parse(&allocator, r#"<div class="a""#);
+
+    assert!(errors.iter().any(|e| e.code == ErrorCode::EofInTag));
+    assert!(errors.iter().any(|e| e.code == ErrorCode::MissingEndTag));
+    assert_eq!(root.children.len(), 1);
+
+    if let TemplateChildNode::Element(el) = &root.children[0] {
+        assert_eq!(el.tag.as_str(), "div");
+        if let PropNode::Attribute(attr) = &el.props[0] {
+            assert_eq!(attr.name.as_str(), "class");
+            assert_eq!(attr.value.as_ref().unwrap().content.as_str(), "a");
+        } else {
+            panic!("Expected recovered attribute");
+        }
+    } else {
+        panic!("Expected recovered element");
+    }
+}
+
+#[test]
+fn test_parse_recovers_missing_attribute_value() {
+    let allocator = Bump::new();
+    let (root, errors) = parse(&allocator, "<div id=></div>");
+
+    assert!(
+        errors
+            .iter()
+            .any(|e| e.code == ErrorCode::MissingAttributeValue)
+    );
+    if let TemplateChildNode::Element(el) = &root.children[0] {
+        if let PropNode::Attribute(attr) = &el.props[0] {
+            assert_eq!(attr.name.as_str(), "id");
+            assert!(attr.value.is_none());
+        } else {
+            panic!("Expected recovered attribute");
+        }
+    } else {
+        panic!("Expected element");
+    }
+}
+
+#[test]
+fn test_parse_recovers_missing_equals_before_quoted_attribute_value() {
+    let allocator = Bump::new();
+    let (root, errors) = parse(&allocator, r#"<div id"foo"></div>"#);
+
+    assert!(
+        errors
+            .iter()
+            .any(|e| e.code == ErrorCode::UnexpectedCharacterInAttributeName)
+    );
+    if let TemplateChildNode::Element(el) = &root.children[0] {
+        if let PropNode::Attribute(attr) = &el.props[0] {
+            assert_eq!(attr.name.as_str(), "id");
+            assert_eq!(attr.value.as_ref().unwrap().content.as_str(), "foo");
+        } else {
+            panic!("Expected recovered attribute");
+        }
+    } else {
+        panic!("Expected element");
+    }
+}
+
+#[test]
+fn test_parse_reports_missing_whitespace_between_attributes_and_continues() {
+    let allocator = Bump::new();
+    let (root, errors) = parse(&allocator, r#"<div id="a"class="b"></div>"#);
+
+    assert!(
+        errors
+            .iter()
+            .any(|e| e.code == ErrorCode::MissingWhitespaceBetweenAttributes)
+    );
+    if let TemplateChildNode::Element(el) = &root.children[0] {
+        assert_eq!(el.props.len(), 2);
+        if let PropNode::Attribute(attr) = &el.props[1] {
+            assert_eq!(attr.name.as_str(), "class");
+            assert_eq!(attr.value.as_ref().unwrap().content.as_str(), "b");
+        } else {
+            panic!("Expected recovered second attribute");
+        }
+    } else {
+        panic!("Expected element");
+    }
+}
+
+#[test]
+fn test_parse_recovers_missing_dynamic_directive_argument_end() {
+    let allocator = Bump::new();
+    let (root, errors) = parse(&allocator, r#"<div :[foo="bar"></div>"#);
+
+    assert!(
+        errors
+            .iter()
+            .any(|e| e.code == ErrorCode::MissingDynamicDirectiveArgumentEnd)
+    );
+    if let TemplateChildNode::Element(el) = &root.children[0] {
+        if let PropNode::Directive(dir) = &el.props[0] {
+            assert_eq!(dir.name.as_str(), "bind");
+            if let Some(ExpressionNode::Simple(arg)) = &dir.arg {
+                assert_eq!(arg.content.as_str(), "foo");
+                assert!(!arg.is_static);
+            } else {
+                panic!("Expected recovered directive argument");
+            }
+        } else {
+            panic!("Expected recovered directive");
+        }
+    } else {
+        panic!("Expected element");
+    }
+}
+
+#[test]
+fn test_parse_reports_missing_directive_name_and_continues() {
+    let allocator = Bump::new();
+    let (root, errors) = parse(&allocator, "<div v->ok</div>");
+
+    assert!(
+        errors
+            .iter()
+            .any(|e| e.code == ErrorCode::MissingDirectiveName)
+    );
+    if let TemplateChildNode::Element(el) = &root.children[0] {
+        assert!(el.props.is_empty());
+        assert_eq!(el.children.len(), 1);
+    } else {
+        panic!("Expected element");
+    }
+}
+
+#[test]
+fn test_parse_unfinished_interpolation_reports_error_but_keeps_text() {
+    let allocator = Bump::new();
+    let (root, errors) = parse(&allocator, "{{ unfinished");
+
+    assert!(
+        errors
+            .iter()
+            .any(|e| e.code == ErrorCode::MissingInterpolationEnd)
+    );
+    assert_eq!(root.children.len(), 1);
+    if let TemplateChildNode::Text(text) = &root.children[0] {
+        assert_eq!(text.content.as_str(), "{{ unfinished");
+    } else {
+        panic!("Expected recovered text");
+    }
+}
+
+#[test]
+fn test_parse_invalid_tag_name_reports_error_and_continues() {
+    let allocator = Bump::new();
+    let (root, errors) = parse(&allocator, "<1div></1div><span></span>");
+
+    assert!(
+        errors
+            .iter()
+            .any(|e| e.code == ErrorCode::InvalidFirstCharacterOfTagName)
+    );
+    assert!(
+        root.children.iter().any(
+            |child| matches!(child, TemplateChildNode::Element(el) if el.tag.as_str() == "span")
+        )
+    );
+}
+
+#[test]
+fn test_parse_incorrectly_closed_comment_reports_error_and_continues() {
+    let allocator = Bump::new();
+    let (root, errors) = parse(&allocator, "<!-- note --!><div></div>");
+
+    assert!(
+        errors
+            .iter()
+            .any(|e| e.code == ErrorCode::IncorrectlyClosedComment)
+    );
+    assert_eq!(root.children.len(), 2);
+    assert!(matches!(&root.children[0], TemplateChildNode::Comment(_)));
+    assert!(matches!(&root.children[1], TemplateChildNode::Element(_)));
 }
 
 #[test]

--- a/crates/vize_armature/src/tokenizer/mod.rs
+++ b/crates/vize_armature/src/tokenizer/mod.rs
@@ -50,6 +50,12 @@ pub struct Tokenizer<'a, C: Callbacks> {
 
     /// For special parsing behavior inside of script and style tags.
     in_rcdata: bool,
+
+    /// True immediately after a quoted attribute value ended.
+    ///
+    /// The tokenizer needs this one-token memory to report `<div a="b"c>` as
+    /// recoverable missing whitespace instead of silently starting `c`.
+    after_quoted_attr_value: bool,
 }
 
 impl<'a, C: Callbacks> Tokenizer<'a, C> {
@@ -81,6 +87,7 @@ impl<'a, C: Callbacks> Tokenizer<'a, C> {
             current_sequence: None,
             sequence_index: 0,
             in_rcdata: false,
+            after_quoted_attr_value: false,
         }
     }
 

--- a/crates/vize_armature/src/tokenizer/states.rs
+++ b/crates/vize_armature/src/tokenizer/states.rs
@@ -6,8 +6,8 @@ use crate::tokenizer::sequences::Sequence;
 use super::{
     Tokenizer,
     char_codes::{
-        AT, COLON, DASH, DOT, DOUBLE_QUOTE, EQ, EXCLAMATION_MARK, GT, LEFT_SQUARE, LOWER_V, LT,
-        NUMBER, QUESTION_MARK, RIGHT_SQUARE, SINGLE_QUOTE, SLASH,
+        AT, COLON, DASH, DOT, DOUBLE_QUOTE, EQ, EXCLAMATION_MARK, GRAVE_ACCENT, GT, LEFT_SQUARE,
+        LOWER_V, LT, NUMBER, QUESTION_MARK, RIGHT_SQUARE, SINGLE_QUOTE, SLASH,
     },
     types::{Callbacks, QuoteType, State, is_end_of_tag_section, is_tag_start_char, is_whitespace},
 };
@@ -19,30 +19,44 @@ impl<'a, C: Callbacks> Tokenizer<'a, C> {
     pub(super) fn cleanup(&mut self) {
         let has_section = self.section_start < self.index;
 
-        if has_section {
-            match self.state {
-                State::Text | State::Interpolation => {
-                    self.callbacks.on_text(self.section_start, self.index);
-                }
-                State::InTagName
-                | State::InSFCRootTagName
-                | State::BeforeClosingTagName
-                | State::InClosingTagName
-                | State::BeforeAttrName
-                | State::InAttrName
-                | State::InDirName
-                | State::InDirArg
-                | State::InDirDynamicArg
-                | State::InDirModifier
-                | State::AfterAttrName
-                | State::BeforeAttrValue
-                | State::InAttrValueDq
-                | State::InAttrValueSq
-                | State::InAttrValueNq => {
-                    self.callbacks.on_error(ErrorCode::EofInTag, self.index);
-                }
-                _ => {}
+        match self.state {
+            State::Text if has_section => {
+                self.callbacks.on_text(self.section_start, self.index);
             }
+            State::Interpolation | State::InterpolationClose if has_section => {
+                self.callbacks
+                    .on_error(ErrorCode::MissingInterpolationEnd, self.index);
+                let start = self.section_start.saturating_sub(self.delimiter_open.len());
+                self.callbacks.on_text(start, self.index);
+            }
+            State::BeforeTagName if has_section => {
+                self.callbacks
+                    .on_error(ErrorCode::EofBeforeTagName, self.index);
+                self.callbacks.on_text(self.section_start, self.index);
+            }
+            State::InTagName
+            | State::InSFCRootTagName
+            | State::BeforeSpecialS
+            | State::BeforeSpecialT
+            | State::SpecialStartSequence
+            | State::BeforeClosingTagName
+            | State::InClosingTagName
+            | State::AfterClosingTagName
+            | State::BeforeAttrName
+            | State::InAttrName
+            | State::InDirName
+            | State::InDirArg
+            | State::InDirDynamicArg
+            | State::InDirModifier
+            | State::AfterAttrName
+            | State::BeforeAttrValue
+            | State::InAttrValueDq
+            | State::InAttrValueSq
+            | State::InAttrValueNq => {
+                self.callbacks.on_error(ErrorCode::EofInTag, self.index);
+                self.recover_incomplete_tag_at_eof();
+            }
+            _ => {}
         }
 
         if self.state == State::InCommentLike {
@@ -60,6 +74,103 @@ impl<'a, C: Callbacks> Tokenizer<'a, C> {
                 }
             }
         }
+    }
+
+    fn recover_incomplete_tag_at_eof(&mut self) {
+        let inferred_tag_end = self.index.saturating_sub(1);
+
+        match self.state {
+            State::InTagName
+            | State::InSFCRootTagName
+            | State::BeforeSpecialS
+            | State::BeforeSpecialT
+            | State::SpecialStartSequence => {
+                self.callbacks
+                    .on_open_tag_name(self.section_start, self.index);
+                self.callbacks.on_open_tag_end(inferred_tag_end);
+            }
+            State::BeforeAttrName => {
+                self.callbacks.on_open_tag_end(inferred_tag_end);
+            }
+            State::InAttrName => {
+                self.callbacks
+                    .on_attrib_name(self.section_start, self.index);
+                self.callbacks.on_attrib_name_end(self.index);
+                self.callbacks.on_attrib_end(QuoteType::NoValue, self.index);
+                self.callbacks.on_open_tag_end(inferred_tag_end);
+            }
+            State::InDirName => {
+                self.callbacks.on_dir_name(self.section_start, self.index);
+                self.callbacks.on_attrib_name_end(self.index);
+                self.callbacks.on_attrib_end(QuoteType::NoValue, self.index);
+                self.callbacks.on_open_tag_end(inferred_tag_end);
+            }
+            State::InDirArg => {
+                if self.section_start < self.index {
+                    self.callbacks.on_dir_arg(self.section_start, self.index);
+                }
+                self.callbacks.on_attrib_name_end(self.index);
+                self.callbacks.on_attrib_end(QuoteType::NoValue, self.index);
+                self.callbacks.on_open_tag_end(inferred_tag_end);
+            }
+            State::InDirDynamicArg => {
+                self.callbacks
+                    .on_error(ErrorCode::MissingDynamicDirectiveArgumentEnd, self.index);
+                if self.section_start < self.index {
+                    self.callbacks.on_dir_arg(self.section_start, self.index);
+                }
+                self.callbacks.on_attrib_name_end(self.index);
+                self.callbacks.on_attrib_end(QuoteType::NoValue, self.index);
+                self.callbacks.on_open_tag_end(inferred_tag_end);
+            }
+            State::InDirModifier => {
+                self.callbacks
+                    .on_dir_modifier(self.section_start, self.index);
+                self.callbacks.on_attrib_name_end(self.index);
+                self.callbacks.on_attrib_end(QuoteType::NoValue, self.index);
+                self.callbacks.on_open_tag_end(inferred_tag_end);
+            }
+            State::AfterAttrName => {
+                self.callbacks.on_attrib_end(QuoteType::NoValue, self.index);
+                self.callbacks.on_open_tag_end(inferred_tag_end);
+            }
+            State::BeforeAttrValue => {
+                self.callbacks
+                    .on_error(ErrorCode::MissingAttributeValue, self.index);
+                self.callbacks.on_attrib_end(QuoteType::NoValue, self.index);
+                self.callbacks.on_open_tag_end(inferred_tag_end);
+            }
+            State::InAttrValueDq => {
+                self.emit_unclosed_attr_value(QuoteType::Double);
+                self.callbacks.on_open_tag_end(inferred_tag_end);
+            }
+            State::InAttrValueSq => {
+                self.emit_unclosed_attr_value(QuoteType::Single);
+                self.callbacks.on_open_tag_end(inferred_tag_end);
+            }
+            State::InAttrValueNq => {
+                self.emit_unclosed_attr_value(QuoteType::Unquoted);
+                self.callbacks.on_open_tag_end(inferred_tag_end);
+            }
+            State::InClosingTagName => {
+                if self.section_start < self.index {
+                    self.callbacks.on_close_tag(self.section_start, self.index);
+                }
+            }
+            State::BeforeClosingTagName | State::AfterClosingTagName => {}
+            _ => {}
+        }
+
+        self.state = State::Text;
+        self.section_start = self.index;
+    }
+
+    fn emit_unclosed_attr_value(&mut self, quote: QuoteType) {
+        if self.section_start < self.index {
+            self.callbacks
+                .on_attrib_data(self.section_start, self.index);
+        }
+        self.callbacks.on_attrib_end(quote, self.index);
     }
 
     // ========== State handlers ==========
@@ -149,6 +260,8 @@ impl<'a, C: Callbacks> Tokenizer<'a, C> {
         } else if c == SLASH {
             self.state = State::BeforeClosingTagName;
         } else {
+            self.callbacks
+                .on_error(ErrorCode::InvalidFirstCharacterOfTagName, self.index);
             self.state = State::Text;
             self.state_text(c);
         }
@@ -186,6 +299,11 @@ impl<'a, C: Callbacks> Tokenizer<'a, C> {
                 .on_error(ErrorCode::MissingEndTagName, self.index);
             self.state = State::Text;
             self.section_start = self.index + 1;
+        } else if !is_tag_start_char(c) {
+            self.callbacks
+                .on_error(ErrorCode::InvalidFirstCharacterOfTagName, self.index);
+            self.state = State::InClosingTagName;
+            self.section_start = self.index;
         } else {
             self.state = State::InClosingTagName;
             self.section_start = self.index;
@@ -208,11 +326,18 @@ impl<'a, C: Callbacks> Tokenizer<'a, C> {
         if c == GT {
             self.state = State::Text;
             self.section_start = self.index + 1;
+        } else if c == SLASH {
+            self.callbacks
+                .on_error(ErrorCode::EndTagWithTrailingSolidus, self.index);
+        } else if !is_whitespace(c) {
+            self.callbacks
+                .on_error(ErrorCode::EndTagWithAttributes, self.index);
         }
     }
 
     pub(super) fn state_before_attr_name(&mut self, c: u8) {
         if c == GT {
+            self.after_quoted_attr_value = false;
             self.callbacks.on_open_tag_end(self.index);
             if self.in_rcdata {
                 self.state = State::InRCDATA;
@@ -221,8 +346,22 @@ impl<'a, C: Callbacks> Tokenizer<'a, C> {
             }
             self.section_start = self.index + 1;
         } else if c == SLASH {
+            self.after_quoted_attr_value = false;
             self.state = State::InSelfClosingTag;
+        } else if is_whitespace(c) {
+            self.after_quoted_attr_value = false;
+        } else if c == EQ {
+            self.after_quoted_attr_value = false;
+            self.callbacks.on_error(
+                ErrorCode::UnexpectedEqualsSignBeforeAttributeName,
+                self.index,
+            );
         } else if !is_whitespace(c) {
+            if self.after_quoted_attr_value {
+                self.callbacks
+                    .on_error(ErrorCode::MissingWhitespaceBetweenAttributes, self.index);
+            }
+            self.after_quoted_attr_value = false;
             self.handle_attr_start(c);
         }
     }
@@ -254,6 +393,21 @@ impl<'a, C: Callbacks> Tokenizer<'a, C> {
             self.section_start = self.index;
             self.state = State::AfterAttrName;
             self.state_after_attr_name(c);
+        } else if c == DOUBLE_QUOTE || c == SINGLE_QUOTE {
+            self.callbacks
+                .on_error(ErrorCode::UnexpectedCharacterInAttributeName, self.index);
+            self.callbacks
+                .on_attrib_name(self.section_start, self.index);
+            self.callbacks.on_attrib_name_end(self.index);
+            self.section_start = self.index + 1;
+            self.state = if c == DOUBLE_QUOTE {
+                State::InAttrValueDq
+            } else {
+                State::InAttrValueSq
+            };
+        } else if c == LT {
+            self.callbacks
+                .on_error(ErrorCode::UnexpectedCharacterInAttributeName, self.index);
         }
     }
 
@@ -308,6 +462,16 @@ impl<'a, C: Callbacks> Tokenizer<'a, C> {
             self.callbacks.on_dir_arg(self.section_start, self.index);
             self.state = State::InDirArg;
             self.section_start = self.index + 1;
+        } else if c == EQ || is_end_of_tag_section(c) {
+            self.callbacks
+                .on_error(ErrorCode::MissingDynamicDirectiveArgumentEnd, self.index);
+            if self.section_start < self.index {
+                self.callbacks.on_dir_arg(self.section_start, self.index);
+            }
+            self.callbacks.on_attrib_name_end(self.index);
+            self.section_start = self.index;
+            self.state = State::AfterAttrName;
+            self.state_after_attr_name(c);
         }
     }
 
@@ -346,6 +510,17 @@ impl<'a, C: Callbacks> Tokenizer<'a, C> {
         } else if c == SINGLE_QUOTE {
             self.state = State::InAttrValueSq;
             self.section_start = self.index + 1;
+        } else if c == EQ {
+            self.callbacks.on_error(
+                ErrorCode::UnexpectedEqualsSignBeforeAttributeName,
+                self.index,
+            );
+        } else if c == GT || c == SLASH {
+            self.callbacks
+                .on_error(ErrorCode::MissingAttributeValue, self.index);
+            self.callbacks.on_attrib_end(QuoteType::NoValue, self.index);
+            self.state = State::BeforeAttrName;
+            self.state_before_attr_name(c);
         } else if !is_whitespace(c) {
             self.section_start = self.index;
             self.state = State::InAttrValueNq;
@@ -377,6 +552,11 @@ impl<'a, C: Callbacks> Tokenizer<'a, C> {
             self.emit_attr_value(QuoteType::Unquoted);
         } else if c == AMP {
             self.start_entity();
+        } else if matches!(c, DOUBLE_QUOTE | SINGLE_QUOTE | LT | EQ | GRAVE_ACCENT) {
+            self.callbacks.on_error(
+                ErrorCode::UnexpectedCharacterInUnquotedAttributeValue,
+                self.index,
+            );
         }
     }
 
@@ -388,6 +568,7 @@ impl<'a, C: Callbacks> Tokenizer<'a, C> {
         self.callbacks.on_attrib_end(quote, self.index);
         self.section_start = self.index + 1;
         self.state = State::BeforeAttrName;
+        self.after_quoted_attr_value = matches!(quote, QuoteType::Double | QuoteType::Single);
     }
 
     pub(super) fn state_before_declaration(&mut self, c: u8) {
@@ -399,6 +580,10 @@ impl<'a, C: Callbacks> Tokenizer<'a, C> {
             self.state = State::CDATASequence;
             self.section_start = self.index + 1;
         } else {
+            self.callbacks.on_error(
+                ErrorCode::IncorrectlyOpenedComment,
+                self.section_start.saturating_sub(2),
+            );
             self.state = State::InDeclaration;
         }
     }
@@ -491,6 +676,12 @@ impl<'a, C: Callbacks> Tokenizer<'a, C> {
             if self.fast_forward_to(sequence_bytes[0]) {
                 self.sequence_index = 1;
             }
+        } else if sequence == Sequence::CommentEnd
+            && self.sequence_index == 2
+            && c == EXCLAMATION_MARK
+        {
+            self.callbacks
+                .on_error(ErrorCode::IncorrectlyClosedComment, self.index);
         } else if c != sequence_bytes[self.sequence_index - 1] {
             // Allow long sequences, eg. --->, ]]]>
             self.sequence_index = 0;


### PR DESCRIPTION
## Summary

- Recover malformed template input while still collecting parser errors so parse results remain failures.
- Add targeted diagnostics for incomplete tags, malformed attributes/directives, invalid tag names, comments, and unfinished interpolations.
- Preserve a recovered AST where possible so downstream diagnostics can continue.

## Context

This is stacked on `codex/reduce-unsafe-hot-paths` as requested, so the PR only contains the parser/tokenizer recovery changes on top of that branch.

## Validation

- `cargo test -p vize_armature`
- `cargo test -p vize_atelier_core`
- `git diff --check`
