### PR TITLE
fix(cli): prefix musea new error messages consistently

### DIFF
--- a/crates/vize/src/commands/musea.rs
+++ b/crates/vize/src/commands/musea.rs
@@ -208,7 +208,7 @@ fn run_new(args: NewArgs) {
     // Create art directory structure
     let stories_dir = target_dir.join("stories");
     if let Err(e) = fs::create_dir_all(&stories_dir) {
-        eprintln!("Error creating stories directory: {}", e);
+        eprintln!("vize musea new: failed to create stories directory: {}", e);
         std::process::exit(1);
     }
 
@@ -243,7 +243,7 @@ import Button from '../src/Button.vue'
 "#;
 
     if let Err(e) = fs::write(&example_story, example_content) {
-        eprintln!("Error creating example story: {}", e);
+        eprintln!("vize musea new: failed to create example story: {}", e);
         std::process::exit(1);
     }
 
@@ -259,7 +259,7 @@ export default defineConfig({
 })
 "#;
         if let Err(e) = fs::write(&config_path, config_content) {
-            eprintln!("Error creating vize.config.ts: {}", e);
+            eprintln!("vize musea new: failed to create vize.config.ts: {}", e);
             std::process::exit(1);
         }
         eprintln!("  Created vize.config.ts");


### PR DESCRIPTION
## Summary

`vize musea new` reported three errors as plain `Error creating ...:` while every other line in the same file — both the `musea serve` paths and the `new` subcommand's progress output (`vize musea new: Creating Musea project ...`) — uses the `vize musea[ new]: ...` prefix. Align the three error paths so users can grep for `vize musea new:` to find all output from this subcommand.

Before:

```
Error creating stories directory: <io error>
Error creating example story: <io error>
Error creating vize.config.ts: <io error>
```

After:

```
vize musea new: failed to create stories directory: <io error>
vize musea new: failed to create example story: <io error>
vize musea new: failed to create vize.config.ts: <io error>
```

## Test plan

- [x] `cargo build -p vize`
- [x] `cargo test -p vize --lib commands::musea` (4 passed)