### PR TITLE
fix(armature): preserve '/' as value char in unquoted attributes

### DIFF
--- a/crates/vize_armature/src/tokenizer/states.rs
+++ b/crates/vize_armature/src/tokenizer/states.rs
@@ -517,13 +517,16 @@ impl<'a, C: Callbacks> Tokenizer<'a, C> {
                 ErrorCode::UnexpectedEqualsSignBeforeAttributeName,
                 self.index,
             );
-        } else if c == GT || c == SLASH {
+        } else if c == GT {
             self.callbacks
                 .on_error(ErrorCode::MissingAttributeValue, self.index);
             self.callbacks.on_attrib_end(QuoteType::NoValue, self.index);
             self.state = State::BeforeAttrName;
             self.state_before_attr_name(c);
         } else if !is_whitespace(c) {
+            // Per HTML spec, anything other than `"`, `'`, `>`, or whitespace
+            // (including `/`) is reconsumed in the attribute value (unquoted)
+            // state. This keeps unquoted URL-ish values intact (#959).
             self.section_start = self.index;
             self.state = State::InAttrValueNq;
             self.state_in_attr_value_nq(c);
@@ -550,8 +553,6 @@ impl<'a, C: Callbacks> Tokenizer<'a, C> {
         if is_whitespace(c) || c == GT {
             self.emit_attr_value(QuoteType::Unquoted);
             self.state_before_attr_name(c);
-        } else if c == SLASH {
-            self.emit_attr_value(QuoteType::Unquoted);
         } else if c == AMP {
             self.start_entity();
         } else if matches!(c, DOUBLE_QUOTE | SINGLE_QUOTE | LT | EQ | GRAVE_ACCENT) {
@@ -560,6 +561,10 @@ impl<'a, C: Callbacks> Tokenizer<'a, C> {
                 self.index,
             );
         }
+        // Per HTML spec, only whitespace and `>` terminate an unquoted
+        // attribute value. `/` is an ordinary value character here; the
+        // self-closing `/` is only recognized in the *before/after attribute*
+        // states. See https://html.spec.whatwg.org/multipage/parsing.html#attribute-value-(unquoted)-state
     }
 
     pub(super) fn emit_attr_value(&mut self, quote: QuoteType) {

--- a/crates/vize_armature/src/tokenizer/tests.rs
+++ b/crates/vize_armature/src/tokenizer/tests.rs
@@ -258,6 +258,29 @@ fn test_attribute_unquoted() {
 }
 
 #[test]
+fn test_attribute_unquoted_slash_is_value_char() {
+    // Per HTML spec, only whitespace and `>` terminate an unquoted attribute
+    // value. `/` is an ordinary value character. Regression for #959.
+    let cb = tokenize("<a href=a/b/c>x</a>");
+    assert!(cb.events.contains(&TokenEvent::AttribName(3, 7)));
+    assert!(cb.events.contains(&TokenEvent::AttribData(8, 13)));
+    assert!(
+        cb.events
+            .contains(&TokenEvent::AttribEnd(QuoteType::Unquoted, 13))
+    );
+}
+
+#[test]
+fn test_attribute_unquoted_slash_in_url_value() {
+    let cb = tokenize("<a href=//cdn/x>x</a>");
+    assert!(cb.events.contains(&TokenEvent::AttribData(8, 15)));
+    assert!(
+        cb.events
+            .contains(&TokenEvent::AttribEnd(QuoteType::Unquoted, 15))
+    );
+}
+
+#[test]
 fn test_attribute_no_value() {
     let cb = tokenize("<input disabled>");
     assert!(cb.events.contains(&TokenEvent::AttribName(7, 15)));


### PR DESCRIPTION
## Summary

Fixes #959.

Per HTML spec, in the *attribute value (unquoted)* and *before attribute value* states, only whitespace and `>` terminate the value. The tokenizer treated `/` as a terminator, so:

- `<a href=a/b/c>` was split into `{ href: "a", b: "", c: "" }` instead of `{ href: "a/b/c" }`.
- `<a href=//cdn/x>` lost the value entirely because `/` triggered `MissingAttributeValue` in `state_before_attr_value`.

Two states updated:
- `state_in_attr_value_nq`: drop the `/`-is-terminator branch.
- `state_before_attr_value`: only `>` (not `/`) triggers `MissingAttributeValue`; `/` reconsumes in unquoted-value state.

Self-closing `/` continues to be recognized only in *before/after attribute name* states, matching the spec.

## Test plan
- [x] `cargo test -p vize_armature --lib` — 133 passed (added `test_attribute_unquoted_slash_is_value_char`, `test_attribute_unquoted_slash_in_url_value`)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/973"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783143441&installation_id=136613492&pr_number=973&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F973&signature=00b4cea934fc3ee126b3220179116e75078ae7a3291101081cffb803987f868f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->