### PR TITLE
docs: fix broken links to stability guide

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -35,7 +35,7 @@ The project uses a lazy-consensus model:
    - an issue or RFC-style discussion before the PR,
    - sign-off from the surface owner listed in the release checklist,
    - a release note that mentions the change under the appropriate SemVer
-     level (see [`docs/release/stability.md`](./docs/release/stability.md)).
+     level (see [`docs/content/stability.md`](./docs/content/stability.md)).
 3. Releases follow [`docs/release/v1-alpha-go-no-go.md`](./docs/release/v1-alpha-go-no-go.md).
    The release captain has final go/no-go authority.
 4. Security issues follow [`SECURITY.md`](./SECURITY.md) and are handled

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -3,7 +3,7 @@
 Vize is still pre-1.0; the surfaces that are ready for adopters and the ones
 that are not are listed in
 [`docs/release/production-readiness.md`](./docs/release/production-readiness.md)
-and [`docs/release/stability.md`](./docs/release/stability.md). Please check
+and [`docs/content/stability.md`](./docs/content/stability.md). Please check
 those before opening a support thread.
 
 ## Where to ask


### PR DESCRIPTION
## Summary

- `GOVERNANCE.md` and `SUPPORT.md` both linked to `./docs/release/stability.md`, which does not exist.
- The actual file is `docs/content/stability.md`, which `README.md` already references correctly.
- Repoint both stale links to the existing path.

## Test plan

- [x] `ls docs/content/stability.md` confirms the target exists
- [x] `rg -n "docs/release/stability\.md"` returns no more references after the change