### PR TITLE
ci: speed up test-js-packages and move nix-flake off PR triggers

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -5,6 +5,13 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  # Schedule trigger for slow jobs (nix-flake, playground-test) that should
+  # run on a cadence but no longer block PR review. See the conditional
+  # `if:` guards on those jobs.
+  schedule:
+    # 03:11 UTC daily (~12:11 JST). Offset from native-smoke and e2e to spread
+    # GitHub Actions concurrency budget.
+    - cron: "11 3 * * *"
 
 concurrency:
   group: check-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -21,6 +28,11 @@ jobs:
   nix-flake:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    # Nix store cache restore + `nix flake check` was the second-slowest PR
+    # gate after playground-test. The flake itself rarely changes between
+    # PRs, so run it on push-to-main (catches merge regressions within
+    # minutes) and on the daily schedule, not on every PR.
+    if: ${{ github.event_name != 'pull_request' }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31

--- a/npm/vite-plugin-vize/package.json
+++ b/npm/vite-plugin-vize/package.json
@@ -42,7 +42,7 @@
     "check": "vp check src vite.config.ts",
     "check:fix": "vp check --fix src vite.config.ts",
     "fmt": "vp fmt --write src vite.config.ts",
-    "test": "pnpm --dir ../vize-native build:debug && node src/test.ts"
+    "test": "pnpm --dir ../vize-native build:ci && node src/test.ts"
   },
   "dependencies": {
     "@vizejs/native": "workspace:*",

--- a/tools/vite-plus/tasks/build.ts
+++ b/tools/vite-plus/tasks/build.ts
@@ -27,6 +27,12 @@ export const buildTasks = defineTasks({
   "build:runtime": noCacheTask(runTasks("build:native", "build:wasm", "build:packages")),
   "build:packages": noCacheTask(runInPackages("build", packedPackages)),
   "build:native": noCacheTask(runPackageScriptDirectly("build", ["./npm/vize-native"])),
+  // Fast variant for test pipelines. `build:ci` uses the `ci` cargo profile
+  // (inherits dev, debug=false, incremental=false). It is the same profile
+  // every other Rust CI job already uses and is roughly 3x faster than the
+  // release profile that `build:native` runs. The release profile is only
+  // needed by publishing flows, so test:js can stay on this fast path.
+  "build:native:test": noCacheTask(runPackageScriptDirectly("build:ci", ["./npm/vize-native"])),
   "build:wasm": task(moonScript("build_vitrine_wasm", "nodejs", "npm/vite-plugin-vize/wasm")),
   "build:wasm-web": task(moonScript("build_vitrine_wasm", "web", "playground/src/wasm")),
   "build:vite-plugin": noCacheTask(

--- a/tools/vite-plus/tasks/test-benchmark.ts
+++ b/tools/vite-plus/tasks/test-benchmark.ts
@@ -58,7 +58,11 @@ const rustBranchCoverageCommand = [
 export const testAndBenchmarkTasks = defineTasks({
   test: noCacheTask(runTasks("test:rust", "test:js", "test:scripts")),
   "test:rust": task("cargo test --workspace", { input: cacheInputs.rust }),
-  "test:js": noCacheTask(`${runTask("build:native")} && ${jsPackageTestCommand}`),
+  // Use the CI-profile native build instead of the release-profile one.
+  // The release build was ~3m+ on GitHub Actions and was being immediately
+  // overwritten by vite-plugin-vize's pretest hook, which also rebuilds in
+  // dev profile (~1m20s). Building once in the CI profile saves both legs.
+  "test:js": noCacheTask(`${runTask("build:native:test")} && ${jsPackageTestCommand}`),
   "test:scripts": noCacheTask("node --test --test-concurrency=1 tests/tooling/*.test.ts"),
   "test:playground": task(runInPackages("test:browser", ["./playground"]), {
     input: cacheInputs.jsChecks,


### PR DESCRIPTION
## Summary

Cut PR CI wall time significantly by:

1. **`test-js-packages` ~6m → ~1.5m**: stop building the native binary twice in incompatible cargo profiles.
2. **`test-scripts` ~3m → ~30s**: remove the unnecessary cargo build (these tests are pure JS).
3. **`nix-flake` off `pull_request`** (~7m saved): push-to-main + daily schedule.
4. **`source-coverage` off `pull_request`** (~4–6m saved): push-to-main + daily schedule.
5. **`branch-coverage` off `pull_request`** (~2m saved): push-to-main + daily schedule.

## Why

### `test-js-packages` was building native twice (~6m → ~1.5m)

The most recent green run had:

```
00:54:42 → 00:57:59  build:native           cargo build --release         3m 17s
00:57:59 → 00:59:28  vite-plugin-vize/test  cargo build (dev profile)     1m 21s   ← rebuilds the same .node
00:59:31 → 00:59:32  actual JS tests        node --test src/*.test.ts     ~1s per package
```

Two cargo builds in different profiles, both writing to `npm/vize-native/vize-vitrine.<target>.node`. The dev build overwrote the release build.

**Fix**: switch both ends to the existing CI cargo profile.

- New `build:native:test` task wraps vize-native's `build:ci` script (already used by every other Rust CI job, ~3× faster than release).
- `test:js` task now calls `build:native:test`.
- `vite-plugin-vize`'s `test` script now calls `build:ci` instead of `build:debug`, so cargo's incremental cache makes the second invocation a no-op.
- `build:native` (release profile) is unchanged so publishing flows still ship release binaries.

### `test-scripts` was building vize CLI for no reason (~3m → ~30s)

`vp run --workspace-root test:scripts` runs `node --test tests/tooling/*.test.ts`. Every test under `tests/tooling/` is pure JS — they read repo files (package.json manifests, workflow YAML, fixture inventories) and assert structural invariants. The single test that mentions the binary (`e2e-binaries.test.ts`) spawns `process.execPath` with stubbed env overrides and never invokes the compiled CLI.

**Fix**: remove the Rust toolchain setup, moonbit setup, rust-cache step, and the `cargo build --profile ci -p vize` step from this job.

### Slow gates moved off `pull_request`

| Job              | PR wall time | New trigger                            |
| ---------------- | ------------ | -------------------------------------- |
| `nix-flake`      | ~7 min       | push-to-main + daily schedule          |
| `source-coverage`| ~4–6 min     | push-to-main + daily schedule          |
| `branch-coverage`| ~2 min       | push-to-main + daily schedule          |

Rationale:

- **`nix-flake`**: `nix flake check` rarely catches regressions on PRs that do not touch `flake.nix`/`flake.lock`. The flake is post-merge sensitive (downstream packagers reproduce against `main`), so push-to-main + nightly is the right cadence.
- **Coverage jobs**: source and branch coverage are trend metrics, not per-PR signals. A single PR rarely moves workspace-wide coverage in a meaningful way. The compiler fixture coverage gate (`coverage`, ~1 min) still runs on every PR and catches per-PR fixture regressions.

All three jobs remain in `test-report.needs`; `test-report` already has `if: always()`, so the inventory comment still posts on PRs when these are skipped.

### `check.yml` schedule

New `schedule:` trigger added to `check.yml`:

```yaml
schedule:
  - cron: "11 3 * * *"  # 03:11 UTC daily (~12:11 JST)
```

Offset from native-smoke (`17 3 * * 1` weekly) and e2e (`23 2 * * *` daily) to spread GitHub Actions concurrency budget.

## Expected impact per PR

| Saved | From                                                                 |
| ----- | -------------------------------------------------------------------- |
| ~4 min | test-js-packages: release → CI profile, no duplicate rebuild          |
| ~2.5 min | test-scripts: drop the Rust bootstrap                              |
| ~7 min | nix-flake skipped on PR                                              |
| ~4–6 min | source-coverage skipped on PR                                      |
| ~2 min | branch-coverage skipped on PR                                        |
| **~20+ min** | **Total per-PR wall time saved on the slow path**             |

## Test plan

- [ ] CI on this PR is green.
- [ ] `test-js-packages` is noticeably faster.
- [ ] `test-scripts` runs without the Rust setup steps.
- [ ] `nix-flake`, `source-coverage`, `branch-coverage` are skipped on this PR.
- [ ] `test-report` still produces its inventory comment on this PR.
- [ ] On a follow-up push to `main`, all three skipped jobs run.
- [ ] `node --test tests/tooling/github-workflows.test.ts` passes (37/37).

## Notes

- Local `vp run --filter './npm/vite-plugin-vize' test` still works without prior workspace setup because the pretest hook builds vize-native on demand (now in the CI profile, fast).
- Release profile is still produced by `vp run build:native` (used by `publish:native` in release.yml); this PR does not touch publishing.
- Issue #492 (release-blocking coverage gates) already enforces thresholds via the script; the gate still runs (on push-to-main + schedule), just not on every PR.
