### PR TITLE
docs: standardize fenced code-block language tags

### DIFF
--- a/docs/content/guide/comment-annotations.md
+++ b/docs/content/guide/comment-annotations.md
@@ -206,7 +206,7 @@ const { count } = inject("state");
 
 ### Invalid Examples
 
-```typescript
+```ts
 // @vize forget
 const { count } = inject("state");
 // ^ Error: requires a reason

--- a/docs/content/guide/vite-plugin.md
+++ b/docs/content/guide/vite-plugin.md
@@ -263,7 +263,7 @@ For Nuxt compatibility, the plugin isolates `define` values per Vite environment
 
 The plugin exposes a compatibility shim for tools that probe for `@vitejs/plugin-vue`'s API (like Nuxt). This means Vize works with Nuxt's built-in Vue integration without special configuration:
 
-```typescript
+```ts
 // nuxt.config.ts — using the dedicated Nuxt module
 export default defineNuxtConfig({
   modules: ["@vizejs/nuxt"],

--- a/docs/content/integrations/nuxt.md
+++ b/docs/content/integrations/nuxt.md
@@ -27,7 +27,7 @@ vp install vize
 
 ### 2. Register the Nuxt Module
 
-```typescript
+```ts
 // nuxt.config.ts
 export default defineNuxtConfig({
   modules: ["@vizejs/nuxt"],
@@ -56,7 +56,7 @@ as `%40fs/` and encoded `assets/` paths while dropping decoded null-byte or trav
 `@vizejs/nuxt` keeps the simple `compiler: true | false` switch, but the module options also expose
 the Vize compiler and Nuxt compatibility bridges for projects that need tighter control:
 
-```typescript
+```ts
 // nuxt.config.ts
 export default defineNuxtConfig({
   modules: ["@vizejs/nuxt"],
@@ -107,7 +107,7 @@ export default defineNuxtConfig({
 
 Alternatively, you can use the Vite plugin directly. Since Nuxt uses Vite under the hood, this works but lacks some Nuxt-specific optimizations:
 
-```typescript
+```ts
 // nuxt.config.ts
 import vize from "@vizejs/vite-plugin";
 
@@ -122,7 +122,7 @@ export default defineNuxtConfig({
 
 The Nuxt module also supports Musea (component gallery) integration:
 
-```typescript
+```ts
 // nuxt.config.ts
 export default defineNuxtConfig({
   modules: ["@vizejs/nuxt"],
@@ -147,7 +147,7 @@ When configured, the Musea gallery is available at `/__musea__/` during developm
 
 Nuxt projects often use features that need to be mocked in the Musea preview environment (vue-i18n, NuxtLink, useNuxtApp, etc.):
 
-```typescript
+```ts
 // musea.preview.ts
 import { createI18n } from "vue-i18n";
 import { createRouter, createMemoryHistory } from "vue-router";
@@ -205,7 +205,7 @@ When the Nuxt module is installed:
 
 The [Vue Fes Japan 2026](https://vuefes.jp/2026) conference website uses Vize with Nuxt 4:
 
-```typescript
+```ts
 // nuxt.config.ts
 export default defineNuxtConfig({
   modules: ["@vizejs/nuxt"],

--- a/docs/release/supply-chain.md
+++ b/docs/release/supply-chain.md
@@ -38,7 +38,7 @@ You need [`cosign`](https://docs.sigstore.dev/system_config/installation/) on
 `create-github-release` job in `.github/workflows/release.yml` on the
 `ubugeeei/vize` repository.
 
-```sh
+```bash
 # Verify a CLI tarball
 cosign verify-blob \
   --bundle vize-x86_64-unknown-linux-gnu.tar.gz.cosign.bundle \
@@ -49,7 +49,7 @@ cosign verify-blob \
 
 Same call works for the SBOM:
 
-```sh
+```bash
 cosign verify-blob \
   --bundle vize-<tag>-cyclonedx.sbom.json.cosign.bundle \
   --certificate-identity-regexp 'https://github.com/ubugeeei/vize/.+' \


### PR DESCRIPTION
## Summary

Three doc files used the long-form \`typescript\` tag (8 fences across `docs/content/integrations/nuxt.md`, `docs/content/guide/comment-annotations.md`, `docs/content/guide/vite-plugin.md`) while the rest of the docs use \`ts\` (35+ fences). Likewise `docs/release/supply-chain.md` used \`sh\` (2 fences) where the docs otherwise use \`bash\` (60+ fences). Convert the outliers so all fenced code blocks use the dominant tag — which also matches the highlighter configuration.

Counts before:
| Tag | Files |
| --- | --- |
| ` ```ts ` | many (dominant) |
| ` ```typescript ` | 8 |
| ` ```bash ` | many (dominant) |
| ` ```sh ` | 2 |

Counts after: zero ` ```typescript ` and zero ` ```sh ` fences remain.

## Test plan

- [x] `rg -n '^\`\`\`(typescript|sh)$' docs/` returns no matches after the change
- [x] Diff only touches the fence lines themselves (10 lines across 4 files)