### PR TITLE
docs(release): add support policy with deprecation windows and SemVer mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,9 @@
 
 > [!WARNING]
 > Vize is under active development. It is not a completely production-ready toolchain yet; see the
-> [production-readiness checklist](./docs/release/production-readiness.md) and stability tiers
-> before adopting it in production.
+> [production-readiness checklist](./docs/release/production-readiness.md), the
+> [support policy](./docs/release/support-policy.md), and the stability tiers before adopting it
+> in production.
 
 > [!IMPORTANT]
 > For day-to-day editor support, keep using the official Vue language tools (`vuejs/language-tools`) for now.

--- a/docs/content/stability.md
+++ b/docs/content/stability.md
@@ -10,6 +10,8 @@ contract: it names the surfaces that should be usable by early adopters, while k
 change internals and experimental integrations quickly. The full project is not yet a completely
 production-ready toolchain; release decisions should use the
 [production-readiness checklist](https://github.com/ubugeeei/vize/blob/main/docs/release/production-readiness.md).
+Deprecation windows, SemVer rules, and release-line support are spelled out in the
+[support policy](https://github.com/ubugeeei/vize/blob/main/docs/release/support-policy.md).
 
 ## Versioning Contract
 

--- a/docs/release/production-readiness.md
+++ b/docs/release/production-readiness.md
@@ -72,6 +72,7 @@ The public compatibility baseline is documented in
 Do not remove the public work-in-progress or experimental warnings until:
 
 - the promoted support scope is named in this document and in the stability guide
+- the [support policy](./support-policy.md) covers the surface, including deprecation windows
 - every required gate above is green on the release commit
 - skipped production-relevant fixtures are either re-enabled or documented as known unsupported behavior
 - dependency audits are blocking, or every temporary ignore has an owner and review date

--- a/docs/release/support-policy.md
+++ b/docs/release/support-policy.md
@@ -1,0 +1,102 @@
+# Support Policy
+
+This page is the canonical answer to "for how long, and under what conditions, will Vize keep
+something working?" It complements the broader [stability tiers](../content/stability.md) and the
+[production-readiness checklist](./production-readiness.md). When this page disagrees with marketing
+copy or a blog post, this page wins.
+
+## Scope of this policy
+
+This policy applies to all surfaces in the `alpha-supported` and `preview` tiers as listed on the
+stability page. `experimental` and `incubating` surfaces are explicitly out of scope: they may
+change or disappear in any release.
+
+In-scope surfaces:
+
+- **CLI**: `vize` binary, its subcommands, and their documented flags.
+- **Config**: `vize.config.*` keys and their value shapes.
+- **Public Rust crates**: items reachable through a published crate's `pub` API.
+- **Public npm packages**: items in each package's exported entrypoints.
+- **Patina lint rules**: rule names, default severities, and message ids.
+- **Type-checker diagnostics**: error codes listed in the docs.
+
+## SemVer mapping
+
+While Vize is in `0.x` alpha:
+
+| Change                                                         | Treated as     |
+| -------------------------------------------------------------- | -------------- |
+| Remove or rename a CLI subcommand, flag, or env var            | Breaking       |
+| Remove or rename a config key                                  | Breaking       |
+| Tighten a config value's accepted shape                        | Breaking       |
+| Remove a `pub` item from a published Rust crate                | Breaking       |
+| Remove or rename an export from a published npm package        | Breaking       |
+| Promote a Patina rule from `warn` to `error` by default        | Breaking       |
+| Demote a Patina rule from `error` to `warn` by default         | Non-breaking   |
+| Add a new diagnostic code                                      | Non-breaking   |
+| Change a diagnostic message string (code unchanged)            | Non-breaking   |
+| Change template parser output for previously rejected programs | Non-breaking   |
+| Change template parser output for previously accepted programs | Breaking       |
+| Change formatter output for the same input                     | Documented[^1] |
+| Change generated `virtualTs` shape for type-checking           | Documented[^1] |
+
+[^1]:
+    Documented in release notes; not a breaking change for SemVer purposes but adopters should
+    treat formatter and `virtualTs` drift as a review-time signal.
+
+Once Vize reaches v1 stable, the same table applies with `0.x` replaced by SemVer-major rules.
+
+## Deprecation windows
+
+Vize keeps deprecated surfaces working for a minimum window before removal:
+
+| Surface                | Minimum deprecation window before removal |
+| ---------------------- | ----------------------------------------- |
+| Public Rust crate item | One minor release with a `#[deprecated]`  |
+| npm package entrypoint | One minor release with a console warning  |
+| CLI flag or subcommand | One minor release with a stderr warning   |
+| Config key             | One minor release with a stderr warning   |
+| Patina rule (name)     | One minor release with a stderr warning   |
+| Diagnostic code (id)   | One minor release with a release note     |
+
+A "minor release" means one published version with `minor` or higher SemVer bump; weekly patches
+do not count. When two deprecations are linked, both removal points must satisfy this window.
+
+Every removal must appear in the release notes for the version that performs it, with a one-line
+"removed since X.Y" entry that includes a link to the migration guidance.
+
+## Emergency breaking changes
+
+A breaking change may bypass the deprecation window only when **all** of:
+
+- It is required to address a security vulnerability that has no non-breaking remediation, **or**
+  required to fix data loss in a published surface.
+- The release notes for the emergency release call out the breakage explicitly.
+- A migration note is published in the same release.
+
+Emergency breakage is rare. Most issues should be addressed by a forward-compatible patch and a
+proper deprecation window for the long-term fix.
+
+## Release line support
+
+Vize publishes a single supported release line at a time:
+
+- The **current minor** receives bug fixes, security backports, and accepted feature work.
+- The **previous minor** receives security backports for the duration of one calendar month after
+  the next minor ships, then is end-of-life.
+- Older minors are end-of-life and do not receive backports of any kind.
+
+Once Vize reaches v1 stable, this policy will be revisited to declare whether Vize will run an LTS
+program. Until then, **Vize does not commit to an LTS release line**.
+
+## Security backports
+
+Security advisories are handled through `SECURITY.md`. Once a fix lands on the current minor, the
+release captain decides whether to backport to the previous minor based on severity and effort. The
+decision is recorded in the security advisory.
+
+## How this policy changes
+
+Changes to this policy ship as a regular pull request and follow the same review process as code
+changes. A change that tightens guarantees may apply retroactively; a change that loosens
+guarantees must be announced in release notes for the next minor before taking effect.


### PR DESCRIPTION
## Summary

Add `docs/release/support-policy.md` — the canonical answer to "for how long, and under what conditions, will Vize keep something working?"

Cross-linked from `README.md`, `docs/content/stability.md`, and `docs/release/production-readiness.md`.

## What it covers

- **Scope**: which surfaces the policy applies to (CLI, config, public Rust crate items, npm package exports, Patina rules, diagnostic codes) vs which are out of scope (experimental, incubating).
- **SemVer mapping table**: which changes count as breaking under 0.x alpha; how the same table reads once v1 stable lands.
- **Deprecation windows**: minimum one minor release with `#[deprecated]` / console / stderr warning per surface before removal, plus a requirement that every removal appears in release notes with a migration link.
- **Emergency breaking changes**: only allowed when required for security or data loss; release notes and migration note must be in the same release.
- **Release-line support**: current minor gets full support; previous minor gets security backports for one calendar month after the next minor ships. **No LTS commitment before v1 stable.**
- **Self-amendment rules**: tightening guarantees can apply retroactively; loosening guarantees must be announced first.

## Closes

Closes #508.

## Test plan

- [ ] All three doc cross-links resolve (`README.md`, `stability.md`, `production-readiness.md`).
- [ ] `vp check` passes formatting.
