### PR TITLE
perf(patina): reuse parsed SFC metadata during lint

### DIFF
--- a/crates/vize_patina/src/linter/config.rs
+++ b/crates/vize_patina/src/linter/config.rs
@@ -193,6 +193,12 @@ impl Linter {
     pub fn rules(&self) -> &[Box<dyn crate::rule::Rule>] {
         self.registry.rules()
     }
+
+    /// Get all registered rule names.
+    #[inline]
+    pub(crate) fn rule_names(&self) -> &[&'static str] {
+        self.registry.rule_names()
+    }
 }
 
 impl Default for Linter {

--- a/crates/vize_patina/src/linter/engine.rs
+++ b/crates/vize_patina/src/linter/engine.rs
@@ -34,15 +34,25 @@ pub(crate) fn analyze_descriptor_for_lint(
 }
 
 impl Linter {
-    fn lint_sfc_level(&self, source: &str, filename: &str) -> LintResult {
+    fn lint_sfc_level<'a>(
+        &self,
+        source: &'a str,
+        filename: &str,
+        shared_descriptor: Option<&'a vize_atelier_sfc::SfcDescriptor<'a>>,
+    ) -> LintResult {
         let capacity = (source.len() * 2).max(self.initial_capacity);
         let allocator = Allocator::with_capacity(capacity);
         let mut ctx = LintContext::with_locale(&allocator, source, filename, self.locale);
         ctx.set_enabled_rules(self.enabled_rules.clone());
         ctx.set_help_level(self.help_level);
 
-        let shared_descriptor = if self.has_active_shared_sfc_descriptor_rules() {
-            profile!(
+        let owned_descriptor;
+        let shared_descriptor = if !self.has_active_shared_sfc_descriptor_rules() {
+            None
+        } else if let Some(descriptor) = shared_descriptor {
+            Some(descriptor)
+        } else {
+            owned_descriptor = profile!(
                 "patina.sfc.level_rules.parse_sfc",
                 parse_sfc(
                     source,
@@ -52,18 +62,22 @@ impl Linter {
                     },
                 )
                 .ok()
-            )
-        } else {
-            None
+            );
+            owned_descriptor.as_ref()
         };
 
-        if let Some(descriptor) = shared_descriptor.as_ref() {
+        if let Some(descriptor) = shared_descriptor {
             ctx.set_sfc_descriptor(descriptor);
         }
 
         profile!("patina.sfc.rules.run_on_sfc", {
-            for rule in self.registry.rules() {
-                ctx.current_rule = rule.meta().name;
+            for (rule, rule_name) in self
+                .registry
+                .rules()
+                .iter()
+                .zip(self.rule_names().iter().copied())
+            {
+                ctx.current_rule = rule_name;
                 rule.run_on_sfc(&mut ctx);
             }
         });
@@ -132,6 +146,22 @@ impl Linter {
             .any(|rule_name| self.registry.has_rule(rule_name) && self.is_rule_enabled(rule_name))
     }
 
+    fn needs_sfc_descriptor_for_lint(&self) -> bool {
+        self.has_active_shared_sfc_descriptor_rules()
+            || super::script_rules::has_active_builtin_script_rules(self)
+            || self.has_active_semantic_template_rules()
+            || {
+                #[cfg(not(target_arch = "wasm32"))]
+                {
+                    super::native_type_aware::has_active_type_aware_rules(self)
+                }
+                #[cfg(target_arch = "wasm32")]
+                {
+                    false
+                }
+            }
+    }
+
     fn run_template_rules<'a>(
         &self,
         allocator: &'a Allocator,
@@ -154,7 +184,7 @@ impl Linter {
             ctx.set_analysis_excluded_rules(super::native_type_aware::TYPE_AWARE_RULES);
         }
 
-        let mut visitor = LintVisitor::new(&mut ctx, self.registry.rules());
+        let mut visitor = LintVisitor::new(&mut ctx, self.registry.rules(), self.rule_names());
         profile!("patina.template.visit", visitor.visit_root(root));
 
         let error_count = ctx.error_count();
@@ -300,16 +330,30 @@ impl Linter {
     /// Uses ultra-fast template extraction optimized for linting.
     #[inline]
     pub fn lint_sfc(&self, source: &str, filename: &str) -> LintResult {
+        let shared_descriptor = if self.needs_sfc_descriptor_for_lint() {
+            profile!(
+                "patina.sfc.shared_parse_sfc",
+                super::script_rules::parse_sfc_for_lint(source, filename).ok()
+            )
+        } else {
+            None
+        };
+
         let sfc_result = profile!(
             "patina.sfc.level_rules",
-            self.lint_sfc_level(source, filename)
+            self.lint_sfc_level(source, filename, shared_descriptor.as_ref())
         );
 
         #[cfg(not(target_arch = "wasm32"))]
         if super::native_type_aware::has_active_type_aware_rules(self) {
             let template_result = profile!(
                 "patina.type_aware.lint_sfc_with_corsa",
-                super::native_type_aware::lint_sfc_with_corsa(self, source, filename)
+                super::native_type_aware::lint_sfc_with_corsa_descriptor(
+                    self,
+                    source,
+                    filename,
+                    shared_descriptor.as_ref(),
+                )
             );
             return Self::merge_lint_results(template_result, sfc_result);
         }
@@ -317,16 +361,13 @@ impl Linter {
         if super::script_rules::has_active_builtin_script_rules(self)
             || self.has_active_semantic_template_rules()
         {
-            let template_result = match profile!(
-                "patina.sfc.parse_for_script_rules",
-                super::script_rules::parse_sfc_for_lint(source, filename)
-            ) {
-                Ok(descriptor) => {
+            let template_result = match shared_descriptor.as_ref() {
+                Some(descriptor) => {
                     profile!("patina.sfc.descriptor_rules", {
-                        super::script_rules::lint_with_descriptor(self, filename, &descriptor)
+                        super::script_rules::lint_with_descriptor(self, filename, descriptor)
                     })
                 }
-                Err(_) => {
+                None => {
                     if let Some((content, byte_offset)) = profile!(
                         "patina.template.extract_fast",
                         extract_template_fast(source)

--- a/crates/vize_patina/src/linter/native_type_aware.rs
+++ b/crates/vize_patina/src/linter/native_type_aware.rs
@@ -6,6 +6,7 @@ use crate::diagnostic::LintDiagnostic;
 use corsa::utils::{
     is_any_like_type_texts, is_promise_like_type_texts, is_unknown_like_type_texts,
 };
+use vize_atelier_sfc::SfcDescriptor;
 use vize_carton::{String, ToCompactString, profile};
 
 mod driver;
@@ -39,16 +40,29 @@ pub(crate) fn has_active_type_aware_rules(linter: &Linter) -> bool {
         .any(|rule_name| linter.registry.has_rule(rule_name) && linter.is_rule_enabled(rule_name))
 }
 
+#[cfg(test)]
 pub(crate) fn lint_sfc_with_corsa(linter: &Linter, source: &str, filename: &str) -> LintResult {
-    let mut result = match profile!(
+    let descriptor = profile!(
         "patina.type_aware.parse_sfc",
         super::script_rules::parse_sfc_for_lint(source, filename)
-    ) {
-        Ok(descriptor) => profile!(
+    )
+    .ok();
+
+    lint_sfc_with_corsa_descriptor(linter, source, filename, descriptor.as_ref())
+}
+
+pub(crate) fn lint_sfc_with_corsa_descriptor<'a>(
+    linter: &Linter,
+    source: &'a str,
+    filename: &str,
+    descriptor: Option<&'a SfcDescriptor<'a>>,
+) -> LintResult {
+    let mut result = match descriptor {
+        Some(descriptor) => profile!(
             "patina.type_aware.driver",
             driver::lint_with_descriptor(linter, source, filename, descriptor)
         ),
-        Err(_) => {
+        None => {
             if let Some((content, byte_offset)) = super::engine::extract_template_fast(source) {
                 let mut fallback = profile!(
                     "patina.type_aware.fallback_template_lint",

--- a/crates/vize_patina/src/linter/native_type_aware/driver.rs
+++ b/crates/vize_patina/src/linter/native_type_aware/driver.rs
@@ -26,7 +26,7 @@ pub(super) fn lint_with_descriptor<'a>(
     linter: &Linter,
     source: &str,
     filename: &str,
-    descriptor: vize_atelier_sfc::SfcDescriptor<'a>,
+    descriptor: &vize_atelier_sfc::SfcDescriptor<'a>,
 ) -> LintResult {
     let allocator =
         vize_carton::Allocator::with_capacity((source.len() * 4).max(linter.initial_capacity));
@@ -38,7 +38,7 @@ pub(super) fn lint_with_descriptor<'a>(
 
     let analysis = profile!("patina.type_aware.croquis", {
         super::super::engine::analyze_descriptor_for_lint(
-            &descriptor,
+            descriptor,
             template_ast.as_ref().map(|(root, _)| root),
         )
     });

--- a/crates/vize_patina/src/linter/native_type_aware/driver.rs
+++ b/crates/vize_patina/src/linter/native_type_aware/driver.rs
@@ -65,7 +65,7 @@ pub(super) fn lint_with_descriptor<'a>(
             warning_count: 0,
         }
     };
-    super::super::script_rules::append_builtin_script_diagnostics(linter, &descriptor, &mut result);
+    super::super::script_rules::append_builtin_script_diagnostics(linter, descriptor, &mut result);
 
     let Some(script_block) = descriptor
         .script_setup

--- a/crates/vize_patina/src/rule.rs
+++ b/crates/vize_patina/src/rule.rs
@@ -97,6 +97,7 @@ pub trait Rule: Send + Sync {
 /// Registry holding all enabled lint rules
 pub struct RuleRegistry {
     rules: Vec<Box<dyn Rule>>,
+    rule_names: Vec<&'static str>,
 }
 
 impl RuleRegistry {
@@ -104,18 +105,23 @@ impl RuleRegistry {
     const HAPPY_PATH_CAPACITY: usize = 90;
     /// Create a new empty registry
     pub fn new() -> Self {
-        Self { rules: Vec::new() }
+        Self {
+            rules: Vec::new(),
+            rule_names: Vec::new(),
+        }
     }
 
     #[inline]
     fn with_capacity(capacity: usize) -> Self {
         Self {
             rules: Vec::with_capacity(capacity),
+            rule_names: Vec::with_capacity(capacity),
         }
     }
 
     /// Register a rule
     pub fn register(&mut self, rule: Box<dyn Rule>) {
+        self.rule_names.push(rule.meta().name);
         self.rules.push(rule);
     }
 
@@ -129,9 +135,14 @@ impl RuleRegistry {
         &self.rules
     }
 
+    /// Get all registered rule names in the same order as [`Self::rules`].
+    pub fn rule_names(&self) -> &[&'static str] {
+        &self.rule_names
+    }
+
     /// Check whether a rule with the given name is registered.
     pub fn has_rule(&self, name: &str) -> bool {
-        self.rules.iter().any(|rule| rule.meta().name == name)
+        self.rule_names.contains(&name)
     }
 
     /// Create a registry for a named preset.

--- a/crates/vize_patina/src/rules/ssr/no_browser_globals_in_ssr.rs
+++ b/crates/vize_patina/src/rules/ssr/no_browser_globals_in_ssr.rs
@@ -495,7 +495,8 @@ mod tests {
         let (root, _) = parser.parse();
 
         let rules: Vec<Box<dyn Rule>> = vec![Box::new(NoBrowserGlobalsInSsr)];
-        let mut visitor = crate::visitor::LintVisitor::new(&mut ctx, &rules);
+        let rule_names = [rules[0].meta().name];
+        let mut visitor = crate::visitor::LintVisitor::new(&mut ctx, &rules, &rule_names);
         visitor.visit_root(&root);
 
         ctx.into_diagnostics()

--- a/crates/vize_patina/src/visitor.rs
+++ b/crates/vize_patina/src/visitor.rs
@@ -14,6 +14,7 @@ use vize_relief::ast::{
 pub struct LintVisitor<'a, 'ctx, 'rules> {
     ctx: &'ctx mut LintContext<'a>,
     rules: &'rules [Box<dyn Rule>],
+    rule_names: &'rules [&'static str],
     /// When true, suppress all diagnostics for the next element
     forget_next_element: bool,
 }
@@ -21,10 +22,15 @@ pub struct LintVisitor<'a, 'ctx, 'rules> {
 impl<'a, 'ctx, 'rules> LintVisitor<'a, 'ctx, 'rules> {
     /// Create a new visitor
     #[inline]
-    pub fn new(ctx: &'ctx mut LintContext<'a>, rules: &'rules [Box<dyn Rule>]) -> Self {
+    pub fn new(
+        ctx: &'ctx mut LintContext<'a>,
+        rules: &'rules [Box<dyn Rule>],
+        rule_names: &'rules [&'static str],
+    ) -> Self {
         Self {
             ctx,
             rules,
+            rule_names,
             forget_next_element: false,
         }
     }
@@ -34,8 +40,8 @@ impl<'a, 'ctx, 'rules> LintVisitor<'a, 'ctx, 'rules> {
     pub fn visit_root(&mut self, root: &RootNode<'a>) {
         // Run template-level checks
         profile!("patina.rules.run_on_template", {
-            for rule in self.rules.iter() {
-                self.ctx.current_rule = rule.meta().name;
+            for (rule, rule_name) in self.rules.iter().zip(self.rule_names.iter().copied()) {
+                self.ctx.current_rule = rule_name;
                 rule.run_on_template(self.ctx, root);
             }
         });
@@ -60,8 +66,9 @@ impl<'a, 'ctx, 'rules> LintVisitor<'a, 'ctx, 'rules> {
             }
             TemplateChildNode::Interpolation(interp) => {
                 profile!("patina.rules.check_interpolation", {
-                    for rule in self.rules.iter() {
-                        self.ctx.current_rule = rule.meta().name;
+                    for (rule, rule_name) in self.rules.iter().zip(self.rule_names.iter().copied())
+                    {
+                        self.ctx.current_rule = rule_name;
                         rule.check_interpolation(self.ctx, interp);
                     }
                 });
@@ -195,8 +202,8 @@ impl<'a, 'ctx, 'rules> LintVisitor<'a, 'ctx, 'rules> {
 
         // Enter element - run rules
         profile!("patina.rules.enter_element", {
-            for rule in self.rules.iter() {
-                self.ctx.current_rule = rule.meta().name;
+            for (rule, rule_name) in self.rules.iter().zip(self.rule_names.iter().copied()) {
+                self.ctx.current_rule = rule_name;
                 rule.enter_element(self.ctx, el);
             }
         });
@@ -205,8 +212,9 @@ impl<'a, 'ctx, 'rules> LintVisitor<'a, 'ctx, 'rules> {
         for prop in el.props.iter() {
             if let PropNode::Directive(dir) = prop {
                 profile!("patina.rules.check_directive", {
-                    for rule in self.rules.iter() {
-                        self.ctx.current_rule = rule.meta().name;
+                    for (rule, rule_name) in self.rules.iter().zip(self.rule_names.iter().copied())
+                    {
+                        self.ctx.current_rule = rule_name;
                         rule.check_directive(self.ctx, el, dir);
                     }
                 });
@@ -220,8 +228,8 @@ impl<'a, 'ctx, 'rules> LintVisitor<'a, 'ctx, 'rules> {
 
         // Exit element - run rules
         profile!("patina.rules.exit_element", {
-            for rule in self.rules.iter() {
-                self.ctx.current_rule = rule.meta().name;
+            for (rule, rule_name) in self.rules.iter().zip(self.rule_names.iter().copied()) {
+                self.ctx.current_rule = rule_name;
                 rule.exit_element(self.ctx, el);
             }
         });
@@ -233,8 +241,8 @@ impl<'a, 'ctx, 'rules> LintVisitor<'a, 'ctx, 'rules> {
     fn visit_if(&mut self, if_node: &vize_relief::ast::IfNode<'a>) {
         // Run if checks
         profile!("patina.rules.check_if", {
-            for rule in self.rules.iter() {
-                self.ctx.current_rule = rule.meta().name;
+            for (rule, rule_name) in self.rules.iter().zip(self.rule_names.iter().copied()) {
+                self.ctx.current_rule = rule_name;
                 rule.check_if(self.ctx, if_node);
             }
         });
@@ -251,8 +259,8 @@ impl<'a, 'ctx, 'rules> LintVisitor<'a, 'ctx, 'rules> {
     fn visit_for(&mut self, for_node: &vize_relief::ast::ForNode<'a>) {
         // Run for checks
         profile!("patina.rules.check_for", {
-            for rule in self.rules.iter() {
-                self.ctx.current_rule = rule.meta().name;
+            for (rule, rule_name) in self.rules.iter().zip(self.rule_names.iter().copied()) {
+                self.ctx.current_rule = rule_name;
                 rule.check_for(self.ctx, for_node);
             }
         });


### PR DESCRIPTION
## Summary

- Parse the SFC descriptor once per linted SFC when lint paths need descriptor-backed work.
- Reuse that descriptor for SFC-level rules, script/semantic descriptor rules, and the native type-aware lint path.
- Cache registered rule names beside rule objects so hot visitor loops avoid repeated metadata lookups.

## Profiling

Profile mode command: `./target/ci/vize lint 'bench/__in__/*.vue' --quiet --profile --slow-threshold 10` over 2,000 generated SFC fixtures.

- Cumulative `lint total`: `2128.726ms` -> `2080.411ms` (~2.3% less worker time).
- Internal span calls: `497,590` -> `495,590`.
- Allocation calls: `608,025` -> `601,101`.
- Duplicate SFC parse rows collapsed from separate `patina.sfc.level_rules.parse_sfc` + `patina.type_aware.parse_sfc` spans into one shared `patina.sfc.shared_parse_sfc` span.

Wall time varied with file-system cache noise, so the profile evidence above focuses on cumulative worker time and internal span counts.

## Checks

- `cargo fmt --check`
- `cargo check -p vize_patina`
- `cargo test -p vize_patina`
- `cargo build --profile ci -p vize`
- `./target/ci/vize lint 'bench/__in__/*.vue' --quiet --profile --slow-threshold 10`