### PR TITLE
fix(atelier_core): guard template expression nesting depth

### DIFF
--- a/crates/vize_atelier_core/src/transforms/transform_expression.rs
+++ b/crates/vize_atelier_core/src/transforms/transform_expression.rs
@@ -14,6 +14,82 @@ use oxc_parser::Parser;
 use oxc_span::SourceType;
 use vize_carton::{Box, Bump, String};
 
+/// Maximum bracket nesting depth allowed in a template expression.
+///
+/// Mirrors the parser's `MAX_ELEMENT_NESTING_DEPTH = 256`, but for the JS/TS
+/// expression text inside `{{ … }}` / directive values. The oxc parser
+/// recurses for each `(` / `[` / `{` it sees, so a sufficiently nested
+/// expression overflows the native stack and aborts the process — a stack
+/// overflow cannot be caught with `catch_unwind`. The same expression
+/// path is shared by `vize build`, `vize check`, the LSP, the linter,
+/// the formatter, and the Vite dev-server middleware. (#956)
+pub const MAX_EXPRESSION_NESTING_DEPTH: usize = 256;
+
+/// Returns the maximum bracket nesting depth in `content`. Only counts
+/// `(`, `[`, `{` and their closers — these are what drive recursion in the
+/// JS parser and the recursive AST walkers in `prefix` / `rewrite`. Strings
+/// and template literals are skipped so contents like `"((((((((..."` don't
+/// trigger a false positive.
+pub fn expression_nesting_depth(content: &str) -> usize {
+    let bytes = content.as_bytes();
+    let mut depth: usize = 0;
+    let mut max_depth: usize = 0;
+    let mut i = 0;
+    while i < bytes.len() {
+        let b = bytes[i];
+        match b {
+            b'"' | b'\'' | b'`' => {
+                let quote = b;
+                i += 1;
+                while i < bytes.len() {
+                    if bytes[i] == b'\\' {
+                        i = i.saturating_add(2);
+                        continue;
+                    }
+                    if bytes[i] == quote {
+                        i += 1;
+                        break;
+                    }
+                    i += 1;
+                }
+                continue;
+            }
+            b'/' if i + 1 < bytes.len() && bytes[i + 1] == b'/' => {
+                while i < bytes.len() && bytes[i] != b'\n' {
+                    i += 1;
+                }
+                continue;
+            }
+            b'/' if i + 1 < bytes.len() && bytes[i + 1] == b'*' => {
+                i += 2;
+                while i + 1 < bytes.len() && !(bytes[i] == b'*' && bytes[i + 1] == b'/') {
+                    i += 1;
+                }
+                i = i.saturating_add(2);
+                continue;
+            }
+            b'(' | b'[' | b'{' => {
+                depth += 1;
+                if depth > max_depth {
+                    max_depth = depth;
+                }
+            }
+            b')' | b']' | b'}' => {
+                depth = depth.saturating_sub(1);
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+    max_depth
+}
+
+/// Returns true if `content` exceeds [`MAX_EXPRESSION_NESTING_DEPTH`].
+#[inline]
+pub fn expression_exceeds_max_depth(content: &str) -> bool {
+    expression_nesting_depth(content) > MAX_EXPRESSION_NESTING_DEPTH
+}
+
 use crate::{
     ast::{ConstantType, ExpressionNode, SimpleExpressionNode},
     transform::TransformContext,
@@ -28,6 +104,9 @@ use rewrite::rewrite_expression;
 /// Returns true if an expression is a callable reference that should be passed
 /// through directly as an event handler, not wrapped as `$event => (...)`.
 pub fn is_event_handler_reference_expression(content: &str) -> bool {
+    if expression_exceeds_max_depth(content) {
+        return false;
+    }
     let allocator = oxc_allocator::Allocator::default();
     let parser = Parser::new(&allocator, content, SourceType::default().with_module(true));
     let Ok(expr) = parser.parse_expression() else {
@@ -49,6 +128,9 @@ pub fn is_event_handler_reference_expression(content: &str) -> bool {
 
 /// Returns true if the whole expression is a function / arrow function expression.
 pub fn is_function_expression(content: &str) -> bool {
+    if expression_exceeds_max_depth(content) {
+        return false;
+    }
     let allocator = oxc_allocator::Allocator::default();
     let parser = Parser::new(&allocator, content, SourceType::default().with_module(true));
     let Ok(expr) = parser.parse_expression() else {
@@ -204,7 +286,12 @@ pub(crate) fn normalize_expression<'a>(
 
 #[cfg(test)]
 mod tests {
-    use super::{clone_expression, process_expression};
+    use super::{
+        MAX_EXPRESSION_NESTING_DEPTH, clone_expression, expression_exceeds_max_depth,
+        expression_nesting_depth, is_event_handler_reference_expression, is_function_expression,
+        prefix::prefix_identifiers_in_expression, process_expression,
+        typescript::strip_typescript_from_expression,
+    };
     use crate::{
         ast::{CompoundExpressionNode, ExpressionNode, Position, RuntimeHelper, SourceLocation},
         options::{BindingMetadata, BindingType, TransformOptions},
@@ -298,6 +385,51 @@ mod tests {
             "$setup.isExternal && $setup.isExternal.value"
         );
         assert!(!ctx.has_helper(RuntimeHelper::Unref));
+    }
+
+    #[test]
+    fn test_expression_nesting_depth_counts_parens() {
+        assert_eq!(expression_nesting_depth("a + b"), 0);
+        assert_eq!(expression_nesting_depth("(a + b)"), 1);
+        assert_eq!(expression_nesting_depth("((a + b))"), 2);
+        assert_eq!(expression_nesting_depth("[[[1]]]"), 3);
+        assert_eq!(expression_nesting_depth("{a: 1}"), 1);
+    }
+
+    #[test]
+    fn test_expression_nesting_depth_ignores_brackets_in_strings_and_comments() {
+        assert_eq!(expression_nesting_depth(r#""((((""#), 0);
+        assert_eq!(expression_nesting_depth(r#"'((((((' + 1"#), 0);
+        assert_eq!(expression_nesting_depth("`((((`"), 0);
+        assert_eq!(expression_nesting_depth("a /* (((( */ b"), 0);
+        assert_eq!(expression_nesting_depth("a // ((((\n + b"), 0);
+    }
+
+    #[test]
+    fn test_expression_exceeds_max_depth_guards_deeply_nested() {
+        let deep = "(".repeat(MAX_EXPRESSION_NESTING_DEPTH + 1)
+            + "1"
+            + &")".repeat(MAX_EXPRESSION_NESTING_DEPTH + 1);
+        assert!(expression_exceeds_max_depth(&deep));
+        let shallow = "(".repeat(MAX_EXPRESSION_NESTING_DEPTH)
+            + "1"
+            + &")".repeat(MAX_EXPRESSION_NESTING_DEPTH);
+        assert!(!expression_exceeds_max_depth(&shallow));
+    }
+
+    #[test]
+    fn test_expression_entry_points_do_not_overflow_on_deep_input() {
+        // Regression for #956: every entry point that previously fed the
+        // recursive oxc parser must return a benign value for an input
+        // beyond MAX_EXPRESSION_NESTING_DEPTH rather than abort the
+        // process via stack overflow.
+        let deep = "(".repeat(100_000) + "1" + &")".repeat(100_000);
+        assert!(!is_event_handler_reference_expression(&deep));
+        assert!(!is_function_expression(&deep));
+        let prefixed = prefix_identifiers_in_expression(&deep);
+        assert_eq!(prefixed.as_str(), deep.as_str());
+        let stripped = strip_typescript_from_expression(&deep);
+        assert_eq!(stripped.as_str(), deep.as_str());
     }
 
     #[test]

--- a/crates/vize_atelier_core/src/transforms/transform_expression/prefix.rs
+++ b/crates/vize_atelier_core/src/transforms/transform_expression/prefix.rs
@@ -102,6 +102,12 @@ pub fn is_simple_identifier(s: &str) -> bool {
 ///
 /// This is a simpler version that doesn't require `TransformContext`.
 pub fn prefix_identifiers_in_expression(content: &str) -> String {
+    // Skip parsing for inputs that would overflow the parser stack — return
+    // the original content unchanged so the compile pipeline emits a normal
+    // diagnostic for the surrounding directive instead of aborting. (#956)
+    if super::expression_exceeds_max_depth(content) {
+        return String::new(content);
+    }
     let allocator = OxcAllocator::default();
     let source_type = SourceType::default().with_module(true);
 

--- a/crates/vize_atelier_core/src/transforms/transform_expression/rewrite.rs
+++ b/crates/vize_atelier_core/src/transforms/transform_expression/rewrite.rs
@@ -99,6 +99,15 @@ pub(crate) fn rewrite_expression(
     ctx: &TransformContext<'_>,
     _as_params: bool,
 ) -> RewriteResult {
+    // Skip parsing for inputs that would overflow the parser stack — return
+    // the original content unchanged so the compile pipeline emits a normal
+    // diagnostic for the surrounding directive instead of aborting. (#956)
+    if super::expression_exceeds_max_depth(content) {
+        return RewriteResult {
+            code: String::new(content),
+            used_unref: false,
+        };
+    }
     // First, if this is TypeScript, strip type annotations
     let js_content = if ctx.options.is_ts {
         strip_typescript_from_expression(content)

--- a/crates/vize_atelier_core/src/transforms/transform_expression/typescript.rs
+++ b/crates/vize_atelier_core/src/transforms/transform_expression/typescript.rs
@@ -209,6 +209,12 @@ fn is_ident_char(ch: char) -> bool {
 
 /// Strip TypeScript type annotations from an expression
 pub fn strip_typescript_from_expression(content: &str) -> String {
+    // Skip parsing for inputs that would overflow the parser stack — return
+    // the original content unchanged so the surrounding pipeline emits a
+    // normal diagnostic instead of aborting. (#956)
+    if super::expression_exceeds_max_depth(content) {
+        return String::new(content);
+    }
     // Only process if TypeScript syntax is detected
     if !needs_typescript_stripping(content) {
         return String::new(content);


### PR DESCRIPTION
## Summary

Fixes #956.

Deeply-nested template expressions overflowed the native stack and aborted the process. The element parser already enforces \`MAX_ELEMENT_NESTING_DEPTH = 256\` in \`vize_armature\`, but every expression entry point fed \`oxc_parser::Parser::parse_expression()\` unchecked, so the failure was shared across \`vize build\`, \`vize check\`, \`vize fmt\`, \`vize lint\`, the LSP, and the Vite dev-server middleware. A stack overflow cannot be caught with \`catch_unwind\`, so this was a DoS for every long-running surface.

Fix:
- New \`MAX_EXPRESSION_NESTING_DEPTH = 256\` (mirrors the element bound) and \`expression_nesting_depth\` byte-level scanner that counts \`(\`/\`[\`/\`{\` while skipping string literals, template literals, and \`//\`/\`/* */\` comments — those don't drive parser recursion.
- Every entry point that fed \`parse_expression\` short-circuits on \`expression_exceeds_max_depth\`:
  - \`is_event_handler_reference_expression\` / \`is_function_expression\` → \`false\`
  - \`prefix_identifiers_in_expression\` / \`rewrite_expression\` → original content
  - \`strip_typescript_from_expression\` → original content

## Test plan
- [x] \`cargo test --workspace --lib\` — green; new unit tests cover the depth counter, the string/comment skipping, and a 100k-deep input through each entry point.
- [x] Smoke-tested locally: \`vize build deep.vue\` with a 4000-depth interpolation previously aborted with "fatal runtime error: stack overflow" (exit 134); now exits 0 with the expression preserved.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/980"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783150845&installation_id=136613492&pr_number=980&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F980&signature=eb17216aef0080d4fdc0a3d56a8f2807a30e184117e83a5c3bd539b2072f0aa0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->