### PR TITLE
fix(build): resolve imported prop base interfaces

### DIFF
--- a/crates/vize/src/commands/build/runner.rs
+++ b/crates/vize/src/commands/build/runner.rs
@@ -737,6 +737,7 @@ fn compile_file_stats_with_cache(
         .and_then(|n| n.to_str())
         .unwrap_or("anonymous.vue")
         .into();
+    let source_id = path.to_string_lossy().as_ref().to_compact_string();
     let component_name = path.file_stem().and_then(|n| n.to_str()).unwrap_or("");
     let cache_key =
         should_cache_stats_compile(&source, component_name).then(|| StatsCompileCacheKey {
@@ -836,7 +837,7 @@ fn compile_file_stats_with_cache(
             ..Default::default()
         },
         script: ScriptCompileOptions {
-            id: Some(filename.clone()),
+            id: Some(source_id),
             is_ts,
             ..Default::default()
         },
@@ -949,6 +950,7 @@ fn compile_file_with_profile(
         .and_then(|n| n.to_str())
         .unwrap_or("anonymous.vue")
         .into();
+    let source_id = path.to_string_lossy().as_ref().to_compact_string();
 
     // Parse
     let parse_start = Instant::now();
@@ -1006,7 +1008,7 @@ fn compile_file_with_profile(
             ..Default::default()
         },
         script: ScriptCompileOptions {
-            id: Some(filename.clone()),
+            id: Some(source_id),
             is_ts,
             ..Default::default()
         },

--- a/crates/vize/tests/build_cli.rs
+++ b/crates/vize/tests/build_cli.rs
@@ -1,0 +1,103 @@
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+fn temp_project_dir(test_name: &str) -> PathBuf {
+    let nonce = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    std::env::temp_dir().join(format!(
+        "vize-build-cli-{}-{}-{}",
+        std::process::id(),
+        test_name,
+        nonce
+    ))
+}
+
+fn write_project_file(root: &Path, path: &str, content: &str) {
+    let file_path = root.join(path);
+    if let Some(parent) = file_path.parent() {
+        fs::create_dir_all(parent).unwrap();
+    }
+    fs::write(file_path, content).unwrap();
+}
+
+#[test]
+fn build_resolves_imported_base_interface_props_in_normal_script() {
+    let project_root = temp_project_dir("imported-base-interface-props");
+    write_project_file(
+        &project_root,
+        "src/primitive.ts",
+        r#"export interface PrimitiveProps {
+  asChild?: boolean
+  as?: string
+}
+"#,
+    );
+    write_project_file(
+        &project_root,
+        "src/App.vue",
+        r#"<script lang="ts">
+import type { PrimitiveProps } from './primitive'
+
+export interface AppProps extends PrimitiveProps {
+  feature?: 'focusable' | 'hidden'
+}
+</script>
+
+<script setup lang="ts">
+withDefaults(defineProps<AppProps>(), {
+  as: 'span',
+  feature: 'focusable',
+})
+</script>
+
+<template>
+  <div
+    :data-as="as"
+    :data-as-child="asChild"
+    :data-feature="feature"
+  />
+</template>
+"#,
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(&project_root)
+        .args(["build", "--format", "js", "src/App.vue", "--output", "dist"])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let js = fs::read_to_string(project_root.join("dist/App.js")).unwrap();
+    assert!(
+        js.contains("asChild: {\n      type: Boolean,\n      required: false\n    }"),
+        "{js}"
+    );
+    assert!(
+        js.contains(
+            "as: {\n      type: String,\n      required: false,\n      default: \"span\"\n    }"
+        ),
+        "{js}"
+    );
+    assert!(
+        js.contains("feature: {\n      type: String,\n      required: false,\n      default: \"focusable\"\n    }"),
+        "{js}"
+    );
+    assert!(js.contains("\"data-as\": __props.as"), "{js}");
+    assert!(js.contains("\"data-as-child\": __props.asChild"), "{js}");
+    assert!(js.contains("\"data-feature\": __props.feature"), "{js}");
+    assert!(!js.contains("_ctx.as"), "{js}");
+    assert!(!js.contains("_ctx.asChild"), "{js}");
+
+    let _ = fs::remove_dir_all(project_root);
+}

--- a/crates/vize_atelier_sfc/src/compile.rs
+++ b/crates/vize_atelier_sfc/src/compile.rs
@@ -134,7 +134,12 @@ fn compile_sfc_inner(
     let mut css = None;
     let macro_artifacts = extract_descriptor_macro_artifacts(descriptor);
 
-    let filename = options.script.id.as_deref().unwrap_or("anonymous.vue");
+    let filename = if options.parse.filename.is_empty() {
+        options.script.id.as_deref().unwrap_or("anonymous.vue")
+    } else {
+        options.parse.filename.as_str()
+    };
+    let source_filename = options.script.id.as_deref().unwrap_or(filename);
 
     let has_styles = !descriptor.styles.is_empty();
     let has_scoped = descriptor.styles.iter().any(|s| s.scoped);
@@ -489,13 +494,13 @@ fn compile_sfc_inner(
     }
     profile!(
         "atelier.sfc.script_context.collect_setup_import_types",
-        ctx.collect_imported_types_from_path(&script_setup_content, filename)
+        ctx.collect_imported_types_from_path(&script_setup_content, source_filename)
     );
     if has_script {
         let script = descriptor.script.as_ref().unwrap();
         profile!(
             "atelier.sfc.script_context.collect_normal_import_types",
-            ctx.collect_imported_types_from_path(&script.content, filename)
+            ctx.collect_imported_types_from_path(&script.content, source_filename)
         );
     }
     profile!("atelier.sfc.script_context.analyze", ctx.analyze());
@@ -698,7 +703,7 @@ fn compile_sfc_inner(
             normal_script_content.as_deref(),
             &descriptor.css_vars,
             &scope_id,
-            options.script.id.as_deref().unwrap_or(filename),
+            filename,
             options.template.is_prod,
         )
     )?;


### PR DESCRIPTION
## Summary
- pass the source file path into SFC compilation so relative type imports resolve during build
- keep display/scope filename handling separate from the source path
- add a build CLI regression for withDefaults over an interface extending an imported base interface

Fixes #857

## Tests
- cargo test -p vize --test build_cli build_resolves_imported_base_interface_props_in_normal_script -- --nocapture
- cargo test -p vize --test build_cli
- cargo test -p vize_atelier_sfc
- cargo clippy -p vize -p vize_atelier_sfc -- -D warnings
- cargo fmt --all -- --check
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/901"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783015211&installation_id=136613492&pr_number=901&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F901&signature=cf8aa987369cc222e1c809ae1148e00aca4f00060fe4acdb26ab048a8ec40f7a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->