### PR TITLE
fix(vdom): close built-in fixture gaps

### DIFF
--- a/crates/vize_atelier_core/src/codegen.rs
+++ b/crates/vize_atelier_core/src/codegen.rs
@@ -367,7 +367,7 @@ mod tests {
     }
 
     #[test]
-    fn test_codegen_default_slot_with_v_if_is_marked_dynamic() {
+    fn test_codegen_default_slot_with_v_if_is_stable() {
         let result = compile!(
             r#"<PageWithHeader>
   <div v-if="tab === 'overview'">Overview</div>

--- a/crates/vize_atelier_core/src/codegen/element/block.rs
+++ b/crates/vize_atelier_core/src/codegen/element/block.rs
@@ -29,7 +29,7 @@ use super::{
     },
     helpers::{
         has_custom_directives, has_renderable_props, has_vmodel_directive, has_vshow_directive,
-        is_dynamic_component_tag, is_is_prop, is_renderable_prop, is_whitespace_or_comment,
+        is_dynamic_component, is_is_prop, is_renderable_prop, is_whitespace_or_comment,
     },
     v_once::generate_v_once_element,
 };
@@ -253,8 +253,8 @@ pub fn generate_element_block(ctx: &mut CodegenContext, el: &ElementNode<'_>) {
             ctx.push("(");
 
             // Check for dynamic component (<component :is="..."> or <Component is="...">)
-            let is_dynamic_component = is_dynamic_component_tag(&el.tag);
-            let (dynamic_is, static_is) = if is_dynamic_component {
+            let is_dynamic = is_dynamic_component(el);
+            let (dynamic_is, static_is) = if is_dynamic {
                 // Check for :is="..." (dynamic binding)
                 let dynamic = el.props.iter().find_map(|p| {
                     if let PropNode::Directive(dir) = p
@@ -311,7 +311,7 @@ pub fn generate_element_block(ctx: &mut CodegenContext, el: &ElementNode<'_>) {
 
             // Calculate patch flag and dynamic props for component
             // For dynamic components, skip the :is binding from patch flag calculation
-            let (mut patch_flag, dynamic_props) = if is_dynamic_component {
+            let (mut patch_flag, dynamic_props) = if is_dynamic {
                 calculate_element_patch_info_skip_is(
                     el,
                     ctx.options.binding_metadata.as_ref(),
@@ -344,7 +344,7 @@ pub fn generate_element_block(ctx: &mut CodegenContext, el: &ElementNode<'_>) {
 
             // Generate props (only if there are renderable props, not just v-show)
             // For dynamic components (<component :is="...">), filter out the `is` prop
-            let effective_has_props = if is_dynamic_component {
+            let effective_has_props = if is_dynamic {
                 // Check if there are renderable props besides `is`
                 el.props
                     .iter()
@@ -354,7 +354,7 @@ pub fn generate_element_block(ctx: &mut CodegenContext, el: &ElementNode<'_>) {
             };
             if effective_has_props {
                 ctx.push(", ");
-                if is_dynamic_component {
+                if is_dynamic {
                     ctx.skip_is_prop = true;
                 }
                 // Components: skip scope_id in props -- Vue runtime applies it via __scopeId
@@ -392,7 +392,7 @@ pub fn generate_element_block(ctx: &mut CodegenContext, el: &ElementNode<'_>) {
                     if is_keep_alive
                         && let TemplateChildNode::Element(child_el) = child
                         && child_el.tag_type == ElementType::Component
-                        && is_dynamic_component_tag(&child_el.tag)
+                        && is_dynamic_component(child_el)
                     {
                         generate_element_block(ctx, child_el);
                         continue;

--- a/crates/vize_atelier_core/src/codegen/element/helpers.rs
+++ b/crates/vize_atelier_core/src/codegen/element/helpers.rs
@@ -119,9 +119,14 @@ pub(crate) fn is_is_prop(p: &PropNode<'_>) -> bool {
     }
 }
 
-/// Check if a tag is Vue's dynamic component special tag.
+/// Check if a tag is Vue's lowercase dynamic component special tag.
 pub(crate) fn is_dynamic_component_tag(tag: &str) -> bool {
-    matches!(tag, "component" | "Component")
+    tag == "component"
+}
+
+/// Check if an element should compile through resolveDynamicComponent().
+pub(crate) fn is_dynamic_component(el: &ElementNode<'_>) -> bool {
+    is_dynamic_component_tag(&el.tag) || (el.tag == "Component" && el.props.iter().any(is_is_prop))
 }
 
 /// Check if a single prop is renderable (not v-show or unsupported directive)

--- a/crates/vize_atelier_core/src/codegen/element/inline.rs
+++ b/crates/vize_atelier_core/src/codegen/element/inline.rs
@@ -29,7 +29,7 @@ use super::{
     },
     helpers::{
         has_custom_directives, has_renderable_props, has_vmodel_directive, has_vshow_directive,
-        is_dynamic_component_tag, is_is_prop, is_renderable_prop, is_whitespace_or_comment,
+        is_dynamic_component, is_is_prop, is_renderable_prop, is_whitespace_or_comment,
     },
 };
 use vize_carton::ToCompactString;
@@ -191,8 +191,8 @@ pub fn generate_element(ctx: &mut CodegenContext, el: &ElementNode<'_>) {
             ctx.push("(");
 
             // Check for dynamic component (<component :is="..."> or <Component is="...">)
-            let is_dynamic_component = is_dynamic_component_tag(&el.tag);
-            let (dynamic_is, static_is) = if is_dynamic_component {
+            let is_dynamic = is_dynamic_component(el);
+            let (dynamic_is, static_is) = if is_dynamic {
                 let dynamic = el.props.iter().find_map(|p| {
                     if let PropNode::Directive(dir) = p
                         && dir.name == "bind"
@@ -242,7 +242,7 @@ pub fn generate_element(ctx: &mut CodegenContext, el: &ElementNode<'_>) {
 
             // Calculate patch flag and dynamic props for component
             // For dynamic components, skip the :is binding from patch flag calculation
-            let (mut patch_flag, dynamic_props) = if is_dynamic_component {
+            let (mut patch_flag, dynamic_props) = if is_dynamic {
                 calculate_element_patch_info_skip_is(
                     el,
                     ctx.options.binding_metadata.as_ref(),
@@ -274,7 +274,7 @@ pub fn generate_element(ctx: &mut CodegenContext, el: &ElementNode<'_>) {
             let has_patch_info = patch_flag.is_some() || dynamic_props.is_some();
 
             // Generate props -- for dynamic components, filter out the `is` prop
-            let effective_has_props = if is_dynamic_component {
+            let effective_has_props = if is_dynamic {
                 el.props
                     .iter()
                     .any(|p| !is_is_prop(p) && is_renderable_prop(p))
@@ -283,7 +283,7 @@ pub fn generate_element(ctx: &mut CodegenContext, el: &ElementNode<'_>) {
             };
             if effective_has_props {
                 ctx.push(", ");
-                if is_dynamic_component {
+                if is_dynamic {
                     ctx.skip_is_prop = true;
                 }
                 // Components: skip scope_id in props -- Vue runtime applies it via __scopeId
@@ -317,7 +317,7 @@ pub fn generate_element(ctx: &mut CodegenContext, el: &ElementNode<'_>) {
                     if is_keep_alive
                         && let TemplateChildNode::Element(child_el) = child
                         && child_el.tag_type == ElementType::Component
-                        && is_dynamic_component_tag(&child_el.tag)
+                        && is_dynamic_component(child_el)
                     {
                         super::block::generate_element_block(ctx, child_el);
                         continue;

--- a/crates/vize_atelier_core/src/codegen/slots.rs
+++ b/crates/vize_atelier_core/src/codegen/slots.rs
@@ -291,19 +291,8 @@ pub fn has_dynamic_slots_flag(el: &ElementNode<'_>) -> bool {
     if has_forwarded_slot_outlet(el) {
         return true;
     }
-    if has_dynamic_default_slot_children(el) {
-        return true;
-    }
     // Also check for v-if/v-for on slot templates (they become IfNode/ForNode children)
     has_conditional_or_loop_slots(el)
-}
-
-/// Check if the implicit default slot contains structural nodes that depend on
-/// parent state and therefore must force slot updates.
-fn has_dynamic_default_slot_children(el: &ElementNode<'_>) -> bool {
-    el.children
-        .iter()
-        .any(|child| matches!(child, TemplateChildNode::If(_) | TemplateChildNode::For(_)))
 }
 
 /// Check whether this component forwards an incoming slot to another component,
@@ -404,10 +393,8 @@ pub fn generate_slots(ctx: &mut CodegenContext, el: &ElementNode<'_>) {
 
     let collected_slots = collect_slots(el);
     let has_forwarded_slots = has_forwarded_slot_outlet(el);
-    let has_dynamic_slots = ctx.in_v_for
-        || collected_slots.iter().any(|s| s.is_dynamic)
-        || has_forwarded_slots
-        || has_dynamic_default_slot_children(el);
+    let has_dynamic_slots =
+        ctx.in_v_for || collected_slots.iter().any(|s| s.is_dynamic) || has_forwarded_slots;
     let has_conditional_slots = has_conditional_or_loop_slots(el);
 
     // If there are conditional (v-if) or looped (v-for) slots, use createSlots

--- a/crates/vize_atelier_core/src/codegen/v_for.rs
+++ b/crates/vize_atelier_core/src/codegen/v_for.rs
@@ -25,10 +25,22 @@ pub(crate) use helpers::{
 
 /// Generate for node
 pub fn generate_for(ctx: &mut CodegenContext, for_node: &ForNode<'_>) {
-    generate_for_inner(ctx, for_node)
+    generate_for_inner(ctx, for_node, None)
 }
 
-fn generate_for_inner(ctx: &mut CodegenContext, for_node: &ForNode<'_>) {
+pub(crate) fn generate_for_with_fragment_key(
+    ctx: &mut CodegenContext,
+    for_node: &ForNode<'_>,
+    generate_key: &dyn Fn(&mut CodegenContext),
+) {
+    generate_for_inner(ctx, for_node, Some(generate_key))
+}
+
+fn generate_for_inner(
+    ctx: &mut CodegenContext,
+    for_node: &ForNode<'_>,
+    generate_fragment_key: Option<&dyn Fn(&mut CodegenContext)>,
+) {
     ctx.use_helper(RuntimeHelper::OpenBlock);
     ctx.use_helper(RuntimeHelper::CreateElementBlock);
     ctx.use_helper(RuntimeHelper::Fragment);
@@ -65,7 +77,13 @@ fn generate_for_inner(ctx: &mut CodegenContext, for_node: &ForNode<'_>) {
     ctx.push(ctx.helper(RuntimeHelper::CreateElementBlock));
     ctx.push("(");
     ctx.push(ctx.helper(RuntimeHelper::Fragment));
-    ctx.push(", null, ");
+    if let Some(generate_key) = generate_fragment_key {
+        ctx.push(", { key: ");
+        generate_key(ctx);
+        ctx.push(" }, ");
+    } else {
+        ctx.push(", null, ");
+    }
     ctx.push(ctx.helper(RuntimeHelper::RenderList));
     ctx.push("(");
     generate_expression(ctx, &for_node.source);

--- a/crates/vize_atelier_core/src/codegen/v_for/generate.rs
+++ b/crates/vize_atelier_core/src/codegen/v_for/generate.rs
@@ -11,7 +11,7 @@ use crate::{
 use super::super::{
     children::{generate_children, generate_children_force_array},
     context::CodegenContext,
-    element::helpers::{is_dynamic_component_tag, is_is_prop},
+    element::helpers::{is_dynamic_component, is_is_prop},
     element::{
         generate_custom_directives_closing, generate_vmodel_closing, generate_vshow_closing,
         has_custom_directives, has_vmodel_directive, has_vshow_directive,
@@ -34,7 +34,7 @@ pub fn generate_for_item(ctx: &mut CodegenContext, node: &TemplateChildNode<'_>,
             let key_exp = get_element_key(el);
             let is_template = el.tag_type == ElementType::Template;
             let is_component = el.tag_type == ElementType::Component;
-            let is_dynamic_component = is_component && is_dynamic_component_tag(&el.tag);
+            let is_dynamic = is_component && is_dynamic_component(el);
             let prev_skip_scope_id = ctx.skip_scope_id;
             let unwrapped_child = unwrap_template_single_element(el);
             let gen_is_template = is_template && unwrapped_child.is_none();
@@ -104,7 +104,7 @@ pub fn generate_for_item(ctx: &mut CodegenContext, node: &TemplateChildNode<'_>,
 
                 // Props with key and all other props
                 let props_el = unwrapped_child.unwrap_or(el);
-                generate_for_item_props(ctx, props_el, key_exp, is_dynamic_component);
+                generate_for_item_props(ctx, props_el, key_exp, is_dynamic);
 
                 // Children
                 let children_el = unwrapped_child.unwrap_or(el);
@@ -157,7 +157,7 @@ pub fn generate_for_item(ctx: &mut CodegenContext, node: &TemplateChildNode<'_>,
                     ctx.push(ctx.helper(RuntimeHelper::CreateBlock));
                     ctx.push("(");
                     // Handle dynamic component
-                    if is_dynamic_component {
+                    if is_dynamic {
                         let dynamic_is = el.props.iter().find_map(|p| {
                             if let PropNode::Directive(dir) = p
                                 && dir.name == "bind"
@@ -228,7 +228,7 @@ pub fn generate_for_item(ctx: &mut CodegenContext, node: &TemplateChildNode<'_>,
                 // Props with key and all other props
                 // For unwrapped template child, use child's props with template's key
                 let props_el = unwrapped_child.unwrap_or(el);
-                generate_for_item_props(ctx, props_el, key_exp, is_dynamic_component);
+                generate_for_item_props(ctx, props_el, key_exp, is_dynamic);
 
                 // Children
                 let children_el = unwrapped_child.unwrap_or(el);
@@ -263,7 +263,7 @@ pub fn generate_for_item(ctx: &mut CodegenContext, node: &TemplateChildNode<'_>,
 
                 // Add patch flag
                 if is_component {
-                    let (mut patch_flag, dynamic_props) = if is_dynamic_component {
+                    let (mut patch_flag, dynamic_props) = if is_dynamic {
                         calculate_element_patch_info_skip_is(
                             el,
                             ctx.options.binding_metadata.as_ref(),

--- a/crates/vize_atelier_core/src/codegen/v_if/branch.rs
+++ b/crates/vize_atelier_core/src/codegen/v_if/branch.rs
@@ -4,7 +4,7 @@
 //! component, element, template fragment, and regular fragment rendering.
 
 use crate::ast::{
-    ElementNode, ElementType, ExpressionNode, IfBranchNode, PropNode, RuntimeHelper,
+    ElementNode, ElementType, ExpressionNode, ForNode, IfBranchNode, PropNode, RuntimeHelper,
     TemplateChildNode,
 };
 use vize_carton::ToCompactString;
@@ -13,11 +13,11 @@ use super::{
     super::{
         children::{generate_children_force_array, is_directive_comment},
         context::CodegenContext,
-        element::is_whitespace_or_comment,
         element::{
             generate_custom_directives_closing, generate_vmodel_closing, generate_vshow_closing,
             has_custom_directives, has_vmodel_directive, has_vshow_directive,
         },
+        element::{helpers::is_dynamic_component, is_whitespace_or_comment},
         expression::generate_expression,
         helpers::{escape_js_string, is_builtin_component, to_valid_asset_identifier},
         node::generate_node,
@@ -76,13 +76,28 @@ pub(super) fn generate_if_branch(
             }
             _ => {
                 // Other node types - wrap in fragment
-                generate_if_branch_fragment(ctx, branch, branch_index);
+                if let TemplateChildNode::For(for_node) = &branch.children[0] {
+                    generate_if_branch_for(ctx, for_node, branch, branch_index);
+                } else {
+                    generate_if_branch_fragment(ctx, branch, branch_index);
+                }
             }
         }
     } else {
         // Multiple children - wrap in fragment
         generate_if_branch_fragment(ctx, branch, branch_index);
     }
+}
+
+fn generate_if_branch_for(
+    ctx: &mut CodegenContext,
+    for_node: &ForNode<'_>,
+    branch: &IfBranchNode<'_>,
+    branch_index: usize,
+) {
+    super::super::v_for::generate_for_with_fragment_key(ctx, for_node, &|ctx| {
+        super::generate_if_branch_key(ctx, branch, branch_index);
+    });
 }
 
 /// Generate slot outlet for if branch.
@@ -130,7 +145,7 @@ fn generate_if_branch_component(
     branch: &IfBranchNode<'_>,
     branch_index: usize,
 ) {
-    let is_dynamic_component = el.tag == "component" || el.tag == "Component";
+    let is_dynamic = is_dynamic_component(el);
     let has_custom_dirs = has_custom_directives(el);
     if has_custom_dirs {
         ctx.use_helper(RuntimeHelper::WithDirectives);
@@ -156,7 +171,7 @@ fn generate_if_branch_component(
     ctx.push("(");
     // Generate component name
     // Handle dynamic component (<component :is="..."> / <Component :is="...">)
-    if is_dynamic_component {
+    if is_dynamic {
         let dynamic_is = el.props.iter().find_map(|p| {
             if let PropNode::Directive(dir) = p
                 && dir.name == "bind"
@@ -204,7 +219,7 @@ fn generate_if_branch_component(
         ctx.push(&to_valid_asset_identifier("component", &el.tag));
     }
 
-    let (mut patch_flag, dynamic_props) = if is_dynamic_component {
+    let (mut patch_flag, dynamic_props) = if is_dynamic {
         calculate_element_patch_info_skip_is(
             el,
             ctx.options.binding_metadata.as_ref(),

--- a/crates/vize_atelier_core/src/snapshots/vize_atelier_core__codegen__tests__codegen_default_slot_with_v_if_is_stable.snap
+++ b/crates/vize_atelier_core/src/snapshots/vize_atelier_core__codegen__tests__codegen_default_slot_with_v_if_is_stable.snap
@@ -15,6 +15,6 @@ function render(_ctx, _cache, $props, $setup, $data, $options) {
           ? (_openBlock(), _createElementBlock("div", { key: 1 }, "Emojis"))
         : (_openBlock(), _createElementBlock("div", { key: 2 }, "Charts"))
     ]),
-    _: 2 /* DYNAMIC */
-  }, 1024 /* DYNAMIC_SLOTS */))
+    _: 1 /* STABLE */
+  }))
 }

--- a/crates/vize_atelier_core/src/transform/element.rs
+++ b/crates/vize_atelier_core/src/transform/element.rs
@@ -7,8 +7,8 @@ use crate::transforms::transform_expression::process_inline_handler;
 
 use super::{ExitFn, TransformContext};
 
-fn is_dynamic_component_tag(tag: &str) -> bool {
-    matches!(tag, "component" | "Component")
+fn is_dynamic_component(el: &ElementNode<'_>) -> bool {
+    el.tag == "component" || (el.tag == "Component" && has_is_attribute(el))
 }
 
 /// Transform element node
@@ -27,7 +27,7 @@ pub fn transform_element<'a>(
             ctx.helper(RuntimeHelper::CreateElementVNode);
         }
         ElementType::Component => {
-            if is_dynamic_component_tag(&el.tag) {
+            if is_dynamic_component(el) {
                 return None;
             }
 
@@ -66,7 +66,7 @@ fn maybe_promote_element_to_component(
         return;
     }
 
-    let looks_like_component = is_dynamic_component_tag(&el.tag)
+    let looks_like_component = el.tag == "component"
         || el.tag.chars().next().is_some_and(|c| c.is_uppercase())
         || el.tag.contains('-');
 
@@ -92,7 +92,14 @@ fn maybe_promote_element_to_component(
 
 fn has_is_attribute(el: &ElementNode<'_>) -> bool {
     el.props.iter().any(|prop| match prop {
-        PropNode::Directive(dir) => dir.name == "is",
+        PropNode::Directive(dir) => {
+            dir.name == "is"
+                || (dir.name == "bind"
+                    && matches!(
+                        &dir.arg,
+                        Some(ExpressionNode::Simple(arg)) if arg.content == "is"
+                    ))
+        }
         PropNode::Attribute(attr) => attr.name == "is",
     })
 }

--- a/tests/vize_test_runner/src/coverage.rs
+++ b/tests/vize_test_runner/src/coverage.rs
@@ -10,25 +10,15 @@ use std::path::PathBuf;
 use vize_carton::String;
 use vize_test_runner::{CompilerMode, run_fixture_tests};
 
-const MIN_VDOM_PASSED: usize = 343;
+const MIN_VDOM_PASSED: usize = 353;
 const MIN_VAPOR_PASSED: usize = 101;
 const MIN_SFC_PASSED: usize = 60;
-const MIN_TOTAL_PASSED: usize = 504;
+const MIN_TOTAL_PASSED: usize = 514;
 
 // Known v1 alpha fixture debt. CI allows these exact failures so existing gaps
 // do not block unrelated work, but any new failure or pass-count regression
 // fails the coverage job.
 const KNOWN_FAILURES: &[(&str, &str)] = &[
-    ("vdom/component", "Suspense"),
-    ("vdom/component", "KeepAlive"),
-    ("vdom/component", "Transition"),
-    ("vdom/component", "TransitionGroup"),
-    ("vdom/component", "keep-alive kebab-case"),
-    ("vdom/component", "transition kebab-case"),
-    ("vdom/component", "transition-group kebab-case"),
-    ("vdom/component", "suspense kebab-case"),
-    ("vdom/v-for", "v-for with v-if"),
-    ("vdom/v-slot", "Transition slot"),
     ("vapor/v-if", "v-if/v-else-if/v-else"),
     ("vapor/v-if", "nested v-if"),
     ("vapor/v-for", "nested v-for"),
@@ -422,10 +412,10 @@ mod tests {
 
     #[test]
     fn tracks_the_current_known_failure_budget() {
-        assert_eq!(KNOWN_FAILURES.len(), 90);
+        assert_eq!(KNOWN_FAILURES.len(), 80);
         let unique_failures: HashSet<_> = KNOWN_FAILURES.iter().collect();
         assert_eq!(unique_failures.len(), KNOWN_FAILURES.len());
-        assert!(is_known_failure("vdom/component", "Suspense"));
+        assert!(is_known_failure("vapor/v-if", "v-if/v-else-if/v-else"));
         assert!(is_known_failure(
             "sfc/script-setup",
             "defineProps type-only with destructure defaults"


### PR DESCRIPTION
## Summary
- match Vue's dynamic-component rules so plain <Component> stays a normal component while <Component :is> and <component> use resolveDynamicComponent
- keep implicit default slots with v-if/v-for stable unless slot structure itself is dynamic
- emit Vue-compatible fragment keys for v-if branches that lower to v-for, bringing VDOM fixtures to 353/353
- tighten the v1 alpha coverage budget from 92 to 82 known failures

Closes #423

## Validation
- cargo test -p vize_atelier_core --no-fail-fast
- cargo test -p vize_test_runner --bin coverage
- cargo run -p vize_test_runner --bin coverage
- cargo clippy -p vize_atelier_core -p vize_test_runner -- -D warnings
- git diff --check

Note: cargo clippy -p vize_atelier_core -p vize_test_runner --all-targets -- -D warnings still hits existing insta snapshot tests via clippy::disallowed_macros; this PR does not introduce that failure.