### PR TITLE
chore(release): validate changelog arguments

### DIFF
--- a/tests/tooling/release-changelog.test.ts
+++ b/tests/tooling/release-changelog.test.ts
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { buildGitCliffArgs } from "../../tools/release/regenerate-changelog.mjs";
+
+test("changelog regeneration builds git-cliff args from supported flags", () => {
+  assert.deepEqual(buildGitCliffArgs([]), ["--config", "cliff.toml", "--output", "CHANGELOG.md"]);
+  assert.deepEqual(buildGitCliffArgs(["--unreleased", "--latest"]), [
+    "--config",
+    "cliff.toml",
+    "--output",
+    "CHANGELOG.md",
+    "--unreleased",
+    "--latest",
+  ]);
+  assert.deepEqual(buildGitCliffArgs(["--tag", "v1.2.3"]), [
+    "--config",
+    "cliff.toml",
+    "--output",
+    "CHANGELOG.md",
+    "--tag",
+    "v1.2.3",
+  ]);
+});
+
+test("changelog regeneration validates tag and unknown arguments before running git-cliff", () => {
+  assert.throws(() => buildGitCliffArgs(["--tag"]), /Missing value for --tag/);
+  assert.throws(() => buildGitCliffArgs(["--tag", "--latest"]), /Missing value for --tag/);
+  assert.throws(() => buildGitCliffArgs(["--bogus"]), /Unknown argument: --bogus/);
+});

--- a/tools/release/regenerate-changelog.mjs
+++ b/tools/release/regenerate-changelog.mjs
@@ -21,7 +21,8 @@ import { promisify } from "node:util";
 const execFileP = promisify(execFile);
 
 const GIT_CLIFF_VERSION = "2.6.1";
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const scriptPath = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(scriptPath);
 const repoRoot = path.resolve(__dirname, "../..");
 
 function resolveAsset() {
@@ -98,17 +99,38 @@ async function ensureGitCliff() {
   return bin;
 }
 
+export function buildGitCliffArgs(argv) {
+  const args = ["--config", "cliff.toml", "--output", "CHANGELOG.md"];
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--unreleased") {
+      args.push("--unreleased");
+      continue;
+    }
+    if (arg === "--latest") {
+      args.push("--latest");
+      continue;
+    }
+    if (arg === "--tag") {
+      const tag = argv[i + 1];
+      if (tag == null || tag === "" || tag.startsWith("--")) {
+        throw new Error("Missing value for --tag");
+      }
+      args.push("--tag", tag);
+      i += 1;
+      continue;
+    }
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  return args;
+}
+
 async function main() {
+  const args = buildGitCliffArgs(process.argv.slice(2));
   await mkdir(path.dirname(path.join(repoRoot, "CHANGELOG.md")), { recursive: true });
   const cliffBin = await ensureGitCliff();
-
-  const args = ["--config", "cliff.toml", "--output", "CHANGELOG.md"];
-  if (process.argv.includes("--unreleased")) args.push("--unreleased");
-  if (process.argv.includes("--latest")) args.push("--latest");
-  if (process.argv.includes("--tag")) {
-    const i = process.argv.indexOf("--tag");
-    args.push("--tag", process.argv[i + 1]);
-  }
 
   const result = spawnSync(cliffBin, args, { cwd: repoRoot, stdio: "inherit" });
   if (result.status !== 0) {
@@ -121,7 +143,9 @@ async function main() {
   }
 }
 
-main().catch((error) => {
-  console.error(error);
-  process.exit(1);
-});
+if (process.argv[1] != null && path.resolve(process.argv[1]) === scriptPath) {
+  main().catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Summary
- parse changelog regeneration flags before probing or downloading git-cliff
- fail fast on `--tag` without a value and on unknown flags
- add unit coverage for supported flags and validation errors

## Verification
- vp fmt --write tools/release/regenerate-changelog.mjs tests/tooling/release-changelog.test.ts
- node --test tests/tooling/release-changelog.test.ts
- vp check tools/release/regenerate-changelog.mjs tests/tooling/release-changelog.test.ts
- git diff --check