### PR TITLE
ci: speed up actions with blacksmith

### DIFF
--- a/.github/workflows/native-smoke.yml
+++ b/.github/workflows/native-smoke.yml
@@ -38,10 +38,10 @@ jobs:
           - runner: macos-15-intel
             target: darwin-x64
             msvc_arch: amd64
-          - runner: macos-15
+          - runner: blacksmith-12vcpu-macos-15
             target: darwin-arm64
             msvc_arch: amd64
-          - runner: windows-2025
+          - runner: blacksmith-32vcpu-windows-2025
             target: win32-x64-msvc
             msvc_arch: amd64
           - runner: windows-11-arm
@@ -95,8 +95,8 @@ jobs:
       fail-fast: false
       matrix:
         node-version: ["22", "24"]
-        # Linux musl targets are intentionally absent here: hosted Ubuntu
-        # runners provide GNU hosts, not native Alpine/musl hosts. Keep the
+        # Linux musl targets are intentionally absent here: Ubuntu runners
+        # provide GNU hosts, not native Alpine/musl hosts. Keep the
         # known-limitation policy in docs/content/stability.md in sync when
         # containerized musl tarball staging is added.
         platform:
@@ -109,10 +109,10 @@ jobs:
           - runner: macos-15-intel
             target: darwin-x64
             msvc_arch: amd64
-          - runner: macos-15
+          - runner: blacksmith-12vcpu-macos-15
             target: darwin-arm64
             msvc_arch: amd64
-          - runner: windows-2025
+          - runner: blacksmith-32vcpu-windows-2025
             target: win32-x64-msvc
             msvc_arch: amd64
           - runner: windows-11-arm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,16 +31,16 @@ jobs:
       fail-fast: false
       matrix:
         settings:
-          - host: macos-15
+          - host: blacksmith-12vcpu-macos-15
             target: x86_64-apple-darwin
             archive: vize-x86_64-apple-darwin.tar.gz
-          - host: macos-15
+          - host: blacksmith-12vcpu-macos-15
             target: aarch64-apple-darwin
             archive: vize-aarch64-apple-darwin.tar.gz
-          - host: windows-2025
+          - host: blacksmith-32vcpu-windows-2025
             target: x86_64-pc-windows-msvc
             archive: vize-x86_64-pc-windows-msvc.zip
-          - host: windows-2025
+          - host: blacksmith-32vcpu-windows-2025
             target: aarch64-pc-windows-msvc
             archive: vize-aarch64-pc-windows-msvc.zip
           - host: blacksmith-32vcpu-ubuntu-2404
@@ -301,6 +301,60 @@ jobs:
           if-no-files-found: error
           compression-level: 0
 
+  # Build WASM once on Blacksmith; the npm publish job only attaches provenance.
+  build-wasm-package:
+    name: Build @vizejs/wasm package
+    runs-on: blacksmith-32vcpu-ubuntu-2404
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: ./.github/actions/setup-moonbit
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          shared-key: release-wasm
+          cache-workspace-crates: "true"
+
+      - name: Cache WASM package build
+        id: cache-wasm
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        with:
+          path: npm/vize-wasm
+          key: ${{ runner.os }}-release-wasm-${{ hashFiles('crates/**/*.rs', 'Cargo.lock', 'npm/vize-wasm/package.json', 'npm/vize-wasm/index.js', 'npm/vize-wasm/index.d.ts', 'tools/moon/scripts/build_vize_wasm_package.mbtx') }}
+
+      - name: Install wasm-bindgen-cli
+        if: steps.cache-wasm.outputs.cache-hit != 'true'
+        uses: taiki-e/install-action@184183c2401be73c3bf42c2e61268aa5855379c1 # v2
+        with:
+          tool: wasm-bindgen-cli@0.2.121
+
+      - name: Build WASM
+        if: steps.cache-wasm.outputs.cache-hit != 'true'
+        run: moon run --target native - -- < tools/moon/scripts/build_vize_wasm_package.mbtx
+
+      - name: Setup Vite+ and Node.js
+        uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1
+        with:
+          node-version-file: ".node-version"
+          run-install: false
+
+      - name: Smoke @vizejs/wasm package
+        run: node tools/npm/smoke-wasm-package.mjs npm/vize-wasm
+
+      - name: Upload WASM package artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: release-package-vize-wasm
+          path: npm/vize-wasm
+          if-no-files-found: error
+          compression-level: 0
+
   # Build native bindings (vize-native + fresco-native) for all platforms
   build-native-all:
     name: Build Native - ${{ matrix.settings.target }}
@@ -313,13 +367,13 @@ jobs:
           # MoonBit's native installer does not publish a Darwin x64 toolchain.
           # Build the darwin-x64 native package from the macOS ARM runner,
           # matching the CLI release job.
-          - host: macos-15
+          - host: blacksmith-12vcpu-macos-15
             target: x86_64-apple-darwin
             cross_compile: false
-          - host: macos-15
+          - host: blacksmith-12vcpu-macos-15
             target: aarch64-apple-darwin
             cross_compile: false
-          - host: windows-2025
+          - host: blacksmith-32vcpu-windows-2025
             target: x86_64-pc-windows-msvc
             cross_compile: false
           - host: windows-11-arm
@@ -535,10 +589,12 @@ jobs:
             npm/musea-nuxt \
             npm/nuxt
 
+  # npm Trusted Publishing/provenance currently rejects self-hosted runners.
+  # Keep the publish edge on GitHub-hosted runners; build and smoke jobs stay on Blacksmith.
   # Publish native packages to npm (using Trusted Publishing / OIDC)
   release-npm-native:
     name: Release @vizejs/native to npm
-    runs-on: blacksmith-32vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     needs: build-native-all
     timeout-minutes: 30
     environment: npm
@@ -592,7 +648,7 @@ jobs:
   # Publish fresco native packages to npm (using Trusted Publishing / OIDC)
   release-npm-fresco-native:
     name: Release @vizejs/fresco-native to npm
-    runs-on: blacksmith-32vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     needs: build-native-all
     timeout-minutes: 20
     environment: npm
@@ -631,10 +687,11 @@ jobs:
       - name: Publish
         run: moon run --target native - -- npm/fresco-native --provenance < tools/moon/scripts/publish_npm_package.mbtx
 
-  # Build and publish WASM package (using Trusted Publishing / OIDC)
+  # Publish WASM package (using Trusted Publishing / OIDC)
   release-npm-wasm:
     name: Release @vizejs/wasm to npm
-    runs-on: blacksmith-32vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
+    needs: build-wasm-package
     timeout-minutes: 30
     environment: npm
     permissions:
@@ -644,39 +701,17 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: ./.github/actions/setup-moonbit
 
-      - name: Setup Rust
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
-        with:
-          targets: wasm32-unknown-unknown
-
-      - name: Cache Rust
-        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-        with:
-          shared-key: release-wasm
-          cache-workspace-crates: "true"
-
-      - name: Cache WASM package build
-        id: cache-wasm
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
-        with:
-          path: npm/vize-wasm
-          key: ${{ runner.os }}-release-wasm-${{ hashFiles('crates/**/*.rs', 'Cargo.lock', 'npm/vize-wasm/package.json', 'npm/vize-wasm/index.js', 'npm/vize-wasm/index.d.ts', 'tools/moon/scripts/build_vize_wasm_package.mbtx') }}
-
-      - name: Install wasm-bindgen-cli
-        if: steps.cache-wasm.outputs.cache-hit != 'true'
-        uses: taiki-e/install-action@184183c2401be73c3bf42c2e61268aa5855379c1 # v2
-        with:
-          tool: wasm-bindgen-cli@0.2.121
-
-      - name: Build WASM
-        if: steps.cache-wasm.outputs.cache-hit != 'true'
-        run: moon run --target native - -- < tools/moon/scripts/build_vize_wasm_package.mbtx
-
       - name: Setup Vite+ and Node.js
         uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1
         with:
           node-version-file: ".node-version"
           run-install: false
+
+      - name: Download prebuilt WASM package
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: release-package-vize-wasm
+          path: npm/vize-wasm
 
       - name: Smoke @vizejs/wasm package
         run: node tools/npm/smoke-wasm-package.mjs npm/vize-wasm
@@ -690,7 +725,7 @@ jobs:
   # Build and publish Vite plugin (using Trusted Publishing / OIDC)
   release-npm-vite-plugin:
     name: Release @vizejs/vite-plugin to npm
-    runs-on: blacksmith-32vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     needs: [build-release-packages, release-npm-native, release-npm-cli, smoke-release-packages]
     timeout-minutes: 15
     environment: npm
@@ -719,7 +754,7 @@ jobs:
   # Build and publish Oxlint plugin package (using Trusted Publishing / OIDC)
   release-npm-oxlint-plugin:
     name: Release oxlint-plugin-vize to npm
-    runs-on: blacksmith-32vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     needs: [build-release-packages, release-npm-native, smoke-release-packages]
     timeout-minutes: 15
     environment: npm
@@ -751,7 +786,7 @@ jobs:
   # Build and publish unplugin package (using Trusted Publishing / OIDC)
   release-npm-unplugin:
     name: Release @vizejs/unplugin to npm
-    runs-on: blacksmith-32vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     needs: [build-release-packages, release-npm-native, smoke-release-packages]
     timeout-minutes: 15
     environment: npm
@@ -780,7 +815,7 @@ jobs:
   # Build and publish Fresco package (using Trusted Publishing / OIDC)
   release-npm-fresco:
     name: Release @vizejs/fresco to npm
-    runs-on: blacksmith-32vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     needs: [build-release-packages, release-npm-fresco-native, smoke-release-packages]
     timeout-minutes: 15
     environment: npm
@@ -809,7 +844,7 @@ jobs:
   # Build and publish Musea MCP server (using Trusted Publishing / OIDC)
   release-npm-musea-mcp-server:
     name: Release @vizejs/musea-mcp-server to npm
-    runs-on: blacksmith-32vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     needs: [build-release-packages, release-npm-native, smoke-release-packages]
     timeout-minutes: 15
     environment: npm
@@ -838,7 +873,7 @@ jobs:
   # Build and publish Vite plugin for Musea (using Trusted Publishing / OIDC)
   release-npm-vite-plugin-musea:
     name: Release @vizejs/vite-plugin-musea to npm
-    runs-on: blacksmith-32vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     needs: [build-release-packages, release-npm-native, smoke-release-packages]
     timeout-minutes: 15
     environment: npm
@@ -867,7 +902,7 @@ jobs:
   # Build and publish Rspack plugin (using Trusted Publishing / OIDC)
   release-npm-rspack-plugin:
     name: Release @vizejs/rspack-plugin to npm
-    runs-on: blacksmith-32vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     needs: [build-release-packages, release-npm-native, smoke-release-packages]
     timeout-minutes: 15
     environment: npm
@@ -896,7 +931,7 @@ jobs:
   # Build and publish Musea Nuxt (using Trusted Publishing / OIDC)
   release-npm-musea-nuxt:
     name: Release @vizejs/musea-nuxt to npm
-    runs-on: blacksmith-32vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     needs: [build-release-packages, release-npm-native, smoke-release-packages]
     timeout-minutes: 15
     environment: npm
@@ -925,7 +960,7 @@ jobs:
   # Build and publish @vizejs/nuxt (using Trusted Publishing / OIDC)
   release-npm-nuxt:
     name: Release @vizejs/nuxt to npm
-    runs-on: blacksmith-32vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     needs:
       [
         build-release-packages,
@@ -1121,7 +1156,7 @@ jobs:
   # Native bindings are distributed via @vizejs/native-* optionalDependencies (NAPI-RS)
   release-npm-cli:
     name: Release vize CLI to npm
-    runs-on: blacksmith-32vcpu-ubuntu-2404
+    runs-on: ubuntu-24.04
     needs: [build-release-packages, release-npm-native, smoke-release-packages]
     timeout-minutes: 15
     environment: npm

--- a/flake.nix
+++ b/flake.nix
@@ -24,7 +24,12 @@
       let
         pkgs = import nixpkgs {
           inherit system overlays;
-          config.allowUnfreePredicate = pkg: (pkg.pname or null) == "moonbit";
+          config.allowUnfreePredicate =
+            pkg:
+            builtins.elem (pkg.pname or null) [
+              "blacksmith"
+              "moonbit"
+            ];
         };
 
         lib = pkgs.lib;
@@ -127,19 +132,19 @@
         blacksmithArtifacts = {
           aarch64-darwin = {
             url = "https://clireleases.blacksmith.sh/cli/latest/darwin/arm64/blacksmith";
-            hash = lib.fakeHash;
+            hash = "sha256-ozZ6tBUbEqTqdxUVwxSg1ItiKUwLZxMl1Ccx8r6XP2Y=";
           };
           x86_64-darwin = {
             url = "https://clireleases.blacksmith.sh/cli/latest/darwin/amd64/blacksmith";
-            hash = lib.fakeHash;
+            hash = "sha256-YhC5jCuLeQNHlFYnd1PdCVntNPAibp1cQAIcl6JG9OE=";
           };
           x86_64-linux = {
             url = "https://clireleases.blacksmith.sh/cli/latest/linux/amd64/blacksmith";
-            hash = lib.fakeHash;
+            hash = "sha256-OPHHrvGjbIfkC5tQvFc+zbu3hd5GsoJelcuauvo1m90=";
           };
           aarch64-linux = {
             url = "https://clireleases.blacksmith.sh/cli/latest/linux/arm64/blacksmith";
-            hash = lib.fakeHash;
+            hash = "sha256-+HBaib2jDECu1UIxkWX0jO5H6W+9XlT/leB5Uow8hy4=";
           };
         };
         blacksmith =

--- a/tests/tooling/github-workflows.test.ts
+++ b/tests/tooling/github-workflows.test.ts
@@ -48,7 +48,7 @@ function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
-// Linux runner pairs (hosted GitHub label, equivalent Blacksmith label) accepted by
+// Runner pairs (hosted GitHub label, equivalent Blacksmith label) accepted by
 // the workflow-shape tests. Letting either form match keeps the cross-platform
 // coverage assertion strict on _which_ platforms are present without pinning the
 // runner-pool vendor; switching back to GitHub-hosted shouldn't break the test
@@ -59,6 +59,12 @@ function hostedOrBlacksmith(hostedLabel: string): string {
   }
   if (hostedLabel === "ubuntu-24.04-arm") {
     return "(?:ubuntu-24\\.04-arm|blacksmith-\\d+vcpu-ubuntu-2404-arm)";
+  }
+  if (hostedLabel === "macos-15") {
+    return "(?:macos-15|blacksmith-(?:6|12)vcpu-macos-15)";
+  }
+  if (hostedLabel === "windows-2025") {
+    return "(?:windows-2025|blacksmith-\\d+vcpu-windows-2025)";
   }
   return escapeRegExp(hostedLabel);
 }
@@ -92,17 +98,17 @@ test("GitHub workflows use the current cache action", () => {
 });
 
 test("GitHub workflows declare the expected cross-platform runner matrix", () => {
-  // We use Blacksmith-hosted Linux runners for speed and intentionally let
-  // any `blacksmith-Nvcpu-ubuntu-2404[-arm]` SKU pass — bumping vCPU shouldn't
-  // need a test change. macOS and Windows continue to use GitHub-hosted
-  // runners because Blacksmith does not offer equivalent SKUs.
+  // We use Blacksmith-hosted runners where compatible and intentionally let
+  // any matching vCPU SKU pass — bumping vCPU shouldn't need a test change.
+  // macOS Intel and Windows ARM still use GitHub-hosted runners because
+  // Blacksmith does not offer equivalent SKUs.
   //
   // We only validate matrix `host:` / `runner:` values here; `runs-on:` is
   // usually templated (`${{ matrix.settings.host }}` or the conditional
   // `github.event_name == 'pull_request' && 'ubuntu-latest' || 'ubuntu-24.04'`)
   // and is asserted shape-by-shape further down.
   const allowedRunnerPattern =
-    /^(?:ubuntu-(?:latest|24\.04)(?:-arm)?|blacksmith-\d+vcpu-ubuntu-2404(?:-arm)?|macos-15(?:-intel)?|windows-(?:2025|11-arm))$/;
+    /^(?:ubuntu-(?:latest|24\.04)(?:-arm)?|blacksmith-\d+vcpu-ubuntu-2404(?:-arm)?|macos-15(?:-intel)?|blacksmith-(?:6|12)vcpu-macos-15|windows-(?:2025|11-arm)|blacksmith-\d+vcpu-windows-2025)$/;
   const matrixRunnerPattern = /(?:runner|host):\s*([A-Za-z0-9._-]+)/g;
   const violations: string[] = [];
 
@@ -126,11 +132,11 @@ test("GitHub workflows declare the expected cross-platform runner matrix", () =>
   // (or temporarily reverting to GitHub-hosted) doesn't churn this test.
   assert.match(checkWorkflow, new RegExp(`runs-on:\\s*${hostedOrBlacksmith("ubuntu-24.04")}`));
   assert.match(nativeWorkflow, new RegExp(`runner:\\s*${hostedOrBlacksmith("ubuntu-24.04-arm")}`));
-  assert.match(nativeWorkflow, /runner:\s*macos-15/);
-  assert.match(nativeWorkflow, /runner:\s*windows-2025/);
+  assert.match(nativeWorkflow, new RegExp(`runner:\\s*${hostedOrBlacksmith("macos-15")}`));
+  assert.match(nativeWorkflow, new RegExp(`runner:\\s*${hostedOrBlacksmith("windows-2025")}`));
   assert.match(releaseWorkflow, new RegExp(`host:\\s*${hostedOrBlacksmith("ubuntu-24.04-arm")}`));
-  assert.match(releaseWorkflow, /host:\s*macos-15/);
-  assert.match(releaseWorkflow, /host:\s*windows-2025/);
+  assert.match(releaseWorkflow, new RegExp(`host:\\s*${hostedOrBlacksmith("macos-15")}`));
+  assert.match(releaseWorkflow, new RegExp(`host:\\s*${hostedOrBlacksmith("windows-2025")}`));
 });
 
 test("GitHub workflows use Node 24-compatible artifact downloads", () => {
@@ -279,6 +285,7 @@ test("release workflow jobs cap runtime with explicit timeouts", () => {
     ["build-editor-extensions", 30],
     ["release-vscode-extension", 15],
     ["build-release-packages", 45],
+    ["build-wasm-package", 30],
     ["build-native-all", 90],
     ["smoke-release-packages", 30],
     ["release-npm-native", 30],
@@ -598,6 +605,12 @@ test("WASM build jobs install MoonBit before invoking moon run", () => {
       moonRun:
         "run: moon run --target native - -- npm/vize-wasm playground/src/wasm < tools/moon/scripts/github/build_vitrine_wasm.mbtx",
     },
+    {
+      workflowName: "release.yml",
+      jobName: "build-wasm-package",
+      moonRun:
+        "run: moon run --target native - -- < tools/moon/scripts/build_vize_wasm_package.mbtx",
+    },
   ] as const;
 
   for (const { workflowName, jobName, moonRun } of cases) {
@@ -692,7 +705,8 @@ test("release workflow publishes npm packages through Trusted Publishing only", 
 
   for (const jobName of npmPublishJobs) {
     const job = workflowJobBody(workflow, jobName);
-    assert.match(job, new RegExp(`runs-on:\\s*${hostedOrBlacksmith("ubuntu-24.04")}`));
+    assert.match(job, /runs-on:\s*ubuntu-24\.04\b/);
+    assert.doesNotMatch(job, /runs-on:\s*blacksmith-/);
     assert.match(job, /environment:\s*npm/);
     assert.match(job, /id-token:\s*write/);
     assert.match(job, /--provenance/);
@@ -716,11 +730,13 @@ test("release workflow publishes npm packages from package-specific artifacts", 
     "release-package-rspack-vize-plugin",
     "release-package-musea-nuxt",
     "release-package-nuxt",
+    "release-package-vize-wasm",
   ]) {
     assert.match(workflow, new RegExp(`name:\\s*${artifactName}`));
   }
 
   const downloadTargets = [
+    ["release-npm-wasm", "release-package-vize-wasm", "npm/vize-wasm"],
     ["release-npm-vite-plugin", "release-package-vite-plugin-vize", "npm/vite-plugin-vize"],
     ["release-npm-oxlint-plugin", "release-package-oxlint-plugin-vize", "npm/oxlint-plugin-vize"],
     ["release-npm-unplugin", "release-package-unplugin-vize", "npm/unplugin-vize"],
@@ -747,21 +763,29 @@ test("release workflow publishes npm packages from package-specific artifacts", 
 
 test("release workflow smokes the wasm package wrapper before publishing", () => {
   const workflow = readRepoFile(".github", "workflows", "release.yml");
-  const job = workflowJobBody(workflow, "release-npm-wasm");
+  const buildJob = workflowJobBody(workflow, "build-wasm-package");
+  const publishJob = workflowJobBody(workflow, "release-npm-wasm");
 
-  assert.match(job, /npm\/vize-wasm\/index\.js/);
-  assert.match(job, /npm\/vize-wasm\/index\.d\.ts/);
-  assert.match(job, /tools\/moon\/scripts\/build_vize_wasm_package\.mbtx/);
+  assert.match(buildJob, /runs-on:\s*blacksmith-\d+vcpu-ubuntu-2404/);
+  assert.match(buildJob, /npm\/vize-wasm\/index\.js/);
+  assert.match(buildJob, /npm\/vize-wasm\/index\.d\.ts/);
+  assert.match(buildJob, /tools\/moon\/scripts\/build_vize_wasm_package\.mbtx/);
+  assert.match(buildJob, /name:\s*release-package-vize-wasm/);
+  assert.match(publishJob, /needs:\s*build-wasm-package/);
+  assert.match(publishJob, /name:\s*release-package-vize-wasm/);
+  assert.match(publishJob, /path:\s*npm\/vize-wasm/);
 
-  const setupNode = job.indexOf("name: Setup Vite+ and Node.js");
-  const smoke = job.indexOf("name: Smoke @vizejs/wasm package");
-  const publish = job.indexOf("name: Publish @vizejs/wasm");
+  const setupNode = publishJob.indexOf("name: Setup Vite+ and Node.js");
+  const download = publishJob.indexOf("name: Download prebuilt WASM package");
+  const smoke = publishJob.indexOf("name: Smoke @vizejs/wasm package");
+  const publish = publishJob.indexOf("name: Publish @vizejs/wasm");
 
   assert.notEqual(setupNode, -1);
+  assert.notEqual(download, -1);
   assert.notEqual(smoke, -1);
   assert.notEqual(publish, -1);
-  assert.ok(setupNode < smoke && smoke < publish);
-  assert.match(job, /node tools\/npm\/smoke-wasm-package\.mjs npm\/vize-wasm/);
+  assert.ok(setupNode < download && download < smoke && smoke < publish);
+  assert.match(publishJob, /node tools\/npm\/smoke-wasm-package\.mjs npm\/vize-wasm/);
 });
 
 test("release workflow creates GitHub Releases only after registry publishing succeeds", () => {
@@ -850,8 +874,8 @@ test("native smoke workflow covers host platforms before release tags", () => {
     [hostedOrBlacksmith("ubuntu-24.04"), "linux-x64-gnu"],
     [hostedOrBlacksmith("ubuntu-24.04-arm"), "linux-arm64-gnu"],
     ["macos-15-intel", "darwin-x64"],
-    ["macos-15", "darwin-arm64"],
-    ["windows-2025", "win32-x64-msvc"],
+    [hostedOrBlacksmith("macos-15"), "darwin-arm64"],
+    [hostedOrBlacksmith("windows-2025"), "win32-x64-msvc"],
     ["windows-11-arm", "win32-arm64-msvc"],
   ] as const) {
     assert.match(job, new RegExp(`runner:\\s*${runner}[\\s\\S]*target:\\s*${target}`));
@@ -870,8 +894,8 @@ test("native smoke workflow fresh-installs runtime tarballs across supported tar
     [hostedOrBlacksmith("ubuntu-24.04"), "linux-x64-gnu"],
     [hostedOrBlacksmith("ubuntu-24.04-arm"), "linux-arm64-gnu"],
     ["macos-15-intel", "darwin-x64"],
-    ["macos-15", "darwin-arm64"],
-    ["windows-2025", "win32-x64-msvc"],
+    [hostedOrBlacksmith("macos-15"), "darwin-arm64"],
+    [hostedOrBlacksmith("windows-2025"), "win32-x64-msvc"],
     ["windows-11-arm", "win32-arm64-msvc"],
   ] as const) {
     assert.match(job, new RegExp(`runner:\\s*${runner}[\\s\\S]*target:\\s*${target}`));
@@ -898,11 +922,11 @@ test("release workflow builds native targets on MoonBit-supported runners", () =
   );
 
   for (const [host, target] of [
-    ["macos-15", "x86_64-apple-darwin"],
-    ["macos-15", "aarch64-apple-darwin"],
+    [hostedOrBlacksmith("macos-15"), "x86_64-apple-darwin"],
+    [hostedOrBlacksmith("macos-15"), "aarch64-apple-darwin"],
     [hostedOrBlacksmith("ubuntu-24.04"), "x86_64-unknown-linux-gnu"],
     [hostedOrBlacksmith("ubuntu-24.04-arm"), "aarch64-unknown-linux-gnu"],
-    ["windows-2025", "x86_64-pc-windows-msvc"],
+    [hostedOrBlacksmith("windows-2025"), "x86_64-pc-windows-msvc"],
     ["windows-11-arm", "aarch64-pc-windows-msvc"],
   ] as const) {
     assert.match(job, new RegExp(`host:\\s*${host}[\\s\\S]*target:\\s*${target}`));


### PR DESCRIPTION
## Summary
- move compatible release and native-smoke macOS/Windows jobs to Blacksmith runners
- keep npm provenance publish jobs on GitHub-hosted runners and split WASM build so only publish runs there
- fix Nix flake evaluation by allowing and pinning the Blacksmith CLI package

## Verification
- node --test tests/tooling/github-workflows.test.ts
- node --test tests/tooling/moonbit-publish.test.ts
- actrun lint .github/workflows/check.yml
- actrun workflow run .github/workflows/check.yml --job nix-flake --trigger push --dry-run --include-dirty
- nix eval .#checks.x86_64-linux.shell.drvPath
- nix flake check --no-build
- pnpm exec oxfmt --check tests/tooling/github-workflows.test.ts
- nix fmt -- --check flake.nix
- ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "#{f}: ok" }' .github/workflows/release.yml .github/workflows/native-smoke.yml
- go run github.com/rhysd/actionlint/cmd/actionlint@latest -ignore 'label "blacksmith-[^"]+" is unknown' .github/workflows/release.yml .github/workflows/native-smoke.yml .github/workflows/check.yml

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/780"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782801082&installation_id=136613492&pr_number=780&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F780&signature=67de0b1507488745f14370821f7eac1dfa1c4328e978bda6d4dff46efcb4e7ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->