### PR TITLE
fix(vize): make @pkl-community/pkl an optional peer dependency, not bundled

### DIFF
--- a/docs/content/guide/configuration.md
+++ b/docs/content/guide/configuration.md
@@ -65,6 +65,24 @@ export default defineConfig(({ command, mode, isSsrBuild }) => ({
 
 ## PKL Config
 
+The `@pkl-community/pkl` CLI is an optional peer dependency, not a bundled
+dependency, because its native binaries add ~50 MB to the install footprint of
+projects that never use PKL config. Add it to your project only when you want
+`vize.config.pkl` resolution:
+
+```sh
+npm install --save-dev @pkl-community/pkl
+# or:
+pnpm add -D @pkl-community/pkl
+# or:
+yarn add -D @pkl-community/pkl
+```
+
+Vize also accepts a system `pkl` binary on `PATH`, so installing the npm
+package is optional if your environment already provides one. When no pkl
+binary is reachable, `vize.config.pkl` is skipped and Vize falls back to the
+next supported config format.
+
 ```pkl
 amends "node_modules/vize/pkl/vize.pkl"
 

--- a/npm/vize/package.json
+++ b/npm/vize/package.json
@@ -67,8 +67,13 @@
     "vite": "catalog:vite-stack",
     "vite-plus": "catalog:vite-stack"
   },
-  "optionalDependencies": {
+  "peerDependencies": {
     "@pkl-community/pkl": "catalog:repo-tooling"
+  },
+  "peerDependenciesMeta": {
+    "@pkl-community/pkl": {
+      "optional": true
+    }
   },
   "engines": {
     "node": ">=22"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -760,10 +760,6 @@ importers:
       vite-plus:
         specifier: catalog:vite-stack
         version: 0.1.21(@tsdown/css@0.22.0)(@types/node@25.7.0)(@voidzero-dev/vite-plus-core@0.1.21(@tsdown/css@0.22.0)(@types/node@25.7.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0))(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0)
-    optionalDependencies:
-      '@pkl-community/pkl':
-        specifier: catalog:repo-tooling
-        version: 0.27.2
 
   npm/vize-native:
     devDependencies:


### PR DESCRIPTION
## Summary

- `@pkl-community/pkl` ships native Java binaries that add ~50 MB to the install footprint of every project depending on `vize`, regardless of whether the project actually writes `vize.config.pkl`. The user feedback was: \"pkl をバンドルするとでかい — peer にしてほしい.\"
- Move the entry from `optionalDependencies` to `peerDependencies` + `peerDependenciesMeta` (optional). npm/pnpm/yarn no longer pull pkl into the dependency tree by default and do not warn when it is absent. Projects that want PKL config explicitly `npm install --save-dev @pkl-community/pkl`.
- Drop the matching `optionalDependencies` block from npm/vize's importer in `pnpm-lock.yaml`. The repo-tooling catalog pin stays because vize's runtime still resolves `@pkl-community/pkl` through `import.meta.resolve` when the consumer installs it explicitly, and the catalog gives that resolution a stable version.
- Document the explicit install command in the PKL Config section of the configuration guide, and reiterate that a `pkl` binary on PATH is an acceptable substitute.

## No behavior change for users who want PKL

`npm/vize/src/config.ts` already handles the missing-pkl case gracefully:

1. `import.meta.resolve(\"@pkl-community/pkl\")` — used when the peer is installed.
2. `execFileSync(\"pkl\", [\"--version\"])` — system PATH fallback.
3. Console warning + fall back to the next config format when neither is found.

Switching the dependency kind only changes whether pkl is installed *by default*, not whether it works when present.

## Test plan

- [x] `npm/vize/package.json` parses as valid JSON.
- [x] `node --test tests/tooling/package-manifests.test.ts` — only the pre-existing v0.108.0 catalog-drift test fails (tracked separately by [#522](https://github.com/ubugeeei/vize/pull/522)); the other 11 tests pass, including the ones that read `optionalDependencies` for `@vizejs/native-*`.
- [ ] `pnpm install --frozen-lockfile` on a fresh clone (will be exercised by the `node-engine-compat` and fresh-install smoke jobs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)