### PR TITLE
chore(rust): allow snapshot test clippy

### DIFF
--- a/crates/vize_atelier_core/src/codegen.rs
+++ b/crates/vize_atelier_core/src/codegen.rs
@@ -138,6 +138,7 @@ pub fn generate(root: &RootNode<'_>, options: CodegenOptions) -> CodegenResult {
 }
 
 #[cfg(test)]
+#[allow(clippy::disallowed_macros)]
 mod tests {
     use crate::compile;
 

--- a/crates/vize_atelier_core/src/codegen/expression/generate.rs
+++ b/crates/vize_atelier_core/src/codegen/expression/generate.rs
@@ -149,6 +149,7 @@ pub fn generate_event_handler(
 }
 
 #[cfg(test)]
+#[allow(clippy::disallowed_macros)]
 mod tests {
     use super::generate_simple_expression_with_prefix;
     use crate::ast::{ExpressionNode, SimpleExpressionNode, SourceLocation};

--- a/crates/vize_atelier_core/src/test_macros.rs
+++ b/crates/vize_atelier_core/src/test_macros.rs
@@ -266,6 +266,7 @@ macro_rules! get_directive {
 
 /// Assert codegen output against a full snapshot.
 #[macro_export]
+#[allow(clippy::disallowed_macros)]
 macro_rules! assert_codegen {
     ($input:expr => snapshot) => {{
         let allocator = bumpalo::Bump::new();
@@ -314,6 +315,7 @@ macro_rules! compile {
 }
 
 #[cfg(test)]
+#[allow(clippy::disallowed_macros)]
 mod tests {
     #[test]
     fn test_assert_parse_element() {

--- a/crates/vize_atelier_core/src/transform.rs
+++ b/crates/vize_atelier_core/src/transform.rs
@@ -206,6 +206,7 @@ fn create_root_codegen<'a>(ctx: &mut TransformContext<'a>, root: &mut RootNode<'
 }
 
 #[cfg(test)]
+#[allow(clippy::disallowed_macros)]
 mod tests {
     use super::transform;
     use crate::codegen::generate;

--- a/crates/vize_atelier_core/src/transforms/transform_expression/typescript.rs
+++ b/crates/vize_atelier_core/src/transforms/transform_expression/typescript.rs
@@ -203,6 +203,7 @@ fn has_matching_outer_parens(s: &str) -> bool {
 }
 
 #[cfg(test)]
+#[allow(clippy::disallowed_macros)]
 mod tests {
     use super::{needs_typescript_stripping, strip_typescript_from_expression};
 

--- a/tests/vize_test_runner/src/coverage.rs
+++ b/tests/vize_test_runner/src/coverage.rs
@@ -408,12 +408,12 @@ fn main() {
 #[cfg(test)]
 mod tests {
     use super::{KNOWN_FAILURES, is_known_failure};
-    use std::collections::HashSet;
+    use vize_carton::FxHashSet;
 
     #[test]
     fn tracks_the_current_known_failure_budget() {
         assert_eq!(KNOWN_FAILURES.len(), 80);
-        let unique_failures: HashSet<_> = KNOWN_FAILURES.iter().collect();
+        let unique_failures: FxHashSet<_> = KNOWN_FAILURES.iter().collect();
         assert_eq!(unique_failures.len(), KNOWN_FAILURES.len());
         assert!(is_known_failure("vapor/v-if", "v-if/v-else-if/v-else"));
         assert!(is_known_failure(


### PR DESCRIPTION
## Summary
- localize clippy::disallowed_macros allows to snapshot-only test modules and the snapshot assertion helper
- switch the coverage known-failure uniqueness test to vize_carton::FxHashSet
- make all-targets clippy usable as a strict local hardening gate

Closes #433

## Validation
- cargo clippy -p vize_atelier_core -p vize_test_runner --all-targets -- -D warnings
- cargo test -p vize_atelier_core --no-fail-fast
- cargo test -p vize_test_runner --bin coverage
- git diff --check

## Merge note
Draft until #432 lands because both PRs touch the coverage budget test helper. After #432 merges, this should be rebased and marked ready.