### PR TITLE
fix(docs): repair blog links

### DIFF
--- a/docs/content/blog/index.md
+++ b/docs/content/blog/index.md
@@ -37,59 +37,59 @@ The Vize docs now have two writing lanes:
 ## Latest Posts
 
 <div class="blog-post-list">
-  <a class="blog-post-list-item" href="./notes/2026-05-16-comparing-vize-with-official-vue-oxc-golar-verter-flint-and-tsslint.md">
+  <a class="blog-post-list-item" href="./notes/2026-05-16-comparing-vize-with-official-vue-oxc-golar-verter-flint-and-tsslint/">
     <strong>Tooling Compare</strong>
     <span>A practical comparison of Vize and nearby projects across official Vue tooling, Oxc, Golar, Verter, Flint, and TSSLint.</span>
   </a>
-  <a class="blog-post-list-item" href="./notes/2026-05-16-performance-tuning-notes-for-a-vue-toolchain.md">
+  <a class="blog-post-list-item" href="./notes/2026-05-16-performance-tuning-notes-for-a-vue-toolchain/">
     <strong>Performance Tuning</strong>
     <span>Practical performance lessons from building a Vue toolchain where parsing, allocation, parallelism, and feedback loops all matter.</span>
   </a>
-  <a class="blog-post-list-item" href="./notes/2026-05-16-testing-agentic-coding-and-trust.md">
+  <a class="blog-post-list-item" href="./notes/2026-05-16-testing-agentic-coding-and-trust/">
     <strong>Testing & Agents</strong>
     <span>Why snapshot-heavy tests, real-world fixtures, and deterministic checks matter more when agents are part of the development loop.</span>
   </a>
-  <a class="blog-post-list-item" href="./notes/2026-05-16-vapor-mode-and-the-next-vue-compiler-surface.md">
+  <a class="blog-post-list-item" href="./notes/2026-05-16-vapor-mode-and-the-next-vue-compiler-surface/">
     <strong>Vapor Mode</strong>
     <span>Why Vapor Mode matters for Vize, and why a direct fine-grained compiler path changes more than runtime performance.</span>
   </a>
-  <a class="blog-post-list-item" href="./notes/2026-05-16-vue-as-a-language-and-the-strongest-frontend-environment.md">
+  <a class="blog-post-list-item" href="./notes/2026-05-16-vue-as-a-language-and-the-strongest-frontend-environment/">
     <strong>Vue as Language</strong>
     <span>Building on the idea that Vue is a language for UI, this note explains why frontend development needs a coherent environment rather than scattered tools.</span>
   </a>
-  <a class="blog-post-list-item" href="./notes/2026-05-16-why-musea-and-design-systems-matter-in-the-ai-era.md">
+  <a class="blog-post-list-item" href="./notes/2026-05-16-why-musea-and-design-systems-matter-in-the-ai-era/">
     <strong>Musea & AI</strong>
     <span>AI can generate UI quickly, but Musea and design systems make the intent, constraints, accessibility, and review workflow durable.</span>
   </a>
-  <a class="blog-post-list-item" href="./notes/2026-05-16-real-world-feedback-and-the-road-to-production-ready.md">
+  <a class="blog-post-list-item" href="./notes/2026-05-16-real-world-feedback-and-the-road-to-production-ready/">
     <strong>Production Ready</strong>
     <span>Why exhaustive real-world validation and community feedback are the path from experimental project to production-ready toolchain.</span>
   </a>
-  <a class="blog-post-list-item" href="./notes/2026-05-16-unofficial-personal-tooling-and-development-speed.md">
+  <a class="blog-post-list-item" href="./notes/2026-05-16-unofficial-personal-tooling-and-development-speed/">
     <strong>Personal Speed</strong>
     <span>Why Vize being unofficial and personal can be an advantage for exploration, speed, and ambitious toolchain design.</span>
   </a>
-  <a class="blog-post-list-item" href="./notes/2026-03-26-the-advantages-and-beauty-of-toolchains-and-vertical-integration.md">
+  <a class="blog-post-list-item" href="./notes/2026-03-26-the-advantages-and-beauty-of-toolchains-and-vertical-integration/">
     <strong>Vertical Toolchains</strong>
     <span>Why owning more of the stack can improve speed, coherence, and even the aesthetic quality of developer tools.</span>
   </a>
-  <a class="blog-post-list-item" href="./notes/2026-03-26-why-ai-needs-deterministic-fast-static-analysis.md">
+  <a class="blog-post-list-item" href="./notes/2026-03-26-why-ai-needs-deterministic-fast-static-analysis/">
     <strong>Static Analysis for AI</strong>
     <span>As AI writes more code, we need faster and more reliable static feedback, not less.</span>
   </a>
-  <a class="blog-post-list-item" href="./notes/2026-03-26-where-vize-fits-in-the-vue-tooling-landscape.md">
+  <a class="blog-post-list-item" href="./notes/2026-03-26-where-vize-fits-in-the-vue-tooling-landscape/">
     <strong>Vue Tooling Map</strong>
     <span>A map of where Vize sits in the current Vue tooling landscape, and how it differs from adjacent projects.</span>
   </a>
-  <a class="blog-post-list-item" href="./releases/2026-03-26-oxlint-plugin-vize-alpha.md">
+  <a class="blog-post-list-item" href="./releases/2026-03-26-oxlint-plugin-vize-alpha/">
     <strong><code>oxlint-plugin-vize</code> Alpha</strong>
     <span>A new Oxlint JS plugin bridge brings Vize Patina diagnostics into a single Oxlint run for Vue SFCs.</span>
   </a>
-  <a class="blog-post-list-item" href="./releases/2026-03-26-docs-blog-support.md">
+  <a class="blog-post-list-item" href="./releases/2026-03-26-docs-blog-support/">
     <strong>Docs Blog</strong>
     <span>The Vize docs can now host both release notes and irregular notes.</span>
   </a>
-  <a class="blog-post-list-item" href="./notes/2026-03-26-why-vize-needs-notes.md">
+  <a class="blog-post-list-item" href="./notes/2026-03-26-why-vize-needs-notes/">
     <strong>Notes Lane</strong>
     <span>Some project updates need room for context, not just a changelog entry.</span>
   </a>

--- a/docs/content/blog/notes/index.md
+++ b/docs/content/blog/notes/index.md
@@ -17,51 +17,51 @@ Use this section for writing that does not fit a release announcement: architect
 ## Posts
 
 <div class="blog-post-list">
-  <a class="blog-post-list-item" href="./2026-05-16-comparing-vize-with-official-vue-oxc-golar-verter-flint-and-tsslint.md">
+  <a class="blog-post-list-item" href="./2026-05-16-comparing-vize-with-official-vue-oxc-golar-verter-flint-and-tsslint/">
     <strong>Tooling Compare</strong>
     <span>A practical comparison of Vize and nearby projects across official Vue tooling, Oxc, Golar, Verter, Flint, and TSSLint.</span>
   </a>
-  <a class="blog-post-list-item" href="./2026-05-16-performance-tuning-notes-for-a-vue-toolchain.md">
+  <a class="blog-post-list-item" href="./2026-05-16-performance-tuning-notes-for-a-vue-toolchain/">
     <strong>Performance Tuning</strong>
     <span>Practical performance lessons from building a Vue toolchain where parsing, allocation, parallelism, and feedback loops all matter.</span>
   </a>
-  <a class="blog-post-list-item" href="./2026-05-16-testing-agentic-coding-and-trust.md">
+  <a class="blog-post-list-item" href="./2026-05-16-testing-agentic-coding-and-trust/">
     <strong>Testing & Agents</strong>
     <span>Why snapshot-heavy tests, real-world fixtures, and deterministic checks matter more when agents are part of the development loop.</span>
   </a>
-  <a class="blog-post-list-item" href="./2026-05-16-vapor-mode-and-the-next-vue-compiler-surface.md">
+  <a class="blog-post-list-item" href="./2026-05-16-vapor-mode-and-the-next-vue-compiler-surface/">
     <strong>Vapor Mode</strong>
     <span>Why Vapor Mode matters for Vize, and why a direct fine-grained compiler path changes more than runtime performance.</span>
   </a>
-  <a class="blog-post-list-item" href="./2026-05-16-vue-as-a-language-and-the-strongest-frontend-environment.md">
+  <a class="blog-post-list-item" href="./2026-05-16-vue-as-a-language-and-the-strongest-frontend-environment/">
     <strong>Vue as Language</strong>
     <span>Building on the idea that Vue is a language for UI, this note explains why frontend development needs a coherent environment rather than scattered tools.</span>
   </a>
-  <a class="blog-post-list-item" href="./2026-05-16-why-musea-and-design-systems-matter-in-the-ai-era.md">
+  <a class="blog-post-list-item" href="./2026-05-16-why-musea-and-design-systems-matter-in-the-ai-era/">
     <strong>Musea & AI</strong>
     <span>AI can generate UI quickly, but Musea and design systems make the intent, constraints, accessibility, and review workflow durable.</span>
   </a>
-  <a class="blog-post-list-item" href="./2026-05-16-real-world-feedback-and-the-road-to-production-ready.md">
+  <a class="blog-post-list-item" href="./2026-05-16-real-world-feedback-and-the-road-to-production-ready/">
     <strong>Production Ready</strong>
     <span>Why exhaustive real-world validation and community feedback are the path from experimental project to production-ready toolchain.</span>
   </a>
-  <a class="blog-post-list-item" href="./2026-05-16-unofficial-personal-tooling-and-development-speed.md">
+  <a class="blog-post-list-item" href="./2026-05-16-unofficial-personal-tooling-and-development-speed/">
     <strong>Personal Speed</strong>
     <span>Why Vize being unofficial and personal can be an advantage for exploration, speed, and ambitious toolchain design.</span>
   </a>
-  <a class="blog-post-list-item" href="./2026-03-26-the-advantages-and-beauty-of-toolchains-and-vertical-integration.md">
+  <a class="blog-post-list-item" href="./2026-03-26-the-advantages-and-beauty-of-toolchains-and-vertical-integration/">
     <strong>Vertical Toolchains</strong>
     <span>Why owning more of the stack can improve speed, coherence, and even the aesthetic quality of developer tools.</span>
   </a>
-  <a class="blog-post-list-item" href="./2026-03-26-why-ai-needs-deterministic-fast-static-analysis.md">
+  <a class="blog-post-list-item" href="./2026-03-26-why-ai-needs-deterministic-fast-static-analysis/">
     <strong>Static Analysis for AI</strong>
     <span>As AI writes more code, we need faster and more reliable static feedback, not less.</span>
   </a>
-  <a class="blog-post-list-item" href="./2026-03-26-where-vize-fits-in-the-vue-tooling-landscape.md">
+  <a class="blog-post-list-item" href="./2026-03-26-where-vize-fits-in-the-vue-tooling-landscape/">
     <strong>Vue Tooling Map</strong>
     <span>A map of where Vize sits in the current Vue tooling landscape, and how it differs from adjacent projects.</span>
   </a>
-  <a class="blog-post-list-item" href="./2026-03-26-why-vize-needs-notes.md">
+  <a class="blog-post-list-item" href="./2026-03-26-why-vize-needs-notes/">
     <strong>Notes Lane</strong>
     <span>Some project updates need room for context, not just a changelog entry.</span>
   </a>

--- a/docs/content/blog/releases/index.md
+++ b/docs/content/blog/releases/index.md
@@ -17,11 +17,11 @@ Use this section for shipped changes: new versions, notable fixes, migrations, d
 ## Posts
 
 <div class="blog-post-list">
-  <a class="blog-post-list-item" href="./2026-03-26-oxlint-plugin-vize-alpha.md">
+  <a class="blog-post-list-item" href="./2026-03-26-oxlint-plugin-vize-alpha/">
     <strong><code>oxlint-plugin-vize</code> Alpha</strong>
     <span>A new Oxlint JS plugin bridge brings Vize Patina diagnostics into a single Oxlint run for Vue SFCs.</span>
   </a>
-  <a class="blog-post-list-item" href="./2026-03-26-docs-blog-support.md">
+  <a class="blog-post-list-item" href="./2026-03-26-docs-blog-support/">
     <strong>Docs Blog</strong>
     <span>The Vize docs can now host both release notes and irregular notes.</span>
   </a>


### PR DESCRIPTION
## Summary

- Replace raw blog listing links that pointed at Markdown files with generated trailing-slash page URLs.
- Apply the fix to the blog overview, notes index, and releases index.

## Root Cause

The SSG generates blog posts as `.../index.html`, but raw HTML anchors in the Markdown content were emitted unchanged with `.md` hrefs. Those `.md` URLs do not exist in the built site, so the blog post links returned 404.

## Validation

- `pnpm -C docs build`
- `pnpm -C docs exec node --test theme/navigation.test.js theme/syntax-highlight.test.js`
- Verified generated blog relative links resolve to files in `docs/dist`.
- Verified preview HTTP responses: all 17 blog URLs returned 200.
- Verified in the in-app browser that `/blog/` opens the first post without a 404.