### PR TITLE
fix(sfc): avoid duplicate unref runtime import

### DIFF
--- a/crates/vize_atelier_sfc/src/compile/tests.rs
+++ b/crates/vize_atelier_sfc/src/compile/tests.rs
@@ -126,6 +126,45 @@ const color = 'tomato'
 }
 
 #[test]
+fn test_script_setup_css_v_bind_dedupes_template_unref_import() {
+    let source = r#"<script setup>
+let color = 'tomato'
+</script>
+
+<template>
+  <div class="box">{{ color }}</div>
+</template>
+
+<style scoped>
+.box {
+  color: v-bind(color);
+}
+</style>"#;
+
+    let descriptor = parse_sfc(source, SfcParseOptions::default()).expect("Failed to parse SFC");
+    let mut opts = SfcCompileOptions {
+        scope_id: Some("test".into()),
+        ..Default::default()
+    };
+    opts.script.id = Some("src/Box.vue".into());
+    let result = compile_sfc(&descriptor, opts).expect("Failed to compile SFC");
+
+    assert_eq!(
+        result.code.matches("unref as _unref").count(),
+        1,
+        "CSS vars and template unwrapping should share the same _unref import:\n{}",
+        result.code
+    );
+    assert!(
+        result.code.contains("useCssVars as _useCssVars")
+            && result.code.contains(r#""test-color": (_unref(color))"#)
+            && result.code.contains("_toDisplayString(_unref(color))"),
+        "CSS vars and render output should both use _unref:\n{}",
+        result.code
+    );
+}
+
+#[test]
 fn test_script_setup_define_page_is_compile_time_only() {
     let source = r#"<script setup lang="ts">
 definePage({

--- a/crates/vize_atelier_sfc/src/compile_script/import_utils.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/import_utils.rs
@@ -10,6 +10,37 @@ use oxc_span::SourceType;
 
 use vize_carton::ToCompactString;
 
+/// Returns true when an import block already declares a local binding from a
+/// specific module.
+pub fn import_block_has_local_from(imports: &str, module_source: &str, local_name: &str) -> bool {
+    let allocator = Allocator::default();
+    let source_type = SourceType::ts();
+    let parser = Parser::new(&allocator, imports, source_type);
+    let result = parser.parse();
+
+    if !result.errors.is_empty() {
+        return false;
+    }
+
+    result.program.body.iter().any(|stmt| {
+        let Statement::ImportDeclaration(decl) = stmt else {
+            return false;
+        };
+        if decl.source.value.as_str() != module_source {
+            return false;
+        }
+        decl.specifiers.as_ref().is_some_and(|specifiers| {
+            specifiers.iter().any(|spec| match spec {
+                ImportDeclarationSpecifier::ImportSpecifier(s) => s.local.name == local_name,
+                ImportDeclarationSpecifier::ImportDefaultSpecifier(s) => s.local.name == local_name,
+                ImportDeclarationSpecifier::ImportNamespaceSpecifier(s) => {
+                    s.local.name == local_name
+                }
+            })
+        })
+    })
+}
+
 /// Process import statement to remove TypeScript type-only imports using OXC
 /// Returns None if the entire import should be removed, Some(processed) otherwise
 pub fn process_import_for_types(import: &str) -> Option<vize_carton::String> {
@@ -167,7 +198,17 @@ pub fn extract_import_identifiers(import: &str) -> Vec<vize_carton::String> {
 
 #[cfg(test)]
 mod tests {
-    use super::process_import_for_types;
+    use super::{import_block_has_local_from, process_import_for_types};
+
+    #[test]
+    fn test_import_block_has_local_from() {
+        let input = r#"import { openBlock as _openBlock, unref as _unref } from "vue"
+import { foo } from "other""#;
+
+        assert!(import_block_has_local_from(input, "vue", "_unref"));
+        assert!(!import_block_has_local_from(input, "vue", "_useCssVars"));
+        assert!(!import_block_has_local_from(input, "other", "_unref"));
+    }
 
     #[test]
     fn test_default_import_with_type_named_import() {

--- a/crates/vize_atelier_sfc/src/compile_script/inline/compiler/preamble.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/inline/compiler/preamble.rs
@@ -2,6 +2,7 @@ use vize_carton::{String, profile};
 
 use super::super::super::TemplateParts;
 use super::super::super::function_mode::dedupe_imports;
+use super::super::super::import_utils::import_block_has_local_from;
 use super::parser::parse_script_content;
 
 pub(super) struct PreambleState {
@@ -43,9 +44,13 @@ pub(super) fn emit_preamble(
 
     // useCssVars import if style has v-bind()
     if has_css_vars {
-        output.extend_from_slice(
-            b"import { useCssVars as _useCssVars, unref as _unref } from 'vue'\n",
-        );
+        if import_block_has_local_from(template.imports, "vue", "_unref") {
+            output.extend_from_slice(b"import { useCssVars as _useCssVars } from 'vue'\n");
+        } else {
+            output.extend_from_slice(
+                b"import { useCssVars as _useCssVars, unref as _unref } from 'vue'\n",
+            );
+        }
     }
 
     // Component helper import (skip if already emitted with withAsyncContext)


### PR DESCRIPTION
## Summary
- Avoid emitting a second `unref as _unref` runtime import when CSS `v-bind()` and template unwrapping both need `_unref`.
- Add a parser-backed import-block helper and regression coverage for CSS vars plus template unwrapping.

## Validation
- `cargo fmt --all`
- `cargo test -p vize_atelier_sfc`