### PR TITLE
feat(vscode): improve VS Code extension startup defaults

### DIFF
--- a/docs/content/integrations/vscode.md
+++ b/docs/content/integrations/vscode.md
@@ -25,6 +25,8 @@ reference support in addition to syntax highlighting.
 The Vize extension starts `vize lsp` and can opt into specific capability bundles.
 When you open a Vue file with the extension still disabled, or with no capabilities enabled, the extension now offers a one-click recommended workspace setup so hover, jump, and diagnostics do not silently stay off.
 That setup writes `vize.enable`, `vize.lint.enable`, `vize.typecheck.enable`, and `vize.editor.enable` for the current workspace.
+If you manually set only `vize.enable: true`, Vize also uses that recommended diagnostics and
+editor profile instead of starting an empty language server.
 
 ### Recommended Starting Point
 
@@ -50,6 +52,7 @@ existing Vue tooling.
 | `vize.lint.enable`           | Enable lint diagnostics                            |
 | `vize.typecheck.enable`      | Enable type-aware diagnostics and backend features |
 | `vize.editor.enable`         | Enable the editor assistance bundle                |
+| `vize.completion.enable`     | Enable completion                                  |
 | `vize.formatting.enable`     | Enable document formatting                         |
 | `vize.definition.enable`     | Enable go-to-definition                            |
 | `vize.references.enable`     | Enable references                                  |
@@ -108,11 +111,12 @@ require("lspconfig").vize.setup({
   filetypes = { "vue" },
   init_options = {
     lint = true,
-    typecheck = false,
-    editor = false,
+    typecheck = true,
+    editor = true,
   },
 })
 ```
 
-When another TypeScript server such as tsgo owns project diagnostics, keep `typecheck = false` and
-turn on only the Vue-specific capabilities you want to evaluate.
+`editor = true` is the easiest way to test hover, completion, jump, references, and symbols
+together. When another TypeScript server such as tsgo owns project diagnostics, keep
+`typecheck = false` and turn on only the Vue-specific capabilities you want to evaluate.

--- a/npm/vscode-vize/README.md
+++ b/npm/vscode-vize/README.md
@@ -48,6 +48,7 @@ vp exec vsce package --no-dependencies --out dist/vize.vsix
 
 Opening a Vue file now prompts you to apply a recommended workspace setup if the extension is still disabled or if no Vize capabilities are enabled yet.
 That quick setup writes `vize.enable`, `vize.lint.enable`, `vize.typecheck.enable`, and `vize.editor.enable` for the current workspace so diagnostics, hover, and jump work immediately.
+If you manually set only `vize.enable: true`, the extension uses that same recommended diagnostics and editor profile instead of starting an empty language server.
 
 If you dismissed that prompt and want a lighter rollout, start with lint-only mode, then opt into type checking or editor features after confirming it does not overlap with your existing Vue setup.
 
@@ -68,11 +69,14 @@ When you are ready to evaluate Vize editor assistance separately from `vuejs/lan
   "vize.enable": true,
   "vize.lint.enable": true,
   "vize.typecheck.enable": true,
-  "vize.definition.enable": true,
-  "vize.references.enable": true,
-  "vize.hover.enable": true
+  "vize.editor.enable": true
 }
 ```
+
+`vize.editor.enable` turns on completion, hover, definition, references, symbols, rename,
+semantic tokens, links, folding ranges, inlay hints, and file rename handling. If you prefer
+individual switches, make sure to include `vize.completion.enable`, `vize.hover.enable`, and
+`vize.definition.enable` together when testing the core editor flow.
 
 When paired with the `Vize Art` extension, the same editor capabilities also apply to `*.art.vue`
 documents.

--- a/npm/vscode-vize/package.json
+++ b/npm/vscode-vize/package.json
@@ -118,7 +118,7 @@
         "vize.enable": {
           "type": "boolean",
           "default": false,
-          "description": "Enable the Vize language server. Individual capabilities remain opt-in so this can coexist with the official Vue language tools."
+          "description": "Enable the Vize language server. If no capability switches are explicitly set, Vize starts with the recommended diagnostics and editor profile."
         },
         "vize.serverPath": {
           "type": "string",

--- a/npm/vscode-vize/src/extension.ts
+++ b/npm/vscode-vize/src/extension.ts
@@ -1,5 +1,7 @@
 import * as fs from "fs";
 import * as path from "path";
+import { execFile } from "child_process";
+import { promisify } from "util";
 import {
   ConfigurationTarget,
   ExtensionContext,
@@ -19,10 +21,20 @@ import {
   TransportKind,
 } from "vscode-languageclient/node";
 
+const execFileAsync = promisify(execFile);
 let client: LanguageClient | undefined;
 let outputChannel: OutputChannel;
 
 type LspInitializationOptions = Partial<Record<string, boolean>>;
+type ServerCandidateSource = "configured" | "bundled" | "development" | "cargo" | "path";
+type ServerCandidate = {
+  path: string;
+  source: ServerCandidateSource;
+};
+type InspectedServerCandidate = ServerCandidate & {
+  version?: string;
+  versionError?: string;
+};
 const SUPPORTED_LANGUAGE_IDS = ["vue", "art-vue"] as const;
 const SUPPORTED_URI_SCHEMES = ["file", "untitled"] as const;
 const RECOMMENDED_SETUP_ACTION = "Enable Recommended";
@@ -226,6 +238,12 @@ function hasAnyEnabledCapability(config: ReturnType<typeof workspace.getConfigur
   return FEATURE_SETTING_KEYS.some((key) => config.get<boolean>(key, false));
 }
 
+function hasAnyExplicitCapabilityValue(
+  config: ReturnType<typeof workspace.getConfiguration>,
+): boolean {
+  return FEATURE_SETTING_KEYS.some((key) => hasExplicitConfigurationValue(config, key));
+}
+
 function hasWorkspaceLspConfig(): boolean {
   const workspaceFolders = workspace.workspaceFolders;
   if (!workspaceFolders) {
@@ -375,6 +393,20 @@ function getInitializationOptions(
   setIfEnabled(options, "inlayHints", config.get<boolean>("inlayHints.enable", false));
   setIfEnabled(options, "fileRename", config.get<boolean>("fileRename.enable", false));
 
+  if (
+    Object.keys(options).length === 0 &&
+    config.get<boolean>("enable", false) &&
+    !hasAnyExplicitCapabilityValue(config) &&
+    !hasWorkspaceLspConfig()
+  ) {
+    outputChannel.appendLine(
+      "Vize is enabled with no explicit feature switches. Using the recommended diagnostics and editor profile.",
+    );
+    options.lint = true;
+    options.typecheck = true;
+    options.editor = true;
+  }
+
   return options;
 }
 
@@ -397,42 +429,53 @@ async function findServerPath(
   config: ReturnType<typeof workspace.getConfiguration>,
 ): Promise<string | undefined> {
   const exeName = process.platform === "win32" ? "vize.exe" : "vize";
+  const expectedVersion = getExtensionVersion(context);
 
-  const configuredPath = config.get<string>("serverPath");
-  if (configuredPath && fs.existsSync(configuredPath)) {
-    outputChannel.appendLine(`Found server at configured path: ${configuredPath}`);
-    return configuredPath;
+  const configuredPath = config.get<string>("serverPath")?.trim();
+  if (configuredPath) {
+    if (fs.existsSync(configuredPath)) {
+      const candidate = await inspectServerCandidate({
+        path: configuredPath,
+        source: "configured",
+      });
+      logSelectedServer(candidate, expectedVersion);
+      void warnAboutVersionMismatch(candidate, expectedVersion);
+      return configuredPath;
+    }
+
+    outputChannel.appendLine(`Configured server path does not exist: ${configuredPath}`);
   }
 
-  const homeDir = process.env.HOME || process.env.USERPROFILE || "";
-  const cargoPath = path.join(homeDir, ".cargo", "bin", exeName);
-  if (fs.existsSync(cargoPath)) {
-    outputChannel.appendLine(`Found server at cargo path: ${cargoPath}`);
-    return cargoPath;
-  }
+  const candidates = await inspectServerCandidates(collectServerCandidates(context, exeName));
 
-  const pathEnv = process.env.PATH || "";
-  const pathSeparator = process.platform === "win32" ? ";" : ":";
-  const pathDirs = pathEnv.split(pathSeparator);
-
-  for (const dir of pathDirs) {
-    const serverPath = path.join(dir, exeName);
-    if (fs.existsSync(serverPath)) {
-      outputChannel.appendLine(`Found server in PATH: ${serverPath}`);
-      return serverPath;
+  if (expectedVersion) {
+    const matchingCandidate = candidates.find((candidate) => candidate.version === expectedVersion);
+    if (matchingCandidate) {
+      logSelectedServer(matchingCandidate, expectedVersion);
+      return matchingCandidate.path;
     }
   }
+
+  const fallbackCandidate = candidates[0];
+  if (fallbackCandidate) {
+    logSelectedServer(fallbackCandidate, expectedVersion);
+    void warnAboutVersionMismatch(fallbackCandidate, expectedVersion);
+    return fallbackCandidate.path;
+  }
+
+  outputChannel.appendLine("Server not found in any location");
+  return undefined;
+}
+
+function collectServerCandidates(context: ExtensionContext, exeName: string): ServerCandidate[] {
+  const candidates: ServerCandidate[] = [];
 
   const bundledPaths = [
     path.join(context.extensionPath, "dist", exeName),
     path.join(context.extensionPath, "server", exeName),
   ];
-
   for (const serverPath of bundledPaths) {
-    if (fs.existsSync(serverPath)) {
-      outputChannel.appendLine(`Found bundled server: ${serverPath}`);
-      return serverPath;
-    }
+    candidates.push({ path: serverPath, source: "bundled" });
   }
 
   const devPaths = [
@@ -440,16 +483,118 @@ async function findServerPath(
     path.join(context.extensionPath, "..", "..", "target", "debug", exeName),
     ...getWorkspaceDevPaths(exeName),
   ];
-
   for (const serverPath of devPaths) {
-    if (fs.existsSync(serverPath)) {
-      outputChannel.appendLine(`Found dev server: ${serverPath}`);
-      return serverPath;
+    candidates.push({ path: serverPath, source: "development" });
+  }
+
+  const homeDir = process.env.HOME || process.env.USERPROFILE || "";
+  if (homeDir) {
+    candidates.push({
+      path: path.join(homeDir, ".cargo", "bin", exeName),
+      source: "cargo",
+    });
+  }
+
+  const pathEnv = process.env.PATH || "";
+  const pathSeparator = process.platform === "win32" ? ";" : ":";
+  for (const dir of pathEnv.split(pathSeparator)) {
+    if (dir) {
+      candidates.push({ path: path.join(dir, exeName), source: "path" });
     }
   }
 
-  outputChannel.appendLine("Server not found in any location");
-  return undefined;
+  return dedupeCandidates(candidates).filter((candidate) => fs.existsSync(candidate.path));
+}
+
+function dedupeCandidates(candidates: ServerCandidate[]): ServerCandidate[] {
+  const seen = new Set<string>();
+  const deduped: ServerCandidate[] = [];
+
+  for (const candidate of candidates) {
+    const key = path.resolve(candidate.path);
+    if (seen.has(key)) {
+      continue;
+    }
+
+    seen.add(key);
+    deduped.push(candidate);
+  }
+
+  return deduped;
+}
+
+async function inspectServerCandidates(
+  candidates: ServerCandidate[],
+): Promise<InspectedServerCandidate[]> {
+  return Promise.all(candidates.map(inspectServerCandidate));
+}
+
+async function inspectServerCandidate(
+  candidate: ServerCandidate,
+): Promise<InspectedServerCandidate> {
+  try {
+    const { stdout } = await execFileAsync(candidate.path, ["--version"], {
+      timeout: 3000,
+    });
+    return {
+      ...candidate,
+      version: parseVizeVersion(stdout),
+    };
+  } catch (error) {
+    return {
+      ...candidate,
+      versionError: String(error),
+    };
+  }
+}
+
+function parseVizeVersion(output: string): string | undefined {
+  const match = output.match(/\bvize\s+([0-9]+\.[0-9]+\.[0-9]+(?:[-+][^\s]+)?)/);
+  return match?.[1];
+}
+
+function getExtensionVersion(context: ExtensionContext): string | undefined {
+  const packageJson = context.extension.packageJSON as { version?: unknown };
+  return typeof packageJson.version === "string" ? packageJson.version : undefined;
+}
+
+function logSelectedServer(
+  candidate: InspectedServerCandidate,
+  expectedVersion: string | undefined,
+): void {
+  const version = candidate.version ?? "unknown";
+  const expected = expectedVersion ? `, extension ${expectedVersion}` : "";
+  outputChannel.appendLine(
+    `Using ${candidate.source} server: ${candidate.path} (server ${version}${expected})`,
+  );
+
+  if (candidate.versionError) {
+    outputChannel.appendLine(`Could not inspect server version: ${candidate.versionError}`);
+  }
+}
+
+async function warnAboutVersionMismatch(
+  candidate: InspectedServerCandidate,
+  expectedVersion: string | undefined,
+): Promise<void> {
+  if (!expectedVersion || !candidate.version || candidate.version === expectedVersion) {
+    return;
+  }
+
+  const selection = await window.showWarningMessage(
+    `Vize: extension version ${expectedVersion} is starting language server ${candidate.version}. Hover, completion, and navigation may not work correctly.`,
+    OPEN_SETTINGS_ACTION,
+    SHOW_OUTPUT_ACTION,
+  );
+
+  if (selection === OPEN_SETTINGS_ACTION) {
+    await commands.executeCommand("workbench.action.openSettings", "vize.serverPath");
+    return;
+  }
+
+  if (selection === SHOW_OUTPUT_ACTION) {
+    outputChannel.show();
+  }
 }
 
 function getWorkspaceDevPaths(exeName: string): string[] {


### PR DESCRIPTION
## Summary

- Use the recommended lint/typecheck/editor initialization profile when `vize.enable` is true and no capability switches are explicitly configured.
- Prefer a Vize language server binary that matches the extension version, with warnings when the selected server version differs.
- Update the VS Code extension README and integration docs for the recommended editor profile and completion option.

## Impact

Users who manually enable Vize get diagnostics and editor assistance instead of an empty language server, and version mismatches are easier to spot when hover, completion, or navigation behaves unexpectedly.

## Validation

- `git diff --check`
- `pnpm -C npm/vscode-vize check`
