### PR TITLE
chore(build): make root command lookup side-effect free

### DIFF
--- a/tests/tooling/task-shell.test.ts
+++ b/tests/tooling/task-shell.test.ts
@@ -1,6 +1,10 @@
 import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { test } from "node:test";
 
+import { commandExists } from "../../tools/vite-plus/root-build-task-plugin.ts";
 import {
   getTaskShellLocaleAssignments,
   normalizeTaskShellLocale,
@@ -14,6 +18,7 @@ import {
 } from "../../tools/vite-plus/task-commands.ts";
 import { checkTasks } from "../../tools/vite-plus/tasks/check.ts";
 import { releaseTasks } from "../../tools/vite-plus/tasks/release.ts";
+import { writeFakeCommand } from "./support/fake-command.ts";
 
 test("macOS task shells fall back from C.UTF-8 to an installed UTF-8 locale", () => {
   assert.deepEqual(
@@ -135,4 +140,27 @@ test("normalizing a macOS C.UTF-8 environment updates child-process locale varia
   assert.equal(env.LC_ALL, "en_US.UTF-8");
   assert.equal(env.LC_CTYPE, "en_US.UTF-8");
   assert.equal(env.LANG, "en_US.UTF-8");
+});
+
+test("root build command lookup checks PATH without executing the command", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "vize-command-lookup-"));
+  const binDir = path.join(dir, "bin");
+  const sentinelPath = path.join(dir, "sentinel");
+  fs.mkdirSync(binDir);
+
+  try {
+    writeFakeCommand(
+      binDir,
+      "side-effect-tool",
+      `require("node:fs").writeFileSync(${JSON.stringify(sentinelPath)}, "ran");`,
+    );
+
+    assert.equal(commandExists("side-effect-tool", { PATH: binDir }), true);
+    assert.equal(fs.existsSync(sentinelPath), false);
+    assert.equal(commandExists("missing-tool", { PATH: binDir }), false);
+    assert.equal(commandExists(`side-effect-tool; touch ${sentinelPath}`, { PATH: binDir }), false);
+    assert.equal(fs.existsSync(sentinelPath), false);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
 });

--- a/tools/vite-plus/root-build-task-plugin.ts
+++ b/tools/vite-plus/root-build-task-plugin.ts
@@ -1,8 +1,60 @@
-import { execFileSync, spawnSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
 import type { Plugin } from "vite";
 
-const commandExists = (command: string) =>
-  spawnSync(command, ["--version"], { stdio: "ignore" }).status === 0;
+const pathDelimiterForPlatform = (platform: NodeJS.Platform) => (platform === "win32" ? ";" : ":");
+
+const pathDirectoriesForEnv = (env: NodeJS.ProcessEnv, platform: NodeJS.Platform) =>
+  (env.PATH ?? "")
+    .split(pathDelimiterForPlatform(platform))
+    .filter((directory, index, directories) => directory !== "" || directories.length > 1)
+    .map((directory) => (directory === "" ? "." : directory));
+
+const commandExtensionsForPlatform = (
+  command: string,
+  env: NodeJS.ProcessEnv,
+  platform: NodeJS.Platform,
+) => {
+  if (platform !== "win32" || path.extname(command) !== "") {
+    return [""];
+  }
+
+  return (env.PATHEXT ?? ".COM;.EXE;.BAT;.CMD")
+    .split(";")
+    .map((extension) => extension.trim())
+    .filter(Boolean);
+};
+
+const isExecutableFile = (candidate: string, platform: NodeJS.Platform) => {
+  try {
+    const stat = fs.statSync(candidate);
+    if (!stat.isFile()) return false;
+    if (platform === "win32") return true;
+    fs.accessSync(candidate, fs.constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+export const commandExists = (
+  command: string,
+  env: NodeJS.ProcessEnv = process.env,
+  platform: NodeJS.Platform = process.platform,
+) => {
+  const directories = /[/\\]/.test(command) ? [""] : pathDirectoriesForEnv(env, platform);
+  const extensions = commandExtensionsForPlatform(command, env, platform);
+
+  return directories.some((directory) =>
+    extensions.some((extension) =>
+      isExecutableFile(
+        directory === "" ? `${command}${extension}` : path.join(directory, command + extension),
+        platform,
+      ),
+    ),
+  );
+};
 
 /**
  * Builds the root library artifact by delegating to the workspace build task.


### PR DESCRIPTION
## Summary
- replace the root build helper's command availability probe with PATH/executable checks instead of running `--version`
- preserve Windows PATHEXT handling and direct path lookup behavior
- add a regression test proving lookup does not execute candidate commands or shell-looking input

## Verification
- vp fmt --write tools/vite-plus/root-build-task-plugin.ts tests/tooling/task-shell.test.ts
- node --test tests/tooling/task-shell.test.ts
- vp check tools/vite-plus/root-build-task-plugin.ts tests/tooling/task-shell.test.ts
- git diff --check