### PR TITLE
fix: search workspace ancestors for Corsa

### DIFF
--- a/crates/vize_canon/src/lsp_client/paths.rs
+++ b/crates/vize_canon/src/lsp_client/paths.rs
@@ -46,10 +46,16 @@ pub(crate) fn corsa_search_roots(working_dir: Option<&Path>) -> Vec<PathBuf> {
 
     if let Some(working_dir) = working_dir {
         push_unique_root(&mut roots, working_dir.to_path_buf());
+        for ancestor in working_dir.ancestors().skip(1) {
+            push_unique_root(&mut roots, ancestor.to_path_buf());
+        }
     }
 
     if let Ok(current_dir) = std::env::current_dir() {
-        push_unique_root(&mut roots, current_dir);
+        push_unique_root(&mut roots, current_dir.clone());
+        for ancestor in current_dir.ancestors().skip(1) {
+            push_unique_root(&mut roots, ancestor.to_path_buf());
+        }
     }
 
     if let Some(workspace_root) = Path::new(env!("CARGO_MANIFEST_DIR"))

--- a/crates/vize_canon/src/lsp_client/tests.rs
+++ b/crates/vize_canon/src/lsp_client/tests.rs
@@ -1,6 +1,9 @@
 use super::{
     bootstrap::resolve_corsa_executable,
-    paths::{find_corsa_in_local_node_modules, find_corsa_in_search_roots, resolve_temp_dir_base},
+    paths::{
+        corsa_search_roots, find_corsa_in_local_node_modules, find_corsa_in_search_roots,
+        resolve_temp_dir_base,
+    },
     utils::convert_diagnostics,
 };
 use lsp_types::{Diagnostic, DiagnosticSeverity, NumberOrString, Position, Range};
@@ -197,6 +200,20 @@ fn resolves_corsa_from_secondary_search_root() {
         resolved,
         Some(fallback_cache.to_string_lossy().into_owned().into())
     );
+}
+
+#[test]
+fn search_roots_include_workspace_ancestors() {
+    let temp_dir = TempDir::new().unwrap();
+    let workspace_root = temp_dir.path().join("workspace");
+    let project_root = workspace_root.join("apps").join("app");
+
+    fs::create_dir_all(&project_root).unwrap();
+
+    let search_roots = corsa_search_roots(Some(&project_root));
+
+    assert!(search_roots.contains(&project_root));
+    assert!(search_roots.contains(&workspace_root));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- include the project root ancestors when searching for local Corsa/native-preview binaries
- keep current working directory ancestors in the search set
- add coverage for pnpm-style workspace ancestor lookup

Fixes #567.
Backlink: https://github.com/ushironoko/vize-config-repro

Thanks @ushironoko for the focused repro.

## Verification
- cargo test -p vize_canon search_roots_include_workspace_ancestors --no-fail-fast
- cargo check -p vize_carton -p vize_patina -p vize_canon -p vize
- /tmp/vize-config-fixes/target/debug/vize check 'src/**/*.vue' --tsconfig tsconfig.json --no-check-props --no-check-template-bindings in ushironoko/vize-config-repro/apps/app