### PR TITLE
fix(nuxt): resolve generated auto imports and template globals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -394,21 +394,6 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "compact_str"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32"
-dependencies = [
- "castaway",
- "cfg-if",
- "itoa",
- "rustversion",
- "ryu",
- "serde",
- "static_assertions",
-]
-
-[[package]]
-name = "compact_str"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb1325a1cece981e8a296ab8f0f9b63ae357bd0784a9faaf548cc7b480707a"
@@ -488,9 +473,9 @@ dependencies = [
 
 [[package]]
 name = "corsa"
-version = "0.7.0"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33c2e4bfb456dc2e76c7d79b9df8feae329f71e6118f24c9b572ed058d7db16d"
+checksum = "05cae3e14a400484c06b0578e63cb14f60de01fd33f4e0a143e64c4d96ad2924"
 dependencies = [
  "base64",
  "corsa_client",
@@ -505,9 +490,9 @@ dependencies = [
 
 [[package]]
 name = "corsa_client"
-version = "0.7.0"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffe10d23b91bc741d8a8f7321ce511217e4d3fefad9b06339bbe1080701a0ca5"
+checksum = "3acf8c65e85211669765894f4253700de59e8e1e2b6264b1faf6a3aafba901b0"
 dependencies = [
  "base64",
  "corsa_core",
@@ -516,20 +501,20 @@ dependencies = [
  "log",
  "lsp-types 0.97.0",
  "parking_lot",
- "phf 0.11.3",
+ "phf 0.13.1",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "corsa_core"
-version = "0.7.0"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9f06b9e750f1fe976dee2fd0de533e3a29cbba9ce65ca976d2116f46cef09cf"
+checksum = "31da616b7b3ee544694fa852a66e92a1656fdcaa99562020f1d3670662c2a1e6"
 dependencies = [
  "base64",
  "bumpalo",
- "compact_str 0.8.1",
+ "compact_str",
  "memchr",
  "rustc-hash",
  "serde",
@@ -540,9 +525,9 @@ dependencies = [
 
 [[package]]
 name = "corsa_jsonrpc"
-version = "0.7.0"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "779769900e053e7c3dbb7f30c0d56feb81f49f03630c4ba076d3d44c5c4f2b1e"
+checksum = "e9400f1602c4fc0c3b5a66efe30a951f1030cd2c6e0e3cf4984785e4a3b46159"
 dependencies = [
  "corsa_core",
  "corsa_runtime",
@@ -554,9 +539,9 @@ dependencies = [
 
 [[package]]
 name = "corsa_lsp"
-version = "0.7.0"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc18e8e59f595f5d6975a81a9a980832002c557a13e8484f77632d2dcaa738f7"
+checksum = "ddd75a7c6341921b87108af76c298e2ef0e83312282e78927c5e95387c0730e5"
 dependencies = [
  "corsa_core",
  "corsa_jsonrpc",
@@ -569,9 +554,9 @@ dependencies = [
 
 [[package]]
 name = "corsa_orchestrator"
-version = "0.7.0"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52150949519b09b03ad8d63e3f310b35b921b23b4cf9f6b15976c0f1cecd7730"
+checksum = "cb47caeb0f4a355d43e71de4df4a84ba6c2d2ff70ea7420a967c4588f088270c"
 dependencies = [
  "corsa_client",
  "corsa_core",
@@ -586,9 +571,9 @@ dependencies = [
 
 [[package]]
 name = "corsa_runtime"
-version = "0.7.0"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b023b8de46eaca504cec95861ce4d19970e99e199c3fc2128067189634450df8"
+checksum = "c88dc8c86f67beee84e4ff5b3ba2398f63db78213a8631d1ed7c3a5f0a96e407"
 dependencies = [
  "smallvec",
 ]
@@ -2027,7 +2012,7 @@ name = "oxc_span"
 version = "0.127.0"
 source = "git+https://github.com/oxc-project/oxc?rev=8265ed94b8f743a11dbf6f81fdd6fd248906f366#8265ed94b8f743a11dbf6f81fdd6fd248906f366"
 dependencies = [
- "compact_str 0.9.0",
+ "compact_str",
  "oxc-miette",
  "oxc_allocator",
  "oxc_ast_macros",
@@ -2040,7 +2025,7 @@ name = "oxc_str"
 version = "0.127.0"
 source = "git+https://github.com/oxc-project/oxc?rev=8265ed94b8f743a11dbf6f81fdd6fd248906f366#8265ed94b8f743a11dbf6f81fdd6fd248906f366"
 dependencies = [
- "compact_str 0.9.0",
+ "compact_str",
  "hashbrown 0.17.0",
  "oxc_allocator",
  "oxc_estree",
@@ -2071,7 +2056,7 @@ version = "0.127.0"
 source = "git+https://github.com/oxc-project/oxc?rev=8265ed94b8f743a11dbf6f81fdd6fd248906f366#8265ed94b8f743a11dbf6f81fdd6fd248906f366"
 dependencies = [
  "base64",
- "compact_str 0.9.0",
+ "compact_str",
  "indexmap",
  "itoa",
  "memchr",
@@ -3428,7 +3413,7 @@ dependencies = [
 name = "vize_armature"
 version = "0.164.0"
 dependencies = [
- "compact_str 0.9.0",
+ "compact_str",
  "htmlize",
  "insta",
  "serde",
@@ -3442,7 +3427,7 @@ name = "vize_atelier_core"
 version = "0.164.0"
 dependencies = [
  "bumpalo",
- "compact_str 0.9.0",
+ "compact_str",
  "insta",
  "memoffset",
  "oxc_allocator",
@@ -3577,7 +3562,7 @@ version = "0.164.0"
 dependencies = [
  "bitflags 2.11.1",
  "bumpalo",
- "compact_str 0.9.0",
+ "compact_str",
  "insta",
  "once_cell",
  "phf 0.13.1",
@@ -3639,7 +3624,7 @@ dependencies = [
 name = "vize_fresco"
 version = "0.164.0"
 dependencies = [
- "compact_str 0.9.0",
+ "compact_str",
  "criterion",
  "crossterm",
  "insta",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,9 +136,9 @@ insta = { version = "=1.47.2", features = ["toml"] }
 criterion = "=0.8.2"
 
 # Published corsa crates
-corsa = { package = "corsa", version = "=0.7.0" }
-corsa_lsp = { package = "corsa_lsp", version = "=0.7.0" }
-corsa_runtime = { package = "corsa_runtime", version = "=0.7.0" }
+corsa = { package = "corsa", version = "=0.36.0" }
+corsa_lsp = { package = "corsa_lsp", version = "=0.36.0" }
+corsa_runtime = { package = "corsa_runtime", version = "=0.36.0" }
 
 [profile.release]
 # Release artifacts are benchmarked and shipped from this profile. Fat LTO plus

--- a/crates/vize/src/commands/check/nuxt.rs
+++ b/crates/vize/src/commands/check/nuxt.rs
@@ -18,6 +18,7 @@ use super::dts::{
     parse_declared_global_values, parse_interface_members_with_rewritten_imports,
     rewrite_relative_specifier,
 };
+use vize_canon::virtual_ts::TemplateGlobal;
 
 pub(super) fn detect_nuxt_auto_imports(options: &mut VirtualTsOptions, cwd: &Path) {
     if !is_nuxt_project(cwd) {
@@ -48,6 +49,7 @@ pub(super) fn detect_nuxt_auto_imports(options: &mut VirtualTsOptions, cwd: &Pat
     );
     collect_plugin_injection_stubs(cwd, &mut collected, &mut seen_names);
     collect_fallback_stubs(&mut collected, &mut seen_names);
+    collect_generated_template_globals(cwd, options, &seen_names);
 
     for stub in &collected {
         if let Some(name) = declared_name(stub)
@@ -121,6 +123,7 @@ fn collect_generated_stubs(
         }
     }
 
+    collect_root_generated_global_stubs(cwd, stubs, seen_names);
     collect_root_generated_component_stubs(cwd, stubs, seen_names, external_template_bindings);
 
     if found_typed_imports {
@@ -171,26 +174,27 @@ fn collect_generated_stubs(
     }
 }
 
+fn collect_root_generated_global_stubs(
+    cwd: &Path,
+    stubs: &mut Vec<String>,
+    seen_names: &mut FxHashSet<String>,
+) {
+    for path in root_generated_dts_files(cwd) {
+        if let Ok(values) = parse_declared_global_values(path.as_path()) {
+            for (name, type_annotation) in values {
+                push_declared_const(stubs, seen_names, &name, &type_annotation);
+            }
+        }
+    }
+}
+
 fn collect_root_generated_component_stubs(
     cwd: &Path,
     stubs: &mut Vec<String>,
     seen_names: &mut FxHashSet<String>,
     external_template_bindings: &mut FxHashSet<String>,
 ) {
-    let nuxt_dir = cwd.join(".nuxt");
-    let Ok(entries) = fs::read_dir(&nuxt_dir) else {
-        return;
-    };
-
-    for entry in entries.flatten() {
-        let path = entry.path();
-        let is_dts = path
-            .file_name()
-            .and_then(|name| name.to_str())
-            .is_some_and(|name| name.ends_with(".d.ts"));
-        if !path.is_file() || !is_dts {
-            continue;
-        }
+    for path in root_generated_dts_files(cwd) {
         collect_global_component_stubs(
             cwd,
             path.as_path(),
@@ -199,6 +203,25 @@ fn collect_root_generated_component_stubs(
             external_template_bindings,
         );
     }
+}
+
+fn root_generated_dts_files(cwd: &Path) -> Vec<std::path::PathBuf> {
+    let nuxt_dir = cwd.join(".nuxt");
+    let Ok(entries) = fs::read_dir(&nuxt_dir) else {
+        return Vec::new();
+    };
+
+    entries
+        .flatten()
+        .map(|entry| entry.path())
+        .filter(|path| {
+            path.is_file()
+                && path
+                    .file_name()
+                    .and_then(|name| name.to_str())
+                    .is_some_and(|name| name.ends_with(".d.ts"))
+        })
+        .collect()
 }
 
 fn collect_global_component_stubs(
@@ -222,6 +245,96 @@ fn collect_global_component_stubs(
             rewrite_component_imports_for_virtual_project(type_annotation.as_str(), cwd);
         external_template_bindings.insert(name.clone());
         push_declared_const(stubs, seen_names, name.as_str(), type_annotation.as_str());
+    }
+}
+
+fn collect_generated_template_globals(
+    cwd: &Path,
+    options: &mut VirtualTsOptions,
+    seen_auto_imports: &FxHashSet<String>,
+) {
+    let mut seen_globals = options
+        .template_globals
+        .iter()
+        .map(|global| global.name.clone())
+        .collect::<FxHashSet<_>>();
+
+    for path in generated_dts_files(cwd) {
+        let Ok(members) = parse_interface_members_with_rewritten_imports(
+            path.as_path(),
+            "interface ComponentCustomProperties",
+        ) else {
+            continue;
+        };
+
+        for (name, _type_annotation) in members {
+            let Some(name) = normalize_component_binding_name(name.as_str()) else {
+                continue;
+            };
+            if !name.starts_with('$') {
+                continue;
+            }
+            push_template_global(options, &mut seen_globals, name.as_str(), "any");
+        }
+    }
+
+    if seen_auto_imports.contains("useI18n") || seen_auto_imports.contains("useLocalePath") {
+        collect_i18n_template_globals(options, &mut seen_globals);
+    }
+}
+
+fn generated_dts_files(cwd: &Path) -> Vec<std::path::PathBuf> {
+    let mut files = root_generated_dts_files(cwd);
+    let nuxt_types_dir = cwd.join(".nuxt/types");
+    if nuxt_types_dir.exists() {
+        let walker = WalkBuilder::new(&nuxt_types_dir)
+            .hidden(false)
+            .standard_filters(false)
+            .build();
+
+        for entry in walker.flatten() {
+            let path = entry.path();
+            let is_dts = path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| name.ends_with(".d.ts"));
+            if path.is_file() && is_dts {
+                files.push(path.to_path_buf());
+            }
+        }
+    }
+    files
+}
+
+fn collect_i18n_template_globals(
+    options: &mut VirtualTsOptions,
+    seen_globals: &mut FxHashSet<String>,
+) {
+    for (name, type_annotation) in [
+        ("$t", "(...args: any[]) => any"),
+        ("$rt", "(...args: any[]) => any"),
+        ("$d", "(...args: any[]) => any"),
+        ("$n", "(...args: any[]) => any"),
+        ("$tm", "(...args: any[]) => any"),
+        ("$te", "(...args: any[]) => boolean"),
+        ("$i18n", "any"),
+    ] {
+        push_template_global(options, seen_globals, name, type_annotation);
+    }
+}
+
+fn push_template_global(
+    options: &mut VirtualTsOptions,
+    seen_globals: &mut FxHashSet<String>,
+    name: &str,
+    type_annotation: &str,
+) {
+    if seen_globals.insert(name.to_compact_string()) {
+        options.template_globals.push(TemplateGlobal {
+            name: name.to_compact_string(),
+            type_annotation: type_annotation.to_compact_string(),
+            default_value: "undefined as any".into(),
+        });
     }
 }
 
@@ -888,6 +1001,69 @@ export {}
                 .external_template_bindings
                 .iter()
                 .any(|name| name == "ClientOnly")
+        );
+
+        let _ = std::fs::remove_dir_all(&project_root);
+    }
+
+    #[test]
+    fn detects_root_nuxt_imports_and_i18n_template_globals() {
+        let project_root = unique_case_dir("nuxt-root-imports");
+        let _ = std::fs::remove_dir_all(&project_root);
+        std::fs::create_dir_all(project_root.join(".nuxt/types")).unwrap();
+        std::fs::create_dir_all(project_root.join("app/composables")).unwrap();
+        std::fs::write(project_root.join("nuxt.config.ts"), "export default {}").unwrap();
+        std::fs::write(
+            project_root.join(".nuxt/imports.d.ts"),
+            r#"declare global {
+  const useI18n: typeof import('../app/composables/i18n')['useI18n']
+  const useLocalePath: typeof import('../app/composables/i18n')['useLocalePath']
+  const queryCollection: typeof import('../app/composables/content')['queryCollection']
+}
+export {}
+"#,
+        )
+        .unwrap();
+        std::fs::write(
+            project_root.join(".nuxt/types/i18n.d.ts"),
+            r#"declare module 'vue' {
+  export interface ComponentCustomProperties {
+    $t: (...args: any[]) => string
+  }
+}
+export {}
+"#,
+        )
+        .unwrap();
+
+        let mut options = VirtualTsOptions::default();
+        detect_nuxt_auto_imports(&mut options, &project_root);
+
+        for name in ["useI18n", "useLocalePath", "queryCollection"] {
+            assert!(
+                options
+                    .auto_import_stubs
+                    .iter()
+                    .any(|stub| stub.contains(&format!("declare const {name}:"))),
+                "expected {name} stub, got: {:#?}",
+                options.auto_import_stubs
+            );
+        }
+        assert!(
+            options
+                .template_globals
+                .iter()
+                .any(|global| global.name == "$t"),
+            "expected $t template global, got: {:#?}",
+            options.template_globals
+        );
+        assert!(
+            options
+                .template_globals
+                .iter()
+                .any(|global| global.name == "$te"),
+            "expected i18n fallback template globals, got: {:#?}",
+            options.template_globals
         );
 
         let _ = std::fs::remove_dir_all(&project_root);

--- a/crates/vize_canon/src/lsp_client/diagnostics.rs
+++ b/crates/vize_canon/src/lsp_client/diagnostics.rs
@@ -488,6 +488,8 @@ fn diagnostics_api_is_unsupported(error: &str) -> bool {
     error.contains("unknown API method")
         || error.contains("method not found")
         || error.contains("Unsupported")
+        || error.contains("unsupported")
+        || error.contains("not supported")
 }
 
 fn lsp_diagnostics_error_is_transient(error: &str) -> bool {
@@ -668,7 +670,21 @@ fn language_id_for_uri(uri: &str) -> &'static str {
 
 #[cfg(test)]
 mod tests {
-    use super::lsp_diagnostics_error_is_transient;
+    use super::{diagnostics_api_is_unsupported, lsp_diagnostics_error_is_transient};
+
+    #[test]
+    fn recognizes_unsupported_diagnostics_api_errors() {
+        assert!(diagnostics_api_is_unsupported("unknown API method"));
+        assert!(diagnostics_api_is_unsupported(
+            "unsupported: project diagnostics are not supported by this runtime"
+        ));
+        assert!(diagnostics_api_is_unsupported(
+            "project diagnostics are not supported by this runtime"
+        ));
+        assert!(!diagnostics_api_is_unsupported(
+            "Failed to request Corsa project diagnostics: process exited"
+        ));
+    }
 
     #[test]
     fn recognizes_transient_lsp_transport_errors() {

--- a/crates/vize_canon/src/lsp_client/session.rs
+++ b/crates/vize_canon/src/lsp_client/session.rs
@@ -3,11 +3,11 @@
 use super::{CorsaProjectClient, utils::remap_serialized_uris};
 use crate::file_uri::{file_uri_to_path, path_to_file_uri};
 use corsa::{
+    CorsaError,
     api::{
         ApiMode, ApiSpawnConfig, CapabilitiesResponse, DocumentIdentifier, FileChangeSummary,
         FileChanges, OverlayChanges, OverlayUpdate, ProjectSession,
     },
-    error::TsgoError,
     fast::CompactString,
     runtime::block_on,
 };
@@ -59,7 +59,7 @@ async fn spawn_project_session_with_mode(
     cwd: &Path,
     config_path: &str,
     mode: ApiMode,
-) -> Result<ProjectSession, TsgoError> {
+) -> Result<ProjectSession, CorsaError> {
     ProjectSession::spawn(
         ApiSpawnConfig::new(executable)
             .with_mode(mode)
@@ -70,12 +70,12 @@ async fn spawn_project_session_with_mode(
     .await
 }
 
-fn should_retry_json_rpc(mode: ApiMode, error: &TsgoError) -> bool {
+fn should_retry_json_rpc(mode: ApiMode, error: &CorsaError) -> bool {
     if mode != ApiMode::SyncMsgpackStdio {
         return false;
     }
 
-    let TsgoError::Protocol(message) = error else {
+    let CorsaError::Protocol(message) = error else {
         return false;
     };
 
@@ -413,8 +413,8 @@ mod tests {
         api_mode_for_executable, line_character_to_utf16_offset, should_retry_json_rpc,
         uri_document_identifier,
     };
+    use corsa::CorsaError;
     use corsa::api::{ApiMode, DocumentIdentifier};
-    use corsa::error::TsgoError;
 
     #[test]
     fn uses_async_json_rpc_for_node_modules_bin_wrappers() {
@@ -444,7 +444,7 @@ mod tests {
 
     #[test]
     fn retries_json_rpc_after_msgpack_shape_mismatch() {
-        let error = TsgoError::Protocol("expected tuple marker, got 61".into());
+        let error = CorsaError::Protocol("expected tuple marker, got 61".into());
 
         assert!(should_retry_json_rpc(ApiMode::SyncMsgpackStdio, &error));
         assert!(!should_retry_json_rpc(ApiMode::AsyncJsonRpcStdio, &error));

--- a/npm/nuxt/src/components.test.ts
+++ b/npm/nuxt/src/components.test.ts
@@ -147,6 +147,57 @@ void test("Nuxt component resolver reads generated d.ts, runtime fallbacks, and 
   }
 });
 
+void test("Nuxt component resolver reads GlobalComponents declarations", () => {
+  const fixture = createFixture();
+  try {
+    const helloCardPath = writeFile(path.join(fixture.rootDir, "app/components/HelloCard.vue"));
+    const quotedWidgetPath = writeFile(
+      path.join(fixture.rootDir, "app/components/widgets/QuotedWidget.vue"),
+    );
+    writeFile(
+      path.join(fixture.buildDir, "types/components.d.ts"),
+      [
+        `declare module "vue" {`,
+        `  export interface GlobalComponents {`,
+        `    HelloCard: typeof import(${JSON.stringify(
+          path.relative(path.join(fixture.buildDir, "types"), helloCardPath),
+        )})["default"]`,
+        `    "QuotedWidget": typeof import(${JSON.stringify(
+          path.relative(path.join(fixture.buildDir, "types"), quotedWidgetPath),
+        )})["default"]`,
+        `  }`,
+        `}`,
+        `export {}`,
+        "",
+      ].join("\n"),
+    );
+
+    const resolver = createNuxtComponentResolver({
+      buildDir: fixture.buildDir,
+      rootDir: fixture.rootDir,
+    });
+
+    assert.deepEqual(
+      resolver.resolve("HelloCard"),
+      {
+        exportName: "default",
+        filePath: path.join(fixture.rootDir, "app/components/HelloCard.vue"),
+      },
+      "Nuxt 4 GlobalComponents d.ts entries should resolve app components",
+    );
+    assert.deepEqual(
+      resolver.resolve("quoted-widget"),
+      {
+        exportName: "default",
+        filePath: path.join(fixture.rootDir, "app/components/widgets/QuotedWidget.vue"),
+      },
+      "quoted GlobalComponents entries should get kebab aliases",
+    );
+  } finally {
+    fs.rmSync(fixture.rootDir, { recursive: true, force: true });
+  }
+});
+
 void test("Nuxt component import injection rewrites resolved runtime components", () => {
   const fixture = createFixture();
   try {

--- a/npm/nuxt/src/components.ts
+++ b/npm/nuxt/src/components.ts
@@ -29,6 +29,8 @@ const COMPONENTS_IMPORT_RE = /import\s+(?!type\b)\{([^}]*)\}\s+from\s+(["'])#com
 const COMPONENT_EXT_RE = /\.(?:[cm]?js|ts|vue)$/;
 const DTS_COMPONENT_RE =
   /^export const (\w+): (?:LazyComponent<)?typeof import\((["'])(.+?)\2\)(?:\.([A-Za-z_$][\w$]*)|\[['"]([A-Za-z_$][\w$]*)['"]\])>?/;
+const DTS_GLOBAL_COMPONENT_RE =
+  /^(?:"([^"]+)"|'([^']+)'|([A-Za-z_$][\w$]*))\??:\s*(?:LazyComponent<)?typeof import\((["'])(.+?)\4\)(?:\.([A-Za-z_$][\w$]*)|\[['"]([A-Za-z_$][\w$]*)['"]\])>?;?$/;
 const DTS_EXT_RE = /\.d\.ts$/;
 const FILE_EXTS = [".js", ".mjs", ".ts", ".vue"];
 const CLIENT_COMPONENT_RE = /\.client\.(?:[cm]?js|ts|vue)$/;
@@ -267,12 +269,54 @@ function loadDtsComponents(rootDir: string, buildDir: string): Map<string, NuxtC
   const resolved = new Map<string, NuxtComponentImport>();
 
   for (const filePath of getNuxtComponentDtsFiles(rootDir, buildDir)) {
+    let inGlobalComponents = false;
+    let braceDepth = 0;
+
     forEachLine(fs.readFileSync(filePath, "utf-8"), (line) => {
-      const match = line.match(DTS_COMPONENT_RE);
-      if (!match) {
+      const trimmed = line.trim();
+      if (!inGlobalComponents && trimmed.includes("interface GlobalComponents")) {
+        inGlobalComponents = true;
+        braceDepth = countBraceDelta(trimmed);
         return;
       }
 
+      if (inGlobalComponents) {
+        braceDepth += countBraceDelta(trimmed);
+        if (braceDepth <= 0) {
+          inGlobalComponents = false;
+          return;
+        }
+
+        const globalMatch = trimmed.match(DTS_GLOBAL_COMPONENT_RE);
+        if (globalMatch) {
+          const doubleQuotedName = globalMatch[1];
+          const singleQuotedName = globalMatch[2];
+          const bareName = globalMatch[3];
+          const importPath = globalMatch[5]!;
+          const exportNameDot = globalMatch[6];
+          const exportNameBracket = globalMatch[7];
+          const name = doubleQuotedName || singleQuotedName || bareName;
+          const exportName = exportNameDot || exportNameBracket;
+          if (name && exportName) {
+            const absoluteImportPath = resolveImportPath(
+              path.resolve(path.dirname(filePath), importPath),
+            );
+            const componentImport = createComponentImport(
+              absoluteImportPath,
+              exportName,
+              name.startsWith("Lazy"),
+            );
+            addComponentAlias(resolved, name, componentImport);
+            addLazyComponentAlias(resolved, name, componentImport);
+          }
+        }
+        return;
+      }
+
+      const match = trimmed.match(DTS_COMPONENT_RE);
+      if (!match) {
+        return;
+      }
       const [, name, , importPath, exportNameDot, exportNameBracket] = match;
       const exportName = exportNameDot || exportNameBracket;
       if (!exportName) {
@@ -294,6 +338,18 @@ function loadDtsComponents(rootDir: string, buildDir: string): Map<string, NuxtC
   }
 
   return resolved;
+}
+
+function countBraceDelta(line: string): number {
+  let delta = 0;
+  for (const ch of line) {
+    if (ch === "{") {
+      delta++;
+    } else if (ch === "}") {
+      delta--;
+    }
+  }
+  return delta;
 }
 
 function getProjectPackageNames(moduleNames: string[] | undefined): string[] {


### PR DESCRIPTION
Closes #928
Closes #913

## Summary
- resolve Nuxt 4 `GlobalComponents` declarations when rewriting Vize virtual modules, so auto-imported `app/components` entries become direct imports instead of runtime `resolveComponent` misses
- load root `.nuxt/*.d.ts` generated globals such as `.nuxt/imports.d.ts` into the Corsa virtual project for Nuxt checks
- add generated `ComponentCustomProperties` / Nuxt i18n template globals so `$t` and related helpers resolve in templates
- update Corsa crates from `0.7.0` to `0.36.0` and adjust the LSP session error type to `CorsaError`
- treat lowercase Corsa diagnostics `unsupported` / `not supported` errors as fallback signals so runtimes without project diagnostics can continue via the existing fallback path

## Validation
- `cargo fmt --check`
- `git diff --check`
- `cargo check -p vize_canon -p vize_patina -p vize`
- `cargo test -p vize_canon lsp_client::diagnostics --lib`
- `cargo test -p vize_canon lsp_client::session --lib`
- `cargo test -p vize check::nuxt --lib`
- `corepack pnpm --filter @vizejs/nuxt test`

## Notes
- `corepack pnpm --filter @vizejs/nuxt check` and local `vue-parity` fixture reproduction could not run locally because this worktree has no `node_modules`; CI is used for those checks.
