### PR TITLE
fix: align Vue Fes scoped CSS parity

### DIFF
--- a/crates/vize_atelier_sfc/src/vite_plugin/css_scope.rs
+++ b/crates/vize_atelier_sfc/src/vite_plugin/css_scope.rs
@@ -722,7 +722,7 @@ mod tests {
                 "data-v-x"
             )
             .as_str(),
-            "/* High contrast */\n@media (forced-colors: active) { .foo[data-v-x] { color: red; } }"
+            "/* High contrast */\n@media (forced-colors: active) { .foo[data-v-x]{color: red;}}"
         );
     }
 
@@ -730,7 +730,7 @@ mod tests {
     fn keeps_leading_comments_before_selectors() {
         assert_eq!(
             scope_css_for_pipeline("/* Button */\n.foo { color: red; }", "data-v-x").as_str(),
-            "/* Button */\n.foo[data-v-x] { color: red; }"
+            "/* Button */\n.foo[data-v-x]{color: red;}"
         );
     }
 }

--- a/crates/vize_atelier_sfc/src/vite_plugin/css_scope.rs
+++ b/crates/vize_atelier_sfc/src/vite_plugin/css_scope.rs
@@ -13,46 +13,71 @@ pub(super) fn unwrap_deep_selectors(css: &str) -> String {
 }
 
 fn transform_css_block(css: &str, scope_id: &str) -> String {
+    transform_css_block_with_parents(css, scope_id, None)
+}
+
+fn transform_css_block_with_parents(
+    css: &str,
+    scope_id: &str,
+    parent_selectors: Option<&[String]>,
+) -> String {
     let mut output = String::with_capacity(css.len() + scope_id.len());
     let mut cursor = 0usize;
+    let mut declarations = String::default();
 
     while cursor < css.len() {
         let Some(brace) = find_next_top_level_brace(css, cursor) else {
-            output.push_str(&css[cursor..]);
+            declarations.push_str(&css[cursor..]);
             break;
         };
 
         let Some(end) = find_matching_brace(css, brace) else {
-            output.push_str(&css[cursor..]);
+            declarations.push_str(&css[cursor..]);
             break;
         };
 
-        let header = &css[cursor..brace];
+        let header_start = find_rule_header_start(css, cursor, brace);
+        declarations.push_str(&css[cursor..header_start]);
+        flush_declarations(
+            &mut output,
+            parent_selectors,
+            scope_id,
+            declarations.as_str(),
+        );
+        declarations.clear();
+
+        let header = &css[header_start..brace];
         let body = &css[brace + 1..end];
-        let leading_length = leading_trivia_end(header);
-        let leading = leading_length.map_or(header, |length| &header[..length]);
-        let statement = leading_length.map_or("", |length| &header[length..]);
+        let (leading, statement) = split_leading_trivia(header);
 
         output.push_str(leading);
         if statement.trim_start().starts_with('@') {
             output.push_str(statement);
             output.push('{');
             if should_recurse_at_rule(statement) {
-                output.push_str(transform_css_block(body, scope_id).as_str());
+                output.push_str(
+                    transform_css_block_with_parents(body, scope_id, parent_selectors).as_str(),
+                );
             } else {
                 output.push_str(body);
             }
             output.push('}');
         } else {
-            output.push_str(scope_selector_list(statement, scope_id).as_str());
-            output.push('{');
-            output.push_str(body);
-            output.push('}');
+            let selectors = combine_selector_lists(parent_selectors, statement);
+            output.push_str(
+                transform_css_block_with_parents(body, scope_id, Some(&selectors)).as_str(),
+            );
         }
 
         cursor = end + 1;
     }
 
+    flush_declarations(
+        &mut output,
+        parent_selectors,
+        scope_id,
+        declarations.as_str(),
+    );
     output
 }
 
@@ -61,6 +86,128 @@ fn should_recurse_at_rule(statement: &str) -> bool {
         statement.split_whitespace().next(),
         Some("@container" | "@layer" | "@media" | "@supports")
     )
+}
+
+fn find_rule_header_start(css: &str, start: usize, brace: usize) -> usize {
+    let mut paren_depth = 0usize;
+    let mut bracket_depth = 0usize;
+    let mut quote = None;
+    let mut in_comment = false;
+    let mut header_start = start;
+    let mut iter = css[start..brace].char_indices().peekable();
+
+    while let Some((relative, char)) = iter.next() {
+        let index = start + relative;
+        let next = iter.peek().map(|(_, next)| *next);
+
+        if in_comment {
+            if char == '*' && next == Some('/') {
+                iter.next();
+                in_comment = false;
+            }
+            continue;
+        }
+
+        if let Some(active_quote) = quote {
+            if char == '\\' {
+                iter.next();
+            } else if char == active_quote {
+                quote = None;
+            }
+            continue;
+        }
+
+        match char {
+            '/' if next == Some('*') => {
+                iter.next();
+                in_comment = true;
+            }
+            '\'' | '"' => quote = Some(char),
+            '(' => paren_depth += 1,
+            ')' => paren_depth = paren_depth.saturating_sub(1),
+            '[' => bracket_depth += 1,
+            ']' => bracket_depth = bracket_depth.saturating_sub(1),
+            ';' if paren_depth == 0 && bracket_depth == 0 => {
+                header_start = index + 1;
+            }
+            _ => {}
+        }
+    }
+
+    header_start
+}
+
+fn flush_declarations(
+    output: &mut String,
+    parent_selectors: Option<&[String]>,
+    scope_id: &str,
+    declarations: &str,
+) {
+    let declarations = declarations.trim();
+    if declarations.is_empty() {
+        return;
+    }
+
+    let Some(selectors) = parent_selectors else {
+        output.push_str(declarations);
+        return;
+    };
+
+    let mut selector_list = String::default();
+    for (index, selector) in selectors.iter().enumerate() {
+        if index > 0 {
+            selector_list.push(',');
+        }
+        selector_list.push_str(selector.as_str());
+    }
+
+    output.push_str(scope_selector_list(selector_list.as_str(), scope_id).as_str());
+    output.push('{');
+    output.push_str(declarations);
+    output.push('}');
+}
+
+fn combine_selector_lists(
+    parent_selectors: Option<&[String]>,
+    selector_list: &str,
+) -> SmallVec<[String; 4]> {
+    let selectors = split_selector_list(selector_list);
+    let mut output = SmallVec::new();
+
+    let Some(parents) = parent_selectors else {
+        for selector in selectors {
+            output.push(String::from(selector.trim()));
+        }
+        return output;
+    };
+
+    for parent in parents {
+        for selector in &selectors {
+            output.push(combine_selector(parent.as_str(), selector.trim()));
+        }
+    }
+
+    output
+}
+
+fn combine_selector(parent: &str, selector: &str) -> String {
+    if selector.contains('&') {
+        return String::from(selector.replace('&', parent).as_str());
+    }
+
+    let mut output = String::with_capacity(parent.len() + selector.len() + 1);
+    output.push_str(parent);
+    if selector
+        .chars()
+        .find(|char| !char.is_whitespace())
+        .is_some_and(|char| matches!(char, '>' | '+' | '~'))
+    {
+        output.push_str(selector);
+    } else {
+        output.push(' ');
+        output.push_str(selector);
+    }
+    output
 }
 
 fn find_next_top_level_brace(css: &str, start: usize) -> Option<usize> {
@@ -242,6 +389,27 @@ fn scope_selector(selector: &str, scope_id: &str) -> String {
     output.push_str(body.as_str());
     output.push_str(trailing);
     output
+}
+
+fn split_leading_trivia(value: &str) -> (&str, &str) {
+    let mut cursor = 0usize;
+
+    loop {
+        let ws_end = value[cursor..]
+            .char_indices()
+            .find(|(_, char)| !char.is_whitespace())
+            .map_or(value.len(), |(index, _)| cursor + index);
+        cursor = ws_end;
+
+        if !value[cursor..].starts_with("/*") {
+            return (&value[..cursor], &value[cursor..]);
+        }
+
+        let Some(end) = value[cursor + 2..].find("*/") else {
+            return (&value[..cursor], &value[cursor..]);
+        };
+        cursor += 2 + end + 2;
+    }
 }
 
 fn add_scope_before_trailing_combinator(selector: &str, scope_id: &str) -> String {
@@ -444,27 +612,6 @@ fn first_non_ws(value: &str) -> Option<usize> {
         .map(|(index, _)| index)
 }
 
-fn leading_trivia_end(value: &str) -> Option<usize> {
-    let mut cursor = 0usize;
-
-    loop {
-        let (relative, _) = value[cursor..]
-            .char_indices()
-            .find(|(_, char)| !char.is_whitespace())?;
-        cursor += relative;
-
-        if !value[cursor..].starts_with("/*") {
-            return Some(cursor);
-        }
-
-        let comment_body_start = cursor + 2;
-        let Some(comment_end) = value[comment_body_start..].find("*/") else {
-            return Some(cursor);
-        };
-        cursor = comment_body_start + comment_end + 2;
-    }
-}
-
 fn trailing_trim_end(value: &str) -> usize {
     value
         .char_indices()
@@ -493,7 +640,7 @@ mod tests {
     fn scopes_basic_selectors() {
         assert_eq!(
             scope_css_for_pipeline(".foo, .bar:hover { color: red; }", "data-v-x").as_str(),
-            ".foo[data-v-x], .bar[data-v-x]:hover { color: red; }"
+            ".foo[data-v-x],.bar[data-v-x]:hover{color: red;}"
         );
     }
 
@@ -505,7 +652,7 @@ mod tests {
                 "data-v-x"
             )
             .as_str(),
-            ".parent[data-v-x] .child:nth-child(2) { color: red; }"
+            ".parent[data-v-x] .child:nth-child(2){color: red;}"
         );
     }
 
@@ -517,7 +664,7 @@ mod tests {
                 "data-v-x"
             )
             .as_str(),
-            ".parent[data-v-x] > .child:nth-child(2) { color: red; }"
+            ".parent[data-v-x] > .child:nth-child(2){color: red;}"
         );
     }
 
@@ -539,7 +686,31 @@ mod tests {
                 "data-v-x"
             )
             .as_str(),
-            "@media (min-width: 1px) { .foo[data-v-x] { color: red; } }"
+            "@media (min-width: 1px) { .foo[data-v-x]{color: red;}}"
+        );
+    }
+
+    #[test]
+    fn scopes_nested_css_like_vue_pipeline() {
+        assert_eq!(
+            scope_css_for_pipeline(
+                "#pages-store { row-gap: 1.5rem; @media (--mobile) { row-gap: 1rem; } h1 { margin: 0; } :deep(.divider) { border: 0; } }",
+                "data-v-x"
+            )
+            .as_str(),
+            "#pages-store[data-v-x]{row-gap: 1.5rem;} @media (--mobile) {#pages-store[data-v-x]{row-gap: 1rem;}} #pages-store h1[data-v-x]{margin: 0;} #pages-store[data-v-x] .divider{border: 0;}"
+        );
+    }
+
+    #[test]
+    fn scopes_nested_css_under_media_rules() {
+        assert_eq!(
+            scope_css_for_pipeline(
+                "@media (--mobile) { .foo { color: red; :deep(.bar) { color: blue; } } }",
+                "data-v-x"
+            )
+            .as_str(),
+            "@media (--mobile) { .foo[data-v-x]{color: red;} .foo[data-v-x] .bar{color: blue;}}"
         );
     }
 

--- a/npm/rspack-vize-plugin/src/shared/utils.test.ts
+++ b/npm/rspack-vize-plugin/src/shared/utils.test.ts
@@ -235,7 +235,7 @@ void describe("addScopeToCssFallback", () => {
   void test("delegates scoped CSS transformation to native pipeline", () => {
     const output = addScopeToCssFallback(".root { color: red; }", "abc123");
 
-    assert.equal(output, ".root[data-v-abc123] { color: red; }");
+    assert.match(output, /^\.root\[data-v-abc123\]\s*\{\s*color:\s*red;\s*\}$/);
   });
 });
 

--- a/npm/vite-plugin-vize/src/plugin/compat.test.ts
+++ b/npm/vite-plugin-vize/src/plugin/compat.test.ts
@@ -86,7 +86,7 @@ const msg = 'hello'
 
   assert.equal(
     transformed,
-    ".rrevdjwu > .group + .group[data-v-menu] { color: red; }",
+    ".rrevdjwu > .group + .group[data-v-menu]{color: red;}",
     "Scoped preprocessor CSS should be scoped after preprocessing, matching Vue selector placement",
   );
 }
@@ -117,6 +117,16 @@ const msg = 'hello'
   assert.ok(
     result && typeof result === "object",
     "Production virtual SFC transforms should succeed",
+  );
+  assert.match(
+    result.code,
+    /import "\/virtual\/Card\.setup\.ts\?vue=&type=style&index=0&lang=css";/,
+    "Production virtual SFC transforms should emit Vite-visible plain CSS imports",
+  );
+  assert.doesNotMatch(
+    result.code,
+    /__vize_css__/,
+    "Production virtual SFC transforms should not inline CSS when extraction is enabled",
   );
   assert.equal(
     state.collectedCss.has(virtualSfcId),

--- a/npm/vite-plugin-vize/src/plugin/compat.test.ts
+++ b/npm/vite-plugin-vize/src/plugin/compat.test.ts
@@ -99,7 +99,7 @@ const msg = 'hello'
 
   assert.equal(
     transformed,
-    ".rrevdjwu > .group + .group[data-v-menu] { color: red; }",
+    ".rrevdjwu > .group + .group[data-v-menu]{color: red;}",
     "CSS-visible style IDs should still receive scoped preprocessor post-processing",
   );
 }

--- a/npm/vite-plugin-vize/src/plugin/load.test.ts
+++ b/npm/vite-plugin-vize/src/plugin/load.test.ts
@@ -597,11 +597,13 @@ assert.ok(
   applyCssVirtualLoad && typeof applyCssVirtualLoad === "object",
   "Delegated @apply CSS should load as a virtual style module",
 );
-assert.equal(
+assert.match(
   applyCssVirtualLoad.code,
-  String.raw`.root[data-v-applycss] { @apply text-fg; height: var(--applycss-height\ \+\ \'px\'); }`,
+  /\.root\[data-v-applycss\]\s*\{/,
   "Delegated @apply CSS should keep @apply while applying scoped selector and CSS vars",
 );
+assert.match(applyCssVirtualLoad.code, /@apply text-fg/);
+assert.ok(applyCssVirtualLoad.code.includes(String.raw`var(--applycss-height\ \+\ \'px\')`));
 assert.doesNotMatch(
   applyCssVirtualLoad.code,
   /v-bind\(/,
@@ -622,6 +624,46 @@ assert.equal(
   String.raw`.root[data-v-applycss] { @apply text-fg; height: var(--applycss-height\ \+\ \'px\'); }`,
   "CSS-visible delegated styles should keep Vite pipeline semantics",
 );
+
+const nestedCssPath = "/src/NestedStyles.vue";
+const nestedCssState: VizePluginState = {
+  ...hmrState,
+  cache: new Map([
+    [
+      nestedCssPath,
+      {
+        code: `const _sfc_main = { name: "NestedStyles" }
+export default _sfc_main`,
+        scopeId: "nestedcss",
+        hasScoped: true,
+        styles: [
+          {
+            content: `#pages-store { row-gap: 1.5rem; @media (--mobile) { row-gap: 1rem; } h1 { margin: 0; } :deep(.divider) { border: 0; } }`,
+            lang: "css",
+            scoped: true,
+            module: false,
+            index: 0,
+          },
+        ],
+      },
+    ],
+  ]),
+  ssrCache: new Map(),
+};
+
+const nestedCssVirtualLoad = loadHook(
+  nestedCssState,
+  "/src/NestedStyles.vue?vue=&type=style&index=0&scoped=data-v-nestedcss&lang=css.css",
+  { ssr: false },
+);
+assert.ok(
+  nestedCssVirtualLoad && typeof nestedCssVirtualLoad === "object",
+  "Nested plain CSS should load through the virtual style pipeline",
+);
+assert.match(nestedCssVirtualLoad.code, /#pages-store\[data-v-nestedcss\]/);
+assert.match(nestedCssVirtualLoad.code, /#pages-store h1\[data-v-nestedcss\]/);
+assert.match(nestedCssVirtualLoad.code, /#pages-store\[data-v-nestedcss\] \.divider/);
+assert.doesNotMatch(nestedCssVirtualLoad.code, /:deep/);
 
 const scssPath = "/src/MkSuperMenu.vue";
 const scssState: VizePluginState = {
@@ -695,6 +737,11 @@ assert.doesNotMatch(
   onDemandProdLoad.code,
   /__vize_css__/,
   "Production on-demand loads should not inline CSS when extraction is enabled",
+);
+assert.match(
+  onDemandProdLoad.code,
+  /import ".*OnDemandProd\.vue\?vue=&type=style&index=0&lang=css";/,
+  "Production on-demand loads should emit a Vite-visible plain CSS import",
 );
 assert.equal(
   onDemandProdState.collectedCss.has(onDemandProdPath),

--- a/npm/vite-plugin-vize/src/plugin/load.test.ts
+++ b/npm/vite-plugin-vize/src/plugin/load.test.ts
@@ -621,7 +621,7 @@ assert.ok(
 );
 assert.equal(
   applyCssVisibleStyleLoad.code,
-  String.raw`.root[data-v-applycss] { @apply text-fg; height: var(--applycss-height\ \+\ \'px\'); }`,
+  String.raw`.root[data-v-applycss]{@apply text-fg; height: var(--applycss-height\ \+\ \'px\');}`,
   "CSS-visible delegated styles should keep Vite pipeline semantics",
 );
 

--- a/npm/vite-plugin-vize/src/plugin/load.ts
+++ b/npm/vite-plugin-vize/src/plugin/load.ts
@@ -199,15 +199,6 @@ function loadDefinePageMetaArtifact(
   return code ? { code, map: null } : null;
 }
 
-function normalizeStyleVirtualId(id: string): string {
-  let styleId = id.startsWith("\0") ? id.slice(1) : id;
-  if (!styleId.includes("?vue")) {
-    return styleId;
-  }
-
-  return styleId.replace(/\.module\.\w+$/, "").replace(/\.\w+$/, "");
-}
-
 export function loadHook(
   state: VizePluginState,
   id: string,

--- a/npm/vite-plugin-vize/src/plugin/load.ts
+++ b/npm/vite-plugin-vize/src/plugin/load.ts
@@ -199,6 +199,15 @@ function loadDefinePageMetaArtifact(
   return code ? { code, map: null } : null;
 }
 
+function normalizeStyleVirtualId(id: string): string {
+  let styleId = id.startsWith("\0") ? id.slice(1) : id;
+  if (!styleId.includes("?vue")) {
+    return styleId;
+  }
+
+  return styleId.replace(/\.module\.\w+$/, "").replace(/\.\w+$/, "");
+}
+
 export function loadHook(
   state: VizePluginState,
   id: string,

--- a/npm/vite-plugin-vize/src/plugin/resolve.test.ts
+++ b/npm/vite-plugin-vize/src/plugin/resolve.test.ts
@@ -101,6 +101,23 @@ function expectResolvedId(resolved: Awaited<ReturnType<typeof resolveIdHook>>): 
 }
 
 {
+  const tempRoot = createTempRoot("style-query");
+  const source = path.join(tempRoot, "Styled.vue");
+  fs.writeFileSync(source, "<template /><style scoped>.root { color: red; }</style>");
+  const id = `${source}?vue=&type=style&index=0&scoped=data-v-resolve&lang=css`;
+
+  const state = createState(tempRoot);
+  state.server = null;
+  const resolved = await resolveIdHook(nullResolveContext, state, id, undefined, undefined);
+
+  assert.equal(
+    expectResolvedId(resolved),
+    `${id}.css`,
+    "Vue style queries should resolve to CSS-visible virtual style IDs in build mode",
+  );
+}
+
+{
   const tempRoot = createTempRoot("define-page");
   const source = path.join(tempRoot, "Home.vue");
   fs.writeFileSync(source, "<script setup>definePage({})</script>");

--- a/npm/vite-plugin-vize/src/plugin/state.test.ts
+++ b/npm/vite-plugin-vize/src/plugin/state.test.ts
@@ -244,6 +244,22 @@ assert.equal(
   "Delegated CSS modules should stay out of the extracted plain CSS bundle",
 );
 
+const legacyCssModule: CompiledModule = {
+  code: "export default {}",
+  css: ".legacy { color: red; }",
+  scopeId: "legacycss",
+  hasScoped: false,
+  macroArtifacts: [],
+  styles: [],
+};
+
+syncCollectedCssForFile(cssState, "/src/Legacy.vue", legacyCssModule);
+assert.equal(
+  cssState.collectedCss.get("/src/Legacy.vue"),
+  ".legacy { color: red; }",
+  "Legacy compiled modules without style metadata should still use the extracted CSS bundle",
+);
+
 const ssrCssState = {
   extractCss: false,
   collectedCss: new Map<string, string>([["/src/App.vue", ".app { color: red; }"]]),

--- a/npm/vite-plugin-vize/src/utils.test.ts
+++ b/npm/vite-plugin-vize/src/utils.test.ts
@@ -297,6 +297,46 @@ export default _sfc_main
   );
 }
 
+// Test 3h: production scoped CSS extraction should still delegate plain CSS to Vite
+{
+  const output = generateOutput(
+    {
+      code: `
+const _sfc_main = { name: "PlainCss" }
+export default _sfc_main
+`,
+      scopeId: "plaincss",
+      hasScoped: true,
+      styles: [
+        {
+          content: ".root { color: red; }",
+          lang: "css",
+          scoped: true,
+          module: false,
+          index: 0,
+        },
+      ],
+    },
+    {
+      isProduction: true,
+      isDev: false,
+      extractCss: true,
+      filePath: "/src/PlainCss.vue",
+    },
+  );
+
+  assert.ok(
+    output.includes(
+      'import "/src/PlainCss.vue?vue=&type=style&index=0&scoped=data-v-plaincss&lang=css";',
+    ),
+    "Production plain CSS extraction should emit a Vite-visible style import",
+  );
+  assert.ok(
+    !output.includes("__vize_css__"),
+    "Production plain CSS extraction should not use inline CSS injection",
+  );
+}
+
 // =============================================================================
 // Test: Query parameter preservation in relative imports
 // =============================================================================

--- a/npm/vite-plugin-vize/src/utils/index.ts
+++ b/npm/vite-plugin-vize/src/utils/index.ts
@@ -136,7 +136,9 @@ export function generateOutput(compiled: CompiledModule, options: GenerateOutput
     output += "\nexport default _sfc_main;";
   }
 
-  // Determine whether to use delegated style imports or inline CSS injection
+  // Determine whether to use style imports or inline CSS injection.
+  // Production CSS extraction must still import plain CSS through Vite so its
+  // CSS pipeline can apply nesting, minification, and chunk graph ownership.
   const useStyleImports =
     !!filePath &&
     !!compiled.styles?.length &&

--- a/tests/_helpers/apps.ts
+++ b/tests/_helpers/apps.ts
@@ -95,6 +95,10 @@ const NPMX_E2E_ENV = {
   NUXT_SESSION_PASSWORD: "e2e-test-dummy-session-password-32chars!",
   VIZE_E2E_DISABLE_LUNARIA: "1",
 } as const;
+const VUEFES_E2E_ENV = {
+  AUTH_SECRET: "e2e-test-dummy-auth-secret-32chars!",
+  NEXTAUTH_SECRET: "e2e-test-dummy-auth-secret-32chars!",
+} as const;
 const TRANSPARENT_PNG = Buffer.from(
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQIW2P8z/C/HwAFgwJ/lE6nWQAAAABJRU5ErkJggg==",
   "base64",
@@ -1466,33 +1470,69 @@ function setupVuefesWorktree(opts?: { enableVize?: boolean; variant?: string }):
   return vuefesDir;
 }
 
-function createVuefesVisualParityApp(kind: "candidate" | "reference", port: number): AppConfig {
-  const variant = `vrt-${kind}`;
+type VuefesVisualParityMode = "dev" | "preview";
+
+function createVuefesVisualParityApp(
+  kind: "candidate" | "reference",
+  port: number,
+  mode: VuefesVisualParityMode,
+): AppConfig {
+  const variant = `vrt-${mode}-${kind}`;
+  const command =
+    mode === "preview"
+      ? ["exec", "nuxt", "preview", "--port", String(port)]
+      : ["exec", "nuxt", "dev", "--port", String(port), "--host", "0.0.0.0"];
+
   return {
-    name: `vuefes-2025:${kind}`,
+    name: `vuefes-2025:${mode}:${kind}`,
     cwd: getMutableGitFixtureDir("vuefes-2025", variant),
     command: "npx",
-    args: ["-y", "pnpm@10", "exec", "nuxt", "dev", "--port", String(port), "--host", "0.0.0.0"],
+    args: ["-y", "pnpm@10", ...command],
     port,
-    url: `http://127.0.0.1:${port}`,
+    url: mode === "preview" ? `http://127.0.0.1:${port}/2025` : `http://127.0.0.1:${port}`,
     mountSelector: "#__nuxt",
-    readyPattern: new RegExp(
-      `Local:\\s+http:\\/\\/(localhost|127\\.0\\.0\\.1|0\\.0\\.0\\.0):${port}`,
-    ),
+    readyPattern:
+      mode === "preview"
+        ? /Listening on/
+        : new RegExp(`Local:\\s+http:\\/\\/(localhost|127\\.0\\.0\\.1|0\\.0\\.0\\.0):${port}`),
     allowNon200: true,
     waitUntil: "load",
     readyDelay: 30_000,
-    startupTimeout: 180_000,
+    env: {
+      ...VUEFES_E2E_ENV,
+      CONTEXT: "production",
+      NODE_ENV: mode === "preview" ? "production" : "development",
+    },
+    startupTimeout: 300_000,
     setup() {
-      setupVuefesWorktree({ enableVize: kind === "candidate", variant });
+      const vuefesDir = setupVuefesWorktree({ enableVize: kind === "candidate", variant });
+      if (mode === "preview") {
+        execSync("npx -y pnpm@10 build", {
+          cwd: vuefesDir,
+          env: {
+            ...process.env,
+            ...VUEFES_E2E_ENV,
+            CONTEXT: "production",
+            NODE_ENV: "production",
+          },
+          stdio: "inherit",
+          timeout: 300_000,
+        });
+      }
     },
   };
 }
 
-export function createVuefesVisualParityApps(): { candidate: AppConfig; reference: AppConfig } {
+export function createVuefesVisualParityApps(mode: VuefesVisualParityMode = "dev"): {
+  candidate: AppConfig;
+  reference: AppConfig;
+} {
+  const referencePort = mode === "preview" ? 5332 : 5326;
+  const candidatePort = mode === "preview" ? 5333 : 5327;
+
   return {
-    reference: createVuefesVisualParityApp("reference", 5326),
-    candidate: createVuefesVisualParityApp("candidate", 5327),
+    reference: createVuefesVisualParityApp("reference", referencePort, mode),
+    candidate: createVuefesVisualParityApp("candidate", candidatePort, mode),
   };
 }
 

--- a/tests/app/vrt/vuefes.spec.ts
+++ b/tests/app/vrt/vuefes.spec.ts
@@ -22,13 +22,16 @@ interface VisualRoute {
   viewport?: { height: number; width: number };
 }
 
+type VisualMode = "dev" | "preview";
+
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const OUTPUT_DIR =
   process.env.VIZE_VUEFES_VRT_OUTPUT_DIR ??
   path.resolve(__dirname, "../../../__agent_only/vuefes-vrt/artifacts");
 const DEFAULT_VIEWPORT = { width: 1280, height: 720 };
 const MOBILE_VIEWPORT = { width: 390, height: 844 };
-const apps = createVuefesVisualParityApps();
+const VUEFES_VRT_TIMEOUT = 900_000;
+const modes: VisualMode[] = ["dev", "preview"];
 
 const routes: VisualRoute[] = [
   { name: "home", path: "/" },
@@ -37,8 +40,10 @@ const routes: VisualRoute[] = [
   { name: "photo", path: "/photo" },
   { name: "timetable", path: "/timetable", maxDiffRatio: 0.004 },
   { name: "speaker", path: "/speaker" },
+  { name: "speaker-panel", path: "/speaker?section=panel-discussion" },
   { name: "speaker-detail", path: "/speaker/yyx990803" },
   { name: "event", path: "/event", maxDiffRatio: 0.007 },
+  { name: "event-panel", path: "/event?section=panel-discussion", maxDiffRatio: 0.007 },
   { name: "store", path: "/store" },
   { name: "ticket", path: "/ticket" },
   { name: "sponsors", path: "/sponsors" },
@@ -51,24 +56,30 @@ const routes: VisualRoute[] = [
 ];
 
 test.describe("vuefes-2025 visual parity", () => {
-  test.describe.configure({ mode: "serial" });
+  test.describe.configure({ mode: "serial", timeout: VUEFES_VRT_TIMEOUT });
 
-  const servers: Array<ReturnType<typeof startDevServer>> = [];
+  for (const mode of modes) {
+    test.describe(mode, () => {
+      const apps = createVuefesVisualParityApps(mode);
+      const servers: Array<ReturnType<typeof startDevServer>> = [];
 
-  test.beforeAll(async () => {
-    servers.push(await startApp(apps.reference));
-    servers.push(await startApp(apps.candidate));
-  });
+      test.beforeAll(async () => {
+        test.setTimeout(VUEFES_VRT_TIMEOUT);
+        servers.push(await startApp(apps.reference));
+        servers.push(await startApp(apps.candidate));
+      });
 
-  test.afterAll(async () => {
-    for (const server of servers) {
-      killProcess(server);
-    }
-  });
+      test.afterAll(async () => {
+        for (const server of servers) {
+          killProcess(server);
+        }
+      });
 
-  for (const route of routes) {
-    test(route.name, async ({ browser }) => {
-      await compareRoute(browser, route);
+      for (const route of routes) {
+        test(route.name, async ({ browser }) => {
+          await compareRoute(browser, apps, mode, route);
+        });
+      }
     });
   }
 });
@@ -83,7 +94,12 @@ async function startApp(app: AppConfig): Promise<ReturnType<typeof startDevServe
   return server;
 }
 
-async function compareRoute(browser: Browser, route: VisualRoute): Promise<void> {
+async function compareRoute(
+  browser: Browser,
+  apps: ReturnType<typeof createVuefesVisualParityApps>,
+  mode: VisualMode,
+  route: VisualRoute,
+): Promise<void> {
   const context = await browser.newContext({
     colorScheme: "light",
     deviceScaleFactor: 1,
@@ -105,7 +121,7 @@ async function compareRoute(browser: Browser, route: VisualRoute): Promise<void>
 
     await expectVisualParity(referencePage, candidatePage, {
       maxDiffRatio: route.maxDiffRatio,
-      name: route.name,
+      name: `${mode}-${route.name}`,
       outputDir: OUTPUT_DIR,
     });
   } finally {


### PR DESCRIPTION
## Summary
- Add Vue Fes 2025 visual parity coverage for both dev and production preview builds.
- Run reference snapshots with the Vue compiler and candidate snapshots with Vize across the full Vue Fes route set, including panel-section query states.
- Align Vize production CSS extraction with Vite-visible style imports and fix nested scoped CSS / :deep handling used by Vue Fes.

## Validation
- `VIZE_TEST_WORKTREE_ID=codex-vuefes-vrt VIZE_E2E_MAX_EMITTED_PROCESS_LOG_LINES=200 npx -y pnpm@10 --dir tests exec playwright test --config app/playwright.vrt.config.ts app/vrt/vuefes.spec.ts --grep "preview"` (19 passed)
- `VIZE_TEST_WORKTREE_ID=codex-vuefes-vrt VIZE_E2E_MAX_EMITTED_PROCESS_LOG_LINES=200 npx -y pnpm@10 --dir tests exec playwright test --config app/playwright.vrt.config.ts app/vrt/vuefes.spec.ts --grep "dev"` (19 passed)
- `vp run --workspace-root check:ci`
- `vp run --filter './npm/vite-plugin-vize' test`
- `vp run --filter './npm/vite-plugin-vize' check`
- `vp run --filter './npm/vite-plugin-vize' build`
- `cargo fmt --all -- --check`
- `cargo clippy -p vize_atelier_sfc -- -D warnings`
- `cargo test -p vize_atelier_sfc vite_plugin::css_scope`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/811"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782888616&installation_id=136613492&pr_number=811&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F811&signature=527e58e54ec44753ef37c81589af06bf109e6bd11be768e3937204a2968c13ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->