### PR TITLE
feat(inspector): add highlighted diff views

### DIFF
--- a/playground/src/features/inspector/InspectorPlayground.css
+++ b/playground/src/features/inspector/InspectorPlayground.css
@@ -107,38 +107,33 @@
   accent-color: var(--accent-rust);
 }
 
-.inspector-summary {
-  display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: 8px;
-  margin-bottom: 12px;
-}
-
-.inspector-stat {
-  border: 1px solid var(--border-color);
-  border-radius: 6px;
-  padding: 10px;
-  background: var(--bg-secondary);
-  min-width: 0;
-}
-
-.inspector-stat-value {
-  display: block;
-  color: var(--text-primary);
-  font-family: var(--font-mono);
-  font-size: 16px;
-  font-weight: 600;
-}
-
-.inspector-stat-label {
-  display: block;
-  margin-top: 2px;
-  color: var(--text-muted);
-  font-size: 11px;
-}
-
 .inspector-tab-panel {
   min-height: 0;
+}
+
+.inspector-diff-toolbar {
+  display: inline-flex;
+  gap: 4px;
+  margin-bottom: 8px;
+  border: 1px solid var(--border-color);
+  border-radius: 6px;
+  background: var(--bg-tertiary);
+  padding: 2px;
+}
+
+.inspector-diff-mode {
+  border: 0;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: 12px;
+  padding: 4px 10px;
+}
+
+.inspector-diff-mode.active {
+  background: var(--bg-panel);
+  color: var(--text-primary);
 }
 
 .inspector-diff {
@@ -186,11 +181,51 @@
   text-align: center;
 }
 
+.inspector-diff-split {
+  overflow-x: auto;
+}
+
+.inspector-split-line {
+  display: grid;
+  grid-template-columns: 46px minmax(280px, 1fr) 46px minmax(280px, 1fr);
+  min-width: 720px;
+  min-height: 22px;
+  border-bottom: 1px solid rgba(127, 127, 127, 0.08);
+}
+
+.inspector-split-line:last-child {
+  border-bottom: 0;
+}
+
+.inspector-split-code {
+  border-left: 1px solid rgba(127, 127, 127, 0.08);
+}
+
+.inspector-split-code.remove {
+  background: var(--color-error-bg);
+}
+
+.inspector-split-code.add {
+  background: var(--color-success-bg);
+}
+
+.inspector-split-code.empty {
+  background: color-mix(in srgb, var(--bg-tertiary) 45%, transparent);
+}
+
 .inspector-diff-code {
   padding: 2px 10px;
   color: var(--text-primary);
   white-space: pre-wrap;
   word-break: break-word;
+}
+
+.inspector-diff-code span {
+  color: var(--l, inherit);
+}
+
+body[data-theme="dark"] .inspector-diff-code span {
+  color: var(--d, inherit);
 }
 
 .inspector-empty-diff {
@@ -471,10 +506,6 @@
 }
 
 @media (max-width: 900px) {
-  .inspector-summary {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-
   .inspector-diff-line {
     grid-template-columns: 38px 38px 20px minmax(0, 1fr);
   }

--- a/playground/src/features/inspector/InspectorPlayground.vue
+++ b/playground/src/features/inspector/InspectorPlayground.vue
@@ -4,6 +4,11 @@ import { mdiGithub } from "@mdi/js";
 import { computed, onMounted, onUnmounted, ref, watch } from "vue";
 import MonacoEditor from "../../shared/MonacoEditor.vue";
 import CodeHighlight from "../../shared/CodeHighlight.vue";
+import {
+  codeToThemedTokenLines,
+  type CodeHighlightLanguage,
+  type ThemedCodeToken,
+} from "../../shared/codeHighlighting";
 import { PRESETS } from "../../presets";
 import { useClipboard } from "../../utils/useClipboard";
 import { useTheme } from "../../utils/useTheme";
@@ -18,6 +23,7 @@ import type {
   InspectorPayload,
   InspectorReport,
   InspectorTarget,
+  DiffLine,
 } from "./types";
 
 const props = defineProps<{
@@ -45,6 +51,24 @@ const isCompiling = ref(false);
 const activeOutputTab = ref<
   "compare" | "official" | "vize" | "virtual-ts" | "vir" | "graph" | "payload"
 >("compare");
+const diffViewMode = ref<"merged" | "split">("merged");
+const highlightedDiffLines = ref<HighlightedDiffLine[]>([]);
+let latestDiffHighlightId = 0;
+
+type HighlightedDiffLine = DiffLine & {
+  tokens: ThemedCodeToken[];
+};
+
+interface SplitDiffSide {
+  kind: "same" | "remove" | "add" | "empty";
+  line: number | null;
+  tokens: ThemedCodeToken[];
+}
+
+interface SplitDiffRow {
+  left: SplitDiffSide;
+  right: SplitDiffSide;
+}
 
 const selectedFile = computed(() => files.value[selectedFileIndex.value] ?? files.value[0]!);
 const source = computed({
@@ -75,9 +99,6 @@ const pullRequestUrl = computed(() =>
   }),
 );
 const permalinkTooLong = computed(() => permalink.value.length > 7000);
-const hasChanges = computed(
-  () => (report.value?.stats.additions ?? 0) > 0 || (report.value?.stats.removals ?? 0) > 0,
-);
 const inspectorMessages = computed(() => {
   if (!report.value) return [];
   return [
@@ -118,6 +139,12 @@ const graphEdgesBySource = computed(() => {
   }
   return grouped;
 });
+const diffLanguage = computed<CodeHighlightLanguage>(() =>
+  report.value?.official.parser === "typescript" || report.value?.vize.parser === "typescript"
+    ? "typescript"
+    : "javascript",
+);
+const splitDiffRows = computed(() => buildSplitDiffRows(highlightedDiffLines.value));
 
 function graphEdgesFor(path: string): InspectorGraphEdge[] {
   return graphEdgesBySource.value[path] ?? [];
@@ -173,6 +200,113 @@ function openPullRequest() {
   window.open(pullRequestUrl.value, "_blank", "noopener,noreferrer");
 }
 
+function diffLineText(line: DiffLine): string {
+  return line.text || " ";
+}
+
+function renderPlainDiffLines(lines: DiffLine[]): HighlightedDiffLine[] {
+  return lines.map((line) => ({
+    ...line,
+    tokens: [
+      {
+        content: diffLineText(line),
+        darkColor: undefined,
+        lightColor: undefined,
+      },
+    ],
+  }));
+}
+
+function emptySplitSide(): SplitDiffSide {
+  return {
+    kind: "empty",
+    line: null,
+    tokens: [
+      {
+        content: "",
+        darkColor: undefined,
+        lightColor: undefined,
+      },
+    ],
+  };
+}
+
+function toSplitSide(line: HighlightedDiffLine, side: "left" | "right"): SplitDiffSide {
+  return {
+    kind: line.kind,
+    line: side === "left" ? line.leftLine : line.rightLine,
+    tokens: line.tokens,
+  };
+}
+
+function buildSplitDiffRows(lines: HighlightedDiffLine[]): SplitDiffRow[] {
+  const rows: SplitDiffRow[] = [];
+
+  for (let index = 0; index < lines.length; ) {
+    const line = lines[index]!;
+    if (line.kind === "same") {
+      rows.push({
+        left: toSplitSide(line, "left"),
+        right: toSplitSide(line, "right"),
+      });
+      index += 1;
+      continue;
+    }
+
+    const removals: HighlightedDiffLine[] = [];
+    const additions: HighlightedDiffLine[] = [];
+    while (index < lines.length && lines[index]!.kind !== "same") {
+      const changedLine = lines[index]!;
+      if (changedLine.kind === "remove") {
+        removals.push(changedLine);
+      } else {
+        additions.push(changedLine);
+      }
+      index += 1;
+    }
+
+    const rowCount = Math.max(removals.length, additions.length);
+    for (let rowIndex = 0; rowIndex < rowCount; rowIndex += 1) {
+      rows.push({
+        left: removals[rowIndex] ? toSplitSide(removals[rowIndex], "left") : emptySplitSide(),
+        right: additions[rowIndex] ? toSplitSide(additions[rowIndex], "right") : emptySplitSide(),
+      });
+    }
+  }
+
+  return rows;
+}
+
+async function updateDiffHighlights() {
+  const diff = report.value?.diff ?? [];
+  const renderId = ++latestDiffHighlightId;
+  highlightedDiffLines.value = renderPlainDiffLines(diff);
+
+  if (diff.length === 0) {
+    return;
+  }
+
+  const highlightedLines = await codeToThemedTokenLines(
+    diff.map(diffLineText).join("\n"),
+    diffLanguage.value,
+  );
+
+  if (renderId !== latestDiffHighlightId) {
+    return;
+  }
+
+  highlightedDiffLines.value = diff.map((line, index) => ({
+    ...line,
+    tokens: highlightedLines[index] ?? [
+      {
+        content: diffLineText(line),
+        darkColor: undefined,
+        lightColor: undefined,
+      },
+    ],
+  }));
+}
+
 watch(
   [source, target, options, selectedFileIndex],
   () => {
@@ -188,6 +322,10 @@ watch(
   },
   { immediate: true },
 );
+
+watch([() => report.value?.diff, diffLanguage], () => void updateDiffHighlights(), {
+  immediate: true,
+});
 
 let hasCompilerInitialized = false;
 let pollInterval: ReturnType<typeof setInterval> | null = null;
@@ -362,25 +500,6 @@ onUnmounted(() => {
       </div>
 
       <template v-else-if="report">
-        <div class="inspector-summary">
-          <div class="inspector-stat">
-            <span class="inspector-stat-value">{{ report.target.toUpperCase() }}</span>
-            <span class="inspector-stat-label">target</span>
-          </div>
-          <div class="inspector-stat">
-            <span class="inspector-stat-value">{{ hasChanges ? "changed" : "same" }}</span>
-            <span class="inspector-stat-label">compiler output</span>
-          </div>
-          <div class="inspector-stat">
-            <span class="inspector-stat-value">+{{ report.stats.additions }}</span>
-            <span class="inspector-stat-label">Vize-only lines</span>
-          </div>
-          <div class="inspector-stat">
-            <span class="inspector-stat-value">-{{ report.stats.removals }}</span>
-            <span class="inspector-stat-label">Vue-only lines</span>
-          </div>
-        </div>
-
         <div v-if="inspectorMessages.length > 0" class="inspector-warning-list">
           <pre
             v-for="(warning, index) in inspectorMessages"
@@ -391,12 +510,26 @@ onUnmounted(() => {
         </div>
 
         <div v-if="activeOutputTab === 'compare'" class="inspector-tab-panel">
-          <div v-if="report.diff.length === 0" class="inspector-empty-diff">
+          <div class="inspector-diff-toolbar" aria-label="Diff view">
+            <button
+              :class="['inspector-diff-mode', { active: diffViewMode === 'merged' }]"
+              @click="diffViewMode = 'merged'"
+            >
+              Merged
+            </button>
+            <button
+              :class="['inspector-diff-mode', { active: diffViewMode === 'split' }]"
+              @click="diffViewMode = 'split'"
+            >
+              Split
+            </button>
+          </div>
+          <div v-if="highlightedDiffLines.length === 0" class="inspector-empty-diff">
             Both compiler outputs are empty.
           </div>
-          <div v-else class="inspector-diff">
+          <div v-else-if="diffViewMode === 'merged'" class="inspector-diff">
             <div
-              v-for="(line, index) in report.diff"
+              v-for="(line, index) in highlightedDiffLines"
               :key="index"
               :class="['inspector-diff-line', line.kind]"
             >
@@ -405,7 +538,40 @@ onUnmounted(() => {
               <span class="inspector-diff-mark">{{
                 line.kind === "add" ? "+" : line.kind === "remove" ? "-" : ""
               }}</span>
-              <code class="inspector-diff-code">{{ line.text || " " }}</code>
+              <code class="inspector-diff-code"
+                ><span
+                  v-for="(token, tokenIndex) in line.tokens"
+                  :key="tokenIndex"
+                  :style="{ '--d': token.darkColor, '--l': token.lightColor }"
+                  >{{ token.content }}</span
+                ></code
+              >
+            </div>
+          </div>
+          <div v-else class="inspector-diff inspector-diff-split">
+            <div
+              v-for="(row, index) in splitDiffRows"
+              :key="index"
+              :class="['inspector-split-line', `left-${row.left.kind}`, `right-${row.right.kind}`]"
+            >
+              <span class="inspector-diff-num">{{ row.left.line ?? "" }}</span>
+              <code :class="['inspector-diff-code', 'inspector-split-code', row.left.kind]"
+                ><span
+                  v-for="(token, tokenIndex) in row.left.tokens"
+                  :key="tokenIndex"
+                  :style="{ '--d': token.darkColor, '--l': token.lightColor }"
+                  >{{ token.content }}</span
+                ></code
+              >
+              <span class="inspector-diff-num">{{ row.right.line ?? "" }}</span>
+              <code :class="['inspector-diff-code', 'inspector-split-code', row.right.kind]"
+                ><span
+                  v-for="(token, tokenIndex) in row.right.tokens"
+                  :key="tokenIndex"
+                  :style="{ '--d': token.darkColor, '--l': token.lightColor }"
+                  >{{ token.content }}</span
+                ></code
+              >
             </div>
           </div>
         </div>
@@ -526,7 +692,7 @@ onUnmounted(() => {
         </div>
 
         <div v-else>
-          <pre class="inspector-payload">{{ payloadJson }}</pre>
+          <CodeHighlight :code="payloadJson" language="json" :theme show-line-numbers />
           <p v-if="permalinkTooLong" class="inspector-url-note">
             Permalink is long; prefer copying the payload for this batch.
           </p>

--- a/playground/src/shared/CodeHighlight.vue
+++ b/playground/src/shared/CodeHighlight.vue
@@ -1,162 +1,21 @@
 <script setup lang="ts">
 import { useTemplateRef, watch } from "vue";
-import { createHighlighter, type Highlighter, type ThemeRegistration } from "shiki";
+import {
+  codeToThemedHtmlLines,
+  normalizePlainHtmlLines,
+  type CodeHighlightLanguage,
+} from "./codeHighlighting";
 
 const props = defineProps<{
   code: string;
-  language: "javascript" | "json" | "css" | "html" | "typescript";
+  language: CodeHighlightLanguage;
   showLineNumbers?: boolean;
   theme?: "dark" | "light";
 }>();
 
-// Custom themes — warm earthy tones matching brand
-const vizeDarkTheme: ThemeRegistration = {
-  name: "vize-dark",
-  type: "dark",
-  colors: {
-    "editor.background": "#1a1a1a",
-    "editor.foreground": "#E6E2D6",
-  },
-  tokenColors: [
-    {
-      scope: ["keyword", "storage.type", "storage.modifier"],
-      settings: { foreground: "#D4BA92" },
-    },
-    {
-      scope: ["entity.name.function", "support.function"],
-      settings: { foreground: "#E2CBA6" },
-    },
-    {
-      scope: ["entity.name.tag", "punctuation.definition.tag"],
-      settings: { foreground: "#D0BA9E" },
-    },
-    {
-      scope: ["entity.other.attribute-name"],
-      settings: { foreground: "#9C9488" },
-    },
-    { scope: ["string", "string.quoted"], settings: { foreground: "#A8B5A0" } },
-    {
-      scope: ["constant.numeric", "constant.language"],
-      settings: { foreground: "#DABA8C" },
-    },
-    {
-      scope: ["variable", "variable.other"],
-      settings: { foreground: "#E6E2D6" },
-    },
-    {
-      scope: ["comment", "punctuation.definition.comment"],
-      settings: { foreground: "#6B6560" },
-    },
-    {
-      scope: ["punctuation", "meta.brace"],
-      settings: { foreground: "#8A8478" },
-    },
-    {
-      scope: ["entity.name.type", "support.type"],
-      settings: { foreground: "#B8ADA0" },
-    },
-    {
-      scope: ["meta.property-name", "support.type.property-name"],
-      settings: { foreground: "#D0BA9E" },
-    },
-    {
-      scope: ["meta.property-value", "support.constant.property-value"],
-      settings: { foreground: "#A8B5A0" },
-    },
-  ],
-};
-
-const vizeLightTheme: ThemeRegistration = {
-  name: "vize-light",
-  type: "light",
-  colors: {
-    "editor.background": "#ddd9cd",
-    "editor.foreground": "#121212",
-  },
-  tokenColors: [
-    {
-      scope: ["keyword", "storage.type", "storage.modifier"],
-      settings: { foreground: "#73603E" },
-    },
-    {
-      scope: ["entity.name.function", "support.function"],
-      settings: { foreground: "#655232" },
-    },
-    {
-      scope: ["entity.name.tag", "punctuation.definition.tag"],
-      settings: { foreground: "#65573E" },
-    },
-    {
-      scope: ["entity.other.attribute-name"],
-      settings: { foreground: "#6B6050" },
-    },
-    { scope: ["string", "string.quoted"], settings: { foreground: "#5A6B50" } },
-    {
-      scope: ["constant.numeric", "constant.language"],
-      settings: { foreground: "#735C2E" },
-    },
-    {
-      scope: ["variable", "variable.other"],
-      settings: { foreground: "#121212" },
-    },
-    {
-      scope: ["comment", "punctuation.definition.comment"],
-      settings: { foreground: "#9A9590" },
-    },
-    {
-      scope: ["punctuation", "meta.brace"],
-      settings: { foreground: "#6B6560" },
-    },
-    {
-      scope: ["entity.name.type", "support.type"],
-      settings: { foreground: "#6B5F50" },
-    },
-    {
-      scope: ["meta.property-name", "support.type.property-name"],
-      settings: { foreground: "#65573E" },
-    },
-    {
-      scope: ["meta.property-value", "support.constant.property-value"],
-      settings: { foreground: "#4A5F3E" },
-    },
-  ],
-};
-
 const codeContentEl = useTemplateRef<HTMLDivElement>("codeContentEl");
 const lineNumbersEl = useTemplateRef<HTMLDivElement>("lineNumbersEl");
 let latestRenderId = 0;
-
-type SharedHighlighterState = {
-  highlighter: Highlighter | null;
-  highlighterPromise: Promise<Highlighter> | null;
-};
-
-type SharedGlobal = typeof globalThis & {
-  __vizeCodeHighlightState?: SharedHighlighterState;
-};
-
-const sharedGlobal = globalThis as SharedGlobal;
-const sharedState =
-  sharedGlobal.__vizeCodeHighlightState ??
-  (sharedGlobal.__vizeCodeHighlightState = {
-    highlighter: null,
-    highlighterPromise: null,
-  });
-
-function escapeHtml(value: string): string {
-  return value.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
-}
-
-function normalizePlainLines(code: string): string[] {
-  if (!code) {
-    return [];
-  }
-  const lines = code.split("\n");
-  if (lines.length > 0 && lines[lines.length - 1] === "") {
-    lines.pop();
-  }
-  return lines.map((line) => (line ? escapeHtml(line) : "&nbsp;"));
-}
 
 function renderLineNumbers(count: number) {
   if (!lineNumbersEl.value) {
@@ -185,60 +44,8 @@ function renderCodeLines(lines: string[]) {
   renderLineNumbers(lines.length);
 }
 
-async function initHighlighter() {
-  if (sharedState.highlighter) {
-    return sharedState.highlighter;
-  }
-  if (!sharedState.highlighterPromise) {
-    sharedState.highlighterPromise = createHighlighter({
-      themes: [vizeDarkTheme, vizeLightTheme],
-      langs: ["javascript", "json", "css", "html", "typescript"],
-    }).then((instance) => {
-      sharedState.highlighter = instance;
-      return instance;
-    });
-  }
-  return sharedState.highlighterPromise;
-}
-
 async function highlight(renderId: number) {
-  const hl = await initHighlighter();
-
-  // Tokenize with both themes so CSS can switch colors without JS re-render
-  const darkTokens = hl.codeToTokens(props.code, {
-    lang: props.language,
-    theme: "vize-dark",
-  });
-  const lightTokens = hl.codeToTokens(props.code, {
-    lang: props.language,
-    theme: "vize-light",
-  });
-
-  let darkLines = darkTokens.tokens;
-  let lightLines = lightTokens.tokens;
-
-  // Remove trailing empty line if present
-  if (darkLines.length > 0 && darkLines[darkLines.length - 1].length === 0) {
-    darkLines = darkLines.slice(0, -1);
-  }
-  if (lightLines.length > 0 && lightLines[lightLines.length - 1].length === 0) {
-    lightLines = lightLines.slice(0, -1);
-  }
-
-  // Build HTML with both theme colors as CSS custom properties
-  const nextLines = darkLines.map((lineTokens, lineIdx) => {
-    if (lineTokens.length === 0) {
-      return "&nbsp;";
-    }
-    return lineTokens
-      .map((token, tokenIdx) => {
-        const escaped = escapeHtml(token.content);
-        const darkColor = token.color;
-        const lightColor = lightLines[lineIdx]?.[tokenIdx]?.color ?? token.color;
-        return `<span style="--d:${darkColor};--l:${lightColor}">${escaped}</span>`;
-      })
-      .join("");
-  });
+  const nextLines = await codeToThemedHtmlLines(props.code, props.language);
 
   if (renderId !== latestRenderId) {
     return;
@@ -249,7 +56,7 @@ async function highlight(renderId: number) {
 
 function render() {
   const renderId = ++latestRenderId;
-  renderCodeLines(normalizePlainLines(props.code));
+  renderCodeLines(normalizePlainHtmlLines(props.code));
   void highlight(renderId);
 }
 

--- a/playground/src/shared/codeHighlighting.ts
+++ b/playground/src/shared/codeHighlighting.ts
@@ -1,0 +1,230 @@
+import { createHighlighter, type Highlighter, type ThemeRegistration } from "shiki";
+
+export type CodeHighlightLanguage = "javascript" | "json" | "css" | "html" | "typescript";
+
+export interface ThemedCodeToken {
+  content: string;
+  darkColor: string | undefined;
+  lightColor: string | undefined;
+}
+
+// Custom themes - warm earthy tones matching brand
+const vizeDarkTheme: ThemeRegistration = {
+  name: "vize-dark",
+  type: "dark",
+  colors: {
+    "editor.background": "#1a1a1a",
+    "editor.foreground": "#E6E2D6",
+  },
+  tokenColors: [
+    {
+      scope: ["keyword", "storage.type", "storage.modifier"],
+      settings: { foreground: "#D4BA92" },
+    },
+    {
+      scope: ["entity.name.function", "support.function"],
+      settings: { foreground: "#E2CBA6" },
+    },
+    {
+      scope: ["entity.name.tag", "punctuation.definition.tag"],
+      settings: { foreground: "#D0BA9E" },
+    },
+    {
+      scope: ["entity.other.attribute-name"],
+      settings: { foreground: "#9C9488" },
+    },
+    { scope: ["string", "string.quoted"], settings: { foreground: "#A8B5A0" } },
+    {
+      scope: ["constant.numeric", "constant.language"],
+      settings: { foreground: "#DABA8C" },
+    },
+    {
+      scope: ["variable", "variable.other"],
+      settings: { foreground: "#E6E2D6" },
+    },
+    {
+      scope: ["comment", "punctuation.definition.comment"],
+      settings: { foreground: "#6B6560" },
+    },
+    {
+      scope: ["punctuation", "meta.brace"],
+      settings: { foreground: "#8A8478" },
+    },
+    {
+      scope: ["entity.name.type", "support.type"],
+      settings: { foreground: "#B8ADA0" },
+    },
+    {
+      scope: ["meta.property-name", "support.type.property-name"],
+      settings: { foreground: "#D0BA9E" },
+    },
+    {
+      scope: ["meta.property-value", "support.constant.property-value"],
+      settings: { foreground: "#A8B5A0" },
+    },
+  ],
+};
+
+const vizeLightTheme: ThemeRegistration = {
+  name: "vize-light",
+  type: "light",
+  colors: {
+    "editor.background": "#ddd9cd",
+    "editor.foreground": "#121212",
+  },
+  tokenColors: [
+    {
+      scope: ["keyword", "storage.type", "storage.modifier"],
+      settings: { foreground: "#73603E" },
+    },
+    {
+      scope: ["entity.name.function", "support.function"],
+      settings: { foreground: "#655232" },
+    },
+    {
+      scope: ["entity.name.tag", "punctuation.definition.tag"],
+      settings: { foreground: "#65573E" },
+    },
+    {
+      scope: ["entity.other.attribute-name"],
+      settings: { foreground: "#6B6050" },
+    },
+    { scope: ["string", "string.quoted"], settings: { foreground: "#5A6B50" } },
+    {
+      scope: ["constant.numeric", "constant.language"],
+      settings: { foreground: "#735C2E" },
+    },
+    {
+      scope: ["variable", "variable.other"],
+      settings: { foreground: "#121212" },
+    },
+    {
+      scope: ["comment", "punctuation.definition.comment"],
+      settings: { foreground: "#9A9590" },
+    },
+    {
+      scope: ["punctuation", "meta.brace"],
+      settings: { foreground: "#6B6560" },
+    },
+    {
+      scope: ["entity.name.type", "support.type"],
+      settings: { foreground: "#6B5F50" },
+    },
+    {
+      scope: ["meta.property-name", "support.type.property-name"],
+      settings: { foreground: "#65573E" },
+    },
+    {
+      scope: ["meta.property-value", "support.constant.property-value"],
+      settings: { foreground: "#4A5F3E" },
+    },
+  ],
+};
+
+type SharedHighlighterState = {
+  highlighter: Highlighter | null;
+  highlighterPromise: Promise<Highlighter> | null;
+};
+
+type SharedGlobal = typeof globalThis & {
+  __vizeCodeHighlightState?: SharedHighlighterState;
+};
+
+const sharedGlobal = globalThis as SharedGlobal;
+const sharedState =
+  sharedGlobal.__vizeCodeHighlightState ??
+  (sharedGlobal.__vizeCodeHighlightState = {
+    highlighter: null,
+    highlighterPromise: null,
+  });
+
+export function escapeHtml(value: string): string {
+  return value.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+export function normalizePlainHtmlLines(code: string): string[] {
+  if (!code) {
+    return [];
+  }
+  const lines = code.split("\n");
+  if (lines.length > 0 && lines[lines.length - 1] === "") {
+    lines.pop();
+  }
+  return lines.map((line) => (line ? escapeHtml(line) : "&nbsp;"));
+}
+
+export async function initCodeHighlighter() {
+  if (sharedState.highlighter) {
+    return sharedState.highlighter;
+  }
+  if (!sharedState.highlighterPromise) {
+    sharedState.highlighterPromise = createHighlighter({
+      themes: [vizeDarkTheme, vizeLightTheme],
+      langs: ["javascript", "json", "css", "html", "typescript"],
+    }).then((instance) => {
+      sharedState.highlighter = instance;
+      return instance;
+    });
+  }
+  return sharedState.highlighterPromise;
+}
+
+export async function codeToThemedHtmlLines(
+  code: string,
+  language: CodeHighlightLanguage,
+): Promise<string[]> {
+  const tokenLines = await codeToThemedTokenLines(code, language);
+  return tokenLines.map(codeTokensToHtml);
+}
+
+export async function codeToThemedTokenLines(
+  code: string,
+  language: CodeHighlightLanguage,
+): Promise<ThemedCodeToken[][]> {
+  const highlighter = await initCodeHighlighter();
+
+  // Tokenize with both themes so CSS can switch colors without JS re-render.
+  const darkTokens = highlighter.codeToTokens(code, {
+    lang: language,
+    theme: "vize-dark",
+  });
+  const lightTokens = highlighter.codeToTokens(code, {
+    lang: language,
+    theme: "vize-light",
+  });
+
+  let darkLines = darkTokens.tokens;
+  let lightLines = lightTokens.tokens;
+
+  if (darkLines.length > 0 && darkLines[darkLines.length - 1].length === 0) {
+    darkLines = darkLines.slice(0, -1);
+  }
+  if (lightLines.length > 0 && lightLines[lightLines.length - 1].length === 0) {
+    lightLines = lightLines.slice(0, -1);
+  }
+
+  return darkLines.map((lineTokens, lineIdx) => {
+    if (lineTokens.length === 0) {
+      return [{ content: "", darkColor: undefined, lightColor: undefined }];
+    }
+    return lineTokens.map((token, tokenIdx) => ({
+      content: token.content,
+      darkColor: token.color,
+      lightColor: lightLines[lineIdx]?.[tokenIdx]?.color ?? token.color,
+    }));
+  });
+}
+
+function codeTokensToHtml(tokens: ThemedCodeToken[]): string {
+  if (tokens.every((token) => token.content === "")) {
+    return "&nbsp;";
+  }
+  return tokens
+    .map(
+      (token) =>
+        `<span style="--d:${token.darkColor};--l:${token.lightColor}">${escapeHtml(
+          token.content,
+        )}</span>`,
+    )
+    .join("");
+}


### PR DESCRIPTION
## Summary

- Add syntax highlighting to the Inspector compare diff using the shared Shiki highlighter.
- Add Merged and Split diff display modes.
- Remove the Inspector compare summary cards so the diff is the first visible output.
- Render the Inspector payload through the highlighted code viewer.

## Validation

- `vp test run --config vite.test.config.ts src/features/inspector/compareCompilers.test.ts src/features/atelier/codeOutputs.test.ts`
- `ROOT="$(cd .. && pwd -P)" && vp check src 'e2e/*.ts' 'e2e/vrt/*.ts' vite.config.ts vite.app.config.ts vite.test.config.ts vite.node.config.ts playwright.config.ts && cargo run --quiet --manifest-path "$ROOT/Cargo.toml" -p vize -- lint --max-warnings 0`
- Browser verification at `http://127.0.0.1:5180/?tab=inspector`: Merged and Split diff modes render highlighted tokens, summary cards are absent, and no console errors were reported.