### PR TITLE
fix(formatter): preserve leading SFC comments

### DIFF
--- a/crates/vize_glyph/src/formatter.rs
+++ b/crates/vize_glyph/src/formatter.rs
@@ -29,6 +29,13 @@ pub struct GlyphFormatter<'a> {
     allocator: &'a Allocator,
 }
 
+enum Block<'b> {
+    Script(&'b vize_atelier_sfc::SfcScriptBlock<'b>),
+    Template(&'b vize_atelier_sfc::SfcTemplateBlock<'b>),
+    Style(&'b vize_atelier_sfc::SfcStyleBlock<'b>),
+    Custom(&'b vize_atelier_sfc::SfcCustomBlock<'b>),
+}
+
 impl<'a> GlyphFormatter<'a> {
     /// Create a new formatter with the given options and allocator
     #[inline]
@@ -47,13 +54,6 @@ impl<'a> GlyphFormatter<'a> {
         let mut output = Vec::with_capacity(estimated_size);
 
         // Collect all blocks with their sort keys
-        enum Block<'b> {
-            Script(&'b vize_atelier_sfc::SfcScriptBlock<'b>),
-            Template(&'b vize_atelier_sfc::SfcTemplateBlock<'b>),
-            Style(&'b vize_atelier_sfc::SfcStyleBlock<'b>),
-            Custom(&'b vize_atelier_sfc::SfcCustomBlock<'b>),
-        }
-
         let mut blocks: Vec<(usize, Block<'_>)> = Vec::new();
 
         if let Some(script) = &descriptor.script {
@@ -98,6 +98,14 @@ impl<'a> GlyphFormatter<'a> {
         }
 
         blocks.sort_by_key(|(order, _)| *order);
+
+        if let Some(prologue) = document_prologue(source, &blocks) {
+            output.extend_from_slice(prologue.as_bytes());
+            if !blocks.is_empty() {
+                output.extend_from_slice(newline);
+                output.extend_from_slice(newline);
+            }
+        }
 
         // Format each block in order
         for (i, (_, block)) in blocks.iter().enumerate() {
@@ -318,6 +326,21 @@ impl<'a> GlyphFormatter<'a> {
 
         Ok(())
     }
+}
+
+fn document_prologue<'a>(source: &'a str, blocks: &[(usize, Block<'_>)]) -> Option<&'a str> {
+    let first_tag_start = blocks
+        .iter()
+        .map(|(_, block)| match block {
+            Block::Script(block) => block.loc.tag_start,
+            Block::Template(block) => block.loc.tag_start,
+            Block::Style(block) => block.loc.tag_start,
+            Block::Custom(block) => block.loc.tag_start,
+        })
+        .min()
+        .unwrap_or(source.len());
+    let prologue = source[..first_tag_start].trim();
+    (!prologue.is_empty()).then_some(prologue)
 }
 
 fn write_remaining_attrs(

--- a/crates/vize_glyph/src/lib.rs
+++ b/crates/vize_glyph/src/lib.rs
@@ -170,6 +170,27 @@ const msg = 'hello'
     }
 
     #[test]
+    fn test_format_sfc_preserves_leading_comment() {
+        let source = r#"<!--
+SPDX-FileCopyrightText: Example Author
+SPDX-License-Identifier: MIT
+-->
+
+<template>
+<div>Hello</div>
+</template>
+
+<script setup lang="ts">
+const message = 'hello';
+</script>
+"#;
+        let options = FormatOptions::default();
+        let result = format_sfc(source, &options).unwrap();
+
+        insta::assert_snapshot!(result.code.as_str());
+    }
+
+    #[test]
     fn test_allocator_reuse() {
         let allocator = Allocator::with_capacity(4096);
         let options = FormatOptions::default();

--- a/crates/vize_glyph/src/snapshots/vize_glyph__tests__format_sfc_preserves_leading_comment.snap
+++ b/crates/vize_glyph/src/snapshots/vize_glyph__tests__format_sfc_preserves_leading_comment.snap
@@ -1,0 +1,18 @@
+---
+source: crates/vize_glyph/src/lib.rs
+expression: result.code.as_str()
+---
+<!--
+SPDX-FileCopyrightText: Example Author
+SPDX-License-Identifier: MIT
+-->
+
+<script setup lang="ts">
+const message = "hello";
+</script>
+
+<template>
+  <div>
+    Hello
+  </div>
+</template>


### PR DESCRIPTION
Summary
- Preserve SFC-level leading comments before formatting sorted blocks.
- Add snapshot coverage for SPDX-style comments before the first block.

Validation
- cargo fmt --package vize_glyph
- cargo test -p vize_glyph
- git diff --check

Closes #865

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/871"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783001500&installation_id=136613492&pr_number=871&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F871&signature=bb10f2cc3949b71a26967b213ef6cbb0c02a74760e9857b1917d117b35a0f496"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->