### PR TITLE
fix(lsp): suppress Corsa diagnostics after SFC compile errors

### DIFF
--- a/crates/vize_maestro/src/ide/diagnostics.rs
+++ b/crates/vize_maestro/src/ide/diagnostics.rs
@@ -311,7 +311,15 @@ fn has_blocking_parser_error(diagnostics: &[Diagnostic]) -> bool {
     diagnostics.iter().any(|diagnostic| {
         matches!(
             diagnostic.source.as_deref(),
-            Some(sources::SFC_PARSER | sources::SCRIPT_PARSER | sources::TEMPLATE_PARSER)
+            // Parser-level errors plus SFC compile-time validation errors
+            // both leave the script body in a state where Corsa would just
+            // cascade — the user already has the actionable diagnostic.
+            Some(
+                sources::SFC_PARSER
+                    | sources::SCRIPT_PARSER
+                    | sources::TEMPLATE_PARSER
+                    | sources::SFC_COMPILER
+            )
         ) && diagnostic.severity == Some(DiagnosticSeverity::ERROR)
     })
 }


### PR DESCRIPTION
Closes #684 (partial).

`has_blocking_parser_error` previously stopped Corsa diagnostics when the SFC, script, or template parser raised an error. SFC compile-time validation errors (e.g. `DEFINE_PROPS_DESTRUCTURE_DEFAULT_TYPE` landed in #675) leave the script body in the same state, but the check ignored them, so the user got the actionable Vize-flavored diagnostic plus a cascade of TypeScript noise on top.

Adds `sources::SFC_COMPILER` to the suppression list so the user sees only the actionable diagnostic.

## Out of scope

- Per-block scope suppression after error recovery (the broader #684 ask). Tracked there.
