### PR TITLE
fix(compiler): preserve numeric v-for components

### DIFF
--- a/crates/vize_atelier_core/src/codegen.rs
+++ b/crates/vize_atelier_core/src/codegen.rs
@@ -387,6 +387,23 @@ mod tests {
     }
 
     #[test]
+    fn test_codegen_numeric_component_v_for_uses_component_block() {
+        let result =
+            compile!(r#"<Child v-for="(id, index) in 4" :key="id" :label="String(index)" />"#);
+
+        assert!(
+            result.code.contains("_createBlock(_component_Child"),
+            "numeric component v-for should render a component block. Got:\n{}",
+            result.code
+        );
+        assert!(
+            !result.code.contains(r#"_createElementVNode("Child""#),
+            "numeric component v-for must not render Child as a native element. Got:\n{}",
+            result.code
+        );
+    }
+
+    #[test]
     fn test_codegen_v_if_template_fragment_wraps_interpolation_in_text_vnode() {
         let result = compile!(
             r#"<p><template v-if="ready">{{ count }}</template><span v-if="pending">updating</span></p>"#

--- a/crates/vize_atelier_core/src/codegen/v_for/generate.rs
+++ b/crates/vize_atelier_core/src/codegen/v_for/generate.rs
@@ -86,7 +86,7 @@ pub fn generate_for_item(ctx: &mut CodegenContext, node: &TemplateChildNode<'_>,
 
             if el.tag_type == ElementType::Slot {
                 generate_for_slot_outlet(ctx, el);
-            } else if is_stable {
+            } else if is_stable && !is_component {
                 if gen_is_template {
                     ctx.use_helper(RuntimeHelper::OpenBlock);
                     ctx.use_helper(RuntimeHelper::CreateElementBlock);

--- a/crates/vize_atelier_sfc/src/lib.rs
+++ b/crates/vize_atelier_sfc/src/lib.rs
@@ -211,6 +211,43 @@ if (fx == null) {
     }
 
     #[test]
+    fn test_compile_sfc_imported_component_numeric_v_for() {
+        let source = r#"
+<template>
+  <Child
+    v-for="(id, index) in 4"
+    :key="id"
+    :label="String(index)"
+  />
+</template>
+
+<script setup lang="ts">
+import { Child } from "./components";
+</script>
+"#;
+        let descriptor = parse_sfc(source, Default::default()).unwrap();
+        let result = compile_sfc(&descriptor, SfcCompileOptions::default()).unwrap();
+
+        assert!(
+            result
+                .code
+                .contains(r#"import { Child } from "./components";"#),
+            "script setup import should be preserved. Got:\n{}",
+            result.code
+        );
+        assert!(
+            result.code.contains("_createBlock(Child"),
+            "numeric component v-for should render the imported component. Got:\n{}",
+            result.code
+        );
+        assert!(
+            !result.code.contains(r#"_createElementVNode("Child""#),
+            "numeric component v-for must not render Child as a native element. Got:\n{}",
+            result.code
+        );
+    }
+
+    #[test]
     fn test_compile_sfc_ts_ref_condition_and_handler_keep_value_access() {
         use vize_carton::ToCompactString;
 


### PR DESCRIPTION
## Summary
- Keep numeric `v-for` fragments stable without lowering component children to native elements.
- Add core codegen and SFC regression tests for imported components used in numeric `v-for`.

## Validation
- `cargo fmt -p vize_atelier_core -p vize_atelier_sfc`
- `cargo test -p vize_atelier_core codegen::tests`
- `cargo test -p vize_atelier_sfc tests::test_compile_sfc_imported_component_numeric_v_for`
- `git diff --check`

Closes #881

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/886"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783004201&installation_id=136613492&pr_number=886&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F886&signature=9cc9e13aa3b6c4cd610e6f8007fbc7d6f8a2786f58de5461c68d1ac49bbda4c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->