### PR TITLE
fix(vite-plugin): preserve SFC transform hooks

### DIFF
--- a/npm/vite-plugin-vize/src/plugin/load.test.ts
+++ b/npm/vite-plugin-vize/src/plugin/load.test.ts
@@ -9,7 +9,7 @@ import { loadHook } from "./load.ts";
 import { normalizeVueServerRendererImport } from "./load.ts";
 import { transformHook } from "./load.ts";
 import { rewriteImportMetaGlobBase } from "../transform.ts";
-import { toVirtualId } from "../virtual.ts";
+import { toPluginVisibleVirtualId, toVirtualId } from "../virtual.ts";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -159,6 +159,23 @@ assert.equal(
   virtualDefineTransform.map,
   null,
   "Virtual module OXC transforms should not allocate sourcemaps that Vize discards",
+);
+
+const visibleVirtualDefineTransform = await transformHook(
+  virtualDefineState,
+  `export const flags = [import.meta.client, import.meta.server, import.meta.dev, import.meta.hot];`,
+  toPluginVisibleVirtualId("/src/EnvFlags.vue"),
+  { ssr: false },
+);
+
+assert.ok(
+  visibleVirtualDefineTransform && typeof visibleVirtualDefineTransform === "object",
+  "Plugin-visible virtual module transforms should succeed",
+);
+assert.doesNotMatch(
+  visibleVirtualDefineTransform.code,
+  /import\.meta\.(client|server|dev)/,
+  "Plugin-visible virtual module transforms should inline environment flags before post plugins run",
 );
 
 assert.equal(
@@ -477,6 +494,30 @@ assert.match(
   clientEnvironmentLoad.code,
   /ClientCompiled/,
   "Client loads should read from the client compilation cache",
+);
+
+const visibleClientEnvironmentLoad = loadHook(environmentState, toPluginVisibleVirtualId(envPath), {
+  ssr: false,
+});
+assert.ok(
+  visibleClientEnvironmentLoad && typeof visibleClientEnvironmentLoad === "object",
+  "Plugin-visible client environment loads should succeed",
+);
+assert.match(
+  visibleClientEnvironmentLoad.code,
+  /ClientCompiled/,
+  "Plugin-visible client loads should read from the client compilation cache",
+);
+
+const rawClientEnvironmentLoad = loadHook(environmentState, envPath, { ssr: false });
+assert.ok(
+  rawClientEnvironmentLoad && typeof rawClientEnvironmentLoad === "object",
+  "Raw Vue SFC loads should be claimed when a bundler bypasses resolveId output",
+);
+assert.match(
+  rawClientEnvironmentLoad.code,
+  /ClientCompiled/,
+  "Raw Vue SFC loads should read from the client compilation cache",
 );
 
 const ssrEnvironmentLoad = loadHook(environmentState, toVirtualId(envPath, true), { ssr: true });

--- a/npm/vite-plugin-vize/src/plugin/load.ts
+++ b/npm/vite-plugin-vize/src/plugin/load.ts
@@ -20,6 +20,8 @@ import {
   transformCssVarsForPipeline,
 } from "../utils/css.ts";
 import {
+  fromPluginVisibleVirtualId,
+  isPluginVisibleSsrVirtualId,
   LEGACY_VIZE_PREFIX,
   RESOLVED_CSS_MODULE,
   rewriteDynamicTemplateImports,
@@ -94,12 +96,40 @@ function findMacroArtifactModule(
   return compiled?.macroArtifacts?.find((artifact) => artifact.kind === kind)?.moduleCode ?? null;
 }
 
-function hasNuxtComponentQuery(request: ReturnType<typeof classifyVitePluginRequest>): boolean {
-  if (!request.querySuffix) {
+function shouldLoadVueSfcRequest(request: ReturnType<typeof classifyVitePluginRequest>): boolean {
+  if (
+    !request.isVueSfcPath ||
+    request.isVueStyleQuery ||
+    request.hasMacroQuery ||
+    request.hasDefinePageQuery
+  ) {
     return false;
   }
 
-  return new URLSearchParams(request.querySuffix.slice(1)).has("nuxt_component");
+  if (!request.querySuffix) {
+    return true;
+  }
+
+  const params = new URLSearchParams(request.querySuffix.slice(1));
+  if (
+    params.has("raw") ||
+    params.has("url") ||
+    params.has("worker") ||
+    params.has("sharedworker")
+  ) {
+    return false;
+  }
+
+  return params.has("nuxt_component");
+}
+
+function getLoadableVueSfcPath(
+  request: ReturnType<typeof classifyVitePluginRequest>,
+): string | null {
+  if (!shouldLoadVueSfcRequest(request)) {
+    return null;
+  }
+  return classifyVitePluginRequest(request.normalizedFsId ?? request.path).normalizedVuePath;
 }
 
 function normalizeStyleVirtualId(id: string): string {
@@ -210,6 +240,8 @@ export function loadHook(
   loadOptions?: { ssr?: boolean },
 ): string | { code: string; map: null } | null {
   const request = classifyVitePluginRequest(id);
+  const pluginVisibleVirtualPath = fromPluginVisibleVirtualId(id);
+  const loadableVueSfcPath = getLoadableVueSfcPath(request);
 
   // Pick the correct viteBase for URL resolution based on the build environment.
   const currentBase = loadOptions?.ssr ? state.serverViteBase : state.clientViteBase;
@@ -275,10 +307,13 @@ export function loadHook(
     return "";
   }
 
-  if (id !== RESOLVED_CSS_MODULE && !id.startsWith("\0")) {
-    if (!request.isVueSfcPath || !hasNuxtComponentQuery(request)) {
-      return null;
-    }
+  if (
+    id !== RESOLVED_CSS_MODULE &&
+    !id.startsWith("\0") &&
+    !pluginVisibleVirtualPath &&
+    !loadableVueSfcPath
+  ) {
+    return null;
   }
 
   // Handle Vue Router's ?definePage query through extracted artifacts.
@@ -302,9 +337,9 @@ export function loadHook(
   }
 
   // Handle vize virtual modules
-  if (request.isVizeVirtual) {
-    const realPath = request.vizeVirtualPath ?? "";
-    const isSsr = request.isVizeSsrVirtual || !!loadOptions?.ssr;
+  if (request.isVizeVirtual || pluginVisibleVirtualPath) {
+    const realPath = request.vizeVirtualPath ?? pluginVisibleVirtualPath ?? "";
+    const isSsr = request.isVizeSsrVirtual || isPluginVisibleSsrVirtualId(id) || !!loadOptions?.ssr;
 
     if (!realPath.endsWith(".vue")) {
       state.logger.log(`load: skipping non-vue virtual module ${realPath}`);
@@ -313,12 +348,9 @@ export function loadHook(
     return loadCompiledSfcModule(state, realPath, isSsr, currentBase, loadOptions);
   }
 
-  if (request.isVueSfcPath && hasNuxtComponentQuery(request)) {
-    const realPath = classifyVitePluginRequest(
-      request.normalizedFsId ?? request.path,
-    ).normalizedVuePath;
+  if (loadableVueSfcPath) {
     const isSsr = !!loadOptions?.ssr;
-    return loadCompiledSfcModule(state, realPath, isSsr, currentBase, loadOptions);
+    return loadCompiledSfcModule(state, loadableVueSfcPath, isSsr, currentBase, loadOptions);
   }
 
   // Handle \0-prefixed non-vue files leaked from virtual module dynamic imports.
@@ -354,15 +386,16 @@ export async function transformHook(
   id: string,
   options?: { ssr?: boolean },
 ): Promise<TransformResult | null> {
-  if (!id.startsWith("\0")) {
+  const pluginVisibleVirtualPath = fromPluginVisibleVirtualId(id);
+  if (!id.startsWith("\0") && !pluginVisibleVirtualPath) {
     return null;
   }
 
   const request = classifyVitePluginRequest(id);
-  if (request.isVizeVirtual || request.isMacroVirtualId) {
+  if (request.isVizeVirtual || request.isMacroVirtualId || pluginVisibleVirtualPath) {
     const realPath = request.isMacroVirtualId
       ? (request.strippedVirtualPath ?? "")
-      : (request.vizeVirtualPath ?? "");
+      : (request.vizeVirtualPath ?? pluginVisibleVirtualPath ?? "");
     try {
       const result = await transformWithOxc(code, realPath, {
         lang: "ts",

--- a/npm/vite-plugin-vize/src/plugin/resolve.test.ts
+++ b/npm/vite-plugin-vize/src/plugin/resolve.test.ts
@@ -966,6 +966,24 @@ function expectResolvedId(resolved: Awaited<ReturnType<typeof resolveIdHook>>): 
 }
 
 {
+  const projectRoot = createTempProject("dependency-scan-virtual");
+  const source = path.join(projectRoot, "app", "pages", "index.vue");
+  const resolved = await resolveIdHook(
+    nullResolveContext,
+    createState(projectRoot),
+    source,
+    undefined,
+    { scan: true },
+  );
+
+  assert.equal(
+    expectResolvedId(resolved),
+    toVirtualId(source),
+    "Dependency scans should use load-hook virtual IDs instead of plugin-visible file-like IDs",
+  );
+}
+
+{
   const projectRoot = createTempProject("ssr-entry");
   const source = path.join(projectRoot, "app", "pages", "index.vue");
   const resolved = await resolveIdHook(

--- a/npm/vite-plugin-vize/src/plugin/resolve.test.ts
+++ b/npm/vite-plugin-vize/src/plugin/resolve.test.ts
@@ -1,18 +1,20 @@
 import assert from "node:assert/strict";
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { createRequire } from "node:module";
 import { fileURLToPath } from "node:url";
 
 import type { VizePluginState } from "./state.ts";
 import { resolveIdHook } from "./resolve.ts";
-import { toVirtualId } from "../virtual.ts";
+import { toPluginVisibleVirtualId, toVirtualId } from "../virtual.ts";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const workspaceRoot = path.resolve(__dirname, "../../../..");
-const testRoot = path.join(workspaceRoot, "target", "vize-tests", "tests", "vite-plugin-vize");
-fs.mkdirSync(testRoot, { recursive: true });
+const testRoot = fs.mkdtempSync(
+  path.join(fs.realpathSync(os.tmpdir()), "vize-vite-plugin-resolve-"),
+);
 
 function writeFixtureFile(filePath: string, content = ""): void {
   fs.mkdirSync(path.dirname(filePath), { recursive: true });
@@ -369,7 +371,7 @@ function expectResolvedId(resolved: Awaited<ReturnType<typeof resolveIdHook>>): 
   );
   assert.equal(
     expectResolvedId(resolved),
-    toVirtualId(aliased),
+    toPluginVisibleVirtualId(aliased),
     "Aliased Vue imports should be filtered after Vite resolves the real file path",
   );
 }
@@ -941,6 +943,29 @@ function expectResolvedId(resolved: Awaited<ReturnType<typeof resolveIdHook>>): 
 }
 
 {
+  const projectRoot = createTempProject("plugin-visible-virtual");
+  const source = path.join(projectRoot, "app", "pages", "index.vue");
+  const resolved = await resolveIdHook(
+    nullResolveContext,
+    createState(projectRoot),
+    source,
+    undefined,
+    undefined,
+  );
+
+  assert.equal(
+    expectResolvedId(resolved),
+    toPluginVisibleVirtualId(source),
+    "Resolved Vue SFC modules should keep a Vue-compatible query so post plugins can transform them",
+  );
+  assert.equal(
+    expectResolvedId(resolved).startsWith("\0"),
+    false,
+    "Plugin-visible Vue SFC modules should not use Rollup-internal virtual IDs",
+  );
+}
+
+{
   const projectRoot = createTempProject("ssr-entry");
   const source = path.join(projectRoot, "app", "pages", "index.vue");
   const resolved = await resolveIdHook(
@@ -953,7 +978,7 @@ function expectResolvedId(resolved: Awaited<ReturnType<typeof resolveIdHook>>): 
 
   assert.equal(
     expectResolvedId(resolved),
-    toVirtualId(source, true),
+    toPluginVisibleVirtualId(source, true),
     "SSR resolves should use a dedicated virtual module ID",
   );
 }
@@ -971,8 +996,26 @@ function expectResolvedId(resolved: Awaited<ReturnType<typeof resolveIdHook>>): 
 
   assert.equal(
     expectResolvedId(resolved),
-    toVirtualId(source, true),
+    toPluginVisibleVirtualId(source, true),
     "SSR resolution should upgrade client virtual IDs to SSR-specific virtual IDs",
+  );
+}
+
+{
+  const projectRoot = createTempProject("ssr-upgrade-visible");
+  const source = path.join(projectRoot, "app", "pages", "index.vue");
+  const resolved = await resolveIdHook(
+    nullResolveContext,
+    createState(projectRoot),
+    toPluginVisibleVirtualId(source),
+    undefined,
+    { isEntry: false, ssr: true },
+  );
+
+  assert.equal(
+    expectResolvedId(resolved),
+    toPluginVisibleVirtualId(source, true),
+    "SSR resolution should not duplicate the Vue-compatible query",
   );
 }
 
@@ -1060,7 +1103,7 @@ function expectResolvedId(resolved: Awaited<ReturnType<typeof resolveIdHook>>): 
 
     assert.equal(
       expectResolvedId(resolved),
-      toVirtualId(source, true),
+      toPluginVisibleVirtualId(source, true),
       "SSR resolves should use a dedicated virtual module ID",
     );
   }
@@ -1080,7 +1123,7 @@ function expectResolvedId(resolved: Awaited<ReturnType<typeof resolveIdHook>>): 
 
     assert.equal(
       expectResolvedId(resolved),
-      toVirtualId(source, true),
+      toPluginVisibleVirtualId(source, true),
       "SSR resolution should upgrade client virtual IDs to SSR-specific virtual IDs",
     );
   }

--- a/npm/vite-plugin-vize/src/plugin/resolve.ts
+++ b/npm/vite-plugin-vize/src/plugin/resolve.ts
@@ -22,6 +22,7 @@ import {
   fromPluginVisibleVirtualId,
   isPluginVisibleSsrVirtualId,
   toPluginVisibleVirtualId,
+  toVirtualId,
 } from "../virtual.ts";
 import { toNativeCssAliasRule } from "../utils/css.ts";
 
@@ -412,6 +413,7 @@ async function resolveAliasedVueImport(
   handleNodeModules: boolean,
   querySuffix: string,
   preserveQueryAsPath: boolean,
+  isDependencyScan: boolean,
 ): Promise<string | null> {
   if (path.isAbsolute(id)) {
     return null;
@@ -439,7 +441,9 @@ async function resolveAliasedVueImport(
     state.logger.log(`resolveId: resolved via Vite fallback ${id} to ${realPath}`);
     return preserveQueryAsPath
       ? `${realPath}${querySuffix}`
-      : toPluginVisibleVirtualId(realPath, isSsrRequest, querySuffix);
+      : isDependencyScan
+        ? toVirtualId(realPath, isSsrRequest)
+        : toPluginVisibleVirtualId(realPath, isSsrRequest, querySuffix);
   }
 
   return null;
@@ -450,7 +454,7 @@ export async function resolveIdHook(
   state: VizePluginState,
   id: string,
   importer?: string,
-  options?: { ssr?: boolean },
+  options?: { ssr?: boolean; scan?: boolean },
 ): Promise<string | { id: string; external?: boolean } | null | undefined> {
   // Fast-return before request classification for the common case where neither
   // the id nor importer can involve a Vue SFC or Vize virtual module. This was
@@ -461,6 +465,7 @@ export async function resolveIdHook(
   }
 
   const isBuild = state.server === null;
+  const isDependencyScan = !!options?.scan;
   const importerRequest = importer ? classifyVitePluginRequest(importer) : null;
   const isSsrRequest =
     !!options?.ssr ||
@@ -470,6 +475,9 @@ export async function resolveIdHook(
   const pluginVisibleVirtualPath = fromPluginVisibleVirtualId(id);
 
   if (pluginVisibleVirtualPath) {
+    if (isDependencyScan) {
+      return toVirtualId(pluginVisibleVirtualPath, isSsrRequest);
+    }
     return isSsrRequest
       ? toPluginVisibleVirtualId(pluginVisibleVirtualPath, true, request.querySuffix)
       : id;
@@ -481,7 +489,9 @@ export async function resolveIdHook(
     // treats imports of Vize virtual modules from other virtual modules as resolved.
     if (request.isVizeVirtual) {
       if (isSsrRequest && !request.isVizeSsrVirtual && request.vizeVirtualPath) {
-        return toPluginVisibleVirtualId(request.vizeVirtualPath, true, request.querySuffix);
+        return isDependencyScan
+          ? toVirtualId(request.vizeVirtualPath, true)
+          : toPluginVisibleVirtualId(request.vizeVirtualPath, true, request.querySuffix);
       }
       return id;
     }
@@ -816,6 +826,7 @@ export async function resolveIdHook(
         handleNodeModules,
         request.querySuffix,
         preserveQueryAsPath,
+        isDependencyScan,
       );
       if (aliased) {
         return aliased;
@@ -844,7 +855,9 @@ export async function resolveIdHook(
       if (preserveQueryAsPath) {
         return `${resolved}${request.querySuffix}`;
       }
-      return toPluginVisibleVirtualId(resolved, isSsrRequest, request.querySuffix);
+      return isDependencyScan
+        ? toVirtualId(resolved, isSsrRequest)
+        : toPluginVisibleVirtualId(resolved, isSsrRequest, request.querySuffix);
     }
   }
 

--- a/npm/vite-plugin-vize/src/plugin/resolve.ts
+++ b/npm/vite-plugin-vize/src/plugin/resolve.ts
@@ -19,7 +19,9 @@ import {
   LEGACY_VIZE_PREFIX,
   VIRTUAL_CSS_MODULE,
   RESOLVED_CSS_MODULE,
-  toVirtualId,
+  fromPluginVisibleVirtualId,
+  isPluginVisibleSsrVirtualId,
+  toPluginVisibleVirtualId,
 } from "../virtual.ts";
 import { toNativeCssAliasRule } from "../utils/css.ts";
 
@@ -329,6 +331,7 @@ function isPotentialVizeResolveId(id: string): boolean {
     id === VIRTUAL_CSS_MODULE ||
     id.endsWith(".vue") ||
     id.includes(".vue?") ||
+    id.includes(".vue.ts?") ||
     id.includes("?macro=true") ||
     id.includes("?definePage")
   );
@@ -389,7 +392,7 @@ function cleanVueSfcImporter(
   importer: string,
   request: ReturnType<typeof classifyVitePluginRequest> | null,
 ): string {
-  let cleanImporter = request?.normalizedFsId ?? importer;
+  let cleanImporter = request?.normalizedFsId ?? request?.normalizedVuePath ?? importer;
 
   if (cleanImporter.startsWith("/@id/__x00__")) {
     cleanImporter = cleanImporter.slice("/@id/__x00__".length);
@@ -436,7 +439,7 @@ async function resolveAliasedVueImport(
     state.logger.log(`resolveId: resolved via Vite fallback ${id} to ${realPath}`);
     return preserveQueryAsPath
       ? `${realPath}${querySuffix}`
-      : `${toVirtualId(realPath, isSsrRequest)}${querySuffix}`;
+      : toPluginVisibleVirtualId(realPath, isSsrRequest, querySuffix);
   }
 
   return null;
@@ -459,8 +462,18 @@ export async function resolveIdHook(
 
   const isBuild = state.server === null;
   const importerRequest = importer ? classifyVitePluginRequest(importer) : null;
-  const isSsrRequest = !!options?.ssr || (importerRequest?.isVizeSsrVirtual ?? false);
+  const isSsrRequest =
+    !!options?.ssr ||
+    (importerRequest?.isVizeSsrVirtual ?? false) ||
+    (importer ? isPluginVisibleSsrVirtualId(importer) : false);
   const request = classifyVitePluginRequest(id);
+  const pluginVisibleVirtualPath = fromPluginVisibleVirtualId(id);
+
+  if (pluginVisibleVirtualPath) {
+    return isSsrRequest
+      ? toPluginVisibleVirtualId(pluginVisibleVirtualPath, true, request.querySuffix)
+      : id;
+  }
 
   // Skip all virtual module IDs
   if (id.startsWith("\0")) {
@@ -468,7 +481,7 @@ export async function resolveIdHook(
     // treats imports of Vize virtual modules from other virtual modules as resolved.
     if (request.isVizeVirtual) {
       if (isSsrRequest && !request.isVizeSsrVirtual && request.vizeVirtualPath) {
-        return `${toVirtualId(request.vizeVirtualPath, true)}${request.querySuffix}`;
+        return toPluginVisibleVirtualId(request.vizeVirtualPath, true, request.querySuffix);
       }
       return id;
     }
@@ -831,7 +844,7 @@ export async function resolveIdHook(
       if (preserveQueryAsPath) {
         return `${resolved}${request.querySuffix}`;
       }
-      return `${toVirtualId(resolved, isSsrRequest)}${request.querySuffix}`;
+      return toPluginVisibleVirtualId(resolved, isSsrRequest, request.querySuffix);
     }
   }
 

--- a/npm/vite-plugin-vize/src/virtual.test.ts
+++ b/npm/vite-plugin-vize/src/virtual.test.ts
@@ -1,6 +1,13 @@
 import assert from "node:assert/strict";
 
-import { fromVirtualId, isVizeVirtual, normalizeVizeVirtualVueModuleId } from "./virtual.ts";
+import {
+  fromPluginVisibleVirtualId,
+  fromVirtualId,
+  isPluginVisibleSsrVirtualId,
+  isVizeVirtual,
+  normalizeVizeVirtualVueModuleId,
+  toPluginVisibleVirtualId,
+} from "./virtual.ts";
 
 const clientVirtualId = "\0/repo/app/components/Foo.vue.ts?macro=true";
 const ssrVirtualId = "\0vize-ssr:/repo/app/components/Foo.vue.ts?vue&type=template";
@@ -36,6 +43,34 @@ assert.equal(
   normalizeVizeVirtualVueModuleId(ssrVirtualId),
   "/repo/app/components/Foo.vue?vue&type=template",
   "Normalized SSR virtual IDs should keep the original query string for downstream plugins",
+);
+
+const visibleVirtualId = toPluginVisibleVirtualId("/repo/app/components/Foo.vue");
+const visibleSsrVirtualId = toPluginVisibleVirtualId(
+  "/repo/app/components/Foo.vue",
+  true,
+  "?vue&used=true",
+);
+
+assert.equal(
+  visibleVirtualId,
+  "/repo/app/components/Foo.vue.ts?vue&vize",
+  "Plugin-visible virtual IDs should keep the Vue query without using a null-byte prefix",
+);
+assert.equal(
+  visibleSsrVirtualId,
+  "/repo/app/components/Foo.vue.ts?vue&vize-ssr&used=true",
+  "SSR plugin-visible virtual IDs should preserve non-Vize query parameters",
+);
+assert.equal(
+  fromPluginVisibleVirtualId(visibleVirtualId),
+  "/repo/app/components/Foo.vue",
+  "Plugin-visible virtual IDs should resolve back to the real .vue path",
+);
+assert.equal(
+  isPluginVisibleSsrVirtualId(visibleSsrVirtualId),
+  true,
+  "SSR plugin-visible virtual IDs should keep an explicit SSR marker",
 );
 
 console.log("✅ vite-plugin-vize virtual module tests passed!");

--- a/npm/vite-plugin-vize/src/virtual.ts
+++ b/npm/vite-plugin-vize/src/virtual.ts
@@ -44,6 +44,37 @@ export function toVirtualId(realPath: string, ssr = false): string {
   return createViteVirtualId(realPath, ssr);
 }
 
+export function toPluginVisibleVirtualId(realPath: string, ssr = false, querySuffix = ""): string {
+  const params = new URLSearchParams(querySuffix.startsWith("?") ? querySuffix.slice(1) : "");
+  params.delete("vue");
+  params.delete("vize");
+  params.delete("vize-ssr");
+  const rest = params.toString();
+  return `${realPath}.ts?vue&${ssr ? "vize-ssr" : "vize"}${rest ? `&${rest}` : ""}`;
+}
+
+export function fromPluginVisibleVirtualId(id: string): string | null {
+  if (id.startsWith("\0")) {
+    return null;
+  }
+  const request = classifyVitePluginRequest(id);
+  if (!request.path.endsWith(".vue.ts") || !request.querySuffix) {
+    return null;
+  }
+  const params = new URLSearchParams(request.querySuffix.slice(1));
+  if (!params.has("vue") || (!params.has("vize") && !params.has("vize-ssr"))) {
+    return null;
+  }
+  return classifyVitePluginRequest(request.normalizedFsId ?? id).normalizedVuePath;
+}
+
+export function isPluginVisibleSsrVirtualId(id: string): boolean {
+  const request = classifyVitePluginRequest(id);
+  return request.querySuffix
+    ? new URLSearchParams(request.querySuffix.slice(1)).has("vize-ssr")
+    : false;
+}
+
 /** Extract the real .vue file path from a virtual module ID */
 export function fromVirtualId(virtualId: string): string {
   return fromViteVirtualId(virtualId);


### PR DESCRIPTION
## Summary
- resolve compiled SFC modules with plugin-visible `.vue.ts?vue&vize` ids so post transforms can process them
- teach Vize load and transform hooks to handle those ids while preserving SSR markers
- explicitly claim raw `.vue` loads when a bundler pipeline bypasses resolve output
- keep resolve fixtures outside the repo tree so isolated dependency tests do not see ancestor node_modules

Closes #880
Closes #878
Closes #877

## Validation
- pnpm -C npm/vite-plugin-vize test
- pnpm -C npm/vite-plugin-vize check
- temporary Vite build with unplugin-auto-import object-form named import
- temporary Vite build with unplugin-vue-components component auto import
- temporary tsdown build with `dts: { vue: true }`