### PR TITLE
fix(config): await TypeScript config transforms

### DIFF
--- a/npm/vize/src/config.ts
+++ b/npm/vize/src/config.ts
@@ -203,7 +203,7 @@ async function resolveConfigExport(
 
 async function loadTypeScriptConfig(filePath: string, env?: ConfigEnv): Promise<VizeConfig> {
   const source = fs.readFileSync(filePath, "utf-8");
-  const result = transform(filePath, source, {
+  const result = await transform(filePath, source, {
     typescript: {
       onlyRemoveTypeImports: true,
     },

--- a/tests/tooling/config-loading.test.ts
+++ b/tests/tooling/config-loading.test.ts
@@ -1,0 +1,40 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+import { loadConfig } from "../../npm/vize/src/config.ts";
+
+test("vize.config.ts loads through the public config API", async () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "vize-config-ts-"));
+
+  try {
+    fs.writeFileSync(
+      path.join(tempDir, "vize.config.ts"),
+      [
+        "type Command = 'serve' | 'build';",
+        "",
+        "export default ({ mode, command }: { mode: string; command: Command }) => ({",
+        "  compiler: {",
+        "    sourceMap: mode === 'production',",
+        "  },",
+        "  formatter: {",
+        "    lineWidth: command === 'build' ? 100 : 80,",
+        "  },",
+        "});",
+        "",
+      ].join("\n"),
+    );
+
+    const config = await loadConfig(tempDir, {
+      env: { command: "build", mode: "production" },
+      mode: "root",
+    });
+
+    assert.equal(config?.compiler?.sourceMap, true);
+    assert.equal(config?.formatter?.lineWidth, 100);
+  } finally {
+    fs.rmSync(tempDir, { force: true, recursive: true });
+  }
+});


### PR DESCRIPTION
## Summary

- await the async `oxc-transform` result when loading `vize.config.ts`
- add a public-loader regression test for TypeScript config functions and env values

Closes #458.

## Verification

```sh
vp install --frozen-lockfile --prefer-offline
node --test tests/tooling/config-loading.test.ts
```