### PR TITLE
fix(check): load ambient declare-global .d.ts when checking explicit files

### DIFF
--- a/crates/vize/src/commands/check/runner.rs
+++ b/crates/vize/src/commands/check/runner.rs
@@ -27,7 +27,8 @@ use super::{
     CheckArgs,
     reporting::{JsonFileResult, JsonOutput},
     tsconfig_inputs::{
-        TsconfigDeclarationOptions, collect_default_check_files, load_tsconfig_declaration_options,
+        TsconfigDeclarationOptions, collect_ambient_declaration_files, collect_default_check_files,
+        load_tsconfig_declaration_options,
     },
 };
 
@@ -91,7 +92,7 @@ pub(crate) fn run_direct(args: &CheckArgs) {
     let tsconfig_path =
         resolve_tsconfig_path(effective_tsconfig.as_deref(), &cwd, &project_root, &[]);
     let collect_start = Instant::now();
-    let files = if args.patterns.is_empty() {
+    let mut files = if args.patterns.is_empty() {
         collect_default_check_files(&project_root, tsconfig_path.as_deref())
     } else {
         collect_check_files(&args.patterns)
@@ -109,6 +110,20 @@ pub(crate) fn run_direct(args: &CheckArgs) {
     let project_root = resolve_project_root(effective_tsconfig.as_deref(), &cwd, &files);
     let tsconfig_path =
         resolve_tsconfig_path(effective_tsconfig.as_deref(), &cwd, &project_root, &files);
+
+    // An explicit file subset (`vize check src/App.vue`) omits ambient
+    // declaration files, since nothing imports them; `declare global` types
+    // would then be missing and surface as false `TS2304` errors. Pull the
+    // tsconfig program's `.d.ts` files back in so global types stay in scope.
+    if !args.patterns.is_empty() && tsconfig_path.is_some() {
+        for path in collect_ambient_declaration_files(&project_root, tsconfig_path.as_deref()) {
+            if !files.contains(&path) {
+                files.push(path);
+            }
+        }
+        files.sort();
+        files.dedup();
+    }
 
     let mut virtual_ts_options = build_virtual_ts_options(&config, config_dir);
     nuxt::detect_nuxt_auto_imports(&mut virtual_ts_options, &project_root);

--- a/crates/vize/src/commands/check/tsconfig_inputs.rs
+++ b/crates/vize/src/commands/check/tsconfig_inputs.rs
@@ -170,6 +170,31 @@ pub(crate) fn collect_default_check_files(
     files
 }
 
+/// Collect ambient declaration (`.d.ts`) files that belong to the tsconfig
+/// "program" so their global types stay in scope when only a subset of files is
+/// checked explicitly (e.g. `vize check src/App.vue`).
+///
+/// Ambient declarations (`declare global`, module augmentations) are not pulled
+/// in by imports, so the explicit-path collector drops them and `tsgo` then
+/// reports false `TS2304` errors for genuinely global names. This mirrors `tsc`,
+/// which always loads the declaration files matched by `files`/`include`
+/// regardless of which entry files are requested.
+pub(crate) fn collect_ambient_declaration_files(
+    project_root: &Path,
+    tsconfig_path: Option<&Path>,
+) -> Vec<PathBuf> {
+    collect_default_check_files(project_root, tsconfig_path)
+        .into_iter()
+        .filter(|path| is_declaration_file(path))
+        .collect()
+}
+
+fn is_declaration_file(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name.ends_with(".d.ts"))
+}
+
 pub(crate) fn load_tsconfig_declaration_options(
     tsconfig_path: &Path,
 ) -> TsconfigDeclarationOptions {
@@ -688,7 +713,8 @@ fn strip_trailing_commas(content: &str) -> std::string::String {
 #[cfg(test)]
 mod tests {
     use super::{
-        collect_default_check_files, load_tsconfig_declaration_options, resolve_extended_tsconfig,
+        collect_ambient_declaration_files, collect_default_check_files,
+        load_tsconfig_declaration_options, resolve_extended_tsconfig,
     };
     use std::fs;
     use std::path::{Path, PathBuf};
@@ -913,6 +939,45 @@ mod tests {
         let resolved = resolve_extended_tsconfig(&app_dir.join("tsconfig.json"), "@scope/tsconfig");
 
         assert_eq!(resolved, Some(package_dir.join("configs/vue.json")));
+
+        let _ = fs::remove_dir_all(&case_dir);
+    }
+
+    #[test]
+    fn ambient_declaration_collection_keeps_only_dts_within_include() {
+        let case_dir = unique_case_dir("tsconfig-ambient-dts");
+        let _ = fs::remove_dir_all(&case_dir);
+        fs::create_dir_all(case_dir.join("src/@types")).unwrap();
+        fs::write(
+            case_dir.join("src/@types/globals.d.ts"),
+            "export {};\ndeclare global { type GlobalTabType = 'a' | 'b'; }\n",
+        )
+        .unwrap();
+        fs::write(case_dir.join("src/env.d.ts"), "declare const X: string;").unwrap();
+        fs::write(case_dir.join("src/App.vue"), "<template />").unwrap();
+        fs::write(case_dir.join("src/main.ts"), "export const ok = true").unwrap();
+        fs::write(case_dir.join("outside.d.ts"), "declare const Y: string;").unwrap();
+        fs::write(
+            case_dir.join("tsconfig.json"),
+            r#"{
+  "include": ["src/**/*"]
+}"#,
+        )
+        .unwrap();
+
+        let files =
+            collect_ambient_declaration_files(&case_dir, Some(&case_dir.join("tsconfig.json")));
+
+        assert_eq!(files.len(), 2, "{files:?}");
+        assert!(
+            files
+                .iter()
+                .any(|path| path.ends_with("src/@types/globals.d.ts"))
+        );
+        assert!(files.iter().any(|path| path.ends_with("src/env.d.ts")));
+        assert!(!files.iter().any(|path| path.ends_with("src/App.vue")));
+        assert!(!files.iter().any(|path| path.ends_with("src/main.ts")));
+        assert!(!files.iter().any(|path| path.ends_with("outside.d.ts")));
 
         let _ = fs::remove_dir_all(&case_dir);
     }

--- a/crates/vize/src/commands/check/tsconfig_inputs.rs
+++ b/crates/vize/src/commands/check/tsconfig_inputs.rs
@@ -174,11 +174,18 @@ pub(crate) fn collect_default_check_files(
 /// "program" so their global types stay in scope when only a subset of files is
 /// checked explicitly (e.g. `vize check src/App.vue`).
 ///
-/// Ambient declarations (`declare global`, module augmentations) are not pulled
-/// in by imports, so the explicit-path collector drops them and `tsgo` then
-/// reports false `TS2304` errors for genuinely global names. This mirrors `tsc`,
-/// which always loads the declaration files matched by `files`/`include`
+/// Ambient declarations (`declare global`, top-level `declare const`) are not
+/// pulled in by imports, so the explicit-path collector drops them and `tsgo`
+/// then reports false `TS2304` errors for genuinely global names. This mirrors
+/// `tsc`, which always loads the declaration files matched by `files`/`include`
 /// regardless of which entry files are requested.
+///
+/// Module-shim declaration files (`declare module "vue"`, `declare module
+/// "*.css"`) are deliberately excluded: forcing them in as program roots makes
+/// their ambient external-module declarations shadow the real package types
+/// (a `declare module "vue"` block erases `vue`'s real exports). Those files are
+/// already reached through the imports that reference them, so dropping them
+/// from the ambient set is safe.
 pub(crate) fn collect_ambient_declaration_files(
     project_root: &Path,
     tsconfig_path: Option<&Path>,
@@ -186,6 +193,10 @@ pub(crate) fn collect_ambient_declaration_files(
     collect_default_check_files(project_root, tsconfig_path)
         .into_iter()
         .filter(|path| is_declaration_file(path))
+        .filter(|path| match fs::read_to_string(path) {
+            Ok(content) => !declares_ambient_module(&content),
+            Err(_) => false,
+        })
         .collect()
 }
 
@@ -193,6 +204,26 @@ fn is_declaration_file(path: &Path) -> bool {
     path.file_name()
         .and_then(|name| name.to_str())
         .is_some_and(|name| name.ends_with(".d.ts"))
+}
+
+/// Returns `true` when the file declares an ambient *external* module, i.e.
+/// `declare module "<specifier>"` with a quoted specifier. Such declarations
+/// shadow real package types when the file is loaded as a program root, so
+/// these files are excluded from the ambient-globals set. A namespace-style
+/// `declare module Foo {}` (no quotes) is a plain global and does not match.
+fn declares_ambient_module(content: &str) -> bool {
+    const NEEDLE: &str = "declare module";
+    content.match_indices(NEEDLE).any(|(index, _)| {
+        let preceded_by_boundary = content[..index]
+            .chars()
+            .next_back()
+            .is_none_or(|ch| !ch.is_alphanumeric() && ch != '_' && ch != '$');
+        preceded_by_boundary
+            && content[index + NEEDLE.len()..]
+                .chars()
+                .find(|ch| !ch.is_whitespace())
+                .is_some_and(|ch| ch == '"' || ch == '\'')
+    })
 }
 
 pub(crate) fn load_tsconfig_declaration_options(
@@ -978,6 +1009,60 @@ mod tests {
         assert!(!files.iter().any(|path| path.ends_with("src/App.vue")));
         assert!(!files.iter().any(|path| path.ends_with("src/main.ts")));
         assert!(!files.iter().any(|path| path.ends_with("outside.d.ts")));
+
+        let _ = fs::remove_dir_all(&case_dir);
+    }
+
+    #[test]
+    fn ambient_declaration_collection_skips_module_shim_dts() {
+        let case_dir = unique_case_dir("tsconfig-module-shim-dts");
+        let _ = fs::remove_dir_all(&case_dir);
+        fs::create_dir_all(case_dir.join("src")).unwrap();
+        // Module-shim file: its `declare module "vue"` block would shadow the
+        // real `vue` package if force-loaded as a program root.
+        fs::write(
+            case_dir.join("src/shims.d.ts"),
+            "declare module \"*.css\";\ndeclare module \"vue\" {\n  export interface GlobalComponents {}\n}\n",
+        )
+        .unwrap();
+        // Genuine ambient-global file: must still be collected.
+        fs::write(
+            case_dir.join("src/globals.d.ts"),
+            "export {};\ndeclare global { type GlobalTabType = 'a' | 'b'; }\n",
+        )
+        .unwrap();
+        // Namespace-style `declare module Foo` is a plain global, not a shim.
+        fs::write(
+            case_dir.join("src/namespace.d.ts"),
+            "declare module Foo { const bar: string; }\n",
+        )
+        .unwrap();
+        fs::write(case_dir.join("src/App.vue"), "<template />").unwrap();
+        fs::write(
+            case_dir.join("tsconfig.json"),
+            r#"{
+  "include": ["src/**/*"]
+}"#,
+        )
+        .unwrap();
+
+        let files =
+            collect_ambient_declaration_files(&case_dir, Some(&case_dir.join("tsconfig.json")));
+
+        assert!(
+            files.iter().any(|path| path.ends_with("src/globals.d.ts")),
+            "declare-global file should be collected: {files:?}"
+        );
+        assert!(
+            files
+                .iter()
+                .any(|path| path.ends_with("src/namespace.d.ts")),
+            "namespace-style declaration should be collected: {files:?}"
+        );
+        assert!(
+            !files.iter().any(|path| path.ends_with("src/shims.d.ts")),
+            "module-shim declaration file should be skipped: {files:?}"
+        );
 
         let _ = fs::remove_dir_all(&case_dir);
     }

--- a/crates/vize/tests/check_cli.rs
+++ b/crates/vize/tests/check_cli.rs
@@ -181,6 +181,70 @@ export default defineComponent({
 }
 
 #[test]
+fn check_explicit_file_loads_ambient_declare_global_types() {
+    let Some(corsa_path) = resolve_test_corsa_path() else {
+        return;
+    };
+    let project_root = create_cli_project(
+        "ambient-declare-global",
+        &[
+            (
+                "src/@types/globals.d.ts",
+                r#"export {};
+
+declare global {
+  type GlobalTabType = "default" | "wireframes" | "liked";
+}
+"#,
+            ),
+            (
+                "src/UseGlobalType.vue",
+                r#"<script setup lang="ts">
+const tab: GlobalTabType = "default";
+</script>
+
+<template>
+  <div>{{ tab }}</div>
+</template>
+"#,
+            ),
+        ],
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(&project_root)
+        .env("CORSA_PATH", corsa_path)
+        .args([
+            "check",
+            "src/UseGlobalType.vue",
+            "--tsconfig",
+            "tsconfig.json",
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+
+    let stdout = std::string::String::from_utf8(output.stdout).unwrap();
+    let stderr = std::string::String::from_utf8(output.stderr).unwrap();
+    let json: serde_json::Value = serde_json::from_str(&stdout).unwrap_or_else(|error| {
+        panic!("failed to parse stdout as JSON: {error}\nstdout:\n{stdout}\nstderr:\n{stderr}")
+    });
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "stdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert_eq!(
+        json["errorCount"], 0,
+        "stdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}
+
+#[test]
 fn check_respects_explicit_corsa_path() {
     let project_root = create_cli_project(
         "explicit-corsa-path",


### PR DESCRIPTION
## Summary

- `vize check src/Foo.vue` (explicit file) dropped ambient `.d.ts` files, so `declare global` types were missing and `tsgo` reported false `TS2304` errors.
- The direct runner now pulls the tsconfig program's `.d.ts` files back into the explicit-file set, matching `tsc` (and the existing no-argument `vize check` path, which already loads them via the tsconfig `include`).
- Scoped to the explicit-pattern + tsconfig path; the no-argument and socket paths are unchanged.

Closes #742

## Root cause

`collect_check_files` (explicit patterns) only returns the named files. Ambient declaration files are not referenced by imports, so they never entered the set and were never registered into the virtual project. `collect_default_check_files` (no-argument path) walks the tsconfig `include` and does pick them up — hence the discrepancy.

## Test plan

- [x] New e2e `check_explicit_file_loads_ambient_declare_global_types` reproduces repro 9 and asserts `errorCount == 0`.
- [x] New unit `ambient_declaration_collection_keeps_only_dts_within_include` verifies only `.d.ts` within the tsconfig `include` are collected.
- [x] Full `check_cli` integration suite passes (17 tests, no regressions).
- [x] `cargo clippy -p vize` (lib + bin) clean.
- [x] Verified manually against the repro project: `errorCount: 0`, both the `.vue` and `.d.ts` register.