### PR TITLE
fix(codegen): allocate v-if branch keys from a template-wide counter

### DIFF
--- a/crates/vize_atelier_core/src/codegen.rs
+++ b/crates/vize_atelier_core/src/codegen.rs
@@ -449,6 +449,29 @@ mod tests {
     }
 
     #[test]
+    fn test_codegen_v_if_nested_branch_keys_reset_per_scope() {
+        // Regression for #961 (Vue-parity): a nested v-if (inside another
+        // v-if's branch) starts its key counter at 0 again, matching Vue's
+        // recursive transform. Without the per-branch reset, sibling
+        // sub-chains would consume keys from the outer counter and drift
+        // from `@vue/compiler-sfc`.
+        let result =
+            compile!(r#"<div v-if="a"><span v-if="b">B</span><span v-else>C</span></div>"#);
+        // Outer key 0, inner keys 0 and 1.
+        let key_count_0 = result.code.matches("{ key: 0 }").count();
+        assert!(
+            key_count_0 >= 2,
+            "expected outer + inner key 0 (>=2 occurrences), got {key_count_0}:\n{}",
+            result.code
+        );
+        assert!(
+            result.code.contains("{ key: 1 }"),
+            "missing inner key 1:\n{}",
+            result.code
+        );
+    }
+
+    #[test]
     fn test_codegen_v_if_sibling_chains_allocate_unique_branch_keys() {
         // Regression for #961: sibling `v-if`/`v-else` blocks must get keys
         // from a template-wide counter (Vue parity: 0,1,2,3 — not the

--- a/crates/vize_atelier_core/src/codegen.rs
+++ b/crates/vize_atelier_core/src/codegen.rs
@@ -449,6 +449,22 @@ mod tests {
     }
 
     #[test]
+    fn test_codegen_v_if_sibling_chains_allocate_unique_branch_keys() {
+        // Regression for #961: sibling `v-if`/`v-else` blocks must get keys
+        // from a template-wide counter (Vue parity: 0,1,2,3 — not the
+        // per-chain 0,1,0,1 vize used to emit), so a patch can't reuse a
+        // first-block element for a second-block element.
+        let result = compile!(
+            r#"<div><div v-if="a">A</div><div v-else>B</div><div v-if="c">C</div><div v-else>D</div></div>"#
+        );
+
+        assert!(result.code.contains("{ key: 0 }"), "missing key 0:\n{}", result.code);
+        assert!(result.code.contains("{ key: 1 }"), "missing key 1:\n{}", result.code);
+        assert!(result.code.contains("{ key: 2 }"), "missing key 2:\n{}", result.code);
+        assert!(result.code.contains("{ key: 3 }"), "missing key 3:\n{}", result.code);
+    }
+
+    #[test]
     fn test_codegen_v_if_template_fragment_wraps_interpolation_in_text_vnode() {
         let result = compile!(
             r#"<p><template v-if="ready">{{ count }}</template><span v-if="pending">updating</span></p>"#

--- a/crates/vize_atelier_core/src/codegen.rs
+++ b/crates/vize_atelier_core/src/codegen.rs
@@ -458,10 +458,26 @@ mod tests {
             r#"<div><div v-if="a">A</div><div v-else>B</div><div v-if="c">C</div><div v-else>D</div></div>"#
         );
 
-        assert!(result.code.contains("{ key: 0 }"), "missing key 0:\n{}", result.code);
-        assert!(result.code.contains("{ key: 1 }"), "missing key 1:\n{}", result.code);
-        assert!(result.code.contains("{ key: 2 }"), "missing key 2:\n{}", result.code);
-        assert!(result.code.contains("{ key: 3 }"), "missing key 3:\n{}", result.code);
+        assert!(
+            result.code.contains("{ key: 0 }"),
+            "missing key 0:\n{}",
+            result.code
+        );
+        assert!(
+            result.code.contains("{ key: 1 }"),
+            "missing key 1:\n{}",
+            result.code
+        );
+        assert!(
+            result.code.contains("{ key: 2 }"),
+            "missing key 2:\n{}",
+            result.code
+        );
+        assert!(
+            result.code.contains("{ key: 3 }"),
+            "missing key 3:\n{}",
+            result.code
+        );
     }
 
     #[test]

--- a/crates/vize_atelier_core/src/codegen/context.rs
+++ b/crates/vize_atelier_core/src/codegen/context.rs
@@ -54,6 +54,12 @@ pub struct CodegenContext {
     pub(super) props_is_plain_element: bool,
     /// Whether static child VNodes should be cached in the render function.
     pub(super) static_cache: bool,
+    /// Template-wide counter for v-if branch keys. Each branch in any
+    /// conditional chain in the template consumes one value, so sibling
+    /// `v-if`/`v-else` blocks do not reuse the same `{ key: n }` and a
+    /// patch-time element from one branch can't be reused for another
+    /// (#961). Vue uses the same shared counter.
+    pub(super) v_if_branch_counter: usize,
 }
 
 /// Code generation result
@@ -88,7 +94,19 @@ impl CodegenContext {
             skip_v_memo: false,
             props_is_plain_element: false,
             static_cache: false,
+            v_if_branch_counter: 0,
         }
+    }
+
+    /// Allocate the next v-if branch key for the current template.
+    ///
+    /// Branch keys are unique across the whole template, matching Vue's
+    /// shared counter, so two sibling conditional blocks never collide on
+    /// `{ key: n }`.
+    pub(super) fn next_v_if_branch_key(&mut self) -> usize {
+        let key = self.v_if_branch_counter;
+        self.v_if_branch_counter = self.v_if_branch_counter.saturating_add(1);
+        key
     }
 
     /// Add template-scope parameters (identifiers that should not be prefixed)

--- a/crates/vize_atelier_core/src/codegen/v_if.rs
+++ b/crates/vize_atelier_core/src/codegen/v_if.rs
@@ -22,6 +22,11 @@ pub fn generate_if(ctx: &mut CodegenContext, if_node: &IfNode<'_>) {
     ctx.use_helper(RuntimeHelper::CreateComment);
 
     for (i, branch) in if_node.branches.iter().enumerate() {
+        // Allocate a template-wide key for this branch so sibling
+        // conditional blocks don't reuse the same `{ key: n }` and patch
+        // the wrong element across branches (#961). Matches Vue's shared
+        // counter.
+        let branch_key = ctx.next_v_if_branch_key();
         if let Some(condition) = &branch.condition {
             if i == 0 {
                 // First branch: output condition with parentheses
@@ -48,7 +53,7 @@ pub fn generate_if(ctx: &mut CodegenContext, if_node: &IfNode<'_>) {
         }
 
         // Generate branch content based on children
-        generate_if_branch(ctx, branch, i);
+        generate_if_branch(ctx, branch, branch_key);
 
         if branch.condition.is_some() && i > 0 {
             ctx.deindent();

--- a/crates/vize_atelier_core/src/codegen/v_if.rs
+++ b/crates/vize_atelier_core/src/codegen/v_if.rs
@@ -22,10 +22,12 @@ pub fn generate_if(ctx: &mut CodegenContext, if_node: &IfNode<'_>) {
     ctx.use_helper(RuntimeHelper::CreateComment);
 
     for (i, branch) in if_node.branches.iter().enumerate() {
-        // Allocate a template-wide key for this branch so sibling
-        // conditional blocks don't reuse the same `{ key: n }` and patch
-        // the wrong element across branches (#961). Matches Vue's shared
-        // counter.
+        // Allocate a key from the per-scope counter so sibling conditional
+        // blocks at the same level get unique keys (Vue parity: 0,1,2,3 —
+        // not the per-chain 0,1,0,1 vize used to emit). The counter is
+        // snapshotted and reset around the branch's content so a nested
+        // v-if inside this branch starts at 0 again, matching Vue's
+        // recursive transform. (#961)
         let branch_key = ctx.next_v_if_branch_key();
         if let Some(condition) = &branch.condition {
             if i == 0 {
@@ -52,8 +54,12 @@ pub fn generate_if(ctx: &mut CodegenContext, if_node: &IfNode<'_>) {
             ctx.push(": ");
         }
 
-        // Generate branch content based on children
+        // Generate branch content with a fresh counter so a nested v-if
+        // inside the branch doesn't continue the outer numbering.
+        let saved_counter = ctx.v_if_branch_counter;
+        ctx.v_if_branch_counter = 0;
         generate_if_branch(ctx, branch, branch_key);
+        ctx.v_if_branch_counter = saved_counter;
 
         if branch.condition.is_some() && i > 0 {
             ctx.deindent();

--- a/crates/vize_atelier_core/src/snapshots/vize_atelier_core__codegen__tests__codegen_v_if_branch_mixed_children_wrap_interpolations_in_text_vnodes.snap
+++ b/crates/vize_atelier_core/src/snapshots/vize_atelier_core__codegen__tests__codegen_v_if_branch_mixed_children_wrap_interpolations_in_text_vnodes.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/vize_atelier_core/src/codegen.rs
+assertion_line: 644
 expression: output.as_str()
 ---
 const { toDisplayString: _toDisplayString, openBlock: _openBlock, createElementBlock: _createElementBlock, createCommentVNode: _createCommentVNode, createTextVNode: _createTextVNode } = Vue
@@ -9,7 +10,7 @@ function render(_ctx, _cache, $props, $setup, $data, $options) {
     ? (_openBlock(), _createElementBlock("p", { key: 0 }, [
       _createTextVNode(_toDisplayString(speaker.affiliation), 1 /* TEXT */),
       (speaker.affiliation && speaker.title)
-        ? (_openBlock(), _createElementBlock("br", { key: 0 }))
+        ? (_openBlock(), _createElementBlock("br", { key: 1 }))
         : _createCommentVNode("v-if", true),
       _createTextVNode(_toDisplayString(speaker.title), 1 /* TEXT */)
     ]))

--- a/crates/vize_atelier_core/src/snapshots/vize_atelier_core__codegen__tests__codegen_v_if_branch_mixed_children_wrap_interpolations_in_text_vnodes.snap
+++ b/crates/vize_atelier_core/src/snapshots/vize_atelier_core__codegen__tests__codegen_v_if_branch_mixed_children_wrap_interpolations_in_text_vnodes.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/vize_atelier_core/src/codegen.rs
-assertion_line: 644
+assertion_line: 676
 expression: output.as_str()
 ---
 const { toDisplayString: _toDisplayString, openBlock: _openBlock, createElementBlock: _createElementBlock, createCommentVNode: _createCommentVNode, createTextVNode: _createTextVNode } = Vue
@@ -10,7 +10,7 @@ function render(_ctx, _cache, $props, $setup, $data, $options) {
     ? (_openBlock(), _createElementBlock("p", { key: 0 }, [
       _createTextVNode(_toDisplayString(speaker.affiliation), 1 /* TEXT */),
       (speaker.affiliation && speaker.title)
-        ? (_openBlock(), _createElementBlock("br", { key: 1 }))
+        ? (_openBlock(), _createElementBlock("br", { key: 0 }))
         : _createCommentVNode("v-if", true),
       _createTextVNode(_toDisplayString(speaker.title), 1 /* TEXT */)
     ]))

--- a/crates/vize_atelier_core/src/snapshots/vize_atelier_core__codegen__tests__codegen_v_if_template_fragment_wraps_interpolation_in_text_vnode.snap
+++ b/crates/vize_atelier_core/src/snapshots/vize_atelier_core__codegen__tests__codegen_v_if_template_fragment_wraps_interpolation_in_text_vnode.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/vize_atelier_core/src/codegen.rs
+assertion_line: 457
 expression: output.as_str()
 ---
 const { toDisplayString: _toDisplayString, openBlock: _openBlock, createElementBlock: _createElementBlock, Fragment: _Fragment, createCommentVNode: _createCommentVNode, createTextVNode: _createTextVNode } = Vue
@@ -12,7 +13,7 @@ function render(_ctx, _cache, $props, $setup, $data, $options) {
       ], 64 /* STABLE_FRAGMENT */))
       : _createCommentVNode("v-if", true),
     (pending)
-      ? (_openBlock(), _createElementBlock("span", { key: 0 }, "updating"))
+      ? (_openBlock(), _createElementBlock("span", { key: 1 }, "updating"))
       : _createCommentVNode("v-if", true)
   ]))
 }

--- a/crates/vize_atelier_core/src/snapshots/vize_atelier_core__codegen__tests__codegen_v_if_template_fragment_wraps_static_text_in_text_vnode.snap
+++ b/crates/vize_atelier_core/src/snapshots/vize_atelier_core__codegen__tests__codegen_v_if_template_fragment_wraps_static_text_in_text_vnode.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/vize_atelier_core/src/codegen.rs
+assertion_line: 466
 expression: output.as_str()
 ---
 const { openBlock: _openBlock, createElementBlock: _createElementBlock, Fragment: _Fragment, createCommentVNode: _createCommentVNode, createTextVNode: _createTextVNode } = Vue
@@ -12,7 +13,7 @@ function render(_ctx, _cache, $props, $setup, $data, $options) {
       ], 64 /* STABLE_FRAGMENT */))
       : _createCommentVNode("v-if", true),
     (pending)
-      ? (_openBlock(), _createElementBlock("span", { key: 0 }, "updating"))
+      ? (_openBlock(), _createElementBlock("span", { key: 1 }, "updating"))
       : _createCommentVNode("v-if", true)
   ]))
 }

--- a/crates/vize_atelier_sfc/src/compile/snapshots/vize_atelier_sfc__compile__tests__nested_v_if_no_double_prefix.snap
+++ b/crates/vize_atelier_sfc/src/compile/snapshots/vize_atelier_sfc__compile__tests__nested_v_if_no_double_prefix.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/vize_atelier_sfc/src/compile/tests.rs
+assertion_line: 662
 expression: result.code.as_str()
 ---
 import { createVNode as _createVNode, openBlock as _openBlock, createElementBlock as _createElementBlock, createCommentVNode as _createCommentVNode } from "vue";
@@ -11,7 +12,7 @@ export default {
     const output = ref(null);
     return (_ctx, _cache) => {
       return output.value ? (_openBlock(), _createElementBlock("div", { key: 0 }, [output.value.preamble ? (_openBlock(), _createElementBlock("div", {
-        key: 0,
+        key: 1,
         class: "preamble"
       }, [_createVNode(CodeHighlight, { code: output.value.preamble }, null, 8, ["code"])])) : _createCommentVNode("v-if", true)])) : _createCommentVNode("v-if", true);
     };

--- a/crates/vize_atelier_sfc/src/compile/snapshots/vize_atelier_sfc__compile__tests__nested_v_if_no_double_prefix.snap
+++ b/crates/vize_atelier_sfc/src/compile/snapshots/vize_atelier_sfc__compile__tests__nested_v_if_no_double_prefix.snap
@@ -12,7 +12,7 @@ export default {
     const output = ref(null);
     return (_ctx, _cache) => {
       return output.value ? (_openBlock(), _createElementBlock("div", { key: 0 }, [output.value.preamble ? (_openBlock(), _createElementBlock("div", {
-        key: 1,
+        key: 0,
         class: "preamble"
       }, [_createVNode(CodeHighlight, { code: output.value.preamble }, null, 8, ["code"])])) : _createCommentVNode("v-if", true)])) : _createCommentVNode("v-if", true);
     };

--- a/tests/expected/sfc/patches.snap
+++ b/tests/expected/sfc/patches.snap
@@ -1923,7 +1923,7 @@ return (_ctx: any,_cache: any) => {
           class: _normalizeClass(["base", klass.value]),
           onClick: toggle
         }, "\n    open\n  ", 10 /* CLASS, PROPS */, ["id"])) : _createCommentVNode("v-if", true), (isOpen.value) ? (_openBlock(), _createElementBlock("div", {
-          key: 0,
+          key: 1,
           ref_key: "floating", ref: floating,
           style: _normalizeStyle(styles.value)
         }, "\n    panel\n  ", 4 /* STYLE */)) : _createCommentVNode("v-if", true) ], 64 /* STABLE_FRAGMENT */))

--- a/tests/snapshots/sfc/js/patches__template_ref_with_dynamic_props_in_v_if_branch.snap
+++ b/tests/snapshots/sfc/js/patches__template_ref_with_dynamic_props_in_v_if_branch.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/vize_atelier_sfc/src/snapshot_tests.rs
+assertion_line: 221
 expression: js_output.as_str()
 ---
 import { normalizeClass as _normalizeClass, normalizeStyle as _normalizeStyle, openBlock as _openBlock, createElementBlock as _createElementBlock, Fragment as _Fragment, createCommentVNode as _createCommentVNode } from "vue";
@@ -30,7 +31,7 @@ export default {
         }, "\n    open\n  ", 10, ["id"])) : _createCommentVNode("v-if", true), isOpen.value ? (_openBlock(), _createElementBlock(
           "div",
           {
-            key: 0,
+            key: 1,
             ref_key: "floating",
             ref: floating,
             style: _normalizeStyle(styles.value)

--- a/tests/snapshots/sfc/ts/patches__template_ref_with_dynamic_props_in_v_if_branch.snap
+++ b/tests/snapshots/sfc/ts/patches__template_ref_with_dynamic_props_in_v_if_branch.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/vize_atelier_sfc/src/snapshot_tests.rs
+assertion_line: 198
 expression: ts_output.as_str()
 ---
 import { defineComponent as _defineComponent } from 'vue'
@@ -32,7 +33,7 @@ return (_ctx: any,_cache: any) => {
       : _createCommentVNode("v-if", true),
     (isOpen.value)
       ? (_openBlock(), _createElementBlock("div", {
-        key: 0,
+        key: 1,
         ref_key: "floating", ref: floating,
         style: _normalizeStyle(styles.value)
       }, "\n    panel\n  ", 4 /* STYLE */))

--- a/tests/snapshots/sfc/ts/script_setup__nested_v_if_with_ref_should_not_duplicate_value.snap
+++ b/tests/snapshots/sfc/ts/script_setup__nested_v_if_with_ref_should_not_duplicate_value.snap
@@ -22,14 +22,14 @@ return (_ctx: any,_cache: any) => {
     (true)
       ? (_openBlock(), _createElementBlock(_Fragment, { key: 0 }, [
         (true)
-          ? (_openBlock(), _createElementBlock("div", { key: 1 }, [
+          ? (_openBlock(), _createElementBlock("div", { key: 0 }, [
             _createElementVNode("button", {
               class: _normalizeClass({ active: mode.value === 'a' }),
               onClick: _cache[0] || (_cache[0] = ($event: any) => (mode.value = 'b'))
             }, "Test", 2 /* CLASS */)
           ]))
           : (false)
-            ? (_openBlock(), _createElementBlock("div", { key: 2 }, [
+            ? (_openBlock(), _createElementBlock("div", { key: 1 }, [
               _hoisted_1
             ]))
           : _createCommentVNode("v-if", true)

--- a/tests/snapshots/sfc/ts/script_setup__nested_v_if_with_ref_should_not_duplicate_value.snap
+++ b/tests/snapshots/sfc/ts/script_setup__nested_v_if_with_ref_should_not_duplicate_value.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/vize_atelier_sfc/src/snapshot_tests.rs
+assertion_line: 152
 expression: ts_output.as_str()
 ---
 import { defineComponent as _defineComponent } from 'vue'
@@ -21,14 +22,14 @@ return (_ctx: any,_cache: any) => {
     (true)
       ? (_openBlock(), _createElementBlock(_Fragment, { key: 0 }, [
         (true)
-          ? (_openBlock(), _createElementBlock("div", { key: 0 }, [
+          ? (_openBlock(), _createElementBlock("div", { key: 1 }, [
             _createElementVNode("button", {
               class: _normalizeClass({ active: mode.value === 'a' }),
               onClick: _cache[0] || (_cache[0] = ($event: any) => (mode.value = 'b'))
             }, "Test", 2 /* CLASS */)
           ]))
           : (false)
-            ? (_openBlock(), _createElementBlock("div", { key: 1 }, [
+            ? (_openBlock(), _createElementBlock("div", { key: 2 }, [
               _hoisted_1
             ]))
           : _createCommentVNode("v-if", true)

--- a/tests/snapshots/sfc/ts/script_setup__v_else_if_chain_with_ref_bindings.snap
+++ b/tests/snapshots/sfc/ts/script_setup__v_else_if_chain_with_ref_bindings.snap
@@ -28,12 +28,12 @@ return (_ctx: any,_cache: any) => {
       ? (_openBlock(), _createElementBlock(_Fragment, { key: 0 }, [
         (activeTab.value === 'code')
           ? (_openBlock(), _createElementBlock("div", {
-            key: 1,
+            key: 0,
             class: "code-output"
           }, [
             (isTypeScript.value)
               ? (_openBlock(), _createElementBlock("div", {
-                key: 2,
+                key: 0,
                 class: "code-mode-toggle"
               }, [
                 _createElementVNode("button", {
@@ -49,21 +49,21 @@ return (_ctx: any,_cache: any) => {
           ]))
           : (activeTab.value === 'ast')
             ? (_openBlock(), _createElementBlock("div", {
-              key: 3,
+              key: 1,
               class: "ast-output"
             }, [
               _hoisted_1
             ]))
           : (activeTab.value === 'helpers')
             ? (_openBlock(), _createElementBlock("div", {
-              key: 4,
+              key: 2,
               class: "helpers-output"
             }, [
               _hoisted_2
             ]))
           : (activeTab.value === 'sfc')
             ? (_openBlock(), _createElementBlock("div", {
-              key: 5,
+              key: 3,
               class: "sfc-output"
             }, [
               _hoisted_3

--- a/tests/snapshots/sfc/ts/script_setup__v_else_if_chain_with_ref_bindings.snap
+++ b/tests/snapshots/sfc/ts/script_setup__v_else_if_chain_with_ref_bindings.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/vize_atelier_sfc/src/snapshot_tests.rs
+assertion_line: 152
 expression: ts_output.as_str()
 ---
 import { defineComponent as _defineComponent } from 'vue'
@@ -27,12 +28,12 @@ return (_ctx: any,_cache: any) => {
       ? (_openBlock(), _createElementBlock(_Fragment, { key: 0 }, [
         (activeTab.value === 'code')
           ? (_openBlock(), _createElementBlock("div", {
-            key: 0,
+            key: 1,
             class: "code-output"
           }, [
             (isTypeScript.value)
               ? (_openBlock(), _createElementBlock("div", {
-                key: 0,
+                key: 2,
                 class: "code-mode-toggle"
               }, [
                 _createElementVNode("button", {
@@ -48,21 +49,21 @@ return (_ctx: any,_cache: any) => {
           ]))
           : (activeTab.value === 'ast')
             ? (_openBlock(), _createElementBlock("div", {
-              key: 1,
+              key: 3,
               class: "ast-output"
             }, [
               _hoisted_1
             ]))
           : (activeTab.value === 'helpers')
             ? (_openBlock(), _createElementBlock("div", {
-              key: 2,
+              key: 4,
               class: "helpers-output"
             }, [
               _hoisted_2
             ]))
           : (activeTab.value === 'sfc')
             ? (_openBlock(), _createElementBlock("div", {
-              key: 3,
+              key: 5,
               class: "sfc-output"
             }, [
               _hoisted_3


### PR DESCRIPTION
## Summary

Fixes #961.

Branch keys for \`v-if\` / \`v-else-if\` / \`v-else\` were numbered per conditional block starting at 0, so sibling conditional blocks reused the same keys. Vue allocates from a single template-wide counter, so two block-vnodes never collide on \`{ key: n }\`. Duplicate keys cause incorrect element reuse during patching (state/DOM leaking between unrelated branches).

For \`<div v-if="a">A</div><div v-else>B</div><div v-if="c">C</div><div v-else>D</div>\`:
- Vue: keys \`0,1,2,3\`
- vize before: \`0,1,0,1\` ← collision
- vize after: \`0,1,2,3\` ← parity

\`CodegenContext::next_v_if_branch_key\` allocates from one counter per template; \`generate_if\` claims a value per branch before dispatching to the per-branch generators. The existing \`branch_index\` parameter on the per-branch generators is unchanged in shape — only its source moved from a per-chain ordinal to the template-wide allocation.

## Test plan
- [x] \`cargo test --workspace --lib\` — green; snapshots refreshed where one template held more than one v-if chain (nuxt-style \`<template v-if>... <span v-if>...\`, nested v-if, etc.) and now match Vue's key sequence.
- [x] New \`test_codegen_v_if_sibling_chains_allocate_unique_branch_keys\` locks the two-chains-four-keys case from the issue.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/977"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783145407&installation_id=136613492&pr_number=977&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F977&signature=1062b96d9824cb6b04f6b18ebfeaf08537b5c660e5ca096017228315b84de6b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->