### PR TITLE
feat(devshell): Blacksmith Testbox + vp test/lint/build

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -111,6 +111,62 @@
             }
           else
             null;
+        # Blacksmith CLI (Testbox). Distributed as a single prebuilt binary
+        # from a mutable `latest` channel, so — like the MoonBit block above —
+        # each platform pins the current binary's hash. The placeholder hashes
+        # below must be filled before this builds: run `nix build` once and
+        # paste the `got: sha256-…` value Nix reports for each platform, or
+        #   nix store prefetch-file --name blacksmith \
+        #     https://clireleases.blacksmith.sh/cli/latest/<os>/<arch>/blacksmith
+        #
+        # NOTE: the CLI self-updates in the background on every invocation,
+        # which cannot write into the read-only Nix store. If the pinned
+        # binary errors while trying to self-update, gate the update off (check
+        # `blacksmith --help` for the flag/env var) — the store path is the
+        # source of truth and is refreshed by bumping the hashes here.
+        blacksmithArtifacts = {
+          aarch64-darwin = {
+            url = "https://clireleases.blacksmith.sh/cli/latest/darwin/arm64/blacksmith";
+            hash = lib.fakeHash;
+          };
+          x86_64-darwin = {
+            url = "https://clireleases.blacksmith.sh/cli/latest/darwin/amd64/blacksmith";
+            hash = lib.fakeHash;
+          };
+          x86_64-linux = {
+            url = "https://clireleases.blacksmith.sh/cli/latest/linux/amd64/blacksmith";
+            hash = lib.fakeHash;
+          };
+          aarch64-linux = {
+            url = "https://clireleases.blacksmith.sh/cli/latest/linux/arm64/blacksmith";
+            hash = lib.fakeHash;
+          };
+        };
+        blacksmith =
+          if builtins.hasAttr system blacksmithArtifacts then
+            let
+              artifact = blacksmithArtifacts.${system};
+            in
+            pkgs.stdenvNoCC.mkDerivation {
+              pname = "blacksmith";
+              version = "latest";
+              src = pkgs.fetchurl { inherit (artifact) url hash; };
+              dontUnpack = true;
+              nativeBuildInputs = lib.optionals pkgs.stdenv.isLinux [ pkgs.autoPatchelfHook ];
+              installPhase = ''
+                runHook preInstall
+                install -Dm755 $src $out/bin/blacksmith
+                runHook postInstall
+              '';
+              meta = {
+                description = "Blacksmith CLI (Testbox)";
+                homepage = "https://docs.blacksmith.sh/blacksmith-testbox/overview";
+                license = lib.licenses.unfree;
+                platforms = builtins.attrNames blacksmithArtifacts;
+              };
+            }
+          else
+            null;
         nodejs = pkgs.nodejs_24;
         pnpm = pkgs.pnpm;
         workspaceVp = pkgs.writeShellApplication {
@@ -271,6 +327,7 @@
           ]
           ++ lib.optionals pkgs.stdenv.isDarwin [ workspaceXcrun ]
           ++ lib.optionals (moonbit != null) [ moonbit ]
+          ++ lib.optionals (blacksmith != null) [ blacksmith ]
           ++ commonNativeBuildInputs;
 
           RUST_SRC_PATH = "${rustToolchain}/lib/rustlib/src/rust/library";

--- a/tools/vite-plus/task-groups.ts
+++ b/tools/vite-plus/task-groups.ts
@@ -5,6 +5,7 @@ import { generationAndCliTasks } from "./tasks/generation-cli.ts";
 import { releaseTasks } from "./tasks/release.ts";
 import { setupAndDevTasks } from "./tasks/setup-dev.ts";
 import { testAndBenchmarkTasks } from "./tasks/test-benchmark.ts";
+import { testboxTasks } from "./tasks/testbox.ts";
 
 /**
  * Fully assembled root Vite+ task catalog.
@@ -22,4 +23,5 @@ export const taskCatalog = defineTasks({
   ...testAndBenchmarkTasks,
   ...checkTasks,
   ...releaseTasks,
+  ...testboxTasks,
 });

--- a/tools/vite-plus/tasks/build.ts
+++ b/tools/vite-plus/tasks/build.ts
@@ -10,6 +10,7 @@ import {
   runTasks,
   task,
 } from "../task-helpers.ts";
+import { inTestbox } from "./testbox.ts";
 
 /**
  * Build and packaging tasks for the repository's compiled artifacts.
@@ -21,7 +22,9 @@ import {
  * forcing unrelated test or release commands into the same module.
  */
 export const buildTasks = defineTasks({
-  build: noCacheTask(runTasks("build:rust", "build:all")),
+  // `vp build` runs inside a Blacksmith Testbox; the underlying build:* tasks
+  // stay local. See tools/vite-plus/tasks/testbox.ts.
+  build: noCacheTask(inTestbox(runTasks("build:rust", "build:all"))),
   "build:all": noCacheTask(runTasks("build:runtime", "package:editor-extensions")),
   "build:rust": task("cargo build --workspace", { input: cacheInputs.rust }),
   "build:runtime": noCacheTask(runTasks("build:native", "build:wasm", "build:packages")),

--- a/tools/vite-plus/tasks/check.ts
+++ b/tools/vite-plus/tasks/check.ts
@@ -18,6 +18,7 @@ import {
   shellCommand,
   task,
 } from "../task-helpers.ts";
+import { inTestbox } from "./testbox.ts";
 
 const ciPackageCheckCommand = runInPackages("check", ciCheckedPackages, {
   concurrencyLimit: 1,
@@ -82,7 +83,8 @@ export const checkTasks = defineTasks({
   "fmt:js": noCacheTask(runInPackages("fmt", checkedPackages)),
   "fmt:rust": task("cargo fmt --all", { input: cacheInputs.rust }),
   "fmt:all": noCacheTask(runTask("fmt")),
-  lint: noCacheTask(runTask("check")),
+  // `vp lint` runs inside a Blacksmith Testbox; `check` stays local.
+  lint: noCacheTask(inTestbox(runTask("check"))),
   "lint:fix": noCacheTask(runTask("check:fix")),
   "lint:rust": task("cargo clippy --workspace -- -D warnings", { input: cacheInputs.rust }),
   "lint:all": noCacheTask(runTasks("lint:rust", "check")),

--- a/tools/vite-plus/tasks/test-benchmark.ts
+++ b/tools/vite-plus/tasks/test-benchmark.ts
@@ -9,6 +9,7 @@ import {
   runTasks,
   task,
 } from "../task-helpers.ts";
+import { inTestbox } from "./testbox.ts";
 
 const jsPackageTestCommand = runInPackages("test", testedPackages, {
   concurrencyLimit: 1,
@@ -57,7 +58,11 @@ const rustBranchCoverageCommand = [
  * performance regressions difficult to miss.
  */
 export const testAndBenchmarkTasks = defineTasks({
-  test: noCacheTask(runTasks("test:rust", "test:js", "test:scripts", "test:zed-extension:unit")),
+  // `vp test` runs inside a Blacksmith Testbox; the underlying test:* tasks
+  // stay local. See tools/vite-plus/tasks/testbox.ts.
+  test: noCacheTask(
+    inTestbox(runTasks("test:rust", "test:js", "test:scripts", "test:zed-extension:unit")),
+  ),
   "test:rust": task("cargo test --workspace", { input: cacheInputs.rust }),
   // Use the CI-profile native build instead of the release-profile one.
   // The release build was ~3m+ on GitHub Actions and was being immediately

--- a/tools/vite-plus/tasks/testbox.ts
+++ b/tools/vite-plus/tasks/testbox.ts
@@ -1,0 +1,43 @@
+import { defineTasks, noCacheTask, shellQuote } from "../task-helpers.ts";
+
+/**
+ * Blacksmith Testbox integration.
+ *
+ * A testbox syncs the local working tree to a Blacksmith Linux microVM that is
+ * running the real CI environment, then executes commands there (1-3s
+ * incremental syncs after the first). This lets `vp test|lint|build` run
+ * against the exact CI toolchain from a macOS workstation.
+ *
+ * The CLI ships from the dev shell (see the `blacksmith` derivation in
+ * flake.nix). `blacksmith testbox run` requires an explicit `--id` on every
+ * call and has no concept of a "current" box, so the id is threaded through
+ * `BLACKSMITH_TESTBOX_ID`. Typical flow:
+ *
+ *   # once per session — warms a box from a workflow that sets up vp/Rust/etc.
+ *   export BLACKSMITH_TESTBOX_ID="$(vp testbox:warmup | tail -n1)"
+ *   vp test        # runs the suite inside the box
+ *   vp testbox:stop
+ *
+ * `tail -n1` assumes warmup prints the id last; adjust once verified against a
+ * real run. Auth is interactive on first use (browser login).
+ */
+const REQUIRE_ID =
+  "${BLACKSMITH_TESTBOX_ID:?BLACKSMITH_TESTBOX_ID is unset — warm a box first: vp testbox:warmup}";
+
+/**
+ * Wrap a workspace command so it runs inside the testbox instead of locally.
+ * `command` is the exact shell string that would otherwise run on this host;
+ * it is forwarded verbatim to the box, which has the synced tree and CI tools.
+ */
+export const inTestbox = (command: string): string =>
+  `blacksmith testbox run --id "${REQUIRE_ID}" ${shellQuote(command)}`;
+
+/**
+ * Lifecycle helpers. Warmup targets the Check workflow because its setup steps
+ * (Vite+/Node, Rust, MoonBit) leave `vp` and the toolchains on PATH inside the
+ * box, which is what `vp test|lint|build` need there.
+ */
+export const testboxTasks = defineTasks({
+  "testbox:warmup": noCacheTask("blacksmith testbox warmup .github/workflows/check.yml"),
+  "testbox:stop": noCacheTask(`blacksmith testbox stop --id "${REQUIRE_ID}"`),
+});


### PR DESCRIPTION
## What

Installs the **Blacksmith Testbox** CLI via the Nix flake and routes `vp test|lint|build` through it, so those commands run inside a Linux microVM with the real CI toolchain (1-3s incremental syncs) — the "develop on macOS, run on Linux CI env" use case.

## Changes
- **flake.nix** — `blacksmith` CLI packaged as a per-platform `fetchurl` derivation (darwin/linux × arm64/amd64), added to the dev shell, mirroring the MoonBit block.
- **tools/vite-plus/tasks/testbox.ts** — `inTestbox()` wrapper + `testbox:warmup` / `testbox:stop` tasks.
- **test/lint/build** rewired to run their existing sub-tasks *inside the box* (sub-tasks stay local → no recursion).

## Verified locally ✅
- `vp run` catalog loads; `test`/`lint`/`build` render the wrapped command correctly.
- Task tooling tests pass (19/19).
- CI never calls the bare `test`/`lint`/`build` tasks → runner jobs unaffected.

## ⚠️ Needs real-machine verification before merge
1. **Nix hashes are `lib.fakeHash` placeholders** — fill from the first `nix build` (the CLI only ships a mutable `latest` channel, so hashes need periodic refresh, like MoonBit).
2. **End-to-end testbox flow** — auth (browser login) + the exact `warmup` output format for capturing the id into `BLACKSMITH_TESTBOX_ID` (the README assumes `tail -n1`).
3. **Self-update vs Nix store** — the CLI auto-updates on every invocation, which can't write into the read-only store; may need an update-disable flag/env var.
4. **`ci` ripple** — `ci` composes `test`, so `vp run ci` now also requires a warm box. Decide whether `ci` should stay local.

## Usage
```sh
export BLACKSMITH_TESTBOX_ID="$(vp testbox:warmup | tail -n1)"
vp test
vp testbox:stop
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/778"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782792979&installation_id=136613492&pr_number=778&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F778&signature=62d184ab8a8b7d7736af7ca52c153ae0ce8543fa72c6c753ae28a0afa4a45d2b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->