### PR TITLE
fix: honor linter rules from shared config

### DIFF
--- a/crates/vize/src/commands/lint.rs
+++ b/crates/vize/src/commands/lint.rs
@@ -119,6 +119,15 @@ pub fn run(args: LintArgs) {
         .as_deref()
         .and_then(Path::parent)
         .unwrap_or(cwd.as_path());
+    let linter_config = if args.no_config {
+        crate::config::LinterConfig::default()
+    } else {
+        crate::config::load_linter_config(args.config.as_deref())
+    };
+    if !linter_config.enabled {
+        eprintln!("[vize] Skipping lint because linter.enabled is false in vize.config.");
+        return;
+    }
     let configured_corsa_path = loaded_config
         .config
         .type_checker
@@ -140,8 +149,14 @@ pub fn run(args: LintArgs) {
         "short" => HelpLevel::Short,
         _ => HelpLevel::Full,
     };
-    let preset = LintPreset::parse(&args.preset).unwrap_or_default();
-    let mut linter = Linter::with_preset(preset).with_help_level(help_level);
+    let preset_name = linter_config
+        .preset
+        .as_deref()
+        .unwrap_or(args.preset.as_str());
+    let preset = LintPreset::parse(preset_name).unwrap_or_default();
+    let mut linter = Linter::with_preset(preset)
+        .with_disabled_rules(linter_config.disabled_rules())
+        .with_help_level(help_level);
     #[cfg(not(target_arch = "wasm32"))]
     {
         linter = linter.with_corsa_path(configured_corsa_path);

--- a/crates/vize_carton/src/config.rs
+++ b/crates/vize_carton/src/config.rs
@@ -3,9 +3,9 @@
 mod loader;
 mod model;
 
-pub use loader::{LoadedConfig, load_config, load_config_with_source};
+pub use loader::{LoadedConfig, load_config, load_config_with_source, load_linter_config};
 pub use model::{
     ArrowParens, AttributeSortOrder, EndOfLine, FormatterConfig, GlobalTypeDeclaration,
-    GlobalTypesConfig, LanguageServerConfig, LspConfig, QuoteProps, TrailingComma,
-    TypeCheckerConfig, VizeConfig,
+    GlobalTypesConfig, LanguageServerConfig, LintRuleSeverity, LinterConfig, LspConfig, QuoteProps,
+    TrailingComma, TypeCheckerConfig, VizeConfig,
 };

--- a/crates/vize_carton/src/config/loader.rs
+++ b/crates/vize_carton/src/config/loader.rs
@@ -1,12 +1,22 @@
 //! Config loading helpers.
 
-use std::path::{Path, PathBuf};
+use std::{
+    io::{Error as IoError, ErrorKind},
+    path::{Path, PathBuf},
+    process::Command,
+};
 
 use pklrust::{Error as PklError, EvaluatorManager, EvaluatorOptions, ModuleSource};
 
-use super::model::{RawVizeConfig, VizeConfig};
+use super::model::{LinterConfig, RawVizeConfig, VizeConfig};
 
-const CONFIG_FILE_NAMES: [&str; 2] = ["vize.config.pkl", "vize.config.json"];
+const CONFIG_FILE_NAMES: [&str; 5] = [
+    "vize.config.pkl",
+    "vize.config.ts",
+    "vize.config.js",
+    "vize.config.mjs",
+    "vize.config.json",
+];
 
 /// Loaded config and its source path.
 #[derive(Debug, Clone)]
@@ -62,6 +72,36 @@ pub fn load_config_with_source(path: Option<&Path>) -> LoadedConfig {
     }
 }
 
+/// Load linter-specific configuration from a directory or file path.
+pub fn load_linter_config(path: Option<&Path>) -> LinterConfig {
+    let base = path
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| std::env::current_dir().unwrap_or_default());
+
+    if let Some(file_path) = resolve_file_path(&base) {
+        return parse_raw_config_file(&file_path)
+            .map(|config| config.linter)
+            .unwrap_or_default();
+    }
+
+    let Some(dir_path) = resolve_dir_path(&base) else {
+        return LinterConfig::default();
+    };
+
+    for file_name in CONFIG_FILE_NAMES {
+        let candidate = dir_path.join(file_name);
+        if !candidate.exists() {
+            continue;
+        }
+
+        if let Some(config) = try_parse_raw_candidate(&candidate) {
+            return config.linter;
+        }
+    }
+
+    LinterConfig::default()
+}
+
 fn resolve_file_path(base: &Path) -> Option<PathBuf> {
     if base.is_file() {
         Some(base.to_path_buf())
@@ -83,7 +123,11 @@ fn resolve_dir_path(base: &Path) -> Option<PathBuf> {
 }
 
 fn try_parse_candidate(path: &Path) -> Option<VizeConfig> {
-    match parse_config_file(path) {
+    try_parse_raw_candidate(path).map(Into::into)
+}
+
+fn try_parse_raw_candidate(path: &Path) -> Option<RawVizeConfig> {
+    match parse_raw_config_file(path) {
         Ok(config) => Some(config),
         Err(error) => {
             let should_try_next = should_try_next_config(path, error.as_ref());
@@ -95,7 +139,7 @@ fn try_parse_candidate(path: &Path) -> Option<VizeConfig> {
             if should_try_next {
                 None
             } else {
-                Some(VizeConfig::default())
+                Some(RawVizeConfig::default())
             }
         }
     }
@@ -112,19 +156,55 @@ fn should_try_next_config(path: &Path, error: &(dyn std::error::Error + 'static)
 }
 
 fn parse_config_file(path: &Path) -> Result<VizeConfig, Box<dyn std::error::Error>> {
+    Ok(parse_raw_config_file(path)?.into())
+}
+
+fn parse_raw_config_file(path: &Path) -> Result<RawVizeConfig, Box<dyn std::error::Error>> {
     let config = match path.extension().and_then(|ext| ext.to_str()) {
         Some("pkl") => parse_pkl_config(path)?,
+        Some("ts" | "js" | "mjs") => parse_js_config(path)?,
         Some("json") => {
             let content = std::fs::read_to_string(path)?;
-            serde_json::from_str::<RawVizeConfig>(&content)?.into()
+            serde_json::from_str::<RawVizeConfig>(&content)?
         }
-        _ => return Ok(VizeConfig::default()),
+        _ => return Ok(RawVizeConfig::default()),
     };
 
     Ok(config)
 }
 
-fn parse_pkl_config(path: &Path) -> Result<VizeConfig, Box<dyn std::error::Error>> {
+fn parse_js_config(path: &Path) -> Result<RawVizeConfig, Box<dyn std::error::Error>> {
+    let script = r#"
+import { pathToFileURL } from "node:url";
+
+const configPath = process.argv[1];
+const module = await import(pathToFileURL(configPath).href);
+const exported = module.default ?? module;
+const config = typeof exported === "function"
+  ? await exported({ mode: "development", command: "serve" })
+  : exported;
+process.stdout.write(JSON.stringify(config ?? {}));
+"#;
+    let output = Command::new("node")
+        .arg("--input-type=module")
+        .arg("-e")
+        .arg(script)
+        .arg(path)
+        .current_dir(path.parent().unwrap_or_else(|| Path::new(".")))
+        .output()?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(Box::new(IoError::new(
+            ErrorKind::InvalidData,
+            crate::cstr!("node failed to load config: {}", stderr.trim()).to_string(),
+        )));
+    }
+
+    Ok(serde_json::from_slice::<RawVizeConfig>(&output.stdout)?)
+}
+
+fn parse_pkl_config(path: &Path) -> Result<RawVizeConfig, Box<dyn std::error::Error>> {
     let mut last_process_error = None;
 
     for command in pkl_command_candidates(path) {
@@ -147,7 +227,7 @@ fn parse_pkl_config(path: &Path) -> Result<VizeConfig, Box<dyn std::error::Error
         }))
 }
 
-fn parse_pkl_config_with_command(path: &Path, command: &Path) -> Result<VizeConfig, PklError> {
+fn parse_pkl_config_with_command(path: &Path, command: &Path) -> Result<RawVizeConfig, PklError> {
     let command = command.to_string_lossy();
     let mut manager = EvaluatorManager::with_command(command.as_ref())?;
     let options = pkl_evaluator_options(path);
@@ -156,7 +236,7 @@ fn parse_pkl_config_with_command(path: &Path, command: &Path) -> Result<VizeConf
         manager.evaluate_module_typed::<RawVizeConfig>(&evaluator, ModuleSource::file(path));
     let _ = manager.close_evaluator(&evaluator);
 
-    result.map(Into::into)
+    result
 }
 
 fn pkl_evaluator_options(path: &Path) -> EvaluatorOptions {
@@ -213,7 +293,7 @@ fn local_pkl_candidates(base: &Path) -> [PathBuf; 6] {
 }
 #[cfg(test)]
 mod tests {
-    use super::load_config_with_source;
+    use super::{load_config_with_source, load_linter_config};
 
     #[test]
     fn load_config_uses_explicit_file_path() {
@@ -224,5 +304,30 @@ mod tests {
         let loaded = load_config_with_source(Some(&config_path));
         assert_eq!(loaded.source_path.as_deref(), Some(config_path.as_path()));
         assert!(loaded.config.formatter.single_quote);
+    }
+
+    #[test]
+    fn load_config_uses_typescript_config() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("vize.config.ts");
+        std::fs::write(
+            &config_path,
+            r#"
+export default {
+  linter: {
+    rules: {
+      "vue/prop-name-casing": "off",
+    },
+  },
+}
+"#,
+        )
+        .unwrap();
+
+        let loaded = load_config_with_source(Some(dir.path()));
+        let linter = load_linter_config(Some(dir.path()));
+
+        assert_eq!(loaded.source_path.as_deref(), Some(config_path.as_path()));
+        assert_eq!(linter.disabled_rules(), ["vue/prop-name-casing"]);
     }
 }

--- a/crates/vize_carton/src/config/model.rs
+++ b/crates/vize_carton/src/config/model.rs
@@ -3,6 +3,7 @@
 mod formatter;
 mod global_types;
 mod language_server;
+mod linter;
 mod type_checker;
 
 use serde::{Deserialize, Serialize};
@@ -14,6 +15,8 @@ pub use formatter::{
 };
 pub use global_types::{GlobalTypeDeclaration, GlobalTypesConfig, RawGlobalTypesConfig};
 pub use language_server::{LanguageServerConfig, LspConfig};
+#[allow(unused_imports)]
+pub use linter::{LintRuleSeverity, LinterConfig};
 pub use type_checker::TypeCheckerConfig;
 
 /// Effective shared configuration.
@@ -53,6 +56,7 @@ pub(crate) struct RawVizeConfig {
     #[serde(rename = "$schema")]
     pub schema: Option<String>,
     pub formatter: FormatterConfig,
+    pub linter: LinterConfig,
     #[serde(rename = "typeChecker")]
     pub type_checker: TypeCheckerConfig,
     #[serde(rename = "languageServer")]

--- a/crates/vize_carton/src/config/model/linter.rs
+++ b/crates/vize_carton/src/config/model/linter.rs
@@ -1,0 +1,52 @@
+//! Linter config model.
+
+use serde::{Deserialize, Serialize};
+
+use crate::{FxHashMap, String};
+
+/// Per-rule lint severity.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum LintRuleSeverity {
+    Off,
+    Warn,
+    Error,
+}
+
+/// Linter settings shared by CLI and IDE linting.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default, rename_all = "camelCase")]
+pub struct LinterConfig {
+    pub enabled: bool,
+    pub preset: Option<String>,
+    pub rules: FxHashMap<String, LintRuleSeverity>,
+}
+
+impl LinterConfig {
+    /// Returns true when the config matches the built-in defaults.
+    pub fn is_default(&self) -> bool {
+        self == &Self::default()
+    }
+
+    /// Rule names explicitly disabled by config.
+    pub fn disabled_rules(&self) -> Vec<String> {
+        let mut rules = self
+            .rules
+            .iter()
+            .filter(|(_, severity)| matches!(severity, LintRuleSeverity::Off))
+            .map(|(rule, _)| rule.clone())
+            .collect::<Vec<_>>();
+        rules.sort();
+        rules
+    }
+}
+
+impl Default for LinterConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            preset: None,
+            rules: FxHashMap::default(),
+        }
+    }
+}

--- a/crates/vize_patina/src/context.rs
+++ b/crates/vize_patina/src/context.rs
@@ -53,6 +53,8 @@ pub struct LintContext<'a> {
     line_offsets: Vec<u32>,
     /// Optional set of enabled rule names (if None, all rules are enabled).
     enabled_rules: Option<FxHashSet<String>>,
+    /// Rule names disabled by host configuration.
+    config_disabled_rules: FxHashSet<String>,
     /// Optional semantic analysis from croquis.
     pub(crate) analysis: Option<&'a Croquis>,
     /// Optional parsed SFC descriptor shared by SFC-level rules.
@@ -104,6 +106,7 @@ impl<'a> LintContext<'a> {
             disabled_rules: FxHashMap::default(),
             line_offsets: Self::compute_line_offsets(source),
             enabled_rules: None,
+            config_disabled_rules: FxHashSet::default(),
             analysis: None,
             sfc_descriptor: None,
             analysis_excluded_rules: None,
@@ -137,6 +140,7 @@ impl<'a> LintContext<'a> {
             disabled_rules: FxHashMap::default(),
             line_offsets: Self::compute_line_offsets(source),
             enabled_rules: None,
+            config_disabled_rules: FxHashSet::default(),
             analysis: Some(analysis),
             sfc_descriptor: None,
             analysis_excluded_rules: None,
@@ -228,9 +232,18 @@ impl<'a> LintContext<'a> {
         self.enabled_rules = enabled;
     }
 
+    /// Set globally disabled rules from host configuration.
+    #[inline]
+    pub fn set_config_disabled_rules(&mut self, disabled: FxHashSet<String>) {
+        self.config_disabled_rules = disabled;
+    }
+
     /// Check if a rule is enabled.
     #[inline]
     pub fn is_rule_enabled(&self, rule_name: &str) -> bool {
+        if self.config_disabled_rules.contains(rule_name) {
+            return false;
+        }
         match &self.enabled_rules {
             Some(set) => set.contains(rule_name),
             None => true,

--- a/crates/vize_patina/src/linter/config.rs
+++ b/crates/vize_patina/src/linter/config.rs
@@ -59,6 +59,8 @@ pub struct Linter {
     pub(crate) locale: Locale,
     /// Optional set of enabled rule names (if None, all rules are enabled).
     pub(crate) enabled_rules: Option<FxHashSet<String>>,
+    /// Rule names disabled by host configuration.
+    pub(crate) disabled_rules: FxHashSet<String>,
     /// Help display level.
     pub(crate) help_level: HelpLevel,
     /// Built-in script rules enabled for this linter.
@@ -85,6 +87,7 @@ impl Linter {
             initial_capacity: Self::DEFAULT_INITIAL_CAPACITY,
             locale: Locale::default(),
             enabled_rules: None,
+            disabled_rules: FxHashSet::default(),
             help_level: HelpLevel::default(),
             script_rules: builtin_script_rule_names(preset),
             #[cfg(not(target_arch = "wasm32"))]
@@ -103,6 +106,7 @@ impl Linter {
             initial_capacity: Self::DEFAULT_INITIAL_CAPACITY,
             locale: Locale::default(),
             enabled_rules: None,
+            disabled_rules: FxHashSet::default(),
             help_level: HelpLevel::default(),
             script_rules: builtin_script_rule_names(preset),
             #[cfg(not(target_arch = "wasm32"))]
@@ -121,6 +125,7 @@ impl Linter {
             initial_capacity: Self::DEFAULT_INITIAL_CAPACITY,
             locale: Locale::default(),
             enabled_rules: None,
+            disabled_rules: FxHashSet::default(),
             help_level: HelpLevel::default(),
             script_rules: &[],
             #[cfg(not(target_arch = "wasm32"))]
@@ -161,6 +166,13 @@ impl Linter {
         self
     }
 
+    /// Disable selected rules while preserving the active preset.
+    #[inline]
+    pub fn with_disabled_rules(mut self, rules: Vec<String>) -> Self {
+        self.disabled_rules = rules.into_iter().collect();
+        self
+    }
+
     /// Register an extra rule if the active preset did not already include it.
     #[inline]
     pub fn with_rule(mut self, rule: Box<dyn crate::rule::Rule>) -> Self {
@@ -195,6 +207,9 @@ impl Linter {
     /// Check if a rule is enabled.
     #[inline]
     pub fn is_rule_enabled(&self, rule_name: &str) -> bool {
+        if self.disabled_rules.contains(rule_name) {
+            return false;
+        }
         match &self.enabled_rules {
             Some(set) => set.contains(rule_name),
             None => true,

--- a/crates/vize_patina/src/linter/engine.rs
+++ b/crates/vize_patina/src/linter/engine.rs
@@ -172,6 +172,7 @@ impl Linter {
     ) -> LintResult {
         let mut ctx = LintContext::with_locale(allocator, source, filename, self.locale);
         ctx.set_enabled_rules(self.enabled_rules.clone());
+        ctx.set_config_disabled_rules(self.disabled_rules.clone());
         ctx.set_help_level(self.help_level);
         #[cfg(not(target_arch = "wasm32"))]
         #[cfg(not(target_arch = "wasm32"))]

--- a/docs/content/guide/cli.md
+++ b/docs/content/guide/cli.md
@@ -33,13 +33,12 @@ cargo install --path crates/vize --force --locked
 
 ## Rust CLI vs npm CLI
 
-| Need                                                                   | Recommended entry point                  |
-| ---------------------------------------------------------------------- | ---------------------------------------- |
-| Package scripts for build, format, lint, check, ready, and upgrade     | `vp exec vize ...` from the npm package  |
-| Project-backed type checking across `.vue`, `.ts`, `.tsx`, and `.d.ts` | Rust `vize check`                        |
-| LSP, IDE setup, `check-server`, and profiling artifacts                | Rust `vize` binary                       |
-| Shared Vite plugin and npm CLI settings                                | `vize.config.ts` through the npm package |
-| Rust command-native settings                                           | `vize.config.pkl` or `vize.config.json`  |
+| Need                                                                   | Recommended entry point                 |
+| ---------------------------------------------------------------------- | --------------------------------------- |
+| Package scripts for build, format, lint, check, ready, and upgrade     | `vp exec vize ...` from the npm package |
+| Project-backed type checking across `.vue`, `.ts`, `.tsx`, and `.d.ts` | Rust `vize check`                       |
+| LSP, IDE setup, `check-server`, and profiling artifacts                | Rust `vize` binary                      |
+| Shared Vite plugin, npm CLI, and Rust CLI settings                     | `vize.config.*`                         |
 
 ## Commands
 

--- a/docs/content/guide/configuration.md
+++ b/docs/content/guide/configuration.md
@@ -4,8 +4,7 @@ title: Configuration
 
 # Configuration
 
-Vize uses `vize.config.*` for shared npm CLI and Vite plugin settings. Some Rust CLI commands also
-read config directly, but their supported file formats and field names are currently narrower.
+Vize uses `vize.config.*` for shared npm CLI, Vite plugin, and Rust CLI settings.
 
 ## Config Files
 
@@ -17,8 +16,8 @@ The npm CLI and `@vizejs/vite-plugin` load these files from the project root:
 - `vize.config.pkl`
 - `vize.config.json`
 
-The Rust CLI currently reads `vize.config.pkl` first and then `vize.config.json` for command-native
-settings such as `check`, `lsp`, and `fmt`.
+The Rust CLI reads the same config file names in the order above for command-native settings such as
+`check`, `lint`, `lsp`, and `fmt`.
 
 ## TypeScript Config
 


### PR DESCRIPTION
## Summary
- load Rust CLI config from vize.config.ts/js/mjs in addition to pkl/json
- model linter.enabled, linter.preset, and rule severities from shared config
- apply config-disabled lint rules and refresh CLI/config docs

Fixes #564.
Backlink: https://github.com/ushironoko/vize-config-repro

Thanks @ushironoko for the focused repro.

## Verification
- cargo test -p vize_carton config::loader::tests::load_config_uses_typescript_config --no-fail-fast
- cargo check -p vize_carton -p vize_patina -p vize_canon -p vize
- /tmp/vize-config-fixes/target/debug/vize lint 'src/**/*.vue' in ushironoko/vize-config-repro/apps/app