### PR TITLE
chore(ci): split actrun tasks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,6 +41,14 @@ actrun workflow run .github/workflows/check.yml --dry-run
 actrun workflow run .github/workflows/check.yml --job check-js
 ```
 
+To run focused jobs independently, use the split Vite+ tasks:
+
+```sh
+vp run actrun:lint
+vp run actrun:dry-run
+vp run actrun:job --job check-js
+```
+
 ## Language Processor Change Discipline
 
 Vize follows compiler-project practice from rustc, TypeScript, TypeScript-Go, and Flow: classify the

--- a/tools/vite-plus/tasks/check.ts
+++ b/tools/vite-plus/tasks/check.ts
@@ -34,9 +34,9 @@ const ciVizeAppCheckCommand = [
   ),
 ].join(" && ");
 const localActrunCommand = [
-  "actrun lint .github/workflows/check.yml",
-  "actrun workflow run .github/workflows/check.yml --dry-run",
-  "actrun workflow run .github/workflows/check.yml --job check-js",
+  runTask("actrun:lint"),
+  runTask("actrun:dry-run"),
+  runTask("actrun:check-js"),
 ].join(" && ");
 
 /**
@@ -83,5 +83,11 @@ export const checkTasks = defineTasks({
   "lint:all": noCacheTask(runTasks("lint:rust", "check")),
   "fmt:check": noCacheTask(runTask("check")),
   actrun: noCacheTask(localActrunCommand),
+  "actrun:lint": noCacheTask("actrun lint .github/workflows/check.yml"),
+  "actrun:dry-run": noCacheTask("actrun workflow run .github/workflows/check.yml --dry-run"),
+  "actrun:job": noCacheTask('actrun workflow run .github/workflows/check.yml "$@"', {
+    forwardArguments: true,
+  }),
+  "actrun:check-js": noCacheTask(runTask("actrun:job") + " --job check-js"),
   ci: noCacheTask(runTasks("fmt:all", "clippy", "test", "check:ci")),
 });


### PR DESCRIPTION
## Summary
- split the root `actrun` Vite+ task into reusable focused tasks
- keep `vp run actrun` as the aggregate entrypoint
- add a forwarded `actrun:job` task so individual workflow jobs can be launched independently

## Validation
- `vp run actrun:lint`
- `vp run actrun:dry-run`
- `vp run actrun:check-js`
- `vp run actrun`
- `vp check tools/vite-plus/tasks/check.ts`
- `git diff --check`
