### PR TITLE
feat(lsp): add languageServer.crossFile config knob

### DIFF
--- a/crates/vize_carton/src/config/model/language_server.rs
+++ b/crates/vize_carton/src/config/model/language_server.rs
@@ -54,6 +54,13 @@ pub struct LanguageServerConfig {
     /// Deprecated alias for `corsa`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tsgo: Option<bool>,
+    /// Opt into cross-file diagnostic groups (provide/inject matching,
+    /// reactivity tracking, race conditions, etc.) from the language server.
+    /// Defaults to off because these groups need a workspace-wide scan and
+    /// can be slower than single-file lint. See `vize lint --cross-file` for
+    /// the same machinery on the CLI side.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cross_file: Option<bool>,
 }
 
 impl LanguageServerConfig {

--- a/crates/vize_carton/tests/snapshots/loading__loads_legacy_pkl_lsp_alias.snap.new
+++ b/crates/vize_carton/tests/snapshots/loading__loads_legacy_pkl_lsp_alias.snap.new
@@ -1,0 +1,6 @@
+---
+source: crates/vize_carton/tests/loading.rs
+assertion_line: 165
+expression: "serde_json::to_string_pretty(&config).unwrap()"
+---
+{}

--- a/crates/vize_carton/tests/snapshots/loading__loads_pkl_defaults.snap.new
+++ b/crates/vize_carton/tests/snapshots/loading__loads_pkl_defaults.snap.new
@@ -1,0 +1,6 @@
+---
+source: crates/vize_carton/tests/loading.rs
+assertion_line: 34
+expression: "serde_json::to_string_pretty(&config).unwrap()"
+---
+{}

--- a/crates/vize_maestro/src/ide/diagnostics.rs
+++ b/crates/vize_maestro/src/ide/diagnostics.rs
@@ -174,6 +174,18 @@ impl DiagnosticService {
                 Self::collect_lint_diagnostics(uri, &content, features.ecosystem, &linter_config);
             tracing::info!("collect: patina lint diagnostics: {}", lint_diags.len());
             diagnostics.extend(lint_diags);
+            if features.cross_file {
+                // Cross-file analysis is opt-in (defaults to off) because it
+                // touches every Vue file in the workspace. When enabled, the
+                // same analyzer groups used by `vize lint --cross-file` join
+                // the editor's diagnostic stream. The actual cross-file
+                // analyzer wiring is being added incrementally — for now
+                // the gate is observable through tracing so callers can
+                // verify the config knob took effect.
+                tracing::info!(
+                    "collect: cross-file lint enabled (groups will surface as they are wired up)"
+                );
+            }
         } else {
             tracing::info!("collect: patina lint diagnostics skipped (disabled by config)");
         }

--- a/crates/vize_maestro/src/server/capabilities.rs
+++ b/crates/vize_maestro/src/server/capabilities.rs
@@ -242,6 +242,7 @@ mod tests {
             folding_ranges: true,
             inlay_hints: true,
             file_rename: true,
+            cross_file: true,
         }
     }
 

--- a/crates/vize_maestro/src/server/state.rs
+++ b/crates/vize_maestro/src/server/state.rs
@@ -56,6 +56,7 @@ struct LspConfigSection {
     file_rename: Option<bool>,
     corsa: Option<bool>,
     tsgo: Option<bool>,
+    cross_file: Option<bool>,
 }
 
 impl LspConfigSection {
@@ -140,6 +141,9 @@ impl LspConfigSection {
         if let Some(enabled) = self.file_rename {
             features.file_rename = enabled;
         }
+        if let Some(enabled) = self.cross_file {
+            features.cross_file = enabled;
+        }
     }
 }
 
@@ -170,6 +174,7 @@ impl From<LanguageServerConfig> for LspConfigSection {
             file_rename: config.file_rename,
             corsa: config.corsa,
             tsgo: config.tsgo,
+            cross_file: config.cross_file,
         }
     }
 }
@@ -199,6 +204,7 @@ pub struct LspFeatureConfig {
     pub(crate) folding_ranges: bool,
     pub(crate) inlay_hints: bool,
     pub(crate) file_rename: bool,
+    pub(crate) cross_file: bool,
 }
 
 impl LspFeatureConfig {
@@ -223,6 +229,7 @@ impl LspFeatureConfig {
             folding_ranges: false,
             inlay_hints: false,
             file_rename: false,
+            cross_file: false,
         }
     }
 
@@ -270,6 +277,11 @@ impl Default for LspFeatureConfig {
             folding_ranges: true,
             inlay_hints: true,
             file_rename: true,
+            // Cross-file diagnostic groups are off by default — they scan
+            // every Vue file in the workspace, which is too slow for the
+            // default editor experience. Opt in via
+            // `languageServer.crossFile = true`.
+            cross_file: false,
         }
     }
 }


### PR DESCRIPTION
Closes #685 (foundation).

Adds `languageServer.crossFile` (default `false`) to `LanguageServerConfig` (`vize_carton`) and the local `LspFeatureConfig` / `LspConfigSection` used by Maestro. The diagnostics collector logs the gate when enabled.

Wiring the cross-file analyzer groups (provide/inject, reactivity tracking, race conditions, etc.) into the editor diagnostic stream happens in follow-ups; the knob is observable now so users can opt in and extension work can rely on the schema.

## Out of scope

- Actually producing cross-file diagnostics when the flag is on.
- VS Code extension setting binding.
