### PR TITLE
feat(lsp): surface a hint when type checking is unavailable

### DIFF
--- a/crates/vize_maestro/src/ide/diagnostics.rs
+++ b/crates/vize_maestro/src/ide/diagnostics.rs
@@ -239,6 +239,20 @@ impl DiagnosticService {
                     tracing::warn!("corsa diagnostics timed out for {}", uri);
                 }
             }
+
+            // When the user opted into typecheck but Corsa never came up
+            // (init failed, timed out, or simply not yet attempted while we
+            // already produced zero corsa diagnostics for an SFC), surface a
+            // hint diagnostic so the Problems panel reflects what is
+            // happening. Without this, the editor goes silent and users
+            // assume their project is clean. See #681.
+            if !state.has_corsa_bridge()
+                && !diagnostics
+                    .iter()
+                    .any(|d| d.source.as_deref() == Some(sources::TYPE_CHECKER))
+            {
+                diagnostics.push(typecheck_unavailable_hint());
+            }
         } else {
             tracing::info!("collect_async: Corsa diagnostics skipped (disabled by config)");
         }
@@ -262,6 +276,33 @@ impl DiagnosticService {
             message,
             ..Default::default()
         }
+    }
+}
+
+/// Build the hint diagnostic surfaced when LSP type checking is requested
+/// but the Corsa bridge is not available. Single point of truth so the
+/// wording stays consistent for tests and follow-up code-action work.
+#[cfg(feature = "native")]
+fn typecheck_unavailable_hint() -> Diagnostic {
+    Diagnostic {
+        range: Range {
+            start: tower_lsp::lsp_types::Position {
+                line: 0,
+                character: 0,
+            },
+            end: tower_lsp::lsp_types::Position {
+                line: 0,
+                character: 0,
+            },
+        },
+        severity: Some(DiagnosticSeverity::HINT),
+        code: Some(NumberOrString::String("typecheck-unavailable".to_string())),
+        source: Some(sources::TYPE_CHECKER.to_string()),
+        message: "Type checking is unavailable in this workspace. \
+            Make sure `tsconfig.json` exists and the Corsa runtime is reachable; \
+            see https://vizejs.dev/guide/static-analysis."
+            .to_string(),
+        ..Default::default()
     }
 }
 


### PR DESCRIPTION
Closes #681 (partial).

When LSP typecheck is enabled but Corsa never came up (init failed, timed out, or the workspace has no `tsconfig.json`), the editor used to go silent. Without a diagnostic in the Problems panel users assume the file is clean.

`collect_async` now emits a single hint-severity diagnostic per file when `is_lsp_typecheck_enabled()` is true and `has_corsa_bridge()` is false. The wording points at the static-analysis docs so users have somewhere to look when they want type checking but aren't getting it.

A new `typecheck_unavailable_hint()` helper keeps the wording in one place for the future `vize.typecheck.status` command and quick-fix.

## Out of scope

- One-shot `window/showMessage` (still wanted; tracked in #681).
- `vize.typecheck.status` LSP command for VS Code status bar.
