### PR TITLE
fix: wrap mutable props destructure defaults

### DIFF
--- a/crates/vize_atelier_sfc/src/compile/tests.rs
+++ b/crates/vize_atelier_sfc/src/compile/tests.rs
@@ -844,6 +844,34 @@ const doubled = computed(() => count * 2)
 }
 
 #[test]
+fn test_props_destructure_mutable_defaults_use_factories() {
+    let input = r#"<script setup lang="ts">
+const {
+  items = [],
+  options = { dense: true },
+  formatter = () => "ok",
+} = defineProps<{
+  items?: string[]
+  options?: { dense: boolean }
+  formatter?: () => string
+}>()
+</script>
+
+<template>
+  <div>{{ items.length }} {{ options.dense }} {{ formatter() }}</div>
+</template>"#;
+
+    let descriptor = parse_sfc(input, SfcParseOptions::default()).unwrap();
+    let mut compile_opts = SfcCompileOptions::default();
+    compile_opts.script.id = Some("test.vue".to_compact_string());
+    let result = compile_sfc(&descriptor, compile_opts).unwrap();
+
+    assert!(result.code.contains("default: () => []"));
+    assert!(result.code.contains("default: () => ({ dense: true })"));
+    assert!(result.code.contains("default: () => \"ok\""));
+}
+
+#[test]
 fn test_let_var_unref() {
     let input = r#"
 <script setup>

--- a/crates/vize_atelier_sfc/src/compile_script/function_mode/compiler.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/function_mode/compiler.rs
@@ -18,6 +18,7 @@ use super::super::import_utils::extract_import_identifiers;
 use super::super::lazy_hydration::transform_lazy_hydration_macros;
 use super::super::props::{
     add_null_to_runtime_type, extract_emit_names_from_type, extract_prop_types_from_type,
+    normalize_destructure_default_value,
 };
 use super::super::statement_sections::extract_script_sections;
 use super::super::typescript::transform_typescript_to_js;
@@ -360,6 +361,7 @@ fn emit_props_definition(
                     output.extend_from_slice(b"  ");
                     output.extend_from_slice(key.as_bytes());
                     output.extend_from_slice(b": ");
+                    let default_val = normalize_destructure_default_value(default_val);
                     output.extend_from_slice(default_val.as_bytes());
                     output.push(b'\n');
                 }

--- a/crates/vize_atelier_sfc/src/compile_script/inline/compiler/props.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/inline/compiler/props.rs
@@ -4,7 +4,7 @@ use crate::script::ScriptCompileContext;
 
 use super::super::super::props::{
     add_null_to_runtime_type, extract_prop_types_from_type, extract_with_defaults_defaults,
-    resolve_prop_js_type,
+    normalize_destructure_default_value, resolve_prop_js_type,
 };
 use super::{super::type_handling::resolve_type_args, model::collect_model_infos};
 
@@ -87,6 +87,7 @@ pub(super) fn build_props_emits(
                         && let Some(ref default_val) = binding.default
                     {
                         props_emits_buf.extend_from_slice(b", default: ");
+                        let default_val = normalize_destructure_default_value(default_val);
                         props_emits_buf.extend_from_slice(default_val.as_bytes());
                     }
                     props_emits_buf.extend_from_slice(b" }");
@@ -130,6 +131,7 @@ pub(super) fn build_props_emits(
                     props_emits_buf.extend_from_slice(b"  ");
                     props_emits_buf.extend_from_slice(key.as_bytes());
                     props_emits_buf.extend_from_slice(b": ");
+                    let default_val = normalize_destructure_default_value(default_val);
                     props_emits_buf.extend_from_slice(default_val.as_bytes());
                     if i < defaults.len() - 1 {
                         props_emits_buf.push(b',');

--- a/crates/vize_atelier_sfc/src/compile_script/props.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/props.rs
@@ -689,6 +689,30 @@ pub fn extract_with_defaults_defaults(with_defaults_args: &str) -> FxHashMap<Str
     defaults
 }
 
+/// Normalize default values from reactive props destructure for runtime props.
+///
+/// Vue treats array/object destructure defaults as per-instance factories, while
+/// function defaults are already factories/values and must not be wrapped.
+pub(crate) fn normalize_destructure_default_value(default_value: &str) -> String {
+    let trimmed = default_value.trim();
+    if trimmed.starts_with('[') {
+        let mut wrapped = String::with_capacity(trimmed.len() + 6);
+        wrapped.push_str("() => ");
+        wrapped.push_str(trimmed);
+        return wrapped;
+    }
+
+    if trimmed.starts_with('{') {
+        let mut wrapped = String::with_capacity(trimmed.len() + 8);
+        wrapped.push_str("() => (");
+        wrapped.push_str(trimmed);
+        wrapped.push(')');
+        return wrapped;
+    }
+
+    default_value.to_compact_string()
+}
+
 /// Check if a string is a valid JS identifier
 pub fn is_valid_identifier(s: &str) -> bool {
     if s.is_empty() {

--- a/crates/vize_atelier_sfc/src/compile_script/tests.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/tests.rs
@@ -6,6 +6,7 @@ mod compile_script_tests {
     use crate::compile_script::function_mode::compile_script_setup;
     use crate::compile_script::props::{
         extract_prop_types_from_type, extract_with_defaults_defaults, is_valid_identifier,
+        normalize_destructure_default_value,
     };
     use crate::compile_script::typescript::transform_typescript_to_js;
     use crate::types::SfcDescriptor;
@@ -77,6 +78,23 @@ mod compile_script_tests {
             defaults4.get("description"),
             Some(&"'a fast, modern browser for the **npm registry**'".to_compact_string())
         );
+    }
+
+    #[test]
+    fn test_normalize_destructure_default_value() {
+        assert_eq!(
+            normalize_destructure_default_value("[]").as_str(),
+            "() => []"
+        );
+        assert_eq!(
+            normalize_destructure_default_value("{ count: 0 }").as_str(),
+            "() => ({ count: 0 })"
+        );
+        assert_eq!(
+            normalize_destructure_default_value("() => []").as_str(),
+            "() => []"
+        );
+        assert_eq!(normalize_destructure_default_value("42").as_str(), "42");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Normalize reactive props destructure defaults so array and object literals are emitted as per-instance factories.
- Apply the same normalization in inline and function-mode script compilation.
- Add focused coverage for array/object/function destructure defaults.

## Validation

- `cargo fmt --check`
- `cargo test -p vize_atelier_sfc normalize_destructure_default_value`
- `cargo test -p vize_atelier_sfc props_destructure_mutable_defaults_use_factories`

## Stack

- Based on #667 so this PR is not blocked by the current `main` playground VRT color expectation failure.