### PR TITLE
fix(check): support absolute input paths

### DIFF
--- a/crates/vize/src/commands/check/runner.rs
+++ b/crates/vize/src/commands/check/runner.rs
@@ -133,6 +133,23 @@ pub(crate) fn run_direct(args: &CheckArgs) {
         return;
     }
 
+    // An explicit subset only registers the requested files, so a relative
+    // import (`import { Foo } from './types'`) cannot see its sibling's real
+    // types and degrades to `any`. Register the transitive closure of relative
+    // source imports — analogous to the ambient pull-in below — so cross-file
+    // types resolve precisely, the way tsc/vue-tsc load the reachable program.
+    // Do this before root resolution so cwd-external files without tsconfig can
+    // still choose a materialization root covering all registered source files.
+    if !args.patterns.is_empty() {
+        for path in super::imports::collect_transitive_local_imports(&files, &cwd) {
+            if !files.contains(&path) {
+                files.push(path);
+            }
+        }
+        files.sort();
+        files.dedup();
+    }
+
     let project_root = resolve_project_root(effective_tsconfig.as_deref(), &cwd, &files);
     let tsconfig_path =
         resolve_tsconfig_path(effective_tsconfig.as_deref(), &cwd, &project_root, &files);
@@ -143,21 +160,6 @@ pub(crate) fn run_direct(args: &CheckArgs) {
     // tsconfig program's `.d.ts` files back in so global types stay in scope.
     if !args.patterns.is_empty() && tsconfig_path.is_some() {
         for path in collect_ambient_declaration_files(&project_root, tsconfig_path.as_deref()) {
-            if !files.contains(&path) {
-                files.push(path);
-            }
-        }
-        files.sort();
-        files.dedup();
-    }
-
-    // An explicit subset only registers the requested files, so a relative
-    // import (`import { Foo } from './types'`) cannot see its sibling's real
-    // types and degrades to `any`. Register the transitive closure of relative
-    // source imports — analogous to the ambient pull-in above — so cross-file
-    // types resolve precisely, the way tsc/vue-tsc load the reachable program.
-    if !args.patterns.is_empty() {
-        for path in super::imports::collect_transitive_local_imports(&files, &cwd) {
             if !files.contains(&path) {
                 files.push(path);
             }
@@ -804,7 +806,7 @@ fn find_nearest_tsconfig_dir(path: &Path) -> Option<PathBuf> {
 
 fn resolve_project_root_from_files(files: &[PathBuf]) -> Option<PathBuf> {
     let common = common_file_parent(files)?;
-    find_nearest_tsconfig_dir(&common)
+    Some(find_nearest_tsconfig_dir(&common).unwrap_or(common))
 }
 
 fn common_file_parent(files: &[PathBuf]) -> Option<PathBuf> {
@@ -991,6 +993,29 @@ mod tests {
         );
 
         let _ = std::fs::remove_dir_all(&project_root);
+    }
+
+    #[test]
+    fn falls_back_to_common_file_parent_for_external_files_without_tsconfig() {
+        let case_root = std::env::temp_dir().join(format!(
+            "vize-check-runner-external-root-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&case_root);
+        let cwd = case_root.join("cwd");
+        let source_dir = case_root.join("external");
+        std::fs::create_dir_all(&cwd).unwrap();
+        std::fs::create_dir_all(&source_dir).unwrap();
+        let files = vec![source_dir.join("Repro.vue")];
+        std::fs::write(&files[0], "<template />").unwrap();
+
+        let resolved_root = resolve_project_root(None, &cwd, &files);
+        let resolved_tsconfig = resolve_tsconfig_path(None, &cwd, &resolved_root, &files);
+
+        assert_eq!(resolved_root, source_dir);
+        assert_eq!(resolved_tsconfig, None);
+
+        let _ = std::fs::remove_dir_all(&case_root);
     }
 
     #[test]

--- a/crates/vize/tests/check_cli.rs
+++ b/crates/vize/tests/check_cli.rs
@@ -218,6 +218,87 @@ fn check_json_reports_empty_result_when_no_files_match() {
 }
 
 #[test]
+fn check_accepts_absolute_input_file_outside_cwd() {
+    let Some(corsa_path) = resolve_test_corsa_path() else {
+        return;
+    };
+    let case_root = std::env::temp_dir().join(
+        cstr!(
+            "vize-check-absolute-input-outside-cwd-{}",
+            std::process::id()
+        )
+        .as_str(),
+    );
+    let _ = std::fs::remove_dir_all(&case_root);
+    let cwd = case_root.join("cwd");
+    let source_root = case_root.join("source");
+    let source_dir = source_root.join("src");
+    std::fs::create_dir_all(&cwd).unwrap();
+    std::fs::create_dir_all(&source_dir).unwrap();
+    link_workspace_node_modules(&source_root).unwrap();
+    std::fs::write(
+        source_root.join("shared.ts"),
+        "export const message = 'hello'\n",
+    )
+    .unwrap();
+    let source_file = source_dir.join("Repro.vue");
+    std::fs::write(
+        &source_file,
+        r#"<script setup lang="ts">
+import { message } from '../shared'
+</script>
+
+<template>
+  <p>{{ message }}</p>
+</template>
+"#,
+    )
+    .unwrap();
+    let source_arg = source_file.to_string_lossy().into_owned();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(&cwd)
+        .env("CORSA_PATH", corsa_path)
+        .args([
+            "check",
+            "--no-config",
+            "--format",
+            "json",
+            source_arg.as_str(),
+        ])
+        .output()
+        .unwrap();
+
+    let stdout = std::string::String::from_utf8(output.stdout).unwrap();
+    let stderr = std::string::String::from_utf8(output.stderr).unwrap();
+    let json: serde_json::Value = serde_json::from_str(&stdout).unwrap_or_else(|error| {
+        panic!("failed to parse stdout as JSON: {error}\nstdout:\n{stdout}\nstderr:\n{stderr}")
+    });
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "stdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert_eq!(json["fileCount"], 1, "stdout:\n{stdout}\nstderr:\n{stderr}");
+    assert_eq!(
+        json["errorCount"], 0,
+        "stdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    let expected_file = source_file.canonicalize().unwrap().display().to_string();
+    assert_eq!(
+        json["files"][0]["file"], expected_file,
+        "stdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert!(
+        !stderr.contains("Failed to strip prefix from path"),
+        "stdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+
+    let _ = std::fs::remove_dir_all(&case_root);
+}
+
+#[test]
 fn check_preserves_named_exports_from_split_script_vue() {
     let Some(corsa_path) = resolve_test_corsa_path() else {
         return;


### PR DESCRIPTION
Summary
- Use the explicit input files common parent as the project root fallback when no tsconfig can be found.
- Include transitive local imports before root resolution so cwd-external inputs materialize their imported siblings.
- Add CLI coverage for checking an absolute SFC path from a different working directory.

Validation
- cargo fmt --package vize
- cargo test -p vize commands::check::runner::tests
- cargo test -p vize --test check_cli check_accepts_absolute_input_file_outside_cwd
- git diff --check

Closes #873