### PR TITLE
fix(release): publish croquis cross-file crate

### DIFF
--- a/tests/tooling/moonbit-publish-crates.test.ts
+++ b/tests/tooling/moonbit-publish-crates.test.ts
@@ -16,6 +16,8 @@ type CargoMetadata = {
 type CargoPackage = {
   name: string;
   dependencies: CargoDependency[];
+  manifest_path: string;
+  publish: string[] | null;
 };
 
 type CargoDependency = {
@@ -70,6 +72,17 @@ test("publish_crates script keeps publishable workspace dependencies ordered", (
       );
     }
   }
+});
+
+test("publish_crates includes every publishable crate package", () => {
+  const publishedCrates = new Set(getPublishedCrates());
+  const missingCrates = getMetadata().packages
+    .filter((pkg) => path.relative(repoRoot, pkg.manifest_path).startsWith(`crates${path.sep}`))
+    .filter((pkg) => pkg.publish === null || pkg.publish.length > 0)
+    .map((pkg) => pkg.name)
+    .filter((crateName) => !publishedCrates.has(crateName));
+
+  assert.deepEqual(missingCrates, []);
 });
 
 test("publish_crates runs as a native MoonBit script", () => {

--- a/tools/moon/scripts/publish_crates.mbtx
+++ b/tools/moon/scripts/publish_crates.mbtx
@@ -28,6 +28,7 @@ let published_crates : Array[String] = [
   "vize_relief",
   "vize_armature",
   "vize_croquis",
+  "vize_croquis_cf",
   "vize_atelier_core",
   "vize_atelier_dom",
   "vize_atelier_vapor",


### PR DESCRIPTION
## Summary

- add `vize_croquis_cf` to the crates.io publish order
- add a guard that compares publishable crate packages under `crates/` against the release publish list

Closes #463.

## Verification

```sh
node --test tests/tooling/moonbit-publish-crates.test.ts
```