### PR TITLE
fix(nuxt): keep route announcer direct

### DIFF
--- a/npm/nuxt/src/components.test.ts
+++ b/npm/nuxt/src/components.test.ts
@@ -222,7 +222,7 @@ export default {
   }
 });
 
-void test("Nuxt component resolver preserves explicit component mode from registry", () => {
+void test("Nuxt component resolver keeps NuxtRouteAnnouncer unwrapped", () => {
   const fixture = createFixture();
   try {
     const routeAnnouncerPath = writeFile(
@@ -269,13 +269,13 @@ export default {
 
     assert.match(
       transformed,
-      /import \{ createClientOnly as __nuxt_create_client_only \} from "#app\/components\/client-only";/,
-      "registry client-only components should import createClientOnly",
+      /import __nuxt_component_0 from ".*nuxt-route-announcer\.js";/,
+      "NuxtRouteAnnouncer should be imported directly before use",
     );
-    assert.match(
-      transformed,
-      /import __nuxt_component_0_raw from ".*nuxt-route-announcer\.js";\s*const __nuxt_component_0 = __nuxt_create_client_only\(__nuxt_component_0_raw\);/s,
-      "registry client-only components should be wrapped before use",
+    assert.equal(
+      transformed.includes("__nuxt_create_client_only"),
+      false,
+      "NuxtRouteAnnouncer should not use createClientOnly",
     );
 
     const componentImportTransformed = injectNuxtComponentImports(
@@ -305,8 +305,13 @@ export default {
     );
     assert.match(
       componentImportTransformed,
-      /import (__nuxt_import_component_\d+_raw) from ".*nuxt-route-announcer\.js";\s*const NuxtRouteAnnouncer = __nuxt_create_client_only\(\1\);/s,
-      "#components imports should wrap registry client-only components",
+      /import NuxtRouteAnnouncer from ".*nuxt-route-announcer\.js";/,
+      "#components imports should keep NuxtRouteAnnouncer direct",
+    );
+    assert.equal(
+      componentImportTransformed.includes("__nuxt_create_client_only"),
+      false,
+      "#components imports should not wrap NuxtRouteAnnouncer",
     );
   } finally {
     fs.rmSync(fixture.rootDir, { recursive: true, force: true });

--- a/npm/nuxt/src/components.ts
+++ b/npm/nuxt/src/components.ts
@@ -33,6 +33,7 @@ const DTS_EXT_RE = /\.d\.ts$/;
 const FILE_EXTS = [".js", ".mjs", ".ts", ".vue"];
 const CLIENT_COMPONENT_RE = /\.client\.(?:[cm]?js|ts|vue)$/;
 const SERVER_COMPONENT_RE = /\.server\.(?:[cm]?js|ts|vue)$/;
+const NUXT_ROUTE_ANNOUNCER_RE = /(?:^|[/\\])nuxt-route-announcer\.(?:[cm]?js|ts|vue)$/;
 const RUNTIME_COMPONENT_DIRS = [
   "dist/runtime/components",
   "dist/runtime/components/nuxt4",
@@ -132,6 +133,17 @@ function normalizeComponentMode(mode: unknown): NuxtComponentImport["mode"] {
   return mode === "client" || mode === "server" ? mode : undefined;
 }
 
+function needsClientOnlyWrapper(resolved: NuxtComponentImport): boolean {
+  if (resolved.mode !== "client") {
+    return false;
+  }
+
+  // NuxtRouteAnnouncer supplies scoped default slot props itself. The generic
+  // client-only wrapper can expose a props-less placeholder slot path during
+  // hydration, which breaks destructured slots like `v-slot="{ message }"`.
+  return !NUXT_ROUTE_ANNOUNCER_RE.test(resolved.filePath);
+}
+
 function parseComponentImportSpecifier(raw: string): ComponentImportSpecifier | null {
   const trimmed = raw.trim();
   if (!trimmed) {
@@ -189,6 +201,7 @@ function addResolvedComponentBinding(
 ): ComponentBindingResult {
   let needsCreateClientOnly = false;
   let needsDefineAsyncComponent = false;
+  const wrapClientOnly = needsClientOnlyWrapper(resolved);
 
   if (resolved.lazy) {
     needsDefineAsyncComponent = true;
@@ -196,7 +209,7 @@ function addResolvedComponentBinding(
       resolved.exportName === "default"
         ? "module.default"
         : `module[${JSON.stringify(resolved.exportName)}]`;
-    if (resolved.mode === "client") {
+    if (wrapClientOnly) {
       needsCreateClientOnly = true;
       componentImports.push(
         `const ${variableName} = __nuxt_define_async_component(() => import(${JSON.stringify(resolved.filePath)}).then((module) => __nuxt_create_client_only(${exportAccessor})));`,
@@ -210,7 +223,7 @@ function addResolvedComponentBinding(
   }
 
   if (resolved.exportName === "default") {
-    if (resolved.mode === "client") {
+    if (wrapClientOnly) {
       needsCreateClientOnly = true;
       componentImports.push(`import ${rawVariableName} from ${JSON.stringify(resolved.filePath)};`);
       componentImports.push(
@@ -222,7 +235,7 @@ function addResolvedComponentBinding(
     return { needsCreateClientOnly, needsDefineAsyncComponent };
   }
 
-  if (resolved.mode === "client") {
+  if (wrapClientOnly) {
     needsCreateClientOnly = true;
     componentImports.push(
       `import { ${resolved.exportName} as ${rawVariableName} } from ${JSON.stringify(resolved.filePath)};`,


### PR DESCRIPTION
Closes #926

## Summary
- keep NuxtRouteAnnouncer imported directly even when Nuxt registry marks it client-only
- preserve generic client-only wrapping for other Nuxt client components
- update Nuxt component import injection tests for both resolveComponent and #components paths

## Validation
- node npm/nuxt/src/components.test.ts
- cargo fmt --check
- cargo test -p vize_atelier_core --lib
- cargo run --profile ci -p vize_test_runner --bin coverage

Note: direct local node npm/vite-plugin-vize/src/compiler.test.ts could not start without workspace node_modules/@vizejs/native; CI test-js-packages covers that path.