### PR TITLE
test: add vscode extension host smoke

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ _build/
 # npm package build outputs
 npm/*/dist/
 npm/vite-plugin-vize/wasm/
+npm/vscode-vize/.vscode-test/
 npm/zed-vize/target/
 
 # Native (NAPI) build output

--- a/npm/vscode-vize/.vscodeignore
+++ b/npm/vscode-vize/.vscodeignore
@@ -1,6 +1,9 @@
 node_modules/
 src/
+.vscode-test/
 .vscode/
+test/
+test-fixtures/
 *.vsix
 **/*.vsix
 tsconfig.json

--- a/npm/vscode-vize/package.json
+++ b/npm/vscode-vize/package.json
@@ -35,6 +35,7 @@
     "check:fix": "vp check --fix src vite.config.ts && tsgo --noEmit",
     "fmt": "vp fmt --write src vite.config.ts",
     "package": "vsce package --no-dependencies --out dist/vize.vsix",
+    "test:host": "node test/run-extension-host.mjs",
     "publish": "vsce publish --no-dependencies",
     "publish:pre": "vsce publish --no-dependencies --pre-release"
   },
@@ -45,6 +46,7 @@
     "@types/node": "25.6.0",
     "@types/vscode": "1.75.0",
     "@typescript/native-preview": "7.0.0-dev.20260421.1",
+    "@vscode/test-electron": "2.5.2",
     "@vscode/vsce": "3.9.1",
     "typescript": "6.0.3",
     "vite-plus": "0.1.19"

--- a/npm/vscode-vize/test-fixtures/extension-host/basic-vue/.vscode/settings.json
+++ b/npm/vscode-vize/test-fixtures/extension-host/basic-vue/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "vize.enable": false
+}

--- a/npm/vscode-vize/test-fixtures/extension-host/basic-vue/src/App.vue
+++ b/npm/vscode-vize/test-fixtures/extension-host/basic-vue/src/App.vue
@@ -1,0 +1,7 @@
+<script setup lang="ts">
+const message = "hello from vize";
+</script>
+
+<template>
+  <main>{{ message }}</main>
+</template>

--- a/npm/vscode-vize/test-fixtures/extension-host/basic-vue/src/Variant.art.vue
+++ b/npm/vscode-vize/test-fixtures/extension-host/basic-vue/src/Variant.art.vue
@@ -1,0 +1,7 @@
+<script setup lang="ts">
+const label = "art vue";
+</script>
+
+<template>
+  <section>{{ label }}</section>
+</template>

--- a/npm/vscode-vize/test/run-extension-host.mjs
+++ b/npm/vscode-vize/test/run-extension-host.mjs
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { runTests } from "@vscode/test-electron";
+
+const extensionDevelopmentPath = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const workspacePath = path.join(
+  extensionDevelopmentPath,
+  "test-fixtures",
+  "extension-host",
+  "basic-vue",
+);
+const extensionTestsPath = path.join(
+  extensionDevelopmentPath,
+  "test",
+  "suite",
+  "extension-host.cjs",
+);
+
+await runTests({
+  extensionDevelopmentPath,
+  extensionTestsPath,
+  launchArgs: [
+    "--disable-extensions",
+    "--disable-workspace-trust",
+    "--skip-welcome",
+    "--skip-release-notes",
+    workspacePath,
+  ],
+});

--- a/npm/vscode-vize/test/suite/extension-host.cjs
+++ b/npm/vscode-vize/test/suite/extension-host.cjs
@@ -1,0 +1,53 @@
+const assert = require("node:assert/strict");
+const path = require("node:path");
+const vscode = require("vscode");
+
+const extensionId = "ubugeeei.vize";
+const commandIds = [
+  "vize.disable",
+  "vize.enableLintOnlyProfile",
+  "vize.enableRecommendedProfile",
+  "vize.findReferences",
+  "vize.restartServer",
+  "vize.selectServerPath",
+  "vize.showOutput",
+  "vize.showStatus",
+];
+
+exports.run = async function run() {
+  const extension = vscode.extensions.getExtension(extensionId);
+  assert.ok(extension, `missing extension: ${extensionId}`);
+  assert.equal(extension.packageJSON.name, "vize");
+  assert.equal(extension.packageJSON.publisher, "ubugeeei");
+
+  await extension.activate();
+  assert.equal(extension.isActive, true);
+
+  const allCommands = await vscode.commands.getCommands(true);
+  for (const commandId of commandIds) {
+    assert.ok(allCommands.includes(commandId), `missing command: ${commandId}`);
+  }
+
+  const config = vscode.workspace.getConfiguration("vize");
+  assert.equal(config.get("enable"), false);
+  assert.equal(config.get("serverPath"), "");
+
+  const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+  assert.ok(workspaceFolder, "expected a workspace folder");
+
+  const vueDocument = await vscode.workspace.openTextDocument(
+    vscode.Uri.file(path.join(workspaceFolder.uri.fsPath, "src", "App.vue")),
+  );
+  assert.equal(vueDocument.languageId, "vue");
+
+  const artVueDocument = await vscode.workspace.openTextDocument(
+    vscode.Uri.file(path.join(workspaceFolder.uri.fsPath, "src", "Variant.art.vue")),
+  );
+  assert.equal(artVueDocument.languageId, "art-vue");
+
+  await vscode.window.showTextDocument(vueDocument);
+  await vscode.commands.executeCommand("vize.showOutput");
+  await vscode.commands.executeCommand("vize.disable");
+
+  assert.equal(vscode.workspace.getConfiguration("vize").get("enable"), false);
+};

--- a/tests/tooling/editor-integrations.test.ts
+++ b/tests/tooling/editor-integrations.test.ts
@@ -219,6 +219,7 @@ test("CI packages editor extension artifacts", () => {
   assert.match(buildTasks, /package:vscode-extension[\s\S]*assert-vsix-package\.mjs/);
   assert.match(buildTasks, /package:editor-extensions[\s\S]*assert-vsix-package\.mjs/);
   assert.match(testTasks, /test:vscode-extension:vsix[\s\S]*assert-vsix-package\.mjs/);
+  assert.match(testTasks, /test:vscode-extension:host[\s\S]*pnpm run test:host/);
   assert.match(buildTasks, /package:zed-extension[\s\S]*assert-zed-package\.mjs/);
   assert.match(testTasks, /test:zed-extension:package[\s\S]*package:zed-extension/);
 });

--- a/tools/vite-plus/tasks/test-benchmark.ts
+++ b/tools/vite-plus/tasks/test-benchmark.ts
@@ -71,6 +71,9 @@ export const testAndBenchmarkTasks = defineTasks({
       "node ../../tools/vscode-vize/assert-vsix-package.mjs dist/vize.vsix",
     ),
   ),
+  "test:vscode-extension:host": noCacheTask(
+    runInVscodeExtension("pnpm exec vp pack", "pnpm run test:host"),
+  ),
   "test:zed-extension:package": noCacheTask("vp run --workspace-root package:zed-extension"),
   "test:playground": task(runInPackages("test:browser", ["./playground"]), {
     input: cacheInputs.jsChecks,

--- a/tools/vscode-vize/assert-vsix-package.mjs
+++ b/tools/vscode-vize/assert-vsix-package.mjs
@@ -79,6 +79,7 @@ for (const name of entryNames.filter((entry) => entry.startsWith("extension/")))
 
 const forbiddenEntries = [
   /^extension\/\.github\//,
+  /^extension\/\.vscode-test\//,
   /^extension\/\.vscode\//,
   /^extension\/dist\/.*\.map$/,
   /^extension\/node_modules\//,
@@ -86,6 +87,7 @@ const forbiddenEntries = [
   /^extension\/pnpm-lock\.yaml$/,
   /^extension\/src\//,
   /^extension\/test(?:s)?\//,
+  /^extension\/test-fixtures\//,
   /^extension\/tsconfig\.json$/,
   /^extension\/vite\.config\.ts$/,
   /\.vsix$/,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,7 +4,12 @@ import { floatingPromiseTestPatterns } from "./tools/vite-plus/task-inputs.ts";
 import { taskCatalog } from "./tools/vite-plus/task-groups.ts";
 import { rootBuildTaskPlugin } from "./tools/vite-plus/task-helpers.ts";
 
-const localGeneratedIgnorePatterns = [".cache/**", ".direnv/**", "target/**"];
+const localGeneratedIgnorePatterns = [
+  ".cache/**",
+  ".direnv/**",
+  "npm/vscode-vize/.vscode-test/**",
+  "target/**",
+];
 
 /**
  * Root Vite+ configuration.


### PR DESCRIPTION
## Summary
- add a VS Code Extension Host smoke that runs the extension inside real VS Code via @vscode/test-electron
- cover activation, contributed commands, opt-in default settings, and Vue / Art Vue language detection in a fixture workspace
- keep generated VS Code downloads and host fixtures out of the VSIX package, with archive assertions guarding against accidental shipment

## Validation
- vp run --workspace-root check:repo
- vp run --workspace-root test:vscode-extension:host
- vp run --workspace-root test:vscode-extension:vsix
- node --test tests/tooling/editor-integrations.test.ts
- vp run --workspace-root package:editor-extensions
- git diff --check

Refs #588
