### PR TITLE
fix(ci): restore main check workflow

### DIFF
--- a/crates/vize_canon/src/batch/executor.rs
+++ b/crates/vize_canon/src/batch/executor.rs
@@ -12,7 +12,7 @@ use super::import_rewriter::ImportRewriter;
 use super::type_checker::{
     DeclarationEmitOptions, DeclarationEmitResult, DeclarationOutput, TypeCheckResult,
 };
-use super::virtual_project::VirtualProject;
+use super::virtual_project::{AUTO_IMPORT_STUBS_FILE, VUE_MODULE_STUBS_FILE, VirtualProject};
 use crate::{
     corsa_client::CorsaProjectClient,
     file_uri::path_to_file_uri,
@@ -260,6 +260,9 @@ fn collect_virtual_file_uris(virtual_root: &Path) -> CorsaResult<Vec<String>> {
         if !path.is_file() {
             continue;
         }
+        if is_internal_virtual_project_stub(path) {
+            continue;
+        }
         if let Some("ts" | "tsx") = path.extension().and_then(|extension| extension.to_str()) {
             uris.push(path_to_file_uri(path));
         }
@@ -267,6 +270,12 @@ fn collect_virtual_file_uris(virtual_root: &Path) -> CorsaResult<Vec<String>> {
 
     uris.sort();
     Ok(uris)
+}
+
+fn is_internal_virtual_project_stub(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| matches!(name, AUTO_IMPORT_STUBS_FILE | VUE_MODULE_STUBS_FILE))
 }
 
 fn collect_declaration_outputs(out_dir: &Path) -> CorsaResult<Vec<DeclarationOutput>> {
@@ -387,6 +396,8 @@ mod tests {
 
         fs::write(root.join("index.ts"), "").unwrap();
         fs::write(root.join("component.vue.ts"), "").unwrap();
+        fs::write(root.join("__vize_vue_modules.d.ts"), "").unwrap();
+        fs::write(root.join("__vize_auto_imports.d.ts"), "").unwrap();
         fs::write(root.join("tsconfig.json"), "{}").unwrap();
         fs::write(root.join("ignored.js"), "").unwrap();
 

--- a/crates/vize_canon/src/batch/virtual_project.rs
+++ b/crates/vize_canon/src/batch/virtual_project.rs
@@ -28,8 +28,8 @@ use vize_carton::{
     Bump, FxHashMap, FxHashSet, String as CompactString, ToCompactString, cstr, profile,
 };
 
-const AUTO_IMPORT_STUBS_FILE: &str = "__vize_auto_imports.d.ts";
-const VUE_MODULE_STUBS_FILE: &str = "__vize_vue_modules.d.ts";
+pub(super) const AUTO_IMPORT_STUBS_FILE: &str = "__vize_auto_imports.d.ts";
+pub(super) const VUE_MODULE_STUBS_FILE: &str = "__vize_vue_modules.d.ts";
 const PATH_SENSITIVE_COMPILER_OPTIONS: &[&str] = &[
     "baseUrl",
     "paths",

--- a/flake.nix
+++ b/flake.nix
@@ -60,7 +60,7 @@
               };
               coreSrc = pkgs.fetchurl {
                 url = "https://cli.moonbitlang.com/cores/core-latest.tar.gz";
-                hash = "sha256-29JAjdJqvXh3XN/JeyQ4gzhFwsLPlTSnoP0dthW4s+g=";
+                hash = "sha256-nfVjWYUgPMFpV6dJAPwCLxbVlJGAMr7vpgdOaBwXGMk=";
               };
               nativeBuildInputs = lib.optionals pkgs.stdenv.isLinux [ pkgs.patchelf ];
               dontUnpack = true;


### PR DESCRIPTION
## Summary

- update the pinned MoonBit core tarball hash used by the Nix flake
- skip generated internal virtual-project stubs when collecting Corsa diagnostic targets

## Root cause

The latest main `Check` run failed in two places:

- `nix-flake`: `core-latest.tar.gz` changed upstream, so the fixed-output derivation hash in `flake.nix` no longer matched.
- `source-coverage`: Corsa diagnostics were requested for `__vize_vue_modules.d.ts`, an internal generated stub that is not mapped back to user source and should not be part of the diagnostic fetch set. The LSP fallback hit a protocol parse error on that stub under coverage.

## Validation

- `cargo fmt --all`
- `cargo test -p vize_canon batch::executor::tests::collects_virtual_type_script_files_only`
- `cargo test -p vize --test check_cli check_declaration_emit_uses_tsconfig_options -- --nocapture`
- `cargo llvm-cov -p vize --test check_cli --no-report -- --nocapture`
- `cargo llvm-cov --workspace --json --summary-only --output-path target/llvm-cov/source-summary.json --fail-under-lines 70 --fail-under-functions 70 --fail-under-regions 70`
- `node tools/coverage/enforce-rust-source-coverage.mjs --json target/llvm-cov/source-summary.json --min-lines 70 --min-functions 70 --min-regions 70`
- `nix build .#moonbit --no-link`
- `nix flake check --all-systems --no-build`