### PR TITLE
fix(fresco): detect non-interactive terminals

### DIFF
--- a/crates/vize_fresco/src/napi/terminal.rs
+++ b/crates/vize_fresco/src/napi/terminal.rs
@@ -52,9 +52,11 @@ pub fn init_terminal() -> Result<()> {
 #[allow(clippy::disallowed_macros)]
 pub fn init_terminal_with_mouse() -> Result<()> {
     init_terminal_with_options(TerminalOptionsNapi {
+        raw_mode: Some(true),
         alternate_screen: Some(true),
         mouse: Some(true),
         bracketed_paste: Some(true),
+        hide_cursor: Some(true),
     })
 }
 
@@ -82,9 +84,11 @@ pub fn init_terminal_with_options(options: TerminalOptionsNapi) -> Result<()> {
 
     backend
         .init_with_options(TerminalOptions {
+            raw_mode: options.raw_mode.unwrap_or(true),
             alternate_screen: options.alternate_screen.unwrap_or(false),
             mouse_capture: options.mouse.unwrap_or(false),
             bracketed_paste: options.bracketed_paste.unwrap_or(true),
+            hide_cursor: options.hide_cursor.unwrap_or(true),
         })
         .map_err(|e| {
             Error::new(

--- a/crates/vize_fresco/src/napi/types.rs
+++ b/crates/vize_fresco/src/napi/types.rs
@@ -241,6 +241,9 @@ pub struct TerminalInfoNapi {
 #[napi(object)]
 #[derive(Debug, Clone, Default)]
 pub struct TerminalOptionsNapi {
+    /// Enable raw mode
+    #[napi(js_name = "rawMode")]
+    pub raw_mode: Option<bool>,
     /// Enable the alternate screen buffer
     #[napi(js_name = "alternateScreen")]
     pub alternate_screen: Option<bool>,
@@ -249,6 +252,9 @@ pub struct TerminalOptionsNapi {
     /// Enable bracketed paste mode
     #[napi(js_name = "bracketedPaste")]
     pub bracketed_paste: Option<bool>,
+    /// Hide the terminal cursor
+    #[napi(js_name = "hideCursor")]
+    pub hide_cursor: Option<bool>,
 }
 
 fn modifiers_from_key(key: &crate::input::KeyEvent) -> ModifiersNapi {

--- a/crates/vize_fresco/src/terminal/backend.rs
+++ b/crates/vize_fresco/src/terminal/backend.rs
@@ -18,17 +18,21 @@ use super::{buffer::Buffer, cell::Style, cursor::Cursor};
 /// Terminal mode switches used during backend initialization.
 #[derive(Debug, Clone, Copy)]
 pub struct TerminalOptions {
+    pub raw_mode: bool,
     pub alternate_screen: bool,
     pub mouse_capture: bool,
     pub bracketed_paste: bool,
+    pub hide_cursor: bool,
 }
 
 impl Default for TerminalOptions {
     fn default() -> Self {
         Self {
+            raw_mode: true,
             alternate_screen: true,
             mouse_capture: false,
             bracketed_paste: true,
+            hide_cursor: true,
         }
     }
 }
@@ -45,6 +49,8 @@ pub struct Backend {
     alternate_screen: bool,
     /// Whether the cursor was hidden during initialization
     cursor_hidden: bool,
+    /// Whether raw mode is enabled
+    raw_mode: bool,
     /// Whether mouse capture is enabled
     mouse_capture: bool,
     /// Whether bracketed paste is enabled
@@ -65,6 +71,7 @@ impl Backend {
             cursor: Cursor::new(),
             alternate_screen: false,
             cursor_hidden: false,
+            raw_mode: false,
             mouse_capture: false,
             bracketed_paste: false,
             width,
@@ -79,7 +86,11 @@ impl Backend {
 
     /// Initialize the terminal for TUI mode with explicit mode options.
     pub fn init_with_options(&mut self, options: TerminalOptions) -> io::Result<()> {
-        enable_raw_mode()?;
+        if options.raw_mode {
+            enable_raw_mode()?;
+            self.raw_mode = true;
+        }
+
         let mut stdout = io::stdout();
 
         if options.alternate_screen {
@@ -97,8 +108,10 @@ impl Backend {
             self.mouse_capture = true;
         }
 
-        execute!(stdout, Hide)?;
-        self.cursor_hidden = true;
+        if options.hide_cursor {
+            execute!(stdout, Hide)?;
+            self.cursor_hidden = true;
+        }
         Ok(())
     }
 
@@ -134,7 +147,10 @@ impl Backend {
             self.cursor_hidden = false;
         }
 
-        disable_raw_mode()?;
+        if self.raw_mode {
+            disable_raw_mode()?;
+            self.raw_mode = false;
+        }
         Ok(())
     }
 
@@ -413,5 +429,7 @@ mod tests {
         assert!(options.alternate_screen);
         assert!(!options.mouse_capture);
         assert!(options.bracketed_paste);
+        assert!(options.raw_mode);
+        assert!(options.hide_cursor);
     }
 }

--- a/npm/fresco-native/index.d.ts
+++ b/npm/fresco-native/index.d.ts
@@ -114,9 +114,11 @@ export interface TerminalInfoNapi {
 }
 
 export interface TerminalOptionsNapi {
+  rawMode?: boolean;
   alternateScreen?: boolean;
   mouse?: boolean;
   bracketedPaste?: boolean;
+  hideCursor?: boolean;
 }
 
 export interface LayoutResultNapi {

--- a/npm/fresco/src/app.ts
+++ b/npm/fresco/src/app.ts
@@ -265,12 +265,28 @@ function updateAppSize(context: UseAppReturn | null, width: number, height: numb
   context.height.value = height;
 }
 
+const CI_ENVIRONMENT_KEYS = ["CI", "CONTINUOUS_INTEGRATION", "BUILD_NUMBER", "RUN_ID"] as const;
+
+function isTruthyEnvironmentValue(value: string | undefined): boolean {
+  if (!value) return false;
+  return !["0", "false", "no"].includes(value.toLowerCase());
+}
+
+function isCiEnvironment(env: NodeJS.ProcessEnv = process.env): boolean {
+  return CI_ENVIRONMENT_KEYS.some((key) => isTruthyEnvironmentValue(env[key]));
+}
+
+function detectInteractiveMode(options: AppOptions): boolean {
+  const stdout = options.stdout ?? process.stdout;
+  return options.interactive ?? (stdout.isTTY === true && !isCiEnvironment());
+}
+
 /**
  * Create a Fresco TUI app
  */
 export function createApp(rootComponent: AppRoot, options: AppOptions = {}): App {
   const { mouse = false, exitOnCtrlC = true, onError } = options;
-  const interactive = options.interactive ?? true;
+  const interactive = detectInteractiveMode(options);
   const screenReaderEnabled = ref(
     options.isScreenReaderEnabled ?? isScreenReaderEnabledByDefault(),
   );
@@ -310,7 +326,9 @@ export function createApp(rootComponent: AppRoot, options: AppOptions = {}): App
       n.initTerminalWithOptions({
         alternateScreen: interactive && options.alternateScreen === true,
         bracketedPaste: interactive,
+        hideCursor: interactive,
         mouse: interactive && mouse,
+        rawMode: interactive,
       });
     } else if (mouse) {
       n.initTerminalWithMouse();
@@ -318,7 +336,7 @@ export function createApp(rootComponent: AppRoot, options: AppOptions = {}): App
       n.initTerminal();
     }
 
-    n.enableIme?.();
+    if (interactive) n.enableIme?.();
 
     // Initialize layout engine
     n.initLayout();

--- a/npm/fresco/src/composables/useStreams.ts
+++ b/npm/fresco/src/composables/useStreams.ts
@@ -58,7 +58,7 @@ export function createStreamsContext(options: StreamsContextOptions = {}): Strea
     stdout,
     stderr,
     setRawMode: (isRawMode: boolean) => {
-      if (typeof stdin.setRawMode !== "function") return;
+      if (!isInteractive || typeof stdin.setRawMode !== "function") return;
 
       stdin.setEncoding?.("utf8");
 
@@ -84,7 +84,7 @@ export function createStreamsContext(options: StreamsContextOptions = {}): Strea
         stdin.unref?.();
       });
     },
-    isRawModeSupported: typeof stdin.setRawMode === "function",
+    isRawModeSupported: isInteractive && typeof stdin.setRawMode === "function",
     setBracketedPasteMode: (isEnabled: boolean) => {
       if (!isInteractive) return;
 


### PR DESCRIPTION
## Summary
- detect interactive mode from stdout.isTTY and CI-like environment variables when options.interactive is not provided
- keep raw mode unsupported/no-op for non-interactive stream contexts
- let native terminal initialization opt out of raw mode and cursor hiding for non-interactive renders

## Verification
- pnpm --filter @vizejs/fresco check
- pnpm --filter @vizejs/fresco build
- cargo check -p vize_fresco --features napi
- cargo test -p vize_fresco terminal_options_default_preserves_legacy_init_modes --features napi
- git diff --check