### PR TITLE
fix(check): preserve monorepo root resolution

### DIFF
--- a/crates/vize/src/commands/check/runner.rs
+++ b/crates/vize/src/commands/check/runner.rs
@@ -609,10 +609,8 @@ fn resolve_project_root(
             .unwrap_or_else(|| cwd.to_path_buf());
     }
 
-    for file in files {
-        if let Some(root) = find_nearest_tsconfig_dir(file) {
-            return root;
-        }
+    if let Some(root) = resolve_project_root_from_files(files) {
+        return root;
     }
 
     if let Some(root) = find_nearest_tsconfig_dir(cwd) {
@@ -637,6 +635,11 @@ fn resolve_tsconfig_path(
         return Some(tsconfig_path.canonicalize().unwrap_or(tsconfig_path));
     }
 
+    let candidate = project_root.join("tsconfig.json");
+    if candidate.exists() {
+        return Some(candidate);
+    }
+
     for file in files {
         let Some(root) = find_nearest_tsconfig_dir(file) else {
             continue;
@@ -647,8 +650,7 @@ fn resolve_tsconfig_path(
         }
     }
 
-    let candidate = project_root.join("tsconfig.json");
-    candidate.exists().then_some(candidate)
+    None
 }
 
 fn find_nearest_tsconfig_dir(path: &Path) -> Option<PathBuf> {
@@ -666,6 +668,29 @@ fn find_nearest_tsconfig_dir(path: &Path) -> Option<PathBuf> {
     }
 
     None
+}
+
+fn resolve_project_root_from_files(files: &[PathBuf]) -> Option<PathBuf> {
+    let common = common_file_parent(files)?;
+    find_nearest_tsconfig_dir(&common)
+}
+
+fn common_file_parent(files: &[PathBuf]) -> Option<PathBuf> {
+    let mut common = files
+        .first()
+        .and_then(|path| path.parent())
+        .map(Path::to_path_buf)?;
+
+    for file in &files[1..] {
+        let parent = file.parent().unwrap_or(file.as_path());
+        while !parent.starts_with(&common) {
+            if !common.pop() {
+                return None;
+            }
+        }
+    }
+
+    Some(common)
 }
 
 fn display_path(base: &Path, path: &Path) -> vize_carton::String {
@@ -704,7 +729,10 @@ fn parse_dts_globals(
 
 #[cfg(test)]
 mod tests {
-    use super::{resolve_declaration_dir, resolve_declaration_emit_options};
+    use super::{
+        find_nearest_tsconfig_dir, resolve_declaration_dir, resolve_declaration_emit_options,
+        resolve_project_root, resolve_tsconfig_path,
+    };
     use crate::commands::check::tsconfig_inputs::TsconfigDeclarationOptions;
     use std::{
         path::{Path, PathBuf},
@@ -722,6 +750,79 @@ mod tests {
                 "check-runner-{name}-{}-{case_id}",
                 std::process::id()
             ))
+    }
+
+    #[test]
+    fn resolves_monorepo_root_for_files_spanning_package_tsconfigs() {
+        let project_root = unique_case_dir("monorepo-root");
+        let _ = std::fs::remove_dir_all(&project_root);
+        let app_dir = project_root.join("packages/app");
+        let ui_dir = project_root.join("packages/ui");
+        std::fs::create_dir_all(app_dir.join("src")).unwrap();
+        std::fs::create_dir_all(ui_dir.join("src")).unwrap();
+        std::fs::write(project_root.join("tsconfig.json"), "{}").unwrap();
+        std::fs::write(app_dir.join("tsconfig.json"), "{}").unwrap();
+        std::fs::write(ui_dir.join("tsconfig.json"), "{}").unwrap();
+        let files = vec![app_dir.join("src/App.vue"), ui_dir.join("src/UiButton.vue")];
+        for file in &files {
+            std::fs::write(file, "<template />").unwrap();
+        }
+
+        let resolved_root = resolve_project_root(None, &project_root, &files);
+        let resolved_tsconfig = resolve_tsconfig_path(None, &project_root, &resolved_root, &files);
+
+        assert_eq!(resolved_root, project_root);
+        assert_eq!(resolved_tsconfig, Some(resolved_root.join("tsconfig.json")));
+
+        let _ = std::fs::remove_dir_all(&resolved_root);
+    }
+
+    #[test]
+    fn resolves_package_root_for_files_inside_one_package() {
+        let project_root = unique_case_dir("package-root");
+        let _ = std::fs::remove_dir_all(&project_root);
+        let app_dir = project_root.join("packages/app");
+        std::fs::create_dir_all(app_dir.join("src")).unwrap();
+        std::fs::write(project_root.join("tsconfig.json"), "{}").unwrap();
+        std::fs::write(app_dir.join("tsconfig.json"), "{}").unwrap();
+        let files = vec![app_dir.join("src/App.vue"), app_dir.join("src/main.ts")];
+        for file in &files {
+            std::fs::write(file, "").unwrap();
+        }
+
+        let resolved_root = resolve_project_root(None, &project_root, &files);
+        let resolved_tsconfig = resolve_tsconfig_path(None, &project_root, &resolved_root, &files);
+
+        assert_eq!(resolved_root, app_dir);
+        assert_eq!(resolved_tsconfig, Some(resolved_root.join("tsconfig.json")));
+
+        let _ = std::fs::remove_dir_all(&project_root);
+    }
+
+    #[test]
+    fn falls_back_to_cwd_resolution_when_files_have_no_tsconfig() {
+        let project_root = unique_case_dir("no-tsconfig");
+        let _ = std::fs::remove_dir_all(&project_root);
+        let src_dir = project_root.join("src");
+        std::fs::create_dir_all(&src_dir).unwrap();
+        let files = vec![src_dir.join("App.vue")];
+        std::fs::write(&files[0], "<template />").unwrap();
+
+        let resolved_root = resolve_project_root(None, &project_root, &files);
+        let resolved_tsconfig = resolve_tsconfig_path(None, &project_root, &resolved_root, &files);
+        let expected_root =
+            find_nearest_tsconfig_dir(&project_root).unwrap_or_else(|| project_root.clone());
+
+        assert_eq!(resolved_root, expected_root);
+        assert_eq!(
+            resolved_tsconfig,
+            resolved_root
+                .join("tsconfig.json")
+                .exists()
+                .then_some(resolved_root.join("tsconfig.json"))
+        );
+
+        let _ = std::fs::remove_dir_all(&project_root);
     }
 
     #[test]

--- a/crates/vize/tests/check_cli.rs
+++ b/crates/vize/tests/check_cli.rs
@@ -535,6 +535,154 @@ defineProps<PublicProps>()
     let _ = std::fs::remove_dir_all(&project_root);
 }
 
+#[test]
+fn check_json_handles_monorepo_tsconfig_extends_paths_and_excludes() {
+    let Some(corsa_path) = resolve_test_corsa_path() else {
+        return;
+    };
+    let project_root = create_cli_project(
+        "monorepo-tsconfig",
+        &[
+            (
+                "tsconfig.base.json",
+                r#"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "baseUrl": ".",
+    "paths": {
+      "@shared/*": ["packages/shared/src/*"]
+    },
+    "noEmit": true
+  }
+}"#,
+            ),
+            (
+                "tsconfig.json",
+                r#"{
+  "extends": "./tsconfig.base.json",
+  "include": [
+    "packages/*/src/**/*.ts",
+    "packages/*/src/**/*.vue"
+  ],
+  "exclude": [
+    "packages/*/src/generated/**"
+  ]
+}"#,
+            ),
+            (
+                "packages/app/tsconfig.json",
+                r#"{
+  "extends": "../../tsconfig.base.json",
+  "include": ["src/**/*.ts", "src/**/*.vue"]
+}"#,
+            ),
+            (
+                "packages/ui/tsconfig.json",
+                r#"{
+  "extends": "../../tsconfig.base.json",
+  "include": ["src/**/*.ts", "src/**/*.vue"]
+}"#,
+            ),
+            (
+                "packages/shared/tsconfig.json",
+                r#"{
+  "extends": "../../tsconfig.base.json",
+  "include": ["src/**/*.ts"]
+}"#,
+            ),
+            (
+                "packages/shared/src/contracts.ts",
+                r#"export type Label = string
+"#,
+            ),
+            (
+                "packages/ui/src/UiButton.vue",
+                r#"<script setup lang="ts">
+import type { Label } from '@shared/contracts'
+
+defineProps<{
+  label: Label
+  count: number
+}>()
+</script>
+
+<template>
+  <button>{{ label }} {{ count }}</button>
+</template>
+"#,
+            ),
+            (
+                "packages/app/src/App.vue",
+                r#"<script setup lang="ts">
+import UiButton from '../../ui/src/UiButton.vue'
+import type { Label } from '@shared/contracts'
+
+const label: Label = 'Save'
+const count = 'not a number'
+</script>
+
+<template>
+  <UiButton :label="label" :count="count" />
+</template>
+"#,
+            ),
+            (
+                "packages/app/src/generated/Bad.vue",
+                r#"<script setup lang="ts">
+const shouldNotBeChecked: string = 0
+</script>
+"#,
+            ),
+        ],
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(&project_root)
+        .env("CORSA_PATH", corsa_path)
+        .args(["check", "--format", "json"])
+        .output()
+        .unwrap();
+
+    let stdout = std::string::String::from_utf8(output.stdout).unwrap();
+    let stderr = std::string::String::from_utf8(output.stderr).unwrap();
+    let json: serde_json::Value = serde_json::from_str(&stdout).unwrap_or_else(|error| {
+        panic!("failed to parse stdout as JSON: {error}\nstdout:\n{stdout}\nstderr:\n{stderr}")
+    });
+    let diagnostics = json["files"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .flat_map(|file| file["diagnostics"].as_array().unwrap().iter())
+        .filter_map(|diagnostic| diagnostic.as_str())
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "stdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert_eq!(json["fileCount"], 3);
+    assert!(
+        diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.contains("[TS2322]") && diagnostic.contains("number")),
+        "expected imported monorepo component prop type error, got: {diagnostics:#?}"
+    );
+    assert!(
+        diagnostics.iter().all(|diagnostic| {
+            !diagnostic.contains("Cannot find module")
+                && !diagnostic.contains("shouldNotBeChecked")
+                && !diagnostic.contains("generated/Bad.vue")
+        }),
+        "monorepo tsconfig paths/excludes should be respected: {diagnostics:#?}"
+    );
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}
+
 fn collect_declaration_snapshot(
     declaration_dir: &Path,
 ) -> Vec<(std::string::String, std::string::String)> {


### PR DESCRIPTION
## Summary
- Preserve the shared monorepo root when collected check inputs span package-local tsconfigs.
- Prefer the resolved project root tsconfig before falling back to a per-file package tsconfig.
- Add a complex CLI fixture covering root tsconfig extends, package tsconfigs, path aliases, excludes, and a cross-package Vue prop type error.

## Root Cause
`vize check` collected files from the root tsconfig, then recomputed `project_root` from the first file nearest tsconfig. In monorepos that could move the root into `packages/app`, making sibling package files fail path prefix handling and tsconfig alias resolution.

## Validation
- `cargo fmt --check`
- `cargo test -p vize --test check_cli check_json_handles_monorepo_tsconfig_extends_paths_and_excludes -- --nocapture`
- `cargo test -p vize resolves_ -- --nocapture`
- `cargo test -p vize falls_back_to_cwd_resolution_when_files_have_no_tsconfig -- --nocapture`
- `cargo test -p vize --test check_cli`
- `cargo test -p vize`
- `cargo clippy --workspace -- -D warnings`
- `cargo test --workspace`
