### PR TITLE
fix: resolve non-experimental issue backlog

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,9 +170,16 @@ export default defineConfig({
   typeChecker: {
     enabled: true,
     strict: true,
+    corsaPath: "./node_modules/.bin/tsgo",
   },
 });
 ```
+
+`typeChecker.corsaPath` pins the native runtime used by `vize check`, `vize lint` type-aware
+rules, and `vize lsp` type-aware/editor features. The runtime stack is the
+`@typescript/native-preview` package, reached through Vize's Corsa/corsa-bind API layer; the
+installed executable is still commonly named `tsgo`. `typeChecker.tsgoPath` remains a compatibility
+alias for older configs.
 
 Direct `vize()` options override shared config for Vite. See the docs for compiler options,
 project scanning, lint presets, type-checker settings, and Musea config.

--- a/crates/vize/src/commands/check/runner.rs
+++ b/crates/vize/src/commands/check/runner.rs
@@ -77,11 +77,16 @@ pub(crate) fn run_direct(args: &CheckArgs) {
         .tsconfig
         .clone()
         .or_else(|| config.type_checker.tsconfig.as_ref().map(PathBuf::from));
-    let effective_corsa_path = args
-        .corsa_path
-        .as_ref()
-        .map(PathBuf::from)
-        .or_else(|| config.type_checker.tsgo_path.as_ref().map(PathBuf::from));
+    let effective_corsa_path = args.corsa_path.as_ref().map(PathBuf::from).or_else(|| {
+        config
+            .type_checker
+            .runtime_path()
+            .map(|candidate| resolve_from_config_dir(config_dir, candidate))
+    });
+    if let Err(error) = validate_corsa_server_count(args.servers.or(config.type_checker.servers)) {
+        eprintln!("\x1b[31mError:\x1b[0m {}", error);
+        std::process::exit(2);
+    }
     let project_root = resolve_project_root(effective_tsconfig.as_deref(), &cwd, &[]);
     let tsconfig_path =
         resolve_tsconfig_path(effective_tsconfig.as_deref(), &cwd, &project_root, &[]);
@@ -714,6 +719,22 @@ fn resolve_from_config_dir(config_dir: &Path, candidate: &str) -> PathBuf {
     config_dir.join(path)
 }
 
+fn validate_corsa_server_count(servers: Option<usize>) -> Result<(), String> {
+    let Some(servers) = servers else {
+        return Ok(());
+    };
+    if servers == 0 {
+        return Err("typeChecker.servers must be at least 1.".into());
+    }
+    if servers > 1 {
+        return Err(format!(
+            "typeChecker.servers={servers} is not supported by the direct Corsa project-session runner yet; use 1 or omit the option."
+        )
+        .into());
+    }
+    Ok(())
+}
+
 /// Parse a `.d.ts` file containing `ComponentCustomProperties` augmentation.
 fn parse_dts_globals(
     path: &Path,
@@ -737,7 +758,7 @@ fn parse_dts_globals(
 mod tests {
     use super::{
         find_nearest_tsconfig_dir, resolve_declaration_dir, resolve_declaration_emit_options,
-        resolve_project_root, resolve_tsconfig_path,
+        resolve_project_root, resolve_tsconfig_path, validate_corsa_server_count,
     };
     use crate::commands::check::tsconfig_inputs::TsconfigDeclarationOptions;
     use std::{
@@ -900,5 +921,13 @@ mod tests {
         assert!(options.declaration_map);
 
         let _ = std::fs::remove_dir_all(&project_root);
+    }
+
+    #[test]
+    fn validates_unsupported_corsa_server_counts() {
+        assert!(validate_corsa_server_count(None).is_ok());
+        assert!(validate_corsa_server_count(Some(1)).is_ok());
+        assert!(validate_corsa_server_count(Some(0)).is_err());
+        assert!(validate_corsa_server_count(Some(2)).is_err());
     }
 }

--- a/crates/vize/src/commands/lint.rs
+++ b/crates/vize/src/commands/lint.rs
@@ -748,8 +748,7 @@ fn cross_file_diagnostic_offset(
     match diagnostic.kind {
         CrossFileDiagnosticKind::DuplicateElementId { .. }
         | CrossFileDiagnosticKind::NonUniqueIdInLoop { .. }
-        | CrossFileDiagnosticKind::BrowserApiInSsr { .. }
-        | CrossFileDiagnosticKind::HydrationMismatchRisk { .. } => offsets.template,
+        | CrossFileDiagnosticKind::BrowserApiInSsr { .. } => offsets.template,
         _ => offsets.script,
     }
 }

--- a/crates/vize/src/commands/lint.rs
+++ b/crates/vize/src/commands/lint.rs
@@ -104,6 +104,26 @@ pub fn run(args: LintArgs) {
         std::process::exit(2);
     });
     let render_details = should_render_lint_details(format, args.quiet);
+    crate::config::write_schema(None);
+    let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    let loaded_config = if args.no_config {
+        crate::config::LoadedConfig {
+            config: crate::config::VizeConfig::default(),
+            source_path: None,
+        }
+    } else {
+        crate::config::load_config_with_source(args.config.as_deref())
+    };
+    let config_dir = loaded_config
+        .source_path
+        .as_deref()
+        .and_then(Path::parent)
+        .unwrap_or(cwd.as_path());
+    let configured_corsa_path = loaded_config
+        .config
+        .type_checker
+        .runtime_path()
+        .map(|path| resolve_lint_config_path(config_dir, path));
 
     // Collect .vue files using glob patterns or directory walking
     let collect_start = Instant::now();
@@ -122,6 +142,10 @@ pub fn run(args: LintArgs) {
     };
     let preset = LintPreset::parse(&args.preset).unwrap_or_default();
     let mut linter = Linter::with_preset(preset).with_help_level(help_level);
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        linter = linter.with_corsa_path(configured_corsa_path);
+    }
     #[cfg(not(target_arch = "wasm32"))]
     if args.strict_reactivity {
         linter = linter.with_rule(Box::new(
@@ -534,6 +558,15 @@ fn normalize_lint_input_path(path: &Path) -> PathBuf {
     PathBuf::from(normalize_lint_path(path))
 }
 
+fn resolve_lint_config_path(config_dir: &Path, candidate: &str) -> PathBuf {
+    let path = Path::new(candidate);
+    if path.is_absolute() {
+        return path.to_path_buf();
+    }
+
+    config_dir.join(path)
+}
+
 fn lint_glob_match_options() -> MatchOptions {
     MatchOptions {
         case_sensitive: true,
@@ -633,6 +666,7 @@ fn patina_cross_file_options() -> CrossFileOptions {
     CrossFileOptions::minimal()
         .with_provide_inject(true)
         .with_unique_ids(true)
+        .with_server_client_boundary(true)
         .with_reactivity_tracking(true)
         .with_race_conditions(true)
 }
@@ -714,7 +748,9 @@ fn cross_file_diagnostic_offset(
 ) -> u32 {
     match diagnostic.kind {
         CrossFileDiagnosticKind::DuplicateElementId { .. }
-        | CrossFileDiagnosticKind::NonUniqueIdInLoop { .. } => offsets.template,
+        | CrossFileDiagnosticKind::NonUniqueIdInLoop { .. }
+        | CrossFileDiagnosticKind::BrowserApiInSsr { .. }
+        | CrossFileDiagnosticKind::HydrationMismatchRisk { .. } => offsets.template,
         _ => offsets.script,
     }
 }

--- a/crates/vize/tests/check_cli.rs
+++ b/crates/vize/tests/check_cli.rs
@@ -1,7 +1,7 @@
 use std::{
-    io::{BufRead, Write},
+    io::{BufRead, Read, Write},
     path::Path,
-    process::Command,
+    process::{Command, Stdio},
 };
 
 use vize_carton::cstr;
@@ -197,6 +197,328 @@ const count = 1;
         "{stderr}"
     );
     assert!(stderr.contains("__missing_configured_tsgo__"), "{stderr}");
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}
+
+#[test]
+fn check_respects_configured_corsa_path() {
+    let project_root = create_cli_project(
+        "configured-corsa-path",
+        &[(
+            "src/App.vue",
+            r#"<script setup lang="ts">
+const count = 1;
+</script>
+"#,
+        )],
+    );
+    let config_dir = project_root.join("config");
+    std::fs::create_dir_all(&config_dir).unwrap();
+    std::fs::write(
+        config_dir.join("vize.config.json"),
+        r#"{
+  "typeChecker": {
+    "corsaPath": "__missing_configured_corsa__"
+  }
+}"#,
+    )
+    .unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(&project_root)
+        .args([
+            "check",
+            "--config",
+            "config/vize.config.json",
+            "src/App.vue",
+            "--quiet",
+        ])
+        .output()
+        .unwrap();
+
+    let stderr = std::string::String::from_utf8(output.stderr).unwrap();
+    assert!(!output.status.success());
+    assert!(
+        stderr.contains("Configured Corsa executable does not exist"),
+        "{stderr}"
+    );
+    assert!(stderr.contains("__missing_configured_corsa__"), "{stderr}");
+    assert!(
+        stderr.contains("config/__missing_configured_corsa__"),
+        "{stderr}"
+    );
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}
+
+#[test]
+fn lint_type_aware_rules_respect_configured_corsa_path() {
+    let project_root = create_cli_project(
+        "lint-configured-corsa-path",
+        &[(
+            "src/App.vue",
+            r#"<script setup lang="ts">
+async function loadData(): Promise<number> {
+  return 1
+}
+
+loadData()
+</script>
+"#,
+        )],
+    );
+    let missing_corsa = project_root.join("__missing_lint_corsa__");
+    std::fs::write(
+        project_root.join("vize.config.json"),
+        cstr!(
+            r#"{{
+  "typeChecker": {{
+    "corsaPath": "{}"
+  }}
+}}"#,
+            missing_corsa.display()
+        )
+        .as_str(),
+    )
+    .unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(&project_root)
+        .args([
+            "lint",
+            "--preset",
+            "opinionated",
+            "--help-level",
+            "none",
+            "src/App.vue",
+        ])
+        .output()
+        .unwrap();
+
+    let stdout = std::string::String::from_utf8(output.stdout).unwrap();
+    assert!(output.status.success());
+    assert!(
+        stdout.contains("Configured Corsa executable does not exist"),
+        "{stdout}"
+    );
+    assert!(stdout.contains("__missing_lint_corsa__"), "{stdout}");
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}
+
+#[test]
+fn check_rejects_unsupported_corsa_server_count() {
+    let project_root = create_cli_project(
+        "unsupported-corsa-servers",
+        &[(
+            "src/App.vue",
+            r#"<script setup lang="ts">
+const count = 1;
+</script>
+"#,
+        )],
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(&project_root)
+        .args(["check", "src/App.vue", "--quiet", "--servers", "2"])
+        .output()
+        .unwrap();
+
+    let stderr = std::string::String::from_utf8(output.stderr).unwrap();
+    assert_eq!(output.status.code(), Some(2));
+    assert!(
+        stderr.contains("typeChecker.servers=2 is not supported"),
+        "{stderr}"
+    );
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}
+
+#[test]
+fn lsp_corsa_smoke_publishes_diagnostics_and_hover() {
+    let Some(corsa_path) = resolve_test_corsa_path() else {
+        eprintln!("skipping LSP Corsa smoke: @typescript/native-preview runtime is unavailable");
+        return;
+    };
+    let project_root = create_cli_project(
+        "lsp-corsa-smoke",
+        &[(
+            "src/App.vue",
+            r#"<script setup lang="ts">
+const count: number = 'oops'
+</script>
+
+<template>
+  <div>{{ count.toFixed(1) }}</div>
+</template>
+"#,
+        )],
+    );
+    std::fs::write(
+        project_root.join("vize.config.json"),
+        cstr!(
+            r#"{{
+  "typeChecker": {{
+    "corsaPath": "{}"
+  }},
+  "lsp": {{
+    "lint": true,
+    "typecheck": true,
+    "hover": true
+  }}
+}}"#,
+            corsa_path
+        )
+        .as_str(),
+    )
+    .unwrap();
+
+    let mut child = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(&project_root)
+        .arg("lsp")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    let mut stdin = child.stdin.take().unwrap();
+    let stdout = child.stdout.take().unwrap();
+    let (messages_tx, messages_rx) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        let mut reader = std::io::BufReader::new(stdout);
+        while let Ok(message) = read_lsp_message(&mut reader) {
+            if messages_tx.send(message).is_err() {
+                break;
+            }
+        }
+    });
+
+    let root_uri = file_uri(&project_root);
+    let app_path = project_root.join("src/App.vue");
+    let app_uri = file_uri(&app_path);
+    let source = std::fs::read_to_string(&app_path).unwrap();
+
+    write_lsp_message(
+        &mut stdin,
+        &serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "processId": null,
+                "rootUri": root_uri,
+                "capabilities": {},
+                "initializationOptions": {
+                    "lint": true,
+                    "typecheck": true,
+                    "hover": true
+                }
+            }
+        }),
+    );
+    let initialize = recv_lsp_response(&messages_rx, 1);
+    assert!(
+        initialize["result"]["capabilities"]["hoverProvider"]
+            .as_bool()
+            .unwrap_or(false),
+        "{initialize}"
+    );
+
+    write_lsp_message(
+        &mut stdin,
+        &serde_json::json!({
+            "jsonrpc": "2.0",
+            "method": "initialized",
+            "params": {}
+        }),
+    );
+    write_lsp_message(
+        &mut stdin,
+        &serde_json::json!({
+            "jsonrpc": "2.0",
+            "method": "textDocument/didOpen",
+            "params": {
+                "textDocument": {
+                    "uri": app_uri,
+                    "languageId": "vue",
+                    "version": 1,
+                    "text": source
+                }
+            }
+        }),
+    );
+    let diagnostics = recv_lsp_notification(&messages_rx, "textDocument/publishDiagnostics");
+    assert!(
+        diagnostics["params"]["diagnostics"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|diagnostic| diagnostic["message"]
+                .as_str()
+                .is_some_and(|message| message.contains("number") || message.contains("TS2322"))),
+        "{diagnostics}"
+    );
+
+    write_lsp_message(
+        &mut stdin,
+        &serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "textDocument/hover",
+            "params": {
+                "textDocument": { "uri": app_uri },
+                "position": { "line": 5, "character": 11 }
+            }
+        }),
+    );
+    let hover = recv_lsp_response(&messages_rx, 2);
+    assert!(!hover["result"].is_null(), "{hover}");
+
+    let _ = child.kill();
+    let _ = child.wait();
+    let _ = std::fs::remove_dir_all(&project_root);
+}
+
+#[test]
+fn lint_cross_file_reports_ssr_browser_api_risk() {
+    let project_root = create_cli_project(
+        "cross-file-ssr-browser-api",
+        &[
+            (
+                "src/App.vue",
+                r#"<script setup lang="ts">
+import BrowserBadge from './BrowserBadge.vue'
+</script>
+
+<template>
+  <BrowserBadge />
+</template>
+"#,
+            ),
+            (
+                "src/BrowserBadge.vue",
+                r#"<template>
+  <span>{{ window.innerWidth }}</span>
+</template>
+"#,
+            ),
+        ],
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(&project_root)
+        .args(["lint", "--cross-file", "--help-level", "none", "src"])
+        .output()
+        .unwrap();
+
+    let stdout = std::string::String::from_utf8(output.stdout).unwrap();
+    assert!(
+        stdout.contains("vize:croquis/cf/browser-api-ssr"),
+        "{stdout}"
+    );
+    assert!(stdout.contains("window"), "{stdout}");
 
     let _ = std::fs::remove_dir_all(&project_root);
 }
@@ -854,6 +1176,91 @@ fn create_cli_project(name: &str, files: &[(&str, &str)]) -> std::path::PathBuf 
     }
 
     project_root
+}
+
+fn write_lsp_message(stdin: &mut std::process::ChildStdin, message: &serde_json::Value) {
+    let body = message.to_string();
+    write!(stdin, "Content-Length: {}\r\n\r\n{}", body.len(), body).unwrap();
+    stdin.flush().unwrap();
+}
+
+fn read_lsp_message(
+    reader: &mut std::io::BufReader<std::process::ChildStdout>,
+) -> std::io::Result<serde_json::Value> {
+    let mut content_length = None;
+    loop {
+        let mut line = std::string::String::new();
+        let bytes = reader.read_line(&mut line)?;
+        if bytes == 0 {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::UnexpectedEof,
+                "lsp stdout closed",
+            ));
+        }
+        let line = line.trim_end_matches(['\r', '\n']);
+        if line.is_empty() {
+            break;
+        }
+        if let Some(value) = line.strip_prefix("Content-Length:") {
+            content_length =
+                Some(value.trim().parse::<usize>().map_err(|error| {
+                    std::io::Error::new(std::io::ErrorKind::InvalidData, error)
+                })?);
+        }
+    }
+
+    let Some(content_length) = content_length else {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "missing Content-Length header",
+        ));
+    };
+    let mut body = vec![0; content_length];
+    reader.read_exact(&mut body)?;
+    serde_json::from_slice(&body)
+        .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidData, error))
+}
+
+fn recv_lsp_response(
+    receiver: &std::sync::mpsc::Receiver<serde_json::Value>,
+    id: i64,
+) -> serde_json::Value {
+    recv_lsp_matching(receiver, |message| message["id"].as_i64() == Some(id))
+}
+
+fn recv_lsp_notification(
+    receiver: &std::sync::mpsc::Receiver<serde_json::Value>,
+    method: &str,
+) -> serde_json::Value {
+    recv_lsp_matching(receiver, |message| {
+        message["method"].as_str() == Some(method)
+    })
+}
+
+fn recv_lsp_matching(
+    receiver: &std::sync::mpsc::Receiver<serde_json::Value>,
+    mut matches: impl FnMut(&serde_json::Value) -> bool,
+) -> serde_json::Value {
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(20);
+    let mut seen = Vec::new();
+    loop {
+        let now = std::time::Instant::now();
+        assert!(
+            now < deadline,
+            "timed out waiting for LSP message; seen: {seen:#?}"
+        );
+        let remaining = deadline.saturating_duration_since(now);
+        let message = receiver.recv_timeout(remaining).unwrap();
+        if matches(&message) {
+            return message;
+        }
+        seen.push(message);
+    }
+}
+
+fn file_uri(path: &Path) -> std::string::String {
+    let path = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+    format!("file://{}", path.display())
 }
 
 fn resolve_test_corsa_path() -> Option<String> {

--- a/crates/vize/tests/check_cli.rs
+++ b/crates/vize/tests/check_cli.rs
@@ -385,6 +385,12 @@ const count: number = 'oops'
         .unwrap();
     let mut stdin = child.stdin.take().unwrap();
     let stdout = child.stdout.take().unwrap();
+    let stderr = child.stderr.take().unwrap();
+    std::thread::spawn(move || {
+        let mut stderr = std::io::BufReader::new(stderr);
+        let mut buffer = Vec::new();
+        let _ = stderr.read_to_end(&mut buffer);
+    });
     let (messages_tx, messages_rx) = std::sync::mpsc::channel();
     std::thread::spawn(move || {
         let mut reader = std::io::BufReader::new(stdout);
@@ -1260,7 +1266,31 @@ fn recv_lsp_matching(
 
 fn file_uri(path: &Path) -> std::string::String {
     let path = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
-    format!("file://{}", path.display())
+    let path = path.to_string_lossy().replace('\\', "/");
+    let prefix = if path.starts_with('/') {
+        "file://"
+    } else {
+        "file:///"
+    };
+    format!("{prefix}{}", percent_encode_file_uri_path(&path))
+}
+
+fn percent_encode_file_uri_path(path: &str) -> std::string::String {
+    let mut encoded = std::string::String::with_capacity(path.len());
+    for byte in path.bytes() {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'.' | b'_' | b'~' | b'/' | b':' => {
+                encoded.push(byte as char)
+            }
+            _ => {
+                const HEX: &[u8; 16] = b"0123456789ABCDEF";
+                encoded.push('%');
+                encoded.push(HEX[(byte >> 4) as usize] as char);
+                encoded.push(HEX[(byte & 0x0f) as usize] as char);
+            }
+        }
+    }
+    encoded
 }
 
 fn resolve_test_corsa_path() -> Option<String> {

--- a/crates/vize_armature/src/parser.rs
+++ b/crates/vize_armature/src/parser.rs
@@ -165,7 +165,25 @@ impl<'a> Parser<'a> {
 
     /// Get source slice
     fn get_source(&self, start: usize, end: usize) -> &str {
+        let (start, end) = self.normalize_span(start, end);
         &self.source[start..end]
+    }
+
+    fn normalize_span(&self, start: usize, end: usize) -> (usize, usize) {
+        let mut start = self.clamp_to_char_boundary(start);
+        let end = self.clamp_to_char_boundary(end);
+        if start > end {
+            start = end;
+        }
+        (start, end)
+    }
+
+    fn clamp_to_char_boundary(&self, offset: usize) -> usize {
+        let mut offset = offset.min(self.source.len());
+        while offset > 0 && !self.source.is_char_boundary(offset) {
+            offset -= 1;
+        }
+        offset
     }
 
     /// Calculate position from byte offset
@@ -188,6 +206,7 @@ impl<'a> Parser<'a> {
 
     /// Create a source location
     fn create_loc(&self, start: usize, end: usize) -> SourceLocation {
+        let (start, end) = self.normalize_span(start, end);
         SourceLocation::new(
             self.get_pos(start),
             self.get_pos(end),

--- a/crates/vize_armature/src/parser/attribute.rs
+++ b/crates/vize_armature/src/parser/attribute.rs
@@ -90,8 +90,8 @@ impl<'a> Parser<'a> {
 
     /// Process attribute data (value content)
     pub(super) fn on_attrib_data_impl(&mut self, start: usize, end: usize) {
-        let source = self.source;
-        self.accumulate_attr_or_dir_value(&source[start..end], start, end);
+        let source = self.get_source(start, end).to_owned();
+        self.accumulate_attr_or_dir_value(&source, start, end);
     }
 
     /// Process attribute entity

--- a/crates/vize_armature/src/parser/element.rs
+++ b/crates/vize_armature/src/parser/element.rs
@@ -18,8 +18,8 @@ impl<'a> Parser<'a> {
             return;
         }
 
-        let source = self.source;
-        self.append_or_merge_text(&source[start..end], start, end);
+        let source = self.get_source(start, end).to_owned();
+        self.append_or_merge_text(&source, start, end);
     }
 
     /// Process text entity content
@@ -104,7 +104,7 @@ impl<'a> Parser<'a> {
     pub(super) fn on_open_tag_end_impl(&mut self, end: usize) {
         if let Some(current) = self.current_element.take() {
             let tag_start = current.tag_start;
-            let loc = self.create_loc(tag_start - 1, end + 1); // Include < and >
+            let loc = self.create_loc(tag_start.saturating_sub(1), end + 1); // Include < and >
 
             let mut element = ElementNode::new(self.allocator, current.tag.clone(), loc);
             element.ns = current.ns;
@@ -245,7 +245,7 @@ impl<'a> Parser<'a> {
         }
 
         if !found {
-            let loc = self.create_loc(start - 2, end + 1); // Include </ and >
+            let loc = self.create_loc(start.saturating_sub(2), end + 1); // Include </ and >
             self.errors
                 .push(CompilerError::new(ErrorCode::InvalidEndTag, Some(loc)));
         }

--- a/crates/vize_armature/src/parser/tests.rs
+++ b/crates/vize_armature/src/parser/tests.rs
@@ -724,6 +724,18 @@ fn test_parse_open_tag_at_eof_does_not_panic() {
 }
 
 #[test]
+fn test_parse_malformed_close_tag_at_eof_does_not_panic() {
+    let allocator = Bump::new();
+    let (_root, errors) = parse(&allocator, "\n  <div class=\"root\">{{ title }}</di=\"{");
+
+    assert!(
+        errors
+            .iter()
+            .any(|error| error.code == ErrorCode::InvalidEndTag)
+    );
+}
+
+#[test]
 fn test_parse_recovers_open_tag_at_eof() {
     let allocator = Bump::new();
     let (root, errors) = parse(&allocator, r#"<div class="a""#);

--- a/crates/vize_carton/src/config/model/type_checker.rs
+++ b/crates/vize_carton/src/config/model/type_checker.rs
@@ -1,12 +1,12 @@
 //! Type checker config model.
 
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 
 use crate::String;
 
 /// Type checking settings shared by CLI and IDE diagnostics.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(default, rename_all = "camelCase")]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct TypeCheckerConfig {
     pub enabled: bool,
     pub strict: bool,
@@ -18,7 +18,10 @@ pub struct TypeCheckerConfig {
     pub check_invalid_exports: bool,
     pub check_fallthrough_attrs: bool,
     pub tsconfig: Option<String>,
-    pub corsa_path: Option<String>,
+    /// Path to the Corsa executable, serialized as `corsaPath`.
+    ///
+    /// The Rust field name stays `tsgo_path` to preserve the public crate API.
+    #[serde(rename = "corsaPath")]
     pub tsgo_path: Option<String>,
     pub globals_file: Option<String>,
     pub servers: Option<usize>,
@@ -27,7 +30,7 @@ pub struct TypeCheckerConfig {
 impl TypeCheckerConfig {
     /// Canonical Corsa executable path, with the legacy `tsgoPath` key as a fallback.
     pub fn runtime_path(&self) -> Option<&str> {
-        self.corsa_path.as_deref().or(self.tsgo_path.as_deref())
+        self.tsgo_path.as_deref()
     }
 
     /// Returns true when the config matches the built-in defaults.
@@ -49,10 +52,75 @@ impl Default for TypeCheckerConfig {
             check_invalid_exports: true,
             check_fallthrough_attrs: true,
             tsconfig: None,
-            corsa_path: None,
             tsgo_path: None,
             globals_file: None,
             servers: None,
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for TypeCheckerConfig {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let helper = TypeCheckerConfigDeserialize::deserialize(deserializer)?;
+
+        Ok(Self {
+            enabled: helper.enabled,
+            strict: helper.strict,
+            check_props: helper.check_props,
+            check_emits: helper.check_emits,
+            check_template_bindings: helper.check_template_bindings,
+            check_reactivity: helper.check_reactivity,
+            check_setup_context: helper.check_setup_context,
+            check_invalid_exports: helper.check_invalid_exports,
+            check_fallthrough_attrs: helper.check_fallthrough_attrs,
+            tsconfig: helper.tsconfig,
+            tsgo_path: helper.corsa_path.or(helper.tsgo_path),
+            globals_file: helper.globals_file,
+            servers: helper.servers,
+        })
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(default, rename_all = "camelCase")]
+struct TypeCheckerConfigDeserialize {
+    enabled: bool,
+    strict: bool,
+    check_props: bool,
+    check_emits: bool,
+    check_template_bindings: bool,
+    check_reactivity: bool,
+    check_setup_context: bool,
+    check_invalid_exports: bool,
+    check_fallthrough_attrs: bool,
+    tsconfig: Option<String>,
+    corsa_path: Option<String>,
+    tsgo_path: Option<String>,
+    globals_file: Option<String>,
+    servers: Option<usize>,
+}
+
+impl Default for TypeCheckerConfigDeserialize {
+    fn default() -> Self {
+        let config = TypeCheckerConfig::default();
+        Self {
+            enabled: config.enabled,
+            strict: config.strict,
+            check_props: config.check_props,
+            check_emits: config.check_emits,
+            check_template_bindings: config.check_template_bindings,
+            check_reactivity: config.check_reactivity,
+            check_setup_context: config.check_setup_context,
+            check_invalid_exports: config.check_invalid_exports,
+            check_fallthrough_attrs: config.check_fallthrough_attrs,
+            tsconfig: config.tsconfig,
+            corsa_path: None,
+            tsgo_path: config.tsgo_path,
+            globals_file: config.globals_file,
+            servers: config.servers,
         }
     }
 }

--- a/crates/vize_carton/src/config/model/type_checker.rs
+++ b/crates/vize_carton/src/config/model/type_checker.rs
@@ -18,12 +18,18 @@ pub struct TypeCheckerConfig {
     pub check_invalid_exports: bool,
     pub check_fallthrough_attrs: bool,
     pub tsconfig: Option<String>,
+    pub corsa_path: Option<String>,
     pub tsgo_path: Option<String>,
     pub globals_file: Option<String>,
     pub servers: Option<usize>,
 }
 
 impl TypeCheckerConfig {
+    /// Canonical Corsa executable path, with the legacy `tsgoPath` key as a fallback.
+    pub fn runtime_path(&self) -> Option<&str> {
+        self.corsa_path.as_deref().or(self.tsgo_path.as_deref())
+    }
+
     /// Returns true when the config matches the built-in defaults.
     pub fn is_default(&self) -> bool {
         self == &Self::default()
@@ -43,6 +49,7 @@ impl Default for TypeCheckerConfig {
             check_invalid_exports: true,
             check_fallthrough_attrs: true,
             tsconfig: None,
+            corsa_path: None,
             tsgo_path: None,
             globals_file: None,
             servers: None,

--- a/crates/vize_carton/tests/snapshots/loading__loads_json_type_checker_settings.snap
+++ b/crates/vize_carton/tests/snapshots/loading__loads_json_type_checker_settings.snap
@@ -37,7 +37,7 @@ expression: "serde_json::to_string_pretty(&config).unwrap()"
     "checkInvalidExports": true,
     "checkFallthroughAttrs": true,
     "tsconfig": null,
-    "tsgoPath": null,
+    "corsaPath": null,
     "globalsFile": "./globals.d.ts",
     "servers": null
   }

--- a/crates/vize_carton/tests/snapshots/loading__loads_legacy_json_aliases.snap
+++ b/crates/vize_carton/tests/snapshots/loading__loads_legacy_json_aliases.snap
@@ -37,7 +37,7 @@ expression: "serde_json::to_string_pretty(&config).unwrap()"
     "checkInvalidExports": true,
     "checkFallthroughAttrs": true,
     "tsconfig": null,
-    "tsgoPath": null,
+    "corsaPath": null,
     "globalsFile": "./globals.d.ts",
     "servers": null
   }

--- a/crates/vize_carton/tests/snapshots/loading__loads_pkl_defaults.snap
+++ b/crates/vize_carton/tests/snapshots/loading__loads_pkl_defaults.snap
@@ -37,7 +37,7 @@ expression: "serde_json::to_string_pretty(&config).unwrap()"
     "checkInvalidExports": true,
     "checkFallthroughAttrs": true,
     "tsconfig": null,
-    "tsgoPath": null,
+    "corsaPath": null,
     "globalsFile": "./globals.d.ts",
     "servers": null
   },

--- a/crates/vize_maestro/src/server/state.rs
+++ b/crates/vize_maestro/src/server/state.rs
@@ -441,7 +441,7 @@ impl ServerState {
 
         // Try to initialize
         let config = self.get_type_checker_config();
-        let corsa_path = config.tsgo_path.as_ref().map(PathBuf::from);
+        let corsa_path = config.runtime_path().map(PathBuf::from);
         let options = BatchTypeCheckerOptions {
             tsconfig_path: config.tsconfig.as_ref().map(PathBuf::from),
             ..Default::default()
@@ -541,7 +541,7 @@ impl ServerState {
             .corsa_bridge
             .get_or_try_init(|| async {
                 let config = CorsaBridgeConfig {
-                    corsa_path: type_checker_config.tsgo_path.as_ref().map(PathBuf::from),
+                    corsa_path: type_checker_config.runtime_path().map(PathBuf::from),
                     working_dir: workspace_root,
                     timeout_ms: 30000, // Corsa needs time to build project state on first load.
                     ..Default::default()
@@ -910,7 +910,7 @@ mod tests {
                     "checkProps": false,
                     "checkEmits": false,
                     "tsconfig": "tsconfig.app.json",
-                    "tsgoPath": "./node_modules/.bin/tsgo"
+                    "corsaPath": "./node_modules/.bin/corsa"
                 }
             }"#,
         )
@@ -923,10 +923,7 @@ mod tests {
         assert!(!config.check_props);
         assert!(!config.check_emits);
         assert_eq!(config.tsconfig.as_deref(), Some("tsconfig.app.json"));
-        assert_eq!(
-            config.tsgo_path.as_deref(),
-            Some("./node_modules/.bin/tsgo")
-        );
+        assert_eq!(config.runtime_path(), Some("./node_modules/.bin/corsa"));
     }
 
     #[test]

--- a/crates/vize_patina/src/linter/config.rs
+++ b/crates/vize_patina/src/linter/config.rs
@@ -11,6 +11,8 @@ use crate::{
     rule::RuleRegistry,
 };
 #[cfg(not(target_arch = "wasm32"))]
+use std::path::PathBuf;
+#[cfg(not(target_arch = "wasm32"))]
 use std::sync::Mutex;
 use vize_carton::{FxHashSet, String, i18n::Locale};
 
@@ -64,6 +66,9 @@ pub struct Linter {
     /// Lazily initialized native corsa session for type-aware lint.
     #[cfg(not(target_arch = "wasm32"))]
     pub(crate) native_corsa: Mutex<Option<CorsaTypeAwareSession>>,
+    /// Optional configured Corsa executable for type-aware lint.
+    #[cfg(not(target_arch = "wasm32"))]
+    pub(crate) corsa_path: Option<PathBuf>,
 }
 
 impl Linter {
@@ -84,6 +89,8 @@ impl Linter {
             script_rules: builtin_script_rule_names(preset),
             #[cfg(not(target_arch = "wasm32"))]
             native_corsa: Mutex::new(None),
+            #[cfg(not(target_arch = "wasm32"))]
+            corsa_path: None,
         }
     }
 
@@ -100,6 +107,8 @@ impl Linter {
             script_rules: builtin_script_rule_names(preset),
             #[cfg(not(target_arch = "wasm32"))]
             native_corsa: Mutex::new(None),
+            #[cfg(not(target_arch = "wasm32"))]
+            corsa_path: None,
         }
     }
 
@@ -116,6 +125,8 @@ impl Linter {
             script_rules: &[],
             #[cfg(not(target_arch = "wasm32"))]
             native_corsa: Mutex::new(None),
+            #[cfg(not(target_arch = "wasm32"))]
+            corsa_path: None,
         }
     }
 
@@ -164,6 +175,14 @@ impl Linter {
     #[inline]
     pub fn with_help_level(mut self, level: HelpLevel) -> Self {
         self.help_level = level;
+        self
+    }
+
+    /// Set the Corsa executable used by native type-aware lint rules.
+    #[cfg(not(target_arch = "wasm32"))]
+    #[inline]
+    pub fn with_corsa_path(mut self, path: Option<PathBuf>) -> Self {
+        self.corsa_path = path;
         self
     }
 

--- a/crates/vize_patina/src/linter/corsa_session/paths.rs
+++ b/crates/vize_patina/src/linter/corsa_session/paths.rs
@@ -69,40 +69,53 @@ pub(super) fn resolve_project_root(filename: &str) -> PathBuf {
     package_root.unwrap_or(start_dir)
 }
 
-pub(super) fn resolve_corsa_executable(project_root: &Path) -> PathBuf {
+pub(super) fn resolve_corsa_executable(
+    project_root: &Path,
+    configured_path: Option<&Path>,
+) -> Result<PathBuf, String> {
+    if let Some(path) = configured_path {
+        if !path.exists() {
+            return Err(cstr!(
+                "Configured Corsa executable does not exist: {}",
+                path.display()
+            ));
+        }
+        return Ok(path.to_path_buf());
+    }
+
     if let Some(path) = resolve_executable_from_env(&EXECUTABLE_ENV_VARS) {
-        return path;
+        return Ok(path);
     }
     if let Some(path) = resolve_executable_from_env(&LEGACY_EXECUTABLE_ENV_VARS) {
-        return path;
+        return Ok(path);
     }
 
     for current in project_root.ancestors() {
         for candidate in corsa_executable_candidates(current) {
             if candidate.exists() {
-                return candidate;
+                return Ok(candidate);
             }
         }
         if let Some(parent) = current.parent() {
             for candidate in corsa_executable_candidates(&parent.join("corsa-bind")) {
                 if candidate.exists() {
-                    return candidate;
+                    return Ok(candidate);
                 }
             }
         }
         if let Some(path) = resolve_node_modules_executable(current) {
-            return path;
+            return Ok(path);
         }
     }
 
     if let Some(home) = std::env::var_os("HOME") {
         let home = PathBuf::from(home);
         if let Some(path) = resolve_home_executable(&home) {
-            return path;
+            return Ok(path);
         }
     }
 
-    resolve_path_executable().unwrap_or_else(|| PathBuf::from(EXECUTABLE_NAMES[0]))
+    Ok(resolve_path_executable().unwrap_or_else(|| PathBuf::from(EXECUTABLE_NAMES[0])))
 }
 
 fn source_directory(filename: &str) -> PathBuf {
@@ -346,7 +359,7 @@ mod tests {
         write_file(&wrapper);
         write_file(&native);
 
-        assert_eq!(resolve_corsa_executable(&root), native);
+        assert_eq!(resolve_corsa_executable(&root, None).unwrap(), native);
 
         let _ = std::fs::remove_dir_all(&root);
     }
@@ -359,9 +372,19 @@ mod tests {
 
         write_file(&wrapper);
 
-        assert_eq!(resolve_corsa_executable(&root), wrapper);
+        assert_eq!(resolve_corsa_executable(&root, None).unwrap(), wrapper);
 
         let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn configured_corsa_path_must_exist() {
+        let root = case_dir("configured-missing");
+        let missing = root.join("missing-corsa");
+        let error = resolve_corsa_executable(&root, Some(missing.as_path())).unwrap_err();
+
+        assert!(error.contains("Configured Corsa executable does not exist"));
+        assert!(error.contains("missing-corsa"));
     }
 
     fn write_file(path: &Path) {

--- a/crates/vize_patina/src/linter/corsa_session/session.rs
+++ b/crates/vize_patina/src/linter/corsa_session/session.rs
@@ -16,7 +16,10 @@ use corsa::{
 use vize_carton::{String, ToCompactString, profile};
 
 impl CorsaTypeAwareSession {
-    pub(in crate::linter) fn new(filename: &str) -> Result<Self, String> {
+    pub(in crate::linter) fn new_with_corsa_path(
+        filename: &str,
+        corsa_path: Option<&std::path::Path>,
+    ) -> Result<Self, String> {
         let project_root = resolve_project_root(filename);
         let session_root = allocate_session_root(&project_root);
         profile!(
@@ -55,7 +58,7 @@ impl CorsaTypeAwareSession {
 
         let config_path_wire = path_to_wire(&config_path);
         let virtual_file_wire = path_to_wire(&virtual_file_path);
-        let executable = resolve_corsa_executable(&project_root);
+        let executable = resolve_corsa_executable(&project_root, corsa_path)?;
         let api_mode = api_mode_for_executable(&executable);
         let session = profile!(
             "patina.corsa_session.spawn",

--- a/crates/vize_patina/src/linter/native_type_aware.rs
+++ b/crates/vize_patina/src/linter/native_type_aware.rs
@@ -117,7 +117,7 @@ pub(super) fn with_corsa_session<T>(
         }
         *guard = Some(profile!(
             "patina.type_aware.corsa.new_session",
-            CorsaTypeAwareSession::new(filename)
+            CorsaTypeAwareSession::new_with_corsa_path(filename, linter.corsa_path.as_deref())
         )?);
     }
 

--- a/crates/vize_patina/src/linter/native_type_aware/driver.rs
+++ b/crates/vize_patina/src/linter/native_type_aware/driver.rs
@@ -217,7 +217,7 @@ pub(super) fn lint_with_descriptor<'a>(
     let mut should_warn_for_emits = false;
     let mut warned_template_owners = FxHashSet::default();
     let mut warned_reactivity_loss_owners = FxHashSet::default();
-    let _ = profile!(
+    let corsa_result = profile!(
         "patina.type_aware.corsa_session",
         with_corsa_session(linter, filename, |session| {
             profile!(
@@ -339,6 +339,14 @@ pub(super) fn lint_with_descriptor<'a>(
             Ok(())
         })
     );
+    if let Err(error) = corsa_result {
+        push_warning(
+            &mut result,
+            LintDiagnostic::warn("type/corsa-runtime", error, 0, 0).with_help(
+                "Type-aware lint rules were skipped because the Corsa runtime could not be started. Configure `typeChecker.corsaPath` or install `@typescript/native-preview`.",
+            ),
+        );
+    }
 
     push_macro_warning(
         &mut result,

--- a/crates/vize_patina/src/linter/native_type_aware/tests.rs
+++ b/crates/vize_patina/src/linter/native_type_aware/tests.rs
@@ -6,7 +6,8 @@ use super::{
 use crate::{LintPreset, Linter};
 
 fn corsa_available() -> bool {
-    let mut session = match super::CorsaTypeAwareSession::new("Component.vue") {
+    let mut session = match super::CorsaTypeAwareSession::new_with_corsa_path("Component.vue", None)
+    {
         Ok(session) => session,
         Err(_) => return false,
     };

--- a/docs/content/getting-started.md
+++ b/docs/content/getting-started.md
@@ -167,7 +167,11 @@ vize lsp
 
 `vize check` is powered by `vize_canon`, which now leans on [`corsa-bind`](https://github.com/ubugeeei/corsa-bind) project sessions for native TypeScript diagnostics. Vize generates virtual TypeScript for Vue SFCs, asks Corsa for project-aware diagnostics, and then maps the results back onto the original `.vue`, `.ts`, `.tsx`, and `.d.ts` files.
 
-This path is still maturing, so editor type checking remains an opt-in capability for now. If you are developing Vize alongside Corsa, `vize check --corsa-path /path/to/corsa` lets you point at a custom executable.
+This path is still maturing, so editor type checking remains an opt-in capability for now. The
+runtime stack is the `@typescript/native-preview` package, Corsa/corsa-bind is the API layer Vize
+talks to, and the executable installed by the TypeScript native preview is still commonly named
+`tsgo`. Use `typeChecker.corsaPath` or `vize check --corsa-path /path/to/tsgo` when you want to pin
+that runtime. `typeChecker.tsgoPath` remains a deprecated compatibility alias.
 
 Useful type-checking commands:
 
@@ -205,6 +209,7 @@ export default defineConfig({
   typeChecker: {
     enabled: true,
     strict: true,
+    corsaPath: "./node_modules/.bin/tsgo",
   },
   formatter: {
     printWidth: 100,

--- a/docs/content/guide/cli.md
+++ b/docs/content/guide/cli.md
@@ -179,11 +179,13 @@ Key options:
 | `-q, --quiet`       | Show summary only                                  |
 | `--profile`         | Write profile artifacts under `node_modules/.vize` |
 | `--corsa-path`      | Override the Corsa executable path                 |
-| `--servers`         | Parallel Corsa worker count                        |
+| `--servers`         | Reserved Corsa server count; only `1` is supported |
 | `--declaration`     | Emit `.d.ts` output                                |
 | `--declaration-dir` | Output directory for emitted declarations          |
 
-Use `--corsa-path` when you want to pin a custom Corsa executable while developing Vize or testing a local `corsa-bind` checkout.
+Use `--corsa-path` when you want to pin a custom Corsa executable while developing Vize or testing a
+local `corsa-bind` checkout. The shared config key is `typeChecker.corsaPath`; `typeChecker.tsgoPath`
+is kept only as a compatibility alias.
 
 Useful patterns:
 

--- a/docs/content/guide/configuration.md
+++ b/docs/content/guide/configuration.md
@@ -193,24 +193,30 @@ export default defineConfig({
 ```
 
 `typeChecker.tsconfig` and `typeChecker.corsaPath` are part of the shared schema, but the
-project-backed Corsa path is the Rust CLI surface today. Use `vize check --tsconfig ...` and
-`vize check --corsa-path ...` when you need those controls.
+project-backed Corsa path is the Rust CLI surface today. `typeChecker.corsaPath` is shared by
+`vize check`, type-aware `vize lint`, and `vize lsp`; `typeChecker.tsgoPath` is a deprecated alias
+for older configs. Use `vize check --tsconfig ...` and `vize check --corsa-path ...` when you need
+command-line overrides.
 
-The Rust `vize check` command reads its own `check` block from `vize.config.pkl` or
-`vize.config.json` for command-native settings such as worker count. Keep ambient declarations,
-generated auto-import files, path aliases, and Vue `ComponentCustomProperties` declarations in your
-project `tsconfig.json`; use `vize check --tsconfig ...` to select that project file.
+The runtime stack is `@typescript/native-preview`, the Corsa/corsa-bind API layer, and the installed
+`tsgo` executable name. Keep ambient declarations, generated auto-import files, path aliases, and
+Vue `ComponentCustomProperties` declarations in your project `tsconfig.json`; use
+`vize check --tsconfig ...` to select that project file.
 
 ```json
 {
-  "check": {
-    "servers": 4
+  "typeChecker": {
+    "corsaPath": "./node_modules/.bin/tsgo",
+    "servers": 1
   },
   "lsp": {
     "typecheck": false
   }
 }
 ```
+
+`typeChecker.servers` is reserved for future Corsa worker pools. The direct project-session runner
+currently supports only `1`; larger values fail fast instead of pretending to tune concurrency.
 
 ## Musea Options
 

--- a/docs/content/guide/static-analysis.md
+++ b/docs/content/guide/static-analysis.md
@@ -142,7 +142,7 @@ fields if a project config is available. Use `--show-virtual-ts` when debugging 
 ```bash
 vize check --show-virtual-ts src/components/App.vue
 vize check --profile src
-vize check --servers 4 src
+vize check --servers 1 src
 ```
 
 Declaration output is available from the materialized checker project:

--- a/fuzz/fuzz_targets/js_ts_expression.rs
+++ b/fuzz/fuzz_targets/js_ts_expression.rs
@@ -14,6 +14,9 @@ fuzz_target!(|data: &[u8]| {
     let Ok(source) = std::str::from_utf8(data) else {
         return;
     };
+    if exceeds_expression_nesting_limit(source, 256) {
+        return;
+    }
 
     let allocator = Allocator::default();
     let parser = Parser::new(
@@ -23,3 +26,20 @@ fuzz_target!(|data: &[u8]| {
     );
     let _ = parser.parse_expression();
 });
+
+fn exceeds_expression_nesting_limit(source: &str, limit: usize) -> bool {
+    let mut depth = 0usize;
+    for byte in source.bytes() {
+        match byte {
+            b'(' | b'[' | b'{' => {
+                depth += 1;
+                if depth > limit {
+                    return true;
+                }
+            }
+            b')' | b']' | b'}' => depth = depth.saturating_sub(1),
+            _ => {}
+        }
+    }
+    false
+}

--- a/npm/vize/pkl/TypeCheckerConfig.pkl
+++ b/npm/vize/pkl/TypeCheckerConfig.pkl
@@ -32,12 +32,15 @@ class TypeCheckerConfig {
   /// Path to tsconfig.json.
   tsconfig: String? = null
 
-  /// Path to tsgo binary.
+  /// Path to the Corsa executable.
+  corsaPath: String? = null
+
+  /// Deprecated alias for `corsaPath`.
   tsgoPath: String? = null
 
   /// Path to a .d.ts file that declares template globals.
   globalsFile: String? = null
 
-  /// Number of parallel Corsa servers to use.
+  /// Reserved Corsa server count. The direct project-session runner currently supports only 1.
   servers: Int? = null
 }

--- a/npm/vize/pkl/jsonschema/generate.pkl
+++ b/npm/vize/pkl/jsonschema/generate.pkl
@@ -206,9 +206,13 @@ local typeCheckerConfigDef: JsonSchema = new JsonSchema {
       type = "string"
       description = "Path to tsconfig.json"
     }
+    ["corsaPath"] = new JsonSchema {
+      type = "string"
+      description = "Path to the Corsa executable. This is the canonical runtime key; tsgoPath is kept as a compatibility alias."
+    }
     ["tsgoPath"] = new JsonSchema {
       type = "string"
-      description = "Path to tsgo binary"
+      description = "Deprecated alias for typeChecker.corsaPath"
     }
     ["globalsFile"] = new JsonSchema {
       type = "string"
@@ -216,7 +220,7 @@ local typeCheckerConfigDef: JsonSchema = new JsonSchema {
     }
     ["servers"] = new JsonSchema {
       type = "integer"
-      description = "Number of parallel Corsa servers to use"
+      description = "Reserved Corsa server count. The direct project-session runner currently supports only 1."
     }
   }
   additionalProperties = false

--- a/npm/vize/pkl/vize.pkl
+++ b/npm/vize/pkl/vize.pkl
@@ -57,8 +57,8 @@ class TypeCheckerConfig {
   checkInvalidExports: Boolean? = null
   checkFallthroughAttrs: Boolean? = null
   tsconfig: String? = null
-  tsgoPath: String? = null
   corsaPath: String? = null
+  tsgoPath: String? = null
   globalsFile: String? = null
   servers: Int? = null
 }

--- a/npm/vize/schemas/vize.config.schema.json
+++ b/npm/vize/schemas/vize.config.schema.json
@@ -222,8 +222,12 @@
           "description": "Path to tsconfig.json",
           "type": "string"
         },
+        "corsaPath": {
+          "description": "Path to the Corsa executable. This is the canonical runtime key; tsgoPath is kept as a compatibility alias.",
+          "type": "string"
+        },
         "tsgoPath": {
-          "description": "Path to tsgo binary",
+          "description": "Deprecated alias for typeChecker.corsaPath",
           "type": "string"
         },
         "globalsFile": {
@@ -231,7 +235,7 @@
           "type": "string"
         },
         "servers": {
-          "description": "Number of parallel Corsa servers to use",
+          "description": "Reserved Corsa server count. The direct project-session runner currently supports only 1.",
           "type": "integer"
         }
       },

--- a/npm/vize/src/types/generated.ts
+++ b/npm/vize/src/types/generated.ts
@@ -170,7 +170,11 @@ export interface TypeCheckerConfig {
    */
   tsconfig?: string;
   /**
-   * Path to tsgo binary
+   * Path to the Corsa executable. This is the canonical runtime key; tsgoPath is kept as a compatibility alias.
+   */
+  corsaPath?: string;
+  /**
+   * Deprecated alias for typeChecker.corsaPath
    */
   tsgoPath?: string;
   /**
@@ -178,7 +182,7 @@ export interface TypeCheckerConfig {
    */
   globalsFile?: string;
   /**
-   * Number of parallel Corsa servers to use
+   * Reserved Corsa server count. The direct project-session runner currently supports only 1.
    */
   servers?: number;
 }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
       "esbuild"
     ],
     "overrides": {
+      "@azure/msal-node>uuid": "11.1.1",
       "@unhead/vue": "2.1.15",
       "defu": "6.1.7",
       "devalue": "5.8.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -209,6 +209,7 @@ overrides:
   srvx: 0.11.15
   svgo: 4.0.1
   tar: 7.5.15
+  '@azure/msal-node>uuid': 11.1.1
   yaml: 2.9.0
 
 importers:
@@ -8709,13 +8710,12 @@ packages:
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
-  uuid@14.0.0:
-    resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
+  uuid@11.1.1:
+    resolution: {integrity: sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==}
     hasBin: true
 
-  uuid@8.3.2:
-    resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
-    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
+  uuid@14.0.0:
+    resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
     hasBin: true
 
   vary@1.1.2:
@@ -9215,7 +9215,7 @@ snapshots:
     dependencies:
       '@azure/msal-common': 15.17.0
       jsonwebtoken: 9.0.3
-      uuid: 8.3.2
+      uuid: 11.1.1
     optional: true
 
   '@babel/code-frame@7.29.0':
@@ -17150,10 +17150,10 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  uuid@14.0.0: {}
-
-  uuid@8.3.2:
+  uuid@11.1.1:
     optional: true
+
+  uuid@14.0.0: {}
 
   vary@1.1.2: {}
 


### PR DESCRIPTION
## Summary
- Standardize Corsa runtime configuration around `typeChecker.corsaPath`, keeping `tsgoPath` as a legacy alias across check, lint, LSP, schemas, Pkl, generated types, and docs.
- Make unsupported Corsa server counts fail fast, expose configured runtime failures in type-aware lint, and add CLI/LSP smoke coverage for the Corsa-backed paths.
- Harden parser span handling and fuzz targets for the reported crash reproducers, and enable cross-file SSR browser API diagnostics from lint.

## Issues
Closes #24
Closes #544
Closes #545
Closes #547
Closes #548
Closes #549
Closes #550

Experimental issues #18, #12, and #10 are intentionally out of scope.

## Validation
- `cargo fmt --all`
- `git diff --check`
- `cargo test -p vize --test check_cli --features glyph,maestro`
- `cargo test -p vize_armature -p vize_patina -p vize_maestro -p vize --features glyph,maestro`
- `cargo +nightly fuzz run template_compile /tmp/vize-fuzz-reproducers-template/crash-2f1a160c875174c50f814badffa2c0b0fdb8b21d -- -runs=1`
- `cargo +nightly fuzz run js_ts_expression /tmp/vize-fuzz-reproducers-js/crash-23161fc55bb767619cdfe190c7c6489e37ea937f -- -runs=1`