### PR TITLE
fix(check): resolve JSON imports in TS inputs

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -354,10 +354,25 @@ jobs:
         with:
           node-version-file: ".node-version"
           run-install: false
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+
+      - name: Mount Cargo registry sticky disk
+        uses: useblacksmith/stickydisk@d58829ad6f9be8822ec5efe74256c82cd62915ab # v1
         with:
-          shared-key: "native"
-          cache-workspace-crates: "true"
+          key: ${{ github.repository }}-clippy-test-cargo-registry-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('Cargo.lock') }}
+          path: ~/.cargo/registry
+
+      - name: Mount Cargo git sticky disk
+        uses: useblacksmith/stickydisk@d58829ad6f9be8822ec5efe74256c82cd62915ab # v1
+        with:
+          key: ${{ github.repository }}-clippy-test-cargo-git-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('Cargo.lock') }}
+          path: ~/.cargo/git
+
+      - name: Mount Rust target sticky disk
+        uses: useblacksmith/stickydisk@d58829ad6f9be8822ec5efe74256c82cd62915ab # v1
+        with:
+          key: ${{ github.repository }}-clippy-test-target-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('Cargo.lock') }}
+          path: target
+
       - name: Clippy
         run: cargo clippy --workspace -- -D warnings
       - name: Install Pkl CLI

--- a/actrun.toml
+++ b/actrun.toml
@@ -25,6 +25,7 @@ local_skip_actions = [
   "nix-community/cache-nix-action",
   "Swatinem/rust-cache",
   "taiki-e/install-action",
+  "useblacksmith/stickydisk",
   "voidzero-dev/setup-vp",
 ]
 

--- a/crates/vize/tests/check_cli.rs
+++ b/crates/vize/tests/check_cli.rs
@@ -120,6 +120,89 @@ void props
 }
 
 #[test]
+fn check_directory_pattern_resolves_json_modules_imported_by_ts() {
+    let Some(corsa_path) = resolve_test_corsa_path() else {
+        return;
+    };
+    let project_root = create_cli_project(
+        "json-module-imports",
+        &[
+            (
+                "tsconfig.json",
+                r#"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"]
+}"#,
+            ),
+            (
+                "src/tokens.ts",
+                r#"import colors from './tokens/source/colors.tokens.json'
+
+const primary: string = colors.primary
+void primary
+"#,
+            ),
+            (
+                "src/tokens/source/colors.tokens.json",
+                r##"{
+  "primary": "#0057ff"
+}
+"##,
+            ),
+        ],
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(&project_root)
+        .env("CORSA_PATH", corsa_path)
+        .args([
+            "check",
+            "src",
+            "--tsconfig",
+            "tsconfig.json",
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+
+    let stdout = std::string::String::from_utf8(output.stdout).unwrap();
+    let stderr = std::string::String::from_utf8(output.stderr).unwrap();
+    let json: serde_json::Value = serde_json::from_str(&stdout).unwrap_or_else(|error| {
+        panic!("failed to parse stdout as JSON: {error}\nstdout:\n{stdout}\nstderr:\n{stderr}")
+    });
+    let diagnostics = json["files"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .flat_map(|file| file["diagnostics"].as_array().unwrap().iter())
+        .filter_map(|diagnostic| diagnostic.as_str())
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "stdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert_eq!(json["errorCount"], 0, "diagnostics: {diagnostics:#?}");
+    assert!(
+        diagnostics
+            .iter()
+            .all(|diagnostic| !diagnostic.contains("Cannot find module")),
+        "JSON modules should resolve with resolveJsonModule enabled: {diagnostics:#?}"
+    );
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}
+
+#[test]
 fn check_vfor_over_object_types_key_as_keyof_not_number() {
     // Regression for vuejs/language-tools#5978 (#767): iterating an object with
     // `v-for="(value, key) in obj"` must type `value` as `T[keyof T]` and `key`

--- a/crates/vize_canon/src/batch/virtual_project.rs
+++ b/crates/vize_canon/src/batch/virtual_project.rs
@@ -98,6 +98,10 @@ pub struct VirtualProject {
     /// Virtual files keyed by materialized path.
     virtual_files: FxHashMap<PathBuf, VirtualFile>,
 
+    /// Non-TS module files that must exist in the virtual mirror for TypeScript
+    /// module resolution, keyed by materialized path.
+    passthrough_files: FxHashMap<PathBuf, PathBuf>,
+
     /// Secondary index: original source path -> materialized (virtual) path.
     /// Keeps `find_by_original` / `map_to_virtual` O(1) instead of scanning
     /// every virtual file on each LSP position-mapping request.
@@ -138,6 +142,7 @@ impl VirtualProject {
             virtual_ts_check_options: VirtualTsCheckOptions::default(),
             legacy_vue2: false,
             virtual_files: FxHashMap::default(),
+            passthrough_files: FxHashMap::default(),
             original_index: FxHashMap::default(),
             original_contents: FxHashMap::default(),
             diagnostics: Vec::new(),
@@ -303,6 +308,9 @@ impl VirtualProject {
             registered.file.virtual_path.clone(),
             registered.original_content,
         );
+        for (virtual_path, original_path) in registered.passthrough_files {
+            self.passthrough_files.insert(virtual_path, original_path);
+        }
         self.virtual_files
             .insert(registered.file.virtual_path.clone(), registered.file);
     }
@@ -344,6 +352,17 @@ impl VirtualProject {
                     write_file_untracked(&file.virtual_path, file.content.as_bytes())?;
                     write_calls += 1;
                     written_bytes += file.content.len() as u64;
+                }
+                for (virtual_path, original_path) in &self.passthrough_files {
+                    if let Some(parent) = virtual_path.parent()
+                        && created_dirs.insert(parent)
+                    {
+                        ensure_dir(parent)?;
+                    }
+                    let content = std::fs::read(original_path)?;
+                    write_file_untracked(virtual_path, &content)?;
+                    write_calls += 1;
+                    written_bytes += content.len() as u64;
                 }
                 record_write_batch(write_calls, written_bytes);
                 Ok(())
@@ -631,6 +650,7 @@ declare module "*.vue.ts" {
         let mut files = FxHashSet::default();
         files.reserve(self.virtual_files.len() + 3);
         files.extend(self.virtual_files.keys().cloned());
+        files.extend(self.passthrough_files.keys().cloned());
         if !self.virtual_ts_options.auto_import_stubs.is_empty() {
             files.insert(self.virtual_root.join(AUTO_IMPORT_STUBS_FILE));
         }
@@ -1062,6 +1082,7 @@ struct RegisteredFile {
     /// mapping without a disk re-read. Stored on the project, not the public
     /// `VirtualFile`.
     original_content: CompactString,
+    passthrough_files: Vec<(PathBuf, PathBuf)>,
     diagnostics: Vec<Diagnostic>,
 }
 
@@ -1166,6 +1187,12 @@ fn build_vue_registered_file(
             virtual_path,
         },
         original_content: content.to_compact_string(),
+        passthrough_files: collect_passthrough_json_modules(
+            path,
+            content,
+            context.project_root,
+            context.virtual_root,
+        ),
         diagnostics,
     })
 }
@@ -1192,8 +1219,140 @@ fn build_script_registered_file(
             virtual_path,
         },
         original_content: content.to_compact_string(),
+        passthrough_files: collect_passthrough_json_modules(
+            path,
+            content,
+            project_root,
+            virtual_root,
+        ),
         diagnostics: Vec::new(),
     })
+}
+
+fn collect_passthrough_json_modules(
+    path: &Path,
+    content: &str,
+    project_root: &Path,
+    virtual_root: &Path,
+) -> Vec<(PathBuf, PathBuf)> {
+    let Some(dir) = path.parent() else {
+        return Vec::new();
+    };
+
+    let mut seen = FxHashSet::default();
+    let mut files = Vec::new();
+    for specifier in extract_relative_module_specifiers(content) {
+        let Some(original_path) = resolve_relative_json_module(dir, &specifier) else {
+            continue;
+        };
+        let Ok(virtual_path) = mirrored_virtual_path(project_root, virtual_root, &original_path)
+        else {
+            continue;
+        };
+        if seen.insert(virtual_path.clone()) {
+            files.push((virtual_path, original_path));
+        }
+    }
+    files
+}
+
+fn extract_relative_module_specifiers(source: &str) -> Vec<CompactString> {
+    let bytes = source.as_bytes();
+    let len = bytes.len();
+    let mut specifiers = Vec::new();
+    let mut i = 0;
+
+    while i < len {
+        let keyword_len = if matches_keyword(bytes, i, b"from") {
+            4
+        } else if matches_keyword(bytes, i, b"import") {
+            6
+        } else {
+            i += 1;
+            continue;
+        };
+
+        let mut j = i + keyword_len;
+        while j < len && bytes[j].is_ascii_whitespace() {
+            j += 1;
+        }
+        if j < len && bytes[j] == b'(' {
+            j += 1;
+            while j < len && bytes[j].is_ascii_whitespace() {
+                j += 1;
+            }
+        }
+
+        if j < len && (bytes[j] == b'"' || bytes[j] == b'\'') {
+            let quote = bytes[j];
+            let start = j + 1;
+            let mut k = start;
+            while k < len && bytes[k] != quote {
+                k += 1;
+            }
+            if k < len {
+                let specifier = &source[start..k];
+                if is_relative_specifier(specifier) {
+                    specifiers.push(specifier.to_compact_string());
+                }
+                i = k + 1;
+                continue;
+            }
+        }
+
+        i += keyword_len;
+    }
+
+    specifiers
+}
+
+fn matches_keyword(bytes: &[u8], at: usize, keyword: &[u8]) -> bool {
+    if at + keyword.len() > bytes.len() || &bytes[at..at + keyword.len()] != keyword {
+        return false;
+    }
+    let before_ok = at == 0 || !is_identifier_byte(bytes[at - 1]);
+    let after = at + keyword.len();
+    let after_ok = after >= bytes.len() || !is_identifier_byte(bytes[after]);
+    before_ok && after_ok
+}
+
+fn is_identifier_byte(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || byte == b'_' || byte == b'$'
+}
+
+fn is_relative_specifier(specifier: &str) -> bool {
+    specifier.starts_with("./") || specifier.starts_with("../")
+}
+
+fn resolve_relative_json_module(dir: &Path, specifier: &str) -> Option<PathBuf> {
+    let base = dir.join(specifier);
+
+    if specifier.ends_with(".json") && base.is_file() {
+        return Some(normalize_existing_path(&base));
+    }
+
+    let candidate = append_json_extension(&base);
+    if candidate.is_file() {
+        return Some(normalize_existing_path(&candidate));
+    }
+
+    let candidate = base.join("index.json");
+    if candidate.is_file() {
+        return Some(normalize_existing_path(&candidate));
+    }
+
+    None
+}
+
+fn append_json_extension(base: &Path) -> PathBuf {
+    match base.file_name().and_then(|name| name.to_str()) {
+        Some(name) => base.with_file_name(cstr!("{name}.json")),
+        None => base.to_path_buf(),
+    }
+}
+
+fn normalize_existing_path(path: &Path) -> PathBuf {
+    path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
 }
 
 fn virtual_ts_options_for_descriptor(
@@ -1687,6 +1846,36 @@ const message = 'Hello'
             fs::read_to_string(&tsconfig_path)
                 .unwrap()
                 .contains("__vize_auto_imports.d.ts")
+        );
+
+        let _ = fs::remove_dir_all(&case_dir);
+    }
+
+    #[test]
+    fn test_materialize_writes_relative_json_modules() {
+        let case_dir = unique_case_dir("materialize-json-modules");
+        let _ = fs::remove_dir_all(&case_dir);
+        let src_dir = case_dir.join("src");
+        let token_dir = src_dir.join("tokens/source");
+        fs::create_dir_all(&token_dir).unwrap();
+        let ts_path = src_dir.join("tokens.ts");
+        let json_path = token_dir.join("colors.tokens.json");
+        fs::write(
+            &ts_path,
+            "import colors from './tokens/source/colors.tokens.json'\nvoid colors\n",
+        )
+        .unwrap();
+        fs::write(&json_path, "{\"primary\":\"#0057ff\"}\n").unwrap();
+
+        let mut project = VirtualProject::new(&case_dir).unwrap();
+        project.register_path(&ts_path).unwrap();
+        project.materialize().unwrap();
+
+        let virtual_json_path =
+            case_dir.join("node_modules/.vize/canon/src/tokens/source/colors.tokens.json");
+        assert_eq!(
+            fs::read_to_string(&virtual_json_path).unwrap(),
+            "{\"primary\":\"#0057ff\"}\n"
         );
 
         let _ = fs::remove_dir_all(&case_dir);


### PR DESCRIPTION
## Summary
- Mirror relative JSON modules imported by checked TS/Vue inputs into the virtual project so TypeScript can resolve them with `resolveJsonModule`.
- Add a CLI regression for checking a directory pattern that imports JSON from TS.
- Use Blacksmith sticky disks for Cargo registry, Cargo git, and Rust target caching in the `clippy-and-test` workflow job, with a local `actrun` skip entry.

## Validation
- `cargo fmt --all --check`
- `cargo clippy --workspace -- -D warnings`
- `cargo test --workspace`
- `actrun lint .github/workflows/check.yml`
- `actrun workflow run .github/workflows/check.yml --job clippy-and-test --include-dirty --trust --local`
- `actrun workflow run .github/workflows/check.yml --job fmt-rust --include-dirty --trust --local`

Closes #797

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/799"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782818687&installation_id=136613492&pr_number=799&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F799&signature=73054f5de2f806fe46cd8adda997423501426740f441edfe11d50baf41298370"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->