### PR TITLE
fix(check): isolate declaration emit config

### DIFF
--- a/crates/vize_canon/src/batch/type_checker/tests.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests.rs
@@ -842,6 +842,76 @@ const props = defineProps<PublicProps>()
     let _ = std::fs::remove_dir_all(&project_root);
 }
 
+#[test]
+fn batch_type_checker_declaration_emit_keeps_paths_alias_imports_in_virtual_project() {
+    if resolve_test_tsgo_binary().is_none() {
+        return;
+    }
+    let project_root = create_project_case(
+        "declaration-path-alias",
+        &[
+            (
+                "src/App.vue",
+                r#"<script setup lang="ts">
+import { answer } from '@/helper'
+
+const value = answer
+</script>
+
+<template>
+  <div>{{ value }}</div>
+</template>
+"#,
+            ),
+            ("src/helper.ts", "export const answer = 42;\n"),
+            (
+                "src/index.ts",
+                r#"export { default as App } from './App.vue'
+export { answer } from '@/helper'
+"#,
+            ),
+        ],
+    );
+    std::fs::write(
+        project_root.join("tsconfig.json"),
+        r#"{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    },
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts", "src/**/*.vue"]
+}"#,
+    )
+    .unwrap();
+
+    let mut checker = match BatchTypeChecker::new(&project_root) {
+        Ok(checker) => checker,
+        Err(_) => return,
+    };
+    checker.scan_project().unwrap();
+    let out_dir = project_root.join("types");
+    let emitted = checker
+        .emit_declarations(&DeclarationEmitOptions::new(out_dir.clone()))
+        .unwrap();
+    let mut paths: Vec<_> = emitted
+        .files
+        .into_iter()
+        .map(|file| relative_path(&out_dir, &file.path))
+        .collect();
+    paths.sort();
+
+    assert_eq!(paths, vec!["App.vue.d.ts", "helper.d.ts", "index.d.ts"]);
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}
+
 fn relative_path(root: &std::path::Path, file: &std::path::Path) -> String {
     file.strip_prefix(root)
         .map(|path| cstr!("{}", path.display()))

--- a/crates/vize_canon/src/batch/virtual_project.rs
+++ b/crates/vize_canon/src/batch/virtual_project.rs
@@ -530,7 +530,9 @@ impl VirtualProject {
     ) -> CorsaResult<Value> {
         let mut config = Map::new();
         let original_tsconfig = self.resolved_tsconfig_path();
-        if let Some(ref tsconfig_path) = original_tsconfig {
+        if out_dir.is_none()
+            && let Some(ref tsconfig_path) = original_tsconfig
+        {
             config.insert(
                 "extends".into(),
                 Value::String(tsconfig_path.to_string_lossy().into_owned()),


### PR DESCRIPTION
Summary
- build declaration emit tsconfig from resolved compilerOptions without extending the source tsconfig
- keep alias remaps pointed at the virtual mirror during declaration emit
- add a paths-alias declaration emit regression test covering Vue and TS outputs

Root cause
- the generated declaration tsconfig copied path-sensitive options out of compilerOptions, but still extended the source tsconfig, so baseUrl/rootDir-like settings could re-enter through inheritance and resolve aliases outside the virtual project.

Closes #872

Validation
- cargo fmt --all -- --check
- cargo clippy -p vize_canon -- -D warnings
- cargo test -p vize_canon

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/891"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783008722&installation_id=136613492&pr_number=891&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F891&signature=8c2e9d006d88f89a9268ec16ebe07eba94587ce8c23018fbacbb34ce2efd5be2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->