### PR TITLE
docs(governance): add security and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,83 @@
+name: Bug report
+description: Report a reproducible problem in Vize
+title: "fix: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report this. Please include a minimal reproduction when possible.
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - CLI
+        - Vite plugin
+        - Nuxt integration
+        - Rspack plugin
+        - Oxlint plugin
+        - Fresco
+        - Musea
+        - VS Code or editor integration
+        - Release or package install
+        - Documentation
+        - Other
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: Package version, commit SHA, or tag.
+      placeholder: "0.101.0"
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Minimal reproduction
+      description: Link a repository or paste the smallest commands/files that reproduce the problem.
+      placeholder: |
+        git clone ...
+        vp check ...
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: What happened? Include logs, diagnostics, stack traces, or screenshots when useful.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What should have happened instead?
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Include OS, architecture, Node.js version, package manager, Rust version, and framework versions when relevant.
+      value: |
+        - OS:
+        - Architecture:
+        - Node.js:
+        - Package manager:
+        - Rust:
+        - Framework:
+    validations:
+      required: true
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I checked existing issues and pull requests.
+          required: true
+        - label: This is not a private security report.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/ubugeeei/vize/security/policy
+    about: Please report suspected vulnerabilities privately.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,55 @@
+name: Feature request
+description: Propose a new capability or compatibility target
+title: "feat: "
+labels:
+  - enhancement
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What user workflow, integration, or production-readiness gap does this address?
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - CLI
+        - Vite plugin
+        - Nuxt integration
+        - Rspack plugin
+        - Oxlint plugin
+        - Fresco
+        - Musea
+        - VS Code or editor integration
+        - Release or package install
+        - Documentation
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposal
+      description: Describe the behavior, API, command, or workflow you want.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: What workarounds or different designs have you considered?
+  - type: textarea
+    id: compatibility
+    attributes:
+      label: Compatibility and rollout
+      description: Note breaking changes, migration needs, release-channel concerns, or support-matrix impact.
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I checked existing issues and pull requests.
+          required: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,40 @@
+# Contributing
+
+Thanks for helping make Vize sharper. This project is still moving toward v1 alpha, so small, focused changes with clear verification are the easiest to review.
+
+## Setup
+
+Use the Node.js version from `.node-version`, then install dependencies from the workspace root:
+
+```sh
+vp install --frozen-lockfile --prefer-offline
+```
+
+If `vp` is not available yet, install the package manager from `package.json` and use the workspace scripts through the local toolchain.
+
+## Common Checks
+
+Run the narrowest check that covers your change, then broaden when you touch shared behavior.
+
+```sh
+vp check <changed-files>
+node --test tests/tooling/<test-file>.test.ts
+cargo fmt --all -- --check
+cargo test -p <crate>
+```
+
+Before opening a PR that changes shared tooling, release automation, native bindings, or compiler behavior, run the relevant workspace task from CI locally when practical.
+
+## Pull Requests
+
+- Use Conventional Commits for commit messages and PR titles, such as `fix(vite-plugin): surface SFC compile errors`.
+- Keep PRs focused on one behavioral change or one documentation/governance change.
+- Include verification commands in the PR body.
+- Do not refresh large snapshot baselines unless the PR is specifically about those outputs.
+- Do not include secrets, registry tokens, private vulnerability details, or machine-local paths in issues, commits, or PRs.
+
+## Issues
+
+Use the bug report template for regressions, crashes, incorrect diagnostics, package installation problems, and release failures. Use the feature request template for new integrations, API changes, or workflow improvements.
+
+Security issues should follow `SECURITY.md` instead of the public issue templates.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,33 @@
+# Security Policy
+
+## Supported Versions
+
+Vize is preparing for a v1 alpha release. Until a stable v1 line exists, security support covers:
+
+- the latest commit on `main`
+- the latest published prerelease for each package
+
+Older prereleases are not supported unless a maintainer explicitly marks them as supported in a release note.
+
+## Reporting a Vulnerability
+
+Please do not open a public issue for a suspected vulnerability.
+
+Use GitHub's private vulnerability reporting flow for this repository. If that is unavailable, contact the maintainer through their GitHub profile and ask for a private channel.
+
+Include as much of the following as you can:
+
+- affected package, CLI command, or integration
+- affected version or commit SHA
+- operating system, architecture, Node.js version, and package manager
+- minimal reproduction steps
+- impact, such as code execution, filesystem access, data exposure, denial of service, or supply-chain risk
+- whether the issue is already public
+
+## Response Expectations
+
+Maintainers aim to acknowledge credible reports within 7 days. Confirmed vulnerabilities are handled privately until a fix or mitigation is available, then disclosed in release notes with credit when the reporter wants attribution.
+
+## Scope
+
+Security-sensitive areas include native bindings, WASM artifacts, package publication, CLI filesystem behavior, compiler input handling, editor integrations, and dev-server middleware. Reports outside those areas are still welcome when they affect users of Vize packages.

--- a/tests/tooling/repo-governance.test.ts
+++ b/tests/tooling/repo-governance.test.ts
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+
+test("repository governance docs cover contribution and security paths", () => {
+  const security = readRepoFile("SECURITY.md");
+  const contributing = readRepoFile("CONTRIBUTING.md");
+
+  assert.match(security, /Supported Versions/);
+  assert.match(security, /Please do not open a public issue/);
+  assert.match(security, /private vulnerability reporting/);
+  assert.match(security, /latest published prerelease/);
+
+  assert.match(contributing, /Conventional Commits/);
+  assert.match(contributing, /vp install --frozen-lockfile --prefer-offline/);
+  assert.match(contributing, /vp check <changed-files>/);
+  assert.match(contributing, /Security issues should follow `SECURITY\.md`/);
+});
+
+test("issue templates collect reproducible production-readiness reports", () => {
+  const bugReport = readRepoFile(".github", "ISSUE_TEMPLATE", "bug_report.yml");
+  const featureRequest = readRepoFile(".github", "ISSUE_TEMPLATE", "feature_request.yml");
+  const config = readRepoFile(".github", "ISSUE_TEMPLATE", "config.yml");
+
+  for (const field of ["area", "version", "reproduction", "actual", "expected", "environment"]) {
+    assert.match(bugReport, new RegExp(`id:\\s*${field}`));
+  }
+  assert.match(bugReport, /This is not a private security report/);
+  assert.match(featureRequest, /id:\s*problem/);
+  assert.match(featureRequest, /id:\s*proposal/);
+  assert.match(featureRequest, /id:\s*compatibility/);
+  assert.match(config, /blank_issues_enabled:\s*false/);
+  assert.match(config, /vize\/security\/policy/);
+});
+
+function readRepoFile(...segments: string[]): string {
+  return fs.readFileSync(path.join(root, ...segments), "utf8");
+}


### PR DESCRIPTION
## Summary
- add SECURITY.md with supported prerelease scope, private reporting guidance, and response expectations
- add CONTRIBUTING.md with setup, checks, PR conventions, and security handling
- add bug/feature issue forms plus tests that keep required reproduction and security routing fields present

Fixes #382

## Verification
- node --test tests/tooling/repo-governance.test.ts
- vp check CONTRIBUTING.md SECURITY.md .github/ISSUE_TEMPLATE/bug_report.yml .github/ISSUE_TEMPLATE/feature_request.yml .github/ISSUE_TEMPLATE/config.yml tests/tooling/repo-governance.test.ts
- git diff --check