### PR TITLE
fix(compiler): preserve native v-model directives

### DIFF
--- a/crates/vize_atelier_core/src/codegen.rs
+++ b/crates/vize_atelier_core/src/codegen.rs
@@ -434,6 +434,18 @@ mod tests {
     }
 
     #[test]
+    fn test_codegen_v_model_on_input_with_custom_directive() {
+        let result = compile!(r#"<input v-model="inputValue" v-example />"#);
+        assert_codegen_snapshot!(result);
+    }
+
+    #[test]
+    fn test_codegen_nested_v_model_on_input_with_custom_directive() {
+        let result = compile!(r#"<div><input v-model="inputValue" v-example /></div>"#);
+        assert_codegen_snapshot!(result);
+    }
+
+    #[test]
     fn test_codegen_v_model_with_other_props() {
         // v-model with other props should not produce comments
         let result = compile!(r#"<MonacoEditor v-model="source" :language="editorLanguage" />"#);

--- a/crates/vize_atelier_core/src/codegen/element/block.rs
+++ b/crates/vize_atelier_core/src/codegen/element/block.rs
@@ -69,15 +69,16 @@ pub fn generate_element_block(ctx: &mut CodegenContext, el: &ElementNode<'_>) {
         ctx.push("(");
     }
 
-    // Check for v-model directive on native elements (only if no custom directives)
-    let has_vmodel = has_vmodel_directive(el) && !has_custom_dirs;
-    if has_vmodel {
+    // Native v-model is a runtime directive. If custom directives are present,
+    // it is merged into their withDirectives array.
+    let has_vmodel = has_vmodel_directive(el);
+    if has_vmodel && !has_custom_dirs {
         ctx.use_helper(RuntimeHelper::WithDirectives);
         ctx.push(ctx.helper(RuntimeHelper::WithDirectives));
         ctx.push("(");
     }
 
-    // Check for v-show directive (only if no custom directives or vmodel)
+    // v-show is merged into custom/v-model wrappers when either is present.
     let has_vshow = has_vshow_directive(el) && !has_vmodel && !has_custom_dirs;
     if has_vshow {
         ctx.use_helper(RuntimeHelper::WithDirectives);
@@ -229,13 +230,14 @@ pub fn generate_element_block(ctx: &mut CodegenContext, el: &ElementNode<'_>) {
 
             ctx.push("))");
 
-            // Close withDirectives for custom directives
+            // Close withDirectives for custom directives, merging native
+            // v-model/v-show entries when they share the same element.
             if has_custom_dirs {
                 generate_custom_directives_closing(ctx, el);
             }
 
             // Close withDirectives for v-model
-            if has_vmodel {
+            if has_vmodel && !has_custom_dirs {
                 generate_vmodel_closing(ctx, el);
             }
 

--- a/crates/vize_atelier_core/src/codegen/element/directives.rs
+++ b/crates/vize_atelier_core/src/codegen/element/directives.rs
@@ -9,84 +9,164 @@ use crate::{
 };
 
 use super::super::{context::CodegenContext, expression::generate_expression};
-use super::helpers::{get_custom_directives, get_vmodel_directive, has_vshow_directive};
+use super::helpers::{
+    get_custom_directives, get_vmodel_directive, has_vmodel_directive, has_vshow_directive,
+};
 use crate::codegen::helpers::to_valid_asset_identifier;
+
+fn generate_vmodel_entry(
+    ctx: &mut CodegenContext,
+    el: &ElementNode<'_>,
+    dir: &crate::ast::DirectiveNode<'_>,
+) {
+    let helper = get_vmodel_helper(el);
+    ctx.use_helper(helper);
+
+    let modifiers: Vec<_> = dir.modifiers.iter().map(|m| m.content.as_str()).collect();
+    let parsed_mods = parse_model_modifiers(&dir.modifiers);
+    let has_modifiers = parsed_mods.lazy || parsed_mods.number || parsed_mods.trim;
+
+    if has_modifiers {
+        let active_modifiers: Vec<_> = modifiers
+            .iter()
+            .filter(|m| matches!(*m, &"lazy" | &"number" | &"trim"))
+            .collect();
+        let is_single_modifier = active_modifiers.len() == 1;
+
+        ctx.push("  [");
+        ctx.newline();
+        ctx.push("    ");
+        ctx.push(ctx.helper(helper));
+        ctx.push(",");
+        ctx.newline();
+        ctx.push("    ");
+        if let Some(exp) = &dir.exp {
+            generate_expression(ctx, exp);
+        }
+        ctx.push(",");
+        ctx.newline();
+        ctx.push("    void 0,");
+        ctx.newline();
+
+        if is_single_modifier {
+            ctx.push("    { ");
+            ctx.push(active_modifiers[0]);
+            ctx.push(": true }");
+        } else {
+            ctx.push("    {");
+            for (i, modifier) in active_modifiers.iter().enumerate() {
+                ctx.newline();
+                ctx.push("      ");
+                ctx.push(modifier);
+                ctx.push(": true");
+                if i < active_modifiers.len() - 1 {
+                    ctx.push(",");
+                }
+            }
+            ctx.newline();
+            ctx.push("    }");
+        }
+        ctx.newline();
+        ctx.push("  ]");
+    } else {
+        ctx.push("  [");
+        ctx.push(ctx.helper(helper));
+        ctx.push(", ");
+        if let Some(exp) = &dir.exp {
+            generate_expression(ctx, exp);
+        }
+        ctx.push("]");
+    }
+}
+
+fn generate_vshow_entry(ctx: &mut CodegenContext, dir: &crate::ast::DirectiveNode<'_>) -> bool {
+    let Some(exp) = &dir.exp else {
+        return false;
+    };
+
+    ctx.use_helper(RuntimeHelper::VShow);
+    ctx.push("  [");
+    ctx.push(ctx.helper(RuntimeHelper::VShow));
+    ctx.push(", ");
+    generate_expression(ctx, exp);
+    ctx.push("]");
+    true
+}
+
+fn generate_custom_directive_entry(ctx: &mut CodegenContext, dir: &crate::ast::DirectiveNode<'_>) {
+    ctx.push("  [");
+    ctx.push(&to_valid_asset_identifier("directive", &dir.name));
+
+    if let Some(exp) = &dir.exp {
+        ctx.push(", ");
+        generate_expression(ctx, exp);
+    }
+
+    if let Some(arg) = &dir.arg {
+        if dir.exp.is_none() {
+            ctx.push(", void 0");
+        }
+        ctx.push(", ");
+        match arg {
+            ExpressionNode::Simple(simple) => {
+                if simple.is_static {
+                    ctx.push("\"");
+                    ctx.push(&simple.content);
+                    ctx.push("\"");
+                } else {
+                    ctx.push(&simple.content);
+                }
+            }
+            ExpressionNode::Compound(compound) => {
+                ctx.push(&compound.loc.source);
+            }
+        }
+    }
+
+    if !dir.modifiers.is_empty() {
+        if dir.exp.is_none() && dir.arg.is_none() {
+            ctx.push(", void 0, void 0");
+        } else if dir.arg.is_none() {
+            ctx.push(", void 0");
+        }
+        ctx.push(", { ");
+        for (j, modifier) in dir.modifiers.iter().enumerate() {
+            if j > 0 {
+                ctx.push(", ");
+            }
+            ctx.push(&modifier.content);
+            ctx.push(": true");
+        }
+        ctx.push(" }");
+    }
+
+    ctx.push("]");
+}
 
 /// Generate v-model directive closing
 pub fn generate_vmodel_closing(ctx: &mut CodegenContext, el: &ElementNode<'_>) {
-    if let Some(dir) = get_vmodel_directive(el) {
-        let helper = get_vmodel_helper(el);
-        ctx.use_helper(helper);
+    let Some(dir) = get_vmodel_directive(el) else {
+        return;
+    };
 
-        ctx.push(", [");
-        ctx.newline();
+    ctx.push(", [");
+    ctx.newline();
+    generate_vmodel_entry(ctx, el, dir);
 
-        // Check for modifiers
-        let modifiers: Vec<_> = dir.modifiers.iter().map(|m| m.content.as_str()).collect();
-        let parsed_mods = parse_model_modifiers(&dir.modifiers);
-        let has_modifiers = parsed_mods.lazy || parsed_mods.number || parsed_mods.trim;
-
-        if has_modifiers {
-            // Count active modifiers
-            let active_modifiers: Vec<_> = modifiers
-                .iter()
-                .filter(|m| matches!(*m, &"lazy" | &"number" | &"trim"))
-                .collect();
-            let is_single_modifier = active_modifiers.len() == 1;
-
-            // Multi-line format with modifiers
-            ctx.push("  [");
-            ctx.newline();
-            ctx.push("    ");
-            ctx.push(ctx.helper(helper));
+    for prop in &el.props {
+        if let PropNode::Directive(show_dir) = prop
+            && show_dir.name.as_str() == "show"
+            && show_dir.exp.is_some()
+        {
             ctx.push(",");
             ctx.newline();
-            ctx.push("    ");
-            // Value expression
-            if let Some(exp) = &dir.exp {
-                generate_expression(ctx, exp);
-            }
-            ctx.push(",");
-            ctx.newline();
-            ctx.push("    void 0,");
-            ctx.newline();
-
-            if is_single_modifier {
-                // Single modifier: inline format { lazy: true }
-                ctx.push("    { ");
-                ctx.push(active_modifiers[0]);
-                ctx.push(": true }");
-            } else {
-                // Multiple modifiers: multiline format
-                ctx.push("    {");
-                for (i, modifier) in active_modifiers.iter().enumerate() {
-                    ctx.newline();
-                    ctx.push("      ");
-                    ctx.push(modifier);
-                    ctx.push(": true");
-                    if i < active_modifiers.len() - 1 {
-                        ctx.push(",");
-                    }
-                }
-                ctx.newline();
-                ctx.push("    }");
-            }
-            ctx.newline();
-            ctx.push("  ]");
-        } else {
-            // Simple format without modifiers
-            ctx.push("  [");
-            ctx.push(ctx.helper(helper));
-            ctx.push(", ");
-            if let Some(exp) = &dir.exp {
-                generate_expression(ctx, exp);
-            }
-            ctx.push("]");
+            generate_vshow_entry(ctx, show_dir);
+            break;
         }
-
-        ctx.newline();
-        ctx.push("])");
     }
+
+    ctx.newline();
+    ctx.push("])");
 }
 
 /// Generate v-show directive closing if present
@@ -94,18 +174,13 @@ pub fn generate_vshow_closing(ctx: &mut CodegenContext, el: &ElementNode<'_>) {
     for prop in &el.props {
         if let PropNode::Directive(dir) = prop
             && dir.name.as_str() == "show"
+            && dir.exp.is_some()
         {
-            if let Some(exp) = &dir.exp {
-                ctx.push(", [");
-                ctx.newline();
-                ctx.push("  [");
-                ctx.push(ctx.helper(RuntimeHelper::VShow));
-                ctx.push(", ");
-                generate_expression(ctx, exp);
-                ctx.push("]");
-                ctx.newline();
-                ctx.push("])");
-            }
+            ctx.push(", [");
+            ctx.newline();
+            generate_vshow_entry(ctx, dir);
+            ctx.newline();
+            ctx.push("])");
             return;
         }
     }
@@ -121,81 +196,34 @@ pub fn generate_custom_directives_closing(ctx: &mut CodegenContext, el: &Element
     ctx.push(", [");
     ctx.newline();
 
-    for (i, dir) in custom_dirs.iter().enumerate() {
-        if i > 0 {
+    let has_native_vmodel = has_vmodel_directive(el);
+    let mut emitted = false;
+
+    if has_native_vmodel && let Some(dir) = get_vmodel_directive(el) {
+        generate_vmodel_entry(ctx, el, dir);
+        emitted = true;
+    }
+
+    for dir in custom_dirs {
+        if emitted {
             ctx.push(",");
             ctx.newline();
         }
-        ctx.push("  [");
-        ctx.push(&to_valid_asset_identifier("directive", &dir.name));
-
-        // Add value if present
-        if let Some(exp) = &dir.exp {
-            ctx.push(", ");
-            generate_expression(ctx, exp);
-        }
-
-        // Add argument if present
-        if let Some(arg) = &dir.arg {
-            // Need to add value placeholder if not present
-            if dir.exp.is_none() {
-                ctx.push(", void 0");
-            }
-            ctx.push(", ");
-            match arg {
-                ExpressionNode::Simple(simple) => {
-                    if simple.is_static {
-                        ctx.push("\"");
-                        ctx.push(&simple.content);
-                        ctx.push("\"");
-                    } else {
-                        ctx.push(&simple.content);
-                    }
-                }
-                ExpressionNode::Compound(compound) => {
-                    ctx.push(&compound.loc.source);
-                }
-            }
-        }
-
-        // Add modifiers if present
-        if !dir.modifiers.is_empty() {
-            // Need to add placeholders if not present
-            if dir.exp.is_none() && dir.arg.is_none() {
-                ctx.push(", void 0, void 0");
-            } else if dir.arg.is_none() {
-                ctx.push(", void 0");
-            }
-            ctx.push(", { ");
-            for (j, modifier) in dir.modifiers.iter().enumerate() {
-                if j > 0 {
-                    ctx.push(", ");
-                }
-                ctx.push(&modifier.content);
-                ctx.push(": true");
-            }
-            ctx.push(" }");
-        }
-
-        ctx.push("]");
+        generate_custom_directive_entry(ctx, dir);
+        emitted = true;
     }
 
-    // Also include v-show in the same withDirectives array if present
     if has_vshow_directive(el) {
         for prop in &el.props {
             if let PropNode::Directive(dir) = prop
                 && dir.name.as_str() == "show"
+                && dir.exp.is_some()
             {
-                if let Some(exp) = &dir.exp {
+                if emitted {
                     ctx.push(",");
                     ctx.newline();
-                    ctx.push("  [");
-                    ctx.use_helper(RuntimeHelper::VShow);
-                    ctx.push(ctx.helper(RuntimeHelper::VShow));
-                    ctx.push(", ");
-                    generate_expression(ctx, exp);
-                    ctx.push("]");
                 }
+                generate_vshow_entry(ctx, dir);
                 break;
             }
         }

--- a/crates/vize_atelier_core/src/codegen/element/inline.rs
+++ b/crates/vize_atelier_core/src/codegen/element/inline.rs
@@ -71,15 +71,16 @@ pub fn generate_element(ctx: &mut CodegenContext, el: &ElementNode<'_>) {
                 ctx.push("(");
             }
 
-            // Check for v-model directive on native elements (only if no custom directives)
-            let has_vmodel = has_vmodel_directive(el) && !has_custom_dirs;
-            if has_vmodel {
+            // Native v-model is a runtime directive. If custom directives are
+            // present, it is merged into their withDirectives array.
+            let has_vmodel = has_vmodel_directive(el);
+            if has_vmodel && !has_custom_dirs {
                 ctx.use_helper(RuntimeHelper::WithDirectives);
                 ctx.push(ctx.helper(RuntimeHelper::WithDirectives));
                 ctx.push("(");
             }
 
-            // Check for v-show directive (only if no custom directives or v-model)
+            // v-show is merged into custom/v-model wrappers when either is present.
             let has_vshow = has_vshow_directive(el) && !has_vmodel && !has_custom_dirs;
             if has_vshow {
                 ctx.use_helper(RuntimeHelper::WithDirectives);
@@ -152,14 +153,14 @@ pub fn generate_element(ctx: &mut CodegenContext, el: &ElementNode<'_>) {
 
             ctx.push(")");
 
-            // Close withDirectives for custom directives.
-            // This helper also merges v-show when both are present.
+            // Close withDirectives for custom directives. This helper also
+            // merges native v-model/v-show when they share the same element.
             if has_custom_dirs {
                 generate_custom_directives_closing(ctx, el);
             }
 
             // Close withDirectives for v-model
-            if has_vmodel {
+            if has_vmodel && !has_custom_dirs {
                 generate_vmodel_closing(ctx, el);
             }
 

--- a/crates/vize_atelier_core/src/snapshots/vize_atelier_core__codegen__tests__codegen_nested_v_model_on_input_with_custom_directive.snap
+++ b/crates/vize_atelier_core/src/snapshots/vize_atelier_core__codegen__tests__codegen_nested_v_model_on_input_with_custom_directive.snap
@@ -1,0 +1,18 @@
+---
+source: crates/vize_atelier_core/src/codegen.rs
+expression: output.as_str()
+---
+const { resolveDirective: _resolveDirective, vModelText: _vModelText, withDirectives: _withDirectives, createElementVNode: _createElementVNode, openBlock: _openBlock, createElementBlock: _createElementBlock } = Vue
+
+function render(_ctx, _cache, $props, $setup, $data, $options) {
+  const _directive_example = _resolveDirective("example")
+  
+  return (_openBlock(), _createElementBlock("div", null, [
+    _withDirectives(_createElementVNode("input", {
+      "onUpdate:modelValue": $event => ((inputValue) = $event)
+    }, null, 8 /* PROPS */, ["onUpdate:modelValue"]), [
+      [_vModelText, inputValue],
+      [_directive_example]
+    ])
+  ]))
+}

--- a/crates/vize_atelier_core/src/snapshots/vize_atelier_core__codegen__tests__codegen_v_model_on_input_with_custom_directive.snap
+++ b/crates/vize_atelier_core/src/snapshots/vize_atelier_core__codegen__tests__codegen_v_model_on_input_with_custom_directive.snap
@@ -1,0 +1,16 @@
+---
+source: crates/vize_atelier_core/src/codegen.rs
+expression: output.as_str()
+---
+const { resolveDirective: _resolveDirective, vModelText: _vModelText, withDirectives: _withDirectives, openBlock: _openBlock, createElementBlock: _createElementBlock } = Vue
+
+function render(_ctx, _cache, $props, $setup, $data, $options) {
+  const _directive_example = _resolveDirective("example")
+  
+  return _withDirectives((_openBlock(), _createElementBlock("input", {
+    "onUpdate:modelValue": $event => ((inputValue) = $event)
+  }, null, 8 /* PROPS */, ["onUpdate:modelValue"])), [
+    [_vModelText, inputValue],
+    [_directive_example]
+  ])
+}

--- a/crates/vize_atelier_sfc/src/lib.rs
+++ b/crates/vize_atelier_sfc/src/lib.rs
@@ -368,4 +368,42 @@ const fetchOlder = () => {}
             result.code
         );
     }
+
+    #[test]
+    fn test_compile_sfc_native_v_model_keeps_custom_directive() {
+        let source = r#"
+<template>
+  <input v-model="local" v-example @input="touches++">
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+
+const local = ref('initial')
+const touches = ref(0)
+</script>
+"#;
+        let descriptor = parse_sfc(source, Default::default()).unwrap();
+        let result = compile_sfc(&descriptor, SfcCompileOptions::default()).unwrap();
+        let normalized = result.code.replace('\n', " ");
+
+        assert!(
+            result
+                .code
+                .contains(r#"const _directive_example = _resolveDirective("example")"#),
+            "unexpected code:\n{}",
+            result.code
+        );
+        assert!(
+            normalized.contains(r#"[_vModelText, local.value], [_directive_example]"#),
+            "unexpected code:\n{}",
+            result.code
+        );
+        assert!(
+            result.code.contains(r#""onUpdate:modelValue":"#)
+                && result.code.contains("local.value = $event"),
+            "unexpected code:\n{}",
+            result.code
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- Keep native `v-model` runtime directives when an element also has custom directives.
- Merge native `v-model`, custom directives, and `v-show` into the same `withDirectives` array.
- Add core codegen snapshots and an SFC compile regression for `<input v-model="local" v-example>`.

## Validation
- `cargo fmt --package vize_atelier_core --package vize_atelier_sfc`
- `cargo test -p vize_atelier_core v_model_on_input_with_custom_directive -- --nocapture`
- `cargo test -p vize_atelier_sfc custom_directive -- --nocapture`
- `cargo test -p vize_atelier_core codegen::tests -- --nocapture`
- `cargo test -p vize_atelier_core`
- `cargo test -p vize_atelier_sfc`
- `git diff --check`

Closes #883

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/887"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783004249&installation_id=136613492&pr_number=887&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F887&signature=1803368ad941f22199adbd212391809be9f652a274e243950c1a4c936a0c530a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->