### PR TITLE
fix(linter): report v-for unused aliases at source span

### DIFF
--- a/crates/vize_croquis/src/analyzer/template/visit_element.rs
+++ b/crates/vize_croquis/src/analyzer/template/visit_element.rs
@@ -4,7 +4,6 @@
 //! info (which must be entered before other directives), second pass
 //! processes v-bind, v-if, v-show, v-model, v-on in the correct scope.
 
-use crate::ScopeBinding;
 use crate::analysis::ComponentUsage;
 use crate::analyzer::Analyzer;
 use crate::analyzer::helpers::{
@@ -13,7 +12,6 @@ use crate::analyzer::helpers::{
 };
 use crate::scope::{ParamNames, VForScopeData, VSlotScopeData};
 use vize_carton::{CompactString, SmallVec, profile, smallvec};
-use vize_relief::BindingType;
 use vize_relief::ast::{ElementNode, ExpressionNode, PropNode, TemplateChildNode};
 
 /// End offset of an element's full subtree (including children) in the source.
@@ -86,7 +84,12 @@ impl Analyzer {
 
         // Collect v-for scope
         #[allow(clippy::type_complexity)]
-        let mut for_scope: Option<(VForScopeAliases, u32, u32)> = None;
+        let mut for_scope: Option<(
+            VForScopeAliases,
+            SmallVec<[(CompactString, u32); 4]>,
+            u32,
+            u32,
+        )> = None;
 
         let mut key_expression: Option<CompactString> = None;
 
@@ -126,8 +129,13 @@ impl Analyzer {
                                 parse_v_for_scope_expression(content)
                             );
                             if let Some(aliases) = aliases {
-                                for_scope =
-                                    Some((aliases, el.loc.start.offset, element_subtree_end(el)));
+                                let alias_offsets = v_for_alias_declaration_offsets(exp, &aliases);
+                                for_scope = Some((
+                                    aliases,
+                                    alias_offsets,
+                                    el.loc.start.offset,
+                                    element_subtree_end(el),
+                                ));
                             }
                         }
                     }
@@ -257,7 +265,7 @@ impl Analyzer {
             };
 
         // Enter v-for scope if present
-        let for_vars_count = if let Some((aliases, start, end)) = for_scope {
+        let for_vars_count = if let Some((aliases, alias_offsets, start, end)) = for_scope {
             let scope_bindings = v_for_scope_bindings(&aliases);
             let count = scope_bindings.len();
 
@@ -275,10 +283,14 @@ impl Analyzer {
                     end,
                 );
 
+                let scope = self.summary.scopes.current_scope_mut();
+                for (name, offset) in &alias_offsets {
+                    if let Some(binding) = scope.get_binding_mut(name.as_str()) {
+                        binding.declaration_offset = *offset;
+                    }
+                }
+
                 for var in &scope_bindings {
-                    self.summary
-                        .scopes
-                        .add_binding(var.clone(), ScopeBinding::new(BindingType::SetupConst, 0));
                     scope_vars.push(var.clone());
                 }
             }
@@ -476,4 +488,77 @@ fn v_for_scope_bindings(aliases: &VForScopeAliases) -> ParamNames {
         bindings.push(index.clone());
     }
     bindings
+}
+
+fn v_for_alias_declaration_offsets(
+    exp: &ExpressionNode<'_>,
+    aliases: &VForScopeAliases,
+) -> SmallVec<[(CompactString, u32); 4]> {
+    let (content, base_offset) = expression_content_and_offset(exp);
+    let Some((alias_start, alias_end)) = v_for_alias_range(content) else {
+        return SmallVec::new();
+    };
+    let alias_text = &content[alias_start..alias_end];
+    let alias_base = base_offset + alias_start as u32;
+
+    let mut offsets = SmallVec::new();
+    for name in v_for_scope_bindings(aliases) {
+        if let Some(relative) = find_identifier_token(alias_text, name.as_str()) {
+            offsets.push((name, alias_base + relative as u32));
+        }
+    }
+    offsets
+}
+
+fn expression_content_and_offset<'a>(exp: &'a ExpressionNode<'_>) -> (&'a str, u32) {
+    let loc = exp.loc();
+    let content = match exp {
+        ExpressionNode::Simple(simple) => simple.content.as_str(),
+        ExpressionNode::Compound(compound) => compound.loc.source.as_str(),
+    };
+    (content, loc.start.offset)
+}
+
+fn v_for_alias_range(expr: &str) -> Option<(usize, usize)> {
+    let leading = expr.len() - expr.trim_start().len();
+    let trimmed = expr.trim();
+    let separator = find_v_for_separator(trimmed)?;
+    let alias = &trimmed[..separator];
+    let alias_leading = alias.len() - alias.trim_start().len();
+    let alias_end = alias.trim_end().len();
+    Some((leading + alias_leading, leading + alias_end))
+}
+
+fn find_v_for_separator(expr: &str) -> Option<usize> {
+    let bytes = expr.as_bytes();
+    let mut index = 0;
+    while index + 4 <= bytes.len() {
+        if bytes[index] == b' '
+            && ((bytes[index + 1] == b'i' && bytes[index + 2] == b'n')
+                || (bytes[index + 1] == b'o' && bytes[index + 2] == b'f'))
+            && bytes[index + 3] == b' '
+        {
+            return Some(index);
+        }
+        index += 1;
+    }
+    None
+}
+
+fn find_identifier_token(text: &str, name: &str) -> Option<usize> {
+    text.match_indices(name).find_map(|(index, _)| {
+        let before = index
+            .checked_sub(1)
+            .and_then(|prev| text.as_bytes().get(prev))
+            .is_none_or(|byte| !is_identifier_continue(*byte));
+        let after = text
+            .as_bytes()
+            .get(index + name.len())
+            .is_none_or(|byte| !is_identifier_continue(*byte));
+        (before && after).then_some(index)
+    })
+}
+
+fn is_identifier_continue(byte: u8) -> bool {
+    byte == b'_' || byte == b'$' || byte.is_ascii_alphanumeric()
 }

--- a/crates/vize_patina/src/linter/tests/basic.rs
+++ b/crates/vize_patina/src/linter/tests/basic.rs
@@ -39,6 +39,46 @@ fn test_lint_template_uses_semantic_analysis_for_unused_v_for_vars() {
 }
 
 #[test]
+fn test_lint_template_reports_unused_v_for_alias_at_alias_span() {
+    let linter =
+        Linter::new().with_enabled_rules(Some(vec!["vue/no-unused-vars".to_compact_string()]));
+    let source = r#"<template>
+<div>
+  <span v-for="(item, i) in items" :key="item">{{ item }}</span>
+  <span v-for="(entry, j) in items" :key="entry">{{ entry }}</span>
+</div>
+</template>
+<script setup>
+const items = ['a', 'b'];
+</script>"#;
+    let result = linter.lint_sfc(source, "test.vue");
+
+    assert_eq!(result.warning_count, 2);
+
+    let i_start = source.find(", i)").unwrap() as u32 + 2;
+    let j_start = source.find(", j)").unwrap() as u32 + 2;
+    let i_diagnostic = result
+        .diagnostics
+        .iter()
+        .find(|diagnostic| diagnostic.message.contains("'i'"))
+        .expect("unused i alias should be reported");
+    let j_diagnostic = result
+        .diagnostics
+        .iter()
+        .find(|diagnostic| diagnostic.message.contains("'j'"))
+        .expect("unused j alias should be reported");
+
+    assert_eq!(
+        (i_diagnostic.start, i_diagnostic.end),
+        (i_start, i_start + 1)
+    );
+    assert_eq!(
+        (j_diagnostic.start, j_diagnostic.end),
+        (j_start, j_start + 1)
+    );
+}
+
+#[test]
 fn test_ecosystem_template_rules_are_enabled_by_default() {
     let source = r#"<template><RouterLink>Home</RouterLink></template>"#;
 


### PR DESCRIPTION
Fixes #867.

## Changes
- Preserve source offsets for v-for aliases when creating template scope bindings.
- Add an SFC regression test for vue/no-unused-vars diagnostics on tuple aliases.

## Verification
- cargo fmt --all -- --check
- cargo test -p vize_patina test_lint_template_reports_unused_v_for_alias_at_alias_span
- cargo test -p vize_patina test_lint_template_uses_semantic_analysis_for_unused_v_for_vars
- cargo test -p vize_croquis v_for
- cargo test -p vize_patina no_unused
- cargo clippy -p vize_croquis -p vize_patina -- -D warnings
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/895"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783011535&installation_id=136613492&pr_number=895&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F895&signature=38647bf973716ac1063ac61458263daf78db2fb6d418e3ccff3cae97c7e11095"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->