### PR TITLE
fix(lsp): list reactive setup bindings once in completion

### DIFF
--- a/crates/vize_maestro/src/ide/completion.rs
+++ b/crates/vize_maestro/src/ide/completion.rs
@@ -928,6 +928,46 @@ const title = t("auth.")
         assert_eq!(labels, vec!["auth.login"]);
     }
 
+    #[test]
+    fn test_script_completion_lists_reactive_binding_once() {
+        // A ref/computed binding is both a binding and a reactive source.
+        // Completion must surface each name once, not twice.
+        let source = r#"<script setup lang="ts">
+import { ref, computed } from 'vue'
+const st = ref(0)
+const ts = computed(() => st.value * 2)
+st
+</script>
+"#;
+        let (state, uri) = state_with_document("ScriptDedup.vue", source);
+        let offset = source.rfind("st\n").unwrap() + 2;
+        let ctx = IdeContext::new(&state, &uri, offset).unwrap();
+        let labels = completion_labels(CompletionService::complete(&ctx).unwrap());
+
+        assert_eq!(labels.iter().filter(|l| l.as_str() == "st").count(), 1);
+        assert_eq!(labels.iter().filter(|l| l.as_str() == "ts").count(), 1);
+    }
+
+    #[test]
+    fn test_template_completion_lists_reactive_binding_once() {
+        let source = r#"<script setup lang="ts">
+import { ref, computed } from 'vue'
+const st = ref(0)
+const ts = computed(() => st.value * 2)
+</script>
+<template>
+  <div>{{ st }}</div>
+</template>
+"#;
+        let (state, uri) = state_with_document("TemplateDedup.vue", source);
+        let offset = source.rfind("st }}").unwrap() + 2;
+        let ctx = IdeContext::new(&state, &uri, offset).unwrap();
+        let labels = completion_labels(CompletionService::complete(&ctx).unwrap());
+
+        assert_eq!(labels.iter().filter(|l| l.as_str() == "st").count(), 1);
+        assert_eq!(labels.iter().filter(|l| l.as_str() == "ts").count(), 1);
+    }
+
     fn completion_labels(response: CompletionResponse) -> Vec<String> {
         completion_items(response)
             .into_iter()

--- a/crates/vize_maestro/src/ide/completion/script.rs
+++ b/crates/vize_maestro/src/ide/completion/script.rs
@@ -155,8 +155,14 @@ pub(crate) fn complete_script(ctx: &IdeContext, is_setup: bool) -> Vec<Completio
             });
         }
 
-        // Add reactive sources
+        // Add reactive sources. Reactive bindings (ref/computed/...) are
+        // already emitted by the bindings loop above with their reactive type
+        // detail, so skip any source whose name is a known binding to avoid
+        // listing the same identifier twice.
         for source in croquis.reactivity.sources() {
+            if croquis.bindings.contains(source.name.as_str()) {
+                continue;
+            }
             let needs_value = source.kind.needs_value_access();
             let (type_detail, doc) =
                 reactive_completion_info(&script_content, source.name.as_str(), source.kind)

--- a/crates/vize_maestro/src/ide/completion/template.rs
+++ b/crates/vize_maestro/src/ide/completion/template.rs
@@ -541,6 +541,11 @@ fn analyzed_template_binding_completions(
         }
 
         for source in croquis.reactivity.sources() {
+            // Reactive bindings are already surfaced by the bindings loop
+            // above; skip known bindings so an identifier is not offered twice.
+            if croquis.bindings.contains(source.name.as_str()) {
+                continue;
+            }
             let kind_str = source.kind.to_display();
             #[allow(clippy::disallowed_macros)]
             items_vec.push(CompletionItem {


### PR DESCRIPTION
## Summary
- Reactive setup bindings (`ref`/`computed`/...) were added to the completion list twice: once by the `croquis.bindings` loop and again by the `croquis.reactivity.sources()` loop. Identifiers such as `st` and `ts` therefore showed up as duplicate candidates.
- Skip reactivity sources whose name is already a known binding, in both script (`script.rs`) and template (`template.rs`) completion. The bindings loop already attaches the reactive type detail, so nothing is lost.

## Test plan
- [x] `cargo test -p vize_maestro --lib` (283 passed)
- [x] Added regression tests asserting `st`/`ts` appear exactly once in script and template completion
- [x] `cargo fmt -p vize_maestro` / `cargo clippy -p vize_maestro --lib` clean