### PR TITLE
fix(fresco): persist static output above live frame

### DIFF
--- a/npm/fresco/src/app.ts
+++ b/npm/fresco/src/app.ts
@@ -289,9 +289,19 @@ function nodeText(node: FrescoNode): string {
   return "";
 }
 
-function treeToString(node: FrescoNode): string {
+function isStaticNode(node: FrescoNode): boolean {
+  return node.props.internal_static === true || node.props.internalStatic === true;
+}
+
+function joinOutput(parts: string[], separator = "\n"): string {
+  return parts.filter(Boolean).join(separator);
+}
+
+function treeToString(node: FrescoNode, options: { skipStatic?: boolean } = {}): string {
+  if (options.skipStatic && isStaticNode(node)) return "";
+
   const ownText = nodeText(node);
-  const childOutput = node.children.map((child) => treeToString(child));
+  const childOutput = node.children.map((child) => treeToString(child, options));
 
   if (node.type === "text" || node.type === "input") {
     return `${ownText}${childOutput.join("")}`;
@@ -300,7 +310,109 @@ function treeToString(node: FrescoNode): string {
   const style = (node.props.style ?? {}) as Record<string, unknown>;
   const flexDirection = style.flexDirection ?? style.flex_direction;
   const separator = flexDirection === "column" ? "\n" : "";
-  return childOutput.filter(Boolean).join(separator);
+  return joinOutput(childOutput, separator);
+}
+
+function normalizeOutput(output: string): string {
+  return output.endsWith("\n") ? output.slice(0, -1) : output;
+}
+
+function appendOutput(previous: string, next: string): string {
+  const normalized = normalizeOutput(next);
+  if (!normalized) return previous;
+  return previous ? `${previous}\n${normalized}` : normalized;
+}
+
+function captureStaticOutput(node: FrescoNode, renderedStaticItems: Map<number, number>): string {
+  const output: string[] = [];
+
+  function visit(current: FrescoNode) {
+    if (isStaticNode(current)) {
+      const renderedItems = renderedStaticItems.get(current.id) ?? 0;
+      const nextItems = current.children.slice(renderedItems);
+      const nextOutput = joinOutput(
+        nextItems.map((child) => treeToString(child)),
+        "\n",
+      );
+      if (nextOutput) output.push(nextOutput);
+      renderedStaticItems.set(current.id, current.children.length);
+      return;
+    }
+
+    for (const child of current.children) {
+      visit(child);
+    }
+  }
+
+  visit(node);
+  return joinOutput(output, "\n");
+}
+
+function createStaticOutputNode(output: string): FrescoElement | null {
+  const normalized = normalizeOutput(output);
+  if (!normalized) return null;
+
+  const staticRoot: FrescoElement = {
+    id: -1,
+    type: "box",
+    props: {
+      style: {
+        flexDirection: "column",
+      },
+    },
+    children: [],
+    parent: null,
+  };
+
+  staticRoot.children = normalized.split("\n").map((line, index) => ({
+    id: -2 - index,
+    type: "text",
+    props: {
+      text: line,
+    },
+    children: [],
+    parent: staticRoot,
+  }));
+
+  return staticRoot;
+}
+
+function cloneDynamicTree(node: FrescoNode): FrescoElement | null {
+  if (isStaticNode(node)) return null;
+
+  const clone: FrescoElement = {
+    id: node.id,
+    type: node.type,
+    props: node.props,
+    children: [],
+    parent: null,
+    text: node.text,
+  };
+
+  clone.children = node.children
+    .map((child) => cloneDynamicTree(child))
+    .filter((child): child is FrescoElement => child !== null);
+  for (const child of clone.children) {
+    child.parent = clone;
+  }
+
+  return clone;
+}
+
+function createRenderTree(root: FrescoElement, staticOutput: string): FrescoElement {
+  const dynamicRoot = cloneDynamicTree(root) ?? createRootElement();
+  const staticOutputNode = createStaticOutputNode(staticOutput);
+
+  if (staticOutputNode) {
+    staticOutputNode.parent = dynamicRoot;
+    dynamicRoot.children = [staticOutputNode, ...dynamicRoot.children];
+  }
+
+  return dynamicRoot;
+}
+
+function renderPlainOutput(root: FrescoNode, staticOutput: string): string {
+  return joinOutput([staticOutput, treeToString(root, { skipStatic: true })], "\n");
 }
 
 function updateAppSize(context: UseAppReturn | null, width: number, height: number) {
@@ -362,6 +474,8 @@ export function createApp(rootComponent: AppRoot, options: AppOptions = {}): App
   let consoleRestore: (() => void) | null = null;
   let isWritingExternalOutput = false;
   let nonInteractiveOutput = "";
+  let staticOutput = "";
+  const renderedStaticItems = new Map<number, number>();
 
   let exitSettled = false;
   let resolveExit: ((value?: unknown) => void) | null = null;
@@ -449,7 +563,11 @@ export function createApp(rootComponent: AppRoot, options: AppOptions = {}): App
     running = false;
 
     if (!interactive && rootElement) {
-      nonInteractiveOutput = treeToString(rootElement);
+      staticOutput = appendOutput(
+        staticOutput,
+        captureStaticOutput(rootElement, renderedStaticItems),
+      );
+      nonInteractiveOutput = renderPlainOutput(rootElement, staticOutput);
     }
 
     if (native && interactive) {
@@ -496,6 +614,7 @@ export function createApp(rootComponent: AppRoot, options: AppOptions = {}): App
 
   function clear() {
     if (!mounted) return;
+    staticOutput = "";
     if (!interactive) {
       nonInteractiveOutput = "";
       return;
@@ -563,7 +682,11 @@ export function createApp(rootComponent: AppRoot, options: AppOptions = {}): App
 
     try {
       if (!interactive) {
-        nonInteractiveOutput = treeToString(rootElement);
+        staticOutput = appendOutput(
+          staticOutput,
+          captureStaticOutput(rootElement, renderedStaticItems),
+        );
+        nonInteractiveOutput = renderPlainOutput(rootElement, staticOutput);
         options.onRender?.({ renderTime: performance.now() - start });
         return;
       }
@@ -572,9 +695,14 @@ export function createApp(rootComponent: AppRoot, options: AppOptions = {}): App
         return;
       }
 
+      staticOutput = appendOutput(
+        staticOutput,
+        captureStaticOutput(rootElement, renderedStaticItems),
+      );
+      const renderRoot = createRenderTree(rootElement, staticOutput);
       const renderNodes = screenReaderEnabled.value
-        ? treeToScreenReaderRenderNodes(rootElement)
-        : treeToRenderNodes(rootElement);
+        ? treeToScreenReaderRenderNodes(renderRoot)
+        : treeToRenderNodes(renderRoot);
 
       // Send to native for rendering
       if (renderNodes.length > 0) {
@@ -816,7 +944,9 @@ export function renderToString(root: AppRoot, options: RenderToStringOptions = {
   );
   app.mount(rootElement);
 
-  const output = treeToString(rootElement);
+  const renderedStaticItems = new Map<number, number>();
+  const staticOutput = captureStaticOutput(rootElement, renderedStaticItems);
+  const output = renderPlainOutput(rootElement, staticOutput);
   app.unmount();
   return output;
 }

--- a/npm/fresco/src/components/Static.ts
+++ b/npm/fresco/src/components/Static.ts
@@ -1,9 +1,8 @@
 /**
  * Static Component - renders stable items above the live area.
  *
- * Fresco keeps this component declarative for Vue. The native renderer does not
- * yet persist historical frames separately, so current items are rendered in
- * order with the same child function API as Ink.
+ * The app renderer treats this component specially: newly added items are
+ * promoted into a persistent output region above the live frame.
  */
 
 import { defineComponent, h, type PropType } from "@vue/runtime-core";
@@ -33,12 +32,26 @@ export const Static = defineComponent({
       return h(
         "box",
         {
+          internal_static: true,
           style: {
+            position: "absolute",
             flexDirection: "column",
             ...props.style,
           },
         },
-        props.items.flatMap((item, index) => renderItem?.({ item, index }) ?? []),
+        props.items.map((item, index) =>
+          h(
+            "box",
+            {
+              key: index,
+              internal_static_item: true,
+              style: {
+                flexDirection: "column",
+              },
+            },
+            renderItem?.({ item, index }) ?? [],
+          ),
+        ),
       );
     };
   },


### PR DESCRIPTION
## Summary
- persist `<Static>` items above the live Fresco frame instead of rendering them as normal dynamic children
- append only newly added static items, matching Ink's permanent-output behavior
- include static output in `renderToString` and non-interactive final frames without duplicating it in the live region

## Verification
- pnpm --filter @vizejs/fresco check
- pnpm --filter @vizejs/fresco build
- git diff --check
- node smoke: `renderToString` and non-interactive `render()` preserve Static history above live output