### PR TITLE
fix(fresco): export ink instance types

### DIFF
--- a/npm/fresco/src/app.ts
+++ b/npm/fresco/src/app.ts
@@ -134,7 +134,7 @@ export interface AppOptions {
   /** Ink-compatible option, accepted for API parity */
   patchConsole?: boolean;
   /** Called after a frame is rendered */
-  onRender?: (metrics: { renderTime: number }) => void;
+  onRender?: (metrics: RenderMetrics) => void;
   /** Enable screen reader rendering hints */
   isScreenReaderEnabled?: boolean;
   /** Maximum render frames per second */
@@ -154,6 +154,14 @@ export interface AppOptions {
 export type RenderOptions = AppOptions;
 
 export type AppRoot = Component | VNode;
+
+/**
+ * Performance metrics for a render operation.
+ */
+export interface RenderMetrics {
+  /** Time spent rendering in milliseconds */
+  renderTime: number;
+}
 
 /**
  * Fresco App instance
@@ -183,6 +191,8 @@ export interface RenderInstance {
   cleanup(): Promise<void>;
   clear(): void;
 }
+
+export type Instance = RenderInstance;
 
 export interface RenderToStringOptions {
   /** Width of the virtual terminal in columns */

--- a/npm/fresco/src/index.ts
+++ b/npm/fresco/src/index.ts
@@ -13,6 +13,8 @@ export {
   type AppOptions,
   type RenderOptions,
   type RenderInstance,
+  type Instance,
+  type RenderMetrics,
   type RenderToStringOptions,
   lastKeyEvent,
   lastPasteEvent,


### PR DESCRIPTION
## Summary
- export Ink-compatible `Instance` as an alias for Fresco render instances
- expose `RenderMetrics` and use it for `onRender` options

## Verification
- pnpm --filter @vizejs/fresco check
- pnpm --filter @vizejs/fresco build
- git diff --check
- rg `RenderMetrics|type Instance` npm/fresco/dist/index.d.mts