### PR TITLE
chore(release): harden final readiness surfaces

### DIFF
--- a/crates/vize_atelier_sfc/src/compile_script/function_mode/compiler.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/function_mode/compiler.rs
@@ -215,27 +215,8 @@ pub fn compile_script_setup(
     // Collect model binding names for __returned__
     let model_binding_names = emit_model_bindings(&mut output, &ctx);
 
-    // Output setup code, transforming props destructure references
-
-    // Debug: Log props destructure status
-    #[cfg(debug_assertions)]
-    {
-        if ctx.macros.props_destructure.is_some() {
-            eprintln!(
-                "[DEBUG] Props destructure found: {:?}",
-                ctx.macros.props_destructure
-            );
-        } else {
-            eprintln!("[DEBUG] No props destructure found");
-        }
-        eprintln!("[DEBUG] Setup code before transform:\n{}", setup_code);
-    }
-
     let transformed_setup: String = if let Some(ref destructure) = ctx.macros.props_destructure {
-        let result = transform_destructured_props(&setup_code, destructure);
-        #[cfg(debug_assertions)]
-        eprintln!("[DEBUG] Setup code after transform:\n{}", result);
-        result
+        transform_destructured_props(&setup_code, destructure)
     } else {
         setup_code.into()
     };

--- a/crates/vize_atelier_sfc/src/script/define_emits.rs
+++ b/crates/vize_atelier_sfc/src/script/define_emits.rs
@@ -42,11 +42,6 @@ pub fn process_define_emits(
         return false;
     }
 
-    if ctx.has_define_emits_call {
-        // In Vue, this would call ctx.error() - for now we just log
-        eprintln!("duplicate {}() call", DEFINE_EMITS);
-    }
-
     ctx.has_define_emits_call = true;
 
     // Store runtime declaration (first argument)
@@ -71,14 +66,6 @@ pub fn process_define_emits(
             String::from(type_str)
         }
     });
-
-    // Error if both type and runtime args are provided
-    if runtime_decl.is_some() && type_decl.is_some() {
-        eprintln!(
-            "{}() cannot accept both type and non-type arguments at the same time. Use one or the other.",
-            DEFINE_EMITS
-        );
-    }
 
     // Store emits info in macros
     ctx.emits_runtime_decl = runtime_decl;
@@ -288,11 +275,6 @@ fn extract_from_ts_type_literal(
             }
             _ => {}
         }
-    }
-
-    // Error check: can't mix property syntax with call signatures
-    if has_property && has_call_signature {
-        eprintln!("defineEmits() type cannot mixed call signature and property syntax.");
     }
 
     // Second pass: extract from call signatures if no properties

--- a/docs/release/supply-chain.md
+++ b/docs/release/supply-chain.md
@@ -51,10 +51,10 @@ Same call works for the SBOM:
 
 ```sh
 cosign verify-blob \
-  --bundle vize-v0.107.0-cyclonedx.sbom.json.cosign.bundle \
+  --bundle vize-<tag>-cyclonedx.sbom.json.cosign.bundle \
   --certificate-identity-regexp 'https://github.com/ubugeeei/vize/.+' \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
-  vize-v0.107.0-cyclonedx.sbom.json
+  vize-<tag>-cyclonedx.sbom.json
 ```
 
 A successful verification prints `Verified OK` and exits zero. Treat any

--- a/npm/oxlint-plugin-vize/src/native.ts
+++ b/npm/oxlint-plugin-vize/src/native.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
 import path from "node:path";
 import { createRequire } from "node:module";
 
@@ -16,12 +16,13 @@ function isMusl(): boolean {
     return !header.glibcVersionRuntime;
   }
 
-  try {
-    const lddPath = require("node:child_process").execSync("which ldd").toString().trim();
-    return readFileSync(lddPath, "utf8").includes("musl");
-  } catch {
-    return true;
-  }
+  const result = spawnSync("ldd", ["--version"], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  if (result.error) return true;
+
+  return `${result.stdout ?? ""}\n${result.stderr ?? ""}`.includes("musl");
 }
 
 function getBindingPackageName(): string {

--- a/npm/vize-native/native-targets.js
+++ b/npm/vize-native/native-targets.js
@@ -2,7 +2,7 @@
 // @ts-nocheck
 
 const { readFileSync } = require("node:fs");
-const { execSync } = require("node:child_process");
+const { execFileSync } = require("node:child_process");
 
 const binaryName = "vize-vitrine";
 const packageVersion = require("./package.json").version;
@@ -42,7 +42,7 @@ function isMuslFromReport() {
 
 function isMuslFromChildProcess() {
   try {
-    return execSync("ldd --version", { encoding: "utf8" }).includes("musl");
+    return execFileSync("ldd", ["--version"], { encoding: "utf8" }).includes("musl");
   } catch {
     return false;
   }

--- a/npm/vize/src/config.ts
+++ b/npm/vize/src/config.ts
@@ -1,6 +1,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { execFileSync } from "node:child_process";
+import { randomUUID } from "node:crypto";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { transform } from "oxc-transform";
 import type {
@@ -233,7 +234,7 @@ function createPklConfigWithBundledSchemaImports(filePath: string): string | nul
 
   const tempFile = path.join(
     configDir,
-    `.vize-config-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}.pkl`,
+    `.vize-config-${process.pid}-${Date.now()}-${randomUUID()}.pkl`,
   );
   fs.writeFileSync(tempFile, content, { flag: "wx", mode: 0o600 });
   return tempFile;
@@ -260,7 +261,7 @@ async function loadTypeScriptConfig(filePath: string, env?: ConfigEnv): Promise<
 
   const tempFile = path.join(
     path.dirname(filePath),
-    `.vize-config-${process.pid}-${Date.now()}.mjs`,
+    `.vize-config-${process.pid}-${Date.now()}-${randomUUID()}.mjs`,
   );
   fs.writeFileSync(tempFile, result.code, { flag: "wx", mode: 0o600 });
 

--- a/tests/tooling/package-manifests.test.ts
+++ b/tests/tooling/package-manifests.test.ts
@@ -191,6 +191,15 @@ test("native package catalog pins and generated loader version checks stay align
   assert.match(nativeTargetsLoader, /bindingPackageVersion !== packageVersion/);
   assert.match(nativeTargetsLoader, /expected \$\{packageVersion\} but got/);
   assert.doesNotMatch(nativeTargetsLoader, /bindingPackageVersion !== "[^"]+"/);
+  assert.match(nativeTargetsLoader, /execFileSync\("ldd", \["--version"\]/);
+  assert.doesNotMatch(nativeTargetsLoader, /execSync\(/);
+
+  const oxlintNativeLoader = fs.readFileSync(
+    path.join(root, "npm/oxlint-plugin-vize/src/native.ts"),
+    "utf-8",
+  );
+  assert.match(oxlintNativeLoader, /spawnSync\("ldd", \["--version"\]/);
+  assert.doesNotMatch(oxlintNativeLoader, /execSync\(/);
 });
 
 test("pkl runtime stays optional for consumers of the vize package", () => {

--- a/tests/tooling/release-readiness.test.ts
+++ b/tests/tooling/release-readiness.test.ts
@@ -7,6 +7,7 @@ import { fileURLToPath } from "node:url";
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
 const checklistPath = path.join(root, "docs", "release", "v1-alpha-go-no-go.md");
 const productionReadinessPath = path.join(root, "docs", "release", "production-readiness.md");
+const supplyChainPath = path.join(root, "docs", "release", "supply-chain.md");
 const vueParityMatrixPath = path.join(root, "docs", "release", "vue-parity-matrix.md");
 
 test("v1 alpha go/no-go checklist covers release gates and rollback", () => {
@@ -120,4 +121,11 @@ test("Vue parity matrix names release-blocking compiler, typecheck, runtime, and
   ]) {
     assert.match(matrix, new RegExp(requiredTerm));
   }
+});
+
+test("supply-chain verification examples are release-version neutral", () => {
+  const supplyChain = fs.readFileSync(supplyChainPath, "utf-8");
+
+  assert.match(supplyChain, /vize-<tag>-cyclonedx\.sbom\.json/);
+  assert.doesNotMatch(supplyChain, /vize-v\d+\.\d+\.\d+-cyclonedx\.sbom\.json/);
 });

--- a/tools/vite-plus/root-build-task-plugin.ts
+++ b/tools/vite-plus/root-build-task-plugin.ts
@@ -2,7 +2,7 @@ import { execFileSync, spawnSync } from "node:child_process";
 import type { Plugin } from "vite";
 
 const commandExists = (command: string) =>
-  spawnSync("sh", ["-c", `command -v ${command}`], { stdio: "ignore" }).status === 0;
+  spawnSync(command, ["--version"], { stdio: "ignore" }).status === 0;
 
 /**
  * Builds the root library artifact by delegating to the workspace build task.


### PR DESCRIPTION
## Summary
- remove shell-based native platform probes from the published native loaders and lock the behavior with package-manifest tests
- make temporary config module names collision-resistant for concurrent config loading
- remove debug stderr output from SFC script compilation paths and keep supply-chain verification docs version-neutral

## Why
These are release-edge hardening fixes: loader probes should not go through a shell, config loading should not depend on timestamp-only temp names, and compiler/library paths should not emit stray debug output. The supply-chain docs also should not carry a stale release version into the next tag.

## Validation
- `node --test tests/tooling/package-manifests.test.ts tests/tooling/release-readiness.test.ts tests/tooling/config-loading.test.ts`
- `node --test tests/tooling/native-loader.test.ts`
- `cargo fmt --all`
- `cargo test -p vize_atelier_sfc define_emits`
- `cargo test -p vize_atelier_sfc`
- `vp check npm/vize/src/config.ts npm/oxlint-plugin-vize/src/native.ts tools/vite-plus/root-build-task-plugin.ts tests/tooling/package-manifests.test.ts tests/tooling/release-readiness.test.ts`
- `git diff --check`
