### PR TITLE
perf: trim lint and compile hot paths

### DIFF
--- a/crates/vize/src/commands/lint.rs
+++ b/crates/vize/src/commands/lint.rs
@@ -457,8 +457,7 @@ fn add_lint_file(path: &Path, files: &mut Vec<PathBuf>, seen: &mut FxHashSet<Pat
         return;
     }
     let normalized = normalize_lint_input_path(path);
-    let canonical = path.canonicalize().unwrap_or_else(|_| normalized.clone());
-    if seen.insert(canonical) {
+    if seen.insert(normalized.clone()) {
         files.push(normalized);
     }
 }

--- a/crates/vize_atelier_core/src/transform.rs
+++ b/crates/vize_atelier_core/src/transform.rs
@@ -7,7 +7,7 @@ pub mod element;
 pub mod structural;
 pub mod traverse;
 
-use vize_carton::{Box, Bump, FxHashSet, String, Vec, profile};
+use vize_carton::{Box, Bump, FxHashSet, SmallVec, String, Vec, profile};
 use vize_croquis::{Croquis, ScopeChain};
 
 use crate::ast::*;
@@ -18,10 +18,11 @@ use traverse::traverse_children;
 
 /// Transform function for nodes - returns optional exit function(s)
 pub type NodeTransform<'a> =
-    fn(&mut TransformContext<'a>, &mut TemplateChildNode<'a>) -> Option<std::vec::Vec<ExitFn<'a>>>;
+    fn(&mut TransformContext<'a>, &mut TemplateChildNode<'a>) -> Option<ExitFns<'a>>;
 
 /// Exit function called after children are processed
 pub type ExitFn<'a> = std::boxed::Box<dyn FnOnce(&mut TransformContext<'a>) + 'a>;
+pub type ExitFns<'a> = SmallVec<[ExitFn<'a>; 2]>;
 
 /// Transform function for directives
 pub type DirectiveTransform<'a> = fn(

--- a/crates/vize_atelier_core/src/transform/element.rs
+++ b/crates/vize_atelier_core/src/transform/element.rs
@@ -5,7 +5,7 @@ use vize_carton::{Box, String, Vec, capitalize, is_builtin_directive, is_native_
 use crate::ast::*;
 use crate::transforms::transform_expression::process_inline_handler;
 
-use super::{ExitFn, TransformContext};
+use super::{ExitFns, TransformContext};
 
 fn is_dynamic_component(el: &ElementNode<'_>) -> bool {
     el.tag == "component" || (el.tag == "Component" && has_is_attribute(el))
@@ -15,7 +15,7 @@ fn is_dynamic_component(el: &ElementNode<'_>) -> bool {
 pub fn transform_element<'a>(
     ctx: &mut TransformContext<'a>,
     el: &mut Box<'a, ElementNode<'a>>,
-) -> Option<std::vec::Vec<ExitFn<'a>>> {
+) -> Option<ExitFns<'a>> {
     maybe_promote_element_to_component(ctx, el);
 
     // Process props and directives
@@ -43,9 +43,11 @@ pub fn transform_element<'a>(
             }
             // Defer add_component to exit phase so inner components resolve before outer ones
             let tag = el.tag.clone();
-            return Some(vec![std::boxed::Box::new(move |ctx| {
+            let mut exits = ExitFns::new();
+            exits.push(std::boxed::Box::new(move |ctx| {
                 ctx.add_component(tag);
-            })]);
+            }));
+            return Some(exits);
         }
         ElementType::Slot => {
             ctx.helper(RuntimeHelper::RenderSlot);

--- a/crates/vize_atelier_core/src/transform/structural.rs
+++ b/crates/vize_atelier_core/src/transform/structural.rs
@@ -7,7 +7,7 @@ use crate::errors::ErrorCode;
 
 use super::context::clone_expression;
 use super::traverse::traverse_children;
-use super::{ExitFn, ParentNode, TransformContext};
+use super::{ExitFns, ParentNode, TransformContext};
 
 /// Simple expression content for passing between functions
 pub struct SimpleExpressionContent {
@@ -125,7 +125,7 @@ pub fn transform_v_if<'a>(
     ctx: &mut TransformContext<'a>,
     exp: Option<&SimpleExpressionContent>,
     is_root: bool,
-) -> Option<std::vec::Vec<ExitFn<'a>>> {
+) -> Option<ExitFns<'a>> {
     let allocator = ctx.allocator;
 
     if is_root {
@@ -391,7 +391,7 @@ pub fn transform_v_if<'a>(
 pub fn transform_v_for<'a>(
     ctx: &mut TransformContext<'a>,
     exp: Option<&SimpleExpressionContent>,
-) -> Option<std::vec::Vec<ExitFn<'a>>> {
+) -> Option<ExitFns<'a>> {
     let allocator = ctx.allocator;
 
     let Some(exp) = exp else {

--- a/crates/vize_atelier_core/src/transform/traverse.rs
+++ b/crates/vize_atelier_core/src/transform/traverse.rs
@@ -8,7 +8,7 @@ use super::element::{transform_element, transform_interpolation};
 use super::structural::{
     StructuralDirectiveKind, take_structural_directive, transform_v_for, transform_v_if,
 };
-use super::{ExitFn, ParentNode, TransformContext};
+use super::{ExitFns, ParentNode, TransformContext};
 
 fn enter_v_slot_scope_if_needed<'a>(ctx: &mut TransformContext<'a>, el: &ElementNode<'a>) -> bool {
     if el.children.is_empty()
@@ -70,7 +70,7 @@ pub fn traverse_node<'a>(ctx: &mut TransformContext<'a>, node: &mut TemplateChil
     ctx.current_node = Some(node as *mut _);
 
     // Collect exit functions from transforms
-    let mut exit_fns: std::vec::Vec<ExitFn<'a>> = std::vec::Vec::new();
+    let mut exit_fns = ExitFns::new();
 
     // Apply node transforms based on node type
     match node {

--- a/crates/vize_patina/src/context.rs
+++ b/crates/vize_patina/src/context.rs
@@ -10,6 +10,7 @@ mod state;
 pub use state::{DisabledRange, ElementContext, SsrMode};
 
 use crate::diagnostic::{HelpLevel, LintDiagnostic, Severity};
+use memchr::memchr_iter;
 use std::borrow::Cow;
 use vize_atelier_sfc::SfcDescriptor;
 use vize_carton::String;
@@ -257,10 +258,8 @@ impl<'a> LintContext<'a> {
     /// Compute line offsets for fast line number lookup.
     fn compute_line_offsets(source: &str) -> Vec<u32> {
         let mut offsets = vec![0];
-        for (i, c) in source.char_indices() {
-            if c == '\n' {
-                offsets.push((i + 1) as u32);
-            }
+        for offset in memchr_iter(b'\n', source.as_bytes()) {
+            offsets.push((offset + 1) as u32);
         }
         offsets
     }


### PR DESCRIPTION
## Summary
- avoid per-file canonicalization during lint input collection and dedupe on normalized paths instead
- use inline `SmallVec` storage for transform exit callbacks to avoid tiny hot-path vector allocations
- scan line offsets with `memchr` instead of Unicode scalar iteration

## Profiling
Profile mode on `bench/__in__` after release build:
- `vize lint --profile --quiet --help-level none --preset happy-path bench/__in__`: wall `20.865ms -> 9.525ms`, collect files `7.662ms -> 1.510ms`, lint total `146.460ms -> 96.368ms`
- `vize build --profile --format stats bench/__in__`: wall `20.988ms -> 13.705ms`, compile total `221.786ms -> 157.280ms`, template compile `116.533ms -> 91.833ms`

Criterion:
- `vize_patina` lint bench: `template/lint_small` improved ~29%, `template/lint_large` improved ~12%, `script/has_vue_imports` improved ~14%, `musea/lint` improved ~14%
- `vize_atelier_sfc` compile bench completed: template_only ~4.68us, script_setup_medium ~98.5us, script_setup_complex ~123us, prop_heavy_list ~86.0us

## Checks
- `cargo fmt --all`
- `cargo check -p vize --features glyph,maestro`
- `cargo test -p vize_atelier_core -p vize_patina -p vize --features glyph,maestro`
- `cargo build -p vize --release --features glyph,maestro`
- `cargo bench -p vize_patina --bench lint_bench -- --warm-up-time 1 --measurement-time 3`
- `cargo bench -p vize_atelier_sfc --bench sfc_compile -- --warm-up-time 1 --measurement-time 3`