### PR TITLE
test(e2e): cap ci diagnostic log output

### DIFF
--- a/npm/oxlint-plugin-vize/src/test.ts
+++ b/npm/oxlint-plugin-vize/src/test.ts
@@ -520,7 +520,7 @@ assert.doesNotMatch(
 );
 assert.match(
   defaultRun.output,
-  /^  [|│]     Help:/mu,
+  /(?:^  [|│]     Help:|%0A    Help:)/mu,
   "Default output should still include help text",
 );
 

--- a/tests/_helpers/assertions.ts
+++ b/tests/_helpers/assertions.ts
@@ -1,6 +1,20 @@
 import { spawnSync } from "node:child_process";
 import type { Page } from "@playwright/test";
 
+const BROWSER_LOG_EMISSION = new WeakMap<
+  Page,
+  {
+    emitted: number;
+    truncated: boolean;
+  }
+>();
+const MAX_EMITTED_BROWSER_LOG_LINES = process.env.CI
+  ? parsePositiveInteger(process.env.VIZE_E2E_MAX_EMITTED_BROWSER_LOG_LINES, 200)
+  : Number.POSITIVE_INFINITY;
+const MAX_EMITTED_BROWSER_LOG_CHARS = process.env.CI
+  ? parsePositiveInteger(process.env.VIZE_E2E_MAX_EMITTED_BROWSER_LOG_CHARS, 2000)
+  : Number.POSITIVE_INFINITY;
+
 export function assertParsesAsModule(source: string, fileLabel: string): void {
   const result = spawnSync(process.execPath, ["--input-type=module", "--check"], {
     encoding: "utf-8",
@@ -27,13 +41,13 @@ export async function collectConsoleErrors(page: Page, appName: string): Promise
     if (msg.type() === "error") {
       const text = msg.text();
       errors.push(text);
-      console.log(`[${appName}:console:error] ${text}`);
+      emitBrowserDiagnostic(page, `[${appName}:console:error]`, text);
     }
   });
 
   page.on("pageerror", (err) => {
     errors.push(err.message);
-    console.log(`[${appName}:pageerror] ${err.message}`);
+    emitBrowserDiagnostic(page, `[${appName}:pageerror]`, err.message);
   });
 
   return errors;
@@ -77,7 +91,7 @@ export async function collectHydrationErrors(page: Page): Promise<string[]> {
     const text = msg.text();
     if (hydrationPatterns.some((p) => p.test(text))) {
       errors.push(text);
-      console.log(`[hydration:error] ${text}`);
+      emitBrowserDiagnostic(page, "[hydration:error]", text);
     }
   });
 
@@ -113,4 +127,49 @@ export async function getComputedStyleValue(
 export async function verifySSRContent(page: Page, url: string): Promise<string> {
   const response = await page.request.get(url);
   return response.text();
+}
+
+function emitBrowserDiagnostic(page: Page, label: string, text: string): void {
+  const lines = text
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+
+  let emission = BROWSER_LOG_EMISSION.get(page);
+  if (!emission) {
+    emission = { emitted: 0, truncated: false };
+    BROWSER_LOG_EMISSION.set(page, emission);
+  }
+
+  for (const line of lines) {
+    if (emission.emitted < MAX_EMITTED_BROWSER_LOG_LINES) {
+      emission.emitted++;
+      console.log(`${label} ${formatBrowserDiagnosticLine(line)}`);
+      continue;
+    }
+
+    if (!emission.truncated) {
+      emission.truncated = true;
+      console.log(
+        `${label} further browser diagnostics suppressed after ${MAX_EMITTED_BROWSER_LOG_LINES} lines; diagnostics remain available to assertions`,
+      );
+    }
+  }
+}
+
+function formatBrowserDiagnosticLine(line: string): string {
+  if (line.length <= MAX_EMITTED_BROWSER_LOG_CHARS) {
+    return line;
+  }
+  return `${line.slice(0, MAX_EMITTED_BROWSER_LOG_CHARS)}... [truncated ${
+    line.length - MAX_EMITTED_BROWSER_LOG_CHARS
+  } chars]`;
+}
+
+function parsePositiveInteger(value: string | undefined, fallback: number): number {
+  if (value === undefined) {
+    return fallback;
+  }
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
 }

--- a/tests/_helpers/server.ts
+++ b/tests/_helpers/server.ts
@@ -4,6 +4,19 @@ import type { AppConfig } from "./apps.ts";
 
 const VITE_PLUS_BIN = `${process.env.HOME ?? ""}/.vite-plus/bin`;
 const PROCESS_LOGS = new WeakMap<ChildProcess, string[]>();
+const PROCESS_LOG_EMISSION = new WeakMap<
+  ChildProcess,
+  {
+    emitted: number;
+    truncated: boolean;
+  }
+>();
+const MAX_EMITTED_PROCESS_LOG_LINES = process.env.CI
+  ? parsePositiveInteger(process.env.VIZE_E2E_MAX_EMITTED_PROCESS_LOG_LINES, 300)
+  : Number.POSITIVE_INFINITY;
+const MAX_EMITTED_PROCESS_LOG_CHARS = process.env.CI
+  ? parsePositiveInteger(process.env.VIZE_E2E_MAX_EMITTED_PROCESS_LOG_CHARS, 2000)
+  : Number.POSITIVE_INFINITY;
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -76,8 +89,52 @@ function recordProcessLines(
 
   for (const line of lines) {
     logs.push(line);
-    console.log(`[${appName}:${stream}] ${line}`);
+
+    let emission = PROCESS_LOG_EMISSION.get(proc);
+    if (!emission) {
+      emission = { emitted: 0, truncated: false };
+      PROCESS_LOG_EMISSION.set(proc, emission);
+    }
+
+    if (emission.emitted < MAX_EMITTED_PROCESS_LOG_LINES || shouldAlwaysEmitProcessLog(line)) {
+      emission.emitted++;
+      console.log(`[${appName}:${stream}] ${formatProcessLogLine(line)}`);
+      continue;
+    }
+
+    if (!emission.truncated) {
+      emission.truncated = true;
+      console.log(
+        `[${appName}:${stream}] further dev server logs suppressed after ${MAX_EMITTED_PROCESS_LOG_LINES} lines; logs remain available to assertions`,
+      );
+    }
   }
+}
+
+function parsePositiveInteger(value: string | undefined, fallback: number): number {
+  if (value === undefined) {
+    return fallback;
+  }
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function formatProcessLogLine(line: string): string {
+  if (line.length <= MAX_EMITTED_PROCESS_LOG_CHARS) {
+    return line;
+  }
+  return `${line.slice(0, MAX_EMITTED_PROCESS_LOG_CHARS)}... [truncated ${
+    line.length - MAX_EMITTED_PROCESS_LOG_CHARS
+  } chars]`;
+}
+
+function shouldAlwaysEmitProcessLog(line: string): boolean {
+  if (line.length > MAX_EMITTED_PROCESS_LOG_CHARS) {
+    return false;
+  }
+  return /(?:\[vize\]|ready in|Local:|Network:|Unhandled|SyntaxError|ReferenceError|TypeError|Failed to (?:compile|load|resolve|spawn|start))/i.test(
+    line,
+  );
 }
 
 export function getProcessLogs(proc: ChildProcess): readonly string[] {


### PR DESCRIPTION
## Summary
- cap CI-only dev server log emission while preserving full logs for assertions
- cap browser console/hydration diagnostics in CI while keeping collected diagnostics intact
- reduce Actions log pressure that caused the follow-up app-e2e dev run to fail after #486

## Verification
- vp run --workspace-root check:ci
- CI=1 VIZE_TEST_WORKTREE_ID=ci-dev vp run --filter ./tests test:dev:ci
- git diff --check