### PR TITLE
fix: clean up stale patina sessions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3733,6 +3733,7 @@ dependencies = [
  "corsa",
  "criterion",
  "insta",
+ "libc",
  "lightningcss",
  "memchr",
  "oxc_allocator",

--- a/crates/vize_patina/Cargo.toml
+++ b/crates/vize_patina/Cargo.toml
@@ -40,6 +40,9 @@ memchr.workspace = true
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 corsa.workspace = true
 
+[target.'cfg(all(not(target_arch = "wasm32"), unix))'.dependencies]
+libc.workspace = true
+
 [dev-dependencies]
 insta.workspace = true
 criterion.workspace = true

--- a/crates/vize_patina/src/linter/corsa_session/paths.rs
+++ b/crates/vize_patina/src/linter/corsa_session/paths.rs
@@ -7,6 +7,7 @@ use vize_carton::{String, ToCompactString, cstr};
 const EXECUTABLE_ENV_VARS: [&str; 2] = ["CORSA_EXECUTABLE", "CORSA_PATH"];
 const LEGACY_EXECUTABLE_ENV_VARS: [&str; 2] = ["TSGO_EXECUTABLE", "TSGO_PATH"];
 const EXECUTABLE_NAMES: [&str; 2] = ["corsa", "tsgo"];
+const SESSION_DIRECTORY_PREFIX: &str = "session-";
 pub(super) const VIRTUAL_FILE_NAME: &str = "active.patina.ts";
 pub(super) const TSCONFIG_FILE_NAME: &str = "tsconfig.json";
 static SESSION_COUNTER: AtomicU64 = AtomicU64::new(0);
@@ -30,11 +31,13 @@ pub(super) fn path_to_wire(path: &Path) -> String {
 
 pub(super) fn allocate_session_root(project_root: &Path) -> PathBuf {
     let session_name = next_session_directory_name();
-    project_root
-        .join("node_modules")
-        .join(".vize")
-        .join("patina")
-        .join(session_name.as_str())
+    cleanup_stale_session_roots(project_root);
+    session_store_root(project_root).join(session_name.as_str())
+}
+
+pub(super) fn remove_session_root(session_root: &Path) {
+    let _ = std::fs::remove_dir_all(session_root);
+    remove_empty_session_parents(session_root);
 }
 
 pub(super) fn next_session_directory_name() -> String {
@@ -46,6 +49,87 @@ pub(super) fn next_session_directory_name() -> String {
     name.push('-');
     push_u64(&mut name, counter);
     name
+}
+
+fn session_store_root(project_root: &Path) -> PathBuf {
+    project_root.join(".vize").join("patina")
+}
+
+fn legacy_session_store_root(project_root: &Path) -> PathBuf {
+    project_root
+        .join("node_modules")
+        .join(".vize")
+        .join("patina")
+}
+
+fn cleanup_stale_session_roots(project_root: &Path) {
+    cleanup_stale_sessions_in(&session_store_root(project_root));
+    cleanup_stale_sessions_in(&legacy_session_store_root(project_root));
+}
+
+fn cleanup_stale_sessions_in(session_store: &Path) {
+    let Ok(entries) = std::fs::read_dir(session_store) else {
+        return;
+    };
+
+    for entry in entries.flatten() {
+        let Ok(file_type) = entry.file_type() else {
+            continue;
+        };
+        if !file_type.is_dir() {
+            continue;
+        }
+
+        let name = entry.file_name();
+        let Some(name) = name.to_str() else {
+            continue;
+        };
+        if is_stale_session_directory(name) {
+            remove_session_root(&entry.path());
+        }
+    }
+}
+
+fn is_stale_session_directory(name: &str) -> bool {
+    let Some(pid) = session_directory_pid(name) else {
+        return false;
+    };
+    !process_is_running(pid)
+}
+
+fn session_directory_pid(name: &str) -> Option<u64> {
+    let rest = name.strip_prefix(SESSION_DIRECTORY_PREFIX)?;
+    let (pid, _) = rest.split_once('-')?;
+    pid.parse().ok()
+}
+
+#[cfg(unix)]
+fn process_is_running(pid: u64) -> bool {
+    if pid == 0 || pid > i32::MAX as u64 {
+        return false;
+    }
+
+    let result = unsafe { libc::kill(pid as libc::pid_t, 0) };
+    result == 0 || std::io::Error::last_os_error().raw_os_error() == Some(libc::EPERM)
+}
+
+#[cfg(not(unix))]
+fn process_is_running(_pid: u64) -> bool {
+    true
+}
+
+fn remove_empty_session_parents(session_root: &Path) {
+    let Some(session_store) = session_root.parent() else {
+        return;
+    };
+    let _ = std::fs::remove_dir(session_store);
+
+    let Some(vize_dir) = session_store.parent() else {
+        return;
+    };
+    if vize_dir.file_name().and_then(|name| name.to_str()) == Some(".vize") {
+        let _ = std::fs::remove_dir(vize_dir);
+    }
 }
 
 pub(super) fn resolve_project_root(filename: &str) -> PathBuf {
@@ -324,7 +408,9 @@ fn push_u64(buffer: &mut String, value: u64) {
 
 #[cfg(test)]
 mod tests {
-    use super::resolve_corsa_executable;
+    #[cfg(unix)]
+    use super::is_stale_session_directory;
+    use super::{cleanup_stale_session_roots, resolve_corsa_executable, session_store_root};
     use std::{
         path::{Path, PathBuf},
         sync::atomic::{AtomicU64, Ordering},
@@ -385,6 +471,57 @@ mod tests {
 
         assert!(error.contains("Configured Corsa executable does not exist"));
         assert!(error.contains("missing-corsa"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn removes_dead_session_directories() {
+        let root = case_dir("dead-session-cleanup");
+        let _ = std::fs::remove_dir_all(&root);
+        let store = session_store_root(&root);
+        let stale = store.join("session-9999999999-0");
+        let legacy_stale = root
+            .join("node_modules")
+            .join(".vize")
+            .join("patina")
+            .join("session-9999999999-1");
+        let unrelated = store.join("cache");
+
+        std::fs::create_dir_all(&stale).unwrap();
+        std::fs::create_dir_all(&legacy_stale).unwrap();
+        std::fs::create_dir_all(&unrelated).unwrap();
+
+        cleanup_stale_session_roots(&root);
+
+        assert!(!stale.exists());
+        assert!(!legacy_stale.exists());
+        assert!(unrelated.exists());
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn keeps_live_session_directories() {
+        let root = case_dir("live-session-cleanup");
+        let _ = std::fs::remove_dir_all(&root);
+        let store = session_store_root(&root);
+        let live = store.join(&*cstr!("session-{}-0", std::process::id()));
+
+        std::fs::create_dir_all(&live).unwrap();
+
+        cleanup_stale_session_roots(&root);
+
+        assert!(live.exists());
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn identifies_session_directories_by_pid() {
+        assert!(is_stale_session_directory("session-9999999999-0"));
+        assert!(!is_stale_session_directory("session-not-a-pid-0"));
+        assert!(!is_stale_session_directory("cache"));
     }
 
     fn write_file(path: &Path) {

--- a/crates/vize_patina/src/linter/corsa_session/session.rs
+++ b/crates/vize_patina/src/linter/corsa_session/session.rs
@@ -3,7 +3,7 @@ use super::{
     errors::{compact_error, io_error_message},
     paths::{
         TSCONFIG_CONTENTS, TSCONFIG_FILE_NAME, VIRTUAL_FILE_NAME, allocate_session_root,
-        path_to_wire, resolve_corsa_executable, resolve_project_root,
+        path_to_wire, remove_session_root, resolve_corsa_executable, resolve_project_root,
     },
 };
 use corsa::{
@@ -21,7 +21,9 @@ impl CorsaTypeAwareSession {
         corsa_path: Option<&std::path::Path>,
     ) -> Result<Self, String> {
         let project_root = resolve_project_root(filename);
+        let executable = resolve_corsa_executable(&project_root, corsa_path)?;
         let session_root = allocate_session_root(&project_root);
+        let cleanup_guard = SessionRootCleanup::new(session_root.clone());
         profile!(
             "patina.corsa_session.create_dir",
             std::fs::create_dir_all(&session_root)
@@ -58,7 +60,6 @@ impl CorsaTypeAwareSession {
 
         let config_path_wire = path_to_wire(&config_path);
         let virtual_file_wire = path_to_wire(&virtual_file_path);
-        let executable = resolve_corsa_executable(&project_root, corsa_path)?;
         let api_mode = api_mode_for_executable(&executable);
         let session = profile!(
             "patina.corsa_session.spawn",
@@ -83,6 +84,7 @@ impl CorsaTypeAwareSession {
         .map(|capabilities| capabilities.overlay.update_snapshot_overlay_changes)
         .unwrap_or(false);
 
+        let session_root = cleanup_guard.keep();
         Ok(Self {
             session,
             project_root,
@@ -166,7 +168,29 @@ impl CorsaTypeAwareSession {
         }
         self.closed = true;
         let _ = block_on(self.session.close());
-        let _ = std::fs::remove_dir_all(&self.session_root);
+        remove_session_root(&self.session_root);
+    }
+}
+
+struct SessionRootCleanup {
+    path: Option<std::path::PathBuf>,
+}
+
+impl SessionRootCleanup {
+    fn new(path: std::path::PathBuf) -> Self {
+        Self { path: Some(path) }
+    }
+
+    fn keep(mut self) -> std::path::PathBuf {
+        self.path.take().expect("session root cleanup path")
+    }
+}
+
+impl Drop for SessionRootCleanup {
+    fn drop(&mut self) {
+        if let Some(path) = &self.path {
+            remove_session_root(path);
+        }
     }
 }
 
@@ -203,8 +227,13 @@ fn api_mode_for_executable(path: &std::path::Path) -> ApiMode {
 #[cfg(test)]
 mod tests {
     use super::api_mode_for_executable;
+    use crate::linter::corsa_session::CorsaTypeAwareSession;
     use corsa::api::ApiMode;
     use std::path::Path;
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use vize_carton::cstr;
+
+    static NEXT_CASE_ID: AtomicU64 = AtomicU64::new(0);
 
     #[test]
     fn uses_json_rpc_for_node_wrappers() {
@@ -228,5 +257,44 @@ mod tests {
             )),
             ApiMode::SyncMsgpackStdio
         );
+    }
+
+    #[test]
+    fn cleans_session_root_when_spawn_fails() {
+        let root = case_dir("spawn-fails");
+        let _ = std::fs::remove_dir_all(&root);
+        let source = root.join("Component.vue");
+        let invalid_corsa = root.join("not-corsa");
+
+        std::fs::create_dir_all(&root).unwrap();
+        std::fs::write(root.join("package.json"), "{}").unwrap();
+        std::fs::write(&invalid_corsa, "").unwrap();
+
+        let error = match CorsaTypeAwareSession::new_with_corsa_path(
+            source.to_str().unwrap(),
+            Some(invalid_corsa.as_path()),
+        ) {
+            Ok(mut session) => {
+                session.close();
+                panic!("invalid corsa executable unexpectedly started");
+            }
+            Err(error) => error,
+        };
+
+        assert!(error.contains("Failed to start corsa type-aware session"));
+        assert!(!root.join(".vize").join("patina").exists());
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    fn case_dir(name: &str) -> std::path::PathBuf {
+        let id = NEXT_CASE_ID.fetch_add(1, Ordering::Relaxed);
+        std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("target")
+            .join("vize-tests")
+            .join(&*cstr!(
+                "patina-corsa-session-{name}-{}-{id}",
+                std::process::id()
+            ))
     }
 }


### PR DESCRIPTION
## Summary

- Move Patina Corsa session directories out of `node_modules/.vize` into the project `.vize/patina` store.
- Clean up stale `session-*` directories from dead processes, including the legacy `node_modules/.vize/patina` location.
- Remove session directories on initialization failure and collapse empty `.vize` parents after close.

## Why

Type-aware lint sessions could leave behind `session-*` directories when Corsa startup failed or when a process exited without running `Drop`. Repeated runs could grow local `.vize` state indefinitely.

## Validation

- `cargo fmt --check`
- `cargo check -p vize_patina`
- `cargo test -p vize_patina corsa_session --lib`
- `cargo test -p vize_patina native_type_aware --lib`
- `git diff --check HEAD^ HEAD`