### PR TITLE
test: add neovim extension package smoke

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -148,6 +148,7 @@ jobs:
           name: editor-extensions
           path: |
             npm/vscode-vize/dist/vize.vsix
+            nvim-vize-extension.tar.gz
             zed-vize-extension.tar.gz
           if-no-files-found: error
           compression-level: 0

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ examples/*/.vite/
 .DS_Store
 *.tgz
 *.vsix
+nvim-vize-extension.tar.gz
 zed-vize-extension.tar.gz
 
 # Benchmark input/output files

--- a/npm/nvim-vize/LICENSE
+++ b/npm/nvim-vize/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) Vize contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/npm/nvim-vize/README.md
+++ b/npm/nvim-vize/README.md
@@ -1,0 +1,31 @@
+# nvim-vize
+
+Neovim integration for the Vize language server.
+
+```lua
+require("vize").setup({
+  profile = "lint",
+})
+```
+
+The plugin configures `vim.lsp.config("vize", ...)` with `cmd = { "vize", "lsp" }` and filetypes
+for `vue` and `art-vue`. Features are opt-in through initialization options.
+
+Profiles:
+
+- `lint`: enables Vize lint diagnostics only.
+- `recommended`: enables lint, typecheck, editor, and ecosystem features.
+- `off`: starts Vize with no features enabled.
+
+Custom configuration:
+
+```lua
+require("vize").setup({
+  cmd = { "/path/to/vize", "lsp" },
+  init_options = {
+    lint = true,
+    hover = true,
+    references = true,
+  },
+})
+```

--- a/npm/nvim-vize/ftdetect/vize.lua
+++ b/npm/nvim-vize/ftdetect/vize.lua
@@ -1,0 +1,15 @@
+vim.api.nvim_create_autocmd({ "BufNewFile", "BufRead" }, {
+  group = vim.api.nvim_create_augroup("vize_filetypes", { clear = true }),
+  pattern = "*.vue",
+  callback = function()
+    vim.bo.filetype = "vue"
+  end,
+})
+
+vim.api.nvim_create_autocmd({ "BufNewFile", "BufRead" }, {
+  group = vim.api.nvim_create_augroup("vize_art_vue_filetypes", { clear = true }),
+  pattern = "*.art.vue",
+  callback = function()
+    vim.bo.filetype = "art-vue"
+  end,
+})

--- a/npm/nvim-vize/lua/vize/config.lua
+++ b/npm/nvim-vize/lua/vize/config.lua
@@ -1,0 +1,88 @@
+local M = {}
+
+local profiles = {
+  lint = {
+    lint = true,
+  },
+  off = {},
+  recommended = {
+    editor = true,
+    ecosystem = true,
+    lint = true,
+    typecheck = true,
+  },
+}
+
+local default_config = {
+  autostart = true,
+  cmd = { "vize", "lsp" },
+  filetypes = { "vue", "art-vue" },
+  init_options = profiles.lint,
+  root_markers = { "vize.config.pkl", "vize.config.json", "package.json", ".git" },
+  settings = {},
+}
+
+local function copy(value)
+  return vim.deepcopy(value)
+end
+
+local function assert_list(name, value)
+  assert(type(value) == "table", "vize." .. name .. " must be a list")
+  assert(#value > 0, "vize." .. name .. " must not be empty")
+  for index, item in ipairs(value) do
+    assert(type(item) == "string", "vize." .. name .. "[" .. index .. "] must be a string")
+    assert(item ~= "", "vize." .. name .. "[" .. index .. "] must not be empty")
+  end
+  return copy(value)
+end
+
+function M.profile(name)
+  local profile = profiles[name]
+  assert(profile ~= nil, "unknown vize profile: " .. tostring(name))
+  return copy(profile)
+end
+
+function M.default_config()
+  return copy(default_config)
+end
+
+function M.normalize(opts)
+  opts = opts or {}
+  assert(type(opts) == "table", "vize.setup options must be a table")
+
+  local config = M.default_config()
+  if opts.profile ~= nil then
+    config.init_options = M.profile(opts.profile)
+  end
+
+  if opts.cmd ~= nil then
+    config.cmd = assert_list("cmd", opts.cmd)
+  end
+
+  if opts.filetypes ~= nil then
+    config.filetypes = assert_list("filetypes", opts.filetypes)
+  end
+
+  if opts.root_markers ~= nil then
+    config.root_markers = assert_list("root_markers", opts.root_markers)
+  end
+
+  if opts.init_options ~= nil then
+    assert(type(opts.init_options) == "table", "vize.init_options must be a table")
+    config.init_options = copy(opts.init_options)
+  end
+
+  if opts.settings ~= nil then
+    assert(type(opts.settings) == "table", "vize.settings must be a table")
+    config.settings = copy(opts.settings)
+  end
+
+  if opts.autostart ~= nil then
+    assert(type(opts.autostart) == "boolean", "vize.autostart must be a boolean")
+    config.autostart = opts.autostart
+  end
+
+  return config
+end
+
+return M

--- a/npm/nvim-vize/lua/vize/init.lua
+++ b/npm/nvim-vize/lua/vize/init.lua
@@ -1,0 +1,20 @@
+local config = require("vize.config")
+
+local M = {
+  config = config,
+}
+
+function M.setup(opts)
+  local resolved = config.normalize(opts)
+
+  assert(vim.lsp ~= nil and vim.lsp.config ~= nil, "vize.nvim requires Neovim 0.11+")
+  vim.lsp.config("vize", resolved)
+
+  if resolved.autostart and vim.lsp.enable ~= nil then
+    vim.lsp.enable("vize")
+  end
+
+  return resolved
+end
+
+return M

--- a/npm/nvim-vize/plugin/vize.lua
+++ b/npm/nvim-vize/plugin/vize.lua
@@ -1,0 +1,11 @@
+if vim.g.loaded_vize == 1 then
+  return
+end
+
+vim.g.loaded_vize = 1
+
+vim.api.nvim_create_user_command("VizeSetup", function()
+  require("vize").setup()
+end, {
+  desc = "Configure the Vize language server",
+})

--- a/npm/nvim-vize/test/vize_spec.lua
+++ b/npm/nvim-vize/test/vize_spec.lua
@@ -1,0 +1,51 @@
+local plugin_root = vim.fn.fnamemodify(debug.getinfo(1, "S").source:sub(2), ":p:h:h")
+vim.opt.runtimepath:prepend(plugin_root)
+
+local config = require("vize.config")
+
+local function assert_eq(actual, expected, label)
+  assert(vim.deep_equal(actual, expected), label .. "\nactual: " .. vim.inspect(actual))
+end
+
+local defaults = config.normalize()
+assert_eq(defaults.cmd, { "vize", "lsp" }, "default cmd")
+assert_eq(defaults.filetypes, { "vue", "art-vue" }, "default filetypes")
+assert_eq(defaults.init_options, { lint = true }, "default lint profile")
+assert(defaults.root_markers[1] == "vize.config.pkl", "prefers vize config root marker")
+
+local recommended = config.normalize({ profile = "recommended" })
+assert_eq(recommended.init_options, {
+  editor = true,
+  ecosystem = true,
+  lint = true,
+  typecheck = true,
+}, "recommended profile")
+
+local custom = config.normalize({
+  autostart = false,
+  cmd = { "/tmp/vize", "lsp", "--debug" },
+  filetypes = { "vue" },
+  init_options = { hover = true, references = true },
+  root_markers = { "deno.json", ".git" },
+  settings = { vize = { trace = "messages" } },
+})
+
+assert_eq(custom.cmd, { "/tmp/vize", "lsp", "--debug" }, "custom cmd")
+assert_eq(custom.filetypes, { "vue" }, "custom filetypes")
+assert_eq(custom.init_options, { hover = true, references = true }, "custom init options")
+assert_eq(custom.root_markers, { "deno.json", ".git" }, "custom root markers")
+assert(custom.autostart == false, "custom autostart")
+
+local ok, err = pcall(config.normalize, { cmd = {} })
+assert(not ok and err:match("cmd"), "rejects empty cmd")
+
+local setup_config = require("vize").setup({ autostart = false, profile = "off" })
+assert_eq(setup_config.init_options, {}, "setup returns normalized config")
+assert_eq(vim.lsp.config.vize.cmd, { "vize", "lsp" }, "registered LSP cmd")
+assert_eq(vim.lsp.config.vize.filetypes, { "vue", "art-vue" }, "registered LSP filetypes")
+
+vim.cmd("runtime! ftdetect/vize.lua")
+vim.cmd("edit " .. vim.fn.fnameescape(vim.fn.tempname() .. ".vue"))
+assert(vim.bo.filetype == "vue", "detects .vue")
+vim.cmd("edit " .. vim.fn.fnameescape(vim.fn.tempname() .. ".art.vue"))
+assert(vim.bo.filetype == "art-vue", "detects .art.vue")

--- a/tests/tooling/editor-integrations.test.ts
+++ b/tests/tooling/editor-integrations.test.ts
@@ -224,4 +224,8 @@ test("CI packages editor extension artifacts", () => {
   assert.match(testTasks, /test:zed-extension:package[\s\S]*package:zed-extension/);
   assert.match(testTasks, /test:zed-extension:unit[\s\S]*cargo test/);
   assert.match(buildTasks, /package:editor-extensions[\s\S]*test:zed-extension:unit/);
+  assert.match(buildTasks, /package:nvim-extension[\s\S]*assert-nvim-package\.mjs/);
+  assert.match(buildTasks, /package:editor-extensions[\s\S]*package:nvim-extension/);
+  assert.match(testTasks, /test:nvim-extension:headless[\s\S]*nvim --headless/);
+  assert.match(testTasks, /test:nvim-extension:package[\s\S]*package:nvim-extension/);
 });

--- a/tools/nvim-vize/assert-nvim-package.mjs
+++ b/tools/nvim-vize/assert-nvim-package.mjs
@@ -1,0 +1,165 @@
+#!/usr/bin/env node
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import zlib from "node:zlib";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const archivePath = path.resolve(
+  process.cwd(),
+  process.argv[2] ?? path.join(root, "nvim-vize-extension.tar.gz"),
+);
+
+assert.ok(fs.existsSync(archivePath), `Neovim extension archive does not exist: ${archivePath}`);
+
+const archiveSize = fs.statSync(archivePath).size;
+assert.ok(archiveSize > 2_000, `Neovim archive is suspiciously small: ${archiveSize} bytes`);
+assert.ok(archiveSize < 200_000, `Neovim archive is unexpectedly large: ${archiveSize} bytes`);
+
+const entries = readTarGz(archivePath);
+const entryNames = entries.map((entry) => entry.name).sort((a, b) => a.localeCompare(b));
+const entryMap = new Map(entries.map((entry) => [entry.name, entry]));
+
+assert.deepEqual(entryNames, Array.from(new Set(entryNames)), "Neovim archive has duplicates");
+
+for (const name of entryNames) {
+  assert.ok(!name.includes("\\"), `Neovim archive entry must use POSIX separators: ${name}`);
+  assert.ok(!name.includes("\0"), `Neovim archive entry contains a NUL byte: ${name}`);
+  assert.ok(!name.startsWith("/"), `Neovim archive entry must be relative: ${name}`);
+  assert.ok(!name.split("/").includes(".."), `Neovim archive entry must not traverse: ${name}`);
+  assert.ok(name === "nvim-vize/" || name.startsWith("nvim-vize/"), `unexpected root: ${name}`);
+}
+
+const requiredFiles = [
+  "nvim-vize/LICENSE",
+  "nvim-vize/README.md",
+  "nvim-vize/ftdetect/vize.lua",
+  "nvim-vize/lua/vize/config.lua",
+  "nvim-vize/lua/vize/init.lua",
+  "nvim-vize/plugin/vize.lua",
+  "nvim-vize/test/vize_spec.lua",
+];
+
+for (const name of requiredFiles) {
+  assert.ok(entryMap.has(name), `Neovim archive is missing required file: ${name}`);
+  assert.ok(readTextEntry(entryMap, name).trim().length > 0, `Neovim file is empty: ${name}`);
+}
+
+const allowedEntries = [
+  /^nvim-vize\/$/,
+  /^nvim-vize\/LICENSE$/,
+  /^nvim-vize\/README\.md$/,
+  /^nvim-vize\/ftdetect\/$/,
+  /^nvim-vize\/ftdetect\/vize\.lua$/,
+  /^nvim-vize\/lua\/$/,
+  /^nvim-vize\/lua\/vize\/$/,
+  /^nvim-vize\/lua\/vize\/(?:config|init)\.lua$/,
+  /^nvim-vize\/plugin\/$/,
+  /^nvim-vize\/plugin\/vize\.lua$/,
+  /^nvim-vize\/test\/$/,
+  /^nvim-vize\/test\/vize_spec\.lua$/,
+];
+
+for (const name of entryNames) {
+  assert.ok(
+    allowedEntries.some((pattern) => pattern.test(name)),
+    `Neovim archive ships an unexpected file: ${name}`,
+  );
+}
+
+const forbiddenEntries = [
+  /^nvim-vize\/\.git/,
+  /^nvim-vize\/\.github\//,
+  /^nvim-vize\/node_modules\//,
+  /^nvim-vize\/target\//,
+  /\/\.DS_Store$/,
+  /\.tar\.gz$/,
+  /~$/,
+];
+
+for (const name of entryNames) {
+  for (const pattern of forbiddenEntries) {
+    assert.ok(!pattern.test(name), `Neovim archive must not ship ${name}`);
+  }
+}
+
+const configLua = readTextEntry(entryMap, "nvim-vize/lua/vize/config.lua");
+const initLua = readTextEntry(entryMap, "nvim-vize/lua/vize/init.lua");
+const ftdetectLua = readTextEntry(entryMap, "nvim-vize/ftdetect/vize.lua");
+const specLua = readTextEntry(entryMap, "nvim-vize/test/vize_spec.lua");
+
+assert.match(configLua, /cmd = \{ "vize", "lsp" \}/);
+assert.match(configLua, /filetypes = \{ "vue", "art-vue" \}/);
+assert.match(
+  configLua,
+  /root_markers = \{ "vize\.config\.pkl", "vize\.config\.json", "package\.json", "\.git" \}/,
+);
+assert.match(configLua, /lint = true/);
+assert.match(configLua, /recommended = \{/);
+assert.match(configLua, /assert_list\("cmd"/);
+assert.match(initLua, /vim\.lsp\.config\("vize", resolved\)/);
+assert.match(initLua, /vim\.lsp\.enable\("vize"\)/);
+assert.match(ftdetectLua, /pattern = "\*\.vue"/);
+assert.match(ftdetectLua, /pattern = "\*\.art\.vue"/);
+assert.match(ftdetectLua, /filetype = "art-vue"/);
+assert.match(specLua, /config\.normalize/);
+assert.match(specLua, /vim\.lsp\.config\.vize/);
+
+console.log(
+  `Neovim package smoke passed: ${path.relative(root, archivePath)} (${entryNames.length} entries)`,
+);
+
+function readTextEntry(entryMap, name) {
+  const entry = entryMap.get(name);
+  assert.ok(entry, `missing tar entry: ${name}`);
+  return entry.data.toString("utf-8");
+}
+
+function readTarGz(filePath) {
+  const buffer = zlib.gunzipSync(fs.readFileSync(filePath));
+  const entries = [];
+  let offset = 0;
+
+  while (offset + 512 <= buffer.byteLength) {
+    const header = buffer.subarray(offset, offset + 512);
+    if (header.every((byte) => byte === 0)) {
+      break;
+    }
+
+    const name = readTarString(header, 0, 100);
+    const prefix = readTarString(header, 345, 155);
+    const fullName = prefix ? `${prefix}/${name}` : name;
+    const size = parseOctal(readTarString(header, 124, 12));
+    const typeflag = readTarString(header, 156, 1) || "0";
+    const dataOffset = offset + 512;
+    const data = buffer.subarray(dataOffset, dataOffset + size);
+
+    assert.ok(fullName, "tar entry name must not be empty");
+    if (typeflag === "x" || typeflag === "g") {
+      offset = dataOffset + Math.ceil(size / 512) * 512;
+      continue;
+    }
+
+    assert.ok(
+      typeflag === "0" || typeflag === "5",
+      `unsupported tar entry type ${typeflag}: ${fullName}`,
+    );
+
+    entries.push({ data, name: fullName, size, typeflag });
+    offset = dataOffset + Math.ceil(size / 512) * 512;
+  }
+
+  return entries;
+}
+
+function readTarString(buffer, offset, length) {
+  const raw = buffer.subarray(offset, offset + length);
+  const end = raw.indexOf(0);
+  return raw.subarray(0, end === -1 ? raw.byteLength : end).toString("utf-8");
+}
+
+function parseOctal(value) {
+  const trimmed = value.trim();
+  return trimmed ? Number.parseInt(trimmed, 8) : 0;
+}

--- a/tools/vite-plus/tasks/build.ts
+++ b/tools/vite-plus/tasks/build.ts
@@ -57,6 +57,9 @@ export const buildTasks = defineTasks({
   "package:zed-extension": noCacheTask(
     "COPYFILE_DISABLE=1 LC_ALL=C LANG=C tar --exclude 'zed-vize/target' -czf zed-vize-extension.tar.gz -C npm zed-vize && node tools/zed-vize/assert-zed-package.mjs zed-vize-extension.tar.gz",
   ),
+  "package:nvim-extension": noCacheTask(
+    "COPYFILE_DISABLE=1 LC_ALL=C LANG=C tar -czf nvim-vize-extension.tar.gz -C npm nvim-vize && node tools/nvim-vize/assert-nvim-package.mjs nvim-vize-extension.tar.gz",
+  ),
   "package:editor-extensions": noCacheTask(
     `${runInVscodeExtension(
       "pnpm exec tsgo --noEmit",
@@ -65,7 +68,7 @@ export const buildTasks = defineTasks({
       "node ../../tools/vscode-vize/assert-vsix-package.mjs dist/vize.vsix",
     )} && ${runTask("check:zed-extension")} && ${runTask(
       "test:zed-extension:unit",
-    )} && ${runTask("package:zed-extension")}`,
+    )} && ${runTask("package:zed-extension")} && ${runTask("package:nvim-extension")}`,
   ),
   "install:plugin": noCacheTask("vp install --filter './npm/vite-plugin-vize'"),
 });

--- a/tools/vite-plus/tasks/test-benchmark.ts
+++ b/tools/vite-plus/tasks/test-benchmark.ts
@@ -78,6 +78,10 @@ export const testAndBenchmarkTasks = defineTasks({
   "test:zed-extension:unit": task("cargo test --manifest-path npm/zed-vize/Cargo.toml", {
     input: ["npm/zed-vize/**"],
   }),
+  "test:nvim-extension:headless": noCacheTask(
+    "nvim --headless -u NONE --noplugin '+set runtimepath^=npm/nvim-vize' '+luafile npm/nvim-vize/test/vize_spec.lua' '+qa'",
+  ),
+  "test:nvim-extension:package": noCacheTask("vp run --workspace-root package:nvim-extension"),
   "test:playground": task(runInPackages("test:browser", ["./playground"]), {
     input: cacheInputs.jsChecks,
   }),


### PR DESCRIPTION
## Summary
- add a Neovim `nvim-vize` runtime package that configures `vim.lsp.config("vize", ...)`
- cover default lint profile, recommended/off profiles, custom cmd/filetypes/root markers/settings, filetype detection, and LSP registration in a headless Neovim smoke
- add strict package archive assertions and include the Neovim archive in editor-extension packaging/release artifacts

## Validation
- vp run --workspace-root test:nvim-extension:headless
- vp run --workspace-root test:nvim-extension:package
- node --test tests/tooling/editor-integrations.test.ts
- vp run --workspace-root check:repo
- vp run --workspace-root package:editor-extensions
- git diff --check

Refs #588
