### PR TITLE
fix(sfc): point props-destructure default-type diagnostic at the default value

### DIFF
--- a/crates/vize_atelier_sfc/src/compile_script/function_mode/compiler.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/function_mode/compiler.rs
@@ -42,7 +42,7 @@ pub fn compile_script_setup(
 
     let mut ctx = ScriptCompileContext::new(content);
     ctx.analyze();
-    validate_props_destructure_default_types(&ctx)?;
+    validate_props_destructure_default_types(&ctx, 0, content)?;
 
     // Use arena-allocated Vec for better performance
     let bump = vize_carton::Bump::new();

--- a/crates/vize_atelier_sfc/src/compile_script/inline/compiler.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/inline/compiler.rs
@@ -118,7 +118,7 @@ pub(crate) fn compile_script_setup_inline_with_context(
             .map(|d| d.bindings.values().any(|b| b.default.is_some()))
             .unwrap_or(false);
 
-    validate_props_destructure_default_types(&ctx)?;
+    validate_props_destructure_default_types(&ctx, 0, content)?;
 
     let has_define_model = !ctx.macros.define_models.is_empty();
     let has_define_slots = ctx.macros.define_slots.is_some();

--- a/crates/vize_atelier_sfc/src/compile_script/props.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/props.rs
@@ -725,17 +725,124 @@ pub(crate) fn normalize_destructure_default_value(default_value: &str) -> String
 /// the cost of `compile_sfc`. Returns `Ok(())` when there is no `<script
 /// setup>` or no actionable issue.
 pub fn validate_script_setup_semantics(script_setup_content: &str) -> Result<(), SfcError> {
+    // Delegating with a zero block offset yields block-relative diagnostic
+    // locations. Callers that know where the `<script setup>` block sits in
+    // the full SFC should prefer `validate_script_setup_semantics_located` so
+    // diagnostics map to the correct document position.
+    validate_script_setup_semantics_located(script_setup_content, 0, script_setup_content)
+}
+
+/// Like [`validate_script_setup_semantics`], but rebases diagnostic locations
+/// onto the full SFC: `block_start` is the byte offset of the script-setup
+/// block content within `sfc_source` (i.e. `script_setup.loc.start`), and
+/// `sfc_source` is the whole SFC text used to resolve line/column. This lets
+/// editor/check diagnostics point at the offending span (e.g. a destructure
+/// default) instead of the start of the `<script setup>` block.
+pub fn validate_script_setup_semantics_located(
+    script_setup_content: &str,
+    block_start: usize,
+    sfc_source: &str,
+) -> Result<(), SfcError> {
     if script_setup_content.is_empty() {
         return Ok(());
     }
     let mut ctx = ScriptCompileContext::new(script_setup_content);
     ctx.analyze();
-    validate_props_destructure_default_types(&ctx)
+    validate_props_destructure_default_types(&ctx, block_start, sfc_source)
+}
+
+/// Build a 1-based [`BlockLocation`] for an absolute byte span in `source`.
+/// Columns count UTF-16 code units to match the LSP position convention.
+fn block_location_for_span(source: &str, start: usize, end: usize) -> crate::types::BlockLocation {
+    fn line_col_1based(source: &str, offset: usize) -> (usize, usize) {
+        let target = offset.min(source.len());
+        let mut line = 1usize;
+        let mut column = 1usize;
+        for (index, ch) in source.char_indices() {
+            if index >= target {
+                break;
+            }
+            if ch == '\n' {
+                line += 1;
+                column = 1;
+            } else {
+                column += ch.len_utf16();
+            }
+        }
+        (line, column)
+    }
+    let (start_line, start_column) = line_col_1based(source, start);
+    let (end_line, end_column) = line_col_1based(source, end);
+    crate::types::BlockLocation {
+        start,
+        end,
+        tag_start: start,
+        tag_end: end,
+        start_line,
+        start_column,
+        end_line,
+        end_column,
+    }
+}
+
+/// Locate the byte span `(start, end)` of a reactive props-destructure
+/// default's value expression for `prop_key`, relative to
+/// `script_setup_content` (e.g. the `0` in `const { msg = 0 } = defineProps<…>()`).
+///
+/// Used to point the default-type-mismatch diagnostic at the offending
+/// default rather than the start of the `<script setup>` block. Re-parses the
+/// script-setup content; only the rare diagnostic error path calls this, so
+/// the extra parse is not on the hot path. The span lives on the AST, not on
+/// the public `PropsDestructureBinding`, to keep that type's API stable.
+fn props_destructure_default_span(
+    script_setup_content: &str,
+    prop_key: &str,
+) -> Option<(u32, u32)> {
+    use oxc_ast::ast::BindingPattern;
+
+    let allocator = Allocator::default();
+    let parsed = Parser::new(&allocator, script_setup_content, SourceType::ts()).parse();
+    for stmt in &parsed.program.body {
+        let Statement::VariableDeclaration(var_decl) = stmt else {
+            continue;
+        };
+        for decl in &var_decl.declarations {
+            // Match `const { … } = defineProps(…)`.
+            let BindingPattern::ObjectPattern(obj_pat) = &decl.id else {
+                continue;
+            };
+            let is_define_props = matches!(
+                &decl.init,
+                Some(Expression::CallExpression(call))
+                    if matches!(&call.callee, Expression::Identifier(id) if id.name == "defineProps")
+            );
+            if !is_define_props {
+                continue;
+            }
+            for prop in obj_pat.properties.iter() {
+                let key = match &prop.key {
+                    PropertyKey::StaticIdentifier(id) => id.name.as_str(),
+                    PropertyKey::StringLiteral(lit) => lit.value.as_str(),
+                    _ => continue,
+                };
+                if key != prop_key {
+                    continue;
+                }
+                if let BindingPattern::AssignmentPattern(assign) = &prop.value {
+                    let span = assign.right.span();
+                    return Some((span.start, span.end));
+                }
+            }
+        }
+    }
+    None
 }
 
 /// Validate reactive props destructure defaults against inferred runtime prop types.
 pub(crate) fn validate_props_destructure_default_types(
     ctx: &ScriptCompileContext,
+    block_start: usize,
+    sfc_source: &str,
 ) -> Result<(), SfcError> {
     let Some(destructure) = ctx.macros.props_destructure.as_ref() else {
         return Ok(());
@@ -782,6 +889,18 @@ pub(crate) fn validate_props_destructure_default_types(
         };
 
         if !runtime_type_includes(resolved_js_type.as_str(), default_type) {
+            // Point the diagnostic at the offending default expression when we
+            // can locate it, rebasing the block-relative span onto the full
+            // SFC. Falls back to no location (callers then pick a block-start
+            // fallback) only when the span cannot be resolved.
+            let loc =
+                props_destructure_default_span(&ctx.source, name).map(|(rel_start, rel_end)| {
+                    block_location_for_span(
+                        sfc_source,
+                        block_start + rel_start as usize,
+                        block_start + rel_end as usize,
+                    )
+                });
             return Err(SfcError {
                 message: {
                     let mut message = String::from("Default value of prop \"");
@@ -790,7 +909,7 @@ pub(crate) fn validate_props_destructure_default_types(
                     message
                 },
                 code: Some("DEFINE_PROPS_DESTRUCTURE_DEFAULT_TYPE".into()),
-                loc: None,
+                loc,
             });
         }
     }

--- a/crates/vize_atelier_sfc/src/lib.rs
+++ b/crates/vize_atelier_sfc/src/lib.rs
@@ -59,7 +59,9 @@ pub use bundler::{
     strip_css_comments_for_scoped, wrap_scoped_preprocessor_style,
 };
 pub use compile::{ScriptCompileResult, compile_sfc, compile_sfc_with_vue_parser_quirks};
-pub use compile_script::props::validate_script_setup_semantics;
+pub use compile_script::props::{
+    validate_script_setup_semantics, validate_script_setup_semantics_located,
+};
 pub use css::{
     CssAstResult, CssCompileOptions, CssCompileResult, CssTargets, bundle_css, compile_css,
     compile_style_block, parse_css_ast, print_css_ast,

--- a/crates/vize_canon/src/batch/virtual_project.rs
+++ b/crates/vize_canon/src/batch/virtual_project.rs
@@ -30,7 +30,7 @@ use vize_atelier_sfc::{
         SfcCroquisOptions, analyze_sfc_descriptor_with_context,
         analyze_sfc_descriptor_with_context_legacy_vue2,
     },
-    parse_sfc, validate_script_setup_semantics,
+    parse_sfc, validate_script_setup_semantics_located,
 };
 use vize_carton::{
     Bump, FxHashMap, FxHashSet, String as CompactString, ToCompactString, cstr, profile,
@@ -877,7 +877,11 @@ fn collect_sfc_compile_diagnostic(
         return None;
     }
 
-    match validate_script_setup_semantics(&script_setup.content) {
+    match validate_script_setup_semantics_located(
+        &script_setup.content,
+        script_setup.loc.start,
+        source,
+    ) {
         Ok(()) => None,
         Err(error) => Some(sfc_error_to_diagnostic(path, source, descriptor, &error)),
     }

--- a/crates/vize_canon/src/corsa_server.rs
+++ b/crates/vize_canon/src/corsa_server.rs
@@ -487,8 +487,11 @@ fn collect_sfc_compile_diagnostic(
         return None;
     }
 
-    let Err(error) = vize_atelier_sfc::validate_script_setup_semantics(&script_setup.content)
-    else {
+    let Err(error) = vize_atelier_sfc::validate_script_setup_semantics_located(
+        &script_setup.content,
+        script_setup.loc.start,
+        source,
+    ) else {
         return None;
     };
 

--- a/crates/vize_maestro/src/ide/diagnostics.rs
+++ b/crates/vize_maestro/src/ide/diagnostics.rs
@@ -584,6 +584,28 @@ const { msg = 0 } = defineProps<{ msg?: string }>();
             diagnostic.message
         );
         assert_eq!(diagnostic.severity, Some(DiagnosticSeverity::ERROR));
+
+        // The diagnostic must point at the offending default value (`0` on the
+        // second SFC line, after `const { msg = `), not at the start of the
+        // `<script setup>` block (line 0), which was the previous behavior.
+        assert_eq!(
+            diagnostic.range.start,
+            tower_lsp::lsp_types::Position {
+                line: 1,
+                character: 14,
+            },
+            "diagnostic should point at the default value `0`, got {:?}",
+            diagnostic.range,
+        );
+        assert_eq!(
+            diagnostic.range.end,
+            tower_lsp::lsp_types::Position {
+                line: 1,
+                character: 15,
+            },
+            "diagnostic should span the single-character default `0`, got {:?}",
+            diagnostic.range,
+        );
     }
 
     #[test]

--- a/crates/vize_maestro/src/ide/diagnostics/collectors.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/collectors.rs
@@ -314,8 +314,11 @@ impl DiagnosticService {
             return Vec::new();
         }
 
-        let Err(err) = vize_atelier_sfc::validate_script_setup_semantics(&script_setup.content)
-        else {
+        let Err(err) = vize_atelier_sfc::validate_script_setup_semantics_located(
+            &script_setup.content,
+            script_setup.loc.start,
+            content,
+        ) else {
             return Vec::new();
         };
 


### PR DESCRIPTION
## Problem

The `DEFINE_PROPS_DESTRUCTURE_DEFAULT_TYPE` diagnostic — *"Default value of prop \"msg\" does not match declared type"* — rendered at the **start of the `<script setup>` block** (the tag line) instead of on the offending default value.

Root cause: the diagnostic was constructed with `loc: None`, so both consumers (the LSP collector and the canon/CLI path) fell back to `script_setup.loc.start`. The `PropsDestructureBinding` carried no span for the default expression.

## Fix

- Add `validate_script_setup_semantics_located(content, block_start, sfc_source)` which rebases the diagnostic onto the full SFC. The offending default's byte span is resolved from the AST and offset by the script-setup block start, then converted to an absolute 1-based line/column (UTF-16 columns, matching the LSP convention).
- The existing public `validate_script_setup_semantics` is **kept** and delegates with a zero offset, so `vize_atelier_sfc`'s public API is unchanged (verified with `cargo semver-checks`).
- The default's span is re-derived from the AST inside the validator (only on the rare error branch) rather than stored on the public `PropsDestructureBinding`, keeping that type's API stable.
- Wired through the LSP collector (`collectors.rs`), socket-mode check (`corsa_server.rs`), and batch checker (`virtual_project.rs`).

## Tests

The existing LSP regression test never asserted the range (which is how this slipped through). It now pins the diagnostic to the default value's position (line 1, char 14–15) rather than the block start. All `vize_atelier_sfc` (405), `vize_canon` (227), and `vize_maestro` (283) tests pass; clippy clean; `cargo semver-checks` reports no API change for `vize_atelier_sfc` / `vize_canon`.