### PR TITLE
ci: move App E2E and VRT off PR triggers onto daily schedule

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,26 +1,14 @@
 name: App E2E
 
 on:
-  pull_request:
-    branches: [main]
-    paths:
-      - ".github/actions/setup-moonbit/**"
-      - ".github/workflows/e2e.yml"
-      - ".node-version"
-      - "Cargo.lock"
-      - "Cargo.toml"
-      - "crates/**"
-      - "npm/musea-nuxt/**"
-      - "npm/nuxt/**"
-      - "npm/vite-plugin-musea/**"
-      - "npm/vite-plugin-vize/**"
-      - "npm/vize/**"
-      - "npm/vize-native/**"
-      - "package.json"
-      - "pnpm-lock.yaml"
-      - "pnpm-workspace.yaml"
-      - "tests/**"
-      - "tools/**"
+  # App E2E (dev/preview/build/check/lint/check-fixtures) and VRT are slow
+  # workflows that historically gated every PR. They are now run nightly and
+  # on demand so PR review latency is bounded by faster gates (Check,
+  # Benchmark, Native Smoke). Regressions caught by the nightly run still
+  # block release through the readiness gates.
+  schedule:
+    # 02:23 UTC daily (~11:23 JST). Covers every suite including vrt.
+    - cron: "23 2 * * *"
   workflow_dispatch:
     inputs:
       suite:
@@ -38,7 +26,7 @@ on:
           - check-fixtures
 
 concurrency:
-  group: app-e2e-${{ github.event.pull_request.number || github.ref }}-${{ github.event.inputs.suite || 'pull-request' }}
+  group: app-e2e-${{ github.ref }}-${{ github.event.inputs.suite || github.event_name }}
   cancel-in-progress: true
 
 env:
@@ -55,7 +43,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        suite: ${{ github.event_name == 'workflow_dispatch' && fromJSON(format('["{0}"]', inputs.suite)) || fromJSON('["dev","preview","build","check","lint","check-fixtures"]') }}
+        # workflow_dispatch: pick one suite. schedule: run every suite,
+        # including vrt, because nothing else exercises the visual regression
+        # baselines today.
+        suite: ${{ github.event_name == 'workflow_dispatch' && fromJSON(format('["{0}"]', inputs.suite)) || fromJSON('["dev","vrt","preview","build","check","lint","check-fixtures"]') }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:

--- a/tests/tooling/e2e-workflow.test.ts
+++ b/tests/tooling/e2e-workflow.test.ts
@@ -10,17 +10,21 @@ function readRepoFile(...segments: string[]): string {
   return fs.readFileSync(path.join(root, ...segments), "utf8");
 }
 
-test("app e2e workflow is manually selectable and uploads failure artifacts", () => {
+test("app e2e workflow runs on schedule + workflow_dispatch and uploads failure artifacts", () => {
   const workflow = readRepoFile(".github", "workflows", "e2e.yml");
 
-  assert.match(workflow, /pull_request:\n\s+branches: \[main\]/);
+  // App E2E and VRT are slow and now run nightly on schedule plus on demand
+  // via workflow_dispatch. They no longer block PR merges (faster gates take
+  // over there). Regressions still gate release via the readiness pipeline.
+  assert.match(workflow, /schedule:[\s\S]*?- cron:\s*"/);
+  assert.doesNotMatch(workflow, /pull_request:/);
   assert.match(workflow, /name: app-e2e \(\$\{\{ matrix\.suite \}\}\)/);
   assert.match(workflow, /fail-fast:\s*false/);
+  // Scheduled runs exercise every suite, including vrt.
   assert.match(
     workflow,
-    /fromJSON\('\["dev","preview","build","check","lint","check-fixtures"\]'\)/,
+    /fromJSON\('\["dev","vrt","preview","build","check","lint","check-fixtures"\]'\)/,
   );
-  assert.doesNotMatch(workflow, /fromJSON\('\["dev","vrt","preview"/);
   assert.match(workflow, /workflow_dispatch:/);
   assert.match(workflow, /type:\s*choice/);
   for (const suite of ["dev", "vrt", "preview", "check", "lint", "build", "check-fixtures"]) {


### PR DESCRIPTION
## Summary

Move the slowest PR gates — `App E2E` (all suites), `VRT`, and `playground-test` — off `pull_request` triggers.

## Why

These three jobs dominate PR review latency:

- **App E2E** (dev / preview / build / check / lint / check-fixtures): Playwright matrix on cloned real-world apps, several minutes per suite.
- **VRT**: visual regression baselines via Playwright.
- **playground-test**: Playwright + WASM smoke on the live playground bundle.

Together they keep PR pipelines red or yellow for tens of minutes while the type/lint/unit gates that actually catch most regressions complete in single-digit minutes. A flake on any of them (e.g. the cross-OS snapshot mismatch in #510) blocks unrelated PRs from merging.

## Behavior change

### `.github/workflows/e2e.yml`

- `pull_request:` trigger removed.
- New `schedule:` trigger at `23 2 * * *` (daily 02:23 UTC, ~11:23 JST).
- Scheduled matrix now runs **every** suite including `vrt` (previously `workflow_dispatch`-only).
- `workflow_dispatch` unchanged.
- `tests/tooling/e2e-workflow.test.ts` updated to expect the new trigger shape.

### `.github/workflows/check.yml`

- `playground-test` gains `if: ${{ github.event_name != 'pull_request' }}`.
- Still runs on every push to `main` (so regressions surface within minutes of merge).
- Still listed in `test-report.needs`; `test-report` has `if: always()` so it continues to produce the inventory comment on PRs even when `playground-test` is skipped.

The faster PR gates (Check minus playground, Benchmark, Native host smoke) continue to run on every PR.

## Release safety

All three suites still gate release via the production-readiness checklist (which references both workflows). A red post-merge `playground-test` on `main` or a red nightly E2E run should be treated as a release blocker.

## Test plan

- [ ] CI on this PR is green (no app-e2e jobs, playground-test skipped).
- [ ] Nightly schedule fires at the configured time and runs all 7 e2e suites.
- [ ] `workflow_dispatch` still lets a maintainer pick one suite on demand.
- [ ] On push to `main`, `playground-test` runs as before.
