### PR TITLE
style: collapse single-line imports in lsp-roadmap-completion test

### DIFF
--- a/tests/tooling/lsp-roadmap-completion.test.ts
+++ b/tests/tooling/lsp-roadmap-completion.test.ts
@@ -3,10 +3,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { test } from "node:test";
 import { pathToFileURL } from "node:url";
-import {
-  completionLabels,
-  offsetToPosition,
-} from "./support/lsp/assertions.ts";
+import { completionLabels, offsetToPosition } from "./support/lsp/assertions.ts";
 import { testOutputRoot } from "./support/lsp/paths.ts";
 import { LspSession } from "./support/lsp/session.ts";
 


### PR DESCRIPTION
`vp check` rejected the import block in `tests/tooling/lsp-roadmap-completion.test.ts` because it preferred the single-line form. The Check workflow's `check-js` job on main has been failing on this since #717. Pure formatting fix, no behavior change.

Verified locally with `vp run --workspace-root check:ci`.
