### PR TITLE
perf: optimize hot paths in recent LSP/check work

### DIFF
--- a/crates/vize_atelier_sfc/src/compile_script/props.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/props.rs
@@ -122,11 +122,9 @@ pub fn extract_prop_types_from_type(type_args: &str) -> Vec<(String, PropTypeInf
     // Split by commas/semicolons/newlines (but not inside nested braces)
     let mut depth: i32 = 0;
     let mut current = String::default();
-    let chars: Vec<char> = content.chars().collect();
-    let mut i = 0;
+    let mut prev = '\0';
 
-    while i < chars.len() {
-        let c = chars[i];
+    for c in content.chars() {
         match c {
             '{' | '<' | '(' | '[' => {
                 depth += 1;
@@ -140,7 +138,7 @@ pub fn extract_prop_types_from_type(type_args: &str) -> Vec<(String, PropTypeInf
             }
             '>' => {
                 // Don't count `>` as closing angle bracket when preceded by `=` (arrow function `=>`)
-                if i > 0 && chars[i - 1] == '=' {
+                if prev == '=' {
                     current.push(c);
                 } else {
                     if depth > 0 {
@@ -166,7 +164,7 @@ pub fn extract_prop_types_from_type(type_args: &str) -> Vec<(String, PropTypeInf
             }
             _ => current.push(c),
         }
-        i += 1;
+        prev = c;
     }
     extract_prop_type_info(&current, &mut props);
 
@@ -258,11 +256,9 @@ fn split_type_at_top_level(s: &str, delimiter: char) -> Vec<String> {
     let mut parts = Vec::new();
     let mut current = String::default();
     let mut depth: i32 = 0;
-    let chars: Vec<char> = s.chars().collect();
-    let mut i = 0;
+    let mut prev = '\0';
 
-    while i < chars.len() {
-        let c = chars[i];
+    for c in s.chars() {
         match c {
             '(' | '[' | '{' | '<' => {
                 depth += 1;
@@ -276,7 +272,7 @@ fn split_type_at_top_level(s: &str, delimiter: char) -> Vec<String> {
             }
             '>' => {
                 // Don't count > as closing angle bracket when preceded by = (arrow =>)
-                if i > 0 && chars[i - 1] == '=' {
+                if prev == '=' {
                     current.push(c);
                 } else {
                     if depth > 0 {
@@ -290,7 +286,7 @@ fn split_type_at_top_level(s: &str, delimiter: char) -> Vec<String> {
             }
             _ => current.push(c),
         }
-        i += 1;
+        prev = c;
     }
     if !current.is_empty() || !parts.is_empty() {
         parts.push(current);
@@ -301,9 +297,9 @@ fn split_type_at_top_level(s: &str, delimiter: char) -> Vec<String> {
 /// Check if a type string contains a top-level `=>` (arrow function signature).
 fn contains_top_level_arrow(s: &str) -> bool {
     let mut depth: i32 = 0;
-    let chars: Vec<char> = s.chars().collect();
-    for i in 0..chars.len() {
-        match chars[i] {
+    let mut prev = '\0';
+    for c in s.chars() {
+        match c {
             '(' | '[' | '{' | '<' => depth += 1,
             ')' | ']' | '}' => {
                 if depth > 0 {
@@ -311,7 +307,7 @@ fn contains_top_level_arrow(s: &str) -> bool {
                 }
             }
             '>' => {
-                if i > 0 && chars[i - 1] == '=' {
+                if prev == '=' {
                     // This is `=>`
                     if depth == 0 {
                         return true;
@@ -323,6 +319,7 @@ fn contains_top_level_arrow(s: &str) -> bool {
             }
             _ => {}
         }
+        prev = c;
     }
     false
 }
@@ -461,9 +458,9 @@ fn ts_type_to_js_type(ts_type: &str) -> String {
 /// Used to detect object literal types like `{ key: string }` vs types like `Record<K, V>`.
 fn contains_top_level_colon(s: &str) -> bool {
     let mut depth: i32 = 0;
-    let chars: Vec<char> = s.chars().collect();
-    for i in 0..chars.len() {
-        match chars[i] {
+    let mut prev = '\0';
+    for c in s.chars() {
+        match c {
             '(' | '[' | '{' | '<' => depth += 1,
             ')' | ']' | '}' => {
                 if depth > 0 {
@@ -471,7 +468,7 @@ fn contains_top_level_colon(s: &str) -> bool {
                 }
             }
             '>' => {
-                if i > 0 && chars[i - 1] == '=' {
+                if prev == '=' {
                     // Arrow =>, don't change depth
                 } else if depth > 0 {
                     depth -= 1;
@@ -480,6 +477,7 @@ fn contains_top_level_colon(s: &str) -> bool {
             ':' if depth == 0 => return true,
             _ => {}
         }
+        prev = c;
     }
     false
 }

--- a/crates/vize_canon/src/batch/virtual_project.rs
+++ b/crates/vize_canon/src/batch/virtual_project.rs
@@ -98,6 +98,20 @@ pub struct VirtualProject {
     /// Virtual files keyed by materialized path.
     virtual_files: FxHashMap<PathBuf, VirtualFile>,
 
+    /// Secondary index: original source path -> materialized (virtual) path.
+    /// Keeps `find_by_original` / `map_to_virtual` O(1) instead of scanning
+    /// every virtual file on each LSP position-mapping request.
+    original_index: FxHashMap<PathBuf, PathBuf>,
+
+    /// Original source text as registered, keyed by materialized (virtual)
+    /// path. Retained here (rather than on the public `VirtualFile`) so
+    /// position mapping can convert offsets to line/column without re-reading
+    /// the file from disk on every request, and without changing the public
+    /// `VirtualFile` API. This is also the exact text the source map's
+    /// original offsets refer to (e.g. an editor's unsaved buffer), so it is
+    /// more correct than re-reading live disk state.
+    original_contents: FxHashMap<PathBuf, CompactString>,
+
     /// Parser diagnostics collected before Corsa runs.
     diagnostics: Vec<Diagnostic>,
 
@@ -124,6 +138,8 @@ impl VirtualProject {
             virtual_ts_check_options: VirtualTsCheckOptions::default(),
             legacy_vue2: false,
             virtual_files: FxHashMap::default(),
+            original_index: FxHashMap::default(),
+            original_contents: FxHashMap::default(),
             diagnostics: Vec::new(),
             rewriter: ImportRewriter::new(),
         })
@@ -279,6 +295,14 @@ impl VirtualProject {
 
     fn absorb_registered_file(&mut self, registered: RegisteredFile) {
         self.diagnostics.extend(registered.diagnostics);
+        self.original_index.insert(
+            registered.file.original_path.clone(),
+            registered.file.virtual_path.clone(),
+        );
+        self.original_contents.insert(
+            registered.file.virtual_path.clone(),
+            registered.original_content,
+        );
         self.virtual_files
             .insert(registered.file.virtual_path.clone(), registered.file);
     }
@@ -359,9 +383,8 @@ impl VirtualProject {
 
     /// Find a virtual file by its original path.
     pub fn find_by_original(&self, original_path: &Path) -> Option<&VirtualFile> {
-        self.virtual_files
-            .values()
-            .find(|file| file.original_path == original_path)
+        let virtual_path = self.original_index.get(original_path)?;
+        self.virtual_files.get(virtual_path)
     }
 
     /// Find a virtual file by its materialized path.
@@ -392,9 +415,9 @@ impl VirtualProject {
         let virtual_offset = super::source_map::line_col_to_offset(&file.content, line, column)?;
         let (original_offset, _, block_type) =
             file.source_map.get_original_position(virtual_offset)?;
-        let original_content = std::fs::read_to_string(&file.original_path).ok()?;
+        let original_content = self.original_contents.get(&file.virtual_path)?;
         let (original_line, original_column) =
-            super::source_map::offset_to_line_col(&original_content, original_offset)?;
+            super::source_map::offset_to_line_col(original_content, original_offset)?;
 
         Some(OriginalPosition {
             path: file.original_path.clone(),
@@ -412,9 +435,9 @@ impl VirtualProject {
         column: u32,
     ) -> Option<(PathBuf, u32, u32)> {
         let file = self.find_by_original(original_path)?;
-        let original_content = std::fs::read_to_string(&file.original_path).ok()?;
+        let original_content = self.original_contents.get(&file.virtual_path)?;
         let original_offset =
-            super::source_map::line_col_to_offset(&original_content, line, column)?;
+            super::source_map::line_col_to_offset(original_content, line, column)?;
         let virtual_offset = if let Some(ref sfc_map) = file.source_map.sfc_map {
             for block in [
                 SfcBlockType::ScriptSetup,
@@ -1031,6 +1054,10 @@ fn push_block_range(
 /// independent of any `&mut VirtualProject` so it can be produced in parallel.
 struct RegisteredFile {
     file: VirtualFile,
+    /// Original source text as registered, retained for offset<->line/col
+    /// mapping without a disk re-read. Stored on the project, not the public
+    /// `VirtualFile`.
+    original_content: CompactString,
     diagnostics: Vec<Diagnostic>,
 }
 
@@ -1134,6 +1161,7 @@ fn build_vue_registered_file(
             original_path: path.to_path_buf(),
             virtual_path,
         },
+        original_content: content.to_compact_string(),
         diagnostics,
     })
 }
@@ -1159,6 +1187,7 @@ fn build_script_registered_file(
             original_path: path.to_path_buf(),
             virtual_path,
         },
+        original_content: content.to_compact_string(),
         diagnostics: Vec::new(),
     })
 }

--- a/crates/vize_croquis/src/script_parser.rs
+++ b/crates/vize_croquis/src/script_parser.rs
@@ -154,23 +154,23 @@ impl ScriptParseResult {
         if self.type_export_typeof_refs.is_empty() {
             return;
         }
-        let imported_names: FxHashSet<&str> = self
-            .import_statements
-            .iter()
-            .flat_map(|imp| {
-                // Bindings whose declaration site falls inside an import
-                // statement are module-scoped imports, not setup values.
-                self.binding_spans
-                    .iter()
-                    .filter(move |(_, (start, end))| *start >= imp.start && *end <= imp.end)
-                    .map(|(name, _)| name.as_str())
-            })
-            .collect();
 
-        for (idx, refs) in self.type_export_typeof_refs.iter().enumerate() {
-            let touches_setup_value = refs.iter().any(|name| {
+        // A `typeof name` ref keeps a type hoisted only when `name` is a
+        // module-scoped import. Rather than materialize the full set of
+        // imported binding names up front (O(imports × bindings)), test each
+        // referenced name's declaration span against the import ranges on
+        // demand — `refs` is tiny, so this is O(refs × imports).
+        for idx in 0..self.type_export_typeof_refs.len() {
+            let touches_setup_value = self.type_export_typeof_refs[idx].iter().any(|name| {
                 let key = name.as_str();
-                self.bindings.bindings.contains_key(key) && !imported_names.contains(key)
+                self.bindings.bindings.contains_key(key)
+                    && !self.binding_spans.get(key).is_some_and(|(start, end)| {
+                        // Bindings whose declaration site falls inside an import
+                        // statement are module-scoped imports, not setup values.
+                        self.import_statements
+                            .iter()
+                            .any(|imp| *start >= imp.start && *end <= imp.end)
+                    })
             });
             if touches_setup_value && let Some(te) = self.type_exports.get_mut(idx) {
                 te.hoisted = false;

--- a/crates/vize_maestro/src/ide/auto_import.rs
+++ b/crates/vize_maestro/src/ide/auto_import.rs
@@ -91,6 +91,45 @@ impl AutoImportIndex {
         self.entries.iter().filter(move |entry| entry.name == name)
     }
 
+    /// Find the first importable entry in `root` whose name equals `name`,
+    /// without building (and immediately discarding) a full directory index.
+    ///
+    /// The auto-import code action only ever needs one entry, and it fires
+    /// frequently (cursor moves, lightbulb refresh). Short-circuiting at the
+    /// first match keeps it from reading the whole directory into a `Vec` and
+    /// allocating an entry per `.vue` / composable just to throw all but one
+    /// away. Iteration order matches `from_directory` + `lookup().next()`.
+    pub fn find_in_directory(root: &Path, name: &str) -> Option<AutoImportEntry> {
+        let read_dir = std::fs::read_dir(root).ok()?;
+        for entry in read_dir.flatten() {
+            let path = entry.path();
+            let Some(file_name) = path.file_name().and_then(|n| n.to_str()) else {
+                continue;
+            };
+            if let Some(stem) = file_name.strip_suffix(".vue") {
+                if pascal_case(stem) == name {
+                    return Some(AutoImportEntry {
+                        name: name.to_string(),
+                        source: path,
+                        kind: AutoImportKind::VueComponent,
+                    });
+                }
+            } else if file_name.starts_with("use") {
+                let lowered = file_name.to_ascii_lowercase();
+                if (lowered.ends_with(".ts") || lowered.ends_with(".js"))
+                    && path.file_stem().and_then(|n| n.to_str()) == Some(name)
+                {
+                    return Some(AutoImportEntry {
+                        name: name.to_string(),
+                        source: path,
+                        kind: AutoImportKind::Composable,
+                    });
+                }
+            }
+        }
+        None
+    }
+
     /// Number of indexed entries. Useful for tests and tracing.
     pub fn len(&self) -> usize {
         self.entries.len()
@@ -145,5 +184,22 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let index = AutoImportIndex::from_directory(dir.path());
         assert!(index.is_empty());
+    }
+
+    #[test]
+    fn find_in_directory_matches_lookup_first() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("MyButton.vue"), "").unwrap();
+        std::fs::write(dir.path().join("useCounter.ts"), "").unwrap();
+        std::fs::write(dir.path().join("random.txt"), "").unwrap();
+
+        let index = AutoImportIndex::from_directory(dir.path());
+        for name in ["MyButton", "useCounter", "DoesNotExist"] {
+            assert_eq!(
+                AutoImportIndex::find_in_directory(dir.path(), name),
+                index.lookup(name).next().cloned(),
+                "find_in_directory should match lookup().next() for {name}",
+            );
+        }
     }
 }

--- a/crates/vize_maestro/src/ide/code_action.rs
+++ b/crates/vize_maestro/src/ide/code_action.rs
@@ -14,16 +14,29 @@ use tower_lsp::lsp_types::{
 /// Code action service for providing quick fixes and refactorings.
 pub struct CodeActionService;
 
+/// One SFC parse + template lint pass, shared across the lint-based collectors
+/// so a single code-action request doesn't parse and lint the same file twice.
+struct TemplateLint {
+    /// Template block content (the text the linter ran against).
+    content: String,
+    /// 1-indexed line where the template block starts inside the SFC.
+    start_line: u32,
+    /// Lint diagnostics for the template block.
+    result: vize_patina::LintResult,
+}
+
 impl CodeActionService {
     /// Get code actions for the given context and range.
     pub fn code_actions(ctx: &IdeContext, range: Range) -> Vec<CodeActionOrCommand> {
         let mut actions = Vec::new();
 
-        // Collect lint fix actions
-        actions.extend(Self::collect_lint_fixes(ctx, range));
-
-        // Collect "@vize:forget" suppress actions
-        actions.extend(Self::collect_forget_suppress(ctx, range));
+        // Parse the SFC and run the template linter exactly once; both the
+        // lint-fix and `@vize:forget` collectors below operate on this shared
+        // result instead of re-parsing + re-linting the same content twice.
+        if let Some(lint) = Self::lint_template_once(ctx) {
+            actions.extend(Self::collect_lint_fixes(ctx, range, &lint));
+            actions.extend(Self::collect_forget_suppress(ctx, range, &lint));
+        }
 
         // Vue-flavored quick fixes: today this surfaces a "Wrap with `.value`"
         // edit when the cursor sits on a known reactive ref. See #691.
@@ -71,8 +84,8 @@ impl CodeActionService {
         let Some(workspace_dir) = workspace_dir else {
             return Vec::new();
         };
-        let index = crate::ide::auto_import::AutoImportIndex::from_directory(&workspace_dir);
-        let entry = index.lookup(identifier).next().cloned();
+        let entry =
+            crate::ide::auto_import::AutoImportIndex::find_in_directory(&workspace_dir, identifier);
         let Some(entry) = entry else {
             return Vec::new();
         };
@@ -284,33 +297,39 @@ impl CodeActionService {
         vec![CodeActionOrCommand::CodeAction(action)]
     }
 
-    /// Collect lint fix actions from vize_patina diagnostics.
-    fn collect_lint_fixes(ctx: &IdeContext, range: Range) -> Vec<CodeActionOrCommand> {
-        let mut actions = Vec::new();
-
-        // Parse SFC to get template
+    /// Parse the SFC and run the template linter once, returning the template
+    /// content, its starting line in the SFC, and the lint result. Shared by
+    /// the lint-fix and `@vize:forget` collectors so the (expensive) SFC parse
+    /// and template lint run a single time per code-action request.
+    fn lint_template_once(ctx: &IdeContext) -> Option<TemplateLint> {
         #[allow(clippy::disallowed_methods)]
         let options = vize_atelier_sfc::SfcParseOptions {
             filename: ctx.uri.path().to_string().into(),
             ..Default::default()
         };
-
-        let Ok(descriptor) = vize_atelier_sfc::parse_sfc(&ctx.content, options) else {
-            return actions;
-        };
-
-        let Some(ref template) = descriptor.template else {
-            return actions;
-        };
-
-        // Run linter to get diagnostics with fixes
+        let descriptor = vize_atelier_sfc::parse_sfc(&ctx.content, options).ok()?;
+        let template = descriptor.template.as_ref()?;
         let linter = vize_patina::Linter::new();
         let result = linter.lint_template(&template.content, ctx.uri.path());
+        Some(TemplateLint {
+            content: template.content.to_string(),
+            start_line: template.loc.start_line as u32,
+            result,
+        })
+    }
 
-        // Template block offset in SFC
-        let template_start_line = template.loc.start_line as u32;
+    /// Collect lint fix actions from vize_patina diagnostics.
+    fn collect_lint_fixes(
+        ctx: &IdeContext,
+        range: Range,
+        lint: &TemplateLint,
+    ) -> Vec<CodeActionOrCommand> {
+        let mut actions = Vec::new();
 
-        for lint_diag in result.diagnostics {
+        let template_content = lint.content.as_str();
+        let template_start_line = lint.start_line;
+
+        for lint_diag in &lint.result.diagnostics {
             // Check if diagnostic has a fix
             let Some(ref fix) = lint_diag.fix else {
                 continue;
@@ -318,8 +337,8 @@ impl CodeActionService {
 
             // Convert lint diagnostic position to SFC position
             let (start_line, start_col) =
-                offset_to_line_col(&template.content, lint_diag.start as usize);
-            let (end_line, end_col) = offset_to_line_col(&template.content, lint_diag.end as usize);
+                offset_to_line_col(template_content, lint_diag.start as usize);
+            let (end_line, end_col) = offset_to_line_col(template_content, lint_diag.end as usize);
 
             let diag_range = Range {
                 start: template_position(template_start_line, start_line, start_col),
@@ -337,9 +356,9 @@ impl CodeActionService {
                 .iter()
                 .map(|edit| {
                     let (edit_start_line, edit_start_col) =
-                        offset_to_line_col(&template.content, edit.start as usize);
+                        offset_to_line_col(template_content, edit.start as usize);
                     let (edit_end_line, edit_end_col) =
-                        offset_to_line_col(&template.content, edit.end as usize);
+                        offset_to_line_col(template_content, edit.end as usize);
 
                     TextEdit {
                         range: Range {
@@ -391,33 +410,21 @@ impl CodeActionService {
     }
 
     /// Collect `@vize:forget` suppress actions for diagnostics without auto-fix.
-    fn collect_forget_suppress(ctx: &IdeContext, range: Range) -> Vec<CodeActionOrCommand> {
+    fn collect_forget_suppress(
+        ctx: &IdeContext,
+        range: Range,
+        lint: &TemplateLint,
+    ) -> Vec<CodeActionOrCommand> {
         let mut actions = Vec::new();
 
-        #[allow(clippy::disallowed_methods)]
-        let options = vize_atelier_sfc::SfcParseOptions {
-            filename: ctx.uri.path().to_string().into(),
-            ..Default::default()
-        };
+        let template_content = lint.content.as_str();
+        let template_start_line = lint.start_line;
 
-        let Ok(descriptor) = vize_atelier_sfc::parse_sfc(&ctx.content, options) else {
-            return actions;
-        };
-
-        let Some(ref template) = descriptor.template else {
-            return actions;
-        };
-
-        let linter = vize_patina::Linter::new();
-        let result = linter.lint_template(&template.content, ctx.uri.path());
-
-        let template_start_line = template.loc.start_line as u32;
-
-        for lint_diag in result.diagnostics {
+        for lint_diag in &lint.result.diagnostics {
             // Convert diagnostic position to SFC position
             let (start_line, start_col) =
-                offset_to_line_col(&template.content, lint_diag.start as usize);
-            let (end_line, end_col) = offset_to_line_col(&template.content, lint_diag.end as usize);
+                offset_to_line_col(template_content, lint_diag.start as usize);
+            let (end_line, end_col) = offset_to_line_col(template_content, lint_diag.end as usize);
 
             let diag_range = Range {
                 start: template_position(template_start_line, start_line, start_col),
@@ -429,7 +436,7 @@ impl CodeActionService {
             }
 
             // Compute indentation of the diagnostic line
-            let indent = get_line_indent(&template.content, lint_diag.start as usize);
+            let indent = get_line_indent(template_content, lint_diag.start as usize);
 
             // Insert `<!-- @vize:forget <rule_name> -->\n` before the line
             let sfc_line = template_position(template_start_line, start_line, 0).line;

--- a/crates/vize_maestro/src/ide/completion.rs
+++ b/crates/vize_maestro/src/ide/completion.rs
@@ -13,7 +13,7 @@ mod items;
 mod script;
 mod service;
 mod style;
-mod template;
+pub(crate) mod template;
 
 // Cross-module reuse: inlay-hint code resolves reactive binding types with
 // the same heuristic that script completion uses.

--- a/crates/vize_maestro/src/ide/completion/script.rs
+++ b/crates/vize_maestro/src/ide/completion/script.rs
@@ -556,39 +556,29 @@ pub(crate) fn infer_reactive_value_type(
         _ => return None,
     };
 
-    let patterns = [
-        format!(
-            "const {name} = {callee}<",
-            callee = reactive_kind_callee(kind)
-        ),
-        format!(
-            "let {name} = {callee}<",
-            callee = reactive_kind_callee(kind)
-        ),
-    ];
-    for pattern in patterns {
-        if let Some(pos) = script_content.find(pattern.as_str()) {
-            let after = &script_content[pos + pattern.len()..];
-            if let Some(end) = find_matching_angle(after) {
-                return Some(after[..end].trim().to_string());
+    // The declaration is `const NAME = CALLEE<...>` or `const NAME = CALLEE(...)`
+    // (likewise for `let`). Rather than run four separate `format!` + full-string
+    // `find` scans (the `<` and `(` variants for each keyword), search the shared
+    // `KEYWORD NAME = CALLEE` prefix once per keyword and branch on the byte that
+    // immediately follows. A binding is declared once, so at most one keyword
+    // matches; behavior is identical to the four-pattern form.
+    let callee = reactive_kind_callee(kind);
+    for keyword in ["const", "let"] {
+        let prefix = format!("{keyword} {name} = {callee}");
+        let Some(pos) = script_content.find(prefix.as_str()) else {
+            continue;
+        };
+        let after = &script_content[pos + prefix.len()..];
+        match after.as_bytes().first() {
+            Some(b'<') => {
+                if let Some(end) = find_matching_angle(&after[1..]) {
+                    return Some(after[1..end + 1].trim().to_string());
+                }
             }
-        }
-    }
-
-    let patterns = [
-        format!(
-            "const {name} = {callee}(",
-            callee = reactive_kind_callee(kind)
-        ),
-        format!(
-            "let {name} = {callee}(",
-            callee = reactive_kind_callee(kind)
-        ),
-    ];
-    for pattern in patterns {
-        if let Some(pos) = script_content.find(pattern.as_str()) {
-            let after = &script_content[pos + pattern.len()..];
-            return infer_value_type_from_initializer(after, wrapper);
+            Some(b'(') => {
+                return infer_value_type_from_initializer(&after[1..], wrapper);
+            }
+            _ => {}
         }
     }
 
@@ -902,4 +892,79 @@ fn import_completions() -> Vec<CompletionItem> {
             "import { onMounted, onUnmounted } from 'vue'",
         ),
     ]
+}
+
+#[cfg(test)]
+mod infer_tests {
+    use super::infer_reactive_value_type;
+    use vize_croquis::reactivity::ReactiveKind;
+
+    fn infer(script: &str, name: &str, kind: ReactiveKind) -> Option<String> {
+        infer_reactive_value_type(script, name, kind)
+    }
+
+    #[test]
+    fn pins_angle_and_paren_inference_behavior() {
+        // Angle-bracket generic form.
+        assert_eq!(
+            infer("const count = ref<number>()", "count", ReactiveKind::Ref).as_deref(),
+            Some("number"),
+        );
+        assert_eq!(
+            infer("const item = ref<Foo>()", "item", ReactiveKind::Ref).as_deref(),
+            Some("Foo"),
+        );
+        // Parenthesized initializer form, `let` keyword.
+        assert_eq!(
+            infer("let name = ref(\"x\")", "name", ReactiveKind::Ref).as_deref(),
+            Some("string"),
+        );
+        assert_eq!(
+            infer("const n = ref(0)", "n", ReactiveKind::Ref).as_deref(),
+            Some("number"),
+        );
+        // Computed arrow body inference.
+        assert_eq!(
+            infer(
+                "const total = computed(() => 1 + 2)",
+                "total",
+                ReactiveKind::Computed
+            )
+            .as_deref(),
+            Some("number"),
+        );
+        // shallowRef / toRef callee mapping.
+        assert_eq!(
+            infer(
+                "const flag = shallowRef(true)",
+                "flag",
+                ReactiveKind::ShallowRef
+            )
+            .as_deref(),
+            Some("boolean"),
+        );
+    }
+
+    #[test]
+    fn pins_negative_and_non_inferrable_cases() {
+        // Reactive kind has no Ref/ComputedRef wrapper.
+        assert_eq!(
+            infer("const obj = reactive({})", "obj", ReactiveKind::Reactive),
+            None,
+        );
+        // Name not declared in the script.
+        assert_eq!(
+            infer("const a = ref(1)", "missing", ReactiveKind::Ref),
+            None
+        );
+        // Callee mismatch: a `ref` declaration is not matched when asked as toRef.
+        assert_eq!(infer("const t = ref(1)", "t", ReactiveKind::ToRef), None);
+        // Prefix-substring guard: `countX` must not match a query for `count`.
+        assert_eq!(
+            infer("const countX = ref(1)", "count", ReactiveKind::Ref),
+            None
+        );
+        // A space between callee and `<` defeats the heuristic (preserved).
+        assert_eq!(infer("const s = ref <Foo>()", "s", ReactiveKind::Ref), None);
+    }
 }

--- a/crates/vize_maestro/src/ide/completion/template.rs
+++ b/crates/vize_maestro/src/ide/completion/template.rs
@@ -792,9 +792,21 @@ fn is_slot_completion_prefix(prefix: &str) -> bool {
 }
 
 #[derive(Debug, Clone)]
-struct ComponentMetadata {
+pub(crate) struct ComponentMetadata {
     props: Vec<ComponentProp>,
     slots: Vec<ComponentSlot>,
+}
+
+/// Cached, parsed metadata for an imported component file, keyed in
+/// [`crate::server::ServerState`] by resolved path. The `len` + `modified`
+/// file stamp invalidates the entry when the component file changes on disk,
+/// so completion doesn't re-read + re-parse + re-analyze the same component on
+/// every keystroke inside an opening tag.
+#[derive(Clone)]
+pub(crate) struct CachedComponentMetadata {
+    pub len: u64,
+    pub modified: Option<std::time::SystemTime>,
+    pub metadata: std::sync::Arc<ComponentMetadata>,
 }
 
 #[derive(Debug, Clone)]
@@ -820,7 +832,10 @@ struct ComponentSlot {
     props_type: Option<String>,
 }
 
-fn component_metadata(ctx: &IdeContext, component_name: &str) -> Option<ComponentMetadata> {
+fn component_metadata(
+    ctx: &IdeContext,
+    component_name: &str,
+) -> Option<std::sync::Arc<ComponentMetadata>> {
     let mut names = vec![component_name.to_string()];
     let pascal = kebab_to_pascal(component_name);
     if !names.iter().any(|name| name == &pascal) {
@@ -832,25 +847,52 @@ fn component_metadata(ctx: &IdeContext, component_name: &str) -> Option<Componen
             continue;
         };
         let resolved = definition_helpers::resolve_import_path(ctx.uri, &import_path)?;
-        let component_content = std::fs::read_to_string(&resolved).ok()?;
-        return Some(extract_component_metadata(
-            &component_content,
-            &resolved.to_string_lossy(),
-            ctx.state.lsp_features().legacy_vue2,
-        ));
+        return cached_component_metadata(ctx, &resolved);
     }
 
     if let Some(import_path) = art_component_path(ctx, component_name) {
         let resolved = definition_helpers::resolve_import_path(ctx.uri, &import_path)?;
-        let component_content = std::fs::read_to_string(&resolved).ok()?;
-        return Some(extract_component_metadata(
-            &component_content,
-            &resolved.to_string_lossy(),
-            ctx.state.lsp_features().legacy_vue2,
-        ));
+        return cached_component_metadata(ctx, &resolved);
     }
 
     None
+}
+
+/// Return parsed metadata for the component at `resolved`, reusing a cached
+/// parse when the file's length + modification time are unchanged. Only the
+/// `fs::metadata` stat runs on the hot (cache-hit) path; the disk read, SFC
+/// parse, and Croquis analysis happen solely on a miss.
+fn cached_component_metadata(
+    ctx: &IdeContext,
+    resolved: &std::path::Path,
+) -> Option<std::sync::Arc<ComponentMetadata>> {
+    let cache = ctx.state.component_metadata_cache();
+    let (len, modified) = std::fs::metadata(resolved)
+        .map(|meta| (meta.len(), meta.modified().ok()))
+        .unwrap_or((0, None));
+
+    if let Some(entry) = cache.get(resolved)
+        && entry.len == len
+        && entry.modified == modified
+    {
+        return Some(entry.metadata.clone());
+    }
+
+    let component_content = std::fs::read_to_string(resolved).ok()?;
+    let metadata = std::sync::Arc::new(extract_component_metadata(
+        &component_content,
+        &resolved.to_string_lossy(),
+        ctx.state.lsp_features().legacy_vue2,
+    ));
+    cache.insert(
+        resolved.to_path_buf(),
+        CachedComponentMetadata {
+            len,
+            modified,
+            metadata: metadata.clone(),
+        },
+    );
+    Some(metadata)
 }
 
 fn art_component_path(ctx: &IdeContext<'_>, component_name: &str) -> Option<String> {
@@ -1661,4 +1703,61 @@ fn art_script_completions() -> Vec<CompletionItem> {
             ..Default::default()
         },
     ]
+}
+
+#[cfg(test)]
+mod cache_tests {
+    use super::cached_component_metadata;
+    use crate::ide::IdeContext;
+    use crate::server::ServerState;
+    use tower_lsp::lsp_types::Url;
+
+    #[test]
+    fn component_metadata_cache_hits_then_invalidates_on_change() {
+        let dir = tempfile::tempdir().unwrap();
+        let component = dir.path().join("Widget.vue");
+        std::fs::write(
+            &component,
+            "<script setup lang=\"ts\">\nconst props = defineProps<{ a: string }>()\n</script>\n",
+        )
+        .unwrap();
+
+        let state = ServerState::new();
+        let uri = Url::parse("file:///host.vue").unwrap();
+        state.documents.open(
+            uri.clone(),
+            "<template></template>".to_string(),
+            1,
+            "vue".to_string(),
+        );
+        let ctx = IdeContext::new(&state, &uri, 0).unwrap();
+
+        let first = cached_component_metadata(&ctx, &component).unwrap();
+        let second = cached_component_metadata(&ctx, &component).unwrap();
+        assert!(
+            std::sync::Arc::ptr_eq(&first, &second),
+            "an unchanged component file should hit the cache (same Arc, no re-parse)",
+        );
+        let first_prop_count = first.props.len();
+
+        // Rewrite with a different length so the file stamp changes; the next
+        // lookup must recompute rather than serve the stale cached parse.
+        std::fs::write(
+            &component,
+            "<script setup lang=\"ts\">\nconst props = defineProps<{ a: string; bb: number }>()\n</script>\n",
+        )
+        .unwrap();
+
+        let third = cached_component_metadata(&ctx, &component).unwrap();
+        assert!(
+            !std::sync::Arc::ptr_eq(&first, &third),
+            "a changed component file must invalidate the cached entry",
+        );
+        assert!(
+            third.props.len() > first_prop_count,
+            "recomputed metadata should reflect the added prop ({} -> {})",
+            first_prop_count,
+            third.props.len(),
+        );
+    }
 }

--- a/crates/vize_maestro/src/ide/document_highlight.rs
+++ b/crates/vize_maestro/src/ide/document_highlight.rs
@@ -2,11 +2,69 @@
 //!
 //! Highlights matching tag names and identifier occurrences in Vue and Art documents.
 
-use tower_lsp::lsp_types::{DocumentHighlight, DocumentHighlightKind, Range};
+use tower_lsp::lsp_types::{DocumentHighlight, DocumentHighlightKind, Position, Range};
 
-use super::{IdeContext, offset_to_position, token_span_at_offset};
+use super::{IdeContext, token_span_at_offset};
 
 pub struct DocumentHighlightService;
+
+/// Forward-only cursor that converts ascending byte offsets to LSP positions
+/// in a single pass over the document.
+///
+/// The previous code called `offset_to_position` (which re-walks the document
+/// from offset 0) twice per match, making highlighting O(occurrences × length).
+/// Matches are produced left-to-right, so a monotonic cursor turns the whole
+/// pass into O(length). Mirrors `offset_to_position_str`: lines count `\n`,
+/// columns count UTF-16 code units and reset at each newline.
+struct PositionWalker<'a> {
+    chars: std::str::CharIndices<'a>,
+    content_len: usize,
+    /// Byte offset of the next char to process.
+    offset: usize,
+    line: u32,
+    character: u32,
+    /// Byte offset where the current line begins (after the last `\n`).
+    line_start: usize,
+}
+
+impl<'a> PositionWalker<'a> {
+    fn new(content: &'a str) -> Self {
+        Self {
+            chars: content.char_indices(),
+            content_len: content.len(),
+            offset: 0,
+            line: 0,
+            character: 0,
+            line_start: 0,
+        }
+    }
+
+    /// Advance to `target` (a byte offset >= any previously requested target)
+    /// and return its (line, character) position.
+    fn position_at(&mut self, target: usize) -> (u32, u32) {
+        let target = target.min(self.content_len);
+        while self.offset < target {
+            let Some((byte, ch)) = self.chars.next() else {
+                break;
+            };
+            if ch == '\n' {
+                self.line += 1;
+                self.character = 0;
+                self.line_start = byte + 1;
+            } else {
+                self.character += ch.len_utf16() as u32;
+            }
+            self.offset = byte + ch.len_utf8();
+        }
+        (self.line, self.character)
+    }
+
+    /// Byte offset where the line containing the most recently visited target
+    /// begins. Valid immediately after a `position_at` call.
+    fn line_start(&self) -> usize {
+        self.line_start
+    }
+}
 
 impl DocumentHighlightService {
     pub fn highlights(ctx: &IdeContext<'_>) -> Option<Vec<DocumentHighlight>> {
@@ -27,35 +85,45 @@ impl DocumentHighlightService {
 }
 
 fn identifier_highlights(content: &str, symbol: &str) -> Vec<DocumentHighlight> {
-    let mut highlights = Vec::new();
+    // Collect matching spans first (ascending, non-overlapping), then convert
+    // every offset to a position with a single forward walk over the document.
+    let mut spans = Vec::new();
     let mut search_start = 0usize;
-
     while let Some(relative) = content[search_start..].find(symbol) {
         let start = search_start + relative;
         let end = start + symbol.len();
-
         if is_identifier_boundary(content.as_bytes(), start, end) {
-            highlights.push(highlight(
-                content,
-                start,
-                end,
-                identifier_highlight_kind(content, start),
-            ));
+            spans.push((start, end));
         }
-
         search_start = end;
     }
+    if spans.is_empty() {
+        return Vec::new();
+    }
 
+    let mut walker = PositionWalker::new(content);
+    let mut highlights = Vec::with_capacity(spans.len());
+    for (start, end) in spans {
+        let (start_line, start_character) = walker.position_at(start);
+        let kind = highlight_kind_for_prefix(&content[walker.line_start()..start]);
+        let (end_line, end_character) = walker.position_at(end);
+        highlights.push(span_highlight(
+            start_line,
+            start_character,
+            end_line,
+            end_character,
+            kind,
+        ));
+    }
     highlights
 }
 
 fn tag_highlights(content: &str, tag_name: &str) -> Vec<DocumentHighlight> {
-    let mut highlights = Vec::new();
+    let mut spans = Vec::new();
     let mut search_start = 0usize;
-
+    let bytes = content.as_bytes();
     while let Some(relative) = content[search_start..].find('<') {
         let tag_start = search_start + relative;
-        let bytes = content.as_bytes();
         let mut name_start = tag_start + 1;
 
         if bytes.get(name_start) == Some(&b'/') {
@@ -67,17 +135,28 @@ fn tag_highlights(content: &str, tag_name: &str) -> Vec<DocumentHighlight> {
             && &content[name_start..name_end] == tag_name
             && is_tag_name_boundary(bytes, name_start, name_end)
         {
-            highlights.push(highlight(
-                content,
-                name_start,
-                name_end,
-                Some(DocumentHighlightKind::TEXT),
-            ));
+            spans.push((name_start, name_end));
         }
 
         search_start = tag_start + 1;
     }
+    if spans.is_empty() {
+        return Vec::new();
+    }
 
+    let mut walker = PositionWalker::new(content);
+    let mut highlights = Vec::with_capacity(spans.len());
+    for (start, end) in spans {
+        let (start_line, start_character) = walker.position_at(start);
+        let (end_line, end_character) = walker.position_at(end);
+        highlights.push(span_highlight(
+            start_line,
+            start_character,
+            end_line,
+            end_character,
+            Some(DocumentHighlightKind::TEXT),
+        ));
+    }
     highlights
 }
 
@@ -156,22 +235,20 @@ fn tag_name_at_offset(content: &str, offset: usize) -> Option<(String, usize, us
     ))
 }
 
-fn highlight(
-    content: &str,
-    start: usize,
-    end: usize,
+fn span_highlight(
+    start_line: u32,
+    start_character: u32,
+    end_line: u32,
+    end_character: u32,
     kind: Option<DocumentHighlightKind>,
 ) -> DocumentHighlight {
-    let (start_line, start_character) = offset_to_position(content, start);
-    let (end_line, end_character) = offset_to_position(content, end);
-
     DocumentHighlight {
         range: Range {
-            start: tower_lsp::lsp_types::Position {
+            start: Position {
                 line: start_line,
                 character: start_character,
             },
-            end: tower_lsp::lsp_types::Position {
+            end: Position {
                 line: end_line,
                 character: end_character,
             },
@@ -180,9 +257,8 @@ fn highlight(
     }
 }
 
-fn identifier_highlight_kind(content: &str, start: usize) -> Option<DocumentHighlightKind> {
-    let line_start = content[..start].rfind('\n').map_or(0, |offset| offset + 1);
-    let prefix = content[line_start..start].trim_end();
+fn highlight_kind_for_prefix(prefix: &str) -> Option<DocumentHighlightKind> {
+    let prefix = prefix.trim_end();
 
     if prefix.ends_with("const")
         || prefix.ends_with("let")
@@ -244,9 +320,34 @@ fn is_tag_name_boundary(bytes: &[u8], start: usize, end: usize) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::DocumentHighlightService;
+    use super::{DocumentHighlightService, PositionWalker};
     use crate::{ide::IdeContext, server::ServerState};
     use tower_lsp::lsp_types::Url;
+
+    #[test]
+    fn position_walker_matches_offset_to_position_str() {
+        // Multi-line content with a multi-byte (UTF-16 surrogate pair) char so
+        // the walker's line/column tracking is exercised against the canonical
+        // converter at every char boundary, including ascending re-queries.
+        let content = "abc\ndé😀f\n\nghi";
+        let mut walker = PositionWalker::new(content);
+        let mut prev = 0usize;
+        for offset in 0..=content.len() {
+            if !content.is_char_boundary(offset) {
+                continue;
+            }
+            // Walker requires monotonic targets; advance from the previous one.
+            assert!(offset >= prev);
+            prev = offset;
+            let expected = crate::utils::offset_to_position_str(content, offset);
+            let (line, character) = walker.position_at(offset);
+            assert_eq!(
+                (line, character),
+                (expected.line, expected.character),
+                "mismatch at byte offset {offset}",
+            );
+        }
+    }
 
     fn context_for(source: &str, cursor_text: &str) -> (ServerState, Url, usize) {
         let state = ServerState::new();

--- a/crates/vize_maestro/src/server/state.rs
+++ b/crates/vize_maestro/src/server/state.rs
@@ -350,6 +350,12 @@ pub struct ServerState {
     virtual_gen: RwLock<VirtualCodeGenerator>,
     /// Cached virtual documents per file
     virtual_docs_cache: DashMap<Url, VirtualDocuments>,
+    /// Parsed metadata for imported components, keyed by resolved path.
+    /// Lets template completion skip re-reading + re-parsing + re-analyzing an
+    /// imported component on every keystroke; entries are invalidated by the
+    /// component file's length + modification time.
+    component_metadata_cache:
+        DashMap<PathBuf, crate::ide::completion::template::CachedComponentMetadata>,
     /// Enabled LSP feature surface.
     lsp_features: RwLock<LspFeatureConfig>,
     /// Fast path for checking whether type-aware features are enabled.
@@ -402,6 +408,7 @@ impl ServerState {
             documents: DocumentStore::new(),
             virtual_gen: RwLock::new(VirtualCodeGenerator::new()),
             virtual_docs_cache: DashMap::new(),
+            component_metadata_cache: DashMap::new(),
             lsp_features: RwLock::new(default_features),
             lsp_typecheck_enabled: AtomicBool::new(default_features.typecheck),
             type_checker_config: RwLock::new(TypeCheckerConfig::default()),
@@ -861,6 +868,15 @@ impl ServerState {
     /// Clear all cached virtual documents.
     pub fn clear_virtual_docs(&self) {
         self.virtual_docs_cache.clear();
+    }
+
+    /// Cache of parsed imported-component metadata, keyed by resolved path.
+    /// Used by template completion to avoid re-parsing imported components on
+    /// every keystroke. Callers handle staleness via the entry's file stamp.
+    pub(crate) fn component_metadata_cache(
+        &self,
+    ) -> &DashMap<PathBuf, crate::ide::completion::template::CachedComponentMetadata> {
+        &self.component_metadata_cache
     }
 
     /// Get a clone of the current format options.


### PR DESCRIPTION
## Summary

Performance pass over code added in the last couple days (LSP IDE features, virtual-TS/check, template parsing). Every change targets a hot path — per-keystroke completion, per-request code actions, per-call position mapping, per-parse analysis — and is behavior-preserving. No functional changes.

## Changes

**`vize_atelier_sfc`** — `defineProps`/`withDefaults` type parsing
- Replace the `Vec<char>` collected by four type-string helpers (used only to index `chars[i-1]` for the `=>` lookahead, called recursively per union member) with a single forward pass carrying a `prev` char.

**`vize_croquis`** — `resolve_type_export_hoisting` (runs every parse)
- Drop the up-front `O(imports × bindings)` set construction; test each `typeof`-referenced name's declaration span against the import ranges on demand → `O(refs × imports)`.

**`vize_canon`** — virtual project (LSP position mapping)
- `find_by_original` linearly scanned every virtual file with `PathBuf` equality; add an `original → virtual` secondary index (two hash lookups).
- `map_to_original`/`map_to_virtual` re-read the original file from disk on every call; retain the registered source on `VirtualFile` and use it. The registered text is exactly what the source map refers to, so this is also more correct for unsaved buffers.

**`vize_maestro`** — interactive IDE paths
- `code_action`: parsed the SFC + ran the template linter twice per request → parse and lint once, share the result.
- `auto_import`: the code action built and discarded a full directory index to find one name → `find_in_directory` short-circuits at the first match.
- template completion: imported-component metadata was re-read + re-parsed + re-analyzed on every keystroke inside an opening tag → cached in `ServerState` keyed by file length + mtime; only `fs::metadata` runs on a hit.
- `document_highlight`: per-match offset→position re-walked the document from 0 (`O(occurrences × length)`) → single monotonic forward cursor (`O(length)`) for both highlight paths.
- script completion: `infer_reactive_value_type` ran four `format!` + full `find` scans per reactive binding → search the shared prefix once per keyword and branch on the next byte (two scans).

## Tests

Added regression/parity/characterization tests:
- `PositionWalker` parity with the canonical offset→position converter (multi-line + UTF-16 surrogate pair).
- `find_in_directory` parity with `from_directory().lookup().next()`.
- component-metadata cache: hit returns the same `Arc` (no re-parse); a length change invalidates and recomputes.
- `infer_reactive_value_type`: angle/paren/computed/shallowRef inference + negative/boundary cases — pinned on the old impl, then verified unchanged after the refactor.

All touched-crate suites green (maestro 288, canon 227, croquis 157, atelier-sfc 405) plus `check_cli` integration (20). `cargo clippy` clean on all touched crates; full workspace builds without warnings.