### PR TITLE
perf(maestro): parse each SFC once per diagnostic pass

### DIFF
--- a/crates/vize_maestro/src/ide/diagnostics.rs
+++ b/crates/vize_maestro/src/ide/diagnostics.rs
@@ -125,26 +125,26 @@ impl DiagnosticService {
             return diagnostics;
         }
 
-        // Standard SFC processing
-        // Collect parser diagnostics when any diagnostic pipeline is enabled.
-        let sfc_diags = Self::collect_sfc_diagnostics(uri, &content);
-        let has_sfc_parse_error = !sfc_diags.is_empty();
-        tracing::info!("collect: SFC parser diagnostics: {}", sfc_diags.len());
-        diagnostics.extend(sfc_diags);
-        if has_sfc_parse_error {
-            tracing::info!("collect: skipping dependent diagnostics after SFC parse error");
-            return diagnostics;
-        }
+        // Standard SFC processing — parse once and share the descriptor with
+        // every block-level collector below.
+        let descriptor = match Self::parse_sfc_for_collect(uri, &content) {
+            Ok(descriptor) => descriptor,
+            Err(parse_diagnostic) => {
+                tracing::info!("collect: skipping dependent diagnostics after SFC parse error");
+                diagnostics.push(parse_diagnostic);
+                return diagnostics;
+            }
+        };
 
         // Collect parser diagnostics for script and template blocks before
         // dependent analyzers, so broken blocks do not fan out into noisy
         // lint/type/Corsa diagnostics.
-        let script_diags = Self::collect_script_diagnostics(uri, &content);
+        let script_diags = Self::collect_script_diagnostics(uri, &content, &descriptor);
         let has_script_parse_error = !script_diags.is_empty();
         tracing::info!("collect: script parser diagnostics: {}", script_diags.len());
         diagnostics.extend(script_diags);
 
-        let template_diags = Self::collect_template_diagnostics(uri, &content);
+        let template_diags = Self::collect_template_diagnostics(uri, &content, &descriptor);
         let has_template_parse_error = !template_diags.is_empty();
         tracing::info!(
             "collect: template parser diagnostics: {}",
@@ -187,7 +187,7 @@ impl DiagnosticService {
 
         // Also lint inline <art> blocks in regular .vue files
         if features.lint {
-            let inline_art_diags = Self::collect_inline_art_diagnostics(uri, &content);
+            let inline_art_diags = Self::collect_inline_art_diagnostics(uri, &content, &descriptor);
             tracing::info!(
                 "collect: inline art diagnostics: {}",
                 inline_art_diags.len()

--- a/crates/vize_maestro/src/ide/diagnostics/collectors.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/collectors.rs
@@ -12,6 +12,7 @@ use tower_lsp::lsp_types::{
 use oxc_allocator::Allocator as OxcAllocator;
 use oxc_parser::Parser as OxcParser;
 use oxc_span::SourceType;
+use vize_atelier_sfc::SfcDescriptor;
 use vize_carton::config::LinterConfig;
 use vize_patina::{HelpRenderTarget, LintPreset, render_help};
 
@@ -77,17 +78,12 @@ impl DiagnosticService {
     }
 
     /// Collect diagnostics for inline <art> custom blocks in regular .vue files.
-    pub(super) fn collect_inline_art_diagnostics(uri: &Url, content: &str) -> Vec<Diagnostic> {
+    pub(super) fn collect_inline_art_diagnostics(
+        _uri: &Url,
+        content: &str,
+        descriptor: &SfcDescriptor<'_>,
+    ) -> Vec<Diagnostic> {
         use vize_patina::rules::musea::MuseaLinter;
-
-        let options = vize_atelier_sfc::SfcParseOptions {
-            filename: uri.path().to_string().into(),
-            ..Default::default()
-        };
-
-        let Ok(descriptor) = vize_atelier_sfc::parse_sfc(content, options) else {
-            return vec![];
-        };
 
         let mut diagnostics = Vec::new();
 
@@ -211,15 +207,20 @@ impl DiagnosticService {
         diagnostics
     }
 
-    /// Collect SFC parser diagnostics.
-    pub(super) fn collect_sfc_diagnostics(uri: &Url, content: &str) -> Vec<Diagnostic> {
+    /// Parse the SFC once for the diagnostic pipeline, returning either the
+    /// parsed descriptor or a single SFC parser error diagnostic to surface.
+    #[allow(clippy::result_large_err)]
+    pub(super) fn parse_sfc_for_collect<'a>(
+        uri: &Url,
+        content: &'a str,
+    ) -> Result<SfcDescriptor<'a>, Diagnostic> {
         let options = vize_atelier_sfc::SfcParseOptions {
             filename: uri.path().to_string().into(),
             ..Default::default()
         };
 
         match vize_atelier_sfc::parse_sfc(content, options) {
-            Ok(_) => vec![],
+            Ok(descriptor) => Ok(descriptor),
             Err(err) => {
                 let range = if let Some(ref loc) = err.loc {
                     Range {
@@ -236,29 +237,24 @@ impl DiagnosticService {
                     Range::default()
                 };
 
-                vec![Diagnostic {
+                Err(Diagnostic {
                     range,
                     severity: Some(DiagnosticSeverity::ERROR),
                     source: Some(sources::SFC_PARSER.to_string()),
                     #[allow(clippy::disallowed_methods)]
                     message: err.message.to_string(),
                     ..Default::default()
-                }]
+                })
             }
         }
     }
 
     /// Collect template parser diagnostics.
-    pub(super) fn collect_template_diagnostics(uri: &Url, content: &str) -> Vec<Diagnostic> {
-        let options = vize_atelier_sfc::SfcParseOptions {
-            filename: uri.path().to_string().into(),
-            ..Default::default()
-        };
-
-        let Ok(descriptor) = vize_atelier_sfc::parse_sfc(content, options) else {
-            return vec![];
-        };
-
+    pub(super) fn collect_template_diagnostics(
+        _uri: &Url,
+        _content: &str,
+        descriptor: &SfcDescriptor<'_>,
+    ) -> Vec<Diagnostic> {
         let Some(ref template) = descriptor.template else {
             return vec![];
         };
@@ -299,16 +295,11 @@ impl DiagnosticService {
     }
 
     /// Collect script parser diagnostics.
-    pub(super) fn collect_script_diagnostics(uri: &Url, content: &str) -> Vec<Diagnostic> {
-        let options = vize_atelier_sfc::SfcParseOptions {
-            filename: uri.path().to_string().into(),
-            ..Default::default()
-        };
-
-        let Ok(descriptor) = vize_atelier_sfc::parse_sfc(content, options) else {
-            return vec![];
-        };
-
+    pub(super) fn collect_script_diagnostics(
+        _uri: &Url,
+        content: &str,
+        descriptor: &SfcDescriptor<'_>,
+    ) -> Vec<Diagnostic> {
         let mut diagnostics = Vec::new();
 
         if let Some(ref script) = descriptor.script {
@@ -343,15 +334,7 @@ impl DiagnosticService {
             return vec![];
         }
 
-        let options = vize_atelier_sfc::SfcParseOptions {
-            filename: uri.path().to_string().into(),
-            ..Default::default()
-        };
-
         let is_standalone_html = crate::utils::is_standalone_html_path(uri.path());
-        if !is_standalone_html && vize_atelier_sfc::parse_sfc(content, options).is_err() {
-            return vec![];
-        }
 
         // Create linter and lint the full SFC so editor diagnostics match the CLI.
         let preset = linter_config


### PR DESCRIPTION
## Summary

- Replace five independent `parse_sfc` invocations in `DiagnosticService::collect` with a single shared parse.
- Thread the parsed `SfcDescriptor` through `collect_script_diagnostics`, `collect_template_diagnostics`, and `collect_inline_art_diagnostics`.
- Drop the defensive redundant parse inside `collect_lint_diagnostics` — the top-level parse already validates the file.
- On a parser error, surface exactly one SFC parser diagnostic and short-circuit (same behavior as before).

## Why

LSP diagnostics fire on every `did_open` and `did_change`. The previous flow re-parsed the same SFC source four times for the in-process collectors (sfc → script → template → lint validation → inline art), plus once more inside `vize_patina`. For non-trivial SFCs this is straight wasted CPU on the editor hot path. Each parse is small (single-digit µs in our bench), but four extras per keystroke add up, especially on larger files where parsing scales linearly.

## Test plan

- [x] \`cargo test -p vize_maestro\` (229 passed)
- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo clippy --workspace --no-deps -- -D warnings\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)