### PR TITLE
fix: treat slots as a11y content

### DIFF
--- a/crates/vize_patina/src/rules/a11y/anchor_has_content.rs
+++ b/crates/vize_patina/src/rules/a11y/anchor_has_content.rs
@@ -10,6 +10,7 @@
 use crate::context::LintContext;
 use crate::diagnostic::Severity;
 use crate::rule::{Rule, RuleCategory, RuleMeta};
+use crate::rules::a11y::helpers::is_slot_element;
 use vize_relief::ast::{ElementNode, PropNode, TemplateChildNode};
 
 static META: RuleMeta = RuleMeta {
@@ -52,6 +53,9 @@ impl AnchorHasContent {
                     return true;
                 }
                 TemplateChildNode::Element(el) => {
+                    if is_slot_element(el) {
+                        return true;
+                    }
                     // Check for img with alt
                     if el.tag == "img" {
                         for prop in &el.props {
@@ -134,5 +138,12 @@ mod tests {
         let linter = create_linter();
         let result = linter.lint_template(r#"<a href="/">   </a>"#, "test.vue");
         assert_eq!(result.warning_count, 1);
+    }
+
+    #[test]
+    fn test_valid_with_default_slot() {
+        let linter = create_linter();
+        let result = linter.lint_template(r#"<a href="/"><slot></slot></a>"#, "test.vue");
+        assert_eq!(result.warning_count, 0);
     }
 }

--- a/crates/vize_patina/src/rules/a11y/heading_has_content.rs
+++ b/crates/vize_patina/src/rules/a11y/heading_has_content.rs
@@ -9,6 +9,7 @@
 use crate::context::LintContext;
 use crate::diagnostic::Severity;
 use crate::rule::{Rule, RuleCategory, RuleMeta};
+use crate::rules::a11y::helpers::is_slot_element;
 use vize_relief::ast::{ElementNode, PropNode, TemplateChildNode};
 
 static META: RuleMeta = RuleMeta {
@@ -45,6 +46,9 @@ impl HeadingHasContent {
                     return true;
                 }
                 TemplateChildNode::Interpolation(_) => {
+                    return true;
+                }
+                TemplateChildNode::Element(el) if is_slot_element(el) => {
                     return true;
                 }
                 TemplateChildNode::Element(el) if Self::has_accessible_content(el) => {
@@ -130,5 +134,12 @@ mod tests {
         let linter = create_linter();
         let result = linter.lint_template(r#"<h1></h1>"#, "test.vue");
         assert_eq!(result.warning_count, 1);
+    }
+
+    #[test]
+    fn test_valid_with_default_slot() {
+        let linter = create_linter();
+        let result = linter.lint_template(r#"<h1><slot></slot></h1>"#, "test.vue");
+        assert_eq!(result.warning_count, 0);
     }
 }

--- a/crates/vize_patina/src/rules/a11y/helpers.rs
+++ b/crates/vize_patina/src/rules/a11y/helpers.rs
@@ -19,6 +19,11 @@ pub fn is_component_like_element(element: &ElementNode) -> bool {
     ) || !is_native_tag(element.tag.as_str())
 }
 
+/// Check if an element represents a Vue slot outlet.
+pub fn is_slot_element(element: &ElementNode) -> bool {
+    matches!(element.tag_type, ElementType::Slot) || element.tag == "slot"
+}
+
 /// Check if an element is natively interactive (has implicit keyboard support)
 pub fn is_interactive_element(tag: &str) -> bool {
     matches!(


### PR DESCRIPTION
## Summary
- count Vue slot outlets as potential accessible content for a11y content rules
- add coverage for <slot> inside anchors and headings

## Validation
- cargo fmt --all --check
- cargo test -p vize_patina anchor_has_content
- cargo test -p vize_patina heading_has_content
- git diff --check

Fixes #829

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/842"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782982937&installation_id=136613492&pr_number=842&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F842&signature=bcc524bbd1b15a98ad3001d52981a43d5489a66ad5266c579d307d9d6e71a1eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->