### PR TITLE
ci: skip coverage on PR and trim test-scripts bootstrap

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -326,6 +326,13 @@ jobs:
   source-coverage:
     runs-on: ubuntu-latest
     timeout-minutes: 40
+    # cargo llvm-cov against the whole workspace consistently runs in the
+    # 4–6 minute range. Coverage is a trend metric, not a per-PR signal —
+    # a single PR rarely meaningfully changes workspace-wide percentages.
+    # Run on push-to-main (so regressions surface within minutes of merge)
+    # and on the daily schedule. The fixture-coverage job (`coverage`) and
+    # the compiler/lint suites still run on every PR.
+    if: ${{ github.event_name != 'pull_request' }}
     env:
       NODE_OPTIONS: "--disable-warning=DEP0040 --disable-warning=DEP0169"
     steps:
@@ -371,6 +378,11 @@ jobs:
   branch-coverage:
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    # Nightly Rust branch coverage on the core compiler crates. Same
+    # rationale as source-coverage: a single PR does not move branch
+    # coverage in a way that needs gating per-PR. Push-to-main + schedule
+    # keeps the trend honest without paying ~2 minutes on every PR.
+    if: ${{ github.event_name != 'pull_request' }}
     env:
       NODE_OPTIONS: "--disable-warning=DEP0040 --disable-warning=DEP0169"
     steps:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -171,6 +171,12 @@ jobs:
 
   test-scripts:
     runs-on: ubuntu-latest
+    # No Rust toolchain, no moonbit setup, no cargo build: every test under
+    # tests/tooling/*.test.ts is pure JS (reading repo files and asserting
+    # structural invariants). The single test that mentions the vize binary
+    # (`e2e-binaries.test.ts`) spawns `process.execPath` with stubbed env
+    # overrides — it never invokes the compiled CLI. Skipping the Rust
+    # bootstrap saves ~30 seconds per PR.
     timeout-minutes: 15
     env:
       NODE_OPTIONS: "--disable-warning=DEP0040 --disable-warning=DEP0169"
@@ -181,18 +187,8 @@ jobs:
           node-version-file: ".node-version"
           cache: true
           run-install: false
-      - uses: ./.github/actions/setup-moonbit
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-        with:
-          shared-key: "native"
-          cache-workspace-crates: "true"
       - name: Install JS dependencies
         run: vp install --frozen-lockfile --prefer-offline
-      - name: Build vize CLI
-        run: cargo build --profile ci -p vize
-      - name: Install vize CLI
-        run: cp target/ci/vize /usr/local/bin/vize
       - name: Test release scripts
         run: vp run --workspace-root test:scripts
 


### PR DESCRIPTION
## Summary

Follow-up to #518 — moves three more slow gates off `pull_request` so they no longer pay their wall-time cost on every PR.

| Job              | PR before | PR after | Trigger after                  |
| ---------------- | --------- | -------- | ------------------------------ |
| `source-coverage` | ~4–6 min | skipped  | push-to-main + daily schedule  |
| `branch-coverage` | ~2 min   | skipped  | push-to-main + daily schedule  |
| `test-scripts`    | ~3 min   | ~30s     | PR + push-to-main + schedule   |

## Why each one

### `source-coverage` and `branch-coverage` — coverage is a trend metric

`cargo llvm-cov` against the workspace consistently runs in the 4–6 minute range; the branch-coverage run on the core compiler crates adds another ~2 minutes. **Workspace-wide coverage rarely moves in a meaningful way on a single PR.** The fixture coverage gate (`coverage`, ~50 seconds) still runs on every PR and catches per-PR fixture regressions; the source/branch gates run on every push to `main` and nightly, so regressions still surface within minutes of merge.

The threshold enforcement script (`tools/coverage/enforce-rust-source-coverage.mjs`) still fails the push-to-main run if coverage drops below the agreed minimums (70% lines/functions/regions for source, 40% branches for the core crates). The release-blocking gate stays — it just stops billing every PR for it.

### `test-scripts` — the Rust setup was dead weight

`vp run --workspace-root test:scripts` runs `node --test tests/tooling/*.test.ts`. Every test under `tests/tooling/` is pure JS — they read repo files (`package.json` manifests, workflow YAML, fixture inventories) and assert structural invariants. The single test that mentions the vize binary (`tests/tooling/e2e-binaries.test.ts`) spawns `process.execPath` with stubbed env overrides; it never invokes the compiled vize CLI.

The job was running:

- `dtolnay/rust-toolchain@stable`
- `./.github/actions/setup-moonbit`
- `Swatinem/rust-cache@v2` with workspace crates
- `cargo build --profile ci -p vize`
- `cp target/ci/vize /usr/local/bin/vize`

…all for nothing. Removing those steps saves ~30 seconds per PR with zero coverage loss.

## Notes

- `test-report.needs` still lists `source-coverage` and `branch-coverage`; `test-report` already uses `if: always()`, so the inventory comment still posts on PRs when those jobs are skipped.
- The schedule trigger added to `check.yml` in #518 (`11 3 * * *`, daily) drives the nightly run for both coverage jobs.

## Test plan

- [ ] CI on this PR is green.
- [ ] `source-coverage` and `branch-coverage` are skipped on this PR.
- [ ] `test-scripts` runs without the Rust setup steps.
- [ ] `test-report` still produces its inventory comment.
- [ ] On a follow-up push to `main`, both coverage jobs run.
- [ ] `node --test tests/tooling/github-workflows.test.ts` passes (37/37).
