### PR TITLE
fix(core): extract defaulted v-for destructure params

### DIFF
--- a/crates/vize_atelier_core/src/codegen/v_for/helpers.rs
+++ b/crates/vize_atelier_core/src/codegen/v_for/helpers.rs
@@ -44,17 +44,9 @@ pub(crate) fn extract_destructure_params(trimmed: &str, params: &mut Vec<String>
                 }
                 continue;
             }
-            // Handle default values: "item = default" -- take name before =
-            if let Some(eq_pos) = part.find('=') {
-                let name = part[..eq_pos].trim();
-                if !name.is_empty() && is_valid_ident(name) {
-                    params.push(name.to_compact_string());
-                }
-                continue;
-            }
             // Handle renaming/nested: "original: value"
-            if let Some(colon_pos) = part.find(':') {
-                let value = part[colon_pos + 1..].trim();
+            if let Some(colon_pos) = find_top_level_char(part, ':') {
+                let value = strip_default_value(part[colon_pos + 1..].trim());
                 // Value might be another destructure pattern or a simple identifier
                 if value.starts_with('{') || value.starts_with('[') {
                     extract_destructure_params(value, params);
@@ -63,6 +55,9 @@ pub(crate) fn extract_destructure_params(trimmed: &str, params: &mut Vec<String>
                 }
                 continue;
             }
+
+            // Handle default values: "item = default" -- take name before =
+            let part = strip_default_value(part);
             // Simple identifier
             if !part.is_empty() && is_valid_ident(part) {
                 params.push(part.to_compact_string());
@@ -77,7 +72,11 @@ pub(crate) fn extract_destructure_params(trimmed: &str, params: &mut Vec<String>
                 if !rest.is_empty() && is_valid_ident(rest) {
                     params.push(rest.to_compact_string());
                 }
-            } else if part.starts_with('{') || part.starts_with('[') {
+                continue;
+            }
+
+            let part = strip_default_value(part);
+            if part.starts_with('{') || part.starts_with('[') {
                 extract_destructure_params(part, params);
             } else if !part.is_empty() && is_valid_ident(part) {
                 params.push(part.to_compact_string());
@@ -92,20 +91,68 @@ pub(crate) fn extract_destructure_params(trimmed: &str, params: &mut Vec<String>
 pub(crate) fn split_top_level(s: &str) -> Vec<&str> {
     let mut parts = Vec::new();
     let mut depth = 0i32;
+    let mut quote = None;
     let mut start = 0;
-    for (i, b) in s.bytes().enumerate() {
-        match b {
-            b'{' | b'[' | b'(' => depth += 1,
-            b'}' | b']' | b')' => depth -= 1,
-            b',' if depth == 0 => {
+    let mut prev = '\0';
+
+    for (i, ch) in s.char_indices() {
+        if let Some(open_quote) = quote {
+            if ch == open_quote && prev != '\\' {
+                quote = None;
+            }
+            prev = ch;
+            continue;
+        }
+
+        match ch {
+            '"' | '\'' | '`' => quote = Some(ch),
+            '{' | '[' | '(' => depth += 1,
+            '}' | ']' | ')' => depth -= 1,
+            ',' if depth == 0 => {
                 parts.push(&s[start..i]);
-                start = i + 1;
+                start = i + ch.len_utf8();
             }
             _ => {}
         }
+        prev = ch;
     }
     parts.push(&s[start..]);
     parts
+}
+
+fn strip_default_value(pattern: &str) -> &str {
+    if let Some(index) = find_top_level_char(pattern, '=') {
+        pattern[..index].trim()
+    } else {
+        pattern.trim()
+    }
+}
+
+fn find_top_level_char(s: &str, needle: char) -> Option<usize> {
+    let mut depth = 0i32;
+    let mut quote = None;
+    let mut prev = '\0';
+
+    for (i, ch) in s.char_indices() {
+        if let Some(open_quote) = quote {
+            if ch == open_quote && prev != '\\' {
+                quote = None;
+            }
+            prev = ch;
+            continue;
+        }
+
+        match ch {
+            '"' | '\'' | '`' => quote = Some(ch),
+            '{' | '[' | '(' => depth += 1,
+            '}' | ']' | ')' => depth -= 1,
+            _ if ch == needle && depth == 0 => return Some(i),
+            _ => {}
+        }
+        prev = ch;
+    }
+
+    None
 }
 
 /// Check if a string is a valid JS identifier
@@ -197,7 +244,7 @@ pub(crate) fn should_skip_prop(p: &PropNode<'_>) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::is_numeric_content;
+    use super::{extract_destructure_params, is_numeric_content, split_top_level};
 
     /// Test numeric source detection for v-for range expressions.
     #[test]
@@ -221,5 +268,39 @@ mod tests {
 
         // Invalid: empty string
         assert!(!is_numeric_content(""));
+    }
+
+    #[test]
+    fn test_extract_destructure_params_with_defaulted_aliases() {
+        let mut params = Vec::new();
+        extract_destructure_params(
+            r#"{ id: itemId = fallback, user: { name = "a,b" }, tags: [firstTag = "x,y"] }"#,
+            &mut params,
+        );
+
+        assert_eq!(params, ["itemId", "name", "firstTag"]);
+    }
+
+    #[test]
+    fn test_extract_array_destructure_params_with_defaults() {
+        let mut params = Vec::new();
+        extract_destructure_params(
+            "[first = fallback, { id: secondId = makeId() }]",
+            &mut params,
+        );
+
+        assert_eq!(params, ["first", "secondId"]);
+    }
+
+    #[test]
+    fn test_split_top_level_ignores_commas_inside_strings() {
+        assert_eq!(
+            split_top_level(r#"id = "a,b", name: label, nested: { value: "c,d" }"#),
+            vec![
+                r#"id = "a,b""#,
+                " name: label",
+                r#" nested: { value: "c,d" }"#
+            ]
+        );
     }
 }


### PR DESCRIPTION
## Summary
- recognize defaulted aliases in object and array v-for destructuring
- ignore commas inside string literals when splitting destructure patterns
- keep nested destructure params registered as local callback scope variables

## Validation
- cargo test -p vize_atelier_core --lib
- git diff --check