### PR TITLE
fix(canon): keep typeof-anchored types inside __setup scope

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3598,6 +3598,7 @@ dependencies = [
  "once_cell",
  "oxc_allocator",
  "oxc_ast",
+ "oxc_ast_visit",
  "oxc_parser",
  "oxc_span",
  "phf 0.13.1",

--- a/crates/vize_canon/src/sfc_typecheck.rs
+++ b/crates/vize_canon/src/sfc_typecheck.rs
@@ -302,6 +302,48 @@ const count = ref(0);
     }
 
     #[test]
+    fn test_type_check_typeof_setup_const_stays_in_setup_scope() {
+        // Regression: vize check used to lift `type Name = ...` to module
+        // scope while the `const names` it referenced via `typeof` stayed
+        // inside `__setup`, producing a spurious
+        // "Cannot find name 'names'" diagnostic.
+        // See https://github.com/ushironoko/vize-config-repro#repro-8.
+        let source = r#"<script setup lang="ts">
+type Name = (typeof names)[number]
+const names = ['a', 'b', 'c'] as const
+const value: Name = 'a'
+</script>
+<template>
+    <div>{{ value }}</div>
+</template>"#;
+        let options = SfcTypeCheckOptions::new("test.vue").with_virtual_ts();
+        let result = type_check_sfc(source, &options);
+
+        // The type alias must not be lifted above the const it depends on.
+        let virtual_ts = result.virtual_ts.clone().expect("virtual ts produced");
+        let setup_start = virtual_ts
+            .find("function __setup()")
+            .expect("__setup function emitted");
+        let type_pos = virtual_ts
+            .find("type Name = (typeof names)[number]")
+            .expect("type alias emitted somewhere");
+        assert!(
+            type_pos > setup_start,
+            "type alias was hoisted above __setup; setup_start={setup_start}, \
+             type_pos={type_pos}:\n{virtual_ts}"
+        );
+
+        assert!(
+            !result
+                .diagnostics
+                .iter()
+                .any(|d| d.message.as_str().contains("Cannot find name 'names'")),
+            "regressed: 'Cannot find name names' surfaced again: {:#?}",
+            result.diagnostics
+        );
+    }
+
+    #[test]
     fn test_type_check_virtual_ts_generation() {
         let source = r#"<script setup lang="ts">
 const props = defineProps<{ count: number }>();

--- a/crates/vize_canon/src/virtual_ts/generator.rs
+++ b/crates/vize_canon/src/virtual_ts/generator.rs
@@ -133,7 +133,11 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
             module_spans.push((re.start, re.end));
         }
         for te in &summary.type_exports {
-            module_spans.push((te.start, te.end));
+            // Non-hoisted types reference setup-scope values via `typeof`
+            // and must stay inside `__setup` so TS can resolve them.
+            if te.hoisted {
+                module_spans.push((te.start, te.end));
+            }
         }
         module_spans.sort_by_key(|&(start, _)| start);
         module_spans

--- a/crates/vize_croquis/Cargo.toml
+++ b/crates/vize_croquis/Cargo.toml
@@ -21,6 +21,7 @@ regex.workspace = true
 # OXC for high-performance AST parsing
 oxc_parser.workspace = true
 oxc_ast.workspace = true
+oxc_ast_visit.workspace = true
 oxc_span.workspace = true
 oxc_allocator.workspace = true
 

--- a/crates/vize_croquis/src/script_parser.rs
+++ b/crates/vize_croquis/src/script_parser.rs
@@ -16,6 +16,7 @@
 
 mod extract;
 mod process;
+mod typeof_refs;
 mod walk;
 
 use oxc_allocator::Allocator;
@@ -109,9 +110,65 @@ pub struct ScriptParseResult {
     pub component_registrations: Vec<ComponentRegistration>,
     /// Definition spans for bindings (name -> (start, end) offset in script)
     pub binding_spans: FxHashMap<CompactString, (u32, u32)>,
+    /// Names referenced via `typeof X` in the body of each `type_exports`
+    /// entry, indexed in parallel with `type_exports`. Used by
+    /// `resolve_type_export_hoisting` to keep types adjacent to the
+    /// setup-scope values they depend on. Pushed to in lockstep with
+    /// `type_exports` via `record_type_export`.
+    pub(crate) type_export_typeof_refs: Vec<FxHashSet<CompactString>>,
 }
 
 impl ScriptParseResult {
+    /// Record a `TypeExport` together with the `typeof` value-identifier
+    /// references found in its body. Must be the only call site that pushes
+    /// to `type_exports` so the two vectors stay in lockstep for
+    /// `resolve_type_export_hoisting`.
+    pub(crate) fn record_type_export(
+        &mut self,
+        export: TypeExport,
+        typeof_refs: FxHashSet<CompactString>,
+    ) {
+        self.type_exports.push(export);
+        self.type_export_typeof_refs.push(typeof_refs);
+    }
+
+    /// Demote `TypeExport::hoisted` to `false` for any type whose body
+    /// references a setup-scope value binding via `typeof`. The virtual TS
+    /// generator only lifts hoisted types to module scope, so demoted types
+    /// stay inside the synthetic `__setup` function alongside the values
+    /// they depend on — which is the only place TS can resolve them.
+    ///
+    /// Imports add value bindings at module scope, so a `typeof importedName`
+    /// reference is left as hoisted: the import is visible from the module
+    /// scope where the type lands.
+    pub(crate) fn resolve_type_export_hoisting(&mut self) {
+        if self.type_export_typeof_refs.is_empty() {
+            return;
+        }
+        let imported_names: FxHashSet<&str> = self
+            .import_statements
+            .iter()
+            .flat_map(|imp| {
+                // Bindings whose declaration site falls inside an import
+                // statement are module-scoped imports, not setup values.
+                self.binding_spans
+                    .iter()
+                    .filter(move |(_, (start, end))| *start >= imp.start && *end <= imp.end)
+                    .map(|(name, _)| name.as_str())
+            })
+            .collect();
+
+        for (idx, refs) in self.type_export_typeof_refs.iter().enumerate() {
+            let touches_setup_value = refs.iter().any(|name| {
+                let key = name.as_str();
+                self.bindings.bindings.contains_key(key) && !imported_names.contains(key)
+            });
+            if touches_setup_value && let Some(te) = self.type_exports.get_mut(idx) {
+                te.hoisted = false;
+            }
+        }
+    }
+
     /// Apply script analysis fields to an existing SFC analysis summary.
     ///
     /// This keeps script parsing as the single owner of script-scoped data while
@@ -312,6 +369,14 @@ pub fn parse_script_setup_with_generic(source: &str, generic: Option<&str>) -> S
         }
     });
 
+    // After every binding is known, demote any `type` / `interface` that
+    // references a setup-scope value via `typeof` so the virtual TS keeps
+    // it inside `__setup` instead of hoisting it to module scope.
+    profile!(
+        "croquis.script_setup.resolve_type_hoisting",
+        result.resolve_type_export_hoisting()
+    );
+
     result
 }
 
@@ -370,6 +435,13 @@ pub fn parse_script(source: &str) -> ScriptParseResult {
             process::process_statement(&mut result, stmt, source);
         }
     });
+
+    // Mirror the setup path so non-setup scripts also keep typeof-anchored
+    // types adjacent to their value bindings in any downstream emitters.
+    profile!(
+        "croquis.script_plain.resolve_type_hoisting",
+        result.resolve_type_export_hoisting()
+    );
 
     result
 }

--- a/crates/vize_croquis/src/script_parser/extract.rs
+++ b/crates/vize_croquis/src/script_parser/extract.rs
@@ -2073,24 +2073,31 @@ pub fn get_binding_type_from_kind(kind: VariableDeclarationKind) -> BindingType 
 
 /// Process type export (export type / export interface)
 pub fn process_type_export(result: &mut ScriptParseResult, decl: &Declaration<'_>, span: Span) {
+    let typeof_refs = super::typeof_refs::collect_from_declaration(decl);
     match decl {
         Declaration::TSTypeAliasDeclaration(type_alias) => {
-            result.type_exports.push(TypeExport {
-                name: CompactString::new(type_alias.id.name.as_str()),
-                kind: TypeExportKind::Type,
-                start: span.start,
-                end: span.end,
-                hoisted: true,
-            });
+            result.record_type_export(
+                TypeExport {
+                    name: CompactString::new(type_alias.id.name.as_str()),
+                    kind: TypeExportKind::Type,
+                    start: span.start,
+                    end: span.end,
+                    hoisted: true,
+                },
+                typeof_refs,
+            );
         }
         Declaration::TSInterfaceDeclaration(interface) => {
-            result.type_exports.push(TypeExport {
-                name: CompactString::new(interface.id.name.as_str()),
-                kind: TypeExportKind::Interface,
-                start: span.start,
-                end: span.end,
-                hoisted: true,
-            });
+            result.record_type_export(
+                TypeExport {
+                    name: CompactString::new(interface.id.name.as_str()),
+                    kind: TypeExportKind::Interface,
+                    start: span.start,
+                    end: span.end,
+                    hoisted: true,
+                },
+                typeof_refs,
+            );
         }
         _ => {}
     }

--- a/crates/vize_croquis/src/script_parser/process.rs
+++ b/crates/vize_croquis/src/script_parser/process.rs
@@ -239,25 +239,33 @@ pub fn process_statement(result: &mut ScriptParseResult, stmt: &Statement<'_>, s
         Statement::TSTypeAliasDeclaration(type_alias) => {
             // Type aliases are allowed (not bindings, but tracked)
             let name = type_alias.id.name.as_str();
-            result.type_exports.push(TypeExport {
-                name: CompactString::new(name),
-                kind: TypeExportKind::Type,
-                start: type_alias.span.start,
-                end: type_alias.span.end,
-                hoisted: true,
-            });
+            let typeof_refs = super::typeof_refs::collect_from_type_alias(type_alias);
+            result.record_type_export(
+                TypeExport {
+                    name: CompactString::new(name),
+                    kind: TypeExportKind::Type,
+                    start: type_alias.span.start,
+                    end: type_alias.span.end,
+                    hoisted: true,
+                },
+                typeof_refs,
+            );
         }
 
         Statement::TSInterfaceDeclaration(interface) => {
             // Interfaces are allowed (not bindings, but tracked)
             let name = interface.id.name.as_str();
-            result.type_exports.push(TypeExport {
-                name: CompactString::new(name),
-                kind: TypeExportKind::Interface,
-                start: interface.span.start,
-                end: interface.span.end,
-                hoisted: true,
-            });
+            let typeof_refs = super::typeof_refs::collect_from_interface(interface);
+            result.record_type_export(
+                TypeExport {
+                    name: CompactString::new(name),
+                    kind: TypeExportKind::Interface,
+                    start: interface.span.start,
+                    end: interface.span.end,
+                    hoisted: true,
+                },
+                typeof_refs,
+            );
         }
 
         // Block statements at top level (scoped blocks)

--- a/crates/vize_croquis/src/script_parser/typeof_refs.rs
+++ b/crates/vize_croquis/src/script_parser/typeof_refs.rs
@@ -1,0 +1,123 @@
+//! Collects identifiers referenced via `typeof X` in type position.
+//!
+//! Used by virtual-TS generation to decide whether a `type` / `interface`
+//! declaration may be hoisted to module scope. If the body of a type
+//! declaration uses `typeof X` and `X` is a setup-scope value binding
+//! (i.e. a `const`/`let`/`var`/function declared inside `<script setup>`),
+//! the declaration must stay in the setup function — otherwise the
+//! generated TS at module level cannot resolve `X` and TS reports
+//! `Cannot find name 'X'`.
+
+use oxc_ast::ast::{
+    TSInterfaceDeclaration, TSType, TSTypeAliasDeclaration, TSTypeName, TSTypeQueryExprName,
+};
+use oxc_ast_visit::{Visit, walk};
+use vize_carton::{CompactString, FxHashSet};
+
+/// Visitor that records the leftmost identifier of every `typeof X[.Y.Z]`
+/// it encounters inside a TypeScript type tree.
+#[derive(Default)]
+pub(crate) struct TypeofValueRefs {
+    pub idents: FxHashSet<CompactString>,
+}
+
+impl<'a> Visit<'a> for TypeofValueRefs {
+    fn visit_ts_type_query_expr_name(&mut self, it: &TSTypeQueryExprName<'a>) {
+        match it {
+            TSTypeQueryExprName::IdentifierReference(id) => {
+                self.idents.insert(CompactString::new(id.name.as_str()));
+            }
+            TSTypeQueryExprName::QualifiedName(qn) => {
+                // `typeof A.B.C` — only the root identifier `A` resolves to a
+                // value binding; `.B.C` are property lookups on that value's
+                // type.
+                let mut left = &qn.left;
+                loop {
+                    match left {
+                        TSTypeName::IdentifierReference(id) => {
+                            self.idents.insert(CompactString::new(id.name.as_str()));
+                            break;
+                        }
+                        TSTypeName::QualifiedName(inner) => left = &inner.left,
+                        TSTypeName::ThisExpression(_) => break,
+                    }
+                }
+            }
+            TSTypeQueryExprName::TSImportType(_) => {
+                // `typeof import('foo')` resolves at module scope; never a
+                // setup-scope reference.
+            }
+            // `typeof this` is permitted by the TSTypeQueryExprName grammar
+            // via inherited TSTypeName variants but never names a value
+            // binding we can detect, so just skip it.
+            _ => {}
+        }
+        walk::walk_ts_type_query_expr_name(self, it);
+    }
+}
+
+/// Collect `typeof` value identifier refs in a type alias body
+/// (`type X = ...`), including its generic parameter constraints and
+/// default types.
+pub(crate) fn collect_from_type_alias(
+    decl: &TSTypeAliasDeclaration<'_>,
+) -> FxHashSet<CompactString> {
+    let mut visitor = TypeofValueRefs::default();
+    visitor.visit_ts_type(&decl.type_annotation);
+    if let Some(params) = &decl.type_parameters {
+        for param in params.params.iter() {
+            if let Some(constraint) = &param.constraint {
+                visitor.visit_ts_type(constraint);
+            }
+            if let Some(default) = &param.default {
+                visitor.visit_ts_type(default);
+            }
+        }
+    }
+    visitor.idents
+}
+
+/// Collect `typeof` value identifier refs in an interface body
+/// (`interface X { ... }`), including its extends clauses and generic
+/// parameter constraints / defaults.
+pub(crate) fn collect_from_interface(
+    decl: &TSInterfaceDeclaration<'_>,
+) -> FxHashSet<CompactString> {
+    let mut visitor = TypeofValueRefs::default();
+    visitor.visit_ts_interface_body(&decl.body);
+    for clause in decl.extends.iter() {
+        if let Some(args) = &clause.type_arguments {
+            for arg in args.params.iter() {
+                visitor.visit_ts_type(arg);
+            }
+        }
+    }
+    if let Some(params) = &decl.type_parameters {
+        for param in params.params.iter() {
+            if let Some(constraint) = &param.constraint {
+                visitor.visit_ts_type(constraint);
+            }
+            if let Some(default) = &param.default {
+                visitor.visit_ts_type(default);
+            }
+        }
+    }
+    visitor.idents
+}
+
+/// Dispatch helper: collect refs from any `Declaration` that may carry
+/// a type alias or interface (used by `export type` / `export interface`).
+pub(crate) fn collect_from_declaration(
+    decl: &oxc_ast::ast::Declaration<'_>,
+) -> FxHashSet<CompactString> {
+    match decl {
+        oxc_ast::ast::Declaration::TSTypeAliasDeclaration(t) => collect_from_type_alias(t),
+        oxc_ast::ast::Declaration::TSInterfaceDeclaration(i) => collect_from_interface(i),
+        _ => FxHashSet::default(),
+    }
+}
+
+// `TSType` is re-exported here so the `Visit` impl above type-checks against
+// the AST crate version used by the workspace.
+#[allow(dead_code)]
+fn _ts_type_witness(_: &TSType<'_>) {}

--- a/crates/vize_croquis/src/snapshots/vize_croquis__script_parser__tests__parse_imports.snap
+++ b/crates/vize_croquis/src/snapshots/vize_croquis__script_parser__tests__parse_imports.snap
@@ -1311,4 +1311,5 @@ ScriptParseResult {
             79,
         ),
     },
+    type_export_typeof_refs: [],
 }

--- a/crates/vize_croquis/src/snapshots/vize_croquis__script_parser__tests__parse_reactivity.snap
+++ b/crates/vize_croquis/src/snapshots/vize_croquis__script_parser__tests__parse_reactivity.snap
@@ -1299,4 +1299,5 @@ ScriptParseResult {
             24,
         ),
     },
+    type_export_typeof_refs: [],
 }


### PR DESCRIPTION
## Summary

Closes [ushironoko/vize-config-repro / Repro 8](https://github.com/ushironoko/vize-config-repro#repro-8--vize-check-splits-script-setup-type-and-value-declarations-into-different-scopes).

The virtual-TS generator behind `vize check` lifts every `<script setup>` type alias and interface to the **module scope** of the synthesized TS file so `export type Props = …` can surface them. When the type body references a setup-scope value via `typeof X`, the type landed at module level without a way to resolve `X` — and tsc reported `Cannot find name 'X'`.

Reproducer:

```vue
<script setup lang=\"ts\">
type Name = (typeof names)[number]
const names = ['a', 'b', 'c'] as const
const value: Name = 'a'
</script>
```

Before: `error:2:21 [TS2552] Cannot find name 'names'`. After: clean.

## How

- New `script_parser/typeof_refs.rs` in `vize_croquis` uses `oxc_ast_visit::Visit` to walk a TS type tree and record the leftmost identifier of every `TSTypeQuery` (`typeof X.Y.Z` → `X`). It covers type alias bodies *and* generic param constraints/defaults, plus interface bodies / extends clauses.
- `ScriptParseResult` gains a parallel `type_export_typeof_refs` side table; a new `record_type_export` helper is the only push path so the two stay in lockstep.
- After the walk, `resolve_type_export_hoisting` demotes `TypeExport::hoisted = false` whenever a recorded ref names a true setup-scope value binding (imports are excluded by checking `import_statements` against `binding_spans` so `typeof importedThing` still hoists cleanly).
- `vize_canon::virtual_ts::generator` now skips non-hoisted types from the module-span sweep, so they fall through to the line-by-line `__setup` body emission alongside the values they depend on.

## Test plan

- [x] New regression test `test_type_check_typeof_setup_const_stays_in_setup_scope` in `crates/vize_canon/src/sfc_typecheck.rs` asserts the type alias is emitted **after** `function __setup()` and that no \"Cannot find name 'names'\" diagnostic surfaces.
- [x] `cargo test -p vize_canon --lib` — 209 passed
- [x] `cargo test -p vize_croquis --lib` — 144 passed (two existing Debug-snapshot files updated for the new private `type_export_typeof_refs: []` field)
- [x] `cargo test -p vize_croquis_cf --lib` — 108 passed
- [x] `cargo test -p vize_maestro --lib` — 236 passed
- [x] `cargo fmt --all -- --check`