### PR TITLE
fix(sfc): expose normal script bindings to templates

### DIFF
--- a/crates/vize_atelier_sfc/src/compile.rs
+++ b/crates/vize_atelier_sfc/src/compile.rs
@@ -24,7 +24,9 @@ use crate::types::{
     BindingType, SfcCompileOptions, SfcCompileResult, SfcDescriptor, SfcError, SfcMacroArtifact,
 };
 
-use self::bindings::{croquis_to_legacy_bindings, register_normal_script_bindings};
+use self::bindings::{
+    collect_normal_script_bindings, croquis_to_legacy_bindings, merge_normal_script_bindings,
+};
 use self::helpers::{
     demote_v_model_reactive_const_bindings, extract_component_name, generate_scope_id,
 };
@@ -491,16 +493,18 @@ pub fn compile_sfc(
     }
 
     // Register bindings from normal <script> block.
-    // When both <script> and <script setup> exist, all imports and exported
-    // variables from the normal script are accessible in the template.
+    // When both <script> and <script setup> exist, top-level imports and
+    // declarations from the normal script are accessible in the template.
     // This enables proper component resolution (e.g., `import { Form as PForm }`)
     // and identifier prefix resolution (avoiding incorrect `_ctx.` prefix).
     if has_script {
         let script = descriptor.script.as_ref().unwrap();
-        profile!(
+        let normal_script_bindings = profile!(
             "atelier.sfc.normal_script.register_bindings",
-            register_normal_script_bindings(&script.content, &mut script_bindings)
+            collect_normal_script_bindings(&script.content)
         );
+        merge_normal_script_bindings(&mut script_bindings, &normal_script_bindings);
+        merge_normal_script_bindings(&mut ctx.bindings, &normal_script_bindings);
     }
 
     if let Some(template) = &descriptor.template {

--- a/crates/vize_atelier_sfc/src/compile/bindings.rs
+++ b/crates/vize_atelier_sfc/src/compile/bindings.rs
@@ -3,6 +3,10 @@
 //! Handles converting between Croquis and legacy binding formats,
 //! and registering bindings from normal `<script>` blocks.
 
+use oxc_ast::ast::{
+    BindingPattern, Declaration, Expression, ImportDeclarationSpecifier, Statement,
+    VariableDeclaration, VariableDeclarationKind,
+};
 use vize_carton::ToCompactString;
 
 use crate::types::{BindingMetadata, BindingType};
@@ -23,24 +27,24 @@ pub(super) fn croquis_to_legacy_bindings(
     dst
 }
 
-/// Register bindings from normal `<script>` block into `BindingMetadata`.
+/// Collect bindings from normal `<script>` block.
 ///
-/// When both `<script>` and `<script setup>` exist, all imports and exported
+/// When both `<script>` and `<script setup>` exist, top-level imports and
 /// declarations from the normal script are accessible in the template.
-/// Uses OXC parser for accurate import extraction (handles `import { Form as PForm }`,
-/// default imports, namespace imports, re-exports, etc.).
-pub(super) fn register_normal_script_bindings(content: &str, bindings: &mut BindingMetadata) {
+/// Uses OXC parser for accurate import and declaration extraction (handles
+/// `import { Form as PForm }`, default imports, and namespace imports).
+pub(super) fn collect_normal_script_bindings(content: &str) -> BindingMetadata {
     use oxc_allocator::Allocator;
-    use oxc_ast::ast::{Declaration, ImportDeclarationSpecifier, Statement};
     use oxc_parser::Parser;
     use oxc_span::SourceType;
 
     let allocator = Allocator::default();
     let source_type = SourceType::from_path("script.ts").unwrap_or_default();
     let ret = Parser::new(&allocator, content, source_type).parse();
+    let mut bindings = BindingMetadata::default();
 
     if ret.panicked {
-        return;
+        return bindings;
     }
 
     for stmt in ret.program.body.iter() {
@@ -83,23 +87,170 @@ pub(super) fn register_normal_script_bindings(content: &str, bindings: &mut Bind
                     }
                 }
             }
-            // Register exported variable declarations: export const foo = ...
+            Statement::VariableDeclaration(var_decl) => {
+                register_variable_declaration(var_decl, &mut bindings);
+            }
+            Statement::FunctionDeclaration(func) => {
+                if let Some(id) = &func.id {
+                    bindings
+                        .bindings
+                        .entry(id.name.to_compact_string())
+                        .or_insert(BindingType::SetupConst);
+                }
+            }
+            Statement::ClassDeclaration(class) => {
+                if let Some(id) = &class.id {
+                    bindings
+                        .bindings
+                        .entry(id.name.to_compact_string())
+                        .or_insert(BindingType::SetupConst);
+                }
+            }
             Statement::ExportNamedDeclaration(decl) => {
-                if let Some(ref declaration) = decl.declaration
-                    && let Declaration::VariableDeclaration(var_decl) = declaration
-                {
-                    for declarator in &var_decl.declarations {
-                        if let oxc_ast::ast::BindingPattern::BindingIdentifier(id) = &declarator.id
-                        {
-                            bindings
-                                .bindings
-                                .entry(id.name.to_compact_string())
-                                .or_insert(BindingType::SetupConst);
+                if let Some(ref declaration) = decl.declaration {
+                    match declaration {
+                        Declaration::VariableDeclaration(var_decl) => {
+                            register_variable_declaration(var_decl, &mut bindings);
                         }
+                        Declaration::FunctionDeclaration(func) => {
+                            if let Some(id) = &func.id {
+                                bindings
+                                    .bindings
+                                    .entry(id.name.to_compact_string())
+                                    .or_insert(BindingType::SetupConst);
+                            }
+                        }
+                        Declaration::ClassDeclaration(class) => {
+                            if let Some(id) = &class.id {
+                                bindings
+                                    .bindings
+                                    .entry(id.name.to_compact_string())
+                                    .or_insert(BindingType::SetupConst);
+                            }
+                        }
+                        _ => {}
                     }
                 }
             }
             _ => {}
         }
+    }
+
+    bindings
+}
+
+fn register_variable_declaration(
+    var_decl: &VariableDeclaration<'_>,
+    bindings: &mut BindingMetadata,
+) {
+    for declarator in &var_decl.declarations {
+        let binding_type = infer_variable_binding_type(var_decl.kind, declarator.init.as_ref());
+        register_binding_pattern(&declarator.id, binding_type, bindings);
+    }
+}
+
+fn infer_variable_binding_type(
+    kind: VariableDeclarationKind,
+    init: Option<&Expression<'_>>,
+) -> BindingType {
+    let Some(init) = init else {
+        return match kind {
+            VariableDeclarationKind::Const
+            | VariableDeclarationKind::Using
+            | VariableDeclarationKind::AwaitUsing => BindingType::SetupConst,
+            VariableDeclarationKind::Let | VariableDeclarationKind::Var => BindingType::SetupLet,
+        };
+    };
+
+    if let Expression::CallExpression(call) = init
+        && let Expression::Identifier(callee) = &call.callee
+    {
+        match callee.name.as_str() {
+            "ref" | "shallowRef" | "customRef" | "toRef" | "toRefs" | "computed"
+            | "useTemplateRef" => return BindingType::SetupRef,
+            "reactive" | "shallowReactive" | "readonly" | "shallowReadonly" => {
+                return BindingType::SetupReactiveConst;
+            }
+            _ => {}
+        }
+    }
+
+    if kind == VariableDeclarationKind::Const {
+        if is_literal(init) {
+            return BindingType::LiteralConst;
+        }
+        if matches!(
+            init,
+            Expression::ArrowFunctionExpression(_)
+                | Expression::FunctionExpression(_)
+                | Expression::ObjectExpression(_)
+                | Expression::ArrayExpression(_)
+        ) {
+            return BindingType::SetupConst;
+        }
+    }
+
+    match kind {
+        VariableDeclarationKind::Const => BindingType::SetupMaybeRef,
+        VariableDeclarationKind::Let | VariableDeclarationKind::Var => BindingType::SetupLet,
+        VariableDeclarationKind::Using | VariableDeclarationKind::AwaitUsing => {
+            BindingType::SetupConst
+        }
+    }
+}
+
+fn is_literal(expr: &Expression<'_>) -> bool {
+    match expr {
+        Expression::StringLiteral(_)
+        | Expression::NumericLiteral(_)
+        | Expression::BooleanLiteral(_)
+        | Expression::NullLiteral(_)
+        | Expression::BigIntLiteral(_) => true,
+        Expression::TemplateLiteral(tl) => tl.expressions.is_empty(),
+        _ => false,
+    }
+}
+
+fn register_binding_pattern(
+    pattern: &BindingPattern<'_>,
+    binding_type: BindingType,
+    bindings: &mut BindingMetadata,
+) {
+    match pattern {
+        BindingPattern::BindingIdentifier(id) => {
+            bindings
+                .bindings
+                .entry(id.name.to_compact_string())
+                .or_insert(binding_type);
+        }
+        BindingPattern::ObjectPattern(obj) => {
+            for prop in obj.properties.iter() {
+                register_binding_pattern(&prop.value, binding_type, bindings);
+            }
+            if let Some(rest) = obj.rest.as_ref() {
+                register_binding_pattern(&rest.argument, binding_type, bindings);
+            }
+        }
+        BindingPattern::ArrayPattern(arr) => {
+            for element in arr.elements.iter().flatten() {
+                register_binding_pattern(element, binding_type, bindings);
+            }
+            if let Some(rest) = arr.rest.as_ref() {
+                register_binding_pattern(&rest.argument, binding_type, bindings);
+            }
+        }
+        BindingPattern::AssignmentPattern(assign) => {
+            register_binding_pattern(&assign.left, binding_type, bindings);
+        }
+    }
+}
+
+/// Merge normal script bindings without changing the target metadata flags.
+pub(super) fn merge_normal_script_bindings(
+    target: &mut BindingMetadata,
+    normal_bindings: &BindingMetadata,
+) {
+    for (name, binding_type) in &normal_bindings.bindings {
+        target.bindings.entry(name.clone()).or_insert(*binding_type);
     }
 }

--- a/crates/vize_atelier_sfc/src/compile/tests.rs
+++ b/crates/vize_atelier_sfc/src/compile/tests.rs
@@ -781,6 +781,83 @@ const { items } = defineProps<{
 }
 
 #[test]
+fn test_compile_both_script_blocks_exposes_normal_script_bindings_to_template() {
+    let source = r#"<script lang="ts">
+import { ref } from "vue";
+
+const dragging = ref(false);
+let dropCallback = null;
+
+function resetDragging() {
+  dragging.value = false;
+}
+</script>
+
+<script setup lang="ts">
+const items = [{ id: "a" }];
+
+function start() {
+  dragging.value = true;
+  dropCallback = resetDragging;
+}
+</script>
+
+<template>
+  <div :class="{ dragging }">
+    <button v-for="item in items" :key="item.id" @click="start">{{ item.id }}</button>
+  </div>
+</template>"#;
+
+    let descriptor = parse_sfc(source, SfcParseOptions::default()).expect("Failed to parse SFC");
+    let opts = SfcCompileOptions {
+        script: ScriptCompileOptions {
+            is_ts: true,
+            ..Default::default()
+        },
+        template: TemplateCompileOptions {
+            is_ts: true,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let result = compile_sfc(&descriptor, opts).expect("Failed to compile SFC");
+
+    assert!(
+        result.code.contains("dragging.value"),
+        "template should read normal-script ref binding directly: {}",
+        result.code
+    );
+    assert!(
+        !result.code.contains("_ctx.dragging"),
+        "normal-script ref binding should not be emitted as instance context access: {}",
+        result.code
+    );
+
+    let bindings = result.bindings.expect("bindings should be available");
+    assert!(
+        matches!(
+            bindings.bindings.get("dragging"),
+            Some(BindingType::SetupRef)
+        ),
+        "dragging should be registered as a ref binding"
+    );
+    assert!(
+        matches!(
+            bindings.bindings.get("dropCallback"),
+            Some(BindingType::SetupLet)
+        ),
+        "dropCallback should be registered as a let binding"
+    );
+    assert!(
+        matches!(
+            bindings.bindings.get("resetDragging"),
+            Some(BindingType::SetupConst)
+        ),
+        "resetDragging should be registered as a normal-script function binding"
+    );
+}
+
+#[test]
 fn test_script_setup_typescript_downcompiles_to_javascript_by_default() {
     let source = r#"<script setup lang="ts">
 const props = withDefaults(defineProps<{

--- a/tests/snapshots/build/__snapshots__/misskey-build-output/MkDraggable.js
+++ b/tests/snapshots/build/__snapshots__/misskey-build-output/MkDraggable.js
@@ -108,7 +108,7 @@ export default {
         leaveToClass: _ctx.$style.transition_items_leaveTo,
         moveClass: _ctx.$style.transition_items_move,
         class: _normalizeClass([_ctx.$style.items, {
-          [_ctx.$style.dragging]: _ctx.dragging,
+          [_ctx.$style.dragging]: dragging.value,
           [_ctx.$style.horizontal]: __props.direction === "horizontal",
           [_ctx.$style.vertical]: __props.direction === "vertical",
           [_ctx.$style.withGaps]: __props.withGaps,

--- a/tests/snapshots/build/misskey.ts
+++ b/tests/snapshots/build/misskey.ts
@@ -157,5 +157,15 @@ describe(`${app.name} build (compiler)`, () => {
       ),
       "MkPagination.js should keep the appear binding on the upward load-more button",
     );
+
+    const draggable = readOutput("MkDraggable.js");
+    assert.ok(
+      !draggable.includes("_ctx.dragging"),
+      "MkDraggable.js should not read the normal <script> dragging ref from instance context",
+    );
+    assert.ok(
+      draggable.includes("dragging.value"),
+      "MkDraggable.js should read the normal <script> dragging ref as a setup/module binding",
+    );
   });
 });


### PR DESCRIPTION
## Summary

- Collect top-level normal `<script>` imports/declarations when compiling SFCs with `<script setup>`.
- Merge those bindings into both template binding metadata and setup return metadata so templates do not fall back to `_ctx`.
- Add a minimal regression for the `MkDraggable` pattern and assert the Misskey build output reads `dragging.value` instead of `_ctx.dragging`.

## Root Cause

`MkDraggable` declares `const dragging = ref(false)` in normal `<script>` and reads `dragging` from the template class binding. Vize only registered imports/exported variables from the normal script, so the template compiler emitted `_ctx.dragging`; the dragging class never became active under Vize.

Source discussion: https://github.com/ubugeeei/vize/discussions/71#discussioncomment-17030636
Closes #582

## Verification

- `cargo fmt --check`
- `cargo test -p vize_atelier_sfc`
- `cargo build -p vize`
- `VIZE_BIN=/Users/ubugeeei/Source/github.com/ubugeeei/vize/target/debug/vize node --test tests/snapshots/build/misskey.ts`