### PR TITLE
feat(nuxt): expose module integration options

### DIFF
--- a/docs/content/integrations/nuxt.md
+++ b/docs/content/integrations/nuxt.md
@@ -51,6 +51,55 @@ Nuxt.
 During development, the server response cleanup preserves valid URL-encoded Nuxt asset links such
 as `%40fs/` and encoded `assets/` paths while dropping decoded null-byte or traversal paths.
 
+## Module Options
+
+`@vizejs/nuxt` keeps the simple `compiler: true | false` switch, but the module options also expose
+the Vize compiler and Nuxt compatibility bridges for projects that need tighter control:
+
+```typescript
+// nuxt.config.ts
+export default defineNuxtConfig({
+  modules: ["@vizejs/nuxt"],
+  vize: {
+    compiler: {
+      // Any @vizejs/vite-plugin option can be passed here.
+      configMode: "auto",
+      customRenderer: false,
+      debug: false,
+      handleNodeModulesVue: false,
+      ignorePatterns: ["node_modules/**", ".nuxt/**", ".output/**"],
+      precompileBatchSize: 64,
+      scanPatterns: [], // Nuxt defaults to on-demand compilation
+      sourceMap: true,
+      vapor: false,
+    },
+    bridge: {
+      autoImports: true,
+      components: true,
+      i18n: true,
+      stableInjectedKeys: true,
+    },
+    unocss: {
+      originalSource: {
+        maxBytes: 2 * 1024 * 1024,
+      },
+    },
+    dev: {
+      stylesheetLinks: true,
+    },
+  },
+});
+```
+
+| Option                | Type                                 | Default                                           | Description                                                                                                                                                                           |
+| --------------------- | ------------------------------------ | ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `compiler`            | `boolean \| VizeNuxtCompilerOptions` | `true`                                            | Enables Vize as the Vue SFC compiler. Passing an object forwards options to `@vizejs/vite-plugin` while keeping Nuxt defaults for `root`, `devUrlBase`, and on-demand `scanPatterns`. |
+| `bridge`              | `boolean \| VizeNuxtBridgeOptions`   | `true`                                            | Controls the Nuxt transform bridge for auto-imports, component imports, i18n helpers, and stable async-data keys on Vize virtual modules.                                             |
+| `unocss`              | `boolean \| VizeNuxtUnoCssOptions`   | `true`                                            | Controls the UnoCSS bridge for Vize virtual modules. `originalSource: false` disables reading source SFCs; `maxBytes` limits memory use.                                              |
+| `dev.stylesheetLinks` | `boolean`                            | `true`                                            | Enables dev-only SSR HTML stylesheet-link cleanup for Vize-generated Nuxt asset URLs.                                                                                                 |
+| `musea`               | `false \| MuseaOptions`              | `{ include: ["**/*.art.vue"], inlineArt: false }` | Configures or disables Musea gallery integration.                                                                                                                                     |
+| `nuxtMusea`           | `NuxtMuseaOptions`                   | `{ route: { path: "/" } }`                        | Documents the Nuxt mock shape used by Musea preview helpers. The Nuxt module does not install the mock layer globally because doing so would shadow Nuxt's own `#imports`.            |
+
 ## Advanced Setup
 
 ### Using the Vite Plugin Directly

--- a/npm/nuxt/src/compiler-options.ts
+++ b/npm/nuxt/src/compiler-options.ts
@@ -1,0 +1,43 @@
+export type VizeNuxtPattern = string | RegExp;
+
+/**
+ * Nuxt-facing mirror of the public `@vizejs/vite-plugin` options.
+ *
+ * Keeping this shape local lets the Nuxt module expose compiler configuration
+ * without requiring the sibling package's generated declaration files to exist
+ * during monorepo lint runs.
+ */
+export interface VizeNuxtCompilerOptions {
+  /** Override the public base used for dev-time asset URLs. */
+  devUrlBase?: string;
+  /** Files to include in compilation. */
+  include?: VizeNuxtPattern | VizeNuxtPattern[];
+  /** Files to exclude from compilation. */
+  exclude?: VizeNuxtPattern | VizeNuxtPattern[];
+  /** Force production mode. */
+  isProduction?: boolean;
+  /** Enable SSR mode. */
+  ssr?: boolean;
+  /** Enable source map generation. */
+  sourceMap?: boolean;
+  /** Enable Vapor mode compilation. */
+  vapor?: boolean;
+  /** Treat lowercase non-HTML tags as custom renderer elements. */
+  customRenderer?: boolean;
+  /** Root directory to scan for .vue files. */
+  root?: string;
+  /** Glob patterns to scan for .vue files during pre-compilation. */
+  scanPatterns?: string[];
+  /** Maximum number of Vue files to compile in a single native batch. */
+  precompileBatchSize?: number;
+  /** Glob patterns to ignore during pre-compilation. */
+  ignorePatterns?: string[];
+  /** Config file search mode. */
+  configMode?: "root" | "auto" | false;
+  /** Custom config file path. */
+  configFile?: string;
+  /** Handle .vue files in node_modules during on-demand compilation. */
+  handleNodeModulesVue?: boolean;
+  /** Enable debug logging. */
+  debug?: boolean;
+}

--- a/npm/nuxt/src/index.ts
+++ b/npm/nuxt/src/index.ts
@@ -11,12 +11,17 @@
 import { addServerPlugin, addVitePlugin, createResolver, defineNuxtModule } from "@nuxt/kit";
 import vize from "@vizejs/vite-plugin";
 import { musea } from "@vizejs/vite-plugin-musea";
-import type { MuseaOptions } from "@vizejs/vite-plugin-musea";
-import type { NuxtMuseaOptions } from "@vizejs/musea-nuxt";
 import { createNuxtComponentResolver, injectNuxtComponentImports } from "./components";
 import { injectNuxtI18nHelpers } from "./i18n";
+import type { VizeNuxtOptions } from "./options";
 import {
-  buildNuxtCompilerOptions,
+  resolveNuxtBridgeOptions,
+  resolveNuxtCompilerOptions,
+  resolveNuxtDevOptions,
+  resolveNuxtUnoCssOptions,
+} from "./options";
+import {
+  buildNuxtDevAssetBase,
   isVizeVirtualVueModuleId,
   normalizeNuxtInjectedKeysForVizeVirtualModule,
   normalizeVizeVirtualVueModuleId,
@@ -69,29 +74,6 @@ function patchNuxtKeyedFunctionsPlugin(plugin: { transform?: unknown }): void {
   };
 }
 
-export interface VizeNuxtOptions {
-  /**
-   * Enable/disable the Vize compiler (Vue SFC compilation via Vite plugin).
-   * Set to `false` to use Vue's default SFC compiler instead.
-   * @default true
-   */
-  compiler?: boolean;
-
-  /**
-   * Musea gallery options.
-   * Set to `false` to disable musea.
-   */
-  musea?: MuseaOptions | false;
-
-  /**
-   * Nuxt mock options for musea gallery.
-   * NOTE: In Nuxt context, nuxtMusea mocks are NOT added as a global Vite plugin
-   * because they would intercept `#imports` resolution and break Nuxt's internals.
-   * Real Nuxt composables are available via Nuxt's own plugin pipeline.
-   */
-  nuxtMusea?: NuxtMuseaOptions;
-}
-
 export default defineNuxtModule<VizeNuxtOptions>({
   meta: {
     name: "@vizejs/nuxt",
@@ -108,23 +90,29 @@ export default defineNuxtModule<VizeNuxtOptions>({
   },
   setup(options, nuxt) {
     const resolver = createResolver(import.meta.url);
+    const bridgeOptions = resolveNuxtBridgeOptions(options.bridge);
+    const devOptions = resolveNuxtDevOptions(options.dev);
+    const unocssOptions = resolveNuxtUnoCssOptions(options.unocss);
 
     nuxt.options.vite.plugins = nuxt.options.vite.plugins || [];
 
     // Compiler
-    if (options.compiler !== false) {
-      const compilerOptions = buildNuxtCompilerOptions(
-        nuxt.options.rootDir,
-        nuxt.options.app.baseURL,
-        nuxt.options.app.buildAssetsDir,
-      );
-
+    const compilerOptions = resolveNuxtCompilerOptions(
+      nuxt.options.rootDir,
+      nuxt.options.app.baseURL,
+      nuxt.options.app.buildAssetsDir,
+      options.compiler,
+    );
+    if (compilerOptions !== false) {
       nuxt.options.vite.plugins.push(vize(compilerOptions));
 
-      if (nuxt.options.dev) {
+      if (nuxt.options.dev && devOptions.stylesheetLinks) {
+        const devAssetBase =
+          compilerOptions.devUrlBase ??
+          buildNuxtDevAssetBase(nuxt.options.app.baseURL, nuxt.options.app.buildAssetsDir);
         nuxt.options.nitro.virtual ||= {};
         nuxt.options.nitro.virtual["#vizejs/nuxt/dev-stylesheet-links-config"] =
-          `export const devAssetBase = ${JSON.stringify(compilerOptions.devUrlBase)};`;
+          `export const devAssetBase = ${JSON.stringify(devAssetBase)};`;
         addServerPlugin(resolver.resolve("./runtime/server/dev-stylesheet-links"));
       }
 
@@ -144,7 +132,7 @@ export default defineNuxtModule<VizeNuxtOptions>({
           const name = p && typeof p === "object" && "name" in p ? p.name : "";
           if (name === "vite:vue") {
             config.plugins.splice(i, 1);
-          } else if (name === "nuxt:compiler:keyed-functions") {
+          } else if (bridgeOptions.stableInjectedKeys && name === "nuxt:compiler:keyed-functions") {
             patchNuxtKeyedFunctionsPlugin(p);
           }
         }
@@ -165,88 +153,108 @@ export default defineNuxtModule<VizeNuxtOptions>({
         id?: string,
       ) => Promise<{ code: string; s: unknown; imports: unknown[] }>;
     } | null = null;
-    nuxt.hook("imports:context", (ctx: unknown) => {
-      unimportCtx = ctx as typeof unimportCtx;
-    });
+    if (bridgeOptions.autoImports) {
+      nuxt.hook("imports:context", (ctx: unknown) => {
+        unimportCtx = ctx as typeof unimportCtx;
+      });
+    }
 
-    const nuxtComponentResolver = createNuxtComponentResolver({
-      buildDir: nuxt.options.buildDir,
-      moduleNames: nuxt.options.modules.filter(
-        (moduleName): moduleName is string => typeof moduleName === "string",
-      ),
-      rootDir: nuxt.options.rootDir,
-    });
+    const nuxtComponentResolver = bridgeOptions.components
+      ? createNuxtComponentResolver({
+          buildDir: nuxt.options.buildDir,
+          moduleNames: nuxt.options.modules.filter(
+            (moduleName): moduleName is string => typeof moduleName === "string",
+          ),
+          rootDir: nuxt.options.rootDir,
+        })
+      : null;
 
     // Capture component registry for component auto-imports (NuxtPage, NuxtLayout, etc.)
-    nuxt.hook("components:extend", (comps: unknown) => {
-      nuxtComponentResolver.register(
-        comps as Array<{
-          pascalName: string;
-          kebabName: string;
-          name: string;
-          filePath: string;
-          export: string;
-        }>,
-      );
-    });
+    if (nuxtComponentResolver) {
+      nuxt.hook("components:extend", (comps: unknown) => {
+        nuxtComponentResolver.register(
+          comps as Array<{
+            pascalName: string;
+            kebabName: string;
+            name: string;
+            filePath: string;
+            export: string;
+          }>,
+        );
+      });
+    }
 
-    addVitePlugin({
-      name: "vizejs:nuxt-transform-bridge",
-      enforce: "post" as const,
-      async transform(code: string, id: string) {
-        // Only process vize virtual modules
-        if (!isVizeVirtualVueModuleId(id)) return;
+    const shouldAddNuxtTransformBridge =
+      bridgeOptions.autoImports ||
+      bridgeOptions.components ||
+      bridgeOptions.i18n ||
+      bridgeOptions.stableInjectedKeys;
 
-        let result = code;
-        let changed = false;
+    if (shouldAddNuxtTransformBridge) {
+      addVitePlugin({
+        name: "vizejs:nuxt-transform-bridge",
+        enforce: "post" as const,
+        async transform(code: string, id: string) {
+          // Only process vize virtual modules
+          if (!isVizeVirtualVueModuleId(id)) return;
 
-        // 1. Component auto-imports: replace _resolveComponent("Name") with direct imports
-        // Nuxt's LoaderPlugin normally does this, but skips \0-prefixed IDs.
-        const nextComponentResult = injectNuxtComponentImports(result, (name) => {
-          return nuxtComponentResolver.resolve(name);
-        });
-        if (nextComponentResult !== result) {
-          result = nextComponentResult;
-          changed = true;
-        }
+          let result = code;
+          let changed = false;
 
-        // 2. i18n function injection: inject useI18n() for $t, $rt, $d, $n, $tm, $te
-        // @nuxtjs/i18n's TransformI18nFunctionPlugin skips \0-prefixed IDs.
-        // Must inject inside the setup() function body, not at module top level.
-        // Use negative lookbehind to exclude `_ctx.$t(` and `this.$t(` (property access),
-        // which are Vue template globals and don't need useI18n injection.
-        const nextResult = injectNuxtI18nHelpers(result);
-        if (nextResult !== result) {
-          result = nextResult;
-          changed = true;
-        }
-
-        // 3. Composable auto-imports: inject useRoute, ref, computed, useI18n, etc.
-        // Nuxt's unimport TransformPlugin normally does this, but skips \0-prefixed IDs.
-        // Runs after i18n injection so unimport picks up the `useI18n` reference.
-        if (unimportCtx) {
-          try {
-            const injected = await unimportCtx.injectImports(result, id);
-            if (injected.imports && injected.imports.length > 0) {
-              result = injected.code;
+          // 1. Component auto-imports: replace _resolveComponent("Name") with direct imports
+          // Nuxt's LoaderPlugin normally does this, but skips \0-prefixed IDs.
+          if (nuxtComponentResolver) {
+            const nextComponentResult = injectNuxtComponentImports(result, (name) => {
+              return nuxtComponentResolver.resolve(name);
+            });
+            if (nextComponentResult !== result) {
+              result = nextComponentResult;
               changed = true;
             }
-          } catch {
-            // Ignore errors — auto-imports might not be needed for all modules
           }
-        }
 
-        const stableKeyResult = normalizeNuxtInjectedKeysForVizeVirtualModule(result, id);
-        if (stableKeyResult !== result) {
-          result = stableKeyResult;
-          changed = true;
-        }
+          // 2. i18n function injection: inject useI18n() for $t, $rt, $d, $n, $tm, $te
+          // @nuxtjs/i18n's TransformI18nFunctionPlugin skips \0-prefixed IDs.
+          // Must inject inside the setup() function body, not at module top level.
+          // Use negative lookbehind to exclude `_ctx.$t(` and `this.$t(` (property access),
+          // which are Vue template globals and don't need useI18n injection.
+          if (bridgeOptions.i18n) {
+            const nextResult = injectNuxtI18nHelpers(result);
+            if (nextResult !== result) {
+              result = nextResult;
+              changed = true;
+            }
+          }
 
-        if (changed) {
-          return { code: result, map: null };
-        }
-      },
-    });
+          // 3. Composable auto-imports: inject useRoute, ref, computed, useI18n, etc.
+          // Nuxt's unimport TransformPlugin normally does this, but skips \0-prefixed IDs.
+          // Runs after i18n injection so unimport picks up the `useI18n` reference.
+          if (unimportCtx) {
+            try {
+              const injected = await unimportCtx.injectImports(result, id);
+              if (injected.imports && injected.imports.length > 0) {
+                result = injected.code;
+                changed = true;
+              }
+            } catch {
+              // Ignore errors — auto-imports might not be needed for all modules
+            }
+          }
+
+          if (bridgeOptions.stableInjectedKeys) {
+            const stableKeyResult = normalizeNuxtInjectedKeysForVizeVirtualModule(result, id);
+            if (stableKeyResult !== result) {
+              result = stableKeyResult;
+              changed = true;
+            }
+          }
+
+          if (changed) {
+            return { code: result, map: null };
+          }
+        },
+      });
+    }
 
     // ─── UnoCSS bridge: patch filter to accept vize virtual modules ────────
     // UnoCSS's Vite plugin uses createFilter from unplugin-utils which
@@ -258,42 +266,46 @@ export default defineNuxtModule<VizeNuxtOptions>({
     // JS render functions where these become object properties (e.g.
     // `{ flex: "~ col gap1" }`). To support attributify, we also feed the
     // original .vue source to UnoCSS's extractor alongside the compiled JS.
-    addVitePlugin({
-      name: "vizejs:unocss-bridge",
-      configResolved(config: { plugins: Array<{ name: string; transform?: Function }> }) {
-        for (const plugin of config.plugins) {
-          if (plugin.name?.startsWith("unocss:") && typeof plugin.transform === "function") {
-            const origTransform = plugin.transform;
-            // Only enrich with original .vue source for the global mode plugin
-            // (unocss:global:*) which does extraction only (returns null).
-            // Other plugins like unocss:transformers modify the code and would
-            // propagate the appended .vue source into the transform pipeline,
-            // causing parse errors in downstream transforms (e.g. transformWithOxc).
-            const isExtractionOnly = plugin.name.startsWith("unocss:global");
-            plugin.transform = function (code: string, id: string, ...args: unknown[]) {
-              if (isVizeVirtualVueModuleId(id)) {
-                // Strip \0 prefix AND .ts suffix so UnoCSS's filter accepts it.
-                // UnoCSS's defaultPipelineInclude is /\.(vue|...)($|\?)/ which
-                // requires .vue at end-of-string or before ?, not .vue.ts.
-                const normalizedId = normalizeVizeVirtualVueModuleId(id);
+    if (unocssOptions !== false) {
+      addVitePlugin({
+        name: "vizejs:unocss-bridge",
+        configResolved(config: { plugins: Array<{ name: string; transform?: Function }> }) {
+          for (const plugin of config.plugins) {
+            if (plugin.name?.startsWith("unocss:") && typeof plugin.transform === "function") {
+              const origTransform = plugin.transform;
+              // Only enrich with original .vue source for the global mode plugin
+              // (unocss:global:*) which does extraction only (returns null).
+              // Other plugins like unocss:transformers modify the code and would
+              // propagate the appended .vue source into the transform pipeline,
+              // causing parse errors in downstream transforms (e.g. transformWithOxc).
+              const isExtractionOnly = plugin.name.startsWith("unocss:global");
+              plugin.transform = function (code: string, id: string, ...args: unknown[]) {
+                if (isVizeVirtualVueModuleId(id)) {
+                  // Strip \0 prefix AND .ts suffix so UnoCSS's filter accepts it.
+                  // UnoCSS's defaultPipelineInclude is /\.(vue|...)($|\?)/ which
+                  // requires .vue at end-of-string or before ?, not .vue.ts.
+                  const normalizedId = normalizeVizeVirtualVueModuleId(id);
 
-                // For extraction-only plugins, append original .vue source so
-                // UnoCSS's attributify extractor can find HTML-style attribute
-                // patterns (flex="~ col gap1" etc.) that don't survive
-                // template-to-render-function compilation.
-                let effectiveCode = code;
-                if (isExtractionOnly) {
-                  effectiveCode = appendOriginalVueSourceForUnoCss(code, normalizedId);
+                  // For extraction-only plugins, append original .vue source so
+                  // UnoCSS's attributify extractor can find HTML-style attribute
+                  // patterns (flex="~ col gap1" etc.) that don't survive
+                  // template-to-render-function compilation.
+                  let effectiveCode = code;
+                  if (isExtractionOnly && unocssOptions.originalSource !== false) {
+                    effectiveCode = appendOriginalVueSourceForUnoCss(code, normalizedId, {
+                      maxBytes: unocssOptions.originalSource.maxBytes,
+                    });
+                  }
+
+                  return origTransform.call(this, effectiveCode, normalizedId, ...args);
                 }
-
-                return origTransform.call(this, effectiveCode, normalizedId, ...args);
-              }
-              return origTransform.call(this, code, id, ...args);
-            };
+                return origTransform.call(this, code, id, ...args);
+              };
+            }
           }
-        }
-      },
-    });
+        },
+      });
+    }
 
     // Musea gallery (without nuxtMusea mock layer)
     // In Nuxt context, real composables/components are already available
@@ -320,3 +332,10 @@ export default defineNuxtModule<VizeNuxtOptions>({
 // Re-export types for convenience
 export type { MuseaOptions } from "@vizejs/vite-plugin-musea";
 export type { NuxtMuseaOptions } from "@vizejs/musea-nuxt";
+export type {
+  VizeNuxtBridgeOptions,
+  VizeNuxtCompilerOptions,
+  VizeNuxtDevOptions,
+  VizeNuxtOptions,
+  VizeNuxtUnoCssOptions,
+} from "./options";

--- a/npm/nuxt/src/options.test.ts
+++ b/npm/nuxt/src/options.test.ts
@@ -1,0 +1,95 @@
+import assert from "node:assert/strict";
+
+import {
+  resolveNuxtBridgeOptions,
+  resolveNuxtCompilerOptions,
+  resolveNuxtDevOptions,
+  resolveNuxtUnoCssOptions,
+} from "./options.ts";
+
+assert.deepEqual(
+  resolveNuxtCompilerOptions("/repo/app", "/docs/", "_assets", true),
+  {
+    devUrlBase: "/docs/_assets/",
+    root: "/repo/app",
+    scanPatterns: [],
+  },
+  "compiler true should resolve to Nuxt-aware Vize defaults",
+);
+
+assert.equal(
+  resolveNuxtCompilerOptions("/repo/app", "/", "/_nuxt/", false),
+  false,
+  "compiler false should disable the Vize compiler",
+);
+
+assert.deepEqual(
+  resolveNuxtCompilerOptions("/repo/app", "/", "/_nuxt/", {
+    configMode: "auto",
+    customRenderer: true,
+    handleNodeModulesVue: false,
+    include: [/\.vue$/, /\.ce\.vue$/],
+    precompileBatchSize: 32,
+    sourceMap: false,
+  }),
+  {
+    configMode: "auto",
+    customRenderer: true,
+    devUrlBase: "/_nuxt/",
+    handleNodeModulesVue: false,
+    include: [/\.vue$/, /\.ce\.vue$/],
+    precompileBatchSize: 32,
+    root: "/repo/app",
+    scanPatterns: [],
+    sourceMap: false,
+  },
+  "compiler object should expose the underlying @vizejs/vite-plugin options",
+);
+
+assert.deepEqual(
+  resolveNuxtBridgeOptions({ components: false, i18n: false }),
+  {
+    autoImports: true,
+    components: false,
+    i18n: false,
+    stableInjectedKeys: true,
+  },
+  "partial bridge options should merge with enabled defaults",
+);
+
+assert.deepEqual(
+  resolveNuxtBridgeOptions(false),
+  {
+    autoImports: false,
+    components: false,
+    i18n: false,
+    stableInjectedKeys: false,
+  },
+  "bridge false should disable every Nuxt transform bridge",
+);
+
+assert.deepEqual(
+  resolveNuxtUnoCssOptions({ originalSource: { maxBytes: 4096 } }),
+  {
+    originalSource: { maxBytes: 4096 },
+  },
+  "UnoCSS original-source bridge should expose its memory limit",
+);
+
+assert.deepEqual(
+  resolveNuxtUnoCssOptions({ originalSource: false }),
+  {
+    originalSource: false,
+  },
+  "UnoCSS bridge should allow disabling original SFC reads while keeping id normalization",
+);
+
+assert.deepEqual(
+  resolveNuxtDevOptions({ stylesheetLinks: false }),
+  {
+    stylesheetLinks: false,
+  },
+  "dev stylesheet cleanup should be configurable",
+);
+
+console.log("✅ nuxt option normalization tests passed!");

--- a/npm/nuxt/src/options.ts
+++ b/npm/nuxt/src/options.ts
@@ -1,0 +1,194 @@
+import type { MuseaOptions } from "@vizejs/vite-plugin-musea";
+import type { NuxtMuseaOptions } from "@vizejs/musea-nuxt";
+import type { VizeNuxtCompilerOptions } from "./compiler-options.ts";
+import { buildNuxtCompilerOptions } from "./utils.ts";
+
+export type { VizeNuxtCompilerOptions } from "./compiler-options.ts";
+
+export interface VizeNuxtBridgeOptions {
+  /**
+   * Re-apply Nuxt auto-import injection to Vize virtual Vue modules.
+   * @default true
+   */
+  autoImports?: boolean;
+
+  /**
+   * Re-apply Nuxt component auto-import resolution to Vize virtual Vue modules.
+   * @default true
+   */
+  components?: boolean;
+
+  /**
+   * Re-apply @nuxtjs/i18n helper injection to Vize virtual Vue modules.
+   * @default true
+   */
+  i18n?: boolean;
+
+  /**
+   * Stabilize Nuxt generated async-data keys between client and SSR transforms.
+   * @default true
+   */
+  stableInjectedKeys?: boolean;
+}
+
+export interface VizeNuxtUnoCssOptions {
+  /**
+   * Feed the original .vue source to UnoCSS extraction-only plugins so
+   * attributify syntax survives Vize's render-function output.
+   *
+   * Set to `false` to skip reading SFC source files. Use an object to tune the
+   * maximum source size read into Node.
+   *
+   * @default true
+   */
+  originalSource?:
+    | boolean
+    | {
+        /**
+         * Maximum original .vue source size to append for UnoCSS extraction.
+         * @default 2097152
+         */
+        maxBytes?: number;
+      };
+}
+
+export interface VizeNuxtDevOptions {
+  /**
+   * Remove broken duplicate/unsafe stylesheet links from Nuxt dev SSR HTML
+   * when Vize is the Vue compiler.
+   *
+   * @default true
+   */
+  stylesheetLinks?: boolean;
+}
+
+export interface VizeNuxtOptions {
+  /**
+   * Enable/disable the Vize compiler (Vue SFC compilation via Vite plugin).
+   * Pass an object to configure the underlying `@vizejs/vite-plugin`.
+   *
+   * @default true
+   */
+  compiler?: boolean | VizeNuxtCompilerOptions;
+
+  /**
+   * Nuxt compatibility bridges for transforms that normally skip Rollup
+   * virtual module ids.
+   *
+   * @default true
+   */
+  bridge?: boolean | VizeNuxtBridgeOptions;
+
+  /**
+   * UnoCSS bridge options for Vize virtual Vue modules.
+   *
+   * @default true
+   */
+  unocss?: boolean | VizeNuxtUnoCssOptions;
+
+  /**
+   * Dev-server integration options.
+   */
+  dev?: VizeNuxtDevOptions;
+
+  /**
+   * Musea gallery options.
+   * Set to `false` to disable musea.
+   */
+  musea?: MuseaOptions | false;
+
+  /**
+   * Nuxt mock options for musea gallery.
+   * NOTE: In Nuxt context, nuxtMusea mocks are NOT added as a global Vite plugin
+   * because they would intercept `#imports` resolution and break Nuxt's internals.
+   * Real Nuxt composables are available via Nuxt's own plugin pipeline.
+   */
+  nuxtMusea?: NuxtMuseaOptions;
+}
+
+export interface ResolvedVizeNuxtUnoCssOptions {
+  originalSource: false | { maxBytes?: number };
+}
+
+export const DEFAULT_NUXT_BRIDGE_OPTIONS: Required<VizeNuxtBridgeOptions> = {
+  autoImports: true,
+  components: true,
+  i18n: true,
+  stableInjectedKeys: true,
+};
+
+export const DEFAULT_NUXT_UNOCSS_OPTIONS: ResolvedVizeNuxtUnoCssOptions = {
+  originalSource: {},
+};
+
+export const DEFAULT_NUXT_DEV_OPTIONS: Required<VizeNuxtDevOptions> = {
+  stylesheetLinks: true,
+};
+
+export function resolveNuxtCompilerOptions(
+  rootDir: string,
+  baseURL: string | undefined,
+  buildAssetsDir: string | undefined,
+  compiler: VizeNuxtOptions["compiler"],
+): VizeNuxtCompilerOptions | false {
+  if (compiler === false) {
+    return false;
+  }
+
+  const overrides = typeof compiler === "object" && compiler != null ? compiler : {};
+  return buildNuxtCompilerOptions(rootDir, baseURL, buildAssetsDir, overrides);
+}
+
+export function resolveNuxtBridgeOptions(
+  bridge: VizeNuxtOptions["bridge"],
+): Required<VizeNuxtBridgeOptions> {
+  if (bridge === false) {
+    return {
+      autoImports: false,
+      components: false,
+      i18n: false,
+      stableInjectedKeys: false,
+    };
+  }
+
+  if (bridge === true || bridge == null) {
+    return { ...DEFAULT_NUXT_BRIDGE_OPTIONS };
+  }
+
+  return {
+    autoImports: bridge.autoImports ?? DEFAULT_NUXT_BRIDGE_OPTIONS.autoImports,
+    components: bridge.components ?? DEFAULT_NUXT_BRIDGE_OPTIONS.components,
+    i18n: bridge.i18n ?? DEFAULT_NUXT_BRIDGE_OPTIONS.i18n,
+    stableInjectedKeys: bridge.stableInjectedKeys ?? DEFAULT_NUXT_BRIDGE_OPTIONS.stableInjectedKeys,
+  };
+}
+
+export function resolveNuxtUnoCssOptions(
+  unocss: VizeNuxtOptions["unocss"],
+): ResolvedVizeNuxtUnoCssOptions | false {
+  if (unocss === false) {
+    return false;
+  }
+
+  if (unocss === true || unocss == null) {
+    return { ...DEFAULT_NUXT_UNOCSS_OPTIONS };
+  }
+
+  const originalSource = unocss.originalSource;
+  if (originalSource === false) {
+    return { originalSource: false };
+  }
+
+  if (originalSource === true || originalSource == null) {
+    return { originalSource: {} };
+  }
+
+  return { originalSource };
+}
+
+export function resolveNuxtDevOptions(dev: VizeNuxtOptions["dev"]): Required<VizeNuxtDevOptions> {
+  return {
+    ...DEFAULT_NUXT_DEV_OPTIONS,
+    ...dev,
+  };
+}

--- a/npm/nuxt/src/utils.test.ts
+++ b/npm/nuxt/src/utils.test.ts
@@ -35,6 +35,28 @@ assert.deepStrictEqual(
   "Nuxt compiler options should use on-demand compilation to avoid retaining every SFC in large Nuxt apps",
 );
 
+assert.deepStrictEqual(
+  buildNuxtCompilerOptions("/repo/app", "/2026/", "/_nuxt/", {
+    configFile: "vize.nuxt.config.ts",
+    debug: true,
+    ignorePatterns: ["node_modules/**", ".nuxt/**", "fixtures/**"],
+    scanPatterns: ["app/**/*.vue", "layers/**/*.vue"],
+    sourceMap: false,
+    vapor: true,
+  }),
+  {
+    configFile: "vize.nuxt.config.ts",
+    debug: true,
+    devUrlBase: "/2026/_nuxt/",
+    ignorePatterns: ["node_modules/**", ".nuxt/**", "fixtures/**"],
+    root: "/repo/app",
+    scanPatterns: ["app/**/*.vue", "layers/**/*.vue"],
+    sourceMap: false,
+    vapor: true,
+  },
+  "Nuxt compiler options should forward Vite plugin overrides while keeping Nuxt defaults",
+);
+
 assert.equal(
   isVizeVirtualVueModuleId("\0vize-ssr:/repo/app/components/Foo.vue.ts"),
   true,

--- a/npm/nuxt/src/utils.ts
+++ b/npm/nuxt/src/utils.ts
@@ -1,4 +1,4 @@
-import type { VizeOptions } from "@vizejs/vite-plugin";
+import type { VizeNuxtCompilerOptions } from "./compiler-options.ts";
 import { createHash } from "node:crypto";
 
 function normalizeUrlPrefix(value: string): string {
@@ -18,12 +18,23 @@ export function buildNuxtCompilerOptions(
   rootDir: string,
   baseURL = "/",
   buildAssetsDir = "/_nuxt/",
-): Pick<VizeOptions, "devUrlBase" | "root" | "scanPatterns"> {
-  return {
+  overrides: VizeNuxtCompilerOptions = {},
+): VizeNuxtCompilerOptions {
+  const defaults: VizeNuxtCompilerOptions = {
     devUrlBase: buildNuxtDevAssetBase(baseURL, buildAssetsDir),
     root: rootDir,
     scanPatterns: [],
   };
+
+  for (const [key, value] of Object.entries(overrides) as Array<
+    [keyof VizeNuxtCompilerOptions, VizeNuxtCompilerOptions[keyof VizeNuxtCompilerOptions]]
+  >) {
+    if (value !== undefined) {
+      defaults[key] = value as never;
+    }
+  }
+
+  return defaults;
 }
 
 export function isVizeVirtualVueModuleId(id: string): boolean {


### PR DESCRIPTION
## Summary
- Let `compiler` accept the underlying Vize compiler options while preserving the existing boolean switch.
- Add Nuxt module options for transform bridges, UnoCSS original-source extraction, and dev stylesheet cleanup.
- Document the expanded module surface and add option normalization coverage.

## Validation
- `pnpm --filter @vizejs/nuxt check`
- `pnpm --filter @vizejs/nuxt test`
- `pnpm --filter @vizejs/nuxt build`
- `./node_modules/.bin/oxfmt --check docs/content/integrations/nuxt.md`
- `git diff --check`
