### PR TITLE
feat: add opt-in Vue 2.7 and Nuxt 2 support

### DIFF
--- a/crates/vize/src/commands/check/runner.rs
+++ b/crates/vize/src/commands/check/runner.rs
@@ -54,13 +54,15 @@ pub(crate) fn run_direct(args: &CheckArgs) {
 
     let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
     let loaded_config = if args.no_config {
-        crate::config::LoadedConfig {
+        crate::config::LoadedConfigWithFeatures {
             config: crate::config::VizeConfig::default(),
             source_path: None,
+            features: crate::config::ConfigFeatureFlags::default(),
         }
     } else {
-        crate::config::load_config_with_source(args.config.as_deref())
+        crate::config::load_config_with_features_and_source(args.config.as_deref())
     };
+    let legacy_vue2 = loaded_config.features.type_checker_legacy_vue2;
     let config = loaded_config.config;
     let config_dir = loaded_config
         .source_path
@@ -134,6 +136,9 @@ pub(crate) fn run_direct(args: &CheckArgs) {
             std::process::exit(1);
         }
     };
+    if legacy_vue2 {
+        checker.enable_legacy_vue2();
+    }
     checker.set_virtual_ts_checks(
         config.type_checker.check_props && !args.no_check_props,
         config.type_checker.check_template_bindings && !args.no_check_template_bindings,

--- a/crates/vize_atelier_sfc/src/croquis.rs
+++ b/crates/vize_atelier_sfc/src/croquis.rs
@@ -108,10 +108,31 @@ pub fn analyze_sfc_descriptor_with_context(
     template_ast: Option<&RootNode<'_>>,
     options: SfcCroquisOptions,
 ) -> SfcCroquisAnalysis {
+    analyze_sfc_descriptor_with_context_impl(descriptor, template_ast, options, false)
+}
+
+/// Analyze an SFC descriptor with Vue 2.7 / Nuxt 2 Options API compatibility enabled.
+pub fn analyze_sfc_descriptor_with_context_legacy_vue2(
+    descriptor: &SfcDescriptor<'_>,
+    template_ast: Option<&RootNode<'_>>,
+    options: SfcCroquisOptions,
+) -> SfcCroquisAnalysis {
+    analyze_sfc_descriptor_with_context_impl(descriptor, template_ast, options, true)
+}
+
+fn analyze_sfc_descriptor_with_context_impl(
+    descriptor: &SfcDescriptor<'_>,
+    template_ast: Option<&RootNode<'_>>,
+    options: SfcCroquisOptions,
+    legacy_vue2: bool,
+) -> SfcCroquisAnalysis {
     let script_analyzed = options.analyzer_options.analyze_script
         && (descriptor.script.is_some() || descriptor.script_setup.is_some());
-    let summary = analyze_scripts(descriptor, options);
+    let summary = analyze_scripts(descriptor, options, legacy_vue2);
     let mut analyzer = Analyzer::with_summary(options.analyzer_options, summary, script_analyzed);
+    if legacy_vue2 {
+        analyzer = analyzer.with_legacy_vue2();
+    }
 
     if let Some(root) = template_ast {
         profile!(
@@ -150,7 +171,11 @@ pub fn script_content_for_descriptor(
     }
 }
 
-fn analyze_scripts(descriptor: &SfcDescriptor<'_>, options: SfcCroquisOptions) -> Croquis {
+fn analyze_scripts(
+    descriptor: &SfcDescriptor<'_>,
+    options: SfcCroquisOptions,
+    legacy_vue2: bool,
+) -> Croquis {
     if !options.analyzer_options.analyze_script {
         return Croquis::new();
     }
@@ -158,6 +183,9 @@ fn analyze_scripts(descriptor: &SfcDescriptor<'_>, options: SfcCroquisOptions) -
     match (descriptor.script.as_ref(), descriptor.script_setup.as_ref()) {
         (Some(script), Some(script_setup)) if options.merge_scripts => {
             let mut plain_analyzer = Analyzer::with_options(options.analyzer_options);
+            if legacy_vue2 {
+                plain_analyzer = plain_analyzer.with_legacy_vue2();
+            }
             profile!(
                 "atelier.sfc.croquis.script_plain",
                 plain_analyzer.analyze_script_plain(script.content.as_ref())
@@ -165,6 +193,9 @@ fn analyze_scripts(descriptor: &SfcDescriptor<'_>, options: SfcCroquisOptions) -
             let plain = plain_analyzer.finish();
 
             let mut setup_analyzer = Analyzer::with_options(options.analyzer_options);
+            if legacy_vue2 {
+                setup_analyzer = setup_analyzer.with_legacy_vue2();
+            }
             let generic = script_setup
                 .attrs
                 .get("generic")
@@ -183,6 +214,9 @@ fn analyze_scripts(descriptor: &SfcDescriptor<'_>, options: SfcCroquisOptions) -
         }
         (_, Some(script_setup)) => {
             let mut analyzer = Analyzer::with_options(options.analyzer_options);
+            if legacy_vue2 {
+                analyzer = analyzer.with_legacy_vue2();
+            }
             let generic = script_setup
                 .attrs
                 .get("generic")
@@ -195,6 +229,9 @@ fn analyze_scripts(descriptor: &SfcDescriptor<'_>, options: SfcCroquisOptions) -
         }
         (Some(script), None) => {
             let mut analyzer = Analyzer::with_options(options.analyzer_options);
+            if legacy_vue2 {
+                analyzer = analyzer.with_legacy_vue2();
+            }
             profile!(
                 "atelier.sfc.croquis.script_plain",
                 analyzer.analyze_script_plain(script.content.as_ref())

--- a/crates/vize_canon/src/batch/type_checker.rs
+++ b/crates/vize_canon/src/batch/type_checker.rs
@@ -142,6 +142,11 @@ impl BatchTypeChecker {
         })
     }
 
+    /// Enable Vue 2.7 / Nuxt 2 Options API compatibility for generated virtual files.
+    pub fn enable_legacy_vue2(&mut self) {
+        self.project.set_legacy_vue2(true);
+    }
+
     /// Configure which virtual TypeScript checks are generated for Vue files.
     pub fn set_virtual_ts_checks(
         &mut self,

--- a/crates/vize_canon/src/batch/virtual_project.rs
+++ b/crates/vize_canon/src/batch/virtual_project.rs
@@ -17,7 +17,8 @@ use super::source_map::{CompositeSourceMap, SfcBlockRange, SfcSourceMap};
 use super::{Diagnostic, SfcBlockType};
 use crate::script_parse::collect_script_parse_diagnostics;
 use crate::virtual_ts::{
-    VirtualTsCheckOptions, VirtualTsOptions, generate_virtual_ts_with_offsets_and_checks,
+    VirtualTsCheckOptions, VirtualTsGenerationOptions, VirtualTsOptions,
+    generate_virtual_ts_with_offsets_and_checks,
 };
 use oxc_span::SourceType;
 use rayon::prelude::*;
@@ -25,7 +26,10 @@ use serde_json::{Map, Value};
 use vize_atelier_core::parser::parse;
 use vize_atelier_sfc::{
     SfcDescriptor, SfcParseOptions,
-    croquis::{SfcCroquisOptions, analyze_sfc_descriptor_with_context},
+    croquis::{
+        SfcCroquisOptions, analyze_sfc_descriptor_with_context,
+        analyze_sfc_descriptor_with_context_legacy_vue2,
+    },
     parse_sfc,
 };
 use vize_carton::{
@@ -88,6 +92,9 @@ pub struct VirtualProject {
     /// Internal check generation settings applied to every Vue file.
     virtual_ts_check_options: VirtualTsCheckOptions,
 
+    /// Enable Vue 2.7 / Nuxt 2 Options API compatibility for virtual files.
+    legacy_vue2: bool,
+
     /// Virtual files keyed by materialized path.
     virtual_files: FxHashMap<PathBuf, VirtualFile>,
 
@@ -115,6 +122,7 @@ impl VirtualProject {
             tsconfig_path: None,
             virtual_ts_options: VirtualTsOptions::default(),
             virtual_ts_check_options: VirtualTsCheckOptions::default(),
+            legacy_vue2: false,
             virtual_files: FxHashMap::default(),
             diagnostics: Vec::new(),
             rewriter: ImportRewriter::new(),
@@ -133,6 +141,10 @@ impl VirtualProject {
 
     pub(crate) fn set_virtual_ts_check_options(&mut self, options: VirtualTsCheckOptions) {
         self.virtual_ts_check_options = options;
+    }
+
+    pub(crate) fn set_legacy_vue2(&mut self, enabled: bool) {
+        self.legacy_vue2 = enabled;
     }
 
     /// Get the project root.
@@ -156,11 +168,14 @@ impl VirtualProject {
         let registered = build_registered_file(
             path,
             content,
-            &self.project_root,
-            &self.virtual_root,
-            &self.virtual_ts_options,
-            self.virtual_ts_check_options,
-            &self.rewriter,
+            VirtualBuildContext {
+                project_root: &self.project_root,
+                virtual_root: &self.virtual_root,
+                virtual_ts_options: &self.virtual_ts_options,
+                virtual_ts_check_options: self.virtual_ts_check_options,
+                legacy_vue2: self.legacy_vue2,
+                rewriter: &self.rewriter,
+            },
         )?;
         self.absorb_registered_file(registered);
         Ok(())
@@ -187,25 +202,20 @@ impl VirtualProject {
             return Ok(());
         }
 
-        let project_root = self.project_root.as_path();
-        let virtual_root = self.virtual_root.as_path();
-        let virtual_ts_options = &self.virtual_ts_options;
-        let virtual_ts_check_options = self.virtual_ts_check_options;
-        let rewriter = &self.rewriter;
+        let build_context = VirtualBuildContext {
+            project_root: self.project_root.as_path(),
+            virtual_root: self.virtual_root.as_path(),
+            virtual_ts_options: &self.virtual_ts_options,
+            virtual_ts_check_options: self.virtual_ts_check_options,
+            legacy_vue2: self.legacy_vue2,
+            rewriter: &self.rewriter,
+        };
 
         let registered: Result<Vec<RegisteredFile>, CorsaError> = valid_paths
             .par_iter()
             .map(|&path| {
                 let content = profile!("canon.file.read", std::fs::read_to_string(path))?;
-                build_registered_file(
-                    path,
-                    &content,
-                    project_root,
-                    virtual_root,
-                    virtual_ts_options,
-                    virtual_ts_check_options,
-                    rewriter,
-                )
+                build_registered_file(path, &content, build_context)
             })
             .collect();
 
@@ -221,11 +231,14 @@ impl VirtualProject {
         let registered = build_vue_registered_file(
             path,
             content,
-            &self.project_root,
-            &self.virtual_root,
-            &self.virtual_ts_options,
-            self.virtual_ts_check_options,
-            &self.rewriter,
+            VirtualBuildContext {
+                project_root: &self.project_root,
+                virtual_root: &self.virtual_root,
+                virtual_ts_options: &self.virtual_ts_options,
+                virtual_ts_check_options: self.virtual_ts_check_options,
+                legacy_vue2: self.legacy_vue2,
+                rewriter: &self.rewriter,
+            },
         )?;
         self.absorb_registered_file(registered);
         Ok(())
@@ -651,6 +664,7 @@ fn generate_vue_virtual_ts(
     descriptor: &SfcDescriptor,
     options: &VirtualTsOptions,
     check_options: VirtualTsCheckOptions,
+    legacy_vue2: bool,
 ) -> CorsaResult<GeneratedVueFile> {
     let allocator = Bump::new();
     let mut diagnostics = Vec::new();
@@ -725,13 +739,19 @@ fn generate_vue_virtual_ts(
         });
     }
 
+    let croquis_options = SfcCroquisOptions::full();
+
     let analysis = profile!(
         "canon.croquis.analyze_sfc",
-        analyze_sfc_descriptor_with_context(
-            descriptor,
-            template_ast.as_ref(),
-            SfcCroquisOptions::full()
-        )
+        if legacy_vue2 {
+            analyze_sfc_descriptor_with_context_legacy_vue2(
+                descriptor,
+                template_ast.as_ref(),
+                croquis_options,
+            )
+        } else {
+            analyze_sfc_descriptor_with_context(descriptor, template_ast.as_ref(), croquis_options)
+        }
     );
 
     let output = profile!(
@@ -743,7 +763,10 @@ fn generate_vue_virtual_ts(
             analysis.script_offset,
             template_offset,
             options,
-            check_options,
+            VirtualTsGenerationOptions {
+                check_options,
+                legacy_vue2,
+            },
         )
     );
 
@@ -850,25 +873,23 @@ struct RegisteredFile {
     diagnostics: Vec<Diagnostic>,
 }
 
+#[derive(Clone, Copy)]
+struct VirtualBuildContext<'a> {
+    project_root: &'a Path,
+    virtual_root: &'a Path,
+    virtual_ts_options: &'a VirtualTsOptions,
+    virtual_ts_check_options: VirtualTsCheckOptions,
+    legacy_vue2: bool,
+    rewriter: &'a ImportRewriter,
+}
+
 fn build_registered_file(
     path: &Path,
     content: &str,
-    project_root: &Path,
-    virtual_root: &Path,
-    virtual_ts_options: &VirtualTsOptions,
-    virtual_ts_check_options: VirtualTsCheckOptions,
-    rewriter: &ImportRewriter,
+    context: VirtualBuildContext<'_>,
 ) -> CorsaResult<RegisteredFile> {
     if path.extension().and_then(|extension| extension.to_str()) == Some("vue") {
-        return build_vue_registered_file(
-            path,
-            content,
-            project_root,
-            virtual_root,
-            virtual_ts_options,
-            virtual_ts_check_options,
-            rewriter,
-        );
+        return build_vue_registered_file(path, content, context);
     }
 
     if path
@@ -880,9 +901,9 @@ fn build_registered_file(
             path,
             content,
             SourceType::ts(),
-            project_root,
-            virtual_root,
-            rewriter,
+            context.project_root,
+            context.virtual_root,
+            context.rewriter,
         );
     }
 
@@ -893,20 +914,16 @@ fn build_registered_file(
         path,
         content,
         source_type,
-        project_root,
-        virtual_root,
-        rewriter,
+        context.project_root,
+        context.virtual_root,
+        context.rewriter,
     )
 }
 
 fn build_vue_registered_file(
     path: &Path,
     content: &str,
-    project_root: &Path,
-    virtual_root: &Path,
-    virtual_ts_options: &VirtualTsOptions,
-    virtual_ts_check_options: VirtualTsCheckOptions,
-    rewriter: &ImportRewriter,
+    context: VirtualBuildContext<'_>,
 ) -> CorsaResult<RegisteredFile> {
     let descriptor = profile!(
         "canon.sfc.parse",
@@ -920,7 +937,8 @@ fn build_vue_registered_file(
         .map_err(|error| CorsaError::SfcParse(error.message.to_compact_string()))
     )?;
 
-    let mut effective_options = virtual_ts_options_for_descriptor(virtual_ts_options, &descriptor);
+    let mut effective_options =
+        virtual_ts_options_for_descriptor(context.virtual_ts_options, &descriptor);
     effective_options.auto_import_stubs.clear();
     let generated = profile!(
         "canon.vue.virtual_ts",
@@ -929,7 +947,8 @@ fn build_vue_registered_file(
             content,
             &descriptor,
             &effective_options,
-            virtual_ts_check_options,
+            context.virtual_ts_check_options,
+            context.legacy_vue2,
         )
     )?;
     let GeneratedVueFile {
@@ -939,13 +958,13 @@ fn build_vue_registered_file(
     } = generated;
     let rewritten = profile!(
         "canon.import.rewrite.vue",
-        rewriter.rewrite(&code, SourceType::ts())
+        context.rewriter.rewrite(&code, SourceType::ts())
     );
     let source_map = CompositeSourceMap::new_vue(
         SfcSourceMap::new(mappings, collect_sfc_block_ranges(&descriptor)),
         rewritten.source_map,
     );
-    let virtual_path = virtual_vue_path(project_root, virtual_root, path)?;
+    let virtual_path = virtual_vue_path(context.project_root, context.virtual_root, path)?;
 
     Ok(RegisteredFile {
         file: VirtualFile {

--- a/crates/vize_canon/src/lib.rs
+++ b/crates/vize_canon/src/lib.rs
@@ -87,7 +87,7 @@ pub use intelligence::{
 };
 pub use sfc_typecheck::{
     SfcRelatedLocation, SfcTypeCheckOptions, SfcTypeCheckResult, SfcTypeDiagnostic,
-    SfcTypeSeverity, type_check_sfc,
+    SfcTypeSeverity, type_check_sfc, type_check_sfc_with_legacy_vue2,
 };
 pub use source_map::{
     Mapping, MappingFlags, MappingKind, Position, SourceMap, Span, offset_to_position,

--- a/crates/vize_canon/src/sfc_typecheck.rs
+++ b/crates/vize_canon/src/sfc_typecheck.rs
@@ -46,12 +46,13 @@ mod virtual_ts;
 pub use analysis::{
     SfcRelatedLocation, SfcTypeCheckOptions, SfcTypeCheckResult, SfcTypeDiagnostic, SfcTypeSeverity,
 };
-pub use runner::type_check_sfc;
+pub use runner::{type_check_sfc, type_check_sfc_with_legacy_vue2};
 
 #[cfg(test)]
 mod tests {
     use super::{
-        SfcTypeCheckOptions, SfcTypeCheckResult, SfcTypeDiagnostic, SfcTypeSeverity, type_check_sfc,
+        SfcTypeCheckOptions, SfcTypeCheckResult, SfcTypeDiagnostic, SfcTypeSeverity,
+        type_check_sfc, type_check_sfc_with_legacy_vue2,
     };
 
     fn stable_snapshot_result(mut result: SfcTypeCheckResult) -> SfcTypeCheckResult {
@@ -320,6 +321,55 @@ export const buttonId =
                 .any(|d| d.code.as_deref() == Some("undefined-binding")),
             "unexpected diagnostics: {:#?}",
             result.diagnostics
+        );
+    }
+
+    #[test]
+    fn test_type_check_legacy_vue2_options_api_opt_in() {
+        let source = r#"<script lang="ts">
+export default {
+  props: ['message', 'user-id'],
+  asyncData() {
+    return { pageTitle: 'Hello' }
+  },
+  data() {
+    return { count: 1 }
+  },
+  computed: {
+    doubled() {
+      return this.count * 2
+    }
+  },
+  methods: {
+    save() {}
+  }
+}
+</script>
+<template>
+  <div>
+    {{ message }} {{ userId }} {{ pageTitle }} {{ count }} {{ doubled }}
+    <button @click="save">{{ $route.path }}</button>
+  </div>
+</template>"#;
+
+        let default_result = type_check_sfc(source, &SfcTypeCheckOptions::new("Legacy.vue"));
+        assert!(
+            default_result
+                .diagnostics
+                .iter()
+                .any(|d| d.code.as_deref() == Some("undefined-binding")),
+            "expected default mode to keep Vue 2 Options API bindings disabled"
+        );
+
+        let options = SfcTypeCheckOptions::new("Legacy.vue");
+        let legacy_result = type_check_sfc_with_legacy_vue2(source, &options);
+        assert!(
+            !legacy_result
+                .diagnostics
+                .iter()
+                .any(|d| d.code.as_deref() == Some("undefined-binding")),
+            "unexpected diagnostics: {:#?}",
+            legacy_result.diagnostics
         );
     }
 

--- a/crates/vize_canon/src/sfc_typecheck/runner.rs
+++ b/crates/vize_canon/src/sfc_typecheck/runner.rs
@@ -7,6 +7,7 @@ use vize_carton::Bump;
 use vize_carton::cstr;
 
 use crate::script_parse::collect_script_parse_diagnostics;
+use crate::virtual_ts::generate_virtual_ts_with_offsets_legacy_vue2;
 
 use super::{
     analysis::{SfcTypeCheckOptions, SfcTypeCheckResult, SfcTypeDiagnostic, SfcTypeSeverity},
@@ -27,10 +28,29 @@ use super::{
 ///
 /// For full TypeScript type checking with Corsa, use `TypeCheckService`.
 pub fn type_check_sfc(source: &str, options: &SfcTypeCheckOptions) -> SfcTypeCheckResult {
+    type_check_sfc_impl(source, options, false)
+}
+
+/// Perform type checking on a Vue SFC with Vue 2.7 / Nuxt 2 compatibility enabled.
+pub fn type_check_sfc_with_legacy_vue2(
+    source: &str,
+    options: &SfcTypeCheckOptions,
+) -> SfcTypeCheckResult {
+    type_check_sfc_impl(source, options, true)
+}
+
+fn type_check_sfc_impl(
+    source: &str,
+    options: &SfcTypeCheckOptions,
+    legacy_vue2: bool,
+) -> SfcTypeCheckResult {
     use vize_atelier_core::parser::parse;
     use vize_atelier_sfc::{
         SfcParseOptions,
-        croquis::{SfcCroquisOptions, analyze_sfc_descriptor_with_context},
+        croquis::{
+            SfcCroquisOptions, analyze_sfc_descriptor_with_context,
+            analyze_sfc_descriptor_with_context_legacy_vue2,
+        },
         parse_sfc,
     };
 
@@ -119,11 +139,17 @@ pub fn type_check_sfc(source: &str, options: &SfcTypeCheckOptions) -> SfcTypeChe
         (0, None)
     };
 
-    let analysis = analyze_sfc_descriptor_with_context(
-        &descriptor,
-        template_ast.as_ref(),
-        SfcCroquisOptions::full(),
-    );
+    let croquis_options = SfcCroquisOptions::full();
+
+    let analysis = if legacy_vue2 {
+        analyze_sfc_descriptor_with_context_legacy_vue2(
+            &descriptor,
+            template_ast.as_ref(),
+            croquis_options,
+        )
+    } else {
+        analyze_sfc_descriptor_with_context(&descriptor, template_ast.as_ref(), croquis_options)
+    };
     let script_content = analysis.script_content;
     let script_offset = analysis.script_offset;
     let summary = analysis.croquis;
@@ -165,13 +191,25 @@ pub fn type_check_sfc(source: &str, options: &SfcTypeCheckOptions) -> SfcTypeChe
 
     // Generate virtual TypeScript with scope information if requested
     if options.include_virtual_ts && !has_template_parse_errors && !has_script_parse_errors {
-        result.virtual_ts = Some(generate_virtual_ts_with_scopes(
-            &summary,
-            script_content.as_deref(),
-            script_offset,
-            template_ast.as_ref(),
-            template_offset,
-        ));
+        result.virtual_ts = Some(if legacy_vue2 {
+            generate_virtual_ts_with_offsets_legacy_vue2(
+                &summary,
+                script_content.as_deref(),
+                template_ast.as_ref(),
+                script_offset,
+                template_offset,
+                &crate::virtual_ts::VirtualTsOptions::default(),
+            )
+            .code
+        } else {
+            generate_virtual_ts_with_scopes(
+                &summary,
+                script_content.as_deref(),
+                script_offset,
+                template_ast.as_ref(),
+                template_offset,
+            )
+        });
     }
 
     // Record analysis time on native only

--- a/crates/vize_canon/src/typecheck_service.rs
+++ b/crates/vize_canon/src/typecheck_service.rs
@@ -105,13 +105,36 @@ impl TypeCheckService {
         &self,
         source: &str,
         filename: &str,
+        options: &TypeCheckServiceOptions,
+    ) -> Result<SfcTypeCheckResult, CorsaBridgeError> {
+        self.check_sfc_impl(source, filename, options, false).await
+    }
+
+    /// Type check a Vue SFC with Vue 2.7 / Nuxt 2 compatibility enabled.
+    pub async fn check_sfc_with_legacy_vue2(
+        &self,
+        source: &str,
+        filename: &str,
+        options: &TypeCheckServiceOptions,
+    ) -> Result<SfcTypeCheckResult, CorsaBridgeError> {
+        self.check_sfc_impl(source, filename, options, true).await
+    }
+
+    async fn check_sfc_impl(
+        &self,
+        source: &str,
+        filename: &str,
         _options: &TypeCheckServiceOptions,
+        legacy_vue2: bool,
     ) -> Result<SfcTypeCheckResult, CorsaBridgeError> {
         use std::time::Instant;
         use vize_atelier_core::parser::parse;
         use vize_atelier_sfc::{
             SfcParseOptions,
-            croquis::{SfcCroquisOptions, analyze_sfc_descriptor_with_context},
+            croquis::{
+                SfcCroquisOptions, analyze_sfc_descriptor_with_context,
+                analyze_sfc_descriptor_with_context_legacy_vue2,
+            },
             parse_sfc,
         };
         use vize_carton::Bump;
@@ -201,11 +224,16 @@ impl TypeCheckService {
             (0, None)
         };
 
-        let analysis = analyze_sfc_descriptor_with_context(
-            &descriptor,
-            template_ast.as_ref(),
-            SfcCroquisOptions::full(),
-        );
+        let croquis_options = SfcCroquisOptions::full();
+        let analysis = if legacy_vue2 {
+            analyze_sfc_descriptor_with_context_legacy_vue2(
+                &descriptor,
+                template_ast.as_ref(),
+                croquis_options,
+            )
+        } else {
+            analyze_sfc_descriptor_with_context(&descriptor, template_ast.as_ref(), croquis_options)
+        };
 
         if has_template_parse_errors || has_script_parse_errors {
             result.analysis_time_ms = Some(start_time.elapsed().as_secs_f64() * 1000.0);
@@ -215,13 +243,19 @@ impl TypeCheckService {
         let script_offset = analysis.script_offset;
 
         // Generate virtual TypeScript
-        let virtual_ts_output = generate_virtual_ts_with_offsets(
+        let virtual_ts_options = VirtualTsOptions::default();
+        let generate_virtual_ts = if legacy_vue2 {
+            crate::virtual_ts::generate_virtual_ts_with_offsets_legacy_vue2
+        } else {
+            generate_virtual_ts_with_offsets
+        };
+        let virtual_ts_output = generate_virtual_ts(
             &analysis.croquis,
             analysis.script_content_ref(),
             template_ast.as_ref(),
             script_offset,
             template_offset,
-            &VirtualTsOptions::default(),
+            &virtual_ts_options,
         );
 
         result.virtual_ts = Some(virtual_ts_output.code.clone());

--- a/crates/vize_canon/src/virtual_ts.rs
+++ b/crates/vize_canon/src/virtual_ts.rs
@@ -16,17 +16,21 @@ mod types;
 
 #[cfg(any(test, feature = "native"))]
 pub(crate) use generator::generate_virtual_ts_with_offsets_and_checks;
-pub use generator::{generate_virtual_ts, generate_virtual_ts_with_offsets};
-#[cfg(any(test, feature = "native"))]
-pub(crate) use types::VirtualTsCheckOptions;
+pub use generator::{
+    generate_virtual_ts, generate_virtual_ts_with_offsets,
+    generate_virtual_ts_with_offsets_legacy_vue2,
+};
 pub use types::{TemplateGlobal, VirtualTsOptions, VirtualTsOutput, VizeMapping};
+#[cfg(any(test, feature = "native"))]
+pub(crate) use types::{VirtualTsCheckOptions, VirtualTsGenerationOptions};
 
 #[cfg(test)]
 mod tests {
     use super::helpers::{VUE_SETUP_HELPERS, generate_template_context, get_dom_event_type};
     use super::{
-        TemplateGlobal, VirtualTsCheckOptions, VirtualTsOptions, generate_virtual_ts,
-        generate_virtual_ts_with_offsets, generate_virtual_ts_with_offsets_and_checks,
+        TemplateGlobal, VirtualTsCheckOptions, VirtualTsGenerationOptions, VirtualTsOptions,
+        generate_virtual_ts, generate_virtual_ts_with_offsets,
+        generate_virtual_ts_with_offsets_and_checks,
     };
 
     fn assert_virtual_ts_snapshot(name: &str, value: &str) {
@@ -196,8 +200,11 @@ const wrong = 'not a number'
             0,
             0,
             &VirtualTsOptions::default(),
-            VirtualTsCheckOptions {
-                check_props: false,
+            VirtualTsGenerationOptions {
+                check_options: VirtualTsCheckOptions {
+                    check_props: false,
+                    ..Default::default()
+                },
                 ..Default::default()
             },
         );
@@ -228,8 +235,11 @@ const wrong = 'not a number'
             0,
             0,
             &VirtualTsOptions::default(),
-            VirtualTsCheckOptions {
-                check_template_bindings: false,
+            VirtualTsGenerationOptions {
+                check_options: VirtualTsCheckOptions {
+                    check_template_bindings: false,
+                    ..Default::default()
+                },
                 ..Default::default()
             },
         );

--- a/crates/vize_canon/src/virtual_ts/generator.rs
+++ b/crates/vize_canon/src/virtual_ts/generator.rs
@@ -12,7 +12,7 @@ use super::{
     },
     props::{collect_template_prop_names, generate_props_type, generate_props_variables},
     scope::generate_scope_closures,
-    types::{VirtualTsCheckOptions, VirtualTsOptions, VirtualTsOutput, VizeMapping},
+    types::{VirtualTsGenerationOptions, VirtualTsOptions, VirtualTsOutput, VizeMapping},
 };
 use vize_carton::append;
 use vize_carton::cstr;
@@ -64,7 +64,30 @@ pub fn generate_virtual_ts_with_offsets(
         script_offset,
         template_offset,
         options,
-        VirtualTsCheckOptions::default(),
+        VirtualTsGenerationOptions::default(),
+    )
+}
+
+/// Generate virtual TypeScript with Vue 2.7 / Nuxt 2 compatibility enabled.
+pub fn generate_virtual_ts_with_offsets_legacy_vue2(
+    summary: &Croquis,
+    script_content: Option<&str>,
+    template_ast: Option<&vize_relief::ast::RootNode<'_>>,
+    script_offset: u32,
+    template_offset: u32,
+    options: &VirtualTsOptions,
+) -> VirtualTsOutput {
+    generate_virtual_ts_with_offsets_and_checks(
+        summary,
+        script_content,
+        template_ast,
+        script_offset,
+        template_offset,
+        options,
+        VirtualTsGenerationOptions {
+            legacy_vue2: true,
+            ..Default::default()
+        },
     )
 }
 
@@ -75,8 +98,10 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
     script_offset: u32,
     template_offset: u32,
     options: &VirtualTsOptions,
-    check_options: VirtualTsCheckOptions,
+    generation_options: VirtualTsGenerationOptions,
 ) -> VirtualTsOutput {
+    let check_options = generation_options.check_options;
+    let legacy_vue2 = generation_options.legacy_vue2;
     let mut ts = String::default();
     let mut mappings: Vec<VizeMapping> = Vec::new();
 
@@ -404,6 +429,12 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
                 "canon.virtual_ts.generate_props_variables",
                 generate_props_variables(&mut ts, summary, script_content, generic_param)
             );
+            if legacy_vue2 {
+                profile!(
+                    "canon.virtual_ts.generate_legacy_vue2_variables",
+                    generate_legacy_vue2_variables(&mut ts, summary, options)
+                );
+            }
             let template_prop_names = profile!(
                 "canon.virtual_ts.collect_template_prop_names",
                 collect_template_prop_names(summary, script_content)
@@ -709,4 +740,64 @@ fn is_local_setup_binding(summary: &Croquis, name: &str) -> bool {
         .import_statements
         .iter()
         .any(|import| start >= import.start && end <= import.end)
+}
+
+fn generate_legacy_vue2_variables(
+    mut ts: &mut String,
+    summary: &Croquis,
+    options: &VirtualTsOptions,
+) {
+    let macro_prop_names: FxHashSet<&str> = summary
+        .macros
+        .props()
+        .iter()
+        .map(|prop| prop.name.as_str())
+        .collect();
+    let configured_globals: FxHashSet<&str> = options
+        .template_globals
+        .iter()
+        .map(|global| global.name.as_str())
+        .collect();
+    let mut names: Vec<&str> = summary
+        .bindings
+        .bindings
+        .iter()
+        .filter_map(|(name, binding_type)| {
+            let name = name.as_str();
+            match binding_type {
+                BindingType::Data | BindingType::Options | BindingType::VueGlobal => Some(name),
+                BindingType::Props if !macro_prop_names.contains(name) => Some(name),
+                _ => None,
+            }
+        })
+        .filter(|name| !configured_globals.contains(name))
+        .filter(|name| is_safe_value_identifier(name))
+        .collect();
+    names.sort_unstable();
+    names.dedup();
+
+    if names.is_empty() {
+        return;
+    }
+
+    ts.push_str("  // Vue 2.7 / Nuxt 2 Options API template bindings\n");
+    for name in &names {
+        append!(ts, "  const {name}: any = undefined as any;\n");
+    }
+    ts.push_str("  ");
+    for name in &names {
+        append!(ts, "void {name};");
+    }
+    ts.push('\n');
+}
+
+fn is_safe_value_identifier(name: &str) -> bool {
+    let mut chars = name.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    if !(first.is_ascii_alphabetic() || first == '_' || first == '$') {
+        return false;
+    }
+    chars.all(|ch| ch.is_ascii_alphanumeric() || ch == '_' || ch == '$')
 }

--- a/crates/vize_canon/src/virtual_ts/types.rs
+++ b/crates/vize_canon/src/virtual_ts/types.rs
@@ -77,6 +77,12 @@ impl Default for VirtualTsCheckOptions {
     }
 }
 
+#[derive(Debug, Clone, Copy, Default)]
+pub(crate) struct VirtualTsGenerationOptions {
+    pub(crate) check_options: VirtualTsCheckOptions,
+    pub(crate) legacy_vue2: bool,
+}
+
 /// Default plugin globals.
 /// Returns empty by default. Configure via `vize.config.pkl` `globalTypes`
 /// or `typeChecker.globalsFile`.

--- a/crates/vize_carton/src/config.rs
+++ b/crates/vize_carton/src/config.rs
@@ -4,11 +4,12 @@ mod loader;
 mod model;
 
 pub use loader::{
-    LoadedConfig, load_config, load_config_and_linter_with_source, load_config_with_source,
-    load_linter_config,
+    LoadedConfig, LoadedConfigWithFeatures, load_config,
+    load_config_and_linter_with_features_and_source, load_config_and_linter_with_source,
+    load_config_with_features_and_source, load_config_with_source, load_linter_config,
 };
 pub use model::{
-    ArrowParens, AttributeSortOrder, EndOfLine, FormatterConfig, GlobalTypeDeclaration,
-    GlobalTypesConfig, LanguageServerConfig, LintRuleSeverity, LinterConfig, LspConfig, QuoteProps,
-    TrailingComma, TypeCheckerConfig, VizeConfig,
+    ArrowParens, AttributeSortOrder, ConfigFeatureFlags, EndOfLine, FormatterConfig,
+    GlobalTypeDeclaration, GlobalTypesConfig, LanguageServerConfig, LintRuleSeverity, LinterConfig,
+    LspConfig, QuoteProps, TrailingComma, TypeCheckerConfig, VizeConfig,
 };

--- a/crates/vize_carton/src/config/loader.rs
+++ b/crates/vize_carton/src/config/loader.rs
@@ -8,7 +8,7 @@ use std::{
 
 use pklrust::{Error as PklError, EvaluatorManager, EvaluatorOptions, ModuleSource};
 
-use super::model::{LinterConfig, RawVizeConfig, VizeConfig};
+use super::model::{ConfigFeatureFlags, LinterConfig, RawVizeConfig, VizeConfig};
 
 const CONFIG_FILE_NAMES: [&str; 5] = [
     "vize.config.pkl",
@@ -27,6 +27,17 @@ pub struct LoadedConfig {
     pub source_path: Option<PathBuf>,
 }
 
+/// Loaded config with auxiliary feature flags.
+#[derive(Debug, Clone)]
+pub struct LoadedConfigWithFeatures {
+    /// Effective configuration with defaults applied.
+    pub config: VizeConfig,
+    /// Path of the config file that was used, if any.
+    pub source_path: Option<PathBuf>,
+    /// Auxiliary feature flags parsed from config keys.
+    pub features: ConfigFeatureFlags,
+}
+
 struct LoadedRawConfig {
     config: RawVizeConfig,
     source_path: Option<PathBuf>,
@@ -40,9 +51,21 @@ pub fn load_config(path: Option<&Path>) -> VizeConfig {
 /// Load configuration from a directory or file path and return its source path.
 pub fn load_config_with_source(path: Option<&Path>) -> LoadedConfig {
     let loaded = load_raw_config_with_source(path);
+    let (config, _) = loaded.config.into_config_and_features();
     LoadedConfig {
-        config: loaded.config.into(),
+        config,
         source_path: loaded.source_path,
+    }
+}
+
+/// Load configuration and auxiliary feature flags from a directory or file path.
+pub fn load_config_with_features_and_source(path: Option<&Path>) -> LoadedConfigWithFeatures {
+    let loaded = load_raw_config_with_source(path);
+    let (config, features) = loaded.config.into_config_and_features();
+    LoadedConfigWithFeatures {
+        config,
+        source_path: loaded.source_path,
+        features,
     }
 }
 
@@ -50,10 +73,28 @@ pub fn load_config_with_source(path: Option<&Path>) -> LoadedConfig {
 pub fn load_config_and_linter_with_source(path: Option<&Path>) -> (LoadedConfig, LinterConfig) {
     let loaded = load_raw_config_with_source(path);
     let linter = loaded.config.linter.clone();
+    let (config, _) = loaded.config.into_config_and_features();
     (
         LoadedConfig {
-            config: loaded.config.into(),
+            config,
             source_path: loaded.source_path,
+        },
+        linter,
+    )
+}
+
+/// Load configuration, auxiliary feature flags, and linter settings in one pass.
+pub fn load_config_and_linter_with_features_and_source(
+    path: Option<&Path>,
+) -> (LoadedConfigWithFeatures, LinterConfig) {
+    let loaded = load_raw_config_with_source(path);
+    let linter = loaded.config.linter.clone();
+    let (config, features) = loaded.config.into_config_and_features();
+    (
+        LoadedConfigWithFeatures {
+            config,
+            source_path: loaded.source_path,
+            features,
         },
         linter,
     )

--- a/crates/vize_carton/src/config/model.rs
+++ b/crates/vize_carton/src/config/model.rs
@@ -49,6 +49,14 @@ pub struct VizeConfig {
     pub global_types: GlobalTypesConfig,
 }
 
+/// Feature flags parsed from config keys that are not exposed as stable Rust
+/// model fields.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ConfigFeatureFlags {
+    pub type_checker_legacy_vue2: bool,
+    pub language_server_legacy_vue2: Option<bool>,
+}
+
 /// Raw config representation with legacy aliases preserved for migration.
 #[derive(Debug, Clone, Default, Deserialize)]
 #[serde(default)]
@@ -58,9 +66,9 @@ pub(crate) struct RawVizeConfig {
     pub formatter: FormatterConfig,
     pub linter: LinterConfig,
     #[serde(rename = "typeChecker")]
-    pub type_checker: TypeCheckerConfig,
+    type_checker: RawTypeCheckerConfig,
     #[serde(rename = "languageServer")]
-    pub language_server: LanguageServerConfig,
+    language_server: RawLanguageServerConfig,
     #[serde(rename = "globalTypes")]
     pub global_types: RawGlobalTypesConfig,
     #[serde(rename = "check")]
@@ -68,7 +76,23 @@ pub(crate) struct RawVizeConfig {
     #[serde(rename = "fmt")]
     legacy_formatter: Option<FormatterConfig>,
     #[serde(rename = "lsp")]
-    legacy_lsp: Option<LanguageServerConfig>,
+    legacy_lsp: Option<RawLanguageServerConfig>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default, rename_all = "camelCase")]
+struct RawTypeCheckerConfig {
+    #[serde(flatten)]
+    config: TypeCheckerConfig,
+    legacy_vue2: bool,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default, rename_all = "camelCase")]
+struct RawLanguageServerConfig {
+    #[serde(flatten)]
+    config: LanguageServerConfig,
+    legacy_vue2: Option<bool>,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -78,10 +102,23 @@ struct LegacyCheckConfig {
     servers: Option<usize>,
 }
 
-impl From<RawVizeConfig> for VizeConfig {
-    fn from(raw: RawVizeConfig) -> Self {
-        let mut type_checker = raw.type_checker;
-        if let Some(legacy_check) = raw.legacy_check {
+impl RawVizeConfig {
+    pub(crate) fn into_config_and_features(self) -> (VizeConfig, ConfigFeatureFlags) {
+        let RawVizeConfig {
+            schema,
+            formatter,
+            linter: _,
+            type_checker: raw_type_checker,
+            language_server: raw_language_server,
+            global_types,
+            legacy_check,
+            legacy_formatter,
+            legacy_lsp,
+        } = self;
+
+        let type_checker_legacy_vue2 = raw_type_checker.legacy_vue2;
+        let mut type_checker = raw_type_checker.config;
+        if let Some(legacy_check) = legacy_check {
             if type_checker.globals_file.is_none() {
                 type_checker.globals_file = legacy_check.globals;
             }
@@ -90,24 +127,37 @@ impl From<RawVizeConfig> for VizeConfig {
             }
         }
 
-        let formatter = if raw.formatter == FormatterConfig::default() {
-            raw.legacy_formatter.unwrap_or(raw.formatter)
+        let formatter = if formatter == FormatterConfig::default() {
+            legacy_formatter.unwrap_or(formatter)
         } else {
-            raw.formatter
+            formatter
         };
 
-        let language_server = if raw.language_server == LanguageServerConfig::default() {
-            raw.legacy_lsp.unwrap_or(raw.language_server)
+        let language_server_raw = if raw_language_server.config == LanguageServerConfig::default() {
+            legacy_lsp.unwrap_or(raw_language_server)
         } else {
-            raw.language_server
+            raw_language_server
+        };
+        let language_server = language_server_raw.config;
+        let features = ConfigFeatureFlags {
+            type_checker_legacy_vue2,
+            language_server_legacy_vue2: language_server_raw.legacy_vue2,
         };
 
-        Self {
-            schema: raw.schema,
+        let config = VizeConfig {
+            schema,
             formatter,
             type_checker,
             language_server,
-            global_types: raw.global_types.into(),
-        }
+            global_types: global_types.into(),
+        };
+
+        (config, features)
+    }
+}
+
+impl From<RawVizeConfig> for VizeConfig {
+    fn from(raw: RawVizeConfig) -> Self {
+        raw.into_config_and_features().0
     }
 }

--- a/crates/vize_carton/tests/loading.rs
+++ b/crates/vize_carton/tests/loading.rs
@@ -1,6 +1,8 @@
 #![allow(clippy::disallowed_macros)]
 
-use vize_carton::config::{load_config, load_config_with_source};
+use vize_carton::config::{
+    load_config, load_config_with_features_and_source, load_config_with_source,
+};
 
 #[test]
 fn loads_pkl_defaults() {
@@ -53,6 +55,29 @@ fn loads_json_type_checker_settings() {
     let config = load_config(Some(dir.path()));
 
     insta::assert_snapshot!(serde_json::to_string_pretty(&config).unwrap());
+}
+
+#[test]
+fn loads_json_legacy_vue2_feature_flags() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(
+        dir.path().join("vize.config.json"),
+        r#"{
+          "typeChecker": {
+            "legacyVue2": true
+          },
+          "languageServer": {
+            "legacyVue2": true
+          }
+        }"#,
+    )
+    .unwrap();
+
+    let loaded = load_config_with_features_and_source(Some(dir.path()));
+
+    assert!(loaded.features.type_checker_legacy_vue2);
+    assert_eq!(loaded.features.language_server_legacy_vue2, Some(true));
+    assert!(loaded.config.type_checker.enabled);
 }
 
 #[test]

--- a/crates/vize_croquis/src/analyzer.rs
+++ b/crates/vize_croquis/src/analyzer.rs
@@ -102,6 +102,7 @@ impl AnalyzerOptions {
 /// Uses lazy evaluation and efficient data structures to minimize overhead.
 pub struct Analyzer {
     pub(crate) options: AnalyzerOptions,
+    pub(crate) legacy_vue2: bool,
     pub(crate) summary: Croquis,
     /// Track if script was analyzed (for undefined detection)
     pub(crate) script_analyzed: bool,
@@ -121,6 +122,7 @@ impl Analyzer {
     pub fn with_options(options: AnalyzerOptions) -> Self {
         Self {
             options,
+            legacy_vue2: false,
             summary: Croquis::new(),
             script_analyzed: false,
             vif_guard_stack: Vec::new(),
@@ -135,10 +137,18 @@ impl Analyzer {
     pub fn with_summary(options: AnalyzerOptions, summary: Croquis, script_analyzed: bool) -> Self {
         Self {
             options,
+            legacy_vue2: false,
             summary,
             script_analyzed,
             vif_guard_stack: Vec::new(),
         }
+    }
+
+    /// Enable Vue 2.7 / Nuxt 2 compatibility helpers.
+    #[inline]
+    pub fn with_legacy_vue2(mut self) -> Self {
+        self.legacy_vue2 = true;
+        self
     }
 
     /// Get the current v-if guard (combined from stack)
@@ -216,7 +226,12 @@ impl Analyzer {
         // Use OXC-based parser for non-script-setup
         let result = profile!(
             "croquis.analyzer.script_plain",
-            crate::script_parser::parse_script(source)
+            crate::script_parser::parse_script_with_options(
+                source,
+                crate::script_parser::ScriptParserOptions {
+                    legacy_vue2: self.legacy_vue2,
+                }
+            )
         );
 
         result.apply_to_croquis(&mut self.summary);

--- a/crates/vize_croquis/src/script_parser.rs
+++ b/crates/vize_croquis/src/script_parser.rs
@@ -120,6 +120,13 @@ pub struct ScriptParseResult {
     pub(crate) type_export_typeof_refs: Vec<FxHashSet<CompactString>>,
 }
 
+/// Options for plain script parsing.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct ScriptParserOptions {
+    /// Extract Vue 2.7 / Nuxt 2 Options API template bindings.
+    pub legacy_vue2: bool,
+}
+
 impl ScriptParseResult {
     /// Record a `TypeExport` together with the `typeof` value-identifier
     /// references found in its body. Must be the only call site that pushes
@@ -392,6 +399,11 @@ pub fn parse_script_setup(source: &str) -> ScriptParseResult {
 
 /// Parse non-script-setup (Options API) source code using OXC parser.
 pub fn parse_script(source: &str) -> ScriptParseResult {
+    parse_script_with_options(source, ScriptParserOptions::default())
+}
+
+/// Parse non-script-setup source code using OXC parser with explicit options.
+pub fn parse_script_with_options(source: &str, options: ScriptParserOptions) -> ScriptParseResult {
     let allocator = Allocator::default();
     let source_type = SourceType::from_path("script.ts").unwrap_or_default();
 
@@ -429,7 +441,7 @@ pub fn parse_script(source: &str) -> ScriptParseResult {
         source_len,
     );
 
-    process::collect_options_api_component_registrations(&mut result, &ret.program);
+    process::collect_options_api_component_metadata(&mut result, &ret.program, options.legacy_vue2);
 
     // Process all statements
     profile!("croquis.script_plain.walk_statements", {
@@ -450,7 +462,7 @@ pub fn parse_script(source: &str) -> ScriptParseResult {
 
 #[cfg(test)]
 mod tests {
-    use super::{parse_script, parse_script_setup};
+    use super::{ScriptParserOptions, parse_script, parse_script_setup, parse_script_with_options};
     use vize_carton::{CompactString, append, cstr};
 
     #[test]
@@ -791,6 +803,56 @@ export class MyClass {}
             "Expected at least 3 scopes, got {}",
             result.scopes.len()
         );
+    }
+
+    #[test]
+    fn test_parse_legacy_vue2_options_api_template_bindings() {
+        let source = r#"
+export default {
+  props: {
+    message: String,
+    'user-id': Number
+  },
+  data() {
+    return {
+      count: 0
+    }
+  },
+  asyncData() {
+    return {
+      pageTitle: 'Hello'
+    }
+  },
+  computed: {
+    doubled() {
+      return this.count * 2
+    }
+  },
+  methods: {
+    save() {}
+  },
+  setup() {
+    return {
+      setupValue: 1
+    }
+  }
+}
+"#;
+        let result = parse_script_with_options(source, ScriptParserOptions { legacy_vue2: true });
+
+        for name in [
+            "message",
+            "userId",
+            "count",
+            "pageTitle",
+            "doubled",
+            "save",
+            "setupValue",
+            "$route",
+            "$nuxt",
+        ] {
+            assert!(result.bindings.contains(name), "missing binding {name}");
+        }
     }
 
     #[test]

--- a/crates/vize_croquis/src/script_parser/process.rs
+++ b/crates/vize_croquis/src/script_parser/process.rs
@@ -14,9 +14,9 @@ mod bindings;
 mod macros;
 
 use oxc_ast::ast::{
-    Argument, BindingPattern, CallExpression, Class, Declaration, ExportDefaultDeclarationKind,
-    Expression, Function, ObjectExpression, ObjectPropertyKind, Program, PropertyKey, Statement,
-    VariableDeclaration,
+    Argument, ArrayExpression, ArrayExpressionElement, BindingPattern, CallExpression, Class,
+    Declaration, ExportDefaultDeclarationKind, Expression, Function, ObjectExpression,
+    ObjectPropertyKind, Program, PropertyKey, Statement, VariableDeclaration,
 };
 use oxc_span::GetSpan;
 
@@ -26,7 +26,7 @@ use crate::analysis::{
     TypeExport, TypeExportKind,
 };
 use crate::scope::{BlockKind, BlockScopeData, ClosureScopeData, ExternalModuleScopeData};
-use vize_carton::{CompactString, FxHashMap, FxHashSet};
+use vize_carton::{CompactString, FxHashMap, FxHashSet, String};
 use vize_relief::BindingType;
 
 use super::ScriptParseResult;
@@ -327,9 +327,10 @@ struct ComponentOptionsRef<'a> {
     object: &'a ObjectExpression<'a>,
 }
 
-pub(in crate::script_parser) fn collect_options_api_component_registrations(
+pub(in crate::script_parser) fn collect_options_api_component_metadata(
     result: &mut ScriptParseResult,
     program: &Program<'_>,
+    legacy_vue2: bool,
 ) {
     let mut object_bindings = FxHashMap::default();
     collect_object_bindings(program, &mut object_bindings);
@@ -348,6 +349,17 @@ pub(in crate::script_parser) fn collect_options_api_component_registrations(
             continue;
         };
         collect_component_registrations_from_options(result, options.object, &object_bindings);
+        if legacy_vue2 {
+            collect_legacy_vue2_template_bindings_from_options(
+                result,
+                options.object,
+                &object_bindings,
+            );
+        }
+    }
+
+    if legacy_vue2 {
+        add_nuxt2_template_globals(result);
     }
 }
 
@@ -427,6 +439,266 @@ fn collect_component_registrations_from_options<'a>(
         &mut seen,
         &mut FxHashSet::default(),
     );
+}
+
+fn collect_legacy_vue2_template_bindings_from_options<'a>(
+    result: &mut ScriptParseResult,
+    options: &'a ObjectExpression<'a>,
+    object_bindings: &FxHashMap<&'a str, &'a ObjectExpression<'a>>,
+) {
+    collect_props_bindings(result, options, object_bindings);
+    collect_object_option_bindings(
+        result,
+        options,
+        object_bindings,
+        "computed",
+        BindingType::Options,
+    );
+    collect_object_option_bindings(
+        result,
+        options,
+        object_bindings,
+        "methods",
+        BindingType::Options,
+    );
+    collect_object_option_bindings(
+        result,
+        options,
+        object_bindings,
+        "inject",
+        BindingType::Options,
+    );
+    collect_returned_object_option_bindings(
+        result,
+        options,
+        object_bindings,
+        "data",
+        BindingType::Data,
+    );
+    collect_returned_object_option_bindings(
+        result,
+        options,
+        object_bindings,
+        "asyncData",
+        BindingType::Data,
+    );
+    collect_returned_object_option_bindings(
+        result,
+        options,
+        object_bindings,
+        "setup",
+        BindingType::Options,
+    );
+}
+
+fn add_nuxt2_template_globals(result: &mut ScriptParseResult) {
+    for name in [
+        "$config",
+        "$fetchState",
+        "$nuxt",
+        "$route",
+        "$router",
+        "$store",
+    ] {
+        add_template_binding(result, name, BindingType::VueGlobal, 0, 0);
+    }
+}
+
+fn collect_props_bindings<'a>(
+    result: &mut ScriptParseResult,
+    options: &'a ObjectExpression<'a>,
+    object_bindings: &FxHashMap<&'a str, &'a ObjectExpression<'a>>,
+) {
+    let Some(props) = option_expression_property(options, "props") else {
+        return;
+    };
+
+    match props {
+        Expression::ArrayExpression(array) => {
+            collect_array_string_bindings(result, array, BindingType::Props);
+        }
+        Expression::ObjectExpression(object) => {
+            collect_object_property_bindings(result, object, BindingType::Props);
+        }
+        Expression::Identifier(identifier) => {
+            if let Some(object) = object_bindings.get(identifier.name.as_str()).copied() {
+                collect_object_property_bindings(result, object, BindingType::Props);
+            }
+        }
+        Expression::ParenthesizedExpression(parenthesized) => {
+            collect_props_bindings_from_expression(
+                result,
+                &parenthesized.expression,
+                object_bindings,
+            )
+        }
+        Expression::TSAsExpression(ts_as) => {
+            collect_props_bindings_from_expression(result, &ts_as.expression, object_bindings)
+        }
+        Expression::TSSatisfiesExpression(ts_satisfies) => collect_props_bindings_from_expression(
+            result,
+            &ts_satisfies.expression,
+            object_bindings,
+        ),
+        Expression::TSNonNullExpression(ts_non_null) => {
+            collect_props_bindings_from_expression(result, &ts_non_null.expression, object_bindings)
+        }
+        _ => {}
+    }
+}
+
+fn collect_props_bindings_from_expression<'a>(
+    result: &mut ScriptParseResult,
+    expression: &'a Expression<'a>,
+    object_bindings: &FxHashMap<&'a str, &'a ObjectExpression<'a>>,
+) {
+    match expression {
+        Expression::ArrayExpression(array) => {
+            collect_array_string_bindings(result, array, BindingType::Props);
+        }
+        Expression::ObjectExpression(object) => {
+            collect_object_property_bindings(result, object, BindingType::Props);
+        }
+        Expression::Identifier(identifier) => {
+            if let Some(object) = object_bindings.get(identifier.name.as_str()).copied() {
+                collect_object_property_bindings(result, object, BindingType::Props);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn collect_object_option_bindings<'a>(
+    result: &mut ScriptParseResult,
+    options: &'a ObjectExpression<'a>,
+    object_bindings: &FxHashMap<&'a str, &'a ObjectExpression<'a>>,
+    key_name: &str,
+    binding_type: BindingType,
+) {
+    let Some(object) = option_object_property(options, key_name, object_bindings) else {
+        return;
+    };
+
+    collect_object_property_bindings(result, object, binding_type);
+}
+
+fn collect_returned_object_option_bindings<'a>(
+    result: &mut ScriptParseResult,
+    options: &'a ObjectExpression<'a>,
+    object_bindings: &FxHashMap<&'a str, &'a ObjectExpression<'a>>,
+    key_name: &str,
+    binding_type: BindingType,
+) {
+    let Some(expression) = option_expression_property(options, key_name) else {
+        return;
+    };
+    let Some(object) = returned_object_from_expression(expression, object_bindings) else {
+        return;
+    };
+
+    collect_object_property_bindings(result, object, binding_type);
+}
+
+fn collect_array_string_bindings(
+    result: &mut ScriptParseResult,
+    array: &ArrayExpression<'_>,
+    binding_type: BindingType,
+) {
+    for element in &array.elements {
+        let ArrayExpressionElement::StringLiteral(literal) = element else {
+            continue;
+        };
+        let name = normalize_template_binding_name(literal.value.as_str());
+        if let Some(name) = name {
+            let start = literal.span.start.saturating_add(1);
+            let end = literal.span.end.saturating_sub(1);
+            add_template_binding(result, name.as_str(), binding_type, start, end);
+        }
+    }
+}
+
+fn collect_object_property_bindings(
+    result: &mut ScriptParseResult,
+    object: &ObjectExpression<'_>,
+    binding_type: BindingType,
+) {
+    for property in &object.properties {
+        let ObjectPropertyKind::ObjectProperty(property) = property else {
+            continue;
+        };
+        if property.computed {
+            continue;
+        }
+
+        let Some(raw_name) = property_key_name(&property.key) else {
+            continue;
+        };
+        let Some(name) = normalize_template_binding_name(raw_name) else {
+            continue;
+        };
+        let span = property.key.span();
+        add_template_binding(result, name.as_str(), binding_type, span.start, span.end);
+    }
+}
+
+fn add_template_binding(
+    result: &mut ScriptParseResult,
+    name: &str,
+    binding_type: BindingType,
+    start: u32,
+    end: u32,
+) {
+    result.bindings.add(name, binding_type);
+    result
+        .binding_spans
+        .entry(CompactString::new(name))
+        .or_insert((start, end));
+    result.scopes.add_binding(
+        CompactString::new(name),
+        ScopeBinding::new(binding_type, start),
+    );
+}
+
+fn normalize_template_binding_name(name: &str) -> Option<CompactString> {
+    if is_valid_template_binding_name(name) {
+        return Some(CompactString::new(name));
+    }
+
+    if name.contains('-') {
+        let camel = kebab_to_camel(name);
+        if is_valid_template_binding_name(&camel) {
+            return Some(CompactString::new(camel));
+        }
+    }
+
+    None
+}
+
+fn is_valid_template_binding_name(name: &str) -> bool {
+    let mut chars = name.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    if !(first.is_ascii_alphabetic() || first == '_' || first == '$') {
+        return false;
+    }
+    chars.all(|ch| ch.is_ascii_alphanumeric() || ch == '_' || ch == '$')
+}
+
+fn kebab_to_camel(name: &str) -> String {
+    let mut result = String::with_capacity(name.len());
+    let mut upper_next = false;
+    for ch in name.chars() {
+        if ch == '-' {
+            upper_next = true;
+        } else if upper_next {
+            result.push(ch.to_ascii_uppercase());
+            upper_next = false;
+        } else {
+            result.push(ch);
+        }
+    }
+    result
 }
 
 fn collect_component_registrations_from_components_object<'a>(
@@ -612,6 +884,66 @@ fn object_expression_from_expression_or_binding<'a>(
     }
 }
 
+fn returned_object_from_expression<'a>(
+    expression: &'a Expression<'a>,
+    object_bindings: &FxHashMap<&'a str, &'a ObjectExpression<'a>>,
+) -> Option<&'a ObjectExpression<'a>> {
+    match expression {
+        Expression::ArrowFunctionExpression(arrow) => {
+            if arrow.expression {
+                let Statement::ExpressionStatement(expr_stmt) = arrow.body.statements.first()?
+                else {
+                    return None;
+                };
+                object_expression_from_expression_or_binding(&expr_stmt.expression, object_bindings)
+            } else {
+                function_body_return_object(&arrow.body.statements, object_bindings)
+            }
+        }
+        Expression::FunctionExpression(function) => {
+            function_body_return_object(&function.body.as_ref()?.statements, object_bindings)
+        }
+        Expression::ObjectExpression(object) => Some(object.as_ref()),
+        Expression::Identifier(identifier) => {
+            object_bindings.get(identifier.name.as_str()).copied()
+        }
+        Expression::ParenthesizedExpression(parenthesized) => {
+            returned_object_from_expression(&parenthesized.expression, object_bindings)
+        }
+        Expression::TSAsExpression(ts_as) => {
+            returned_object_from_expression(&ts_as.expression, object_bindings)
+        }
+        Expression::TSSatisfiesExpression(ts_satisfies) => {
+            returned_object_from_expression(&ts_satisfies.expression, object_bindings)
+        }
+        Expression::TSNonNullExpression(ts_non_null) => {
+            returned_object_from_expression(&ts_non_null.expression, object_bindings)
+        }
+        _ => None,
+    }
+}
+
+fn function_body_return_object<'a>(
+    statements: &'a oxc_allocator::Vec<'a, Statement<'a>>,
+    object_bindings: &FxHashMap<&'a str, &'a ObjectExpression<'a>>,
+) -> Option<&'a ObjectExpression<'a>> {
+    for statement in statements.iter() {
+        let Statement::ReturnStatement(ret) = statement else {
+            continue;
+        };
+        let Some(argument) = &ret.argument else {
+            continue;
+        };
+        if let Some(object) =
+            object_expression_from_expression_or_binding(argument, object_bindings)
+        {
+            return Some(object);
+        }
+    }
+
+    None
+}
+
 fn local_name_from_expression<'a>(expression: &'a Expression<'a>) -> Option<&'a str> {
     match expression {
         Expression::Identifier(identifier) => Some(identifier.name.as_str()),
@@ -657,6 +989,21 @@ fn option_object_property<'a>(
             return None;
         }
         object_expression_from_expression_or_binding(&property.value, object_bindings)
+    })
+}
+
+fn option_expression_property<'a>(
+    object: &'a ObjectExpression<'a>,
+    key_name: &str,
+) -> Option<&'a Expression<'a>> {
+    object.properties.iter().find_map(|property| {
+        let ObjectPropertyKind::ObjectProperty(property) = property else {
+            return None;
+        };
+        if property.computed || property_key_name(&property.key) != Some(key_name) {
+            return None;
+        }
+        Some(&property.value)
     })
 }
 

--- a/crates/vize_maestro/src/ide/completion/service.rs
+++ b/crates/vize_maestro/src/ide/completion/service.rs
@@ -178,7 +178,11 @@ impl super::CompletionService {
             if !corsa_items.is_empty() {
                 let mut items = corsa_items;
                 items.extend(match block_type {
-                    BlockType::Template => template::contextual_directive_completions(ctx),
+                    BlockType::Template => {
+                        let mut extras = template::contextual_directive_completions(ctx);
+                        extras.extend(template::legacy_vue2_template_completions(ctx));
+                        extras
+                    }
                     BlockType::Script => script::composition_api_completions(),
                     BlockType::ScriptSetup => {
                         let mut v = script::composition_api_completions();

--- a/crates/vize_maestro/src/ide/completion/template.rs
+++ b/crates/vize_maestro/src/ide/completion/template.rs
@@ -14,7 +14,11 @@ use tower_lsp::lsp_types::{
     CompletionItem, CompletionItemKind, CompletionItemLabelDetails, CompletionResponse,
     Documentation, InsertTextFormat, MarkupContent, MarkupKind,
 };
+use vize_atelier_sfc::croquis::{
+    SfcCroquisOptions, analyze_sfc_descriptor, analyze_sfc_descriptor_with_context_legacy_vue2,
+};
 use vize_croquis::{Analyzer, AnalyzerOptions};
+use vize_relief::BindingType;
 
 use super::{
     is_inside_art_tag, is_inside_html_comment, is_inside_variant_tag, items,
@@ -37,6 +41,9 @@ pub(crate) fn complete_template(ctx: &IdeContext) -> Vec<CompletionItem> {
 
     // Add built-in components
     items_vec.extend(builtin_component_completions());
+    if ctx.state.lsp_features().legacy_vue2 {
+        items_vec.extend(legacy_vue2_component_completions());
+    }
     items_vec.extend(component_surface_completions(ctx));
 
     if !crate::ide::is_in_vue_template_expression(&ctx.content, ctx.offset) {
@@ -44,116 +51,24 @@ pub(crate) fn complete_template(ctx: &IdeContext) -> Vec<CompletionItem> {
         return items_vec;
     }
 
-    // Use vize_croquis for accurate scope analysis and type information
-    let options = vize_atelier_sfc::SfcParseOptions {
-        filename: ctx.uri.path().to_string().into(),
-        ..Default::default()
-    };
-
-    if let Ok(descriptor) = vize_atelier_sfc::parse_sfc(&ctx.content, options)
-        && let Some(ref script_setup) = descriptor.script_setup
-    {
-        let mut analyzer = Analyzer::with_options(AnalyzerOptions {
-            analyze_script: true,
-            ..Default::default()
-        });
-        analyzer.analyze_script_setup(&script_setup.content);
-        let croquis = analyzer.finish();
-
-        // Add bindings with accurate type information
-        for (name, binding_type) in croquis.bindings.iter() {
-            let (kind, type_detail, doc) = items::binding_type_to_completion_info(binding_type);
-            #[allow(clippy::disallowed_macros)]
-            items_vec.push(CompletionItem {
-                label: name.to_string(),
-                kind: Some(kind),
-                label_details: Some(CompletionItemLabelDetails {
-                    detail: Some(type_detail.clone()),
-                    description: None,
-                }),
-                detail: Some(type_detail),
-                documentation: Some(Documentation::MarkupContent(MarkupContent {
-                    kind: MarkupKind::Markdown,
-                    value: doc,
-                })),
-                sort_text: Some(format!("0{}", name)),
-                ..Default::default()
-            });
-        }
-
-        // Add props with type information
-        for prop in croquis.macros.props() {
-            let prop_type = prop
-                .prop_type
-                .as_ref()
-                .map(|t| t.as_str())
-                .unwrap_or("unknown");
-            let required = if prop.required { "" } else { "?" };
-
-            #[allow(clippy::disallowed_macros)]
-            items_vec.push(CompletionItem {
-                label: prop.name.to_string(),
-                kind: Some(CompletionItemKind::PROPERTY),
-                label_details: Some(CompletionItemLabelDetails {
-                    detail: Some(format!(": {}{}", prop_type, required)),
-                    description: None,
-                }),
-                detail: Some(format!("prop: {}", prop_type)),
-                documentation: Some(Documentation::MarkupContent(MarkupContent {
-                    kind: MarkupKind::Markdown,
-                    value: format!(
-                        "**Prop** `{}`\n\n```typescript\n{}: {}{}\n```\n\n{}",
-                        prop.name,
-                        prop.name,
-                        prop_type,
-                        if prop.required { "" } else { " // optional" },
-                        if prop.default_value.is_some() {
-                            "Has default value"
-                        } else {
-                            ""
-                        }
-                    ),
-                })),
-                sort_text: Some(format!("0{}", prop.name)),
-                ..Default::default()
-            });
-        }
-
-        // Add reactive sources with special handling
-        for source in croquis.reactivity.sources() {
-            let kind_str = source.kind.to_display();
-            #[allow(clippy::disallowed_macros)]
-            items_vec.push(CompletionItem {
-                label: source.name.to_string(),
-                kind: Some(CompletionItemKind::VARIABLE),
-                label_details: Some(CompletionItemLabelDetails {
-                    detail: Some(format!(" ({})", kind_str)),
-                    description: None,
-                }),
-                detail: Some(format!("Reactive: {}", kind_str)),
-                documentation: Some(Documentation::MarkupContent(MarkupContent {
-                    kind: MarkupKind::Markdown,
-                    value: format!(
-                        "**{}** `{}`\n\n{}\n\nAuto-unwrapped in template.",
-                        kind_str,
-                        source.name,
-                        if source.kind.needs_value_access() {
-                            "Needs `.value` in script"
-                        } else {
-                            "Direct access (no `.value` needed)"
-                        }
-                    ),
-                })),
-                sort_text: Some(format!("0{}", source.name)),
-                ..Default::default()
-            });
-        }
-    }
+    items_vec.extend(analyzed_template_binding_completions(ctx, true));
 
     // Add common template snippets
     items_vec.extend(template_snippets());
 
     items_vec
+}
+
+pub(crate) fn legacy_vue2_template_completions(ctx: &IdeContext) -> Vec<CompletionItem> {
+    if !ctx.state.lsp_features().legacy_vue2 {
+        return Vec::new();
+    }
+
+    if crate::ide::is_in_vue_template_expression(&ctx.content, ctx.offset) {
+        analyzed_template_binding_completions(ctx, false)
+    } else {
+        legacy_vue2_component_completions()
+    }
 }
 
 /// Get completions for Art files (*.art.vue).
@@ -381,6 +296,170 @@ pub(crate) fn builtin_component_completions() -> Vec<CompletionItem> {
     ]
 }
 
+fn legacy_vue2_component_completions() -> Vec<CompletionItem> {
+    vec![
+        items::component_item(
+            "NuxtLink",
+            "Nuxt 2 route link",
+            "<NuxtLink to=\"$1\">$0</NuxtLink>",
+        ),
+        items::component_item(
+            "nuxt-link",
+            "Nuxt 2 route link",
+            "<nuxt-link to=\"$1\">$0</nuxt-link>",
+        ),
+        items::component_item("Nuxt", "Nuxt 2 page outlet", "<Nuxt />"),
+        items::component_item("NuxtChild", "Nuxt 2 child route outlet", "<NuxtChild />"),
+        items::component_item(
+            "ClientOnly",
+            "Client-only render",
+            "<ClientOnly>$0</ClientOnly>",
+        ),
+        items::component_item(
+            "client-only",
+            "Client-only render",
+            "<client-only>$0</client-only>",
+        ),
+        items::component_item("NoSsr", "Client-only render", "<NoSsr>$0</NoSsr>"),
+    ]
+}
+
+fn analyzed_template_binding_completions(
+    ctx: &IdeContext,
+    include_vue3_details: bool,
+) -> Vec<CompletionItem> {
+    let options = vize_atelier_sfc::SfcParseOptions {
+        filename: ctx.uri.path().to_string().into(),
+        ..Default::default()
+    };
+
+    let Ok(descriptor) = vize_atelier_sfc::parse_sfc(&ctx.content, options) else {
+        return Vec::new();
+    };
+
+    let croquis_options = SfcCroquisOptions::full();
+    let croquis = if ctx.state.lsp_features().legacy_vue2 {
+        analyze_sfc_descriptor_with_context_legacy_vue2(&descriptor, None, croquis_options).croquis
+    } else {
+        analyze_sfc_descriptor(&descriptor, None, croquis_options)
+    };
+
+    let mut items_vec = Vec::new();
+    let macro_prop_names: BTreeSet<&str> = if include_vue3_details {
+        BTreeSet::new()
+    } else {
+        croquis
+            .macros
+            .props()
+            .iter()
+            .map(|prop| prop.name.as_str())
+            .collect()
+    };
+
+    for (name, binding_type) in croquis.bindings.iter() {
+        if !include_vue3_details
+            && (!is_legacy_vue2_binding(binding_type)
+                || binding_type == BindingType::Props && macro_prop_names.contains(name))
+        {
+            continue;
+        }
+        let (kind, type_detail, doc) = items::binding_type_to_completion_info(binding_type);
+        #[allow(clippy::disallowed_macros)]
+        items_vec.push(CompletionItem {
+            label: name.to_string(),
+            kind: Some(kind),
+            label_details: Some(CompletionItemLabelDetails {
+                detail: Some(type_detail.clone()),
+                description: None,
+            }),
+            detail: Some(type_detail),
+            documentation: Some(Documentation::MarkupContent(MarkupContent {
+                kind: MarkupKind::Markdown,
+                value: doc,
+            })),
+            sort_text: Some(format!("0{}", name)),
+            ..Default::default()
+        });
+    }
+
+    if include_vue3_details {
+        for prop in croquis.macros.props() {
+            let prop_type = prop
+                .prop_type
+                .as_ref()
+                .map(|t| t.as_str())
+                .unwrap_or("unknown");
+            let required = if prop.required { "" } else { "?" };
+
+            #[allow(clippy::disallowed_macros)]
+            items_vec.push(CompletionItem {
+                label: prop.name.to_string(),
+                kind: Some(CompletionItemKind::PROPERTY),
+                label_details: Some(CompletionItemLabelDetails {
+                    detail: Some(format!(": {}{}", prop_type, required)),
+                    description: None,
+                }),
+                detail: Some(format!("prop: {}", prop_type)),
+                documentation: Some(Documentation::MarkupContent(MarkupContent {
+                    kind: MarkupKind::Markdown,
+                    value: format!(
+                        "**Prop** `{}`\n\n```typescript\n{}: {}{}\n```\n\n{}",
+                        prop.name,
+                        prop.name,
+                        prop_type,
+                        if prop.required { "" } else { " // optional" },
+                        if prop.default_value.is_some() {
+                            "Has default value"
+                        } else {
+                            ""
+                        }
+                    ),
+                })),
+                sort_text: Some(format!("0{}", prop.name)),
+                ..Default::default()
+            });
+        }
+
+        for source in croquis.reactivity.sources() {
+            let kind_str = source.kind.to_display();
+            #[allow(clippy::disallowed_macros)]
+            items_vec.push(CompletionItem {
+                label: source.name.to_string(),
+                kind: Some(CompletionItemKind::VARIABLE),
+                label_details: Some(CompletionItemLabelDetails {
+                    detail: Some(format!(" ({})", kind_str)),
+                    description: None,
+                }),
+                detail: Some(format!("Reactive: {}", kind_str)),
+                documentation: Some(Documentation::MarkupContent(MarkupContent {
+                    kind: MarkupKind::Markdown,
+                    value: format!(
+                        "**{}** `{}`\n\n{}\n\nAuto-unwrapped in template.",
+                        kind_str,
+                        source.name,
+                        if source.kind.needs_value_access() {
+                            "Needs `.value` in script"
+                        } else {
+                            "Direct access (no `.value` needed)"
+                        }
+                    ),
+                })),
+                sort_text: Some(format!("0{}", source.name)),
+                ..Default::default()
+            });
+        }
+    }
+
+    items_vec
+}
+
+fn is_legacy_vue2_binding(binding_type: BindingType) -> bool {
+    matches!(
+        binding_type,
+        BindingType::Data | BindingType::Options | BindingType::Props | BindingType::VueGlobal
+    )
+}
+
 /// Template snippet completions.
 fn template_snippets() -> Vec<CompletionItem> {
     vec![
@@ -585,6 +664,7 @@ fn component_metadata(ctx: &IdeContext, component_name: &str) -> Option<Componen
         return Some(extract_component_metadata(
             &component_content,
             &resolved.to_string_lossy(),
+            ctx.state.lsp_features().legacy_vue2,
         ));
     }
 
@@ -594,6 +674,7 @@ fn component_metadata(ctx: &IdeContext, component_name: &str) -> Option<Componen
         return Some(extract_component_metadata(
             &component_content,
             &resolved.to_string_lossy(),
+            ctx.state.lsp_features().legacy_vue2,
         ));
     }
 
@@ -638,7 +719,11 @@ fn art_component_path(ctx: &IdeContext<'_>, component_name: &str) -> Option<Stri
     (component_name == stem || pascal_component == pascal_stem).then(|| component_path.to_string())
 }
 
-fn extract_component_metadata(content: &str, filename: &str) -> ComponentMetadata {
+fn extract_component_metadata(
+    content: &str,
+    filename: &str,
+    legacy_vue2: bool,
+) -> ComponentMetadata {
     let options = vize_atelier_sfc::SfcParseOptions {
         filename: filename.to_string().into(),
         ..Default::default()
@@ -666,10 +751,14 @@ fn extract_component_metadata(content: &str, filename: &str) -> ComponentMetadat
                 .map(|script| script.content.as_ref())
         })
     {
-        let mut analyzer = Analyzer::with_options(AnalyzerOptions {
+        let analyzer_options = AnalyzerOptions {
             analyze_script: true,
             ..Default::default()
-        });
+        };
+        let mut analyzer = Analyzer::with_options(analyzer_options);
+        if legacy_vue2 {
+            analyzer = analyzer.with_legacy_vue2();
+        }
         if descriptor.script_setup.is_some() {
             analyzer.analyze_script_setup(script_content);
         } else {
@@ -690,6 +779,18 @@ fn extract_component_metadata(content: &str, filename: &str) -> ComponentMetadat
                         .or_else(|| inferred.map(|prop| prop.type_detail.clone())),
                     required: inferred.map_or(prop.required, |prop| prop.required),
                 });
+            }
+        }
+
+        if legacy_vue2 {
+            for (name, binding_type) in summary.bindings.iter() {
+                if binding_type == BindingType::Props && seen_props.insert(name.to_string()) {
+                    props.push(ComponentProp {
+                        name: name.to_string(),
+                        type_detail: None,
+                        required: false,
+                    });
+                }
             }
         }
 

--- a/crates/vize_maestro/src/ide/definition.rs
+++ b/crates/vize_maestro/src/ide/definition.rs
@@ -8,7 +8,7 @@
 
 pub mod bindings;
 pub(crate) mod helpers;
-mod script;
+pub(crate) mod script;
 mod service;
 mod template;
 

--- a/crates/vize_maestro/src/ide/definition/script.rs
+++ b/crates/vize_maestro/src/ide/definition/script.rs
@@ -76,7 +76,71 @@ pub(crate) fn definition_in_script(ctx: &IdeContext) -> Option<GotoDefinitionRes
         }
     }
 
+    if ctx.state.lsp_features().legacy_vue2
+        && let Some(location) = find_analyzed_binding_location(ctx, &word, true)
+    {
+        return Some(GotoDefinitionResponse::Scalar(location));
+    }
+
     None
+}
+
+/// Find a binding location from Croquis analysis, including opt-in Options API spans.
+pub(crate) fn find_analyzed_binding_location(
+    ctx: &IdeContext,
+    word: &str,
+    legacy_vue2: bool,
+) -> Option<Location> {
+    use vize_atelier_sfc::{
+        SfcParseOptions,
+        croquis::{
+            SfcCroquisOptions, analyze_sfc_descriptor_with_context,
+            analyze_sfc_descriptor_with_context_legacy_vue2,
+        },
+        parse_sfc,
+    };
+
+    let descriptor = parse_sfc(
+        &ctx.content,
+        SfcParseOptions {
+            filename: ctx.uri.path().to_string().into(),
+            ..Default::default()
+        },
+    )
+    .ok()?;
+
+    let croquis_options = SfcCroquisOptions::full();
+    let analysis = if legacy_vue2 {
+        analyze_sfc_descriptor_with_context_legacy_vue2(&descriptor, None, croquis_options)
+    } else {
+        analyze_sfc_descriptor_with_context(&descriptor, None, croquis_options)
+    };
+    let &(start, end) = analysis.croquis.binding_spans.get(word)?;
+    if end <= start {
+        return None;
+    }
+
+    let offset = analysis.script_offset as usize + start as usize;
+    Some(location_from_sfc_offset(
+        ctx,
+        offset,
+        (end - start) as usize,
+    ))
+}
+
+pub(crate) fn location_from_sfc_offset(ctx: &IdeContext, offset: usize, len: usize) -> Location {
+    let (line, character) = helpers::offset_to_position(&ctx.content, offset);
+
+    Location {
+        uri: ctx.uri.clone(),
+        range: Range {
+            start: Position { line, character },
+            end: Position {
+                line,
+                character: character + len as u32,
+            },
+        },
+    }
 }
 
 /// Find definition for a symbol in style context.

--- a/crates/vize_maestro/src/ide/definition/template.rs
+++ b/crates/vize_maestro/src/ide/definition/template.rs
@@ -46,6 +46,12 @@ pub(crate) fn definition_in_template(ctx: &IdeContext) -> Option<GotoDefinitionR
         return Some(def);
     }
 
+    if ctx.state.lsp_features().legacy_vue2
+        && let Some(location) = super::script::find_analyzed_binding_location(ctx, &word, true)
+    {
+        return Some(GotoDefinitionResponse::Scalar(location));
+    }
+
     // Parse SFC to get the actual script content (not virtual code)
     let options = vize_atelier_sfc::SfcParseOptions {
         filename: ctx.uri.path().to_string().into(),
@@ -442,6 +448,37 @@ pub(crate) fn find_component_prop_definition(
                     end: Position {
                         line,
                         character: character + "defineProps".len() as u32,
+                    },
+                },
+            }));
+        }
+    }
+
+    if ctx.state.lsp_features().legacy_vue2 {
+        use vize_atelier_sfc::croquis::{
+            SfcCroquisOptions, analyze_sfc_descriptor_with_context_legacy_vue2,
+        };
+
+        let analysis = analyze_sfc_descriptor_with_context_legacy_vue2(
+            &descriptor,
+            None,
+            SfcCroquisOptions::full(),
+        );
+        if let Some(&(start, end)) = analysis.croquis.binding_spans.get(prop_name.as_str())
+            && end > start
+        {
+            let sfc_offset = analysis.script_offset + start;
+            let (line, character) =
+                helpers::offset_to_position(&component_content, sfc_offset as usize);
+
+            let file_uri = tower_lsp::lsp_types::Url::from_file_path(&resolved_path).ok()?;
+            return Some(GotoDefinitionResponse::Scalar(Location {
+                uri: file_uri,
+                range: Range {
+                    start: Position { line, character },
+                    end: Position {
+                        line,
+                        character: character + (end - start),
                     },
                 },
             }));

--- a/crates/vize_maestro/src/ide/diagnostics/corsa.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/corsa.rs
@@ -44,10 +44,11 @@ impl DiagnosticService {
 
         // Generate virtual TypeScript
         let is_art_file = uri.path().ends_with(".art.vue");
+        let legacy_vue2 = state.legacy_vue2_enabled();
         let virtual_result = if is_art_file {
             Self::generate_virtual_ts_for_art(uri, &content)
         } else {
-            Self::generate_virtual_ts(uri, &content)
+            Self::generate_virtual_ts(uri, &content, legacy_vue2)
         };
         let Some(virtual_result) = virtual_result else {
             tracing::warn!("failed to generate virtual ts for {}", uri);
@@ -263,10 +264,23 @@ impl DiagnosticService {
     }
 
     /// Generate virtual TypeScript for a Vue SFC.
-    pub(super) fn generate_virtual_ts(uri: &Url, content: &str) -> Option<VirtualTsResult> {
-        use vize_atelier_sfc::{SfcParseOptions, parse_sfc};
-        use vize_canon::virtual_ts::{VirtualTsOptions, generate_virtual_ts_with_offsets};
-        use vize_croquis::{Analyzer, AnalyzerOptions};
+    pub(super) fn generate_virtual_ts(
+        uri: &Url,
+        content: &str,
+        legacy_vue2: bool,
+    ) -> Option<VirtualTsResult> {
+        use vize_atelier_sfc::{
+            SfcParseOptions,
+            croquis::{
+                SfcCroquisOptions, analyze_sfc_descriptor_with_context,
+                analyze_sfc_descriptor_with_context_legacy_vue2,
+            },
+            parse_sfc,
+        };
+        use vize_canon::virtual_ts::{
+            VirtualTsOptions, generate_virtual_ts_with_offsets,
+            generate_virtual_ts_with_offsets_legacy_vue2,
+        };
 
         let options = SfcParseOptions {
             filename: uri.path().to_string().into(),
@@ -275,52 +289,47 @@ impl DiagnosticService {
 
         let descriptor = parse_sfc(content, options).ok()?;
 
-        // Get script block info
-        let (script_content, script_offset, sfc_script_start_line) = descriptor
-            .script_setup
-            .as_ref()
-            .map(|s| {
-                (
-                    s.content.as_ref(),
-                    s.loc.start as u32,
-                    s.loc.start_line as u32,
-                )
-            })
-            .or_else(|| {
-                descriptor.script.as_ref().map(|s| {
-                    (
-                        s.content.as_ref(),
-                        s.loc.start as u32,
-                        s.loc.start_line as u32,
-                    )
-                })
-            })?;
-
         let template_block = descriptor.template.as_ref()?;
         let template_offset = template_block.loc.start as u32;
 
         let allocator = vize_carton::Bump::new();
         let (template_ast, _) = vize_armature::parse(&allocator, &template_block.content);
 
-        let mut analyzer = Analyzer::with_options(AnalyzerOptions::full());
-        analyzer.analyze_script(script_content);
-        analyzer.analyze_template(&template_ast);
+        let croquis_options = SfcCroquisOptions::full();
+        let analysis = if legacy_vue2 {
+            analyze_sfc_descriptor_with_context_legacy_vue2(
+                &descriptor,
+                Some(&template_ast),
+                croquis_options,
+            )
+        } else {
+            analyze_sfc_descriptor_with_context(&descriptor, Some(&template_ast), croquis_options)
+        };
+        let script_content = analysis.script_content?;
+        let script_offset = analysis.script_offset;
+        let sfc_script_start_line =
+            crate::ide::offset_to_position(content, script_offset as usize).0 + 1;
 
-        let summary = analyzer.finish();
-        let output = generate_virtual_ts_with_offsets(
-            &summary,
-            Some(script_content),
+        let virtual_ts_options = VirtualTsOptions::default();
+        let generate_virtual_ts = if legacy_vue2 {
+            generate_virtual_ts_with_offsets_legacy_vue2
+        } else {
+            generate_virtual_ts_with_offsets
+        };
+        let output = generate_virtual_ts(
+            &analysis.croquis,
+            Some(script_content.as_str()),
             Some(&template_ast),
             script_offset,
             template_offset,
-            &VirtualTsOptions::default(),
+            &virtual_ts_options,
         );
         let code = output.code;
         let source_mappings = output.mappings;
 
         // Count import lines in script content (these are moved to module scope)
         // Import lines are skipped from user setup code section
-        let skipped_import_lines = Self::count_import_lines(script_content);
+        let skipped_import_lines = Self::count_import_lines(script_content.as_str());
 
         // Find where user code starts in generated virtual TS
         // Look for "// User setup code" comment

--- a/crates/vize_maestro/src/ide/hover/script.rs
+++ b/crates/vize_maestro/src/ide/hover/script.rs
@@ -134,12 +134,17 @@ impl HoverService {
             .or_else(|| descriptor.script.as_ref().map(|s| s.content.as_ref()));
 
         // Create analyzer and analyze script
-        let mut analyzer = Analyzer::with_options(AnalyzerOptions::full());
+        let analyzer_options = AnalyzerOptions::full();
+        let mut analyzer = Analyzer::with_options(analyzer_options);
+        if ctx.state.lsp_features().legacy_vue2 {
+            analyzer = analyzer.with_legacy_vue2();
+        }
 
+        if let Some(ref script) = descriptor.script {
+            analyzer.analyze_script_plain(&script.content);
+        }
         if let Some(ref script_setup) = descriptor.script_setup {
             analyzer.analyze_script_setup(&script_setup.content);
-        } else if let Some(ref script) = descriptor.script {
-            analyzer.analyze_script_plain(&script.content);
         }
 
         let summary = analyzer.finish();

--- a/crates/vize_maestro/src/ide/hover/template.rs
+++ b/crates/vize_maestro/src/ide/hover/template.rs
@@ -10,6 +10,7 @@
 
 use tower_lsp::lsp_types::Hover;
 use vize_croquis::{Analyzer, AnalyzerOptions};
+use vize_relief::BindingType;
 
 #[cfg(feature = "native")]
 use std::sync::Arc;
@@ -166,12 +167,17 @@ impl HoverService {
             .or_else(|| descriptor.script.as_ref().map(|s| s.content.as_ref()));
 
         // Create analyzer and analyze script
-        let mut analyzer = Analyzer::with_options(AnalyzerOptions::full());
+        let analyzer_options = AnalyzerOptions::full();
+        let mut analyzer = Analyzer::with_options(analyzer_options);
+        if ctx.state.lsp_features().legacy_vue2 {
+            analyzer = analyzer.with_legacy_vue2();
+        }
 
+        if let Some(ref script) = descriptor.script {
+            analyzer.analyze_script_plain(&script.content);
+        }
         if let Some(ref script_setup) = descriptor.script_setup {
             analyzer.analyze_script_setup(&script_setup.content);
-        } else if let Some(ref script) = descriptor.script {
-            analyzer.analyze_script_plain(&script.content);
         }
 
         // Analyze template if present
@@ -193,6 +199,25 @@ impl HoverService {
 
         // Format the hover content
         let kind_desc = Self::binding_type_to_description(binding_type);
+        let source = if matches!(
+            binding_type,
+            BindingType::Data | BindingType::Options | BindingType::VueGlobal
+        ) {
+            "`<script>`"
+        } else if descriptor.script_setup.is_some() {
+            "`<script setup>`"
+        } else {
+            "`<script>`"
+        };
+        let resolved_from = if descriptor.script_setup.is_some()
+            && !matches!(
+                binding_type,
+                BindingType::Data | BindingType::Options | BindingType::VueGlobal
+            ) {
+            "The binding is resolved from `<script setup>` analysis."
+        } else {
+            "The binding is resolved from `<script>` analysis."
+        };
 
         #[allow(clippy::disallowed_macros)]
         let signature = format!("{word}: {inferred_type}");
@@ -203,11 +228,12 @@ impl HoverService {
                 .meta("Template binding from script")
                 .code("typescript", &signature)
                 .description(kind_desc)
+                .section("Source", source)
                 .bullets(
                     "Template behavior",
                     &[
                         "Ref values are automatically unwrapped in templates.",
-                        "The binding is resolved from `<script setup>` analysis.",
+                        resolved_from,
                     ],
                 )
                 .build(),

--- a/crates/vize_maestro/src/ide/references/script.rs
+++ b/crates/vize_maestro/src/ide/references/script.rs
@@ -14,6 +14,13 @@ impl ReferencesService {
         let options = vize_atelier_sfc::SfcParseOptions::default();
         let descriptor = vize_atelier_sfc::parse_sfc(&ctx.content, options).ok()?;
 
+        if ctx.state.lsp_features().legacy_vue2
+            && let Some(location) =
+                crate::ide::definition::script::find_analyzed_binding_location(ctx, word, true)
+        {
+            return Some(location);
+        }
+
         if let Some(ref script_setup) = descriptor.script_setup
             && let Some(loc) = Self::find_binding_in_script(&script_setup.content, word)
         {

--- a/crates/vize_maestro/src/ide/type_service.rs
+++ b/crates/vize_maestro/src/ide/type_service.rs
@@ -43,6 +43,8 @@ pub struct LspTypeCheckOptions {
     pub check_invalid_exports: bool,
     /// Check fallthrough attrs with multi-root
     pub check_fallthrough_attrs: bool,
+    /// Include Vue 2.7 / Nuxt 2 Options API template bindings.
+    pub legacy_vue2: bool,
 }
 
 impl Default for LspTypeCheckOptions {
@@ -56,6 +58,7 @@ impl Default for LspTypeCheckOptions {
             check_setup_context: true,
             check_invalid_exports: true,
             check_fallthrough_attrs: true,
+            legacy_vue2: false,
         }
     }
 }

--- a/crates/vize_maestro/src/ide/type_service/diagnostics.rs
+++ b/crates/vize_maestro/src/ide/type_service/diagnostics.rs
@@ -11,6 +11,7 @@ use tower_lsp::lsp_types::{
 };
 use vize_canon::{
     SfcTypeCheckOptions as TypeCheckOptions, SfcTypeSeverity as TypeSeverity, type_check_sfc,
+    type_check_sfc_with_legacy_vue2,
 };
 
 use super::{LspTypeCheckOptions, TypeService};
@@ -32,6 +33,7 @@ impl TypeService {
                 check_setup_context: cfg.check_setup_context,
                 check_invalid_exports: cfg.check_invalid_exports,
                 check_fallthrough_attrs: cfg.check_fallthrough_attrs,
+                legacy_vue2: state.legacy_vue2_enabled(),
             },
         )
     }
@@ -62,7 +64,11 @@ impl TypeService {
             include_virtual_ts: false,
         };
 
-        let result = type_check_sfc(&content, &options);
+        let result = if lsp_options.legacy_vue2 {
+            type_check_sfc_with_legacy_vue2(&content, &options)
+        } else {
+            type_check_sfc(&content, &options)
+        };
 
         // Convert to LSP diagnostics
         result

--- a/crates/vize_maestro/src/server/capabilities.rs
+++ b/crates/vize_maestro/src/server/capabilities.rs
@@ -226,6 +226,7 @@ mod tests {
             lint: true,
             typecheck: true,
             ecosystem: true,
+            legacy_vue2: true,
             completion: true,
             hover: true,
             definition: true,

--- a/crates/vize_maestro/src/server/state.rs
+++ b/crates/vize_maestro/src/server/state.rs
@@ -38,6 +38,7 @@ struct LspConfigSection {
     typecheck: Option<bool>,
     editor: Option<bool>,
     ecosystem: Option<bool>,
+    legacy_vue2: Option<bool>,
     completion: Option<bool>,
     hover: Option<bool>,
     definition: Option<bool>,
@@ -88,6 +89,10 @@ impl LspConfigSection {
 
         if let Some(enabled) = self.ecosystem {
             features.ecosystem = enabled;
+        }
+
+        if let Some(enabled) = self.legacy_vue2 {
+            features.legacy_vue2 = enabled;
         }
 
         if let Some(enabled) = self.completion {
@@ -147,6 +152,7 @@ impl From<LanguageServerConfig> for LspConfigSection {
             typecheck: config.typecheck,
             editor: config.editor,
             ecosystem: config.ecosystem,
+            legacy_vue2: None,
             completion: config.completion,
             hover: config.hover,
             definition: config.definition,
@@ -177,6 +183,7 @@ pub struct LspFeatureConfig {
     pub(crate) lint: bool,
     pub(crate) typecheck: bool,
     pub(crate) ecosystem: bool,
+    pub(crate) legacy_vue2: bool,
     pub(crate) completion: bool,
     pub(crate) hover: bool,
     pub(crate) definition: bool,
@@ -200,6 +207,7 @@ impl LspFeatureConfig {
             lint: false,
             typecheck: false,
             ecosystem: false,
+            legacy_vue2: false,
             completion: false,
             hover: false,
             definition: false,
@@ -246,6 +254,7 @@ impl Default for LspFeatureConfig {
             lint: true,
             typecheck: true,
             ecosystem: true,
+            legacy_vue2: false,
             completion: true,
             hover: true,
             definition: true,
@@ -335,6 +344,8 @@ pub struct ServerState {
     lsp_typecheck_enabled: AtomicBool,
     /// Type checker options shared by LSP diagnostics.
     type_checker_config: RwLock<TypeCheckerConfig>,
+    /// Vue 2.7 / Nuxt 2 type checker compatibility flag from config.
+    type_checker_legacy_vue2: RwLock<bool>,
     /// Linter options shared by LSP diagnostics.
     linter_config: RwLock<LinterConfig>,
     /// Formatting options (loaded from vize.config.json)
@@ -377,6 +388,7 @@ impl ServerState {
             lsp_features: RwLock::new(default_features),
             lsp_typecheck_enabled: AtomicBool::new(default_features.typecheck),
             type_checker_config: RwLock::new(TypeCheckerConfig::default()),
+            type_checker_legacy_vue2: RwLock::new(false),
             linter_config: RwLock::new(LinterConfig::default()),
             #[cfg(feature = "glyph")]
             format_options: RwLock::new(vize_glyph::FormatOptions::default()),
@@ -413,6 +425,11 @@ impl ServerState {
     #[inline]
     pub(crate) fn lsp_features(&self) -> LspFeatureConfig {
         *self.lsp_features.read()
+    }
+
+    #[inline]
+    pub(crate) fn legacy_vue2_enabled(&self) -> bool {
+        *self.type_checker_legacy_vue2.read() || self.lsp_features().legacy_vue2
     }
 
     /// Check whether LSP lint diagnostics are enabled.
@@ -455,6 +472,14 @@ impl ServerState {
         tracing::info!("Loaded type checker config from {}", source);
     }
 
+    fn apply_config_features(&self, features: vize_carton::config::ConfigFeatureFlags) {
+        *self.type_checker_legacy_vue2.write() = features.type_checker_legacy_vue2;
+        if let Some(enabled) = features.language_server_legacy_vue2 {
+            let mut lsp_features = self.lsp_features.write();
+            lsp_features.legacy_vue2 = enabled;
+        }
+    }
+
     fn apply_linter_config(&self, config: LinterConfig, source: &str) {
         *self.linter_config.write() = config;
         tracing::info!("Loaded linter config from {}", source);
@@ -471,7 +496,7 @@ impl ServerState {
     /// Load all workspace-scoped options from `vize.config.pkl` (preferred) or JSON.
     pub fn load_workspace_config(&self, dir: &Path) {
         let (loaded, linter_config) =
-            vize_carton::config::load_config_and_linter_with_source(Some(dir));
+            vize_carton::config::load_config_and_linter_with_features_and_source(Some(dir));
         if let Some(source_path) = loaded.source_path {
             let source = source_path.display().to_string();
             let config = loaded.config;
@@ -483,18 +508,20 @@ impl ServerState {
             self.apply_linter_config(linter_config, &source);
             self.apply_type_checker_config(config.type_checker, &source);
             self.apply_lsp_config(config.language_server.into(), &source);
+            self.apply_config_features(loaded.features);
         }
     }
 
     /// Load LSP options from `vize.config.pkl` (preferred) or `vize.config.json`.
     pub fn load_lsp_config(&self, dir: &Path) {
         let (loaded, linter_config) =
-            vize_carton::config::load_config_and_linter_with_source(Some(dir));
+            vize_carton::config::load_config_and_linter_with_features_and_source(Some(dir));
         if let Some(source_path) = loaded.source_path {
             let source = source_path.display().to_string();
             self.apply_linter_config(linter_config, &source);
             self.apply_type_checker_config(loaded.config.type_checker, &source);
             self.apply_lsp_config(loaded.config.language_server.into(), &source);
+            self.apply_config_features(loaded.features);
         }
     }
 
@@ -523,7 +550,7 @@ impl ServerState {
         let corsa_path = config.runtime_path().map(PathBuf::from);
         let options = BatchTypeCheckerOptions {
             tsconfig_path: config.tsconfig.as_ref().map(PathBuf::from),
-            ..Default::default()
+            virtual_ts_options: vize_canon::virtual_ts::VirtualTsOptions::default(),
         };
 
         match BatchTypeChecker::with_options_and_corsa_path(
@@ -531,7 +558,10 @@ impl ServerState {
             options,
             corsa_path.as_deref(),
         ) {
-            Ok(checker) => {
+            Ok(mut checker) => {
+                if self.legacy_vue2_enabled() {
+                    checker.enable_legacy_vue2();
+                }
                 let arc = Arc::new(RwLock::new(checker));
                 // get_or_init to handle race condition
                 Some(self.batch_checker.get_or_init(|| arc.clone()).clone())

--- a/crates/vize_vitrine/src/lib.rs
+++ b/crates/vize_vitrine/src/lib.rs
@@ -15,6 +15,6 @@ pub mod types;
 
 pub use typecheck::{
     RelatedLocation, TypeCheckOptions, TypeCheckResult, TypeDiagnostic, TypeSeverity,
-    type_check_sfc,
+    type_check_sfc, type_check_sfc_with_legacy_vue2,
 };
 pub use types::*;

--- a/crates/vize_vitrine/src/napi_typecheck.rs
+++ b/crates/vize_vitrine/src/napi_typecheck.rs
@@ -10,7 +10,9 @@
 use napi::bindgen_prelude::*;
 use napi_derive::napi;
 
-use crate::typecheck::{TypeCheckOptions, TypeSeverity, type_check_sfc};
+use crate::typecheck::{
+    TypeCheckOptions, TypeSeverity, type_check_sfc, type_check_sfc_with_legacy_vue2,
+};
 
 /// Type check options for NAPI
 #[napi(object)]
@@ -26,6 +28,7 @@ pub struct TypeCheckOptionsNapi {
     pub check_setup_context: Option<bool>,
     pub check_invalid_exports: Option<bool>,
     pub check_fallthrough_attrs: Option<bool>,
+    pub legacy_vue2: Option<bool>,
 }
 
 /// Related location for diagnostic (NAPI)
@@ -88,7 +91,11 @@ pub fn type_check_napi(
     let mut check_opts = TypeCheckOptions::new(filename);
     apply_napi_options(&opts, &mut check_opts);
 
-    let result = type_check_sfc(&source, &check_opts);
+    let result = if opts.legacy_vue2.unwrap_or(false) {
+        type_check_sfc_with_legacy_vue2(&source, &check_opts)
+    } else {
+        type_check_sfc(&source, &check_opts)
+    };
 
     Ok(TypeCheckResultNapi {
         diagnostics: result
@@ -348,7 +355,11 @@ pub fn type_check_batch_napi(
         apply_napi_options(&opts, &mut check_opts);
         check_opts.include_virtual_ts = false; // Don't generate virtual TS for batch
 
-        let result = type_check_sfc(&source, &check_opts);
+        let result = if opts.legacy_vue2.unwrap_or(false) {
+            type_check_sfc_with_legacy_vue2(&source, &check_opts)
+        } else {
+            type_check_sfc(&source, &check_opts)
+        };
 
         files_checked.fetch_add(1, Ordering::Relaxed);
         if result.error_count > 0 {

--- a/crates/vize_vitrine/src/typecheck.rs
+++ b/crates/vize_vitrine/src/typecheck.rs
@@ -20,7 +20,7 @@
 // Re-export from canon for backwards compatibility
 pub use vize_canon::{
     SfcRelatedLocation, SfcTypeCheckOptions, SfcTypeCheckResult, SfcTypeDiagnostic,
-    SfcTypeSeverity, type_check_sfc,
+    SfcTypeSeverity, type_check_sfc, type_check_sfc_with_legacy_vue2,
 };
 
 // Type aliases for backwards compatibility

--- a/crates/vize_vitrine/src/wasm_typecheck.rs
+++ b/crates/vize_vitrine/src/wasm_typecheck.rs
@@ -9,7 +9,7 @@
 
 use wasm_bindgen::prelude::*;
 
-use crate::typecheck::{TypeCheckOptions, type_check_sfc};
+use crate::typecheck::{TypeCheckOptions, type_check_sfc, type_check_sfc_with_legacy_vue2};
 
 /// Helper function to serialize values to JsValue with maps as objects
 fn to_js_value<T: serde::Serialize>(value: &T) -> Result<JsValue, JsValue> {
@@ -59,6 +59,10 @@ pub fn type_check_wasm(source: &str, options: JsValue) -> Result<JsValue, JsValu
             .ok()
             .and_then(|v| v.as_bool())
             .unwrap_or(true);
+    let legacy_vue2 = js_sys::Reflect::get(&options, &JsValue::from_str("legacyVue2"))
+        .ok()
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
 
     let mut opts = TypeCheckOptions::new(filename);
     opts.strict = strict;
@@ -67,7 +71,11 @@ pub fn type_check_wasm(source: &str, options: JsValue) -> Result<JsValue, JsValu
     opts.check_emits = check_emits;
     opts.check_template_bindings = check_template_bindings;
 
-    let result = type_check_sfc(source, &opts);
+    let result = if legacy_vue2 {
+        type_check_sfc_with_legacy_vue2(source, &opts)
+    } else {
+        type_check_sfc(source, &opts)
+    };
 
     // Convert to JSON-friendly format
     let output = serde_json::json!({

--- a/npm/vize-native/types/typecheck.d.ts
+++ b/npm/vize-native/types/typecheck.d.ts
@@ -55,6 +55,7 @@ export interface TypeCheckOptionsNapi {
   checkSetupContext?: boolean;
   checkInvalidExports?: boolean;
   checkFallthroughAttrs?: boolean;
+  legacyVue2?: boolean;
 }
 
 /** Type check result for NAPI */

--- a/npm/vize/pkl/LanguageServerConfig.pkl
+++ b/npm/vize/pkl/LanguageServerConfig.pkl
@@ -17,6 +17,9 @@ class LanguageServerConfig {
   /// Enable editor-oriented IDE features.
   editor: Boolean? = null
 
+  /// Enable Vue 2.7 / Nuxt 2 editor and type-checking compatibility.
+  legacyVue2: Boolean? = null
+
   /// Enable completions.
   completion: Boolean? = null
 

--- a/npm/vize/pkl/TypeCheckerConfig.pkl
+++ b/npm/vize/pkl/TypeCheckerConfig.pkl
@@ -29,6 +29,9 @@ class TypeCheckerConfig {
   /// Check fallthrough attrs on multi-root templates.
   checkFallthroughAttrs: Boolean = true
 
+  /// Enable Vue 2.7 / Nuxt 2 Options API template binding support.
+  legacyVue2: Boolean = false
+
   /// Path to tsconfig.json.
   tsconfig: String? = null
 

--- a/npm/vize/pkl/jsonschema/generate.pkl
+++ b/npm/vize/pkl/jsonschema/generate.pkl
@@ -220,6 +220,11 @@ local typeCheckerConfigDef: JsonSchema = new JsonSchema {
       description = "Check fallthrough attrs on multi-root templates"
       default = true
     }
+    ["legacyVue2"] = new JsonSchema {
+      type = "boolean"
+      description = "Enable Vue 2.7 / Nuxt 2 Options API template binding support"
+      default = false
+    }
     ["tsconfig"] = new JsonSchema {
       type = "string"
       description = "Path to tsconfig.json"
@@ -391,6 +396,10 @@ local languageServerConfigDef: JsonSchema = new JsonSchema {
     ["ecosystem"] = new JsonSchema {
       type = "boolean"
       description = "Enable Vue ecosystem lint and editor helpers"
+    }
+    ["legacyVue2"] = new JsonSchema {
+      type = "boolean"
+      description = "Enable Vue 2.7 / Nuxt 2 editor and type-checking compatibility"
     }
     ["completion"] = new JsonSchema {
       type = "boolean"

--- a/npm/vize/pkl/vize.pkl
+++ b/npm/vize/pkl/vize.pkl
@@ -58,6 +58,7 @@ class TypeCheckerConfig {
   checkSetupContext: Boolean? = null
   checkInvalidExports: Boolean? = null
   checkFallthroughAttrs: Boolean? = null
+  legacyVue2: Boolean? = null
   tsconfig: String? = null
   corsaPath: String? = null
   tsgoPath: String? = null
@@ -82,6 +83,7 @@ class LspConfig {
   typecheck: Boolean? = null
   editor: Boolean? = null
   ecosystem: Boolean? = null
+  legacyVue2: Boolean? = null
   completion: Boolean? = null
   hover: Boolean? = null
   definition: Boolean? = null

--- a/npm/vize/schemas/vize.config.schema.json
+++ b/npm/vize/schemas/vize.config.schema.json
@@ -223,6 +223,11 @@
           "default": true,
           "type": "boolean"
         },
+        "legacyVue2": {
+          "description": "Enable Vue 2.7 / Nuxt 2 Options API template binding support",
+          "default": false,
+          "type": "boolean"
+        },
         "tsconfig": {
           "description": "Path to tsconfig.json",
           "type": "string"
@@ -393,6 +398,10 @@
         },
         "ecosystem": {
           "description": "Enable Vue ecosystem lint and editor helpers",
+          "type": "boolean"
+        },
+        "legacyVue2": {
+          "description": "Enable Vue 2.7 / Nuxt 2 editor and type-checking compatibility",
           "type": "boolean"
         },
         "completion": {

--- a/npm/vize/src/types/generated.ts
+++ b/npm/vize/src/types/generated.ts
@@ -200,6 +200,10 @@ export interface TypeCheckerConfig {
    */
   checkFallthroughAttrs?: boolean;
   /**
+   * Enable Vue 2.7 / Nuxt 2 Options API template binding support
+   */
+  legacyVue2?: boolean;
+  /**
    * Path to tsconfig.json
    */
   tsconfig?: string;
@@ -337,6 +341,10 @@ export interface LanguageServerConfig {
    * Enable Vue ecosystem lint and editor helpers
    */
   ecosystem?: boolean;
+  /**
+   * Enable Vue 2.7 / Nuxt 2 editor and type-checking compatibility
+   */
+  legacyVue2?: boolean;
   /**
    * Enable completions
    */

--- a/npm/vscode-vize/README.md
+++ b/npm/vscode-vize/README.md
@@ -89,6 +89,9 @@ individual switches, make sure to include `vize.completion.enable`, `vize.hover.
 diagnostics for `useRoute()`, Vue I18n key completions, workspace key validation, inlay previews,
 Void Vue route completions, and ecosystem lint diagnostics.
 
+Vue 2.7 / Nuxt 2 support is opt-in. Set `vize.legacyVue2.enable: true` to include Options API
+template bindings and Nuxt 2 globals in type checking, completion, hover, definition, and references.
+
 When paired with the `Vize Art` extension, the same editor capabilities also apply to `*.art.vue`
 documents.
 

--- a/npm/vscode-vize/package.json
+++ b/npm/vscode-vize/package.json
@@ -158,6 +158,11 @@
           "default": true,
           "description": "Enable Vue ecosystem diagnostics and editor helpers for Vue Router route names and file-route params, Vue I18n catalogs, Nuxt, and Void Vue."
         },
+        "vize.legacyVue2.enable": {
+          "type": "boolean",
+          "default": false,
+          "description": "Enable opt-in Vue 2.7 / Nuxt 2 template, typecheck, completion, hover, navigation, and reference helpers."
+        },
         "vize.diagnostics.enable": {
           "type": "boolean",
           "default": false,

--- a/npm/vscode-vize/src/extension.ts
+++ b/npm/vscode-vize/src/extension.ts
@@ -88,6 +88,7 @@ const FEATURE_SETTING_KEYS = [
   "typecheck.enable",
   "editor.enable",
   "ecosystem.enable",
+  "legacyVue2.enable",
   "completion.enable",
   "hover.enable",
   "definition.enable",
@@ -108,6 +109,7 @@ const CAPABILITY_LABELS: Record<string, string> = {
   lint: "lint",
   typecheck: "type check",
   editor: "editor bundle",
+  legacyVue2: "Vue 2.7 / Nuxt 2",
   completion: "completion",
   hover: "hover",
   definition: "definition",
@@ -706,6 +708,7 @@ function getInitializationOptions(
   setFeatureOption(options, config, "typecheck.enable", "typecheck", true);
   setFeatureOption(options, config, "editor.enable", "editor", true);
   setFeatureOption(options, config, "ecosystem.enable", "ecosystem", true);
+  setFeatureOption(options, config, "legacyVue2.enable", "legacyVue2", false);
   setFeatureOption(options, config, "completion.enable", "completion", true);
   setFeatureOption(options, config, "hover.enable", "hover", true);
   setFeatureOption(options, config, "definition.enable", "definition", true);

--- a/playground/src/wasm/types/analysis.ts
+++ b/playground/src/wasm/types/analysis.ts
@@ -8,6 +8,7 @@ export interface TypeCheckOptions {
   checkProps?: boolean;
   checkEmits?: boolean;
   checkTemplateBindings?: boolean;
+  legacyVue2?: boolean;
 }
 
 export interface TypeCheckRelatedLocation {

--- a/tools/vscode-vize/assert-vsix-package.mjs
+++ b/tools/vscode-vize/assert-vsix-package.mjs
@@ -150,7 +150,11 @@ for (const [key, property] of Object.entries(configurationProperties)) {
     continue;
   }
   const expectedDefault =
-    key === "vize.diagnostics.enable" || key === "vize.formatting.enable" ? false : true;
+    key === "vize.diagnostics.enable" ||
+    key === "vize.formatting.enable" ||
+    key === "vize.legacyVue2.enable"
+      ? false
+      : true;
   assert.equal(property.default, expectedDefault, `${key} has an unexpected default`);
 }
 


### PR DESCRIPTION
## Summary

- Add an opt-in `legacyVue2` mode for Vue 2.7 / Nuxt 2 projects.
- Extract Options API template bindings from `props`, `data`, `asyncData`, `computed`, `methods`, `inject`, and `setup` return values.
- Wire the mode through type checking, virtual TypeScript generation, LSP completion, hover, definition, references, config schemas, VS Code settings, NAPI, and WASM types.
- Add Nuxt 2 template globals such as `$route`, `$router`, `$store`, `$config`, `$fetchState`, and `$nuxt`.

## Validation

- `cargo test -p vize_croquis test_parse_legacy_vue2_options_api_template_bindings`
- `cargo test -p vize_canon test_type_check_legacy_vue2_options_api_opt_in`
- `cargo check -p vize_maestro`
- `cargo check -p vize`
- `corepack pnpm --filter ./npm/vize run check`
- `corepack pnpm run check` in `npm/vscode-vize`
- `git diff --check`