### PR TITLE
fix(lint): skip Nuxt route filename casing

### DIFF
--- a/crates/vize_patina/src/rules/vue/component_definition_name_casing.rs
+++ b/crates/vize_patina/src/rules/vue/component_definition_name_casing.rs
@@ -60,6 +60,13 @@ fn is_pascal_case(s: &str) -> bool {
     true
 }
 
+fn is_nuxt_route_file(filename: &str) -> bool {
+    filename
+        .replace('\\', "/")
+        .split('/')
+        .any(|segment| segment == "pages")
+}
+
 /// Common exception filenames that don't need PascalCase
 const EXCEPTION_NAMES: &[&str] = &["App"];
 
@@ -71,6 +78,10 @@ impl Rule for ComponentDefinitionNameCasing {
     fn run_on_template<'a>(&self, ctx: &mut LintContext<'a>, root: &RootNode<'a>) {
         let filename = ctx.filename;
         if !filename.ends_with(".vue") {
+            return;
+        }
+
+        if is_nuxt_route_file(filename) {
             return;
         }
 
@@ -153,6 +164,27 @@ mod tests {
     }
 
     #[test]
+    fn test_valid_nuxt_pages_route_kebab_case() {
+        let linter = create_linter();
+        let result = linter.lint_template(r#"<div>Content</div>"#, "pages/job-board.vue");
+        assert_eq!(result.warning_count, 0);
+    }
+
+    #[test]
+    fn test_valid_nuxt_app_pages_route_kebab_case() {
+        let linter = create_linter();
+        let result = linter.lint_template(r#"<div>Content</div>"#, "app/pages/job-board.vue");
+        assert_eq!(result.warning_count, 0);
+    }
+
+    #[test]
+    fn test_valid_nuxt_src_pages_route_kebab_case() {
+        let linter = create_linter();
+        let result = linter.lint_template(r#"<div>Content</div>"#, "src/pages/job-board.vue");
+        assert_eq!(result.warning_count, 0);
+    }
+
+    #[test]
     fn test_invalid_camel_case() {
         let linter = create_linter();
         let result = linter.lint_template(r#"<div>Content</div>"#, "myComponent.vue");
@@ -165,6 +197,13 @@ mod tests {
         let result =
             linter.lint_template(r#"<div>Content</div>"#, "src/components/MyComponent.vue");
         assert_eq!(result.warning_count, 0);
+    }
+
+    #[test]
+    fn test_invalid_component_kebab_case_with_path() {
+        let linter = create_linter();
+        let result = linter.lint_template(r#"<div>Content</div>"#, "src/components/job-board.vue");
+        assert_eq!(result.warning_count, 1);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- skip `vue/component-definition-name-casing` for Vue files under Nuxt `pages` route directories
- cover root `pages/`, `app/pages/`, and `src/pages/` route files
- keep PascalCase enforcement for normal component paths

Closes #917

## Verification

- `cargo test -p vize_patina rules::vue::component_definition_name_casing::tests`
- `cargo fmt --check --package vize_patina`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/939"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783060993&installation_id=136613492&pr_number=939&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F939&signature=53e299daef56fb12ab99d3efdadc0f0ceab7e5106f5a17855e6ec79bcda8396b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->