### PR TITLE
fix(formatter): preserve multiline interpolation indentation

### DIFF
--- a/crates/vize_glyph/src/template.rs
+++ b/crates/vize_glyph/src/template.rs
@@ -108,6 +108,42 @@ mod tests {
     }
 
     #[test]
+    fn test_multiline_interpolation_keeps_expression_indented() {
+        let source = r#"<span>
+  {{
+    preview
+      ? [
+          preview.document.collectionLabel,
+          preview.document.publishedAt
+            ? formatDate(preview.document.publishedAt)
+            : "Frontmatter required",
+          isPreviewPending ? "Previewing" : "Ready",
+        ].join(" / ")
+      : (activePath ?? "No file selected")
+  }}
+</span>"#;
+        let options = FormatOptions::default();
+        let result = format_template_content(source, &options).unwrap();
+
+        assert_eq!(
+            result.as_str(),
+            r#"<span>
+  {{
+    preview
+      ? [
+          preview.document.collectionLabel,
+          preview.document.publishedAt
+            ? formatDate(preview.document.publishedAt)
+            : "Frontmatter required",
+          isPreviewPending ? "Previewing" : "Ready",
+        ].join(" / ")
+      : (activePath ?? "No file selected")
+  }}
+</span>"#
+        );
+    }
+
+    #[test]
     fn directive_expression_double_quote_formatting_keeps_valid_attribute_quotes() {
         let source = r#"<MfCheckbox @blur="form.validateField('agreeToPolicy')" />"#;
         let mut options = FormatOptions::default();

--- a/crates/vize_glyph/src/template/formatter.rs
+++ b/crates/vize_glyph/src/template/formatter.rs
@@ -55,6 +55,20 @@ impl<'a> TemplateFormatter<'a> {
                 continue;
             }
 
+            if pos + 1 < len
+                && source[pos] == b'{'
+                && source[pos + 1] == b'{'
+                && let Some((expr_start, expr_end, end_pos)) =
+                    parse_interpolation_range(source, pos)
+                && source[pos..end_pos].contains(&b'\n')
+            {
+                self.flush_text_buffer(&mut output, &mut line_buffer, depth);
+                let expr = std::str::from_utf8(&source[expr_start..expr_end]).unwrap_or("");
+                self.write_multiline_interpolation(&mut output, expr, depth);
+                pos = end_pos;
+                continue;
+            }
+
             // HTML comment <!-- ... -->
             if pos + 3 < len && &source[pos..pos + 4] == b"<!--" {
                 self.flush_text_buffer(&mut output, &mut line_buffer, depth);
@@ -226,6 +240,19 @@ impl<'a> TemplateFormatter<'a> {
         let formatted = format_interpolations(text, self.options);
         self.write_indented_line(output, formatted.as_bytes(), depth);
         buffer.clear();
+    }
+
+    fn write_multiline_interpolation(&self, output: &mut Vec<u8>, expr: &str, depth: usize) {
+        self.write_indented_line(output, b"{{", depth);
+
+        let formatted_expr = format_interpolation_expression(expr, self.options);
+        for line in formatted_expr.trim().lines() {
+            self.write_indent(output, depth + 1);
+            output.extend_from_slice(line.trim_end_matches('\r').as_bytes());
+            output.extend_from_slice(self.newline);
+        }
+
+        self.write_indented_line(output, b"}}", depth);
     }
 
     #[inline]
@@ -492,8 +519,7 @@ pub(crate) fn format_interpolations(text: &str, options: &FormatOptions) -> Stri
 
             if depth == 0 {
                 let expr = &text[expr_start..expr_end];
-                let formatted_expr = script::format_js_expression(expr, options)
-                    .unwrap_or_else(|| expr.trim().to_compact_string());
+                let formatted_expr = format_interpolation_expression(expr, options);
                 result.push_str("{{ ");
                 result.push_str(&formatted_expr);
                 result.push_str(" }}");
@@ -515,4 +541,36 @@ pub(crate) fn format_interpolations(text: &str, options: &FormatOptions) -> Stri
     }
 
     result
+}
+
+fn format_interpolation_expression(expr: &str, options: &FormatOptions) -> String {
+    script::format_js_expression(expr, options).unwrap_or_else(|| expr.trim().to_compact_string())
+}
+
+fn parse_interpolation_range(source: &[u8], start: usize) -> Option<(usize, usize, usize)> {
+    let len = source.len();
+    if start + 1 >= len || source[start] != b'{' || source[start + 1] != b'{' {
+        return None;
+    }
+
+    let expr_start = start + 2;
+    let mut depth = 1;
+    let mut pos = expr_start;
+
+    while pos + 1 < len {
+        if source[pos] == b'{' && source[pos + 1] == b'{' {
+            depth += 1;
+            pos += 2;
+        } else if source[pos] == b'}' && source[pos + 1] == b'}' {
+            depth -= 1;
+            if depth == 0 {
+                return Some((expr_start, pos, pos + 2));
+            }
+            pos += 2;
+        } else {
+            pos += 1;
+        }
+    }
+
+    None
 }


### PR DESCRIPTION
## Summary
- Parse multiline `{{ ... }}` blocks as a single interpolation instead of flushing each source line separately.
- Reformat the interpolation expression once and write it back at the template nesting depth.
- Add a regression test for a ternary/array expression inside an interpolation.

## Verification
- cargo fmt --all -- --check
- git diff --check origin/main..HEAD
- cargo test -p vize_glyph
- cargo clippy -p vize_glyph -- -D warnings
- cargo run -p vize -- fmt --write --no-config /tmp/vize-multiline-interpolation.vue
- actrun lint .github/workflows/check.yml
- actrun workflow run .github/workflows/check.yml --job fmt-rust --include-dirty --local --trust

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/794"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782812849&installation_id=136613492&pr_number=794&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F794&signature=4b8fe5d8367dc5637e519d314c2b82c81273b5064a45363088593b665ae39a4a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->