### PR TITLE
test: add helix extension package smoke

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,6 +147,7 @@ jobs:
         with:
           name: editor-extensions
           path: |
+            helix-vize-extension.tar.gz
             npm/vscode-vize/dist/vize.vsix
             nvim-vize-extension.tar.gz
             vim-vize-extension.tar.gz

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ examples/*/.vite/
 .DS_Store
 *.tgz
 *.vsix
+helix-vize-extension.tar.gz
 nvim-vize-extension.tar.gz
 vim-vize-extension.tar.gz
 zed-vize-extension.tar.gz

--- a/npm/helix-vize/LICENSE
+++ b/npm/helix-vize/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) Vize contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/npm/helix-vize/README.md
+++ b/npm/helix-vize/README.md
@@ -1,0 +1,23 @@
+# helix-vize
+
+Helix `languages.toml` integration for the Vize language server.
+
+Copy or merge `languages.toml` into:
+
+```text
+~/.config/helix/languages.toml
+```
+
+The default profile is lint-only:
+
+```toml
+[language-server.vize]
+command = "vize"
+args = ["lsp"]
+
+[language-server.vize.config]
+lint = true
+```
+
+The package registers Vize for `vue` and `art-vue`. The `art-vue` language uses a glob so
+`*.art.vue` files do not get swallowed by the generic `.vue` suffix rule.

--- a/npm/helix-vize/languages.toml
+++ b/npm/helix-vize/languages.toml
@@ -1,0 +1,21 @@
+[language-server.vize]
+command = "vize"
+args = ["lsp"]
+
+[language-server.vize.config]
+lint = true
+
+[[language]]
+name = "vue"
+scope = "source.vue"
+file-types = ["vue"]
+roots = ["vize.config.pkl", "vize.config.json", "package.json", ".git"]
+language-servers = ["vize"]
+
+[[language]]
+name = "art-vue"
+language-id = "art-vue"
+scope = "source.art-vue"
+file-types = [{ glob = "*.art.vue" }]
+roots = ["vize.config.pkl", "vize.config.json", "package.json", ".git"]
+language-servers = ["vize"]

--- a/tests/tooling/editor-integrations.test.ts
+++ b/tests/tooling/editor-integrations.test.ts
@@ -232,4 +232,7 @@ test("CI packages editor extension artifacts", () => {
   assert.match(buildTasks, /package:editor-extensions[\s\S]*package:vim-extension/);
   assert.match(testTasks, /test:vim-extension:headless[\s\S]*vim -Nu NONE/);
   assert.match(testTasks, /test:vim-extension:package[\s\S]*package:vim-extension/);
+  assert.match(buildTasks, /package:helix-extension[\s\S]*assert-helix-package\.mjs/);
+  assert.match(buildTasks, /package:editor-extensions[\s\S]*package:helix-extension/);
+  assert.match(testTasks, /test:helix-extension:package[\s\S]*package:helix-extension/);
 });

--- a/tools/helix-vize/assert-helix-package.mjs
+++ b/tools/helix-vize/assert-helix-package.mjs
@@ -1,0 +1,163 @@
+#!/usr/bin/env node
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import zlib from "node:zlib";
+import toml from "@iarna/toml";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const archivePath = path.resolve(
+  process.cwd(),
+  process.argv[2] ?? path.join(root, "helix-vize-extension.tar.gz"),
+);
+
+assert.ok(fs.existsSync(archivePath), `Helix extension archive does not exist: ${archivePath}`);
+
+const archiveSize = fs.statSync(archivePath).size;
+assert.ok(archiveSize > 1_000, `Helix archive is suspiciously small: ${archiveSize} bytes`);
+assert.ok(archiveSize < 100_000, `Helix archive is unexpectedly large: ${archiveSize} bytes`);
+
+const entries = readTarGz(archivePath);
+const entryNames = entries.map((entry) => entry.name).sort((a, b) => a.localeCompare(b));
+const entryMap = new Map(entries.map((entry) => [entry.name, entry]));
+
+assert.deepEqual(entryNames, Array.from(new Set(entryNames)), "Helix archive has duplicates");
+
+for (const name of entryNames) {
+  assert.ok(!name.includes("\\"), `Helix archive entry must use POSIX separators: ${name}`);
+  assert.ok(!name.includes("\0"), `Helix archive entry contains a NUL byte: ${name}`);
+  assert.ok(!name.startsWith("/"), `Helix archive entry must be relative: ${name}`);
+  assert.ok(!name.split("/").includes(".."), `Helix archive entry must not traverse: ${name}`);
+  assert.ok(name === "helix-vize/" || name.startsWith("helix-vize/"), `unexpected root: ${name}`);
+}
+
+const requiredFiles = ["helix-vize/LICENSE", "helix-vize/README.md", "helix-vize/languages.toml"];
+
+for (const name of requiredFiles) {
+  assert.ok(entryMap.has(name), `Helix archive is missing required file: ${name}`);
+  assert.ok(readTextEntry(entryMap, name).trim().length > 0, `Helix file is empty: ${name}`);
+}
+
+const allowedEntries = [
+  /^helix-vize\/$/,
+  /^helix-vize\/LICENSE$/,
+  /^helix-vize\/README\.md$/,
+  /^helix-vize\/languages\.toml$/,
+];
+
+for (const name of entryNames) {
+  assert.ok(
+    allowedEntries.some((pattern) => pattern.test(name)),
+    `Helix archive ships an unexpected file: ${name}`,
+  );
+}
+
+const forbiddenEntries = [
+  /^helix-vize\/\.git/,
+  /^helix-vize\/\.github\//,
+  /^helix-vize\/node_modules\//,
+  /^helix-vize\/target\//,
+  /\/\.DS_Store$/,
+  /\.tar\.gz$/,
+  /~$/,
+];
+
+for (const name of entryNames) {
+  for (const pattern of forbiddenEntries) {
+    assert.ok(!pattern.test(name), `Helix archive must not ship ${name}`);
+  }
+}
+
+const languagesToml = readTextEntry(entryMap, "helix-vize/languages.toml");
+const parsed = toml.parse(languagesToml);
+
+assert.equal(parsed["language-server"].vize.command, "vize");
+assert.deepEqual(parsed["language-server"].vize.args, ["lsp"]);
+assert.deepEqual(parsed["language-server"].vize.config, { lint: true });
+
+const languages = new Map(parsed.language.map((language) => [language.name, language]));
+assertLanguage(languages.get("vue"), {
+  fileTypes: ["vue"],
+  languageId: undefined,
+  scope: "source.vue",
+});
+assertLanguage(languages.get("art-vue"), {
+  fileTypes: [{ glob: "*.art.vue" }],
+  languageId: "art-vue",
+  scope: "source.art-vue",
+});
+
+assert.match(languagesToml, /^\[language-server\.vize\]$/m);
+assert.match(languagesToml, /^command = "vize"$/m);
+assert.match(languagesToml, /^args = \["lsp"\]$/m);
+assert.match(languagesToml, /^\[language-server\.vize\.config\]$/m);
+assert.match(languagesToml, /^lint = true$/m);
+assert.match(languagesToml, /^file-types = \[\{ glob = "\*\.art\.vue" \}\]$/m);
+
+console.log(
+  `Helix package smoke passed: ${path.relative(root, archivePath)} (${entryNames.length} entries)`,
+);
+
+function assertLanguage(language, expected) {
+  assert.ok(language, `missing language: ${expected.scope}`);
+  assert.equal(language.scope, expected.scope);
+  assert.equal(language["language-id"], expected.languageId);
+  assert.deepEqual(language["file-types"], expected.fileTypes);
+  assert.deepEqual(language.roots, ["vize.config.pkl", "vize.config.json", "package.json", ".git"]);
+  assert.deepEqual(language["language-servers"], ["vize"]);
+}
+
+function readTextEntry(entryMap, name) {
+  const entry = entryMap.get(name);
+  assert.ok(entry, `missing tar entry: ${name}`);
+  return entry.data.toString("utf-8");
+}
+
+function readTarGz(filePath) {
+  const buffer = zlib.gunzipSync(fs.readFileSync(filePath));
+  const entries = [];
+  let offset = 0;
+
+  while (offset + 512 <= buffer.byteLength) {
+    const header = buffer.subarray(offset, offset + 512);
+    if (header.every((byte) => byte === 0)) {
+      break;
+    }
+
+    const name = readTarString(header, 0, 100);
+    const prefix = readTarString(header, 345, 155);
+    const fullName = prefix ? `${prefix}/${name}` : name;
+    const size = parseOctal(readTarString(header, 124, 12));
+    const typeflag = readTarString(header, 156, 1) || "0";
+    const dataOffset = offset + 512;
+    const data = buffer.subarray(dataOffset, dataOffset + size);
+
+    assert.ok(fullName, "tar entry name must not be empty");
+    if (typeflag === "x" || typeflag === "g") {
+      offset = dataOffset + Math.ceil(size / 512) * 512;
+      continue;
+    }
+
+    assert.ok(
+      typeflag === "0" || typeflag === "5",
+      `unsupported tar entry type ${typeflag}: ${fullName}`,
+    );
+
+    entries.push({ data, name: fullName, size, typeflag });
+    offset = dataOffset + Math.ceil(size / 512) * 512;
+  }
+
+  return entries;
+}
+
+function readTarString(buffer, offset, length) {
+  const raw = buffer.subarray(offset, offset + length);
+  const end = raw.indexOf(0);
+  return raw.subarray(0, end === -1 ? raw.byteLength : end).toString("utf-8");
+}
+
+function parseOctal(value) {
+  const trimmed = value.trim();
+  return trimmed ? Number.parseInt(trimmed, 8) : 0;
+}

--- a/tools/vite-plus/tasks/build.ts
+++ b/tools/vite-plus/tasks/build.ts
@@ -63,6 +63,9 @@ export const buildTasks = defineTasks({
   "package:vim-extension": noCacheTask(
     "COPYFILE_DISABLE=1 LC_ALL=C LANG=C tar -czf vim-vize-extension.tar.gz -C npm vim-vize && node tools/vim-vize/assert-vim-package.mjs vim-vize-extension.tar.gz",
   ),
+  "package:helix-extension": noCacheTask(
+    "COPYFILE_DISABLE=1 LC_ALL=C LANG=C tar -czf helix-vize-extension.tar.gz -C npm helix-vize && node tools/helix-vize/assert-helix-package.mjs helix-vize-extension.tar.gz",
+  ),
   "package:editor-extensions": noCacheTask(
     `${runInVscodeExtension(
       "pnpm exec tsgo --noEmit",
@@ -73,7 +76,7 @@ export const buildTasks = defineTasks({
       "test:zed-extension:unit",
     )} && ${runTask("package:zed-extension")} && ${runTask(
       "package:nvim-extension",
-    )} && ${runTask("package:vim-extension")}`,
+    )} && ${runTask("package:vim-extension")} && ${runTask("package:helix-extension")}`,
   ),
   "install:plugin": noCacheTask("vp install --filter './npm/vite-plugin-vize'"),
 });

--- a/tools/vite-plus/tasks/test-benchmark.ts
+++ b/tools/vite-plus/tasks/test-benchmark.ts
@@ -86,6 +86,7 @@ export const testAndBenchmarkTasks = defineTasks({
     "vim -Nu NONE -n -es -S npm/vim-vize/test/vize_spec.vim",
   ),
   "test:vim-extension:package": noCacheTask("vp run --workspace-root package:vim-extension"),
+  "test:helix-extension:package": noCacheTask("vp run --workspace-root package:helix-extension"),
   "test:playground": task(runInPackages("test:browser", ["./playground"]), {
     input: cacheInputs.jsChecks,
   }),


### PR DESCRIPTION
## Summary
- add a Helix `languages.toml` integration package for Vize
- configure `language-server.vize` with `command = "vize"`, `args = ["lsp"]`, and lint-only config
- validate Vue and Art Vue language entries, including `*.art.vue` glob handling, with strict package archive assertions

## Validation
- vp run --workspace-root test:helix-extension:package
- node --test tests/tooling/editor-integrations.test.ts
- vp run --workspace-root check:repo
- vp run --workspace-root package:editor-extensions
- git diff --check

Refs #588
