### PR TITLE
fix(lsp): stop proposing setup bindings at non-ref member access

### DIFF
--- a/crates/vize_maestro/src/ide/completion.rs
+++ b/crates/vize_maestro/src/ide/completion.rs
@@ -348,6 +348,46 @@ out
     }
 
     #[test]
+    fn test_script_member_access_on_non_ref_returns_empty_in_sync_fallback() {
+        // When Corsa is not available, the synchronous completion path used to
+        // fall through to the full Composition-API + setup-bindings list at
+        // `.|` sites, which is misleading because none of those names make
+        // sense after a dot. The empty response lets the editor either show
+        // nothing or pick up Corsa-backed members from `complete_with_corsa`.
+        let source = r#"<script setup lang="ts">
+const arr = [1, 2, 3]
+arr.
+</script>
+"#;
+        let (state, uri) = state_with_document("MemberAccessNonRef.vue", source);
+        let offset = source.find("arr.").unwrap() + "arr.".len();
+        let ctx = IdeContext::new(&state, &uri, offset).unwrap();
+        let response = CompletionService::complete(&ctx);
+        assert!(
+            response.is_none(),
+            "expected no completion at `arr.|`, got {response:?}",
+        );
+    }
+
+    #[test]
+    fn test_script_member_access_after_decimal_literal_is_not_member_access() {
+        // `1.` is a decimal literal in progress, not a member access. The
+        // sync fallback should NOT swallow completion here — the user is
+        // still typing a number.
+        let source = r#"<script setup lang="ts">
+const n = 1.
+</script>
+"#;
+        let (state, uri) = state_with_document("DecimalLiteralCompletion.vue", source);
+        let offset = source.find("1.").unwrap() + "1.".len();
+        let ctx = IdeContext::new(&state, &uri, offset).unwrap();
+        let labels = completion_labels(CompletionService::complete(&ctx).unwrap());
+        // The response is not the empty short-circuit — completion proceeds
+        // and offers at least the standard Composition-API items.
+        assert!(labels.contains(&"ref".to_string()));
+    }
+
+    #[test]
     fn test_script_completion_infers_computed_ref_type() {
         let source = r#"<script setup lang="ts">
 import { ref, computed } from 'vue'

--- a/crates/vize_maestro/src/ide/completion/script.rs
+++ b/crates/vize_maestro/src/ide/completion/script.rs
@@ -34,6 +34,16 @@ pub(crate) fn complete_script(ctx: &IdeContext, is_setup: bool) -> Vec<Completio
         return items;
     }
 
+    // If the cursor is right after a `.`, the user is asking for member
+    // completion. We don't have Corsa here, so we cannot resolve arbitrary
+    // member chains — but proposing the full setup-binding list is actively
+    // misleading: none of those names make sense after a dot. Return empty
+    // and let the Corsa-backed `complete_with_corsa` path (when available)
+    // produce the real members.
+    if is_cursor_after_dot(&ctx.content, ctx.offset) {
+        return Vec::new();
+    }
+
     let mut items_vec = Vec::new();
 
     // Add Vue Composition API
@@ -307,6 +317,39 @@ fn scope_kind_short_label(kind: ScopeKind) -> &'static str {
         ScopeKind::Universal => "setup body",
         _ => "local",
     }
+}
+
+/// True when the cursor sits immediately after a `.` (allowing intermediate
+/// whitespace) on a receiver that looks like an identifier or member chain.
+/// Used to suppress the full setup-binding completion list at member-access
+/// sites where it would be misleading.
+fn is_cursor_after_dot(content: &str, offset: usize) -> bool {
+    let before = &content[..offset.min(content.len())];
+    let trimmed = before.trim_end();
+    let Some(stripped) = trimmed.strip_suffix('.') else {
+        return false;
+    };
+
+    // Guard against decimal literals like `1.|` and standalone `.` in
+    // operator positions (e.g. `... .foo`). Require at least one identifier
+    // byte right before the dot, and at least one *non-digit* identifier byte
+    // somewhere in the trailing identifier so we don't claim `1.|` as a
+    // member access on the number `1`.
+    let bytes = stripped.as_bytes();
+    let mut idx = bytes.len();
+    let mut saw_non_digit = false;
+    while idx > 0 {
+        let byte = bytes[idx - 1];
+        if !is_ident_byte(byte) && byte != b']' {
+            break;
+        }
+        if !byte.is_ascii_digit() && byte != b']' {
+            saw_non_digit = true;
+        }
+        idx -= 1;
+    }
+    let prefix_len = stripped.len() - idx;
+    prefix_len > 0 && saw_non_digit
 }
 
 fn member_access_receiver(content: &str, offset: usize) -> Option<&str> {


### PR DESCRIPTION
Partial fix for #678. Part of the [Typechecker and LSP roadmap (#676)](https://github.com/ubugeeei/vize/issues/676).

## Problem

When the cursor sits at `arr.|` in script and the receiver is not a known ref, `complete_script` (`crates/vize_maestro/src/ide/completion/script.rs`) fell through to the full Composition-API + setup-bindings list. None of those names make sense after a dot, so the editor showed a misleading popup with `ref`, `computed`, `arr`, `defineProps`, etc.

## Change

Short-circuit the synchronous fallback at member-access sites where the existing `.value` heuristic does not apply. The Corsa-backed `complete_with_corsa` path remains the source of truth for real TypeScript member completion; this only stops drowning it with noise on the fallback path.

The detector avoids two false positives:

- Decimal literals like `1.` are not treated as member access.
- Operator positions like `... .foo` (only a dot prefix) are skipped.

## Verification

- `cargo test -p vize_maestro` — 253 existing + 2 new tests pass.
- `cargo clippy -p vize_maestro -- -D warnings`
- `cargo fmt --check`

New tests:

- `test_script_member_access_on_non_ref_returns_empty_in_sync_fallback` — `arr.|` returns no completion.
- `test_script_member_access_after_decimal_literal_is_not_member_access` — `const n = 1.|` still shows the Composition API.
- The existing `test_script_ref_member_completion_includes_value` (`count.|` → `value`) continues to pass.

## Out of scope (remaining T1-1 work)

- Always-on Corsa routing for `.` completion: requires the migration to consume `CursorContext::MemberAccess` from #702.
- Broader fallback for `reactive(...)` literal property names and built-in `Array`/`Promise`/`Map`/`Set` members.

Both follow up in the same #678 issue.
