### PR TITLE
perf: optimize release profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -141,9 +141,14 @@ corsa_lsp = { package = "corsa_lsp", version = "=0.7.0" }
 corsa_runtime = { package = "corsa_runtime", version = "=0.7.0" }
 
 [profile.release]
-lto = true
-codegen-units = 1
 opt-level = 3
+lto = "fat"
+codegen-units = 1
+panic = "abort"
+debug = false
+debug-assertions = false
+overflow-checks = false
+incremental = false
 
 [profile.ci]
 inherits = "dev"


### PR DESCRIPTION
## Summary

- Make the release profile's fat LTO setting explicit.
- Disable release debug info, debug assertions, overflow checks, and incremental compilation.
- Set release panic strategy to `abort` for smaller optimized artifacts.

## Validation

- `cargo metadata --no-deps --format-version 1`
- `cargo check --release -p vize --no-default-features`