### PR TITLE
fix(sfc): type-only defineProps now emits required:true and method-signature props

### DIFF
--- a/crates/vize_atelier_sfc/src/compile/snapshots/vize_atelier_sfc__compile__tests__compile_both_script_blocks.snap
+++ b/crates/vize_atelier_sfc/src/compile/snapshots/vize_atelier_sfc__compile__tests__compile_both_script_blocks.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/vize_atelier_sfc/src/compile/tests.rs
+assertion_line: 1165
 expression: result.code.as_str()
 ---
 import { defineComponent as _defineComponent } from 'vue'
@@ -18,7 +19,7 @@ export type { TabItem };
 export default /*@__PURE__*/_defineComponent({
   __name: 'anonymous',
   props: {
-    items: { type: Array }
+    items: { type: Array, required: true }
   },
   setup(__props: any) {
 

--- a/crates/vize_atelier_sfc/src/compile/snapshots/vize_atelier_sfc__compile__tests__define_props_interface_extends_imported_type_alias.snap
+++ b/crates/vize_atelier_sfc/src/compile/snapshots/vize_atelier_sfc__compile__tests__define_props_interface_extends_imported_type_alias.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/vize_atelier_sfc/src/compile/tests.rs
+assertion_line: 1414
 expression: result.code.as_str()
 ---
 import { useModel as _useModel, mergeModels as _mergeModels } from "vue";
@@ -16,7 +17,10 @@ export default {
       required: false,
       default: "md"
     },
-    items: { type: Array }
+    items: {
+      type: Array,
+      required: true
+    }
   }, {
     "modelValue": {
       type: String,

--- a/crates/vize_atelier_sfc/src/compile/snapshots/vize_atelier_sfc__compile__tests__full_sfc_props_destructure.snap
+++ b/crates/vize_atelier_sfc/src/compile/snapshots/vize_atelier_sfc__compile__tests__full_sfc_props_destructure.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/vize_atelier_sfc/src/compile/tests.rs
+assertion_line: 978
 expression: result.code.as_str()
 ---
 import { toDisplayString as _toDisplayString, createElementVNode as _createElementVNode, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue";
@@ -8,7 +9,10 @@ import { computed } from "vue";
 export default {
   __name: "test",
   props: {
-    name: { type: String },
+    name: {
+      type: String,
+      required: true
+    },
     count: {
       type: Number,
       required: false,

--- a/crates/vize_atelier_sfc/src/compile/snapshots/vize_atelier_sfc__compile__tests__script_setup_css_v_bind_reads_define_props.snap
+++ b/crates/vize_atelier_sfc/src/compile/snapshots/vize_atelier_sfc__compile__tests__script_setup_css_v_bind_reads_define_props.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/vize_atelier_sfc/src/compile/tests.rs
+assertion_line: 336
 expression: "sfc_compile_snapshot(&descriptor.css_vars, &result)"
 ---
 css vars:
@@ -24,9 +25,18 @@ import { resolveDirective as _resolveDirective, withDirectives as _withDirective
 export default {
   __name: "MkFeatureBanner",
   props: {
-    icon: { type: String },
-    color: { type: String },
-    offset: { type: Number }
+    icon: {
+      type: String,
+      required: true
+    },
+    color: {
+      type: String,
+      required: true
+    },
+    offset: {
+      type: Number,
+      required: true
+    }
   },
   setup(__props) {
     _useCssVars((_ctx) => ({

--- a/crates/vize_atelier_sfc/src/compile/snapshots/vize_atelier_sfc__compile__tests__script_setup_css_v_bind_reads_destructured_prop_aliases.snap
+++ b/crates/vize_atelier_sfc/src/compile/snapshots/vize_atelier_sfc__compile__tests__script_setup_css_v_bind_reads_destructured_prop_aliases.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/vize_atelier_sfc/src/compile/tests.rs
+assertion_line: 368
 expression: "sfc_compile_snapshot(&descriptor.css_vars, &result)"
 ---
 css vars:
@@ -20,7 +21,10 @@ const _hoisted_1 = {
 };
 export default {
   __name: "Alias",
-  props: { color: { type: String } },
+  props: { color: {
+    type: String,
+    required: true
+  } },
   setup(__props) {
     _useCssVars((_ctx) => ({ "test-bannerColor": __props.color }));
     return (_ctx, _cache) => {

--- a/crates/vize_atelier_sfc/src/compile_script/inline/compiler/props.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/inline/compiler/props.rs
@@ -112,13 +112,21 @@ pub(super) fn build_user_props_decl(
                         decl.push(b'>');
                     }
                 }
-                if prop_type.optional && !is_prod {
+                if !is_prod {
+                    // Vue's type-only inference emits `required` explicitly
+                    // for both branches in dev mode so prop-validation
+                    // warnings fire for required props that are omitted. The
+                    // previous output skipped `required: true` entirely. (#967)
                     if has_option {
                         decl.extend_from_slice(b", ");
                     } else {
                         decl.push(b' ');
                     }
-                    decl.extend_from_slice(b"required: false");
+                    if prop_type.optional {
+                        decl.extend_from_slice(b"required: false");
+                    } else {
+                        decl.extend_from_slice(b"required: true");
+                    }
                     has_option = true;
                 }
                 let mut has_default = false;

--- a/crates/vize_atelier_sfc/src/compile_script/inline/snapshots/vize_atelier_sfc__compile_script__inline__tests__tests__define_props_assignment_value_on_next_line.snap
+++ b/crates/vize_atelier_sfc/src/compile_script/inline/snapshots/vize_atelier_sfc__compile_script__inline__tests__tests__define_props_assignment_value_on_next_line.snap
@@ -1,13 +1,20 @@
 ---
 source: crates/vize_atelier_sfc/src/compile_script/inline/tests.rs
+assertion_line: 412
 expression: output.as_str()
 ---
 import { computed } from "vue";
 export default {
   __name: "TestComponent",
   props: {
-    msg: { type: String },
-    count: { type: Number }
+    msg: {
+      type: String,
+      required: true
+    },
+    count: {
+      type: Number,
+      required: true
+    }
   },
   setup(__props) {
     const props = __props;

--- a/crates/vize_atelier_sfc/src/compile_script/inline/snapshots/vize_atelier_sfc__compile_script__inline__tests__tests__define_props_destructure_value_on_next_line.snap
+++ b/crates/vize_atelier_sfc/src/compile_script/inline/snapshots/vize_atelier_sfc__compile_script__inline__tests__tests__define_props_destructure_value_on_next_line.snap
@@ -1,14 +1,24 @@
 ---
 source: crates/vize_atelier_sfc/src/compile_script/inline/tests.rs
+assertion_line: 375
 expression: output.as_str()
 ---
 import { computed } from "vue";
 export default {
   __name: "TestComponent",
   props: {
-    type: { type: String },
-    title: { type: String },
-    startTime: { type: String }
+    type: {
+      type: String,
+      required: true
+    },
+    title: {
+      type: String,
+      required: true
+    },
+    startTime: {
+      type: String,
+      required: true
+    }
   },
   setup(__props) {
     const accentColor = computed(() => __props.type === "event" ? "primary" : "secondary");

--- a/crates/vize_atelier_sfc/src/compile_script/inline/snapshots/vize_atelier_sfc__compile_script__inline__tests__tests__define_props_destructure_value_on_next_line_with_semicolon.snap
+++ b/crates/vize_atelier_sfc/src/compile_script/inline/snapshots/vize_atelier_sfc__compile_script__inline__tests__tests__define_props_destructure_value_on_next_line_with_semicolon.snap
@@ -1,13 +1,20 @@
 ---
 source: crates/vize_atelier_sfc/src/compile_script/inline/tests.rs
+assertion_line: 394
 expression: output.as_str()
 ---
 import { ref } from "vue";
 export default {
   __name: "TestComponent",
   props: {
-    msg: { type: String },
-    count: { type: Number }
+    msg: {
+      type: String,
+      required: true
+    },
+    count: {
+      type: Number,
+      required: true
+    }
   },
   setup(__props) {
     const doubled = ref(__props.count * 2);

--- a/crates/vize_atelier_sfc/src/compile_script/inline/snapshots/vize_atelier_sfc__compile_script__inline__tests__tests__define_props_with_trailing_semicolon.snap
+++ b/crates/vize_atelier_sfc/src/compile_script/inline/snapshots/vize_atelier_sfc__compile_script__inline__tests__tests__define_props_with_trailing_semicolon.snap
@@ -1,11 +1,15 @@
 ---
 source: crates/vize_atelier_sfc/src/compile_script/inline/tests.rs
+assertion_line: 236
 expression: output.as_str()
 ---
 import { ref } from "vue";
 export default {
   __name: "TestComponent",
-  props: { msg: { type: String } },
+  props: { msg: {
+    type: String,
+    required: true
+  } },
   setup(__props) {
     const count = ref(0);
     return (_ctx, _cache) => {

--- a/crates/vize_atelier_sfc/src/compile_script/inline/snapshots/vize_atelier_sfc__compile_script__inline__tests__tests__export_type_generates_props_declaration.snap
+++ b/crates/vize_atelier_sfc/src/compile_script/inline/snapshots/vize_atelier_sfc__compile_script__inline__tests__tests__export_type_generates_props_declaration.snap
@@ -1,13 +1,23 @@
 ---
 source: crates/vize_atelier_sfc/src/compile_script/inline/tests.rs
+assertion_line: 341
 expression: output.as_str()
 ---
 export default {
   __name: "TestComponent",
   props: {
-    id: { type: String },
-    label: { type: String },
-    routeName: { type: String },
+    id: {
+      type: String,
+      required: true
+    },
+    label: {
+      type: String,
+      required: true
+    },
+    routeName: {
+      type: String,
+      required: true
+    },
     disabled: {
       type: Boolean,
       required: false

--- a/crates/vize_atelier_sfc/src/compile_script/inline/snapshots/vize_atelier_sfc__compile_script__inline__tests__tests__multiline_define_props_with_trailing_semicolon.snap
+++ b/crates/vize_atelier_sfc/src/compile_script/inline/snapshots/vize_atelier_sfc__compile_script__inline__tests__tests__multiline_define_props_with_trailing_semicolon.snap
@@ -1,12 +1,16 @@
 ---
 source: crates/vize_atelier_sfc/src/compile_script/inline/tests.rs
+assertion_line: 252
 expression: output.as_str()
 ---
 import { ref } from "vue";
 export default {
   __name: "TestComponent",
   props: {
-    label: { type: String },
+    label: {
+      type: String,
+      required: true
+    },
     disabled: {
       type: Boolean,
       required: false

--- a/crates/vize_atelier_sfc/src/compile_script/inline/snapshots/vize_atelier_sfc__compile_script__inline__tests__tests__with_defaults_trailing_semicolon.snap
+++ b/crates/vize_atelier_sfc/src/compile_script/inline/snapshots/vize_atelier_sfc__compile_script__inline__tests__tests__with_defaults_trailing_semicolon.snap
@@ -1,12 +1,16 @@
 ---
 source: crates/vize_atelier_sfc/src/compile_script/inline/tests.rs
+assertion_line: 272
 expression: output.as_str()
 ---
 import { ref } from "vue";
 export default {
   __name: "TestComponent",
   props: {
-    msg: { type: String },
+    msg: {
+      type: String,
+      required: true
+    },
     count: {
       type: Number,
       required: false,

--- a/crates/vize_atelier_sfc/src/compile_script/inline/tests.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/inline/tests.rs
@@ -444,6 +444,45 @@ const x = computed(() => 1)
     }
 
     #[test]
+    fn test_define_props_type_only_required_and_undefined_union() {
+        // Regression for #967: type-only `defineProps` must emit
+        // `required: true` for required props (no `?`) — including unions
+        // with `undefined` — and `required: false` only when the `?`
+        // modifier is present. Method-signature props must surface as
+        // `Function`-typed props instead of being silently dropped.
+        let content = r#"
+defineProps<{
+  a: string
+  b?: number
+  c: string | undefined
+  onChange(e: Event): void
+}>()
+"#;
+        let output = compile_setup(content);
+        let normalized: String = output
+            .split_whitespace()
+            .collect::<Vec<_>>()
+            .join(" ")
+            .into();
+        assert!(
+            normalized.contains("a: { type: String, required: true }"),
+            "expected `a` to be required, got:\n{output}"
+        );
+        assert!(
+            normalized.contains("b: { type: Number, required: false }"),
+            "expected `b` to be optional, got:\n{output}"
+        );
+        assert!(
+            normalized.contains("c: { type: String, required: true }"),
+            "expected `c` (union with undefined, no ?) to stay required, got:\n{output}"
+        );
+        assert!(
+            normalized.contains("onChange: { type: Function, required: true }"),
+            "expected `onChange` method-signature prop to surface, got:\n{output}"
+        );
+    }
+
+    #[test]
     fn test_non_props_destructure_value_on_next_line() {
         // Ensure regular (non-defineProps) destructures with value on next line
         // still work correctly

--- a/crates/vize_atelier_sfc/src/compile_script/props.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/props.rs
@@ -179,12 +179,44 @@ fn extract_prop_type_info(segment: &str, props: &mut Vec<(String, PropTypeInfo)>
         return;
     }
 
+    // Method-signature props (`onChange(e: E): void`, `update?(): T`) — the
+    // first `:` lives inside the parameter list. Detect by an opening paren
+    // before any colon, recover the name from the part preceding `(`, and
+    // treat the prop as a Function type. (#967)
+    if let Some(paren_pos) = trimmed.find('(') {
+        let before_paren = &trimmed[..paren_pos];
+        let has_colon_before_paren =
+            trimmed[..paren_pos].find(':').is_some();
+        if !has_colon_before_paren {
+            let optional = before_paren.trim_end().ends_with('?');
+            let name = before_paren.trim_end_matches('?').trim();
+            if !name.is_empty() && is_valid_identifier(name) {
+                let ts_type_str: String = (&trimmed[paren_pos..]).to_compact_string();
+                if !props.iter().any(|(n, _)| n == name) {
+                    props.push((
+                        name.to_compact_string(),
+                        PropTypeInfo {
+                            js_type: "Function".to_compact_string(),
+                            ts_type: Some(ts_type_str),
+                            optional,
+                            nullable: false,
+                        },
+                    ));
+                }
+            }
+            return;
+        }
+    }
+
     // Parse "name?: Type" or "name: Type"
     if let Some(colon_pos) = trimmed.find(':') {
         let name_part = &trimmed[..colon_pos];
         let type_part = &trimmed[colon_pos + 1..];
 
-        let optional = name_part.ends_with('?') || type_includes_top_level_undefined(type_part);
+        // Per Vue's type-only inference, a property is `required: false` only
+        // when the declaration carries the `?` optional modifier. `T |
+        // undefined` (no `?`) is still required. (#967)
+        let optional = name_part.ends_with('?');
         let nullable = type_includes_top_level_null(type_part);
         let name = name_part.trim().trim_end_matches('?').trim();
 
@@ -207,6 +239,7 @@ fn extract_prop_type_info(segment: &str, props: &mut Vec<(String, PropTypeInfo)>
     }
 }
 
+#[allow(dead_code)]
 fn type_includes_top_level_undefined(ts_type: &str) -> bool {
     split_type_at_top_level(ts_type.trim(), '|')
         .into_iter()

--- a/crates/vize_atelier_sfc/src/compile_script/props.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/props.rs
@@ -185,8 +185,7 @@ fn extract_prop_type_info(segment: &str, props: &mut Vec<(String, PropTypeInfo)>
     // treat the prop as a Function type. (#967)
     if let Some(paren_pos) = trimmed.find('(') {
         let before_paren = &trimmed[..paren_pos];
-        let has_colon_before_paren =
-            trimmed[..paren_pos].find(':').is_some();
+        let has_colon_before_paren = trimmed[..paren_pos].find(':').is_some();
         if !has_colon_before_paren {
             let optional = before_paren.trim_end().ends_with('?');
             let name = before_paren.trim_end_matches('?').trim();

--- a/crates/vize_atelier_sfc/src/compile_script/props.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/props.rs
@@ -179,14 +179,17 @@ fn extract_prop_type_info(segment: &str, props: &mut Vec<(String, PropTypeInfo)>
         return;
     }
 
-    // Method-signature props (`onChange(e: E): void`, `update?(): T`) — the
-    // first `:` lives inside the parameter list. Detect by an opening paren
-    // before any colon, recover the name from the part preceding `(`, and
-    // treat the prop as a Function type. (#967)
-    if let Some(paren_pos) = trimmed.find('(') {
-        let before_paren = &trimmed[..paren_pos];
-        let has_colon_before_paren = trimmed[..paren_pos].find(':').is_some();
-        if !has_colon_before_paren {
+    // Parse "name?: Type" or "name: Type"
+    if let Some(colon_pos) = trimmed.find(':') {
+        // Method-signature props (`onChange(e: E): void`, `update?(): T`)
+        // have a `(` somewhere in the parameter list *before* this colon.
+        // Detect by scanning the bytes up to `colon_pos` for `(`; on a hit,
+        // recover the name from before that `(` and treat the prop as
+        // `Function`-typed. Plain props (`name: Type`) skip this branch
+        // because there's no `(` before the colon. (#967)
+        let before_colon_bytes = &trimmed.as_bytes()[..colon_pos];
+        if let Some(paren_pos) = before_colon_bytes.iter().position(|&b| b == b'(') {
+            let before_paren = &trimmed[..paren_pos];
             let optional = before_paren.trim_end().ends_with('?');
             let name = before_paren.trim_end_matches('?').trim();
             if !name.is_empty() && is_valid_identifier(name) {
@@ -205,10 +208,6 @@ fn extract_prop_type_info(segment: &str, props: &mut Vec<(String, PropTypeInfo)>
             }
             return;
         }
-    }
-
-    // Parse "name?: Type" or "name: Type"
-    if let Some(colon_pos) = trimmed.find(':') {
         let name_part = &trimmed[..colon_pos];
         let type_part = &trimmed[colon_pos + 1..];
 

--- a/tests/snapshots/sfc/js/patches__complex_type_based_props_destructure_with_defaults.snap
+++ b/tests/snapshots/sfc/js/patches__complex_type_based_props_destructure_with_defaults.snap
@@ -1,12 +1,16 @@
 ---
 source: crates/vize_atelier_sfc/src/snapshot_tests.rs
+assertion_line: 221
 expression: js_output.as_str()
 ---
 import { toDisplayString as _toDisplayString, createElementVNode as _createElementVNode, normalizeClass as _normalizeClass, openBlock as _openBlock, createElementBlock as _createElementBlock, Fragment as _Fragment, renderList as _renderList } from "vue";
 export default {
   __name: "test",
   props: {
-    title: { type: String },
+    title: {
+      type: String,
+      required: true
+    },
     count: {
       type: Number,
       required: false,

--- a/tests/snapshots/sfc/js/patches__function_typed_prop_param_does_not_shadow_local_t.snap
+++ b/tests/snapshots/sfc/js/patches__function_typed_prop_param_does_not_shadow_local_t.snap
@@ -1,11 +1,15 @@
 ---
 source: crates/vize_atelier_sfc/src/snapshot_tests.rs
+assertion_line: 221
 expression: js_output.as_str()
 ---
 import { resolveComponent as _resolveComponent, toDisplayString as _toDisplayString, createElementVNode as _createElementVNode, createVNode as _createVNode, normalizeClass as _normalizeClass, openBlock as _openBlock, createBlock as _createBlock, unref as _unref, withCtx as _withCtx } from "vue";
 export default {
   __name: "test",
-  props: { renderLabel: { type: Function } },
+  props: { renderLabel: {
+    type: Function,
+    required: true
+  } },
   setup(__props) {
     const props = __props;
     const { format } = useFormatter(catalog);

--- a/tests/snapshots/sfc/js/patches__nullable_runtime_prop_types_keep_null.snap
+++ b/tests/snapshots/sfc/js/patches__nullable_runtime_prop_types_keep_null.snap
@@ -1,14 +1,24 @@
 ---
 source: crates/vize_atelier_sfc/src/snapshot_tests.rs
+assertion_line: 221
 expression: js_output.as_str()
 ---
 import { openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue";
 export default {
   __name: "test",
   props: {
-    activeKey: { type: [String, null] },
-    items: { type: [Array, null] },
-    groupName: { type: [String, null] }
+    activeKey: {
+      type: [String, null],
+      required: true
+    },
+    items: {
+      type: [Array, null],
+      required: true
+    },
+    groupName: {
+      type: [String, null],
+      required: true
+    }
   },
   setup(__props) {
     return (_ctx, _cache) => {

--- a/tests/snapshots/sfc/js/patches__type_keyword_in_conditional.snap
+++ b/tests/snapshots/sfc/js/patches__type_keyword_in_conditional.snap
@@ -1,11 +1,15 @@
 ---
 source: crates/vize_atelier_sfc/src/snapshot_tests.rs
+assertion_line: 221
 expression: js_output.as_str()
 ---
 import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock, createCommentVNode as _createCommentVNode } from "vue";
 export default {
   __name: "test",
-  props: { item: { type: Object } },
+  props: { item: {
+    type: Object,
+    required: true
+  } },
   setup(__props) {
     const props = __props;
     return (_ctx, _cache) => {

--- a/tests/snapshots/sfc/ts/patches__complex_type_based_props_destructure_with_defaults.snap
+++ b/tests/snapshots/sfc/ts/patches__complex_type_based_props_destructure_with_defaults.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/vize_atelier_sfc/src/snapshot_tests.rs
+assertion_line: 198
 expression: ts_output.as_str()
 ---
 import { defineComponent as _defineComponent } from 'vue'
@@ -9,7 +10,7 @@ import { toDisplayString as _toDisplayString, createElementVNode as _createEleme
 export default /*@__PURE__*/_defineComponent({
   __name: 'test',
   props: {
-    title: { type: String },
+    title: { type: String, required: true },
     count: { type: Number, required: false, default: 0 },
     disabled: { type: Boolean, required: false, default: false },
     items: { type: Array, required: false, default: () => [] }

--- a/tests/snapshots/sfc/ts/patches__function_typed_prop_param_does_not_shadow_local_t.snap
+++ b/tests/snapshots/sfc/ts/patches__function_typed_prop_param_does_not_shadow_local_t.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/vize_atelier_sfc/src/snapshot_tests.rs
+assertion_line: 198
 expression: ts_output.as_str()
 ---
 import { defineComponent as _defineComponent } from 'vue'
@@ -9,7 +10,7 @@ import { resolveComponent as _resolveComponent, toDisplayString as _toDisplayStr
 export default /*@__PURE__*/_defineComponent({
   __name: 'test',
   props: {
-    renderLabel: { type: Function }
+    renderLabel: { type: Function, required: true }
   },
   setup(__props: any) {
 

--- a/tests/snapshots/sfc/ts/patches__nullable_runtime_prop_types_keep_null.snap
+++ b/tests/snapshots/sfc/ts/patches__nullable_runtime_prop_types_keep_null.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/vize_atelier_sfc/src/snapshot_tests.rs
+assertion_line: 198
 expression: ts_output.as_str()
 ---
 import { defineComponent as _defineComponent } from 'vue'
@@ -9,9 +10,9 @@ import { openBlock as _openBlock, createElementBlock as _createElementBlock } fr
 export default /*@__PURE__*/_defineComponent({
   __name: 'test',
   props: {
-    activeKey: { type: [String, null] },
-    items: { type: [Array, null] },
-    groupName: { type: [String, null] }
+    activeKey: { type: [String, null], required: true },
+    items: { type: [Array, null], required: true },
+    groupName: { type: [String, null], required: true }
   },
   setup(__props: any) {
 

--- a/tests/snapshots/sfc/ts/patches__type_keyword_in_conditional.snap
+++ b/tests/snapshots/sfc/ts/patches__type_keyword_in_conditional.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/vize_atelier_sfc/src/snapshot_tests.rs
+assertion_line: 198
 expression: ts_output.as_str()
 ---
 import { defineComponent as _defineComponent } from 'vue'
@@ -15,7 +16,7 @@ interface Item {
 export default /*@__PURE__*/_defineComponent({
   __name: 'test',
   props: {
-    item: { type: Object }
+    item: { type: Object, required: true }
   },
   setup(__props: any) {
 

--- a/tests/snapshots/sfc/ts/script_setup__generic_component_basic.snap
+++ b/tests/snapshots/sfc/ts/script_setup__generic_component_basic.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/vize_atelier_sfc/src/snapshot_tests.rs
+assertion_line: 152
 expression: ts_output.as_str()
 ---
 import { defineComponent as _defineComponent } from 'vue'
@@ -9,8 +10,8 @@ import { toDisplayString as _toDisplayString, openBlock as _openBlock, createEle
 export default /*@__PURE__*/_defineComponent({
   __name: 'test',
   props: {
-    items: { type: Array },
-    selected: { type: null }
+    items: { type: Array, required: true },
+    selected: { type: null, required: true }
   },
   setup(__props: any) {
 

--- a/tests/snapshots/sfc/ts/script_setup__generic_component_with_complex_constraint.snap
+++ b/tests/snapshots/sfc/ts/script_setup__generic_component_with_complex_constraint.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/vize_atelier_sfc/src/snapshot_tests.rs
+assertion_line: 152
 expression: ts_output.as_str()
 ---
 import { defineComponent as _defineComponent } from 'vue'
@@ -11,8 +12,8 @@ import { ref } from 'vue'
 export default /*@__PURE__*/_defineComponent({
   __name: 'test',
   props: {
-    initialState: { type: null },
-    onSubmit: { type: Function }
+    initialState: { type: null, required: true },
+    onSubmit: { type: Function, required: true }
   },
   setup(__props: any) {
 

--- a/tests/snapshots/sfc/ts/script_setup__generic_component_with_default_type.snap
+++ b/tests/snapshots/sfc/ts/script_setup__generic_component_with_default_type.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/vize_atelier_sfc/src/snapshot_tests.rs
+assertion_line: 152
 expression: ts_output.as_str()
 ---
 import { defineComponent as _defineComponent } from 'vue'
@@ -9,7 +10,7 @@ import { toDisplayString as _toDisplayString, openBlock as _openBlock, createEle
 export default /*@__PURE__*/_defineComponent({
   __name: 'test',
   props: {
-    value: { type: null }
+    value: { type: null, required: true }
   },
   setup(__props: any) {
 

--- a/tests/snapshots/sfc/ts/script_setup__generic_component_with_extends.snap
+++ b/tests/snapshots/sfc/ts/script_setup__generic_component_with_extends.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/vize_atelier_sfc/src/snapshot_tests.rs
+assertion_line: 152
 expression: ts_output.as_str()
 ---
 import { defineComponent as _defineComponent } from 'vue'
@@ -9,8 +10,8 @@ import { toDisplayString as _toDisplayString, openBlock as _openBlock, createEle
 export default /*@__PURE__*/_defineComponent({
   __name: 'test',
   props: {
-    value: { type: null },
-    options: { type: Array }
+    value: { type: null, required: true },
+    options: { type: Array, required: true }
   },
   setup(__props: any) {
 

--- a/tests/snapshots/sfc/ts/script_setup__generic_component_with_multiple_type_params.snap
+++ b/tests/snapshots/sfc/ts/script_setup__generic_component_with_multiple_type_params.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/vize_atelier_sfc/src/snapshot_tests.rs
+assertion_line: 152
 expression: ts_output.as_str()
 ---
 import { defineComponent as _defineComponent } from 'vue'
@@ -9,8 +10,8 @@ import { toDisplayString as _toDisplayString, openBlock as _openBlock, createEle
 export default /*@__PURE__*/_defineComponent({
   __name: 'test',
   props: {
-    items: { type: Array },
-    keyField: { type: null }
+    items: { type: Array, required: true },
+    keyField: { type: null, required: true }
   },
   setup(__props: any) {
 

--- a/tests/snapshots/sfc/ts/script_setup__interface_with_async_callback.snap
+++ b/tests/snapshots/sfc/ts/script_setup__interface_with_async_callback.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/vize_atelier_sfc/src/snapshot_tests.rs
+assertion_line: 152
 expression: ts_output.as_str()
 ---
 import { defineComponent as _defineComponent } from 'vue'
@@ -15,7 +16,7 @@ interface Props {
 export default /*@__PURE__*/_defineComponent({
   __name: 'test',
   props: {
-    onSubmit: { type: Function },
+    onSubmit: { type: Function, required: true },
     onError: { type: Function, required: false }
   },
   setup(__props: any) {

--- a/tests/snapshots/sfc/ts/script_setup__interface_with_callback_function_type.snap
+++ b/tests/snapshots/sfc/ts/script_setup__interface_with_callback_function_type.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/vize_atelier_sfc/src/snapshot_tests.rs
+assertion_line: 152
 expression: ts_output.as_str()
 ---
 import { defineComponent as _defineComponent } from 'vue'
@@ -14,7 +15,7 @@ interface Props {
 export default /*@__PURE__*/_defineComponent({
   __name: 'test',
   props: {
-    refreshMethod: { type: Function }
+    refreshMethod: { type: Function, required: true }
   },
   setup(__props: any) {
 

--- a/tests/snapshots/sfc/ts/script_setup__props_with_arrow_function_types.snap
+++ b/tests/snapshots/sfc/ts/script_setup__props_with_arrow_function_types.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/vize_atelier_sfc/src/snapshot_tests.rs
+assertion_line: 152
 expression: ts_output.as_str()
 ---
 import { defineComponent as _defineComponent } from 'vue'
@@ -9,9 +10,9 @@ import { openBlock as _openBlock, createElementBlock as _createElementBlock } fr
 export default /*@__PURE__*/_defineComponent({
   __name: 'test',
   props: {
-    onSuccess: { type: Function },
-    onError: { type: Function },
-    transform: { type: Function }
+    onSuccess: { type: Function, required: true },
+    onError: { type: Function, required: true },
+    transform: { type: Function, required: true }
   },
   setup(__props: any) {
 

--- a/tests/snapshots/sfc/ts/script_setup__props_with_intersection_types.snap
+++ b/tests/snapshots/sfc/ts/script_setup__props_with_intersection_types.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/vize_atelier_sfc/src/snapshot_tests.rs
+assertion_line: 152
 expression: ts_output.as_str()
 ---
 import { defineComponent as _defineComponent } from 'vue'
@@ -18,9 +19,9 @@ interface ExtendedProps {
 export default /*@__PURE__*/_defineComponent({
   __name: 'test',
   props: {
-    id: { type: String },
-    name: { type: String },
-    extra: { type: Boolean }
+    id: { type: String, required: true },
+    name: { type: String, required: true },
+    extra: { type: Boolean, required: true }
   },
   setup(__props: any) {
 

--- a/tests/snapshots/sfc/ts/script_setup__props_with_method_signatures_in_object.snap
+++ b/tests/snapshots/sfc/ts/script_setup__props_with_method_signatures_in_object.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/vize_atelier_sfc/src/snapshot_tests.rs
+assertion_line: 152
 expression: ts_output.as_str()
 ---
 import { defineComponent as _defineComponent } from 'vue'
@@ -9,7 +10,7 @@ import { openBlock as _openBlock, createElementBlock as _createElementBlock, cre
 export default /*@__PURE__*/_defineComponent({
   __name: 'test',
   props: {
-    context: { type: Object }
+    context: { type: Object, required: true }
   },
   setup(__props: any) {
 

--- a/tests/snapshots/sfc/ts/script_setup__props_with_nested_object_types.snap
+++ b/tests/snapshots/sfc/ts/script_setup__props_with_nested_object_types.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/vize_atelier_sfc/src/snapshot_tests.rs
+assertion_line: 152
 expression: ts_output.as_str()
 ---
 import { defineComponent as _defineComponent } from 'vue'
@@ -9,7 +10,7 @@ import { toDisplayString as _toDisplayString, openBlock as _openBlock, createEle
 export default /*@__PURE__*/_defineComponent({
   __name: 'test',
   props: {
-    config: { type: Object }
+    config: { type: Object, required: true }
   },
   setup(__props: any) {
 

--- a/tests/snapshots/sfc/ts/script_setup__props_with_readonly_arrays.snap
+++ b/tests/snapshots/sfc/ts/script_setup__props_with_readonly_arrays.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/vize_atelier_sfc/src/snapshot_tests.rs
+assertion_line: 152
 expression: ts_output.as_str()
 ---
 import { defineComponent as _defineComponent } from 'vue'
@@ -9,7 +10,7 @@ import { toDisplayString as _toDisplayString, openBlock as _openBlock, createEle
 export default /*@__PURE__*/_defineComponent({
   __name: 'test',
   props: {
-    options: { type: Array }
+    options: { type: Array, required: true }
   },
   setup(__props: any) {
 

--- a/tests/snapshots/sfc/ts/script_setup__props_with_union_types.snap
+++ b/tests/snapshots/sfc/ts/script_setup__props_with_union_types.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/vize_atelier_sfc/src/snapshot_tests.rs
+assertion_line: 152
 expression: ts_output.as_str()
 ---
 import { defineComponent as _defineComponent } from 'vue'
@@ -14,7 +15,7 @@ type ButtonVariant =
 export default /*@__PURE__*/_defineComponent({
   __name: 'test',
   props: {
-    variant: { type: [null, Object] }
+    variant: { type: [null, Object], required: true }
   },
   setup(__props: any) {
 

--- a/tests/snapshots/sfc/ts/script_setup__reco_guidanceprogresslapinputbtn_pattern.snap
+++ b/tests/snapshots/sfc/ts/script_setup__reco_guidanceprogresslapinputbtn_pattern.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/vize_atelier_sfc/src/snapshot_tests.rs
+assertion_line: 152
 expression: ts_output.as_str()
 ---
 import { defineComponent as _defineComponent } from 'vue'
@@ -22,7 +23,7 @@ interface Props {
 export default /*@__PURE__*/_defineComponent({
   __name: 'test',
   props: {
-    guidanceProgress: { type: Object },
+    guidanceProgress: { type: Object, required: true },
     disabled: { type: Boolean, required: false },
     readonly: { type: Boolean, required: false }
   },

--- a/tests/snapshots/sfc/ts/script_setup__script_with_type_definitions_and_script_setup.snap
+++ b/tests/snapshots/sfc/ts/script_setup__script_with_type_definitions_and_script_setup.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/vize_atelier_sfc/src/snapshot_tests.rs
+assertion_line: 152
 expression: ts_output.as_str()
 ---
 import { defineComponent as _defineComponent } from 'vue'
@@ -18,7 +19,7 @@ export type { TabItem };
 export default /*@__PURE__*/_defineComponent({
   __name: 'test',
   props: {
-    items: { type: Array }
+    items: { type: Array, required: true }
   },
   setup(__props: any) {
 

--- a/tests/snapshots/sfc/ts/script_setup__withdefaults_with_optional_props.snap
+++ b/tests/snapshots/sfc/ts/script_setup__withdefaults_with_optional_props.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/vize_atelier_sfc/src/snapshot_tests.rs
+assertion_line: 152
 expression: ts_output.as_str()
 ---
 import { defineComponent as _defineComponent } from 'vue'
@@ -16,7 +17,7 @@ interface Props {
 export default /*@__PURE__*/_defineComponent({
   __name: 'test',
   props: {
-    msg: { type: String },
+    msg: { type: String, required: true },
     count: { type: Number, required: false, default: 0 },
     disabled: { type: Boolean, required: false, default: false }
   },


### PR DESCRIPTION
## Summary

Fixes #967.

Type-only \`defineProps\` had three related correctness gaps versus Vue:

1. **required props omitted \`required: true\`** entirely in dev mode, so dev-mode prop-validation warnings never fired for missing required props.
2. **\`T | undefined\` (no \`?\`) was inferred as optional.** Per Vue's type-only inference, only the \`?\` modifier makes a prop optional; a union with \`undefined\` is still required.
3. **method-signature props (\`onChange(e: E): void\`) were silently dropped** because the parameter list's first \`:\` derailed the name parse.

The fix is in three files:
- \`compile_script/props.rs\` — \`extract_prop_type_info\` detects a method signature (paren before any top-level colon), recovers the name from the part before \`(\`, and emits a \`Function\`-typed prop with its original signature as the TS source.
- Same function: \`optional\` is now strictly the \`?\` modifier; \`T | undefined\` flows through as required.
- \`compile_script/inline/compiler/props.rs\` — emits an explicit \`required: true\` (in addition to the existing \`required: false\`) in dev mode, matching Vue.

## Test plan
- [x] \`cargo test --workspace --lib\` — all 18 lib suites green; type-only props snapshots refreshed across the suite to add \`required: true\` to required props.
- [x] New \`test_define_props_type_only_required_and_undefined_union\` covers the exact \`a: string / b?: number / c: string | undefined / onChange(e): void\` mix from the issue.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/979"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783150400&installation_id=136613492&pr_number=979&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F979&signature=669046f75457378cafb4d23bc571c8dbe21077ce5c155cd6ddecbd6606a442d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->