### PR TITLE
fix(nuxt): avoid sqlite wasm build OOM

### DIFF
--- a/docs/content/integrations/nuxt.md
+++ b/docs/content/integrations/nuxt.md
@@ -87,18 +87,19 @@ export default defineNuxtConfig({
     dev: {
       stylesheetLinks: true,
     },
+    musea: false,
   },
 });
 ```
 
-| Option                | Type                                 | Default                                           | Description                                                                                                                                                                           |
-| --------------------- | ------------------------------------ | ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `compiler`            | `boolean \| VizeNuxtCompilerOptions` | `true`                                            | Enables Vize as the Vue SFC compiler. Passing an object forwards options to `@vizejs/vite-plugin` while keeping Nuxt defaults for `root`, `devUrlBase`, and on-demand `scanPatterns`. |
-| `bridge`              | `boolean \| VizeNuxtBridgeOptions`   | `true`                                            | Controls the Nuxt transform bridge for auto-imports, component imports, i18n helpers, and stable async-data keys on Vize virtual modules.                                             |
-| `unocss`              | `boolean \| VizeNuxtUnoCssOptions`   | `true`                                            | Controls the UnoCSS bridge for Vize virtual modules. `originalSource: false` disables reading source SFCs; `maxBytes` limits memory use.                                              |
-| `dev.stylesheetLinks` | `boolean`                            | `true`                                            | Enables dev-only SSR HTML stylesheet-link cleanup for Vize-generated Nuxt asset URLs.                                                                                                 |
-| `musea`               | `false \| MuseaOptions`              | `{ include: ["**/*.art.vue"], inlineArt: false }` | Configures or disables Musea gallery integration.                                                                                                                                     |
-| `nuxtMusea`           | `NuxtMuseaOptions`                   | `{ route: { path: "/" } }`                        | Documents the Nuxt mock shape used by Musea preview helpers. The Nuxt module does not install the mock layer globally because doing so would shadow Nuxt's own `#imports`.            |
+| Option                | Type                                 | Default                    | Description                                                                                                                                                                           |
+| --------------------- | ------------------------------------ | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `compiler`            | `boolean \| VizeNuxtCompilerOptions` | `true`                     | Enables Vize as the Vue SFC compiler. Passing an object forwards options to `@vizejs/vite-plugin` while keeping Nuxt defaults for `root`, `devUrlBase`, and on-demand `scanPatterns`. |
+| `bridge`              | `boolean \| VizeNuxtBridgeOptions`   | `true`                     | Controls the Nuxt transform bridge for auto-imports, component imports, i18n helpers, and stable async-data keys on Vize virtual modules.                                             |
+| `unocss`              | `boolean \| VizeNuxtUnoCssOptions`   | `true`                     | Controls the UnoCSS bridge for Vize virtual modules. `originalSource: false` disables reading source SFCs; `maxBytes` limits memory use.                                              |
+| `dev.stylesheetLinks` | `boolean`                            | `true`                     | Enables dev-only SSR HTML stylesheet-link cleanup for Vize-generated Nuxt asset URLs.                                                                                                 |
+| `musea`               | `boolean \| MuseaOptions`            | `false`                    | Opts into Musea gallery integration. Use `true` for Musea defaults or pass an object to configure include patterns, tokens, preview CSS, and routing.                                 |
+| `nuxtMusea`           | `NuxtMuseaOptions`                   | `{ route: { path: "/" } }` | Documents the Nuxt mock shape used by Musea preview helpers. The Nuxt module does not install the mock layer globally because doing so would shadow Nuxt's own `#imports`.            |
 
 ## Advanced Setup
 

--- a/npm/nuxt/src/index.ts
+++ b/npm/nuxt/src/index.ts
@@ -18,6 +18,7 @@ import {
   resolveNuxtBridgeOptions,
   resolveNuxtCompilerOptions,
   resolveNuxtDevOptions,
+  resolveNuxtMuseaOptions,
   resolveNuxtUnoCssOptions,
 } from "./options";
 import {
@@ -80,10 +81,7 @@ export default defineNuxtModule<VizeNuxtOptions>({
     configKey: "vize",
   },
   defaults: {
-    musea: {
-      include: ["**/*.art.vue"],
-      inlineArt: false,
-    },
+    musea: false,
     nuxtMusea: {
       route: { path: "/" },
     },
@@ -92,6 +90,7 @@ export default defineNuxtModule<VizeNuxtOptions>({
     const resolver = createResolver(import.meta.url);
     const bridgeOptions = resolveNuxtBridgeOptions(options.bridge);
     const devOptions = resolveNuxtDevOptions(options.dev);
+    const museaOptions = resolveNuxtMuseaOptions(options.musea);
     const unocssOptions = resolveNuxtUnoCssOptions(options.unocss);
 
     nuxt.options.vite.plugins = nuxt.options.vite.plugins || [];
@@ -311,12 +310,12 @@ export default defineNuxtModule<VizeNuxtOptions>({
     // In Nuxt context, real composables/components are already available
     // via Nuxt's own Vite plugins. Adding nuxtMusea globally would shadow
     // Nuxt's #imports resolution and break the app.
-    if (options.musea !== false) {
+    if (museaOptions !== false) {
       const museaBasePath =
-        options.musea && typeof options.musea === "object" && "basePath" in options.musea
-          ? ((options.musea as Record<string, unknown>).basePath as string)
+        "basePath" in museaOptions
+          ? ((museaOptions as Record<string, unknown>).basePath as string)
           : "/__musea__";
-      nuxt.options.vite.plugins.push(...musea(options.musea || {}));
+      nuxt.options.vite.plugins.push(...musea(museaOptions));
 
       // Print Musea Gallery URL after dev server starts
       nuxt.hook("listen", (_server: unknown, listener: { url: string }) => {

--- a/npm/nuxt/src/options.test.ts
+++ b/npm/nuxt/src/options.test.ts
@@ -4,6 +4,7 @@ import {
   resolveNuxtBridgeOptions,
   resolveNuxtCompilerOptions,
   resolveNuxtDevOptions,
+  resolveNuxtMuseaOptions,
   resolveNuxtUnoCssOptions,
 } from "./options.ts";
 
@@ -90,6 +91,24 @@ assert.deepEqual(
     stylesheetLinks: false,
   },
   "dev stylesheet cleanup should be configurable",
+);
+
+assert.equal(
+  resolveNuxtMuseaOptions(undefined),
+  false,
+  "Musea should be opt-in so normal Nuxt builds do not include the gallery plugin",
+);
+
+assert.deepEqual(
+  resolveNuxtMuseaOptions(true),
+  {},
+  "musea true should enable the gallery with plugin defaults",
+);
+
+assert.deepEqual(
+  resolveNuxtMuseaOptions({ include: ["**/*.art.vue"], inlineArt: false }),
+  { include: ["**/*.art.vue"], inlineArt: false },
+  "musea object should pass through explicit gallery options",
 );
 
 console.log("✅ nuxt option normalization tests passed!");

--- a/npm/nuxt/src/options.ts
+++ b/npm/nuxt/src/options.ts
@@ -93,9 +93,11 @@ export interface VizeNuxtOptions {
 
   /**
    * Musea gallery options.
-   * Set to `false` to disable musea.
+   * Set to `true` to enable Musea with default options.
+   *
+   * @default false
    */
-  musea?: MuseaOptions | false;
+  musea?: boolean | MuseaOptions;
 
   /**
    * Nuxt mock options for musea gallery.
@@ -191,4 +193,14 @@ export function resolveNuxtDevOptions(dev: VizeNuxtOptions["dev"]): Required<Viz
     ...DEFAULT_NUXT_DEV_OPTIONS,
     ...dev,
   };
+}
+
+export function resolveNuxtMuseaOptions(musea: VizeNuxtOptions["musea"]): MuseaOptions | false {
+  if (musea === true) {
+    return {};
+  }
+  if (musea === false || musea == null) {
+    return false;
+  }
+  return musea;
 }

--- a/npm/vite-plugin-vize/src/plugin/index.ts
+++ b/npm/vite-plugin-vize/src/plugin/index.ts
@@ -10,6 +10,7 @@ import { loadConfig, vizeConfigStore } from "../config.ts";
 import {
   DEFAULT_PRECOMPILE_BATCH_SIZE,
   DEFAULT_PRECOMPILE_IGNORE_PATTERNS,
+  clearBuildCaches,
   type VizePluginState,
   compileAll,
   normalizePrecompileBatchSize,
@@ -240,6 +241,12 @@ export function vize(options: VizeOptions = {}): Plugin[] {
 
     generateBundle() {
       handleGenerateBundleHook(state, this.emitFile.bind(this));
+    },
+
+    closeBundle() {
+      if (state.server === null) {
+        clearBuildCaches(state);
+      }
     },
   };
 

--- a/npm/vite-plugin-vize/src/plugin/load.test.ts
+++ b/npm/vite-plugin-vize/src/plugin/load.test.ts
@@ -6,6 +6,7 @@ import { fileURLToPath } from "node:url";
 import type { VizePluginState } from "./state.ts";
 import { getBoundaryPlaceholderCode } from "./load.ts";
 import { loadHook } from "./load.ts";
+import { normalizeVueServerRendererImport } from "./load.ts";
 import { transformHook } from "./load.ts";
 import { toVirtualId } from "../virtual.ts";
 
@@ -49,6 +50,14 @@ assert.equal(
   getBoundaryPlaceholderCode("/src/Foo.vue", true),
   null,
   "Regular SFCs must not be stubbed",
+);
+
+assert.equal(
+  normalizeVueServerRendererImport(
+    "import { ssrRenderAttrs } from '@vue/server-renderer';\nexport { ssrRenderAttrs };",
+  ),
+  'import { ssrRenderAttrs } from "vue/server-renderer";\nexport { ssrRenderAttrs };',
+  "SSR helper imports should use Vue's public server-renderer entry for Nuxt/Nitro externalization",
 );
 
 const realPath = "/src/Hmr.vue";

--- a/npm/vite-plugin-vize/src/plugin/load.ts
+++ b/npm/vite-plugin-vize/src/plugin/load.ts
@@ -61,6 +61,10 @@ function getVirtualModuleDefines(
   };
 }
 
+export function normalizeVueServerRendererImport(code: string): string {
+  return code.replace(/\bfrom\s+(['"])@vue\/server-renderer\1/g, 'from "vue/server-renderer"');
+}
+
 function findMacroArtifactModule(
   state: VizePluginState,
   realPath: string,
@@ -275,16 +279,17 @@ export function loadHook(
           ),
         };
       }
+      const generatedOutput = generateOutput(compiled, {
+        isProduction: state.isProduction,
+        isDev: state.server !== null && !isSsr,
+        ssr: isSsr,
+        hmrUpdateType: pendingHmrUpdateType,
+        extractCss: state.extractCss,
+        filePath: realPath,
+      });
       const output = rewriteStaticAssetUrls(
         rewriteDynamicTemplateImports(
-          generateOutput(compiled, {
-            isProduction: state.isProduction,
-            isDev: state.server !== null && !isSsr,
-            ssr: isSsr,
-            hmrUpdateType: pendingHmrUpdateType,
-            extractCss: state.extractCss,
-            filePath: realPath,
-          }),
+          isSsr ? normalizeVueServerRendererImport(generatedOutput) : generatedOutput,
           state.dynamicImportAliasRules,
         ),
         state.dynamicImportAliasRules,

--- a/npm/vite-plugin-vize/src/plugin/resolve.test.ts
+++ b/npm/vite-plugin-vize/src/plugin/resolve.test.ts
@@ -170,6 +170,36 @@ function expectResolvedId(resolved: Awaited<ReturnType<typeof resolveIdHook>>): 
 }
 
 {
+  const tempRoot = createTempRoot("ssr-vue-runtime");
+  const importer = path.join(tempRoot, "App.vue");
+  fs.writeFileSync(importer, "<template><div /></template>");
+
+  assert.deepEqual(
+    await resolveIdHook(
+      nullResolveContext,
+      createState(tempRoot),
+      "@vue/server-renderer",
+      toVirtualId(importer, true),
+      { ssr: true },
+    ),
+    { id: "vue/server-renderer", external: true },
+    "SSR virtual modules should externalize Vue's public server renderer entry",
+  );
+
+  assert.deepEqual(
+    await resolveIdHook(
+      nullResolveContext,
+      createState(tempRoot),
+      "vue/dist/vue.esm-bundler.js",
+      toVirtualId(importer, true),
+      { ssr: true },
+    ),
+    { id: "vue", external: true },
+    "SSR virtual modules should not bundle Vue runtime aliases into Nuxt server output",
+  );
+}
+
+{
   const tempRoot = createTempRoot("alias-vue");
   const importer = path.join(tempRoot, "src", "App.vue");
   const aliased = path.join(tempRoot, "src", "views", "Aliased.vue");

--- a/npm/vite-plugin-vize/src/plugin/resolve.ts
+++ b/npm/vite-plugin-vize/src/plugin/resolve.ts
@@ -34,7 +34,7 @@ interface ResolveContext {
     id: string,
     importer?: string,
     options?: { skipSelf: boolean },
-  ): Promise<{ id: string } | null>;
+  ): Promise<{ id: string; external?: boolean } | null>;
 }
 
 function resolveAliasRequest(
@@ -133,6 +133,27 @@ function isVueRuntimeRequest(id: string): boolean {
   return splitViteIdQuery(id).request === "vue";
 }
 
+function resolveSsrExternalVueRequest(id: string): string | null {
+  const { request, querySuffix } = splitViteIdQuery(id);
+  if (querySuffix) {
+    return null;
+  }
+
+  if (request === "@vue/server-renderer" || request === "vue/server-renderer") {
+    return "vue/server-renderer";
+  }
+
+  if (request === "vue" || request.startsWith("vue/dist/")) {
+    return "vue";
+  }
+
+  if (request.startsWith("@vue/")) {
+    return request;
+  }
+
+  return null;
+}
+
 function isVuePackageEntry(id: string): boolean {
   const { request } = splitViteIdQuery(id);
   const normalized = request.split(path.sep).join("/");
@@ -224,7 +245,7 @@ export async function resolveIdHook(
   id: string,
   importer?: string,
   options?: { ssr?: boolean },
-): Promise<string | { id: string } | null | undefined> {
+): Promise<string | { id: string; external?: boolean } | null | undefined> {
   if (!isPotentialVizeResolveId(id) && !isPotentialVizeImporter(importer)) {
     return null;
   }
@@ -336,6 +357,11 @@ export async function resolveIdHook(
 
     // For non-vue files, resolve relative to the real importer
     if (!id.endsWith(".vue")) {
+      const ssrExternalVueRequest = isSsrRequest ? resolveSsrExternalVueRequest(id) : null;
+      if (ssrExternalVueRequest) {
+        return { id: ssrExternalVueRequest, external: true };
+      }
+
       // For bare module specifiers (not relative, not absolute),
       // resolve them from the real importer path so that Vite can find
       // packages in the correct node_modules directory.

--- a/npm/vite-plugin-vize/src/plugin/state.test.ts
+++ b/npm/vite-plugin-vize/src/plugin/state.test.ts
@@ -7,6 +7,7 @@ import {
   DEFAULT_PRECOMPILE_BATCH_MAX_BYTES,
   DEFAULT_PRECOMPILE_BATCH_SIZE,
   DEFAULT_PRECOMPILE_IGNORE_PATTERNS,
+  clearBuildCaches,
   chunkPrecompileFiles,
   compileAll,
   diffPrecompileFiles,
@@ -228,6 +229,37 @@ assert.equal(
   cssState.collectedCss.has("/src/Button.vue"),
   false,
   "Delegated CSS modules should stay out of the extracted plain CSS bundle",
+);
+
+const retainedBuildState = {
+  cache: new Map([["/src/App.vue", plainCssModule]]),
+  ssrCache: new Map([["/src/App.vue", plainCssModule]]),
+  collectedCss: new Map([["/src/App.vue", ".app{}"]]),
+  precompileMetadata: new Map([["/src/App.vue", { mtimeMs: 1, size: 100 }]]),
+  pendingHmrUpdateTypes: new Map([["/src/App.vue", "template-only" as const]]),
+};
+
+clearBuildCaches(retainedBuildState);
+assert.equal(retainedBuildState.cache.size, 0, "build cache should be released after bundling");
+assert.equal(
+  retainedBuildState.ssrCache.size,
+  0,
+  "SSR build cache should be released after bundling",
+);
+assert.equal(
+  retainedBuildState.collectedCss.size,
+  0,
+  "collected CSS cache should be released after CSS emission",
+);
+assert.equal(
+  retainedBuildState.precompileMetadata.size,
+  0,
+  "precompile metadata should be released after build",
+);
+assert.equal(
+  retainedBuildState.pendingHmrUpdateTypes.size,
+  0,
+  "build-only HMR bookkeeping should be released after build",
 );
 
 console.log("✅ vite-plugin-vize state tests passed!");

--- a/npm/vite-plugin-vize/src/plugin/state.ts
+++ b/npm/vite-plugin-vize/src/plugin/state.ts
@@ -101,6 +101,19 @@ export function syncCollectedCssForFile(
   }
 }
 
+export function clearBuildCaches(
+  state: Pick<
+    VizePluginState,
+    "cache" | "collectedCss" | "pendingHmrUpdateTypes" | "precompileMetadata" | "ssrCache"
+  >,
+): void {
+  state.cache.clear();
+  state.ssrCache.clear();
+  state.collectedCss.clear();
+  state.precompileMetadata.clear();
+  state.pendingHmrUpdateTypes.clear();
+}
+
 /**
  * Pre-compile all Vue files matching scan patterns.
  */


### PR DESCRIPTION
## Summary
- make the Nuxt Musea gallery integration opt-in so regular Nuxt builds do not pull its extra build graph by default
- keep SSR virtual-module Vue runtime imports external for Nuxt/Nitro instead of bundling Vue runtime/server-renderer into server output
- release Vize build caches after production bundles finish

## Root cause
The SQLite WASM repro only OOMed when the Vize Nuxt module was enabled. Two defaults amplified the build graph: Musea was enabled even for apps that did not use the gallery, and SSR virtual modules could resolve Vue runtime helpers to file paths that Nitro bundled into the server chunk.

## Validation
- `nix develop path:/Users/nishimura/Code/github.com/ubugeeei/vize-nuxt-options --command pnpm --filter @vizejs/vite-plugin check`
- `nix develop path:/Users/nishimura/Code/github.com/ubugeeei/vize-nuxt-options --command pnpm --filter @vizejs/vite-plugin test`
- `nix develop path:/Users/nishimura/Code/github.com/ubugeeei/vize-nuxt-options --command pnpm --filter @vizejs/vite-plugin build`
- `nix develop path:/Users/nishimura/Code/github.com/ubugeeei/vize-nuxt-options --command pnpm --filter @vizejs/nuxt check`
- `nix develop path:/Users/nishimura/Code/github.com/ubugeeei/vize-nuxt-options --command pnpm --filter @vizejs/nuxt test`
- `nix develop path:/Users/nishimura/Code/github.com/ubugeeei/vize-nuxt-options --command pnpm --filter @vizejs/nuxt build`
- `nix develop path:/Users/nishimura/Code/github.com/ubugeeei/vize-nuxt-options --command pnpm run build:heap512` from the ignored SQLite WASM Nuxt repro
- `git diff --check`

The heap-limited repro now completes with Nitro `server.mjs` at 40.3 kB instead of bundling the Vue runtime into a much larger server chunk.