### PR TITLE
fix(maestro): use boundary-safe str access in template definition handler

### DIFF
--- a/crates/vize_maestro/src/ide/cursor_context.rs
+++ b/crates/vize_maestro/src/ide/cursor_context.rs
@@ -79,7 +79,12 @@ fn clamp_offset(content: &str, offset: usize) -> usize {
 /// block. Mirrors `crate::ide::completion::is_inside_html_comment` so the
 /// detector can be used outside the completion module too.
 fn is_inside_html_comment(content: &str, offset: usize) -> bool {
-    let before = &content[..offset];
+    // Guard against an offset that lands mid-codepoint (the LSP may report a
+    // UTF-16 column that doesn't translate cleanly back to a UTF-8 byte
+    // boundary) — bail out rather than panic. #964
+    let Some(before) = content.get(..offset) else {
+        return false;
+    };
     let Some(comment_start) = before.rfind("<!--") else {
         return false;
     };
@@ -88,7 +93,7 @@ fn is_inside_html_comment(content: &str, offset: usize) -> bool {
 }
 
 fn detect_member_access<'a>(content: &'a str, offset: usize) -> Option<CursorContext<'a>> {
-    let before = &content[..offset];
+    let before = content.get(..offset)?;
     // Allow whitespace between the `.` and the cursor — e.g. when the
     // editor's auto-indent inserts a newline.
     let trimmed = before.trim_end();
@@ -123,6 +128,9 @@ fn is_receiver_byte(byte: u8) -> bool {
 }
 
 fn detect_identifier<'a>(content: &'a str, offset: usize) -> CursorContext<'a> {
+    if offset > content.len() {
+        return CursorContext::Other;
+    }
     let bytes = content.as_bytes();
     let mut start = offset;
     while start > 0 && is_ident_byte(bytes[start - 1]) {
@@ -131,10 +139,14 @@ fn detect_identifier<'a>(content: &'a str, offset: usize) -> CursorContext<'a> {
     if start == offset {
         return CursorContext::Other;
     }
-    CursorContext::Identifier {
-        prefix: &content[start..offset],
-        start,
-    }
+    // Both `start` and `offset` sit on UTF-8 boundaries because the ident-byte
+    // predicate only matches ASCII bytes; `get` over `Other`-on-mismatch is a
+    // belt-and-braces guard for upstream offset arithmetic that may have
+    // landed mid-codepoint. #964
+    let Some(prefix) = content.get(start..offset) else {
+        return CursorContext::Other;
+    };
+    CursorContext::Identifier { prefix, start }
 }
 
 #[inline]

--- a/crates/vize_maestro/src/ide/definition.rs
+++ b/crates/vize_maestro/src/ide/definition.rs
@@ -617,6 +617,33 @@ const color = 'red'
         assert!(DefinitionService::definition(&ctx).is_none());
     }
 
+    #[test]
+    fn test_definition_does_not_panic_on_non_ascii_before_identifier() {
+        // Regression for #964: a non-ASCII character right before an
+        // identifier used to place `word_start - 6` inside a multi-byte
+        // codepoint and panic the LSP with "byte index N is not a char
+        // boundary". The handler must return a normal (possibly empty)
+        // response instead.
+        let dir = tempfile::tempdir().unwrap();
+        let source_path = dir.path().join("CJK.vue");
+        let source = "<script setup lang=\"ts\">\nconst title = 'こんにちは'\n</script>\n\n<template>\n  <div>あいうえおtitle</div>\n</template>\n";
+        fs::write(&source_path, source).unwrap();
+
+        let uri = Url::from_file_path(&source_path).unwrap();
+        let state = ServerState::new();
+        state
+            .documents
+            .open(uri.clone(), source.to_string(), 1, "vue".to_string());
+        state.update_virtual_docs(&uri, source);
+
+        // Land right after the `title` identifier that is preceded by CJK.
+        let offset = source.rfind("title").unwrap() + "title".len();
+        let ctx = IdeContext::new(&state, &uri, offset).unwrap();
+
+        // Must not panic. Returning Some or None are both acceptable.
+        let _ = DefinitionService::definition(&ctx);
+    }
+
     fn scalar_location(response: GotoDefinitionResponse) -> Location {
         match response {
             GotoDefinitionResponse::Scalar(location) => location,

--- a/crates/vize_maestro/src/ide/definition/template.rs
+++ b/crates/vize_maestro/src/ide/definition/template.rs
@@ -331,7 +331,11 @@ pub(crate) fn find_props_property_definition(
         return None;
     }
 
-    let prefix = &ctx.content[word_start.saturating_sub(6)..word_start];
+    // Use checked slicing — non-ASCII text right before the identifier could
+    // place `word_start - 6` mid-codepoint, panicking the LSP. Skip the prefix
+    // check on a non-boundary instead of slicing. (#964)
+    let prefix_start = word_start.saturating_sub(6);
+    let prefix = ctx.content.get(prefix_start..word_start)?;
     if prefix != "props." {
         return None;
     }


### PR DESCRIPTION
## Summary

Fixes #964 (p0).

Go-to-definition computed a 6-byte prefix slice (\`&content[word_start - 6..word_start]\`) without checking whether \`word_start - 6\` landed on a UTF-8 char boundary. A multi-byte codepoint just before the identifier (common in international source: CJK comments, accented labels, emoji) panicked the LSP with "byte index N is not a char boundary", tearing down the connection and breaking the editor session.

- Switch the prefix read to \`str::get\`, returning \`None\` instead of slicing on a non-boundary.
- Harden \`cursor_context\` (\`is_inside_html_comment\`, \`detect_member_access\`, \`detect_identifier\`) with the same boundary-checked pattern so an out-of-range or mid-codepoint offset yields a benign \`Other\`/\`false\` instead of a panic.

## Test plan
- [x] \`cargo test -p vize_maestro\` — all 292 lib tests passing including new \`test_definition_does_not_panic_on_non_ascii_before_identifier\` that triggers definition right after an identifier preceded by CJK text.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/976"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783144539&installation_id=136613492&pr_number=976&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F976&signature=33cb94163cec5b4ad9a2a0b1b4f1bbfb3d31e56938f27696f10d2610606b0da7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->