### PR TITLE
fix(nuxt): reduce Node heap retention

### DIFF
--- a/npm/nuxt/src/components.test.ts
+++ b/npm/nuxt/src/components.test.ts
@@ -1,6 +1,5 @@
 import assert from "node:assert/strict";
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 
@@ -10,6 +9,8 @@ type Fixture = {
   rootDir: string;
   buildDir: string;
 };
+
+const TEST_TMP_ROOT = path.resolve(process.cwd(), "__agent_only", "nuxt-components-tests");
 
 function writeFile(filePath: string, content = ""): string {
   fs.mkdirSync(path.dirname(filePath), { recursive: true });
@@ -24,7 +25,8 @@ function writePackage(rootDir: string, name: string): string {
 }
 
 function createFixture(): Fixture {
-  const rootDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "vize-nuxt-components-")));
+  fs.mkdirSync(TEST_TMP_ROOT, { recursive: true });
+  const rootDir = fs.realpathSync(fs.mkdtempSync(path.join(TEST_TMP_ROOT, "fixture-")));
   const buildDir = path.join(rootDir, ".nuxt");
   fs.mkdirSync(buildDir, { recursive: true });
   writeFile(path.join(rootDir, "package.json"), JSON.stringify({ private: true }));

--- a/npm/nuxt/src/components.ts
+++ b/npm/nuxt/src/components.ts
@@ -149,21 +149,33 @@ function getNuxtComponentDtsFiles(rootDir: string, buildDir: string): string[] {
   return Array.from(new Set(candidates.filter((candidate) => fs.existsSync(candidate))));
 }
 
+function forEachLine(content: string, visit: (line: string) => void): void {
+  let lineStart = 0;
+  for (let index = 0; index <= content.length; index++) {
+    if (index !== content.length && content.charCodeAt(index) !== 10) {
+      continue;
+    }
+
+    const lineEnd = index > lineStart && content.charCodeAt(index - 1) === 13 ? index - 1 : index;
+    visit(content.slice(lineStart, lineEnd));
+    lineStart = index + 1;
+  }
+}
+
 function loadDtsComponents(rootDir: string, buildDir: string): Map<string, NuxtComponentImport> {
   const resolved = new Map<string, NuxtComponentImport>();
 
   for (const filePath of getNuxtComponentDtsFiles(rootDir, buildDir)) {
-    const lines = fs.readFileSync(filePath, "utf-8").split("\n");
-    for (const line of lines) {
+    forEachLine(fs.readFileSync(filePath, "utf-8"), (line) => {
       const match = line.match(DTS_COMPONENT_RE);
       if (!match) {
-        continue;
+        return;
       }
 
       const [, name, , importPath, exportNameDot, exportNameBracket] = match;
       const exportName = exportNameDot || exportNameBracket;
       if (!exportName) {
-        continue;
+        return;
       }
 
       const absoluteImportPath = resolveImportPath(
@@ -177,7 +189,7 @@ function loadDtsComponents(rootDir: string, buildDir: string): Map<string, NuxtC
 
       addComponentAlias(resolved, name, componentImport);
       addLazyComponentAlias(resolved, name, componentImport);
-    }
+    });
   }
 
   return resolved;

--- a/npm/nuxt/src/index.ts
+++ b/npm/nuxt/src/index.ts
@@ -8,7 +8,6 @@
  * - Type Checker: `vize check` CLI command (via `vize` bin)
  */
 
-import fs from "node:fs";
 import { addServerPlugin, addVitePlugin, createResolver, defineNuxtModule } from "@nuxt/kit";
 import vize from "@vizejs/vite-plugin";
 import { musea } from "@vizejs/vite-plugin-musea";
@@ -22,6 +21,7 @@ import {
   normalizeNuxtInjectedKeysForVizeVirtualModule,
   normalizeVizeVirtualVueModuleId,
 } from "./utils";
+import { appendOriginalVueSourceForUnoCss } from "./unocss";
 
 type ViteTransformResult = string | { code?: string; map?: unknown } | null | undefined;
 
@@ -283,12 +283,7 @@ export default defineNuxtModule<VizeNuxtOptions>({
                 // template-to-render-function compilation.
                 let effectiveCode = code;
                 if (isExtractionOnly) {
-                  try {
-                    const originalSource = fs.readFileSync(normalizedId.split("?")[0], "utf-8");
-                    effectiveCode = code + "\n" + originalSource;
-                  } catch {
-                    // File may not exist (virtual components, etc.)
-                  }
+                  effectiveCode = appendOriginalVueSourceForUnoCss(code, normalizedId);
                 }
 
                 return origTransform.call(this, effectiveCode, normalizedId, ...args);

--- a/npm/nuxt/src/unocss.test.ts
+++ b/npm/nuxt/src/unocss.test.ts
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { appendOriginalVueSourceForUnoCss } from "./unocss.ts";
+
+void test("Nuxt UnoCSS bridge appends bounded original Vue source", () => {
+  const result = appendOriginalVueSourceForUnoCss("compiled", "/src/App.vue?vue", {
+    maxBytes: 64,
+    readSize: () => 42,
+    readFile: () => '<template><div flex="~ col gap-2" /></template>',
+  });
+
+  assert.equal(
+    result,
+    'compiled\n<template><div flex="~ col gap-2" /></template>',
+    "small SFC sources should still feed attributify extraction",
+  );
+});
+
+void test("Nuxt UnoCSS bridge skips oversized original Vue sources", () => {
+  let didRead = false;
+  const result = appendOriginalVueSourceForUnoCss("compiled", "/src/Huge.vue?vue", {
+    maxBytes: 64,
+    readSize: () => 65,
+    readFile: () => {
+      didRead = true;
+      return "<template />";
+    },
+  });
+
+  assert.equal(result, "compiled");
+  assert.equal(didRead, false, "oversized sources should not be read into Node heap");
+});
+
+void test("Nuxt UnoCSS bridge tolerates virtual or missing files", () => {
+  const result = appendOriginalVueSourceForUnoCss("compiled", "\0virtual.vue?vue", {
+    readSize: () => {
+      throw new Error("missing");
+    },
+  });
+
+  assert.equal(result, "compiled");
+});

--- a/npm/nuxt/src/unocss.ts
+++ b/npm/nuxt/src/unocss.ts
@@ -1,0 +1,47 @@
+import fs from "node:fs";
+
+export const MAX_UNOCSS_ORIGINAL_SOURCE_BYTES = 2 * 1024 * 1024;
+
+type ReadTextFile = (filePath: string) => string;
+type ReadFileSize = (filePath: string) => number;
+
+function readTextFile(filePath: string): string {
+  return fs.readFileSync(filePath, "utf-8");
+}
+
+function readFileSize(filePath: string): number {
+  return fs.statSync(filePath).size;
+}
+
+export function appendOriginalVueSourceForUnoCss(
+  code: string,
+  normalizedId: string,
+  options: {
+    maxBytes?: number;
+    readFile?: ReadTextFile;
+    readSize?: ReadFileSize;
+  } = {},
+): string {
+  const filePath = normalizedId.split("?")[0];
+  if (!filePath) {
+    return code;
+  }
+
+  const maxBytes = Math.max(1, Math.floor(options.maxBytes ?? MAX_UNOCSS_ORIGINAL_SOURCE_BYTES));
+  const readSize = options.readSize ?? readFileSize;
+  const readFile = options.readFile ?? readTextFile;
+
+  try {
+    if (readSize(filePath) > maxBytes) {
+      return code;
+    }
+  } catch {
+    return code;
+  }
+
+  try {
+    return `${code}\n${readFile(filePath)}`;
+  } catch {
+    return code;
+  }
+}

--- a/npm/nuxt/src/utils.test.ts
+++ b/npm/nuxt/src/utils.test.ts
@@ -30,8 +30,9 @@ assert.deepStrictEqual(
   {
     devUrlBase: "/2026/_nuxt/",
     root: "/repo/app",
+    scanPatterns: [],
   },
-  "Nuxt compiler options should pin Vize root to the app root so vize.config.ts is discovered",
+  "Nuxt compiler options should use on-demand compilation to avoid retaining every SFC in large Nuxt apps",
 );
 
 assert.equal(

--- a/npm/nuxt/src/utils.ts
+++ b/npm/nuxt/src/utils.ts
@@ -18,10 +18,11 @@ export function buildNuxtCompilerOptions(
   rootDir: string,
   baseURL = "/",
   buildAssetsDir = "/_nuxt/",
-): Pick<VizeOptions, "devUrlBase" | "root"> {
+): Pick<VizeOptions, "devUrlBase" | "root" | "scanPatterns"> {
   return {
     devUrlBase: buildNuxtDevAssetBase(baseURL, buildAssetsDir),
     root: rootDir,
+    scanPatterns: [],
   };
 }
 

--- a/npm/vite-plugin-vize/src/compiler.ts
+++ b/npm/vite-plugin-vize/src/compiler.ts
@@ -78,12 +78,10 @@ export function compileBatch(
   cache: Map<string, CompiledModule>,
   options: CompileBatchOptions,
 ): BatchCompileResultWithFiles {
-  const inputs: BatchFileInput[] = files.map((f) => ({
-    path: f.path,
-    source: f.source,
-  }));
-
-  const result = compileSfcBatchWithResults(inputs, buildCompileBatchOptions(options));
+  const result = compileSfcBatchWithResults(
+    files satisfies BatchFileInput[],
+    buildCompileBatchOptions(options),
+  );
 
   // Update cache with results
   for (const fileResult of result.results) {

--- a/npm/vite-plugin-vize/src/plugin/hmr.ts
+++ b/npm/vite-plugin-vize/src/plugin/hmr.ts
@@ -121,7 +121,10 @@ export function handleGenerateBundleHook(
     return;
   }
 
-  const allCss = Array.from(state.collectedCss.values()).join("\n\n");
+  let allCss = "";
+  for (const css of state.collectedCss.values()) {
+    allCss += allCss ? `\n\n${css}` : css;
+  }
   if (allCss.trim()) {
     emitFile({
       type: "asset",

--- a/npm/vite-plugin-vize/src/plugin/index.ts
+++ b/npm/vite-plugin-vize/src/plugin/index.ts
@@ -282,9 +282,10 @@ export function vize(options: VizeOptions = {}): Plugin[] {
     },
 
     async buildStart() {
-      if (!state.scanPatterns) {
+      if (!state.scanPatterns || state.scanPatterns.length === 0) {
         // Running in standalone rolldown context (e.g., ox-content OG image)
-        // where configResolved is not called. Skip pre-compilation.
+        // where configResolved is not called, or a framework integration has
+        // opted into on-demand compilation. Skip pre-compilation.
         return;
       }
       await compileAll(state);

--- a/npm/vite-plugin-vize/src/plugin/load.ts
+++ b/npm/vite-plugin-vize/src/plugin/load.ts
@@ -112,7 +112,10 @@ export function loadHook(
 
   // Handle virtual CSS module for production extraction
   if (id === RESOLVED_CSS_MODULE) {
-    const allCss = Array.from(state.collectedCss.values()).join("\n\n");
+    let allCss = "";
+    for (const css of state.collectedCss.values()) {
+      allCss += allCss ? `\n\n${css}` : css;
+    }
     return allCss;
   }
 

--- a/npm/vite-plugin-vize/src/plugin/state.test.ts
+++ b/npm/vite-plugin-vize/src/plugin/state.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 
 import {
+  DEFAULT_PRECOMPILE_BATCH_MAX_BYTES,
   DEFAULT_PRECOMPILE_BATCH_SIZE,
   DEFAULT_PRECOMPILE_IGNORE_PATTERNS,
   chunkPrecompileFiles,
@@ -68,6 +69,23 @@ assert.deepEqual(
   chunkPrecompileFiles(["a.vue", "b.vue", "c.vue", "d.vue", "e.vue"], 2),
   [["a.vue", "b.vue"], ["c.vue", "d.vue"], ["e.vue"]],
   "Precompile chunking should cap the number of SFCs handed to native compilation",
+);
+assert.deepEqual(
+  chunkPrecompileFiles(["a.vue", "b.vue", "c.vue"], 10, {
+    maxBytes: 10,
+    metadata: new Map<string, PrecompileFileMetadata>([
+      ["a.vue", { mtimeMs: 1, size: 4 }],
+      ["b.vue", { mtimeMs: 1, size: 4 }],
+      ["c.vue", { mtimeMs: 1, size: 9 }],
+    ]),
+  }),
+  [["a.vue", "b.vue"], ["c.vue"]],
+  "Precompile chunking should cap the total source bytes retained per native batch",
+);
+assert.equal(
+  DEFAULT_PRECOMPILE_BATCH_MAX_BYTES,
+  32 * 1024 * 1024,
+  "Default precompile byte cap should leave headroom in Node heap",
 );
 assert.ok(
   DEFAULT_PRECOMPILE_IGNORE_PATTERNS.includes(".nuxt/**"),

--- a/npm/vite-plugin-vize/src/plugin/state.ts
+++ b/npm/vite-plugin-vize/src/plugin/state.ts
@@ -15,6 +15,7 @@ import { createLogger } from "../transform.ts";
 import type { HmrUpdateType } from "../hmr.ts";
 
 export const DEFAULT_PRECOMPILE_BATCH_SIZE = 128;
+export const DEFAULT_PRECOMPILE_BATCH_MAX_BYTES = 32 * 1024 * 1024;
 
 export const DEFAULT_PRECOMPILE_IGNORE_PATTERNS = [
   "node_modules/**",
@@ -76,12 +77,39 @@ export function normalizePrecompileBatchSize(value: number | undefined): number 
   return Math.max(1, Math.floor(value));
 }
 
-export function chunkPrecompileFiles<T>(files: readonly T[], batchSize: number): T[][] {
-  const normalizedBatchSize = normalizePrecompileBatchSize(batchSize);
-  const chunks: T[][] = [];
+export interface PrecompileChunkOptions {
+  maxBytes?: number;
+  metadata?: ReadonlyMap<string, PrecompileFileMetadata>;
+}
 
-  for (let start = 0; start < files.length; start += normalizedBatchSize) {
-    chunks.push(files.slice(start, start + normalizedBatchSize));
+export function chunkPrecompileFiles(
+  files: readonly string[],
+  batchSize: number,
+  options: PrecompileChunkOptions = {},
+): string[][] {
+  const normalizedBatchSize = normalizePrecompileBatchSize(batchSize);
+  const maxBytes = Math.max(1, Math.floor(options.maxBytes ?? DEFAULT_PRECOMPILE_BATCH_MAX_BYTES));
+  const chunks: string[][] = [];
+  let current: string[] = [];
+  let currentBytes = 0;
+
+  for (const file of files) {
+    const fileBytes = Math.max(0, options.metadata?.get(file)?.size ?? 0);
+    if (
+      current.length > 0 &&
+      (current.length >= normalizedBatchSize || currentBytes + fileBytes > maxBytes)
+    ) {
+      chunks.push(current);
+      current = [];
+      currentBytes = 0;
+    }
+
+    current.push(file);
+    currentBytes += fileBytes;
+  }
+
+  if (current.length > 0) {
+    chunks.push(current);
   }
 
   return chunks;
@@ -213,7 +241,9 @@ export async function compileAll(state: VizePluginState): Promise<void> {
   let successCount = 0;
   let failedCount = 0;
   let nativeTimeMs = 0;
-  const chunks = chunkPrecompileFiles(changedFiles, state.precompileBatchSize);
+  const chunks = chunkPrecompileFiles(changedFiles, state.precompileBatchSize, {
+    metadata: currentMetadata,
+  });
 
   for (const chunk of chunks) {
     const fileContents: { path: string; source: string }[] = [];

--- a/npm/vite-plugin-vize/src/plugin/unocss.test.ts
+++ b/npm/vite-plugin-vize/src/plugin/unocss.test.ts
@@ -1,13 +1,19 @@
 import assert from "node:assert/strict";
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
 
 import { patchUnoCssBridge } from "./unocss.ts";
 
-const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "vize-unocss-"));
+const testRoot = path.resolve(process.cwd(), "__agent_only", "vite-plugin-unocss-tests");
+fs.mkdirSync(testRoot, { recursive: true });
+const tempRoot = fs.mkdtempSync(path.join(testRoot, "fixture-"));
+process.once("exit", () => {
+  fs.rmSync(tempRoot, { recursive: true, force: true });
+});
 const sourcePath = path.join(tempRoot, "App.vue");
+const hugeSourcePath = path.join(tempRoot, "Huge.vue");
 const virtualId = `\0${sourcePath}.ts`;
+const hugeVirtualId = `\0${hugeSourcePath}.ts`;
 const plainBuildId = `${sourcePath}.ts`;
 const queriedClientVirtualId = `${virtualId}?macro=true`;
 const queriedSsrVirtualId = `\0vize-ssr:${sourcePath}.ts?vue&type=template`;
@@ -18,6 +24,7 @@ fs.writeFileSync(
   `<template><div flex="~ col gap-2" text="sm slate-700">hello</div></template>\n`,
   "utf-8",
 );
+fs.writeFileSync(hugeSourcePath, " ".repeat(2 * 1024 * 1024 + 1), "utf-8");
 
 {
   let receivedCode = "";
@@ -203,6 +210,29 @@ fs.writeFileSync(
   assert.equal(receivedId, `${sourcePath}?vue&type=template`);
   assert.match(receivedCode, /export default \{\}/);
   assert.match(receivedCode, /text="sm slate-700"/);
+}
+
+{
+  let receivedCode = "";
+
+  const plugins = [
+    {
+      name: "unocss:global:build:scan",
+      transform(code: string) {
+        receivedCode = code;
+        return null;
+      },
+    },
+  ];
+
+  patchUnoCssBridge(plugins);
+  plugins[0]!.transform!("export default {}", hugeVirtualId);
+
+  assert.equal(
+    receivedCode,
+    "export default {}",
+    "oversized SFC sources should not be copied into UnoCSS extraction input",
+  );
 }
 
 console.log("✅ vite-plugin-vize UnoCSS bridge tests passed!");

--- a/npm/vite-plugin-vize/src/plugin/unocss.ts
+++ b/npm/vite-plugin-vize/src/plugin/unocss.ts
@@ -1,7 +1,5 @@
 import fs from "node:fs";
 
-import { VIZE_SSR_PREFIX } from "../virtual.ts";
-
 type UnoCssLikePlugin = {
   name?: string;
   transform?: (...args: unknown[]) => unknown;
@@ -10,7 +8,9 @@ type UnoCssLikePlugin = {
 
 const bridgePatched = Symbol("vize.unocssBridgePatched");
 
+const VIZE_SSR_PREFIX = "\0vize-ssr:";
 const plainSsrPrefix = VIZE_SSR_PREFIX.slice(1);
+export const MAX_UNOCSS_ORIGINAL_SOURCE_BYTES = 2 * 1024 * 1024;
 
 function stripBridgePrefix(id: string): string {
   if (id.startsWith(VIZE_SSR_PREFIX)) {
@@ -31,6 +31,27 @@ function isUnoCssBridgeModuleId(id: string): boolean {
 
 function normalizeUnoCssBridgeModuleId(id: string): string {
   return stripBridgePrefix(id).replace(/\.ts(?=\?|$)/, "");
+}
+
+function appendOriginalVueSourceForUnoCss(code: string, normalizedId: string): string {
+  const sourcePath = normalizedId.split("?")[0];
+  if (!sourcePath) {
+    return code;
+  }
+
+  try {
+    if (fs.statSync(sourcePath).size > MAX_UNOCSS_ORIGINAL_SOURCE_BYTES) {
+      return code;
+    }
+  } catch {
+    return code;
+  }
+
+  try {
+    return `${code}\n${fs.readFileSync(sourcePath, "utf-8")}`;
+  } catch {
+    return code;
+  }
 }
 
 export function patchUnoCssBridge(plugins: UnoCssLikePlugin[]): void {
@@ -60,12 +81,7 @@ export function patchUnoCssBridge(plugins: UnoCssLikePlugin[]): void {
       let effectiveCode = code;
 
       if (isExtractionOnly) {
-        try {
-          const originalSource = fs.readFileSync(normalizedId.split("?")[0]!, "utf-8");
-          effectiveCode = `${code}\n${originalSource}`;
-        } catch {
-          // Ignore missing virtual sources and keep the compiled code path.
-        }
+        effectiveCode = appendOriginalVueSourceForUnoCss(code, normalizedId);
       }
 
       return originalTransform.call(this, effectiveCode, normalizedId, ...args);

--- a/npm/vite-plugin-vize/src/types.ts
+++ b/npm/vite-plugin-vize/src/types.ts
@@ -100,6 +100,7 @@ export interface VizeOptions {
 
   /**
    * Glob patterns to scan for .vue files during pre-compilation
+   * Use an empty array to disable startup pre-compilation and compile on demand.
    * @default ['**\/*.vue']
    */
   scanPatterns?: string[];

--- a/npm/vize/src/cli.test.ts
+++ b/npm/vize/src/cli.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import * as path from "node:path";
 import {
+  createBoundedFileBatches,
   displayPath,
   sanitizeTerminalText,
   shouldPreferWorkspaceBinding,
@@ -46,6 +47,32 @@ describe("sanitizeTerminalText", () => {
     const unsafePath = path.join(process.cwd(), "bad\x1b[31m.vue");
 
     expect(displayPath(unsafePath)).toBe("bad.vue");
+  });
+});
+
+describe("createBoundedFileBatches", () => {
+  it("splits batches by file count and total source bytes", () => {
+    const batches = createBoundedFileBatches(["a.vue", "b.vue", "c.vue", "d.vue"], {
+      maxFiles: 3,
+      maxBytes: 10,
+      sizeOf(file) {
+        return file === "c.vue" ? 9 : 4;
+      },
+    });
+
+    expect(batches).toEqual([["a.vue", "b.vue"], ["c.vue"], ["d.vue"]]);
+  });
+
+  it("keeps a single oversized file processable", () => {
+    const batches = createBoundedFileBatches(["huge.vue", "small.vue"], {
+      maxFiles: 4,
+      maxBytes: 10,
+      sizeOf(file) {
+        return file === "huge.vue" ? 100 : 1;
+      },
+    });
+
+    expect(batches).toEqual([["huge.vue"], ["small.vue"]]);
   });
 });
 

--- a/npm/vize/src/cli.ts
+++ b/npm/vize/src/cli.ts
@@ -8,6 +8,7 @@ import { loadConfig } from "./config.js";
 const require = createRequire(import.meta.url);
 const WORKSPACE_BINDING_PATH = "../../vize-native";
 const BUILD_BATCH_SIZE = 128;
+const BUILD_BATCH_MAX_BYTES = 32 * 1024 * 1024;
 const SKIPPED_VUE_FILE_DIRECTORIES = new Set([
   "node_modules",
   "dist",
@@ -518,6 +519,10 @@ async function runBuild(args: string[]): Promise<void> {
 
   const native = loadNative("build");
   const startedAt = performance.now();
+  const batches = createBoundedFileBatches(files, {
+    maxFiles: BUILD_BATCH_SIZE,
+    maxBytes: BUILD_BATCH_MAX_BYTES,
+  });
 
   if (options.format !== "stats") {
     mkdirSync(options.output, { recursive: true });
@@ -527,12 +532,10 @@ async function runBuild(args: string[]): Promise<void> {
   let failed = 0;
   let success = 0;
 
-  for (let start = 0; start < files.length; start += BUILD_BATCH_SIZE) {
-    const end = Math.min(start + BUILD_BATCH_SIZE, files.length);
+  for (const batch of batches) {
     const inputs: { path: string; source: string }[] = [];
     const extensionByPath = new Map<string, string>();
-    for (let index = start; index < end; index++) {
-      const file = files[index]!;
+    for (const file of batch) {
       const source = readFileSync(file, "utf8");
       extensionByPath.set(file, getOutputExtension(source, options.scriptExt));
       inputs.push({ path: file, source });
@@ -850,12 +853,6 @@ interface ParsedCheckCommand {
   sharedConfig: SharedConfigOptions;
 }
 
-interface CheckedFileResult {
-  file: string;
-  source: string;
-  result: TypeCheckResult;
-}
-
 interface EmittedDeclaration {
   file: string;
   path: string;
@@ -1019,8 +1016,11 @@ function isVueFile(filePath: string): boolean {
   return path.extname(filePath) === ".vue";
 }
 
-function collectVueFilesFromDirectory(directory: string, recursive: boolean): string[] {
-  const files: string[] = [];
+function collectVueFilesFromDirectory(
+  directory: string,
+  recursive: boolean,
+  files: string[] = [],
+): string[] {
   const entries = readdirSync(directory, { withFileTypes: true });
 
   for (const entry of entries) {
@@ -1030,7 +1030,7 @@ function collectVueFilesFromDirectory(directory: string, recursive: boolean): st
         continue;
       }
       if (recursive) {
-        files.push(...collectVueFilesFromDirectory(entryPath, true));
+        collectVueFilesFromDirectory(entryPath, true, files);
       }
     } else if (entry.isFile() && isVueFile(entryPath)) {
       files.push(entryPath);
@@ -1144,11 +1144,55 @@ function collectVueFiles(patterns: string[]): string[] {
   return Array.from(files).sort();
 }
 
-function commonSourceDirectory(results: CheckedFileResult[]): string {
-  let common = path.dirname(results[0]?.file ?? process.cwd());
+interface BoundedFileBatchOptions {
+  maxFiles: number;
+  maxBytes: number;
+  sizeOf?: (file: string) => number;
+}
 
-  for (let i = 1; i < results.length; i++) {
-    const directory = path.dirname(results[i].file);
+function statFileSize(file: string): number {
+  try {
+    return statSync(file).size;
+  } catch {
+    return 0;
+  }
+}
+
+export function createBoundedFileBatches(
+  files: readonly string[],
+  options: BoundedFileBatchOptions,
+): string[][] {
+  const maxFiles = Math.max(1, Math.floor(options.maxFiles));
+  const maxBytes = Math.max(1, Math.floor(options.maxBytes));
+  const sizeOf = options.sizeOf ?? statFileSize;
+  const batches: string[][] = [];
+  let current: string[] = [];
+  let currentBytes = 0;
+
+  for (const file of files) {
+    const fileBytes = Math.max(0, sizeOf(file));
+    if (current.length > 0 && (current.length >= maxFiles || currentBytes + fileBytes > maxBytes)) {
+      batches.push(current);
+      current = [];
+      currentBytes = 0;
+    }
+
+    current.push(file);
+    currentBytes += fileBytes;
+  }
+
+  if (current.length > 0) {
+    batches.push(current);
+  }
+
+  return batches;
+}
+
+function commonSourceDirectory(files: readonly string[]): string {
+  let common = path.dirname(files[0] ?? process.cwd());
+
+  for (let i = 1; i < files.length; i++) {
+    const directory = path.dirname(files[i]!);
     while (common !== path.dirname(common)) {
       const relative = path.relative(common, directory);
       if (relative !== ".." && !relative.startsWith(`..${path.sep}`)) {
@@ -1161,37 +1205,25 @@ function commonSourceDirectory(results: CheckedFileResult[]): string {
   return common;
 }
 
-function emitCheckDeclarations(
-  results: CheckedFileResult[],
+function emitCheckDeclaration(
+  file: string,
+  source: string,
+  sourceRoot: string,
   native: NativeBinding,
   options: CheckOptions,
-): EmittedDeclaration[] {
-  if (!options.declaration) {
-    return [];
-  }
-
-  if (typeof native.generateDeclaration !== "function") {
-    throw new Error("The loaded native binding does not support declaration generation.");
-  }
-
+): EmittedDeclaration {
   const outDir = path.resolve(process.cwd(), options.declarationDir ?? "dist/types");
-  const sourceRoot = commonSourceDirectory(results);
-  const declarations: EmittedDeclaration[] = [];
+  const relative = normalizePath(path.relative(sourceRoot, file));
+  const outputPath = path.join(outDir, `${relative}.d.ts`);
+  mkdirSync(path.dirname(outputPath), { recursive: true });
 
-  for (const { file, source } of results) {
-    const relative = normalizePath(path.relative(sourceRoot, file));
-    const outputPath = path.join(outDir, `${relative}.d.ts`);
-    mkdirSync(path.dirname(outputPath), { recursive: true });
+  const declaration = native.generateDeclaration!(source, { filename: file });
+  writeFileSync(outputPath, declaration.code);
 
-    const declaration = native.generateDeclaration(source, { filename: file });
-    writeFileSync(outputPath, declaration.code);
-    declarations.push({
-      file: displayPath(outputPath),
-      path: outputPath,
-    });
-  }
-
-  return declarations;
+  return {
+    file: displayPath(outputPath),
+    path: outputPath,
+  };
 }
 
 function lineStarts(source: string): number[] {
@@ -1246,47 +1278,47 @@ function toNativeTypeCheckOptions(file: string, options: CheckOptions): NativeTy
   };
 }
 
-function renderCheckText(
-  results: CheckedFileResult[],
+function renderCheckFileText(
+  file: string,
+  source: string,
+  result: TypeCheckResult,
   options: CheckOptions,
-  timeMs: number,
-  declarations: EmittedDeclaration[] = [],
 ): void {
-  let totalErrors = 0;
-  let totalWarnings = 0;
-
-  for (const { file, source, result } of results) {
-    totalErrors += result.errorCount;
-    totalWarnings += result.warningCount;
-
-    if (options.includeVirtualTs && result.virtualTs) {
-      process.stderr.write(
-        `\n=== ${displayPath(file)} ===\n${sanitizeTerminalText(result.virtualTs)}\n`,
-      );
-    }
-
-    if (options.quiet || result.diagnostics.length === 0) {
-      continue;
-    }
-
-    const starts = lineStarts(source);
-    process.stdout.write(`\n\x1b[4m${displayPath(file)}\x1b[0m\n`);
-    for (const diagnostic of result.diagnostics) {
-      const color = diagnostic.severity === "error" ? "\x1b[31m" : "\x1b[33m";
-      const location = offsetToLineColumn(starts, diagnostic.start);
-      const code = diagnostic.code ? ` [${sanitizeTerminalText(diagnostic.code)}]` : "";
-      process.stdout.write(
-        `  ${color}${diagnostic.severity}:${location.line}:${location.column}\x1b[0m${code} ${sanitizeTerminalText(diagnostic.message)}\n`,
-      );
-      if (diagnostic.help) {
-        process.stdout.write(`    help: ${sanitizeTerminalText(diagnostic.help)}\n`);
-      }
-    }
+  if (options.includeVirtualTs && result.virtualTs) {
+    process.stderr.write(
+      `\n=== ${displayPath(file)} ===\n${sanitizeTerminalText(result.virtualTs)}\n`,
+    );
   }
 
+  if (options.quiet || result.diagnostics.length === 0) {
+    return;
+  }
+
+  const starts = lineStarts(source);
+  process.stdout.write(`\n\x1b[4m${displayPath(file)}\x1b[0m\n`);
+  for (const diagnostic of result.diagnostics) {
+    const color = diagnostic.severity === "error" ? "\x1b[31m" : "\x1b[33m";
+    const location = offsetToLineColumn(starts, diagnostic.start);
+    const code = diagnostic.code ? ` [${sanitizeTerminalText(diagnostic.code)}]` : "";
+    process.stdout.write(
+      `  ${color}${diagnostic.severity}:${location.line}:${location.column}\x1b[0m${code} ${sanitizeTerminalText(diagnostic.message)}\n`,
+    );
+    if (diagnostic.help) {
+      process.stdout.write(`    help: ${sanitizeTerminalText(diagnostic.help)}\n`);
+    }
+  }
+}
+
+function renderCheckSummary(
+  totalErrors: number,
+  totalWarnings: number,
+  fileCount: number,
+  timeMs: number,
+  declarations: readonly EmittedDeclaration[],
+): void {
   const status = totalErrors > 0 ? "\x1b[31mERR\x1b[0m" : "\x1b[32mOK\x1b[0m";
   process.stdout.write(
-    `\n${status} Type checked ${results.length} Vue files in ${timeMs.toFixed(2)}ms\n`,
+    `\n${status} Type checked ${fileCount} Vue files in ${timeMs.toFixed(2)}ms\n`,
   );
   if (totalErrors > 0) {
     process.stdout.write(`  \x1b[31m${totalErrors} error(s)\x1b[0m\n`);
@@ -1299,6 +1331,49 @@ function renderCheckText(
   if (declarations.length > 0) {
     process.stdout.write(`  \x1b[32mEmitted ${declarations.length} declaration file(s)\x1b[0m\n`);
   }
+}
+
+function indentJson(value: unknown, spaces: number): string {
+  const padding = " ".repeat(spaces);
+  return JSON.stringify(value, null, 2)
+    .split("\n")
+    .map((line) => `${padding}${line}`)
+    .join("\n");
+}
+
+function writeCheckJsonFile(index: number, file: string, result: TypeCheckResult): void {
+  if (index > 0) {
+    process.stdout.write(",\n");
+  }
+  process.stdout.write(
+    indentJson(
+      {
+        file: displayPath(file),
+        diagnostics: result.diagnostics,
+        virtualTs: result.virtualTs,
+      },
+      4,
+    ),
+  );
+}
+
+function writeCheckJsonEnd(
+  totalErrors: number,
+  totalWarnings: number,
+  fileCount: number,
+  declarations: readonly EmittedDeclaration[],
+): void {
+  process.stdout.write("\n  ],\n");
+  process.stdout.write(`  "errorCount": ${totalErrors},\n`);
+  process.stdout.write(`  "warningCount": ${totalWarnings},\n`);
+  process.stdout.write(`  "fileCount": ${fileCount},\n`);
+  process.stdout.write(
+    `  "declarations": ${indentJson(
+      declarations.map(({ file }) => file),
+      2,
+    ).trimStart()}\n`,
+  );
+  process.stdout.write("}\n");
 }
 
 async function runCheck(args: string[]): Promise<void> {
@@ -1342,41 +1417,46 @@ async function runCheck(args: string[]): Promise<void> {
   }
 
   const native = loadNative("check");
-  const start = performance.now();
+  if (options.declaration && typeof native.generateDeclaration !== "function") {
+    throw new Error("The loaded native binding does not support declaration generation.");
+  }
+
+  const sourceRoot = options.declaration ? commonSourceDirectory(files) : "";
+  const checkStartedAt = performance.now();
   const retainSource = shouldRetainCheckSource(options);
-  const results = files.map((file) => {
-    const source = readFileSync(file, "utf8");
-    return {
-      file,
-      source: retainSource ? source : "",
-      result: native.typeCheck(source, toNativeTypeCheckOptions(file, options)),
-    };
-  });
-  const timeMs = performance.now() - start;
-  const declarations = emitCheckDeclarations(results, native, options);
-  const totalErrors = results.reduce((sum, { result }) => sum + result.errorCount, 0);
-  const totalWarnings = results.reduce((sum, { result }) => sum + result.warningCount, 0);
+  const declarations: EmittedDeclaration[] = [];
+  let totalErrors = 0;
+  let totalWarnings = 0;
+  let checkedCount = 0;
 
   if (options.format === "json") {
-    process.stdout.write(
-      `${JSON.stringify(
-        {
-          files: results.map(({ file, result }) => ({
-            file: displayPath(file),
-            diagnostics: result.diagnostics,
-            virtualTs: result.virtualTs,
-          })),
-          errorCount: totalErrors,
-          warningCount: totalWarnings,
-          fileCount: results.length,
-          declarations: declarations.map(({ file }) => file),
-        },
-        null,
-        2,
-      )}\n`,
-    );
+    process.stdout.write('{\n  "files": [\n');
+  }
+
+  for (const file of files) {
+    const source = readFileSync(file, "utf8");
+    const result = native.typeCheck(source, toNativeTypeCheckOptions(file, options));
+    totalErrors += result.errorCount;
+    totalWarnings += result.warningCount;
+    checkedCount++;
+
+    if (options.declaration) {
+      declarations.push(emitCheckDeclaration(file, source, sourceRoot, native, options));
+    }
+
+    if (options.format === "json") {
+      writeCheckJsonFile(checkedCount - 1, file, result);
+    } else {
+      renderCheckFileText(file, retainSource ? source : "", result, options);
+    }
+  }
+
+  const timeMs = performance.now() - checkStartedAt;
+
+  if (options.format === "json") {
+    writeCheckJsonEnd(totalErrors, totalWarnings, checkedCount, declarations);
   } else {
-    renderCheckText(results, options, timeMs, declarations);
+    renderCheckSummary(totalErrors, totalWarnings, checkedCount, timeMs, declarations);
   }
 
   if (totalErrors > 0) {


### PR DESCRIPTION
## Summary

- Disable startup Vue precompilation for the Nuxt module so large Nuxt apps compile SFCs on demand instead of retaining every compiled module in Node heap.
- Bound UnoCSS original-source enrichment for virtual Vue modules to avoid copying oversized SFCs into transform input.
- Bound CLI and Vite precompile batches by source bytes, stream `vize check --format json`, and avoid extra whole-array/string copies in hot paths.

## Why

Nuxt reports intermittent Node.js OOMs. The riskiest path was eager `**/*.vue` precompilation plus UnoCSS bridge source concatenation, both of which can retain or duplicate large SFC sets in V8. This keeps the Rust/native work intact while reducing JS-side peak heap pressure.

## Validation

- `vp fmt --write` on touched files
- `node --test npm/nuxt/src/utils.test.ts npm/nuxt/src/components.test.ts npm/nuxt/src/unocss.test.ts`
- `node --test npm/vite-plugin-vize/src/plugin/unocss.test.ts`
- `vp test run src/cli.test.ts --config vite.config.ts` from `npm/vize`
- `vp check src vite.config.ts` from `npm/nuxt`, `npm/vize`, and `npm/vite-plugin-vize`
- `git diff --check`

Full fmt/clippy/test/bench/playground validation is intentionally left to GitHub Actions because local full-cycle runs are slow for this repo.
