### PR TITLE
fix: link pnpm vue runtime dependencies

### DIFF
--- a/crates/vize/tests/check_cli.rs
+++ b/crates/vize/tests/check_cli.rs
@@ -460,6 +460,7 @@ export default defineComponent({
 
     // Force the virtual project to use vize's fallback Vue stub instead of a
     // workspace-linked full Vue installation.
+    remove_path_if_exists(&project_root.join("node_modules").join("vue")).unwrap();
     remove_path_if_exists(&project_root.join("node_modules").join("@vue")).unwrap();
 
     let output = Command::new(env!("CARGO_BIN_EXE_vize"))
@@ -496,12 +497,19 @@ export default defineComponent({
 }
 
 #[test]
-fn check_stubbed_vue_exports_runtime_helpers_used_by_nuxt_apps() {
+fn check_links_real_vue_namespace_from_pnpm_vue_symlink() {
     let Some(corsa_path) = resolve_test_corsa_path() else {
         return;
     };
+    let Some(workspace_node_modules) = resolve_workspace_node_modules() else {
+        return;
+    };
+    if !workspace_node_modules.join("vue").exists() {
+        return;
+    }
+
     let project_root = create_cli_project(
-        "stubbed-vue-runtime-helpers",
+        "pnpm-vue-symlink-runtime-helpers",
         &[(
             "src/App.vue",
             r#"<script setup lang="ts">
@@ -542,8 +550,9 @@ void Transition;
         )],
     );
 
-    // Force the virtual project to use vize's fallback Vue stub instead of a
-    // workspace-linked full Vue installation.
+    // Simulate pnpm projects where root node_modules has a vue symlink but no
+    // root @vue namespace. The real @vue packages live next to the symlink
+    // target under node_modules/.pnpm.
     remove_path_if_exists(&project_root.join("node_modules").join("@vue")).unwrap();
 
     let output = Command::new(env!("CARGO_BIN_EXE_vize"))
@@ -2721,31 +2730,11 @@ fn write_test_vue_stub(target: &Path) -> std::io::Result<()> {
 
 export interface ShallowRef<T = any, S = T> extends Ref<T, S> {}
 
-export type WatchStopHandle = () => void;
-export type WatchCleanup = (cleanupFn: () => void) => void;
-export type WatchEffect = (onCleanup: WatchCleanup) => void | Promise<void>;
-export type PropConstructor<T = any> =
-  | { new (...args: any[]): T & {} }
-  | { (): T }
-  | ((...args: any[]) => T);
-export type PropType<T> = PropConstructor<T> | readonly PropConstructor<T>[];
-
-export interface ComponentCustomProperties {}
-
 export interface ComponentPublicInstance {
   $attrs: any;
   $slots: any;
   $refs: any;
   $emit: (...args: any[]) => void;
-}
-
-export interface App<Element = any> {
-  config: {
-    globalProperties: ComponentCustomProperties & Record<string, any>;
-    [key: string]: any;
-  };
-  mount(rootContainer: string | Element): ComponentPublicInstance;
-  unmount(): void;
 }
 
 export type DefineComponent<
@@ -2765,15 +2754,6 @@ export type DefineComponent<
 export declare function ref<T>(value: T): Ref<T>;
 export declare function useTemplateRef<T = any>(key: string): ShallowRef<T | null>;
 export declare function defineComponent<Props = any>(options: any): DefineComponent<Props>;
-export declare function defineProps<T = any>(): T;
-export declare function defineProps<const T extends readonly string[]>(_props: T): { [K in T[number]]?: any };
-export declare function defineProps<const T extends Record<string, any>>(_props: T): T;
-export declare function createApp(rootComponent: any, rootProps?: any): App;
-export declare function watch<T>(source: any, cb: any, options?: any): WatchStopHandle;
-export declare function watchEffect(effect: WatchEffect, options?: any): WatchStopHandle;
-export declare function useId(): string;
-export declare const Transition: DefineComponent;
-export declare const TransitionGroup: DefineComponent;
 "#,
     )?;
     Ok(())

--- a/crates/vize_canon/src/batch/runtime_deps.rs
+++ b/crates/vize_canon/src/batch/runtime_deps.rs
@@ -22,16 +22,9 @@ export interface ComputedRef<T = any> extends Readonly<Ref<T>> {
 
 export type UnwrapRef<T> = T extends Ref<infer V, any> ? V : T;
 export type WatchStopHandle = () => void;
-export type WatchCleanup = (cleanupFn: () => void) => void;
-export type WatchEffect = (onCleanup: WatchCleanup) => void | Promise<void>;
 export type LifecycleHook = () => void | Promise<void>;
 
 export type InjectionKey<T> = symbol & { readonly __vize_injection?: T };
-export type PropConstructor<T = any> =
-  | { new (...args: any[]): T & {} }
-  | { (): T }
-  | ((...args: any[]) => T);
-export type PropType<T> = PropConstructor<T> | readonly PropConstructor<T>[];
 
 export interface ComponentCustomProperties {}
 
@@ -43,10 +36,6 @@ export interface ComponentPublicInstance extends ComponentCustomProperties {
 }
 
 export interface App<Element = any> {
-  config: {
-    globalProperties: ComponentCustomProperties & Record<string, any>;
-    [key: string]: any;
-  };
   mount(rootContainer: string | Element): ComponentPublicInstance;
   unmount(): void;
   use(plugin: any, ...options: any[]): App<Element>;
@@ -76,14 +65,11 @@ export declare function readonly<T>(value: T): Readonly<T>;
 export declare function createApp(rootComponent: any, rootProps?: any): App;
 export declare function createSSRApp(rootComponent: any, rootProps?: any): App;
 export declare function defineComponent<Props = any>(options: any): DefineComponent<Props>;
-export declare function defineProps<T = any>(): T;
-export declare function defineProps<const T extends readonly string[]>(_props: T): { [K in T[number]]?: any };
-export declare function defineProps<const T extends Record<string, any>>(_props: T): T;
 export declare function provide<T>(key: InjectionKey<T> | string | symbol, value: T): void;
 export declare function inject<T>(key: InjectionKey<T> | string | symbol): T | undefined;
 export declare function inject<T>(key: InjectionKey<T> | string | symbol, defaultValue: T): T;
-export declare function watch<T>(source: any, cb: any, options?: any): WatchStopHandle;
-export declare function watchEffect(effect: WatchEffect, options?: any): WatchStopHandle;
+export declare function watch<T>(source: any, cb: any): WatchStopHandle;
+export declare function watchEffect(effect: () => void | Promise<void>): WatchStopHandle;
 export declare function onMounted(hook: LifecycleHook): void;
 export declare function onUnmounted(hook: LifecycleHook): void;
 export declare function onBeforeMount(hook: LifecycleHook): void;
@@ -93,9 +79,6 @@ export declare function onUpdated(hook: LifecycleHook): void;
 export declare function nextTick<T>(fn: () => T | Promise<T>): Promise<T>;
 export declare function nextTick(): Promise<void>;
 export declare function useTemplateRef<T = any>(key: string): ShallowRef<T | null>;
-export declare function useId(): string;
-export declare const Transition: DefineComponent;
-export declare const TransitionGroup: DefineComponent;
 "#;
 
 const VITE_STUB_PACKAGE_JSON: &str = r#"{
@@ -133,12 +116,17 @@ fn materialize_vue_support(project_root: &Path, node_modules_dir: &Path) -> std:
     let vue_target = node_modules_dir.join("vue");
     let vue_namespace_target = node_modules_dir.join("@vue");
 
-    if let (Some(vue_source), Some(vue_namespace_source)) = (
-        resolve_ancestor_package(project_root, "vue"),
-        resolve_ancestor_package(project_root, "@vue"),
-    ) && symlink_path(&vue_source, &vue_target).is_ok()
-        && symlink_path(&vue_namespace_source, &vue_namespace_target).is_ok()
+    if let Some(vue_source) = resolve_ancestor_package(project_root, "vue")
+        && symlink_path(&vue_source, &vue_target).is_ok()
     {
+        if let Some(vue_namespace_source) = resolve_vue_namespace_package(project_root, &vue_source)
+        {
+            if symlink_path(&vue_namespace_source, &vue_namespace_target).is_err() {
+                remove_path(&vue_namespace_target)?;
+            }
+        } else {
+            remove_path(&vue_namespace_target)?;
+        }
         return Ok(());
     }
 
@@ -156,6 +144,27 @@ fn materialize_vite_support(project_root: &Path, node_modules_dir: &Path) -> std
     }
 
     write_vite_stub(node_modules_dir)
+}
+
+fn resolve_vue_namespace_package(project_root: &Path, vue_source: &Path) -> Option<PathBuf> {
+    resolve_ancestor_package(project_root, "@vue")
+        .or_else(|| resolve_adjacent_vue_namespace_package(vue_source))
+}
+
+fn resolve_adjacent_vue_namespace_package(vue_source: &Path) -> Option<PathBuf> {
+    let mut candidates = Vec::new();
+
+    if let Some(parent) = vue_source.parent() {
+        candidates.push(parent.join("@vue"));
+    }
+
+    if let Ok(real_vue_source) = std::fs::canonicalize(vue_source)
+        && let Some(parent) = real_vue_source.parent()
+    {
+        candidates.push(parent.join("@vue"));
+    }
+
+    candidates.into_iter().find(|candidate| candidate.exists())
 }
 
 fn resolve_ancestor_package(project_root: &Path, package: &str) -> Option<PathBuf> {


### PR DESCRIPTION
## Summary

This is a follow-up to #850 that changes the approach back to using Vue's own type declarations instead of growing vize's fallback Vue stub.

The bug was that vize only linked the real Vue package when both root `node_modules/vue` and root `node_modules/@vue` existed. pnpm projects can expose `node_modules/vue` as a symlink while the matching `@vue/*` packages live next to that symlink target under `node_modules/.pnpm/.../node_modules/@vue`. In that shape, vize incorrectly fell back to its local stub, which caused false positives for real Vue exports such as `PropType`, `Transition`, `useId`, `defineProps`, watch cleanup signatures, and `App.config`.

This PR:

- always links the real `vue` package when it is available,
- resolves `@vue` first from normal ancestor `node_modules`, then from the real/canonical Vue package's adjacent `node_modules/@vue`,
- removes the extra Vue API surface that #850 added to the fallback stub,
- keeps the small fallback stub only for projects that genuinely do not have Vue installed,
- updates the regression test so fallback is tested by removing `vue` itself, and adds a pnpm-style symlink regression where root `@vue` is absent but the real Vue types are still used.

Refs #832

## Verification

- `cargo fmt --all --check`
- `git diff --check`
- `cargo test -p vize --test check_cli check_links_real_vue_namespace_from_pnpm_vue_symlink -- --nocapture`
- `cargo test -p vize --test check_cli check_options_api_can_import_define_component_from_stubbed_vue -- --nocapture`
- `cargo clippy --workspace -- -D warnings`
- vuejs-jp/vuefes-2026 repro with local debug binary: diagnostics are 13 remaining, and the Vue missing-export/watch/App.config false positives are gone.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/852"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782990632&installation_id=136613492&pr_number=852&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F852&signature=b15ead907f66690344f222a69d8ac9f156091f11d898f887b3f748f036d21e21"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->