### PR TITLE
fix: align multiline self-closing tags

### DIFF
--- a/crates/vize_glyph/src/template.rs
+++ b/crates/vize_glyph/src/template.rs
@@ -83,6 +83,25 @@ mod tests {
     }
 
     #[test]
+    fn test_multiline_self_closing_slash_aligns_with_opening_tag() {
+        let source = r#"<slot name="slide" :data="item" :index="index" :is-active="index === selectedIndex" :is-in-view="slidesInView.includes(index)" />"#;
+        let mut options = FormatOptions::default();
+        options.sort_attributes = false;
+        let result = format_template_content(source, &options).unwrap();
+
+        assert_eq!(
+            result.as_str(),
+            r#"<slot
+  name="slide"
+  :data="item"
+  :index="index"
+  :is-active="index === selectedIndex"
+  :is-in-view="slidesInView.includes(index)"
+/>"#
+        );
+    }
+
+    #[test]
     fn test_empty_element_stays_inline() {
         let source = "<div>\n</div>";
         let options = FormatOptions::default();

--- a/crates/vize_glyph/src/template/formatter.rs
+++ b/crates/vize_glyph/src/template/formatter.rs
@@ -122,6 +122,7 @@ impl<'a> TemplateFormatter<'a> {
                     output.push(b'<');
                     output.extend_from_slice(tag_name.as_bytes());
 
+                    let mut closing_bracket_on_own_line = false;
                     if !sorted_attrs.is_empty() {
                         let use_multiline =
                             self.should_use_multiline_attrs(&tag_name, &sorted_attrs, depth);
@@ -151,6 +152,7 @@ impl<'a> TemplateFormatter<'a> {
                             if !self.options.bracket_same_line {
                                 output.extend_from_slice(self.newline);
                                 self.write_indent(&mut output, depth);
+                                closing_bracket_on_own_line = true;
                             }
                         } else {
                             for attr in &sorted_attrs {
@@ -161,7 +163,11 @@ impl<'a> TemplateFormatter<'a> {
                     }
 
                     if is_self_closing {
-                        output.extend_from_slice(b" />");
+                        if closing_bracket_on_own_line {
+                            output.extend_from_slice(b"/>");
+                        } else {
+                            output.extend_from_slice(b" />");
+                        }
                     } else if !is_void_element_str(&tag_name)
                         && let Some(closing_end_pos) =
                             self.parse_immediate_empty_closing_tag(source, end_pos, &tag_name)


### PR DESCRIPTION
## Summary
- stop adding an extra leading space before `/>` when multiline self-closing tags place the bracket on its own line
- keep inline self-closing tags and `bracket_same_line` behavior unchanged
- add regression coverage for slot-style multiline self-closing formatting

## Validation
- cargo fmt --all --check
- cargo test -p vize_glyph test_multiline_self_closing_slash_aligns_with_opening_tag
- cargo test -p vize_glyph
- git diff --check

Fixes #834

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/844"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782983397&installation_id=136613492&pr_number=844&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F844&signature=fdb806f7bb2a52c611b510ac48e80a380e455f75c6d33a6c06a27e4ee5962284"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->