### PR TITLE
chore(ci): add actrun local workflow config

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,19 @@ cargo test -p <crate>
 
 Before opening a PR that changes shared tooling, release automation, native bindings, or compiler behavior, run the relevant workspace task from CI locally when practical.
 
+For GitHub Actions changes, use `actrun` to lint or preview the workflow graph before pushing:
+
+```sh
+actrun lint .github/workflows/check.yml
+actrun workflow run .github/workflows/check.yml --dry-run
+```
+
+When a focused job is practical on your machine, run it locally before opening the PR:
+
+```sh
+actrun workflow run .github/workflows/check.yml --job check-js
+```
+
 ## Language Processor Change Discipline
 
 Vize follows compiler-project practice from rustc, TypeScript, TypeScript-Go, and Flow: classify the

--- a/actrun.toml
+++ b/actrun.toml
@@ -1,0 +1,32 @@
+# Local GitHub Actions runner configuration.
+#
+# The workflow files remain the source of truth. This config trims cloud-only
+# setup, cache, and artifact steps so local runs exercise the repository
+# commands with the host toolchain inside an isolated git worktree.
+
+workspace_mode = "worktree"
+include_dirty = true
+trust_actions = true
+nix_mode = "off"
+
+local_skip_actions = [
+  "actions/checkout",
+  "actions/setup-node",
+  "actions/setup-python",
+  "actions/setup-go",
+  "actions/cache",
+  "actions/upload-artifact",
+  "actions/download-artifact",
+  "./.github/actions/setup-moonbit",
+  "actions-rust-lang/setup-rust-toolchain",
+  "cachix/install-nix-action",
+  "dtolnay/rust-toolchain",
+  "ilammy/msvc-dev-cmd",
+  "nix-community/cache-nix-action",
+  "Swatinem/rust-cache",
+  "taiki-e/install-action",
+  "voidzero-dev/setup-vp",
+]
+
+[lint]
+preset = "default"


### PR DESCRIPTION
## Summary

- add `actrun.toml` for local GitHub Actions runs
- skip cloud-only setup, cache, and artifact actions locally
- document the focused `actrun` commands contributors can run before pushing workflow changes

## Change Class

- [ ] Parser or AST
- [ ] Compiler and codegen
- [ ] Semantic analysis, lint, and cross-file analysis
- [ ] Virtual TypeScript and type checking
- [ ] Formatter and LSP
- [ ] Runtime packaging, release, or docs
- [x] Not language-facing

## Behavior Reference

Local CI workflow only; the GitHub Actions workflow files remain the source of truth.

## Verification Evidence

- [x] `actrun lint .github/workflows/check.yml`
- [x] `actrun workflow run .github/workflows/check.yml --dry-run`
- [x] `actrun workflow run .github/workflows/check.yml --job check-js`
- [ ] Minimal fixture or focused regression test added or updated
- [ ] Snapshot/baseline changes reviewed and explained
- [ ] Parity or real-world fixture coverage considered
- [ ] Security/audit impact considered
- [ ] Performance status or PR benchmark impact considered
- [ ] Fuzzing target or crash-reproducer coverage considered
- [ ] Editor/LSP scenario coverage considered
- [ ] Ecosystem or broad app compatibility impact considered
- [x] Docs, release, or stability notes updated when public behavior changed

## Risk

Low. This only affects local `actrun` usage and contributor documentation; hosted Actions keep using the existing workflow definitions.