### PR TITLE
fix(vapor): resolve destructured v-for aliases

### DIFF
--- a/crates/vize_atelier_vapor/src/generate.rs
+++ b/crates/vize_atelier_vapor/src/generate.rs
@@ -3,6 +3,7 @@
 //! Generates JavaScript code from Vapor IR.
 
 mod context;
+mod destructure;
 mod expression;
 mod helpers;
 mod operations;

--- a/crates/vize_atelier_vapor/src/generate/context.rs
+++ b/crates/vize_atelier_vapor/src/generate/context.rs
@@ -1,6 +1,9 @@
 //! Code generation context that tracks state during Vapor code emission.
 
-use super::expression;
+use super::{
+    destructure::{parse_destructure_bindings, parse_destructure_names},
+    expression,
+};
 use vize_atelier_core::options::BindingMetadata;
 use vize_carton::{FxHashMap, FxHashSet, String, ToCompactString, camelize, capitalize, cstr};
 use vize_croquis::builtins::is_global_allowed;
@@ -205,11 +208,10 @@ impl<'a> GenerateContext<'a> {
             if let Some(ref value_alias) = scope.value_alias {
                 let for_var = cstr!("_for_item{}", scope.depth);
 
-                if value_alias.starts_with('{') || value_alias.starts_with('(') {
-                    let names = parse_destructure_names(value_alias.as_str());
-                    for binding_name in &names {
-                        if name == *binding_name {
-                            return Some(cstr!("{}.value.{}", for_var, binding_name));
+                if value_alias.starts_with(['{', '[', '(']) {
+                    for binding in parse_destructure_bindings(value_alias.as_str()) {
+                        if name == binding.local.as_str() {
+                            return Some(cstr!("{}.value{}", for_var, binding.path));
                         }
                     }
                 } else if name == value_alias.as_str() {
@@ -388,10 +390,7 @@ impl<'a> GenerateContext<'a> {
         let slot_props_var = cstr!("_slotProps{}", self.slot_scope_count);
         self.slot_scope_count += 1;
 
-        let names = parse_destructure_names(destructure_pattern)
-            .into_iter()
-            .map(|s| s.to_compact_string())
-            .collect();
+        let names = parse_destructure_names(destructure_pattern);
 
         self.slot_scopes.push(SlotScope {
             names,
@@ -411,27 +410,6 @@ impl<'a> GenerateContext<'a> {
         self.temp_count += 1;
         name
     }
-}
-
-/// Parse destructured variable names from patterns like "{ id, name }" or "{ a: b }"
-fn parse_destructure_names(pattern: &str) -> std::vec::Vec<&str> {
-    let inner = pattern
-        .trim_start_matches(['{', '(', ' '])
-        .trim_end_matches(['}', ')', ' ']);
-    inner
-        .split(',')
-        .filter_map(|part| {
-            let part = part.trim();
-            // Handle "a: b" -> use "b" (the bound name)
-            if let Some(pos) = part.find(':') {
-                Some(part[pos + 1..].trim())
-            } else if part.is_empty() {
-                None
-            } else {
-                Some(part)
-            }
-        })
-        .collect()
 }
 
 impl std::fmt::Write for GenerateContext<'_> {

--- a/crates/vize_atelier_vapor/src/generate/destructure.rs
+++ b/crates/vize_atelier_vapor/src/generate/destructure.rs
@@ -1,0 +1,288 @@
+use vize_carton::{String, ToCompactString, cstr};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct DestructureBinding {
+    pub(super) local: String,
+    pub(super) path: String,
+}
+
+pub(super) fn parse_destructure_bindings(pattern: &str) -> std::vec::Vec<DestructureBinding> {
+    let mut bindings = std::vec::Vec::new();
+    parse_pattern(
+        strip_default(pattern.trim()),
+        String::default(),
+        &mut bindings,
+    );
+    bindings
+}
+
+pub(super) fn parse_destructure_names(pattern: &str) -> std::vec::Vec<String> {
+    parse_destructure_bindings(pattern)
+        .into_iter()
+        .map(|binding| binding.local)
+        .collect()
+}
+
+fn parse_pattern(pattern: &str, prefix: String, bindings: &mut std::vec::Vec<DestructureBinding>) {
+    let pattern = strip_wrapping_parens(pattern.trim());
+
+    if pattern.starts_with('{') && pattern.ends_with('}') {
+        parse_object_pattern(pattern, prefix, bindings);
+    } else if pattern.starts_with('[') && pattern.ends_with(']') {
+        parse_array_pattern(pattern, prefix, bindings);
+    } else if is_valid_ident(pattern) {
+        bindings.push(DestructureBinding {
+            local: pattern.to_compact_string(),
+            path: prefix,
+        });
+    }
+}
+
+fn parse_object_pattern(
+    pattern: &str,
+    prefix: String,
+    bindings: &mut std::vec::Vec<DestructureBinding>,
+) {
+    let inner = &pattern[1..pattern.len() - 1];
+    for part in split_top_level(inner) {
+        let part = part.trim();
+        if part.is_empty() || part.starts_with("...") {
+            continue;
+        }
+
+        if let Some(colon) = find_top_level_char(part, ':') {
+            let key = part[..colon].trim();
+            let value = strip_default(part[colon + 1..].trim());
+            let Some(segment) = object_path_segment(key) else {
+                continue;
+            };
+            parse_pattern(value, cstr!("{prefix}{segment}"), bindings);
+            continue;
+        }
+
+        let name = strip_default(part);
+        if is_valid_ident(name) {
+            bindings.push(DestructureBinding {
+                local: name.to_compact_string(),
+                path: cstr!("{prefix}.{}", name),
+            });
+        }
+    }
+}
+
+fn parse_array_pattern(
+    pattern: &str,
+    prefix: String,
+    bindings: &mut std::vec::Vec<DestructureBinding>,
+) {
+    let inner = &pattern[1..pattern.len() - 1];
+    for (index, part) in split_top_level(inner).into_iter().enumerate() {
+        let part = part.trim();
+        if part.is_empty() || part.starts_with("...") {
+            continue;
+        }
+        parse_pattern(strip_default(part), cstr!("{prefix}[{index}]"), bindings);
+    }
+}
+
+fn strip_default(pattern: &str) -> &str {
+    if let Some(index) = find_top_level_char(pattern, '=') {
+        pattern[..index].trim()
+    } else {
+        pattern.trim()
+    }
+}
+
+fn strip_wrapping_parens(pattern: &str) -> &str {
+    if pattern.starts_with('(') && pattern.ends_with(')') && matching_outer_pair(pattern, '(', ')')
+    {
+        pattern[1..pattern.len() - 1].trim()
+    } else {
+        pattern
+    }
+}
+
+fn object_path_segment(key: &str) -> Option<String> {
+    if is_valid_ident(key) {
+        return Some(cstr!(".{key}"));
+    }
+
+    if let Some(unquoted) = strip_string_literal(key) {
+        return Some(cstr!("[\"{}\"]", escape_js_string_literal(unquoted)));
+    }
+
+    if key.parse::<usize>().is_ok() {
+        return Some(cstr!("[{key}]"));
+    }
+
+    None
+}
+
+fn strip_string_literal(value: &str) -> Option<&str> {
+    let quote = value.as_bytes().first().copied()?;
+    if quote != b'\'' && quote != b'"' {
+        return None;
+    }
+    if value.as_bytes().last().copied()? != quote {
+        return None;
+    }
+    Some(&value[1..value.len() - 1])
+}
+
+fn escape_js_string_literal(value: &str) -> String {
+    let mut escaped = String::with_capacity(value.len());
+    for ch in value.chars() {
+        match ch {
+            '\\' => escaped.push_str("\\\\"),
+            '"' => escaped.push_str("\\\""),
+            '\n' => escaped.push_str("\\n"),
+            '\r' => escaped.push_str("\\r"),
+            '\t' => escaped.push_str("\\t"),
+            _ => escaped.push(ch),
+        }
+    }
+    escaped
+}
+
+fn split_top_level(s: &str) -> std::vec::Vec<&str> {
+    let mut parts = std::vec::Vec::new();
+    let mut depth = 0i32;
+    let mut quote = None;
+    let mut start = 0usize;
+    let mut prev = '\0';
+
+    for (index, ch) in s.char_indices() {
+        if let Some(open_quote) = quote {
+            if ch == open_quote && prev != '\\' {
+                quote = None;
+            }
+            prev = ch;
+            continue;
+        }
+
+        match ch {
+            '"' | '\'' | '`' => quote = Some(ch),
+            '{' | '[' | '(' => depth += 1,
+            '}' | ']' | ')' => depth -= 1,
+            ',' if depth == 0 => {
+                parts.push(&s[start..index]);
+                start = index + ch.len_utf8();
+            }
+            _ => {}
+        }
+        prev = ch;
+    }
+
+    parts.push(&s[start..]);
+    parts
+}
+
+fn find_top_level_char(s: &str, needle: char) -> Option<usize> {
+    let mut depth = 0i32;
+    let mut quote = None;
+    let mut prev = '\0';
+
+    for (index, ch) in s.char_indices() {
+        if let Some(open_quote) = quote {
+            if ch == open_quote && prev != '\\' {
+                quote = None;
+            }
+            prev = ch;
+            continue;
+        }
+
+        match ch {
+            '"' | '\'' | '`' => quote = Some(ch),
+            '{' | '[' | '(' => depth += 1,
+            '}' | ']' | ')' => depth -= 1,
+            _ if ch == needle && depth == 0 => return Some(index),
+            _ => {}
+        }
+        prev = ch;
+    }
+
+    None
+}
+
+fn matching_outer_pair(s: &str, open: char, close: char) -> bool {
+    let mut depth = 0i32;
+    let mut quote = None;
+    let mut prev = '\0';
+
+    for (index, ch) in s.char_indices() {
+        if let Some(open_quote) = quote {
+            if ch == open_quote && prev != '\\' {
+                quote = None;
+            }
+            prev = ch;
+            continue;
+        }
+
+        match ch {
+            '"' | '\'' | '`' => quote = Some(ch),
+            _ if ch == open => depth += 1,
+            _ if ch == close => {
+                depth -= 1;
+                if depth == 0 && index + ch.len_utf8() < s.len() {
+                    return false;
+                }
+            }
+            _ => {}
+        }
+        prev = ch;
+    }
+
+    depth == 0
+}
+
+fn is_valid_ident(s: &str) -> bool {
+    let mut chars = s.chars();
+    match chars.next() {
+        Some(ch) if ch.is_ascii_alphabetic() || ch == '_' || ch == '$' => {}
+        _ => return false,
+    }
+    chars.all(|ch| ch.is_ascii_alphanumeric() || ch == '_' || ch == '$')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_destructure_bindings;
+
+    #[test]
+    fn parses_object_aliases_and_nested_paths() {
+        let bindings = parse_destructure_bindings(
+            r#"{ id, name: label, user: { id: userId }, meta: { count: total = 0 }, "data-id": dataId }"#,
+        );
+
+        let pairs = bindings
+            .iter()
+            .map(|binding| (binding.local.as_str(), binding.path.as_str()))
+            .collect::<std::vec::Vec<_>>();
+
+        assert_eq!(
+            pairs,
+            vec![
+                ("id", ".id"),
+                ("label", ".name"),
+                ("userId", ".user.id"),
+                ("total", ".meta.count"),
+                ("dataId", "[\"data-id\"]"),
+            ]
+        );
+    }
+
+    #[test]
+    fn parses_array_aliases_and_nested_objects() {
+        let bindings = parse_destructure_bindings("[first, { id: secondId }, third = fallback]");
+
+        let pairs = bindings
+            .iter()
+            .map(|binding| (binding.local.as_str(), binding.path.as_str()))
+            .collect::<std::vec::Vec<_>>();
+
+        assert_eq!(
+            pairs,
+            vec![("first", "[0]"), ("secondId", "[1].id"), ("third", "[2]"),]
+        );
+    }
+}

--- a/crates/vize_atelier_vapor/src/generate/operations/for_loop.rs
+++ b/crates/vize_atelier_vapor/src/generate/operations/for_loop.rs
@@ -4,6 +4,7 @@ use vize_carton::{FxHashMap, String, ToCompactString, cstr};
 use super::{
     super::{
         context::{ForScope, GenerateContext},
+        destructure::parse_destructure_bindings,
         generate_block,
     },
     insertion::{block_requires_parent_insertion_state, emit_insertion_state},
@@ -163,11 +164,15 @@ fn resolve_key_expression(
 fn restore_current_alias_reference(expr: &mut String, reference: &str, alias: &str) {
     if is_simple_local_alias(alias) && expr.contains(reference) {
         *expr = expr.replace(reference, alias).into();
-    } else if alias.trim_start().starts_with(['{', '(']) {
-        for name in parse_destructure_names(alias) {
-            let property_reference = cstr!("{}.{}", reference, name);
+    } else if alias.trim_start().starts_with(['{', '[', '(']) {
+        let mut bindings = parse_destructure_bindings(alias);
+        bindings.sort_by(|a, b| b.path.len().cmp(&a.path.len()));
+        for binding in bindings {
+            let property_reference = cstr!("{}{}", reference, binding.path);
             if expr.contains(property_reference.as_str()) {
-                *expr = expr.replace(property_reference.as_str(), name).into();
+                *expr = expr
+                    .replace(property_reference.as_str(), binding.local.as_str())
+                    .into();
             }
         }
     }
@@ -182,25 +187,6 @@ fn is_simple_local_alias(alias: &str) -> bool {
         && chars.all(|ch| ch.is_ascii_alphanumeric() || ch == '_' || ch == '$')
 }
 
-fn parse_destructure_names(pattern: &str) -> std::vec::Vec<&str> {
-    let inner = pattern
-        .trim_start_matches(['{', '(', ' '])
-        .trim_end_matches(['}', ')', ' ']);
-    inner
-        .split(',')
-        .filter_map(|part| {
-            let part = part.trim();
-            if let Some(pos) = part.find(':') {
-                Some(part[pos + 1..].trim())
-            } else if part.is_empty() {
-                None
-            } else {
-                Some(part)
-            }
-        })
-        .collect()
-}
-
 #[cfg(test)]
 mod tests {
     use super::restore_current_alias_reference;
@@ -208,10 +194,14 @@ mod tests {
 
     #[test]
     fn restores_destructured_key_alias_references() {
-        let mut expr = "_for_item0.value.id".to_compact_string();
+        let mut expr = "_for_item0.value.name + _for_item0.value.user.id".to_compact_string();
 
-        restore_current_alias_reference(&mut expr, "_for_item0.value", "{ id, name }");
+        restore_current_alias_reference(
+            &mut expr,
+            "_for_item0.value",
+            "{ name: label, user: { id: userId } }",
+        );
 
-        assert_eq!(expr, "id");
+        assert_eq!(expr, "label + userId");
     }
 }

--- a/crates/vize_atelier_vapor/src/generate/operations/for_loop.rs
+++ b/crates/vize_atelier_vapor/src/generate/operations/for_loop.rs
@@ -166,7 +166,7 @@ fn restore_current_alias_reference(expr: &mut String, reference: &str, alias: &s
         *expr = expr.replace(reference, alias).into();
     } else if alias.trim_start().starts_with(['{', '[', '(']) {
         let mut bindings = parse_destructure_bindings(alias);
-        bindings.sort_by(|a, b| b.path.len().cmp(&a.path.len()));
+        bindings.sort_by_key(|binding| std::cmp::Reverse(binding.path.len()));
         for binding in bindings {
             let property_reference = cstr!("{}{}", reference, binding.path);
             if expr.contains(property_reference.as_str()) {

--- a/crates/vize_atelier_vapor/src/lib.rs
+++ b/crates/vize_atelier_vapor/src/lib.rs
@@ -598,6 +598,45 @@ mod tests {
     }
 
     #[test]
+    fn test_compile_v_for_destructured_aliases_resolve_source_paths() {
+        let allocator = Bump::new();
+        let result = compile_vapor(
+            &allocator,
+            r#"<ul><li v-for="{ id: itemId, user: { name }, meta: { count: total = 0 } } in rows" :key="itemId" :title="name">{{ total }}</li></ul>"#,
+            Default::default(),
+        );
+
+        assert!(
+            result.error_messages.is_empty(),
+            "Expected no errors: {:?}",
+            result.error_messages
+        );
+
+        assert_parses_as_module(&result.code);
+        assert!(
+            result
+                .code
+                .contains(r#"_setProp(n2, "title", _for_item0.value.user.name)"#),
+            "{}",
+            result.code
+        );
+        assert!(
+            result
+                .code
+                .contains("_setText(x2, _toDisplayString(_for_item0.value.meta.count))"),
+            "{}",
+            result.code
+        );
+        assert!(
+            result.code.contains(
+                "}, ({ id: itemId, user: { name }, meta: { count: total = 0 } }) => (itemId))"
+            ),
+            "{}",
+            result.code
+        );
+    }
+
+    #[test]
     fn test_compile_nested_v_for_key_uses_outer_alias() {
         let allocator = Bump::new();
         let result = compile_vapor(


### PR DESCRIPTION
## Summary
- add a shared Vapor destructuring helper that preserves local aliases and source paths
- resolve nested/object/array destructured v-for aliases against the correct _for_item source path
- restore destructured locals in generated v-for key functions

## Validation
- cargo test -p vize_atelier_vapor --lib
- git diff --check