### PR TITLE
chore(release): declare workspace MSRV (rust-version = 1.95.0)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,9 @@ Thanks for helping make Vize sharper. This project is still moving toward v1 alp
 
 ## Setup
 
-Use the Node.js version from `.node-version`, then install dependencies from the workspace root:
+Use the Node.js version from `.node-version` and the Rust version from `rust-toolchain.toml`. The workspace declares a minimum supported Rust version (MSRV) of `1.95.0` in `Cargo.toml` (`[workspace.package].rust-version`); contributions must compile under that version.
+
+Install dependencies from the workspace root:
 
 ```sh
 vp install --frozen-lockfile --prefer-offline

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ members = [
 [workspace.package]
 version = "0.107.0"
 edition = "2024"
+rust-version = "1.95.0"
 license = "MIT"
 repository = "https://github.com/ubugeeei/vize"
 

--- a/crates/vize/Cargo.toml
+++ b/crates/vize/Cargo.toml
@@ -2,6 +2,7 @@
 name = "vize"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Vize - High-performance Vue.js toolchain in Rust"

--- a/crates/vize_armature/Cargo.toml
+++ b/crates/vize_armature/Cargo.toml
@@ -2,6 +2,7 @@
 name = "vize_armature"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Armature - The structural parser framework for Vize Vue templates"

--- a/crates/vize_atelier_core/Cargo.toml
+++ b/crates/vize_atelier_core/Cargo.toml
@@ -2,6 +2,7 @@
 name = "vize_atelier_core"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Atelier Core - The core workshop for Vize Vue template parsing and transforms"

--- a/crates/vize_atelier_dom/Cargo.toml
+++ b/crates/vize_atelier_dom/Cargo.toml
@@ -2,6 +2,7 @@
 name = "vize_atelier_dom"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Atelier DOM - The DOM compiler workshop for Vize"

--- a/crates/vize_atelier_sfc/Cargo.toml
+++ b/crates/vize_atelier_sfc/Cargo.toml
@@ -2,6 +2,7 @@
 name = "vize_atelier_sfc"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Atelier SFC - The Single File Component workshop for Vize"

--- a/crates/vize_atelier_ssr/Cargo.toml
+++ b/crates/vize_atelier_ssr/Cargo.toml
@@ -2,6 +2,7 @@
 name = "vize_atelier_ssr"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Vue SSR compiler for Vize"

--- a/crates/vize_atelier_vapor/Cargo.toml
+++ b/crates/vize_atelier_vapor/Cargo.toml
@@ -2,6 +2,7 @@
 name = "vize_atelier_vapor"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Atelier Vapor - The Vapor mode compiler workshop for Vize"

--- a/crates/vize_canon/Cargo.toml
+++ b/crates/vize_canon/Cargo.toml
@@ -2,6 +2,7 @@
 name = "vize_canon"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Canon - The standard of correctness for Vize type checking"

--- a/crates/vize_carton/Cargo.toml
+++ b/crates/vize_carton/Cargo.toml
@@ -2,6 +2,7 @@
 name = "vize_carton"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Carton - The artist's toolbox for Vize compiler"

--- a/crates/vize_croquis/Cargo.toml
+++ b/crates/vize_croquis/Cargo.toml
@@ -2,6 +2,7 @@
 name = "vize_croquis"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Croquis - Semantic analysis layer for Vize. Quick sketches of meaning from Vue templates."

--- a/crates/vize_croquis_cf/Cargo.toml
+++ b/crates/vize_croquis_cf/Cargo.toml
@@ -2,6 +2,7 @@
 name = "vize_croquis_cf"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Cross-file semantic analysis for Vize Croquis."

--- a/crates/vize_fresco/Cargo.toml
+++ b/crates/vize_fresco/Cargo.toml
@@ -2,6 +2,7 @@
 name = "vize_fresco"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Fresco - Vue TUI framework (Terminal User Interface)"

--- a/crates/vize_glyph/Cargo.toml
+++ b/crates/vize_glyph/Cargo.toml
@@ -2,6 +2,7 @@
 name = "vize_glyph"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Glyph - The beautiful letterforms for Vize code formatting"

--- a/crates/vize_maestro/Cargo.toml
+++ b/crates/vize_maestro/Cargo.toml
@@ -2,6 +2,7 @@
 name = "vize_maestro"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Maestro - Language Server Protocol implementation for Vize Vue templates"

--- a/crates/vize_musea/Cargo.toml
+++ b/crates/vize_musea/Cargo.toml
@@ -2,6 +2,7 @@
 name = "vize_musea"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Musea - Component gallery and documentation for Vize Vue components"

--- a/crates/vize_patina/Cargo.toml
+++ b/crates/vize_patina/Cargo.toml
@@ -2,6 +2,7 @@
 name = "vize_patina"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Patina - The quality checker for Vize code linting"

--- a/crates/vize_relief/Cargo.toml
+++ b/crates/vize_relief/Cargo.toml
@@ -2,6 +2,7 @@
 name = "vize_relief"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 description = "Relief - The sculptured AST surface for Vize Vue templates"

--- a/crates/vize_vitrine/Cargo.toml
+++ b/crates/vize_vitrine/Cargo.toml
@@ -2,6 +2,7 @@
 name = "vize_vitrine"
 version.workspace = true
 edition = "2024"
+rust-version.workspace = true
 license = "MIT"
 repository = "https://github.com/ubugeeei/vize"
 description = "Vitrine - The display case for Vize (Node.js/WASM bindings)"

--- a/docs/content/stability.md
+++ b/docs/content/stability.md
@@ -37,6 +37,12 @@ The release workflow builds native packages for macOS, Linux, and Windows across
 where the package declares support. CI compatibility jobs cover the declared Node floor and the
 current project Node version.
 
+The minimum supported Rust version (MSRV) for the workspace is declared in `Cargo.toml` under
+`[workspace.package].rust-version`. The development toolchain pinned by `rust-toolchain.toml`
+may be the same version or newer. Before v1 stable the MSRV may move forward in any prerelease;
+the move is called out in release notes when it changes. Downstream packagers should read
+`rust-version` from a crate's `Cargo.toml` rather than infer it from the toolchain file.
+
 ## Package Support Tiers
 
 | Tier                  | Packages                                                                                      | Contract                                                                                       |

--- a/tests/vize_test_runner/Cargo.toml
+++ b/tests/vize_test_runner/Cargo.toml
@@ -2,6 +2,7 @@
 name = "vize_test_runner"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 
 [[bin]]


### PR DESCRIPTION
## Summary

- Declare `[workspace.package].rust-version = "1.95.0"` in `Cargo.toml`.
- Propagate it via `rust-version.workspace = true` to all 19 crates (publishable, workspace-only, and the test runner).
- Add an MSRV note to the `CONTRIBUTING.md` Setup section.
- Add an MSRV policy paragraph to the `docs/content/stability.md` Runtime Support section.

Without an explicit MSRV, downstream packagers (Nix, Homebrew, Debian) and `cargo install` users could not reason about which toolchain Vize promises to support. This PR makes the contract explicit.

## Why 1.95.0

The initial MSRV matches the development toolchain currently pinned in `rust-toolchain.toml`. As long as edition 2024 is in use, the absolute floor is 1.85.0, but verifying how far the MSRV can actually move down is left for a follow-up PR that adds CI enforcement against an older toolchain.

## Verification

```sh
cargo metadata --no-deps --format-version 1 --offline \
  | python3 -c "import json,sys; [print(p['name'], p.get('rust_version')) for p in json.load(sys.stdin)['packages']]"
```

- 19/19 crates report `rust-version = 1.95.0`.

## Test plan

- [ ] CI `Check` workflow is green.
- [ ] `cargo metadata` shows `rust-version` on every crate.
- [ ] Downstream packagers can read `rust-version` from any crate's `Cargo.toml`.

## Related

Closes part of #503. CI enforcement of the declared MSRV (running `cargo +<MSRV> check`) is left for a follow-up.
