### PR TITLE
test: reuse lint worktree id

### DIFF
--- a/tests/package.json
+++ b/tests/package.json
@@ -8,7 +8,7 @@
     "test:vrt": "playwright test --config app/playwright.vrt.config.ts",
     "test:preview": "RUN_BUILD_TESTS=1 node app/preview/elk.ts && RUN_BUILD_TESTS=1 node app/preview/misskey.ts && RUN_BUILD_TESTS=1 node app/preview/npmx.ts && RUN_BUILD_TESTS=1 node app/preview/vuefes.ts",
     "test:check": "node --test --test-concurrency=1 snapshots/check/ant-design-vue.ts snapshots/check/elk.ts snapshots/check/misskey.ts snapshots/check/npmx.ts snapshots/check/nuxt-ui.ts snapshots/check/reka-ui.ts snapshots/check/vuefes.ts",
-    "test:lint": "node --test --test-concurrency=1 snapshots/lint/ant-design-vue.ts snapshots/lint/elk.ts snapshots/lint/misskey.ts snapshots/lint/npmx.ts snapshots/lint/nuxt-ui.ts snapshots/lint/reka-ui.ts snapshots/lint/vuefes.ts",
+    "test:lint": "VIZE_TEST_WORKTREE_ID=${VIZE_TEST_WORKTREE_ID:-lint} node --test --test-concurrency=1 snapshots/lint/ant-design-vue.ts snapshots/lint/elk.ts snapshots/lint/misskey.ts snapshots/lint/npmx.ts snapshots/lint/nuxt-ui.ts snapshots/lint/reka-ui.ts snapshots/lint/vuefes.ts",
     "test:build": "node --test snapshots/build/elk.ts snapshots/build/misskey.ts snapshots/build/npmx.ts snapshots/build/vuefes.ts",
     "test:check:fixtures": "node --test --test-concurrency=1 snapshots/check/typecheck-errors.ts snapshots/check/compiler-macros.ts snapshots/check/style-preprocessors.ts snapshots/check/ecosystem-products.ts snapshots/check/toolchain-parity.ts"
   },


### PR DESCRIPTION
## Summary

- Set a stable default `VIZE_TEST_WORKTREE_ID` for the `test:lint` npm script.
- Keep lint snapshot tests reusing `tests/_fixtures/_projects/_git-worktrees/lint` instead of creating a new `pid-*` directory for each run.

## Root Cause

`tests/_helpers/apps.ts` defaults mutable fixture worktrees to `pid-${process.pid}` when `VIZE_TEST_WORKTREE_ID` is absent. `test:lint` can exercise the Misskey mutable fixture path, so each local lint run created another ignored worktree directory.

## Validation

- `VIZE_TEST_WORKTREE_ID=lint node --test --test-concurrency=1 --test-name-pattern '__codex_no_match__' snapshots/lint/ant-design-vue.ts snapshots/lint/elk.ts snapshots/lint/misskey.ts snapshots/lint/npmx.ts snapshots/lint/nuxt-ui.ts snapshots/lint/reka-ui.ts snapshots/lint/vuefes.ts`