### PR TITLE
perf: trim config and virtual ts overhead

### DIFF
--- a/bench/generate.mjs
+++ b/bench/generate.mjs
@@ -406,6 +406,22 @@ export default [
 writeFileSync(join(benchDir, "eslint.config.mjs"), eslintConfig);
 console.log("Generated eslint.config.mjs");
 
+// Generate vize.config.json so benchmark runs cover shared config loading.
+const vizeConfig = {
+  linter: {
+    rules: {
+      "vue/prop-name-casing": "off",
+    },
+  },
+  typeChecker: {
+    checkProps: true,
+    checkTemplateBindings: true,
+    checkEmits: true,
+  },
+};
+writeFileSync(join(benchDir, "vize.config.json"), `${JSON.stringify(vizeConfig, null, 2)}\n`);
+console.log("Generated vize.config.json");
+
 // Generate vite entry file for vite-plugin benchmark
 const viteEntryImports = [];
 const viteEntryComponents = [];

--- a/bench/lint.ts
+++ b/bench/lint.ts
@@ -143,7 +143,7 @@ async function runEslintMultiThread(): Promise<number> {
 // Run shell command, ignoring exit code (linter may exit non-zero on warnings)
 function execIgnoreExit(cmd: string): void {
   try {
-    execSync(cmd, { stdio: "ignore" });
+    execSync(cmd, { stdio: "ignore", cwd: INPUT_DIR });
   } catch {
     // ignore non-zero exit code
   }

--- a/crates/vize/src/commands/lint.rs
+++ b/crates/vize/src/commands/lint.rs
@@ -119,17 +119,13 @@ pub fn run(args: LintArgs) {
         .as_deref()
         .and_then(Path::parent)
         .unwrap_or(cwd.as_path());
-    let linter_config = if args.no_config {
-        crate::config::LinterConfig::default()
-    } else {
-        crate::config::load_linter_config(args.config.as_deref())
-    };
+    let config = loaded_config.config;
+    let linter_config = config.linter.clone();
     if !linter_config.enabled {
         eprintln!("[vize] Skipping lint because linter.enabled is false in vize.config.");
         return;
     }
-    let configured_corsa_path = loaded_config
-        .config
+    let configured_corsa_path = config
         .type_checker
         .runtime_path()
         .map(|path| resolve_lint_config_path(config_dir, path));

--- a/crates/vize_canon/src/virtual_ts/generator.rs
+++ b/crates/vize_canon/src/virtual_ts/generator.rs
@@ -177,23 +177,24 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
     // Collect imported names from all module-level import statements to handle
     // cases where plain <script> imports are not in summary.bindings (which
     // only holds <script setup> bindings when both blocks exist).
-    let imported_names: Vec<&str> = profile!("canon.virtual_ts.extract_imported_names", {
-        if let Some(script) = script_content {
-            summary
-                .import_statements
-                .iter()
-                .flat_map(|imp| {
-                    let text = script
-                        .get(imp.start as usize..imp.end as usize)
-                        .unwrap_or("");
-                    extract_import_names(text)
-                })
-                .collect()
-        } else {
-            Vec::new()
-        }
-    });
     if !options.auto_import_stubs.is_empty() {
+        let imported_names: FxHashSet<&str> = profile!(
+            "canon.virtual_ts.extract_imported_names",
+            if let Some(script) = script_content {
+                summary
+                    .import_statements
+                    .iter()
+                    .flat_map(|imp| {
+                        let text = script
+                            .get(imp.start as usize..imp.end as usize)
+                            .unwrap_or("");
+                        extract_import_names(text)
+                    })
+                    .collect()
+            } else {
+                FxHashSet::default()
+            }
+        );
         profile!("canon.virtual_ts.emit_auto_import_stubs", {
             let mut has_header = false;
             for stub in &options.auto_import_stubs {
@@ -241,8 +242,8 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
             // Use split('\n') to correctly track byte offsets for CRLF files.
             // Rust's lines() strips \r from CRLF but +1 for \n undercounts,
             // causing src_byte_offset drift that incorrectly skips user code.
-            let raw_lines: Vec<&str> = script.split('\n').collect();
             let mut src_byte_offset: usize = 0; // offset within script content
+            let mut module_span_index = 0usize;
 
             // Check if script uses import.meta and add a polyfill variable.
             // This avoids TS1343 when module is not set to es2020+.
@@ -251,7 +252,7 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
                 ts.push_str("  const __import_meta: any = {};\n");
             }
 
-            for raw_line in raw_lines.iter() {
+            for raw_line in script.split('\n') {
                 // Strip trailing \r for output (normalize CRLF to LF)
                 let line = raw_line.strip_suffix('\r').unwrap_or(raw_line);
                 // raw_line.len() includes \r if present; +1 for the \n from split
@@ -260,9 +261,15 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
                 // Skip lines that overlap with module-level spans (imports, re-exports, type decls)
                 let line_start = src_byte_offset;
                 let line_end = line_start + raw_line.len(); // use raw length for span check
-                let is_module_level = module_spans
+                while module_span_index < module_spans.len()
+                    && module_spans[module_span_index].1 as usize <= line_start
+                {
+                    module_span_index += 1;
+                }
+                let is_module_level = module_spans[module_span_index..]
                     .iter()
-                    .any(|&(s, e)| line_start < e as usize && line_end > s as usize);
+                    .take_while(|&&(start, _)| (start as usize) < line_end)
+                    .any(|&(start, end)| line_start < end as usize && line_end > start as usize);
                 if is_module_level {
                     src_byte_offset += raw_byte_len;
                     continue;

--- a/crates/vize_carton/src/config/loader.rs
+++ b/crates/vize_carton/src/config/loader.rs
@@ -328,6 +328,10 @@ export default {
         let linter = load_linter_config(Some(dir.path()));
 
         assert_eq!(loaded.source_path.as_deref(), Some(config_path.as_path()));
+        assert_eq!(
+            loaded.config.linter.disabled_rules(),
+            ["vue/prop-name-casing"]
+        );
         assert_eq!(linter.disabled_rules(), ["vue/prop-name-casing"]);
     }
 }

--- a/crates/vize_carton/src/config/model.rs
+++ b/crates/vize_carton/src/config/model.rs
@@ -29,6 +29,9 @@ pub struct VizeConfig {
     /// Formatter settings shared by CLI and IDE formatting.
     #[serde(skip_serializing_if = "FormatterConfig::is_default")]
     pub formatter: FormatterConfig,
+    /// Linter settings shared by CLI and IDE linting.
+    #[serde(skip_serializing_if = "LinterConfig::is_default")]
+    pub linter: LinterConfig,
     /// Type checker settings shared by CLI and IDE diagnostics.
     #[serde(
         rename = "typeChecker",
@@ -105,6 +108,7 @@ impl From<RawVizeConfig> for VizeConfig {
         Self {
             schema: raw.schema,
             formatter,
+            linter: raw.linter,
             type_checker,
             language_server,
             global_types: raw.global_types.into(),


### PR DESCRIPTION
## Summary

- Preserve linter settings on the loaded shared config and reuse that config in `vize lint`, avoiding a second config parse.
- Reduce virtual TS generation overhead by only extracting import names when auto-import stubs are present and by scanning module-level spans linearly while emitting script body lines.
- Update benchmark input generation so PR benchmarks include a `vize.config.json` shared-config path, and run the standalone lint benchmark from that generated fixture directory.

## Validation

- `cargo test -p vize_carton config::loader --lib`
- `cargo test -p vize_canon virtual_ts --lib`
- `cargo check -p vize --profile ci`
- `node --check bench/generate.mjs`
- `node --check bench/lint.ts`
- `git diff --check`