### PR TITLE
fix(maestro): collect directive semantic token edges

### DIFF
--- a/crates/vize_maestro/src/ide/semantic_tokens.rs
+++ b/crates/vize_maestro/src/ide/semantic_tokens.rs
@@ -642,6 +642,24 @@ mod tests {
         decoded
     }
 
+    fn has_token_text(
+        template_str: &str,
+        tokens: &[super::types::AbsoluteToken],
+        token_type: TokenType,
+        text: &str,
+    ) -> bool {
+        let Some(start) = template_str.find(text) else {
+            return false;
+        };
+
+        tokens.iter().any(|token| {
+            token.line == 0
+                && token.start == start as u32
+                && token.length == text.len() as u32
+                && token.token_type == token_type as u32
+        })
+    }
+
     #[test]
     fn test_extract_identifiers() {
         let expr = "count + message.length";
@@ -831,6 +849,42 @@ import Button from './Button.vue'
                 .any(|token| token.token_type == TokenType::Variable as u32),
             "{tokens:#?}"
         );
+    }
+
+    #[test]
+    fn test_template_semantic_tokens_collect_dynamic_shorthand_args() {
+        let template_str = r#"<button @[eventName].stop="run" :[propName].camel="value"></button>"#;
+        let mut tokens = Vec::new();
+        template::collect_template_tokens(template_str, 0, &mut tokens);
+
+        assert!(
+            has_token_text(template_str, &tokens, TokenType::Event, "@[eventName].stop"),
+            "{tokens:#?}"
+        );
+        assert!(
+            has_token_text(template_str, &tokens, TokenType::Property, ":[propName]"),
+            "{tokens:#?}"
+        );
+        for name in ["eventName", "propName", "run", "value"] {
+            assert!(
+                has_token_text(template_str, &tokens, TokenType::Variable, name),
+                "missing {name}: {tokens:#?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_template_semantic_tokens_collect_unquoted_directive_values() {
+        let template_str = r#"<div v-if=ready @click=save :class=classes></div>"#;
+        let mut tokens = Vec::new();
+        template::collect_template_tokens(template_str, 0, &mut tokens);
+
+        for name in ["ready", "save", "classes"] {
+            assert!(
+                has_token_text(template_str, &tokens, TokenType::Variable, name),
+                "missing {name}: {tokens:#?}"
+            );
+        }
     }
 
     #[test]

--- a/crates/vize_maestro/src/ide/semantic_tokens/template.rs
+++ b/crates/vize_maestro/src/ide/semantic_tokens/template.rs
@@ -146,23 +146,23 @@ fn collect_bind_tokens(template: &str, base_line: u32, tokens: &mut Vec<Absolute
         }
 
         // Check if it's in an attribute context.
-        if is_attribute_start(template, abs_start) {
-            if let Some(token_end) = shorthand_name_end(
+        if is_attribute_start(template, abs_start)
+            && let Some(token_end) = shorthand_name_end(
                 template,
                 abs_start,
                 |ch| ch.is_ascii_alphanumeric() || ch == '-',
                 false,
-            ) {
-                let (line, col) = offset_to_line_col(template, abs_start);
+            )
+        {
+            let (line, col) = offset_to_line_col(template, abs_start);
 
-                tokens.push(AbsoluteToken {
-                    line: base_line + line,
-                    start: col,
-                    length: utf16_len(&template[abs_start..token_end]),
-                    token_type: TokenType::Property as u32,
-                    modifiers: 0,
-                });
-            }
+            tokens.push(AbsoluteToken {
+                line: base_line + line,
+                start: col,
+                length: utf16_len(&template[abs_start..token_end]),
+                token_type: TokenType::Property as u32,
+                modifiers: 0,
+            });
         }
 
         pos = abs_start + 1;

--- a/crates/vize_maestro/src/ide/semantic_tokens/template.rs
+++ b/crates/vize_maestro/src/ide/semantic_tokens/template.rs
@@ -111,20 +111,18 @@ fn collect_event_tokens(template: &str, base_line: u32, tokens: &mut Vec<Absolut
             continue;
         }
 
-        let remaining = &template[abs_start + 1..];
-
-        // Find the event name
-        let event_end = remaining
-            .find(|c: char| !c.is_ascii_alphanumeric() && c != '-' && c != ':' && c != '.')
-            .unwrap_or(remaining.len());
-
-        if event_end > 0 {
+        if let Some(token_end) = shorthand_name_end(
+            template,
+            abs_start,
+            |ch| ch.is_ascii_alphanumeric() || ch == '-' || ch == ':' || ch == '.',
+            true,
+        ) {
             let (line, col) = offset_to_line_col(template, abs_start);
 
             tokens.push(AbsoluteToken {
                 line: base_line + line,
                 start: col,
-                length: utf16_len(&template[abs_start..abs_start + event_end + 1]),
+                length: utf16_len(&template[abs_start..token_end]),
                 token_type: TokenType::Event as u32,
                 modifiers: 0,
             });
@@ -149,18 +147,18 @@ fn collect_bind_tokens(template: &str, base_line: u32, tokens: &mut Vec<Absolute
 
         // Check if it's in an attribute context.
         if is_attribute_start(template, abs_start) {
-            let remaining = &template[abs_start + 1..];
-            let prop_end = remaining
-                .find(|c: char| !c.is_ascii_alphanumeric() && c != '-')
-                .unwrap_or(remaining.len());
-
-            if prop_end > 0 {
+            if let Some(token_end) = shorthand_name_end(
+                template,
+                abs_start,
+                |ch| ch.is_ascii_alphanumeric() || ch == '-',
+                false,
+            ) {
                 let (line, col) = offset_to_line_col(template, abs_start);
 
                 tokens.push(AbsoluteToken {
                     line: base_line + line,
                     start: col,
-                    length: utf16_len(&template[abs_start..abs_start + prop_end + 1]),
+                    length: utf16_len(&template[abs_start..token_end]),
                     token_type: TokenType::Property as u32,
                     modifiers: 0,
                 });
@@ -200,20 +198,113 @@ pub(crate) fn collect_directive_expression_tokens(
             None
         };
 
-        if let Some(start) = attr_start
-            && let Some((expr_start, expr_end)) = quoted_attribute_value(template, start)
-        {
-            let expr = &template[expr_start..expr_end];
+        if let Some(start) = attr_start {
+            if let Some((arg_start, arg_end)) = dynamic_argument_value(template, start) {
+                let arg = &template[arg_start..arg_end];
+                tokenize_expression(arg, template, arg_start, base_line, tokens);
+            }
 
-            // Tokenize the entire expression
-            tokenize_expression(expr, template, expr_start, base_line, tokens);
+            if let Some((expr_start, expr_end)) = attribute_value(template, start) {
+                let expr = &template[expr_start..expr_end];
+                tokenize_expression(expr, template, expr_start, base_line, tokens);
 
-            pos = expr_end + 1;
-            continue;
+                pos = expr_end + 1;
+                continue;
+            }
         }
 
         pos += 1;
     }
+}
+
+fn shorthand_name_end(
+    template: &str,
+    attr_start: usize,
+    is_plain_name_char: impl Fn(char) -> bool,
+    include_modifiers: bool,
+) -> Option<usize> {
+    let mut pos = attr_start + 1;
+    if pos >= template.len() {
+        return None;
+    }
+
+    if template[pos..].starts_with('[') {
+        pos = find_matching_square_bracket(template, pos)? + 1;
+        if include_modifiers {
+            pos = consume_modifier_suffix(template, pos);
+        }
+        return Some(pos);
+    }
+
+    let name_start = pos;
+    while pos < template.len() {
+        let ch = template[pos..].chars().next()?;
+        if !is_plain_name_char(ch) {
+            break;
+        }
+        pos += ch.len_utf8();
+    }
+
+    if pos == name_start { None } else { Some(pos) }
+}
+
+fn consume_modifier_suffix(template: &str, mut pos: usize) -> usize {
+    while pos < template.len() && template[pos..].starts_with('.') {
+        pos += 1;
+        while pos < template.len() {
+            let Some(ch) = template[pos..].chars().next() else {
+                break;
+            };
+            if !ch.is_ascii_alphanumeric() && ch != '-' && ch != '_' {
+                break;
+            }
+            pos += ch.len_utf8();
+        }
+    }
+    pos
+}
+
+fn dynamic_argument_value(template: &str, attr_start: usize) -> Option<(usize, usize)> {
+    let name_end = attribute_name_end(template, attr_start);
+    let search = &template[attr_start..name_end];
+    let bracket_offset = search.find('[')? + attr_start;
+    let bracket_end = find_matching_square_bracket(template, bracket_offset)?;
+    Some((bracket_offset + 1, bracket_end))
+}
+
+fn find_matching_square_bracket(template: &str, open_offset: usize) -> Option<usize> {
+    if !template[open_offset..].starts_with('[') {
+        return None;
+    }
+
+    let mut depth = 0i32;
+    let mut quote = None;
+    let mut prev = '\0';
+
+    for (relative, ch) in template[open_offset..].char_indices() {
+        if let Some(open_quote) = quote {
+            if ch == open_quote && prev != '\\' {
+                quote = None;
+            }
+            prev = ch;
+            continue;
+        }
+
+        match ch {
+            '"' | '\'' | '`' => quote = Some(ch),
+            '[' => depth += 1,
+            ']' => {
+                depth -= 1;
+                if depth == 0 {
+                    return Some(open_offset + relative);
+                }
+            }
+            _ => {}
+        }
+        prev = ch;
+    }
+
+    None
 }
 
 fn is_attribute_start(template: &str, offset: usize) -> bool {
@@ -276,7 +367,7 @@ fn attribute_name_end(template: &str, start: usize) -> usize {
     end
 }
 
-fn quoted_attribute_value(template: &str, attr_start: usize) -> Option<(usize, usize)> {
+fn attribute_value(template: &str, attr_start: usize) -> Option<(usize, usize)> {
     let mut pos = attribute_name_end(template, attr_start);
 
     while pos < template.len() {
@@ -301,14 +392,30 @@ fn quoted_attribute_value(template: &str, attr_start: usize) -> Option<(usize, u
     }
 
     let quote = template.as_bytes().get(pos).copied()?;
-    if quote != b'"' && quote != b'\'' {
-        return None;
+    if quote == b'"' || quote == b'\'' {
+        let value_start = pos + 1;
+        let quote_char = quote as char;
+        let value_end = template[value_start..].find(quote_char)? + value_start;
+        return Some((value_start, value_end));
     }
 
-    let value_start = pos + 1;
-    let quote_char = quote as char;
-    let value_end = template[value_start..].find(quote_char)? + value_start;
-    Some((value_start, value_end))
+    let value_start = pos;
+    while pos < template.len() {
+        let ch = template[pos..].chars().next()?;
+        if ch.is_ascii_whitespace()
+            || ch == '>'
+            || (ch == '/' && template[pos + ch.len_utf8()..].starts_with('>'))
+        {
+            break;
+        }
+        pos += ch.len_utf8();
+    }
+
+    if pos == value_start {
+        None
+    } else {
+        Some((value_start, pos))
+    }
 }
 
 /// Collect tokens from script content (compiler macros and Vue functions).


### PR DESCRIPTION
## Summary
- collect semantic tokens for dynamic directive shorthand names like @[event] and :[prop]
- tokenize dynamic directive arguments and unquoted directive values
- keep existing safeguards that ignore text/static-attribute lookalikes

## Validation
- cargo test -p vize_maestro semantic_tokens --lib
- git diff --check