### PR TITLE
fix(canon): bind script-setup generics on hoisted type declarations

### DIFF
--- a/crates/vize/tests/check_cli.rs
+++ b/crates/vize/tests/check_cli.rs
@@ -181,6 +181,69 @@ export default defineComponent({
 }
 
 #[test]
+fn check_generic_script_setup_resolves_type_referencing_generic_param() {
+    // `<script setup generic="T">` declares a type that references `T`. The
+    // type is lifted to module scope, so the generic parameter must be
+    // re-declared on it; otherwise `T` is unbound there (TS2304).
+    let Some(corsa_path) = resolve_test_corsa_path() else {
+        return;
+    };
+    let project_root = create_cli_project(
+        "generic-script-setup-hoisted-type",
+        &[(
+            "src/Generic.vue",
+            r#"<script setup lang="ts" generic="T extends string">
+type Option = { key: T; label: string }
+
+defineProps<{
+  options: Option[]
+  current: T | undefined
+}>()
+</script>
+
+<template>
+  <ul>
+    <li v-for="o in options" :key="o.key">{{ o.label }}</li>
+  </ul>
+</template>
+"#,
+        )],
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(&project_root)
+        .env("CORSA_PATH", corsa_path)
+        .args([
+            "check",
+            "src/Generic.vue",
+            "--tsconfig",
+            "tsconfig.json",
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+
+    let stdout = std::string::String::from_utf8(output.stdout).unwrap();
+    let stderr = std::string::String::from_utf8(output.stderr).unwrap();
+    let json: serde_json::Value = serde_json::from_str(&stdout).unwrap_or_else(|error| {
+        panic!("failed to parse stdout as JSON: {error}\nstdout:\n{stdout}\nstderr:\n{stderr}")
+    });
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "stdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert_eq!(
+        json["errorCount"], 0,
+        "stdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}
+
+#[test]
 fn check_respects_explicit_corsa_path() {
     let project_root = create_cli_project(
         "explicit-corsa-path",

--- a/crates/vize_canon/src/virtual_ts.rs
+++ b/crates/vize_canon/src/virtual_ts.rs
@@ -604,6 +604,48 @@ const heightLimit = "65vh";
     }
 
     #[test]
+    fn test_script_setup_generic_param_injected_into_hoisted_type() {
+        // A type declared in `<script setup generic="T">` that references the
+        // generic parameter is lifted to module scope; the generic must be
+        // re-declared on it so `T` resolves there (a residual of the repro-8
+        // hoisting fix). Bare uses like `Option[]` still resolve via `= any`.
+        use vize_croquis::{Analyzer, AnalyzerOptions};
+
+        let script = r#"type Option = { key: T; label: string }
+
+defineProps<{
+  options: Option[]
+  current: T | undefined
+}>()
+"#;
+
+        let mut analyzer = Analyzer::with_options(AnalyzerOptions::full());
+        analyzer.analyze_script_setup_with_generic(script, Some("T extends string"));
+        let summary = analyzer.finish();
+
+        let output = generate_virtual_ts_with_offsets(
+            &summary,
+            Some(script),
+            None,
+            0,
+            0,
+            &Default::default(),
+        );
+
+        let (module_scope, _setup_scope) = output
+            .code
+            .split_once("// ========== Setup Scope ==========")
+            .expect("setup scope marker present");
+
+        assert!(
+            module_scope
+                .contains("type Option<T extends string = any> = { key: T; label: string }"),
+            "hoisted type should gain the SFC generic parameter so `T` resolves at module scope:\n{}",
+            output.code
+        );
+    }
+
+    #[test]
     fn test_vfor_component_props_in_scope() {
         // Component inside v-for should have prop checks inside the forEach closure
         use vize_croquis::{Analyzer, AnalyzerOptions};

--- a/crates/vize_canon/src/virtual_ts/generator.rs
+++ b/crates/vize_canon/src/virtual_ts/generator.rs
@@ -10,14 +10,17 @@ use super::{
         IMPORT_META_AUGMENTATION, SETUP_SCOPE_HELPER_NAMES, VUE_SETUP_HELPERS, VUE_TYPE_HELPERS,
         generate_template_context, to_safe_identifier,
     },
-    props::{collect_template_prop_names, generate_props_type, generate_props_variables},
+    props::{
+        add_generic_defaults, collect_template_prop_names, extract_generic_names,
+        generate_props_type, generate_props_variables,
+    },
     scope::generate_scope_closures,
     types::{VirtualTsGenerationOptions, VirtualTsOptions, VirtualTsOutput, VizeMapping},
 };
 use vize_carton::append;
 use vize_carton::cstr;
 use vize_carton::profile;
-use vize_carton::{FxHashSet, String};
+use vize_carton::{FxHashMap, FxHashSet, String};
 
 /// Generate virtual TypeScript from Vue SFC analysis.
 ///
@@ -168,11 +171,78 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
         module_spans
     });
 
+    // For a `<script setup generic="...">` SFC, hoisted type declarations are
+    // lifted verbatim to module scope, but the generic parameters only live on
+    // `__setup<...>()`. A lifted declaration that mentions a generic parameter
+    // (e.g. `type Option = { key: T }`) would reference an unbound name there.
+    // Re-declare the SFC generics as defaulted parameters on each such
+    // declaration (`type Option<T extends string = any> = ...`) so the
+    // reference resolves at module scope while bare uses (`Option[]`) still
+    // work via the `= any` defaults.
+    let generic_injection: Option<(String, Vec<String>)> = generic_param.map(|g| {
+        let defaults = add_generic_defaults(g);
+        let names = extract_generic_names(g)
+            .split(',')
+            .map(|n| String::from(n.trim()))
+            .filter(|n| !n.is_empty())
+            .collect();
+        (defaults, names)
+    });
+    let hoisted_type_spans: FxHashMap<(u32, u32), &str> = if generic_injection.is_some() {
+        summary
+            .type_exports
+            .iter()
+            .filter(|te| te.hoisted)
+            .map(|te| ((te.start, te.end), te.name.as_str()))
+            .collect()
+    } else {
+        FxHashMap::default()
+    };
+
     if let Some(script) = script_content {
         profile!("canon.virtual_ts.emit_module_statements", {
             // Emit each module-level statement with source mapping
             for &(start, end) in &module_spans {
                 let text = &script[start as usize..end as usize];
+
+                // Splice the SFC generic parameters into a hoisted
+                // type/interface declaration that references them, so the
+                // reference resolves at module scope.
+                if let Some((defaults, names)) = &generic_injection
+                    && let Some(type_name) = hoisted_type_spans.get(&(start, end))
+                    && references_any_identifier(text, names)
+                    && let Some(inject_at) = generic_injection_point(text, type_name)
+                {
+                    let (prefix, suffix) = text.split_at(inject_at);
+                    let src_base = script_offset as usize + start as usize;
+
+                    let gen_start = ts.len();
+                    ts.push_str(prefix);
+                    mappings.push(VizeMapping {
+                        gen_range: gen_start..ts.len(),
+                        src_range: src_base..(src_base + prefix.len()),
+                        sub_spans: Vec::new(),
+                    });
+
+                    // Synthetic parameter list; no corresponding source span.
+                    append!(ts, "<{defaults}>");
+                    // Avoid forming `>=` when the alias has no space before `=`.
+                    if suffix.starts_with('=') {
+                        ts.push(' ');
+                    }
+
+                    let gen_start = ts.len();
+                    ts.push_str(suffix);
+                    ts.push('\n');
+                    mappings.push(VizeMapping {
+                        gen_range: gen_start..ts.len(),
+                        src_range: (src_base + prefix.len())
+                            ..(src_base + prefix.len() + suffix.len()),
+                        sub_spans: Vec::new(),
+                    });
+                    continue;
+                }
+
                 let gen_start = ts.len();
                 ts.push_str(text);
                 ts.push('\n');
@@ -802,4 +872,85 @@ fn is_safe_value_identifier(name: &str) -> bool {
         return false;
     }
     chars.all(|ch| ch.is_ascii_alphanumeric() || ch == '_' || ch == '$')
+}
+
+fn is_ident_byte(b: u8) -> bool {
+    b == b'_' || b == b'$' || b.is_ascii_alphanumeric()
+}
+
+fn skip_ascii_ws(bytes: &[u8], mut i: usize) -> usize {
+    while i < bytes.len() && bytes[i].is_ascii_whitespace() {
+        i += 1;
+    }
+    i
+}
+
+/// Whether `haystack` mentions any of `idents` as a whole-word identifier.
+/// Used to decide whether a lifted type declaration depends on an SFC generic
+/// parameter and therefore needs that parameter re-declared on it.
+fn references_any_identifier(haystack: &str, idents: &[String]) -> bool {
+    let bytes = haystack.as_bytes();
+    idents.iter().any(|ident| {
+        let ident = ident.as_str();
+        if ident.is_empty() {
+            return false;
+        }
+        let mut from = 0;
+        while let Some(rel) = haystack[from..].find(ident) {
+            let at = from + rel;
+            let before_ok = at == 0 || !is_ident_byte(bytes[at - 1]);
+            let after = at + ident.len();
+            let after_ok = after >= bytes.len() || !is_ident_byte(bytes[after]);
+            if before_ok && after_ok {
+                return true;
+            }
+            from = at + ident.len();
+        }
+        false
+    })
+}
+
+/// Byte offset within a hoisted `type` / `interface` declaration immediately
+/// after the declared name, where synthetic generic parameters can be spliced
+/// in. Returns `None` if the declaration already has its own `<...>` parameter
+/// list or the name can't be located (the declaration is then emitted as-is).
+fn generic_injection_point(decl: &str, type_name: &str) -> Option<usize> {
+    let bytes = decl.as_bytes();
+    let mut i = skip_ascii_ws(bytes, 0);
+
+    // Optional `export` modifier.
+    if decl[i..].starts_with("export")
+        && matches!(bytes.get(i + 6), Some(b) if b.is_ascii_whitespace())
+    {
+        i = skip_ascii_ws(bytes, i + 6);
+    }
+
+    // Declaration keyword.
+    if decl[i..].starts_with("type")
+        && matches!(bytes.get(i + 4), Some(b) if b.is_ascii_whitespace())
+    {
+        i += 4;
+    } else if decl[i..].starts_with("interface")
+        && matches!(bytes.get(i + 9), Some(b) if b.is_ascii_whitespace())
+    {
+        i += 9;
+    } else {
+        return None;
+    }
+    i = skip_ascii_ws(bytes, i);
+
+    // Declared name.
+    if !decl[i..].starts_with(type_name) {
+        return None;
+    }
+    let name_end = i + type_name.len();
+    // Reject partial-name matches (`Foo` inside `Foobar`).
+    if matches!(bytes.get(name_end), Some(&b) if is_ident_byte(b)) {
+        return None;
+    }
+    // Skip declarations that already declare their own type parameters.
+    if bytes.get(skip_ascii_ws(bytes, name_end)) == Some(&b'<') {
+        return None;
+    }
+    Some(name_end)
 }

--- a/crates/vize_canon/src/virtual_ts/props.rs
+++ b/crates/vize_canon/src/virtual_ts/props.rs
@@ -345,7 +345,7 @@ fn find_matching_brace(s: &str, start: usize) -> usize {
 /// e.g., `"T extends Foo, P extends Bar"` → `"T, P"`
 /// e.g., `"T"` → `"T"`
 /// e.g., `"T extends Record<string, any>, U"` → `"T, U"`
-fn extract_generic_names(generic_param: &str) -> String {
+pub(crate) fn extract_generic_names(generic_param: &str) -> String {
     let mut names = String::default();
     let mut depth = 0i32; // track <> nesting
     let mut current_name = String::default();
@@ -393,7 +393,7 @@ fn extract_generic_names(generic_param: &str) -> String {
 /// Add `= any` defaults to each generic parameter that doesn't already have a default.
 /// e.g., `"T extends Foo, P"` → `"T extends Foo = any, P = any"`
 /// e.g., `"T = string"` → `"T = string"` (unchanged, already has default)
-fn add_generic_defaults(generic_param: &str) -> String {
+pub(crate) fn add_generic_defaults(generic_param: &str) -> String {
     let mut result = String::default();
     let mut depth = 0i32;
     let mut current_param = String::default();


### PR DESCRIPTION
## Summary

A type declared in `<script setup generic="T">` that references the generic parameter is lifted verbatim to module scope, but `T` only exists on the synthetic `__setup<T>()` function — so the lifted declaration references an unbound name (`TS2304`).

The `Props` type is also emitted at module scope and references such types, so they cannot be demoted into `__setup` the way repro 8 handles `typeof`-anchored types (that would break the `Props` reference).

## Fix

Re-declare the SFC generics as defaulted parameters on each hoisted declaration that references them:

```ts
// before — T unbound at module scope
type Option = { key: T; label: string }

// after
type Option<T extends string = any> = { key: T; label: string }
```

The reference resolves at module scope, while bare uses (`Option[]`) still work via the `= any` defaults. Declarations that already declare their own `<...>` type parameters are left untouched.

## Test plan

- [x] Unit: `test_script_setup_generic_param_injected_into_hoisted_type` (vize_canon) — module scope emits the parameterized declaration
- [x] E2E: `check_generic_script_setup_resolves_type_referencing_generic_param` (vize check_cli) — `errorCount == 0` against `tsgo`
- [x] `cargo test -p vize_canon --lib` (224 passed)

Closes #740