### PR TITLE
chore(cargo): drop trailing periods from crate descriptions

### DIFF
--- a/crates/vize_croquis/Cargo.toml
+++ b/crates/vize_croquis/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
-description = "Croquis - Semantic analysis layer for Vize. Quick sketches of meaning from Vue templates."
+description = "Croquis - Semantic analysis layer for Vize. Quick sketches of meaning from Vue templates"
 
 [dependencies]
 vize_carton.workspace = true

--- a/crates/vize_croquis_cf/Cargo.toml
+++ b/crates/vize_croquis_cf/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
-description = "Cross-file semantic analysis for Vize Croquis."
+description = "Cross-file semantic analysis for Vize Croquis"
 
 [dependencies]
 vize_carton.workspace = true


### PR DESCRIPTION
## Summary

16 of the 18 workspace crate descriptions in `crates/*/Cargo.toml` omit a trailing period; only `vize_croquis` and `vize_croquis_cf` carried one. Align both with the workspace convention so crates.io and `cargo metadata` output read consistently.

```diff
-description = "Croquis - Semantic analysis layer for Vize. Quick sketches of meaning from Vue templates."
+description = "Croquis - Semantic analysis layer for Vize. Quick sketches of meaning from Vue templates"
```

```diff
-description = "Cross-file semantic analysis for Vize Croquis."
+description = "Cross-file semantic analysis for Vize Croquis"
```

## Test plan

- [x] `rg '^description = ' crates/*/Cargo.toml` — every line now lacks a trailing period
- [x] No code change, no build needed