### PR TITLE
fix(parser): recover unclosed comments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3413,6 +3413,7 @@ version = "0.96.0"
 dependencies = [
  "compact_str 0.9.0",
  "htmlize",
+ "insta",
  "serde",
  "thiserror",
  "vize_carton",

--- a/crates/vize_armature/Cargo.toml
+++ b/crates/vize_armature/Cargo.toml
@@ -14,3 +14,6 @@ compact_str = { workspace = true }
 serde = { workspace = true }
 thiserror = { workspace = true }
 htmlize = { workspace = true }
+
+[dev-dependencies]
+insta = { workspace = true }

--- a/crates/vize_armature/src/parser/element.rs
+++ b/crates/vize_armature/src/parser/element.rs
@@ -345,7 +345,9 @@ impl<'a> Parser<'a> {
     /// Process comment
     pub(super) fn on_comment_impl(&mut self, start: usize, end: usize) {
         let content = self.get_source(start, end);
-        let loc = self.create_loc(start - 4, end + 3); // Include <!-- and -->
+        let loc_start = start.saturating_sub(4);
+        let loc_end = end.saturating_add(3).min(self.source.len());
+        let loc = self.create_loc(loc_start, loc_end); // Include <!-- and --> when present.
 
         // Check for @vize: directive
         let directive = parse_vize_directive(content, loc.start.line, loc.start.offset);
@@ -399,6 +401,10 @@ impl<'a> Parser<'a> {
             ),
             ErrorCode::EofInTag => Some(
                 "Unexpected end of input inside a tag; inferred the missing tag close so parsing can continue."
+                    .into(),
+            ),
+            ErrorCode::EofInComment => Some(
+                "Comment is missing its closing `-->`; preserving the unfinished comment so parsing can finish."
                     .into(),
             ),
             ErrorCode::InvalidFirstCharacterOfTagName => Some(

--- a/crates/vize_armature/src/parser/tests.rs
+++ b/crates/vize_armature/src/parser/tests.rs
@@ -4,9 +4,24 @@ use super::{parse, parse_with_options};
 use vize_carton::Bump;
 use vize_relief::{
     ast::{ElementType, ExpressionNode, Namespace, PropNode, TemplateChildNode},
-    errors::ErrorCode,
+    errors::{CompilerError, ErrorCode},
     options::ParserOptions,
 };
+
+fn error_recovery_snapshot<'a>(
+    errors: &'a [CompilerError],
+) -> std::vec::Vec<(ErrorCode, &'a str, &'a str)> {
+    errors
+        .iter()
+        .map(|error| {
+            (
+                error.code,
+                error.message.as_str(),
+                error.loc.as_ref().map_or("", |loc| loc.source.as_str()),
+            )
+        })
+        .collect()
+}
 
 #[test]
 fn test_parse_simple_element() {
@@ -891,6 +906,30 @@ fn test_parse_incorrectly_closed_comment_reports_error_and_continues() {
     assert_eq!(root.children.len(), 2);
     assert!(matches!(&root.children[0], TemplateChildNode::Comment(_)));
     assert!(matches!(&root.children[1], TemplateChildNode::Element(_)));
+}
+
+#[test]
+fn test_parse_unclosed_comment_reports_error_without_losing_comment() {
+    let allocator = Bump::new();
+    let (root, errors) = parse(&allocator, "before<!-- open");
+
+    insta::assert_debug_snapshot!(error_recovery_snapshot(&errors), @r###"
+    [
+        (
+            EofInComment,
+            "Comment is missing its closing `-->`; preserving the unfinished comment so parsing can finish.",
+            "<",
+        ),
+    ]
+    "###);
+    assert_eq!(root.children.len(), 2);
+    assert!(matches!(&root.children[0], TemplateChildNode::Text(_)));
+    if let TemplateChildNode::Comment(comment) = &root.children[1] {
+        assert_eq!(comment.content.as_str(), " open");
+        assert_eq!(comment.loc.source.as_str(), "<!-- open");
+    } else {
+        panic!("Expected recovered comment");
+    }
 }
 
 #[test]

--- a/crates/vize_armature/src/tokenizer/states.rs
+++ b/crates/vize_armature/src/tokenizer/states.rs
@@ -64,7 +64,11 @@ impl<'a, C: Callbacks> Tokenizer<'a, C> {
                 Some(Sequence::CdataEnd) => ErrorCode::EofInCdata,
                 _ => ErrorCode::EofInComment,
             };
-            self.callbacks.on_error(code, self.index);
+            let error_index = match self.current_sequence {
+                Some(Sequence::CdataEnd) => self.section_start.saturating_sub(9),
+                _ => self.section_start.saturating_sub(4),
+            };
+            self.callbacks.on_error(code, error_index);
             match self.current_sequence {
                 Some(Sequence::CdataEnd) => {
                     self.callbacks.on_cdata(self.section_start, self.index);


### PR DESCRIPTION
## Summary
- clamp recovered comment locations when a comment reaches EOF without closing marker
- point EOF-in-comment diagnostics at the comment opener and add a recovery-specific message
- add an inline snapshot regression test for preserving unfinished comments

## Validation
- cargo fmt --all
- cargo test -p vize_armature test_parse_unclosed_comment_reports_error_without_losing_comment
- full Rust/JS/playground validation is left to GitHub Actions per maintainer preference
