### PR TITLE
feat: polish hover information

### DIFF
--- a/crates/vize_maestro/src/ide/hover.rs
+++ b/crates/vize_maestro/src/ide/hover.rs
@@ -109,17 +109,24 @@ impl HoverService {
             _ => return None,
         };
 
-        #[allow(clippy::disallowed_macros)]
-        Some(Hover {
-            contents: HoverContents::Markup(MarkupContent {
-                kind: MarkupKind::Markdown,
-                value: format!(
-                    "**{}**\n\n{}\n\n[Vue SFC CSS Features](https://vuejs.org/api/sfc-css-features.html)",
-                    title, description
-                ),
-            }),
-            range: None,
-        })
+        Some(
+            HoverBuilder::new()
+                .title(title)
+                .meta("Vue SFC CSS feature")
+                .description(description)
+                .bullets(
+                    "Behavior",
+                    &[
+                        "Applies during Vue SFC scoped CSS compilation.",
+                        "Keep the selector explicit so the compiled output remains predictable.",
+                    ],
+                )
+                .link(
+                    "Vue SFC CSS Features",
+                    "https://vuejs.org/api/sfc-css-features.html",
+                )
+                .build(),
+        )
     }
 
     // =========================================================================
@@ -462,11 +469,41 @@ impl HoverBuilder {
         self
     }
 
+    /// Add compact metadata under the title.
+    #[allow(clippy::disallowed_macros)]
+    pub fn meta(mut self, text: &str) -> Self {
+        self.sections.push(format!("_{}_", text));
+        self
+    }
+
     /// Add a code block.
     #[allow(clippy::disallowed_macros)]
     pub fn code(mut self, language: &str, code: &str) -> Self {
         self.sections
             .push(format!("```{}\n{}\n```", language, code));
+        self
+    }
+
+    /// Add a named text section.
+    #[allow(clippy::disallowed_macros)]
+    pub fn section(mut self, heading: &str, text: &str) -> Self {
+        self.sections.push(format!("**{}**\n\n{}", heading, text));
+        self
+    }
+
+    /// Add a named bullet list.
+    #[allow(clippy::disallowed_macros)]
+    pub fn bullets(mut self, heading: &str, items: &[&str]) -> Self {
+        if items.is_empty() {
+            return self;
+        }
+
+        let body = items
+            .iter()
+            .map(|item| format!("- {}", item))
+            .collect::<Vec<_>>()
+            .join("\n");
+        self.sections.push(format!("**{}**\n{}", heading, body));
         self
     }
 
@@ -653,6 +690,21 @@ const double = computed(() => count.value * 2)
         } else {
             panic!("Expected Markup content");
         }
+    }
+
+    #[cfg(feature = "native")]
+    #[test]
+    fn test_corsa_hover_is_decorated_for_editor_clients() {
+        let hover = HoverService::convert_lsp_hover(vize_canon::LspHover {
+            contents: vize_canon::LspHoverContents::String("(property) count: number".to_string()),
+            range: None,
+        });
+        let value = hover_markdown(hover);
+
+        assert!(value.contains("TypeScript quick info"));
+        assert!(value.contains("Resolved through Vize virtual TypeScript"));
+        assert!(value.contains("```typescript"));
+        assert!(value.contains("count: number"));
     }
 
     #[test]

--- a/crates/vize_maestro/src/ide/hover/corsa.rs
+++ b/crates/vize_maestro/src/ide/hover/corsa.rs
@@ -176,46 +176,38 @@ impl HoverService {
 
     /// Convert a Corsa hover payload to tower-lsp Hover.
     pub(super) fn convert_lsp_hover(lsp_hover: LspHover) -> Hover {
-        let contents = match lsp_hover.contents {
+        let value = match lsp_hover.contents {
             LspHoverContents::Markup(markup) => {
-                let value = if markup.kind == "markdown" {
+                if markup.kind == "markdown" {
                     markup.value
                 } else {
                     // Wrap plaintext TypeScript type info in a code block for better rendering
                     Self::wrap_type_info_in_codeblock(&markup.value)
-                };
-                HoverContents::Markup(MarkupContent {
-                    kind: MarkupKind::Markdown,
-                    value,
-                })
+                }
             }
             LspHoverContents::String(s) => {
                 // Wrap plaintext in a TypeScript code block
-                HoverContents::Markup(MarkupContent {
-                    kind: MarkupKind::Markdown,
-                    value: Self::wrap_type_info_in_codeblock(&s),
-                })
+                Self::wrap_type_info_in_codeblock(&s)
             }
-            LspHoverContents::Array(items) => {
-                let value = items
-                    .into_iter()
-                    .map(|item| match item {
-                        LspMarkedString::String(s) => Self::wrap_type_info_in_codeblock(&s),
-                        LspMarkedString::LanguageString { language, value } => {
-                            #[allow(clippy::disallowed_macros)]
-                            {
-                                format!("```{}\n{}\n```", language, value)
-                            }
+            LspHoverContents::Array(items) => items
+                .into_iter()
+                .map(|item| match item {
+                    LspMarkedString::String(s) => Self::wrap_type_info_in_codeblock(&s),
+                    LspMarkedString::LanguageString { language, value } => {
+                        #[allow(clippy::disallowed_macros)]
+                        {
+                            format!("```{}\n{}\n```", language, value)
                         }
-                    })
-                    .collect::<Vec<_>>()
-                    .join("\n\n");
-                HoverContents::Markup(MarkupContent {
-                    kind: MarkupKind::Markdown,
-                    value,
+                    }
                 })
-            }
+                .collect::<Vec<_>>()
+                .join("\n\n"),
         };
+
+        let contents = HoverContents::Markup(MarkupContent {
+            kind: MarkupKind::Markdown,
+            value: Self::decorate_corsa_hover_markdown(&value),
+        });
 
         let range = lsp_hover.range.map(|r| Range {
             start: tower_lsp::lsp_types::Position {
@@ -262,6 +254,20 @@ impl HoverService {
             }
         } else {
             text.to_string()
+        }
+    }
+
+    fn decorate_corsa_hover_markdown(value: &str) -> String {
+        let value = value.trim();
+        if value.is_empty() {
+            return String::new();
+        }
+
+        #[allow(clippy::disallowed_macros)]
+        {
+            format!(
+                "**TypeScript quick info**\n\n_Resolved through Vize virtual TypeScript_\n\n{value}"
+            )
         }
     }
 }

--- a/crates/vize_maestro/src/ide/hover/script.rs
+++ b/crates/vize_maestro/src/ide/hover/script.rs
@@ -8,7 +8,7 @@
     clippy::disallowed_macros
 )]
 
-use tower_lsp::lsp_types::{Hover, HoverContents, MarkupContent, MarkupKind};
+use tower_lsp::lsp_types::{Hover, HoverContents};
 use vize_croquis::{Analyzer, AnalyzerOptions};
 use vize_relief::BindingType;
 
@@ -18,7 +18,7 @@ use std::sync::Arc;
 #[cfg(feature = "native")]
 use vize_canon::CorsaBridge;
 
-use super::HoverService;
+use super::{HoverBuilder, HoverService};
 use crate::ide::IdeContext;
 impl HoverService {
     /// Get hover for script context.
@@ -152,33 +152,23 @@ impl HoverService {
             .and_then(|content| Self::infer_type_from_script(content, word, binding_type))
             .unwrap_or_else(|| Self::binding_type_to_ts_display(binding_type).to_string());
 
-        // Format the hover content with reactivity hints for script context
         let kind_desc = Self::binding_type_to_description(binding_type);
-
-        // Add .value hint for refs in script
         #[allow(clippy::disallowed_macros)]
-        let value_hint = if summary.needs_value_in_script(word) {
-            format!(
-                "\n\n**Tip:** Use `{}.value` to access the value in script.",
-                word
-            )
-        } else {
-            String::new()
-        };
+        let signature = format!("{word}: {inferred_type}");
 
-        #[allow(clippy::disallowed_macros)]
-        let value = format!(
-            "```typescript\n{}: {}\n```\n\n{}{}",
-            word, inferred_type, kind_desc, value_hint
-        );
+        let mut builder = HoverBuilder::new()
+            .title(word)
+            .meta("Script binding")
+            .code("typescript", &signature)
+            .description(kind_desc);
 
-        Some(Hover {
-            contents: HoverContents::Markup(MarkupContent {
-                kind: MarkupKind::Markdown,
-                value,
-            }),
-            range: None,
-        })
+        if summary.needs_value_in_script(word) {
+            #[allow(clippy::disallowed_macros)]
+            let tip = format!("Use `{}.value` to read or write this ref in script.", word);
+            builder = builder.section("Tip", &tip);
+        }
+
+        Some(builder.build())
     }
 
     /// Get hover for Vue Composition API.
@@ -263,17 +253,22 @@ impl HoverService {
             _ => return None,
         };
 
-        #[allow(clippy::disallowed_macros)]
-        Some(Hover {
-            contents: HoverContents::Markup(MarkupContent {
-                kind: MarkupKind::Markdown,
-                value: format!(
-                    "```typescript\n{}\n```\n\n{}\n\n[Vue Documentation](https://vuejs.org/api/)",
-                    signature, description
-                ),
-            }),
-            range: None,
-        })
+        Some(
+            HoverBuilder::new()
+                .title(word)
+                .meta("Vue Composition API")
+                .code("typescript", signature)
+                .description(description)
+                .bullets(
+                    "Usage",
+                    &[
+                        "Import from `vue` in normal scripts.",
+                        "Works naturally in `<script setup>` and Composition API setup functions.",
+                    ],
+                )
+                .link("Vue API Reference", "https://vuejs.org/api/")
+                .build(),
+        )
     }
 
     /// Get hover for Vue macros.
@@ -314,17 +309,21 @@ impl HoverService {
             _ => return None,
         };
 
-        #[allow(clippy::disallowed_macros)]
-        Some(Hover {
-            contents: HoverContents::Markup(MarkupContent {
-                kind: MarkupKind::Markdown,
-                value: format!(
-                    "```typescript\n{}\n```\n\n{}\n\n*Compiler macro - only usable inside `<script setup>`*",
-                    signature, description
-                ),
-            }),
-            range: None,
-        })
+        Some(
+            HoverBuilder::new()
+                .title(word)
+                .meta("Vue compiler macro")
+                .code("typescript", signature)
+                .description(description)
+                .bullets(
+                    "Macro behavior",
+                    &[
+                        "Only usable inside `<script setup>`.",
+                        "No runtime import is required because the SFC compiler handles it.",
+                    ],
+                )
+                .build(),
+        )
     }
 
     /// Convert BindingType to TypeScript type display string.

--- a/crates/vize_maestro/src/ide/hover/template.rs
+++ b/crates/vize_maestro/src/ide/hover/template.rs
@@ -8,7 +8,7 @@
     clippy::disallowed_macros
 )]
 
-use tower_lsp::lsp_types::{Hover, HoverContents, MarkupContent, MarkupKind};
+use tower_lsp::lsp_types::Hover;
 use vize_croquis::{Analyzer, AnalyzerOptions};
 
 #[cfg(feature = "native")]
@@ -17,9 +17,8 @@ use std::sync::Arc;
 #[cfg(feature = "native")]
 use vize_canon::CorsaBridge;
 
-use super::HoverService;
+use super::{HoverBuilder, HoverService};
 use crate::ide::IdeContext;
-use vize_carton::append;
 
 impl HoverService {
     /// Get hover for template context.
@@ -48,19 +47,17 @@ impl HoverService {
         // Try to get type information from vize_canon
         if let Some(type_info) = crate::ide::TypeService::get_type_at(ctx) {
             #[allow(clippy::disallowed_macros)]
-            let mut value = format!("**{}**\n\n```typescript\n{}\n```", word, type_info.display);
+            let signature = format!("{word}: {}", type_info.display);
+            let mut builder = HoverBuilder::new()
+                .title(&word)
+                .meta("Template expression type")
+                .code("typescript", &signature);
 
             if let Some(ref doc) = type_info.documentation {
-                append!(value, "\n\n{doc}");
+                builder = builder.section("Documentation", doc);
             }
 
-            return Some(Hover {
-                contents: HoverContents::Markup(MarkupContent {
-                    kind: MarkupKind::Markdown,
-                    value,
-                }),
-                range: None,
-            });
+            return Some(builder.build());
         }
 
         // Check for template bindings from script setup
@@ -70,26 +67,31 @@ impl HoverService {
             let bindings =
                 crate::virtual_code::extract_simple_bindings(&script_setup.content, true);
             if bindings.contains(&word) {
-                return Some(Hover {
-                    contents: HoverContents::Markup(MarkupContent {
-                        kind: MarkupKind::Markdown,
-                        #[allow(clippy::disallowed_macros)]
-                        value: format!("**{}**\n\n*Binding from `<script setup>`*", word),
-                    }),
-                    range: None,
-                });
+                return Some(
+                    HoverBuilder::new()
+                        .title(&word)
+                        .meta("Template binding")
+                        .description("Binding from `<script setup>`.")
+                        .bullets(
+                            "Behavior",
+                            &[
+                                "Available directly in the template scope.",
+                                "Vue automatically unwraps refs when rendering templates.",
+                            ],
+                        )
+                        .build(),
+                );
             }
         }
 
         // Default: show it's a template expression
-        Some(Hover {
-            contents: HoverContents::Markup(MarkupContent {
-                kind: MarkupKind::Markdown,
-                #[allow(clippy::disallowed_macros)]
-                value: format!("**{}**\n\n*Template expression*", word),
-            }),
-            range: None,
-        })
+        Some(
+            HoverBuilder::new()
+                .title(&word)
+                .meta("Template expression")
+                .description("Expression evaluated against the component template scope.")
+                .build(),
+        )
     }
 
     /// Get hover for template context with Corsa support.
@@ -193,18 +195,23 @@ impl HoverService {
         let kind_desc = Self::binding_type_to_description(binding_type);
 
         #[allow(clippy::disallowed_macros)]
-        let value = format!(
-            "```typescript\n{}: {}\n```\n\n{}\n\n*Source: `<script setup>`*",
-            word, inferred_type, kind_desc
-        );
+        let signature = format!("{word}: {inferred_type}");
 
-        Some(Hover {
-            contents: HoverContents::Markup(MarkupContent {
-                kind: MarkupKind::Markdown,
-                value,
-            }),
-            range: None,
-        })
+        Some(
+            HoverBuilder::new()
+                .title(word)
+                .meta("Template binding from script")
+                .code("typescript", &signature)
+                .description(kind_desc)
+                .bullets(
+                    "Template behavior",
+                    &[
+                        "Ref values are automatically unwrapped in templates.",
+                        "The binding is resolved from `<script setup>` analysis.",
+                    ],
+                )
+                .build(),
+        )
     }
 
     /// Get hover for Vue directives.
@@ -267,16 +274,23 @@ impl HoverService {
             _ => return None,
         };
 
-        Some(Hover {
-            contents: HoverContents::Markup(MarkupContent {
-                kind: MarkupKind::Markdown,
-                #[allow(clippy::disallowed_macros)]
-                value: format!(
-                    "**{}**\n\n{}\n\n[Vue Documentation](https://vuejs.org/api/built-in-directives.html)",
-                    title, description
-                ),
-            }),
-            range: None,
-        })
+        Some(
+            HoverBuilder::new()
+                .title(title)
+                .meta("Vue template directive")
+                .description(description)
+                .bullets(
+                    "Usage",
+                    &[
+                        "Use inside `<template>` markup.",
+                        "Directive expressions are evaluated in component scope.",
+                    ],
+                )
+                .link(
+                    "Vue Built-in Directives",
+                    "https://vuejs.org/api/built-in-directives.html",
+                )
+                .build(),
+        )
     }
 }

--- a/playground/src/features/canon/useMonacoTypeCheck.ts
+++ b/playground/src/features/canon/useMonacoTypeCheck.ts
@@ -193,6 +193,49 @@ export function useMonacoTypeCheck({
     return null;
   }
 
+  function getSeverityLabel(severity: Diagnostic["severity"]): string {
+    if (severity === "error") return "Error";
+    if (severity === "warning") return "Warning";
+    return "Info";
+  }
+
+  function getDiagnosticRangeLabel(diag: Diagnostic): string {
+    const endLine = diag.endLine ?? diag.startLine;
+    const endColumn = diag.endColumn ?? diag.startColumn + 1;
+    if (endLine === diag.startLine) {
+      return `Line ${diag.startLine}, columns ${diag.startColumn}-${endColumn}`;
+    }
+    return `Lines ${diag.startLine}:${diag.startColumn}-${endLine}:${endColumn}`;
+  }
+
+  function getDiagnosticSourceLabel(diag: Diagnostic): string {
+    if (diag.code) return `TypeScript TS${diag.code}`;
+    if (diag.message.startsWith("[vize:")) return "Vize type checker";
+    return "Type analysis";
+  }
+
+  function buildDiagnosticHover(diag: Diagnostic): monaco.IMarkdownString[] {
+    const contents: monaco.IMarkdownString[] = [
+      {
+        value: [
+          `**${getSeverityLabel(diag.severity)}**`,
+          "",
+          `_${getDiagnosticSourceLabel(diag)}_ - ${getDiagnosticRangeLabel(diag)}`,
+          "",
+          diag.message,
+        ].join("\n"),
+      },
+    ];
+
+    if (diag.help) {
+      contents.push({
+        value: ["---", "**How to fix**", "", diag.help].join("\n"),
+      });
+    }
+
+    return contents;
+  }
+
   function registerHoverProvider() {
     if (hoverProviderDisposable) hoverProviderDisposable.dispose();
 
@@ -202,12 +245,7 @@ export function useMonacoTypeCheck({
 
         const diag = findDiagnosticAtPosition(position.lineNumber, position.column);
         if (diag) {
-          const severityLabel =
-            diag.severity === "error" ? "Error" : diag.severity === "warning" ? "Warning" : "Info";
-          contents.push({ value: `**[${severityLabel}]** ${diag.message}` });
-          if (diag.help) {
-            contents.push({ value: `---\n**Hint**\n\n${diag.help}` });
-          }
+          contents.push(...buildDiagnosticHover(diag));
         }
 
         const srcOffset = model.getOffsetAt(position);
@@ -216,7 +254,9 @@ export function useMonacoTypeCheck({
           const hoverContent = await getTypeScriptHover(genOffset);
           if (hoverContent) {
             if (contents.length > 0) contents.push({ value: "---" });
-            contents.push({ value: hoverContent });
+            contents.push({
+              value: ["**TypeScript quick info**", "", hoverContent].join("\n"),
+            });
           }
         }
 

--- a/playground/src/features/croquis/useCroquisAnalysis.ts
+++ b/playground/src/features/croquis/useCroquisAnalysis.ts
@@ -46,6 +46,8 @@ export function useCroquisAnalysis(getCompilerProp: () => WasmModule | null) {
         end: scope.end,
         kind: scope.kind,
         kindStr: scope.kindStr,
+        depth: scope.depth,
+        bindings: scope.bindings,
       }));
   });
 

--- a/playground/src/features/patina/useLinting.ts
+++ b/playground/src/features/patina/useLinting.ts
@@ -131,6 +131,47 @@ export function useLinting(options: UseLintingOptions) {
     return null;
   }
 
+  function getSeverityLabel(severity: LintDiagnostic["severity"]): string {
+    if (severity === "error") return "Error";
+    if (severity === "warning") return "Warning";
+    return "Info";
+  }
+
+  function getDiagnosticRangeLabel(diag: LintDiagnostic): string {
+    const start = diag.location.start;
+    const end = diag.location.end;
+    if (!end || (end.line === start.line && end.column === start.column)) {
+      return `Line ${start.line}, column ${start.column}`;
+    }
+    if (end.line === start.line) {
+      return `Line ${start.line}, columns ${start.column}-${end.column}`;
+    }
+    return `Lines ${start.line}:${start.column}-${end.line}:${end.column}`;
+  }
+
+  function buildDiagnosticHover(diag: LintDiagnostic): monaco.IMarkdownString[] {
+    const severityLabel = getSeverityLabel(diag.severity);
+    const contents: monaco.IMarkdownString[] = [
+      {
+        value: [
+          `**${severityLabel}**`,
+          "",
+          `_Patina rule_ \`${diag.rule}\` - ${getDiagnosticRangeLabel(diag)}`,
+          "",
+          diag.message,
+        ].join("\n"),
+      },
+    ];
+
+    if (diag.help) {
+      contents.push({
+        value: ["---", "**How to fix**", "", diag.help].join("\n"),
+      });
+    }
+
+    return contents;
+  }
+
   /** Register Monaco hover provider to show diagnostic help on hover */
   function registerHoverProvider() {
     if (hoverProviderDisposable) {
@@ -144,18 +185,7 @@ export function useLinting(options: UseLintingOptions) {
         // Check if hovering over a diagnostic
         const diag = findDiagnosticAtPosition(position.lineNumber, position.column);
         if (diag) {
-          // Add diagnostic message with severity indicator
-          const severityLabel = diag.severity === "error" ? "Error" : "Warning";
-          contents.push({
-            value: `**[${severityLabel}]** \`${diag.rule}\`\n\n${diag.message}`,
-          });
-
-          // Add help if available (render as markdown)
-          if (diag.help) {
-            contents.push({
-              value: `---\n**Hint**\n\n${diag.help}`,
-            });
-          }
+          contents.push(...buildDiagnosticHover(diag));
         }
 
         if (contents.length === 0) return null;

--- a/playground/src/shared/MonacoEditor.css
+++ b/playground/src/shared/MonacoEditor.css
@@ -1,90 +1,300 @@
-/* Scope decoration styles - using abbreviated names with better visibility */
+/* Scope decorations stay quiet in the editor, with color as a compact cue. */
+.scope-decoration-setup,
+.scope-decoration-plain,
+.scope-decoration-extern,
+.scope-decoration-vue,
+.scope-decoration-client,
+.scope-decoration-server,
+.scope-decoration-universal,
+.scope-decoration-vFor,
+.scope-decoration-vSlot,
+.scope-decoration-function,
+.scope-decoration-closure,
+.scope-decoration-block,
+.scope-decoration-event,
+.scope-decoration-callback,
+.scope-decoration-computed,
+.scope-decoration-watch,
+.scope-decoration-mod,
+.scope-decoration-default {
+  background: color-mix(in srgb, var(--scope-accent) var(--scope-bg-strength, 14%), transparent);
+  border-radius: 3px;
+  box-shadow:
+    inset 0 -1px 0 color-mix(in srgb, var(--scope-accent) 72%, transparent),
+    inset 0 0 0 1px color-mix(in srgb, var(--scope-accent) 14%, transparent);
+}
+
 .scope-decoration-setup {
-  background: rgba(34, 197, 94, 0.2);
-  border-left: 3px solid #22c55e;
+  --scope-accent: #2d6a35;
+  --scope-bg-strength: 16%;
 }
 
 .scope-decoration-plain {
-  background: rgba(251, 191, 36, 0.2);
-  border-left: 3px solid #fbbf24;
+  --scope-accent: #8b7040;
 }
 
 .scope-decoration-extern {
-  background: rgba(96, 165, 250, 0.2);
-  border-left: 3px solid #60a5fa;
+  --scope-accent: #4a6b8a;
 }
 
 .scope-decoration-vue {
-  background: rgba(66, 184, 131, 0.25);
-  border-left: 3px solid #42b883;
+  --scope-accent: #3a7a70;
+  --scope-bg-strength: 17%;
 }
 
 .scope-decoration-client {
-  background: rgba(249, 115, 22, 0.25);
-  border-left: 3px solid #f97316;
+  --scope-accent: #b85c38;
+  --scope-bg-strength: 15%;
 }
 
 .scope-decoration-server {
-  background: rgba(59, 130, 246, 0.25);
-  border-left: 3px solid #3b82f6;
+  --scope-accent: #3f6fae;
+  --scope-bg-strength: 15%;
 }
 
 .scope-decoration-universal {
-  background: rgba(139, 92, 246, 0.2);
-  border-left: 3px solid #8b5cf6;
+  --scope-accent: #6b5090;
 }
 
 .scope-decoration-vFor {
-  background: rgba(167, 139, 250, 0.2);
-  border-left: 3px solid #a78bfa;
+  --scope-accent: #7c5fb2;
 }
 
 .scope-decoration-vSlot {
-  background: rgba(244, 114, 182, 0.2);
-  border-left: 3px solid #f472b6;
+  --scope-accent: #a6537f;
 }
 
 .scope-decoration-function {
-  background: rgba(45, 212, 191, 0.15);
-  border-left: 3px solid #2dd4bf;
+  --scope-accent: #287d87;
 }
 
 .scope-decoration-closure {
-  background: rgba(251, 191, 36, 0.15);
-  border-left: 3px solid #fbbf24;
+  --scope-accent: #9a6a22;
 }
 
 .scope-decoration-block {
-  background: rgba(148, 163, 184, 0.1);
-  border-left: 3px solid #94a3b8;
+  --scope-accent: #6b7280;
+  --scope-bg-strength: 10%;
 }
 
 .scope-decoration-event {
-  background: rgba(244, 114, 182, 0.15);
-  border-left: 3px solid #f472b6;
+  --scope-accent: #a6537f;
 }
 
-.scope-decoration-callback {
-  background: rgba(251, 146, 60, 0.15);
-  border-left: 3px solid #fb923c;
-}
-
+.scope-decoration-callback,
 .scope-decoration-computed {
-  background: rgba(251, 146, 60, 0.2);
-  border-left: 3px solid #fb923c;
+  --scope-accent: #b85c38;
 }
 
 .scope-decoration-watch {
-  background: rgba(99, 102, 241, 0.2);
-  border-left: 3px solid #6366f1;
+  --scope-accent: #5d6cc1;
 }
 
-.scope-decoration-mod {
-  background: rgba(156, 163, 175, 0.1);
-  border-left: 3px solid #9ca3af;
-}
-
+.scope-decoration-mod,
 .scope-decoration-default {
-  background: rgba(156, 163, 175, 0.1);
-  border-left: 3px solid #6b7280;
+  --scope-accent: #6b7280;
+  --scope-bg-strength: 10%;
+}
+
+body[data-theme="dark"] .scope-decoration-setup {
+  --scope-accent: #a8b5a0;
+}
+
+body[data-theme="dark"] .scope-decoration-plain,
+body[data-theme="dark"] .scope-decoration-closure {
+  --scope-accent: #d4ba92;
+}
+
+body[data-theme="dark"] .scope-decoration-extern,
+body[data-theme="dark"] .scope-decoration-server {
+  --scope-accent: #8aabca;
+}
+
+body[data-theme="dark"] .scope-decoration-vue,
+body[data-theme="dark"] .scope-decoration-function {
+  --scope-accent: #80bdb0;
+}
+
+body[data-theme="dark"] .scope-decoration-client,
+body[data-theme="dark"] .scope-decoration-callback,
+body[data-theme="dark"] .scope-decoration-computed {
+  --scope-accent: #d8a082;
+}
+
+body[data-theme="dark"] .scope-decoration-universal,
+body[data-theme="dark"] .scope-decoration-vFor,
+body[data-theme="dark"] .scope-decoration-watch {
+  --scope-accent: #b8a0d0;
+}
+
+body[data-theme="dark"] .scope-decoration-vSlot,
+body[data-theme="dark"] .scope-decoration-event {
+  --scope-accent: #d79abd;
+}
+
+:root {
+  --editor-hover-bg: #f8f6ef;
+  --editor-hover-border: rgba(74, 107, 138, 0.32);
+  --editor-hover-shadow: rgba(18, 18, 18, 0.18);
+  --editor-hover-soft-shadow: rgba(74, 107, 138, 0.1);
+  --editor-hover-code-bg: #eeebe2;
+  --editor-hover-rule: rgba(18, 18, 18, 0.12);
+  --editor-hover-chip-bg: #e7f0ed;
+  --editor-hover-chip-border: #b6d0ca;
+  --editor-hover-chip-text: #245f57;
+  --editor-hover-link: #315f82;
+}
+
+body[data-theme="dark"] {
+  --editor-hover-bg: #18191c;
+  --editor-hover-border: rgba(138, 171, 202, 0.34);
+  --editor-hover-shadow: rgba(0, 0, 0, 0.42);
+  --editor-hover-soft-shadow: rgba(128, 189, 176, 0.08);
+  --editor-hover-code-bg: #22252a;
+  --editor-hover-rule: rgba(230, 226, 214, 0.14);
+  --editor-hover-chip-bg: #1f3432;
+  --editor-hover-chip-border: #426760;
+  --editor-hover-chip-text: #b8ded5;
+  --editor-hover-link: #a5c8e3;
+}
+
+.monaco-hover {
+  width: min(440px, calc(100vw - 32px)) !important;
+  max-width: min(440px, calc(100vw - 32px)) !important;
+  border: 1px solid var(--editor-hover-border) !important;
+  border-radius: 8px !important;
+  background: var(--editor-hover-bg) !important;
+  box-shadow:
+    0 18px 46px var(--editor-hover-shadow),
+    0 0 0 1px var(--editor-hover-soft-shadow) !important;
+  overflow: hidden !important;
+}
+
+.monaco-hover::before {
+  content: "";
+  display: block;
+  height: 2px;
+  background: linear-gradient(
+    90deg,
+    color-mix(in srgb, var(--color-info) 86%, transparent),
+    color-mix(in srgb, var(--color-teal) 82%, transparent),
+    color-mix(in srgb, var(--color-notice) 76%, transparent)
+  );
+}
+
+.monaco-hover .monaco-hover-content,
+.monaco-hover .hover-contents {
+  color: var(--text-primary) !important;
+  font-family: var(--font-sans);
+  font-size: 12px !important;
+  line-height: 1.55 !important;
+  max-width: 100% !important;
+}
+
+.monaco-hover .monaco-hover-content {
+  padding: 10px 12px 12px !important;
+  width: auto !important;
+}
+
+.monaco-hover .markdown-hover {
+  font-size: 12px !important;
+  overflow-wrap: anywhere;
+  white-space: normal;
+}
+
+.monaco-hover .markdown-hover .hover-contents:not(:first-child) {
+  margin-top: 10px;
+  padding-top: 10px;
+  border-top: 1px solid var(--editor-hover-rule);
+}
+
+.monaco-hover .markdown-hover p,
+.monaco-hover .markdown-hover .rendered-markdown p {
+  margin: 0 0 8px;
+}
+
+.monaco-hover .markdown-hover p:last-child,
+.monaco-hover .markdown-hover .rendered-markdown p:last-child {
+  margin-bottom: 0;
+}
+
+.monaco-hover .markdown-hover hr {
+  height: 1px;
+  margin: 10px -2px;
+  border: 0;
+  background: var(--editor-hover-rule);
+}
+
+.monaco-hover .markdown-hover strong {
+  color: var(--text-primary);
+  font-weight: 700;
+}
+
+.monaco-hover .markdown-hover em {
+  color: var(--text-secondary);
+  font-style: normal;
+}
+
+.monaco-hover .markdown-hover ul {
+  margin: 7px 0 0 16px;
+  padding: 0;
+}
+
+.monaco-hover .markdown-hover li {
+  margin: 3px 0;
+}
+
+.monaco-hover .markdown-hover code {
+  padding: 1px 5px;
+  border: 1px solid var(--editor-hover-chip-border);
+  border-radius: 5px;
+  background: var(--editor-hover-chip-bg);
+  color: var(--editor-hover-chip-text);
+  font-family: var(--font-mono);
+  font-size: 11px;
+}
+
+.monaco-hover .markdown-hover pre {
+  margin: 8px 0 10px;
+  padding: 9px 10px;
+  border: 1px solid color-mix(in srgb, var(--color-info) 24%, transparent);
+  border-radius: 7px;
+  background: var(--editor-hover-code-bg);
+}
+
+.monaco-hover .markdown-hover .rendered-markdown div[data-code] {
+  margin: 8px 0 10px;
+  padding: 9px 10px;
+  border: 1px solid color-mix(in srgb, var(--color-info) 24%, transparent);
+  border-radius: 7px;
+  background: var(--editor-hover-code-bg);
+}
+
+.monaco-hover .markdown-hover pre code {
+  padding: 0;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  color: var(--text-primary);
+  font-size: 11.5px;
+  line-height: 1.5;
+}
+
+.monaco-hover .markdown-hover .monaco-tokenized-source {
+  font-size: 11.5px !important;
+  line-height: 1.45 !important;
+}
+
+.monaco-hover .markdown-hover .monaco-tokenized-source span {
+  color: var(--text-primary) !important;
+}
+
+.monaco-hover .markdown-hover a {
+  color: var(--editor-hover-link);
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.monaco-hover .markdown-hover a:hover {
+  text-decoration: underline;
 }

--- a/playground/src/shared/MonacoEditor.vue
+++ b/playground/src/shared/MonacoEditor.vue
@@ -7,6 +7,8 @@ import {
   getScopeDecorationClass,
   offsetToPosition,
   getOverviewRulerColor,
+  getScopeDecorationHoverMessage,
+  type ScopeDecorationInfo,
 } from "./scopeDecorations";
 
 export interface Diagnostic {
@@ -18,12 +20,7 @@ export interface Diagnostic {
   severity: "error" | "warning" | "info";
 }
 
-export interface ScopeDecoration {
-  start: number; // Character offset
-  end: number; // Character offset
-  kind: string; // Scope kind for styling
-  kindStr?: string; // Human-readable description
-}
+export interface ScopeDecoration extends ScopeDecorationInfo {}
 
 const props = defineProps<{
   modelValue: string;
@@ -58,7 +55,7 @@ function applyScopeDecorations(scopes: ScopeDecoration[] | undefined) {
   const newDecorations: monaco.editor.IModelDeltaDecoration[] = scopes.map((scope) => {
     const startPos = offsetToPosition(model, scope.start);
     const endPos = offsetToPosition(model, scope.end);
-    const className = getScopeDecorationClass(scope.kindStr || scope.kind);
+    const className = getScopeDecorationClass(scope.kind);
 
     return {
       range: new monaco.Range(
@@ -69,7 +66,7 @@ function applyScopeDecorations(scopes: ScopeDecoration[] | undefined) {
       ),
       options: {
         className,
-        hoverMessage: { value: `**Scope:** ${scope.kindStr || scope.kind}` },
+        hoverMessage: getScopeDecorationHoverMessage(scope),
         isWholeLine: false,
         overviewRuler: {
           color: getOverviewRulerColor(scope.kind),

--- a/playground/src/shared/scopeDecorations.ts
+++ b/playground/src/shared/scopeDecorations.ts
@@ -1,5 +1,14 @@
 import * as monaco from "monaco-editor";
 
+export interface ScopeDecorationInfo {
+  start: number;
+  end: number;
+  kind: string;
+  kindStr?: string;
+  depth?: number;
+  bindings?: string[];
+}
+
 // Scope kind to CSS class mapping (O(1) lookup for exact matches)
 const SCOPE_CLASS_MAP: Record<string, string> = {
   setup: "scope-decoration-setup",
@@ -32,6 +41,162 @@ export function getScopeDecorationClass(kind: string): string {
   if (kindLower.includes("computed")) return "scope-decoration-computed";
   if (kindLower.includes("watch")) return "scope-decoration-watch";
   return "scope-decoration-default";
+}
+
+interface ScopeHoverCopy {
+  title: string;
+  description: string;
+  notes: string[];
+}
+
+const SCOPE_HOVER_COPY: Record<string, ScopeHoverCopy> = {
+  setup: {
+    title: "Script setup scope",
+    description: "Top-level bindings declared in `<script setup>` and exposed to the template.",
+    notes: [
+      "Refs are available directly in templates.",
+      "Top-level imports and constants are part of this scope.",
+    ],
+  },
+  plain: {
+    title: "Classic script scope",
+    description: "Bindings from a regular `<script>` block.",
+    notes: [
+      "Useful for module-level code and explicit component options.",
+      "Template exposure depends on returned options and setup behavior.",
+    ],
+  },
+  extern: {
+    title: "External module scope",
+    description: "Symbols resolved from imported modules.",
+    notes: ["Imported bindings are read-only from the template analysis point of view."],
+  },
+  extmod: {
+    title: "External module scope",
+    description: "Symbols resolved from imported modules.",
+    notes: ["Imported bindings are read-only from the template analysis point of view."],
+  },
+  vue: {
+    title: "Vue template global scope",
+    description: "Built-in Vue template globals such as `$slots`, `$attrs`, and `$emit`.",
+    notes: ["These symbols are provided by Vue at render time."],
+  },
+  universal: {
+    title: "Universal runtime scope",
+    description: "Globals that are safe to reference in both client and server contexts.",
+    notes: ["Prefer this scope for code that must behave consistently during SSR and hydration."],
+  },
+  server: {
+    title: "Server runtime scope",
+    description: "Bindings that are only valid while rendering on the server.",
+    notes: ["Keep browser-only APIs out of this scope."],
+  },
+  client: {
+    title: "Client runtime scope",
+    description: "Bindings that are only valid in the browser runtime.",
+    notes: ["Use this for DOM, window, and browser lifecycle dependent code."],
+  },
+  vfor: {
+    title: "v-for iteration scope",
+    description: "Loop aliases and index bindings introduced by `v-for`.",
+    notes: ["Aliases shadow outer bindings inside the repeated region."],
+  },
+  "v-for": {
+    title: "v-for iteration scope",
+    description: "Loop aliases and index bindings introduced by `v-for`.",
+    notes: ["Aliases shadow outer bindings inside the repeated region."],
+  },
+  vslot: {
+    title: "v-slot scope",
+    description: "Slot props introduced by `v-slot` or shorthand slot syntax.",
+    notes: ["Slot props are local to the slot template region."],
+  },
+  "v-slot": {
+    title: "v-slot scope",
+    description: "Slot props introduced by `v-slot` or shorthand slot syntax.",
+    notes: ["Slot props are local to the slot template region."],
+  },
+  function: {
+    title: "Function scope",
+    description: "Bindings introduced by a function body or function parameters.",
+    notes: ["Local bindings shadow parent scopes until the function exits."],
+  },
+  arrowfunction: {
+    title: "Arrow function scope",
+    description: "Bindings introduced by an arrow function body or parameters.",
+    notes: ["Useful for computed callbacks, watchers, and inline handlers."],
+  },
+  block: {
+    title: "Block scope",
+    description: "Bindings introduced by a lexical block.",
+    notes: ["`let` and `const` bindings stay inside this block."],
+  },
+  closure: {
+    title: "Closure scope",
+    description: "A nested function scope that captures values from parent scopes.",
+    notes: ["Captured values remain visible while the closure is alive."],
+  },
+  event: {
+    title: "Event handler scope",
+    description: "Temporary scope for inline event handler expressions.",
+    notes: ["Handler locals and `$event` are resolved here before parent scopes."],
+  },
+  callback: {
+    title: "Callback scope",
+    description: "Scope created for callback parameters and callback-local bindings.",
+    notes: ["Common in watchers, computed callbacks, and array helpers."],
+  },
+};
+
+function getScopeHoverCopy(kind: string): ScopeHoverCopy {
+  const kindLower = kind.toLowerCase();
+  const exact = SCOPE_HOVER_COPY[kindLower];
+  if (exact) return exact;
+  if (kindLower.includes("clientonly") || kindLower.includes("mounted"))
+    return SCOPE_HOVER_COPY.client;
+  if (kindLower.includes("server")) return SCOPE_HOVER_COPY.server;
+  if (kindLower.includes("computed") || kindLower.includes("watch"))
+    return SCOPE_HOVER_COPY.callback;
+  return {
+    title: "Semantic scope",
+    description: "Region produced by Croquis semantic scope analysis.",
+    notes: ["Use this region to understand which bindings are visible at the cursor."],
+  };
+}
+
+function inlineCode(value: string): string {
+  return `\`${value.replace(/`/g, "\\`")}\``;
+}
+
+export function getScopeDecorationHoverMessage(scope: ScopeDecorationInfo): monaco.IMarkdownString {
+  const kindLabel = scope.kindStr || scope.kind;
+  const copy = getScopeHoverCopy(scope.kind || kindLabel);
+  const bindings = scope.bindings ?? [];
+  const metadata = [
+    `kind: ${kindLabel}`,
+    `range: ${scope.start}-${scope.end}`,
+    scope.depth == null ? null : `depth: ${scope.depth}`,
+    `bindings: ${bindings.length}`,
+  ]
+    .filter(Boolean)
+    .join("\n");
+
+  const sections = [
+    `**${copy.title}**`,
+    `_Croquis scope analysis_`,
+    copy.description,
+    `\`\`\`text\n${metadata}\n\`\`\``,
+  ];
+
+  if (bindings.length > 0) {
+    const visibleBindings = bindings.slice(0, 6).map(inlineCode).join(", ");
+    const suffix = bindings.length > 6 ? `, +${bindings.length - 6} more` : "";
+    sections.push(`**Bindings**\n\n${visibleBindings}${suffix}`);
+  }
+
+  sections.push(`**Note**\n- ${copy.notes[0]}`);
+
+  return { value: sections.join("\n\n") };
 }
 
 export function offsetToPosition(


### PR DESCRIPTION
## Summary

- Enrich Vize LSP hover Markdown for template bindings, directives, script bindings, Vue APIs, macros, CSS features, and Corsa TypeScript quick info.
- Polish playground Monaco hover styling with restrained card treatment, better wrapping, scope hover details, and theme-aware colors.
- Improve hover readability in light and dark themes while preserving editor-client compatibility for Zed, VS Code, and Neovim.

## Validation

- `cargo test -p vize_maestro hover`
- `corepack pnpm --filter vize-playground check`
- `git diff --check`
- In-app browser visual checks for Patina and Croquis hover states, including light/dark contrast spot checks.