### PR TITLE
chore(ci): add actrun benchmark tasks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,8 @@ The aggregate task wraps the focused local Actions check:
 actrun lint .github/workflows/check.yml
 actrun workflow run .github/workflows/check.yml --dry-run
 actrun workflow run .github/workflows/check.yml --job check-js
+actrun lint .github/workflows/benchmark.yml
+actrun workflow run .github/workflows/benchmark.yml --dry-run
 ```
 
 To run focused jobs independently, use the split Vite+ tasks:
@@ -47,7 +49,11 @@ To run focused jobs independently, use the split Vite+ tasks:
 vp run actrun:lint
 vp run actrun:dry-run
 vp run actrun:job --job check-js
+vp run actrun:benchmark:lint
+vp run actrun:benchmark:dry-run
 ```
+
+Prefer the Vite+ tasks when launching multiple local workflow runs in parallel; they assign separate actrun workspaces.
 
 ## Language Processor Change Discipline
 

--- a/tools/vite-plus/tasks/check.ts
+++ b/tools/vite-plus/tasks/check.ts
@@ -15,6 +15,7 @@ import {
   runPackageScriptDirectly,
   runTask,
   runTasks,
+  shellCommand,
   task,
 } from "../task-helpers.ts";
 
@@ -33,11 +34,15 @@ const ciVizeAppCheckCommand = [
     "vp check src 'e2e/*.ts' 'e2e/vrt/*.ts' vite.config.ts vite.app.config.ts vite.test.config.ts vite.node.config.ts playwright.config.ts && vize lint --max-warnings 0",
   ),
 ].join(" && ");
-const localActrunCommand = [
-  runTask("actrun:lint"),
-  runTask("actrun:dry-run"),
-  runTask("actrun:check-js"),
-].join(" && ");
+const localActrunCommand = [runTask("actrun:check"), runTask("actrun:benchmark")].join(" && ");
+const actrunWorkspaceFlag = (workflow: string) =>
+  `--workspace _build/actrun/workspace/${workflow}-$$`;
+const actrunWorkflowRunCommand = (workflow: string, ...args: string[]) =>
+  shellCommand(
+    `actrun workflow run .github/workflows/${workflow}.yml ${actrunWorkspaceFlag(workflow)} ${args.join(" ")}`,
+  );
+const actrunWorkflowRunForwardingCommand = (workflow: string) =>
+  `actrun workflow run .github/workflows/${workflow}.yml ${actrunWorkspaceFlag(workflow)} "$@"`;
 
 /**
  * Repository-wide formatting, linting, package checks, and CI aggregate tasks.
@@ -83,11 +88,18 @@ export const checkTasks = defineTasks({
   "lint:all": noCacheTask(runTasks("lint:rust", "check")),
   "fmt:check": noCacheTask(runTask("check")),
   actrun: noCacheTask(localActrunCommand),
+  "actrun:check": noCacheTask(runTasks("actrun:lint", "actrun:dry-run", "actrun:check-js")),
   "actrun:lint": noCacheTask("actrun lint .github/workflows/check.yml"),
-  "actrun:dry-run": noCacheTask("actrun workflow run .github/workflows/check.yml --dry-run"),
-  "actrun:job": noCacheTask('actrun workflow run .github/workflows/check.yml "$@"', {
+  "actrun:dry-run": noCacheTask(actrunWorkflowRunCommand("check", "--dry-run")),
+  "actrun:job": noCacheTask(actrunWorkflowRunForwardingCommand("check"), {
     forwardArguments: true,
   }),
   "actrun:check-js": noCacheTask(runTask("actrun:job") + " --job check-js"),
+  "actrun:benchmark": noCacheTask(runTasks("actrun:benchmark:lint", "actrun:benchmark:dry-run")),
+  "actrun:benchmark:lint": noCacheTask("actrun lint .github/workflows/benchmark.yml"),
+  "actrun:benchmark:dry-run": noCacheTask(actrunWorkflowRunCommand("benchmark", "--dry-run")),
+  "actrun:benchmark:job": noCacheTask(actrunWorkflowRunForwardingCommand("benchmark"), {
+    forwardArguments: true,
+  }),
   ci: noCacheTask(runTasks("fmt:all", "clippy", "test", "check:ci")),
 });


### PR DESCRIPTION
## Summary

- add Benchmark workflow actrun lint and dry-run Vite+ tasks
- include the Benchmark preview in the aggregate `vp run actrun` task
- pass PID-suffixed actrun workspaces for workflow runs so local workflow previews can run in parallel without worktree collisions

## Validation

- `vp check tools/vite-plus/tasks/check.ts`
- `git diff --check`
- `vp run actrun:benchmark:lint`
- `vp run actrun:benchmark:dry-run`
- `vp run actrun:benchmark:job --dry-run --job pr-benchmark`
- concurrent local run: `vp run actrun:dry-run`, `vp run actrun:benchmark:dry-run`, `vp run actrun:benchmark:job --dry-run --job pr-benchmark`
- `vp run actrun`