### PR TITLE
test: add emacs extension package smoke

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,6 +147,7 @@ jobs:
         with:
           name: editor-extensions
           path: |
+            emacs-vize-extension.tar.gz
             helix-vize-extension.tar.gz
             npm/vscode-vize/dist/vize.vsix
             nvim-vize-extension.tar.gz

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ examples/*/.vite/
 .DS_Store
 *.tgz
 *.vsix
+emacs-vize-extension.tar.gz
 helix-vize-extension.tar.gz
 nvim-vize-extension.tar.gz
 vim-vize-extension.tar.gz

--- a/npm/emacs-vize/LICENSE
+++ b/npm/emacs-vize/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) Vize contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/npm/emacs-vize/README.md
+++ b/npm/emacs-vize/README.md
@@ -1,0 +1,19 @@
+# emacs-vize
+
+Emacs Eglot integration for the Vize language server.
+
+```elisp
+(add-to-list 'load-path "/path/to/emacs-vize")
+(require 'vize)
+(vize-setup-eglot 'lint)
+```
+
+Profiles:
+
+- `lint`: enables Vize lint diagnostics only.
+- `recommended`: enables lint, typecheck, editor, and ecosystem features.
+- `off`: starts Vize with no features enabled.
+
+The package registers `vize-vue-mode`, `vize-art-vue-mode`, and common Vue major modes with
+`eglot-server-programs`. Eglot starts `("vize" "lsp")` and passes `:initializationOptions` for
+the selected profile.

--- a/npm/emacs-vize/test/vize-test.el
+++ b/npm/emacs-vize/test/vize-test.el
@@ -1,0 +1,23 @@
+(require 'ert)
+
+(load-file (expand-file-name "../vize.el" (file-name-directory load-file-name)))
+
+(ert-deftest vize-eglot-default-program ()
+  (should
+   (equal (vize-eglot-server-program)
+          '("vize" "lsp" :initializationOptions (:lint t)))))
+
+(ert-deftest vize-eglot-recommended-program ()
+  (should
+   (equal (vize-eglot-server-program 'recommended)
+          '("vize" "lsp" :initializationOptions
+            (:editor t :ecosystem t :lint t :typecheck t)))))
+
+(ert-deftest vize-eglot-off-program ()
+  (should (equal (vize-eglot-server-program 'off) '("vize" "lsp"))))
+
+(ert-deftest vize-eglot-custom-command ()
+  (let ((vize-eglot-command '("/tmp/vize" "lsp" "--debug")))
+    (should
+     (equal (vize-eglot-server-program 'lint)
+            '("/tmp/vize" "lsp" "--debug" :initializationOptions (:lint t))))))

--- a/npm/emacs-vize/vize.el
+++ b/npm/emacs-vize/vize.el
@@ -1,0 +1,82 @@
+;;; vize.el --- Eglot integration for Vize -*- lexical-binding: t; -*-
+
+;; Copyright (C) Vize contributors
+;; SPDX-License-Identifier: MIT
+
+;;; Commentary:
+
+;; Configure the Vize language server for Eglot.
+
+;;; Code:
+
+(defgroup vize nil
+  "Vize language server integration."
+  :group 'tools
+  :prefix "vize-")
+
+(defcustom vize-eglot-command '("vize" "lsp")
+  "Command used to start the Vize language server."
+  :type '(repeat string)
+  :group 'vize)
+
+(defcustom vize-eglot-profile 'lint
+  "Default Vize feature profile for Eglot."
+  :type '(choice (const :tag "Lint only" lint)
+                 (const :tag "Recommended" recommended)
+                 (const :tag "Off" off))
+  :group 'vize)
+
+(defcustom vize-eglot-major-modes
+  '(vue-mode vue-ts-mode web-mode vize-vue-mode vize-art-vue-mode)
+  "Major modes that should start the Vize language server."
+  :type '(repeat symbol)
+  :group 'vize)
+
+(defconst vize--profiles
+  '((lint . (:lint t))
+    (off . nil)
+    (recommended . (:editor t :ecosystem t :lint t :typecheck t)))
+  "Vize initialization option profiles.")
+
+;;;###autoload
+(define-derived-mode vize-vue-mode prog-mode "Vue"
+  "Fallback major mode for Vue single-file components.")
+
+;;;###autoload
+(define-derived-mode vize-art-vue-mode prog-mode "Art Vue"
+  "Fallback major mode for Art Vue single-file components.")
+
+;;;###autoload
+(add-to-list 'auto-mode-alist '("\\.vue\\'" . vize-vue-mode))
+
+;;;###autoload
+(add-to-list 'auto-mode-alist '("\\.art\\.vue\\'" . vize-art-vue-mode))
+
+(defun vize-profile-options (&optional profile)
+  "Return initialization options for PROFILE."
+  (let* ((profile (or profile vize-eglot-profile))
+         (entry (assq profile vize--profiles)))
+    (unless entry
+      (error "Unknown Vize profile: %S" profile))
+    (copy-tree (cdr entry))))
+
+(defun vize-eglot-server-program (&optional profile)
+  "Return an `eglot-server-programs' value for PROFILE."
+  (let ((command (copy-sequence vize-eglot-command))
+        (options (vize-profile-options profile)))
+    (if options
+        (append command (list :initializationOptions options))
+      command)))
+
+;;;###autoload
+(defun vize-setup-eglot (&optional profile)
+  "Register Vize with Eglot for PROFILE."
+  (interactive)
+  (with-eval-after-load 'eglot
+    (dolist (mode vize-eglot-major-modes)
+      (add-to-list 'eglot-server-programs
+                   (cons mode (vize-eglot-server-program profile))))))
+
+(provide 'vize)
+
+;;; vize.el ends here

--- a/tests/tooling/editor-integrations.test.ts
+++ b/tests/tooling/editor-integrations.test.ts
@@ -235,4 +235,7 @@ test("CI packages editor extension artifacts", () => {
   assert.match(buildTasks, /package:helix-extension[\s\S]*assert-helix-package\.mjs/);
   assert.match(buildTasks, /package:editor-extensions[\s\S]*package:helix-extension/);
   assert.match(testTasks, /test:helix-extension:package[\s\S]*package:helix-extension/);
+  assert.match(buildTasks, /package:emacs-extension[\s\S]*assert-emacs-package\.mjs/);
+  assert.match(buildTasks, /package:editor-extensions[\s\S]*package:emacs-extension/);
+  assert.match(testTasks, /test:emacs-extension:package[\s\S]*package:emacs-extension/);
 });

--- a/tools/emacs-vize/assert-emacs-package.mjs
+++ b/tools/emacs-vize/assert-emacs-package.mjs
@@ -1,0 +1,157 @@
+#!/usr/bin/env node
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import zlib from "node:zlib";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const archivePath = path.resolve(
+  process.cwd(),
+  process.argv[2] ?? path.join(root, "emacs-vize-extension.tar.gz"),
+);
+
+assert.ok(fs.existsSync(archivePath), `Emacs extension archive does not exist: ${archivePath}`);
+
+const archiveSize = fs.statSync(archivePath).size;
+assert.ok(archiveSize > 2_000, `Emacs archive is suspiciously small: ${archiveSize} bytes`);
+assert.ok(archiveSize < 200_000, `Emacs archive is unexpectedly large: ${archiveSize} bytes`);
+
+const entries = readTarGz(archivePath);
+const entryNames = entries.map((entry) => entry.name).sort((a, b) => a.localeCompare(b));
+const entryMap = new Map(entries.map((entry) => [entry.name, entry]));
+
+assert.deepEqual(entryNames, Array.from(new Set(entryNames)), "Emacs archive has duplicates");
+
+for (const name of entryNames) {
+  assert.ok(!name.includes("\\"), `Emacs archive entry must use POSIX separators: ${name}`);
+  assert.ok(!name.includes("\0"), `Emacs archive entry contains a NUL byte: ${name}`);
+  assert.ok(!name.startsWith("/"), `Emacs archive entry must be relative: ${name}`);
+  assert.ok(!name.split("/").includes(".."), `Emacs archive entry must not traverse: ${name}`);
+  assert.ok(name === "emacs-vize/" || name.startsWith("emacs-vize/"), `unexpected root: ${name}`);
+}
+
+const requiredFiles = [
+  "emacs-vize/LICENSE",
+  "emacs-vize/README.md",
+  "emacs-vize/test/vize-test.el",
+  "emacs-vize/vize.el",
+];
+
+for (const name of requiredFiles) {
+  assert.ok(entryMap.has(name), `Emacs archive is missing required file: ${name}`);
+  assert.ok(readTextEntry(entryMap, name).trim().length > 0, `Emacs file is empty: ${name}`);
+}
+
+const allowedEntries = [
+  /^emacs-vize\/$/,
+  /^emacs-vize\/LICENSE$/,
+  /^emacs-vize\/README\.md$/,
+  /^emacs-vize\/test\/$/,
+  /^emacs-vize\/test\/vize-test\.el$/,
+  /^emacs-vize\/vize\.el$/,
+];
+
+for (const name of entryNames) {
+  assert.ok(
+    allowedEntries.some((pattern) => pattern.test(name)),
+    `Emacs archive ships an unexpected file: ${name}`,
+  );
+}
+
+const forbiddenEntries = [
+  /^emacs-vize\/\.git/,
+  /^emacs-vize\/\.github\//,
+  /^emacs-vize\/node_modules\//,
+  /^emacs-vize\/target\//,
+  /\/\.DS_Store$/,
+  /\.elc$/,
+  /\.tar\.gz$/,
+  /~$/,
+];
+
+for (const name of entryNames) {
+  for (const pattern of forbiddenEntries) {
+    assert.ok(!pattern.test(name), `Emacs archive must not ship ${name}`);
+  }
+}
+
+const vizeEl = readTextEntry(entryMap, "emacs-vize/vize.el");
+const testEl = readTextEntry(entryMap, "emacs-vize/test/vize-test.el");
+
+assert.match(vizeEl, /lexical-binding: t/);
+assert.match(vizeEl, /defcustom vize-eglot-command '\("vize" "lsp"\)/);
+assert.match(vizeEl, /defcustom vize-eglot-profile 'lint/);
+assert.match(vizeEl, /recommended \. \(:editor t :ecosystem t :lint t :typecheck t\)/);
+assert.match(vizeEl, /define-derived-mode vize-vue-mode/);
+assert.match(vizeEl, /define-derived-mode vize-art-vue-mode/);
+assert.ok(vizeEl.includes("(add-to-list 'auto-mode-alist '(\"\\\\.vue\\\\'\" . vize-vue-mode))"));
+assert.ok(
+  vizeEl.includes(
+    "(add-to-list 'auto-mode-alist '(\"\\\\.art\\\\.vue\\\\'\" . vize-art-vue-mode))",
+  ),
+);
+assert.match(vizeEl, /:initializationOptions options/);
+assert.match(vizeEl, /eglot-server-programs/);
+assert.match(vizeEl, /provide 'vize/);
+assert.match(testEl, /ert-deftest vize-eglot-default-program/);
+assert.match(testEl, /:initializationOptions \(:lint t\)/);
+assert.match(testEl, /ert-deftest vize-eglot-off-program/);
+
+console.log(
+  `Emacs package smoke passed: ${path.relative(root, archivePath)} (${entryNames.length} entries)`,
+);
+
+function readTextEntry(entryMap, name) {
+  const entry = entryMap.get(name);
+  assert.ok(entry, `missing tar entry: ${name}`);
+  return entry.data.toString("utf-8");
+}
+
+function readTarGz(filePath) {
+  const buffer = zlib.gunzipSync(fs.readFileSync(filePath));
+  const entries = [];
+  let offset = 0;
+
+  while (offset + 512 <= buffer.byteLength) {
+    const header = buffer.subarray(offset, offset + 512);
+    if (header.every((byte) => byte === 0)) {
+      break;
+    }
+
+    const name = readTarString(header, 0, 100);
+    const prefix = readTarString(header, 345, 155);
+    const fullName = prefix ? `${prefix}/${name}` : name;
+    const size = parseOctal(readTarString(header, 124, 12));
+    const typeflag = readTarString(header, 156, 1) || "0";
+    const dataOffset = offset + 512;
+    const data = buffer.subarray(dataOffset, dataOffset + size);
+
+    assert.ok(fullName, "tar entry name must not be empty");
+    if (typeflag === "x" || typeflag === "g") {
+      offset = dataOffset + Math.ceil(size / 512) * 512;
+      continue;
+    }
+
+    assert.ok(
+      typeflag === "0" || typeflag === "5",
+      `unsupported tar entry type ${typeflag}: ${fullName}`,
+    );
+
+    entries.push({ data, name: fullName, size, typeflag });
+    offset = dataOffset + Math.ceil(size / 512) * 512;
+  }
+
+  return entries;
+}
+
+function readTarString(buffer, offset, length) {
+  const raw = buffer.subarray(offset, offset + length);
+  const end = raw.indexOf(0);
+  return raw.subarray(0, end === -1 ? raw.byteLength : end).toString("utf-8");
+}
+
+function parseOctal(value) {
+  const trimmed = value.trim();
+  return trimmed ? Number.parseInt(trimmed, 8) : 0;
+}

--- a/tools/vite-plus/tasks/build.ts
+++ b/tools/vite-plus/tasks/build.ts
@@ -66,6 +66,9 @@ export const buildTasks = defineTasks({
   "package:helix-extension": noCacheTask(
     "COPYFILE_DISABLE=1 LC_ALL=C LANG=C tar -czf helix-vize-extension.tar.gz -C npm helix-vize && node tools/helix-vize/assert-helix-package.mjs helix-vize-extension.tar.gz",
   ),
+  "package:emacs-extension": noCacheTask(
+    "COPYFILE_DISABLE=1 LC_ALL=C LANG=C tar -czf emacs-vize-extension.tar.gz -C npm emacs-vize && node tools/emacs-vize/assert-emacs-package.mjs emacs-vize-extension.tar.gz",
+  ),
   "package:editor-extensions": noCacheTask(
     `${runInVscodeExtension(
       "pnpm exec tsgo --noEmit",
@@ -76,7 +79,9 @@ export const buildTasks = defineTasks({
       "test:zed-extension:unit",
     )} && ${runTask("package:zed-extension")} && ${runTask(
       "package:nvim-extension",
-    )} && ${runTask("package:vim-extension")} && ${runTask("package:helix-extension")}`,
+    )} && ${runTask("package:vim-extension")} && ${runTask(
+      "package:helix-extension",
+    )} && ${runTask("package:emacs-extension")}`,
   ),
   "install:plugin": noCacheTask("vp install --filter './npm/vite-plugin-vize'"),
 });

--- a/tools/vite-plus/tasks/test-benchmark.ts
+++ b/tools/vite-plus/tasks/test-benchmark.ts
@@ -87,6 +87,7 @@ export const testAndBenchmarkTasks = defineTasks({
   ),
   "test:vim-extension:package": noCacheTask("vp run --workspace-root package:vim-extension"),
   "test:helix-extension:package": noCacheTask("vp run --workspace-root package:helix-extension"),
+  "test:emacs-extension:package": noCacheTask("vp run --workspace-root package:emacs-extension"),
   "test:playground": task(runInPackages("test:browser", ["./playground"]), {
     input: cacheInputs.jsChecks,
   }),


### PR DESCRIPTION
## Summary
- add an Emacs `emacs-vize` Eglot integration package
- configure `eglot-server-programs` with `("vize" "lsp")` and profile-specific `:initializationOptions`
- include fallback Vue / Art Vue major modes, ERT coverage, strict package archive assertions, and release/editor-extension packaging wiring

## Validation
- vp run --workspace-root test:emacs-extension:package
- node --test tests/tooling/editor-integrations.test.ts
- vp run --workspace-root check:repo
- vp run --workspace-root package:editor-extensions
- git diff --check

Refs #588
