### PR TITLE
docs(patina): fix 'a' vs 'an' typo in require-vapor-attribute doc

### DIFF
--- a/crates/vize_patina/src/rules/opinionated/vapor/require_vapor_attribute.rs
+++ b/crates/vize_patina/src/rules/opinionated/vapor/require_vapor_attribute.rs
@@ -2,7 +2,7 @@
 //!
 //! Suggest adding the vapor attribute to script setup blocks.
 //!
-//! This is a informational rule that helps identify components that
+//! This is an informational rule that helps identify components that
 //! could be migrated to Vapor mode. Components with `<script setup>`
 //! are candidates for Vapor mode optimization.
 //!


### PR DESCRIPTION
## Summary

The module-level doc comment for the `vapor/require-vapor-attribute` rule read "This is **a** informational rule". Fix the article so it reads "**an** informational rule".

## Test plan

- [x] Doc-comment-only change; no build needed.