### PR TITLE
feat(lsp): include nested-scope bindings in script completion

### DIFF
--- a/crates/vize_croquis/src/scope/chain.rs
+++ b/crates/vize_croquis/src/scope/chain.rs
@@ -14,7 +14,9 @@ mod resolution;
 
 use core::fmt;
 
-use vize_carton::{CompactString, FxHashMap, SmallVec, String, ToCompactString, smallvec};
+use vize_carton::{
+    CompactString, FxHashMap, FxHashSet, SmallVec, String, ToCompactString, smallvec,
+};
 use vize_relief::BindingType;
 
 use super::types::{
@@ -425,6 +427,89 @@ impl ScopeChain {
     #[inline]
     pub fn find_scope_by_kind(&self, kind: ScopeKind) -> Option<ScopeId> {
         self.scopes.iter().find(|s| s.kind == kind).map(|s| s.id)
+    }
+
+    /// Find the deepest scope whose span contains `offset`.
+    ///
+    /// Scopes are entered in depth-first order during analysis, so the deepest
+    /// containing scope is the one with the highest id among those that
+    /// contain the offset. Global scopes (universal, browser, vue) use the
+    /// default span and are never matched here — they are reached only by
+    /// walking the parent chain of the matched scope.
+    pub fn scope_at_offset(&self, offset: u32) -> Option<ScopeId> {
+        let mut best: Option<(ScopeId, u32)> = None;
+        for scope in &self.scopes {
+            if matches!(
+                scope.kind,
+                ScopeKind::JsGlobalUniversal
+                    | ScopeKind::JsGlobalBrowser
+                    | ScopeKind::JsGlobalNode
+                    | ScopeKind::JsGlobalDeno
+                    | ScopeKind::JsGlobalBun
+                    | ScopeKind::VueGlobal
+            ) {
+                continue;
+            }
+            if scope.span.contains(offset) {
+                // Smaller spans win (deepest); ties broken by higher id which
+                // is created later in DFS traversal.
+                let len = scope.span.len();
+                let should_replace = match best {
+                    None => true,
+                    Some((_, current_len)) if len < current_len => true,
+                    Some((current_id, current_len)) if len == current_len => {
+                        scope.id.as_u32() > current_id.as_u32()
+                    }
+                    _ => false,
+                };
+                if should_replace {
+                    best = Some((scope.id, len));
+                }
+            }
+        }
+        best.map(|(id, _)| id)
+    }
+
+    /// Collect every binding visible at `offset`, walking from the deepest
+    /// containing scope outward through its parents.
+    ///
+    /// Inner-scope bindings shadow outer ones — the first occurrence of each
+    /// name wins. Returns `(name, binding, scope_kind)` triples. The order is
+    /// inner-most first, which the LSP uses to prioritize closer scopes in
+    /// completion sort order.
+    pub fn bindings_visible_at(&self, offset: u32) -> Vec<(&str, ScopeBinding, ScopeKind)> {
+        let Some(start_id) = self.scope_at_offset(offset) else {
+            return Vec::new();
+        };
+
+        let mut seen: FxHashSet<&str> = FxHashSet::default();
+        let mut out: Vec<(&str, ScopeBinding, ScopeKind)> = Vec::new();
+        let mut stack: Vec<ScopeId> = Vec::new();
+        let mut to_visit: Vec<ScopeId> = vec![start_id];
+
+        while let Some(id) = to_visit.pop() {
+            // Avoid revisiting the same scope through multiple parent paths.
+            if stack.contains(&id) {
+                continue;
+            }
+            stack.push(id);
+
+            let Some(scope) = self.get_scope(id) else {
+                continue;
+            };
+
+            for (name, binding) in scope.bindings() {
+                if seen.insert(name) {
+                    out.push((name, *binding, scope.kind));
+                }
+            }
+
+            for parent in scope.parents.iter().copied() {
+                to_visit.push(parent);
+            }
+        }
+
+        out
     }
 
     /// Get mutable scope by ID

--- a/crates/vize_croquis/src/scope/chain/chain_tests.rs
+++ b/crates/vize_croquis/src/scope/chain/chain_tests.rs
@@ -916,3 +916,121 @@ fn test_snapshot_binding_types() {
 
     assert_snapshot!(output);
 }
+
+#[test]
+fn test_bindings_visible_at_walks_nested_closures() {
+    // Models the SFC:
+    //   function increment() {            // span [0, 100]
+    //     const local = 1                 // declared inside the closure
+    //     // cursor lands here (offset 50)
+    //   }
+    //   const outer = ref(0)              // setup-scope binding
+    let mut chain = ScopeChain::new();
+    chain.enter_script_setup_scope(
+        ScriptSetupScopeData {
+            is_ts: true,
+            is_async: false,
+            generic: None,
+        },
+        0,
+        200,
+    );
+    chain.add_binding(
+        CompactString::new("outer"),
+        ScopeBinding::new(BindingType::SetupRef, 110),
+    );
+
+    chain.enter_closure_scope(
+        crate::scope::types::ClosureScopeData {
+            name: Some(CompactString::new("increment")),
+            param_names: vize_carton::smallvec![],
+            is_arrow: false,
+            is_async: false,
+            is_generator: false,
+        },
+        0,
+        100,
+    );
+    chain.add_binding(
+        CompactString::new("local"),
+        ScopeBinding::new(BindingType::SetupConst, 30),
+    );
+
+    // Restore current so subsequent calls don't see a stale scope.
+    chain.exit_scope();
+
+    // Offset 50 lives inside the closure. Both `local` (closure) and `outer`
+    // (script setup) should be visible. The closure binding comes first
+    // because the walk starts from the deepest containing scope.
+    let visible = chain.bindings_visible_at(50);
+    let names: Vec<&str> = visible.iter().map(|(name, _, _)| *name).collect();
+    assert!(
+        names.contains(&"local"),
+        "closure local should be visible at offset 50, got {names:?}",
+    );
+    assert!(
+        names.contains(&"outer"),
+        "script-setup binding should be visible at offset 50, got {names:?}",
+    );
+    let local_idx = names.iter().position(|n| *n == "local").unwrap();
+    let outer_idx = names.iter().position(|n| *n == "outer").unwrap();
+    assert!(
+        local_idx < outer_idx,
+        "inner scope must precede outer scope: {names:?}",
+    );
+
+    // Offset 150 is past the closure, in setup scope only.
+    let visible = chain.bindings_visible_at(150);
+    let names: Vec<&str> = visible.iter().map(|(name, _, _)| *name).collect();
+    assert!(names.contains(&"outer"));
+    assert!(!names.contains(&"local"));
+}
+
+#[test]
+fn test_bindings_visible_at_respects_shadowing() {
+    let mut chain = ScopeChain::new();
+    chain.enter_script_setup_scope(
+        ScriptSetupScopeData {
+            is_ts: true,
+            is_async: false,
+            generic: None,
+        },
+        0,
+        200,
+    );
+    chain.add_binding(
+        CompactString::new("x"),
+        ScopeBinding::new(BindingType::SetupRef, 0),
+    );
+
+    chain.enter_closure_scope(
+        crate::scope::types::ClosureScopeData {
+            name: Some(CompactString::new("inner")),
+            param_names: vize_carton::smallvec![],
+            is_arrow: false,
+            is_async: false,
+            is_generator: false,
+        },
+        10,
+        90,
+    );
+    chain.add_binding(
+        CompactString::new("x"),
+        ScopeBinding::new(BindingType::SetupLet, 20),
+    );
+    chain.exit_scope();
+
+    let visible = chain.bindings_visible_at(50);
+    let xs: Vec<_> = visible.iter().filter(|(name, _, _)| *name == "x").collect();
+    assert_eq!(xs.len(), 1, "shadowed name should appear only once: {xs:?}");
+    assert_eq!(xs[0].1.binding_type, BindingType::SetupLet);
+}
+
+#[test]
+fn test_bindings_visible_at_returns_empty_outside_any_scope() {
+    let chain = ScopeChain::new();
+    // Root scope uses the default span (0..0), so any non-zero offset finds
+    // no containing scope and returns nothing.
+    let visible = chain.bindings_visible_at(42);
+    assert!(visible.is_empty(), "expected empty, got {visible:?}");
+}

--- a/crates/vize_croquis/src/scope/types/binding.rs
+++ b/crates/vize_croquis/src/scope/types/binding.rs
@@ -26,6 +26,28 @@ impl Span {
         self.start = self.start.saturating_add(delta);
         self.end = self.end.saturating_add(delta);
     }
+
+    /// Returns true when `offset` falls within `[start, end]`, inclusive.
+    ///
+    /// Cursor positions live between bytes, so a cursor sitting at exactly
+    /// `end` is still considered "inside" the span. Default spans (start=end=0)
+    /// only contain offset 0.
+    #[inline]
+    pub const fn contains(&self, offset: u32) -> bool {
+        self.start <= offset && offset <= self.end
+    }
+
+    /// Span length in bytes.
+    #[inline]
+    pub const fn len(&self) -> u32 {
+        self.end.saturating_sub(self.start)
+    }
+
+    /// True when the span has zero length (default or unset spans).
+    #[inline]
+    pub const fn is_empty(&self) -> bool {
+        self.start == self.end
+    }
 }
 
 bitflags! {

--- a/crates/vize_maestro/src/ide/completion.rs
+++ b/crates/vize_maestro/src/ide/completion.rs
@@ -278,6 +278,76 @@ count.
     }
 
     #[test]
+    fn test_script_completion_includes_closure_local_binding() {
+        // Cursor inside a closure body should see the binding declared in
+        // that closure as well as setup-scope siblings.
+        let source = r#"<script setup lang="ts">
+import { ref } from 'vue'
+
+const outer = ref(0)
+
+function increment() {
+  const localStep = 1
+  loc
+}
+</script>
+"#;
+        let (state, uri) = state_with_document("ScopeAwareCompletion.vue", source);
+        let offset = source.find("\n  loc\n").unwrap() + "\n  loc".len();
+        let ctx = IdeContext::new(&state, &uri, offset).unwrap();
+        let items = completion_items(CompletionService::complete(&ctx).unwrap());
+        let labels: Vec<&str> = items.iter().map(|item| item.label.as_str()).collect();
+
+        assert!(
+            labels.contains(&"localStep"),
+            "closure local should be visible, got {labels:?}",
+        );
+        assert!(
+            labels.contains(&"outer"),
+            "setup-scope binding should be visible, got {labels:?}",
+        );
+
+        let local_item = items.iter().find(|item| item.label == "localStep").unwrap();
+        let outer_item = items.iter().find(|item| item.label == "outer").unwrap();
+        assert!(
+            local_item.sort_text.as_deref().unwrap_or("")
+                < outer_item.sort_text.as_deref().unwrap_or(""),
+            "inner scope binding must sort before setup-scope binding: \
+             local={:?}, outer={:?}",
+            local_item.sort_text,
+            outer_item.sort_text,
+        );
+    }
+
+    #[test]
+    fn test_script_completion_excludes_inner_binding_outside_its_scope() {
+        // The same binding declared inside a closure must NOT leak into
+        // completion at the module level.
+        let source = r#"<script setup lang="ts">
+import { ref } from 'vue'
+
+function helper() {
+  const onlyHere = 1
+  void onlyHere
+}
+
+const outer = ref(0)
+out
+</script>
+"#;
+        let (state, uri) = state_with_document("ScopeAwareLeak.vue", source);
+        let offset = source.find("\nout\n").unwrap() + "\nout".len();
+        let ctx = IdeContext::new(&state, &uri, offset).unwrap();
+        let labels = completion_labels(CompletionService::complete(&ctx).unwrap());
+
+        assert!(
+            !labels.iter().any(|l| l == "onlyHere"),
+            "closure-local binding must not leak to setup scope, got {labels:?}",
+        );
+        assert!(labels.iter().any(|l| l == "outer"));
+    }
+
+    #[test]
     fn test_script_completion_infers_computed_ref_type() {
         let source = r#"<script setup lang="ts">
 import { ref, computed } from 'vue'

--- a/crates/vize_maestro/src/ide/completion/script.rs
+++ b/crates/vize_maestro/src/ide/completion/script.rs
@@ -13,7 +13,7 @@ use tower_lsp::lsp_types::{
     MarkupKind,
 };
 use vize_croquis::reactivity::ReactiveKind;
-use vize_croquis::{Analyzer, AnalyzerOptions};
+use vize_croquis::{Analyzer, AnalyzerOptions, ScopeKind};
 use vize_relief::BindingType;
 
 use super::items;
@@ -48,7 +48,9 @@ pub(crate) fn complete_script(ctx: &IdeContext, is_setup: bool) -> Vec<Completio
     items_vec.extend(import_completions());
 
     // Use vize_croquis for accurate bindings in script
-    if let Some(script_content) = script_content_for_context(ctx, is_setup) {
+    if let Some((script_content, script_offset)) =
+        script_content_and_offset_for_context(ctx, is_setup)
+    {
         let mut analyzer = Analyzer::with_options(AnalyzerOptions {
             analyze_script: true,
             ..Default::default()
@@ -61,6 +63,29 @@ pub(crate) fn complete_script(ctx: &IdeContext, is_setup: bool) -> Vec<Completio
         }
 
         let croquis = analyzer.finish();
+
+        // Scope-aware completion: include nested bindings (closures, blocks,
+        // v-for params, etc.) that are visible at the cursor. We avoid
+        // duplicating top-level bindings that the loop below already adds.
+        let local_offset = ctx.offset.saturating_sub(script_offset) as u32;
+        if local_offset <= script_content.len() as u32 {
+            for (name, binding, scope_kind) in croquis.scopes.bindings_visible_at(local_offset) {
+                if croquis.bindings.contains(name) {
+                    continue;
+                }
+                if !is_nested_user_scope(scope_kind) {
+                    // Module / global scopes are surfaced via the existing
+                    // composition_api and import completion blocks; skip them
+                    // here to avoid duplicating well-known names.
+                    continue;
+                }
+                items_vec.push(inner_scope_completion_item(
+                    name,
+                    binding.binding_type,
+                    scope_kind,
+                ));
+            }
+        }
 
         // Add bindings with type information
         for (name, binding_type) in croquis.bindings.iter() {
@@ -191,6 +216,17 @@ fn complete_member_access(ctx: &IdeContext, is_setup: bool) -> Option<Vec<Comple
 }
 
 fn script_content_for_context(ctx: &IdeContext<'_>, is_setup: bool) -> Option<String> {
+    script_content_and_offset_for_context(ctx, is_setup).map(|(content, _)| content)
+}
+
+/// Returns the script (or script setup) content along with the byte offset of
+/// the block's content within the full SFC. The offset lets callers translate
+/// SFC-absolute cursor positions into script-local positions, which is the
+/// coordinate system used by Croquis scope spans.
+fn script_content_and_offset_for_context(
+    ctx: &IdeContext<'_>,
+    is_setup: bool,
+) -> Option<(String, usize)> {
     let options = vize_atelier_sfc::SfcParseOptions {
         filename: ctx.uri.path().to_string().into(),
         ..Default::default()
@@ -200,9 +236,76 @@ fn script_content_for_context(ctx: &IdeContext<'_>, is_setup: bool) -> Option<St
     if is_setup {
         descriptor
             .script_setup
-            .map(|script| script.content.into_owned())
+            .map(|script| (script.content.into_owned(), script.loc.start))
     } else {
-        descriptor.script.map(|script| script.content.into_owned())
+        descriptor
+            .script
+            .map(|script| (script.content.into_owned(), script.loc.start))
+    }
+}
+
+/// True for scope kinds that only become visible from inside the script setup
+/// body (closures, blocks, v-for, etc.). Module-level and global scopes are
+/// excluded so we don't re-add Vue Composition API names that
+/// `composition_api_completions` already covers.
+fn is_nested_user_scope(kind: ScopeKind) -> bool {
+    matches!(
+        kind,
+        ScopeKind::Closure
+            | ScopeKind::Block
+            | ScopeKind::Function
+            | ScopeKind::Callback
+            | ScopeKind::EventHandler
+            | ScopeKind::VFor
+            | ScopeKind::VSlot
+            | ScopeKind::ClientOnly
+            | ScopeKind::Universal
+    )
+}
+
+#[allow(clippy::disallowed_macros)]
+fn inner_scope_completion_item(
+    name: &str,
+    binding_type: BindingType,
+    scope_kind: ScopeKind,
+) -> CompletionItem {
+    let (kind, type_detail, doc) = items::binding_type_to_completion_info(binding_type);
+    let scope_label = scope_kind_short_label(scope_kind);
+    let description = format!("local · {scope_label}");
+    CompletionItem {
+        label: name.to_string(),
+        kind: Some(kind),
+        label_details: Some(CompletionItemLabelDetails {
+            detail: Some(type_detail.clone()),
+            description: Some(description.clone()),
+        }),
+        detail: Some(format!("{type_detail} (in {scope_label})")),
+        documentation: Some(Documentation::MarkupContent(MarkupContent {
+            kind: MarkupKind::Markdown,
+            value: format!(
+                "**Local binding** in `{scope_label}` scope.\n\n```typescript\n{name}: {type_detail}\n```\n\n{doc}",
+            ),
+        })),
+        // `00` is lexicographically smaller than the `0` prefix used for
+        // top-level setup bindings, so closer-scope candidates rank higher in
+        // the editor's completion list.
+        sort_text: Some(format!("00{name}")),
+        ..Default::default()
+    }
+}
+
+fn scope_kind_short_label(kind: ScopeKind) -> &'static str {
+    match kind {
+        ScopeKind::Closure => "closure",
+        ScopeKind::Block => "block",
+        ScopeKind::Function => "function",
+        ScopeKind::Callback => "callback",
+        ScopeKind::EventHandler => "event handler",
+        ScopeKind::VFor => "v-for",
+        ScopeKind::VSlot => "v-slot",
+        ScopeKind::ClientOnly => "lifecycle hook",
+        ScopeKind::Universal => "setup body",
+        _ => "local",
     }
 }
 


### PR DESCRIPTION
Closes #679. Part of the [Typechecker and LSP roadmap (#676)](https://github.com/ubugeeei/vize/issues/676).

## Problem

Script completion in Maestro enumerated only top-level setup bindings via `croquis.bindings`. Variables declared inside function bodies, callbacks, blocks, `v-for`, `v-slot`, etc. were tracked by the Croquis `ScopeChain` but never reached the completion list:

```vue
<script setup lang="ts">
function increment() {
  const localStep = 1
  loc| // <- 'localStep' was missing
}
</script>
```

## Change

Three layers, kept narrow:

- `vize_croquis::scope::types::binding::Span` gets `contains`, `len`, `is_empty`.
- `ScopeChain::scope_at_offset(offset)` returns the deepest scope whose span contains the offset, ignoring global scopes that use the default span.
- `ScopeChain::bindings_visible_at(offset)` walks from that scope through its parents and yields each visible `(name, ScopeBinding, ScopeKind)`. Inner-scope bindings shadow outer ones.

`vize_maestro::ide::completion::script::complete_script` translates the SFC-absolute cursor offset into the script-local coordinate system the scope chain uses, then merges nested-scope bindings into the completion list. They sort with a `00` prefix so closer scopes rank above setup-scope candidates. Module / global scopes are skipped here — `composition_api_completions` and `import_completions` already cover those.

## Verification

- `cargo test -p vize_croquis` — 153 passed (three new tests for `bindings_visible_at`).
- `cargo test -p vize_maestro` — 255 passed (two new LSP tests).
- `cargo clippy -p vize_croquis -p vize_maestro -- -D warnings`
- `cargo fmt --check`

## Out of scope

- Surfacing scoped types and TypeScript-resolved details on the inner-scope items — that needs the Corsa member-access path landed by T1-1 (#678).
- Routing `.` member access through cursor-context (T1-3, #680).
- Inner-scope bindings in *template* completion — covered by the same issue but split out so this PR stays focused on the script side.
