### PR TITLE
fix(release): initialize MoonBit registry before scripts

### DIFF
--- a/tests/tooling/task-shell.test.ts
+++ b/tests/tooling/task-shell.test.ts
@@ -8,7 +8,10 @@ import {
   shellCommandForwardingArguments,
   withRustTaskEnvironment,
 } from "../../tools/vite-plus/task-shell.ts";
-import { moonCommandForEnvironment } from "../../tools/vite-plus/task-commands.ts";
+import {
+  moonCommandForEnvironment,
+  moonRegistryUpdateGuardForEnvironment,
+} from "../../tools/vite-plus/task-commands.ts";
 import { checkTasks } from "../../tools/vite-plus/tasks/check.ts";
 import { releaseTasks } from "../../tools/vite-plus/tasks/release.ts";
 
@@ -77,6 +80,26 @@ test("MoonBit task commands preserve the GitHub runner shim", () => {
   assert.equal(
     moonCommandForEnvironment({ MOON_BIN: "/runner-temp/moonbit-shims/moon" }, () => true),
     "/runner-temp/moonbit-shims/moon",
+  );
+});
+
+test("MoonBit task commands initialize the workspace registry index", () => {
+  assert.equal(
+    moonRegistryUpdateGuardForEnvironment(
+      {},
+      (candidate) => candidate === ".cache/moonbit/bin/moon",
+    ),
+    "( [ -d .cache/moonbit/registry/index/.git ] || env MOON_HOME=.cache/moonbit MOON_BIN=.cache/moonbit/bin/moon .cache/moonbit/bin/moon update )",
+  );
+});
+
+test("MoonBit task commands leave explicit MoonBit shims untouched", () => {
+  assert.equal(
+    moonRegistryUpdateGuardForEnvironment(
+      { MOON_BIN: "/runner-temp/moonbit-shims/moon" },
+      () => true,
+    ),
+    null,
   );
 });
 

--- a/tools/vite-plus/task-commands.ts
+++ b/tools/vite-plus/task-commands.ts
@@ -65,6 +65,7 @@ export const runTasks = (...taskNames: string[]) => taskNames.map(runTask).join(
 
 const workspaceMoonHome = ".cache/moonbit";
 const workspaceMoonBin = `${workspaceMoonHome}/bin/moon`;
+const workspaceMoonRegistryIndex = `${workspaceMoonHome}/registry/index/.git`;
 
 export const moonCommandForEnvironment = (
   env: NodeJS.ProcessEnv = process.env,
@@ -81,7 +82,20 @@ export const moonCommandForEnvironment = (
   return "moon";
 };
 
+export const moonRegistryUpdateGuardForEnvironment = (
+  env: NodeJS.ProcessEnv = process.env,
+  pathExists: (path: string) => boolean = existsSync,
+) => {
+  const hasExplicitMoonBin = env.MOON_BIN != null && env.MOON_BIN !== "";
+  if (hasExplicitMoonBin || !pathExists(workspaceMoonBin)) {
+    return null;
+  }
+
+  return `( [ -d ${workspaceMoonRegistryIndex} ] || ${moonCommandForEnvironment(env, pathExists)} update )`;
+};
+
 const moonCommand = moonCommandForEnvironment();
+const moonRegistryUpdateGuard = moonRegistryUpdateGuardForEnvironment();
 
 /**
  * Executes a repository MoonBit script through native script mode.
@@ -93,6 +107,7 @@ const moonCommand = moonCommandForEnvironment();
  */
 export const moonScript = (name: string, ...args: string[]) =>
   [
+    ...(moonRegistryUpdateGuard == null ? [] : [moonRegistryUpdateGuard, "&&"]),
     moonCommand,
     "run",
     "-q",


### PR DESCRIPTION
## Summary

- Add a registry-index guard before workspace-local MoonBit script execution.
- Run `moon update` automatically when `.cache/moonbit/registry/index/.git` is missing.
- Cover the guard behavior in task shell tests while preserving explicit `MOON_BIN` shims.

## Root Cause

A fresh workspace-local MoonBit cache can contain the toolchain binaries without a cloned registry index. In that state, `moon run -` cannot resolve registry dependencies such as `moonbitlang/async` and `moonbitlang/x`, so release automation fails before the script can run.

## Validation

- `pnpm exec tsx --test tests/tooling/task-shell.test.ts`
- `pnpm exec oxlint tools/vite-plus/task-commands.ts tests/tooling/task-shell.test.ts`
- `pnpm exec oxfmt --check tools/vite-plus/task-commands.ts tests/tooling/task-shell.test.ts`
- `vp run release --print-bump 0.107.0 minor`
- Temporarily moved `.cache/moonbit/registry` aside and verified `vp run release --print-bump 0.107.0 minor` clones the index and succeeds.