### PR TITLE
fix: emit component css for nuxt ssr builds

### DIFF
--- a/npm/vite-plugin-vize/src/plugin/compat.test.ts
+++ b/npm/vite-plugin-vize/src/plugin/compat.test.ts
@@ -25,6 +25,7 @@ function createState(overrides: Partial<VizePluginState> = {}): VizePluginState 
     dynamicImportAliasRules: [],
     cssAliasRules: [],
     extractCss: false,
+    componentsCssFileName: "assets/vize-components.css",
     clientViteDefine: {},
     serverViteDefine: {},
     logger: {

--- a/npm/vite-plugin-vize/src/plugin/compat.ts
+++ b/npm/vite-plugin-vize/src/plugin/compat.ts
@@ -6,6 +6,7 @@ import { classifyVitePluginRequest } from "@vizejs/native";
 import {
   getCompileOptionsForRequest,
   getEnvironmentCache,
+  shouldExtractCssForRequest,
   syncCollectedCssForFile,
   type VizePluginState,
 } from "./state.ts";
@@ -98,19 +99,20 @@ export function createPostTransformPlugin(state: VizePluginState): Plugin {
         state.logger.log(`post-transform: compiling virtual SFC content from ${id}`);
         try {
           const isSsr = !!transformOptions?.ssr;
+          const extractCss = shouldExtractCssForRequest(state, isSsr);
           const compiled = compileFile(
             id,
             getEnvironmentCache(state, isSsr),
             getCompileOptionsForRequest(state, isSsr),
             code,
           );
-          syncCollectedCssForFile(state, id, compiled);
+          syncCollectedCssForFile({ ...state, extractCss }, id, compiled);
 
           const output = generateOutput(compiled, {
             isProduction: state.isProduction,
             isDev: state.server !== null,
             ssr: isSsr,
-            extractCss: state.extractCss,
+            extractCss,
             filePath: id,
           });
 

--- a/npm/vite-plugin-vize/src/plugin/hmr.test.ts
+++ b/npm/vite-plugin-vize/src/plugin/hmr.test.ts
@@ -1,11 +1,17 @@
 import assert from "node:assert/strict";
 
 import type { VizePluginState } from "./state.ts";
-import { handleGenerateBundleHook, VIZE_COMPONENTS_CSS_FILE } from "./hmr.ts";
+import {
+  handleGenerateBundleHook,
+  resolveComponentsCssFileName,
+  VIZE_COMPONENTS_CSS_BASENAME,
+  VIZE_COMPONENTS_CSS_FILE,
+} from "./hmr.ts";
 
 function createState(): VizePluginState {
   return {
     extractCss: true,
+    componentsCssFileName: VIZE_COMPONENTS_CSS_FILE,
     collectedCss: new Map([
       ["/src/App.vue", ".app { color: red; }"],
       ["/src/Page.vue", ".page { color: blue; }"],
@@ -15,6 +21,22 @@ function createState(): VizePluginState {
     },
   } as VizePluginState;
 }
+
+assert.equal(
+  resolveComponentsCssFileName(undefined),
+  VIZE_COMPONENTS_CSS_FILE,
+  "default Vite builds should keep the existing assets/ output path",
+);
+assert.equal(
+  resolveComponentsCssFileName("_nuxt"),
+  `_nuxt/${VIZE_COMPONENTS_CSS_BASENAME}`,
+  "Nuxt client builds should emit component CSS under build.assetsDir",
+);
+assert.equal(
+  resolveComponentsCssFileName("."),
+  VIZE_COMPONENTS_CSS_BASENAME,
+  "assetless builds should place component CSS beside chunks",
+);
 
 {
   const emitted: Array<{ type: "asset"; fileName: string; source: string }> = [];
@@ -64,6 +86,30 @@ function createState(): VizePluginState {
 
 {
   const emitted: Array<{ type: "asset"; fileName: string; source: string }> = [];
+  const cssFileName = "_nuxt/vize-components.css";
+  const bundle = {
+    "_nuxt/index.js": {
+      type: "chunk",
+      isEntry: true,
+      isDynamicEntry: false,
+    },
+  } satisfies Parameters<typeof handleGenerateBundleHook>[2];
+  const state = {
+    ...createState(),
+    componentsCssFileName: cssFileName,
+  };
+
+  handleGenerateBundleHook(state, (file) => emitted.push(file), bundle);
+
+  const entryChunk = bundle["_nuxt/index.js"] as {
+    viteMetadata?: { importedCss?: Set<string> };
+  };
+  assert.equal(emitted[0]?.fileName, cssFileName);
+  assert.deepEqual(entryChunk.viteMetadata?.importedCss, new Set([cssFileName]));
+}
+
+{
+  const emitted: Array<{ type: "asset"; fileName: string; source: string }> = [];
   const bundle = {
     "assets/index.js": {
       type: "chunk",
@@ -79,6 +125,30 @@ function createState(): VizePluginState {
   };
   assert.equal(emitted.length, 1);
   assert.deepEqual(entryChunk.viteMetadata?.importedCss, new Set([VIZE_COMPONENTS_CSS_FILE]));
+}
+
+{
+  const emitted: Array<{ type: "asset"; fileName: string; source: string }> = [];
+  const bundle = {
+    "assets/index.js": {
+      type: "chunk",
+      isEntry: true,
+      isDynamicEntry: false,
+    },
+  } satisfies Parameters<typeof handleGenerateBundleHook>[2];
+  const state = {
+    ...createState(),
+    extractCss: false,
+  };
+
+  handleGenerateBundleHook(state, (file) => emitted.push(file), bundle);
+
+  assert.equal(emitted.length, 0, "SSR builds should not emit or attach extracted CSS");
+  assert.equal(
+    "viteMetadata" in bundle["assets/index.js"],
+    false,
+    "SSR chunks should not reference client-only extracted CSS",
+  );
 }
 
 console.log("✅ vite-plugin-vize plugin hmr tests passed!");

--- a/npm/vite-plugin-vize/src/plugin/hmr.ts
+++ b/npm/vite-plugin-vize/src/plugin/hmr.ts
@@ -10,7 +10,8 @@ import { hasDelegatedStyles } from "../utils/index.ts";
 import { toVirtualId } from "../virtual.ts";
 import { resolveCssImports } from "../utils/css.ts";
 
-export const VIZE_COMPONENTS_CSS_FILE = "assets/vize-components.css";
+export const VIZE_COMPONENTS_CSS_BASENAME = "vize-components.css";
+export const VIZE_COMPONENTS_CSS_FILE = `assets/${VIZE_COMPONENTS_CSS_BASENAME}`;
 
 type GenerateBundleItem =
   | {
@@ -144,19 +145,30 @@ export function handleGenerateBundleHook(
     allCss += allCss ? `\n\n${css}` : css;
   }
   if (allCss.trim()) {
+    const cssFileName = state.componentsCssFileName || VIZE_COMPONENTS_CSS_FILE;
     emitFile({
       type: "asset",
-      fileName: VIZE_COMPONENTS_CSS_FILE,
+      fileName: cssFileName,
       source: allCss,
     });
-    attachComponentsCssToEntryChunks(bundle);
-    state.logger.log(
-      `Extracted CSS to ${VIZE_COMPONENTS_CSS_FILE} (${state.collectedCss.size} components)`,
-    );
+    attachComponentsCssToEntryChunks(bundle, cssFileName);
+    state.logger.log(`Extracted CSS to ${cssFileName} (${state.collectedCss.size} components)`);
   }
 }
 
-function attachComponentsCssToEntryChunks(bundle: GenerateBundle): void {
+export function resolveComponentsCssFileName(assetsDir: string | undefined): string {
+  const normalizedAssetsDir = (assetsDir || "assets")
+    .replace(/\\/g, "/")
+    .replace(/^\/+|\/+$/g, "");
+
+  if (!normalizedAssetsDir || normalizedAssetsDir === ".") {
+    return VIZE_COMPONENTS_CSS_BASENAME;
+  }
+
+  return `${normalizedAssetsDir}/${VIZE_COMPONENTS_CSS_BASENAME}`;
+}
+
+function attachComponentsCssToEntryChunks(bundle: GenerateBundle, cssFileName: string): void {
   for (const item of Object.values(bundle)) {
     if (item.type !== "chunk" || (!item.isEntry && !item.isDynamicEntry)) {
       continue;
@@ -164,6 +176,6 @@ function attachComponentsCssToEntryChunks(bundle: GenerateBundle): void {
 
     item.viteMetadata ??= {};
     item.viteMetadata.importedCss ??= new Set<string>();
-    item.viteMetadata.importedCss.add(VIZE_COMPONENTS_CSS_FILE);
+    item.viteMetadata.importedCss.add(cssFileName);
   }
 }

--- a/npm/vite-plugin-vize/src/plugin/hmr.ts
+++ b/npm/vite-plugin-vize/src/plugin/hmr.ts
@@ -157,9 +157,7 @@ export function handleGenerateBundleHook(
 }
 
 export function resolveComponentsCssFileName(assetsDir: string | undefined): string {
-  const normalizedAssetsDir = (assetsDir || "assets")
-    .replace(/\\/g, "/")
-    .replace(/^\/+|\/+$/g, "");
+  const normalizedAssetsDir = (assetsDir || "assets").replace(/\\/g, "/").replace(/^\/+|\/+$/g, "");
 
   if (!normalizedAssetsDir || normalizedAssetsDir === ".") {
     return VIZE_COMPONENTS_CSS_BASENAME;

--- a/npm/vite-plugin-vize/src/plugin/index.ts
+++ b/npm/vite-plugin-vize/src/plugin/index.ts
@@ -17,7 +17,11 @@ import {
 } from "./state.ts";
 import { resolveIdHook } from "./resolve.ts";
 import { loadHook, transformHook } from "./load.ts";
-import { handleHotUpdateHook, handleGenerateBundleHook } from "./hmr.ts";
+import {
+  handleHotUpdateHook,
+  handleGenerateBundleHook,
+  resolveComponentsCssFileName,
+} from "./hmr.ts";
 import {
   createPostTransformPlugin,
   createStylePostTransformPlugin,
@@ -80,6 +84,25 @@ function mergeSharedConfig(
   };
 }
 
+function shouldExtractCssForBuild(
+  state: Pick<VizePluginState, "extractCss" | "isProduction">,
+  context: { environment?: { name?: string } },
+): boolean {
+  if (!state.isProduction) {
+    return false;
+  }
+
+  const environmentName = context.environment?.name;
+  if (environmentName === "client" || environmentName === "browser") {
+    return true;
+  }
+  if (environmentName === "ssr" || environmentName === "server") {
+    return false;
+  }
+
+  return state.extractCss;
+}
+
 export function vize(options: VizeOptions = {}): Plugin[] {
   if (isLegacyVueCompatibilityMode(options)) {
     return [createLegacyVueCompatibilityPlugin(options)];
@@ -105,6 +128,7 @@ export function vize(options: VizeOptions = {}): Plugin[] {
     dynamicImportAliasRules: [],
     cssAliasRules: [],
     extractCss: false,
+    componentsCssFileName: "assets/vize-components.css",
     clientViteDefine: {},
     serverViteDefine: {},
     logger: createLogger(options.debug ?? false),
@@ -145,7 +169,8 @@ export function vize(options: VizeOptions = {}): Plugin[] {
       } else {
         state.clientViteBase = currentBase;
       }
-      state.extractCss = state.isProduction;
+      state.extractCss = state.isProduction && !isSsrBuild;
+      state.componentsCssFileName = resolveComponentsCssFileName(resolvedConfig.build.assetsDir);
 
       // Capture Vite define values for applying to virtual modules. Vite's
       // built-in define plugin may not process \0-prefixed virtual modules, so
@@ -289,7 +314,7 @@ export function vize(options: VizeOptions = {}): Plugin[] {
         // opted into on-demand compilation. Skip pre-compilation.
         return;
       }
-      await compileAll(state);
+      await compileAll({ ...state, extractCss: shouldExtractCssForBuild(state, this) });
       state.logger.log("Cache keys:", [...state.cache.keys()].slice(0, 3));
     },
 
@@ -310,7 +335,11 @@ export function vize(options: VizeOptions = {}): Plugin[] {
     },
 
     generateBundle(_, bundle) {
-      handleGenerateBundleHook(state, this.emitFile.bind(this), bundle);
+      handleGenerateBundleHook(
+        { ...state, extractCss: shouldExtractCssForBuild(state, this) },
+        this.emitFile.bind(this),
+        bundle,
+      );
     },
 
     closeBundle() {

--- a/npm/vite-plugin-vize/src/plugin/load.test.ts
+++ b/npm/vite-plugin-vize/src/plugin/load.test.ts
@@ -101,6 +101,7 @@ export default _sfc_main`,
   dynamicImportAliasRules: [],
   cssAliasRules: [],
   extractCss: false,
+  componentsCssFileName: "assets/vize-components.css",
   clientViteDefine: {},
   serverViteDefine: {},
   logger: {

--- a/npm/vite-plugin-vize/src/plugin/load.ts
+++ b/npm/vite-plugin-vize/src/plugin/load.ts
@@ -8,6 +8,7 @@ import { transformWithOxc } from "vite";
 import {
   getCompileOptionsForRequest,
   getEnvironmentCache,
+  shouldExtractCssForRequest,
   syncCollectedCssForFile,
   type VizePluginState,
 } from "./state.ts";
@@ -76,14 +77,15 @@ function findMacroArtifactModule(
   kind: string,
 ): string | null {
   const cache = getEnvironmentCache(state, ssr);
+  const extractCss = shouldExtractCssForRequest(state, ssr);
   realPath = classifyVitePluginRequest(realPath).normalizedVuePath;
   let compiled = cache.get(realPath) ?? state.cache.get(realPath) ?? state.ssrCache.get(realPath);
 
   if (!compiled && fs.existsSync(realPath)) {
     const source = fs.readFileSync(realPath, "utf-8");
     compiled = compileFile(realPath, cache, getCompileOptionsForRequest(state, ssr), source);
-    syncCollectedCssForFile(state, realPath, compiled);
   }
+  syncCollectedCssForFile({ ...state, extractCss }, realPath, compiled);
 
   return compiled?.macroArtifacts?.find((artifact) => artifact.kind === kind)?.moduleCode ?? null;
 }
@@ -113,14 +115,15 @@ function loadCompiledSfcModule(
   }
 
   const cache = getEnvironmentCache(state, isSsr);
+  const extractCss = shouldExtractCssForRequest(state, isSsr);
   let compiled = cache.get(realPath);
 
   // On-demand compile if not cached
   if (!compiled && fs.existsSync(realPath)) {
     state.logger.log(`load: on-demand compiling ${realPath}`);
     compiled = compileFile(realPath, cache, getCompileOptionsForRequest(state, isSsr));
-    syncCollectedCssForFile(state, realPath, compiled);
   }
+  syncCollectedCssForFile({ ...state, extractCss }, realPath, compiled);
 
   if (!compiled) {
     return null;
@@ -147,7 +150,7 @@ function loadCompiledSfcModule(
     isDev: state.server !== null && !isSsr,
     ssr: isSsr,
     hmrUpdateType: pendingHmrUpdateType,
-    extractCss: state.extractCss,
+    extractCss,
     filePath: realPath,
   });
   const output = rewriteStaticAssetUrls(

--- a/npm/vite-plugin-vize/src/plugin/resolve.test.ts
+++ b/npm/vite-plugin-vize/src/plugin/resolve.test.ts
@@ -54,6 +54,7 @@ function createState(root: string): VizePluginState {
     dynamicImportAliasRules: [],
     cssAliasRules: [],
     extractCss: false,
+    componentsCssFileName: "assets/vize-components.css",
     clientViteDefine: {},
     serverViteDefine: {},
     logger: {

--- a/npm/vite-plugin-vize/src/plugin/state.test.ts
+++ b/npm/vite-plugin-vize/src/plugin/state.test.ts
@@ -117,6 +117,7 @@ const brokenPrecompileState: VizePluginState = {
   dynamicImportAliasRules: [],
   cssAliasRules: [],
   extractCss: false,
+  componentsCssFileName: "assets/vize-components.css",
   clientViteDefine: {},
   serverViteDefine: {},
   logger: {
@@ -180,7 +181,7 @@ assert.deepEqual(
 );
 
 const cssState = {
-  isProduction: true,
+  extractCss: true,
   collectedCss: new Map<string, string>(),
   cssAliasRules: [],
 };
@@ -231,6 +232,19 @@ assert.equal(
   cssState.collectedCss.has("/src/Button.vue"),
   false,
   "Delegated CSS modules should stay out of the extracted plain CSS bundle",
+);
+
+const ssrCssState = {
+  extractCss: false,
+  collectedCss: new Map<string, string>([["/src/App.vue", ".app { color: red; }"]]),
+  cssAliasRules: [],
+};
+
+syncCollectedCssForFile(ssrCssState, "/src/App.vue", plainCssModule);
+assert.equal(
+  ssrCssState.collectedCss.get("/src/App.vue"),
+  ".app { color: red; }",
+  "SSR builds should not overwrite client CSS collection",
 );
 
 const retainedBuildState = {

--- a/npm/vite-plugin-vize/src/plugin/state.ts
+++ b/npm/vite-plugin-vize/src/plugin/state.ts
@@ -52,6 +52,7 @@ export interface VizePluginState {
   dynamicImportAliasRules: DynamicImportAliasRule[];
   cssAliasRules: CssAliasRule[];
   extractCss: boolean;
+  componentsCssFileName: string;
   clientViteDefine: Record<string, string>;
   serverViteDefine: Record<string, string>;
   logger: ReturnType<typeof createLogger>;
@@ -85,11 +86,11 @@ export function getCompileOptionsForRequest(
 }
 
 export function syncCollectedCssForFile(
-  state: Pick<VizePluginState, "isProduction" | "collectedCss" | "cssAliasRules">,
+  state: Pick<VizePluginState, "extractCss" | "collectedCss" | "cssAliasRules">,
   filePath: string,
   compiled: CompiledModule | undefined,
 ): void {
-  if (!compiled || !state.isProduction) {
+  if (!compiled || !state.extractCss) {
     return;
   }
 
@@ -101,6 +102,13 @@ export function syncCollectedCssForFile(
   } else {
     state.collectedCss.delete(filePath);
   }
+}
+
+export function shouldExtractCssForRequest(
+  state: Pick<VizePluginState, "isProduction">,
+  ssr: boolean,
+): boolean {
+  return state.isProduction && !ssr;
 }
 
 export function clearBuildCaches(
@@ -150,7 +158,9 @@ export async function compileAll(state: VizePluginState): Promise<void> {
   for (const file of deletedFiles) {
     state.cache.delete(file);
     state.ssrCache.delete(file);
-    state.collectedCss.delete(file);
+    if (state.extractCss) {
+      state.collectedCss.delete(file);
+    }
     state.precompileMetadata.delete(file);
     state.pendingHmrUpdateTypes.delete(file);
   }
@@ -166,7 +176,9 @@ export async function compileAll(state: VizePluginState): Promise<void> {
   }
 
   for (const file of changedFiles) {
-    state.collectedCss.delete(file);
+    if (state.extractCss) {
+      state.collectedCss.delete(file);
+    }
     state.pendingHmrUpdateTypes.delete(file);
   }
 
@@ -187,7 +199,9 @@ export async function compileAll(state: VizePluginState): Promise<void> {
       } catch (e) {
         failedCount++;
         state.cache.delete(file);
-        state.collectedCss.delete(file);
+        if (state.extractCss) {
+          state.collectedCss.delete(file);
+        }
         state.precompileMetadata.delete(file);
         precompileFailures.push(`[vize] Failed to read ${file}: ${formatUnknownError(e)}`);
         state.logger.error(`Failed to read ${file}:`, e);
@@ -220,7 +234,9 @@ export async function compileAll(state: VizePluginState): Promise<void> {
 
       if (fileResult.errors.length > 0) {
         state.cache.delete(fileResult.path);
-        state.collectedCss.delete(fileResult.path);
+        if (state.extractCss) {
+          state.collectedCss.delete(fileResult.path);
+        }
         state.precompileMetadata.delete(fileResult.path);
         precompileFailures.push(formatCompileErrorMessage(fileResult.path, fileResult.errors));
         continue;

--- a/tests/app/preview/npmx.ts
+++ b/tests/app/preview/npmx.ts
@@ -1,5 +1,8 @@
 import { describe, it, before } from "node:test";
+import assert from "node:assert/strict";
 import { execSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as path from "node:path";
 import { npmxApp } from "../../_helpers/apps.ts";
 
 const app = npmxApp;
@@ -32,5 +35,75 @@ describe(`${app.name} build`, () => {
     });
 
     console.log("Build completed successfully");
+
+    const publicDir = path.join(app.cwd, ".output", "public");
+    const references = collectVizeComponentsCssReferences(path.join(app.cwd, ".output"));
+    for (const reference of references) {
+      const componentsCssPath = findPublicAssetPath(publicDir, reference);
+      assert.ok(
+        componentsCssPath,
+        `Nuxt SSR build references ${reference}, so it should exist in public assets`,
+      );
+      assert.ok(
+        fs.statSync(componentsCssPath).size > 0,
+        `Nuxt SSR emitted component stylesheet ${reference} should not be empty`,
+      );
+    }
   });
 });
+
+function collectVizeComponentsCssReferences(outputDir: string): string[] {
+  const references = new Set<string>();
+  visitFiles(outputDir, (filePath) => {
+    if (!/\.(?:js|mjs|json)$/.test(filePath)) {
+      return;
+    }
+
+    const source = fs.readFileSync(filePath, "utf-8");
+    for (const match of source.matchAll(/["']([^"']*vize-components\.css)["']/g)) {
+      const reference = normalizeVizeComponentsCssReference(match[1]);
+      if (reference) {
+        references.add(reference);
+      }
+    }
+  });
+  return [...references].sort();
+}
+
+function normalizeVizeComponentsCssReference(reference: string): string | null {
+  if (reference.startsWith("../public/")) {
+    return reference.slice("../public/".length);
+  }
+  if (reference.startsWith("../")) {
+    return null;
+  }
+
+  return reference.replace(/^\.?\//, "");
+}
+
+function findPublicAssetPath(publicDir: string, reference: string): string | null {
+  const candidates = [path.join(publicDir, reference)];
+  if (!reference.includes("/")) {
+    candidates.push(path.join(publicDir, "_nuxt", reference));
+  }
+
+  return candidates.find((candidate) => fs.existsSync(candidate)) ?? null;
+}
+
+function visitFiles(dir: string, visitor: (filePath: string) => void): void {
+  if (!fs.existsSync(dir)) {
+    return;
+  }
+
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const entryPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      visitFiles(entryPath, visitor);
+      continue;
+    }
+
+    if (entry.isFile()) {
+      visitor(entryPath);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- emit vize-components.css under Vite's configured build.assetsDir
- collect and attach extracted component CSS only for client/browser production builds
- add an npmx Nuxt SSR build assertion that referenced component CSS exists in public assets

## Fixes
Fixes #801

## Validation
- npx -y pnpm@10 --filter @vizejs/vite-plugin test
- npx -y pnpm@10 --filter @vizejs/vite-plugin build
- VIZE_TEST_WORKTREE_ID=issue-801 RUN_BUILD_TESTS=1 node app/preview/npmx.ts

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/803"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782845354&installation_id=136613492&pr_number=803&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F803&signature=6e6d227e75b7339553880316f2cb115a83ba8f643b018eebf3bc1a98c519b338"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->