### PR TITLE
fix: store oxlint workaround files under node_modules cache

### DIFF
--- a/npm/oxlint-plugin-vize/src/cli/output.ts
+++ b/npm/oxlint-plugin-vize/src/cli/output.ts
@@ -21,15 +21,18 @@ if (import.meta.vitest) {
   describe("rewriteReportedPaths", () => {
     it("rewrites both absolute and relative temporary filenames", () => {
       const replacements = new Map<string, string>([
-        ["/repo/__oxlint_plugin_vize_temp__/100/0-Example.vue", "/repo/src/Example.vue"],
-        ["__oxlint_plugin_vize_temp__/100/0-Example.vue", "/repo/src/Example.vue"],
+        [
+          "/repo/node_modules/.vize/oxlint-plugin-vize/100-abcd/0-Example.vue",
+          "/repo/src/Example.vue",
+        ],
+        ["node_modules/.vize/oxlint-plugin-vize/100-abcd/0-Example.vue", "/repo/src/Example.vue"],
       ]);
 
       expect(
         rewriteReportedPaths(
           [
-            "__oxlint_plugin_vize_temp__/100/0-Example.vue",
-            "/repo/__oxlint_plugin_vize_temp__/100/0-Example.vue",
+            "node_modules/.vize/oxlint-plugin-vize/100-abcd/0-Example.vue",
+            "/repo/node_modules/.vize/oxlint-plugin-vize/100-abcd/0-Example.vue",
           ].join("\n"),
           replacements,
         ),

--- a/npm/oxlint-plugin-vize/src/cli/workaround-files.ts
+++ b/npm/oxlint-plugin-vize/src/cli/workaround-files.ts
@@ -14,7 +14,10 @@ export function prepareScriptlessWorkaroundFiles(
   cwd: string,
   filenames: readonly string[],
 ): PreparedWorkaroundFiles {
-  const tempDir = path.join(cwd, "__oxlint_plugin_vize_temp__", String(process.pid));
+  const nodeModulesDir = path.join(cwd, "node_modules");
+  const tempRoot = path.join(nodeModulesDir, ".vize", "oxlint-plugin-vize");
+  let tempDir: string | undefined;
+  let createdNodeModules = false;
   const ignoreArgs: string[] = [];
   const tempArgs: string[] = [];
   const pathReplacements = new Map<string, string>();
@@ -28,6 +31,11 @@ export function prepareScriptlessWorkaroundFiles(
     }
 
     const relativeFilename = path.relative(cwd, filename);
+    if (tempDir == null) {
+      const created = createWorkaroundTempDir(nodeModulesDir, tempRoot);
+      tempDir = created.tempDir;
+      createdNodeModules = created.createdNodeModules;
+    }
     const tempBasename = isStandaloneHtml
       ? `${path.basename(filename)}.vue`
       : path.basename(filename);
@@ -45,15 +53,53 @@ export function prepareScriptlessWorkaroundFiles(
   return {
     appendedArgs: [...ignoreArgs, ...tempArgs],
     cleanup() {
-      if (pathReplacements.size === 0) {
+      if (tempDir == null) {
         return;
       }
 
       fs.rmSync(tempDir, { force: true, recursive: true });
+      removeEmptyDirectory(tempRoot);
+      removeEmptyDirectory(path.dirname(tempRoot));
+      if (createdNodeModules) {
+        removeEmptyDirectory(nodeModulesDir);
+      }
     },
     pathReplacements,
     usedScriptlessWorkaround: pathReplacements.size > 0,
   };
+}
+
+function createWorkaroundTempDir(
+  nodeModulesDir: string,
+  tempRoot: string,
+): { createdNodeModules: boolean; tempDir: string } {
+  const createdNodeModules = !fs.existsSync(nodeModulesDir);
+  fs.mkdirSync(tempRoot, { recursive: true });
+  return {
+    createdNodeModules,
+    tempDir: fs.mkdtempSync(path.join(tempRoot, `${process.pid}-`)),
+  };
+}
+
+function removeEmptyDirectory(dirname: string): void {
+  try {
+    fs.rmdirSync(dirname);
+  } catch (error) {
+    if (!isIgnorableRemoveDirError(error)) {
+      throw error;
+    }
+  }
+}
+
+function isIgnorableRemoveDirError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    "code" in error &&
+    (error.code === "ENOENT" ||
+      error.code === "ENOTDIR" ||
+      error.code === "ENOTEMPTY" ||
+      error.code === "EEXIST")
+  );
 }
 
 function toCliPath(filename: string): string {

--- a/npm/oxlint-plugin-vize/src/test.ts
+++ b/npm/oxlint-plugin-vize/src/test.ts
@@ -526,6 +526,19 @@ function readSnapshot(name: string): string {
   return normalizeOutput(fs.readFileSync(path.join(snapshotsDir, name), "utf8"));
 }
 
+function assertNoWorkaroundGarbage(): void {
+  assert.equal(
+    fs.existsSync(path.join(fixtureDir, "__oxlint_plugin_vize_temp__")),
+    false,
+    "scriptless workaround should not create project-local legacy temp directories",
+  );
+  assert.equal(
+    fs.existsSync(path.join(fixtureDir, "node_modules", ".vize", "oxlint-plugin-vize")),
+    false,
+    "scriptless workaround cleanup should remove generated node_modules/.vize files",
+  );
+}
+
 const defaultRun = runOxlint(["-c", ".oxlintrc.json", "App.vue"]);
 assert.notEqual(defaultRun.exitCode, 0, "oxlint should fail when Patina reports an error");
 assert.match(
@@ -584,6 +597,7 @@ const scriptlessJsonRun = runOxlintVize([
   "json",
   "Scriptless.vue",
 ]);
+assertNoWorkaroundGarbage();
 assert.notEqual(
   scriptlessJsonRun.exitCode,
   0,
@@ -596,7 +610,7 @@ assert.match(
 );
 assert.doesNotMatch(
   scriptlessJsonRun.output,
-  /__oxlint_plugin_vize_temp__/u,
+  /node_modules\/\.vize\/oxlint-plugin-vize|__oxlint_plugin_vize_temp__/u,
   "scriptless JSON output should not leak temporary workaround paths",
 );
 assert.equal(scriptlessJsonRun.output, readSnapshot("json-scriptless-workaround-output.txt"));
@@ -795,6 +809,7 @@ const scriptlessRun = runOxlintVize([
   "stylish",
   "Scriptless.vue",
 ]);
+assertNoWorkaroundGarbage();
 assert.notEqual(
   scriptlessRun.exitCode,
   0,
@@ -807,8 +822,8 @@ assert.match(
 );
 assert.doesNotMatch(
   scriptlessRun.output,
-  /node_modules\/\.cache\/oxlint-plugin-vize/u,
-  "scriptless workaround should not leak temporary cache paths to users",
+  /node_modules\/\.vize\/oxlint-plugin-vize/u,
+  "scriptless workaround should not leak temporary workaround paths to users",
 );
 assert.equal(scriptlessRun.output, readSnapshot("stylish-scriptless-workaround-output.txt"));
 
@@ -819,6 +834,7 @@ const standaloneHtmlRun = runOxlintVize([
   "stylish",
   "Standalone.html",
 ]);
+assertNoWorkaroundGarbage();
 assert.notEqual(
   standaloneHtmlRun.exitCode,
   0,
@@ -831,7 +847,7 @@ assert.match(
 );
 assert.doesNotMatch(
   standaloneHtmlRun.output,
-  /__oxlint_plugin_vize_temp__/u,
+  /node_modules\/\.vize\/oxlint-plugin-vize|__oxlint_plugin_vize_temp__/u,
   "standalone HTML output should not leak temporary workaround paths",
 );
 assert.equal(standaloneHtmlRun.output, readSnapshot("stylish-standalone-html-output.txt"));


### PR DESCRIPTION
## Summary
- move oxlint-vize scriptless workaround files from the old project-local `__oxlint_plugin_vize_temp__` directory to `node_modules/.vize/oxlint-plugin-vize`
- clean up generated workaround directories after each CLI run, including an empty `node_modules` only when this command created it
- add integration assertions that workaround output does not leak temp paths and generated `.vize` files are removed

## Validation
- `npx -y pnpm@10 --filter oxlint-plugin-vize check`
- `npx -y pnpm@10 --filter oxlint-plugin-vize test`