### PR TITLE
feat(fresco): support alternate screen option

### DIFF
--- a/crates/vize_fresco/src/napi.rs
+++ b/crates/vize_fresco/src/napi.rs
@@ -48,9 +48,9 @@ pub use render::{
 };
 pub use terminal::{
     clear_screen, flush_terminal, get_terminal_info, init_terminal, init_terminal_with_mouse,
-    restore_terminal, sync_terminal_size,
+    init_terminal_with_options, restore_terminal, sync_terminal_size,
 };
 pub use types::{
     FlexStyleNapi, ImeStateNapi, InputEventNapi, LayoutResultNapi, ModifiersNapi, RenderNodeNapi,
-    StyleNapi, TerminalInfoNapi,
+    StyleNapi, TerminalInfoNapi, TerminalOptionsNapi,
 };

--- a/crates/vize_fresco/src/napi/terminal.rs
+++ b/crates/vize_fresco/src/napi/terminal.rs
@@ -7,9 +7,9 @@ use napi::bindgen_prelude::*;
 use napi_derive::napi;
 use std::sync::Mutex;
 
-use crate::terminal::Backend;
+use crate::terminal::{Backend, TerminalOptions};
 
-use super::types::TerminalInfoNapi;
+use super::types::{TerminalInfoNapi, TerminalOptionsNapi};
 
 // Global terminal backend (lazy initialized)
 static BACKEND: Mutex<Option<Backend>> = Mutex::new(None);
@@ -51,6 +51,17 @@ pub fn init_terminal() -> Result<()> {
 #[napi(js_name = "initTerminalWithMouse")]
 #[allow(clippy::disallowed_macros)]
 pub fn init_terminal_with_mouse() -> Result<()> {
+    init_terminal_with_options(TerminalOptionsNapi {
+        alternate_screen: Some(true),
+        mouse: Some(true),
+        bracketed_paste: Some(true),
+    })
+}
+
+/// Initialize terminal with explicit TUI mode options.
+#[napi(js_name = "initTerminalWithOptions")]
+#[allow(clippy::disallowed_macros)]
+pub fn init_terminal_with_options(options: TerminalOptionsNapi) -> Result<()> {
     let mut guard = BACKEND
         .lock()
         .map_err(|e| Error::new(Status::GenericFailure, format!("Lock error: {}", e)))?;
@@ -69,12 +80,18 @@ pub fn init_terminal_with_mouse() -> Result<()> {
         )
     })?;
 
-    backend.init_with_mouse().map_err(|e| {
-        Error::new(
-            Status::GenericFailure,
-            format!("Failed to init terminal: {}", e),
-        )
-    })?;
+    backend
+        .init_with_options(TerminalOptions {
+            alternate_screen: options.alternate_screen.unwrap_or(false),
+            mouse_capture: options.mouse.unwrap_or(false),
+            bracketed_paste: options.bracketed_paste.unwrap_or(true),
+        })
+        .map_err(|e| {
+            Error::new(
+                Status::GenericFailure,
+                format!("Failed to init terminal: {}", e),
+            )
+        })?;
 
     *guard = Some(backend);
     Ok(())

--- a/crates/vize_fresco/src/napi/types.rs
+++ b/crates/vize_fresco/src/napi/types.rs
@@ -237,6 +237,20 @@ pub struct TerminalInfoNapi {
     pub true_color: bool,
 }
 
+/// Terminal initialization options for NAPI.
+#[napi(object)]
+#[derive(Debug, Clone, Default)]
+pub struct TerminalOptionsNapi {
+    /// Enable the alternate screen buffer
+    #[napi(js_name = "alternateScreen")]
+    pub alternate_screen: Option<bool>,
+    /// Enable mouse capture
+    pub mouse: Option<bool>,
+    /// Enable bracketed paste mode
+    #[napi(js_name = "bracketedPaste")]
+    pub bracketed_paste: Option<bool>,
+}
+
 fn modifiers_from_key(key: &crate::input::KeyEvent) -> ModifiersNapi {
     ModifiersNapi {
         ctrl: key.ctrl(),

--- a/crates/vize_fresco/src/terminal.rs
+++ b/crates/vize_fresco/src/terminal.rs
@@ -11,7 +11,7 @@ mod buffer;
 mod cell;
 mod cursor;
 
-pub use backend::Backend;
+pub use backend::{Backend, TerminalOptions};
 pub use buffer::Buffer;
 pub use cell::{Cell, Color, Style};
 pub use cursor::{Cursor, CursorShape};

--- a/crates/vize_fresco/src/terminal/backend.rs
+++ b/crates/vize_fresco/src/terminal/backend.rs
@@ -15,6 +15,24 @@ use crossterm::{
 
 use super::{buffer::Buffer, cell::Style, cursor::Cursor};
 
+/// Terminal mode switches used during backend initialization.
+#[derive(Debug, Clone, Copy)]
+pub struct TerminalOptions {
+    pub alternate_screen: bool,
+    pub mouse_capture: bool,
+    pub bracketed_paste: bool,
+}
+
+impl Default for TerminalOptions {
+    fn default() -> Self {
+        Self {
+            alternate_screen: true,
+            mouse_capture: false,
+            bracketed_paste: true,
+        }
+    }
+}
+
 /// Terminal backend for rendering.
 pub struct Backend {
     /// Current buffer (what should be displayed)
@@ -25,6 +43,8 @@ pub struct Backend {
     cursor: Cursor,
     /// Whether alternate screen is enabled
     alternate_screen: bool,
+    /// Whether the cursor was hidden during initialization
+    cursor_hidden: bool,
     /// Whether mouse capture is enabled
     mouse_capture: bool,
     /// Whether bracketed paste is enabled
@@ -44,6 +64,7 @@ impl Backend {
             previous: Buffer::new(width, height),
             cursor: Cursor::new(),
             alternate_screen: false,
+            cursor_hidden: false,
             mouse_capture: false,
             bracketed_paste: false,
             width,
@@ -53,24 +74,40 @@ impl Backend {
 
     /// Initialize the terminal for TUI mode.
     pub fn init(&mut self) -> io::Result<()> {
+        self.init_with_options(TerminalOptions::default())
+    }
+
+    /// Initialize the terminal for TUI mode with explicit mode options.
+    pub fn init_with_options(&mut self, options: TerminalOptions) -> io::Result<()> {
         enable_raw_mode()?;
-        execute!(
-            io::stdout(),
-            EnterAlternateScreen,
-            EnableBracketedPaste,
-            Hide
-        )?;
-        self.alternate_screen = true;
-        self.bracketed_paste = true;
+        let mut stdout = io::stdout();
+
+        if options.alternate_screen {
+            execute!(stdout, EnterAlternateScreen)?;
+            self.alternate_screen = true;
+        }
+
+        if options.bracketed_paste {
+            execute!(stdout, EnableBracketedPaste)?;
+            self.bracketed_paste = true;
+        }
+
+        if options.mouse_capture {
+            execute!(stdout, EnableMouseCapture)?;
+            self.mouse_capture = true;
+        }
+
+        execute!(stdout, Hide)?;
+        self.cursor_hidden = true;
         Ok(())
     }
 
     /// Initialize with mouse capture enabled.
     pub fn init_with_mouse(&mut self) -> io::Result<()> {
-        self.init()?;
-        execute!(io::stdout(), EnableMouseCapture)?;
-        self.mouse_capture = true;
-        Ok(())
+        self.init_with_options(TerminalOptions {
+            mouse_capture: true,
+            ..TerminalOptions::default()
+        })
     }
 
     /// Restore the terminal to normal mode.
@@ -88,8 +125,13 @@ impl Backend {
         }
 
         if self.alternate_screen {
-            execute!(stdout, LeaveAlternateScreen, Show)?;
+            execute!(stdout, LeaveAlternateScreen)?;
             self.alternate_screen = false;
+        }
+
+        if self.cursor_hidden {
+            execute!(stdout, Show)?;
+            self.cursor_hidden = false;
         }
 
         disable_raw_mode()?;
@@ -353,7 +395,7 @@ impl Drop for Backend {
 
 #[cfg(test)]
 mod tests {
-    use super::Backend;
+    use super::{Backend, TerminalOptions};
 
     #[test]
     fn test_backend_size() {
@@ -362,5 +404,14 @@ mod tests {
             assert!(backend.width() > 0);
             assert!(backend.height() > 0);
         }
+    }
+
+    #[test]
+    fn terminal_options_default_preserves_legacy_init_modes() {
+        let options = TerminalOptions::default();
+
+        assert!(options.alternate_screen);
+        assert!(!options.mouse_capture);
+        assert!(options.bracketed_paste);
     }
 }

--- a/npm/fresco-native/index.d.ts
+++ b/npm/fresco-native/index.d.ts
@@ -113,6 +113,12 @@ export interface TerminalInfoNapi {
   trueColor: boolean;
 }
 
+export interface TerminalOptionsNapi {
+  alternateScreen?: boolean;
+  mouse?: boolean;
+  bracketedPaste?: boolean;
+}
+
 export interface LayoutResultNapi {
   id: number;
   x: number;
@@ -123,6 +129,7 @@ export interface LayoutResultNapi {
 
 export function initTerminal(): void;
 export function initTerminalWithMouse(): void;
+export function initTerminalWithOptions(options: TerminalOptionsNapi): void;
 export function restoreTerminal(): void;
 export function getTerminalInfo(): TerminalInfoNapi;
 export function clearScreen(): void;

--- a/npm/fresco-native/index.js
+++ b/npm/fresco-native/index.js
@@ -316,6 +316,7 @@ const {
   getLastRenderLayouts,
   initTerminal,
   initTerminalWithMouse,
+  initTerminalWithOptions,
   restoreTerminal,
   getTerminalInfo,
   clearScreen,
@@ -354,6 +355,7 @@ module.exports.renderTree = renderTree;
 module.exports.getLastRenderLayouts = getLastRenderLayouts;
 module.exports.initTerminal = initTerminal;
 module.exports.initTerminalWithMouse = initTerminalWithMouse;
+module.exports.initTerminalWithOptions = initTerminalWithOptions;
 module.exports.restoreTerminal = restoreTerminal;
 module.exports.getTerminalInfo = getTerminalInfo;
 module.exports.clearScreen = clearScreen;

--- a/npm/fresco/src/app.ts
+++ b/npm/fresco/src/app.ts
@@ -270,6 +270,7 @@ function updateAppSize(context: UseAppReturn | null, width: number, height: numb
  */
 export function createApp(rootComponent: AppRoot, options: AppOptions = {}): App {
   const { mouse = false, exitOnCtrlC = true, onError } = options;
+  const interactive = options.interactive ?? true;
   const screenReaderEnabled = ref(
     options.isScreenReaderEnabled ?? isScreenReaderEnabledByDefault(),
   );
@@ -279,7 +280,7 @@ export function createApp(rootComponent: AppRoot, options: AppOptions = {}): App
     stdout: options.stdout,
     stderr: options.stderr,
     exitOnCtrlC,
-    interactive: options.interactive ?? true,
+    interactive,
   });
 
   let vueApp: VueApp | null = null;
@@ -305,8 +306,13 @@ export function createApp(rootComponent: AppRoot, options: AppOptions = {}): App
 
     const n = await loadNative();
 
-    // Initialize terminal
-    if (mouse) {
+    if (typeof n.initTerminalWithOptions === "function") {
+      n.initTerminalWithOptions({
+        alternateScreen: interactive && options.alternateScreen === true,
+        bracketedPaste: interactive,
+        mouse: interactive && mouse,
+      });
+    } else if (mouse) {
       n.initTerminalWithMouse();
     } else {
       n.initTerminal();

--- a/npm/fresco/src/index.ts
+++ b/npm/fresco/src/index.ts
@@ -51,6 +51,7 @@ export type {
   InputEventNapi,
   ImeStateNapi,
   TerminalInfoNapi,
+  TerminalOptionsNapi,
   LayoutResultNapi,
   ModifiersNapi,
 } from "@vizejs/fresco-native";


### PR DESCRIPTION
## Summary
- add native terminal initialization options for alternate screen, mouse capture, and bracketed paste
- wire Fresco render options so alternateScreen is opt-in and ignored when interactive is false
- keep legacy native init helpers compatible with their previous alternate-screen behavior

## Verification
- pnpm --filter @vizejs/fresco check
- pnpm --filter @vizejs/fresco build
- cargo check -p vize_fresco --features napi
- cargo test -p vize_fresco terminal_options_default_preserves_legacy_init_modes --features napi
- git diff --check