### PR TITLE
fix(vapor): escape generated static string literals

### DIFF
--- a/crates/vize_atelier_vapor/src/generate/helpers.rs
+++ b/crates/vize_atelier_vapor/src/generate/helpers.rs
@@ -3,7 +3,11 @@
 use crate::ir::{IREffect, OperationNode};
 use vize_carton::{FxHashMap, String, cstr};
 
-use super::{context::GenerateContext, operations::generate_operation, setup::is_svg_tag};
+use super::{
+    context::GenerateContext,
+    operations::generate_operation,
+    setup::{escape_js_string_literal, is_svg_tag},
+};
 
 /// Generate effect
 pub(crate) fn generate_effect(
@@ -56,7 +60,7 @@ pub(crate) fn generate_operation_inline(
                 .iter()
                 .map(|v| {
                     if v.is_static {
-                        cstr!("\"{}\"", escape_text_literal(v.content.as_str()))
+                        cstr!("\"{}\"", escape_js_string_literal(v.content.as_str()))
                     } else {
                         ctx.use_helper("toDisplayString");
                         let resolved = ctx.resolve_expression(&v.content);
@@ -130,7 +134,7 @@ fn build_prop_value(
             .iter()
             .map(|v| {
                 if v.is_static {
-                    cstr!("\"{}\"", v.content)
+                    cstr!("\"{}\"", escape_js_string_literal(v.content.as_str()))
                 } else {
                     ctx.resolve_expression(&v.content)
                 }
@@ -139,7 +143,7 @@ fn build_prop_value(
         cstr!("[{}]", parts.join(", "))
     } else if let Some(first) = set_prop.prop.values.first() {
         if first.is_static {
-            cstr!("\"{}\"", first.content)
+            cstr!("\"{}\"", escape_js_string_literal(first.content.as_str()))
         } else {
             ctx.resolve_expression(&first.content)
         }
@@ -170,7 +174,7 @@ fn generate_set_dynamic_props_inline(
             .iter()
             .map(|p| {
                 if p.is_static {
-                    cstr!("\"{}\"", p.content)
+                    cstr!("\"{}\"", escape_js_string_literal(p.content.as_str()))
                 } else {
                     ctx.resolve_expression(&p.content)
                 }
@@ -178,13 +182,4 @@ fn generate_set_dynamic_props_inline(
             .collect();
         cstr!("_setDynamicProps({element}, [{}])", props_parts.join(", "))
     }
-}
-
-fn escape_text_literal(text: &str) -> String {
-    text.replace('\\', "\\\\")
-        .replace('"', "\\\"")
-        .replace('\n', "\\n")
-        .replace('\r', "\\r")
-        .replace('\t', "\\t")
-        .into()
 }

--- a/crates/vize_atelier_vapor/src/generate/operations/dom.rs
+++ b/crates/vize_atelier_vapor/src/generate/operations/dom.rs
@@ -1,7 +1,10 @@
 use crate::ir::{SetDynamicPropsIRNode, SetHtmlIRNode, SetPropIRNode, SetTextIRNode};
 use vize_carton::{String, cstr};
 
-use super::super::{context::GenerateContext, setup::is_svg_tag};
+use super::super::{
+    context::GenerateContext,
+    setup::{escape_js_string_literal, is_svg_tag},
+};
 
 /// Generate SetProp
 pub(super) fn generate_set_prop(ctx: &mut GenerateContext, set_prop: &SetPropIRNode<'_>) {
@@ -17,7 +20,7 @@ pub(super) fn generate_set_prop(ctx: &mut GenerateContext, set_prop: &SetPropIRN
             .iter()
             .map(|v| {
                 if v.is_static {
-                    cstr!("\"{}\"", v.content)
+                    cstr!("\"{}\"", escape_js_string_literal(v.content.as_str()))
                 } else {
                     ctx.resolve_expression(&v.content)
                 }
@@ -26,7 +29,7 @@ pub(super) fn generate_set_prop(ctx: &mut GenerateContext, set_prop: &SetPropIRN
         cstr!("[{}]", parts.join(", "))
     } else if let Some(first) = set_prop.prop.values.first() {
         if first.is_static {
-            cstr!("\"{}\"", first.content)
+            cstr!("\"{}\"", escape_js_string_literal(first.content.as_str()))
         } else {
             ctx.resolve_expression(&first.content)
         }
@@ -85,7 +88,7 @@ pub(super) fn generate_set_dynamic_props(
             .iter()
             .map(|p| {
                 if p.is_static {
-                    cstr!("\"{}\"", p.content)
+                    cstr!("\"{}\"", escape_js_string_literal(p.content.as_str()))
                 } else {
                     ctx.resolve_expression(&p.content)
                 }
@@ -115,7 +118,7 @@ pub(super) fn generate_set_text(ctx: &mut GenerateContext, set_text: &SetTextIRN
         .iter()
         .map(|v| {
             if v.is_static {
-                cstr!("\"{}\"", v.content)
+                cstr!("\"{}\"", escape_js_string_literal(v.content.as_str()))
             } else {
                 ctx.use_helper("toDisplayString");
                 let resolved = ctx.resolve_expression(&v.content);
@@ -140,7 +143,10 @@ pub(super) fn generate_set_html(ctx: &mut GenerateContext, set_html: &SetHtmlIRN
     let element = cstr!("n{}", set_html.element);
 
     let value = if set_html.value.is_static {
-        cstr!("\"{}\"", set_html.value.content)
+        cstr!(
+            "\"{}\"",
+            escape_js_string_literal(set_html.value.content.as_str())
+        )
     } else {
         ctx.resolve_expression(set_html.value.content.as_str())
     };

--- a/crates/vize_atelier_vapor/src/generate/setup.rs
+++ b/crates/vize_atelier_vapor/src/generate/setup.rs
@@ -84,6 +84,36 @@ pub(crate) fn escape_template(s: &str) -> String {
         .into()
 }
 
+/// Escape a value for use inside a double-quoted JavaScript string literal.
+pub(crate) fn escape_js_string_literal(s: &str) -> String {
+    let mut result = String::with_capacity(s.len());
+
+    fn push_hex4(out: &mut String, value: u32) {
+        const HEX: &[u8; 16] = b"0123456789abcdef";
+        out.push_str("\\u");
+        out.push(HEX[((value >> 12) & 0xF) as usize] as char);
+        out.push(HEX[((value >> 8) & 0xF) as usize] as char);
+        out.push(HEX[((value >> 4) & 0xF) as usize] as char);
+        out.push(HEX[(value & 0xF) as usize] as char);
+    }
+
+    for char in s.chars() {
+        match char {
+            '\\' => result.push_str("\\\\"),
+            '"' => result.push_str("\\\""),
+            '\n' => result.push_str("\\n"),
+            '\r' => result.push_str("\\r"),
+            '\t' => result.push_str("\\t"),
+            '\x08' => result.push_str("\\b"),
+            '\x0C' => result.push_str("\\f"),
+            char if char.is_control() => push_hex4(&mut result, char as u32),
+            char => result.push(char),
+        }
+    }
+
+    result
+}
+
 /// Check if a tag is an SVG element
 pub(crate) fn is_svg_tag(tag: &str) -> bool {
     matches!(

--- a/crates/vize_atelier_vapor/src/lib.rs
+++ b/crates/vize_atelier_vapor/src/lib.rs
@@ -158,6 +158,9 @@ fn get_namespace(tag: &str, parent: Option<&str>) -> Namespace {
 #[cfg(test)]
 mod tests {
     use super::compile_vapor;
+    use oxc_allocator::Allocator;
+    use oxc_parser::Parser;
+    use oxc_span::SourceType;
     use vize_atelier_core::options::{BindingMetadata, BindingType};
     use vize_carton::Bump;
     use vize_carton::FxHashMap;
@@ -168,6 +171,25 @@ mod tests {
             .filter(|line| !line.is_empty())
             .collect::<Vec<_>>()
             .join("\n")
+    }
+
+    fn assert_parses_as_module(code: &str) {
+        let allocator = Allocator::default();
+        let parsed = Parser::new(
+            &allocator,
+            code,
+            SourceType::default()
+                .with_module(true)
+                .with_typescript(true),
+        )
+        .parse();
+
+        assert!(
+            parsed.errors.is_empty(),
+            "generated code should parse, got: {:?}\n\n{}",
+            parsed.errors,
+            code
+        );
     }
 
     #[test]
@@ -708,6 +730,26 @@ mod tests {
 
         let code = normalize_code(&result.code);
         insta::assert_snapshot!(code.as_str());
+    }
+
+    #[test]
+    fn test_compile_dynamic_text_escapes_multiline_static_part() {
+        let allocator = Bump::new();
+        let result = compile_vapor(
+            &allocator,
+            r#"<button :class="cls">{{ count }} all
+selected</button>"#,
+            Default::default(),
+        );
+
+        assert!(
+            result.error_messages.is_empty(),
+            "Expected no errors: {:?}",
+            result.error_messages
+        );
+
+        assert!(result.code.contains(r#"" all\nselected""#));
+        assert_parses_as_module(result.code.as_str());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- escape static values emitted into Vapor-generated JavaScript string literals
- reuse the escape path for inline and block DOM operations
- add a regression test that parses generated code with multiline static text next to dynamic text

## Root Cause
`generate_set_text` escaped static text in the inline effect path, but the block operation path interpolated static text directly into `"..."`. Multiline template text therefore produced an unterminated JavaScript string during playground production builds.

## Verification
- cargo fmt --check
- git diff --check
- cargo test -p vize_atelier_vapor --no-fail-fast
- cargo clippy -p vize_atelier_vapor -- -D warnings
- RUSTFLAGS='--cfg getrandom_backend="wasm_js"' cargo build --release -p vize_vitrine --no-default-features --features wasm --target wasm32-unknown-unknown
- wasm-bindgen target/wasm32-unknown-unknown/release/vize_vitrine.wasm --out-dir playground/src/wasm --target web
- vp run --filter './npm/vize-native' build:ci
- vp run --filter './npm/vite-plugin-vize' build
- vp run --filter './playground' build

Note: local `vp run --filter './npm/vize' build` is blocked by the local Moonbit toolchain cache/schema mismatch (`to_repr` unbound in moonbitlang/x); CI's setup-moonbit path is expected to supply the matching toolchain.
