### PR TITLE
fix(typechecker): escape reserved template prop names

### DIFF
--- a/crates/vize_canon/src/sfc_typecheck.rs
+++ b/crates/vize_canon/src/sfc_typecheck.rs
@@ -454,6 +454,33 @@ const message = ref('Hello');
     }
 
     #[test]
+    fn test_type_check_escapes_reserved_template_prop_names() {
+        let source = r#"<template>
+    <div :class="{ active: static, class }">{{ default }}</div>
+</template>
+<script setup lang="ts">
+defineProps<{
+    static?: boolean;
+    default?: string;
+    class?: boolean;
+}>();
+</script>"#;
+        let options = SfcTypeCheckOptions::new("test.vue").with_virtual_ts();
+        let result = type_check_sfc(source, &options);
+        let virtual_ts = result.virtual_ts.expect("virtual ts produced");
+
+        assert!(
+            virtual_ts.contains("void ({ active: props[\"static\"], class: props[\"class\"] });"),
+            "{virtual_ts}"
+        );
+        assert!(
+            virtual_ts.contains("void (props[\"default\"]);"),
+            "{virtual_ts}"
+        );
+        assert!(!virtual_ts.contains("active: static"), "{virtual_ts}");
+    }
+
+    #[test]
     fn test_type_severity_serialization() {
         assert_eq!(
             serde_json::to_string(&SfcTypeSeverity::Error).unwrap(),

--- a/crates/vize_canon/src/virtual_ts/expressions.rs
+++ b/crates/vize_canon/src/virtual_ts/expressions.rs
@@ -154,10 +154,244 @@ fn rewrite_reserved_template_prop(
     expression: &str,
     template_prop_names: &FxHashSet<String>,
 ) -> Option<String> {
-    if !is_reserved_identifier(expression) || !template_prop_names.contains(expression) {
+    if template_prop_names.is_empty() {
         return None;
     }
-    Some(cstr!("props[\"{expression}\"]"))
+
+    let bytes = expression.as_bytes();
+    let len = bytes.len();
+    let mut i = 0;
+    let mut output = String::with_capacity(expression.len());
+    let mut changed = false;
+
+    while i < len {
+        let current = bytes[i];
+
+        if current == b'\'' || current == b'"' || current == b'`' {
+            let end = skip_quoted_literal(bytes, i);
+            output.push_str(&expression[i..end]);
+            i = end;
+            continue;
+        }
+
+        if current == b'/'
+            && i + 1 < len
+            && bytes[i + 1] != b'/'
+            && bytes[i + 1] != b'*'
+            && starts_regex_literal(bytes, i)
+        {
+            let end = skip_regex_literal(bytes, i);
+            output.push_str(&expression[i..end]);
+            i = end;
+            continue;
+        }
+
+        if is_identifier_start(current) {
+            let start = i;
+            i += 1;
+            while i < len && is_identifier_continue(bytes[i]) {
+                i += 1;
+            }
+            let ident = &expression[start..i];
+            if is_reserved_identifier(ident)
+                && template_prop_names.contains(ident)
+                && !is_property_access(bytes, start)
+                && !is_object_property_key(bytes, i)
+            {
+                if is_object_shorthand(bytes, start, i) {
+                    append!(output, "{ident}: props[\"{ident}\"]");
+                } else {
+                    append!(output, "props[\"{ident}\"]");
+                }
+                changed = true;
+            } else {
+                output.push_str(ident);
+            }
+            continue;
+        }
+
+        output.push(current as char);
+        i += 1;
+    }
+
+    changed.then_some(output)
+}
+
+fn skip_quoted_literal(bytes: &[u8], start: usize) -> usize {
+    let quote = bytes[start];
+    let mut i = start + 1;
+    while i < bytes.len() {
+        let current = bytes[i];
+        i += 1;
+        if current == b'\\' {
+            i = (i + 1).min(bytes.len());
+            continue;
+        }
+        if current == quote {
+            break;
+        }
+    }
+    i
+}
+
+fn skip_regex_literal(bytes: &[u8], start: usize) -> usize {
+    let mut i = start + 1;
+    let mut in_class = false;
+    while i < bytes.len() {
+        let current = bytes[i];
+        i += 1;
+        if current == b'\\' {
+            i = (i + 1).min(bytes.len());
+            continue;
+        }
+        match current {
+            b'[' => in_class = true,
+            b']' => in_class = false,
+            b'/' if !in_class => break,
+            _ => {}
+        }
+    }
+    while i < bytes.len() && bytes[i].is_ascii_alphabetic() {
+        i += 1;
+    }
+    i
+}
+
+fn starts_regex_literal(bytes: &[u8], slash: usize) -> bool {
+    let Some(prev) = previous_significant_byte(bytes, slash) else {
+        return true;
+    };
+    matches!(
+        prev,
+        b'(' | b'{'
+            | b'['
+            | b','
+            | b':'
+            | b';'
+            | b'='
+            | b'?'
+            | b'!'
+            | b'&'
+            | b'|'
+            | b'+'
+            | b'-'
+            | b'*'
+            | b'%'
+            | b'^'
+            | b'~'
+            | b'<'
+            | b'>'
+    )
+}
+
+fn previous_significant_byte(bytes: &[u8], before: usize) -> Option<u8> {
+    bytes[..before]
+        .iter()
+        .rev()
+        .copied()
+        .find(|b| !b.is_ascii_whitespace())
+}
+
+fn next_significant_byte(bytes: &[u8], after: usize) -> Option<u8> {
+    bytes[after..]
+        .iter()
+        .copied()
+        .find(|b| !b.is_ascii_whitespace())
+}
+
+fn is_property_access(bytes: &[u8], ident_start: usize) -> bool {
+    previous_significant_byte(bytes, ident_start) == Some(b'.')
+}
+
+fn is_object_property_key(bytes: &[u8], ident_end: usize) -> bool {
+    next_significant_byte(bytes, ident_end) == Some(b':')
+}
+
+fn is_object_shorthand(bytes: &[u8], ident_start: usize, ident_end: usize) -> bool {
+    matches!(
+        previous_significant_byte(bytes, ident_start),
+        Some(b'{') | Some(b',')
+    ) && matches!(
+        next_significant_byte(bytes, ident_end),
+        Some(b'}') | Some(b',')
+    )
+}
+
+fn is_identifier_start(byte: u8) -> bool {
+    byte.is_ascii_alphabetic() || byte == b'_' || byte == b'$'
+}
+
+fn is_identifier_continue(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || byte == b'_' || byte == b'$'
+}
+
+#[cfg(test)]
+mod tests {
+    use super::rewrite_reserved_template_prop;
+    use vize_carton::FxHashSet;
+
+    fn reserved_props() -> FxHashSet<vize_carton::String> {
+        ["static", "default", "class"]
+            .into_iter()
+            .map(Into::into)
+            .collect()
+    }
+
+    #[test]
+    fn rewrites_reserved_prop_identifier() {
+        assert_eq!(
+            rewrite_reserved_template_prop("static", &reserved_props()).as_deref(),
+            Some("props[\"static\"]")
+        );
+    }
+
+    #[test]
+    fn rewrites_reserved_prop_inside_object_value() {
+        assert_eq!(
+            rewrite_reserved_template_prop("{ active: static }", &reserved_props()).as_deref(),
+            Some("{ active: props[\"static\"] }")
+        );
+    }
+
+    #[test]
+    fn rewrites_reserved_prop_shorthand() {
+        assert_eq!(
+            rewrite_reserved_template_prop("{ static, class }", &reserved_props()).as_deref(),
+            Some("{ static: props[\"static\"], class: props[\"class\"] }")
+        );
+    }
+
+    #[test]
+    fn leaves_property_keys_and_member_accesses_alone() {
+        assert_eq!(
+            rewrite_reserved_template_prop(
+                "{ static: true, value: props.static, nested: item.default, active: static }",
+                &reserved_props(),
+            )
+            .as_deref(),
+            Some(
+                "{ static: true, value: props.static, nested: item.default, active: props[\"static\"] }",
+            )
+        );
+    }
+
+    #[test]
+    fn leaves_literals_and_regexes_alone() {
+        assert_eq!(
+            rewrite_reserved_template_prop(
+                "'static' + /static/.test(value) + `class` + static",
+                &reserved_props(),
+            )
+            .as_deref(),
+            Some("'static' + /static/.test(value) + `class` + props[\"static\"]")
+        );
+    }
+
+    #[test]
+    fn ignores_non_reserved_props() {
+        let props = ["count"].into_iter().map(Into::into).collect();
+        assert_eq!(rewrite_reserved_template_prop("count + 1", &props), None);
+    }
 }
 
 #[derive(Clone, Copy)]

--- a/crates/vize_canon/src/virtual_ts/props.rs
+++ b/crates/vize_canon/src/virtual_ts/props.rs
@@ -10,7 +10,7 @@ use vize_carton::cstr;
 use vize_carton::profile;
 use vize_croquis::Croquis;
 
-use super::helpers::to_safe_identifier;
+use super::helpers::{is_reserved_identifier, to_safe_identifier};
 
 #[inline]
 fn should_skip_template_prop_binding(summary: &Croquis, prop_name: &str) -> bool {
@@ -181,6 +181,9 @@ pub(crate) fn collect_template_prop_names(
             if should_skip_template_prop_binding(summary, prop.name.as_str()) {
                 continue;
             }
+            if !is_reserved_identifier(prop.name.as_str()) {
+                continue;
+            }
             names.insert(prop.name.as_str().into());
         }
         return names;
@@ -200,6 +203,9 @@ pub(crate) fn collect_template_prop_names(
             if should_skip_template_prop_binding(summary, prop.name.as_str()) {
                 continue;
             }
+            if !is_reserved_identifier(prop.name.as_str()) {
+                continue;
+            }
             names.insert(prop.name.as_str().into());
         }
         return names;
@@ -214,6 +220,9 @@ pub(crate) fn collect_template_prop_names(
     );
     for field in &field_names {
         if should_skip_template_prop_binding(summary, field.as_str()) {
+            continue;
+        }
+        if !is_reserved_identifier(field.as_str()) {
             continue;
         }
         names.insert(field.clone());


### PR DESCRIPTION
## Summary

- Rewrite reserved-word template prop references inside generated virtual TS expressions to `props["..."]`.
- Preserve object-literal property keys, member accesses, strings, and regex literals while rewriting value-position references.
- Add regression coverage for `static`, `default`, and `class` prop names in template expressions.

## Root cause

The previous rewrite only handled expressions that were exactly a reserved prop name, such as `static`. Composite expressions like `{ active: static }` still emitted the reserved word directly and produced TypeScript syntax/name diagnostics.

Fixes #910.

## Validation

- `cargo fmt -- crates/vize_canon/src/virtual_ts/expressions.rs crates/vize_canon/src/sfc_typecheck.rs`
- `cargo test -p vize_canon virtual_ts::expressions::tests -- --nocapture`
- `cargo test -p vize_canon test_type_check_escapes_reserved_template_prop_names -- --nocapture`
- `cargo build -p vize`
- temporary-project `target/debug/vize check --no-config --tsconfig tsconfig.json --format json src` for the `static` prop reproduction

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/923"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783054873&installation_id=136613492&pr_number=923&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F923&signature=c1ee0eb0d34f5956415cc79945ac7dae93f6f88556a1bd4f69ae4bc6707d1708"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->