### PR TITLE
fix(release): publish vize before dependents

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -690,7 +690,7 @@ jobs:
   release-npm-vite-plugin:
     name: Release @vizejs/vite-plugin to npm
     runs-on: ubuntu-latest
-    needs: [build-release-packages, release-npm-native, smoke-release-packages]
+    needs: [build-release-packages, release-npm-native, release-npm-cli, smoke-release-packages]
     environment: npm
     permissions:
       contents: read
@@ -963,6 +963,7 @@ jobs:
         release-npm-vite-plugin,
         release-npm-vite-plugin-musea,
         release-npm-musea-nuxt,
+        release-npm-cli,
         smoke-release-packages,
       ]
     environment: npm

--- a/tests/tooling/package-manifests.test.ts
+++ b/tests/tooling/package-manifests.test.ts
@@ -66,6 +66,40 @@ function readRepoFile(filePath: string): string {
   return fs.readFileSync(path.join(root, filePath), "utf-8");
 }
 
+function releaseWorkflowJobBlock(jobName: string): string {
+  const workflow = readRepoFile(".github/workflows/release.yml");
+  const startMarker = `  ${jobName}:\n`;
+  const start = workflow.indexOf(startMarker);
+  assert.notEqual(start, -1, `missing release workflow job ${jobName}`);
+
+  const rest = workflow.slice(start + startMarker.length);
+  const nextJob = rest.search(/\n  [a-zA-Z0-9_-]+:\n/);
+  return nextJob === -1 ? rest : rest.slice(0, nextJob);
+}
+
+function parseNeedsList(value: string): string[] {
+  return value.match(/[a-zA-Z0-9][a-zA-Z0-9_-]*/g) ?? [];
+}
+
+function releaseWorkflowNeeds(jobName: string): string[] {
+  const block = releaseWorkflowJobBlock(jobName);
+  const inline = block.match(/^    needs:\s*\[(?<needs>[^\]]+)\]/m)?.groups?.needs;
+  if (inline != null) {
+    return parseNeedsList(inline);
+  }
+
+  const lines = block.split("\n");
+  const needsLine = lines.findIndex((line) => /^    needs:\s*$/.test(line));
+  assert.notEqual(needsLine, -1, `missing needs for release workflow job ${jobName}`);
+
+  const needsBlock: string[] = [];
+  for (const line of lines.slice(needsLine + 1)) {
+    if (/^    \S/.test(line)) break;
+    needsBlock.push(line);
+  }
+  return parseNeedsList(needsBlock.join("\n"));
+}
+
 test("esm packed npm manifests point at mjs and d.mts outputs", () => {
   const failures: string[] = [];
 
@@ -182,6 +216,17 @@ test("documented install commands point at supported release artifacts", () => {
   if (/^publish = false$/m.test(vizeCrateToml)) {
     assert.deepEqual(unsupportedCargoInstallDocs, []);
   }
+});
+
+test("release workflow publishes npm packages after their npm dependencies", () => {
+  const vitePluginNeeds = releaseWorkflowNeeds("release-npm-vite-plugin");
+  const nuxtNeeds = releaseWorkflowNeeds("release-npm-nuxt");
+
+  assert.ok(vitePluginNeeds.includes("release-npm-cli"));
+  assert.ok(nuxtNeeds.includes("release-npm-cli"));
+  assert.ok(nuxtNeeds.includes("release-npm-vite-plugin"));
+  assert.ok(nuxtNeeds.includes("release-npm-vite-plugin-musea"));
+  assert.ok(nuxtNeeds.includes("release-npm-musea-nuxt"));
 });
 
 test("editor extension manifests stay opt-in and version aligned", () => {


### PR DESCRIPTION
## Summary
- make `release-npm-vite-plugin` wait for the `vize` npm package publish
- make `release-npm-nuxt` explicitly wait for `release-npm-cli`
- add tooling coverage so the release workflow keeps downstream npm packages behind their direct package dependencies

Closes #429

## Verification
- `pnpm exec vp fmt --write tests/tooling/package-manifests.test.ts`
- `node --test tests/tooling/package-manifests.test.ts`
- `pnpm exec vp check tests/tooling/package-manifests.test.ts`
- `ruby -e 'require "yaml"; wf=YAML.load_file(".github/workflows/release.yml"); jobs=wf.fetch("jobs"); deps={}; jobs.each{|name,job| n=job["needs"]; deps[name]=n.nil? ? [] : n.is_a?(Array) ? n : [n]}; missing=deps.flat_map{|j,ns| ns.reject{|n| deps.key?(n)}.map{|n| "#{j}->#{n}"}}; raise "missing needs: #{missing.join(", ")}" unless missing.empty?; visiting={}; visited={}; stack=[]; cycle=nil; visit=lambda{|j| return if visited[j] || cycle; if visiting[j]; cycle=(stack+[j]).join(" -> "); return; end; visiting[j]=true; stack << j; deps[j].each{|n| visit.call(n)}; stack.pop; visiting.delete(j); visited[j]=true}; deps.keys.each{|j| visit.call(j)}; raise "cycle: #{cycle}" if cycle; puts "release workflow needs graph OK (#{deps.length} jobs)"'`
- `git diff --check`
