### PR TITLE
fix(type-checker): linearize v-else-if virtual TS

### DIFF
--- a/crates/vize_canon/snapshots/vize_canon__virtual_ts__tests__virtual_ts_nested_vif_velse_chain.snap
+++ b/crates/vize_canon/snapshots/vize_canon__virtual_ts__tests__virtual_ts_nested_vif_velse_chain.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/vize_canon/src/virtual_ts.rs
-assertion_line: 41
 expression: value
 ---
 /// <reference lib="es2022" />
@@ -93,15 +92,10 @@ function __setup() {
     const $emit = __ctx.$emit;
     void __ctx; void $attrs; void $slots; void $refs; void $emit;
 
-  if ((status === 'loading')) {
-    void (status === 'loading'); // VIf
+  if (status === 'loading') {
     // @vize-map: expr -> 19:39
-  }
-  if (!(status === 'loading') && (status === 'error')) {
-    void (status === 'error'); // VIf
+  } else if (status === 'error') {
     // @vize-map: expr -> 73:91
-  }
-  if (!(status === 'loading') && (status === 'error')) {
     void (message); // Interpolation
     // @vize-map: expr -> 96:103
   }

--- a/crates/vize_canon/src/snapshots/vize_canon__tests__virtual_ts_tests__virtual_ts_nested_v_if_v_else.snap
+++ b/crates/vize_canon/src/snapshots/vize_canon__tests__virtual_ts_tests__virtual_ts_nested_v_if_v_else.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/vize_canon/src/tests.rs
-assertion_line: 238
 expression: virtual_ts
 ---
 /// <reference lib="es2022" />
@@ -98,15 +97,10 @@ function __setup() {
     const $emit = __ctx.$emit;
     void __ctx; void $attrs; void $slots; void $refs; void $emit;
 
-  if ((status === 'loading')) {
-    void (status === 'loading'); // VIf
+  if (status === 'loading') {
     // @vize-map: expr -> 215:235
-  }
-  if (!(status === 'loading') && (status === 'error')) {
-    void (status === 'error'); // VIf
+  } else if (status === 'error') {
     // @vize-map: expr -> 274:292
-  }
-  if (!(status === 'loading') && (status === 'error')) {
     void (message); // Interpolation
     // @vize-map: expr -> 311:318
   }

--- a/crates/vize_canon/src/virtual_ts.rs
+++ b/crates/vize_canon/src/virtual_ts.rs
@@ -421,6 +421,56 @@ const message = ref('')
     }
 
     #[test]
+    fn test_v_else_if_chain_uses_linear_control_flow() {
+        use vize_croquis::{Analyzer, AnalyzerOptions};
+
+        let script = r#"type Log =
+  | { type: 't0'; info: { value0: string } }
+  | { type: 't1'; info: { value1: string } }
+  | { type: 't2'; info: { value2: string } }
+
+defineProps<{ log: Log }>()
+"#;
+        let template = r#"<div>
+  <span v-if="log.type === 't0'">{{ log.info.value0 }}</span>
+  <span v-else-if="log.type === 't1'">{{ log.info.value1 }}</span>
+  <span v-else-if="log.type === 't2'">{{ log.info.value2 }}</span>
+</div>"#;
+
+        let allocator = vize_carton::Bump::new();
+        let (root, _) = vize_armature::parse(&allocator, template);
+
+        let mut analyzer = Analyzer::with_options(AnalyzerOptions::full());
+        analyzer.analyze_script_setup(script);
+        analyzer.analyze_template(&root);
+        let summary = analyzer.finish();
+
+        let output = generate_virtual_ts(&summary, Some(script), Some(&root), 0);
+
+        assert!(
+            output.code.contains("if (log.type === 't0') {"),
+            "expected first branch to use native control flow:\n{}",
+            output.code
+        );
+        assert!(
+            output.code.contains("} else if (log.type === 't1') {")
+                && output.code.contains("} else if (log.type === 't2') {"),
+            "expected else-if branches to use native control flow:\n{}",
+            output.code
+        );
+        assert!(
+            !output.code.contains("!(log.type === 't0') &&"),
+            "virtual TS should not repeat cumulative negated branch guards:\n{}",
+            output.code
+        );
+        assert!(
+            !output.code.contains("void (log.type === 't1'); // VIf"),
+            "branch conditions should not be emitted again inside the branch body:\n{}",
+            output.code
+        );
+    }
+
+    #[test]
     fn test_scoped_slot_expressions() {
         use vize_croquis::{Analyzer, AnalyzerOptions};
 

--- a/crates/vize_canon/src/virtual_ts/expressions.rs
+++ b/crates/vize_canon/src/virtual_ts/expressions.rs
@@ -414,12 +414,7 @@ fn emit_vif_control_flow_chain(
         );
 
         let body_indent = cstr!("{indent}  ");
-        for (expr_index, expr) in exprs
-            .iter()
-            .enumerate()
-            .take(branch.end)
-            .skip(branch.start)
-        {
+        for (expr_index, expr) in exprs.iter().enumerate().take(branch.end).skip(branch.start) {
             if branch.condition_expr_index == Some(expr_index) {
                 continue;
             }

--- a/crates/vize_canon/src/virtual_ts/expressions.rs
+++ b/crates/vize_canon/src/virtual_ts/expressions.rs
@@ -398,6 +398,10 @@ fn emit_vif_control_flow_chain(
     template_offset: u32,
     indent: &str,
 ) {
+    let context = VifBranchEmitContext {
+        template_offset,
+        indent,
+    };
     for (branch_index, branch) in chain.branches.iter().enumerate() {
         emit_vif_branch_open(
             ts,
@@ -406,19 +410,23 @@ fn emit_vif_control_flow_chain(
             chain,
             branch,
             branch_index == 0,
-            template_offset,
-            indent,
+            &context,
         );
 
         let body_indent = cstr!("{indent}  ");
-        for expr_index in branch.start..branch.end {
+        for (expr_index, expr) in exprs
+            .iter()
+            .enumerate()
+            .take(branch.end)
+            .skip(branch.start)
+        {
             if branch.condition_expr_index == Some(expr_index) {
                 continue;
             }
             generate_expression_statement(
                 ts,
                 mappings,
-                exprs[expr_index],
+                expr,
                 template_prop_names,
                 template_offset,
                 &body_indent,
@@ -435,13 +443,12 @@ fn emit_vif_branch_open(
     chain: &VifControlFlowChain<'_>,
     branch: &VifBranch<'_>,
     first: bool,
-    template_offset: u32,
-    indent: &str,
+    context: &VifBranchEmitContext<'_>,
 ) {
     let prefix_is_empty = chain.prefix.is_empty();
     match (first, branch.condition) {
         (true, Some(condition)) => {
-            append!(*ts, "{indent}if (");
+            append!(*ts, "{}if (", context.indent);
             append_guard_condition(
                 ts,
                 &chain.prefix,
@@ -449,12 +456,12 @@ fn emit_vif_branch_open(
                 mappings,
                 exprs,
                 branch,
-                template_offset,
+                context.template_offset,
             );
             ts.push_str(") {\n");
         }
         (false, Some(condition)) => {
-            append!(*ts, "{indent}}} else if (");
+            append!(*ts, "{}}} else if (", context.indent);
             append_guard_condition(
                 ts,
                 &chain.prefix,
@@ -462,15 +469,15 @@ fn emit_vif_branch_open(
                 mappings,
                 exprs,
                 branch,
-                template_offset,
+                context.template_offset,
             );
             ts.push_str(") {\n");
         }
         (false, None) if prefix_is_empty => {
-            append!(*ts, "{indent}}} else {{\n");
+            append!(*ts, "{}}} else {{\n", context.indent);
         }
         (false, None) => {
-            append!(*ts, "{indent}}} else if (");
+            append!(*ts, "{}}} else if (", context.indent);
             append_guard_condition(
                 ts,
                 &chain.prefix,
@@ -478,7 +485,7 @@ fn emit_vif_branch_open(
                 mappings,
                 exprs,
                 branch,
-                template_offset,
+                context.template_offset,
             );
             ts.push_str(") {\n");
         }
@@ -487,13 +494,19 @@ fn emit_vif_branch_open(
 
     if let Some(expr_index) = branch.condition_expr_index {
         let expr = exprs[expr_index];
-        let src_start = (template_offset + expr.start) as usize;
-        let src_end = (template_offset + expr.end) as usize;
+        let src_start = (context.template_offset + expr.start) as usize;
+        let src_end = (context.template_offset + expr.end) as usize;
         append!(
             *ts,
-            "{indent}  // @vize-map: expr -> {src_start}:{src_end}\n",
+            "{}  // @vize-map: expr -> {src_start}:{src_end}\n",
+            context.indent,
         );
     }
+}
+
+struct VifBranchEmitContext<'a> {
+    template_offset: u32,
+    indent: &'a str,
 }
 
 fn append_guard_condition(

--- a/crates/vize_canon/src/virtual_ts/expressions.rs
+++ b/crates/vize_canon/src/virtual_ts/expressions.rs
@@ -14,8 +14,49 @@ use vize_carton::String;
 use vize_carton::append;
 use vize_carton::cstr;
 use vize_carton::profile;
-use vize_croquis::analysis::ComponentUsage;
+use vize_croquis::analysis::{ComponentUsage, TemplateExpression, TemplateExpressionKind};
 use vize_croquis::analyzer::strip_js_comments;
+
+/// Generate template expressions, compacting recognized v-if chains into
+/// TypeScript control-flow blocks.
+pub(crate) fn generate_expressions(
+    ts: &mut String,
+    mappings: &mut Vec<VizeMapping>,
+    exprs: &[&TemplateExpression],
+    template_prop_names: &FxHashSet<String>,
+    template_offset: u32,
+    indent: &str,
+) {
+    let mut index = 0;
+    while index < exprs.len() {
+        if let Some(chain) = VifControlFlowChain::collect(exprs, index) {
+            emit_vif_control_flow_chain(
+                ts,
+                mappings,
+                exprs,
+                &chain,
+                template_prop_names,
+                template_offset,
+                indent,
+            );
+            index = chain.end;
+            continue;
+        }
+
+        profile!(
+            "canon.virtual_ts.generate_expression",
+            generate_expression(
+                ts,
+                mappings,
+                exprs[index],
+                template_prop_names,
+                template_offset,
+                indent,
+            )
+        );
+        index += 1;
+    }
+}
 
 /// Generate a template expression with optional v-if narrowing.
 ///
@@ -30,6 +71,43 @@ pub(crate) fn generate_expression(
     ts: &mut String,
     mappings: &mut Vec<VizeMapping>,
     expr: &vize_croquis::TemplateExpression,
+    template_prop_names: &FxHashSet<String>,
+    template_offset: u32,
+    indent: &str,
+) {
+    if let Some(ref guard) = expr.vif_guard {
+        let trimmed_guard = guard.as_str().trim();
+        let rewritten_guard = rewrite_reserved_template_prop(trimmed_guard, template_prop_names);
+        let generated_guard = rewritten_guard
+            .as_ref()
+            .map_or_else(|| guard.as_str(), |s| s.as_str());
+        // Wrap in if block for type narrowing
+        append!(*ts, "{indent}if ({generated_guard}) {{\n");
+        generate_expression_statement(
+            ts,
+            mappings,
+            expr,
+            template_prop_names,
+            template_offset,
+            &cstr!("{indent}  "),
+        );
+        append!(*ts, "{indent}}}\n");
+    } else {
+        generate_expression_statement(
+            ts,
+            mappings,
+            expr,
+            template_prop_names,
+            template_offset,
+            indent,
+        );
+    }
+}
+
+fn generate_expression_statement(
+    ts: &mut String,
+    mappings: &mut Vec<VizeMapping>,
+    expr: &TemplateExpression,
     template_prop_names: &FxHashSet<String>,
     template_offset: u32,
     indent: &str,
@@ -52,56 +130,24 @@ pub(crate) fn generate_expression(
         expression.as_ref()
     };
 
-    if let Some(ref guard) = expr.vif_guard {
-        let trimmed_guard = guard.as_str().trim();
-        let rewritten_guard = rewrite_reserved_template_prop(trimmed_guard, template_prop_names);
-        let generated_guard = rewritten_guard
-            .as_ref()
-            .map_or_else(|| guard.as_str(), |s| s.as_str());
-        // Wrap in if block for type narrowing
-        append!(*ts, "{indent}if ({generated_guard}) {{\n");
-        let gen_stmt_start = ts.len();
-        append!(
-            *ts,
-            "{indent}  void ({}); // {}\n",
-            generated_expression,
-            expr.kind.as_str()
-        );
-        let gen_stmt_end = ts.len();
-        mappings.push(VizeMapping {
-            gen_range: generated_text_range(
-                &ts[gen_stmt_start..gen_stmt_end],
-                mapping_needle,
-                gen_stmt_start,
-            ),
-            src_range: src_start..src_end,
-            sub_spans: Vec::new(),
-        });
-        append!(
-            *ts,
-            "{indent}  // @vize-map: expr -> {src_start}:{src_end}\n",
-        );
-        append!(*ts, "{indent}}}\n");
-    } else {
-        let gen_stmt_start = ts.len();
-        append!(
-            *ts,
-            "{indent}void ({}); // {}\n",
-            generated_expression,
-            expr.kind.as_str()
-        );
-        let gen_stmt_end = ts.len();
-        mappings.push(VizeMapping {
-            gen_range: generated_text_range(
-                &ts[gen_stmt_start..gen_stmt_end],
-                mapping_needle,
-                gen_stmt_start,
-            ),
-            src_range: src_start..src_end,
-            sub_spans: Vec::new(),
-        });
-        append!(*ts, "{indent}// @vize-map: expr -> {src_start}:{src_end}\n",);
-    }
+    let gen_stmt_start = ts.len();
+    append!(
+        *ts,
+        "{indent}void ({}); // {}\n",
+        generated_expression,
+        expr.kind.as_str()
+    );
+    let gen_stmt_end = ts.len();
+    mappings.push(VizeMapping {
+        gen_range: generated_text_range(
+            &ts[gen_stmt_start..gen_stmt_end],
+            mapping_needle,
+            gen_stmt_start,
+        ),
+        src_range: src_start..src_end,
+        sub_spans: Vec::new(),
+    });
+    append!(*ts, "{indent}// @vize-map: expr -> {src_start}:{src_end}\n",);
 }
 
 fn rewrite_reserved_template_prop(
@@ -112,6 +158,383 @@ fn rewrite_reserved_template_prop(
         return None;
     }
     Some(cstr!("props[\"{expression}\"]"))
+}
+
+#[derive(Clone, Copy)]
+struct GuardTerm<'a> {
+    negated: bool,
+    condition: &'a str,
+    raw: &'a str,
+}
+
+struct VifBranch<'a> {
+    condition: Option<&'a str>,
+    start: usize,
+    end: usize,
+    condition_expr_index: Option<usize>,
+}
+
+struct VifControlFlowChain<'a> {
+    prefix: Vec<GuardTerm<'a>>,
+    branches: Vec<VifBranch<'a>>,
+    end: usize,
+}
+
+impl<'a> VifControlFlowChain<'a> {
+    fn collect(exprs: &[&'a TemplateExpression], start: usize) -> Option<Self> {
+        let first = collect_guard_group(exprs, start)?;
+        let first_terms = parse_guard_terms(first.guard)?;
+        let (&first_condition, prefix) = first_terms.split_last()?;
+        if first_condition.negated {
+            return None;
+        }
+
+        let mut previous_conditions = vec![first_condition.condition];
+        let mut branches = vec![VifBranch {
+            condition: Some(first_condition.condition),
+            start: first.start,
+            end: first.end,
+            condition_expr_index: find_branch_condition_expr(
+                exprs,
+                first.start,
+                first.end,
+                first_condition.condition,
+            ),
+        }];
+        let mut cursor = first.end;
+
+        while cursor < exprs.len() {
+            let Some(group) = collect_guard_group(exprs, cursor) else {
+                break;
+            };
+            let Some(terms) = parse_guard_terms(group.guard) else {
+                break;
+            };
+            if !prefix_matches(prefix, &terms) {
+                break;
+            }
+
+            let chain_terms = &terms[prefix.len()..];
+            if previous_negations_match(chain_terms, &previous_conditions)
+                && chain_terms.len() == previous_conditions.len() + 1
+                && let Some(current) = chain_terms.last()
+                && !current.negated
+            {
+                previous_conditions.push(current.condition);
+                branches.push(VifBranch {
+                    condition: Some(current.condition),
+                    start: group.start,
+                    end: group.end,
+                    condition_expr_index: find_branch_condition_expr(
+                        exprs,
+                        group.start,
+                        group.end,
+                        current.condition,
+                    ),
+                });
+                cursor = group.end;
+                continue;
+            }
+
+            if previous_negations_match(chain_terms, &previous_conditions)
+                && chain_terms.len() == previous_conditions.len()
+            {
+                branches.push(VifBranch {
+                    condition: None,
+                    start: group.start,
+                    end: group.end,
+                    condition_expr_index: None,
+                });
+                cursor = group.end;
+            }
+            break;
+        }
+
+        if branches.len() < 2 {
+            return None;
+        }
+
+        Some(Self {
+            prefix: prefix.to_vec(),
+            branches,
+            end: cursor,
+        })
+    }
+}
+
+struct GuardGroup<'a> {
+    guard: &'a str,
+    start: usize,
+    end: usize,
+}
+
+fn collect_guard_group<'a>(
+    exprs: &[&'a TemplateExpression],
+    start: usize,
+) -> Option<GuardGroup<'a>> {
+    let guard = exprs.get(start)?.vif_guard.as_ref()?.as_str();
+    let mut end = start + 1;
+    while end < exprs.len() && exprs[end].vif_guard.as_ref().is_some_and(|g| g == guard) {
+        end += 1;
+    }
+    Some(GuardGroup { guard, start, end })
+}
+
+fn parse_guard_terms(guard: &str) -> Option<Vec<GuardTerm<'_>>> {
+    let mut terms = Vec::new();
+    for term in split_top_level_and(guard) {
+        let raw = term.trim();
+        if raw.is_empty() {
+            return None;
+        }
+        if let Some(condition) = strip_negated_wrapped_condition(raw) {
+            terms.push(GuardTerm {
+                negated: true,
+                condition,
+                raw,
+            });
+        } else if let Some(condition) = strip_wrapped_condition(raw) {
+            terms.push(GuardTerm {
+                negated: false,
+                condition,
+                raw,
+            });
+        } else {
+            return None;
+        }
+    }
+    (!terms.is_empty()).then_some(terms)
+}
+
+fn split_top_level_and(input: &str) -> Vec<&str> {
+    let bytes = input.as_bytes();
+    let mut parts = Vec::new();
+    let mut depth = 0usize;
+    let mut start = 0usize;
+    let mut index = 0usize;
+
+    while index < bytes.len() {
+        match bytes[index] {
+            b'(' => depth += 1,
+            b')' => depth = depth.saturating_sub(1),
+            b'&' if depth == 0
+                && bytes.get(index + 1) == Some(&b'&')
+                && is_ascii_space(bytes.get(index.wrapping_sub(1)).copied())
+                && is_ascii_space(bytes.get(index + 2).copied()) =>
+            {
+                parts.push(&input[start..index - 1]);
+                index += 3;
+                start = index;
+                continue;
+            }
+            _ => {}
+        }
+        index += 1;
+    }
+
+    parts.push(&input[start..]);
+    parts
+}
+
+fn is_ascii_space(byte: Option<u8>) -> bool {
+    byte.is_some_and(|b| b.is_ascii_whitespace())
+}
+
+fn strip_negated_wrapped_condition(input: &str) -> Option<&str> {
+    input
+        .strip_prefix("!(")
+        .and_then(|rest| rest.strip_suffix(')'))
+}
+
+fn strip_wrapped_condition(input: &str) -> Option<&str> {
+    input
+        .strip_prefix('(')
+        .and_then(|rest| rest.strip_suffix(')'))
+}
+
+fn prefix_matches(prefix: &[GuardTerm<'_>], terms: &[GuardTerm<'_>]) -> bool {
+    if terms.len() < prefix.len() {
+        return false;
+    }
+    prefix
+        .iter()
+        .zip(terms.iter())
+        .all(|(a, b)| a.negated == b.negated && a.condition == b.condition)
+}
+
+fn previous_negations_match(terms: &[GuardTerm<'_>], previous_conditions: &[&str]) -> bool {
+    if terms.len() < previous_conditions.len() {
+        return false;
+    }
+    terms
+        .iter()
+        .take(previous_conditions.len())
+        .zip(previous_conditions.iter())
+        .all(|(term, condition)| term.negated && term.condition == *condition)
+}
+
+fn find_branch_condition_expr(
+    exprs: &[&TemplateExpression],
+    start: usize,
+    end: usize,
+    condition: &str,
+) -> Option<usize> {
+    let trimmed_condition = condition.trim();
+    (start..end).find(|&idx| {
+        exprs[idx].kind == TemplateExpressionKind::VIf
+            && strip_js_comments(exprs[idx].content.as_str())
+                .as_ref()
+                .trim()
+                == trimmed_condition
+    })
+}
+
+fn emit_vif_control_flow_chain(
+    ts: &mut String,
+    mappings: &mut Vec<VizeMapping>,
+    exprs: &[&TemplateExpression],
+    chain: &VifControlFlowChain<'_>,
+    template_prop_names: &FxHashSet<String>,
+    template_offset: u32,
+    indent: &str,
+) {
+    for (branch_index, branch) in chain.branches.iter().enumerate() {
+        emit_vif_branch_open(
+            ts,
+            mappings,
+            exprs,
+            chain,
+            branch,
+            branch_index == 0,
+            template_offset,
+            indent,
+        );
+
+        let body_indent = cstr!("{indent}  ");
+        for expr_index in branch.start..branch.end {
+            if branch.condition_expr_index == Some(expr_index) {
+                continue;
+            }
+            generate_expression_statement(
+                ts,
+                mappings,
+                exprs[expr_index],
+                template_prop_names,
+                template_offset,
+                &body_indent,
+            );
+        }
+    }
+    append!(*ts, "{indent}}}\n");
+}
+
+fn emit_vif_branch_open(
+    ts: &mut String,
+    mappings: &mut Vec<VizeMapping>,
+    exprs: &[&TemplateExpression],
+    chain: &VifControlFlowChain<'_>,
+    branch: &VifBranch<'_>,
+    first: bool,
+    template_offset: u32,
+    indent: &str,
+) {
+    let prefix_is_empty = chain.prefix.is_empty();
+    match (first, branch.condition) {
+        (true, Some(condition)) => {
+            append!(*ts, "{indent}if (");
+            append_guard_condition(
+                ts,
+                &chain.prefix,
+                Some(condition),
+                mappings,
+                exprs,
+                branch,
+                template_offset,
+            );
+            ts.push_str(") {\n");
+        }
+        (false, Some(condition)) => {
+            append!(*ts, "{indent}}} else if (");
+            append_guard_condition(
+                ts,
+                &chain.prefix,
+                Some(condition),
+                mappings,
+                exprs,
+                branch,
+                template_offset,
+            );
+            ts.push_str(") {\n");
+        }
+        (false, None) if prefix_is_empty => {
+            append!(*ts, "{indent}}} else {{\n");
+        }
+        (false, None) => {
+            append!(*ts, "{indent}}} else if (");
+            append_guard_condition(
+                ts,
+                &chain.prefix,
+                None,
+                mappings,
+                exprs,
+                branch,
+                template_offset,
+            );
+            ts.push_str(") {\n");
+        }
+        (true, None) => {}
+    }
+
+    if let Some(expr_index) = branch.condition_expr_index {
+        let expr = exprs[expr_index];
+        let src_start = (template_offset + expr.start) as usize;
+        let src_end = (template_offset + expr.end) as usize;
+        append!(
+            *ts,
+            "{indent}  // @vize-map: expr -> {src_start}:{src_end}\n",
+        );
+    }
+}
+
+fn append_guard_condition(
+    ts: &mut String,
+    prefix: &[GuardTerm<'_>],
+    condition: Option<&str>,
+    mappings: &mut Vec<VizeMapping>,
+    exprs: &[&TemplateExpression],
+    branch: &VifBranch<'_>,
+    template_offset: u32,
+) {
+    append_guard_prefix(ts, prefix);
+    if let Some(condition) = condition {
+        if !prefix.is_empty() {
+            ts.push_str(" && (");
+        }
+        let gen_start = ts.len();
+        ts.push_str(condition);
+        let gen_end = ts.len();
+        if let Some(expr_index) = branch.condition_expr_index {
+            let expr = exprs[expr_index];
+            mappings.push(VizeMapping {
+                gen_range: gen_start..gen_end,
+                src_range: (template_offset + expr.start) as usize
+                    ..(template_offset + expr.end) as usize,
+                sub_spans: Vec::new(),
+            });
+        }
+        if !prefix.is_empty() {
+            ts.push(')');
+        }
+    }
+}
+
+fn append_guard_prefix(ts: &mut String, prefix: &[GuardTerm<'_>]) {
+    for (index, term) in prefix.iter().enumerate() {
+        if index > 0 {
+            ts.push_str(" && ");
+        }
+        ts.push_str(term.raw);
+    }
 }
 
 /// Generate component prop value checks at the given indentation level.

--- a/crates/vize_canon/src/virtual_ts/scope.rs
+++ b/crates/vize_canon/src/virtual_ts/scope.rs
@@ -15,7 +15,7 @@ use vize_croquis::{
 };
 
 use super::{
-    expressions::{generate_component_prop_checks, generate_expression},
+    expressions::{generate_component_prop_checks, generate_expressions},
     helpers::{
         generated_text_range, get_dom_event_type, to_camel_case, to_safe_identifier,
         to_safe_identifier_fragment,
@@ -137,19 +137,14 @@ pub(crate) fn generate_scope_closures(
             if let Some(exprs) = expressions_by_scope.get(&scope_id)
                 && check_options.check_template_bindings
             {
-                for expr in exprs {
-                    profile!(
-                        "canon.virtual_ts.generate_expression",
-                        generate_expression(
-                            ts,
-                            mappings,
-                            expr,
-                            template_prop_names,
-                            template_offset,
-                            "  "
-                        )
-                    );
-                }
+                generate_expressions(
+                    ts,
+                    mappings,
+                    exprs,
+                    template_prop_names,
+                    template_offset,
+                    "  ",
+                );
             }
             continue;
         }
@@ -640,19 +635,14 @@ fn generate_scope_node(
             if let Some(exprs) = ctx.expressions_by_scope.get(&scope_id)
                 && ctx.check_options.check_template_bindings
             {
-                for expr in exprs {
-                    profile!(
-                        "canon.virtual_ts.generate_expression",
-                        generate_expression(
-                            ts,
-                            mappings,
-                            expr,
-                            ctx.template_prop_names,
-                            ctx.template_offset,
-                            &inner_indent
-                        )
-                    );
-                }
+                generate_expressions(
+                    ts,
+                    mappings,
+                    exprs,
+                    ctx.template_prop_names,
+                    ctx.template_offset,
+                    &inner_indent,
+                );
             }
 
             // Recursively generate child scopes inside this closure
@@ -688,19 +678,14 @@ fn generate_scope_node(
             if let Some(exprs) = ctx.expressions_by_scope.get(&scope_id)
                 && ctx.check_options.check_template_bindings
             {
-                for expr in exprs {
-                    profile!(
-                        "canon.virtual_ts.generate_expression",
-                        generate_expression(
-                            ts,
-                            mappings,
-                            expr,
-                            ctx.template_prop_names,
-                            ctx.template_offset,
-                            &inner_indent
-                        )
-                    );
-                }
+                generate_expressions(
+                    ts,
+                    mappings,
+                    exprs,
+                    ctx.template_prop_names,
+                    ctx.template_offset,
+                    &inner_indent,
+                );
             }
 
             // Recursively generate child scopes inside this closure
@@ -801,19 +786,14 @@ fn generate_scope_node(
             if let Some(exprs) = ctx.expressions_by_scope.get(&scope_id)
                 && ctx.check_options.check_template_bindings
             {
-                for expr in exprs {
-                    profile!(
-                        "canon.virtual_ts.generate_expression",
-                        generate_expression(
-                            ts,
-                            mappings,
-                            expr,
-                            ctx.template_prop_names,
-                            ctx.template_offset,
-                            indent
-                        )
-                    );
-                }
+                generate_expressions(
+                    ts,
+                    mappings,
+                    exprs,
+                    ctx.template_prop_names,
+                    ctx.template_offset,
+                    indent,
+                );
             }
         }
     }


### PR DESCRIPTION
Summary
- emit recoverable v-if / v-else-if / v-else guard groups as one TypeScript control-flow chain
- map branch condition diagnostics from the generated if/else-if condition instead of emitting duplicate body checks
- keep existing guarded expression output as a fallback for unrecognized guard shapes

Closes #876

Validation
- cargo test -p vize_canon

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/890"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783008099&installation_id=136613492&pr_number=890&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F890&signature=2d77e281d481f9af528c546afc822033428c4898ff2d1c2e80b3ffc85ce963dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->