### PR TITLE
feat(lsp): include defineModel-declared props in component completion

### DIFF
--- a/crates/vize_maestro/src/ide/completion/template.rs
+++ b/crates/vize_maestro/src/ide/completion/template.rs
@@ -858,6 +858,20 @@ fn extract_component_metadata(
             }
         }
 
+        // defineModel<T>() introduces a prop alongside an `update:NAME`
+        // event. Prop completion only knew about defineProps before, so
+        // child components using defineModel showed no prop suggestions.
+        // See #686.
+        for model in summary.macros.models() {
+            if seen_props.insert(model.name.to_string()) {
+                props.push(ComponentProp {
+                    name: model.name.to_string(),
+                    type_detail: model.model_type.as_ref().map(|ty| ty.to_string()),
+                    required: model.required,
+                });
+            }
+        }
+
         if legacy_vue2 {
             for (name, binding_type) in summary.bindings.iter() {
                 if binding_type == BindingType::Props && seen_props.insert(name.to_string()) {


### PR DESCRIPTION
Closes #686 (foundation).

Component prop completion read `defineProps` only. Children declared via `defineModel<T>()` got no prop suggestions, so the parent template showed an empty completion list even though the binding exists. This change appends `defineModel` models to the component metadata during the prop scan.

## Out of scope

- The companion `update:NAME` event entry for two-way `v-model` (will appear naturally once event completion lands).
- `withDefaults` default values surfaced in completion documentation.
- Generic components binding their type parameters at the call site.
