### PR TITLE
fix(vite-plugin): resolve Vue from virtual modules under pnpm-isolated installs

### DIFF
--- a/npm/vite-plugin-vize/src/plugin/resolve.test.ts
+++ b/npm/vite-plugin-vize/src/plugin/resolve.test.ts
@@ -391,6 +391,130 @@ function expectResolvedId(resolved: Awaited<ReturnType<typeof resolveIdHook>>): 
   );
 }
 
+// pnpm-isolated dev install: the project root has no `node_modules/vue`, so
+// deferring to Vite's secondary resolveId pass (which uses the \0-prefixed
+// virtual ID as importer and falls back to root) cannot find Vue. The plugin
+// must resolve Vue from the importer's package subtree instead.
+{
+  const projectRoot = createTempProject("dev-vue-pnpm-isolated-ctx");
+  const nuxtImporter = path.join(
+    projectRoot,
+    "node_modules",
+    ".pnpm",
+    "nuxt@4.4.2_x",
+    "node_modules",
+    "nuxt",
+    "dist",
+    "app",
+    "components",
+    "nuxt-root.vue",
+  );
+  const vuePackage = path.join(
+    projectRoot,
+    "node_modules",
+    ".pnpm",
+    "vue@3.5.30_x",
+    "node_modules",
+    "vue",
+  );
+  const vueLink = path.join(
+    projectRoot,
+    "node_modules",
+    ".pnpm",
+    "nuxt@4.4.2_x",
+    "node_modules",
+    "vue",
+  );
+  const vueBundlerEntry = path.join(vuePackage, "dist", "vue.runtime.esm-bundler.js");
+  writeFixtureFile(nuxtImporter, "<template><div /></template>");
+  writeFixtureFile(
+    path.join(vuePackage, "package.json"),
+    JSON.stringify({ name: "vue", main: "index.js" }, null, 2),
+  );
+  writeFixtureFile(path.join(vuePackage, "index.js"), "module.exports = {};");
+  writeFixtureFile(vueBundlerEntry, "export const Transition = () => null;");
+  fs.mkdirSync(path.dirname(vueLink), { recursive: true });
+  fs.symlinkSync(vuePackage, vueLink, "dir");
+
+  const isolatedResolved = path.join(vueLink, "dist", "vue.runtime.esm-bundler.js");
+
+  const resolved = await resolveIdHook(
+    {
+      resolve: async (id) => (id === "vue" ? { id: isolatedResolved } : null),
+    },
+    createState(projectRoot),
+    "vue",
+    toVirtualId(nuxtImporter),
+    undefined,
+  );
+
+  assert.equal(
+    expectResolvedId(resolved),
+    vueBundlerEntry,
+    "Dev virtual SFC Vue imports must resolve to the importer-local Vue runtime when the project root has no hoisted node_modules/vue",
+  );
+}
+
+// Same pnpm-isolated dev scenario, but Vite's own resolver cannot see Vue
+// (e.g. when the secondary lookup uses the virtual ID as importer). The
+// plugin must still find Vue via Node's resolution chain through the
+// importer's package subtree.
+{
+  const projectRoot = createTempProject("dev-vue-pnpm-isolated-node-fallback");
+  const nuxtImporter = path.join(
+    projectRoot,
+    "node_modules",
+    ".pnpm",
+    "nuxt@4.4.2_x",
+    "node_modules",
+    "nuxt",
+    "dist",
+    "app",
+    "components",
+    "nuxt-root.vue",
+  );
+  const vuePackage = path.join(
+    projectRoot,
+    "node_modules",
+    ".pnpm",
+    "vue@3.5.30_x",
+    "node_modules",
+    "vue",
+  );
+  const vueLink = path.join(
+    projectRoot,
+    "node_modules",
+    ".pnpm",
+    "nuxt@4.4.2_x",
+    "node_modules",
+    "vue",
+  );
+  const vueBundlerEntry = path.join(vuePackage, "dist", "vue.runtime.esm-bundler.js");
+  writeFixtureFile(nuxtImporter, "<template><div /></template>");
+  writeFixtureFile(
+    path.join(vuePackage, "package.json"),
+    JSON.stringify({ name: "vue", main: "index.js" }, null, 2),
+  );
+  writeFixtureFile(path.join(vuePackage, "index.js"), "module.exports = {};");
+  writeFixtureFile(vueBundlerEntry, "export const Transition = () => null;");
+  fs.mkdirSync(path.dirname(vueLink), { recursive: true });
+  fs.symlinkSync(vuePackage, vueLink, "dir");
+
+  const resolved = await resolveIdHook(
+    nullResolveContext,
+    createState(projectRoot),
+    "vue",
+    toVirtualId(nuxtImporter),
+    undefined,
+  );
+
+  assert.equal(
+    expectResolvedId(resolved),
+    vueBundlerEntry,
+    "Dev virtual SFC Vue imports must fall back to Node's importer-local resolution when Vite cannot see Vue from the project root",
+  );
+}
+
 {
   const tempRoot = createTempRoot("regexp-bare-alias");
   const viteRoot = path.join(tempRoot, "app");

--- a/npm/vite-plugin-vize/src/plugin/resolve.ts
+++ b/npm/vite-plugin-vize/src/plugin/resolve.ts
@@ -172,6 +172,30 @@ function isOptimizedVueDependency(id: string): boolean {
   return normalized.includes("/node_modules/.vite/deps/vue.");
 }
 
+// Cache per project root: does `<root>/node_modules/vue` resolve via Node?
+//
+// When vize defers Vue runtime in dev (returns null), Vite re-runs resolveId
+// with the \0-prefixed virtual module ID as importer. With pnpm-isolated
+// installs the project root has no hoisted `node_modules/vue`, so that
+// secondary lookup fails with `Failed to resolve import "vue"`. The deferral
+// only makes sense when the project root can serve as a fallback base for
+// vite:resolve.
+const vueResolvableFromRootCache = new Map<string, boolean>();
+function isVueResolvableFromRoot(root: string): boolean {
+  let cached = vueResolvableFromRootCache.get(root);
+  if (cached === undefined) {
+    cached = false;
+    try {
+      createRequire(path.join(root, "__vize_probe__.js")).resolve("vue");
+      cached = true;
+    } catch {
+      // Not resolvable from root.
+    }
+    vueResolvableFromRootCache.set(root, cached);
+  }
+  return cached;
+}
+
 function normalizeResolvedVuePath(id: string): string | null {
   return normalizeViteResolvedVuePath(id);
 }
@@ -439,8 +463,18 @@ export async function resolveIdHook(
             }
 
             if (isVueRuntime && state.server !== null && !isOptimizedVueDependency(resolved.id)) {
-              state.logger.log(`resolveId: deferring Vue runtime ${resolved.id} to Vite optimizer`);
-              return null;
+              if (isVueResolvableFromRoot(state.root)) {
+                state.logger.log(
+                  `resolveId: deferring Vue runtime ${resolved.id} to Vite optimizer`,
+                );
+                return null;
+              }
+              const isolatedEntry =
+                resolveVueBundlerEntryWithNode(state, id, cleanImporter) ?? resolved.id;
+              state.logger.log(
+                `resolveId: isolated install — resolved Vue runtime to ${isolatedEntry}`,
+              );
+              return isolatedEntry;
             }
 
             if (isVueRuntime && isVuePackageEntry(resolved.id)) {
@@ -454,9 +488,10 @@ export async function resolveIdHook(
 
             if (isViteBareSpecifier(resolved.id)) {
               if (isVueRuntime) {
-                const vueBundlerEntry = isBuild
-                  ? resolveVueBundlerEntryWithNode(state, id, cleanImporter)
-                  : null;
+                const vueBundlerEntry =
+                  isBuild || !isVueResolvableFromRoot(state.root)
+                    ? resolveVueBundlerEntryWithNode(state, id, cleanImporter)
+                    : null;
                 if (vueBundlerEntry) {
                   state.logger.log(`resolveId: resolved Vue runtime to ${vueBundlerEntry}`);
                   return vueBundlerEntry;
@@ -486,9 +521,10 @@ export async function resolveIdHook(
         }
 
         if (isVueRuntime) {
-          const vueBundlerEntry = isBuild
-            ? resolveVueBundlerEntryWithNode(state, id, cleanImporter)
-            : null;
+          const vueBundlerEntry =
+            isBuild || !isVueResolvableFromRoot(state.root)
+              ? resolveVueBundlerEntryWithNode(state, id, cleanImporter)
+              : null;
           if (vueBundlerEntry) {
             state.logger.log(`resolveId: resolved Vue runtime to ${vueBundlerEntry}`);
             return vueBundlerEntry;


### PR DESCRIPTION
## Summary

Fixes [#704](https://github.com/ubugeeei/vize/issues/704) — `[plugin:vite:import-analysis] Failed to resolve import "vue" from "nuxt-root.vue.ts"` when running `@vizejs/nuxt` with the Vize compiler enabled under a pnpm-isolated install.

## Why this happens

`@vizejs/nuxt` removes `@vitejs/plugin-vue` when `vize.compiler: true` ([npm/nuxt/src/index.ts:209-219](https://github.com/ubugeeei/vize/blob/codex/fix-pnpm-virtual-vue-resolve/npm/nuxt/src/index.ts#L209-L219)) and lets Vize emit `\0…\.vue.ts` virtual modules whose code begins with:

```js
import { defineAsyncComponent as __nuxt_define_async_component } from "vue";
```

In dev, Vize's `resolveIdHook` was unconditionally deferring Vue runtime resolution back to Vite (returning `null`) so Vue could be deduped through the optimizer (#486). That deferral assumes Vite's secondary `resolveId("vue", "<virtual-id>")` pass will reach Vue from the project root — which holds for npm/yarn installs that hoist `node_modules/vue` to the root.

Under a pnpm-isolated install (the default; no `shamefully-hoist`):

- `<root>/node_modules/vue` does not exist (the project has no direct `vue` dependency).
- Vue physically lives at `<root>/node_modules/.pnpm/vue@3.5.30_.../node_modules/vue` and is only symlinked into the dependency subtree (e.g. `<root>/node_modules/.pnpm/nuxt@4.4.2_.../node_modules/vue`).
- Vite's secondary resolution from the `\0`-prefixed virtual ID falls back to the project root, finds no `node_modules/vue`, and fails import-analysis.

## Fix

Only defer Vue runtime resolution to Vite's optimizer when the project root can actually resolve `"vue"`. When it can't (pnpm isolation), resolve Vue from the importer's package subtree directly — preferring the ESM bundler entry via [`resolveVueBundlerEntryWithNode`](https://github.com/ubugeeei/vize/blob/codex/fix-pnpm-virtual-vue-resolve/npm/vite-plugin-vize/src/plugin/resolve.ts), falling back to the path Vite already found.

Applied at the three deferral sites in [`resolve.ts`](npm/vite-plugin-vize/src/plugin/resolve.ts) (Vite resolver succeeded with a non-optimized path, Vite resolver returned a bare specifier, Vite resolver failed). The check is memoized per project root.

## Tests

- `vp check npm/vite-plugin-vize/src/plugin/resolve.ts npm/vite-plugin-vize/src/plugin/resolve.test.ts`
- `node --test npm/vite-plugin-vize/src/plugin/*.test.ts`
- `node --test npm/vite-plugin-vize/src/*.test.ts`
- `node --test npm/nuxt/src/*.test.ts`

New `resolve.test.ts` fixtures:

- **`dev-vue-pnpm-isolated-ctx`** — project root has no `node_modules/vue`; importer is `<root>/node_modules/.pnpm/nuxt@.../node_modules/nuxt/dist/app/components/nuxt-root.vue`; Vite resolver returns a `.pnpm`-symlinked Vue entry. Expected: returns the ESM bundler entry, not `null`.
- **`dev-vue-pnpm-isolated-node-fallback`** — same layout but the Vite resolver returns nothing (mirrors the secondary lookup with the `\0` importer). Expected: resolves Vue through Node's importer-local chain to the bundler entry.

The existing `dev-vue-node-fallback` test (npm-style hoisted install) still asserts `null` for the deferral path, so the optimizer dedup behavior from #486 is preserved when `<root>/node_modules/vue` exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
