### PR TITLE
ci: fix windows arm release build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,11 @@ jobs:
           - host: blacksmith-32vcpu-windows-2025
             target: x86_64-pc-windows-msvc
             archive: vize-x86_64-pc-windows-msvc.zip
-          - host: blacksmith-32vcpu-windows-2025
+          # Blacksmith Windows x64 images currently expose x64 MSVC SDK libs
+          # after setup-moonbit's amd64 toolchain setup, which breaks ARM64
+          # linking with rust-lld. Keep this cross build on the known-good
+          # GitHub-hosted image until setup can select amd64_arm64 per target.
+          - host: windows-2025
             target: aarch64-pc-windows-msvc
             archive: vize-aarch64-pc-windows-msvc.zip
           - host: blacksmith-32vcpu-ubuntu-2404

--- a/tests/tooling/github-workflows.test.ts
+++ b/tests/tooling/github-workflows.test.ts
@@ -933,6 +933,21 @@ test("release workflow builds native targets on MoonBit-supported runners", () =
   }
 });
 
+test("release workflow keeps the Windows ARM64 CLI cross build on a compatible hosted runner", () => {
+  const workflow = readRepoFile(".github", "workflows", "release.yml");
+  const job = workflowJobBody(workflow, "build-cli");
+
+  assert.match(
+    job,
+    /host:\s*windows-2025\s*\n\s*target:\s*aarch64-pc-windows-msvc/,
+    "Blacksmith Windows x64 images expose x64 MSVC SDK libs after setup-moonbit, which breaks ARM64 linking",
+  );
+  assert.doesNotMatch(
+    job,
+    /host:\s*blacksmith-\d+vcpu-windows-2025\s*\n\s*target:\s*aarch64-pc-windows-msvc/,
+  );
+});
+
 test("release workflow bundles fresco-native binaries into the root package instead of publishing platform packages", () => {
   const workflow = readRepoFile(".github", "workflows", "release.yml");
   const frescoJobStart = workflow.indexOf("\n  release-npm-fresco-native:\n");


### PR DESCRIPTION
## Summary
- keep the Windows ARM64 CLI release cross-build on GitHub-hosted windows-2025
- document the Blacksmith Windows x64 MSVC SDK mismatch that breaks ARM64 rust-lld linking
- add a workflow-shape regression test for this runner choice

## Verification
- node --test tests/tooling/github-workflows.test.ts
- pnpm exec oxfmt --check tests/tooling/github-workflows.test.ts
- ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "#{f}: ok" }' .github/workflows/release.yml
- go run github.com/rhysd/actionlint/cmd/actionlint@latest -ignore 'label "blacksmith-[^"]+" is unknown' .github/workflows/release.yml

## CI failure
- Release v0.147.0 failed at Build CLI - aarch64-pc-windows-msvc because rust-lld picked x64 Windows SDK import libs on Blacksmith Windows x64.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/781"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782804565&installation_id=136613492&pr_number=781&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F781&signature=71a59bdad58fdc7e80c8a7596691492b04a4eef36fa7fb59c7c5581852aafbea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->