### PR TITLE
fix(canon): honor tsconfig declaration emit options

### DIFF
--- a/crates/vize/src/commands/check/runner.rs
+++ b/crates/vize/src/commands/check/runner.rs
@@ -28,7 +28,9 @@ use crate::commands::profile::{
 use super::{
     CheckArgs,
     reporting::{JsonFileResult, JsonOutput},
-    tsconfig_inputs::collect_default_check_files,
+    tsconfig_inputs::{
+        TsconfigDeclarationOptions, collect_default_check_files, load_tsconfig_declaration_options,
+    },
 };
 
 mod collect;
@@ -113,7 +115,7 @@ pub(crate) fn run_direct(args: &CheckArgs) {
     let mut checker = match BatchTypeChecker::with_options(
         &project_root,
         BatchTypeCheckerOptions {
-            tsconfig_path,
+            tsconfig_path: tsconfig_path.clone(),
             virtual_ts_options,
         },
     ) {
@@ -168,9 +170,13 @@ pub(crate) fn run_direct(args: &CheckArgs) {
 
     let emit_start = Instant::now();
     let emitted_declarations = if args.declaration {
-        let declaration_dir =
-            resolve_declaration_dir(args.declaration_dir.as_deref(), &project_root);
-        match checker.emit_declarations(&DeclarationEmitOptions::new(declaration_dir.clone())) {
+        let declaration_options = resolve_declaration_emit_options(
+            args.declaration_dir.as_deref(),
+            tsconfig_path.as_deref(),
+            &project_root,
+        );
+        let declaration_dir = declaration_options.out_dir.clone();
+        match checker.emit_declarations(&declaration_options) {
             Ok(result) => Some((declaration_dir, result)),
             Err(error) => {
                 eprintln!("\x1b[31mError:\x1b[0m {}", error);
@@ -555,7 +561,25 @@ fn build_virtual_ts_options(
     }
 }
 
-fn resolve_declaration_dir(declaration_dir: Option<&Path>, project_root: &Path) -> PathBuf {
+fn resolve_declaration_emit_options(
+    declaration_dir: Option<&Path>,
+    tsconfig_path: Option<&Path>,
+    project_root: &Path,
+) -> DeclarationEmitOptions {
+    let tsconfig_options = tsconfig_path
+        .map(load_tsconfig_declaration_options)
+        .unwrap_or_default();
+    let out_dir = resolve_declaration_dir(declaration_dir, &tsconfig_options, project_root);
+
+    DeclarationEmitOptions::new(out_dir)
+        .with_declaration_map(tsconfig_options.declaration_map.unwrap_or(false))
+}
+
+fn resolve_declaration_dir(
+    declaration_dir: Option<&Path>,
+    tsconfig_options: &TsconfigDeclarationOptions,
+    project_root: &Path,
+) -> PathBuf {
     declaration_dir
         .map(|path| {
             if path.is_absolute() {
@@ -564,6 +588,7 @@ fn resolve_declaration_dir(declaration_dir: Option<&Path>, project_root: &Path) 
                 project_root.join(path)
             }
         })
+        .or_else(|| tsconfig_options.output_dir().map(Path::to_path_buf))
         .unwrap_or_else(|| project_root.join("dist").join("types"))
 }
 
@@ -679,19 +704,94 @@ fn parse_dts_globals(
 
 #[cfg(test)]
 mod tests {
-    use super::resolve_declaration_dir;
-    use std::path::{Path, PathBuf};
+    use super::{resolve_declaration_dir, resolve_declaration_emit_options};
+    use crate::commands::check::tsconfig_inputs::TsconfigDeclarationOptions;
+    use std::{
+        path::{Path, PathBuf},
+        sync::atomic::{AtomicUsize, Ordering},
+    };
+
+    fn unique_case_dir(name: &str) -> PathBuf {
+        static NEXT_CASE_ID: AtomicUsize = AtomicUsize::new(0);
+
+        let case_id = NEXT_CASE_ID.fetch_add(1, Ordering::Relaxed);
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("__agent_only")
+            .join("tests")
+            .join(format!(
+                "check-runner-{name}-{}-{case_id}",
+                std::process::id()
+            ))
+    }
 
     #[test]
     fn resolve_declaration_dir_defaults_to_dist_types() {
         let project_root = PathBuf::from("/workspace/project");
+        let tsconfig_options = TsconfigDeclarationOptions::default();
         assert_eq!(
-            resolve_declaration_dir(None, &project_root),
+            resolve_declaration_dir(None, &tsconfig_options, &project_root),
             project_root.join("dist").join("types")
         );
         assert_eq!(
-            resolve_declaration_dir(Some(Path::new("types")), &project_root),
+            resolve_declaration_dir(Some(Path::new("types")), &tsconfig_options, &project_root),
             project_root.join("types")
         );
+    }
+
+    #[test]
+    fn resolve_declaration_dir_uses_tsconfig_when_cli_dir_is_absent() {
+        let project_root = PathBuf::from("/workspace/project");
+        let tsconfig_options = TsconfigDeclarationOptions {
+            declaration_dir: Some(project_root.join("types")),
+            out_dir: Some(project_root.join("dist")),
+            declaration_map: Some(true),
+        };
+
+        assert_eq!(
+            resolve_declaration_dir(None, &tsconfig_options, &project_root),
+            project_root.join("types")
+        );
+        assert_eq!(
+            resolve_declaration_dir(Some(Path::new("custom")), &tsconfig_options, &project_root),
+            project_root.join("custom")
+        );
+
+        let out_dir_only = TsconfigDeclarationOptions {
+            declaration_dir: None,
+            out_dir: Some(project_root.join("dist")),
+            declaration_map: None,
+        };
+        assert_eq!(
+            resolve_declaration_dir(None, &out_dir_only, &project_root),
+            project_root.join("dist")
+        );
+    }
+
+    #[test]
+    fn resolve_declaration_emit_options_uses_tsconfig_declaration_map() {
+        let project_root = unique_case_dir("declaration-options");
+        let _ = std::fs::remove_dir_all(&project_root);
+        std::fs::create_dir_all(&project_root).unwrap();
+        std::fs::write(
+            project_root.join("tsconfig.json"),
+            r#"{
+  "compilerOptions": {
+    "declarationDir": "types",
+    "declarationMap": true
+  }
+}"#,
+        )
+        .unwrap();
+
+        let options = resolve_declaration_emit_options(
+            None,
+            Some(&project_root.join("tsconfig.json")),
+            &project_root,
+        );
+
+        assert_eq!(options.out_dir, project_root.join("types"));
+        assert!(options.declaration_map);
+
+        let _ = std::fs::remove_dir_all(&project_root);
     }
 }

--- a/crates/vize/src/commands/check/tsconfig_inputs.rs
+++ b/crates/vize/src/commands/check/tsconfig_inputs.rs
@@ -43,6 +43,31 @@ impl TsconfigInputSpec {
     }
 }
 
+#[derive(Debug, Clone, Default)]
+pub(crate) struct TsconfigDeclarationOptions {
+    pub(crate) declaration_dir: Option<PathBuf>,
+    pub(crate) out_dir: Option<PathBuf>,
+    pub(crate) declaration_map: Option<bool>,
+}
+
+impl TsconfigDeclarationOptions {
+    fn apply_extended(&mut self, extended: Self) {
+        if extended.declaration_dir.is_some() {
+            self.declaration_dir = extended.declaration_dir;
+        }
+        if extended.out_dir.is_some() {
+            self.out_dir = extended.out_dir;
+        }
+        if extended.declaration_map.is_some() {
+            self.declaration_map = extended.declaration_map;
+        }
+    }
+
+    pub(crate) fn output_dir(&self) -> Option<&Path> {
+        self.declaration_dir.as_deref().or(self.out_dir.as_deref())
+    }
+}
+
 #[derive(Debug, Clone)]
 struct RelativePathSpec {
     base_dir: PathBuf,
@@ -139,6 +164,13 @@ pub(crate) fn collect_default_check_files(
 
     files.sort();
     files
+}
+
+pub(crate) fn load_tsconfig_declaration_options(
+    tsconfig_path: &Path,
+) -> TsconfigDeclarationOptions {
+    let mut seen = FxHashSet::default();
+    load_tsconfig_declaration_options_inner(tsconfig_path, &mut seen).unwrap_or_default()
 }
 
 fn collect_supported_files(
@@ -241,6 +273,51 @@ fn load_tsconfig_inputs_inner(
     Ok(merged)
 }
 
+fn load_tsconfig_declaration_options_inner(
+    tsconfig_path: &Path,
+    seen: &mut FxHashSet<PathBuf>,
+) -> Result<TsconfigDeclarationOptions, std::io::Error> {
+    let resolved = normalize_input_path(tsconfig_path);
+    if !seen.insert(resolved.clone()) {
+        return Ok(TsconfigDeclarationOptions::default());
+    }
+
+    let content = tracked_read_to_string(&resolved)?;
+    let value = parse_jsonc_value(&content).unwrap_or(Value::Null);
+    let dir = resolved.parent().unwrap_or(Path::new("."));
+
+    let mut merged = TsconfigDeclarationOptions::default();
+    for extends in read_extends_entries(&value) {
+        let Some(extends_path) = resolve_extended_tsconfig(&resolved, &extends) else {
+            continue;
+        };
+        let extended = load_tsconfig_declaration_options_inner(&extends_path, seen)?;
+        merged.apply_extended(extended);
+    }
+
+    let Some(compiler_options) = value.get("compilerOptions").and_then(Value::as_object) else {
+        return Ok(merged);
+    };
+
+    if let Some(declaration_dir) = compiler_options
+        .get("declarationDir")
+        .and_then(Value::as_str)
+    {
+        merged.declaration_dir = Some(resolve_tsconfig_path_option(dir, declaration_dir));
+    }
+    if let Some(out_dir) = compiler_options.get("outDir").and_then(Value::as_str) {
+        merged.out_dir = Some(resolve_tsconfig_path_option(dir, out_dir));
+    }
+    if let Some(declaration_map) = compiler_options
+        .get("declarationMap")
+        .and_then(Value::as_bool)
+    {
+        merged.declaration_map = Some(declaration_map);
+    }
+
+    Ok(merged)
+}
+
 fn resolve_extended_tsconfig(tsconfig_path: &Path, extends: &str) -> Option<PathBuf> {
     let base_dir = tsconfig_path.parent().unwrap_or(Path::new("."));
     let mut candidates = Vec::new();
@@ -259,6 +336,15 @@ fn resolve_extended_tsconfig(tsconfig_path: &Path, extends: &str) -> Option<Path
     }
 
     candidates.into_iter().find(|candidate| candidate.is_file())
+}
+
+fn resolve_tsconfig_path_option(base_dir: &Path, value: &str) -> PathBuf {
+    let path = Path::new(value);
+    if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        base_dir.join(path)
+    }
 }
 
 fn push_node_modules_tsconfig_candidates(
@@ -567,7 +653,9 @@ fn strip_trailing_commas(content: &str) -> std::string::String {
 
 #[cfg(test)]
 mod tests {
-    use super::{collect_default_check_files, resolve_extended_tsconfig};
+    use super::{
+        collect_default_check_files, load_tsconfig_declaration_options, resolve_extended_tsconfig,
+    };
     use std::fs;
     use std::path::{Path, PathBuf};
     use vize_carton::cstr;
@@ -644,6 +732,50 @@ mod tests {
         let files = collect_default_check_files(&case_dir, Some(&case_dir.join("tsconfig.json")));
 
         assert_eq!(files, vec![case_dir.join("src/App.vue")]);
+
+        let _ = fs::remove_dir_all(&case_dir);
+    }
+
+    #[test]
+    fn declaration_options_inherit_extends_and_use_config_relative_paths() {
+        let case_dir = unique_case_dir("tsconfig-declaration-options");
+        let _ = fs::remove_dir_all(&case_dir);
+        fs::create_dir_all(case_dir.join("configs")).unwrap();
+        fs::write(
+            case_dir.join("configs/base.json"),
+            r#"{
+  "compilerOptions": {
+    "declarationDir": "base-types",
+    "outDir": "base-dist",
+    "declarationMap": true
+  }
+}"#,
+        )
+        .unwrap();
+        fs::write(
+            case_dir.join("tsconfig.json"),
+            r#"{
+  "extends": "./configs/base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "declarationMap": false
+  }
+}"#,
+        )
+        .unwrap();
+
+        let options = load_tsconfig_declaration_options(&case_dir.join("tsconfig.json"));
+
+        assert_eq!(
+            options.declaration_dir,
+            Some(case_dir.join("configs/base-types"))
+        );
+        assert_eq!(options.out_dir, Some(case_dir.join("dist")));
+        assert_eq!(options.declaration_map, Some(false));
+        assert_eq!(
+            options.output_dir(),
+            Some(case_dir.join("configs/base-types").as_path())
+        );
 
         let _ = fs::remove_dir_all(&case_dir);
     }

--- a/crates/vize/tests/check_cli.rs
+++ b/crates/vize/tests/check_cli.rs
@@ -339,6 +339,111 @@ export {}
     let _ = std::fs::remove_dir_all(&project_root);
 }
 
+#[test]
+fn check_declaration_emit_uses_tsconfig_options() {
+    let Some(corsa_path) = resolve_test_corsa_path() else {
+        return;
+    };
+    let project_root = create_cli_project(
+        "emit-declarations-tsconfig",
+        &[
+            (
+                "tsconfig.json",
+                r#"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true,
+    "declarationDir": "types-from-tsconfig",
+    "declarationMap": true
+  },
+  "include": ["src/**/*"]
+}"#,
+            ),
+            (
+                "src/App.vue",
+                r#"<script setup lang="ts">
+export interface PublicProps {
+  label: string
+}
+
+defineProps<PublicProps>()
+</script>
+
+<template>
+  <button>{{ label }}</button>
+</template>
+"#,
+            ),
+            (
+                "src/index.ts",
+                r#"export { default as App } from './App.vue'
+"#,
+            ),
+        ],
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(&project_root)
+        .env("CORSA_PATH", corsa_path)
+        .args(["check", ".", "--format", "json", "--declaration"])
+        .output()
+        .unwrap();
+
+    let stdout = std::string::String::from_utf8(output.stdout).unwrap();
+    let stderr = std::string::String::from_utf8(output.stderr).unwrap();
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "stdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+
+    let json: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    let declarations = json["declarations"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|path| path.as_str().unwrap())
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        declarations,
+        vec![
+            "types-from-tsconfig/App.vue.d.ts",
+            "types-from-tsconfig/index.d.ts"
+        ]
+    );
+    assert!(
+        project_root
+            .join("types-from-tsconfig/App.vue.d.ts")
+            .is_file()
+    );
+    assert!(
+        project_root
+            .join("types-from-tsconfig/App.vue.d.ts.map")
+            .is_file()
+    );
+    assert!(
+        project_root
+            .join("types-from-tsconfig/index.d.ts")
+            .is_file()
+    );
+    assert!(
+        project_root
+            .join("types-from-tsconfig/index.d.ts.map")
+            .is_file()
+    );
+    assert!(!project_root.join("dist/types").exists());
+
+    let app_declaration =
+        std::fs::read_to_string(project_root.join("types-from-tsconfig/App.vue.d.ts")).unwrap();
+    assert!(app_declaration.contains("export interface PublicProps"));
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}
+
 fn collect_declaration_snapshot(
     declaration_dir: &Path,
 ) -> Vec<(std::string::String, std::string::String)> {


### PR DESCRIPTION
## Summary
- resolve declaration emit output from tsconfig compilerOptions.declarationDir, falling back to outDir and then the existing dist/types default
- preserve declarationMap from tsconfig during .vue/.ts declaration emit
- add strict unit and CLI coverage for inherited tsconfig options and .vue .d.ts/.d.ts.map output

## Local verification
- cargo fmt --all -- --check
- cargo clippy --workspace -- -D warnings
- cargo test --workspace