### PR TITLE
feat(lsp): fire one-shot showMessage when type checking is unavailable

### DIFF
--- a/crates/vize_maestro/src/server/helpers.rs
+++ b/crates/vize_maestro/src/server/helpers.rs
@@ -6,7 +6,7 @@
 
 use tower_lsp::lsp_types::{
     CompletionItem, CompletionItemKind, DiagnosticSeverity, Hover, HoverContents, InsertTextFormat,
-    MarkupContent, MarkupKind, NumberOrString, Position, Url,
+    MarkupContent, MarkupKind, MessageType, NumberOrString, Position, Url,
 };
 
 use crate::ide::DiagnosticService;
@@ -60,6 +60,25 @@ impl MaestroServer {
         self.client
             .publish_diagnostics(uri.clone(), diagnostics, Some(version))
             .await;
+
+        // Surface a one-shot UI notification when type checking is requested
+        // but Corsa never came up. The hint diagnostic emitted by
+        // collect_async (see #708) shows up in the Problems panel; this
+        // adds a window/showMessage so users with the Problems panel
+        // collapsed also notice. See #681.
+        #[cfg(feature = "native")]
+        if self.state.is_lsp_typecheck_enabled()
+            && !self.state.has_corsa_bridge()
+            && self.state.claim_typecheck_unavailable_notice()
+        {
+            self.client
+                .show_message(
+                    MessageType::WARNING,
+                    "Vize: type checking is unavailable in this workspace. \
+                     Make sure tsconfig.json exists and the Corsa runtime is reachable.",
+                )
+                .await;
+        }
     }
 
     /// Get block snippet completions (when outside all blocks).

--- a/crates/vize_maestro/src/server/state.rs
+++ b/crates/vize_maestro/src/server/state.rs
@@ -372,6 +372,11 @@ pub struct ServerState {
     /// Flag to track if Corsa initialization has been attempted and failed
     #[cfg(feature = "native")]
     corsa_init_failed: std::sync::atomic::AtomicBool,
+    /// True once the LSP server has shown the user a one-shot
+    /// `window/showMessage` explaining that type checking is unavailable.
+    /// Prevents the message from firing once per file.
+    #[cfg(feature = "native")]
+    typecheck_unavailable_notified: std::sync::atomic::AtomicBool,
     /// Workspace root path
     #[cfg(feature = "native")]
     workspace_root: RwLock<Option<PathBuf>>,
@@ -411,12 +416,25 @@ impl ServerState {
             #[cfg(feature = "native")]
             corsa_init_failed: std::sync::atomic::AtomicBool::new(false),
             #[cfg(feature = "native")]
+            typecheck_unavailable_notified: std::sync::atomic::AtomicBool::new(false),
+            #[cfg(feature = "native")]
             workspace_root: RwLock::new(None),
             #[cfg(feature = "native")]
             batch_checker: OnceLock::new(),
             #[cfg(feature = "native")]
             batch_cache: BatchTypeCheckCache::new(),
         }
+    }
+
+    /// Try to claim the right to fire the "type checking unavailable"
+    /// message. Returns true the first time it is called, false thereafter
+    /// for the lifetime of the server. The caller is responsible for
+    /// actually sending the message via the LSP client.
+    #[cfg(feature = "native")]
+    pub fn claim_typecheck_unavailable_notice(&self) -> bool {
+        !self
+            .typecheck_unavailable_notified
+            .swap(true, std::sync::atomic::Ordering::SeqCst)
     }
 
     /// Set the workspace root path.


### PR DESCRIPTION
Follow-up to #708 (issue #681).

The hint diagnostic added in #708 surfaces the unavailability in the Problems panel, but users with the panel collapsed never notice. This commit fires a `window/showMessage` warning once per server session when typecheck is enabled but the Corsa bridge fails to initialize.

A new `claim_typecheck_unavailable_notice()` on `ServerState` atomically test-and-sets a flag so the message can't fire twice in a session. `publish_diagnostics` consults it after publishing.

## Out of scope

- `vize.typecheck.status` LSP command for VS Code status bar integration (still wanted; tracked in #681).
