### PR TITLE
fix(compiler): preserve inline handler local bindings

### DIFF
--- a/crates/vize_atelier_core/src/transforms/transform_expression/collector.rs
+++ b/crates/vize_atelier_core/src/transforms/transform_expression/collector.rs
@@ -6,8 +6,13 @@
 use oxc_ast::ast as oxc_ast_types;
 use oxc_ast_visit::{
     Visit,
-    walk::{walk_assignment_expression, walk_object_property, walk_update_expression},
+    walk::{
+        walk_arrow_function_expression, walk_assignment_expression, walk_block_statement,
+        walk_catch_clause, walk_function, walk_object_property, walk_update_expression,
+        walk_variable_declarator,
+    },
 };
+use oxc_syntax::scope::ScopeFlags;
 use vize_carton::FxHashSet;
 use vize_carton::String;
 
@@ -22,8 +27,8 @@ pub(crate) struct IdentifierCollector<'a, 'ctx> {
     pub(crate) ctx: &'a TransformContext<'ctx>,
     /// The wrapped source text (for scanning paren positions)
     pub(crate) source: &'a str,
-    /// Identifiers that are being declared (e.g., in arrow function params)
-    pub(crate) local_scope: FxHashSet<String>,
+    /// Lexical scopes for inline handler locals.
+    pub(crate) local_scopes: Vec<FxHashSet<String>>,
     /// (position, prefix) pairs for rewrites
     pub(crate) rewrites: FxHashSet<(usize, String)>,
     /// (position, suffix) pairs for suffix rewrites (e.g., .value for refs)
@@ -39,7 +44,7 @@ impl<'a, 'ctx> IdentifierCollector<'a, 'ctx> {
         Self {
             ctx,
             source,
-            local_scope: FxHashSet::default(),
+            local_scopes: vec![FxHashSet::default()],
             rewrites: FxHashSet::default(),
             suffix_rewrites: Vec::new(),
             assignment_targets: FxHashSet::default(),
@@ -47,10 +52,31 @@ impl<'a, 'ctx> IdentifierCollector<'a, 'ctx> {
         }
     }
 
+    fn push_scope(&mut self) {
+        self.local_scopes.push(FxHashSet::default());
+    }
+
+    fn pop_scope(&mut self) {
+        self.local_scopes.pop();
+    }
+
+    fn add_local(&mut self, name: &str) {
+        if let Some(scope) = self.local_scopes.last_mut() {
+            scope.insert(String::new(name));
+        }
+    }
+
+    fn is_local(&self, name: &str) -> bool {
+        self.local_scopes
+            .iter()
+            .rev()
+            .any(|scope| scope.contains(name))
+    }
+
     /// Check if an identifier is a ref that needs .value suffix
     fn is_ref_binding(&self, name: &str) -> bool {
         // Skip if in local scope
-        if self.local_scope.contains(name) {
+        if self.is_local(name) {
             return false;
         }
 
@@ -71,7 +97,7 @@ impl<'a, 'ctx> IdentifierCollector<'a, 'ctx> {
     }
 
     fn is_value_access_binding(&self, name: &str) -> bool {
-        if self.local_scope.contains(name) {
+        if self.is_local(name) {
             return false;
         }
 
@@ -93,7 +119,7 @@ impl<'a, 'ctx> IdentifierCollector<'a, 'ctx> {
     /// This applies to let/var declarations and maybe-ref bindings.
     fn needs_unref(&self, name: &str) -> bool {
         // Skip if in local scope
-        if self.local_scope.contains(name) {
+        if self.is_local(name) {
             return false;
         }
 
@@ -122,7 +148,7 @@ impl<'a, 'ctx> IdentifierCollector<'a, 'ctx> {
     pub(crate) fn collect_binding_pattern(&mut self, pattern: &oxc_ast_types::BindingPattern<'_>) {
         match pattern {
             oxc_ast_types::BindingPattern::BindingIdentifier(id) => {
-                self.local_scope.insert(String::new(id.name.as_str()));
+                self.add_local(id.name.as_str());
             }
             oxc_ast_types::BindingPattern::ObjectPattern(obj) => {
                 for prop in &obj.properties {
@@ -242,7 +268,7 @@ impl<'a, 'ctx> Visit<'_> for IdentifierCollector<'a, 'ctx> {
     fn visit_identifier_reference(&mut self, ident: &oxc_ast_types::IdentifierReference<'_>) {
         let name = ident.name.as_str();
         // Skip if in local scope
-        if self.local_scope.contains(name) {
+        if self.is_local(name) {
             return;
         }
 
@@ -335,16 +361,56 @@ impl<'a, 'ctx> Visit<'_> for IdentifierCollector<'a, 'ctx> {
         &mut self,
         arrow: &oxc_ast_types::ArrowFunctionExpression<'_>,
     ) {
-        // Add params to local scope
+        self.push_scope();
         for param in &arrow.params.items {
             self.collect_binding_pattern(&param.pattern);
         }
         if let Some(rest) = &arrow.params.rest {
             self.collect_binding_pattern(&rest.rest.argument);
         }
+        walk_arrow_function_expression(self, arrow);
+        self.pop_scope();
+    }
 
-        // Visit body
-        self.visit_function_body(&arrow.body);
+    fn visit_function(&mut self, func: &oxc_ast_types::Function<'_>, flags: ScopeFlags) {
+        if func.r#type == oxc_ast_types::FunctionType::FunctionDeclaration
+            && let Some(id) = &func.id
+        {
+            self.add_local(id.name.as_str());
+        }
+
+        self.push_scope();
+        if let Some(id) = &func.id {
+            self.add_local(id.name.as_str());
+        }
+        for param in &func.params.items {
+            self.collect_binding_pattern(&param.pattern);
+        }
+        if let Some(rest) = &func.params.rest {
+            self.collect_binding_pattern(&rest.rest.argument);
+        }
+        walk_function(self, func, flags);
+        self.pop_scope();
+    }
+
+    fn visit_block_statement(&mut self, block: &oxc_ast_types::BlockStatement<'_>) {
+        self.push_scope();
+        walk_block_statement(self, block);
+        self.pop_scope();
+    }
+
+    fn visit_catch_clause(&mut self, catch_clause: &oxc_ast_types::CatchClause<'_>) {
+        self.push_scope();
+        if let Some(param) = &catch_clause.param {
+            self.collect_binding_pattern(&param.pattern);
+        }
+        walk_catch_clause(self, catch_clause);
+        self.pop_scope();
+    }
+
+    fn visit_variable_declarator(&mut self, declarator: &oxc_ast_types::VariableDeclarator<'_>) {
+        walk_variable_declarator(self, declarator);
+        self.collect_binding_pattern(&declarator.id);
     }
 
     fn visit_assignment_expression(&mut self, expr: &oxc_ast_types::AssignmentExpression<'_>) {
@@ -362,7 +428,7 @@ impl<'a, 'ctx> Visit<'_> for IdentifierCollector<'a, 'ctx> {
             && let oxc_ast_types::PropertyKey::StaticIdentifier(ident) = &prop.key
         {
             let name = ident.name.as_str();
-            if self.local_scope.contains(name) || is_global_allowed(name) {
+            if self.is_local(name) || is_global_allowed(name) {
                 return;
             }
             if self.ctx.is_in_scope(name) {

--- a/crates/vize_atelier_core/src/transforms/transform_expression/inline_handler.rs
+++ b/crates/vize_atelier_core/src/transforms/transform_expression/inline_handler.rs
@@ -193,6 +193,8 @@ mod tests {
         let mut bindings = FxHashMap::default();
         bindings.insert("selectedFolders".into(), BindingType::SetupRef);
         bindings.insert("folder".into(), BindingType::SetupRef);
+        bindings.insert("compute".into(), BindingType::SetupConst);
+        bindings.insert("emit".into(), BindingType::SetupConst);
 
         TransformContext::new(
             allocator,
@@ -245,5 +247,24 @@ mod tests {
                 .contains("selectedFolders.value = selectedFolders.value.filter(")
         );
         assert!(result.content.contains("folder.value.id"));
+    }
+
+    #[test]
+    fn test_process_inline_handler_preserves_local_block_binding() {
+        let allocator = Bump::new();
+        let mut ctx = test_context(&allocator);
+        let expr = compound_expression(
+            &allocator,
+            "() => { const value = compute(); emit('change', value) }",
+        );
+
+        let result = process_inline_handler(&mut ctx, &expr);
+        let ExpressionNode::Simple(result) = result else {
+            panic!("expected simple expression");
+        };
+
+        assert!(result.content.contains("const value = compute()"));
+        assert!(result.content.contains("emit('change', value)"));
+        assert!(!result.content.contains("_ctx.value"));
     }
 }

--- a/crates/vize_atelier_sfc/src/compile/tests.rs
+++ b/crates/vize_atelier_sfc/src/compile/tests.rs
@@ -717,6 +717,39 @@ const editDashboard = ref()
 }
 
 #[test]
+fn test_inline_handler_preserves_local_block_binding() {
+    let source = r#"<script setup lang="ts">
+const emit = defineEmits<{ change: [value: number] }>()
+function compute() { return 1 }
+</script>
+
+<template>
+  <button
+    @click="() => {
+      const value = compute();
+      emit('change', value)
+    }"
+  >
+    Click
+  </button>
+</template>"#;
+
+    let descriptor = parse_sfc(source, SfcParseOptions::default()).expect("Failed to parse SFC");
+    let opts = SfcCompileOptions {
+        script: ScriptCompileOptions {
+            is_ts: true,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let result = compile_sfc(&descriptor, opts).expect("Failed to compile SFC");
+
+    assert!(result.code.contains("const value = compute()"));
+    assert!(result.code.contains("emit('change', value)"));
+    assert!(!result.code.contains("_ctx.value"));
+}
+
+#[test]
 fn test_typescript_function_types_preserved() {
     // When is_ts=true, TypeScript is preserved in the output
     // (matching Vue's @vue/compiler-sfc behavior - TS stripping is the bundler's job)

--- a/tests/expected/sfc/patches.snap
+++ b/tests/expected/sfc/patches.snap
@@ -1325,7 +1325,7 @@ return (_ctx, _cache) => {
   return (_openBlock(), _createElementBlock("button", {
     onClick: _cache[0] || (_cache[0] = () => {
       const newValue = count.value + 1;
-      count.value = _ctx.newValue;
+      count.value = newValue;
       console.log('incremented');
     })
   }, "Increment"))

--- a/tests/snapshots/sfc/js/patches__multiline_arrow_function_in_event_handler.snap
+++ b/tests/snapshots/sfc/js/patches__multiline_arrow_function_in_event_handler.snap
@@ -17,7 +17,7 @@ return (_ctx, _cache) => {
   return (_openBlock(), _createElementBlock("button", {
     onClick: _cache[0] || (_cache[0] = () => {
     const newValue = count.value + 1;
-    count.value = _ctx.newValue;
+    count.value = newValue;
     console.log('incremented');
   })
   }, "Increment"))

--- a/tests/snapshots/sfc/ts/patches__multiline_arrow_function_in_event_handler.snap
+++ b/tests/snapshots/sfc/ts/patches__multiline_arrow_function_in_event_handler.snap
@@ -18,7 +18,7 @@ return (_ctx: any,_cache: any) => {
   return (_openBlock(), _createElementBlock("button", {
     onClick: _cache[0] || (_cache[0] = () => {
     const newValue = count.value + 1;
-    count.value = _ctx.newValue;
+    count.value = newValue;
     console.log('incremented');
   })
   }, "Increment"))


### PR DESCRIPTION
## Summary
- track lexical scopes while rewriting inline handler expressions
- keep handler block locals, function params, catch params, and nested block bindings from being resolved through component context
- add transform and SFC regression coverage for local handler bindings

Fixes #866

## Validation
- cargo fmt --all -- --check
- cargo test -p vize_atelier_core transform_expression
- cargo test -p vize_atelier_sfc test_inline_handler_preserves_local_block_binding
- cargo test -p vize_atelier_sfc test_multi_statement_event_handler
- cargo clippy -p vize_atelier_core -p vize_atelier_sfc -- -D warnings
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/896"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783012294&installation_id=136613492&pr_number=896&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F896&signature=7a91e790dcb5163e0e912c776fd28761c5f2fcc4d1d5cdd985970e1e88ffb16a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->