### PR TITLE
fix(vite-plugin): compile transformed markdown SFC modules

### DIFF
--- a/npm/vite-plugin-vize/src/plugin/compat.test.ts
+++ b/npm/vite-plugin-vize/src/plugin/compat.test.ts
@@ -79,6 +79,68 @@ const msg = 'hello'
 }
 
 {
+  const state = createState({
+    filter: () => false,
+  });
+  const plugin = createPostTransformPlugin(state);
+  const markdownSfcId = path.join("/docs", "Page.md");
+  const result = await plugin.transform?.(virtualSfcSource, markdownSfcId, {
+    ssr: false,
+  });
+
+  assert.ok(
+    result && typeof result === "object",
+    "Markdown modules that contain transformed SFC source should compile by default",
+  );
+  assert.doesNotMatch(
+    result.code,
+    /^<template>/,
+    "Compiled Markdown SFC modules should not leak raw SFC blocks to Rolldown",
+  );
+  assert.match(
+    result.code,
+    /export default _sfc_main/,
+    "Compiled Markdown SFC modules should export the component",
+  );
+}
+
+{
+  const state = createState({
+    filter: (id) => id.endsWith(".mdx"),
+  });
+  const plugin = createPostTransformPlugin(state);
+  const mdxSfcId = path.join("/docs", "Page.mdx");
+  const result = await plugin.transform?.(virtualSfcSource, mdxSfcId, {
+    ssr: false,
+  });
+
+  assert.ok(
+    result && typeof result === "object",
+    "Custom extensions included by plugin options should compile when they contain SFC source",
+  );
+}
+
+{
+  const state = createState({
+    filter: () => true,
+  });
+  const plugin = createPostTransformPlugin(state);
+  const result = await plugin.transform?.(
+    `export default "<template><div /></template>";`,
+    path.join("/docs", "literal.md"),
+    {
+      ssr: false,
+    },
+  );
+
+  assert.equal(
+    result,
+    null,
+    "Post-transform should ignore regular JavaScript modules that merely contain SFC-looking strings",
+  );
+}
+
+{
   const transformed = transformScopedPreprocessorCss(
     ".rrevdjwu > .group + .group { color: red; }",
     "\0/src/MkSuperMenu.vue?vue=&type=style&index=0&scoped=data-v-menu&lang=scss.scss",

--- a/npm/vite-plugin-vize/src/plugin/compat.ts
+++ b/npm/vite-plugin-vize/src/plugin/compat.ts
@@ -77,6 +77,33 @@ export function createStylePostTransformPlugin(): Plugin {
   };
 }
 
+function stripQuery(id: string): string {
+  const queryStart = id.search(/[?#]/);
+  return queryStart === -1 ? id : id.slice(0, queryStart);
+}
+
+function isSfcLikeSource(code: string): boolean {
+  return /^<(?:template|script|style)(?:\s|>|\/)/.test(code.trimStart());
+}
+
+function shouldPostTransformSfcLikeModule(state: VizePluginState, id: string): boolean {
+  const filename = stripQuery(id);
+  if (
+    filename.endsWith(".vue") ||
+    filename.endsWith(".vue.ts") ||
+    filename.includes("node_modules")
+  ) {
+    return false;
+  }
+  if (filename.endsWith(".setup.ts")) {
+    return true;
+  }
+  if (state.filter(filename) || state.filter(id)) {
+    return true;
+  }
+  return /\.(?:md|markdown)$/i.test(filename);
+}
+
 // Post-transform plugin to handle virtual SFC content from other plugins.
 export function createPostTransformPlugin(state: VizePluginState): Plugin {
   return {
@@ -87,13 +114,7 @@ export function createPostTransformPlugin(state: VizePluginState): Plugin {
       id: string,
       transformOptions?: { ssr?: boolean },
     ): Promise<TransformResult | null> {
-      if (
-        !id.endsWith(".vue") &&
-        !id.endsWith(".vue.ts") &&
-        !id.includes("node_modules") &&
-        id.endsWith(".setup.ts") &&
-        /<script\s+setup[\s>]/.test(code)
-      ) {
+      if (shouldPostTransformSfcLikeModule(state, id) && isSfcLikeSource(code)) {
         state.logger.log(`post-transform: compiling virtual SFC content from ${id}`);
         try {
           const isSsr = !!transformOptions?.ssr;


### PR DESCRIPTION
## Summary
- broaden the Vite post-transform SFC detection to SFC-like transformed modules
- compile Markdown / Markdown-like outputs after upstream plugins emit Vue SFC blocks
- honor custom included extensions while ignoring regular JavaScript strings

## Validation
- npx -y pnpm@10 --dir npm/vite-plugin-vize check
- targeted node check for Markdown, custom extension, and JS string post-transform paths
- git diff --check

Note: running the full local compat test with symlinked dependencies stops on an existing CSS scoping expectation unrelated to this change; GitHub Actions remains the source of truth for the full matrix.

Closes #921

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/942"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783063071&installation_id=136613492&pr_number=942&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F942&signature=d0b7454222e62158396607677904694ec77e79bcc6dd3c936689a2f8c0bb4b3a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->