### PR TITLE
docs(community): add GOVERNANCE.md and SUPPORT.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,3 +38,9 @@ Before opening a PR that changes shared tooling, release automation, native bind
 Use the bug report template for regressions, crashes, incorrect diagnostics, package installation problems, and release failures. Use the feature request template for new integrations, API changes, or workflow improvements.
 
 Security issues should follow `SECURITY.md` instead of the public issue templates.
+
+## Code of Conduct and Governance
+
+By participating, you agree to abide by the [Contributor Covenant v2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).
+The governance model and decision-making process are documented in [`GOVERNANCE.md`](./GOVERNANCE.md).
+For help finding the right channel, see [`SUPPORT.md`](./SUPPORT.md).

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,65 @@
+# Governance
+
+This document describes how Vize is maintained. It is intentionally lightweight
+for the v1 alpha phase and will be revisited before v1 GA.
+
+## Roles
+
+### Maintainer
+
+A maintainer can merge pull requests, cut releases, and triage issues across
+the workspace. The current maintainer is listed in `package.json` and
+`Cargo.toml`. Today the project is led by [@ubugeeei](https://github.com/ubugeeei).
+
+### Surface owner
+
+Some areas of the codebase have a designated owner who signs off on changes
+that affect that surface during a release. The owners are listed in
+[`docs/release/v1-alpha-go-no-go.md`](./docs/release/v1-alpha-go-no-go.md).
+
+### Contributor
+
+Anyone who opens an issue, discussion, or pull request. Contributions of any
+size are welcome; see [`CONTRIBUTING.md`](./CONTRIBUTING.md) for how to set up
+the workspace.
+
+## Decision making
+
+The project uses a lazy-consensus model:
+
+1. Routine changes — bug fixes, dependency bumps, documentation edits — land
+   once a maintainer approves the pull request and CI is green.
+2. Behavioral changes to public surfaces (CLI flags, `vize.config.*` schema,
+   Patina rule semantics, type-checker diagnostics, npm package exports,
+   public Rust crate APIs) require:
+   - an issue or RFC-style discussion before the PR,
+   - sign-off from the surface owner listed in the release checklist,
+   - a release note that mentions the change under the appropriate SemVer
+     level (see [`docs/release/stability.md`](./docs/release/stability.md)).
+3. Releases follow [`docs/release/v1-alpha-go-no-go.md`](./docs/release/v1-alpha-go-no-go.md).
+   The release captain has final go/no-go authority.
+4. Security issues follow [`SECURITY.md`](./SECURITY.md) and are handled
+   privately until a fix is available.
+
+When a decision is contested, the maintainer makes the final call. A future
+governance revision may introduce a steering committee once the contributor
+base grows.
+
+## Becoming a maintainer
+
+There is no fixed timeline. Sustained, high-quality contributions over
+multiple releases, paired with willingness to take on release or surface
+ownership, are the practical signals. Open an issue or reach the maintainer
+through the channel listed in [`SUPPORT.md`](./SUPPORT.md) if you would like
+to discuss it.
+
+## Code of conduct
+
+Vize adopts the [Contributor Covenant v2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).
+Enforcement contact is the same as the security reporting channel described in
+[`SECURITY.md`](./SECURITY.md).
+
+## Changes to this document
+
+Changes to governance require a pull request and a maintainer's approval.
+Substantive changes should be announced in a release note.

--- a/README.md
+++ b/README.md
@@ -285,6 +285,13 @@ vp run --workspace-root check:fix
 vp run --workspace-root bench:all
 ```
 
+## Community
+
+- [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct/) — Vize adopts the Contributor Covenant v2.1.
+- [Governance](./GOVERNANCE.md) — maintainer model and decision-making process.
+- [Support](./SUPPORT.md) — where to ask questions, file bugs, or report security issues.
+- [Contributing](./CONTRIBUTING.md) — setup and pull-request guidelines.
+
 ## Credits
 
 This project draws inspiration from:

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -8,15 +8,15 @@ those before opening a support thread.
 
 ## Where to ask
 
-| You want to                                                  | Use                                                                    |
-| ------------------------------------------------------------ | ---------------------------------------------------------------------- |
-| Read documentation                                           | https://vizejs.dev                                                     |
-| Try Vize without installing                                  | https://vizejs.dev/play/                                               |
-| Report a reproducible bug, regression, or incorrect output   | [GitHub Issues](https://github.com/ubugeeei/vize/issues/new/choose)    |
-| Propose a feature, integration, or workflow change           | [GitHub Issues](https://github.com/ubugeeei/vize/issues/new/choose)    |
-| Discuss design, ask "how do I", share usage feedback         | [GitHub Discussions](https://github.com/ubugeeei/vize/discussions)     |
-| Report a security vulnerability                              | Follow [`SECURITY.md`](./SECURITY.md) — do **not** open a public issue |
-| Sponsor / fund development                                   | https://github.com/sponsors/ubugeeei                                   |
+| You want to                                                | Use                                                                    |
+| ---------------------------------------------------------- | ---------------------------------------------------------------------- |
+| Read documentation                                         | https://vizejs.dev                                                     |
+| Try Vize without installing                                | https://vizejs.dev/play/                                               |
+| Report a reproducible bug, regression, or incorrect output | [GitHub Issues](https://github.com/ubugeeei/vize/issues/new/choose)    |
+| Propose a feature, integration, or workflow change         | [GitHub Issues](https://github.com/ubugeeei/vize/issues/new/choose)    |
+| Discuss design, ask "how do I", share usage feedback       | [GitHub Discussions](https://github.com/ubugeeei/vize/discussions)     |
+| Report a security vulnerability                            | Follow [`SECURITY.md`](./SECURITY.md) — do **not** open a public issue |
+| Sponsor / fund development                                 | https://github.com/sponsors/ubugeeei                                   |
 
 If GitHub Discussions are not enabled yet for this repository, open an issue
 with the `question` label and we will move the conversation if it grows.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,63 @@
+# Getting Support
+
+Vize is still pre-1.0; the surfaces that are ready for adopters and the ones
+that are not are listed in
+[`docs/release/production-readiness.md`](./docs/release/production-readiness.md)
+and [`docs/release/stability.md`](./docs/release/stability.md). Please check
+those before opening a support thread.
+
+## Where to ask
+
+| You want to                                                  | Use                                                                    |
+| ------------------------------------------------------------ | ---------------------------------------------------------------------- |
+| Read documentation                                           | https://vizejs.dev                                                     |
+| Try Vize without installing                                  | https://vizejs.dev/play/                                               |
+| Report a reproducible bug, regression, or incorrect output   | [GitHub Issues](https://github.com/ubugeeei/vize/issues/new/choose)    |
+| Propose a feature, integration, or workflow change           | [GitHub Issues](https://github.com/ubugeeei/vize/issues/new/choose)    |
+| Discuss design, ask "how do I", share usage feedback         | [GitHub Discussions](https://github.com/ubugeeei/vize/discussions)     |
+| Report a security vulnerability                              | Follow [`SECURITY.md`](./SECURITY.md) — do **not** open a public issue |
+| Sponsor / fund development                                   | https://github.com/sponsors/ubugeeei                                   |
+
+If GitHub Discussions are not enabled yet for this repository, open an issue
+with the `question` label and we will move the conversation if it grows.
+
+## What is in scope
+
+The following are in scope for the issue tracker:
+
+- bugs in the supported tiers listed in
+  [`docs/release/production-readiness.md`](./docs/release/production-readiness.md)
+- crashes, panics, or memory issues in the CLI, native bindings, or WASM
+  builds
+- incorrect or missing diagnostics from `vize lint`, `vize check`, or LSP
+- install failures of any published npm or crates.io package
+- regressions in the compiler, formatter, type checker, or Vue/Vapor runtime
+  output
+- documentation gaps in the official docs site or repository docs
+
+## What is not in scope
+
+These are not in scope for the issue tracker (the right place is in the
+table above):
+
+- general Vue, Vite, Nuxt, Rust, or Node.js questions
+- design debates without a concrete proposal
+- support for surfaces marked **experimental** or **incubating** in the
+  stability guide (we will read these, but they may close without action)
+
+## Response expectations
+
+Vize is maintained on a best-effort basis by [@ubugeeei](https://github.com/ubugeeei).
+We do not promise a fixed SLA outside of security reports (see
+[`SECURITY.md`](./SECURITY.md)). For everything else:
+
+- Triage usually happens within a few days.
+- Bug reports with a minimal reproduction get attention soonest.
+- Releases follow the schedule described in the release docs; bug fixes are
+  not always backported to older prereleases.
+
+## Commercial / priority support
+
+There is no commercial support tier. Sponsorship through
+[GitHub Sponsors](https://github.com/sponsors/ubugeeei) helps keep the project
+funded but does not grant priority issue handling.


### PR DESCRIPTION
## Summary

- Add `GOVERNANCE.md` — maintainer / surface owner / contributor roles, lazy-consensus decision-making, the path to becoming a maintainer, and how this document itself changes.
- Add `SUPPORT.md` — routing table (docs / playground / issues / discussions / security / sponsorship), in-scope vs out-of-scope for the issue tracker, and best-effort response expectations.
- Adopt the [Contributor Covenant v2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/) **by reference** — linked from `README.md`, `CONTRIBUTING.md`, and `GOVERNANCE.md`.
- Unify the Code of Conduct enforcement contact with the private channel described in `SECURITY.md`.

## Why

Three baseline community files expected of production-ready open-source projects were missing. Contributors had no canonical place to learn the project's decision-making model or where to ask for help.

## Why the Code of Conduct is not vendored

Vendoring the full Contributor Covenant text would create drift risk against upstream revisions and would invite local rewording. We link the canonical document instead. Adding a vendored `CODE_OF_CONDUCT.md` to satisfy the GitHub Community Standards badge is left as an optional follow-up.

## Test plan

- [ ] Links from `README.md`, `CONTRIBUTING.md`, and `GOVERNANCE.md` resolve.
- [ ] GitHub Community Standards recognizes `GOVERNANCE.md` and `SUPPORT.md`.
- [ ] The private enforcement channel in `SECURITY.md` is confirmed to be the same one used for Code of Conduct enforcement.

## Related

Closes part of #501.
