### PR TITLE
fix: preserve scoped css comments before selectors

### DIFF
--- a/crates/vize_atelier_sfc/src/css/scoped.rs
+++ b/crates/vize_atelier_sfc/src/css/scoped.rs
@@ -130,8 +130,12 @@ pub(crate) fn apply_scoped_css<'a>(bump: &'a Bump, css: &str, scope_id: &str) ->
                     && (brace_depth == 1 || (at_rule_depth > 0 && brace_depth > at_rule_depth))
                 {
                     // End of selector, apply scope
-                    if let Some(selector_str) = css.get(last_selector_end..i).map(str::trim) {
-                        scope_selector(&mut output, selector_str, attr_selector);
+                    if let Some(selector_str) = css.get(last_selector_end..i) {
+                        scope_selector_with_leading_comments(
+                            &mut output,
+                            selector_str,
+                            attr_selector,
+                        );
                     }
                     output.push(b'{');
                     in_selector = false;
@@ -181,6 +185,48 @@ pub(crate) fn apply_scoped_css<'a>(bump: &'a Bump, css: &str, scope_id: &str) ->
     // copy owns the bytes for the returned lifetime, and skipping revalidation
     // keeps scoped-style rewriting linear with minimal overhead.
     unsafe { std::str::from_utf8_unchecked(bump.alloc_slice_copy(&output)) }
+}
+
+/// Add scope to selector text while preserving leading CSS comments verbatim.
+fn scope_selector_with_leading_comments(
+    out: &mut BumpVec<u8>,
+    selector: &str,
+    attr_selector: &[u8],
+) {
+    let Some(prefix_end) = leading_css_comment_trivia_end(selector) else {
+        scope_selector(out, selector.trim(), attr_selector);
+        return;
+    };
+
+    out.extend_from_slice(&selector.as_bytes()[..prefix_end]);
+
+    let selector_body = selector[prefix_end..].trim();
+    if !selector_body.is_empty() {
+        scope_selector(out, selector_body, attr_selector);
+    }
+}
+
+fn leading_css_comment_trivia_end(value: &str) -> Option<usize> {
+    let mut cursor = 0usize;
+    let mut found_comment = false;
+
+    loop {
+        let ws_end = value[cursor..]
+            .char_indices()
+            .find(|(_, char)| !char.is_whitespace())
+            .map_or(value.len(), |(index, _)| cursor + index);
+        cursor = ws_end;
+
+        if !value[cursor..].starts_with("/*") {
+            return found_comment.then_some(cursor);
+        }
+
+        found_comment = true;
+        let Some(end) = value[cursor + 2..].find("*/") else {
+            return Some(value.len());
+        };
+        cursor += 2 + end + 2;
+    }
 }
 
 /// Add scope attribute to a selector

--- a/crates/vize_atelier_sfc/src/css/tests.rs
+++ b/crates/vize_atelier_sfc/src/css/tests.rs
@@ -250,6 +250,30 @@ fn test_scope_deep_after_child_combinator() {
 }
 
 #[test]
+fn test_apply_scoped_css_preserves_deep_comment_before_selector() {
+    let bump = Bump::new();
+    let css = "/* override :deep(p) from the parent */\n.foo { color: red; }";
+    let result = apply_scoped_css(&bump, css, "data-v-123");
+
+    assert_eq!(
+        result,
+        "/* override :deep(p) from the parent */\n.foo[data-v-123]{ color: red; }"
+    );
+}
+
+#[test]
+fn test_apply_scoped_css_preserves_deep_comment_inside_at_rule() {
+    let bump = Bump::new();
+    let css = "@media (min-width: 1px) { /* A <span>, not a <p>; ignore :deep(p). */\n.conferences__venue { display: block; } }";
+    let result = apply_scoped_css(&bump, css, "data-v-abc");
+
+    assert_eq!(
+        result,
+        "@media (min-width: 1px){ /* A <span>, not a <p>; ignore :deep(p). */\n.conferences__venue[data-v-abc]{ display: block; }}"
+    );
+}
+
+#[test]
 fn test_scope_global() {
     let bump = Bump::new();
     let mut out = BumpVec::new_in(&bump);

--- a/crates/vize_atelier_sfc/src/style.rs
+++ b/crates/vize_atelier_sfc/src/style.rs
@@ -108,14 +108,20 @@ pub fn apply_scoped_css(css: &str, scope_id: &str) -> String {
                 } else if in_selector && brace_depth == 1 {
                     // End of selector at root level, apply scope
                     let selector_part = &current[last_selector_end..current.len() - 1];
-                    output.push_str(&scope_selector(selector_part.trim(), &attr_selector));
+                    output.push_str(&scope_selector_with_leading_comments(
+                        selector_part,
+                        &attr_selector,
+                    ));
                     output.push('{');
                     in_selector = false;
                     last_selector_end = current.len();
                 } else if in_selector && at_rule_depth > 0 && brace_depth > at_rule_depth {
                     // End of selector inside at-rule (e.g., inside @media), apply scope
                     let selector_part = &current[last_selector_end..current.len() - 1];
-                    output.push_str(&scope_selector(selector_part.trim(), &attr_selector));
+                    output.push_str(&scope_selector_with_leading_comments(
+                        selector_part,
+                        &attr_selector,
+                    ));
                     output.push('{');
                     in_selector = false;
                     last_selector_end = current.len();
@@ -180,6 +186,46 @@ pub fn apply_scoped_css(css: &str, scope_id: &str) -> String {
     }
 
     output
+}
+
+/// Add scope to selector text while preserving leading CSS comments verbatim.
+fn scope_selector_with_leading_comments(selector: &str, attr_selector: &str) -> String {
+    let Some(prefix_end) = leading_css_comment_trivia_end(selector) else {
+        return scope_selector(selector.trim(), attr_selector);
+    };
+
+    let mut output = String::with_capacity(selector.len() + attr_selector.len());
+    output.push_str(&selector[..prefix_end]);
+
+    let selector_body = selector[prefix_end..].trim();
+    if !selector_body.is_empty() {
+        output.push_str(&scope_selector(selector_body, attr_selector));
+    }
+
+    output
+}
+
+fn leading_css_comment_trivia_end(value: &str) -> Option<usize> {
+    let mut cursor = 0usize;
+    let mut found_comment = false;
+
+    loop {
+        let ws_end = value[cursor..]
+            .char_indices()
+            .find(|(_, char)| !char.is_whitespace())
+            .map_or(value.len(), |(index, _)| cursor + index);
+        cursor = ws_end;
+
+        if !value[cursor..].starts_with("/*") {
+            return found_comment.then_some(cursor);
+        }
+
+        found_comment = true;
+        let Some(end) = value[cursor + 2..].find("*/") else {
+            return Some(value.len());
+        };
+        cursor += 2 + end + 2;
+    }
 }
 
 /// Add scope attribute to a selector
@@ -421,6 +467,28 @@ mod tests {
         assert_eq!(
             result,
             ".sponsors__item[data-v-123] > .sponsor{ width: 100%; }"
+        );
+    }
+
+    #[test]
+    fn test_apply_scoped_css_preserves_deep_comment_before_selector() {
+        let css = "/* override :deep(p) from the parent */\n.foo { color: red; }";
+        let result = apply_scoped_css(css, "data-v-123");
+
+        assert_eq!(
+            result,
+            "/* override :deep(p) from the parent */\n.foo[data-v-123]{ color: red; }"
+        );
+    }
+
+    #[test]
+    fn test_apply_scoped_css_preserves_deep_comment_inside_at_rule() {
+        let css = "@media (min-width: 1px) { /* A <span>, not a <p>; ignore :deep(p). */\n.conferences__venue { display: block; } }";
+        let result = apply_scoped_css(css, "data-v-abc");
+
+        assert_eq!(
+            result,
+            "@media (min-width: 1px){ /* A <span>, not a <p>; ignore :deep(p). */\n.conferences__venue[data-v-abc]{ display: block; }}"
         );
     }
 


### PR DESCRIPTION
## Summary
- preserve leading CSS comments during scoped selector transforms so pseudo-selectors inside comments stay untouched
- scope the real selector that follows the comment in both SFC style paths
- add regression tests for root-level and at-rule scoped selectors

## Verification
- cargo fmt --all -- --check
- cargo test -p vize_atelier_sfc
- cargo clippy -p vize_atelier_sfc -- -D warnings

Closes #816

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/819"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782956791&installation_id=136613492&pr_number=819&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F819&signature=9b92e3daf4ab04b9d93c10023b64307e35a2dc9cb764e486709f75a6a5f2bf1d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->