### PR TITLE
fix(config): stop falling back after invalid pkl config

### DIFF
--- a/crates/vize_carton/src/config/loader.rs
+++ b/crates/vize_carton/src/config/loader.rs
@@ -86,14 +86,29 @@ fn try_parse_candidate(path: &Path) -> Option<VizeConfig> {
     match parse_config_file(path) {
         Ok(config) => Some(config),
         Err(error) => {
+            let should_try_next = should_try_next_config(path, error.as_ref());
             eprintln!(
                 "\x1b[33mWarning:\x1b[0m Failed to parse {}: {}",
                 path.display(),
                 error
             );
-            None
+            if should_try_next {
+                None
+            } else {
+                Some(VizeConfig::default())
+            }
         }
     }
+}
+
+fn should_try_next_config(path: &Path, error: &(dyn std::error::Error + 'static)) -> bool {
+    if path.extension().and_then(|ext| ext.to_str()) != Some("pkl") {
+        return true;
+    }
+
+    error
+        .downcast_ref::<PklError>()
+        .is_some_and(is_process_error)
 }
 
 fn parse_config_file(path: &Path) -> Result<VizeConfig, Box<dyn std::error::Error>> {

--- a/crates/vize_carton/tests/loading.rs
+++ b/crates/vize_carton/tests/loading.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::disallowed_macros)]
 
-use vize_carton::config::load_config;
+use vize_carton::config::{load_config, load_config_with_source};
 
 #[test]
 fn loads_pkl_defaults() {
@@ -138,4 +138,35 @@ lsp {
     let config = load_config(Some(dir.path()));
 
     insta::assert_snapshot!(serde_json::to_string_pretty(&config).unwrap());
+}
+
+#[test]
+fn invalid_pkl_config_does_not_fall_back_to_json() {
+    let dir = tempfile::tempdir().unwrap();
+    let config_path = dir.path().join("vize.config.pkl");
+    install_pkl_modules(dir.path());
+    std::fs::write(
+        &config_path,
+        r#"
+amends "node_modules/vize/pkl/VizeConfig.pkl"
+
+formatter {
+  singleQuote =
+}
+"#,
+    )
+    .unwrap();
+    std::fs::write(
+        dir.path().join("vize.config.json"),
+        r#"{ "formatter": { "singleQuote": true } }"#,
+    )
+    .unwrap();
+
+    let loaded = load_config_with_source(Some(dir.path()));
+
+    assert_eq!(loaded.source_path.as_deref(), Some(config_path.as_path()));
+    assert!(
+        !loaded.config.formatter.single_quote,
+        "invalid higher-priority pkl config must not silently fall back to json",
+    );
 }


### PR DESCRIPTION
## Summary
- stop directory config discovery from silently falling through to JSON when a higher-priority PKL config exists but fails evaluation
- keep fallback behavior for missing/unstartable PKL runtimes so JSON-only users are not blocked
- add a regression test covering invalid PKL plus lower-priority JSON

## Verification
- cargo fmt --all
- cargo test -p vize_carton invalid_pkl_config_does_not_fall_back_to_json -- --nocapture
- cargo test -p vize_carton
- cargo clippy -p vize_carton --all-targets -- -D warnings
- git diff --check