### PR TITLE
fix(canon): lift script-setup re-export statements to module scope

### DIFF
--- a/crates/vize/tests/check_cli.rs
+++ b/crates/vize/tests/check_cli.rs
@@ -181,6 +181,83 @@ export default defineComponent({
 }
 
 #[test]
+fn check_lifts_script_setup_type_reexports() {
+    let Some(corsa_path) = resolve_test_corsa_path() else {
+        return;
+    };
+    let project_root = create_cli_project(
+        "script-setup-type-reexport",
+        &[
+            (
+                "src/ReExportType.ts",
+                "export type FilterType = 'image' | 'text'\n",
+            ),
+            (
+                "src/ReExportType.vue",
+                r#"<script setup lang="ts">
+import { type FilterType } from './ReExportType'
+
+export type { FilterType }
+
+defineProps<{ kind?: FilterType }>()
+</script>
+
+<template>
+  <div />
+</template>
+"#,
+            ),
+            (
+                "src/ReExportTypeConsumer.vue",
+                r#"<script setup lang="ts">
+import ReExportType, { type FilterType } from './ReExportType.vue'
+
+const v: FilterType = 'image'
+</script>
+
+<template>
+  <ReExportType :kind="v" />
+</template>
+"#,
+            ),
+        ],
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(&project_root)
+        .env("CORSA_PATH", corsa_path)
+        .args([
+            "check",
+            "src/ReExportType.vue",
+            "src/ReExportTypeConsumer.vue",
+            "--tsconfig",
+            "tsconfig.json",
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+
+    let stdout = std::string::String::from_utf8(output.stdout).unwrap();
+    let stderr = std::string::String::from_utf8(output.stderr).unwrap();
+    let json: serde_json::Value = serde_json::from_str(&stdout).unwrap_or_else(|error| {
+        panic!("failed to parse stdout as JSON: {error}\nstdout:\n{stdout}\nstderr:\n{stderr}")
+    });
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "stdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert_eq!(
+        json["errorCount"], 0,
+        "stdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}
+
+#[test]
 fn check_respects_explicit_corsa_path() {
     let project_root = create_cli_project(
         "explicit-corsa-path",

--- a/crates/vize_canon/src/virtual_ts.rs
+++ b/crates/vize_canon/src/virtual_ts.rs
@@ -604,6 +604,49 @@ const heightLimit = "65vh";
     }
 
     #[test]
+    fn test_script_setup_type_reexport_lifted_to_module_scope() {
+        // `export type { X }` re-exports must be emitted at module top level,
+        // not inside `__setup()` where `export` is a syntax error (TS1233).
+        use vize_croquis::{Analyzer, AnalyzerOptions};
+
+        let script = r#"import { type FilterType } from './ReExportType'
+
+export type { FilterType }
+
+defineProps<{ kind?: FilterType }>()
+"#;
+
+        let mut analyzer = Analyzer::with_options(AnalyzerOptions::full());
+        analyzer.analyze_script_setup(script);
+        let summary = analyzer.finish();
+
+        let output = generate_virtual_ts_with_offsets(
+            &summary,
+            Some(script),
+            None,
+            0,
+            0,
+            &Default::default(),
+        );
+
+        let (module_scope, setup_scope) = output
+            .code
+            .split_once("// ========== Setup Scope ==========")
+            .expect("setup scope marker present");
+
+        assert!(
+            module_scope.contains("export type { FilterType }"),
+            "re-export should be lifted to module scope:\n{}",
+            output.code
+        );
+        assert!(
+            !setup_scope.contains("export type { FilterType }"),
+            "re-export must not be trapped inside __setup():\n{}",
+            output.code
+        );
+    }
+
+    #[test]
     fn test_vfor_component_props_in_scope() {
         // Component inside v-for should have prop checks inside the forEach closure
         use vize_croquis::{Analyzer, AnalyzerOptions};

--- a/crates/vize_croquis/src/script_parser/process.rs
+++ b/crates/vize_croquis/src/script_parser/process.rs
@@ -161,6 +161,18 @@ pub fn process_statement(result: &mut ScriptParseResult, stmt: &Statement<'_>, s
                 return;
             }
 
+            // Specifier-only export without a declaration, e.g.
+            // `export { Foo }` / `export type { Foo }`. These re-export
+            // local or imported bindings and are only valid at module top
+            // level, so lift them out of the synthetic `__setup` function.
+            if export.declaration.is_none() {
+                result.re_exports.push(ReExportInfo {
+                    start: export.span.start,
+                    end: export.span.end,
+                });
+                return;
+            }
+
             if let Some(decl) = &export.declaration {
                 // Check if the declaration itself is a type declaration
                 match decl {


### PR DESCRIPTION
## Summary

A specifier-only export in `<script setup>` (`export { X }` / `export type { X }`) has no module source and no declaration, so it was never recorded as a re-export and ended up emitted inside the synthetic `__setup()` function, where `export` is a syntax error.

This produced `TS1233` / `TS2303` on the SFC itself and `TS2614` on consumers importing the re-exported binding.

## Fix

Record specifier-only exports as re-exports in the croquis script parser so they are lifted to module top level alongside `export ... from "..."` statements.

## Test plan

- [x] Unit: `test_script_setup_type_reexport_lifted_to_module_scope` (vize_canon) — asserts the re-export lands in module scope, not setup scope
- [x] E2E: `check_lifts_script_setup_type_reexports` (vize check_cli) — `errorCount == 0`

Closes #738