### PR TITLE
fix(nuxt): preserve client-only component imports

### DIFF
--- a/npm/nuxt/src/components.test.ts
+++ b/npm/nuxt/src/components.test.ts
@@ -277,6 +277,37 @@ export default {
       /import __nuxt_component_0_raw from ".*nuxt-route-announcer\.js";\s*const __nuxt_component_0 = __nuxt_create_client_only\(__nuxt_component_0_raw\);/s,
       "registry client-only components should be wrapped before use",
     );
+
+    const componentImportTransformed = injectNuxtComponentImports(
+      `
+import { NuxtPage, NuxtRouteAnnouncer } from "#components";
+
+export default {
+  setup(__props) {
+    return (_ctx, _cache) => {
+      return [NuxtPage, NuxtRouteAnnouncer];
+    };
+  }
+}
+`,
+      (name) => resolver.resolve(name),
+    );
+
+    assert.equal(
+      componentImportTransformed.includes('from "#components"'),
+      false,
+      "#components imports should be rewritten when every imported component resolves",
+    );
+    assert.match(
+      componentImportTransformed,
+      /import NuxtPage from ".*page\.js";/,
+      "#components imports should preserve imported local component names",
+    );
+    assert.match(
+      componentImportTransformed,
+      /import (__nuxt_import_component_\d+_raw) from ".*nuxt-route-announcer\.js";\s*const NuxtRouteAnnouncer = __nuxt_create_client_only\(\1\);/s,
+      "#components imports should wrap registry client-only components",
+    );
   } finally {
     fs.rmSync(fixture.rootDir, { recursive: true, force: true });
   }

--- a/npm/nuxt/src/components.ts
+++ b/npm/nuxt/src/components.ts
@@ -25,6 +25,7 @@ export interface NuxtComponentResolverOptions {
 }
 
 const COMPONENT_CALL_RE = /_?resolveComponent\s*\(\s*["'`]([^"'`]+)["'`]\s*(?:,\s*[^)]+)?\)/g;
+const COMPONENTS_IMPORT_RE = /import\s+(?!type\b)\{([^}]*)\}\s+from\s+(["'])#components\2\s*;?/g;
 const COMPONENT_EXT_RE = /\.(?:[cm]?js|ts|vue)$/;
 const DTS_COMPONENT_RE =
   /^export const (\w+): (?:LazyComponent<)?typeof import\((["'])(.+?)\2\)(?:\.([A-Za-z_$][\w$]*)|\[['"]([A-Za-z_$][\w$]*)['"]\])>?/;
@@ -37,6 +38,18 @@ const RUNTIME_COMPONENT_DIRS = [
   "dist/runtime/components/nuxt4",
   "runtime/components",
 ];
+const IMPORT_SPECIFIER_RE = /^(type\s+)?([A-Za-z_$][\w$]*)(?:\s+as\s+([A-Za-z_$][\w$]*))?$/;
+
+interface ComponentImportSpecifier {
+  importedName: string;
+  localName: string;
+  typeOnly: boolean;
+}
+
+interface ComponentBindingResult {
+  needsCreateClientOnly: boolean;
+  needsDefineAsyncComponent: boolean;
+}
 
 function toKebabCase(name: string): string {
   return name
@@ -119,6 +132,32 @@ function normalizeComponentMode(mode: unknown): NuxtComponentImport["mode"] {
   return mode === "client" || mode === "server" ? mode : undefined;
 }
 
+function parseComponentImportSpecifier(raw: string): ComponentImportSpecifier | null {
+  const trimmed = raw.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  const match = trimmed.match(IMPORT_SPECIFIER_RE);
+  if (!match) {
+    return null;
+  }
+
+  const [, typeKeyword, importedName, localName] = match;
+  return {
+    importedName,
+    localName: localName || importedName,
+    typeOnly: Boolean(typeKeyword),
+  };
+}
+
+function splitComponentImportSpecifiers(specifiers: string): string[] {
+  return specifiers
+    .split(",")
+    .map((specifier) => specifier.trim())
+    .filter(Boolean);
+}
+
 function createComponentImport(
   filePath: string,
   exportName: string,
@@ -140,6 +179,62 @@ function createComponentImport(
   }
 
   return componentImport;
+}
+
+function addResolvedComponentBinding(
+  componentImports: string[],
+  resolved: NuxtComponentImport,
+  variableName: string,
+  rawVariableName: string,
+): ComponentBindingResult {
+  let needsCreateClientOnly = false;
+  let needsDefineAsyncComponent = false;
+
+  if (resolved.lazy) {
+    needsDefineAsyncComponent = true;
+    const exportAccessor =
+      resolved.exportName === "default"
+        ? "module.default"
+        : `module[${JSON.stringify(resolved.exportName)}]`;
+    if (resolved.mode === "client") {
+      needsCreateClientOnly = true;
+      componentImports.push(
+        `const ${variableName} = __nuxt_define_async_component(() => import(${JSON.stringify(resolved.filePath)}).then((module) => __nuxt_create_client_only(${exportAccessor})));`,
+      );
+    } else {
+      componentImports.push(
+        `const ${variableName} = __nuxt_define_async_component(() => import(${JSON.stringify(resolved.filePath)}).then((module) => ${exportAccessor}));`,
+      );
+    }
+    return { needsCreateClientOnly, needsDefineAsyncComponent };
+  }
+
+  if (resolved.exportName === "default") {
+    if (resolved.mode === "client") {
+      needsCreateClientOnly = true;
+      componentImports.push(`import ${rawVariableName} from ${JSON.stringify(resolved.filePath)};`);
+      componentImports.push(
+        `const ${variableName} = __nuxt_create_client_only(${rawVariableName});`,
+      );
+    } else {
+      componentImports.push(`import ${variableName} from ${JSON.stringify(resolved.filePath)};`);
+    }
+    return { needsCreateClientOnly, needsDefineAsyncComponent };
+  }
+
+  if (resolved.mode === "client") {
+    needsCreateClientOnly = true;
+    componentImports.push(
+      `import { ${resolved.exportName} as ${rawVariableName} } from ${JSON.stringify(resolved.filePath)};`,
+    );
+    componentImports.push(`const ${variableName} = __nuxt_create_client_only(${rawVariableName});`);
+  } else {
+    componentImports.push(
+      `import { ${resolved.exportName} as ${variableName} } from ${JSON.stringify(resolved.filePath)};`,
+    );
+  }
+
+  return { needsCreateClientOnly, needsDefineAsyncComponent };
 }
 
 function getNuxtComponentDtsFiles(rootDir: string, buildDir: string): string[] {
@@ -323,71 +418,78 @@ export function injectNuxtComponentImports(
   const componentImports: string[] = [];
   const importedComponents = new Map<string, string>();
   let counter = 0;
+  let importCounter = 0;
   let needsDefineAsyncComponent = false;
   let needsCreateClientOnly = false;
 
-  const nextCode = code.replace(COMPONENT_CALL_RE, (match: string, name: string) => {
-    const resolved = resolveComponentImport(name);
-    if (!resolved) {
-      return match;
-    }
+  const codeWithComponentImports = code.replace(
+    COMPONENTS_IMPORT_RE,
+    (match: string, specifiers: string) => {
+      const unresolvedSpecifiers: string[] = [];
+      let changed = false;
 
-    const importKey = `${resolved.exportName}\u0000${resolved.filePath}\u0000${resolved.lazy ? "lazy" : "eager"}\u0000${resolved.mode ?? "default"}`;
-    let variableName = importedComponents.get(importKey);
-    if (!variableName) {
-      variableName = `__nuxt_component_${counter++}`;
-      importedComponents.set(importKey, variableName);
-      if (resolved.lazy) {
-        needsDefineAsyncComponent = true;
-        const exportAccessor =
-          resolved.exportName === "default"
-            ? "module.default"
-            : `module[${JSON.stringify(resolved.exportName)}]`;
-        if (resolved.mode === "client") {
-          needsCreateClientOnly = true;
-          componentImports.push(
-            `const ${variableName} = __nuxt_define_async_component(() => import(${JSON.stringify(resolved.filePath)}).then((module) => __nuxt_create_client_only(${exportAccessor})));`,
-          );
-        } else {
-          componentImports.push(
-            `const ${variableName} = __nuxt_define_async_component(() => import(${JSON.stringify(resolved.filePath)}).then((module) => ${exportAccessor}));`,
-          );
+      for (const rawSpecifier of splitComponentImportSpecifiers(specifiers)) {
+        const specifier = parseComponentImportSpecifier(rawSpecifier);
+        if (!specifier || specifier.typeOnly) {
+          unresolvedSpecifiers.push(rawSpecifier);
+          continue;
         }
-      } else if (resolved.exportName === "default") {
-        if (resolved.mode === "client") {
-          needsCreateClientOnly = true;
-          const rawVariableName = `${variableName}_raw`;
-          componentImports.push(
-            `import ${rawVariableName} from ${JSON.stringify(resolved.filePath)};`,
-          );
-          componentImports.push(
-            `const ${variableName} = __nuxt_create_client_only(${rawVariableName});`,
-          );
-        } else {
-          componentImports.push(
-            `import ${variableName} from ${JSON.stringify(resolved.filePath)};`,
-          );
+
+        const resolved = resolveComponentImport(specifier.importedName);
+        if (!resolved) {
+          unresolvedSpecifiers.push(rawSpecifier);
+          continue;
         }
-      } else {
-        if (resolved.mode === "client") {
-          needsCreateClientOnly = true;
-          const rawVariableName = `${variableName}_raw`;
-          componentImports.push(
-            `import { ${resolved.exportName} as ${rawVariableName} } from ${JSON.stringify(resolved.filePath)};`,
-          );
-          componentImports.push(
-            `const ${variableName} = __nuxt_create_client_only(${rawVariableName});`,
-          );
-        } else {
-          componentImports.push(
-            `import { ${resolved.exportName} as ${variableName} } from ${JSON.stringify(resolved.filePath)};`,
-          );
-        }
+
+        changed = true;
+        const result = addResolvedComponentBinding(
+          componentImports,
+          resolved,
+          specifier.localName,
+          `__nuxt_import_component_${importCounter++}_raw`,
+        );
+        needsCreateClientOnly ||= result.needsCreateClientOnly;
+        needsDefineAsyncComponent ||= result.needsDefineAsyncComponent;
       }
-    }
 
-    return variableName;
-  });
+      if (!changed) {
+        return match;
+      }
+
+      if (unresolvedSpecifiers.length === 0) {
+        return "";
+      }
+
+      return `import { ${unresolvedSpecifiers.join(", ")} } from "#components";`;
+    },
+  );
+
+  const nextCode = codeWithComponentImports.replace(
+    COMPONENT_CALL_RE,
+    (match: string, name: string) => {
+      const resolved = resolveComponentImport(name);
+      if (!resolved) {
+        return match;
+      }
+
+      const importKey = `${resolved.exportName}\u0000${resolved.filePath}\u0000${resolved.lazy ? "lazy" : "eager"}\u0000${resolved.mode ?? "default"}`;
+      let variableName = importedComponents.get(importKey);
+      if (!variableName) {
+        variableName = `__nuxt_component_${counter++}`;
+        importedComponents.set(importKey, variableName);
+        const result = addResolvedComponentBinding(
+          componentImports,
+          resolved,
+          variableName,
+          `${variableName}_raw`,
+        );
+        needsCreateClientOnly ||= result.needsCreateClientOnly;
+        needsDefineAsyncComponent ||= result.needsDefineAsyncComponent;
+      }
+
+      return variableName;
+    },
+  );
 
   if (componentImports.length === 0) {
     return code;


### PR DESCRIPTION
## Summary

- rewrite named imports from `#components` inside Vize/Nuxt virtual Vue modules to resolved component imports
- reuse the existing Nuxt component metadata path so `mode: "client"` components are wrapped with `createClientOnly`
- cover the custom app-root `NuxtRouteAnnouncer` import path with a regression test

## Root cause

The Nuxt bridge already restored component auto-import behavior for generated `resolveComponent("...")` calls, including `components:extend` metadata such as `mode: "client"`. Custom app roots can also import Nuxt components explicitly from `#components`, and that path bypassed the bridge, leaving `NuxtRouteAnnouncer` without Nuxt's client-only wrapper.

Fixes #824.

## Validation

- `corepack pnpm --filter @vizejs/nuxt fmt`
- `corepack pnpm --filter @vizejs/nuxt test`
- `corepack pnpm --filter @vizejs/nuxt check`
- `corepack pnpm --filter @vizejs/nuxt build`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/825"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782980162&installation_id=136613492&pr_number=825&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F825&signature=2a0c3eec090da0606e7b3cc5ce4038e2f2684b2264909c2b15f5ebf07d49d7ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->