### PR TITLE
feat(lsp): complete reactive() object keys without Corsa

### DIFF
--- a/crates/vize_maestro/src/ide/completion.rs
+++ b/crates/vize_maestro/src/ide/completion.rs
@@ -393,6 +393,31 @@ out
     }
 
     #[test]
+    fn test_script_member_access_lists_reactive_object_keys() {
+        // Follow-up to #678: `const obj = reactive({ a: 1, b: '' })` then
+        // `obj.|` should surface `a` and `b` from the initializer even
+        // when Corsa isn't available.
+        let source = r#"<script setup lang="ts">
+import { reactive } from 'vue'
+const obj = reactive({ count: 0, label: 'hello' })
+obj.
+</script>
+"#;
+        let (state_, uri) = state_with_document("ReactiveKeys.vue", source);
+        let offset = source.find("obj.\n").unwrap() + "obj.".len();
+        let ctx = IdeContext::new(&state_, &uri, offset).unwrap();
+        let labels = completion_labels(CompletionService::complete(&ctx).unwrap());
+        assert!(
+            labels.iter().any(|l| l == "count"),
+            "expected `count` from reactive() keys, got {labels:?}",
+        );
+        assert!(
+            labels.iter().any(|l| l == "label"),
+            "expected `label` from reactive() keys, got {labels:?}",
+        );
+    }
+
+    #[test]
     fn test_script_member_access_on_non_ref_returns_empty_in_sync_fallback() {
         // When Corsa is not available, the synchronous completion path used to
         // fall through to the full Composition-API + setup-bindings list at

--- a/crates/vize_maestro/src/ide/completion/script.rs
+++ b/crates/vize_maestro/src/ide/completion/script.rs
@@ -228,6 +228,14 @@ fn complete_member_access(ctx: &IdeContext, is_setup: bool) -> Option<Vec<Comple
     let kind = reactive_kind_for_name(&script_content, receiver)?;
 
     if !kind.needs_value_access() {
+        // reactive() / shallowReactive() bindings expose their object's own
+        // keys directly. Without Corsa we can't resolve the type, but for
+        // the common `reactive({ a: 1, b: '' })` form we can lift the
+        // literal's keys from the source. Falls through to no completion
+        // when the receiver is not a recognized reactive object.
+        if matches!(kind, ReactiveKind::Reactive | ReactiveKind::ShallowReactive) {
+            return Some(reactive_object_key_completions(&script_content, receiver));
+        }
         return None;
     }
 
@@ -236,6 +244,125 @@ fn complete_member_access(ctx: &IdeContext, is_setup: bool) -> Option<Vec<Comple
     let readonly = kind == ReactiveKind::Computed;
 
     Some(vec![value_completion_item(&value_type, readonly)])
+}
+
+/// Extract the keys of `reactive({ ... })` / `shallowReactive({ ... })`
+/// initializer literals so completion can offer them at `receiver.|` even
+/// without a backing Corsa session. Returns an empty Vec when the initializer
+/// is too dynamic (e.g. `reactive(someFn())`) — callers downstream handle
+/// the empty case as "no completion".
+fn reactive_object_key_completions(script_content: &str, name: &str) -> Vec<CompletionItem> {
+    let initializer = match reactive_object_initializer(script_content, name) {
+        Some(s) => s,
+        None => return Vec::new(),
+    };
+    let keys = extract_object_literal_keys(initializer);
+    keys.into_iter()
+        .map(|key| {
+            #[allow(clippy::disallowed_macros)]
+            CompletionItem {
+                label: key.clone(),
+                kind: Some(CompletionItemKind::PROPERTY),
+                detail: Some("reactive property".to_string()),
+                documentation: Some(Documentation::MarkupContent(MarkupContent {
+                    kind: MarkupKind::Markdown,
+                    value: format!("Key inferred from `reactive(...)` initializer for `{name}`."),
+                })),
+                sort_text: Some(format!("0{key}")),
+                ..Default::default()
+            }
+        })
+        .collect()
+}
+
+fn reactive_object_initializer<'a>(script_content: &'a str, name: &str) -> Option<&'a str> {
+    for callee in ["reactive", "shallowReactive"] {
+        for keyword in ["const", "let"] {
+            let needle = vize_carton::cstr!("{keyword} {name} = {callee}(");
+            let Some(pos) = script_content.find(needle.as_str()) else {
+                continue;
+            };
+            let after = &script_content[pos + needle.len()..];
+            let after = after.trim_start();
+            if after.starts_with('{') {
+                return Some(after);
+            }
+        }
+    }
+    None
+}
+
+/// Extract top-level keys from a JS/TS object literal starting at `{`.
+/// Handles nested braces, string keys, and trailing commas; returns names in
+/// source order without duplicates.
+fn extract_object_literal_keys(initializer: &str) -> Vec<String> {
+    let bytes = initializer.as_bytes();
+    if bytes.first() != Some(&b'{') {
+        return Vec::new();
+    }
+    let mut depth = 0i32;
+    let mut keys = Vec::new();
+    let mut seen = std::collections::BTreeSet::new();
+    let mut i = 0;
+    let mut at_key_start = false;
+    while i < bytes.len() {
+        let b = bytes[i];
+        match b {
+            b'{' | b'[' | b'(' => {
+                depth += 1;
+                if depth == 1 {
+                    at_key_start = true;
+                }
+            }
+            b'}' | b']' | b')' => {
+                depth -= 1;
+                if depth == 0 {
+                    break;
+                }
+            }
+            b',' if depth == 1 => {
+                at_key_start = true;
+            }
+            b' ' | b'\t' | b'\n' | b'\r' => {}
+            b'"' | b'\'' | b'`' if depth == 1 && at_key_start => {
+                let quote = b;
+                let key_start = i + 1;
+                let mut j = key_start;
+                while j < bytes.len() && bytes[j] != quote {
+                    j += 1;
+                }
+                if let Ok(key) = std::str::from_utf8(&bytes[key_start..j])
+                    && seen.insert(key.to_string())
+                {
+                    keys.push(key.to_string());
+                }
+                i = j;
+                at_key_start = false;
+            }
+            b if depth == 1
+                && at_key_start
+                && (b.is_ascii_alphabetic() || b == b'_' || b == b'$') =>
+            {
+                let key_start = i;
+                let mut j = i;
+                while j < bytes.len()
+                    && (bytes[j].is_ascii_alphanumeric() || bytes[j] == b'_' || bytes[j] == b'$')
+                {
+                    j += 1;
+                }
+                if let Ok(key) = std::str::from_utf8(&bytes[key_start..j])
+                    && seen.insert(key.to_string())
+                {
+                    keys.push(key.to_string());
+                }
+                i = j.saturating_sub(1);
+                at_key_start = false;
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+    keys
 }
 
 fn script_content_for_context(ctx: &IdeContext<'_>, is_setup: bool) -> Option<String> {


### PR DESCRIPTION
Follow-up to #678. Member access on `const obj = reactive({ ... })` previously returned an empty list when Corsa wasn't available because `needs_value_access()` is false for `Reactive` bindings.

The sync fallback now lifts the keys directly from the initializer literal so `obj.|` proposes the declared properties at least.

`extract_object_literal_keys` walks the brace-balanced initializer, handles string keys, and yields top-level property names in source order. `shallowReactive()` is treated the same way.

## Out of scope

- Type-aware completion when the initializer is not a literal (e.g. `reactive(someFn())`). Requires Corsa.
- `Array.prototype` / `Promise.prototype` / `Map` / `Set` built-in members. Tracked in #678.
