### PR TITLE
test(wasm): smoke package exports

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -530,7 +530,7 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: npm/vize-wasm
-          key: ${{ runner.os }}-release-wasm-${{ hashFiles('crates/**/*.rs', 'Cargo.lock', 'npm/vize-wasm/package.json') }}
+          key: ${{ runner.os }}-release-wasm-${{ hashFiles('crates/**/*.rs', 'Cargo.lock', 'npm/vize-wasm/package.json', 'npm/vize-wasm/index.js', 'npm/vize-wasm/index.d.ts', 'tools/moon/scripts/build_vize_wasm_package.mbtx') }}
 
       - name: Install wasm-bindgen-cli
         if: steps.cache-wasm.outputs.cache-hit != 'true'
@@ -547,6 +547,9 @@ jobs:
         with:
           node-version-file: ".node-version"
           run-install: false
+
+      - name: Smoke @vizejs/wasm package
+        run: node tools/npm/smoke-wasm-package.mjs npm/vize-wasm
 
       - name: Configure npm auth fallback
         env:

--- a/npm/vize-wasm/package.json
+++ b/npm/vize-wasm/package.json
@@ -1,23 +1,39 @@
 {
   "name": "@vizejs/wasm",
-  "type": "module",
-  "description": "Vize WASM bindings for browser environments",
   "version": "0.101.0",
+  "description": "Vize WASM bindings for browser environments",
+  "homepage": "https://github.com/ubugeeei/vize",
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/ubugeeei/vize.git",
     "directory": "npm/vize-wasm"
   },
-  "homepage": "https://github.com/ubugeeei/vize",
   "files": [
+    "index.js",
+    "index.d.ts",
     "vize_vitrine_bg.wasm",
     "vize_vitrine.js",
-    "vize_vitrine.d.ts"
+    "vize_vitrine.d.ts",
+    "snippets/**"
   ],
-  "main": "vize_vitrine.js",
-  "types": "vize_vitrine.d.ts",
+  "type": "module",
   "sideEffects": [
     "./snippets/*"
-  ]
+  ],
+  "main": "./index.js",
+  "types": "./index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./index.d.ts",
+      "import": "./index.js",
+      "default": "./index.js"
+    },
+    "./vize_vitrine.js": {
+      "types": "./vize_vitrine.d.ts",
+      "import": "./vize_vitrine.js",
+      "default": "./vize_vitrine.js"
+    },
+    "./vize_vitrine_bg.wasm": "./vize_vitrine_bg.wasm"
+  }
 }

--- a/tests/tooling/github-workflows.test.ts
+++ b/tests/tooling/github-workflows.test.ts
@@ -482,6 +482,25 @@ test("release workflow publishes npm packages from package-specific artifacts", 
   }
 });
 
+test("release workflow smokes the wasm package wrapper before publishing", () => {
+  const workflow = readRepoFile(".github", "workflows", "release.yml");
+  const job = workflowJobBody(workflow, "release-npm-wasm");
+
+  assert.match(job, /npm\/vize-wasm\/index\.js/);
+  assert.match(job, /npm\/vize-wasm\/index\.d\.ts/);
+  assert.match(job, /tools\/moon\/scripts\/build_vize_wasm_package\.mbtx/);
+
+  const setupNode = job.indexOf("name: Setup Vite+ and Node.js");
+  const smoke = job.indexOf("name: Smoke @vizejs/wasm package");
+  const publish = job.indexOf("name: Publish @vizejs/wasm");
+
+  assert.notEqual(setupNode, -1);
+  assert.notEqual(smoke, -1);
+  assert.notEqual(publish, -1);
+  assert.ok(setupNode < smoke && smoke < publish);
+  assert.match(job, /node tools\/npm\/smoke-wasm-package\.mjs npm\/vize-wasm/);
+});
+
 test("release workflow bundles fresco-native binaries into the root package instead of publishing platform packages", () => {
   const workflow = readRepoFile(".github", "workflows", "release.yml");
   const frescoJobStart = workflow.indexOf("\n  release-npm-fresco-native:\n");

--- a/tests/tooling/package-manifests.test.ts
+++ b/tests/tooling/package-manifests.test.ts
@@ -157,6 +157,41 @@ test("vize package delegates rule type generation to the workspace MoonBit task"
   );
 });
 
+test("wasm package publishes the wrapper entrypoint and raw wasm assets", () => {
+  const wasmPackage = JSON.parse(
+    fs.readFileSync(path.join(root, "npm/vize-wasm/package.json"), "utf-8"),
+  ) as {
+    exports?: Record<string, string | Record<string, string>>;
+    files?: string[];
+    main?: string;
+    types?: string;
+  };
+
+  assert.equal(wasmPackage.main, "./index.js");
+  assert.equal(wasmPackage.types, "./index.d.ts");
+  assert.deepEqual(wasmPackage.exports?.["."], {
+    types: "./index.d.ts",
+    import: "./index.js",
+    default: "./index.js",
+  });
+  assert.deepEqual(wasmPackage.exports?.["./vize_vitrine.js"], {
+    types: "./vize_vitrine.d.ts",
+    import: "./vize_vitrine.js",
+    default: "./vize_vitrine.js",
+  });
+  assert.equal(wasmPackage.exports?.["./vize_vitrine_bg.wasm"], "./vize_vitrine_bg.wasm");
+
+  for (const file of [
+    "index.js",
+    "index.d.ts",
+    "vize_vitrine.js",
+    "vize_vitrine.d.ts",
+    "vize_vitrine_bg.wasm",
+  ]) {
+    assert.ok(wasmPackage.files?.includes(file), `@vizejs/wasm files include ${file}`);
+  }
+});
+
 test("workspace TypeScript package builds use vp pack", () => {
   const packages = [
     ["npm/fresco", "vp pack", "vp pack --watch"],

--- a/tests/tooling/wasm-package-smoke.test.ts
+++ b/tests/tooling/wasm-package-smoke.test.ts
@@ -1,0 +1,61 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { smokeWasmPackage } from "../../tools/npm/smoke-wasm-package.mjs";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+
+function copyRepoFile(targetDir: string, relativePath: string): void {
+  fs.copyFileSync(path.join(root, relativePath), path.join(targetDir, path.basename(relativePath)));
+}
+
+test("wasm package smoke validates manifest, files, exports, and init guard", async () => {
+  const packageDir = fs.mkdtempSync(path.join(os.tmpdir(), "vize-wasm-smoke-"));
+
+  copyRepoFile(packageDir, "npm/vize-wasm/package.json");
+  copyRepoFile(packageDir, "npm/vize-wasm/index.js");
+  copyRepoFile(packageDir, "npm/vize-wasm/index.d.ts");
+  fs.writeFileSync(path.join(packageDir, "vize_vitrine.d.ts"), "export {};\n");
+  fs.writeFileSync(path.join(packageDir, "vize_vitrine_bg.wasm"), "");
+  fs.writeFileSync(
+    path.join(packageDir, "vize_vitrine.js"),
+    `export default async function init() {}
+export class Compiler {
+  compile() {}
+  compileVapor() {}
+  parse() {}
+  parseSfc() {}
+  compileSfc() {}
+  compileCss() {}
+  free() {}
+}
+export function compile() {}
+export function compileVapor() {}
+export function parseTemplate() {}
+export function parseSfc() {}
+export function compileSfc() {}
+export function compileCss() {}
+`,
+  );
+
+  await smokeWasmPackage(packageDir);
+});
+
+test("wasm package smoke fails when wrapper entrypoint is missing", async () => {
+  const packageDir = fs.mkdtempSync(path.join(os.tmpdir(), "vize-wasm-smoke-missing-"));
+
+  copyRepoFile(packageDir, "npm/vize-wasm/package.json");
+  fs.writeFileSync(path.join(packageDir, "index.d.ts"), "export {};\n");
+  fs.writeFileSync(
+    path.join(packageDir, "vize_vitrine.js"),
+    "export default async function init() {}\n",
+  );
+  fs.writeFileSync(path.join(packageDir, "vize_vitrine.d.ts"), "export {};\n");
+  fs.writeFileSync(path.join(packageDir, "vize_vitrine_bg.wasm"), "");
+
+  await assert.rejects(() => smokeWasmPackage(packageDir), /index\.js is missing/);
+});

--- a/tools/npm/smoke-wasm-package.mjs
+++ b/tools/npm/smoke-wasm-package.mjs
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+/**
+ * Smoke-test the publishable @vizejs/wasm package directory.
+ */
+
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const REQUIRED_FILES = [
+  "index.js",
+  "index.d.ts",
+  "vize_vitrine.js",
+  "vize_vitrine.d.ts",
+  "vize_vitrine_bg.wasm",
+];
+
+const REQUIRED_EXPORTS = [
+  "Compiler",
+  "compile",
+  "compileCss",
+  "compileSfc",
+  "compileVapor",
+  "default",
+  "init",
+  "isInitialized",
+  "parseSfc",
+  "parseTemplate",
+];
+
+function requireArg(argv) {
+  const packageDir = argv[0];
+  if (!packageDir) {
+    throw new Error("Usage: smoke-wasm-package.mjs <npm/vize-wasm>");
+  }
+  return path.resolve(packageDir);
+}
+
+function readPackageJson(packageDir) {
+  return JSON.parse(fs.readFileSync(path.join(packageDir, "package.json"), "utf8"));
+}
+
+function assertManifest(packageJson) {
+  assert.equal(packageJson.name, "@vizejs/wasm");
+  assert.equal(packageJson.type, "module");
+  assert.equal(packageJson.main, "./index.js");
+  assert.equal(packageJson.types, "./index.d.ts");
+  assert.equal(packageJson.exports?.["."]?.import, "./index.js");
+  assert.equal(packageJson.exports?.["."]?.types, "./index.d.ts");
+  assert.equal(packageJson.exports?.["./vize_vitrine.js"]?.import, "./vize_vitrine.js");
+  assert.equal(packageJson.exports?.["./vize_vitrine.js"]?.types, "./vize_vitrine.d.ts");
+  assert.equal(packageJson.exports?.["./vize_vitrine_bg.wasm"], "./vize_vitrine_bg.wasm");
+
+  for (const file of REQUIRED_FILES) {
+    assert.ok(packageJson.files?.includes(file), `package files must include ${file}`);
+  }
+}
+
+function assertFilesExist(packageDir) {
+  for (const file of REQUIRED_FILES) {
+    assert.ok(fs.existsSync(path.join(packageDir, file)), `${file} is missing`);
+  }
+}
+
+async function assertEntryPoint(packageDir) {
+  const entry = await import(
+    `${pathToFileURL(path.join(packageDir, "index.js")).href}?smoke=${Date.now()}`
+  );
+  for (const exportName of REQUIRED_EXPORTS) {
+    assert.ok(exportName in entry, `missing export ${exportName}`);
+  }
+
+  assert.equal(entry.default, entry.init);
+  assert.equal(entry.isInitialized(), false);
+  assert.throws(() => entry.compile("<div />"), /Call `await init\(\)` first/);
+}
+
+export async function smokeWasmPackage(packageDir) {
+  const packageJson = readPackageJson(packageDir);
+  assertManifest(packageJson);
+  assertFilesExist(packageDir);
+  await assertEntryPoint(packageDir);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    await smokeWasmPackage(requireArg(process.argv.slice(2)));
+    console.log("@vizejs/wasm package smoke passed");
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+}


### PR DESCRIPTION
## Summary
- publish the @vizejs/wasm wrapper entrypoint and type declarations as the package root
- add a package smoke script that imports the wrapper and checks expected exports/init guard
- run the wasm package smoke before npm publish and key the release cache on wrapper metadata

## Validation
- node --test tests/tooling/wasm-package-smoke.test.ts tests/tooling/package-manifests.test.ts tests/tooling/github-workflows.test.ts
- vp check npm/vize-wasm/package.json .github/workflows/release.yml tools/npm/smoke-wasm-package.mjs tests/tooling/wasm-package-smoke.test.ts tests/tooling/package-manifests.test.ts tests/tooling/github-workflows.test.ts
- git diff --check

Fixes #386