### PR TITLE
docs: add community credits

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,16 @@ This project draws inspiration from
 [Storybook](https://github.com/storybookjs/storybook), and
 [OXC](https://github.com/oxc-project/oxc).
 
+Special thanks to:
+
+- [かっこかり](https://github.com/kakkokari-gtyih) for regular debugging and monitoring around
+  Misskey, including many compiler-focused bug reports.
+- [ushironoko](https://github.com/ushironoko) for compiler, linter, and CLI bug reports,
+  reference implementations, and reproduction repositories.
+- [dannote](https://github.com/dannote) for Elixier ecosystem feedback and pull requests,
+  especially for CSS-facing APIs and fixes.
+- Everyone who has mentioned, shared, tested, or amplified Vize across the community.
+
 ## License
 
 [MIT](./LICENSE)

--- a/docs/content/credits.md
+++ b/docs/content/credits.md
@@ -1,0 +1,21 @@
+---
+title: Credits
+description: People and community feedback that have shaped Vize.
+---
+
+# Credits
+
+Vize is shaped by practical feedback from people using it against real applications, adjacent
+tooling, and ecosystem experiments. In particular, thank you to:
+
+- [かっこかり](https://github.com/kakkokari-gtyih) for regular debugging and monitoring around
+  Misskey, with many reports around compiler behavior and edge cases.
+- [ushironoko](https://github.com/ushironoko) for bug reports from the compiler, linter, and CLI
+  sides of the project, along with reference implementations for fixes and reproduction
+  repositories for difficult issues.
+- [dannote](https://github.com/dannote) for feedback and pull requests from the Elixier ecosystem,
+  especially for CSS-facing APIs and bug fixes.
+
+Thanks also to everyone who has mentioned, shared, tested, or amplified Vize in the community, and
+to everyone connected to that work. Those signals make it easier to see where the toolchain is
+useful, where it breaks, and what it should become next.

--- a/docs/theme/navigation.js
+++ b/docs/theme/navigation.js
@@ -38,6 +38,7 @@ const vizeDocsNavigation = (() => {
     ["/", "Overview"],
     ["/getting-started", "Getting Started"],
     ["/stability", "Stability"],
+    ["/credits", "Credits"],
     ["/guide/configuration", "Configuration"],
     ["/guide/cli", "CLI"],
     ["/guide/vite-plugin", "Vite Plugin"],
@@ -77,7 +78,7 @@ const vizeDocsNavigation = (() => {
   const navGroups = [
     {
       title: "Start",
-      paths: ["/", "/getting-started", "/stability"],
+      paths: ["/", "/getting-started", "/stability", "/credits"],
     },
     {
       title: "Project Setup",

--- a/docs/theme/navigation.test.js
+++ b/docs/theme/navigation.test.js
@@ -231,6 +231,7 @@ void test("applyNavigationOrder keeps the stability contract in Start", () => {
     ["/", "index"],
     ["/getting-started", "Getting Started"],
     ["/stability", "Stability"],
+    ["/credits", "Credits"],
   ]);
 
   applyNavigation(document);
@@ -238,7 +239,7 @@ void test("applyNavigationOrder keeps the stability contract in Start", () => {
   assert.deepEqual(sections(document), [
     {
       title: "Start",
-      labels: ["Overview", "Getting Started", "Stability"],
+      labels: ["Overview", "Getting Started", "Stability", "Credits"],
     },
   ]);
 });


### PR DESCRIPTION
## Summary

- Add community credits to the README.
- Add a dedicated docs Credits page.
- Include the Credits page in the docs Start navigation and cover it in the navigation test.

## Validation

- `node --test docs/theme/navigation.test.js`
- `node --test tests/tooling/readme-boundary.test.ts`
- `vp build` in `docs`
- `git diff --check`