### PR TITLE
test(fuzz): cover parser css and expression targets

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -31,6 +31,7 @@ concurrency:
 
 permissions:
   contents: read
+  issues: write
 
 env:
   CARGO_INCREMENTAL: 0
@@ -54,7 +55,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: [sfc_parse, template_compile]
+        target: [sfc_parse, template_lexer, js_ts_expression, css_parse, template_compile]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -136,3 +137,39 @@ jobs:
           name: fuzz-reproducers-${{ matrix.target }}
           path: fuzz/artifacts/${{ matrix.target }}
           if-no-files-found: ignore
+
+      - name: Create or update fuzz triage issue
+        if: github.event_name != 'pull_request' && hashFiles(format('fuzz/artifacts/{0}/**', matrix.target)) != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          title="fuzz: ${{ matrix.target }} found a reproducer"
+          run_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          body_file="$(mktemp)"
+          cat > "$body_file" <<EOF
+          Fuzz target \`${{ matrix.target }}\` found a crash, timeout, or OOM reproducer.
+
+          - Workflow run: ${run_url}
+          - Artifact: \`fuzz-reproducers-${{ matrix.target }}\`
+          - Commit: \`${{ github.sha }}\`
+
+          Download the artifact from the workflow run and replay it locally with:
+
+          \`\`\`sh
+          cargo +nightly fuzz run ${{ matrix.target }} fuzz/artifacts/${{ matrix.target }}/<reproducer>
+          \`\`\`
+          EOF
+
+          existing_issue="$(
+            gh issue list \
+              --state open \
+              --search "${title} in:title" \
+              --json number \
+              --jq '.[0].number // ""'
+          )"
+
+          if [ -n "$existing_issue" ]; then
+            gh issue comment "$existing_issue" --body-file "$body_file"
+          else
+            gh issue create --title "$title" --body-file "$body_file"
+          fi

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -18,13 +18,40 @@ cargo-fuzz = true
 
 [dependencies]
 libfuzzer-sys = "0.4"
-vize_atelier_sfc = { path = "../crates/vize_atelier_sfc", default-features = false }
+oxc_allocator = { version = "=0.127.0", git = "https://github.com/oxc-project/oxc", rev = "8265ed94b8f743a11dbf6f81fdd6fd248906f366" }
+oxc_parser = { version = "=0.127.0", git = "https://github.com/oxc-project/oxc", rev = "8265ed94b8f743a11dbf6f81fdd6fd248906f366" }
+oxc_span = { version = "=0.127.0", git = "https://github.com/oxc-project/oxc", rev = "8265ed94b8f743a11dbf6f81fdd6fd248906f366" }
+vize_armature = { path = "../crates/vize_armature" }
+vize_atelier_sfc = { path = "../crates/vize_atelier_sfc", default-features = false, features = [
+  "native",
+] }
 vize_atelier_dom = { path = "../crates/vize_atelier_dom" }
 vize_carton = { path = "../crates/vize_carton" }
 
 [[bin]]
 name = "sfc_parse"
 path = "fuzz_targets/sfc_parse.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "template_lexer"
+path = "fuzz_targets/template_lexer.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "js_ts_expression"
+path = "fuzz_targets/js_ts_expression.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "css_parse"
+path = "fuzz_targets/css_parse.rs"
 test = false
 doc = false
 bench = false

--- a/fuzz/fuzz_targets/css_parse.rs
+++ b/fuzz/fuzz_targets/css_parse.rs
@@ -1,0 +1,17 @@
+#![no_main]
+
+// CSS parser fuzz target.
+//
+// Exercises the vize_atelier_sfc Lightning CSS integration through the public
+// serialized-AST API. Syntax errors should be returned in CssAstResult; panics
+// are always a bug in the integration layer or upstream parser boundary.
+use libfuzzer_sys::fuzz_target;
+use vize_atelier_sfc::{CssCompileOptions, parse_css_ast};
+
+fuzz_target!(|data: &[u8]| {
+    let Ok(source) = std::str::from_utf8(data) else {
+        return;
+    };
+
+    let _ = parse_css_ast(source, &CssCompileOptions::default());
+});

--- a/fuzz/fuzz_targets/js_ts_expression.rs
+++ b/fuzz/fuzz_targets/js_ts_expression.rs
@@ -1,0 +1,25 @@
+#![no_main]
+
+// JS/TS expression parser fuzz target.
+//
+// Drives the same OXC expression parsing path used by template expression
+// transforms and import-usage checks. Invalid expressions are expected and
+// reported as parser errors; panics are not.
+use libfuzzer_sys::fuzz_target;
+use oxc_allocator::Allocator;
+use oxc_parser::Parser;
+use oxc_span::SourceType;
+
+fuzz_target!(|data: &[u8]| {
+    let Ok(source) = std::str::from_utf8(data) else {
+        return;
+    };
+
+    let allocator = Allocator::default();
+    let parser = Parser::new(
+        &allocator,
+        source,
+        SourceType::default().with_module(true).with_typescript(true),
+    );
+    let _ = parser.parse_expression();
+});

--- a/fuzz/fuzz_targets/template_lexer.rs
+++ b/fuzz/fuzz_targets/template_lexer.rs
@@ -1,0 +1,48 @@
+#![no_main]
+
+// Vue template tokenizer/lexer fuzz target.
+//
+// Drives the low-level `vize_armature::Tokenizer` state machine directly with
+// arbitrary UTF-8 template input. The parser fuzz target covers callback-driven
+// AST construction; this target isolates tokenizer state transitions and
+// recovery from malformed tags, attributes, entities, comments, and
+// interpolations.
+//
+// The corpus is seeded from the `<template>` blocks of repository .vue
+// fixtures by `tools/fuzz/seed_corpus.mjs`.
+use libfuzzer_sys::fuzz_target;
+use vize_armature::{Callbacks, ErrorCode, QuoteType, Tokenizer};
+
+#[derive(Default)]
+struct SinkCallbacks;
+
+impl Callbacks for SinkCallbacks {
+    fn on_text(&mut self, _start: usize, _end: usize) {}
+    fn on_text_entity(&mut self, _char: char, _start: usize, _end: usize) {}
+    fn on_interpolation(&mut self, _start: usize, _end: usize) {}
+    fn on_open_tag_name(&mut self, _start: usize, _end: usize) {}
+    fn on_open_tag_end(&mut self, _end: usize) {}
+    fn on_self_closing_tag(&mut self, _end: usize) {}
+    fn on_close_tag(&mut self, _start: usize, _end: usize) {}
+    fn on_attrib_data(&mut self, _start: usize, _end: usize) {}
+    fn on_attrib_entity(&mut self, _char: char, _start: usize, _end: usize) {}
+    fn on_attrib_end(&mut self, _quote: QuoteType, _end: usize) {}
+    fn on_attrib_name(&mut self, _start: usize, _end: usize) {}
+    fn on_attrib_name_end(&mut self, _end: usize) {}
+    fn on_dir_name(&mut self, _start: usize, _end: usize) {}
+    fn on_dir_arg(&mut self, _start: usize, _end: usize) {}
+    fn on_dir_modifier(&mut self, _start: usize, _end: usize) {}
+    fn on_comment(&mut self, _start: usize, _end: usize) {}
+    fn on_cdata(&mut self, _start: usize, _end: usize) {}
+    fn on_processing_instruction(&mut self, _start: usize, _end: usize) {}
+    fn on_end(&mut self) {}
+    fn on_error(&mut self, _code: ErrorCode, _index: usize) {}
+}
+
+fuzz_target!(|data: &[u8]| {
+    let Ok(source) = std::str::from_utf8(data) else {
+        return;
+    };
+    let mut tokenizer = Tokenizer::new(source, SinkCallbacks);
+    tokenizer.tokenize();
+});

--- a/tests/tooling/fuzz-setup.test.ts
+++ b/tests/tooling/fuzz-setup.test.ts
@@ -57,6 +57,30 @@ test("fuzz CI workflow gates short PR fuzz and schedules long nightly fuzz", () 
   // Reproducers on failure must be uploaded so triage does not have to
   // re-run the fuzzer to recover the failing input.
   assert.match(workflow, /upload-artifact[\s\S]*fuzz\/artifacts\//);
+  assert.match(workflow, /issues:\s*write/);
+  assert.match(workflow, /github\.event_name != 'pull_request'/);
+  assert.match(workflow, /gh issue (create|comment)/);
+});
+
+test("fuzz workspace covers parser, lexer, and compiler harnesses", () => {
+  const manifest = readRepoFile("fuzz/Cargo.toml");
+
+  for (const target of [
+    "sfc_parse",
+    "template_lexer",
+    "js_ts_expression",
+    "css_parse",
+    "template_compile",
+  ]) {
+    assert.match(
+      manifest,
+      new RegExp(`name = "${target}"[\\s\\S]*path = "fuzz_targets/${target}\\.rs"`),
+      `fuzz workspace missing ${target}`,
+    );
+  }
+
+  assert.match(manifest, /oxc_parser\s*=/);
+  assert.match(manifest, /features = \[\s*"native",?\s*\]/);
 });
 
 test("seed_corpus.mjs writes seeds for every declared fuzz target", () => {

--- a/tools/fuzz/seed_corpus.mjs
+++ b/tools/fuzz/seed_corpus.mjs
@@ -7,6 +7,9 @@
 //
 // Targets currently seeded:
 //   - sfc_parse: whole .vue files
+//   - template_lexer: contents of <template>...</template> blocks
+//   - js_ts_expression: script snippets and template interpolation expressions
+//   - css_parse: contents of <style>...</style> blocks
 //   - template_compile: contents of <template>...</template> blocks
 //
 // Usage: node tools/fuzz/seed_corpus.mjs
@@ -62,13 +65,35 @@ function extractTemplateBlock(source) {
   return source.slice(start, closeIdx);
 }
 
+function extractBlocks(source, tagName) {
+  const blocks = [];
+  const pattern = new RegExp(`<${tagName}\\b[^>]*>([\\s\\S]*?)</${tagName}>`, "gi");
+  for (const match of source.matchAll(pattern)) {
+    blocks.push(match[1]);
+  }
+  return blocks;
+}
+
+function extractInterpolations(template) {
+  const expressions = [];
+  for (const match of template.matchAll(/\{\{([\s\S]*?)\}\}/g)) {
+    expressions.push(match[1].trim());
+  }
+  return expressions;
+}
+
 function main() {
   const sfcDir = resetCorpus("sfc_parse");
+  const templateLexerDir = resetCorpus("template_lexer");
+  const jsTsExpressionDir = resetCorpus("js_ts_expression");
+  const cssParseDir = resetCorpus("css_parse");
   const templateDir = resetCorpus("template_compile");
 
   const files = findVueFiles();
   let sfcCount = 0;
   let templateCount = 0;
+  let expressionCount = 0;
+  let styleCount = 0;
   for (const path of files) {
     const content = readFileSync(path, "utf8");
     writeSeed(sfcDir, content);
@@ -76,13 +101,28 @@ function main() {
 
     const template = extractTemplateBlock(content);
     if (template != null) {
+      writeSeed(templateLexerDir, template);
       writeSeed(templateDir, template);
+      for (const expression of extractInterpolations(template)) {
+        writeSeed(jsTsExpressionDir, expression);
+        expressionCount += 1;
+      }
       templateCount += 1;
+    }
+
+    for (const script of extractBlocks(content, "script")) {
+      writeSeed(jsTsExpressionDir, script);
+      expressionCount += 1;
+    }
+
+    for (const style of extractBlocks(content, "style")) {
+      writeSeed(cssParseDir, style);
+      styleCount += 1;
     }
   }
 
   process.stdout.write(
-    `Seeded ${sfcCount} sfc_parse entries and ${templateCount} template_compile entries from ${files.length} fixtures.\n`,
+    `Seeded ${sfcCount} sfc_parse entries, ${templateCount} template entries, ${expressionCount} JS/TS expression entries, and ${styleCount} CSS entries from ${files.length} fixtures.\n`,
   );
 }
 


### PR DESCRIPTION
Fixes #507

## Summary
- Add cargo-fuzz harnesses for template lexing, JS/TS expression parsing, CSS parsing, and template compilation alongside SFC parsing.
- Seed each target from existing Vue fixtures and restore grown corpora through the fuzz workflow cache.
- Run short PR fuzz and scheduled long fuzz, upload reproducers, and create or update triage issues for scheduled/manual reproducer artifacts.

## Validation
- `node tools/fuzz/seed_corpus.mjs && node --test tests/tooling/fuzz-setup.test.ts`
- `cargo +nightly check --manifest-path fuzz/Cargo.toml --bins`
- `cargo +nightly fuzz build`
- `cargo +nightly fuzz run js_ts_expression -- -max_total_time=2 -max_len=65536 -timeout=10`
- `cargo +nightly fuzz run css_parse -- -max_total_time=2 -max_len=65536 -timeout=10`