### PR TITLE
fix(vite-plugin): preserve regexp filter config

### DIFF
--- a/npm/vite-plugin-vize/src/utils.test.ts
+++ b/npm/vite-plugin-vize/src/utils.test.ts
@@ -10,8 +10,36 @@ import assert from "node:assert";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { generateOutput } from "./utils/index.ts";
+import { resolveConfigExport } from "../../vize/src/config.ts";
+import { createFilter, generateOutput } from "./utils/index.ts";
 import { resolveCssImports } from "./utils/css.ts";
+
+// =============================================================================
+// Test: Shared config RegExp filters
+// =============================================================================
+
+const regexpConfig = await resolveConfigExport({
+  vite: {
+    include: [/\.vue$/],
+    exclude: [/node_modules/],
+  },
+});
+const regexpInclude = Array.isArray(regexpConfig.vite?.include)
+  ? regexpConfig.vite.include[0]
+  : regexpConfig.vite?.include;
+const regexpExclude = Array.isArray(regexpConfig.vite?.exclude)
+  ? regexpConfig.vite.exclude[0]
+  : regexpConfig.vite?.exclude;
+assert.ok(regexpInclude instanceof RegExp, "Shared config should preserve include RegExp values");
+assert.ok(regexpExclude instanceof RegExp, "Shared config should preserve exclude RegExp values");
+
+const regexpFilter = createFilter(regexpConfig.vite?.include, regexpConfig.vite?.exclude);
+assert.equal(regexpFilter("/src/App.vue"), true, "RegExp include should match Vue files");
+assert.equal(
+  regexpFilter("/src/node_modules/App.vue"),
+  false,
+  "RegExp exclude should filter node_modules",
+);
 
 // =============================================================================
 // Test: Non-script-setup SFC _sfc_main duplication fix

--- a/npm/vize/src/config.ts
+++ b/npm/vize/src/config.ts
@@ -384,10 +384,6 @@ function isEmptyConfigEntry(entry: VizeConfigEntry): boolean {
   return Object.keys(entry).length === 0;
 }
 
-function isPlainObject(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
 function stripNullish(value: unknown): unknown {
   if (value === null) {
     return undefined;
@@ -397,7 +393,7 @@ function stripNullish(value: unknown): unknown {
     return value.map((entry) => stripNullish(entry)).filter((entry) => entry !== undefined);
   }
 
-  if (typeof value === "object" && value !== null) {
+  if (isPlainObject(value)) {
     const result: Record<string, unknown> = {};
     for (const [key, entry] of Object.entries(value)) {
       const normalizedEntry = stripNullish(entry);
@@ -409,6 +405,15 @@ function stripNullish(value: unknown): unknown {
   }
 
   return value;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return false;
+  }
+
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
 }
 
 function getErrorMessage(error: unknown): string {


### PR DESCRIPTION
Summary
- Preserve RegExp values while normalizing shared Vize config objects.
- Add regression coverage that RegExp include/exclude values from shared config still work with the existing Vite plugin filter.

Validation
- pnpm --dir npm/vite-plugin-vize exec node src/utils.test.ts
- pnpm --dir npm/vite-plugin-vize check
- pnpm --dir npm/vize check
- git diff --check

Closes #862