### PR TITLE
perf(croquis): trim child traversal profile spans

### DIFF
--- a/crates/vize_croquis/src/analyzer/template/directives/control_flow.rs
+++ b/crates/vize_croquis/src/analyzer/template/directives/control_flow.rs
@@ -88,11 +88,9 @@ impl Analyzer {
                 false
             };
 
-            profile!("croquis.template.v_if.children", {
-                for child in branch.children.iter() {
-                    self.visit_template_child(child, scope_vars);
-                }
-            });
+            for child in branch.children.iter() {
+                self.visit_template_child(child, scope_vars);
+            }
 
             // Pop v-if guard
             if guard_pushed {
@@ -158,11 +156,9 @@ impl Analyzer {
             );
         }
 
-        profile!("croquis.template.v_for.children", {
-            for child in for_node.children.iter() {
-                self.visit_template_child(child, scope_vars);
-            }
-        });
+        for child in for_node.children.iter() {
+            self.visit_template_child(child, scope_vars);
+        }
 
         for _ in 0..vars_count {
             scope_vars.pop();

--- a/crates/vize_croquis/src/analyzer/template/visit_element.rs
+++ b/crates/vize_croquis/src/analyzer/template/visit_element.rs
@@ -357,11 +357,9 @@ impl Analyzer {
         });
 
         // Visit children
-        profile!("croquis.template.element.children", {
-            for child in el.children.iter() {
-                self.visit_template_child(child, scope_vars);
-            }
-        });
+        for child in el.children.iter() {
+            self.visit_template_child(child, scope_vars);
+        }
 
         // Pop v-if guard after visiting children
         if vif_guard_pushed {


### PR DESCRIPTION
## Summary

- Remove wrapper-only Croquis analyzer child traversal profile spans.
- Keep concrete work spans for directive processing, expression checks, interpolation, and control-flow conditions.

## Measurements

Input: 2,000 generated benchmark SFCs from `node bench/generate.mjs 2000`.

- Before: `target/ci/vize lint 'bench/__in__/*.vue' --quiet --profile --slow-threshold 5` reported 817,329 internal span calls.
- After: the same command reported 778,031 internal span calls.
- In this corpus, the measurable reduction comes from removing `croquis.template.element.children` around the child traversal loop.

## Validation

- `cargo fmt --all --check`
- `cargo build --profile ci -p vize`
- `git diff --check`
- `target/ci/vize lint 'bench/__in__/*.vue' --quiet`
- `target/ci/vize lint 'bench/__in__/*.vue' --quiet --profile --slow-threshold 5`
