### PR TITLE
test: add zed extension command unit smoke

### DIFF
--- a/npm/zed-vize/src/lib.rs
+++ b/npm/zed-vize/src/lib.rs
@@ -1,10 +1,44 @@
-use zed_extension_api::{self as zed, settings::LspSettings, Result};
+use std::collections::HashMap;
+
+use zed_extension_api::{
+    self as zed, Result,
+    settings::{CommandSettings, LspSettings},
+};
 
 struct VizeExtension;
 
 impl VizeExtension {
     const SERVER_NAME: &'static str = "vize";
     const SERVER_BINARY: &'static str = "vize";
+
+    fn server_command_from_settings(
+        settings: LspSettings,
+        discovered_server_path: Option<String>,
+        shell_env: zed::EnvVars,
+    ) -> Result<zed::Command> {
+        let binary = settings.binary;
+        let command = binary
+            .as_ref()
+            .and_then(configured_binary_path)
+            .or(discovered_server_path)
+            .ok_or_else(Self::missing_server_message)?;
+
+        let args = binary
+            .as_ref()
+            .and_then(|binary| binary.arguments.clone())
+            .unwrap_or_else(|| vec!["lsp".to_string()]);
+        let env = merge_env(shell_env, binary.and_then(|binary| binary.env));
+
+        Ok(zed::Command { command, args, env })
+    }
+
+    fn missing_server_message() -> String {
+        format!(
+            "Could not find the `{}` binary. Install the Vize CLI or configure lsp.{}.binary.path.",
+            Self::SERVER_BINARY,
+            Self::SERVER_NAME
+        )
+    }
 }
 
 impl zed::Extension for VizeExtension {
@@ -18,30 +52,11 @@ impl zed::Extension for VizeExtension {
         worktree: &zed::Worktree,
     ) -> Result<zed::Command> {
         let settings = LspSettings::for_worktree(language_server_id.as_ref(), worktree)?;
-        let binary = settings.binary;
-        let command = binary
-            .as_ref()
-            .and_then(|binary| binary.path.clone())
-            .or_else(|| worktree.which(Self::SERVER_BINARY))
-            .ok_or_else(|| {
-                format!(
-                    "Could not find the `{}` binary. Install the Vize CLI or configure lsp.{}.binary.path.",
-                    Self::SERVER_BINARY,
-                    Self::SERVER_NAME
-                )
-            })?;
-
-        let args = binary
-            .as_ref()
-            .and_then(|binary| binary.arguments.clone())
-            .unwrap_or_else(|| vec!["lsp".to_string()]);
-
-        let mut env = worktree.shell_env();
-        if let Some(custom_env) = binary.and_then(|binary| binary.env) {
-            env.extend(custom_env);
-        }
-
-        Ok(zed::Command { command, args, env })
+        Self::server_command_from_settings(
+            settings,
+            worktree.which(Self::SERVER_BINARY),
+            worktree.shell_env(),
+        )
     }
 
     fn language_server_initialization_options(
@@ -64,3 +79,161 @@ impl zed::Extension for VizeExtension {
 }
 
 zed::register_extension!(VizeExtension);
+
+fn configured_binary_path(binary: &CommandSettings) -> Option<String> {
+    let path = binary.path.as_deref()?.trim();
+    if path.is_empty() {
+        None
+    } else {
+        Some(path.to_string())
+    }
+}
+
+fn merge_env(shell_env: zed::EnvVars, custom_env: Option<HashMap<String, String>>) -> zed::EnvVars {
+    let Some(custom_env) = custom_env else {
+        return shell_env;
+    };
+
+    let mut env = shell_env
+        .into_iter()
+        .filter(|(key, _)| !custom_env.contains_key(key))
+        .collect::<zed::EnvVars>();
+    let mut custom_env = custom_env.into_iter().collect::<Vec<_>>();
+    custom_env.sort_by(|(left, _), (right, _)| left.cmp(right));
+    env.extend(custom_env);
+    env
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn discovered_binary_defaults_to_lsp() {
+        let command = VizeExtension::server_command_from_settings(
+            LspSettings::default(),
+            Some("/usr/local/bin/vize".to_string()),
+            env_vars([("PATH", "/usr/bin")]),
+        )
+        .unwrap();
+
+        assert_eq!(command.command, "/usr/local/bin/vize");
+        assert_eq!(command.args, vec!["lsp"]);
+        assert_eq!(command.env, env_vars([("PATH", "/usr/bin")]));
+    }
+
+    #[test]
+    fn configured_binary_path_wins_over_path_lookup() {
+        let command = VizeExtension::server_command_from_settings(
+            settings_with_binary(binary(Some(" /opt/vize/bin/vize "), None, &[])),
+            Some("/usr/local/bin/vize".to_string()),
+            env_vars([]),
+        )
+        .unwrap();
+
+        assert_eq!(command.command, "/opt/vize/bin/vize");
+        assert_eq!(command.args, vec!["lsp"]);
+    }
+
+    #[test]
+    fn configured_arguments_and_env_override_defaults() {
+        let command = VizeExtension::server_command_from_settings(
+            settings_with_binary(binary(
+                Some("/opt/vize/bin/vize"),
+                Some(&["lsp", "--debug"]),
+                &[("PATH", "/custom/bin"), ("VIZE_LOG", "trace")],
+            )),
+            Some("/usr/local/bin/vize".to_string()),
+            env_vars([("PATH", "/usr/bin"), ("RUST_LOG", "info")]),
+        )
+        .unwrap();
+
+        assert_eq!(command.command, "/opt/vize/bin/vize");
+        assert_eq!(command.args, vec!["lsp", "--debug"]);
+        assert_eq!(
+            command.env,
+            env_vars([
+                ("RUST_LOG", "info"),
+                ("PATH", "/custom/bin"),
+                ("VIZE_LOG", "trace"),
+            ])
+        );
+    }
+
+    #[test]
+    fn explicit_empty_arguments_are_preserved() {
+        let command = VizeExtension::server_command_from_settings(
+            settings_with_binary(binary(Some("/opt/vize/bin/vize"), Some(&[]), &[])),
+            None,
+            env_vars([]),
+        )
+        .unwrap();
+
+        assert_eq!(command.args, Vec::<String>::new());
+    }
+
+    #[test]
+    fn blank_configured_path_falls_back_to_path_lookup() {
+        let command = VizeExtension::server_command_from_settings(
+            settings_with_binary(binary(Some(" \t "), None, &[])),
+            Some("/usr/local/bin/vize".to_string()),
+            env_vars([]),
+        )
+        .unwrap();
+
+        assert_eq!(command.command, "/usr/local/bin/vize");
+        assert_eq!(command.args, vec!["lsp"]);
+    }
+
+    #[test]
+    fn missing_binary_reports_install_and_settings_guidance() {
+        let error = VizeExtension::server_command_from_settings(
+            settings_with_binary(binary(None, None, &[])),
+            None,
+            env_vars([]),
+        )
+        .unwrap_err();
+
+        assert!(error.contains("Install the Vize CLI"));
+        assert!(error.contains("lsp.vize.binary.path"));
+    }
+
+    fn settings_with_binary(binary: CommandSettings) -> LspSettings {
+        LspSettings {
+            binary: Some(binary),
+            ..LspSettings::default()
+        }
+    }
+
+    fn binary(
+        path: Option<&str>,
+        arguments: Option<&[&str]>,
+        env: &[(&str, &str)],
+    ) -> CommandSettings {
+        CommandSettings {
+            arguments: arguments.map(|arguments| {
+                arguments
+                    .iter()
+                    .copied()
+                    .map(ToString::to_string)
+                    .collect::<Vec<_>>()
+            }),
+            env: if env.is_empty() {
+                None
+            } else {
+                Some(
+                    env.into_iter()
+                        .map(|(key, value)| (key.to_string(), value.to_string()))
+                        .collect(),
+                )
+            },
+            path: path.map(ToString::to_string),
+        }
+    }
+
+    fn env_vars<const N: usize>(env: [(&str, &str); N]) -> zed::EnvVars {
+        env.into_iter()
+            .map(|(key, value)| (key.to_string(), value.to_string()))
+            .collect()
+    }
+}

--- a/tests/tooling/editor-integrations.test.ts
+++ b/tests/tooling/editor-integrations.test.ts
@@ -222,4 +222,6 @@ test("CI packages editor extension artifacts", () => {
   assert.match(testTasks, /test:vscode-extension:host[\s\S]*pnpm run test:host/);
   assert.match(buildTasks, /package:zed-extension[\s\S]*assert-zed-package\.mjs/);
   assert.match(testTasks, /test:zed-extension:package[\s\S]*package:zed-extension/);
+  assert.match(testTasks, /test:zed-extension:unit[\s\S]*cargo test/);
+  assert.match(buildTasks, /package:editor-extensions[\s\S]*test:zed-extension:unit/);
 });

--- a/tools/vite-plus/tasks/build.ts
+++ b/tools/vite-plus/tasks/build.ts
@@ -63,7 +63,9 @@ export const buildTasks = defineTasks({
       "pnpm exec vp check src vite.config.ts",
       "pnpm exec vsce package --no-dependencies --out dist/vize.vsix",
       "node ../../tools/vscode-vize/assert-vsix-package.mjs dist/vize.vsix",
-    )} && ${runTask("check:zed-extension")} && ${runTask("package:zed-extension")}`,
+    )} && ${runTask("check:zed-extension")} && ${runTask(
+      "test:zed-extension:unit",
+    )} && ${runTask("package:zed-extension")}`,
   ),
   "install:plugin": noCacheTask("vp install --filter './npm/vite-plugin-vize'"),
 });

--- a/tools/vite-plus/tasks/test-benchmark.ts
+++ b/tools/vite-plus/tasks/test-benchmark.ts
@@ -57,7 +57,7 @@ const rustBranchCoverageCommand = [
  * performance regressions difficult to miss.
  */
 export const testAndBenchmarkTasks = defineTasks({
-  test: noCacheTask(runTasks("test:rust", "test:js", "test:scripts")),
+  test: noCacheTask(runTasks("test:rust", "test:js", "test:scripts", "test:zed-extension:unit")),
   "test:rust": task("cargo test --workspace", { input: cacheInputs.rust }),
   // Use the CI-profile native build instead of the release-profile one.
   // The release build was ~3m+ on GitHub Actions and was being immediately
@@ -75,6 +75,9 @@ export const testAndBenchmarkTasks = defineTasks({
     runInVscodeExtension("pnpm exec vp pack", "pnpm run test:host"),
   ),
   "test:zed-extension:package": noCacheTask("vp run --workspace-root package:zed-extension"),
+  "test:zed-extension:unit": task("cargo test --manifest-path npm/zed-vize/Cargo.toml", {
+    input: ["npm/zed-vize/**"],
+  }),
   "test:playground": task(runInPackages("test:browser", ["./playground"]), {
     input: cacheInputs.jsChecks,
   }),


### PR DESCRIPTION
## Summary
- add Zed extension unit coverage for language-server command resolution
- cover discovered `vize` fallback, configured binary path precedence, default `lsp` args, explicit empty args, env overrides, blank path fallback, and missing-binary guidance
- wire the Zed unit smoke into the root `test` aggregate and editor-extension packaging path

## Validation
- vp run --workspace-root test:zed-extension:unit
- vp run --workspace-root check:repo
- vp run --workspace-root package:editor-extensions
- node --test tests/tooling/editor-integrations.test.ts
- git diff --check

Refs #588
