### PR TITLE
fix(wasm): declare public publish access

### DIFF
--- a/npm/vize-wasm/package.json
+++ b/npm/vize-wasm/package.json
@@ -39,6 +39,9 @@
     },
     "./vize_vitrine_bg.wasm": "./vize_vitrine_bg.wasm"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "engines": {
     "node": ">=22"
   }

--- a/tests/tooling/package-manifests.test.ts
+++ b/tests/tooling/package-manifests.test.ts
@@ -351,9 +351,11 @@ test("wasm package publishes the wrapper entrypoint and raw wasm assets", () => 
     exports?: Record<string, string | Record<string, string>>;
     files?: string[];
     main?: string;
+    publishConfig?: Record<string, string>;
     types?: string;
   };
 
+  assert.equal(wasmPackage.publishConfig?.access, "public");
   assert.equal(wasmPackage.main, "./index.js");
   assert.equal(wasmPackage.types, "./index.d.ts");
   assert.deepEqual(wasmPackage.exports?.["."], {


### PR DESCRIPTION
## Summary

- add `publishConfig.access: public` to `@vizejs/wasm`
- extend the WASM package manifest guard to keep public publish access in place

Closes #478.

## Verification

```sh
node --test tests/tooling/package-manifests.test.ts
```