### PR TITLE
perf(script): cache regex matchers

### DIFF
--- a/crates/vize_atelier_sfc/src/script/define_emits.rs
+++ b/crates/vize_atelier_sfc/src/script/define_emits.rs
@@ -15,6 +15,19 @@ use super::context::ScriptCompileContext;
 
 pub use vize_croquis::macros::DEFINE_EMITS;
 
+static FUNCTION_TYPE_EMIT_RE: LazyLock<regex::Regex> = LazyLock::new(|| {
+    regex::Regex::new(r#"\(\s*\w+\s*:\s*['"]([^'"]+)['"]\s*[,)]"#)
+        .expect("valid defineEmits function type regex")
+});
+static CALL_SIGNATURE_EMIT_RE: LazyLock<regex::Regex> = LazyLock::new(|| {
+    regex::Regex::new(r#"\(\s*\w+\s*:\s*['"]([^'"]+)['"]\s*(?:,\s*[^)]+)?\)\s*:"#)
+        .expect("valid defineEmits call signature regex")
+});
+static EMIT_PROPERTY_RE: LazyLock<regex::Regex> = LazyLock::new(|| {
+    regex::Regex::new(r#"(?:^|[{;,])\s*([a-zA-Z_$][a-zA-Z0-9_$]*)\s*:"#)
+        .expect("valid defineEmits property regex")
+});
+
 /// Result of processing defineEmits
 #[derive(Debug, Clone, Default)]
 #[allow(dead_code)]
@@ -178,38 +191,28 @@ pub fn extract_runtime_emits(ctx: &ScriptCompileContext) -> FxHashSet<String> {
 /// Extract event name from a function type like (e: 'click') => void
 fn extract_event_name_from_function_type(type_str: &str) -> Option<String> {
     // Look for pattern like (e: 'eventName') or (e: "eventName")
-    let re = regex::Regex::new(r#"\(\s*\w+\s*:\s*['"]([^'"]+)['"]\s*[,)]"#).ok()?;
-    re.captures(type_str)
+    FUNCTION_TYPE_EMIT_RE
+        .captures(type_str)
         .and_then(|cap| cap.get(1).map(|m| m.as_str().to_compact_string()))
 }
 
 /// Extract events from a type literal (object type)
 fn extract_events_from_type_literal(type_str: &str, emits: &mut FxHashSet<String>) {
-    static CALL_SIG_RE: LazyLock<Result<regex::Regex, regex::Error>> = LazyLock::new(|| {
-        regex::Regex::new(r#"\(\s*\w+\s*:\s*['"]([^'"]+)['"]\s*(?:,\s*[^)]+)?\)\s*:"#)
-    });
-    static PROP_RE: LazyLock<Result<regex::Regex, regex::Error>> =
-        LazyLock::new(|| regex::Regex::new(r#"(?:^|[{;,])\s*([a-zA-Z_$][a-zA-Z0-9_$]*)\s*:"#));
-
     // Handle call signatures: { (e: 'click'): void; (e: 'update'): void }
-    if let Ok(call_sig_re) = &*CALL_SIG_RE {
-        for cap in call_sig_re.captures_iter(type_str) {
-            if let Some(event_name) = cap.get(1) {
-                emits.insert(event_name.as_str().to_compact_string());
-            }
+    for cap in CALL_SIGNATURE_EMIT_RE.captures_iter(type_str) {
+        if let Some(event_name) = cap.get(1) {
+            emits.insert(event_name.as_str().to_compact_string());
         }
     }
 
     // Handle property syntax: { click: [...], update: [...] }
     // This is for the newer emit type syntax
-    if let Ok(prop_re) = &*PROP_RE {
-        for cap in prop_re.captures_iter(type_str) {
-            if let Some(prop_name) = cap.get(1) {
-                let name = prop_name.as_str();
-                // Skip common type keywords
-                if !matches!(name, "type" | "required" | "default" | "validator") {
-                    emits.insert(name.to_compact_string());
-                }
+    for cap in EMIT_PROPERTY_RE.captures_iter(type_str) {
+        if let Some(prop_name) = cap.get(1) {
+            let name = prop_name.as_str();
+            // Skip common type keywords
+            if !matches!(name, "type" | "required" | "default" | "validator") {
+                emits.insert(name.to_compact_string());
             }
         }
     }

--- a/crates/vize_croquis/src/import_resolver.rs
+++ b/crates/vize_croquis/src/import_resolver.rs
@@ -12,10 +12,22 @@
 
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::sync::LazyLock;
 
 use dashmap::DashMap;
 use serde::Deserialize;
 use vize_carton::{CompactString, FxHashMap, String, ToCompactString, cstr, profiler::CacheStats};
+
+static EXPORT_INTERFACE_RE: LazyLock<regex::Regex> = LazyLock::new(|| {
+    regex::Regex::new(
+        r"(?s)export\s+interface\s+(\w+)(?:<[^>]*>)?\s*\{([^}]*(?:\{[^}]*\}[^}]*)*)\}",
+    )
+    .expect("valid export interface regex")
+});
+static EXPORT_TYPE_ALIAS_RE: LazyLock<regex::Regex> = LazyLock::new(|| {
+    regex::Regex::new(r"export\s+type\s+(\w+)(?:<[^>]*>)?\s*=\s*([^;]+);")
+        .expect("valid export type alias regex")
+});
 
 /// Resolved module information
 #[derive(Debug, Clone)]
@@ -389,30 +401,22 @@ impl ImportResolver {
         // TODO: Use OXC for more accurate parsing
 
         // Extract interface definitions
-        let interface_re = regex::Regex::new(
-            r"(?s)export\s+interface\s+(\w+)(?:<[^>]*>)?\s*\{([^}]*(?:\{[^}]*\}[^}]*)*)\}",
-        );
-        if let Ok(re) = interface_re {
-            for cap in re.captures_iter(content) {
-                if let (Some(name), Some(body)) = (cap.get(1), cap.get(2)) {
-                    definitions.insert(
-                        CompactString::new(name.as_str()),
-                        cstr!("{{ {} }}", body.as_str().trim()),
-                    );
-                }
+        for cap in EXPORT_INTERFACE_RE.captures_iter(content) {
+            if let (Some(name), Some(body)) = (cap.get(1), cap.get(2)) {
+                definitions.insert(
+                    CompactString::new(name.as_str()),
+                    cstr!("{{ {} }}", body.as_str().trim()),
+                );
             }
         }
 
         // Extract type alias definitions
-        let type_re = regex::Regex::new(r"export\s+type\s+(\w+)(?:<[^>]*>)?\s*=\s*([^;]+);");
-        if let Ok(re) = type_re {
-            for cap in re.captures_iter(content) {
-                if let (Some(name), Some(body)) = (cap.get(1), cap.get(2)) {
-                    definitions.insert(
-                        CompactString::new(name.as_str()),
-                        CompactString::new(body.as_str().trim()),
-                    );
-                }
+        for cap in EXPORT_TYPE_ALIAS_RE.captures_iter(content) {
+            if let (Some(name), Some(body)) = (cap.get(1), cap.get(2)) {
+                definitions.insert(
+                    CompactString::new(name.as_str()),
+                    CompactString::new(body.as_str().trim()),
+                );
             }
         }
 

--- a/crates/vize_croquis/src/virtual_ts/generator/script.rs
+++ b/crates/vize_croquis/src/virtual_ts/generator/script.rs
@@ -8,7 +8,15 @@ use super::{
     BindingMetadata, BindingType, CompactString, MacroTracker, Path, RootNode, ScopeChain,
     ScopeData, ScopeKind, ScriptParseResult, VirtualTsConfig, VirtualTsGenerator, VirtualTsOutput,
 };
+use std::sync::LazyLock;
 use vize_carton::{String, ToCompactString, profile};
+
+static RELATIVE_IMPORT_RE: LazyLock<regex::Regex> = LazyLock::new(|| {
+    regex::Regex::new(
+        r#"(import\s+(?:type\s+)?(?:\{[^}]*\}|[^{}\s]+)\s+from\s+['"])(\.[^'"]+)(['"])"#,
+    )
+    .expect("valid relative import regex")
+});
 
 impl VirtualTsGenerator {
     /// Extract setup scope info from ScopeChain.
@@ -372,29 +380,22 @@ impl VirtualTsGenerator {
             return content.to_compact_string();
         };
 
-        let import_re = regex::Regex::new(
-            r#"(import\s+(?:type\s+)?(?:\{[^}]*\}|[^{}\s]+)\s+from\s+['"])(\.[^'"]+)(['"])"#,
-        );
+        RELATIVE_IMPORT_RE
+            .replace_all(content, |caps: &regex::Captures| {
+                let prefix = caps.get(1).map(|m| m.as_str()).unwrap_or("");
+                let rel_path = caps.get(2).map(|m| m.as_str()).unwrap_or("");
+                let suffix = caps.get(3).map(|m| m.as_str()).unwrap_or("");
 
-        match import_re {
-            Ok(re) => re
-                .replace_all(content, |caps: &regex::Captures| {
-                    let prefix = caps.get(1).map(|m| m.as_str()).unwrap_or("");
-                    let rel_path = caps.get(2).map(|m| m.as_str()).unwrap_or("");
-                    let suffix = caps.get(3).map(|m| m.as_str()).unwrap_or("");
+                let resolved = parent.join(rel_path);
+                let abs_path = resolved
+                    .canonicalize()
+                    .ok()
+                    .and_then(|p| p.to_str().map(String::from))
+                    .unwrap_or_else(|| resolved.to_string_lossy().to_compact_string());
 
-                    let resolved = parent.join(rel_path);
-                    let abs_path = resolved
-                        .canonicalize()
-                        .ok()
-                        .and_then(|p| p.to_str().map(String::from))
-                        .unwrap_or_else(|| resolved.to_string_lossy().to_compact_string());
-
-                    format!("{}{}{}", prefix, abs_path, suffix)
-                })
-                .to_compact_string(),
-            Err(_) => content.to_compact_string(),
-        }
+                format!("{}{}{}", prefix, abs_path, suffix)
+            })
+            .to_compact_string()
     }
 
     /// Generate props type definition.


### PR DESCRIPTION
## Summary

- cache defineEmits runtime emit regexes instead of recompiling them during script processing
- cache type-definition extraction regexes in the Croquis import resolver
- cache the legacy relative import rewrite regex used by virtual TypeScript generation

## Validation

- `cargo test -p vize_atelier_sfc define_emits`
- `cargo test -p vize_croquis import_resolver`
- `cargo test -p vize_croquis virtual_ts`
- `cargo clippy -p vize_croquis -p vize_atelier_sfc -- -D warnings`
- `cargo test -p vize_croquis`
- `cargo test -p vize_atelier_sfc`
- `cargo fmt --all -- --check`
- `git diff --check`