### PR TITLE
fix: inspect sfc style blocks for scoped style

### DIFF
--- a/crates/vize_patina/src/linter/engine.rs
+++ b/crates/vize_patina/src/linter/engine.rs
@@ -28,6 +28,7 @@ const SEMANTIC_TEMPLATE_RULES: &[&str] = &[
 
 const SHARED_SFC_DESCRIPTOR_RULES: &[&str] = &[
     "vue/sfc-element-order",
+    "vue/require-scoped-style",
     "vue/single-style-block",
     "ecosystem/void-link-require-href",
     "ecosystem/void-link-valid-method",

--- a/crates/vize_patina/src/rules/vue/require_scoped_style.rs
+++ b/crates/vize_patina/src/rules/vue/require_scoped_style.rs
@@ -43,6 +43,9 @@
 use crate::context::LintContext;
 use crate::diagnostic::{LintDiagnostic, Severity};
 use crate::rule::{Rule, RuleCategory, RuleMeta};
+use vize_atelier_sfc::{SfcParseOptions, parse_sfc};
+use vize_carton::profile;
+
 static META: RuleMeta = RuleMeta {
     name: "vue/require-scoped-style",
     description: "Require scoped attribute on style tags",
@@ -61,42 +64,52 @@ impl Rule for RequireScopedStyle {
     }
 
     fn run_on_sfc<'a>(&self, ctx: &mut LintContext<'a>) {
-        let source = ctx.source;
+        let owned_descriptor;
+        let descriptor = if let Some(descriptor) = ctx.sfc_descriptor() {
+            descriptor
+        } else {
+            owned_descriptor = match profile!(
+                "patina.rule.require_scoped_style.parse_sfc",
+                parse_sfc(
+                    ctx.source,
+                    SfcParseOptions {
+                        filename: ctx.filename.into(),
+                        ..Default::default()
+                    },
+                )
+            ) {
+                Ok(descriptor) => descriptor,
+                Err(_) => return,
+            };
+            &owned_descriptor
+        };
 
-        // Find all <style tags.
-        let mut pos = 0;
-        while let Some(style_start) = source[pos..].find("<style") {
-            let abs_pos = pos + style_start;
-            pos = abs_pos + 6;
+        // App/layout files are common exceptions for global styles.
+        let filename = ctx.filename;
+        let is_exception = filename.ends_with("App.vue")
+            || filename.contains("layout")
+            || filename.contains("Layout");
+        if is_exception {
+            return;
+        }
 
-            // Find the closing >.
-            if let Some(tag_end) = source[abs_pos..].find('>') {
-                let tag_content = &source[abs_pos..abs_pos + tag_end + 1];
+        let unscoped_style_ranges = descriptor
+            .styles
+            .iter()
+            .filter(|style| !style.scoped && style.module.is_none())
+            .map(|style| (style.loc.tag_start as u32, style.loc.start as u32))
+            .collect::<Vec<_>>();
 
-                // Check if it has scoped or module attribute.
-                let has_scoped = tag_content.contains("scoped");
-                let has_module = tag_content.contains("module");
-
-                if !has_scoped && !has_module {
-                    // App/layout files are common exceptions for global styles.
-                    let filename = ctx.filename;
-                    let is_exception = filename.ends_with("App.vue")
-                        || filename.contains("layout")
-                        || filename.contains("Layout");
-
-                    if !is_exception {
-                        ctx.report(
-                            LintDiagnostic::warn(
-                                META.name,
-                                "Style block should use `scoped` or `module` attribute to prevent CSS leaking",
-                                abs_pos as u32,
-                                (abs_pos + tag_end + 1) as u32,
-                            )
-                            .with_help("Add `scoped` attribute: `<style scoped>`"),
-                        );
-                    }
-                }
-            }
+        for (start, end) in unscoped_style_ranges {
+            ctx.report(
+                LintDiagnostic::warn(
+                    META.name,
+                    "Style block should use `scoped` or `module` attribute to prevent CSS leaking",
+                    start,
+                    end,
+                )
+                .with_help("Add `scoped` attribute: `<style scoped>`"),
+            );
         }
     }
 }
@@ -168,5 +181,39 @@ body { margin: 0; }
             "App.vue",
         );
         assert_eq!(result.warning_count, 0);
+    }
+
+    #[test]
+    fn test_ignores_style_string_literals() {
+        let linter = create_linter();
+        let result = linter.lint_sfc(
+            r#"<script setup lang="ts">
+const ssrStyles = computed(() => `<style>${styles}</style>`);
+</script>
+
+<template><div>Hello</div></template>
+"#,
+            "Component.vue",
+        );
+        assert_eq!(result.warning_count, 0);
+    }
+
+    #[test]
+    fn test_reports_real_style_block_once_with_style_string_literal() {
+        let linter = create_linter();
+        let result = linter.lint_sfc(
+            r#"<script setup lang="ts">
+const ssrStyles = computed(() => `<style>${styles}</style>`);
+</script>
+
+<template><div>Hello</div></template>
+<style>
+.button { color: red; }
+</style>
+"#,
+            "Component.vue",
+        );
+        assert_eq!(result.warning_count, 1);
+        assert_eq!(result.diagnostics[0].rule_name, "vue/require-scoped-style");
     }
 }


### PR DESCRIPTION
## Summary
- evaluate vue/require-scoped-style against parsed SFC style blocks instead of raw source text
- share the SFC descriptor for the rule through the linter engine
- add coverage for <style> text inside script string literals

## Validation
- cargo fmt --all --check
- cargo test -p vize_patina require_scoped_style
- git diff --check

Fixes #828

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/838"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782981932&installation_id=136613492&pr_number=838&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F838&signature=507a962f2d5abb8f1fb6e8079e62641f39d8e127d88fd93453fe9470268b13de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->