### PR TITLE
fix(formatter): preserve valid attribute quotes

### DIFF
--- a/crates/vize_glyph/src/template.rs
+++ b/crates/vize_glyph/src/template.rs
@@ -83,6 +83,22 @@ mod tests {
     }
 
     #[test]
+    fn directive_expression_double_quote_formatting_keeps_valid_attribute_quotes() {
+        let source = r#"<MfCheckbox @blur="form.validateField('agreeToPolicy')" />"#;
+        let mut options = FormatOptions::default();
+        options.single_quote = false;
+
+        let result = format_template_content(source, &options).unwrap();
+        assert_eq!(
+            result.as_str(),
+            r#"<MfCheckbox @blur='form.validateField("agreeToPolicy")' />"#
+        );
+
+        let formatted_again = format_template_content(&result, &options).unwrap();
+        assert_eq!(formatted_again, result);
+    }
+
+    #[test]
     fn test_directive_shorthand_v_bind() {
         let source = r#"<div v-bind:class="active"></div>"#;
         let options = FormatOptions::default();

--- a/crates/vize_glyph/src/template/attributes.rs
+++ b/crates/vize_glyph/src/template/attributes.rs
@@ -4,7 +4,7 @@
 //! according to Vue style guide order, plus rendering them back to strings.
 
 use crate::options::{AttributeSortOrder, FormatOptions};
-use vize_carton::String;
+use vize_carton::{String, ToCompactString};
 
 /// Parsed attribute with structured information for sorting and rendering.
 #[derive(Debug, Clone)]
@@ -142,7 +142,67 @@ pub(crate) fn attribute_priority(name: &str) -> u8 {
 #[allow(clippy::disallowed_macros)]
 pub(crate) fn render_attribute(attr: &ParsedAttribute) -> String {
     match &attr.value {
-        Some(value) => format!("{}=\"{}\"", attr.name, value).into(),
+        Some(value) => {
+            let quote = attribute_quote(value);
+            let value = escape_attribute_value(value, quote);
+            format!("{}={}{}{}", attr.name, quote, value, quote).into()
+        }
         None => attr.name.clone(),
+    }
+}
+
+fn attribute_quote(value: &str) -> char {
+    if value.contains('"') && !value.contains('\'') {
+        '\''
+    } else {
+        '"'
+    }
+}
+
+fn escape_attribute_value(value: &str, quote: char) -> String {
+    if !value.contains(quote) {
+        return value.to_compact_string();
+    }
+
+    let mut escaped = String::default();
+    for ch in value.chars() {
+        match (quote, ch) {
+            ('"', '"') => escaped.push_str("&quot;"),
+            ('\'', '\'') => escaped.push_str("&#39;"),
+            _ => escaped.push(ch),
+        }
+    }
+    escaped
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ParsedAttribute, render_attribute};
+
+    #[test]
+    fn render_attribute_uses_single_quotes_when_value_contains_double_quotes() {
+        let attr = ParsedAttribute {
+            name: "title".into(),
+            value: Some(r#"say "hello""#.into()),
+            priority: 0,
+            original_index: 0,
+        };
+
+        assert_eq!(render_attribute(&attr).as_str(), r#"title='say "hello"'"#);
+    }
+
+    #[test]
+    fn render_attribute_escapes_double_quotes_when_value_contains_both_quote_styles() {
+        let attr = ParsedAttribute {
+            name: "title".into(),
+            value: Some(r#"say "hello" and 'bye'"#.into()),
+            priority: 0,
+            original_index: 0,
+        };
+
+        assert_eq!(
+            render_attribute(&attr).as_str(),
+            r#"title="say &quot;hello&quot; and 'bye'""#
+        );
     }
 }


### PR DESCRIPTION
## Summary
- Choose a valid Vue template attribute quote when formatted directive expressions contain double quotes.
- Escape the selected quote when an attribute value contains both quote styles.
- Add regression coverage for the reported `@blur` formatting case and idempotency.

Fixes #788

## Validation
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test -p vize_glyph`
- `cargo clippy -p vize_glyph -- -D warnings`
- `cargo run -p vize -- fmt --write --no-config --single-quote=false <temp>/src/App.vue`
- `cargo run -p vize -- fmt --check --no-config --single-quote=false <temp>/src/App.vue`
- `actrun lint .github/workflows/check.yml`
- `actrun workflow run .github/workflows/check.yml --dry-run --include-dirty`
- `actrun workflow run .github/workflows/check.yml --job fmt-rust --include-dirty --local --trust`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/791"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782811456&installation_id=136613492&pr_number=791&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F791&signature=9b8e278724f5ee5d11f9835a286e741d332049c0d4a567b52f91ebc64d59a9e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->