### PR TITLE
perf(cli): make inspector globs ignore-aware

### DIFF
--- a/crates/vize/src/commands/inspector.rs
+++ b/crates/vize/src/commands/inspector.rs
@@ -6,7 +6,7 @@
 //! Vize WASM output.
 
 use clap::{Args, ValueEnum};
-use ignore::Walk;
+use ignore::WalkBuilder;
 use std::{
     collections::BTreeSet,
     fs,
@@ -141,14 +141,17 @@ fn collect_files(patterns: &[String], max_files: Option<usize>) -> Vec<PathBuf> 
         }
 
         if path.is_dir() {
-            for entry in Walk::new(path).flatten() {
-                let entry_path = entry.path();
-                if entry_path.is_file() && is_vue_file(entry_path) {
-                    files.insert(entry_path.to_path_buf());
-                    if max_files.is_some_and(|limit| files.len() >= limit) {
-                        return files.into_iter().collect();
-                    }
-                }
+            if collect_walked_vue_files(path, &mut files, max_files) {
+                return files.into_iter().collect();
+            }
+            continue;
+        }
+
+        if let Some(root) = recursive_vue_glob_root(pattern)
+            && root.exists()
+        {
+            if collect_walked_vue_files(&root, &mut files, max_files) {
+                return files.into_iter().collect();
             }
             continue;
         }
@@ -178,6 +181,44 @@ fn collect_files(patterns: &[String], max_files: Option<usize>) -> Vec<PathBuf> 
     files
 }
 
+fn collect_walked_vue_files(
+    root: &Path,
+    files: &mut BTreeSet<PathBuf>,
+    max_files: Option<usize>,
+) -> bool {
+    for entry in WalkBuilder::new(root).require_git(false).build().flatten() {
+        let entry_path = entry.path();
+        if entry_path.is_file() && is_vue_file(entry_path) {
+            files.insert(entry_path.to_path_buf());
+            if max_files.is_some_and(|limit| files.len() >= limit) {
+                return true;
+            }
+        }
+    }
+
+    false
+}
+
+fn recursive_vue_glob_root(pattern: &str) -> Option<PathBuf> {
+    let normalized = pattern.replace('\\', "/");
+    if normalized == "**/*.vue" || normalized == "./**/*.vue" {
+        return Some(PathBuf::from("."));
+    }
+
+    let root = normalized.strip_suffix("/**/*.vue")?;
+    if root.is_empty() || contains_glob_meta(root) {
+        return None;
+    }
+
+    Some(PathBuf::from(root))
+}
+
+fn contains_glob_meta(value: &str) -> bool {
+    value
+        .bytes()
+        .any(|byte| matches!(byte, b'*' | b'?' | b'[' | b']' | b'{' | b'}'))
+}
+
 fn is_vue_file(path: &Path) -> bool {
     path.extension().is_some_and(|extension| extension == "vue")
 }
@@ -193,6 +234,7 @@ fn collect_source_files(files: &[PathBuf]) -> Vec<curator_inspector::InspectorSo
             });
             let display_path = path
                 .strip_prefix(&current_dir)
+                .or_else(|_| path.strip_prefix("."))
                 .unwrap_or(path)
                 .to_string_lossy()
                 .replace('\\', "/")

--- a/crates/vize/tests/inspector_cli.rs
+++ b/crates/vize/tests/inspector_cli.rs
@@ -103,6 +103,49 @@ fn inspector_url_supports_batch_payloads() {
 }
 
 #[test]
+fn inspector_default_glob_respects_gitignore() {
+    let project = tempfile::tempdir().unwrap();
+    let src = project.path().join("src");
+    let ignored = project.path().join("ignored");
+    fs::create_dir_all(&src).unwrap();
+    fs::create_dir_all(&ignored).unwrap();
+    fs::write(project.path().join(".gitignore"), "ignored/\n").unwrap();
+    fs::write(
+        src.join("App.vue"),
+        "<template><div>included</div></template>\n",
+    )
+    .unwrap();
+    fs::write(
+        ignored.join("Ignored.vue"),
+        "<template><div>ignored</div></template>\n",
+    )
+    .unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(project.path())
+        .args(["inspector", "--format", "json"])
+        .output()
+        .unwrap();
+
+    let stdout = std::string::String::from_utf8(output.stdout).unwrap();
+    let stderr = std::string::String::from_utf8(output.stderr).unwrap();
+    assert!(
+        output.status.success(),
+        "stdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+
+    let json: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    let files = json["files"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|file| file["path"].as_str().unwrap())
+        .collect::<Vec<_>>();
+
+    assert_eq!(files, ["src/App.vue"]);
+}
+
+#[test]
 fn inspector_agent_outputs_report_with_graph() {
     let project = tempfile::tempdir().unwrap();
     let src = project.path().join("src");


### PR DESCRIPTION
## Summary
- route recursive Vue inspector globs through the ignore-aware walker
- keep generated and ignored fixture trees out of default inspector batches
- add a CLI regression for `.gitignore` handling

## Verification
- `cargo fmt --all -- --check`
- `cargo test -p vize --test inspector_cli`
- `cargo run -q -p vize -- inspector 'tests/_fixtures/_git/elk/app/**/*.vue' 'tests/_fixtures/_git/misskey/packages/frontend/src/**/*.vue' 'tests/_fixtures/_git/npmx.dev/app/**/*.vue' 'tests/_fixtures/_git/vuefes-2025/app/**/*.vue' 'tests/_fixtures/_git/ant-design-vue/components/**/*.vue' 'tests/_fixtures/_git/ant-design-vue/site/**/*.vue' 'tests/_fixtures/_git/nuxt-ui/src/**/*.vue' 'tests/_fixtures/_git/reka-ui/packages/**/*.vue' 'tests/_fixtures/_projects/compiler-macros/src/**/*.vue' 'tests/_fixtures/_projects/style-preprocessors/src/**/*.vue' 'tests/_fixtures/_projects/typecheck-errors/src/**/*.vue' 'tests/_fixtures/_projects/ecosystem-products/src/**/*.vue' --format agent --output target/inspect-test-targets.agent.json` (2691 files)
- `actrun lint .github/workflows/check.yml`
- `actrun workflow run .github/workflows/check.yml --dry-run`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/783"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782807167&installation_id=136613492&pr_number=783&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F783&signature=59633a5a2748a1e1102803592098b527136811f25be93e19cb9a308c16ba6c2d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->