### PR TITLE
fix(lsp): version diagnostic publishes

### DIFF
--- a/crates/vize_maestro/src/server/helpers.rs
+++ b/crates/vize_maestro/src/server/helpers.rs
@@ -17,12 +17,23 @@ use vize_carton::append;
 impl MaestroServer {
     /// Publish diagnostics for a document.
     pub(crate) async fn publish_diagnostics(&self, uri: &Url) {
+        let version = self
+            .state
+            .documents
+            .get(uri)
+            .map(|document| document.version);
+
         if !self.state.lsp_features().has_diagnostics() {
             self.client
-                .publish_diagnostics(uri.clone(), Vec::new(), None)
+                .publish_diagnostics(uri.clone(), Vec::new(), version)
                 .await;
             return;
         }
+
+        let Some(version) = version else {
+            tracing::debug!("skipping diagnostics for unopened document: {}", uri);
+            return;
+        };
 
         // Use async version when native feature is enabled (includes Corsa diagnostics)
         #[cfg(feature = "native")]
@@ -31,8 +42,23 @@ impl MaestroServer {
         #[cfg(not(feature = "native"))]
         let diagnostics = DiagnosticService::collect(&self.state, uri);
 
+        let current_version = self
+            .state
+            .documents
+            .get(uri)
+            .map(|document| document.version);
+        if current_version != Some(version) {
+            tracing::debug!(
+                "skipping stale diagnostics for {}: collected version {}, current {:?}",
+                uri,
+                version,
+                current_version
+            );
+            return;
+        }
+
         self.client
-            .publish_diagnostics(uri.clone(), diagnostics, None)
+            .publish_diagnostics(uri.clone(), diagnostics, Some(version))
             .await;
     }
 

--- a/tests/tooling/lsp-smoke.test.ts
+++ b/tests/tooling/lsp-smoke.test.ts
@@ -459,6 +459,7 @@ test("vize lsp publishes and clears malformed SFC diagnostics", async () => {
       "textDocument/publishDiagnostics",
       (params) => hasDiagnosticSource(params, brokenUri, "vize/sfc"),
     )) as PublishDiagnosticsParams;
+    assert.equal(brokenPublish.version, 1);
     const parserDiagnostic = brokenPublish.diagnostics.find(
       (diagnostic) => diagnostic.source === "vize/sfc",
     );
@@ -489,6 +490,7 @@ test("vize lsp publishes and clears malformed SFC diagnostics", async () => {
       (params) => isDiagnosticsForUri(params, brokenUri),
     )) as PublishDiagnosticsParams;
 
+    assert.equal(fixedPublish.version, 2);
     assert.deepEqual(fixedPublish.diagnostics, []);
   } finally {
     await session.shutdown();

--- a/tests/tooling/support/lsp/protocol.ts
+++ b/tests/tooling/support/lsp/protocol.ts
@@ -29,5 +29,6 @@ export type LspDiagnostic = {
 
 export type PublishDiagnosticsParams = {
   uri: string;
+  version?: number;
   diagnostics: LspDiagnostic[];
 };


### PR DESCRIPTION
## Summary
- attach document versions to LSP publishDiagnostics payloads
- skip stale diagnostic publishes when async collection finishes after a newer document version
- assert diagnostic versions in the LSP smoke coverage

## Verification
- cargo fmt --all
- pnpm exec vp fmt --write tests/tooling/lsp-smoke.test.ts tests/tooling/support/lsp/protocol.ts
- cargo test -p vize_maestro diagnostics --no-fail-fast
- cargo build -p vize
- node --test tests/tooling/lsp-smoke.test.ts
- git diff --check