### PR TITLE
fix: preserve empty static attributes

### DIFF
--- a/crates/vize_atelier_core/src/codegen/element/v_once.rs
+++ b/crates/vize_atelier_core/src/codegen/element/v_once.rs
@@ -185,7 +185,7 @@ pub fn generate_v_once_props(ctx: &mut CodegenContext, el: &ElementNode<'_>) {
                     ctx.push(&escape_js_string(&value.content));
                     ctx.push("\"");
                 } else {
-                    ctx.push("true");
+                    ctx.push("\"\"");
                 }
             }
             _ => {}

--- a/crates/vize_atelier_core/src/transforms/hoist_static.rs
+++ b/crates/vize_atelier_core/src/transforms/hoist_static.rs
@@ -272,7 +272,7 @@ fn create_props_expression<'a>(
             let value_exp = if let Some(v) = &attr.value {
                 SimpleExpressionNode::new(v.content.clone(), true, v.loc.clone())
             } else {
-                SimpleExpressionNode::new("true", true, attr.loc.clone())
+                SimpleExpressionNode::new("", true, attr.loc.clone())
             };
             let value = JsChildNode::SimpleExpression(Box::new_in(value_exp, allocator));
 
@@ -453,7 +453,7 @@ fn hoist_element_props<'a>(
             let value_exp = if let Some(v) = &attr.value {
                 SimpleExpressionNode::new(v.content.clone(), true, v.loc.clone())
             } else {
-                SimpleExpressionNode::new("true", true, attr.loc.clone())
+                SimpleExpressionNode::new("", true, attr.loc.clone())
             };
             let value = JsChildNode::SimpleExpression(Box::new_in(value_exp, allocator));
 

--- a/crates/vize_atelier_dom/src/lib.rs
+++ b/crates/vize_atelier_dom/src/lib.rs
@@ -350,6 +350,32 @@ mod tests {
     }
 
     #[test]
+    fn test_inline_hoisted_bare_static_attrs_are_empty_strings() {
+        let allocator = Bump::new();
+        let options = DomCompilerOptions {
+            mode: CodegenMode::Module,
+            prefix_identifiers: true,
+            inline: true,
+            ..Default::default()
+        };
+
+        let (_, errors, result) = compile_template_with_options(
+            &allocator,
+            r#"<section><h2 sr-only font-bold flex="~ gap-1"><span block /></h2></section>"#,
+            options,
+        );
+
+        assert!(errors.is_empty(), "Errors: {:?}", errors);
+        let full = full_output(&result.preamble, &result.code);
+        assert!(full.contains(r#""sr-only": """#), "{full}");
+        assert!(full.contains(r#""font-bold": """#), "{full}");
+        assert!(full.contains(r#"block: """#), "{full}");
+        assert!(!full.contains(r#""sr-only": "true""#), "{full}");
+        assert!(!full.contains(r#""font-bold": "true""#), "{full}");
+        assert!(!full.contains(r#"block: "true""#), "{full}");
+    }
+
+    #[test]
     fn test_inline_component_dynamic_prop_keeps_props_patch_flag() {
         use vize_atelier_core::options::{BindingMetadata, BindingType};
         use vize_carton::FxHashMap;


### PR DESCRIPTION
## Summary
- emit empty strings for hoisted bare static attributes
- align v-once bare static attribute output with the normal prop path
- add a DOM compiler regression test for attributify-style bare attributes

## Validation
- `cargo fmt --check`
- `cargo test -p vize_atelier_dom test_inline_hoisted_bare_static_attrs_are_empty_strings`
- `cargo test -p vize_atelier_core -p vize_atelier_dom`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/805"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782849042&installation_id=136613492&pr_number=805&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F805&signature=621c54a97037638483ffd777ce93d4fb8e52c726afe4b6d6ceaea6f851463943"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->