### PR TITLE
ci: add pkg.pr.new preview publishing

### DIFF
--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -42,8 +42,15 @@ jobs:
         run: vp run --workspace-root build:packages
 
       - name: Publish pkg.pr.new preview
+        # The pkg.pr.new GitHub App must be installed on this repository for
+        # the publish call to succeed. Until it is, the job logs a clear
+        # message and is marked successful so the workflow does not red-light
+        # every PR while waiting on a one-time install action by a maintainer.
+        # https://github.com/apps/pkg-pr-new
         run: |
-          vp exec pkg-pr-new publish --pnpm --packageManager=pnpm --comment=update \
+          set -e
+          OUTPUT_FILE=$(mktemp)
+          if vp exec pkg-pr-new publish --pnpm --packageManager=pnpm --comment=update \
             './npm/vize' \
             './npm/vite-plugin-vize' \
             './npm/oxlint-plugin-vize' \
@@ -53,4 +60,11 @@ jobs:
             './npm/vite-plugin-musea' \
             './npm/rspack-vize-plugin' \
             './npm/musea-nuxt' \
-            './npm/nuxt'
+            './npm/nuxt' 2>&1 | tee "$OUTPUT_FILE"; then
+            exit 0
+          fi
+          if grep -q "The app https://github.com/apps/pkg-pr-new is not installed" "$OUTPUT_FILE"; then
+            echo "::warning::pkg-pr-new GitHub App is not installed on this repository. Install https://github.com/apps/pkg-pr-new to enable preview publishing. Skipping for now."
+            exit 0
+          fi
+          exit 1

--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -1,0 +1,56 @@
+name: pkg.pr.new
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: pkg-pr-new-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  NODE_OPTIONS: "--disable-warning=DEP0040 --disable-warning=DEP0169"
+
+jobs:
+  publish-preview:
+    name: Publish preview packages
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Setup Vite+ and Node.js
+        uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1
+        with:
+          node-version-file: ".node-version"
+          cache: true
+          run-install: false
+
+      - uses: ./.github/actions/setup-moonbit
+
+      - name: Install package build dependencies
+        run: moon run --target native - -- --filter './npm/vize...' --filter './npm/vite-plugin-vize...' --filter './npm/oxlint-plugin-vize...' --filter './npm/unplugin-vize...' --filter './npm/fresco...' --filter './npm/musea-mcp-server...' --filter './npm/vite-plugin-musea...' --filter './npm/rspack-vize-plugin...' --filter './npm/musea-nuxt...' --filter './npm/nuxt...' < tools/moon/scripts/github/vp_install.mbtx
+
+      - name: Build preview packages
+        run: vp run --workspace-root build:packages
+
+      - name: Publish pkg.pr.new preview
+        run: |
+          vp exec pkg-pr-new publish --pnpm --packageManager=pnpm --comment=update \
+            './npm/vize' \
+            './npm/vite-plugin-vize' \
+            './npm/oxlint-plugin-vize' \
+            './npm/unplugin-vize' \
+            './npm/fresco' \
+            './npm/musea-mcp-server' \
+            './npm/vite-plugin-musea' \
+            './npm/rspack-vize-plugin' \
+            './npm/musea-nuxt' \
+            './npm/nuxt'

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "json-schema-to-typescript": "catalog:repo-tooling",
     "oxfmt": "catalog:linting",
     "oxlint": "catalog:linting",
+    "pkg-pr-new": "catalog:repo-tooling",
     "tsdown": "catalog:vite-stack",
     "vite": "catalog:vite-stack",
     "vite-plus": "catalog:vite-stack"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -117,6 +117,9 @@ catalogs:
     json-schema-to-typescript:
       specifier: 15.0.4
       version: 15.0.4
+    pkg-pr-new:
+      specifier: 0.0.73
+      version: 0.0.73
     prettier:
       specifier: 3.8.3
       version: 3.8.3
@@ -236,6 +239,9 @@ importers:
       oxlint:
         specifier: catalog:linting
         version: 1.64.0(oxlint-tsgolint@0.22.1)
+      pkg-pr-new:
+        specifier: catalog:repo-tooling
+        version: 0.0.73
       tsdown:
         specifier: catalog:vite-stack
         version: 0.22.0(@tsdown/css@0.22.0)(@typescript/native-preview@7.0.0-dev.20260514.1)(tsx@4.21.0)(typescript@6.0.3)(unrun@0.2.39)(vue-tsc@3.2.9(typescript@6.0.3))
@@ -7490,6 +7496,10 @@ packages:
   pkce-challenge@5.0.1:
     resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
     engines: {node: '>=16.20.0'}
+
+  pkg-pr-new@0.0.73:
+    resolution: {integrity: sha512-/4iUn/yiDo5Fur+wGBASVPUTPPzcu422+BA0KeyTtDNX7uPuDfB/Lul9vGLXyk6Y2lULZ9YIxfqnNTGiImRLbw==}
+    hasBin: true
 
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
@@ -15821,6 +15831,8 @@ snapshots:
       pngjs: 7.0.0
 
   pkce-challenge@5.0.1: {}
+
+  pkg-pr-new@0.0.73: {}
 
   pkg-types@1.3.1:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -19,6 +19,7 @@ catalogs:
     "@pkl-community/pkl": "0.27.2"
     glob: "13.0.6"
     json-schema-to-typescript: "15.0.4"
+    pkg-pr-new: "0.0.73"
     prettier: "3.8.3"
     tinyglobby: "0.2.16"
 

--- a/tests/tooling/github-workflows.test.ts
+++ b/tests/tooling/github-workflows.test.ts
@@ -45,7 +45,13 @@ function workflowJobBody(workflow: string, jobName: string): string {
 }
 
 test("GitHub workflows opt JavaScript actions into Node 24", () => {
-  for (const workflowName of ["check.yml", "deploy-docs.yml", "native-smoke.yml", "release.yml"]) {
+  for (const workflowName of [
+    "check.yml",
+    "deploy-docs.yml",
+    "native-smoke.yml",
+    "pkg-pr-new.yml",
+    "release.yml",
+  ]) {
     const workflow = readRepoFile(".github", "workflows", workflowName);
     assert.match(workflow, /FORCE_JAVASCRIPT_ACTIONS_TO_NODE24:\s*true/);
   }
@@ -771,4 +777,30 @@ test("check and docs workflows use the CI Rust profile for non-release native bu
   assert.match(checkWorkflow, /cp target\/ci\/vize \/usr\/local\/bin\/vize/);
   assert.match(checkWorkflow, /vp run --filter '\.\/npm\/vize-native' build:ci/);
   assert.match(deployDocsWorkflow, /vp run --filter '\.\/npm\/vize-native' build:ci/);
+});
+
+test("pkg.pr.new workflow publishes built npm packages from the lockfile", () => {
+  const workflow = readRepoFile(".github", "workflows", "pkg-pr-new.yml");
+  const job = workflowJobBody(workflow, "publish-preview");
+
+  assert.match(job, /timeout-minutes:\s*30/);
+  assert.match(job, /vp run --workspace-root build:packages/);
+  assert.match(job, /vp exec pkg-pr-new publish --pnpm --packageManager=pnpm --comment=update/);
+  assert.doesNotMatch(job, /\b(?:npx|bunx)\b|pnpm dlx|yarn dlx/);
+  assert.equal([...job.matchAll(/pkg-pr-new publish/g)].length, 1);
+
+  for (const packagePath of [
+    "./npm/vize",
+    "./npm/vite-plugin-vize",
+    "./npm/oxlint-plugin-vize",
+    "./npm/unplugin-vize",
+    "./npm/fresco",
+    "./npm/musea-mcp-server",
+    "./npm/vite-plugin-musea",
+    "./npm/rspack-vize-plugin",
+    "./npm/musea-nuxt",
+    "./npm/nuxt",
+  ]) {
+    assert.match(job, new RegExp(packagePath.replaceAll("/", "\\/").replace(".", "\\.")));
+  }
 });


### PR DESCRIPTION
## What changed

- Added a `pkg.pr.new` GitHub Actions workflow for PR, `main`, and manual preview package publishing.
- Installed `pkg-pr-new` through the repo tooling catalog and lockfile.
- Added workflow tests to keep preview publishing on the lockfile-backed `vp exec` path and ensure the publish command runs once for all selected packages.

## Why

This gives contributors installable preview package URLs from PR builds without publishing temporary versions to npm.

## Notes

The pkg.pr.new GitHub App must be installed on this repository for the workflow to publish previews and comment on PRs.

## Validation

- `node --test --test-concurrency=1 tests/tooling/github-workflows.test.ts`
- `pnpm install --frozen-lockfile --lockfile-only`
- `git diff --check`
