### PR TITLE
perf(glyph): reuse worker allocator

### DIFF
--- a/crates/vize/src/commands/fmt.rs
+++ b/crates/vize/src/commands/fmt.rs
@@ -117,43 +117,46 @@ pub fn run(args: FmtArgs) {
         profiler.enable();
     }
 
-    // Process files in parallel, each thread gets its own allocator for maximum performance
+    // Process files in parallel, reusing one arena per Rayon worker.
     let process_start = Instant::now();
-    files.par_iter().for_each(|path| {
-        // Create per-thread allocator with estimated capacity
-        let allocator = Allocator::with_capacity(64 * 1024); // 64KB initial capacity
+    files.par_iter().for_each_init(
+        || Allocator::with_capacity(64 * 1024),
+        |allocator, path| {
+            allocator.reset();
 
-        match process_file(
-            path,
-            &options,
-            &allocator,
-            args.check,
-            args.write,
-            args.profile,
-        ) {
-            Ok(result) => {
-                if result.changed {
-                    files_changed.fetch_add(1, Ordering::Relaxed);
-                    if args.check {
-                        has_errors.store(true, Ordering::Relaxed);
+            match process_file(
+                path,
+                &options,
+                allocator,
+                args.check,
+                args.write,
+                args.profile,
+            ) {
+                Ok(result) => {
+                    if result.changed {
+                        files_changed.fetch_add(1, Ordering::Relaxed);
+                        if args.check {
+                            has_errors.store(true, Ordering::Relaxed);
+                        }
+                    } else {
+                        files_unchanged.fetch_add(1, Ordering::Relaxed);
                     }
-                } else {
-                    files_unchanged.fetch_add(1, Ordering::Relaxed);
-                }
 
-                if let (Some(profile), Some(profile_rows)) = (result.profile, profile_rows.as_ref())
-                    && let Ok(mut rows) = profile_rows.lock()
-                {
-                    rows.push(profile);
+                    if let (Some(profile), Some(profile_rows)) =
+                        (result.profile, profile_rows.as_ref())
+                        && let Ok(mut rows) = profile_rows.lock()
+                    {
+                        rows.push(profile);
+                    }
+                }
+                Err(err) => {
+                    eprintln!("Error formatting {}: {}", path.display(), err);
+                    files_errored.fetch_add(1, Ordering::Relaxed);
+                    has_errors.store(true, Ordering::Relaxed);
                 }
             }
-            Err(err) => {
-                eprintln!("Error formatting {}: {}", path.display(), err);
-                files_errored.fetch_add(1, Ordering::Relaxed);
-                has_errors.store(true, Ordering::Relaxed);
-            }
-        }
-    });
+        },
+    );
     let process_time = process_start.elapsed();
 
     // Print summary


### PR DESCRIPTION
## Summary
- Reuse one formatter arena per Rayon worker with `for_each_init` instead of allocating a fresh arena for every file.
- Reset the worker-local arena before each file so the formatter keeps per-file isolation while lowering allocator churn.

## Profiling
Ran `./target/ci/vize fmt 'bench/__in__/*.vue' --profile --slow-threshold 5` over 2000 generated SFCs. Timing is noisy, but allocation pressure dropped from about 1,180.41 MiB / 1,085,299 calls to about 1,117.87 MiB / 1,084,355 calls.\n\n## Checks\n- `cargo fmt --check`\n- `cargo check -p vize`\n- `cargo build --profile ci -p vize`\n- `cargo test -p vize`