### PR TITLE
perf(build): skip repeated output dir creation

### DIFF
--- a/crates/vize/src/commands/build/runner.rs
+++ b/crates/vize/src/commands/build/runner.rs
@@ -166,23 +166,6 @@ pub(crate) fn run(args: BuildArgs) {
                     .unwrap_or_else(|| PathBuf::from("output").with_extension(ext));
                 let out_path = args.output.join(filename);
 
-                if let Some(parent) = out_path.parent() {
-                    match profile!(
-                        "cli.build.output.create_dir_all",
-                        fs::create_dir_all(parent)
-                    ) {
-                        Ok(()) => global_profiler().record_fs_create_dir_all(),
-                        Err(error) => {
-                            global_profiler().record_fs_create_dir_all_failure();
-                            eprintln!(
-                                "Failed to create output subdirectory {}: {error}",
-                                parent.display()
-                            );
-                            continue;
-                        }
-                    }
-                }
-
                 let content: String = match args.format {
                     OutputFormat::Js => output.code,
                     OutputFormat::Json =>


### PR DESCRIPTION
## Summary
- Stop calling `create_dir_all` for every compiled output file.
- Keep the existing single output-root creation before the write loop.

## Profiling
Ran `./target/ci/vize build --format js --output /tmp/vize-build-{before,after} --profile --slow-threshold 5 /tmp/vize-build-fixtures` over 2000 generated SFCs.

Before: `cli.build.output.create_dir_all` ran 2001 times, 7.446ms total; syscall call-sites were 6001; write outputs wall was 103.137ms.

After: `cli.build.output.create_dir_all` runs once, 0.093ms total; syscall call-sites are 4001; write outputs wall was 99.395ms. Total wall varied with compile noise.

## Checks
- `cargo fmt --check`
- `cargo check -p vize`
- `cargo build --profile ci -p vize`
- `cargo test -p vize`