### PR TITLE
fix(nuxt): preserve registered component mode

### DIFF
--- a/npm/nuxt/src/components.test.ts
+++ b/npm/nuxt/src/components.test.ts
@@ -222,6 +222,66 @@ export default {
   }
 });
 
+void test("Nuxt component resolver preserves explicit component mode from registry", () => {
+  const fixture = createFixture();
+  try {
+    const routeAnnouncerPath = writeFile(
+      path.join(fixture.rootDir, "node_modules/nuxt/dist/app/components/nuxt-route-announcer.js"),
+    );
+    const resolver = createNuxtComponentResolver({
+      buildDir: fixture.buildDir,
+      rootDir: fixture.rootDir,
+    });
+    resolver.register([
+      {
+        pascalName: "NuxtRouteAnnouncer",
+        kebabName: "nuxt-route-announcer",
+        name: "NuxtRouteAnnouncer",
+        filePath: routeAnnouncerPath,
+        export: "default",
+        mode: "client",
+      },
+    ]);
+
+    assert.deepEqual(
+      resolver.resolve("NuxtRouteAnnouncer"),
+      {
+        exportName: "default",
+        filePath: routeAnnouncerPath,
+        mode: "client",
+      },
+      "components:extend entries should preserve explicit client-only mode",
+    );
+
+    const transformed = injectNuxtComponentImports(
+      `
+export default {
+  setup(__props) {
+    return (_ctx, _cache) => {
+      const _component_NuxtRouteAnnouncer = resolveComponent("NuxtRouteAnnouncer");
+      return _component_NuxtRouteAnnouncer;
+    };
+  }
+}
+`,
+      (name) => resolver.resolve(name),
+    );
+
+    assert.match(
+      transformed,
+      /import \{ createClientOnly as __nuxt_create_client_only \} from "#app\/components\/client-only";/,
+      "registry client-only components should import createClientOnly",
+    );
+    assert.match(
+      transformed,
+      /import __nuxt_component_0_raw from ".*nuxt-route-announcer\.js";\s*const __nuxt_component_0 = __nuxt_create_client_only\(__nuxt_component_0_raw\);/s,
+      "registry client-only components should be wrapped before use",
+    );
+  } finally {
+    fs.rmSync(fixture.rootDir, { recursive: true, force: true });
+  }
+});
+
 void test("Nuxt component import injection dedupes repeated component resolutions", () => {
   const deduped = injectNuxtComponentImports(
     `

--- a/npm/nuxt/src/components.ts
+++ b/npm/nuxt/src/components.ts
@@ -8,6 +8,7 @@ export interface NuxtComponentDescriptor {
   name?: string;
   filePath: string;
   export?: string;
+  mode?: "client" | "server";
 }
 
 export interface NuxtComponentImport {
@@ -114,10 +115,15 @@ function detectComponentMode(filePath: string): NuxtComponentImport["mode"] {
   return undefined;
 }
 
+function normalizeComponentMode(mode: unknown): NuxtComponentImport["mode"] {
+  return mode === "client" || mode === "server" ? mode : undefined;
+}
+
 function createComponentImport(
   filePath: string,
   exportName: string,
   lazy?: boolean,
+  mode?: unknown,
 ): NuxtComponentImport {
   const componentImport: NuxtComponentImport = {
     exportName,
@@ -128,9 +134,9 @@ function createComponentImport(
     componentImport.lazy = true;
   }
 
-  const mode = detectComponentMode(filePath);
-  if (mode) {
-    componentImport.mode = mode;
+  const resolvedMode = normalizeComponentMode(mode) ?? detectComponentMode(filePath);
+  if (resolvedMode) {
+    componentImport.mode = resolvedMode;
   }
 
   return componentImport;
@@ -279,7 +285,12 @@ export function createNuxtComponentResolver(options: NuxtComponentResolverOption
   return {
     register(components: NuxtComponentDescriptor[]): void {
       for (const component of components) {
-        const resolved = createComponentImport(component.filePath, component.export || "default");
+        const resolved = createComponentImport(
+          component.filePath,
+          component.export || "default",
+          false,
+          component.mode,
+        );
         addComponentAlias(registered, component.pascalName, resolved);
         addComponentAlias(registered, component.kebabName, resolved);
         addComponentAlias(registered, component.name, resolved);

--- a/npm/nuxt/src/index.ts
+++ b/npm/nuxt/src/index.ts
@@ -404,6 +404,7 @@ export default defineNuxtModule<VizeNuxtOptions>({
             name: string;
             filePath: string;
             export: string;
+            mode?: "client" | "server";
           }>,
         );
       });


### PR DESCRIPTION
## Summary

Fixes #821.

- Preserve `component.mode` from Nuxt `components:extend` registry entries.
- Pass explicit component mode through the Vize Nuxt component resolver so client-only registered components are wrapped with `createClientOnly()`.
- Add a regression test for `NuxtRouteAnnouncer`-style registered client-only components without a `.client.*` filename.

## Root Cause

The Nuxt component bridge only inferred mode from file names such as `.client.vue` or `.server.vue`. Components registered through `components:extend` can carry explicit `mode` metadata even when their file path does not encode the mode, and Vize dropped that metadata before generating direct imports.

## Validation

- `node --test npm/nuxt/src/components.test.ts`
- `corepack pnpm --dir npm/nuxt check`
- `corepack pnpm --dir npm/nuxt test`
- `corepack pnpm --dir npm/nuxt build`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/823"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782973961&installation_id=136613492&pr_number=823&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F823&signature=16eeb40114f4387e4b9df0cb24f653aad61891a9c8bcb433eade12352ad64995"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->