### PR TITLE
fix(compiler): VDOM template-compiler parity with @vue/compiler-sfc

### DIFF
--- a/crates/vize_armature/src/parser/attribute.rs
+++ b/crates/vize_armature/src/parser/attribute.rs
@@ -241,7 +241,10 @@ impl<'a> Parser<'a> {
         // The `.foo` shorthand is equivalent to `v-bind:foo.prop`: detect it
         // before `raw_name` is moved so we can synthesize a `prop` modifier.
         let dot_shorthand_prop = dir.raw_name.starts_with('.')
-            && !dir.modifiers.iter().any(|(content, _, _)| content == "prop");
+            && !dir
+                .modifiers
+                .iter()
+                .any(|(content, _, _)| content == "prop");
 
         let mut dir_node = DirectiveNode::new(self.allocator, dir.name.clone(), loc);
         dir_node.raw_name = Some(dir.raw_name);

--- a/crates/vize_armature/src/parser/attribute.rs
+++ b/crates/vize_armature/src/parser/attribute.rs
@@ -238,6 +238,11 @@ impl<'a> Parser<'a> {
             return;
         }
 
+        // The `.foo` shorthand is equivalent to `v-bind:foo.prop`: detect it
+        // before `raw_name` is moved so we can synthesize a `prop` modifier.
+        let dot_shorthand_prop = dir.raw_name.starts_with('.')
+            && !dir.modifiers.iter().any(|(content, _, _)| content == "prop");
+
         let mut dir_node = DirectiveNode::new(self.allocator, dir.name.clone(), loc);
         dir_node.raw_name = Some(dir.raw_name);
 
@@ -262,6 +267,15 @@ impl<'a> Parser<'a> {
             }
             let arg_boxed = Box::new_in(arg_expr, self.allocator);
             dir_node.arg = Some(ExpressionNode::Simple(arg_boxed));
+        }
+
+        // The `.foo` shorthand is equivalent to `v-bind:foo.prop`: synthesize
+        // a leading `prop` modifier so codegen treats it as a DOM property bind.
+        // (Vue's parser injects this modifier for the dot shorthand.)
+        if dot_shorthand_prop {
+            let mod_loc = self.create_loc(dir.name_start, dir.name_start + 1);
+            let mod_expr = SimpleExpressionNode::new("prop", true, mod_loc);
+            dir_node.modifiers.push(mod_expr);
         }
 
         // Add modifiers

--- a/crates/vize_atelier_core/src/codegen.rs
+++ b/crates/vize_atelier_core/src/codegen.rs
@@ -91,7 +91,17 @@ pub fn generate(root: &RootNode<'_>, options: CodegenOptions) -> CodegenResult {
         }
         ctx.deindent();
         ctx.newline();
-        ctx.push("], 64 /* STABLE_FRAGMENT */))");
+        // Vue tags a root fragment as DEV_ROOT_FRAGMENT when it wraps a single
+        // real node plus comment siblings, so dev tooling treats it as a root.
+        let non_comment_children = root_children
+            .iter()
+            .filter(|child| !matches!(child, TemplateChildNode::Comment(_)))
+            .count();
+        if non_comment_children == 1 {
+            ctx.push("], 2112 /* STABLE_FRAGMENT, DEV_ROOT_FRAGMENT */))");
+        } else {
+            ctx.push("], 64 /* STABLE_FRAGMENT */))");
+        }
     }
 
     ctx.deindent();

--- a/crates/vize_atelier_core/src/codegen.rs
+++ b/crates/vize_atelier_core/src/codegen.rs
@@ -205,10 +205,12 @@ mod tests {
         );
         let output = result_output(&super::generate(&root, crate::CodegenOptions::default()));
 
+        // Vue encodes non-word characters by char code (`:` -> 58), matching
+        // `toValidAssetId` (issue #4422).
         assert!(
-            output.contains(r#"const _component_global_head = _resolveComponent("global:head")"#)
+            output.contains(r#"const _component_global58head = _resolveComponent("global:head")"#)
         );
-        assert!(output.contains("_createBlock(_component_global_head"));
+        assert!(output.contains("_createBlock(_component_global58head"));
         assert!(!output.contains("_component_global:head"));
     }
 

--- a/crates/vize_atelier_core/src/codegen/context.rs
+++ b/crates/vize_atelier_core/src/codegen/context.rs
@@ -46,6 +46,11 @@ pub struct CodegenContext {
     pub(super) in_v_for: bool,
     /// When true, skip v-memo wrapping (already handled by v-for + v-memo)
     pub(super) skip_v_memo: bool,
+    /// When true, the props currently being generated belong to a plain
+    /// (native) element rather than a component/slot/template. Affects v-on
+    /// event-name casing rules (Vue preserves case via `on:` for plain
+    /// elements that have uppercase letters in the raw event name).
+    pub(super) props_is_plain_element: bool,
 }
 
 /// Code generation result
@@ -78,6 +83,7 @@ impl CodegenContext {
             skip_normalize: false,
             in_v_for: false,
             skip_v_memo: false,
+            props_is_plain_element: false,
         }
     }
 

--- a/crates/vize_atelier_core/src/codegen/element/block.rs
+++ b/crates/vize_atelier_core/src/codegen/element/block.rs
@@ -172,7 +172,9 @@ pub fn generate_element_block(ctx: &mut CodegenContext, el: &ElementNode<'_>) {
                 ctx.push(&hoisted_index.to_compact_string());
             } else if has_renderable_props(el) {
                 ctx.push(", ");
+                ctx.props_is_plain_element = true;
                 generate_props(ctx, &el.props);
+                ctx.props_is_plain_element = false;
             } else if !el.children.is_empty() || has_patch_info {
                 ctx.push(", null");
             }

--- a/crates/vize_atelier_core/src/codegen/element/inline.rs
+++ b/crates/vize_atelier_core/src/codegen/element/inline.rs
@@ -111,7 +111,9 @@ pub fn generate_element(ctx: &mut CodegenContext, el: &ElementNode<'_>) {
                 ctx.push(&hoisted_index.to_compact_string());
             } else if super::helpers::has_renderable_props(el) {
                 ctx.push(", ");
+                ctx.props_is_plain_element = true;
                 generate_props(ctx, &el.props);
+                ctx.props_is_plain_element = false;
             } else if !el.children.is_empty() || has_patch_info {
                 ctx.push(", null");
             }

--- a/crates/vize_atelier_core/src/codegen/expression/generate.rs
+++ b/crates/vize_atelier_core/src/codegen/expression/generate.rs
@@ -118,11 +118,12 @@ pub fn generate_event_handler(
                 return;
             }
 
-            // Compound expression: wrap as arrow function
+            // Compound expression: wrap as arrow function. Vue emits the
+            // multi-statement body with no surrounding spaces (`$event => {...}`).
             if processed.contains(';') {
-                ctx.push("$event => { ");
+                ctx.push("$event => {");
                 ctx.push(&processed);
-                ctx.push(" }");
+                ctx.push("}");
             } else {
                 ctx.push("$event => (");
                 ctx.push(&processed);

--- a/crates/vize_atelier_core/src/codegen/helpers.rs
+++ b/crates/vize_atelier_core/src/codegen/helpers.rs
@@ -12,7 +12,7 @@ use oxc_ast_visit::{
 use oxc_parser::Parser;
 use oxc_span::SourceType;
 use oxc_syntax::scope::ScopeFlags;
-use vize_carton::FxHashSet;
+use vize_carton::{FxHashSet, ToCompactString};
 use vize_croquis::builtins::is_global_allowed;
 
 /// Decode HTML entities (numeric character references) in a string
@@ -138,7 +138,7 @@ pub fn to_valid_asset_identifier(kind: &str, name: &str) -> String {
         } else if c == '-' {
             ident.push('_');
         } else {
-            ident.push_str(&(c as u32).to_string());
+            ident.push_str(&(c as u32).to_compact_string());
         }
     }
 

--- a/crates/vize_atelier_core/src/codegen/helpers.rs
+++ b/crates/vize_atelier_core/src/codegen/helpers.rs
@@ -129,11 +129,16 @@ pub fn to_valid_asset_identifier(kind: &str, name: &str) -> String {
     ident.push_str(kind);
     ident.push('_');
 
+    // Mirror Vue's `toValidAssetId` (compiler-core utils, issue #4422): word
+    // characters pass through, `-` becomes `_`, and every other character is
+    // replaced by its char code rendered as a decimal string.
     for c in name.chars() {
         if c.is_ascii_alphanumeric() || c == '_' {
             ident.push(c);
-        } else {
+        } else if c == '-' {
             ident.push('_');
+        } else {
+            ident.push_str(&(c as u32).to_string());
         }
     }
 

--- a/crates/vize_atelier_core/src/codegen/patch_flag.rs
+++ b/crates/vize_atelier_core/src/codegen/patch_flag.rs
@@ -219,8 +219,8 @@ fn calculate_element_patch_info_inner(
                                 // Build the dynamic-prop event name using the same
                                 // casing rules as v-on prop codegen so the
                                 // dynamicProps array matches the generated keys.
-                                let on_plain_element = el.tag_type == ElementType::Element
-                                    && dir.raw_name.is_some();
+                                let on_plain_element =
+                                    el.tag_type == ElementType::Element && dir.raw_name.is_some();
                                 let event_name = super::props::von_event_key_for(
                                     base_event,
                                     on_plain_element,

--- a/crates/vize_atelier_core/src/codegen/patch_flag.rs
+++ b/crates/vize_atelier_core/src/codegen/patch_flag.rs
@@ -124,6 +124,11 @@ fn calculate_element_patch_info_inner(
                             if !exp.is_static {
                                 // Dynamic key - FULL_PROPS
                                 flag |= 16;
+                                // .prop modifier requires NEED_HYDRATION even with a
+                                // dynamic argument (e.g. :[key].prop).
+                                if has_prop {
+                                    flag |= 32; // NEED_HYDRATION
+                                }
                             } else {
                                 let key = exp.content.as_str();
                                 match key {
@@ -211,36 +216,16 @@ fn calculate_element_patch_info_inner(
                                     base_event
                                 };
 
-                                // Build event name
-                                let mut event_name = String::with_capacity(2 + actual_event.len());
-                                event_name.push_str("on");
-                                // Capitalize first letter inline
-                                let mut chars = actual_event.chars();
-                                if let Some(c) = chars.next() {
-                                    for uc in c.to_uppercase() {
-                                        event_name.push(uc);
-                                    }
-                                    event_name.push_str(chars.as_str());
-                                }
-
-                                // Check for event option modifiers that affect the event name
-                                for modifier in dir.modifiers.iter() {
-                                    let mod_name = modifier.content.as_str();
-                                    if mod_name == "capture"
-                                        || mod_name == "once"
-                                        || mod_name == "passive"
-                                    {
-                                        let mut cap_mod = String::default();
-                                        let mut chars = mod_name.chars();
-                                        if let Some(c) = chars.next() {
-                                            for uc in c.to_uppercase() {
-                                                cap_mod.push(uc);
-                                            }
-                                            cap_mod.push_str(chars.as_str());
-                                        }
-                                        event_name.push_str(&cap_mod);
-                                    }
-                                }
+                                // Build the dynamic-prop event name using the same
+                                // casing rules as v-on prop codegen so the
+                                // dynamicProps array matches the generated keys.
+                                let on_plain_element = el.tag_type == ElementType::Element
+                                    && dir.raw_name.is_some();
+                                let event_name = super::props::von_event_key_for(
+                                    base_event,
+                                    on_plain_element,
+                                    dir.modifiers.iter().map(|m| m.content.as_str()),
+                                );
 
                                 // Check if the handler references a constant binding
                                 // If so, we don't need PROPS flag since the handler won't change
@@ -278,22 +263,30 @@ fn calculate_element_patch_info_inner(
 
                                 // Events that don't need NEED_HYDRATION:
                                 // - Basic click/dblclick without special modifiers
-                                // - update:* events (v-model internal events)
+                                // - the v-model `onUpdate:modelValue` handler (Vue
+                                //   excludes this exact reserved key only)
                                 // - Component events (non-DOM element events)
-                                // Note: event name can be "update:modelValue" or "Update:modelValue"
-                                let lower_event = base_event.to_lowercase();
-                                let is_vmodel_update = lower_event.starts_with("update:");
-                                let is_simple_click = matches!(actual_event, "click" | "dblclick")
+                                let is_vmodel_update = event_name == "onUpdate:modelValue";
+                                // Vue's hydration fast-path covers `onclick` only
+                                // (not dblclick or other mouse events).
+                                let is_simple_click = actual_event == "click"
                                     && !has_option_modifier
                                     && !has_key_modifier
                                     && !has_right_modifier
                                     && !has_middle_modifier;
                                 let is_component_event = el.tag_type == ElementType::Component;
+                                // onVnodeXXX lifecycle hooks are reserved props and
+                                // never trigger hydration event binding.
+                                let is_vnode_hook = event_name.starts_with("onVnode");
 
                                 // NEED_HYDRATION is needed for non-click/dblclick events
                                 // This tells Vue to properly hydrate event listeners during SSR
                                 // Note: NEED_HYDRATION is added regardless of caching status
-                                if !is_simple_click && !is_vmodel_update && !is_component_event {
+                                if !is_simple_click
+                                    && !is_vmodel_update
+                                    && !is_component_event
+                                    && !is_vnode_hook
+                                {
                                     flag |= 32; // NEED_HYDRATION
                                 }
                             }

--- a/crates/vize_atelier_core/src/codegen/patch_flag.rs
+++ b/crates/vize_atelier_core/src/codegen/patch_flag.rs
@@ -441,6 +441,9 @@ pub fn patch_flag_name(flag: i32) -> String {
     if flag & 1024 != 0 {
         names.push("DYNAMIC_SLOTS");
     }
+    if flag & 2048 != 0 {
+        names.push("DEV_ROOT_FRAGMENT");
+    }
 
     if names.is_empty() {
         "UNKNOWN".to_compact_string()

--- a/crates/vize_atelier_core/src/codegen/props.rs
+++ b/crates/vize_atelier_core/src/codegen/props.rs
@@ -9,7 +9,7 @@ use crate::ast::{PropNode, RuntimeHelper};
 
 use super::{context::CodegenContext, expression::generate_expression};
 
-pub use directives::{generate_directive_prop_with_static, is_supported_directive};
+pub use directives::{StaticMerge, generate_directive_prop_with_static, is_supported_directive};
 pub use events::von_event_key_for;
 pub use generate::generate_props;
 

--- a/crates/vize_atelier_core/src/codegen/props.rs
+++ b/crates/vize_atelier_core/src/codegen/props.rs
@@ -10,6 +10,7 @@ use crate::ast::{PropNode, RuntimeHelper};
 use super::{context::CodegenContext, expression::generate_expression};
 
 pub use directives::{generate_directive_prop_with_static, is_supported_directive};
+pub use events::von_event_key_for;
 pub use generate::generate_props;
 
 /// Check if there's a v-bind without argument (object spread)

--- a/crates/vize_atelier_core/src/codegen/props/directives.rs
+++ b/crates/vize_atelier_core/src/codegen/props/directives.rs
@@ -6,7 +6,7 @@ use super::super::{
     context::CodegenContext,
     expression::{generate_event_handler, generate_expression, generate_simple_expression},
     helpers::{
-        camelize, capitalize_first, escape_js_string, is_constant_simple_expression,
+        camelize, escape_js_string, is_constant_simple_expression,
         is_valid_js_identifier,
     },
 };
@@ -101,34 +101,58 @@ fn generate_vbind_prop(
 
     if let Some(ExpressionNode::Simple(exp)) = &dir.arg {
         if !exp.is_static {
-            // Dynamic attribute name: [_ctx.expr || ""]: value
-            ctx.push("[");
-            // If the expression doesn't already have a prefix, add _ctx.
-            let content = exp.content.as_str();
-            if content.contains('.')
-                || content.starts_with('_')
-                || content.starts_with('$')
-                || content.contains('`')
-                || content.contains('(')
-            {
-                // Template literal or already prefixed expression
-                // For template literals, wrap with parens and prefix inner identifiers
-                if content.starts_with('`') {
-                    ctx.push("(");
-                    // Prefix identifiers inside template literals with _ctx.
-                    let prefixed = super::super::expression::generate_simple_expression_with_prefix(
-                        ctx, content,
-                    );
-                    ctx.push(&prefixed);
-                    ctx.push(")");
+            // Dynamic attribute name. Modifiers transform the computed key:
+            //   (none)  -> [<expr> || ""]
+            //   .camel  -> [_camelize(<expr> || "")]
+            //   .prop   -> [`.${<expr> || ""}`]
+            //   .attr   -> [`^${<expr> || ""}`]
+            let emit_key_expr = |ctx: &mut CodegenContext| {
+                // If the expression doesn't already have a prefix, add _ctx.
+                let content = exp.content.as_str();
+                if content.contains('.')
+                    || content.starts_with('_')
+                    || content.starts_with('$')
+                    || content.contains('`')
+                    || content.contains('(')
+                {
+                    // Template literal or already prefixed expression
+                    // For template literals, wrap with parens and prefix inner identifiers
+                    if content.starts_with('`') {
+                        ctx.push("(");
+                        let prefixed =
+                            super::super::expression::generate_simple_expression_with_prefix(
+                                ctx, content,
+                            );
+                        ctx.push(&prefixed);
+                        ctx.push(")");
+                    } else {
+                        generate_simple_expression(ctx, exp);
+                    }
                 } else {
-                    generate_simple_expression(ctx, exp);
+                    ctx.push("_ctx.");
+                    ctx.push(content);
                 }
+            };
+
+            ctx.push("[");
+            if has_camel {
+                ctx.use_helper(RuntimeHelper::Camelize);
+                ctx.push("_camelize(");
+                emit_key_expr(ctx);
+                ctx.push(" || \"\")");
+            } else if has_prop {
+                ctx.push("`.${");
+                emit_key_expr(ctx);
+                ctx.push(" || \"\"}`");
+            } else if has_attr {
+                ctx.push("`^${");
+                emit_key_expr(ctx);
+                ctx.push(" || \"\"}`");
             } else {
-                ctx.push("_ctx.");
-                ctx.push(content);
+                emit_key_expr(ctx);
+                ctx.push(" || \"\"");
             }
-            ctx.push(" || \"\"]: ");
+            ctx.push("]: ");
         } else {
             let key = &exp.content;
             is_class = key == "class";
@@ -301,56 +325,28 @@ fn generate_von_prop(ctx: &mut CodegenContext, dir: &DirectiveNode<'_>) {
             }
             ctx.push(")]: ");
         } else {
-            let mut event_name = exp.content.as_str();
+            // Mirror Vue's event-name casing rule (transforms/vOn.ts), including
+            // mouse-button event renaming, `vue:` vnode hooks, and the `on:`
+            // case-preserving form for custom-element events on plain elements.
+            // The `on:` case-preserving form only applies to user-authored v-on
+            // directives (those carry a `raw_name`). Compiler-synthesized handlers
+            // like v-model's `update:modelValue` always camelize.
+            let on_plain_element = ctx.props_is_plain_element && dir.raw_name.is_some();
+            let event_name = super::events::von_event_key_for(
+                exp.content.as_str(),
+                on_plain_element,
+                dir.modifiers.iter().map(|m| m.content.as_str()),
+            );
 
-            // Special mouse button modifiers that change the event name
-            // @click.right -> onContextmenu, @click.middle -> onMouseup
-            let has_right_modifier = system_modifiers.contains(&"right");
-            let has_middle_modifier = system_modifiers.contains(&"middle");
-
-            if event_name == "click" && has_right_modifier {
-                event_name = "contextmenu";
-            } else if event_name == "click" && has_middle_modifier {
-                event_name = "mouseup";
+            let needs_quotes = !is_valid_js_identifier(&event_name);
+            if needs_quotes {
+                ctx.push("\"");
             }
-
-            // Handle special event names like "update:modelValue"
-            if event_name.contains(':') {
-                // Event name with colon needs quotes (e.g., "onUpdate:modelValue")
-                let parts: Vec<&str> = event_name.splitn(2, ':').collect();
-                if parts.len() == 2 {
-                    ctx.push("\"on");
-                    // Capitalize the first part (e.g., "update" -> "Update")
-                    // Also convert kebab-case to camelCase
-                    let first_part_camelized = camelize(parts[0]);
-                    if let Some(first) = first_part_camelized.chars().next() {
-                        ctx.push(&first.to_uppercase().to_compact_string());
-                        ctx.push(&first_part_camelized[first.len_utf8()..]);
-                    }
-                    ctx.push(":");
-                    ctx.push(parts[1]);
-                    // Append event option modifiers
-                    for opt_mod in &event_option_modifiers {
-                        ctx.push(&capitalize_first(opt_mod));
-                    }
-                    ctx.push("\": ");
-                }
-            } else {
-                // Simple event names don't need quotes (onUpdate, onClick)
-                // Convert kebab-case to camelCase first (e.g., "select-koma" -> "selectKoma")
-                let camelized = camelize(event_name);
-                ctx.push("on");
-                // Capitalize first letter of camelized name
-                if let Some(first) = camelized.chars().next() {
-                    ctx.push(&first.to_uppercase().to_compact_string());
-                    ctx.push(&camelized[first.len_utf8()..]);
-                }
-                // Append event option modifiers (Capture, Once, Passive)
-                for opt_mod in &event_option_modifiers {
-                    ctx.push(&capitalize_first(opt_mod));
-                }
-                ctx.push(": ");
+            ctx.push(&event_name);
+            if needs_quotes {
+                ctx.push("\"");
             }
+            ctx.push(": ");
         }
     }
 

--- a/crates/vize_atelier_core/src/codegen/props/directives.rs
+++ b/crates/vize_atelier_core/src/codegen/props/directives.rs
@@ -38,16 +38,62 @@ pub fn is_supported_directive(dir: &DirectiveNode<'_>) -> bool {
     matches!(dir.name.as_str(), "bind" | "on" | "html" | "text")
 }
 
+/// A static class/style attribute that will be merged with a dynamic
+/// `:class`/`:style` binding, plus whether the static value appears before
+/// the dynamic one in source order (Vue preserves source order in the merged
+/// array).
+#[derive(Clone, Copy, Default)]
+pub struct StaticMerge<'a> {
+    pub class: Option<&'a str>,
+    pub class_before: bool,
+    pub style: Option<&'a str>,
+    pub style_before: bool,
+}
+
+impl<'a> StaticMerge<'a> {
+    /// Build the merge metadata from an element's props in source order.
+    pub fn from_props(props: &'a [crate::ast::PropNode<'a>]) -> Self {
+        let mut merge = StaticMerge::default();
+        let mut class_index = None;
+        let mut style_index = None;
+        for (index, prop) in props.iter().enumerate() {
+            match prop {
+                crate::ast::PropNode::Attribute(attr) => {
+                    if attr.name == "class" && merge.class.is_none() {
+                        merge.class = attr.value.as_ref().map(|v| v.content.as_str());
+                        class_index = Some(index);
+                    } else if attr.name == "style" && merge.style.is_none() {
+                        merge.style = attr.value.as_ref().map(|v| v.content.as_str());
+                        style_index = Some(index);
+                    }
+                }
+                crate::ast::PropNode::Directive(dir) => {
+                    if dir.name == "bind"
+                        && let Some(ExpressionNode::Simple(exp)) = &dir.arg
+                        && exp.is_static
+                    {
+                        if exp.content == "class" && class_index.is_some_and(|i| i < index) {
+                            merge.class_before = true;
+                        } else if exp.content == "style" && style_index.is_some_and(|i| i < index) {
+                            merge.style_before = true;
+                        }
+                    }
+                }
+            }
+        }
+        merge
+    }
+}
+
 /// Generate directive as prop with optional static class/style merging
 pub fn generate_directive_prop_with_static(
     ctx: &mut CodegenContext,
     dir: &DirectiveNode<'_>,
-    static_class: Option<&str>,
-    static_style: Option<&str>,
+    static_merge: StaticMerge<'_>,
 ) {
     match dir.name.as_str() {
         "bind" => {
-            generate_vbind_prop(ctx, dir, static_class, static_style);
+            generate_vbind_prop(ctx, dir, static_merge);
         }
         "on" => {
             generate_von_prop(ctx, dir);
@@ -88,9 +134,10 @@ pub fn generate_directive_prop_with_static(
 fn generate_vbind_prop(
     ctx: &mut CodegenContext,
     dir: &DirectiveNode<'_>,
-    static_class: Option<&str>,
-    static_style: Option<&str>,
+    static_merge: StaticMerge<'_>,
 ) {
+    let static_class = static_merge.class;
+    let static_style = static_merge.style;
     let mut is_class = false;
     let mut is_style = false;
 
@@ -198,12 +245,22 @@ fn generate_vbind_prop(
                 ctx.use_helper(RuntimeHelper::NormalizeClass);
                 ctx.push("_normalizeClass(");
             }
-            // Merge static class if present (needed even inside mergeProps)
+            // Merge static class if present (needed even inside mergeProps).
+            // The array order follows source order: `class` before `:class`
+            // yields `["static", dynamic]`, otherwise `[dynamic, "static"]`.
             if let Some(static_val) = static_class {
-                ctx.push("[\"");
-                ctx.push(&escape_js_string(static_val));
-                ctx.push("\", ");
-                generate_expression(ctx, exp);
+                ctx.push("[");
+                if static_merge.class_before {
+                    ctx.push("\"");
+                    ctx.push(&escape_js_string(static_val));
+                    ctx.push("\", ");
+                    generate_expression(ctx, exp);
+                } else {
+                    generate_expression(ctx, exp);
+                    ctx.push(", \"");
+                    ctx.push(&escape_js_string(static_val));
+                    ctx.push("\"");
+                }
                 ctx.push("]");
             } else {
                 generate_expression(ctx, exp);
@@ -218,31 +275,42 @@ fn generate_vbind_prop(
                 ctx.use_helper(RuntimeHelper::NormalizeStyle);
                 ctx.push("_normalizeStyle(");
             }
-            // Merge static style if present (needed even inside mergeProps)
+            // Merge static style if present (needed even inside mergeProps).
+            // The array order follows source order, like class merging above.
             if let Some(static_val) = static_style {
-                ctx.push("[{");
-                // Parse static style and convert to object
-                for (i, part) in static_val
-                    .split(';')
-                    .filter(|s| !s.trim().is_empty())
-                    .enumerate()
-                {
-                    if i > 0 {
-                        ctx.push(",");
+                let emit_static_style = |ctx: &mut CodegenContext| {
+                    ctx.push("{");
+                    for (i, part) in static_val
+                        .split(';')
+                        .filter(|s| !s.trim().is_empty())
+                        .enumerate()
+                    {
+                        if i > 0 {
+                            ctx.push(",");
+                        }
+                        let parts: Vec<&str> = part.splitn(2, ':').collect();
+                        if parts.len() == 2 {
+                            let key = parts[0].trim();
+                            let value = parts[1].trim();
+                            ctx.push("\"");
+                            ctx.push(key);
+                            ctx.push("\":\"");
+                            ctx.push(value);
+                            ctx.push("\"");
+                        }
                     }
-                    let parts: Vec<&str> = part.splitn(2, ':').collect();
-                    if parts.len() == 2 {
-                        let key = parts[0].trim();
-                        let value = parts[1].trim();
-                        ctx.push("\"");
-                        ctx.push(key);
-                        ctx.push("\":\"");
-                        ctx.push(value);
-                        ctx.push("\"");
-                    }
+                    ctx.push("}");
+                };
+                ctx.push("[");
+                if static_merge.style_before {
+                    emit_static_style(ctx);
+                    ctx.push(", ");
+                    generate_expression(ctx, exp);
+                } else {
+                    generate_expression(ctx, exp);
+                    ctx.push(", ");
+                    emit_static_style(ctx);
                 }
-                ctx.push("}, ");
-                generate_expression(ctx, exp);
                 ctx.push("]");
             } else {
                 generate_expression(ctx, exp);

--- a/crates/vize_atelier_core/src/codegen/props/directives.rs
+++ b/crates/vize_atelier_core/src/codegen/props/directives.rs
@@ -5,10 +5,7 @@ use crate::ast::{DirectiveNode, ExpressionNode, RuntimeHelper};
 use super::super::{
     context::CodegenContext,
     expression::{generate_event_handler, generate_expression, generate_simple_expression},
-    helpers::{
-        camelize, escape_js_string, is_constant_simple_expression,
-        is_valid_js_identifier,
-    },
+    helpers::{camelize, escape_js_string, is_constant_simple_expression, is_valid_js_identifier},
 };
 use vize_carton::String;
 use vize_carton::ToCompactString;

--- a/crates/vize_atelier_core/src/codegen/props/events.rs
+++ b/crates/vize_atelier_core/src/codegen/props/events.rs
@@ -3,9 +3,78 @@
 use crate::ast::{DirectiveNode, ExpressionNode, PropNode, RuntimeHelper};
 
 use super::super::{
-    context::CodegenContext, expression::generate_event_handler, helpers::camelize,
+    context::CodegenContext,
+    expression::generate_event_handler,
+    helpers::{camelize, capitalize_first},
 };
 use vize_carton::String;
+
+/// Compute the prop key for a static v-on event, mirroring Vue's
+/// `transforms/vOn.ts` casing rules.
+///
+/// * `raw` is the static event argument (e.g. `click`, `foo-bar`, `vue:mounted`).
+/// * `is_plain_element` distinguishes native elements from components/slots.
+/// * `option_modifiers` are the `capture`/`once`/`passive` modifiers appended
+///   (capitalized) to the resulting key when `with_option_modifiers` is set.
+pub fn von_event_key_for(
+    raw: &str,
+    is_plain_element: bool,
+    modifiers: impl Iterator<Item = impl AsRef<str>>,
+) -> String {
+    // `@click.right` -> contextmenu, `@click.middle` -> mouseup. Detect first.
+    let mut has_right = false;
+    let mut has_middle = false;
+    let mut option_modifiers: Vec<&'static str> = Vec::new();
+    let collected: Vec<String> = modifiers.map(|m| m.as_ref().into()).collect();
+    for m in &collected {
+        match m.as_str() {
+            "right" => has_right = true,
+            "middle" => has_middle = true,
+            "capture" => option_modifiers.push("capture"),
+            "once" => option_modifiers.push("once"),
+            "passive" => option_modifiers.push("passive"),
+            _ => {}
+        }
+    }
+
+    let mut raw_name = raw;
+    if raw_name == "click" && has_right {
+        raw_name = "contextmenu";
+    } else if raw_name == "click" && has_middle {
+        raw_name = "mouseup";
+    }
+
+    // `vue:mounted` -> `vnode-mounted`
+    let vnode_owned: String;
+    if let Some(rest) = raw_name.strip_prefix("vue:") {
+        let mut s = String::with_capacity(rest.len() + 6);
+        s.push_str("vnode-");
+        s.push_str(rest);
+        vnode_owned = s;
+        raw_name = &vnode_owned;
+    }
+
+    let mut name = if !is_plain_element
+        || raw_name.starts_with("vnode")
+        || !raw_name.chars().any(|c| c.is_ascii_uppercase())
+    {
+        let camelized = camelize(raw_name);
+        let mut n = String::with_capacity(camelized.len() + 2);
+        n.push_str("on");
+        n.push_str(&capitalize_first(&camelized));
+        n
+    } else {
+        let mut n = String::with_capacity(raw_name.len() + 3);
+        n.push_str("on:");
+        n.push_str(raw_name);
+        n
+    };
+
+    for opt in &option_modifiers {
+        name.push_str(&capitalize_first(opt));
+    }
+    name
+}
 
 /// Get the event key for a v-on directive (e.g., "onClick", "onKeyupEnter")
 pub(super) fn get_von_event_key(dir: &DirectiveNode<'_>) -> Option<String> {

--- a/crates/vize_atelier_core/src/codegen/props/generate.rs
+++ b/crates/vize_atelier_core/src/codegen/props/generate.rs
@@ -443,8 +443,12 @@ fn generate_props_object_inner(
                     generate_directive_prop_with_static(
                         ctx,
                         dir,
-                        scan.static_class,
-                        scan.static_style,
+                        super::directives::StaticMerge {
+                            class: scan.static_class,
+                            class_before: scan.static_class_before_dynamic,
+                            style: scan.static_style,
+                            style_before: scan.static_style_before_dynamic,
+                        },
                     );
                 }
             }

--- a/crates/vize_atelier_core/src/codegen/props/generate.rs
+++ b/crates/vize_atelier_core/src/codegen/props/generate.rs
@@ -4,11 +4,11 @@ use crate::ast::{ExpressionNode, PropNode, RuntimeHelper};
 use vize_relief::options::BindingType;
 
 use super::{
+    super::expression::generate_expression,
     super::{
         context::CodegenContext,
         helpers::{escape_js_string, is_valid_js_identifier},
     },
-    super::expression::generate_expression,
     directives::{generate_directive_prop_with_static, is_supported_directive},
     events::{generate_merged_event_handlers, get_von_event_key},
     generate_vbind_object_exp, generate_von_object_exp,
@@ -67,9 +67,7 @@ pub fn generate_props(ctx: &mut CodegenContext, props: &[PropNode<'_>]) {
                     // Does this range hold any renderable non-spread prop?
                     let segment = &props[start..end];
                     let has_renderable = segment.iter().any(|p| match p {
-                        PropNode::Attribute(attr) => {
-                            !(ctx.skip_is_prop && attr.name == "is")
-                        }
+                        PropNode::Attribute(attr) => !(ctx.skip_is_prop && attr.name == "is"),
                         PropNode::Directive(dir) => {
                             !(dir.arg.is_none() && (dir.name == "bind" || dir.name == "on"))
                                 && is_supported_directive(dir)

--- a/crates/vize_atelier_core/src/codegen/props/generate.rs
+++ b/crates/vize_atelier_core/src/codegen/props/generate.rs
@@ -8,6 +8,7 @@ use super::{
         context::CodegenContext,
         helpers::{escape_js_string, is_valid_js_identifier},
     },
+    super::expression::generate_expression,
     directives::{generate_directive_prop_with_static, is_supported_directive},
     events::{generate_merged_event_handlers, get_von_event_key},
     generate_vbind_object_exp, generate_von_object_exp,
@@ -46,37 +47,87 @@ pub fn generate_props(ctx: &mut CodegenContext, props: &[PropNode<'_>]) {
     // Handle cases with object spreads (v-bind="obj" or v-on="obj")
     if scan.has_vbind_obj || scan.has_von_obj {
         if scan.has_other || (scan.has_vbind_obj && scan.has_von_obj) {
-            // Multiple spreads or spread with other props: _mergeProps(...)
+            // Multiple spreads or spread with other props: _mergeProps(...).
+            // Vue walks props in source order, accumulating non-spread props into
+            // object literals and flushing them around each spread, preserving
+            // the original ordering (transforms/transformElement.ts buildProps).
             ctx.use_helper(RuntimeHelper::MergeProps);
             ctx.push(ctx.helper(RuntimeHelper::MergeProps));
             ctx.push("(");
 
             let mut first_merge_arg = true;
+            let mut seg_start = 0usize;
 
-            // Add v-bind object spread
-            if scan.has_vbind_obj {
-                generate_vbind_object_exp(ctx, props);
-                first_merge_arg = false;
-            }
+            // scope_id is emitted once as a trailing object, never per segment.
+            let prev_skip_scope_id = ctx.skip_scope_id;
+            ctx.skip_scope_id = true;
 
-            // Add v-on object spread (wrapped with toHandlers)
-            if scan.has_von_obj {
+            let flush_object =
+                |ctx: &mut CodegenContext, start: usize, end: usize, first: &mut bool| {
+                    // Does this range hold any renderable non-spread prop?
+                    let segment = &props[start..end];
+                    let has_renderable = segment.iter().any(|p| match p {
+                        PropNode::Attribute(attr) => {
+                            !(ctx.skip_is_prop && attr.name == "is")
+                        }
+                        PropNode::Directive(dir) => {
+                            !(dir.arg.is_none() && (dir.name == "bind" || dir.name == "on"))
+                                && is_supported_directive(dir)
+                                && dir.name != "slot"
+                        }
+                    });
+                    if !has_renderable {
+                        return;
+                    }
+                    if !*first {
+                        ctx.push(", ");
+                    }
+                    *first = false;
+                    let seg_scan = PropsScan::new(ctx, segment, ctx.skip_is_prop);
+                    generate_props_object_inner(ctx, segment, true, true, &seg_scan);
+                };
+
+            for (index, prop) in props.iter().enumerate() {
+                let PropNode::Directive(dir) = prop else {
+                    continue;
+                };
+                let is_vbind_spread = dir.name == "bind" && dir.arg.is_none();
+                let is_von_spread = dir.name == "on" && dir.arg.is_none();
+                if !is_vbind_spread && !is_von_spread {
+                    continue;
+                }
+
+                // Flush accumulated non-spread props before this spread.
+                flush_object(ctx, seg_start, index, &mut first_merge_arg);
+                seg_start = index + 1;
+
                 if !first_merge_arg {
                     ctx.push(", ");
                 }
-                generate_von_object_exp(ctx, props);
                 first_merge_arg = false;
+                if is_vbind_spread {
+                    if let Some(exp) = &dir.exp {
+                        generate_expression(ctx, exp);
+                    }
+                } else {
+                    // v-on spread wrapped with _toHandlers(..., true)
+                    ctx.use_helper(RuntimeHelper::ToHandlers);
+                    ctx.push(ctx.helper(RuntimeHelper::ToHandlers));
+                    ctx.push("(");
+                    if let Some(exp) = &dir.exp {
+                        generate_expression(ctx, exp);
+                    }
+                    ctx.push(", true)");
+                }
             }
 
-            // Add other props as object (includes scope_id)
-            // Inside mergeProps, skip normalizeClass/normalizeStyle - mergeProps handles it
-            if scan.has_other {
-                if !first_merge_arg {
-                    ctx.push(", ");
-                }
-                generate_props_object_inner(ctx, props, true, true, &scan);
-            } else if let Some(ref sid) = scope_id {
-                // No other props but we have scope_id, add it as separate object
+            // Flush any trailing non-spread props.
+            flush_object(ctx, seg_start, props.len(), &mut first_merge_arg);
+
+            ctx.skip_scope_id = prev_skip_scope_id;
+
+            // scope_id (if present) is appended as a trailing object.
+            if let Some(ref sid) = scope_id {
                 if !first_merge_arg {
                     ctx.push(", ");
                 }

--- a/crates/vize_atelier_core/src/codegen/props/scan.rs
+++ b/crates/vize_atelier_core/src/codegen/props/scan.rs
@@ -66,6 +66,12 @@ pub(super) struct PropsScan<'props> {
     has_dynamic_vmodel: bool,
     has_dynamic_class: bool,
     has_dynamic_style: bool,
+    /// Whether the static `class` attribute appears before the dynamic `:class`
+    /// binding in source order (controls the merged array order to match Vue).
+    pub(super) static_class_before_dynamic: bool,
+    pub(super) static_style_before_dynamic: bool,
+    static_class_index: Option<usize>,
+    static_style_index: Option<usize>,
     visible_prop_count: usize,
     visible_class_attrs: usize,
     visible_style_attrs: usize,
@@ -90,6 +96,10 @@ impl<'props> PropsScan<'props> {
             has_dynamic_vmodel: false,
             has_dynamic_class: false,
             has_dynamic_style: false,
+            static_class_before_dynamic: false,
+            static_style_before_dynamic: false,
+            static_class_index: None,
+            static_style_index: None,
             visible_prop_count: 0,
             visible_class_attrs: 0,
             visible_style_attrs: 0,
@@ -98,7 +108,7 @@ impl<'props> PropsScan<'props> {
             event_counts: EventNameCounts::default(),
         };
 
-        for prop in props {
+        for (index, prop) in props.iter().enumerate() {
             scan.observe_other_prop(prop);
 
             let visible = !skip_is || !is_is_prop(prop);
@@ -107,6 +117,7 @@ impl<'props> PropsScan<'props> {
                     if attr.name == "class" {
                         if scan.static_class.is_none() {
                             scan.static_class = attr.value.as_ref().map(|v| v.content.as_str());
+                            scan.static_class_index = Some(index);
                         }
                         if visible {
                             scan.visible_class_attrs += 1;
@@ -114,6 +125,7 @@ impl<'props> PropsScan<'props> {
                     } else if attr.name == "style" {
                         if scan.static_style.is_none() {
                             scan.static_style = attr.value.as_ref().map(|v| v.content.as_str());
+                            scan.static_style_index = Some(index);
                         }
                         if visible {
                             scan.visible_style_attrs += 1;
@@ -125,6 +137,22 @@ impl<'props> PropsScan<'props> {
                     }
                 }
                 PropNode::Directive(dir) => {
+                    // Record source ordering of the first dynamic :class/:style
+                    // relative to the static class/style attribute.
+                    if let Some(ExpressionNode::Simple(exp)) = &dir.arg
+                        && dir.name == "bind"
+                        && exp.is_static
+                    {
+                        if exp.content == "class" && !scan.has_dynamic_class {
+                            scan.static_class_before_dynamic = scan
+                                .static_class_index
+                                .is_some_and(|i| i < index);
+                        } else if exp.content == "style" && !scan.has_dynamic_style {
+                            scan.static_style_before_dynamic = scan
+                                .static_style_index
+                                .is_some_and(|i| i < index);
+                        }
+                    }
                     scan.observe_directive(ctx, dir);
                     if visible && is_supported_directive(dir) {
                         scan.visible_prop_count += 1;

--- a/crates/vize_atelier_core/src/codegen/props/scan.rs
+++ b/crates/vize_atelier_core/src/codegen/props/scan.rs
@@ -144,13 +144,11 @@ impl<'props> PropsScan<'props> {
                         && exp.is_static
                     {
                         if exp.content == "class" && !scan.has_dynamic_class {
-                            scan.static_class_before_dynamic = scan
-                                .static_class_index
-                                .is_some_and(|i| i < index);
+                            scan.static_class_before_dynamic =
+                                scan.static_class_index.is_some_and(|i| i < index);
                         } else if exp.content == "style" && !scan.has_dynamic_style {
-                            scan.static_style_before_dynamic = scan
-                                .static_style_index
-                                .is_some_and(|i| i < index);
+                            scan.static_style_before_dynamic =
+                                scan.static_style_index.is_some_and(|i| i < index);
                         }
                     }
                     scan.observe_directive(ctx, dir);

--- a/crates/vize_atelier_core/src/codegen/slots.rs
+++ b/crates/vize_atelier_core/src/codegen/slots.rs
@@ -200,29 +200,7 @@ pub(crate) fn has_slot_outlet_props(el: &ElementNode<'_>) -> bool {
 }
 
 pub(crate) fn generate_slot_outlet_props_entries(ctx: &mut CodegenContext, el: &ElementNode<'_>) {
-    let static_class = el.props.iter().find_map(|prop| {
-        if is_slot_name_prop(prop) {
-            return None;
-        }
-        if let PropNode::Attribute(attr) = prop
-            && attr.name.as_str() == "class"
-        {
-            return attr.value.as_ref().map(|v| v.content.as_str());
-        }
-        None
-    });
-
-    let static_style = el.props.iter().find_map(|prop| {
-        if is_slot_name_prop(prop) {
-            return None;
-        }
-        if let PropNode::Attribute(attr) = prop
-            && attr.name.as_str() == "style"
-        {
-            return attr.value.as_ref().map(|v| v.content.as_str());
-        }
-        None
-    });
+    let static_merge = crate::codegen::props::StaticMerge::from_props(&el.props);
 
     let has_dynamic_class = el.props.iter().any(|prop| match prop {
         PropNode::Directive(dir) if !is_slot_name_bind(dir) && dir.name.as_str() == "bind" => {
@@ -292,7 +270,7 @@ pub(crate) fn generate_slot_outlet_props_entries(ctx: &mut CodegenContext, el: &
                 if !first {
                     ctx.push(", ");
                 }
-                generate_directive_prop_with_static(ctx, dir, static_class, static_style);
+                generate_directive_prop_with_static(ctx, dir, static_merge);
                 first = false;
             }
         }

--- a/crates/vize_atelier_core/src/codegen/v_for.rs
+++ b/crates/vize_atelier_core/src/codegen/v_for.rs
@@ -155,20 +155,20 @@ fn generate_for_inner(
         ctx.push(")");
         ctx.newline();
 
-        // if (_cached && _cached.key === key && _isMemoSame(_cached, _memo)) return _cached
+        // if (_cached && _cached.el && [_cached.key === key &&] _isMemoSame(_cached, _memo)) return _cached
         ctx.use_helper(RuntimeHelper::IsMemoSame);
         let key_exp = if let TemplateChildNode::Element(el) = &for_node.children[0] {
             get_element_key(el)
         } else {
             None
         };
-        ctx.push("if (_cached && _cached.key === ");
+        ctx.push("if (_cached && _cached.el && ");
+        // The key comparison is only emitted when the item has an explicit key.
         if let Some(key) = key_exp {
+            ctx.push("_cached.key === ");
             generate_expression(ctx, key);
-        } else {
-            ctx.push("undefined");
+            ctx.push(" && ");
         }
-        ctx.push(" && ");
         ctx.push(ctx.helper(RuntimeHelper::IsMemoSame));
         ctx.push("(_cached, _memo)) return _cached");
         ctx.newline();

--- a/crates/vize_atelier_core/src/codegen/v_for/generate.rs
+++ b/crates/vize_atelier_core/src/codegen/v_for/generate.rs
@@ -540,15 +540,14 @@ pub(crate) fn generate_for_item_props(
     let skip_static_class = static_class.is_some() && has_dynamic_class;
     let skip_static_style = static_style.is_some() && has_dynamic_style;
 
-    let merge_static_class = if skip_static_class {
-        static_class
-    } else {
-        None
-    };
-    let merge_static_style = if skip_static_style {
-        static_style
-    } else {
-        None
+    // Static class/style are only merged into the dynamic binding's array when a
+    // dynamic counterpart exists; source ordering is preserved via StaticMerge.
+    let full_merge = super::super::props::StaticMerge::from_props(&el.props);
+    let merge_static = super::super::props::StaticMerge {
+        class: if skip_static_class { full_merge.class } else { None },
+        class_before: full_merge.class_before,
+        style: if skip_static_style { full_merge.style } else { None },
+        style_before: full_merge.style_before,
     };
 
     if let Some(key) = key_exp {
@@ -577,7 +576,7 @@ pub(crate) fn generate_for_item_props(
             }
             ctx.push(",");
             ctx.newline();
-            generate_single_prop(ctx, prop, merge_static_class, merge_static_style);
+            generate_single_prop(ctx, prop, merge_static);
         }
 
         if let Some(sid) = scope_id {
@@ -615,7 +614,7 @@ pub(crate) fn generate_for_item_props(
                 ctx.push(",");
             }
             ctx.push(" ");
-            generate_single_prop(ctx, prop, merge_static_class, merge_static_style);
+            generate_single_prop(ctx, prop, merge_static);
             first = false;
         }
 
@@ -705,7 +704,7 @@ fn generate_for_item_props_merged(
                 ctx.push(",");
             }
             ctx.newline();
-            generate_single_prop(ctx, prop, None, None);
+            generate_single_prop(ctx, prop, super::super::props::StaticMerge::default());
             first_prop = false;
         }
 
@@ -731,8 +730,7 @@ fn generate_for_item_props_merged(
 fn generate_single_prop(
     ctx: &mut CodegenContext,
     prop: &PropNode<'_>,
-    static_class: Option<&str>,
-    static_style: Option<&str>,
+    static_merge: super::super::props::StaticMerge<'_>,
 ) {
     match prop {
         PropNode::Attribute(attr) => {
@@ -754,12 +752,7 @@ fn generate_single_prop(
             }
         }
         PropNode::Directive(dir) => {
-            super::super::props::generate_directive_prop_with_static(
-                ctx,
-                dir,
-                static_class,
-                static_style,
-            );
+            super::super::props::generate_directive_prop_with_static(ctx, dir, static_merge);
         }
     }
 }

--- a/crates/vize_atelier_core/src/codegen/v_for/generate.rs
+++ b/crates/vize_atelier_core/src/codegen/v_for/generate.rs
@@ -544,9 +544,17 @@ pub(crate) fn generate_for_item_props(
     // dynamic counterpart exists; source ordering is preserved via StaticMerge.
     let full_merge = super::super::props::StaticMerge::from_props(&el.props);
     let merge_static = super::super::props::StaticMerge {
-        class: if skip_static_class { full_merge.class } else { None },
+        class: if skip_static_class {
+            full_merge.class
+        } else {
+            None
+        },
         class_before: full_merge.class_before,
-        style: if skip_static_style { full_merge.style } else { None },
+        style: if skip_static_style {
+            full_merge.style
+        } else {
+            None
+        },
         style_before: full_merge.style_before,
     };
 

--- a/crates/vize_atelier_core/src/codegen/v_if/branch.rs
+++ b/crates/vize_atelier_core/src/codegen/v_if/branch.rs
@@ -243,7 +243,7 @@ fn generate_if_branch_component(
     let has_patch_info = patch_flag.is_some() || dynamic_props.is_some();
 
     // Extract static class/style for merging with dynamic bindings
-    let (static_class, static_style) = extract_static_class_style(el);
+    let static_merge = extract_static_class_style(el);
     let has_dyn_class = has_dynamic_class(el);
     let has_dyn_style = has_dynamic_style(el);
 
@@ -299,8 +299,7 @@ fn generate_if_branch_component(
             el,
             branch,
             branch_index,
-            static_class,
-            static_style,
+            static_merge,
             has_dyn_class,
             has_dyn_style,
         );
@@ -312,8 +311,7 @@ fn generate_if_branch_component(
             el,
             branch,
             branch_index,
-            static_class,
-            static_style,
+            static_merge,
             has_dyn_class,
             has_dyn_style,
         );
@@ -420,7 +418,7 @@ fn generate_if_branch_element(
     ctx.push("\"");
 
     // Extract static class/style for merging with dynamic bindings
-    let (static_class, static_style) = extract_static_class_style(el);
+    let static_merge = extract_static_class_style(el);
     let has_dyn_class = has_dynamic_class(el);
     let has_dyn_style = has_dynamic_style(el);
 
@@ -476,8 +474,7 @@ fn generate_if_branch_element(
             el,
             branch,
             branch_index,
-            static_class,
-            static_style,
+            static_merge,
             has_dyn_class,
             has_dyn_style,
         );
@@ -489,8 +486,7 @@ fn generate_if_branch_element(
             el,
             branch,
             branch_index,
-            static_class,
-            static_style,
+            static_merge,
             has_dyn_class,
             has_dyn_style,
         );

--- a/crates/vize_atelier_core/src/codegen/v_if/generate.rs
+++ b/crates/vize_atelier_core/src/codegen/v_if/generate.rs
@@ -8,7 +8,7 @@ use crate::ast::{DirectiveNode, ElementNode, ExpressionNode, IfBranchNode, PropN
 use super::super::{
     context::CodegenContext,
     helpers::{camelize, capitalize_first, escape_js_string, is_valid_js_identifier},
-    props::{generate_directive_prop_with_static, is_supported_directive},
+    props::{StaticMerge, generate_directive_prop_with_static, is_supported_directive},
 };
 use super::generate_if_branch_key;
 use vize_carton::FxHashSet;
@@ -49,26 +49,9 @@ pub(super) fn should_skip_prop_for_if(
     }
 }
 
-/// Extract static class and style values from element props.
-pub(super) fn extract_static_class_style<'a>(
-    el: &'a ElementNode<'_>,
-) -> (Option<&'a str>, Option<&'a str>) {
-    let mut static_class = None;
-    let mut static_style = None;
-    for prop in el.props.iter() {
-        if let PropNode::Attribute(attr) = prop {
-            if attr.name == "class" {
-                if let Some(val) = &attr.value {
-                    static_class = Some(val.content.as_str());
-                }
-            } else if attr.name == "style"
-                && let Some(val) = &attr.value
-            {
-                static_style = Some(val.content.as_str());
-            }
-        }
-    }
-    (static_class, static_style)
+/// Extract static class/style values and their source ordering from props.
+pub(super) fn extract_static_class_style<'a>(el: &'a ElementNode<'_>) -> StaticMerge<'a> {
+    StaticMerge::from_props(&el.props)
 }
 
 /// Check if element has dynamic `:class` binding.
@@ -101,8 +84,7 @@ pub(super) fn has_dynamic_style(el: &ElementNode<'_>) -> bool {
 pub(super) fn generate_single_prop_for_if(
     ctx: &mut CodegenContext,
     prop: &PropNode<'_>,
-    static_class: Option<&str>,
-    static_style: Option<&str>,
+    static_merge: StaticMerge<'_>,
 ) {
     match prop {
         PropNode::Attribute(attr) => {
@@ -157,7 +139,7 @@ pub(super) fn generate_single_prop_for_if(
             }
         }
         PropNode::Directive(dir) => {
-            generate_directive_prop_with_static(ctx, dir, static_class, static_style);
+            generate_directive_prop_with_static(ctx, dir, static_merge);
         }
     }
 }
@@ -169,8 +151,7 @@ pub(super) fn generate_if_branch_props_object(
     el: &ElementNode<'_>,
     branch: &IfBranchNode<'_>,
     branch_index: usize,
-    static_class: Option<&str>,
-    static_style: Option<&str>,
+    static_merge: StaticMerge<'_>,
     has_dynamic_class: bool,
     has_dynamic_style: bool,
 ) {
@@ -236,7 +217,7 @@ pub(super) fn generate_if_branch_props_object(
         }
         ctx.push(",");
         ctx.newline();
-        generate_single_prop_for_if(ctx, prop, static_class, static_style);
+        generate_single_prop_for_if(ctx, prop, static_merge);
     }
 
     // Add scope_id for scoped CSS

--- a/crates/vize_atelier_core/src/transforms/transform_expression/inline_handler.rs
+++ b/crates/vize_atelier_core/src/transforms/transform_expression/inline_handler.rs
@@ -144,13 +144,14 @@ pub fn process_inline_handler<'a>(
     } else {
         content.clone()
     };
-    // Use block body { ... } for multi-statement handlers (semicolons),
-    // concise body ( ... ) for single expressions
+    // Use block body {...} for multi-statement handlers (semicolons),
+    // concise body ( ... ) for single expressions. Vue emits the block body
+    // with no surrounding spaces (`$event => {...}`).
     let new_content = if rewritten.contains(';') {
-        let mut s = String::with_capacity(14 + rewritten.len() + 2);
-        s.push_str("$event => { ");
+        let mut s = String::with_capacity(12 + rewritten.len() + 1);
+        s.push_str("$event => {");
         s.push_str(&rewritten);
-        s.push_str(" }");
+        s.push('}');
         s
     } else {
         let mut s = String::with_capacity(12 + rewritten.len() + 1);

--- a/crates/vize_atelier_dom/src/snapshots/vize_atelier_dom__tests__event_handler_setup_ref_value.snap
+++ b/crates/vize_atelier_dom/src/snapshots/vize_atelier_dom__tests__event_handler_setup_ref_value.snap
@@ -1,11 +1,12 @@
 ---
 source: crates/vize_atelier_dom/src/lib.rs
+assertion_line: 272
 expression: full.as_str()
 ---
 import { openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 
 export function render(_ctx, _cache, $props, $setup, $data, $options) {
   return (_openBlock(), _createElementBlock("button", {
-    onClick: _cache[0] || (_cache[0] = $event => { quoteId.value = null; renoteTargetNote.value = null; })
+    onClick: _cache[0] || (_cache[0] = $event => {quoteId.value = null; renoteTargetNote.value = null;})
   }, "x"))
 }

--- a/crates/vize_atelier_sfc/src/compile/snapshots/vize_atelier_sfc__compile__tests__multi_statement_event_handler.snap
+++ b/crates/vize_atelier_sfc/src/compile/snapshots/vize_atelier_sfc__compile__tests__multi_statement_event_handler.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/vize_atelier_sfc/src/compile/tests.rs
+assertion_line: 614
 expression: result.code.as_str()
 ---
 import { defineComponent as _defineComponent } from 'vue'
@@ -14,10 +15,10 @@ const editDashboard = ref()
 
 return (_ctx: any,_cache: any) => {
   return (_openBlock(), _createElementBlock("div", {
-      onClick: _cache[0] || (_cache[0] = ($event: any) => { 
+      onClick: _cache[0] || (_cache[0] = ($event: any) => {
       editDashboard.value = 'test';
       console.log('done');
-     })
+    })
     }))
 }
 }

--- a/crates/vize_atelier_sfc/src/compile_script/inline/compiler/body.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/inline/compiler/body.rs
@@ -162,7 +162,7 @@ pub(super) fn compile_script_setup_inline_body(
         let mut code = output_str;
         if is_ts {
             code = code.replace("$event => (", "($event: any) => (");
-            code = code.replace("$event => { ", "($event: any) => { ");
+            code = code.replace("$event => {", "($event: any) => {");
         }
         code.into()
     } else {

--- a/tests/expected/vdom/component.snap
+++ b/tests/expected/vdom/component.snap
@@ -77,9 +77,9 @@ options: vdom
 import { resolveComponent as _resolveComponent, openBlock as _openBlock, createBlock as _createBlock } from "vue"
 
 export function render(_ctx, _cache) {
-  const _component_global_head = _resolveComponent("global:head")
+  const _component_global58head = _resolveComponent("global:head")
 
-  return (_openBlock(), _createBlock(_component_global_head, { title: "Page Title" }))
+  return (_openBlock(), _createBlock(_component_global58head, { title: "Page Title" }))
 }
 ===
 name: static prop
@@ -617,4 +617,43 @@ export function render(_ctx, _cache) {
   const _component_MyComponent = _resolveComponent("MyComponent")
 
   return (_openBlock(), _createBlock(_component_MyComponent, { onUpdateOnce: _ctx.onUpdate }, null, 8 /* PROPS */, ["onUpdateOnce"]))
+}
+===
+name: component static class before v-bind spread
+options: vdom
+--- INPUT ---
+<Foo class="a" v-bind="obj" />
+--- OUTPUT ---
+import { resolveComponent as _resolveComponent, mergeProps as _mergeProps, openBlock as _openBlock, createBlock as _createBlock } from "vue"
+
+export function render(_ctx, _cache) {
+  const _component_Foo = _resolveComponent("Foo")
+
+  return (_openBlock(), _createBlock(_component_Foo, _mergeProps({ class: "a" }, _ctx.obj), null, 16 /* FULL_PROPS */))
+}
+===
+name: component static and dynamic around v-bind spread
+options: vdom
+--- INPUT ---
+<Foo id="x" v-bind="a" :title="t" />
+--- OUTPUT ---
+import { resolveComponent as _resolveComponent, mergeProps as _mergeProps, openBlock as _openBlock, createBlock as _createBlock } from "vue"
+
+export function render(_ctx, _cache) {
+  const _component_Foo = _resolveComponent("Foo")
+
+  return (_openBlock(), _createBlock(_component_Foo, _mergeProps({ id: "x" }, _ctx.a, { title: _ctx.t }), null, 16 /* FULL_PROPS */, ["title"]))
+}
+===
+name: component handler before v-bind spread
+options: vdom
+--- INPUT ---
+<Foo @click="fn" v-bind="props" />
+--- OUTPUT ---
+import { resolveComponent as _resolveComponent, mergeProps as _mergeProps, openBlock as _openBlock, createBlock as _createBlock } from "vue"
+
+export function render(_ctx, _cache) {
+  const _component_Foo = _resolveComponent("Foo")
+
+  return (_openBlock(), _createBlock(_component_Foo, _mergeProps({ onClick: _ctx.fn }, _ctx.props), null, 16 /* FULL_PROPS */, ["onClick"]))
 }

--- a/tests/expected/vdom/element.snap
+++ b/tests/expected/vdom/element.snap
@@ -492,3 +492,47 @@ export function render(_ctx, _cache) {
     _createElementVNode("span", null, "two")
   ], 64 /* STABLE_FRAGMENT */))
 }
+===
+name: single element with trailing root comment
+options: vdom
+--- INPUT ---
+<div></div><!-- trailing -->
+--- OUTPUT ---
+import { createElementVNode as _createElementVNode, createCommentVNode as _createCommentVNode, Fragment as _Fragment, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+export function render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock(_Fragment, null, [
+    _createElementVNode("div"),
+    _createCommentVNode(" trailing ")
+  ], 2112 /* STABLE_FRAGMENT, DEV_ROOT_FRAGMENT */))
+}
+===
+name: single element with leading and trailing root comments
+options: vdom
+--- INPUT ---
+<!-- lead --><div>x</div><!-- trail -->
+--- OUTPUT ---
+import { createCommentVNode as _createCommentVNode, createElementVNode as _createElementVNode, Fragment as _Fragment, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+export function render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock(_Fragment, null, [
+    _createCommentVNode(" lead "),
+    _createElementVNode("div", null, "x"),
+    _createCommentVNode(" trail ")
+  ], 2112 /* STABLE_FRAGMENT, DEV_ROOT_FRAGMENT */))
+}
+===
+name: two elements with root comment is stable fragment
+options: vdom
+--- INPUT ---
+<div>a</div><!-- c --><div>b</div>
+--- OUTPUT ---
+import { createElementVNode as _createElementVNode, createCommentVNode as _createCommentVNode, Fragment as _Fragment, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+export function render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock(_Fragment, null, [
+    _createElementVNode("div", null, "a"),
+    _createCommentVNode(" c "),
+    _createElementVNode("div", null, "b")
+  ], 64 /* STABLE_FRAGMENT */))
+}

--- a/tests/expected/vdom/v-bind.snap
+++ b/tests/expected/vdom/v-bind.snap
@@ -498,3 +498,69 @@ import { normalizeProps as _normalizeProps, openBlock as _openBlock, createEleme
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("div", _normalizeProps({ [_ctx.key || ""]: _ctx.val }), null, 16 /* FULL_PROPS */))
 }
+===
+name: dynamic class before static class
+options: vdom
+--- INPUT ---
+<div :class="a" class="b"></div>
+--- OUTPUT ---
+import { normalizeClass as _normalizeClass, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+export function render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("div", {
+    class: _normalizeClass([_ctx.a, "b"])
+  }, null, 2 /* CLASS */))
+}
+===
+name: static class before dynamic class
+options: vdom
+--- INPUT ---
+<div class="b" :class="a"></div>
+--- OUTPUT ---
+import { normalizeClass as _normalizeClass, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+export function render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("div", {
+    class: _normalizeClass(["b", _ctx.a])
+  }, null, 2 /* CLASS */))
+}
+===
+name: dynamic style before static style
+options: vdom
+--- INPUT ---
+<div :style="s" style="color:red"></div>
+--- OUTPUT ---
+import { normalizeStyle as _normalizeStyle, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+export function render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("div", {
+    style: _normalizeStyle([_ctx.s, {"color":"red"}])
+  }, null, 4 /* STYLE */))
+}
+===
+name: static style before dynamic style
+options: vdom
+--- INPUT ---
+<div style="color:red" :style="s"></div>
+--- OUTPUT ---
+import { normalizeStyle as _normalizeStyle, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+export function render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("div", {
+    style: _normalizeStyle([{"color":"red"}, _ctx.s])
+  }, null, 4 /* STYLE */))
+}
+===
+name: mixed class and style merge order
+options: vdom
+--- INPUT ---
+<div class="b" :class="a" :style="s" style="x:1"></div>
+--- OUTPUT ---
+import { normalizeClass as _normalizeClass, normalizeStyle as _normalizeStyle, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+export function render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("div", {
+    class: _normalizeClass(["b", _ctx.a]),
+    style: _normalizeStyle([_ctx.s, {"x":"1"}])
+  }, null, 6 /* CLASS, STYLE */))
+}

--- a/tests/expected/vdom/v-bind.snap
+++ b/tests/expected/vdom/v-bind.snap
@@ -432,3 +432,69 @@ import { openBlock as _openBlock, createElementBlock as _createElementBlock } fr
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("input", { readonly: _ctx.isReadonly }, null, 8 /* PROPS */, ["readonly"]))
 }
+===
+name: dot-prop shorthand
+options: vdom
+--- INPUT ---
+<div .foo="val"></div>
+--- OUTPUT ---
+import { openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+export function render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("div", { ".foo": _ctx.val }, null, 40 /* PROPS, NEED_HYDRATION */, [".foo"]))
+}
+===
+name: dot-prop shorthand with valid identifier key
+options: vdom
+--- INPUT ---
+<div .fooBar="val"></div>
+--- OUTPUT ---
+import { openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+export function render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("div", { ".fooBar": _ctx.val }, null, 40 /* PROPS, NEED_HYDRATION */, [".fooBar"]))
+}
+===
+name: v-bind dynamic arg with .prop
+options: vdom
+--- INPUT ---
+<div :[key].prop="val"></div>
+--- OUTPUT ---
+import { normalizeProps as _normalizeProps, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+export function render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("div", _normalizeProps({ [`.${_ctx.key || ""}`]: _ctx.val }), null, 48 /* FULL_PROPS, NEED_HYDRATION */))
+}
+===
+name: v-bind dynamic arg with .camel
+options: vdom
+--- INPUT ---
+<div :[key].camel="val"></div>
+--- OUTPUT ---
+import { camelize as _camelize, normalizeProps as _normalizeProps, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+export function render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("div", _normalizeProps({ [_camelize(_ctx.key || "")]: _ctx.val }), null, 16 /* FULL_PROPS */))
+}
+===
+name: v-bind dynamic arg with .attr
+options: vdom
+--- INPUT ---
+<div :[key].attr="val"></div>
+--- OUTPUT ---
+import { normalizeProps as _normalizeProps, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+export function render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("div", _normalizeProps({ [`^${_ctx.key || ""}`]: _ctx.val }), null, 16 /* FULL_PROPS */))
+}
+===
+name: v-bind dynamic arg plain
+options: vdom
+--- INPUT ---
+<div :[key]="val"></div>
+--- OUTPUT ---
+import { normalizeProps as _normalizeProps, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+export function render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("div", _normalizeProps({ [_ctx.key || ""]: _ctx.val }), null, 16 /* FULL_PROPS */))
+}

--- a/tests/expected/vdom/v-bind.snap
+++ b/tests/expected/vdom/v-bind.snap
@@ -564,3 +564,72 @@ export function render(_ctx, _cache) {
     style: _normalizeStyle([_ctx.s, {"x":"1"}])
   }, null, 6 /* CLASS, STYLE */))
 }
+===
+name: static class after v-bind spread
+options: vdom
+--- INPUT ---
+<div v-bind="obj" class="a"></div>
+--- OUTPUT ---
+import { mergeProps as _mergeProps, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+export function render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("div", _mergeProps(_ctx.obj, { class: "a" }), null, 16 /* FULL_PROPS */))
+}
+===
+name: static class before v-bind spread
+options: vdom
+--- INPUT ---
+<div class="a" v-bind="obj"></div>
+--- OUTPUT ---
+import { mergeProps as _mergeProps, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+export function render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("div", _mergeProps({ class: "a" }, _ctx.obj), null, 16 /* FULL_PROPS */))
+}
+===
+name: static and dynamic props around v-bind spread
+options: vdom
+--- INPUT ---
+<div id="x" v-bind="obj" :title="t"></div>
+--- OUTPUT ---
+import { mergeProps as _mergeProps, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+export function render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("div", _mergeProps({ id: "x" }, _ctx.obj, { title: _ctx.t }), null, 16 /* FULL_PROPS */, ["title"]))
+}
+===
+name: static props before and after v-bind spread
+options: vdom
+--- INPUT ---
+<div id="x" :title="t" v-bind="obj"></div>
+--- OUTPUT ---
+import { mergeProps as _mergeProps, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+export function render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("div", _mergeProps({
+    id: "x",
+    title: _ctx.t
+  }, _ctx.obj), null, 16 /* FULL_PROPS */, ["title"]))
+}
+===
+name: v-on spread before handler
+options: vdom
+--- INPUT ---
+<div v-on="handlers" @click="fn"></div>
+--- OUTPUT ---
+import { toHandlers as _toHandlers, mergeProps as _mergeProps, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+export function render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("div", _mergeProps(_toHandlers(_ctx.handlers, true), { onClick: _ctx.fn }), null, 16 /* FULL_PROPS */, ["onClick"]))
+}
+===
+name: handler before v-on spread
+options: vdom
+--- INPUT ---
+<div @click="fn" v-on="handlers"></div>
+--- OUTPUT ---
+import { toHandlers as _toHandlers, mergeProps as _mergeProps, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+export function render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("div", _mergeProps({ onClick: _ctx.fn }, _toHandlers(_ctx.handlers, true)), null, 16 /* FULL_PROPS */, ["onClick"]))
+}

--- a/tests/expected/vdom/v-on.snap
+++ b/tests/expected/vdom/v-on.snap
@@ -603,3 +603,150 @@ export function render(_ctx, _cache) {
     onMouseenter: _cache[1] || (_cache[1] = $event => (_ctx.hover = true))
   }, null, 32 /* NEED_HYDRATION */))
 }
+===
+name: vue: vnode lifecycle hook
+options: vdom
+--- INPUT ---
+<div @vue:mounted="fn"></div>
+--- OUTPUT ---
+import { openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+export function render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("div", { onVnodeMounted: _ctx.fn }, null, 8 /* PROPS */, ["onVnodeMounted"]))
+}
+===
+name: vue: vnode hook kebab
+options: vdom
+--- INPUT ---
+<div @vue:before-update="fn"></div>
+--- OUTPUT ---
+import { openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+export function render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("div", { onVnodeBeforeUpdate: _ctx.fn }, null, 8 /* PROPS */, ["onVnodeBeforeUpdate"]))
+}
+===
+name: vue: vnode hook on component
+options: vdom
+--- INPUT ---
+<MyComp @vue:updated="fn" />
+--- OUTPUT ---
+import { resolveComponent as _resolveComponent, openBlock as _openBlock, createBlock as _createBlock } from "vue"
+
+export function render(_ctx, _cache) {
+  const _component_MyComp = _resolveComponent("MyComp")
+
+  return (_openBlock(), _createBlock(_component_MyComp, { onVnodeUpdated: _ctx.fn }, null, 8 /* PROPS */, ["onVnodeUpdated"]))
+}
+===
+name: camelCase event on plain element preserves case
+options: vdom
+--- INPUT ---
+<div @fooBar="fn"></div>
+--- OUTPUT ---
+import { openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+export function render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("div", { "on:fooBar": _ctx.fn }, null, 40 /* PROPS, NEED_HYDRATION */, ["on:fooBar"]))
+}
+===
+name: PascalCase event on plain element preserves case
+options: vdom
+--- INPUT ---
+<div @FooBar="fn"></div>
+--- OUTPUT ---
+import { openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+export function render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("div", { "on:FooBar": _ctx.fn }, null, 40 /* PROPS, NEED_HYDRATION */, ["on:FooBar"]))
+}
+===
+name: kebab event on plain element camelizes
+options: vdom
+--- INPUT ---
+<div @foo-bar="fn"></div>
+--- OUTPUT ---
+import { openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+export function render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("div", { onFooBar: _ctx.fn }, null, 40 /* PROPS, NEED_HYDRATION */, ["onFooBar"]))
+}
+===
+name: camelCase event on component camelizes
+options: vdom
+--- INPUT ---
+<MyComp @fooBar="fn" />
+--- OUTPUT ---
+import { resolveComponent as _resolveComponent, openBlock as _openBlock, createBlock as _createBlock } from "vue"
+
+export function render(_ctx, _cache) {
+  const _component_MyComp = _resolveComponent("MyComp")
+
+  return (_openBlock(), _createBlock(_component_MyComp, { onFooBar: _ctx.fn }, null, 8 /* PROPS */, ["onFooBar"]))
+}
+===
+name: colon event with uppercase on element
+options: vdom
+--- INPUT ---
+<div @update:modelValue="fn"></div>
+--- OUTPUT ---
+import { openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+export function render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("div", { "on:update:modelValue": _ctx.fn }, null, 40 /* PROPS, NEED_HYDRATION */, ["on:update:modelValue"]))
+}
+===
+name: colon event lowercase on element
+options: vdom
+--- INPUT ---
+<div @update:foo="fn"></div>
+--- OUTPUT ---
+import { openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+export function render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("div", { "onUpdate:foo": _ctx.fn }, null, 40 /* PROPS, NEED_HYDRATION */, ["onUpdate:foo"]))
+}
+===
+name: camelCase event with option modifier
+options: vdom
+--- INPUT ---
+<div @fooBar.once="fn"></div>
+--- OUTPUT ---
+import { openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+export function render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("div", { "on:fooBarOnce": _ctx.fn }, null, 40 /* PROPS, NEED_HYDRATION */, ["on:fooBarOnce"]))
+}
+===
+name: dblclick needs hydration
+options: vdom
+--- INPUT ---
+<div @dblclick="fn"></div>
+--- OUTPUT ---
+import { openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+export function render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("div", { onDblclick: _ctx.fn }, null, 40 /* PROPS, NEED_HYDRATION */, ["onDblclick"]))
+}
+===
+name: click no hydration
+options: vdom
+--- INPUT ---
+<div @click="fn"></div>
+--- OUTPUT ---
+import { openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+export function render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("div", { onClick: _ctx.fn }, null, 8 /* PROPS */, ["onClick"]))
+}
+===
+name: mouseover needs hydration
+options: vdom
+--- INPUT ---
+<div @mouseover="fn"></div>
+--- OUTPUT ---
+import { openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+export function render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("div", { onMouseover: _ctx.fn }, null, 40 /* PROPS, NEED_HYDRATION */, ["onMouseover"]))
+}

--- a/tests/expected/vdom/v-on.snap
+++ b/tests/expected/vdom/v-on.snap
@@ -750,3 +750,29 @@ import { openBlock as _openBlock, createElementBlock as _createElementBlock } fr
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("div", { onMouseover: _ctx.fn }, null, 40 /* PROPS, NEED_HYDRATION */, ["onMouseover"]))
 }
+===
+name: inline multi-statement handler
+options: vdom
+--- INPUT ---
+<a @click="foo();bar()"></a>
+--- OUTPUT ---
+import { openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+export function render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("a", {
+    onClick: $event => {_ctx.foo();_ctx.bar()}
+  }, null, 8 /* PROPS */, ["onClick"]))
+}
+===
+name: inline single-statement handler
+options: vdom
+--- INPUT ---
+<a @click="foo()"></a>
+--- OUTPUT ---
+import { openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+export function render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("a", {
+    onClick: $event => (_ctx.foo())
+  }, null, 8 /* PROPS */, ["onClick"]))
+}

--- a/tests/expected/vdom/v-once.snap
+++ b/tests/expected/vdom/v-once.snap
@@ -198,7 +198,7 @@ import { renderList as _renderList, Fragment as _Fragment, openBlock as _openBlo
 export function render(_ctx, _cache) {
   return (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(_ctx.items, (item, __, ___, _cached) => {
     const _memo = ([item.selected])
-    if (_cached && _cached.key === item.id && _isMemoSame(_cached, _memo)) return _cached
+    if (_cached && _cached.el && _cached.key === item.id && _isMemoSame(_cached, _memo)) return _cached
     const _item = (_openBlock(), _createElementBlock("div", {
       key: item.id
     }, [
@@ -219,7 +219,7 @@ import { renderList as _renderList, Fragment as _Fragment, openBlock as _openBlo
 export function render(_ctx, _cache) {
   return (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(_ctx.items, (item, __, ___, _cached) => {
     const _memo = ([item.id === _ctx.selected])
-    if (_cached && _cached.key === item.id && _isMemoSame(_cached, _memo)) return _cached
+    if (_cached && _cached.el && _cached.key === item.id && _isMemoSame(_cached, _memo)) return _cached
     const _item = (_openBlock(), _createElementBlock("div", {
       key: item.id
     }, [
@@ -255,4 +255,23 @@ export function render(_ctx, _cache) {
     _createElementVNode("div", null, "A"),
     _createElementVNode("div", null, "B")
   ])), _cache, 0)
+}
+===
+name: v-memo in v-for without key
+options: vdom
+--- INPUT ---
+<li v-for="item in items" v-memo="[item.id]">{{ item }}</li>
+--- OUTPUT ---
+import { renderList as _renderList, Fragment as _Fragment, openBlock as _openBlock, createElementBlock as _createElementBlock, toDisplayString as _toDisplayString, createTextVNode as _createTextVNode, isMemoSame as _isMemoSame, withMemo as _withMemo } from "vue"
+
+export function render(_ctx, _cache) {
+  return (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(_ctx.items, (item, __, ___, _cached) => {
+    const _memo = ([item.id])
+    if (_cached && _cached.el && _isMemoSame(_cached, _memo)) return _cached
+    const _item = (_openBlock(), _createElementBlock("li", null, [
+      _createTextVNode(_toDisplayString(item), 1 /* TEXT */)
+    ]))
+    _item.memo = _memo
+    return _item
+  }, _cache, 0), 256 /* UNKEYED_FRAGMENT */))
 }

--- a/tests/fixtures/vdom/component.toml
+++ b/tests/fixtures/vdom/component.toml
@@ -201,3 +201,15 @@ input = '<MyComponent @update="onUpdate" @change="onChange" />'
 [[cases]]
 name = "component event modifiers"
 input = '<MyComponent @update.once="onUpdate" />'
+
+[[cases]]
+name = "component static class before v-bind spread"
+input = '<Foo class="a" v-bind="obj" />'
+
+[[cases]]
+name = "component static and dynamic around v-bind spread"
+input = '<Foo id="x" v-bind="a" :title="t" />'
+
+[[cases]]
+name = "component handler before v-bind spread"
+input = '<Foo @click="fn" v-bind="props" />'

--- a/tests/fixtures/vdom/element.toml
+++ b/tests/fixtures/vdom/element.toml
@@ -193,3 +193,15 @@ input = "<div><span></span><!-- between --><p></p></div>"
 [[cases]]
 name = "root comment between elements"
 input = "<span>one</span><!-- between --><span>two</span>"
+
+[[cases]]
+name = "single element with trailing root comment"
+input = "<div></div><!-- trailing -->"
+
+[[cases]]
+name = "single element with leading and trailing root comments"
+input = "<!-- lead --><div>x</div><!-- trail -->"
+
+[[cases]]
+name = "two elements with root comment is stable fragment"
+input = "<div>a</div><!-- c --><div>b</div>"

--- a/tests/fixtures/vdom/v-bind.toml
+++ b/tests/fixtures/vdom/v-bind.toml
@@ -229,3 +229,31 @@ input = '<div style="color:red" :style="s"></div>'
 [[cases]]
 name = "mixed class and style merge order"
 input = '<div class="b" :class="a" :style="s" style="x:1"></div>'
+
+# =============================================================================
+# mergeProps source-order preservation (static prop before/after v-bind spread)
+# =============================================================================
+
+[[cases]]
+name = "static class after v-bind spread"
+input = '<div v-bind="obj" class="a"></div>'
+
+[[cases]]
+name = "static class before v-bind spread"
+input = '<div class="a" v-bind="obj"></div>'
+
+[[cases]]
+name = "static and dynamic props around v-bind spread"
+input = '<div id="x" v-bind="obj" :title="t"></div>'
+
+[[cases]]
+name = "static props before and after v-bind spread"
+input = '<div id="x" :title="t" v-bind="obj"></div>'
+
+[[cases]]
+name = "v-on spread before handler"
+input = '<div v-on="handlers" @click="fn"></div>'
+
+[[cases]]
+name = "handler before v-on spread"
+input = '<div @click="fn" v-on="handlers"></div>'

--- a/tests/fixtures/vdom/v-bind.toml
+++ b/tests/fixtures/vdom/v-bind.toml
@@ -177,3 +177,31 @@ input = '<input :disabled="count > 0">'
 [[cases]]
 name = "boolean readonly"
 input = '<input :readonly="isReadonly">'
+
+# =============================================================================
+# .prop shorthand and modifiers on dynamic args
+# =============================================================================
+
+[[cases]]
+name = "dot-prop shorthand"
+input = '<div .foo="val"></div>'
+
+[[cases]]
+name = "dot-prop shorthand with valid identifier key"
+input = '<div .fooBar="val"></div>'
+
+[[cases]]
+name = "v-bind dynamic arg with .prop"
+input = '<div :[key].prop="val"></div>'
+
+[[cases]]
+name = "v-bind dynamic arg with .camel"
+input = '<div :[key].camel="val"></div>'
+
+[[cases]]
+name = "v-bind dynamic arg with .attr"
+input = '<div :[key].attr="val"></div>'
+
+[[cases]]
+name = "v-bind dynamic arg plain"
+input = '<div :[key]="val"></div>'

--- a/tests/fixtures/vdom/v-bind.toml
+++ b/tests/fixtures/vdom/v-bind.toml
@@ -205,3 +205,27 @@ input = '<div :[key].attr="val"></div>'
 [[cases]]
 name = "v-bind dynamic arg plain"
 input = '<div :[key]="val"></div>'
+
+# =============================================================================
+# Static/dynamic class & style merge order (source order preserved)
+# =============================================================================
+
+[[cases]]
+name = "dynamic class before static class"
+input = '<div :class="a" class="b"></div>'
+
+[[cases]]
+name = "static class before dynamic class"
+input = '<div class="b" :class="a"></div>'
+
+[[cases]]
+name = "dynamic style before static style"
+input = '<div :style="s" style="color:red"></div>'
+
+[[cases]]
+name = "static style before dynamic style"
+input = '<div style="color:red" :style="s"></div>'
+
+[[cases]]
+name = "mixed class and style merge order"
+input = '<div class="b" :class="a" :style="s" style="x:1"></div>'

--- a/tests/fixtures/vdom/v-on.toml
+++ b/tests/fixtures/vdom/v-on.toml
@@ -243,3 +243,59 @@ name = "multiple cached handlers"
 input = '<button @click="count++" @mouseenter="hover = true"></button>'
 [cases.options]
 cacheHandlers = true
+
+# =============================================================================
+# Event name casing rules (vue: hooks, on: case preservation)
+# =============================================================================
+
+[[cases]]
+name = "vue: vnode lifecycle hook"
+input = '<div @vue:mounted="fn"></div>'
+
+[[cases]]
+name = "vue: vnode hook kebab"
+input = '<div @vue:before-update="fn"></div>'
+
+[[cases]]
+name = "vue: vnode hook on component"
+input = '<MyComp @vue:updated="fn" />'
+
+[[cases]]
+name = "camelCase event on plain element preserves case"
+input = '<div @fooBar="fn"></div>'
+
+[[cases]]
+name = "PascalCase event on plain element preserves case"
+input = '<div @FooBar="fn"></div>'
+
+[[cases]]
+name = "kebab event on plain element camelizes"
+input = '<div @foo-bar="fn"></div>'
+
+[[cases]]
+name = "camelCase event on component camelizes"
+input = '<MyComp @fooBar="fn" />'
+
+[[cases]]
+name = "colon event with uppercase on element"
+input = '<div @update:modelValue="fn"></div>'
+
+[[cases]]
+name = "colon event lowercase on element"
+input = '<div @update:foo="fn"></div>'
+
+[[cases]]
+name = "camelCase event with option modifier"
+input = '<div @fooBar.once="fn"></div>'
+
+[[cases]]
+name = "dblclick needs hydration"
+input = '<div @dblclick="fn"></div>'
+
+[[cases]]
+name = "click no hydration"
+input = '<div @click="fn"></div>'
+
+[[cases]]
+name = "mouseover needs hydration"
+input = '<div @mouseover="fn"></div>'

--- a/tests/fixtures/vdom/v-on.toml
+++ b/tests/fixtures/vdom/v-on.toml
@@ -299,3 +299,11 @@ input = '<div @click="fn"></div>'
 [[cases]]
 name = "mouseover needs hydration"
 input = '<div @mouseover="fn"></div>'
+
+[[cases]]
+name = "inline multi-statement handler"
+input = '<a @click="foo();bar()"></a>'
+
+[[cases]]
+name = "inline single-statement handler"
+input = '<a @click="foo()"></a>'

--- a/tests/fixtures/vdom/v-once.toml
+++ b/tests/fixtures/vdom/v-once.toml
@@ -85,3 +85,7 @@ input = '<div v-memo="[item?.id]">{{ item?.name }}</div>'
 [[cases]]
 name = "v-memo on template"
 input = '<template v-memo="[value]"><div>A</div><div>B</div></template>'
+
+[[cases]]
+name = "v-memo in v-for without key"
+input = '<li v-for="item in items" v-memo="[item.id]">{{ item }}</li>'


### PR DESCRIPTION
## What

Expands the differential-parity fixture corpus with hard VDOM template cases mined from `vuejs/core` issues + its compiler test suite, and fixes the divergences they revealed against the official `@vue/compiler-sfc` (3.6 beta). Each fixture's expected output is generated from the real Vue compiler, so passing them is objective parity.

## Fixes
- `fix(atelier-core,armature)`: match Vue's v-on event-name casing, `.prop` shorthand, and dynamic v-bind modifier handling
- `fix(atelier-core)`: emit inline multi-statement v-on handler bodies without inner spaces
- `fix(atelier-core)`: preserve source order when merging static/dynamic `class` & `style`
- `fix(atelier-core)`: preserve source order in `mergeProps` and char-code asset ids
- `fix(atelier-core)`: include the `_cached.el` guard in the `v-for` + `v-memo` memoization check
- `fix(atelier-core)`: set `DEV_ROOT_FRAGMENT` on single-element root fragments with comments

## Verification
`cargo run -p vize_test_runner --bin coverage` → **664/664 (100%)**, exit 0 (VDOM 422/422, up from 383; Vapor 104; SFC 138). New fixtures live in `tests/fixtures/vdom/*` with expected output regenerated from `@vue/compiler-sfc`.

Part of an effort to close compiler-output gaps surfaced by `vuejs/core` issues; remaining divergences tracked in follow-up issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)