### PR TITLE
fix: align frontend phpcon visual parity

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -14,6 +14,10 @@
 	path = tests/_fixtures/_git/vuefes-2025
 	url = https://github.com/vuejs-jp/vuefes-2025-website.git
 
+[submodule "tests/_fixtures/_git/frontend-phpcon-do-website"]
+	path = tests/_fixtures/_git/frontend-phpcon-do-website
+	url = https://github.com/frontend-phpcon-do/frontend-phpcon-do-website.git
+
 [submodule "tests/_fixtures/_git/ant-design-vue"]
 	path = tests/_fixtures/_git/ant-design-vue
 	url = https://github.com/vueComponent/ant-design-vue

--- a/crates/vize_atelier_core/src/codegen/expression/helpers.rs
+++ b/crates/vize_atelier_core/src/codegen/expression/helpers.rs
@@ -155,12 +155,15 @@ pub(crate) fn prefix_identifiers_with_context(content: &str, ctx: &CodegenContex
             };
 
             if is_assignment_target {
-                let needs_value = matches!(
-                    binding_type,
-                    Some(
-                        BindingType::SetupLet | BindingType::SetupMaybeRef | BindingType::SetupRef
-                    )
-                );
+                let needs_value = self.ctx.options.inline
+                    && matches!(
+                        binding_type,
+                        Some(
+                            BindingType::SetupLet
+                                | BindingType::SetupMaybeRef
+                                | BindingType::SetupRef
+                        )
+                    );
                 let replacement = if needs_value {
                     let mut out = String::with_capacity(prefix.len() + name.len() + 6);
                     out.push_str(prefix);

--- a/crates/vize_atelier_core/src/codegen/expression/snapshots/vize_atelier_core__codegen__expression__generate__tests__assignment_setup_let_adds_value.snap
+++ b/crates/vize_atelier_core/src/codegen/expression/snapshots/vize_atelier_core__codegen__expression__generate__tests__assignment_setup_let_adds_value.snap
@@ -2,4 +2,4 @@
 source: crates/vize_atelier_core/src/codegen/expression/generate.rs
 expression: result.as_str()
 ---
-$setup.count.value = $setup.count + 1
+$setup.count = $setup.count + 1

--- a/crates/vize_atelier_core/src/codegen/expression/snapshots/vize_atelier_core__codegen__expression__generate__tests__assignment_setup_ref_adds_value.snap
+++ b/crates/vize_atelier_core/src/codegen/expression/snapshots/vize_atelier_core__codegen__expression__generate__tests__assignment_setup_ref_adds_value.snap
@@ -2,4 +2,4 @@
 source: crates/vize_atelier_core/src/codegen/expression/generate.rs
 expression: result.as_str()
 ---
-$setup.quoteId.value = null
+$setup.quoteId = null

--- a/crates/vize_atelier_core/src/transforms/transform_expression.rs
+++ b/crates/vize_atelier_core/src/transforms/transform_expression.rs
@@ -266,7 +266,7 @@ mod tests {
     }
 
     #[test]
-    fn test_process_expression_unrefs_function_mode_setup_refs() {
+    fn test_process_expression_uses_setup_proxy_in_function_mode() {
         let allocator = Bump::new();
         let mut bindings = FxHashMap::default();
         bindings.insert("isExternal".into(), BindingType::SetupRef);
@@ -295,9 +295,9 @@ mod tests {
 
         assert_eq!(
             result.content.as_str(),
-            "_unref($setup.isExternal) && $setup.isExternal.value"
+            "$setup.isExternal && $setup.isExternal.value"
         );
-        assert!(ctx.has_helper(RuntimeHelper::Unref));
+        assert!(!ctx.has_helper(RuntimeHelper::Unref));
     }
 
     #[test]

--- a/crates/vize_atelier_core/src/transforms/transform_expression/collector.rs
+++ b/crates/vize_atelier_core/src/transforms/transform_expression/collector.rs
@@ -98,24 +98,23 @@ impl<'a, 'ctx> IdentifierCollector<'a, 'ctx> {
         }
 
         // In inline mode, known refs are accessed with `.value`. In function
-        // mode, setup bindings live on `$setup` and must be unwrapped when
-        // read from templates.
-        if let Some(kind) = self.ctx.get_reactive_kind(name) {
-            return !self.ctx.options.inline && kind.needs_value_access();
+        // mode, setup bindings are read through Vue's `$setup` proxy, matching
+        // @vue/compiler-sfc output.
+        if self.ctx.get_reactive_kind(name).is_some() {
+            return false;
         }
 
-        // Fallback: SetupLet/SetupMaybeRef have unknown type, need _unref().
-        // SetupRef also needs _unref in function mode because `$setup.foo`
-        // refers to the raw ref/computed object.
+        // Fallback: SetupLet/SetupMaybeRef have unknown type and need
+        // _unref() only when they are captured by an inline render closure.
         if let Some(bindings) = &self.ctx.options.binding_metadata
             && let Some(binding_type) = bindings.bindings.get(name)
         {
-            return match binding_type {
-                crate::options::BindingType::SetupRef => !self.ctx.options.inline,
-                crate::options::BindingType::SetupLet
-                | crate::options::BindingType::SetupMaybeRef => true,
-                _ => false,
-            };
+            return self.ctx.options.inline
+                && matches!(
+                    binding_type,
+                    crate::options::BindingType::SetupLet
+                        | crate::options::BindingType::SetupMaybeRef
+                );
         }
         false
     }
@@ -257,7 +256,7 @@ impl<'a, 'ctx> Visit<'_> for IdentifierCollector<'a, 'ctx> {
                 self.rewrites
                     .insert((ident.span.start as usize, String::new(prefix)));
             }
-            if self.is_ref_binding(name) || needs_unref {
+            if self.ctx.options.inline && (self.is_ref_binding(name) || needs_unref) {
                 // For assignment targets wrapped in parens like ((model) = $event),
                 // we need to place .value after the closing paren: ((model).value = $event)
                 // Scan forward from ident.span.end to skip past ')' characters
@@ -272,8 +271,6 @@ impl<'a, 'ctx> Visit<'_> for IdentifierCollector<'a, 'ctx> {
         }
 
         if let Some(prefix) = get_identifier_prefix(name, self.ctx) {
-            // In function mode, SetupLet bindings need both $setup. prefix and _unref() wrapper
-            // Result: _unref($setup.b) instead of just $setup.b
             if needs_unref && prefix == "$setup." {
                 self.rewrites
                     .insert((ident.span.start as usize, String::new("_unref($setup.")));
@@ -380,16 +377,13 @@ impl<'a, 'ctx> Visit<'_> for IdentifierCollector<'a, 'ctx> {
             // or needs _unref() wrapping.
             // In inline mode, refs have no prefix but need .value, so shorthand
             // { hasForm } must become { hasForm: hasForm.value } (not { hasForm.value }).
-            // Similarly, SetupLet/SetupMaybeRef bindings need _unref():
+            // Similarly, inline SetupLet/SetupMaybeRef bindings need _unref():
             // { paddingBottom } must become { paddingBottom: _unref(paddingBottom) }
             if prefix.is_some_and(|p| !p.is_empty()) || is_ref || needs_unref {
                 let p = prefix.unwrap_or("");
                 let (value_prefix, value_suffix) = if needs_unref && p.is_empty() {
                     // Inline mode: wrap with _unref()
                     ("_unref(", ")")
-                } else if needs_unref && p == "$setup." {
-                    // Function mode: wrap with _unref($setup.)
-                    ("_unref($setup.", ")")
                 } else if is_ref {
                     ("", ".value")
                 } else {

--- a/crates/vize_atelier_sfc/src/compile.rs
+++ b/crates/vize_atelier_sfc/src/compile.rs
@@ -227,6 +227,7 @@ fn compile_sfc_inner(
                         scope_id: &scope_id,
                         apply_scope_id: options.template.ssr && has_scoped,
                         is_ts: template_is_ts,
+                        inline: false,
                         component_name: Some(&component_name),
                         bindings: None,
                         croquis: None,
@@ -345,6 +346,7 @@ fn compile_sfc_inner(
                             scope_id: &scope_id,
                             apply_scope_id: options.template.ssr && has_scoped,
                             is_ts: template_is_ts,
+                            inline: false,
                             component_name: Some(&component_name),
                             bindings: None,
                             croquis: None,
@@ -564,6 +566,11 @@ fn compile_sfc_inner(
         }
     }
 
+    let source_is_ts = script_setup
+        .lang
+        .as_ref()
+        .is_some_and(|l| l == "ts" || l == "tsx");
+
     // Compile template with bindings (if present) to get the render function
     let template_result = if let Some(template) = &descriptor.template {
         if is_vapor {
@@ -590,6 +597,7 @@ fn compile_sfc_inner(
                         scope_id: &scope_id,
                         apply_scope_id: options.template.ssr && has_scoped,
                         is_ts: template_is_ts,
+                        inline: true,
                         component_name: Some(&component_name),
                         bindings: Some(&script_bindings),
                         croquis: Some(croquis),
@@ -666,12 +674,6 @@ fn compile_sfc_inner(
     // 2. User imports
     // 3. Hoisted literal consts (module-level)
     // 4. export default { __name, props?, emits?, setup(__props) { ... return (_ctx, _cache) => { ... } } }
-    // Detect if the source script setup uses TypeScript
-    let source_is_ts = script_setup
-        .lang
-        .as_ref()
-        .is_some_and(|l| l == "ts" || l == "tsx");
-
     let script_result = profile!(
         "atelier.sfc.script_setup.inline_compile",
         compile_script_setup_inline_with_context(

--- a/crates/vize_atelier_sfc/src/compile/tests.rs
+++ b/crates/vize_atelier_sfc/src/compile/tests.rs
@@ -1858,7 +1858,7 @@ const schema = {}
     assert!(
         result
             .code
-            .contains("_unref($setup.valibotResolver)($setup.schema)"),
+            .contains("$setup.valibotResolver($setup.schema)"),
         "{}",
         result.code
     );

--- a/crates/vize_atelier_sfc/src/compile/tests.rs
+++ b/crates/vize_atelier_sfc/src/compile/tests.rs
@@ -1505,6 +1505,62 @@ import DashTest from './dash-test.vue'
 }
 
 #[test]
+fn test_script_setup_resolve_component_uses_inline_render_mode() {
+    let source = r#"<script setup lang="ts">
+import Child from './Child.vue'
+import { computed, resolveComponent } from 'vue'
+
+const componentsMap = computed(() => ({
+  h1: resolveComponent('prose-h1', false),
+}))
+</script>
+
+<template>
+  <Child :components="componentsMap" />
+</template>"#;
+
+    let descriptor = parse_sfc(source, SfcParseOptions::default()).expect("Failed to parse SFC");
+    let opts = SfcCompileOptions {
+        script: ScriptCompileOptions {
+            is_ts: true,
+            ..Default::default()
+        },
+        template: TemplateCompileOptions {
+            is_ts: true,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let result = compile_sfc(&descriptor, opts).expect("Failed to compile SFC");
+
+    assert!(
+        result.code.contains("return (_ctx: any,_cache: any) =>"),
+        "{}",
+        result.code
+    );
+    assert!(
+        result.code.contains("componentsMap.value"),
+        "{}",
+        result.code
+    );
+    assert!(
+        !result.code.contains("function _sfc_render("),
+        "{}",
+        result.code
+    );
+    assert!(
+        !result.code.contains("__sfc__.render = _sfc_render"),
+        "{}",
+        result.code
+    );
+    assert!(
+        !result.code.contains("components: $setup.componentsMap"),
+        "{}",
+        result.code
+    );
+}
+
+#[test]
 fn test_script_setup_sfc_uses_setup_member_bindings_for_dotted_components() {
     let source = r#"<script setup lang="ts">
 import { Form, Input } from 'ant-design-vue'

--- a/crates/vize_atelier_sfc/src/compile_template.rs
+++ b/crates/vize_atelier_sfc/src/compile_template.rs
@@ -22,6 +22,7 @@ pub(crate) struct TemplateBlockCompileContext<'a> {
     pub(crate) scope_id: &'a str,
     pub(crate) apply_scope_id: bool,
     pub(crate) is_ts: bool,
+    pub(crate) inline: bool,
     pub(crate) component_name: Option<&'a str>,
     pub(crate) bindings: Option<&'a BindingMetadata>,
     pub(crate) croquis: Option<vize_croquis::analysis::Croquis>,
@@ -38,6 +39,7 @@ pub(crate) fn compile_template_block(
         scope_id,
         apply_scope_id,
         is_ts,
+        inline,
         component_name,
         bindings,
         croquis,
@@ -121,7 +123,7 @@ pub(crate) fn compile_template_block(
     // For script setup, use inline mode to match Vue's actual compiler behavior
     // Inline mode generates direct closure references (e.g., msg instead of $setup.msg)
     // which are captured in the setup() function scope
-    if bindings.is_some() {
+    if inline && bindings.is_some() {
         dom_opts.inline = true;
         dom_opts.hoist_static = true;
         dom_opts.cache_handlers = true;

--- a/crates/vize_atelier_sfc/src/css/scoped.rs
+++ b/crates/vize_atelier_sfc/src/css/scoped.rs
@@ -315,12 +315,12 @@ fn push_deep_scope_prefix(out: &mut BumpVec<u8>, before: &str, attr_selector: &[
     let target_end = before[..combinator_start].trim_end().len();
     if target_end == 0 {
         out.extend_from_slice(attr_selector);
-        out.extend_from_slice(before[combinator_start..].as_bytes());
+        out.extend_from_slice(&before.as_bytes()[combinator_start..]);
         return;
     }
 
     scope_single_selector(out, &before[..target_end], attr_selector);
-    out.extend_from_slice(before[target_end..].as_bytes());
+    out.extend_from_slice(&before.as_bytes()[target_end..]);
 }
 
 fn trailing_combinator_start(value: &str) -> Option<usize> {

--- a/crates/vize_atelier_sfc/src/css/scoped.rs
+++ b/crates/vize_atelier_sfc/src/css/scoped.rs
@@ -291,17 +291,44 @@ pub(super) fn transform_deep(
         let inner = &after[..end];
         let rest = &after[end + 1..];
 
-        if before.is_empty() {
-            out.extend_from_slice(attr_selector);
-        } else {
-            out.extend_from_slice(before.trim().as_bytes());
-            out.extend_from_slice(attr_selector);
-        }
+        push_deep_scope_prefix(out, before, attr_selector);
         out.push(b' ');
         out.extend_from_slice(inner.as_bytes());
         out.extend_from_slice(rest.as_bytes());
     } else {
         out.extend_from_slice(selector.as_bytes());
+    }
+}
+
+fn push_deep_scope_prefix(out: &mut BumpVec<u8>, before: &str, attr_selector: &[u8]) {
+    let before = before.trim_end();
+    if before.is_empty() {
+        out.extend_from_slice(attr_selector);
+        return;
+    }
+
+    let Some(combinator_start) = trailing_combinator_start(before) else {
+        scope_single_selector(out, before.trim(), attr_selector);
+        return;
+    };
+
+    let target_end = before[..combinator_start].trim_end().len();
+    if target_end == 0 {
+        out.extend_from_slice(attr_selector);
+        out.extend_from_slice(before[combinator_start..].as_bytes());
+        return;
+    }
+
+    scope_single_selector(out, &before[..target_end], attr_selector);
+    out.extend_from_slice(before[target_end..].as_bytes());
+}
+
+fn trailing_combinator_start(value: &str) -> Option<usize> {
+    let bytes = value.as_bytes();
+    match bytes.last().copied()? {
+        b'>' | b'+' | b'~' => Some(bytes.len() - 1),
+        b'|' if bytes.len() >= 2 && bytes[bytes.len() - 2] == b'|' => Some(bytes.len() - 2),
+        _ => None,
     }
 }
 

--- a/crates/vize_atelier_sfc/src/css/tests.rs
+++ b/crates/vize_atelier_sfc/src/css/tests.rs
@@ -239,6 +239,17 @@ fn test_scope_deep() {
 }
 
 #[test]
+fn test_scope_deep_after_child_combinator() {
+    let bump = Bump::new();
+    let css = ".sponsors__item > :deep(.sponsor) { width: 100%; }";
+    let result = apply_scoped_css(&bump, css, "data-v-123");
+    assert_eq!(
+        result,
+        ".sponsors__item[data-v-123] > .sponsor{ width: 100%; }"
+    );
+}
+
+#[test]
 fn test_scope_global() {
     let bump = Bump::new();
     let mut out = BumpVec::new_in(&bump);

--- a/crates/vize_atelier_sfc/src/lib.rs
+++ b/crates/vize_atelier_sfc/src/lib.rs
@@ -271,6 +271,7 @@ const isRootSelected = ref(false)
                 scope_id: "",
                 apply_scope_id: false,
                 is_ts: true,
+                inline: true,
                 component_name: None,
                 bindings: Some(&binding_metadata),
                 croquis: Some(croquis),

--- a/crates/vize_atelier_sfc/src/style.rs
+++ b/crates/vize_atelier_sfc/src/style.rs
@@ -279,15 +279,7 @@ fn transform_deep(selector: &str, attr_selector: &str) -> String {
             let inner = &after[..end];
             let rest = &after[end + 1..];
 
-            let scoped_before = if before.is_empty() {
-                attr_selector.to_compact_string()
-            } else {
-                let trimmed = before.trim();
-                let mut result = String::with_capacity(trimmed.len() + attr_selector.len());
-                result.push_str(trimmed);
-                result.push_str(attr_selector);
-                result
-            };
+            let scoped_before = scope_deep_prefix(before, attr_selector);
 
             let mut result =
                 String::with_capacity(scoped_before.len() + inner.len() + rest.len() + 1);
@@ -300,6 +292,40 @@ fn transform_deep(selector: &str, attr_selector: &str) -> String {
     }
 
     selector.to_compact_string()
+}
+
+fn scope_deep_prefix(before: &str, attr_selector: &str) -> String {
+    let before = before.trim_end();
+    if before.is_empty() {
+        return attr_selector.to_compact_string();
+    }
+
+    let Some(combinator_start) = trailing_combinator_start(before) else {
+        return scope_single_selector(before.trim(), attr_selector);
+    };
+
+    let target_end = before[..combinator_start].trim_end().len();
+    if target_end == 0 {
+        let mut result = String::with_capacity(attr_selector.len() + before.len());
+        result.push_str(attr_selector);
+        result.push_str(&before[combinator_start..]);
+        return result;
+    }
+
+    let scoped_target = scope_single_selector(&before[..target_end], attr_selector);
+    let mut result = String::with_capacity(scoped_target.len() + before.len() - target_end);
+    result.push_str(&scoped_target);
+    result.push_str(&before[target_end..]);
+    result
+}
+
+fn trailing_combinator_start(value: &str) -> Option<usize> {
+    let bytes = value.as_bytes();
+    match bytes.last().copied()? {
+        b'>' | b'+' | b'~' => Some(bytes.len() - 1),
+        b'|' if bytes.len() >= 2 && bytes[bytes.len() - 2] == b'|' => Some(bytes.len() - 2),
+        _ => None,
+    }
 }
 
 /// Transform :slotted() for slot content
@@ -380,6 +406,22 @@ mod tests {
     fn test_transform_deep() {
         let result = transform_deep(":deep(.child)", "[data-v-123]");
         assert_eq!(result, "[data-v-123] .child");
+    }
+
+    #[test]
+    fn test_transform_deep_after_child_combinator() {
+        let result = transform_deep(".sponsors__item > :deep(.sponsor)", "[data-v-123]");
+        assert_eq!(result, ".sponsors__item[data-v-123] > .sponsor");
+    }
+
+    #[test]
+    fn test_apply_scoped_css_deep_after_child_combinator() {
+        let css = ".sponsors__item > :deep(.sponsor) { width: 100%; }";
+        let result = apply_scoped_css(css, "data-v-123");
+        assert_eq!(
+            result,
+            ".sponsors__item[data-v-123] > .sponsor{ width: 100%; }"
+        );
     }
 
     #[test]

--- a/crates/vize_atelier_sfc/src/vite_plugin/css_scope.rs
+++ b/crates/vize_atelier_sfc/src/vite_plugin/css_scope.rs
@@ -334,6 +334,9 @@ fn split_selector_list(selector_list: &str) -> SmallVec<[&str; 4]> {
         }
 
         match char {
+            '\\' => {
+                iter.next();
+            }
             '\'' | '"' => quote = Some(char),
             '(' => paren_depth += 1,
             ')' => paren_depth = paren_depth.saturating_sub(1),
@@ -500,6 +503,9 @@ fn find_scope_insert_position(target: &str) -> usize {
         }
 
         match char {
+            '\\' => {
+                iter.next();
+            }
             '\'' | '"' => quote = Some(char),
             '(' => paren_depth += 1,
             ')' => paren_depth = paren_depth.saturating_sub(1),
@@ -731,6 +737,18 @@ mod tests {
         assert_eq!(
             scope_css_for_pipeline("/* card */\n.foo { color: red; }", "data-v-x").as_str(),
             "/* card */\n.foo[data-v-x]{color: red;}"
+        );
+    }
+
+    #[test]
+    fn scopes_escaped_utility_selectors() {
+        assert_eq!(
+            scope_css_for_pipeline(
+                ".hover\\:text-\\[\\#00DC82\\]:hover { color: red; }.text-\\[80px\\] { font-size: 80px; }",
+                "data-v-x"
+            )
+            .as_str(),
+            ".hover\\:text-\\[\\#00DC82\\][data-v-x]:hover{color: red;}.text-\\[80px\\][data-v-x]{font-size: 80px;}"
         );
     }
 }

--- a/crates/vize_atelier_sfc/src/vite_plugin/css_scope.rs
+++ b/crates/vize_atelier_sfc/src/vite_plugin/css_scope.rs
@@ -715,22 +715,22 @@ mod tests {
     }
 
     #[test]
-    fn keeps_leading_comments_before_media_rules() {
+    fn preserves_comments_before_media_rules() {
         assert_eq!(
             scope_css_for_pipeline(
-                "/* High contrast */\n@media (forced-colors: active) { .foo { color: red; } }",
+                "/* desktop */\n@media (min-width: 1px) { .foo { color: red; } }",
                 "data-v-x"
             )
             .as_str(),
-            "/* High contrast */\n@media (forced-colors: active) { .foo[data-v-x]{color: red;}}"
+            "/* desktop */\n@media (min-width: 1px) { .foo[data-v-x]{color: red;}}"
         );
     }
 
     #[test]
-    fn keeps_leading_comments_before_selectors() {
+    fn preserves_comments_before_selectors() {
         assert_eq!(
-            scope_css_for_pipeline("/* Button */\n.foo { color: red; }", "data-v-x").as_str(),
-            "/* Button */\n.foo[data-v-x]{color: red;}"
+            scope_css_for_pipeline("/* card */\n.foo { color: red; }", "data-v-x").as_str(),
+            "/* card */\n.foo[data-v-x]{color: red;}"
         );
     }
 }

--- a/crates/vize_atelier_ssr/src/codegen/element/component.rs
+++ b/crates/vize_atelier_ssr/src/codegen/element/component.rs
@@ -38,6 +38,11 @@ impl<'a> SsrCodegenContext<'a> {
             self.resolve_component_binding_name(tag)
         };
         let props = self.build_component_props(el, false, is_dynamic_component);
+        let props = if is_dynamic_component {
+            self.with_scope_id_prop(props)
+        } else {
+            props
+        };
         let props = self.with_fallthrough_attrs(props, inherit_attrs);
 
         if is_dynamic_component {
@@ -273,6 +278,25 @@ impl<'a> SsrCodegenContext<'a> {
         let mut out = String::from("_mergeProps(");
         out.push_str(&props);
         out.push_str(", _attrs)");
+        out
+    }
+
+    fn with_scope_id_prop(&mut self, props: String) -> String {
+        let Some(scope_id) = self.options.scope_id.as_deref() else {
+            return props;
+        };
+
+        let scope_props = component_props_object(&[component_prop_entry(scope_id, "\"\"", false)]);
+        if props == "null" {
+            return scope_props;
+        }
+
+        self.use_core_helper(RuntimeHelper::MergeProps);
+        let mut out = String::from("_mergeProps(");
+        out.push_str(&props);
+        out.push_str(", ");
+        out.push_str(&scope_props);
+        out.push(')');
         out
     }
 

--- a/crates/vize_atelier_ssr/src/codegen/element/vnode.rs
+++ b/crates/vize_atelier_ssr/src/codegen/element/vnode.rs
@@ -277,6 +277,9 @@ impl<'a> SsrCodegenContext<'a> {
 
     fn build_plain_vnode_props(&mut self, el: &ElementNode) -> String {
         if el.props.is_empty() {
+            if let Some(scope_id) = self.options.scope_id.as_deref() {
+                return component_props_object(&[component_prop_entry(scope_id, "\"\"", false)]);
+            }
             return "null".to_compact_string();
         }
 
@@ -321,6 +324,10 @@ impl<'a> SsrCodegenContext<'a> {
                     }
                 }
             }
+        }
+
+        if let Some(scope_id) = self.options.scope_id.as_deref() {
+            entries.push(component_prop_entry(scope_id, "\"\"", false));
         }
 
         let entries = normalize_prop_entries(entries);

--- a/crates/vize_atelier_ssr/src/lib.rs
+++ b/crates/vize_atelier_ssr/src/lib.rs
@@ -159,7 +159,7 @@ fn get_namespace(tag: &str, parent: Option<&str>) -> Namespace {
 
 #[cfg(test)]
 mod tests {
-    use super::{Bump, compile_ssr};
+    use super::{Bump, SsrCompilerOptions, compile_ssr, compile_ssr_with_options};
 
     #[test]
     fn test_compile_simple_element() {
@@ -178,5 +178,35 @@ mod tests {
 
         assert!(errors.is_empty());
         insta::assert_snapshot!(result.code.as_str());
+    }
+
+    #[test]
+    fn test_scoped_dynamic_component_keeps_scope_id() {
+        let allocator = Bump::new();
+        let (_, errors, result) = compile_ssr_with_options(
+            &allocator,
+            r#"<component :is="tag"><span>Logo</span></component>"#,
+            SsrCompilerOptions {
+                scope_id: Some("data-v-test".into()),
+                ..SsrCompilerOptions::default()
+            },
+        );
+
+        assert!(errors.is_empty());
+        assert!(
+            result
+                .code
+                .contains(r#"_mergeProps({  }, { "data-v-test": "" })"#)
+                || result.code.contains(r#"{ "data-v-test": "" }"#),
+            "{}",
+            result.code
+        );
+        assert!(
+            result
+                .code
+                .contains(r#"_createElementVNode("span", { "data-v-test": "" }"#),
+            "{}",
+            result.code
+        );
     }
 }

--- a/npm/nuxt/src/index.ts
+++ b/npm/nuxt/src/index.ts
@@ -30,13 +30,30 @@ import {
 } from "./options";
 import {
   buildNuxtDevAssetBase,
+  isVizeGeneratedVueModuleId,
   isVizeVirtualVueModuleId,
   normalizeNuxtInjectedKeysForVizeVirtualModule,
+  preserveExplicitVueImportsFromVizeModuleSource,
   normalizeVizeVirtualVueModuleId,
+  preserveExplicitVueImportsFromNuxtAutoImports,
 } from "./utils";
 import { appendOriginalVueSourceForUnoCss } from "./unocss";
 
 type ViteTransformResult = string | { code?: string; map?: unknown } | null | undefined;
+const VIZE_NUXT_AUTO_IMPORT_PATCHED = "__vizeNuxtAutoImportPatched";
+const VUE_RUNTIME_DEDUPE = [
+  "vue",
+  "@vue/reactivity",
+  "@vue/runtime-core",
+  "@vue/runtime-dom",
+  "@vue/shared",
+];
+const VUE_CLIENT_RUNTIME_IMPORT = "vue/dist/vue.runtime.esm-bundler.js";
+type VitePluginWithTransform = {
+  name?: string;
+  transform?: unknown;
+  [VIZE_NUXT_AUTO_IMPORT_PATCHED]?: boolean;
+};
 type NuxtWithBuilderOptions = {
   options: {
     app?: {
@@ -50,7 +67,7 @@ type NuxtWithBuilderOptions = {
     router?: {
       base?: string;
     };
-    vite?: { plugins?: unknown[] };
+    vite?: { plugins?: unknown[]; resolve?: { dedupe?: string[] } };
     nitro?: { virtual?: Record<string, string> };
   };
 };
@@ -94,6 +111,35 @@ function shouldUseVizeCompiler(
   compilerOptions: false | VizeNuxtCompilerOptions,
 ): compilerOptions is VizeNuxtCompilerOptions {
   return compilerOptions !== false && (compilerOptions.vueVersion ?? 3) === 3;
+}
+
+function dedupeVueRuntimePackages(vite: NonNullable<NuxtWithBuilderOptions["options"]["vite"]>) {
+  vite.resolve ||= {};
+  const dedupe = new Set(vite.resolve.dedupe ?? []);
+  for (const packageName of VUE_RUNTIME_DEDUPE) {
+    dedupe.add(packageName);
+  }
+  vite.resolve.dedupe = [...dedupe];
+}
+
+function isViteSsrTransform(args: unknown[]): boolean {
+  const options = args[0];
+  return (
+    typeof options === "object" &&
+    options !== null &&
+    "ssr" in options &&
+    (options as { ssr?: boolean }).ssr === true
+  );
+}
+
+function rewriteBareVueImportsToClientRuntime(code: string): string {
+  return code
+    .replace(/(\bfrom\s*)(["'])vue\2/g, (_, prefix: string, quote: string) => {
+      return `${prefix}${quote}${VUE_CLIENT_RUNTIME_IMPORT}${quote}`;
+    })
+    .replace(/(\bimport\s*)(["'])vue\2/g, (_, prefix: string, quote: string) => {
+      return `${prefix}${quote}${VUE_CLIENT_RUNTIME_IMPORT}${quote}`;
+    });
 }
 
 function normalizeNuxtKeyedTransformResult(
@@ -140,6 +186,82 @@ function patchNuxtKeyedFunctionsPlugin(plugin: { transform?: unknown }): void {
   };
 }
 
+function normalizeNuxtAutoImportTransformResult(
+  code: string,
+  id: string,
+  result: ViteTransformResult,
+  rewriteVueRuntimeImports: boolean,
+): ViteTransformResult {
+  if (!isVizeGeneratedVueModuleId(id) || result == null) {
+    return result;
+  }
+  if (typeof result === "string") {
+    const normalized = preserveExplicitVueImportsFromNuxtAutoImports(code, result);
+    const restored = preserveExplicitVueImportsFromVizeModuleSource(id, normalized);
+    return rewriteVueRuntimeImports ? rewriteBareVueImportsToClientRuntime(restored) : restored;
+  }
+  if (typeof result.code !== "string") {
+    return result;
+  }
+  let normalized = preserveExplicitVueImportsFromVizeModuleSource(
+    id,
+    preserveExplicitVueImportsFromNuxtAutoImports(code, result.code),
+  );
+  if (rewriteVueRuntimeImports) {
+    normalized = rewriteBareVueImportsToClientRuntime(normalized);
+  }
+  return normalized === result.code ? result : { ...result, code: normalized };
+}
+
+function patchNuxtAutoImportTransformPlugin(
+  plugin: VitePluginWithTransform | undefined,
+  isBuild: boolean,
+): void {
+  if (!plugin) {
+    return;
+  }
+  if (plugin[VIZE_NUXT_AUTO_IMPORT_PATCHED]) {
+    return;
+  }
+
+  if (typeof plugin.transform === "function") {
+    const original = plugin.transform;
+    plugin.transform = async function (
+      this: unknown,
+      code: string,
+      id: string,
+      ...args: unknown[]
+    ) {
+      const result = (await original.call(this, code, id, ...args)) as ViteTransformResult;
+      return normalizeNuxtAutoImportTransformResult(
+        code,
+        id,
+        result,
+        isBuild && !isViteSsrTransform(args),
+      );
+    };
+    plugin[VIZE_NUXT_AUTO_IMPORT_PATCHED] = true;
+    return;
+  }
+
+  const transform = plugin.transform as { handler?: unknown } | undefined;
+  if (!transform || typeof transform.handler !== "function") {
+    return;
+  }
+
+  const original = transform.handler;
+  transform.handler = async function (this: unknown, code: string, id: string, ...args: unknown[]) {
+    const result = (await original.call(this, code, id, ...args)) as ViteTransformResult;
+    return normalizeNuxtAutoImportTransformResult(
+      code,
+      id,
+      result,
+      isBuild && !isViteSsrTransform(args),
+    );
+  };
+  plugin[VIZE_NUXT_AUTO_IMPORT_PATCHED] = true;
+}
+
 export default defineNuxtModule<VizeNuxtOptions>({
   meta: {
     name: "@vizejs/nuxt",
@@ -175,13 +297,25 @@ export default defineNuxtModule<VizeNuxtOptions>({
         vueVersion,
       },
     );
+    const usesVizeCompiler = shouldUseVizeCompiler(compilerOptions);
     if (compilerOptions !== false) {
       nuxt.options.vite ||= {};
       nuxt.options.vite.plugins = nuxt.options.vite.plugins || [];
       nuxt.options.vite.plugins.push(vize(compilerOptions));
     }
 
-    const usesVizeCompiler = shouldUseVizeCompiler(compilerOptions);
+    let isNuxtBuild = false;
+    let isViteBuild = false;
+    if (usesVizeCompiler) {
+      nuxt.hook("build:before", () => {
+        if (nuxt.options.dev !== false) {
+          return;
+        }
+        isNuxtBuild = true;
+        nuxt.options.vite ||= {};
+        dedupeVueRuntimePackages(nuxt.options.vite);
+      });
+    }
 
     if (usesVizeCompiler) {
       if (nuxt.options.dev && devOptions.stylesheetLinks) {
@@ -206,17 +340,27 @@ export default defineNuxtModule<VizeNuxtOptions>({
       // a shallow copy of the config, so we must MUTATE the plugins array
       // in-place (splice) rather than replacing it (filter), so the change
       // propagates to the original config used by createServer().
-      nuxt.hook("vite:configResolved", (config: { plugins: Array<{ name?: string }> }) => {
-        for (let i = config.plugins.length - 1; i >= 0; i--) {
-          const p = config.plugins[i];
-          const name = p && typeof p === "object" && "name" in p ? p.name : "";
-          if (name === "vite:vue") {
-            config.plugins.splice(i, 1);
-          } else if (bridgeOptions.stableInjectedKeys && name === "nuxt:compiler:keyed-functions") {
-            patchNuxtKeyedFunctionsPlugin(p);
+      nuxt.hook(
+        "vite:configResolved",
+        (config: { command?: string; plugins: VitePluginWithTransform[] }) => {
+          isViteBuild = config.command === "build" || isNuxtBuild || nuxt.options.dev === false;
+          for (let i = config.plugins.length - 1; i >= 0; i--) {
+            const p = config.plugins[i];
+            const name = p && typeof p === "object" && "name" in p ? p.name : "";
+            if (name === "vite:vue") {
+              config.plugins.splice(i, 1);
+            } else if (
+              bridgeOptions.stableInjectedKeys &&
+              name === "nuxt:compiler:keyed-functions"
+            ) {
+              patchNuxtKeyedFunctionsPlugin(p);
+            }
+            if (bridgeOptions.autoImports) {
+              patchNuxtAutoImportTransformPlugin(p, isViteBuild);
+            }
           }
-        }
-      });
+        },
+      );
     }
 
     // ─── Bridge: Apply Nuxt transforms to vize virtual modules ────────────
@@ -276,7 +420,7 @@ export default defineNuxtModule<VizeNuxtOptions>({
       addVitePlugin({
         name: "vizejs:nuxt-transform-bridge",
         enforce: "post" as const,
-        async transform(code: string, id: string) {
+        async transform(code: string, id: string, ...args: unknown[]) {
           // Only process vize virtual modules
           if (!isVizeVirtualVueModuleId(id)) return;
 
@@ -313,9 +457,13 @@ export default defineNuxtModule<VizeNuxtOptions>({
           // Runs after i18n injection so unimport picks up the `useI18n` reference.
           if (unimportCtx) {
             try {
+              const beforeUnimport = result;
               const injected = await unimportCtx.injectImports(result, id);
               if (injected.imports && injected.imports.length > 0) {
-                result = injected.code;
+                result = preserveExplicitVueImportsFromNuxtAutoImports(
+                  beforeUnimport,
+                  injected.code,
+                );
                 changed = true;
               }
             } catch {
@@ -323,10 +471,26 @@ export default defineNuxtModule<VizeNuxtOptions>({
             }
           }
 
+          if (bridgeOptions.autoImports) {
+            const nextResult = preserveExplicitVueImportsFromVizeModuleSource(id, result);
+            if (nextResult !== result) {
+              result = nextResult;
+              changed = true;
+            }
+          }
+
           if (bridgeOptions.stableInjectedKeys) {
             const stableKeyResult = normalizeNuxtInjectedKeysForVizeVirtualModule(result, id);
             if (stableKeyResult !== result) {
               result = stableKeyResult;
+              changed = true;
+            }
+          }
+
+          if (isViteBuild && !isViteSsrTransform(args)) {
+            const clientRuntimeResult = rewriteBareVueImportsToClientRuntime(result);
+            if (clientRuntimeResult !== result) {
+              result = clientRuntimeResult;
               changed = true;
             }
           }

--- a/npm/nuxt/src/utils.test.ts
+++ b/npm/nuxt/src/utils.test.ts
@@ -1,10 +1,16 @@
 import assert from "node:assert";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import {
   buildNuxtCompilerOptions,
   buildNuxtDevAssetBase,
+  isVizeGeneratedVueModuleId,
   isVizeVirtualVueModuleId,
   normalizeNuxtInjectedKeysForVizeVirtualModule,
   normalizeVizeVirtualVueModuleId,
+  preserveExplicitVueImportsFromNuxtAutoImports,
+  preserveExplicitVueImportsFromVizeModuleSource,
 } from "./utils.ts";
 
 assert.strictEqual(
@@ -63,6 +69,11 @@ assert.equal(
   "SSR virtual Vue modules should stay eligible for Nuxt bridge transforms",
 );
 
+assert.equal(isVizeGeneratedVueModuleId("\0/repo/app/components/Foo.vue.ts"), true);
+assert.equal(isVizeGeneratedVueModuleId("/repo/app/components/Foo.vue.ts"), true);
+assert.equal(isVizeGeneratedVueModuleId("/@id/__x00__/repo/app/components/Foo.vue.ts"), true);
+assert.equal(isVizeGeneratedVueModuleId("/repo/app/components/Foo.vue"), false);
+
 assert.equal(
   normalizeVizeVirtualVueModuleId("\0vize-ssr:/repo/app/components/Foo.vue.ts"),
   "/repo/app/components/Foo.vue",
@@ -94,6 +105,72 @@ assert.equal(
       "\0vize-ssr:/repo/app/components/Foo.vue.ts",
     ),
     "Nuxt injected keys should match between client and SSR virtual modules",
+  );
+}
+
+{
+  const originalCode = `import { resolveComponent, computed as _computed } from "vue";
+const resolved = resolveComponent(name);
+const doubled = _computed(() => value * 2);`;
+  const injectedCode = `import { resolveComponent, computed as _computed, useRuntimeConfig } from "#imports";
+const resolved = resolveComponent(name);
+const doubled = _computed(() => value * 2);
+const config = useRuntimeConfig();`;
+
+  assert.equal(
+    preserveExplicitVueImportsFromNuxtAutoImports(originalCode, injectedCode),
+    `import { resolveComponent, computed as _computed } from "vue";
+import { useRuntimeConfig } from "#imports";
+const resolved = resolveComponent(name);
+const doubled = _computed(() => value * 2);
+const config = useRuntimeConfig();`,
+    "Nuxt auto-imports should not move explicit Vue runtime imports from vize virtual modules into #imports",
+  );
+}
+
+{
+  const originalCode = `import { defineAsyncComponent } from "vue";
+const component = defineAsyncComponent(loader);`;
+  const injectedCode = `import { defineAsyncComponent, useRoute } from "#entry";
+const component = defineAsyncComponent(loader);
+const route = useRoute();`;
+
+  assert.equal(
+    preserveExplicitVueImportsFromNuxtAutoImports(originalCode, injectedCode),
+    `import { defineAsyncComponent } from "vue";
+import { useRoute } from "#entry";
+const component = defineAsyncComponent(loader);
+const route = useRoute();`,
+    "Already-normalized #entry imports should also give explicit Vue helpers back to vue",
+  );
+}
+
+{
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "vize-nuxt-utils-"));
+  const sourcePath = path.join(tmpDir, "ContentRenderer.vue");
+  fs.writeFileSync(
+    sourcePath,
+    `<script setup>
+import { resolveComponent, computed as _computed } from "vue";
+import { useRuntimeConfig } from "#imports";
+</script>
+`,
+  );
+
+  assert.equal(
+    preserveExplicitVueImportsFromVizeModuleSource(
+      `\0${sourcePath}.ts`,
+      `import { resolveComponent, computed as _computed, useRuntimeConfig } from "#entry";
+const resolved = resolveComponent(name);
+const doubled = _computed(() => value * 2);
+const config = useRuntimeConfig();`,
+    ),
+    `import { resolveComponent, computed as _computed } from "vue";
+import { useRuntimeConfig } from "#entry";
+const resolved = resolveComponent(name);
+const doubled = _computed(() => value * 2);
+const config = useRuntimeConfig();`,
+    "Nuxt bridge should restore explicit Vue helpers from the original Vize module source",
   );
 }
 

--- a/npm/nuxt/src/utils.ts
+++ b/npm/nuxt/src/utils.ts
@@ -1,5 +1,6 @@
 import type { VizeNuxtCompilerOptions } from "./compiler-options.ts";
 import { createHash } from "node:crypto";
+import fs from "node:fs";
 
 function normalizeUrlPrefix(value: string): string {
   const withLeadingSlash = value.startsWith("/") ? value : `/${value}`;
@@ -41,6 +42,16 @@ export function isVizeVirtualVueModuleId(id: string): boolean {
   return id.startsWith("\0") && /\.vue\.ts(?:\?|$)/.test(id);
 }
 
+export function isVizeGeneratedVueModuleId(id: string): boolean {
+  let normalized = id;
+  if (normalized.startsWith("/@id/__x00__")) {
+    normalized = normalized.slice("/@id/__x00__".length);
+  } else if (normalized.startsWith("__x00__")) {
+    normalized = normalized.slice("__x00__".length);
+  }
+  return /\.vue\.ts(?:\?|$)/.test(normalized);
+}
+
 export function normalizeVizeVirtualVueModuleId(id: string): string {
   const withoutPrefix = id.startsWith("\0vize-ssr:") ? id.slice("\0vize-ssr:".length) : id.slice(1);
   return withoutPrefix.replace(/\.ts(?=\?|$)/, "");
@@ -65,4 +76,159 @@ export function normalizeNuxtInjectedKeysForVizeVirtualModule(code: string, id: 
     index += 1;
     return `'$${buildStableNuxtKey(normalizedId, index)}' ${NUXT_INJECTED_MARKER}`;
   });
+}
+
+type NamedImportSpecifier = {
+  imported: string;
+  local: string;
+  raw: string;
+};
+
+type NamedImportStatement = {
+  end: number;
+  quote: string;
+  source: string;
+  specifiers: NamedImportSpecifier[];
+  start: number;
+};
+
+const NAMED_IMPORT_RE = /^import\s*\{([\s\S]*?)\}\s*from\s*(['"])(vue|#imports|#entry)\2\s*;?/gm;
+
+function parseNamedImportSpecifiers(specifierSource: string): NamedImportSpecifier[] {
+  return specifierSource
+    .split(",")
+    .map((specifier) => specifier.trim())
+    .filter(Boolean)
+    .flatMap((specifier) => {
+      const withoutType = specifier.replace(/^type\s+/, "").trim();
+      if (!withoutType) {
+        return [];
+      }
+      const match = withoutType.match(/^([A-Za-z_$][\w$]*)(?:\s+as\s+([A-Za-z_$][\w$]*))?$/);
+      if (!match) {
+        return [];
+      }
+      const imported = match[1]!;
+      const local = match[2] ?? imported;
+      return [{ imported, local, raw: withoutType }];
+    });
+}
+
+function collectNamedImports(code: string): NamedImportStatement[] {
+  const imports: NamedImportStatement[] = [];
+  for (const match of code.matchAll(NAMED_IMPORT_RE)) {
+    imports.push({
+      start: match.index ?? 0,
+      end: (match.index ?? 0) + match[0].length,
+      quote: match[2]!,
+      source: match[3]!,
+      specifiers: parseNamedImportSpecifiers(match[1] ?? ""),
+    });
+  }
+  return imports;
+}
+
+function renderNamedImport(
+  specifiers: NamedImportSpecifier[],
+  source: string,
+  quote: string,
+): string {
+  return `import { ${specifiers.map((specifier) => specifier.raw).join(", ")} } from ${quote}${source}${quote};`;
+}
+
+export function preserveExplicitVueImportsFromNuxtAutoImports(
+  originalCode: string,
+  injectedCode: string,
+): string {
+  const originalVueSpecifiers = new Map<string, NamedImportSpecifier>();
+  for (const statement of collectNamedImports(originalCode)) {
+    if (statement.source !== "vue") {
+      continue;
+    }
+    for (const specifier of statement.specifiers) {
+      originalVueSpecifiers.set(specifier.local, specifier);
+    }
+  }
+
+  if (originalVueSpecifiers.size === 0) {
+    return injectedCode;
+  }
+
+  const restoredSpecifiers = new Map<string, NamedImportSpecifier>();
+  const replacements: Array<{ start: number; end: number; text: string }> = [];
+
+  for (const statement of collectNamedImports(injectedCode)) {
+    if (statement.source !== "#imports" && statement.source !== "#entry") {
+      continue;
+    }
+
+    const keep: NamedImportSpecifier[] = [];
+    let changed = false;
+    for (const specifier of statement.specifiers) {
+      const original = originalVueSpecifiers.get(specifier.local);
+      if (original) {
+        restoredSpecifiers.set(specifier.local, original);
+        changed = true;
+      } else {
+        keep.push(specifier);
+      }
+    }
+
+    if (!changed) {
+      continue;
+    }
+
+    replacements.push({
+      start: statement.start,
+      end: statement.end,
+      text: keep.length > 0 ? renderNamedImport(keep, statement.source, statement.quote) : "",
+    });
+  }
+
+  if (replacements.length === 0) {
+    return injectedCode;
+  }
+
+  let output = injectedCode;
+  for (const replacement of replacements.reverse()) {
+    output = output.slice(0, replacement.start) + replacement.text + output.slice(replacement.end);
+  }
+
+  const currentVueLocals = new Set<string>();
+  for (const statement of collectNamedImports(output)) {
+    if (statement.source !== "vue") {
+      continue;
+    }
+    for (const specifier of statement.specifiers) {
+      currentVueLocals.add(specifier.local);
+    }
+  }
+
+  const missing = [...restoredSpecifiers.values()].filter(
+    (specifier) => !currentVueLocals.has(specifier.local),
+  );
+  if (missing.length > 0) {
+    output = `${renderNamedImport(missing, "vue", '"')}\n${output}`;
+  }
+
+  return output.replace(/\n{3,}/g, "\n\n");
+}
+
+export function preserveExplicitVueImportsFromVizeModuleSource(id: string, code: string): string {
+  if (!isVizeVirtualVueModuleId(id) && !isVizeGeneratedVueModuleId(id)) {
+    return code;
+  }
+
+  const normalizedId = isVizeVirtualVueModuleId(id)
+    ? normalizeVizeVirtualVueModuleId(id)
+    : id
+        .replace(/^\/@id\/__x00__/, "")
+        .replace(/^__x00__/, "")
+        .replace(/\.ts(?=\?|$)/, "");
+  const sourcePath = normalizedId.replace(/\?.*$/, "");
+  if (!sourcePath.endsWith(".vue") || !fs.existsSync(sourcePath)) {
+    return code;
+  }
+
+  return preserveExplicitVueImportsFromNuxtAutoImports(fs.readFileSync(sourcePath, "utf-8"), code);
 }

--- a/npm/vite-plugin-vize/src/compiler.test.ts
+++ b/npm/vite-plugin-vize/src/compiler.test.ts
@@ -669,10 +669,10 @@ assert.doesNotMatch(
   /_resolveComponent\("Suspense"\)/,
   "SSR builds must not resolve built-in Suspense through runtime component lookup",
 );
-assert.match(
+assert.doesNotMatch(
   ssrSuspenseCompiled.code,
   /unref as _unref/,
-  "SSR builds should import unref when transformed setup bindings use _unref()",
+  "SSR function-mode setup bindings should use the setup proxy without importing unused unref",
 );
 
 const ssrComponentPropsSource = `<script setup lang="ts">
@@ -698,8 +698,8 @@ const ssrComponentPropsCompiled = compileFile(
 
 assert.match(
   ssrComponentPropsCompiled.code,
-  /\$setup\.ErrorBoundary, \{ error: _unref\(\$setup\.error\) \}/,
-  "SSR builds should pass dynamic props to setup-bound components",
+  /\$setup\.ErrorBoundary, \{ error: \$setup\.error \}/,
+  "SSR builds should pass dynamic props through the setup proxy",
 );
 assert.match(
   ssrComponentPropsCompiled.code,

--- a/npm/vite-plugin-vize/src/plugin/resolve.test.ts
+++ b/npm/vite-plugin-vize/src/plugin/resolve.test.ts
@@ -409,6 +409,71 @@ function expectResolvedId(resolved: Awaited<ReturnType<typeof resolveIdHook>>): 
   );
 }
 
+{
+  const projectRoot = createTempProject("build-vue-compiled-importer");
+  const importer = path.join(projectRoot, "app", "pages", "index.vue");
+  const compiledImporter = `${importer}.ts`;
+  const vueRoot = path.join(projectRoot, "node_modules", "vue");
+  const vueBundlerEntry = path.join(vueRoot, "dist", "vue.runtime.esm-bundler.js");
+  writeFixtureFile(
+    path.join(vueRoot, "package.json"),
+    JSON.stringify({ name: "vue", main: "index.js" }, null, 2),
+  );
+  writeFixtureFile(path.join(vueRoot, "index.js"), "module.exports = {};");
+  writeFixtureFile(vueBundlerEntry, "export const resolveComponent = () => null;");
+
+  const state = createState(projectRoot);
+  state.server = null;
+
+  const resolved = await resolveIdHook(
+    {
+      resolve: async (id) => (id === "vue" ? { id: "#entry" } : null),
+    },
+    state,
+    "vue",
+    compiledImporter,
+    undefined,
+  );
+
+  assert.equal(
+    expectResolvedId(resolved),
+    vueBundlerEntry,
+    "Build imports from compiled .vue.ts modules must not let Nuxt's #entry alias replace Vue runtime imports",
+  );
+}
+
+{
+  const projectRoot = createTempProject("build-vue-plain-sfc-importer");
+  const importer = path.join(projectRoot, "app", "pages", "index.vue");
+  const vueRoot = path.join(projectRoot, "node_modules", "vue");
+  const vueBundlerEntry = path.join(vueRoot, "dist", "vue.runtime.esm-bundler.js");
+  writeFixtureFile(
+    path.join(vueRoot, "package.json"),
+    JSON.stringify({ name: "vue", main: "index.js" }, null, 2),
+  );
+  writeFixtureFile(path.join(vueRoot, "index.js"), "module.exports = {};");
+  writeFixtureFile(vueBundlerEntry, "export const resolveComponent = () => null;");
+
+  const state = createState(projectRoot);
+  state.server = null;
+
+  const resolved = await resolveIdHook(
+    {
+      resolve: async (id) => (id === "vue" ? { id: "#entry" } : null),
+    },
+    state,
+    "vue",
+    importer,
+    undefined,
+  );
+
+  assert.equal(
+    expectResolvedId(resolved),
+    vueBundlerEntry,
+    "Build imports from Vue SFC modules should bypass Nuxt's #entry alias for Vue runtime helpers",
+  );
+}
+
 // pnpm-isolated dev install: the project root has no `node_modules/vue`, so
 // deferring to Vite's secondary resolveId pass (which uses the \0-prefixed
 // virtual ID as importer and falls back to root) cannot find Vue. The plugin
@@ -789,6 +854,41 @@ function expectResolvedId(resolved: Awaited<ReturnType<typeof resolveIdHook>>): 
     expectResolvedId(resolved),
     toVirtualId(source, true),
     "SSR resolution should upgrade client virtual IDs to SSR-specific virtual IDs",
+  );
+}
+
+{
+  const parentRoot = createTempRoot("vue-parent-runtime");
+  const projectRoot = path.join(parentRoot, "nested-project");
+  writeFixtureFile(path.join(parentRoot, "node_modules", "vue", "package.json"), "{}");
+  writeFixtureFile(path.join(projectRoot, "package.json"), "{}");
+  const source = path.join(projectRoot, "app", "pages", "index.vue");
+  writeFixtureFile(source, "<template />\n");
+  const resolvedVue = path.join(
+    projectRoot,
+    "node_modules",
+    ".pnpm",
+    "vue@3.6.0",
+    "node_modules",
+    "vue",
+    "dist",
+    "vue.runtime.esm-bundler.js",
+  );
+
+  const resolved = await resolveIdHook(
+    {
+      resolve: async () => ({ id: resolvedVue }),
+    },
+    createState(projectRoot),
+    "vue",
+    toVirtualId(source),
+    undefined,
+  );
+
+  assert.equal(
+    resolved,
+    null,
+    "Vue runtime imports from virtual modules should defer when Vue resolves from a parent root",
   );
 }
 

--- a/npm/vite-plugin-vize/src/plugin/resolve.ts
+++ b/npm/vite-plugin-vize/src/plugin/resolve.ts
@@ -217,14 +217,14 @@ function isOptimizedVueDependency(id: string): boolean {
   return normalized.includes("/node_modules/.vite/deps/vue.");
 }
 
-// Cache per project root: does `<root>/node_modules/vue` resolve via Node?
+// Cache per project root: does `vue` resolve from that root via Node?
 //
 // When vize defers Vue runtime in dev (returns null), Vite re-runs resolveId
 // with the \0-prefixed virtual module ID as importer. With pnpm-isolated
 // installs the project root has no hoisted `node_modules/vue`, so that
 // secondary lookup fails with `Failed to resolve import "vue"`. The deferral
-// only makes sense when the project root can serve as a fallback base for
-// vite:resolve.
+// only makes sense when the project root or one of its parent directories can
+// serve as a fallback base for vite:resolve.
 const vueResolvableFromRootCache = new Map<string, boolean>();
 function isVueResolvableFromRoot(root: string): boolean {
   let cached = vueResolvableFromRootCache.get(root);
@@ -234,11 +234,8 @@ function isVueResolvableFromRoot(root: string): boolean {
     cached = fs.existsSync(directPackageJson);
     if (!cached) {
       try {
-        const resolved = createRequire(path.join(root, "__vize_probe__.js")).resolve(
-          "vue/package.json",
-        );
-        const relative = path.relative(rootNodeModules, resolved);
-        cached = relative !== "" && !relative.startsWith("..") && !path.isAbsolute(relative);
+        createRequire(path.join(root, "__vize_probe__.js")).resolve("vue/package.json");
+        cached = true;
       } catch {
         // Not resolvable from root.
       }
@@ -274,7 +271,15 @@ function isPotentialVizeResolveId(id: string): boolean {
 }
 
 function isPotentialVizeImporter(importer: string | undefined): boolean {
-  return importer !== undefined && (importer.startsWith("\0") || importer.startsWith("vize:"));
+  if (importer === undefined) {
+    return false;
+  }
+  if (importer.startsWith("\0") || importer.startsWith("vize:")) {
+    return true;
+  }
+
+  const request = classifyVitePluginRequest(importer);
+  return request.isVueSfcPath;
 }
 
 function shouldCompileVueSfcRequest(
@@ -312,6 +317,21 @@ function hasNuxtComponentQuery(request: ReturnType<typeof classifyVitePluginRequ
   }
 
   return new URLSearchParams(request.querySuffix.slice(1)).has("nuxt_component");
+}
+
+function cleanVueSfcImporter(
+  importer: string,
+  request: ReturnType<typeof classifyVitePluginRequest> | null,
+): string {
+  let cleanImporter = request?.normalizedFsId ?? importer;
+
+  if (cleanImporter.startsWith("/@id/__x00__")) {
+    cleanImporter = cleanImporter.slice("/@id/__x00__".length);
+  } else if (cleanImporter.startsWith("__x00__")) {
+    cleanImporter = cleanImporter.slice("__x00__".length);
+  }
+
+  return cleanImporter.endsWith(".vue.ts") ? cleanImporter.slice(0, -3) : cleanImporter;
 }
 
 async function resolveAliasedVueImport(
@@ -466,10 +486,13 @@ export async function resolveIdHook(
   // If importer is a vize virtual module or macro module, resolve imports against the real path
   const isMacroImporter = importerRequest?.isMacroVirtualId ?? false;
   const isVizeVirtualImporter = importerRequest?.isVizeVirtual ?? false;
-  if (importer && (isVizeVirtualImporter || isMacroImporter)) {
+  const isVueSfcImporter = importerRequest?.isVueSfcPath ?? false;
+  if (importer && (isVizeVirtualImporter || isMacroImporter || isVueSfcImporter)) {
     const cleanImporter = isMacroImporter
       ? (importerRequest?.strippedVirtualPath ?? "")
-      : (importerRequest?.vizeVirtualPath ?? "");
+      : isVizeVirtualImporter
+        ? (importerRequest?.vizeVirtualPath ?? "")
+        : cleanVueSfcImporter(importer, importerRequest);
 
     state.logger.log(`resolveId from virtual: id=${id}, cleanImporter=${cleanImporter}`);
 
@@ -494,6 +517,14 @@ export async function resolveIdHook(
       // packages in the correct node_modules directory.
       if (!id.startsWith("./") && !id.startsWith("../") && !id.startsWith("/")) {
         const isVueRuntime = isVueRuntimeRequest(id);
+        if (isVueRuntime && isBuild) {
+          const vueBundlerEntry = resolveVueBundlerEntryWithNode(state, id, cleanImporter);
+          if (vueBundlerEntry) {
+            state.logger.log(`resolveId: resolved Vue runtime to ${vueBundlerEntry}`);
+            return vueBundlerEntry;
+          }
+        }
+
         const aliasRequest = resolveAliasRequest(state, id);
         if (!isVueRuntime && aliasRequest && isViteBareSpecifier(aliasRequest)) {
           const nodeResolved = resolveBareImportCandidatesWithNode(state, id, cleanImporter);

--- a/tests/_helpers/apps.ts
+++ b/tests/_helpers/apps.ts
@@ -1441,7 +1441,10 @@ function patchFrontendPhpconVisualFixture(frontendDir: string): void {
   },`,
     "  content: {},",
   );
-  nextSource = nextSource.replace("  devtools: { enabled: true },", "  devtools: { enabled: false },");
+  nextSource = nextSource.replace(
+    "  devtools: { enabled: true },",
+    "  devtools: { enabled: false },",
+  );
   if (nextSource !== source) {
     fs.writeFileSync(configPath, nextSource);
   }

--- a/tests/_helpers/apps.ts
+++ b/tests/_helpers/apps.ts
@@ -99,6 +99,22 @@ const VUEFES_E2E_ENV = {
   AUTH_SECRET: "e2e-test-dummy-auth-secret-32chars!",
   NEXTAUTH_SECRET: "e2e-test-dummy-auth-secret-32chars!",
 } as const;
+const FRONTEND_PHPCON_E2E_ENV = {
+  NUXT_PUBLIC_API_BASE: "/__vize_e2e/api",
+  NUXT_TELEMETRY_DISABLED: "1",
+} as const;
+const VUE_BETA_OVERRIDES = {
+  "@vue/compiler-core": "3.6.0-beta.10",
+  "@vue/compiler-dom": "3.6.0-beta.10",
+  "@vue/compiler-sfc": "3.6.0-beta.10",
+  "@vue/compiler-ssr": "3.6.0-beta.10",
+  "@vue/reactivity": "3.6.0-beta.10",
+  "@vue/runtime-core": "3.6.0-beta.10",
+  "@vue/runtime-dom": "3.6.0-beta.10",
+  "@vue/server-renderer": "3.6.0-beta.10",
+  "@vue/shared": "3.6.0-beta.10",
+  vue: "3.6.0-beta.10",
+} as const;
 const TRANSPARENT_PNG = Buffer.from(
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQIW2P8z/C/HwAFgwJ/lE6nWQAAAABJRU5ErkJggg==",
   "base64",
@@ -690,6 +706,7 @@ function syncGitFixtureWorktree(name: string, variant?: string): string {
 const ELK_WORK_DIR = getMutableGitFixtureDir("elk");
 export const MISSKEY_WORK_DIR = getMutableGitFixtureDir("misskey");
 const NPMX_WORK_DIR = getMutableGitFixtureDir("npmx.dev");
+const FRONTEND_PHPCON_WORK_DIR = getMutableGitFixtureDir("frontend-phpcon-do-website");
 const NUXT_UI_WORK_DIR = getMutableGitFixtureDir("nuxt-ui", "playground");
 const REKA_UI_DOCS_WORK_DIR = getMutableGitFixtureDir("reka-ui", "docs");
 const VUEFES_WORK_DIR = getMutableGitFixtureDir("vuefes-2025");
@@ -1369,6 +1386,261 @@ export function createNpmxVisualParityApps(mode: VisualParityMode = "dev"): {
   return {
     reference: createNpmxVisualParityApp("reference", referencePort, mode),
     candidate: createNpmxVisualParityApp("candidate", candidatePort, mode),
+  };
+}
+
+export const frontendPhpconApp: AppConfig = {
+  name: "frontend-phpcon-do-website",
+  cwd: FRONTEND_PHPCON_WORK_DIR,
+  command: "npx",
+  args: ["-y", "pnpm@10", "exec", "nuxt", "dev", "--port", "3007", "--host", "0.0.0.0"],
+  port: 3007,
+  url: "http://127.0.0.1:3007",
+  mountSelector: "#__nuxt",
+  readyPattern: /Local:\s+http:\/\/(localhost|127\.0\.0\.1|0\.0\.0\.0):3007/,
+  allowNon200: true,
+  waitUntil: "load",
+  readyDelay: 15_000,
+  env: FRONTEND_PHPCON_E2E_ENV,
+  startupTimeout: 240_000,
+  setup() {
+    setupFrontendPhpconWorktree();
+  },
+  build: {
+    command: "npx",
+    args: ["-y", "pnpm@10", "build"],
+    timeout: 300_000,
+  },
+  preview: {
+    command: "npx",
+    args: ["-y", "pnpm@10", "exec", "nuxt", "preview", "--port", "3008"],
+    port: 3008,
+    url: "http://127.0.0.1:3008",
+    readyPattern: /Listening on/,
+  },
+  check: {
+    cwd: path.join(GIT_DIR, "frontend-phpcon-do-website"),
+    patterns: ["app/**/*.vue"],
+  },
+  lint: {
+    cwd: path.join(GIT_DIR, "frontend-phpcon-do-website"),
+    patterns: ["app/**/*.vue"],
+  },
+};
+
+function patchFrontendPhpconVisualFixture(frontendDir: string): void {
+  const configPath = path.join(frontendDir, "nuxt.config.ts");
+  const source = fs.readFileSync(configPath, "utf-8");
+  let nextSource = source.replace('    preset: "cloudflare_module",', '    preset: "node-server",');
+  nextSource = nextSource.replace(
+    `  content: {
+    database: {
+      type: "d1",
+      bindingName: "DB",
+    },
+  },`,
+    "  content: {},",
+  );
+  nextSource = nextSource.replace("  devtools: { enabled: true },", "  devtools: { enabled: false },");
+  if (nextSource !== source) {
+    fs.writeFileSync(configPath, nextSource);
+  }
+
+  ensureFileContent(
+    path.join(frontendDir, "server", "routes", "__vize_e2e", "api", "sponsors.get.ts"),
+    `export default defineEventHandler(() => ({
+  sponsor_plans: [
+    {
+      name: "Platinum",
+      name_en: "Platinum",
+      tier: "A",
+      sponsors: [
+        {
+          id: "e3f03260-28a2-4cd8-8f4c-d6cc61774ca5",
+          name: "Frontend PHP Labs",
+          pr: "Building reliable web platforms with Vue and PHP.",
+          url: "https://example.com/frontend-php-labs",
+        },
+        {
+          id: "ea9a7096-2de4-407e-8e60-ef69fc8fa588",
+          name: "Hokkaido Web Studio",
+          pr: "Local engineering team supporting the conference community.",
+          url: "https://example.com/hokkaido-web-studio",
+        },
+      ],
+    },
+    {
+      name: "Gold",
+      name_en: "Gold",
+      tier: "B",
+      sponsors: [
+        {
+          id: "2ad98278-5a9a-4a17-bbe6-924be25534a9",
+          name: "Sapporo Type Systems",
+          pr: "Tooling, design systems, and product engineering.",
+          url: "https://example.com/sapporo-type-systems",
+        },
+      ],
+    },
+    {
+      name: "Booth",
+      name_en: "Booth",
+      tier: "C",
+      sponsors: [
+        {
+          id: "8e55bc66-2146-4115-8d7c-55eb4cfc83bc",
+          name: "Filtered Booth Sponsor",
+          url: "https://example.com/booth",
+        },
+      ],
+    },
+  ],
+}));
+`,
+  );
+
+  for (const imageDir of [
+    path.join(frontendDir, "public", "individual-sponsors"),
+    path.join(frontendDir, "public", "sponsors"),
+  ]) {
+    replacePngFilesWithTransparentFixture(imageDir);
+  }
+}
+
+function replacePngFilesWithTransparentFixture(dir: string): void {
+  if (!fs.existsSync(dir)) {
+    return;
+  }
+
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const entryPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      replacePngFilesWithTransparentFixture(entryPath);
+      continue;
+    }
+    if (entry.isFile() && entry.name.endsWith(".png")) {
+      fs.writeFileSync(entryPath, TRANSPARENT_PNG);
+    }
+  }
+}
+
+function setupFrontendPhpconWorktree(opts?: { enableVize?: boolean; variant?: string }): string {
+  const enableVize = opts?.enableVize ?? true;
+  const frontendDir = syncGitFixtureWorktree("frontend-phpcon-do-website", opts?.variant);
+
+  if (enableVize) {
+    ensureLocalVizePackagesBuilt();
+  }
+
+  addPnpmOverrides(path.join(frontendDir, "package.json"), {
+    ...VUE_BETA_OVERRIDES,
+    vite: "^8.0.0",
+  });
+  patchNuxtConfig(path.join(frontendDir, "nuxt.config.ts"), {
+    enableVize,
+    removeModules: ["@nuxt/fonts", "@nuxt/test-utils"],
+  });
+  patchFrontendPhpconVisualFixture(frontendDir);
+
+  console.log(
+    `[frontend-phpcon-do-website:${enableVize ? "candidate" : "reference"}:setup] pnpm install...`,
+  );
+  execSync("npx -y pnpm@10 install --no-frozen-lockfile", {
+    cwd: frontendDir,
+    stdio: "inherit",
+    timeout: 300_000,
+    env: {
+      ...process.env,
+      ...FRONTEND_PHPCON_E2E_ENV,
+    },
+  });
+
+  if (enableVize) {
+    createVizeSymlinks(path.join(frontendDir, "node_modules"));
+  }
+
+  console.log(
+    `[frontend-phpcon-do-website:${enableVize ? "candidate" : "reference"}:setup] nuxt prepare...`,
+  );
+  execSync("npx -y pnpm@10 exec nuxt prepare", {
+    cwd: frontendDir,
+    stdio: "inherit",
+    timeout: 180_000,
+    env: {
+      ...process.env,
+      ...FRONTEND_PHPCON_E2E_ENV,
+    },
+  });
+
+  return frontendDir;
+}
+
+type FrontendPhpconVisualParityMode = "dev" | "preview";
+
+function createFrontendPhpconVisualParityApp(
+  kind: "candidate" | "reference",
+  port: number,
+  mode: FrontendPhpconVisualParityMode,
+): AppConfig {
+  const variant = `vrt-${mode}-${kind}`;
+  const command =
+    mode === "preview"
+      ? ["exec", "nuxt", "preview", "--port", String(port)]
+      : ["exec", "nuxt", "dev", "--port", String(port), "--host", "0.0.0.0"];
+
+  return {
+    name: `frontend-phpcon-do-website:${mode}:${kind}`,
+    cwd: getMutableGitFixtureDir("frontend-phpcon-do-website", variant),
+    command: "npx",
+    args: ["-y", "pnpm@10", ...command],
+    port,
+    url: `http://127.0.0.1:${port}`,
+    mountSelector: "#__nuxt",
+    readyPattern:
+      mode === "preview"
+        ? /Listening on/
+        : new RegExp(`Local:\\s+http:\\/\\/(localhost|127\\.0\\.0\\.1|0\\.0\\.0\\.0):${port}`),
+    allowNon200: true,
+    waitUntil: "load",
+    readyDelay: 15_000,
+    env: {
+      ...FRONTEND_PHPCON_E2E_ENV,
+      NODE_ENV: mode === "preview" ? "production" : "development",
+    },
+    startupTimeout: 300_000,
+    setup() {
+      const frontendDir = setupFrontendPhpconWorktree({
+        enableVize: kind === "candidate",
+        variant,
+      });
+      if (mode === "preview") {
+        execSync("npx -y pnpm@10 build", {
+          cwd: frontendDir,
+          env: {
+            ...process.env,
+            ...FRONTEND_PHPCON_E2E_ENV,
+            NODE_ENV: "production",
+          },
+          stdio: "inherit",
+          timeout: 300_000,
+        });
+      }
+    },
+  };
+}
+
+export function createFrontendPhpconVisualParityApps(
+  mode: FrontendPhpconVisualParityMode = "dev",
+): {
+  candidate: AppConfig;
+  reference: AppConfig;
+} {
+  const referencePort = mode === "preview" ? 5338 : 5336;
+  const candidatePort = mode === "preview" ? 5339 : 5337;
+
+  return {
+    reference: createFrontendPhpconVisualParityApp("reference", referencePort, mode),
+    candidate: createFrontendPhpconVisualParityApp("candidate", candidatePort, mode),
   };
 }
 

--- a/tests/app/vrt/frontend-phpcon.spec.ts
+++ b/tests/app/vrt/frontend-phpcon.spec.ts
@@ -1,0 +1,204 @@
+import { test, expect, type Browser, type Page } from "@playwright/test";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+import { createFrontendPhpconVisualParityApps, type AppConfig } from "../../_helpers/apps";
+import {
+  ensurePortFree,
+  killProcess,
+  startDevServer,
+  waitForHttpReady,
+  waitForServerReady,
+} from "../../_helpers/server";
+import {
+  expectVisualParity,
+  installVisualStabilityHooks,
+  prepareStableVisualState,
+} from "../../_helpers/visual-parity";
+
+interface VisualRoute {
+  action?: (page: Page) => Promise<void>;
+  maxDiffRatio?: number;
+  name: string;
+  path: string;
+  viewport?: { height: number; width: number };
+}
+
+type VisualMode = "dev" | "preview";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const OUTPUT_DIR =
+  process.env.VIZE_FRONTEND_PHPCON_VRT_OUTPUT_DIR ??
+  path.resolve(__dirname, "../../../__agent_only/frontend-phpcon-vrt/artifacts");
+const DEFAULT_VIEWPORT = { width: 1280, height: 720 };
+const MOBILE_VIEWPORT = { width: 390, height: 844 };
+const FRONTEND_PHPCON_VRT_TIMEOUT = 900_000;
+const modes: VisualMode[] = ["dev", "preview"];
+
+const routes: VisualRoute[] = [
+  { name: "home", path: "/", maxDiffRatio: 0.004 },
+  { name: "home-mobile", path: "/", viewport: MOBILE_VIEWPORT, maxDiffRatio: 0.004 },
+  {
+    name: "mobile-menu",
+    path: "/",
+    viewport: MOBILE_VIEWPORT,
+    maxDiffRatio: 0.004,
+    action: async (page) => {
+      await page.getByRole("button", { name: /open menu/i }).click();
+      await expect(page.locator("#mobile-menu")).toBeVisible({ timeout: 10_000 });
+      await page.waitForTimeout(1200);
+    },
+  },
+  { name: "about", path: "/about" },
+  { name: "news", path: "/news/2026-05-06-social-gathering-ticket" },
+  { name: "timetable", path: "/timetable" },
+  { name: "job-board", path: "/job-board", maxDiffRatio: 0.004 },
+  { name: "english-home", path: "/en", maxDiffRatio: 0.004 },
+  { name: "english-about", path: "/en/about" },
+  { name: "english-news", path: "/en/news/2026-05-06-social-gathering-ticket" },
+  { name: "english-job-board", path: "/en/job-board", maxDiffRatio: 0.004 },
+  {
+    name: "language-switch",
+    path: "/",
+    maxDiffRatio: 0.004,
+    action: async (page) => {
+      await page.getByRole("button", { name: "EN" }).first().click();
+      await expect(page).toHaveURL(/\/en(?:\/)?$/);
+      await expect(page.getByRole("button", { name: "EN" }).first()).toHaveAttribute(
+        "aria-pressed",
+        "true",
+      );
+    },
+  },
+];
+
+test.describe("frontend-phpcon-do-website visual parity", () => {
+  test.describe.configure({ mode: "serial", timeout: FRONTEND_PHPCON_VRT_TIMEOUT });
+
+  for (const mode of modes) {
+    test.describe(mode, () => {
+      const apps = createFrontendPhpconVisualParityApps(mode);
+      const servers: Array<ReturnType<typeof startDevServer>> = [];
+
+      test.beforeAll(async () => {
+        test.setTimeout(FRONTEND_PHPCON_VRT_TIMEOUT);
+        servers.push(await startApp(apps.reference));
+        servers.push(await startApp(apps.candidate));
+      });
+
+      test.afterAll(async () => {
+        for (const server of servers) {
+          killProcess(server);
+        }
+      });
+
+      for (const route of routes) {
+        test(route.name, async ({ browser }) => {
+          await compareRoute(browser, apps, mode, route);
+        });
+      }
+    });
+  }
+});
+
+async function startApp(app: AppConfig): Promise<ReturnType<typeof startDevServer>> {
+  if (app.setup) app.setup();
+  await ensurePortFree(app.port);
+
+  const server = startDevServer(app);
+  await waitForServerReady(server, app.port, app.readyPattern, app.startupTimeout, app.readyDelay);
+  await waitForHttpReady(app.url, app.port);
+  return server;
+}
+
+async function compareRoute(
+  browser: Browser,
+  apps: ReturnType<typeof createFrontendPhpconVisualParityApps>,
+  mode: VisualMode,
+  route: VisualRoute,
+): Promise<void> {
+  const context = await browser.newContext({
+    colorScheme: "light",
+    deviceScaleFactor: 1,
+    reducedMotion: "reduce",
+    viewport: route.viewport ?? DEFAULT_VIEWPORT,
+  });
+
+  try {
+    const referencePage = await context.newPage();
+    const candidatePage = await context.newPage();
+
+    await Promise.all([setupPage(referencePage), setupPage(candidatePage)]);
+    await Promise.all([
+      openRoute(referencePage, apps.reference.url, route),
+      openRoute(candidatePage, apps.candidate.url, route),
+    ]);
+
+    if (route.action) {
+      await Promise.all([route.action(referencePage), route.action(candidatePage)]);
+    }
+
+    await Promise.all([
+      prepareFrontendPhpconVisualState(referencePage),
+      prepareFrontendPhpconVisualState(candidatePage),
+    ]);
+
+    await expectVisualParity(referencePage, candidatePage, {
+      maxDiffRatio: route.maxDiffRatio,
+      name: `${mode}-${route.name}`,
+      outputDir: OUTPUT_DIR,
+    });
+  } finally {
+    await context.close();
+  }
+}
+
+async function setupPage(page: Page): Promise<void> {
+  await installVisualStabilityHooks(page);
+  await page.addInitScript(() => {
+    localStorage.setItem("nuxt-color-mode", "light");
+  });
+}
+
+async function prepareFrontendPhpconVisualState(page: Page): Promise<void> {
+  await page.evaluate(async () => {
+    const images = Array.from(document.images);
+    for (const image of images) {
+      image.loading = "eager";
+    }
+
+    await Promise.all(
+      images.map((image) =>
+        image.complete
+          ? Promise.resolve()
+          : new Promise<void>((resolve) => {
+              image.addEventListener("load", () => resolve(), { once: true });
+              image.addEventListener("error", () => resolve(), { once: true });
+            }),
+      ),
+    );
+
+    await Promise.all(images.map((image) => image.decode?.().catch(() => undefined)));
+  });
+  await prepareStableVisualState(page);
+}
+
+async function openRoute(page: Page, baseUrl: string, route: VisualRoute): Promise<void> {
+  const response = await page.goto(`${baseUrl}${route.path}`, {
+    timeout: 60_000,
+    waitUntil: "domcontentloaded",
+  });
+  expect(response?.status()).toBeLessThan(500);
+  await expect(page.locator("#__nuxt")).toBeAttached({ timeout: 15_000 });
+  await expect
+    .poll(
+      () =>
+        page.evaluate(() => {
+          const el = document.querySelector("#__nuxt");
+          return el?.textContent?.trim().length ?? 0;
+        }),
+      { timeout: 30_000 },
+    )
+    .toBeGreaterThan(0);
+  await page.waitForLoadState("networkidle", { timeout: 10_000 }).catch(() => undefined);
+  await page.waitForTimeout(1000);
+}


### PR DESCRIPTION
## Summary
- add frontend-phpcon-do-website as a VRT fixture and cover dev/preview visual parity flows
- align Vize compiler behavior for Nuxt/Vite Vue runtime resolution, explicit Vue imports, scoped CSS, and script setup render mode
- preserve scoped attrs for SSR dynamic component VNodes

## Validation
- cargo fmt --all -- --check
- git diff --check
- cargo test -p vize_atelier_ssr test_scoped_dynamic_component_keeps_scope_id
- cargo test -p vize_atelier_sfc test_script_setup_resolve_component_uses_inline_render_mode
- cargo test -p vize_atelier_core test_process_expression_uses_setup_proxy_in_function_mode
- cargo test -p vize_atelier_sfc vite_plugin::css_scope
- cargo test -p vize_atelier_sfc deep_after_child_combinator --features native
- npx -y pnpm@10 --dir npm/vite-plugin-vize test
- npx -y pnpm@10 --dir npm/vite-plugin-vize check
- npx -y pnpm@10 --dir npm/vite-plugin-vize build
- npx -y pnpm@10 --dir npm/nuxt test
- npx -y pnpm@10 --dir npm/nuxt check
- npx -y pnpm@10 --dir npm/nuxt build
- npx -y pnpm@10 --dir npm/vize-native build:debug
- VIZE_TEST_WORKTREE_ID=codex-frontend-phpcon-vrt VIZE_E2E_MAX_EMITTED_PROCESS_LOG_LINES=100 VIZE_E2E_MAX_EMITTED_PROCESS_LOG_CHARS=1400 npx -y pnpm@10 --dir tests exec playwright test --config app/playwright.vrt.config.ts app/vrt/frontend-phpcon.spec.ts --grep "dev"
- VIZE_TEST_WORKTREE_ID=codex-frontend-phpcon-vrt VIZE_E2E_MAX_EMITTED_PROCESS_LOG_LINES=100 VIZE_E2E_MAX_EMITTED_PROCESS_LOG_CHARS=1400 npx -y pnpm@10 --dir tests exec playwright test --config app/playwright.vrt.config.ts app/vrt/frontend-phpcon.spec.ts --grep "preview"

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/813"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782905047&installation_id=136613492&pr_number=813&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F813&signature=a99d2f562e9bd8fc7c4e8e0dc3a343a3213605a8587713f095689a796b2fa06a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->