### PR TITLE
perf(patina): share sfc descriptor across rules

### DIFF
--- a/crates/vize_patina/src/context.rs
+++ b/crates/vize_patina/src/context.rs
@@ -11,6 +11,7 @@ pub use state::{DisabledRange, ElementContext, SsrMode};
 
 use crate::diagnostic::{HelpLevel, LintDiagnostic, Severity};
 use std::borrow::Cow;
+use vize_atelier_sfc::SfcDescriptor;
 use vize_carton::String;
 use vize_carton::{
     Allocator, CompactString, FxHashMap, FxHashSet,
@@ -53,6 +54,8 @@ pub struct LintContext<'a> {
     enabled_rules: Option<FxHashSet<String>>,
     /// Optional semantic analysis from croquis.
     pub(crate) analysis: Option<&'a Croquis>,
+    /// Optional parsed SFC descriptor shared by SFC-level rules.
+    sfc_descriptor: Option<&'a SfcDescriptor<'a>>,
     /// Rules that should ignore semantic analysis for this lint pass.
     analysis_excluded_rules: Option<&'static [&'static str]>,
     /// SSR mode for linting.
@@ -101,6 +104,7 @@ impl<'a> LintContext<'a> {
             line_offsets: Self::compute_line_offsets(source),
             enabled_rules: None,
             analysis: None,
+            sfc_descriptor: None,
             analysis_excluded_rules: None,
             ssr_mode: SsrMode::default(),
             help_level: HelpLevel::default(),
@@ -133,6 +137,7 @@ impl<'a> LintContext<'a> {
             line_offsets: Self::compute_line_offsets(source),
             enabled_rules: None,
             analysis: Some(analysis),
+            sfc_descriptor: None,
             analysis_excluded_rules: None,
             ssr_mode: SsrMode::default(),
             help_level: HelpLevel::default(),
@@ -169,6 +174,18 @@ impl<'a> LintContext<'a> {
     #[inline]
     pub fn has_analysis(&self) -> bool {
         self.analysis().is_some()
+    }
+
+    /// Set parsed SFC descriptor shared by SFC-level rules.
+    #[inline]
+    pub fn set_sfc_descriptor(&mut self, descriptor: &'a SfcDescriptor<'a>) {
+        self.sfc_descriptor = Some(descriptor);
+    }
+
+    /// Get parsed SFC descriptor if one was prepared by the engine.
+    #[inline]
+    pub fn sfc_descriptor(&self) -> Option<&SfcDescriptor<'a>> {
+        self.sfc_descriptor
     }
 
     /// Set SSR mode.

--- a/crates/vize_patina/src/linter/engine.rs
+++ b/crates/vize_patina/src/linter/engine.rs
@@ -5,6 +5,7 @@
 
 use crate::{context::LintContext, diagnostic::LintSummary, visitor::LintVisitor};
 use vize_armature::Parser;
+use vize_atelier_sfc::{SfcParseOptions, parse_sfc};
 use vize_carton::Allocator;
 use vize_carton::String;
 use vize_carton::ToCompactString;
@@ -21,6 +22,8 @@ const SEMANTIC_TEMPLATE_RULES: &[&str] = &[
     "vue/no-mutating-props",
     "a11y/no-refer-to-non-existent-id",
 ];
+
+const SHARED_SFC_DESCRIPTOR_RULES: &[&str] = &["vue/sfc-element-order", "vue/single-style-block"];
 
 pub(crate) fn analyze_descriptor_for_lint(
     descriptor: &vize_atelier_sfc::SfcDescriptor<'_>,
@@ -52,6 +55,26 @@ impl Linter {
         let mut ctx = LintContext::with_locale(&allocator, source, filename, self.locale);
         ctx.set_enabled_rules(self.enabled_rules.clone());
         ctx.set_help_level(self.help_level);
+
+        let shared_descriptor = if self.has_active_shared_sfc_descriptor_rules() {
+            profile!(
+                "patina.sfc.level_rules.parse_sfc",
+                parse_sfc(
+                    source,
+                    SfcParseOptions {
+                        filename: filename.into(),
+                        ..Default::default()
+                    },
+                )
+                .ok()
+            )
+        } else {
+            None
+        };
+
+        if let Some(descriptor) = shared_descriptor.as_ref() {
+            ctx.set_sfc_descriptor(descriptor);
+        }
 
         profile!("patina.sfc.rules.run_on_sfc", {
             for rule in self.registry.rules() {
@@ -112,6 +135,13 @@ impl Linter {
 
     fn has_active_semantic_template_rules(&self) -> bool {
         SEMANTIC_TEMPLATE_RULES
+            .iter()
+            .copied()
+            .any(|rule_name| self.registry.has_rule(rule_name) && self.is_rule_enabled(rule_name))
+    }
+
+    fn has_active_shared_sfc_descriptor_rules(&self) -> bool {
+        SHARED_SFC_DESCRIPTOR_RULES
             .iter()
             .copied()
             .any(|rule_name| self.registry.has_rule(rule_name) && self.is_rule_enabled(rule_name))

--- a/crates/vize_patina/src/rules/ecosystem/i18n_no_missing_key.rs
+++ b/crates/vize_patina/src/rules/ecosystem/i18n_no_missing_key.rs
@@ -34,8 +34,15 @@ impl Rule for VueI18nNoMissingKey {
             return;
         }
 
-        let Ok(descriptor) = parse_sfc(ctx.source, sfc_parse_options(ctx.filename)) else {
-            return;
+        let owned_descriptor;
+        let descriptor = if let Some(descriptor) = ctx.sfc_descriptor() {
+            descriptor
+        } else {
+            owned_descriptor = match parse_sfc(ctx.source, sfc_parse_options(ctx.filename)) {
+                Ok(descriptor) => descriptor,
+                Err(_) => return,
+            };
+            &owned_descriptor
         };
 
         let mut keys = FxHashSet::default();

--- a/crates/vize_patina/src/rules/vue/sfc_element_order.rs
+++ b/crates/vize_patina/src/rules/vue/sfc_element_order.rs
@@ -87,18 +87,24 @@ impl Rule for SfcElementOrder {
     }
 
     fn run_on_sfc<'a>(&self, ctx: &mut LintContext<'a>) {
-        let descriptor = match profile!(
-            "patina.rule.sfc_element_order.parse_sfc",
-            parse_sfc(
-                ctx.source,
-                SfcParseOptions {
-                    filename: ctx.filename.into(),
-                    ..Default::default()
-                },
-            )
-        ) {
-            Ok(descriptor) => descriptor,
-            Err(_) => return,
+        let owned_descriptor;
+        let descriptor = if let Some(descriptor) = ctx.sfc_descriptor() {
+            descriptor
+        } else {
+            owned_descriptor = match profile!(
+                "patina.rule.sfc_element_order.parse_sfc",
+                parse_sfc(
+                    ctx.source,
+                    SfcParseOptions {
+                        filename: ctx.filename.into(),
+                        ..Default::default()
+                    },
+                )
+            ) {
+                Ok(descriptor) => descriptor,
+                Err(_) => return,
+            };
+            &owned_descriptor
         };
 
         let mut blocks = Vec::with_capacity(2 + descriptor.styles.len());

--- a/crates/vize_patina/src/rules/vue/single_style_block.rs
+++ b/crates/vize_patina/src/rules/vue/single_style_block.rs
@@ -66,18 +66,24 @@ impl Rule for SingleStyleBlock {
     }
 
     fn run_on_sfc<'a>(&self, ctx: &mut LintContext<'a>) {
-        let descriptor = match profile!(
-            "patina.rule.single_style_block.parse_sfc",
-            parse_sfc(
-                ctx.source,
-                SfcParseOptions {
-                    filename: ctx.filename.into(),
-                    ..Default::default()
-                },
-            )
-        ) {
-            Ok(descriptor) => descriptor,
-            Err(_) => return,
+        let owned_descriptor;
+        let descriptor = if let Some(descriptor) = ctx.sfc_descriptor() {
+            descriptor
+        } else {
+            owned_descriptor = match profile!(
+                "patina.rule.single_style_block.parse_sfc",
+                parse_sfc(
+                    ctx.source,
+                    SfcParseOptions {
+                        filename: ctx.filename.into(),
+                        ..Default::default()
+                    },
+                )
+            ) {
+                Ok(descriptor) => descriptor,
+                Err(_) => return,
+            };
+            &owned_descriptor
         };
 
         if descriptor.styles.len() <= 1 {


### PR DESCRIPTION
## Summary
- parse the SFC descriptor once for descriptor-backed SFC-level rules
- reuse the prepared descriptor in `vue/sfc-element-order`, `vue/single-style-block`, and vue-i18n local key checks
- keep rule fallback parsing for direct/custom contexts where the engine did not preload a descriptor

## Profiling
- baseline single-thread: `patina.rule.sfc_element_order.parse_sfc` 1.897ms + `patina.rule.single_style_block.parse_sfc` 1.186ms
- head single-thread: `patina.sfc.level_rules.parse_sfc` 1.854ms; `patina.sfc.level_rules` 5.319ms
- head parallel: `patina.sfc.level_rules.parse_sfc` 4.795ms

## Validation
- cargo fmt --all
- cargo check -p vize_patina
- cargo test -p vize_patina
- cargo clippy -p vize_patina -- -D warnings
- cargo build --release -p vize
- RAYON_NUM_THREADS=1 ./target/release/vize lint bench/__in__ --quiet --profile --slow-threshold 9999
- ./target/release/vize lint bench/__in__ --quiet --profile --slow-threshold 9999