### PR TITLE
fix: tighten vize clean lifecycle

### DIFF
--- a/crates/vize/src/commands/clean.rs
+++ b/crates/vize/src/commands/clean.rs
@@ -5,11 +5,19 @@ use std::{fs, io::ErrorKind};
 
 #[derive(clap::Args, Debug, Clone)]
 pub struct CleanArgs {
-    /// Project root whose node_modules/.vize cache should be removed
+    /// Project root whose Vize-generated artifacts should be removed
     #[arg(default_value = ".")]
     pub root: PathBuf,
 
-    /// Print the cache path without deleting it
+    /// Which Vize artifact roots to remove
+    #[arg(long, value_enum, default_value_t = CleanScope::All)]
+    pub scope: CleanScope,
+
+    /// Remove the selected artifact roots, including unrecognized entries
+    #[arg(long)]
+    pub force: bool,
+
+    /// Print artifact paths without deleting them
     #[arg(long)]
     pub dry_run: bool,
 
@@ -18,49 +26,288 @@ pub struct CleanArgs {
     pub quiet: bool,
 }
 
+#[derive(clap::ValueEnum, Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CleanScope {
+    /// Remove both .vize and node_modules/.vize
+    All,
+    /// Remove .vize under the project root
+    Project,
+    /// Remove node_modules/.vize under the project root
+    NodeModules,
+}
+
 pub fn run(args: CleanArgs) {
     let root = args.root.canonicalize().unwrap_or(args.root);
-    let cache_dir = vize_cache_dir(&root);
+    let artifact_paths = if args.force {
+        vize_artifact_roots(&root, args.scope)
+    } else {
+        managed_vize_artifact_paths(&root, args.scope)
+    };
 
     if args.dry_run {
         if !args.quiet {
-            println!("{}", cache_dir.display());
+            for artifact_path in &artifact_paths {
+                println!("{}", artifact_path.display());
+            }
         }
         return;
     }
 
-    match fs::remove_dir_all(&cache_dir) {
-        Ok(()) => {
-            if !args.quiet {
-                println!("Removed {}", cache_dir.display());
+    let mut removed_any = false;
+    for artifact_path in &artifact_paths {
+        match remove_path(artifact_path) {
+            Ok(true) => {
+                removed_any = true;
+                if !args.quiet {
+                    println!("Removed {}", artifact_path.display());
+                }
+            }
+            Ok(false) => {}
+            Err(error) => {
+                eprintln!("Failed to remove {}: {}", artifact_path.display(), error);
+                std::process::exit(1);
             }
         }
-        Err(error) if error.kind() == ErrorKind::NotFound => {
-            if !args.quiet {
-                println!("No Vize cache found at {}", cache_dir.display());
-            }
-        }
-        Err(error) => {
-            eprintln!("Failed to remove {}: {}", cache_dir.display(), error);
-            std::process::exit(1);
+    }
+
+    if !args.force {
+        remove_empty_artifact_roots(&root, args.scope);
+    }
+
+    if !removed_any && !args.quiet {
+        match artifact_paths.as_slice() {
+            [artifact_path] => println!(
+                "No managed Vize artifacts found at {}",
+                artifact_path.display()
+            ),
+            _ => println!("No managed Vize artifacts found under {}", root.display()),
         }
     }
 }
 
-fn vize_cache_dir(root: &Path) -> PathBuf {
+fn managed_vize_artifact_paths(root: &Path, scope: CleanScope) -> Vec<PathBuf> {
+    let mut paths = Vec::new();
+    if matches!(scope, CleanScope::All | CleanScope::Project) {
+        paths.extend(project_vize_artifact_paths(root));
+    }
+    if matches!(scope, CleanScope::All | CleanScope::NodeModules) {
+        paths.extend(node_modules_vize_artifact_paths(root));
+    }
+    paths
+}
+
+fn vize_artifact_roots(root: &Path, scope: CleanScope) -> Vec<PathBuf> {
+    match scope {
+        CleanScope::All => vec![project_vize_dir(root), node_modules_vize_dir(root)],
+        CleanScope::Project => vec![project_vize_dir(root)],
+        CleanScope::NodeModules => vec![node_modules_vize_dir(root)],
+    }
+}
+
+fn project_vize_dir(root: &Path) -> PathBuf {
+    root.join(".vize")
+}
+
+fn node_modules_vize_dir(root: &Path) -> PathBuf {
     root.join("node_modules").join(".vize")
+}
+
+fn project_vize_artifact_paths(root: &Path) -> Vec<PathBuf> {
+    let project_vize_dir = project_vize_dir(root);
+    ["patina", "reports", "snapshots", "tokens"]
+        .into_iter()
+        .map(|name| project_vize_dir.join(name))
+        .collect()
+}
+
+fn node_modules_vize_artifact_paths(root: &Path) -> Vec<PathBuf> {
+    let node_modules_vize_dir = node_modules_vize_dir(root);
+    [
+        "canon",
+        "check-profile",
+        "corsa",
+        "corsa-overlay",
+        "lsp.log",
+        "oxc-dumps",
+        "oxlint-plugin-vize",
+        "patina",
+        "vize.config.schema.json",
+        "vize.sock",
+    ]
+    .into_iter()
+    .map(|name| node_modules_vize_dir.join(name))
+    .collect()
+}
+
+fn remove_path(path: &Path) -> Result<bool, std::io::Error> {
+    let metadata = match fs::symlink_metadata(path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == ErrorKind::NotFound => return Ok(false),
+        Err(error) => return Err(error),
+    };
+
+    let file_type = metadata.file_type();
+    if file_type.is_dir() && !file_type.is_symlink() {
+        fs::remove_dir_all(path)?;
+    } else {
+        fs::remove_file(path)?;
+    }
+    Ok(true)
+}
+
+fn remove_empty_artifact_roots(root: &Path, scope: CleanScope) {
+    for artifact_root in vize_artifact_roots(root, scope) {
+        let _ = fs::remove_dir(artifact_root);
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::vize_cache_dir;
+    use super::{
+        CleanArgs, CleanScope, managed_vize_artifact_paths, node_modules_vize_artifact_paths,
+        node_modules_vize_dir, project_vize_artifact_paths, project_vize_dir, run,
+        vize_artifact_roots,
+    };
     use std::path::Path;
 
     #[test]
-    fn vize_cache_dir_points_under_node_modules() {
+    fn vize_artifact_roots_default_to_project_and_node_modules() {
         assert_eq!(
-            vize_cache_dir(Path::new("/project")),
+            vize_artifact_roots(Path::new("/project"), CleanScope::All),
+            vec![
+                Path::new("/project").join(".vize"),
+                Path::new("/project").join("node_modules").join(".vize"),
+            ]
+        );
+    }
+
+    #[test]
+    fn scoped_vize_artifact_roots_can_target_each_root() {
+        assert_eq!(
+            project_vize_dir(Path::new("/project")),
+            Path::new("/project").join(".vize")
+        );
+        assert_eq!(
+            node_modules_vize_dir(Path::new("/project")),
             Path::new("/project").join("node_modules").join(".vize")
         );
+        assert_eq!(
+            vize_artifact_roots(Path::new("/project"), CleanScope::Project),
+            vec![Path::new("/project").join(".vize")]
+        );
+        assert_eq!(
+            vize_artifact_roots(Path::new("/project"), CleanScope::NodeModules),
+            vec![Path::new("/project").join("node_modules").join(".vize")]
+        );
+    }
+
+    #[test]
+    fn managed_artifact_paths_are_lifecycle_owned_entries() {
+        let root = Path::new("/project");
+
+        assert_eq!(
+            project_vize_artifact_paths(root),
+            vec![
+                root.join(".vize").join("patina"),
+                root.join(".vize").join("reports"),
+                root.join(".vize").join("snapshots"),
+                root.join(".vize").join("tokens"),
+            ]
+        );
+        assert_eq!(
+            node_modules_vize_artifact_paths(root),
+            vec![
+                root.join("node_modules/.vize/canon"),
+                root.join("node_modules/.vize/check-profile"),
+                root.join("node_modules/.vize/corsa"),
+                root.join("node_modules/.vize/corsa-overlay"),
+                root.join("node_modules/.vize/lsp.log"),
+                root.join("node_modules/.vize/oxc-dumps"),
+                root.join("node_modules/.vize/oxlint-plugin-vize"),
+                root.join("node_modules/.vize/patina"),
+                root.join("node_modules/.vize/vize.config.schema.json"),
+                root.join("node_modules/.vize/vize.sock"),
+            ]
+        );
+        assert_eq!(
+            managed_vize_artifact_paths(root, CleanScope::All).len(),
+            project_vize_artifact_paths(root).len() + node_modules_vize_artifact_paths(root).len()
+        );
+    }
+
+    #[test]
+    fn clean_removes_managed_project_and_node_modules_vize_artifacts() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        let project_artifact = root.join(".vize").join("patina").join("session-1-0");
+        let node_modules_artifact = root.join("node_modules").join(".vize").join("canon");
+        std::fs::create_dir_all(&project_artifact).unwrap();
+        std::fs::create_dir_all(&node_modules_artifact).unwrap();
+        std::fs::write(root.join("node_modules").join(".vize").join("lsp.log"), "").unwrap();
+        std::fs::write(root.join("node_modules").join("keep.txt"), "keep").unwrap();
+
+        run(CleanArgs {
+            root: root.to_path_buf(),
+            scope: CleanScope::All,
+            force: false,
+            dry_run: false,
+            quiet: true,
+        });
+
+        assert!(!root.join(".vize").exists());
+        assert!(!root.join("node_modules").join(".vize").exists());
+        assert!(root.join("node_modules").join("keep.txt").exists());
+    }
+
+    #[test]
+    fn clean_preserves_unrecognized_entries_without_force() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        let managed_project_artifact = root.join(".vize").join("reports");
+        let unknown_project_artifact = root.join(".vize").join("custom").join("keep.txt");
+        let managed_node_modules_artifact = root.join("node_modules/.vize/canon");
+        let unknown_node_modules_artifact = root.join("node_modules/.vize/custom/keep.txt");
+        std::fs::create_dir_all(&managed_project_artifact).unwrap();
+        std::fs::create_dir_all(unknown_project_artifact.parent().unwrap()).unwrap();
+        std::fs::write(&unknown_project_artifact, "keep").unwrap();
+        std::fs::create_dir_all(&managed_node_modules_artifact).unwrap();
+        std::fs::create_dir_all(unknown_node_modules_artifact.parent().unwrap()).unwrap();
+        std::fs::write(&unknown_node_modules_artifact, "keep").unwrap();
+
+        run(CleanArgs {
+            root: root.to_path_buf(),
+            scope: CleanScope::All,
+            force: false,
+            dry_run: false,
+            quiet: true,
+        });
+
+        assert!(!managed_project_artifact.exists());
+        assert!(!managed_node_modules_artifact.exists());
+        assert!(unknown_project_artifact.exists());
+        assert!(unknown_node_modules_artifact.exists());
+    }
+
+    #[test]
+    fn force_clean_removes_selected_artifact_roots() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        let unknown_project_artifact = root.join(".vize").join("custom").join("keep.txt");
+        let unknown_node_modules_artifact = root.join("node_modules/.vize/custom/keep.txt");
+        std::fs::create_dir_all(unknown_project_artifact.parent().unwrap()).unwrap();
+        std::fs::write(&unknown_project_artifact, "keep").unwrap();
+        std::fs::create_dir_all(unknown_node_modules_artifact.parent().unwrap()).unwrap();
+        std::fs::write(&unknown_node_modules_artifact, "keep").unwrap();
+
+        run(CleanArgs {
+            root: root.to_path_buf(),
+            scope: CleanScope::Project,
+            force: true,
+            dry_run: false,
+            quiet: true,
+        });
+
+        assert!(!root.join(".vize").exists());
+        assert!(unknown_node_modules_artifact.exists());
     }
 }

--- a/crates/vize/src/snapshots/vize__cli__tests__cli_clean_help.snap
+++ b/crates/vize/src/snapshots/vize__cli__tests__cli_clean_help.snap
@@ -9,16 +9,29 @@ Usage: clean [OPTIONS] [ROOT]
 
 Arguments:
   [ROOT]
-          Project root whose node_modules/.vize cache should be removed
+          Project root whose Vize-generated artifacts should be removed
 
           [default: .]
 
 Options:
+      --scope <SCOPE>
+          Which Vize artifact roots to remove
+
+          Possible values:
+          - all:          Remove both .vize and node_modules/.vize
+          - project:      Remove .vize under the project root
+          - node-modules: Remove node_modules/.vize under the project root
+
+          [default: all]
+
+      --force
+          Remove the selected artifact roots, including unrecognized entries
+
       --dry-run
-          Print the cache path without deleting it
+          Print artifact paths without deleting them
 
   -q, --quiet
           Suppress status output
 
   -h, --help
-          Print help
+          Print help (see a summary with '-h')

--- a/docs/content/guide/cli.md
+++ b/docs/content/guide/cli.md
@@ -261,11 +261,19 @@ See [Compiler Inspector](./compiler-inspector.md) for the contributor workflow.
 ```bash
 vize clean
 vize clean --dry-run
+vize clean --scope node-modules
+vize clean --scope project
+vize clean --force
 vize clean path/to/project
 ```
 
-`vize clean` removes `node_modules/.vize` for the selected project root. Use it when profile
-artifacts or materialized Corsa project files should be rebuilt from a blank cache directory.
+`vize clean` removes known Vize-owned local artifacts for the selected project root, then removes
+empty `.vize` and `node_modules/.vize` parents. The managed artifact list covers profile outputs,
+Musea reports/snapshots/tokens, Patina sessions, config schemas, LSP logs, socket leftovers, OXC
+dumps, Oxlint workaround files, and materialized Corsa project files. Unknown entries under `.vize`
+are preserved by default; use `--force` only when the selected artifact root should be removed
+wholesale. `--dry-run` prints the artifact paths that would be removed. Use `--scope node-modules`
+or `--scope project` when only one artifact root should be cleaned.
 
 ## Ready
 


### PR DESCRIPTION
## Summary

- make `vize clean` remove known Vize-owned `.vize` artifacts instead of blindly treating `node_modules/.vize` as the only cache root
- add `--scope` and `--force` so normal cleanup preserves unrecognized `.vize` entries while explicit force cleanup can remove selected roots wholesale
- update clean help snapshots and CLI docs with the lifecycle behavior

## Why

`.vize` now contains several different artifact lifecycles: temporary Patina sessions, generated Musea outputs, materialized Corsa project files, logs, schemas, sockets, and plugin workaround files. The clean command needs to reflect those ownership boundaries so cleanup is predictable and does not delete unknown data by default.

## Validation

- `cargo fmt --check`
- `cargo test -p vize --lib`
- `cargo run -p vize -- clean --dry-run`
- `cargo run -p vize -- clean --dry-run --force`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/953"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783079667&installation_id=136613492&pr_number=953&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F953&signature=875a3f8fd05dd554aa17245aa8111db1ee48dab7ded3a1ddfbf9152d4dccb5be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->