### PR TITLE
fix(sfc): trim generated code trailing newlines

### DIFF
--- a/crates/vize_atelier_sfc/src/compile.rs
+++ b/crates/vize_atelier_sfc/src/compile.rs
@@ -101,6 +101,12 @@ fn extract_descriptor_macro_artifacts(descriptor: &SfcDescriptor) -> Vec<SfcMacr
     artifacts
 }
 
+fn trim_trailing_newlines(code: &mut String) {
+    while code.ends_with('\n') {
+        code.pop();
+    }
+}
+
 /// Compile an SFC descriptor into JavaScript and CSS
 pub fn compile_sfc(
     descriptor: &SfcDescriptor,
@@ -255,6 +261,8 @@ fn compile_sfc_inner(
             css = Some(all_css);
         }
 
+        trim_trailing_newlines(&mut code);
+
         return Ok(SfcCompileResult {
             code,
             css,
@@ -399,6 +407,8 @@ fn compile_sfc_inner(
         if !all_css.is_empty() {
             css = Some(all_css);
         }
+
+        trim_trailing_newlines(&mut code);
 
         return Ok(SfcCompileResult {
             code,
@@ -695,6 +705,8 @@ fn compile_sfc_inner(
     if !all_css.is_empty() {
         css = Some(all_css);
     }
+
+    trim_trailing_newlines(&mut code);
 
     Ok(SfcCompileResult {
         code,

--- a/crates/vize_atelier_sfc/src/compile/tests.rs
+++ b/crates/vize_atelier_sfc/src/compile/tests.rs
@@ -66,6 +66,54 @@ fn test_extract_component_name() {
 }
 
 #[test]
+fn test_compile_sfc_trims_trailing_newline() {
+    let cases = [
+        (
+            "script setup",
+            r#"<script setup>
+const message = 'hello'
+</script>
+
+<template>
+  <p>{{ message }}</p>
+</template>"#,
+        ),
+        (
+            "normal script",
+            r#"<script>
+export default {
+  data() {
+    return { message: 'hello' }
+  }
+}
+</script>
+
+<template>
+  <p>{{ message }}</p>
+</template>"#,
+        ),
+        (
+            "template only",
+            r#"<template>
+  <p>hello</p>
+</template>"#,
+        ),
+    ];
+
+    for (name, source) in cases {
+        let descriptor =
+            parse_sfc(source, SfcParseOptions::default()).expect("Failed to parse SFC");
+        let result =
+            compile_sfc(&descriptor, SfcCompileOptions::default()).expect("Failed to compile SFC");
+        assert!(
+            !result.code.ends_with('\n'),
+            "{name} output should not end with a newline:\n{}",
+            result.code
+        );
+    }
+}
+
+#[test]
 fn test_v_model_on_component_in_sfc() {
     let source = r#"<script setup>
 import { ref } from 'vue'


### PR DESCRIPTION
## Summary
- trim final newlines from generated SFC JavaScript to match @vue/compiler-sfc output
- cover script setup, normal script, and template-only compile paths
- re-ran inspector compare across 2108 targeted fixture SFCs; changed files dropped 2108 -> 2107 and added diff lines dropped 128361 -> 126276

## Verification
- cargo fmt --all -- --check
- cargo test -p vize_atelier_sfc
- cargo test -p vize --test inspector_cli -- --nocapture
- cargo clippy --workspace -- -D warnings
- cargo build --profile ci -p vize
- vp run --filter './tests' test:check:fixtures\n- cargo test --workspace\n- actrun lint .github/workflows/check.yml\n- actrun workflow run .github/workflows/check.yml --dry-run --include-dirty

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/798"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782815335&installation_id=136613492&pr_number=798&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F798&signature=b2b98279479968d39e915aea2e503a104e4f13930bc5869d6c5184055d06a331"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->