### PR TITLE
fix: resolve options api component bindings

### DIFF
--- a/crates/vize_croquis/src/script_parser.rs
+++ b/crates/vize_croquis/src/script_parser.rs
@@ -362,6 +362,8 @@ pub fn parse_script(source: &str) -> ScriptParseResult {
         source_len,
     );
 
+    process::collect_options_api_component_registrations(&mut result, &ret.program);
+
     // Process all statements
     profile!("croquis.script_plain.walk_statements", {
         for stmt in ret.program.body.iter() {
@@ -495,7 +497,7 @@ mod tests {
 
     #[test]
     fn test_parse_options_api_component_registrations() {
-        let result = parse_script(
+        let output = options_api_parse_snapshot(
             r#"
             import Style from './style.vue'
             import Basic from './basic.vue'
@@ -512,20 +514,64 @@ mod tests {
         "#,
         );
 
-        let registrations: Vec<_> = result
-            .component_registrations
-            .iter()
-            .map(|registration| (registration.name.as_str(), registration.local_name.as_str()))
-            .collect();
+        insta::assert_snapshot!(output);
+    }
 
-        assert_eq!(
-            registrations,
-            vec![
-                ("FourStyle", "Style"),
-                ("Basic", "Basic"),
-                ("string-name", "Basic")
-            ]
+    #[test]
+    fn test_parse_options_api_component_registrations_through_bindings() {
+        let output = options_api_parse_snapshot(
+            r#"
+            import LocalButton from './LocalButton.vue'
+            import SharedBadge from './SharedBadge.vue'
+            import LateCard from './LateCard.vue'
+            import { defineComponent } from 'vue'
+
+            const component = defineComponent(options)
+            const sharedComponents = {
+                SharedBadge,
+            }
+            const components = {
+                ...sharedComponents,
+                PrimaryButton: LocalButton,
+                LocalButton,
+                'late-card': LateCard as any,
+            }
+            const options = {
+                components,
+            }
+
+            export default component
+        "#,
         );
+
+        insta::assert_snapshot!(output);
+    }
+
+    fn options_api_parse_snapshot(source: &str) -> String {
+        let result = parse_script(source);
+        let mut output = String::new();
+
+        output.push_str("=== Component Registrations ===\n");
+        for registration in &result.component_registrations {
+            append!(
+                output,
+                "{} -> {}\n",
+                registration.name,
+                registration.local_name
+            );
+        }
+
+        output.push_str("=== Invalid Exports ===\n");
+        for invalid_export in &result.invalid_exports {
+            append!(
+                output,
+                "{}: {:?}\n",
+                invalid_export.name,
+                invalid_export.kind
+            );
+        }
+
+        output
     }
 
     #[test]

--- a/crates/vize_croquis/src/script_parser/process.rs
+++ b/crates/vize_croquis/src/script_parser/process.rs
@@ -14,8 +14,8 @@ mod bindings;
 mod macros;
 
 use oxc_ast::ast::{
-    Argument, CallExpression, Declaration, ExportDefaultDeclarationKind, Expression,
-    ObjectExpression, ObjectPropertyKind, PropertyKey, Statement,
+    Argument, BindingPattern, CallExpression, Declaration, ExportDefaultDeclarationKind,
+    Expression, ObjectExpression, ObjectPropertyKind, Program, PropertyKey, Statement,
 };
 use oxc_span::GetSpan;
 
@@ -25,7 +25,7 @@ use crate::analysis::{
     TypeExport, TypeExportKind,
 };
 use crate::scope::{BlockKind, BlockScopeData, ClosureScopeData, ExternalModuleScopeData};
-use vize_carton::CompactString;
+use vize_carton::{CompactString, FxHashMap, FxHashSet};
 use vize_relief::BindingType;
 
 use super::ScriptParseResult;
@@ -216,7 +216,7 @@ pub fn process_statement(result: &mut ScriptParseResult, stmt: &Statement<'_>, s
                         // Check if it's a type-only export (export type { ... })
                         if export.export_kind.is_type() {
                             process_type_export(result, decl, stmt.span());
-                        } else {
+                        } else if !result.is_non_setup_script {
                             // Value exports are invalid in script setup
                             process_invalid_export(result, decl, stmt.span());
                         }
@@ -225,11 +225,7 @@ pub fn process_statement(result: &mut ScriptParseResult, stmt: &Statement<'_>, s
             }
         }
 
-        Statement::ExportDefaultDeclaration(export) => {
-            if result.is_non_setup_script {
-                collect_options_api_component_registrations(result, &export.declaration);
-            }
-
+        Statement::ExportDefaultDeclaration(export) if !result.is_non_setup_script => {
             // Default exports are invalid in script setup
             result.invalid_exports.push(InvalidExport {
                 name: CompactString::new("default"),
@@ -283,63 +279,196 @@ pub fn process_statement(result: &mut ScriptParseResult, stmt: &Statement<'_>, s
     }
 }
 
-fn collect_options_api_component_registrations(
+#[derive(Clone, Copy)]
+struct ComponentOptionsRef<'a> {
+    object: &'a ObjectExpression<'a>,
+}
+
+pub(in crate::script_parser) fn collect_options_api_component_registrations(
     result: &mut ScriptParseResult,
-    declaration: &ExportDefaultDeclarationKind<'_>,
+    program: &Program<'_>,
 ) {
-    let Some(options) = component_options_from_export(declaration) else {
-        return;
-    };
+    let mut object_bindings = FxHashMap::default();
+    collect_object_bindings(program, &mut object_bindings);
 
-    let Some(components) = option_object_property(options, "components") else {
-        return;
-    };
+    let mut component_option_bindings = FxHashMap::default();
+    collect_component_options_bindings(program, &mut component_option_bindings);
 
-    for property in &components.properties {
-        let ObjectPropertyKind::ObjectProperty(property) = property else {
-            continue;
-        };
-        if property.computed {
-            continue;
-        }
-
-        let Some(name) = property_key_name(&property.key) else {
+    for statement in program.body.iter() {
+        let Statement::ExportDefaultDeclaration(export) = statement else {
             continue;
         };
 
-        let local_name = if property.shorthand {
-            name
-        } else {
-            let Expression::Identifier(identifier) = &property.value else {
+        let Some(options) =
+            component_options_from_export(&export.declaration, &component_option_bindings)
+        else {
+            continue;
+        };
+        collect_component_registrations_from_options(result, options.object, &object_bindings);
+    }
+}
+
+fn collect_object_bindings<'a>(
+    program: &'a Program<'a>,
+    object_bindings: &mut FxHashMap<&'a str, &'a ObjectExpression<'a>>,
+) {
+    for statement in program.body.iter() {
+        let Statement::VariableDeclaration(declaration) = statement else {
+            continue;
+        };
+
+        for declarator in declaration.declarations.iter() {
+            let BindingPattern::BindingIdentifier(id) = &declarator.id else {
                 continue;
             };
-            identifier.name.as_str()
-        };
+            let Some(init) = declarator.init.as_ref() else {
+                continue;
+            };
+            let Some(object) = object_expression_from_expression(init) else {
+                continue;
+            };
+            object_bindings.insert(id.name.as_str(), object);
+        }
+    }
+}
 
-        result.component_registrations.push(ComponentRegistration {
-            name: CompactString::new(name),
-            local_name: CompactString::new(local_name),
-        });
+fn collect_component_options_bindings<'a>(
+    program: &'a Program<'a>,
+    bindings: &mut FxHashMap<&'a str, ComponentOptionsRef<'a>>,
+) {
+    let mut changed = true;
+
+    while changed {
+        changed = false;
+
+        for statement in program.body.iter() {
+            let Statement::VariableDeclaration(declaration) = statement else {
+                continue;
+            };
+
+            for declarator in declaration.declarations.iter() {
+                let BindingPattern::BindingIdentifier(id) = &declarator.id else {
+                    continue;
+                };
+                if bindings.contains_key(id.name.as_str()) {
+                    continue;
+                }
+                let Some(init) = declarator.init.as_ref() else {
+                    continue;
+                };
+                let Some(options) = component_options_from_expression(init, bindings) else {
+                    continue;
+                };
+
+                bindings.insert(id.name.as_str(), options);
+                changed = true;
+            }
+        }
+    }
+}
+
+fn collect_component_registrations_from_options<'a>(
+    result: &mut ScriptParseResult,
+    options: &'a ObjectExpression<'a>,
+    object_bindings: &FxHashMap<&'a str, &'a ObjectExpression<'a>>,
+) {
+    let Some(components) = option_object_property(options, "components", object_bindings) else {
+        return;
+    };
+
+    let mut seen = FxHashSet::default();
+    collect_component_registrations_from_components_object(
+        result,
+        components,
+        object_bindings,
+        &mut seen,
+        &mut FxHashSet::default(),
+    );
+}
+
+fn collect_component_registrations_from_components_object<'a>(
+    result: &mut ScriptParseResult,
+    components: &'a ObjectExpression<'a>,
+    object_bindings: &FxHashMap<&'a str, &'a ObjectExpression<'a>>,
+    seen: &mut FxHashSet<(CompactString, CompactString)>,
+    visited_spreads: &mut FxHashSet<&'a str>,
+) {
+    for property in &components.properties {
+        match property {
+            ObjectPropertyKind::ObjectProperty(property) => {
+                if property.computed {
+                    continue;
+                }
+
+                let Some(name) = property_key_name(&property.key) else {
+                    continue;
+                };
+
+                let local_name = if property.shorthand {
+                    name
+                } else {
+                    let Some(local_name) = local_name_from_expression(&property.value) else {
+                        continue;
+                    };
+                    local_name
+                };
+
+                let pair = (CompactString::new(name), CompactString::new(local_name));
+                if seen.insert(pair.clone()) {
+                    result.component_registrations.push(ComponentRegistration {
+                        name: pair.0,
+                        local_name: pair.1,
+                    });
+                }
+            }
+            ObjectPropertyKind::SpreadProperty(spread) => {
+                let Expression::Identifier(identifier) = &spread.argument else {
+                    continue;
+                };
+                let name = identifier.name.as_str();
+                if !visited_spreads.insert(name) {
+                    continue;
+                }
+                let Some(object) = object_bindings.get(name).copied() else {
+                    continue;
+                };
+                collect_component_registrations_from_components_object(
+                    result,
+                    object,
+                    object_bindings,
+                    seen,
+                    visited_spreads,
+                );
+            }
+        }
     }
 }
 
 fn component_options_from_export<'a>(
     declaration: &'a ExportDefaultDeclarationKind<'a>,
-) -> Option<&'a ObjectExpression<'a>> {
+    bindings: &FxHashMap<&'a str, ComponentOptionsRef<'a>>,
+) -> Option<ComponentOptionsRef<'a>> {
     match declaration {
-        ExportDefaultDeclarationKind::ObjectExpression(object) => Some(object),
-        ExportDefaultDeclarationKind::CallExpression(call) => component_options_from_call(call),
+        ExportDefaultDeclarationKind::ObjectExpression(object) => Some(ComponentOptionsRef {
+            object: object.as_ref(),
+        }),
+        ExportDefaultDeclarationKind::CallExpression(call) => {
+            component_options_from_call(call, bindings)
+        }
+        ExportDefaultDeclarationKind::Identifier(identifier) => {
+            bindings.get(identifier.name.as_str()).copied()
+        }
         ExportDefaultDeclarationKind::ParenthesizedExpression(parenthesized) => {
-            component_options_from_expression(&parenthesized.expression)
+            component_options_from_expression(&parenthesized.expression, bindings)
         }
         ExportDefaultDeclarationKind::TSAsExpression(ts_as) => {
-            component_options_from_expression(&ts_as.expression)
+            component_options_from_expression(&ts_as.expression, bindings)
         }
         ExportDefaultDeclarationKind::TSSatisfiesExpression(ts_satisfies) => {
-            component_options_from_expression(&ts_satisfies.expression)
+            component_options_from_expression(&ts_satisfies.expression, bindings)
         }
         ExportDefaultDeclarationKind::TSNonNullExpression(ts_non_null) => {
-            component_options_from_expression(&ts_non_null.expression)
+            component_options_from_expression(&ts_non_null.expression, bindings)
         }
         _ => None,
     }
@@ -347,19 +476,25 @@ fn component_options_from_export<'a>(
 
 fn component_options_from_expression<'a>(
     expression: &'a Expression<'a>,
-) -> Option<&'a ObjectExpression<'a>> {
+    bindings: &FxHashMap<&'a str, ComponentOptionsRef<'a>>,
+) -> Option<ComponentOptionsRef<'a>> {
     match expression {
-        Expression::ObjectExpression(object) => Some(object),
-        Expression::CallExpression(call) => component_options_from_call(call),
+        Expression::ObjectExpression(object) => Some(ComponentOptionsRef {
+            object: object.as_ref(),
+        }),
+        Expression::CallExpression(call) => component_options_from_call(call, bindings),
+        Expression::Identifier(identifier) => bindings.get(identifier.name.as_str()).copied(),
         Expression::ParenthesizedExpression(parenthesized) => {
-            component_options_from_expression(&parenthesized.expression)
+            component_options_from_expression(&parenthesized.expression, bindings)
         }
-        Expression::TSAsExpression(ts_as) => component_options_from_expression(&ts_as.expression),
+        Expression::TSAsExpression(ts_as) => {
+            component_options_from_expression(&ts_as.expression, bindings)
+        }
         Expression::TSSatisfiesExpression(ts_satisfies) => {
-            component_options_from_expression(&ts_satisfies.expression)
+            component_options_from_expression(&ts_satisfies.expression, bindings)
         }
         Expression::TSNonNullExpression(ts_non_null) => {
-            component_options_from_expression(&ts_non_null.expression)
+            component_options_from_expression(&ts_non_null.expression, bindings)
         }
         _ => None,
     }
@@ -367,41 +502,109 @@ fn component_options_from_expression<'a>(
 
 fn component_options_from_call<'a>(
     call: &'a CallExpression<'a>,
-) -> Option<&'a ObjectExpression<'a>> {
-    let Expression::Identifier(callee) = &call.callee else {
-        return None;
-    };
-    if !matches!(callee.name.as_str(), "defineComponent" | "_defineComponent") {
+    bindings: &FxHashMap<&'a str, ComponentOptionsRef<'a>>,
+) -> Option<ComponentOptionsRef<'a>> {
+    if !is_define_component_callee(&call.callee) {
         return None;
     }
 
     let first_arg = call.arguments.first()?;
-    component_options_from_argument(first_arg)
+    component_options_from_argument(first_arg, bindings)
 }
 
 fn component_options_from_argument<'a>(
     argument: &'a Argument<'a>,
-) -> Option<&'a ObjectExpression<'a>> {
+    bindings: &FxHashMap<&'a str, ComponentOptionsRef<'a>>,
+) -> Option<ComponentOptionsRef<'a>> {
     match argument {
-        Argument::ObjectExpression(object) => Some(object),
-        Argument::CallExpression(call) => component_options_from_call(call),
+        Argument::ObjectExpression(object) => Some(ComponentOptionsRef {
+            object: object.as_ref(),
+        }),
+        Argument::CallExpression(call) => component_options_from_call(call, bindings),
+        Argument::Identifier(identifier) => bindings.get(identifier.name.as_str()).copied(),
         Argument::ParenthesizedExpression(parenthesized) => {
-            component_options_from_expression(&parenthesized.expression)
+            component_options_from_expression(&parenthesized.expression, bindings)
         }
-        Argument::TSAsExpression(ts_as) => component_options_from_expression(&ts_as.expression),
+        Argument::TSAsExpression(ts_as) => {
+            component_options_from_expression(&ts_as.expression, bindings)
+        }
         Argument::TSSatisfiesExpression(ts_satisfies) => {
-            component_options_from_expression(&ts_satisfies.expression)
+            component_options_from_expression(&ts_satisfies.expression, bindings)
         }
         Argument::TSNonNullExpression(ts_non_null) => {
-            component_options_from_expression(&ts_non_null.expression)
+            component_options_from_expression(&ts_non_null.expression, bindings)
         }
         _ => None,
+    }
+}
+
+fn object_expression_from_expression<'a>(
+    expression: &'a Expression<'a>,
+) -> Option<&'a ObjectExpression<'a>> {
+    match expression {
+        Expression::ObjectExpression(object) => Some(object.as_ref()),
+        Expression::ParenthesizedExpression(parenthesized) => {
+            object_expression_from_expression(&parenthesized.expression)
+        }
+        Expression::TSAsExpression(ts_as) => object_expression_from_expression(&ts_as.expression),
+        Expression::TSSatisfiesExpression(ts_satisfies) => {
+            object_expression_from_expression(&ts_satisfies.expression)
+        }
+        Expression::TSNonNullExpression(ts_non_null) => {
+            object_expression_from_expression(&ts_non_null.expression)
+        }
+        _ => None,
+    }
+}
+
+fn object_expression_from_expression_or_binding<'a>(
+    expression: &'a Expression<'a>,
+    object_bindings: &FxHashMap<&'a str, &'a ObjectExpression<'a>>,
+) -> Option<&'a ObjectExpression<'a>> {
+    match expression {
+        Expression::Identifier(identifier) => {
+            object_bindings.get(identifier.name.as_str()).copied()
+        }
+        _ => object_expression_from_expression(expression),
+    }
+}
+
+fn local_name_from_expression<'a>(expression: &'a Expression<'a>) -> Option<&'a str> {
+    match expression {
+        Expression::Identifier(identifier) => Some(identifier.name.as_str()),
+        Expression::ParenthesizedExpression(parenthesized) => {
+            local_name_from_expression(&parenthesized.expression)
+        }
+        Expression::TSAsExpression(ts_as) => local_name_from_expression(&ts_as.expression),
+        Expression::TSSatisfiesExpression(ts_satisfies) => {
+            local_name_from_expression(&ts_satisfies.expression)
+        }
+        Expression::TSNonNullExpression(ts_non_null) => {
+            local_name_from_expression(&ts_non_null.expression)
+        }
+        _ => None,
+    }
+}
+
+fn is_define_component_callee(callee: &Expression<'_>) -> bool {
+    match callee {
+        Expression::Identifier(callee) => {
+            matches!(callee.name.as_str(), "defineComponent" | "_defineComponent")
+        }
+        Expression::StaticMemberExpression(member) => {
+            matches!(
+                member.property.name.as_str(),
+                "defineComponent" | "_defineComponent"
+            )
+        }
+        _ => false,
     }
 }
 
 fn option_object_property<'a>(
     object: &'a ObjectExpression<'a>,
     key_name: &str,
+    object_bindings: &FxHashMap<&'a str, &'a ObjectExpression<'a>>,
 ) -> Option<&'a ObjectExpression<'a>> {
     object.properties.iter().find_map(|property| {
         let ObjectPropertyKind::ObjectProperty(property) = property else {
@@ -410,10 +613,7 @@ fn option_object_property<'a>(
         if property.computed || property_key_name(&property.key) != Some(key_name) {
             return None;
         }
-        match &property.value {
-            Expression::ObjectExpression(object) => Some(object.as_ref()),
-            _ => None,
-        }
+        object_expression_from_expression_or_binding(&property.value, object_bindings)
     })
 }
 

--- a/crates/vize_croquis/src/snapshots/vize_croquis__script_parser__tests__parse_options_api_component_registrations.snap
+++ b/crates/vize_croquis/src/snapshots/vize_croquis__script_parser__tests__parse_options_api_component_registrations.snap
@@ -1,0 +1,9 @@
+---
+source: crates/vize_croquis/src/script_parser.rs
+expression: output
+---
+=== Component Registrations ===
+FourStyle -> Style
+Basic -> Basic
+string-name -> Basic
+=== Invalid Exports ===

--- a/crates/vize_croquis/src/snapshots/vize_croquis__script_parser__tests__parse_options_api_component_registrations_through_bindings.snap
+++ b/crates/vize_croquis/src/snapshots/vize_croquis__script_parser__tests__parse_options_api_component_registrations_through_bindings.snap
@@ -1,0 +1,10 @@
+---
+source: crates/vize_croquis/src/script_parser.rs
+expression: output
+---
+=== Component Registrations ===
+SharedBadge -> SharedBadge
+PrimaryButton -> LocalButton
+LocalButton -> LocalButton
+late-card -> LateCard
+=== Invalid Exports ===

--- a/crates/vize_patina/src/rules/script/no_options_api.rs
+++ b/crates/vize_patina/src/rules/script/no_options_api.rs
@@ -634,12 +634,7 @@ Vue.createApp({
         let mut result = ScriptLintResult::default();
         rule.check(source, 0, &mut result);
         assert_eq!(result.error_count, 1);
-        assert!(
-            result.diagnostics[0]
-                .labels
-                .iter()
-                .any(|label| label.message.contains("data() option"))
-        );
+        insta::assert_debug_snapshot!(result.diagnostics);
     }
 
     #[test]
@@ -658,12 +653,7 @@ createApp(options).mount("#app")
         let mut result = ScriptLintResult::default();
         rule.check(source, 0, &mut result);
         assert_eq!(result.error_count, 1);
-        assert!(
-            result.diagnostics[0]
-                .labels
-                .iter()
-                .any(|label| label.message.contains("methods option"))
-        );
+        insta::assert_debug_snapshot!(result.diagnostics);
     }
 
     #[test]

--- a/crates/vize_patina/src/rules/script/snapshots/vize_patina__rules__script__no_options_api__tests__invalid_cdn_create_app_options.snap
+++ b/crates/vize_patina/src/rules/script/snapshots/vize_patina__rules__script__no_options_api__tests__invalid_cdn_create_app_options.snap
@@ -1,0 +1,24 @@
+---
+source: crates/vize_patina/src/rules/script/no_options_api.rs
+expression: result.diagnostics
+---
+[
+    LintDiagnostic {
+        rule_name: "script/no-options-api",
+        severity: Error,
+        message: "Options API component declarations are not supported",
+        start: 15,
+        end: 57,
+        help: Some(
+            "Use <script setup> with Composition API. Move props/emits to defineProps()/defineEmits(), lifecycle options to onMounted()/onUnmounted(), and component metadata to defineOptions() when needed.",
+        ),
+        labels: [
+            Label {
+                message: "data() option (use ref()/reactive())",
+                start: 19,
+                end: 23,
+            },
+        ],
+        fix: None,
+    },
+]

--- a/crates/vize_patina/src/rules/script/snapshots/vize_patina__rules__script__no_options_api__tests__invalid_destructured_create_app_options.snap
+++ b/crates/vize_patina/src/rules/script/snapshots/vize_patina__rules__script__no_options_api__tests__invalid_destructured_create_app_options.snap
@@ -1,0 +1,24 @@
+---
+source: crates/vize_patina/src/rules/script/no_options_api.rs
+expression: result.diagnostics
+---
+[
+    LintDiagnostic {
+        rule_name: "script/no-options-api",
+        severity: Error,
+        message: "Options API component declarations are not supported",
+        start: 43,
+        end: 82,
+        help: Some(
+            "Use <script setup> with Composition API. Move props/emits to defineProps()/defineEmits(), lifecycle options to onMounted()/onUnmounted(), and component metadata to defineOptions() when needed.",
+        ),
+        labels: [
+            Label {
+                message: "methods option (use plain functions)",
+                start: 47,
+                end: 54,
+            },
+        ],
+        fix: None,
+    },
+]


### PR DESCRIPTION
Closes #612

## Summary

- Resolve Options API component registrations through exported bindings and `defineComponent(options)` indirection.
- Support `components` objects held in bindings, spreads from object bindings, and TS assertion wrappers around local component values.
- Keep regular `<script>` exports out of `<script setup>` invalid-export diagnostics.
- Replace partial no-options-api assertions with full diagnostic snapshots.

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo test -p vize_croquis --no-default-features`
- `cargo test -p vize_patina no_options_api --no-default-features`
- `cargo test -p vize_canon invalid_exports --no-default-features`
- `cargo clippy -p vize_croquis --no-default-features -- -D warnings`
- `cargo clippy -p vize_patina --no-default-features -- -D warnings`
