### PR TITLE
chore(ci): drop redundant check-fixtures suite from nightly e2e

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,7 +1,7 @@
 name: App E2E
 
 on:
-  # App E2E (dev/preview/build/check/lint/check-fixtures) and VRT are slow
+  # App E2E (dev/preview/build/check/lint) and VRT are slow
   # workflows that historically gated every PR. They are now run nightly and
   # on demand so PR review latency is bounded by faster gates (Check,
   # Benchmark, Native Smoke). Regressions caught by the nightly run still
@@ -23,7 +23,6 @@ on:
           - check
           - lint
           - build
-          - check-fixtures
 
 concurrency:
   group: app-e2e-${{ github.ref }}-${{ github.event.inputs.suite || github.event_name }}
@@ -46,7 +45,7 @@ jobs:
         # workflow_dispatch: pick one suite. schedule: run every suite,
         # including vrt, because nothing else exercises the visual regression
         # baselines today.
-        suite: ${{ github.event_name == 'workflow_dispatch' && fromJSON(format('["{0}"]', inputs.suite)) || fromJSON('["dev","vrt","preview","build","check","lint","check-fixtures"]') }}
+        suite: ${{ github.event_name == 'workflow_dispatch' && fromJSON(format('["{0}"]', inputs.suite)) || fromJSON('["dev","vrt","preview","build","check","lint"]') }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -119,9 +118,6 @@ jobs:
               ;;
             build)
               vp run --filter './tests' test:build
-              ;;
-            check-fixtures)
-              vp run --filter './tests' test:check:fixtures
               ;;
           esac
 


### PR DESCRIPTION
## What
Removes the `check-fixtures` suite from the nightly **App E2E** workflow (`e2e.yml`).

## Why
The suite ran:
```
vp run --filter './tests' test:check:fixtures
```
…which is the **exact** command `check.yml`'s `vue-parity` job already runs on every PR (`check.yml:215`). The nightly copy was pure duplication — removing it changes no coverage; `test:check:fixtures` is still gated per-PR by `vue-parity`.

Surfaced by a full audit of `.github/workflows/` (all 8 files): this was the only genuinely-redundant piece. No workflow file was unnecessary — every other workflow (Check, Benchmark, Deploy docs, App E2E's remaining suites, Fuzz, pkg.pr.new, Release, weekly Native Smoke) has a unique role.

## Changes
- Drop `check-fixtures` from the `schedule` matrix array
- Drop `check-fixtures` from the `workflow_dispatch` suite options
- Drop the `check-fixtures)` case branch
- Update the header comment's suite list

The remaining nightly suites (`dev`, `vrt`, `preview`, `build`, `check`, `lint`) and the `./tests` VRT baselines are unique and untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)