### PR TITLE
fix(cli): avoid retaining check sources

### DIFF
--- a/npm/vize/src/cli.test.ts
+++ b/npm/vize/src/cli.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 import * as path from "node:path";
-import { displayPath, sanitizeTerminalText, shouldPreferWorkspaceBinding } from "./cli";
+import {
+  displayPath,
+  sanitizeTerminalText,
+  shouldPreferWorkspaceBinding,
+  shouldRetainCheckSource,
+} from "./cli";
 
 describe("shouldPreferWorkspaceBinding", () => {
   it("detects the local workspace native package", () => {
@@ -41,5 +46,17 @@ describe("sanitizeTerminalText", () => {
     const unsafePath = path.join(process.cwd(), "bad\x1b[31m.vue");
 
     expect(displayPath(unsafePath)).toBe("bad.vue");
+  });
+});
+
+describe("shouldRetainCheckSource", () => {
+  it("drops source retention for JSON and quiet check output", () => {
+    expect(shouldRetainCheckSource({ format: "json" })).toBe(false);
+    expect(shouldRetainCheckSource({ quiet: true })).toBe(false);
+  });
+
+  it("keeps source retention when diagnostics or declarations need it", () => {
+    expect(shouldRetainCheckSource({})).toBe(true);
+    expect(shouldRetainCheckSource({ format: "json", declaration: true })).toBe(true);
   });
 });

--- a/npm/vize/src/cli.ts
+++ b/npm/vize/src/cli.ts
@@ -923,6 +923,14 @@ function parseCheckCommand(args: string[]): ParsedCheckCommand {
   return { patterns, options, sharedConfig };
 }
 
+export function shouldRetainCheckSource(options: {
+  declaration?: boolean;
+  format?: string;
+  quiet?: boolean;
+}): boolean {
+  return Boolean(options.declaration || (options.format !== "json" && !options.quiet));
+}
+
 function hasGlobSyntax(pattern: string): boolean {
   return pattern.includes("*") || pattern.includes("?") || pattern.includes("[");
 }
@@ -1330,11 +1338,12 @@ async function runCheck(args: string[]): Promise<void> {
 
   const native = loadNative("check");
   const start = performance.now();
+  const retainSource = shouldRetainCheckSource(options);
   const results = files.map((file) => {
     const source = readFileSync(file, "utf8");
     return {
       file,
-      source,
+      source: retainSource ? source : "",
       result: native.typeCheck(source, toNativeTypeCheckOptions(file, options)),
     };
   });


### PR DESCRIPTION
## Summary
- stop retaining Vue source strings for check results when JSON or quiet output does not need them
- keep source retention for text diagnostics and declaration generation
- add unit coverage for the retention decision

## Validation
- vp fmt --write src vite.config.ts
- vp check src vite.config.ts
- full Rust/JS/playground validation is left to GitHub Actions per maintainer preference
