### PR TITLE
perf(croquis): allocate comment buffer lazily

### DIFF
--- a/crates/vize_croquis/src/analyzer/helpers/identifiers.rs
+++ b/crates/vize_croquis/src/analyzer/helpers/identifiers.rs
@@ -22,7 +22,7 @@ pub fn strip_js_comments(expr: &str) -> Cow<'_, str> {
     let len = bytes.len();
     let mut i = 0;
     let mut changed = false;
-    let mut out = std::string::String::with_capacity(expr.len());
+    let mut out = std::string::String::new();
 
     while i < len {
         let c = bytes[i];
@@ -64,6 +64,7 @@ pub fn strip_js_comments(expr: &str) -> Cow<'_, str> {
 
             if next == b'/' {
                 if !changed {
+                    out.reserve(expr.len());
                     out.push_str(&expr[..i]);
                     changed = true;
                 }
@@ -81,6 +82,7 @@ pub fn strip_js_comments(expr: &str) -> Cow<'_, str> {
 
             if next == b'*' {
                 if !changed {
+                    out.reserve(expr.len());
                     out.push_str(&expr[..i]);
                     changed = true;
                 }


### PR DESCRIPTION
## Summary
- avoid allocating a comment-stripping buffer for template expressions that have no JS comments
- keep the existing behavior for line and block comments by reserving only when a comment is actually stripped

## Profiling
- baseline single-thread: `croquis.template.expression.extract_identifiers` 3.897ms
- head single-thread: `croquis.template.expression.extract_identifiers` 3.055ms; `croquis.helpers.identifiers.fast` 0.663ms
- head parallel: `croquis.template.expression.extract_identifiers` 21.271ms

## Validation
- cargo fmt --all -- --check
- cargo test -p vize_croquis analyzer::helpers::identifiers::tests -- --nocapture
- cargo check -p vize_croquis
- cargo clippy -p vize_croquis -- -D warnings
- cargo build --release -p vize
- RAYON_NUM_THREADS=1 ./target/release/vize lint bench/__in__ --quiet --profile --slow-threshold 9999
- ./target/release/vize lint bench/__in__ --quiet --profile --slow-threshold 9999