### PR TITLE
fix(vite): expose extracted css in manifest

### DIFF
--- a/npm/vite-plugin-vize/src/plugin/hmr.test.ts
+++ b/npm/vite-plugin-vize/src/plugin/hmr.test.ts
@@ -1,0 +1,84 @@
+import assert from "node:assert/strict";
+
+import type { VizePluginState } from "./state.ts";
+import { handleGenerateBundleHook, VIZE_COMPONENTS_CSS_FILE } from "./hmr.ts";
+
+function createState(): VizePluginState {
+  return {
+    extractCss: true,
+    collectedCss: new Map([
+      ["/src/App.vue", ".app { color: red; }"],
+      ["/src/Page.vue", ".page { color: blue; }"],
+    ]),
+    logger: {
+      log() {},
+    },
+  } as VizePluginState;
+}
+
+{
+  const emitted: Array<{ type: "asset"; fileName: string; source: string }> = [];
+  const existingCss = new Set(["assets/app.css"]);
+  const dynamicCss = new Set<string>();
+  const bundle = {
+    "assets/index.js": {
+      type: "chunk",
+      isEntry: true,
+      isDynamicEntry: false,
+      viteMetadata: {
+        importedCss: existingCss,
+      },
+    },
+    "assets/lazy.js": {
+      type: "chunk",
+      isEntry: false,
+      isDynamicEntry: true,
+      viteMetadata: {
+        importedCss: dynamicCss,
+      },
+    },
+    "assets/shared.js": {
+      type: "chunk",
+      isEntry: false,
+      isDynamicEntry: false,
+    },
+    "assets/logo.svg": {
+      type: "asset",
+    },
+  } satisfies Parameters<typeof handleGenerateBundleHook>[2];
+
+  handleGenerateBundleHook(createState(), (file) => emitted.push(file), bundle);
+
+  assert.deepEqual(emitted, [
+    {
+      type: "asset",
+      fileName: VIZE_COMPONENTS_CSS_FILE,
+      source: ".app { color: red; }\n\n.page { color: blue; }",
+    },
+  ]);
+  assert.equal(existingCss.has("assets/app.css"), true);
+  assert.equal(existingCss.has(VIZE_COMPONENTS_CSS_FILE), true);
+  assert.equal(dynamicCss.has(VIZE_COMPONENTS_CSS_FILE), true);
+  assert.equal("viteMetadata" in bundle["assets/shared.js"], false);
+}
+
+{
+  const emitted: Array<{ type: "asset"; fileName: string; source: string }> = [];
+  const bundle = {
+    "assets/index.js": {
+      type: "chunk",
+      isEntry: true,
+      isDynamicEntry: false,
+    },
+  } satisfies Parameters<typeof handleGenerateBundleHook>[2];
+
+  handleGenerateBundleHook(createState(), (file) => emitted.push(file), bundle);
+
+  const entryChunk = bundle["assets/index.js"] as {
+    viteMetadata?: { importedCss?: Set<string> };
+  };
+  assert.equal(emitted.length, 1);
+  assert.deepEqual(entryChunk.viteMetadata?.importedCss, new Set([VIZE_COMPONENTS_CSS_FILE]));
+}
+
+console.log("✅ vite-plugin-vize plugin hmr tests passed!");

--- a/npm/vite-plugin-vize/src/plugin/hmr.ts
+++ b/npm/vite-plugin-vize/src/plugin/hmr.ts
@@ -10,6 +10,23 @@ import { hasDelegatedStyles } from "../utils/index.ts";
 import { toVirtualId } from "../virtual.ts";
 import { resolveCssImports } from "../utils/css.ts";
 
+export const VIZE_COMPONENTS_CSS_FILE = "assets/vize-components.css";
+
+type GenerateBundleItem =
+  | {
+      type: "chunk";
+      isEntry?: boolean;
+      isDynamicEntry?: boolean;
+      viteMetadata?: {
+        importedCss?: Set<string>;
+      };
+    }
+  | {
+      type?: string;
+    };
+
+type GenerateBundle = Record<string, GenerateBundleItem>;
+
 export async function handleHotUpdateHook(
   state: VizePluginState,
   ctx: HmrContext,
@@ -116,6 +133,7 @@ export async function handleHotUpdateHook(
 export function handleGenerateBundleHook(
   state: VizePluginState,
   emitFile: (file: { type: "asset"; fileName: string; source: string }) => void,
+  bundle: GenerateBundle,
 ): void {
   if (!state.extractCss || state.collectedCss.size === 0) {
     return;
@@ -128,11 +146,24 @@ export function handleGenerateBundleHook(
   if (allCss.trim()) {
     emitFile({
       type: "asset",
-      fileName: "assets/vize-components.css",
+      fileName: VIZE_COMPONENTS_CSS_FILE,
       source: allCss,
     });
+    attachComponentsCssToEntryChunks(bundle);
     state.logger.log(
-      `Extracted CSS to assets/vize-components.css (${state.collectedCss.size} components)`,
+      `Extracted CSS to ${VIZE_COMPONENTS_CSS_FILE} (${state.collectedCss.size} components)`,
     );
+  }
+}
+
+function attachComponentsCssToEntryChunks(bundle: GenerateBundle): void {
+  for (const item of Object.values(bundle)) {
+    if (item.type !== "chunk" || (!item.isEntry && !item.isDynamicEntry)) {
+      continue;
+    }
+
+    item.viteMetadata ??= {};
+    item.viteMetadata.importedCss ??= new Set<string>();
+    item.viteMetadata.importedCss.add(VIZE_COMPONENTS_CSS_FILE);
   }
 }

--- a/npm/vite-plugin-vize/src/plugin/index.ts
+++ b/npm/vite-plugin-vize/src/plugin/index.ts
@@ -309,8 +309,8 @@ export function vize(options: VizeOptions = {}): Plugin[] {
       return handleHotUpdateHook(state, ctx);
     },
 
-    generateBundle() {
-      handleGenerateBundleHook(state, this.emitFile.bind(this));
+    generateBundle(_, bundle) {
+      handleGenerateBundleHook(state, this.emitFile.bind(this), bundle);
     },
 
     closeBundle() {

--- a/npm/vite-plugin-vize/src/test.ts
+++ b/npm/vite-plugin-vize/src/test.ts
@@ -2,6 +2,7 @@ import "./hmr.test.ts";
 import "./compiler.test.ts";
 import "./utils.test.ts";
 import "./plugin/compat.test.ts";
+import "./plugin/hmr.test.ts";
 import "./plugin/index.test.ts";
 import "./plugin/load.test.ts";
 import "./plugin/native.test.ts";


### PR DESCRIPTION
## Summary
- Add the extracted Vize component CSS asset to Vite entry and dynamic-entry chunk metadata.
- Preserve any existing imported CSS metadata so Vite's manifest can discover both files.
- Cover generated asset emission and manifest metadata wiring with a plugin hook test.

Fixes #787

## Verification
- pnpm --filter @vizejs/vite-plugin check
- node npm/vite-plugin-vize/src/plugin/hmr.test.ts
- git diff --check
- actrun lint .github/workflows/check.yml
- actrun workflow run .github/workflows/check.yml --dry-run --include-dirty

Note: local full `pnpm --filter @vizejs/vite-plugin test` reaches the new plugin hmr test, then fails later in the existing `plugin/resolve.test.ts` pnpm-isolated Vue runtime case. This PR does not touch resolver behavior; CI will run the full suite in the clean runner.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/795"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782813509&installation_id=136613492&pr_number=795&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F795&signature=585d65f2d5d72ea780a69d430aa457f0f552e9257743594168d150a5a601b1f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->