### PR TITLE
chore(npm): add repository.directory to remaining workspace packages

### DIFF
--- a/npm/fresco-native/package.json
+++ b/npm/fresco-native/package.json
@@ -18,7 +18,8 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/ubugeeei/vize"
+    "url": "https://github.com/ubugeeei/vize",
+    "directory": "npm/fresco-native"
   },
   "files": [
     "index.js",

--- a/npm/vize-native/package.json
+++ b/npm/vize-native/package.json
@@ -17,7 +17,8 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/ubugeeei/vize"
+    "url": "https://github.com/ubugeeei/vize",
+    "directory": "npm/vize-native"
   },
   "files": [
     "index.js",

--- a/npm/vize/package.json
+++ b/npm/vize/package.json
@@ -18,7 +18,8 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/ubugeeei/vize"
+    "url": "https://github.com/ubugeeei/vize",
+    "directory": "npm/vize"
   },
   "bin": {
     "vize": "bin/vize"

--- a/npm/vscode-art/package.json
+++ b/npm/vscode-art/package.json
@@ -13,7 +13,8 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/ubugeeei/vize"
+    "url": "https://github.com/ubugeeei/vize",
+    "directory": "npm/vscode-art"
   },
   "publisher": "vize",
   "main": "./out/extension.js",

--- a/npm/vscode-vize/package.json
+++ b/npm/vscode-vize/package.json
@@ -23,7 +23,8 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/ubugeeei/vize"
+    "url": "https://github.com/ubugeeei/vize",
+    "directory": "npm/vscode-vize"
   },
   "publisher": "ubugeeei",
   "main": "./dist/extension.cjs",


### PR DESCRIPTION
## Summary

10 of the 15 packages under `npm/` already declared `repository.directory` so npm registry pages can link straight to the package source inside the monorepo. The other 5 omitted it:

- `npm/fresco-native`
- `npm/vize-native`
- `npm/vize`
- `npm/vscode-art`
- `npm/vscode-vize`

Add `directory` to each so every published package follows the same monorepo discovery convention (recommended by [npm docs](https://docs.npmjs.com/cli/v10/configuring-npm/package-json#repository) for monorepo packages).

## Test plan

- [x] `jq -e '.repository.directory' npm/*/package.json` returns a path for every package
- [x] No script or build changes; metadata only