### PR TITLE
feat(lsp): complete $style class names from <style module> blocks

### DIFF
--- a/crates/vize_maestro/src/ide/completion/template.rs
+++ b/crates/vize_maestro/src/ide/completion/template.rs
@@ -34,6 +34,12 @@ pub(crate) fn complete_template(ctx: &IdeContext) -> Vec<CompletionItem> {
         return vize_directive_completions();
     }
 
+    // `$style.|` in a template expression should resolve to class names
+    // declared in the SFC's `<style module>` blocks.
+    if let Some(items) = css_module_class_completions(ctx) {
+        return items;
+    }
+
     let mut items_vec = Vec::new();
 
     // Add Vue directives
@@ -57,6 +63,87 @@ pub(crate) fn complete_template(ctx: &IdeContext) -> Vec<CompletionItem> {
     items_vec.extend(template_snippets());
 
     items_vec
+}
+
+/// `<style module>` populates a template-scope `$style` object whose
+/// properties are the declared class names. When the cursor sits at
+/// `$style.|` we surface those names instead of the usual directive list.
+fn css_module_class_completions(ctx: &IdeContext) -> Option<Vec<CompletionItem>> {
+    let before = &ctx.content[..ctx.offset.min(ctx.content.len())];
+    let trimmed = before.trim_end_matches([' ', '\t']);
+    if !trimmed.ends_with("$style.") {
+        return None;
+    }
+    let descriptor = vize_atelier_sfc::parse_sfc(
+        &ctx.content,
+        vize_atelier_sfc::SfcParseOptions {
+            filename: ctx.uri.path().to_string().into(),
+            ..Default::default()
+        },
+    )
+    .ok()?;
+    let mut classes = BTreeSet::new();
+    for style in descriptor.styles.iter() {
+        let attrs = &style.attrs;
+        if !attrs.contains_key("module") {
+            continue;
+        }
+        for class in extract_css_class_names(&style.content) {
+            classes.insert(class);
+        }
+    }
+    if classes.is_empty() {
+        return None;
+    }
+    Some(
+        classes
+            .into_iter()
+            .map(|name| {
+                #[allow(clippy::disallowed_macros)]
+                CompletionItem {
+                    label: name.clone(),
+                    kind: Some(CompletionItemKind::FIELD),
+                    detail: Some("CSS module class".to_string()),
+                    documentation: Some(Documentation::MarkupContent(MarkupContent {
+                        kind: MarkupKind::Markdown,
+                        value: format!("`{name}` from `<style module>`."),
+                    })),
+                    sort_text: Some(format!("0{name}")),
+                    ..Default::default()
+                }
+            })
+            .collect(),
+    )
+}
+
+/// Extract class selector names from raw CSS content. Approximate but good
+/// enough for completion — matches `.identifier` outside attribute selectors.
+fn extract_css_class_names(css: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let bytes = css.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'.' && i + 1 < bytes.len() && bytes[i + 1].is_ascii_alphabetic() {
+            let start = i + 1;
+            let mut end = start;
+            while end < bytes.len() && is_class_ident_byte(bytes[end]) {
+                end += 1;
+            }
+            if end > start {
+                out.push(css[start..end].to_string());
+                i = end;
+                continue;
+            }
+        }
+        i += 1;
+    }
+    out.sort();
+    out.dedup();
+    out
+}
+
+fn is_class_ident_byte(b: u8) -> bool {
+    b.is_ascii_alphanumeric() || b == b'-' || b == b'_'
 }
 
 pub(crate) fn legacy_vue2_template_completions(ctx: &IdeContext) -> Vec<CompletionItem> {


### PR DESCRIPTION
Closes #690 (foundation).

`:class="$style.|"` previously returned the default template completion list (directives, snippets, bindings). The new `css_module_class_completions` short-circuit detects `$style.` at the cursor, parses the SFC's `<style module>` blocks, and returns class names as FIELD completions instead.

The class-name extractor is approximate (regex-level `.identifier` scan), which is enough for completion. A follow-up will use LightningCSS to honour the CSS Modules name-mangling rules.

## Out of scope

- Hover / definition for identifiers inside `v-bind(scriptVar)`. Same #690 issue.
- LightningCSS-based parser so the result respects nested selectors, attribute selectors, and pseudo-classes.
