### PR TITLE
fix(vite-plugin): scope preprocessed styles

### DIFF
--- a/npm/vite-plugin-vize/src/plugin/compat.test.ts
+++ b/npm/vite-plugin-vize/src/plugin/compat.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import path from "node:path";
 
-import { createPostTransformPlugin } from "./compat.ts";
+import { createPostTransformPlugin, transformScopedPreprocessorCss } from "./compat.ts";
 import type { VizePluginState } from "./state.ts";
 
 function createState(overrides: Partial<VizePluginState> = {}): VizePluginState {
@@ -74,6 +74,19 @@ const msg = 'hello'
     result.map,
     null,
     "SSR post-transforms should not allocate discarded OXC sourcemaps",
+  );
+}
+
+{
+  const transformed = transformScopedPreprocessorCss(
+    ".rrevdjwu > .group + .group { color: red; }",
+    "\0/src/MkSuperMenu.vue?vue=&type=style&index=0&scoped=data-v-menu&lang=scss.scss",
+  );
+
+  assert.equal(
+    transformed,
+    ".rrevdjwu > .group + .group[data-v-menu] { color: red; }",
+    "Scoped preprocessor CSS should be scoped after preprocessing, matching Vue selector placement",
   );
 }
 

--- a/npm/vite-plugin-vize/src/plugin/compat.ts
+++ b/npm/vite-plugin-vize/src/plugin/compat.ts
@@ -1,6 +1,7 @@
 import type { Plugin, TransformResult } from "vite";
 import { transformWithOxc } from "vite";
 import { createRequire } from "node:module";
+import { classifyVitePluginRequest } from "@vizejs/native";
 
 import {
   getCompileOptionsForRequest,
@@ -10,6 +11,7 @@ import {
 } from "./state.ts";
 import { compileFile } from "../compiler.ts";
 import { generateOutput } from "../utils/index.ts";
+import { scopeCssForPipeline } from "../utils/css.ts";
 import { applyDefineReplacements } from "../transform.ts";
 
 export function createVueCompatPlugin(state: VizePluginState): Plugin {
@@ -37,6 +39,41 @@ export function createVueCompatPlugin(state: VizePluginState): Plugin {
           template: {},
         };
       },
+    },
+  };
+}
+
+export function normalizeVirtualStyleId(id: string): string {
+  if (!id.startsWith("\0") || !id.includes("?vue")) {
+    return id;
+  }
+
+  return id
+    .slice(1)
+    .replace(/\.module\.\w+$/, "")
+    .replace(/\.\w+$/, "");
+}
+
+export function transformScopedPreprocessorCss(code: string, id: string): string | null {
+  const request = classifyVitePluginRequest(normalizeVirtualStyleId(id));
+  if (
+    !request.isVueStyleQuery ||
+    !request.styleScoped ||
+    !request.styleLang ||
+    request.styleLang === "css"
+  ) {
+    return null;
+  }
+
+  return scopeCssForPipeline(code, request.styleScoped);
+}
+
+export function createStylePostTransformPlugin(): Plugin {
+  return {
+    name: "vize:style-post-transform",
+    transform(code: string, id: string): TransformResult | null {
+      const scoped = transformScopedPreprocessorCss(code, id);
+      return scoped === null ? null : { code: scoped, map: null };
     },
   };
 }

--- a/npm/vite-plugin-vize/src/plugin/index.ts
+++ b/npm/vite-plugin-vize/src/plugin/index.ts
@@ -18,7 +18,11 @@ import {
 import { resolveIdHook } from "./resolve.ts";
 import { loadHook, transformHook } from "./load.ts";
 import { handleHotUpdateHook, handleGenerateBundleHook } from "./hmr.ts";
-import { createVueCompatPlugin, createPostTransformPlugin } from "./compat.ts";
+import {
+  createPostTransformPlugin,
+  createStylePostTransformPlugin,
+  createVueCompatPlugin,
+} from "./compat.ts";
 import { patchUnoCssBridge } from "./unocss.ts";
 import { patchCssModuleGenerateScopedName } from "./css-modules.ts";
 import { installVirtualAssetMiddleware } from "./dev-middleware.ts";
@@ -250,5 +254,10 @@ export function vize(options: VizeOptions = {}): Plugin[] {
     },
   };
 
-  return [createVueCompatPlugin(state), mainPlugin, createPostTransformPlugin(state)];
+  return [
+    createVueCompatPlugin(state),
+    mainPlugin,
+    createStylePostTransformPlugin(),
+    createPostTransformPlugin(state),
+  ];
 }

--- a/npm/vite-plugin-vize/src/plugin/load.test.ts
+++ b/npm/vite-plugin-vize/src/plugin/load.test.ts
@@ -583,6 +583,51 @@ assert.doesNotMatch(
   "Delegated style CSS should not leak v-bind() to Vite",
 );
 
+const scssPath = "/src/MkSuperMenu.vue";
+const scssState: VizePluginState = {
+  ...hmrState,
+  cache: new Map([
+    [
+      scssPath,
+      {
+        code: `const _sfc_main = { name: "MkSuperMenu" }
+export default _sfc_main`,
+        scopeId: "scssscope",
+        hasScoped: true,
+        styles: [
+          {
+            content: `.rrevdjwu {
+  > .group {
+    & + .group { color: red; }
+  }
+}`,
+            lang: "scss",
+            scoped: true,
+            module: false,
+            index: 0,
+          },
+        ],
+      },
+    ],
+  ]),
+  ssrCache: new Map(),
+};
+
+const scssVirtualLoad = loadHook(
+  scssState,
+  "\0/src/MkSuperMenu.vue?vue=&type=style&index=0&scoped=data-v-scssscope&lang=scss.scss",
+  { ssr: false },
+);
+assert.ok(
+  scssVirtualLoad && typeof scssVirtualLoad === "object",
+  "Delegated SCSS should load as a virtual style module",
+);
+assert.doesNotMatch(
+  scssVirtualLoad.code,
+  /^\[data-v-scssscope\]/,
+  "Scoped preprocessors should not be wrapped before Sass expands nested selectors",
+);
+
 const onDemandProdDir = createTempRoot("load");
 const onDemandProdPath = path.join(onDemandProdDir, "OnDemandProd.vue");
 fs.writeFileSync(

--- a/npm/vite-plugin-vize/src/plugin/load.ts
+++ b/npm/vite-plugin-vize/src/plugin/load.ts
@@ -165,28 +165,6 @@ export function loadHook(
         styleContent = scopeCssForPipeline(styleContent, scoped);
       }
 
-      // For scoped preprocessor styles, wrap content in a scope selector
-      if (scoped && block.scoped && lang && lang !== "css") {
-        const lines = styleContent.split("\n");
-        const hoisted: string[] = [];
-        const body: string[] = [];
-        for (const line of lines) {
-          const trimmed = line.trimStart();
-          if (
-            trimmed.startsWith("@use ") ||
-            trimmed.startsWith("@forward ") ||
-            trimmed.startsWith("@import ")
-          ) {
-            hoisted.push(line);
-          } else {
-            body.push(line);
-          }
-        }
-        const bodyContent = body.join("\n");
-        const hoistedContent = hoisted.length > 0 ? hoisted.join("\n") + "\n\n" : "";
-        styleContent = `${hoistedContent}[${scoped}] {\n${bodyContent}\n}`;
-      }
-
       styleContent = transformCssVarsForPipeline(styleContent, fallbackCompiled.scopeId);
 
       return {


### PR DESCRIPTION
## Summary
- stop wrapping scoped SCSS/Less/etc. style blocks before Vite preprocesses them
- add a normal-order style transform that scopes delegated preprocessor CSS after Vite expands it
- cover the MkSuperMenu selector shape and virtual SCSS load path

## Why
Vize was wrapping delegated scoped preprocessor styles as `[data-v-*] { ... }` before Sass ran. Nested selectors then compiled with the scope attribute as an ancestor, e.g. `[data-v-*] .rrevdjwu > .group + .group`, instead of Vue-compatible `.rrevdjwu > .group + .group[data-v-*]`.

Closes #581
Refs https://github.com/ubugeeei/vize/discussions/71#discussioncomment-17030636

## Checks
- `pnpm --dir npm/vite-plugin-vize check`
- `pnpm --dir npm/vite-plugin-vize test`