### PR TITLE
fix(vscode-art): declare Marketplace license

### DIFF
--- a/npm/vscode-art/package.json
+++ b/npm/vscode-art/package.json
@@ -10,6 +10,7 @@
   "bugs": {
     "url": "https://github.com/ubugeeei/vize/issues"
   },
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/ubugeeei/vize"

--- a/tests/tooling/editor-integrations.test.ts
+++ b/tests/tooling/editor-integrations.test.ts
@@ -110,11 +110,13 @@ test("vscode-art grammar stays aligned with vue-aware editor support", () => {
         embeddedLanguages?: Record<string, string>;
       }>;
     };
+    license?: string;
     scripts?: Record<string, string>;
     version?: string;
   }>("npm/vscode-art/package.json");
 
   assert.equal(manifest.version, workspaceVersion());
+  assert.equal(manifest.license, "MIT");
   assert.equal(manifest.scripts?.compile, "tsgo -p ./");
   assert.equal(manifest.scripts?.watch, "tsgo -watch -p ./");
 


### PR DESCRIPTION
## Summary

- add explicit MIT license metadata to the standalone `vize-art` VS Code extension manifest
- extend editor integration tests to keep the manifest license aligned

Closes #479.

## Verification

```sh
node --test tests/tooling/editor-integrations.test.ts
```