### PR TITLE
fix: restore main CI checks

### DIFF
--- a/crates/vize/src/commands/lint.rs
+++ b/crates/vize/src/commands/lint.rs
@@ -106,13 +106,16 @@ pub fn run(args: LintArgs) {
     let render_details = should_render_lint_details(format, args.quiet);
     crate::config::write_schema(None);
     let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
-    let loaded_config = if args.no_config {
-        crate::config::LoadedConfig {
-            config: crate::config::VizeConfig::default(),
-            source_path: None,
-        }
+    let (loaded_config, linter_config) = if args.no_config {
+        (
+            crate::config::LoadedConfig {
+                config: crate::config::VizeConfig::default(),
+                source_path: None,
+            },
+            crate::config::LinterConfig::default(),
+        )
     } else {
-        crate::config::load_config_with_source(args.config.as_deref())
+        crate::config::load_config_and_linter_with_source(args.config.as_deref())
     };
     let config_dir = loaded_config
         .source_path
@@ -120,7 +123,6 @@ pub fn run(args: LintArgs) {
         .and_then(Path::parent)
         .unwrap_or(cwd.as_path());
     let config = loaded_config.config;
-    let linter_config = config.linter.clone();
     if !linter_config.enabled {
         eprintln!("[vize] Skipping lint because linter.enabled is false in vize.config.");
         return;

--- a/crates/vize_carton/src/config.rs
+++ b/crates/vize_carton/src/config.rs
@@ -3,7 +3,10 @@
 mod loader;
 mod model;
 
-pub use loader::{LoadedConfig, load_config, load_config_with_source, load_linter_config};
+pub use loader::{
+    LoadedConfig, load_config, load_config_and_linter_with_source, load_config_with_source,
+    load_linter_config,
+};
 pub use model::{
     ArrowParens, AttributeSortOrder, EndOfLine, FormatterConfig, GlobalTypeDeclaration,
     GlobalTypesConfig, LanguageServerConfig, LintRuleSeverity, LinterConfig, LspConfig, QuoteProps,

--- a/crates/vize_carton/src/config/loader.rs
+++ b/crates/vize_carton/src/config/loader.rs
@@ -27,6 +27,11 @@ pub struct LoadedConfig {
     pub source_path: Option<PathBuf>,
 }
 
+struct LoadedRawConfig {
+    config: RawVizeConfig,
+    source_path: Option<PathBuf>,
+}
+
 /// Load configuration from a directory or file path.
 pub fn load_config(path: Option<&Path>) -> VizeConfig {
     load_config_with_source(path).config
@@ -34,20 +39,46 @@ pub fn load_config(path: Option<&Path>) -> VizeConfig {
 
 /// Load configuration from a directory or file path and return its source path.
 pub fn load_config_with_source(path: Option<&Path>) -> LoadedConfig {
+    let loaded = load_raw_config_with_source(path);
+    LoadedConfig {
+        config: loaded.config.into(),
+        source_path: loaded.source_path,
+    }
+}
+
+/// Load configuration and linter settings from a directory or file path in one pass.
+pub fn load_config_and_linter_with_source(path: Option<&Path>) -> (LoadedConfig, LinterConfig) {
+    let loaded = load_raw_config_with_source(path);
+    let linter = loaded.config.linter.clone();
+    (
+        LoadedConfig {
+            config: loaded.config.into(),
+            source_path: loaded.source_path,
+        },
+        linter,
+    )
+}
+
+/// Load linter-specific configuration from a directory or file path.
+pub fn load_linter_config(path: Option<&Path>) -> LinterConfig {
+    load_raw_config_with_source(path).config.linter
+}
+
+fn load_raw_config_with_source(path: Option<&Path>) -> LoadedRawConfig {
     let base = path
         .map(Path::to_path_buf)
         .unwrap_or_else(|| std::env::current_dir().unwrap_or_default());
 
     if let Some(file_path) = resolve_file_path(&base) {
-        return LoadedConfig {
-            config: parse_config_file(&file_path).unwrap_or_default(),
+        return LoadedRawConfig {
+            config: parse_raw_config_file(&file_path).unwrap_or_default(),
             source_path: Some(file_path),
         };
     }
 
     let Some(dir_path) = resolve_dir_path(&base) else {
-        return LoadedConfig {
-            config: VizeConfig::default(),
+        return LoadedRawConfig {
+            config: RawVizeConfig::default(),
             source_path: None,
         };
     };
@@ -59,47 +90,17 @@ pub fn load_config_with_source(path: Option<&Path>) -> LoadedConfig {
         }
 
         if let Some(config) = try_parse_candidate(&candidate) {
-            return LoadedConfig {
+            return LoadedRawConfig {
                 config,
                 source_path: Some(candidate),
             };
         }
     }
 
-    LoadedConfig {
-        config: VizeConfig::default(),
+    LoadedRawConfig {
+        config: RawVizeConfig::default(),
         source_path: None,
     }
-}
-
-/// Load linter-specific configuration from a directory or file path.
-pub fn load_linter_config(path: Option<&Path>) -> LinterConfig {
-    let base = path
-        .map(Path::to_path_buf)
-        .unwrap_or_else(|| std::env::current_dir().unwrap_or_default());
-
-    if let Some(file_path) = resolve_file_path(&base) {
-        return parse_raw_config_file(&file_path)
-            .map(|config| config.linter)
-            .unwrap_or_default();
-    }
-
-    let Some(dir_path) = resolve_dir_path(&base) else {
-        return LinterConfig::default();
-    };
-
-    for file_name in CONFIG_FILE_NAMES {
-        let candidate = dir_path.join(file_name);
-        if !candidate.exists() {
-            continue;
-        }
-
-        if let Some(config) = try_parse_raw_candidate(&candidate) {
-            return config.linter;
-        }
-    }
-
-    LinterConfig::default()
 }
 
 fn resolve_file_path(base: &Path) -> Option<PathBuf> {
@@ -122,8 +123,8 @@ fn resolve_dir_path(base: &Path) -> Option<PathBuf> {
     None
 }
 
-fn try_parse_candidate(path: &Path) -> Option<VizeConfig> {
-    try_parse_raw_candidate(path).map(Into::into)
+fn try_parse_candidate(path: &Path) -> Option<RawVizeConfig> {
+    try_parse_raw_candidate(path)
 }
 
 fn try_parse_raw_candidate(path: &Path) -> Option<RawVizeConfig> {
@@ -153,10 +154,6 @@ fn should_try_next_config(path: &Path, error: &(dyn std::error::Error + 'static)
     error
         .downcast_ref::<PklError>()
         .is_some_and(is_process_error)
-}
-
-fn parse_config_file(path: &Path) -> Result<VizeConfig, Box<dyn std::error::Error>> {
-    Ok(parse_raw_config_file(path)?.into())
 }
 
 fn parse_raw_config_file(path: &Path) -> Result<RawVizeConfig, Box<dyn std::error::Error>> {
@@ -293,7 +290,7 @@ fn local_pkl_candidates(base: &Path) -> [PathBuf; 6] {
 }
 #[cfg(test)]
 mod tests {
-    use super::{load_config_with_source, load_linter_config};
+    use super::{load_config_and_linter_with_source, load_config_with_source, load_linter_config};
 
     #[test]
     fn load_config_uses_explicit_file_path() {
@@ -324,12 +321,13 @@ export default {
         )
         .unwrap();
 
-        let loaded = load_config_with_source(Some(dir.path()));
+        let (loaded, linter_from_loaded_config) =
+            load_config_and_linter_with_source(Some(dir.path()));
         let linter = load_linter_config(Some(dir.path()));
 
         assert_eq!(loaded.source_path.as_deref(), Some(config_path.as_path()));
         assert_eq!(
-            loaded.config.linter.disabled_rules(),
+            linter_from_loaded_config.disabled_rules(),
             ["vue/prop-name-casing"]
         );
         assert_eq!(linter.disabled_rules(), ["vue/prop-name-casing"]);

--- a/crates/vize_carton/src/config/model.rs
+++ b/crates/vize_carton/src/config/model.rs
@@ -29,9 +29,6 @@ pub struct VizeConfig {
     /// Formatter settings shared by CLI and IDE formatting.
     #[serde(skip_serializing_if = "FormatterConfig::is_default")]
     pub formatter: FormatterConfig,
-    /// Linter settings shared by CLI and IDE linting.
-    #[serde(skip_serializing_if = "LinterConfig::is_default")]
-    pub linter: LinterConfig,
     /// Type checker settings shared by CLI and IDE diagnostics.
     #[serde(
         rename = "typeChecker",
@@ -108,7 +105,6 @@ impl From<RawVizeConfig> for VizeConfig {
         Self {
             schema: raw.schema,
             formatter,
-            linter: raw.linter,
             type_checker,
             language_server,
             global_types: raw.global_types.into(),

--- a/flake.nix
+++ b/flake.nix
@@ -32,19 +32,19 @@
         workspaceVersion = workspaceCargo.workspace.package.version;
         moonbitArtifacts = {
           aarch64-darwin = {
-            version = "0.9.2-2026-05-13";
+            version = "0.9.3-2026-05-22";
             url = "https://cli.moonbitlang.com/binaries/latest/moonbit-darwin-aarch64.tar.gz";
-            hash = "sha256-5OtkpeuCcOi8YoJVVEOMMlVm5kHHCJ4vO/Vk6RhDMbk=";
+            hash = "sha256-xv9K8uh5mV5eHooKh6DjnIIKv1ickhl1JV/YSUVW44Q=";
           };
           x86_64-linux = {
-            version = "0.9.2-2026-05-13";
+            version = "0.9.3-2026-05-22";
             url = "https://cli.moonbitlang.com/binaries/latest/moonbit-linux-x86_64.tar.gz";
-            hash = "sha256-LDpa8gIMnOs/4R5kV+ZHohWEbZfXHI54Sz0KfIz8YGs=";
+            hash = "sha256-ZwrAmmo6ZAC8lmeFbeZwXd7AqXzjvUwZxMOAtwfmhWw=";
           };
           aarch64-linux = {
-            version = "0.9.2-2026-05-13";
+            version = "0.9.3-2026-05-22";
             url = "https://cli.moonbitlang.com/binaries/latest/moonbit-linux-aarch64.tar.gz";
-            hash = "sha256-0n7Hu3h4+TLbrcyja6/0xOIntAChGFoChSE5HPp7kPg=";
+            hash = "sha256-9nRdhueeaA2kMthHVdXKzVleSjrbu7ZP+uWI0Uzs5dY=";
           };
         };
         moonbit =
@@ -60,7 +60,7 @@
               };
               coreSrc = pkgs.fetchurl {
                 url = "https://cli.moonbitlang.com/cores/core-latest.tar.gz";
-                hash = "sha256-xoulYgG9jZnbRCtt9ZnCwhewUo7ex9bebocbblicUC4=";
+                hash = "sha256-29JAjdJqvXh3XN/JeyQ4gzhFwsLPlTSnoP0dthW4s+g=";
               };
               nativeBuildInputs = lib.optionals pkgs.stdenv.isLinux [ pkgs.patchelf ];
               dontUnpack = true;


### PR DESCRIPTION
## Summary
- update MoonBit and core fixed-output hashes used by the Nix flake
- keep VizeConfig's public struct fields compatible while loading linter config in one pass for the CLI

## Verification
- cargo test -p vize_carton config::loader
- cargo check -p vize
- cargo semver-checks check-release --package vize_armature --package vize_atelier_core --package vize_atelier_dom --package vize_atelier_sfc --package vize_atelier_ssr --package vize_atelier_vapor --package vize_canon --package vize_carton --package vize_croquis --package vize_fresco --package vize_musea --package vize_patina --package vize_relief
- nix store prefetch-file --json https://cli.moonbitlang.com/cores/core-latest.tar.gz
- nix flake check
- nix flake check --all-systems --no-build