### PR TITLE
perf(croquis): trim template traversal profile spans

### DIFF
--- a/crates/vize_croquis/src/analyzer/template/mod.rs
+++ b/crates/vize_croquis/src/analyzer/template/mod.rs
@@ -73,12 +73,7 @@ impl Analyzer {
         scope_vars: &mut Vec<CompactString>,
     ) {
         match node {
-            TemplateChildNode::Element(el) => {
-                profile!(
-                    "croquis.template.visit_element",
-                    self.visit_element(el, scope_vars)
-                )
-            }
+            TemplateChildNode::Element(el) => self.visit_element(el, scope_vars),
             TemplateChildNode::If(if_node) => {
                 profile!(
                     "croquis.template.visit_if",

--- a/crates/vize_croquis/src/virtual_ts/generator/template.rs
+++ b/crates/vize_croquis/src/virtual_ts/generator/template.rs
@@ -112,10 +112,7 @@ impl VirtualTsGenerator {
     /// Visit template children.
     pub(crate) fn visit_children(&mut self, children: &[TemplateChildNode]) {
         for child in children {
-            profile!(
-                "croquis.virtual_ts.template.visit_child",
-                self.visit_child(child)
-            );
+            self.visit_child(child);
         }
     }
 


### PR DESCRIPTION
## Summary

- Remove two high-volume wrapper-only profile spans from Croquis template traversal.
- Keep the more specific template processing spans, such as directive handling, interpolation, and element children, so profile output still points at real work.

## Measurements

Input: 2,000 generated benchmark SFCs from `node bench/generate.mjs 2000`.

- Before: `target/ci/vize lint 'bench/__in__/*.vue' --quiet --profile --slow-threshold 5` reported 817,329 internal span calls.
- After: the same command reported 719,416 internal span calls.
- The removed wrapper spans were `croquis.template.visit_element` (39,298 calls) and `croquis.virtual_ts.template.visit_child` (58,615 calls).
- Local wall time was noisy on this run, so this PR is scoped to reducing profiler call volume and disabled-profile branch checks.

## Validation

- `cargo fmt --all --check`
- `cargo build --profile ci -p vize`
- `git diff --check`
- `target/ci/vize lint 'bench/__in__/*.vue' --quiet`
- `target/ci/vize lint 'bench/__in__/*.vue' --quiet --profile --slow-threshold 5`
