### PR TITLE
fix(vite-plugin): preserve Nuxt dev route modules

### DIFF
--- a/crates/vize_atelier_sfc/src/compile_script/artifacts.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/artifacts.rs
@@ -200,9 +200,17 @@ fn collect_static_imports<'a>(
     imports
 }
 
-fn build_artifact_module(_kind: &str, payload: &str, static_imports: &str) -> String {
+fn build_artifact_module(kind: &str, payload: &str, static_imports: &str) -> String {
     let mut module_code = String::default();
     module_code.push_str(static_imports);
+
+    if kind == "nuxt.definePageMeta" {
+        module_code.push_str("const __nuxt_page_meta = ");
+        module_code.push_str(payload.trim());
+        module_code.push_str("\nexport default __nuxt_page_meta\n");
+        return module_code;
+    }
+
     module_code.push_str("export default ");
     module_code.push_str(payload.trim());
     module_code.push('\n');
@@ -273,7 +281,14 @@ const msg = 'ready'
                 .module_code
                 .as_ref()
                 .unwrap()
-                .contains("import { pageAlias } from './route'\nexport default {")
+                .contains("import { pageAlias } from './route'\nconst __nuxt_page_meta = {")
+        );
+        assert!(
+            artifacts[0]
+                .module_code
+                .as_ref()
+                .unwrap()
+                .contains("export default __nuxt_page_meta")
         );
     }
 

--- a/npm/vite-plugin-vize/src/compiler.test.ts
+++ b/npm/vite-plugin-vize/src/compiler.test.ts
@@ -219,8 +219,13 @@ assert.equal(
 );
 assert.match(
   definePageMetaCompiled.macroArtifacts?.[0]?.moduleCode ?? "",
-  /export default \{/,
-  "definePageMeta artifacts should include loadable module code",
+  /const __nuxt_page_meta = \{/,
+  "definePageMeta artifacts should include Nuxt-compatible module code",
+);
+assert.match(
+  definePageMetaCompiled.macroArtifacts?.[0]?.moduleCode ?? "",
+  /export default __nuxt_page_meta/,
+  "definePageMeta artifacts should not be treated as empty by Nuxt's page meta transform",
 );
 
 const defineRouteRulesSource = `<script setup lang="ts">

--- a/npm/vite-plugin-vize/src/plugin/load.test.ts
+++ b/npm/vite-plugin-vize/src/plugin/load.test.ts
@@ -164,7 +164,9 @@ fs.writeFileSync(
   `<script setup lang="ts">
 definePageMeta({
   name: "docs",
-  meta: { scrollMargin: 180 },
+  path: "/package-docs/:path+",
+  alias: ["/docs/:path+"],
+  scrollMargin: 180,
 })
 
 const msg = "ready"
@@ -184,8 +186,13 @@ assert.ok(
 );
 assert.match(
   definePageMetaLoad.code,
-  /export default \{/,
-  "Nuxt definePageMeta macro queries should return the extracted page metadata module",
+  /const __nuxt_page_meta = \{/,
+  "Nuxt definePageMeta macro queries should return Nuxt-compatible page metadata modules",
+);
+assert.match(
+  definePageMetaLoad.code,
+  /export default __nuxt_page_meta/,
+  "Nuxt definePageMeta macro queries should not be treated as empty by Nuxt's page meta transform",
 );
 assert.match(
   definePageMetaLoad.code,

--- a/npm/vite-plugin-vize/src/plugin/resolve.test.ts
+++ b/npm/vite-plugin-vize/src/plugin/resolve.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import fs from "node:fs";
 import path from "node:path";
+import { createRequire } from "node:module";
 import { fileURLToPath } from "node:url";
 
 import type { VizePluginState } from "./state.ts";
@@ -70,6 +71,19 @@ const nullResolveContext = {
 
 function hasFixtureProject(projectRoot: string): boolean {
   return fs.existsSync(path.join(projectRoot, "package.json"));
+}
+
+function canResolveFixtureDependency(projectRoot: string, specifier: string): boolean {
+  if (!hasFixtureProject(projectRoot)) {
+    return false;
+  }
+
+  try {
+    createRequire(path.join(projectRoot, "package.json")).resolve(specifier);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 function expectResolvedId(resolved: Awaited<ReturnType<typeof resolveIdHook>>): string {
@@ -220,6 +234,43 @@ function expectResolvedId(resolved: Awaited<ReturnType<typeof resolveIdHook>>): 
     expectResolvedId(resolved),
     entry,
     "Aliased package subpaths from virtual modules should resolve to loadable files",
+  );
+}
+
+{
+  const projectRoot = createTempProject("preserve-vite-vue");
+  const importer = path.join(projectRoot, "app", "pages", "index.vue");
+  const vueRoot = path.join(projectRoot, "node_modules", "vue");
+  const vueCjsEntry = path.join(vueRoot, "index.js");
+  const vueBundlerEntry = path.join(vueRoot, "dist", "vue.runtime.esm-bundler.js");
+  writeFixtureFile(
+    path.join(vueRoot, "package.json"),
+    JSON.stringify(
+      {
+        name: "vue",
+        main: "index.js",
+      },
+      null,
+      2,
+    ),
+  );
+  writeFixtureFile(vueCjsEntry, "module.exports = require('./dist/vue.cjs.js');");
+  writeFixtureFile(vueBundlerEntry, "export const createBlock = () => null;");
+
+  const resolved = await resolveIdHook(
+    {
+      resolve: async (id) => (id === "vue" ? { id: vueBundlerEntry } : null),
+    },
+    createState(projectRoot),
+    "vue",
+    toVirtualId(importer),
+    undefined,
+  );
+
+  assert.equal(
+    expectResolvedId(resolved),
+    vueBundlerEntry,
+    "Vite-resolved Vue ESM entries must not be replaced by Node's CommonJS entry",
   );
 }
 
@@ -384,7 +435,7 @@ function expectResolvedId(resolved: Awaited<ReturnType<typeof resolveIdHook>>): 
 
 {
   const projectRoot = path.join(workspaceRoot, "tests", "_fixtures", "_git", "npmx.dev");
-  if (hasFixtureProject(projectRoot)) {
+  if (canResolveFixtureDependency(projectRoot, "vue-data-ui/style.css")) {
     const importer = toVirtualId(path.join(projectRoot, "app", "pages", "index.vue"));
     const resolved = await resolveIdHook(
       nullResolveContext,
@@ -400,7 +451,7 @@ function expectResolvedId(resolved: Awaited<ReturnType<typeof resolveIdHook>>): 
 
 {
   const projectRoot = path.join(workspaceRoot, "tests", "_fixtures", "_git", "vuefes-2025");
-  if (hasFixtureProject(projectRoot)) {
+  if (canResolveFixtureDependency(projectRoot, "@primevue/forms/resolvers/valibot")) {
     const importer = toVirtualId(path.join(projectRoot, "app", "pages", "index.vue"));
     const resolved = await resolveIdHook(
       nullResolveContext,

--- a/npm/vite-plugin-vize/src/plugin/resolve.ts
+++ b/npm/vite-plugin-vize/src/plugin/resolve.ts
@@ -271,19 +271,19 @@ export async function resolveIdHook(
               return { ...resolved, id: normalizedFsId };
             }
 
-            const nodeResolved = resolveBareImportCandidatesWithNode(
-              state,
-              id,
-              cleanImporter,
-              resolved.id,
-            );
-            if (nodeResolved) {
-              state.logger.log(
-                `resolveId: normalized bare ${id} to ${nodeResolved} via Node fallback`,
-              );
-              return nodeResolved;
-            }
             if (isViteBareSpecifier(resolved.id)) {
+              const nodeResolved = resolveBareImportCandidatesWithNode(
+                state,
+                id,
+                cleanImporter,
+                resolved.id,
+              );
+              if (nodeResolved) {
+                state.logger.log(
+                  `resolveId: normalized bare ${id} to ${nodeResolved} via Node fallback`,
+                );
+                return nodeResolved;
+              }
               return null;
             }
             return resolved;
@@ -310,19 +310,19 @@ export async function resolveIdHook(
                 return { ...resolved, id: normalizedFsId };
               }
 
-              const nodeResolved = resolveBareImportCandidatesWithNode(
-                state,
-                id,
-                cleanImporter,
-                resolved.id,
-              );
-              if (nodeResolved) {
-                state.logger.log(
-                  `resolveId: normalized aliased bare ${id} to ${nodeResolved} via Node fallback`,
-                );
-                return nodeResolved;
-              }
               if (isViteBareSpecifier(resolved.id)) {
+                const nodeResolved = resolveBareImportCandidatesWithNode(
+                  state,
+                  id,
+                  cleanImporter,
+                  resolved.id,
+                );
+                if (nodeResolved) {
+                  state.logger.log(
+                    `resolveId: normalized aliased bare ${id} to ${nodeResolved} via Node fallback`,
+                  );
+                  return nodeResolved;
+                }
                 return null;
               }
               return resolved;


### PR DESCRIPTION
## Summary

- keep Vite-resolved bare Vue imports for virtual `.vue.ts` modules so browser ESM exports stay intact
- emit Nuxt-compatible `definePageMeta` macro artifacts via `__nuxt_page_meta`
- cover both virtual resolver and Nuxt page meta artifact loading with regressions

## Why

Vize's Vite plugin had two Nuxt dev route compatibility gaps:

- virtual `.vue.ts` imports could re-resolve Vite's ESM Vue entry back to the CJS package entry, breaking browser imports like `createBlock`
- pre-extracted `definePageMeta` artifacts were emitted as plain `export default { ... }`, which Nuxt's page meta transform treats as empty dev metadata

Together these showed up in real-world app dev E2E as runtime module/export failures and missing `route.meta` for `npmx.dev` docs alias routes.

Closes #416.
Closes #421.

## Validation

- `pnpm --dir npm/vite-plugin-vize test`
- `cargo test -p vize_atelier_sfc compile_script::artifacts`
- `cd tests && VIZE_TEST_WORKTREE_ID=debug-npmx-docs-alias-fixed npx playwright test --config app/playwright.config.ts app/dev/npmx.spec.ts -g "SSR: docs alias resolves definePageMeta alias and meta" --reporter=list --retries=0 --workers=1`
