### PR TITLE
fix: print image-set CSS AST

### DIFF
--- a/crates/vize_atelier_sfc/src/css/parser.rs
+++ b/crates/vize_atelier_sfc/src/css/parser.rs
@@ -20,9 +20,6 @@ pub(crate) fn version_to_u32(major: u32) -> u32 {
 
 use super::CssModuleExport as VizeCssModuleExport;
 
-const EMPTY_IMAGE_SET_FILE_TYPE: &str = "__vize_empty_image_set_file_type__";
-const EMPTY_IMAGE_SET_FILE_TYPE_CSS: &str = " type(\"__vize_empty_image_set_file_type__\")";
-
 /// CSS Modules compilation result
 pub(crate) struct CssInternalResult {
     pub code: String,
@@ -156,7 +153,7 @@ pub(crate) fn print_css_ast_internal(
             });
 
             CssInternalResult {
-                code: denormalize_image_set_file_types(&result.code),
+                code: result.code.into(),
                 errors: vec![],
                 exports,
             }
@@ -178,10 +175,7 @@ fn normalize_image_set_file_types(value: &mut Value) {
     match value {
         Value::Object(map) => {
             if map.get("fileType") == Some(&Value::Null) {
-                map.insert(
-                    "fileType".into(),
-                    Value::String(EMPTY_IMAGE_SET_FILE_TYPE.into()),
-                );
+                map.remove("fileType");
             }
 
             for child in map.values_mut() {
@@ -195,10 +189,6 @@ fn normalize_image_set_file_types(value: &mut Value) {
         }
         _ => {}
     }
-}
-
-fn denormalize_image_set_file_types(code: &str) -> String {
-    code.replace(EMPTY_IMAGE_SET_FILE_TYPE_CSS, "").into()
 }
 
 /// Internal CSS compilation with owned strings to avoid borrow issues

--- a/crates/vize_atelier_sfc/src/css/parser.rs
+++ b/crates/vize_atelier_sfc/src/css/parser.rs
@@ -20,6 +20,9 @@ pub(crate) fn version_to_u32(major: u32) -> u32 {
 
 use super::CssModuleExport as VizeCssModuleExport;
 
+const EMPTY_IMAGE_SET_FILE_TYPE: &str = "__vize_empty_image_set_file_type__";
+const EMPTY_IMAGE_SET_FILE_TYPE_CSS: &str = " type(\"__vize_empty_image_set_file_type__\")";
+
 /// CSS Modules compilation result
 pub(crate) struct CssInternalResult {
     pub code: String,
@@ -93,10 +96,12 @@ pub(crate) fn parse_css_ast_internal(
 }
 
 pub(crate) fn print_css_ast_internal(
-    ast: Value,
+    mut ast: Value,
     minify: bool,
     targets: Targets,
 ) -> CssInternalResult {
+    normalize_image_set_file_types(&mut ast);
+
     let mut stylesheet: StyleSheet = match StyleSheet::deserialize(ast.into_deserializer()) {
         Ok(stylesheet) => stylesheet,
         Err(e) => {
@@ -151,7 +156,7 @@ pub(crate) fn print_css_ast_internal(
             });
 
             CssInternalResult {
-                code: result.code.into(),
+                code: denormalize_image_set_file_types(&result.code),
                 errors: vec![],
                 exports,
             }
@@ -167,6 +172,33 @@ pub(crate) fn print_css_ast_internal(
             }
         }
     }
+}
+
+fn normalize_image_set_file_types(value: &mut Value) {
+    match value {
+        Value::Object(map) => {
+            if map.get("fileType") == Some(&Value::Null) {
+                map.insert(
+                    "fileType".into(),
+                    Value::String(EMPTY_IMAGE_SET_FILE_TYPE.into()),
+                );
+            }
+
+            for child in map.values_mut() {
+                normalize_image_set_file_types(child);
+            }
+        }
+        Value::Array(items) => {
+            for child in items {
+                normalize_image_set_file_types(child);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn denormalize_image_set_file_types(code: &str) -> String {
+    code.replace(EMPTY_IMAGE_SET_FILE_TYPE_CSS, "").into()
 }
 
 /// Internal CSS compilation with owned strings to avoid borrow issues

--- a/crates/vize_atelier_sfc/src/css/tests.rs
+++ b/crates/vize_atelier_sfc/src/css/tests.rs
@@ -96,6 +96,34 @@ fn test_parse_and_print_css_ast() {
 
 #[test]
 #[cfg(feature = "native")]
+fn test_parse_and_print_css_ast_with_image_set() {
+    let css = ".hero { background-image: image-set(url('./one.png') 1x, url('./two.png') 2x); }";
+    let ast_result = parse_css_ast(css, &CssCompileOptions::default());
+
+    assert!(
+        ast_result.errors.is_empty(),
+        "Unexpected errors: {:?}",
+        ast_result.errors
+    );
+
+    let result = print_css_ast(
+        ast_result.ast.expect("expected serialized CSS AST"),
+        &CssCompileOptions::default(),
+    );
+
+    assert!(
+        result.errors.is_empty(),
+        "Unexpected errors: {:?}",
+        result.errors
+    );
+    assert!(result.code.contains("image-set"));
+    assert!(result.code.contains("./one.png"));
+    assert!(result.code.contains("./two.png"));
+    assert!(!result.code.contains("type(\""));
+}
+
+#[test]
+#[cfg(feature = "native")]
 fn test_compile_minified_css() {
     let css = ".foo {\n  color: red;\n  background: blue;\n}";
     let result = compile_css(


### PR DESCRIPTION
## Summary

Fix CSS AST printing for stylesheets that contain `image-set(...)` values without an explicit `type(...)` hint.

LightningCSS serializes these options as `fileType: null`, but the serde deserialization path used by `print_css_ast` expects the optional field to be absent rather than null. The print path now normalizes null `fileType` values before deserializing the AST.

This keeps parse/print round trips working for common syntax such as:

```css
.hero {
  background-image: image-set(url('./one.png') 1x, url('./two.png') 2x);
}
```

## Validation

```bash
cargo test -p vize_atelier_sfc test_parse_and_print_css_ast --features native
cargo clippy -p vize_atelier_sfc --lib --features native -- -D warnings
```
