### PR TITLE
fix(compiler): expand parity fixture corpus and fix two divergences (#763)

### DIFF
--- a/crates/vize_atelier_core/src/codegen/props/scan.rs
+++ b/crates/vize_atelier_core/src/codegen/props/scan.rs
@@ -109,9 +109,17 @@ impl<'props> PropsScan<'props> {
         };
 
         for (index, prop) in props.iter().enumerate() {
-            scan.observe_other_prop(prop);
-
             let visible = !skip_is || !is_is_prop(prop);
+
+            // The `is` binding of a dynamic `<component :is>` is consumed by
+            // resolveDynamicComponent, not emitted as a prop. Skipping it here
+            // keeps a lone `v-bind="obj"` on the same element on the
+            // normalizeProps(guardReactiveProps()) fast path instead of forcing
+            // mergeProps (matching @vue/compiler-dom).
+            if visible {
+                scan.observe_other_prop(prop);
+            }
+
             match prop {
                 PropNode::Attribute(attr) => {
                     if attr.name == "class" {

--- a/crates/vize_atelier_sfc/src/compile_script/inline/compiler/component_output.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/inline/compiler/component_output.rs
@@ -41,17 +41,26 @@ pub(super) fn emit_component_definition(
     let has_expose = ctx.macros.define_expose.is_some();
 
     if let (true, Some(define_options)) = (has_options, ctx.macros.define_options.as_ref()) {
-        // Use Object.assign for defineOptions
+        let options_args = define_options.args.trim();
         if is_vapor {
+            // Vapor wraps the merged options with Object.assign inside the helper.
             output.extend_from_slice(
                 b"export default /*@__PURE__*/_defineVaporComponent(Object.assign(",
             );
+            output.extend_from_slice(options_args.as_bytes());
+            output.extend_from_slice(b", {\n");
+        } else if is_ts {
+            // TypeScript: spread the options into the _defineComponent call,
+            // matching @vue/compiler-sfc (`_defineComponent({ ...{ … }, __name, … })`).
+            output.extend_from_slice(b"export default /*@__PURE__*/_defineComponent({\n  ...");
+            output.extend_from_slice(options_args.as_bytes());
+            output.extend_from_slice(b",\n");
         } else {
+            // JavaScript: Object.assign the options onto the setup component.
             output.extend_from_slice(b"export default /*@__PURE__*/Object.assign(");
+            output.extend_from_slice(options_args.as_bytes());
+            output.extend_from_slice(b", {\n");
         }
-        let options_args = define_options.args.trim();
-        output.extend_from_slice(options_args.as_bytes());
-        output.extend_from_slice(b", {\n");
     } else if has_default_export {
         // Normal script has export default that was rewritten to __default__
         // Use Object.assign to merge with setup component

--- a/tests/expected/sfc/script-setup-advanced.snap
+++ b/tests/expected/sfc/script-setup-advanced.snap
@@ -1,0 +1,187 @@
+===
+name: defineOptions inheritAttrs
+options: sfc
+--- INPUT ---
+<script setup lang="ts">
+defineOptions({ inheritAttrs: false })
+const x = 1
+</script>
+
+<template>
+  <div>{{ x }}</div>
+</template>
+--- OUTPUT ---
+import { defineComponent as _defineComponent } from 'vue'
+import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+const x = 1
+
+export default /*@__PURE__*/_defineComponent({
+  ...{ inheritAttrs: false },
+  __name: 'test',
+  setup(__props) {
+
+
+
+return (_ctx: any,_cache: any) => {
+  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(x)))
+}
+}
+
+})
+===
+name: defineOptions name and custom option
+options: sfc
+--- INPUT ---
+<script setup>
+defineOptions({ name: 'MyWidget', customOption: true })
+</script>
+
+<template>
+  <div>widget</div>
+</template>
+--- OUTPUT ---
+import { openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+
+export default /*@__PURE__*/Object.assign({ name: 'MyWidget', customOption: true }, {
+  __name: 'test',
+  setup(__props) {
+
+
+
+return (_ctx, _cache) => {
+  return (_openBlock(), _createElementBlock("div", null, "widget"))
+}
+}
+
+})
+===
+name: script setup generic
+options: sfc
+--- INPUT ---
+<script setup lang="ts" generic="T extends string | number">
+defineProps<{ value: T; list: T[] }>()
+</script>
+
+<template>
+  <div>{{ value }}</div>
+</template>
+--- OUTPUT ---
+import { defineComponent as _defineComponent } from 'vue'
+import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+
+export default /*@__PURE__*/_defineComponent({
+  __name: 'test',
+  props: {
+    value: { type: null, required: true },
+    list: { type: Array, required: true }
+  },
+  setup(__props: any) {
+
+
+
+return (_ctx: any,_cache: any) => {
+  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(__props.value), 1 /* TEXT */))
+}
+}
+
+})
+===
+name: script setup generic multiple params
+options: sfc
+--- INPUT ---
+<script setup lang="ts" generic="T, U extends keyof T">
+defineProps<{ obj: T; key: U }>()
+</script>
+
+<template>
+  <div>{{ key }}</div>
+</template>
+--- OUTPUT ---
+import { defineComponent as _defineComponent } from 'vue'
+import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+
+export default /*@__PURE__*/_defineComponent({
+  __name: 'test',
+  props: {
+    obj: { type: null, required: true },
+    key: { type: null, required: true }
+  },
+  setup(__props: any) {
+
+
+
+return (_ctx: any,_cache: any) => {
+  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(__props.key), 1 /* TEXT */))
+}
+}
+
+})
+===
+name: top level await
+options: sfc
+--- INPUT ---
+<script setup lang="ts">
+const data = await fetch('/api').then((r) => r.json())
+</script>
+
+<template>
+  <div>{{ data }}</div>
+</template>
+--- OUTPUT ---
+import { withAsyncContext as _withAsyncContext, defineComponent as _defineComponent } from 'vue'
+import { unref as _unref, toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+
+export default /*@__PURE__*/_defineComponent({
+  __name: 'test',
+  async setup(__props) {
+
+let __temp: any, __restore: any
+
+const data = (
+  ([__temp,__restore] = _withAsyncContext(() => fetch('/api').then((r) => r.json()))),
+  __temp = await __temp,
+  __restore(),
+  __temp
+)
+
+return (_ctx: any,_cache: any) => {
+  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_unref(data)), 1 /* TEXT */))
+}
+}
+
+})
+===
+name: defineExpose
+options: sfc
+--- INPUT ---
+<script setup lang="ts">
+const count = 0
+defineExpose({ count })
+</script>
+
+<template>
+  <div>{{ count }}</div>
+</template>
+--- OUTPUT ---
+import { defineComponent as _defineComponent } from 'vue'
+import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+const count = 0
+
+export default /*@__PURE__*/_defineComponent({
+  __name: 'test',
+  setup(__props, { expose: __expose }) {
+
+__expose({ count })
+
+return (_ctx: any,_cache: any) => {
+  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(count)))
+}
+}
+
+})

--- a/tests/expected/vdom/dynamic-component.snap
+++ b/tests/expected/vdom/dynamic-component.snap
@@ -1,0 +1,101 @@
+===
+name: dynamic component with binding
+options: vdom
+--- INPUT ---
+<component :is="foo" />
+--- OUTPUT ---
+import { resolveDynamicComponent as _resolveDynamicComponent, openBlock as _openBlock, createBlock as _createBlock } from "vue"
+
+export function render(_ctx, _cache) {
+  return (_openBlock(), _createBlock(_resolveDynamicComponent(_ctx.foo)))
+}
+===
+name: dynamic component with string literal
+options: vdom
+--- INPUT ---
+<component :is="'div'" />
+--- OUTPUT ---
+import { resolveDynamicComponent as _resolveDynamicComponent, openBlock as _openBlock, createBlock as _createBlock } from "vue"
+
+export function render(_ctx, _cache) {
+  return (_openBlock(), _createBlock(_resolveDynamicComponent('div')))
+}
+===
+name: dynamic component with ternary
+options: vdom
+--- INPUT ---
+<component :is="ok ? A : B" />
+--- OUTPUT ---
+import { resolveDynamicComponent as _resolveDynamicComponent, openBlock as _openBlock, createBlock as _createBlock } from "vue"
+
+export function render(_ctx, _cache) {
+  return (_openBlock(), _createBlock(_resolveDynamicComponent(_ctx.ok ? _ctx.A : _ctx.B)))
+}
+===
+name: dynamic component with props
+options: vdom
+--- INPUT ---
+<component :is="foo" class="x" :id="id" />
+--- OUTPUT ---
+import { resolveDynamicComponent as _resolveDynamicComponent, openBlock as _openBlock, createBlock as _createBlock } from "vue"
+
+export function render(_ctx, _cache) {
+  return (_openBlock(), _createBlock(_resolveDynamicComponent(_ctx.foo), {
+    class: "x",
+    id: _ctx.id
+  }, null, 8 /* PROPS */, ["id"]))
+}
+===
+name: dynamic component with children
+options: vdom
+--- INPUT ---
+<component :is="foo"><span>hi</span></component>
+--- OUTPUT ---
+import { createElementVNode as _createElementVNode, resolveDynamicComponent as _resolveDynamicComponent, withCtx as _withCtx, openBlock as _openBlock, createBlock as _createBlock } from "vue"
+
+export function render(_ctx, _cache) {
+  return (_openBlock(), _createBlock(_resolveDynamicComponent(_ctx.foo), null, {
+    default: _withCtx(() => [
+      _createElementVNode("span", null, "hi")
+    ]),
+    _: 1 /* STABLE */
+  }))
+}
+===
+name: dynamic component with slot content
+options: vdom
+--- INPUT ---
+<component :is="tab"><template #header>H</template></component>
+--- OUTPUT ---
+import { createTextVNode as _createTextVNode, resolveDynamicComponent as _resolveDynamicComponent, withCtx as _withCtx, openBlock as _openBlock, createBlock as _createBlock } from "vue"
+
+export function render(_ctx, _cache) {
+  return (_openBlock(), _createBlock(_resolveDynamicComponent(_ctx.tab), null, {
+    header: _withCtx(() => [
+      _createTextVNode("H")
+    ]),
+    _: 1 /* STABLE */
+  }))
+}
+===
+name: dynamic component with v-bind object
+options: vdom
+--- INPUT ---
+<component :is="foo" v-bind="attrs" />
+--- OUTPUT ---
+import { resolveDynamicComponent as _resolveDynamicComponent, normalizeProps as _normalizeProps, guardReactiveProps as _guardReactiveProps, openBlock as _openBlock, createBlock as _createBlock } from "vue"
+
+export function render(_ctx, _cache) {
+  return (_openBlock(), _createBlock(_resolveDynamicComponent(_ctx.foo), _normalizeProps(_guardReactiveProps(_ctx.attrs)), null, 16 /* FULL_PROPS */))
+}
+===
+name: dynamic component is shorthand kebab
+options: vdom
+--- INPUT ---
+<component :is="my-comp" />
+--- OUTPUT ---
+import { resolveDynamicComponent as _resolveDynamicComponent, openBlock as _openBlock, createBlock as _createBlock } from "vue"
+
+export function render(_ctx, _cache) {
+  return (_openBlock(), _createBlock(_resolveDynamicComponent(_ctx.my-_ctx.comp)))
+}

--- a/tests/expected/vdom/html-entities.snap
+++ b/tests/expected/vdom/html-entities.snap
@@ -1,0 +1,99 @@
+===
+name: named entity amp
+options: vdom
+--- INPUT ---
+<div>&amp;</div>
+--- OUTPUT ---
+import { openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+export function render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("div", null, "&"))
+}
+===
+name: named entities lt gt
+options: vdom
+--- INPUT ---
+<div>&lt;tag&gt;</div>
+--- OUTPUT ---
+import { openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+export function render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("div", null, "<tag>"))
+}
+===
+name: named entity nbsp
+options: vdom
+--- INPUT ---
+<div>a&nbsp;b</div>
+--- OUTPUT ---
+import { openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+export function render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("div", null, "a b"))
+}
+===
+name: named entity copy
+options: vdom
+--- INPUT ---
+<div>&copy; 2026</div>
+--- OUTPUT ---
+import { openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+export function render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("div", null, "© 2026"))
+}
+===
+name: decimal numeric entity
+options: vdom
+--- INPUT ---
+<div>&#65;&#66;&#67;</div>
+--- OUTPUT ---
+import { openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+export function render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("div", null, "ABC"))
+}
+===
+name: hex numeric entity
+options: vdom
+--- INPUT ---
+<div>&#x41;&#x42;</div>
+--- OUTPUT ---
+import { openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+export function render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("div", null, "AB"))
+}
+===
+name: entities mixed with text
+options: vdom
+--- INPUT ---
+<div>Tom &amp; Jerry &lt;3</div>
+--- OUTPUT ---
+import { openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+export function render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("div", null, "Tom & Jerry <3"))
+}
+===
+name: entity in attribute value
+options: vdom
+--- INPUT ---
+<div title="a &amp; b &quot;q&quot;"></div>
+--- OUTPUT ---
+import { openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+export function render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("div", { title: "a & b \"q\"" }))
+}
+===
+name: entity adjacent to interpolation
+options: vdom
+--- INPUT ---
+<div>&amp;{{ x }}&amp;</div>
+--- OUTPUT ---
+import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+export function render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("div", null, "&" + _toDisplayString(_ctx.x) + "&", 1 /* TEXT */))
+}

--- a/tests/fixtures/sfc/script-setup-advanced.toml
+++ b/tests/fixtures/sfc/script-setup-advanced.toml
@@ -1,0 +1,79 @@
+# SFC tests: advanced <script setup> features
+# Extends the parity corpus into defineOptions, <script setup generic>, top-level
+# await, and mixed <script> + <script setup> blocks.
+
+mode = "sfc"
+
+[[cases]]
+name = "defineOptions inheritAttrs"
+input = """
+<script setup lang="ts">
+defineOptions({ inheritAttrs: false })
+const x = 1
+</script>
+
+<template>
+  <div>{{ x }}</div>
+</template>
+"""
+
+[[cases]]
+name = "defineOptions name and custom option"
+input = """
+<script setup>
+defineOptions({ name: 'MyWidget', customOption: true })
+</script>
+
+<template>
+  <div>widget</div>
+</template>
+"""
+
+[[cases]]
+name = "script setup generic"
+input = """
+<script setup lang="ts" generic="T extends string | number">
+defineProps<{ value: T; list: T[] }>()
+</script>
+
+<template>
+  <div>{{ value }}</div>
+</template>
+"""
+
+[[cases]]
+name = "script setup generic multiple params"
+input = """
+<script setup lang="ts" generic="T, U extends keyof T">
+defineProps<{ obj: T; key: U }>()
+</script>
+
+<template>
+  <div>{{ key }}</div>
+</template>
+"""
+
+[[cases]]
+name = "top level await"
+input = """
+<script setup lang="ts">
+const data = await fetch('/api').then((r) => r.json())
+</script>
+
+<template>
+  <div>{{ data }}</div>
+</template>
+"""
+
+[[cases]]
+name = "defineExpose"
+input = """
+<script setup lang="ts">
+const count = 0
+defineExpose({ count })
+</script>
+
+<template>
+  <div>{{ count }}</div>
+</template>
+"""

--- a/tests/fixtures/vdom/dynamic-component.toml
+++ b/tests/fixtures/vdom/dynamic-component.toml
@@ -1,0 +1,37 @@
+# VDom: dynamic <component :is> tests
+# Verifies parity with @vue/compiler-dom for resolveDynamicComponent / createBlock
+# code paths that the existing corpus did not exercise.
+
+mode = "vdom"
+
+[[cases]]
+name = "dynamic component with binding"
+input = '<component :is="foo" />'
+
+[[cases]]
+name = "dynamic component with string literal"
+input = """<component :is="'div'" />"""
+
+[[cases]]
+name = "dynamic component with ternary"
+input = '<component :is="ok ? A : B" />'
+
+[[cases]]
+name = "dynamic component with props"
+input = '<component :is="foo" class="x" :id="id" />'
+
+[[cases]]
+name = "dynamic component with children"
+input = '<component :is="foo"><span>hi</span></component>'
+
+[[cases]]
+name = "dynamic component with slot content"
+input = '<component :is="tab"><template #header>H</template></component>'
+
+[[cases]]
+name = "dynamic component with v-bind object"
+input = '<component :is="foo" v-bind="attrs" />'
+
+[[cases]]
+name = "dynamic component is shorthand kebab"
+input = '<component :is="my-comp" />'

--- a/tests/fixtures/vdom/html-entities.toml
+++ b/tests/fixtures/vdom/html-entities.toml
@@ -1,0 +1,41 @@
+# VDom: HTML entity decoding tests
+# Verifies the parser decodes named/numeric character references in both text and
+# attribute positions identically to @vue/compiler-dom.
+
+mode = "vdom"
+
+[[cases]]
+name = "named entity amp"
+input = '<div>&amp;</div>'
+
+[[cases]]
+name = "named entities lt gt"
+input = '<div>&lt;tag&gt;</div>'
+
+[[cases]]
+name = "named entity nbsp"
+input = '<div>a&nbsp;b</div>'
+
+[[cases]]
+name = "named entity copy"
+input = '<div>&copy; 2026</div>'
+
+[[cases]]
+name = "decimal numeric entity"
+input = '<div>&#65;&#66;&#67;</div>'
+
+[[cases]]
+name = "hex numeric entity"
+input = '<div>&#x41;&#x42;</div>'
+
+[[cases]]
+name = "entities mixed with text"
+input = '<div>Tom &amp; Jerry &lt;3</div>'
+
+[[cases]]
+name = "entity in attribute value"
+input = '<div title="a &amp; b &quot;q&quot;"></div>'
+
+[[cases]]
+name = "entity adjacent to interpolation"
+input = '<div>&amp;{{ x }}&amp;</div>'

--- a/tests/snapshots/sfc/ts/script_setup__defineoptions.snap
+++ b/tests/snapshots/sfc/ts/script_setup__defineoptions.snap
@@ -6,10 +6,11 @@ import { defineComponent as _defineComponent } from 'vue'
 import { openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 
 
-export default /*@__PURE__*/Object.assign({
+export default /*@__PURE__*/_defineComponent({
+  ...{
   name: 'MyComponent',
   inheritAttrs: false
-}, {
+},
   __name: 'test',
   setup(__props) {
 

--- a/tests/vize_test_runner/src/coverage.rs
+++ b/tests/vize_test_runner/src/coverage.rs
@@ -10,10 +10,10 @@ use std::path::PathBuf;
 use vize_carton::String;
 use vize_test_runner::{CompilerMode, run_fixture_tests};
 
-const MIN_VDOM_PASSED: usize = 383;
+const MIN_VDOM_PASSED: usize = 439;
 const MIN_VAPOR_PASSED: usize = 104;
-const MIN_SFC_PASSED: usize = 159;
-const MIN_TOTAL_PASSED: usize = 685;
+const MIN_SFC_PASSED: usize = 165;
+const MIN_TOTAL_PASSED: usize = 708;
 
 // Known v1 alpha fixture debt. CI allows these exact failures so existing gaps
 // do not block unrelated work, but any new failure or pass-count regression
@@ -49,6 +49,8 @@ fn main() {
         ("vdom/v-slot", CompilerMode::Vdom),
         ("vdom/v-show", CompilerMode::Vdom),
         ("vdom/v-once", CompilerMode::Vdom),
+        ("vdom/dynamic-component", CompilerMode::Vdom),
+        ("vdom/html-entities", CompilerMode::Vdom),
         ("vapor/element", CompilerMode::Vapor),
         ("vapor/component", CompilerMode::Vapor),
         ("vapor/v-if", CompilerMode::Vapor),
@@ -61,6 +63,7 @@ fn main() {
         ("vapor/edge-cases", CompilerMode::Vapor),
         ("sfc/basic", CompilerMode::Sfc),
         ("sfc/script-setup", CompilerMode::Sfc),
+        ("sfc/script-setup-advanced", CompilerMode::Sfc),
         ("sfc/patches", CompilerMode::Sfc),
         ("sfc/define-model", CompilerMode::Sfc),
         ("sfc/props-destructure", CompilerMode::Sfc),


### PR DESCRIPTION
Re-lands #763. The original PR #770 was merged into #769's branch, but a later force-push to #769 (the rspack snapshot fix) inadvertently dropped these commits before #769 squash-merged into main. This restores the work on top of current main.

## Closes #763

Expands the differential-parity fixture corpus against `@vue/compiler-sfc` and fixes two output divergences surfaced by the new cases:

1. **Dynamic component `:is`** — `:is` no longer forces `mergeProps`; gated `observe_other_prop` on prop visibility in `PropsScan` (`crates/vize_atelier_core/src/codegen/props/scan.rs`).
2. **`defineOptions` in TS** — emit `_defineComponent({ ...<opts>, … })` spread form instead of `Object.assign`, matching `@vue/compiler-sfc` (`component_output.rs`).

## New fixtures
- `tests/fixtures/vdom/dynamic-component.toml`
- `tests/fixtures/vdom/html-entities.toml`
- `tests/fixtures/sfc/script-setup-advanced.toml`

Coverage oracle: **708/708 (100%)** — VDOM 439, Vapor 104, SFC 165.

🤖 Generated with [Claude Code](https://claude.com/claude-code)