### PR TITLE
fix: clarify musea nuxt cli usage

### DIFF
--- a/crates/vize/src/commands/musea.rs
+++ b/crates/vize/src/commands/musea.rs
@@ -141,7 +141,13 @@ fn create_serve_plan(args: &ServeArgs, cwd: &Path) -> Result<ServePlan, String> 
         ));
     }
 
-    let program = resolve_vite_binary(cwd).unwrap_or_else(|| PathBuf::from("vite"));
+    let program = match resolve_vite_binary(cwd) {
+        Some(program) => program,
+        None if let Some(nuxt_root) = find_nuxt_project_root(cwd) => {
+            return Err(nuxt_musea_message(&nuxt_root, args.build));
+        }
+        None => PathBuf::from("vite"),
+    };
     let mut vite_args = if args.build {
         vec![cstr!("build")]
     } else {
@@ -175,6 +181,69 @@ fn resolve_vite_binary(cwd: &Path) -> Option<PathBuf> {
         }
     }
     None
+}
+
+fn find_nuxt_project_root(cwd: &Path) -> Option<PathBuf> {
+    cwd.ancestors()
+        .find(|ancestor| is_nuxt_project_root(ancestor))
+        .map(Path::to_path_buf)
+}
+
+fn is_nuxt_project_root(root: &Path) -> bool {
+    ["nuxt.config.ts", "nuxt.config.mts", "nuxt.config.js"]
+        .into_iter()
+        .any(|file_name| root.join(file_name).exists())
+        || package_json_has_dependency(root, "nuxt")
+}
+
+fn package_json_has_dependency(root: &Path, dependency: &str) -> bool {
+    let Ok(content) = fs::read_to_string(root.join("package.json")) else {
+        return false;
+    };
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(&content) else {
+        return false;
+    };
+
+    [
+        "dependencies",
+        "devDependencies",
+        "peerDependencies",
+        "optionalDependencies",
+    ]
+    .into_iter()
+    .any(|section| {
+        value
+            .get(section)
+            .and_then(serde_json::Value::as_object)
+            .is_some_and(|dependencies| dependencies.contains_key(dependency))
+    })
+}
+
+fn has_vize_nuxt_integration(root: &Path) -> bool {
+    package_json_has_dependency(root, "@vizejs/nuxt")
+        || root
+            .join("node_modules")
+            .join("@vizejs")
+            .join("nuxt")
+            .join("package.json")
+            .exists()
+}
+
+fn nuxt_musea_message(root: &Path, build: bool) -> String {
+    let command = if build { "nuxi build" } else { "nuxi dev" };
+    if has_vize_nuxt_integration(root) {
+        return cstr!(
+            "vize musea: detected a Nuxt project using `@vizejs/nuxt` at {}.\n  The standalone `vize musea` command only runs direct Vite projects with `vite` and `@vizejs/vite-plugin-musea` configured in Vite.\n  In this Nuxt setup, Musea is provided by the Nuxt module at `/__musea__/`; run `{}` and open that route instead.",
+            root.display(),
+            command
+        );
+    }
+
+    cstr!(
+        "vize musea: detected a Nuxt project at {}.\n  The standalone `vize musea` command only runs direct Vite projects with `vite` and `@vizejs/vite-plugin-musea` configured in Vite.\n  For Nuxt, enable `@vizejs/nuxt`, run `{}`, and open `/__musea__/` instead.",
+        root.display(),
+        command
+    )
 }
 
 #[cfg(windows)]
@@ -348,6 +417,36 @@ mod tests {
 
         assert_eq!(plan.program, vite_bin);
         assert_eq!(plan.args, ["build"]);
+    }
+
+    #[test]
+    fn serve_plan_rejects_nuxt_project_without_direct_vite() {
+        let temp = tempfile::tempdir().unwrap();
+        fs::write(temp.path().join("nuxt.config.ts"), "export default {}").unwrap();
+        fs::write(
+            temp.path().join("package.json"),
+            r#"{
+  "dependencies": {
+    "@vizejs/nuxt": "0.162.0",
+    "nuxt": "4.3.1"
+  }
+}"#,
+        )
+        .unwrap();
+
+        let error = create_serve_plan(
+            &ServeArgs {
+                build: true,
+                ..ServeArgs::default()
+            },
+            temp.path(),
+        )
+        .unwrap_err();
+
+        assert!(error.contains("detected a Nuxt project"));
+        assert!(error.contains("standalone `vize musea` command only runs direct Vite projects"));
+        assert!(error.contains("nuxi build"));
+        assert!(error.contains("/__musea__/"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- detect Nuxt projects before the standalone Musea CLI falls through to a missing `vite` binary
- explain that `vize musea` is for direct Vite projects and that Nuxt serves Musea through `@vizejs/nuxt` at `/__musea__/`
- point Nuxt users to `nuxi dev` or `nuxi build` depending on the requested mode

## Validation
- cargo fmt --all --check
- cargo test -p vize commands::musea
- git diff --check

Fixes #833

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/846"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782983955&installation_id=136613492&pr_number=846&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F846&signature=354f8d8ebd4f57eb658c5b4a309a0caa56c01b72024aefb200f200a54bc604d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->