### PR TITLE
feat(config): add monorepo-aware config entries

### DIFF
--- a/docs/content/getting-started.md
+++ b/docs/content/getting-started.md
@@ -186,10 +186,10 @@ vize check --declaration --declaration-dir dist/types
 
 The npm CLI and `@vizejs/vite-plugin` share config discovery:
 
+- `vize.config.pkl`
 - `vize.config.ts`
 - `vize.config.js`
 - `vize.config.mjs`
-- `vize.config.pkl`
 - `vize.config.json`
 
 TypeScript config:

--- a/docs/content/guide/configuration.md
+++ b/docs/content/guide/configuration.md
@@ -8,12 +8,13 @@ Vize uses `vize.config.*` for shared npm CLI, Vite plugin, and Rust CLI settings
 
 ## Config Files
 
-The npm CLI and `@vizejs/vite-plugin` load these files from the project root:
+The npm CLI and `@vizejs/vite-plugin` load these files from the project root in this priority
+order:
 
+- `vize.config.pkl`
 - `vize.config.ts`
 - `vize.config.js`
 - `vize.config.mjs`
-- `vize.config.pkl`
 - `vize.config.json`
 
 The Rust CLI reads the same config file names in the order above for command-native settings such as
@@ -63,6 +64,38 @@ export default defineConfig(({ command, mode, isSsrBuild }) => ({
 }));
 ```
 
+## Experimental Flat Entries
+
+Monorepos can describe root defaults and package-scoped overrides with `entries`. Plain object
+configs are normalized to one entry internally, and array exports are accepted by `defineConfig` for
+ESLint-flat-config-style authoring.
+
+```ts
+export default defineConfig({
+  formatter: {
+    printWidth: 100,
+  },
+  entries: [
+    {
+      name: "web app",
+      basePath: "apps/web",
+      files: ["src/**/*.vue"],
+      typeChecker: {
+        tsconfig: "tsconfig.app.json",
+      },
+    },
+    {
+      name: "ui package",
+      basePath: "packages/ui",
+      files: ["src/**/*.vue"],
+      formatter: {
+        singleQuote: true,
+      },
+    },
+  ],
+});
+```
+
 ## PKL Config
 
 ```pkl
@@ -88,6 +121,17 @@ linter {
 typeChecker {
   enabled = true
   strict = true
+}
+
+entries = new Listing {
+  new ConfigEntry {
+    name = "web app"
+    basePath = "apps/web"
+    files = new Listing { "src/**/*.vue" }
+    typeChecker {
+      tsconfig = "tsconfig.app.json"
+    }
+  }
 }
 
 lsp {

--- a/docs/content/guide/vite-plugin.md
+++ b/docs/content/guide/vite-plugin.md
@@ -50,10 +50,10 @@ vp install -D vize
 
 Supported config files:
 
+- `vize.config.pkl`
 - `vize.config.ts`
 - `vize.config.js`
 - `vize.config.mjs`
-- `vize.config.pkl`
 - `vize.config.json`
 
 TypeScript config:
@@ -106,9 +106,40 @@ Importing `defineConfig` from `@vizejs/vite-plugin` still works for backward com
 
 See [Configuration](./configuration.md) for the full shared config shape.
 
+Vite Plus-first projects can also keep startup-only settings inline in `vite.config.ts`:
+
+```ts
+import { defineConfig } from "vite-plus";
+import vize from "@vizejs/vite-plugin";
+
+export default defineConfig({
+  plugins: [
+    vize({
+      config: {
+        compiler: {
+          sourceMap: true,
+          vapor: false,
+        },
+        vite: {
+          scanPatterns: ["src/**/*.vue"],
+        },
+        musea: {
+          include: ["src/**/*.art.vue"],
+        },
+      },
+    }),
+  ],
+});
+```
+
+Inline config is available to the Vite plugin and shared plugin store during Vite Plus execution.
+Use `vize.config.*` for settings that must also be read by CLI and LSP commands.
+
 ## Compiler Options
 
 Direct options passed to `vize()` override `vize.config.*`.
+The full precedence is direct plugin options, then inline `config`, then `vize.config.*`, then
+defaults.
 
 ```ts
 vize({
@@ -135,6 +166,7 @@ vize({
 | `ignorePatterns`       | `vite.ignorePatterns` or `vize({ ignorePatterns })`       | Glob patterns skipped during startup pre-compilation.                                                     |
 | `configMode`           | `vize({ configMode })`                                    | Use `"root"`, `"auto"`, or `false` for shared config loading.                                             |
 | `configFile`           | `vize({ configFile })`                                    | Load a specific config file.                                                                              |
+| `config`               | `vize({ config })`                                        | Inline shared config for Vite Plus runtime settings.                                                      |
 | `handleNodeModulesVue` | `vize({ handleNodeModulesVue })`                          | Compile `.vue` files imported from `node_modules` on demand.                                              |
 | `debug`                | `vize({ debug })`                                         | Print plugin debug logs.                                                                                  |
 

--- a/npm/vite-plugin-vize/src/config.ts
+++ b/npm/vite-plugin-vize/src/config.ts
@@ -5,16 +5,23 @@
  * npm CLI resolve the same `vize.config.*` files with the same behavior.
  */
 
-import type { VizeConfig } from "./types.ts";
+import type { ResolvedVizeConfig } from "./types.ts";
 import {
   CONFIG_FILE_NAMES,
   defineConfig,
   loadConfig,
+  resolveConfigExport,
   VIZE_CONFIG_JSON_SCHEMA_PATH,
   VIZE_CONFIG_PKL_SCHEMA_PATH,
 } from "vize";
 
-export { defineConfig, loadConfig, VIZE_CONFIG_JSON_SCHEMA_PATH, VIZE_CONFIG_PKL_SCHEMA_PATH };
+export {
+  defineConfig,
+  loadConfig,
+  resolveConfigExport,
+  VIZE_CONFIG_JSON_SCHEMA_PATH,
+  VIZE_CONFIG_PKL_SCHEMA_PATH,
+};
 
 export const CONFIG_FILES = [...CONFIG_FILE_NAMES];
 
@@ -23,4 +30,4 @@ export const CONFIG_FILES = [...CONFIG_FILE_NAMES];
  * Key = project root, Value = resolved VizeConfig.
  * Used by musea() and other plugins to access the unified config.
  */
-export const vizeConfigStore = new Map<string, VizeConfig>();
+export const vizeConfigStore = new Map<string, ResolvedVizeConfig>();

--- a/npm/vite-plugin-vize/src/index.ts
+++ b/npm/vite-plugin-vize/src/index.ts
@@ -3,13 +3,15 @@
  */
 
 export { vize } from "./plugin/index.ts";
-export { defineConfig, loadConfig, vizeConfigStore } from "./config.ts";
+export { defineConfig, loadConfig, resolveConfigExport, vizeConfigStore } from "./config.ts";
 export { rewriteStaticAssetUrls as __internal_rewriteStaticAssetUrls } from "./transform.ts";
 export type {
   VizeOptions,
   CompiledModule,
   MacroArtifact,
   VizeConfig,
+  ResolvedVizeConfig,
+  UserConfigExport,
   LoadConfigOptions,
 } from "./types.ts";
 

--- a/npm/vite-plugin-vize/src/plugin/index.ts
+++ b/npm/vite-plugin-vize/src/plugin/index.ts
@@ -2,11 +2,11 @@
 
 import type { Plugin, ResolvedConfig, ViteDevServer } from "vite";
 
-import type { VizeOptions, ConfigEnv } from "../types.ts";
+import type { VizeOptions, ConfigEnv, ResolvedVizeConfig } from "../types.ts";
 import { createFilter } from "../utils/index.ts";
 import { toBrowserImportPrefix } from "../virtual.ts";
 import { shouldApplyDefineInVirtualModule, createLogger } from "../transform.ts";
-import { loadConfig, vizeConfigStore } from "../config.ts";
+import { loadConfig, resolveConfigExport, vizeConfigStore } from "../config.ts";
 import {
   DEFAULT_PRECOMPILE_BATCH_SIZE,
   DEFAULT_PRECOMPILE_IGNORE_PATTERNS,
@@ -31,6 +31,52 @@ export type { VizePluginState } from "./state.ts";
 
 function aliasSortKey(find: string | RegExp): number {
   return typeof find === "string" ? find.length : find.source.length;
+}
+
+function mergeSharedConfig(
+  baseConfig: ResolvedVizeConfig | null,
+  overrideConfig: ResolvedVizeConfig | null,
+): ResolvedVizeConfig | null {
+  if (!baseConfig) return overrideConfig;
+  if (!overrideConfig) return baseConfig;
+
+  return {
+    ...baseConfig,
+    ...overrideConfig,
+    compiler: {
+      ...baseConfig.compiler,
+      ...overrideConfig.compiler,
+    },
+    vite: {
+      ...baseConfig.vite,
+      ...overrideConfig.vite,
+    },
+    linter: {
+      ...baseConfig.linter,
+      ...overrideConfig.linter,
+    },
+    typeChecker: {
+      ...baseConfig.typeChecker,
+      ...overrideConfig.typeChecker,
+    },
+    formatter: {
+      ...baseConfig.formatter,
+      ...overrideConfig.formatter,
+    },
+    languageServer: {
+      ...baseConfig.languageServer,
+      ...overrideConfig.languageServer,
+    },
+    musea: {
+      ...baseConfig.musea,
+      ...overrideConfig.musea,
+    },
+    globalTypes: {
+      ...baseConfig.globalTypes,
+      ...overrideConfig.globalTypes,
+    },
+    entries: [...baseConfig.entries, ...overrideConfig.entries],
+  };
 }
 
 export function vize(options: VizeOptions = {}): Plugin[] {
@@ -128,7 +174,7 @@ export function vize(options: VizeOptions = {}): Plugin[] {
         isSsrBuild: !!resolvedConfig.build?.ssr,
       };
 
-      let fileConfig = null;
+      let fileConfig: ResolvedVizeConfig | null = null;
       if (options.configMode !== false) {
         try {
           fileConfig = await loadConfig(state.root, {
@@ -138,7 +184,6 @@ export function vize(options: VizeOptions = {}): Plugin[] {
           });
           if (fileConfig) {
             state.logger.log("Loaded config from vize.config file");
-            vizeConfigStore.set(state.root, fileConfig);
           }
         } catch (error) {
           state.logger.warn(
@@ -148,8 +193,23 @@ export function vize(options: VizeOptions = {}): Plugin[] {
         }
       }
 
-      const viteConfig = fileConfig?.vite ?? {};
-      const compilerConfig = fileConfig?.compiler ?? {};
+      let inlineConfig: ResolvedVizeConfig | null = null;
+      if (options.config) {
+        try {
+          inlineConfig = await resolveConfigExport(options.config, configEnv);
+          state.logger.log("Loaded inline vize config from plugin options");
+        } catch (error) {
+          state.logger.warn("Failed to resolve inline vize config:", error);
+        }
+      }
+
+      const sharedConfig = mergeSharedConfig(fileConfig, inlineConfig);
+      if (sharedConfig) {
+        vizeConfigStore.set(state.root, sharedConfig);
+      }
+
+      const viteConfig = sharedConfig?.vite ?? {};
+      const compilerConfig = sharedConfig?.compiler ?? {};
 
       state.mergedOptions = {
         ...options,

--- a/npm/vite-plugin-vize/src/types.ts
+++ b/npm/vite-plugin-vize/src/types.ts
@@ -1,5 +1,8 @@
+import type { UserConfigExport } from "../../vize/src/types/index.ts";
+
 export type {
   VizeConfig,
+  ResolvedVizeConfig,
   LoadConfigOptions,
   ConfigEnv,
   UserConfigExport,
@@ -44,6 +47,12 @@ export type CompileSfcFn = (
 ) => SfcCompileResultNapi;
 
 export interface VizeOptions {
+  /**
+   * Inline shared Vize config for Vite Plus-first projects.
+   * Direct plugin options still take precedence over these values.
+   */
+  config?: UserConfigExport;
+
   /**
    * Override the public base used for dev-time asset URLs such as /@fs paths.
    * Useful for frameworks like Nuxt that serve Vite from a subpath (e.g. /_nuxt/).

--- a/npm/vize/README.md
+++ b/npm/vize/README.md
@@ -52,10 +52,10 @@ Recommended scripts:
 
 Shared config discovery is supported for the npm CLI:
 
+- `vize.config.pkl`
 - `vize.config.ts`
 - `vize.config.js`
 - `vize.config.mjs`
-- `vize.config.pkl`
 - `vize.config.json`
 
 Pkl config files require either `@pkl-community/pkl` installed in the project or a `pkl` binary on

--- a/npm/vize/pkl/VizeConfig.pkl
+++ b/npm/vize/pkl/VizeConfig.pkl
@@ -23,6 +23,71 @@ import "LanguageServerConfig.pkl"
 import "MuseaConfig.pkl"
 import "GlobalTypesConfig.pkl"
 
+typealias ConfigExtends = String | Listing<String>
+
+class ConfigEntry {
+  /// Human-readable entry name for inspect output and diagnostics.
+  name: String? = null
+
+  /// Directory used as the base for scoped file patterns and relative paths.
+  basePath: String? = null
+
+  /// Glob patterns this entry applies to.
+  files: Listing<String>? = null
+
+  /// Glob patterns this entry excludes.
+  ignores: Listing<String>? = null
+
+  /// Base config files or presets amended by this entry.
+  `extends`: ConfigExtends? = null
+
+  /// Vue compiler options.
+  compiler: CompilerConfig.CompilerConfig = new CompilerConfig.CompilerConfig {}
+
+  /// Vite plugin options.
+  vite: VitePluginConfig.VitePluginConfig = new VitePluginConfig.VitePluginConfig {}
+
+  /// Linter options.
+  linter: LinterConfig.LinterConfig = new LinterConfig.LinterConfig {}
+
+  /// Type checker options.
+  typeChecker: TypeCheckerConfig.TypeCheckerConfig = new TypeCheckerConfig.TypeCheckerConfig {}
+
+  /// Formatter options.
+  formatter: FormatterConfig.FormatterConfig = new FormatterConfig.FormatterConfig {}
+
+  /// Language server options.
+  languageServer: LanguageServerConfig.LanguageServerConfig = new LanguageServerConfig.LanguageServerConfig {}
+
+  /// Legacy alias for `languageServer`.
+  @Deprecated {
+    message = "Use languageServer instead."
+    replaceWith = "languageServer"
+  }
+  lsp: LanguageServerConfig.LanguageServerConfig = languageServer
+
+  /// Musea component gallery options.
+  musea: MuseaConfig.MuseaConfig = new MuseaConfig.MuseaConfig {}
+
+  /// Global type declarations.
+  globalTypes: GlobalTypesConfig.GlobalTypesConfig = new GlobalTypesConfig.GlobalTypesConfig {}
+}
+
+/// Human-readable entry name for inspect output and diagnostics.
+name: String? = null
+
+/// Directory used as the base for scoped file patterns and relative paths.
+basePath: String? = null
+
+/// Glob patterns this config applies to.
+files: Listing<String>? = null
+
+/// Glob patterns this config excludes.
+ignores: Listing<String>? = null
+
+/// Base config files or presets amended by this config.
+`extends`: ConfigExtends? = null
+
 /// Vue compiler options.
 compiler: CompilerConfig.CompilerConfig = new CompilerConfig.CompilerConfig {}
 
@@ -53,3 +118,6 @@ musea: MuseaConfig.MuseaConfig = new MuseaConfig.MuseaConfig {}
 
 /// Global type declarations.
 globalTypes: GlobalTypesConfig.GlobalTypesConfig = new GlobalTypesConfig.GlobalTypesConfig {}
+
+/// Scoped config entries for monorepos and workspaces.
+entries: Listing<ConfigEntry>? = null

--- a/npm/vize/pkl/jsonschema/generate.pkl
+++ b/npm/vize/pkl/jsonschema/generate.pkl
@@ -15,6 +15,19 @@ local lintPresetEnum: JsonSchema = new JsonSchema {
   enum = new Listing { "happy-path"; "opinionated"; "essential"; "incremental"; "ecosystem"; "nuxt" }
 }
 
+local stringListDef: JsonSchema = new JsonSchema {
+  type = "array"
+  items = new JsonSchema { type = "string" }
+}
+
+local configExtendsDef: JsonSchema = new JsonSchema {
+  description = "Base config files or presets to compose"
+  oneOf = new Listing {
+    new JsonSchema { type = "string" }
+    stringListDef
+  }
+}
+
 local compilerConfigDef: JsonSchema = new JsonSchema {
   type = "object"
   description = "Vue compiler options"
@@ -594,6 +607,42 @@ local globalTypesConfigDef: JsonSchema = new JsonSchema {
   }
 }
 
+local configEntryDef: JsonSchema = new JsonSchema {
+  type = "object"
+  description = "Scoped Vize config entry for monorepos and workspaces"
+  properties {
+    ["name"] = new JsonSchema {
+      type = "string"
+      description = "Human-readable entry name for inspect output and diagnostics"
+    }
+    ["basePath"] = new JsonSchema {
+      type = "string"
+      description = "Directory used as the base for scoped file patterns and relative paths"
+    }
+    ["files"] = new JsonSchema {
+      type = "array"
+      items = new JsonSchema { type = "string" }
+      description = "Glob patterns this entry applies to"
+    }
+    ["ignores"] = new JsonSchema {
+      type = "array"
+      items = new JsonSchema { type = "string" }
+      description = "Glob patterns this entry excludes"
+    }
+    ["extends"] = configExtendsDef
+    ["compiler"] = new JsonSchema { `$ref` = "#/definitions/CompilerConfig" }
+    ["vite"] = new JsonSchema { `$ref` = "#/definitions/VitePluginConfig" }
+    ["linter"] = new JsonSchema { `$ref` = "#/definitions/LinterConfig" }
+    ["typeChecker"] = new JsonSchema { `$ref` = "#/definitions/TypeCheckerConfig" }
+    ["formatter"] = new JsonSchema { `$ref` = "#/definitions/FormatterConfig" }
+    ["languageServer"] = new JsonSchema { `$ref` = "#/definitions/LanguageServerConfig" }
+    ["lsp"] = new JsonSchema { `$ref` = "#/definitions/LanguageServerConfig" }
+    ["musea"] = new JsonSchema { `$ref` = "#/definitions/MuseaConfig" }
+    ["globalTypes"] = new JsonSchema { `$ref` = "#/definitions/GlobalTypesConfig" }
+  }
+  additionalProperties = false
+}
+
 output {
   value = new JsonSchema {
     `$schema` = "http://json-schema.org/draft-07/schema#"
@@ -614,12 +663,32 @@ output {
       ["MuseaConfig"] = museaConfigDef
       ["GlobalTypeDeclaration"] = globalTypeDeclarationDef
       ["GlobalTypesConfig"] = globalTypesConfigDef
+      ["VizeConfigEntry"] = configEntryDef
     }
     properties {
       ["$schema"] = new JsonSchema {
         type = "string"
         description = "JSON Schema reference for editor autocompletion"
       }
+      ["name"] = new JsonSchema {
+        type = "string"
+        description = "Human-readable entry name for inspect output and diagnostics"
+      }
+      ["basePath"] = new JsonSchema {
+        type = "string"
+        description = "Directory used as the base for scoped file patterns and relative paths"
+      }
+      ["files"] = new JsonSchema {
+        type = "array"
+        items = new JsonSchema { type = "string" }
+        description = "Glob patterns this config applies to"
+      }
+      ["ignores"] = new JsonSchema {
+        type = "array"
+        items = new JsonSchema { type = "string" }
+        description = "Glob patterns this config excludes"
+      }
+      ["extends"] = configExtendsDef
       ["compiler"] = new JsonSchema { `$ref` = "#/definitions/CompilerConfig" }
       ["vite"] = new JsonSchema { `$ref` = "#/definitions/VitePluginConfig" }
       ["linter"] = new JsonSchema { `$ref` = "#/definitions/LinterConfig" }
@@ -629,6 +698,11 @@ output {
       ["lsp"] = new JsonSchema { `$ref` = "#/definitions/LanguageServerConfig" }
       ["musea"] = new JsonSchema { `$ref` = "#/definitions/MuseaConfig" }
       ["globalTypes"] = new JsonSchema { `$ref` = "#/definitions/GlobalTypesConfig" }
+      ["entries"] = new JsonSchema {
+        type = "array"
+        items = new JsonSchema { `$ref` = "#/definitions/VizeConfigEntry" }
+        description = "Scoped config entries for monorepos and workspaces"
+      }
     }
     additionalProperties = false
   }

--- a/npm/vize/pkl/vize.pkl
+++ b/npm/vize/pkl/vize.pkl
@@ -15,6 +15,7 @@ typealias LintPreset = "happy-path" | "opinionated" | "essential" | "incremental
 typealias TrailingComma = "all" | "none" | "es5"
 typealias FilterPattern = String | Listing<String>
 typealias GlobalTypeValue = String | GlobalTypeDeclaration
+typealias ConfigExtends = String | Listing<String>
 
 class CompilerConfig {
   mode: CompilerMode? = null
@@ -139,6 +140,29 @@ class GlobalTypeDeclaration {
   defaultValue: String? = null
 }
 
+class ConfigEntry {
+  name: String? = null
+  basePath: String? = null
+  files: Listing<String>? = null
+  ignores: Listing<String>? = null
+  `extends`: ConfigExtends? = null
+  compiler: CompilerConfig?
+  vite: VitePluginConfig?
+  linter: LinterConfig?
+  typeChecker: TypeCheckerConfig?
+  formatter: FormatterConfig?
+  languageServer: LspConfig?
+  /// Deprecated: use `languageServer`.
+  lsp: LspConfig?
+  musea: MuseaConfig?
+  globalTypes: Mapping<String, GlobalTypeValue>? = null
+}
+
+name: String? = null
+basePath: String? = null
+files: Listing<String>? = null
+ignores: Listing<String>? = null
+`extends`: ConfigExtends? = null
 compiler: CompilerConfig?
 vite: VitePluginConfig?
 linter: LinterConfig?
@@ -149,3 +173,4 @@ languageServer: LspConfig?
 lsp: LspConfig?
 musea: MuseaConfig?
 globalTypes: Mapping<String, GlobalTypeValue>? = null
+entries: Listing<ConfigEntry>? = null

--- a/npm/vize/schemas/vize.config.schema.json
+++ b/npm/vize/schemas/vize.config.schema.json
@@ -619,6 +619,76 @@
           }
         ]
       }
+    },
+    "VizeConfigEntry": {
+      "description": "Scoped Vize config entry for monorepos and workspaces",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "Human-readable entry name for inspect output and diagnostics",
+          "type": "string"
+        },
+        "basePath": {
+          "description": "Directory used as the base for scoped file patterns and relative paths",
+          "type": "string"
+        },
+        "files": {
+          "description": "Glob patterns this entry applies to",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "ignores": {
+          "description": "Glob patterns this entry excludes",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "extends": {
+          "description": "Base config files or presets to compose",
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "compiler": {
+          "$ref": "#/definitions/CompilerConfig"
+        },
+        "vite": {
+          "$ref": "#/definitions/VitePluginConfig"
+        },
+        "linter": {
+          "$ref": "#/definitions/LinterConfig"
+        },
+        "typeChecker": {
+          "$ref": "#/definitions/TypeCheckerConfig"
+        },
+        "formatter": {
+          "$ref": "#/definitions/FormatterConfig"
+        },
+        "languageServer": {
+          "$ref": "#/definitions/LanguageServerConfig"
+        },
+        "lsp": {
+          "$ref": "#/definitions/LanguageServerConfig"
+        },
+        "musea": {
+          "$ref": "#/definitions/MuseaConfig"
+        },
+        "globalTypes": {
+          "$ref": "#/definitions/GlobalTypesConfig"
+        }
+      },
+      "additionalProperties": false
     }
   },
   "title": "VizeConfig",
@@ -628,6 +698,42 @@
     "$schema": {
       "description": "JSON Schema reference for editor autocompletion",
       "type": "string"
+    },
+    "name": {
+      "description": "Human-readable entry name for inspect output and diagnostics",
+      "type": "string"
+    },
+    "basePath": {
+      "description": "Directory used as the base for scoped file patterns and relative paths",
+      "type": "string"
+    },
+    "files": {
+      "description": "Glob patterns this config applies to",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "ignores": {
+      "description": "Glob patterns this config excludes",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "extends": {
+      "description": "Base config files or presets to compose",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      ]
     },
     "compiler": {
       "$ref": "#/definitions/CompilerConfig"
@@ -655,6 +761,13 @@
     },
     "globalTypes": {
       "$ref": "#/definitions/GlobalTypesConfig"
+    },
+    "entries": {
+      "description": "Scoped config entries for monorepos and workspaces",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/VizeConfigEntry"
+      }
     }
   },
   "additionalProperties": false

--- a/npm/vize/src/config.ts
+++ b/npm/vize/src/config.ts
@@ -7,6 +7,8 @@ import { transform } from "oxc-transform";
 import type {
   LanguageServerConfig,
   VizeConfig,
+  VizeConfigEntry,
+  ResolvedVizeConfig,
   LoadConfigOptions,
   UserConfigExport,
   ConfigEnv,
@@ -44,6 +46,10 @@ type CompatVizeConfig = VizeConfig & {
   lsp?: LanguageServerConfig;
 };
 
+type CompatVizeConfigEntry = VizeConfigEntry & {
+  lsp?: LanguageServerConfig;
+};
+
 /**
  * Define a Vize configuration with type checking.
  * Accepts a plain object or a function that receives ConfigEnv.
@@ -58,7 +64,7 @@ export function defineConfig(config: UserConfigExport): UserConfigExport {
 export async function loadConfig(
   root: string,
   options: LoadConfigOptions = {},
-): Promise<VizeConfig | null> {
+): Promise<ResolvedVizeConfig | null> {
   const { mode = "root", configFile, env } = options;
 
   if (mode === "none") {
@@ -80,7 +86,7 @@ export async function loadConfig(
   return loadConfigFromDir(root, env);
 }
 
-async function loadConfigFromDir(dir: string, env?: ConfigEnv): Promise<VizeConfig | null> {
+async function loadConfigFromDir(dir: string, env?: ConfigEnv): Promise<ResolvedVizeConfig | null> {
   for (const name of CONFIG_FILE_NAMES) {
     const filePath = path.join(dir, name);
     if (!fs.existsSync(filePath)) {
@@ -98,7 +104,7 @@ async function loadConfigFromDir(dir: string, env?: ConfigEnv): Promise<VizeConf
 async function loadConfigFromDirAuto(
   startDir: string,
   env?: ConfigEnv,
-): Promise<VizeConfig | null> {
+): Promise<ResolvedVizeConfig | null> {
   let currentDir = path.resolve(startDir);
 
   while (true) {
@@ -116,7 +122,10 @@ async function loadConfigFromDirAuto(
   }
 }
 
-async function loadConfigFile(filePath: string, env?: ConfigEnv): Promise<VizeConfig | null> {
+async function loadConfigFile(
+  filePath: string,
+  env?: ConfigEnv,
+): Promise<ResolvedVizeConfig | null> {
   const absolutePath = path.resolve(filePath);
   if (!fs.existsSync(absolutePath)) {
     return null;
@@ -175,7 +184,7 @@ function findPklBinary(): string | null {
   }
 }
 
-function loadPklConfig(filePath: string): VizeConfig | null {
+function loadPklConfig(filePath: string): ResolvedVizeConfig | null {
   const pklBin = findPklBinary();
   if (!pklBin) {
     console.warn(
@@ -240,10 +249,10 @@ function createPklConfigWithBundledSchemaImports(filePath: string): string | nul
   return tempFile;
 }
 
-async function resolveConfigExport(
+export async function resolveConfigExport(
   exported: UserConfigExport,
   env?: ConfigEnv,
-): Promise<VizeConfig> {
+): Promise<ResolvedVizeConfig> {
   if (typeof exported === "function") {
     return normalizeLoadedConfig(await exported(env ?? DEFAULT_CONFIG_ENV));
   }
@@ -251,7 +260,10 @@ async function resolveConfigExport(
   return normalizeLoadedConfig(exported);
 }
 
-async function loadTypeScriptConfig(filePath: string, env?: ConfigEnv): Promise<VizeConfig> {
+async function loadTypeScriptConfig(
+  filePath: string,
+  env?: ConfigEnv,
+): Promise<ResolvedVizeConfig> {
   const source = fs.readFileSync(filePath, "utf-8");
   const result = await transform(filePath, source, {
     typescript: {
@@ -274,7 +286,7 @@ async function loadTypeScriptConfig(filePath: string, env?: ConfigEnv): Promise<
   }
 }
 
-async function loadESMConfig(filePath: string, env?: ConfigEnv): Promise<VizeConfig> {
+async function loadESMConfig(filePath: string, env?: ConfigEnv): Promise<ResolvedVizeConfig> {
   const module = await importFresh(filePath);
   const exported: UserConfigExport = module.default || module;
   return resolveConfigExport(exported, env);
@@ -286,7 +298,7 @@ async function importFresh(filePath: string): Promise<Record<string, unknown>> {
   return import(fileUrl.href);
 }
 
-function parseJsonConfig(content: string, filePath: string): VizeConfig {
+function parseJsonConfig(content: string, filePath: string): ResolvedVizeConfig {
   try {
     return normalizeLoadedConfig(JSON.parse(content));
   } catch (error) {
@@ -294,9 +306,86 @@ function parseJsonConfig(content: string, filePath: string): VizeConfig {
   }
 }
 
-function normalizeLoadedConfig(config: unknown): VizeConfig {
+function normalizeLoadedConfig(config: unknown): ResolvedVizeConfig {
   const normalized = stripNullish(config);
-  return normalizeConfigAliases((normalized ?? {}) as CompatVizeConfig);
+  if (Array.isArray(normalized)) {
+    return normalizeConfigEntries(normalized as CompatVizeConfigEntry[]);
+  }
+
+  return normalizeConfigObject((normalized ?? {}) as CompatVizeConfig);
+}
+
+function normalizeConfigObject(config: CompatVizeConfig): ResolvedVizeConfig {
+  const { entries: rawEntries, ...rootConfig } = normalizeConfigAliases(config) as VizeConfig & {
+    entries?: CompatVizeConfigEntry[];
+  };
+  const rootEntry = rootConfig as VizeConfigEntry;
+  const entries = [
+    ...(isEmptyConfigEntry(rootEntry) ? [] : [rootEntry]),
+    ...(rawEntries ?? []).map((entry) => normalizeConfigAliases(entry) as VizeConfigEntry),
+  ];
+
+  return {
+    ...rootEntry,
+    entries,
+  };
+}
+
+function normalizeConfigEntries(entries: CompatVizeConfigEntry[]): ResolvedVizeConfig {
+  const normalizedEntries = entries.map(
+    (entry) => normalizeConfigAliases(entry) as VizeConfigEntry,
+  );
+  const globalConfig = mergeConfigEntries(normalizedEntries.filter(isGlobalConfigEntry));
+
+  return {
+    ...globalConfig,
+    entries: normalizedEntries,
+  };
+}
+
+function mergeConfigEntries(entries: VizeConfigEntry[]): VizeConfigEntry {
+  const result: Record<string, unknown> = {};
+  for (const entry of entries) {
+    deepMerge(result, stripEntryMetadata(entry));
+  }
+  return result as VizeConfigEntry;
+}
+
+function stripEntryMetadata(entry: VizeConfigEntry): Partial<VizeConfigEntry> {
+  const { name, basePath, files, ignores, extends: extendsConfig, ...config } = entry;
+  void name;
+  void basePath;
+  void files;
+  void ignores;
+  void extendsConfig;
+  return config;
+}
+
+function deepMerge(target: Record<string, unknown>, source: Record<string, unknown>): void {
+  for (const [key, value] of Object.entries(source)) {
+    if (value === undefined) {
+      continue;
+    }
+
+    const current = target[key];
+    if (isPlainObject(current) && isPlainObject(value)) {
+      deepMerge(current, value);
+    } else {
+      target[key] = value;
+    }
+  }
+}
+
+function isGlobalConfigEntry(entry: VizeConfigEntry): boolean {
+  return entry.basePath === undefined && entry.files === undefined && entry.ignores === undefined;
+}
+
+function isEmptyConfigEntry(entry: VizeConfigEntry): boolean {
+  return Object.keys(entry).length === 0;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function stripNullish(value: unknown): unknown {

--- a/npm/vize/src/index.ts
+++ b/npm/vize/src/index.ts
@@ -29,8 +29,11 @@ export type {
   LintPreset,
   RuleSeverity,
   RuleCategory,
+  VizeConfigEntry,
   LintRuleName,
   LintRulesConfig,
+  UserConfigInput,
+  ResolvedVizeConfig,
 } from "./types/index.js";
 
 // Config utilities
@@ -40,5 +43,6 @@ export {
   VIZE_CONFIG_PKL_SCHEMA_PATH,
   defineConfig,
   loadConfig,
+  resolveConfigExport,
   normalizeGlobalTypes,
 } from "./config.js";

--- a/npm/vize/src/types/generated.ts
+++ b/npm/vize/src/types/generated.ts
@@ -21,6 +21,26 @@ export type RuleCategory = "correctness" | "suspicious" | "style" | "perf" | "a1
  * Configuration file for vize - High-performance Vue.js toolchain
  */
 export interface VizeConfig {
+  /**
+   * Human-readable entry name for inspect output and diagnostics
+   */
+  name?: string;
+  /**
+   * Directory used as the base for scoped file patterns and relative paths
+   */
+  basePath?: string;
+  /**
+   * Glob patterns this config applies to
+   */
+  files?: string[];
+  /**
+   * Glob patterns this config excludes
+   */
+  ignores?: string[];
+  /**
+   * Base config files or presets to compose
+   */
+  extends?: string | string[];
   compiler?: CompilerConfig;
   vite?: VitePluginConfig;
   linter?: LinterConfig;
@@ -30,6 +50,10 @@ export interface VizeConfig {
   lsp?: LanguageServerConfig;
   musea?: MuseaConfig;
   globalTypes?: GlobalTypesConfig;
+  /**
+   * Scoped config entries for monorepos and workspaces
+   */
+  entries?: VizeConfigEntry[];
 }
 /**
  * Vue compiler options
@@ -487,4 +511,38 @@ export interface GlobalTypeDeclaration {
    * Default value
    */
   defaultValue?: string;
+}
+/**
+ * Scoped Vize config entry for monorepos and workspaces
+ */
+export interface VizeConfigEntry {
+  /**
+   * Human-readable entry name for inspect output and diagnostics
+   */
+  name?: string;
+  /**
+   * Directory used as the base for scoped file patterns and relative paths
+   */
+  basePath?: string;
+  /**
+   * Glob patterns this entry applies to
+   */
+  files?: string[];
+  /**
+   * Glob patterns this entry excludes
+   */
+  ignores?: string[];
+  /**
+   * Base config files or presets to compose
+   */
+  extends?: string | string[];
+  compiler?: CompilerConfig;
+  vite?: VitePluginConfig;
+  linter?: LinterConfig;
+  typeChecker?: TypeCheckerConfig;
+  formatter?: FormatterConfig;
+  languageServer?: LanguageServerConfig;
+  lsp?: LanguageServerConfig;
+  musea?: MuseaConfig;
+  globalTypes?: GlobalTypesConfig;
 }

--- a/npm/vize/src/types/index.ts
+++ b/npm/vize/src/types/index.ts
@@ -3,6 +3,7 @@ export type {
   RuleSeverity,
   RuleCategory,
   VizeConfig,
+  VizeConfigEntry,
   CompilerConfig,
   VitePluginConfig,
   LinterConfig,
@@ -25,4 +26,11 @@ export type { LintRuleName, LintRulesConfig } from "./rules.js";
  */
 export type LspConfig = import("./generated.js").LanguageServerConfig;
 
-export type { MaybePromise, ConfigEnv, UserConfigExport, LoadConfigOptions } from "./runtime.js";
+export type {
+  MaybePromise,
+  ConfigEnv,
+  UserConfigInput,
+  UserConfigExport,
+  ResolvedVizeConfig,
+  LoadConfigOptions,
+} from "./runtime.js";

--- a/npm/vize/src/types/runtime.ts
+++ b/npm/vize/src/types/runtime.ts
@@ -1,4 +1,4 @@
-import type { LanguageServerConfig, VizeConfig } from "./generated.js";
+import type { LanguageServerConfig, VizeConfig, VizeConfigEntry } from "./generated.js";
 
 // ============================================================================
 // TS-specific runtime types (cannot be expressed in Pkl)
@@ -20,7 +20,19 @@ export type UserConfig = VizeConfig & {
   lsp?: LanguageServerConfig;
 };
 
-export type UserConfigExport = UserConfig | ((env: ConfigEnv) => MaybePromise<UserConfig>);
+export type UserConfigInput = UserConfig | VizeConfigEntry[];
+
+export type ResolvedVizeConfig = VizeConfig & {
+  /**
+   * Normalized flat entries. Plain object configs become one entry; array configs
+   * keep their order.
+   */
+  entries: VizeConfigEntry[];
+};
+
+export type UserConfigExport =
+  | UserConfigInput
+  | ((env: ConfigEnv) => MaybePromise<UserConfigInput>);
 
 // ============================================================================
 // LoadConfigOptions

--- a/tests/tooling/moonbit-postprocess-types.test.ts
+++ b/tests/tooling/moonbit-postprocess-types.test.ts
@@ -61,7 +61,7 @@ export interface MuseaA11YConfig {}
  * and run json-schema-to-typescript to regenerate this file.
  */
 
-export type LintPreset = "happy-path" | "opinionated" | "essential" | "incremental" | "nuxt";
+export type LintPreset = "happy-path" | "opinionated" | "essential" | "incremental" | "ecosystem" | "nuxt";
 
 export type RuleSeverity = "off" | "warn" | "error";
 

--- a/tools/moon/scripts/postprocess_types.mbtx
+++ b/tools/moon/scripts/postprocess_types.mbtx
@@ -122,7 +122,7 @@ fn postprocess_generated_types(content : String) -> String {
   let marker = "regenerate this file.\n */\n"
   let type_aliases =
     "\n" +
-    "export type LintPreset = \"happy-path\" | \"opinionated\" | \"essential\" | \"incremental\" | \"nuxt\";\n" +
+    "export type LintPreset = \"happy-path\" | \"opinionated\" | \"essential\" | \"incremental\" | \"ecosystem\" | \"nuxt\";\n" +
     "\n" +
     "export type RuleSeverity = \"off\" | \"warn\" | \"error\";\n" +
     "\n" +


### PR DESCRIPTION
## Summary

Part of #591.

- add experimental flat config entry support with normalized `entries` in the shared config loader
- add `vize({ config })` inline config support for Vite Plus runtime configuration
- extend the Pkl schema, JSON Schema, and generated TypeScript config types with `name`, `basePath`, `files`, `ignores`, `extends`, and `entries`
- sync docs with the implemented config priority order and document the inline config boundary

## Validation

- `pnpm --dir npm/vize check`
- `pnpm --dir npm/vite-plugin-vize check`
- `pnpm --dir npm/vite-plugin-vize build`
- `pnpm --dir npm/vize exec vp pack`
- `git diff --check`
- Node smoke check for normalized config entries
- Pkl schema evaluation checks

## Notes

`pnpm --dir npm/vize build` includes the workspace rule type generation task, which ran for several minutes without producing output during this pass. I stopped that broader task and verified the package build surface with `vp pack` directly.