### PR TITLE
fix: honor check toggles in virtual TS

### DIFF
--- a/crates/vize/src/commands/check/runner.rs
+++ b/crates/vize/src/commands/check/runner.rs
@@ -136,6 +136,11 @@ pub(crate) fn run_direct(args: &CheckArgs) {
             std::process::exit(1);
         }
     };
+    checker.set_virtual_ts_checks(
+        config.type_checker.check_props && !args.no_check_props,
+        config.type_checker.check_template_bindings && !args.no_check_template_bindings,
+        config.type_checker.check_emits && !args.no_check_emits,
+    );
 
     if let Err(error) = checker.scan_paths(&files) {
         eprintln!("\x1b[31mError:\x1b[0m {}", error);

--- a/crates/vize_canon/src/batch/type_checker.rs
+++ b/crates/vize_canon/src/batch/type_checker.rs
@@ -6,7 +6,7 @@ use super::Diagnostic;
 use super::error::{CorsaError, CorsaResult};
 use super::executor::CorsaExecutor;
 use super::virtual_project::VirtualProject;
-use crate::virtual_ts::VirtualTsOptions;
+use crate::virtual_ts::{VirtualTsCheckOptions, VirtualTsOptions};
 use vize_carton::String;
 
 /// Result of type checking.
@@ -140,6 +140,21 @@ impl BatchTypeChecker {
             executor,
             scanned: false,
         })
+    }
+
+    /// Configure which virtual TypeScript checks are generated for Vue files.
+    pub fn set_virtual_ts_checks(
+        &mut self,
+        check_props: bool,
+        check_template_bindings: bool,
+        check_emits: bool,
+    ) {
+        self.project
+            .set_virtual_ts_check_options(VirtualTsCheckOptions {
+                check_props,
+                check_template_bindings,
+                check_emits,
+            });
     }
 
     /// Scan an explicit set of project files.

--- a/crates/vize_canon/src/batch/virtual_project.rs
+++ b/crates/vize_canon/src/batch/virtual_project.rs
@@ -12,7 +12,9 @@ use super::runtime_deps::materialize_runtime_dependencies;
 use super::source_map::{CompositeSourceMap, SfcBlockRange, SfcSourceMap};
 use super::{Diagnostic, SfcBlockType};
 use crate::script_parse::collect_script_parse_diagnostics;
-use crate::virtual_ts::{VirtualTsOptions, generate_virtual_ts_with_offsets};
+use crate::virtual_ts::{
+    VirtualTsCheckOptions, VirtualTsOptions, generate_virtual_ts_with_offsets_and_checks,
+};
 use oxc_span::SourceType;
 use serde_json::{Map, Value};
 use vize_atelier_core::parser::parse;
@@ -77,6 +79,9 @@ pub struct VirtualProject {
     /// Global virtual TS options applied to every Vue file.
     virtual_ts_options: VirtualTsOptions,
 
+    /// Internal check generation settings applied to every Vue file.
+    virtual_ts_check_options: VirtualTsCheckOptions,
+
     /// Virtual files keyed by materialized path.
     virtual_files: FxHashMap<PathBuf, VirtualFile>,
 
@@ -103,6 +108,7 @@ impl VirtualProject {
             virtual_root,
             tsconfig_path: None,
             virtual_ts_options: VirtualTsOptions::default(),
+            virtual_ts_check_options: VirtualTsCheckOptions::default(),
             virtual_files: FxHashMap::default(),
             diagnostics: Vec::new(),
             rewriter: ImportRewriter::new(),
@@ -117,6 +123,10 @@ impl VirtualProject {
     /// Set the shared virtual TS options.
     pub fn set_virtual_ts_options(&mut self, options: VirtualTsOptions) {
         self.virtual_ts_options = options;
+    }
+
+    pub(crate) fn set_virtual_ts_check_options(&mut self, options: VirtualTsCheckOptions) {
+        self.virtual_ts_check_options = options;
     }
 
     /// Get the project root.
@@ -174,7 +184,13 @@ impl VirtualProject {
         effective_options.auto_import_stubs.clear();
         let generated = profile!(
             "canon.vue.virtual_ts",
-            generate_vue_virtual_ts(path, content, &descriptor, &effective_options)
+            generate_vue_virtual_ts(
+                path,
+                content,
+                &descriptor,
+                &effective_options,
+                self.virtual_ts_check_options,
+            )
         )?;
         let GeneratedVueFile {
             code,
@@ -576,6 +592,7 @@ fn generate_vue_virtual_ts(
     source: &str,
     descriptor: &SfcDescriptor,
     options: &VirtualTsOptions,
+    check_options: VirtualTsCheckOptions,
 ) -> CorsaResult<GeneratedVueFile> {
     let allocator = Bump::new();
     let mut diagnostics = Vec::new();
@@ -661,13 +678,14 @@ fn generate_vue_virtual_ts(
 
     let output = profile!(
         "canon.virtual_ts.generate",
-        generate_virtual_ts_with_offsets(
+        generate_virtual_ts_with_offsets_and_checks(
             &analysis.croquis,
             analysis.script_content_ref(),
             template_ast.as_ref(),
             analysis.script_offset,
             template_offset,
             options,
+            check_options,
         )
     );
 

--- a/crates/vize_canon/src/virtual_ts.rs
+++ b/crates/vize_canon/src/virtual_ts.rs
@@ -14,14 +14,17 @@ mod props;
 mod scope;
 mod types;
 
+pub(crate) use generator::generate_virtual_ts_with_offsets_and_checks;
 pub use generator::{generate_virtual_ts, generate_virtual_ts_with_offsets};
+pub(crate) use types::VirtualTsCheckOptions;
 pub use types::{TemplateGlobal, VirtualTsOptions, VirtualTsOutput, VizeMapping};
 
 #[cfg(test)]
 mod tests {
     use super::helpers::{VUE_SETUP_HELPERS, generate_template_context, get_dom_event_type};
     use super::{
-        TemplateGlobal, VirtualTsOptions, generate_virtual_ts, generate_virtual_ts_with_offsets,
+        TemplateGlobal, VirtualTsCheckOptions, VirtualTsOptions, generate_virtual_ts,
+        generate_virtual_ts_with_offsets, generate_virtual_ts_with_offsets_and_checks,
     };
 
     fn assert_virtual_ts_snapshot(name: &str, value: &str) {
@@ -131,6 +134,71 @@ const count = 1
                 .code
                 .contains("type __AutoCard_Props_0 = typeof AutoCard")
         );
+    }
+
+    #[test]
+    fn test_check_props_option_disables_component_prop_checks() {
+        use vize_croquis::{Analyzer, AnalyzerOptions};
+
+        let script = r#"import Child from './Child.vue'
+const wrong = 'not a number'
+"#;
+        let template = r#"<Child :count="wrong" />"#;
+
+        let allocator = vize_carton::Bump::new();
+        let (root, _) = vize_armature::parse(&allocator, template);
+
+        let mut analyzer = Analyzer::with_options(AnalyzerOptions::full());
+        analyzer.analyze_script_setup(script);
+        analyzer.analyze_template(&root);
+        let summary = analyzer.finish();
+
+        let output = generate_virtual_ts_with_offsets_and_checks(
+            &summary,
+            Some(script),
+            Some(&root),
+            0,
+            0,
+            &VirtualTsOptions::default(),
+            VirtualTsCheckOptions {
+                check_props: false,
+                ..Default::default()
+            },
+        );
+
+        assert!(!output.code.contains("__vize_prop_check"));
+        assert!(!output.code.contains("type __Child_Props_0"));
+    }
+
+    #[test]
+    fn test_check_template_bindings_option_disables_template_expressions() {
+        use vize_croquis::{Analyzer, AnalyzerOptions};
+
+        let script = "const message = 'hello'\n";
+        let template = r#"<div>{{ message }}</div>"#;
+
+        let allocator = vize_carton::Bump::new();
+        let (root, _) = vize_armature::parse(&allocator, template);
+
+        let mut analyzer = Analyzer::with_options(AnalyzerOptions::full());
+        analyzer.analyze_script_setup(script);
+        analyzer.analyze_template(&root);
+        let summary = analyzer.finish();
+
+        let output = generate_virtual_ts_with_offsets_and_checks(
+            &summary,
+            Some(script),
+            Some(&root),
+            0,
+            0,
+            &VirtualTsOptions::default(),
+            VirtualTsCheckOptions {
+                check_template_bindings: false,
+                ..Default::default()
+            },
+        );
+
+        assert!(!output.code.contains("void (message);"));
     }
 
     #[test]

--- a/crates/vize_canon/src/virtual_ts/generator.rs
+++ b/crates/vize_canon/src/virtual_ts/generator.rs
@@ -12,7 +12,7 @@ use super::{
     },
     props::{collect_template_prop_names, generate_props_type, generate_props_variables},
     scope::generate_scope_closures,
-    types::{VirtualTsOptions, VirtualTsOutput, VizeMapping},
+    types::{VirtualTsCheckOptions, VirtualTsOptions, VirtualTsOutput, VizeMapping},
 };
 use vize_carton::append;
 use vize_carton::cstr;
@@ -56,6 +56,26 @@ pub fn generate_virtual_ts_with_offsets(
     script_offset: u32,
     template_offset: u32,
     options: &VirtualTsOptions,
+) -> VirtualTsOutput {
+    generate_virtual_ts_with_offsets_and_checks(
+        summary,
+        script_content,
+        template_ast,
+        script_offset,
+        template_offset,
+        options,
+        VirtualTsCheckOptions::default(),
+    )
+}
+
+pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
+    summary: &Croquis,
+    script_content: Option<&str>,
+    template_ast: Option<&vize_relief::ast::RootNode<'_>>,
+    script_offset: u32,
+    template_offset: u32,
+    options: &VirtualTsOptions,
+    check_options: VirtualTsCheckOptions,
 ) -> VirtualTsOutput {
     let mut ts = String::default();
     let mut mappings: Vec<VizeMapping> = Vec::new();
@@ -368,16 +388,19 @@ pub fn generate_virtual_ts_with_offsets(
             );
 
             // Generate scope closures
-            profile!(
-                "canon.virtual_ts.generate_scope_closures",
-                generate_scope_closures(
-                    &mut ts,
-                    &mut mappings,
-                    summary,
-                    &template_prop_names,
-                    template_offset
-                )
-            );
+            if check_options.any_enabled() {
+                profile!(
+                    "canon.virtual_ts.generate_scope_closures",
+                    generate_scope_closures(
+                        &mut ts,
+                        &mut mappings,
+                        summary,
+                        &template_prop_names,
+                        template_offset,
+                        check_options,
+                    )
+                );
+            }
 
             // Declare unresolved components (auto-imported or built-in) as `any`.
             // Names known to be provided by ambient project declarations stay

--- a/crates/vize_canon/src/virtual_ts/scope.rs
+++ b/crates/vize_canon/src/virtual_ts/scope.rs
@@ -20,7 +20,7 @@ use super::{
         generated_text_range, get_dom_event_type, strip_as_assertion, to_camel_case,
         to_safe_identifier, to_safe_identifier_fragment,
     },
-    types::VizeMapping,
+    types::{VirtualTsCheckOptions, VizeMapping},
 };
 use vize_carton::append;
 use vize_carton::cstr;
@@ -32,6 +32,7 @@ pub(crate) struct ScopeGenContext<'a> {
     pub(crate) children_map: &'a FxHashMap<u32, Vec<ScopeId>>,
     pub(crate) template_prop_names: &'a FxHashSet<String>,
     pub(crate) template_offset: u32,
+    pub(crate) check_options: VirtualTsCheckOptions,
 }
 
 /// Context for recursive component prop checks inside v-for scopes.
@@ -60,6 +61,7 @@ pub(crate) fn generate_scope_closures(
     summary: &Croquis,
     template_prop_names: &FxHashSet<String>,
     template_offset: u32,
+    check_options: VirtualTsCheckOptions,
 ) {
     // Group expressions by scope_id
     let expressions_by_scope: FxHashMap<u32, Vec<_>> =
@@ -124,7 +126,9 @@ pub(crate) fn generate_scope_closures(
                 | ScopeKind::JsGlobalNode
                 | ScopeKind::VueGlobal
         ) {
-            if let Some(exprs) = expressions_by_scope.get(&scope_id) {
+            if let Some(exprs) = expressions_by_scope.get(&scope_id)
+                && check_options.check_template_bindings
+            {
                 for expr in exprs {
                     profile!(
                         "canon.virtual_ts.generate_expression",
@@ -148,6 +152,7 @@ pub(crate) fn generate_scope_closures(
             children_map: &children_map,
             template_prop_names,
             template_offset,
+            check_options,
         };
         profile!(
             "canon.virtual_ts.scope_node",
@@ -156,23 +161,27 @@ pub(crate) fn generate_scope_closures(
     }
 
     // Handle undefined references
-    profile!(
-        "canon.virtual_ts.undefined_refs",
-        generate_undefined_refs(ts, mappings, summary, template_offset)
-    );
+    if check_options.check_template_bindings {
+        profile!(
+            "canon.virtual_ts.undefined_refs",
+            generate_undefined_refs(ts, mappings, summary, template_offset)
+        );
+    }
 
     // Generate component props type checks (scope-aware)
-    profile!(
-        "canon.virtual_ts.component_props",
-        generate_component_props(
-            ts,
-            mappings,
-            summary,
-            &children_map,
-            template_prop_names,
-            template_offset
-        )
-    );
+    if check_options.check_props {
+        profile!(
+            "canon.virtual_ts.component_props",
+            generate_component_props(
+                ts,
+                mappings,
+                summary,
+                &children_map,
+                template_prop_names,
+                template_offset,
+            )
+        );
+    }
 }
 
 /// Handle undefined references from template.
@@ -448,7 +457,9 @@ fn generate_scope_node(
             }
 
             // Generate expressions in this scope
-            if let Some(exprs) = ctx.expressions_by_scope.get(&scope_id) {
+            if let Some(exprs) = ctx.expressions_by_scope.get(&scope_id)
+                && ctx.check_options.check_template_bindings
+            {
                 for expr in exprs {
                     profile!(
                         "canon.virtual_ts.generate_expression",
@@ -493,7 +504,9 @@ fn generate_scope_node(
                 }
             }
 
-            if let Some(exprs) = ctx.expressions_by_scope.get(&scope_id) {
+            if let Some(exprs) = ctx.expressions_by_scope.get(&scope_id)
+                && ctx.check_options.check_template_bindings
+            {
                 for expr in exprs {
                     profile!(
                         "canon.virtual_ts.generate_expression",
@@ -518,7 +531,7 @@ fn generate_scope_node(
             ts.push_str(indent);
             ts.push_str("};\n");
         }
-        ScopeData::EventHandler(data) => {
+        ScopeData::EventHandler(data) if ctx.check_options.check_emits => {
             append!(*ts, "\n{indent}// @{} handler\n", data.event_name);
 
             let safe_event_name = to_safe_identifier(data.event_name.as_str());
@@ -597,7 +610,9 @@ fn generate_scope_node(
             }
         }
         _ => {
-            if let Some(exprs) = ctx.expressions_by_scope.get(&scope_id) {
+            if let Some(exprs) = ctx.expressions_by_scope.get(&scope_id)
+                && ctx.check_options.check_template_bindings
+            {
                 for expr in exprs {
                     profile!(
                         "canon.virtual_ts.generate_expression",

--- a/crates/vize_canon/src/virtual_ts/types.rs
+++ b/crates/vize_canon/src/virtual_ts/types.rs
@@ -54,6 +54,29 @@ impl Default for VirtualTsOptions {
     }
 }
 
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct VirtualTsCheckOptions {
+    pub(crate) check_props: bool,
+    pub(crate) check_template_bindings: bool,
+    pub(crate) check_emits: bool,
+}
+
+impl VirtualTsCheckOptions {
+    pub(crate) fn any_enabled(self) -> bool {
+        self.check_props || self.check_template_bindings || self.check_emits
+    }
+}
+
+impl Default for VirtualTsCheckOptions {
+    fn default() -> Self {
+        Self {
+            check_props: true,
+            check_template_bindings: true,
+            check_emits: true,
+        }
+    }
+}
+
 /// Default plugin globals.
 /// Returns empty by default. Configure via `vize.config.pkl` `globalTypes`
 /// or `typeChecker.globalsFile`.


### PR DESCRIPTION
## Summary
- thread typeChecker/CLI check toggles into VirtualTsOptions
- suppress prop, emit, and template binding diagnostics when disabled
- cover disabled prop and template-binding generation with tests

Fixes #565.
Backlink: https://github.com/ushironoko/vize-config-repro

Thanks @ushironoko for the focused repro.

## Verification
- cargo test -p vize_canon test_check --no-fail-fast
- cargo check -p vize_carton -p vize_patina -p vize_canon -p vize
- /tmp/vize-config-fixes/target/debug/vize check 'src/**/*.vue' --tsconfig tsconfig.json --no-check-props --no-check-template-bindings in ushironoko/vize-config-repro/apps/app