### PR TITLE
fix(compiler): resolve src alias type imports

### DIFF
--- a/crates/vize_atelier_sfc/src/compile/tests.rs
+++ b/crates/vize_atelier_sfc/src/compile/tests.rs
@@ -20,6 +20,19 @@ fn fixtures_path() -> PathBuf {
         .join("imported_types")
 }
 
+fn temp_compile_project_dir(test_name: &str) -> PathBuf {
+    let nonce = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    std::env::temp_dir().join(format!(
+        "vize-sfc-compile-{}-{}-{}",
+        std::process::id(),
+        test_name,
+        nonce
+    ))
+}
+
 fn sfc_compile_snapshot(
     css_vars: &[std::borrow::Cow<'_, str>],
     result: &SfcCompileResult,
@@ -1277,6 +1290,97 @@ fn test_define_props_interface_extends_imported_type_alias() {
     let result = compile_sfc(&descriptor, opts).expect("Failed to compile SFC");
 
     insta::assert_snapshot!(result.code.as_str());
+}
+
+#[test]
+fn test_with_defaults_resolves_imported_vue_type_from_src_alias() {
+    let project = temp_compile_project_dir("with-defaults-src-alias");
+    let components = project.join("packages/frontend/src/components");
+    fs::create_dir_all(&components).unwrap();
+
+    fs::write(
+        components.join("MkPagination.vue"),
+        r#"<script lang="ts">
+export type MkPaginationOptions = {
+  autoLoad?: boolean;
+  direction?: 'up' | 'down' | 'both';
+  pullToRefresh?: boolean;
+  withControl?: boolean;
+  forceDisableInfiniteScroll?: boolean;
+};
+</script>"#,
+    )
+    .unwrap();
+
+    let source = r#"<template>
+  <MkPagination
+    :paginator="paginator"
+    :direction="direction"
+    :autoLoad="autoLoad"
+    :pullToRefresh="pullToRefresh"
+    :withControl="withControl"
+    :forceDisableInfiniteScroll="forceDisableInfiniteScroll"
+  />
+</template>
+
+<script setup lang="ts" generic="T">
+import type { MkPaginationOptions } from '@/components/MkPagination.vue';
+import MkPagination from '@/components/MkPagination.vue';
+
+const props = withDefaults(defineProps<MkPaginationOptions & {
+  paginator: T;
+  noGap?: boolean;
+}>(), {
+  autoLoad: true,
+  direction: 'down',
+  pullToRefresh: true,
+  withControl: true,
+  forceDisableInfiniteScroll: false,
+});
+</script>"#;
+
+    let descriptor = parse_sfc(source, SfcParseOptions::default()).expect("Failed to parse SFC");
+    let mut opts = SfcCompileOptions::default();
+    let fixture_path = components.join("MkNotesTimeline.vue");
+    opts.script.id = Some(fixture_path.to_string_lossy().as_ref().to_compact_string());
+
+    let result = compile_sfc(&descriptor, opts).expect("Failed to compile SFC");
+
+    assert!(
+        result.code.contains(
+            "autoLoad: {\n      type: Boolean,\n      required: false,\n      default: true\n    }"
+        ),
+        "{}",
+        result.code
+    );
+    assert!(
+        result.code.contains(
+            "direction: {\n      type: String,\n      required: false,\n      default: \"down\"\n    }"
+        ),
+        "{}",
+        result.code
+    );
+    assert!(
+        result.code.contains(
+            "pullToRefresh: {\n      type: Boolean,\n      required: false,\n      default: true\n    }"
+        ),
+        "{}",
+        result.code
+    );
+    assert!(
+        result.code.contains(
+            "withControl: {\n      type: Boolean,\n      required: false,\n      default: true\n    }"
+        ),
+        "{}",
+        result.code
+    );
+    assert!(
+        result.code.contains("forceDisableInfiniteScroll: {\n      type: Boolean,\n      required: false,\n      default: false\n    }"),
+        "{}",
+        result.code
+    );
+
+    let _ = fs::remove_dir_all(project);
 }
 
 #[test]

--- a/crates/vize_atelier_sfc/src/script/context/external_types.rs
+++ b/crates/vize_atelier_sfc/src/script/context/external_types.rs
@@ -125,6 +125,10 @@ impl ScriptCompileContext {
 }
 
 fn resolve_import_path(current_file: &Path, specifier: &str) -> Option<PathBuf> {
+    if let Some(alias_path) = resolve_at_src_alias(current_file, specifier) {
+        return Some(alias_path);
+    }
+
     if !specifier.starts_with('.') && !specifier.starts_with('/') {
         return None;
     }
@@ -136,6 +140,20 @@ fn resolve_import_path(current_file: &Path, specifier: &str) -> Option<PathBuf> 
         base_dir.join(specifier)
     };
 
+    resolve_candidate_path(candidate)
+}
+
+fn resolve_at_src_alias(current_file: &Path, specifier: &str) -> Option<PathBuf> {
+    let rest = specifier.strip_prefix("@/")?;
+    let src_dir = current_file
+        .parent()?
+        .ancestors()
+        .find(|path| path.file_name().is_some_and(|name| name == "src"))?;
+
+    resolve_candidate_path(src_dir.join(rest))
+}
+
+fn resolve_candidate_path(candidate: PathBuf) -> Option<PathBuf> {
     if candidate.is_file() {
         return canonicalize_or_original(candidate);
     }
@@ -171,4 +189,54 @@ fn canonicalize_or_original(path: PathBuf) -> Option<PathBuf> {
 
 fn path_key(path: &Path) -> String {
     path.to_string_lossy().as_ref().to_compact_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{resolve_at_src_alias, resolve_import_path};
+    use std::path::{Path, PathBuf};
+
+    fn temp_project_dir(test_name: &str) -> PathBuf {
+        let nonce = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::env::temp_dir().join(format!(
+            "vize-sfc-external-types-{}-{}-{}",
+            std::process::id(),
+            test_name,
+            nonce
+        ))
+    }
+
+    #[test]
+    fn resolves_at_alias_from_nearest_src_directory() {
+        let project = temp_project_dir("at-alias");
+        let components = project.join("packages/frontend/src/components");
+        std::fs::create_dir_all(&components).unwrap();
+        let target = components.join("Base.vue");
+        std::fs::write(&target, "").unwrap();
+
+        let current = components.join("Child.vue");
+        let resolved = resolve_at_src_alias(&current, "@/components/Base.vue");
+        let target = target.canonicalize().unwrap();
+
+        assert_eq!(resolved.as_deref(), Some(target.as_path()));
+
+        let _ = std::fs::remove_dir_all(project);
+    }
+
+    #[test]
+    fn ignores_at_alias_without_src_ancestor() {
+        let current = Path::new("/repo/packages/frontend/components/Child.vue");
+
+        assert!(resolve_at_src_alias(current, "@/components/Base.vue").is_none());
+    }
+
+    #[test]
+    fn leaves_non_at_alias_specifiers_to_existing_resolution() {
+        let current = Path::new("/repo/src/components/Child.vue");
+
+        assert!(resolve_import_path(current, "vue").is_none());
+    }
 }


### PR DESCRIPTION
## Summary

- Resolve `@/` SFC type imports from the nearest `src` ancestor while collecting external type declarations.
- Add regression coverage for Misskey-style `MkPaginationOptions` used with `withDefaults` so default runtime props are preserved.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p vize_atelier_sfc external_types`
- `cargo test -p vize_atelier_sfc test_with_defaults_resolves_imported_vue_type_from_src_alias`
- `cargo test -p vize_atelier_sfc`
- `cargo clippy -p vize_atelier_sfc -- -D warnings`
- `actrun lint .github/workflows/check.yml`
- `actrun workflow run .github/workflows/check.yml --dry-run --include-dirty`
- `actrun workflow run .github/workflows/check.yml --job fmt-rust --include-dirty --local --trust`

Fixes #782

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/786"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782809602&installation_id=136613492&pr_number=786&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F786&signature=1d44ee375960d13b5b4aac6ff20891e0a2a7bfdc93ec3d96c8e58d31116d3fd6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->