### PR TITLE
fix: macOS release native runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -301,7 +301,10 @@ jobs:
       fail-fast: false
       matrix:
         settings:
-          - host: macos-15-intel
+          # MoonBit's native installer does not publish a Darwin x64 toolchain.
+          # Build the darwin-x64 native package from the macOS ARM runner,
+          # matching the CLI release job.
+          - host: macos-latest
             target: x86_64-apple-darwin
             cross_compile: false
           - host: macos-latest

--- a/tests/tooling/github-workflows.test.ts
+++ b/tests/tooling/github-workflows.test.ts
@@ -757,12 +757,18 @@ test("native smoke workflow fresh-installs runtime tarballs across supported tar
   );
 });
 
-test("release workflow builds directly hosted native targets on matching runners", () => {
+test("release workflow builds native targets on MoonBit-supported runners", () => {
   const workflow = readRepoFile(".github", "workflows", "release.yml");
   const job = workflowJobBody(workflow, "build-native-all");
 
+  assert.doesNotMatch(
+    job,
+    /host:\s*macos-15-intel[\s\S]*target:\s*x86_64-apple-darwin/,
+    "MoonBit native scripts cannot run on macOS Intel runners",
+  );
+
   for (const [host, target] of [
-    ["macos-15-intel", "x86_64-apple-darwin"],
+    ["macos-latest", "x86_64-apple-darwin"],
     ["macos-latest", "aarch64-apple-darwin"],
     ["ubuntu-latest", "x86_64-unknown-linux-gnu"],
     ["ubuntu-24.04-arm", "aarch64-unknown-linux-gnu"],


### PR DESCRIPTION
## Summary

- Move the release `x86_64-apple-darwin` native package build back to the macOS ARM runner.
- Document why the release job avoids `macos-15-intel`: the MoonBit native installer does not support Darwin x64.
- Add a workflow regression assertion so the release native build does not return to a MoonBit-unsupported macOS Intel runner.

## Root Cause

The failing Release run was `Build Native - x86_64-apple-darwin` on `macos-15-intel`. The `.github/actions/setup-moonbit` action failed during installation with `Unsupported platform: Darwin x86_64`. The CLI release job already builds the x64 Darwin target on `macos-latest`, whose current runner image is macOS ARM64 and can run the MoonBit native toolchain.

## Validation

- `git diff --check`
- `node --test tests/tooling/github-workflows.test.ts`

## CI Evidence

- Failing run: https://github.com/ubugeeei/vize/actions/runs/26151393066
- Same failure also appeared in the in-progress `v0.111.0` release run: https://github.com/ubugeeei/vize/actions/runs/26152766413
