### PR TITLE
feat(lsp): surface --strict-reactivity findings in editor diagnostics

### DIFF
--- a/crates/vize_carton/src/config/model/linter.rs
+++ b/crates/vize_carton/src/config/model/linter.rs
@@ -28,6 +28,17 @@ impl LinterConfig {
         self == &Self::default()
     }
 
+    /// Whether the host wants the strict-reactivity rule enabled. The rule
+    /// shows up when `type/no-reactivity-loss` is explicitly configured to
+    /// `warn` or `error` (rather than `off`). CLI users opt in via
+    /// `--strict-reactivity`; LSP users opt in via the same rule entry.
+    pub fn strict_reactivity_enabled(&self) -> bool {
+        self.rules
+            .get("type/no-reactivity-loss")
+            .map(|severity| !matches!(severity, LintRuleSeverity::Off))
+            .unwrap_or(false)
+    }
+
     /// Rule names explicitly disabled by config.
     pub fn disabled_rules(&self) -> Vec<String> {
         let mut rules = self

--- a/crates/vize_maestro/src/ide/diagnostics/collectors.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/collectors.rs
@@ -422,6 +422,20 @@ impl DiagnosticService {
         }
         .with_additional_rules(linter_config.enabled_rules())
         .with_disabled_rules(linter_config.disabled_rules());
+
+        // Opt-in strict-reactivity rule, mirroring `vize lint --strict-reactivity`.
+        // The CLI registers this via a flag; in the LSP it follows the
+        // `languageServer.crossFile` knob (#685) for now, on the principle
+        // that the rule needs broader analysis. A dedicated `strictReactivity`
+        // knob can split off later if usage warrants it.
+        #[cfg(not(target_arch = "wasm32"))]
+        let linter = if linter_config.strict_reactivity_enabled() {
+            linter.with_rule(Box::new(
+                vize_patina::rules::type_aware::NoReactivityLoss::new(),
+            ))
+        } else {
+            linter
+        };
         let result = if is_standalone_html {
             linter.lint_standalone_html(content, uri.path())
         } else {


### PR DESCRIPTION
Closes #692 (foundation).

`vize lint --strict-reactivity` registers Patina's reactivity-loss type-aware rule. The LSP never did. Editor users who opted into the rule via config got no signal.

This change wires the same rule into the LSP linting path when the shared `LinterConfig.rules["type/no-reactivity-loss"]` is set to a non-`off` severity. `LinterConfig::strict_reactivity_enabled()` centralizes the check so the CLI can adopt the same predicate in a follow-up.

## Out of scope

- Editor responsiveness budget for the rule. It runs per-file, but project-wide reactivity-flow tracking will land with the cross-file groups (#685).
