### PR TITLE
fix(inspector): align Vue render diff output

### DIFF
--- a/playground/src/features/inspector/compareCompilers.test.ts
+++ b/playground/src/features/inspector/compareCompilers.test.ts
@@ -191,4 +191,117 @@ describe("compileInspectorReport", () => {
     ]);
     expect(buildInspectorDiff).toHaveBeenCalled();
   });
+
+  it("compares script setup DOM output with Vue's inline production render shape", async () => {
+    const buildInspectorDiff = vi.fn(() => ({
+      lines: [],
+      stats: {
+        additions: 0,
+        removals: 0,
+        unchanged: 0,
+      },
+    }));
+    const compiler = {
+      compileSfc: vi.fn(() => ({
+        descriptor: {
+          filename: "src/App.vue",
+          source: "",
+          template: {
+            content: "{{ msg }}",
+            loc: { start: 0, end: 0 },
+            attrs: {},
+          },
+          script: undefined,
+          scriptSetup: {
+            content: "const msg: string = 'hi'",
+            loc: { start: 0, end: 0 },
+            attrs: { lang: "ts" },
+            lang: "ts",
+            setup: true,
+          },
+          styles: [],
+          customBlocks: [],
+        },
+        script: { code: "export default {}" },
+        warnings: [],
+      })),
+      typeCheck: vi.fn(() => ({
+        diagnostics: [],
+        virtualTs: "",
+        errorCount: 0,
+        warningCount: 0,
+      })),
+      analyzeSfc: vi.fn(() => ({
+        croquis: {
+          is_setup: true,
+          bindings: [],
+          scopes: [],
+          macros: [],
+          props: [],
+          emits: [],
+          provides: [],
+          injects: [],
+          typeExports: [],
+          invalidExports: [],
+          diagnostics: [],
+          stats: {
+            binding_count: 0,
+            unused_binding_count: 0,
+            scope_count: 0,
+            macro_count: 0,
+            type_export_count: 0,
+            invalid_export_count: 0,
+            error_count: 0,
+            warning_count: 0,
+          },
+        },
+        diagnostics: [],
+        vir: "",
+      })),
+      analyzeCrossFile: vi.fn(() => ({
+        diagnostics: [],
+        circularDependencies: [],
+        stats: null,
+        filePaths: ["src/App.vue"],
+      })),
+      buildInspectorGraph: vi.fn(() => ({
+        nodes: [],
+        edges: [],
+      })),
+      buildInspectorDiff,
+    } as unknown as WasmModule;
+
+    await compileInspectorReport({
+      compiler,
+      file: {
+        path: "src/App.vue",
+        source:
+          "<script setup lang=\"ts\">const msg: string = 'hi'</script><template><div>{{ msg }}</div></template>",
+      },
+      target: "dom",
+    });
+
+    const [officialOutput] = buildInspectorDiff.mock.calls[0]!;
+
+    expect(officialOutput).toContain("return (_ctx: any,_cache: any) => {");
+    expect(officialOutput).not.toContain("export function render");
+    expect(officialOutput).not.toContain("Object.defineProperty(__returned__");
+
+    buildInspectorDiff.mockClear();
+
+    await compileInspectorReport({
+      compiler,
+      file: {
+        path: "src/App.vue",
+        source:
+          "<script setup lang=\"ts\">const msg: string = 'hi'</script><template><div>{{ msg }}</div></template>",
+      },
+      target: "ssr",
+    });
+
+    const [ssrOfficialOutput] = buildInspectorDiff.mock.calls[0]!;
+
+    expect(ssrOfficialOutput).toContain("export function ssrRender");
+    expect(ssrOfficialOutput).not.toContain("return (_ctx: any,_cache: any) => {");
+  });
 });

--- a/playground/src/features/inspector/compareCompilers.ts
+++ b/playground/src/features/inspector/compareCompilers.ts
@@ -79,23 +79,40 @@ async function compileOfficialVue(
     const warnings = normalizeCompilerMessages(parsed.errors);
     let bindingMetadata: BindingMetadata = {};
     let scriptCode = "";
+    const scoped = descriptor.styles.some((style) => style.scoped);
+    const inlineTemplate = Boolean(
+      descriptor.scriptSetup && descriptor.template && target === "dom",
+    );
 
     if (descriptor.script || descriptor.scriptSetup) {
       const script = compileScript(descriptor, {
         id: file.path,
-        inlineTemplate: false,
+        inlineTemplate,
+        isProd: true,
+        templateOptions: inlineTemplate
+          ? {
+              filename: file.path,
+              id: file.path,
+              scoped,
+              isProd: true,
+              compilerOptions: {
+                expressionPlugins: isTypeScript ? ["typescript"] : undefined,
+              },
+            }
+          : undefined,
       });
       scriptCode = script.content;
       bindingMetadata = script.bindings;
     }
 
     let templateCode = "";
-    if (descriptor.template) {
+    if (descriptor.template && !inlineTemplate) {
       const template = compileTemplate({
         source: descriptor.template.content,
         filename: file.path,
         id: file.path,
-        scoped: descriptor.styles.some((style) => style.scoped),
+        scoped,
+        isProd: true,
         ssr: target === "ssr",
         compilerOptions: {
           bindingMetadata,


### PR DESCRIPTION
## Summary
- Compile Vue official inspector output with inline production render output for DOM `<script setup>` SFCs.
- Avoid noisy diffs between `export function render` and Vize's `return (_ctx, _cache) =>` render shape.
- Keep separate template compilation for non-inline cases such as template-only and SSR.

## Validation
- `vp test run --config vite.test.config.ts src/features/inspector/compareCompilers.test.ts src/features/inspector/diffRows.test.ts src/features/atelier/codeOutputs.test.ts`
- `ROOT="$(cd .. && pwd -P)" && vp check src 'e2e/*.ts' 'e2e/vrt/*.ts' vite.config.ts vite.app.config.ts vite.test.config.ts vite.node.config.ts playwright.config.ts && cargo run --quiet --manifest-path "$ROOT/Cargo.toml" -p vize -- lint --max-warnings 0`
- `vp run --workspace-root check:ci`
- Browser verified Inspector Compare no longer contains `export function render` for the default script-setup DOM case, and no console errors were emitted.