### PR TITLE
fix(inspector): improve diff alignment

### DIFF
--- a/crates/vize_curator/src/inspector.rs
+++ b/crates/vize_curator/src/inspector.rs
@@ -292,11 +292,16 @@ pub fn build_line_diff(left: &str, right: &str) -> Vec<InspectorDiffLine> {
 
     for left_index in (0..left_lines.len()).rev() {
         for right_index in (0..right_lines.len()).rev() {
-            table[left_index][right_index] = if left_lines[left_index] == right_lines[right_index] {
-                table[left_index + 1][right_index + 1] + 1
+            let same_score =
+                diff_line_match_weight(&left_lines[left_index], &right_lines[right_index]);
+            let take_same = if same_score > 0 {
+                table[left_index + 1][right_index + 1] + same_score
             } else {
-                table[left_index + 1][right_index].max(table[left_index][right_index + 1])
+                0
             };
+            table[left_index][right_index] = take_same
+                .max(table[left_index + 1][right_index])
+                .max(table[left_index][right_index + 1]);
         }
     }
 
@@ -305,7 +310,16 @@ pub fn build_line_diff(left: &str, right: &str) -> Vec<InspectorDiffLine> {
     let mut right_index = 0;
 
     while left_index < left_lines.len() && right_index < right_lines.len() {
-        if left_lines[left_index] == right_lines[right_index] {
+        let same_score = diff_line_match_weight(&left_lines[left_index], &right_lines[right_index]);
+        let take_same = if same_score > 0 {
+            table[left_index + 1][right_index + 1] + same_score
+        } else {
+            0
+        };
+        if same_score > 0
+            && take_same >= table[left_index + 1][right_index]
+            && take_same >= table[left_index][right_index + 1]
+        {
             diff.push(InspectorDiffLine {
                 kind: "same",
                 left_line: Some(left_index + 1),
@@ -354,6 +368,24 @@ pub fn build_line_diff(left: &str, right: &str) -> Vec<InspectorDiffLine> {
     }
 
     diff
+}
+
+fn diff_line_match_weight(left: &str, right: &str) -> usize {
+    if left != right {
+        return 0;
+    }
+
+    let trimmed = left.trim();
+    if trimmed.is_empty() {
+        1
+    } else if trimmed
+        .chars()
+        .any(|character| character.is_alphanumeric() || character == '_' || character == '$')
+    {
+        32 + trimmed.chars().take(80).count()
+    } else {
+        2 + trimmed.chars().take(8).count()
+    }
 }
 
 pub fn diff_stats(lines: &[InspectorDiffLine]) -> InspectorDiffStats {
@@ -747,7 +779,7 @@ fn line_count(source: &str) -> usize {
 mod tests {
     use super::{
         InspectorOptions, InspectorSourceFile, InspectorTarget, build_agent_report, build_diff,
-        build_graph, build_payload, build_playground_url, serialize_agent_report,
+        build_graph, build_line_diff, build_payload, build_playground_url, serialize_agent_report,
         serialize_payload,
     };
     use vize_carton::cstr;
@@ -869,6 +901,38 @@ import RuntimeOnly from './RuntimeOnly.vue';
         assert_eq!(diff.lines[1].kind, "remove");
         assert_eq!(diff.lines[2].kind, "add");
         assert_eq!(diff.lines[4].right_line, Some(4));
+    }
+
+    #[test]
+    fn line_diff_prefers_content_matches_over_empty_line_anchors() {
+        let left = "\
+import { defineComponent as _defineComponent } from 'vue'
+import { computed, watch } from 'vue'
+
+// Reactive Props Destructure
+export default {}";
+        let right = "\
+import { defineComponent as _defineComponent } from 'vue'
+import {
+  openBlock as _openBlock,
+} from 'vue'
+
+import { computed, watch } from 'vue'
+
+export default {}";
+
+        let diff = build_line_diff(left, right);
+        let matched_import = diff
+            .iter()
+            .find(|line| line.text == "import { computed, watch } from 'vue'")
+            .expect("matching import line exists");
+
+        assert_eq!(matched_import.kind, "same");
+        assert_eq!(matched_import.left_line, Some(2));
+        assert_eq!(matched_import.right_line, Some(6));
+        assert!(!diff.iter().any(|line| {
+            line.kind == "remove" && line.text == "import { computed, watch } from 'vue'"
+        }));
     }
 
     #[test]

--- a/playground/src/features/inspector/InspectorPlayground.vue
+++ b/playground/src/features/inspector/InspectorPlayground.vue
@@ -4,16 +4,18 @@ import { mdiGithub } from "@mdi/js";
 import { computed, onMounted, onUnmounted, ref, watch } from "vue";
 import MonacoEditor from "../../shared/MonacoEditor.vue";
 import CodeHighlight from "../../shared/CodeHighlight.vue";
-import {
-  codeToThemedTokenLines,
-  type CodeHighlightLanguage,
-  type ThemedCodeToken,
-} from "../../shared/codeHighlighting";
+import { codeToThemedTokenLines, type CodeHighlightLanguage } from "../../shared/codeHighlighting";
 import { PRESETS } from "../../presets";
 import { useClipboard } from "../../utils/useClipboard";
 import { useTheme } from "../../utils/useTheme";
 import { type loadWasm, getWasm } from "../../wasm/index";
 import { compileInspectorReport } from "./compareCompilers";
+import {
+  buildSplitDiffRows,
+  diffLineText,
+  renderPlainDiffLines,
+  type HighlightedDiffLine,
+} from "./diffRows";
 import { parseVirLines } from "../croquis/useVirTokenizer";
 import { createInspectorUrl, createPullRequestUrl, readInspectorPayloadFromUrl } from "./share";
 import type {
@@ -23,7 +25,6 @@ import type {
   InspectorPayload,
   InspectorReport,
   InspectorTarget,
-  DiffLine,
 } from "./types";
 
 const props = defineProps<{
@@ -54,21 +55,6 @@ const activeOutputTab = ref<
 const diffViewMode = ref<"merged" | "split">("merged");
 const highlightedDiffLines = ref<HighlightedDiffLine[]>([]);
 let latestDiffHighlightId = 0;
-
-type HighlightedDiffLine = DiffLine & {
-  tokens: ThemedCodeToken[];
-};
-
-interface SplitDiffSide {
-  kind: "same" | "remove" | "add" | "empty";
-  line: number | null;
-  tokens: ThemedCodeToken[];
-}
-
-interface SplitDiffRow {
-  left: SplitDiffSide;
-  right: SplitDiffSide;
-}
 
 const selectedFile = computed(() => files.value[selectedFileIndex.value] ?? files.value[0]!);
 const source = computed({
@@ -198,83 +184,6 @@ function scheduleCompile() {
 
 function openPullRequest() {
   window.open(pullRequestUrl.value, "_blank", "noopener,noreferrer");
-}
-
-function diffLineText(line: DiffLine): string {
-  return line.text || " ";
-}
-
-function renderPlainDiffLines(lines: DiffLine[]): HighlightedDiffLine[] {
-  return lines.map((line) => ({
-    ...line,
-    tokens: [
-      {
-        content: diffLineText(line),
-        darkColor: undefined,
-        lightColor: undefined,
-      },
-    ],
-  }));
-}
-
-function emptySplitSide(): SplitDiffSide {
-  return {
-    kind: "empty",
-    line: null,
-    tokens: [
-      {
-        content: "",
-        darkColor: undefined,
-        lightColor: undefined,
-      },
-    ],
-  };
-}
-
-function toSplitSide(line: HighlightedDiffLine, side: "left" | "right"): SplitDiffSide {
-  return {
-    kind: line.kind,
-    line: side === "left" ? line.leftLine : line.rightLine,
-    tokens: line.tokens,
-  };
-}
-
-function buildSplitDiffRows(lines: HighlightedDiffLine[]): SplitDiffRow[] {
-  const rows: SplitDiffRow[] = [];
-
-  for (let index = 0; index < lines.length; ) {
-    const line = lines[index]!;
-    if (line.kind === "same") {
-      rows.push({
-        left: toSplitSide(line, "left"),
-        right: toSplitSide(line, "right"),
-      });
-      index += 1;
-      continue;
-    }
-
-    const removals: HighlightedDiffLine[] = [];
-    const additions: HighlightedDiffLine[] = [];
-    while (index < lines.length && lines[index]!.kind !== "same") {
-      const changedLine = lines[index]!;
-      if (changedLine.kind === "remove") {
-        removals.push(changedLine);
-      } else {
-        additions.push(changedLine);
-      }
-      index += 1;
-    }
-
-    const rowCount = Math.max(removals.length, additions.length);
-    for (let rowIndex = 0; rowIndex < rowCount; rowIndex += 1) {
-      rows.push({
-        left: removals[rowIndex] ? toSplitSide(removals[rowIndex], "left") : emptySplitSide(),
-        right: additions[rowIndex] ? toSplitSide(additions[rowIndex], "right") : emptySplitSide(),
-      });
-    }
-  }
-
-  return rows;
 }
 
 async function updateDiffHighlights() {

--- a/playground/src/features/inspector/diffRows.test.ts
+++ b/playground/src/features/inspector/diffRows.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vite-plus/test";
+import { buildSplitDiffRows, type HighlightedDiffLine } from "./diffRows";
+
+function diffLine(
+  kind: HighlightedDiffLine["kind"],
+  leftLine: number | null,
+  rightLine: number | null,
+  text: string,
+): HighlightedDiffLine {
+  return {
+    kind,
+    leftLine,
+    rightLine,
+    text,
+    tokens: [
+      {
+        content: text,
+        darkColor: undefined,
+        lightColor: undefined,
+      },
+    ],
+  };
+}
+
+describe("buildSplitDiffRows", () => {
+  it("keeps unchanged lines on both sides", () => {
+    const rows = buildSplitDiffRows([diffLine("same", 1, 1, "return count")]);
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.left).toMatchObject({
+      kind: "same",
+      line: 1,
+    });
+    expect(rows[0]!.right).toMatchObject({
+      kind: "same",
+      line: 1,
+    });
+  });
+
+  it("pairs similar changed lines after an added offset line", () => {
+    const rows = buildSplitDiffRows([
+      diffLine("remove", 1, null, "const title = _ctx.title;"),
+      diffLine("remove", 2, null, "const count = _ctx.count;"),
+      diffLine("add", null, 1, "return _openBlock(), _createElementBlock('main');"),
+      diffLine("add", null, 2, "const title = title;"),
+      diffLine("add", null, 3, "const count = count;"),
+    ]);
+
+    expect(
+      rows.map((row) => ({
+        left: row.left.tokens[0]?.content ?? "",
+        right: row.right.tokens[0]?.content ?? "",
+      })),
+    ).toEqual([
+      {
+        left: "",
+        right: "return _openBlock(), _createElementBlock('main');",
+      },
+      {
+        left: "const title = _ctx.title;",
+        right: "const title = title;",
+      },
+      {
+        left: "const count = _ctx.count;",
+        right: "const count = count;",
+      },
+    ]);
+  });
+
+  it("does not pair unrelated changed lines", () => {
+    const rows = buildSplitDiffRows([
+      diffLine("remove", 1, null, "const title = _ctx.title;"),
+      diffLine("add", null, 1, "return _renderSlot(_ctx.$slots, 'default');"),
+    ]);
+
+    expect(rows).toHaveLength(2);
+    expect(rows[0]!.left.kind).toBe("remove");
+    expect(rows[0]!.right.kind).toBe("empty");
+    expect(rows[1]!.left.kind).toBe("empty");
+    expect(rows[1]!.right.kind).toBe("add");
+  });
+
+  it("does not pair a full line with a short matching fragment", () => {
+    const rows = buildSplitDiffRows([
+      diffLine("remove", 1, null, "import { computed, watch } from 'vue'"),
+      diffLine("add", null, 1, "} from 'vue'"),
+    ]);
+
+    expect(rows).toHaveLength(2);
+    expect(rows[0]!.left.kind).toBe("remove");
+    expect(rows[0]!.right.kind).toBe("empty");
+    expect(rows[1]!.left.kind).toBe("empty");
+    expect(rows[1]!.right.kind).toBe("add");
+  });
+});

--- a/playground/src/features/inspector/diffRows.ts
+++ b/playground/src/features/inspector/diffRows.ts
@@ -1,0 +1,270 @@
+import type { ThemedCodeToken } from "../../shared/codeHighlighting";
+import type { DiffLine } from "./types";
+
+export type HighlightedDiffLine = DiffLine & {
+  tokens: ThemedCodeToken[];
+};
+
+export interface SplitDiffSide {
+  kind: "same" | "remove" | "add" | "empty";
+  line: number | null;
+  tokens: ThemedCodeToken[];
+}
+
+export interface SplitDiffRow {
+  left: SplitDiffSide;
+  right: SplitDiffSide;
+}
+
+type ChangedPair = {
+  removal: HighlightedDiffLine | null;
+  addition: HighlightedDiffLine | null;
+};
+
+type AlignAction = "pair" | "remove" | "add";
+
+const MIN_CHANGED_LINE_SCORE = 0.45;
+const PAIR_BONUS = 0.06;
+
+export function diffLineText(line: DiffLine): string {
+  return line.text || " ";
+}
+
+export function renderPlainDiffLines(lines: DiffLine[]): HighlightedDiffLine[] {
+  return lines.map((line) => ({
+    ...line,
+    tokens: [
+      {
+        content: diffLineText(line),
+        darkColor: undefined,
+        lightColor: undefined,
+      },
+    ],
+  }));
+}
+
+export function buildSplitDiffRows(lines: HighlightedDiffLine[]): SplitDiffRow[] {
+  const rows: SplitDiffRow[] = [];
+
+  for (let index = 0; index < lines.length; ) {
+    const line = lines[index]!;
+    if (line.kind === "same") {
+      rows.push({
+        left: toSplitSide(line, "left"),
+        right: toSplitSide(line, "right"),
+      });
+      index += 1;
+      continue;
+    }
+
+    const removals: HighlightedDiffLine[] = [];
+    const additions: HighlightedDiffLine[] = [];
+    while (index < lines.length && lines[index]!.kind !== "same") {
+      const changedLine = lines[index]!;
+      if (changedLine.kind === "remove") {
+        removals.push(changedLine);
+      } else {
+        additions.push(changedLine);
+      }
+      index += 1;
+    }
+
+    for (const pair of alignChangedLines(removals, additions)) {
+      rows.push({
+        left: pair.removal ? toSplitSide(pair.removal, "left") : emptySplitSide(),
+        right: pair.addition ? toSplitSide(pair.addition, "right") : emptySplitSide(),
+      });
+    }
+  }
+
+  return rows;
+}
+
+function alignChangedLines(
+  removals: HighlightedDiffLine[],
+  additions: HighlightedDiffLine[],
+): ChangedPair[] {
+  const rowCount = removals.length + 1;
+  const colCount = additions.length + 1;
+  const scores = Array.from({ length: rowCount }, () => Array<number>(colCount).fill(0));
+  const actions = Array.from({ length: rowCount }, () =>
+    Array<AlignAction | null>(colCount).fill(null),
+  );
+
+  for (let leftIndex = removals.length; leftIndex >= 0; leftIndex -= 1) {
+    for (let rightIndex = additions.length; rightIndex >= 0; rightIndex -= 1) {
+      if (leftIndex === removals.length && rightIndex === additions.length) {
+        continue;
+      }
+
+      let bestScore = Number.NEGATIVE_INFINITY;
+      let bestAction: AlignAction | null = null;
+
+      if (leftIndex < removals.length) {
+        bestScore = scores[leftIndex + 1]![rightIndex]!;
+        bestAction = "remove";
+      }
+
+      if (rightIndex < additions.length) {
+        const addScore = scores[leftIndex]![rightIndex + 1]!;
+        if (addScore > bestScore) {
+          bestScore = addScore;
+          bestAction = "add";
+        }
+      }
+
+      if (leftIndex < removals.length && rightIndex < additions.length) {
+        const lineScore = diffLineSimilarity(
+          removals[leftIndex]!.text,
+          additions[rightIndex]!.text,
+        );
+        const pairScore =
+          lineScore >= MIN_CHANGED_LINE_SCORE
+            ? scores[leftIndex + 1]![rightIndex + 1]! + lineScore + PAIR_BONUS
+            : Number.NEGATIVE_INFINITY;
+        if (pairScore > bestScore) {
+          bestScore = pairScore;
+          bestAction = "pair";
+        }
+      }
+
+      scores[leftIndex]![rightIndex] = bestScore;
+      actions[leftIndex]![rightIndex] = bestAction;
+    }
+  }
+
+  const pairs: ChangedPair[] = [];
+  let leftIndex = 0;
+  let rightIndex = 0;
+
+  while (leftIndex < removals.length || rightIndex < additions.length) {
+    const action = actions[leftIndex]?.[rightIndex];
+    if (action === "pair") {
+      pairs.push({
+        removal: removals[leftIndex]!,
+        addition: additions[rightIndex]!,
+      });
+      leftIndex += 1;
+      rightIndex += 1;
+    } else if (action === "add") {
+      pairs.push({
+        removal: null,
+        addition: additions[rightIndex]!,
+      });
+      rightIndex += 1;
+    } else {
+      pairs.push({
+        removal: removals[leftIndex]!,
+        addition: null,
+      });
+      leftIndex += 1;
+    }
+  }
+
+  return pairs;
+}
+
+function emptySplitSide(): SplitDiffSide {
+  return {
+    kind: "empty",
+    line: null,
+    tokens: [
+      {
+        content: "",
+        darkColor: undefined,
+        lightColor: undefined,
+      },
+    ],
+  };
+}
+
+function toSplitSide(line: HighlightedDiffLine, side: "left" | "right"): SplitDiffSide {
+  return {
+    kind: line.kind,
+    line: side === "left" ? line.leftLine : line.rightLine,
+    tokens: line.tokens,
+  };
+}
+
+function diffLineSimilarity(left: string, right: string): number {
+  const normalizedLeft = normalizeLineForSimilarity(left);
+  const normalizedRight = normalizeLineForSimilarity(right);
+
+  if (!normalizedLeft || !normalizedRight) {
+    return normalizedLeft === normalizedRight ? 1 : 0;
+  }
+
+  if (normalizedLeft === normalizedRight) {
+    return 1;
+  }
+
+  const compactLeft = normalizedLeft.replace(/\s+/g, "");
+  const compactRight = normalizedRight.replace(/\s+/g, "");
+  if (compactLeft === compactRight) {
+    return 0.96;
+  }
+
+  const lengthRatio =
+    Math.min(compactLeft.length, compactRight.length) /
+    Math.max(compactLeft.length, compactRight.length);
+  if (Math.max(compactLeft.length, compactRight.length) >= 16 && lengthRatio < 0.42) {
+    return 0;
+  }
+
+  const charScore = diceScore(compactLeft, compactRight);
+  const tokenScore = diceScore(
+    tokenizeSimilarityParts(normalizedLeft),
+    tokenizeSimilarityParts(normalizedRight),
+  );
+
+  return Math.min(1, charScore * 0.58 + tokenScore * 0.42);
+}
+
+function normalizeLineForSimilarity(value: string): string {
+  return value
+    .trim()
+    .replace(/\b_ctx\./g, "")
+    .replace(/\b_([A-Za-z]\w*)/g, "$1")
+    .replace(/\s+/g, " ");
+}
+
+function tokenizeSimilarityParts(value: string): string[] {
+  return value.match(/[A-Za-z_$][\w$]*|\d+|[^\s\w$]/g) ?? [];
+}
+
+function diceScore(left: string | string[], right: string | string[]): number {
+  const leftParts = Array.isArray(left) ? left : bigrams(left);
+  const rightParts = Array.isArray(right) ? right : bigrams(right);
+
+  if (leftParts.length === 0 || rightParts.length === 0) {
+    return leftParts.length === rightParts.length ? 1 : 0;
+  }
+
+  const rightCounts = new Map<string, number>();
+  for (const part of rightParts) {
+    rightCounts.set(part, (rightCounts.get(part) ?? 0) + 1);
+  }
+
+  let intersection = 0;
+  for (const part of leftParts) {
+    const count = rightCounts.get(part) ?? 0;
+    if (count > 0) {
+      intersection += 1;
+      rightCounts.set(part, count - 1);
+    }
+  }
+
+  return (2 * intersection) / (leftParts.length + rightParts.length);
+}
+
+function bigrams(value: string): string[] {
+  if (value.length <= 1) {
+    return value ? [value] : [];
+  }
+
+  const result: string[] = [];
+  for (let index = 0; index < value.length - 1; index += 1) {
+    result.push(value.slice(index, index + 2));
+  }
+  return result;
+}


### PR DESCRIPTION
## Summary
- Improve inspector line diff matching so meaningful identical lines win over empty or punctuation-only anchors.
- Move split diff row construction into a tested helper.
- Align split changed hunks by line similarity while avoiding short-fragment false matches.

## Validation
- `cargo test -p vize_curator inspector::tests::`
- `vp test run --config vite.test.config.ts src/features/inspector/diffRows.test.ts src/features/inspector/compareCompilers.test.ts src/features/atelier/codeOutputs.test.ts`
- `ROOT="$(cd .. && pwd -P)" && vp check src 'e2e/*.ts' 'e2e/vrt/*.ts' vite.config.ts vite.app.config.ts vite.test.config.ts vite.node.config.ts playwright.config.ts && cargo run --quiet --manifest-path "$ROOT/Cargo.toml" -p vize -- lint --max-warnings 0`
- `vp run --workspace-root check:ci`
- `vp run --workspace-root build:wasm-web`
- Browser verified Split diff aligns `import { computed, watch } from 'vue'` as `same` and has no console errors.
