### PR TITLE
perf(sfc): skip unnecessary v-model demotion scans

### DIFF
--- a/crates/vize_atelier_sfc/src/compile/helpers.rs
+++ b/crates/vize_atelier_sfc/src/compile/helpers.rs
@@ -42,11 +42,32 @@ pub(super) fn demote_v_model_reactive_const_bindings(
     script_bindings: &mut BindingMetadata,
     croquis: &mut vize_croquis::analysis::Croquis,
 ) -> Vec<String> {
+    if !template_content.contains("v-model") {
+        return Vec::new();
+    }
+
+    if !script_bindings
+        .bindings
+        .values()
+        .any(|binding_type| matches!(binding_type, BindingType::SetupReactiveConst))
+    {
+        return Vec::new();
+    }
+
     let template_allocator = TemplateAllocator::default();
     let (root, _) = vize_atelier_core::parse(&template_allocator, template_content);
     let v_model_ids = resolve_template_v_model_identifiers(&root);
 
     if v_model_ids.is_empty() {
+        return Vec::new();
+    }
+
+    if !v_model_ids.iter().any(|binding_name| {
+        matches!(
+            script_bindings.bindings.get(binding_name.as_str()),
+            Some(BindingType::SetupReactiveConst)
+        )
+    }) {
         return Vec::new();
     }
 


### PR DESCRIPTION
## Summary
- skip the v-model demotion parser path when the template has no v-model directive
- skip the same pass when script binding metadata has no reactive const candidate
- avoid reparsing script content when parsed v-model targets cannot be demoted

## Profile
2000 generated SFCs with `vize build --profile --slow-threshold 5`:
- total wall: 373.918ms -> 336.520ms
- compile wall: 257.895ms -> 226.410ms
- `atelier.sfc.script_setup.demote_v_model_reactive_consts`: 296.755ms -> 4.652ms
- alloc pressure: 1948.88 MiB -> 1846.89 MiB

## Checks
- `cargo fmt --check`
- `cargo build --profile ci -p vize`
- `cargo test -p vize_atelier_sfc`
- `cargo clippy --workspace -- -D warnings`
- `cargo test --workspace`