### PR TITLE
fix(formatter): keep empty elements inline

### DIFF
--- a/crates/vize_glyph/src/snapshots/vize_glyph__template__tests__directive_shorthand_v_bind.snap
+++ b/crates/vize_glyph/src/snapshots/vize_glyph__template__tests__directive_shorthand_v_bind.snap
@@ -2,5 +2,4 @@
 source: crates/vize_glyph/src/template.rs
 expression: result.as_str()
 ---
-<div :class="active">
-</div>
+<div :class="active"></div>

--- a/crates/vize_glyph/src/snapshots/vize_glyph__template__tests__directive_shorthand_v_on.snap
+++ b/crates/vize_glyph/src/snapshots/vize_glyph__template__tests__directive_shorthand_v_on.snap
@@ -2,5 +2,4 @@
 source: crates/vize_glyph/src/template.rs
 expression: result.as_str()
 ---
-<div @click="handler">
-</div>
+<div @click="handler"></div>

--- a/crates/vize_glyph/src/snapshots/vize_glyph__template__tests__directive_shorthand_v_slot.snap
+++ b/crates/vize_glyph/src/snapshots/vize_glyph__template__tests__directive_shorthand_v_slot.snap
@@ -2,5 +2,4 @@
 source: crates/vize_glyph/src/template.rs
 expression: result.as_str()
 ---
-<template #default="props">
-</template>
+<template #default="props"></template>

--- a/crates/vize_glyph/src/snapshots/vize_glyph__template__tests__normalize_directive_shorthands_disabled.snap
+++ b/crates/vize_glyph/src/snapshots/vize_glyph__template__tests__normalize_directive_shorthands_disabled.snap
@@ -2,5 +2,4 @@
 source: crates/vize_glyph/src/template.rs
 expression: result.as_str()
 ---
-<div v-bind:class="active" v-on:click="handler">
-</div>
+<div v-bind:class="active" v-on:click="handler"></div>

--- a/crates/vize_glyph/src/template.rs
+++ b/crates/vize_glyph/src/template.rs
@@ -83,6 +83,31 @@ mod tests {
     }
 
     #[test]
+    fn test_empty_element_stays_inline() {
+        let source = "<div>\n</div>";
+        let options = FormatOptions::default();
+        let result = format_template_content(source, &options).unwrap();
+
+        assert_eq!(result.as_str(), "<div></div>");
+    }
+
+    #[test]
+    fn test_empty_element_with_multiline_attributes_closes_inline() {
+        let source = r#"<div class="container" id="main"></div>"#;
+        let mut options = FormatOptions::default();
+        options.single_attribute_per_line = true;
+        let result = format_template_content(source, &options).unwrap();
+
+        assert_eq!(
+            result.as_str(),
+            r#"<div
+  id="main"
+  class="container"
+></div>"#
+        );
+    }
+
+    #[test]
     fn directive_expression_double_quote_formatting_keeps_valid_attribute_quotes() {
         let source = r#"<MfCheckbox @blur="form.validateField('agreeToPolicy')" />"#;
         let mut options = FormatOptions::default();
@@ -377,7 +402,7 @@ mod tests {
 
         // 2 attrs <= 3 limit, no wrapping
         let lines: Vec<&str> = result.lines().collect();
-        assert_eq!(lines.len(), 2, "Should not wrap (div + closing)");
+        assert_eq!(lines.len(), 1, "Should keep the empty element inline");
     }
 
     #[test]

--- a/crates/vize_glyph/src/template/formatter.rs
+++ b/crates/vize_glyph/src/template/formatter.rs
@@ -148,6 +148,17 @@ impl<'a> TemplateFormatter<'a> {
 
                     if is_self_closing {
                         output.extend_from_slice(b" />");
+                    } else if !is_void_element_str(&tag_name)
+                        && let Some(closing_end_pos) =
+                            self.parse_immediate_empty_closing_tag(source, end_pos, &tag_name)
+                    {
+                        output.push(b'>');
+                        output.extend_from_slice(b"</");
+                        output.extend_from_slice(tag_name.as_bytes());
+                        output.push(b'>');
+                        output.extend_from_slice(self.newline);
+                        pos = closing_end_pos;
+                        continue;
                     } else {
                         output.push(b'>');
                         if !is_void_element_str(&tag_name) {
@@ -326,6 +337,32 @@ impl<'a> TemplateFormatter<'a> {
         }
 
         Some((tag_name, attrs, is_self_closing, pos))
+    }
+
+    /// Return the end of an immediately following matching closing tag.
+    fn parse_immediate_empty_closing_tag(
+        &self,
+        source: &[u8],
+        start: usize,
+        tag_name: &str,
+    ) -> Option<usize> {
+        let len = source.len();
+        let mut pos = start;
+
+        while pos < len && is_whitespace(source[pos]) {
+            pos += 1;
+        }
+
+        if pos + 1 >= len || source[pos] != b'<' || source[pos + 1] != b'/' {
+            return None;
+        }
+
+        let (closing_tag_name, end_pos) = parse_closing_tag(source, pos)?;
+        if closing_tag_name.as_str() == tag_name {
+            Some(end_pos)
+        } else {
+            None
+        }
     }
 
     /// Parse a single attribute: name, optional `="value"`.


### PR DESCRIPTION
## Summary
- Keep empty template elements on one line when the matching closing tag immediately follows the opening tag.
- Preserve multiline attribute indentation while closing empty elements inline.
- Update glyph snapshots for empty directive shorthand elements.

## Verification
- cargo fmt --all -- --check
- git diff --check
- cargo test -p vize_glyph
- cargo clippy -p vize_glyph -- -D warnings
- cargo run -p vize -- fmt --write --no-config /tmp/vize-glyph-empty.vue
- actrun lint .github/workflows/check.yml
- actrun workflow run .github/workflows/check.yml --dry-run --include-dirty
- actrun workflow run .github/workflows/check.yml --job fmt-rust --include-dirty --local --trust

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/793"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782812336&installation_id=136613492&pr_number=793&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F793&signature=99d2bc810dff4cfd7970eece92f666f069ffab30a11defe00d6ce056c9a1582d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->