### PR TITLE
fix: flush lint json output before exit

### DIFF
--- a/crates/vize/src/commands/lint.rs
+++ b/crates/vize/src/commands/lint.rs
@@ -5,6 +5,7 @@ use glob::{MatchOptions, Pattern};
 use ignore::WalkBuilder;
 use rayon::prelude::*;
 use std::fs;
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -438,6 +439,9 @@ pub fn run(args: LintArgs) {
         };
         print_profile_report(&report);
     }
+
+    // `process::exit` below bypasses normal stdout teardown, so flush report output first.
+    let _ = std::io::stdout().flush();
 
     // Exit with appropriate code
     if total_errors > 0 {

--- a/crates/vize/tests/check_cli.rs
+++ b/crates/vize/tests/check_cli.rs
@@ -1018,6 +1018,51 @@ loadData()
 }
 
 #[test]
+fn lint_json_output_is_valid_when_error_exit_runs() {
+    let project_root = create_cli_project(
+        "lint-json-error-exit",
+        &[(
+            "src/App.vue",
+            r#"<script setup lang="ts">
+const items = [1, 2]
+</script>
+
+<template>
+  <div v-for="item in items">{{ item }}</div>
+</template>
+"#,
+        )],
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(&project_root)
+        .args([
+            "lint",
+            "--format",
+            "json",
+            "--help-level",
+            "none",
+            "src/App.vue",
+        ])
+        .output()
+        .unwrap();
+
+    let stdout = std::string::String::from_utf8(output.stdout).unwrap();
+    let stderr = std::string::String::from_utf8(output.stderr).unwrap();
+    assert_eq!(output.status.code(), Some(1), "{stderr}");
+    let json: serde_json::Value = serde_json::from_str(&stdout).unwrap_or_else(|error| {
+        panic!("failed to parse stdout as JSON: {error}\nstdout:\n{stdout}\nstderr:\n{stderr}")
+    });
+    let files = json
+        .as_array()
+        .expect("lint JSON output should be an array");
+    assert_eq!(files.len(), 1, "{stdout}");
+    assert_eq!(files[0]["errorCount"], 1, "{stdout}");
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}
+
+#[test]
 fn check_rejects_unsupported_corsa_server_count() {
     let project_root = create_cli_project(
         "unsupported-corsa-servers",


### PR DESCRIPTION
## Summary
- flush lint stdout before exit paths can terminate the process
- add a CLI regression test that parses JSON output when lint exits with an error

## Validation
- cargo fmt --all --check
- cargo test -p vize lint_json_output_is_valid_when_error_exit_runs
- git diff --check

Fixes #826

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/839"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782982338&installation_id=136613492&pr_number=839&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F839&signature=542bbed7c2eede658f7acbb7bf660a081c0a6953cbd30b574759bcfb428d19cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->