### PR TITLE
feat: expose CSS AST parse/print

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -707,6 +707,7 @@ dependencies = [
  "dtoa-short",
  "itoa",
  "phf 0.11.3",
+ "serde",
  "smallvec",
 ]
 
@@ -1434,6 +1435,7 @@ dependencies = [
  "serde",
  "serde-content",
  "smallvec",
+ "static-self",
 ]
 
 [[package]]
@@ -2111,7 +2113,9 @@ dependencies = [
  "phf_codegen 0.11.3",
  "precomputed-hash",
  "rustc-hash",
+ "serde",
  "smallvec",
+ "static-self",
 ]
 
 [[package]]
@@ -2911,6 +2915,28 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "static-self"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6635404b73efc136af3a7956e53c53d4f34b2f16c95a15c438929add0f69412"
+dependencies = [
+ "indexmap",
+ "smallvec",
+ "static-self-derive",
+]
+
+[[package]]
+name = "static-self-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5268c96d4b907c558a9a52d8492522d6c7b559651a5e1d8f2d551e461b9425d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "static_assertions"

--- a/crates/vize_atelier_sfc/Cargo.toml
+++ b/crates/vize_atelier_sfc/Cargo.toml
@@ -9,7 +9,7 @@ description = "Atelier SFC - The Single File Component workshop for Vize"
 
 [features]
 default = ["native"]
-native = ["dep:lightningcss"]
+native = ["dep:lightningcss", "lightningcss/serde"]
 
 [dependencies]
 vize_carton = { workspace = true }

--- a/crates/vize_atelier_sfc/README.md
+++ b/crates/vize_atelier_sfc/README.md
@@ -8,12 +8,15 @@
 - Script compilation and binding metadata extraction
 - Template compilation through DOM or Vapor backends
 - Scoped CSS and style transforms powered by Lightning CSS
+- Serialized CSS AST parse/print helpers for parser-backed tooling
 
 ## Key Entry Points
 
 - `parse_sfc`
 - `compile_sfc`
 - `compile_css`
+- `parse_css_ast`
+- `print_css_ast`
 - `compile_style_block`
 - `SfcParseOptions`
 - `SfcCompileOptions`

--- a/crates/vize_atelier_sfc/src/css.rs
+++ b/crates/vize_atelier_sfc/src/css.rs
@@ -94,6 +94,23 @@ pub struct CssModuleExport {
     pub is_referenced: bool,
 }
 
+/// CSS AST parsing result.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CssAstResult {
+    /// Serialized LightningCSS AST.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ast: Option<serde_json::Value>,
+
+    /// Errors during parsing or serialization.
+    #[serde(default)]
+    pub errors: Vec<String>,
+
+    /// Warnings during parsing.
+    #[serde(default)]
+    pub warnings: Vec<String>,
+}
+
 /// CSS compilation result
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -121,6 +138,71 @@ pub struct CssCompileResult {
     /// Only populated when `css_modules: true`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub exports: Option<FxHashMap<String, CssModuleExport>>,
+}
+
+/// Parse CSS into a serialized LightningCSS AST.
+#[cfg(feature = "native")]
+pub fn parse_css_ast(css: &str, options: &CssCompileOptions) -> CssAstResult {
+    let result = parser::parse_css_ast_internal(
+        css,
+        options.filename.as_deref().unwrap_or("style.css"),
+        options.custom_media,
+        options.css_modules,
+    );
+
+    CssAstResult {
+        ast: result.ast,
+        errors: result.errors,
+        warnings: result.warnings,
+    }
+}
+
+/// Print CSS from a serialized LightningCSS AST.
+#[cfg(feature = "native")]
+pub fn print_css_ast(ast: serde_json::Value, options: &CssCompileOptions) -> CssCompileResult {
+    let targets = options
+        .targets
+        .as_ref()
+        .map(|t| t.to_lightningcss_targets())
+        .unwrap_or_default();
+
+    let result = parser::print_css_ast_internal(ast, options.minify, targets);
+
+    CssCompileResult {
+        code: result.code,
+        map: None,
+        css_vars: vec![],
+        errors: result.errors,
+        warnings: vec![],
+        exports: result.exports,
+    }
+}
+
+/// Parse CSS into a serialized AST (wasm fallback).
+#[cfg(not(feature = "native"))]
+pub fn parse_css_ast(_css: &str, _options: &CssCompileOptions) -> CssAstResult {
+    CssAstResult {
+        ast: None,
+        errors: vec![String::from(
+            "CSS AST parsing requires the `native` feature",
+        )],
+        warnings: vec![],
+    }
+}
+
+/// Print CSS from a serialized AST (wasm fallback).
+#[cfg(not(feature = "native"))]
+pub fn print_css_ast(_ast: serde_json::Value, _options: &CssCompileOptions) -> CssCompileResult {
+    CssCompileResult {
+        code: String::default(),
+        map: None,
+        css_vars: vec![],
+        errors: vec![String::from(
+            "CSS AST printing requires the `native` feature",
+        )],
+        warnings: vec![],
+        exports: None,
+    }
 }
 
 /// Compile CSS using LightningCSS (native feature enabled)

--- a/crates/vize_atelier_sfc/src/css/parser.rs
+++ b/crates/vize_atelier_sfc/src/css/parser.rs
@@ -7,6 +7,9 @@ use lightningcss::bundler::{Bundler, FileProvider};
 use lightningcss::printer::PrinterOptions;
 use lightningcss::stylesheet::{MinifyOptions, ParserFlags, ParserOptions, StyleSheet};
 use lightningcss::targets::Targets;
+use serde::Deserialize;
+use serde::de::IntoDeserializer;
+use serde_json::Value;
 use std::path::Path;
 use vize_carton::{FxHashMap, String, ToCompactString};
 
@@ -22,6 +25,148 @@ pub(crate) struct CssInternalResult {
     pub code: String,
     pub errors: Vec<String>,
     pub exports: Option<FxHashMap<String, VizeCssModuleExport>>,
+}
+
+pub(crate) struct CssAstInternalResult {
+    pub ast: Option<Value>,
+    pub errors: Vec<String>,
+    pub warnings: Vec<String>,
+}
+
+pub(crate) fn parse_css_ast_internal(
+    css: &str,
+    filename: &str,
+    custom_media: bool,
+    css_modules: bool,
+) -> CssAstInternalResult {
+    let mut flags = ParserFlags::NESTING | ParserFlags::DEEP_SELECTOR_COMBINATOR;
+    if custom_media {
+        flags |= ParserFlags::CUSTOM_MEDIA;
+    }
+
+    let css_modules_config = if css_modules {
+        Some(lightningcss::css_modules::Config {
+            pattern: lightningcss::css_modules::Pattern::default(),
+            ..Default::default()
+        })
+    } else {
+        None
+    };
+
+    let parser_options = ParserOptions {
+        filename: filename.into(),
+        flags,
+        css_modules: css_modules_config,
+        ..Default::default()
+    };
+
+    let stylesheet = match StyleSheet::parse(css, parser_options) {
+        Ok(stylesheet) => stylesheet,
+        Err(e) => {
+            let mut message = String::from("CSS parse error: ");
+            message.push_str(&e.to_compact_string());
+            return CssAstInternalResult {
+                ast: None,
+                errors: vec![message],
+                warnings: vec![],
+            };
+        }
+    };
+
+    match serde_json::to_value(stylesheet) {
+        Ok(ast) => CssAstInternalResult {
+            ast: Some(ast),
+            errors: vec![],
+            warnings: vec![],
+        },
+        Err(e) => {
+            let mut message = String::from("CSS AST serialization error: ");
+            use std::fmt::Write as _;
+            let _ = write!(&mut message, "{e}");
+            CssAstInternalResult {
+                ast: None,
+                errors: vec![message],
+                warnings: vec![],
+            }
+        }
+    }
+}
+
+pub(crate) fn print_css_ast_internal(
+    ast: Value,
+    minify: bool,
+    targets: Targets,
+) -> CssInternalResult {
+    let mut stylesheet: StyleSheet = match StyleSheet::deserialize(ast.into_deserializer()) {
+        Ok(stylesheet) => stylesheet,
+        Err(e) => {
+            let mut message = String::from("CSS AST deserialization error: ");
+            use std::fmt::Write as _;
+            let _ = write!(&mut message, "{e}");
+            return CssInternalResult {
+                code: String::from(""),
+                errors: vec![message],
+                exports: None,
+            };
+        }
+    };
+
+    if minify
+        && let Err(e) = stylesheet.minify(lightningcss::stylesheet::MinifyOptions {
+            targets,
+            ..Default::default()
+        })
+    {
+        let mut message = String::from("CSS minify error: ");
+        use std::fmt::Write as _;
+        let _ = write!(&mut message, "{e:?}");
+        return CssInternalResult {
+            code: String::from(""),
+            errors: vec![message],
+            exports: None,
+        };
+    }
+
+    let printer_options = PrinterOptions {
+        minify,
+        targets,
+        ..Default::default()
+    };
+
+    match stylesheet.to_css(printer_options) {
+        Ok(result) => {
+            let exports = result.exports.map(|export_map| {
+                export_map
+                    .into_iter()
+                    .map(|(original, export)| {
+                        (
+                            original.to_compact_string(),
+                            VizeCssModuleExport {
+                                name: export.name.to_compact_string(),
+                                is_referenced: export.is_referenced,
+                            },
+                        )
+                    })
+                    .collect()
+            });
+
+            CssInternalResult {
+                code: result.code.into(),
+                errors: vec![],
+                exports,
+            }
+        }
+        Err(e) => {
+            let mut message = String::from("CSS print error: ");
+            use std::fmt::Write as _;
+            let _ = write!(&mut message, "{e:?}");
+            CssInternalResult {
+                code: String::from(""),
+                errors: vec![message],
+                exports: None,
+            }
+        }
+    }
 }
 
 /// Internal CSS compilation with owned strings to avoid borrow issues

--- a/crates/vize_atelier_sfc/src/css/tests.rs
+++ b/crates/vize_atelier_sfc/src/css/tests.rs
@@ -11,7 +11,7 @@ use super::scoped::{
     add_scope_to_element, apply_scoped_css, transform_deep, transform_global, transform_slotted,
 };
 use super::transform::extract_and_transform_v_bind;
-use super::{CssCompileOptions, bundle_css, compile_css};
+use super::{CssCompileOptions, bundle_css, compile_css, parse_css_ast, print_css_ast};
 
 fn test_utf8(bytes: &[u8]) -> &str {
     match std::str::from_utf8(bytes) {
@@ -41,6 +41,57 @@ fn test_compile_scoped_css() {
     );
     assert!(result.errors.is_empty());
     insta::assert_debug_snapshot!(result);
+}
+
+#[cfg(feature = "native")]
+fn rewrite_url_nodes(value: &mut serde_json::Value, from: &str, to: &str) {
+    match value {
+        serde_json::Value::Object(map) => {
+            if map.get("url") == Some(&serde_json::Value::String(from.to_string())) {
+                map.insert("url".to_string(), serde_json::Value::String(to.to_string()));
+            }
+
+            for child in map.values_mut() {
+                rewrite_url_nodes(child, from, to);
+            }
+        }
+        serde_json::Value::Array(items) => {
+            for child in items {
+                rewrite_url_nodes(child, from, to);
+            }
+        }
+        _ => {}
+    }
+}
+
+#[test]
+#[cfg(feature = "native")]
+fn test_parse_and_print_css_ast() {
+    let css = ".foo { background: url('./logo.svg'); color: red; }";
+    let ast_result = parse_css_ast(css, &CssCompileOptions::default());
+
+    assert!(
+        ast_result.errors.is_empty(),
+        "Unexpected errors: {:?}",
+        ast_result.errors
+    );
+
+    let mut ast = ast_result.ast.expect("expected serialized CSS AST");
+    assert!(
+        ast.get("rules").is_some(),
+        "expected stylesheet rules in {ast:?}"
+    );
+
+    rewrite_url_nodes(&mut ast, "./logo.svg", "/assets/logo-hash.svg");
+
+    let result = print_css_ast(ast, &CssCompileOptions::default());
+    assert!(
+        result.errors.is_empty(),
+        "Unexpected errors: {:?}",
+        result.errors
+    );
+    assert!(result.code.contains("background"));
+    assert!(result.code.contains("/assets/logo-hash.svg"));
 }
 
 #[test]

--- a/crates/vize_atelier_sfc/src/lib.rs
+++ b/crates/vize_atelier_sfc/src/lib.rs
@@ -60,7 +60,8 @@ pub use bundler::{
 };
 pub use compile::{ScriptCompileResult, compile_sfc};
 pub use css::{
-    CssCompileOptions, CssCompileResult, CssTargets, bundle_css, compile_css, compile_style_block,
+    CssAstResult, CssCompileOptions, CssCompileResult, CssTargets, bundle_css, compile_css,
+    compile_style_block, parse_css_ast, print_css_ast,
 };
 pub use parse::parse_sfc;
 pub use types::{

--- a/crates/vize_vitrine/src/napi/sfc/css.rs
+++ b/crates/vize_vitrine/src/napi/sfc/css.rs
@@ -26,6 +26,13 @@ pub struct CssTargetsNapi {
 }
 
 #[napi(object)]
+pub struct CssAstResultNapi {
+    pub ast: Option<serde_json::Value>,
+    pub errors: Vec<String>,
+    pub warnings: Vec<String>,
+}
+
+#[napi(object)]
 pub struct CssCompileResultNapi {
     pub code: String,
     pub map: Option<String>,
@@ -34,12 +41,10 @@ pub struct CssCompileResultNapi {
     pub warnings: Vec<String>,
 }
 
-#[napi(js_name = "compileCss")]
-pub fn compile_css_napi(
-    source: String,
+fn css_options_from_napi(
     options: Option<CssCompileOptionsNapi>,
-) -> Result<CssCompileResultNapi> {
-    use vize_atelier_sfc::{CssCompileOptions, CssTargets, compile_css};
+) -> vize_atelier_sfc::CssCompileOptions {
+    use vize_atelier_sfc::{CssCompileOptions, CssTargets};
 
     let opts = options.unwrap_or_default();
     let targets = opts.targets.map(|targets| CssTargets {
@@ -51,19 +56,54 @@ pub fn compile_css_napi(
         android: targets.android,
     });
 
-    let result = compile_css(
-        &source,
-        &CssCompileOptions {
-            filename: opts.filename.map(Into::into),
-            scoped: opts.scoped.unwrap_or(false),
-            scope_id: opts.scope_id.map(Into::into),
-            source_map: opts.source_map.unwrap_or(false),
-            minify: opts.minify.unwrap_or(false),
-            css_modules: opts.css_modules.unwrap_or(false),
-            custom_media: opts.custom_media.unwrap_or(false),
-            targets,
-        },
-    );
+    CssCompileOptions {
+        filename: opts.filename.map(Into::into),
+        scoped: opts.scoped.unwrap_or(false),
+        scope_id: opts.scope_id.map(Into::into),
+        source_map: opts.source_map.unwrap_or(false),
+        minify: opts.minify.unwrap_or(false),
+        css_modules: opts.css_modules.unwrap_or(false),
+        custom_media: opts.custom_media.unwrap_or(false),
+        targets,
+    }
+}
+
+#[napi(js_name = "parseCssAst")]
+pub fn parse_css_ast_napi(
+    source: String,
+    options: Option<CssCompileOptionsNapi>,
+) -> Result<CssAstResultNapi> {
+    let result = vize_atelier_sfc::parse_css_ast(&source, &css_options_from_napi(options));
+
+    Ok(CssAstResultNapi {
+        ast: result.ast,
+        errors: result.errors.into_iter().map(Into::into).collect(),
+        warnings: result.warnings.into_iter().map(Into::into).collect(),
+    })
+}
+
+#[napi(js_name = "printCssAst")]
+pub fn print_css_ast_napi(
+    ast: serde_json::Value,
+    options: Option<CssCompileOptionsNapi>,
+) -> Result<CssCompileResultNapi> {
+    let result = vize_atelier_sfc::print_css_ast(ast, &css_options_from_napi(options));
+
+    Ok(CssCompileResultNapi {
+        code: result.code.into(),
+        map: result.map.map(Into::into),
+        css_vars: result.css_vars.into_iter().map(Into::into).collect(),
+        errors: result.errors.into_iter().map(Into::into).collect(),
+        warnings: result.warnings.into_iter().map(Into::into).collect(),
+    })
+}
+
+#[napi(js_name = "compileCss")]
+pub fn compile_css_napi(
+    source: String,
+    options: Option<CssCompileOptionsNapi>,
+) -> Result<CssCompileResultNapi> {
+    let result = vize_atelier_sfc::compile_css(&source, &css_options_from_napi(options));
 
     Ok(CssCompileResultNapi {
         code: result.code.into(),

--- a/crates/vize_vitrine/src/wasm.rs
+++ b/crates/vize_vitrine/src/wasm.rs
@@ -504,6 +504,26 @@ impl Compiler {
         }
     }
 
+    /// Parse CSS into a serialized LightningCSS AST.
+    #[wasm_bindgen(js_name = "parseCssAst")]
+    pub fn parse_css_ast_method(&self, css: &str, options: JsValue) -> Result<JsValue, JsValue> {
+        use vize_atelier_sfc::parse_css_ast;
+        let opts = parse_css_options(options);
+        let result = parse_css_ast(css, &opts);
+        to_js_value(&result)
+    }
+
+    /// Print CSS from a serialized LightningCSS AST.
+    #[wasm_bindgen(js_name = "printCssAst")]
+    pub fn print_css_ast_method(&self, ast: JsValue, options: JsValue) -> Result<JsValue, JsValue> {
+        use vize_atelier_sfc::print_css_ast;
+        let ast = serde_wasm_bindgen::from_value(ast)
+            .map_err(|e| JsValue::from_str(&format!("Invalid CSS AST: {e}")))?;
+        let opts = parse_css_options(options);
+        let result = print_css_ast(ast, &opts);
+        to_js_value(&result)
+    }
+
     /// Compile CSS with LightningCSS
     #[wasm_bindgen(js_name = "compileCss")]
     pub fn compile_css_method(&self, css: &str, options: JsValue) -> Result<JsValue, JsValue> {
@@ -900,6 +920,18 @@ pub fn parse_sfc_fn(source: &str, options: JsValue) -> Result<JsValue, JsValue> 
 #[wasm_bindgen(js_name = "compileSfc")]
 pub fn compile_sfc_fn(source: &str, options: JsValue) -> Result<JsValue, JsValue> {
     Compiler::new().compile_sfc(source, options)
+}
+
+/// Parse CSS to AST (free function)
+#[wasm_bindgen(js_name = "parseCssAst")]
+pub fn parse_css_ast_fn(css: &str, options: JsValue) -> Result<JsValue, JsValue> {
+    Compiler::new().parse_css_ast_method(css, options)
+}
+
+/// Print CSS from AST (free function)
+#[wasm_bindgen(js_name = "printCssAst")]
+pub fn print_css_ast_fn(ast: JsValue, options: JsValue) -> Result<JsValue, JsValue> {
+    Compiler::new().print_css_ast_method(ast, options)
 }
 
 /// Compile CSS (free function)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,29 +77,29 @@ catalogs:
       version: 1.64.0
   native-binaries:
     '@vizejs/native-darwin-arm64':
-      specifier: 0.107.0
-      version: 0.107.0
+      specifier: 0.108.0
+      version: 0.108.0
     '@vizejs/native-darwin-x64':
-      specifier: 0.107.0
-      version: 0.107.0
+      specifier: 0.108.0
+      version: 0.108.0
     '@vizejs/native-linux-arm64-gnu':
-      specifier: 0.107.0
-      version: 0.107.0
+      specifier: 0.108.0
+      version: 0.108.0
     '@vizejs/native-linux-arm64-musl':
-      specifier: 0.107.0
-      version: 0.107.0
+      specifier: 0.108.0
+      version: 0.108.0
     '@vizejs/native-linux-x64-gnu':
-      specifier: 0.107.0
-      version: 0.107.0
+      specifier: 0.108.0
+      version: 0.108.0
     '@vizejs/native-linux-x64-musl':
-      specifier: 0.107.0
-      version: 0.107.0
+      specifier: 0.108.0
+      version: 0.108.0
     '@vizejs/native-win32-arm64-msvc':
-      specifier: 0.107.0
-      version: 0.107.0
+      specifier: 0.108.0
+      version: 0.108.0
     '@vizejs/native-win32-x64-msvc':
-      specifier: 0.107.0
-      version: 0.107.0
+      specifier: 0.108.0
+      version: 0.108.0
   oxc:
     oxc-transform:
       specifier: 0.130.0
@@ -512,28 +512,28 @@ importers:
     optionalDependencies:
       '@vizejs/native-darwin-arm64':
         specifier: catalog:native-binaries
-        version: 0.107.0
+        version: 0.108.0
       '@vizejs/native-darwin-x64':
         specifier: catalog:native-binaries
-        version: 0.107.0
+        version: 0.108.0
       '@vizejs/native-linux-arm64-gnu':
         specifier: catalog:native-binaries
-        version: 0.107.0
+        version: 0.108.0
       '@vizejs/native-linux-arm64-musl':
         specifier: catalog:native-binaries
-        version: 0.107.0
+        version: 0.108.0
       '@vizejs/native-linux-x64-gnu':
         specifier: catalog:native-binaries
-        version: 0.107.0
+        version: 0.108.0
       '@vizejs/native-linux-x64-musl':
         specifier: catalog:native-binaries
-        version: 0.107.0
+        version: 0.108.0
       '@vizejs/native-win32-arm64-msvc':
         specifier: catalog:native-binaries
-        version: 0.107.0
+        version: 0.108.0
       '@vizejs/native-win32-x64-msvc':
         specifier: catalog:native-binaries
-        version: 0.107.0
+        version: 0.108.0
 
   npm/rspack-vize-plugin:
     dependencies:
@@ -773,28 +773,28 @@ importers:
     optionalDependencies:
       '@vizejs/native-darwin-arm64':
         specifier: catalog:native-binaries
-        version: 0.107.0
+        version: 0.108.0
       '@vizejs/native-darwin-x64':
         specifier: catalog:native-binaries
-        version: 0.107.0
+        version: 0.108.0
       '@vizejs/native-linux-arm64-gnu':
         specifier: catalog:native-binaries
-        version: 0.107.0
+        version: 0.108.0
       '@vizejs/native-linux-arm64-musl':
         specifier: catalog:native-binaries
-        version: 0.107.0
+        version: 0.108.0
       '@vizejs/native-linux-x64-gnu':
         specifier: catalog:native-binaries
-        version: 0.107.0
+        version: 0.108.0
       '@vizejs/native-linux-x64-musl':
         specifier: catalog:native-binaries
-        version: 0.107.0
+        version: 0.108.0
       '@vizejs/native-win32-arm64-msvc':
         specifier: catalog:native-binaries
-        version: 0.107.0
+        version: 0.108.0
       '@vizejs/native-win32-x64-msvc':
         specifier: catalog:native-binaries
-        version: 0.107.0
+        version: 0.108.0
 
   npm/vize-wasm: {}
 
@@ -4644,49 +4644,49 @@ packages:
       vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
       vue: ^3.2.25
 
-  '@vizejs/native-darwin-arm64@0.107.0':
+  '@vizejs/native-darwin-arm64@0.108.0':
     resolution: {integrity: sha512-ZqvwALhqWnJTqQyhSUqDJ34MqA5+oI5wY11jS3xLVZsvfPm9DNLJQNXn2VDo49yWFhEU8OHqgAqOU8emaSH3hg==}
     engines: {node: '>=22'}
     cpu: [arm64]
     os: [darwin]
 
-  '@vizejs/native-darwin-x64@0.107.0':
+  '@vizejs/native-darwin-x64@0.108.0':
     resolution: {integrity: sha512-OTh68An/PkJoXdwrbYNHacIZTnAUVKc5ZbxBRIXA5Tl89B3uvBpNes8YE4lh5EVAoAzSszDR80wYchHGdk43IQ==}
     engines: {node: '>=22'}
     cpu: [x64]
     os: [darwin]
 
-  '@vizejs/native-linux-arm64-gnu@0.107.0':
+  '@vizejs/native-linux-arm64-gnu@0.108.0':
     resolution: {integrity: sha512-gTvZOaGGnR027Nzsv/QiBucduAYZ16KXr1rdOAxk5TSfDaOBP+kqKYBDMdGNHl3cRFU+MD3/+gka7c5pIUNI7A==}
     engines: {node: '>=22'}
     cpu: [arm64]
     os: [linux]
 
-  '@vizejs/native-linux-arm64-musl@0.107.0':
+  '@vizejs/native-linux-arm64-musl@0.108.0':
     resolution: {integrity: sha512-DGzhXoGBFbzDB/5AErzefQApBIpjJ0jSsXr2rTPxpjRKa3q7xGErl6FOTlCPCkdedTN824Krt7hZl64mDVTv2A==}
     engines: {node: '>=22'}
     cpu: [arm64]
     os: [linux]
 
-  '@vizejs/native-linux-x64-gnu@0.107.0':
+  '@vizejs/native-linux-x64-gnu@0.108.0':
     resolution: {integrity: sha512-OssgduEJmTlr9MTk9YN910X/CF9SBIpq4lo9XCphWekzMzFeDN0miah363xevhgoyUHBTtCrylGPRnuzb5uNVw==}
     engines: {node: '>=22'}
     cpu: [x64]
     os: [linux]
 
-  '@vizejs/native-linux-x64-musl@0.107.0':
+  '@vizejs/native-linux-x64-musl@0.108.0':
     resolution: {integrity: sha512-c9a0SxdjphfYRmxGjEcND3oNGZ8GRZ6N1BAx75JWE8Cre9KgZOho+prGtYAg6iXuCYVexWFC5+TjfLVzmuKErA==}
     engines: {node: '>=22'}
     cpu: [x64]
     os: [linux]
 
-  '@vizejs/native-win32-arm64-msvc@0.107.0':
+  '@vizejs/native-win32-arm64-msvc@0.108.0':
     resolution: {integrity: sha512-5BEr5xkXDLcdr6uSabLiuscPqBTOxQoW5MdfX3OCZX9XeMMoDm44VE6D6WJLxpjyJqNnxOl6HrScGMxV4htupQ==}
     engines: {node: '>=22'}
     cpu: [arm64]
     os: [win32]
 
-  '@vizejs/native-win32-x64-msvc@0.107.0':
+  '@vizejs/native-win32-x64-msvc@0.108.0':
     resolution: {integrity: sha512-kWNFqhgtpPcJjXrwCYWRcfu7oaMF7puYjtntC90AhEdhejYCRkbm24Yd4dlQpEREn9/IGieG5/p9y8mIcYh5Xw==}
     engines: {node: '>=22'}
     cpu: [x64]
@@ -12361,28 +12361,28 @@ snapshots:
       vite: 7.3.3(@types/node@25.7.0)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.9.0)
       vue: 3.5.34(typescript@6.0.3)
 
-  '@vizejs/native-darwin-arm64@0.107.0':
+  '@vizejs/native-darwin-arm64@0.108.0':
     optional: true
 
-  '@vizejs/native-darwin-x64@0.107.0':
+  '@vizejs/native-darwin-x64@0.108.0':
     optional: true
 
-  '@vizejs/native-linux-arm64-gnu@0.107.0':
+  '@vizejs/native-linux-arm64-gnu@0.108.0':
     optional: true
 
-  '@vizejs/native-linux-arm64-musl@0.107.0':
+  '@vizejs/native-linux-arm64-musl@0.108.0':
     optional: true
 
-  '@vizejs/native-linux-x64-gnu@0.107.0':
+  '@vizejs/native-linux-x64-gnu@0.108.0':
     optional: true
 
-  '@vizejs/native-linux-x64-musl@0.107.0':
+  '@vizejs/native-linux-x64-musl@0.108.0':
     optional: true
 
-  '@vizejs/native-win32-arm64-msvc@0.107.0':
+  '@vizejs/native-win32-arm64-msvc@0.108.0':
     optional: true
 
-  '@vizejs/native-win32-x64-msvc@0.107.0':
+  '@vizejs/native-win32-x64-msvc@0.108.0':
     optional: true
 
   '@voidzero-dev/vite-plus-core@0.1.21(@tsdown/css@0.22.0)(@types/node@25.7.0)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0)':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -100,14 +100,14 @@ catalogs:
 
   # Published native binary packages that are installed optionally at runtime.
   native-binaries:
-    "@vizejs/native-darwin-arm64": "0.107.0"
-    "@vizejs/native-darwin-x64": "0.107.0"
-    "@vizejs/native-linux-arm64-gnu": "0.107.0"
-    "@vizejs/native-linux-arm64-musl": "0.107.0"
-    "@vizejs/native-linux-x64-gnu": "0.107.0"
-    "@vizejs/native-linux-x64-musl": "0.107.0"
-    "@vizejs/native-win32-arm64-msvc": "0.107.0"
-    "@vizejs/native-win32-x64-msvc": "0.107.0"
+    "@vizejs/native-darwin-arm64": "0.108.0"
+    "@vizejs/native-darwin-x64": "0.108.0"
+    "@vizejs/native-linux-arm64-gnu": "0.108.0"
+    "@vizejs/native-linux-arm64-musl": "0.108.0"
+    "@vizejs/native-linux-x64-gnu": "0.108.0"
+    "@vizejs/native-linux-x64-musl": "0.108.0"
+    "@vizejs/native-win32-arm64-msvc": "0.108.0"
+    "@vizejs/native-win32-x64-msvc": "0.108.0"
 
 peerDependencyRules:
   allowAny:


### PR DESCRIPTION
Expose LightningCSS-backed CSS AST parse/print helpers from `vize_atelier_sfc`.

### Changes

- Add `parse_css_ast(css, options)` returning a serialized LightningCSS stylesheet AST
- Add `print_css_ast(ast, options)` for printing CSS from a transformed AST
- Enable LightningCSS serde support for native CSS parsing
- Re-export the new helpers from `vize_atelier_sfc`
- Expose `parseCssAst` and `printCssAst` through NAPI and WASM
- Add a test that mutates a `url(...)` node through the AST and prints CSS

### Motivation

Vize already relies on LightningCSS for CSS parsing and transformation, but consumers can currently only access the final compiled CSS. Exposing a serialized CSS AST gives NAPI/WASM/Rust consumers a lower-level building block for parser-backed CSS tooling without adding narrow APIs for each use case.

This is useful for integrations that need to inspect or transform CSS references such as `url(...)`, `@import`, `image-set(...)`, or future LightningCSS-supported constructs while still letting LightningCSS own parsing and printing.

[Volt](https://github.com/elixir-volt/volt) is one concrete downstream consumer: it needs parser-backed CSS asset handling for production builds and wants to avoid hand-rolled CSS parsing.