### PR TITLE
fix(parser): collapse whitespace inside text nodes in condense mode

### DIFF
--- a/crates/vize_armature/src/parser/tests.rs
+++ b/crates/vize_armature/src/parser/tests.rs
@@ -54,6 +54,28 @@ fn test_parse_text() {
 }
 
 #[test]
+fn test_parse_condense_whitespace_collapses_runs_inside_text_nodes() {
+    // Regression for #960: `whitespace: 'condense'` (the default) must
+    // collapse runs of `[ \t\n\f\r]` to a single U+0020 inside text
+    // nodes, matching `@vue/compiler-sfc`. The previous behavior left
+    // mixed text nodes verbatim, so `x   y\n   z` stayed raw.
+    let allocator = Bump::new();
+    let (root, errors) = parse(&allocator, "<div>x   y\n   z</div>");
+    assert!(errors.is_empty(), "{errors:?}");
+
+    if let TemplateChildNode::Element(el) = &root.children[0] {
+        assert_eq!(el.children.len(), 1);
+        if let TemplateChildNode::Text(text) = &el.children[0] {
+            assert_eq!(text.content.as_str(), "x y z");
+        } else {
+            panic!("expected text child, got {:?}", el.children[0]);
+        }
+    } else {
+        panic!("expected element root");
+    }
+}
+
+#[test]
 fn test_parse_text_with_entities_preserves_raw_source() {
     let allocator = Bump::new();
     let (root, errors) = parse(&allocator, "&lt;foo&gt;");

--- a/crates/vize_armature/src/parser/whitespace.rs
+++ b/crates/vize_armature/src/parser/whitespace.rs
@@ -137,7 +137,7 @@ pub(super) fn condense_whitespace<'a>(
                 if let TemplateChildNode::Text(ref mut text) = children[i]
                     && let Some(condensed) = condense_internal_whitespace(text.content.as_str())
                 {
-                    text.content = condensed.into();
+                    text.content = condensed;
                 }
             }
         }

--- a/crates/vize_armature/src/parser/whitespace.rs
+++ b/crates/vize_armature/src/parser/whitespace.rs
@@ -1,10 +1,61 @@
 //! Whitespace condensing logic for the parser.
 //!
 //! Implements the `condense` whitespace strategy which removes or condenses
-//! whitespace-only text nodes between elements.
+//! whitespace-only text nodes between elements and collapses runs of
+//! whitespace inside mixed text nodes, matching `@vue/compiler-sfc`. Vue's
+//! whitespace alphabet is the ASCII set `[ \t\n\f\r]`, so this module uses
+//! `is_vue_whitespace` rather than the full-Unicode `char::is_whitespace`.
 
-use vize_carton::Vec;
+use vize_carton::{String, Vec};
 use vize_relief::ast::TemplateChildNode;
+
+/// Per Vue: only `[ \t\n\f\r]` is whitespace for the condense strategy.
+#[inline]
+fn is_vue_whitespace(c: char) -> bool {
+    matches!(c, ' ' | '\t' | '\n' | '\u{000C}' | '\r')
+}
+
+/// Collapse every maximal run of `[ \t\n\f\r]` in `text` to a single U+0020.
+fn condense_internal_whitespace(text: &str) -> Option<String> {
+    let needs_condense = {
+        let mut prev_ws = false;
+        let mut any_run = false;
+        let mut has_non_space_ws = false;
+        for c in text.chars() {
+            if is_vue_whitespace(c) {
+                if prev_ws {
+                    any_run = true;
+                }
+                if c != ' ' {
+                    has_non_space_ws = true;
+                }
+                prev_ws = true;
+            } else {
+                prev_ws = false;
+            }
+        }
+        any_run || has_non_space_ws
+    };
+
+    if !needs_condense {
+        return None;
+    }
+
+    let mut out = String::with_capacity(text.len());
+    let mut prev_ws = false;
+    for c in text.chars() {
+        if is_vue_whitespace(c) {
+            if !prev_ws {
+                out.push(' ');
+                prev_ws = true;
+            }
+        } else {
+            out.push(c);
+            prev_ws = false;
+        }
+    }
+    Some(out)
+}
 
 /// Condense whitespace in children
 pub(super) fn condense_whitespace<'a>(
@@ -14,7 +65,7 @@ pub(super) fn condense_whitespace<'a>(
     // First pass: remove leading whitespace-only text nodes
     while !children.is_empty() {
         if let TemplateChildNode::Text(ref text) = children[0]
-            && text.content.chars().all(char::is_whitespace)
+            && text.content.chars().all(is_vue_whitespace)
         {
             children.remove(0);
             continue;
@@ -26,7 +77,7 @@ pub(super) fn condense_whitespace<'a>(
     while !children.is_empty() {
         let last = children.len() - 1;
         if let TemplateChildNode::Text(ref text) = children[last]
-            && text.content.chars().all(char::is_whitespace)
+            && text.content.chars().all(is_vue_whitespace)
         {
             children.remove(last);
             continue;
@@ -77,7 +128,18 @@ pub(super) fn condense_whitespace<'a>(
                     children.remove(i + 1);
                 }
             }
-            WhitespaceAction::Keep => {}
+            WhitespaceAction::Keep => {
+                // For mixed-content text nodes (text + whitespace runs),
+                // collapse internal whitespace runs to a single U+0020 too,
+                // matching Vue's `condense` strategy. Without this `x   y\n
+                // z` would keep its raw whitespace and diverge from
+                // `@vue/compiler-sfc`. (#960)
+                if let TemplateChildNode::Text(ref mut text) = children[i]
+                    && let Some(condensed) = condense_internal_whitespace(text.content.as_str())
+                {
+                    text.content = condensed.into();
+                }
+            }
         }
 
         // Recurse into elements
@@ -93,7 +155,7 @@ pub(super) fn condense_whitespace<'a>(
 
 #[inline]
 fn is_whitespace_text(child: &TemplateChildNode<'_>) -> bool {
-    matches!(child, TemplateChildNode::Text(text) if text.content.chars().all(char::is_whitespace))
+    matches!(child, TemplateChildNode::Text(text) if text.content.chars().all(is_vue_whitespace))
 }
 
 #[inline]
@@ -108,7 +170,7 @@ fn whitespace_has_newline(child: &TemplateChildNode<'_>) -> bool {
 fn is_text_like(child: &TemplateChildNode<'_>) -> bool {
     match child {
         TemplateChildNode::Interpolation(_) => true,
-        TemplateChildNode::Text(text) => !text.content.chars().all(char::is_whitespace),
+        TemplateChildNode::Text(text) => !text.content.chars().all(is_vue_whitespace),
         _ => false,
     }
 }

--- a/crates/vize_atelier_vapor/src/lib.rs
+++ b/crates/vize_atelier_vapor/src/lib.rs
@@ -796,10 +796,13 @@ mod tests {
     #[test]
     fn test_compile_dynamic_text_escapes_multiline_static_part() {
         let allocator = Bump::new();
+        // Condense mode collapses the `\n` in the static part to a space
+        // (Vue parity, #960), so a `<pre>` wrapper preserves it for this
+        // escape-handling check.
         let result = compile_vapor(
             &allocator,
-            r#"<button :class="cls">{{ count }} all
-selected</button>"#,
+            r#"<pre :class="cls">{{ count }} all
+selected</pre>"#,
             Default::default(),
         );
 

--- a/crates/vize_atelier_vapor/src/snapshots/vize_atelier_vapor__tests__compile_dynamic_siblings_around_control_flow_children.snap
+++ b/crates/vize_atelier_vapor/src/snapshots/vize_atelier_vapor__tests__compile_dynamic_siblings_around_control_flow_children.snap
@@ -1,10 +1,11 @@
 ---
 source: crates/vize_atelier_vapor/src/lib.rs
+assertion_line: 793
 expression: code.as_str()
 ---
 import { child as _child, next as _next, setClass as _setClass, createInvoker as _createInvoker, delegateEvents as _delegateEvents, setInsertionState as _setInsertionState, renderEffect as _renderEffect, createIf as _createIf, template as _template } from 'vue';
-const t0 = _template("<button>\n                  Bindings\n                </button>", true)
-const t1 = _template("<section><div class=\"tabs\"><button>\n                  Code\n                </button><button>\n                  Helpers\n                </button></div></section>", true)
+const t0 = _template("<button> Bindings </button>", true)
+const t1 = _template("<section><div class=\"tabs\"><button> Code </button><button> Helpers </button></div></section>", true)
 _delegateEvents("click")
 export function render(_ctx) {
 const n1 = t1()

--- a/playground/e2e/vrt/atelier-code-tabs.spec.ts
+++ b/playground/e2e/vrt/atelier-code-tabs.spec.ts
@@ -84,9 +84,12 @@ test("atelier code targets expose VDOM, SSR, and Vapor outputs with stable toggl
     /_ssrRenderAttrs\(_mergeProps\(\{\s*class:\s*['"]card['"]\s*\},\s*_attrs\)\)/,
   );
   expect(ssrLines).toContain("  <h2>${_ssrInterpolate(name)}</h2>");
-  expect(ssrLines).toContain("  <button${_ssrIncludeBooleanAttr(disabled) ? ' disabled' : ''}>");
-  expect(ssrLines).toContain("      Increment");
-  expect(ssrLines).toContain("    </button>");
+  // SSR static parts are condensed per Vue's `whitespace: 'condense'` (#960),
+  // so the multi-line `<button>\n  Increment\n</button>` source renders as
+  // a single-line emit with the inner whitespace collapsed.
+  expect(
+    ssrLines.some((line) => line.includes("_ssrIncludeBooleanAttr(disabled)") && line.includes("Increment")),
+  ).toBe(true);
 
   await vaporButton.click();
   await expect(page.locator(".code-header h4")).toHaveText("Vapor Output");

--- a/playground/e2e/vrt/atelier-code-tabs.spec.ts
+++ b/playground/e2e/vrt/atelier-code-tabs.spec.ts
@@ -88,7 +88,9 @@ test("atelier code targets expose VDOM, SSR, and Vapor outputs with stable toggl
   // so the multi-line `<button>\n  Increment\n</button>` source renders as
   // a single-line emit with the inner whitespace collapsed.
   expect(
-    ssrLines.some((line) => line.includes("_ssrIncludeBooleanAttr(disabled)") && line.includes("Increment")),
+    ssrLines.some(
+      (line) => line.includes("_ssrIncludeBooleanAttr(disabled)") && line.includes("Increment"),
+    ),
   ).toBe(true);
 
   await vaporButton.click();

--- a/tests/expected/sfc/patches.snap
+++ b/tests/expected/sfc/patches.snap
@@ -455,7 +455,7 @@ return (_ctx, _cache) => {
         onClick: _cache[0] || (_cache[0] = (...args) => (_ctx.handleClick && _ctx.handleClick(...args)))
       }), {
         default: _withCtx(() => [
-          _createTextVNode("\n    Click me\n  ")
+          _createTextVNode(" Click me ")
         ]),
         _: 1 /* STABLE */
       }, 16 /* FULL_PROPS */))
@@ -1922,11 +1922,11 @@ return (_ctx: any,_cache: any) => {
           id: isOpen.value ? 'open' : undefined,
           class: _normalizeClass(["base", klass.value]),
           onClick: toggle
-        }, "\n    open\n  ", 10 /* CLASS, PROPS */, ["id"])) : _createCommentVNode("v-if", true), (isOpen.value) ? (_openBlock(), _createElementBlock("div", {
+        }, " open ", 10 /* CLASS, PROPS */, ["id"])) : _createCommentVNode("v-if", true), (isOpen.value) ? (_openBlock(), _createElementBlock("div", {
           key: 1,
           ref_key: "floating", ref: floating,
           style: _normalizeStyle(styles.value)
-        }, "\n    panel\n  ", 4 /* STYLE */)) : _createCommentVNode("v-if", true) ], 64 /* STABLE_FRAGMENT */))
+        }, " panel ", 4 /* STYLE */)) : _createCommentVNode("v-if", true) ], 64 /* STABLE_FRAGMENT */))
 }
 }
 

--- a/tests/snapshots/sfc/js/patches__template_ref_with_dynamic_props_in_v_if_branch.snap
+++ b/tests/snapshots/sfc/js/patches__template_ref_with_dynamic_props_in_v_if_branch.snap
@@ -28,7 +28,7 @@ export default {
           id: isOpen.value ? "open" : undefined,
           class: _normalizeClass(["base", klass.value]),
           onClick: toggle
-        }, "\n    open\n  ", 10, ["id"])) : _createCommentVNode("v-if", true), isOpen.value ? (_openBlock(), _createElementBlock(
+        }, " open ", 10, ["id"])) : _createCommentVNode("v-if", true), isOpen.value ? (_openBlock(), _createElementBlock(
           "div",
           {
             key: 1,
@@ -36,7 +36,7 @@ export default {
             ref: floating,
             style: _normalizeStyle(styles.value)
           },
-          "\n    panel\n  ",
+          " panel ",
           4
           /* STYLE */
         )) : _createCommentVNode("v-if", true)],

--- a/tests/snapshots/sfc/js/patches__v_if_with_v_bind_object_spread.snap
+++ b/tests/snapshots/sfc/js/patches__v_if_with_v_bind_object_spread.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/vize_atelier_sfc/src/snapshot_tests.rs
+assertion_line: 221
 expression: js_output.as_str()
 ---
 import { mergeProps as _mergeProps, openBlock as _openBlock, createBlock as _createBlock, createCommentVNode as _createCommentVNode, createTextVNode as _createTextVNode, withCtx as _withCtx } from "vue"
@@ -22,7 +23,7 @@ return (_ctx, _cache) => {
       onClick: _cache[0] || (_cache[0] = (...args) => (_ctx.handleClick && _ctx.handleClick(...args)))
     }), {
       default: _withCtx(() => [
-        _createTextVNode("\n    Click me\n  ")
+        _createTextVNode(" Click me ")
       ]),
       _: 1 /* STABLE */
     }, 16 /* FULL_PROPS */))

--- a/tests/snapshots/sfc/ts/patches__template_ref_with_dynamic_props_in_v_if_branch.snap
+++ b/tests/snapshots/sfc/ts/patches__template_ref_with_dynamic_props_in_v_if_branch.snap
@@ -29,14 +29,14 @@ return (_ctx: any,_cache: any) => {
         id: isOpen.value ? 'open' : undefined,
         class: _normalizeClass(["base", klass.value]),
         onClick: toggle
-      }, "\n    open\n  ", 10 /* CLASS, PROPS */, ["id"]))
+      }, " open ", 10 /* CLASS, PROPS */, ["id"]))
       : _createCommentVNode("v-if", true),
     (isOpen.value)
       ? (_openBlock(), _createElementBlock("div", {
         key: 1,
         ref_key: "floating", ref: floating,
         style: _normalizeStyle(styles.value)
-      }, "\n    panel\n  ", 4 /* STYLE */))
+      }, " panel ", 4 /* STYLE */))
       : _createCommentVNode("v-if", true)
   ], 64 /* STABLE_FRAGMENT */))
 }

--- a/tests/snapshots/sfc/ts/patches__v_if_with_v_bind_object_spread.snap
+++ b/tests/snapshots/sfc/ts/patches__v_if_with_v_bind_object_spread.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/vize_atelier_sfc/src/snapshot_tests.rs
+assertion_line: 198
 expression: ts_output.as_str()
 ---
 import { defineComponent as _defineComponent } from 'vue'
@@ -23,7 +24,7 @@ return (_ctx: any,_cache: any) => {
       onClick: _cache[0] || (_cache[0] = (...args) => (_ctx.handleClick && _ctx.handleClick(...args)))
     }), {
       default: _withCtx(() => [
-        _createTextVNode("\n    Click me\n  ")
+        _createTextVNode(" Click me ")
       ]),
       _: 1 /* STABLE */
     }, 16 /* FULL_PROPS */))


### PR DESCRIPTION
## Summary

Fixes #960.

The parser's \`condense\` whitespace strategy only removed whitespace-only text nodes **between** siblings; runs of whitespace **inside** a mixed text node survived. Official Vue collapses every run of \`[ \t\n\f\r]\` to a single U+0020 (outside \`<pre>\` / RCDATA / \`v-pre\`), so rendered text and static-string content diverged.

\`<div>x   y\n   z</div>\` → Vue: \`x y z\`; vize before: \`x   y\n   z\`.

- New \`condense_internal_whitespace\` wired into the Keep branch of the existing whitespace pass; \`<pre>\` recursion stays gated.
- The condense alphabet is narrowed from full-Unicode \`char::is_whitespace\` to Vue's ASCII-only set \`[ \t\n\f\r]\` (\`is_vue_whitespace\`), matching the spec.

## Test plan
- [x] \`cargo test --workspace --lib\` — green; snapshots refreshed where affected inputs had multi-line indentation (e.g. \`<button>\\n  open\\n</button>\` → \`<button> open </button>\`).
- [x] New \`test_parse_condense_whitespace_collapses_runs_inside_text_nodes\` locks the exact \`x   y\\n   z\` → \`x y z\` case from the issue.
- [x] The vapor \`test_compile_dynamic_text_escapes_multiline_static_part\` was retargeted at \`<pre>\` so the JS-escape-handling check still exercises a preserved \`\\n\`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/978"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783146252&installation_id=136613492&pr_number=978&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F978&signature=474dfa93c60dd272155b7fd87c1c47281230ac82f7a5098f5fb1074764d8cc08"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->