### PR TITLE
feat: add standalone HTML and petite-vue LSP support

### DIFF
--- a/crates/vize/src/commands/lint.rs
+++ b/crates/vize/src/commands/lint.rs
@@ -156,6 +156,7 @@ pub fn run(args: LintArgs) {
         .unwrap_or(args.preset.as_str());
     let preset = LintPreset::parse(preset_name).unwrap_or_default();
     let mut linter = Linter::with_preset(preset)
+        .with_additional_rules(linter_config.enabled_rules())
         .with_disabled_rules(linter_config.disabled_rules())
         .with_help_level(help_level);
     #[cfg(not(target_arch = "wasm32"))]

--- a/crates/vize/src/commands/lint.rs
+++ b/crates/vize/src/commands/lint.rs
@@ -37,7 +37,7 @@ use crate::commands::profile::{
 #[derive(Args)]
 #[allow(clippy::disallowed_types)]
 pub struct LintArgs {
-    /// Glob pattern(s) to match .vue files
+    /// Glob pattern(s) to match .vue or standalone .html files
     #[arg(default_value = "./**/*.vue")]
     pub patterns: Vec<String>,
 
@@ -132,13 +132,16 @@ pub fn run(args: LintArgs) {
         .runtime_path()
         .map(|path| resolve_lint_config_path(config_dir, path));
 
-    // Collect .vue files using glob patterns or directory walking
+    // Collect .vue and standalone .html files using glob patterns or directory walking
     let collect_start = Instant::now();
     let files = collect_lint_files(&args.patterns);
     let collect_time = collect_start.elapsed();
 
     if files.is_empty() {
-        eprintln!("No .vue files found matching patterns: {:?}", args.patterns);
+        eprintln!(
+            "No .vue or .html files found matching patterns: {:?}",
+            args.patterns
+        );
         return;
     }
 
@@ -198,10 +201,13 @@ pub fn run(args: LintArgs) {
 
             let filename = path.to_string_lossy().to_compact_string();
             let lint_file_start = args.profile.then(Instant::now);
-            let result = profile!(
-                "cli.lint.file.lint_sfc",
-                linter.lint_sfc(&source, &filename)
-            );
+            let result = profile!("cli.lint.file.lint", {
+                if is_standalone_html_path(path) {
+                    linter.lint_standalone_html(&source, &filename)
+                } else {
+                    linter.lint_sfc(&source, &filename)
+                }
+            });
             let lint_time = lint_file_start
                 .map(|start| start.elapsed())
                 .unwrap_or(Duration::ZERO);
@@ -490,13 +496,27 @@ fn collect_lint_files_from_dir(
 }
 
 fn add_lint_file(path: &Path, files: &mut Vec<PathBuf>, seen: &mut FxHashSet<PathBuf>) {
-    if path.extension().and_then(|extension| extension.to_str()) != Some("vue") {
+    if !is_lintable_path(path) {
         return;
     }
     let normalized = normalize_lint_input_path(path);
     if seen.insert(normalized.clone()) {
         files.push(normalized);
     }
+}
+
+fn is_lintable_path(path: &Path) -> bool {
+    matches!(
+        path.extension().and_then(|extension| extension.to_str()),
+        Some("vue" | "html" | "htm")
+    )
+}
+
+fn is_standalone_html_path(path: &Path) -> bool {
+    matches!(
+        path.extension().and_then(|extension| extension.to_str()),
+        Some("html" | "htm")
+    )
 }
 
 fn base_dir_from_lint_pattern(pattern: &str) -> PathBuf {

--- a/crates/vize_carton/src/config/loader.rs
+++ b/crates/vize_carton/src/config/loader.rs
@@ -314,6 +314,7 @@ export default {
   linter: {
     rules: {
       "vue/prop-name-casing": "off",
+      "script/no-options-api": "error",
     },
   },
 }
@@ -330,6 +331,11 @@ export default {
             linter_from_loaded_config.disabled_rules(),
             ["vue/prop-name-casing"]
         );
+        assert_eq!(
+            linter_from_loaded_config.enabled_rules(),
+            ["script/no-options-api"]
+        );
         assert_eq!(linter.disabled_rules(), ["vue/prop-name-casing"]);
+        assert_eq!(linter.enabled_rules(), ["script/no-options-api"]);
     }
 }

--- a/crates/vize_carton/src/config/model/linter.rs
+++ b/crates/vize_carton/src/config/model/linter.rs
@@ -39,6 +39,18 @@ impl LinterConfig {
         rules.sort();
         rules
     }
+
+    /// Rule names explicitly enabled by config.
+    pub fn enabled_rules(&self) -> Vec<String> {
+        let mut rules = self
+            .rules
+            .iter()
+            .filter(|(_, severity)| !matches!(severity, LintRuleSeverity::Off))
+            .map(|(rule, _)| rule.clone())
+            .collect::<Vec<_>>();
+        rules.sort();
+        rules
+    }
 }
 
 impl Default for LinterConfig {

--- a/crates/vize_maestro/src/ide.rs
+++ b/crates/vize_maestro/src/ide.rs
@@ -327,9 +327,13 @@ fn is_inside_raw_html_element(content: &str, offset: usize, tag_name: &str) -> b
         return false;
     };
 
-    let close_needle = format!("</{tag_name}");
+    let close_needle = if tag_name == "script" {
+        "</script"
+    } else {
+        "</style"
+    };
     if before
-        .rfind(&close_needle)
+        .rfind(close_needle)
         .is_some_and(|close_start| close_start > open_start)
     {
         return false;
@@ -339,12 +343,16 @@ fn is_inside_raw_html_element(content: &str, offset: usize, tag_name: &str) -> b
 }
 
 fn last_start_tag(content: &str, tag_name: &str) -> Option<usize> {
-    let needle = format!("<{tag_name}");
+    let needle = if tag_name == "script" {
+        "<script"
+    } else {
+        "<style"
+    };
     let bytes = content.as_bytes();
     let mut search_start = 0;
     let mut last = None;
 
-    while let Some(relative) = content[search_start..].find(&needle) {
+    while let Some(relative) = content[search_start..].find(needle) {
         let start = search_start + relative;
         let after_name = start + needle.len();
         if after_name == bytes.len()

--- a/crates/vize_maestro/src/ide.rs
+++ b/crates/vize_maestro/src/ide.rs
@@ -49,6 +49,7 @@ pub use workspace_symbols::WorkspaceSymbolsService;
 use tower_lsp::lsp_types::Url;
 
 use crate::server::ServerState;
+use crate::utils::is_standalone_html_path;
 use crate::virtual_code::{
     ArtCursorPosition, BlockType, VirtualDocuments, find_art_block_at_offset, find_block_at_offset,
 };
@@ -309,6 +310,57 @@ fn is_in_vue_directive_attribute_value(content: &str, offset: usize) -> bool {
         || attr_name.starts_with("v-")
 }
 
+fn standalone_html_block_at_offset(content: &str, offset: usize) -> BlockType {
+    if is_inside_raw_html_element(content, offset, "script") {
+        BlockType::Script
+    } else if is_inside_raw_html_element(content, offset, "style") {
+        BlockType::Style(0)
+    } else {
+        BlockType::Template
+    }
+}
+
+fn is_inside_raw_html_element(content: &str, offset: usize, tag_name: &str) -> bool {
+    let cursor = offset.min(content.len());
+    let before = content[..cursor].to_ascii_lowercase();
+    let Some(open_start) = last_start_tag(&before, tag_name) else {
+        return false;
+    };
+
+    let close_needle = format!("</{tag_name}");
+    if before
+        .rfind(&close_needle)
+        .is_some_and(|close_start| close_start > open_start)
+    {
+        return false;
+    }
+
+    before[open_start..].contains('>')
+}
+
+fn last_start_tag(content: &str, tag_name: &str) -> Option<usize> {
+    let needle = format!("<{tag_name}");
+    let bytes = content.as_bytes();
+    let mut search_start = 0;
+    let mut last = None;
+
+    while let Some(relative) = content[search_start..].find(&needle) {
+        let start = search_start + relative;
+        let after_name = start + needle.len();
+        if after_name == bytes.len()
+            || matches!(
+                bytes[after_name],
+                b'>' | b'/' | b' ' | b'\t' | b'\n' | b'\r'
+            )
+        {
+            last = Some(start);
+        }
+        search_start = after_name;
+    }
+
+    last
+}
+
 /// Context for IDE operations.
 pub struct IdeContext<'a> {
     /// Server state
@@ -335,6 +387,8 @@ impl<'a> IdeContext<'a> {
         let block_type = if uri.path().ends_with(".art.vue") {
             // For art files, use art-specific block detection
             find_art_block_at_offset(&content, offset)
+        } else if is_standalone_html_path(uri.path()) {
+            Some(standalone_html_block_at_offset(&content, offset))
         } else {
             // Parse SFC to determine block type
             let options = vize_atelier_sfc::SfcParseOptions {

--- a/crates/vize_maestro/src/ide/completion.rs
+++ b/crates/vize_maestro/src/ide/completion.rs
@@ -110,6 +110,17 @@ mod tests {
     }
 
     #[test]
+    fn test_petite_vue_directive_completions() {
+        let items = template::petite_vue_directive_completions();
+        let labels: Vec<&str> = items.iter().map(|item| item.label.as_str()).collect();
+
+        assert!(labels.contains(&"v-scope"));
+        assert!(labels.contains(&"v-effect"));
+        assert!(labels.contains(&"@vue:mounted"));
+        assert!(labels.contains(&"@vue:unmounted"));
+    }
+
+    #[test]
     fn test_composition_api_completions() {
         let items = script::composition_api_completions();
         assert!(!items.is_empty());
@@ -218,6 +229,32 @@ const message = ref('hello')
         let labels = completion_labels(CompletionService::complete(&ctx).unwrap());
 
         assert!(!has_label(&labels, "message"));
+        assert!(has_label(&labels, "v-if"));
+    }
+
+    #[test]
+    fn test_standalone_html_completion_includes_petite_vue_directives() {
+        let dir = tempfile::tempdir().unwrap();
+        let source_path = dir.path().join("index.html");
+        let source = r#"<script src="https://unpkg.com/petite-vue" defer init></script>
+<div v-scope="{ count: 0 }" >{{ count }}</div>
+"#;
+        fs::write(&source_path, source).unwrap();
+
+        let uri = Url::from_file_path(&source_path).unwrap();
+        let state = ServerState::new();
+        state
+            .documents
+            .open(uri.clone(), source.to_string(), 1, "html".to_string());
+        state.update_virtual_docs(&uri, source);
+
+        let offset = source.find("<div ").unwrap() + "<div ".len();
+        let ctx = IdeContext::new(&state, &uri, offset).unwrap();
+        let labels = completion_labels(CompletionService::complete(&ctx).unwrap());
+
+        assert!(has_label(&labels, "v-scope"));
+        assert!(has_label(&labels, "v-effect"));
+        assert!(has_label(&labels, "@vue:mounted"));
         assert!(has_label(&labels, "v-if"));
     }
 

--- a/crates/vize_maestro/src/ide/completion/service.rs
+++ b/crates/vize_maestro/src/ide/completion/service.rs
@@ -175,7 +175,7 @@ impl super::CompletionService {
             if !corsa_items.is_empty() {
                 let mut items = corsa_items;
                 items.extend(match block_type {
-                    BlockType::Template => template::directive_completions(),
+                    BlockType::Template => template::contextual_directive_completions(ctx),
                     BlockType::Script => script::composition_api_completions(),
                     BlockType::ScriptSetup => {
                         let mut v = script::composition_api_completions();

--- a/crates/vize_maestro/src/ide/completion/template.rs
+++ b/crates/vize_maestro/src/ide/completion/template.rs
@@ -30,7 +30,7 @@ pub(crate) fn complete_template(ctx: &IdeContext) -> Vec<CompletionItem> {
     let mut items_vec = Vec::new();
 
     // Add Vue directives
-    items_vec.extend(directive_completions());
+    items_vec.extend(contextual_directive_completions(ctx));
 
     // Add built-in components
     items_vec.extend(builtin_component_completions());
@@ -225,6 +225,71 @@ pub(crate) fn directive_completions() -> Vec<CompletionItem> {
         items::directive_item(":", "Bind shorthand", ":$1=\"$2\""),
         items::directive_item("#", "Slot shorthand", "#$1"),
     ]
+}
+
+/// Vue directive completions, extended with opt-in document-specific directives.
+pub(crate) fn contextual_directive_completions(ctx: &IdeContext) -> Vec<CompletionItem> {
+    let mut completions = directive_completions();
+    if crate::utils::is_standalone_html_path(ctx.uri.path())
+        && crate::utils::is_petite_vue_document(&ctx.content)
+    {
+        completions.extend(petite_vue_directive_completions());
+    }
+    completions
+}
+
+/// petite-vue directive and lifecycle event completions.
+pub(crate) fn petite_vue_directive_completions() -> Vec<CompletionItem> {
+    vec![
+        petite_vue_item(
+            "v-scope",
+            "petite-vue scope root",
+            "v-scope=\"{ $1 }\"",
+            "Marks an HTML region controlled by petite-vue.",
+        ),
+        petite_vue_item(
+            "v-effect",
+            "Reactive inline effect",
+            "v-effect=\"$1\"",
+            "Runs reactive inline statements when referenced state changes.",
+        ),
+        petite_vue_item(
+            "@vue:mounted",
+            "petite-vue mounted event",
+            "@vue:mounted=\"$1\"",
+            "Listens for the petite-vue mounted lifecycle event.",
+        ),
+        petite_vue_item(
+            "@vue:unmounted",
+            "petite-vue unmounted event",
+            "@vue:unmounted=\"$1\"",
+            "Listens for the petite-vue unmounted lifecycle event.",
+        ),
+    ]
+}
+
+#[allow(clippy::disallowed_macros)]
+fn petite_vue_item(
+    label: &str,
+    detail: &str,
+    snippet: &str,
+    documentation: &str,
+) -> CompletionItem {
+    CompletionItem {
+        label: label.to_string(),
+        kind: Some(CompletionItemKind::KEYWORD),
+        detail: Some(detail.to_string()),
+        insert_text: Some(snippet.to_string()),
+        insert_text_format: Some(InsertTextFormat::SNIPPET),
+        documentation: Some(Documentation::MarkupContent(MarkupContent {
+            kind: MarkupKind::Markdown,
+            value: format!(
+                "**{}**\n\n{}\n\n[petite-vue](https://github.com/vuejs/petite-vue)",
+                label, documentation
+            ),
+        })),
+        ..Default::default()
+    }
 }
 
 /// Vize directive completions for use inside HTML comments.

--- a/crates/vize_maestro/src/ide/definition.rs
+++ b/crates/vize_maestro/src/ide/definition.rs
@@ -455,6 +455,68 @@ const secondaryLabel = ref('secondary')
     }
 
     #[test]
+    fn test_definition_resolves_standalone_html_v_scope_property() {
+        let dir = tempfile::tempdir().unwrap();
+        let source_path = dir.path().join("index.html");
+        let source = r#"<script src="https://unpkg.com/petite-vue" defer init></script>
+<div v-scope="{ count: 0, inc() { count++ } }">
+  {{ count }}
+  <button @click="inc">inc</button>
+</div>
+"#;
+        fs::write(&source_path, source).unwrap();
+
+        let uri = Url::from_file_path(&source_path).unwrap();
+        let state = ServerState::new();
+        state
+            .documents
+            .open(uri.clone(), source.to_string(), 1, "html".to_string());
+        state.update_virtual_docs(&uri, source);
+
+        let offset = source.rfind("count").unwrap() + "count".len();
+        let ctx = IdeContext::new(&state, &uri, offset).unwrap();
+        let location = scalar_location(DefinitionService::definition(&ctx).unwrap());
+        let expected_binding_offset = source.find("count: 0").unwrap();
+        let (line, character) = crate::ide::offset_to_position(source, expected_binding_offset);
+
+        assert_eq!(location.uri, uri);
+        assert_eq!(location.range.start.line, line);
+        assert_eq!(location.range.start.character, character);
+    }
+
+    #[test]
+    fn test_definition_resolves_standalone_html_create_app_property() {
+        let dir = tempfile::tempdir().unwrap();
+        let source_path = dir.path().join("index.html");
+        let source = r#"<script src="https://unpkg.com/petite-vue"></script>
+<script>
+PetiteVue.createApp({
+  count: 0
+}).mount()
+</script>
+<div v-scope>{{ count }}</div>
+"#;
+        fs::write(&source_path, source).unwrap();
+
+        let uri = Url::from_file_path(&source_path).unwrap();
+        let state = ServerState::new();
+        state
+            .documents
+            .open(uri.clone(), source.to_string(), 1, "html".to_string());
+        state.update_virtual_docs(&uri, source);
+
+        let offset = source.rfind("count").unwrap() + "count".len();
+        let ctx = IdeContext::new(&state, &uri, offset).unwrap();
+        let location = scalar_location(DefinitionService::definition(&ctx).unwrap());
+        let expected_binding_offset = source.find("count: 0").unwrap();
+        let (line, character) = crate::ide::offset_to_position(source, expected_binding_offset);
+
+        assert_eq!(location.uri, uri);
+        assert_eq!(location.range.start.line, line);
+        assert_eq!(location.range.start.character, character);
+    }
+
+    #[test]
     fn test_definition_in_style_resolves_inside_v_bind_argument() {
         let dir = tempfile::tempdir().unwrap();
         let source_path = dir.path().join("Styled.vue");

--- a/crates/vize_maestro/src/ide/definition/template.rs
+++ b/crates/vize_maestro/src/ide/definition/template.rs
@@ -40,6 +40,12 @@ pub(crate) fn definition_in_template(ctx: &IdeContext) -> Option<GotoDefinitionR
         return Some(def);
     }
 
+    if crate::utils::is_standalone_html_path(ctx.uri.path())
+        && let Some(def) = find_standalone_html_scope_definition(ctx, &word)
+    {
+        return Some(def);
+    }
+
     // Parse SFC to get the actual script content (not virtual code)
     let options = vize_atelier_sfc::SfcParseOptions {
         filename: ctx.uri.path().to_string().into(),
@@ -96,6 +102,213 @@ pub(crate) fn definition_in_template(ctx: &IdeContext) -> Option<GotoDefinitionR
     }
 
     None
+}
+
+fn find_standalone_html_scope_definition(
+    ctx: &IdeContext<'_>,
+    word: &str,
+) -> Option<GotoDefinitionResponse> {
+    if !crate::utils::is_petite_vue_document(&ctx.content) {
+        return None;
+    }
+
+    let (cursor_start, _) =
+        crate::ide::token_span_at_offset(&ctx.content, ctx.offset, helpers::is_word_char)?;
+
+    for range in v_scope_value_ranges(&ctx.content)
+        .into_iter()
+        .chain(create_app_object_ranges(&ctx.content))
+    {
+        if let Some(offset) =
+            find_object_property_key_in_range(&ctx.content, range, word, cursor_start)
+        {
+            return Some(location_response(ctx, offset, word.len()));
+        }
+    }
+
+    None
+}
+
+fn v_scope_value_ranges(content: &str) -> Vec<(usize, usize)> {
+    let mut ranges = Vec::new();
+    let bytes = content.as_bytes();
+    let mut search_start = 0;
+
+    while let Some(relative) = content[search_start..].find("v-scope") {
+        let attr_start = search_start + relative;
+        let mut pos = attr_start + "v-scope".len();
+
+        if pos < bytes.len()
+            && (bytes[pos].is_ascii_alphanumeric() || bytes[pos] == b'-' || bytes[pos] == b'_')
+        {
+            search_start = pos;
+            continue;
+        }
+
+        while pos < bytes.len() && bytes[pos].is_ascii_whitespace() {
+            pos += 1;
+        }
+        if bytes.get(pos) != Some(&b'=') {
+            search_start = pos;
+            continue;
+        }
+        pos += 1;
+        while pos < bytes.len() && bytes[pos].is_ascii_whitespace() {
+            pos += 1;
+        }
+
+        let Some(&quote) = bytes.get(pos) else {
+            break;
+        };
+        if quote != b'"' && quote != b'\'' {
+            search_start = pos + 1;
+            continue;
+        }
+        let value_start = pos + 1;
+        let Some(relative_end) = content[value_start..].find(quote as char) else {
+            break;
+        };
+        let value_end = value_start + relative_end;
+        ranges.push((value_start, value_end));
+        search_start = value_end + 1;
+    }
+
+    ranges
+}
+
+fn create_app_object_ranges(content: &str) -> Vec<(usize, usize)> {
+    let mut ranges = Vec::new();
+    let bytes = content.as_bytes();
+    let mut search_start = 0;
+
+    while let Some(relative) = content[search_start..].find("createApp") {
+        let name_start = search_start + relative;
+        if name_start > 0 && helpers::is_word_char(bytes[name_start - 1]) {
+            search_start = name_start + "createApp".len();
+            continue;
+        }
+
+        let mut pos = name_start + "createApp".len();
+        if pos < bytes.len() && helpers::is_word_char(bytes[pos]) {
+            search_start = pos;
+            continue;
+        }
+
+        while pos < bytes.len() && bytes[pos].is_ascii_whitespace() {
+            pos += 1;
+        }
+        if bytes.get(pos) != Some(&b'(') {
+            search_start = pos;
+            continue;
+        }
+        pos += 1;
+        while pos < bytes.len() && bytes[pos].is_ascii_whitespace() {
+            pos += 1;
+        }
+        if bytes.get(pos) != Some(&b'{') {
+            search_start = pos;
+            continue;
+        }
+
+        if let Some(end) = find_matching_byte(content, pos, b'{', b'}') {
+            ranges.push((pos + 1, end));
+            search_start = end + 1;
+        } else {
+            break;
+        }
+    }
+
+    ranges
+}
+
+fn find_object_property_key_in_range(
+    content: &str,
+    range: (usize, usize),
+    word: &str,
+    cursor_start: usize,
+) -> Option<usize> {
+    let (start, end) = range;
+    let bytes = content.as_bytes();
+    let mut search_start = start;
+
+    while search_start < end {
+        let relative = content[search_start..end].find(word)?;
+        let key_start = search_start + relative;
+        let key_end = key_start + word.len();
+
+        if key_start != cursor_start
+            && is_identifier_boundary(bytes, key_start, key_end)
+            && is_property_key_tail(bytes, key_end, end)
+        {
+            return Some(key_start);
+        }
+
+        search_start = key_end;
+    }
+
+    None
+}
+
+fn is_identifier_boundary(bytes: &[u8], start: usize, end: usize) -> bool {
+    let before = start.checked_sub(1).and_then(|index| bytes.get(index));
+    let after = bytes.get(end);
+    !before.is_some_and(|byte| helpers::is_word_char(*byte))
+        && !after.is_some_and(|byte| helpers::is_word_char(*byte))
+}
+
+fn is_property_key_tail(bytes: &[u8], key_end: usize, range_end: usize) -> bool {
+    let mut pos = key_end;
+    while pos < range_end && bytes[pos].is_ascii_whitespace() {
+        pos += 1;
+    }
+
+    pos >= range_end || matches!(bytes[pos], b':' | b'(' | b',' | b'}')
+}
+
+fn find_matching_byte(content: &str, start: usize, open: u8, close: u8) -> Option<usize> {
+    let bytes = content.as_bytes();
+    let mut depth = 0usize;
+    let mut quote = None;
+    let mut pos = start;
+
+    while pos < bytes.len() {
+        let byte = bytes[pos];
+        if let Some(current_quote) = quote {
+            if byte == b'\\' {
+                pos += 2;
+                continue;
+            }
+            if byte == current_quote {
+                quote = None;
+            }
+        } else if byte == b'"' || byte == b'\'' || byte == b'`' {
+            quote = Some(byte);
+        } else if byte == open {
+            depth += 1;
+        } else if byte == close {
+            depth = depth.saturating_sub(1);
+            if depth == 0 {
+                return Some(pos);
+            }
+        }
+        pos += 1;
+    }
+
+    None
+}
+
+fn location_response(ctx: &IdeContext<'_>, offset: usize, len: usize) -> GotoDefinitionResponse {
+    let (line, character) = helpers::offset_to_position(&ctx.content, offset);
+    GotoDefinitionResponse::Scalar(Location {
+        uri: ctx.uri.clone(),
+        range: Range {
+            start: Position { line, character },
+            end: Position {
+                line,
+                character: character + len as u32,
+            },
+        },
+    })
 }
 
 /// Find the definition of a props property (e.g., props.title -> defineProps).

--- a/crates/vize_maestro/src/ide/diagnostics.rs
+++ b/crates/vize_maestro/src/ide/diagnostics.rs
@@ -15,6 +15,7 @@ use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, NumberOrString, Range
 
 use crate::ide::ecosystem;
 use crate::server::ServerState;
+use crate::utils::is_standalone_html_path;
 
 /// Diagnostic source identifiers.
 pub mod sources {
@@ -106,6 +107,24 @@ impl DiagnosticService {
             return diagnostics;
         }
 
+        if is_standalone_html_path(path) {
+            if features.lint {
+                let linter_config = state.get_linter_config();
+                let lint_diags = Self::collect_lint_diagnostics(
+                    uri,
+                    &content,
+                    features.ecosystem,
+                    &linter_config,
+                );
+                tracing::info!(
+                    "collect: standalone HTML patina lint diagnostics: {}",
+                    lint_diags.len()
+                );
+                diagnostics.extend(lint_diags);
+            }
+            return diagnostics;
+        }
+
         // Standard SFC processing
         // Collect parser diagnostics when any diagnostic pipeline is enabled.
         let sfc_diags = Self::collect_sfc_diagnostics(uri, &content);
@@ -139,7 +158,9 @@ impl DiagnosticService {
 
         if features.lint {
             // Collect linter diagnostics (vize_patina)
-            let lint_diags = Self::collect_lint_diagnostics(uri, &content, features.ecosystem);
+            let linter_config = state.get_linter_config();
+            let lint_diags =
+                Self::collect_lint_diagnostics(uri, &content, features.ecosystem, &linter_config);
             tracing::info!("collect: patina lint diagnostics: {}", lint_diags.len());
             diagnostics.extend(lint_diags);
         } else {
@@ -187,6 +208,10 @@ impl DiagnosticService {
         tracing::info!("sync diagnostics count: {}", diagnostics.len());
         if has_blocking_parser_error(&diagnostics) {
             tracing::info!("collect_async: Corsa diagnostics skipped after parser error");
+            return diagnostics;
+        }
+        if is_standalone_html_path(uri.path()) {
+            tracing::info!("collect_async: Corsa diagnostics skipped for standalone HTML");
             return diagnostics;
         }
 
@@ -475,6 +500,60 @@ mod tests {
 
         assert_eq!(diagnostic.range.start.line, 1);
         assert!(diagnostic.message.contains("<script> should come before"));
+    }
+
+    #[test]
+    fn collect_lints_standalone_html_with_configured_preset() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("vize.config.json"),
+            r#"{
+                "lsp": { "lint": true },
+                "linter": { "preset": "opinionated" }
+            }"#,
+        )
+        .unwrap();
+
+        let state = ServerState::new();
+        state.load_lsp_config(dir.path());
+
+        let source_path = dir.path().join("index.html");
+        let uri = Url::from_file_path(&source_path).unwrap();
+        let source = r##"<!doctype html>
+<html>
+<head>
+  <script src="https://unpkg.com/vue@3/dist/vue.global.js"></script>
+</head>
+<body>
+  <div id="app">{{ count }}</div>
+  <script>
+Vue.createApp({
+  data() {
+    return { count: 0 }
+  }
+}).mount("#app")
+  </script>
+</body>
+</html>
+"##;
+        state
+            .documents
+            .open(uri.clone(), source.to_string(), 1, "html".to_string());
+        state.update_virtual_docs(&uri, source);
+
+        let diagnostics = DiagnosticService::collect(&state, &uri);
+
+        assert!(state.get_virtual_docs(&uri).is_none());
+        assert!(
+            diagnostics
+                .iter()
+                .all(|diagnostic| diagnostic.source.as_deref() != Some(sources::SFC_PARSER))
+        );
+        assert!(diagnostics.iter().any(|diagnostic| {
+            diagnostic.source.as_deref() == Some(sources::LINTER)
+                && diagnostic.code
+                    == Some(NumberOrString::String("script/no-options-api".to_string()))
+        }));
     }
 
     #[test]

--- a/crates/vize_maestro/src/ide/diagnostics.rs
+++ b/crates/vize_maestro/src/ide/diagnostics.rs
@@ -503,13 +503,17 @@ mod tests {
     }
 
     #[test]
-    fn collect_lints_standalone_html_with_configured_preset() {
+    fn collect_lints_standalone_html_with_configured_rule() {
         let dir = tempfile::tempdir().unwrap();
         std::fs::write(
             dir.path().join("vize.config.json"),
             r#"{
                 "lsp": { "lint": true },
-                "linter": { "preset": "opinionated" }
+                "linter": {
+                    "rules": {
+                        "script/no-options-api": "error"
+                    }
+                }
             }"#,
         )
         .unwrap();
@@ -543,7 +547,7 @@ Vue.createApp({
 
         let diagnostics = DiagnosticService::collect(&state, &uri);
 
-        assert!(state.get_virtual_docs(&uri).is_none());
+        assert!(state.get_virtual_docs(&uri).is_some());
         assert!(
             diagnostics
                 .iter()

--- a/crates/vize_maestro/src/ide/diagnostics/collectors.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/collectors.rs
@@ -364,6 +364,7 @@ impl DiagnosticService {
         } else {
             vize_patina::Linter::with_preset(preset)
         }
+        .with_additional_rules(linter_config.enabled_rules())
         .with_disabled_rules(linter_config.disabled_rules());
         let result = if is_standalone_html {
             linter.lint_standalone_html(content, uri.path())

--- a/crates/vize_maestro/src/ide/diagnostics/collectors.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/collectors.rs
@@ -12,7 +12,8 @@ use tower_lsp::lsp_types::{
 use oxc_allocator::Allocator as OxcAllocator;
 use oxc_parser::Parser as OxcParser;
 use oxc_span::SourceType;
-use vize_patina::{HelpRenderTarget, render_help};
+use vize_carton::config::LinterConfig;
+use vize_patina::{HelpRenderTarget, LintPreset, render_help};
 
 use super::{DiagnosticService, offset_to_line_col, sources};
 use vize_carton::append;
@@ -336,23 +337,39 @@ impl DiagnosticService {
         uri: &Url,
         content: &str,
         ecosystem_enabled: bool,
+        linter_config: &LinterConfig,
     ) -> Vec<Diagnostic> {
+        if !linter_config.enabled {
+            return vec![];
+        }
+
         let options = vize_atelier_sfc::SfcParseOptions {
             filename: uri.path().to_string().into(),
             ..Default::default()
         };
 
-        if vize_atelier_sfc::parse_sfc(content, options).is_err() {
+        let is_standalone_html = crate::utils::is_standalone_html_path(uri.path());
+        if !is_standalone_html && vize_atelier_sfc::parse_sfc(content, options).is_err() {
             return vec![];
         }
 
         // Create linter and lint the full SFC so editor diagnostics match the CLI.
-        let linter = if ecosystem_enabled {
+        let preset = linter_config
+            .preset
+            .as_deref()
+            .and_then(LintPreset::parse)
+            .unwrap_or_default();
+        let linter = if ecosystem_enabled && linter_config.preset.is_none() {
             vize_patina::Linter::with_ecosystem()
         } else {
-            vize_patina::Linter::new()
+            vize_patina::Linter::with_preset(preset)
+        }
+        .with_disabled_rules(linter_config.disabled_rules());
+        let result = if is_standalone_html {
+            linter.lint_standalone_html(content, uri.path())
+        } else {
+            linter.lint_sfc(content, uri.path())
         };
-        let result = linter.lint_sfc(content, uri.path());
 
         // Convert lint diagnostics to LSP diagnostics
         result

--- a/crates/vize_maestro/src/ide/hover/corsa.rs
+++ b/crates/vize_maestro/src/ide/hover/corsa.rs
@@ -26,6 +26,14 @@ impl HoverService {
         let virtual_docs = ctx.virtual_docs.as_ref()?;
         let template = virtual_docs.template.as_ref()?;
 
+        if crate::utils::is_standalone_html_path(ctx.uri.path()) {
+            return template
+                .source_map
+                .to_generated(sfc_offset as u32)
+                .map(|o| o as usize)
+                .or(Some(sfc_offset));
+        }
+
         // Get template block start offset in SFC
         let options = vize_atelier_sfc::SfcParseOptions {
             filename: ctx.uri.path().to_string().into(),

--- a/crates/vize_maestro/src/server/state.rs
+++ b/crates/vize_maestro/src/server/state.rs
@@ -10,7 +10,7 @@ use parking_lot::RwLock;
 use serde::Deserialize;
 use tokio::sync::OnceCell;
 use tower_lsp::lsp_types::Url;
-use vize_carton::config::{LanguageServerConfig, TypeCheckerConfig};
+use vize_carton::config::{LanguageServerConfig, LinterConfig, TypeCheckerConfig};
 
 #[cfg(feature = "glyph")]
 use vize_carton::config::FormatterConfig;
@@ -25,6 +25,7 @@ use vize_canon::{
 };
 
 use crate::document::DocumentStore;
+use crate::utils::is_standalone_html_path;
 use crate::virtual_code::{VirtualCodeGenerator, VirtualDocuments};
 
 #[derive(Debug, Default, Deserialize)]
@@ -288,6 +289,8 @@ pub struct ServerState {
     lsp_typecheck_enabled: AtomicBool,
     /// Type checker options shared by LSP diagnostics.
     type_checker_config: RwLock<TypeCheckerConfig>,
+    /// Linter options shared by LSP diagnostics.
+    linter_config: RwLock<LinterConfig>,
     /// Formatting options (loaded from vize.config.json)
     #[cfg(feature = "glyph")]
     format_options: RwLock<vize_glyph::FormatOptions>,
@@ -324,6 +327,7 @@ impl ServerState {
             lsp_features: RwLock::new(LspFeatureConfig::default()),
             lsp_typecheck_enabled: AtomicBool::new(false),
             type_checker_config: RwLock::new(TypeCheckerConfig::default()),
+            linter_config: RwLock::new(LinterConfig::default()),
             #[cfg(feature = "glyph")]
             format_options: RwLock::new(vize_glyph::FormatOptions::default()),
             #[cfg(feature = "native")]
@@ -388,9 +392,20 @@ impl ServerState {
         self.type_checker_config.read().clone()
     }
 
+    /// Get a clone of the current linter config.
+    #[inline]
+    pub fn get_linter_config(&self) -> LinterConfig {
+        self.linter_config.read().clone()
+    }
+
     fn apply_type_checker_config(&self, config: TypeCheckerConfig, source: &str) {
         *self.type_checker_config.write() = config;
         tracing::info!("Loaded type checker config from {}", source);
+    }
+
+    fn apply_linter_config(&self, config: LinterConfig, source: &str) {
+        *self.linter_config.write() = config;
+        tracing::info!("Loaded linter config from {}", source);
     }
 
     fn apply_lsp_config(&self, config: LspConfigSection, source: &str) {
@@ -403,7 +418,8 @@ impl ServerState {
 
     /// Load all workspace-scoped options from `vize.config.pkl` (preferred) or JSON.
     pub fn load_workspace_config(&self, dir: &Path) {
-        let loaded = vize_carton::config::load_config_with_source(Some(dir));
+        let (loaded, linter_config) =
+            vize_carton::config::load_config_and_linter_with_source(Some(dir));
         if let Some(source_path) = loaded.source_path {
             let source = source_path.display().to_string();
             let config = loaded.config;
@@ -412,6 +428,7 @@ impl ServerState {
                 *self.format_options.write() = format_options_from_config(&config.formatter);
                 tracing::info!("Loaded format config from {}", source);
             }
+            self.apply_linter_config(linter_config, &source);
             self.apply_type_checker_config(config.type_checker, &source);
             self.apply_lsp_config(config.language_server.into(), &source);
         }
@@ -419,9 +436,11 @@ impl ServerState {
 
     /// Load LSP options from `vize.config.pkl` (preferred) or `vize.config.json`.
     pub fn load_lsp_config(&self, dir: &Path) {
-        let loaded = vize_carton::config::load_config_with_source(Some(dir));
+        let (loaded, linter_config) =
+            vize_carton::config::load_config_and_linter_with_source(Some(dir));
         if let Some(source_path) = loaded.source_path {
             let source = source_path.display().to_string();
+            self.apply_linter_config(linter_config, &source);
             self.apply_type_checker_config(loaded.config.type_checker, &source);
             self.apply_lsp_config(loaded.config.language_server.into(), &source);
         }
@@ -595,6 +614,11 @@ impl ServerState {
     pub fn update_virtual_docs(&self, uri: &Url, content: &str) {
         if uri.path().ends_with(".art.vue") {
             self.update_art_virtual_docs(uri, content);
+            return;
+        }
+
+        if is_standalone_html_path(uri.path()) {
+            self.remove_virtual_docs(uri);
             return;
         }
 
@@ -933,6 +957,29 @@ mod tests {
         assert!(!config.check_emits);
         assert_eq!(config.tsconfig.as_deref(), Some("tsconfig.app.json"));
         assert_eq!(config.runtime_path(), Some("./node_modules/.bin/corsa"));
+    }
+
+    #[test]
+    fn load_lsp_config_updates_linter_config() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("vize.config.json"),
+            r#"{
+                "linter": {
+                    "preset": "opinionated",
+                    "rules": {
+                        "vue/prop-name-casing": "off"
+                    }
+                }
+            }"#,
+        )
+        .unwrap();
+
+        let state = ServerState::new();
+        state.load_lsp_config(dir.path());
+        let config = state.get_linter_config();
+        assert_eq!(config.preset.as_deref(), Some("opinionated"));
+        assert_eq!(config.disabled_rules(), ["vue/prop-name-casing"]);
     }
 
     #[test]

--- a/crates/vize_maestro/src/server/state.rs
+++ b/crates/vize_maestro/src/server/state.rs
@@ -618,7 +618,7 @@ impl ServerState {
         }
 
         if is_standalone_html_path(uri.path()) {
-            self.remove_virtual_docs(uri);
+            self.update_standalone_html_virtual_docs(uri, content);
             return;
         }
 
@@ -635,6 +635,24 @@ impl ServerState {
         let base_uri = uri.path();
         let virtual_docs = self.virtual_gen.write().generate(&descriptor, base_uri);
         self.virtual_docs_cache.insert(uri.clone(), virtual_docs);
+    }
+
+    /// Generate and cache virtual documents for standalone HTML files.
+    fn update_standalone_html_virtual_docs(&self, uri: &Url, content: &str) {
+        use crate::virtual_code::{TemplateCodeGenerator, VirtualDocuments};
+
+        let allocator = vize_carton::Bump::new();
+        let (ast, _errors) = vize_armature::parse(&allocator, content);
+        let base_uri = uri.path();
+
+        let mut template_gen = TemplateCodeGenerator::new();
+        template_gen.set_block_offset(0);
+        let mut template_doc = template_gen.generate(&ast, content);
+        template_doc.uri = vize_carton::cstr!("{base_uri}.__template.ts").to_string();
+
+        let mut docs = VirtualDocuments::new();
+        docs.template = Some(template_doc);
+        self.virtual_docs_cache.insert(uri.clone(), docs);
     }
 
     /// Generate and cache virtual documents for an art file (*.art.vue).
@@ -1061,6 +1079,20 @@ const secondaryLabel = ref('secondary')
             .source_map
             .to_generated(info.relative_offset as u32);
         assert!(generated_offset.is_some());
+    }
+
+    #[test]
+    fn update_virtual_docs_generates_standalone_html_template_doc() {
+        let state = ServerState::new();
+        let uri = Url::parse("file:///index.html").unwrap();
+        let source = r#"<div v-scope="{ count: 0 }">{{ count }}</div>"#;
+
+        state.update_virtual_docs(&uri, source);
+
+        let virtual_docs = state.get_virtual_docs(&uri).unwrap();
+        let template = virtual_docs.template.as_ref().unwrap();
+        assert!(template.uri.ends_with("index.html.__template.ts"));
+        assert!(template.content.contains("count"));
     }
 
     #[test]

--- a/crates/vize_maestro/src/utils.rs
+++ b/crates/vize_maestro/src/utils.rs
@@ -6,3 +6,10 @@ pub use position::{
     internal_to_lsp_position, line_range, make_range, offset_to_position, offset_to_position_str,
     position_to_offset, position_to_offset_str, source_location_to_range,
 };
+
+/// Returns true for standalone HTML files that should be linted outside the SFC pipeline.
+#[inline]
+pub fn is_standalone_html_path(path: &str) -> bool {
+    let path = path.to_ascii_lowercase();
+    path.ends_with(".html") || path.ends_with(".htm")
+}

--- a/crates/vize_maestro/src/utils.rs
+++ b/crates/vize_maestro/src/utils.rs
@@ -13,3 +13,12 @@ pub fn is_standalone_html_path(path: &str) -> bool {
     let path = path.to_ascii_lowercase();
     path.ends_with(".html") || path.ends_with(".htm")
 }
+
+/// Returns true when a standalone HTML document appears to use petite-vue.
+#[inline]
+pub fn is_petite_vue_document(content: &str) -> bool {
+    content.contains("petite-vue")
+        || content.contains("PetiteVue")
+        || content.contains("v-scope")
+        || content.contains("v-effect")
+}

--- a/crates/vize_patina/src/linter/config.rs
+++ b/crates/vize_patina/src/linter/config.rs
@@ -185,6 +185,34 @@ impl Linter {
         self
     }
 
+    /// Enable additional opt-in rules while preserving the active preset's rules.
+    #[inline]
+    pub fn with_additional_rules(mut self, rules: Vec<String>) -> Self {
+        if rules.is_empty() {
+            return self;
+        }
+
+        let mut enabled_rules = self.enabled_rules.take().unwrap_or_else(|| {
+            let mut names = self
+                .registry
+                .rule_names()
+                .iter()
+                .map(|name| String::from(*name))
+                .collect::<FxHashSet<_>>();
+            names.extend(self.script_rules.iter().map(|name| String::from(*name)));
+            names
+        });
+
+        if matches!(self.preset, Some(LintPreset::Incremental)) {
+            self.registry = RuleRegistry::with_preset(LintPreset::Opinionated);
+        }
+        self.registry.register_opt_in_rules();
+        self.script_rules = super::script_rules::all_builtin_script_rule_names();
+        enabled_rules.extend(rules);
+        self.enabled_rules = Some(enabled_rules);
+        self
+    }
+
     /// Disable selected rules while preserving the active preset.
     #[inline]
     pub fn with_disabled_rules(mut self, rules: Vec<String>) -> Self {

--- a/crates/vize_patina/src/linter/engine.rs
+++ b/crates/vize_patina/src/linter/engine.rs
@@ -446,6 +446,25 @@ impl Linter {
 
         Self::merge_lint_results(result, sfc_result)
     }
+
+    /// Lint a standalone HTML document that may use Vue from a CDN.
+    #[inline]
+    pub fn lint_standalone_html(&self, source: &str, filename: &str) -> LintResult {
+        let mut result = self.lint_template(source, filename);
+
+        if super::script_rules::has_active_builtin_script_rules(self) {
+            super::script_rules::append_builtin_script_diagnostics_from_html(
+                self,
+                source,
+                &mut result,
+            );
+            result
+                .diagnostics
+                .sort_unstable_by_key(|diagnostic| (diagnostic.start, diagnostic.end));
+        }
+
+        result
+    }
 }
 
 /// Ultra-fast template extraction using memchr for SIMD-accelerated search.

--- a/crates/vize_patina/src/linter/script_rules.rs
+++ b/crates/vize_patina/src/linter/script_rules.rs
@@ -209,6 +209,73 @@ pub(crate) fn append_builtin_script_diagnostics<'a>(
     );
 }
 
+pub(crate) fn append_builtin_script_diagnostics_from_html(
+    linter: &Linter,
+    source: &str,
+    result: &mut LintResult,
+) {
+    if linter.script_rules.is_empty() {
+        return;
+    }
+
+    for (script, offset) in extract_inline_scripts(source) {
+        append_builtin_script_rule_for_source(
+            linter,
+            script,
+            offset,
+            result,
+            RULE_NO_OPTIONS_API,
+            "patina.script_rule.no_options_api",
+            &NoOptionsApi,
+        );
+        append_builtin_script_rule_for_source(
+            linter,
+            script,
+            offset,
+            result,
+            RULE_NO_GET_CURRENT_INSTANCE,
+            "patina.script_rule.no_get_current_instance",
+            &NoGetCurrentInstance,
+        );
+        append_builtin_script_rule_for_source(
+            linter,
+            script,
+            offset,
+            result,
+            RULE_NO_NEXT_TICK,
+            "patina.script_rule.no_next_tick",
+            &NoNextTick,
+        );
+        append_builtin_script_rule_for_source(
+            linter,
+            script,
+            offset,
+            result,
+            RULE_PINIA_PREFER_STORE_TO_REFS,
+            "patina.script_rule.pinia_prefer_store_to_refs",
+            &PiniaPreferStoreToRefs,
+        );
+        append_builtin_script_rule_for_source(
+            linter,
+            script,
+            offset,
+            result,
+            RULE_VUE_ROUTER_PREFER_NAMED_PUSH,
+            "patina.script_rule.vue_router_prefer_named_push",
+            &VueRouterPreferNamedPush,
+        );
+        append_builtin_script_rule_for_source(
+            linter,
+            script,
+            offset,
+            result,
+            RULE_VUE_TEST_UTILS_NO_HTML_SNAPSHOT,
+            "patina.script_rule.vue_test_utils_no_html_snapshot",
+            &VueTestUtilsNoHtmlSnapshot,
+        );
+    }
+}
+
 fn merge_script_result(
     result: &mut LintResult,
     script_result: crate::rules::script::ScriptLintResult,
@@ -231,25 +298,45 @@ fn append_builtin_script_rule<'a, R: ScriptRule>(
     }
 
     if let Some(script) = descriptor.script.as_ref() {
-        let mut lint = crate::rules::script::ScriptLintResult::default();
-        profile!(
+        append_builtin_script_rule_for_source(
+            linter,
+            script.content.as_ref(),
+            script.loc.start,
+            result,
+            rule_name,
             profile_name,
-            rule.check(script.content.as_ref(), script.loc.start, &mut lint)
+            &rule,
         );
-        merge_script_result(result, lint);
     }
     if let Some(script_setup) = descriptor.script_setup.as_ref() {
-        let mut lint = crate::rules::script::ScriptLintResult::default();
-        profile!(
+        append_builtin_script_rule_for_source(
+            linter,
+            script_setup.content.as_ref(),
+            script_setup.loc.start,
+            result,
+            rule_name,
             profile_name,
-            rule.check(
-                script_setup.content.as_ref(),
-                script_setup.loc.start,
-                &mut lint,
-            )
+            &rule,
         );
-        merge_script_result(result, lint);
     }
+}
+
+fn append_builtin_script_rule_for_source<R: ScriptRule>(
+    linter: &Linter,
+    source: &str,
+    offset: usize,
+    result: &mut LintResult,
+    rule_name: &str,
+    profile_name: &'static str,
+    rule: &R,
+) {
+    if !linter.is_rule_enabled(rule_name) || !linter.script_rules.contains(&rule_name) {
+        return;
+    }
+
+    let mut lint = crate::rules::script::ScriptLintResult::default();
+    profile!(profile_name, rule.check(source, offset, &mut lint));
+    merge_script_result(result, lint);
 }
 
 #[inline]
@@ -257,5 +344,97 @@ fn sfc_parse_options(filename: &str) -> SfcParseOptions {
     SfcParseOptions {
         filename: filename.into(),
         ..Default::default()
+    }
+}
+
+fn extract_inline_scripts(source: &str) -> Vec<(&str, usize)> {
+    let mut scripts = Vec::new();
+    let mut cursor = 0;
+
+    while let Some(open_start) = find_script_open(source, cursor) {
+        let Some(open_end) = find_tag_end(source, open_start) else {
+            break;
+        };
+
+        let content_start = open_end + 1;
+        let Some(close_start) = find_ascii_case_insensitive(source, "</script", content_start)
+        else {
+            break;
+        };
+
+        let content = &source[content_start..close_start];
+        if !content.trim().is_empty() {
+            scripts.push((content, content_start));
+        }
+
+        cursor = find_tag_end(source, close_start).map_or(close_start + 9, |end| end + 1);
+    }
+
+    scripts
+}
+
+fn find_script_open(source: &str, from: usize) -> Option<usize> {
+    let mut cursor = from;
+    while let Some(index) = find_ascii_case_insensitive(source, "<script", cursor) {
+        let boundary = source.as_bytes().get(index + 7).copied();
+        if matches!(
+            boundary,
+            None | Some(b'>' | b'/' | b' ' | b'\n' | b'\r' | b'\t' | b'\x0c')
+        ) {
+            return Some(index);
+        }
+        cursor = index + 7;
+    }
+    None
+}
+
+fn find_tag_end(source: &str, from: usize) -> Option<usize> {
+    let mut quote = None;
+    for (relative, byte) in source.as_bytes()[from..].iter().copied().enumerate() {
+        match (quote, byte) {
+            (Some(current), value) if value == current => quote = None,
+            (None, b'"' | b'\'') => quote = Some(byte),
+            (None, b'>') => return Some(from + relative),
+            _ => {}
+        }
+    }
+    None
+}
+
+fn find_ascii_case_insensitive(source: &str, needle: &str, from: usize) -> Option<usize> {
+    let haystack = source.as_bytes();
+    let needle = needle.as_bytes();
+    if needle.is_empty() || from >= haystack.len() {
+        return None;
+    }
+
+    haystack[from..]
+        .windows(needle.len())
+        .position(|window| window.eq_ignore_ascii_case(needle))
+        .map(|index| from + index)
+}
+
+#[cfg(test)]
+mod standalone_html_tests {
+    use super::extract_inline_scripts;
+
+    #[test]
+    fn extracts_inline_scripts_from_standalone_html() {
+        let source = r##"<!doctype html>
+<html>
+<head>
+  <script src="https://unpkg.com/vue@3/dist/vue.global.js"></script>
+</head>
+<body>
+  <script>
+Vue.createApp({ data() { return { count: 0 } } }).mount("#app")
+  </script>
+</body>
+</html>"##;
+
+        let scripts = extract_inline_scripts(source);
+        assert_eq!(scripts.len(), 1);
+        assert!(scripts[0].0.contains("Vue.createApp"));
+        assert_eq!(&source[scripts[0].1..scripts[0].1 + 3], "\nVu");
     }
 }

--- a/crates/vize_patina/src/linter/tests/basic.rs
+++ b/crates/vize_patina/src/linter/tests/basic.rs
@@ -253,3 +253,34 @@ export default {
     assert_eq!(result.error_count, 1);
     assert_eq!(result.diagnostics[0].rule_name, "script/no-options-api");
 }
+
+#[test]
+fn test_lint_standalone_html_reports_cdn_options_api() {
+    let linter = Linter::with_preset(LintPreset::Opinionated)
+        .with_enabled_rules(Some(vec!["script/no-options-api".into()]));
+    let source = r##"<!doctype html>
+<html>
+<head>
+  <script src="https://unpkg.com/vue@3/dist/vue.global.js"></script>
+</head>
+<body>
+  <div id="app">{{ count }}</div>
+  <script>
+Vue.createApp({
+  data() {
+    return { count: 0 }
+  }
+}).mount("#app")
+  </script>
+</body>
+</html>
+"##;
+
+    let result = linter.lint_standalone_html(source, "index.html");
+    assert_eq!(result.error_count, 1);
+    assert_eq!(result.diagnostics[0].rule_name, "script/no-options-api");
+    assert!(
+        result.diagnostics[0].start > source.find("Vue.createApp").unwrap() as u32,
+        "diagnostic should use standalone HTML source offsets"
+    );
+}

--- a/crates/vize_patina/src/linter/tests/basic.rs
+++ b/crates/vize_patina/src/linter/tests/basic.rs
@@ -284,3 +284,34 @@ Vue.createApp({
         "diagnostic should use standalone HTML source offsets"
     );
 }
+
+#[test]
+fn test_lint_standalone_html_allows_petite_vue_create_app_scope() {
+    let linter = Linter::with_preset(LintPreset::Opinionated)
+        .with_enabled_rules(Some(vec!["script/no-options-api".into()]));
+    let source = r##"<!doctype html>
+<html>
+<body>
+  <div v-scope>{{ count }}</div>
+  <script src="https://unpkg.com/petite-vue" defer init></script>
+  <script>
+PetiteVue.createApp({
+  count: 0,
+  increment() {
+    this.count++
+  }
+}).mount()
+  </script>
+</body>
+</html>
+"##;
+
+    let result = linter.lint_standalone_html(source, "index.html");
+    assert_eq!(result.error_count, 0);
+    assert!(
+        result
+            .diagnostics
+            .iter()
+            .all(|diagnostic| diagnostic.rule_name != "script/no-options-api")
+    );
+}

--- a/crates/vize_patina/src/rules/script/no_options_api.rs
+++ b/crates/vize_patina/src/rules/script/no_options_api.rs
@@ -144,6 +144,13 @@ fn find_component_options(source: &str) -> Option<ComponentOptionsMatch> {
         return Some(build_component_options_match(options.object));
     }
 
+    for statement in parsed.program.body.iter() {
+        let Some(options) = extract_create_app_options_from_statement(statement, &bindings) else {
+            continue;
+        };
+        return Some(build_component_options_match(options.object));
+    }
+
     None
 }
 
@@ -214,6 +221,83 @@ fn extract_component_options_from_call<'a>(
 
     let first_arg = call.arguments.first()?;
     extract_component_options_from_argument(first_arg, bindings)
+}
+
+fn extract_create_app_options_from_statement<'a>(
+    statement: &'a Statement<'a>,
+    bindings: &FxHashMap<&'a str, ComponentOptionsRef<'a>>,
+) -> Option<ComponentOptionsRef<'a>> {
+    match statement {
+        Statement::ExpressionStatement(statement) => {
+            extract_create_app_options_from_expression(&statement.expression, bindings)
+        }
+        Statement::VariableDeclaration(declaration) => {
+            for declarator in &declaration.declarations {
+                let Some(init) = declarator.init.as_ref() else {
+                    continue;
+                };
+                if let Some(options) = extract_create_app_options_from_expression(init, bindings) {
+                    return Some(options);
+                }
+            }
+            None
+        }
+        _ => None,
+    }
+}
+
+fn extract_create_app_options_from_expression<'a>(
+    expression: &'a Expression<'a>,
+    bindings: &FxHashMap<&'a str, ComponentOptionsRef<'a>>,
+) -> Option<ComponentOptionsRef<'a>> {
+    match expression {
+        Expression::CallExpression(call) => {
+            extract_create_app_options_from_create_app_call(call, bindings)
+                .or_else(|| extract_create_app_options_from_expression(&call.callee, bindings))
+        }
+        Expression::StaticMemberExpression(member) => {
+            extract_create_app_options_from_expression(&member.object, bindings)
+        }
+        Expression::ParenthesizedExpression(paren) => {
+            extract_create_app_options_from_expression(&paren.expression, bindings)
+        }
+        Expression::TSAsExpression(ts_as) => {
+            extract_create_app_options_from_expression(&ts_as.expression, bindings)
+        }
+        Expression::TSSatisfiesExpression(ts_satisfies) => {
+            extract_create_app_options_from_expression(&ts_satisfies.expression, bindings)
+        }
+        Expression::TSNonNullExpression(ts_non_null) => {
+            extract_create_app_options_from_expression(&ts_non_null.expression, bindings)
+        }
+        _ => None,
+    }
+}
+
+fn extract_create_app_options_from_create_app_call<'a>(
+    call: &'a oxc_ast::ast::CallExpression<'a>,
+    bindings: &FxHashMap<&'a str, ComponentOptionsRef<'a>>,
+) -> Option<ComponentOptionsRef<'a>> {
+    if !is_create_app_callee(&call.callee) {
+        return None;
+    }
+
+    let first_arg = call.arguments.first()?;
+    extract_component_options_from_argument(first_arg, bindings)
+}
+
+fn is_create_app_callee(callee: &Expression<'_>) -> bool {
+    match callee {
+        Expression::Identifier(callee) => callee.name.as_str() == "createApp",
+        Expression::StaticMemberExpression(member) => {
+            member.property.name.as_str() == "createApp"
+                && matches!(
+                    &member.object,
+                    Expression::Identifier(object) if object.name.as_str() == "Vue"
+                )
+        }
+        _ => false,
+    }
 }
 
 fn extract_component_options_from_argument<'a>(
@@ -379,6 +463,51 @@ export default {
         rule.check(source, 0, &mut result);
         assert_eq!(result.error_count, 1);
         insta::assert_debug_snapshot!(result.diagnostics);
+    }
+
+    #[test]
+    fn test_invalid_cdn_create_app_options() {
+        let source = r##"
+Vue.createApp({
+  data() {
+    return { count: 0 }
+  }
+}).mount("#app")
+"##;
+        let rule = NoOptionsApi;
+        let mut result = ScriptLintResult::default();
+        rule.check(source, 0, &mut result);
+        assert_eq!(result.error_count, 1);
+        assert!(
+            result.diagnostics[0]
+                .labels
+                .iter()
+                .any(|label| label.message.contains("data() option"))
+        );
+    }
+
+    #[test]
+    fn test_invalid_destructured_create_app_options() {
+        let source = r##"
+const { createApp } = Vue
+const options = {
+  methods: {
+    increment() {}
+  }
+}
+
+createApp(options).mount("#app")
+"##;
+        let rule = NoOptionsApi;
+        let mut result = ScriptLintResult::default();
+        rule.check(source, 0, &mut result);
+        assert_eq!(result.error_count, 1);
+        assert!(
+            result.diagnostics[0]
+                .labels
+                .iter()
+                .any(|label| label.message.contains("methods option"))
+        );
     }
 
     #[test]

--- a/crates/vize_patina/src/rules/script/no_options_api.rs
+++ b/crates/vize_patina/src/rules/script/no_options_api.rs
@@ -34,12 +34,12 @@ use super::{ScriptLintResult, ScriptRule, ScriptRuleMeta};
 use crate::diagnostic::{LintDiagnostic, Severity};
 use oxc_allocator::Allocator;
 use oxc_ast::ast::{
-    Argument, BindingPattern, ExportDefaultDeclarationKind, Expression, ObjectExpression,
-    ObjectPropertyKind, PropertyKey, Statement,
+    Argument, BindingPattern, ExportDefaultDeclarationKind, Expression, ImportDeclarationSpecifier,
+    ObjectExpression, ObjectPropertyKind, PropertyKey, Statement,
 };
 use oxc_parser::Parser;
 use oxc_span::{GetSpan, SourceType};
-use vize_carton::{CompactString, FxHashMap};
+use vize_carton::{CompactString, FxHashMap, FxHashSet};
 
 static META: ScriptRuleMeta = ScriptRuleMeta {
     name: "script/no-options-api",
@@ -95,6 +95,12 @@ struct ComponentOptionsRef<'a> {
     object: &'a ObjectExpression<'a>,
 }
 
+#[derive(Default)]
+struct PetiteVueBindings<'a> {
+    create_app_bindings: FxHashSet<&'a str>,
+    namespace_bindings: FxHashSet<&'a str>,
+}
+
 struct ComponentOptionsMatch {
     start: u32,
     end: u32,
@@ -116,18 +122,27 @@ fn find_component_options(source: &str) -> Option<ComponentOptionsMatch> {
     }
 
     let mut bindings = FxHashMap::default();
+    let mut petite_vue = PetiteVueBindings::default();
+
+    for statement in parsed.program.body.iter() {
+        collect_petite_vue_imports(statement, &mut petite_vue);
+    }
+
     for statement in parsed.program.body.iter() {
         let Statement::VariableDeclaration(declaration) = statement else {
             continue;
         };
         for declarator in &declaration.declarations {
-            let BindingPattern::BindingIdentifier(id) = &declarator.id else {
-                continue;
-            };
             let Some(init) = declarator.init.as_ref() else {
                 continue;
             };
-            if let Some(options) = extract_component_options_from_expression(init, &bindings) {
+
+            collect_petite_vue_variable_binding(&declarator.id, init, &mut petite_vue);
+
+            if let BindingPattern::BindingIdentifier(id) = &declarator.id
+                && let Some(options) =
+                    extract_component_options_from_expression(init, &bindings, &petite_vue)
+            {
                 bindings.insert(id.name.as_str(), options);
             }
         }
@@ -137,7 +152,8 @@ fn find_component_options(source: &str) -> Option<ComponentOptionsMatch> {
         let Statement::ExportDefaultDeclaration(export) = statement else {
             continue;
         };
-        let Some(options) = extract_component_options_from_export(&export.declaration, &bindings)
+        let Some(options) =
+            extract_component_options_from_export(&export.declaration, &bindings, &petite_vue)
         else {
             continue;
         };
@@ -145,7 +161,9 @@ fn find_component_options(source: &str) -> Option<ComponentOptionsMatch> {
     }
 
     for statement in parsed.program.body.iter() {
-        let Some(options) = extract_create_app_options_from_statement(statement, &bindings) else {
+        let Some(options) =
+            extract_create_app_options_from_statement(statement, &bindings, &petite_vue)
+        else {
             continue;
         };
         return Some(build_component_options_match(options.object));
@@ -157,28 +175,33 @@ fn find_component_options(source: &str) -> Option<ComponentOptionsMatch> {
 fn extract_component_options_from_export<'a>(
     declaration: &'a ExportDefaultDeclarationKind<'a>,
     bindings: &FxHashMap<&'a str, ComponentOptionsRef<'a>>,
+    petite_vue: &PetiteVueBindings<'a>,
 ) -> Option<ComponentOptionsRef<'a>> {
     match declaration {
         ExportDefaultDeclarationKind::ObjectExpression(object) => {
             Some(ComponentOptionsRef { object })
         }
         ExportDefaultDeclarationKind::CallExpression(call) => {
-            extract_component_options_from_call(call, bindings)
+            extract_component_options_from_call(call, bindings, petite_vue)
         }
         ExportDefaultDeclarationKind::Identifier(identifier) => {
             bindings.get(identifier.name.as_str()).copied()
         }
         ExportDefaultDeclarationKind::ParenthesizedExpression(paren) => {
-            extract_component_options_from_expression(&paren.expression, bindings)
+            extract_component_options_from_expression(&paren.expression, bindings, petite_vue)
         }
         ExportDefaultDeclarationKind::TSAsExpression(ts_as) => {
-            extract_component_options_from_expression(&ts_as.expression, bindings)
+            extract_component_options_from_expression(&ts_as.expression, bindings, petite_vue)
         }
         ExportDefaultDeclarationKind::TSSatisfiesExpression(ts_satisfies) => {
-            extract_component_options_from_expression(&ts_satisfies.expression, bindings)
+            extract_component_options_from_expression(
+                &ts_satisfies.expression,
+                bindings,
+                petite_vue,
+            )
         }
         ExportDefaultDeclarationKind::TSNonNullExpression(ts_non_null) => {
-            extract_component_options_from_expression(&ts_non_null.expression, bindings)
+            extract_component_options_from_expression(&ts_non_null.expression, bindings, petite_vue)
         }
         _ => None,
     }
@@ -187,22 +210,29 @@ fn extract_component_options_from_export<'a>(
 fn extract_component_options_from_expression<'a>(
     expression: &'a Expression<'a>,
     bindings: &FxHashMap<&'a str, ComponentOptionsRef<'a>>,
+    petite_vue: &PetiteVueBindings<'a>,
 ) -> Option<ComponentOptionsRef<'a>> {
     match expression {
         Expression::ObjectExpression(object) => Some(ComponentOptionsRef { object }),
-        Expression::CallExpression(call) => extract_component_options_from_call(call, bindings),
+        Expression::CallExpression(call) => {
+            extract_component_options_from_call(call, bindings, petite_vue)
+        }
         Expression::Identifier(identifier) => bindings.get(identifier.name.as_str()).copied(),
         Expression::ParenthesizedExpression(paren) => {
-            extract_component_options_from_expression(&paren.expression, bindings)
+            extract_component_options_from_expression(&paren.expression, bindings, petite_vue)
         }
         Expression::TSAsExpression(ts_as) => {
-            extract_component_options_from_expression(&ts_as.expression, bindings)
+            extract_component_options_from_expression(&ts_as.expression, bindings, petite_vue)
         }
         Expression::TSSatisfiesExpression(ts_satisfies) => {
-            extract_component_options_from_expression(&ts_satisfies.expression, bindings)
+            extract_component_options_from_expression(
+                &ts_satisfies.expression,
+                bindings,
+                petite_vue,
+            )
         }
         Expression::TSNonNullExpression(ts_non_null) => {
-            extract_component_options_from_expression(&ts_non_null.expression, bindings)
+            extract_component_options_from_expression(&ts_non_null.expression, bindings, petite_vue)
         }
         _ => None,
     }
@@ -211,6 +241,7 @@ fn extract_component_options_from_expression<'a>(
 fn extract_component_options_from_call<'a>(
     call: &'a oxc_ast::ast::CallExpression<'a>,
     bindings: &FxHashMap<&'a str, ComponentOptionsRef<'a>>,
+    petite_vue: &PetiteVueBindings<'a>,
 ) -> Option<ComponentOptionsRef<'a>> {
     let Expression::Identifier(callee) = &call.callee else {
         return None;
@@ -220,23 +251,26 @@ fn extract_component_options_from_call<'a>(
     }
 
     let first_arg = call.arguments.first()?;
-    extract_component_options_from_argument(first_arg, bindings)
+    extract_component_options_from_argument(first_arg, bindings, petite_vue)
 }
 
 fn extract_create_app_options_from_statement<'a>(
     statement: &'a Statement<'a>,
     bindings: &FxHashMap<&'a str, ComponentOptionsRef<'a>>,
+    petite_vue: &PetiteVueBindings<'a>,
 ) -> Option<ComponentOptionsRef<'a>> {
     match statement {
         Statement::ExpressionStatement(statement) => {
-            extract_create_app_options_from_expression(&statement.expression, bindings)
+            extract_create_app_options_from_expression(&statement.expression, bindings, petite_vue)
         }
         Statement::VariableDeclaration(declaration) => {
             for declarator in &declaration.declarations {
                 let Some(init) = declarator.init.as_ref() else {
                     continue;
                 };
-                if let Some(options) = extract_create_app_options_from_expression(init, bindings) {
+                if let Some(options) =
+                    extract_create_app_options_from_expression(init, bindings, petite_vue)
+                {
                     return Some(options);
                 }
             }
@@ -249,27 +283,34 @@ fn extract_create_app_options_from_statement<'a>(
 fn extract_create_app_options_from_expression<'a>(
     expression: &'a Expression<'a>,
     bindings: &FxHashMap<&'a str, ComponentOptionsRef<'a>>,
+    petite_vue: &PetiteVueBindings<'a>,
 ) -> Option<ComponentOptionsRef<'a>> {
     match expression {
-        Expression::CallExpression(call) => {
-            extract_create_app_options_from_create_app_call(call, bindings)
-                .or_else(|| extract_create_app_options_from_expression(&call.callee, bindings))
-        }
+        Expression::CallExpression(call) => extract_create_app_options_from_create_app_call(
+            call, bindings, petite_vue,
+        )
+        .or_else(|| extract_create_app_options_from_expression(&call.callee, bindings, petite_vue)),
         Expression::StaticMemberExpression(member) => {
-            extract_create_app_options_from_expression(&member.object, bindings)
+            extract_create_app_options_from_expression(&member.object, bindings, petite_vue)
         }
         Expression::ParenthesizedExpression(paren) => {
-            extract_create_app_options_from_expression(&paren.expression, bindings)
+            extract_create_app_options_from_expression(&paren.expression, bindings, petite_vue)
         }
         Expression::TSAsExpression(ts_as) => {
-            extract_create_app_options_from_expression(&ts_as.expression, bindings)
+            extract_create_app_options_from_expression(&ts_as.expression, bindings, petite_vue)
         }
         Expression::TSSatisfiesExpression(ts_satisfies) => {
-            extract_create_app_options_from_expression(&ts_satisfies.expression, bindings)
+            extract_create_app_options_from_expression(
+                &ts_satisfies.expression,
+                bindings,
+                petite_vue,
+            )
         }
-        Expression::TSNonNullExpression(ts_non_null) => {
-            extract_create_app_options_from_expression(&ts_non_null.expression, bindings)
-        }
+        Expression::TSNonNullExpression(ts_non_null) => extract_create_app_options_from_expression(
+            &ts_non_null.expression,
+            bindings,
+            petite_vue,
+        ),
         _ => None,
     }
 }
@@ -277,23 +318,31 @@ fn extract_create_app_options_from_expression<'a>(
 fn extract_create_app_options_from_create_app_call<'a>(
     call: &'a oxc_ast::ast::CallExpression<'a>,
     bindings: &FxHashMap<&'a str, ComponentOptionsRef<'a>>,
+    petite_vue: &PetiteVueBindings<'a>,
 ) -> Option<ComponentOptionsRef<'a>> {
-    if !is_create_app_callee(&call.callee) {
+    if !is_create_app_callee(&call.callee, petite_vue) {
         return None;
     }
 
     let first_arg = call.arguments.first()?;
-    extract_component_options_from_argument(first_arg, bindings)
+    extract_component_options_from_argument(first_arg, bindings, petite_vue)
 }
 
-fn is_create_app_callee(callee: &Expression<'_>) -> bool {
+fn is_create_app_callee(callee: &Expression<'_>, petite_vue: &PetiteVueBindings<'_>) -> bool {
     match callee {
-        Expression::Identifier(callee) => callee.name.as_str() == "createApp",
+        Expression::Identifier(callee) => {
+            callee.name.as_str() == "createApp"
+                && !petite_vue
+                    .create_app_bindings
+                    .contains(callee.name.as_str())
+        }
         Expression::StaticMemberExpression(member) => {
             member.property.name.as_str() == "createApp"
                 && matches!(
                     &member.object,
-                    Expression::Identifier(object) if object.name.as_str() == "Vue"
+                    Expression::Identifier(object)
+                        if object.name.as_str() == "Vue"
+                            && !petite_vue.namespace_bindings.contains(object.name.as_str())
                 )
         }
         _ => false,
@@ -303,23 +352,130 @@ fn is_create_app_callee(callee: &Expression<'_>) -> bool {
 fn extract_component_options_from_argument<'a>(
     argument: &'a Argument<'a>,
     bindings: &FxHashMap<&'a str, ComponentOptionsRef<'a>>,
+    petite_vue: &PetiteVueBindings<'a>,
 ) -> Option<ComponentOptionsRef<'a>> {
     match argument {
         Argument::ObjectExpression(object) => Some(ComponentOptionsRef { object }),
-        Argument::CallExpression(call) => extract_component_options_from_call(call, bindings),
+        Argument::CallExpression(call) => {
+            extract_component_options_from_call(call, bindings, petite_vue)
+        }
         Argument::Identifier(identifier) => bindings.get(identifier.name.as_str()).copied(),
         Argument::ParenthesizedExpression(paren) => {
-            extract_component_options_from_expression(&paren.expression, bindings)
+            extract_component_options_from_expression(&paren.expression, bindings, petite_vue)
         }
         Argument::TSAsExpression(ts_as) => {
-            extract_component_options_from_expression(&ts_as.expression, bindings)
+            extract_component_options_from_expression(&ts_as.expression, bindings, petite_vue)
         }
-        Argument::TSSatisfiesExpression(ts_satisfies) => {
-            extract_component_options_from_expression(&ts_satisfies.expression, bindings)
-        }
+        Argument::TSSatisfiesExpression(ts_satisfies) => extract_component_options_from_expression(
+            &ts_satisfies.expression,
+            bindings,
+            petite_vue,
+        ),
         Argument::TSNonNullExpression(ts_non_null) => {
-            extract_component_options_from_expression(&ts_non_null.expression, bindings)
+            extract_component_options_from_expression(&ts_non_null.expression, bindings, petite_vue)
         }
+        _ => None,
+    }
+}
+
+fn collect_petite_vue_imports<'a>(
+    statement: &'a Statement<'a>,
+    petite_vue: &mut PetiteVueBindings<'a>,
+) {
+    let Statement::ImportDeclaration(import) = statement else {
+        return;
+    };
+    if !is_petite_vue_module(import.source.value.as_str()) {
+        return;
+    }
+
+    let Some(specifiers) = &import.specifiers else {
+        return;
+    };
+
+    for specifier in specifiers {
+        match specifier {
+            ImportDeclarationSpecifier::ImportSpecifier(specifier)
+                if specifier.imported.name().as_str() == "createApp" =>
+            {
+                petite_vue
+                    .create_app_bindings
+                    .insert(specifier.local.name.as_str());
+            }
+            ImportDeclarationSpecifier::ImportNamespaceSpecifier(specifier) => {
+                petite_vue
+                    .namespace_bindings
+                    .insert(specifier.local.name.as_str());
+            }
+            _ => {}
+        }
+    }
+}
+
+fn collect_petite_vue_variable_binding<'a>(
+    pattern: &'a BindingPattern<'a>,
+    init: &'a Expression<'a>,
+    petite_vue: &mut PetiteVueBindings<'a>,
+) {
+    match pattern {
+        BindingPattern::BindingIdentifier(identifier)
+            if is_petite_vue_namespace_expression(init, petite_vue) =>
+        {
+            petite_vue
+                .namespace_bindings
+                .insert(identifier.name.as_str());
+        }
+        BindingPattern::ObjectPattern(pattern)
+            if is_petite_vue_namespace_expression(init, petite_vue) =>
+        {
+            for property in &pattern.properties {
+                if property_key_name(&property.key) != Some("createApp") {
+                    continue;
+                }
+                if let Some(local_name) = binding_pattern_name(&property.value) {
+                    petite_vue.create_app_bindings.insert(local_name);
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+fn is_petite_vue_namespace_expression(
+    expression: &Expression<'_>,
+    petite_vue: &PetiteVueBindings<'_>,
+) -> bool {
+    match expression {
+        Expression::Identifier(identifier) => {
+            identifier.name.as_str() == "PetiteVue"
+                || petite_vue
+                    .namespace_bindings
+                    .contains(identifier.name.as_str())
+        }
+        Expression::ParenthesizedExpression(paren) => {
+            is_petite_vue_namespace_expression(&paren.expression, petite_vue)
+        }
+        Expression::TSAsExpression(ts_as) => {
+            is_petite_vue_namespace_expression(&ts_as.expression, petite_vue)
+        }
+        Expression::TSSatisfiesExpression(ts_satisfies) => {
+            is_petite_vue_namespace_expression(&ts_satisfies.expression, petite_vue)
+        }
+        Expression::TSNonNullExpression(ts_non_null) => {
+            is_petite_vue_namespace_expression(&ts_non_null.expression, petite_vue)
+        }
+        _ => false,
+    }
+}
+
+fn is_petite_vue_module(value: &str) -> bool {
+    value == "petite-vue" || value.starts_with("petite-vue/") || value.contains("/petite-vue")
+}
+
+fn binding_pattern_name<'a>(pattern: &'a BindingPattern<'a>) -> Option<&'a str> {
+    match pattern {
+        BindingPattern::BindingIdentifier(identifier) => Some(identifier.name.as_str()),
+        BindingPattern::AssignmentPattern(assignment) => binding_pattern_name(&assignment.left),
         _ => None,
     }
 }
@@ -508,6 +664,94 @@ createApp(options).mount("#app")
                 .iter()
                 .any(|label| label.message.contains("methods option"))
         );
+    }
+
+    #[test]
+    fn test_petite_vue_global_create_app_is_not_options_api() {
+        let source = r##"
+PetiteVue.createApp({
+  count: 0,
+  increment() {
+    this.count++
+  }
+}).mount()
+"##;
+        let rule = NoOptionsApi;
+        let mut result = ScriptLintResult::default();
+        rule.check(source, 0, &mut result);
+        assert_eq!(result.error_count, 0);
+    }
+
+    #[test]
+    fn test_petite_vue_imported_create_app_is_not_options_api() {
+        let source = r##"
+import { createApp } from 'petite-vue'
+
+createApp({
+  count: 0,
+  increment() {
+    this.count++
+  }
+}).mount()
+"##;
+        let rule = NoOptionsApi;
+        let mut result = ScriptLintResult::default();
+        rule.check(source, 0, &mut result);
+        assert_eq!(result.error_count, 0);
+    }
+
+    #[test]
+    fn test_petite_vue_cdn_imported_create_app_is_not_options_api() {
+        let source = r##"
+import { createApp as createPetiteApp } from 'https://unpkg.com/petite-vue?module'
+
+createPetiteApp({
+  count: 0,
+  increment() {
+    this.count++
+  }
+}).mount()
+"##;
+        let rule = NoOptionsApi;
+        let mut result = ScriptLintResult::default();
+        rule.check(source, 0, &mut result);
+        assert_eq!(result.error_count, 0);
+    }
+
+    #[test]
+    fn test_petite_vue_destructured_create_app_is_not_options_api() {
+        let source = r##"
+const { createApp } = PetiteVue
+
+createApp({
+  count: 0,
+  increment() {
+    this.count++
+  }
+}).mount()
+"##;
+        let rule = NoOptionsApi;
+        let mut result = ScriptLintResult::default();
+        rule.check(source, 0, &mut result);
+        assert_eq!(result.error_count, 0);
+    }
+
+    #[test]
+    fn test_petite_vue_namespace_named_vue_is_not_options_api() {
+        let source = r##"
+import * as Vue from 'petite-vue'
+
+Vue.createApp({
+  count: 0,
+  increment() {
+    this.count++
+  }
+}).mount()
+"##;
+        let rule = NoOptionsApi;
+        let mut result = ScriptLintResult::default();
+        rule.check(source, 0, &mut result);
+        assert_eq!(result.error_count, 0);
     }
 
     #[test]

--- a/crates/vize_vitrine/src/napi/lint.rs
+++ b/crates/vize_vitrine/src/napi/lint.rs
@@ -306,7 +306,11 @@ pub fn lint_patina_sfc(source: String, options: Option<PatinaLintOptionsNapi>) -
         .with_locale(locale)
         .with_help_level(help_level)
         .with_enabled_rules(enabled_rules);
-    let result = linter.lint_sfc(&source, &filename);
+    let result = if is_standalone_html_filename(&filename) {
+        linter.lint_standalone_html(&source, &filename)
+    } else {
+        linter.lint_sfc(&source, &filename)
+    };
     let lsp_diagnostics = LspEmitter::to_lsp_diagnostics_with_source(&result, &source);
 
     if result.diagnostics.len() != lsp_diagnostics.len() {
@@ -397,7 +401,9 @@ pub fn lint(patterns: Vec<String>, options: Option<LintOptionsNapi>) -> Result<L
                     .flatten()
                     .filter_map(|r| r.ok())
                     .filter(|p| {
-                        p.extension().is_some_and(|ext| ext == "vue")
+                        p.extension()
+                            .and_then(|ext| ext.to_str())
+                            .is_some_and(is_lintable_extension)
                             && !p.components().any(|c| c.as_os_str() == "node_modules")
                     })
                     .collect::<Vec<_>>()
@@ -405,7 +411,12 @@ pub fn lint(patterns: Vec<String>, options: Option<LintOptionsNapi>) -> Result<L
                 // Use directory walking for paths (respects .gitignore)
                 Walk::new(pattern)
                     .filter_map(|e| e.ok())
-                    .filter(|e| e.path().extension().is_some_and(|ext| ext == "vue"))
+                    .filter(|e| {
+                        e.path()
+                            .extension()
+                            .and_then(|ext| ext.to_str())
+                            .is_some_and(is_lintable_extension)
+                    })
                     .map(|e| e.path().to_path_buf())
                     .collect::<Vec<_>>()
             }
@@ -414,7 +425,10 @@ pub fn lint(patterns: Vec<String>, options: Option<LintOptionsNapi>) -> Result<L
 
     if files.is_empty() {
         return Ok(LintResultNapi {
-            output: format!("No .vue files found matching patterns: {:?}", patterns),
+            output: format!(
+                "No .vue or .html files found matching patterns: {:?}",
+                patterns
+            ),
             error_count: 0,
             warning_count: 0,
             file_count: 0,
@@ -442,7 +456,11 @@ pub fn lint(patterns: Vec<String>, options: Option<LintOptionsNapi>) -> Result<L
             };
 
             let filename = path.to_string_lossy().to_string();
-            let result = linter.lint_sfc(&source, &filename);
+            let result = if is_standalone_html_filename(&filename) {
+                linter.lint_standalone_html(&source, &filename)
+            } else {
+                linter.lint_sfc(&source, &filename)
+            };
 
             error_count.fetch_add(result.error_count, Ordering::Relaxed);
             warning_count.fetch_add(result.warning_count, Ordering::Relaxed);
@@ -499,6 +517,14 @@ pub fn lint(patterns: Vec<String>, options: Option<LintOptionsNapi>) -> Result<L
         file_count: files.len() as u32,
         time_ms: elapsed.as_secs_f64() * 1000.0,
     })
+}
+
+fn is_standalone_html_filename(filename: &str) -> bool {
+    filename.ends_with(".html") || filename.ends_with(".htm")
+}
+
+fn is_lintable_extension(extension: &str) -> bool {
+    matches!(extension, "vue" | "html" | "htm")
 }
 
 #[cfg(test)]

--- a/npm/oxlint-plugin-vize/src/__snapshots__/stylish-standalone-html-output.txt
+++ b/npm/oxlint-plugin-vize/src/__snapshots__/stylish-standalone-html-output.txt
@@ -1,0 +1,4 @@
+Standalone.html
+  9:15  error  Options API component declarations are not supported  vize(script/no-options-api)
+
+✖ 1 problem (1 error, 0 warnings)

--- a/npm/oxlint-plugin-vize/src/cli.ts
+++ b/npm/oxlint-plugin-vize/src/cli.ts
@@ -11,8 +11,8 @@ async function main(): Promise<void> {
   const cwd = process.cwd();
   const forwardedArgs = process.argv.slice(2);
   const targets = getLintTargets(forwardedArgs);
-  const vueFiles = collectVueFilesFromTargets(cwd, targets);
-  const prepared = prepareScriptlessWorkaroundFiles(cwd, vueFiles);
+  const lintFiles = collectVueFilesFromTargets(cwd, targets);
+  const prepared = prepareScriptlessWorkaroundFiles(cwd, lintFiles);
   const oxlintEntrypoint = resolveOxlintCliEntrypoint(cwd);
   const args = [oxlintEntrypoint, ...forwardedArgs, ...prepared.appendedArgs];
 
@@ -32,7 +32,7 @@ async function main(): Promise<void> {
     if (prepared.usedScriptlessWorkaround && forwardedArgs.includes("--fix")) {
       await writeStream(
         process.stderr,
-        "\n[oxlint-plugin-vize] Scriptless SFC workaround is active; fixes are not applied back to original .vue files yet.\n",
+        "\n[oxlint-plugin-vize] Temporary Vue workaround is active; fixes are not applied back to original files yet.\n",
       );
     }
 

--- a/npm/oxlint-plugin-vize/src/cli/files.ts
+++ b/npm/oxlint-plugin-vize/src/cli/files.ts
@@ -24,7 +24,7 @@ function collectVueFilesFromTarget(cwd: string, target: string): string[] {
         exclude: ["**/node_modules/**", "**/.git/**"],
       })
       .map((entry) => path.resolve(cwd, entry))
-      .filter(isVueFile);
+      .filter(isSupportedLintFile);
   }
 
   const absoluteTarget = path.resolve(cwd, target);
@@ -35,17 +35,18 @@ function collectVueFilesFromTarget(cwd: string, target: string): string[] {
   const stat = fs.statSync(absoluteTarget);
   if (stat.isDirectory()) {
     return fs
-      .globSync("**/*.vue", {
+      .globSync("**/*", {
         cwd: absoluteTarget,
         withFileTypes: false,
         exclude: ["**/node_modules/**", "**/.git/**"],
       })
-      .map((entry) => path.resolve(absoluteTarget, entry));
+      .map((entry) => path.resolve(absoluteTarget, entry))
+      .filter(isSupportedLintFile);
   }
 
-  return isVueFile(absoluteTarget) ? [absoluteTarget] : [];
+  return isSupportedLintFile(absoluteTarget) ? [absoluteTarget] : [];
 }
 
-function isVueFile(filename: string): boolean {
-  return filename.endsWith(".vue");
+function isSupportedLintFile(filename: string): boolean {
+  return filename.endsWith(".vue") || filename.endsWith(".html") || filename.endsWith(".htm");
 }

--- a/npm/oxlint-plugin-vize/src/cli/workaround-files.ts
+++ b/npm/oxlint-plugin-vize/src/cli/workaround-files.ts
@@ -22,12 +22,16 @@ export function prepareScriptlessWorkaroundFiles(
 
   for (const filename of filenames) {
     const source = fs.readFileSync(filename, "utf8");
-    if (hasScriptLikeBlock(source)) {
+    const isStandaloneHtml = isStandaloneHtmlFile(filename);
+    if (!isStandaloneHtml && hasScriptLikeBlock(source)) {
       continue;
     }
 
     const relativeFilename = path.relative(cwd, filename);
-    const tempFilename = path.join(tempDir, `${counter}-${path.basename(filename)}`);
+    const tempBasename = isStandaloneHtml
+      ? `${path.basename(filename)}.vue`
+      : path.basename(filename);
+    const tempFilename = path.join(tempDir, `${counter}-${tempBasename}`);
     counter += 1;
 
     fs.mkdirSync(path.dirname(tempFilename), { recursive: true });
@@ -54,6 +58,10 @@ export function prepareScriptlessWorkaroundFiles(
 
 function toCliPath(filename: string): string {
   return filename.split(path.sep).join("/");
+}
+
+function isStandaloneHtmlFile(filename: string): boolean {
+  return filename.endsWith(".html") || filename.endsWith(".htm");
 }
 
 function registerPathReplacementVariants(

--- a/npm/oxlint-plugin-vize/src/settings.ts
+++ b/npm/oxlint-plugin-vize/src/settings.ts
@@ -21,7 +21,7 @@ const PRESET_ALIASES = new Map<string, PatinaPreset>([
 ]);
 
 export function isVueLikeFile(filename: string): boolean {
-  return filename.endsWith(".vue");
+  return filename.endsWith(".vue") || filename.endsWith(".html") || filename.endsWith(".htm");
 }
 
 export function getVizeSettings(context: Context): PatinaSettings {

--- a/npm/oxlint-plugin-vize/src/test.ts
+++ b/npm/oxlint-plugin-vize/src/test.ts
@@ -35,6 +35,7 @@ const optionsApiVuePath = path.join(fixtureDir, "OptionsApi.vue");
 const dualScriptVuePath = path.join(fixtureDir, "DualScript.vue");
 const coreRulesVuePath = path.join(fixtureDir, "CoreRules.vue");
 const scriptlessVuePath = path.join(fixtureDir, "Scriptless.vue");
+const standaloneHtmlPath = path.join(fixtureDir, "Standalone.html");
 const hugeJsonVuePath = path.join(fixtureDir, "HugeJson.vue");
 const snapshotsDir = path.join(packageDir, "__snapshots__");
 const ansiEscapePattern = new RegExp(String.raw`\u001B\[[0-9;]*m`, "gu");
@@ -415,6 +416,27 @@ fs.writeFileSync(
 );
 
 fs.writeFileSync(
+  standaloneHtmlPath,
+  `<!doctype html>
+<html>
+<head>
+  <script src="https://unpkg.com/vue@3/dist/vue.global.js"></script>
+</head>
+<body>
+  <div id="app">{{ count }}</div>
+  <script>
+Vue.createApp({
+  data() {
+    return { count: 1 };
+  },
+}).mount("#app");
+  </script>
+</body>
+</html>
+`,
+);
+
+fs.writeFileSync(
   hugeJsonVuePath,
   `<template>
 ${Array.from({ length: 700 }, (_, index) => `  <demo-card  :title="'Item ${index}'" />`).join("\n")}
@@ -789,6 +811,30 @@ assert.doesNotMatch(
   "scriptless workaround should not leak temporary cache paths to users",
 );
 assert.equal(scriptlessRun.output, readSnapshot("stylish-scriptless-workaround-output.txt"));
+
+const standaloneHtmlRun = runOxlintVize([
+  "-c",
+  ".oxlintrc.opinionated-script.json",
+  "-f",
+  "stylish",
+  "Standalone.html",
+]);
+assert.notEqual(
+  standaloneHtmlRun.exitCode,
+  0,
+  "oxlint-vize should lint standalone HTML that uses Vue from a CDN",
+);
+assert.match(
+  standaloneHtmlRun.output,
+  /Standalone\.html[\s\S]*9:15[\s\S]*Options API component declarations are not supported/u,
+  "standalone HTML output should report the original inline script location",
+);
+assert.doesNotMatch(
+  standaloneHtmlRun.output,
+  /__oxlint_plugin_vize_temp__/u,
+  "standalone HTML output should not leak temporary workaround paths",
+);
+assert.equal(standaloneHtmlRun.output, readSnapshot("stylish-standalone-html-output.txt"));
 
 const sampleBlocks = extractSfcBlocks(
   `<script setup lang="ts">\nconst count = 1\n</script>\n<template>\n  <div>{{ count }}</div>\n</template>\n<style scoped>\n.foo {}\n</style>\n<i18n>\n{}\n</i18n>\n`,

--- a/npm/vscode-vize/package.json
+++ b/npm/vscode-vize/package.json
@@ -301,11 +301,11 @@
         },
         {
           "command": "vize.restartServer",
-          "when": "editorLangId == vue || editorLangId == art-vue"
+          "when": "editorLangId == vue || editorLangId == art-vue || editorLangId == html"
         },
         {
           "command": "vize.showOutput",
-          "when": "editorLangId == vue || editorLangId == art-vue"
+          "when": "editorLangId == vue || editorLangId == art-vue || editorLangId == html"
         }
       ]
     },
@@ -364,6 +364,7 @@
     "onCommand:vize.showOutput",
     "onCommand:vize.showStatus",
     "onLanguage:art-vue",
+    "onLanguage:html",
     "onLanguage:vue"
   ],
   "icon": "icons/logo.png",

--- a/npm/vscode-vize/src/extension.ts
+++ b/npm/vscode-vize/src/extension.ts
@@ -57,7 +57,7 @@ type VizeStatusAction =
 type VizeStatusQuickPickItem = QuickPickItem & {
   action: VizeStatusAction;
 };
-const SUPPORTED_LANGUAGE_IDS = ["vue", "art-vue"] as const;
+const SUPPORTED_LANGUAGE_IDS = ["vue", "art-vue", "html"] as const;
 const SUPPORTED_URI_SCHEMES = ["file", "untitled"] as const;
 const RECOMMENDED_SETUP_ACTION = "Enable Recommended";
 const LINT_ONLY_SETUP_ACTION = "Enable Lint Only";
@@ -193,12 +193,14 @@ function scheduleClientSync(context: ExtensionContext, reason: string): void {
 
 async function syncClientToConfiguration(context: ExtensionContext, reason: string): Promise<void> {
   let config = workspace.getConfiguration("vize");
+  let enabled = shouldStartFromConfiguration(config);
 
-  if (!config.get<boolean>("enable", false)) {
+  if (!enabled) {
     await maybeOfferInitialSetup(context, config);
     config = workspace.getConfiguration("vize");
+    enabled = shouldStartFromConfiguration(config);
 
-    if (!config.get<boolean>("enable", false)) {
+    if (!enabled) {
       if (client) {
         updateStatusBar("starting", "Stopping language server");
         outputChannel.appendLine(`Stopping Vize language server (${reason}; extension disabled).`);
@@ -213,6 +215,8 @@ async function syncClientToConfiguration(context: ExtensionContext, reason: stri
     }
 
     outputChannel.appendLine("Recommended Vize setup was applied. Starting language server...");
+  } else if (!config.get<boolean>("enable", false)) {
+    outputChannel.appendLine("Starting Vize language server from workspace vize.config.");
   }
 
   if (client) {
@@ -524,6 +528,20 @@ function hasAnyExplicitCapabilityValue(
   return FEATURE_SETTING_KEYS.some((key) => hasExplicitConfigurationValue(config, key));
 }
 
+function shouldStartFromConfiguration(
+  config: ReturnType<typeof workspace.getConfiguration>,
+): boolean {
+  if (config.get<boolean>("enable", false)) {
+    return true;
+  }
+
+  if (hasExplicitConfigurationValue(config, "enable")) {
+    return false;
+  }
+
+  return hasWorkspaceLspConfig();
+}
+
 function hasWorkspaceLspConfig(): boolean {
   const workspaceFolders = workspace.workspaceFolders;
   if (!workspaceFolders) {
@@ -636,7 +654,10 @@ function createClientOptions(
     ),
     synchronize: {
       configurationSection: "vize",
-      fileEvents: workspace.createFileSystemWatcher("**/*.vue"),
+      fileEvents: [
+        workspace.createFileSystemWatcher("**/*.vue"),
+        workspace.createFileSystemWatcher("**/*.{html,htm}"),
+      ],
     },
     outputChannel,
     traceOutputChannel: outputChannel,

--- a/tests/tooling/editor-integrations.test.ts
+++ b/tests/tooling/editor-integrations.test.ts
@@ -66,7 +66,7 @@ test("vscode-vize wires art-vue documents into editor features", () => {
     "utf-8",
   );
 
-  assert.match(extensionSource, /SUPPORTED_LANGUAGE_IDS\s*=\s*\["vue", "art-vue"\]/);
+  assert.match(extensionSource, /SUPPORTED_LANGUAGE_IDS\s*=\s*\["vue", "art-vue", "html"\]/);
   assert.match(extensionSource, /SUPPORTED_URI_SCHEMES\s*=\s*\["file", "untitled"\]/);
   assert.match(extensionSource, /documentSelector:\s*SUPPORTED_URI_SCHEMES\.flatMap/);
   assert.match(extensionSource, /onDidChangeConfiguration/);


### PR DESCRIPTION
## Summary

- Detect Options API component objects passed to CDN-style `Vue.createApp({ ... })` and `createApp({ ... })` calls in standalone HTML.
- Keep `script/no-options-api` opt-in via `vize.config`, and apply configured rules consistently in CLI and Maestro LSP diagnostics.
- Generate template virtual docs for standalone `.html` / `.htm` files so LSP template features can run outside SFCs.
- Add petite-vue handling: avoid Options API false positives for petite-vue `createApp`, offer `v-scope` / `v-effect` / lifecycle event completions, and jump from template expressions to inline `v-scope` or `createApp` scope properties.
- Let the VS Code client attach to HTML documents and start from workspace `vize.config` when `vize.enable` is not explicitly disabled.

## Why

Standalone CDN HTML and petite-vue examples do not use SFC `export default`, but users still expect `vize.config`-driven diagnostics and editor features like completion and go-to-definition in `.html` files. petite-vue `createApp({ ... })` also represents a root scope object, not a Vue Options API component object.

## Impact

Users can opt in to standalone HTML lint diagnostics and LSP editor support without forcing those rules on every project. petite-vue pages get relevant directive completions and small same-file jumps while avoiding incorrect Options API reports.

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo clippy --workspace -- -D warnings`
- `cargo test -p vize_carton load_config_uses_typescript_config -- --nocapture`
- `cargo test -p vize_patina no_options_api -- --nocapture`
- `cargo test -p vize_patina standalone_html -- --nocapture`
- `cargo test -p vize_maestro standalone_html -- --nocapture`
- `cargo test -p vize_maestro petite_vue -- --nocapture`
- `cargo test -p vize_maestro --lib -- --nocapture`
- `cargo test -p vize lint -- --nocapture`
- `node --test --test-concurrency=1 tests/tooling/editor-integrations.test.ts`
- `vp run --workspace-root test:scripts`
- `pnpm --dir npm/vscode-vize check`
