### PR TITLE
feat(canon): typed payloads for modern DOM events in virtual TS

### DIFF
--- a/crates/vize_canon/src/virtual_ts/helpers.rs
+++ b/crates/vize_canon/src/virtual_ts/helpers.rs
@@ -285,8 +285,46 @@ pub(crate) fn get_dom_event_type(event_name: &str) -> &'static str {
         // Selection events
         "select" | "selectionchange" | "selectstart" => "Event",
 
+        // Modern UI events that were absent — without an entry, `@toggle` /
+        // `@beforetoggle` etc. fell back to the bare `Event` interface and
+        // the user lost the specific payload members. See #688.
+        "toggle" | "beforetoggle" => "ToggleEvent",
+        "formdata" => "FormDataEvent",
+        "popstate" => "PopStateEvent",
+        "hashchange" => "HashChangeEvent",
+        "message" => "MessageEvent",
+        "storage" => "StorageEvent",
+        "online" | "offline" => "Event",
+        "securitypolicyviolation" => "SecurityPolicyViolationEvent",
+
         // Default fallback
         _ => "Event",
+    }
+}
+
+#[cfg(test)]
+mod event_type_tests {
+    use super::get_dom_event_type;
+
+    #[test]
+    fn maps_legacy_dom_events() {
+        assert_eq!(get_dom_event_type("click"), "MouseEvent");
+        assert_eq!(get_dom_event_type("keydown"), "KeyboardEvent");
+        assert_eq!(get_dom_event_type("submit"), "SubmitEvent");
+    }
+
+    #[test]
+    fn maps_modern_dom_events() {
+        // These fell back to `Event` before #688 — now they get the specific
+        // interface so `e.newState` / `e.formData` etc. complete.
+        assert_eq!(get_dom_event_type("toggle"), "ToggleEvent");
+        assert_eq!(get_dom_event_type("beforetoggle"), "ToggleEvent");
+        assert_eq!(get_dom_event_type("formdata"), "FormDataEvent");
+    }
+
+    #[test]
+    fn unknown_events_fall_back_to_event() {
+        assert_eq!(get_dom_event_type("totally-made-up"), "Event");
     }
 }
 


### PR DESCRIPTION
Closes #688 (foundation).

Event handler scope codegen in `vize_canon` already infers the TypeScript event type for every `<@event>` binding and exposes `$event` with that type to the type checker. The mapping table missed several modern UI events though, so `@toggle`, `@beforetoggle`, `@formdata`, `@popstate`, `@hashchange`, `@message`, `@storage`, `@securitypolicyviolation` all fell back to the bare `Event` interface — and member completion on `$event` lost the specific payload shape.

Extends `get_dom_event_type` with those entries plus three unit tests covering legacy, modern, and fallback paths.

## Out of scope

- Custom component event payloads via `defineEmits<{ name: (arg: T) => any }>()`. Already wired in scope.rs for `check_emits = true` (the default); follow-ups in #688 cover the inference edge cases.
