### PR TITLE
fix: ignore slot props in unsafe url rule

### DIFF
--- a/crates/vize_patina/src/rules/vue/no_unsafe_url.rs
+++ b/crates/vize_patina/src/rules/vue/no_unsafe_url.rs
@@ -78,6 +78,10 @@ fn is_router_link_tag(tag: &str) -> bool {
     tag == "router-link" || tag == "RouterLink" || tag == "nuxt-link" || tag == "NuxtLink"
 }
 
+fn is_slot_tag(tag: &str) -> bool {
+    tag == "slot"
+}
+
 fn is_unsafe_static_attr_value(attr_name: &str, value: &str) -> bool {
     if attr_name.eq_ignore_ascii_case("srcset") {
         return value
@@ -134,6 +138,11 @@ impl Rule for NoUnsafeUrl {
     ) {
         // Only check v-bind
         if directive.name != "bind" {
+            return;
+        }
+
+        // Bindings on <slot> are slot props, not URL-bearing DOM attributes.
+        if is_slot_tag(element.tag.as_str()) {
             return;
         }
 
@@ -266,6 +275,13 @@ mod tests {
         let linter = create_linter();
         let result = linter.lint_template(r#"<iframe :src="url"></iframe>"#, "test.vue");
         assert_eq!(result.warning_count, 1);
+    }
+
+    #[test]
+    fn test_allows_slot_prop_bindings() {
+        let linter = create_linter();
+        let result = linter.lint_template(r#"<slot name="item" :data="item" />"#, "test.vue");
+        assert_eq!(result.warning_count, 0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Skip `vue/no-unsafe-url` dynamic URL checks on Vue `<slot>` outlets because bindings there are slot props, not URL-bearing DOM attributes. This prevents false positives for props like `:data` while preserving checks on real DOM URL attributes.

Fixes #827

## Change Class

- [x] Semantic analysis, lint, and cross-file analysis
- [ ] Not language-facing

## Behavior Reference

Issue #827.

## Verification Evidence

- [x] Minimal fixture or focused regression test added or updated
- [ ] Snapshot/baseline changes reviewed and explained
- [x] Security/audit impact considered

`cargo test -p vize_patina no_unsafe_url`

## Risk

Low. The skip is limited to `<slot>` outlets, where bound values are exposed as slot props rather than applied to DOM URL attributes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/837"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782981619&installation_id=136613492&pr_number=837&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F837&signature=ae57e5ff951fcf4167f89d6e2f5b2bfa28b8b987b6b97edc99c30267b04e24c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->