### PR TITLE
test: add vim extension package smoke

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,6 +149,7 @@ jobs:
           path: |
             npm/vscode-vize/dist/vize.vsix
             nvim-vize-extension.tar.gz
+            vim-vize-extension.tar.gz
             zed-vize-extension.tar.gz
           if-no-files-found: error
           compression-level: 0

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ examples/*/.vite/
 *.tgz
 *.vsix
 nvim-vize-extension.tar.gz
+vim-vize-extension.tar.gz
 zed-vize-extension.tar.gz
 
 # Benchmark input/output files

--- a/npm/vim-vize/LICENSE
+++ b/npm/vim-vize/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) Vize contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/npm/vim-vize/README.md
+++ b/npm/vim-vize/README.md
@@ -1,0 +1,28 @@
+# vim-vize
+
+Vim integration for the Vize language server.
+
+Vim does not include a built-in LSP client. This package provides filetype detection and a
+`vim-lsp` server registration helper.
+
+```vim
+Plug 'prabirshrestha/vim-lsp'
+Plug 'ubugeeei/vize', { 'rtp': 'npm/vim-vize' }
+
+call vize#setup({'profile': 'lint'})
+```
+
+Profiles:
+
+- `lint`: enables Vize lint diagnostics only.
+- `recommended`: enables lint, typecheck, editor, and ecosystem features.
+- `off`: starts Vize with no features enabled.
+
+Custom command:
+
+```vim
+call vize#setup({
+      \ 'cmd': ['/path/to/vize', 'lsp'],
+      \ 'initialization_options': {'lint': v:true, 'references': v:true},
+      \ })
+```

--- a/npm/vim-vize/autoload/vize.vim
+++ b/npm/vim-vize/autoload/vize.vim
@@ -1,0 +1,96 @@
+let s:profiles = {
+      \ 'lint': {'lint': v:true},
+      \ 'off': {},
+      \ 'recommended': {
+      \   'editor': v:true,
+      \   'ecosystem': v:true,
+      \   'lint': v:true,
+      \   'typecheck': v:true,
+      \ },
+      \ }
+
+let s:default_config = {
+      \ 'allowlist': ['vue', 'art-vue'],
+      \ 'cmd': ['vize', 'lsp'],
+      \ 'initialization_options': s:profiles.lint,
+      \ }
+
+function! vize#profile(name) abort
+  if !has_key(s:profiles, a:name)
+    throw 'unknown vize profile: ' . string(a:name)
+  endif
+  return deepcopy(s:profiles[a:name])
+endfunction
+
+function! vize#default_config() abort
+  return deepcopy(s:default_config)
+endfunction
+
+function! vize#normalize(...) abort
+  let l:opts = a:0 ? a:1 : {}
+  if type(l:opts) != v:t_dict
+    throw 'vize.setup options must be a dictionary'
+  endif
+
+  let l:config = vize#default_config()
+  if has_key(l:opts, 'profile')
+    let l:config.initialization_options = vize#profile(l:opts.profile)
+  endif
+
+  if has_key(l:opts, 'cmd')
+    let l:config.cmd = s:assert_string_list('cmd', l:opts.cmd)
+  endif
+
+  if has_key(l:opts, 'allowlist')
+    let l:config.allowlist = s:assert_string_list('allowlist', l:opts.allowlist)
+  endif
+
+  if has_key(l:opts, 'initialization_options')
+    if type(l:opts.initialization_options) != v:t_dict
+      throw 'vize.initialization_options must be a dictionary'
+    endif
+    let l:config.initialization_options = deepcopy(l:opts.initialization_options)
+  endif
+
+  return l:config
+endfunction
+
+function! vize#vim_lsp_config(...) abort
+  let l:config = vize#normalize(a:0 ? a:1 : {})
+  return {
+        \ 'name': 'vize',
+        \ 'cmd': function('s:server_cmd', [l:config.cmd]),
+        \ 'allowlist': l:config.allowlist,
+        \ 'initialization_options': l:config.initialization_options,
+        \ }
+endfunction
+
+function! vize#setup(...) abort
+  let l:config = vize#normalize(a:0 ? a:1 : {})
+  if exists('*lsp#register_server')
+    call lsp#register_server(vize#vim_lsp_config(l:config))
+  else
+    echohl WarningMsg
+    echom 'vim-lsp not found; install vim-lsp and call vize#setup() again'
+    echohl None
+  endif
+  return l:config
+endfunction
+
+function! s:assert_string_list(name, value) abort
+  if type(a:value) != v:t_list || empty(a:value)
+    throw 'vize.' . a:name . ' must be a non-empty list'
+  endif
+
+  for l:item in a:value
+    if type(l:item) != v:t_string || empty(l:item)
+      throw 'vize.' . a:name . ' must contain non-empty strings'
+    endif
+  endfor
+
+  return deepcopy(a:value)
+endfunction
+
+function! s:server_cmd(cmd, server_info) abort
+  return deepcopy(a:cmd)
+endfunction

--- a/npm/vim-vize/ftdetect/vize.vim
+++ b/npm/vim-vize/ftdetect/vize.vim
@@ -1,0 +1,5 @@
+augroup vize_filetypes
+  autocmd!
+  autocmd BufNewFile,BufRead *.vue setlocal filetype=vue
+  autocmd BufNewFile,BufRead *.art.vue setlocal filetype=art-vue
+augroup END

--- a/npm/vim-vize/plugin/vize.vim
+++ b/npm/vim-vize/plugin/vize.vim
@@ -1,0 +1,7 @@
+if exists('g:loaded_vize')
+  finish
+endif
+
+let g:loaded_vize = 1
+
+command! VizeSetup call vize#setup()

--- a/npm/vim-vize/test/vize_spec.vim
+++ b/npm/vim-vize/test/vize_spec.vim
@@ -1,0 +1,48 @@
+set runtimepath^=npm/vim-vize
+runtime autoload/vize.vim
+
+let s:defaults = vize#normalize({})
+call assert_equal(['vize', 'lsp'], s:defaults.cmd)
+call assert_equal(['vue', 'art-vue'], s:defaults.allowlist)
+call assert_equal({'lint': v:true}, s:defaults.initialization_options)
+
+let s:recommended = vize#normalize({'profile': 'recommended'})
+call assert_equal({
+      \ 'editor': v:true,
+      \ 'ecosystem': v:true,
+      \ 'lint': v:true,
+      \ 'typecheck': v:true,
+      \ }, s:recommended.initialization_options)
+
+let s:custom = vize#normalize({
+      \ 'cmd': ['/tmp/vize', 'lsp', '--debug'],
+      \ 'allowlist': ['vue'],
+      \ 'initialization_options': {'hover': v:true, 'references': v:true},
+      \ })
+call assert_equal(['/tmp/vize', 'lsp', '--debug'], s:custom.cmd)
+call assert_equal(['vue'], s:custom.allowlist)
+call assert_equal({'hover': v:true, 'references': v:true}, s:custom.initialization_options)
+
+let s:lsp_config = vize#vim_lsp_config({'profile': 'off'})
+call assert_equal('vize', s:lsp_config.name)
+call assert_equal(['vue', 'art-vue'], s:lsp_config.allowlist)
+call assert_equal({}, s:lsp_config.initialization_options)
+call assert_equal(['vize', 'lsp'], s:lsp_config.cmd({}))
+
+try
+  call vize#normalize({'cmd': []})
+  call assert_report('expected empty cmd to fail')
+catch /cmd/
+endtry
+
+runtime ftdetect/vize.vim
+execute 'edit ' . fnameescape(tempname() . '.vue')
+call assert_equal('vue', &filetype)
+execute 'edit ' . fnameescape(tempname() . '.art.vue')
+call assert_equal('art-vue', &filetype)
+
+if !empty(v:errors)
+  cquit
+endif
+
+quitall!

--- a/tests/tooling/editor-integrations.test.ts
+++ b/tests/tooling/editor-integrations.test.ts
@@ -228,4 +228,8 @@ test("CI packages editor extension artifacts", () => {
   assert.match(buildTasks, /package:editor-extensions[\s\S]*package:nvim-extension/);
   assert.match(testTasks, /test:nvim-extension:headless[\s\S]*nvim --headless/);
   assert.match(testTasks, /test:nvim-extension:package[\s\S]*package:nvim-extension/);
+  assert.match(buildTasks, /package:vim-extension[\s\S]*assert-vim-package\.mjs/);
+  assert.match(buildTasks, /package:editor-extensions[\s\S]*package:vim-extension/);
+  assert.match(testTasks, /test:vim-extension:headless[\s\S]*vim -Nu NONE/);
+  assert.match(testTasks, /test:vim-extension:package[\s\S]*package:vim-extension/);
 });

--- a/tools/vim-vize/assert-vim-package.mjs
+++ b/tools/vim-vize/assert-vim-package.mjs
@@ -1,0 +1,155 @@
+#!/usr/bin/env node
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import zlib from "node:zlib";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const archivePath = path.resolve(
+  process.cwd(),
+  process.argv[2] ?? path.join(root, "vim-vize-extension.tar.gz"),
+);
+
+assert.ok(fs.existsSync(archivePath), `Vim extension archive does not exist: ${archivePath}`);
+
+const archiveSize = fs.statSync(archivePath).size;
+assert.ok(archiveSize > 2_000, `Vim archive is suspiciously small: ${archiveSize} bytes`);
+assert.ok(archiveSize < 200_000, `Vim archive is unexpectedly large: ${archiveSize} bytes`);
+
+const entries = readTarGz(archivePath);
+const entryNames = entries.map((entry) => entry.name).sort((a, b) => a.localeCompare(b));
+const entryMap = new Map(entries.map((entry) => [entry.name, entry]));
+
+assert.deepEqual(entryNames, Array.from(new Set(entryNames)), "Vim archive has duplicates");
+
+for (const name of entryNames) {
+  assert.ok(!name.includes("\\"), `Vim archive entry must use POSIX separators: ${name}`);
+  assert.ok(!name.includes("\0"), `Vim archive entry contains a NUL byte: ${name}`);
+  assert.ok(!name.startsWith("/"), `Vim archive entry must be relative: ${name}`);
+  assert.ok(!name.split("/").includes(".."), `Vim archive entry must not traverse: ${name}`);
+  assert.ok(name === "vim-vize/" || name.startsWith("vim-vize/"), `unexpected root: ${name}`);
+}
+
+const requiredFiles = [
+  "vim-vize/LICENSE",
+  "vim-vize/README.md",
+  "vim-vize/autoload/vize.vim",
+  "vim-vize/ftdetect/vize.vim",
+  "vim-vize/plugin/vize.vim",
+  "vim-vize/test/vize_spec.vim",
+];
+
+for (const name of requiredFiles) {
+  assert.ok(entryMap.has(name), `Vim archive is missing required file: ${name}`);
+  assert.ok(readTextEntry(entryMap, name).trim().length > 0, `Vim file is empty: ${name}`);
+}
+
+const allowedEntries = [
+  /^vim-vize\/$/,
+  /^vim-vize\/LICENSE$/,
+  /^vim-vize\/README\.md$/,
+  /^vim-vize\/autoload\/$/,
+  /^vim-vize\/autoload\/vize\.vim$/,
+  /^vim-vize\/ftdetect\/$/,
+  /^vim-vize\/ftdetect\/vize\.vim$/,
+  /^vim-vize\/plugin\/$/,
+  /^vim-vize\/plugin\/vize\.vim$/,
+  /^vim-vize\/test\/$/,
+  /^vim-vize\/test\/vize_spec\.vim$/,
+];
+
+for (const name of entryNames) {
+  assert.ok(
+    allowedEntries.some((pattern) => pattern.test(name)),
+    `Vim archive ships an unexpected file: ${name}`,
+  );
+}
+
+const forbiddenEntries = [
+  /^vim-vize\/\.git/,
+  /^vim-vize\/\.github\//,
+  /^vim-vize\/node_modules\//,
+  /^vim-vize\/target\//,
+  /\/\.DS_Store$/,
+  /\.tar\.gz$/,
+  /~$/,
+];
+
+for (const name of entryNames) {
+  for (const pattern of forbiddenEntries) {
+    assert.ok(!pattern.test(name), `Vim archive must not ship ${name}`);
+  }
+}
+
+const autoload = readTextEntry(entryMap, "vim-vize/autoload/vize.vim");
+const ftdetect = readTextEntry(entryMap, "vim-vize/ftdetect/vize.vim");
+const spec = readTextEntry(entryMap, "vim-vize/test/vize_spec.vim");
+
+assert.match(autoload, /'cmd': \['vize', 'lsp'\]/);
+assert.match(autoload, /'allowlist': \['vue', 'art-vue'\]/);
+assert.match(autoload, /'initialization_options': s:profiles\.lint/);
+assert.match(autoload, /function! vize#vim_lsp_config/);
+assert.match(autoload, /lsp#register_server/);
+assert.match(ftdetect, /\*\.vue setlocal filetype=vue/);
+assert.match(ftdetect, /\*\.art\.vue setlocal filetype=art-vue/);
+assert.match(spec, /vize#vim_lsp_config/);
+assert.match(spec, /assert_equal\(\['vize', 'lsp'\]/);
+
+console.log(
+  `Vim package smoke passed: ${path.relative(root, archivePath)} (${entryNames.length} entries)`,
+);
+
+function readTextEntry(entryMap, name) {
+  const entry = entryMap.get(name);
+  assert.ok(entry, `missing tar entry: ${name}`);
+  return entry.data.toString("utf-8");
+}
+
+function readTarGz(filePath) {
+  const buffer = zlib.gunzipSync(fs.readFileSync(filePath));
+  const entries = [];
+  let offset = 0;
+
+  while (offset + 512 <= buffer.byteLength) {
+    const header = buffer.subarray(offset, offset + 512);
+    if (header.every((byte) => byte === 0)) {
+      break;
+    }
+
+    const name = readTarString(header, 0, 100);
+    const prefix = readTarString(header, 345, 155);
+    const fullName = prefix ? `${prefix}/${name}` : name;
+    const size = parseOctal(readTarString(header, 124, 12));
+    const typeflag = readTarString(header, 156, 1) || "0";
+    const dataOffset = offset + 512;
+    const data = buffer.subarray(dataOffset, dataOffset + size);
+
+    assert.ok(fullName, "tar entry name must not be empty");
+    if (typeflag === "x" || typeflag === "g") {
+      offset = dataOffset + Math.ceil(size / 512) * 512;
+      continue;
+    }
+
+    assert.ok(
+      typeflag === "0" || typeflag === "5",
+      `unsupported tar entry type ${typeflag}: ${fullName}`,
+    );
+
+    entries.push({ data, name: fullName, size, typeflag });
+    offset = dataOffset + Math.ceil(size / 512) * 512;
+  }
+
+  return entries;
+}
+
+function readTarString(buffer, offset, length) {
+  const raw = buffer.subarray(offset, offset + length);
+  const end = raw.indexOf(0);
+  return raw.subarray(0, end === -1 ? raw.byteLength : end).toString("utf-8");
+}
+
+function parseOctal(value) {
+  const trimmed = value.trim();
+  return trimmed ? Number.parseInt(trimmed, 8) : 0;
+}

--- a/tools/vite-plus/tasks/build.ts
+++ b/tools/vite-plus/tasks/build.ts
@@ -60,6 +60,9 @@ export const buildTasks = defineTasks({
   "package:nvim-extension": noCacheTask(
     "COPYFILE_DISABLE=1 LC_ALL=C LANG=C tar -czf nvim-vize-extension.tar.gz -C npm nvim-vize && node tools/nvim-vize/assert-nvim-package.mjs nvim-vize-extension.tar.gz",
   ),
+  "package:vim-extension": noCacheTask(
+    "COPYFILE_DISABLE=1 LC_ALL=C LANG=C tar -czf vim-vize-extension.tar.gz -C npm vim-vize && node tools/vim-vize/assert-vim-package.mjs vim-vize-extension.tar.gz",
+  ),
   "package:editor-extensions": noCacheTask(
     `${runInVscodeExtension(
       "pnpm exec tsgo --noEmit",
@@ -68,7 +71,9 @@ export const buildTasks = defineTasks({
       "node ../../tools/vscode-vize/assert-vsix-package.mjs dist/vize.vsix",
     )} && ${runTask("check:zed-extension")} && ${runTask(
       "test:zed-extension:unit",
-    )} && ${runTask("package:zed-extension")} && ${runTask("package:nvim-extension")}`,
+    )} && ${runTask("package:zed-extension")} && ${runTask(
+      "package:nvim-extension",
+    )} && ${runTask("package:vim-extension")}`,
   ),
   "install:plugin": noCacheTask("vp install --filter './npm/vite-plugin-vize'"),
 });

--- a/tools/vite-plus/tasks/test-benchmark.ts
+++ b/tools/vite-plus/tasks/test-benchmark.ts
@@ -82,6 +82,10 @@ export const testAndBenchmarkTasks = defineTasks({
     "nvim --headless -u NONE --noplugin '+set runtimepath^=npm/nvim-vize' '+luafile npm/nvim-vize/test/vize_spec.lua' '+qa'",
   ),
   "test:nvim-extension:package": noCacheTask("vp run --workspace-root package:nvim-extension"),
+  "test:vim-extension:headless": noCacheTask(
+    "vim -Nu NONE -n -es -S npm/vim-vize/test/vize_spec.vim",
+  ),
+  "test:vim-extension:package": noCacheTask("vp run --workspace-root package:vim-extension"),
   "test:playground": task(runInPackages("test:browser", ["./playground"]), {
     input: cacheInputs.jsChecks,
   }),


### PR DESCRIPTION
## Summary
- add a Vim `vim-vize` runtime package with filetype detection and `vim-lsp` registration helpers
- cover lint/recommended/off profiles, custom cmd/allowlist/init options, generated vim-lsp config, and `.vue` / `.art.vue` detection in a Vimscript smoke
- add strict package archive assertions and include the Vim archive in editor-extension packaging/release artifacts

## Validation
- vp run --workspace-root test:vim-extension:headless
- vp run --workspace-root test:vim-extension:package
- node --test tests/tooling/editor-integrations.test.ts
- vp run --workspace-root check:repo
- vp run --workspace-root package:editor-extensions
- git diff --check

Refs #588
