### PR TITLE
fix(check): resolve root above explicit tsconfig

### DIFF
--- a/crates/vize/src/commands/check/runner.rs
+++ b/crates/vize/src/commands/check/runner.rs
@@ -749,10 +749,17 @@ fn resolve_project_root(
         } else {
             cwd.join(tsconfig)
         };
-        return tsconfig_path
+        let tsconfig_dir = tsconfig_path
+            .canonicalize()
+            .unwrap_or(tsconfig_path)
             .parent()
             .map(|parent| parent.to_path_buf())
             .unwrap_or_else(|| cwd.to_path_buf());
+        if files.is_empty() {
+            return tsconfig_dir;
+        }
+
+        return common_project_root(tsconfig_dir, files);
     }
 
     if let Some(root) = resolve_project_root_from_files(files) {
@@ -837,6 +844,19 @@ fn common_file_parent(files: &[PathBuf]) -> Option<PathBuf> {
     }
 
     Some(common)
+}
+
+fn common_project_root(mut common: PathBuf, files: &[PathBuf]) -> PathBuf {
+    for file in files {
+        let parent = file.parent().unwrap_or(file.as_path());
+        while !parent.starts_with(&common) {
+            if !common.pop() {
+                return common;
+            }
+        }
+    }
+
+    common
 }
 
 fn display_path(base: &Path, path: &Path) -> vize_carton::String {
@@ -979,6 +999,30 @@ mod tests {
         assert_eq!(resolved_tsconfig, Some(resolved_root.join("tsconfig.json")));
 
         let _ = std::fs::remove_dir_all(&project_root);
+    }
+
+    #[test]
+    fn resolves_common_root_when_explicit_tsconfig_is_below_inputs() {
+        let project_root = unique_case_dir("explicit-tsconfig-below-inputs");
+        let _ = std::fs::remove_dir_all(&project_root);
+        let config_dir = project_root.join("config");
+        let src_dir = project_root.join("src");
+        std::fs::create_dir_all(&config_dir).unwrap();
+        std::fs::create_dir_all(&src_dir).unwrap();
+        let tsconfig = config_dir.join("tsconfig.json");
+        let app = src_dir.join("App.vue");
+        std::fs::write(&tsconfig, "{}").unwrap();
+        std::fs::write(&app, "<template />").unwrap();
+        let files = vec![app];
+
+        let resolved_root = resolve_project_root(Some(&tsconfig), &project_root, &files);
+        let resolved_tsconfig =
+            resolve_tsconfig_path(Some(&tsconfig), &project_root, &resolved_root, &files);
+
+        assert_eq!(resolved_root, project_root);
+        assert_eq!(resolved_tsconfig, Some(tsconfig));
+
+        let _ = std::fs::remove_dir_all(&resolved_root);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- choose a common project root when an explicit tsconfig sits below checked input files
- keep the explicit tsconfig path as configuration metadata while materializing files under the shared root
- add a runner regression test for a config/tsconfig.json checking src/App.vue

## Verification
- cargo test -p vize resolves_common_root_when_explicit_tsconfig_is_below_inputs
- cargo test -p vize commands::check::runner
- cargo clippy -p vize -- -D warnings
- cargo fmt --all -- --check
- git diff --check

Fixes #861

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/898"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783013528&installation_id=136613492&pr_number=898&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F898&signature=5806e9898407eef042673826f912c0d7d2e16131f57b8e37f518249566ece570"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->