### PR TITLE
fix(compiler): preserve defineEmits spacing

### DIFF
--- a/crates/vize_atelier_sfc/src/compile_script/inline/compiler/setup_emit.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/inline/compiler/setup_emit.rs
@@ -112,6 +112,9 @@ pub(super) fn emit_setup_body(
         output.extend_from_slice(b"const ");
         output.extend_from_slice(binding_name.as_bytes());
         output.extend_from_slice(b" = __emit\n");
+        if has_blank_line_after_macro(ctx.source.as_str(), emits_macro.end) {
+            output.push(b'\n');
+        }
     }
 
     // Props binding: const props = __props
@@ -196,5 +199,61 @@ pub(super) fn emit_setup_body(
             output.extend_from_slice(b"\n");
         }
         output.extend_from_slice(b"}))\n");
+    }
+}
+
+fn has_blank_line_after_macro(source: &str, macro_end: usize) -> bool {
+    let Some(mut rest) = source.get(macro_end..) else {
+        return false;
+    };
+
+    rest = rest.trim_start_matches([' ', '\t']);
+    if let Some(after_semicolon) = rest.strip_prefix(';') {
+        rest = after_semicolon.trim_start_matches([' ', '\t']);
+    }
+
+    let mut newline_count = 0usize;
+    for byte in rest.bytes() {
+        match byte {
+            b'\n' => {
+                newline_count += 1;
+                if newline_count >= 2 {
+                    return true;
+                }
+            }
+            b'\r' | b' ' | b'\t' => {}
+            _ => return false,
+        }
+    }
+
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::has_blank_line_after_macro;
+
+    #[test]
+    fn detects_blank_line_after_macro_call() {
+        let source = "const emit = defineEmits<{ change: [] }>();\n\nfunction call() {}";
+        let macro_end = source.find(";\n").unwrap();
+
+        assert!(has_blank_line_after_macro(source, macro_end));
+    }
+
+    #[test]
+    fn ignores_single_newline_after_macro_call() {
+        let source = "const emit = defineEmits(['change'])\nfunction call() {}";
+        let macro_end = source.find('\n').unwrap();
+
+        assert!(!has_blank_line_after_macro(source, macro_end));
+    }
+
+    #[test]
+    fn ignores_non_whitespace_after_macro_call() {
+        let source = "const emit = defineEmits(['change']); // comment\nfunction call() {}";
+        let macro_end = source.find(';').unwrap();
+
+        assert!(!has_blank_line_after_macro(source, macro_end));
     }
 }

--- a/tests/expected/sfc/patches.snap
+++ b/tests/expected/sfc/patches.snap
@@ -2131,3 +2131,42 @@ return (_ctx, _cache) => {
 }
 
 }
+===
+name: defineEmits binding preserves blank line before setup body
+options: sfc
+--- INPUT ---
+<script setup lang="ts">
+const emit = defineEmits<{
+  change: [value: string]
+}>()
+
+function handleClick() {
+  emit('change', 'hello')
+}
+</script>
+
+<template>
+  <button @click="handleClick">Click</button>
+</template>
+--- OUTPUT ---
+import { defineComponent as _defineComponent } from 'vue'
+import { openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+
+export default /*@__PURE__*/_defineComponent({
+  __name: 'test',
+  emits: ["change"],
+  setup(__props, { emit: __emit }) {
+
+const emit = __emit
+
+function handleClick() {
+  emit('change', 'hello')
+}
+
+return (_ctx: any,_cache: any) => {
+  return (_openBlock(), _createElementBlock("button", { onClick: handleClick }, "Click"))
+}
+}
+
+})

--- a/tests/fixtures/sfc/patches.toml
+++ b/tests/fixtures/sfc/patches.toml
@@ -1033,3 +1033,21 @@ import MyComponent from './MyComponent.vue'
   </div>
 </template>
 """
+
+[[cases]]
+name = "defineEmits binding preserves blank line before setup body"
+input = """
+<script setup lang="ts">
+const emit = defineEmits<{
+  change: [value: string]
+}>()
+
+function handleClick() {
+  emit('change', 'hello')
+}
+</script>
+
+<template>
+  <button @click="handleClick">Click</button>
+</template>
+"""

--- a/tests/snapshots/sfc/js/patches__defineemits_binding_preserves_blank_line_before_setup_body.snap
+++ b/tests/snapshots/sfc/js/patches__defineemits_binding_preserves_blank_line_before_setup_body.snap
@@ -1,0 +1,18 @@
+---
+source: crates/vize_atelier_sfc/src/snapshot_tests.rs
+expression: js_output.as_str()
+---
+import { openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue";
+export default {
+  __name: "test",
+  emits: ["change"],
+  setup(__props, { emit: __emit }) {
+    const emit = __emit;
+    function handleClick() {
+      emit("change", "hello");
+    }
+    return (_ctx, _cache) => {
+      return _openBlock(), _createElementBlock("button", { onClick: handleClick }, "Click");
+    };
+  }
+};

--- a/tests/snapshots/sfc/ts/patches__defineemits_binding_preserves_blank_line_before_setup_body.snap
+++ b/tests/snapshots/sfc/ts/patches__defineemits_binding_preserves_blank_line_before_setup_body.snap
@@ -1,0 +1,25 @@
+---
+source: crates/vize_atelier_sfc/src/snapshot_tests.rs
+expression: ts_output.as_str()
+---
+import { defineComponent as _defineComponent } from 'vue'
+import { openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+
+export default /*@__PURE__*/_defineComponent({
+  __name: 'test',
+  emits: ["change"],
+  setup(__props, { emit: __emit }) {
+
+const emit = __emit
+
+function handleClick() {
+  emit('change', 'hello')
+}
+
+return (_ctx: any,_cache: any) => {
+  return (_openBlock(), _createElementBlock("button", { onClick: handleClick }, "Click"))
+}
+}
+
+})

--- a/tests/vize_test_runner/src/coverage.rs
+++ b/tests/vize_test_runner/src/coverage.rs
@@ -12,8 +12,8 @@ use vize_test_runner::{CompilerMode, run_fixture_tests};
 
 const MIN_VDOM_PASSED: usize = 439;
 const MIN_VAPOR_PASSED: usize = 104;
-const MIN_SFC_PASSED: usize = 165;
-const MIN_TOTAL_PASSED: usize = 708;
+const MIN_SFC_PASSED: usize = 166;
+const MIN_TOTAL_PASSED: usize = 709;
 
 // Known v1 alpha fixture debt. CI allows these exact failures so existing gaps
 // do not block unrelated work, but any new failure or pass-count regression


### PR DESCRIPTION
## Summary
- preserve a source blank line after an assigned defineEmits macro when emitting the __emit alias
- add focused SFC snapshots and fixture expectations for this upstream compiler spacing case
- cover the macro-gap detector for blank, single-line, and comment cases
- raise the fixture coverage budget to include the new passing case

## Verification
- `cargo fmt --all -- --check`
- `cargo test -p vize_atelier_sfc setup_emit::tests`
- `cargo test -p vize_atelier_sfc test_patches`
- `cargo run -p vize_test_runner --bin coverage`
- `cargo test -p vize_test_runner tracks_the_current_known_failure_budget`
- `git diff --check`
- `actrun lint .github/workflows/check.yml`
- `actrun workflow run .github/workflows/check.yml --dry-run`