### PR TITLE
ci(e2e): run app suites on pull requests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -55,7 +55,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        suite: ${{ github.event_name == 'workflow_dispatch' && fromJSON(format('["{0}"]', inputs.suite)) || fromJSON('["dev","preview","check","lint","build","check-fixtures"]') }}
+        suite: ${{ github.event_name == 'workflow_dispatch' && fromJSON(format('["{0}"]', inputs.suite)) || fromJSON('["dev","preview","build"]') }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,6 +1,26 @@
 name: App E2E
 
 on:
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/actions/setup-moonbit/**"
+      - ".github/workflows/e2e.yml"
+      - ".node-version"
+      - "Cargo.lock"
+      - "Cargo.toml"
+      - "crates/**"
+      - "npm/musea-nuxt/**"
+      - "npm/nuxt/**"
+      - "npm/vite-plugin-musea/**"
+      - "npm/vite-plugin-vize/**"
+      - "npm/vize/**"
+      - "npm/vize-native/**"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
+      - "tests/**"
+      - "tools/**"
   workflow_dispatch:
     inputs:
       suite:
@@ -18,7 +38,7 @@ on:
           - check-fixtures
 
 concurrency:
-  group: app-e2e-${{ github.ref }}-${{ inputs.suite }}
+  group: app-e2e-${{ github.event.pull_request.number || github.ref }}-${{ github.event.inputs.suite || 'pull-request' }}
   cancel-in-progress: true
 
 env:
@@ -27,10 +47,15 @@ env:
 
 jobs:
   app-e2e:
+    name: app-e2e (${{ matrix.suite }})
     runs-on: ubuntu-latest
     timeout-minutes: 90
     permissions:
       contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        suite: ${{ github.event_name == 'workflow_dispatch' && fromJSON(format('["{0}"]', inputs.suite)) || fromJSON('["dev","preview","check","lint","build","check-fixtures"]') }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -84,7 +109,7 @@ jobs:
 
       - name: Run selected app e2e suite
         run: |
-          case "${{ inputs.suite }}" in
+          case "${{ matrix.suite }}" in
             dev)
               vp run --filter './tests' test:dev
               ;;
@@ -112,7 +137,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: app-e2e-artifacts-${{ inputs.suite }}
+          name: app-e2e-artifacts-${{ matrix.suite }}
           path: |
             tests/app/results/
             tests/app/screenshots/

--- a/tests/tooling/e2e-workflow.test.ts
+++ b/tests/tooling/e2e-workflow.test.ts
@@ -10,8 +10,20 @@ function readRepoFile(...segments: string[]): string {
   return fs.readFileSync(path.join(root, ...segments), "utf8");
 }
 
-test("app e2e workflow is manually selectable and uploads failure artifacts", () => {
+test("app e2e workflow runs a PR matrix, stays manually selectable, and uploads artifacts", () => {
   const workflow = readRepoFile(".github", "workflows", "e2e.yml");
+
+  assert.match(workflow, /pull_request:/);
+  assert.match(workflow, /branches:\s*\[main\]/);
+  for (const pathFilter of [
+    '".github/workflows/e2e.yml"',
+    '"crates/**"',
+    '"npm/vize/**"',
+    '"npm/vite-plugin-vize/**"',
+    '"tests/**"',
+  ]) {
+    assert.match(workflow, new RegExp(`- ${pathFilter.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}`));
+  }
 
   assert.match(workflow, /workflow_dispatch:/);
   assert.match(workflow, /type:\s*choice/);
@@ -19,6 +31,10 @@ test("app e2e workflow is manually selectable and uploads failure artifacts", ()
     assert.match(workflow, new RegExp(`- ${suite}`));
     assert.match(workflow, new RegExp(`${suite}\\)\\n\\s+`));
   }
+  assert.match(
+    workflow,
+    /fromJSON\('\["dev","preview","check","lint","build","check-fixtures"\]'\)/,
+  );
 
   assert.match(workflow, /--filter '\.\/tests\.\.\.'/);
   assert.match(workflow, /--filter '\.\/npm\/vize-native\.\.\.'/);
@@ -29,9 +45,11 @@ test("app e2e workflow is manually selectable and uploads failure artifacts", ()
   assert.match(workflow, /uses: \.\/\.github\/actions\/setup-moonbit/);
   assert.match(workflow, /Cache Playwright browsers/);
   assert.match(workflow, /vp exec --filter '\.\/tests' -- playwright install --with-deps chromium/);
+  assert.match(workflow, /case "\$\{\{ matrix\.suite \}\}" in/);
   assert.match(workflow, /RUN_BUILD_TESTS=1 vp run --filter '\.\/tests' test:preview/);
   assert.doesNotMatch(workflow, /pnpm --dir tests/);
   assert.match(workflow, /- name: Upload app e2e artifacts\s+if: failure\(\)/);
+  assert.match(workflow, /name: app-e2e-artifacts-\$\{\{ matrix\.suite \}\}/);
   assert.match(workflow, /tests\/app\/results\//);
   assert.match(workflow, /tests\/app\/screenshots\//);
   assert.match(workflow, /tests\/app\/playwright-report\//);

--- a/tests/tooling/e2e-workflow.test.ts
+++ b/tests/tooling/e2e-workflow.test.ts
@@ -27,14 +27,20 @@ test("app e2e workflow runs a PR matrix, stays manually selectable, and uploads 
 
   assert.match(workflow, /workflow_dispatch:/);
   assert.match(workflow, /type:\s*choice/);
-  for (const suite of ["dev", "vrt", "preview", "check", "lint", "build", "check-fixtures"]) {
+  const manuallySelectableSuites = [
+    "dev",
+    "vrt",
+    "preview",
+    "check",
+    "lint",
+    "build",
+    "check-fixtures",
+  ];
+  for (const suite of manuallySelectableSuites) {
     assert.match(workflow, new RegExp(`- ${suite}`));
     assert.match(workflow, new RegExp(`${suite}\\)\\n\\s+`));
   }
-  assert.match(
-    workflow,
-    /fromJSON\('\["dev","preview","check","lint","build","check-fixtures"\]'\)/,
-  );
+  assert.match(workflow, /fromJSON\('\["dev","preview","build"\]'\)/);
 
   assert.match(workflow, /--filter '\.\/tests\.\.\.'/);
   assert.match(workflow, /--filter '\.\/npm\/vize-native\.\.\.'/);


### PR DESCRIPTION
## Summary
- run the App E2E workflow on pull requests for release-impacting paths
- add a PR matrix for the app-facing dev, preview, and build suites
- keep manual dispatch for individual suites including VRT, check, lint, and check-fixtures
- preserve per-suite failure artifact uploads

Fixes #378
Tracks snapshot baseline follow-up in #399

## Validation
- node --test tests/tooling/e2e-workflow.test.ts
- node --test tests/tooling/github-workflows.test.ts
- vp check tests/tooling/e2e-workflow.test.ts
- git diff --check
