### PR TITLE
fix(check): honor referenced tsconfig projects

### DIFF
--- a/crates/vize/src/commands/check/runner.rs
+++ b/crates/vize/src/commands/check/runner.rs
@@ -28,7 +28,7 @@ use super::{
     reporting::{JsonFileResult, JsonOutput},
     tsconfig_inputs::{
         TsconfigDeclarationOptions, collect_ambient_declaration_files, collect_default_check_files,
-        load_tsconfig_declaration_options,
+        load_tsconfig_declaration_options, resolve_tsconfig_for_files,
     },
 };
 
@@ -97,6 +97,11 @@ pub(crate) fn run_direct(args: &CheckArgs) {
     } else {
         collect_check_files(&args.patterns)
     };
+    let explicit_files = if args.patterns.is_empty() {
+        Vec::new()
+    } else {
+        files.clone()
+    };
     let collect_time = collect_start.elapsed();
 
     // For an explicit subset, only the requested files' diagnostics are
@@ -153,13 +158,20 @@ pub(crate) fn run_direct(args: &CheckArgs) {
     let project_root = resolve_project_root(effective_tsconfig.as_deref(), &cwd, &files);
     let tsconfig_path =
         resolve_tsconfig_path(effective_tsconfig.as_deref(), &cwd, &project_root, &files);
+    let program_tsconfig_path = if args.patterns.is_empty() {
+        tsconfig_path.clone()
+    } else {
+        resolve_tsconfig_for_files(tsconfig_path.as_deref(), &explicit_files)
+    };
 
     // An explicit file subset (`vize check src/App.vue`) omits ambient
     // declaration files, since nothing imports them; `declare global` types
     // would then be missing and surface as false `TS2304` errors. Pull the
     // tsconfig program's `.d.ts` files back in so global types stay in scope.
-    if !args.patterns.is_empty() && tsconfig_path.is_some() {
-        for path in collect_ambient_declaration_files(&project_root, tsconfig_path.as_deref()) {
+    if !args.patterns.is_empty() && program_tsconfig_path.is_some() {
+        for path in
+            collect_ambient_declaration_files(&project_root, program_tsconfig_path.as_deref())
+        {
             if !files.contains(&path) {
                 files.push(path);
             }
@@ -183,7 +195,7 @@ pub(crate) fn run_direct(args: &CheckArgs) {
     let mut checker = match BatchTypeChecker::with_options_and_corsa_path(
         &project_root,
         BatchTypeCheckerOptions {
-            tsconfig_path: tsconfig_path.clone(),
+            tsconfig_path: program_tsconfig_path.clone(),
             virtual_ts_options,
         },
         effective_corsa_path.as_deref(),
@@ -259,7 +271,7 @@ pub(crate) fn run_direct(args: &CheckArgs) {
     let emitted_declarations = if args.declaration {
         let declaration_options = resolve_declaration_emit_options(
             args.declaration_dir.as_deref(),
-            tsconfig_path.as_deref(),
+            program_tsconfig_path.as_deref(),
             &project_root,
         );
         let declaration_dir = declaration_options.out_dir.clone();

--- a/crates/vize/src/commands/check/tsconfig_inputs.rs
+++ b/crates/vize/src/commands/check/tsconfig_inputs.rs
@@ -133,9 +133,30 @@ fn collect_default_check_files_inner(
         return collect_supported_files(project_root, &[], &[]);
     };
 
-    let spec = load_tsconfig_inputs(tsconfig_path).unwrap_or_default();
     let mut files = Vec::new();
     let mut seen = FxHashSet::default();
+    for tsconfig_path in collect_tsconfig_project_paths(tsconfig_path) {
+        collect_default_check_files_for_tsconfig(
+            project_root,
+            &tsconfig_path,
+            include_hidden_tsconfig_roots,
+            &mut files,
+            &mut seen,
+        );
+    }
+
+    files.sort();
+    files
+}
+
+fn collect_default_check_files_for_tsconfig(
+    project_root: &Path,
+    tsconfig_path: &Path,
+    include_hidden_tsconfig_roots: bool,
+    files: &mut Vec<PathBuf>,
+    seen: &mut FxHashSet<PathBuf>,
+) {
+    let spec = load_tsconfig_inputs(tsconfig_path).unwrap_or_default();
 
     for file in spec.files {
         let resolved = normalize_input_path(&file.resolve());
@@ -191,9 +212,50 @@ fn collect_default_check_files_inner(
             }
         }
     }
+}
 
-    files.sort();
-    files
+pub(crate) fn resolve_tsconfig_for_files(
+    tsconfig_path: Option<&Path>,
+    files: &[PathBuf],
+) -> Option<PathBuf> {
+    let tsconfig_path = tsconfig_path?;
+    let projects = collect_tsconfig_project_paths(tsconfig_path);
+    let root_project = projects
+        .first()
+        .cloned()
+        .unwrap_or_else(|| normalize_input_path(tsconfig_path));
+    let files = files
+        .iter()
+        .filter(|path| is_supported_check_file(path))
+        .map(|path| normalize_input_path(path))
+        .collect::<Vec<_>>();
+    if files.is_empty() {
+        return Some(root_project);
+    }
+
+    if let Some(owner) = projects
+        .iter()
+        .find(|project| files.iter().all(|file| tsconfig_owns_file(project, file)))
+    {
+        return Some(owner.clone());
+    }
+
+    let mut shared_owner = None::<PathBuf>;
+    for file in &files {
+        let Some(owner) = projects
+            .iter()
+            .find(|project| tsconfig_owns_file(project, file))
+        else {
+            return Some(root_project);
+        };
+        match &shared_owner {
+            Some(shared) if shared != owner => return Some(root_project),
+            Some(_) => {}
+            None => shared_owner = Some(owner.clone()),
+        }
+    }
+
+    shared_owner.or(Some(root_project))
 }
 
 /// Collect ambient declaration (`.d.ts`) files that belong to the tsconfig
@@ -520,6 +582,72 @@ fn matches_tsconfig_patterns(path: &Path, includes: &[GlobSpec], excludes: &[Glo
     !excludes.iter().any(|glob| glob.matches(path))
 }
 
+fn tsconfig_owns_file(tsconfig_path: &Path, file: &Path) -> bool {
+    let Some(spec) = load_tsconfig_inputs(tsconfig_path) else {
+        return false;
+    };
+    let file = normalize_input_path(file);
+    if spec
+        .files
+        .iter()
+        .any(|entry| normalize_input_path(&entry.resolve()) == file)
+    {
+        return true;
+    }
+
+    let default_base_dir = tsconfig_path
+        .parent()
+        .map(Path::to_path_buf)
+        .unwrap_or_default();
+    let includes = if !spec.has_includes && !spec.has_files {
+        GlobSpec::new(&default_base_dir, "**/*")
+            .into_iter()
+            .collect::<Vec<_>>()
+    } else {
+        spec.includes
+    };
+    if includes.is_empty() || !is_supported_check_file(&file) {
+        return false;
+    }
+    let excludes = if !spec.has_excludes {
+        default_exclude_specs(&default_base_dir)
+    } else {
+        spec.excludes
+    };
+
+    matches_tsconfig_patterns(&file, &includes, &excludes)
+}
+
+fn collect_tsconfig_project_paths(tsconfig_path: &Path) -> Vec<PathBuf> {
+    let mut paths = Vec::new();
+    let mut seen = FxHashSet::default();
+    collect_tsconfig_project_paths_inner(tsconfig_path, &mut seen, &mut paths);
+    paths
+}
+
+fn collect_tsconfig_project_paths_inner(
+    tsconfig_path: &Path,
+    seen: &mut FxHashSet<PathBuf>,
+    paths: &mut Vec<PathBuf>,
+) {
+    let resolved = normalize_input_path(tsconfig_path);
+    if !seen.insert(resolved.clone()) {
+        return;
+    }
+    paths.push(resolved.clone());
+
+    let Ok(content) = tracked_read_to_string(&resolved) else {
+        return;
+    };
+    let value = parse_jsonc_value(&content).unwrap_or(Value::Null);
+    for reference in read_reference_entries(&value) {
+        let Some(reference_path) = resolve_referenced_tsconfig(&resolved, &reference) else {
+            continue;
+        };
+        collect_tsconfig_project_paths_inner(&reference_path, seen, paths);
+    }
+}
+
 fn load_tsconfig_inputs(tsconfig_path: &Path) -> Option<TsconfigInputSpec> {
     let mut seen = FxHashSet::default();
     load_tsconfig_inputs_inner(tsconfig_path, &mut seen).ok()
@@ -639,6 +767,19 @@ fn resolve_extended_tsconfig(tsconfig_path: &Path, extends: &str) -> Option<Path
     candidates.into_iter().find(|candidate| candidate.is_file())
 }
 
+fn resolve_referenced_tsconfig(tsconfig_path: &Path, reference: &str) -> Option<PathBuf> {
+    let base_dir = tsconfig_path.parent().unwrap_or(Path::new("."));
+    let reference_path = Path::new(reference);
+    let base = if reference_path.is_absolute() {
+        reference_path.to_path_buf()
+    } else {
+        base_dir.join(reference_path)
+    };
+    let mut candidates = Vec::new();
+    push_tsconfig_candidates(&mut candidates, base);
+    candidates.into_iter().find(|candidate| candidate.is_file())
+}
+
 fn resolve_tsconfig_path_option(base_dir: &Path, value: &str) -> PathBuf {
     let path = Path::new(value);
     if path.is_absolute() {
@@ -753,6 +894,17 @@ fn read_extends_entries(value: &Value) -> Vec<std::string::String> {
             .collect(),
         _ => Vec::new(),
     }
+}
+
+fn read_reference_entries(value: &Value) -> Vec<std::string::String> {
+    value
+        .get("references")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(|item| item.get("path").and_then(Value::as_str))
+        .map(std::string::String::from)
+        .collect()
 }
 
 fn normalize_tsconfig_glob(value: &str) -> std::string::String {
@@ -1008,7 +1160,7 @@ fn strip_trailing_commas(content: &str) -> std::string::String {
 mod tests {
     use super::{
         collect_ambient_declaration_files, collect_default_check_files,
-        load_tsconfig_declaration_options, resolve_extended_tsconfig,
+        load_tsconfig_declaration_options, resolve_extended_tsconfig, resolve_tsconfig_for_files,
     };
     use std::fs;
     use std::path::{Path, PathBuf};
@@ -1439,6 +1591,87 @@ mod tests {
         let files = collect_default_check_files(&case_dir, Some(&case_dir.join("tsconfig.json")));
 
         assert_eq!(files, vec![case_dir.join("src/entry.ts")]);
+
+        let _ = fs::remove_dir_all(&case_dir);
+    }
+
+    #[test]
+    fn default_collection_follows_referenced_tsconfigs() {
+        let case_dir = unique_case_dir("tsconfig-references");
+        let _ = fs::remove_dir_all(&case_dir);
+        fs::create_dir_all(case_dir.join(".generated")).unwrap();
+        fs::create_dir_all(case_dir.join("src")).unwrap();
+        fs::write(case_dir.join("src/App.vue"), "<template />").unwrap();
+        fs::write(
+            case_dir.join(".generated/types.d.ts"),
+            "declare const X: true",
+        )
+        .unwrap();
+        fs::write(
+            case_dir.join("tsconfig.json"),
+            r#"{
+  "files": [],
+  "references": [{ "path": "./.generated/tsconfig.app.json" }]
+}"#,
+        )
+        .unwrap();
+        fs::write(
+            case_dir.join(".generated/tsconfig.app.json"),
+            r#"{
+  "include": ["./types.d.ts", "../src/**/*.vue"]
+}"#,
+        )
+        .unwrap();
+
+        let files = collect_default_check_files(&case_dir, Some(&case_dir.join("tsconfig.json")));
+
+        assert!(files.iter().any(|path| path.ends_with("src/App.vue")));
+        assert!(
+            !files
+                .iter()
+                .any(|path| path.ends_with(".generated/types.d.ts")),
+            "normal default scan keeps hidden generated roots ignored: {files:?}"
+        );
+
+        let ambient =
+            collect_ambient_declaration_files(&case_dir, Some(&case_dir.join("tsconfig.json")));
+        assert!(
+            ambient
+                .iter()
+                .any(|path| path.ends_with(".generated/types.d.ts")),
+            "ambient scan should include hidden referenced declaration roots: {ambient:?}"
+        );
+
+        let _ = fs::remove_dir_all(&case_dir);
+    }
+
+    #[test]
+    fn tsconfig_for_files_uses_referenced_owner() {
+        let case_dir = unique_case_dir("tsconfig-reference-owner");
+        let _ = fs::remove_dir_all(&case_dir);
+        fs::create_dir_all(case_dir.join(".generated")).unwrap();
+        fs::create_dir_all(case_dir.join("src")).unwrap();
+        let app = case_dir.join("src/App.vue");
+        fs::write(&app, "<template />").unwrap();
+        fs::write(
+            case_dir.join("tsconfig.json"),
+            r#"{
+  "files": [],
+  "references": [{ "path": "./.generated/tsconfig.app.json" }]
+}"#,
+        )
+        .unwrap();
+        fs::write(
+            case_dir.join(".generated/tsconfig.app.json"),
+            r#"{
+  "include": ["../src/**/*.vue"]
+}"#,
+        )
+        .unwrap();
+
+        let owner = resolve_tsconfig_for_files(Some(&case_dir.join("tsconfig.json")), &[app]);
+
+        assert_eq!(owner, Some(case_dir.join(".generated/tsconfig.app.json")));
 
         let _ = fs::remove_dir_all(&case_dir);
     }

--- a/crates/vize/tests/check_cli.rs
+++ b/crates/vize/tests/check_cli.rs
@@ -990,6 +990,125 @@ const tab: GlobalTabType = "default";
 }
 
 #[test]
+fn check_solution_tsconfig_uses_referenced_project_for_explicit_file() {
+    let Some(corsa_path) = resolve_test_corsa_path() else {
+        return;
+    };
+    let project_root = create_cli_project(
+        "solution-tsconfig-references",
+        &[(
+            "src/App.vue",
+            r##"<script setup lang="ts">
+import { getEntry, type Registry } from "#registry";
+
+const entry = getEntry("home");
+const same: Registry["home"] = entry;
+</script>
+
+<template>
+  <div>{{ same.title }}</div>
+</template>
+"##,
+        )],
+    );
+    std::fs::create_dir_all(project_root.join(".generated")).unwrap();
+    std::fs::write(
+        project_root.join("tsconfig.json"),
+        r#"{
+  "files": [],
+  "references": [{ "path": "./.generated/tsconfig.app.json" }]
+}"#,
+    )
+    .unwrap();
+    std::fs::write(
+        project_root.join(".generated/tsconfig.app.json"),
+        r##"{
+  "compilerOptions": {
+    "composite": true,
+    "strict": true,
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "noEmit": true,
+    "baseUrl": ".",
+    "paths": {
+      "#registry": ["./registry"]
+    }
+  },
+  "include": ["./types.d.ts", "../src/**/*.vue"]
+}"##,
+    )
+    .unwrap();
+    std::fs::write(
+        project_root.join(".generated/registry.d.ts"),
+        r#"export interface Registry {
+  home: {
+    title: string;
+  };
+}
+
+export declare function getEntry<K extends keyof Registry>(key: K): Registry[K];
+"#,
+    )
+    .unwrap();
+    std::fs::write(
+        project_root.join(".generated/types.d.ts"),
+        r##"import type { Registry as GeneratedRegistry } from "#registry";
+
+declare global {
+  type AppRegistry = GeneratedRegistry;
+}
+"##,
+    )
+    .unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(&project_root)
+        .env("CORSA_PATH", corsa_path)
+        .args([
+            "check",
+            "--tsconfig",
+            "tsconfig.json",
+            "src/App.vue",
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+
+    let stdout = std::string::String::from_utf8(output.stdout).unwrap();
+    let stderr = std::string::String::from_utf8(output.stderr).unwrap();
+    let json: serde_json::Value = serde_json::from_str(&stdout).unwrap_or_else(|error| {
+        panic!("failed to parse stdout as JSON: {error}\nstdout:\n{stdout}\nstderr:\n{stderr}")
+    });
+    let diagnostics = json["files"]
+        .as_array()
+        .into_iter()
+        .flatten()
+        .flat_map(|file| file["diagnostics"].as_array().cloned().unwrap_or_default())
+        .map(|d| d.as_str().unwrap_or_default().to_string())
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "stdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert_eq!(
+        json["errorCount"], 0,
+        "diagnostics: {diagnostics:#?}\nstderr:\n{stderr}"
+    );
+    assert!(
+        diagnostics
+            .iter()
+            .all(|diagnostic| !diagnostic.contains("Cannot find module")),
+        "referenced project path mappings should resolve #registry: {diagnostics:#?}"
+    );
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}
+
+#[test]
 fn check_template_dollar_globals_use_component_custom_properties() {
     let Some(corsa_path) = resolve_test_corsa_path() else {
         return;


### PR DESCRIPTION
Fixes #868

Summary:
- Follow tsconfig references when collecting default and ambient check inputs.
- Select the referenced project that owns explicit input files before building the virtual project.
- Add unit and CLI regressions for solution-style tsconfig path aliases and generated declarations.

Validation:
- cargo fmt --all -- --check
- git diff --check
- cargo test -p vize tsconfig_inputs
- cargo test -p vize --test check_cli check_solution_tsconfig_uses_referenced_project_for_explicit_file -- --nocapture
- cargo clippy -p vize -- -D warnings

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/894"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783010539&installation_id=136613492&pr_number=894&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F894&signature=cdad98d3e40da7aa248577ab6fe640a7ad438530d8f1e5abd8135fe0d51e5e10"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->