### PR TITLE
fix(nix): update blacksmith cli hash

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -140,7 +140,7 @@
           };
           x86_64-linux = {
             url = "https://clireleases.blacksmith.sh/cli/latest/linux/amd64/blacksmith";
-            hash = "sha256-OPHHrvGjbIfkC5tQvFc+zbu3hd5GsoJelcuauvo1m90=";
+            hash = "sha256-W8ljKPdzda1SCCpg8FbxlsioKA8GlNqueLtePYb/XZg=";
           };
           aarch64-linux = {
             url = "https://clireleases.blacksmith.sh/cli/latest/linux/arm64/blacksmith";


### PR DESCRIPTION
## Summary
- update the linux amd64 Blacksmith CLI fixed-output hash used by the Nix flake

## Validation
- nix store prefetch-file --name blacksmith https://clireleases.blacksmith.sh/cli/latest/linux/amd64/blacksmith
- nix flake check --no-build
- nix flake check --all-systems --no-build
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/902"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783041834&installation_id=136613492&pr_number=902&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F902&signature=5b41ef986003f158097fe5759e9d38a39227621b70c47e8c32b813d9d8aeeffc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->