### PR TITLE
perf(cli): skip unchanged schema writes

### DIFF
--- a/crates/vize/src/config.rs
+++ b/crates/vize/src/config.rs
@@ -1,6 +1,6 @@
 //! Shared config helpers for the CLI.
 
-use std::path::Path;
+use std::{fs, path::Path};
 
 pub use vize_carton::config::*;
 
@@ -13,9 +13,20 @@ pub fn write_schema(dir: Option<&Path>) {
         .map(Path::to_path_buf)
         .unwrap_or_else(|| std::env::current_dir().unwrap_or_default());
     let schema_dir = base.join("node_modules/.vize");
-    if std::fs::create_dir_all(&schema_dir).is_ok() {
+    if fs::create_dir_all(&schema_dir).is_ok() {
         let schema_path = schema_dir.join("vize.config.schema.json");
-        let _ = std::fs::write(&schema_path, VIZE_CONFIG_SCHEMA);
+        if schema_needs_write(&schema_path) {
+            let _ = fs::write(&schema_path, VIZE_CONFIG_SCHEMA);
+        }
+    }
+}
+
+fn schema_needs_write(path: &Path) -> bool {
+    match fs::metadata(path) {
+        Ok(metadata) if metadata.len() == VIZE_CONFIG_SCHEMA.len() as u64 => {
+            fs::read_to_string(path).map_or(true, |current| current.as_str() != VIZE_CONFIG_SCHEMA)
+        }
+        Ok(_) | Err(_) => true,
     }
 }
 
@@ -63,5 +74,50 @@ pub fn to_glyph_format_options(config: &FormatterConfig) -> vize_glyph::FormatOp
         attribute_groups: config.attribute_groups.clone(),
         normalize_directive_shorthands: config.normalize_directive_shorthands,
         sort_blocks: config.sort_blocks,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn schema_needs_write_when_missing() {
+        let project = tempfile::tempdir().unwrap();
+
+        assert!(schema_needs_write(
+            &project.path().join("vize.config.schema.json")
+        ));
+    }
+
+    #[test]
+    fn schema_needs_write_when_stale() {
+        let project = tempfile::tempdir().unwrap();
+        let schema_path = project.path().join("vize.config.schema.json");
+        fs::write(&schema_path, "{}").unwrap();
+
+        assert!(schema_needs_write(&schema_path));
+    }
+
+    #[test]
+    fn schema_write_is_skipped_when_current() {
+        let project = tempfile::tempdir().unwrap();
+        let schema_path = project.path().join("vize.config.schema.json");
+        fs::write(&schema_path, VIZE_CONFIG_SCHEMA).unwrap();
+
+        assert!(!schema_needs_write(&schema_path));
+    }
+
+    #[test]
+    fn write_schema_refreshes_stale_schema() {
+        let project = tempfile::tempdir().unwrap();
+        let schema_dir = project.path().join("node_modules/.vize");
+        fs::create_dir_all(&schema_dir).unwrap();
+        let schema_path = schema_dir.join("vize.config.schema.json");
+        fs::write(&schema_path, "{}").unwrap();
+
+        write_schema(Some(project.path()));
+
+        assert_eq!(fs::read_to_string(schema_path).unwrap(), VIZE_CONFIG_SCHEMA);
     }
 }


### PR DESCRIPTION
## Summary
- avoid rewriting `node_modules/.vize/vize.config.schema.json` when it already matches the bundled schema
- keep stale and missing schema refresh behavior unchanged
- add focused unit coverage for the write decision

## Verification
- `cargo fmt --all -- --check`
- `cargo test -p vize config::tests`
- `actrun lint .github/workflows/check.yml`
- `actrun workflow run .github/workflows/check.yml --dry-run`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/784"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782807316&installation_id=136613492&pr_number=784&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F784&signature=e6d4ecf87f0fd31468e58962d55d58dac60881030dcdf08076610f5a3c2af4a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->