### PR TITLE
fix(lsp): correct UTF-16 rename ranges

### DIFF
--- a/crates/vize_maestro/src/ide.rs
+++ b/crates/vize_maestro/src/ide.rs
@@ -67,30 +67,43 @@ pub fn offset_to_position(content: &str, offset: usize) -> (u32, u32) {
 /// Convert (line, character) position to byte offset in a document.
 #[inline]
 pub fn position_to_offset(content: &str, line: u32, character: u32) -> Option<usize> {
-    let mut current_line = 0u32;
-    let mut current_col = 0u32;
-    let mut offset = 0usize;
+    fn offset_in_line(content: &str, line_start: usize, character: u32) -> Option<usize> {
+        let mut utf16_units = 0u32;
 
-    for ch in content.chars() {
-        if current_line == line && current_col == character {
-            return Some(offset);
-        }
-        if ch == '\n' {
-            if current_line == line {
-                // Reached end of target line
-                return Some(offset);
+        for (relative_offset, ch) in content[line_start..].char_indices() {
+            if ch == '\n' {
+                return (utf16_units == character).then_some(line_start + relative_offset);
             }
-            current_line += 1;
-            current_col = 0;
-        } else {
-            current_col += 1;
+            if utf16_units == character {
+                return Some(line_start + relative_offset);
+            }
+
+            let next_utf16_units = utf16_units + ch.len_utf16() as u32;
+            if character < next_utf16_units {
+                return None;
+            }
+            utf16_units = next_utf16_units;
         }
-        offset += ch.len_utf8();
+
+        (utf16_units == character).then_some(content.len())
     }
 
-    // Handle end of file
-    if current_line == line && current_col == character {
-        return Some(offset);
+    let mut current_line = 0u32;
+    let mut line_start = 0usize;
+
+    for (offset, ch) in content.char_indices() {
+        if current_line == line {
+            return offset_in_line(content, line_start, character);
+        }
+
+        if ch == '\n' {
+            current_line += 1;
+            line_start = offset + ch.len_utf8();
+        }
+    }
+
+    if current_line == line {
+        return offset_in_line(content, line_start, character);
     }
 
     None
@@ -425,6 +438,22 @@ mod tests {
         assert_eq!(position_to_offset(content, 1, 0), Some(6));
         assert_eq!(position_to_offset(content, 1, 2), Some(8));
         assert_eq!(position_to_offset(content, 2, 0), Some(12));
+    }
+
+    #[test]
+    fn test_position_to_offset_counts_utf16_code_units() {
+        let content = "a😀b\nc";
+
+        assert_eq!(position_to_offset(content, 0, 3), Some("a😀".len()));
+        assert_eq!(position_to_offset(content, 0, 4), Some("a😀b".len()));
+        assert_eq!(position_to_offset(content, 1, 1), Some(content.len()));
+    }
+
+    #[test]
+    fn test_position_to_offset_rejects_utf16_surrogate_pair_interior() {
+        let content = "a😀b";
+
+        assert_eq!(position_to_offset(content, 0, 2), None);
     }
 
     #[test]

--- a/crates/vize_maestro/src/ide/rename.rs
+++ b/crates/vize_maestro/src/ide/rename.rs
@@ -478,27 +478,7 @@ impl RenameService {
 
     /// Convert byte offset to LSP Position.
     fn offset_to_position(content: &str, offset: usize) -> Position {
-        let mut line = 0u32;
-        let mut col = 0u32;
-        let mut current = 0;
-
-        for ch in content.chars() {
-            if current >= offset {
-                break;
-            }
-            if ch == '\n' {
-                line += 1;
-                col = 0;
-            } else {
-                col += 1;
-            }
-            current += ch.len_utf8();
-        }
-
-        Position {
-            line,
-            character: col,
-        }
+        crate::utils::offset_to_position_str(content, offset)
     }
 
     /// Check if character can start an identifier.
@@ -657,5 +637,17 @@ mod tests {
         let css = ".container { color: v-bind(textColor); width: v-bind('width'); }";
         let occurrences = RenameService::find_vbind_occurrences(css, "textColor");
         assert_eq!(occurrences.len(), 1);
+    }
+
+    #[test]
+    fn test_offset_range_to_lsp_counts_utf16_code_units() {
+        let content = "const emoji = \"😀\"; const message = ref(emoji)";
+        let start = content.find("message").unwrap();
+        let end = start + "message".len();
+        let range = RenameService::offset_range_to_lsp(content, start, end);
+
+        assert_eq!(range.start.line, 0);
+        assert_eq!(range.start.character, 26);
+        assert_eq!(range.end.character, 33);
     }
 }

--- a/tests/tooling/lsp-smoke.test.ts
+++ b/tests/tooling/lsp-smoke.test.ts
@@ -319,6 +319,98 @@ const message = 'hello'
   }
 });
 
+test("vize lsp rename fallback returns UTF-16 edit ranges", async () => {
+  const agentOnlyDir = path.join(root, "__agent_only", "lsp-rename-utf16");
+  fs.mkdirSync(agentOnlyDir, { recursive: true });
+  const workspaceDir = fs.mkdtempSync(path.join(agentOnlyDir, "workspace-"));
+  const session = new LspSession();
+
+  try {
+    await session.initialize(workspaceDir, {
+      editor: true,
+      lint: false,
+      typecheck: false,
+    });
+
+    const source = `<script setup lang="ts">
+const emoji = "😀"; const message = ref(emoji)
+</script>
+
+<template>
+  <p>{{ message }}</p>
+</template>
+`;
+    const filePath = path.join(workspaceDir, "RenameUtf16.vue");
+    const uri = pathToFileURL(filePath).href;
+    fs.writeFileSync(filePath, source, "utf8");
+
+    session.notify("textDocument/didOpen", {
+      textDocument: {
+        uri,
+        languageId: "vue",
+        version: 1,
+        text: source,
+      },
+    });
+
+    await session.waitForNotification("textDocument/publishDiagnostics", (params) =>
+      isDiagnosticsForUri(params, uri),
+    );
+
+    const usageStart = source.lastIndexOf("message");
+    const usageEnd = usageStart + "message".length;
+    const declarationStart = source.indexOf("message =");
+    const declarationEnd = declarationStart + "message".length;
+    const usagePosition = offsetToPosition(source, usageEnd);
+
+    const prepare = (await session.request("textDocument/prepareRename", {
+      textDocument: { uri },
+      position: usagePosition,
+    })) as {
+      start?: { line: number; character: number };
+      end?: { line: number; character: number };
+    };
+
+    assert.deepEqual(prepare.start, offsetToPosition(source, usageStart));
+    assert.deepEqual(prepare.end, offsetToPosition(source, usageEnd));
+
+    const edit = (await session.request("textDocument/rename", {
+      textDocument: { uri },
+      position: usagePosition,
+      newName: "renamedMessage",
+    })) as {
+      changes?: Record<
+        string,
+        Array<{
+          range: {
+            start: { line: number; character: number };
+            end: { line: number; character: number };
+          };
+          newText: string;
+        }>
+      >;
+    } | null;
+
+    const edits = edit?.changes?.[uri] ?? [];
+    assert.ok(edits.length >= 2, JSON.stringify(edit));
+    assert.ok(
+      edits.some(
+        (textEdit) =>
+          textEdit.newText === "renamedMessage" &&
+          textEdit.range.start.line === offsetToPosition(source, declarationStart).line &&
+          textEdit.range.start.character === offsetToPosition(source, declarationStart).character &&
+          textEdit.range.end.line === offsetToPosition(source, declarationEnd).line &&
+          textEdit.range.end.character === offsetToPosition(source, declarationEnd).character,
+      ),
+      JSON.stringify(edits),
+    );
+  } finally {
+    await session.shutdown();
+    fs.rmSync(workspaceDir, { recursive: true, force: true });
+    fs.rmSync(agentOnlyDir, { recursive: true, force: true });
+  }
+});
+
 test("vize lsp publishes and clears malformed SFC diagnostics", async () => {
   const agentOnlyDir = path.join(root, "__agent_only", "lsp-malformed");
   fs.mkdirSync(agentOnlyDir, { recursive: true });


### PR DESCRIPTION
## Summary
- Make shared IDE position-to-offset conversion count LSP characters as UTF-16 code units and reject surrogate-pair interiors.
- Route fallback rename edit ranges through the UTF-16 offset-to-position helper.
- Add an end-to-end LSP smoke test for prepareRename/rename after an emoji with typecheck disabled, so the non-Corsa fallback stays honest.

## Local checks
- `cargo fmt --all`
- `pnpm exec vp fmt --write tests/tooling/lsp-smoke.test.ts`
- `cargo test -p vize_maestro rename --no-fail-fast`
- `cargo test -p vize_maestro test_position_to_offset --no-fail-fast`
- `cargo build -p vize`
- `node --test tests/tooling/lsp-smoke.test.ts`
- `git diff --check`

Full validation is left to GitHub Actions.
