### PR TITLE
fix(patina): suppression applies to whole line; identifier-aware v-if-with-v-for

### DIFF
--- a/crates/vize_patina/src/context.rs
+++ b/crates/vize_patina/src/context.rs
@@ -316,14 +316,17 @@ impl<'a> LintContext<'a> {
             return;
         }
 
-        // Check if this line has an @vize:expected directive
-        if self.expected_error_lines.remove(&line) {
-            // Error was expected -- suppress it
+        // Check if this line has an @vize:expected directive. Use
+        // `contains`, not `remove`, so a line that legitimately emits
+        // multiple diagnostics has them all suppressed (#968).
+        if self.expected_error_lines.contains(&line) {
             return;
         }
 
-        // Apply @vize:level severity override
-        if let Some(override_severity) = self.severity_overrides.remove(&line) {
+        // Apply @vize:level severity override. Same reasoning: the directive
+        // applies to every diagnostic on the targeted line, not just the
+        // first one we happen to report. (#968)
+        if let Some(override_severity) = self.severity_overrides.get(&line).copied() {
             match override_severity {
                 DirectiveSeverity::Off => return,
                 DirectiveSeverity::Warn => diagnostic.severity = Severity::Warning,

--- a/crates/vize_patina/src/linter/tests/directives.rs
+++ b/crates/vize_patina/src/linter/tests/directives.rs
@@ -63,6 +63,51 @@ fn test_vize_expected_suppresses_error() {
 }
 
 #[test]
+fn test_vize_expected_suppresses_every_diagnostic_on_the_line() {
+    // Regression for #968: `@vize:expected` was implemented with `remove`
+    // and so consumed itself after the first matching diagnostic — any
+    // additional diagnostic on the same line then leaked through. The
+    // directive must scope to the whole line.
+    let linter = Linter::new();
+    let result = linter.lint_template(
+        r#"<!-- @vize:expected -->
+<li v-for="item in items" v-if="item.active">{{ item }}</li>"#,
+        "test.vue",
+    );
+    assert_eq!(
+        result.error_count, 0,
+        "v-for missing-key error should be suppressed"
+    );
+    assert_eq!(
+        result.warning_count, 0,
+        "v-if-with-v-for warning on the same line must also be suppressed"
+    );
+}
+
+#[test]
+fn test_vize_expected_suppresses_run_on_template_diagnostic() {
+    // Regression for #968: `run_on_template` rules emit during a phase
+    // that runs *before* per-element traversal would register directives,
+    // so suppression directives must be pre-scanned. `vue/no-dupe-v-else-if`
+    // reports in that phase.
+    let linter = Linter::new();
+    let result = linter.lint_template(
+        r#"<!-- @vize:expected -->
+<div v-if="a"></div><div v-else-if="a"></div>"#,
+        "test.vue",
+    );
+    assert_eq!(
+        result
+            .diagnostics
+            .iter()
+            .filter(|d| d.rule_name == "vue/no-dupe-v-else-if")
+            .count(),
+        0,
+        "run_on_template-phase rule must be suppressed by @vize:expected"
+    );
+}
+
+#[test]
 fn test_vize_ignore_start_end_region() {
     let linter = Linter::new();
     let result = linter.lint_template(

--- a/crates/vize_patina/src/rules/vue/no_use_v_if_with_v_for.rs
+++ b/crates/vize_patina/src/rules/vue/no_use_v_if_with_v_for.rs
@@ -80,7 +80,10 @@ impl Rule for NoUseVIfWithVFor {
                 })
                 .unwrap_or_default();
 
-            // Check if v-if uses any v-for variables
+            // Check if v-if uses any v-for variables. Match resolved
+            // identifiers, not raw substrings, so `v-for="item in items"`
+            // plus `v-if="itemCount > 0"` does not misclassify `itemCount`
+            // as a reference to `item`. (#968)
             let v_if_uses_v_for_var = if let Some(exp) = v_if_exp {
                 let v_if_content = match exp {
                     ExpressionNode::Simple(s) => s.content.as_str(),
@@ -88,7 +91,7 @@ impl Rule for NoUseVIfWithVFor {
                 };
                 v_for_vars
                     .iter()
-                    .any(|var| v_if_content.contains(var.as_str()))
+                    .any(|var| expression_references_identifier(v_if_content, var.as_str()))
             } else {
                 false
             };
@@ -184,4 +187,65 @@ mod tests {
         );
         assert_eq!(result.warning_count, 1);
     }
+
+    #[test]
+    fn test_v_if_with_v_for_substring_identifier_is_not_a_reference() {
+        // Regression for #968: `itemCount` must NOT be treated as a
+        // reference to `item` — the previous substring match flagged this
+        // as an access-pattern false positive.
+        let linter = create_linter();
+        let result = linter.lint_template(
+            r#"<div v-for="item in items" v-if="itemCount > 0">{{ item }}</div>"#,
+            "test.vue",
+        );
+        assert_eq!(result.warning_count, 1);
+        assert!(
+            result.diagnostics[0].message.as_str().contains("access")
+                || result.diagnostics[0]
+                    .message
+                    .as_str()
+                    .contains("v-if condition"),
+            "expected access-style message (not access-pattern), got: {}",
+            result.diagnostics[0].message
+        );
+    }
+
+    #[test]
+    fn test_v_if_with_v_for_real_identifier_reference_is_flagged() {
+        let linter = create_linter();
+        let result = linter.lint_template(
+            r#"<div v-for="item in items" v-if="item.active">{{ item }}</div>"#,
+            "test.vue",
+        );
+        assert_eq!(result.warning_count, 1);
+    }
+}
+
+/// Returns true if `expression` references `name` as a distinct identifier
+/// (rather than appearing only as a substring of another identifier).
+/// Walks the expression text byte-by-byte and respects identifier boundaries.
+fn expression_references_identifier(expression: &str, name: &str) -> bool {
+    if name.is_empty() || expression.is_empty() {
+        return false;
+    }
+    let bytes = expression.as_bytes();
+    let needle = name.as_bytes();
+    let mut i = 0;
+    while i + needle.len() <= bytes.len() {
+        if bytes[i..i + needle.len()] == *needle {
+            let prev_is_ident = i > 0 && is_ident_byte(bytes[i - 1]);
+            let next = bytes.get(i + needle.len()).copied();
+            let next_is_ident = matches!(next, Some(b) if is_ident_byte(b));
+            if !prev_is_ident && !next_is_ident {
+                return true;
+            }
+        }
+        i += 1;
+    }
+    false
+}
+
+#[inline]
+fn is_ident_byte(b: u8) -> bool {
+    b.is_ascii_alphanumeric() || b == b'_' || b == b'$'
 }

--- a/crates/vize_patina/src/visitor.rs
+++ b/crates/vize_patina/src/visitor.rs
@@ -41,6 +41,14 @@ impl<'a, 'ctx, 'rules> LintVisitor<'a, 'ctx, 'rules> {
     /// Visit the root node and traverse the AST
     #[inline]
     pub fn visit_root(&mut self, root: &RootNode<'a>) {
+        // Pre-scan for `@vize:expected` / `@vize:level` directives so they
+        // can suppress diagnostics produced by `run_on_template` rules
+        // (which fire before per-element traversal would register them).
+        // Without this pass, directives are registered too late and
+        // template-phase rules — `vue/no-dupe-v-else-if`,
+        // `vue/no-mutating-props`, etc. — can't be suppressed. (#968)
+        self.prescan_suppression_directives(root);
+
         // Run template-level checks under one profiling span. Rule dispatch
         // happens for every file, so profiling once around the callback batch is
         // cheaper than creating a span for every individual rule callback.
@@ -54,6 +62,55 @@ impl<'a, 'ctx, 'rules> LintVisitor<'a, 'ctx, 'rules> {
         // Visit children
         for child in root.children.iter() {
             self.visit_child(child);
+        }
+    }
+
+    /// Walk the AST and register every `@vize:expected` / `@vize:level`
+    /// directive into the context up-front. Other directive kinds (Todo,
+    /// Fixme, IgnoreStart/End, Forget, Deprecated) are intentionally NOT
+    /// processed here — they may emit diagnostics and rely on the existing
+    /// ordering and ignore-region bookkeeping that runs during the main
+    /// traversal. (#968)
+    fn prescan_suppression_directives(&mut self, root: &RootNode<'a>) {
+        for child in root.children.iter() {
+            self.prescan_suppression_in_child(child);
+        }
+    }
+
+    fn prescan_suppression_in_child(&mut self, node: &TemplateChildNode<'a>) {
+        match node {
+            TemplateChildNode::Comment(comment) => {
+                if let Some(kind) = comment.directive {
+                    let line = comment.loc.start.line;
+                    match kind {
+                        DirectiveKind::Expected => {
+                            self.ctx.expect_error_next_line(line);
+                        }
+                        DirectiveKind::Level => {
+                            if let Some(d) = parse_vize_directive(
+                                &comment.content,
+                                line,
+                                comment.loc.start.offset,
+                            ) && let Some(severity) = parse_level_severity(&d.payload)
+                            {
+                                self.ctx.set_severity_override_next_line(line, severity);
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+            }
+            TemplateChildNode::Element(el) => {
+                for child in el.children.iter() {
+                    self.prescan_suppression_in_child(child);
+                }
+            }
+            TemplateChildNode::For(for_node) => {
+                for child in for_node.children.iter() {
+                    self.prescan_suppression_in_child(child);
+                }
+            }
+            _ => {}
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes #968. Three correctness gaps in the Patina linter, bundled because they all touch directive/diagnostic plumbing.

### 1. Suppression directives applied only to the first diagnostic
\`@vize:expected\` / \`@vize:level\` used \`HashSet::remove\` / \`HashMap::remove\`, so a line emitting multiple diagnostics had only the first suppressed; the rest leaked through. Switched to \`contains\` / \`get\` so the directive scopes the whole line.

### 2. \`run_on_template\` rules couldn't be suppressed
Rules that report in the template-phase (e.g. \`vue/no-dupe-v-else-if\`, \`vue/no-mutating-props\`) fire BEFORE the per-element traversal would register the directive. Added a pre-scan over the AST that walks comment nodes and registers \`@vize:expected\` / \`@vize:level\` up-front. Other directive kinds keep their original ordering — they emit diagnostics and depend on the ignore-region bookkeeping that the main traversal does.

### 3. \`vue/no-use-v-if-with-v-for\` substring false-positive
The rule used \`str::contains\` to decide whether \`v-if\` referenced the \`v-for\` variable, so \`v-for="item in items"\` + \`v-if="itemCount > 0"\` was misclassified as referencing \`item\`. Replaced with an identifier-boundary scanner.

## Test plan
- [x] \`cargo test --workspace --lib\` — green; added three regression tests covering each gap.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/982"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783153796&installation_id=136613492&pr_number=982&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F982&signature=7882c1c162a6d929432648901aad2a474961b728363ffa1b7dcca71202b2ad7f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->