### PR TITLE
fix: cover nuxt vue runtime helper exports

### DIFF
--- a/crates/vize/tests/check_cli.rs
+++ b/crates/vize/tests/check_cli.rs
@@ -496,6 +496,90 @@ export default defineComponent({
 }
 
 #[test]
+fn check_stubbed_vue_exports_runtime_helpers_used_by_nuxt_apps() {
+    let Some(corsa_path) = resolve_test_corsa_path() else {
+        return;
+    };
+    let project_root = create_cli_project(
+        "stubbed-vue-runtime-helpers",
+        &[(
+            "src/App.vue",
+            r#"<script setup lang="ts">
+import {
+  Transition,
+  createApp,
+  defineProps,
+  ref,
+  useId,
+  watch,
+  watchEffect,
+  type PropType,
+} from "vue";
+
+const labelType = String as PropType<string>;
+const props = defineProps<{ label?: string }>();
+const count = ref(0);
+const id = useId();
+
+watch(count, () => {}, { immediate: true });
+watchEffect((onCleanup) => {
+  onCleanup(() => {});
+});
+
+const app = createApp({});
+app.config.globalProperties.$id = id;
+
+void labelType;
+void Transition;
+</script>
+
+<template>
+  <Transition>
+    <p>{{ props.label }} {{ id }}</p>
+  </Transition>
+</template>
+"#,
+        )],
+    );
+
+    // Force the virtual project to use vize's fallback Vue stub instead of a
+    // workspace-linked full Vue installation.
+    remove_path_if_exists(&project_root.join("node_modules").join("@vue")).unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(&project_root)
+        .env("CORSA_PATH", corsa_path)
+        .args([
+            "check",
+            "src/App.vue",
+            "--tsconfig",
+            "tsconfig.json",
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+
+    let stdout = std::string::String::from_utf8(output.stdout).unwrap();
+    let stderr = std::string::String::from_utf8(output.stderr).unwrap();
+    let json: serde_json::Value = serde_json::from_str(&stdout).unwrap_or_else(|error| {
+        panic!("failed to parse stdout as JSON: {error}\nstdout:\n{stdout}\nstderr:\n{stderr}")
+    });
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "stdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert_eq!(
+        json["errorCount"], 0,
+        "stdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}
+
+#[test]
 fn check_resolves_named_exports_from_vue_imported_via_path_alias() {
     let Some(corsa_path) = resolve_test_corsa_path() else {
         return;
@@ -2637,11 +2721,31 @@ fn write_test_vue_stub(target: &Path) -> std::io::Result<()> {
 
 export interface ShallowRef<T = any, S = T> extends Ref<T, S> {}
 
+export type WatchStopHandle = () => void;
+export type WatchCleanup = (cleanupFn: () => void) => void;
+export type WatchEffect = (onCleanup: WatchCleanup) => void | Promise<void>;
+export type PropConstructor<T = any> =
+  | { new (...args: any[]): T & {} }
+  | { (): T }
+  | ((...args: any[]) => T);
+export type PropType<T> = PropConstructor<T> | readonly PropConstructor<T>[];
+
+export interface ComponentCustomProperties {}
+
 export interface ComponentPublicInstance {
   $attrs: any;
   $slots: any;
   $refs: any;
   $emit: (...args: any[]) => void;
+}
+
+export interface App<Element = any> {
+  config: {
+    globalProperties: ComponentCustomProperties & Record<string, any>;
+    [key: string]: any;
+  };
+  mount(rootContainer: string | Element): ComponentPublicInstance;
+  unmount(): void;
 }
 
 export type DefineComponent<
@@ -2661,6 +2765,15 @@ export type DefineComponent<
 export declare function ref<T>(value: T): Ref<T>;
 export declare function useTemplateRef<T = any>(key: string): ShallowRef<T | null>;
 export declare function defineComponent<Props = any>(options: any): DefineComponent<Props>;
+export declare function defineProps<T = any>(): T;
+export declare function defineProps<const T extends readonly string[]>(_props: T): { [K in T[number]]?: any };
+export declare function defineProps<const T extends Record<string, any>>(_props: T): T;
+export declare function createApp(rootComponent: any, rootProps?: any): App;
+export declare function watch<T>(source: any, cb: any, options?: any): WatchStopHandle;
+export declare function watchEffect(effect: WatchEffect, options?: any): WatchStopHandle;
+export declare function useId(): string;
+export declare const Transition: DefineComponent;
+export declare const TransitionGroup: DefineComponent;
 "#,
     )?;
     Ok(())

--- a/crates/vize_canon/src/batch/runtime_deps.rs
+++ b/crates/vize_canon/src/batch/runtime_deps.rs
@@ -22,9 +22,16 @@ export interface ComputedRef<T = any> extends Readonly<Ref<T>> {
 
 export type UnwrapRef<T> = T extends Ref<infer V, any> ? V : T;
 export type WatchStopHandle = () => void;
+export type WatchCleanup = (cleanupFn: () => void) => void;
+export type WatchEffect = (onCleanup: WatchCleanup) => void | Promise<void>;
 export type LifecycleHook = () => void | Promise<void>;
 
 export type InjectionKey<T> = symbol & { readonly __vize_injection?: T };
+export type PropConstructor<T = any> =
+  | { new (...args: any[]): T & {} }
+  | { (): T }
+  | ((...args: any[]) => T);
+export type PropType<T> = PropConstructor<T> | readonly PropConstructor<T>[];
 
 export interface ComponentCustomProperties {}
 
@@ -36,6 +43,10 @@ export interface ComponentPublicInstance extends ComponentCustomProperties {
 }
 
 export interface App<Element = any> {
+  config: {
+    globalProperties: ComponentCustomProperties & Record<string, any>;
+    [key: string]: any;
+  };
   mount(rootContainer: string | Element): ComponentPublicInstance;
   unmount(): void;
   use(plugin: any, ...options: any[]): App<Element>;
@@ -65,11 +76,14 @@ export declare function readonly<T>(value: T): Readonly<T>;
 export declare function createApp(rootComponent: any, rootProps?: any): App;
 export declare function createSSRApp(rootComponent: any, rootProps?: any): App;
 export declare function defineComponent<Props = any>(options: any): DefineComponent<Props>;
+export declare function defineProps<T = any>(): T;
+export declare function defineProps<const T extends readonly string[]>(_props: T): { [K in T[number]]?: any };
+export declare function defineProps<const T extends Record<string, any>>(_props: T): T;
 export declare function provide<T>(key: InjectionKey<T> | string | symbol, value: T): void;
 export declare function inject<T>(key: InjectionKey<T> | string | symbol): T | undefined;
 export declare function inject<T>(key: InjectionKey<T> | string | symbol, defaultValue: T): T;
-export declare function watch<T>(source: any, cb: any): WatchStopHandle;
-export declare function watchEffect(effect: () => void | Promise<void>): WatchStopHandle;
+export declare function watch<T>(source: any, cb: any, options?: any): WatchStopHandle;
+export declare function watchEffect(effect: WatchEffect, options?: any): WatchStopHandle;
 export declare function onMounted(hook: LifecycleHook): void;
 export declare function onUnmounted(hook: LifecycleHook): void;
 export declare function onBeforeMount(hook: LifecycleHook): void;
@@ -79,6 +93,9 @@ export declare function onUpdated(hook: LifecycleHook): void;
 export declare function nextTick<T>(fn: () => T | Promise<T>): Promise<T>;
 export declare function nextTick(): Promise<void>;
 export declare function useTemplateRef<T = any>(key: string): ShallowRef<T | null>;
+export declare function useId(): string;
+export declare const Transition: DefineComponent;
+export declare const TransitionGroup: DefineComponent;
 "#;
 
 const VITE_STUB_PACKAGE_JSON: &str = r#"{


### PR DESCRIPTION
## Summary

This tightens the fallback Vue runtime declaration file that vize materializes for virtual projects when a full Vue/@vue install cannot be linked. Nuxt/Vue apps can legitimately import and use several Vue runtime helpers that were missing or under-typed in that fallback stub, so vize reported false positives even though Nuxt typechecking accepted the project.

The PR adds stub coverage for:

- Vue named exports used by the vuefes reproduction: `PropType`, `Transition`, `TransitionGroup`, `useId`, and `defineProps`.
- watcher signatures that accept cleanup callbacks and options objects, covering `watchEffect((onCleanup) => ...)` and three-argument `watch(...)` calls.
- `App.config.globalProperties`, so plugin-style setup code can assign global properties without vize reporting that `config` does not exist.

I also updated the test-only Vue stub and added a CLI regression that forces the fallback stub path, then checks a small SFC using those helpers with zero diagnostics.

Refs #832

## Verification

- `cargo test -p vize --test check_cli check_stubbed_vue_exports_runtime_helpers_used_by_nuxt_apps -- --nocapture`
- `cargo test -p vize --test check_cli check_options_api_can_import_define_component_from_stubbed_vue -- --nocapture`
- `cargo fmt --all --check`
- `git diff --check`
- `cargo clippy --workspace -- -D warnings`
- `cargo build -p vize`
- vuejs-jp/vuefes-2026 repro with the local debug binary: current diagnostics dropped from 30 to 15, removing the Vue `TS2305` missing-export group plus the watch/watchEffect/App.config stub false positives.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/850"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782989840&installation_id=136613492&pr_number=850&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F850&signature=17a697b80b78f50af43156df977f205404c1dda35c4accb9bba1484230f2fea0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->