### PR TITLE
fix: validate props destructure defaults

### DIFF
--- a/crates/vize_atelier_sfc/src/compile/tests.rs
+++ b/crates/vize_atelier_sfc/src/compile/tests.rs
@@ -872,6 +872,61 @@ const {
 }
 
 #[test]
+fn test_props_destructure_default_type_mismatch_errors() {
+    let input = r#"<script setup lang="ts">
+const { count = "zero" } = defineProps<{
+  count?: number
+}>()
+</script>
+
+<template>
+  <div>{{ count }}</div>
+</template>"#;
+
+    let descriptor = parse_sfc(input, SfcParseOptions::default()).unwrap();
+    let mut compile_opts = SfcCompileOptions::default();
+    compile_opts.script.id = Some("test.vue".to_compact_string());
+    let error = compile_sfc(&descriptor, compile_opts).unwrap_err();
+
+    assert_eq!(
+        error.code.as_deref(),
+        Some("DEFINE_PROPS_DESTRUCTURE_DEFAULT_TYPE")
+    );
+    assert_eq!(
+        error.message.as_str(),
+        "Default value of prop \"count\" does not match declared type."
+    );
+}
+
+#[test]
+fn test_props_destructure_default_factory_return_types_are_validated() {
+    let input = r#"<script setup lang="ts">
+const {
+  items = () => [],
+  options = () => ({ dense: true }),
+  formatter = () => "ok",
+} = defineProps<{
+  items?: string[]
+  options?: { dense: boolean }
+  formatter?: () => string
+}>()
+</script>
+
+<template>
+  <div>{{ items.length }} {{ options.dense }} {{ formatter() }}</div>
+</template>"#;
+
+    let descriptor = parse_sfc(input, SfcParseOptions::default()).unwrap();
+    let mut compile_opts = SfcCompileOptions::default();
+    compile_opts.script.id = Some("test.vue".to_compact_string());
+    let result = compile_sfc(&descriptor, compile_opts).unwrap();
+
+    assert!(result.code.contains("default: () => []"));
+    assert!(result.code.contains("default: () => ({ dense: true })"));
+    assert!(result.code.contains("default: () => \"ok\""));
+}
+
+#[test]
 fn test_let_var_unref() {
     let input = r#"
 <script setup>

--- a/crates/vize_atelier_sfc/src/compile_script/function_mode/compiler.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/function_mode/compiler.rs
@@ -18,7 +18,7 @@ use super::super::import_utils::extract_import_identifiers;
 use super::super::lazy_hydration::transform_lazy_hydration_macros;
 use super::super::props::{
     add_null_to_runtime_type, extract_emit_names_from_type, extract_prop_types_from_type,
-    normalize_destructure_default_value,
+    normalize_destructure_default_value, validate_props_destructure_default_types,
 };
 use super::super::statement_sections::extract_script_sections;
 use super::super::typescript::transform_typescript_to_js;
@@ -42,6 +42,7 @@ pub fn compile_script_setup(
 
     let mut ctx = ScriptCompileContext::new(content);
     ctx.analyze();
+    validate_props_destructure_default_types(&ctx)?;
 
     // Use arena-allocated Vec for better performance
     let bump = vize_carton::Bump::new();

--- a/crates/vize_atelier_sfc/src/compile_script/inline/compiler.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/inline/compiler.rs
@@ -23,6 +23,7 @@ use crate::types::SfcError;
 
 use super::super::function_mode::contains_top_level_await;
 use super::super::lazy_hydration::transform_lazy_hydration_macros;
+use super::super::props::validate_props_destructure_default_types;
 use super::super::{ScriptCompileResult, TemplateParts};
 use body::compile_script_setup_inline_body;
 use parser::parse_script_content;
@@ -116,6 +117,8 @@ pub(crate) fn compile_script_setup_inline_with_context(
             .as_ref()
             .map(|d| d.bindings.values().any(|b| b.default.is_some()))
             .unwrap_or(false);
+
+    validate_props_destructure_default_types(&ctx)?;
 
     let has_define_model = !ctx.macros.define_models.is_empty();
     let has_define_slots = ctx.macros.define_slots.is_some();

--- a/crates/vize_atelier_sfc/src/compile_script/props.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/props.rs
@@ -10,6 +10,9 @@ use oxc_span::{GetSpan, SourceType};
 use vize_carton::FxHashMap;
 use vize_carton::{String, ToCompactString};
 
+use crate::script::ScriptCompileContext;
+use crate::types::SfcError;
+
 /// Prop type information
 #[derive(Debug, Clone)]
 pub struct PropTypeInfo {
@@ -711,6 +714,178 @@ pub(crate) fn normalize_destructure_default_value(default_value: &str) -> String
     }
 
     default_value.to_compact_string()
+}
+
+/// Validate reactive props destructure defaults against inferred runtime prop types.
+pub(crate) fn validate_props_destructure_default_types(
+    ctx: &ScriptCompileContext,
+) -> Result<(), SfcError> {
+    let Some(destructure) = ctx.macros.props_destructure.as_ref() else {
+        return Ok(());
+    };
+    let Some(props_macro) = ctx.macros.define_props.as_ref() else {
+        return Ok(());
+    };
+    let Some(type_args) = props_macro.type_args.as_ref() else {
+        return Ok(());
+    };
+
+    let resolved_type_args =
+        crate::script::resolve_type_args(type_args, &ctx.interfaces, &ctx.type_aliases);
+    let prop_types = extract_prop_types_from_type(&resolved_type_args);
+
+    for (name, prop_type) in &prop_types {
+        let Some(binding) = destructure.bindings.get(name.as_str()) else {
+            continue;
+        };
+        let Some(default_value) = binding.default.as_deref() else {
+            continue;
+        };
+
+        let resolved_js_type = if prop_type.js_type == "null" {
+            prop_type
+                .ts_type
+                .as_ref()
+                .and_then(|ts_type| {
+                    resolve_prop_js_type(ts_type, &ctx.interfaces, &ctx.type_aliases)
+                })
+                .unwrap_or_else(|| prop_type.js_type.clone())
+        } else {
+            prop_type.js_type.clone()
+        };
+
+        if resolved_js_type == "null" || prop_type.nullable {
+            continue;
+        }
+
+        let Some(default_type) =
+            infer_default_value_runtime_type(default_value, resolved_js_type.as_str())
+        else {
+            continue;
+        };
+
+        if !runtime_type_includes(resolved_js_type.as_str(), default_type) {
+            return Err(SfcError {
+                message: {
+                    let mut message = String::from("Default value of prop \"");
+                    message.push_str(name);
+                    message.push_str("\" does not match declared type.");
+                    message
+                },
+                code: Some("DEFINE_PROPS_DESTRUCTURE_DEFAULT_TYPE".into()),
+                loc: None,
+            });
+        }
+    }
+
+    Ok(())
+}
+
+fn infer_default_value_runtime_type(
+    default_value: &str,
+    expected_runtime_type: &str,
+) -> Option<&'static str> {
+    const WRAP_PREFIX: &str = "const __vize_default__ = ";
+    let mut wrapped = String::with_capacity(WRAP_PREFIX.len() + default_value.len() + 1);
+    wrapped.push_str(WRAP_PREFIX);
+    wrapped.push_str(default_value);
+    wrapped.push(';');
+
+    let allocator = Allocator::default();
+    let parse_result = Parser::new(
+        &allocator,
+        &wrapped,
+        SourceType::default().with_typescript(true),
+    )
+    .parse();
+    if !parse_result.errors.is_empty() {
+        return None;
+    }
+
+    let Some(Statement::VariableDeclaration(var_decl)) = parse_result.program.body.first() else {
+        return None;
+    };
+    let declarator = var_decl.declarations.first()?;
+    let value = declarator.init.as_ref()?;
+
+    infer_expression_runtime_type(unwrap_ts_expression(value), expected_runtime_type)
+}
+
+fn unwrap_ts_expression<'a>(expr: &'a Expression<'a>) -> &'a Expression<'a> {
+    match expr {
+        Expression::ParenthesizedExpression(paren) => unwrap_ts_expression(&paren.expression),
+        Expression::TSAsExpression(ts_as) => unwrap_ts_expression(&ts_as.expression),
+        Expression::TSSatisfiesExpression(ts_satisfies) => {
+            unwrap_ts_expression(&ts_satisfies.expression)
+        }
+        Expression::TSNonNullExpression(ts_non_null) => {
+            unwrap_ts_expression(&ts_non_null.expression)
+        }
+        _ => expr,
+    }
+}
+
+fn infer_expression_runtime_type(
+    expr: &Expression<'_>,
+    expected_runtime_type: &str,
+) -> Option<&'static str> {
+    match expr {
+        Expression::StringLiteral(_) => Some("String"),
+        Expression::TemplateLiteral(template) if template.expressions.is_empty() => Some("String"),
+        Expression::NumericLiteral(_) => Some("Number"),
+        Expression::BooleanLiteral(_) => Some("Boolean"),
+        Expression::ObjectExpression(_) => Some("Object"),
+        Expression::ArrayExpression(_) => Some("Array"),
+        Expression::ArrowFunctionExpression(arrow) => {
+            if runtime_type_includes(expected_runtime_type, "Function") {
+                return Some("Function");
+            }
+            arrow_return_expression(arrow)
+                .and_then(|expr| infer_expression_runtime_type(expr, expected_runtime_type))
+        }
+        Expression::FunctionExpression(func) => {
+            if runtime_type_includes(expected_runtime_type, "Function") {
+                return Some("Function");
+            }
+            function_body_return_expression(&func.body.as_ref()?.statements)
+                .and_then(|expr| infer_expression_runtime_type(expr, expected_runtime_type))
+        }
+        _ => None,
+    }
+}
+
+fn arrow_return_expression<'a>(
+    arrow: &'a oxc_ast::ast::ArrowFunctionExpression<'a>,
+) -> Option<&'a Expression<'a>> {
+    if !arrow.expression {
+        return function_body_return_expression(&arrow.body.statements);
+    }
+
+    let Statement::ExpressionStatement(expr_stmt) = arrow.body.statements.first()? else {
+        return None;
+    };
+    Some(&expr_stmt.expression)
+}
+
+fn function_body_return_expression<'a>(
+    statements: &'a oxc_allocator::Vec<'a, Statement<'a>>,
+) -> Option<&'a Expression<'a>> {
+    for stmt in statements.iter() {
+        if let Statement::ReturnStatement(ret) = stmt
+            && let Some(argument) = &ret.argument
+        {
+            return Some(argument);
+        }
+    }
+    None
+}
+
+fn runtime_type_includes(runtime_type: &str, value_type: &str) -> bool {
+    runtime_type
+        .trim_matches(|c| c == '[' || c == ']')
+        .split(',')
+        .map(str::trim)
+        .any(|part| part == value_type)
 }
 
 /// Check if a string is a valid JS identifier


### PR DESCRIPTION
## Summary
- validate reactive props destructure defaults against type-based defineProps runtime types
- infer literal default value runtime types to catch mismatches like number props defaulting to strings
- run the validation in both inline and function-mode script setup compilers

Stacked on #667. #668 is already merged into the stack base.

## Validation
- cargo fmt --check
- cargo test -p vize_atelier_sfc props_destructure_default_type_mismatch_errors
- cargo test -p vize_atelier_sfc props_destructure_mutable_defaults_use_factories