### PR TITLE
feat(inspector): add compiler inspector and agent reports

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,6 +76,11 @@ For language-facing changes, include the fixture or snapshot diff that proves th
 snapshot refreshes, explain why the new output is correct and avoid broad baseline churn unless the
 PR is specifically about that output family.
 
+When a compiler mismatch starts from an external repro or a local project file, use the playground
+Compiler Inspector to compare the official Vue output with Vize output. Add the inspector permalink
+to the PR body, then land the minimized fixture or snapshot that turns the diff into a reviewed
+contract. Local batches can be packaged with `vize inspector <file-or-glob>`.
+
 ## Pull Requests
 
 - Use Conventional Commits for commit messages and PR titles, such as `fix(vite-plugin): surface SFC compile errors`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,9 +77,10 @@ snapshot refreshes, explain why the new output is correct and avoid broad baseli
 PR is specifically about that output family.
 
 When a compiler mismatch starts from an external repro or a local project file, use the playground
-Compiler Inspector to compare the official Vue output with Vize output. Add the inspector permalink
-to the PR body, then land the minimized fixture or snapshot that turns the diff into a reviewed
-contract. Local batches can be packaged with `vize inspector <file-or-glob>`.
+Compiler Inspector to inspect the official Vue output, Vize output, Virtual TS, VIR, and cross-file
+graph. Add the inspector permalink to the PR body, then land the minimized fixture or full snapshot
+that turns the output into a reviewed contract. Local batches can be packaged with
+`vize inspector <file-or-glob>`, and agent handoff can use `vize inspector --format agent`.
 
 ## Pull Requests
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3427,6 +3427,7 @@ dependencies = [
  "vize_carton",
  "vize_croquis",
  "vize_croquis_cf",
+ "vize_curator",
  "vize_glyph",
  "vize_maestro",
  "vize_musea",
@@ -3633,6 +3634,15 @@ dependencies = [
  "vize_armature",
  "vize_carton",
  "vize_croquis",
+]
+
+[[package]]
+name = "vize_curator"
+version = "0.133.0"
+dependencies = [
+ "serde",
+ "serde_json",
+ "vize_carton",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ members = [
   "crates/vize_glyph",
   "crates/vize_musea",
   "crates/vize_maestro",
+  "crates/vize_curator",
   "crates/vize_fresco",
   "tests/vize_test_runner",
 ]
@@ -50,6 +51,7 @@ vize_fresco = { path = "crates/vize_fresco", version = "=0.133.0", default-featu
 vize_vitrine = { path = "crates/vize_vitrine", default-features = false }
 vize_glyph = { path = "crates/vize_glyph" }
 vize_maestro = { path = "crates/vize_maestro" }
+vize_curator = { path = "crates/vize_curator" }
 
 # OXC dependencies (pinned to a specific upstream revision for reproducibility)
 oxc_parser = { version = "=0.127.0", git = "https://github.com/oxc-project/oxc", rev = "8265ed94b8f743a11dbf6f81fdd6fd248906f366" }

--- a/crates/vize/Cargo.toml
+++ b/crates/vize/Cargo.toml
@@ -36,6 +36,7 @@ vize_canon = { workspace = true, features = ["native"] }
 vize_croquis = { workspace = true }
 vize_croquis_cf = { workspace = true }
 vize_musea = { workspace = true }
+vize_curator = { workspace = true }
 vize_maestro = { workspace = true, optional = true }
 
 # CLI

--- a/crates/vize/src/cli.rs
+++ b/crates/vize/src/cli.rs
@@ -32,7 +32,7 @@ enum Commands {
     /// Type check Vue SFC files
     Check(crate::commands::check::CheckArgs),
 
-    /// Create playground compiler inspector payloads
+    /// Create playground compiler inspector payloads and agent reports
     Inspector(crate::commands::inspector::InspectorArgs),
 
     /// Remove Vize-generated cache artifacts

--- a/crates/vize/src/cli.rs
+++ b/crates/vize/src/cli.rs
@@ -32,6 +32,9 @@ enum Commands {
     /// Type check Vue SFC files
     Check(crate::commands::check::CheckArgs),
 
+    /// Create playground compiler inspector payloads
+    Inspector(crate::commands::inspector::InspectorArgs),
+
     /// Remove Vize-generated cache artifacts
     Clean(crate::commands::clean::CleanArgs),
 
@@ -77,6 +80,7 @@ fn run(cli: Cli) {
         Some(Commands::Fmt(args)) => crate::commands::fmt::run(args),
         Some(Commands::Lint(args)) => crate::commands::lint::run(args),
         Some(Commands::Check(args)) => crate::commands::check::run(args),
+        Some(Commands::Inspector(args)) => crate::commands::inspector::run(args),
         Some(Commands::Clean(args)) => crate::commands::clean::run(args),
         #[cfg(unix)]
         Some(Commands::CheckServer(args)) => crate::commands::check_server::run(args),
@@ -125,6 +129,11 @@ mod tests {
     #[test]
     fn clean_help_snapshot() {
         insta::assert_snapshot!("cli_clean_help", command_help("clean"));
+    }
+
+    #[test]
+    fn inspector_help_snapshot() {
+        insta::assert_snapshot!("cli_inspector_help", command_help("inspector"));
     }
 
     fn command_help(command_name: &str) -> String {

--- a/crates/vize/src/commands.rs
+++ b/crates/vize/src/commands.rs
@@ -7,6 +7,7 @@ pub mod clean;
 pub mod fmt;
 #[cfg(feature = "maestro")]
 pub mod ide;
+pub mod inspector;
 pub mod lint;
 #[cfg(feature = "maestro")]
 pub mod lsp;

--- a/crates/vize/src/commands/inspector.rs
+++ b/crates/vize/src/commands/inspector.rs
@@ -9,11 +9,11 @@ use clap::{Args, ValueEnum};
 use ignore::Walk;
 use std::{
     collections::BTreeSet,
-    fmt::Write as _,
     fs,
     path::{Path, PathBuf},
 };
-use vize_carton::{String, ToCompactString};
+use vize_carton::ToCompactString;
+use vize_curator::inspector as curator_inspector;
 
 #[derive(Debug, Clone, Copy, ValueEnum, Default, serde::Serialize)]
 #[serde(rename_all = "kebab-case")]
@@ -23,10 +23,11 @@ pub enum InspectorOutputFormat {
     Url,
     /// Print the raw inspector JSON payload
     Json,
+    /// Print an AI-agent friendly JSON report with payload, URL, and graph metadata
+    Agent,
 }
 
-#[derive(Debug, Clone, Copy, ValueEnum, Default, serde::Serialize)]
-#[serde(rename_all = "kebab-case")]
+#[derive(Debug, Clone, Copy, ValueEnum, Default)]
 pub enum InspectorTarget {
     /// Compare DOM compiler output
     #[default]
@@ -35,11 +36,11 @@ pub enum InspectorTarget {
     Ssr,
 }
 
-impl InspectorTarget {
-    fn as_payload_str(self) -> &'static str {
-        match self {
-            Self::Dom => "dom",
-            Self::Ssr => "ssr",
+impl From<InspectorTarget> for curator_inspector::InspectorTarget {
+    fn from(target: InspectorTarget) -> Self {
+        match target {
+            InspectorTarget::Dom => Self::Dom,
+            InspectorTarget::Ssr => Self::Ssr,
         }
     }
 }
@@ -80,29 +81,6 @@ pub struct InspectorArgs {
     pub vue_parser_quirks: bool,
 }
 
-#[derive(serde::Serialize)]
-#[serde(rename_all = "camelCase")]
-struct InspectorPayload {
-    version: u8,
-    target: &'static str,
-    selected_file: Option<String>,
-    options: InspectorPayloadOptions,
-    files: Vec<InspectorPayloadFile>,
-}
-
-#[derive(serde::Serialize)]
-#[serde(rename_all = "camelCase")]
-struct InspectorPayloadOptions {
-    custom_renderer: bool,
-    vue_parser_quirks: bool,
-}
-
-#[derive(serde::Serialize)]
-struct InspectorPayloadFile {
-    path: String,
-    source: String,
-}
-
 pub fn run(args: InspectorArgs) {
     let files = collect_files(&args.patterns, args.max_files);
     if files.is_empty() {
@@ -110,22 +88,32 @@ pub fn run(args: InspectorArgs) {
         std::process::exit(1);
     }
 
-    let payload = build_payload(&args, &files);
-    let json = serde_json::to_string(&payload).unwrap_or_else(|error| {
+    let source_files = collect_source_files(&files);
+    let payload = build_payload(&args, source_files.clone());
+    let json = curator_inspector::serialize_payload(&payload).unwrap_or_else(|error| {
         eprintln!("Failed to serialize inspector payload: {error}");
         std::process::exit(1);
     });
+    let playground_url =
+        curator_inspector::build_playground_url(&args.playground_url, json.as_str());
     let output = match args.format {
-        InspectorOutputFormat::Json => json.to_compact_string(),
+        InspectorOutputFormat::Json => json,
         InspectorOutputFormat::Url => {
-            let url = build_playground_url(&args.playground_url, &json);
-            if url.len() > 7000 {
+            if playground_url.len() > 7000 {
                 eprintln!(
                     "Inspector URL is {} bytes; use --format json for large batches if the browser rejects it.",
-                    url.len()
+                    playground_url.len()
                 );
             }
-            url
+            playground_url
+        }
+        InspectorOutputFormat::Agent => {
+            let report =
+                curator_inspector::build_agent_report(payload, playground_url, source_files);
+            curator_inspector::serialize_agent_report(&report).unwrap_or_else(|error| {
+                eprintln!("Failed to serialize inspector agent report: {error}");
+                std::process::exit(1);
+            })
         }
     };
 
@@ -194,9 +182,9 @@ fn is_vue_file(path: &Path) -> bool {
     path.extension().is_some_and(|extension| extension == "vue")
 }
 
-fn build_payload(args: &InspectorArgs, files: &[PathBuf]) -> InspectorPayload {
+fn collect_source_files(files: &[PathBuf]) -> Vec<curator_inspector::InspectorSourceFile> {
     let current_dir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
-    let files: Vec<_> = files
+    files
         .iter()
         .map(|path| {
             let source = fs::read_to_string(path).unwrap_or_else(|error| {
@@ -210,58 +198,24 @@ fn build_payload(args: &InspectorArgs, files: &[PathBuf]) -> InspectorPayload {
                 .replace('\\', "/")
                 .to_compact_string();
 
-            InspectorPayloadFile {
+            curator_inspector::InspectorSourceFile {
                 path: display_path,
                 source: source.to_compact_string(),
             }
         })
-        .collect();
+        .collect()
+}
 
-    let selected_file = files.first().map(|file| file.path.clone());
-
-    InspectorPayload {
-        version: 1,
-        target: args.target.as_payload_str(),
-        selected_file,
-        options: InspectorPayloadOptions {
+fn build_payload(
+    args: &InspectorArgs,
+    files: Vec<curator_inspector::InspectorSourceFile>,
+) -> curator_inspector::InspectorPayload {
+    curator_inspector::build_payload(
+        args.target.into(),
+        curator_inspector::InspectorOptions {
             custom_renderer: args.custom_renderer,
             vue_parser_quirks: args.vue_parser_quirks,
         },
         files,
-    }
-}
-
-fn build_playground_url(base: &str, payload_json: &str) -> String {
-    let base_without_hash = base.split('#').next().unwrap_or(base);
-    let separator = if base_without_hash.contains('?') {
-        if base_without_hash.ends_with('?') || base_without_hash.ends_with('&') {
-            ""
-        } else {
-            "&"
-        }
-    } else {
-        "?"
-    };
-
-    let mut url = String::default();
-    url.push_str(base_without_hash);
-    url.push_str(separator);
-    url.push_str("tab=inspector#inspector=");
-    url.push_str(percent_encode(payload_json).as_str());
-    url
-}
-
-fn percent_encode(value: &str) -> String {
-    let mut encoded = String::default();
-    for byte in value.bytes() {
-        match byte {
-            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
-                encoded.push(byte as char);
-            }
-            _ => {
-                let _ = write!(encoded, "%{byte:02X}");
-            }
-        }
-    }
-    encoded
+    )
 }

--- a/crates/vize/src/commands/inspector.rs
+++ b/crates/vize/src/commands/inspector.rs
@@ -1,0 +1,267 @@
+//! Compiler inspector payload generation.
+//!
+//! The command does not run the JavaScript reference compiler itself. It packages
+//! one or more Vue SFC sources into the same payload shape consumed by the
+//! playground inspector, where the browser can compare @vue/compiler-sfc and
+//! Vize WASM output.
+
+use clap::{Args, ValueEnum};
+use ignore::Walk;
+use std::{
+    collections::BTreeSet,
+    fmt::Write as _,
+    fs,
+    path::{Path, PathBuf},
+};
+use vize_carton::{String, ToCompactString};
+
+#[derive(Debug, Clone, Copy, ValueEnum, Default, serde::Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum InspectorOutputFormat {
+    /// Print a playground URL containing the encoded inspector payload
+    #[default]
+    Url,
+    /// Print the raw inspector JSON payload
+    Json,
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum, Default, serde::Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum InspectorTarget {
+    /// Compare DOM compiler output
+    #[default]
+    Dom,
+    /// Compare SSR compiler output
+    Ssr,
+}
+
+impl InspectorTarget {
+    fn as_payload_str(self) -> &'static str {
+        match self {
+            Self::Dom => "dom",
+            Self::Ssr => "ssr",
+        }
+    }
+}
+
+#[derive(Args, Default)]
+#[allow(clippy::disallowed_types)]
+pub struct InspectorArgs {
+    /// File, directory, or glob pattern(s) to include (default: ./**/*.vue)
+    #[arg(default_value = "./**/*.vue")]
+    pub patterns: Vec<String>,
+
+    /// Output format
+    #[arg(short, long, value_enum, default_value = "url")]
+    pub format: InspectorOutputFormat,
+
+    /// Playground URL used when --format url is selected
+    #[arg(long, default_value = "https://vizejs.dev/play/")]
+    pub playground_url: String,
+
+    /// Compiler target to compare
+    #[arg(long, value_enum, default_value = "dom")]
+    pub target: InspectorTarget,
+
+    /// Write output to a file instead of stdout
+    #[arg(short, long)]
+    pub output: Option<PathBuf>,
+
+    /// Limit the number of files in the payload
+    #[arg(long)]
+    pub max_files: Option<usize>,
+
+    /// Enable custom renderer comparison in the playground
+    #[arg(long)]
+    pub custom_renderer: bool,
+
+    /// Enable Vue parser compatibility quirks in the Vize side of the comparison
+    #[arg(long)]
+    pub vue_parser_quirks: bool,
+}
+
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct InspectorPayload {
+    version: u8,
+    target: &'static str,
+    selected_file: Option<String>,
+    options: InspectorPayloadOptions,
+    files: Vec<InspectorPayloadFile>,
+}
+
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct InspectorPayloadOptions {
+    custom_renderer: bool,
+    vue_parser_quirks: bool,
+}
+
+#[derive(serde::Serialize)]
+struct InspectorPayloadFile {
+    path: String,
+    source: String,
+}
+
+pub fn run(args: InspectorArgs) {
+    let files = collect_files(&args.patterns, args.max_files);
+    if files.is_empty() {
+        eprintln!("No .vue files found matching the patterns");
+        std::process::exit(1);
+    }
+
+    let payload = build_payload(&args, &files);
+    let json = serde_json::to_string(&payload).unwrap_or_else(|error| {
+        eprintln!("Failed to serialize inspector payload: {error}");
+        std::process::exit(1);
+    });
+    let output = match args.format {
+        InspectorOutputFormat::Json => json.to_compact_string(),
+        InspectorOutputFormat::Url => {
+            let url = build_playground_url(&args.playground_url, &json);
+            if url.len() > 7000 {
+                eprintln!(
+                    "Inspector URL is {} bytes; use --format json for large batches if the browser rejects it.",
+                    url.len()
+                );
+            }
+            url
+        }
+    };
+
+    if let Some(output_path) = args.output {
+        if let Err(error) = fs::write(&output_path, output.as_str()) {
+            eprintln!("Failed to write {}: {error}", output_path.display());
+            std::process::exit(1);
+        }
+    } else {
+        println!("{output}");
+    }
+}
+
+#[allow(clippy::disallowed_types)]
+fn collect_files(patterns: &[String], max_files: Option<usize>) -> Vec<PathBuf> {
+    let mut files = BTreeSet::new();
+
+    for pattern in patterns {
+        let path = Path::new(pattern.as_str());
+        if path.is_file() {
+            if is_vue_file(path) {
+                files.insert(path.to_path_buf());
+            }
+            continue;
+        }
+
+        if path.is_dir() {
+            for entry in Walk::new(path).flatten() {
+                let entry_path = entry.path();
+                if entry_path.is_file() && is_vue_file(entry_path) {
+                    files.insert(entry_path.to_path_buf());
+                    if max_files.is_some_and(|limit| files.len() >= limit) {
+                        return files.into_iter().collect();
+                    }
+                }
+            }
+            continue;
+        }
+
+        match glob::glob(pattern.as_str()) {
+            Ok(paths) => {
+                for path in paths.flatten() {
+                    if path.is_file() && is_vue_file(&path) {
+                        files.insert(path);
+                        if max_files.is_some_and(|limit| files.len() >= limit) {
+                            return files.into_iter().collect();
+                        }
+                    }
+                }
+            }
+            Err(error) => {
+                eprintln!("Invalid glob pattern {pattern}: {error}");
+                std::process::exit(1);
+            }
+        }
+    }
+
+    let mut files: Vec<_> = files.into_iter().collect();
+    if let Some(limit) = max_files {
+        files.truncate(limit);
+    }
+    files
+}
+
+fn is_vue_file(path: &Path) -> bool {
+    path.extension().is_some_and(|extension| extension == "vue")
+}
+
+fn build_payload(args: &InspectorArgs, files: &[PathBuf]) -> InspectorPayload {
+    let current_dir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    let files: Vec<_> = files
+        .iter()
+        .map(|path| {
+            let source = fs::read_to_string(path).unwrap_or_else(|error| {
+                eprintln!("Failed to read {}: {error}", path.display());
+                std::process::exit(1);
+            });
+            let display_path = path
+                .strip_prefix(&current_dir)
+                .unwrap_or(path)
+                .to_string_lossy()
+                .replace('\\', "/")
+                .to_compact_string();
+
+            InspectorPayloadFile {
+                path: display_path,
+                source: source.to_compact_string(),
+            }
+        })
+        .collect();
+
+    let selected_file = files.first().map(|file| file.path.clone());
+
+    InspectorPayload {
+        version: 1,
+        target: args.target.as_payload_str(),
+        selected_file,
+        options: InspectorPayloadOptions {
+            custom_renderer: args.custom_renderer,
+            vue_parser_quirks: args.vue_parser_quirks,
+        },
+        files,
+    }
+}
+
+fn build_playground_url(base: &str, payload_json: &str) -> String {
+    let base_without_hash = base.split('#').next().unwrap_or(base);
+    let separator = if base_without_hash.contains('?') {
+        if base_without_hash.ends_with('?') || base_without_hash.ends_with('&') {
+            ""
+        } else {
+            "&"
+        }
+    } else {
+        "?"
+    };
+
+    let mut url = String::default();
+    url.push_str(base_without_hash);
+    url.push_str(separator);
+    url.push_str("tab=inspector#inspector=");
+    url.push_str(percent_encode(payload_json).as_str());
+    url
+}
+
+fn percent_encode(value: &str) -> String {
+    let mut encoded = String::default();
+    for byte in value.bytes() {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                encoded.push(byte as char);
+            }
+            _ => {
+                let _ = write!(encoded, "%{byte:02X}");
+            }
+        }
+    }
+    encoded
+}

--- a/crates/vize/src/snapshots/vize__cli__tests__cli_inspector_help.snap
+++ b/crates/vize/src/snapshots/vize__cli__tests__cli_inspector_help.snap
@@ -1,0 +1,52 @@
+---
+source: crates/vize/src/cli.rs
+expression: "command_help(\"inspector\")"
+---
+Create playground compiler inspector payloads
+
+Usage: inspector [OPTIONS] [PATTERNS]...
+
+Arguments:
+  [PATTERNS]...
+          File, directory, or glob pattern(s) to include (default: ./**/*.vue)
+
+          [default: ./**/*.vue]
+
+Options:
+  -f, --format <FORMAT>
+          Output format
+
+          Possible values:
+          - url:  Print a playground URL containing the encoded inspector payload
+          - json: Print the raw inspector JSON payload
+
+          [default: url]
+
+      --playground-url <PLAYGROUND_URL>
+          Playground URL used when --format url is selected
+
+          [default: https://vizejs.dev/play/]
+
+      --target <TARGET>
+          Compiler target to compare
+
+          Possible values:
+          - dom: Compare DOM compiler output
+          - ssr: Compare SSR compiler output
+
+          [default: dom]
+
+  -o, --output <OUTPUT>
+          Write output to a file instead of stdout
+
+      --max-files <MAX_FILES>
+          Limit the number of files in the payload
+
+      --custom-renderer
+          Enable custom renderer comparison in the playground
+
+      --vue-parser-quirks
+          Enable Vue parser compatibility quirks in the Vize side of the comparison
+
+  -h, --help
+          Print help (see a summary with '-h')

--- a/crates/vize/src/snapshots/vize__cli__tests__cli_inspector_help.snap
+++ b/crates/vize/src/snapshots/vize__cli__tests__cli_inspector_help.snap
@@ -1,8 +1,9 @@
 ---
 source: crates/vize/src/cli.rs
+assertion_line: 136
 expression: "command_help(\"inspector\")"
 ---
-Create playground compiler inspector payloads
+Create playground compiler inspector payloads and agent reports
 
 Usage: inspector [OPTIONS] [PATTERNS]...
 
@@ -17,8 +18,9 @@ Options:
           Output format
 
           Possible values:
-          - url:  Print a playground URL containing the encoded inspector payload
-          - json: Print the raw inspector JSON payload
+          - url:   Print a playground URL containing the encoded inspector payload
+          - json:  Print the raw inspector JSON payload
+          - agent: Print an AI-agent friendly JSON report with payload, URL, and graph metadata
 
           [default: url]
 

--- a/crates/vize/src/snapshots/vize__cli__tests__cli_long_help.snap
+++ b/crates/vize/src/snapshots/vize__cli__tests__cli_long_help.snap
@@ -11,7 +11,7 @@ Commands:
   fmt           Format Vue SFC files [aliases: glyph]
   lint          Lint Vue SFC files [aliases: patina]
   check         Type check Vue SFC files
-  inspector     Create playground compiler inspector payloads
+  inspector     Create playground compiler inspector payloads and agent reports
   clean         Remove Vize-generated cache artifacts
   check-server  Start type check JSON-RPC server (Unix only)
   musea         Start component gallery server

--- a/crates/vize/src/snapshots/vize__cli__tests__cli_long_help.snap
+++ b/crates/vize/src/snapshots/vize__cli__tests__cli_long_help.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/vize/src/cli.rs
-expression: "String::from_utf8(help).unwrap()"
+expression: normalize_help(help)
 ---
 High-performance Vue.js toolchain in Rust
 
@@ -11,6 +11,7 @@ Commands:
   fmt           Format Vue SFC files [aliases: glyph]
   lint          Lint Vue SFC files [aliases: patina]
   check         Type check Vue SFC files
+  inspector     Create playground compiler inspector payloads
   clean         Remove Vize-generated cache artifacts
   check-server  Start type check JSON-RPC server (Unix only)
   musea         Start component gallery server

--- a/crates/vize/tests/inspector_cli.rs
+++ b/crates/vize/tests/inspector_cli.rs
@@ -101,3 +101,61 @@ fn inspector_url_supports_batch_payloads() {
     assert!(stdout.contains("App.vue"), "{stdout}");
     assert!(stdout.contains("Nested.vue"), "{stdout}");
 }
+
+#[test]
+fn inspector_agent_outputs_report_with_graph() {
+    let project = tempfile::tempdir().unwrap();
+    let src = project.path().join("src");
+    fs::create_dir_all(&src).unwrap();
+    fs::write(
+        src.join("App.vue"),
+        r#"<script setup lang="ts">
+import Child from './Child'
+</script>
+
+<template>
+  <Child />
+</template>
+"#,
+    )
+    .unwrap();
+    fs::write(
+        src.join("Child.vue"),
+        r#"<template>
+  <span>child</span>
+</template>
+"#,
+    )
+    .unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(project.path())
+        .args([
+            "inspector",
+            "src",
+            "--format",
+            "agent",
+            "--playground-url",
+            "https://example.test/play/",
+        ])
+        .output()
+        .unwrap();
+
+    let stdout = std::string::String::from_utf8(output.stdout).unwrap();
+    let stderr = std::string::String::from_utf8(output.stderr).unwrap();
+    assert!(
+        output.status.success(),
+        "stdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+
+    let json: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+
+    insta::with_settings!({
+        snapshot_path => "snapshots"
+    }, {
+        insta::assert_snapshot!(
+            "inspector_agent_outputs_report_with_graph",
+            serde_json::to_string_pretty(&json).unwrap()
+        );
+    });
+}

--- a/crates/vize/tests/inspector_cli.rs
+++ b/crates/vize/tests/inspector_cli.rs
@@ -1,0 +1,103 @@
+use std::{fs, process::Command};
+
+#[test]
+fn inspector_json_supports_single_file_payloads() {
+    let project = tempfile::tempdir().unwrap();
+    let src = project.path().join("src");
+    fs::create_dir_all(&src).unwrap();
+    fs::write(
+        src.join("App.vue"),
+        r#"<script setup lang="ts">
+const msg: string = "hello";
+</script>
+
+<template>
+  <div>{{ msg }}</div>
+</template>
+"#,
+    )
+    .unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(project.path())
+        .args([
+            "inspector",
+            "src/App.vue",
+            "--format",
+            "json",
+            "--target",
+            "ssr",
+            "--vue-parser-quirks",
+        ])
+        .output()
+        .unwrap();
+
+    let stdout = std::string::String::from_utf8(output.stdout).unwrap();
+    let stderr = std::string::String::from_utf8(output.stderr).unwrap();
+    assert!(
+        output.status.success(),
+        "stdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+
+    let json: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    let snapshot = serde_json::json!({
+        "version": json["version"],
+        "target": json["target"],
+        "selectedFile": json["selectedFile"],
+        "options": json["options"],
+        "files": json["files"].as_array().unwrap().iter().map(|file| {
+            serde_json::json!({
+                "path": file["path"],
+                "source": file["source"],
+            })
+        }).collect::<Vec<_>>(),
+    });
+
+    insta::with_settings!({
+        snapshot_path => "snapshots"
+    }, {
+        insta::assert_snapshot!(
+            "inspector_json_supports_single_file_payloads",
+            serde_json::to_string_pretty(&snapshot).unwrap()
+        );
+    });
+}
+
+#[test]
+fn inspector_url_supports_batch_payloads() {
+    let project = tempfile::tempdir().unwrap();
+    let src = project.path().join("src");
+    fs::create_dir_all(&src).unwrap();
+    fs::write(src.join("App.vue"), "<template><div>one</div></template>\n").unwrap();
+    fs::write(
+        src.join("Nested.vue"),
+        "<template><span>two</span></template>\n",
+    )
+    .unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(project.path())
+        .args([
+            "inspector",
+            "src",
+            "--format",
+            "url",
+            "--playground-url",
+            "https://example.test/play/",
+        ])
+        .output()
+        .unwrap();
+
+    let stdout = std::string::String::from_utf8(output.stdout).unwrap();
+    let stderr = std::string::String::from_utf8(output.stderr).unwrap();
+    assert!(
+        output.status.success(),
+        "stdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert!(
+        stdout.starts_with("https://example.test/play/?tab=inspector#inspector="),
+        "{stdout}"
+    );
+    assert!(stdout.contains("App.vue"), "{stdout}");
+    assert!(stdout.contains("Nested.vue"), "{stdout}");
+}

--- a/crates/vize/tests/snapshots/inspector_cli__inspector_agent_outputs_report_with_graph.snap
+++ b/crates/vize/tests/snapshots/inspector_cli__inspector_agent_outputs_report_with_graph.snap
@@ -1,0 +1,67 @@
+---
+source: crates/vize/tests/inspector_cli.rs
+assertion_line: 156
+expression: "serde_json::to_string_pretty(&json).unwrap()"
+---
+{
+  "generatedBy": "vize_curator",
+  "graph": {
+    "edges": [
+      {
+        "from": "src/App.vue",
+        "kind": "import",
+        "specifier": "./Child",
+        "to": "src/Child.vue"
+      }
+    ],
+    "nodes": [
+      {
+        "isEntry": true,
+        "kind": "vue",
+        "path": "src/App.vue",
+        "sourceBytes": 99,
+        "sourceLines": 7
+      },
+      {
+        "isEntry": false,
+        "kind": "vue",
+        "path": "src/Child.vue",
+        "sourceBytes": 44,
+        "sourceLines": 3
+      }
+    ]
+  },
+  "payload": {
+    "files": [
+      {
+        "path": "src/App.vue",
+        "source": "<script setup lang=\"ts\">\nimport Child from './Child'\n</script>\n\n<template>\n  <Child />\n</template>\n"
+      },
+      {
+        "path": "src/Child.vue",
+        "source": "<template>\n  <span>child</span>\n</template>\n"
+      }
+    ],
+    "options": {
+      "customRenderer": false,
+      "vueParserQuirks": false
+    },
+    "selectedFile": "src/App.vue",
+    "target": "dom",
+    "version": 1
+  },
+  "playgroundUrl": "https://example.test/play/?tab=inspector#inspector=%7B%22version%22%3A1%2C%22target%22%3A%22dom%22%2C%22selectedFile%22%3A%22src%2FApp.vue%22%2C%22options%22%3A%7B%22customRenderer%22%3Afalse%2C%22vueParserQuirks%22%3Afalse%7D%2C%22files%22%3A%5B%7B%22path%22%3A%22src%2FApp.vue%22%2C%22source%22%3A%22%3Cscript%20setup%20lang%3D%5C%22ts%5C%22%3E%5Cnimport%20Child%20from%20%27.%2FChild%27%5Cn%3C%2Fscript%3E%5Cn%5Cn%3Ctemplate%3E%5Cn%20%20%3CChild%20%2F%3E%5Cn%3C%2Ftemplate%3E%5Cn%22%7D%2C%7B%22path%22%3A%22src%2FChild.vue%22%2C%22source%22%3A%22%3Ctemplate%3E%5Cn%20%20%3Cspan%3Echild%3C%2Fspan%3E%5Cn%3C%2Ftemplate%3E%5Cn%22%7D%5D%7D",
+  "schema": "vize.inspector.agent",
+  "summary": {
+    "fileCount": 2,
+    "options": {
+      "customRenderer": false,
+      "vueParserQuirks": false
+    },
+    "selectedFile": "src/App.vue",
+    "sourceBytes": 143,
+    "sourceLines": 10,
+    "target": "dom"
+  },
+  "version": 1
+}

--- a/crates/vize/tests/snapshots/inspector_cli__inspector_json_supports_single_file_payloads.snap
+++ b/crates/vize/tests/snapshots/inspector_cli__inspector_json_supports_single_file_payloads.snap
@@ -1,0 +1,19 @@
+---
+source: crates/vize/tests/inspector_cli.rs
+expression: "serde_json::to_string_pretty(&snapshot).unwrap()"
+---
+{
+  "files": [
+    {
+      "path": "src/App.vue",
+      "source": "<script setup lang=\"ts\">\nconst msg: string = \"hello\";\n</script>\n\n<template>\n  <div>{{ msg }}</div>\n</template>\n"
+    }
+  ],
+  "options": {
+    "customRenderer": false,
+    "vueParserQuirks": true
+  },
+  "selectedFile": "src/App.vue",
+  "target": "ssr",
+  "version": 1
+}

--- a/crates/vize_curator/Cargo.toml
+++ b/crates/vize_curator/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "vize_curator"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Curator - local inspection and reporting utilities for Vize"
+publish = false
+
+[dependencies]
+serde = { workspace = true }
+serde_json = { workspace = true }
+vize_carton = { workspace = true }

--- a/crates/vize_curator/README.md
+++ b/crates/vize_curator/README.md
@@ -1,0 +1,26 @@
+# vize_curator
+
+`vize_curator` contains local-only inspection and reporting helpers for Vize.
+
+The crate is not published. It is meant for developer workflows that package
+compiler inspector payloads, agent-readable reports, graph metadata, and future
+profiling artifacts without growing the public crate surface.
+
+## Current Entry Points
+
+- `inspector::build_payload`
+- `inspector::build_playground_url`
+- `inspector::build_agent_report`
+- `inspector::build_graph`
+
+## Agent Reports
+
+`vize inspector --format agent` uses this crate to print a JSON report with:
+
+- the exact playground payload
+- a ready-to-open playground URL
+- summary metrics for files and options
+- a lightweight cross-file graph extracted from local imports
+
+The report is intended for local debugging and AI-agent handoff, not as a
+stable public interchange format.

--- a/crates/vize_curator/src/inspector.rs
+++ b/crates/vize_curator/src/inspector.rs
@@ -225,7 +225,7 @@ pub fn build_graph(files: &[InspectorSourceFile]) -> InspectorGraph {
         left.from
             .cmp(&right.from)
             .then_with(|| left.to.cmp(&right.to))
-            .then_with(|| left.kind.cmp(&right.kind))
+            .then_with(|| left.kind.cmp(right.kind))
             .then_with(|| left.specifier.cmp(&right.specifier))
     });
 

--- a/crates/vize_curator/src/inspector.rs
+++ b/crates/vize_curator/src/inspector.rs
@@ -1,0 +1,481 @@
+//! Compiler inspector payload helpers.
+
+use std::fmt::Write as _;
+use vize_carton::{String, ToCompactString};
+
+#[derive(Debug, Clone, Copy, serde::Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum InspectorTarget {
+    Dom,
+    Ssr,
+}
+
+impl InspectorTarget {
+    fn as_payload_str(self) -> &'static str {
+        match self {
+            Self::Dom => "dom",
+            Self::Ssr => "ssr",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct InspectorOptions {
+    pub custom_renderer: bool,
+    pub vue_parser_quirks: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct InspectorSourceFile {
+    pub path: String,
+    pub source: String,
+}
+
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct InspectorPayload {
+    version: u8,
+    target: &'static str,
+    selected_file: Option<String>,
+    options: InspectorPayloadOptions,
+    files: Vec<InspectorPayloadFile>,
+}
+
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct InspectorPayloadOptions {
+    custom_renderer: bool,
+    vue_parser_quirks: bool,
+}
+
+#[derive(serde::Serialize)]
+struct InspectorPayloadFile {
+    path: String,
+    source: String,
+}
+
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct InspectorAgentReport {
+    schema: &'static str,
+    version: u8,
+    generated_by: &'static str,
+    playground_url: String,
+    summary: InspectorAgentSummary,
+    graph: InspectorGraph,
+    payload: InspectorPayload,
+}
+
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct InspectorAgentSummary {
+    target: &'static str,
+    selected_file: Option<String>,
+    file_count: usize,
+    source_bytes: usize,
+    source_lines: usize,
+    options: InspectorPayloadOptions,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct InspectorGraph {
+    pub nodes: Vec<InspectorGraphNode>,
+    pub edges: Vec<InspectorGraphEdge>,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct InspectorGraphNode {
+    pub path: String,
+    pub kind: &'static str,
+    pub is_entry: bool,
+    pub source_bytes: usize,
+    pub source_lines: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct InspectorGraphEdge {
+    pub from: String,
+    pub to: String,
+    pub kind: &'static str,
+    pub specifier: String,
+}
+
+pub fn build_payload(
+    target: InspectorTarget,
+    options: InspectorOptions,
+    files: Vec<InspectorSourceFile>,
+) -> InspectorPayload {
+    let files: Vec<_> = files
+        .into_iter()
+        .map(|file| InspectorPayloadFile {
+            path: file.path,
+            source: file.source,
+        })
+        .collect();
+
+    let selected_file = files.first().map(|file| file.path.clone());
+
+    InspectorPayload {
+        version: 1,
+        target: target.as_payload_str(),
+        selected_file,
+        options: InspectorPayloadOptions {
+            custom_renderer: options.custom_renderer,
+            vue_parser_quirks: options.vue_parser_quirks,
+        },
+        files,
+    }
+}
+
+pub fn build_agent_report(
+    payload: InspectorPayload,
+    playground_url: String,
+    files: Vec<InspectorSourceFile>,
+) -> InspectorAgentReport {
+    let source_bytes = files.iter().map(|file| file.source.len()).sum();
+    let source_lines = files
+        .iter()
+        .map(|file| line_count(file.source.as_str()))
+        .sum();
+    let graph = build_graph(&files);
+    let summary = InspectorAgentSummary {
+        target: payload.target,
+        selected_file: payload.selected_file.clone(),
+        file_count: payload.files.len(),
+        source_bytes,
+        source_lines,
+        options: InspectorPayloadOptions {
+            custom_renderer: payload.options.custom_renderer,
+            vue_parser_quirks: payload.options.vue_parser_quirks,
+        },
+    };
+
+    InspectorAgentReport {
+        schema: "vize.inspector.agent",
+        version: 1,
+        generated_by: "vize_curator",
+        playground_url,
+        summary,
+        graph,
+        payload,
+    }
+}
+
+pub fn serialize_payload(payload: &InspectorPayload) -> Result<String, serde_json::Error> {
+    serde_json::to_string(payload).map(|json| json.to_compact_string())
+}
+
+pub fn serialize_agent_report(report: &InspectorAgentReport) -> Result<String, serde_json::Error> {
+    serde_json::to_string_pretty(report).map(|json| json.to_compact_string())
+}
+
+pub fn build_playground_url(base: &str, payload_json: &str) -> String {
+    let base_without_hash = base.split('#').next().unwrap_or(base);
+    let separator = if base_without_hash.contains('?') {
+        if base_without_hash.ends_with('?') || base_without_hash.ends_with('&') {
+            ""
+        } else {
+            "&"
+        }
+    } else {
+        "?"
+    };
+
+    let mut url = String::default();
+    url.push_str(base_without_hash);
+    url.push_str(separator);
+    url.push_str("tab=inspector#inspector=");
+    url.push_str(percent_encode(payload_json).as_str());
+    url
+}
+
+pub fn build_graph(files: &[InspectorSourceFile]) -> InspectorGraph {
+    let nodes = files
+        .iter()
+        .map(|file| InspectorGraphNode {
+            path: file.path.clone(),
+            kind: file_kind(file.path.as_str()),
+            is_entry: is_entry_path(file.path.as_str()),
+            source_bytes: file.source.len(),
+            source_lines: line_count(file.source.as_str()),
+        })
+        .collect();
+
+    let mut edges = Vec::new();
+    for file in files {
+        for import in extract_imports(file.source.as_str()) {
+            if let Some(to) = resolve_import(files, file.path.as_str(), import.specifier.as_str()) {
+                let edge = InspectorGraphEdge {
+                    from: file.path.clone(),
+                    to,
+                    kind: import.kind,
+                    specifier: import.specifier,
+                };
+                if !edges.contains(&edge) {
+                    edges.push(edge);
+                }
+            }
+        }
+    }
+
+    edges.sort_by(|left, right| {
+        left.from
+            .cmp(&right.from)
+            .then_with(|| left.to.cmp(&right.to))
+            .then_with(|| left.kind.cmp(&right.kind))
+            .then_with(|| left.specifier.cmp(&right.specifier))
+    });
+
+    InspectorGraph { nodes, edges }
+}
+
+fn percent_encode(value: &str) -> String {
+    let mut encoded = String::default();
+    for byte in value.bytes() {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                encoded.push(byte as char);
+            }
+            _ => {
+                let _ = write!(encoded, "%{byte:02X}");
+            }
+        }
+    }
+    encoded
+}
+
+#[derive(Debug)]
+struct ImportEdge {
+    specifier: String,
+    kind: &'static str,
+}
+
+fn extract_imports(source: &str) -> Vec<ImportEdge> {
+    let mut imports = Vec::new();
+    collect_imports_after(source, "from", "import", &mut imports);
+    collect_imports_after(source, "import(", "dynamic-import", &mut imports);
+    imports
+}
+
+fn collect_imports_after(
+    source: &str,
+    marker: &str,
+    kind: &'static str,
+    imports: &mut Vec<ImportEdge>,
+) {
+    let mut offset = 0;
+    while let Some(index) = source[offset..].find(marker) {
+        let start = offset + index + marker.len();
+        if let Some((specifier, end)) = read_quoted(source, start) {
+            imports.push(ImportEdge { specifier, kind });
+            offset = end;
+        } else {
+            offset = start;
+        }
+    }
+}
+
+fn read_quoted(source: &str, start: usize) -> Option<(String, usize)> {
+    let bytes = source.as_bytes();
+    let mut index = start;
+    while index < bytes.len() && bytes[index].is_ascii_whitespace() {
+        index += 1;
+    }
+    let quote = *bytes.get(index)?;
+    if quote != b'\'' && quote != b'"' {
+        return None;
+    }
+    index += 1;
+    let value_start = index;
+    while index < bytes.len() && bytes[index] != quote {
+        index += 1;
+    }
+    if index >= bytes.len() {
+        return None;
+    }
+    Some((String::from(&source[value_start..index]), index + 1))
+}
+
+fn resolve_import(files: &[InspectorSourceFile], from: &str, specifier: &str) -> Option<String> {
+    if !specifier.starts_with('.') {
+        return None;
+    }
+
+    import_candidates(from, specifier)
+        .into_iter()
+        .find(|candidate| {
+            files
+                .iter()
+                .any(|file| file.path.as_str() == candidate.as_str())
+        })
+}
+
+fn import_candidates(from: &str, specifier: &str) -> Vec<String> {
+    let base = normalize_path(join_path(parent_path(from).as_str(), specifier).as_str());
+    let mut candidates = vec![base.clone()];
+
+    if !has_known_extension(base.as_str()) {
+        for extension in [".vue", ".ts", ".tsx", ".js", ".jsx"] {
+            let mut candidate = base.clone();
+            candidate.push_str(extension);
+            candidates.push(candidate);
+        }
+
+        for extension in ["/index.vue", "/index.ts", "/index.js"] {
+            let mut candidate = base.clone();
+            candidate.push_str(extension);
+            candidates.push(candidate);
+        }
+    }
+
+    candidates
+}
+
+fn parent_path(path: &str) -> String {
+    path.rsplit_once('/')
+        .map(|(parent, _)| parent.to_compact_string())
+        .unwrap_or_default()
+}
+
+fn join_path(parent: &str, specifier: &str) -> String {
+    if parent.is_empty() {
+        specifier.to_compact_string()
+    } else {
+        let mut joined = parent.to_compact_string();
+        joined.push('/');
+        joined.push_str(specifier);
+        joined
+    }
+}
+
+fn normalize_path(path: &str) -> String {
+    let mut parts = Vec::new();
+    for part in path.split('/') {
+        match part {
+            "" | "." => {}
+            ".." => {
+                parts.pop();
+            }
+            _ => parts.push(part),
+        }
+    }
+    parts.join("/").to_compact_string()
+}
+
+fn has_known_extension(path: &str) -> bool {
+    path.rsplit_once('.')
+        .is_some_and(|(_, extension)| matches!(extension, "vue" | "ts" | "tsx" | "js" | "jsx"))
+}
+
+fn file_kind(path: &str) -> &'static str {
+    match path.rsplit_once('.').map(|(_, extension)| extension) {
+        Some("vue") => "vue",
+        Some("ts") | Some("tsx") => "typescript",
+        Some("js") | Some("jsx") => "javascript",
+        _ => "other",
+    }
+}
+
+fn is_entry_path(path: &str) -> bool {
+    matches!(
+        path.rsplit('/').next().unwrap_or(path),
+        "App.vue" | "app.vue" | "index.vue" | "main.ts" | "main.js"
+    )
+}
+
+fn line_count(source: &str) -> usize {
+    if source.is_empty() {
+        0
+    } else {
+        source.lines().count()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        InspectorOptions, InspectorSourceFile, InspectorTarget, build_agent_report, build_graph,
+        build_payload, build_playground_url, serialize_agent_report, serialize_payload,
+    };
+    use vize_carton::cstr;
+
+    #[test]
+    fn builds_inspector_payload_json_and_url() {
+        let payload = build_payload(
+            InspectorTarget::Dom,
+            InspectorOptions {
+                custom_renderer: false,
+                vue_parser_quirks: true,
+            },
+            vec![InspectorSourceFile {
+                path: cstr!("src/App.vue"),
+                source: cstr!("<template><div>msg</div></template>"),
+            }],
+        );
+        let json = serialize_payload(&payload).expect("payload serializes");
+
+        assert_eq!(
+            json.as_str(),
+            r#"{"version":1,"target":"dom","selectedFile":"src/App.vue","options":{"customRenderer":false,"vueParserQuirks":true},"files":[{"path":"src/App.vue","source":"<template><div>msg</div></template>"}]}"#
+        );
+        assert_eq!(
+            build_playground_url("https://vizejs.dev/play/?foo=bar#old", json.as_str()).as_str(),
+            "https://vizejs.dev/play/?foo=bar&tab=inspector#inspector=%7B%22version%22%3A1%2C%22target%22%3A%22dom%22%2C%22selectedFile%22%3A%22src%2FApp.vue%22%2C%22options%22%3A%7B%22customRenderer%22%3Afalse%2C%22vueParserQuirks%22%3Atrue%7D%2C%22files%22%3A%5B%7B%22path%22%3A%22src%2FApp.vue%22%2C%22source%22%3A%22%3Ctemplate%3E%3Cdiv%3Emsg%3C%2Fdiv%3E%3C%2Ftemplate%3E%22%7D%5D%7D"
+        );
+    }
+
+    #[test]
+    fn builds_graph_edges_for_relative_imports() {
+        let files = vec![
+            InspectorSourceFile {
+                path: cstr!("src/App.vue"),
+                source: cstr!("import Child from './Child.vue'\n"),
+            },
+            InspectorSourceFile {
+                path: cstr!("src/Child.vue"),
+                source: cstr!("<template><span /></template>\n"),
+            },
+        ];
+
+        let graph = build_graph(&files);
+
+        assert_eq!(graph.nodes.len(), 2);
+        assert_eq!(graph.edges.len(), 1);
+        assert_eq!(graph.edges[0].from.as_str(), "src/App.vue");
+        assert_eq!(graph.edges[0].to.as_str(), "src/Child.vue");
+        assert_eq!(graph.edges[0].kind, "import");
+    }
+
+    #[test]
+    fn builds_agent_report_with_payload_url_and_graph() {
+        let files = vec![
+            InspectorSourceFile {
+                path: cstr!("src/App.vue"),
+                source: cstr!("import Child from './Child'\n"),
+            },
+            InspectorSourceFile {
+                path: cstr!("src/Child.vue"),
+                source: cstr!("<template><span /></template>\n"),
+            },
+        ];
+        let payload = build_payload(
+            InspectorTarget::Ssr,
+            InspectorOptions {
+                custom_renderer: true,
+                vue_parser_quirks: false,
+            },
+            files.clone(),
+        );
+        let json = serialize_payload(&payload).expect("payload serializes");
+        let url = build_playground_url("https://vizejs.dev/play/", json.as_str());
+        let report = build_agent_report(payload, url, files);
+        let report_json = serialize_agent_report(&report).expect("report serializes");
+
+        assert!(report_json.contains(r#""schema": "vize.inspector.agent""#));
+        assert!(report_json.contains(r#""target": "ssr""#));
+        assert!(report_json.contains(r#""to": "src/Child.vue""#));
+    }
+}

--- a/crates/vize_curator/src/lib.rs
+++ b/crates/vize_curator/src/lib.rs
@@ -1,0 +1,7 @@
+//! Local inspection and reporting utilities for Vize.
+//!
+//! Curator owns developer-facing artifacts that describe what Vize observed or
+//! generated. It is intentionally workspace-local and is not part of the
+//! published crate set.
+
+pub mod inspector;

--- a/docs/content/guide/cli.md
+++ b/docs/content/guide/cli.md
@@ -54,6 +54,7 @@ When invoked without a command, `vize` defaults to `build`.
 | `fmt`          | Format Vue SFC files                            |
 | `lint`         | Lint Vue SFC files                              |
 | `check`        | Type check Vue SFC, TS, TSX, and `.d.ts` inputs |
+| `inspector`    | Create playground compiler inspector payloads   |
 | `clean`        | Remove Vize-generated cache artifacts           |
 | `ready`        | Run `fmt`, `lint`, `check`, and `build`         |
 | `upgrade`      | Update the installed CLI                        |
@@ -218,6 +219,32 @@ declare module "vue" {
 ```bash
 vize check --tsconfig tsconfig.app.json src
 ```
+
+## Inspector
+
+```bash
+vize inspector src/App.vue
+vize inspector "src/**/*.vue" --target ssr
+vize inspector src --format json --output inspector-payload.json
+```
+
+`vize inspector` packages one or more `.vue` files into the payload consumed by the playground
+compiler inspector. The browser then compares the official `@vue/compiler-sfc` output with Vize
+WASM output and produces a permalink plus a prefilled pull request link.
+
+Key options:
+
+| Option                | Description                             |
+| --------------------- | --------------------------------------- |
+| `-f, --format`        | Output format: `url` or `json`          |
+| `--target`            | Compiler target: `dom` or `ssr`         |
+| `--playground-url`    | Playground base URL for generated links |
+| `--max-files`         | Limit files included in a batch payload |
+| `--custom-renderer`   | Enable custom renderer comparison       |
+| `--vue-parser-quirks` | Enable Vue parser compatibility quirks  |
+| `-o, --output`        | Write the URL or JSON payload to a file |
+
+See [Compiler Inspector](./compiler-inspector.md) for the contributor workflow.
 
 ## Clean
 

--- a/docs/content/guide/cli.md
+++ b/docs/content/guide/cli.md
@@ -226,17 +226,21 @@ vize check --tsconfig tsconfig.app.json src
 vize inspector src/App.vue
 vize inspector "src/**/*.vue" --target ssr
 vize inspector src --format json --output inspector-payload.json
+vize inspector src --format agent --output inspector-agent.json
 ```
 
 `vize inspector` packages one or more `.vue` files into the payload consumed by the playground
-compiler inspector. The browser then compares the official `@vue/compiler-sfc` output with Vize
-WASM output and produces a permalink plus a prefilled pull request link.
+compiler inspector. The browser then inspects Vue output, Vize output, Virtual TS, VIR, and the
+cross-file graph, then produces a permalink plus a prefilled pull request link.
+
+Use `--format agent` when another local tool or AI agent needs the same repro without opening the
+browser. The report contains the exact payload, playground URL, summary metrics, and import graph.
 
 Key options:
 
 | Option                | Description                             |
 | --------------------- | --------------------------------------- |
-| `-f, --format`        | Output format: `url` or `json`          |
+| `-f, --format`        | Output format: `url`, `json`, or `agent` |
 | `--target`            | Compiler target: `dom` or `ssr`         |
 | `--playground-url`    | Playground base URL for generated links |
 | `--max-files`         | Limit files included in a batch payload |

--- a/docs/content/guide/cli.md
+++ b/docs/content/guide/cli.md
@@ -238,15 +238,15 @@ browser. The report contains the exact payload, playground URL, summary metrics,
 
 Key options:
 
-| Option                | Description                             |
-| --------------------- | --------------------------------------- |
+| Option                | Description                              |
+| --------------------- | ---------------------------------------- |
 | `-f, --format`        | Output format: `url`, `json`, or `agent` |
-| `--target`            | Compiler target: `dom` or `ssr`         |
-| `--playground-url`    | Playground base URL for generated links |
-| `--max-files`         | Limit files included in a batch payload |
-| `--custom-renderer`   | Enable custom renderer comparison       |
-| `--vue-parser-quirks` | Enable Vue parser compatibility quirks  |
-| `-o, --output`        | Write the URL or JSON payload to a file |
+| `--target`            | Compiler target: `dom` or `ssr`          |
+| `--playground-url`    | Playground base URL for generated links  |
+| `--max-files`         | Limit files included in a batch payload  |
+| `--custom-renderer`   | Enable custom renderer comparison        |
+| `--vue-parser-quirks` | Enable Vue parser compatibility quirks   |
+| `-o, --output`        | Write the URL or JSON payload to a file  |
 
 See [Compiler Inspector](./compiler-inspector.md) for the contributor workflow.
 

--- a/docs/content/guide/compiler-inspector.md
+++ b/docs/content/guide/compiler-inspector.md
@@ -1,0 +1,73 @@
+---
+title: Compiler Inspector
+---
+
+# Compiler Inspector
+
+The playground inspector compares the official Vue SFC compiler output with Vize's compiler output
+for the same `.vue` source. Use it when a report, fixture, or pull request needs a concrete parity
+artifact instead of a prose description of the mismatch.
+
+Open the inspector from the playground:
+
+```bash
+https://vizejs.dev/play/?tab=inspector
+```
+
+The inspector runs both compilers in the browser:
+
+- `@vue/compiler-sfc` for the reference output
+- Vize WASM for the Vize output
+- DOM or SSR target selection
+- Optional custom renderer and Vue parser quirk toggles
+- Full output tabs for both compilers
+- A unified diff tab with Vue-only and Vize-only lines
+- A permalink and prefilled pull request link
+
+## CLI Payloads
+
+Use `vize inspector` when the repro already exists in a local project. A single file produces a
+playground URL by default:
+
+```bash
+vize inspector src/App.vue
+```
+
+Directories and globs create batch payloads. The playground opens the batch and lets you switch
+between files.
+
+```bash
+vize inspector src/components
+vize inspector "src/**/*.vue" --target ssr
+```
+
+For large batches, emit JSON instead of a long URL:
+
+```bash
+vize inspector "src/**/*.vue" --format json --output inspector-payload.json
+```
+
+Useful options:
+
+| Option                | Description                                    |
+| --------------------- | ---------------------------------------------- |
+| `--target dom`        | Compare DOM compiler output                    |
+| `--target ssr`        | Compare SSR compiler output                    |
+| `--custom-renderer`   | Enable custom renderer mode in the playground  |
+| `--vue-parser-quirks` | Enable Vue parser compatibility quirks in Vize |
+| `--max-files <n>`     | Limit the number of files in a batch payload   |
+| `--playground-url`    | Override the playground URL used for links     |
+
+## PR Workflow
+
+When opening a compiler parity PR, include the inspector permalink in the PR body and add the
+minimal fixture or snapshot that makes the diff reviewable in CI. The prefilled PR link is a
+starting point; after pushing your branch, replace the compare head if GitHub asks for it.
+
+The useful PR evidence is:
+
+- The inspector permalink
+- The selected target and options
+- The minimized `.vue` fixture or snapshot diff
+- The reason the Vize output should match or intentionally differ from Vue
+- The local verification command that covers the touched compiler surface

--- a/docs/content/guide/compiler-inspector.md
+++ b/docs/content/guide/compiler-inspector.md
@@ -4,9 +4,9 @@ title: Compiler Inspector
 
 # Compiler Inspector
 
-The playground inspector compares the official Vue SFC compiler output with Vize's compiler output
-for the same `.vue` source. Use it when a report, fixture, or pull request needs a concrete parity
-artifact instead of a prose description of the mismatch.
+The playground inspector collects the compiler and analysis surfaces needed to review a `.vue`
+repro. It shows the official Vue SFC compiler output, Vize compiler output, Virtual TS, VIR, and a
+cross-file graph for local batches.
 
 Open the inspector from the playground:
 
@@ -14,14 +14,17 @@ Open the inspector from the playground:
 https://vizejs.dev/play/?tab=inspector
 ```
 
-The inspector runs both compilers in the browser:
+The inspector runs these checks in the browser:
 
 - `@vue/compiler-sfc` for the reference output
 - Vize WASM for the Vize output
+- Canon-backed Virtual TS for the selected file
+- Croquis VIR for the selected file
+- Cross-file graph and diagnostics for the payload files
 - DOM or SSR target selection
 - Optional custom renderer and Vue parser quirk toggles
 - Full output tabs for both compilers
-- A unified diff tab with Vue-only and Vize-only lines
+- A compare tab with Vue-only and Vize-only lines
 - A permalink and prefilled pull request link
 
 ## CLI Payloads
@@ -47,12 +50,20 @@ For large batches, emit JSON instead of a long URL:
 vize inspector "src/**/*.vue" --format json --output inspector-payload.json
 ```
 
+For AI agents or terminal handoff, emit the agent report. It includes the payload, playground URL,
+summary metrics, and cross-file graph metadata.
+
+```bash
+vize inspector "src/**/*.vue" --format agent --output inspector-agent.json
+```
+
 Useful options:
 
 | Option                | Description                                    |
 | --------------------- | ---------------------------------------------- |
 | `--target dom`        | Compare DOM compiler output                    |
 | `--target ssr`        | Compare SSR compiler output                    |
+| `--format agent`      | Emit agent-readable JSON with graph metadata   |
 | `--custom-renderer`   | Enable custom renderer mode in the playground  |
 | `--vue-parser-quirks` | Enable Vue parser compatibility quirks in Vize |
 | `--max-files <n>`     | Limit the number of files in a batch payload   |
@@ -61,13 +72,14 @@ Useful options:
 ## PR Workflow
 
 When opening a compiler parity PR, include the inspector permalink in the PR body and add the
-minimal fixture or snapshot that makes the diff reviewable in CI. The prefilled PR link is a
-starting point; after pushing your branch, replace the compare head if GitHub asks for it.
+minimal fixture or full snapshot that makes the output change reviewable in CI. The prefilled PR
+link is a starting point; after pushing your branch, replace the compare head if GitHub asks for it.
 
 The useful PR evidence is:
 
 - The inspector permalink
 - The selected target and options
-- The minimized `.vue` fixture or snapshot diff
+- The minimized `.vue` fixture or full snapshot
+- Relevant Virtual TS, VIR, or graph context when the issue crosses compiler surfaces
 - The reason the Vize output should match or intentionally differ from Vue
 - The local verification command that covers the touched compiler surface

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -39,7 +39,7 @@ features:
     details: Compile, format, lint, and type-check Vue SFC files from native commands when scripts or terminal workflows are the right entry point.
     link: guide/cli.md
   - title: Compiler Inspector
-    details: Compare official Vue compiler output against Vize output, share permalinked diffs, and open parity PRs from focused repros.
+    details: Inspect Vue output, Vize output, Virtual TS, VIR, and cross-file graphs, then share permalinked repros or agent reports.
     link: guide/compiler-inspector.md
   - title: Oxlint Plugin
     details: Run Vize's Vue diagnostics inside Oxlint and combine them with OXC's JS and TS rules in one pass.

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -38,6 +38,9 @@ features:
   - title: CLI Reference
     details: Compile, format, lint, and type-check Vue SFC files from native commands when scripts or terminal workflows are the right entry point.
     link: guide/cli.md
+  - title: Compiler Inspector
+    details: Compare official Vue compiler output against Vize output, share permalinked diffs, and open parity PRs from focused repros.
+    link: guide/compiler-inspector.md
   - title: Oxlint Plugin
     details: Run Vize's Vue diagnostics inside Oxlint and combine them with OXC's JS and TS rules in one pass.
     link: guide/oxlint.md

--- a/playground/e2e/vite-plugin-vapor.test.ts
+++ b/playground/e2e/vite-plugin-vapor.test.ts
@@ -11,27 +11,29 @@ const { compileSfc } = native;
 
 describe("vite-plugin vapor options", () => {
   it("builds scoped single-file options with vapor enabled", () => {
-    const options = buildCompileFileOptions(
-      "/src/App.vue",
-      "<template><div /></template><style scoped>.root { color: red; }</style>",
-      { sourceMap: true, ssr: false, vapor: true },
-    );
+    const options = buildCompileFileOptions("/src/App.vue", {
+      sourceMap: true,
+      ssr: false,
+      vapor: true,
+    });
 
     expect(options).toMatchObject({
       filename: "/src/App.vue",
       sourceMap: true,
       ssr: false,
       vapor: true,
+      customRenderer: false,
+      vueParserQuirks: false,
     });
     expect(options.scopeId).toMatch(/^data-v-/);
   });
 
-  it("omits scopeId for unscoped styles while keeping vapor", () => {
-    const options = buildCompileFileOptions(
-      "/src/App.vue",
-      "<template><div /></template><style>.root { color: red; }</style>",
-      { sourceMap: false, ssr: true, vapor: true },
-    );
+  it("builds SSR single-file options while keeping vapor", () => {
+    const options = buildCompileFileOptions("/src/App.vue", {
+      sourceMap: false,
+      ssr: true,
+      vapor: true,
+    });
 
     expect(options).toEqual({
       filename: "/src/App.vue",
@@ -39,7 +41,8 @@ describe("vite-plugin vapor options", () => {
       ssr: true,
       vapor: true,
       customRenderer: false,
-      scopeId: undefined,
+      vueParserQuirks: false,
+      scopeId: "data-v-c0cc6f12",
     });
   });
 
@@ -48,6 +51,7 @@ describe("vite-plugin vapor options", () => {
       ssr: false,
       vapor: true,
       customRenderer: false,
+      vueParserQuirks: false,
     });
   });
 
@@ -120,8 +124,8 @@ const count = 1;
     expect(result.code).toContain("_createIf");
     expect(result.code).toContain("_setClass");
     expect(result.code).toContain('_delegateEvents("click")');
-    expect(result.code).toContain("_setInsertionState(n16, null, true)\n  const n17 = _createIf(");
-    expect(result.code).toContain("_setInsertionState(n1, null, true)\n  const n22 = _createIf(");
+    expect(result.code).toContain("_setInsertionState(n17, null, true)\n  const n18 = _createIf(");
+    expect(result.code).toContain("_setInsertionState(n1, null, true)\n  const n23 = _createIf(");
     expect(result.code).toContain(
       '<g transform=\\"translate(15, 10) skewX(-15)\\"><path d=\\"M 65 0 L 40 60 L 70 20 L 65 0 Z\\" fill=\\"currentColor\\"></path><path d=\\"M 20 0 L 40 60 L 53 13 L 20 0 Z\\" fill=\\"currentColor\\"></path></g>',
     );

--- a/playground/src/App.vue
+++ b/playground/src/App.vue
@@ -8,6 +8,7 @@ import GlyphPlayground from "./features/glyph/GlyphPlayground.vue";
 import CroquisPlayground from "./features/croquis/CroquisPlayground.vue";
 import CrossFilePlayground from "./features/cross-file/CrossFilePlayground.vue";
 import TypeCheckPlayground from "./features/canon/TypeCheckPlayground.vue";
+import InspectorPlayground from "./features/inspector/InspectorPlayground.vue";
 
 // Theme toggle
 const isDark = ref(false);
@@ -19,9 +20,18 @@ function toggleTheme() {
 }
 
 // Main tab
-type MainTab = "atelier" | "patina" | "canon" | "croquis" | "cross-file" | "musea" | "glyph";
+type MainTab =
+  | "atelier"
+  | "inspector"
+  | "patina"
+  | "canon"
+  | "croquis"
+  | "cross-file"
+  | "musea"
+  | "glyph";
 const validTabs: MainTab[] = [
   "atelier",
+  "inspector",
   "patina",
   "canon",
   "croquis",
@@ -98,6 +108,13 @@ onMounted(async () => {
         >
           <span class="tab-name">Atelier</span>
           <span class="tab-desc">compiler</span>
+        </button>
+        <button
+          :class="['main-tab', { active: mainTab === 'inspector' }]"
+          @click="mainTab = 'inspector'"
+        >
+          <span class="tab-name">Inspector</span>
+          <span class="tab-desc">diff</span>
         </button>
         <button :class="['main-tab', { active: mainTab === 'patina' }]" @click="mainTab = 'patina'">
           <span class="tab-name">Patina</span>
@@ -192,6 +209,9 @@ onMounted(async () => {
     <main class="main">
       <template v-if="mainTab === 'patina'">
         <PatinaPlayground :compiler />
+      </template>
+      <template v-else-if="mainTab === 'inspector'">
+        <InspectorPlayground :compiler />
       </template>
       <template v-else-if="mainTab === 'canon'">
         <TypeCheckPlayground :compiler />

--- a/playground/src/features/inspector/InspectorPlayground.css
+++ b/playground/src/features/inspector/InspectorPlayground.css
@@ -230,6 +230,240 @@
   word-break: break-word;
 }
 
+.inspector-vir-output {
+  display: flex;
+  min-height: 0;
+  flex-direction: column;
+}
+
+.inspector-vir-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 6px 10px;
+  border: 1px solid var(--border-color);
+  border-bottom: 0;
+  border-radius: 6px 6px 0 0;
+  background: var(--bg-tertiary);
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 11px;
+}
+
+.inspector-vir-content {
+  min-height: 280px;
+  max-height: 58vh;
+  overflow: auto;
+  border: 1px solid var(--border-color);
+  border-radius: 0 0 6px 6px;
+  background: var(--bg-secondary);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  line-height: 1.55;
+}
+
+.inspector-vir-line {
+  display: flex;
+  white-space: pre;
+}
+
+.inspector-vir-ln {
+  min-width: 42px;
+  padding: 0 8px;
+  border-right: 1px solid var(--border-color);
+  color: var(--text-muted);
+  text-align: right;
+  user-select: none;
+}
+
+.inspector-vir-line-text {
+  padding: 0 10px;
+}
+
+.vir-token {
+  color: var(--text-secondary);
+}
+
+.vir-section,
+.vir-section-name,
+.vir-binding,
+.vir-identifier {
+  color: var(--text-primary);
+}
+
+.vir-macro {
+  color: var(--accent-rust);
+}
+
+.vir-type,
+.vir-source,
+.vir-keyword,
+.vir-number,
+.vir-colon,
+.vir-bracket,
+.vir-tag,
+.vir-arrow,
+.vir-border {
+  color: var(--text-muted);
+}
+
+.vir-line-diagnostic {
+  background: var(--color-error-bg);
+}
+
+.inspector-graph-panel {
+  display: flex;
+  min-height: 0;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.inspector-graph-summary {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.inspector-graph-summary span,
+.inspector-graph-kind,
+.inspector-graph-edge-kind,
+.inspector-graph-issues {
+  border: 1px solid var(--border-color);
+  border-radius: 999px;
+  padding: 2px 8px;
+  background: var(--bg-secondary);
+  color: var(--text-muted);
+  font-size: 11px;
+}
+
+.inspector-graph {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 8px;
+}
+
+.inspector-graph-node {
+  min-width: 0;
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  background: var(--bg-secondary);
+  padding: 10px;
+}
+
+.inspector-graph-node.active {
+  border-color: var(--accent-rust);
+}
+
+.inspector-graph-node.issues {
+  border-color: color-mix(in srgb, var(--color-warning) 42%, var(--border-color));
+}
+
+.inspector-graph-node-main {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+}
+
+.inspector-graph-file {
+  min-width: 0;
+  flex: 1;
+  overflow: hidden;
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  font-weight: 600;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.inspector-graph-issues {
+  border-color: color-mix(in srgb, var(--color-warning) 55%, transparent);
+  color: var(--color-warning);
+}
+
+.inspector-graph-node-meta {
+  display: flex;
+  gap: 8px;
+  margin-top: 6px;
+  color: var(--text-muted);
+  font-size: 11px;
+}
+
+.inspector-graph-edges {
+  margin-top: 10px;
+  border-top: 1px solid var(--border-color);
+  padding-top: 8px;
+}
+
+.inspector-graph-edge {
+  display: grid;
+  grid-template-columns: auto 20px minmax(0, 1fr);
+  align-items: center;
+  gap: 4px;
+  color: var(--text-secondary);
+  font-family: var(--font-mono);
+  font-size: 11px;
+}
+
+.inspector-graph-edge + .inspector-graph-edge {
+  margin-top: 5px;
+}
+
+.inspector-graph-target {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.inspector-graph-arrow {
+  color: var(--text-muted);
+  text-align: center;
+}
+
+.inspector-graph-diagnostics {
+  display: flex;
+  max-height: 220px;
+  flex-direction: column;
+  gap: 6px;
+  overflow: auto;
+}
+
+.inspector-graph-diagnostic {
+  display: grid;
+  grid-template-columns: minmax(76px, auto) minmax(90px, 0.8fr) minmax(0, 1.4fr);
+  gap: 8px;
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  background: var(--bg-secondary);
+  padding: 8px;
+  color: var(--text-secondary);
+  font-size: 12px;
+}
+
+.inspector-graph-diagnostic.error {
+  border-color: color-mix(in srgb, var(--color-error) 45%, var(--border-color));
+}
+
+.inspector-graph-diagnostic.warning {
+  border-color: color-mix(in srgb, var(--color-warning) 45%, var(--border-color));
+}
+
+.inspector-graph-diagnostic-code,
+.inspector-graph-diagnostic-file {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.inspector-graph-diagnostic-message {
+  min-width: 0;
+}
+
 .inspector-url-note {
   margin-top: 8px;
   color: var(--color-warning);
@@ -243,5 +477,9 @@
 
   .inspector-diff-line {
     grid-template-columns: 38px 38px 20px minmax(0, 1fr);
+  }
+
+  .inspector-graph-diagnostic {
+    grid-template-columns: minmax(0, 1fr);
   }
 }

--- a/playground/src/features/inspector/InspectorPlayground.css
+++ b/playground/src/features/inspector/InspectorPlayground.css
@@ -1,0 +1,247 @@
+.inspector-file-list {
+  display: flex;
+  gap: 4px;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--border-color);
+  background: var(--bg-secondary);
+  overflow-x: auto;
+}
+
+.inspector-file-tab {
+  max-width: 220px;
+  padding: 5px 10px;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  cursor: pointer;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.inspector-file-tab:hover,
+.inspector-file-tab.active {
+  background: var(--bg-tertiary);
+  border-color: var(--border-color);
+  color: var(--text-primary);
+}
+
+.inspector-controls {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.inspector-targets {
+  display: flex;
+  gap: 4px;
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  padding: 2px;
+}
+
+.inspector-target {
+  border: 0;
+  background: transparent;
+  color: var(--text-muted);
+  border-radius: 4px;
+  padding: 4px 10px;
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.inspector-target.active {
+  background: var(--bg-panel);
+  color: var(--text-primary);
+}
+
+.inspector-pr-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-height: 30px;
+  padding: 5px 12px;
+  border: 1px solid color-mix(in srgb, var(--text-primary) 28%, transparent);
+  border-radius: 6px;
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+  font-size: 12px;
+  font-weight: 600;
+  text-decoration: underline;
+  text-underline-offset: 3px;
+  cursor: pointer;
+  transition:
+    border-color 0.15s ease,
+    background 0.15s ease;
+}
+
+.inspector-pr-link:hover {
+  border-color: var(--text-primary);
+  background: var(--bg-panel);
+}
+
+.inspector-pr-link svg {
+  width: 15px;
+  height: 15px;
+  fill: currentColor;
+  flex-shrink: 0;
+}
+
+.inspector-option {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--text-secondary);
+  font-size: 12px;
+  cursor: pointer;
+  user-select: none;
+}
+
+.inspector-option input {
+  accent-color: var(--accent-rust);
+}
+
+.inspector-summary {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+.inspector-stat {
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  padding: 10px;
+  background: var(--bg-secondary);
+  min-width: 0;
+}
+
+.inspector-stat-value {
+  display: block;
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+  font-size: 16px;
+  font-weight: 600;
+}
+
+.inspector-stat-label {
+  display: block;
+  margin-top: 2px;
+  color: var(--text-muted);
+  font-size: 11px;
+}
+
+.inspector-tab-panel {
+  min-height: 0;
+}
+
+.inspector-diff {
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  overflow: hidden;
+  background: var(--bg-secondary);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  line-height: 1.55;
+}
+
+.inspector-diff-line {
+  display: grid;
+  grid-template-columns: 46px 46px 22px minmax(0, 1fr);
+  min-height: 22px;
+  border-bottom: 1px solid rgba(127, 127, 127, 0.08);
+}
+
+.inspector-diff-line:last-child {
+  border-bottom: 0;
+}
+
+.inspector-diff-line.add {
+  background: var(--color-success-bg);
+}
+
+.inspector-diff-line.remove {
+  background: var(--color-error-bg);
+}
+
+.inspector-diff-line.same {
+  background: transparent;
+}
+
+.inspector-diff-num,
+.inspector-diff-mark {
+  padding: 2px 6px;
+  color: var(--text-muted);
+  text-align: right;
+  user-select: none;
+}
+
+.inspector-diff-mark {
+  text-align: center;
+}
+
+.inspector-diff-code {
+  padding: 2px 10px;
+  color: var(--text-primary);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.inspector-empty-diff {
+  padding: 24px;
+  color: var(--text-muted);
+  text-align: center;
+}
+
+.inspector-warning-list {
+  margin-bottom: 12px;
+}
+
+.inspector-warning {
+  padding: 8px 10px;
+  border: 1px solid color-mix(in srgb, var(--color-warning) 35%, transparent);
+  border-radius: 6px;
+  background: var(--color-warning-bg);
+  color: var(--color-warning);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  white-space: pre-wrap;
+}
+
+.inspector-warning + .inspector-warning {
+  margin-top: 6px;
+}
+
+.inspector-payload {
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  background: var(--bg-secondary);
+  padding: 12px;
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.inspector-url-note {
+  margin-top: 8px;
+  color: var(--color-warning);
+  font-size: 12px;
+}
+
+@media (max-width: 900px) {
+  .inspector-summary {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .inspector-diff-line {
+    grid-template-columns: 38px 38px 20px minmax(0, 1fr);
+  }
+}

--- a/playground/src/features/inspector/InspectorPlayground.vue
+++ b/playground/src/features/inspector/InspectorPlayground.vue
@@ -1,0 +1,376 @@
+<script setup lang="ts">
+import "./InspectorPlayground.css";
+import { mdiGithub } from "@mdi/js";
+import { computed, onMounted, onUnmounted, ref, watch } from "vue";
+import MonacoEditor from "../../shared/MonacoEditor.vue";
+import CodeHighlight from "../../shared/CodeHighlight.vue";
+import { PRESETS } from "../../presets";
+import { useClipboard } from "../../utils/useClipboard";
+import { useTheme } from "../../utils/useTheme";
+import { type loadWasm, getWasm } from "../../wasm/index";
+import { compileInspectorReport } from "./compareCompilers";
+import { createInspectorUrl, createPullRequestUrl, readInspectorPayloadFromUrl } from "./share";
+import type {
+  InspectorFile,
+  InspectorOptions,
+  InspectorPayload,
+  InspectorReport,
+  InspectorTarget,
+} from "./types";
+
+const props = defineProps<{
+  compiler: Awaited<ReturnType<typeof loadWasm>> | null;
+}>();
+
+const { theme } = useTheme();
+const { copyToClipboard } = useClipboard();
+
+const files = ref<InspectorFile[]>([
+  {
+    path: "src/App.vue",
+    source: PRESETS.propsDestructure.code,
+  },
+]);
+const selectedFileIndex = ref(0);
+const target = ref<InspectorTarget>("dom");
+const options = ref<InspectorOptions>({
+  customRenderer: false,
+  vueParserQuirks: false,
+});
+const report = ref<InspectorReport | null>(null);
+const error = ref<string | null>(null);
+const isCompiling = ref(false);
+const activeOutputTab = ref<"diff" | "official" | "vize" | "payload">("diff");
+
+const selectedFile = computed(() => files.value[selectedFileIndex.value] ?? files.value[0]!);
+const source = computed({
+  get: () => selectedFile.value.source,
+  set: (value: string) => {
+    files.value[selectedFileIndex.value] = {
+      ...selectedFile.value,
+      source: value,
+    };
+  },
+});
+
+const payload = computed<InspectorPayload>(() => ({
+  version: 1,
+  target: target.value,
+  selectedFile: selectedFile.value.path,
+  options: { ...options.value },
+  files: files.value.map((file) => ({ ...file })),
+}));
+
+const payloadJson = computed(() => JSON.stringify(payload.value, null, 2));
+const permalink = computed(() => createInspectorUrl(payload.value));
+const pullRequestUrl = computed(() =>
+  createPullRequestUrl({
+    permalink: permalink.value,
+    payload: payload.value,
+    stats: report.value?.stats ?? { additions: 0, removals: 0, unchanged: 0 },
+  }),
+);
+const permalinkTooLong = computed(() => permalink.value.length > 7000);
+const hasChanges = computed(
+  () => (report.value?.stats.additions ?? 0) > 0 || (report.value?.stats.removals ?? 0) > 0,
+);
+
+function applyPayload(nextPayload: InspectorPayload) {
+  files.value = nextPayload.files.map((file, index) => ({
+    path: file.path || `repro-${index + 1}.vue`,
+    source: file.source,
+  }));
+  target.value = nextPayload.target === "ssr" ? "ssr" : "dom";
+  options.value = {
+    customRenderer: nextPayload.options?.customRenderer ?? false,
+    vueParserQuirks: nextPayload.options?.vueParserQuirks ?? false,
+  };
+  const selected = nextPayload.selectedFile
+    ? files.value.findIndex((file) => file.path === nextPayload.selectedFile)
+    : 0;
+  selectedFileIndex.value = selected >= 0 ? selected : 0;
+}
+
+async function compile() {
+  const compiler = props.compiler ?? getWasm();
+  if (!compiler) return;
+
+  isCompiling.value = true;
+  error.value = null;
+
+  try {
+    report.value = await compileInspectorReport({
+      compiler,
+      file: selectedFile.value,
+      target: target.value,
+      options: options.value,
+    });
+  } catch (compileError) {
+    error.value = compileError instanceof Error ? compileError.message : String(compileError);
+  } finally {
+    isCompiling.value = false;
+  }
+}
+
+let compileTimer: ReturnType<typeof setTimeout> | null = null;
+function scheduleCompile() {
+  if (compileTimer) clearTimeout(compileTimer);
+  compileTimer = setTimeout(() => {
+    void compile();
+  }, 250);
+}
+
+function openPullRequest() {
+  window.open(pullRequestUrl.value, "_blank", "noopener,noreferrer");
+}
+
+watch(
+  [source, target, options, selectedFileIndex],
+  () => {
+    if (props.compiler ?? getWasm()) scheduleCompile();
+  },
+  { deep: true },
+);
+
+watch(
+  () => props.compiler,
+  () => {
+    if (props.compiler) void compile();
+  },
+  { immediate: true },
+);
+
+let hasCompilerInitialized = false;
+let pollInterval: ReturnType<typeof setInterval> | null = null;
+
+function tryInitialize() {
+  const compiler = getWasm();
+  if (compiler && !hasCompilerInitialized) {
+    hasCompilerInitialized = true;
+    if (pollInterval) {
+      clearInterval(pollInterval);
+      pollInterval = null;
+    }
+    void compile();
+  }
+}
+
+onMounted(() => {
+  const urlPayload = readInspectorPayloadFromUrl();
+  if (urlPayload) {
+    applyPayload(urlPayload);
+  }
+
+  tryInitialize();
+  if (!hasCompilerInitialized) {
+    pollInterval = setInterval(tryInitialize, 100);
+    setTimeout(() => {
+      if (pollInterval) {
+        clearInterval(pollInterval);
+        pollInterval = null;
+      }
+    }, 10000);
+  }
+});
+
+onUnmounted(() => {
+  if (compileTimer) clearTimeout(compileTimer);
+  if (pollInterval) {
+    clearInterval(pollInterval);
+    pollInterval = null;
+  }
+});
+</script>
+
+<template>
+  <div class="panel input-panel">
+    <div class="panel-header">
+      <h2>Inspector Source</h2>
+      <div class="panel-actions">
+        <button class="btn-ghost" @click="copyToClipboard(source)">Copy</button>
+        <button class="btn-ghost" @click="copyToClipboard(permalink)">Permalink</button>
+        <button class="btn-ghost" @click="copyToClipboard(payloadJson)">Payload</button>
+      </div>
+    </div>
+
+    <div class="inspector-file-list">
+      <button
+        v-for="(file, index) in files"
+        :key="`${file.path}-${index}`"
+        :class="['inspector-file-tab', { active: selectedFileIndex === index }]"
+        :title="file.path"
+        @click="selectedFileIndex = index"
+      >
+        {{ file.path }}
+      </button>
+    </div>
+
+    <div class="panel-header">
+      <div class="inspector-controls">
+        <div class="inspector-targets" aria-label="Compiler target">
+          <button
+            :class="['inspector-target', { active: target === 'dom' }]"
+            @click="target = 'dom'"
+          >
+            DOM
+          </button>
+          <button
+            :class="['inspector-target', { active: target === 'ssr' }]"
+            @click="target = 'ssr'"
+          >
+            SSR
+          </button>
+        </div>
+        <label class="inspector-option">
+          <input v-model="options.customRenderer" type="checkbox" />
+          <span>custom renderer</span>
+        </label>
+        <label class="inspector-option">
+          <input v-model="options.vueParserQuirks" type="checkbox" />
+          <span>Vue parser quirks</span>
+        </label>
+      </div>
+    </div>
+
+    <div class="editor-container">
+      <MonacoEditor v-model="source" language="vue" :theme />
+    </div>
+  </div>
+
+  <div class="panel output-panel">
+    <div class="panel-header">
+      <h2>
+        Compiler Diff
+        <span v-if="report" class="compile-time">
+          {{ (report.official.timeMs + report.vize.timeMs).toFixed(2) }}ms
+        </span>
+      </h2>
+      <div class="tabs">
+        <button
+          :class="['tab', { active: activeOutputTab === 'diff' }]"
+          @click="activeOutputTab = 'diff'"
+        >
+          Diff
+        </button>
+        <button
+          :class="['tab', { active: activeOutputTab === 'official' }]"
+          @click="activeOutputTab = 'official'"
+        >
+          Vue
+        </button>
+        <button
+          :class="['tab', { active: activeOutputTab === 'vize' }]"
+          @click="activeOutputTab = 'vize'"
+        >
+          Vize
+        </button>
+        <button
+          :class="['tab', { active: activeOutputTab === 'payload' }]"
+          @click="activeOutputTab = 'payload'"
+        >
+          Payload
+        </button>
+        <a
+          class="inspector-pr-link tab-copy-btn"
+          href="https://github.com/ubugeeei/vize/compare/main...compiler-inspector-repro"
+          target="_blank"
+          rel="noreferrer"
+          @click.prevent="openPullRequest"
+        >
+          <svg viewBox="0 0 24 24" aria-hidden="true">
+            <path :d="mdiGithub" />
+          </svg>
+          <span>Create PR</span>
+        </a>
+      </div>
+    </div>
+
+    <div class="output-content">
+      <div v-if="isCompiling" class="compiling">
+        <div class="spinner" />
+        <span>Compiling...</span>
+      </div>
+
+      <div v-else-if="error" class="wasm-error">
+        <h3>Inspector Error</h3>
+        <pre>{{ error }}</pre>
+      </div>
+
+      <template v-else-if="report">
+        <div class="inspector-summary">
+          <div class="inspector-stat">
+            <span class="inspector-stat-value">{{ report.target.toUpperCase() }}</span>
+            <span class="inspector-stat-label">target</span>
+          </div>
+          <div class="inspector-stat">
+            <span class="inspector-stat-value">{{ hasChanges ? "diff" : "same" }}</span>
+            <span class="inspector-stat-label">status</span>
+          </div>
+          <div class="inspector-stat">
+            <span class="inspector-stat-value">+{{ report.stats.additions }}</span>
+            <span class="inspector-stat-label">Vize-only lines</span>
+          </div>
+          <div class="inspector-stat">
+            <span class="inspector-stat-value">-{{ report.stats.removals }}</span>
+            <span class="inspector-stat-label">Vue-only lines</span>
+          </div>
+        </div>
+
+        <div
+          v-if="report.official.warnings.length > 0 || report.vize.warnings.length > 0"
+          class="inspector-warning-list"
+        >
+          <pre
+            v-for="(warning, index) in [...report.official.warnings, ...report.vize.warnings]"
+            :key="index"
+            class="inspector-warning"
+            >{{ warning }}</pre
+          >
+        </div>
+
+        <div v-if="activeOutputTab === 'diff'" class="inspector-tab-panel">
+          <div v-if="report.diff.length === 0" class="inspector-empty-diff">
+            Both compilers produced empty output.
+          </div>
+          <div v-else class="inspector-diff">
+            <div
+              v-for="(line, index) in report.diff"
+              :key="index"
+              :class="['inspector-diff-line', line.kind]"
+            >
+              <span class="inspector-diff-num">{{ line.leftLine ?? "" }}</span>
+              <span class="inspector-diff-num">{{ line.rightLine ?? "" }}</span>
+              <span class="inspector-diff-mark">{{
+                line.kind === "add" ? "+" : line.kind === "remove" ? "-" : ""
+              }}</span>
+              <code class="inspector-diff-code">{{ line.text || " " }}</code>
+            </div>
+          </div>
+        </div>
+
+        <CodeHighlight
+          v-else-if="activeOutputTab === 'official'"
+          :code="report.official.formattedCode || report.official.error || report.official.code"
+          :language="report.official.parser === 'typescript' ? 'typescript' : 'javascript'"
+          :theme
+          show-line-numbers
+        />
+
+        <CodeHighlight
+          v-else-if="activeOutputTab === 'vize'"
+          :code="report.vize.formattedCode || report.vize.error || report.vize.code"
+          :language="report.vize.parser === 'typescript' ? 'typescript' : 'javascript'"
+          :theme
+          show-line-numbers
+        />
+
+        <div v-else>
+          <pre class="inspector-payload">{{ payloadJson }}</pre>
+          <p v-if="permalinkTooLong" class="inspector-url-note">
+            Permalink is long; prefer copying the payload for this batch.
+          </p>
+        </div>
+      </template>
+    </div>
+  </div>
+</template>

--- a/playground/src/features/inspector/InspectorPlayground.vue
+++ b/playground/src/features/inspector/InspectorPlayground.vue
@@ -9,9 +9,11 @@ import { useClipboard } from "../../utils/useClipboard";
 import { useTheme } from "../../utils/useTheme";
 import { type loadWasm, getWasm } from "../../wasm/index";
 import { compileInspectorReport } from "./compareCompilers";
+import { parseVirLines } from "../croquis/useVirTokenizer";
 import { createInspectorUrl, createPullRequestUrl, readInspectorPayloadFromUrl } from "./share";
 import type {
   InspectorFile,
+  InspectorGraphEdge,
   InspectorOptions,
   InspectorPayload,
   InspectorReport,
@@ -40,7 +42,9 @@ const options = ref<InspectorOptions>({
 const report = ref<InspectorReport | null>(null);
 const error = ref<string | null>(null);
 const isCompiling = ref(false);
-const activeOutputTab = ref<"diff" | "official" | "vize" | "payload">("diff");
+const activeOutputTab = ref<
+  "compare" | "official" | "vize" | "virtual-ts" | "vir" | "graph" | "payload"
+>("compare");
 
 const selectedFile = computed(() => files.value[selectedFileIndex.value] ?? files.value[0]!);
 const source = computed({
@@ -74,6 +78,50 @@ const permalinkTooLong = computed(() => permalink.value.length > 7000);
 const hasChanges = computed(
   () => (report.value?.stats.additions ?? 0) > 0 || (report.value?.stats.removals ?? 0) > 0,
 );
+const inspectorMessages = computed(() => {
+  if (!report.value) return [];
+  return [
+    ...report.value.official.warnings,
+    ...report.value.vize.warnings,
+    ...report.value.virtualTs.warnings,
+    ...report.value.vir.warnings,
+    ...(report.value.virtualTs.error ? [`Virtual TS: ${report.value.virtualTs.error}`] : []),
+    ...(report.value.vir.error ? [`VIR: ${report.value.vir.error}`] : []),
+    ...(report.value.graph.error ? [`Graph: ${report.value.graph.error}`] : []),
+  ];
+});
+const totalInspectTime = computed(() =>
+  report.value
+    ? report.value.official.timeMs +
+      report.value.vize.timeMs +
+      report.value.virtualTs.timeMs +
+      report.value.vir.timeMs +
+      report.value.graph.timeMs
+    : 0,
+);
+const virLines = computed(() => parseVirLines(report.value?.vir.code ?? ""));
+const graphDiagnostics = computed(() => report.value?.graph.diagnostics ?? []);
+const graphSummary = computed(() => {
+  const graph = report.value?.graph;
+  return {
+    nodes: graph?.nodes.length ?? 0,
+    edges: graph?.edges.length ?? 0,
+    diagnostics: graph?.diagnostics.length ?? 0,
+    cycles: graph?.circularDependencies.length ?? 0,
+  };
+});
+const graphEdgesBySource = computed(() => {
+  const grouped: Record<string, InspectorGraphEdge[]> = {};
+  for (const edge of report.value?.graph.edges ?? []) {
+    if (!grouped[edge.from]) grouped[edge.from] = [];
+    grouped[edge.from].push(edge);
+  }
+  return grouped;
+});
+
+function graphEdgesFor(path: string): InspectorGraphEdge[] {
+  return graphEdgesBySource.value[path] ?? [];
+}
 
 function applyPayload(nextPayload: InspectorPayload) {
   files.value = nextPayload.files.map((file, index) => ({
@@ -102,6 +150,7 @@ async function compile() {
     report.value = await compileInspectorReport({
       compiler,
       file: selectedFile.value,
+      files: files.value,
       target: target.value,
       options: options.value,
     });
@@ -240,17 +289,15 @@ onUnmounted(() => {
   <div class="panel output-panel">
     <div class="panel-header">
       <h2>
-        Compiler Diff
-        <span v-if="report" class="compile-time">
-          {{ (report.official.timeMs + report.vize.timeMs).toFixed(2) }}ms
-        </span>
+        Compiler Inspector
+        <span v-if="report" class="compile-time"> {{ totalInspectTime.toFixed(2) }}ms </span>
       </h2>
       <div class="tabs">
         <button
-          :class="['tab', { active: activeOutputTab === 'diff' }]"
-          @click="activeOutputTab = 'diff'"
+          :class="['tab', { active: activeOutputTab === 'compare' }]"
+          @click="activeOutputTab = 'compare'"
         >
-          Diff
+          Compare
         </button>
         <button
           :class="['tab', { active: activeOutputTab === 'official' }]"
@@ -263,6 +310,24 @@ onUnmounted(() => {
           @click="activeOutputTab = 'vize'"
         >
           Vize
+        </button>
+        <button
+          :class="['tab', { active: activeOutputTab === 'virtual-ts' }]"
+          @click="activeOutputTab = 'virtual-ts'"
+        >
+          Virtual TS
+        </button>
+        <button
+          :class="['tab', { active: activeOutputTab === 'vir' }]"
+          @click="activeOutputTab = 'vir'"
+        >
+          VIR
+        </button>
+        <button
+          :class="['tab', { active: activeOutputTab === 'graph' }]"
+          @click="activeOutputTab = 'graph'"
+        >
+          Graph
         </button>
         <button
           :class="['tab', { active: activeOutputTab === 'payload' }]"
@@ -303,8 +368,8 @@ onUnmounted(() => {
             <span class="inspector-stat-label">target</span>
           </div>
           <div class="inspector-stat">
-            <span class="inspector-stat-value">{{ hasChanges ? "diff" : "same" }}</span>
-            <span class="inspector-stat-label">status</span>
+            <span class="inspector-stat-value">{{ hasChanges ? "changed" : "same" }}</span>
+            <span class="inspector-stat-label">compiler output</span>
           </div>
           <div class="inspector-stat">
             <span class="inspector-stat-value">+{{ report.stats.additions }}</span>
@@ -316,21 +381,18 @@ onUnmounted(() => {
           </div>
         </div>
 
-        <div
-          v-if="report.official.warnings.length > 0 || report.vize.warnings.length > 0"
-          class="inspector-warning-list"
-        >
+        <div v-if="inspectorMessages.length > 0" class="inspector-warning-list">
           <pre
-            v-for="(warning, index) in [...report.official.warnings, ...report.vize.warnings]"
+            v-for="(warning, index) in inspectorMessages"
             :key="index"
             class="inspector-warning"
             >{{ warning }}</pre
           >
         </div>
 
-        <div v-if="activeOutputTab === 'diff'" class="inspector-tab-panel">
+        <div v-if="activeOutputTab === 'compare'" class="inspector-tab-panel">
           <div v-if="report.diff.length === 0" class="inspector-empty-diff">
-            Both compilers produced empty output.
+            Both compiler outputs are empty.
           </div>
           <div v-else class="inspector-diff">
             <div
@@ -363,6 +425,105 @@ onUnmounted(() => {
           :theme
           show-line-numbers
         />
+
+        <CodeHighlight
+          v-else-if="activeOutputTab === 'virtual-ts'"
+          :code="
+            report.virtualTs.formattedCode ||
+            report.virtualTs.error ||
+            report.virtualTs.code ||
+            'No Virtual TS generated.'
+          "
+          language="typescript"
+          :theme
+          show-line-numbers
+        />
+
+        <div v-else-if="activeOutputTab === 'vir'" class="inspector-vir-output">
+          <div class="inspector-vir-header">
+            <span>VIR</span>
+            <span>{{ virLines.length }} lines</span>
+          </div>
+          <div class="inspector-vir-content">
+            <div
+              v-for="line in virLines"
+              :key="line.index"
+              :class="['inspector-vir-line', `vir-line-${line.lineType}`]"
+            >
+              <span class="inspector-vir-ln">{{ line.index + 1 }}</span>
+              <span class="inspector-vir-line-text"
+                ><template v-if="line.tokens.length > 0"
+                  ><span
+                    v-for="(token, tokenIndex) in line.tokens"
+                    :key="tokenIndex"
+                    :class="['vir-token', `vir-${token.type}`]"
+                    >{{ token.text }}</span
+                  ></template
+                ><template v-else><span>&#160;</span></template></span
+              >
+            </div>
+          </div>
+          <div v-if="virLines.length === 0" class="inspector-empty-diff">No VIR generated.</div>
+        </div>
+
+        <div v-else-if="activeOutputTab === 'graph'" class="inspector-graph-panel">
+          <div class="inspector-graph-summary">
+            <span>{{ graphSummary.nodes }} files</span>
+            <span>{{ graphSummary.edges }} edges</span>
+            <span>{{ graphSummary.diagnostics }} diagnostics</span>
+            <span>{{ graphSummary.cycles }} cycles</span>
+          </div>
+
+          <div class="inspector-graph">
+            <div
+              v-for="node in report.graph.nodes"
+              :key="node.path"
+              :class="[
+                'inspector-graph-node',
+                {
+                  active: node.path === selectedFile.path,
+                  entry: node.isEntry,
+                  issues: node.issueCount > 0,
+                },
+              ]"
+            >
+              <div class="inspector-graph-node-main">
+                <span class="inspector-graph-file">{{ node.path }}</span>
+                <span class="inspector-graph-kind">{{ node.kind }}</span>
+                <span v-if="node.issueCount > 0" class="inspector-graph-issues">
+                  {{ node.issueCount }}
+                </span>
+              </div>
+              <div class="inspector-graph-node-meta">
+                <span>{{ node.sourceLines }} lines</span>
+                <span>{{ node.sourceBytes }} bytes</span>
+              </div>
+              <div v-if="graphEdgesFor(node.path).length > 0" class="inspector-graph-edges">
+                <div
+                  v-for="edge in graphEdgesFor(node.path)"
+                  :key="`${edge.from}-${edge.to}-${edge.kind}-${edge.specifier}`"
+                  class="inspector-graph-edge"
+                >
+                  <span class="inspector-graph-edge-kind">{{ edge.kind }}</span>
+                  <span class="inspector-graph-arrow">-&gt;</span>
+                  <span class="inspector-graph-target">{{ edge.to }}</span>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div v-if="graphDiagnostics.length > 0" class="inspector-graph-diagnostics">
+            <div
+              v-for="(diagnostic, index) in graphDiagnostics"
+              :key="`${diagnostic.file}-${diagnostic.code}-${index}`"
+              :class="['inspector-graph-diagnostic', diagnostic.severity]"
+            >
+              <span class="inspector-graph-diagnostic-code">{{ diagnostic.code }}</span>
+              <span class="inspector-graph-diagnostic-file">{{ diagnostic.file }}</span>
+              <span class="inspector-graph-diagnostic-message">{{ diagnostic.message }}</span>
+            </div>
+          </div>
+        </div>
 
         <div v-else>
           <pre class="inspector-payload">{{ payloadJson }}</pre>

--- a/playground/src/features/inspector/compareCompilers.test.ts
+++ b/playground/src/features/inspector/compareCompilers.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it, vi } from "vite-plus/test";
+import { compileInspectorReport } from "./compareCompilers";
+import type { CompilerOptions, WasmModule } from "../../wasm/index";
+
+vi.mock("../atelier/formatters", () => ({
+  formatCode: vi.fn(async (code: string, parser: string) => `[${parser}]\n${code}`),
+}));
+
+describe("compileInspectorReport", () => {
+  it("includes virtual ts, vir, and graph inspector outputs", async () => {
+    const compileSfc = vi.fn((_: string, options: CompilerOptions) => ({
+      descriptor: {
+        filename: "src/App.vue",
+        source: "",
+        template: {
+          content: "{{ msg }}",
+          loc: { start: 0, end: 0 },
+          attrs: {},
+        },
+        script: undefined,
+        scriptSetup: { content: "", loc: { start: 0, end: 0 }, attrs: {}, setup: true },
+        styles: [],
+        customBlocks: [],
+      },
+      script: { code: options.ssr ? "export const ssr = true;" : "export const dom = true;" },
+      warnings: [],
+    }));
+    const typeCheck = vi.fn(() => ({
+      diagnostics: [
+        {
+          severity: "warning" as const,
+          message: "virtual note",
+          start: 0,
+          end: 0,
+          code: "vts-note",
+          related: [],
+        },
+      ],
+      virtualTs: "const __vts = 1;",
+      errorCount: 0,
+      warningCount: 1,
+    }));
+    const analyzeSfc = vi.fn(() => ({
+      croquis: {
+        is_setup: true,
+        bindings: [],
+        scopes: [],
+        macros: [],
+        props: [],
+        emits: [],
+        provides: [],
+        injects: [],
+        typeExports: [],
+        invalidExports: [],
+        diagnostics: [],
+        stats: {
+          binding_count: 0,
+          unused_binding_count: 0,
+          scope_count: 0,
+          macro_count: 0,
+          type_export_count: 0,
+          invalid_export_count: 0,
+          error_count: 0,
+          warning_count: 0,
+        },
+      },
+      diagnostics: [],
+      vir: "[vir]\nbindings=0\n",
+    }));
+    const analyzeCrossFile = vi.fn(() => ({
+      diagnostics: [],
+      circularDependencies: [],
+      stats: {
+        filesAnalyzed: 2,
+        vueComponents: 2,
+        dependencyEdges: 1,
+        errorCount: 0,
+        warningCount: 0,
+        infoCount: 0,
+        analysisTimeMs: 0,
+      },
+      filePaths: ["src/App.vue", "src/Child.vue"],
+    }));
+    const compiler = {
+      compileSfc,
+      typeCheck,
+      analyzeSfc,
+      analyzeCrossFile,
+    } as unknown as WasmModule;
+
+    const report = await compileInspectorReport({
+      compiler,
+      file: {
+        path: "src/App.vue",
+        source:
+          "<script setup>import Child from './Child.vue'; const msg = 'hi'</script><template><Child />{{ msg }}</template>",
+      },
+      files: [
+        {
+          path: "src/App.vue",
+          source:
+            "<script setup>import Child from './Child.vue'; const msg = 'hi'</script><template><Child />{{ msg }}</template>",
+        },
+        {
+          path: "src/Child.vue",
+          source: "<template><span /></template>",
+        },
+      ],
+      target: "dom",
+    });
+
+    expect(report.virtualTs.code).toBe("const __vts = 1;");
+    expect(report.virtualTs.formattedCode).toContain("[typescript]");
+    expect(report.virtualTs.warnings).toEqual(["warning vts-note: virtual note"]);
+    expect(report.vir.code).toBe("[vir]\nbindings=0\n");
+    expect(report.graph.nodes).toHaveLength(2);
+    expect(report.graph.edges).toEqual([
+      {
+        from: "src/App.vue",
+        to: "src/Child.vue",
+        kind: "import",
+        specifier: "./Child.vue",
+      },
+      {
+        from: "src/App.vue",
+        to: "src/Child.vue",
+        kind: "component",
+        specifier: "./Child.vue",
+      },
+    ]);
+    expect(typeCheck).toHaveBeenCalledWith(expect.any(String), {
+      filename: "src/App.vue",
+      includeVirtualTs: true,
+    });
+  });
+});

--- a/playground/src/features/inspector/compareCompilers.ts
+++ b/playground/src/features/inspector/compareCompilers.ts
@@ -1,0 +1,191 @@
+import {
+  compileScript,
+  compileTemplate,
+  parse,
+  type BindingMetadata,
+  type SFCDescriptor,
+} from "vue/compiler-sfc";
+import type { CompilerOptions, WasmModule } from "../../wasm/index";
+import { formatCode } from "../atelier/formatters";
+import { buildLineDiff, getDiffStats } from "./diff";
+import type {
+  CompilerRun,
+  InspectorFile,
+  InspectorOptions,
+  InspectorReport,
+  InspectorTarget,
+} from "./types";
+
+const DEFAULT_OPTIONS: InspectorOptions = {
+  customRenderer: false,
+  vueParserQuirks: false,
+};
+
+function toErrorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  return String(error);
+}
+
+function normalizeCompilerMessages(messages: unknown[] | undefined): string[] {
+  return (messages ?? []).map((message) => {
+    if (message instanceof Error) return message.message;
+    if (typeof message === "object" && message && "message" in message) {
+      return String((message as { message: unknown }).message);
+    }
+    return String(message);
+  });
+}
+
+function descriptorUsesTypeScript(descriptor: SFCDescriptor): boolean {
+  const langs = [descriptor.script?.lang, descriptor.scriptSetup?.lang];
+  return langs.some((lang) => lang === "ts" || lang === "tsx");
+}
+
+function outputText(run: CompilerRun): string {
+  return run.error ?? run.formattedCode ?? run.code;
+}
+
+async function formatRunCode(code: string, parser: CompilerRun["parser"]): Promise<string> {
+  if (!code) return "";
+  return formatCode(code, parser);
+}
+
+async function compileOfficialVue(
+  file: InspectorFile,
+  target: InspectorTarget,
+): Promise<CompilerRun> {
+  const start = performance.now();
+
+  try {
+    const parsed = parse(file.source, { filename: file.path });
+    const descriptor = parsed.descriptor;
+    const isTypeScript = descriptorUsesTypeScript(descriptor);
+    const parser = isTypeScript ? "typescript" : "babel";
+    const warnings = normalizeCompilerMessages(parsed.errors);
+    let bindingMetadata: BindingMetadata = {};
+    let scriptCode = "";
+
+    if (descriptor.script || descriptor.scriptSetup) {
+      const script = compileScript(descriptor, {
+        id: file.path,
+        inlineTemplate: false,
+      });
+      scriptCode = script.content;
+      bindingMetadata = script.bindings;
+    }
+
+    let templateCode = "";
+    if (descriptor.template) {
+      const template = compileTemplate({
+        source: descriptor.template.content,
+        filename: file.path,
+        id: file.path,
+        scoped: descriptor.styles.some((style) => style.scoped),
+        ssr: target === "ssr",
+        compilerOptions: {
+          bindingMetadata,
+          expressionPlugins: isTypeScript ? ["typescript"] : undefined,
+        },
+      });
+      templateCode = template.code;
+      warnings.push(...normalizeCompilerMessages(template.errors));
+      warnings.push(...normalizeCompilerMessages(template.tips));
+    }
+
+    const code = [scriptCode, templateCode].filter(Boolean).join("\n\n");
+    const formattedCode = await formatRunCode(code, parser);
+    return {
+      label: "@vue/compiler-sfc",
+      code,
+      formattedCode,
+      parser,
+      warnings,
+      error: null,
+      timeMs: performance.now() - start,
+    };
+  } catch (error) {
+    return {
+      label: "@vue/compiler-sfc",
+      code: "",
+      formattedCode: "",
+      parser: "babel",
+      warnings: [],
+      error: toErrorMessage(error),
+      timeMs: performance.now() - start,
+    };
+  }
+}
+
+async function compileVize(
+  compiler: WasmModule,
+  file: InspectorFile,
+  target: InspectorTarget,
+  options: InspectorOptions,
+): Promise<CompilerRun> {
+  const start = performance.now();
+
+  try {
+    const compileOptions: CompilerOptions = {
+      mode: "module",
+      filename: file.path,
+      ssr: target === "ssr",
+      scriptExt: "preserve",
+      outputMode: "vdom",
+      customRenderer: options.customRenderer,
+      vueParserQuirks: options.vueParserQuirks,
+    };
+    const result = compiler.compileSfc(file.source, compileOptions);
+    const code = result.script?.code || result.template?.code || "";
+    const parser = descriptorUsesTypeScript(result.descriptor as SFCDescriptor)
+      ? "typescript"
+      : "babel";
+    const formattedCode = await formatRunCode(code, parser);
+    return {
+      label: "Vize",
+      code,
+      formattedCode,
+      parser,
+      warnings: result.warnings ?? [],
+      error: null,
+      timeMs: performance.now() - start,
+    };
+  } catch (error) {
+    return {
+      label: "Vize",
+      code: "",
+      formattedCode: "",
+      parser: "babel",
+      warnings: [],
+      error: toErrorMessage(error),
+      timeMs: performance.now() - start,
+    };
+  }
+}
+
+export async function compileInspectorReport({
+  compiler,
+  file,
+  target,
+  options,
+}: {
+  compiler: WasmModule;
+  file: InspectorFile;
+  target: InspectorTarget;
+  options?: Partial<InspectorOptions>;
+}): Promise<InspectorReport> {
+  const normalizedOptions = { ...DEFAULT_OPTIONS, ...options };
+  const [official, vize] = await Promise.all([
+    compileOfficialVue(file, target),
+    compileVize(compiler, file, target, normalizedOptions),
+  ]);
+  const diff = buildLineDiff(outputText(official), outputText(vize));
+
+  return {
+    filename: file.path,
+    target,
+    official,
+    vize,
+    diff,
+    stats: getDiffStats(diff),
+  };
+}

--- a/playground/src/features/inspector/compareCompilers.ts
+++ b/playground/src/features/inspector/compareCompilers.ts
@@ -5,12 +5,19 @@ import {
   type BindingMetadata,
   type SFCDescriptor,
 } from "vue/compiler-sfc";
-import type { CompilerOptions, WasmModule } from "../../wasm/index";
+import type {
+  CompilerOptions,
+  CroquisDiagnostic,
+  TypeCheckDiagnostic,
+  WasmModule,
+} from "../../wasm/index";
 import { formatCode } from "../atelier/formatters";
 import { buildLineDiff, getDiffStats } from "./diff";
+import { buildInspectorGraph } from "./graph";
 import type {
   CompilerRun,
   InspectorFile,
+  InspectorGraphRun,
   InspectorOptions,
   InspectorReport,
   InspectorTarget,
@@ -43,6 +50,16 @@ function descriptorUsesTypeScript(descriptor: SFCDescriptor): boolean {
 
 function outputText(run: CompilerRun): string {
   return run.error ?? run.formattedCode ?? run.code;
+}
+
+function formatTypeCheckDiagnostic(diagnostic: TypeCheckDiagnostic): string {
+  const code = diagnostic.code ? ` ${diagnostic.code}` : "";
+  return `${diagnostic.severity}${code}: ${diagnostic.message}`;
+}
+
+function formatCroquisDiagnostic(diagnostic: CroquisDiagnostic): string {
+  const code = diagnostic.code ? ` ${diagnostic.code}` : "";
+  return `${diagnostic.severity}${code}: ${diagnostic.message}`;
 }
 
 async function formatRunCode(code: string, parser: CompilerRun["parser"]): Promise<string> {
@@ -162,21 +179,128 @@ async function compileVize(
   }
 }
 
+async function inspectVirtualTs(compiler: WasmModule, file: InspectorFile): Promise<CompilerRun> {
+  const start = performance.now();
+
+  try {
+    const result = compiler.typeCheck(file.source, {
+      filename: file.path,
+      includeVirtualTs: true,
+    });
+    const code = result.virtualTs ?? "";
+    const formattedCode = await formatRunCode(code, "typescript");
+
+    return {
+      label: "Virtual TS",
+      code,
+      formattedCode,
+      parser: "typescript",
+      warnings: result.diagnostics.map(formatTypeCheckDiagnostic),
+      error: null,
+      timeMs: performance.now() - start,
+    };
+  } catch (error) {
+    return {
+      label: "Virtual TS",
+      code: "",
+      formattedCode: "",
+      parser: "typescript",
+      warnings: [],
+      error: toErrorMessage(error),
+      timeMs: performance.now() - start,
+    };
+  }
+}
+
+function inspectVir(compiler: WasmModule, file: InspectorFile): CompilerRun {
+  const start = performance.now();
+
+  try {
+    const result = compiler.analyzeSfc(file.source, { filename: file.path });
+    const code = result.vir ?? "";
+
+    return {
+      label: "VIR",
+      code,
+      formattedCode: code,
+      parser: "babel",
+      warnings: result.diagnostics.map(formatCroquisDiagnostic),
+      error: null,
+      timeMs: performance.now() - start,
+    };
+  } catch (error) {
+    return {
+      label: "VIR",
+      code: "",
+      formattedCode: "",
+      parser: "babel",
+      warnings: [],
+      error: toErrorMessage(error),
+      timeMs: performance.now() - start,
+    };
+  }
+}
+
+function inspectCrossFileGraph(compiler: WasmModule, files: InspectorFile[]): InspectorGraphRun {
+  const start = performance.now();
+  const graph = buildInspectorGraph(files);
+
+  try {
+    const result = compiler.analyzeCrossFile(
+      files.map((file) => ({ path: file.path, source: file.source })),
+      { all: true, maxImportDepth: 10 },
+    );
+    const issueCounts = new Map<string, number>();
+    for (const diagnostic of result.diagnostics) {
+      issueCounts.set(diagnostic.file, (issueCounts.get(diagnostic.file) ?? 0) + 1);
+    }
+
+    return {
+      nodes: graph.nodes.map((node) => ({
+        ...node,
+        issueCount: issueCounts.get(node.path) ?? 0,
+      })),
+      edges: graph.edges,
+      diagnostics: result.diagnostics,
+      circularDependencies: result.circularDependencies,
+      stats: result.stats,
+      error: null,
+      timeMs: performance.now() - start,
+    };
+  } catch (error) {
+    return {
+      nodes: graph.nodes,
+      edges: graph.edges,
+      diagnostics: [],
+      circularDependencies: [],
+      stats: null,
+      error: toErrorMessage(error),
+      timeMs: performance.now() - start,
+    };
+  }
+}
+
 export async function compileInspectorReport({
   compiler,
   file,
+  files,
   target,
   options,
 }: {
   compiler: WasmModule;
   file: InspectorFile;
+  files?: InspectorFile[];
   target: InspectorTarget;
   options?: Partial<InspectorOptions>;
 }): Promise<InspectorReport> {
   const normalizedOptions = { ...DEFAULT_OPTIONS, ...options };
-  const [official, vize] = await Promise.all([
+  const inspectedFiles = files?.length ? files : [file];
+  const [official, vize, virtualTs, vir, graph] = await Promise.all([
     compileOfficialVue(file, target),
     compileVize(compiler, file, target, normalizedOptions),
+    inspectVirtualTs(compiler, file),
+    Promise.resolve(inspectVir(compiler, file)),
+    Promise.resolve(inspectCrossFileGraph(compiler, inspectedFiles)),
   ]);
   const diff = buildLineDiff(outputText(official), outputText(vize));
 
@@ -185,6 +309,9 @@ export async function compileInspectorReport({
     target,
     official,
     vize,
+    virtualTs,
+    vir,
+    graph,
     diff,
     stats: getDiffStats(diff),
   };

--- a/playground/src/features/inspector/diff.test.ts
+++ b/playground/src/features/inspector/diff.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vite-plus/test";
+import { buildLineDiff, getDiffStats } from "./diff";
+
+describe("buildLineDiff", () => {
+  it("creates a full unified line diff", () => {
+    const diff = buildLineDiff("one\ntwo\nthree", "one\nTWO\nthree\nfour");
+
+    expect(diff).toEqual([
+      { kind: "same", leftLine: 1, rightLine: 1, text: "one" },
+      { kind: "remove", leftLine: 2, rightLine: null, text: "two" },
+      { kind: "add", leftLine: null, rightLine: 2, text: "TWO" },
+      { kind: "same", leftLine: 3, rightLine: 3, text: "three" },
+      { kind: "add", leftLine: null, rightLine: 4, text: "four" },
+    ]);
+    expect(getDiffStats(diff)).toEqual({
+      additions: 2,
+      removals: 1,
+      unchanged: 2,
+    });
+  });
+});

--- a/playground/src/features/inspector/diff.ts
+++ b/playground/src/features/inspector/diff.ts
@@ -1,0 +1,90 @@
+import type { DiffLine, DiffStats } from "./types";
+
+function splitLines(value: string): string[] {
+  if (!value) return [];
+  return value.replace(/\r\n/g, "\n").split("\n");
+}
+
+export function buildLineDiff(left: string, right: string): DiffLine[] {
+  const leftLines = splitLines(left);
+  const rightLines = splitLines(right);
+  const rows = leftLines.length + 1;
+  const cols = rightLines.length + 1;
+  const table: number[][] = Array.from({ length: rows }, () => Array(cols).fill(0));
+
+  for (let leftIndex = leftLines.length - 1; leftIndex >= 0; leftIndex -= 1) {
+    for (let rightIndex = rightLines.length - 1; rightIndex >= 0; rightIndex -= 1) {
+      table[leftIndex]![rightIndex] =
+        leftLines[leftIndex] === rightLines[rightIndex]
+          ? table[leftIndex + 1]![rightIndex + 1]! + 1
+          : Math.max(table[leftIndex + 1]![rightIndex]!, table[leftIndex]![rightIndex + 1]!);
+    }
+  }
+
+  const diff: DiffLine[] = [];
+  let leftIndex = 0;
+  let rightIndex = 0;
+
+  while (leftIndex < leftLines.length && rightIndex < rightLines.length) {
+    if (leftLines[leftIndex] === rightLines[rightIndex]) {
+      diff.push({
+        kind: "same",
+        leftLine: leftIndex + 1,
+        rightLine: rightIndex + 1,
+        text: leftLines[leftIndex]!,
+      });
+      leftIndex += 1;
+      rightIndex += 1;
+    } else if (table[leftIndex + 1]![rightIndex]! >= table[leftIndex]![rightIndex + 1]!) {
+      diff.push({
+        kind: "remove",
+        leftLine: leftIndex + 1,
+        rightLine: null,
+        text: leftLines[leftIndex]!,
+      });
+      leftIndex += 1;
+    } else {
+      diff.push({
+        kind: "add",
+        leftLine: null,
+        rightLine: rightIndex + 1,
+        text: rightLines[rightIndex]!,
+      });
+      rightIndex += 1;
+    }
+  }
+
+  while (leftIndex < leftLines.length) {
+    diff.push({
+      kind: "remove",
+      leftLine: leftIndex + 1,
+      rightLine: null,
+      text: leftLines[leftIndex]!,
+    });
+    leftIndex += 1;
+  }
+
+  while (rightIndex < rightLines.length) {
+    diff.push({
+      kind: "add",
+      leftLine: null,
+      rightLine: rightIndex + 1,
+      text: rightLines[rightIndex]!,
+    });
+    rightIndex += 1;
+  }
+
+  return diff;
+}
+
+export function getDiffStats(diff: DiffLine[]): DiffStats {
+  return diff.reduce<DiffStats>(
+    (stats, line) => {
+      if (line.kind === "add") stats.additions += 1;
+      if (line.kind === "remove") stats.removals += 1;
+      if (line.kind === "same") stats.unchanged += 1;
+      return stats;
+    },
+    { additions: 0, removals: 0, unchanged: 0 },
+  );
+}

--- a/playground/src/features/inspector/graph.ts
+++ b/playground/src/features/inspector/graph.ts
@@ -1,0 +1,203 @@
+import type {
+  InspectorFile,
+  InspectorGraphEdge,
+  InspectorGraphNode,
+  InspectorGraphNodeKind,
+} from "./types";
+
+interface ImportRecord {
+  specifier: string;
+  kind: InspectorGraphEdge["kind"];
+  locals: string[];
+}
+
+export function buildInspectorGraph(files: InspectorFile[]): {
+  nodes: InspectorGraphNode[];
+  edges: InspectorGraphEdge[];
+} {
+  const fileMap = new Map(files.map((file) => [normalizePath(file.path), file]));
+  const nodes = files.map((file) => ({
+    path: normalizePath(file.path),
+    kind: fileKind(file.path),
+    isEntry: isEntryPath(file.path),
+    sourceLines: lineCount(file.source),
+    sourceBytes: new TextEncoder().encode(file.source).length,
+    issueCount: 0,
+  }));
+  const edges: InspectorGraphEdge[] = [];
+
+  for (const file of files) {
+    const from = normalizePath(file.path);
+    for (const record of extractImports(file.source)) {
+      const target = resolveImport(fileMap, from, record.specifier);
+      if (!target) continue;
+
+      pushEdge(edges, {
+        from,
+        to: target.path,
+        kind: record.kind,
+        specifier: record.specifier,
+      });
+
+      if (target.path.endsWith(".vue") && componentIsUsed(file.source, record.locals)) {
+        pushEdge(edges, {
+          from,
+          to: target.path,
+          kind: "component",
+          specifier: record.specifier,
+        });
+      }
+    }
+  }
+
+  return { nodes, edges };
+}
+
+function pushEdge(edges: InspectorGraphEdge[], edge: InspectorGraphEdge) {
+  if (
+    edges.some(
+      (existing) =>
+        existing.from === edge.from &&
+        existing.to === edge.to &&
+        existing.kind === edge.kind &&
+        existing.specifier === edge.specifier,
+    )
+  ) {
+    return;
+  }
+  edges.push(edge);
+}
+
+function extractImports(source: string): ImportRecord[] {
+  const records: ImportRecord[] = [];
+  const staticImportPattern = /import\s+([\s\S]*?)\s+from\s+["']([^"']+)["']/g;
+  const dynamicImportPattern = /import\s*\(\s*["']([^"']+)["']\s*\)/g;
+  let match: RegExpExecArray | null;
+
+  while ((match = staticImportPattern.exec(source)) !== null) {
+    records.push({
+      specifier: match[2],
+      kind: "import",
+      locals: extractImportLocals(match[1]),
+    });
+  }
+
+  while ((match = dynamicImportPattern.exec(source)) !== null) {
+    records.push({
+      specifier: match[1],
+      kind: "dynamic-import",
+      locals: [],
+    });
+  }
+
+  return records;
+}
+
+function extractImportLocals(clause: string): string[] {
+  const locals: string[] = [];
+  const trimmed = clause.trim().replace(/^type\s+/, "");
+  const defaultName = trimmed.split(",")[0]?.trim();
+  if (defaultName && /^[A-Za-z_$][\w$]*$/.test(defaultName)) {
+    locals.push(defaultName);
+  }
+
+  const namedMatch = trimmed.match(/\{([^}]+)\}/);
+  if (namedMatch) {
+    for (const part of namedMatch[1].split(",")) {
+      const local = part
+        .split(/\s+as\s+/)
+        .pop()
+        ?.trim();
+      if (local && /^[A-Za-z_$][\w$]*$/.test(local)) {
+        locals.push(local);
+      }
+    }
+  }
+
+  return locals;
+}
+
+function componentIsUsed(source: string, locals: string[]): boolean {
+  return locals.some((local) => {
+    const pascal = escapeRegExp(local);
+    const kebab = escapeRegExp(toKebabCase(local));
+    return new RegExp(`<\\s*(?:${pascal}|${kebab})(?:\\s|/|>)`).test(source);
+  });
+}
+
+function resolveImport(
+  fileMap: Map<string, InspectorFile>,
+  from: string,
+  specifier: string,
+): { path: string; file: InspectorFile } | null {
+  if (!specifier.startsWith(".")) return null;
+  for (const candidate of importCandidates(from, specifier)) {
+    const file = fileMap.get(candidate);
+    if (file) return { path: candidate, file };
+  }
+  return null;
+}
+
+function importCandidates(from: string, specifier: string): string[] {
+  const base = normalizePath(`${parentPath(from)}/${specifier}`);
+  const candidates = [base];
+
+  if (!hasKnownExtension(base)) {
+    for (const extension of [".vue", ".ts", ".tsx", ".js", ".jsx"]) {
+      candidates.push(`${base}${extension}`);
+    }
+    for (const extension of ["/index.vue", "/index.ts", "/index.js"]) {
+      candidates.push(`${base}${extension}`);
+    }
+  }
+
+  return candidates;
+}
+
+function normalizePath(path: string): string {
+  const parts: string[] = [];
+  for (const part of path.replace(/\\/g, "/").split("/")) {
+    if (!part || part === ".") continue;
+    if (part === "..") {
+      parts.pop();
+      continue;
+    }
+    parts.push(part);
+  }
+  return parts.join("/");
+}
+
+function parentPath(path: string): string {
+  return path.includes("/") ? path.slice(0, path.lastIndexOf("/")) : "";
+}
+
+function fileKind(path: string): InspectorGraphNodeKind {
+  if (path.endsWith(".vue")) return "vue";
+  if (path.endsWith(".ts") || path.endsWith(".tsx")) return "typescript";
+  if (path.endsWith(".js") || path.endsWith(".jsx")) return "javascript";
+  return "other";
+}
+
+function isEntryPath(path: string): boolean {
+  const basename = path.split("/").pop();
+  return basename === "App.vue" || basename === "app.vue" || basename === "index.vue";
+}
+
+function hasKnownExtension(path: string): boolean {
+  return /\.(vue|ts|tsx|js|jsx)$/.test(path);
+}
+
+function lineCount(source: string): number {
+  return source ? source.split("\n").length : 0;
+}
+
+function toKebabCase(value: string): string {
+  return value
+    .replace(/([a-z0-9])([A-Z])/g, "$1-$2")
+    .replace(/_/g, "-")
+    .toLowerCase();
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/playground/src/features/inspector/share.test.ts
+++ b/playground/src/features/inspector/share.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vite-plus/test";
+import {
+  createInspectorUrl,
+  createPullRequestBody,
+  decodeInspectorPayload,
+  encodeInspectorPayload,
+  readInspectorPayloadFromUrl,
+} from "./share";
+import type { InspectorPayload } from "./types";
+
+const payload: InspectorPayload = {
+  version: 1,
+  target: "dom",
+  selectedFile: "src/App.vue",
+  options: {
+    customRenderer: false,
+    vueParserQuirks: true,
+  },
+  files: [
+    {
+      path: "src/App.vue",
+      source: "<template><div>{{ msg }}</div></template>",
+    },
+  ],
+};
+
+describe("inspector share payloads", () => {
+  it("round-trips encoded payloads", () => {
+    expect(decodeInspectorPayload(encodeInspectorPayload(payload))).toEqual(payload);
+  });
+
+  it("creates and reads playground URLs", () => {
+    const url = createInspectorUrl(payload, "https://vizejs.dev/play/?tab=atelier");
+
+    expect(url).toMatch(/^https:\/\/vizejs\.dev\/play\/\?tab=inspector#inspector=/);
+    expect(readInspectorPayloadFromUrl(url)).toEqual(payload);
+  });
+
+  it("builds a complete PR body with the permalink and diff summary", () => {
+    const body = createPullRequestBody({
+      permalink: "https://vizejs.dev/play/?tab=inspector#inspector=abc",
+      payload,
+      stats: {
+        additions: 2,
+        removals: 1,
+        unchanged: 5,
+      },
+    });
+
+    expect(body).toEqual(`## Compiler inspector
+
+Playground permalink: https://vizejs.dev/play/?tab=inspector#inspector=abc
+
+### Scope
+
+- Target: DOM
+- Files: 1
+- Diff: +2 / -1
+
+### Repro files
+
+- \`src/App.vue\`
+
+### Notes
+
+Generated from the Vize playground compiler inspector. Please add the minimized fixture or snapshot that explains the parity change.`);
+  });
+});

--- a/playground/src/features/inspector/share.test.ts
+++ b/playground/src/features/inspector/share.test.ts
@@ -55,7 +55,8 @@ Playground permalink: https://vizejs.dev/play/?tab=inspector#inspector=abc
 
 - Target: DOM
 - Files: 1
-- Diff: +2 / -1
+- Output delta: +2 / -1
+- Includes: Vue output, Vize output, Virtual TS, VIR, and cross-file graph
 
 ### Repro files
 
@@ -63,6 +64,6 @@ Playground permalink: https://vizejs.dev/play/?tab=inspector#inspector=abc
 
 ### Notes
 
-Generated from the Vize playground compiler inspector. Please add the minimized fixture or snapshot that explains the parity change.`);
+Generated from the Vize playground compiler inspector. Please add the minimized fixture or full snapshot that explains the parity change.`);
   });
 });

--- a/playground/src/features/inspector/share.ts
+++ b/playground/src/features/inspector/share.ts
@@ -58,7 +58,8 @@ export function createPullRequestBody({
     "",
     `- Target: ${target}`,
     `- Files: ${payload.files.length}`,
-    `- Diff: +${stats.additions} / -${stats.removals}`,
+    `- Output delta: +${stats.additions} / -${stats.removals}`,
+    "- Includes: Vue output, Vize output, Virtual TS, VIR, and cross-file graph",
     "",
     "### Repro files",
     "",
@@ -66,7 +67,7 @@ export function createPullRequestBody({
     "",
     "### Notes",
     "",
-    "Generated from the Vize playground compiler inspector. Please add the minimized fixture or snapshot that explains the parity change.",
+    "Generated from the Vize playground compiler inspector. Please add the minimized fixture or full snapshot that explains the parity change.",
   ].join("\n");
 }
 

--- a/playground/src/features/inspector/share.ts
+++ b/playground/src/features/inspector/share.ts
@@ -1,0 +1,91 @@
+import type { DiffStats, InspectorPayload } from "./types";
+
+export const INSPECTOR_HASH_KEY = "inspector";
+const REPOSITORY_URL = "https://github.com/ubugeeei/vize";
+
+export function encodeInspectorPayload(payload: InspectorPayload): string {
+  return encodeURIComponent(JSON.stringify(payload));
+}
+
+export function decodeInspectorPayload(value: string): InspectorPayload | null {
+  try {
+    const decoded = decodeURIComponent(value);
+    const payload = JSON.parse(decoded) as Partial<InspectorPayload>;
+    if (payload.version !== 1 || !Array.isArray(payload.files) || payload.files.length === 0) {
+      return null;
+    }
+    return payload as InspectorPayload;
+  } catch {
+    return null;
+  }
+}
+
+export function readInspectorPayloadFromUrl(href = window.location.href): InspectorPayload | null {
+  const url = new URL(href);
+  const hash = url.hash.replace(/^#/, "");
+  if (!hash) return null;
+
+  const params = new URLSearchParams(hash);
+  const value = params.get(INSPECTOR_HASH_KEY) ?? params.get("payload") ?? hash;
+  return decodeInspectorPayload(value);
+}
+
+export function createInspectorUrl(payload: InspectorPayload, href = window.location.href): string {
+  const url = new URL(href);
+  url.searchParams.set("tab", "inspector");
+  url.hash = `${INSPECTOR_HASH_KEY}=${encodeInspectorPayload(payload)}`;
+  return url.toString();
+}
+
+export function createPullRequestBody({
+  permalink,
+  payload,
+  stats,
+}: {
+  permalink: string;
+  payload: InspectorPayload;
+  stats: DiffStats;
+}): string {
+  const files = payload.files.map((file) => `- \`${file.path}\``).join("\n");
+  const target = payload.target === "ssr" ? "SSR" : "DOM";
+
+  return [
+    "## Compiler inspector",
+    "",
+    `Playground permalink: ${permalink}`,
+    "",
+    "### Scope",
+    "",
+    `- Target: ${target}`,
+    `- Files: ${payload.files.length}`,
+    `- Diff: +${stats.additions} / -${stats.removals}`,
+    "",
+    "### Repro files",
+    "",
+    files,
+    "",
+    "### Notes",
+    "",
+    "Generated from the Vize playground compiler inspector. Please add the minimized fixture or snapshot that explains the parity change.",
+  ].join("\n");
+}
+
+export function createPullRequestUrl({
+  permalink,
+  payload,
+  stats,
+}: {
+  permalink: string;
+  payload: InspectorPayload;
+  stats: DiffStats;
+}): string {
+  const title = "fix(compiler): align Vue compiler output";
+  const body = createPullRequestBody({ permalink, payload, stats });
+  const params = new URLSearchParams({
+    quick_pull: "1",
+    title,
+    body,
+  });
+
+  return `${REPOSITORY_URL}/compare/main...compiler-inspector-repro?${params.toString()}`;
+}

--- a/playground/src/features/inspector/types.ts
+++ b/playground/src/features/inspector/types.ts
@@ -1,3 +1,5 @@
+import type { CrossFileDiagnostic, CrossFileStats } from "../../wasm/index";
+
 export type InspectorTarget = "dom" | "ssr";
 
 export interface InspectorOptions {
@@ -33,8 +35,41 @@ export interface InspectorReport {
   target: InspectorTarget;
   official: CompilerRun;
   vize: CompilerRun;
+  virtualTs: CompilerRun;
+  vir: CompilerRun;
+  graph: InspectorGraphRun;
   diff: DiffLine[];
   stats: DiffStats;
+}
+
+export type InspectorGraphNodeKind = "vue" | "typescript" | "javascript" | "other";
+
+export interface InspectorGraphNode {
+  path: string;
+  kind: InspectorGraphNodeKind;
+  isEntry: boolean;
+  sourceLines: number;
+  sourceBytes: number;
+  issueCount: number;
+}
+
+export type InspectorGraphEdgeKind = "import" | "dynamic-import" | "component";
+
+export interface InspectorGraphEdge {
+  from: string;
+  to: string;
+  kind: InspectorGraphEdgeKind;
+  specifier: string;
+}
+
+export interface InspectorGraphRun {
+  nodes: InspectorGraphNode[];
+  edges: InspectorGraphEdge[];
+  diagnostics: CrossFileDiagnostic[];
+  circularDependencies: string[][];
+  stats: CrossFileStats | null;
+  error: string | null;
+  timeMs: number;
 }
 
 export type DiffLineKind = "same" | "remove" | "add";

--- a/playground/src/features/inspector/types.ts
+++ b/playground/src/features/inspector/types.ts
@@ -1,0 +1,53 @@
+export type InspectorTarget = "dom" | "ssr";
+
+export interface InspectorOptions {
+  customRenderer: boolean;
+  vueParserQuirks: boolean;
+}
+
+export interface InspectorFile {
+  path: string;
+  source: string;
+}
+
+export interface InspectorPayload {
+  version: 1;
+  target: InspectorTarget;
+  files: InspectorFile[];
+  selectedFile?: string;
+  options?: Partial<InspectorOptions>;
+}
+
+export interface CompilerRun {
+  label: string;
+  code: string;
+  formattedCode: string;
+  parser: "babel" | "typescript";
+  warnings: string[];
+  error: string | null;
+  timeMs: number;
+}
+
+export interface InspectorReport {
+  filename: string;
+  target: InspectorTarget;
+  official: CompilerRun;
+  vize: CompilerRun;
+  diff: DiffLine[];
+  stats: DiffStats;
+}
+
+export type DiffLineKind = "same" | "remove" | "add";
+
+export interface DiffLine {
+  kind: DiffLineKind;
+  leftLine: number | null;
+  rightLine: number | null;
+  text: string;
+}
+
+export interface DiffStats {
+  additions: number;
+  removals: number;
+  unchanged: number;
+}

--- a/playground/src/wasm/types/compiler.ts
+++ b/playground/src/wasm/types/compiler.ts
@@ -13,6 +13,8 @@ export interface CompilerOptions {
   isTs?: boolean;
   // Script extension: 'preserve' keeps TypeScript, 'downcompile' (default) transpiles to JS
   scriptExt?: "preserve" | "downcompile";
+  customRenderer?: boolean;
+  vueParserQuirks?: boolean;
   bindingMetadata?: SfcBindingMetadata;
 }
 

--- a/playground/vite.app.config.ts
+++ b/playground/vite.app.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
     alias: [
       { find: "@mdi/js", replacement: "@mdi/js/mdi.js" },
       { find: /^monaco-editor$/, replacement: "monaco-editor/esm/vs/editor/editor.main.js" },
-      { find: "vue", replacement: "vue/dist/vue.runtime.esm-bundler.js" },
+      { find: /^vue$/, replacement: "vue/dist/vue.runtime.esm-bundler.js" },
     ],
     dedupe: ["vue"],
   },

--- a/playground/vite.test.config.ts
+++ b/playground/vite.test.config.ts
@@ -7,7 +7,7 @@ const testOutputIgnorePattern = ["**", "target", "vize-tests", "**"].join("/");
 export default defineConfig({
   plugins: [vize()],
   resolve: {
-    alias: [{ find: "vue", replacement: "vue/dist/vue.runtime.esm-bundler.js" }],
+    alias: [{ find: /^vue$/, replacement: "vue/dist/vue.runtime.esm-bundler.js" }],
     dedupe: ["vue"],
   },
   optimizeDeps: {


### PR DESCRIPTION
## Summary

- Expand the playground Compiler Inspector with Virtual TS, VIR, and cross-file graph views alongside Vue/Vize output comparison.
- Add local-only `vize_curator` for inspector payload, playground URL, graph, and AI-agent report generation.
- Extend `vize inspector` with `--format agent` for batch/local handoff, plus docs for contributors and CLI users.

Thanks to the external repro reports that shaped this inspector workflow and made the missing evidence paths clear.

## Validation

- `cargo fmt --all`
- `cargo test -p vize_curator`
- `cargo test -p vize --test inspector_cli`
- `cargo test -p vize cli::tests::inspector_help_snapshot`
- `cargo check -p vize --tests`
- `vp check src/features/inspector src/wasm/types/compiler.ts`
- `CI=1 vp test run --config vite.test.config.ts src/features/inspector/share.test.ts src/features/inspector/diff.test.ts src/features/inspector/compareCompilers.test.ts`
- `vp build --config vite.app.config.ts`
- Browser check at `http://127.0.0.1:5180/?tab=inspector`: Virtual TS/VIR/Graph tabs render, 2-file graph payload shows 2 nodes / 2 edges, and console has no warnings/errors.
