### PR TITLE
feat(profiler): track allocations and I/O in profile mode

### DIFF
--- a/crates/vize/src/commands/build/runner.rs
+++ b/crates/vize/src/commands/build/runner.rs
@@ -22,7 +22,7 @@ use vize_carton::String;
 use vize_carton::ToCompactString;
 use vize_carton::cstr;
 use vize_carton::profile;
-use vize_carton::profiler::global_profiler;
+use vize_carton::profiler::{allocation_snapshot, global_profiler};
 
 use crate::commands::profile::{
     ProfileFileRow, ProfilePhase, ProfilePhaseKind, ProfileReport, print_profile_report,
@@ -121,12 +121,19 @@ pub(crate) fn run(args: BuildArgs) {
     match args.format {
         OutputFormat::Stats => {}
         OutputFormat::Js | OutputFormat::Json => {
-            if let Err(error) = fs::create_dir_all(&args.output) {
-                eprintln!(
-                    "Failed to create output directory {}: {error}",
-                    args.output.display()
-                );
-                std::process::exit(1);
+            match profile!(
+                "cli.build.output.create_dir_all",
+                fs::create_dir_all(&args.output)
+            ) {
+                Ok(()) => global_profiler().record_fs_create_dir_all(),
+                Err(error) => {
+                    global_profiler().record_fs_create_dir_all_failure();
+                    eprintln!(
+                        "Failed to create output directory {}: {error}",
+                        args.output.display()
+                    );
+                    std::process::exit(1);
+                }
             }
 
             for (path, output) in results.into_iter().flatten() {
@@ -142,14 +149,21 @@ pub(crate) fn run(args: BuildArgs) {
                     .unwrap_or_else(|| PathBuf::from("output").with_extension(ext));
                 let out_path = args.output.join(filename);
 
-                if let Some(parent) = out_path.parent()
-                    && let Err(error) = fs::create_dir_all(parent)
-                {
-                    eprintln!(
-                        "Failed to create output subdirectory {}: {error}",
-                        parent.display()
-                    );
-                    continue;
+                if let Some(parent) = out_path.parent() {
+                    match profile!(
+                        "cli.build.output.create_dir_all",
+                        fs::create_dir_all(parent)
+                    ) {
+                        Ok(()) => global_profiler().record_fs_create_dir_all(),
+                        Err(error) => {
+                            global_profiler().record_fs_create_dir_all_failure();
+                            eprintln!(
+                                "Failed to create output subdirectory {}: {error}",
+                                parent.display()
+                            );
+                            continue;
+                        }
+                    }
                 }
 
                 let content: String = match args.format {
@@ -164,9 +178,17 @@ pub(crate) fn run(args: BuildArgs) {
                     OutputFormat::Stats => unreachable!(),
                 };
 
-                fs::write(&out_path, content).unwrap_or_else(|e| {
-                    eprintln!("Failed to write {}: {}", out_path.display(), e);
-                });
+                let bytes = content.len();
+                match profile!(
+                    "cli.build.output.write",
+                    fs::write(&out_path, content.as_str())
+                ) {
+                    Ok(()) => global_profiler().record_fs_write(bytes),
+                    Err(error) => {
+                        global_profiler().record_fs_write_failure(bytes);
+                        eprintln!("Failed to write {}: {}", out_path.display(), error);
+                    }
+                }
             }
         }
     }
@@ -272,6 +294,8 @@ pub(crate) fn run(args: BuildArgs) {
     // Profile breakdown
     if args.profile {
         let profiler = global_profiler();
+        let allocation_summary = allocation_snapshot();
+        let counter_summary = profiler.counter_summary();
         let operation_summary = profiler.summary();
         profiler.disable();
         let total_parse = stats.total_parse_time();
@@ -386,6 +410,8 @@ pub(crate) fn run(args: BuildArgs) {
             slow_threshold,
             throughput_bytes: Some(total_bytes),
             operations: Some(&operation_summary),
+            counters: Some(&counter_summary),
+            allocations: Some(allocation_summary),
             recommendations: &recommendations,
         };
         print_profile_report(&report);
@@ -504,11 +530,20 @@ fn compile_file_with_profile(
     let file_start = Instant::now();
 
     // Read file
-    let source = fs::read_to_string(path).map_err(|e| CompileError {
-        path: path.clone(),
-        error: cstr!("Failed to read file: {}", e),
-        phase: ErrorPhase::Read,
-    })?;
+    let source = match profile!("cli.build.file.read", fs::read_to_string(path)) {
+        Ok(source) => {
+            global_profiler().record_fs_read_to_string(source.len());
+            source
+        }
+        Err(error) => {
+            global_profiler().record_fs_read_to_string_failure();
+            return Err(CompileError {
+                path: path.clone(),
+                error: cstr!("Failed to read file: {}", error),
+                phase: ErrorPhase::Read,
+            });
+        }
+    };
 
     let file_size = source.len();
     stats.total_bytes.fetch_add(file_size, Ordering::Relaxed);

--- a/crates/vize/src/commands/check/dts.rs
+++ b/crates/vize/src/commands/check/dts.rs
@@ -1,14 +1,25 @@
 //! Helpers for lightweight `.d.ts` parsing used by `vize check`.
 
+#![allow(clippy::disallowed_macros)]
+
 use std::{fs, path::Path};
 
-use vize_carton::{String, ToCompactString};
+use vize_carton::{String, ToCompactString, profile, profiler::global_profiler};
 
 pub(super) fn parse_interface_members(
     path: &Path,
     interface_name: &str,
 ) -> Result<Vec<(String, String)>, std::io::Error> {
-    let content = fs::read_to_string(path)?;
+    let content = match profile!("cli.check.dts.read", fs::read_to_string(path)) {
+        Ok(content) => {
+            global_profiler().record_fs_read_to_string(content.len());
+            content
+        }
+        Err(error) => {
+            global_profiler().record_fs_read_to_string_failure();
+            return Err(error);
+        }
+    };
     Ok(parse_interface_members_content(&content, interface_name))
 }
 
@@ -68,7 +79,16 @@ pub(super) fn parse_interface_members_content(
 pub(super) fn parse_declared_global_values(
     path: &Path,
 ) -> Result<Vec<(String, String)>, std::io::Error> {
-    let content = fs::read_to_string(path)?;
+    let content = match profile!("cli.check.dts.read", fs::read_to_string(path)) {
+        Ok(content) => {
+            global_profiler().record_fs_read_to_string(content.len());
+            content
+        }
+        Err(error) => {
+            global_profiler().record_fs_read_to_string_failure();
+            return Err(error);
+        }
+    };
     let base_dir = path.parent().unwrap_or_else(|| Path::new("."));
     Ok(parse_declared_global_values_content(&content, base_dir))
 }

--- a/crates/vize/src/commands/check/nuxt.rs
+++ b/crates/vize/src/commands/check/nuxt.rs
@@ -1,5 +1,7 @@
 //! Nuxt-specific auto-import and plugin injection helpers.
 
+#![allow(clippy::disallowed_macros)]
+
 use std::{fs, path::Path};
 
 use ignore::WalkBuilder;
@@ -10,7 +12,7 @@ use oxc_ast::ast::{
 use oxc_parser::Parser;
 use oxc_span::SourceType;
 use vize_canon::virtual_ts::VirtualTsOptions;
-use vize_carton::{FxHashSet, String, ToCompactString, cstr};
+use vize_carton::{FxHashSet, String, ToCompactString, cstr, profile, profiler::global_profiler};
 
 use super::dts::{parse_declared_global_values, rewrite_relative_specifier};
 
@@ -92,7 +94,7 @@ fn collect_generated_stubs(
         return;
     }
 
-    if let Ok(content) = fs::read_to_string(&imports_path) {
+    if let Ok(content) = tracked_read_to_string(&imports_path) {
         let base_dir = imports_path.parent().unwrap_or_else(|| Path::new("."));
         for line in content.lines() {
             let trimmed = line.trim();
@@ -161,7 +163,7 @@ fn collect_plugin_injection_stubs(
                 continue;
             }
 
-            if let Ok(source) = fs::read_to_string(path) {
+            if let Ok(source) = tracked_read_to_string(path) {
                 plugin_keys.extend(extract_plugin_provide_keys_from_source(&source));
             }
         }
@@ -204,6 +206,20 @@ fn push_declared_const(
         seen_names,
         cstr!("declare const {name}: {type_annotation};"),
     );
+}
+
+#[allow(clippy::disallowed_types)]
+fn tracked_read_to_string(path: &Path) -> Result<std::string::String, std::io::Error> {
+    match profile!("cli.check.nuxt.read", fs::read_to_string(path)) {
+        Ok(content) => {
+            global_profiler().record_fs_read_to_string(content.len());
+            Ok(content)
+        }
+        Err(error) => {
+            global_profiler().record_fs_read_to_string_failure();
+            Err(error)
+        }
+    }
 }
 
 fn push_stub(stubs: &mut Vec<String>, seen_names: &mut FxHashSet<String>, stub: String) {

--- a/crates/vize/src/commands/check/runner.rs
+++ b/crates/vize/src/commands/check/runner.rs
@@ -16,7 +16,10 @@ use vize_canon::{
     BatchTypeChecker, BatchTypeCheckerOptions, DeclarationEmitOptions,
     batch::TypeChecker as BatchTypeCheckerTrait,
 };
-use vize_carton::{String, cstr, profiler::global_profiler};
+use vize_carton::{
+    String, cstr, profile,
+    profiler::{allocation_snapshot, global_profiler},
+};
 
 use crate::commands::profile::{
     ProfilePhase, ProfilePhaseKind, ProfileReport, print_profile_report,
@@ -170,6 +173,8 @@ pub(crate) fn run_direct(args: &CheckArgs) {
 
     if args.profile {
         let profiler = global_profiler();
+        let allocation_summary = allocation_snapshot();
+        let counter_summary = profiler.counter_summary();
         let operation_summary = profiler.summary();
         profiler.disable();
         let mut phases = vec![
@@ -251,6 +256,8 @@ pub(crate) fn run_direct(args: &CheckArgs) {
             slow_threshold: Duration::from_millis(0),
             throughput_bytes: Some(virtual_bytes),
             operations: Some(&operation_summary),
+            counters: Some(&counter_summary),
+            allocations: Some(allocation_summary),
             recommendations: &recommendations,
         };
         print_profile_report(&report);
@@ -421,20 +428,34 @@ fn render_diagnostics(
 
 fn write_profile_virtual_ts(files: &[&vize_canon::VirtualFile]) {
     let profile_dir = PathBuf::from("node_modules/.vize/check-profile");
-    if profile_dir.exists()
-        && let Err(error) = fs::remove_dir_all(&profile_dir)
-    {
-        eprintln!(
-            "Failed to clean profile directory {}: {}",
-            profile_dir.display(),
-            error
-        );
-        return;
+    if profile_dir.exists() {
+        match profile!(
+            "cli.check.profile_artifact.remove_dir_all",
+            fs::remove_dir_all(&profile_dir)
+        ) {
+            Ok(()) => global_profiler().record_fs_remove_dir_all(),
+            Err(error) => {
+                global_profiler().record_fs_remove_dir_all_failure();
+                eprintln!(
+                    "Failed to clean profile directory {}: {}",
+                    profile_dir.display(),
+                    error
+                );
+                return;
+            }
+        }
     }
 
-    if let Err(error) = fs::create_dir_all(&profile_dir) {
-        eprintln!("Failed to create profile directory: {}", error);
-        return;
+    match profile!(
+        "cli.check.profile_artifact.create_dir_all",
+        fs::create_dir_all(&profile_dir)
+    ) {
+        Ok(()) => global_profiler().record_fs_create_dir_all(),
+        Err(error) => {
+            global_profiler().record_fs_create_dir_all_failure();
+            eprintln!("Failed to create profile directory: {}", error);
+            return;
+        }
     }
 
     for file in files {
@@ -445,8 +466,16 @@ fn write_profile_virtual_ts(files: &[&vize_canon::VirtualFile]) {
             .map(|name| cstr!("{name}.ts"))
             .unwrap_or_else(|| "unknown.ts".into());
         let target = profile_dir.join(file_name.as_str());
-        if let Err(error) = fs::write(&target, &file.content) {
-            eprintln!("Failed to write {}: {}", target.display(), error);
+        let bytes = file.content.len();
+        match profile!(
+            "cli.check.profile_artifact.write",
+            fs::write(&target, &file.content)
+        ) {
+            Ok(()) => global_profiler().record_fs_write(bytes),
+            Err(error) => {
+                global_profiler().record_fs_write_failure(bytes);
+                eprintln!("Failed to write {}: {}", target.display(), error);
+            }
         }
     }
 

--- a/crates/vize/src/commands/check/runner/socket.rs
+++ b/crates/vize/src/commands/check/runner/socket.rs
@@ -12,7 +12,10 @@ use std::{
     time::{Duration, Instant},
 };
 
-use vize_carton::{String, cstr};
+use vize_carton::{
+    String, cstr, profile,
+    profiler::{allocation_snapshot, global_profiler},
+};
 
 use crate::commands::{
     check::{CheckArgs, JsonRpcResponse, ServerCheckResult},
@@ -24,6 +27,12 @@ use super::collect::collect_vue_files;
 /// Run type checking via Unix socket connection to check-server.
 pub(crate) fn run_with_socket(args: &CheckArgs, socket_path: &str) {
     let start = Instant::now();
+    if args.profile {
+        let profiler = global_profiler();
+        profiler.clear();
+        profiler.enable();
+    }
+
     let collect_start = Instant::now();
     #[allow(clippy::disallowed_types)]
     let default_patterns = vec![std::string::String::from(".")];
@@ -67,9 +76,13 @@ pub(crate) fn run_with_socket(args: &CheckArgs, socket_path: &str) {
     let request_start = Instant::now();
     for path in &files {
         #[allow(clippy::disallowed_types)]
-        let source = match fs::read_to_string(path) {
-            Ok(source) => source,
+        let source = match profile!("cli.check.socket.file.read", fs::read_to_string(path)) {
+            Ok(source) => {
+                global_profiler().record_fs_read_to_string(source.len());
+                source
+            }
             Err(error) => {
+                global_profiler().record_fs_read_to_string_failure();
                 eprintln!("Failed to read {}: {}", path.display(), error);
                 continue;
             }
@@ -88,18 +101,44 @@ pub(crate) fn run_with_socket(args: &CheckArgs, socket_path: &str) {
             }
         });
 
-        if writeln!(stream, "{}", request).is_err() || stream.flush().is_err() {
+        let request_payload = match serde_json::to_string(&request) {
+            Ok(payload) => payload,
+            Err(error) => {
+                eprintln!("Failed to encode request: {}", error);
+                continue;
+            }
+        };
+        let request_bytes = request_payload.len() + 1;
+        if writeln!(stream, "{request_payload}").is_err() || stream.flush().is_err() {
+            global_profiler().record_counter("io.socket.write.calls", 1);
+            global_profiler()
+                .record_counter("io.socket.write.attempted_bytes", request_bytes as u64);
+            global_profiler().record_counter("io.socket.write.failures", 1);
+            global_profiler().record_counter("syscall.socket.write.calls", 1);
+            global_profiler().record_counter("syscall.socket.write.failures", 1);
             eprintln!("Failed to send request");
             break;
         }
+        global_profiler().record_counter("io.socket.write.calls", 1);
+        global_profiler().record_counter("io.socket.write.attempted_bytes", request_bytes as u64);
+        global_profiler().record_counter("io.socket.write.bytes", request_bytes as u64);
+        global_profiler().record_counter("syscall.socket.write.calls", 1);
+        global_profiler().record_counter("syscall.socket.flush.calls", 1);
 
         let mut reader = BufReader::new(&stream);
         #[allow(clippy::disallowed_types)]
         let mut response_line = std::string::String::new();
         if reader.read_line(&mut response_line).is_err() {
+            global_profiler().record_counter("io.socket.read.calls", 1);
+            global_profiler().record_counter("io.socket.read.failures", 1);
+            global_profiler().record_counter("syscall.socket.read.calls", 1);
+            global_profiler().record_counter("syscall.socket.read.failures", 1);
             eprintln!("Failed to read response");
             break;
         }
+        global_profiler().record_counter("io.socket.read.calls", 1);
+        global_profiler().record_counter("io.socket.read.bytes", response_line.len() as u64);
+        global_profiler().record_counter("syscall.socket.read.calls", 1);
 
         let response: JsonRpcResponse = match serde_json::from_str(&response_line) {
             Ok(response) => response,
@@ -170,6 +209,11 @@ pub(crate) fn run_with_socket(args: &CheckArgs, socket_path: &str) {
         total_time
     );
     if args.profile {
+        let profiler = global_profiler();
+        let allocation_summary = allocation_snapshot();
+        let counter_summary = profiler.counter_summary();
+        let operation_summary = profiler.summary();
+        profiler.disable();
         let phases = [
             ProfilePhase {
                 name: "collect files",
@@ -217,7 +261,9 @@ pub(crate) fn run_with_socket(args: &CheckArgs, socket_path: &str) {
             files: &[],
             slow_threshold: Duration::from_millis(0),
             throughput_bytes: None,
-            operations: None,
+            operations: Some(&operation_summary),
+            counters: Some(&counter_summary),
+            allocations: Some(allocation_summary),
             recommendations: &recommendations,
         };
         print_profile_report(&report);

--- a/crates/vize/src/commands/check/tsconfig_inputs.rs
+++ b/crates/vize/src/commands/check/tsconfig_inputs.rs
@@ -4,7 +4,7 @@
 //! project's configured `files` / `include` / `exclude` fields instead of
 //! recursively scanning every TypeScript file under the working directory.
 
-#![allow(clippy::disallowed_types)]
+#![allow(clippy::disallowed_macros, clippy::disallowed_types)]
 
 use std::{
     fs,
@@ -14,7 +14,7 @@ use std::{
 use glob::{MatchOptions, Pattern};
 use ignore::WalkBuilder;
 use serde_json::Value;
-use vize_carton::FxHashSet;
+use vize_carton::{FxHashSet, profile, profiler::global_profiler};
 
 #[derive(Debug, Clone, Default)]
 struct TsconfigInputSpec {
@@ -201,7 +201,7 @@ fn load_tsconfig_inputs_inner(
         return Ok(TsconfigInputSpec::default());
     }
 
-    let content = fs::read_to_string(&resolved)?;
+    let content = tracked_read_to_string(&resolved)?;
     let value = parse_jsonc_value(&content).unwrap_or(Value::Null);
     let dir = resolved.parent().unwrap_or(Path::new("."));
 
@@ -311,7 +311,7 @@ fn split_package_specifier(extends: &str) -> Option<(&str, Option<&str>)> {
 
 fn push_package_json_tsconfig_candidates(candidates: &mut Vec<PathBuf>, package_root: &Path) {
     let package_json_path = package_root.join("package.json");
-    let Some(tsconfig) = fs::read_to_string(package_json_path)
+    let Some(tsconfig) = tracked_read_to_string(&package_json_path)
         .ok()
         .and_then(|content| parse_jsonc_value(&content).ok())
         .and_then(|value| {
@@ -325,6 +325,19 @@ fn push_package_json_tsconfig_candidates(candidates: &mut Vec<PathBuf>, package_
     };
 
     push_tsconfig_candidates(candidates, package_root.join(tsconfig));
+}
+
+fn tracked_read_to_string(path: &Path) -> Result<std::string::String, std::io::Error> {
+    match profile!("cli.check.tsconfig.read", fs::read_to_string(path)) {
+        Ok(content) => {
+            global_profiler().record_fs_read_to_string(content.len());
+            Ok(content)
+        }
+        Err(error) => {
+            global_profiler().record_fs_read_to_string_failure();
+            Err(error)
+        }
+    }
 }
 
 fn push_tsconfig_candidates(candidates: &mut Vec<PathBuf>, base: PathBuf) {

--- a/crates/vize/src/commands/fmt.rs
+++ b/crates/vize/src/commands/fmt.rs
@@ -11,7 +11,10 @@ use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::time::{Duration, Instant};
-use vize_carton::cstr;
+use vize_carton::{
+    cstr, profile,
+    profiler::{allocation_snapshot, global_profiler},
+};
 use vize_glyph::{Allocator, FormatOptions, format_sfc_with_allocator};
 
 use crate::commands::profile::{
@@ -104,6 +107,11 @@ pub fn run(args: FmtArgs) {
     let files_unchanged = AtomicUsize::new(0);
     let files_errored = AtomicUsize::new(0);
     let profile_rows = args.profile.then(|| Mutex::new(Vec::new()));
+    if args.profile {
+        let profiler = global_profiler();
+        profiler.clear();
+        profiler.enable();
+    }
 
     // Process files in parallel, each thread gets its own allocator for maximum performance
     let process_start = Instant::now();
@@ -268,6 +276,12 @@ pub fn run(args: FmtArgs) {
             unchanged,
             errored
         );
+        let profiler = global_profiler();
+        let allocation_summary = allocation_snapshot();
+        let counter_summary = profiler.counter_summary();
+        let operation_summary = profiler.summary();
+        profiler.disable();
+
         let report = ProfileReport {
             title: "fmt",
             summary: summary.as_str(),
@@ -276,7 +290,9 @@ pub fn run(args: FmtArgs) {
             files: &file_rows,
             slow_threshold,
             throughput_bytes: Some(total_bytes),
-            operations: None,
+            operations: Some(&operation_summary),
+            counters: Some(&counter_summary),
+            allocations: Some(allocation_summary),
             recommendations: &recommendations,
         };
         print_profile_report(&report);
@@ -470,15 +486,27 @@ fn process_file(
 
     // Read the file
     let read_start = profile.then(Instant::now);
-    let source = fs::read_to_string(path).map_err(|e| format!("Failed to read file: {}", e))?;
+    let source = match profile!("cli.fmt.file.read", fs::read_to_string(path)) {
+        Ok(source) => {
+            global_profiler().record_fs_read_to_string(source.len());
+            source
+        }
+        Err(error) => {
+            global_profiler().record_fs_read_to_string_failure();
+            return Err(format!("Failed to read file: {}", error));
+        }
+    };
     let read_time = read_start
         .map(|start| start.elapsed())
         .unwrap_or(Duration::ZERO);
 
     // Format the source using the provided allocator
     let format_start = profile.then(Instant::now);
-    let result = format_sfc_with_allocator(&source, options, allocator)
-        .map_err(|e| format!("Format error: {}", e))?;
+    let result = profile!(
+        "cli.fmt.file.format_sfc",
+        format_sfc_with_allocator(&source, options, allocator)
+    )
+    .map_err(|e| format!("Format error: {}", e))?;
     let format_time = format_start
         .map(|start| start.elapsed())
         .unwrap_or(Duration::ZERO);
@@ -490,7 +518,12 @@ fn process_file(
             eprintln!("Would reformat: {}", path.display());
         } else if write {
             // Write the formatted output
-            fs::write(path, &result.code).map_err(|e| format!("Failed to write file: {}", e))?;
+            let bytes = result.code.len();
+            if let Err(error) = profile!("cli.fmt.file.write", fs::write(path, &result.code)) {
+                global_profiler().record_fs_write_failure(bytes);
+                return Err(format!("Failed to write file: {}", error));
+            }
+            global_profiler().record_fs_write(bytes);
             eprintln!("Reformatted: {}", path.display());
         } else {
             // Print the diff or formatted output

--- a/crates/vize/src/commands/lint.rs
+++ b/crates/vize/src/commands/lint.rs
@@ -13,7 +13,8 @@ use std::time::Instant;
 use vize_armature::Parser;
 use vize_atelier_sfc::{SfcParseOptions, parse_sfc};
 use vize_carton::{
-    Allocator, CompactString, FxHashMap, String, ToCompactString, cstr, profiler::global_profiler,
+    Allocator, CompactString, FxHashMap, String, ToCompactString, cstr, profile,
+    profiler::{allocation_snapshot, global_profiler},
 };
 use vize_croquis::cross_file::{
     CrossFileAnalyzer, CrossFileDiagnostic, CrossFileDiagnosticKind, CrossFileOptions,
@@ -158,9 +159,13 @@ pub fn run(args: LintArgs) {
         .filter_map(|path| {
             let file_start = args.profile.then(Instant::now);
             let read_start = args.profile.then(Instant::now);
-            let source = match fs::read_to_string(path) {
-                Ok(s) => s,
+            let source = match profile!("cli.lint.file.read", fs::read_to_string(path)) {
+                Ok(s) => {
+                    global_profiler().record_fs_read_to_string(s.len());
+                    s
+                }
                 Err(e) => {
+                    global_profiler().record_fs_read_to_string_failure();
                     eprintln!("Failed to read {}: {}", path.display(), e);
                     return None;
                 }
@@ -171,7 +176,10 @@ pub fn run(args: LintArgs) {
 
             let filename = path.to_string_lossy().to_compact_string();
             let lint_file_start = args.profile.then(Instant::now);
-            let result = linter.lint_sfc(&source, &filename);
+            let result = profile!(
+                "cli.lint.file.lint_sfc",
+                linter.lint_sfc(&source, &filename)
+            );
             let lint_time = lint_file_start
                 .map(|start| start.elapsed())
                 .unwrap_or(Duration::ZERO);
@@ -212,27 +220,23 @@ pub fn run(args: LintArgs) {
             .iter()
             .map(|(path, _, source, _)| (path.clone(), source.as_str()))
             .collect();
-        let cross_file_output =
-            build_cross_file_lint_output(&cross_file_inputs, help_level, args.cross_file_tree);
+        let cross_file_output = profile!(
+            "cli.lint.cross_file.build",
+            build_cross_file_lint_output(&cross_file_inputs, help_level, args.cross_file_tree)
+        );
         cross_file_tree = cross_file_output.provide_inject_tree;
 
-        for (index, cross_result) in cross_file_output.results.into_iter().enumerate() {
-            if let Some((_, _, _, result)) = results.get_mut(index) {
-                merge_lint_result(result, cross_result);
+        profile!("cli.lint.cross_file.merge", {
+            for (index, cross_result) in cross_file_output.results.into_iter().enumerate() {
+                if let Some((_, _, _, result)) = results.get_mut(index) {
+                    merge_lint_result(result, cross_result);
+                }
             }
-        }
+        });
     }
     let cross_file_time = cross_file_start
         .map(|start| start.elapsed())
         .unwrap_or(Duration::ZERO);
-    let operation_summary = if args.profile {
-        let profiler = global_profiler();
-        let summary = profiler.summary();
-        profiler.disable();
-        Some(summary)
-    } else {
-        None
-    };
 
     let total_errors: usize = results
         .iter()
@@ -246,18 +250,37 @@ pub fn run(args: LintArgs) {
     // Format and print results
     let output_start = Instant::now();
     if render_details {
-        let lint_results: Vec<_> = results.iter().map(|(_, _, _, r)| r).cloned().collect();
-        let sources: Vec<_> = results
-            .iter()
-            .map(|(_, f, s, _)| (f.clone(), vize_carton::String::from(s.as_str())))
-            .collect();
+        let lint_results: Vec<_> = profile!(
+            "cli.lint.output.clone_results",
+            results.iter().map(|(_, _, _, r)| r).cloned().collect()
+        );
+        let sources: Vec<_> = profile!(
+            "cli.lint.output.clone_sources",
+            results
+                .iter()
+                .map(|(_, f, s, _)| (f.clone(), vize_carton::String::from(s.as_str())))
+                .collect()
+        );
 
-        let output = format_results(&lint_results, &sources, format);
+        let output = profile!(
+            "cli.lint.output.format_results",
+            format_results(&lint_results, &sources, format)
+        );
         if !output.trim().is_empty() {
             print!("{}", output);
         }
     }
     let output_time = output_start.elapsed();
+    let (operation_summary, counter_summary, allocation_summary) = if args.profile {
+        let profiler = global_profiler();
+        let allocation = allocation_snapshot();
+        let counters = profiler.counter_summary();
+        let operations = profiler.summary();
+        profiler.disable();
+        (Some(operations), Some(counters), Some(allocation))
+    } else {
+        (None, None, None)
+    };
 
     // Print summary
     let elapsed = start.elapsed();
@@ -377,6 +400,8 @@ pub fn run(args: LintArgs) {
             slow_threshold,
             throughput_bytes: Some(total_bytes),
             operations: operation_summary.as_ref(),
+            counters: counter_summary.as_ref(),
+            allocations: allocation_summary,
             recommendations: &recommendations,
         };
         print_profile_report(&report);

--- a/crates/vize/src/commands/profile.rs
+++ b/crates/vize/src/commands/profile.rs
@@ -3,7 +3,7 @@
 use std::path::PathBuf;
 use std::time::Duration;
 
-use vize_carton::profiler::ProfileSummary;
+use vize_carton::profiler::{AllocationSnapshot, CounterSummary, ProfileSummary};
 use vize_carton::{String, append, appendln, appends};
 
 const RESET: &str = "\x1b[0m";
@@ -49,6 +49,8 @@ pub(crate) struct ProfileReport<'a> {
     pub slow_threshold: Duration,
     pub throughput_bytes: Option<usize>,
     pub operations: Option<&'a ProfileSummary>,
+    pub counters: Option<&'a CounterSummary>,
+    pub allocations: Option<AllocationSnapshot>,
     pub recommendations: &'a [String],
 }
 
@@ -76,9 +78,14 @@ pub(crate) fn render_profile_report(report: &ProfileReport<'_>) -> String {
     out.push('\n');
 
     render_strict_audit(&mut out, report);
+    render_allocation_table(&mut out, report);
+    render_counter_table(&mut out, report, "I/O counters", "io.");
+    render_counter_table(&mut out, report, "System calls", "syscall.");
     render_phase_table(&mut out, report);
     render_file_table(&mut out, report);
     render_operation_table(&mut out, report);
+    render_latency_table(&mut out, report);
+    render_call_volume_table(&mut out, report);
     render_recommendations(&mut out, report);
 
     out
@@ -101,17 +108,26 @@ fn render_strict_audit(out: &mut String, report: &ProfileReport<'_>) {
         .iter()
         .filter(|file| file.total > report.slow_threshold)
         .count();
-    let (operation_count, operation_total) = report
+    let (operation_count, operation_total, operation_self, operation_child) = report
         .operations
         .map(|summary| {
-            summary
-                .entries
-                .iter()
-                .fold((0u64, Duration::ZERO), |(count, total), entry| {
-                    (count + entry.count, total + entry.total)
-                })
+            summary.entries.iter().fold(
+                (0u64, Duration::ZERO, Duration::ZERO, Duration::ZERO),
+                |(count, total, self_total, child_total), entry| {
+                    (
+                        count + entry.count,
+                        total + entry.total,
+                        self_total + entry.self_total,
+                        child_total + entry.child_total,
+                    )
+                },
+            )
         })
-        .unwrap_or((0, Duration::ZERO));
+        .unwrap_or((0, Duration::ZERO, Duration::ZERO, Duration::ZERO));
+    let io_read_bytes = counter_total(report, "io.read.bytes");
+    let io_write_bytes = counter_total(report, "io.write.bytes");
+    let syscall_calls = counter_total_matching(report, "syscall.", ".calls");
+    let syscall_failures = counter_total_matching(report, "syscall.", ".failures");
 
     appendln!(out);
     appendln!(out, BOLD, "Strict audit", RESET);
@@ -177,6 +193,94 @@ fn render_strict_audit(out: &mut String, report: &ProfileReport<'_>) {
         ("captured", GREEN)
     };
     audit_row(out, "internal spans", value.as_str(), status, color);
+
+    value.clear();
+    write_duration(&mut value, operation_self);
+    append!(
+        value,
+        " ({:.1}%)",
+        percent_of(operation_self, operation_total)
+    );
+    let (status, color) = if operation_count == 0 {
+        ("not captured", DIM)
+    } else {
+        ("exclusive cost", GREEN)
+    };
+    audit_row(out, "internal self", value.as_str(), status, color);
+
+    value.clear();
+    write_duration(&mut value, operation_child);
+    append!(
+        value,
+        " ({:.1}%)",
+        percent_of(operation_child, operation_total)
+    );
+    let (status, color) = if operation_child > operation_self {
+        ("nested heavy", YELLOW)
+    } else if operation_child.is_zero() {
+        ("flat", DIM)
+    } else {
+        ("nested visible", CYAN)
+    };
+    audit_row(out, "nested span tax", value.as_str(), status, color);
+
+    if let Some(allocation) = report.allocations {
+        value.clear();
+        append!(value, "{} call(s), ", allocation.allocation_calls());
+        write_bytes_u64(&mut value, allocation.requested_bytes());
+        let (status, color) = if allocation.allocation_calls() == 0 {
+            ("zero", DIM)
+        } else if allocation.allocation_failures() > 0 {
+            ("failures", RED)
+        } else {
+            ("tracked", GREEN)
+        };
+        audit_row(out, "alloc pressure", value.as_str(), status, color);
+
+        value.clear();
+        write_signed_bytes(&mut value, allocation.net_bytes());
+        append!(
+            value,
+            " ({:.1} B/call)",
+            allocation.requested_bytes_per_call()
+        );
+        let (status, color) = if allocation.net_bytes() > 0 {
+            ("growth window", YELLOW)
+        } else if allocation.net_bytes() < 0 {
+            ("release window", CYAN)
+        } else {
+            ("balanced", GREEN)
+        };
+        audit_row(out, "heap delta", value.as_str(), status, color);
+    }
+
+    if report.counters.is_some() {
+        value.clear();
+        appends!(value, "read ");
+        write_bytes_u64(&mut value, io_read_bytes);
+        appends!(value, ", wrote ");
+        write_bytes_u64(&mut value, io_write_bytes);
+        let (status, color) = if io_read_bytes == 0 && io_write_bytes == 0 {
+            ("no bytes", DIM)
+        } else {
+            ("tracked", GREEN)
+        };
+        audit_row(out, "I/O bytes", value.as_str(), status, color);
+
+        value.clear();
+        append!(
+            value,
+            "{syscall_calls} call-site hit(s), {syscall_failures} failed"
+        );
+        let (status, color) = if syscall_calls == 0 {
+            ("not captured", DIM)
+        } else if syscall_failures > 0 {
+            ("failures", RED)
+        } else {
+            ("clean", GREEN)
+        };
+        audit_row(out, "syscall sites", value.as_str(), status, color);
+    }
 }
 
 fn audit_row(out: &mut String, metric: &str, value: &str, status: &str, color: &str) {
@@ -187,6 +291,126 @@ fn audit_row(out: &mut String, metric: &str, value: &str, status: &str, color: &
     appends!(out, " ", color);
     append_padded(out, status, 16);
     appendln!(out, RESET);
+}
+
+fn render_allocation_table(out: &mut String, report: &ProfileReport<'_>) {
+    let Some(allocation) = report.allocations else {
+        return;
+    };
+
+    appendln!(out);
+    appendln!(out, BOLD, "Allocation pressure", RESET);
+    appendln!(
+        out,
+        DIM,
+        "  kind             calls       bytes          failures  note",
+        RESET
+    );
+
+    allocation_row(
+        out,
+        "alloc",
+        allocation.alloc_calls + allocation.alloc_zeroed_calls,
+        allocation.alloc_bytes + allocation.alloc_zeroed_bytes,
+        allocation.alloc_failures + allocation.alloc_zeroed_failures,
+        "fresh allocations",
+    );
+    allocation_row(
+        out,
+        "realloc in",
+        allocation.realloc_calls,
+        allocation.realloc_old_bytes,
+        allocation.realloc_failures,
+        "old layouts replaced",
+    );
+    allocation_row(
+        out,
+        "realloc out",
+        allocation.realloc_calls,
+        allocation.realloc_new_bytes,
+        allocation.realloc_failures,
+        "new requested sizes",
+    );
+    allocation_row(
+        out,
+        "dealloc",
+        allocation.dealloc_calls,
+        allocation.dealloc_bytes,
+        0,
+        "released layouts",
+    );
+
+    appends!(out, "  ");
+    append_padded(out, "net delta", 16);
+    appends!(out, " ");
+    append_padded(out, "n/a", 10);
+    appends!(out, "  ");
+    write_signed_bytes_padded(out, allocation.net_bytes(), 13);
+    appends!(out, "  ");
+    write_count_padded(out, allocation.allocation_failures(), 8);
+    appends!(out, "  profile-window requested minus released");
+    out.push('\n');
+}
+
+fn allocation_row(out: &mut String, kind: &str, calls: u64, bytes: u64, failures: u64, note: &str) {
+    appends!(out, "  ");
+    append_padded(out, kind, 16);
+    appends!(out, " ");
+    write_count_padded(out, calls, 10);
+    appends!(out, "  ");
+    write_bytes_u64_padded(out, bytes, 13);
+    appends!(out, "  ");
+    write_count_padded(out, failures, 8);
+    appends!(out, "  ", DIM, note, RESET);
+    out.push('\n');
+}
+
+fn render_counter_table(out: &mut String, report: &ProfileReport<'_>, title: &str, prefix: &str) {
+    let Some(summary) = report.counters else {
+        return;
+    };
+
+    let entries: Vec<_> = summary
+        .entries
+        .iter()
+        .filter(|entry| entry.name.starts_with(prefix))
+        .collect();
+    if entries.is_empty() {
+        return;
+    }
+
+    appendln!(out);
+    appendln!(out, BOLD, title, RESET);
+    if prefix == "syscall." {
+        appendln!(
+            out,
+            DIM,
+            "  std::fs call-site hits tracked by Vize; this is not a kernel trace.",
+            RESET
+        );
+    }
+    appendln!(
+        out,
+        DIM,
+        "  counter                                samples    total        avg         min         max",
+        RESET
+    );
+
+    for entry in entries {
+        appends!(out, "  ");
+        append_padded(out, entry.name, 38);
+        appends!(out, " ");
+        write_count_padded(out, entry.samples, 7);
+        appends!(out, "  ");
+        write_counter_total_padded(out, entry.name, entry.total, 10);
+        appends!(out, "  ");
+        write_counter_average_padded(out, entry.name, entry.average, 10);
+        appends!(out, "  ");
+        write_counter_total_padded(out, entry.name, entry.min, 10);
+        appends!(out, "  ");
+        write_counter_total_padded(out, entry.name, entry.max, 10);
+        out.push('\n');
+    }
 }
 
 fn render_phase_table(out: &mut String, report: &ProfileReport<'_>) {
@@ -243,7 +467,7 @@ fn render_file_table(mut out: &mut String, report: &ProfileReport<'_>) {
     appendln!(
         out,
         DIM,
-        "  #  total       share   breakdown                          size      rate       status       file",
+        "  #  total       share   breakdown                                      gap        size      rate       status       file",
         RESET
     );
 
@@ -253,6 +477,8 @@ fn render_file_table(mut out: &mut String, report: &ProfileReport<'_>) {
         let is_slow = file.total > report.slow_threshold;
         let color = if is_slow { YELLOW } else { GREEN };
         let status = file_status(file, report.slow_threshold);
+        let accounted = file.primary + file.secondary;
+        let gap = file.total.saturating_sub(accounted);
 
         appends!(out, "  ");
         write_count_padded(out, (index + 1) as u64, 2);
@@ -272,6 +498,10 @@ fn render_file_table(mut out: &mut String, report: &ProfileReport<'_>) {
         write_duration_padded(out, file.secondary, 9);
         appends!(out, " ");
         write_percent_padded(out, percent_of(file.secondary, file.total), 6);
+        appends!(out, "  ");
+        write_duration_padded(out, gap, 9);
+        appends!(out, " ");
+        write_percent_padded(out, percent_of(gap, file.total), 6);
         appends!(out, "  ");
         write_bytes(out, file.bytes);
         appends!(out, "  ");
@@ -315,11 +545,11 @@ fn render_operation_table(out: &mut String, report: &ProfileReport<'_>) {
     appendln!(
         out,
         DIM,
-        "  operation                         count   total       share   avg         min         max       max/avg  status",
+        "  operation                         count   total       self        child       wall%   self%   avg         self/call   max/avg  status",
         RESET
     );
 
-    let displayed = summary.entries.len().min(48);
+    let displayed = summary.entries.len().min(64);
     for entry in summary.entries.iter().take(displayed) {
         let max_avg_ratio = duration_ratio(entry.max, entry.average);
         let (status, color) = operation_status(entry, report.total, max_avg_ratio);
@@ -331,13 +561,17 @@ fn render_operation_table(out: &mut String, report: &ProfileReport<'_>) {
         appends!(out, "  ");
         write_duration_padded(out, entry.total, 10);
         appends!(out, "  ");
+        write_duration_padded(out, entry.self_total, 10);
+        appends!(out, "  ");
+        write_duration_padded(out, entry.child_total, 10);
+        appends!(out, "  ");
         write_percent_padded(out, percent_of(entry.total, report.total), 6);
+        appends!(out, "  ");
+        write_percent_padded(out, percent_of(entry.self_total, report.total), 6);
         appends!(out, "  ");
         write_duration_padded(out, entry.average, 10);
         appends!(out, "  ");
-        write_duration_padded(out, entry.min, 10);
-        appends!(out, "  ");
-        write_duration_padded(out, entry.max, 10);
+        write_duration_padded(out, entry.self_average, 10);
         appends!(out, "  ");
         write_ratio_padded(out, max_avg_ratio, 7);
         appends!(out, "  ", color);
@@ -355,6 +589,90 @@ fn render_operation_table(out: &mut String, report: &ProfileReport<'_>) {
             " more operation(s)",
             RESET
         );
+    }
+}
+
+fn render_latency_table(out: &mut String, report: &ProfileReport<'_>) {
+    let Some(summary) = report.operations else {
+        return;
+    };
+    if summary.entries.is_empty() {
+        return;
+    }
+
+    let mut entries: Vec<_> = summary.entries.iter().collect();
+    entries.sort_by_key(|entry| std::cmp::Reverse((entry.p99, entry.max, entry.total)));
+
+    appendln!(out);
+    appendln!(out, BOLD, "Tail latency", RESET);
+    appendln!(
+        out,
+        DIM,
+        "  operation                         count   p50         p95         p99         min         max         >=1ms  >=10ms >=100ms",
+        RESET
+    );
+
+    for entry in entries.into_iter().take(32) {
+        appends!(out, "  ");
+        append_padded(out, entry.name, 33);
+        appends!(out, " ");
+        write_count_padded(out, entry.count, 5);
+        appends!(out, "  ");
+        write_duration_padded(out, entry.p50, 10);
+        appends!(out, "  ");
+        write_duration_padded(out, entry.p95, 10);
+        appends!(out, "  ");
+        write_duration_padded(out, entry.p99, 10);
+        appends!(out, "  ");
+        write_duration_padded(out, entry.min, 10);
+        appends!(out, "  ");
+        write_duration_padded(out, entry.max, 10);
+        appends!(out, "  ");
+        write_count_padded(out, entry.samples_over_1ms, 5);
+        appends!(out, "  ");
+        write_count_padded(out, entry.samples_over_10ms, 5);
+        appends!(out, "  ");
+        write_count_padded(out, entry.samples_over_100ms, 6);
+        out.push('\n');
+    }
+}
+
+fn render_call_volume_table(out: &mut String, report: &ProfileReport<'_>) {
+    let Some(summary) = report.operations else {
+        return;
+    };
+    if summary.entries.is_empty() {
+        return;
+    }
+
+    let mut entries: Vec<_> = summary.entries.iter().collect();
+    entries.sort_by_key(|entry| std::cmp::Reverse((entry.count, entry.total)));
+
+    appendln!(out);
+    appendln!(out, BOLD, "Call volume", RESET);
+    appendln!(
+        out,
+        DIM,
+        "  operation                         count     calls/ms  total       self        avg         self/call",
+        RESET
+    );
+
+    for entry in entries.into_iter().take(32) {
+        appends!(out, "  ");
+        append_padded(out, entry.name, 33);
+        appends!(out, " ");
+        write_count_padded(out, entry.count, 7);
+        appends!(out, "  ");
+        write_calls_per_ms_padded(out, entry.count, report.total, 9);
+        appends!(out, "  ");
+        write_duration_padded(out, entry.total, 10);
+        appends!(out, "  ");
+        write_duration_padded(out, entry.self_total, 10);
+        appends!(out, "  ");
+        write_duration_padded(out, entry.average, 10);
+        appends!(out, "  ");
+        write_duration_padded(out, entry.self_average, 10);
+        out.push('\n');
     }
 }
 
@@ -482,7 +800,11 @@ fn write_rate(mut out: &mut String, bytes: usize, duration: Duration) {
     }
 }
 
-fn write_bytes(mut out: &mut String, bytes: usize) {
+fn write_bytes(out: &mut String, bytes: usize) {
+    write_bytes_u64(out, bytes as u64);
+}
+
+fn write_bytes_u64(mut out: &mut String, bytes: u64) {
     if bytes >= 1024 * 1024 {
         append!(out, "{:>7.2} MiB", bytes as f64 / 1024.0 / 1024.0);
     } else if bytes >= 1024 {
@@ -492,12 +814,75 @@ fn write_bytes(mut out: &mut String, bytes: usize) {
     }
 }
 
+fn write_bytes_u64_padded(out: &mut String, bytes: u64, width: usize) {
+    let before = out.len();
+    write_bytes_u64(out, bytes);
+    pad_recent(out, before, width);
+}
+
+fn write_signed_bytes(out: &mut String, bytes: i128) {
+    if bytes < 0 {
+        appends!(out, "-");
+        write_bytes_u64(out, bytes.unsigned_abs() as u64);
+    } else {
+        write_bytes_u64(out, bytes as u64);
+    }
+}
+
+fn write_signed_bytes_padded(out: &mut String, bytes: i128, width: usize) {
+    let before = out.len();
+    write_signed_bytes(out, bytes);
+    pad_recent(out, before, width);
+}
+
 fn write_count_padded(mut out: &mut String, count: u64, width: usize) {
     append!(out, "{count:>width$}");
 }
 
 fn write_ratio_padded(mut out: &mut String, ratio: f64, width: usize) {
     append!(out, "{ratio:>width$.1}x");
+}
+
+fn write_calls_per_ms_padded(mut out: &mut String, count: u64, duration: Duration, width: usize) {
+    let ms = duration.as_secs_f64() * 1000.0;
+    if ms <= f64::EPSILON {
+        append!(out, "{:>width$}", "n/a");
+    } else {
+        append!(out, "{:>width$.2}", count as f64 / ms);
+    }
+}
+
+fn write_counter_total_padded(out: &mut String, name: &str, value: u64, width: usize) {
+    if name.ends_with("bytes") {
+        write_bytes_u64_padded(out, value, width);
+    } else {
+        write_count_padded(out, value, width);
+    }
+}
+
+fn write_counter_average_padded(mut out: &mut String, name: &str, value: f64, width: usize) {
+    if name.ends_with("bytes") {
+        if value >= 1024.0 * 1024.0 {
+            append!(out, "{:>width$.2} MiB", value / 1024.0 / 1024.0);
+        } else if value >= 1024.0 {
+            append!(out, "{:>width$.2} KiB", value / 1024.0);
+        } else {
+            append!(out, "{value:>width$.1} B");
+        }
+    } else {
+        append!(out, "{value:>width$.1}");
+    }
+}
+
+fn pad_recent(out: &mut String, before: usize, width: usize) {
+    let written = out.len() - before;
+    if written < width {
+        let value = out.split_off(before);
+        for _ in 0..(width - written) {
+            out.push(' ');
+        }
+        out.push_str(value.as_str());
+    }
 }
 
 fn write_bar(out: &mut String, percent: f64) {
@@ -528,6 +913,20 @@ fn duration_ratio(duration: Duration, baseline: Duration) -> f64 {
     }
 }
 
+fn counter_total(report: &ProfileReport<'_>, name: &str) -> u64 {
+    report
+        .counters
+        .map(|summary| summary.total(name))
+        .unwrap_or(0)
+}
+
+fn counter_total_matching(report: &ProfileReport<'_>, prefix: &str, suffix: &str) -> u64 {
+    report
+        .counters
+        .map(|summary| summary.total_matching(prefix, suffix))
+        .unwrap_or(0)
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
@@ -536,7 +935,9 @@ mod tests {
     use std::path::PathBuf;
     use std::time::Duration;
     use vize_carton::String;
-    use vize_carton::profiler::{ProfileEntry, ProfileSummary};
+    use vize_carton::profiler::{
+        AllocationSnapshot, CounterEntry, CounterSummary, ProfileEntry, ProfileSummary,
+    };
 
     #[test]
     #[allow(clippy::disallowed_macros)]
@@ -574,17 +975,67 @@ mod tests {
                     name: "atelier.sfc.parse",
                     count: 1,
                     total: Duration::from_millis(8),
+                    self_total: Duration::from_millis(7),
+                    child_total: Duration::from_millis(1),
                     average: Duration::from_millis(8),
+                    self_average: Duration::from_millis(7),
                     min: Duration::from_millis(8),
                     max: Duration::from_millis(8),
+                    self_min: Duration::from_millis(7),
+                    self_max: Duration::from_millis(7),
+                    p50: Duration::from_millis(8),
+                    p95: Duration::from_millis(8),
+                    p99: Duration::from_millis(8),
+                    samples_over_1ms: 1,
+                    samples_over_10ms: 0,
+                    samples_over_100ms: 0,
                 },
                 ProfileEntry {
                     name: "atelier.transform.element",
                     count: 24,
                     total: Duration::from_millis(6),
+                    self_total: Duration::from_millis(6),
+                    child_total: Duration::ZERO,
                     average: Duration::from_micros(250),
+                    self_average: Duration::from_micros(250),
                     min: Duration::from_micros(100),
                     max: Duration::from_micros(600),
+                    self_min: Duration::from_micros(100),
+                    self_max: Duration::from_micros(600),
+                    p50: Duration::from_micros(256),
+                    p95: Duration::from_micros(512),
+                    p99: Duration::from_micros(1024),
+                    samples_over_1ms: 0,
+                    samples_over_10ms: 0,
+                    samples_over_100ms: 0,
+                },
+            ],
+        };
+        let counters = CounterSummary {
+            entries: vec![
+                CounterEntry {
+                    name: "io.read.bytes",
+                    samples: 1,
+                    total: 2048,
+                    average: 2048.0,
+                    min: 2048,
+                    max: 2048,
+                },
+                CounterEntry {
+                    name: "io.read.calls",
+                    samples: 1,
+                    total: 1,
+                    average: 1.0,
+                    min: 1,
+                    max: 1,
+                },
+                CounterEntry {
+                    name: "syscall.fs.read_to_string.calls",
+                    samples: 1,
+                    total: 1,
+                    average: 1.0,
+                    min: 1,
+                    max: 1,
                 },
             ],
         };
@@ -597,6 +1048,21 @@ mod tests {
             slow_threshold: Duration::from_millis(30),
             throughput_bytes: Some(2048),
             operations: Some(&operations),
+            counters: Some(&counters),
+            allocations: Some(AllocationSnapshot {
+                alloc_calls: 40,
+                alloc_zeroed_calls: 2,
+                alloc_failures: 0,
+                alloc_zeroed_failures: 0,
+                alloc_bytes: 65_536,
+                alloc_zeroed_bytes: 4096,
+                dealloc_calls: 35,
+                dealloc_bytes: 49_152,
+                realloc_calls: 6,
+                realloc_failures: 0,
+                realloc_old_bytes: 12_288,
+                realloc_new_bytes: 24_576,
+            }),
             recommendations: &recommendations,
         };
 

--- a/crates/vize/src/commands/snapshots/vize__commands__profile__tests__profile_report_snapshot.snap
+++ b/crates/vize/src/commands/snapshots/vize__commands__profile__tests__profile_report_snapshot.snap
@@ -15,6 +15,30 @@ expression: render_profile_report(&report)
   cumulative work         42.000ms (0.8x wall)   [36mparallel/nested [0m
   slow files              1 / 1                  [33mthreshold hit   [0m
   internal spans          25 call(s), 14.000ms   [32mcaptured        [0m
+  internal self           13.000ms (92.9%)       [32mexclusive cost  [0m
+  nested span tax         1.000ms (7.1%)         [36mnested visible  [0m
+  alloc pressure          48 call(s),   92.00 KiB [32mtracked         [0m
+  heap delta                32.00 KiB (1962.7 B/call) [33mgrowth window   [0m
+  I/O bytes               read    2.00 KiB, wrote       0 B [32mtracked         [0m
+  syscall sites           1 call-site hit(s), 0 failed [32mclean           [0m
+
+[1mAllocation pressure[0m
+[90m  kind             calls       bytes          failures  note[0m
+  alloc                    42      68.00 KiB         0  [90mfresh allocations[0m
+  realloc in                6      12.00 KiB         0  [90mold layouts replaced[0m
+  realloc out               6      24.00 KiB         0  [90mnew requested sizes[0m
+  dealloc                  35      48.00 KiB         0  [90mreleased layouts[0m
+  net delta        n/a             32.00 KiB         0  profile-window requested minus released
+
+[1mI/O counters[0m
+[90m  counter                                samples    total        avg         min         max[0m
+  io.read.bytes                                1     2.00 KiB        2.00 KiB     2.00 KiB     2.00 KiB
+  io.read.calls                                1           1         1.0           1           1
+
+[1mSystem calls[0m
+[90m  std::fs call-site hits tracked by Vize; this is not a kernel trace.[0m
+[90m  counter                                samples    total        avg         min         max[0m
+  syscall.fs.read_to_string.calls              1           1         1.0           1           1
 
 [1mTiming breakdown[0m
 [90m  phase                         time        share  kind        note[0m
@@ -23,13 +47,23 @@ expression: render_profile_report(&report)
 
 [1mHot files[0m
 [90m  slow threshold: 30.000ms[0m
-[90m  #  total       share   breakdown                          size      rate       status       file[0m
-   1  [33m  31.000ms[0m    62.0%  parse     8.000ms   25.8%  compile  20.000ms   64.5%     2.00 KiB  64.52 KiB/s  [33mSLOW x1.0   [0m src/App.vue[90m  1 style block[0m
+[90m  #  total       share   breakdown                                      gap        size      rate       status       file[0m
+   1  [33m  31.000ms[0m    62.0%  parse     8.000ms   25.8%  compile  20.000ms   64.5%    3.000ms    9.7%     2.00 KiB  64.52 KiB/s  [33mSLOW x1.0   [0m src/App.vue[90m  1 style block[0m
 
 [1mInternal operations[0m
-[90m  operation                         count   total       share   avg         min         max       max/avg  status[0m
-  atelier.sfc.parse                     1     8.000ms    16.0%     8.000ms     8.000ms     8.000ms      1.0x  [32mok      [0m
-  atelier.transform.element            24     6.000ms    12.0%     0.250ms     0.100ms     0.600ms      2.4x  [32mok      [0m
+[90m  operation                         count   total       self        child       wall%   self%   avg         self/call   max/avg  status[0m
+  atelier.sfc.parse                     1     8.000ms     7.000ms     1.000ms    16.0%    14.0%     8.000ms     7.000ms      1.0x  [32mok      [0m
+  atelier.transform.element            24     6.000ms     6.000ms     0.000ms    12.0%    12.0%     0.250ms     0.250ms      2.4x  [32mok      [0m
+
+[1mTail latency[0m
+[90m  operation                         count   p50         p95         p99         min         max         >=1ms  >=10ms >=100ms[0m
+  atelier.sfc.parse                     1     8.000ms     8.000ms     8.000ms     8.000ms     8.000ms      1      0       0
+  atelier.transform.element            24     0.256ms     0.512ms     1.024ms     0.100ms     0.600ms      0      0       0
+
+[1mCall volume[0m
+[90m  operation                         count     calls/ms  total       self        avg         self/call[0m
+  atelier.transform.element              24       0.48     6.000ms     6.000ms     0.250ms     0.250ms
+  atelier.sfc.parse                       1       0.02     8.000ms     7.000ms     8.000ms     7.000ms
 
 [1mNotes[0m
   [36m- [0msrc/App.vue spent most of its time in compile; inspect template complexity.

--- a/crates/vize/src/main.rs
+++ b/crates/vize/src/main.rs
@@ -14,6 +14,10 @@ mod config;
 
 use clap::{Parser, Subcommand};
 
+#[global_allocator]
+static GLOBAL_ALLOCATOR: vize_carton::profiler::ProfilingAllocator =
+    vize_carton::profiler::ProfilingAllocator::new();
+
 #[derive(Parser)]
 #[command(name = "vize")]
 #[command(about = "High-performance Vue.js toolchain in Rust", long_about = None)]

--- a/crates/vize_carton/src/profiler.rs
+++ b/crates/vize_carton/src/profiler.rs
@@ -3,6 +3,8 @@
 //! Provides simple timing and metrics collection for tracking
 //! type checking and compilation performance.
 
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::cell::{Cell, RefCell};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 use std::time::{Duration, Instant};
@@ -10,6 +12,111 @@ use std::time::{Duration, Instant};
 use rustc_hash::FxHashMap;
 
 const PROFILER_SHARDS: usize = 32;
+const PROFILE_HISTOGRAM_BUCKETS: usize = 48;
+
+thread_local! {
+    static PROFILE_STACK: RefCell<std::vec::Vec<ProfileFrame>> = const { RefCell::new(std::vec::Vec::new()) };
+    static ALLOCATION_TRACKING_SUPPRESSION: Cell<u32> = const { Cell::new(0) };
+}
+
+static ALLOCATION_TRACKING_ENABLED: AtomicBool = AtomicBool::new(false);
+static ALLOC_CALLS: AtomicU64 = AtomicU64::new(0);
+static ALLOC_ZEROED_CALLS: AtomicU64 = AtomicU64::new(0);
+static ALLOC_FAILURES: AtomicU64 = AtomicU64::new(0);
+static ALLOC_ZEROED_FAILURES: AtomicU64 = AtomicU64::new(0);
+static ALLOC_BYTES: AtomicU64 = AtomicU64::new(0);
+static ALLOC_ZEROED_BYTES: AtomicU64 = AtomicU64::new(0);
+static DEALLOC_CALLS: AtomicU64 = AtomicU64::new(0);
+static DEALLOC_BYTES: AtomicU64 = AtomicU64::new(0);
+static REALLOC_CALLS: AtomicU64 = AtomicU64::new(0);
+static REALLOC_FAILURES: AtomicU64 = AtomicU64::new(0);
+static REALLOC_OLD_BYTES: AtomicU64 = AtomicU64::new(0);
+static REALLOC_NEW_BYTES: AtomicU64 = AtomicU64::new(0);
+
+#[derive(Debug)]
+struct AllocationTrackingPause;
+
+impl Drop for AllocationTrackingPause {
+    fn drop(&mut self) {
+        ALLOCATION_TRACKING_SUPPRESSION.with(|depth| {
+            depth.set(depth.get().saturating_sub(1));
+        });
+    }
+}
+
+#[inline]
+fn pause_allocation_tracking() -> AllocationTrackingPause {
+    ALLOCATION_TRACKING_SUPPRESSION.with(|depth| {
+        depth.set(depth.get().saturating_add(1));
+    });
+    AllocationTrackingPause
+}
+
+#[inline]
+fn allocation_tracking_is_suppressed() -> bool {
+    ALLOCATION_TRACKING_SUPPRESSION
+        .try_with(|depth| depth.get() > 0)
+        .unwrap_or(false)
+}
+
+#[inline]
+fn allocation_tracking_is_enabled() -> bool {
+    ALLOCATION_TRACKING_ENABLED.load(Ordering::Relaxed) && !allocation_tracking_is_suppressed()
+}
+
+#[derive(Debug)]
+struct ProfileFrame {
+    name: &'static str,
+    start: Instant,
+    child_duration: Duration,
+}
+
+/// RAII guard for nested global profiling spans.
+#[derive(Debug)]
+pub struct ProfileGuard {
+    profiler: &'static Profiler,
+    active: bool,
+}
+
+impl ProfileGuard {
+    #[inline]
+    fn start(profiler: &'static Profiler, name: &'static str) -> Self {
+        let _allocation_tracking = pause_allocation_tracking();
+        PROFILE_STACK.with(|stack| {
+            stack.borrow_mut().push(ProfileFrame {
+                name,
+                start: Instant::now(),
+                child_duration: Duration::ZERO,
+            });
+        });
+        Self {
+            profiler,
+            active: true,
+        }
+    }
+}
+
+impl Drop for ProfileGuard {
+    fn drop(&mut self) {
+        if !self.active {
+            return;
+        }
+
+        PROFILE_STACK.with(|stack| {
+            let mut stack = stack.borrow_mut();
+            let Some(frame) = stack.pop() else {
+                return;
+            };
+
+            let duration = frame.start.elapsed();
+            if let Some(parent) = stack.last_mut() {
+                parent.child_duration += duration;
+            }
+            self.profiler
+                .record_sample_enabled(frame.name, duration, frame.child_duration);
+        });
+    }
+}
 
 /// A lightweight timer for measuring durations.
 #[derive(Debug)]
@@ -54,10 +161,22 @@ pub struct Metrics {
     pub count: u64,
     /// Total duration across all calls
     pub total_duration: Duration,
+    /// Total duration excluding nested child spans
+    pub self_duration: Duration,
+    /// Total nested child span duration
+    pub child_duration: Duration,
     /// Minimum duration
     pub min_duration: Duration,
     /// Maximum duration
     pub max_duration: Duration,
+    /// Minimum self duration
+    pub min_self_duration: Duration,
+    /// Maximum self duration
+    pub max_self_duration: Duration,
+    histogram: [u64; PROFILE_HISTOGRAM_BUCKETS],
+    samples_over_1ms: u64,
+    samples_over_10ms: u64,
+    samples_over_100ms: u64,
 }
 
 impl Metrics {
@@ -66,31 +185,142 @@ impl Metrics {
         Self {
             count: 0,
             total_duration: Duration::ZERO,
+            self_duration: Duration::ZERO,
+            child_duration: Duration::ZERO,
             min_duration: Duration::MAX,
             max_duration: Duration::ZERO,
+            min_self_duration: Duration::MAX,
+            max_self_duration: Duration::ZERO,
+            histogram: [0; PROFILE_HISTOGRAM_BUCKETS],
+            samples_over_1ms: 0,
+            samples_over_10ms: 0,
+            samples_over_100ms: 0,
         }
     }
 
     /// Record a duration.
     pub fn record(&mut self, duration: Duration) {
+        self.record_with_child(duration, Duration::ZERO);
+    }
+
+    /// Record a duration and the already-accounted nested child span duration.
+    pub fn record_with_child(&mut self, duration: Duration, child_duration: Duration) {
+        let self_duration = duration.saturating_sub(child_duration);
+
         self.count += 1;
         self.total_duration += duration;
+        self.self_duration += self_duration;
+        self.child_duration += child_duration;
         self.min_duration = self.min_duration.min(duration);
         self.max_duration = self.max_duration.max(duration);
+        self.min_self_duration = self.min_self_duration.min(self_duration);
+        self.max_self_duration = self.max_self_duration.max(self_duration);
+        self.histogram[duration_bucket(duration)] += 1;
+
+        if duration >= Duration::from_millis(1) {
+            self.samples_over_1ms += 1;
+        }
+        if duration >= Duration::from_millis(10) {
+            self.samples_over_10ms += 1;
+        }
+        if duration >= Duration::from_millis(100) {
+            self.samples_over_100ms += 1;
+        }
     }
 
     /// Get the average duration.
     pub fn average(&self) -> Duration {
+        average_duration(self.total_duration, self.count)
+    }
+
+    /// Get the average self duration.
+    pub fn self_average(&self) -> Duration {
+        average_duration(self.self_duration, self.count)
+    }
+
+    /// Estimate a percentile from the logarithmic duration histogram.
+    pub fn percentile(&self, percentile: f64) -> Duration {
         if self.count == 0 {
-            Duration::ZERO
-        } else {
-            let nanos = self.total_duration.as_nanos() / u128::from(self.count);
-            Duration::from_nanos(nanos.try_into().unwrap_or(u64::MAX))
+            return Duration::ZERO;
         }
+
+        let target = ((self.count as f64) * percentile.clamp(0.0, 1.0)).ceil() as u64;
+        let target = target.max(1);
+        let mut seen = 0u64;
+        for (index, count) in self.histogram.iter().enumerate() {
+            seen += count;
+            if seen >= target {
+                return bucket_upper_bound(index);
+            }
+        }
+        bucket_upper_bound(PROFILE_HISTOGRAM_BUCKETS - 1)
+    }
+
+    /// Number of samples at or above one millisecond.
+    pub fn samples_over_1ms(&self) -> u64 {
+        self.samples_over_1ms
+    }
+
+    /// Number of samples at or above ten milliseconds.
+    pub fn samples_over_10ms(&self) -> u64 {
+        self.samples_over_10ms
+    }
+
+    /// Number of samples at or above one hundred milliseconds.
+    pub fn samples_over_100ms(&self) -> u64 {
+        self.samples_over_100ms
     }
 }
 
 impl Default for Metrics {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Monotonic counter metrics for non-duration profile signals.
+#[derive(Debug, Clone)]
+pub struct CounterMetrics {
+    /// Number of samples recorded for this counter.
+    pub samples: u64,
+    /// Sum of all recorded values.
+    pub total: u64,
+    /// Smallest recorded value.
+    pub min: u64,
+    /// Largest recorded value.
+    pub max: u64,
+}
+
+impl CounterMetrics {
+    /// Create new counter metrics.
+    pub fn new() -> Self {
+        Self {
+            samples: 0,
+            total: 0,
+            min: u64::MAX,
+            max: 0,
+        }
+    }
+
+    /// Record a counter sample.
+    pub fn record(&mut self, value: u64) {
+        self.samples = self.samples.saturating_add(1);
+        self.total = self.total.saturating_add(value);
+        self.min = self.min.min(value);
+        self.max = self.max.max(value);
+    }
+
+    /// Get the average recorded value.
+    pub fn average(&self) -> f64 {
+        if self.samples == 0 {
+            0.0
+        } else {
+            self.total as f64 / self.samples as f64
+        }
+    }
+}
+
+impl Default for CounterMetrics {
     fn default() -> Self {
         Self::new()
     }
@@ -102,6 +332,8 @@ pub struct Profiler {
     /// Metrics by operation name, split into shards to keep parallel profile runs from
     /// funnelling every span through the same lock.
     metrics: [RwLock<FxHashMap<&'static str, Metrics>>; PROFILER_SHARDS],
+    /// Non-duration counters by name.
+    counters: [RwLock<FxHashMap<&'static str, CounterMetrics>>; PROFILER_SHARDS],
     /// Whether profiling is enabled
     enabled: AtomicBool,
 }
@@ -111,6 +343,7 @@ impl Profiler {
     pub fn new() -> Self {
         Self {
             metrics: std::array::from_fn(|_| RwLock::new(FxHashMap::default())),
+            counters: std::array::from_fn(|_| RwLock::new(FxHashMap::default())),
             enabled: AtomicBool::new(false),
         }
     }
@@ -124,12 +357,15 @@ impl Profiler {
 
     /// Enable profiling.
     pub fn enable(&self) {
+        reset_allocation_counters();
+        ALLOCATION_TRACKING_ENABLED.store(true, Ordering::Relaxed);
         self.enabled.store(true, Ordering::Relaxed);
     }
 
     /// Disable profiling.
     pub fn disable(&self) {
         self.enabled.store(false, Ordering::Relaxed);
+        ALLOCATION_TRACKING_ENABLED.store(false, Ordering::Relaxed);
     }
 
     /// Check if profiling is enabled.
@@ -160,8 +396,132 @@ impl Profiler {
     /// Record a duration after the caller has already checked that profiling is enabled.
     #[doc(hidden)]
     pub fn record_enabled(&self, name: &'static str, duration: Duration) {
+        self.record_sample_enabled(name, duration, Duration::ZERO);
+    }
+
+    /// Start a nested profiling span on the global profiler.
+    #[inline]
+    pub fn global_span(&'static self, name: &'static str) -> Option<ProfileGuard> {
+        if self.is_enabled() {
+            Some(ProfileGuard::start(self, name))
+        } else {
+            None
+        }
+    }
+
+    /// Record a duration and child duration after the caller has already checked profiling.
+    #[doc(hidden)]
+    pub fn record_sample_enabled(
+        &self,
+        name: &'static str,
+        duration: Duration,
+        child_duration: Duration,
+    ) {
+        let _allocation_tracking = pause_allocation_tracking();
         let mut metrics = self.metrics_write(Self::shard_index(name));
-        metrics.entry(name).or_default().record(duration);
+        metrics
+            .entry(name)
+            .or_default()
+            .record_with_child(duration, child_duration);
+    }
+
+    /// Record a non-duration counter sample.
+    pub fn record_counter(&self, name: &'static str, value: u64) {
+        if !self.is_enabled() {
+            return;
+        }
+
+        self.record_counter_enabled(name, value);
+    }
+
+    /// Record a counter after the caller has already checked profiling.
+    #[doc(hidden)]
+    pub fn record_counter_enabled(&self, name: &'static str, value: u64) {
+        let _allocation_tracking = pause_allocation_tracking();
+        let mut counters = self.counters_write(Self::shard_index(name));
+        counters.entry(name).or_default().record(value);
+    }
+
+    /// Record a successful `std::fs::read_to_string` call.
+    pub fn record_fs_read_to_string(&self, bytes: usize) {
+        if !self.is_enabled() {
+            return;
+        }
+
+        self.record_counter_enabled("io.read.calls", 1);
+        self.record_counter_enabled("io.read.bytes", bytes as u64);
+        self.record_counter_enabled("syscall.fs.read_to_string.calls", 1);
+    }
+
+    /// Record a failed `std::fs::read_to_string` call.
+    pub fn record_fs_read_to_string_failure(&self) {
+        if !self.is_enabled() {
+            return;
+        }
+
+        self.record_counter_enabled("io.read.calls", 1);
+        self.record_counter_enabled("io.read.failures", 1);
+        self.record_counter_enabled("syscall.fs.read_to_string.calls", 1);
+        self.record_counter_enabled("syscall.fs.read_to_string.failures", 1);
+    }
+
+    /// Record a successful `std::fs::write` call.
+    pub fn record_fs_write(&self, bytes: usize) {
+        if !self.is_enabled() {
+            return;
+        }
+
+        self.record_counter_enabled("io.write.calls", 1);
+        self.record_counter_enabled("io.write.attempted_bytes", bytes as u64);
+        self.record_counter_enabled("io.write.bytes", bytes as u64);
+        self.record_counter_enabled("syscall.fs.write.calls", 1);
+    }
+
+    /// Record a failed `std::fs::write` call.
+    pub fn record_fs_write_failure(&self, bytes: usize) {
+        if !self.is_enabled() {
+            return;
+        }
+
+        self.record_counter_enabled("io.write.calls", 1);
+        self.record_counter_enabled("io.write.attempted_bytes", bytes as u64);
+        self.record_counter_enabled("io.write.failures", 1);
+        self.record_counter_enabled("syscall.fs.write.calls", 1);
+        self.record_counter_enabled("syscall.fs.write.failures", 1);
+    }
+
+    /// Record a successful `std::fs::create_dir_all` call.
+    pub fn record_fs_create_dir_all(&self) {
+        if self.is_enabled() {
+            self.record_counter_enabled("syscall.fs.create_dir_all.calls", 1);
+        }
+    }
+
+    /// Record a failed `std::fs::create_dir_all` call.
+    pub fn record_fs_create_dir_all_failure(&self) {
+        if !self.is_enabled() {
+            return;
+        }
+
+        self.record_counter_enabled("syscall.fs.create_dir_all.calls", 1);
+        self.record_counter_enabled("syscall.fs.create_dir_all.failures", 1);
+    }
+
+    /// Record a successful `std::fs::remove_dir_all` call.
+    pub fn record_fs_remove_dir_all(&self) {
+        if self.is_enabled() {
+            self.record_counter_enabled("syscall.fs.remove_dir_all.calls", 1);
+        }
+    }
+
+    /// Record a failed `std::fs::remove_dir_all` call.
+    pub fn record_fs_remove_dir_all_failure(&self) {
+        if !self.is_enabled() {
+            return;
+        }
+
+        self.record_counter_enabled("syscall.fs.remove_dir_all.calls", 1);
+        self.record_counter_enabled("syscall.fs.remove_dir_all.failures", 1);
     }
 
     /// Get metrics for the given operation.
@@ -173,6 +533,7 @@ impl Profiler {
 
     /// Get all metrics.
     pub fn all(&self) -> FxHashMap<&'static str, Metrics> {
+        let _allocation_tracking = pause_allocation_tracking();
         let mut all = FxHashMap::default();
         for shard in &self.metrics {
             let metrics = shard
@@ -189,7 +550,14 @@ impl Profiler {
 
     /// Clear all metrics.
     pub fn clear(&self) {
+        let _allocation_tracking = pause_allocation_tracking();
         for shard in &self.metrics {
+            shard
+                .write()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .clear();
+        }
+        for shard in &self.counters {
             shard
                 .write()
                 .unwrap_or_else(|poisoned| poisoned.into_inner())
@@ -199,6 +567,7 @@ impl Profiler {
 
     /// Generate a summary report.
     pub fn summary(&self) -> ProfileSummary {
+        let _allocation_tracking = pause_allocation_tracking();
         let mut entries = Vec::new();
         for shard in &self.metrics {
             let metrics = shard
@@ -209,9 +578,20 @@ impl Profiler {
                 name,
                 count: m.count,
                 total: m.total_duration,
+                self_total: m.self_duration,
+                child_total: m.child_duration,
                 average: m.average(),
+                self_average: m.self_average(),
                 min: m.min_duration,
                 max: m.max_duration,
+                self_min: m.min_self_duration,
+                self_max: m.max_self_duration,
+                p50: m.percentile(0.50),
+                p95: m.percentile(0.95),
+                p99: m.percentile(0.99),
+                samples_over_1ms: m.samples_over_1ms(),
+                samples_over_10ms: m.samples_over_10ms(),
+                samples_over_100ms: m.samples_over_100ms(),
             }));
         }
 
@@ -219,6 +599,30 @@ impl Profiler {
         entries.sort_by_key(|entry| std::cmp::Reverse(entry.total));
 
         ProfileSummary { entries }
+    }
+
+    /// Generate a counter summary report.
+    pub fn counter_summary(&self) -> CounterSummary {
+        let _allocation_tracking = pause_allocation_tracking();
+        let mut entries = Vec::new();
+        for shard in &self.counters {
+            let counters = shard
+                .read()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            entries.reserve(counters.len());
+            entries.extend(counters.iter().map(|(name, counter)| CounterEntry {
+                name,
+                samples: counter.samples,
+                total: counter.total,
+                average: counter.average(),
+                min: if counter.samples == 0 { 0 } else { counter.min },
+                max: counter.max,
+            }));
+        }
+
+        entries.sort_by(|left, right| left.name.cmp(right.name));
+
+        CounterSummary { entries }
     }
 
     #[inline]
@@ -234,6 +638,16 @@ impl Profiler {
         shard: usize,
     ) -> RwLockWriteGuard<'_, FxHashMap<&'static str, Metrics>> {
         self.metrics[shard]
+            .write()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
+    #[inline]
+    fn counters_write(
+        &self,
+        shard: usize,
+    ) -> RwLockWriteGuard<'_, FxHashMap<&'static str, CounterMetrics>> {
+        self.counters[shard]
             .write()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
     }
@@ -279,24 +693,70 @@ impl ProfileSummary {
     }
 }
 
+/// A summary of non-duration profile counters.
+#[derive(Debug)]
+pub struct CounterSummary {
+    /// Counter entries sorted by name.
+    pub entries: Vec<CounterEntry>,
+}
+
+impl CounterSummary {
+    /// Get a counter total by name.
+    pub fn total(&self, name: &str) -> u64 {
+        self.entries
+            .iter()
+            .find(|entry| entry.name == name)
+            .map(|entry| entry.total)
+            .unwrap_or(0)
+    }
+
+    /// Sum counter totals matching a prefix and suffix.
+    pub fn total_matching(&self, prefix: &str, suffix: &str) -> u64 {
+        self.entries
+            .iter()
+            .filter(|entry| entry.name.starts_with(prefix) && entry.name.ends_with(suffix))
+            .map(|entry| entry.total)
+            .sum()
+    }
+}
+
+/// A single non-duration counter entry.
+#[derive(Debug)]
+pub struct CounterEntry {
+    /// Counter name.
+    pub name: &'static str,
+    /// Number of samples recorded.
+    pub samples: u64,
+    /// Sum of all recorded samples.
+    pub total: u64,
+    /// Average value per sample.
+    pub average: f64,
+    /// Smallest sample.
+    pub min: u64,
+    /// Largest sample.
+    pub max: u64,
+}
+
 impl std::fmt::Display for ProfileSummary {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         writeln!(f, "Profile Summary:")?;
         writeln!(
             f,
-            "{:<30} {:>8} {:>12} {:>12} {:>12} {:>12}",
-            "Operation", "Count", "Total ms", "Avg ms", "Min ms", "Max ms"
+            "{:<30} {:>8} {:>12} {:>12} {:>12} {:>12} {:>12} {:>12}",
+            "Operation", "Count", "Total ms", "Self ms", "Avg ms", "P95 ms", "Min ms", "Max ms"
         )?;
-        writeln!(f, "{}", "-".repeat(88))?;
+        writeln!(f, "{}", "-".repeat(114))?;
 
         for entry in &self.entries {
             writeln!(
                 f,
-                "{:<30} {:>8} {:>12.3} {:>12.3} {:>12.3} {:>12.3}",
+                "{:<30} {:>8} {:>12.3} {:>12.3} {:>12.3} {:>12.3} {:>12.3} {:>12.3}",
                 entry.name,
                 entry.count,
                 duration_ms(entry.total),
+                duration_ms(entry.self_total),
                 duration_ms(entry.average),
+                duration_ms(entry.p95),
                 duration_ms(entry.min),
                 duration_ms(entry.max)
             )?;
@@ -320,12 +780,223 @@ pub struct ProfileEntry {
     pub count: u64,
     /// Total duration
     pub total: Duration,
+    /// Total self duration excluding nested child spans
+    pub self_total: Duration,
+    /// Total nested child duration
+    pub child_total: Duration,
     /// Average duration
     pub average: Duration,
+    /// Average self duration
+    pub self_average: Duration,
     /// Minimum duration
     pub min: Duration,
     /// Maximum duration
     pub max: Duration,
+    /// Minimum self duration
+    pub self_min: Duration,
+    /// Maximum self duration
+    pub self_max: Duration,
+    /// Approximate p50 duration
+    pub p50: Duration,
+    /// Approximate p95 duration
+    pub p95: Duration,
+    /// Approximate p99 duration
+    pub p99: Duration,
+    /// Samples at or above 1ms
+    pub samples_over_1ms: u64,
+    /// Samples at or above 10ms
+    pub samples_over_10ms: u64,
+    /// Samples at or above 100ms
+    pub samples_over_100ms: u64,
+}
+
+/// Allocation counters captured for a profile window.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct AllocationSnapshot {
+    /// Successful `alloc` calls.
+    pub alloc_calls: u64,
+    /// Successful `alloc_zeroed` calls.
+    pub alloc_zeroed_calls: u64,
+    /// Failed `alloc` calls.
+    pub alloc_failures: u64,
+    /// Failed `alloc_zeroed` calls.
+    pub alloc_zeroed_failures: u64,
+    /// Bytes requested through successful `alloc` calls.
+    pub alloc_bytes: u64,
+    /// Bytes requested through successful `alloc_zeroed` calls.
+    pub alloc_zeroed_bytes: u64,
+    /// `dealloc` calls.
+    pub dealloc_calls: u64,
+    /// Bytes released through `dealloc`.
+    pub dealloc_bytes: u64,
+    /// Successful `realloc` calls.
+    pub realloc_calls: u64,
+    /// Failed `realloc` calls.
+    pub realloc_failures: u64,
+    /// Old layout bytes passed to successful `realloc` calls.
+    pub realloc_old_bytes: u64,
+    /// New size bytes requested by successful `realloc` calls.
+    pub realloc_new_bytes: u64,
+}
+
+impl AllocationSnapshot {
+    /// Allocation-like calls that requested new storage.
+    pub fn allocation_calls(&self) -> u64 {
+        self.alloc_calls
+            .saturating_add(self.alloc_zeroed_calls)
+            .saturating_add(self.realloc_calls)
+    }
+
+    /// Total allocation failures.
+    pub fn allocation_failures(&self) -> u64 {
+        self.alloc_failures
+            .saturating_add(self.alloc_zeroed_failures)
+            .saturating_add(self.realloc_failures)
+    }
+
+    /// Bytes requested through allocation-like calls.
+    pub fn requested_bytes(&self) -> u64 {
+        self.alloc_bytes
+            .saturating_add(self.alloc_zeroed_bytes)
+            .saturating_add(self.realloc_new_bytes)
+    }
+
+    /// Bytes released or replaced in this profile window.
+    pub fn released_bytes(&self) -> u64 {
+        self.dealloc_bytes.saturating_add(self.realloc_old_bytes)
+    }
+
+    /// Approximate heap delta during this profile window.
+    pub fn net_bytes(&self) -> i128 {
+        i128::from(self.requested_bytes()) - i128::from(self.released_bytes())
+    }
+
+    /// Average requested bytes per allocation-like call.
+    pub fn requested_bytes_per_call(&self) -> f64 {
+        let calls = self.allocation_calls();
+        if calls == 0 {
+            0.0
+        } else {
+            self.requested_bytes() as f64 / calls as f64
+        }
+    }
+}
+
+/// Global allocator wrapper that records allocation pressure while profiling is enabled.
+#[derive(Debug)]
+pub struct ProfilingAllocator<A = System> {
+    inner: A,
+}
+
+impl ProfilingAllocator<System> {
+    /// Create a profiling allocator backed by [`System`].
+    pub const fn new() -> Self {
+        Self { inner: System }
+    }
+}
+
+impl Default for ProfilingAllocator<System> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<A> ProfilingAllocator<A> {
+    /// Wrap an existing allocator.
+    pub const fn from_allocator(inner: A) -> Self {
+        Self { inner }
+    }
+}
+
+// SAFETY: Every method delegates to the wrapped allocator with the original
+// layout and pointer arguments, then updates lock-free counters only after the
+// allocator call has returned.
+unsafe impl<A: GlobalAlloc> GlobalAlloc for ProfilingAllocator<A> {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        // SAFETY: This forwards the caller-provided layout to the wrapped allocator.
+        let ptr = unsafe { self.inner.alloc(layout) };
+        if allocation_tracking_is_enabled() {
+            if ptr.is_null() {
+                ALLOC_FAILURES.fetch_add(1, Ordering::Relaxed);
+            } else {
+                ALLOC_CALLS.fetch_add(1, Ordering::Relaxed);
+                ALLOC_BYTES.fetch_add(layout.size() as u64, Ordering::Relaxed);
+            }
+        }
+        ptr
+    }
+
+    unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+        // SAFETY: This forwards the caller-provided layout to the wrapped allocator.
+        let ptr = unsafe { self.inner.alloc_zeroed(layout) };
+        if allocation_tracking_is_enabled() {
+            if ptr.is_null() {
+                ALLOC_ZEROED_FAILURES.fetch_add(1, Ordering::Relaxed);
+            } else {
+                ALLOC_ZEROED_CALLS.fetch_add(1, Ordering::Relaxed);
+                ALLOC_ZEROED_BYTES.fetch_add(layout.size() as u64, Ordering::Relaxed);
+            }
+        }
+        ptr
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        if allocation_tracking_is_enabled() {
+            DEALLOC_CALLS.fetch_add(1, Ordering::Relaxed);
+            DEALLOC_BYTES.fetch_add(layout.size() as u64, Ordering::Relaxed);
+        }
+        // SAFETY: This forwards the caller-provided pointer and layout to the wrapped allocator.
+        unsafe { self.inner.dealloc(ptr, layout) };
+    }
+
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        // SAFETY: This forwards the caller-provided pointer, layout, and new size.
+        let new_ptr = unsafe { self.inner.realloc(ptr, layout, new_size) };
+        if allocation_tracking_is_enabled() {
+            if new_ptr.is_null() {
+                REALLOC_FAILURES.fetch_add(1, Ordering::Relaxed);
+            } else {
+                REALLOC_CALLS.fetch_add(1, Ordering::Relaxed);
+                REALLOC_OLD_BYTES.fetch_add(layout.size() as u64, Ordering::Relaxed);
+                REALLOC_NEW_BYTES.fetch_add(new_size as u64, Ordering::Relaxed);
+            }
+        }
+        new_ptr
+    }
+}
+
+/// Reset global allocation counters.
+pub fn reset_allocation_counters() {
+    ALLOC_CALLS.store(0, Ordering::Relaxed);
+    ALLOC_ZEROED_CALLS.store(0, Ordering::Relaxed);
+    ALLOC_FAILURES.store(0, Ordering::Relaxed);
+    ALLOC_ZEROED_FAILURES.store(0, Ordering::Relaxed);
+    ALLOC_BYTES.store(0, Ordering::Relaxed);
+    ALLOC_ZEROED_BYTES.store(0, Ordering::Relaxed);
+    DEALLOC_CALLS.store(0, Ordering::Relaxed);
+    DEALLOC_BYTES.store(0, Ordering::Relaxed);
+    REALLOC_CALLS.store(0, Ordering::Relaxed);
+    REALLOC_FAILURES.store(0, Ordering::Relaxed);
+    REALLOC_OLD_BYTES.store(0, Ordering::Relaxed);
+    REALLOC_NEW_BYTES.store(0, Ordering::Relaxed);
+}
+
+/// Capture allocation counters for the current profile window.
+pub fn allocation_snapshot() -> AllocationSnapshot {
+    AllocationSnapshot {
+        alloc_calls: ALLOC_CALLS.load(Ordering::Relaxed),
+        alloc_zeroed_calls: ALLOC_ZEROED_CALLS.load(Ordering::Relaxed),
+        alloc_failures: ALLOC_FAILURES.load(Ordering::Relaxed),
+        alloc_zeroed_failures: ALLOC_ZEROED_FAILURES.load(Ordering::Relaxed),
+        alloc_bytes: ALLOC_BYTES.load(Ordering::Relaxed),
+        alloc_zeroed_bytes: ALLOC_ZEROED_BYTES.load(Ordering::Relaxed),
+        dealloc_calls: DEALLOC_CALLS.load(Ordering::Relaxed),
+        dealloc_bytes: DEALLOC_BYTES.load(Ordering::Relaxed),
+        realloc_calls: REALLOC_CALLS.load(Ordering::Relaxed),
+        realloc_failures: REALLOC_FAILURES.load(Ordering::Relaxed),
+        realloc_old_bytes: REALLOC_OLD_BYTES.load(Ordering::Relaxed),
+        realloc_new_bytes: REALLOC_NEW_BYTES.load(Ordering::Relaxed),
+    }
 }
 
 /// Global profiler instance.
@@ -344,14 +1015,42 @@ macro_rules! profile {
         let name: &'static str = $name;
         let profiler = $crate::profiler::global_profiler();
         if profiler.is_enabled() {
-            let timer = $crate::profiler::Timer::start(name);
-            let result = $block;
-            profiler.record_enabled(name, timer.elapsed());
-            result
+            let _profile_guard = profiler.global_span(name);
+            $block
         } else {
             $block
         }
     }};
+}
+
+#[inline]
+fn average_duration(duration: Duration, count: u64) -> Duration {
+    if count == 0 {
+        Duration::ZERO
+    } else {
+        let nanos = duration.as_nanos() / u128::from(count);
+        Duration::from_nanos(nanos.try_into().unwrap_or(u64::MAX))
+    }
+}
+
+#[inline]
+fn duration_bucket(duration: Duration) -> usize {
+    let mut upper_micros = 1u128;
+    let micros = duration.as_micros();
+    let mut bucket = 0usize;
+    while bucket + 1 < PROFILE_HISTOGRAM_BUCKETS && micros > upper_micros {
+        upper_micros <<= 1;
+        bucket += 1;
+    }
+    bucket
+}
+
+#[inline]
+fn bucket_upper_bound(bucket: usize) -> Duration {
+    if bucket >= 63 {
+        return Duration::MAX;
+    }
+    Duration::from_micros(1u64 << bucket)
 }
 
 /// Cache statistics.
@@ -464,6 +1163,7 @@ mod tests {
             total_duration: Duration::from_secs(10),
             min_duration: Duration::ZERO,
             max_duration: Duration::from_secs(10),
+            ..Metrics::new()
         };
 
         assert_eq!(
@@ -472,6 +1172,39 @@ mod tests {
                 (Duration::from_secs(10).as_nanos() / u128::from(metrics.count)) as u64
             )
         );
+    }
+
+    #[test]
+    fn metrics_track_self_child_and_tail_counts() {
+        let mut metrics = Metrics::new();
+
+        metrics.record_with_child(Duration::from_millis(10), Duration::from_millis(4));
+        metrics.record_with_child(Duration::from_micros(500), Duration::from_micros(125));
+
+        assert_eq!(metrics.count, 2);
+        assert_eq!(metrics.self_duration, Duration::from_micros(6_375));
+        assert_eq!(metrics.child_duration, Duration::from_micros(4_125));
+        assert_eq!(metrics.self_average(), Duration::from_nanos(3_187_500));
+        assert_eq!(metrics.samples_over_1ms(), 1);
+        assert_eq!(metrics.samples_over_10ms(), 1);
+        assert_eq!(metrics.samples_over_100ms(), 0);
+        assert!(metrics.percentile(0.95) >= Duration::from_millis(10));
+    }
+
+    #[test]
+    fn profiler_tracks_counters() {
+        let profiler = Profiler::enabled();
+
+        profiler.record_counter("io.read.bytes", 10);
+        profiler.record_counter("io.read.bytes", 20);
+        profiler.record_counter("io.read.calls", 1);
+
+        let summary = profiler.counter_summary();
+        profiler.disable();
+
+        assert_eq!(summary.total("io.read.bytes"), 30);
+        assert_eq!(summary.total("io.read.calls"), 1);
+        assert_eq!(summary.total_matching("io.", ".bytes"), 30);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add profile-mode allocation telemetry via a global profiling allocator with lock-free counters
- add profiler counter summaries for I/O bytes/calls and std::fs/socket call-site hits
- expand the profile report with allocation pressure, I/O counters, system-call counters, self/child time, tail latency, and call-volume tables
- instrument build, fmt, lint, and check profile paths for file reads, writes, profile artifact writes, tsconfig/d.ts/Nuxt reads, and socket request traffic

## Validation

- `cargo test -p vize_carton profiler`
- `INSTA_UPDATE=always cargo test -p vize profile_report_snapshot`
- `cargo test -p vize`
- `cargo fmt --all -- --check`
- `cargo clippy -p vize -- -D warnings`

Rust workspace tests are intentionally left to GitHub Actions for this PR.