### PR TITLE
fix(vite-plugin): resolve Nuxt Musea dev SSR Vue imports

### DIFF
--- a/npm/vite-plugin-vize/src/plugin/resolve.test.ts
+++ b/npm/vite-plugin-vize/src/plugin/resolve.test.ts
@@ -191,11 +191,13 @@ function expectResolvedId(resolved: Awaited<ReturnType<typeof resolveIdHook>>): 
   const tempRoot = createTempRoot("ssr-vue-runtime");
   const importer = path.join(tempRoot, "App.vue");
   fs.writeFileSync(importer, "<template><div /></template>");
+  const state = createState(tempRoot);
+  state.server = null;
 
   assert.deepEqual(
     await resolveIdHook(
       nullResolveContext,
-      createState(tempRoot),
+      state,
       "@vue/server-renderer",
       toVirtualId(importer, true),
       { ssr: true },
@@ -207,13 +209,130 @@ function expectResolvedId(resolved: Awaited<ReturnType<typeof resolveIdHook>>): 
   assert.deepEqual(
     await resolveIdHook(
       nullResolveContext,
-      createState(tempRoot),
+      state,
+      "vue/dist/vue.esm-bundler.js/server-renderer",
+      toVirtualId(importer, true),
+      { ssr: true },
+    ),
+    { id: "vue/server-renderer", external: true },
+    "SSR virtual modules should externalize Vue server-renderer suffixes to the public server renderer entry",
+  );
+
+  assert.deepEqual(
+    await resolveIdHook(
+      nullResolveContext,
+      state,
       "vue/dist/vue.esm-bundler.js",
       toVirtualId(importer, true),
       { ssr: true },
     ),
     { id: "vue", external: true },
     "SSR virtual modules should not bundle Vue runtime aliases into Nuxt server output",
+  );
+}
+
+{
+  const projectRoot = createTempProject("dev-ssr-vue-pnpm-isolated");
+  const nuxtImporter = path.join(
+    projectRoot,
+    "node_modules",
+    ".pnpm",
+    "nuxt@4.4.2_x",
+    "node_modules",
+    "nuxt",
+    "dist",
+    "app",
+    "components",
+    "nuxt-root.vue",
+  );
+  const vuePackage = path.join(
+    projectRoot,
+    "node_modules",
+    ".pnpm",
+    "vue@3.6.0-beta.1_x",
+    "node_modules",
+    "vue",
+  );
+  const rendererPackage = path.join(
+    projectRoot,
+    "node_modules",
+    ".pnpm",
+    "@vue+server-renderer@3.6.0-beta.1_x",
+    "node_modules",
+    "@vue",
+    "server-renderer",
+  );
+  const vueLink = path.join(
+    projectRoot,
+    "node_modules",
+    ".pnpm",
+    "nuxt@4.4.2_x",
+    "node_modules",
+    "vue",
+  );
+  const rendererLink = path.join(
+    projectRoot,
+    "node_modules",
+    ".pnpm",
+    "nuxt@4.4.2_x",
+    "node_modules",
+    "@vue",
+    "server-renderer",
+  );
+  const vueBundlerEntry = path.join(vuePackage, "dist", "vue.runtime.esm-bundler.js");
+  const rendererBundlerEntry = path.join(rendererPackage, "dist", "server-renderer.esm-bundler.js");
+
+  writeFixtureFile(nuxtImporter, "<template><Suspense /></template>");
+  writeFixtureFile(
+    path.join(vuePackage, "package.json"),
+    JSON.stringify({ name: "vue", main: "index.js" }, null, 2),
+  );
+  writeFixtureFile(path.join(vuePackage, "index.js"), "module.exports = {};");
+  writeFixtureFile(vueBundlerEntry, "export const Suspense = Symbol();");
+  writeFixtureFile(
+    path.join(rendererPackage, "package.json"),
+    JSON.stringify({ name: "@vue/server-renderer", main: "index.js" }, null, 2),
+  );
+  writeFixtureFile(path.join(rendererPackage, "index.js"), "module.exports = {};");
+  writeFixtureFile(rendererBundlerEntry, "export const ssrRenderSuspense = () => null;");
+  fs.mkdirSync(path.dirname(vueLink), { recursive: true });
+  fs.mkdirSync(path.dirname(rendererLink), { recursive: true });
+  fs.symlinkSync(vuePackage, vueLink, "dir");
+  fs.symlinkSync(rendererPackage, rendererLink, "dir");
+
+  const state = createState(projectRoot);
+  const importer = toVirtualId(nuxtImporter, true);
+
+  assert.equal(
+    expectResolvedId(
+      await resolveIdHook(nullResolveContext, state, "vue", importer, { ssr: true }),
+    ),
+    vueBundlerEntry,
+    "Dev SSR virtual modules should resolve Vue from the importer-local package instead of externalizing a bare import",
+  );
+
+  assert.equal(
+    expectResolvedId(
+      await resolveIdHook(nullResolveContext, state, "vue/server-renderer", importer, {
+        ssr: true,
+      }),
+    ),
+    rendererBundlerEntry,
+    "Dev SSR virtual modules should resolve public Vue server-renderer imports to the renderer ESM bundler entry",
+  );
+
+  assert.equal(
+    expectResolvedId(
+      await resolveIdHook(
+        nullResolveContext,
+        state,
+        "vue/dist/vue.esm-bundler.js/server-renderer",
+        importer,
+        { ssr: true },
+      ),
+    ),
+    rendererBundlerEntry,
+    "Dev SSR virtual modules should resolve Vue server-renderer suffixes to the renderer ESM bundler entry",
   );
 }
 

--- a/npm/vite-plugin-vize/src/plugin/resolve.ts
+++ b/npm/vite-plugin-vize/src/plugin/resolve.ts
@@ -139,32 +139,41 @@ function findPackageRoot(resolvedFile: string): string | null {
   return null;
 }
 
+function resolvePackageRootWithNode(
+  state: Pick<VizePluginState, "root">,
+  packageName: string,
+  importer?: string,
+): string | null {
+  const packageJson = resolveBareImportWithNode(state, `${packageName}/package.json`, importer);
+  if (packageJson) {
+    return path.dirname(packageJson);
+  }
+
+  const resolvedEntry = resolveBareImportWithNode(state, packageName, importer);
+  return resolvedEntry ? findPackageRoot(resolvedEntry) : null;
+}
+
 function resolveVueBundlerEntryWithNode(
   state: Pick<VizePluginState, "root">,
   id: string,
   importer?: string,
 ): string | null {
   const { request, querySuffix } = splitViteIdQuery(id);
-  if (request !== "vue") {
+  let relativeEntries: string[];
+  if (request === "vue") {
+    relativeEntries = ["dist/vue.runtime.esm-bundler.js", "dist/vue.esm-bundler.js", "index.mjs"];
+  } else if (request.startsWith("vue/dist/") && request.endsWith(".js")) {
+    relativeEntries = [request.slice("vue/".length)];
+  } else {
     return null;
   }
 
-  const packageJson = resolveBareImportWithNode(state, "vue/package.json", importer);
-  const resolvedVue = packageJson ? null : resolveBareImportWithNode(state, "vue", importer);
-  const packageRoot = packageJson
-    ? path.dirname(packageJson)
-    : resolvedVue
-      ? findPackageRoot(resolvedVue)
-      : null;
+  const packageRoot = resolvePackageRootWithNode(state, "vue", importer);
   if (!packageRoot) {
     return null;
   }
 
-  for (const relativeEntry of [
-    "dist/vue.runtime.esm-bundler.js",
-    "dist/vue.esm-bundler.js",
-    "index.mjs",
-  ]) {
+  for (const relativeEntry of relativeEntries) {
     const entry = path.join(packageRoot, relativeEntry);
     if (fs.existsSync(entry)) {
       return `${entry}${querySuffix}`;
@@ -178,13 +187,65 @@ function isVueRuntimeRequest(id: string): boolean {
   return splitViteIdQuery(id).request === "vue";
 }
 
+function isVueServerRendererRequest(request: string): boolean {
+  return (
+    request === "@vue/server-renderer" ||
+    request === "vue/server-renderer" ||
+    (request.startsWith("vue/dist/") && request.endsWith("/server-renderer"))
+  );
+}
+
+function resolveVueServerRendererPackageRootWithNode(
+  state: Pick<VizePluginState, "root">,
+  importer?: string,
+): string | null {
+  const packageRoot = resolvePackageRootWithNode(state, "@vue/server-renderer", importer);
+  if (packageRoot) {
+    return packageRoot;
+  }
+
+  const vuePackageRoot = resolvePackageRootWithNode(state, "vue", importer);
+  return vuePackageRoot
+    ? resolvePackageRootWithNode(
+        state,
+        "@vue/server-renderer",
+        path.join(vuePackageRoot, "package.json"),
+      )
+    : null;
+}
+
+function resolveVueServerRendererBundlerEntryWithNode(
+  state: Pick<VizePluginState, "root">,
+  id: string,
+  importer?: string,
+): string | null {
+  const { request, querySuffix } = splitViteIdQuery(id);
+  if (querySuffix || !isVueServerRendererRequest(request)) {
+    return null;
+  }
+
+  const packageRoot = resolveVueServerRendererPackageRootWithNode(state, importer);
+  if (!packageRoot) {
+    return null;
+  }
+
+  for (const relativeEntry of ["dist/server-renderer.esm-bundler.js", "index.mjs", "index.js"]) {
+    const entry = path.join(packageRoot, relativeEntry);
+    if (fs.existsSync(entry)) {
+      return entry;
+    }
+  }
+
+  return null;
+}
+
 function resolveSsrExternalVueRequest(id: string): string | null {
   const { request, querySuffix } = splitViteIdQuery(id);
   if (querySuffix) {
     return null;
   }
 
-  if (request === "@vue/server-renderer" || request === "vue/server-renderer") {
+  if (isVueServerRendererRequest(request)) {
     return "vue/server-renderer";
   }
 
@@ -518,6 +579,16 @@ export async function resolveIdHook(
     if (!id.endsWith(".vue")) {
       const ssrExternalVueRequest = isSsrRequest ? resolveSsrExternalVueRequest(id) : null;
       if (ssrExternalVueRequest) {
+        if (!isBuild) {
+          const devSsrVueEntry =
+            ssrExternalVueRequest === "vue/server-renderer"
+              ? resolveVueServerRendererBundlerEntryWithNode(state, id, cleanImporter)
+              : resolveVueBundlerEntryWithNode(state, id, cleanImporter);
+          if (devSsrVueEntry) {
+            state.logger.log(`resolveId: resolved SSR Vue request ${id} to ${devSsrVueEntry}`);
+            return devSsrVueEntry;
+          }
+        }
         return { id: ssrExternalVueRequest, external: true };
       }
 


### PR DESCRIPTION
## Summary

Fixes #820.

- Resolve Vue runtime imports from `vize-ssr:` virtual modules to importer-local ESM bundler entries during dev SSR.
- Resolve Vue server-renderer requests, including `vue/dist/vue.esm-bundler.js/server-renderer`, to `@vue/server-renderer`'s ESM bundler entry in dev SSR.
- Preserve build-time SSR externalization to Vue's public runtime and server-renderer entries.

## Root Cause

Musea-enabled Nuxt dev SSR imports can originate from Vize SSR virtual modules whose real importer lives inside Nuxt's pnpm-isolated dependency subtree. Returning `external: true` for `vue` and server-renderer imports left Vite/Nitro resolving bare packages from the virtual module id, which could not find Vue and could also map server-renderer helpers to the wrong runtime module.

## Validation

- `node npm/vite-plugin-vize/src/plugin/resolve.test.ts`
- `corepack pnpm --dir npm/vite-plugin-vize check`
- `corepack pnpm --dir npm/vite-plugin-vize test`
- `corepack pnpm --dir npm/vite-plugin-vize build`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/822"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782973284&installation_id=136613492&pr_number=822&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F822&signature=0fc476430c40d08443bb89c65999859479b582e745ca1574f2f3632c5cf79e08"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->