### PR TITLE
fix: improve playground contrast

### DIFF
--- a/playground/src/features/canon/TypeCheckPlayground.css
+++ b/playground/src/features/canon/TypeCheckPlayground.css
@@ -352,74 +352,76 @@
 
 .help-content .help-code {
   margin: 0.5rem 0;
-  padding: 0.75rem;
-  background: rgba(0, 0, 0, 0.3);
-  border-radius: 4px;
+  padding: 1rem 1.125rem;
+  background: var(--code-bg);
+  border: 1px solid var(--code-border);
+  border-radius: 6px;
   overflow-x: auto;
   font-family: "JetBrains Mono", "Fira Code", monospace;
-  font-size: 0.8rem;
-  line-height: 1.5;
+  font-size: 0.8125rem;
+  line-height: 1.55;
 }
 
 .help-content .help-code code {
-  color: #a5d6ff;
+  color: var(--code-foreground);
   background: none;
   padding: 0;
 }
 
 .help-content .help-inline-code {
-  background: rgba(110, 118, 129, 0.3);
-  padding: 0.15rem 0.4rem;
+  background: var(--code-bg);
+  border: 1px solid var(--code-border);
+  padding: 0.18rem 0.42rem;
   border-radius: 3px;
   font-family: "JetBrains Mono", "Fira Code", monospace;
   font-size: 0.85em;
-  color: #ff7b72;
+  color: var(--hl-keyword);
 }
 
 /* Syntax highlighting colors */
 .help-content .hl-keyword {
-  color: #ff7b72;
+  color: var(--hl-keyword);
 }
 
 .help-content .hl-vue-api {
-  color: #7ee787;
+  color: var(--hl-function);
 }
 
 .help-content .hl-string {
-  color: #a5d6ff;
+  color: var(--hl-string);
 }
 
 .help-content .hl-comment {
-  color: #8b949e;
+  color: var(--hl-comment);
   font-style: italic;
 }
 
 .help-content .hl-tag {
-  color: #7ee787;
+  color: var(--hl-tag);
 }
 
 .help-content .hl-directive {
-  color: #d2a8ff;
+  color: var(--hl-directive);
 }
 
 .help-content .hl-delimiter {
-  color: #ffa657;
+  color: var(--hl-delimiter);
 }
 
 .help-content .hl-type {
-  color: #79c0ff;
+  color: var(--hl-type);
 }
 
 .help-content .hl-number {
-  color: #79c0ff;
+  color: var(--hl-number);
 }
 
 .help-content .hl-property {
-  color: #79c0ff;
+  color: var(--hl-property);
 }
 
 .help-content .hl-value {
-  color: #a5d6ff;
+  color: var(--hl-value);
 }
 
 .severity-error .severity-icon {

--- a/playground/src/features/musea/MuseaPlayground.css
+++ b/playground/src/features/musea/MuseaPlayground.css
@@ -146,16 +146,16 @@
 
 /* Error State */
 .error-panel {
-  background: rgba(239, 68, 68, 0.1);
-  border: 1px solid rgba(239, 68, 68, 0.3);
+  background: var(--color-error-bg);
+  border: 1px solid var(--color-error-border);
   border-radius: 6px;
   overflow: hidden;
 }
 
 .error-header {
   padding: 0.5rem 0.75rem;
-  background: rgba(239, 68, 68, 0.15);
-  color: #f87171;
+  background: var(--color-error-bg);
+  color: var(--color-error);
   font-size: 0.75rem;
   font-weight: 600;
 }
@@ -163,7 +163,7 @@
 .error-content {
   padding: 0.75rem;
   font-size: 0.75rem;
-  color: #fca5a5;
+  color: var(--color-error);
   margin: 0;
   white-space: pre-wrap;
   word-break: break-word;
@@ -197,7 +197,8 @@
 .file-badge {
   font-size: 0.5625rem;
   padding: 0.125rem 0.375rem;
-  background: rgba(255, 255, 255, 0.1);
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-primary);
   color: var(--text-muted);
   border-radius: 2px;
   text-transform: uppercase;
@@ -244,14 +245,15 @@
 .meta-code {
   font-size: 0.75rem;
   font-family: "JetBrains Mono", monospace;
-  color: #60a5fa;
+  color: var(--color-info);
   background: var(--bg-tertiary);
+  border: 1px solid var(--border-primary);
   padding: 0.125rem 0.375rem;
   border-radius: 3px;
 }
 
 .category-value {
-  color: #a78bfa;
+  color: var(--color-purple);
 }
 
 .tags-list {
@@ -269,25 +271,50 @@
 }
 
 .status-badge {
+  --status-color: var(--text-secondary);
+  --status-bg: var(--bg-tertiary);
+  --status-border: var(--border-primary);
+
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
   font-size: 0.6875rem;
-  padding: 0.125rem 0.5rem;
-  border-radius: 3px;
+  font-weight: 600;
+  line-height: 1;
+  padding: 0.25rem 0.5rem;
+  border: 1px solid var(--status-border);
+  border-radius: 999px;
+  background: var(--status-bg);
+  color: var(--status-color);
   text-transform: capitalize;
 }
 
+.status-badge::before {
+  content: "";
+  width: 0.375rem;
+  height: 0.375rem;
+  border-radius: 999px;
+  background: currentColor;
+  box-shadow: 0 0 0 2px var(--status-bg);
+  flex-shrink: 0;
+}
+
 .status-badge.ready {
-  background: rgba(74, 222, 128, 0.15);
-  color: #4ade80;
+  --status-bg: var(--color-success-bg);
+  --status-border: var(--color-success-border);
+  --status-color: var(--color-success);
 }
 
 .status-badge.draft {
-  background: rgba(251, 191, 36, 0.15);
-  color: #fbbf24;
+  --status-bg: var(--color-warning-bg);
+  --status-border: var(--color-warning-border);
+  --status-color: var(--color-warning);
 }
 
 .status-badge.deprecated {
-  background: rgba(248, 113, 113, 0.15);
-  color: #f87171;
+  --status-bg: var(--color-error-bg);
+  --status-border: var(--color-error-border);
+  --status-color: var(--color-error);
 }
 
 /* Section Header */
@@ -488,8 +515,9 @@
 .skip-badge {
   font-size: 0.5625rem;
   padding: 0.0625rem 0.375rem;
-  background: rgba(251, 191, 36, 0.2);
-  color: #fbbf24;
+  background: var(--color-warning-bg);
+  color: var(--color-warning);
+  border: 1px solid var(--color-warning-border);
   border-radius: 2px;
   text-transform: uppercase;
   letter-spacing: 0.05em;
@@ -532,7 +560,8 @@
   font-size: 0.625rem;
   font-family: "JetBrains Mono", monospace;
   color: var(--text-muted);
-  background: rgba(255, 255, 255, 0.1);
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-primary);
   padding: 0.125rem 0.375rem;
   border-radius: 3px;
 }

--- a/playground/src/features/patina/PatinaPlayground.css
+++ b/playground/src/features/patina/PatinaPlayground.css
@@ -333,26 +333,26 @@
 
 .help-content .help-code {
   margin: 0.5rem 0;
-  padding: 0.75rem;
-  background: var(--bg-secondary);
-  border: 1px solid var(--border-primary);
-  border-radius: 4px;
+  padding: 1rem 1.125rem;
+  background: var(--code-bg);
+  border: 1px solid var(--code-border);
+  border-radius: 6px;
   overflow-x: auto;
   font-family: "JetBrains Mono", "Fira Code", monospace;
-  font-size: 0.8rem;
-  line-height: 1.5;
+  font-size: 0.8125rem;
+  line-height: 1.55;
 }
 
 .help-content .help-code code {
-  color: var(--text-primary);
+  color: var(--code-foreground);
   background: none;
   padding: 0;
 }
 
 .help-content .help-inline-code {
-  background: var(--bg-secondary);
-  border: 1px solid var(--border-primary);
-  padding: 0.15rem 0.4rem;
+  background: var(--code-bg);
+  border: 1px solid var(--code-border);
+  padding: 0.18rem 0.42rem;
   border-radius: 3px;
   font-family: "JetBrains Mono", "Fira Code", monospace;
   font-size: 0.85em;

--- a/playground/src/shared/CodeHighlight.vue
+++ b/playground/src/shared/CodeHighlight.vue
@@ -92,60 +92,68 @@ watch(
 
 <style scoped>
 .code-highlight {
+  --code-line-height: 21px;
+
   display: flex;
   font-family: "JetBrains Mono", monospace;
   font-size: 13px;
-  line-height: 20px;
-  border-radius: 4px;
+  line-height: var(--code-line-height);
+  border: 1px solid var(--code-border);
+  border-radius: 6px;
   overflow: auto;
-  background: var(--bg-secondary);
+  background: var(--code-bg);
+  color: var(--code-foreground);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
 }
 
-.line-numbers {
+.code-highlight :deep(.line-numbers) {
   display: flex;
   flex-direction: column;
-  padding-top: 12px;
-  padding-bottom: 12px;
-  background: var(--bg-tertiary);
-  border-right: 1px solid var(--border-color);
+  padding-top: 16px;
+  padding-bottom: 16px;
+  background: var(--code-gutter-bg);
+  border-right: 1px solid var(--code-border);
   user-select: none;
   flex-shrink: 0;
   position: sticky;
   left: 0;
 }
 
-.code-content {
+.code-highlight :deep(.code-content) {
   flex: 1;
-  padding-top: 12px;
-  padding-bottom: 12px;
-  padding-left: 16px;
-  padding-right: 16px;
+  min-width: 0;
+  padding: 16px 20px;
   overflow-x: auto;
+}
+
+.code-highlight.with-line-numbers :deep(.code-content) {
+  padding-left: 16px;
 }
 
 .code-highlight :deep(.line-number) {
   display: block;
-  padding: 0 12px;
+  padding: 0 14px;
   text-align: right;
-  color: var(--text-muted);
-  line-height: 20px;
-  height: 20px;
+  color: var(--code-line-number);
+  line-height: var(--code-line-height);
+  height: var(--code-line-height);
   box-sizing: border-box;
 }
 
 .code-highlight :deep(.code-line) {
   white-space: pre;
-  line-height: 20px;
-  height: 20px;
+  color: var(--code-foreground);
+  line-height: var(--code-line-height);
+  min-height: var(--code-line-height);
   box-sizing: border-box;
 }
 
 .code-highlight :deep(.code-line span) {
-  color: var(--l);
+  color: var(--l, var(--code-foreground));
   line-height: inherit;
 }
 
 body[data-theme="dark"] .code-highlight :deep(.code-line span) {
-  color: var(--d);
+  color: var(--d, var(--code-foreground));
 }
 </style>

--- a/playground/src/shared/codeHighlighting.ts
+++ b/playground/src/shared/codeHighlighting.ts
@@ -13,54 +13,54 @@ const vizeDarkTheme: ThemeRegistration = {
   name: "vize-dark",
   type: "dark",
   colors: {
-    "editor.background": "#1a1a1a",
-    "editor.foreground": "#E6E2D6",
+    "editor.background": "#171717",
+    "editor.foreground": "#EEE8DB",
   },
   tokenColors: [
     {
       scope: ["keyword", "storage.type", "storage.modifier"],
-      settings: { foreground: "#D4BA92" },
+      settings: { foreground: "#F2B8A0" },
     },
     {
       scope: ["entity.name.function", "support.function"],
-      settings: { foreground: "#E2CBA6" },
+      settings: { foreground: "#FFD08A" },
     },
     {
       scope: ["entity.name.tag", "punctuation.definition.tag"],
-      settings: { foreground: "#D0BA9E" },
+      settings: { foreground: "#8ECDF0" },
     },
     {
       scope: ["entity.other.attribute-name"],
-      settings: { foreground: "#9C9488" },
+      settings: { foreground: "#D8B4FE" },
     },
-    { scope: ["string", "string.quoted"], settings: { foreground: "#A8B5A0" } },
+    { scope: ["string", "string.quoted"], settings: { foreground: "#A7D8A8" } },
     {
       scope: ["constant.numeric", "constant.language"],
-      settings: { foreground: "#DABA8C" },
+      settings: { foreground: "#F1BC78" },
     },
     {
       scope: ["variable", "variable.other"],
-      settings: { foreground: "#E6E2D6" },
+      settings: { foreground: "#EEE8DB" },
     },
     {
       scope: ["comment", "punctuation.definition.comment"],
-      settings: { foreground: "#6B6560" },
+      settings: { foreground: "#A39B8F" },
     },
     {
       scope: ["punctuation", "meta.brace"],
-      settings: { foreground: "#8A8478" },
+      settings: { foreground: "#B8AFA2" },
     },
     {
       scope: ["entity.name.type", "support.type"],
-      settings: { foreground: "#B8ADA0" },
+      settings: { foreground: "#C4C8FF" },
     },
     {
       scope: ["meta.property-name", "support.type.property-name"],
-      settings: { foreground: "#D0BA9E" },
+      settings: { foreground: "#9DD4FF" },
     },
     {
       scope: ["meta.property-value", "support.constant.property-value"],
-      settings: { foreground: "#A8B5A0" },
+      settings: { foreground: "#BADE9B" },
     },
   ],
 };
@@ -69,54 +69,54 @@ const vizeLightTheme: ThemeRegistration = {
   name: "vize-light",
   type: "light",
   colors: {
-    "editor.background": "#ddd9cd",
-    "editor.foreground": "#121212",
+    "editor.background": "#F3EFE2",
+    "editor.foreground": "#141414",
   },
   tokenColors: [
     {
       scope: ["keyword", "storage.type", "storage.modifier"],
-      settings: { foreground: "#73603E" },
+      settings: { foreground: "#7A2F15" },
     },
     {
       scope: ["entity.name.function", "support.function"],
-      settings: { foreground: "#655232" },
+      settings: { foreground: "#6B4A00" },
     },
     {
       scope: ["entity.name.tag", "punctuation.definition.tag"],
-      settings: { foreground: "#65573E" },
+      settings: { foreground: "#005F80" },
     },
     {
       scope: ["entity.other.attribute-name"],
-      settings: { foreground: "#6B6050" },
+      settings: { foreground: "#5A3D86" },
     },
-    { scope: ["string", "string.quoted"], settings: { foreground: "#5A6B50" } },
+    { scope: ["string", "string.quoted"], settings: { foreground: "#1B6A38" } },
     {
       scope: ["constant.numeric", "constant.language"],
-      settings: { foreground: "#735C2E" },
+      settings: { foreground: "#73470D" },
     },
     {
       scope: ["variable", "variable.other"],
-      settings: { foreground: "#121212" },
+      settings: { foreground: "#141414" },
     },
     {
       scope: ["comment", "punctuation.definition.comment"],
-      settings: { foreground: "#9A9590" },
+      settings: { foreground: "#59554F" },
     },
     {
       scope: ["punctuation", "meta.brace"],
-      settings: { foreground: "#6B6560" },
+      settings: { foreground: "#5C5750" },
     },
     {
       scope: ["entity.name.type", "support.type"],
-      settings: { foreground: "#6B5F50" },
+      settings: { foreground: "#3D4B80" },
     },
     {
       scope: ["meta.property-name", "support.type.property-name"],
-      settings: { foreground: "#65573E" },
+      settings: { foreground: "#005F73" },
     },
     {
       scope: ["meta.property-value", "support.constant.property-value"],
-      settings: { foreground: "#4A5F3E" },
+      settings: { foreground: "#40680F" },
     },
   ],
 };
@@ -222,9 +222,9 @@ function codeTokensToHtml(tokens: ThemedCodeToken[]): string {
   return tokens
     .map(
       (token) =>
-        `<span style="--d:${token.darkColor};--l:${token.lightColor}">${escapeHtml(
-          token.content,
-        )}</span>`,
+        `<span style="--d:${token.darkColor ?? "var(--code-foreground)"};--l:${
+          token.lightColor ?? "var(--code-foreground)"
+        }">${escapeHtml(token.content)}</span>`,
     )
     .join("");
 }

--- a/playground/src/styles.css
+++ b/playground/src/styles.css
@@ -23,32 +23,44 @@
   --color-notice: #8b7040;
   --color-notice-bg: rgba(139, 112, 64, 0.1);
   --color-notice-border: rgba(139, 112, 64, 0.3);
-  --color-success: #2d6a35;
-  --color-success-bg: rgba(45, 106, 53, 0.12);
-  --color-error: #a04040;
-  --color-error-bg: rgba(160, 64, 64, 0.1);
-  --color-error-border: rgba(160, 64, 64, 0.3);
-  --color-warning: #6b5020;
-  --color-warning-bg: rgba(107, 80, 32, 0.12);
+  --color-success: #1f5b28;
+  --color-success-bg: rgba(31, 91, 40, 0.12);
+  --color-success-border: rgba(31, 91, 40, 0.34);
+  --color-error: #8a2f2f;
+  --color-error-bg: rgba(138, 47, 47, 0.1);
+  --color-error-border: rgba(138, 47, 47, 0.32);
+  --color-warning: #60430e;
+  --color-warning-bg: rgba(96, 67, 14, 0.12);
+  --color-warning-border: rgba(96, 67, 14, 0.34);
   --color-info: #4a6b8a;
   --color-info-bg: rgba(74, 107, 138, 0.1);
+  --color-info-border: rgba(74, 107, 138, 0.28);
   --color-purple: #6b5090;
   --color-purple-bg: rgba(107, 80, 144, 0.15);
+  --color-purple-border: rgba(107, 80, 144, 0.3);
   --color-teal: #3a7a70;
   --color-teal-bg: rgba(58, 122, 112, 0.15);
+  --color-teal-border: rgba(58, 122, 112, 0.3);
+
+  /* Readable code surfaces */
+  --code-bg: #f3efe2;
+  --code-gutter-bg: #ebe4d4;
+  --code-border: rgba(18, 18, 18, 0.2);
+  --code-foreground: #141414;
+  --code-line-number: #5f5a52;
 
   /* Syntax highlighting (for code blocks in hints etc.) */
-  --hl-keyword: #73603e;
-  --hl-function: #655232;
-  --hl-string: #486040;
-  --hl-comment: #9a9590;
-  --hl-tag: #65573e;
-  --hl-directive: #6b5f50;
-  --hl-delimiter: #6b6560;
-  --hl-type: #6b5f50;
-  --hl-number: #735c2e;
-  --hl-property: #65573e;
-  --hl-value: #4a5f3e;
+  --hl-keyword: #7a2f15;
+  --hl-function: #6b4a00;
+  --hl-string: #1b6a38;
+  --hl-comment: #59554f;
+  --hl-tag: #005f80;
+  --hl-directive: #5a3d86;
+  --hl-delimiter: #5c5750;
+  --hl-type: #3d4b80;
+  --hl-number: #73470d;
+  --hl-property: #005f73;
+  --hl-value: #40680f;
 }
 
 /* Variables — Dark */
@@ -73,30 +85,42 @@
   --color-notice-border: rgba(212, 186, 146, 0.25);
   --color-success: #a8b5a0;
   --color-success-bg: rgba(168, 181, 160, 0.1);
+  --color-success-border: rgba(168, 181, 160, 0.3);
   --color-error: #d09090;
   --color-error-bg: rgba(208, 144, 144, 0.1);
   --color-error-border: rgba(208, 144, 144, 0.3);
   --color-warning: #d4ba92;
   --color-warning-bg: rgba(212, 186, 146, 0.12);
+  --color-warning-border: rgba(212, 186, 146, 0.3);
   --color-info: #8aabca;
   --color-info-bg: rgba(138, 171, 202, 0.1);
+  --color-info-border: rgba(138, 171, 202, 0.28);
   --color-purple: #b8a0d0;
   --color-purple-bg: rgba(184, 160, 208, 0.12);
+  --color-purple-border: rgba(184, 160, 208, 0.28);
   --color-teal: #80bdb0;
   --color-teal-bg: rgba(128, 189, 176, 0.12);
+  --color-teal-border: rgba(128, 189, 176, 0.28);
+
+  /* Readable code surfaces */
+  --code-bg: #171717;
+  --code-gutter-bg: #202020;
+  --code-border: rgba(230, 226, 214, 0.2);
+  --code-foreground: #eee8db;
+  --code-line-number: #b2aaa0;
 
   /* Syntax highlighting */
-  --hl-keyword: #d4ba92;
-  --hl-function: #e2cba6;
-  --hl-string: #a8b5a0;
-  --hl-comment: #6b6560;
-  --hl-tag: #d0ba9e;
-  --hl-directive: #b8ada0;
-  --hl-delimiter: #8a8478;
-  --hl-type: #b8ada0;
-  --hl-number: #daba8c;
-  --hl-property: #d0ba9e;
-  --hl-value: #a8b5a0;
+  --hl-keyword: #f2b8a0;
+  --hl-function: #ffd08a;
+  --hl-string: #a7d8a8;
+  --hl-comment: #a39b8f;
+  --hl-tag: #8ecdf0;
+  --hl-directive: #d8b4fe;
+  --hl-delimiter: #b8afa2;
+  --hl-type: #c4c8ff;
+  --hl-number: #f1bc78;
+  --hl-property: #9dd4ff;
+  --hl-value: #bade9b;
 }
 
 /* Base */
@@ -571,10 +595,12 @@
 .ast-output pre {
   font-family: var(--font-mono);
   font-size: 13px;
-  line-height: 1;
-  background: var(--bg-secondary) !important;
+  line-height: 1.45;
+  background: var(--code-bg) !important;
+  border: 1px solid var(--code-border);
   border-radius: var(--radius-lg);
-  padding: 16px !important;
+  color: var(--code-foreground);
+  padding: 20px !important;
   overflow: auto;
   margin: 0;
 }
@@ -762,10 +788,12 @@
 .sfc-block pre {
   font-family: var(--font-mono);
   font-size: 13px;
-  line-height: 1;
-  background: var(--bg-secondary) !important;
+  line-height: 1.45;
+  background: var(--code-bg) !important;
+  border: 1px solid var(--code-border);
   border-radius: var(--radius-lg);
-  padding: 12px !important;
+  color: var(--code-foreground);
+  padding: 18px !important;
   overflow: auto;
   margin: 0;
 }
@@ -812,10 +840,12 @@
 .css-compiled pre {
   font-family: var(--font-mono);
   font-size: 13px;
-  line-height: 1;
-  background: var(--bg-secondary) !important;
+  line-height: 1.45;
+  background: var(--code-bg) !important;
+  border: 1px solid var(--code-border);
   border-radius: var(--radius-lg);
-  padding: 16px !important;
+  color: var(--code-foreground);
+  padding: 20px !important;
   overflow: auto;
   margin: 0;
 }


### PR DESCRIPTION
## Summary
- refresh playground code block surfaces, token colors, and padding for stronger light/dark contrast
- make Patina/Canon help code blocks use the shared code color tokens
- replace hardcoded Musea status colors with semantic tokens and add clearer badge styling

## Verification
- `corepack pnpm --filter vize-playground check`
- `git diff --check`
- Browser contrast spot-check: Atelier code tokens >= 5.76:1 light / >= 6.52:1 dark; Musea status >= 4.85:1 light / >= 6.76:1 dark