### PR TITLE
refactor: remove Tokio from LSP runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,10 +113,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "async-codec-lite"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2527c30e3972d8ff366b353125dae828c4252a154dbe6063684f6c5e014760a3"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "log",
+ "pin-project-lite",
+ "thiserror 1.0.69",
+]
 
 [[package]]
 name = "async-trait"
@@ -361,7 +383,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
 dependencies = [
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -513,7 +535,7 @@ dependencies = [
  "serde",
  "serde_json",
  "smallvec",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1733,7 +1755,7 @@ dependencies = [
  "postcard",
  "rustc-hash",
  "serde",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1746,7 +1768,7 @@ dependencies = [
  "owo-colors",
  "oxc-miette-derive",
  "textwrap",
- "thiserror",
+ "thiserror 2.0.18",
  "unicode-segmentation",
  "unicode-width",
 ]
@@ -2316,7 +2338,7 @@ dependencies = [
  "rmpv",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2487,7 +2509,7 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.17",
  "libredox",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2901,16 +2923,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
 
 [[package]]
-name = "socket2"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
-dependencies = [
- "libc",
- "windows-sys",
-]
-
-[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3033,11 +3045,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3094,47 +3126,6 @@ name = "tinyvec_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
-
-[[package]]
-name = "tokio"
-version = "1.52.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
-dependencies = [
- "bytes",
- "libc",
- "mio",
- "parking_lot",
- "pin-project-lite",
- "signal-hook-registry",
- "socket2",
- "tokio-macros",
- "windows-sys",
-]
-
-[[package]]
-name = "tokio-macros"
-version = "2.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "tokio-util"
-version = "0.7.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
-dependencies = [
- "bytes",
- "futures-core",
- "futures-sink",
- "pin-project-lite",
- "tokio",
-]
 
 [[package]]
 name = "toml"
@@ -3216,6 +3207,7 @@ version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4ba052b54a6627628d9b3c34c176e7eda8359b7da9acd497b9f20998d118508"
 dependencies = [
+ "async-codec-lite",
  "async-trait",
  "auto_impl",
  "bytes",
@@ -3226,8 +3218,6 @@ dependencies = [
  "memchr",
  "serde",
  "serde_json",
- "tokio",
- "tokio-util",
  "tower",
  "tower-lsp-macros",
  "tracing",
@@ -3417,7 +3407,6 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "tokio",
  "vize_armature",
  "vize_atelier_core",
  "vize_atelier_dom",
@@ -3442,7 +3431,7 @@ dependencies = [
  "htmlize",
  "insta",
  "serde",
- "thiserror",
+ "thiserror 2.0.18",
  "vize_carton",
  "vize_relief",
 ]
@@ -3467,7 +3456,7 @@ dependencies = [
  "oxc_transformer",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
  "vize_armature",
  "vize_carton",
  "vize_croquis",
@@ -3481,7 +3470,7 @@ dependencies = [
  "insta",
  "phf 0.13.1",
  "serde",
- "thiserror",
+ "thiserror 2.0.18",
  "vize_atelier_core",
  "vize_carton",
  "vize_croquis",
@@ -3508,7 +3497,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
- "thiserror",
+ "thiserror 2.0.18",
  "toml",
  "vize_atelier_core",
  "vize_atelier_dom",
@@ -3543,7 +3532,7 @@ dependencies = [
  "oxc_span",
  "oxc_syntax",
  "serde",
- "thiserror",
+ "thiserror 2.0.18",
  "vize_atelier_core",
  "vize_carton",
  "vize_croquis",
@@ -3569,8 +3558,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror",
- "tokio",
+ "thiserror 2.0.18",
  "tracing",
  "vize_armature",
  "vize_atelier_core",
@@ -3651,7 +3639,7 @@ dependencies = [
  "serde_json",
  "smallvec",
  "taffy",
- "thiserror",
+ "thiserror 2.0.18",
  "unicode-segmentation",
  "unicode-width",
  "vize_carton",
@@ -3671,7 +3659,7 @@ dependencies = [
  "oxc_parser",
  "oxc_span",
  "serde",
- "thiserror",
+ "thiserror 2.0.18",
  "vize_atelier_sfc",
  "vize_carton",
 ]
@@ -3682,6 +3670,7 @@ version = "0.131.0"
 dependencies = [
  "async-trait",
  "dashmap 6.1.0",
+ "futures",
  "ignore",
  "insta",
  "oxc_allocator",
@@ -3695,7 +3684,6 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "tokio",
  "tower-lsp",
  "tracing",
  "tracing-subscriber",
@@ -3719,7 +3707,7 @@ dependencies = [
  "memchr",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
  "vize_atelier_sfc",
  "vize_carton",
  "vize_relief",
@@ -3743,7 +3731,7 @@ dependencies = [
  "oxc_syntax",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
  "vize_armature",
  "vize_atelier_sfc",
  "vize_carton",
@@ -3757,7 +3745,7 @@ version = "0.131.0"
 dependencies = [
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.18",
  "vize_carton",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,9 +74,8 @@ pklrust = "=0.9.0"
 
 # CLI, async, and IDE runtime
 clap = { version = "=4.6.1", features = ["derive"] }
-tokio = "=1.52.3"
 futures = "=0.3.32"
-tower-lsp = "=0.20.0"
+tower-lsp = { version = "=0.20.0", default-features = false, features = ["runtime-agnostic"] }
 async-trait = "=0.1.89"
 tracing = "=0.1.44"
 tracing-subscriber = "=0.3.23"

--- a/crates/vize/Cargo.toml
+++ b/crates/vize/Cargo.toml
@@ -50,8 +50,7 @@ glob.workspace = true
 # Multithreading
 rayon.workspace = true
 
-# Async runtime (for LSP)
-tokio = { workspace = true, features = ["rt-multi-thread"] }
+# Async helpers (for LSP)
 futures.workspace = true
 
 # Serialization (for JSON output)

--- a/crates/vize/src/commands/ide.rs
+++ b/crates/vize/src/commands/ide.rs
@@ -59,26 +59,16 @@ pub fn run(args: IdeArgs) {
 
 /// Run LSP server (default behavior)
 fn run_lsp(args: IdeArgs) {
-    let runtime = match tokio::runtime::Runtime::new() {
-        Ok(runtime) => runtime,
-        Err(error) => {
-            eprintln!("Failed to create tokio runtime: {error}");
-            std::process::exit(1);
-        }
+    let result = if let Some(port) = args.port {
+        vize_maestro::serve_tcp_blocking(port)
+    } else {
+        vize_maestro::serve_blocking()
     };
 
-    runtime.block_on(async {
-        let result = if let Some(port) = args.port {
-            vize_maestro::serve_tcp(port).await
-        } else {
-            vize_maestro::serve().await
-        };
-
-        if let Err(e) = result {
-            eprintln!("LSP server error: {}", e);
-            std::process::exit(1);
-        }
-    });
+    if let Err(e) = result {
+        eprintln!("LSP server error: {}", e);
+        std::process::exit(1);
+    }
 }
 
 /// Handle VSCode extension operations

--- a/crates/vize/src/commands/lsp.rs
+++ b/crates/vize/src/commands/lsp.rs
@@ -18,25 +18,14 @@ pub struct LspArgs {
 }
 
 pub fn run(args: LspArgs) {
-    // Create tokio runtime for async LSP server
-    let runtime = match tokio::runtime::Runtime::new() {
-        Ok(runtime) => runtime,
-        Err(error) => {
-            eprintln!("Failed to create tokio runtime: {error}");
-            std::process::exit(1);
-        }
+    let result = if let Some(port) = args.port {
+        vize_maestro::serve_tcp_blocking(port)
+    } else {
+        vize_maestro::serve_blocking()
     };
 
-    runtime.block_on(async {
-        let result = if let Some(port) = args.port {
-            vize_maestro::serve_tcp(port).await
-        } else {
-            vize_maestro::serve().await
-        };
-
-        if let Err(e) = result {
-            eprintln!("LSP server error: {}", e);
-            std::process::exit(1);
-        }
-    });
+    if let Err(e) = result {
+        eprintln!("LSP server error: {}", e);
+        std::process::exit(1);
+    }
 }

--- a/crates/vize_canon/Cargo.toml
+++ b/crates/vize_canon/Cargo.toml
@@ -49,5 +49,4 @@ libc.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true
-tokio = { workspace = true, features = ["full", "test-util"] }
 insta.workspace = true

--- a/crates/vize_maestro/Cargo.toml
+++ b/crates/vize_maestro/Cargo.toml
@@ -19,7 +19,7 @@ tower-lsp.workspace = true
 # lsp-types is re-exported by tower-lsp, use that version
 
 # Async Runtime
-tokio = { workspace = true, features = ["full"] }
+futures.workspace = true
 async-trait.workspace = true
 
 # Text Processing

--- a/crates/vize_maestro/src/ide/definition.rs
+++ b/crates/vize_maestro/src/ide/definition.rs
@@ -380,11 +380,12 @@ const message = 'hello'
     }
 
     #[cfg(feature = "native")]
-    #[tokio::test]
-    async fn test_definition_with_corsa_fallback_resolves_template_binding_at_boundary() {
-        let dir = tempfile::tempdir().unwrap();
-        let source_path = dir.path().join("Boundary.vue");
-        let source = r#"<script setup lang="ts">
+    #[test]
+    fn test_definition_with_corsa_fallback_resolves_template_binding_at_boundary() {
+        crate::runtime::block_on(async {
+            let dir = tempfile::tempdir().unwrap();
+            let source_path = dir.path().join("Boundary.vue");
+            let source = r#"<script setup lang="ts">
 const count = ref(0)
 </script>
 
@@ -392,28 +393,29 @@ const count = ref(0)
   {{ count }}
 </template>
 "#;
-        fs::write(&source_path, source).unwrap();
+            fs::write(&source_path, source).unwrap();
 
-        let uri = Url::from_file_path(&source_path).unwrap();
-        let state = ServerState::new();
-        state
-            .documents
-            .open(uri.clone(), source.to_string(), 1, "vue".to_string());
-        state.update_virtual_docs(&uri, source);
+            let uri = Url::from_file_path(&source_path).unwrap();
+            let state = ServerState::new();
+            state
+                .documents
+                .open(uri.clone(), source.to_string(), 1, "vue".to_string());
+            state.update_virtual_docs(&uri, source);
 
-        let offset = source.rfind("count").unwrap() + "count".len();
-        let ctx = IdeContext::new(&state, &uri, offset).unwrap();
-        let location = scalar_location(
-            DefinitionService::definition_with_corsa(&ctx, None)
-                .await
-                .unwrap(),
-        );
-        let expected_binding_offset = source.find("const count").unwrap() + "const ".len();
-        let (line, character) = crate::ide::offset_to_position(source, expected_binding_offset);
+            let offset = source.rfind("count").unwrap() + "count".len();
+            let ctx = IdeContext::new(&state, &uri, offset).unwrap();
+            let location = scalar_location(
+                DefinitionService::definition_with_corsa(&ctx, None)
+                    .await
+                    .unwrap(),
+            );
+            let expected_binding_offset = source.find("const count").unwrap() + "const ".len();
+            let (line, character) = crate::ide::offset_to_position(source, expected_binding_offset);
 
-        assert_eq!(location.uri, uri);
-        assert_eq!(location.range.start.line, line);
-        assert_eq!(location.range.start.character, character);
+            assert_eq!(location.uri, uri);
+            assert_eq!(location.range.start.line, line);
+            assert_eq!(location.range.start.character, character);
+        });
     }
 
     #[test]

--- a/crates/vize_maestro/src/ide/diagnostics.rs
+++ b/crates/vize_maestro/src/ide/diagnostics.rs
@@ -219,7 +219,7 @@ impl DiagnosticService {
             // Try to get Corsa diagnostics (with timeout, skip on failure).
             // Use 10s timeout - polling for diagnostics internally uses 5s
             let corsa_future = Self::collect_corsa_diagnostics(state, uri);
-            match tokio::time::timeout(std::time::Duration::from_secs(10), corsa_future).await {
+            match crate::runtime::timeout(std::time::Duration::from_secs(10), corsa_future).await {
                 Ok(corsa_diags) => {
                     tracing::info!("corsa diagnostics count: {}", corsa_diags.len());
                     diagnostics.extend(corsa_diags);

--- a/crates/vize_maestro/src/ide/hover.rs
+++ b/crates/vize_maestro/src/ide/hover.rs
@@ -721,11 +721,12 @@ const secondaryLabel = ref('secondary')
     }
 
     #[cfg(feature = "native")]
-    #[tokio::test]
-    async fn test_hover_with_corsa_fallback_supports_identifier_boundaries() {
-        let dir = tempfile::tempdir().unwrap();
-        let source_path = dir.path().join("HoverBoundary.vue");
-        let source = r#"<script setup lang="ts">
+    #[test]
+    fn test_hover_with_corsa_fallback_supports_identifier_boundaries() {
+        crate::runtime::block_on(async {
+            let dir = tempfile::tempdir().unwrap();
+            let source_path = dir.path().join("HoverBoundary.vue");
+            let source = r#"<script setup lang="ts">
 const count = ref(0)
 </script>
 
@@ -733,49 +734,52 @@ const count = ref(0)
   {{ count }}
 </template>
 "#;
-        fs::write(&source_path, source).unwrap();
+            fs::write(&source_path, source).unwrap();
 
-        let uri = Url::from_file_path(&source_path).unwrap();
-        let state = ServerState::new();
-        state
-            .documents
-            .open(uri.clone(), source.to_string(), 1, "vue".to_string());
-        state.update_virtual_docs(&uri, source);
+            let uri = Url::from_file_path(&source_path).unwrap();
+            let state = ServerState::new();
+            state
+                .documents
+                .open(uri.clone(), source.to_string(), 1, "vue".to_string());
+            state.update_virtual_docs(&uri, source);
 
-        let offset = source.rfind("count").unwrap() + "count".len();
-        let ctx = IdeContext::new(&state, &uri, offset).unwrap();
-        let hover = HoverService::hover_with_corsa(&ctx, None).await.unwrap();
-        let value = hover_markdown(hover);
+            let offset = source.rfind("count").unwrap() + "count".len();
+            let ctx = IdeContext::new(&state, &uri, offset).unwrap();
+            let hover = HoverService::hover_with_corsa(&ctx, None).await.unwrap();
+            let value = hover_markdown(hover);
 
-        assert!(value.contains("count"));
-        assert!(value.contains("Ref<number>"));
+            assert!(value.contains("count"));
+            assert!(value.contains("Ref<number>"));
+        });
     }
 
     #[cfg(feature = "native")]
-    #[tokio::test]
-    async fn test_hover_with_corsa_fallback_supports_directive_boundaries() {
-        let dir = tempfile::tempdir().unwrap();
-        let source_path = dir.path().join("HoverDirective.vue");
-        let source = r#"<template>
+    #[test]
+    fn test_hover_with_corsa_fallback_supports_directive_boundaries() {
+        crate::runtime::block_on(async {
+            let dir = tempfile::tempdir().unwrap();
+            let source_path = dir.path().join("HoverDirective.vue");
+            let source = r#"<template>
   <div v-if="visible" />
 </template>
 "#;
-        fs::write(&source_path, source).unwrap();
+            fs::write(&source_path, source).unwrap();
 
-        let uri = Url::from_file_path(&source_path).unwrap();
-        let state = ServerState::new();
-        state
-            .documents
-            .open(uri.clone(), source.to_string(), 1, "vue".to_string());
-        state.update_virtual_docs(&uri, source);
+            let uri = Url::from_file_path(&source_path).unwrap();
+            let state = ServerState::new();
+            state
+                .documents
+                .open(uri.clone(), source.to_string(), 1, "vue".to_string());
+            state.update_virtual_docs(&uri, source);
 
-        let offset = source.find("v-if").unwrap() + "v-if".len();
-        let ctx = IdeContext::new(&state, &uri, offset).unwrap();
-        let hover = HoverService::hover_with_corsa(&ctx, None).await.unwrap();
-        let value = hover_markdown(hover);
+            let offset = source.find("v-if").unwrap() + "v-if".len();
+            let ctx = IdeContext::new(&state, &uri, offset).unwrap();
+            let hover = HoverService::hover_with_corsa(&ctx, None).await.unwrap();
+            let value = hover_markdown(hover);
 
-        assert!(value.contains("**v-if**"));
-        assert!(value.contains("Conditionally render"));
+            assert!(value.contains("**v-if**"));
+            assert!(value.contains("Conditionally render"));
+        });
     }
 
     fn hover_markdown(hover: tower_lsp::lsp_types::Hover) -> String {

--- a/crates/vize_maestro/src/lib.rs
+++ b/crates/vize_maestro/src/lib.rs
@@ -56,14 +56,14 @@
 //! ## Usage
 //!
 //! ```no_run
-//! #[tokio::main]
-//! async fn main() {
-//!     vize_maestro::serve().await.unwrap();
+//! fn main() {
+//!     vize_maestro::serve_blocking().unwrap();
 //! }
 //! ```
 
 pub mod document;
 pub mod ide;
+pub mod runtime;
 pub mod server;
 pub mod utils;
 pub mod virtual_code;
@@ -121,8 +121,8 @@ pub async fn serve() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 
     tracing::info!("Starting vize_maestro LSP server");
 
-    let stdin = tokio::io::stdin();
-    let stdout = tokio::io::stdout();
+    let stdin = runtime::threaded_reader("vize-lsp-stdin", std::io::stdin())?;
+    let stdout = runtime::threaded_writer("vize-lsp-stdout", std::io::stdout())?;
 
     let (service, socket) = LspService::new(MaestroServer::new);
 
@@ -131,11 +131,16 @@ pub async fn serve() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     Ok(())
 }
 
+/// Start the stdio LSP server on the current thread.
+pub fn serve_blocking() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    runtime::block_on(serve())
+}
+
 /// Start the LSP server on a TCP socket.
 ///
 /// This is useful for debugging and testing.
 pub async fn serve_tcp(port: u16) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    use tokio::net::TcpListener;
+    use std::net::TcpListener;
 
     tracing_subscriber::fmt()
         .with_writer(std::io::stderr)
@@ -146,17 +151,24 @@ pub async fn serve_tcp(port: u16) -> Result<(), Box<dyn std::error::Error + Send
 
     #[allow(clippy::disallowed_macros)]
     let addr = format!("127.0.0.1:{}", port);
-    let listener = TcpListener::bind(addr).await?;
+    let listener = TcpListener::bind(addr)?;
     tracing::info!("Listening on 127.0.0.1:{}", port);
 
-    let (stream, addr) = listener.accept().await?;
+    let (stream, addr) = listener.accept()?;
     tracing::info!("Accepted connection from {}", addr);
 
-    let (read, write) = tokio::io::split(stream);
+    let _ = stream.set_nodelay(true);
+    let read = runtime::threaded_reader("vize-lsp-tcp-read", stream.try_clone()?)?;
+    let write = runtime::threaded_writer("vize-lsp-tcp-write", stream)?;
 
     let (service, socket) = LspService::new(MaestroServer::new);
 
     Server::new(read, write, socket).serve(service).await;
 
     Ok(())
+}
+
+/// Start the TCP LSP server on the current thread.
+pub fn serve_tcp_blocking(port: u16) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    runtime::block_on(serve_tcp(port))
 }

--- a/crates/vize_maestro/src/runtime.rs
+++ b/crates/vize_maestro/src/runtime.rs
@@ -1,0 +1,293 @@
+//! Minimal runtime utilities for the LSP server.
+//!
+//! This module intentionally stays tiny: a single-thread `block_on`, a simple
+//! timeout helper, and thread-backed adapters that let blocking stdio/TCP
+//! handles satisfy `futures::io` traits without depending on Tokio.
+#![allow(clippy::disallowed_types)]
+
+use std::future::Future;
+use std::io::{self, Read, Write};
+use std::pin::Pin;
+use std::sync::Arc;
+use std::sync::mpsc as std_mpsc;
+use std::task::{Context, Poll};
+use std::thread;
+use std::time::Duration;
+
+use futures::channel::{mpsc, oneshot};
+use futures::io::{AsyncRead, AsyncWrite};
+use futures::stream::StreamExt;
+use futures::task::{ArcWake, waker};
+
+/// Runs a future to completion on the current thread.
+pub fn block_on<F>(future: F) -> F::Output
+where
+    F: Future,
+{
+    struct ThreadWaker {
+        thread: thread::Thread,
+    }
+
+    impl ArcWake for ThreadWaker {
+        fn wake_by_ref(arc_self: &Arc<Self>) {
+            arc_self.thread.unpark();
+        }
+    }
+
+    let waker = waker(Arc::new(ThreadWaker {
+        thread: thread::current(),
+    }));
+    let mut context = Context::from_waker(&waker);
+    let mut future = Box::pin(future);
+
+    loop {
+        match future.as_mut().poll(&mut context) {
+            Poll::Ready(output) => return output,
+            Poll::Pending => thread::park(),
+        }
+    }
+}
+
+/// Error returned when a timeout expires before a future completes.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub struct TimeoutElapsed;
+
+/// Resolves with `future`'s output, or `TimeoutElapsed` after `duration`.
+pub async fn timeout<F>(duration: Duration, future: F) -> Result<F::Output, TimeoutElapsed>
+where
+    F: Future,
+{
+    let (tx, mut rx) = oneshot::channel();
+    let _ = thread::Builder::new()
+        .name("vize-timeout".to_string())
+        .spawn(move || {
+            thread::sleep(duration);
+            let _ = tx.send(());
+        });
+
+    futures::pin_mut!(future);
+
+    futures::future::poll_fn(|cx| {
+        if let Poll::Ready(output) = future.as_mut().poll(cx) {
+            return Poll::Ready(Ok(output));
+        }
+
+        match Pin::new(&mut rx).poll(cx) {
+            Poll::Ready(_) => Poll::Ready(Err(TimeoutElapsed)),
+            Poll::Pending => Poll::Pending,
+        }
+    })
+    .await
+}
+
+enum ReadChunk {
+    Data(Vec<u8>),
+    Error(String),
+}
+
+/// AsyncRead adapter backed by a blocking reader thread.
+pub struct ThreadedReader {
+    rx: mpsc::UnboundedReceiver<ReadChunk>,
+    pending: Vec<u8>,
+    offset: usize,
+}
+
+impl ThreadedReader {
+    fn new(rx: mpsc::UnboundedReceiver<ReadChunk>) -> Self {
+        Self {
+            rx,
+            pending: Vec::new(),
+            offset: 0,
+        }
+    }
+}
+
+/// Wraps a blocking reader as a `futures::io::AsyncRead`.
+pub fn threaded_reader<R>(name: &str, mut reader: R) -> io::Result<ThreadedReader>
+where
+    R: Read + Send + 'static,
+{
+    let (tx, rx) = mpsc::unbounded();
+    thread::Builder::new()
+        .name(name.to_string())
+        .spawn(move || {
+            let mut buffer = [0; 8192];
+
+            loop {
+                match reader.read(&mut buffer) {
+                    Ok(0) => break,
+                    Ok(len) => {
+                        if tx
+                            .unbounded_send(ReadChunk::Data(buffer[..len].to_vec()))
+                            .is_err()
+                        {
+                            break;
+                        }
+                    }
+                    Err(error) if error.kind() == io::ErrorKind::Interrupted => {}
+                    Err(error) => {
+                        let _ = tx.unbounded_send(ReadChunk::Error(error.to_string()));
+                        break;
+                    }
+                }
+            }
+        })
+        .map_err(|error| io::Error::other(format!("failed to spawn reader thread: {error}")))?;
+
+    Ok(ThreadedReader::new(rx))
+}
+
+impl AsyncRead for ThreadedReader {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        out: &mut [u8],
+    ) -> Poll<io::Result<usize>> {
+        if out.is_empty() {
+            return Poll::Ready(Ok(0));
+        }
+
+        loop {
+            if self.offset < self.pending.len() {
+                let len = (self.pending.len() - self.offset).min(out.len());
+                out[..len].copy_from_slice(&self.pending[self.offset..self.offset + len]);
+                self.offset += len;
+
+                if self.offset == self.pending.len() {
+                    self.pending.clear();
+                    self.offset = 0;
+                }
+
+                return Poll::Ready(Ok(len));
+            }
+
+            match self.rx.poll_next_unpin(cx) {
+                Poll::Ready(Some(ReadChunk::Data(data))) => {
+                    if !data.is_empty() {
+                        self.pending = data;
+                        self.offset = 0;
+                    }
+                }
+                Poll::Ready(Some(ReadChunk::Error(error))) => {
+                    return Poll::Ready(Err(io::Error::other(error)));
+                }
+                Poll::Ready(None) => return Poll::Ready(Ok(0)),
+                Poll::Pending => return Poll::Pending,
+            }
+        }
+    }
+}
+
+enum WriteCommand {
+    Write(Vec<u8>),
+    Flush(oneshot::Sender<Result<(), String>>),
+}
+
+/// AsyncWrite adapter backed by a blocking writer thread.
+pub struct ThreadedWriter {
+    tx: std_mpsc::Sender<WriteCommand>,
+    pending_flush: Option<oneshot::Receiver<Result<(), String>>>,
+}
+
+/// Wraps a blocking writer as a `futures::io::AsyncWrite`.
+pub fn threaded_writer<W>(name: &str, mut writer: W) -> io::Result<ThreadedWriter>
+where
+    W: Write + Send + 'static,
+{
+    let (tx, rx) = std_mpsc::channel();
+    thread::Builder::new()
+        .name(name.to_string())
+        .spawn(move || {
+            let mut failure: Option<String> = None;
+
+            while let Ok(command) = rx.recv() {
+                match command {
+                    WriteCommand::Write(bytes) => {
+                        if failure.is_none()
+                            && let Err(error) = writer.write_all(&bytes)
+                        {
+                            failure = Some(error.to_string());
+                        }
+                    }
+                    WriteCommand::Flush(reply) => {
+                        let result = if let Some(error) = failure.clone() {
+                            Err(error)
+                        } else {
+                            writer.flush().map_err(|error| {
+                                let message = error.to_string();
+                                failure = Some(message.clone());
+                                message
+                            })
+                        };
+                        let _ = reply.send(result);
+                    }
+                }
+            }
+
+            let _ = writer.flush();
+        })
+        .map_err(|error| io::Error::other(format!("failed to spawn writer thread: {error}")))?;
+
+    Ok(ThreadedWriter {
+        tx,
+        pending_flush: None,
+    })
+}
+
+impl AsyncWrite for ThreadedWriter {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        _: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        if buf.is_empty() {
+            return Poll::Ready(Ok(0));
+        }
+
+        let len = buf.len();
+        let result = self.tx.send(WriteCommand::Write(buf.to_vec()));
+        Poll::Ready(
+            result
+                .map(|()| len)
+                .map_err(|_| io::Error::new(io::ErrorKind::BrokenPipe, "writer thread stopped")),
+        )
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        if self.pending_flush.is_none() {
+            let (tx, rx) = oneshot::channel();
+            self.tx
+                .send(WriteCommand::Flush(tx))
+                .map_err(|_| io::Error::new(io::ErrorKind::BrokenPipe, "writer thread stopped"))?;
+            self.pending_flush = Some(rx);
+        }
+
+        let receiver = self
+            .pending_flush
+            .as_mut()
+            .expect("flush receiver must exist");
+
+        match Pin::new(receiver).poll(cx) {
+            Poll::Ready(Ok(Ok(()))) => {
+                self.pending_flush = None;
+                Poll::Ready(Ok(()))
+            }
+            Poll::Ready(Ok(Err(error))) => {
+                self.pending_flush = None;
+                Poll::Ready(Err(io::Error::other(error)))
+            }
+            Poll::Ready(Err(_)) => {
+                self.pending_flush = None;
+                Poll::Ready(Err(io::Error::new(
+                    io::ErrorKind::BrokenPipe,
+                    "writer thread stopped",
+                )))
+            }
+            Poll::Pending => Poll::Pending,
+        }
+    }
+
+    fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        self.poll_flush(cx)
+    }
+}

--- a/crates/vize_maestro/src/server/state.rs
+++ b/crates/vize_maestro/src/server/state.rs
@@ -6,9 +6,9 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use dashmap::DashMap;
+use futures::lock::Mutex as AsyncMutex;
 use parking_lot::RwLock;
 use serde::Deserialize;
-use tokio::sync::OnceCell;
 use tower_lsp::lsp_types::Url;
 use vize_carton::config::{LanguageServerConfig, LinterConfig, TypeCheckerConfig};
 
@@ -342,7 +342,10 @@ pub struct ServerState {
     format_options: RwLock<vize_glyph::FormatOptions>,
     /// Corsa bridge for native TypeScript language features (lazy initialized)
     #[cfg(feature = "native")]
-    corsa_bridge: OnceCell<Arc<CorsaBridge>>,
+    corsa_bridge: OnceLock<Arc<CorsaBridge>>,
+    /// Serializes Corsa bridge initialization without tying us to a runtime.
+    #[cfg(feature = "native")]
+    corsa_init_lock: AsyncMutex<()>,
     /// Flag to track if Corsa initialization has been attempted and failed
     #[cfg(feature = "native")]
     corsa_init_failed: std::sync::atomic::AtomicBool,
@@ -378,7 +381,9 @@ impl ServerState {
             #[cfg(feature = "glyph")]
             format_options: RwLock::new(vize_glyph::FormatOptions::default()),
             #[cfg(feature = "native")]
-            corsa_bridge: OnceCell::new(),
+            corsa_bridge: OnceLock::new(),
+            #[cfg(feature = "native")]
+            corsa_init_lock: AsyncMutex::new(()),
             #[cfg(feature = "native")]
             corsa_init_failed: std::sync::atomic::AtomicBool::new(false),
             #[cfg(feature = "native")]
@@ -607,44 +612,44 @@ impl ServerState {
             return None;
         }
 
+        let _guard = self.corsa_init_lock.lock().await;
+
+        // Another request may have completed initialization while we were waiting.
+        if let Some(bridge) = self.corsa_bridge.get() {
+            return Some(bridge.clone());
+        }
+
+        if self.corsa_init_failed.load(Ordering::SeqCst) {
+            return None;
+        }
+
         // Get workspace root for Corsa configuration.
         let workspace_root = self.get_workspace_root();
         let type_checker_config = self.get_type_checker_config();
 
-        let result = self
-            .corsa_bridge
-            .get_or_try_init(|| async {
-                let config = CorsaBridgeConfig {
-                    corsa_path: type_checker_config.runtime_path().map(PathBuf::from),
-                    working_dir: workspace_root,
-                    timeout_ms: 30000, // Corsa needs time to build project state on first load.
-                    ..Default::default()
-                };
-                let bridge = CorsaBridge::with_config(config);
+        let config = CorsaBridgeConfig {
+            corsa_path: type_checker_config.runtime_path().map(PathBuf::from),
+            working_dir: workspace_root,
+            timeout_ms: 30000, // Corsa needs time to build project state on first load.
+            ..Default::default()
+        };
+        let bridge = CorsaBridge::with_config(config);
 
-                // Add a guardrail timeout around the initial spawn.
-                match tokio::time::timeout(std::time::Duration::from_secs(5), bridge.spawn()).await
-                {
-                    Ok(Ok(())) => {
-                        tracing::info!("corsa bridge initialized successfully");
-                        Ok(Arc::new(bridge))
-                    }
-                    Ok(Err(e)) => {
-                        tracing::warn!("corsa bridge spawn failed: {}", e);
-                        Err(())
-                    }
-                    Err(_) => {
-                        tracing::warn!("corsa bridge spawn timed out");
-                        Err(())
-                    }
-                }
-            })
-            .await;
-
-        match result {
-            Ok(bridge) => Some(bridge.clone()),
-            Err(()) => {
+        match crate::runtime::timeout(std::time::Duration::from_secs(5), bridge.spawn()).await {
+            Ok(Ok(())) => {
+                tracing::info!("corsa bridge initialized successfully");
+                let bridge = Arc::new(bridge);
+                let _ = self.corsa_bridge.set(bridge.clone());
+                Some(bridge)
+            }
+            Ok(Err(e)) => {
+                tracing::warn!("corsa bridge spawn failed: {}", e);
                 // Mark as failed so we don't retry
+                self.corsa_init_failed.store(true, Ordering::SeqCst);
+                None
+            }
+            Err(_) => {
+                tracing::warn!("corsa bridge spawn timed out");
                 self.corsa_init_failed.store(true, Ordering::SeqCst);
                 None
             }
@@ -654,7 +659,7 @@ impl ServerState {
     /// Check if the Corsa bridge is available (without initializing).
     #[cfg(feature = "native")]
     pub fn has_corsa_bridge(&self) -> bool {
-        self.is_lsp_typecheck_enabled() && self.corsa_bridge.initialized()
+        self.is_lsp_typecheck_enabled() && self.corsa_bridge.get().is_some()
     }
 
     /// Generate and cache virtual documents for a document.


### PR DESCRIPTION
## Summary

- Switch `tower-lsp` to its runtime-agnostic transport so the LSP path no longer pulls Tokio.
- Add a small `vize_maestro::runtime` module with `block_on`, timeout support, and thread-backed stdio/TCP async adapters.
- Update CLI LSP entrypoints, Corsa bridge lazy initialization, and async tests to use the minimal runtime.

## Impact

This keeps the existing `tower-lsp` service model while removing Tokio from the normal `vize` dependency tree. The LSP server now runs on a tiny local executor and blocking I/O adapter layer.

## Validation

- `cargo check -p vize -p vize_maestro -p vize_canon`
- `cargo test -p vize_maestro`
- `cargo test -p vize --lib`
- `cargo tree -p vize --edges normal | rg "tokio"` returns no matches
- `rg "tokio" Cargo.toml Cargo.lock crates npm tests --glob '!tests/_fixtures/**' --glob '!target/**'` returns no matches
