### PR TITLE
refactor(rust): annotate residual unsafe paths

### DIFF
--- a/crates/vize/src/commands/build/runner.rs
+++ b/crates/vize/src/commands/build/runner.rs
@@ -3,8 +3,6 @@
 //! Contains the main compilation pipeline, file collection, pattern matching,
 //! and per-file compilation with profiling.
 
-#![allow(clippy::disallowed_macros)]
-
 use std::{
     fs,
     path::PathBuf,
@@ -133,6 +131,10 @@ pub(crate) fn run(args: BuildArgs) {
                 let ext = match args.format {
                     OutputFormat::Js => get_output_extension(&output.script_lang, args.script_ext),
                     OutputFormat::Json => "json",
+                    // Panic path by control-flow invariant: this match is inside
+                    // the `OutputFormat::Js | OutputFormat::Json` arm above.
+                    // Keeping the enum match explicit lets the compiler keep
+                    // checking newly added output formats here.
                     OutputFormat::Stats => unreachable!(),
                 };
 
@@ -161,6 +163,7 @@ pub(crate) fn run(args: BuildArgs) {
                             .unwrap_or_default()
                             .into()
                     }
+                    // Panic path by the same outer-match invariant as `ext`.
                     OutputFormat::Stats => unreachable!(),
                 };
 
@@ -481,13 +484,28 @@ fn pattern_matches(path: &std::path::Path, pattern: &str) -> bool {
     {
         let prefix = &pattern[..prefix_end];
         let prefix_normalized = prefix.trim_end_matches('/');
-        return path_str.contains(&format!("{}/", prefix_normalized)) && path_str.ends_with(".vue");
+        let has_prefix_dir = prefix_normalized.is_empty()
+            || path_str.match_indices(prefix_normalized).any(|(idx, _)| {
+                path_str.as_bytes().get(idx + prefix_normalized.len()) == Some(&b'/')
+            });
+        return has_prefix_dir && path_str.ends_with(".vue");
     }
 
     if pattern.ends_with(".vue") {
         let pattern_normalized = pattern.replace("\\", "/");
-        return path_str == pattern_normalized
-            || path_str.ends_with(&format!("/{}", pattern_normalized));
+        if path_str == pattern_normalized {
+            return true;
+        }
+
+        if !path_str.ends_with(pattern_normalized.as_str()) {
+            return false;
+        }
+
+        let prefix_len = path_str.len() - pattern_normalized.len();
+        let Some(separator_idx) = prefix_len.checked_sub(1) else {
+            return false;
+        };
+        return path_str.as_bytes().get(separator_idx) == Some(&b'/');
     }
 
     path_str.ends_with(".vue")

--- a/crates/vize_armature/src/parser/attribute.rs
+++ b/crates/vize_armature/src/parser/attribute.rs
@@ -3,7 +3,7 @@
 //! Handles attribute names, directive names/arguments/modifiers,
 //! attribute data (values), and finalization of attribute and directive nodes.
 
-use vize_carton::{Box, String, Vec};
+use vize_carton::{Box, String, Vec, appends};
 use vize_relief::{
     ast::{
         AttributeNode, ConstantType, DirectiveNode, ExpressionNode, PropNode, SimpleExpressionNode,
@@ -182,12 +182,16 @@ impl<'a> Parser<'a> {
         let name_loc = self.create_loc(attr.name_start, attr.name_end);
 
         if self.has_duplicate_attribute(attr.name.as_str()) {
+            let mut message = String::with_capacity(attr.name.len() + 79);
+            appends!(
+                message,
+                "Duplicate attribute `",
+                attr.name.as_str(),
+                "`. Keeping the repeated attribute so parsing can continue."
+            );
             self.errors.push(CompilerError::with_message(
                 ErrorCode::DuplicateAttribute,
-                vize_carton::cstr!(
-                    "Duplicate attribute `{}`. Keeping the repeated attribute so parsing can continue.",
-                    attr.name
-                ),
+                message,
                 Some(name_loc.clone()),
             ));
         }
@@ -219,12 +223,16 @@ impl<'a> Parser<'a> {
         let loc = self.create_loc(dir.name_start, loc_end);
 
         if dir.name.is_empty() {
+            let mut message = String::with_capacity(dir.raw_name.len() + 80);
+            appends!(
+                message,
+                "Directive `",
+                dir.raw_name.as_str(),
+                "` is missing a name. Ignoring it so the rest of the tag can be parsed."
+            );
             self.errors.push(CompilerError::with_message(
                 ErrorCode::MissingDirectiveName,
-                vize_carton::cstr!(
-                    "Directive `{}` is missing a name. Ignoring it so the rest of the tag can be parsed.",
-                    dir.raw_name
-                ),
+                message,
                 Some(loc),
             ));
             return;

--- a/crates/vize_armature/src/parser/element.rs
+++ b/crates/vize_armature/src/parser/element.rs
@@ -3,7 +3,7 @@
 //! Handles text, interpolation, open/close tags, element type determination,
 //! comments, and error reporting.
 
-use vize_carton::{Box, String, directive::parse_vize_directive};
+use vize_carton::{Box, String, appends, directive::parse_vize_directive};
 use vize_relief::{
     ast::*,
     errors::{CompilerError, ErrorCode},
@@ -402,8 +402,7 @@ impl<'a> Parser<'a> {
                     .into(),
             ),
             ErrorCode::InvalidFirstCharacterOfTagName => Some(
-                "Tag name starts with an invalid character; treating the malformed tag as text."
-                    .into(),
+                "Tag name starts with an invalid character; treating the malformed tag as text.".into(),
             ),
             ErrorCode::MissingAttributeValue => {
                 let name = self
@@ -412,18 +411,30 @@ impl<'a> Parser<'a> {
                     .map(|attr| attr.name.as_str())
                     .or_else(|| self.current_dir.as_ref().map(|dir| dir.raw_name.as_str()))
                     .unwrap_or("attribute");
-                Some(vize_carton::cstr!(
-                    "Attribute `{name}` is missing a value after `=`; continuing without the value."
-                ))
+                let mut message = String::with_capacity(name.len() + 70);
+                appends!(
+                    message,
+                    "Attribute `",
+                    name,
+                    "` is missing a value after `=`; continuing without the value."
+                );
+                Some(message)
             }
             ErrorCode::MissingDynamicDirectiveArgumentEnd => Some(
                 "Dynamic directive argument is missing its closing `]`; inferred the argument end at the next tag boundary."
                     .into(),
             ),
-            ErrorCode::MissingInterpolationEnd => Some(vize_carton::cstr!(
-                "Interpolation is missing its closing delimiter `{}`; treating the unfinished interpolation as text.",
-                self.options.delimiters.1
-            )),
+            ErrorCode::MissingInterpolationEnd => {
+                let delimiter = self.options.delimiters.1.as_str();
+                let mut message = String::with_capacity(delimiter.len() + 97);
+                appends!(
+                    message,
+                    "Interpolation is missing its closing delimiter `",
+                    delimiter,
+                    "`; treating the unfinished interpolation as text."
+                );
+                Some(message)
+            }
             ErrorCode::UnexpectedCharacterInAttributeName => Some(
                 "Attribute name contains an invalid character; inferred the nearest attribute boundary and continued."
                     .into(),
@@ -437,16 +448,14 @@ impl<'a> Parser<'a> {
                     .into(),
             ),
             ErrorCode::MissingWhitespaceBetweenAttributes => Some(
-                "Missing whitespace between attributes; inferred a new attribute boundary."
-                    .into(),
+                "Missing whitespace between attributes; inferred a new attribute boundary.".into(),
             ),
             ErrorCode::IncorrectlyClosedComment => Some(
                 "Comment was closed as `--!>`; treating it as `-->` so parsing can continue."
                     .into(),
             ),
             ErrorCode::IncorrectlyOpenedComment => Some(
-                "Declaration or comment syntax is malformed; skipping it until the next `>`."
-                    .into(),
+                "Declaration or comment syntax is malformed; skipping it until the next `>`.".into(),
             ),
             _ => None,
         }

--- a/crates/vize_armature/src/parser/tests.rs
+++ b/crates/vize_armature/src/parser/tests.rs
@@ -404,15 +404,15 @@ fn test_parse_dynamic_directive_arg() {
     let allocator = Bump::new();
     let (root, errors) = parse(&allocator, r#"<div v-bind:[attr]="val"></div>"#);
     assert!(errors.is_empty());
-    if let TemplateChildNode::Element(el) = &root.children[0] {
-        if let PropNode::Directive(dir) = &el.props[0] {
-            assert_eq!(dir.name.as_str(), "bind");
-            if let Some(ExpressionNode::Simple(arg)) = &dir.arg {
-                assert_eq!(arg.content.as_str(), "attr");
-                assert!(!arg.is_static); // dynamic args are not static
-            } else {
-                panic!("Expected arg");
-            }
+    if let TemplateChildNode::Element(el) = &root.children[0]
+        && let PropNode::Directive(dir) = &el.props[0]
+    {
+        assert_eq!(dir.name.as_str(), "bind");
+        if let Some(ExpressionNode::Simple(arg)) = &dir.arg {
+            assert_eq!(arg.content.as_str(), "attr");
+            assert!(!arg.is_static); // dynamic args are not static
+        } else {
+            panic!("Expected arg");
         }
     }
 }

--- a/crates/vize_atelier_core/src/codegen/props/generate.rs
+++ b/crates/vize_atelier_core/src/codegen/props/generate.rs
@@ -180,6 +180,10 @@ fn try_generate_static_attrs(
     let mut first = true;
     for prop in props {
         let PropNode::Attribute(attr) = prop else {
+            // Panic path by invariant: the preflight `all(Attribute)` check above
+            // has already rejected directive props. Reaching this arm would mean
+            // `props` was mutated while iterating, which is impossible through the
+            // shared slice used by codegen.
             unreachable!("checked above");
         };
 

--- a/crates/vize_atelier_core/src/transform/mod.rs
+++ b/crates/vize_atelier_core/src/transform/mod.rs
@@ -104,16 +104,31 @@ impl<'a> ParentNode<'a> {
     /// Get mutable access to children through raw pointer.
     ///
     /// # Safety
-    /// This uses interior mutability via raw pointers stored in the enum variants.
-    /// The raw pointers are valid for the duration of the transform and mutation
-    /// through them is safe as long as we don't create overlapping mutable references.
+    /// `ParentNode` stores pointers into the bump-allocated template tree so the
+    /// traversal can mutate parents without cloning children on every visit. The
+    /// active traversal loop owns the only mutable child slice for the current
+    /// parent, and nested calls only use descendants created from that slice.
+    /// Keeping the invariant here avoids an allocation-heavy zipper structure in
+    /// the hottest template transform path.
     #[allow(clippy::mut_from_ref)]
     pub fn children_mut(&self) -> &mut Vec<'a, TemplateChildNode<'a>> {
+        // SAFETY: every pointer is produced from a live `RootNode`, `ElementNode`,
+        // `IfBranchNode`, or `ForNode` borrowed by the transform driver. The
+        // transform is single-threaded and never keeps two active mutable child
+        // slices for the same parent; sibling traversal advances only after the
+        // previous borrow has been consumed. `ParentNode::If` intentionally has no
+        // children slice, so that variant is rejected before any pointer deref.
         unsafe {
             match self {
                 ParentNode::Root(r) => &mut (*(*r)).children,
                 ParentNode::Element(e) => &mut (*(*e)).children,
-                ParentNode::If(_) => panic!("IfNode doesn't have direct children"),
+                ParentNode::If(_) => {
+                    // Panic path by design: callers must traverse concrete
+                    // branches (`ParentNode::IfBranch`) because an `IfNode`
+                    // itself is only a branch container and has no direct child
+                    // vector to return.
+                    panic!("IfNode doesn't have direct children")
+                }
                 ParentNode::IfBranch(b) => &mut (*(*b)).children,
                 ParentNode::For(f) => &mut (*(*f)).children,
             }

--- a/crates/vize_atelier_core/src/transform/structural.rs
+++ b/crates/vize_atelier_core/src/transform/structural.rs
@@ -82,7 +82,13 @@ pub fn take_structural_directive<'a>(
     let (directive_idx, directive_kind) = selected_if.or(selected_for)?;
     let directive = match el.props.remove(directive_idx) {
         PropNode::Directive(dir) => Box::into_inner(dir),
-        PropNode::Attribute(_) => unreachable!("structural directives are always directive props"),
+        PropNode::Attribute(_) => {
+            // Panic path by invariant: `directive_idx` is selected only while
+            // iterating over `PropNode::Directive`. Hitting this means the prop
+            // vector was mutated between selection and removal, which would be a
+            // transform bug rather than malformed user input.
+            unreachable!("structural directives are always directive props")
+        }
     };
 
     Some((

--- a/crates/vize_atelier_core/src/transform/traverse.rs
+++ b/crates/vize_atelier_core/src/transform/traverse.rs
@@ -112,6 +112,13 @@ pub fn traverse_node<'a>(ctx: &mut TransformContext<'a>, node: &mut TemplateChil
 
                 // If node was replaced (e.g., by v-if transform), we need to traverse the new node
                 if let Some(current_ptr) = ctx.current_node {
+                    // SAFETY: `ctx.current_node` is written immediately before
+                    // transforms run and points at the child slot currently owned
+                    // by the traversal loop. Structural transforms may replace
+                    // that slot, but they do not free the bump-allocated storage
+                    // or retain another mutable reference to it. We reborrow here
+                    // only after the transform call returns so we can inspect the
+                    // replacement without cloning the AST node.
                     let current = unsafe { &mut *current_ptr };
                     match current {
                         TemplateChildNode::If(if_node) => {

--- a/crates/vize_atelier_sfc/src/compile_script/function_mode/compiler.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/function_mode/compiler.rs
@@ -293,7 +293,12 @@ pub fn compile_script_setup(
         output.extend_from_slice(b"});\n"); // Close _defineComponent(
     }
 
-    // Convert arena Vec<u8> to String - SAFETY: we only push valid UTF-8
+    // SAFETY: this byte buffer is a fast append target for valid UTF-8 script
+    // fragments: original source ranges, OXC codegen output, and ASCII component
+    // wrapper text. There is no API in this module that appends arbitrary binary
+    // data, so the generated script remains valid UTF-8 by construction.
+    // Avoiding a second full-buffer validation matters for large script-setup
+    // blocks in function mode.
     #[allow(clippy::disallowed_types)]
     let output_str: std::string::String =
         unsafe { std::string::String::from_utf8_unchecked(output.into_iter().collect()) };

--- a/crates/vize_atelier_sfc/src/compile_script/inline/compiler/body.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/inline/compiler/body.rs
@@ -149,6 +149,11 @@ pub(super) fn compile_script_setup_inline_body(
         output.extend_from_slice(b"}\n");
     }
 
+    // SAFETY: `output` is assembled from UTF-8 source slices, OXC-generated
+    // strings, and ASCII glue emitted by this compiler. The buffer type is bytes
+    // only because we need cheap `extend_from_slice` during script assembly. No
+    // raw non-UTF-8 bytes are ever appended, so validating the whole script again
+    // would only add work to the hot SFC compile path.
     #[allow(clippy::disallowed_types)]
     let output_str: std::string::String =
         unsafe { std::string::String::from_utf8_unchecked(output.into_iter().collect()) };

--- a/crates/vize_atelier_sfc/src/css/scoped.rs
+++ b/crates/vize_atelier_sfc/src/css/scoped.rs
@@ -174,7 +174,12 @@ pub(crate) fn apply_scoped_css<'a>(bump: &'a Bump, css: &str, scope_id: &str) ->
         output.extend_from_slice(&css_bytes[last_selector_end..]);
     }
 
-    // SAFETY: input is valid UTF-8, we only add ASCII bytes
+    // SAFETY: `output` is built by copying selector/content ranges from the
+    // original UTF-8 `css` string and injecting ASCII-only scope attributes and
+    // punctuation. Ranges are advanced at `char_indices` boundaries or ASCII
+    // delimiter positions, so copied slices cannot split a code point. The arena
+    // copy owns the bytes for the returned lifetime, and skipping revalidation
+    // keeps scoped-style rewriting linear with minimal overhead.
     unsafe { std::str::from_utf8_unchecked(bump.alloc_slice_copy(&output)) }
 }
 

--- a/crates/vize_atelier_sfc/src/css/transform.rs
+++ b/crates/vize_atelier_sfc/src/css/transform.rs
@@ -50,7 +50,12 @@ pub(crate) fn extract_and_transform_v_bind<'a>(
         }
     }
 
-    // SAFETY: input is valid UTF-8, we only add ASCII bytes
+    // SAFETY: `result` is assembled from byte slices borrowed from `css` plus
+    // ASCII-only delimiters, hashes, and sanitized v-bind suffixes. Every copied
+    // slice boundary comes from `str::find`/byte scans over ASCII tokens, so it
+    // never cuts through a UTF-8 code point. The bump copy keeps the returned
+    // `&str` alive for the caller's arena lifetime while avoiding a second UTF-8
+    // validation pass on this hot CSS transform path.
     let result_str = unsafe { std::str::from_utf8_unchecked(bump.alloc_slice_copy(&result)) };
     (result_str, vars)
 }

--- a/crates/vize_atelier_sfc/src/parse/tests.rs
+++ b/crates/vize_atelier_sfc/src/parse/tests.rs
@@ -82,10 +82,10 @@ fn test_zero_copy_content() {
     match &template.content {
         Cow::Borrowed(s) => {
             // The string should be a slice of the original source
-            let start = source.as_ptr() as usize;
-            let end = start + source.len();
-            let ptr = s.as_ptr() as usize;
-            assert!((start..end).contains(&ptr));
+            let source_start = source.as_ptr() as usize;
+            let source_end = source_start + source.len();
+            let content_ptr = s.as_ptr() as usize;
+            assert!((source_start..=source_end).contains(&content_ptr));
         }
         Cow::Owned(_) => panic!("Expected Cow::Borrowed, got Cow::Owned"),
     }

--- a/crates/vize_atelier_ssr/src/codegen/mod.rs
+++ b/crates/vize_atelier_ssr/src/codegen/mod.rs
@@ -117,7 +117,12 @@ impl<'a> SsrCodegenContext<'a> {
         let preamble = self.build_preamble();
 
         SsrCodegenResult {
-            // SAFETY: We only push valid UTF-8 strings
+            // SAFETY: `self.code` is filled exclusively through `push(&str)`,
+            // `push_indent`, and helpers that append ASCII punctuation around
+            // already-valid template/source strings. No caller can inject raw
+            // bytes into the buffer, so the Vec<u8> invariant is "always valid
+            // UTF-8". Keeping this unchecked conversion avoids validating the
+            // complete generated SSR module after every compile.
             code: unsafe { String::from_utf8_unchecked(self.code) },
             preamble,
         }

--- a/crates/vize_atelier_vapor/src/transform/element.rs
+++ b/crates/vize_atelier_vapor/src/transform/element.rs
@@ -413,7 +413,10 @@ pub(crate) fn transform_element<'a>(
             block.operation.push(OperationNode::SlotOutlet(slot_outlet));
         }
         ElementType::Template => {
-            // Handled at top of function, unreachable
+            // Panic path by transform invariant: `transform_element` peels
+            // template nodes at function entry because they do not create DOM
+            // elements. Reaching this arm means that guard was bypassed in a
+            // future edit, so continuing would emit an invalid Vapor operation.
             unreachable!("Template elements handled at top of transform_element");
         }
     }

--- a/crates/vize_carton/src/lsp.rs
+++ b/crates/vize_carton/src/lsp.rs
@@ -446,6 +446,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::disallowed_macros)]
     fn test_lsp_message_format() {
         let req = JsonRpcRequest::new(1, "test", None);
         let msg = req.to_lsp_message().unwrap();

--- a/crates/vize_croquis/src/scope/chain/mod.rs
+++ b/crates/vize_croquis/src/scope/chain/mod.rs
@@ -337,7 +337,11 @@ impl ScopeChain {
     /// Get the current scope
     #[inline]
     pub fn current_scope(&self) -> &Scope {
-        // SAFETY: current is always a valid index
+        // SAFETY: `current` is initialized to `ROOT`, and every scope transition
+        // writes an id returned by `push_scope`/`enter_scope`, both of which append
+        // to `self.scopes` before exposing the id. Exiting a scope moves to a
+        // stored parent id, never an arbitrary index. This unchecked access is on
+        // every identifier lookup path, so we keep the invariant centralized here.
         unsafe { self.scopes.get_unchecked(self.current.as_u32() as usize) }
     }
 
@@ -345,7 +349,10 @@ impl ScopeChain {
     #[inline]
     pub fn current_scope_mut(&mut self) -> &mut Scope {
         let idx = self.current.as_u32() as usize;
-        // SAFETY: current is always a valid index
+        // SAFETY: same invariant as `current_scope`: `idx` comes from a
+        // ScopeId minted by this chain and therefore addresses an existing scope.
+        // The `&mut self` receiver guarantees no competing borrow of the scope
+        // vector while returning this mutable reference.
         unsafe { self.scopes.get_unchecked_mut(idx) }
     }
 
@@ -358,9 +365,12 @@ impl ScopeChain {
     /// Get a scope by ID (unchecked)
     ///
     /// # Safety
-    /// Caller must ensure id is valid
+    /// Caller must ensure `id` was produced by this `ScopeChain` and the chain has
+    /// not been rebuilt since. The method exists for analyzer hot paths where the
+    /// caller already proved the id through registry traversal.
     #[inline]
     pub unsafe fn get_scope_unchecked(&self, id: ScopeId) -> &Scope {
+        // SAFETY: upheld by the caller contract above.
         unsafe { self.scopes.get_unchecked(id.as_u32() as usize) }
     }
 

--- a/crates/vize_croquis/src/scope/chain/resolution.rs
+++ b/crates/vize_croquis/src/scope/chain/resolution.rs
@@ -19,6 +19,11 @@ impl ScopeChain {
             }
             visited.push(id);
 
+            // SAFETY: the queue is seeded with `self.current` and only extended
+            // with parent ids stored inside scopes owned by this chain. Scope ids
+            // are never synthesized from user input, so every queued id indexes
+            // `self.scopes`. This keeps lexical lookup branch-light in the
+            // compiler's busiest semantic-analysis loop.
             let scope = unsafe { self.scopes.get_unchecked(id.as_u32() as usize) };
             if let Some(binding) = scope.get_binding(name) {
                 return Some((scope, binding));

--- a/crates/vize_fresco/src/layout/engine.rs
+++ b/crates/vize_fresco/src/layout/engine.rs
@@ -43,6 +43,10 @@ impl LayoutEngine {
         let node_id = self
             .tree
             .new_leaf(taffy_style)
+            // Panic path by backend invariant: Fresco only constructs leaf nodes
+            // with a locally generated style, so Taffy should reject this only if
+            // its internal storage is inconsistent. Returning a synthetic id here
+            // would corrupt `node_map` and make later layout reads unsound.
             .expect("Failed to create node");
 
         self.node_map.insert(id, node_id);
@@ -65,6 +69,9 @@ impl LayoutEngine {
         let node_id = self
             .tree
             .new_leaf(taffy_style)
+            // Panic path by backend invariant: measured leaves are created from a
+            // normalized `FlexStyle` plus finite dimensions supplied by Fresco's
+            // renderer. Failing here means the layout tree is unusable.
             .expect("Failed to create leaf");
 
         self.node_map.insert(id, node_id);
@@ -90,6 +97,10 @@ impl LayoutEngine {
         {
             self.tree
                 .add_child(parent_id, child_id)
+                // Panic path by mapping invariant: both ids came from
+                // `node_map`, so Taffy should know each node. If it rejects the
+                // edge, the mirrored maps are already inconsistent and continuing
+                // would cache wrong layouts.
                 .expect("Failed to add child");
         }
     }
@@ -101,6 +112,9 @@ impl LayoutEngine {
         {
             self.tree
                 .remove_child(parent_id, child_id)
+                // Panic path by mapping invariant: callers can request unknown
+                // ids, but those are filtered above. Once both ids are mapped,
+                // failure means our mirrored Taffy tree has diverged.
                 .expect("Failed to remove child");
         }
     }
@@ -111,6 +125,9 @@ impl LayoutEngine {
             let taffy_style = style.to_taffy();
             self.tree
                 .set_style(node_id, taffy_style)
+                // Panic path by mapping invariant: `node_id` is only read from
+                // `node_map`, so Taffy should still own it. A failure indicates
+                // internal tree corruption rather than user input.
                 .expect("Failed to set style");
         }
     }
@@ -120,6 +137,9 @@ impl LayoutEngine {
         if let Some(node_id) = self.node_map.remove(&id) {
             self.reverse_map.remove(&node_id);
             self.layout_cache.remove(&id);
+            // Panic path by mapping invariant: after a successful lookup in
+            // `node_map`, Taffy must contain the node. Losing it would mean the
+            // mirrored maps and layout tree diverged earlier.
             self.tree.remove(node_id).expect("Failed to remove node");
         }
     }
@@ -134,6 +154,10 @@ impl LayoutEngine {
 
             self.tree
                 .compute_layout(root_id, available)
+                // Panic path by mapping invariant: `root_id` is taken from
+                // `node_map`, and all children are added through the same map.
+                // If Taffy cannot compute this tree, Fresco should fail loudly
+                // instead of rendering stale or partial geometry.
                 .expect("Failed to compute layout");
 
             // Cache all layouts
@@ -144,6 +168,10 @@ impl LayoutEngine {
     /// Cache layout results recursively.
     /// Uses taffy's computed sizes but computes positions manually (top-left aligned).
     fn cache_layouts(&mut self, node_id: NodeId, parent_x: f32, parent_y: f32) {
+        // Panic path by compute invariant: `cache_layouts` is called only after
+        // `compute_layout` succeeds for `root_id`, and recursive calls use
+        // children returned by Taffy itself. Missing layout/style data would mean
+        // Taffy accepted an internally inconsistent tree.
         let layout = self.tree.layout(node_id).expect("Failed to get layout");
         let style = self.tree.style(node_id).expect("Failed to get style");
 
@@ -169,6 +197,9 @@ impl LayoutEngine {
         let child_info: Vec<(NodeId, f32, f32, f32, f32, f32, f32)> = children
             .iter()
             .map(|&cid| {
+                // Panic path by child invariant: `cid` came directly from
+                // `tree.children(node_id)`, so layout/style lookup should be
+                // available after the successful compute pass above.
                 let cl = self.tree.layout(cid).expect("child layout");
                 let cs = self.tree.style(cid).expect("child style");
                 // Get margin from style (not layout) to avoid auto-margin issues

--- a/crates/vize_fresco/src/render/diff.rs
+++ b/crates/vize_fresco/src/render/diff.rs
@@ -167,7 +167,12 @@ impl DiffEngine {
                 (Some(old_id), None) => {
                     Self::collect_removes(old, old_id, result);
                 }
-                (None, None) => unreachable!(),
+                (None, None) => {
+                    // Panic path by loop bound invariant: `i` is always below
+                    // `max(old_children.len(), new_children.len())`, so at least
+                    // one side must contain a node at this index.
+                    unreachable!()
+                }
             }
         }
     }

--- a/crates/vize_fresco/src/terminal/backend.rs
+++ b/crates/vize_fresco/src/terminal/backend.rs
@@ -324,6 +324,9 @@ impl Backend {
 
 impl Default for Backend {
     fn default() -> Self {
+        // Panic path by trait-contract limitation: `Default` cannot return an
+        // I/O error. Callers that need recoverable terminal initialization should
+        // use `Backend::new`; this impl is kept for ergonomic tests and builders.
         Self::new().expect("Failed to create backend")
     }
 }

--- a/crates/vize_glyph/src/formatter.rs
+++ b/crates/vize_glyph/src/formatter.rs
@@ -130,7 +130,11 @@ impl<'a> GlyphFormatter<'a> {
         }
         output.extend_from_slice(newline);
 
-        // SAFETY: We only wrote valid UTF-8 bytes
+        // SAFETY: `output` is composed from the original UTF-8 SFC source plus
+        // formatter output returned as `&str` and ASCII whitespace/newlines. All
+        // byte slicing uses block ranges produced by the SFC parser, which are
+        // source-owned UTF-8 boundaries. We keep the conversion unchecked to avoid
+        // revalidating the full formatted document on every format run.
         let code = unsafe { String::from_utf8_unchecked(output) };
         let changed = code != source;
 

--- a/crates/vize_glyph/src/template/formatter.rs
+++ b/crates/vize_glyph/src/template/formatter.rs
@@ -196,7 +196,12 @@ impl<'a> TemplateFormatter<'a> {
             output.pop();
         }
 
-        // SAFETY: We only wrote valid UTF-8 bytes
+        // SAFETY: `output` contains only copied ranges from the UTF-8 template
+        // source, formatter-produced `&str` fragments, and ASCII indentation or
+        // line breaks. The cursor moves across UTF-8 using the parser's byte
+        // ranges and ASCII delimiter checks, so the buffer cannot contain an
+        // invalid byte sequence. Skipping validation preserves formatter
+        // throughput for large templates.
         Ok(unsafe { String::from_utf8_unchecked(output) })
     }
 

--- a/crates/vize_patina/src/markup.rs
+++ b/crates/vize_patina/src/markup.rs
@@ -626,29 +626,36 @@ fn element_children_relief<'a>(element: MarkupElement<'a>) -> &'a [TemplateChild
 
 #[inline]
 fn jsx_element_ref<'a>(node: *const JSXElement<'a>) -> &'a JSXElement<'a> {
-    // SAFETY: pointers are created from nodes borrowed from a parsed OXC program,
-    // and the owning program outlives all markup wrappers constructed for it.
+    // SAFETY: the pointer is captured while walking an `oxc_ast::Program`
+    // borrowed for the same `'a` lifetime used by the returned markup facade.
+    // Markup wrappers are never stored beyond the lint pass that owns the OXC
+    // allocator, and the pass is single-threaded, so the pointed JSX node cannot
+    // move, be freed, or be mutably aliased while this shared reference exists.
     unsafe { &*node }
 }
 
 #[inline]
 fn jsx_fragment_ref<'a>(node: *const JSXFragment<'a>) -> &'a JSXFragment<'a> {
-    // SAFETY: pointers are created from nodes borrowed from a parsed OXC program,
-    // and the owning program outlives all markup wrappers constructed for it.
+    // SAFETY: same OXC-program lifetime invariant as `jsx_element_ref`. Fragment
+    // pointers originate from visitor callbacks and are dereferenced only while
+    // the source program and allocator are still alive for the current lint pass.
     unsafe { &*node }
 }
 
 #[inline]
 fn jsx_attribute_ref<'a>(node: *const JSXAttribute<'a>) -> &'a JSXAttribute<'a> {
-    // SAFETY: pointers are created from nodes borrowed from a parsed OXC program,
-    // and the owning program outlives all markup wrappers constructed for it.
+    // SAFETY: attribute pointers are copied from JSX element attributes during
+    // traversal and keep the OXC AST lifetime. The wrapper is read-only and does
+    // not outlive the program, so dereferencing avoids a clone without changing
+    // aliasing semantics.
     unsafe { &*node }
 }
 
 #[inline]
 fn jsx_text_ref<'a>(node: *const JSXText<'a>) -> &'a JSXText<'a> {
-    // SAFETY: pointers are created from nodes borrowed from a parsed OXC program,
-    // and the owning program outlives all markup wrappers constructed for it.
+    // SAFETY: text pointers are borrowed from immutable JSX children owned by the
+    // OXC allocator for the current program. The markup adapter only exposes
+    // shared reads, and all adapters are dropped before the program is dropped.
     unsafe { &*node }
 }
 


### PR DESCRIPTION
## Summary
- add strict safety comments to residual unsafe hot paths
- annotate remaining panic-by-invariant paths instead of leaving them implicit
- avoid new formatting allocations in parser diagnostic messages

## Validation
- vp run --workspace-root fmt:all
- vp run --workspace-root clippy
- vp run --workspace-root test was intentionally stopped during native release build; heavy Rust validation is left to GitHub Actions per maintainer preference
