### PR TITLE
fix(canon): preserve object-form v-on expressions

### DIFF
--- a/crates/vize_canon/src/virtual_ts.rs
+++ b/crates/vize_canon/src/virtual_ts.rs
@@ -597,6 +597,42 @@ function handleHover() {}
     }
 
     #[test]
+    fn test_object_form_v_on_is_preserved_as_expression() {
+        use vize_croquis::{Analyzer, AnalyzerOptions};
+
+        let script = r#"const props = defineProps<{
+  handlers?: {
+    'update:modelValue'?: () => void
+  }
+}>()
+"#;
+        let template = r#"<button v-on="{ 'update:modelValue': props.handlers?.['update:modelValue'] }">Click</button>"#;
+
+        let allocator = vize_carton::Bump::new();
+        let (root, _) = vize_armature::parse(&allocator, template);
+
+        let mut analyzer = Analyzer::with_options(AnalyzerOptions::full());
+        analyzer.analyze_script_setup(script);
+        analyzer.analyze_template(&root);
+        let summary = analyzer.finish();
+
+        let output = generate_virtual_ts(&summary, Some(script), Some(&root), 0);
+
+        assert!(
+            output.code.contains(
+                "void ({ 'update:modelValue': props.handlers?.['update:modelValue'] }); // VOn"
+            ),
+            "object-form v-on should be emitted as an expression:\n{}",
+            output.code
+        );
+        assert!(
+            !output.code.contains("@unknown handler"),
+            "object-form v-on must not create a synthetic event handler:\n{}",
+            output.code
+        );
+    }
+
+    #[test]
     fn test_source_mappings_generated() {
         use vize_croquis::{Analyzer, AnalyzerOptions};
 

--- a/crates/vize_croquis/src/analyzer/template/directives/v_on.rs
+++ b/crates/vize_croquis/src/analyzer/template/directives/v_on.rs
@@ -25,6 +25,32 @@ impl Analyzer {
                 ExpressionNode::Compound(c) => c.loc.source.as_str(),
             };
 
+            if dir.arg.is_none() {
+                if self.options.collect_template_expressions {
+                    let loc = exp.loc();
+                    let scope_id = self.summary.scopes.current_id();
+                    self.summary
+                        .template_expressions
+                        .push(crate::analysis::TemplateExpression {
+                            content: CompactString::new(content),
+                            kind: crate::analysis::TemplateExpressionKind::VOn,
+                            start: loc.start.offset,
+                            end: loc.end.offset,
+                            scope_id,
+                            vif_guard: self.current_vif_guard(),
+                        });
+                }
+
+                if self.options.detect_undefined && self.script_analyzed {
+                    profile!(
+                        "croquis.template.v_on.refs",
+                        self.check_expression_refs(exp, scope_vars)
+                    );
+                }
+
+                return;
+            }
+
             // Check for inline arrow/function
             if let Some(params) = profile!(
                 "croquis.template.callback.extract_params",


### PR DESCRIPTION
## Summary
- Treat argument-less v-on as a listener-map expression instead of a single event handler scope.
- Add a regression test for string-literal listener keys in object-form v-on virtual TS.

Fixes #858

## Verification
- cargo test -p vize_croquis
- cargo test -p vize_canon
- cargo clippy -p vize_croquis -p vize_canon -- -D warnings
- cargo fmt --all -- --check
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/899"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783014228&installation_id=136613492&pr_number=899&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F899&signature=a785f7ce629887b5f5eae50c233d4072b8b8e000e8ca8fc65812962a4996f604"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->