### PR TITLE
fix(vize): keep pkl runtime optional for consumers

### DIFF
--- a/npm/vite-plugin-vize/README.md
+++ b/npm/vite-plugin-vize/README.md
@@ -74,6 +74,7 @@ vite {
 `@vizejs/vite-plugin` loads the same `vize.config.ts`, `vize.config.js`, `vize.config.mjs`,
 `vize.config.pkl`, and `vize.config.json` files as the `vize` npm CLI. Importing
 `defineConfig` from `@vizejs/vite-plugin` still works, but `vize` is the shared entry point.
+Install `@pkl-community/pkl` or provide a `pkl` binary on `PATH` when using `vize.config.pkl`.
 
 ### Nuxt
 

--- a/npm/vize/README.md
+++ b/npm/vize/README.md
@@ -58,6 +58,10 @@ Shared config discovery is supported for the npm CLI:
 - `vize.config.pkl`
 - `vize.config.json`
 
+Pkl config files require either `@pkl-community/pkl` installed in the project or a `pkl` binary on
+`PATH`. The Pkl runtime is optional so packages that only consume Vize through framework plugins do
+not install it by default.
+
 ```ts
 import { defineConfig } from "vize";
 

--- a/npm/vize/package.json
+++ b/npm/vize/package.json
@@ -60,6 +60,7 @@
     "oxc-transform": "catalog:oxc"
   },
   "devDependencies": {
+    "@pkl-community/pkl": "catalog:repo-tooling",
     "@tsdown/css": "catalog:content",
     "@types/node": "catalog:typescript",
     "tsdown": "catalog:vite-stack",
@@ -67,8 +68,13 @@
     "vite": "catalog:vite-stack",
     "vite-plus": "catalog:vite-stack"
   },
-  "optionalDependencies": {
+  "peerDependencies": {
     "@pkl-community/pkl": "catalog:repo-tooling"
+  },
+  "peerDependenciesMeta": {
+    "@pkl-community/pkl": {
+      "optional": true
+    }
   },
   "engines": {
     "node": ">=22"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -742,6 +742,9 @@ importers:
         specifier: catalog:oxc
         version: 0.130.0
     devDependencies:
+      '@pkl-community/pkl':
+        specifier: catalog:repo-tooling
+        version: 0.27.2
       '@tsdown/css':
         specifier: catalog:content
         version: 0.22.0(jiti@2.7.0)(postcss@8.5.14)(tsdown@0.22.0)(tsx@4.21.0)(yaml@2.9.0)
@@ -760,10 +763,6 @@ importers:
       vite-plus:
         specifier: catalog:vite-stack
         version: 0.1.21(@tsdown/css@0.22.0)(@types/node@25.7.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0)(typescript@6.0.3)(unrun@0.2.39)(vite@8.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.7.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
-    optionalDependencies:
-      '@pkl-community/pkl':
-        specifier: catalog:repo-tooling
-        version: 0.27.2
 
   npm/vize-native:
     devDependencies:
@@ -11550,7 +11549,6 @@ snapshots:
       '@pkl-community/pkl-darwin-x64': 0.27.2
       '@pkl-community/pkl-linux-arm64': 0.27.2
       '@pkl-community/pkl-linux-x64': 0.27.2
-    optional: true
 
   '@playwright/test@1.60.0':
     dependencies:

--- a/tests/tooling/package-manifests.test.ts
+++ b/tests/tooling/package-manifests.test.ts
@@ -193,6 +193,24 @@ test("native package catalog pins and generated loader version checks stay align
   assert.doesNotMatch(nativeTargetsLoader, /bindingPackageVersion !== "[^"]+"/);
 });
 
+test("pkl runtime stays optional for consumers of the vize package", () => {
+  const packageJson = JSON.parse(readRepoFile("npm/vize/package.json")) as {
+    dependencies?: Record<string, string>;
+    devDependencies?: Record<string, string>;
+    optionalDependencies?: Record<string, string>;
+    peerDependencies?: Record<string, string>;
+    peerDependenciesMeta?: Record<string, { optional?: boolean }>;
+  };
+
+  assert.equal(packageJson.dependencies?.["@pkl-community/pkl"], undefined);
+  assert.equal(packageJson.optionalDependencies?.["@pkl-community/pkl"], undefined);
+  assert.equal(packageJson.devDependencies?.["@pkl-community/pkl"], "catalog:repo-tooling");
+  assert.equal(packageJson.peerDependencies?.["@pkl-community/pkl"], "catalog:repo-tooling");
+  assert.deepEqual(packageJson.peerDependenciesMeta?.["@pkl-community/pkl"], {
+    optional: true,
+  });
+});
+
 test("musea Nuxt tests the same vue-router major that it declares as a peer", () => {
   const workspaceYaml = readRepoFile("pnpm-workspace.yaml");
   const catalogVersion = workspaceYaml.match(/^\s+vue-router: "([^"]+)"$/m)?.[1];


### PR DESCRIPTION
Fixes #526

## Summary
- Move `@pkl-community/pkl` out of consumer-installed optional dependencies for `vize`.
- Keep Pkl available for development and as an optional peer for projects that use `vize.config.pkl`.
- Document the optional runtime and add manifest regression coverage.

## Validation
- `pnpm exec node --test tests/tooling/package-manifests.test.ts tests/tooling/config-loading.test.ts`
- `pnpm audit --prod --audit-level moderate`