### PR TITLE
fix(vite-plugin): preserve import.meta.glob base

### DIFF
--- a/crates/vize_atelier_sfc/src/vite_plugin.rs
+++ b/crates/vize_atelier_sfc/src/vite_plugin.rs
@@ -44,6 +44,6 @@ pub use resolver::{
 };
 pub use transform::{
     DefineReplacement, DynamicImportAliasRule, apply_define_replacements, is_builtin_define,
-    rewrite_dynamic_template_imports, rewrite_static_asset_urls,
+    rewrite_dynamic_template_imports, rewrite_import_meta_glob_base, rewrite_static_asset_urls,
     should_apply_define_in_virtual_module, to_browser_import_prefix,
 };

--- a/crates/vize_atelier_sfc/src/vite_plugin/transform.rs
+++ b/crates/vize_atelier_sfc/src/vite_plugin/transform.rs
@@ -1,3 +1,10 @@
+use std::path::{Component, Path, PathBuf};
+
+use oxc_allocator::Allocator;
+use oxc_ast::ast::{Argument, ArrayExpressionElement, CallExpression, Expression, StringLiteral};
+use oxc_ast_visit::{Visit, walk};
+use oxc_parser::Parser;
+use oxc_span::SourceType;
 use vize_carton::{SmallVec, String};
 
 use super::js_string::push_js_string_literal;
@@ -20,6 +27,12 @@ pub struct DefineReplacement {
     pub value: String,
 }
 
+struct StringLiteralReplacement {
+    start: usize,
+    end: usize,
+    value: String,
+}
+
 const BUILTIN_DEFINE_PREFIXES: [&str; 10] = [
     "import.meta.server",
     "import.meta.client",
@@ -40,6 +53,32 @@ const VIRTUAL_MODULE_DEFINE_KEYS: [&str; 5] = [
     "import.meta.test",
     "import.meta.prerender",
 ];
+
+/// Rewrite relative `import.meta.glob` literals in Vize virtual modules.
+///
+/// Vite resolves relative glob patterns against the importer ID. Vize virtual
+/// modules are `\0` IDs, so Vite requires globs to be rooted before it sees
+/// the module. This keeps the original SFC path as the base while preserving
+/// Vite's own import-glob transform for the rest of the work.
+pub fn rewrite_import_meta_glob_base(code: &str, importer: &str, root: &str) -> String {
+    if !code.contains("import.meta.glob") {
+        return String::from(code);
+    }
+
+    let allocator = Allocator::default();
+    let parsed = Parser::new(&allocator, code, SourceType::tsx().with_module(true)).parse();
+    if !parsed.errors.is_empty() {
+        return String::from(code);
+    }
+
+    let mut collector = ImportMetaGlobCollector {
+        importer,
+        root,
+        replacements: Vec::new(),
+    };
+    collector.visit_program(&parsed.program);
+    apply_string_literal_replacements(code, collector.replacements)
+}
 
 /// Rewrite static asset `src` values in compiled render output into imports.
 pub fn rewrite_static_asset_urls(code: &str, alias_rules: &[DynamicImportAliasRule]) -> String {
@@ -93,6 +132,159 @@ pub fn rewrite_static_asset_urls(code: &str, alias_rules: &[DynamicImportAliasRu
     }
     rewritten.push_str(output.as_str());
     rewritten
+}
+
+struct ImportMetaGlobCollector<'a> {
+    importer: &'a str,
+    root: &'a str,
+    replacements: Vec<StringLiteralReplacement>,
+}
+
+impl ImportMetaGlobCollector<'_> {
+    fn collect_argument<'a>(&mut self, argument: &Argument<'a>) {
+        match argument {
+            Argument::StringLiteral(literal) => self.collect_string_literal(literal),
+            Argument::ArrayExpression(array) => {
+                for element in array.elements.iter() {
+                    if let ArrayExpressionElement::StringLiteral(literal) = element {
+                        self.collect_string_literal(literal);
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn collect_string_literal(&mut self, literal: &StringLiteral<'_>) {
+        let value = literal.value.as_str();
+        let Some(rewritten) = normalize_import_meta_glob_pattern(value, self.importer, self.root)
+        else {
+            return;
+        };
+
+        self.replacements.push(StringLiteralReplacement {
+            start: literal.span.start as usize,
+            end: literal.span.end as usize,
+            value: rewritten,
+        });
+    }
+}
+
+impl<'a> Visit<'a> for ImportMetaGlobCollector<'_> {
+    fn visit_call_expression(&mut self, call: &CallExpression<'a>) {
+        if is_import_meta_glob_call(call)
+            && let Some(argument) = call.arguments.first()
+        {
+            self.collect_argument(argument);
+        }
+        walk::walk_call_expression(self, call);
+    }
+}
+
+fn is_import_meta_glob_call(call: &CallExpression<'_>) -> bool {
+    let Expression::StaticMemberExpression(member) = &call.callee else {
+        return false;
+    };
+    member.property.name.as_str() == "glob" && is_import_meta_expression(&member.object)
+}
+
+fn is_import_meta_expression(expression: &Expression<'_>) -> bool {
+    let Expression::MetaProperty(meta) = expression else {
+        return false;
+    };
+    meta.meta.name.as_str() == "import" && meta.property.name.as_str() == "meta"
+}
+
+fn normalize_import_meta_glob_pattern(pattern: &str, importer: &str, root: &str) -> Option<String> {
+    let (negated, pattern) = pattern
+        .strip_prefix('!')
+        .map_or((false, pattern), |pattern| (true, pattern));
+    if !pattern.starts_with("./") && !pattern.starts_with("../") {
+        return None;
+    }
+
+    let importer_parent = Path::new(importer)
+        .parent()
+        .unwrap_or_else(|| Path::new(""));
+    let absolute_pattern = lexical_normalize(&importer_parent.join(pattern));
+    let absolute_root = lexical_normalize(Path::new(if root.is_empty() { "." } else { root }));
+
+    let mut rewritten = String::with_capacity(pattern.len() + 2);
+    if negated {
+        rewritten.push('!');
+    }
+
+    if let Ok(relative) = absolute_pattern.strip_prefix(&absolute_root) {
+        rewritten.push('/');
+        let relative = normalize_path_for_import(relative);
+        rewritten.push_str(relative.as_str());
+    } else {
+        rewritten.push_str(normalize_path_for_import(&absolute_pattern).as_str());
+    }
+
+    Some(rewritten)
+}
+
+fn normalize_path_for_import(path: &Path) -> String {
+    normalize_slashes(path.to_string_lossy().as_ref())
+}
+
+fn lexical_normalize(path: &Path) -> PathBuf {
+    let mut normalized = PathBuf::new();
+    let mut normal_count = 0usize;
+
+    for component in path.components() {
+        match component {
+            Component::Prefix(prefix) => normalized.push(prefix.as_os_str()),
+            Component::RootDir => normalized.push(component.as_os_str()),
+            Component::CurDir => {}
+            Component::ParentDir => {
+                if normal_count > 0 {
+                    normal_count -= 1;
+                    normalized.pop();
+                } else if !normalized.is_absolute() {
+                    normalized.push(component.as_os_str());
+                }
+            }
+            Component::Normal(part) => {
+                normal_count += 1;
+                normalized.push(part);
+            }
+        }
+    }
+
+    normalized
+}
+
+fn apply_string_literal_replacements(
+    code: &str,
+    mut replacements: Vec<StringLiteralReplacement>,
+) -> String {
+    if replacements.is_empty() {
+        return String::from(code);
+    }
+
+    replacements.sort_by_key(|replacement| replacement.start);
+    let mut output = String::with_capacity(code.len());
+    let mut last = 0usize;
+    let mut changed = false;
+
+    for replacement in replacements {
+        if replacement.start < last || replacement.end > code.len() {
+            continue;
+        }
+        output.push_str(&code[last..replacement.start]);
+        push_js_string_literal(&mut output, replacement.value.as_str());
+        last = replacement.end;
+        changed = true;
+    }
+
+    if !changed {
+        return String::from(code);
+    }
+
+    output.push_str(&code[last..]);
+    output
 }
 
 /// Rewrite dynamic template imports so Vite leaves runtime expressions alone.
@@ -400,6 +592,36 @@ mod tests {
         assert_eq!(
             rewrite_dynamic_template_imports(code, &rules).as_str(),
             "const image = import(/* @vite-ignore */ `/src/assets/${name}.svg`);"
+        );
+    }
+
+    #[test]
+    fn rewrites_import_meta_glob_relative_patterns() {
+        let code = r#"const modules = import.meta.glob("./demos/*.vue", { eager: true });"#;
+
+        assert_eq!(
+            rewrite_import_meta_glob_base(code, "/project/src/App.vue", "/project").as_str(),
+            r#"const modules = import.meta.glob("/src/demos/*.vue", { eager: true });"#
+        );
+    }
+
+    #[test]
+    fn rewrites_import_meta_glob_array_and_negated_patterns() {
+        let code = r#"const modules = import.meta.glob<{ default: unknown }>(["./demos/*.vue", "!../legacy/*.vue", "/src/stable/*.vue"]);"#;
+
+        assert_eq!(
+            rewrite_import_meta_glob_base(code, "/project/src/App.vue", "/project").as_str(),
+            r#"const modules = import.meta.glob<{ default: unknown }>(["/src/demos/*.vue", "!/legacy/*.vue", "/src/stable/*.vue"]);"#
+        );
+    }
+
+    #[test]
+    fn skips_non_calls_and_non_relative_import_meta_globs() {
+        let code = r#"const text = "import.meta.glob('./demos/*.vue')"; const modules = import.meta.glob("/src/demos/*.vue");"#;
+
+        assert_eq!(
+            rewrite_import_meta_glob_base(code, "/project/src/App.vue", "/project").as_str(),
+            code
         );
     }
 

--- a/crates/vize_vitrine/src/napi/plugin.rs
+++ b/crates/vize_vitrine/src/napi/plugin.rs
@@ -165,6 +165,11 @@ pub fn rewrite_vite_dynamic_template_imports(
     vize_atelier_sfc::vite_plugin::rewrite_dynamic_template_imports(&code, &alias_rules).into()
 }
 
+#[napi(js_name = "rewriteViteImportMetaGlobBase")]
+pub fn rewrite_vite_import_meta_glob_base(code: String, importer: String, root: String) -> String {
+    vize_atelier_sfc::vite_plugin::rewrite_import_meta_glob_base(&code, &importer, &root).into()
+}
+
 #[napi(js_name = "isBuiltinViteDefine")]
 pub fn is_builtin_vite_define(key: String) -> bool {
     vize_atelier_sfc::vite_plugin::is_builtin_define(&key)

--- a/npm/vite-plugin-vize/src/plugin/load.test.ts
+++ b/npm/vite-plugin-vize/src/plugin/load.test.ts
@@ -8,6 +8,7 @@ import { getBoundaryPlaceholderCode } from "./load.ts";
 import { loadHook } from "./load.ts";
 import { normalizeVueServerRendererImport } from "./load.ts";
 import { transformHook } from "./load.ts";
+import { rewriteImportMetaGlobBase } from "../transform.ts";
 import { toVirtualId } from "../virtual.ts";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -65,6 +66,18 @@ assert.equal(
   ),
   'import { ssrRenderAttrs } from "vue/server-renderer";\nexport { ssrRenderAttrs };',
   "SSR helper imports should use Vue's public server-renderer entry for Nuxt/Nitro externalization",
+);
+
+assert.equal(
+  rewriteImportMetaGlobBase(
+    `const modules = import.meta.glob("./demos/*.vue", { eager: true });
+const grouped = import.meta.glob(["./demos/*.vue", "../shared/*.vue"]);`,
+    "/project/src/App.vue",
+    "/project",
+  ),
+  `const modules = import.meta.glob("/src/demos/*.vue", { eager: true });
+const grouped = import.meta.glob(["/src/demos/*.vue", "/shared/*.vue"]);`,
+  "Virtual SFC modules should resolve relative import.meta.glob patterns from the original file",
 );
 
 const realPath = "/src/Hmr.vue";
@@ -377,6 +390,52 @@ assert.match(
   inlineLoad.code,
   /__hmrUpdateType = "full-reload"/,
   "Inline-template components must downgrade template-only HMR to full-reload",
+);
+
+const globRoot = createTempRoot("glob-base");
+const globPath = path.join(globRoot, "src", "App.vue");
+const globState: VizePluginState = {
+  ...hmrState,
+  cache: new Map([
+    [
+      globPath,
+      {
+        code: `const modules = import.meta.glob("./demos/*.vue", { eager: true });
+const grouped = import.meta.glob(["./demos/*.vue", "../shared/*.vue"]);
+const _sfc_main = {};
+export default _sfc_main`,
+        scopeId: "globbase",
+        hasScoped: false,
+        styles: [],
+      },
+    ],
+  ]),
+  ssrCache: new Map(),
+  pendingHmrUpdateTypes: new Map(),
+  root: globRoot,
+};
+
+const globLoad = loadHook(globState, toVirtualId(globPath), {
+  ssr: false,
+});
+assert.ok(
+  globLoad && typeof globLoad === "object",
+  "Virtual modules with import.meta.glob should load as code objects",
+);
+assert.match(
+  globLoad.code,
+  /import\.meta\.glob\("\/src\/demos\/\*\.vue", \{ eager: true \}\)/,
+  "Virtual modules should rewrite single relative glob patterns to root-relative paths",
+);
+assert.match(
+  globLoad.code,
+  /import\.meta\.glob\(\["\/src\/demos\/\*\.vue", "\/shared\/\*\.vue"\]\)/,
+  "Virtual modules should rewrite array relative glob patterns to root-relative paths",
+);
+assert.doesNotMatch(
+  globLoad.code,
+  /import\.meta\.glob\((?:\.\/|\["\.\/)/,
+  "Virtual modules should not leave relative import.meta.glob patterns for Vite's virtual import-glob transform",
 );
 
 const envPath = "/src/Environment.vue";

--- a/npm/vite-plugin-vize/src/plugin/load.ts
+++ b/npm/vite-plugin-vize/src/plugin/load.ts
@@ -24,7 +24,11 @@ import {
   RESOLVED_CSS_MODULE,
   rewriteDynamicTemplateImports,
 } from "../virtual.ts";
-import { rewriteStaticAssetUrls, applyDefineReplacements } from "../transform.ts";
+import {
+  applyDefineReplacements,
+  rewriteImportMetaGlobBase,
+  rewriteStaticAssetUrls,
+} from "../transform.ts";
 
 const SERVER_PLACEHOLDER_CODE = `import { createElementBlock, defineComponent } from "vue";
 export default defineComponent({
@@ -169,11 +173,12 @@ function loadCompiledSfcModule(
     ),
     state.dynamicImportAliasRules,
   );
+  const normalizedOutput = rewriteImportMetaGlobBase(output, realPath, state.root);
   if (!loadOptions?.ssr) {
     state.pendingHmrUpdateTypes.delete(realPath);
   }
   return {
-    code: output,
+    code: normalizedOutput,
     map: null,
   };
 }

--- a/npm/vite-plugin-vize/src/plugin/native.test.ts
+++ b/npm/vite-plugin-vize/src/plugin/native.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { classifyVitePluginRequest } from "@vizejs/native";
+import { classifyVitePluginRequest, rewriteViteImportMetaGlobBase } from "@vizejs/native";
 
 {
   const request = classifyVitePluginRequest("/src/pages/Home.vue?definePage");
@@ -49,4 +49,12 @@ import { classifyVitePluginRequest } from "@vizejs/native";
   assert.equal(classifyVitePluginRequest("/src/Foo.client.vue").boundaryKind, "client");
   assert.equal(classifyVitePluginRequest("/src/Foo.server.vue").boundaryKind, "server");
   assert.equal(classifyVitePluginRequest("/src/Foo.vue").boundaryKind ?? undefined, undefined);
+}
+
+{
+  const code = `const modules = import.meta.glob(["./demos/*.vue", "!../legacy/*.vue"], { eager: true });`;
+  assert.equal(
+    rewriteViteImportMetaGlobBase(code, "/project/src/App.vue", "/project"),
+    `const modules = import.meta.glob(["/src/demos/*.vue", "!/legacy/*.vue"], { eager: true });`,
+  );
 }

--- a/npm/vite-plugin-vize/src/transform.ts
+++ b/npm/vite-plugin-vize/src/transform.ts
@@ -8,6 +8,7 @@
 import {
   applyViteDefineReplacements,
   isBuiltinViteDefine,
+  rewriteViteImportMetaGlobBase,
   rewriteViteStaticAssetUrls,
   shouldApplyViteDefineInVirtualModule,
 } from "@vizejs/native";
@@ -22,6 +23,13 @@ import type { DynamicImportAliasRule } from "./virtual.ts";
  */
 export function rewriteStaticAssetUrls(code: string, aliasRules: DynamicImportAliasRule[]): string {
   return rewriteViteStaticAssetUrls(code, aliasRules);
+}
+
+export function rewriteImportMetaGlobBase(code: string, importer: string, root: string): string {
+  if (!code.includes("import.meta.glob")) {
+    return code;
+  }
+  return rewriteViteImportMetaGlobBase(code, importer, root);
 }
 
 /**

--- a/npm/vize-native/index.js
+++ b/npm/vize-native/index.js
@@ -126,6 +126,7 @@ module.exports.resolveViteCssImports = nativeBinding.resolveViteCssImports;
 module.exports.resolveViteRelativeImport = nativeBinding.resolveViteRelativeImport;
 module.exports.resolveViteVuePath = nativeBinding.resolveViteVuePath;
 module.exports.rewriteViteDynamicTemplateImports = nativeBinding.rewriteViteDynamicTemplateImports;
+module.exports.rewriteViteImportMetaGlobBase = nativeBinding.rewriteViteImportMetaGlobBase;
 module.exports.rewriteViteStaticAssetUrls = nativeBinding.rewriteViteStaticAssetUrls;
 module.exports.runCli = nativeBinding.runCli;
 module.exports.scopeViteCssForPipeline = nativeBinding.scopeViteCssForPipeline;

--- a/npm/vize-native/types/vite.d.ts
+++ b/npm/vize-native/types/vite.d.ts
@@ -202,6 +202,12 @@ export declare function rewriteViteDynamicTemplateImports(
   aliasRules: Array<DynamicImportAliasRuleNapi>,
 ): string;
 
+export declare function rewriteViteImportMetaGlobBase(
+  code: string,
+  importer: string,
+  root: string,
+): string;
+
 export declare function rewriteViteStaticAssetUrls(
   code: string,
   aliasRules: Array<DynamicImportAliasRuleNapi>,


### PR DESCRIPTION
## Summary

- Rewrite relative import.meta.glob patterns in SFC virtual modules to root-relative paths before Vite import-glob handling.
- Resolve glob bases from the original Vue file path instead of the virtual module id.
- Add direct and load-hook regression coverage for string and array glob arguments.

## Root cause

Vize emits compiled SFCs as virtual modules. Vite import-glob handling requires glob patterns in virtual modules to start with `/`, so relative patterns like `./demos/*.vue` no longer resolved from the original `.vue` file.

## Validation

- node npm/vite-plugin-vize/src/plugin/load.test.ts
- pnpm --dir npm/vite-plugin-vize check
- git diff --check
- pnpm --dir npm/vite-plugin-vize test (fails in plugin/resolve.test.ts:654, outside this change; load-related tests passed before that failure)

Closes #884

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/888"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783004773&installation_id=136613492&pr_number=888&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F888&signature=1f87a6ced3a88482c286a789a708785c4004239432d9f301ab7ed1990e9e9ddc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->