### PR TITLE
refactor: move profile reports to curator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3629,6 +3629,7 @@ dependencies = [
 name = "vize_curator"
 version = "0.134.0"
 dependencies = [
+ "insta",
  "serde",
  "serde_json",
  "vize_carton",

--- a/crates/vize/src/commands.rs
+++ b/crates/vize/src/commands.rs
@@ -12,7 +12,6 @@ pub mod lint;
 #[cfg(feature = "maestro")]
 pub mod lsp;
 pub mod musea;
-pub mod profile;
 #[cfg(feature = "glyph")]
 pub mod ready;
 pub mod upgrade;

--- a/crates/vize/src/commands/build/runner.rs
+++ b/crates/vize/src/commands/build/runner.rs
@@ -22,7 +22,7 @@ use vize_carton::cstr;
 use vize_carton::profile;
 use vize_carton::profiler::{allocation_snapshot, global_profiler};
 
-use crate::commands::profile::{
+use vize_curator::profile::{
     ProfileFileRow, ProfilePhase, ProfilePhaseKind, ProfileReport, print_profile_report,
 };
 

--- a/crates/vize/src/commands/check/runner.rs
+++ b/crates/vize/src/commands/check/runner.rs
@@ -21,9 +21,7 @@ use vize_carton::{
     profiler::{allocation_snapshot, global_profiler},
 };
 
-use crate::commands::profile::{
-    ProfilePhase, ProfilePhaseKind, ProfileReport, print_profile_report,
-};
+use vize_curator::profile::{ProfilePhase, ProfilePhaseKind, ProfileReport, print_profile_report};
 
 use super::{
     CheckArgs,

--- a/crates/vize/src/commands/check/runner/socket.rs
+++ b/crates/vize/src/commands/check/runner/socket.rs
@@ -17,15 +17,13 @@ use vize_carton::{
     profiler::{allocation_snapshot, global_profiler},
 };
 
-use crate::commands::{
-    check::{
-        CheckArgs, JsonRpcResponse, ServerCheckResult,
-        reporting::{JsonFileResult, JsonOutput},
-    },
-    profile::{ProfilePhase, ProfilePhaseKind, ProfileReport, print_profile_report},
+use crate::commands::check::{
+    CheckArgs, JsonRpcResponse, ServerCheckResult,
+    reporting::{JsonFileResult, JsonOutput},
 };
 
 use super::{collect::collect_vue_files, display_path};
+use vize_curator::profile::{ProfilePhase, ProfilePhaseKind, ProfileReport, print_profile_report};
 
 /// Run type checking via Unix socket connection to check-server.
 pub(crate) fn run_with_socket(args: &CheckArgs, socket_path: &str) {

--- a/crates/vize/src/commands/fmt.rs
+++ b/crates/vize/src/commands/fmt.rs
@@ -17,10 +17,10 @@ use vize_carton::{
 };
 use vize_glyph::{Allocator, FormatOptions, format_sfc_with_allocator};
 
-use crate::commands::profile::{
+use crate::config;
+use vize_curator::profile::{
     ProfileFileRow, ProfilePhase, ProfilePhaseKind, ProfileReport, print_profile_report,
 };
-use crate::config;
 
 const NODE_MODULES_DIR: &str = "node_modules";
 const VIZE_CACHE_DIR: &str = ".vize";

--- a/crates/vize/src/commands/lint.rs
+++ b/crates/vize/src/commands/lint.rs
@@ -30,7 +30,7 @@ use vize_patina::{
     format_summary,
 };
 
-use crate::commands::profile::{
+use vize_curator::profile::{
     ProfileFileRow, ProfilePhase, ProfilePhaseKind, ProfileReport, print_profile_report,
 };
 

--- a/crates/vize_curator/Cargo.toml
+++ b/crates/vize_curator/Cargo.toml
@@ -12,3 +12,6 @@ publish = false
 serde = { workspace = true }
 serde_json = { workspace = true }
 vize_carton = { workspace = true }
+
+[dev-dependencies]
+insta.workspace = true

--- a/crates/vize_curator/README.md
+++ b/crates/vize_curator/README.md
@@ -3,8 +3,8 @@
 `vize_curator` contains local-only inspection and reporting helpers for Vize.
 
 The crate is not published. It is meant for developer workflows that package
-compiler inspector payloads, agent-readable reports, graph metadata, and future
-profiling artifacts without growing the public crate surface.
+compiler inspector payloads, agent-readable reports, graph metadata, and profile
+report rendering without growing the public crate surface.
 
 The playground uses this crate through the Vize WASM package so the browser and
 CLI paths share the same native graph and diff logic. JavaScript remains the
@@ -17,6 +17,8 @@ orchestration layer for running `@vue/compiler-sfc` and formatting output.
 - `inspector::build_agent_report`
 - `inspector::build_graph`
 - `inspector::build_diff`
+- `profile::render_profile_report`
+- `profile::print_profile_report`
 
 ## Agent Reports
 
@@ -34,3 +36,14 @@ TypeScript.
 
 The report is intended for local debugging and AI-agent handoff, not as a
 stable public interchange format.
+
+## Profile Reports
+
+`vize build --profile`, `vize lint --profile`, `vize fmt --profile`, and
+`vize check --profile` all render their terminal reports through
+`profile::print_profile_report`.
+
+The low-level profiler remains in `vize_carton` because it is shared by parser,
+compiler, linter, formatter, and type-checker crates. Curator owns the local CLI
+report shape so profiling output can evolve with inspector and agent-facing
+artifacts without making those crates depend on a developer-only package.

--- a/crates/vize_curator/src/lib.rs
+++ b/crates/vize_curator/src/lib.rs
@@ -5,3 +5,4 @@
 //! published crate set.
 
 pub mod inspector;
+pub mod profile;

--- a/crates/vize_curator/src/profile.rs
+++ b/crates/vize_curator/src/profile.rs
@@ -1,4 +1,4 @@
-//! Shared CLI profile report rendering.
+//! Profile report rendering for local CLI tools.
 
 use std::path::PathBuf;
 use std::time::Duration;
@@ -15,13 +15,13 @@ const RED: &str = "\x1b[31m";
 const CYAN: &str = "\x1b[36m";
 
 #[derive(Debug, Clone, Copy)]
-pub(crate) enum ProfilePhaseKind {
+pub enum ProfilePhaseKind {
     Wall,
     Cumulative,
 }
 
 #[derive(Debug, Clone, Copy)]
-pub(crate) struct ProfilePhase {
+pub struct ProfilePhase {
     pub name: &'static str,
     pub duration: Duration,
     pub kind: ProfilePhaseKind,
@@ -29,7 +29,7 @@ pub(crate) struct ProfilePhase {
 }
 
 #[derive(Debug, Clone)]
-pub(crate) struct ProfileFileRow {
+pub struct ProfileFileRow {
     pub path: PathBuf,
     pub bytes: usize,
     pub total: Duration,
@@ -40,7 +40,7 @@ pub(crate) struct ProfileFileRow {
     pub note: Option<String>,
 }
 
-pub(crate) struct ProfileReport<'a> {
+pub struct ProfileReport<'a> {
     pub title: &'a str,
     pub summary: &'a str,
     pub total: Duration,
@@ -54,11 +54,11 @@ pub(crate) struct ProfileReport<'a> {
     pub recommendations: &'a [String],
 }
 
-pub(crate) fn print_profile_report(report: &ProfileReport<'_>) {
+pub fn print_profile_report(report: &ProfileReport<'_>) {
     eprint!("{}", render_profile_report(report));
 }
 
-pub(crate) fn render_profile_report(report: &ProfileReport<'_>) -> String {
+pub fn render_profile_report(report: &ProfileReport<'_>) -> String {
     let mut out = String::default();
 
     appendln!(out);

--- a/crates/vize_curator/src/snapshots/vize_curator__profile__tests__profile_report_snapshot.snap
+++ b/crates/vize_curator/src/snapshots/vize_curator__profile__tests__profile_report_snapshot.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/vize/src/commands/profile.rs
+source: crates/vize_curator/src/profile.rs
 expression: render_profile_report(&report)
 ---
 

--- a/docs/content/architecture/crates.md
+++ b/docs/content/architecture/crates.md
@@ -6,7 +6,7 @@ title: Crates
 
 > **⚠️ Work in Progress:** Vize is under active development. Crate APIs are still changing.
 
-Vize's Rust workspace is organized around 17 primary crates. Each crate owns one slice of the
+Vize's Rust workspace is organized around 18 primary crates. Each crate owns one slice of the
 pipeline so parsing, semantic analysis, code generation, linting, formatting, type checking, and
 editor tooling can share the same syntax model.
 
@@ -38,6 +38,7 @@ editor tooling can share the same syntax model.
 | `vize_canon`   | Vue-aware type checking and virtual TypeScript generation          |
 | `vize_maestro` | Language Server Protocol implementation                            |
 | `vize_musea`   | Musea art parsing, docs, palette generation, autogen, and VRT core |
+| `vize_curator` | Local inspector payloads, graph/diff metadata, and profile reports |
 | `vize_fresco`  | Terminal UI primitives used by TUI-oriented experiments            |
 
 ## Distribution Layers
@@ -51,6 +52,9 @@ editor tooling can share the same syntax model.
 
 - `vize_musea` is the Rust core for Musea art tooling. The gallery UI and dev-server workflow are
   provided by `@vizejs/vite-plugin-musea`.
+- `vize_curator` is not published. It owns local developer artifacts such as inspector payloads,
+  agent reports, cross-file graph metadata, and CLI profile report rendering. The low-level
+  profiler remains in `vize_carton` because shared crates instrument their own hot paths.
 - `vize_vitrine` is the bridge from Rust to JS. Packages such as `@vizejs/native` and
   `@vizejs/wasm` publish its bindings.
 - `vize` is the full Rust CLI crate in the workspace. For v1 alpha, its public binary channel is
@@ -64,6 +68,7 @@ editor tooling can share the same syntax model.
 | `vize fmt`                  | `vize`, `vize_glyph`                                                                     |
 | `vize lint`                 | `vize`, `vize_patina`                                                                    |
 | `vize check`                | `vize`, `vize_canon`                                                                     |
+| `vize inspector`            | `vize`, `vize_curator`                                                                   |
 | `vize lsp`                  | `vize`, `vize_maestro`                                                                   |
 | `@vizejs/vite-plugin`       | `vize_vitrine`, `vize_atelier_sfc`                                                       |
 | `@vizejs/native`            | `vize_vitrine`                                                                           |

--- a/docs/content/guide/cli.md
+++ b/docs/content/guide/cli.md
@@ -63,6 +63,10 @@ When invoked without a command, `vize` defaults to `build`.
 | `lsp`          | Start the language server                       |
 | `ide`          | Install or manage editor integrations           |
 
+All `--profile` terminal reports are rendered by the local-only `vize_curator` crate. The
+instrumentation hooks remain in `vize_carton`, while curator owns the CLI report shape alongside
+inspector and agent-facing artifacts.
+
 ## Build
 
 ```bash


### PR DESCRIPTION
## Summary

- Move CLI profile report rendering from `vize` into the local-only `vize_curator` crate.
- Keep the low-level profiler instrumentation in `vize_carton` so shared compiler, linter, formatter, and checker crates do not depend on curator.
- Update curator and public docs to describe the profile report ownership split.

## Validation

- `cargo fmt --all --check`
- `cargo test -p vize_curator`
- `cargo check -p vize --features glyph,maestro`
- `cargo clippy -p vize_curator --all-targets -- -D warnings`
- `cargo clippy -p vize --features glyph,maestro --lib --bin vize -- -D warnings`