### PR TITLE
fix(compiler): resolve re-exported SFC interface props

### DIFF
--- a/crates/vize_atelier_sfc/src/compile/tests.rs
+++ b/crates/vize_atelier_sfc/src/compile/tests.rs
@@ -1415,6 +1415,35 @@ fn test_define_props_interface_extends_imported_type_alias() {
 }
 
 #[test]
+fn test_define_props_interface_extends_reexported_vue_interface() {
+    let fixture_path = fixtures_path().join("ReExportedParentWidget.vue");
+    let source = fs::read_to_string(&fixture_path).expect("fixture should load");
+    let descriptor = parse_sfc(&source, SfcParseOptions::default()).expect("Failed to parse SFC");
+    let mut opts = SfcCompileOptions::default();
+    opts.script.id = Some(fixture_path.to_string_lossy().as_ref().to_compact_string());
+
+    let result = compile_sfc(&descriptor, opts).expect("Failed to compile SFC");
+
+    assert!(result.code.contains("props: {"), "{}", result.code);
+    assert!(
+        result.code.contains("as: {\n      type: String"),
+        "{}",
+        result.code
+    );
+    assert!(
+        result.code.contains("asChild: {\n      type: Boolean"),
+        "{}",
+        result.code
+    );
+    assert!(result.code.contains("as: __props.as"), "{}", result.code);
+    assert!(
+        result.code.contains("\"as-child\": props.asChild"),
+        "{}",
+        result.code
+    );
+}
+
+#[test]
 fn test_with_defaults_resolves_imported_vue_type_from_src_alias() {
     let project = temp_compile_project_dir("with-defaults-src-alias");
     let components = project.join("packages/frontend/src/components");

--- a/crates/vize_atelier_sfc/src/script/context/external_types.rs
+++ b/crates/vize_atelier_sfc/src/script/context/external_types.rs
@@ -1,9 +1,9 @@
 use std::path::{Path, PathBuf};
 
 use oxc_allocator::Allocator;
-use oxc_ast::ast::{ImportDeclarationSpecifier, Statement};
+use oxc_ast::ast::{ExportNamedDeclaration, ImportDeclarationSpecifier, Statement};
 use oxc_parser::Parser;
-use oxc_span::SourceType;
+use oxc_span::{GetSpan, SourceType};
 use vize_carton::{FxHashSet, String, ToCompactString};
 
 use crate::parse_sfc;
@@ -28,7 +28,7 @@ const INDEX_CANDIDATES: &[&str] = &[
 
 impl ScriptCompileContext {
     pub fn collect_imported_types_from_path(&mut self, source: &str, filename: &str) {
-        if !source.contains("import") || !source.contains("type") {
+        if !source.contains("type") || (!source.contains("import") && !source.contains("export")) {
             return;
         }
 
@@ -60,46 +60,84 @@ impl ScriptCompileContext {
         }
 
         for stmt in ret.program.body.iter() {
-            let Statement::ImportDeclaration(import_decl) = stmt else {
-                continue;
-            };
+            match stmt {
+                Statement::ImportDeclaration(import_decl) => {
+                    if !import_decl.import_kind.is_type()
+                        && !is_import_type_only(import_decl, source)
+                        && !import_decl.specifiers.as_ref().is_some_and(|specifiers| {
+                            specifiers.iter().any(|specifier| match specifier {
+                                ImportDeclarationSpecifier::ImportSpecifier(spec) => {
+                                    spec.import_kind.is_type()
+                                }
+                                _ => false,
+                            })
+                        })
+                    {
+                        continue;
+                    }
 
-            if !import_decl.import_kind.is_type()
-                && !is_import_type_only(import_decl, source)
-                && !import_decl.specifiers.as_ref().is_some_and(|specifiers| {
-                    specifiers.iter().any(|specifier| match specifier {
-                        ImportDeclarationSpecifier::ImportSpecifier(spec) => {
-                            spec.import_kind.is_type()
-                        }
-                        _ => false,
-                    })
-                })
-            {
-                continue;
+                    self.collect_types_from_specifier(
+                        import_decl.source.value.as_str(),
+                        current_file,
+                        visited,
+                    );
+                }
+                Statement::ExportNamedDeclaration(export_decl) => {
+                    let Some(ref export_source) = export_decl.source else {
+                        continue;
+                    };
+                    if !is_type_re_export(export_decl, source) {
+                        continue;
+                    }
+
+                    self.collect_types_from_specifier(
+                        export_source.value.as_str(),
+                        current_file,
+                        visited,
+                    );
+                }
+                Statement::ExportAllDeclaration(export_decl) => {
+                    if !is_export_all_type_only(stmt, source) {
+                        continue;
+                    }
+
+                    self.collect_types_from_specifier(
+                        export_decl.source.value.as_str(),
+                        current_file,
+                        visited,
+                    );
+                }
+                _ => {}
             }
-
-            let specifier = import_decl.source.value.as_str();
-            let Some(resolved_path) = resolve_import_path(current_file, specifier) else {
-                continue;
-            };
-
-            let key = path_key(&resolved_path);
-            if !visited.insert(key) {
-                continue;
-            }
-
-            let Ok(content) = std::fs::read_to_string(&resolved_path) else {
-                continue;
-            };
-
-            if resolved_path.extension().is_some_and(|ext| ext == "vue") {
-                self.collect_types_from_vue_file(&resolved_path, &content, visited);
-                continue;
-            }
-
-            self.collect_types_from(&content);
-            self.collect_imported_types_recursive(&content, &resolved_path, visited);
         }
+    }
+
+    fn collect_types_from_specifier(
+        &mut self,
+        specifier: &str,
+        current_file: &Path,
+        visited: &mut FxHashSet<String>,
+    ) {
+        let Some(resolved_path) = resolve_import_path(current_file, specifier) else {
+            return;
+        };
+
+        let key = path_key(&resolved_path);
+        if !visited.insert(key) {
+            return;
+        }
+
+        let Ok(content) = std::fs::read_to_string(&resolved_path) else {
+            return;
+        };
+
+        if resolved_path.extension().is_some_and(|ext| ext == "vue") {
+            self.collect_types_from_vue_file(&resolved_path, &content, visited);
+            return;
+        }
+
+        self.collect_types_from(&content);
+        self.collect_imported_types_recursive(&content, &resolved_path, visited);
     }
 
     fn collect_types_from_vue_file(
@@ -187,6 +225,34 @@ fn canonicalize_or_original(path: PathBuf) -> Option<PathBuf> {
     }
 }
 
+fn is_type_re_export(export_decl: &ExportNamedDeclaration<'_>, source: &str) -> bool {
+    if export_decl.export_kind.is_type() {
+        return true;
+    }
+
+    let span = export_decl.span;
+    let start = span.start as usize;
+    let end = span.end as usize;
+    if start >= end || end > source.len() {
+        return false;
+    }
+
+    let raw = source[start..end].trim_start();
+    raw.starts_with("export type ")
+        || raw.contains("{ type ")
+        || raw.contains("{type ")
+        || raw.contains(", type ")
+}
+
+fn is_export_all_type_only(stmt: &Statement<'_>, source: &str) -> bool {
+    let span = stmt.span();
+    let start = span.start as usize;
+    let end = span.end as usize;
+    start < end
+        && end <= source.len()
+        && source[start..end].trim_start().starts_with("export type ")
+}
+
 fn path_key(path: &Path) -> String {
     path.to_string_lossy().as_ref().to_compact_string()
 }
@@ -238,5 +304,52 @@ mod tests {
         let current = Path::new("/repo/src/components/Child.vue");
 
         assert!(resolve_import_path(current, "vue").is_none());
+    }
+
+    #[test]
+    fn collects_type_reexports_from_vue_files() {
+        let project = temp_project_dir("vue-type-reexport");
+        let components = project.join("src/components");
+        std::fs::create_dir_all(&components).unwrap();
+        std::fs::write(
+            components.join("Base.vue"),
+            r#"<script lang="ts">
+export interface BaseProps {
+  as?: string;
+  asChild?: boolean;
+}
+</script>"#,
+        )
+        .unwrap();
+        std::fs::write(
+            components.join("index.ts"),
+            r#"export { type BaseProps } from "./Base.vue";"#,
+        )
+        .unwrap();
+
+        let parent = components.join("Parent.vue");
+        let source = r#"
+import type { BaseProps } from "./index";
+
+interface ParentProps extends BaseProps {}
+
+const props = defineProps<ParentProps>();
+"#;
+
+        let mut ctx = super::ScriptCompileContext::new(source);
+        ctx.collect_imported_types_from_path(source, parent.to_string_lossy().as_ref());
+        ctx.analyze();
+
+        assert!(ctx.interfaces.contains_key("BaseProps"));
+        assert_eq!(
+            ctx.bindings.bindings.get("as"),
+            Some(&crate::types::BindingType::Props)
+        );
+        assert_eq!(
+            ctx.bindings.bindings.get("asChild"),
+            Some(&crate::types::BindingType::Props)
+        );
+
+        let _ = std::fs::remove_dir_all(project);
     }
 }

--- a/crates/vize_canon/src/batch/virtual_project.rs
+++ b/crates/vize_canon/src/batch/virtual_project.rs
@@ -17,7 +17,7 @@ use super::source_map::{CompositeSourceMap, SfcBlockRange, SfcSourceMap};
 use super::{Diagnostic, SfcBlockType};
 use crate::script_parse::collect_script_parse_diagnostics;
 use crate::virtual_ts::{
-    VirtualTsCheckOptions, VirtualTsGenerationOptions, VirtualTsOptions,
+    VirtualTsCheckOptions, VirtualTsGenerationOptions, VirtualTsOptions, extract_interface_fields,
     generate_virtual_ts_with_offsets_and_checks,
 };
 use oxc_span::SourceType;
@@ -30,7 +30,9 @@ use vize_atelier_sfc::{
         SfcCroquisOptions, analyze_sfc_descriptor_with_context,
         analyze_sfc_descriptor_with_context_legacy_vue2,
     },
-    parse_sfc, validate_script_setup_semantics_located,
+    parse_sfc,
+    script::ScriptCompileContext,
+    validate_script_setup_semantics_located,
 };
 use vize_carton::{
     Bump, FxHashMap, FxHashSet, String as CompactString, ToCompactString, cstr, profile,
@@ -938,14 +940,23 @@ fn generate_vue_virtual_ts(
             analyze_sfc_descriptor_with_context(descriptor, template_ast.as_ref(), croquis_options)
         }
     );
+    let vize_atelier_sfc::croquis::SfcCroquisAnalysis {
+        mut croquis,
+        script_content,
+        script_offset,
+    } = analysis;
+    profile!(
+        "canon.croquis.augment_type_props",
+        augment_type_based_props_from_script_context(&mut croquis, descriptor, path)
+    );
 
     let output = profile!(
         "canon.virtual_ts.generate",
         generate_virtual_ts_with_offsets_and_checks(
-            &analysis.croquis,
-            analysis.script_content_ref(),
+            &croquis,
+            script_content.as_deref(),
             template_ast.as_ref(),
-            analysis.script_offset,
+            script_offset,
             template_offset,
             options,
             VirtualTsGenerationOptions {
@@ -970,6 +981,105 @@ fn generate_vue_virtual_ts(
         mappings: output.mappings,
         diagnostics,
     })
+}
+
+fn augment_type_based_props_from_script_context(
+    croquis: &mut vize_croquis::Croquis,
+    descriptor: &SfcDescriptor<'_>,
+    path: &Path,
+) {
+    let Some(script_setup) = descriptor.script_setup.as_ref() else {
+        return;
+    };
+    if croquis
+        .macros
+        .define_props()
+        .is_none_or(|call| call.type_args.is_none())
+    {
+        return;
+    }
+
+    let mut ctx = ScriptCompileContext::new(&script_setup.content);
+    let path_string = path.to_string_lossy();
+
+    if let Some(script) = descriptor.script.as_ref()
+        && !script.content.is_empty()
+    {
+        ctx.collect_types_from(&script.content);
+        ctx.collect_imported_types_from_path(&script.content, path_string.as_ref());
+    }
+    ctx.collect_imported_types_from_path(&script_setup.content, path_string.as_ref());
+    ctx.analyze();
+
+    let known_props = known_type_based_prop_names(croquis, &script_setup.content);
+    let mut missing_props: Vec<CompactString> = ctx
+        .bindings
+        .bindings
+        .iter()
+        .filter_map(|(name, binding_type)| {
+            matches!(binding_type, vize_relief::BindingType::Props)
+                .then(|| name)
+                .filter(|name| !known_props.contains(*name))
+                .cloned()
+        })
+        .collect();
+    if missing_props.is_empty() {
+        return;
+    }
+    missing_props.sort();
+
+    for name in missing_props {
+        croquis
+            .bindings
+            .bindings
+            .entry(name.clone())
+            .or_insert(vize_relief::BindingType::Props);
+        croquis
+            .macros
+            .add_prop(vize_croquis::macros::PropDefinition {
+                name,
+                prop_type: None,
+                required: false,
+                default_value: None,
+            });
+    }
+}
+
+fn known_type_based_prop_names(
+    croquis: &vize_croquis::Croquis,
+    script_setup: &str,
+) -> FxHashSet<CompactString> {
+    let mut names: FxHashSet<CompactString> = croquis
+        .macros
+        .props()
+        .iter()
+        .map(|prop| prop.name.clone())
+        .collect();
+
+    let Some(type_args) = croquis
+        .macros
+        .define_props()
+        .and_then(|call| call.type_args.as_ref())
+    else {
+        return names;
+    };
+
+    let type_name = strip_outer_angle_brackets(type_args.trim());
+    for prop in croquis.types.extract_properties(type_name) {
+        names.insert(prop.name);
+    }
+    for field in extract_interface_fields(script_setup, type_name) {
+        names.insert(CompactString::new(field));
+    }
+
+    names
+}
+
+fn strip_outer_angle_brackets(value: &str) -> &str {
+    value
+        .strip_prefix('<')
+        .and_then(|value| value.strip_suffix('>'))
+        .unwrap_or(value)
 }
 
 /// Run only the script-setup semantic validators on this SFC. We deliberately
@@ -1932,6 +2042,86 @@ const count = 1
                 .contains("export default __vize_component")
         );
         assert!(!virtual_file.content.contains("__vize_check_template"));
+
+        let _ = fs::remove_dir_all(&case_dir);
+    }
+
+    #[test]
+    fn test_virtual_ts_exposes_props_from_reexported_vue_interface() {
+        let case_dir = unique_case_dir("reexported-vue-interface-props");
+        let _ = fs::remove_dir_all(&case_dir);
+        let src_dir = case_dir.join("src");
+        fs::create_dir_all(&src_dir).unwrap();
+
+        let base = src_dir.join("Base.vue");
+        let index = src_dir.join("index.ts");
+        let child = src_dir.join("Child.vue");
+        let parent = src_dir.join("ParentWidget.vue");
+
+        fs::write(
+            &base,
+            r#"<script lang="ts">
+export interface BaseProps {
+  as?: string;
+  asChild?: boolean;
+}
+</script>
+<template><div /></template>"#,
+        )
+        .unwrap();
+        fs::write(&index, r#"export { type BaseProps } from "./Base.vue";"#).unwrap();
+        fs::write(
+            &child,
+            r#"<script setup lang="ts">
+defineProps<{ as?: string; asChild?: boolean }>();
+</script>
+<template><div /></template>"#,
+        )
+        .unwrap();
+        fs::write(
+            &parent,
+            r#"<script lang="ts">
+import type { BaseProps } from "./index";
+
+export interface ParentWidgetProps extends BaseProps {}
+</script>
+<script setup lang="ts">
+import Child from "./Child.vue";
+
+const props = defineProps<ParentWidgetProps>();
+</script>
+<template>
+  <Child :as="as" :as-child="props.asChild" />
+</template>"#,
+        )
+        .unwrap();
+
+        let mut project = VirtualProject::new(&case_dir).unwrap();
+        project
+            .register_paths(&[base, index, child, parent.clone()])
+            .unwrap();
+
+        let virtual_parent = project.find_by_original(&parent).unwrap();
+        assert_ts_parses(&virtual_parent.content);
+        assert!(
+            virtual_parent
+                .content
+                .contains(r#"const _as = props["as"];"#),
+            "{}",
+            virtual_parent.content
+        );
+        assert!(
+            virtual_parent.content.contains(r#"void (props["as"]);"#),
+            "{}",
+            virtual_parent.content
+        );
+        assert!(
+            virtual_parent
+                .content
+                .contains(r#"type Props = ParentWidgetProps;"#),
+            "{}",
+            virtual_parent.content
+        );
 
         let _ = fs::remove_dir_all(&case_dir);
     }

--- a/crates/vize_canon/src/virtual_ts.rs
+++ b/crates/vize_canon/src/virtual_ts.rs
@@ -21,6 +21,7 @@ pub use generator::{
     generate_virtual_ts, generate_virtual_ts_with_offsets,
     generate_virtual_ts_with_offsets_legacy_vue2,
 };
+pub(crate) use props::extract_interface_fields;
 pub use types::{TemplateGlobal, VirtualTsOptions, VirtualTsOutput, VizeMapping};
 #[cfg(any(test, feature = "native"))]
 pub(crate) use types::{VirtualTsCheckOptions, VirtualTsGenerationOptions};

--- a/tests/fixtures/sfc/imported_types/ReExportedBase.vue
+++ b/tests/fixtures/sfc/imported_types/ReExportedBase.vue
@@ -1,0 +1,10 @@
+<script lang="ts">
+export interface ReExportedBaseProps {
+  as?: string;
+  asChild?: boolean;
+}
+</script>
+
+<template>
+  <div />
+</template>

--- a/tests/fixtures/sfc/imported_types/ReExportedChild.vue
+++ b/tests/fixtures/sfc/imported_types/ReExportedChild.vue
@@ -1,0 +1,10 @@
+<script setup lang="ts">
+defineProps<{
+  as?: string;
+  asChild?: boolean;
+}>();
+</script>
+
+<template>
+  <div />
+</template>

--- a/tests/fixtures/sfc/imported_types/ReExportedParentWidget.vue
+++ b/tests/fixtures/sfc/imported_types/ReExportedParentWidget.vue
@@ -1,0 +1,15 @@
+<script lang="ts">
+import type { ReExportedBaseProps } from "./re-exported";
+
+export interface ReExportedParentWidgetProps extends ReExportedBaseProps {}
+</script>
+
+<script setup lang="ts">
+import ReExportedChild from "./ReExportedChild.vue";
+
+const props = defineProps<ReExportedParentWidgetProps>();
+</script>
+
+<template>
+  <ReExportedChild :as="as" :as-child="props.asChild" />
+</template>

--- a/tests/fixtures/sfc/imported_types/re-exported.ts
+++ b/tests/fixtures/sfc/imported_types/re-exported.ts
@@ -1,0 +1,1 @@
+export { type ReExportedBaseProps } from "./ReExportedBase.vue";


### PR DESCRIPTION
## Summary

- follow type-only re-exports while collecting external script types for `defineProps<T>()`
- merge the resolved type-based prop names into Corsa virtual TS generation so direct template prop reads are available
- add compiler and virtual TS coverage for interfaces inherited from Vue SFC types re-exported through a barrel

## Root Cause

The SFC script type collector only followed type imports. A barrel such as `export { type BaseProps } from "./Base.vue"` stopped resolution before Vize could collect the interface exported from the Vue file, so inherited props were missing from runtime props and template bindings.

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo test -p vize_atelier_sfc imported_type -- --nocapture`
- `cargo test -p vize_atelier_sfc collects_type_reexports_from_vue_files -- --nocapture`
- `cargo test -p vize_atelier_sfc test_define_props_interface_extends_reexported_vue_interface -- --nocapture`
- `cargo test -p vize_canon import_rewriter -- --nocapture`
- `cargo test -p vize_canon test_virtual_ts_exposes_props_from_reexported_vue_interface -- --nocapture`
- reproduced `vize build` on the re-exported SFC interface fixture
- reproduced `vize check` with `@typescript/native-preview` installed in a temporary project

Fixes #915

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/945"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783065169&installation_id=136613492&pr_number=945&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F945&signature=f313d1937a2f73f0d98acf902e7e1bab8977fd678ade2509fc4fc85a50f8c85d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->