### PR TITLE
test(coverage): harden vue fixture resolution

### DIFF
--- a/crates/vize/tests/check_cli.rs
+++ b/crates/vize/tests/check_cli.rs
@@ -2919,8 +2919,10 @@ fn link_workspace_node_modules(project_root: &Path) -> std::io::Result<()> {
             write_test_vite_stub,
         )?;
 
-        if let Some(vue_namespace) = resolve_test_vue_namespace(workspace_node_modules) {
+        if let Some(vue_namespace) = resolve_test_vue_runtime_namespace(workspace_node_modules) {
             symlink_path(&vue_namespace, &target.join("@vue"))?;
+        } else {
+            write_test_vue_runtime_dom_stub(&target)?;
         }
     } else {
         write_test_vue_stub(&target)?;
@@ -2953,7 +2955,7 @@ fn link_workspace_node_modules(project_root: &Path) -> std::io::Result<()> {
     Ok(())
 }
 
-fn resolve_test_vue_namespace(workspace_node_modules: &Path) -> Option<std::path::PathBuf> {
+fn resolve_test_vue_runtime_namespace(workspace_node_modules: &Path) -> Option<std::path::PathBuf> {
     let vue_source = workspace_node_modules.join("vue");
     let adjacent = resolve_adjacent_vue_namespace(&vue_source);
     let ancestor = {
@@ -2962,17 +2964,8 @@ fn resolve_test_vue_namespace(workspace_node_modules: &Path) -> Option<std::path
     };
 
     adjacent
-        .as_ref()
         .filter(|path| is_vue_runtime_namespace(path))
-        .cloned()
-        .or_else(|| {
-            ancestor
-                .as_ref()
-                .filter(|path| is_vue_runtime_namespace(path))
-                .cloned()
-        })
-        .or(adjacent)
-        .or(ancestor)
+        .or_else(|| ancestor.filter(|path| is_vue_runtime_namespace(path)))
 }
 
 fn resolve_adjacent_vue_namespace(vue_source: &Path) -> Option<std::path::PathBuf> {
@@ -2989,10 +2982,8 @@ fn resolve_adjacent_vue_namespace(vue_source: &Path) -> Option<std::path::PathBu
     }
 
     candidates
-        .iter()
+        .into_iter()
         .find(|candidate| candidate.exists() && is_vue_runtime_namespace(candidate))
-        .cloned()
-        .or_else(|| candidates.into_iter().find(|candidate| candidate.exists()))
 }
 
 fn is_vue_runtime_namespace(path: &Path) -> bool {
@@ -3023,9 +3014,18 @@ fn link_or_stub_package(
 ) -> std::io::Result<()> {
     let source = workspace_node_modules.join(package);
     if source.exists() {
-        symlink_path(&source, &target.join(package))
+        let link_source = package_link_source(&source, package);
+        symlink_path(&link_source, &target.join(package))
     } else {
         stub_writer(target)
+    }
+}
+
+fn package_link_source(source: &Path, package: &str) -> std::path::PathBuf {
+    if package == "vue" {
+        std::fs::canonicalize(source).unwrap_or_else(|_| source.to_path_buf())
+    } else {
+        source.to_path_buf()
     }
 }
 
@@ -3058,6 +3058,75 @@ fn write_test_vue_stub(target: &Path) -> std::io::Result<()> {
     std::fs::write(
         vue_dir.join("index.d.ts"),
         r#"export * from "@vue/runtime-dom";
+"#,
+    )?;
+    write_test_vue_runtime_dom_stub(target)?;
+    Ok(())
+}
+
+fn write_test_vue_runtime_dom_stub(target: &Path) -> std::io::Result<()> {
+    let runtime_dom_dir = target.join("@vue").join("runtime-dom");
+    std::fs::create_dir_all(&runtime_dom_dir)?;
+    std::fs::write(
+        runtime_dom_dir.join("package.json"),
+        r#"{
+  "name": "@vue/runtime-dom",
+  "types": "index.d.ts"
+}"#,
+    )?;
+    std::fs::write(
+        runtime_dom_dir.join("index.d.ts"),
+        r#"export interface ComponentPublicInstance<Props = {}> {
+  $props: Props;
+  $attrs: { [key: string]: unknown };
+  $slots: { [key: string]: unknown };
+  $refs: { [key: string]: unknown };
+  $emit: (...args: any[]) => void;
+}
+
+export type DefineComponent<
+  Props = {},
+  RawBindings = {},
+  D = {},
+  C = {},
+  M = {},
+  Mixin = {},
+  Extends = {},
+  E = {},
+  EE = string,
+  PP = Props,
+  PropsDefaults = {},
+  MakeDefaultsOptional = true,
+  Options = {},
+  S = {}
+> = {
+  new (): ComponentPublicInstance<Props>;
+};
+
+export interface Ref<T = unknown> {
+  value: T;
+}
+
+export interface ShallowRef<T = unknown> extends Ref<T> {
+  readonly __v_isShallow?: true;
+}
+
+export type PropType<T> = { new (...args: any[]): T & {} } | { (): T } | null;
+
+export declare const Transition: DefineComponent;
+export declare function defineComponent(options: any): DefineComponent;
+export declare function defineProps<T = {}>(): T;
+export declare function ref<T>(value: T): Ref<T>;
+export declare function shallowRef<T>(value: T): ShallowRef<T>;
+export declare function useTemplateRef<T = unknown>(key: string): ShallowRef<T | null>;
+export declare function useId(): string;
+export declare function watch<T>(source: T, callback: (...args: any[]) => void, options?: any): void;
+export declare function watchEffect(effect: (onCleanup: (cleanupFn: () => void) => void) => void): void;
+export declare function createApp(root: any): {
+  config: {
+    globalProperties: { [key: string]: any };
+  };
+};
 "#,
     )?;
     Ok(())

--- a/crates/vize_canon/src/batch/type_checker/tests.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests.rs
@@ -1216,8 +1216,10 @@ fn link_workspace_node_modules(project_root: &Path) -> std::io::Result<()> {
             write_test_vite_stub,
         )?;
 
-        if let Some(vue_namespace) = resolve_test_vue_namespace(workspace_node_modules) {
+        if let Some(vue_namespace) = resolve_test_vue_runtime_namespace(workspace_node_modules) {
             symlink_path(&vue_namespace, &target.join("@vue"))?;
+        } else {
+            write_test_vue_runtime_dom_stub(&target)?;
         }
     } else {
         write_test_vue_stub(&target)?;
@@ -1250,7 +1252,7 @@ fn link_workspace_node_modules(project_root: &Path) -> std::io::Result<()> {
     Ok(())
 }
 
-fn resolve_test_vue_namespace(workspace_node_modules: &Path) -> Option<PathBuf> {
+fn resolve_test_vue_runtime_namespace(workspace_node_modules: &Path) -> Option<PathBuf> {
     let vue_source = workspace_node_modules.join("vue");
     let adjacent = resolve_adjacent_vue_namespace(&vue_source);
     let ancestor = {
@@ -1259,17 +1261,8 @@ fn resolve_test_vue_namespace(workspace_node_modules: &Path) -> Option<PathBuf> 
     };
 
     adjacent
-        .as_ref()
         .filter(|path| is_vue_runtime_namespace(path))
-        .cloned()
-        .or_else(|| {
-            ancestor
-                .as_ref()
-                .filter(|path| is_vue_runtime_namespace(path))
-                .cloned()
-        })
-        .or(adjacent)
-        .or(ancestor)
+        .or_else(|| ancestor.filter(|path| is_vue_runtime_namespace(path)))
 }
 
 fn resolve_adjacent_vue_namespace(vue_source: &Path) -> Option<PathBuf> {
@@ -1286,10 +1279,8 @@ fn resolve_adjacent_vue_namespace(vue_source: &Path) -> Option<PathBuf> {
     }
 
     candidates
-        .iter()
+        .into_iter()
         .find(|candidate| candidate.exists() && is_vue_runtime_namespace(candidate))
-        .cloned()
-        .or_else(|| candidates.into_iter().find(|candidate| candidate.exists()))
 }
 
 fn is_vue_runtime_namespace(path: &Path) -> bool {
@@ -1304,9 +1295,18 @@ fn link_or_stub_package(
 ) -> std::io::Result<()> {
     let source = workspace_node_modules.join(package);
     if source.exists() {
-        symlink_path(&source, &target.join(package))
+        let link_source = package_link_source(&source, package);
+        symlink_path(&link_source, &target.join(package))
     } else {
         stub_writer(target)
+    }
+}
+
+fn package_link_source(source: &Path, package: &str) -> PathBuf {
+    if package == "vue" {
+        std::fs::canonicalize(source).unwrap_or_else(|_| source.to_path_buf())
+    } else {
+        source.to_path_buf()
     }
 }
 
@@ -1339,6 +1339,75 @@ fn write_test_vue_stub(target: &Path) -> std::io::Result<()> {
     std::fs::write(
         vue_dir.join("index.d.ts"),
         r#"export * from "@vue/runtime-dom";
+"#,
+    )?;
+    write_test_vue_runtime_dom_stub(target)?;
+    Ok(())
+}
+
+fn write_test_vue_runtime_dom_stub(target: &Path) -> std::io::Result<()> {
+    let runtime_dom_dir = target.join("@vue").join("runtime-dom");
+    std::fs::create_dir_all(&runtime_dom_dir)?;
+    std::fs::write(
+        runtime_dom_dir.join("package.json"),
+        r#"{
+  "name": "@vue/runtime-dom",
+  "types": "index.d.ts"
+}"#,
+    )?;
+    std::fs::write(
+        runtime_dom_dir.join("index.d.ts"),
+        r#"export interface ComponentPublicInstance<Props = {}> {
+  $props: Props;
+  $attrs: { [key: string]: unknown };
+  $slots: { [key: string]: unknown };
+  $refs: { [key: string]: unknown };
+  $emit: (...args: any[]) => void;
+}
+
+export type DefineComponent<
+  Props = {},
+  RawBindings = {},
+  D = {},
+  C = {},
+  M = {},
+  Mixin = {},
+  Extends = {},
+  E = {},
+  EE = string,
+  PP = Props,
+  PropsDefaults = {},
+  MakeDefaultsOptional = true,
+  Options = {},
+  S = {}
+> = {
+  new (): ComponentPublicInstance<Props>;
+};
+
+export interface Ref<T = unknown> {
+  value: T;
+}
+
+export interface ShallowRef<T = unknown> extends Ref<T> {
+  readonly __v_isShallow?: true;
+}
+
+export type PropType<T> = { new (...args: any[]): T & {} } | { (): T } | null;
+
+export declare const Transition: DefineComponent;
+export declare function defineComponent(options: any): DefineComponent;
+export declare function defineProps<T = {}>(): T;
+export declare function ref<T>(value: T): Ref<T>;
+export declare function shallowRef<T>(value: T): ShallowRef<T>;
+export declare function useTemplateRef<T = unknown>(key: string): ShallowRef<T | null>;
+export declare function useId(): string;
+export declare function watch<T>(source: T, callback: (...args: any[]) => void, options?: any): void;
+export declare function watchEffect(effect: (onCleanup: (cleanupFn: () => void) => void) => void): void;
+export declare function createApp(root: any): {
+  config: {
+    globalProperties: { [key: string]: any };
+  };
+};
 "#,
     )?;
     Ok(())


### PR DESCRIPTION
## Summary
- link fixture Vue packages to their real pnpm package path when available
- require a runtime-capable @vue namespace, falling back to a small local runtime-dom type stub
- keep CLI and canon test helpers aligned

## Validation
- cargo fmt --check
- git diff --check
- CARGO_INCREMENTAL=0 cargo test -p vize --test check_cli check_can_emit_declarations -- --nocapture
- CARGO_INCREMENTAL=0 cargo test -p vize --test check_cli check_declaration_emit_uses_tsconfig_options -- --nocapture
- CARGO_INCREMENTAL=0 cargo test -p vize --test check_cli check_links_real_vue_namespace_from_pnpm_vue_symlink -- --nocapture
- CARGO_INCREMENTAL=0 cargo test -p vize --test check_cli check_json_handles_monorepo_tsconfig_extends_paths_and_excludes -- --nocapture
- VIZE_TEST_WORKSPACE_NODE_MODULES=__none__ CARGO_INCREMENTAL=0 cargo test -p vize --test check_cli check_can_emit_declarations -- --nocapture
- VIZE_TEST_WORKSPACE_NODE_MODULES=__none__ CARGO_INCREMENTAL=0 cargo test -p vize --test check_cli check_declaration_emit_uses_tsconfig_options -- --nocapture
- CARGO_INCREMENTAL=0 cargo test -p vize_canon batch_type_checker_snapshots_cross_file_vue_prop_error -- --nocapture
- cargo llvm-cov --workspace --json --summary-only --output-path target/llvm-cov/source-summary.json --fail-under-lines 70 --fail-under-functions 70 --fail-under-regions 70
- node tools/coverage/enforce-rust-source-coverage.mjs --json target/llvm-cov/source-summary.json --min-lines 70 --min-functions 70 --min-regions 70

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/904"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783045855&installation_id=136613492&pr_number=904&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F904&signature=54832050f216e5284c8ddd455557f26212a82139819caef85ef67d0f688d6cb6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->