### PR TITLE
docs(vite-plugin): use absolute URL for Shared Config link in README

### DIFF
--- a/npm/vite-plugin-vize/README.md
+++ b/npm/vite-plugin-vize/README.md
@@ -18,7 +18,7 @@ Install `vp` once from the [Vite+ install guide](https://viteplus.dev/guide/inst
 vp install -D @vizejs/vite-plugin
 ```
 
-Add `vize` as a direct dependency only if your project imports shared config helpers from `"vize"` (see [Shared Config](../docs/content/guide/vite-plugin.md#shared-config)).
+Add `vize` as a direct dependency only if your project imports shared config helpers from `"vize"` (see [Shared Config](https://github.com/ubugeeei/vize/blob/main/docs/content/guide/vite-plugin.md#shared-config)).
 
 ## Usage
 


### PR DESCRIPTION
## Summary

The README at `npm/vite-plugin-vize/README.md` linked to `../docs/content/guide/vite-plugin.md`, but the README lives one extra level deep (`npm/vite-plugin-vize/`), so the relative path resolves to `npm/docs/...` — a directory that does not exist. The link is broken on GitHub and also doesn't work once the package is on npm (where relative paths to the source repo never resolve).

Switch to the absolute `github.com/ubugeeei/vize/blob/main/...` URL convention already used by `npm/musea-mcp-server/README.md` so the link works in both contexts.

## Test plan

- [x] Verified `docs/content/guide/vite-plugin.md` exists at the new absolute URL's target
- [x] Confirmed no other npm READMEs have the same `../docs/...` pattern (`rg '\(\.\./docs' npm/`)