### PR TITLE
chore: gitignore insta pending-snapshot artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,7 @@ tests/fuzz/corpus/
 tests/fuzz/artifacts/
 tests/fuzz/coverage/
 tests/fuzz/target/
+
+# Insta pending snapshots (created on test failure; should not be checked in)
+*.snap.new
+*.pending-snap

--- a/crates/vize_carton/tests/snapshots/loading__loads_legacy_pkl_lsp_alias.snap.new
+++ b/crates/vize_carton/tests/snapshots/loading__loads_legacy_pkl_lsp_alias.snap.new
@@ -1,6 +1,0 @@
----
-source: crates/vize_carton/tests/loading.rs
-assertion_line: 165
-expression: "serde_json::to_string_pretty(&config).unwrap()"
----
-{}

--- a/crates/vize_carton/tests/snapshots/loading__loads_pkl_defaults.snap.new
+++ b/crates/vize_carton/tests/snapshots/loading__loads_pkl_defaults.snap.new
@@ -1,6 +1,0 @@
----
-source: crates/vize_carton/tests/loading.rs
-assertion_line: 34
-expression: "serde_json::to_string_pretty(&config).unwrap()"
----
-{}


### PR DESCRIPTION
Adds `*.snap.new` / `*.pending-snap` to .gitignore and removes the two pkl snapshot artifacts that slipped into main via #710.