### PR TITLE
fix: resolve vue named exports through aliases

### DIFF
--- a/crates/vize/tests/check_cli.rs
+++ b/crates/vize/tests/check_cli.rs
@@ -218,6 +218,86 @@ fn check_json_reports_empty_result_when_no_files_match() {
 }
 
 #[test]
+fn check_preserves_named_exports_from_split_script_vue() {
+    let Some(corsa_path) = resolve_test_corsa_path() else {
+        return;
+    };
+    let project_root = create_cli_project(
+        "split-script-named-exports",
+        &[
+            (
+                "src/Helper.vue",
+                r#"<script lang="ts">
+const DEFAULT_COUNT = 1;
+
+export type HelperOption = {
+  count?: number;
+};
+
+export interface HelperState {
+  count: number;
+}
+
+export function useHelper(options: HelperOption = {}): HelperState {
+  return {
+    count: options.count ?? DEFAULT_COUNT,
+  };
+}
+</script>
+
+<script setup lang="ts">
+defineProps<{ state?: HelperState }>();
+</script>
+
+<template>
+  <div>{{ state?.count }}</div>
+</template>
+"#,
+            ),
+            (
+                "src/Consumer.vue",
+                r#"<script setup lang="ts">
+import { useHelper, type HelperOption } from "./Helper.vue";
+
+const option: HelperOption = {};
+const state = useHelper(option);
+</script>
+
+<template>
+  <Helper :state="state" />
+</template>
+"#,
+            ),
+        ],
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(&project_root)
+        .env("CORSA_PATH", corsa_path)
+        .args(["check", ".", "--format", "json"])
+        .output()
+        .unwrap();
+
+    let stdout = std::string::String::from_utf8(output.stdout).unwrap();
+    let stderr = std::string::String::from_utf8(output.stderr).unwrap();
+    let json: serde_json::Value = serde_json::from_str(&stdout).unwrap_or_else(|error| {
+        panic!("failed to parse stdout as JSON: {error}\nstdout:\n{stdout}\nstderr:\n{stderr}")
+    });
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "stdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert_eq!(
+        json["errorCount"], 0,
+        "stdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}
+
+#[test]
 fn check_directory_pattern_resolves_json_modules_imported_by_ts() {
     let Some(corsa_path) = resolve_test_corsa_path() else {
         return;

--- a/crates/vize_canon/src/batch/virtual_project.rs
+++ b/crates/vize_canon/src/batch/virtual_project.rs
@@ -711,20 +711,76 @@ declare module "*.vue.ts" {
             return Ok(Map::new());
         };
 
+        let mut seen = FxHashSet::default();
+        self.load_compiler_options_inner(tsconfig_path, &mut seen)
+    }
+
+    #[allow(clippy::disallowed_types)]
+    fn load_compiler_options_inner(
+        &self,
+        tsconfig_path: &Path,
+        seen: &mut FxHashSet<PathBuf>,
+    ) -> CorsaResult<Map<std::string::String, Value>> {
         if !tsconfig_path.exists() {
             return Ok(Map::new());
         }
+        let normalized = normalize_path_lexically(tsconfig_path);
+        if !seen.insert(normalized.clone()) {
+            return Ok(Map::new());
+        }
 
-        let content = profile!(
-            "canon.tsconfig.read",
-            std::fs::read_to_string(tsconfig_path)
-        )?;
+        let content = profile!("canon.tsconfig.read", std::fs::read_to_string(&normalized))?;
         let config = profile!("canon.tsconfig.parse", parse_jsonc_value(&content))?;
-        Ok(config
+        let mut compiler_options = config
             .get("compilerOptions")
             .and_then(Value::as_object)
             .cloned()
-            .unwrap_or_default())
+            .unwrap_or_default();
+        let base_dir = normalized.parent().unwrap_or(self.project_root.as_path());
+        self.normalize_paths_for_project_root(&mut compiler_options, base_dir);
+
+        let Some(parent_path) = config
+            .get("extends")
+            .and_then(Value::as_str)
+            .and_then(|extends| resolve_extended_tsconfig_path(&normalized, extends))
+        else {
+            return Ok(compiler_options);
+        };
+
+        let mut inherited = self.load_compiler_options_inner(&parent_path, seen)?;
+        inherited.extend(compiler_options);
+        Ok(inherited)
+    }
+
+    #[allow(clippy::disallowed_types)]
+    fn normalize_paths_for_project_root(
+        &self,
+        compiler_options: &mut Map<std::string::String, Value>,
+        base_dir: &Path,
+    ) {
+        let Some(paths) = compiler_options
+            .get_mut("paths")
+            .and_then(Value::as_object_mut)
+        else {
+            return;
+        };
+
+        for targets in paths.values_mut() {
+            let Some(targets) = targets.as_array_mut() else {
+                continue;
+            };
+            for target in targets {
+                let Some(raw_target) = target.as_str() else {
+                    continue;
+                };
+                if Path::new(raw_target).is_absolute() {
+                    continue;
+                }
+                *target = Value::String(
+                    normalize_tsconfig_path_target(base_dir, &self.project_root, raw_target).into(),
+                );
+            }
+        }
     }
 
     /// Re-anchor tsconfig `paths` targets into the virtual mirror. Each relative
@@ -1429,6 +1485,74 @@ fn source_type_for_path(path: &Path) -> Option<SourceType> {
     None
 }
 
+fn resolve_extended_tsconfig_path(tsconfig_path: &Path, extends: &str) -> Option<PathBuf> {
+    let base_dir = tsconfig_path.parent().unwrap_or(Path::new("."));
+    let extends_path = Path::new(extends);
+    if !(extends_path.is_absolute()
+        || extends.starts_with("./")
+        || extends.starts_with("../")
+        || extends == "."
+        || extends == "..")
+    {
+        return None;
+    }
+
+    let base = if extends_path.is_absolute() {
+        extends_path.to_path_buf()
+    } else {
+        base_dir.join(extends_path)
+    };
+
+    tsconfig_path_candidates(base)
+        .into_iter()
+        .map(|candidate| normalize_path_lexically(&candidate))
+        .find(|candidate| candidate.exists())
+}
+
+fn tsconfig_path_candidates(base: PathBuf) -> Vec<PathBuf> {
+    if base.extension().is_some() {
+        return vec![base];
+    }
+
+    vec![
+        base.clone(),
+        base.with_extension("json"),
+        base.join("tsconfig.json"),
+    ]
+}
+
+fn normalize_tsconfig_path_target(
+    base_dir: &Path,
+    project_root: &Path,
+    target: &str,
+) -> CompactString {
+    let normalized = normalize_path_lexically(&base_dir.join(target));
+    if let Ok(relative) = normalized.strip_prefix(project_root) {
+        return path_to_tsconfig_target(relative);
+    }
+    path_to_tsconfig_target(&normalized)
+}
+
+fn path_to_tsconfig_target(path: &Path) -> CompactString {
+    path.to_string_lossy().replace('\\', "/").into()
+}
+
+fn normalize_path_lexically(path: &Path) -> PathBuf {
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            std::path::Component::CurDir => {}
+            std::path::Component::ParentDir => {
+                if !normalized.pop() {
+                    normalized.push(component.as_os_str());
+                }
+            }
+            _ => normalized.push(component.as_os_str()),
+        }
+    }
+    normalized
+}
+
 fn parse_jsonc_value(content: &str) -> CorsaResult<Value> {
     let stripped = strip_json_comments(content);
     let normalized = strip_trailing_commas(&stripped);
@@ -2068,6 +2192,59 @@ const message = 'Hello'
         assert_eq!(
             paths["#shared"],
             serde_json::json!(["./shared/index.ts", "../../../shared/index.ts"])
+        );
+
+        let _ = fs::remove_dir_all(&case_dir);
+    }
+
+    #[test]
+    fn materialized_tsconfig_reanchors_extended_paths_from_declaring_config_dir() {
+        let case_dir = unique_case_dir("tsconfig-extended-paths-reanchor");
+        let _ = fs::remove_dir_all(&case_dir);
+        fs::create_dir_all(case_dir.join(".nuxt")).unwrap();
+        fs::create_dir_all(case_dir.join("app/components")).unwrap();
+        fs::write(
+            case_dir.join(".nuxt/tsconfig.json"),
+            r##"{
+  "compilerOptions": {
+    "paths": {
+      "~/*": ["../app/*"],
+      "#imports": ["./imports"]
+    }
+  }
+}"##,
+        )
+        .unwrap();
+        fs::write(
+            case_dir.join("tsconfig.json"),
+            r#"{
+  "extends": "./.nuxt/tsconfig.json"
+}"#,
+        )
+        .unwrap();
+        let vue_path = case_dir.join("app/components/App.vue");
+        fs::write(
+            &vue_path,
+            "<script setup lang=\"ts\">const count = 1</script>",
+        )
+        .unwrap();
+
+        let mut project = VirtualProject::new(&case_dir).unwrap();
+        project.register_path(&vue_path).unwrap();
+        project.materialize().unwrap();
+
+        let tsconfig_path = case_dir.join("node_modules/.vize/canon/tsconfig.json");
+        let value: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(tsconfig_path).unwrap()).unwrap();
+        let paths = value["compilerOptions"]["paths"].as_object().unwrap();
+
+        assert_eq!(
+            paths["~/*"],
+            serde_json::json!(["./app/*", "../../../app/*"])
+        );
+        assert_eq!(
+            paths["#imports"],
+            serde_json::json!(["./.nuxt/imports", "../../../.nuxt/imports"])
         );
 
         let _ = fs::remove_dir_all(&case_dir);

--- a/crates/vize_canon/src/virtual_ts/generator.rs
+++ b/crates/vize_canon/src/virtual_ts/generator.rs
@@ -163,6 +163,16 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
         for re in &summary.re_exports {
             module_spans.push((re.start, re.end));
         }
+        let has_script_setup = summary
+            .scopes
+            .iter()
+            .any(|scope| matches!(scope.kind, ScopeKind::ScriptSetup));
+        if has_script_setup {
+            module_spans.extend(summary.scopes.iter().filter_map(|scope| {
+                matches!(scope.kind, ScopeKind::NonScriptSetup)
+                    .then_some((scope.span.start, scope.span.end))
+            }));
+        }
         for te in &summary.type_exports {
             // Non-hoisted types reference setup-scope values via `typeof`
             // and must stay inside `__setup` so TS can resolve them.
@@ -170,8 +180,7 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
                 module_spans.push((te.start, te.end));
             }
         }
-        module_spans.sort_by_key(|&(start, _)| start);
-        module_spans
+        merge_overlapping_spans(module_spans)
     });
 
     // For a `<script setup generic="...">` SFC, hoisted type declarations are
@@ -247,7 +256,12 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
                 }
 
                 let gen_start = ts.len();
-                ts.push_str(text);
+                if text.contains("export default") {
+                    let text = rewrite_export_default_for_module_scope(text);
+                    ts.push_str(&text);
+                } else {
+                    ts.push_str(text);
+                }
                 ts.push('\n');
                 let gen_end = ts.len();
                 mappings.push(VizeMapping {
@@ -749,6 +763,50 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
     ts.push_str("export default __vize_component__;\n");
 
     VirtualTsOutput { code: ts, mappings }
+}
+
+fn merge_overlapping_spans(mut spans: Vec<(u32, u32)>) -> Vec<(u32, u32)> {
+    spans.retain(|(start, end)| start < end);
+    spans.sort_by_key(|&(start, end)| (start, end));
+
+    let mut merged: Vec<(u32, u32)> = Vec::with_capacity(spans.len());
+    for (start, end) in spans {
+        if let Some((_, previous_end)) = merged.last_mut()
+            && start <= *previous_end
+        {
+            *previous_end = (*previous_end).max(end);
+            continue;
+        }
+        merged.push((start, end));
+    }
+    merged
+}
+
+fn rewrite_export_default_for_module_scope(text: &str) -> String {
+    let mut output = String::with_capacity(text.len());
+    for segment in text.split_inclusive('\n') {
+        let (line_with_optional_cr, newline) = segment
+            .strip_suffix('\n')
+            .map_or((segment, ""), |line| (line, "\n"));
+        let (line, carriage_return) = line_with_optional_cr
+            .strip_suffix('\r')
+            .map_or((line_with_optional_cr, ""), |line| (line, "\r"));
+
+        let trimmed_line = line.trim_start();
+        if let Some(default_expr) = trimmed_line
+            .strip_prefix("export default")
+            .filter(|rest| rest.chars().next().is_none_or(char::is_whitespace))
+        {
+            let leading_ws = &line[..line.len() - trimmed_line.len()];
+            append!(output, "{leading_ws}const __default__ ={default_expr}");
+        } else {
+            output.push_str(line);
+        }
+        output.push_str(carriage_return);
+        output.push_str(newline);
+    }
+
+    output
 }
 
 /// Extract imported identifier names from an import statement string.

--- a/crates/vize_croquis/src/analysis/croquis.rs
+++ b/crates/vize_croquis/src/analysis/croquis.rs
@@ -6,6 +6,7 @@
 use super::Croquis;
 use super::bindings::UnusedTemplateVar;
 use super::bindings::UnusedVarContext;
+use crate::scope::{ScopeData, ScopeKind};
 use vize_carton::CompactString;
 use vize_relief::BindingType;
 
@@ -77,6 +78,19 @@ impl Croquis {
         self.re_exports.extend(plain.re_exports);
         self.component_registrations
             .extend(plain.component_registrations);
+
+        for scope in plain.scopes.iter() {
+            if let (ScopeKind::NonScriptSetup, ScopeData::NonScriptSetup(data)) =
+                (scope.kind, scope.data())
+            {
+                self.scopes.enter_non_script_setup_scope(
+                    data.clone(),
+                    scope.span.start,
+                    scope.span.end,
+                );
+                self.scopes.exit_scope();
+            }
+        }
 
         for (name, span) in plain.binding_spans {
             self.binding_spans.entry(name).or_insert(span);


### PR DESCRIPTION
Refs #832

## What changed
- Preserve normal `<script>` module-scope ranges when an SFC also has `<script setup>`, so named value exports such as composables are emitted at module scope instead of being hidden inside the synthetic setup function.
- Rewrite default exports from the preserved normal script span to a local module binding, avoiding a duplicate default export while keeping named exports visible.
- Follow relative `tsconfig.json` `extends` files and normalize inherited `compilerOptions.paths` from the directory that declared them before re-anchoring those paths into the vize virtual mirror. This lets Nuxt aliases like `~/*` resolve to the materialized `.vue.ts` files instead of falling back to the wildcard Vue module stub.

## Validation
- `cargo fmt --all --check`
- `git diff --check`
- `cargo test -p vize_canon materialized_tsconfig_reanchors_extended_paths_from_declaring_config_dir -- --nocapture`
- `cargo test -p vize_canon materialized_tsconfig_reanchors_paths_into_virtual_mirror -- --nocapture`
- `cargo test -p vize_canon virtual_ts -- --nocapture`
- `cargo test -p vize --test check_cli check_preserves_named_exports_from_split_script_vue -- --nocapture`
- `cargo clippy --workspace -- -D warnings`
- `cargo build -p vize`
- `vize check app --format json --quiet` against `vuejs-jp/vuefes-2026`: TS2614 named-export diagnostics dropped to 0; remaining diagnostics are separate template typing false positives.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/854"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782992521&installation_id=136613492&pr_number=854&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F854&signature=1b4ac81ffbc63efb5dc6c6c6f48ffea379f7e864141360b54968921c9e0515bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->