### PR TITLE
feat(canon): extend VizeMapping with sub-token spans

### DIFF
--- a/crates/vize_canon/src/batch/source_map.rs
+++ b/crates/vize_canon/src/batch/source_map.rs
@@ -236,6 +236,7 @@ mod tests {
                     start: 50,
                     end: 150,
                 },
+                sub_spans: Vec::new(),
             }],
             vec![SfcBlockRange {
                 start: 50,

--- a/crates/vize_canon/src/batch/virtual_ts.rs
+++ b/crates/vize_canon/src/batch/virtual_ts.rs
@@ -106,6 +106,7 @@ impl VirtualTsGenerator {
                 gen_range: start..end,
                 src_range: script_setup.loc.start
                     ..script_setup.loc.start + script_setup.content.len(),
+                sub_spans: Vec::new(),
             });
             blocks.push(SfcBlockRange {
                 start: script_setup.loc.start as u32,
@@ -119,6 +120,7 @@ impl VirtualTsGenerator {
             mappings.push(VizeMapping {
                 gen_range: start..end,
                 src_range: script.loc.start..script.loc.start + script.content.len(),
+                sub_spans: Vec::new(),
             });
             blocks.push(SfcBlockRange {
                 start: script.loc.start as u32,
@@ -137,6 +139,7 @@ impl VirtualTsGenerator {
             mappings.push(VizeMapping {
                 gen_range: start..end,
                 src_range: template.loc.start..template.loc.start + template.content.len(),
+                sub_spans: Vec::new(),
             });
             blocks.push(SfcBlockRange {
                 start: template.loc.start as u32,

--- a/crates/vize_canon/src/virtual_ts/expressions.rs
+++ b/crates/vize_canon/src/virtual_ts/expressions.rs
@@ -73,6 +73,7 @@ pub(crate) fn generate_expression(
                 gen_stmt_start,
             ),
             src_range: src_start..src_end,
+            sub_spans: Vec::new(),
         });
         append!(
             *ts,
@@ -95,6 +96,7 @@ pub(crate) fn generate_expression(
                 gen_stmt_start,
             ),
             src_range: src_start..src_end,
+            sub_spans: Vec::new(),
         });
         append!(*ts, "{indent}// @vize-map: expr -> {src_start}:{src_end}\n",);
     }
@@ -168,6 +170,7 @@ pub(crate) fn generate_component_prop_checks(
             mappings.push(VizeMapping {
                 gen_range: gen_stmt_start..gen_stmt_end,
                 src_range: prop_src_start..prop_src_end,
+                sub_spans: Vec::new(),
             });
 
             if usage.vif_guard.is_some() {

--- a/crates/vize_canon/src/virtual_ts/generator.rs
+++ b/crates/vize_canon/src/virtual_ts/generator.rs
@@ -181,6 +181,7 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
                     gen_range: gen_start..gen_end,
                     src_range: (script_offset as usize + start as usize)
                         ..(script_offset as usize + end as usize),
+                    sub_spans: Vec::new(),
                 });
             }
 
@@ -358,6 +359,7 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
                     mappings.push(VizeMapping {
                         gen_range: gen_content_start..gen_content_end,
                         src_range: src_line_start..src_line_end,
+                        sub_spans: Vec::new(),
                     });
                 }
                 let _ = gen_line_start; // suppress unused warning

--- a/crates/vize_canon/src/virtual_ts/scope.rs
+++ b/crates/vize_canon/src/virtual_ts/scope.rs
@@ -227,6 +227,7 @@ fn generate_undefined_refs(
         mappings.push(VizeMapping {
             gen_range: gen_name_start..gen_name_end,
             src_range: src_start..src_end,
+            sub_spans: Vec::new(),
         });
         append!(
             *ts,
@@ -679,6 +680,7 @@ fn generate_event_handler_expressions(
                     generated_text_range(&ts[gen_stmt_start..gen_stmt_end], content, gen_stmt_start)
                 },
                 src_range: src_start..src_end,
+                sub_spans: Vec::new(),
             });
             append!(
                 *ts,

--- a/crates/vize_canon/src/virtual_ts/types.rs
+++ b/crates/vize_canon/src/virtual_ts/types.rs
@@ -10,6 +10,33 @@ pub struct VizeMapping {
     pub gen_range: Range<usize>,
     /// Byte range in the original SFC source.
     pub src_range: Range<usize>,
+    /// Sub-token spans inside `gen_range`, paired with the matching SFC
+    /// sub-range. Used to map TypeScript diagnostics that point at a
+    /// specific identifier inside a template expression back to its exact
+    /// position in the Vue source.
+    ///
+    /// Empty by default. Populated by template-expression generators that
+    /// know the inner positions (e.g. property access inside an
+    /// interpolation). Consumers fall back to `gen_range` / `src_range`
+    /// when no sub-span covers the diagnostic.
+    pub sub_spans: Vec<VizeSubSpan>,
+}
+
+/// A sub-token span inside a `VizeMapping`'s generated/source ranges.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VizeSubSpan {
+    pub gen_range: Range<usize>,
+    pub src_range: Range<usize>,
+}
+
+impl VizeMapping {
+    /// Look up the SFC sub-range that contains `gen_offset`. Returns `None`
+    /// when no sub-span covers it — callers should fall back to `src_range`.
+    pub fn sub_span_for_gen(&self, gen_offset: usize) -> Option<&VizeSubSpan> {
+        self.sub_spans
+            .iter()
+            .find(|span| span.gen_range.contains(&gen_offset))
+    }
 }
 
 /// A user-defined template global variable (e.g., `$t` from vue-i18n).


### PR DESCRIPTION
Closes #682 (foundation).

`VizeMapping` previously held a single `src_range` per `gen_range`. Template diagnostics about an identifier inside an interpolation could only underline the whole interpolation. The new `sub_spans` field carries inner span pairs (gen offset → SFC offset) so the LSP diagnostic mapper can narrow the range when it knows the precise token position.

Existing call sites pass `sub_spans: Vec::new()`; generator passes that have per-token positions (e.g. property access inside an interpolation) populate the field in a follow-up.

A new `VizeMapping::sub_span_for_gen` helper looks up the matching sub-span for a given generated offset.

## Out of scope

- Populating `sub_spans` from the generator. The diagnostic mapper falls back to `src_range` until then, preserving current behavior.
