### PR TITLE
fix(canon,maestro): resolve relative .vue imports in editor Corsa session (#752)

### DIFF
--- a/crates/vize_canon/src/batch/import_rewriter.rs
+++ b/crates/vize_canon/src/batch/import_rewriter.rs
@@ -425,11 +425,13 @@ export { default as Re } from './Re.vue';
         found.sort();
         // Aliased and bare specifiers are intentionally excluded.
         assert_eq!(
-            found
-                .iter()
-                .map(|s| s.as_str())
-                .collect::<Vec<_>>(),
-            ["../shared/Sibling.vue", "./App.vue", "./Lazy.vue", "./Re.vue"]
+            found.iter().map(|s| s.as_str()).collect::<Vec<_>>(),
+            [
+                "../shared/Sibling.vue",
+                "./App.vue",
+                "./Lazy.vue",
+                "./Re.vue"
+            ]
         );
     }
 

--- a/crates/vize_canon/src/batch/import_rewriter.rs
+++ b/crates/vize_canon/src/batch/import_rewriter.rs
@@ -198,6 +198,57 @@ impl ImportRewriter {
         }
     }
 
+    /// Collect relative `.vue` import specifiers (those starting with `./`
+    /// or `../`) from the source. The editor's Corsa session uses this to
+    /// enumerate siblings whose virtual `.vue.ts` mirrors must be overlaid
+    /// for relative resolution to succeed; alias and bare specifiers are
+    /// excluded because they are handled by tsconfig `paths` and the ambient
+    /// `*.vue.ts` declaration respectively. See issue #752.
+    pub fn collect_relative_vue_specifiers(
+        &self,
+        source: &str,
+        source_type: SourceType,
+    ) -> Vec<String> {
+        if !source.contains(".vue") {
+            return Vec::new();
+        }
+
+        let allocator = Allocator::default();
+        let parser = Parser::new(&allocator, source, source_type);
+        let result = parser.parse();
+
+        let mut specifiers: Vec<String> = Vec::new();
+        let mut push = |path: &str| {
+            if path.ends_with(".vue") && (path.starts_with("./") || path.starts_with("../")) {
+                let candidate = path.to_compact_string();
+                if !specifiers.iter().any(|s| s.as_str() == candidate.as_str()) {
+                    specifiers.push(candidate);
+                }
+            }
+        };
+
+        for stmt in &result.program.body {
+            match stmt {
+                Statement::ImportDeclaration(decl) => push(&decl.source.value),
+                Statement::ExportNamedDeclaration(decl) => {
+                    if let Some(source) = &decl.source {
+                        push(&source.value);
+                    }
+                }
+                Statement::ExportAllDeclaration(decl) => push(&decl.source.value),
+                _ => {}
+            }
+        }
+
+        let mut collector = DynamicImportCollector::new();
+        collector.visit_program(&result.program);
+        for (_, _, path) in collector.imports {
+            push(&path);
+        }
+
+        specifiers
+    }
+
     /// Rewrite a module specifier if it's a .vue import.
     fn rewrite_module_specifier(&self, path: &str) -> Option<String> {
         // Rewrite every `.vue` import to `.vue.ts` so Corsa resolves the
@@ -357,6 +408,29 @@ const x = 1;"#;
 
         // The adjustment is +3 (.ts added), so virtual - 3 = original
         assert!(original_offset < virtual_offset);
+    }
+
+    #[test]
+    fn test_collect_relative_vue_specifiers() {
+        let rewriter = ImportRewriter::new();
+        let source = r#"import App from './App.vue';
+import Sibling from '../shared/Sibling.vue';
+import Aliased from '@/Aliased.vue';
+import { ref } from 'vue';
+import Lazy from './App.vue';
+const Lazy2 = () => import('./Lazy.vue');
+export { default as Re } from './Re.vue';
+"#;
+        let mut found = rewriter.collect_relative_vue_specifiers(source, SourceType::ts());
+        found.sort();
+        // Aliased and bare specifiers are intentionally excluded.
+        assert_eq!(
+            found
+                .iter()
+                .map(|s| s.as_str())
+                .collect::<Vec<_>>(),
+            ["../shared/Sibling.vue", "./App.vue", "./Lazy.vue", "./Re.vue"]
+        );
     }
 
     #[test]

--- a/crates/vize_canon/src/corsa_server.rs
+++ b/crates/vize_canon/src/corsa_server.rs
@@ -377,8 +377,8 @@ impl CorsaServer {
         self.cache.insert(uri.into(), virtual_ts.clone());
 
         // Overlay sibling .vue.ts mirrors discovered from the host's imports.
-        let relative_specifiers =
-            rewriter.collect_relative_vue_specifiers(pre_rewrite_ts.as_str(), oxc_span::SourceType::ts());
+        let relative_specifiers = rewriter
+            .collect_relative_vue_specifiers(pre_rewrite_ts.as_str(), oxc_span::SourceType::ts());
         if !relative_specifiers.is_empty() {
             self.overlay_sibling_vue_mirrors(uri, &relative_specifiers);
         }
@@ -560,7 +560,8 @@ impl CorsaServer {
                 } else {
                     let r = client.did_open(&sibling_virtual_uri, &sibling_virtual_ts);
                     if r.is_ok() {
-                        self.open_virtual_documents.insert(sibling_virtual_uri.clone());
+                        self.open_virtual_documents
+                            .insert(sibling_virtual_uri.clone());
                     }
                     r
                 };

--- a/crates/vize_canon/src/corsa_server.rs
+++ b/crates/vize_canon/src/corsa_server.rs
@@ -362,10 +362,26 @@ impl CorsaServer {
             template_offset,
         );
 
-        let virtual_ts = output.content.clone();
+        // Issue #752: rewrite `.vue` import specifiers to `.vue.ts` so the
+        // socket-mode Corsa session resolves siblings via the same virtual
+        // mirrors used by the batch path, then overlay each relative
+        // sibling's virtual TS into the session. The cached `virtual_ts`
+        // intentionally reflects what we ship to Corsa (rewritten form), so
+        // consumers that introspect the cache see the same coordinates.
+        let pre_rewrite_ts = output.content;
+        let rewriter = crate::batch::ImportRewriter::new();
+        let virtual_ts: String = rewriter
+            .rewrite(pre_rewrite_ts.as_str(), oxc_span::SourceType::ts())
+            .code;
 
-        // Cache the virtual TS
         self.cache.insert(uri.into(), virtual_ts.clone());
+
+        // Overlay sibling .vue.ts mirrors discovered from the host's imports.
+        let relative_specifiers =
+            rewriter.collect_relative_vue_specifiers(pre_rewrite_ts.as_str(), oxc_span::SourceType::ts());
+        if !relative_specifiers.is_empty() {
+            self.overlay_sibling_vue_mirrors(uri, &relative_specifiers);
+        }
 
         // Run Corsa on the virtual TypeScript through the project-session API.
         let mut diagnostics = self.run_corsa(uri, &virtual_ts)?;
@@ -438,6 +454,139 @@ impl CorsaServer {
         Ok(diagnostics)
     }
 
+    /// Overlay sibling `.vue.ts` mirrors for every relative `.vue` import,
+    /// recursively, so socket-mode Corsa can resolve `import App from
+    /// './app.vue'` (issue #752). Errors are logged and skipped so a missing
+    /// sibling still surfaces as TS2307 from the host check.
+    fn overlay_sibling_vue_mirrors(&mut self, host_uri: &str, initial_specifiers: &[String]) {
+        use vize_atelier_core::parser::parse;
+        use vize_atelier_sfc::{
+            SfcParseOptions,
+            croquis::{SfcCroquisOptions, analyze_sfc_descriptor_with_context},
+            parse_sfc,
+        };
+        use vize_carton::Bump;
+        use vize_croquis::virtual_ts::generate_virtual_ts;
+
+        let Some(host_path) = uri_to_path(host_uri, &self.working_dir()) else {
+            tracing::debug!("overlay_sibling_vue_mirrors: cannot resolve host path: {host_uri}");
+            return;
+        };
+        let host_dir = match host_path.parent() {
+            Some(dir) => dir.to_path_buf(),
+            None => return,
+        };
+
+        let mut visited: FxHashSet<PathBuf> = FxHashSet::default();
+        visited.insert(host_path.clone());
+
+        let mut queue: Vec<(PathBuf, Vec<String>)> = vec![(
+            host_dir,
+            initial_specifiers
+                .iter()
+                .map(|s| s.as_str().into())
+                .collect(),
+        )];
+        let rewriter = crate::batch::ImportRewriter::new();
+
+        while let Some((dir, specifiers)) = queue.pop() {
+            for specifier in specifiers {
+                let resolved = dir.join(&specifier);
+                let canonical = std::fs::canonicalize(&resolved).unwrap_or(resolved);
+                if !visited.insert(canonical.clone()) {
+                    continue;
+                }
+
+                let sibling_content = match std::fs::read_to_string(&canonical) {
+                    Ok(text) => text,
+                    Err(err) => {
+                        tracing::debug!(
+                            "socket overlay sibling skipped — read failed for {}: {err}",
+                            canonical.display(),
+                        );
+                        continue;
+                    }
+                };
+
+                let sibling_uri = crate::file_uri::path_to_file_uri(&canonical);
+                let sibling_virtual_uri = self.virtual_uri_for(&sibling_uri);
+
+                let parse_opts = SfcParseOptions {
+                    filename: sibling_uri.as_str().into(),
+                    ..Default::default()
+                };
+                let Ok(descriptor) = parse_sfc(&sibling_content, parse_opts) else {
+                    continue;
+                };
+
+                let allocator = Bump::new();
+                let template_offset = descriptor
+                    .template
+                    .as_ref()
+                    .map(|t| t.loc.start as u32)
+                    .unwrap_or(0);
+                let template_ast = descriptor.template.as_ref().map(|template| {
+                    let (root, _) = parse(&allocator, &template.content);
+                    root
+                });
+                let analysis = analyze_sfc_descriptor_with_context(
+                    &descriptor,
+                    template_ast.as_ref(),
+                    SfcCroquisOptions::full().without_script_merge(),
+                );
+                let sibling_output = generate_virtual_ts(
+                    analysis.script_content_ref(),
+                    template_ast.as_ref(),
+                    &analysis.croquis.bindings,
+                    None,
+                    Some(canonical.as_path()),
+                    template_offset,
+                );
+
+                let sibling_rewrite =
+                    rewriter.rewrite(sibling_output.content.as_str(), oxc_span::SourceType::ts());
+                let sibling_virtual_ts: String = sibling_rewrite.code;
+
+                let client = match self.corsa_client.as_mut() {
+                    Some(client) => client,
+                    None => return,
+                };
+
+                let result = if self
+                    .open_virtual_documents
+                    .contains(sibling_virtual_uri.as_str())
+                {
+                    client.did_change(&sibling_virtual_uri, &sibling_virtual_ts)
+                } else {
+                    let r = client.did_open(&sibling_virtual_uri, &sibling_virtual_ts);
+                    if r.is_ok() {
+                        self.open_virtual_documents.insert(sibling_virtual_uri.clone());
+                    }
+                    r
+                };
+                if let Err(err) = result {
+                    tracing::debug!(
+                        "socket overlay sibling failed for {}: {err}",
+                        canonical.display(),
+                    );
+                    continue;
+                }
+
+                let next_specifiers = rewriter.collect_relative_vue_specifiers(
+                    sibling_output.content.as_str(),
+                    oxc_span::SourceType::ts(),
+                );
+                if !next_specifiers.is_empty() {
+                    let next_dir = canonical
+                        .parent()
+                        .map(|p| p.to_path_buf())
+                        .unwrap_or_else(|| canonical.clone());
+                    queue.push((next_dir, next_specifiers));
+                }
+            }
+        }
+    }
+
     fn virtual_uri_for(&self, uri: &str) -> String {
         if uri.starts_with("file://") || uri.contains("://") {
             return cstr!("{uri}.ts");
@@ -477,6 +626,47 @@ impl Default for CorsaServer {
 /// Surface Vue-specific script-setup semantic errors (e.g.
 /// `DEFINE_PROPS_DESTRUCTURE_DEFAULT_TYPE`). Uses the lightweight validator
 /// entry point so the socket-mode check stays as fast as the Virtual TS path.
+/// Resolve a URI (file:// or plain path) to an absolute filesystem path.
+/// Returns None when the URI is a non-`file` scheme or the path cannot be
+/// extracted. Used by socket-mode sibling overlay to read siblings from disk.
+fn uri_to_path(uri: &str, working_dir: &Path) -> Option<PathBuf> {
+    if let Some(stripped) = uri.strip_prefix("file://") {
+        let decoded = percent_decode(stripped);
+        return Some(PathBuf::from(decoded));
+    }
+    if uri.contains("://") {
+        return None;
+    }
+    let path = Path::new(uri);
+    if path.is_absolute() {
+        Some(path.to_path_buf())
+    } else {
+        Some(working_dir.join(path))
+    }
+}
+
+/// Minimal `%`-decoder for `file://` URIs. Only handles the small set of
+/// characters TypeScript and Corsa typically encode (space, special chars).
+fn percent_decode(input: &str) -> String {
+    let bytes = input.as_bytes();
+    let mut out = String::with_capacity(input.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'%' && i + 2 < bytes.len() {
+            let hi = (bytes[i + 1] as char).to_digit(16);
+            let lo = (bytes[i + 2] as char).to_digit(16);
+            if let (Some(hi), Some(lo)) = (hi, lo) {
+                out.push(((hi * 16 + lo) as u8) as char);
+                i += 3;
+                continue;
+            }
+        }
+        out.push(bytes[i] as char);
+        i += 1;
+    }
+    out
+}
+
 fn collect_sfc_compile_diagnostic(
     _uri: &str,
     source: &str,

--- a/crates/vize_maestro/src/ide/diagnostics.rs
+++ b/crates/vize_maestro/src/ide/diagnostics.rs
@@ -61,10 +61,19 @@ pub(super) struct SourceMapping {
 /// Virtual TypeScript generation result with position mapping info.
 #[cfg(feature = "native")]
 pub(super) struct VirtualTsResult {
-    /// Generated TypeScript code
+    /// Generated TypeScript code (post `.vue` → `.vue.ts` import rewrite).
     pub(super) code: String,
     /// Byte-range source mappings from generated TS back to the source SFC.
+    /// Offsets are in pre-rewrite generated TS coordinates; callers must
+    /// translate post-rewrite byte offsets via `import_source_map` first.
     pub(super) source_mappings: Vec<vize_canon::virtual_ts::VizeMapping>,
+    /// Byte-offset mapping from post-rewrite to pre-rewrite virtual TS.
+    /// Empty when no `.vue` import specifiers were rewritten.
+    pub(super) import_source_map: vize_canon::ImportSourceMap,
+    /// Relative `.vue` import specifiers found in the SFC's script. The
+    /// editor session overlays each sibling's virtual TS so relative
+    /// imports resolve under the temp-dir Corsa session (issue #752).
+    pub(super) relative_vue_imports: Vec<std::string::String>,
     /// Line number where user code starts in virtual TS (0-indexed)
     pub(super) user_code_start_line: u32,
     /// Line number where script starts in original SFC (1-indexed)

--- a/crates/vize_maestro/src/ide/diagnostics/corsa.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/corsa.rs
@@ -9,7 +9,132 @@ use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, Position, Range, Url}
 use crate::server::ServerState;
 
 use super::{DiagnosticService, SourceMapping, VirtualTsResult, sources};
+use vize_canon::{ImportRewriter, ImportSourceMap};
 use vize_carton::cstr;
+
+/// Apply `ImportRewriter` to the generated virtual TS so `.vue` imports
+/// resolve to the generated `.vue.ts` mirrors in the editor Corsa session.
+///
+/// The rewrite only changes bytes *inside* import specifier strings (single
+/// line), so line numbers are preserved — only column offsets within affected
+/// lines shift. Returns the rewritten code and a byte-offset source map that
+/// `map_diagnostic_with_source_mappings` uses to translate post-rewrite
+/// diagnostic offsets back into pre-rewrite virtual TS offsets (which are the
+/// coordinate system the byte-range source mappings operate in).
+fn rewrite_vue_imports(code: &str) -> (std::string::String, ImportSourceMap) {
+    use oxc_span::SourceType;
+    let result = ImportRewriter::new().rewrite(code, SourceType::ts());
+    #[allow(clippy::disallowed_methods)]
+    (result.code.to_string(), result.source_map)
+}
+
+fn collect_relative_vue_specifiers(code: &str) -> Vec<std::string::String> {
+    use oxc_span::SourceType;
+    #[allow(clippy::disallowed_methods)]
+    ImportRewriter::new()
+        .collect_relative_vue_specifiers(code, SourceType::ts())
+        .into_iter()
+        .map(|s| s.to_string())
+        .collect()
+}
+
+/// Overlay the virtual TS for every relative `.vue` import of `host_uri`
+/// into the editor's Corsa session so TypeScript module resolution can find
+/// them (issue #752). Each sibling is opened at `<sibling_abs_path>.ts`,
+/// matching the `.vue.ts` suffix produced by `ImportRewriter`. Transitive
+/// `.vue` imports are followed recursively; cycles are avoided via a
+/// visited set keyed on the canonicalized sibling path. Failures are
+/// logged and skipped — a missing sibling falls through to the existing
+/// TS2307 surface, which is the desired behavior for genuinely missing
+/// modules.
+async fn overlay_sibling_vue_mirrors(
+    bridge: &std::sync::Arc<vize_canon::CorsaBridge>,
+    host_uri: &Url,
+    initial_specifiers: &[std::string::String],
+    legacy_vue2: bool,
+) {
+    use std::collections::HashSet;
+    use std::path::PathBuf;
+
+    if initial_specifiers.is_empty() {
+        return;
+    }
+
+    let Ok(host_path) = host_uri.to_file_path() else {
+        tracing::debug!(
+            "overlay_sibling_vue_mirrors: host URI is not a file path: {host_uri}",
+        );
+        return;
+    };
+    let host_dir = match host_path.parent() {
+        Some(dir) => dir.to_path_buf(),
+        None => return,
+    };
+
+    let mut visited: HashSet<PathBuf> = HashSet::new();
+    visited.insert(host_path.clone());
+
+    let mut queue: Vec<(PathBuf, Vec<std::string::String>)> =
+        vec![(host_dir, initial_specifiers.to_vec())];
+
+    while let Some((dir, specifiers)) = queue.pop() {
+        for specifier in specifiers {
+            let resolved = dir.join(specifier.as_str());
+            // Canonicalize is best-effort: if the file doesn't exist we still
+            // try the lexical join so genuinely missing imports surface
+            // TS2307 just as before.
+            let canonical = std::fs::canonicalize(&resolved).unwrap_or(resolved);
+            if !visited.insert(canonical.clone()) {
+                continue;
+            }
+
+            let sibling_content = match std::fs::read_to_string(&canonical) {
+                Ok(text) => text,
+                Err(err) => {
+                    tracing::debug!(
+                        "overlay sibling skipped — read failed for {}: {err}",
+                        canonical.display(),
+                    );
+                    continue;
+                }
+            };
+
+            let sibling_uri = match Url::from_file_path(&canonical) {
+                Ok(uri) => uri,
+                Err(_) => continue,
+            };
+
+            let sibling_virtual = if canonical.to_string_lossy().ends_with(".art.vue") {
+                DiagnosticService::generate_virtual_ts_for_art(&sibling_uri, &sibling_content)
+            } else {
+                DiagnosticService::generate_virtual_ts(&sibling_uri, &sibling_content, legacy_vue2)
+            };
+            let Some(sibling_virtual) = sibling_virtual else {
+                continue;
+            };
+
+            let sibling_name = cstr!("{}.ts", canonical.to_string_lossy());
+            if let Err(err) = bridge
+                .open_or_update_virtual_document(&sibling_name, &sibling_virtual.code)
+                .await
+            {
+                tracing::debug!(
+                    "overlay sibling failed for {}: {err}",
+                    canonical.display(),
+                );
+                continue;
+            }
+
+            let next_dir = canonical
+                .parent()
+                .map(|p| p.to_path_buf())
+                .unwrap_or_else(|| canonical.clone());
+            if !sibling_virtual.relative_vue_imports.is_empty() {
+                queue.push((next_dir, sibling_virtual.relative_vue_imports));
+            }
+        }
+    }
+}
 
 type LspRangeParts = (u32, u32, u32, u32);
 
@@ -71,6 +196,19 @@ impl DiagnosticService {
 
         // Create the virtual document name used to derive a stable URI.
         let virtual_name = cstr!("{}.ts", uri.path());
+
+        // Issue #752: Overlay sibling `.vue.ts` mirrors for every relative
+        // `.vue` import so TypeScript's module resolution succeeds against
+        // the temp-dir Corsa session. Without this, `import App from
+        // './app.vue'` rewrites correctly to `./app.vue.ts` but still
+        // reports TS2307 because the sibling is not present.
+        overlay_sibling_vue_mirrors(
+            &bridge,
+            uri,
+            &virtual_result.relative_vue_imports,
+            legacy_vue2,
+        )
+        .await;
 
         // Open or update the document in Corsa (uses didChange if already open).
         tracing::info!("opening/updating virtual document: {}", virtual_name);
@@ -143,6 +281,7 @@ impl DiagnosticService {
                     virtual_ts,
                     content.as_str(),
                     source_mappings,
+                    &virtual_result.import_source_map,
                     diag.range.start.line,
                     diag.range.start.character,
                     diag.range.end.line,
@@ -352,12 +491,23 @@ impl DiagnosticService {
         // Parse @vize-map comments to build line mappings
         // Format: // @vize-map: TYPE -> START:END
         // Where START:END are byte offsets in the SFC
+        // @vize-map comments are inserted by the generator on dedicated lines,
+        // so line indices survive the `.vue` → `.vue.ts` import rewrite below
+        // (which only edits bytes inside string literals on import lines).
         let line_mappings = Self::parse_vize_map_comments(&code);
 
+        // Issue #752: rewrite `.vue` import specifiers to `.vue.ts` so the
+        // editor's Corsa session resolves sibling SFCs via the same virtual
+        // mirrors used by the batch path. Collect the relative specifiers
+        // from the pre-rewrite code so the caller can overlay siblings.
+        let relative_vue_imports = collect_relative_vue_specifiers(&code);
+        let (rewritten_code, import_source_map) = rewrite_vue_imports(&code);
+
         Some(VirtualTsResult {
-            #[allow(clippy::disallowed_methods)]
-            code: code.to_string(),
+            code: rewritten_code,
             source_mappings,
+            import_source_map,
+            relative_vue_imports,
             user_code_start_line,
             sfc_script_start_line,
             template_scope_start_line,
@@ -579,10 +729,16 @@ impl DiagnosticService {
         // Parse @vize-map comments
         let line_mappings = Self::parse_vize_map_comments(&code);
 
+        // Issue #752: same rewrite as the non-art path so `.vue` imports in
+        // the art file's `<script setup>` resolve to virtual `.vue.ts` mirrors.
+        let relative_vue_imports = collect_relative_vue_specifiers(&code);
+        let (rewritten_code, import_source_map) = rewrite_vue_imports(&code);
+
         Some(VirtualTsResult {
-            #[allow(clippy::disallowed_methods)]
-            code: code.to_string(),
+            code: rewritten_code,
             source_mappings,
+            import_source_map,
+            relative_vue_imports,
             user_code_start_line,
             sfc_script_start_line,
             template_scope_start_line,
@@ -592,18 +748,25 @@ impl DiagnosticService {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn map_diagnostic_with_source_mappings(
     virtual_ts: &str,
     source: &str,
     mappings: &[vize_canon::virtual_ts::VizeMapping],
+    import_source_map: &ImportSourceMap,
     start_line: u32,
     start_character: u32,
     end_line: u32,
     end_character: u32,
 ) -> Option<LspRangeParts> {
-    let start_offset = line_character_to_byte_offset(virtual_ts, start_line, start_character)?;
-    let end_offset = line_character_to_byte_offset(virtual_ts, end_line, end_character)
-        .unwrap_or(start_offset.saturating_add(1));
+    // Diagnostics come back from Corsa in coordinates of the *rewritten*
+    // virtual TS (the one we sent). The byte-range mappings, however, were
+    // produced before the `.vue` → `.vue.ts` rewrite. Translate first.
+    let start_offset_post = line_character_to_byte_offset(virtual_ts, start_line, start_character)?;
+    let end_offset_post = line_character_to_byte_offset(virtual_ts, end_line, end_character)
+        .unwrap_or(start_offset_post.saturating_add(1));
+    let start_offset = import_source_map.get_original_offset(start_offset_post as u32) as usize;
+    let end_offset = import_source_map.get_original_offset(end_offset_post as u32) as usize;
     let start_mapping = mapping_for_generated_offset(mappings, start_offset)?;
     let src_start = map_generated_offset_to_source(start_mapping, start_offset);
     let src_end = mapping_for_generated_offset(mappings, end_offset)
@@ -821,5 +984,78 @@ mod tests {
         let offset = source.find("missing").unwrap();
 
         assert_eq!(source_offset_to_position(source, offset), (0, 19));
+    }
+
+    /// Issue #752: editor-side virtual TS generation must rewrite `.vue`
+    /// import specifiers to `.vue.ts` so the Corsa session can resolve
+    /// siblings via the virtual mirror — alias *and* relative specifiers
+    /// both get rewritten, mirroring the batch pipeline.
+    #[test]
+    fn editor_virtual_ts_rewrites_dot_vue_imports() {
+        use crate::DiagnosticService;
+        use tower_lsp::lsp_types::Url;
+
+        let uri = Url::parse("file:///tmp/Host.vue").expect("parse uri");
+        let content = "<script setup lang=\"ts\">\n\
+                       import App from './app.vue'\n\
+                       import Sibling from '../shared/Sib.vue'\n\
+                       import Aliased from '@/Alias.vue'\n\
+                       import { ref } from 'vue'\n\
+                       const _u = App\n\
+                       const _v = Sibling\n\
+                       const _w = Aliased\n\
+                       const _r = ref(0)\n\
+                       </script>\n\
+                       <template><div /></template>";
+
+        let result = DiagnosticService::generate_virtual_ts(&uri, content, false)
+            .expect("virtual ts generated");
+
+        assert!(
+            !result.code.contains("'./app.vue'"),
+            "expected relative .vue import to be rewritten, got:\n{}",
+            result.code,
+        );
+        assert!(
+            result.code.contains("'./app.vue.ts'"),
+            "expected rewritten relative specifier, got:\n{}",
+            result.code,
+        );
+        assert!(
+            result.code.contains("'../shared/Sib.vue.ts'"),
+            "expected rewritten parent-path specifier, got:\n{}",
+            result.code,
+        );
+        assert!(
+            result.code.contains("'@/Alias.vue.ts'"),
+            "expected rewritten alias specifier, got:\n{}",
+            result.code,
+        );
+        // Only relative specifiers feed the sibling overlay; alias and bare
+        // imports are excluded since they resolve via tsconfig paths and the
+        // ambient stub respectively.
+        assert!(
+            result
+                .relative_vue_imports
+                .iter()
+                .any(|s| s == "./app.vue"),
+            "expected ./app.vue in relative_vue_imports, got {:?}",
+            result.relative_vue_imports,
+        );
+        assert!(
+            result
+                .relative_vue_imports
+                .iter()
+                .any(|s| s == "../shared/Sib.vue"),
+            "expected ../shared/Sib.vue in relative_vue_imports, got {:?}",
+            result.relative_vue_imports,
+        );
+        assert!(
+            !result
+                .relative_vue_imports
+                .iter()
+                .any(|s| s == "@/Alias.vue"),
+            "alias specifier must not appear in relative_vue_imports",
+        );
     }
 }

--- a/crates/vize_maestro/src/ide/diagnostics/corsa.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/corsa.rs
@@ -61,9 +61,7 @@ async fn overlay_sibling_vue_mirrors(
     }
 
     let Ok(host_path) = host_uri.to_file_path() else {
-        tracing::debug!(
-            "overlay_sibling_vue_mirrors: host URI is not a file path: {host_uri}",
-        );
+        tracing::debug!("overlay_sibling_vue_mirrors: host URI is not a file path: {host_uri}",);
         return;
     };
     let host_dir = match host_path.parent() {
@@ -118,10 +116,7 @@ async fn overlay_sibling_vue_mirrors(
                 .open_or_update_virtual_document(&sibling_name, &sibling_virtual.code)
                 .await
             {
-                tracing::debug!(
-                    "overlay sibling failed for {}: {err}",
-                    canonical.display(),
-                );
+                tracing::debug!("overlay sibling failed for {}: {err}", canonical.display(),);
                 continue;
             }
 
@@ -1035,10 +1030,7 @@ mod tests {
         // imports are excluded since they resolve via tsconfig paths and the
         // ambient stub respectively.
         assert!(
-            result
-                .relative_vue_imports
-                .iter()
-                .any(|s| s == "./app.vue"),
+            result.relative_vue_imports.iter().any(|s| s == "./app.vue"),
             "expected ./app.vue in relative_vue_imports, got {:?}",
             result.relative_vue_imports,
         );


### PR DESCRIPTION
## Summary
- Editor sessions reported TS2307 for `import App from './app.vue'` because the LSP path sent the generated virtual TS to Corsa without rewriting `.vue` specifiers or materializing siblings, and TypeScript's ambient `declare module "*.vue"` doesn't apply to relative specifiers. The batch path masked the same problem by both materializing the mirror and blanket-suppressing TS2307.
- This PR fixes the editor session rigorously instead of mirroring the suppression (per the agreed direction in #752).

### Editor path (`vize_maestro`)
- Reuse `ImportRewriter` to rewrite `.vue` → `.vue.ts` in the editor virtual TS.
- Compose `ImportSourceMap` into `map_diagnostic_with_source_mappings` so diagnostic byte offsets translate back into the pre-rewrite coordinate system that the byte-range source mappings operate in (line numbers are preserved since the rewrite only edits bytes inside import-line string literals).
- `overlay_sibling_vue_mirrors` walks relative `.vue` imports recursively, generates each sibling's virtual TS, and opens it at `<sibling_abs_path>.vue.ts` via the bridge. A canonicalized visited set prevents cycles; read/parse failures fall through so genuinely missing modules still surface TS2307.

### Socket-mode (`corsa_server.rs`)
- Same rewrite + overlay via a sync analogue using the project-session client (`uri_to_path` + minimal `percent_decode` helper for `file://` URIs).

### New API (`vize_canon`)
- `ImportRewriter::collect_relative_vue_specifiers` returns only relative `.vue` import specifiers; alias and bare specifiers are intentionally excluded since they resolve via tsconfig `paths` and the ambient `*.vue.ts` stub respectively.

## Test plan
- [x] `test_collect_relative_vue_specifiers` covers static / dynamic / re-export forms, dedup, and exclusion of alias/bare imports.
- [x] `editor_virtual_ts_rewrites_dot_vue_imports` pins that `./app.vue`, `../shared/Sib.vue`, and `@/Alias.vue` all get rewritten to `.vue.ts` and that only relative specifiers populate `relative_vue_imports`.
- [x] `cargo test -p vize_maestro -p vize_canon --lib` (518 tests, all green).
- [x] `cargo build --workspace`, `cargo clippy -p vize_maestro -p vize_canon --lib --no-deps` (no warnings).

## Follow-ups
- After this lands, the batch path's blanket TS2307 suppression in `should_skip_diagnostic` could plausibly be narrowed to `.vue`-only — left for a separate PR per the issue's notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)