### PR TITLE
fix: preserve destructured props runtime declarations

### DIFF
--- a/crates/vize_atelier_core/src/codegen/expression/helpers.rs
+++ b/crates/vize_atelier_core/src/codegen/expression/helpers.rs
@@ -10,6 +10,84 @@ use super::super::context::CodegenContext;
 use vize_carton::String;
 use vize_carton::ToCompactString;
 
+fn is_identifier_continue(c: char) -> bool {
+    c.is_alphanumeric() || c == '_' || c == '$'
+}
+
+fn is_simple_identifier_name(name: &str) -> bool {
+    let mut chars = name.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    (first.is_alphabetic() || first == '_' || first == '$')
+        && chars.all(|c| c.is_alphanumeric() || c == '_' || c == '$')
+}
+
+fn props_access_expression(object: &str, key: &str) -> String {
+    if is_simple_identifier_name(key) {
+        let mut out = String::with_capacity(object.len() + key.len() + 1);
+        out.push_str(object);
+        out.push('.');
+        out.push_str(key);
+        return out;
+    }
+
+    let mut out = String::with_capacity(object.len() + key.len() + 4);
+    out.push_str(object);
+    out.push('[');
+    use std::fmt::Write as _;
+    let _ = write!(&mut out, "{:?}", key);
+    out.push(']');
+    out
+}
+
+fn replace_prefixed_alias_access(code: String, object: &str, local: &str, key: &str) -> String {
+    let needle = {
+        let mut needle = String::with_capacity(object.len() + local.len() + 1);
+        needle.push_str(object);
+        needle.push('.');
+        needle.push_str(local);
+        needle
+    };
+    let replacement = props_access_expression(object, key);
+
+    let mut result = String::with_capacity(code.len());
+    let mut cursor = 0;
+    while let Some(rel_pos) = code[cursor..].find(needle.as_str()) {
+        let start = cursor + rel_pos;
+        let end = start + needle.len();
+        let after_ok = code[end..]
+            .chars()
+            .next()
+            .is_none_or(|c| !is_identifier_continue(c));
+
+        result.push_str(&code[cursor..start]);
+        if after_ok {
+            result.push_str(&replacement);
+        } else {
+            result.push_str(&code[start..end]);
+        }
+        cursor = end;
+    }
+    result.push_str(&code[cursor..]);
+    result
+}
+
+fn rewrite_props_aliases(code: String, ctx: &CodegenContext) -> String {
+    let Some(bindings) = &ctx.options.binding_metadata else {
+        return code;
+    };
+    if bindings.props_aliases.is_empty() {
+        return code;
+    }
+
+    let mut rewritten = code;
+    for (local, key) in &bindings.props_aliases {
+        rewritten = replace_prefixed_alias_access(rewritten, "$props", local, key);
+    }
+    rewritten
+}
+
 /// Prefix identifiers in expression with appropriate prefix based on binding metadata.
 /// This is a context-aware version that uses `$setup.` for setup bindings in function mode.
 pub(crate) fn prefix_identifiers_with_context(content: &str, ctx: &CodegenContext) -> String {
@@ -365,7 +443,7 @@ pub(crate) fn prefix_identifiers_with_context(content: &str, ctx: &CodegenContex
             };
             visitor.visit_expression(&expr);
 
-            apply_rewrites(content, rewrites)
+            rewrite_props_aliases(apply_rewrites(content, rewrites), ctx)
         }
         Err(_) => {
             // Expression parsing failed -- try parsing as a program
@@ -386,7 +464,7 @@ pub(crate) fn prefix_identifiers_with_context(content: &str, ctx: &CodegenContex
                 };
                 visitor.visit_program(&parse_result2.program);
 
-                apply_rewrites(content, rewrites)
+                rewrite_props_aliases(apply_rewrites(content, rewrites), ctx)
             } else {
                 content.to_compact_string()
             }

--- a/crates/vize_atelier_core/src/transforms/transform_expression/inline_handler.rs
+++ b/crates/vize_atelier_core/src/transforms/transform_expression/inline_handler.rs
@@ -14,7 +14,7 @@ use super::{
     clone_expression, is_event_handler_reference_expression, is_function_expression,
     normalize_expression,
     prefix::{get_identifier_prefix, is_simple_identifier},
-    rewrite::rewrite_expression,
+    rewrite::{rewrite_expression, rewrite_props_aliases},
     typescript::strip_typescript_from_expression,
 };
 
@@ -114,6 +114,8 @@ pub fn process_inline_handler<'a>(
         } else {
             content.clone()
         };
+
+        let new_content = rewrite_props_aliases(new_content, ctx);
 
         return ExpressionNode::Simple(Box::new_in(
             SimpleExpressionNode {

--- a/crates/vize_atelier_core/src/transforms/transform_expression/rewrite.rs
+++ b/crates/vize_atelier_core/src/transforms/transform_expression/rewrite.rs
@@ -17,6 +17,76 @@ use super::{
     typescript::strip_typescript_from_expression,
 };
 
+fn is_identifier_continue(c: char) -> bool {
+    c.is_alphanumeric() || c == '_' || c == '$'
+}
+
+fn prop_access_expression(object: &str, key: &str) -> String {
+    if is_simple_identifier(key) {
+        let mut out = String::with_capacity(object.len() + key.len() + 1);
+        out.push_str(object);
+        out.push('.');
+        out.push_str(key);
+        return out;
+    }
+
+    let mut out = String::with_capacity(object.len() + key.len() + 4);
+    out.push_str(object);
+    out.push('[');
+    use std::fmt::Write as _;
+    let _ = write!(&mut out, "{:?}", key);
+    out.push(']');
+    out
+}
+
+fn replace_prefixed_alias_access(code: String, object: &str, local: &str, key: &str) -> String {
+    let needle = {
+        let mut needle = String::with_capacity(object.len() + local.len() + 1);
+        needle.push_str(object);
+        needle.push('.');
+        needle.push_str(local);
+        needle
+    };
+    let replacement = prop_access_expression(object, key);
+
+    let mut result = String::with_capacity(code.len());
+    let mut cursor = 0;
+    while let Some(rel_pos) = code[cursor..].find(needle.as_str()) {
+        let start = cursor + rel_pos;
+        let end = start + needle.len();
+        let after_ok = code[end..]
+            .chars()
+            .next()
+            .is_none_or(|c| !is_identifier_continue(c));
+
+        result.push_str(&code[cursor..start]);
+        if after_ok {
+            result.push_str(&replacement);
+        } else {
+            result.push_str(&code[start..end]);
+        }
+        cursor = end;
+    }
+    result.push_str(&code[cursor..]);
+    result
+}
+
+pub(super) fn rewrite_props_aliases(code: String, ctx: &TransformContext<'_>) -> String {
+    let Some(bindings) = &ctx.options.binding_metadata else {
+        return code;
+    };
+    if bindings.props_aliases.is_empty() {
+        return code;
+    }
+
+    let mut rewritten = code;
+    for (local, key) in &bindings.props_aliases {
+        rewritten = replace_prefixed_alias_access(rewritten, "__props", local, key);
+        rewritten = replace_prefixed_alias_access(rewritten, "$props", local, key);
+    }
+    rewritten
+}
+
 /// Result of expression rewriting
 pub(crate) struct RewriteResult {
     pub(crate) code: String,
@@ -90,7 +160,7 @@ pub(crate) fn rewrite_expression(
             }
 
             RewriteResult {
-                code: result,
+                code: rewrite_props_aliases(result, ctx),
                 used_unref,
             }
         }
@@ -133,7 +203,7 @@ pub(crate) fn rewrite_expression(
                 }
 
                 return RewriteResult {
-                    code: result,
+                    code: rewrite_props_aliases(result, ctx),
                     used_unref,
                 };
             }
@@ -158,7 +228,7 @@ pub(crate) fn rewrite_expression(
                 js_content
             };
             RewriteResult {
-                code,
+                code: rewrite_props_aliases(code, ctx),
                 used_unref: false,
             }
         }

--- a/crates/vize_atelier_sfc/src/compile.rs
+++ b/crates/vize_atelier_sfc/src/compile.rs
@@ -503,6 +503,12 @@ fn compile_sfc_inner(
             script_bindings.bindings.entry(name.clone()).or_insert(*bt);
         }
     }
+    for (local, key) in &ctx.bindings.props_aliases {
+        script_bindings
+            .props_aliases
+            .entry(local.clone())
+            .or_insert_with(|| key.clone());
+    }
 
     // Register $emit or __emit binding when defineEmits is used, so the template
     // compiler knows not to prefix it with _ctx.

--- a/crates/vize_atelier_sfc/src/compile/tests.rs
+++ b/crates/vize_atelier_sfc/src/compile/tests.rs
@@ -1534,6 +1534,99 @@ import { Form, Input } from 'ant-design-vue'
 }
 
 #[test]
+fn test_script_setup_props_destructure_alias_uses_prop_key_in_inline_render() {
+    let source = r#"<script setup lang="ts">
+const { link: to } = defineProps<{ link?: string }>()
+</script>
+
+<template>
+  <a v-if="to" :href="to">{{ to }}</a>
+</template>"#;
+
+    let descriptor = parse_sfc(source, SfcParseOptions::default()).expect("Failed to parse SFC");
+    let opts = SfcCompileOptions {
+        script: ScriptCompileOptions {
+            is_ts: true,
+            ..Default::default()
+        },
+        template: TemplateCompileOptions {
+            is_ts: true,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let result = compile_sfc(&descriptor, opts).expect("Failed to compile SFC");
+
+    assert!(result.code.contains("__props.link"), "{}", result.code);
+    assert!(!result.code.contains("__props.to"), "{}", result.code);
+}
+
+#[test]
+fn test_script_setup_props_destructure_alias_uses_prop_key_in_ssr_render() {
+    let source = r#"<script setup lang="ts">
+const { link: to } = defineProps<{ link?: string }>()
+</script>
+
+<template>
+  <a v-if="to" :href="to">{{ to }}</a>
+</template>"#;
+
+    let descriptor = parse_sfc(source, SfcParseOptions::default()).expect("Failed to parse SFC");
+    let opts = SfcCompileOptions {
+        script: ScriptCompileOptions {
+            is_ts: true,
+            ..Default::default()
+        },
+        template: TemplateCompileOptions {
+            is_ts: true,
+            ssr: true,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let result = compile_sfc(&descriptor, opts).expect("Failed to compile SFC");
+
+    assert!(result.code.contains("$props.link"), "{}", result.code);
+    assert!(!result.code.contains("$props.to"), "{}", result.code);
+}
+
+#[test]
+fn test_script_setup_imported_type_props_destructure_declares_runtime_props() {
+    let source = r#"<script setup lang="ts">
+import type { TimetableCell } from "~~/i18n/timetable"
+
+const { type, title, speakers } = defineProps<TimetableCell>()
+</script>
+
+<template>
+  <div :class="type">
+    <h2>{{ title }}</h2>
+    <span v-if="speakers">{{ speakers.length }}</span>
+  </div>
+</template>"#;
+
+    let descriptor = parse_sfc(source, SfcParseOptions::default()).expect("Failed to parse SFC");
+    let opts = SfcCompileOptions {
+        script: ScriptCompileOptions {
+            is_ts: true,
+            ..Default::default()
+        },
+        template: TemplateCompileOptions {
+            is_ts: true,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let result = compile_sfc(&descriptor, opts).expect("Failed to compile SFC");
+
+    assert!(result.code.contains("type: {}"), "{}", result.code);
+    assert!(result.code.contains("title: {}"), "{}", result.code);
+    assert!(result.code.contains("speakers: {}"), "{}", result.code);
+    assert!(result.code.contains("__props.title"), "{}", result.code);
+    assert!(result.code.contains("__props.speakers"), "{}", result.code);
+}
+
+#[test]
 fn test_script_setup_sfc_ssr_uses_server_renderer_output() {
     let source = r#"<script setup lang="ts">
 const msg = 'hello'

--- a/crates/vize_atelier_sfc/src/compile_script/function_mode/compiler.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/function_mode/compiler.rs
@@ -8,8 +8,8 @@ use vize_carton::{Bump, FxHashSet, String, ToCompactString};
 use vize_croquis::macros::runtime_erased_macro_names;
 
 use crate::script::{
-    ScriptCompileContext, TemplateUsedIdentifiers, resolve_template_used_identifiers,
-    transform_destructured_props,
+    PropsDestructuredBindings, ScriptCompileContext, TemplateUsedIdentifiers,
+    resolve_template_used_identifiers, transform_destructured_props,
 };
 use crate::types::{BindingType, SfcError};
 
@@ -327,7 +327,11 @@ fn emit_props_definition(
                 if let Some(ref type_args) = props_macro.type_args {
                     let prop_types = extract_prop_types_from_type(type_args);
                     if prop_types.is_empty() {
-                        "{}".to_compact_string()
+                        if let Some(ref destructure) = ctx.macros.props_destructure {
+                            destructured_props_runtime_decl(destructure)
+                        } else {
+                            "{}".to_compact_string()
+                        }
                     } else {
                         let mut names: Vec<_> =
                             prop_types.iter().map(|(n, _)| n.as_str()).collect();
@@ -376,6 +380,30 @@ fn emit_props_definition(
                 output.extend_from_slice(b"  props: ");
                 output.extend_from_slice(props_macro.args.as_bytes());
                 output.extend_from_slice(b",\n");
+            } else if let Some(ref props_macro) = ctx.macros.define_props
+                && props_macro.type_args.is_some()
+            {
+                let prop_types = props_macro
+                    .type_args
+                    .as_ref()
+                    .map(|type_args| extract_prop_types_from_type(type_args))
+                    .unwrap_or_default();
+                if prop_types.is_empty() {
+                    output.extend_from_slice(b"  props: ");
+                    output
+                        .extend_from_slice(destructured_props_runtime_decl(destructure).as_bytes());
+                    output.extend_from_slice(b",\n");
+                } else {
+                    output.extend_from_slice(b"  props: {\n");
+                    let mut names: Vec<_> = prop_types.iter().map(|(n, _)| n.as_str()).collect();
+                    names.sort();
+                    for name in names {
+                        output.extend_from_slice(b"    ");
+                        output.extend_from_slice(name.as_bytes());
+                        output.extend_from_slice(b": {},\n");
+                    }
+                    output.extend_from_slice(b"  },\n");
+                }
             }
         }
     } else if let Some(ref props_macro) = ctx.macros.define_props {
@@ -419,6 +447,19 @@ fn emit_props_definition(
             output.extend_from_slice(b",\n");
         }
     }
+}
+
+fn destructured_props_runtime_decl(destructure: &PropsDestructuredBindings) -> String {
+    let mut decl = String::from("{ ");
+    for (i, key) in destructure.keys.iter().enumerate() {
+        if i > 0 {
+            decl.push_str(", ");
+        }
+        decl.push_str(key.as_str());
+        decl.push_str(": {}");
+    }
+    decl.push_str(" }");
+    decl
 }
 
 /// Collect model names from defineModel calls.

--- a/crates/vize_atelier_sfc/src/compile_script/inline/compiler/props.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/inline/compiler/props.rs
@@ -1,6 +1,6 @@
 use vize_carton::String;
 
-use crate::script::ScriptCompileContext;
+use crate::script::{PropsDestructuredBindings, ScriptCompileContext};
 
 use super::super::super::props::{
     add_null_to_runtime_type, extract_prop_types_from_type, extract_with_defaults_defaults,
@@ -67,94 +67,100 @@ pub(super) fn build_user_props_decl(
         let resolved_type_args = resolve_type_args(type_args, &ctx.interfaces, &ctx.type_aliases);
         let prop_types = extract_prop_types_from_type(&resolved_type_args);
         if prop_types.is_empty() {
-            return None;
-        }
-        decl.extend_from_slice(b"{\n");
-        let total_items = prop_types.len();
-        let mut item_idx = 0;
-        for (name, prop_type) in &prop_types {
-            item_idx += 1;
-            // Try to resolve type references for props that resolved to `null`
-            let resolved_js_type = if prop_type.js_type == "null" {
-                if let Some(ref ts_type) = prop_type.ts_type {
-                    resolve_prop_js_type(ts_type, &ctx.interfaces, &ctx.type_aliases)
-                        .unwrap_or_else(|| prop_type.js_type.clone())
+            if let Some(ref destructure) = ctx.macros.props_destructure {
+                build_unknown_type_destructured_props_decl(&mut decl, destructure);
+            } else {
+                return None;
+            }
+        } else {
+            decl.extend_from_slice(b"{\n");
+            let total_items = prop_types.len();
+            let mut item_idx = 0;
+            for (name, prop_type) in &prop_types {
+                item_idx += 1;
+                // Try to resolve type references for props that resolved to `null`
+                let resolved_js_type = if prop_type.js_type == "null" {
+                    if let Some(ref ts_type) = prop_type.ts_type {
+                        resolve_prop_js_type(ts_type, &ctx.interfaces, &ctx.type_aliases)
+                            .unwrap_or_else(|| prop_type.js_type.clone())
+                    } else {
+                        prop_type.js_type.clone()
+                    }
                 } else {
                     prop_type.js_type.clone()
-                }
-            } else {
-                prop_type.js_type.clone()
-            };
-            let runtime_js_type = add_null_to_runtime_type(&resolved_js_type, prop_type.nullable);
-            decl.extend_from_slice(b"    ");
-            decl.extend_from_slice(name.as_bytes());
-            let mut has_option = false;
-            if is_prod && runtime_js_type != "Boolean" {
-                decl.extend_from_slice(b": {");
-            } else {
-                decl.extend_from_slice(b": { type: ");
-                decl.extend_from_slice(runtime_js_type.as_bytes());
-                has_option = true;
-                if needs_prop_type && let Some(ref ts_type) = prop_type.ts_type {
-                    if resolved_js_type == "null" {
-                        decl.extend_from_slice(b" as unknown as PropType<");
-                    } else {
-                        decl.extend_from_slice(b" as PropType<");
+                };
+                let runtime_js_type =
+                    add_null_to_runtime_type(&resolved_js_type, prop_type.nullable);
+                decl.extend_from_slice(b"    ");
+                decl.extend_from_slice(name.as_bytes());
+                let mut has_option = false;
+                if is_prod && runtime_js_type != "Boolean" {
+                    decl.extend_from_slice(b": {");
+                } else {
+                    decl.extend_from_slice(b": { type: ");
+                    decl.extend_from_slice(runtime_js_type.as_bytes());
+                    has_option = true;
+                    if needs_prop_type && let Some(ref ts_type) = prop_type.ts_type {
+                        if resolved_js_type == "null" {
+                            decl.extend_from_slice(b" as unknown as PropType<");
+                        } else {
+                            decl.extend_from_slice(b" as PropType<");
+                        }
+                        // Normalize multi-line types to single line
+                        let normalized = ts_type.split_whitespace().collect::<Vec<_>>().join(" ");
+                        decl.extend_from_slice(normalized.as_bytes());
+                        decl.push(b'>');
                     }
-                    // Normalize multi-line types to single line
-                    let normalized = ts_type.split_whitespace().collect::<Vec<_>>().join(" ");
-                    decl.extend_from_slice(normalized.as_bytes());
-                    decl.push(b'>');
                 }
-            }
-            if prop_type.optional && !is_prod {
+                if prop_type.optional && !is_prod {
+                    if has_option {
+                        decl.extend_from_slice(b", ");
+                    } else {
+                        decl.push(b' ');
+                    }
+                    decl.extend_from_slice(b"required: false");
+                    has_option = true;
+                }
+                let mut has_default = false;
+                if let Some(ref defaults) = with_defaults_args
+                    && let Some(default_val) = defaults.get(name.as_str())
+                {
+                    if has_option {
+                        decl.extend_from_slice(b", ");
+                    } else {
+                        decl.push(b' ');
+                    }
+                    decl.extend_from_slice(b"default: ");
+                    decl.extend_from_slice(default_val.as_bytes());
+                    has_option = true;
+                    has_default = true;
+                }
+                if !has_default
+                    && let Some(ref destructure) = ctx.macros.props_destructure
+                    && let Some(binding) = destructure.bindings.get(name.as_str())
+                    && let Some(ref default_val) = binding.default
+                {
+                    if has_option {
+                        decl.extend_from_slice(b", ");
+                    } else {
+                        decl.push(b' ');
+                    }
+                    decl.extend_from_slice(b"default: ");
+                    let default_val = normalize_destructure_default_value(default_val);
+                    decl.extend_from_slice(default_val.as_bytes());
+                }
                 if has_option {
-                    decl.extend_from_slice(b", ");
+                    decl.extend_from_slice(b" }");
                 } else {
-                    decl.push(b' ');
+                    decl.push(b'}');
                 }
-                decl.extend_from_slice(b"required: false");
-                has_option = true;
-            }
-            let mut has_default = false;
-            if let Some(ref defaults) = with_defaults_args
-                && let Some(default_val) = defaults.get(name.as_str())
-            {
-                if has_option {
-                    decl.extend_from_slice(b", ");
-                } else {
-                    decl.push(b' ');
+                if item_idx < total_items {
+                    decl.push(b',');
                 }
-                decl.extend_from_slice(b"default: ");
-                decl.extend_from_slice(default_val.as_bytes());
-                has_option = true;
-                has_default = true;
+                decl.push(b'\n');
             }
-            if !has_default
-                && let Some(ref destructure) = ctx.macros.props_destructure
-                && let Some(binding) = destructure.bindings.get(name.as_str())
-                && let Some(ref default_val) = binding.default
-            {
-                if has_option {
-                    decl.extend_from_slice(b", ");
-                } else {
-                    decl.push(b' ');
-                }
-                decl.extend_from_slice(b"default: ");
-                let default_val = normalize_destructure_default_value(default_val);
-                decl.extend_from_slice(default_val.as_bytes());
-            }
-            if has_option {
-                decl.extend_from_slice(b" }");
-            } else {
-                decl.push(b'}');
-            }
-            if item_idx < total_items {
-                decl.push(b',');
-            }
-            decl.push(b'\n');
+            decl.extend_from_slice(b"  }");
         }
-        decl.extend_from_slice(b"  }");
     } else if !props_macro.args.is_empty() {
         if let (true, Some(destructure)) =
             (needs_merge_defaults, ctx.macros.props_destructure.as_ref())
@@ -213,4 +219,30 @@ pub(super) fn build_user_props_decl(
     #[allow(clippy::disallowed_types)]
     let s = unsafe { std::string::String::from_utf8_unchecked(decl) };
     Some(s.into())
+}
+
+fn build_unknown_type_destructured_props_decl(
+    decl: &mut Vec<u8>,
+    destructure: &PropsDestructuredBindings,
+) {
+    decl.extend_from_slice(b"{\n");
+    for (i, key) in destructure.keys.iter().enumerate() {
+        decl.extend_from_slice(b"    ");
+        decl.extend_from_slice(key.as_bytes());
+        if let Some(binding) = destructure.bindings.get(key.as_str())
+            && let Some(default_val) = binding.default.as_ref()
+        {
+            decl.extend_from_slice(b": { default: ");
+            let default_val = normalize_destructure_default_value(default_val);
+            decl.extend_from_slice(default_val.as_bytes());
+            decl.extend_from_slice(b" }");
+        } else {
+            decl.extend_from_slice(b": {}");
+        }
+        if i < destructure.keys.len() - 1 {
+            decl.push(b',');
+        }
+        decl.push(b'\n');
+    }
+    decl.extend_from_slice(b"  }");
 }

--- a/crates/vize_atelier_sfc/src/compile_script/inline/snapshots/vize_atelier_sfc__compile_script__inline__tests__tests__imported_type_destructure_generates_runtime_props_fallback.snap
+++ b/crates/vize_atelier_sfc/src/compile_script/inline/snapshots/vize_atelier_sfc__compile_script__inline__tests__tests__imported_type_destructure_generates_runtime_props_fallback.snap
@@ -1,0 +1,19 @@
+---
+source: crates/vize_atelier_sfc/src/compile_script/inline/tests.rs
+expression: output.as_str()
+---
+import { computed } from "vue";
+export default {
+  __name: "TestComponent",
+  props: {
+    type: {},
+    title: {},
+    speakers: {}
+  },
+  setup(__props) {
+    const isEvent = computed(() => __props.type === "event");
+    return (_ctx, _cache) => {
+      return null;
+    };
+  }
+};

--- a/crates/vize_atelier_sfc/src/compile_script/inline/tests.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/inline/tests.rs
@@ -342,6 +342,19 @@ const { label, disabled, routeName } = defineProps<MenuItemProps>()
     }
 
     #[test]
+    fn test_imported_type_destructure_generates_runtime_props_fallback() {
+        let content = r#"
+import { computed } from 'vue'
+import type { TimetableCell } from '~~/i18n/timetable'
+
+const { type, title, speakers } = defineProps<TimetableCell>()
+const isEvent = computed(() => type === 'event')
+"#;
+        let output = compile_setup(content);
+        insta::assert_snapshot!(output.as_str());
+    }
+
+    #[test]
     fn test_define_props_destructure_value_on_next_line() {
         // Pattern: const { ... } =\n  defineProps<...>()
         // The destructure pattern is complete on line 1, but defineProps is on line 2.

--- a/tests/snapshots/inspect/elk.ts
+++ b/tests/snapshots/inspect/elk.ts
@@ -10,7 +10,7 @@ describe("elk inspector parity with Vue compiler", () => {
       {
         target: "dom",
         changedFiles: 253,
-        additions: 10_447,
+        additions: 10_451,
         removals: 13_198,
         officialErrors: 3,
         vizeErrors: 0,
@@ -18,7 +18,7 @@ describe("elk inspector parity with Vue compiler", () => {
       {
         target: "ssr",
         changedFiles: 253,
-        additions: 9_237,
+        additions: 9_241,
         removals: 24_560,
         officialErrors: 3,
         vizeErrors: 0,


### PR DESCRIPTION
## Summary
- rewrite destructured prop aliases in inline handlers and generated render expressions
- emit runtime prop declarations for destructured `defineProps<T>()` keys when an imported type cannot be resolved locally
- add SFC regression coverage and update the elk inspector parity budget for the new output

## Validation
- `cargo fmt --check`
- `cargo test -p vize_atelier_sfc`
- `cargo clippy -p vize_atelier_core -p vize_atelier_sfc -- -D warnings`
- `cargo build -p vize`
- `npx -y pnpm@10 --filter @vizejs/native build:debug`
- `VIZE_BIN=/Users/ubugeeei/Source/github.com/ubugeeei/vize/__agent_only/pr-props-destructure-runtime/target/debug/vize npx -y pnpm@10 --filter ./tests test:inspect`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/808"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782857041&installation_id=136613492&pr_number=808&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F808&signature=0936a2d0d02a7761b73da6dcdc4bb7b29a7bcd4e5b2e9a043960c04c857703d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->