### PR TITLE
fix: resolve today issue regressions

### DIFF
--- a/crates/vize/tests/build_cli.rs
+++ b/crates/vize/tests/build_cli.rs
@@ -101,3 +101,104 @@ withDefaults(defineProps<AppProps>(), {
 
     let _ = fs::remove_dir_all(project_root);
 }
+
+#[test]
+fn build_resolves_props_from_mixed_reexported_vue_interface() {
+    let project_root = temp_project_dir("mixed-reexported-vue-interface-props");
+    write_project_file(
+        &project_root,
+        "src/primitive.ts",
+        r#"export type AsTag = 'div' | 'span' | ({} & string)
+
+export interface PrimitiveProps {
+  asChild?: boolean
+  as?: AsTag
+}
+"#,
+    );
+    write_project_file(
+        &project_root,
+        "src/content/Content.vue",
+        r#"<script lang="ts">
+import type { PrimitiveProps } from '../primitive'
+
+export interface ContentProps extends PrimitiveProps {
+  forceMount?: boolean
+}
+</script>
+
+<script setup lang="ts">
+defineProps<ContentProps>()
+</script>
+
+<template><div /></template>
+"#,
+    );
+    write_project_file(
+        &project_root,
+        "src/content/index.ts",
+        r#"export {
+  default as Content,
+  type ContentProps,
+} from './Content.vue'
+"#,
+    );
+    write_project_file(
+        &project_root,
+        "src/Wrapper.vue",
+        r#"<script lang="ts">
+import type { ContentProps } from './content'
+
+export interface WrapperProps extends ContentProps {}
+</script>
+
+<script setup lang="ts">
+import { Content } from './content'
+
+const props = defineProps<WrapperProps>()
+</script>
+
+<template>
+  <Content
+    :as-child="props.asChild"
+    :as="as"
+    :force-mount="props.forceMount"
+  />
+</template>
+"#,
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(&project_root)
+        .args([
+            "build",
+            "--format",
+            "js",
+            "src/Wrapper.vue",
+            "--output",
+            "dist",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let js = fs::read_to_string(project_root.join("dist/Wrapper.js")).unwrap();
+    assert!(
+        js.contains("asChild: {\n      type: Boolean,\n      required: false\n    }"),
+        "{js}"
+    );
+    assert!(
+        js.contains("forceMount: {\n      type: Boolean,\n      required: false\n    }"),
+        "{js}"
+    );
+    assert!(js.contains("as: __props.as"), "{js}");
+    assert!(!js.contains("_ctx.as"), "{js}");
+
+    let _ = fs::remove_dir_all(project_root);
+}

--- a/crates/vize_atelier_sfc/src/compile/tests.rs
+++ b/crates/vize_atelier_sfc/src/compile/tests.rs
@@ -1444,6 +1444,94 @@ fn test_define_props_interface_extends_reexported_vue_interface() {
 }
 
 #[test]
+fn test_define_props_interface_extends_mixed_reexported_vue_interface() {
+    let project = temp_compile_project_dir("mixed-reexported-vue-interface-props");
+    let src = project.join("src");
+    let content_dir = src.join("content");
+    fs::create_dir_all(&content_dir).unwrap();
+
+    fs::write(
+        src.join("primitive.ts"),
+        r#"export type AsTag = 'div' | 'span' | ({} & string)
+
+export interface PrimitiveProps {
+  asChild?: boolean
+  as?: AsTag
+}
+"#,
+    )
+    .unwrap();
+    fs::write(
+        content_dir.join("Content.vue"),
+        r#"<script lang="ts">
+import type { PrimitiveProps } from '../primitive'
+
+export interface ContentProps extends PrimitiveProps {
+  forceMount?: boolean
+}
+</script>
+
+<script setup lang="ts">
+defineProps<ContentProps>()
+</script>
+
+<template><div /></template>"#,
+    )
+    .unwrap();
+    fs::write(
+        content_dir.join("index.ts"),
+        r#"export {
+  default as Content,
+  type ContentProps,
+} from './Content.vue'
+"#,
+    )
+    .unwrap();
+
+    let wrapper_path = src.join("Wrapper.vue");
+    let source = r#"<script lang="ts">
+import type { ContentProps } from './content'
+
+export interface WrapperProps extends ContentProps {}
+</script>
+
+<script setup lang="ts">
+import { Content } from './content'
+
+const props = defineProps<WrapperProps>()
+</script>
+
+<template>
+  <Content
+    :as-child="props.asChild"
+    :as="as"
+    :force-mount="props.forceMount"
+  />
+</template>"#;
+
+    let descriptor = parse_sfc(source, SfcParseOptions::default()).expect("Failed to parse SFC");
+    let mut opts = SfcCompileOptions::default();
+    opts.script.id = Some(wrapper_path.to_string_lossy().as_ref().to_compact_string());
+
+    let result = compile_sfc(&descriptor, opts).expect("Failed to compile SFC");
+
+    assert!(
+        result.code.contains("asChild: {\n      type: Boolean"),
+        "{}",
+        result.code
+    );
+    assert!(
+        result.code.contains("forceMount: {\n      type: Boolean"),
+        "{}",
+        result.code
+    );
+    assert!(result.code.contains("as: __props.as"), "{}", result.code);
+    assert!(!result.code.contains("_ctx.as"), "{}", result.code);
+
+    let _ = fs::remove_dir_all(project);
+}
+
+#[test]
 fn test_with_defaults_resolves_imported_vue_type_from_src_alias() {
     let project = temp_compile_project_dir("with-defaults-src-alias");
     let components = project.join("packages/frontend/src/components");

--- a/crates/vize_atelier_sfc/src/script/context/external_types.rs
+++ b/crates/vize_atelier_sfc/src/script/context/external_types.rs
@@ -230,6 +230,14 @@ fn is_type_re_export(export_decl: &ExportNamedDeclaration<'_>, source: &str) -> 
         return true;
     }
 
+    if export_decl
+        .specifiers
+        .iter()
+        .any(|specifier| specifier.export_kind.is_type())
+    {
+        return true;
+    }
+
     let span = export_decl.span;
     let start = span.start as usize;
     let end = span.end as usize;
@@ -259,7 +267,11 @@ fn path_key(path: &Path) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{resolve_at_src_alias, resolve_import_path};
+    use super::{is_type_re_export, resolve_at_src_alias, resolve_import_path};
+    use oxc_allocator::Allocator;
+    use oxc_ast::ast::Statement;
+    use oxc_parser::Parser;
+    use oxc_span::SourceType;
     use std::path::{Path, PathBuf};
 
     fn temp_project_dir(test_name: &str) -> PathBuf {
@@ -341,6 +353,73 @@ const props = defineProps<ParentProps>();
         ctx.analyze();
 
         assert!(ctx.interfaces.contains_key("BaseProps"));
+        assert_eq!(
+            ctx.bindings.bindings.get("as"),
+            Some(&crate::types::BindingType::Props)
+        );
+        assert_eq!(
+            ctx.bindings.bindings.get("asChild"),
+            Some(&crate::types::BindingType::Props)
+        );
+
+        let _ = std::fs::remove_dir_all(project);
+    }
+
+    #[test]
+    fn detects_multiline_mixed_type_reexports() {
+        let source = r#"export {
+  default as Content,
+  type ContentProps,
+} from "./Content.vue";
+"#;
+        let allocator = Allocator::default();
+        let parsed = Parser::new(&allocator, source, SourceType::ts()).parse();
+        let Statement::ExportNamedDeclaration(export_decl) = &parsed.program.body[0] else {
+            panic!("expected export declaration");
+        };
+
+        assert!(is_type_re_export(export_decl, source));
+    }
+
+    #[test]
+    fn collects_mixed_type_reexports_from_vue_files() {
+        let project = temp_project_dir("mixed-vue-type-reexport");
+        let components = project.join("src/components");
+        std::fs::create_dir_all(&components).unwrap();
+        std::fs::write(
+            components.join("Content.vue"),
+            r#"<script lang="ts">
+export interface ContentProps {
+  as?: string;
+  asChild?: boolean;
+}
+</script>"#,
+        )
+        .unwrap();
+        std::fs::write(
+            components.join("index.ts"),
+            r#"export {
+  default as Content,
+  type ContentProps,
+} from "./Content.vue";
+"#,
+        )
+        .unwrap();
+
+        let parent = components.join("Parent.vue");
+        let source = r#"
+import type { ContentProps } from "./index";
+
+interface ParentProps extends ContentProps {}
+
+const props = defineProps<ParentProps>();
+"#;
+
+        let mut ctx = super::ScriptCompileContext::new(source);
+        ctx.collect_imported_types_from_path(source, parent.to_string_lossy().as_ref());
+        ctx.analyze();
+
+        assert!(ctx.interfaces.contains_key("ContentProps"));
         assert_eq!(
             ctx.bindings.bindings.get("as"),
             Some(&crate::types::BindingType::Props)

--- a/crates/vize_canon/src/batch/type_checker/tests.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests.rs
@@ -759,6 +759,209 @@ void props
 }
 
 #[test]
+fn batch_type_checker_accepts_with_defaults_direct_template_prop_identifiers() {
+    if resolve_test_tsgo_binary().is_none() {
+        return;
+    }
+    let project_root = create_project_case(
+        "with-defaults-direct-template-props",
+        &[(
+            "src/CounterButton.vue",
+            r#"<script setup lang="ts">
+const props = withDefaults(
+  defineProps<{
+    count?: number;
+    label: string;
+  }>(),
+  { count: 0 },
+);
+
+const emit = defineEmits<{
+  increment: [value: number];
+}>();
+
+void props;
+</script>
+
+<template>
+  <button type="button" @click="emit('increment', count + 1)">
+    {{ label }}: {{ count }}
+  </button>
+</template>
+"#,
+        )],
+    );
+
+    let Some(snapshot) = snapshot_project_diagnostics(&project_root) else {
+        let _ = std::fs::remove_dir_all(&project_root);
+        return;
+    };
+
+    assert!(
+        snapshot.is_empty(),
+        "defaulted direct template prop identifiers should not report diagnostics, got: {snapshot:?}"
+    );
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}
+
+#[test]
+fn batch_type_checker_accepts_reexported_vue_interface_template_props() {
+    if resolve_test_tsgo_binary().is_none() {
+        return;
+    }
+    let project_root = create_project_case(
+        "reexported-vue-interface-template-props",
+        &[
+            (
+                "src/Base.vue",
+                r#"<script lang="ts">
+export interface BaseProps {
+  as?: string
+  asChild?: boolean
+}
+</script>
+
+<template><div /></template>
+"#,
+            ),
+            (
+                "src/index.ts",
+                r#"export { type BaseProps } from "./Base.vue";"#,
+            ),
+            (
+                "src/Child.vue",
+                r#"<script setup lang="ts">
+defineProps<{
+  as?: string
+  asChild?: boolean
+}>()
+</script>
+
+<template><div /></template>
+"#,
+            ),
+            (
+                "src/ParentWidget.vue",
+                r#"<script lang="ts">
+import type { BaseProps } from './index'
+
+export interface ParentWidgetProps extends BaseProps {}
+</script>
+
+<script setup lang="ts">
+import Child from './Child.vue'
+
+const props = defineProps<ParentWidgetProps>()
+</script>
+
+<template>
+  <Child
+    :as="as"
+    :as-child="props.asChild"
+  />
+</template>
+"#,
+            ),
+        ],
+    );
+
+    let Some(snapshot) = snapshot_project_diagnostics(&project_root) else {
+        let _ = std::fs::remove_dir_all(&project_root);
+        return;
+    };
+
+    assert!(
+        snapshot.is_empty(),
+        "re-exported Vue interface props should resolve in Corsa diagnostics, got: {snapshot:?}"
+    );
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}
+
+#[test]
+fn batch_type_checker_accepts_mixed_reexported_vue_interface_template_props() {
+    if resolve_test_tsgo_binary().is_none() {
+        return;
+    }
+    let project_root = create_project_case(
+        "mixed-reexported-vue-interface-template-props",
+        &[
+            (
+                "src/primitive.ts",
+                r#"export type AsTag = 'div' | 'span' | ({} & string)
+
+export interface PrimitiveProps {
+  asChild?: boolean
+  as?: AsTag
+}
+"#,
+            ),
+            (
+                "src/content/Content.vue",
+                r#"<script lang="ts">
+import type { PrimitiveProps } from '../primitive'
+
+export interface ContentProps extends PrimitiveProps {
+  forceMount?: boolean
+}
+</script>
+
+<script setup lang="ts">
+defineProps<ContentProps>()
+</script>
+
+<template><div /></template>
+"#,
+            ),
+            (
+                "src/content/index.ts",
+                r#"export {
+  default as Content,
+  type ContentProps,
+} from './Content.vue'
+"#,
+            ),
+            (
+                "src/Wrapper.vue",
+                r#"<script lang="ts">
+import type { ContentProps } from './content'
+
+export interface WrapperProps extends ContentProps {}
+</script>
+
+<script setup lang="ts">
+import { Content } from './content'
+
+const props = defineProps<WrapperProps>()
+</script>
+
+<template>
+  <Content
+    :as-child="props.asChild"
+    :as="as"
+    :force-mount="props.forceMount"
+  />
+</template>
+"#,
+            ),
+        ],
+    );
+
+    let Some(snapshot) = snapshot_project_diagnostics(&project_root) else {
+        let _ = std::fs::remove_dir_all(&project_root);
+        return;
+    };
+
+    assert!(
+        snapshot.is_empty(),
+        "mixed Vue type re-exports should resolve in Corsa diagnostics, got: {snapshot:?}"
+    );
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}
+
+#[test]
 fn batch_type_checker_snapshots_ts_imports_vue_component() {
     if resolve_test_tsgo_binary().is_none() {
         return;

--- a/crates/vize_canon/src/batch/virtual_project.rs
+++ b/crates/vize_canon/src/batch/virtual_project.rs
@@ -2127,6 +2127,79 @@ const props = defineProps<ParentWidgetProps>();
     }
 
     #[test]
+    fn test_virtual_ts_preserves_ts_as_assertions_when_prop_is_named_as() {
+        let case_dir = unique_case_dir("template-as-assertion-prop");
+        let _ = fs::remove_dir_all(&case_dir);
+        let src_dir = case_dir.join("src");
+        fs::create_dir_all(&src_dir).unwrap();
+
+        let vue_path = src_dir.join("App.vue");
+        fs::write(
+            &vue_path,
+            r#"<script setup lang="ts">
+defineProps<{
+  as?: string
+}>()
+
+const value = 'demo'
+const onFocus = (target: HTMLElement) => {
+  target.dataset.focused = 'true'
+}
+</script>
+
+<template>
+  <div
+    :data-value="(value as any)"
+    :style="{
+      ['--demo-value' as any]: value,
+    }"
+    v-on="{
+      focusin: (event: FocusEvent) => {
+        onFocus(event.target as HTMLElement)
+      },
+    }"
+  />
+</template>
+"#,
+        )
+        .unwrap();
+
+        let mut project = VirtualProject::new(&case_dir).unwrap();
+        project
+            .register_vue_file(&vue_path, &fs::read_to_string(&vue_path).unwrap())
+            .unwrap();
+
+        let virtual_file = project.find_by_original(&vue_path).unwrap();
+        assert_ts_parses(&virtual_file.content);
+        assert!(
+            virtual_file.content.contains("void ((value as any));"),
+            "{}",
+            virtual_file.content
+        );
+        assert!(
+            virtual_file
+                .content
+                .contains("['--demo-value' as any]: value"),
+            "{}",
+            virtual_file.content
+        );
+        assert!(
+            virtual_file
+                .content
+                .contains("onFocus(event.target as HTMLElement)"),
+            "{}",
+            virtual_file.content
+        );
+        assert!(
+            !virtual_file.content.contains(r#"value props["as"] any"#),
+            "{}",
+            virtual_file.content
+        );
+
+        let _ = fs::remove_dir_all(&case_dir);
+    }
+
+    #[test]
     fn test_materialize_writes_tsconfig_and_virtual_files() {
         let case_dir = unique_case_dir("materialize");
         let _ = fs::remove_dir_all(&case_dir);

--- a/crates/vize_canon/src/sfc_typecheck.rs
+++ b/crates/vize_canon/src/sfc_typecheck.rs
@@ -196,6 +196,49 @@ const { thickness, label } = props;
     }
 
     #[test]
+    fn test_type_check_with_defaults_narrows_direct_template_prop_identifiers() {
+        let source = r#"<script setup lang="ts">
+const props = withDefaults(
+  defineProps<{
+    count?: number;
+    label: string;
+  }>(),
+  { count: 0 },
+);
+
+const emit = defineEmits<{
+  increment: [value: number];
+}>();
+
+void props;
+</script>
+
+<template>
+  <button type="button" @click="emit('increment', count + 1)">
+    {{ label }}: {{ count }}
+  </button>
+</template>"#;
+        let options = SfcTypeCheckOptions::new("test.vue").with_virtual_ts();
+        let result = type_check_sfc(source, &options);
+        let virtual_ts = result.virtual_ts.expect("virtual ts should be generated");
+
+        assert!(
+            virtual_ts.contains(
+                r#"const count = props["count"] as Exclude<__WithDefaultsResult<Props, Pick<Props, "count">>["count"], undefined>;"#
+            ),
+            "{virtual_ts}"
+        );
+        assert!(
+            !virtual_ts.contains(r#"const count = props["count"];"#),
+            "{virtual_ts}"
+        );
+        assert!(
+            virtual_ts.contains(r#"void (emit('increment', count + 1));"#),
+            "{virtual_ts}"
+        );
+    }
+
+    #[test]
     fn test_type_check_with_untyped_props_non_strict() {
         let source = r#"<script setup>
 const props = defineProps(['count', 'name']);
@@ -523,6 +566,58 @@ defineProps<{
             "{virtual_ts}"
         );
         assert!(!virtual_ts.contains("active: static"), "{virtual_ts}");
+    }
+
+    #[test]
+    fn test_type_check_preserves_ts_as_assertions_when_prop_is_named_as() {
+        let source = r#"<script setup lang="ts">
+defineProps<{
+  as?: string
+}>()
+
+const value = 'demo'
+const onFocus = (target: HTMLElement) => {
+  target.dataset.focused = 'true'
+}
+</script>
+
+<template>
+  <div
+    :data-value="(value as any)"
+    :style="{
+      ['--demo-value' as any]: value,
+    }"
+    v-on="{
+      focusin: (event: FocusEvent) => {
+        onFocus(event.target as HTMLElement)
+      },
+    }"
+  />
+</template>"#;
+        let options = SfcTypeCheckOptions::new("test.vue").with_virtual_ts();
+        let result = type_check_sfc(source, &options);
+        let virtual_ts = result.virtual_ts.expect("virtual ts produced");
+
+        assert!(
+            virtual_ts.contains("void ((value as any));"),
+            "{virtual_ts}"
+        );
+        assert!(
+            virtual_ts.contains("['--demo-value' as any]: value"),
+            "{virtual_ts}"
+        );
+        assert!(
+            virtual_ts.contains("onFocus(event.target as HTMLElement)"),
+            "{virtual_ts}"
+        );
+        assert!(
+            !virtual_ts.contains("value props[\"as\"] any"),
+            "{virtual_ts}"
+        );
+        assert!(
+            !virtual_ts.contains("event.target props[\"as\"] HTMLElement"),
+            "{virtual_ts}"
+        );
     }
 
     #[test]

--- a/crates/vize_canon/src/virtual_ts/expressions.rs
+++ b/crates/vize_canon/src/virtual_ts/expressions.rs
@@ -261,6 +261,7 @@ fn rewrite_reserved_template_prop(
                 && template_prop_names.contains(ident)
                 && !is_property_access(bytes, start)
                 && !is_object_property_key(bytes, i)
+                && !is_typescript_as_assertion_operator(bytes, start, i, ident)
             {
                 if is_object_shorthand(bytes, start, i) {
                     append!(output, "{ident}: props[\"{ident}\"]");
@@ -381,6 +382,31 @@ fn is_object_shorthand(bytes: &[u8], ident_start: usize, ident_end: usize) -> bo
     )
 }
 
+fn is_typescript_as_assertion_operator(
+    bytes: &[u8],
+    ident_start: usize,
+    ident_end: usize,
+    ident: &str,
+) -> bool {
+    if ident != "as" {
+        return false;
+    }
+
+    let Some(prev) = previous_significant_byte(bytes, ident_start) else {
+        return false;
+    };
+    let Some(next) = next_significant_byte(bytes, ident_end) else {
+        return false;
+    };
+
+    let expression_before_as = prev.is_ascii_alphanumeric()
+        || matches!(prev, b'_' | b'$' | b')' | b']' | b'}' | b'\'' | b'"' | b'`');
+    let type_after_as =
+        is_identifier_start(next) || matches!(next, b'{' | b'[' | b'(' | b'\'' | b'"');
+
+    expression_before_as && type_after_as
+}
+
 fn is_identifier_start(byte: u8) -> bool {
     byte.is_ascii_alphabetic() || byte == b'_' || byte == b'$'
 }
@@ -455,6 +481,41 @@ mod tests {
     fn ignores_non_reserved_props() {
         let props = ["count"].into_iter().map(Into::into).collect();
         assert_eq!(rewrite_reserved_template_prop("count + 1", &props), None);
+    }
+
+    #[test]
+    fn preserves_typescript_as_assertions_when_prop_is_named_as() {
+        let props = ["as"].into_iter().map(Into::into).collect();
+
+        assert_eq!(
+            rewrite_reserved_template_prop("(value as any)", &props),
+            None
+        );
+        assert_eq!(
+            rewrite_reserved_template_prop("{ ['--demo-value' as any]: value }", &props),
+            None
+        );
+        assert_eq!(
+            rewrite_reserved_template_prop(
+                "{ focusin: (event: FocusEvent) => onFocus(event.target as HTMLElement) }",
+                &props,
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn still_rewrites_as_when_used_as_template_prop_identifier() {
+        let props = ["as"].into_iter().map(Into::into).collect();
+
+        assert_eq!(
+            rewrite_reserved_template_prop("as", &props).as_deref(),
+            Some("props[\"as\"]")
+        );
+        assert_eq!(
+            rewrite_reserved_template_prop("{ as, tag: as }", &props).as_deref(),
+            Some("{ as: props[\"as\"], tag: props[\"as\"] }")
+        );
     }
 }
 

--- a/npm/nuxt/src/options.test.ts
+++ b/npm/nuxt/src/options.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 
 import {
+  NUXT_OG_IMAGE_RENDERER_SFC_EXCLUDE,
   resolveNuxtBridgeOptions,
   resolveNuxtCompilerOptions,
   resolveNuxtDevOptions,
@@ -12,6 +13,7 @@ assert.deepEqual(
   resolveNuxtCompilerOptions("/repo/app", "/docs/", "_assets", true),
   {
     devUrlBase: "/docs/_assets/",
+    exclude: NUXT_OG_IMAGE_RENDERER_SFC_EXCLUDE,
     root: "/repo/app",
     scanPatterns: [],
   },
@@ -40,11 +42,25 @@ assert.deepEqual(
   }),
   {
     devUrlBase: "/_nuxt/",
+    exclude: NUXT_OG_IMAGE_RENDERER_SFC_EXCLUDE,
     root: "/repo/app",
     scanPatterns: [],
     vueVersion: 1,
   },
   "Vite-based legacy Vue projects should pass host-compiler compatibility mode to the Vite plugin",
+);
+
+assert.deepEqual(
+  resolveNuxtCompilerOptions("/repo/app", "/", "/_nuxt/", {
+    exclude: [/\.stories\.vue$/],
+  }),
+  {
+    devUrlBase: "/_nuxt/",
+    exclude: [NUXT_OG_IMAGE_RENDERER_SFC_EXCLUDE, /\.stories\.vue$/],
+    root: "/repo/app",
+    scanPatterns: [],
+  },
+  "Nuxt compiler defaults should skip Takumi OG image SFCs while preserving user excludes",
 );
 
 assert.deepEqual(

--- a/npm/nuxt/src/options.ts
+++ b/npm/nuxt/src/options.ts
@@ -1,9 +1,10 @@
 import type { MuseaOptions } from "@vizejs/vite-plugin-musea";
 import type { NuxtMuseaOptions } from "@vizejs/musea-nuxt";
 import type { VizeNuxtCompilerOptions, VizeNuxtVueVersion } from "./compiler-options.ts";
-import { buildNuxtCompilerOptions } from "./utils.ts";
+import { NUXT_OG_IMAGE_RENDERER_SFC_EXCLUDE, buildNuxtCompilerOptions } from "./utils.ts";
 
 export type { VizeNuxtCompilerOptions, VizeNuxtVueVersion } from "./compiler-options.ts";
+export { NUXT_OG_IMAGE_RENDERER_SFC_EXCLUDE };
 
 export type VizeNuxtMajorVersion = 2 | 3 | 4;
 

--- a/npm/nuxt/src/utils.test.ts
+++ b/npm/nuxt/src/utils.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import {
+  NUXT_OG_IMAGE_RENDERER_SFC_EXCLUDE,
   buildNuxtCompilerOptions,
   buildNuxtDevAssetBase,
   isVizeGeneratedVueModuleId,
@@ -35,6 +36,7 @@ assert.deepStrictEqual(
   buildNuxtCompilerOptions("/repo/app", "/2026/", "/_nuxt/"),
   {
     devUrlBase: "/2026/_nuxt/",
+    exclude: NUXT_OG_IMAGE_RENDERER_SFC_EXCLUDE,
     root: "/repo/app",
     scanPatterns: [],
   },
@@ -54,6 +56,7 @@ assert.deepStrictEqual(
     configFile: "vize.nuxt.config.ts",
     debug: true,
     devUrlBase: "/2026/_nuxt/",
+    exclude: NUXT_OG_IMAGE_RENDERER_SFC_EXCLUDE,
     ignorePatterns: ["node_modules/**", ".nuxt/**", "fixtures/**"],
     root: "/repo/app",
     scanPatterns: ["app/**/*.vue", "layers/**/*.vue"],
@@ -61,6 +64,21 @@ assert.deepStrictEqual(
     vapor: true,
   },
   "Nuxt compiler options should forward Vite plugin overrides while keeping Nuxt defaults",
+);
+
+assert.deepStrictEqual(
+  buildNuxtCompilerOptions("/repo/app", "/2026/", "/_nuxt/", {
+    customRenderer: true,
+    exclude: /\.custom-renderer-only\.vue$/,
+  }),
+  {
+    customRenderer: true,
+    devUrlBase: "/2026/_nuxt/",
+    exclude: /\.custom-renderer-only\.vue$/,
+    root: "/repo/app",
+    scanPatterns: [],
+  },
+  "custom renderer Nuxt compiler options should preserve explicit excludes without adding Takumi defaults",
 );
 
 assert.equal(

--- a/npm/nuxt/src/utils.ts
+++ b/npm/nuxt/src/utils.ts
@@ -2,6 +2,8 @@ import type { VizeNuxtCompilerOptions } from "./compiler-options.ts";
 import { createHash } from "node:crypto";
 import fs from "node:fs";
 
+export const NUXT_OG_IMAGE_RENDERER_SFC_EXCLUDE = /\.takumi\.vue(?:\?|$)/;
+
 function normalizeUrlPrefix(value: string): string {
   const withLeadingSlash = value.startsWith("/") ? value : `/${value}`;
   return withLeadingSlash.endsWith("/") ? withLeadingSlash : `${withLeadingSlash}/`;
@@ -27,15 +29,38 @@ export function buildNuxtCompilerOptions(
     scanPatterns: [],
   };
 
+  if (overrides.customRenderer === true && overrides.exclude !== undefined) {
+    defaults.exclude = overrides.exclude;
+  } else if (overrides.customRenderer !== true) {
+    defaults.exclude = mergeNuxtCompilerPatterns(
+      NUXT_OG_IMAGE_RENDERER_SFC_EXCLUDE,
+      overrides.exclude,
+    );
+  }
+
   for (const [key, value] of Object.entries(overrides) as Array<
     [keyof VizeNuxtCompilerOptions, VizeNuxtCompilerOptions[keyof VizeNuxtCompilerOptions]]
   >) {
+    if (key === "exclude") {
+      continue;
+    }
     if (value !== undefined) {
       defaults[key] = value as never;
     }
   }
 
   return defaults;
+}
+
+function mergeNuxtCompilerPatterns(
+  defaultPattern: NonNullable<VizeNuxtCompilerOptions["exclude"]>,
+  userPattern: VizeNuxtCompilerOptions["exclude"],
+): VizeNuxtCompilerOptions["exclude"] {
+  if (userPattern == null) {
+    return defaultPattern;
+  }
+
+  return [defaultPattern, ...(Array.isArray(userPattern) ? userPattern : [userPattern])];
 }
 
 export function isVizeVirtualVueModuleId(id: string): boolean {

--- a/npm/vize/README.md
+++ b/npm/vize/README.md
@@ -23,12 +23,9 @@ Need `vp` first? Install Vite+ once from the [Vite+ install guide](https://vitep
 vp install -D vize
 ```
 
-`vize check` also needs the Corsa runtime from `@typescript/native-preview`. Install it in projects
-that run `vize check` from package scripts:
-
-```bash
-vp install -D @typescript/native-preview
-```
+The package declares the `@typescript/native-preview` Corsa runtime as an optional dependency, so
+standard installs include the runtime needed by `vize check`. The `--corsa-path` CLI option remains
+available for custom native TypeScript builds.
 
 ## CLI
 
@@ -112,7 +109,7 @@ The human and agent-friendly formats include local rule documentation paths such
 `docs/content/rules/vue.md`.
 
 `vize check` in the npm package uses the packaged NAPI checker and the `@typescript/native-preview`
-Corsa runtime, so it can run from `package.json` scripts after installing both packages:
+Corsa runtime, so it can run from `package.json` scripts after installing `vize`:
 
 ```bash
 vp exec vize check src --strict

--- a/npm/vize/package.json
+++ b/npm/vize/package.json
@@ -71,16 +71,15 @@
     "vite-plus": "catalog:vite-stack"
   },
   "peerDependencies": {
-    "@pkl-community/pkl": "catalog:repo-tooling",
-    "@typescript/native-preview": "catalog:typescript"
+    "@pkl-community/pkl": "catalog:repo-tooling"
   },
   "peerDependenciesMeta": {
-    "@typescript/native-preview": {
-      "optional": true
-    },
     "@pkl-community/pkl": {
       "optional": true
     }
+  },
+  "optionalDependencies": {
+    "@typescript/native-preview": "catalog:typescript"
   },
   "engines": {
     "node": ">=22"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -737,9 +737,6 @@ importers:
 
   npm/vize:
     dependencies:
-      '@typescript/native-preview':
-        specifier: catalog:typescript
-        version: 7.0.0-dev.20260602.1
       '@vizejs/native':
         specifier: workspace:*
         version: link:../vize-native
@@ -771,6 +768,10 @@ importers:
       vite-plus:
         specifier: catalog:vite-stack
         version: 0.1.21(@tsdown/css@0.22.0)(@types/node@25.7.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0)(typescript@6.0.3)(unrun@0.2.39)(vite@8.0.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.7.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+    optionalDependencies:
+      '@typescript/native-preview':
+        specifier: catalog:typescript
+        version: 7.0.0-dev.20260602.1
 
   npm/vize-native:
     devDependencies:

--- a/tests/tooling/package-manifests.test.ts
+++ b/tests/tooling/package-manifests.test.ts
@@ -316,11 +316,12 @@ test("native preview runtime is declared for vize check users", () => {
   };
 
   assert.equal(packageJson.dependencies?.["@typescript/native-preview"], undefined);
-  assert.equal(packageJson.optionalDependencies?.["@typescript/native-preview"], undefined);
-  assert.equal(packageJson.peerDependencies?.["@typescript/native-preview"], "catalog:typescript");
-  assert.deepEqual(packageJson.peerDependenciesMeta?.["@typescript/native-preview"], {
-    optional: true,
-  });
+  assert.equal(
+    packageJson.optionalDependencies?.["@typescript/native-preview"],
+    "catalog:typescript",
+  );
+  assert.equal(packageJson.peerDependencies?.["@typescript/native-preview"], undefined);
+  assert.equal(packageJson.peerDependenciesMeta?.["@typescript/native-preview"], undefined);
 });
 
 test("musea Nuxt tests the same vue-router major that it declares as a peer", () => {

--- a/tests/tooling/release-smoke-install.test.ts
+++ b/tests/tooling/release-smoke-install.test.ts
@@ -90,10 +90,9 @@ test("release install smoke can run runtime checks for Vize packages", () => {
   const script = fs.readFileSync(smokeScript, "utf8");
 
   assert.match(script, /--runtime-checks/);
-  // Runtime peer deps must include the TS native preview pin used by the
-  // smoke project; the version is the single source of truth for what the
-  // matrix runners install.
-  assert.match(script, /"@typescript\/native-preview":\s*"7\.0\.0-dev\.20260602\.1"/);
+  // vize declares @typescript/native-preview itself, so the fresh-install smoke
+  // must not manually add it as a project runtime peer.
+  assert.doesNotMatch(script, /"@typescript\/native-preview":/);
   assert.match(script, /require\("@vizejs\/native"\)/);
   assert.match(script, /import\("@vizejs\/native"\)/);
   assert.match(script, /native\.compileSfc/);

--- a/tools/npm/smoke-release-install.mjs
+++ b/tools/npm/smoke-release-install.mjs
@@ -269,7 +269,6 @@ function assertInstalledPackage(nodeModules, packageInfo) {
 // `vite` bin and its rolldown bindings expect a separate `vite-plus`
 // metapackage at runtime, which together broke `vite build` in CI.)
 const RUNTIME_PEER_DEPENDENCIES = {
-  "@typescript/native-preview": "7.0.0-dev.20260602.1",
   typescript: "6.0.3",
   vite: "^8.0.0",
   vue: "3.5.34",


### PR DESCRIPTION
## Summary
- declare @typescript/native-preview as an optional dependency of vize so vize check installs its runtime by default
- preserve withDefaults narrowing and TypeScript as assertions in virtual template type-checking
- resolve props inherited through Vue SFC type re-exports, including mixed default/type re-export barrels
- skip Takumi OG image SFCs in Nuxt compiler defaults while preserving explicit user excludes

## Validation
- cargo fmt --all -- --check
- cargo test --workspace
- vp run --workspace-root check:ci
- vp run --workspace-root test:scripts
- vp run --filter ./npm/nuxt test
- cargo test -p vize_canon
- cargo test -p vize_atelier_sfc
- cargo test -p vize --test build_cli

Fixes #946
Fixes #947
Fixes #948
Fixes #949
Fixes #950
Fixes #951

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/952"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783077362&installation_id=136613492&pr_number=952&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F952&signature=9dc235850255e6ea8bf025e5a8bb6e79b5f6a77bb81aa71ee54f9b6270e9d653"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->