### PR TITLE
test: add strict zed package smoke

### DIFF
--- a/tests/tooling/editor-integrations.test.ts
+++ b/tests/tooling/editor-integrations.test.ts
@@ -219,4 +219,6 @@ test("CI packages editor extension artifacts", () => {
   assert.match(buildTasks, /package:vscode-extension[\s\S]*assert-vsix-package\.mjs/);
   assert.match(buildTasks, /package:editor-extensions[\s\S]*assert-vsix-package\.mjs/);
   assert.match(testTasks, /test:vscode-extension:vsix[\s\S]*assert-vsix-package\.mjs/);
+  assert.match(buildTasks, /package:zed-extension[\s\S]*assert-zed-package\.mjs/);
+  assert.match(testTasks, /test:zed-extension:package[\s\S]*package:zed-extension/);
 });

--- a/tools/vite-plus/tasks/build.ts
+++ b/tools/vite-plus/tasks/build.ts
@@ -55,7 +55,7 @@ export const buildTasks = defineTasks({
     input: ["npm/zed-vize/**"],
   }),
   "package:zed-extension": noCacheTask(
-    "tar --exclude 'zed-vize/target' -czf zed-vize-extension.tar.gz -C npm zed-vize",
+    "COPYFILE_DISABLE=1 LC_ALL=C LANG=C tar --exclude 'zed-vize/target' -czf zed-vize-extension.tar.gz -C npm zed-vize && node tools/zed-vize/assert-zed-package.mjs zed-vize-extension.tar.gz",
   ),
   "package:editor-extensions": noCacheTask(
     `${runInVscodeExtension(

--- a/tools/vite-plus/tasks/test-benchmark.ts
+++ b/tools/vite-plus/tasks/test-benchmark.ts
@@ -71,6 +71,7 @@ export const testAndBenchmarkTasks = defineTasks({
       "node ../../tools/vscode-vize/assert-vsix-package.mjs dist/vize.vsix",
     ),
   ),
+  "test:zed-extension:package": noCacheTask("vp run --workspace-root package:zed-extension"),
   "test:playground": task(runInPackages("test:browser", ["./playground"]), {
     input: cacheInputs.jsChecks,
   }),

--- a/tools/zed-vize/assert-zed-package.mjs
+++ b/tools/zed-vize/assert-zed-package.mjs
@@ -1,0 +1,229 @@
+#!/usr/bin/env node
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import zlib from "node:zlib";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const archivePath = path.resolve(
+  process.cwd(),
+  process.argv[2] ?? path.join(root, "zed-vize-extension.tar.gz"),
+);
+
+assert.ok(fs.existsSync(archivePath), `Zed extension archive does not exist: ${archivePath}`);
+
+const archiveSize = fs.statSync(archivePath).size;
+assert.ok(archiveSize > 5_000, `Zed extension archive is suspiciously small: ${archiveSize} bytes`);
+assert.ok(
+  archiveSize < 2_000_000,
+  `Zed extension archive is unexpectedly large: ${archiveSize} bytes`,
+);
+
+const entries = readTarGz(archivePath);
+const entryNames = entries.map((entry) => entry.name).sort((a, b) => a.localeCompare(b));
+const entryMap = new Map(entries.map((entry) => [entry.name, entry]));
+
+assert.deepEqual(
+  entryNames,
+  Array.from(new Set(entryNames)),
+  "Zed archive contains duplicate entries",
+);
+
+for (const name of entryNames) {
+  assert.ok(!name.includes("\\"), `Zed archive entry must use POSIX separators: ${name}`);
+  assert.ok(!name.includes("\0"), `Zed archive entry contains a NUL byte: ${name}`);
+  assert.ok(!name.startsWith("/"), `Zed archive entry must be relative: ${name}`);
+  assert.ok(!name.split("/").includes(".."), `Zed archive entry must not traverse: ${name}`);
+  assert.ok(name === "zed-vize/" || name.startsWith("zed-vize/"), `unexpected root: ${name}`);
+}
+
+const requiredFiles = [
+  "zed-vize/Cargo.lock",
+  "zed-vize/Cargo.toml",
+  "zed-vize/LICENSE",
+  "zed-vize/README.md",
+  "zed-vize/extension.toml",
+  "zed-vize/languages/art-vue/brackets.scm",
+  "zed-vize/languages/art-vue/config.toml",
+  "zed-vize/languages/art-vue/highlights.scm",
+  "zed-vize/languages/art-vue/indents.scm",
+  "zed-vize/languages/art-vue/injections.scm",
+  "zed-vize/languages/art-vue/outline.scm",
+  "zed-vize/languages/art-vue/overrides.scm",
+  "zed-vize/src/lib.rs",
+];
+
+for (const name of requiredFiles) {
+  assert.ok(entryMap.has(name), `Zed archive is missing required file: ${name}`);
+  assert.ok(readTextEntry(entryMap, name).trim().length > 0, `Zed archive file is empty: ${name}`);
+}
+
+const allowedEntries = [
+  /^zed-vize\/$/,
+  /^zed-vize\/Cargo\.lock$/,
+  /^zed-vize\/Cargo\.toml$/,
+  /^zed-vize\/LICENSE$/,
+  /^zed-vize\/README\.md$/,
+  /^zed-vize\/extension\.toml$/,
+  /^zed-vize\/languages\/$/,
+  /^zed-vize\/languages\/art-vue\/$/,
+  /^zed-vize\/languages\/art-vue\/(?:brackets|config|highlights|indents|injections|outline|overrides)\.scm$/,
+  /^zed-vize\/languages\/art-vue\/config\.toml$/,
+  /^zed-vize\/src\/$/,
+  /^zed-vize\/src\/lib\.rs$/,
+];
+
+for (const name of entryNames) {
+  assert.ok(
+    allowedEntries.some((pattern) => pattern.test(name)),
+    `Zed archive ships an unexpected file: ${name}`,
+  );
+}
+
+const forbiddenEntries = [
+  /^zed-vize\/\.git/,
+  /^zed-vize\/\.github\//,
+  /^zed-vize\/\.zed\//,
+  /^zed-vize\/node_modules\//,
+  /^zed-vize\/target\//,
+  /\/\.DS_Store$/,
+  /~$/,
+];
+
+for (const name of entryNames) {
+  for (const pattern of forbiddenEntries) {
+    assert.ok(!pattern.test(name), `Zed archive must not ship ${name}`);
+  }
+}
+
+const workspaceVersion = readWorkspaceVersion();
+const extensionToml = readTextEntry(entryMap, "zed-vize/extension.toml");
+const cargoToml = readTextEntry(entryMap, "zed-vize/Cargo.toml");
+const libRs = readTextEntry(entryMap, "zed-vize/src/lib.rs");
+const artVueConfig = readTextEntry(entryMap, "zed-vize/languages/art-vue/config.toml");
+const injections = readTextEntry(entryMap, "zed-vize/languages/art-vue/injections.scm");
+const highlights = readTextEntry(entryMap, "zed-vize/languages/art-vue/highlights.scm");
+
+assertTomlString(extensionToml, "id", "vize");
+assertTomlString(extensionToml, "name", "Vize");
+assertTomlString(extensionToml, "version", workspaceVersion);
+assertTomlString(extensionToml, "repository", "https://github.com/ubugeeei/vize");
+assert.match(extensionToml, /^\[language_servers\.vize\]$/m);
+assert.match(extensionToml, /^languages = \["Vue", "Art Vue"\]$/m);
+assert.match(extensionToml, /^\[language_servers\.vize\.language_ids\]$/m);
+assert.match(extensionToml, /^"Vue" = "vue"$/m);
+assert.match(extensionToml, /^"Art Vue" = "art-vue"$/m);
+assert.match(extensionToml, /^\[grammars\.art-vue\]$/m);
+assert.match(extensionToml, /^commit = "[0-9a-f]{40}"$/m);
+
+assertTomlString(cargoToml, "name", "vize-zed-extension");
+assertTomlString(cargoToml, "version", workspaceVersion);
+assertTomlString(cargoToml, "edition", "2024");
+assertTomlString(cargoToml, "license", "MIT");
+assert.match(cargoToml, /^publish = false$/m);
+assert.match(cargoToml, /^crate-type = \["cdylib"\]$/m);
+assert.match(cargoToml, /^zed_extension_api = "=0\.7\.0"$/m);
+
+assert.match(libRs, /const SERVER_NAME: &'static str = "vize";/);
+assert.match(libRs, /const SERVER_BINARY: &'static str = "vize";/);
+assert.match(libRs, /worktree\.which\(Self::SERVER_BINARY\)/);
+assert.match(libRs, /unwrap_or_else\(\|\| vec!\["lsp"\.to_string\(\)\]\)/);
+assert.match(libRs, /language_server_initialization_options/);
+assert.match(libRs, /language_server_workspace_configuration/);
+assert.match(libRs, /zed::register_extension!\(VizeExtension\);/);
+
+assertTomlString(artVueConfig, "name", "Art Vue");
+assertTomlString(artVueConfig, "grammar", "art-vue");
+assert.match(artVueConfig, /^path_suffixes = \["art\.vue"\]$/m);
+assertTomlString(artVueConfig, "prettier_parser_name", "vue");
+
+for (const queryFile of [
+  "brackets",
+  "highlights",
+  "indents",
+  "injections",
+  "outline",
+  "overrides",
+]) {
+  const contents = readTextEntry(entryMap, `zed-vize/languages/art-vue/${queryFile}.scm`);
+  assert.ok(contents.trim().length > 0, `${queryFile}.scm must not be empty`);
+}
+
+assert.match(injections, /directive_attribute/);
+assert.match(injections, /style_element/);
+assert.match(injections, /template_element/);
+assert.match(highlights, /@tag\.component\.type\.constructor/);
+
+console.log(
+  `Zed package smoke passed: ${path.relative(root, archivePath)} (${entryNames.length} entries)`,
+);
+
+function assertTomlString(source, key, expected) {
+  assert.match(source, new RegExp(`^${escapeRegExp(key)} = "${escapeRegExp(expected)}"$`, "m"));
+}
+
+function readWorkspaceVersion() {
+  const cargoToml = fs.readFileSync(path.join(root, "Cargo.toml"), "utf-8");
+  const version = cargoToml.match(/^version = "(.+)"$/m)?.[1];
+  assert.ok(version, "workspace version is missing from Cargo.toml");
+  return version;
+}
+
+function readTextEntry(entryMap, name) {
+  const entry = entryMap.get(name);
+  assert.ok(entry, `missing tar entry: ${name}`);
+  return entry.data.toString("utf-8");
+}
+
+function readTarGz(filePath) {
+  const buffer = zlib.gunzipSync(fs.readFileSync(filePath));
+  const entries = [];
+  let offset = 0;
+
+  while (offset + 512 <= buffer.byteLength) {
+    const header = buffer.subarray(offset, offset + 512);
+    if (header.every((byte) => byte === 0)) {
+      break;
+    }
+
+    const name = readTarString(header, 0, 100);
+    const prefix = readTarString(header, 345, 155);
+    const fullName = prefix ? `${prefix}/${name}` : name;
+    const size = parseOctal(readTarString(header, 124, 12));
+    const typeflag = readTarString(header, 156, 1) || "0";
+    const dataOffset = offset + 512;
+    const data = buffer.subarray(dataOffset, dataOffset + size);
+
+    assert.ok(fullName, "tar entry name must not be empty");
+    if (typeflag === "x" || typeflag === "g") {
+      offset = dataOffset + Math.ceil(size / 512) * 512;
+      continue;
+    }
+
+    assert.ok(
+      typeflag === "0" || typeflag === "5",
+      `unsupported tar entry type ${typeflag}: ${fullName}`,
+    );
+
+    entries.push({ data, name: fullName, size, typeflag });
+    offset = dataOffset + Math.ceil(size / 512) * 512;
+  }
+
+  return entries;
+}
+
+function readTarString(buffer, offset, length) {
+  const raw = buffer.subarray(offset, offset + length);
+  const end = raw.indexOf(0);
+  return raw.subarray(0, end === -1 ? raw.byteLength : end).toString("utf-8");
+}
+
+function parseOctal(value) {
+  const trimmed = value.trim();
+  return trimmed ? Number.parseInt(trimmed, 8) : 0;
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}


### PR DESCRIPTION
## Summary

Refs #588.

- Add a strict Zed extension archive smoke test that parses `zed-vize-extension.tar.gz` directly.
- Verify archive hygiene: required files, exact allowed layout, no `target/**`, no hidden metadata, no traversal/absolute paths, and no unexpected entries.
- Verify production contract from the artifact: `extension.toml`, version alignment, language server mapping, Art Vue grammar registration, query files, and Rust command/default `vize lsp` behavior.
- Make `package:zed-extension` run the smoke and prevent macOS AppleDouble metadata with `COPYFILE_DISABLE=1`.
- Add focused `test:zed-extension:package` wiring.

## Local Validation

- `vp run --workspace-root test:zed-extension:package`
- `node --test tests/tooling/editor-integrations.test.ts`
- `vp run --workspace-root package:editor-extensions`
- `vp run --workspace-root check:repo`
- `node tools/zed-vize/assert-zed-package.mjs zed-vize-extension.tar.gz`
- `git diff --check`

## CI Policy For This Test Series

Per the latest direction, I did not wait for GitHub Actions on this individual test-addition PR. The plan is to rely on strong local validation for the incremental PRs and run/wait on CI at the final combined checkpoint.