### PR TITLE
fix(armature): cap element nesting depth in the template parser

### DIFF
--- a/crates/vize_armature/src/parser/element.rs
+++ b/crates/vize_armature/src/parser/element.rs
@@ -11,6 +11,19 @@ use vize_relief::{
 
 use super::{CurrentElement, Parser, ParserStackEntry};
 
+/// Maximum element nesting depth retained by the parser.
+///
+/// Elements nested deeper than this are flattened with a recoverable error
+/// instead of being pushed onto the open-element stack. This keeps the depth
+/// of the produced AST bounded so the recursive passes that walk it later
+/// (transform, codegen, semantic analysis) stay within a predictable amount of
+/// stack space regardless of the input. The limit is far beyond any realistic
+/// template while still cheap to enforce.
+const MAX_ELEMENT_NESTING_DEPTH: usize = 256;
+
+/// Message attached to the recoverable error raised when the nesting limit is hit.
+const NESTING_TOO_DEEP_MESSAGE: &str = "Element nesting is too deep.";
+
 impl<'a> Parser<'a> {
     /// Process text content
     pub(super) fn on_text_impl(&mut self, start: usize, end: usize) {
@@ -178,6 +191,18 @@ impl<'a> Parser<'a> {
 
             if current.is_self_closing || (self.options.is_void_tag)(element.tag.as_str()) {
                 // Self-closing or void tag, add directly
+                let boxed = Box::new_in(element, self.allocator);
+                self.add_child(TemplateChildNode::Element(boxed));
+            } else if self.stack.len() >= MAX_ELEMENT_NESTING_DEPTH {
+                // Nesting limit reached: keep the element but do not descend any
+                // further, so the resulting tree depth stays bounded. The
+                // element is attached at the current level as a leaf and a
+                // recoverable error is recorded.
+                self.errors.push(CompilerError::with_message(
+                    ErrorCode::ExtendPoint,
+                    NESTING_TOO_DEEP_MESSAGE,
+                    Some(element.loc.clone()),
+                ));
                 let boxed = Box::new_in(element, self.allocator);
                 self.add_child(TemplateChildNode::Element(boxed));
             } else {

--- a/crates/vize_armature/src/parser/tests.rs
+++ b/crates/vize_armature/src/parser/tests.rs
@@ -640,6 +640,44 @@ fn test_parse_deep_nesting() {
 }
 
 #[test]
+fn test_parse_extreme_nesting_is_bounded() {
+    // Pathologically deep input should parse without unbounded growth and
+    // surface a recoverable error rather than producing an AST that later
+    // passes would have to recurse into without limit.
+    let allocator = Bump::new();
+    let depth = 5000;
+    let mut source = String::new();
+    for _ in 0..depth {
+        source.push_str("<div>");
+    }
+    for _ in 0..depth {
+        source.push_str("</div>");
+    }
+
+    let (root, errors) = parse(&allocator, &source);
+
+    // The nesting limit was reported.
+    assert!(
+        errors
+            .iter()
+            .any(|e| e.message.contains("nesting is too deep")),
+        "expected a nesting-depth error for deeply nested input"
+    );
+
+    // The retained tree depth is bounded by the cap, not by the input depth.
+    let mut node = root.children.first();
+    let mut measured = 0usize;
+    while let Some(TemplateChildNode::Element(el)) = node {
+        measured += 1;
+        node = el.children.first();
+    }
+    assert!(
+        measured <= 257,
+        "tree depth should stay bounded near the cap, got {measured}"
+    );
+}
+
+#[test]
 fn test_parse_component() {
     let allocator = Bump::new();
     let (root, errors) = parse(&allocator, "<MyComponent></MyComponent>");


### PR DESCRIPTION
## Summary

The template parser pushes every open element onto its stack without an upper bound, so the depth of the produced AST is limited only by the input. The recursive passes that walk that tree afterwards — the transform driver (`traverse_node`/`traverse_children`), codegen (`generate_node`), and the croquis analyzer (`visit_element`) — descend one frame per nesting level, so their stack usage scales with how deeply the input nests. On unusually deep input that growth is effectively unbounded, which is fragile for long-running consumers like the LSP / dev-server / Vite plugin.

This caps the retained nesting depth in the parser at a generous limit (`MAX_ELEMENT_NESTING_DEPTH = 256`, far beyond any realistic template). Elements past the limit are attached at the current level as leaves and a recoverable error is recorded, so:

- the produced AST depth stays bounded, and
- every downstream recursive pass keeps predictable stack usage regardless of input.

Because the analyzer and all compile backends consume the AST from this single parser, the cap covers every recursive consumer in one place.

## Changes

- `vize_armature`: enforce `MAX_ELEMENT_NESTING_DEPTH` in `on_open_tag_end_impl`; past the limit, flatten the element at the current level and record a recoverable error (via the existing `ExtendPoint` code + message, so no public API change).
- Test: `test_parse_extreme_nesting_is_bounded` asserts deeply nested input parses with a bounded tree depth and surfaces the error.

## Verification

- `cargo test -p vize_relief -p vize_armature -p vize_atelier_core -p vize_atelier_dom -p vize_croquis` — all green.
- `cargo semver-checks check-release` for `vize_relief`/`vize_armature` — no semver update required (public API unchanged).
- Manually confirmed a 10k-deep template now compiles to completion on a 2 MiB (worker-thread-sized) stack via `compile_template`, where the depth previously drove unbounded recursion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)