### PR TITLE
chore(ci): add vp actrun task

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,13 +30,14 @@ Before opening a PR that changes shared tooling, release automation, native bind
 For GitHub Actions changes, use `actrun` to lint or preview the workflow graph before pushing:
 
 ```sh
-actrun lint .github/workflows/check.yml
-actrun workflow run .github/workflows/check.yml --dry-run
+vp run actrun
 ```
 
-When a focused job is practical on your machine, run it locally before opening the PR:
+The aggregate task wraps the focused local Actions check:
 
 ```sh
+actrun lint .github/workflows/check.yml
+actrun workflow run .github/workflows/check.yml --dry-run
 actrun workflow run .github/workflows/check.yml --job check-js
 ```
 

--- a/tools/vite-plus/tasks/check.ts
+++ b/tools/vite-plus/tasks/check.ts
@@ -33,6 +33,11 @@ const ciVizeAppCheckCommand = [
     "vp check src 'e2e/*.ts' 'e2e/vrt/*.ts' vite.config.ts vite.app.config.ts vite.test.config.ts vite.node.config.ts playwright.config.ts && vize lint --max-warnings 0",
   ),
 ].join(" && ");
+const localActrunCommand = [
+  "actrun lint .github/workflows/check.yml",
+  "actrun workflow run .github/workflows/check.yml --dry-run",
+  "actrun workflow run .github/workflows/check.yml --job check-js",
+].join(" && ");
 
 /**
  * Repository-wide formatting, linting, package checks, and CI aggregate tasks.
@@ -77,5 +82,6 @@ export const checkTasks = defineTasks({
   "lint:rust": task("cargo clippy --workspace -- -D warnings", { input: cacheInputs.rust }),
   "lint:all": noCacheTask(runTasks("lint:rust", "check")),
   "fmt:check": noCacheTask(runTask("check")),
+  actrun: noCacheTask(localActrunCommand),
   ci: noCacheTask(runTasks("fmt:all", "clippy", "test", "check:ci")),
 });


### PR DESCRIPTION
## Summary
- add a root Vite+ task named `actrun`
- wire the task to lint `.github/workflows/check.yml`, preview the workflow graph, and run the focused `check-js` job locally
- document `vp run actrun` as the GitHub Actions local check entrypoint

## Validation
- `vp run actrun`
- `vp check tools/vite-plus/tasks/check.ts`
- `git diff --check`