### PR TITLE
fix: preserve slot outlets in control flow

### DIFF
--- a/crates/vize_atelier_core/src/codegen.rs
+++ b/crates/vize_atelier_core/src/codegen.rs
@@ -328,6 +328,54 @@ mod tests {
     }
 
     #[test]
+    fn test_codegen_conditional_slot_outlet_with_bound_props_uses_render_slot() {
+        let result = compile!(r#"<slot v-if="show" name="updater" v-bind="{ number, update }" />"#);
+        let output = result_output(&result);
+
+        assert!(
+            output.contains(r#"_renderSlot(_ctx.$slots, "updater""#),
+            "conditional slot outlet should use renderSlot. Got:\n{}",
+            output
+        );
+        assert!(
+            output.contains(r#"_mergeProps({ number, update }, { key: 0 })"#),
+            "v-bind object props should be merged with the branch key. Got:\n{}",
+            output
+        );
+        assert!(
+            !output.contains(r#"_createElementBlock("slot""#)
+                && !output.contains(r#"_createElementVNode("slot""#),
+            "slot outlets should not be emitted as literal slot elements. Got:\n{}",
+            output
+        );
+    }
+
+    #[test]
+    fn test_codegen_v_for_slot_outlet_with_bound_props_uses_render_slot() {
+        let result = compile!(
+            r#"<slot v-for="(item, index) of items" v-bind="{ key: item.id }" :item="item" :index="index" />"#
+        );
+        let output = result_output(&result);
+
+        assert!(
+            output.contains(r#"_renderSlot(_ctx.$slots, "default""#),
+            "v-for slot outlet should use renderSlot. Got:\n{}",
+            output
+        );
+        assert!(
+            output.contains(r#"_mergeProps({ key: item.id }, { item: item, index: index })"#),
+            "slot v-bind object props should be preserved with explicit props. Got:\n{}",
+            output
+        );
+        assert!(
+            !output.contains(r#"_createElementBlock("slot""#)
+                && !output.contains(r#"_createElementVNode("slot""#),
+            "slot outlets should not be emitted as literal slot elements. Got:\n{}",
+            output
+        );
+    }
+
+    #[test]
     fn test_codegen_conditional_slot_with_else_does_not_append_undefined() {
         let result = compile!(
             r#"<MyDialog>

--- a/crates/vize_atelier_core/src/codegen/element/block.rs
+++ b/crates/vize_atelier_core/src/codegen/element/block.rs
@@ -20,7 +20,7 @@ use super::{
         },
         props::generate_props,
         slots::{
-            generate_slot_outlet_name, generate_slot_outlet_props_entries, generate_slots,
+            generate_slot_outlet_name, generate_slot_outlet_props, generate_slots,
             has_dynamic_slots_flag, has_slot_children, has_slot_outlet_props,
         },
     },
@@ -97,9 +97,9 @@ pub fn generate_element_block(ctx: &mut CodegenContext, el: &ElementNode<'_>) {
         // Generate fallback content if present
         if !el.children.is_empty() {
             if has_slot_outlet_props(el) {
-                ctx.push(", {");
-                generate_slot_outlet_props_entries(ctx, el);
-                ctx.push("}, () => [");
+                ctx.push(", ");
+                generate_slot_outlet_props(ctx, el);
+                ctx.push(", () => [");
             } else {
                 ctx.push(", {}, () => [");
             }
@@ -120,9 +120,9 @@ pub fn generate_element_block(ctx: &mut CodegenContext, el: &ElementNode<'_>) {
             ctx.newline();
             ctx.push("])");
         } else if has_slot_outlet_props(el) {
-            ctx.push(", {");
-            generate_slot_outlet_props_entries(ctx, el);
-            ctx.push("})");
+            ctx.push(", ");
+            generate_slot_outlet_props(ctx, el);
+            ctx.push(")");
         } else {
             ctx.push(")");
         }
@@ -460,9 +460,8 @@ pub fn generate_element_block(ctx: &mut CodegenContext, el: &ElementNode<'_>) {
                 if !has_slot_props {
                     ctx.push(", {}");
                 } else {
-                    ctx.push(", {");
-                    generate_slot_outlet_props_entries(ctx, el);
-                    ctx.push("}");
+                    ctx.push(", ");
+                    generate_slot_outlet_props(ctx, el);
                 }
                 ctx.push(", () => [");
                 ctx.indent();
@@ -482,9 +481,9 @@ pub fn generate_element_block(ctx: &mut CodegenContext, el: &ElementNode<'_>) {
                 ctx.newline();
                 ctx.push("])");
             } else if has_slot_props {
-                ctx.push(", {");
-                generate_slot_outlet_props_entries(ctx, el);
-                ctx.push("})");
+                ctx.push(", ");
+                generate_slot_outlet_props(ctx, el);
+                ctx.push(")");
             } else {
                 ctx.push(")");
             }

--- a/crates/vize_atelier_core/src/codegen/element/inline.rs
+++ b/crates/vize_atelier_core/src/codegen/element/inline.rs
@@ -20,7 +20,7 @@ use super::{
         },
         props::generate_props,
         slots::{
-            generate_slot_outlet_name, generate_slot_outlet_props_entries, generate_slots,
+            generate_slot_outlet_name, generate_slot_outlet_props, generate_slots,
             has_dynamic_slots_flag, has_slot_children, has_slot_outlet_props,
         },
     },
@@ -381,9 +381,8 @@ pub fn generate_element(ctx: &mut CodegenContext, el: &ElementNode<'_>) {
                 if !has_slot_props {
                     ctx.push(", {}");
                 } else {
-                    ctx.push(", {");
-                    generate_slot_outlet_props_entries(ctx, el);
-                    ctx.push("}");
+                    ctx.push(", ");
+                    generate_slot_outlet_props(ctx, el);
                 }
                 ctx.push(", () => [");
                 ctx.skip_scope_id = prev_skip_scope_id;
@@ -404,10 +403,9 @@ pub fn generate_element(ctx: &mut CodegenContext, el: &ElementNode<'_>) {
                 ctx.newline();
                 ctx.push("])");
             } else if has_slot_props {
-                ctx.push(", {");
-                generate_slot_outlet_props_entries(ctx, el);
+                ctx.push(", ");
+                generate_slot_outlet_props(ctx, el);
                 ctx.skip_scope_id = prev_skip_scope_id;
-                ctx.push("}");
                 ctx.push(")");
             } else {
                 ctx.skip_scope_id = prev_skip_scope_id;

--- a/crates/vize_atelier_core/src/codegen/slots.rs
+++ b/crates/vize_atelier_core/src/codegen/slots.rs
@@ -9,7 +9,10 @@ use super::context::CodegenContext;
 use super::expression::generate_expression;
 use super::helpers::{escape_js_string, is_valid_js_identifier};
 use super::node::generate_node;
-use super::props::{generate_directive_prop_with_static, is_supported_directive};
+use super::props::{
+    generate_directive_prop_with_static, generate_vbind_object_exp, generate_von_object_exp,
+    is_supported_directive,
+};
 use vize_carton::String;
 use vize_carton::ToCompactString;
 
@@ -106,6 +109,58 @@ fn is_slot_name_prop(prop: &PropNode<'_>) -> bool {
     }
 }
 
+fn is_slot_outlet_object_spread(prop: &PropNode<'_>) -> bool {
+    matches!(
+        prop,
+        PropNode::Directive(dir)
+            if (dir.name.as_str() == "bind" || dir.name.as_str() == "on")
+                && dir.arg.is_none()
+                && dir.exp.is_some()
+    )
+}
+
+fn slot_outlet_prop_generates_output(prop: &PropNode<'_>) -> bool {
+    if is_slot_name_prop(prop) {
+        return false;
+    }
+
+    match prop {
+        PropNode::Attribute(_) => true,
+        PropNode::Directive(dir) => {
+            if (dir.name.as_str() == "bind" || dir.name.as_str() == "on") && dir.arg.is_none() {
+                return dir.exp.is_some();
+            }
+            is_supported_directive(dir)
+        }
+    }
+}
+
+fn has_slot_outlet_vbind_object(el: &ElementNode<'_>) -> bool {
+    el.props.iter().any(|prop| {
+        matches!(
+            prop,
+            PropNode::Directive(dir)
+                if dir.name.as_str() == "bind" && dir.arg.is_none() && dir.exp.is_some()
+        )
+    })
+}
+
+fn has_slot_outlet_von_object(el: &ElementNode<'_>) -> bool {
+    el.props.iter().any(|prop| {
+        matches!(
+            prop,
+            PropNode::Directive(dir)
+                if dir.name.as_str() == "on" && dir.arg.is_none() && dir.exp.is_some()
+        )
+    })
+}
+
+fn has_slot_outlet_entry_props(el: &ElementNode<'_>) -> bool {
+    el.props
+        .iter()
+        .any(|prop| !is_slot_outlet_object_spread(prop) && slot_outlet_prop_generates_output(prop))
+}
+
 pub(crate) fn get_slot_outlet_name<'a>(el: &'a ElementNode<'a>) -> SlotOutletName<'a> {
     for prop in &el.props {
         match prop {
@@ -141,7 +196,7 @@ pub(crate) fn generate_slot_outlet_name(ctx: &mut CodegenContext, el: &ElementNo
 }
 
 pub(crate) fn has_slot_outlet_props(el: &ElementNode<'_>) -> bool {
-    el.props.iter().any(|prop| !is_slot_name_prop(prop))
+    el.props.iter().any(slot_outlet_prop_generates_output)
 }
 
 pub(crate) fn generate_slot_outlet_props_entries(ctx: &mut CodegenContext, el: &ElementNode<'_>) {
@@ -228,7 +283,8 @@ pub(crate) fn generate_slot_outlet_props_entries(ctx: &mut CodegenContext, el: &
             }
             PropNode::Directive(dir) => {
                 if !is_supported_directive(dir)
-                    || (dir.name.as_str() == "bind" && dir.arg.is_none())
+                    || (dir.arg.is_none()
+                        && (dir.name.as_str() == "bind" || dir.name.as_str() == "on"))
                 {
                     continue;
                 }
@@ -241,6 +297,107 @@ pub(crate) fn generate_slot_outlet_props_entries(ctx: &mut CodegenContext, el: &
             }
         }
     }
+}
+
+pub(crate) fn generate_slot_outlet_props(ctx: &mut CodegenContext, el: &ElementNode<'_>) {
+    generate_slot_outlet_props_inner(ctx, el, None);
+}
+
+pub(crate) fn generate_slot_outlet_props_with_key(
+    ctx: &mut CodegenContext,
+    el: &ElementNode<'_>,
+    generate_key: &dyn Fn(&mut CodegenContext),
+) {
+    generate_slot_outlet_props_inner(ctx, el, Some(generate_key));
+}
+
+fn generate_slot_outlet_props_inner(
+    ctx: &mut CodegenContext,
+    el: &ElementNode<'_>,
+    generate_key: Option<&dyn Fn(&mut CodegenContext)>,
+) {
+    let has_vbind_object = has_slot_outlet_vbind_object(el);
+    let has_von_object = has_slot_outlet_von_object(el);
+    let has_entries = has_slot_outlet_entry_props(el);
+    let has_key = generate_key.is_some();
+
+    if has_vbind_object || has_von_object {
+        let needs_merge = has_key || has_entries || (has_vbind_object && has_von_object);
+
+        if needs_merge {
+            ctx.use_helper(RuntimeHelper::MergeProps);
+            ctx.push(ctx.helper(RuntimeHelper::MergeProps));
+            ctx.push("(");
+            let mut first = true;
+
+            if has_vbind_object {
+                generate_vbind_object_exp(ctx, &el.props);
+                first = false;
+            }
+
+            if has_von_object {
+                if !first {
+                    ctx.push(", ");
+                }
+                generate_von_object_exp(ctx, &el.props);
+                first = false;
+            }
+
+            if has_key || has_entries {
+                if !first {
+                    ctx.push(", ");
+                }
+                generate_slot_outlet_props_object(ctx, el, generate_key, has_entries);
+            }
+
+            ctx.push(")");
+        } else if has_vbind_object {
+            ctx.use_helper(RuntimeHelper::NormalizeProps);
+            ctx.use_helper(RuntimeHelper::GuardReactiveProps);
+            ctx.push(ctx.helper(RuntimeHelper::NormalizeProps));
+            ctx.push("(");
+            ctx.push(ctx.helper(RuntimeHelper::GuardReactiveProps));
+            ctx.push("(");
+            generate_vbind_object_exp(ctx, &el.props);
+            ctx.push("))");
+        } else {
+            generate_von_object_exp(ctx, &el.props);
+        }
+        return;
+    }
+
+    generate_slot_outlet_props_object(ctx, el, generate_key, has_entries);
+}
+
+fn generate_slot_outlet_props_object(
+    ctx: &mut CodegenContext,
+    el: &ElementNode<'_>,
+    generate_key: Option<&dyn Fn(&mut CodegenContext)>,
+    has_entries: bool,
+) {
+    ctx.push("{");
+    let mut needs_separator = false;
+
+    if let Some(generate_key) = generate_key {
+        ctx.push(" key: ");
+        generate_key(ctx);
+        needs_separator = true;
+    }
+
+    if has_entries {
+        if needs_separator {
+            ctx.push(", ");
+        } else {
+            ctx.push(" ");
+        }
+        generate_slot_outlet_props_entries(ctx, el);
+        needs_separator = true;
+    }
+
+    if needs_separator {
+        ctx.push(" ");
+    }
+    ctx.push("}");
 }
 
 /// Check if component has slot children that need to be generated as slots object

--- a/crates/vize_atelier_core/src/codegen/v_for/generate.rs
+++ b/crates/vize_atelier_core/src/codegen/v_for/generate.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 
 use super::super::{
-    children::{generate_children, generate_children_force_array},
+    children::{generate_children, generate_children_force_array, is_directive_comment},
     context::CodegenContext,
     element::helpers::{is_dynamic_component, is_is_prop},
     element::{
@@ -22,7 +22,10 @@ use super::super::{
     patch_flag::{
         calculate_element_patch_info, calculate_element_patch_info_skip_is, patch_flag_name,
     },
-    slots::{generate_slots, has_slot_children},
+    slots::{
+        generate_slot_outlet_name, generate_slot_outlet_props, generate_slots, has_slot_children,
+        has_slot_outlet_props,
+    },
 };
 use super::helpers::{get_element_key, has_other_props, should_skip_prop};
 use vize_carton::ToCompactString;
@@ -81,7 +84,9 @@ pub fn generate_for_item(ctx: &mut CodegenContext, node: &TemplateChildNode<'_>,
                 ctx.skip_scope_id = true;
             }
 
-            if is_stable {
+            if el.tag_type == ElementType::Slot {
+                generate_for_slot_outlet(ctx, el);
+            } else if is_stable {
                 if gen_is_template {
                     ctx.use_helper(RuntimeHelper::OpenBlock);
                     ctx.use_helper(RuntimeHelper::CreateElementBlock);
@@ -384,6 +389,47 @@ fn unwrap_template_single_element<'a>(el: &'a ElementNode<'a>) -> Option<&'a Ele
         Some(child_el)
     } else {
         None
+    }
+}
+
+fn generate_for_slot_outlet(ctx: &mut CodegenContext, el: &ElementNode<'_>) {
+    ctx.use_helper(RuntimeHelper::RenderSlot);
+    ctx.push(ctx.helper(RuntimeHelper::RenderSlot));
+    ctx.push("(_ctx.$slots, ");
+    generate_slot_outlet_name(ctx, el);
+
+    let has_slot_props = has_slot_outlet_props(el);
+    let filtered: Vec<_> = el
+        .children
+        .iter()
+        .filter(|c| !is_directive_comment(c))
+        .collect();
+
+    if !filtered.is_empty() {
+        if has_slot_props {
+            ctx.push(", ");
+            generate_slot_outlet_props(ctx, el);
+        } else {
+            ctx.push(", {}");
+        }
+        ctx.push(", () => [");
+        ctx.indent();
+        for (i, child) in filtered.iter().enumerate() {
+            if i > 0 {
+                ctx.push(",");
+            }
+            ctx.newline();
+            generate_node(ctx, child);
+        }
+        ctx.deindent();
+        ctx.newline();
+        ctx.push("])");
+    } else if has_slot_props {
+        ctx.push(", ");
+        generate_slot_outlet_props(ctx, el);
+        ctx.push(")");
+    } else {
+        ctx.push(")");
     }
 }
 

--- a/crates/vize_atelier_core/src/codegen/v_if/branch.rs
+++ b/crates/vize_atelier_core/src/codegen/v_if/branch.rs
@@ -25,8 +25,8 @@ use super::{
             calculate_element_patch_info, calculate_element_patch_info_skip_is, patch_flag_name,
         },
         slots::{
-            generate_slot_outlet_name, generate_slot_outlet_props_entries, generate_slots,
-            has_dynamic_slots_flag, has_slot_children, has_slot_outlet_props,
+            generate_slot_outlet_name, generate_slot_outlet_props_with_key, generate_slots,
+            has_dynamic_slots_flag, has_slot_children,
         },
     },
     generate::{
@@ -112,13 +112,9 @@ fn generate_if_branch_slot(
     ctx.push(ctx.helper(RuntimeHelper::RenderSlot));
     ctx.push("(_ctx.$slots, ");
     generate_slot_outlet_name(ctx, el);
-    ctx.push(", { key: ");
-    generate_if_branch_key(ctx, branch, branch_index);
-    if has_slot_outlet_props(el) {
-        ctx.push(", ");
-        generate_slot_outlet_props_entries(ctx, el);
-    }
-    ctx.push("}");
+    ctx.push(", ");
+    let generate_key = |ctx: &mut CodegenContext| generate_if_branch_key(ctx, branch, branch_index);
+    generate_slot_outlet_props_with_key(ctx, el, &generate_key);
 
     if !el.children.is_empty() {
         ctx.push(", () => [");

--- a/tests/expected/sfc/patches.snap
+++ b/tests/expected/sfc/patches.snap
@@ -1735,7 +1735,7 @@ export default {
 const showing = ref(false)
 
 return (_ctx, _cache) => {
-  return (_openBlock(), _createElementBlock("div", null, [ (showing.value) ? _renderSlot(_ctx.$slots, "default", { key: 0}) : _renderSlot(_ctx.$slots, "fallback", { key: 1}) ]))
+  return (_openBlock(), _createElementBlock("div", null, [ (showing.value) ? _renderSlot(_ctx.$slots, "default", { key: 0 }) : _renderSlot(_ctx.$slots, "fallback", { key: 1 }) ]))
 }
 }
 
@@ -1774,7 +1774,7 @@ const tabs = [
 return (_ctx, _cache) => {
   return (_openBlock(), _createElementBlock("div", null, [ (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(tabs, (tab) => {
         return (_openBlock(), _createElementBlock(_Fragment, { key: tab.key }, [
-          _renderSlot(_ctx.$slots, tab.key, {tab: tab})
+          _renderSlot(_ctx.$slots, tab.key, { tab: tab })
         ], 64 /* STABLE_FRAGMENT */))
       }), 128 /* KEYED_FRAGMENT */)) ]))
 }

--- a/tests/expected/sfc/script-setup.snap
+++ b/tests/expected/sfc/script-setup.snap
@@ -1293,7 +1293,7 @@ const formData = ref<FormShape | null>(null)
 return (_ctx: any,_cache: any) => {
   return (_openBlock(), _createElementBlock("form", {
       onSubmit: _withModifiers(() => {}, ["prevent"])
-    }, [ _renderSlot(_ctx.$slots, "default", {data: formData.value}) ], 40 /* PROPS, NEED_HYDRATION */, ["onSubmit"]))
+    }, [ _renderSlot(_ctx.$slots, "default", { data: formData.value }) ], 40 /* PROPS, NEED_HYDRATION */, ["onSubmit"]))
 }
 }
 

--- a/tests/snapshots/sfc/js/patches__dynamic_slot_outlet_name_in_loop.snap
+++ b/tests/snapshots/sfc/js/patches__dynamic_slot_outlet_name_in_loop.snap
@@ -17,7 +17,7 @@ const tabs = [
 return (_ctx, _cache) => {
   return (_openBlock(), _createElementBlock("div", null, [ (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(tabs, (tab) => {
         return (_openBlock(), _createElementBlock(_Fragment, { key: tab.key }, [
-          _renderSlot(_ctx.$slots, tab.key, {tab: tab})
+          _renderSlot(_ctx.$slots, tab.key, { tab: tab })
         ], 64 /* STABLE_FRAGMENT */))
       }), 128 /* KEYED_FRAGMENT */)) ]))
 }

--- a/tests/snapshots/sfc/js/patches__v_if_slot_outlet_with_v_else.snap
+++ b/tests/snapshots/sfc/js/patches__v_if_slot_outlet_with_v_else.snap
@@ -13,7 +13,7 @@ export default {
 const showing = ref(false)
 
 return (_ctx, _cache) => {
-  return (_openBlock(), _createElementBlock("div", null, [ (showing.value) ? _renderSlot(_ctx.$slots, "default", { key: 0}) : _renderSlot(_ctx.$slots, "fallback", { key: 1}) ]))
+  return (_openBlock(), _createElementBlock("div", null, [ (showing.value) ? _renderSlot(_ctx.$slots, "default", { key: 0 }) : _renderSlot(_ctx.$slots, "fallback", { key: 1 }) ]))
 }
 }
 

--- a/tests/snapshots/sfc/ts/patches__dynamic_slot_outlet_name_in_loop.snap
+++ b/tests/snapshots/sfc/ts/patches__dynamic_slot_outlet_name_in_loop.snap
@@ -18,7 +18,7 @@ const tabs = [
 return (_ctx: any,_cache: any) => {
   return (_openBlock(), _createElementBlock("div", null, [ (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(tabs, (tab) => {
         return (_openBlock(), _createElementBlock(_Fragment, { key: tab.key }, [
-          _renderSlot(_ctx.$slots, tab.key, {tab: tab})
+          _renderSlot(_ctx.$slots, tab.key, { tab: tab })
         ], 64 /* STABLE_FRAGMENT */))
       }), 128 /* KEYED_FRAGMENT */)) ]))
 }

--- a/tests/snapshots/sfc/ts/patches__v_if_slot_outlet_with_v_else.snap
+++ b/tests/snapshots/sfc/ts/patches__v_if_slot_outlet_with_v_else.snap
@@ -14,7 +14,7 @@ export default /*@__PURE__*/_defineComponent({
 const showing = ref(false)
 
 return (_ctx: any,_cache: any) => {
-  return (_openBlock(), _createElementBlock("div", null, [ (showing.value) ? _renderSlot(_ctx.$slots, "default", { key: 0}) : _renderSlot(_ctx.$slots, "fallback", { key: 1}) ]))
+  return (_openBlock(), _createElementBlock("div", null, [ (showing.value) ? _renderSlot(_ctx.$slots, "default", { key: 0 }) : _renderSlot(_ctx.$slots, "fallback", { key: 1 }) ]))
 }
 }
 

--- a/tests/snapshots/sfc/ts/script_setup__generic_component_with_complex_constraint.snap
+++ b/tests/snapshots/sfc/ts/script_setup__generic_component_with_complex_constraint.snap
@@ -20,7 +20,7 @@ const formData = ref<FormShape | null>(null)
 return (_ctx: any,_cache: any) => {
   return (_openBlock(), _createElementBlock("form", {
       onSubmit: _withModifiers(() => {}, ["prevent"])
-    }, [ _renderSlot(_ctx.$slots, "default", {data: formData.value}) ], 40 /* PROPS, NEED_HYDRATION */, ["onSubmit"]))
+    }, [ _renderSlot(_ctx.$slots, "default", { data: formData.value }) ], 40 /* PROPS, NEED_HYDRATION */, ["onSubmit"]))
 }
 }
 


### PR DESCRIPTION
## Summary
- emit `_renderSlot` for direct slot outlets inside `v-if` and `v-for` paths
- preserve slot outlet `v-bind`/`v-on` object spreads when merging branch keys or explicit props
- add regression tests for conditional and repeated slot outlets

## Verification
- `cargo test -p vize_atelier_core`
- `cargo build --profile ci -p vize`
- `target/ci/vize build` against Misskey fixture (583 Vue files)
- `target/ci/vize build` against Elk fixture (253 Vue files)
- verified no `_createElementBlock("slot"` or `_createElementVNode("slot"` remains in those fixture outputs

Discussion: https://github.com/ubugeeei/vize/discussions/71#discussioncomment-16752957