### PR TITLE
fix: use tsconfig inputs for check defaults

### DIFF
--- a/crates/vize/src/commands/check/runner.rs
+++ b/crates/vize/src/commands/check/runner.rs
@@ -116,6 +116,16 @@ pub(crate) fn run_direct(args: &CheckArgs) {
     };
 
     if files.is_empty() {
+        if args.format == "json" {
+            emit_json_output(JsonOutput {
+                files: Vec::new(),
+                error_count: 0,
+                warning_count: 0,
+                file_count: 0,
+                declarations: None,
+            });
+            return;
+        }
         eprintln!(
             "No Vue or TypeScript files found matching inputs: {:?}",
             args.patterns
@@ -199,6 +209,16 @@ pub(crate) fn run_direct(args: &CheckArgs) {
 
     let virtual_files = checker.virtual_files();
     if virtual_files.is_empty() {
+        if args.format == "json" {
+            emit_json_output(JsonOutput {
+                files: Vec::new(),
+                error_count: 0,
+                warning_count: 0,
+                file_count: 0,
+                declarations: None,
+            });
+            return;
+        }
         eprintln!("No files were registered for type checking");
         return;
     }
@@ -407,13 +427,7 @@ pub(crate) fn run_direct(args: &CheckArgs) {
             file_count: reported_file_count,
             declarations,
         };
-        match serde_json::to_string_pretty(&json_output) {
-            Ok(output) => println!("{output}"),
-            Err(error) => {
-                eprintln!("Failed to serialize check output: {error}");
-                std::process::exit(1);
-            }
-        }
+        emit_json_output(json_output);
         if total_errors > 0 {
             std::process::exit(1);
         }
@@ -495,6 +509,16 @@ pub(crate) fn run_direct(args: &CheckArgs) {
     {
         eprintln!("\nToo many warnings ({total_warnings} > max {max_warnings})");
         std::process::exit(1);
+    }
+}
+
+fn emit_json_output(json_output: JsonOutput) {
+    match serde_json::to_string_pretty(&json_output) {
+        Ok(output) => println!("{output}"),
+        Err(error) => {
+            eprintln!("Failed to serialize check output: {error}");
+            std::process::exit(1);
+        }
     }
 }
 

--- a/crates/vize/src/commands/check/tsconfig_inputs.rs
+++ b/crates/vize/src/commands/check/tsconfig_inputs.rs
@@ -99,11 +99,10 @@ struct GlobSpec {
 
 impl GlobSpec {
     fn new(base_dir: &Path, value: &str) -> Option<Self> {
-        let normalized = normalize_tsconfig_glob(value);
-        Pattern::new(&normalized).ok().map(|pattern| Self {
-            base_dir: base_dir.to_path_buf(),
-            pattern,
-        })
+        let (base_dir, normalized) = normalize_tsconfig_glob_base(base_dir, value);
+        Pattern::new(&normalized)
+            .ok()
+            .map(|pattern| Self { base_dir, pattern })
     }
 
     fn matches(&self, path: &Path) -> bool {
@@ -548,6 +547,30 @@ fn normalize_tsconfig_glob(value: &str) -> std::string::String {
     normalized
 }
 
+fn normalize_tsconfig_glob_base(base_dir: &Path, value: &str) -> (PathBuf, std::string::String) {
+    let mut base_dir = base_dir.to_path_buf();
+    let mut normalized = normalize_tsconfig_glob(value);
+
+    loop {
+        if let Some(rest) = normalized.strip_prefix("./") {
+            normalized = rest.to_owned();
+        } else if let Some(rest) = normalized.strip_prefix("../") {
+            if let Some(parent) = base_dir.parent() {
+                base_dir = parent.to_path_buf();
+            }
+            normalized = rest.to_owned();
+        } else {
+            break;
+        }
+    }
+
+    if normalized.is_empty() {
+        normalized.push_str("**/*");
+    }
+
+    (base_dir, normalized)
+}
+
 fn default_exclude_specs(base_dir: &Path) -> Vec<GlobSpec> {
     ["node_modules", "bower_components", "jspm_packages"]
         .into_iter()
@@ -826,6 +849,46 @@ mod tests {
         let files = collect_default_check_files(&case_dir, Some(&case_dir.join("tsconfig.json")));
 
         assert_eq!(files, vec![case_dir.join("src/App.vue")]);
+
+        let _ = fs::remove_dir_all(&case_dir);
+    }
+
+    #[test]
+    fn default_collection_matches_parent_relative_extended_include() {
+        let case_dir = unique_case_dir("tsconfig-extends-parent-relative");
+        let _ = fs::remove_dir_all(&case_dir);
+        fs::create_dir_all(case_dir.join(".nuxt")).unwrap();
+        fs::create_dir_all(case_dir.join("src")).unwrap();
+        fs::create_dir_all(case_dir.join("dist")).unwrap();
+        fs::write(case_dir.join("src/App.vue"), "<template />").unwrap();
+        fs::write(case_dir.join("src/main.ts"), "export const ok = true").unwrap();
+        fs::write(
+            case_dir.join("dist/generated.ts"),
+            "export const skip = true",
+        )
+        .unwrap();
+        fs::write(case_dir.join(".nuxt/nuxt.d.ts"), "declare const nuxt: true").unwrap();
+        fs::write(
+            case_dir.join(".nuxt/tsconfig.json"),
+            r#"{
+  "include": ["./nuxt.d.ts", "../src/**/*", "../dist/**/*.ts"],
+  "exclude": ["../dist"]
+}"#,
+        )
+        .unwrap();
+        fs::write(
+            case_dir.join("tsconfig.json"),
+            r#"{
+  "extends": "./.nuxt/tsconfig.json"
+}"#,
+        )
+        .unwrap();
+
+        let files = collect_default_check_files(&case_dir, Some(&case_dir.join("tsconfig.json")));
+
+        assert!(files.iter().any(|path| path.ends_with("src/App.vue")));
+        assert!(files.iter().any(|path| path.ends_with("src/main.ts")));
+        assert!(!files.iter().any(|path| path.ends_with("dist/generated.ts")));
 
         let _ = fs::remove_dir_all(&case_dir);
     }

--- a/crates/vize/tests/check_cli.rs
+++ b/crates/vize/tests/check_cli.rs
@@ -120,6 +120,104 @@ void props
 }
 
 #[test]
+fn check_without_patterns_uses_parent_relative_tsconfig_includes() {
+    let Some(corsa_path) = resolve_test_corsa_path() else {
+        return;
+    };
+    let project_root = create_cli_project(
+        "default-tsconfig-inputs",
+        &[(
+            "src/App.vue",
+            r#"<script setup lang="ts">
+const count = 1
+</script>
+
+<template>
+  <div>{{ count }}</div>
+</template>
+"#,
+        )],
+    );
+    std::fs::create_dir_all(project_root.join(".nuxt")).unwrap();
+    std::fs::write(
+        project_root.join(".nuxt/tsconfig.json"),
+        r#"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true
+  },
+  "include": ["../src/**/*"]
+}"#,
+    )
+    .unwrap();
+    std::fs::write(
+        project_root.join("tsconfig.json"),
+        r#"{
+  "extends": "./.nuxt/tsconfig.json"
+}"#,
+    )
+    .unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(&project_root)
+        .env("CORSA_PATH", corsa_path)
+        .args(["check", "--format", "json"])
+        .output()
+        .unwrap();
+
+    let stdout = std::string::String::from_utf8(output.stdout).unwrap();
+    let stderr = std::string::String::from_utf8(output.stderr).unwrap();
+    let json: serde_json::Value = serde_json::from_str(&stdout).unwrap_or_else(|error| {
+        panic!("failed to parse stdout as JSON: {error}\nstdout:\n{stdout}\nstderr:\n{stderr}")
+    });
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "stdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert_eq!(json["fileCount"], 1, "stdout:\n{stdout}\nstderr:\n{stderr}");
+    assert_eq!(
+        json["files"][0]["file"], "src/App.vue",
+        "stdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}
+
+#[test]
+fn check_json_reports_empty_result_when_no_files_match() {
+    let project_root = create_cli_project("json-empty-inputs", &[]);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(&project_root)
+        .args(["check", "--format", "json"])
+        .output()
+        .unwrap();
+
+    let stdout = std::string::String::from_utf8(output.stdout).unwrap();
+    let stderr = std::string::String::from_utf8(output.stderr).unwrap();
+    let json: serde_json::Value = serde_json::from_str(&stdout).unwrap_or_else(|error| {
+        panic!("failed to parse stdout as JSON: {error}\nstdout:\n{stdout}\nstderr:\n{stderr}")
+    });
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "stdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert_eq!(json["fileCount"], 0);
+    assert_eq!(json["errorCount"], 0);
+    assert_eq!(json["warningCount"], 0);
+    assert_eq!(json["files"].as_array().unwrap().len(), 0);
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}
+
+#[test]
 fn check_directory_pattern_resolves_json_modules_imported_by_ts() {
     let Some(corsa_path) = resolve_test_corsa_path() else {
         return;


### PR DESCRIPTION
## Summary
- resolve tsconfig include/exclude globs that start with `./` or `../` from the config file that owns them
- allow `vize check` with no positional patterns to collect files from Nuxt-style extended tsconfig files
- emit a machine-readable empty JSON result for `vize check --format json` when no files match

## Validation
- cargo fmt --all --check
- cargo test -p vize commands::check::tsconfig_inputs::tests
- cargo test -p vize --test check_cli check_without_patterns_uses_parent_relative_tsconfig_includes
- cargo test -p vize --test check_cli check_json_reports_empty_result_when_no_files_match
- git diff --check

Fixes #831

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/845"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782983719&installation_id=136613492&pr_number=845&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F845&signature=df3dfb653b3a49634ae52e4e219923bdc24cc71732c76444bd1534fb31ec2a63"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->