### PR TITLE
ci: split JS check workflow

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -45,6 +45,98 @@ jobs:
 
   check-js:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      NODE_OPTIONS: "--disable-warning=DEP0040 --disable-warning=DEP0169"
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1
+        with:
+          node-version-file: ".node-version"
+          cache: true
+          run-install: false
+      - name: Install JS dependencies
+        run: vp install --frozen-lockfile --prefer-offline
+      - name: Check JS/TS
+        run: vp run --workspace-root check:ci
+
+  check-vize-apps:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      NODE_OPTIONS: "--disable-warning=DEP0040 --disable-warning=DEP0169"
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1
+        with:
+          node-version-file: ".node-version"
+          cache: true
+          run-install: false
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          shared-key: "native"
+          cache-workspace-crates: "true"
+      - name: Install JS dependencies
+        run: vp install --frozen-lockfile --prefer-offline
+      - name: Build vize CLI
+        run: cargo build --profile ci -p vize
+      - name: Install vize CLI
+        run: cp target/ci/vize /usr/local/bin/vize
+      - name: Check Vize app fixtures
+        run: vp run --workspace-root check:ci:vize-apps
+
+  test-scripts:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      NODE_OPTIONS: "--disable-warning=DEP0040 --disable-warning=DEP0169"
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1
+        with:
+          node-version-file: ".node-version"
+          cache: true
+          run-install: false
+      - uses: ./.github/actions/setup-moonbit
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          shared-key: "native"
+          cache-workspace-crates: "true"
+      - name: Install JS dependencies
+        run: vp install --frozen-lockfile --prefer-offline
+      - name: Build vize CLI
+        run: cargo build --profile ci -p vize
+      - name: Install vize CLI
+        run: cp target/ci/vize /usr/local/bin/vize
+      - name: Test release scripts
+        run: vp run --workspace-root test:scripts
+
+  editor-extensions:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      NODE_OPTIONS: "--disable-warning=DEP0040 --disable-warning=DEP0169"
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1
+        with:
+          node-version-file: ".node-version"
+          cache: true
+          run-install: false
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          shared-key: "native"
+          cache-workspace-crates: "true"
+      - name: Install JS dependencies
+        run: vp install --frozen-lockfile --prefer-offline
+      - name: Check and package editor extensions
+        run: vp run --workspace-root package:editor-extensions
+
+  build-js-packages:
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
       NODE_OPTIONS: "--disable-warning=DEP0040 --disable-warning=DEP0169"
@@ -56,25 +148,33 @@ jobs:
           cache: true
           run-install: false
       - uses: ./.github/actions/setup-moonbit
-      - name: Install JS dependencies
-        run: vp install --frozen-lockfile --prefer-offline
-      - name: Check JS/TS
-        run: vp run --workspace-root check:ci
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: "native"
           cache-workspace-crates: "true"
-      - name: Build vize CLI
-        run: cargo build --profile ci -p vize
-      - name: Install vize CLI
-        run: cp target/ci/vize /usr/local/bin/vize
-      - name: Test release scripts
-        run: vp run --workspace-root test:scripts
-      - name: Check and package editor extensions
-        run: vp run --workspace-root package:editor-extensions
+      - name: Install JS dependencies
+        run: vp install --frozen-lockfile --prefer-offline
+      - name: Build native package
+        run: vp run --filter './npm/vize-native' build:ci
       - name: Build JS packages
         run: vp run --workspace-root build:packages
+      - name: Stage shared JS build artifacts
+        run: |
+          mkdir -p .artifacts/shared-js-build/npm/vize-native
+          mkdir -p .artifacts/shared-js-build/npm/vize
+          mkdir -p .artifacts/shared-js-build/npm/vite-plugin-vize
+          cp npm/vize-native/*.node .artifacts/shared-js-build/npm/vize-native/
+          cp npm/vize-native/index.js npm/vize-native/index.d.ts .artifacts/shared-js-build/npm/vize-native/
+          cp -R npm/vize/dist .artifacts/shared-js-build/npm/vize/
+          cp -R npm/vite-plugin-vize/dist .artifacts/shared-js-build/npm/vite-plugin-vize/
+      - name: Upload shared JS build artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: shared-js-build
+          path: .artifacts/shared-js-build/
+          if-no-files-found: error
+          retention-days: 7
 
   clippy-and-test:
     runs-on: ubuntu-latest
@@ -120,6 +220,8 @@ jobs:
   playground-test:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    needs:
+      - build-js-packages
     permissions:
       contents: read
     steps:
@@ -166,8 +268,11 @@ jobs:
       - name: Install JS dependencies
         run: moon run --target native - -- --filter './playground...' --filter './npm/vite-plugin-vize...' --filter './npm/vize...' --filter './npm/vize-native...' < tools/moon/scripts/github/vp_install.mbtx
 
-      - name: Build npm packages
-        run: moon run --target native - -- vp run --filter './npm/vize-native' build:ci -- vp run --filter './npm/vize' build -- vp run --filter './npm/vite-plugin-vize' build < tools/moon/scripts/github/run_many.mbtx
+      - name: Download shared JS build artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: shared-js-build
+          path: .
 
       - name: Cache Playwright browsers
         id: cache-playwright
@@ -222,6 +327,10 @@ jobs:
       - nix-flake
       - fmt-rust
       - check-js
+      - check-vize-apps
+      - test-scripts
+      - editor-extensions
+      - build-js-packages
       - clippy-and-test
       - coverage
       - playground-test

--- a/tests/tooling/github-workflows.test.ts
+++ b/tests/tooling/github-workflows.test.ts
@@ -109,7 +109,11 @@ test("PR CI jobs cap runtime with explicit timeouts", () => {
   for (const [jobName, minutes] of [
     ["nix-flake", 30],
     ["fmt-rust", 10],
-    ["check-js", 30],
+    ["check-js", 15],
+    ["check-vize-apps", 20],
+    ["test-scripts", 15],
+    ["editor-extensions", 15],
+    ["build-js-packages", 30],
     ["clippy-and-test", 30],
     ["coverage", 10],
     ["playground-test", 30],
@@ -212,6 +216,10 @@ test("check workflow comments a detailed PR test report for each head push", () 
     "nix-flake",
     "fmt-rust",
     "check-js",
+    "check-vize-apps",
+    "test-scripts",
+    "editor-extensions",
+    "build-js-packages",
     "clippy-and-test",
     "coverage",
     "playground-test",
@@ -545,6 +553,26 @@ test("check workflow only installs Playwright browsers on cache misses", () => {
     workflow,
     /- name: Install Playwright browsers\s+if: steps\.cache-playwright\.outputs\.cache-hit != 'true'/,
   );
+});
+
+test("check workflow keeps JS checks separate from native and packaging work", () => {
+  const workflow = readRepoFile(".github", "workflows", "check.yml");
+  const checkJsJob = workflowJobBody(workflow, "check-js");
+  const buildJob = workflowJobBody(workflow, "build-js-packages");
+  const playgroundJob = workflowJobBody(workflow, "playground-test");
+
+  assert.match(checkJsJob, /vp run --workspace-root check:ci/);
+  assert.doesNotMatch(checkJsJob, /cargo build/);
+  assert.doesNotMatch(checkJsJob, /setup-moonbit/);
+  assert.doesNotMatch(checkJsJob, /build:packages/);
+
+  assert.match(buildJob, /vp run --filter '\.\/npm\/vize-native' build:ci/);
+  assert.match(buildJob, /vp run --workspace-root build:packages/);
+  assert.match(buildJob, /name:\s*shared-js-build/);
+
+  assert.match(playgroundJob, /needs:\n\s+- build-js-packages\b/);
+  assert.match(playgroundJob, /name:\s*shared-js-build/);
+  assert.doesNotMatch(playgroundJob, /name: Build npm packages/);
 });
 
 test("check workflow uploads the VRT HTML report when snapshots fail", () => {

--- a/tools/vite-plus/tasks/check.ts
+++ b/tools/vite-plus/tasks/check.ts
@@ -9,6 +9,7 @@ import {
   defineTasks,
   localVp,
   noCacheTask,
+  runInDirectory,
   runInPackages,
   runInVscodeExtension,
   runPackageScriptDirectly,
@@ -21,6 +22,16 @@ const ciPackageCheckCommand = runInPackages("check", ciCheckedPackages, {
   concurrencyLimit: 1,
 });
 const directPackageCheckCommand = runPackageScriptDirectly("check", directCheckPackages);
+const ciVizeAppCheckCommand = [
+  runInDirectory(
+    "./examples/vite-musea",
+    "vize check && vp check src vite.config.ts vite.app.config.ts vize.config.ts playwright.config.ts",
+  ),
+  runInDirectory(
+    "./playground",
+    "vp check src 'e2e/*.ts' 'e2e/vrt/*.ts' vite.config.ts vite.app.config.ts vite.test.config.ts vite.node.config.ts playwright.config.ts && vize lint --max-warnings 0",
+  ),
+].join(" && ");
 
 /**
  * Repository-wide formatting, linting, package checks, and CI aggregate tasks.
@@ -31,21 +42,22 @@ const directPackageCheckCommand = runPackageScriptDirectly("check", directCheckP
  * builds competing with each other on Windows runners.
  */
 export const checkTasks = defineTasks({
-  check: noCacheTask(runTasks("check:repo", "check:rust", "check:js", "check:editor-extensions")),
-  "check:js": noCacheTask(runTasks("check:js:packages", "check:js:direct-packages")),
+  check: noCacheTask(
+    runTasks("check:repo", "check:rust", "check:js", "check:vize-apps", "check:editor-extensions"),
+  ),
+  "check:js": noCacheTask(runTask("check:js:packages")),
   "check:js:packages": task(
     runInPackages("check", checkedPackagesViaVpRun, { concurrencyLimit: 1 }),
     {
       input: cacheInputs.jsChecks,
     },
   ),
-  "check:js:direct-packages": noCacheTask(directPackageCheckCommand),
+  "check:vize-apps": noCacheTask(directPackageCheckCommand),
+  "check:ci:vize-apps": noCacheTask(ciVizeAppCheckCommand),
   "check:repo": noCacheTask(`${localVp} check`),
   // The oxlint example intentionally exits non-zero for its default lint script,
   // so CI checks every package except that runnable failure-case fixture.
-  "check:ci": noCacheTask(
-    `${runTask("check:repo")} && ${ciPackageCheckCommand} && ${directPackageCheckCommand}`,
-  ),
+  "check:ci": noCacheTask(`${runTask("check:repo")} && ${ciPackageCheckCommand}`),
   "check:fix": noCacheTask(runInPackages("check:fix", checkedPackages)),
   "check:rust": noCacheTask("cargo check --workspace"),
   "check:vscode-extension": noCacheTask(


### PR DESCRIPTION
## Summary
- keep check-js focused on JS/TS validation only
- move Vize CLI fixture checks, tooling script tests, editor extension packaging, and package builds into separate CI jobs
- upload shared JS build artifacts from build-js-packages and reuse them in playground-test

## Validation
- node --test tests/tooling/github-workflows.test.ts tests/tooling/editor-integrations.test.ts
- ruby -e "require 'yaml'; YAML.load_file('.github/workflows/check.yml'); puts 'check.yml ok'"
- git diff --check
- vp run --workspace-root check:ci