### PR TITLE
fix(ci): add libLLVM.so.18.1 to moonbit rpath on linux

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -81,6 +81,10 @@
                             pkgs.glibc
                             pkgs.stdenv.cc.cc.lib
                             pkgs.zlib
+                            # `moonc` started dynamically linking libLLVM.so.18.1
+                            # in the latest upstream binary; keep it on the rpath
+                            # so the patched ELF can resolve it.
+                            pkgs.llvmPackages_18.libllvm.lib
                           ]
                         }" \
                         "$binary"


### PR DESCRIPTION
## Summary

After the upstream linux x86_64 hash bump in #629, `moonc` fails on the nix-flake CI job with:

```
error while loading shared libraries: libLLVM.so.18.1:
cannot open shared object file: No such file or directory
```

(Latest occurrence: https://github.com/ubugeeei/vize/actions/runs/26404664267/job/77725043714.)

The new upstream binary dynamically links against libLLVM 18.1, but the flake's patchelf invocation only sets rpath entries for glibc, the stdenv runtime, and zlib. Add `pkgs.llvmPackages_18.libllvm.lib` to the rpath so the patched `moonc` binary can resolve libLLVM at runtime on linux.

Verified locally that `llvmPackages_18.libllvm.lib` resolves to a real store path containing the `libLLVM.so.18.1` SONAME.

## Test plan

- [x] Diff is a single rpath addition with a comment explaining the new upstream linkage
- [ ] Validated by the post-merge `nix-flake` job on main (this job is intentionally skipped on PRs per check.yml)