### PR TITLE
fix(ci): update moonbit linux x86_64 hash to current upstream

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -39,7 +39,7 @@
           x86_64-linux = {
             version = "0.9.3-2026-05-22";
             url = "https://cli.moonbitlang.com/binaries/latest/moonbit-linux-x86_64.tar.gz";
-            hash = "sha256-ZwrAmmo6ZAC8lmeFbeZwXd7AqXzjvUwZxMOAtwfmhWw=";
+            hash = "sha256-Beq5o8g6pV8bm16LnClAHhM7O9nI098jwin6ADAZMLY=";
           };
           aarch64-linux = {
             version = "0.9.3-2026-05-22";


### PR DESCRIPTION
## Summary

`flake.nix` pins three moonbit toolchain binaries by SRI hash against the `cli.moonbitlang.com/binaries/latest/...` URLs. Upstream rebuilt the linux x86_64 binary after the last pin landed, so `nix flake check` on linux now fails on main:

```
error: build of '/nix/store/6rr34xxc2my1xcpwiv7zlx48lxiz46xm-moonbit-linux-x86_64.tar.gz.drv^*' failed:
hash mismatch in fixed-output derivation
         specified: sha256-ZwrAmmo6ZAC8lmeFbeZwXd7AqXzjvUwZxMOAtwfmhWw=
            got:    sha256-Beq5o8g6pV8bm16LnClAHhM7O9nI098jwin6ADAZMLY=
```

(Seen on https://github.com/ubugeeei/vize/actions/runs/26403590550 — the post-v0.131.0 main check.)

Adopt the new hash so main's `nix-flake` job passes again. The darwin and linux aarch64 pins are left as-is since the CI runs against them still pass — `latest` only rotated the linux x86_64 build.

## Test plan

- [x] Hash taken from the CI error's `got:` field, not synthesized
- [x] Diff is a single one-line hash change