### PR TITLE
fix(vite-plugin): publish Vue import client types

### DIFF
--- a/docs/content/guide/vite-plugin.md
+++ b/docs/content/guide/vite-plugin.md
@@ -37,6 +37,31 @@ export default defineConfig({
 
 That's it. Replace `@vitejs/plugin-vue` with `@vizejs/vite-plugin` and your project compiles through Rust.
 
+## TypeScript Vue Imports
+
+Add the plugin package to `compilerOptions.types` to make direct `.vue` imports resolvable by
+TypeScript without writing a local `env.d.ts` shim:
+
+```json
+{
+  "compilerOptions": {
+    "types": ["vite/client", "@vizejs/vite-plugin"]
+  }
+}
+```
+
+This does not require adding `vize` as a direct project dependency.
+
+For Vite Plus projects, keep the Vite Plus client type and append the plugin package:
+
+```json
+{
+  "compilerOptions": {
+    "types": ["vite-plus/client", "@vizejs/vite-plugin"]
+  }
+}
+```
+
 For most projects, keep direct plugin options small and put stable compiler settings in
 `vize.config.ts`.
 

--- a/npm/vite-plugin-vize/README.md
+++ b/npm/vite-plugin-vize/README.md
@@ -38,6 +38,31 @@ export default defineConfig({
 });
 ```
 
+### TypeScript
+
+Add `@vizejs/vite-plugin` to `compilerOptions.types` so TypeScript can resolve direct `.vue`
+imports without a project-local `env.d.ts` shim:
+
+```json
+{
+  "compilerOptions": {
+    "types": ["vite/client", "@vizejs/vite-plugin"]
+  }
+}
+```
+
+This does not require adding `vize` as a direct project dependency.
+
+For Vite Plus projects, keep `vite-plus/client` and append `@vizejs/vite-plugin`:
+
+```json
+{
+  "compilerOptions": {
+    "types": ["vite-plus/client", "@vizejs/vite-plugin"]
+  }
+}
+```
+
 ### Shared config
 
 `vize.config.ts`

--- a/npm/vite-plugin-vize/client.d.ts
+++ b/npm/vite-plugin-vize/client.d.ts
@@ -1,0 +1,6 @@
+declare module "*.vue" {
+  import type { DefineComponent } from "vue";
+
+  const component: DefineComponent<{}, {}, any>;
+  export default component;
+}

--- a/npm/vite-plugin-vize/index.d.mts
+++ b/npm/vite-plugin-vize/index.d.mts
@@ -1,0 +1,4 @@
+import "./client.d.ts";
+
+export { default } from "./dist/index.mjs";
+export * from "./dist/index.mjs";

--- a/npm/vite-plugin-vize/package.json
+++ b/npm/vite-plugin-vize/package.json
@@ -22,15 +22,17 @@
     "directory": "npm/vite-plugin-vize"
   },
   "files": [
+    "client.d.ts",
+    "index.d.mts",
     "dist"
   ],
   "type": "module",
   "main": "./dist/index.mjs",
-  "types": "./dist/index.d.mts",
+  "types": "./index.d.mts",
   "exports": {
     ".": {
-      "import": "./dist/index.mjs",
-      "types": "./dist/index.d.mts"
+      "types": "./index.d.mts",
+      "import": "./dist/index.mjs"
     }
   },
   "publishConfig": {

--- a/tests/tooling/package-manifests.test.ts
+++ b/tests/tooling/package-manifests.test.ts
@@ -1,10 +1,14 @@
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
 import fs from "node:fs";
+import { createRequire } from "node:module";
+import os from "node:os";
 import path from "node:path";
 import { test } from "node:test";
 import { fileURLToPath } from "node:url";
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const require = createRequire(import.meta.url);
 const npmDir = path.join(root, "npm");
 
 function collectStrings(value: unknown, out: string[]): void {
@@ -136,6 +140,89 @@ test("esm packed npm manifests point at mjs and d.mts outputs", () => {
   }
 
   assert.deepEqual(failures, []);
+});
+
+test("vite plugin publishes TypeScript client types for Vue imports", () => {
+  const packageJson = JSON.parse(readRepoFile("npm/vite-plugin-vize/package.json")) as {
+    exports?: Record<string, { import?: string; types?: string }>;
+    files?: string[];
+    types?: string;
+  };
+  const typeEntry = readRepoFile("npm/vite-plugin-vize/index.d.mts");
+  const clientTypes = readRepoFile("npm/vite-plugin-vize/client.d.ts");
+
+  assert.equal(packageJson.types, "./index.d.mts");
+  assert.deepEqual(packageJson.exports?.["."], {
+    types: "./index.d.mts",
+    import: "./dist/index.mjs",
+  });
+  assert.ok(packageJson.files?.includes("client.d.ts"));
+  assert.ok(packageJson.files?.includes("index.d.mts"));
+  assert.match(typeEntry, /import "\.\/client\.d\.ts"/);
+  assert.match(typeEntry, /from "\.\/dist\/index\.mjs"/);
+  assert.match(clientTypes, /declare module "\*\.vue"/);
+});
+
+test("vite plugin type entry resolves direct Vue imports", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "vize-vite-plugin-types-"));
+  try {
+    const pluginDir = path.join(tempDir, "node_modules", "@vizejs", "vite-plugin");
+    const vueDir = path.join(tempDir, "node_modules", "vue");
+    const srcDir = path.join(tempDir, "src");
+    fs.mkdirSync(path.join(pluginDir, "dist"), { recursive: true });
+    fs.mkdirSync(vueDir, { recursive: true });
+    fs.mkdirSync(srcDir, { recursive: true });
+
+    for (const file of ["package.json", "index.d.mts", "client.d.ts"]) {
+      fs.copyFileSync(path.join(root, "npm", "vite-plugin-vize", file), path.join(pluginDir, file));
+    }
+
+    fs.writeFileSync(path.join(pluginDir, "dist", "index.mjs"), "\n");
+    fs.writeFileSync(
+      path.join(pluginDir, "dist", "index.d.mts"),
+      "declare const vize: () => unknown;\nexport { vize as default, vize };\n",
+    );
+    fs.writeFileSync(path.join(vueDir, "package.json"), '{"name":"vue","types":"./index.d.ts"}\n');
+    fs.writeFileSync(
+      path.join(vueDir, "index.d.ts"),
+      "export type DefineComponent<P = {}, B = {}, D = any> = { __props?: P; __bindings?: B; __data?: D };\n",
+    );
+    fs.writeFileSync(
+      path.join(tempDir, "tsconfig.json"),
+      JSON.stringify(
+        {
+          compilerOptions: {
+            module: "ESNext",
+            moduleResolution: "Bundler",
+            strict: true,
+            target: "ES2022",
+            types: ["@vizejs/vite-plugin"],
+          },
+          include: ["src"],
+        },
+        null,
+        2,
+      ),
+    );
+    fs.writeFileSync(path.join(srcDir, "App.vue"), "<template />\n");
+    fs.writeFileSync(path.join(srcDir, "main.ts"), 'import App from "./App.vue";\nApp;\n');
+
+    const result = spawnSync(
+      process.execPath,
+      [require.resolve("typescript/bin/tsc"), "-p", tempDir, "--noEmit", "--pretty", "false"],
+      {
+        encoding: "utf8",
+      },
+    );
+
+    assert.equal(
+      result.status,
+      0,
+      `${result.error?.message ?? ""}\n${result.stderr}\n${result.stdout}`.trim(),
+    );
+  } finally {
+    fs.rmSync(tempDir, { force: true, recursive: true });
+  }
 });
 
 test("native package catalog pins and generated loader version checks stay aligned", () => {


### PR DESCRIPTION
## Summary

- publish a root `@vizejs/vite-plugin` type entry that loads the bundled Vue client shim
- add `client.d.ts` so `compilerOptions.types` can resolve direct `*.vue` imports without a project-local `env.d.ts`
- document the `types` setup for Vite and Vite Plus projects

## Why

Projects using the Vite plugin should not need a direct `vize` dependency or a hand-written local shim just to make TypeScript accept `import App from "./App.vue"`.

The package previously exposed only `dist/index.d.mts`, so adding `@vizejs/vite-plugin` to `compilerOptions.types` did not register a Vue module declaration. The new root wrapper keeps the runtime import pointed at `dist/index.mjs` while loading `client.d.ts` for TypeScript.

## Checks

- `pnpm --dir npm/vite-plugin-vize build`
- `pnpm --dir npm/vite-plugin-vize check`
- `pnpm exec vp check tests/tooling/package-manifests.test.ts docs/content/guide/vite-plugin.md npm/vite-plugin-vize/README.md npm/vite-plugin-vize/package.json npm/vite-plugin-vize/index.d.mts npm/vite-plugin-vize/client.d.ts`
- `node --test tests/tooling/package-manifests.test.ts`
- `npm pack --dry-run --json`
