### PR TITLE
fix: declare native preview check peer

### DIFF
--- a/npm/vize/README.md
+++ b/npm/vize/README.md
@@ -23,6 +23,13 @@ Need `vp` first? Install Vite+ once from the [Vite+ install guide](https://vitep
 vp install -D vize
 ```
 
+`vize check` also needs the Corsa runtime from `@typescript/native-preview`. Install it in projects
+that run `vize check` from package scripts:
+
+```bash
+vp install -D @typescript/native-preview
+```
+
 ## CLI
 
 The npm CLI exposes the common package-script commands:
@@ -104,8 +111,8 @@ Lint output supports `text`, `ansi`, `plain`, `json`, `stylish`, `markdown`, `ht
 The human and agent-friendly formats include local rule documentation paths such as
 `docs/content/rules/vue.md`.
 
-`vize check` in the npm package uses the packaged NAPI checker so it can run from `package.json`
-scripts after installing `vize`:
+`vize check` in the npm package uses the packaged NAPI checker and the `@typescript/native-preview`
+Corsa runtime, so it can run from `package.json` scripts after installing both packages:
 
 ```bash
 vp exec vize check src --strict

--- a/npm/vize/package.json
+++ b/npm/vize/package.json
@@ -70,9 +70,13 @@
     "vite-plus": "catalog:vite-stack"
   },
   "peerDependencies": {
-    "@pkl-community/pkl": "catalog:repo-tooling"
+    "@pkl-community/pkl": "catalog:repo-tooling",
+    "@typescript/native-preview": "catalog:typescript"
   },
   "peerDependenciesMeta": {
+    "@typescript/native-preview": {
+      "optional": true
+    },
     "@pkl-community/pkl": {
       "optional": true
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -737,6 +737,9 @@ importers:
 
   npm/vize:
     dependencies:
+      '@typescript/native-preview':
+        specifier: catalog:typescript
+        version: 7.0.0-dev.20260514.1
       '@vizejs/native':
         specifier: workspace:*
         version: link:../vize-native

--- a/tests/tooling/package-manifests.test.ts
+++ b/tests/tooling/package-manifests.test.ts
@@ -307,6 +307,22 @@ test("pkl runtime stays optional for consumers of the vize package", () => {
   });
 });
 
+test("native preview runtime is declared for vize check users", () => {
+  const packageJson = JSON.parse(readRepoFile("npm/vize/package.json")) as {
+    dependencies?: Record<string, string>;
+    optionalDependencies?: Record<string, string>;
+    peerDependencies?: Record<string, string>;
+    peerDependenciesMeta?: Record<string, { optional?: boolean }>;
+  };
+
+  assert.equal(packageJson.dependencies?.["@typescript/native-preview"], undefined);
+  assert.equal(packageJson.optionalDependencies?.["@typescript/native-preview"], undefined);
+  assert.equal(packageJson.peerDependencies?.["@typescript/native-preview"], "catalog:typescript");
+  assert.deepEqual(packageJson.peerDependenciesMeta?.["@typescript/native-preview"], {
+    optional: true,
+  });
+});
+
 test("musea Nuxt tests the same vue-router major that it declares as a peer", () => {
   const workspaceYaml = readRepoFile("pnpm-workspace.yaml");
   const catalogVersion = workspaceYaml.match(/^\s+vue-router: "([^"]+)"$/m)?.[1];


### PR DESCRIPTION
## Summary

Declare `@typescript/native-preview` as an optional peer for the `vize` npm package and document that projects running `vize check` should install it. This keeps lint/fmt/build consumers from getting a forced runtime dependency while making the check runtime relationship explicit.

Fixes #830

## Change Class

- [x] Runtime packaging, release, or docs
- [ ] Not language-facing

## Behavior Reference

Issue #830.

## Verification Evidence

- [x] Minimal fixture or focused regression test added or updated
- [ ] Snapshot/baseline changes reviewed and explained
- [ ] Security/audit impact considered

`node --test tests/tooling/package-manifests.test.ts`

## Risk

Low. The new peer is marked optional, so package consumers that do not run `vize check` are not forced to install the Corsa runtime.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/836"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782981387&installation_id=136613492&pr_number=836&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F836&signature=63245c0b71622f3f8633de35721475011bd8d7d639e61350adef1acbeddb2e1a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->