### PR TITLE
fix: reset vscode lint-only profile state

### DIFF
--- a/npm/vscode-vize/src/extension.ts
+++ b/npm/vscode-vize/src/extension.ts
@@ -321,6 +321,7 @@ async function applyLintOnlyConfiguration(): Promise<void> {
     ["diagnostics.enable", false],
     ["typecheck.enable", false],
     ["editor.enable", false],
+    ["ecosystem.enable", false],
     ["completion.enable", false],
     ["hover.enable", false],
     ["definition.enable", false],

--- a/npm/vscode-vize/test/fixtures/fake-vize-server.cjs
+++ b/npm/vscode-vize/test/fixtures/fake-vize-server.cjs
@@ -1,0 +1,155 @@
+#!/usr/bin/env node
+const fs = require("node:fs");
+
+const args = process.argv.slice(2);
+const logPath = process.env.VIZE_TEST_SERVER_LOG;
+const version = process.env.VIZE_TEST_SERVER_VERSION ?? "0.0.0";
+
+appendLog({
+  args,
+  event: "process-start",
+  pid: process.pid,
+});
+
+process.on("exit", (code) => {
+  appendLog({
+    code,
+    event: "process-exit",
+    pid: process.pid,
+  });
+});
+
+if (args.includes("--version")) {
+  appendLog({ event: "version" });
+  console.log(`vize ${version}`);
+  process.exit(0);
+}
+
+if (args[0] !== "lsp") {
+  appendLog({
+    event: "unexpected-args",
+  });
+  process.exit(2);
+}
+
+let input = Buffer.alloc(0);
+
+process.stdin.on("data", (chunk) => {
+  input = Buffer.concat([input, chunk]);
+  consumeInput();
+});
+
+process.stdin.on("end", () => {
+  appendLog({ event: "stdin-end" });
+});
+
+function consumeInput() {
+  while (true) {
+    const headerEnd = input.indexOf("\r\n\r\n");
+    if (headerEnd === -1) {
+      return;
+    }
+
+    const header = input.subarray(0, headerEnd).toString("ascii");
+    const lengthMatch = /^Content-Length: (\d+)$/im.exec(header);
+    if (!lengthMatch) {
+      appendLog({
+        event: "malformed-header",
+        header,
+      });
+      process.exit(3);
+    }
+
+    const contentLength = Number(lengthMatch[1]);
+    const messageStart = headerEnd + 4;
+    const messageEnd = messageStart + contentLength;
+    if (input.byteLength < messageEnd) {
+      return;
+    }
+
+    const rawMessage = input.subarray(messageStart, messageEnd).toString("utf-8");
+    input = input.subarray(messageEnd);
+    handleMessage(JSON.parse(rawMessage));
+  }
+}
+
+function handleMessage(message) {
+  appendLog({
+    event: "message",
+    id: message.id,
+    method: message.method,
+    params: summarizeParams(message.params),
+  });
+
+  if (message.method === "initialize") {
+    send({
+      id: message.id,
+      jsonrpc: "2.0",
+      result: {
+        capabilities: {
+          referencesProvider: true,
+          textDocumentSync: 1,
+        },
+        serverInfo: {
+          name: "fake-vize",
+          version,
+        },
+      },
+    });
+    return;
+  }
+
+  if (message.method === "shutdown") {
+    send({
+      id: message.id,
+      jsonrpc: "2.0",
+      result: null,
+    });
+    return;
+  }
+
+  if (message.method === "exit") {
+    process.exit(0);
+  }
+
+  if (message.id !== undefined) {
+    send({
+      id: message.id,
+      jsonrpc: "2.0",
+      result: null,
+    });
+  }
+}
+
+function summarizeParams(params) {
+  if (!params || typeof params !== "object") {
+    return params;
+  }
+
+  return {
+    initializationOptions: params.initializationOptions,
+    processId: params.processId,
+    rootUri: params.rootUri,
+    trace: params.trace,
+    workspaceFolders: params.workspaceFolders,
+  };
+}
+
+function send(payload) {
+  const body = JSON.stringify(payload);
+  process.stdout.write(`Content-Length: ${Buffer.byteLength(body, "utf-8")}\r\n\r\n${body}`);
+}
+
+function appendLog(entry) {
+  if (!logPath) {
+    return;
+  }
+
+  fs.appendFileSync(
+    logPath,
+    `${JSON.stringify({
+      ...entry,
+      time: new Date().toISOString(),
+    })}\n`,
+  );
+}

--- a/npm/vscode-vize/test/run-extension-host.mjs
+++ b/npm/vscode-vize/test/run-extension-host.mjs
@@ -1,14 +1,26 @@
 #!/usr/bin/env node
+import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { runTests } from "@vscode/test-electron";
 
 const extensionDevelopmentPath = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
-const workspacePath = path.join(
+const fixtureWorkspacePath = path.join(
   extensionDevelopmentPath,
   "test-fixtures",
   "extension-host",
   "basic-vue",
+);
+const testDataPath = path.join(extensionDevelopmentPath, ".vscode-test", "host-smoke");
+const workspacePath = path.join(testDataPath, "workspaces", "basic-vue");
+const fakeServerDir = path.join(testDataPath, "fake-server");
+const fakeServerPath = path.join(fakeServerDir, process.platform === "win32" ? "vize.cmd" : "vize");
+const fakeServerLogPath = path.join(fakeServerDir, "events.jsonl");
+const fakeServerScriptPath = path.join(
+  extensionDevelopmentPath,
+  "test",
+  "fixtures",
+  "fake-vize-server.cjs",
 );
 const extensionTestsPath = path.join(
   extensionDevelopmentPath,
@@ -16,10 +28,36 @@ const extensionTestsPath = path.join(
   "suite",
   "extension-host.cjs",
 );
+const packageJson = JSON.parse(
+  fs.readFileSync(path.join(extensionDevelopmentPath, "package.json"), "utf-8"),
+);
+
+fs.rmSync(testDataPath, { force: true, recursive: true });
+fs.mkdirSync(fakeServerDir, { recursive: true });
+fs.cpSync(fixtureWorkspacePath, workspacePath, { recursive: true });
+fs.writeFileSync(fakeServerLogPath, "");
+
+if (process.platform === "win32") {
+  fs.writeFileSync(
+    fakeServerPath,
+    `@echo off\r\n"${process.execPath}" "${fakeServerScriptPath}" %*\r\n`,
+  );
+} else {
+  fs.writeFileSync(
+    fakeServerPath,
+    `#!/bin/sh\nexec ${JSON.stringify(process.execPath)} ${JSON.stringify(fakeServerScriptPath)} "$@"\n`,
+    { mode: 0o755 },
+  );
+}
 
 await runTests({
   extensionDevelopmentPath,
   extensionTestsPath,
+  extensionTestsEnv: {
+    VIZE_TEST_SERVER_LOG: fakeServerLogPath,
+    VIZE_TEST_SERVER_PATH: fakeServerPath,
+    VIZE_TEST_SERVER_VERSION: packageJson.version,
+  },
   launchArgs: [
     "--disable-extensions",
     "--disable-workspace-trust",

--- a/npm/vscode-vize/test/suite/extension-host.cjs
+++ b/npm/vscode-vize/test/suite/extension-host.cjs
@@ -1,4 +1,5 @@
 const assert = require("node:assert/strict");
+const fs = require("node:fs");
 const path = require("node:path");
 const vscode = require("vscode");
 
@@ -15,6 +16,11 @@ const commandIds = [
 ];
 
 exports.run = async function run() {
+  await runDisabledContributionSmoke();
+  await runFakeServerLifecycleSmoke();
+};
+
+async function runDisabledContributionSmoke() {
   const extension = vscode.extensions.getExtension(extensionId);
   assert.ok(extension, `missing extension: ${extensionId}`);
   assert.equal(extension.packageJSON.name, "vize");
@@ -50,4 +56,104 @@ exports.run = async function run() {
   await vscode.commands.executeCommand("vize.disable");
 
   assert.equal(vscode.workspace.getConfiguration("vize").get("enable"), false);
-};
+}
+
+async function runFakeServerLifecycleSmoke() {
+  const fakeServerPath = process.env.VIZE_TEST_SERVER_PATH;
+  const fakeServerLogPath = process.env.VIZE_TEST_SERVER_LOG;
+  assert.ok(fakeServerPath, "VIZE_TEST_SERVER_PATH must be set");
+  assert.ok(fakeServerLogPath, "VIZE_TEST_SERVER_LOG must be set");
+  assert.ok(fs.existsSync(fakeServerPath), `missing fake server: ${fakeServerPath}`);
+
+  fs.writeFileSync(fakeServerLogPath, "");
+
+  await vscode.workspace
+    .getConfiguration("vize")
+    .update("serverPath", fakeServerPath, vscode.ConfigurationTarget.Workspace);
+  await sleep(300);
+  assert.equal(initializeMessages(readLogEntries(fakeServerLogPath)).length, 0);
+
+  await vscode.commands.executeCommand("vize.enableRecommendedProfile");
+
+  let entries = await waitForLogEntries(
+    fakeServerLogPath,
+    (nextEntries) => initializeMessages(nextEntries).length >= 1,
+    "recommended profile initialization",
+  );
+  assert.deepEqual(lastInitialize(entries).params.initializationOptions, {
+    editor: true,
+    ecosystem: true,
+    lint: true,
+    typecheck: true,
+  });
+
+  await vscode.commands.executeCommand("vize.enableLintOnlyProfile");
+  entries = await waitForLogEntries(
+    fakeServerLogPath,
+    (nextEntries) => initializeMessages(nextEntries).length >= 2,
+    "lint-only profile initialization",
+  );
+  assert.deepEqual(lastInitialize(entries).params.initializationOptions, {
+    lint: true,
+  });
+
+  await vscode.commands.executeCommand("vize.restartServer");
+  entries = await waitForLogEntries(
+    fakeServerLogPath,
+    (nextEntries) => initializeMessages(nextEntries).length >= 3,
+    "manual restart initialization",
+  );
+  assert.deepEqual(lastInitialize(entries).params.initializationOptions, {
+    lint: true,
+  });
+
+  await vscode.commands.executeCommand("vize.disable");
+  entries = await waitForLogEntries(
+    fakeServerLogPath,
+    (nextEntries) => nextEntries.filter((entry) => entry.method === "exit").length >= 3,
+    "language server shutdown",
+  );
+
+  assert.equal(vscode.workspace.getConfiguration("vize").get("enable"), false);
+  assert.ok(
+    entries.some((entry) => entry.event === "version"),
+    "expected configured server version inspection",
+  );
+}
+
+function initializeMessages(entries) {
+  return entries.filter((entry) => entry.method === "initialize");
+}
+
+function lastInitialize(entries) {
+  return initializeMessages(entries).at(-1);
+}
+
+async function waitForLogEntries(logPath, predicate, label) {
+  const timeoutAt = Date.now() + 10_000;
+  let entries = [];
+
+  while (Date.now() < timeoutAt) {
+    entries = readLogEntries(logPath);
+    if (predicate(entries)) {
+      return entries;
+    }
+
+    await sleep(100);
+  }
+
+  assert.fail(`${label} did not happen. Last log entries: ${JSON.stringify(entries.slice(-10))}`);
+}
+
+function readLogEntries(logPath) {
+  const text = fs.readFileSync(logPath, "utf-8").trim();
+  if (!text) {
+    return [];
+  }
+
+  return text.split("\n").map((line) => JSON.parse(line));
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}


### PR DESCRIPTION
## Summary
- add a fake stdio LSP server to the VS Code Extension Host smoke
- assert configured server version probing, recommended profile initialization options, lint-only transition, manual restart, and final shutdown
- fix the lint-only profile so it clears `vize.ecosystem.enable` after the recommended profile enabled it

## Validation
- vp run --workspace-root test:vscode-extension:host
- vp run --workspace-root check:repo
- node --test tests/tooling/editor-integrations.test.ts
- git diff --check
- vp run --workspace-root test:vscode-extension:vsix
- vp run --workspace-root package:editor-extensions

Refs #588
