### PR TITLE
fix: CSS v-bind parentheses parsing

### DIFF
--- a/crates/vize_atelier_sfc/src/compile/tests.rs
+++ b/crates/vize_atelier_sfc/src/compile/tests.rs
@@ -126,6 +126,65 @@ const color = 'tomato'
 }
 
 #[test]
+fn test_script_setup_css_v_bind_handles_quoted_parentheses() {
+    let source = r#"<script setup>
+const parentBg = 'red'
+const textCountPercentage = 64
+</script>
+
+<template>
+  <div class="root">Box</div>
+</template>
+
+<style scoped>
+.header {
+  background-color: color(from v-bind("parentBg ?? 'var(--bg)'") srgb r g b / 0.85);
+}
+
+.textCountGraph {
+  background-image: conic-gradient(
+    var(--countColor) 0% v-bind("Math.min(100, textCountPercentage) + '%'"),
+    rgba(0, 0, 0, .2) v-bind("Math.min(100, textCountPercentage) + '%'") 100%
+  );
+}
+</style>"#;
+
+    let descriptor = parse_sfc(source, SfcParseOptions::default()).expect("Failed to parse SFC");
+    let mut opts = SfcCompileOptions {
+        scope_id: Some("test".into()),
+        ..Default::default()
+    };
+    opts.script.id = Some("src/Box.vue".into());
+    let result = compile_sfc(&descriptor, opts).expect("Failed to compile SFC");
+
+    assert_eq!(
+        descriptor.css_vars,
+        vec![
+            "parentBg ?? 'var(--bg)'",
+            "Math.min(100, textCountPercentage) + '%'",
+        ]
+    );
+    assert!(
+        result
+            .css
+            .as_deref()
+            .is_some_and(|css| !css.contains("v-bind(")
+                && css.contains("parentBg")
+                && css.contains("textCountPercentage")),
+        "CSS v-bind should preserve full expressions with nested parentheses:\n{:?}",
+        result.css
+    );
+    assert!(
+        result.code.contains(r#"(_unref(parentBg ?? 'var(--bg)'))"#)
+            && result
+                .code
+                .contains(r#"(_unref(Math.min(100, textCountPercentage) + '%'))"#),
+        "useCssVars should receive complete expressions:\n{}",
+        result.code
+    );
+}
+
+#[test]
 fn test_script_setup_css_v_bind_dedupes_template_unref_import() {
     let source = r#"<script setup>
 let color = 'tomato'

--- a/crates/vize_atelier_sfc/src/css.rs
+++ b/crates/vize_atelier_sfc/src/css.rs
@@ -28,7 +28,6 @@ use crate::types::SfcStyleBlock;
 use self::scoped::apply_scoped_css;
 use self::transform::extract_and_transform_v_bind_with_scope;
 pub(crate) use self::transform::scoped_v_bind_name;
-pub(crate) use self::transform::trim_outer_quotes;
 
 pub(crate) fn transform_css_v_bind(css: &str, scope_id: Option<&str>) -> (String, Vec<String>) {
     let bump = Bump::new();

--- a/crates/vize_atelier_sfc/src/css/tests.rs
+++ b/crates/vize_atelier_sfc/src/css/tests.rs
@@ -10,7 +10,9 @@ use super::CssTargets;
 use super::scoped::{
     add_scope_to_element, apply_scoped_css, transform_deep, transform_global, transform_slotted,
 };
-use super::transform::extract_and_transform_v_bind;
+use super::transform::{
+    extract_and_transform_v_bind, extract_and_transform_v_bind_with_scope, scoped_v_bind_name,
+};
 use super::{CssCompileOptions, bundle_css, compile_css, parse_css_ast, print_css_ast};
 
 fn test_utf8(bytes: &[u8]) -> &str {
@@ -163,6 +165,47 @@ fn test_v_bind_extraction_with_scope_id() {
     assert!(result.code.contains(r#"var(--test-height\ \+\ \'px\')"#));
     assert!(result.code.contains("var(--test-color)"));
     assert_eq!(result.css_vars, vec!["height + 'px'", "color"]);
+}
+
+#[test]
+fn test_v_bind_extraction_handles_quoted_expressions_with_parentheses() {
+    let bump = Bump::new();
+    let css = r#"
+.header {
+  background-color: color(from v-bind("parentBg ?? 'var(--bg)'") srgb r g b / 0.85);
+}
+
+.textCountGraph {
+  background-image: conic-gradient(
+    var(--countColor) 0% v-bind("Math.min(100, textCountPercentage) + '%'"),
+    rgba(0, 0, 0, .2) v-bind("Math.min(100, textCountPercentage) + '%'") 100%
+  );
+}
+"#;
+
+    let (transformed, vars) =
+        extract_and_transform_v_bind_with_scope(&bump, css, Some("data-v-test"));
+
+    assert!(!transformed.contains("v-bind("));
+    assert_eq!(
+        vars,
+        vec![
+            "parentBg ?? 'var(--bg)'".to_compact_string(),
+            "Math.min(100, textCountPercentage) + '%'".to_compact_string(),
+            "Math.min(100, textCountPercentage) + '%'".to_compact_string(),
+        ]
+    );
+
+    for expr in [
+        "parentBg ?? 'var(--bg)'",
+        "Math.min(100, textCountPercentage) + '%'",
+    ] {
+        let var_ref = format!("var(--{})", scoped_v_bind_name("data-v-test", expr));
+        assert!(
+            transformed.contains(&var_ref),
+            "missing {var_ref} in transformed CSS:\n{transformed}"
+        );
+    }
 }
 
 #[test]

--- a/crates/vize_atelier_sfc/src/css/transform.rs
+++ b/crates/vize_atelier_sfc/src/css/transform.rs
@@ -31,12 +31,17 @@ pub(crate) fn extract_and_transform_v_bind_with_scope<'a>(
             let actual_pos = pos + rel_pos;
             let start = actual_pos + 7;
 
-            if let Some(end) = find_byte(&css_bytes[start..], b')') {
+            let Some(after_open) = css.get(start..) else {
+                result.extend_from_slice(&css_bytes[pos..]);
+                break;
+            };
+
+            if let Some(end) = find_matching_paren(after_open) {
                 // Copy everything before v-bind(
                 result.extend_from_slice(&css_bytes[pos..actual_pos]);
 
                 // Extract expression
-                let Some(expr_str) = css.get(start..start + end).map(str::trim) else {
+                let Some(expr_str) = after_open.get(..end).map(str::trim) else {
                     pos = start + end + 1;
                     result.extend_from_slice(&css_bytes[actual_pos..pos]);
                     continue;
@@ -145,12 +150,6 @@ pub(crate) fn find_bytes(haystack: &[u8], needle: &[u8]) -> Option<usize> {
     haystack.windows(needle.len()).position(|w| w == needle)
 }
 
-/// Find single byte in slice
-#[inline]
-pub(crate) fn find_byte(haystack: &[u8], needle: u8) -> Option<usize> {
-    haystack.iter().position(|&b| b == needle)
-}
-
 /// Reverse find single byte in slice
 #[inline]
 pub(crate) fn rfind_byte(haystack: &[u8], needle: u8) -> Option<usize> {
@@ -160,8 +159,32 @@ pub(crate) fn rfind_byte(haystack: &[u8], needle: u8) -> Option<usize> {
 /// Find the matching closing parenthesis
 pub(crate) fn find_matching_paren(s: &str) -> Option<usize> {
     let mut depth = 1u32;
+    let mut quote = None;
+    let mut escaped = false;
+
     for (i, c) in s.char_indices() {
+        if let Some(quote_char) = quote {
+            if escaped {
+                escaped = false;
+                continue;
+            }
+
+            if c == '\\' {
+                escaped = true;
+                continue;
+            }
+
+            if c == quote_char {
+                quote = None;
+            }
+
+            continue;
+        }
+
         match c {
+            '"' | '\'' | '`' => {
+                quote = Some(c);
+            }
             '(' => depth += 1,
             ')' => {
                 depth -= 1;

--- a/crates/vize_atelier_sfc/src/style.rs
+++ b/crates/vize_atelier_sfc/src/style.rs
@@ -349,23 +349,7 @@ fn transform_global(selector: &str) -> String {
 
 /// Extract CSS v-bind() expressions
 pub fn extract_css_vars(css: &str) -> Vec<String> {
-    let mut vars = Vec::new();
-    let mut search_from = 0;
-
-    while let Some(pos) = css[search_from..].find("v-bind(") {
-        let start = search_from + pos + 7;
-        if let Some(end) = css[start..].find(')') {
-            let expr = css[start..start + end].trim();
-            // Remove quotes if present
-            let expr = crate::css::trim_outer_quotes(expr);
-            vars.push(expr.to_compact_string());
-            search_from = start + end + 1;
-        } else {
-            break;
-        }
-    }
-
-    vars
+    crate::css::transform_css_v_bind(css, None).1
 }
 
 #[cfg(test)]
@@ -409,6 +393,30 @@ mod tests {
         let css = ".foo { color: v-bind(color); background: v-bind('bgColor'); }";
         let vars = extract_css_vars(css);
         assert_eq!(vars, vec!["color", "bgColor"]);
+    }
+
+    #[test]
+    fn test_extract_css_vars_with_quoted_parentheses() {
+        let css = r#"
+.header {
+  background-color: color(from v-bind("parentBg ?? 'var(--bg)'") srgb r g b / 0.85);
+}
+.textCountGraph {
+  background-image: conic-gradient(
+    var(--countColor) 0% v-bind("Math.min(100, textCountPercentage) + '%'"),
+    rgba(0, 0, 0, .2) v-bind("Math.min(100, textCountPercentage) + '%'") 100%
+  );
+}
+"#;
+        let vars = extract_css_vars(css);
+        assert_eq!(
+            vars,
+            vec![
+                "parentBg ?? 'var(--bg)'",
+                "Math.min(100, textCountPercentage) + '%'",
+                "Math.min(100, textCountPercentage) + '%'",
+            ]
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes CSS `v-bind()` extraction when the expression contains quoted JavaScript with nested parentheses, such as:

- `v-bind("parentBg ?? 'var(--bg)'")`
- `v-bind("Math.min(100, textCountPercentage) + '%'")`

The extractor now scans for the matching closing parenthesis while respecting nested parentheses and string literals. The SFC parser's `css_vars` extraction now uses the same implementation as the CSS transform path, so generated `useCssVars` expressions and emitted CSS stay aligned.

Discussion context: https://github.com/ubugeeei/vize/discussions/71#discussioncomment-17038283

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p vize_atelier_sfc -- -D warnings`
- `cargo test -p vize_atelier_sfc v_bind`
- `cargo test -p vize_atelier_sfc extract_css_vars`
- `cargo test -p vize_atelier_sfc`
- `pnpm --dir npm/vite-plugin-vize test`
- `cargo test --workspace`
- `cargo clippy --workspace -- -D warnings`