### PR TITLE
fix(nix): fetch crates from static endpoint

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -30,6 +30,12 @@
         lib = pkgs.lib;
         workspaceCargo = builtins.fromTOML (builtins.readFile ./Cargo.toml);
         workspaceVersion = workspaceCargo.workspace.package.version;
+        cratesIoIndex = "registry+https://github.com/rust-lang/crates.io-index";
+        cratesIoNixIndexUrl = "https://vize.invalid/nix-crates.io-index";
+        cratesIoNixIndex = "registry+${cratesIoNixIndexUrl}";
+        nixCargoLockContents = builtins.replaceStrings [ cratesIoIndex ] [ cratesIoNixIndex ] (
+          builtins.readFile ./Cargo.lock
+        );
         moonbitArtifacts = {
           aarch64-darwin = {
             version = "0.9.3-2026-05-22";
@@ -214,9 +220,20 @@
           src = lib.cleanSource ./.;
 
           cargoLock = {
-            lockFile = ./Cargo.lock;
+            lockFileContents = nixCargoLockContents;
             allowBuiltinFetchGit = true;
+            extraRegistries = {
+              # crates.io's API endpoint rejects fetchurl's default request
+              # headers. Use a Nix-only registry alias so Cargo does not
+              # define crates-io twice, then fetch the same tarballs from
+              # the static endpoint.
+              "${cratesIoNixIndexUrl}" = "https://static.crates.io/crates";
+            };
           };
+          postPatch = ''
+            substituteInPlace Cargo.lock \
+              --replace-fail ${lib.escapeShellArg cratesIoIndex} ${lib.escapeShellArg cratesIoNixIndex}
+          '';
 
           cargoBuildFlags = [
             "-p"


### PR DESCRIPTION
## Summary

- route Nix-only crates.io registry entries through a vendor alias
- fetch crate tarballs from `static.crates.io` instead of the crates.io API endpoint
- patch the build-time `Cargo.lock` only inside the Nix derivation so the repository lockfile stays unchanged

## Root cause

The crates.io API download endpoint rejects Nix `fetchurl` requests without a Cargo-style User-Agent, returning HTTP 403. The static endpoint serves the same crate tarballs and works with Nix fixed-output fetching.

## Validation

- `nix build --no-link .#packages.aarch64-darwin.vize.cargoDeps`
- `nix build --no-link .#checks.aarch64-darwin.package`
- `nix flake check --no-build --all-systems`
- `nix flake check`