### PR TITLE
fix(fresco): share animation scheduler

### DIFF
--- a/npm/fresco/src/composables/useAnimation.ts
+++ b/npm/fresco/src/composables/useAnimation.ts
@@ -1,8 +1,8 @@
 /**
- * useAnimation - shared timer-friendly animation state.
+ * useAnimation - Ink-compatible shared animation state.
  */
 
-import { onMounted, onUnmounted, reactive, watch } from "@vue/runtime-core";
+import { computed, onMounted, onUnmounted, reactive, watch } from "@vue/runtime-core";
 
 export interface UseAnimationOptions {
   /** Time between ticks in milliseconds */
@@ -18,10 +18,95 @@ export interface AnimationResult {
   reset: () => void;
 }
 
+const defaultAnimationInterval = 100;
+const maximumTimerInterval = 2_147_483_647;
+
+type AnimationCallback = (currentTime: number) => void;
+
+interface AnimationSubscriber {
+  callback: AnimationCallback;
+  interval: number;
+  startTime: number;
+  nextDueTime: number;
+}
+
+const animationSubscribers = new Map<AnimationCallback, AnimationSubscriber>();
+let animationTimer: ReturnType<typeof setTimeout> | null = null;
+
+function currentTime(): number {
+  return performance.now();
+}
+
+function normalizeAnimationInterval(interval: number): number {
+  if (!Number.isFinite(interval)) {
+    return defaultAnimationInterval;
+  }
+
+  return Math.min(maximumTimerInterval, Math.max(1, interval));
+}
+
+function clearAnimationTimer() {
+  if (!animationTimer) return;
+  clearTimeout(animationTimer);
+  animationTimer = null;
+}
+
+function scheduleAnimationTick() {
+  clearAnimationTimer();
+  if (animationSubscribers.size === 0) return;
+
+  let nextDueTime = Number.POSITIVE_INFINITY;
+  for (const subscriber of animationSubscribers.values()) {
+    nextDueTime = Math.min(nextDueTime, subscriber.nextDueTime);
+  }
+
+  animationTimer = setTimeout(
+    () => {
+      animationTimer = null;
+      const now = currentTime();
+
+      for (const subscriber of animationSubscribers.values()) {
+        if (now < subscriber.nextDueTime) continue;
+
+        subscriber.callback(now);
+
+        const elapsedTime = now - subscriber.startTime;
+        const elapsedFrames = Math.floor(elapsedTime / subscriber.interval) + 1;
+        subscriber.nextDueTime = subscriber.startTime + elapsedFrames * subscriber.interval;
+      }
+
+      scheduleAnimationTick();
+    },
+    Math.max(0, nextDueTime - currentTime()),
+  );
+}
+
+function subscribeToAnimation(callback: AnimationCallback, interval: number) {
+  const startTime = currentTime();
+  animationSubscribers.set(callback, {
+    callback,
+    interval,
+    startTime,
+    nextDueTime: startTime + interval,
+  });
+  scheduleAnimationTick();
+
+  return {
+    startTime,
+    unsubscribe() {
+      animationSubscribers.delete(callback);
+      scheduleAnimationTick();
+    },
+  };
+}
+
 export function useAnimation(options: UseAnimationOptions = {}): AnimationResult {
-  const interval = options.interval ?? 100;
-  let timer: ReturnType<typeof setInterval> | null = null;
-  let startedAt = Date.now();
+  const safeInterval = computed(() =>
+    normalizeAnimationInterval(options.interval ?? defaultAnimationInterval),
+  );
+  const active = computed(() => options.isActive ?? true);
+  let unsubscribe: (() => void) | null = null;
+  let startedAt = currentTime();
   let previousTick = startedAt;
 
   const state = reactive<AnimationResult>({
@@ -29,51 +114,57 @@ export function useAnimation(options: UseAnimationOptions = {}): AnimationResult
     time: 0,
     delta: 0,
     reset: () => {
-      startedAt = Date.now();
-      previousTick = startedAt;
-      state.frame = 0;
-      state.time = 0;
-      state.delta = 0;
+      if (active.value) {
+        start();
+      } else {
+        resetState(currentTime());
+      }
     },
   });
 
-  const tick = () => {
-    const now = Date.now();
-    state.frame += 1;
-    state.time = now - startedAt;
+  const resetState = (now: number) => {
+    startedAt = now;
+    previousTick = now;
+    state.frame = 0;
+    state.time = 0;
+    state.delta = 0;
+  };
+
+  const tick = (now: number) => {
+    const elapsed = now - startedAt;
+    state.frame = Math.floor(elapsed / safeInterval.value);
+    state.time = elapsed;
     state.delta = now - previousTick;
     previousTick = now;
   };
 
   const stop = () => {
-    if (timer) {
-      clearInterval(timer);
-      timer = null;
-    }
+    unsubscribe?.();
+    unsubscribe = null;
   };
 
   const start = () => {
     stop();
-    state.reset();
-    timer = setInterval(tick, interval);
+    resetState(currentTime());
+    const subscription = subscribeToAnimation(tick, safeInterval.value);
+    startedAt = subscription.startTime;
+    previousTick = subscription.startTime;
+    unsubscribe = () => subscription.unsubscribe();
   };
 
   onMounted(() => {
-    if (options.isActive ?? true) {
+    if (active.value) {
       start();
     }
   });
 
-  watch(
-    () => options.isActive,
-    (isActive) => {
-      if (isActive ?? true) {
-        start();
-      } else {
-        stop();
-      }
-    },
-  );
+  watch([active, safeInterval], ([isActive]) => {
+    if (isActive) {
+      start();
+    } else {
+      stop();
+    }
+  });
 
   onUnmounted(stop);
 


### PR DESCRIPTION
## Summary
- move `useAnimation` from one interval per hook to a shared deadline scheduler, matching Ink's timer model
- normalize animation intervals to Ink's safe range, including fallback for non-finite values
- reset timing when active animations restart or their interval changes

## Verification
- pnpm --filter @vizejs/fresco check
- pnpm --filter @vizejs/fresco build
- git diff --check
- node smoke: active animation ticks with normalized `interval: 0`; inactive animation remains at zero