### PR TITLE
feat(lsp): include v-for and v-slot bindings in template completion

### DIFF
--- a/crates/vize_croquis/src/analyzer/template/visit_element.rs
+++ b/crates/vize_croquis/src/analyzer/template/visit_element.rs
@@ -6,16 +6,40 @@
 
 use crate::ScopeBinding;
 use crate::analysis::ComponentUsage;
-use crate::scope::{ParamNames, VForScopeData, VSlotScopeData};
-use vize_carton::{CompactString, SmallVec, profile, smallvec};
-use vize_relief::BindingType;
-use vize_relief::ast::{ElementNode, ExpressionNode, PropNode};
-
 use crate::analyzer::Analyzer;
 use crate::analyzer::helpers::{
     VForScopeAliases, extract_slot_props, is_builtin_directive, is_component_tag,
     parse_v_for_scope_expression,
 };
+use crate::scope::{ParamNames, VForScopeData, VSlotScopeData};
+use vize_carton::{CompactString, SmallVec, profile, smallvec};
+use vize_relief::BindingType;
+use vize_relief::ast::{ElementNode, ExpressionNode, PropNode, TemplateChildNode};
+
+/// End offset of an element's full subtree (including children) in the source.
+/// `ElementNode::loc` only covers the opening tag, so v-for / v-slot scopes
+/// that should extend over the element's interior fall back to this helper.
+fn element_subtree_end(el: &ElementNode<'_>) -> u32 {
+    el.children
+        .last()
+        .map(template_child_end)
+        .unwrap_or(el.loc.end.offset)
+}
+
+fn template_child_end(child: &TemplateChildNode<'_>) -> u32 {
+    match child {
+        TemplateChildNode::Element(e) => element_subtree_end(e),
+        TemplateChildNode::Text(n) => n.loc.end.offset,
+        TemplateChildNode::Comment(n) => n.loc.end.offset,
+        TemplateChildNode::Interpolation(n) => n.loc.end.offset,
+        TemplateChildNode::If(n) => n.loc.end.offset,
+        TemplateChildNode::IfBranch(n) => n.loc.end.offset,
+        TemplateChildNode::For(n) => n.loc.end.offset,
+        TemplateChildNode::TextCall(n) => n.loc.end.offset,
+        TemplateChildNode::CompoundExpression(n) => n.loc.end.offset,
+        TemplateChildNode::Hoisted(_) => 0,
+    }
+}
 
 impl Analyzer {
     /// Visit element node.
@@ -96,7 +120,8 @@ impl Analyzer {
                                 parse_v_for_scope_expression(content)
                             );
                             if let Some(aliases) = aliases {
-                                for_scope = Some((aliases, el.loc.start.offset, el.loc.end.offset));
+                                for_scope =
+                                    Some((aliases, el.loc.start.offset, element_subtree_end(el)));
                             }
                         }
                     }
@@ -177,7 +202,7 @@ impl Analyzer {
                             prop_names: prop_names.iter().cloned().collect(),
                         },
                         offset,
-                        el.loc.end.offset,
+                        element_subtree_end(el),
                     );
 
                     for name in prop_names {

--- a/crates/vize_maestro/src/ide/completion.rs
+++ b/crates/vize_maestro/src/ide/completion.rs
@@ -278,6 +278,47 @@ count.
     }
 
     #[test]
+    fn test_template_completion_includes_v_for_binding() {
+        // Cursor inside the v-for body should see the iteration variable.
+        let source = r#"<script setup lang="ts">
+const items = [1, 2, 3]
+</script>
+<template>
+  <div v-for="item in items">{{ it }}</div>
+</template>
+"#;
+        let (state, uri) = state_with_document("VForCompletion.vue", source);
+        let offset = source.find("{{ it ").unwrap() + "{{ it".len();
+        let ctx = IdeContext::new(&state, &uri, offset).unwrap();
+        let labels = completion_labels(CompletionService::complete(&ctx).unwrap());
+        assert!(
+            labels.contains(&"item".to_string()),
+            "v-for binding must be visible inside v-for body, got {labels:?}",
+        );
+    }
+
+    #[test]
+    fn test_template_completion_excludes_v_for_binding_outside() {
+        // The same v-for binding must NOT leak outside the v-for subtree.
+        let source = r#"<script setup lang="ts">
+const items = [1, 2, 3]
+</script>
+<template>
+  <div v-for="item in items">{{ item }}</div>
+  <p>{{ ite }}</p>
+</template>
+"#;
+        let (state, uri) = state_with_document("VForLeak.vue", source);
+        let offset = source.find("{{ ite ").unwrap() + "{{ ite".len();
+        let ctx = IdeContext::new(&state, &uri, offset).unwrap();
+        let labels = completion_labels(CompletionService::complete(&ctx).unwrap());
+        assert!(
+            !labels.iter().any(|l| l == "item"),
+            "v-for binding must not leak outside its subtree, got {labels:?}",
+        );
+    }
+
+    #[test]
     fn test_script_completion_includes_closure_local_binding() {
         // Cursor inside a closure body should see the binding declared in
         // that closure as well as setup-scope siblings.

--- a/crates/vize_maestro/src/ide/completion/template.rs
+++ b/crates/vize_maestro/src/ide/completion/template.rs
@@ -17,7 +17,7 @@ use tower_lsp::lsp_types::{
 use vize_atelier_sfc::croquis::{
     SfcCroquisOptions, analyze_sfc_descriptor, analyze_sfc_descriptor_with_context_legacy_vue2,
 };
-use vize_croquis::{Analyzer, AnalyzerOptions};
+use vize_croquis::{Analyzer, AnalyzerOptions, ScopeKind};
 use vize_relief::BindingType;
 
 use super::{
@@ -337,14 +337,47 @@ fn analyzed_template_binding_completions(
         return Vec::new();
     };
 
+    // Parse the template so v-for / v-slot scopes land in the Croquis scope
+    // chain. Without the AST, `analyze_sfc_descriptor` skips template-level
+    // analysis and we lose nested binding visibility.
+    let template_block = descriptor.template.as_ref();
+    let allocator = vize_carton::Bump::new();
+    let template_parse =
+        template_block.map(|tb| (vize_armature::parse(&allocator, &tb.content), tb.loc.start));
+
     let croquis_options = SfcCroquisOptions::full();
     let croquis = if ctx.state.lsp_features().legacy_vue2 {
-        analyze_sfc_descriptor_with_context_legacy_vue2(&descriptor, None, croquis_options).croquis
+        analyze_sfc_descriptor_with_context_legacy_vue2(
+            &descriptor,
+            template_parse.as_ref().map(|((ast, _), _)| ast),
+            croquis_options,
+        )
+        .croquis
     } else {
-        analyze_sfc_descriptor(&descriptor, None, croquis_options)
+        analyze_sfc_descriptor(
+            &descriptor,
+            template_parse.as_ref().map(|((ast, _), _)| ast),
+            croquis_options,
+        )
     };
 
     let mut items_vec = Vec::new();
+
+    // Scope-aware completion: include bindings introduced by v-for / v-slot /
+    // event-handler scopes that contain the cursor. Top-level setup bindings
+    // are added by the loop below; we de-dup by name.
+    if let Some((_, template_start)) = template_parse.as_ref() {
+        let template_local = ctx.offset.saturating_sub(*template_start) as u32;
+        for (name, _binding, scope_kind) in croquis.scopes.bindings_visible_at(template_local) {
+            if !is_template_scope_kind(scope_kind) {
+                continue;
+            }
+            if croquis.bindings.contains(name) {
+                continue;
+            }
+            items_vec.push(template_scope_completion_item(name, scope_kind));
+        }
+    }
     let macro_prop_names: BTreeSet<&str> = if include_vue3_details {
         BTreeSet::new()
     } else {
@@ -451,6 +484,49 @@ fn analyzed_template_binding_completions(
     }
 
     items_vec
+}
+
+/// True for scopes introduced by template-level constructs that bring new
+/// names into expression scope (v-for, v-slot, event handlers, callbacks).
+fn is_template_scope_kind(kind: ScopeKind) -> bool {
+    matches!(
+        kind,
+        ScopeKind::VFor | ScopeKind::VSlot | ScopeKind::EventHandler | ScopeKind::Callback
+    )
+}
+
+#[allow(clippy::disallowed_macros)]
+fn template_scope_completion_item(name: &str, scope_kind: ScopeKind) -> CompletionItem {
+    let label = template_scope_label(scope_kind);
+    CompletionItem {
+        label: name.to_string(),
+        kind: Some(CompletionItemKind::VARIABLE),
+        label_details: Some(CompletionItemLabelDetails {
+            detail: Some(format!(" ({label})")),
+            description: Some("local".to_string()),
+        }),
+        detail: Some(format!("Local {label} binding")),
+        documentation: Some(Documentation::MarkupContent(MarkupContent {
+            kind: MarkupKind::Markdown,
+            value: format!(
+                "**Local** binding from `{label}` scope.\n\nVisible only inside the current `{label}` subtree."
+            ),
+        })),
+        // Inner-scope bindings sort above setup-scope candidates that use
+        // a plain `0` prefix.
+        sort_text: Some(format!("00{name}")),
+        ..Default::default()
+    }
+}
+
+fn template_scope_label(kind: ScopeKind) -> &'static str {
+    match kind {
+        ScopeKind::VFor => "v-for",
+        ScopeKind::VSlot => "v-slot",
+        ScopeKind::EventHandler => "event handler",
+        ScopeKind::Callback => "callback",
+        _ => "local",
+    }
 }
 
 fn is_legacy_vue2_binding(binding_type: BindingType) -> bool {


### PR DESCRIPTION
Closes #679 (template side; script side landed in #701).

## Problem

Inside a `v-for` subtree, the iteration variable should be visible in template completion:

```vue
<template>
  <div v-for="item in items">{{ it| }}</div> <!-- completion should propose `item` -->
</template>
```

But `analyzed_template_binding_completions` only enumerated `croquis.bindings` (top-level setup). Two reasons:

1. `analyze_sfc_descriptor` was called with `template_ast: None`, so template scopes were never built.
2. Even if it were called with the AST, the v-for / v-slot scope's `end` was set to `ElementNode::loc.end.offset` — but that loc only covers the opening tag. Children inside `<div v-for>...</div>` fall outside the scope's span.

## Change

**`vize_croquis`** — `element_subtree_end` walks the last child of an element to compute the true subtree end. Both `for_scope` and `enter_v_slot_scope` use this helper instead of `el.loc.end.offset`. The scope chain now correctly contains every position inside the element's children.

**`vize_maestro`** — `analyzed_template_binding_completions` now parses the template, passes the AST to `analyze_sfc_descriptor`, translates the SFC-absolute cursor offset into template-local coordinates, and adds each visible v-for / v-slot / event-handler / callback binding to the completion list. Setup-scope names are de-duped against the existing binding loop. Inner-scope bindings use a `00` sort prefix so they rank above setup-scope candidates.

## Verification

- `cargo test -p vize_croquis` — 153 passed.
- `cargo test -p vize_maestro` — 270 passed (2 new template tests + the existing v-for / v-slot croquis snapshots continue to pass).
- `cargo clippy -p vize_croquis -p vize_maestro -- -D warnings` clean.
- `cargo fmt --check` clean.

New tests:

- `test_template_completion_includes_v_for_binding` — `<div v-for="item in items">{{ it| }}</div>` includes `item`.
- `test_template_completion_excludes_v_for_binding_outside` — `<p>{{ ite| }}</p>` outside the v-for does NOT include `item`.
