### PR TITLE
ci(testbox): add Blacksmith Testbox warmup job

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -23,9 +23,13 @@ on:
           - check
           - lint
           - build
+      testbox_id:
+        description: Blacksmith Testbox session ID
+        required: false
+        type: string
 
 concurrency:
-  group: app-e2e-${{ github.ref }}-${{ github.event.inputs.suite || github.event_name }}
+  group: app-e2e-${{ github.ref }}-${{ github.event.inputs.testbox_id || github.event.inputs.suite || github.event_name }}
   cancel-in-progress: true
 
 env:
@@ -33,8 +37,63 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
+  testbox:
+    name: Testbox
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.testbox_id != '' }}
+    runs-on: blacksmith-32vcpu-ubuntu-2404
+    timeout-minutes: 120
+    permissions:
+      contents: read
+    env:
+      NODE_OPTIONS: "--disable-warning=DEP0040 --disable-warning=DEP0169"
+    steps:
+      - name: Begin Testbox
+        uses: useblacksmith/begin-testbox@233448af4bfdc6fca509a7f0974411ac6d8a8043 # v2
+        with:
+          testbox_id: ${{ inputs.testbox_id }}
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          submodules: recursive
+
+      - name: Setup Vite+ and Node.js
+        uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1
+        with:
+          node-version-file: ".node-version"
+          cache: true
+          run-install: false
+
+      - uses: ./.github/actions/setup-moonbit
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          shared-key: "testbox"
+          cache-workspace-crates: "true"
+
+      - name: Install JS dependencies
+        run: vp install --frozen-lockfile --prefer-offline
+
+      - name: Install Pkl CLI
+        run: npm install --global @pkl-community/pkl@0.27.2
+
+      - name: Install wasm-bindgen-cli
+        uses: taiki-e/install-action@184183c2401be73c3bf42c2e61268aa5855379c1 # v2
+        with:
+          tool: wasm-bindgen-cli@0.2.121
+
+      - name: Run Testbox
+        uses: useblacksmith/run-testbox@5ca05834db1d3813554d1dd109e5f2087a8d7cbc # v2
+        if: always()
+
   app-e2e:
     name: app-e2e (${{ matrix.suite }})
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.testbox_id == '' }}
     runs-on: blacksmith-32vcpu-ubuntu-2404
     timeout-minutes: 90
     permissions:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,6 +54,8 @@ vp run actrun:benchmark:dry-run
 ```
 
 Prefer the Vite+ tasks when launching multiple local workflow runs in parallel; they assign separate actrun workspaces.
+For Blacksmith Testbox job changes, also validate the workflow shape with
+`node --test tests/tooling/github-workflows.test.ts`.
 
 ## Language Processor Change Discipline
 

--- a/tests/tooling/github-workflows.test.ts
+++ b/tests/tooling/github-workflows.test.ts
@@ -170,6 +170,27 @@ test("GitHub workflow actions are pinned by full commit SHA", () => {
   assert.deepEqual(violations, []);
 });
 
+test("App E2E workflow keeps Blacksmith Testbox dispatch hydration separate", () => {
+  const workflow = readRepoFile(".github", "workflows", "e2e.yml");
+  const job = workflowJobBody(workflow, "testbox");
+  const appJob = workflowJobBody(workflow, "app-e2e");
+
+  assert.match(workflow, /\n  workflow_dispatch:\n/);
+  assert.match(workflow, /testbox_id:\n\s+description:\s*Blacksmith Testbox session ID/);
+  assert.match(
+    job,
+    /if:\s*\$\{\{\s*github\.event_name == 'workflow_dispatch' && inputs\.testbox_id != ''\s*\}\}/,
+  );
+  assert.match(job, /uses:\s*useblacksmith\/begin-testbox@[0-9a-f]{40}\s*# v2/);
+  assert.match(job, /testbox_id:\s*\$\{\{\s*inputs\.testbox_id\s*\}\}/);
+  assert.match(job, /uses:\s*useblacksmith\/run-testbox@[0-9a-f]{40}\s*# v2/);
+  assert.doesNotMatch(job, /vp run --workspace-root test|cargo test --workspace/);
+  assert.match(
+    appJob,
+    /if:\s*\$\{\{\s*github\.event_name != 'workflow_dispatch' \|\| inputs\.testbox_id == ''\s*\}\}/,
+  );
+});
+
 test("PR CI jobs cap runtime with explicit timeouts", () => {
   const checkWorkflow = readRepoFile(".github", "workflows", "check.yml");
   const benchmarkWorkflow = readRepoFile(".github", "workflows", "benchmark.yml");

--- a/tools/vite-plus/tasks/testbox.ts
+++ b/tools/vite-plus/tasks/testbox.ts
@@ -13,7 +13,7 @@ import { defineTasks, noCacheTask, shellQuote } from "../task-helpers.ts";
  * call and has no concept of a "current" box, so the id is threaded through
  * `BLACKSMITH_TESTBOX_ID`. Typical flow:
  *
- *   # once per session — warms a box from a workflow that sets up vp/Rust/etc.
+ *   # once per session — warms a box from the current Git branch.
  *   export BLACKSMITH_TESTBOX_ID="$(vp testbox:warmup | tail -n1)"
  *   vp test        # runs the suite inside the box
  *   vp testbox:stop
@@ -33,11 +33,13 @@ export const inTestbox = (command: string): string =>
   `blacksmith testbox run --id "${REQUIRE_ID}" ${shellQuote(command)}`;
 
 /**
- * Lifecycle helpers. Warmup targets the Check workflow because its setup steps
- * (Vite+/Node, Rust, MoonBit) leave `vp` and the toolchains on PATH inside the
- * box, which is what `vp test|lint|build` need there.
+ * Lifecycle helpers. Warmup targets the dedicated Testbox workflow on the
+ * current branch. GitHub fetches workflow files from a remote ref, so new
+ * Testbox workflow changes need to be pushed before warmup can see them.
  */
 export const testboxTasks = defineTasks({
-  "testbox:warmup": noCacheTask("blacksmith testbox warmup .github/workflows/check.yml"),
+  "testbox:warmup": noCacheTask(
+    'blacksmith testbox warmup .github/workflows/e2e.yml --ref "$(git branch --show-current)" --job testbox',
+  ),
   "testbox:stop": noCacheTask(`blacksmith testbox stop --id "${REQUIRE_ID}"`),
 });


### PR DESCRIPTION
## Summary

- Add a Blacksmith Testbox hydration job to the existing dispatchable App E2E workflow.
- Point `vp testbox:warmup` at that job on the current pushed branch so new workflow changes can be warmed before merge.
- Cover the Testbox workflow shape in the GitHub workflow tooling test and document the extra validation step.

## Validation

- `node --test tests/tooling/github-workflows.test.ts`
- `vp check .github/workflows/e2e.yml tools/vite-plus/tasks/testbox.ts tests/tooling/github-workflows.test.ts CONTRIBUTING.md`
- `actrun lint .github/workflows/check.yml`
- `actrun lint .github/workflows/benchmark.yml`
- `actrun workflow run .github/workflows/check.yml --workspace _build/actrun/workspace/check-testbox-change --dry-run`
- `actrun workflow run .github/workflows/benchmark.yml --workspace _build/actrun/workspace/benchmark-testbox-change --dry-run`
- `vp run testbox:warmup` returned `tbx_01ksy94zpg7z4xgcs9wxtwt1f9`; stopped with `blacksmith testbox stop --id tbx_01ksy94zpg7z4xgcs9wxtwt1f9`

Note: this local `actrun` build does not parse dispatch/schedule-only workflows, so the App E2E workflow change is validated by YAML parsing, the workflow tooling test, and an actual Testbox warmup.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/779"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782798496&installation_id=136613492&pr_number=779&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F779&signature=653f4d809e37c5f2a205c59f1679c954e3b3c891827807559da2f69f6e877d6a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->