### PR TITLE
fix: stabilize CI after main merges

### DIFF
--- a/crates/vize/src/commands/lint.rs
+++ b/crates/vize/src/commands/lint.rs
@@ -1,8 +1,8 @@
 //! Lint command - Lint Vue SFC files
 
 use clap::Args;
-use glob::glob;
-use ignore::Walk;
+use glob::{MatchOptions, Pattern};
+use ignore::WalkBuilder;
 use rayon::prelude::*;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -13,7 +13,7 @@ use std::time::Instant;
 use vize_armature::Parser;
 use vize_atelier_sfc::{SfcParseOptions, parse_sfc};
 use vize_carton::{
-    Allocator, CompactString, FxHashMap, String, ToCompactString, cstr, profile,
+    Allocator, CompactString, FxHashMap, FxHashSet, String, ToCompactString, cstr, profile,
     profiler::{allocation_snapshot, global_profiler},
 };
 use vize_croquis::{Analyzer, AnalyzerOptions, Croquis};
@@ -103,33 +103,7 @@ pub fn run(args: LintArgs) {
 
     // Collect .vue files using glob patterns or directory walking
     let collect_start = Instant::now();
-    let files: Vec<PathBuf> = args
-        .patterns
-        .iter()
-        .flat_map(|pattern| {
-            // Check if pattern contains glob characters
-            if pattern.contains('*') || pattern.contains('?') || pattern.contains('[') {
-                // Use glob for pattern matching
-                glob(pattern)
-                    .ok()
-                    .into_iter()
-                    .flatten()
-                    .filter_map(|r| r.ok())
-                    .filter(|p| {
-                        p.extension().is_some_and(|ext| ext == "vue")
-                            && !p.components().any(|c| c.as_os_str() == "node_modules")
-                    })
-                    .collect::<Vec<_>>()
-            } else {
-                // Use directory walking for paths (respects .gitignore)
-                Walk::new(pattern)
-                    .filter_map(|e| e.ok())
-                    .filter(|e| e.path().extension().is_some_and(|ext| ext == "vue"))
-                    .map(|e| e.path().to_path_buf())
-                    .collect::<Vec<_>>()
-            }
-        })
-        .collect();
+    let files = collect_lint_files(&args.patterns);
     let collect_time = collect_start.elapsed();
 
     if files.is_empty() {
@@ -424,6 +398,143 @@ pub fn run(args: LintArgs) {
     {
         eprintln!("\nToo many warnings ({} > max {})", total_warnings, max);
         std::process::exit(1);
+    }
+}
+
+fn collect_lint_files(patterns: &[String]) -> Vec<PathBuf> {
+    let mut files = Vec::new();
+    let mut seen = FxHashSet::default();
+
+    for pattern in patterns {
+        let candidate = PathBuf::from(pattern);
+        if candidate.exists() {
+            if candidate.is_file() {
+                add_lint_file(&candidate, &mut files, &mut seen);
+                continue;
+            }
+            if candidate.is_dir() {
+                collect_lint_files_from_dir(&candidate, None, &mut files, &mut seen);
+                continue;
+            }
+        }
+
+        let base_dir = base_dir_from_lint_pattern(pattern);
+        let matcher = LintInputGlob::new(pattern);
+        collect_lint_files_from_dir(&base_dir, matcher.as_ref(), &mut files, &mut seen);
+    }
+
+    files.sort();
+    files
+}
+
+fn collect_lint_files_from_dir(
+    dir: &Path,
+    matcher: Option<&LintInputGlob>,
+    files: &mut Vec<PathBuf>,
+    seen: &mut FxHashSet<PathBuf>,
+) {
+    for entry in WalkBuilder::new(dir)
+        .standard_filters(true)
+        .hidden(true)
+        .build()
+    {
+        let Ok(entry) = entry else {
+            continue;
+        };
+        let path = entry.path();
+        if path.is_file() && matcher.is_none_or(|matcher| matcher.matches(path)) {
+            add_lint_file(path, files, seen);
+        }
+    }
+}
+
+fn add_lint_file(path: &Path, files: &mut Vec<PathBuf>, seen: &mut FxHashSet<PathBuf>) {
+    if path.extension().and_then(|extension| extension.to_str()) != Some("vue") {
+        return;
+    }
+    let normalized = normalize_lint_input_path(path);
+    let canonical = path.canonicalize().unwrap_or_else(|_| normalized.clone());
+    if seen.insert(canonical) {
+        files.push(normalized);
+    }
+}
+
+fn base_dir_from_lint_pattern(pattern: &str) -> PathBuf {
+    let glob_start = pattern.find(['*', '?', '[', '{']).unwrap_or(pattern.len());
+    let prefix = &pattern[..glob_start];
+    let base = if prefix.is_empty() {
+        "."
+    } else if let Some(index) = prefix.rfind('/') {
+        &prefix[..index]
+    } else {
+        prefix
+    };
+    if base.is_empty() {
+        PathBuf::from(".")
+    } else {
+        PathBuf::from(base)
+    }
+}
+
+struct LintInputGlob {
+    pattern: Pattern,
+    cwd: PathBuf,
+    absolute: bool,
+}
+
+impl LintInputGlob {
+    fn new(pattern: &str) -> Option<Self> {
+        let normalized = normalize_lint_glob_pattern(pattern);
+        let absolute = Path::new(normalized.as_str()).is_absolute();
+        Pattern::new(normalized.as_str()).ok().map(|pattern| Self {
+            pattern,
+            cwd: std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")),
+            absolute,
+        })
+    }
+
+    fn matches(&self, path: &Path) -> bool {
+        let candidate = if self.absolute {
+            let absolute = if path.is_absolute() {
+                path.to_path_buf()
+            } else {
+                self.cwd.join(path)
+            };
+            normalize_lint_path(&absolute)
+        } else {
+            normalize_lint_path(path)
+        };
+
+        self.pattern
+            .matches_with(&candidate, lint_glob_match_options())
+    }
+}
+
+fn normalize_lint_glob_pattern(pattern: &str) -> String {
+    strip_lint_current_dir_prefix(&pattern.replace('\\', "/"))
+}
+
+fn normalize_lint_path(path: &Path) -> String {
+    strip_lint_current_dir_prefix(&path.to_string_lossy().replace('\\', "/"))
+}
+
+fn strip_lint_current_dir_prefix(value: &str) -> String {
+    let mut normalized = value;
+    while let Some(stripped) = normalized.strip_prefix("./") {
+        normalized = stripped;
+    }
+    normalized.into()
+}
+
+fn normalize_lint_input_path(path: &Path) -> PathBuf {
+    PathBuf::from(normalize_lint_path(path))
+}
+
+fn lint_glob_match_options() -> MatchOptions {
+    MatchOptions {
+        case_sensitive: true,
+        require_literal_separator: true,
+        require_literal_leading_dot: false,
     }
 }
 

--- a/crates/vize_patina/src/linter/engine.rs
+++ b/crates/vize_patina/src/linter/engine.rs
@@ -158,6 +158,8 @@ impl Linter {
         let mut ctx = LintContext::with_locale(allocator, source, filename, self.locale);
         ctx.set_enabled_rules(self.enabled_rules.clone());
         ctx.set_help_level(self.help_level);
+        #[cfg(not(target_arch = "wasm32"))]
+        #[cfg(not(target_arch = "wasm32"))]
         let has_analysis = analysis.is_some();
         if let Some(analysis) = analysis {
             ctx.set_analysis(analysis);

--- a/playground/e2e/vrt/atelier-code-tabs.spec.ts
+++ b/playground/e2e/vrt/atelier-code-tabs.spec.ts
@@ -6,7 +6,7 @@ async function waitForAtelier(page: Page) {
     () => document.querySelector(".wasm-status")?.textContent?.includes("WASM"),
     { timeout: 15_000 },
   );
-  await page.waitForSelector(".compile-time", { timeout: 10_000 });
+  await page.waitForSelector(".compile-time", { timeout: 20_000 });
   await expect(page.locator(".code-output .code-content").first()).toBeVisible();
 }
 

--- a/tests/_helpers/apps.ts
+++ b/tests/_helpers/apps.ts
@@ -91,6 +91,10 @@ const VIZE_LOCAL_BUILD_TARGETS = [
   },
 ] as const;
 const MISSKEY_FLUENT_EMOJI_RE = /\/fluent-emoji(?:s)?\/([0-9a-z-]+\.png)\b/g;
+const NPMX_E2E_ENV = {
+  NUXT_SESSION_PASSWORD: "e2e-test-dummy-session-password-32chars!",
+  VIZE_E2E_DISABLE_LUNARIA: "1",
+} as const;
 const TRANSPARENT_PNG = Buffer.from(
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQIW2P8z/C/HwAFgwJ/lE6nWQAAAABJRU5ErkJggg==",
   "base64",
@@ -167,7 +171,8 @@ function patchNuxtConfig(
   // Remove modules that cause issues in the e2e environment
   if (opts?.removeModules) {
     for (const mod of opts.removeModules) {
-      const re = new RegExp(`\\s*'${mod.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}',?\\n?`);
+      const escapedMod = mod.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+      const re = new RegExp(`\\s*["']${escapedMod}["'],?\\n?`);
       if (re.test(config)) {
         config = config.replace(re, "\n");
         changed = true;
@@ -177,6 +182,29 @@ function patchNuxtConfig(
 
   if (changed) {
     fs.writeFileSync(configPath, config);
+  }
+}
+
+function patchNpmxLunariaModule(modulePath: string): void {
+  const source = fs.readFileSync(modulePath, "utf-8");
+  if (source.includes("VIZE_E2E_DISABLE_LUNARIA")) {
+    return;
+  }
+
+  const nextSource = source.replace(
+    "    if (nuxt.options.dev || nuxt.options._prepare || nuxt.options.test || isTest) {\n",
+    "    if (process.env.VIZE_E2E_DISABLE_LUNARIA === '1' || nuxt.options.dev || nuxt.options._prepare || nuxt.options.test || isTest) {\n",
+  );
+  if (nextSource !== source) {
+    fs.writeFileSync(modulePath, nextSource);
+  }
+}
+
+function patchNpmxPrerenderRoutes(configPath: string): void {
+  const source = fs.readFileSync(configPath, "utf-8");
+  const nextSource = source.replace(/prerender: true/g, "prerender: false");
+  if (nextSource !== source) {
+    fs.writeFileSync(configPath, nextSource);
   }
 }
 
@@ -468,6 +496,10 @@ const VUEFES_WORK_DIR = getMutableGitFixtureDir("vuefes-2025");
 
 // --- App configurations ---
 
+const ELK_E2E_ENV = {
+  NUXT_STORAGE_DRIVER: "fs",
+} as const;
+
 export const elkApp: AppConfig = {
   name: "elk",
   cwd: ELK_WORK_DIR,
@@ -481,6 +513,7 @@ export const elkApp: AppConfig = {
   waitUntil: "load",
   readyDelay: 15_000,
   startupTimeout: 120_000,
+  env: ELK_E2E_ENV,
   setup() {
     const elkDir = syncGitFixtureWorktree("elk");
 
@@ -824,9 +857,7 @@ export const npmxApp: AppConfig = {
   allowNon200: true,
   waitUntil: "load",
   readyDelay: 30_000,
-  env: {
-    NUXT_SESSION_PASSWORD: "e2e-test-dummy-session-password-32chars!",
-  },
+  env: NPMX_E2E_ENV,
   startupTimeout: 120_000,
   setup() {
     setupNpmxWorktree();
@@ -873,7 +904,7 @@ function setupNpmxWorktree(opts?: { enableVize?: boolean; variant?: string }): s
     timeout: 300_000,
     env: {
       ...process.env,
-      NUXT_SESSION_PASSWORD: "e2e-test-dummy-session-password-32chars!",
+      ...NPMX_E2E_ENV,
     },
   });
 
@@ -885,6 +916,8 @@ function setupNpmxWorktree(opts?: { enableVize?: boolean; variant?: string }): s
     enableVize,
     removeModules: ["@nuxtjs/html-validator"],
   });
+  patchNpmxPrerenderRoutes(path.join(npmxDir, "nuxt.config.ts"));
+  patchNpmxLunariaModule(path.join(npmxDir, "modules", "lunaria.ts"));
 
   const npmxAppPath = path.join(npmxDir, "app", "app.vue");
   const npmxAppSource = fs.readFileSync(npmxAppPath, "utf-8");
@@ -902,7 +935,7 @@ function setupNpmxWorktree(opts?: { enableVize?: boolean; variant?: string }): s
     timeout: 180_000,
     env: {
       ...process.env,
-      NUXT_SESSION_PASSWORD: "e2e-test-dummy-session-password-32chars!",
+      ...NPMX_E2E_ENV,
     },
   });
 
@@ -925,9 +958,7 @@ function createNpmxVisualParityApp(kind: "candidate" | "reference", port: number
     allowNon200: true,
     waitUntil: "load",
     readyDelay: 30_000,
-    env: {
-      NUXT_SESSION_PASSWORD: "e2e-test-dummy-session-password-32chars!",
-    },
+    env: NPMX_E2E_ENV,
     startupTimeout: 120_000,
     setup() {
       setupNpmxWorktree({ enableVize: kind === "candidate", variant });
@@ -994,7 +1025,9 @@ export const vuefesApp: AppConfig = {
     });
 
     createVizeSymlinks(path.join(vuefesDir, "node_modules"));
-    patchNuxtConfig(path.join(vuefesDir, "nuxt.config.ts"));
+    patchNuxtConfig(path.join(vuefesDir, "nuxt.config.ts"), {
+      removeModules: ["@nuxtjs/storybook"],
+    });
 
     console.log("[vuefes-2025:setup] nuxt prepare...");
     execSync("npx -y pnpm@10 exec nuxt prepare", {

--- a/tests/app/dev/npmx.spec.ts
+++ b/tests/app/dev/npmx.spec.ts
@@ -84,6 +84,28 @@ async function readCurrentRoute(page: Page): Promise<RouteSnapshot> {
   });
 }
 
+async function navigateWithNuxtRouter(page: Page, path: string): Promise<void> {
+  await page.evaluate(async (targetPath) => {
+    const root = document.querySelector("#__nuxt") as {
+      __vue_app__?: {
+        config?: {
+          globalProperties?: {
+            $router?: {
+              push?: (target: string) => Promise<unknown> | void;
+            };
+          };
+        };
+      };
+    } | null;
+    const router = root?.__vue_app__?.config?.globalProperties?.$router;
+    if (typeof router?.push !== "function") {
+      throw new Error("Nuxt router is not available");
+    }
+
+    await router.push(targetPath);
+  }, path);
+}
+
 test.describe("npmx.dev dev", () => {
   let devServer: ChildProcess;
 
@@ -260,34 +282,14 @@ test.describe("npmx.dev dev", () => {
       timeout: 30_000,
     });
     await page.waitForTimeout(3_000);
-    await readCurrentRoute(page);
+    expect((await readCurrentRoute(page)).path).toBe("/");
 
-    // Try to navigate to /about via client-side link
-    const aboutLink = page.locator('a[href="/about"]').first();
-    const hasAboutLink = await aboutLink.count();
-    if (hasAboutLink > 0) {
-      await aboutLink.scrollIntoViewIfNeeded();
+    await navigateWithNuxtRouter(page, "/about");
 
-      for (let attempt = 0; attempt < 2; attempt++) {
-        const navigation = page.waitForURL((url) => url.pathname === "/about", {
-          timeout: 5_000,
-        });
-        await aboutLink.click();
-        try {
-          await navigation;
-          break;
-        } catch (error) {
-          if (attempt === 1) {
-            throw error;
-          }
-          await page.waitForLoadState("load", { timeout: 5_000 }).catch(() => {});
-          await page.waitForTimeout(1_000);
-        }
-      }
-
-      await expect.poll(() => new URL(page.url()).pathname).toBe("/about");
-      await expect.poll(async () => (await readCurrentRoute(page)).path).toBe("/about");
-    }
+    await expect.poll(() => new URL(page.url()).pathname, { timeout: 10_000 }).toBe("/about");
+    await expect
+      .poll(async () => (await readCurrentRoute(page)).path, { timeout: 10_000 })
+      .toBe("/about");
   });
 
   test("reactivity: search input updates state", async ({ page }) => {

--- a/tests/app/dev/vuefes.spec.ts
+++ b/tests/app/dev/vuefes.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect, type Page } from "@playwright/test";
 import type { ChildProcess } from "node:child_process";
 import * as fs from "node:fs";
 import * as path from "node:path";
@@ -23,8 +23,9 @@ const app = vuefesApp;
 
 test.describe("vuefes-2025 dev", () => {
   let devServer: ChildProcess;
+  let page: Page;
 
-  test.beforeAll(async () => {
+  test.beforeAll(async ({ browser }) => {
     if (app.setup) app.setup();
     await ensurePortFree(app.port);
 
@@ -43,35 +44,58 @@ test.describe("vuefes-2025 dev", () => {
       app.readyDelay,
     );
     await waitForHttpReady(app.url, app.port);
+    page = await browser.newPage();
     console.log(`${app.name} server is ready`);
   });
 
   test.afterAll(async () => {
+    await page?.close();
     console.log(`Stopping dev server for ${app.name}...`);
     killProcess(devServer);
     await new Promise((r) => setTimeout(r, 2000));
   });
 
-  test("page renders with #__nuxt attached", async ({ page }) => {
+  async function gotoApp() {
+    const waitUntil = app.waitUntil ?? "networkidle";
+    let lastError: unknown;
+    for (let attempt = 0; attempt < 3; attempt++) {
+      try {
+        return await page.goto(app.url, {
+          waitUntil,
+          timeout: 30_000,
+        });
+      } catch (error) {
+        lastError = error;
+        const message = String(error);
+        const retryableNavigationError =
+          message.includes("net::ERR_ABORTED") ||
+          message.includes("interrupted by another navigation");
+        if (!retryableNavigationError) {
+          throw error;
+        }
+        await page.waitForTimeout(1_000);
+      }
+    }
+    throw lastError;
+  }
+
+  test("page renders with #__nuxt attached", async () => {
     await page.setViewportSize({ width: 1280, height: 720 });
 
-    const response = await page.goto(app.url, {
-      waitUntil: app.waitUntil ?? "networkidle",
-      timeout: 30_000,
-    });
+    const response = await gotoApp();
     expect(response?.status()).toBeDefined();
 
     const mountEl = page.locator(app.mountSelector);
     await expect(mountEl).toBeAttached({ timeout: 15_000 });
   });
 
-  test("SSR: server-rendered HTML is not empty", async ({ page }) => {
+  test("SSR: server-rendered HTML is not empty", async () => {
     const html = await verifySSRContent(page, app.url);
     expect(html).toContain("__nuxt");
     expect(html.length).toBeGreaterThan(100);
   });
 
-  test("server logs stay clean after SSR render", async ({ page }) => {
+  test("server logs stay clean after SSR render", async () => {
     await verifySSRContent(page, app.url);
 
     const fatalLogs = getProcessLogs(devServer).filter(isFatalError);
@@ -81,13 +105,10 @@ test.describe("vuefes-2025 dev", () => {
     expect(fatalLogs).toHaveLength(0);
   });
 
-  test("no hydration mismatch errors", async ({ page }) => {
+  test("no hydration mismatch errors", async () => {
     const hydrationErrors = await collectHydrationErrors(page);
 
-    await page.goto(app.url, {
-      waitUntil: app.waitUntil ?? "networkidle",
-      timeout: 30_000,
-    });
+    await gotoApp();
     await page.waitForTimeout(5_000);
 
     // Filter out known harmless SSR/client hydration differences (PrimeVue Carousel, etc.)
@@ -95,24 +116,18 @@ test.describe("vuefes-2025 dev", () => {
     expect(unexpectedErrors).toHaveLength(0);
   });
 
-  test("scoped CSS: data-v-* attributes exist", async ({ page }) => {
-    await page.goto(app.url, {
-      waitUntil: app.waitUntil ?? "networkidle",
-      timeout: 30_000,
-    });
+  test("scoped CSS: data-v-* attributes exist", async () => {
+    await gotoApp();
     await page.waitForTimeout(3_000);
 
     const count = await verifyScopedCssAttributes(page);
     expect(count).toBeGreaterThan(0);
   });
 
-  test("no fatal console errors", async ({ page }) => {
+  test("no fatal console errors", async () => {
     const errors = await collectConsoleErrors(page, app.name);
 
-    await page.goto(app.url, {
-      waitUntil: app.waitUntil ?? "networkidle",
-      timeout: 30_000,
-    });
+    await gotoApp();
     await page.waitForTimeout(3_000);
 
     const fatalErrors = errors.filter(isFatalError);
@@ -122,13 +137,10 @@ test.describe("vuefes-2025 dev", () => {
     expect(fatalErrors).toHaveLength(0);
   });
 
-  test("screenshot", async ({ page }) => {
+  test("screenshot", async () => {
     await page.setViewportSize({ width: 1280, height: 720 });
 
-    await page.goto(app.url, {
-      waitUntil: app.waitUntil ?? "networkidle",
-      timeout: 30_000,
-    });
+    await gotoApp();
     await page.waitForTimeout(2_000);
 
     fs.mkdirSync(SCREENSHOT_DIR, { recursive: true });

--- a/tests/app/playwright.config.ts
+++ b/tests/app/playwright.config.ts
@@ -14,8 +14,8 @@ export default defineConfig({
   use: {
     headless: true,
     screenshot: "only-on-failure",
-    trace: "retain-on-failure",
-    video: "retain-on-failure",
+    trace: process.env.CI ? "off" : "retain-on-failure",
+    video: process.env.CI ? "off" : "retain-on-failure",
   },
   projects: [
     {

--- a/tests/package.json
+++ b/tests/package.json
@@ -5,9 +5,9 @@
   "scripts": {
     "test:dev": "playwright test --config app/playwright.config.ts",
     "test:vrt": "playwright test --config app/playwright.vrt.config.ts",
-    "test:preview": "node app/preview/elk.ts && node app/preview/misskey.ts && node app/preview/npmx.ts && node app/preview/vuefes.ts",
+    "test:preview": "RUN_BUILD_TESTS=1 node app/preview/elk.ts && RUN_BUILD_TESTS=1 node app/preview/misskey.ts && RUN_BUILD_TESTS=1 node app/preview/npmx.ts && RUN_BUILD_TESTS=1 node app/preview/vuefes.ts",
     "test:check": "node --test --test-concurrency=1 snapshots/check/ant-design-vue.ts snapshots/check/elk.ts snapshots/check/misskey.ts snapshots/check/npmx.ts snapshots/check/nuxt-ui.ts snapshots/check/reka-ui.ts snapshots/check/vuefes.ts",
-    "test:lint": "node --test snapshots/lint/ant-design-vue.ts snapshots/lint/elk.ts snapshots/lint/misskey.ts snapshots/lint/npmx.ts snapshots/lint/nuxt-ui.ts snapshots/lint/reka-ui.ts snapshots/lint/vuefes.ts",
+    "test:lint": "node --test --test-concurrency=1 snapshots/lint/ant-design-vue.ts snapshots/lint/elk.ts snapshots/lint/misskey.ts snapshots/lint/npmx.ts snapshots/lint/nuxt-ui.ts snapshots/lint/reka-ui.ts snapshots/lint/vuefes.ts",
     "test:build": "node --test snapshots/build/elk.ts snapshots/build/misskey.ts snapshots/build/npmx.ts snapshots/build/vuefes.ts",
     "test:check:fixtures": "node --test --test-concurrency=1 snapshots/check/typecheck-errors.ts snapshots/check/compiler-macros.ts snapshots/check/style-preprocessors.ts snapshots/check/toolchain-parity.ts"
   },

--- a/tests/tooling/playwright-app-config.test.ts
+++ b/tests/tooling/playwright-app-config.test.ts
@@ -20,6 +20,6 @@ test("app e2e Playwright config keeps CI runs guarded and debuggable", () => {
     /reporter:\s*process\.env\.CI \? \[\["list"\], \["html", \{ open: "never" \}\]\] : "list"/,
   );
   assert.match(config, /screenshot:\s*"only-on-failure"/);
-  assert.match(config, /trace:\s*"retain-on-failure"/);
-  assert.match(config, /video:\s*"retain-on-failure"/);
+  assert.match(config, /trace:\s*process\.env\.CI \? "off" : "retain-on-failure"/);
+  assert.match(config, /video:\s*process\.env\.CI \? "off" : "retain-on-failure"/);
 });

--- a/tools/vite-plus/tasks/test-benchmark.ts
+++ b/tools/vite-plus/tasks/test-benchmark.ts
@@ -22,9 +22,7 @@ export const testAndBenchmarkTasks = defineTasks({
   test: noCacheTask(runTasks("test:rust", "test:js", "test:scripts")),
   "test:rust": task("cargo test --workspace", { input: cacheInputs.rust }),
   "test:js": noCacheTask(`${runTask("build:native")} && ${runInPackages("test", testedPackages)}`),
-  "test:scripts": task("node --test --test-concurrency=1 tests/tooling/*.test.ts", {
-    input: cacheInputs.rust,
-  }),
+  "test:scripts": noCacheTask("node --test --test-concurrency=1 tests/tooling/*.test.ts"),
   "test:playground": task(runInPackages("test:browser", ["./playground"]), {
     input: cacheInputs.jsChecks,
   }),


### PR DESCRIPTION
## Summary

- make `test:scripts` uncached so tooling tests actually execute in CI
- make `vize lint` fixture collection ignore gitignored and symlinked generated trees
- stabilize app fixture CI for npmx.dev, lint snapshots, and VRT timeout behavior

## Local verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace -- -D warnings`
- `cargo test --workspace`
- `NODE_OPTIONS="--max-old-space-size=8192" vp run --workspace-root check:ci`
- `vp run --workspace-root test:scripts`
- `PATH="$PWD/target/ci:$PATH" NODE_OPTIONS="--max-old-space-size=8192" vp run --filter './tests' test:lint`
- `PATH="$PWD/target/ci:$PATH" NODE_OPTIONS="--max-old-space-size=8192" vp run --filter './tests' test:dev`
