### PR TITLE
fix(vapor): restore destructured v-for keys

### DIFF
--- a/crates/vize_atelier_vapor/src/generate/operations/for_loop.rs
+++ b/crates/vize_atelier_vapor/src/generate/operations/for_loop.rs
@@ -163,6 +163,13 @@ fn resolve_key_expression(
 fn restore_current_alias_reference(expr: &mut String, reference: &str, alias: &str) {
     if is_simple_local_alias(alias) && expr.contains(reference) {
         *expr = expr.replace(reference, alias).into();
+    } else if alias.trim_start().starts_with(['{', '(']) {
+        for name in parse_destructure_names(alias) {
+            let property_reference = cstr!("{}.{}", reference, name);
+            if expr.contains(property_reference.as_str()) {
+                *expr = expr.replace(property_reference.as_str(), name).into();
+            }
+        }
     }
 }
 
@@ -173,4 +180,38 @@ fn is_simple_local_alias(alias: &str) -> bool {
     };
     (first.is_ascii_alphabetic() || first == '_' || first == '$')
         && chars.all(|ch| ch.is_ascii_alphanumeric() || ch == '_' || ch == '$')
+}
+
+fn parse_destructure_names(pattern: &str) -> std::vec::Vec<&str> {
+    let inner = pattern
+        .trim_start_matches(['{', '(', ' '])
+        .trim_end_matches(['}', ')', ' ']);
+    inner
+        .split(',')
+        .filter_map(|part| {
+            let part = part.trim();
+            if let Some(pos) = part.find(':') {
+                Some(part[pos + 1..].trim())
+            } else if part.is_empty() {
+                None
+            } else {
+                Some(part)
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::restore_current_alias_reference;
+    use vize_carton::ToCompactString;
+
+    #[test]
+    fn restores_destructured_key_alias_references() {
+        let mut expr = "_for_item0.value.id".to_compact_string();
+
+        restore_current_alias_reference(&mut expr, "_for_item0.value", "{ id, name }");
+
+        assert_eq!(expr, "id");
+    }
 }

--- a/crates/vize_atelier_vapor/src/generate/operations/refs.rs
+++ b/crates/vize_atelier_vapor/src/generate/operations/refs.rs
@@ -93,9 +93,9 @@ pub(super) fn generate_next_ref(ctx: &mut GenerateContext, next_ref: &NextRefIRN
 }
 
 fn build_next_chain(base: String, offset: usize) -> String {
-    let mut expr = base;
-    for _ in 0..offset {
-        expr = cstr!("_next({})", expr);
+    if offset == 0 {
+        base
+    } else {
+        cstr!("_next({}, {})", base, offset)
     }
-    expr
 }

--- a/crates/vize_atelier_vapor/src/snapshots/vize_atelier_vapor__tests__compile_control_flow_uses_parent_specific_insertion_state.snap
+++ b/crates/vize_atelier_vapor/src/snapshots/vize_atelier_vapor__tests__compile_control_flow_uses_parent_specific_insertion_state.snap
@@ -8,7 +8,7 @@ const t1 = _template("<div><button></button><main></main></div>", true)
 export function render(_ctx) {
 const n2 = t1()
 const n0 = _child(n2)
-const n1 = _next(n0)
+const n1 = _next(n0, 1)
 _setInsertionState(n0, null, true)
 const n3 = _createIf(() => (_ctx.dark), () => {
 const n5 = t0()

--- a/crates/vize_atelier_vapor/src/snapshots/vize_atelier_vapor__tests__compile_dynamic_child_after_multiple_static_siblings.snap
+++ b/crates/vize_atelier_vapor/src/snapshots/vize_atelier_vapor__tests__compile_dynamic_child_after_multiple_static_siblings.snap
@@ -6,7 +6,7 @@ import { child as _child, next as _next, setClass as _setClass, renderEffect as 
 const t0 = _template("<div><header>one</header><p>two</p><button>x</button></div>", true)
 export function render(_ctx) {
 const n1 = t0()
-const n0 = _next(_next(_child(n1)))
+const n0 = _next(_child(n1), 2)
 _renderEffect(() => _setClass(n0, _ctx.cls))
 return n1
 }

--- a/crates/vize_atelier_vapor/src/snapshots/vize_atelier_vapor__tests__compile_dynamic_siblings_around_control_flow_children.snap
+++ b/crates/vize_atelier_vapor/src/snapshots/vize_atelier_vapor__tests__compile_dynamic_siblings_around_control_flow_children.snap
@@ -10,7 +10,7 @@ export function render(_ctx) {
 const n1 = t1()
 const n0 = _child(n1)
 const n2 = _child(n0)
-const n3 = _next(n2)
+const n3 = _next(n2, 1)
 n2.$evtclick = _createInvoker(() => (_ctx.activeTab = 'code'))
 n3.$evtclick = _createInvoker(() => (_ctx.activeTab = 'helpers'))
 _setInsertionState(n0, null, true)

--- a/crates/vize_atelier_vapor/src/snapshots/vize_atelier_vapor__tests__compile_first_dynamic_child_after_static_sibling.snap
+++ b/crates/vize_atelier_vapor/src/snapshots/vize_atelier_vapor__tests__compile_first_dynamic_child_after_static_sibling.snap
@@ -6,7 +6,7 @@ import { child as _child, next as _next, setClass as _setClass, renderEffect as 
 const t0 = _template("<div><span>static</span><button>x</button></div>", true)
 export function render(_ctx) {
 const n1 = t0()
-const n0 = _next(_child(n1))
+const n0 = _next(_child(n1), 1)
 _renderEffect(() => _setClass(n0, _ctx.cls))
 return n1
 }

--- a/crates/vize_atelier_vapor/src/snapshots/vize_atelier_vapor__tests__compile_first_dynamic_child_after_static_text.snap
+++ b/crates/vize_atelier_vapor/src/snapshots/vize_atelier_vapor__tests__compile_first_dynamic_child_after_static_text.snap
@@ -7,7 +7,7 @@ const t0 = _template("<div><span>label <span> </span></span></div>", true)
 export function render(_ctx) {
 const n1 = t0()
 const n0 = _child(n1)
-const n2 = _next(_child(n0))
+const n2 = _next(_child(n0), 1)
 const x2 = _txt(n2)
 _renderEffect(() => _setClass(n2, _ctx.cls))
 _renderEffect(() => _setText(x2, _toDisplayString(_ctx.msg)))

--- a/tests/vize_test_runner/src/coverage.rs
+++ b/tests/vize_test_runner/src/coverage.rs
@@ -11,9 +11,9 @@ use vize_carton::String;
 use vize_test_runner::{CompilerMode, run_fixture_tests};
 
 const MIN_VDOM_PASSED: usize = 343;
-const MIN_VAPOR_PASSED: usize = 99;
+const MIN_VAPOR_PASSED: usize = 100;
 const MIN_SFC_PASSED: usize = 60;
-const MIN_TOTAL_PASSED: usize = 502;
+const MIN_TOTAL_PASSED: usize = 503;
 
 // Known v1 alpha fixture debt. CI allows these exact failures so existing gaps
 // do not block unrelated work, but any new failure or pass-count regression
@@ -32,7 +32,6 @@ const KNOWN_FAILURES: &[(&str, &str)] = &[
     ("vapor/element", "element with dynamic children"),
     ("vapor/v-if", "v-if/v-else-if/v-else"),
     ("vapor/v-if", "nested v-if"),
-    ("vapor/v-for", "v-for destructure"),
     ("vapor/v-for", "nested v-for"),
     ("sfc/basic", "script and template"),
     ("sfc/basic", "lang attributes"),
@@ -424,7 +423,7 @@ mod tests {
 
     #[test]
     fn tracks_the_current_known_failure_budget() {
-        assert_eq!(KNOWN_FAILURES.len(), 92);
+        assert_eq!(KNOWN_FAILURES.len(), 91);
         let unique_failures: HashSet<_> = KNOWN_FAILURES.iter().collect();
         assert_eq!(unique_failures.len(), KNOWN_FAILURES.len());
         assert!(is_known_failure("vdom/component", "Suspense"));


### PR DESCRIPTION
## Summary
- restore destructured `v-for` aliases when generating Vapor key functions
- emit `_next(base, offset)` to match Vue Vapor helper shape
- reduce the v1 alpha coverage ledger from 92 to 91 known failures after `vapor/v-for` destructure passes

Refs #424.

## Verification
- `cargo test -p vize_atelier_vapor`
- `cargo test -p vize_test_runner --bin coverage`
- `cargo run -p vize_test_runner --bin coverage`
- `git diff --check`
