### PR TITLE
feat(fresco): add screen reader API parity

### DIFF
--- a/crates/vize_fresco/src/component/text_node.rs
+++ b/crates/vize_fresco/src/component/text_node.rs
@@ -5,12 +5,14 @@ use compact_str::CompactString;
 use crate::layout::FlexStyle;
 use crate::render::{Appearance, NodeKind, RenderNode, TextContent};
 use crate::terminal::Color;
+use crate::text::WrapMode;
 
 /// Builder for Text nodes.
 #[derive(Debug, Clone, Default)]
 pub struct TextNode {
     text: CompactString,
     wrap: bool,
+    wrap_mode: WrapMode,
     style: FlexStyle,
     appearance: Appearance,
 }
@@ -27,6 +29,14 @@ impl TextNode {
     /// Enable text wrapping.
     pub fn wrap(mut self) -> Self {
         self.wrap = true;
+        self.wrap_mode = WrapMode::Word;
+        self
+    }
+
+    /// Set text wrapping mode.
+    pub fn wrap_mode(mut self, mode: WrapMode) -> Self {
+        self.wrap = !matches!(mode, WrapMode::NoWrap);
+        self.wrap_mode = mode;
         self
     }
 
@@ -83,6 +93,7 @@ impl TextNode {
         let content = TextContent {
             text: self.text,
             wrap: self.wrap,
+            wrap_mode: self.wrap_mode,
         };
         RenderNode::new(id, NodeKind::Text(content))
             .with_style(self.style)

--- a/crates/vize_fresco/src/napi/render.rs
+++ b/crates/vize_fresco/src/napi/render.rs
@@ -8,9 +8,23 @@ use super::terminal::with_backend;
 use super::types::{LayoutResultNapi, RenderNodeNapi, StyleNapi};
 use crate::layout::Rect;
 use crate::terminal::{Color, Style};
+use crate::text::WrapMode;
 
 thread_local! {
     static LAST_RENDER_LAYOUTS: RefCell<Vec<LayoutResultNapi>> = const { RefCell::new(Vec::new()) };
+}
+
+fn parse_wrap_mode(mode: Option<&str>, wrap: Option<bool>) -> WrapMode {
+    match mode {
+        Some("wrap") => WrapMode::Word,
+        Some("hard") => WrapMode::Char,
+        Some("truncate") | Some("truncate-end") => WrapMode::TruncateEnd,
+        Some("truncate-start") => WrapMode::TruncateStart,
+        Some("truncate-middle") => WrapMode::TruncateMiddle,
+        Some("false") | Some("none") => WrapMode::NoWrap,
+        _ if wrap.unwrap_or(false) => WrapMode::Word,
+        _ => WrapMode::NoWrap,
+    }
 }
 
 /// Get layout results from the most recent renderTree call.
@@ -164,6 +178,7 @@ pub fn render_tree(nodes: Vec<RenderNodeNapi>) -> Result<()> {
                 "text" => NodeKind::Text(TextContent {
                     text: text_content.clone().into(),
                     wrap: node.wrap.unwrap_or(false),
+                    wrap_mode: parse_wrap_mode(node.wrap_mode.as_deref(), node.wrap),
                 }),
                 "input" => NodeKind::Input(InputContent {
                     value: node.value.clone().unwrap_or_default().into(),

--- a/crates/vize_fresco/src/napi/types.rs
+++ b/crates/vize_fresco/src/napi/types.rs
@@ -113,6 +113,9 @@ pub struct RenderNodeNapi {
     pub text: Option<String>,
     /// Whether text should wrap
     pub wrap: Option<bool>,
+    /// Ink-compatible text wrapping/truncation mode
+    #[napi(js_name = "wrapMode")]
+    pub wrap_mode: Option<String>,
     /// Input value (for input nodes)
     pub value: Option<String>,
     /// Placeholder text (for input nodes)

--- a/crates/vize_fresco/src/render/diff.rs
+++ b/crates/vize_fresco/src/render/diff.rs
@@ -184,7 +184,9 @@ impl DiffEngine {
         match (&old.kind, &new.kind) {
             (NodeKind::Box, NodeKind::Box) => false,
             (NodeKind::Text(old_text), NodeKind::Text(new_text)) => {
-                old_text.text != new_text.text || old_text.wrap != new_text.wrap
+                old_text.text != new_text.text
+                    || old_text.wrap != new_text.wrap
+                    || old_text.wrap_mode != new_text.wrap_mode
             }
             (NodeKind::Input(old_input), NodeKind::Input(new_input)) => {
                 old_input.value != new_input.value

--- a/crates/vize_fresco/src/render/node.rs
+++ b/crates/vize_fresco/src/render/node.rs
@@ -6,6 +6,7 @@ use smallvec::SmallVec;
 
 use crate::layout::{FlexStyle, Rect};
 use crate::terminal::{Color, Style};
+use crate::text::WrapMode;
 
 /// Unique identifier for render nodes.
 pub type NodeId = u64;
@@ -108,6 +109,8 @@ pub struct TextContent {
     pub text: CompactString,
     /// Whether text should wrap
     pub wrap: bool,
+    /// How text should wrap or truncate within its layout area
+    pub wrap_mode: WrapMode,
 }
 
 impl TextContent {
@@ -116,12 +119,21 @@ impl TextContent {
         Self {
             text: text.into(),
             wrap: false,
+            wrap_mode: WrapMode::NoWrap,
         }
     }
 
     /// Enable text wrapping.
     pub fn with_wrap(mut self) -> Self {
         self.wrap = true;
+        self.wrap_mode = WrapMode::Word;
+        self
+    }
+
+    /// Set the text wrapping mode.
+    pub fn with_wrap_mode(mut self, wrap_mode: WrapMode) -> Self {
+        self.wrap = !matches!(wrap_mode, WrapMode::NoWrap);
+        self.wrap_mode = wrap_mode;
         self
     }
 }

--- a/crates/vize_fresco/src/render/painter.rs
+++ b/crates/vize_fresco/src/render/painter.rs
@@ -63,7 +63,7 @@ impl<'a> Painter<'a> {
                 // Box nodes just provide layout, content is drawn by children
             }
             NodeKind::Text(text) => {
-                self.paint_text(&text.text, content_area, style, text.wrap);
+                self.paint_text(&text.text, content_area, style, text.wrap_mode);
             }
             NodeKind::Input(input) => {
                 self.paint_input(
@@ -117,16 +117,11 @@ impl<'a> Painter<'a> {
     }
 
     /// Paint text content.
-    fn paint_text(&mut self, text: &str, area: Rect, style: Style, wrap: bool) {
+    fn paint_text(&mut self, text: &str, area: Rect, style: Style, mode: WrapMode) {
         if area.is_empty() {
             return;
         }
 
-        let mode = if wrap {
-            WrapMode::Word
-        } else {
-            WrapMode::NoWrap
-        };
         let lines = TextWrap::wrap(text, area.width as usize, mode);
 
         for (i, line) in lines.iter().enumerate() {
@@ -206,6 +201,7 @@ mod tests {
     use super::{BorderStyle, Painter, RenderNode, RenderTree};
     use crate::layout::Rect;
     use crate::terminal::{Buffer, Style};
+    use crate::text::WrapMode;
 
     #[test]
     fn test_paint_text() {
@@ -214,7 +210,7 @@ mod tests {
 
         let area = Rect::new(0, 0, 20, 5);
         let style = Style::new();
-        painter.paint_text("Hello World", area, style, false);
+        painter.paint_text("Hello World", area, style, WrapMode::NoWrap);
 
         assert_eq!(buffer.get(0, 0).map(|c| c.symbol.as_str()), Some("H"));
         assert_eq!(buffer.get(5, 0).map(|c| c.symbol.as_str()), Some(" "));

--- a/crates/vize_fresco/src/text/wrap.rs
+++ b/crates/vize_fresco/src/text/wrap.rs
@@ -12,10 +12,16 @@ pub enum WrapMode {
     NoWrap,
     /// Wrap at word boundaries
     Word,
-    /// Wrap at character boundaries
+    /// Wrap at grapheme boundaries
     Char,
-    /// Truncate with ellipsis
+    /// Truncate at the end with ellipsis
     Truncate,
+    /// Truncate at the end with ellipsis
+    TruncateEnd,
+    /// Truncate at the start with ellipsis
+    TruncateStart,
+    /// Truncate in the middle with ellipsis
+    TruncateMiddle,
 }
 
 /// Text wrapper for terminal output.
@@ -28,10 +34,113 @@ impl TextWrap {
             WrapMode::NoWrap => vec![CompactString::from(text)],
             WrapMode::Word => Self::wrap_word(text, max_width),
             WrapMode::Char => Self::wrap_char(text, max_width),
-            WrapMode::Truncate => {
-                vec![TextWidth::truncate_with_ellipsis(text, max_width)]
-            }
+            WrapMode::Truncate | WrapMode::TruncateEnd => vec![Self::truncate_end(text, max_width)],
+            WrapMode::TruncateStart => vec![Self::truncate_start(text, max_width)],
+            WrapMode::TruncateMiddle => vec![Self::truncate_middle(text, max_width)],
         }
+    }
+
+    fn ellipsis(max_width: usize) -> CompactString {
+        std::iter::repeat_n('.', max_width.min(3)).collect()
+    }
+
+    fn truncate_end(text: &str, max_width: usize) -> CompactString {
+        if TextWidth::width(text) <= max_width {
+            return CompactString::from(text);
+        }
+
+        if max_width <= 3 {
+            return Self::ellipsis(max_width);
+        }
+
+        let target_width = max_width - 3;
+        let mut result = CompactString::default();
+        let mut width = 0;
+
+        for seg in segment(text) {
+            if width + seg.width > target_width {
+                break;
+            }
+
+            width += seg.width;
+            result.push_str(&seg.grapheme);
+        }
+
+        result.push_str("...");
+        result
+    }
+
+    fn truncate_start(text: &str, max_width: usize) -> CompactString {
+        if TextWidth::width(text) <= max_width {
+            return CompactString::from(text);
+        }
+
+        if max_width <= 3 {
+            return Self::ellipsis(max_width);
+        }
+
+        let target_width = max_width - 3;
+        let mut suffix = Vec::new();
+        let mut width = 0;
+
+        for seg in segment(text).collect::<Vec<_>>().into_iter().rev() {
+            if width + seg.width > target_width {
+                break;
+            }
+
+            width += seg.width;
+            suffix.push(seg.grapheme);
+        }
+
+        let mut result = CompactString::from("...");
+        for item in suffix.into_iter().rev() {
+            result.push_str(&item);
+        }
+        result
+    }
+
+    fn truncate_middle(text: &str, max_width: usize) -> CompactString {
+        if TextWidth::width(text) <= max_width {
+            return CompactString::from(text);
+        }
+
+        if max_width <= 3 {
+            return Self::ellipsis(max_width);
+        }
+
+        let target_width = max_width - 3;
+        let prefix_target = target_width.div_ceil(2);
+        let suffix_target = target_width / 2;
+
+        let mut prefix = CompactString::default();
+        let mut prefix_width = 0;
+        let segments = segment(text).collect::<Vec<_>>();
+
+        for seg in &segments {
+            if prefix_width + seg.width > prefix_target {
+                break;
+            }
+
+            prefix_width += seg.width;
+            prefix.push_str(&seg.grapheme);
+        }
+
+        let mut suffix = Vec::new();
+        let mut suffix_width = 0;
+        for seg in segments.into_iter().rev() {
+            if suffix_width + seg.width > suffix_target {
+                break;
+            }
+
+            suffix_width += seg.width;
+            suffix.push(seg.grapheme);
+        }
+
+        prefix.push_str("...");
+        for item in suffix.into_iter().rev() {
+            prefix.push_str(&item);
+        }
+        prefix
     }
 
     /// Wrap at word boundaries.
@@ -230,6 +339,27 @@ mod tests {
         let lines = TextWrap::wrap("Hello World", 8, WrapMode::Truncate);
         assert_eq!(lines.len(), 1);
         assert_eq!(lines[0].as_str(), "Hello...");
+    }
+
+    #[test]
+    fn test_wrap_truncate_start() {
+        let lines = TextWrap::wrap("Hello World", 8, WrapMode::TruncateStart);
+        assert_eq!(lines.len(), 1);
+        assert_eq!(lines[0].as_str(), "...World");
+    }
+
+    #[test]
+    fn test_wrap_truncate_middle() {
+        let lines = TextWrap::wrap("Hello World", 9, WrapMode::TruncateMiddle);
+        assert_eq!(lines.len(), 1);
+        assert_eq!(lines[0].as_str(), "Hel...rld");
+    }
+
+    #[test]
+    fn test_wrap_truncate_cjk_width() {
+        let lines = TextWrap::wrap("あいうえお", 7, WrapMode::TruncateEnd);
+        assert_eq!(lines.len(), 1);
+        assert_eq!(lines[0].as_str(), "あい...");
     }
 
     #[test]

--- a/npm/fresco-native/index.d.ts
+++ b/npm/fresco-native/index.d.ts
@@ -57,6 +57,7 @@ export interface RenderNodeNapi {
   nodeType: string;
   text?: string;
   wrap?: boolean;
+  wrapMode?: string;
   value?: string;
   placeholder?: string;
   focused?: boolean;

--- a/npm/fresco/src/accessibility.ts
+++ b/npm/fresco/src/accessibility.ts
@@ -161,6 +161,7 @@ export function treeToScreenReaderRenderNodes(root: FrescoNode): NativeRenderNod
     nodeType: "text",
     text: output,
     wrap: true,
+    wrapMode: "wrap",
   });
 
   return nodes;

--- a/npm/fresco/src/accessibility.ts
+++ b/npm/fresco/src/accessibility.ts
@@ -1,0 +1,167 @@
+/**
+ * Ink-compatible screen reader helpers.
+ */
+
+import type { InjectionKey, Ref } from "@vue/runtime-core";
+import type { FlexStyleNapi } from "@vizejs/fresco-native";
+import type { FrescoNode, NativeRenderNode } from "./renderer.js";
+
+export const SCREEN_READER_KEY: InjectionKey<Readonly<Ref<boolean>>> =
+  Symbol("fresco-screen-reader");
+
+export type AriaRole =
+  | "button"
+  | "checkbox"
+  | "combobox"
+  | "list"
+  | "listbox"
+  | "listitem"
+  | "menu"
+  | "menuitem"
+  | "option"
+  | "progressbar"
+  | "radio"
+  | "radiogroup"
+  | "tab"
+  | "tablist"
+  | "table"
+  | "textbox"
+  | "timer"
+  | "toolbar";
+
+export type AriaState = Partial<
+  Record<
+    | "busy"
+    | "checked"
+    | "disabled"
+    | "expanded"
+    | "multiline"
+    | "multiselectable"
+    | "readonly"
+    | "required"
+    | "selected",
+    boolean
+  >
+>;
+
+export function isScreenReaderEnabledByDefault(): boolean {
+  return process.env.INK_SCREEN_READER === "true" || process.env.FRESCO_SCREEN_READER === "true";
+}
+
+function stringValue(value: unknown): string | undefined {
+  if (typeof value === "string" || typeof value === "number") return String(value);
+  return undefined;
+}
+
+function nodeText(node: FrescoNode): string {
+  const ariaLabel = stringValue(node.props["aria-label"]);
+  if (ariaLabel !== undefined) return ariaLabel;
+  if (node.text !== undefined) return node.text;
+
+  const propText = node.props.text ?? node.props.content;
+  if (typeof propText === "string" || typeof propText === "number") return String(propText);
+
+  if (node.type === "input") {
+    const value = node.props.value;
+    const placeholder = node.props.placeholder;
+    if (typeof value === "string" || typeof value === "number") return String(value);
+    if (typeof placeholder === "string" || typeof placeholder === "number")
+      return String(placeholder);
+  }
+
+  return "";
+}
+
+function flexDirection(node: FrescoNode): string {
+  const style = (node.props.style ?? {}) as Record<string, unknown>;
+  return stringValue(style.flexDirection ?? style.flex_direction) ?? "column";
+}
+
+function ariaRole(node: FrescoNode): AriaRole | undefined {
+  return stringValue(node.props["aria-role"]) as AriaRole | undefined;
+}
+
+function ariaState(node: FrescoNode): AriaState | undefined {
+  const state = node.props["aria-state"];
+  if (!state || typeof state !== "object") return undefined;
+  return state as AriaState;
+}
+
+function isAriaHidden(node: FrescoNode): boolean {
+  return node.props["aria-hidden"] === true;
+}
+
+export function treeToScreenReaderString(
+  node: FrescoNode,
+  options: { parentRole?: AriaRole } = {},
+): string {
+  if (isAriaHidden(node)) return "";
+
+  let output = "";
+  const text = nodeText(node);
+
+  if (node.type === "text" || node.type === "input") {
+    output = `${text}${node.children.map((child) => treeToScreenReaderString(child, options)).join("")}`;
+  } else if (text) {
+    output = text;
+  } else {
+    const direction = flexDirection(node);
+    const separator = direction === "row" || direction === "row-reverse" ? " " : "\n";
+    const children =
+      direction === "row-reverse" || direction === "column-reverse"
+        ? [...node.children].reverse()
+        : node.children;
+
+    const role = ariaRole(node);
+    output = children
+      .map((child) => treeToScreenReaderString(child, { parentRole: role }))
+      .filter(Boolean)
+      .join(separator);
+  }
+
+  const state = ariaState(node);
+  if (state) {
+    const stateDescription = Object.keys(state)
+      .filter((key) => state[key as keyof AriaState])
+      .join(", ");
+
+    if (stateDescription) {
+      output = `(${stateDescription}) ${output}`;
+    }
+  }
+
+  const role = ariaRole(node);
+  if (role && role !== options.parentRole) {
+    output = `${role}: ${output}`;
+  }
+
+  return output;
+}
+
+export function treeToScreenReaderRenderNodes(root: FrescoNode): NativeRenderNode[] {
+  const output = treeToScreenReaderString(root);
+  const rootStyle = (root.props.style ?? {}) as FlexStyleNapi;
+  const nodes: NativeRenderNode[] = [
+    {
+      id: root.id,
+      nodeType: "root",
+      style: {
+        ...rootStyle,
+        flexDirection: "column",
+      },
+    },
+  ];
+
+  if (!output) return nodes;
+
+  const textId = root.id - 1;
+  nodes[0].children = [textId];
+  nodes.push({
+    id: textId,
+    nodeType: "text",
+    text: output,
+    wrap: true,
+  });
+
+  return nodes;
+}

--- a/npm/fresco/src/app.ts
+++ b/npm/fresco/src/app.ts
@@ -20,6 +20,7 @@ import {
 } from "./accessibility.js";
 import { APP_KEY, createAppContext, type UseAppReturn } from "./composables/useApp.js";
 import { createFocusManager, FOCUS_KEY, type FocusManager } from "./composables/useFocus.js";
+import { createStreamsContext, STREAMS_KEY } from "./composables/useStreams.js";
 import { updateLastRenderLayouts } from "./layoutMetrics.js";
 import type { KittyKeyboardOptions } from "./kittyKeyboard.js";
 import {
@@ -273,6 +274,13 @@ export function createApp(rootComponent: AppRoot, options: AppOptions = {}): App
     options.isScreenReaderEnabled ?? isScreenReaderEnabledByDefault(),
   );
   const frameDelay = Math.max(1, Math.floor(1000 / Math.max(1, options.maxFps ?? 30)));
+  const streamsContext = createStreamsContext({
+    stdin: options.stdin,
+    stdout: options.stdout,
+    stderr: options.stderr,
+    exitOnCtrlC,
+    interactive: options.interactive ?? true,
+  });
 
   let vueApp: VueApp | null = null;
   let rootElement: FrescoElement | null = null;
@@ -322,11 +330,13 @@ export function createApp(rootComponent: AppRoot, options: AppOptions = {}): App
       render,
       clear,
       waitUntilRenderFlush,
+      stdout: streamsContext.stdout,
     });
     focusManager = createFocusManager();
     app.provide(APP_KEY, appContext);
     app.provide(FOCUS_KEY, focusManager);
     app.provide(SCREEN_READER_KEY, screenReaderEnabled);
+    app.provide(STREAMS_KEY, streamsContext);
 
     // Create a root element for mounting
     rootElement = createRootElement();
@@ -400,7 +410,7 @@ export function createApp(rootComponent: AppRoot, options: AppOptions = {}): App
       // Send to native for rendering
       if (renderNodes.length > 0) {
         if (options.debug) {
-          options.stderr?.write(`${JSON.stringify(renderNodes, null, 2)}\n`);
+          streamsContext.stderr.write(`${JSON.stringify(renderNodes, null, 2)}\n`);
         }
 
         // Use renderTree which handles layout and painting
@@ -619,6 +629,7 @@ export function renderToString(root: AppRoot, options: RenderToStringOptions = {
   );
   app.provide(FOCUS_KEY, createFocusManager());
   app.provide(SCREEN_READER_KEY, ref(false));
+  app.provide(STREAMS_KEY, createStreamsContext({ interactive: false }));
   app.mount(rootElement);
 
   const output = treeToString(rootElement);

--- a/npm/fresco/src/app.ts
+++ b/npm/fresco/src/app.ts
@@ -13,8 +13,15 @@ import {
   type VNode,
 } from "@vue/runtime-core";
 import type { InputEventNapi } from "@vizejs/fresco-native";
+import {
+  SCREEN_READER_KEY,
+  isScreenReaderEnabledByDefault,
+  treeToScreenReaderRenderNodes,
+} from "./accessibility.js";
 import { APP_KEY, createAppContext, type UseAppReturn } from "./composables/useApp.js";
 import { createFocusManager, FOCUS_KEY, type FocusManager } from "./composables/useFocus.js";
+import { updateLastRenderLayouts } from "./layoutMetrics.js";
+import type { KittyKeyboardOptions } from "./kittyKeyboard.js";
 import {
   createRenderer,
   treeToRenderNodes,
@@ -124,7 +131,17 @@ export interface AppOptions {
   maxFps?: number;
   /** Use alternate screen buffer */
   alternateScreen?: boolean;
+  /** Ink-compatible option, accepted for API parity */
+  incrementalRendering?: boolean;
+  /** Ink-compatible option, accepted for API parity */
+  concurrent?: boolean;
+  /** Override interactive mode detection */
+  interactive?: boolean;
+  /** Configure Kitty keyboard protocol support */
+  kittyKeyboard?: KittyKeyboardOptions;
 }
+
+export type RenderOptions = AppOptions;
 
 export type AppRoot = Component | VNode;
 
@@ -160,6 +177,23 @@ export interface RenderInstance {
 export interface RenderToStringOptions {
   /** Width of the virtual terminal in columns */
   columns?: number;
+}
+
+export interface WritableStreamLike {
+  write(...args: unknown[]): unknown;
+}
+
+function isWritableStream(value: unknown): value is WritableStreamLike {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "write" in value &&
+    typeof (value as { write?: unknown }).write === "function"
+  );
+}
+
+function normalizeRenderOptions(options: AppOptions | WritableStreamLike): AppOptions {
+  return isWritableStream(options) ? { stdout: options as NodeJS.WriteStream } : options;
 }
 
 function isVNodeRoot(root: AppRoot): root is VNode {
@@ -235,6 +269,10 @@ function updateAppSize(context: UseAppReturn | null, width: number, height: numb
  */
 export function createApp(rootComponent: AppRoot, options: AppOptions = {}): App {
   const { mouse = false, exitOnCtrlC = true, onError } = options;
+  const screenReaderEnabled = ref(
+    options.isScreenReaderEnabled ?? isScreenReaderEnabledByDefault(),
+  );
+  const frameDelay = Math.max(1, Math.floor(1000 / Math.max(1, options.maxFps ?? 30)));
 
   let vueApp: VueApp | null = null;
   let rootElement: FrescoElement | null = null;
@@ -288,6 +326,7 @@ export function createApp(rootComponent: AppRoot, options: AppOptions = {}): App
     focusManager = createFocusManager();
     app.provide(APP_KEY, appContext);
     app.provide(FOCUS_KEY, focusManager);
+    app.provide(SCREEN_READER_KEY, screenReaderEnabled);
 
     // Create a root element for mounting
     rootElement = createRootElement();
@@ -354,8 +393,9 @@ export function createApp(rootComponent: AppRoot, options: AppOptions = {}): App
     const start = performance.now();
 
     try {
-      // Convert Vue tree to render nodes
-      const renderNodes = treeToRenderNodes(rootElement);
+      const renderNodes = screenReaderEnabled.value
+        ? treeToScreenReaderRenderNodes(rootElement)
+        : treeToRenderNodes(rootElement);
 
       // Send to native for rendering
       if (renderNodes.length > 0) {
@@ -365,6 +405,9 @@ export function createApp(rootComponent: AppRoot, options: AppOptions = {}): App
 
         // Use renderTree which handles layout and painting
         native.renderTree(renderNodes);
+        if ("getLastRenderLayouts" in native) {
+          updateLastRenderLayouts(native.getLastRenderLayouts());
+        }
 
         // Flush to display
         native.flushTerminal();
@@ -509,7 +552,7 @@ export function createApp(rootComponent: AppRoot, options: AppOptions = {}): App
       }
 
       // Small delay to prevent busy loop
-      await new Promise((resolve) => setTimeout(resolve, 16));
+      await new Promise((resolve) => setTimeout(resolve, frameDelay));
     }
   }
 
@@ -527,7 +570,11 @@ export function createApp(rootComponent: AppRoot, options: AppOptions = {}): App
 /**
  * Ink-compatible helper that mounts immediately.
  */
-export function render(root: AppRoot, options: AppOptions = {}): RenderInstance {
+export function render(
+  root: AppRoot,
+  options: AppOptions | WritableStreamLike = {},
+): RenderInstance {
+  const renderOptions = normalizeRenderOptions(options);
   const rootRef = shallowRef(root);
   const Root = defineComponent({
     name: "FrescoRenderRoot",
@@ -539,7 +586,7 @@ export function render(root: AppRoot, options: AppOptions = {}): RenderInstance 
     },
   });
 
-  const app = createApp(Root, options);
+  const app = createApp(Root, renderOptions);
   void app.mount();
 
   return {
@@ -571,6 +618,7 @@ export function renderToString(root: AppRoot, options: RenderToStringOptions = {
     }),
   );
   app.provide(FOCUS_KEY, createFocusManager());
+  app.provide(SCREEN_READER_KEY, ref(false));
   app.mount(rootElement);
 
   const output = treeToString(rootElement);

--- a/npm/fresco/src/components/Box.ts
+++ b/npm/fresco/src/components/Box.ts
@@ -3,6 +3,8 @@
  */
 
 import { defineComponent, h, type PropType } from "@vue/runtime-core";
+import type { AriaRole, AriaState } from "../accessibility.js";
+import { useIsScreenReaderEnabled } from "../composables/useIsScreenReaderEnabled.js";
 
 export type DimensionValue = number | string;
 export type BorderStyleName =
@@ -143,27 +145,9 @@ export interface BoxProps {
   /** Hide from screen readers, accepted for Ink API parity */
   "aria-hidden"?: boolean;
   /** Accessibility role, accepted for Ink API parity */
-  "aria-role"?:
-    | "button"
-    | "checkbox"
-    | "combobox"
-    | "list"
-    | "listbox"
-    | "listitem"
-    | "menu"
-    | "menuitem"
-    | "option"
-    | "progressbar"
-    | "radio"
-    | "radiogroup"
-    | "tab"
-    | "tablist"
-    | "table"
-    | "textbox"
-    | "timer"
-    | "toolbar";
+  "aria-role"?: AriaRole;
   /** Accessibility state, accepted for Ink API parity */
-  "aria-state"?: Record<string, boolean | undefined>;
+  "aria-state"?: AriaState;
 }
 
 const dimensionProp = [Number, String] as PropType<DimensionValue>;
@@ -250,7 +234,11 @@ export const Box = defineComponent({
     "aria-state": Object as PropType<BoxProps["aria-state"]>,
   },
   setup(props, { slots }) {
+    const isScreenReaderEnabled = useIsScreenReaderEnabled();
+
     return () => {
+      if (isScreenReaderEnabled && props["aria-hidden"]) return null;
+
       const style: Record<string, unknown> = {};
 
       if (props.display) style.display = props.display;
@@ -313,6 +301,11 @@ export const Box = defineComponent({
       if (props.overflowX) style.overflowX = props.overflowX;
       if (props.overflowY) style.overflowY = props.overflowY;
 
+      const children =
+        isScreenReaderEnabled && props["aria-label"]
+          ? [h("text", { text: props["aria-label"] })]
+          : slots.default?.();
+
       return h(
         "box",
         {
@@ -332,7 +325,7 @@ export const Box = defineComponent({
           "aria-role": props["aria-role"],
           "aria-state": props["aria-state"],
         },
-        slots.default?.(),
+        children,
       );
     };
   },

--- a/npm/fresco/src/components/Text.ts
+++ b/npm/fresco/src/components/Text.ts
@@ -9,12 +9,13 @@ import { stringifyChildren } from "../utils/text.js";
 export type TextWrap =
   | boolean
   | "wrap"
-  | "end"
-  | "middle"
+  | "hard"
   | "truncate"
   | "truncate-start"
   | "truncate-middle"
-  | "truncate-end";
+  | "truncate-end"
+  | "end"
+  | "middle";
 
 export interface TextProps {
   /** Text content (alternative to slot) */

--- a/npm/fresco/src/components/Text.ts
+++ b/npm/fresco/src/components/Text.ts
@@ -3,6 +3,7 @@
  */
 
 import { defineComponent, h, type PropType } from "@vue/runtime-core";
+import { useIsScreenReaderEnabled } from "../composables/useIsScreenReaderEnabled.js";
 import { stringifyChildren } from "../utils/text.js";
 
 export type TextWrap =
@@ -68,8 +69,15 @@ export const Text = defineComponent({
     "aria-hidden": Boolean,
   },
   setup(props, { slots }) {
+    const isScreenReaderEnabled = useIsScreenReaderEnabled();
+
     return () => {
-      const text = props.content ?? stringifyChildren(slots.default?.());
+      if (isScreenReaderEnabled && props["aria-hidden"]) return null;
+
+      const text =
+        isScreenReaderEnabled && props["aria-label"]
+          ? props["aria-label"]
+          : (props.content ?? stringifyChildren(slots.default?.()));
 
       return h("text", {
         text,

--- a/npm/fresco/src/components/Transform.ts
+++ b/npm/fresco/src/components/Transform.ts
@@ -3,6 +3,7 @@
  */
 
 import { defineComponent, h, type PropType } from "@vue/runtime-core";
+import { useIsScreenReaderEnabled } from "../composables/useIsScreenReaderEnabled.js";
 import { stringifyChildren } from "../utils/text.js";
 
 export interface TransformProps {
@@ -22,12 +23,17 @@ export const Transform = defineComponent({
     },
   },
   setup(props, { slots }) {
+    const isScreenReaderEnabled = useIsScreenReaderEnabled();
+
     return () => {
       const text = stringifyChildren(slots.default?.());
-      const transformed = text
-        .split("\n")
-        .map((line, index) => props.transform(line, index))
-        .join("\n");
+      const transformed =
+        isScreenReaderEnabled && props.accessibilityLabel
+          ? props.accessibilityLabel
+          : text
+              .split("\n")
+              .map((line, index) => props.transform(line, index))
+              .join("\n");
 
       return h("text", {
         text: transformed,

--- a/npm/fresco/src/composables/useApp.ts
+++ b/npm/fresco/src/composables/useApp.ts
@@ -28,6 +28,7 @@ export interface AppContextControls {
   render?: () => void;
   clear?: () => void;
   waitUntilRenderFlush?: () => Promise<void>;
+  stdout?: NodeJS.WriteStream;
   width?: number;
   height?: number;
 }
@@ -57,14 +58,16 @@ export function createAppContext(controls: AppContextControls = {}): UseAppRetur
     return controls.waitUntilRenderFlush?.() ?? Promise.resolve();
   };
 
-  // Try to get terminal size
-  if (typeof process !== "undefined" && process.stdout) {
-    width.value = controls.width ?? process.stdout.columns ?? 80;
-    height.value = controls.height ?? process.stdout.rows ?? 24;
+  const stdout = controls.stdout ?? (typeof process !== "undefined" ? process.stdout : undefined);
 
-    process.stdout.on?.("resize", () => {
-      width.value = process.stdout.columns ?? 80;
-      height.value = process.stdout.rows ?? 24;
+  // Try to get terminal size
+  if (stdout) {
+    width.value = controls.width ?? stdout.columns ?? 80;
+    height.value = controls.height ?? stdout.rows ?? 24;
+
+    stdout.on?.("resize", () => {
+      width.value = stdout.columns ?? 80;
+      height.value = stdout.rows ?? 24;
     });
   }
 

--- a/npm/fresco/src/composables/useBoxMetrics.ts
+++ b/npm/fresco/src/composables/useBoxMetrics.ts
@@ -3,6 +3,7 @@
  */
 
 import { onMounted, onUnmounted, reactive, type Ref } from "@vue/runtime-core";
+import { getLastRenderLayout, updateLastRenderLayouts, type DOMElement } from "../layoutMetrics.js";
 
 export interface BoxMetrics {
   width: number;
@@ -15,10 +16,7 @@ export interface UseBoxMetricsResult extends BoxMetrics {
   hasMeasured: boolean;
 }
 
-export interface MetricTarget {
-  id?: number;
-  $el?: { id?: number };
-}
+export type MetricTarget = DOMElement;
 
 async function loadNative() {
   return import("@vizejs/fresco-native");
@@ -53,6 +51,7 @@ export function useBoxMetrics(ref: Ref<MetricTarget | null>): UseBoxMetricsResul
     void loadNative()
       .then((native) => {
         const layouts = "getLastRenderLayouts" in native ? native.getLastRenderLayouts() : [];
+        updateLastRenderLayouts(layouts);
         const layout = layouts.find((item: { id: number }) => item.id === id);
         if (!layout) return;
 
@@ -66,6 +65,15 @@ export function useBoxMetrics(ref: Ref<MetricTarget | null>): UseBoxMetricsResul
   };
 
   onMounted(() => {
+    const layout = getLastRenderLayout(ref.value);
+    if (layout) {
+      metrics.width = layout.width;
+      metrics.height = layout.height;
+      metrics.left = layout.x;
+      metrics.top = layout.y;
+      metrics.hasMeasured = true;
+    }
+
     refresh();
     timer = setInterval(refresh, 100);
   });

--- a/npm/fresco/src/composables/useFocus.ts
+++ b/npm/fresco/src/composables/useFocus.ts
@@ -31,7 +31,7 @@ export interface FocusManager {
   /** Ink-compatible currently focused ID alias */
   activeId: Readonly<Ref<string | undefined>>;
   /** All active focusable element IDs */
-  focusableIds: Ref<string[]>;
+  focusableIds: Readonly<Ref<string[]>>;
   /** Whether focus management is enabled */
   isEnabled: Ref<boolean>;
   /** Enable focus management */
@@ -45,13 +45,20 @@ export interface FocusManager {
   /** Focus previous element */
   focusPrevious: () => void;
   /** Register a focusable element */
-  register: (id: string) => void;
+  register: (id: string, options?: { isActive?: boolean; autoFocus?: boolean }) => void;
   /** Unregister a focusable element */
   unregister: (id: string) => void;
+  /** Activate or deactivate a focusable element while keeping its order */
+  setActive: (id: string, isActive: boolean) => void;
 }
 
-function normalizeIndex(index: number, length: number): number {
-  return ((index % length) + length) % length;
+interface Focusable {
+  id: string;
+  isActive: boolean;
+}
+
+function activeFocusables(focusables: Focusable[]): Focusable[] {
+  return focusables.filter((focusable) => focusable.isActive);
 }
 
 /**
@@ -60,46 +67,74 @@ function normalizeIndex(index: number, length: number): number {
 export function createFocusManager(): FocusManager {
   const focusedId = ref<string | null>(null);
   const activeId = computed(() => focusedId.value ?? undefined);
-  const focusableIds = ref<string[]>([]);
+  const focusables = ref<Focusable[]>([]);
+  const focusableIds = computed(() => activeFocusables(focusables.value).map(({ id }) => id));
   const isEnabled = ref(true);
 
   const focus = (id: string) => {
-    if (isEnabled.value && focusableIds.value.includes(id)) {
+    const target = focusables.value.find((focusable) => focusable.id === id);
+    if (isEnabled.value && target?.isActive) {
       focusedId.value = id;
     }
   };
 
   const focusNext = () => {
-    if (!isEnabled.value || focusableIds.value.length === 0) return;
+    const active = activeFocusables(focusables.value);
+    if (!isEnabled.value || active.length === 0) return;
 
-    const currentIndex = focusedId.value ? focusableIds.value.indexOf(focusedId.value) : -1;
-    focusedId.value =
-      focusableIds.value[normalizeIndex(currentIndex + 1, focusableIds.value.length)];
+    const currentIndex = focusedId.value
+      ? focusables.value.findIndex((focusable) => focusable.id === focusedId.value)
+      : -1;
+    const next = focusables.value.slice(currentIndex + 1).find((focusable) => focusable.isActive);
+    focusedId.value = next?.id ?? active[0]?.id ?? null;
   };
 
   const focusPrevious = () => {
-    if (!isEnabled.value || focusableIds.value.length === 0) return;
+    const active = activeFocusables(focusables.value);
+    if (!isEnabled.value || active.length === 0) return;
 
     const currentIndex = focusedId.value
-      ? focusableIds.value.indexOf(focusedId.value)
-      : focusableIds.value.length;
-    focusedId.value =
-      focusableIds.value[normalizeIndex(currentIndex - 1, focusableIds.value.length)];
+      ? focusables.value.findIndex((focusable) => focusable.id === focusedId.value)
+      : focusables.value.length;
+    const previous = focusables.value
+      .slice(0, currentIndex < 0 ? 0 : currentIndex)
+      .findLast((focusable) => focusable.isActive);
+    focusedId.value = previous?.id ?? active.at(-1)?.id ?? null;
   };
 
-  const register = (id: string) => {
-    if (!focusableIds.value.includes(id)) {
-      focusableIds.value.push(id);
+  const register: FocusManager["register"] = (id, options = {}) => {
+    const existing = focusables.value.find((focusable) => focusable.id === id);
+    if (existing) {
+      existing.isActive = options.isActive ?? existing.isActive;
+    } else {
+      focusables.value.push({
+        id,
+        isActive: options.isActive ?? true,
+      });
+    }
+
+    if (options.autoFocus && !focusedId.value && options.isActive !== false) {
+      focus(id);
     }
   };
 
   const unregister = (id: string) => {
-    const index = focusableIds.value.indexOf(id);
+    const index = focusables.value.findIndex((focusable) => focusable.id === id);
     if (index !== -1) {
-      focusableIds.value.splice(index, 1);
+      focusables.value.splice(index, 1);
       if (focusedId.value === id) {
-        focusedId.value = focusableIds.value[0] ?? null;
+        focusedId.value = null;
       }
+    }
+  };
+
+  const setActive = (id: string, isActive: boolean) => {
+    const focusable = focusables.value.find((item) => item.id === id);
+    if (!focusable) return;
+
+    focusable.isActive = isActive;
+    if (!isActive && focusedId.value === id) {
+      focusedId.value = null;
     }
   };
 
@@ -124,6 +159,7 @@ export function createFocusManager(): FocusManager {
     focusPrevious,
     register,
     unregister,
+    setActive,
   };
 }
 
@@ -174,19 +210,15 @@ export function useFocus(options: UseFocusOptions = {}) {
   };
 
   if (manager) {
+    manager.register(id, { isActive: active.value, autoFocus });
+
     watch(
       active,
       (enabled) => {
-        if (enabled) {
-          manager.register(id);
-          if (autoFocus && !manager.focusedId.value) {
-            manager.focus(id);
-          }
-        } else {
-          manager.unregister(id);
-        }
+        manager.setActive(id, enabled);
+        if (enabled && autoFocus && !manager.focusedId.value) manager.focus(id);
       },
-      { immediate: true },
+      { immediate: false },
     );
 
     onUnmounted(() => {

--- a/npm/fresco/src/composables/useIsScreenReaderEnabled.ts
+++ b/npm/fresco/src/composables/useIsScreenReaderEnabled.ts
@@ -2,6 +2,10 @@
  * useIsScreenReaderEnabled - screen reader mode flag.
  */
 
+import { inject } from "@vue/runtime-core";
+import { SCREEN_READER_KEY, isScreenReaderEnabledByDefault } from "../accessibility.js";
+
 export function useIsScreenReaderEnabled(): boolean {
-  return process.env.INK_SCREEN_READER === "true" || process.env.FRESCO_SCREEN_READER === "true";
+  const enabled = inject(SCREEN_READER_KEY, null);
+  return enabled?.value ?? isScreenReaderEnabledByDefault();
 }

--- a/npm/fresco/src/composables/usePaste.ts
+++ b/npm/fresco/src/composables/usePaste.ts
@@ -2,8 +2,9 @@
  * usePaste - bracketed paste handling.
  */
 
-import { isRef, ref, watch, type Ref } from "@vue/runtime-core";
+import { isRef, onUnmounted, ref, watch, type Ref } from "@vue/runtime-core";
 import { lastPasteEvent } from "../app.js";
+import { useStreamsContext } from "./useStreams.js";
 
 export interface UsePasteOptions {
   /** Whether the paste handler is active */
@@ -16,11 +17,22 @@ function toRef(value: boolean | Ref<boolean>): Ref<boolean> {
 
 export function usePaste(handler: (text: string) => void, options: UsePasteOptions = {}) {
   const isActive = toRef(options.isActive ?? true);
+  const streams = useStreamsContext();
+  let bracketedPasteEnabled = false;
+
+  const syncBracketedPasteMode = (isEnabled: boolean) => {
+    if (bracketedPasteEnabled === isEnabled) return;
+    streams.setBracketedPasteMode(isEnabled);
+    bracketedPasteEnabled = isEnabled;
+  };
 
   watch(lastPasteEvent, (event) => {
     if (!event || !isActive.value) return;
     handler(event.text);
   });
+
+  watch(isActive, syncBracketedPasteMode, { immediate: true });
+  onUnmounted(() => syncBracketedPasteMode(false));
 
   return {
     isActive,

--- a/npm/fresco/src/composables/useStreams.ts
+++ b/npm/fresco/src/composables/useStreams.ts
@@ -2,6 +2,31 @@
  * Stream composables matching Ink's stdin/stdout/stderr helpers.
  */
 
+import { inject, type InjectionKey } from "@vue/runtime-core";
+
+const BRACKETED_PASTE_ENABLE = "\x1B[?2004h";
+const BRACKETED_PASTE_DISABLE = "\x1B[?2004l";
+
+export const STREAMS_KEY: InjectionKey<StreamsContext> = Symbol("fresco-streams");
+
+export interface StreamsContextOptions {
+  stdin?: NodeJS.ReadStream;
+  stdout?: NodeJS.WriteStream;
+  stderr?: NodeJS.WriteStream;
+  exitOnCtrlC?: boolean;
+  interactive?: boolean;
+}
+
+export interface StreamsContext {
+  stdin: NodeJS.ReadStream;
+  stdout: NodeJS.WriteStream;
+  stderr: NodeJS.WriteStream;
+  setRawMode: (isRawMode: boolean) => void;
+  isRawModeSupported: boolean;
+  setBracketedPasteMode: (isEnabled: boolean) => void;
+  internal_exitOnCtrlC: boolean;
+}
+
 export interface UseStdinReturn {
   stdin: NodeJS.ReadStream;
   setRawMode: (isRawMode: boolean) => void;
@@ -19,21 +44,55 @@ export interface UseStderrReturn {
   write: (data: string) => void;
 }
 
-export function useStdin(): UseStdinReturn {
-  const stdin = process.stdin;
+export function createStreamsContext(options: StreamsContextOptions = {}): StreamsContext {
+  const stdin = options.stdin ?? process.stdin;
+  const stdout = options.stdout ?? process.stdout;
+  const stderr = options.stderr ?? process.stderr;
+  const isInteractive = options.interactive ?? true;
+  let bracketedPasteDepth = 0;
 
   return {
     stdin,
+    stdout,
+    stderr,
     setRawMode: (isRawMode: boolean) => {
       stdin.setRawMode?.(isRawMode);
     },
     isRawModeSupported: typeof stdin.setRawMode === "function",
-    internal_exitOnCtrlC: true,
+    setBracketedPasteMode: (isEnabled: boolean) => {
+      if (!isInteractive) return;
+
+      if (isEnabled) {
+        bracketedPasteDepth += 1;
+        if (bracketedPasteDepth === 1) stdout.write(BRACKETED_PASTE_ENABLE);
+        return;
+      }
+
+      if (bracketedPasteDepth === 0) return;
+      bracketedPasteDepth -= 1;
+      if (bracketedPasteDepth === 0) stdout.write(BRACKETED_PASTE_DISABLE);
+    },
+    internal_exitOnCtrlC: options.exitOnCtrlC ?? true,
+  };
+}
+
+export function useStreamsContext(): StreamsContext {
+  return inject(STREAMS_KEY) ?? createStreamsContext();
+}
+
+export function useStdin(): UseStdinReturn {
+  const streams = useStreamsContext();
+
+  return {
+    stdin: streams.stdin,
+    setRawMode: streams.setRawMode,
+    isRawModeSupported: streams.isRawModeSupported,
+    internal_exitOnCtrlC: streams.internal_exitOnCtrlC,
   };
 }
 
 export function useStdout(): UseStdoutReturn {
-  const stdout = process.stdout;
+  const { stdout } = useStreamsContext();
 
   return {
     stdout,
@@ -44,7 +103,7 @@ export function useStdout(): UseStdoutReturn {
 }
 
 export function useStderr(): UseStderrReturn {
-  const stderr = process.stderr;
+  const { stderr } = useStreamsContext();
 
   return {
     stderr,

--- a/npm/fresco/src/index.ts
+++ b/npm/fresco/src/index.ts
@@ -11,6 +11,7 @@ export {
   renderToString,
   type App,
   type AppOptions,
+  type RenderOptions,
   type RenderInstance,
   type RenderToStringOptions,
   lastKeyEvent,
@@ -27,6 +28,14 @@ export {
   type CompositionEvent,
 } from "./app.js";
 export { createRenderer } from "./renderer.js";
+export {
+  kittyFlags,
+  kittyModifiers,
+  resolveKittyFlags,
+  type KittyFlagName,
+  type KittyKeyboardOptions,
+} from "./kittyKeyboard.js";
+export { measureElement, type DOMElement } from "./measureElement.js";
 
 // Components
 export * from "./components/index.js";

--- a/npm/fresco/src/kittyKeyboard.ts
+++ b/npm/fresco/src/kittyKeyboard.ts
@@ -1,0 +1,33 @@
+/**
+ * Kitty keyboard protocol constants compatible with Ink.
+ */
+
+export const kittyFlags = {
+  disambiguateEscapeCodes: 1,
+  reportEventTypes: 2,
+  reportAlternateKeys: 4,
+  reportAllKeysAsEscapeCodes: 8,
+  reportAssociatedText: 16,
+} as const;
+
+export type KittyFlagName = keyof typeof kittyFlags;
+
+export interface KittyKeyboardOptions {
+  mode?: "auto" | "enabled" | "disabled";
+  flags?: KittyFlagName[];
+}
+
+export function resolveKittyFlags(flags: KittyFlagName[]): number {
+  return flags.reduce((bits, flag) => bits | kittyFlags[flag], 0);
+}
+
+export const kittyModifiers = {
+  shift: 1,
+  alt: 2,
+  ctrl: 4,
+  super: 8,
+  hyper: 16,
+  meta: 32,
+  capsLock: 64,
+  numLock: 128,
+} as const;

--- a/npm/fresco/src/layoutMetrics.ts
+++ b/npm/fresco/src/layoutMetrics.ts
@@ -1,0 +1,32 @@
+/**
+ * Shared post-render layout metrics.
+ */
+
+import type { LayoutResultNapi } from "@vizejs/fresco-native";
+
+export interface DOMElement {
+  id?: number;
+  $el?: {
+    id?: number;
+  };
+}
+
+let lastRenderLayouts: LayoutResultNapi[] = [];
+
+export function updateLastRenderLayouts(layouts: LayoutResultNapi[]) {
+  lastRenderLayouts = layouts;
+}
+
+export function getLastRenderLayout(node: DOMElement | null | undefined): LayoutResultNapi | null {
+  const id = node?.id ?? node?.$el?.id;
+  if (id === undefined) return null;
+  return lastRenderLayouts.find((layout) => layout.id === id) ?? null;
+}
+
+export function measureElement(node: DOMElement): { width: number; height: number } {
+  const layout = getLastRenderLayout(node);
+  return {
+    width: layout?.width ?? 0,
+    height: layout?.height ?? 0,
+  };
+}

--- a/npm/fresco/src/measureElement.ts
+++ b/npm/fresco/src/measureElement.ts
@@ -1,0 +1,5 @@
+/**
+ * Ink-compatible synchronous element measurement.
+ */
+
+export { measureElement as default, measureElement, type DOMElement } from "./layoutMetrics.js";

--- a/npm/fresco/src/renderer.ts
+++ b/npm/fresco/src/renderer.ts
@@ -190,6 +190,16 @@ function isWrappingEnabled(value: unknown): boolean {
   return true;
 }
 
+function textWrapMode(value: unknown): string | undefined {
+  if (value === undefined) return undefined;
+  if (value === false) return "none";
+  if (value === true) return "wrap";
+  if (value === "end") return "truncate-end";
+  if (value === "middle") return "truncate-middle";
+  if (typeof value === "string") return value;
+  return undefined;
+}
+
 /**
  * Convert Fresco tree to render nodes for native
  */
@@ -209,6 +219,7 @@ export function treeToRenderNodes(root: FrescoNode): NativeRenderNode[] {
     }
     if (node.props.wrap !== undefined) {
       renderNode.wrap = isWrappingEnabled(node.props.wrap);
+      renderNode.wrapMode = textWrapMode(node.props.wrap);
     }
     if (node.props.value !== undefined) {
       renderNode.value = stringValue(node.props.value) ?? "";


### PR DESCRIPTION
## Summary
- add Ink-compatible screen reader context and ARIA-aware output generation for Fresco
- make Text, Box, and Transform honor aria-label/aria-hidden/accessibilityLabel when screen reader mode is enabled
- expose Ink-compatible render(node, stdout), Kitty keyboard constants, and measureElement layout reads
- preserve focus order when useFocus({ isActive }) toggles inactive, matching Ink focus manager behavior more closely

## Validation
- pnpm --filter @vizejs/fresco check
- pnpm --filter @vizejs/fresco build
- node smoke for renderToString, Kitty constants, measureElement
- node --experimental-strip-types smoke for screen reader ARIA output