### PR TITLE
fix(vapor): coalesce block effects

### DIFF
--- a/crates/vize_atelier_vapor/src/generate.rs
+++ b/crates/vize_atelier_vapor/src/generate.rs
@@ -245,9 +245,21 @@ fn generate_block(
         }
     }
 
-    // Generate effects
-    for effect in block.effect.iter() {
-        generate_effect(ctx, effect, element_template_map);
+    // Generate effects. Multiple reactive updates in the same block share a
+    // single effect, matching Vue Vapor output for sibling dynamic children.
+    if block.effect.len() == 1 {
+        generate_effect(ctx, &block.effect[0], element_template_map);
+    } else if !block.effect.is_empty() {
+        ctx.use_helper("renderEffect");
+        ctx.push_line("_renderEffect(() => {");
+        ctx.indent();
+        for effect in block.effect.iter() {
+            for op in effect.operations.iter() {
+                generate_operation(ctx, op, element_template_map);
+            }
+        }
+        ctx.deindent();
+        ctx.push_line("})");
     }
 
     // Generate return

--- a/crates/vize_atelier_vapor/src/snapshots/vize_atelier_vapor__tests__compile_dynamic_siblings_around_control_flow_children.snap
+++ b/crates/vize_atelier_vapor/src/snapshots/vize_atelier_vapor__tests__compile_dynamic_siblings_around_control_flow_children.snap
@@ -20,7 +20,9 @@ n6.$evtclick = _createInvoker(() => (_ctx.activeTab = 'bindings'))
 _renderEffect(() => _setClass(n6, ['tab', { active: _ctx.activeTab === 'bindings' }]))
 return n6
 })
-_renderEffect(() => _setClass(n2, ['tab', { active: _ctx.activeTab === 'code' }]))
-_renderEffect(() => _setClass(n3, ['tab', { active: _ctx.activeTab === 'helpers' }]))
+_renderEffect(() => {
+_setClass(n2, ['tab', { active: _ctx.activeTab === 'code' }])
+_setClass(n3, ['tab', { active: _ctx.activeTab === 'helpers' }])
+})
 return n1
 }

--- a/crates/vize_atelier_vapor/src/snapshots/vize_atelier_vapor__tests__compile_first_dynamic_child_after_static_text.snap
+++ b/crates/vize_atelier_vapor/src/snapshots/vize_atelier_vapor__tests__compile_first_dynamic_child_after_static_text.snap
@@ -9,7 +9,9 @@ const n1 = t0()
 const n0 = _child(n1)
 const n2 = _next(_child(n0), 1)
 const x2 = _txt(n2)
-_renderEffect(() => _setClass(n2, _ctx.cls))
-_renderEffect(() => _setText(x2, _toDisplayString(_ctx.msg)))
+_renderEffect(() => {
+_setClass(n2, _ctx.cls)
+_setText(x2, _toDisplayString(_ctx.msg))
+})
 return n1
 }

--- a/crates/vize_atelier_vapor/src/snapshots/vize_atelier_vapor__tests__compile_nested_v_for_key_uses_outer_alias.snap
+++ b/crates/vize_atelier_vapor/src/snapshots/vize_atelier_vapor__tests__compile_nested_v_for_key_uses_outer_alias.snap
@@ -13,8 +13,10 @@ _setInsertionState(n0, null, true)
 const n3 = _createFor(() => (_ctx.icons), (_for_item1, _for_key1) => {
 const n5 = t0()
 const x5 = _txt(n5)
-_renderEffect(() => _setClass(n5, _for_item1.value))
-_renderEffect(() => _setText(x5, _toDisplayString(_for_item1.value)))
+_renderEffect(() => {
+_setClass(n5, _for_item1.value)
+_setText(x5, _toDisplayString(_for_item1.value))
+})
 return n5
 }, (icon, i) => (`${_for_item0.value}-${i}`), 1)
 return n3

--- a/crates/vize_atelier_vapor/src/snapshots/vize_atelier_vapor__tests__compile_v_for_aliases_in_complex_expressions.snap
+++ b/crates/vize_atelier_vapor/src/snapshots/vize_atelier_vapor__tests__compile_v_for_aliases_in_complex_expressions.snap
@@ -12,8 +12,10 @@ const n1 = _createFor(() => (_ctx.items), (_for_item0) => {
 const n3 = t0()
 const x3 = _txt(n3)
 n3.$evtclick = _createInvoker(() => (_ctx.pick(_for_item0.value.id)))
-_renderEffect(() => _setClass(n3, ['row', { active: _ctx.selected.has(_for_item0.value.id) }, `kind-${_for_item0.value.kind}`]))
-_renderEffect(() => _setText(x3, _toDisplayString(_for_item0.value.name)))
+_renderEffect(() => {
+_setClass(n3, ['row', { active: _ctx.selected.has(_for_item0.value.id) }, `kind-${_for_item0.value.kind}`])
+_setText(x3, _toDisplayString(_for_item0.value.name))
+})
 return n3
 })
 return n0

--- a/tests/vize_test_runner/src/coverage.rs
+++ b/tests/vize_test_runner/src/coverage.rs
@@ -11,9 +11,9 @@ use vize_carton::String;
 use vize_test_runner::{CompilerMode, run_fixture_tests};
 
 const MIN_VDOM_PASSED: usize = 343;
-const MIN_VAPOR_PASSED: usize = 100;
+const MIN_VAPOR_PASSED: usize = 101;
 const MIN_SFC_PASSED: usize = 60;
-const MIN_TOTAL_PASSED: usize = 503;
+const MIN_TOTAL_PASSED: usize = 504;
 
 // Known v1 alpha fixture debt. CI allows these exact failures so existing gaps
 // do not block unrelated work, but any new failure or pass-count regression
@@ -29,7 +29,6 @@ const KNOWN_FAILURES: &[(&str, &str)] = &[
     ("vdom/component", "suspense kebab-case"),
     ("vdom/v-for", "v-for with v-if"),
     ("vdom/v-slot", "Transition slot"),
-    ("vapor/element", "element with dynamic children"),
     ("vapor/v-if", "v-if/v-else-if/v-else"),
     ("vapor/v-if", "nested v-if"),
     ("vapor/v-for", "nested v-for"),
@@ -423,7 +422,7 @@ mod tests {
 
     #[test]
     fn tracks_the_current_known_failure_budget() {
-        assert_eq!(KNOWN_FAILURES.len(), 91);
+        assert_eq!(KNOWN_FAILURES.len(), 90);
         let unique_failures: HashSet<_> = KNOWN_FAILURES.iter().collect();
         assert_eq!(unique_failures.len(), KNOWN_FAILURES.len());
         assert!(is_known_failure("vdom/component", "Suspense"));


### PR DESCRIPTION
## Summary
- emit one renderEffect for multiple reactive operations in the same Vapor block
- update Vapor snapshots where sibling operations now share the same effect body
- move Vapor fixture coverage from 100/104 to 101/104 on top of #428

Refs #424
Depends on #428

## Validation
- cargo test -p vize_atelier_vapor
- cargo test -p vize_test_runner --bin coverage
- cargo run -p vize_test_runner --bin coverage
- git diff --check

## Merge note
Draft while #428 is pending. After #428 lands, rebase onto main, retarget, and enable auto-merge.