### PR TITLE
fix(ssr): render textarea v-model value as text content

### DIFF
--- a/crates/vize_atelier_ssr/src/codegen/element/plain.rs
+++ b/crates/vize_atelier_ssr/src/codegen/element/plain.rs
@@ -44,6 +44,16 @@ impl<'a> SsrCodegenContext<'a> {
             self.use_ssr_helper(RuntimeHelper::SsrInterpolate);
             let exp = self.expression_to_string(exp);
             self.push_string_part_dynamic(&cstr!("_ssrInterpolate({exp})"));
+        } else if tag.as_str() == "textarea"
+            && let Some(exp) = crate::get_v_model_exp(el)
+        {
+            // SSR `<textarea v-model>` renders the bound value as escaped
+            // text content (matching `@vue/server-renderer`). The earlier
+            // path emitted `<textarea></textarea>` with no content, so the
+            // initial value was lost and hydration mismatched. (#962)
+            self.use_ssr_helper(RuntimeHelper::SsrInterpolate);
+            let exp = self.expression_to_string(exp);
+            self.push_string_part_dynamic(&cstr!("_ssrInterpolate({exp})"));
         } else {
             self.process_children(&el.children, false, false, false);
         }
@@ -228,6 +238,12 @@ impl<'a> SsrCodegenContext<'a> {
         };
 
         if el.tag == "input" {
+            // Dynamic `:type` — fall back to `value` for now, but flag the
+            // direct-process path (called when inherit_attrs=false) so
+            // checkbox/radio at runtime render `checked`. The merged-attrs
+            // path here still emits `value=...` rather than Vue's `_temp0`
+            // trick because the surrounding merge expression isn't shaped
+            // for the dynamic helper yet. (#962)
             let input_type = self.get_element_attr_value(el, "type");
             match input_type.as_deref() {
                 Some("checkbox") => {
@@ -369,6 +385,19 @@ impl<'a> SsrCodegenContext<'a> {
 
         match tag {
             "input" => {
+                // For a dynamic `:type="t"`, the input could be a text input,
+                // checkbox, radio, etc. at runtime — use the dynamic-model
+                // helper so checkbox/radio cases render `checked` correctly.
+                // Without this the SSR path hard-coded the text-input shape
+                // and the `:type` itself was ignored. (#962)
+                if let Some(type_exp) = self.get_dynamic_bind_exp(el, "type") {
+                    self.use_ssr_helper(RuntimeHelper::SsrRenderDynamicModel);
+                    self.push_string_part_dynamic(&cstr!(
+                        "_ssrRenderDynamicModel({type_exp}, {exp}, null)"
+                    ));
+                    return;
+                }
+
                 // Check input type from attributes
                 let input_type = self.get_element_attr_value(el, "type");
                 match input_type.as_deref() {
@@ -450,6 +479,29 @@ impl<'a> SsrCodegenContext<'a> {
                 && attr.name == name
             {
                 return attr.value.as_ref().map(|v| v.content.to_compact_string());
+            }
+        }
+        None
+    }
+
+    /// Return the source expression bound by `:name` (or `v-bind:name`) on
+    /// `el`, if any. Used by SSR v-model lowering to find `:type` on
+    /// `<input :type="t" v-model>` so the dynamic-model helper kicks in.
+    /// (#962)
+    fn get_dynamic_bind_exp(&mut self, el: &ElementNode, name: &str) -> Option<String> {
+        for prop in &el.props {
+            let PropNode::Directive(dir) = prop else {
+                continue;
+            };
+            if dir.name != "bind" {
+                continue;
+            }
+            let matches_name = matches!(
+                &dir.arg,
+                Some(ExpressionNode::Simple(arg)) if arg.is_static && arg.content == name
+            );
+            if matches_name && let Some(exp) = &dir.exp {
+                return Some(self.expression_to_string(exp));
             }
         }
         None

--- a/crates/vize_atelier_ssr/src/lib.rs
+++ b/crates/vize_atelier_ssr/src/lib.rs
@@ -236,6 +236,22 @@ mod tests {
     }
 
     #[test]
+    fn test_ssr_v_model_textarea_renders_bound_value() {
+        // Regression for #962: `<textarea v-model="x">` must render `x` as
+        // escaped text content. The previous SSR path emitted
+        // `<textarea></textarea>` with no body, losing the initial value
+        // and triggering hydration mismatches.
+        let allocator = Bump::new();
+        let (_, errors, result) = compile_ssr(&allocator, r#"<textarea v-model="x"></textarea>"#);
+        assert!(errors.is_empty(), "{errors:?}");
+        assert!(
+            result.code.contains("_ssrInterpolate(_ctx.x)"),
+            "expected textarea body to interpolate the model value, got:\n{}",
+            result.code
+        );
+    }
+
+    #[test]
     fn test_dynamic_slot_outlet_name_stays_expression() {
         let allocator = Bump::new();
         let (_, errors, result) = compile_ssr_with_options(

--- a/crates/vize_atelier_ssr/tests/snapshots/ssr_snapshot__v_model__v_model_textarea.snap
+++ b/crates/vize_atelier_ssr/tests/snapshots/ssr_snapshot__v_model__v_model_textarea.snap
@@ -1,7 +1,8 @@
 ---
 source: crates/vize_atelier_ssr/tests/ssr_snapshot.rs
+assertion_line: 264
 expression: "get_compiled_string(r#\"<textarea v-model=\"msg\"></textarea>\"#)"
 ---
 function ssrRender(_ctx, _push, _parent, _attrs) {
-  _push(`<div${_ssrRenderAttrs(_attrs)}><textarea></textarea></div>`)
+  _push(`<div${_ssrRenderAttrs(_attrs)}><textarea>${_ssrInterpolate(_ctx.msg)}</textarea></div>`)
 }


### PR DESCRIPTION
## Summary

Partial fix for #962 — addresses the most impactful case (textarea data loss).

SSR codegen for \`<textarea v-model="x">\` emitted \`<textarea></textarea>\` with no content, so the initial value was lost and hydration mismatched. The fix detects v-model on textarea before the children traversal and emits \`\${_ssrInterpolate(x)}\` as the body, matching \`@vue/server-renderer\`.

\`<input :type v-model>\` also routes through the dynamic-model helper on the \`process_v_model_on_element\` path (inherit_attrs=false). The merged-attrs path still emits the previous \`value=...\` shape because matching Vue's \`_temp0\` aggregation requires restructuring the surrounding merge expression — left as a follow-up note in code.

\`<select v-model>\` selected-option logic is a follow-up: it requires threading the model expression through child option emission, which the SSR codegen state doesn't currently carry.

## Test plan
- [x] \`cargo test --workspace --lib\` — green, including the new \`test_ssr_v_model_textarea_renders_bound_value\` regression covering the issue's exact \`<textarea v-model>\` case.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/983"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783155155&installation_id=136613492&pr_number=983&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F983&signature=ea778b6e8ad52a9fec9c23dfd9a0e6043d8c4b80189cecb62ae242ce9fd48653"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->