### PR TITLE
fix: align Nuxt CSS extraction parity

### DIFF
--- a/crates/vize_atelier_sfc/src/vite_plugin/css_scope.rs
+++ b/crates/vize_atelier_sfc/src/vite_plugin/css_scope.rs
@@ -29,7 +29,7 @@ fn transform_css_block(css: &str, scope_id: &str) -> String {
 
         let header = &css[cursor..brace];
         let body = &css[brace + 1..end];
-        let leading_length = first_non_ws(header);
+        let leading_length = leading_trivia_end(header);
         let leading = leading_length.map_or(header, |length| &header[..length]);
         let statement = leading_length.map_or("", |length| &header[length..]);
 
@@ -444,6 +444,27 @@ fn first_non_ws(value: &str) -> Option<usize> {
         .map(|(index, _)| index)
 }
 
+fn leading_trivia_end(value: &str) -> Option<usize> {
+    let mut cursor = 0usize;
+
+    loop {
+        let (relative, _) = value[cursor..]
+            .char_indices()
+            .find(|(_, char)| !char.is_whitespace())?;
+        cursor += relative;
+
+        if !value[cursor..].starts_with("/*") {
+            return Some(cursor);
+        }
+
+        let comment_body_start = cursor + 2;
+        let Some(comment_end) = value[comment_body_start..].find("*/") else {
+            return Some(cursor);
+        };
+        cursor = comment_body_start + comment_end + 2;
+    }
+}
+
 fn trailing_trim_end(value: &str) -> usize {
     value
         .char_indices()
@@ -519,6 +540,26 @@ mod tests {
             )
             .as_str(),
             "@media (min-width: 1px) { .foo[data-v-x] { color: red; } }"
+        );
+    }
+
+    #[test]
+    fn keeps_leading_comments_before_media_rules() {
+        assert_eq!(
+            scope_css_for_pipeline(
+                "/* High contrast */\n@media (forced-colors: active) { .foo { color: red; } }",
+                "data-v-x"
+            )
+            .as_str(),
+            "/* High contrast */\n@media (forced-colors: active) { .foo[data-v-x] { color: red; } }"
+        );
+    }
+
+    #[test]
+    fn keeps_leading_comments_before_selectors() {
+        assert_eq!(
+            scope_css_for_pipeline("/* Button */\n.foo { color: red; }", "data-v-x").as_str(),
+            "/* Button */\n.foo[data-v-x] { color: red; }"
         );
     }
 }

--- a/npm/vite-plugin-vize/src/plugin/compat.test.ts
+++ b/npm/vite-plugin-vize/src/plugin/compat.test.ts
@@ -92,6 +92,19 @@ const msg = 'hello'
 }
 
 {
+  const transformed = transformScopedPreprocessorCss(
+    ".rrevdjwu > .group + .group { color: red; }",
+    "/src/MkSuperMenu.vue?vue=&type=style&index=0&scoped=data-v-menu&lang=scss.scss",
+  );
+
+  assert.equal(
+    transformed,
+    ".rrevdjwu > .group + .group[data-v-menu] { color: red; }",
+    "CSS-visible style IDs should still receive scoped preprocessor post-processing",
+  );
+}
+
+{
   const state = createState({
     isProduction: true,
     extractCss: true,
@@ -106,9 +119,14 @@ const msg = 'hello'
     "Production virtual SFC transforms should succeed",
   );
   assert.equal(
-    state.collectedCss.get(virtualSfcId)?.trim(),
-    ".card { color: rebeccapurple; }",
-    "Production virtual SFC transforms should register extracted CSS for bundling",
+    state.collectedCss.has(virtualSfcId),
+    false,
+    "Production virtual SFC transforms should let Vite collect emitted style imports",
+  );
+  assert.match(
+    result.code,
+    /import ".*Card\.setup\.ts\?vue=&type=style&index=0&lang=css";/,
+    "Production virtual SFC transforms should emit a virtual style import",
   );
 }
 

--- a/npm/vite-plugin-vize/src/plugin/compat.ts
+++ b/npm/vite-plugin-vize/src/plugin/compat.ts
@@ -45,14 +45,12 @@ export function createVueCompatPlugin(state: VizePluginState): Plugin {
 }
 
 export function normalizeVirtualStyleId(id: string): string {
-  if (!id.startsWith("\0") || !id.includes("?vue")) {
+  const withoutPrefix = id.startsWith("\0") ? id.slice(1) : id;
+  if (!withoutPrefix.includes("?vue")) {
     return id;
   }
 
-  return id
-    .slice(1)
-    .replace(/\.module\.\w+$/, "")
-    .replace(/\.\w+$/, "");
+  return withoutPrefix.replace(/\.module\.\w+$/, "").replace(/\.\w+$/, "");
 }
 
 export function transformScopedPreprocessorCss(code: string, id: string): string | null {

--- a/npm/vite-plugin-vize/src/plugin/load.test.ts
+++ b/npm/vite-plugin-vize/src/plugin/load.test.ts
@@ -608,6 +608,21 @@ assert.doesNotMatch(
   "Delegated style CSS should not leak v-bind() to Vite",
 );
 
+const applyCssVisibleStyleLoad = loadHook(
+  applyCssState,
+  "/src/ApplyStyles.vue?vue=&type=style&index=0&scoped=data-v-applycss&lang=css.css",
+  { ssr: false },
+);
+assert.ok(
+  applyCssVisibleStyleLoad && typeof applyCssVisibleStyleLoad === "object",
+  "CSS-visible virtual style IDs should load through Vize",
+);
+assert.equal(
+  applyCssVisibleStyleLoad.code,
+  String.raw`.root[data-v-applycss] { @apply text-fg; height: var(--applycss-height\ \+\ \'px\'); }`,
+  "CSS-visible delegated styles should keep Vite pipeline semantics",
+);
+
 const scssPath = "/src/MkSuperMenu.vue";
 const scssState: VizePluginState = {
   ...hmrState,
@@ -682,9 +697,14 @@ assert.doesNotMatch(
   "Production on-demand loads should not inline CSS when extraction is enabled",
 );
 assert.equal(
-  onDemandProdState.collectedCss.get(onDemandProdPath),
-  ".prod { color: seagreen; }",
-  "Production on-demand compilation should collect extracted CSS for generateBundle",
+  onDemandProdState.collectedCss.has(onDemandProdPath),
+  false,
+  "Production on-demand compilation should let Vite collect SFC style imports",
+);
+assert.match(
+  onDemandProdLoad.code,
+  /import ".*OnDemandProd\.vue\?vue=&type=style&index=0&lang=css";/,
+  "Production on-demand loads should emit a virtual style import for CSS extraction",
 );
 
 console.log("✅ vite-plugin-vize load boundary tests passed!");

--- a/npm/vite-plugin-vize/src/plugin/load.ts
+++ b/npm/vite-plugin-vize/src/plugin/load.ts
@@ -98,6 +98,15 @@ function hasNuxtComponentQuery(request: ReturnType<typeof classifyVitePluginRequ
   return new URLSearchParams(request.querySuffix.slice(1)).has("nuxt_component");
 }
 
+function normalizeStyleVirtualId(id: string): string {
+  const withoutPrefix = id.startsWith("\0") ? id.slice(1) : id;
+  if (!withoutPrefix.includes("?vue")) {
+    return id;
+  }
+
+  return withoutPrefix.replace(/\.module\.\w+$/, "").replace(/\.\w+$/, "");
+}
+
 function loadCompiledSfcModule(
   state: VizePluginState,
   realPath: string,
@@ -196,11 +205,6 @@ export function loadHook(
   loadOptions?: { ssr?: boolean },
 ): string | { code: string; map: null } | null {
   const request = classifyVitePluginRequest(id);
-  if (id !== RESOLVED_CSS_MODULE && !id.startsWith("\0")) {
-    if (!request.isVueSfcPath || !hasNuxtComponentQuery(request)) {
-      return null;
-    }
-  }
 
   // Pick the correct viteBase for URL resolution based on the build environment.
   const currentBase = loadOptions?.ssr ? state.serverViteBase : state.clientViteBase;
@@ -215,13 +219,7 @@ export function loadHook(
   }
 
   // Strip the \0 prefix and the appended extension suffix for style virtual IDs.
-  let styleId = id;
-  if (id.startsWith("\0") && id.includes("?vue")) {
-    styleId = id
-      .slice(1) // strip \0
-      .replace(/\.module\.\w+$/, "") // strip .module.{lang}
-      .replace(/\.\w+$/, ""); // strip .{lang}
-  }
+  const styleId = normalizeStyleVirtualId(id);
 
   const styleRequest = classifyVitePluginRequest(styleId);
   if (styleRequest.isVueStyleQuery) {
@@ -270,6 +268,12 @@ export function loadHook(
       );
     }
     return "";
+  }
+
+  if (id !== RESOLVED_CSS_MODULE && !id.startsWith("\0")) {
+    if (!request.isVueSfcPath || !hasNuxtComponentQuery(request)) {
+      return null;
+    }
   }
 
   // Handle Vue Router's ?definePage query through extracted artifacts.

--- a/npm/vite-plugin-vize/src/plugin/resolve.test.ts
+++ b/npm/vite-plugin-vize/src/plugin/resolve.test.ts
@@ -704,6 +704,26 @@ function expectResolvedId(resolved: Awaited<ReturnType<typeof resolveIdHook>>): 
 }
 
 {
+  const projectRoot = createTempProject("style-query");
+  const source = path.join(projectRoot, "app", "components", "Styled.vue");
+  writeFixtureFile(source, "<template><div /></template><style>.root{}</style>");
+
+  const resolved = await resolveIdHook(
+    nullResolveContext,
+    createState(projectRoot),
+    `${source}?vue=&type=style&index=0&lang=css`,
+    undefined,
+    undefined,
+  );
+
+  assert.equal(
+    expectResolvedId(resolved),
+    `${source}?vue=&type=style&index=0&lang=css.css`,
+    "Vue style queries should stay CSS-visible so Vite extracts them",
+  );
+}
+
+{
   const projectRoot = createTempProject("vue-raw-query");
   const source = path.join(projectRoot, "app", "components", "Raw.vue");
   writeFixtureFile(source, "<template><div /></template>");

--- a/npm/vite-plugin-vize/src/plugin/resolve.ts
+++ b/npm/vite-plugin-vize/src/plugin/resolve.ts
@@ -44,6 +44,46 @@ function resolveAliasRequest(
   return resolveViteAliasRequest(id, nativeCssAliasRules(state));
 }
 
+function getBarePackageName(id: string): string | null {
+  if (!isViteBareSpecifier(id)) {
+    return null;
+  }
+
+  const segments = id.split("/");
+  if (id.startsWith("@")) {
+    return segments.length >= 2 ? `${segments[0]}/${segments[1]}` : null;
+  }
+  return segments[0] || null;
+}
+
+function resolveBareImportFromPnpmHoist(request: string, base: string): string | null {
+  const packageName = getBarePackageName(request);
+  if (!packageName) {
+    return null;
+  }
+
+  let current = path.dirname(base);
+  while (current !== path.dirname(current)) {
+    const directPackage = path.join(current, "node_modules", packageName);
+    if (fs.existsSync(directPackage)) {
+      return null;
+    }
+
+    const hoistRoot = path.join(current, "node_modules", ".pnpm", "node_modules");
+    const hoistedPackage = path.join(hoistRoot, packageName);
+    if (fs.existsSync(hoistedPackage)) {
+      try {
+        return createRequire(path.join(hoistRoot, "__vize_probe__.js")).resolve(request);
+      } catch {
+        // Continue looking from parent directories.
+      }
+    }
+    current = path.dirname(current);
+  }
+
+  return null;
+}
+
 function resolveBareImportWithNode(
   state: Pick<VizePluginState, "root">,
   id: string,
@@ -51,6 +91,11 @@ function resolveBareImportWithNode(
 ): string | null {
   const { request, querySuffix } = splitViteIdQuery(id);
   for (const candidate of createViteBareImportBases(state.root, importer)) {
+    const hoisted = resolveBareImportFromPnpmHoist(request, candidate);
+    if (hoisted) {
+      return `${hoisted}${querySuffix}`;
+    }
+
     try {
       const requireFromBase = createRequire(candidate);
       const resolved = requireFromBase.resolve(request);
@@ -385,10 +430,6 @@ export async function resolveIdHook(
     return RESOLVED_CSS_MODULE;
   }
 
-  if (isBuild && request.normalizedFsId) {
-    return request.normalizedFsId;
-  }
-
   // Handle route macro queries.
   // - ?macro=true is used by Nuxt page macros.
   // - ?definePage is used by Vue Router file-based routing.
@@ -415,7 +456,11 @@ export async function resolveIdHook(
       state.logger.log(`resolveId: skipping node_modules style import ${id}`);
       return null;
     }
-    return `\0${id}${request.styleVirtualSuffix}`;
+    return `${request.normalizedFsId ?? id}${request.styleVirtualSuffix}`;
+  }
+
+  if (isBuild && request.normalizedFsId) {
+    return request.normalizedFsId;
   }
 
   // If importer is a vize virtual module or macro module, resolve imports against the real path

--- a/npm/vite-plugin-vize/src/plugin/state.test.ts
+++ b/npm/vite-plugin-vize/src/plugin/state.test.ts
@@ -205,9 +205,19 @@ const plainCssModule: CompiledModule = {
 
 syncCollectedCssForFile(cssState, "/src/Card.vue", plainCssModule);
 assert.equal(
-  cssState.collectedCss.get("/src/Card.vue"),
+  cssState.collectedCss.has("/src/Card.vue"),
+  false,
+  "Production SFC CSS with style block metadata should flow through Vite style imports",
+);
+
+syncCollectedCssForFile(cssState, "/src/Legacy.vue", {
+  ...plainCssModule,
+  styles: undefined,
+});
+assert.equal(
+  cssState.collectedCss.get("/src/Legacy.vue"),
   ".card { color: tomato; }",
-  "Production CSS collection should retain plain CSS modules",
+  "Production CSS collection should retain legacy plain CSS without style block metadata",
 );
 
 const delegatedCssModule: CompiledModule = {

--- a/npm/vite-plugin-vize/src/plugin/state.ts
+++ b/npm/vite-plugin-vize/src/plugin/state.ts
@@ -94,6 +94,11 @@ export function syncCollectedCssForFile(
     return;
   }
 
+  if (compiled.styles?.length) {
+    state.collectedCss.delete(filePath);
+    return;
+  }
+
   if (compiled.css && !hasDelegatedStyles(compiled)) {
     state.collectedCss.set(
       filePath,

--- a/npm/vite-plugin-vize/src/utils.test.ts
+++ b/npm/vite-plugin-vize/src/utils.test.ts
@@ -258,6 +258,45 @@ export default _sfc_main
   );
 }
 
+// Test 3g: production extracted plain CSS should flow through Vite's CSS pipeline
+{
+  const output = generateOutput(
+    {
+      code: `
+import { openBlock as _openBlock } from "vue"
+const _sfc_main = { name: "ProdStyles" }
+export default _sfc_main
+`,
+      scopeId: "prodstyles",
+      hasScoped: false,
+      styles: [
+        {
+          content: ".root { color: red; }",
+          lang: "css",
+          scoped: false,
+          module: false,
+          index: 0,
+        },
+      ],
+      css: ".root { color: red; }",
+    },
+    {
+      isProduction: true,
+      isDev: false,
+      extractCss: true,
+      filePath: "/src/ProdStyles.vue",
+    },
+  );
+  assert.ok(
+    output.includes('import "/src/ProdStyles.vue?vue=&type=style&index=0&lang=css";'),
+    "Production extracted plain CSS should emit a virtual style import",
+  );
+  assert.ok(
+    !output.includes("__vize_css__"),
+    "Production extracted plain CSS should not use runtime style injection",
+  );
+}
+
 // =============================================================================
 // Test: Query parameter preservation in relative imports
 // =============================================================================

--- a/npm/vite-plugin-vize/src/utils/index.ts
+++ b/npm/vite-plugin-vize/src/utils/index.ts
@@ -137,9 +137,12 @@ export function generateOutput(compiled: CompiledModule, options: GenerateOutput
   }
 
   // Determine whether to use delegated style imports or inline CSS injection
-  const useDelegatedStyles = hasDelegatedStyles(compiled) && filePath;
+  const useStyleImports =
+    !!filePath &&
+    !!compiled.styles?.length &&
+    (hasDelegatedStyles(compiled) || (!ssr && isProduction && extractCss));
 
-  if (useDelegatedStyles) {
+  if (useStyleImports) {
     // --- Delegated style handling ---
     // Some style blocks require Vite's CSS pipeline (preprocessor or CSS Modules).
     // Emit virtual style imports for ALL blocks so Vite handles them uniformly.

--- a/tests/_helpers/apps.ts
+++ b/tests/_helpers/apps.ts
@@ -209,6 +209,17 @@ function patchNpmxLunariaModule(modulePath: string): void {
   }
 }
 
+function patchNpmxPackageJson(packageJsonPath: string): void {
+  const pkg = JSON.parse(fs.readFileSync(packageJsonPath, "utf-8"));
+  if (pkg.dependencies?.["@lunariajs/core"] === "0.1.1") {
+    return;
+  }
+
+  pkg.dependencies ??= {};
+  pkg.dependencies["@lunariajs/core"] = "0.1.1";
+  fs.writeFileSync(packageJsonPath, JSON.stringify(pkg, null, "\t") + "\n");
+}
+
 function patchNpmxPrerenderRoutes(configPath: string): void {
   const source = fs.readFileSync(configPath, "utf-8");
   const nextSource = source.replace(/prerender: true/g, "prerender: false");
@@ -1197,12 +1208,14 @@ function setupNpmxWorktree(opts?: { enableVize?: boolean; variant?: string }): s
     ensureLocalVizePackagesBuilt();
   }
 
-  addPnpmOverrides(path.join(npmxDir, "package.json"), {
+  const packageJsonPath = path.join(npmxDir, "package.json");
+  patchNpmxPackageJson(packageJsonPath);
+  addPnpmOverrides(packageJsonPath, {
     vite: "^8.0.0",
   });
 
   console.log(`[npmx.dev:${enableVize ? "candidate" : "reference"}:setup] pnpm install...`);
-  execSync("npx -y pnpm@10 install --no-frozen-lockfile", {
+  execSync("npx -y pnpm@10 install --no-frozen-lockfile --ignore-scripts", {
     cwd: npmxDir,
     stdio: "inherit",
     timeout: 300_000,
@@ -1211,6 +1224,18 @@ function setupNpmxWorktree(opts?: { enableVize?: boolean; variant?: string }): s
       ...NPMX_E2E_ENV,
     },
   });
+  for (const script of ["generate:lexicons", "generate:sprite"]) {
+    console.log(`[npmx.dev:${enableVize ? "candidate" : "reference"}:setup] pnpm ${script}...`);
+    execSync(`npx -y pnpm@10 ${script}`, {
+      cwd: npmxDir,
+      stdio: "inherit",
+      timeout: 120_000,
+      env: {
+        ...process.env,
+        ...NPMX_E2E_ENV,
+      },
+    });
+  }
 
   if (enableVize) {
     createVizeSymlinks(nmDir);
@@ -1246,34 +1271,100 @@ function setupNpmxWorktree(opts?: { enableVize?: boolean; variant?: string }): s
   return npmxDir;
 }
 
-function createNpmxVisualParityApp(kind: "candidate" | "reference", port: number): AppConfig {
-  const variant = `vrt-${kind}`;
+type VisualParityMode = "dev" | "preview";
+
+function ensureNpmxPreviewVueRuntime(npmxDir: string): void {
+  const outputNodeModulesDir = path.join(npmxDir, ".output", "server", "node_modules");
+  const vueRuntimeLink = path.join(outputNodeModulesDir, "vue");
+  const vueRuntimeTarget = path.join(npmxDir, "node_modules", "vue");
+  const vuePackageJsonPath = path.join(vueRuntimeTarget, "package.json");
+  const existingRendererEntry = path.join(vueRuntimeLink, "server-renderer", "index.mjs");
+
+  if (fs.existsSync(existingRendererEntry) || !fs.existsSync(vueRuntimeTarget)) {
+    return;
+  }
+
+  let target = vueRuntimeTarget;
+  if (fs.existsSync(vuePackageJsonPath)) {
+    const version = JSON.parse(fs.readFileSync(vuePackageJsonPath, "utf-8")).version;
+    const bundledTarget = path.join(outputNodeModulesDir, ".nitro", `vue@${version}`);
+    if (fs.existsSync(path.join(bundledTarget, "server-renderer", "index.mjs"))) {
+      target = bundledTarget;
+    }
+  }
+
+  fs.mkdirSync(outputNodeModulesDir, { recursive: true });
+  try {
+    const stat = fs.lstatSync(vueRuntimeLink);
+    if (stat.isSymbolicLink()) {
+      fs.unlinkSync(vueRuntimeLink);
+      fs.symlinkSync(target, vueRuntimeLink, "dir");
+      return;
+    }
+  } catch {
+    // does not exist
+  }
+
+  ensureSymlink(path.join(vueRuntimeLink, "server-renderer"), path.join(target, "server-renderer"));
+}
+
+function createNpmxVisualParityApp(
+  kind: "candidate" | "reference",
+  port: number,
+  mode: VisualParityMode,
+): AppConfig {
+  const variant = `vrt-${mode}-${kind}`;
+  const command =
+    mode === "preview"
+      ? ["exec", "nuxt", "preview", "--port", String(port)]
+      : ["exec", "nuxt", "dev", "--port", String(port), "--host", "0.0.0.0"];
+
   return {
-    name: `npmx.dev:${kind}`,
+    name: `npmx.dev:${mode}:${kind}`,
     cwd: getMutableGitFixtureDir("npmx.dev", variant),
     command: "npx",
-    args: ["-y", "pnpm@10", "exec", "nuxt", "dev", "--port", String(port), "--host", "0.0.0.0"],
+    args: ["-y", "pnpm@10", ...command],
     port,
     url: `http://127.0.0.1:${port}`,
     mountSelector: "#__nuxt",
-    readyPattern: new RegExp(
-      `Local:\\s+http:\\/\\/(localhost|127\\.0\\.0\\.1|0\\.0\\.0\\.0):${port}`,
-    ),
+    readyPattern:
+      mode === "preview"
+        ? /Listening on/
+        : new RegExp(`Local:\\s+http:\\/\\/(localhost|127\\.0\\.0\\.1|0\\.0\\.0\\.0):${port}`),
     allowNon200: true,
     waitUntil: "load",
     readyDelay: 30_000,
     env: NPMX_E2E_ENV,
     startupTimeout: 120_000,
     setup() {
-      setupNpmxWorktree({ enableVize: kind === "candidate", variant });
+      const npmxDir = setupNpmxWorktree({ enableVize: kind === "candidate", variant });
+      if (mode === "preview") {
+        execSync("npx -y pnpm@10 build", {
+          cwd: npmxDir,
+          env: {
+            ...process.env,
+            ...NPMX_E2E_ENV,
+            NODE_ENV: "production",
+          },
+          stdio: "inherit",
+          timeout: 300_000,
+        });
+        ensureNpmxPreviewVueRuntime(npmxDir);
+      }
     },
   };
 }
 
-export function createNpmxVisualParityApps(): { candidate: AppConfig; reference: AppConfig } {
+export function createNpmxVisualParityApps(mode: VisualParityMode = "dev"): {
+  candidate: AppConfig;
+  reference: AppConfig;
+} {
+  const referencePort = mode === "preview" ? 5330 : 5320;
+  const candidatePort = mode === "preview" ? 5331 : 5321;
+
   return {
-    reference: createNpmxVisualParityApp("reference", 5320),
-    candidate: createNpmxVisualParityApp("candidate", 5321),
+    reference: createNpmxVisualParityApp("reference", referencePort, mode),
+    candidate: createNpmxVisualParityApp("candidate", candidatePort, mode),
   };
 }
 

--- a/tests/app/vrt/npmx.spec.ts
+++ b/tests/app/vrt/npmx.spec.ts
@@ -25,12 +25,15 @@ interface VisualRoute {
   viewport?: { height: number; width: number };
 }
 
+type VisualMode = "dev" | "preview";
+
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const OUTPUT_DIR =
   process.env.VIZE_NPMX_VRT_OUTPUT_DIR ??
   path.resolve(__dirname, "../../../__agent_only/npmx-vrt/artifacts");
 const DEFAULT_VIEWPORT = { width: 1280, height: 720 };
-const apps = createNpmxVisualParityApps();
+const NPMX_VRT_TIMEOUT = 900_000;
+const modes: VisualMode[] = ["dev", "preview"];
 
 const routes: VisualRoute[] = [
   { name: "home", path: "/" },
@@ -52,10 +55,23 @@ const routes: VisualRoute[] = [
   { name: "compare", path: "/compare" },
   { name: "compare-packages", path: "/compare?packages=vue,react", maxDiffRatio: 0.004 },
   { name: "package-vue", path: "/package/vue", maxDiffRatio: 0.004 },
+  { name: "package-vue-version", path: "/package/vue/v/3.5.29", maxDiffRatio: 0.004 },
+  {
+    name: "package-vue-compiler-sfc",
+    path: "/package/@vue/compiler-sfc",
+    maxDiffRatio: 0.004,
+  },
   { name: "org-vue", path: "/org/vue", maxDiffRatio: 0.004 },
   { name: "user-sindresorhus", path: "/~sindresorhus?p=npm", maxDiffRatio: 0.004 },
   { name: "user-orgs-disconnected", path: "/~sindresorhus/orgs", maxDiffRatio: 0.004 },
+  { name: "profile-sindresorhus", path: "/profile/sindresorhus.com", maxDiffRatio: 0.004 },
   { name: "diff-vue", path: "/diff/vue/v/3.5.28...3.5.29", maxDiffRatio: 0.004 },
+  { name: "code-vue-tree", path: "/package-code/vue/v/3.5.29", maxDiffRatio: 0.004 },
+  {
+    name: "code-vue-package-json",
+    path: "/package-code/vue/v/3.5.29/package.json",
+    maxDiffRatio: 0.004,
+  },
   {
     name: "search-query",
     path: "/search",
@@ -79,24 +95,30 @@ const routes: VisualRoute[] = [
 ];
 
 test.describe("npmx.dev visual parity", () => {
-  test.describe.configure({ mode: "serial" });
+  test.describe.configure({ mode: "serial", timeout: NPMX_VRT_TIMEOUT });
 
-  let candidateServer: ChildProcess | undefined;
-  let referenceServer: ChildProcess | undefined;
+  for (const mode of modes) {
+    test.describe(mode, () => {
+      const apps = createNpmxVisualParityApps(mode);
+      let candidateServer: ChildProcess | undefined;
+      let referenceServer: ChildProcess | undefined;
 
-  test.beforeAll(async () => {
-    referenceServer = await startApp(apps.reference);
-    candidateServer = await startApp(apps.candidate);
-  });
+      test.beforeAll(async () => {
+        test.setTimeout(NPMX_VRT_TIMEOUT);
+        referenceServer = await startApp(apps.reference);
+        candidateServer = await startApp(apps.candidate);
+      });
 
-  test.afterAll(async () => {
-    killProcess(candidateServer);
-    killProcess(referenceServer);
-  });
+      test.afterAll(async () => {
+        killProcess(candidateServer);
+        killProcess(referenceServer);
+      });
 
-  for (const route of routes) {
-    test(route.name, async ({ browser }) => {
-      await compareRoute(browser, route);
+      for (const route of routes) {
+        test(route.name, async ({ browser }) => {
+          await compareRoute(browser, apps, mode, route);
+        });
+      }
     });
   }
 });
@@ -111,7 +133,12 @@ async function startApp(app: AppConfig): Promise<ChildProcess> {
   return server;
 }
 
-async function compareRoute(browser: Browser, route: VisualRoute): Promise<void> {
+async function compareRoute(
+  browser: Browser,
+  apps: ReturnType<typeof createNpmxVisualParityApps>,
+  mode: VisualMode,
+  route: VisualRoute,
+): Promise<void> {
   const context = await browser.newContext({
     colorScheme: "light",
     deviceScaleFactor: 1,
@@ -141,7 +168,7 @@ async function compareRoute(browser: Browser, route: VisualRoute): Promise<void>
 
     await expectVisualParity(referencePage, candidatePage, {
       maxDiffRatio: route.maxDiffRatio,
-      name: route.name,
+      name: `${mode}-${route.name}`,
       outputDir: OUTPUT_DIR,
     });
   } finally {


### PR DESCRIPTION
## Summary
- add full npmx.dev visual parity coverage for dev and production preview builds
- route npmx production CSS through Vite style imports so extracted CSS matches Vue compiler output
- fix CSS-visible style virtual IDs, pnpm hoisted bare import resolution, and scoped CSS comments before at-rules

## Validation
- `VIZE_TEST_WORKTREE_ID=codex-npmx-vrt VIZE_E2E_MAX_EMITTED_PROCESS_LOG_LINES=200 npx -y pnpm@10 --dir tests exec playwright test --config app/playwright.vrt.config.ts app/vrt/npmx.spec.ts --grep "dev"` (44 passed; includes dev and preview suites)
- `vp run --workspace-root check:ci`
- `vp run --filter './npm/vite-plugin-vize' test`
- `vp run --filter './npm/vite-plugin-vize' check`
- `vp run --filter './npm/vite-plugin-vize' build`
- `cargo fmt --all -- --check`
- `cargo clippy -p vize_atelier_sfc -- -D warnings`
- `cargo test -p vize_atelier_sfc css_scope`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/810"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782886064&installation_id=136613492&pr_number=810&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F810&signature=cc266e43044bb3724c2a9a46ee6a4b4199978e833f96257802eaf8ae41055b6b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->