### PR TITLE
test: increase compiler fixture coverage

### DIFF
--- a/tests/expected/sfc/basic.snap
+++ b/tests/expected/sfc/basic.snap
@@ -328,3 +328,36 @@ return (_ctx, _cache) => {
 }
 
 }
+===
+name: script setup function handler
+options: sfc
+--- INPUT ---
+<script setup>
+const count = 0
+function onClick() {
+  console.log(count)
+}
+</script>
+
+<template>
+  <button @click="onClick">Click</button>
+</template>
+--- OUTPUT ---
+import { openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+const count = 0
+
+export default {
+  __name: 'test',
+  setup(__props) {
+
+function onClick() {
+  console.log(count)
+}
+
+return (_ctx, _cache) => {
+  return (_openBlock(), _createElementBlock("button", { onClick: onClick }, "Click"))
+}
+}
+
+}

--- a/tests/expected/vdom/component.snap
+++ b/tests/expected/vdom/component.snap
@@ -1,6 +1,6 @@
 ===
 name: simple component
-options: default
+options: vdom
 --- INPUT ---
 <MyComponent />
 --- OUTPUT ---
@@ -11,10 +11,9 @@ export function render(_ctx, _cache) {
 
   return (_openBlock(), _createBlock(_component_MyComponent))
 }
-
 ===
 name: component with closing tag
-options: default
+options: vdom
 --- INPUT ---
 <MyComponent></MyComponent>
 --- OUTPUT ---
@@ -25,10 +24,9 @@ export function render(_ctx, _cache) {
 
   return (_openBlock(), _createBlock(_component_MyComponent))
 }
-
 ===
 name: component with text content
-options: default
+options: vdom
 --- INPUT ---
 <MyComponent>content</MyComponent>
 --- OUTPUT ---
@@ -44,10 +42,9 @@ export function render(_ctx, _cache) {
     _: 1 /* STABLE */
   }))
 }
-
 ===
 name: PascalCase component
-options: default
+options: vdom
 --- INPUT ---
 <MyComponent />
 --- OUTPUT ---
@@ -58,10 +55,9 @@ export function render(_ctx, _cache) {
 
   return (_openBlock(), _createBlock(_component_MyComponent))
 }
-
 ===
 name: kebab-case component
-options: default
+options: vdom
 --- INPUT ---
 <my-component />
 --- OUTPUT ---
@@ -72,10 +68,9 @@ export function render(_ctx, _cache) {
 
   return (_openBlock(), _createBlock(_component_my_component))
 }
-
 ===
 name: component name with colon
-options: default
+options: vdom
 --- INPUT ---
 <global:head title="Page Title" />
 --- OUTPUT ---
@@ -86,10 +81,9 @@ export function render(_ctx, _cache) {
 
   return (_openBlock(), _createBlock(_component_global_head, { title: "Page Title" }))
 }
-
 ===
 name: static prop
-options: default
+options: vdom
 --- INPUT ---
 <MyComponent msg="hello" />
 --- OUTPUT ---
@@ -100,10 +94,9 @@ export function render(_ctx, _cache) {
 
   return (_openBlock(), _createBlock(_component_MyComponent, { msg: "hello" }))
 }
-
 ===
 name: dynamic prop
-options: default
+options: vdom
 --- INPUT ---
 <MyComponent :msg="message" />
 --- OUTPUT ---
@@ -114,10 +107,9 @@ export function render(_ctx, _cache) {
 
   return (_openBlock(), _createBlock(_component_MyComponent, { msg: _ctx.message }, null, 8 /* PROPS */, ["msg"]))
 }
-
 ===
 name: boolean prop
-options: default
+options: vdom
 --- INPUT ---
 <MyComponent disabled />
 --- OUTPUT ---
@@ -128,10 +120,9 @@ export function render(_ctx, _cache) {
 
   return (_openBlock(), _createBlock(_component_MyComponent, { disabled: "" }))
 }
-
 ===
 name: multiple props
-options: default
+options: vdom
 --- INPUT ---
 <MyComponent :count="n" title="Test" />
 --- OUTPUT ---
@@ -145,10 +136,9 @@ export function render(_ctx, _cache) {
     title: "Test"
   }, null, 8 /* PROPS */, ["count"]))
 }
-
 ===
 name: v-bind object
-options: default
+options: vdom
 --- INPUT ---
 <MyComponent v-bind="props" />
 --- OUTPUT ---
@@ -159,10 +149,9 @@ export function render(_ctx, _cache) {
 
   return (_openBlock(), _createBlock(_component_MyComponent, _normalizeProps(_guardReactiveProps(_ctx.props)), null, 16 /* FULL_PROPS */))
 }
-
 ===
 name: v-bind object with extra props
-options: default
+options: vdom
 --- INPUT ---
 <MyComponent v-bind="props" :extra="value" />
 --- OUTPUT ---
@@ -173,10 +162,35 @@ export function render(_ctx, _cache) {
 
   return (_openBlock(), _createBlock(_component_MyComponent, _mergeProps(_ctx.props, { extra: _ctx.value }), null, 16 /* FULL_PROPS */, ["extra"]))
 }
+===
+name: dynamic prop name
+options: vdom
+--- INPUT ---
+<MyComponent :[prop]="value" />
+--- OUTPUT ---
+import { resolveComponent as _resolveComponent, normalizeProps as _normalizeProps, openBlock as _openBlock, createBlock as _createBlock } from "vue"
 
+export function render(_ctx, _cache) {
+  const _component_MyComponent = _resolveComponent("MyComponent")
+
+  return (_openBlock(), _createBlock(_component_MyComponent, _normalizeProps({ [_ctx.prop || ""]: _ctx.value }), null, 16 /* FULL_PROPS */))
+}
+===
+name: v-bind object with event
+options: vdom
+--- INPUT ---
+<MyComponent v-bind="props" @update="onUpdate" />
+--- OUTPUT ---
+import { resolveComponent as _resolveComponent, mergeProps as _mergeProps, openBlock as _openBlock, createBlock as _createBlock } from "vue"
+
+export function render(_ctx, _cache) {
+  const _component_MyComponent = _resolveComponent("MyComponent")
+
+  return (_openBlock(), _createBlock(_component_MyComponent, _mergeProps(_ctx.props, { onUpdate: _ctx.onUpdate }), null, 16 /* FULL_PROPS */, ["onUpdate"]))
+}
 ===
 name: Teleport
-options: default
+options: vdom
 --- INPUT ---
 <Teleport to="body"><div>content</div></Teleport>
 --- OUTPUT ---
@@ -187,10 +201,9 @@ export function render(_ctx, _cache) {
     _createElementVNode("div", null, "content")
   ]))
 }
-
 ===
 name: Suspense
-options: default
+options: vdom
 --- INPUT ---
 <Suspense><Component /></Suspense>
 --- OUTPUT ---
@@ -206,10 +219,9 @@ export function render(_ctx, _cache) {
     _: 1 /* STABLE */
   }))
 }
-
 ===
 name: KeepAlive
-options: default
+options: vdom
 --- INPUT ---
 <KeepAlive><Component /></KeepAlive>
 --- OUTPUT ---
@@ -222,10 +234,9 @@ export function render(_ctx, _cache) {
     _createVNode(_component_Component)
   ], 1024 /* DYNAMIC_SLOTS */))
 }
-
 ===
 name: Transition
-options: default
+options: vdom
 --- INPUT ---
 <Transition name="fade"><div v-if="show">content</div></Transition>
 --- OUTPUT ---
@@ -241,10 +252,9 @@ export function render(_ctx, _cache) {
     _: 1 /* STABLE */
   }))
 }
-
 ===
 name: TransitionGroup
-options: default
+options: vdom
 --- INPUT ---
 <TransitionGroup tag="ul"><li v-for="item in items" :key="item">{{ item }}</li></TransitionGroup>
 --- OUTPUT ---
@@ -260,10 +270,9 @@ export function render(_ctx, _cache) {
     _: 1 /* STABLE */
   }))
 }
-
 ===
 name: keep-alive kebab-case
-options: default
+options: vdom
 --- INPUT ---
 <keep-alive><Component /></keep-alive>
 --- OUTPUT ---
@@ -276,10 +285,9 @@ export function render(_ctx, _cache) {
     _createVNode(_component_Component)
   ], 1024 /* DYNAMIC_SLOTS */))
 }
-
 ===
 name: transition kebab-case
-options: default
+options: vdom
 --- INPUT ---
 <transition name="fade"><div v-if="show">content</div></transition>
 --- OUTPUT ---
@@ -295,10 +303,9 @@ export function render(_ctx, _cache) {
     _: 1 /* STABLE */
   }))
 }
-
 ===
 name: transition-group kebab-case
-options: default
+options: vdom
 --- INPUT ---
 <transition-group tag="ul"><li v-for="item in items" :key="item">{{ item }}</li></transition-group>
 --- OUTPUT ---
@@ -314,10 +321,9 @@ export function render(_ctx, _cache) {
     _: 1 /* STABLE */
   }))
 }
-
 ===
 name: teleport kebab-case
-options: default
+options: vdom
 --- INPUT ---
 <teleport to="body"><div>content</div></teleport>
 --- OUTPUT ---
@@ -328,10 +334,9 @@ export function render(_ctx, _cache) {
     _createElementVNode("div", null, "content")
   ]))
 }
-
 ===
 name: suspense kebab-case
-options: default
+options: vdom
 --- INPUT ---
 <suspense><Component /></suspense>
 --- OUTPUT ---
@@ -347,10 +352,9 @@ export function render(_ctx, _cache) {
     _: 1 /* STABLE */
   }))
 }
-
 ===
 name: dynamic component
-options: default
+options: vdom
 --- INPUT ---
 <component :is="currentComponent" />
 --- OUTPUT ---
@@ -359,10 +363,9 @@ import { resolveDynamicComponent as _resolveDynamicComponent, openBlock as _open
 export function render(_ctx, _cache) {
   return (_openBlock(), _createBlock(_resolveDynamicComponent(_ctx.currentComponent)))
 }
-
 ===
 name: dynamic component with static is
-options: default
+options: vdom
 --- INPUT ---
 <component is="MyComponent" />
 --- OUTPUT ---
@@ -371,10 +374,9 @@ import { resolveDynamicComponent as _resolveDynamicComponent, openBlock as _open
 export function render(_ctx, _cache) {
   return (_openBlock(), _createBlock(_resolveDynamicComponent("MyComponent")))
 }
-
 ===
 name: dynamic component with props
-options: default
+options: vdom
 --- INPUT ---
 <component :is="current" :msg="message" />
 --- OUTPUT ---
@@ -383,10 +385,9 @@ import { resolveDynamicComponent as _resolveDynamicComponent, openBlock as _open
 export function render(_ctx, _cache) {
   return (_openBlock(), _createBlock(_resolveDynamicComponent(_ctx.current), { msg: _ctx.message }, null, 8 /* PROPS */, ["msg"]))
 }
-
 ===
 name: v-model on component
-options: default
+options: vdom
 --- INPUT ---
 <MyComponent v-model="value" />
 --- OUTPUT ---
@@ -400,10 +401,9 @@ export function render(_ctx, _cache) {
     "onUpdate:modelValue": $event => ((_ctx.value) = $event)
   }, null, 8 /* PROPS */, ["modelValue", "onUpdate:modelValue"]))
 }
-
 ===
 name: named v-model
-options: default
+options: vdom
 --- INPUT ---
 <MyComponent v-model:title="pageTitle" />
 --- OUTPUT ---
@@ -417,10 +417,9 @@ export function render(_ctx, _cache) {
     "onUpdate:title": $event => ((_ctx.pageTitle) = $event)
   }, null, 8 /* PROPS */, ["title", "onUpdate:title"]))
 }
-
 ===
 name: multiple v-model
-options: default
+options: vdom
 --- INPUT ---
 <MyComponent v-model:first="a" v-model:second="b" />
 --- OUTPUT ---
@@ -436,10 +435,9 @@ export function render(_ctx, _cache) {
     "onUpdate:second": $event => ((_ctx.b) = $event)
   }, null, 8 /* PROPS */, ["first", "onUpdate:first", "second", "onUpdate:second"]))
 }
-
 ===
 name: v-model with modifier
-options: default
+options: vdom
 --- INPUT ---
 <MyComponent v-model.trim="value" />
 --- OUTPUT ---
@@ -454,10 +452,9 @@ export function render(_ctx, _cache) {
     modelModifiers: { trim: true }
   }, null, 8 /* PROPS */, ["modelValue", "onUpdate:modelValue"]))
 }
-
 ===
 name: v-model with multiple modifiers
-options: default
+options: vdom
 --- INPUT ---
 <MyComponent v-model.trim.lazy="value" />
 --- OUTPUT ---
@@ -472,10 +469,9 @@ export function render(_ctx, _cache) {
     modelModifiers: { trim: true, lazy: true }
   }, null, 8 /* PROPS */, ["modelValue", "onUpdate:modelValue"]))
 }
-
 ===
 name: component with v-if
-options: default
+options: vdom
 --- INPUT ---
 <MyComponent v-if="show" />
 --- OUTPUT ---
@@ -488,10 +484,9 @@ export function render(_ctx, _cache) {
     ? (_openBlock(), _createBlock(_component_MyComponent, { key: 0 }))
     : _createCommentVNode("v-if", true)
 }
-
 ===
 name: component with v-else
-options: default
+options: vdom
 --- INPUT ---
 <MyComponent v-if="a" /><OtherComponent v-else />
 --- OUTPUT ---
@@ -505,10 +500,9 @@ export function render(_ctx, _cache) {
     ? (_openBlock(), _createBlock(_component_MyComponent, { key: 0 }))
     : (_openBlock(), _createBlock(_component_OtherComponent, { key: 1 }))
 }
-
 ===
 name: component with v-for
-options: default
+options: vdom
 --- INPUT ---
 <MyComponent v-for="item in items" :key="item.id" />
 --- OUTPUT ---
@@ -523,10 +517,9 @@ export function render(_ctx, _cache) {
     }))
   }), 128 /* KEYED_FRAGMENT */))
 }
-
 ===
 name: component with v-show
-options: default
+options: vdom
 --- INPUT ---
 <MyComponent v-show="visible" />
 --- OUTPUT ---
@@ -539,10 +532,9 @@ export function render(_ctx, _cache) {
     [_vShow, _ctx.visible]
   ])
 }
-
 ===
 name: component with custom directive
-options: default
+options: vdom
 --- INPUT ---
 <MyComponent v-focus />
 --- OUTPUT ---
@@ -556,10 +548,9 @@ export function render(_ctx, _cache) {
     [_directive_focus]
   ])
 }
-
 ===
 name: component event handler
-options: default
+options: vdom
 --- INPUT ---
 <MyComponent @update="onUpdate" />
 --- OUTPUT ---
@@ -570,10 +561,9 @@ export function render(_ctx, _cache) {
 
   return (_openBlock(), _createBlock(_component_MyComponent, { onUpdate: _ctx.onUpdate }, null, 8 /* PROPS */, ["onUpdate"]))
 }
-
 ===
 name: component event with argument
-options: default
+options: vdom
 --- INPUT ---
 <MyComponent @update="onUpdate($event)" />
 --- OUTPUT ---
@@ -586,10 +576,22 @@ export function render(_ctx, _cache) {
     onUpdate: $event => (_ctx.onUpdate($event))
   }, null, 8 /* PROPS */, ["onUpdate"]))
 }
+===
+name: component dynamic event name
+options: vdom
+--- INPUT ---
+<MyComponent @[event]="handler" />
+--- OUTPUT ---
+import { resolveComponent as _resolveComponent, toHandlerKey as _toHandlerKey, openBlock as _openBlock, createBlock as _createBlock } from "vue"
 
+export function render(_ctx, _cache) {
+  const _component_MyComponent = _resolveComponent("MyComponent")
+
+  return (_openBlock(), _createBlock(_component_MyComponent, { [_toHandlerKey(_ctx.event)]: _ctx.handler }, null, 16 /* FULL_PROPS */))
+}
 ===
 name: component multiple events
-options: default
+options: vdom
 --- INPUT ---
 <MyComponent @update="onUpdate" @change="onChange" />
 --- OUTPUT ---
@@ -603,10 +605,9 @@ export function render(_ctx, _cache) {
     onChange: _ctx.onChange
   }, null, 8 /* PROPS */, ["onUpdate", "onChange"]))
 }
-
 ===
 name: component event modifiers
-options: default
+options: vdom
 --- INPUT ---
 <MyComponent @update.once="onUpdate" />
 --- OUTPUT ---

--- a/tests/expected/vdom/directives.snap
+++ b/tests/expected/vdom/directives.snap
@@ -1,6 +1,6 @@
 ===
 name: custom directive
-options: default
+options: vdom
 --- INPUT ---
 <div v-focus></div>
 --- OUTPUT ---
@@ -13,10 +13,9 @@ export function render(_ctx, _cache) {
     [_directive_focus]
   ])
 }
-
 ===
 name: custom directive with value
-options: default
+options: vdom
 --- INPUT ---
 <div v-highlight="color"></div>
 --- OUTPUT ---
@@ -29,10 +28,9 @@ export function render(_ctx, _cache) {
     [_directive_highlight, _ctx.color]
   ])
 }
-
 ===
 name: custom directive with literal
-options: default
+options: vdom
 --- INPUT ---
 <div v-highlight="'yellow'"></div>
 --- OUTPUT ---
@@ -45,10 +43,9 @@ export function render(_ctx, _cache) {
     [_directive_highlight, 'yellow']
   ])
 }
-
 ===
 name: custom directive with object
-options: default
+options: vdom
 --- INPUT ---
 <div v-pin="{ top: 10, left: 20 }"></div>
 --- OUTPUT ---
@@ -61,10 +58,39 @@ export function render(_ctx, _cache) {
     [_directive_pin, { top: 10, left: 20 }]
   ])
 }
+===
+name: custom directive with array
+options: vdom
+--- INPUT ---
+<div v-list="[one, two]"></div>
+--- OUTPUT ---
+import { resolveDirective as _resolveDirective, withDirectives as _withDirectives, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 
+export function render(_ctx, _cache) {
+  const _directive_list = _resolveDirective("list")
+
+  return _withDirectives((_openBlock(), _createElementBlock("div", null, null, 512 /* NEED_PATCH */)), [
+    [_directive_list, [_ctx.one, _ctx.two]]
+  ])
+}
+===
+name: custom directive with function call
+options: vdom
+--- INPUT ---
+<div v-observe="createObserver(item)"></div>
+--- OUTPUT ---
+import { resolveDirective as _resolveDirective, withDirectives as _withDirectives, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+export function render(_ctx, _cache) {
+  const _directive_observe = _resolveDirective("observe")
+
+  return _withDirectives((_openBlock(), _createElementBlock("div", null, null, 512 /* NEED_PATCH */)), [
+    [_directive_observe, _ctx.createObserver(_ctx.item)]
+  ])
+}
 ===
 name: directive with argument
-options: default
+options: vdom
 --- INPUT ---
 <div v-scroll:top="value"></div>
 --- OUTPUT ---
@@ -77,10 +103,9 @@ export function render(_ctx, _cache) {
     [_directive_scroll, _ctx.value, "top"]
   ])
 }
-
 ===
 name: directive with dynamic argument
-options: default
+options: vdom
 --- INPUT ---
 <div v-scroll:[direction]="value"></div>
 --- OUTPUT ---
@@ -93,10 +118,9 @@ export function render(_ctx, _cache) {
     [_directive_scroll, _ctx.value, _ctx.direction]
   ])
 }
-
 ===
 name: directive with modifier
-options: default
+options: vdom
 --- INPUT ---
 <div v-focus.lazy></div>
 --- OUTPUT ---
@@ -114,10 +138,9 @@ export function render(_ctx, _cache) {
     ]
   ])
 }
-
 ===
 name: directive with multiple modifiers
-options: default
+options: vdom
 --- INPUT ---
 <div v-custom.a.b.c></div>
 --- OUTPUT ---
@@ -139,10 +162,9 @@ export function render(_ctx, _cache) {
     ]
   ])
 }
-
 ===
 name: directive with arg and modifiers
-options: default
+options: vdom
 --- INPUT ---
 <div v-dir:arg.mod1.mod2="value"></div>
 --- OUTPUT ---
@@ -163,10 +185,9 @@ export function render(_ctx, _cache) {
     ]
   ])
 }
-
 ===
 name: multiple custom directives
-options: default
+options: vdom
 --- INPUT ---
 <div v-focus v-highlight></div>
 --- OUTPUT ---
@@ -181,10 +202,9 @@ export function render(_ctx, _cache) {
     [_directive_highlight]
   ])
 }
-
 ===
 name: custom with built-in
-options: default
+options: vdom
 --- INPUT ---
 <div v-focus v-show="visible"></div>
 --- OUTPUT ---
@@ -198,10 +218,9 @@ export function render(_ctx, _cache) {
     [_vShow, _ctx.visible]
   ])
 }
-
 ===
 name: directive on component
-options: default
+options: vdom
 --- INPUT ---
 <MyComponent v-focus />
 --- OUTPUT ---
@@ -215,10 +234,9 @@ export function render(_ctx, _cache) {
     [_directive_focus]
   ])
 }
-
 ===
 name: directive on component with props
-options: default
+options: vdom
 --- INPUT ---
 <MyComponent v-focus :prop="value" />
 --- OUTPUT ---
@@ -232,10 +250,9 @@ export function render(_ctx, _cache) {
     [_directive_focus]
   ])
 }
-
 ===
 name: v-html
-options: default
+options: vdom
 --- INPUT ---
 <div v-html="rawHtml"></div>
 --- OUTPUT ---
@@ -244,10 +261,9 @@ import { openBlock as _openBlock, createElementBlock as _createElementBlock } fr
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("div", { innerHTML: _ctx.rawHtml }, null, 8 /* PROPS */, ["innerHTML"]))
 }
-
 ===
 name: v-text
-options: default
+options: vdom
 --- INPUT ---
 <div v-text="msg"></div>
 --- OUTPUT ---
@@ -258,10 +274,9 @@ export function render(_ctx, _cache) {
     textContent: _toDisplayString(_ctx.msg)
   }, null, 8 /* PROPS */, ["textContent"]))
 }
-
 ===
 name: v-html with static
-options: default
+options: vdom
 --- INPUT ---
 <div class="content" v-html="html"></div>
 --- OUTPUT ---
@@ -273,10 +288,9 @@ export function render(_ctx, _cache) {
     innerHTML: _ctx.html
   }, null, 8 /* PROPS */, ["innerHTML"]))
 }
-
 ===
 name: v-cloak
-options: default
+options: vdom
 --- INPUT ---
 <div v-cloak>{{ msg }}</div>
 --- OUTPUT ---
@@ -285,10 +299,9 @@ import { toDisplayString as _toDisplayString, openBlock as _openBlock, createEle
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.msg), 1 /* TEXT */))
 }
-
 ===
 name: v-pre
-options: default
+options: vdom
 --- INPUT ---
 <div v-pre>{{ this will not compile }}</div>
 --- OUTPUT ---
@@ -297,10 +310,9 @@ import { openBlock as _openBlock, createElementBlock as _createElementBlock } fr
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("div", null, "{{ this will not compile }}"))
 }
-
 ===
 name: v-pre with children
-options: default
+options: vdom
 --- INPUT ---
 <div v-pre><span>{{ raw }}</span></div>
 --- OUTPUT ---
@@ -311,10 +323,9 @@ export function render(_ctx, _cache) {
     _createElementVNode("span", null, "{{ raw }}")
   ]))
 }
-
 ===
 name: v-pre with on-prefixed attribute
-options: default
+options: vdom
 --- INPUT ---
 <div v-pre test on-test is-on-test>content</div>
 --- OUTPUT ---
@@ -327,10 +338,9 @@ export function render(_ctx, _cache) {
     "is-on-test": ""
   }, "content"))
 }
-
 ===
 name: v-pre should not process shorthand directives
-options: default
+options: vdom
 --- INPUT ---
 <div v-pre :id="dynamic" @click="handler">{{ raw }}</div>
 --- OUTPUT ---
@@ -342,10 +352,9 @@ export function render(_ctx, _cache) {
     "@click": "handler"
   }, "{{ raw }}"))
 }
-
 ===
 name: v-pre nested elements preserve attributes
-options: default
+options: vdom
 --- INPUT ---
 <div v-pre><span :class="cls" @click="fn">{{ raw }}</span></div>
 --- OUTPUT ---

--- a/tests/expected/vdom/element.snap
+++ b/tests/expected/vdom/element.snap
@@ -1,6 +1,6 @@
 ===
 name: empty div
-options: default
+options: vdom
 --- INPUT ---
 <div></div>
 --- OUTPUT ---
@@ -9,10 +9,9 @@ import { openBlock as _openBlock, createElementBlock as _createElementBlock } fr
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("div"))
 }
-
 ===
 name: self-closing div
-options: default
+options: vdom
 --- INPUT ---
 <div />
 --- OUTPUT ---
@@ -21,10 +20,9 @@ import { openBlock as _openBlock, createElementBlock as _createElementBlock } fr
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("div"))
 }
-
 ===
 name: element with text
-options: default
+options: vdom
 --- INPUT ---
 <div>hello</div>
 --- OUTPUT ---
@@ -33,10 +31,9 @@ import { openBlock as _openBlock, createElementBlock as _createElementBlock } fr
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("div", null, "hello"))
 }
-
 ===
 name: element with interpolation
-options: default
+options: vdom
 --- INPUT ---
 <div>{{ msg }}</div>
 --- OUTPUT ---
@@ -45,10 +42,9 @@ import { toDisplayString as _toDisplayString, openBlock as _openBlock, createEle
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.msg), 1 /* TEXT */))
 }
-
 ===
 name: element with mixed content
-options: default
+options: vdom
 --- INPUT ---
 <div>Hello {{ name }}!</div>
 --- OUTPUT ---
@@ -57,10 +53,9 @@ import { toDisplayString as _toDisplayString, openBlock as _openBlock, createEle
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("div", null, "Hello " + _toDisplayString(_ctx.name) + "!", 1 /* TEXT */))
 }
-
 ===
 name: multiple interpolations
-options: default
+options: vdom
 --- INPUT ---
 <div>{{ a }} and {{ b }}</div>
 --- OUTPUT ---
@@ -69,10 +64,9 @@ import { toDisplayString as _toDisplayString, openBlock as _openBlock, createEle
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.a) + " and " + _toDisplayString(_ctx.b), 1 /* TEXT */))
 }
-
 ===
 name: input element
-options: default
+options: vdom
 --- INPUT ---
 <input>
 --- OUTPUT ---
@@ -81,10 +75,9 @@ import { openBlock as _openBlock, createElementBlock as _createElementBlock } fr
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("input"))
 }
-
 ===
 name: br element
-options: default
+options: vdom
 --- INPUT ---
 <br>
 --- OUTPUT ---
@@ -93,10 +86,9 @@ import { openBlock as _openBlock, createElementBlock as _createElementBlock } fr
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("br"))
 }
-
 ===
 name: img element
-options: default
+options: vdom
 --- INPUT ---
 <img src="test.png">
 --- OUTPUT ---
@@ -105,10 +97,9 @@ import { openBlock as _openBlock, createElementBlock as _createElementBlock } fr
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("img", { src: "test.png" }))
 }
-
 ===
 name: hr element
-options: default
+options: vdom
 --- INPUT ---
 <hr>
 --- OUTPUT ---
@@ -117,10 +108,9 @@ import { openBlock as _openBlock, createElementBlock as _createElementBlock } fr
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("hr"))
 }
-
 ===
 name: nested elements
-options: default
+options: vdom
 --- INPUT ---
 <div><span>text</span></div>
 --- OUTPUT ---
@@ -131,10 +121,9 @@ export function render(_ctx, _cache) {
     _createElementVNode("span", null, "text")
   ]))
 }
-
 ===
 name: deeply nested
-options: default
+options: vdom
 --- INPUT ---
 <div><p><span>deep</span></p></div>
 --- OUTPUT ---
@@ -147,10 +136,9 @@ export function render(_ctx, _cache) {
     ])
   ]))
 }
-
 ===
 name: multiple children
-options: default
+options: vdom
 --- INPUT ---
 <div><span></span><p></p></div>
 --- OUTPUT ---
@@ -162,10 +150,9 @@ export function render(_ctx, _cache) {
     _createElementVNode("p")
   ]))
 }
-
 ===
 name: mixed children types
-options: default
+options: vdom
 --- INPUT ---
 <div>text<span>element</span>{{ interp }}</div>
 --- OUTPUT ---
@@ -178,10 +165,45 @@ export function render(_ctx, _cache) {
     _createTextVNode(_toDisplayString(_ctx.interp), 1 /* TEXT */)
   ]))
 }
+===
+name: text around interpolation
+options: vdom
+--- INPUT ---
+<div>Hello {{ name }}, count is {{ count }}</div>
+--- OUTPUT ---
+import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 
+export function render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("div", null, "Hello " + _toDisplayString(_ctx.name) + ", count is " + _toDisplayString(_ctx.count), 1 /* TEXT */))
+}
+===
+name: textarea with text
+options: vdom
+--- INPUT ---
+<textarea>hello</textarea>
+--- OUTPUT ---
+import { openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+export function render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("textarea", null, "hello"))
+}
+===
+name: template with text and element
+options: vdom
+--- INPUT ---
+<template>hello<span>world</span></template>
+--- OUTPUT ---
+import { createElementVNode as _createElementVNode, createTextVNode as _createTextVNode, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+export function render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("template", null, [
+    _createTextVNode("hello"),
+    _createElementVNode("span", null, "world")
+  ]))
+}
 ===
 name: static id
-options: default
+options: vdom
 --- INPUT ---
 <div id="app"></div>
 --- OUTPUT ---
@@ -190,10 +212,9 @@ import { openBlock as _openBlock, createElementBlock as _createElementBlock } fr
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("div", { id: "app" }))
 }
-
 ===
 name: static class
-options: default
+options: vdom
 --- INPUT ---
 <div class="container"></div>
 --- OUTPUT ---
@@ -202,10 +223,9 @@ import { openBlock as _openBlock, createElementBlock as _createElementBlock } fr
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("div", { class: "container" }))
 }
-
 ===
 name: multiple static attributes
-options: default
+options: vdom
 --- INPUT ---
 <div id="app" class="container"></div>
 --- OUTPUT ---
@@ -217,10 +237,20 @@ export function render(_ctx, _cache) {
     class: "container"
   }))
 }
+===
+name: static title attribute
+options: vdom
+--- INPUT ---
+<div title="hello world"></div>
+--- OUTPUT ---
+import { openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 
+export function render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("div", { title: "hello world" }))
+}
 ===
 name: data attribute
-options: default
+options: vdom
 --- INPUT ---
 <div data-id="123"></div>
 --- OUTPUT ---
@@ -229,10 +259,9 @@ import { openBlock as _openBlock, createElementBlock as _createElementBlock } fr
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("div", { "data-id": "123" }))
 }
-
 ===
 name: boolean attribute
-options: default
+options: vdom
 --- INPUT ---
 <input disabled>
 --- OUTPUT ---
@@ -241,10 +270,9 @@ import { openBlock as _openBlock, createElementBlock as _createElementBlock } fr
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("input", { disabled: "" }))
 }
-
 ===
 name: aria attribute
-options: default
+options: vdom
 --- INPUT ---
 <div aria-label="test"></div>
 --- OUTPUT ---
@@ -253,10 +281,9 @@ import { openBlock as _openBlock, createElementBlock as _createElementBlock } fr
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("div", { "aria-label": "test" }))
 }
-
 ===
 name: dynamic id
-options: default
+options: vdom
 --- INPUT ---
 <div :id="dynamicId"></div>
 --- OUTPUT ---
@@ -265,10 +292,9 @@ import { openBlock as _openBlock, createElementBlock as _createElementBlock } fr
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("div", { id: _ctx.dynamicId }, null, 8 /* PROPS */, ["id"]))
 }
-
 ===
 name: dynamic class
-options: default
+options: vdom
 --- INPUT ---
 <div :class="dynamicClass"></div>
 --- OUTPUT ---
@@ -279,10 +305,9 @@ export function render(_ctx, _cache) {
     class: _normalizeClass(_ctx.dynamicClass)
   }, null, 2 /* CLASS */))
 }
-
 ===
 name: dynamic style
-options: default
+options: vdom
 --- INPUT ---
 <div :style="dynamicStyle"></div>
 --- OUTPUT ---
@@ -293,10 +318,9 @@ export function render(_ctx, _cache) {
     style: _normalizeStyle(_ctx.dynamicStyle)
   }, null, 4 /* STYLE */))
 }
-
 ===
 name: dynamic attribute
-options: default
+options: vdom
 --- INPUT ---
 <div :data-id="id"></div>
 --- OUTPUT ---
@@ -305,10 +329,9 @@ import { openBlock as _openBlock, createElementBlock as _createElementBlock } fr
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("div", { "data-id": _ctx.id }, null, 8 /* PROPS */, ["data-id"]))
 }
-
 ===
 name: mixed static and dynamic
-options: default
+options: vdom
 --- INPUT ---
 <div class="static" :class="dynamic"></div>
 --- OUTPUT ---
@@ -319,10 +342,9 @@ export function render(_ctx, _cache) {
     class: _normalizeClass(["static", _ctx.dynamic])
   }, null, 2 /* CLASS */))
 }
-
 ===
 name: template element
-options: default
+options: vdom
 --- INPUT ---
 <template><div>content</div></template>
 --- OUTPUT ---
@@ -333,10 +355,9 @@ export function render(_ctx, _cache) {
     _createElementVNode("div", null, "content")
   ]))
 }
-
 ===
 name: slot element
-options: default
+options: vdom
 --- INPUT ---
 <slot></slot>
 --- OUTPUT ---
@@ -345,10 +366,9 @@ import { renderSlot as _renderSlot } from "vue"
 export function render(_ctx, _cache) {
   return _renderSlot(_ctx.$slots, "default")
 }
-
 ===
 name: slot with name
-options: default
+options: vdom
 --- INPUT ---
 <slot name="header"></slot>
 --- OUTPUT ---
@@ -357,10 +377,9 @@ import { renderSlot as _renderSlot } from "vue"
 export function render(_ctx, _cache) {
   return _renderSlot(_ctx.$slots, "header")
 }
-
 ===
 name: slot with fallback
-options: default
+options: vdom
 --- INPUT ---
 <slot>fallback content</slot>
 --- OUTPUT ---
@@ -371,10 +390,9 @@ export function render(_ctx, _cache) {
     _createTextVNode("fallback content")
   ])
 }
-
 ===
 name: svg element
-options: default
+options: vdom
 --- INPUT ---
 <svg viewBox="0 0 100 100"><circle cx="50" cy="50" r="40"/></svg>
 --- OUTPUT ---
@@ -389,10 +407,9 @@ export function render(_ctx, _cache) {
     })
   ]))
 }
-
 ===
 name: svg with namespace
-options: default
+options: vdom
 --- INPUT ---
 <svg xmlns="http://www.w3.org/2000/svg"><rect width="100" height="100"/></svg>
 --- OUTPUT ---
@@ -406,10 +423,35 @@ export function render(_ctx, _cache) {
     })
   ]))
 }
+===
+name: svg path element
+options: vdom
+--- INPUT ---
+<svg viewBox="0 0 10 10"><path d="M0 0h10v10z"></path></svg>
+--- OUTPUT ---
+import { createElementVNode as _createElementVNode, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 
+export function render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("svg", { viewBox: "0 0 10 10" }, [
+    _createElementVNode("path", { d: "M0 0h10v10z" })
+  ]))
+}
+===
+name: math element
+options: vdom
+--- INPUT ---
+<math><mi>x</mi></math>
+--- OUTPUT ---
+import { createElementVNode as _createElementVNode, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+export function render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("math", null, [
+    _createElementVNode("mi", null, "x")
+  ]))
+}
 ===
 name: html comment
-options: default
+options: vdom
 --- INPUT ---
 <div><!-- comment --></div>
 --- OUTPUT ---
@@ -420,10 +462,9 @@ export function render(_ctx, _cache) {
     _createCommentVNode(" comment ")
   ]))
 }
-
 ===
 name: comment between elements
-options: default
+options: vdom
 --- INPUT ---
 <div><span></span><!-- between --><p></p></div>
 --- OUTPUT ---
@@ -435,4 +476,19 @@ export function render(_ctx, _cache) {
     _createCommentVNode(" between "),
     _createElementVNode("p")
   ]))
+}
+===
+name: root comment between elements
+options: vdom
+--- INPUT ---
+<span>one</span><!-- between --><span>two</span>
+--- OUTPUT ---
+import { createElementVNode as _createElementVNode, createCommentVNode as _createCommentVNode, Fragment as _Fragment, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+export function render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock(_Fragment, null, [
+    _createElementVNode("span", null, "one"),
+    _createCommentVNode(" between "),
+    _createElementVNode("span", null, "two")
+  ], 64 /* STABLE_FRAGMENT */))
 }

--- a/tests/expected/vdom/patch-flags.snap
+++ b/tests/expected/vdom/patch-flags.snap
@@ -1,6 +1,6 @@
 ===
 name: text patch flag
-options: default
+options: vdom
 --- INPUT ---
 <div>{{ msg }}</div>
 --- OUTPUT ---
@@ -9,10 +9,9 @@ import { toDisplayString as _toDisplayString, openBlock as _openBlock, createEle
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.msg), 1 /* TEXT */))
 }
-
 ===
 name: text in span
-options: default
+options: vdom
 --- INPUT ---
 <span>{{ text }}</span>
 --- OUTPUT ---
@@ -21,10 +20,9 @@ import { toDisplayString as _toDisplayString, openBlock as _openBlock, createEle
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("span", null, _toDisplayString(_ctx.text), 1 /* TEXT */))
 }
-
 ===
 name: multiple interpolations
-options: default
+options: vdom
 --- INPUT ---
 <div>{{ a }} {{ b }}</div>
 --- OUTPUT ---
@@ -33,10 +31,9 @@ import { toDisplayString as _toDisplayString, openBlock as _openBlock, createEle
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.a) + " " + _toDisplayString(_ctx.b), 1 /* TEXT */))
 }
-
 ===
 name: class patch flag
-options: default
+options: vdom
 --- INPUT ---
 <div :class="cls"></div>
 --- OUTPUT ---
@@ -47,10 +44,9 @@ export function render(_ctx, _cache) {
     class: _normalizeClass(_ctx.cls)
   }, null, 2 /* CLASS */))
 }
-
 ===
 name: class object
-options: default
+options: vdom
 --- INPUT ---
 <div :class="{ active: isActive }"></div>
 --- OUTPUT ---
@@ -61,10 +57,9 @@ export function render(_ctx, _cache) {
     class: _normalizeClass({ active: _ctx.isActive })
   }, null, 2 /* CLASS */))
 }
-
 ===
 name: class array
-options: default
+options: vdom
 --- INPUT ---
 <div :class="[a, b]"></div>
 --- OUTPUT ---
@@ -75,10 +70,9 @@ export function render(_ctx, _cache) {
     class: _normalizeClass([_ctx.a, _ctx.b])
   }, null, 2 /* CLASS */))
 }
-
 ===
 name: style patch flag
-options: default
+options: vdom
 --- INPUT ---
 <div :style="styles"></div>
 --- OUTPUT ---
@@ -89,10 +83,9 @@ export function render(_ctx, _cache) {
     style: _normalizeStyle(_ctx.styles)
   }, null, 4 /* STYLE */))
 }
-
 ===
 name: style object
-options: default
+options: vdom
 --- INPUT ---
 <div :style="{ color: textColor }"></div>
 --- OUTPUT ---
@@ -103,10 +96,9 @@ export function render(_ctx, _cache) {
     style: _normalizeStyle({ color: _ctx.textColor })
   }, null, 4 /* STYLE */))
 }
-
 ===
 name: style array
-options: default
+options: vdom
 --- INPUT ---
 <div :style="[a, b]"></div>
 --- OUTPUT ---
@@ -117,10 +109,9 @@ export function render(_ctx, _cache) {
     style: _normalizeStyle([_ctx.a, _ctx.b])
   }, null, 4 /* STYLE */))
 }
-
 ===
 name: props patch flag
-options: default
+options: vdom
 --- INPUT ---
 <div :id="id"></div>
 --- OUTPUT ---
@@ -129,10 +120,9 @@ import { openBlock as _openBlock, createElementBlock as _createElementBlock } fr
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("div", { id: _ctx.id }, null, 8 /* PROPS */, ["id"]))
 }
-
 ===
 name: multiple dynamic props
-options: default
+options: vdom
 --- INPUT ---
 <div :id="id" :title="title"></div>
 --- OUTPUT ---
@@ -144,10 +134,9 @@ export function render(_ctx, _cache) {
     title: _ctx.title
   }, null, 8 /* PROPS */, ["id", "title"]))
 }
-
 ===
 name: dynamic data attribute
-options: default
+options: vdom
 --- INPUT ---
 <div :data-id="id"></div>
 --- OUTPUT ---
@@ -156,10 +145,9 @@ import { openBlock as _openBlock, createElementBlock as _createElementBlock } fr
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("div", { "data-id": _ctx.id }, null, 8 /* PROPS */, ["data-id"]))
 }
-
 ===
 name: v-bind object
-options: default
+options: vdom
 --- INPUT ---
 <div v-bind="props"></div>
 --- OUTPUT ---
@@ -168,10 +156,9 @@ import { normalizeProps as _normalizeProps, guardReactiveProps as _guardReactive
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("div", _normalizeProps(_guardReactiveProps(_ctx.props)), null, 16 /* FULL_PROPS */))
 }
-
 ===
 name: dynamic key
-options: default
+options: vdom
 --- INPUT ---
 <div :[key]="value"></div>
 --- OUTPUT ---
@@ -180,10 +167,9 @@ import { normalizeProps as _normalizeProps, openBlock as _openBlock, createEleme
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("div", _normalizeProps({ [_ctx.key || ""]: _ctx.value }), null, 16 /* FULL_PROPS */))
 }
-
 ===
 name: event handler
-options: default
+options: vdom
 --- INPUT ---
 <button @click="handler">click</button>
 --- OUTPUT ---
@@ -192,10 +178,34 @@ import { openBlock as _openBlock, createElementBlock as _createElementBlock } fr
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("button", { onClick: _ctx.handler }, "click", 8 /* PROPS */, ["onClick"]))
 }
+===
+name: event handler with dynamic text
+options: vdom
+--- INPUT ---
+<button @click="handler">{{ label }}</button>
+--- OUTPUT ---
+import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 
+export function render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("button", { onClick: _ctx.handler }, _toDisplayString(_ctx.label), 9 /* TEXT, PROPS */, ["onClick"]))
+}
+===
+name: event handler with dynamic class
+options: vdom
+--- INPUT ---
+<button :class="cls" @click="handler">click</button>
+--- OUTPUT ---
+import { normalizeClass as _normalizeClass, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+export function render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("button", {
+    class: _normalizeClass(_ctx.cls),
+    onClick: _ctx.handler
+  }, "click", 10 /* CLASS, PROPS */, ["onClick"]))
+}
 ===
 name: ref
-options: default
+options: vdom
 --- INPUT ---
 <div ref="el"></div>
 --- OUTPUT ---
@@ -204,10 +214,9 @@ import { openBlock as _openBlock, createElementBlock as _createElementBlock } fr
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("div", { ref: "el" }, null, 512 /* NEED_PATCH */))
 }
-
 ===
 name: text and class
-options: default
+options: vdom
 --- INPUT ---
 <div :class="cls">{{ msg }}</div>
 --- OUTPUT ---
@@ -218,10 +227,9 @@ export function render(_ctx, _cache) {
     class: _normalizeClass(_ctx.cls)
   }, _toDisplayString(_ctx.msg), 3 /* TEXT, CLASS */))
 }
-
 ===
 name: class and style
-options: default
+options: vdom
 --- INPUT ---
 <div :class="cls" :style="style"></div>
 --- OUTPUT ---
@@ -233,10 +241,9 @@ export function render(_ctx, _cache) {
     style: _normalizeStyle(_ctx.style)
   }, null, 6 /* CLASS, STYLE */))
 }
-
 ===
 name: text and props
-options: default
+options: vdom
 --- INPUT ---
 <div :id="id">{{ msg }}</div>
 --- OUTPUT ---
@@ -245,10 +252,9 @@ import { toDisplayString as _toDisplayString, openBlock as _openBlock, createEle
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("div", { id: _ctx.id }, _toDisplayString(_ctx.msg), 9 /* TEXT, PROPS */, ["id"]))
 }
-
 ===
 name: all dynamic
-options: default
+options: vdom
 --- INPUT ---
 <div :id="id" :class="cls" :style="style">{{ msg }}</div>
 --- OUTPUT ---
@@ -261,10 +267,9 @@ export function render(_ctx, _cache) {
     style: _normalizeStyle(_ctx.style)
   }, _toDisplayString(_ctx.msg), 15 /* TEXT, CLASS, STYLE, PROPS */, ["id"]))
 }
-
 ===
 name: v-for with key
-options: default
+options: vdom
 --- INPUT ---
 <div v-for="item in items" :key="item.id">{{ item }}</div>
 --- OUTPUT ---
@@ -277,10 +282,9 @@ export function render(_ctx, _cache) {
     }, _toDisplayString(item), 1 /* TEXT */))
   }), 128 /* KEYED_FRAGMENT */))
 }
-
 ===
 name: v-for without key
-options: default
+options: vdom
 --- INPUT ---
 <div v-for="item in items">{{ item }}</div>
 --- OUTPUT ---
@@ -291,10 +295,9 @@ export function render(_ctx, _cache) {
     return (_openBlock(), _createElementBlock("div", null, _toDisplayString(item), 1 /* TEXT */))
   }), 256 /* UNKEYED_FRAGMENT */))
 }
-
 ===
 name: ref on element
-options: default
+options: vdom
 --- INPUT ---
 <div ref="el">content</div>
 --- OUTPUT ---
@@ -303,10 +306,9 @@ import { openBlock as _openBlock, createElementBlock as _createElementBlock } fr
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("div", { ref: "el" }, "content", 512 /* NEED_PATCH */))
 }
-
 ===
 name: directive on static
-options: default
+options: vdom
 --- INPUT ---
 <div v-focus>content</div>
 --- OUTPUT ---
@@ -321,10 +323,9 @@ export function render(_ctx, _cache) {
     [_directive_focus]
   ])
 }
-
 ===
 name: dynamic slot name
-options: default
+options: vdom
 --- INPUT ---
 <MyComponent><template #[name]>content</template></MyComponent>
 --- OUTPUT ---
@@ -340,10 +341,9 @@ export function render(_ctx, _cache) {
     _: 2 /* DYNAMIC */
   }, 1024 /* DYNAMIC_SLOTS */))
 }
-
 ===
 name: slot with v-if
-options: default
+options: vdom
 --- INPUT ---
 <MyComponent><template #header v-if="show">Header</template></MyComponent>
 --- OUTPUT ---
@@ -364,10 +364,9 @@ export function render(_ctx, _cache) {
       : undefined
   ]), 1024 /* DYNAMIC_SLOTS */))
 }
-
 ===
 name: slot with v-for
-options: default
+options: vdom
 --- INPUT ---
 <MyComponent><template #item v-for="item in items" :key="item">{{ item }}</template></MyComponent>
 --- OUTPUT ---
@@ -387,10 +386,9 @@ export function render(_ctx, _cache) {
     })
   ]), 1024 /* DYNAMIC_SLOTS */))
 }
-
 ===
 name: component static props
-options: default
+options: vdom
 --- INPUT ---
 <MyComponent msg="hello" />
 --- OUTPUT ---
@@ -401,10 +399,9 @@ export function render(_ctx, _cache) {
 
   return (_openBlock(), _createBlock(_component_MyComponent, { msg: "hello" }))
 }
-
 ===
 name: component dynamic props
-options: default
+options: vdom
 --- INPUT ---
 <MyComponent :msg="message" />
 --- OUTPUT ---
@@ -415,10 +412,9 @@ export function render(_ctx, _cache) {
 
   return (_openBlock(), _createBlock(_component_MyComponent, { msg: _ctx.message }, null, 8 /* PROPS */, ["msg"]))
 }
-
 ===
 name: component mixed props
-options: default
+options: vdom
 --- INPUT ---
 <MyComponent static="value" :dynamic="value" />
 --- OUTPUT ---

--- a/tests/expected/vdom/v-bind.snap
+++ b/tests/expected/vdom/v-bind.snap
@@ -1,6 +1,6 @@
 ===
 name: v-bind attribute
-options: default
+options: vdom
 --- INPUT ---
 <div v-bind:id="id"></div>
 --- OUTPUT ---
@@ -9,10 +9,9 @@ import { openBlock as _openBlock, createElementBlock as _createElementBlock } fr
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("div", { id: _ctx.id }, null, 8 /* PROPS */, ["id"]))
 }
-
 ===
 name: v-bind shorthand
-options: default
+options: vdom
 --- INPUT ---
 <div :id="id"></div>
 --- OUTPUT ---
@@ -21,10 +20,9 @@ import { openBlock as _openBlock, createElementBlock as _createElementBlock } fr
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("div", { id: _ctx.id }, null, 8 /* PROPS */, ["id"]))
 }
-
 ===
 name: v-bind class
-options: default
+options: vdom
 --- INPUT ---
 <div :class="cls"></div>
 --- OUTPUT ---
@@ -35,10 +33,9 @@ export function render(_ctx, _cache) {
     class: _normalizeClass(_ctx.cls)
   }, null, 2 /* CLASS */))
 }
-
 ===
 name: v-bind style
-options: default
+options: vdom
 --- INPUT ---
 <div :style="styles"></div>
 --- OUTPUT ---
@@ -49,10 +46,9 @@ export function render(_ctx, _cache) {
     style: _normalizeStyle(_ctx.styles)
   }, null, 4 /* STYLE */))
 }
-
 ===
 name: class object syntax
-options: default
+options: vdom
 --- INPUT ---
 <div :class="{ active: isActive }"></div>
 --- OUTPUT ---
@@ -63,10 +59,9 @@ export function render(_ctx, _cache) {
     class: _normalizeClass({ active: _ctx.isActive })
   }, null, 2 /* CLASS */))
 }
-
 ===
 name: class multiple objects
-options: default
+options: vdom
 --- INPUT ---
 <div :class="{ active: isActive, error: hasError }"></div>
 --- OUTPUT ---
@@ -77,10 +72,9 @@ export function render(_ctx, _cache) {
     class: _normalizeClass({ active: _ctx.isActive, error: _ctx.hasError })
   }, null, 2 /* CLASS */))
 }
-
 ===
 name: class array syntax
-options: default
+options: vdom
 --- INPUT ---
 <div :class="[activeClass, errorClass]"></div>
 --- OUTPUT ---
@@ -91,10 +85,9 @@ export function render(_ctx, _cache) {
     class: _normalizeClass([_ctx.activeClass, _ctx.errorClass])
   }, null, 2 /* CLASS */))
 }
-
 ===
 name: class array with object
-options: default
+options: vdom
 --- INPUT ---
 <div :class="[{ active: isActive }, errorClass]"></div>
 --- OUTPUT ---
@@ -105,10 +98,9 @@ export function render(_ctx, _cache) {
     class: _normalizeClass([{ active: _ctx.isActive }, _ctx.errorClass])
   }, null, 2 /* CLASS */))
 }
-
 ===
 name: class with static
-options: default
+options: vdom
 --- INPUT ---
 <div class="static" :class="dynamic"></div>
 --- OUTPUT ---
@@ -119,10 +111,9 @@ export function render(_ctx, _cache) {
     class: _normalizeClass(["static", _ctx.dynamic])
   }, null, 2 /* CLASS */))
 }
-
 ===
 name: class ternary
-options: default
+options: vdom
 --- INPUT ---
 <div :class="isActive ? 'active' : 'inactive'"></div>
 --- OUTPUT ---
@@ -133,10 +124,22 @@ export function render(_ctx, _cache) {
     class: _normalizeClass(_ctx.isActive ? 'active' : 'inactive')
   }, null, 2 /* CLASS */))
 }
+===
+name: class array with conditional
+options: vdom
+--- INPUT ---
+<div :class="[base, isActive && active]"></div>
+--- OUTPUT ---
+import { normalizeClass as _normalizeClass, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 
+export function render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("div", {
+    class: _normalizeClass([_ctx.base, _ctx.isActive && _ctx.active])
+  }, null, 2 /* CLASS */))
+}
 ===
 name: style object syntax
-options: default
+options: vdom
 --- INPUT ---
 <div :style="{ color: textColor }"></div>
 --- OUTPUT ---
@@ -147,10 +150,9 @@ export function render(_ctx, _cache) {
     style: _normalizeStyle({ color: _ctx.textColor })
   }, null, 4 /* STYLE */))
 }
-
 ===
 name: style multiple properties
-options: default
+options: vdom
 --- INPUT ---
 <div :style="{ color: textColor, fontSize: size + 'px' }"></div>
 --- OUTPUT ---
@@ -161,10 +163,9 @@ export function render(_ctx, _cache) {
     style: _normalizeStyle({ color: _ctx.textColor, fontSize: _ctx.size + 'px' })
   }, null, 4 /* STYLE */))
 }
-
 ===
 name: style array syntax
-options: default
+options: vdom
 --- INPUT ---
 <div :style="[baseStyles, overrideStyles]"></div>
 --- OUTPUT ---
@@ -175,10 +176,9 @@ export function render(_ctx, _cache) {
     style: _normalizeStyle([_ctx.baseStyles, _ctx.overrideStyles])
   }, null, 4 /* STYLE */))
 }
-
 ===
 name: style with static
-options: default
+options: vdom
 --- INPUT ---
 <div style="color: red" :style="{ fontSize: size }"></div>
 --- OUTPUT ---
@@ -189,10 +189,9 @@ export function render(_ctx, _cache) {
     style: _normalizeStyle([{"color":"red"}, { fontSize: _ctx.size }])
   }, null, 4 /* STYLE */))
 }
-
 ===
 name: style camelCase
-options: default
+options: vdom
 --- INPUT ---
 <div :style="{ backgroundColor: bg }"></div>
 --- OUTPUT ---
@@ -203,10 +202,9 @@ export function render(_ctx, _cache) {
     style: _normalizeStyle({ backgroundColor: _ctx.bg })
   }, null, 4 /* STYLE */))
 }
-
 ===
 name: style kebab-case
-options: default
+options: vdom
 --- INPUT ---
 <div :style="{ 'background-color': bg }"></div>
 --- OUTPUT ---
@@ -217,10 +215,9 @@ export function render(_ctx, _cache) {
     style: _normalizeStyle({ 'background-color': _ctx.bg })
   }, null, 4 /* STYLE */))
 }
-
 ===
 name: v-bind object
-options: default
+options: vdom
 --- INPUT ---
 <div v-bind="attrs"></div>
 --- OUTPUT ---
@@ -229,10 +226,9 @@ import { normalizeProps as _normalizeProps, guardReactiveProps as _guardReactive
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("div", _normalizeProps(_guardReactiveProps(_ctx.attrs)), null, 16 /* FULL_PROPS */))
 }
-
 ===
 name: v-bind object with other attrs
-options: default
+options: vdom
 --- INPUT ---
 <div v-bind="attrs" id="static"></div>
 --- OUTPUT ---
@@ -241,10 +237,9 @@ import { mergeProps as _mergeProps, openBlock as _openBlock, createElementBlock 
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("div", _mergeProps(_ctx.attrs, { id: "static" }), null, 16 /* FULL_PROPS */))
 }
-
 ===
 name: v-bind object with dynamic
-options: default
+options: vdom
 --- INPUT ---
 <div v-bind="attrs" :class="cls"></div>
 --- OUTPUT ---
@@ -253,10 +248,9 @@ import { mergeProps as _mergeProps, openBlock as _openBlock, createElementBlock 
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("div", _mergeProps(_ctx.attrs, { class: _ctx.cls }), null, 16 /* FULL_PROPS */))
 }
-
 ===
 name: v-bind $attrs
-options: default
+options: vdom
 --- INPUT ---
 <div v-bind="$attrs"></div>
 --- OUTPUT ---
@@ -265,10 +259,9 @@ import { normalizeProps as _normalizeProps, guardReactiveProps as _guardReactive
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("div", _normalizeProps(_guardReactiveProps(_ctx.$attrs)), null, 16 /* FULL_PROPS */))
 }
-
 ===
 name: v-bind $props
-options: default
+options: vdom
 --- INPUT ---
 <MyComponent v-bind="$props" />
 --- OUTPUT ---
@@ -279,10 +272,46 @@ export function render(_ctx, _cache) {
 
   return (_openBlock(), _createBlock(_component_MyComponent, _normalizeProps(_guardReactiveProps(_ctx.$props)), null, 16 /* FULL_PROPS */))
 }
+===
+name: aria attribute binding
+options: vdom
+--- INPUT ---
+<button :aria-expanded="isOpen"></button>
+--- OUTPUT ---
+import { openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 
+export function render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("button", { "aria-expanded": _ctx.isOpen }, null, 8 /* PROPS */, ["aria-expanded"]))
+}
+===
+name: data attribute expression
+options: vdom
+--- INPUT ---
+<div :data-count="items.length"></div>
+--- OUTPUT ---
+import { openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+export function render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("div", {
+    "data-count": _ctx.items.length
+  }, null, 8 /* PROPS */, ["data-count"]))
+}
+===
+name: optional chaining binding
+options: vdom
+--- INPUT ---
+<div :title="user?.name"></div>
+--- OUTPUT ---
+import { openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+export function render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("div", {
+    title: _ctx.user?.name
+  }, null, 8 /* PROPS */, ["title"]))
+}
 ===
 name: dynamic attribute name
-options: default
+options: vdom
 --- INPUT ---
 <div :[attr]="value"></div>
 --- OUTPUT ---
@@ -291,10 +320,9 @@ import { normalizeProps as _normalizeProps, openBlock as _openBlock, createEleme
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("div", _normalizeProps({ [_ctx.attr || ""]: _ctx.value }), null, 16 /* FULL_PROPS */))
 }
-
 ===
 name: dynamic attribute with prefix
-options: default
+options: vdom
 --- INPUT ---
 <div :[`data-${key}`]="value"></div>
 --- OUTPUT ---
@@ -303,10 +331,9 @@ import { normalizeProps as _normalizeProps, openBlock as _openBlock, createEleme
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("div", _normalizeProps({ [(`data-${_ctx.key}`) || ""]: _ctx.value }), null, 16 /* FULL_PROPS */))
 }
-
 ===
 name: v-bind.camel
-options: default
+options: vdom
 --- INPUT ---
 <svg :view-box.camel="viewBox"></svg>
 --- OUTPUT ---
@@ -315,10 +342,9 @@ import { openBlock as _openBlock, createElementBlock as _createElementBlock } fr
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("svg", { viewBox: _ctx.viewBox }, null, 8 /* PROPS */, ["viewBox"]))
 }
-
 ===
 name: v-bind.prop
-options: default
+options: vdom
 --- INPUT ---
 <div :text-content.prop="text"></div>
 --- OUTPUT ---
@@ -327,10 +353,9 @@ import { openBlock as _openBlock, createElementBlock as _createElementBlock } fr
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("div", { ".text-content": _ctx.text }, null, 40 /* PROPS, NEED_HYDRATION */, [".text-content"]))
 }
-
 ===
 name: v-bind.attr
-options: default
+options: vdom
 --- INPUT ---
 <div :foo.attr="bar"></div>
 --- OUTPUT ---
@@ -339,10 +364,9 @@ import { openBlock as _openBlock, createElementBlock as _createElementBlock } fr
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("div", { "^foo": _ctx.bar }, null, 8 /* PROPS */, ["^foo"]))
 }
-
 ===
 name: v-bind key
-options: default
+options: vdom
 --- INPUT ---
 <div :key="id"></div>
 --- OUTPUT ---
@@ -351,10 +375,9 @@ import { openBlock as _openBlock, createElementBlock as _createElementBlock } fr
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("div", { key: _ctx.id }))
 }
-
 ===
 name: v-bind ref
-options: default
+options: vdom
 --- INPUT ---
 <div :ref="refName"></div>
 --- OUTPUT ---
@@ -363,10 +386,9 @@ import { openBlock as _openBlock, createElementBlock as _createElementBlock } fr
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("div", { ref: _ctx.refName }, null, 512 /* NEED_PATCH */))
 }
-
 ===
 name: v-bind is
-options: default
+options: vdom
 --- INPUT ---
 <component :is="comp"></component>
 --- OUTPUT ---
@@ -375,10 +397,9 @@ import { resolveDynamicComponent as _resolveDynamicComponent, openBlock as _open
 export function render(_ctx, _cache) {
   return (_openBlock(), _createBlock(_resolveDynamicComponent(_ctx.comp)))
 }
-
 ===
 name: boolean attribute binding
-options: default
+options: vdom
 --- INPUT ---
 <input :disabled="isDisabled">
 --- OUTPUT ---
@@ -387,10 +408,9 @@ import { openBlock as _openBlock, createElementBlock as _createElementBlock } fr
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("input", { disabled: _ctx.isDisabled }, null, 8 /* PROPS */, ["disabled"]))
 }
-
 ===
 name: boolean attribute expression
-options: default
+options: vdom
 --- INPUT ---
 <input :disabled="count > 0">
 --- OUTPUT ---
@@ -401,10 +421,9 @@ export function render(_ctx, _cache) {
     disabled: _ctx.count > 0
   }, null, 8 /* PROPS */, ["disabled"]))
 }
-
 ===
 name: boolean readonly
-options: default
+options: vdom
 --- INPUT ---
 <input :readonly="isReadonly">
 --- OUTPUT ---

--- a/tests/expected/vdom/v-for.snap
+++ b/tests/expected/vdom/v-for.snap
@@ -1,6 +1,6 @@
 ===
 name: v-for array
-options: default
+options: vdom
 --- INPUT ---
 <div v-for="item in items">{{ item }}</div>
 --- OUTPUT ---
@@ -11,10 +11,9 @@ export function render(_ctx, _cache) {
     return (_openBlock(), _createElementBlock("div", null, _toDisplayString(item), 1 /* TEXT */))
   }), 256 /* UNKEYED_FRAGMENT */))
 }
-
 ===
 name: v-for with key
-options: default
+options: vdom
 --- INPUT ---
 <div v-for="item in items" :key="item.id">{{ item.name }}</div>
 --- OUTPUT ---
@@ -27,10 +26,9 @@ export function render(_ctx, _cache) {
     }, _toDisplayString(item.name), 1 /* TEXT */))
   }), 128 /* KEYED_FRAGMENT */))
 }
-
 ===
 name: v-for with index
-options: default
+options: vdom
 --- INPUT ---
 <div v-for="(item, index) in items" :key="index">{{ index }}: {{ item }}</div>
 --- OUTPUT ---
@@ -41,10 +39,9 @@ export function render(_ctx, _cache) {
     return (_openBlock(), _createElementBlock("div", { key: index }, _toDisplayString(index) + ": " + _toDisplayString(item), 1 /* TEXT */))
   }), 128 /* KEYED_FRAGMENT */))
 }
-
 ===
 name: v-for object
-options: default
+options: vdom
 --- INPUT ---
 <div v-for="(value, key) in obj" :key="key">{{ key }}: {{ value }}</div>
 --- OUTPUT ---
@@ -55,10 +52,9 @@ export function render(_ctx, _cache) {
     return (_openBlock(), _createElementBlock("div", { key: key }, _toDisplayString(key) + ": " + _toDisplayString(value), 1 /* TEXT */))
   }), 128 /* KEYED_FRAGMENT */))
 }
-
 ===
 name: v-for object with index
-options: default
+options: vdom
 --- INPUT ---
 <div v-for="(value, key, index) in obj" :key="index">{{ index }}. {{ key }}: {{ value }}</div>
 --- OUTPUT ---
@@ -69,10 +65,9 @@ export function render(_ctx, _cache) {
     return (_openBlock(), _createElementBlock("div", { key: index }, _toDisplayString(index) + ". " + _toDisplayString(key) + ": " + _toDisplayString(value), 1 /* TEXT */))
   }), 128 /* KEYED_FRAGMENT */))
 }
-
 ===
 name: v-for range
-options: default
+options: vdom
 --- INPUT ---
 <div v-for="n in 10" :key="n">{{ n }}</div>
 --- OUTPUT ---
@@ -83,10 +78,9 @@ export function render(_ctx, _cache) {
     return _createElementVNode("div", { key: n }, _toDisplayString(n), 1 /* TEXT */)
   }), 64 /* STABLE_FRAGMENT */))
 }
-
 ===
 name: v-for of array
-options: default
+options: vdom
 --- INPUT ---
 <div v-for="item of items" :key="item">{{ item }}</div>
 --- OUTPUT ---
@@ -97,10 +91,9 @@ export function render(_ctx, _cache) {
     return (_openBlock(), _createElementBlock("div", { key: item }, _toDisplayString(item), 1 /* TEXT */))
   }), 128 /* KEYED_FRAGMENT */))
 }
-
 ===
 name: v-for of with index
-options: default
+options: vdom
 --- INPUT ---
 <div v-for="(item, i) of items" :key="i">{{ item }}</div>
 --- OUTPUT ---
@@ -111,10 +104,9 @@ export function render(_ctx, _cache) {
     return (_openBlock(), _createElementBlock("div", { key: i }, _toDisplayString(item), 1 /* TEXT */))
   }), 128 /* KEYED_FRAGMENT */))
 }
-
 ===
 name: v-for on template
-options: default
+options: vdom
 --- INPUT ---
 <template v-for="item in items" :key="item.id"><div>{{ item.a }}</div><div>{{ item.b }}</div></template>
 --- OUTPUT ---
@@ -130,10 +122,9 @@ export function render(_ctx, _cache) {
     ], 64 /* STABLE_FRAGMENT */))
   }), 128 /* KEYED_FRAGMENT */))
 }
-
 ===
 name: v-for on template with nested
-options: default
+options: vdom
 --- INPUT ---
 <template v-for="item in items" :key="item.id"><span>{{ item }}</span></template>
 --- OUTPUT ---
@@ -146,10 +137,27 @@ export function render(_ctx, _cache) {
     }, _toDisplayString(item), 1 /* TEXT */))
   }), 128 /* KEYED_FRAGMENT */))
 }
+===
+name: v-for on template with index
+options: vdom
+--- INPUT ---
+<template v-for="(item, index) in items" :key="item.id"><div>{{ index }}</div><span>{{ item.name }}</span></template>
+--- OUTPUT ---
+import { renderList as _renderList, Fragment as _Fragment, openBlock as _openBlock, createElementBlock as _createElementBlock, toDisplayString as _toDisplayString, createElementVNode as _createElementVNode } from "vue"
 
+export function render(_ctx, _cache) {
+  return (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(_ctx.items, (item, index) => {
+    return (_openBlock(), _createElementBlock(_Fragment, {
+      key: item.id
+    }, [
+      _createElementVNode("div", null, _toDisplayString(index), 1 /* TEXT */),
+      _createElementVNode("span", null, _toDisplayString(item.name), 1 /* TEXT */)
+    ], 64 /* STABLE_FRAGMENT */))
+  }), 128 /* KEYED_FRAGMENT */))
+}
 ===
 name: v-for on component
-options: default
+options: vdom
 --- INPUT ---
 <MyComponent v-for="item in items" :key="item.id" :item="item" />
 --- OUTPUT ---
@@ -165,10 +173,9 @@ export function render(_ctx, _cache) {
     }, null, 8 /* PROPS */, ["item"]))
   }), 128 /* KEYED_FRAGMENT */))
 }
-
 ===
 name: v-for on component with content
-options: default
+options: vdom
 --- INPUT ---
 <MyComponent v-for="item in items" :key="item.id">{{ item.name }}</MyComponent>
 --- OUTPUT ---
@@ -188,10 +195,9 @@ export function render(_ctx, _cache) {
     }, 1024 /* DYNAMIC_SLOTS */))
   }), 128 /* KEYED_FRAGMENT */))
 }
-
 ===
 name: nested v-for
-options: default
+options: vdom
 --- INPUT ---
 <div v-for="row in rows" :key="row.id"><span v-for="cell in row.cells" :key="cell.id">{{ cell }}</span></div>
 --- OUTPUT ---
@@ -210,10 +216,9 @@ export function render(_ctx, _cache) {
     ]))
   }), 128 /* KEYED_FRAGMENT */))
 }
-
 ===
 name: v-for with v-if
-options: default
+options: vdom
 --- INPUT ---
 <div v-for="item in items" :key="item.id" v-if="item.active">{{ item.name }}</div>
 --- OUTPUT ---
@@ -228,10 +233,9 @@ export function render(_ctx, _cache) {
       }), 128 /* KEYED_FRAGMENT */))
     : _createCommentVNode("v-if", true)
 }
-
 ===
 name: template v-for with v-if inside
-options: default
+options: vdom
 --- INPUT ---
 <template v-for="item in items" :key="item.id"><div v-if="item.show">{{ item.name }}</div></template>
 --- OUTPUT ---
@@ -248,10 +252,9 @@ export function render(_ctx, _cache) {
     ], 64 /* STABLE_FRAGMENT */))
   }), 128 /* KEYED_FRAGMENT */))
 }
-
 ===
 name: v-for with destructure
-options: default
+options: vdom
 --- INPUT ---
 <div v-for="{ id, name } in items" :key="id">{{ name }}</div>
 --- OUTPUT ---
@@ -262,10 +265,9 @@ export function render(_ctx, _cache) {
     return (_openBlock(), _createElementBlock("div", { key: id }, _toDisplayString(name), 1 /* TEXT */))
   }), 128 /* KEYED_FRAGMENT */))
 }
-
 ===
 name: v-for with nested destructure
-options: default
+options: vdom
 --- INPUT ---
 <div v-for="{ user: { name } } in items" :key="name">{{ name }}</div>
 --- OUTPUT ---
@@ -276,29 +278,17 @@ export function render(_ctx, _cache) {
     return (_openBlock(), _createElementBlock("div", { key: name }, _toDisplayString(name), 1 /* TEXT */))
   }), 128 /* KEYED_FRAGMENT */))
 }
-
 ===
 name: v-for with default value
-options: default
+options: vdom
 errors: Attribute name cannot contain U+0022 ("), U+0027 ('), and U+003C (<).; Attribute name cannot contain U+0022 ("), U+0027 ('), and U+003C (<).; v-for has invalid expression.
 --- INPUT ---
 <div v-for="{ id, name = "default" } in items" :key="id">{{ name }}</div>
 --- OUTPUT ---
-import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
-
-export function render(_ctx, _cache) {
-  return (_openBlock(), _createElementBlock("div", {
-    "default\"": "",
-    "}": "",
-    in: "",
-    "items\"": "",
-    key: _ctx.id
-  }, _toDisplayString(_ctx.name), 1 /* TEXT */))
-}
-
+Compile errors: Attribute name cannot contain U+0022 ("), U+0027 ('), and U+003C (<)., Attribute name cannot contain U+0022 ("), U+0027 ('), and U+003C (<)., v-for has invalid expression.
 ===
 name: v-for with rest
-options: default
+options: vdom
 --- INPUT ---
 <div v-for="{ id, ...rest } in items" :key="id">{{ rest }}</div>
 --- OUTPUT ---
@@ -309,10 +299,9 @@ export function render(_ctx, _cache) {
     return (_openBlock(), _createElementBlock("div", { key: id }, _toDisplayString(rest), 1 /* TEXT */))
   }), 128 /* KEYED_FRAGMENT */))
 }
-
 ===
 name: v-for with method call
-options: default
+options: vdom
 --- INPUT ---
 <div v-for="item in getItems()" :key="item.id">{{ item }}</div>
 --- OUTPUT ---
@@ -325,10 +314,9 @@ export function render(_ctx, _cache) {
     }, _toDisplayString(item), 1 /* TEXT */))
   }), 128 /* KEYED_FRAGMENT */))
 }
-
 ===
 name: v-for with computed
-options: default
+options: vdom
 --- INPUT ---
 <div v-for="item in filteredItems" :key="item.id">{{ item }}</div>
 --- OUTPUT ---
@@ -341,10 +329,9 @@ export function render(_ctx, _cache) {
     }, _toDisplayString(item), 1 /* TEXT */))
   }), 128 /* KEYED_FRAGMENT */))
 }
-
 ===
 name: v-for with filter
-options: default
+options: vdom
 --- INPUT ---
 <div v-for="item in items.filter(i => i.active)" :key="item.id">{{ item }}</div>
 --- OUTPUT ---
@@ -357,10 +344,9 @@ export function render(_ctx, _cache) {
     }, _toDisplayString(item), 1 /* TEXT */))
   }), 128 /* KEYED_FRAGMENT */))
 }
-
 ===
 name: v-for with nested property
-options: default
+options: vdom
 --- INPUT ---
 <div v-for="item in state.list.items" :key="item.id">{{ item }}</div>
 --- OUTPUT ---
@@ -371,5 +357,33 @@ export function render(_ctx, _cache) {
     return (_openBlock(), _createElementBlock("div", {
       key: item.id
     }, _toDisplayString(item), 1 /* TEXT */))
+  }), 128 /* KEYED_FRAGMENT */))
+}
+===
+name: v-for over object keys
+options: vdom
+--- INPUT ---
+<div v-for="key in Object.keys(obj)" :key="key">{{ key }}</div>
+--- OUTPUT ---
+import { renderList as _renderList, Fragment as _Fragment, openBlock as _openBlock, createElementBlock as _createElementBlock, toDisplayString as _toDisplayString } from "vue"
+
+export function render(_ctx, _cache) {
+  return (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(Object.keys(_ctx.obj), (key) => {
+    return (_openBlock(), _createElementBlock("div", { key: key }, _toDisplayString(key), 1 /* TEXT */))
+  }), 128 /* KEYED_FRAGMENT */))
+}
+===
+name: v-for with optional chaining source
+options: vdom
+--- INPUT ---
+<div v-for="item in state.items?.list" :key="item.id">{{ item.name }}</div>
+--- OUTPUT ---
+import { renderList as _renderList, Fragment as _Fragment, openBlock as _openBlock, createElementBlock as _createElementBlock, toDisplayString as _toDisplayString } from "vue"
+
+export function render(_ctx, _cache) {
+  return (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(_ctx.state.items?.list, (item) => {
+    return (_openBlock(), _createElementBlock("div", {
+      key: item.id
+    }, _toDisplayString(item.name), 1 /* TEXT */))
   }), 128 /* KEYED_FRAGMENT */))
 }

--- a/tests/expected/vdom/v-if.snap
+++ b/tests/expected/vdom/v-if.snap
@@ -1,6 +1,6 @@
 ===
 name: simple v-if
-options: default
+options: vdom
 --- INPUT ---
 <div v-if="show"></div>
 --- OUTPUT ---
@@ -11,10 +11,9 @@ export function render(_ctx, _cache) {
     ? (_openBlock(), _createElementBlock("div", { key: 0 }))
     : _createCommentVNode("v-if", true)
 }
-
 ===
 name: v-if with content
-options: default
+options: vdom
 --- INPUT ---
 <div v-if="show">content</div>
 --- OUTPUT ---
@@ -25,10 +24,9 @@ export function render(_ctx, _cache) {
     ? (_openBlock(), _createElementBlock("div", { key: 0 }, "content"))
     : _createCommentVNode("v-if", true)
 }
-
 ===
 name: v-if with interpolation
-options: default
+options: vdom
 --- INPUT ---
 <div v-if="show">{{ msg }}</div>
 --- OUTPUT ---
@@ -39,10 +37,9 @@ export function render(_ctx, _cache) {
     ? (_openBlock(), _createElementBlock("div", { key: 0 }, _toDisplayString(_ctx.msg), 1 /* TEXT */))
     : _createCommentVNode("v-if", true)
 }
-
 ===
 name: v-if on component
-options: default
+options: vdom
 --- INPUT ---
 <MyComponent v-if="show" />
 --- OUTPUT ---
@@ -55,10 +52,9 @@ export function render(_ctx, _cache) {
     ? (_openBlock(), _createBlock(_component_MyComponent, { key: 0 }))
     : _createCommentVNode("v-if", true)
 }
-
 ===
 name: v-if with v-else
-options: default
+options: vdom
 --- INPUT ---
 <div v-if="show">yes</div><div v-else>no</div>
 --- OUTPUT ---
@@ -69,10 +65,9 @@ export function render(_ctx, _cache) {
     ? (_openBlock(), _createElementBlock("div", { key: 0 }, "yes"))
     : (_openBlock(), _createElementBlock("div", { key: 1 }, "no"))
 }
-
 ===
 name: v-if/v-else on components
-options: default
+options: vdom
 --- INPUT ---
 <Foo v-if="show" /><Bar v-else />
 --- OUTPUT ---
@@ -86,10 +81,28 @@ export function render(_ctx, _cache) {
     ? (_openBlock(), _createBlock(_component_Foo, { key: 0 }))
     : (_openBlock(), _createBlock(_component_Bar, { key: 1 }))
 }
+===
+name: v-if/v-else-if on components
+options: vdom
+--- INPUT ---
+<Foo v-if="a" /><Bar v-else-if="b" /><Baz v-else />
+--- OUTPUT ---
+import { resolveComponent as _resolveComponent, openBlock as _openBlock, createBlock as _createBlock, createCommentVNode as _createCommentVNode } from "vue"
 
+export function render(_ctx, _cache) {
+  const _component_Foo = _resolveComponent("Foo")
+  const _component_Bar = _resolveComponent("Bar")
+  const _component_Baz = _resolveComponent("Baz")
+
+  return (_ctx.a)
+    ? (_openBlock(), _createBlock(_component_Foo, { key: 0 }))
+    : (_ctx.b)
+      ? (_openBlock(), _createBlock(_component_Bar, { key: 1 }))
+      : (_openBlock(), _createBlock(_component_Baz, { key: 2 }))
+}
 ===
 name: v-if/v-else same element
-options: default
+options: vdom
 --- INPUT ---
 <div v-if="show">A</div><div v-else>B</div>
 --- OUTPUT ---
@@ -100,10 +113,9 @@ export function render(_ctx, _cache) {
     ? (_openBlock(), _createElementBlock("div", { key: 0 }, "A"))
     : (_openBlock(), _createElementBlock("div", { key: 1 }, "B"))
 }
-
 ===
 name: v-if/v-else-if/v-else
-options: default
+options: vdom
 --- INPUT ---
 <div v-if="a">A</div><div v-else-if="b">B</div><div v-else>C</div>
 --- OUTPUT ---
@@ -116,10 +128,9 @@ export function render(_ctx, _cache) {
       ? (_openBlock(), _createElementBlock("div", { key: 1 }, "B"))
       : (_openBlock(), _createElementBlock("div", { key: 2 }, "C"))
 }
-
 ===
 name: multiple v-else-if
-options: default
+options: vdom
 --- INPUT ---
 <div v-if="a">A</div><div v-else-if="b">B</div><div v-else-if="c">C</div><div v-else>D</div>
 --- OUTPUT ---
@@ -134,10 +145,9 @@ export function render(_ctx, _cache) {
         ? (_openBlock(), _createElementBlock("div", { key: 2 }, "C"))
         : (_openBlock(), _createElementBlock("div", { key: 3 }, "D"))
 }
-
 ===
 name: v-else-if without v-else
-options: default
+options: vdom
 --- INPUT ---
 <div v-if="a">A</div><div v-else-if="b">B</div>
 --- OUTPUT ---
@@ -150,10 +160,9 @@ export function render(_ctx, _cache) {
       ? (_openBlock(), _createElementBlock("div", { key: 1 }, "B"))
       : _createCommentVNode("v-if", true)
 }
-
 ===
 name: v-if on template
-options: default
+options: vdom
 --- INPUT ---
 <template v-if="show"><div>A</div><div>B</div></template>
 --- OUTPUT ---
@@ -167,10 +176,9 @@ export function render(_ctx, _cache) {
       ], 64 /* STABLE_FRAGMENT */))
     : _createCommentVNode("v-if", true)
 }
-
 ===
 name: v-if/v-else on template
-options: default
+options: vdom
 --- INPUT ---
 <template v-if="show"><div>yes</div></template><template v-else><div>no</div></template>
 --- OUTPUT ---
@@ -181,10 +189,9 @@ export function render(_ctx, _cache) {
     ? (_openBlock(), _createElementBlock("div", { key: 0 }, "yes"))
     : (_openBlock(), _createElementBlock("div", { key: 1 }, "no"))
 }
-
 ===
 name: v-if on template with multiple children
-options: default
+options: vdom
 --- INPUT ---
 <template v-if="show"><span>1</span><span>2</span><span>3</span></template>
 --- OUTPUT ---
@@ -199,10 +206,9 @@ export function render(_ctx, _cache) {
       ], 64 /* STABLE_FRAGMENT */))
     : _createCommentVNode("v-if", true)
 }
-
 ===
 name: nested v-if
-options: default
+options: vdom
 --- INPUT ---
 <div v-if="a"><span v-if="b">nested</span></div>
 --- OUTPUT ---
@@ -217,10 +223,26 @@ export function render(_ctx, _cache) {
       ]))
     : _createCommentVNode("v-if", true)
 }
+===
+name: nested v-if with else
+options: vdom
+--- INPUT ---
+<div v-if="a"><span v-if="b">B</span><span v-else>C</span></div>
+--- OUTPUT ---
+import { openBlock as _openBlock, createElementBlock as _createElementBlock, createCommentVNode as _createCommentVNode } from "vue"
 
+export function render(_ctx, _cache) {
+  return (_ctx.a)
+    ? (_openBlock(), _createElementBlock("div", { key: 0 }, [
+        (_ctx.b)
+          ? (_openBlock(), _createElementBlock("span", { key: 0 }, "B"))
+          : (_openBlock(), _createElementBlock("span", { key: 1 }, "C"))
+      ]))
+    : _createCommentVNode("v-if", true)
+}
 ===
 name: v-if inside v-for
-options: default
+options: vdom
 --- INPUT ---
 <div v-for="item in items" :key="item.id"><span v-if="item.show">{{ item.name }}</span></div>
 --- OUTPUT ---
@@ -237,10 +259,9 @@ export function render(_ctx, _cache) {
     ]))
   }), 128 /* KEYED_FRAGMENT */))
 }
-
 ===
 name: v-if with key
-options: default
+options: vdom
 --- INPUT ---
 <div v-if="show" key="a">A</div><div v-else key="b">B</div>
 --- OUTPUT ---
@@ -251,10 +272,9 @@ export function render(_ctx, _cache) {
     ? (_openBlock(), _createElementBlock("div", { key: "a" }, "A"))
     : (_openBlock(), _createElementBlock("div", { key: "b" }, "B"))
 }
-
 ===
 name: v-if with dynamic key
-options: default
+options: vdom
 --- INPUT ---
 <div v-if="show" :key="keyA">A</div><div v-else :key="keyB">B</div>
 --- OUTPUT ---
@@ -265,10 +285,9 @@ export function render(_ctx, _cache) {
     ? (_openBlock(), _createElementBlock("div", { key: _ctx.keyA }, "A"))
     : (_openBlock(), _createElementBlock("div", { key: _ctx.keyB }, "B"))
 }
-
 ===
 name: v-if with logical expression
-options: default
+options: vdom
 --- INPUT ---
 <div v-if="a && b">both</div>
 --- OUTPUT ---
@@ -279,10 +298,9 @@ export function render(_ctx, _cache) {
     ? (_openBlock(), _createElementBlock("div", { key: 0 }, "both"))
     : _createCommentVNode("v-if", true)
 }
-
 ===
 name: v-if with comparison
-options: default
+options: vdom
 --- INPUT ---
 <div v-if="count > 0">positive</div>
 --- OUTPUT ---
@@ -293,10 +311,9 @@ export function render(_ctx, _cache) {
     ? (_openBlock(), _createElementBlock("div", { key: 0 }, "positive"))
     : _createCommentVNode("v-if", true)
 }
-
 ===
 name: v-if with ternary in content
-options: default
+options: vdom
 --- INPUT ---
 <div v-if="show">{{ ok ? "yes" : "no" }}</div>
 --- OUTPUT ---
@@ -307,10 +324,9 @@ export function render(_ctx, _cache) {
     ? (_openBlock(), _createElementBlock("div", { key: 0 }, _toDisplayString(_ctx.ok ? "yes" : "no"), 1 /* TEXT */))
     : _createCommentVNode("v-if", true)
 }
-
 ===
 name: v-if with method call
-options: default
+options: vdom
 --- INPUT ---
 <div v-if="isValid()">valid</div>
 --- OUTPUT ---
@@ -321,10 +337,9 @@ export function render(_ctx, _cache) {
     ? (_openBlock(), _createElementBlock("div", { key: 0 }, "valid"))
     : _createCommentVNode("v-if", true)
 }
-
 ===
 name: v-if with negation
-options: default
+options: vdom
 --- INPUT ---
 <div v-if="!hidden">visible</div>
 --- OUTPUT ---
@@ -333,5 +348,18 @@ import { openBlock as _openBlock, createElementBlock as _createElementBlock, cre
 export function render(_ctx, _cache) {
   return (!_ctx.hidden)
     ? (_openBlock(), _createElementBlock("div", { key: 0 }, "visible"))
+    : _createCommentVNode("v-if", true)
+}
+===
+name: v-if with optional chaining
+options: vdom
+--- INPUT ---
+<div v-if="user?.profile">{{ user.profile.name }}</div>
+--- OUTPUT ---
+import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock, createCommentVNode as _createCommentVNode } from "vue"
+
+export function render(_ctx, _cache) {
+  return (_ctx.user?.profile)
+    ? (_openBlock(), _createElementBlock("div", { key: 0 }, _toDisplayString(_ctx.user.profile.name), 1 /* TEXT */))
     : _createCommentVNode("v-if", true)
 }

--- a/tests/expected/vdom/v-on.snap
+++ b/tests/expected/vdom/v-on.snap
@@ -1,6 +1,6 @@
 ===
 name: v-on handler
-options: default
+options: vdom
 --- INPUT ---
 <button v-on:click="handler"></button>
 --- OUTPUT ---
@@ -9,10 +9,9 @@ import { openBlock as _openBlock, createElementBlock as _createElementBlock } fr
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("button", { onClick: _ctx.handler }, null, 8 /* PROPS */, ["onClick"]))
 }
-
 ===
 name: v-on shorthand
-options: default
+options: vdom
 --- INPUT ---
 <button @click="handler"></button>
 --- OUTPUT ---
@@ -21,10 +20,9 @@ import { openBlock as _openBlock, createElementBlock as _createElementBlock } fr
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("button", { onClick: _ctx.handler }, null, 8 /* PROPS */, ["onClick"]))
 }
-
 ===
 name: inline handler
-options: default
+options: vdom
 --- INPUT ---
 <button @click="count++"></button>
 --- OUTPUT ---
@@ -35,10 +33,9 @@ export function render(_ctx, _cache) {
     onClick: $event => (_ctx.count++)
   }, null, 8 /* PROPS */, ["onClick"]))
 }
-
 ===
 name: inline with statement
-options: default
+options: vdom
 --- INPUT ---
 <button @click="count = count + 1"></button>
 --- OUTPUT ---
@@ -49,10 +46,9 @@ export function render(_ctx, _cache) {
     onClick: $event => (_ctx.count = _ctx.count + 1)
   }, null, 8 /* PROPS */, ["onClick"]))
 }
-
 ===
 name: method call
-options: default
+options: vdom
 --- INPUT ---
 <button @click="handler()"></button>
 --- OUTPUT ---
@@ -63,10 +59,9 @@ export function render(_ctx, _cache) {
     onClick: $event => (_ctx.handler())
   }, null, 8 /* PROPS */, ["onClick"]))
 }
-
 ===
 name: method with args
-options: default
+options: vdom
 --- INPUT ---
 <button @click="handler(1, 2)"></button>
 --- OUTPUT ---
@@ -77,10 +72,22 @@ export function render(_ctx, _cache) {
     onClick: $event => (_ctx.handler(1, 2))
   }, null, 8 /* PROPS */, ["onClick"]))
 }
+===
+name: sequence expression handler
+options: vdom
+--- INPUT ---
+<button @click="foo(), bar()"></button>
+--- OUTPUT ---
+import { openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 
+export function render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("button", {
+    onClick: $event => (_ctx.foo(), _ctx.bar())
+  }, null, 8 /* PROPS */, ["onClick"]))
+}
 ===
 name: inline with $event
-options: default
+options: vdom
 --- INPUT ---
 <button @click="handler($event)"></button>
 --- OUTPUT ---
@@ -91,10 +98,9 @@ export function render(_ctx, _cache) {
     onClick: $event => (_ctx.handler($event))
   }, null, 8 /* PROPS */, ["onClick"]))
 }
-
 ===
 name: inline $event property
-options: default
+options: vdom
 --- INPUT ---
 <button @click="handler($event.target.value)"></button>
 --- OUTPUT ---
@@ -105,10 +111,9 @@ export function render(_ctx, _cache) {
     onClick: $event => (_ctx.handler($event.target.value))
   }, null, 8 /* PROPS */, ["onClick"]))
 }
-
 ===
 name: arrow function with event
-options: default
+options: vdom
 --- INPUT ---
 <button @click="e => handler(e)"></button>
 --- OUTPUT ---
@@ -119,10 +124,9 @@ export function render(_ctx, _cache) {
     onClick: e => _ctx.handler(e)
   }, null, 8 /* PROPS */, ["onClick"]))
 }
-
 ===
 name: arrow function with multiple params
-options: default
+options: vdom
 --- INPUT ---
 <div @custom="(a, b) => handler(a, b)"></div>
 --- OUTPUT ---
@@ -133,10 +137,22 @@ export function render(_ctx, _cache) {
     onCustom: (a, b) => _ctx.handler(a, b)
   }, null, 40 /* PROPS, NEED_HYDRATION */, ["onCustom"]))
 }
+===
+name: optional chaining call
+options: vdom
+--- INPUT ---
+<button @click="props.onClick?.($event)"></button>
+--- OUTPUT ---
+import { openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 
+export function render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("button", {
+    onClick: $event => (_ctx.props.onClick?.($event))
+  }, null, 8 /* PROPS */, ["onClick"]))
+}
 ===
 name: stop modifier
-options: default
+options: vdom
 --- INPUT ---
 <button @click.stop="handler"></button>
 --- OUTPUT ---
@@ -147,10 +163,9 @@ export function render(_ctx, _cache) {
     onClick: _withModifiers(_ctx.handler, ["stop"])
   }, null, 8 /* PROPS */, ["onClick"]))
 }
-
 ===
 name: prevent modifier
-options: default
+options: vdom
 --- INPUT ---
 <form @submit.prevent="onSubmit"></form>
 --- OUTPUT ---
@@ -161,10 +176,9 @@ export function render(_ctx, _cache) {
     onSubmit: _withModifiers(_ctx.onSubmit, ["prevent"])
   }, null, 40 /* PROPS, NEED_HYDRATION */, ["onSubmit"]))
 }
-
 ===
 name: stop and prevent
-options: default
+options: vdom
 --- INPUT ---
 <button @click.stop.prevent="handler"></button>
 --- OUTPUT ---
@@ -175,10 +189,9 @@ export function render(_ctx, _cache) {
     onClick: _withModifiers(_ctx.handler, ["stop","prevent"])
   }, null, 8 /* PROPS */, ["onClick"]))
 }
-
 ===
 name: capture modifier
-options: default
+options: vdom
 --- INPUT ---
 <div @click.capture="handler"></div>
 --- OUTPUT ---
@@ -187,10 +200,9 @@ import { openBlock as _openBlock, createElementBlock as _createElementBlock } fr
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("div", { onClickCapture: _ctx.handler }, null, 40 /* PROPS, NEED_HYDRATION */, ["onClickCapture"]))
 }
-
 ===
 name: once modifier
-options: default
+options: vdom
 --- INPUT ---
 <button @click.once="handler"></button>
 --- OUTPUT ---
@@ -199,10 +211,9 @@ import { openBlock as _openBlock, createElementBlock as _createElementBlock } fr
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("button", { onClickOnce: _ctx.handler }, null, 40 /* PROPS, NEED_HYDRATION */, ["onClickOnce"]))
 }
-
 ===
 name: passive modifier
-options: default
+options: vdom
 --- INPUT ---
 <div @scroll.passive="onScroll"></div>
 --- OUTPUT ---
@@ -211,10 +222,9 @@ import { openBlock as _openBlock, createElementBlock as _createElementBlock } fr
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("div", { onScrollPassive: _ctx.onScroll }, null, 40 /* PROPS, NEED_HYDRATION */, ["onScrollPassive"]))
 }
-
 ===
 name: self modifier
-options: default
+options: vdom
 --- INPUT ---
 <div @click.self="handler"></div>
 --- OUTPUT ---
@@ -225,10 +235,9 @@ export function render(_ctx, _cache) {
     onClick: _withModifiers(_ctx.handler, ["self"])
   }, null, 8 /* PROPS */, ["onClick"]))
 }
-
 ===
 name: enter key
-options: default
+options: vdom
 --- INPUT ---
 <input @keyup.enter="submit">
 --- OUTPUT ---
@@ -239,10 +248,9 @@ export function render(_ctx, _cache) {
     onKeyup: _withKeys(_ctx.submit, ["enter"])
   }, null, 40 /* PROPS, NEED_HYDRATION */, ["onKeyup"]))
 }
-
 ===
 name: escape key
-options: default
+options: vdom
 --- INPUT ---
 <input @keyup.esc="cancel">
 --- OUTPUT ---
@@ -253,10 +261,22 @@ export function render(_ctx, _cache) {
     onKeyup: _withKeys(_ctx.cancel, ["esc"])
   }, null, 40 /* PROPS, NEED_HYDRATION */, ["onKeyup"]))
 }
+===
+name: page down key
+options: vdom
+--- INPUT ---
+<input @keyup.page-down="next">
+--- OUTPUT ---
+import { withKeys as _withKeys, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 
+export function render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("input", {
+    onKeyup: _withKeys(_ctx.next, ["page-down"])
+  }, null, 40 /* PROPS, NEED_HYDRATION */, ["onKeyup"]))
+}
 ===
 name: tab key
-options: default
+options: vdom
 --- INPUT ---
 <input @keyup.tab="next">
 --- OUTPUT ---
@@ -267,10 +287,9 @@ export function render(_ctx, _cache) {
     onKeyup: _withKeys(_ctx.next, ["tab"])
   }, null, 40 /* PROPS, NEED_HYDRATION */, ["onKeyup"]))
 }
-
 ===
 name: delete key
-options: default
+options: vdom
 --- INPUT ---
 <input @keyup.delete="remove">
 --- OUTPUT ---
@@ -281,10 +300,9 @@ export function render(_ctx, _cache) {
     onKeyup: _withKeys(_ctx.remove, ["delete"])
   }, null, 40 /* PROPS, NEED_HYDRATION */, ["onKeyup"]))
 }
-
 ===
 name: arrow keys
-options: default
+options: vdom
 --- INPUT ---
 <input @keyup.up="up" @keyup.down="down" @keyup.left="left" @keyup.right="right">
 --- OUTPUT ---
@@ -300,10 +318,9 @@ export function render(_ctx, _cache) {
     ]
   }, null, 40 /* PROPS, NEED_HYDRATION */, ["onKeyup"]))
 }
-
 ===
 name: key code
-options: default
+options: vdom
 --- INPUT ---
 <input @keyup.13="submit">
 --- OUTPUT ---
@@ -314,10 +331,9 @@ export function render(_ctx, _cache) {
     onKeyup: _withKeys(_ctx.submit, ["13"])
   }, null, 40 /* PROPS, NEED_HYDRATION */, ["onKeyup"]))
 }
-
 ===
 name: ctrl modifier
-options: default
+options: vdom
 --- INPUT ---
 <input @keyup.ctrl.enter="submit">
 --- OUTPUT ---
@@ -328,10 +344,9 @@ export function render(_ctx, _cache) {
     onKeyup: _withKeys(_withModifiers(_ctx.submit, ["ctrl"]), ["enter"])
   }, null, 40 /* PROPS, NEED_HYDRATION */, ["onKeyup"]))
 }
-
 ===
 name: alt modifier
-options: default
+options: vdom
 --- INPUT ---
 <button @click.alt="handler"></button>
 --- OUTPUT ---
@@ -342,10 +357,9 @@ export function render(_ctx, _cache) {
     onClick: _withModifiers(_ctx.handler, ["alt"])
   }, null, 8 /* PROPS */, ["onClick"]))
 }
-
 ===
 name: shift modifier
-options: default
+options: vdom
 --- INPUT ---
 <button @click.shift="handler"></button>
 --- OUTPUT ---
@@ -356,10 +370,9 @@ export function render(_ctx, _cache) {
     onClick: _withModifiers(_ctx.handler, ["shift"])
   }, null, 8 /* PROPS */, ["onClick"]))
 }
-
 ===
 name: meta modifier
-options: default
+options: vdom
 --- INPUT ---
 <button @click.meta="handler"></button>
 --- OUTPUT ---
@@ -370,10 +383,9 @@ export function render(_ctx, _cache) {
     onClick: _withModifiers(_ctx.handler, ["meta"])
   }, null, 8 /* PROPS */, ["onClick"]))
 }
-
 ===
 name: exact modifier
-options: default
+options: vdom
 --- INPUT ---
 <button @click.ctrl.exact="handler"></button>
 --- OUTPUT ---
@@ -384,10 +396,9 @@ export function render(_ctx, _cache) {
     onClick: _withModifiers(_ctx.handler, ["ctrl","exact"])
   }, null, 8 /* PROPS */, ["onClick"]))
 }
-
 ===
 name: left click
-options: default
+options: vdom
 --- INPUT ---
 <button @click.left="handler"></button>
 --- OUTPUT ---
@@ -398,10 +409,9 @@ export function render(_ctx, _cache) {
     onClick: _withModifiers(_ctx.handler, ["left"])
   }, null, 8 /* PROPS */, ["onClick"]))
 }
-
 ===
 name: right click
-options: default
+options: vdom
 --- INPUT ---
 <button @click.right="handler"></button>
 --- OUTPUT ---
@@ -412,10 +422,9 @@ export function render(_ctx, _cache) {
     onContextmenu: _withModifiers(_ctx.handler, ["right"])
   }, null, 40 /* PROPS, NEED_HYDRATION */, ["onContextmenu"]))
 }
-
 ===
 name: middle click
-options: default
+options: vdom
 --- INPUT ---
 <button @click.middle="handler"></button>
 --- OUTPUT ---
@@ -426,10 +435,9 @@ export function render(_ctx, _cache) {
     onMouseup: _withModifiers(_ctx.handler, ["middle"])
   }, null, 40 /* PROPS, NEED_HYDRATION */, ["onMouseup"]))
 }
-
 ===
 name: multiple events
-options: default
+options: vdom
 --- INPUT ---
 <input @focus="onFocus" @blur="onBlur">
 --- OUTPUT ---
@@ -441,10 +449,9 @@ export function render(_ctx, _cache) {
     onBlur: _ctx.onBlur
   }, null, 40 /* PROPS, NEED_HYDRATION */, ["onFocus", "onBlur"]))
 }
-
 ===
 name: same event different modifiers
-options: default
+options: vdom
 --- INPUT ---
 <button @click="a" @click.ctrl="b"></button>
 --- OUTPUT ---
@@ -458,10 +465,9 @@ export function render(_ctx, _cache) {
     ]
   }, null, 8 /* PROPS */, ["onClick"]))
 }
-
 ===
 name: dynamic event name
-options: default
+options: vdom
 --- INPUT ---
 <button @[event]="handler"></button>
 --- OUTPUT ---
@@ -470,10 +476,9 @@ import { toHandlerKey as _toHandlerKey, openBlock as _openBlock, createElementBl
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("button", { [_toHandlerKey(_ctx.event)]: _ctx.handler }, null, 16 /* FULL_PROPS */))
 }
-
 ===
 name: dynamic event with modifier
-options: default
+options: vdom
 --- INPUT ---
 <button @[event].stop="handler"></button>
 --- OUTPUT ---
@@ -484,10 +489,9 @@ export function render(_ctx, _cache) {
     [_toHandlerKey(_ctx.event)]: _withModifiers(_ctx.handler, ["stop"])
   }, null, 16 /* FULL_PROPS */))
 }
-
 ===
 name: v-on object
-options: default
+options: vdom
 --- INPUT ---
 <button v-on="handlers"></button>
 --- OUTPUT ---
@@ -496,10 +500,9 @@ import { toHandlers as _toHandlers, openBlock as _openBlock, createElementBlock 
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("button", _toHandlers(_ctx.handlers, true), null, 16 /* FULL_PROPS */))
 }
-
 ===
 name: v-on object with other events
-options: default
+options: vdom
 --- INPUT ---
 <button v-on="handlers" @click="extra"></button>
 --- OUTPUT ---
@@ -508,10 +511,9 @@ import { toHandlers as _toHandlers, mergeProps as _mergeProps, openBlock as _ope
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("button", _mergeProps(_toHandlers(_ctx.handlers, true), { onClick: _ctx.extra }), null, 16 /* FULL_PROPS */, ["onClick"]))
 }
-
 ===
 name: component event
-options: default
+options: vdom
 --- INPUT ---
 <MyComponent @update="onUpdate" />
 --- OUTPUT ---
@@ -522,10 +524,9 @@ export function render(_ctx, _cache) {
 
   return (_openBlock(), _createBlock(_component_MyComponent, { onUpdate: _ctx.onUpdate }, null, 8 /* PROPS */, ["onUpdate"]))
 }
-
 ===
 name: component native event
-options: default
+options: vdom
 --- INPUT ---
 <MyComponent @click.native="onClick" />
 --- OUTPUT ---
@@ -536,10 +537,9 @@ export function render(_ctx, _cache) {
 
   return (_openBlock(), _createBlock(_component_MyComponent, { onClick: _ctx.onClick }, null, 8 /* PROPS */, ["onClick"]))
 }
-
 ===
 name: inline handler (cacheHandlers)
-options: cacheHandlers
+options: vdom
 --- INPUT ---
 <button @click="count++"></button>
 --- OUTPUT ---
@@ -550,10 +550,9 @@ export function render(_ctx, _cache) {
     onClick: _cache[0] || (_cache[0] = $event => (_ctx.count++))
   }))
 }
-
 ===
 name: inline statement (cacheHandlers)
-options: cacheHandlers
+options: vdom
 --- INPUT ---
 <button @click="count = count + 1"></button>
 --- OUTPUT ---
@@ -564,10 +563,9 @@ export function render(_ctx, _cache) {
     onClick: _cache[0] || (_cache[0] = $event => (_ctx.count = _ctx.count + 1))
   }))
 }
-
 ===
 name: method call (cacheHandlers)
-options: cacheHandlers
+options: vdom
 --- INPUT ---
 <button @click="handler()"></button>
 --- OUTPUT ---
@@ -578,10 +576,9 @@ export function render(_ctx, _cache) {
     onClick: _cache[0] || (_cache[0] = $event => (_ctx.handler()))
   }))
 }
-
 ===
 name: handler reference (cacheHandlers)
-options: cacheHandlers
+options: vdom
 --- INPUT ---
 <button @click="handler"></button>
 --- OUTPUT ---
@@ -592,10 +589,9 @@ export function render(_ctx, _cache) {
     onClick: _cache[0] || (_cache[0] = (...args) => (_ctx.handler && _ctx.handler(...args)))
   }))
 }
-
 ===
 name: multiple cached handlers
-options: cacheHandlers
+options: vdom
 --- INPUT ---
 <button @click="count++" @mouseenter="hover = true"></button>
 --- OUTPUT ---

--- a/tests/expected/vdom/v-once.snap
+++ b/tests/expected/vdom/v-once.snap
@@ -1,6 +1,6 @@
 ===
 name: simple v-once
-options: default
+options: vdom
 --- INPUT ---
 <div v-once>static</div>
 --- OUTPUT ---
@@ -16,10 +16,9 @@ export function render(_ctx, _cache) {
     _cache[0]
   )
 }
-
 ===
 name: v-once with interpolation
-options: default
+options: vdom
 --- INPUT ---
 <div v-once>{{ msg }}</div>
 --- OUTPUT ---
@@ -35,10 +34,9 @@ export function render(_ctx, _cache) {
     _cache[0]
   )
 }
-
 ===
 name: v-once with binding
-options: default
+options: vdom
 --- INPUT ---
 <div v-once :class="cls">content</div>
 --- OUTPUT ---
@@ -56,10 +54,9 @@ export function render(_ctx, _cache) {
     _cache[0]
   )
 }
-
 ===
 name: v-once on component
-options: default
+options: vdom
 --- INPUT ---
 <MyComponent v-once />
 --- OUTPUT ---
@@ -75,10 +72,9 @@ export function render(_ctx, _cache) {
     _cache[0]
   )
 }
-
 ===
 name: v-once on template
-options: default
+options: vdom
 --- INPUT ---
 <template v-once><div>A</div><div>B</div></template>
 --- OUTPUT ---
@@ -95,10 +91,9 @@ export function render(_ctx, _cache) {
     _cache[0]
   )
 }
-
 ===
 name: v-once with nested dynamic
-options: default
+options: vdom
 --- INPUT ---
 <div v-once><span :class="cls">{{ msg }}</span></div>
 --- OUTPUT ---
@@ -116,10 +111,9 @@ export function render(_ctx, _cache) {
     _cache[0]
   )
 }
-
 ===
 name: v-once inside v-for
-options: default
+options: vdom
 --- INPUT ---
 <div v-for="item in items" :key="item.id"><span v-once>{{ item.static }}</span></div>
 --- OUTPUT ---
@@ -141,10 +135,9 @@ export function render(_ctx, _cache) {
     ]))
   }), 128 /* KEYED_FRAGMENT */))
 }
-
 ===
 name: basic v-memo
-options: default
+options: vdom
 --- INPUT ---
 <div v-memo="[value]">{{ computed }}</div>
 --- OUTPUT ---
@@ -155,10 +148,9 @@ export function render(_ctx, _cache) {
     _createTextVNode(_toDisplayString(_ctx.computed), 1 /* TEXT */)
   ])), _cache, 0)
 }
-
 ===
 name: v-memo multiple deps
-options: default
+options: vdom
 --- INPUT ---
 <div v-memo="[a, b, c]">{{ result }}</div>
 --- OUTPUT ---
@@ -169,10 +161,9 @@ export function render(_ctx, _cache) {
     _createTextVNode(_toDisplayString(_ctx.result), 1 /* TEXT */)
   ])), _cache, 0)
 }
-
 ===
 name: v-memo empty array
-options: default
+options: vdom
 --- INPUT ---
 <div v-memo="[]">static</div>
 --- OUTPUT ---
@@ -183,10 +174,9 @@ export function render(_ctx, _cache) {
     _createTextVNode("static")
   ])), _cache, 0)
 }
-
 ===
 name: v-memo on component
-options: default
+options: vdom
 --- INPUT ---
 <MyComponent v-memo="[prop]" :prop="prop" />
 --- OUTPUT ---
@@ -197,10 +187,9 @@ export function render(_ctx, _cache) {
 
   return _withMemo([_ctx.prop], () => _createVNode(_component_MyComponent, { prop: _ctx.prop }, null, 8 /* PROPS */, ["prop"]), _cache, 0)
 }
-
 ===
 name: v-memo in v-for
-options: default
+options: vdom
 --- INPUT ---
 <div v-for="item in items" :key="item.id" v-memo="[item.selected]">{{ item.name }}</div>
 --- OUTPUT ---
@@ -219,10 +208,9 @@ export function render(_ctx, _cache) {
     return _item
   }, _cache, 0), 128 /* KEYED_FRAGMENT */))
 }
-
 ===
 name: v-memo with complex expression
-options: default
+options: vdom
 --- INPUT ---
 <div v-for="item in items" :key="item.id" v-memo="[item.id === selected]">{{ item.name }}</div>
 --- OUTPUT ---
@@ -241,10 +229,22 @@ export function render(_ctx, _cache) {
     return _item
   }, _cache, 0), 128 /* KEYED_FRAGMENT */))
 }
+===
+name: v-memo with optional chaining
+options: vdom
+--- INPUT ---
+<div v-memo="[item?.id]">{{ item?.name }}</div>
+--- OUTPUT ---
+import { toDisplayString as _toDisplayString, createTextVNode as _createTextVNode, openBlock as _openBlock, createElementBlock as _createElementBlock, withMemo as _withMemo } from "vue"
 
+export function render(_ctx, _cache) {
+  return _withMemo([_ctx.item?.id], () => (_openBlock(), _createElementBlock("div", null, [
+    _createTextVNode(_toDisplayString(_ctx.item?.name), 1 /* TEXT */)
+  ])), _cache, 0)
+}
 ===
 name: v-memo on template
-options: default
+options: vdom
 --- INPUT ---
 <template v-memo="[value]"><div>A</div><div>B</div></template>
 --- OUTPUT ---

--- a/tests/expected/vdom/v-show.snap
+++ b/tests/expected/vdom/v-show.snap
@@ -1,6 +1,6 @@
 ===
 name: simple v-show
-options: default
+options: vdom
 --- INPUT ---
 <div v-show="visible"></div>
 --- OUTPUT ---
@@ -11,10 +11,9 @@ export function render(_ctx, _cache) {
     [_vShow, _ctx.visible]
   ])
 }
-
 ===
 name: v-show with content
-options: default
+options: vdom
 --- INPUT ---
 <div v-show="visible">content</div>
 --- OUTPUT ---
@@ -25,10 +24,9 @@ export function render(_ctx, _cache) {
     [_vShow, _ctx.visible]
   ])
 }
-
 ===
 name: v-show false
-options: default
+options: vdom
 --- INPUT ---
 <div v-show="false">hidden</div>
 --- OUTPUT ---
@@ -39,10 +37,9 @@ export function render(_ctx, _cache) {
     [_vShow, false]
   ])
 }
-
 ===
 name: v-show true
-options: default
+options: vdom
 --- INPUT ---
 <div v-show="true">visible</div>
 --- OUTPUT ---
@@ -53,10 +50,9 @@ export function render(_ctx, _cache) {
     [_vShow, true]
   ])
 }
-
 ===
 name: v-show on span
-options: default
+options: vdom
 --- INPUT ---
 <span v-show="visible">text</span>
 --- OUTPUT ---
@@ -67,10 +63,9 @@ export function render(_ctx, _cache) {
     [_vShow, _ctx.visible]
   ])
 }
-
 ===
 name: v-show on input
-options: default
+options: vdom
 --- INPUT ---
 <input v-show="visible">
 --- OUTPUT ---
@@ -81,10 +76,9 @@ export function render(_ctx, _cache) {
     [_vShow, _ctx.visible]
   ])
 }
-
 ===
 name: v-show on component
-options: default
+options: vdom
 --- INPUT ---
 <MyComponent v-show="visible" />
 --- OUTPUT ---
@@ -97,10 +91,9 @@ export function render(_ctx, _cache) {
     [_vShow, _ctx.visible]
   ])
 }
-
 ===
 name: v-show with comparison
-options: default
+options: vdom
 --- INPUT ---
 <div v-show="count > 0">positive</div>
 --- OUTPUT ---
@@ -111,10 +104,9 @@ export function render(_ctx, _cache) {
     [_vShow, _ctx.count > 0]
   ])
 }
-
 ===
 name: v-show with logical and
-options: default
+options: vdom
 --- INPUT ---
 <div v-show="a && b">both</div>
 --- OUTPUT ---
@@ -125,10 +117,9 @@ export function render(_ctx, _cache) {
     [_vShow, _ctx.a && _ctx.b]
   ])
 }
-
 ===
 name: v-show with logical or
-options: default
+options: vdom
 --- INPUT ---
 <div v-show="a || b">either</div>
 --- OUTPUT ---
@@ -139,10 +130,9 @@ export function render(_ctx, _cache) {
     [_vShow, _ctx.a || _ctx.b]
   ])
 }
-
 ===
 name: v-show with negation
-options: default
+options: vdom
 --- INPUT ---
 <div v-show="!hidden">visible</div>
 --- OUTPUT ---
@@ -153,10 +143,9 @@ export function render(_ctx, _cache) {
     [_vShow, !_ctx.hidden]
   ])
 }
-
 ===
 name: v-show with method call
-options: default
+options: vdom
 --- INPUT ---
 <div v-show="isVisible()">content</div>
 --- OUTPUT ---
@@ -167,10 +156,22 @@ export function render(_ctx, _cache) {
     [_vShow, _ctx.isVisible()]
   ])
 }
+===
+name: v-show with optional chaining
+options: vdom
+--- INPUT ---
+<div v-show="user?.active">active</div>
+--- OUTPUT ---
+import { vShow as _vShow, withDirectives as _withDirectives, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 
+export function render(_ctx, _cache) {
+  return _withDirectives((_openBlock(), _createElementBlock("div", null, "active", 512 /* NEED_PATCH */)), [
+    [_vShow, _ctx.user?.active]
+  ])
+}
 ===
 name: v-show with v-for
-options: default
+options: vdom
 --- INPUT ---
 <div v-for="item in items" :key="item.id" v-show="item.visible">{{ item.name }}</div>
 --- OUTPUT ---
@@ -185,10 +186,9 @@ export function render(_ctx, _cache) {
     ])
   }), 128 /* KEYED_FRAGMENT */))
 }
-
 ===
 name: v-show with v-bind
-options: default
+options: vdom
 --- INPUT ---
 <div v-show="visible" :class="cls">content</div>
 --- OUTPUT ---
@@ -201,10 +201,9 @@ export function render(_ctx, _cache) {
     [_vShow, _ctx.visible]
   ])
 }
-
 ===
 name: v-show with v-on
-options: default
+options: vdom
 --- INPUT ---
 <button v-show="visible" @click="handler">Click</button>
 --- OUTPUT ---
@@ -215,10 +214,9 @@ export function render(_ctx, _cache) {
     [_vShow, _ctx.visible]
   ])
 }
-
 ===
 name: nested v-show
-options: default
+options: vdom
 --- INPUT ---
 <div v-show="outer"><span v-show="inner">nested</span></div>
 --- OUTPUT ---
@@ -233,10 +231,9 @@ export function render(_ctx, _cache) {
     [_vShow, _ctx.outer]
   ])
 }
-
 ===
 name: v-show with v-if sibling
-options: default
+options: vdom
 --- INPUT ---
 <div v-show="a">A</div><div v-if="b">B</div>
 --- OUTPUT ---
@@ -251,4 +248,21 @@ export function render(_ctx, _cache) {
       ? (_openBlock(), _createElementBlock("div", { key: 0 }, "B"))
       : _createCommentVNode("v-if", true)
   ], 64 /* STABLE_FRAGMENT */))
+}
+===
+name: v-show nested under v-if
+options: vdom
+--- INPUT ---
+<section v-if="ready"><div v-show="visible">content</div></section>
+--- OUTPUT ---
+import { vShow as _vShow, createElementVNode as _createElementVNode, withDirectives as _withDirectives, openBlock as _openBlock, createElementBlock as _createElementBlock, createCommentVNode as _createCommentVNode } from "vue"
+
+export function render(_ctx, _cache) {
+  return (_ctx.ready)
+    ? (_openBlock(), _createElementBlock("section", { key: 0 }, [
+        _withDirectives(_createElementVNode("div", null, "content", 512 /* NEED_PATCH */), [
+          [_vShow, _ctx.visible]
+        ])
+      ]))
+    : _createCommentVNode("v-if", true)
 }

--- a/tests/fixtures/sfc/basic.toml
+++ b/tests/fixtures/sfc/basic.toml
@@ -171,3 +171,18 @@ watch(count, (n) => console.log(n))
   <div>{{ double }}</div>
 </template>
 """
+
+[[cases]]
+name = "script setup function handler"
+input = """
+<script setup>
+const count = 0
+function onClick() {
+  console.log(count)
+}
+</script>
+
+<template>
+  <button @click="onClick">Click</button>
+</template>
+"""

--- a/tests/fixtures/vdom/component.toml
+++ b/tests/fixtures/vdom/component.toml
@@ -58,6 +58,14 @@ input = '<MyComponent v-bind="props" />'
 name = "v-bind object with extra props"
 input = '<MyComponent v-bind="props" :extra="value" />'
 
+[[cases]]
+name = "dynamic prop name"
+input = '<MyComponent :[prop]="value" />'
+
+[[cases]]
+name = "v-bind object with event"
+input = '<MyComponent v-bind="props" @update="onUpdate" />'
+
 # =============================================================================
 # Built-in components
 # =============================================================================
@@ -181,6 +189,10 @@ input = '<MyComponent @update="onUpdate" />'
 [[cases]]
 name = "component event with argument"
 input = '<MyComponent @update="onUpdate($event)" />'
+
+[[cases]]
+name = "component dynamic event name"
+input = '<MyComponent @[event]="handler" />'
 
 [[cases]]
 name = "component multiple events"

--- a/tests/fixtures/vdom/directives.toml
+++ b/tests/fixtures/vdom/directives.toml
@@ -22,6 +22,14 @@ input = "<div v-highlight=\"'yellow'\"></div>"
 name = "custom directive with object"
 input = '<div v-pin="{ top: 10, left: 20 }"></div>'
 
+[[cases]]
+name = "custom directive with array"
+input = '<div v-list="[one, two]"></div>'
+
+[[cases]]
+name = "custom directive with function call"
+input = '<div v-observe="createObserver(item)"></div>'
+
 # =============================================================================
 # Directive arguments
 # =============================================================================

--- a/tests/fixtures/vdom/element.toml
+++ b/tests/fixtures/vdom/element.toml
@@ -70,6 +70,18 @@ input = "<div><span></span><p></p></div>"
 name = "mixed children types"
 input = "<div>text<span>element</span>{{ interp }}</div>"
 
+[[cases]]
+name = "text around interpolation"
+input = "<div>Hello {{ name }}, count is {{ count }}</div>"
+
+[[cases]]
+name = "textarea with text"
+input = "<textarea>hello</textarea>"
+
+[[cases]]
+name = "template with text and element"
+input = "<template>hello<span>world</span></template>"
+
 # =============================================================================
 # Attributes
 # =============================================================================
@@ -85,6 +97,10 @@ input = '<div class="container"></div>'
 [[cases]]
 name = "multiple static attributes"
 input = '<div id="app" class="container"></div>'
+
+[[cases]]
+name = "static title attribute"
+input = '<div title="hello world"></div>'
 
 [[cases]]
 name = "data attribute"
@@ -154,6 +170,14 @@ input = '<svg viewBox="0 0 100 100"><circle cx="50" cy="50" r="40"/></svg>'
 name = "svg with namespace"
 input = '<svg xmlns="http://www.w3.org/2000/svg"><rect width="100" height="100"/></svg>'
 
+[[cases]]
+name = "svg path element"
+input = '<svg viewBox="0 0 10 10"><path d="M0 0h10v10z"></path></svg>'
+
+[[cases]]
+name = "math element"
+input = "<math><mi>x</mi></math>"
+
 # =============================================================================
 # Comments
 # =============================================================================
@@ -165,3 +189,7 @@ input = "<div><!-- comment --></div>"
 [[cases]]
 name = "comment between elements"
 input = "<div><span></span><!-- between --><p></p></div>"
+
+[[cases]]
+name = "root comment between elements"
+input = "<span>one</span><!-- between --><span>two</span>"

--- a/tests/fixtures/vdom/patch-flags.toml
+++ b/tests/fixtures/vdom/patch-flags.toml
@@ -87,6 +87,14 @@ name = "event handler"
 input = '<button @click="handler">click</button>'
 
 [[cases]]
+name = "event handler with dynamic text"
+input = '<button @click="handler">{{ label }}</button>'
+
+[[cases]]
+name = "event handler with dynamic class"
+input = '<button :class="cls" @click="handler">click</button>'
+
+[[cases]]
 name = "ref"
 input = '<div ref="el"></div>'
 

--- a/tests/fixtures/vdom/v-bind.toml
+++ b/tests/fixtures/vdom/v-bind.toml
@@ -50,6 +50,10 @@ input = '<div class="static" :class="dynamic"></div>'
 name = "class ternary"
 input = "<div :class=\"isActive ? 'active' : 'inactive'\"></div>"
 
+[[cases]]
+name = "class array with conditional"
+input = '<div :class="[base, isActive && active]"></div>'
+
 # =============================================================================
 # Style bindings
 # =============================================================================
@@ -101,6 +105,18 @@ input = '<div v-bind="$attrs"></div>'
 [[cases]]
 name = "v-bind $props"
 input = '<MyComponent v-bind="$props" />'
+
+[[cases]]
+name = "aria attribute binding"
+input = '<button :aria-expanded="isOpen"></button>'
+
+[[cases]]
+name = "data attribute expression"
+input = '<div :data-count="items.length"></div>'
+
+[[cases]]
+name = "optional chaining binding"
+input = '<div :title="user?.name"></div>'
 
 # =============================================================================
 # Dynamic attribute name

--- a/tests/fixtures/vdom/v-for.toml
+++ b/tests/fixtures/vdom/v-for.toml
@@ -54,6 +54,10 @@ input = '<template v-for="item in items" :key="item.id"><div>{{ item.a }}</div><
 name = "v-for on template with nested"
 input = '<template v-for="item in items" :key="item.id"><span>{{ item }}</span></template>'
 
+[[cases]]
+name = "v-for on template with index"
+input = '<template v-for="(item, index) in items" :key="item.id"><div>{{ index }}</div><span>{{ item.name }}</span></template>'
+
 # =============================================================================
 # v-for on component
 # =============================================================================
@@ -121,3 +125,11 @@ input = '<div v-for="item in items.filter(i => i.active)" :key="item.id">{{ item
 [[cases]]
 name = "v-for with nested property"
 input = '<div v-for="item in state.list.items" :key="item.id">{{ item }}</div>'
+
+[[cases]]
+name = "v-for over object keys"
+input = '<div v-for="key in Object.keys(obj)" :key="key">{{ key }}</div>'
+
+[[cases]]
+name = "v-for with optional chaining source"
+input = '<div v-for="item in state.items?.list" :key="item.id">{{ item.name }}</div>'

--- a/tests/fixtures/vdom/v-if.toml
+++ b/tests/fixtures/vdom/v-if.toml
@@ -35,6 +35,10 @@ name = "v-if/v-else on components"
 input = '<Foo v-if="show" /><Bar v-else />'
 
 [[cases]]
+name = "v-if/v-else-if on components"
+input = '<Foo v-if="a" /><Bar v-else-if="b" /><Baz v-else />'
+
+[[cases]]
 name = "v-if/v-else same element"
 input = '<div v-if="show">A</div><div v-else>B</div>'
 
@@ -79,6 +83,10 @@ name = "nested v-if"
 input = '<div v-if="a"><span v-if="b">nested</span></div>'
 
 [[cases]]
+name = "nested v-if with else"
+input = '<div v-if="a"><span v-if="b">B</span><span v-else>C</span></div>'
+
+[[cases]]
 name = "v-if inside v-for"
 input = '<div v-for="item in items" :key="item.id"><span v-if="item.show">{{ item.name }}</span></div>'
 
@@ -117,3 +125,7 @@ input = '<div v-if="isValid()">valid</div>'
 [[cases]]
 name = "v-if with negation"
 input = '<div v-if="!hidden">visible</div>'
+
+[[cases]]
+name = "v-if with optional chaining"
+input = '<div v-if="user?.profile">{{ user.profile.name }}</div>'

--- a/tests/fixtures/vdom/v-on.toml
+++ b/tests/fixtures/vdom/v-on.toml
@@ -30,6 +30,10 @@ input = '<button @click="handler()"></button>'
 name = "method with args"
 input = '<button @click="handler(1, 2)"></button>'
 
+[[cases]]
+name = "sequence expression handler"
+input = '<button @click="foo(), bar()"></button>'
+
 # =============================================================================
 # Event with $event
 # =============================================================================
@@ -49,6 +53,10 @@ input = '<button @click="e => handler(e)"></button>'
 [[cases]]
 name = "arrow function with multiple params"
 input = '<div @custom="(a, b) => handler(a, b)"></div>'
+
+[[cases]]
+name = "optional chaining call"
+input = '<button @click="props.onClick?.($event)"></button>'
 
 # =============================================================================
 # Modifiers
@@ -93,6 +101,10 @@ input = '<input @keyup.enter="submit">'
 [[cases]]
 name = "escape key"
 input = '<input @keyup.esc="cancel">'
+
+[[cases]]
+name = "page down key"
+input = '<input @keyup.page-down="next">'
 
 [[cases]]
 name = "tab key"

--- a/tests/fixtures/vdom/v-once.toml
+++ b/tests/fixtures/vdom/v-once.toml
@@ -74,6 +74,10 @@ input = '<div v-for="item in items" :key="item.id" v-memo="[item.selected]">{{ i
 name = "v-memo with complex expression"
 input = '<div v-for="item in items" :key="item.id" v-memo="[item.id === selected]">{{ item.name }}</div>'
 
+[[cases]]
+name = "v-memo with optional chaining"
+input = '<div v-memo="[item?.id]">{{ item?.name }}</div>'
+
 # =============================================================================
 # v-memo on template
 # =============================================================================

--- a/tests/fixtures/vdom/v-show.toml
+++ b/tests/fixtures/vdom/v-show.toml
@@ -62,6 +62,10 @@ input = '<div v-show="!hidden">visible</div>'
 name = "v-show with method call"
 input = '<div v-show="isVisible()">content</div>'
 
+[[cases]]
+name = "v-show with optional chaining"
+input = '<div v-show="user?.active">active</div>'
+
 # =============================================================================
 # v-show with other directives
 # =============================================================================
@@ -89,3 +93,7 @@ input = '<div v-show="outer"><span v-show="inner">nested</span></div>'
 [[cases]]
 name = "v-show with v-if sibling"
 input = '<div v-show="a">A</div><div v-if="b">B</div>'
+
+[[cases]]
+name = "v-show nested under v-if"
+input = '<section v-if="ready"><div v-show="visible">content</div></section>'

--- a/tests/snapshots/sfc/ts/basic__script_setup_function_handler.snap
+++ b/tests/snapshots/sfc/ts/basic__script_setup_function_handler.snap
@@ -1,0 +1,23 @@
+---
+source: crates/vize_atelier_sfc/src/snapshot_tests.rs
+expression: ts_output.as_str()
+---
+import { defineComponent as _defineComponent } from 'vue'
+import { openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+const count = 0
+
+export default /*@__PURE__*/_defineComponent({
+  __name: 'test',
+  setup(__props) {
+
+function onClick() {
+  console.log(count)
+}
+
+return (_ctx: any,_cache: any) => {
+  return (_openBlock(), _createElementBlock("button", { onClick: onClick }, "Click"))
+}
+}
+
+})

--- a/tests/vize_test_runner/src/coverage.rs
+++ b/tests/vize_test_runner/src/coverage.rs
@@ -10,10 +10,10 @@ use std::path::PathBuf;
 use vize_carton::String;
 use vize_test_runner::{CompilerMode, run_fixture_tests};
 
-const MIN_VDOM_PASSED: usize = 353;
+const MIN_VDOM_PASSED: usize = 383;
 const MIN_VAPOR_PASSED: usize = 104;
-const MIN_SFC_PASSED: usize = 60;
-const MIN_TOTAL_PASSED: usize = 517;
+const MIN_SFC_PASSED: usize = 61;
+const MIN_TOTAL_PASSED: usize = 548;
 
 // Known v1 alpha fixture debt. CI allows these exact failures so existing gaps
 // do not block unrelated work, but any new failure or pass-count regression


### PR DESCRIPTION
## Summary

- Add passing compiler fixture cases across VDOM element, component, directive, binding, event, control-flow, memo, patch-flag, and v-show coverage.
- Add one passing SFC basic script setup handler fixture.
- Raise the compiler coverage budget from 517 to 548 total passing cases.

## Validation

- `cargo run -p vize_test_runner --bin coverage`
- `cargo test -p vize_test_runner`
- `cargo fmt --all -- --check`
- `git diff --check`
- `node bench/test-inventory.mjs --json /tmp/vize-test-inventory.json`