### PR TITLE
fix(patina): interpolate lint message placeholders

### DIFF
--- a/crates/vize_patina/src/output.rs
+++ b/crates/vize_patina/src/output.rs
@@ -606,7 +606,10 @@ impl SourceLineIndex {
 
 #[cfg(test)]
 mod tests {
-    use crate::{LintDiagnostic, LintResult, Linter, OutputFormat, format_results, rule_docs_path};
+    use crate::{
+        LintDiagnostic, LintPreset, LintResult, Linter, OutputFormat, format_results,
+        rule_docs_path,
+    };
     use vize_carton::ToCompactString;
 
     #[test]
@@ -644,6 +647,59 @@ const items = [1]
         assert_eq!(OutputFormat::parse("md"), Some(OutputFormat::Markdown));
         assert_eq!(OutputFormat::parse("telegraph"), Some(OutputFormat::Agent));
         assert_eq!(OutputFormat::parse("unknown"), None);
+    }
+
+    #[test]
+    fn rendered_outputs_interpolate_lint_message_placeholders() {
+        let source = r#"<script setup lang="ts">
+defineOptions({
+  name: "Label",
+})
+
+const url = ""
+</script>
+
+<template>
+  <a :href="url" />
+</template>
+"#;
+        let filename = vize_carton::String::from("Label.vue");
+        let result = Linter::with_preset(LintPreset::Essential).lint_sfc(source, &filename);
+
+        assert!(
+            result
+                .diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.message.contains("Component name \"Label\"")),
+            "{:?}",
+            result.diagnostics
+        );
+        assert!(
+            result
+                .diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.message.contains("Dynamic :href binding")),
+            "{:?}",
+            result.diagnostics
+        );
+
+        let sources = [(filename.clone(), vize_carton::String::from(source))];
+        for format in [
+            OutputFormat::Text,
+            OutputFormat::Ansi,
+            OutputFormat::Plain,
+            OutputFormat::Stylish,
+            OutputFormat::Json,
+            OutputFormat::Markdown,
+            OutputFormat::Html,
+            OutputFormat::Agent,
+        ] {
+            let output = format_results(std::slice::from_ref(&result), &sources, format);
+            assert!(!output.contains("{name}"), "{format:?}\n{output}");
+            assert!(!output.contains("{attr}"), "{format:?}\n{output}");
+            assert!(output.contains("Label"), "{format:?}\n{output}");
+            assert!(output.contains("href"), "{format:?}\n{output}");
+        }
     }
 
     #[test]

--- a/crates/vize_patina/src/rules/opinionated/vue/multi_word_component_names.rs
+++ b/crates/vize_patina/src/rules/opinionated/vue/multi_word_component_names.rs
@@ -117,7 +117,10 @@ impl Rule for MultiWordComponentNames {
         // Check if the component name is multi-word
         if !Self::is_multi_word(component_name) {
             ctx.error_with_help(
-                ctx.t("vue/multi-word-component-names.message"),
+                ctx.t_fmt(
+                    "vue/multi-word-component-names.message",
+                    &[("name", component_name)],
+                ),
                 &root.loc,
                 ctx.t("vue/multi-word-component-names.help"),
             );

--- a/crates/vize_patina/src/rules/opinionated/vue/snapshots/vize_patina__rules__opinionated__vue__multi_word_component_names__tests__invalid_single_word_pascal_case.snap
+++ b/crates/vize_patina/src/rules/opinionated/vue/snapshots/vize_patina__rules__opinionated__vue__multi_word_component_names__tests__invalid_single_word_pascal_case.snap
@@ -6,7 +6,7 @@ expression: result.diagnostics
     LintDiagnostic {
         rule_name: "vue/multi-word-component-names",
         severity: Error,
-        message: "Component name \"{name}\" should be multi-word to avoid conflicts with HTML elements",
+        message: "Component name \"Item\" should be multi-word to avoid conflicts with HTML elements",
         start: 0,
         end: 0,
         help: Some(

--- a/crates/vize_patina/src/rules/vue/no_unsafe_url.rs
+++ b/crates/vize_patina/src/rules/vue/no_unsafe_url.rs
@@ -227,7 +227,7 @@ impl Rule for NoUnsafeUrl {
         };
 
         ctx.warn_with_help(
-            ctx.t("vue/no-unsafe-url.message"),
+            ctx.t_fmt("vue/no-unsafe-url.message", &[("attr", attr_name)]),
             &directive.loc,
             help_message,
         );


### PR DESCRIPTION
## Summary

- Interpolate `vue/multi-word-component-names` diagnostics with the concrete component name.
- Interpolate dynamic `vue/no-unsafe-url` diagnostics with the concrete bound attribute.
- Add formatter coverage to ensure rendered outputs do not leak `{name}` or `{attr}` placeholders.

## Validation

- `cargo fmt --package vize_patina`
- `cargo test -p vize_patina rendered_outputs_interpolate_lint_message_placeholders`
- `cargo test -p vize_patina multi_word_component_names`
- `cargo test -p vize_patina no_unsafe_url`

Closes #859

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/864"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783000629&installation_id=136613492&pr_number=864&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F864&signature=5f3f79fc4b6171d3ea7f5d78b7528e209062eeaa60a759cec4070f91b10f1032"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->