### PR TITLE
fix(tsgo): honor configured Corsa runtime paths

### DIFF
--- a/crates/vize/src/commands/check/runner.rs
+++ b/crates/vize/src/commands/check/runner.rs
@@ -77,6 +77,11 @@ pub(crate) fn run_direct(args: &CheckArgs) {
         .tsconfig
         .clone()
         .or_else(|| config.type_checker.tsconfig.as_ref().map(PathBuf::from));
+    let effective_corsa_path = args
+        .corsa_path
+        .as_ref()
+        .map(PathBuf::from)
+        .or_else(|| config.type_checker.tsgo_path.as_ref().map(PathBuf::from));
     let project_root = resolve_project_root(effective_tsconfig.as_deref(), &cwd, &[]);
     let tsconfig_path =
         resolve_tsconfig_path(effective_tsconfig.as_deref(), &cwd, &project_root, &[]);
@@ -112,12 +117,13 @@ pub(crate) fn run_direct(args: &CheckArgs) {
     }
 
     let gen_start = Instant::now();
-    let mut checker = match BatchTypeChecker::with_options(
+    let mut checker = match BatchTypeChecker::with_options_and_corsa_path(
         &project_root,
         BatchTypeCheckerOptions {
             tsconfig_path: tsconfig_path.clone(),
             virtual_ts_options,
         },
+        effective_corsa_path.as_deref(),
     ) {
         Ok(checker) => checker,
         Err(error) => {

--- a/crates/vize/tests/check_cli.rs
+++ b/crates/vize/tests/check_cli.rs
@@ -120,6 +120,88 @@ void props
 }
 
 #[test]
+fn check_respects_explicit_corsa_path() {
+    let project_root = create_cli_project(
+        "explicit-corsa-path",
+        &[(
+            "src/App.vue",
+            r#"<script setup lang="ts">
+const count = 1;
+</script>
+"#,
+        )],
+    );
+    let missing_corsa = project_root.join("__missing_corsa__");
+    let missing_corsa_arg = missing_corsa.to_string_lossy().into_owned();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(&project_root)
+        .args([
+            "check",
+            "src/App.vue",
+            "--quiet",
+            "--corsa-path",
+            missing_corsa_arg.as_str(),
+        ])
+        .output()
+        .unwrap();
+
+    let stderr = std::string::String::from_utf8(output.stderr).unwrap();
+    assert!(!output.status.success());
+    assert!(
+        stderr.contains("Configured Corsa executable does not exist"),
+        "{stderr}"
+    );
+    assert!(stderr.contains("__missing_corsa__"), "{stderr}");
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}
+
+#[test]
+fn check_respects_configured_tsgo_path() {
+    let project_root = create_cli_project(
+        "configured-tsgo-path",
+        &[(
+            "src/App.vue",
+            r#"<script setup lang="ts">
+const count = 1;
+</script>
+"#,
+        )],
+    );
+    let missing_corsa = project_root.join("__missing_configured_tsgo__");
+    std::fs::write(
+        project_root.join("vize.config.json"),
+        cstr!(
+            r#"{{
+  "typeChecker": {{
+    "tsgoPath": "{}"
+  }}
+}}"#,
+            missing_corsa.display()
+        )
+        .as_str(),
+    )
+    .unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(&project_root)
+        .args(["check", "src/App.vue", "--quiet"])
+        .output()
+        .unwrap();
+
+    let stderr = std::string::String::from_utf8(output.stderr).unwrap();
+    assert!(!output.status.success());
+    assert!(
+        stderr.contains("Configured Corsa executable does not exist"),
+        "{stderr}"
+    );
+    assert!(stderr.contains("__missing_configured_tsgo__"), "{stderr}");
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}
+
+#[test]
 fn check_json_reports_broken_sfc_parse_errors_without_secondary_noise() {
     let Some(corsa_path) = resolve_test_corsa_path() else {
         return;

--- a/crates/vize_canon/src/batch/error.rs
+++ b/crates/vize_canon/src/batch/error.rs
@@ -61,13 +61,26 @@ pub enum PackageManager {
 #[derive(Debug)]
 pub struct CorsaNotFoundError {
     detected_pm: Option<PackageManager>,
+    explicit_path: Option<PathBuf>,
 }
 
 impl CorsaNotFoundError {
     /// Create a new CorsaNotFoundError.
     pub fn new(project_root: &Path) -> Self {
         let detected_pm = detect_package_manager(project_root);
-        Self { detected_pm }
+        Self {
+            detected_pm,
+            explicit_path: None,
+        }
+    }
+
+    /// Create a new CorsaNotFoundError for an explicit but missing path.
+    pub fn new_explicit(project_root: &Path, path: &Path) -> Self {
+        let detected_pm = detect_package_manager(project_root);
+        Self {
+            detected_pm,
+            explicit_path: Some(path.to_path_buf()),
+        }
     }
 
     /// Get the detected package manager.
@@ -80,7 +93,15 @@ impl CorsaNotFoundError {
         let mut msg = String::default();
 
         msg.push_str("error: corsa not found\n\n");
-        msg.push_str("vize check requires '@typescript/native-preview' to be installed.\n\n");
+        if let Some(path) = &self.explicit_path {
+            append!(
+                msg,
+                "Configured Corsa executable does not exist: {}\n\n",
+                path.display()
+            );
+        } else {
+            msg.push_str("vize check requires '@typescript/native-preview' to be installed.\n\n");
+        }
 
         if let Some(pm) = self.detected_pm {
             msg.push_str("To install, run:\n\n");
@@ -177,6 +198,7 @@ mod tests {
     fn test_corsa_not_found_error_message() {
         let error = CorsaNotFoundError {
             detected_pm: Some(PackageManager::Pnpm),
+            explicit_path: None,
         };
 
         let msg = error.display_message();
@@ -185,7 +207,10 @@ mod tests {
 
     #[test]
     fn test_corsa_not_found_no_pm() {
-        let error = CorsaNotFoundError { detected_pm: None };
+        let error = CorsaNotFoundError {
+            detected_pm: None,
+            explicit_path: None,
+        };
 
         let msg = error.display_message();
         insta::assert_snapshot!(msg.as_str());

--- a/crates/vize_canon/src/batch/executor.rs
+++ b/crates/vize_canon/src/batch/executor.rs
@@ -36,6 +36,32 @@ pub struct CorsaExecutor {
 impl CorsaExecutor {
     /// Create a new executor by finding a local or global Corsa executable.
     pub fn new(project_root: &Path) -> Result<Self, CorsaNotFoundError> {
+        Self::with_corsa_path(project_root, None)
+    }
+
+    /// Create a new executor with an optional explicit Corsa executable path.
+    pub fn with_corsa_path(
+        project_root: &Path,
+        corsa_path: Option<&Path>,
+    ) -> Result<Self, CorsaNotFoundError> {
+        if let Some(path) = corsa_path {
+            if !path.exists() {
+                return Err(CorsaNotFoundError::new_explicit(project_root, path));
+            }
+            let corsa_path = normalize_corsa_path(path.to_path_buf()).unwrap_or(path.to_path_buf());
+            return Ok(Self { corsa_path });
+        }
+
+        for env_name in ["CORSA_PATH", "TSGO_PATH"] {
+            if let Some(path) = std::env::var_os(env_name).map(PathBuf::from) {
+                if !path.exists() {
+                    return Err(CorsaNotFoundError::new_explicit(project_root, &path));
+                }
+                let corsa_path = normalize_corsa_path(path.clone()).unwrap_or(path);
+                return Ok(Self { corsa_path });
+            }
+        }
+
         let search_roots = corsa_search_roots(Some(project_root));
         if let Some(local_corsa) = find_corsa_in_search_roots(&search_roots)
             && let Some(corsa_path) = normalize_corsa_path(PathBuf::from(local_corsa.as_str()))
@@ -191,6 +217,7 @@ fn normalize_corsa_path(path: PathBuf) -> Option<PathBuf> {
     find_corsa_in_search_roots(&corsa_search_roots(Some(project_root)))
         .map(|resolved| PathBuf::from(resolved.as_str()))
         .filter(|resolved| resolved != &path)
+        .or(Some(path))
 }
 
 fn collect_virtual_file_uris(virtual_root: &Path) -> CorsaResult<Vec<String>> {

--- a/crates/vize_canon/src/batch/type_checker.rs
+++ b/crates/vize_canon/src/batch/type_checker.rs
@@ -120,11 +120,20 @@ impl BatchTypeChecker {
         project_root: &Path,
         options: BatchTypeCheckerOptions,
     ) -> CorsaResult<Self> {
+        Self::with_options_and_corsa_path(project_root, options, None)
+    }
+
+    /// Create a new batch type checker with options and an optional Corsa path.
+    pub fn with_options_and_corsa_path(
+        project_root: &Path,
+        options: BatchTypeCheckerOptions,
+        corsa_path: Option<&Path>,
+    ) -> CorsaResult<Self> {
         let project = VirtualProject::new(project_root)?;
         let mut project = project;
         project.set_tsconfig_path(options.tsconfig_path);
         project.set_virtual_ts_options(options.virtual_ts_options);
-        let executor = CorsaExecutor::new(project_root)?;
+        let executor = CorsaExecutor::with_corsa_path(project_root, corsa_path)?;
 
         Ok(Self {
             project,

--- a/crates/vize_maestro/src/server/state.rs
+++ b/crates/vize_maestro/src/server/state.rs
@@ -19,7 +19,10 @@ use vize_carton::config::FormatterConfig;
 use std::sync::OnceLock;
 
 #[cfg(feature = "native")]
-use vize_canon::{BatchTypeChecker, BatchTypeCheckerTrait, CorsaBridge, CorsaBridgeConfig};
+use vize_canon::{
+    BatchTypeChecker, BatchTypeCheckerOptions, BatchTypeCheckerTrait, CorsaBridge,
+    CorsaBridgeConfig,
+};
 
 use crate::document::DocumentStore;
 use crate::virtual_code::{VirtualCodeGenerator, VirtualDocuments};
@@ -437,7 +440,18 @@ impl ServerState {
         }
 
         // Try to initialize
-        match BatchTypeChecker::new(&workspace_root) {
+        let config = self.get_type_checker_config();
+        let corsa_path = config.tsgo_path.as_ref().map(PathBuf::from);
+        let options = BatchTypeCheckerOptions {
+            tsconfig_path: config.tsconfig.as_ref().map(PathBuf::from),
+            ..Default::default()
+        };
+
+        match BatchTypeChecker::with_options_and_corsa_path(
+            &workspace_root,
+            options,
+            corsa_path.as_deref(),
+        ) {
             Ok(checker) => {
                 let arc = Arc::new(RwLock::new(checker));
                 // get_or_init to handle race condition
@@ -521,11 +535,13 @@ impl ServerState {
 
         // Get workspace root for Corsa configuration.
         let workspace_root = self.get_workspace_root();
+        let type_checker_config = self.get_type_checker_config();
 
         let result = self
             .corsa_bridge
             .get_or_try_init(|| async {
                 let config = CorsaBridgeConfig {
+                    corsa_path: type_checker_config.tsgo_path.as_ref().map(PathBuf::from),
                     working_dir: workspace_root,
                     timeout_ms: 30000, // Corsa needs time to build project state on first load.
                     ..Default::default()
@@ -892,7 +908,9 @@ mod tests {
                 "typeChecker": {
                     "strict": true,
                     "checkProps": false,
-                    "checkEmits": false
+                    "checkEmits": false,
+                    "tsconfig": "tsconfig.app.json",
+                    "tsgoPath": "./node_modules/.bin/tsgo"
                 }
             }"#,
         )
@@ -904,6 +922,11 @@ mod tests {
         assert!(config.strict);
         assert!(!config.check_props);
         assert!(!config.check_emits);
+        assert_eq!(config.tsconfig.as_deref(), Some("tsconfig.app.json"));
+        assert_eq!(
+            config.tsgo_path.as_deref(),
+            Some("./node_modules/.bin/tsgo")
+        );
     }
 
     #[test]

--- a/crates/vize_patina/src/linter/corsa_session/paths.rs
+++ b/crates/vize_patina/src/linter/corsa_session/paths.rs
@@ -2,7 +2,7 @@ use std::{
     path::{Path, PathBuf},
     sync::atomic::{AtomicU64, Ordering},
 };
-use vize_carton::{String, ToCompactString};
+use vize_carton::{String, ToCompactString, cstr};
 
 const SESSION_DIR: &str = "vize-patina";
 const EXECUTABLE_ENV_VARS: [&str; 2] = ["CORSA_EXECUTABLE", "CORSA_PATH"];
@@ -177,6 +177,10 @@ fn corsa_executable_candidates(root: &Path) -> [PathBuf; 12] {
 }
 
 fn resolve_node_modules_executable(root: &Path) -> Option<PathBuf> {
+    if let Some(path) = resolve_native_preview_executable(root) {
+        return Some(path);
+    }
+
     for executable in EXECUTABLE_NAMES {
         let direct = root.join("node_modules").join(".bin").join(executable);
         if direct.exists() {
@@ -193,6 +197,57 @@ fn resolve_node_modules_executable(root: &Path) -> Option<PathBuf> {
             .join(executable);
         if native_preview.exists() {
             return Some(native_preview);
+        }
+    }
+
+    None
+}
+
+fn resolve_native_preview_executable(root: &Path) -> Option<PathBuf> {
+    let platform_suffix = platform_suffix();
+    if platform_suffix.is_empty() {
+        return None;
+    }
+
+    let pnpm_root = root.join("node_modules/.pnpm");
+    if pnpm_root.exists()
+        && let Ok(entries) = std::fs::read_dir(&pnpm_root)
+    {
+        for entry in entries.flatten() {
+            let name = entry.file_name();
+            let name = name.to_string_lossy();
+            if !name.starts_with("@typescript+native-preview-") || !name.contains(platform_suffix) {
+                continue;
+            }
+
+            for executable in EXECUTABLE_NAMES {
+                let candidate = entry.path().join(&*cstr!(
+                    "node_modules/@typescript/native-preview-{}/lib/{}",
+                    platform_suffix,
+                    executable
+                ));
+                if candidate.exists() {
+                    return Some(candidate);
+                }
+            }
+        }
+    }
+
+    for executable in EXECUTABLE_NAMES {
+        let native_candidates = [
+            root.join(&*cstr!(
+                "node_modules/@typescript/native-preview-{}/lib/{}",
+                platform_suffix,
+                executable
+            )),
+            root.join(&*cstr!(
+                "node_modules/@typescript/native-preview/lib/{executable}"
+            )),
+        ];
+        for candidate in native_candidates {
+            if candidate.exists() {
+                return Some(candidate);
+            }
         }
     }
 
@@ -229,7 +284,88 @@ fn resolve_path_executable() -> Option<PathBuf> {
     None
 }
 
+pub(super) fn platform_suffix() -> &'static str {
+    if cfg!(target_os = "macos") {
+        if cfg!(target_arch = "aarch64") {
+            "darwin-arm64"
+        } else {
+            "darwin-x64"
+        }
+    } else if cfg!(target_os = "linux") {
+        if cfg!(target_arch = "aarch64") {
+            "linux-arm64"
+        } else {
+            "linux-x64"
+        }
+    } else if cfg!(target_os = "windows") {
+        "win32-x64"
+    } else {
+        ""
+    }
+}
+
 fn push_u64(buffer: &mut String, value: u64) {
     let rendered = value.to_compact_string();
     buffer.push_str(rendered.as_str());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::resolve_corsa_executable;
+    use std::{
+        path::{Path, PathBuf},
+        sync::atomic::{AtomicU64, Ordering},
+    };
+    use vize_carton::cstr;
+
+    static NEXT_CASE_ID: AtomicU64 = AtomicU64::new(0);
+
+    fn case_dir(name: &str) -> PathBuf {
+        let id = NEXT_CASE_ID.fetch_add(1, Ordering::Relaxed);
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("__agent_only")
+            .join("tests")
+            .join(&*cstr!(
+                "patina-corsa-paths-{name}-{}-{id}",
+                std::process::id()
+            ))
+    }
+
+    #[test]
+    fn prefers_native_preview_binary_over_node_modules_bin_wrapper() {
+        let root = case_dir("native-over-wrapper");
+        let _ = std::fs::remove_dir_all(&root);
+        let wrapper = root.join("node_modules/.bin/tsgo");
+        let native = root
+            .join("node_modules")
+            .join("@typescript")
+            .join(&*cstr!("native-preview-{}", super::platform_suffix()))
+            .join("lib")
+            .join("tsgo");
+
+        write_file(&wrapper);
+        write_file(&native);
+
+        assert_eq!(resolve_corsa_executable(&root), native);
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn resolves_node_modules_bin_wrapper_when_native_binary_is_absent() {
+        let root = case_dir("wrapper-fallback");
+        let _ = std::fs::remove_dir_all(&root);
+        let wrapper = root.join("node_modules/.bin/tsgo");
+
+        write_file(&wrapper);
+
+        assert_eq!(resolve_corsa_executable(&root), wrapper);
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    fn write_file(path: &Path) {
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(path, "").unwrap();
+    }
 }

--- a/crates/vize_patina/src/linter/corsa_session/session.rs
+++ b/crates/vize_patina/src/linter/corsa_session/session.rs
@@ -56,11 +56,12 @@ impl CorsaTypeAwareSession {
         let config_path_wire = path_to_wire(&config_path);
         let virtual_file_wire = path_to_wire(&virtual_file_path);
         let executable = resolve_corsa_executable(&project_root);
+        let api_mode = api_mode_for_executable(&executable);
         let session = profile!(
             "patina.corsa_session.spawn",
             block_on(ProjectSession::spawn(
                 ApiSpawnConfig::new(executable)
-                    .with_mode(ApiMode::SyncMsgpackStdio)
+                    .with_mode(api_mode)
                     .with_cwd(&session_root),
                 config_path_wire.as_str(),
                 Some(virtual_file_wire.as_str().into()),
@@ -163,5 +164,66 @@ impl CorsaTypeAwareSession {
         self.closed = true;
         let _ = block_on(self.session.close());
         let _ = std::fs::remove_dir_all(&self.session_root);
+    }
+}
+
+fn api_mode_for_executable(path: &std::path::Path) -> ApiMode {
+    if path.extension().and_then(|extension| extension.to_str()) == Some("js") {
+        return ApiMode::AsyncJsonRpcStdio;
+    }
+
+    if path
+        .parent()
+        .and_then(|parent| parent.file_name())
+        .and_then(|name| name.to_str())
+        == Some(".bin")
+    {
+        return ApiMode::AsyncJsonRpcStdio;
+    }
+
+    let Some(parent) = path.parent() else {
+        return ApiMode::SyncMsgpackStdio;
+    };
+    let Some(grandparent) = parent.parent() else {
+        return ApiMode::SyncMsgpackStdio;
+    };
+
+    if parent.file_name().and_then(|name| name.to_str()) == Some("bin")
+        && grandparent.file_name().and_then(|name| name.to_str()) == Some("native-preview")
+    {
+        ApiMode::AsyncJsonRpcStdio
+    } else {
+        ApiMode::SyncMsgpackStdio
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::api_mode_for_executable;
+    use corsa::api::ApiMode;
+    use std::path::Path;
+
+    #[test]
+    fn uses_json_rpc_for_node_wrappers() {
+        assert_eq!(
+            api_mode_for_executable(Path::new("/workspace/node_modules/.bin/tsgo")),
+            ApiMode::AsyncJsonRpcStdio
+        );
+        assert_eq!(
+            api_mode_for_executable(Path::new(
+                "/workspace/node_modules/@typescript/native-preview/bin/tsgo.js"
+            )),
+            ApiMode::AsyncJsonRpcStdio
+        );
+    }
+
+    #[test]
+    fn uses_msgpack_for_native_binaries() {
+        assert_eq!(
+            api_mode_for_executable(Path::new(
+                "/workspace/node_modules/@typescript/native-preview-darwin-arm64/lib/tsgo"
+            )),
+            ApiMode::SyncMsgpackStdio
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Wire explicit Corsa/tsgo runtime paths from `vize check --corsa-path` and `typeChecker.tsgoPath` into the batch checker.
- Use the same configured runtime for LSP batch type checking and the Corsa bridge.
- Prefer native `@typescript/native-preview-*` binaries for type-aware lint, with JSON-RPC fallback mode for JS/node wrapper entrypoints.

Closes #546
Refs #547
Refs #548
Refs #549
Refs #550

## Tests

- `cargo fmt --check`
- `cargo test -p vize_canon`
- `cargo test -p vize_patina`
- `cargo test -p vize_maestro`
- `cargo test -p vize --test check_cli`
