### PR TITLE
fix(fresco): route cursor control through app context

### DIFF
--- a/npm/fresco/src/app.ts
+++ b/npm/fresco/src/app.ts
@@ -26,6 +26,7 @@ import {
   STREAMS_KEY,
   type StreamsContext,
 } from "./composables/useStreams.js";
+import { createCursorContext, CURSOR_KEY, type CursorPosition } from "./composables/useCursor.js";
 import { updateLastRenderLayouts } from "./layoutMetrics.js";
 import type { KittyKeyboardOptions } from "./kittyKeyboard.js";
 import {
@@ -476,6 +477,8 @@ export function createApp(rootComponent: AppRoot, options: AppOptions = {}): App
   let nonInteractiveOutput = "";
   let staticOutput = "";
   const renderedStaticItems = new Map<number, number>();
+  let cursorPosition: CursorPosition | undefined;
+  let hasCursorOverride = false;
 
   let exitSettled = false;
   let resolveExit: ((value?: unknown) => void) | null = null;
@@ -536,6 +539,14 @@ export function createApp(rootComponent: AppRoot, options: AppOptions = {}): App
     app.provide(FOCUS_KEY, focusManager);
     app.provide(SCREEN_READER_KEY, screenReaderEnabled);
     app.provide(STREAMS_KEY, streamsContext);
+    app.provide(
+      CURSOR_KEY,
+      createCursorContext((position) => {
+        hasCursorOverride = true;
+        cursorPosition = position;
+        needsRender = true;
+      }),
+    );
 
     // Create a root element for mounting
     rootElement = createRootElement();
@@ -593,6 +604,8 @@ export function createApp(rootComponent: AppRoot, options: AppOptions = {}): App
     mounted = false;
     appContext = null;
     focusManager = null;
+    cursorPosition = undefined;
+    hasCursorOverride = false;
 
     if (!exitSettled) {
       exitSettled = true;
@@ -673,6 +686,17 @@ export function createApp(rootComponent: AppRoot, options: AppOptions = {}): App
     consoleRestore?.();
   }
 
+  function applyCursorOverride() {
+    if (!hasCursorOverride || !native) return;
+
+    if (cursorPosition) {
+      native.setCursor(cursorPosition.x, cursorPosition.y);
+      native.showCursor();
+    } else {
+      native.hideCursor();
+    }
+  }
+
   function render() {
     if (!mounted || !rootElement) {
       return;
@@ -715,6 +739,8 @@ export function createApp(rootComponent: AppRoot, options: AppOptions = {}): App
         if ("getLastRenderLayouts" in native) {
           updateLastRenderLayouts(native.getLastRenderLayouts());
         }
+
+        applyCursorOverride();
 
         // Flush to display
         native.flushTerminal();
@@ -931,6 +957,10 @@ export function renderToString(root: AppRoot, options: RenderToStringOptions = {
   );
   app.provide(FOCUS_KEY, createFocusManager());
   app.provide(SCREEN_READER_KEY, ref(false));
+  app.provide(
+    CURSOR_KEY,
+    createCursorContext(() => {}),
+  );
   app.provide(
     STREAMS_KEY,
     createStreamsContext({

--- a/npm/fresco/src/composables/useCursor.ts
+++ b/npm/fresco/src/composables/useCursor.ts
@@ -2,30 +2,68 @@
  * useCursor - terminal cursor positioning.
  */
 
+import { inject, onUnmounted, type InjectionKey } from "@vue/runtime-core";
+
 export interface CursorPosition {
   x: number;
   y: number;
 }
 
+export interface CursorContext {
+  setCursorPosition: (position: CursorPosition | undefined) => void;
+}
+
+export const CURSOR_KEY: InjectionKey<CursorContext> = Symbol("fresco-cursor");
+
 async function loadNative() {
   return import("@vizejs/fresco-native");
 }
 
-export function useCursor() {
+export function createCursorContext(
+  setCursorPosition: (position: CursorPosition | undefined) => void,
+): CursorContext {
   return {
-    setCursorPosition: (position: CursorPosition | undefined) => {
-      void loadNative()
-        .then((native) => {
-          if (position) {
-            native.setCursor(position.x, position.y);
-            native.showCursor();
-          } else {
-            native.hideCursor();
-          }
-        })
-        .catch(() => {
-          // Cursor control is best-effort outside a mounted Fresco app.
-        });
-    },
+    setCursorPosition,
+  };
+}
+
+function setNativeCursorPosition(position: CursorPosition | undefined) {
+  void loadNative()
+    .then((native) => {
+      if (position) {
+        native.setCursor(position.x, position.y);
+        native.showCursor();
+      } else {
+        native.hideCursor();
+      }
+    })
+    .catch(() => {
+      // Cursor control is best-effort outside a mounted Fresco app.
+    });
+}
+
+export function useCursor() {
+  const context = inject(CURSOR_KEY, null);
+  let didSetCursor = false;
+
+  const setCursorPosition = (position: CursorPosition | undefined) => {
+    didSetCursor = true;
+
+    if (context) {
+      context.setCursorPosition(position);
+      return;
+    }
+
+    setNativeCursorPosition(position);
+  };
+
+  onUnmounted(() => {
+    if (didSetCursor) {
+      context?.setCursorPosition(undefined);
+    }
+  });
+
+  return {
+    setCursorPosition,
   };
 }


### PR DESCRIPTION
## Summary
- add a Fresco cursor context for `useCursor()` so cursor overrides are applied during app rendering
- keep the old best-effort native fallback when `useCursor()` is called outside a mounted app
- provide a no-op cursor context for `renderToString` so cursor hooks remain safe in string rendering

## Verification
- pnpm --filter @vizejs/fresco check
- pnpm --filter @vizejs/fresco build
- git diff --check
- node smoke: `renderToString` with `useCursor().setCursorPosition()` stays side-effect safe