### PR TITLE
fix(armature): treat duplicate attribute as recoverable; codegen dedupes

### DIFF
--- a/crates/vize_armature/src/parser/attribute.rs
+++ b/crates/vize_armature/src/parser/attribute.rs
@@ -182,6 +182,13 @@ impl<'a> Parser<'a> {
         let name_loc = self.create_loc(attr.name_start, attr.name_end);
 
         if self.has_duplicate_attribute(attr.name.as_str()) {
+            // Vue recovers from duplicate attributes — codegen ignores
+            // repeats and keeps the first occurrence — but linters still
+            // want to see both in the AST so they can warn about the
+            // repeat. So we KEEP both in `props` and emit a
+            // *recoverable* diagnostic; downstream pipelines treat it
+            // as non-fatal so a `<div id=a id=b>` no longer yields a
+            // 0-byte module marked as success. (#958)
             let mut message = String::with_capacity(attr.name.len() + 79);
             appends!(
                 message,

--- a/crates/vize_armature/src/parser/tests.rs
+++ b/crates/vize_armature/src/parser/tests.rs
@@ -623,6 +623,10 @@ fn test_parse_error_missing_end_tag() {
 
 #[test]
 fn test_parse_error_duplicate_attribute() {
+    // A duplicate attribute is recorded as a recoverable diagnostic
+    // (#958). Both occurrences remain in the AST so linters can warn
+    // about the repeat; downstream codegen treats the diagnostic as
+    // non-fatal and emits valid render code for the first occurrence.
     let allocator = Bump::new();
     let (root, errors) = parse(&allocator, r#"<div id="a" id="b"></div>"#);
     assert!(

--- a/crates/vize_atelier_core/src/codegen.rs
+++ b/crates/vize_atelier_core/src/codegen.rs
@@ -449,6 +449,45 @@ mod tests {
     }
 
     #[test]
+    fn test_codegen_duplicate_attribute_keeps_first_occurrence() {
+        // Regression for #958: a `<div id="a" id="b">x</div>` template
+        // used to produce a 0-byte module marked as success because the
+        // parser pushed a fatal-looking diagnostic and the SFC pipeline
+        // discarded the template output. Codegen now dedupes by
+        // attribute name (Vue parity: first wins); the parser
+        // diagnostic is classified as recoverable so downstream
+        // continues. The compile macro bails on parse errors, so this
+        // test drives the pipeline by hand.
+        let allocator = bumpalo::Bump::new();
+        let (mut root, errors) = crate::parser::parse(&allocator, r#"<div id="a" id="b">x</div>"#);
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.code == vize_relief::errors::ErrorCode::DuplicateAttribute),
+            "expected a DuplicateAttribute diagnostic, got {errors:?}"
+        );
+        assert!(errors.iter().all(|e| e.is_recoverable()));
+        crate::transform::transform(
+            &allocator,
+            &mut root,
+            crate::options::TransformOptions::default(),
+            None,
+        );
+        let result = crate::codegen::generate(&root, crate::options::CodegenOptions::default());
+        assert!(!result.code.is_empty(), "compiled output must not be empty");
+        assert!(
+            result.code.contains(r#"id: "a""#),
+            "expected first `id` to be retained, got:\n{}",
+            result.code
+        );
+        assert!(
+            !result.code.contains(r#"id: "b""#),
+            "expected duplicate `id` to be dropped, got:\n{}",
+            result.code
+        );
+    }
+
+    #[test]
     fn test_codegen_v_if_nested_branch_keys_reset_per_scope() {
         // Regression for #961 (Vue-parity): a nested v-if (inside another
         // v-if's branch) starts its key counter at 0 again, matching Vue's

--- a/crates/vize_atelier_core/src/codegen/generate.rs
+++ b/crates/vize_atelier_core/src/codegen/generate.rs
@@ -224,10 +224,28 @@ fn generate_props_expression_to_bytes(
     match props {
         PropsExpression::Object(obj) => {
             out.push_str("{ ");
-            for (i, prop) in obj.properties.iter().enumerate() {
-                if i > 0 {
+            // Vue keeps the first occurrence on duplicate attributes; vize's
+            // parser records both nodes so the linter can flag the repeat,
+            // so dedupe by key name here before emitting the props object.
+            // (#958)
+            let mut seen: vize_carton::FxHashSet<vize_carton::String> =
+                vize_carton::FxHashSet::default();
+            let mut emitted = 0usize;
+            for prop in obj.properties.iter() {
+                let key_string = match &prop.key {
+                    ExpressionNode::Simple(exp) if exp.is_static => Some(exp.content.clone()),
+                    _ => None,
+                };
+                if let Some(key) = &key_string {
+                    if seen.contains(key.as_str()) {
+                        continue;
+                    }
+                    seen.insert(key.clone());
+                }
+                if emitted > 0 {
                     out.push_str(", ");
                 }
+                emitted += 1;
                 // Key - quote if contains special characters like hyphens
                 match &prop.key {
                     ExpressionNode::Simple(exp) => {

--- a/crates/vize_atelier_core/src/codegen/props/generate.rs
+++ b/crates/vize_atelier_core/src/codegen/props/generate.rs
@@ -218,7 +218,24 @@ fn try_generate_static_attrs(
         return false;
     }
 
-    let multiline = props.len() + usize::from(scope_id.is_some()) > 1;
+    // Vue's behavior on duplicate attributes is to keep the first
+    // occurrence and ignore later repeats — the parser already records
+    // a recoverable diagnostic for the duplicate but leaves both nodes
+    // in the AST so linters can flag them. Dedupe here so the rendered
+    // props object doesn't emit `{ id: "a", id: "b" }`. (#958)
+    let mut seen: FxHashSet<String> = FxHashSet::default();
+    let mut unique_props: Vec<&PropNode<'_>> = Vec::with_capacity(props.len());
+    for prop in props {
+        if let PropNode::Attribute(attr) = prop {
+            if seen.contains(attr.name.as_str()) {
+                continue;
+            }
+            seen.insert(attr.name.clone());
+        }
+        unique_props.push(prop);
+    }
+
+    let multiline = unique_props.len() + usize::from(scope_id.is_some()) > 1;
     if multiline {
         ctx.push("{");
         ctx.indent();
@@ -227,7 +244,7 @@ fn try_generate_static_attrs(
     }
 
     let mut first = true;
-    for prop in props {
+    for prop in unique_props {
         let PropNode::Attribute(attr) = prop else {
             // Panic path by invariant: the preflight `all(Attribute)` check above
             // has already rejected directive props. Reaching this arm would mean

--- a/crates/vize_atelier_core/src/transforms/hoist_static.rs
+++ b/crates/vize_atelier_core/src/transforms/hoist_static.rs
@@ -260,11 +260,19 @@ fn create_props_expression<'a>(
     props: &[PropNode<'a>],
     scope_id: Option<&vize_carton::String>,
 ) -> Option<PropsExpression<'a>> {
-    // Build object properties from attributes
+    // Build object properties from attributes. Vue keeps the first
+    // occurrence on duplicate attributes (parser records both but
+    // codegen dedupes), so skip names we've already emitted. (#958)
     let mut obj_props = Vec::new_in(allocator);
+    let mut seen: vize_carton::FxHashSet<vize_carton::String> = vize_carton::FxHashSet::default();
 
     for prop in props {
         if let PropNode::Attribute(attr) = prop {
+            if seen.contains(attr.name.as_str()) {
+                continue;
+            }
+            seen.insert(attr.name.clone());
+
             let key = ExpressionNode::Simple(Box::new_in(
                 SimpleExpressionNode::new(attr.name.clone(), true, attr.loc.clone()),
                 allocator,
@@ -441,11 +449,20 @@ fn hoist_element_props<'a>(
     el: &mut ElementNode<'a>,
     allocator: &'a Bump,
 ) {
-    // Build props object from element attributes
+    // Build props object from element attributes. Vue keeps the first
+    // occurrence on duplicate attributes (parser records both for
+    // linters); dedupe here so a hoisted `_hoisted_N` literal doesn't
+    // emit `{ id: "a", id: "b" }`. (#958)
     let mut obj_props = Vec::new_in(allocator);
+    let mut seen: vize_carton::FxHashSet<vize_carton::String> = vize_carton::FxHashSet::default();
 
     for prop in el.props.iter() {
         if let PropNode::Attribute(attr) = prop {
+            if seen.contains(attr.name.as_str()) {
+                continue;
+            }
+            seen.insert(attr.name.clone());
+
             let key = ExpressionNode::Simple(Box::new_in(
                 SimpleExpressionNode::new(attr.name.clone(), true, attr.loc.clone()),
                 allocator,

--- a/crates/vize_atelier_core/src/transforms/transform_element.rs
+++ b/crates/vize_atelier_core/src/transforms/transform_element.rs
@@ -107,10 +107,18 @@ pub fn build_props<'a>(
     let mut properties: Vec<PropItem<'a>> = Vec::new();
     let mut dynamic_prop_names: Vec<String> = Vec::new();
     let mut has_runtime_props = false;
+    // Dedupe by attribute name — Vue keeps the first occurrence on a
+    // duplicate attribute. The parser records both nodes so linters can
+    // warn about the repeat; codegen takes the first only. (#958)
+    let mut seen_attr_names: vize_carton::FxHashSet<String> = vize_carton::FxHashSet::default();
 
     for prop in el.props.iter() {
         match prop {
             PropNode::Attribute(attr) => {
+                if seen_attr_names.contains(attr.name.as_str()) {
+                    continue;
+                }
+                seen_attr_names.insert(attr.name.clone());
                 // Static attribute
                 let key = attr.name.clone();
                 let value = attr.value.as_ref().map(|v| v.content.clone());

--- a/crates/vize_atelier_dom/src/lib.rs
+++ b/crates/vize_atelier_dom/src/lib.rs
@@ -116,7 +116,14 @@ fn compile_template_inner<'a>(
         parse_with_options(allocator, source, parser_opts)
     );
 
-    if !errors.is_empty() {
+    // Parser-level diagnostics that are recoverable (e.g. duplicate
+    // attribute — Vue keeps the first and continues) must NOT gate
+    // codegen, or downstream callers see a 0-byte module reported as a
+    // success. (#958) The recoverable diagnostics still ride along in
+    // the returned errors vec so the caller can surface them as
+    // warnings or test for parity.
+    let fatal_count = errors.iter().filter(|e| !e.is_recoverable()).count();
+    if fatal_count > 0 {
         let codegen_result = CodegenResult {
             code: String::default(),
             preamble: String::default(),

--- a/crates/vize_atelier_sfc/src/compile.rs
+++ b/crates/vize_atelier_sfc/src/compile.rs
@@ -256,7 +256,11 @@ fn compile_sfc_inner(
                     code.push_str("export default _sfc_main\n");
                 }
             }
-            Err(e) => errors.push(e),
+            // Previously this just collected the error into a local vec
+            // and continued, returning Ok with empty code — so callers
+            // wrote a 0-byte module and exited 0 (#958). Propagate the
+            // template error up so the build/CLI surfaces it.
+            Err(e) => return Err(e),
         }
 
         // Compile styles

--- a/crates/vize_atelier_sfc/src/compile_template.rs
+++ b/crates/vize_atelier_sfc/src/compile_template.rs
@@ -88,10 +88,14 @@ pub(crate) fn compile_template_block(
             }
         );
 
-        if !errors.is_empty() {
+        // Recoverable parser diagnostics (e.g. duplicate attribute) must
+        // not gate SFC compilation, or a single `<div id=a id=b>` produces
+        // a 0-byte module marked as success. (#958)
+        let fatal: Vec<_> = errors.iter().filter(|e| !e.is_recoverable()).collect();
+        if !fatal.is_empty() {
             let mut message = String::from("Template compilation errors: ");
             use std::fmt::Write as _;
-            let _ = write!(&mut message, "{:?}", errors);
+            let _ = write!(&mut message, "{:?}", fatal);
             return Err(SfcError {
                 message,
                 code: Some("TEMPLATE_ERROR".to_compact_string()),
@@ -166,10 +170,13 @@ pub(crate) fn compile_template_block(
         }
     );
 
-    if !errors.is_empty() {
+    // See above — drop recoverable parser diagnostics from the gating
+    // check so duplicate-attribute SFCs still produce valid render code. (#958)
+    let fatal: Vec<_> = errors.iter().filter(|e| !e.is_recoverable()).collect();
+    if !fatal.is_empty() {
         let mut message = String::from("Template compilation errors: ");
         use std::fmt::Write as _;
-        let _ = write!(&mut message, "{:?}", errors);
+        let _ = write!(&mut message, "{:?}", fatal);
         return Err(SfcError {
             message,
             code: Some("TEMPLATE_ERROR".to_compact_string()),

--- a/crates/vize_atelier_ssr/src/lib.rs
+++ b/crates/vize_atelier_ssr/src/lib.rs
@@ -93,7 +93,11 @@ fn compile_ssr_inner<'a>(
         parse_with_options(allocator, source, parser_opts)
     );
 
-    if !errors.is_empty() {
+    // Parser-level diagnostics that are recoverable (e.g. duplicate
+    // attribute) must NOT gate SSR codegen for the same reason as the
+    // DOM compiler — see #958.
+    let fatal_count = errors.iter().filter(|e| !e.is_recoverable()).count();
+    if fatal_count > 0 {
         let codegen_result = SsrCodegenResult {
             code: String::default(),
             preamble: String::default(),

--- a/crates/vize_relief/src/errors.rs
+++ b/crates/vize_relief/src/errors.rs
@@ -33,6 +33,15 @@ impl CompilerError {
             loc,
         }
     }
+
+    /// Returns true when this diagnostic is a parser-level warning that
+    /// downstream codegen can recover from. Mirrors `@vue/compiler-sfc`'s
+    /// classification: a duplicate attribute is reported but does not
+    /// gate render emission (#958).
+    #[must_use]
+    pub fn is_recoverable(&self) -> bool {
+        matches!(self.code, ErrorCode::DuplicateAttribute)
+    }
 }
 
 /// Error codes for compiler errors


### PR DESCRIPTION
## Summary

Fixes #958 (p0).

A duplicate attribute on an element made \`vize build\` emit a 0-byte module while reporting success (exit 0) — a single \`<div id=a id=b>\` anywhere in a real project produced an empty compiled component with no signal in CI.

Three changes:

1. **Recoverable-error classification.** New \`CompilerError::is_recoverable\` — today only \`DuplicateAttribute\` is marked recoverable. The DOM and SSR compilers, plus the SFC-template compile path, filter recoverable diagnostics out of the gating check so codegen still runs and the warning still rides along in the returned errors vec.

2. **\`compile_sfc\` propagates template failures.** Previously a template-compile \`Err\` was pushed into a local vec and the function returned \`Ok\` with empty code — that's what produced the 0-byte success. It now returns \`Err\` to the caller.

3. **Codegen dedupes by attribute name** (Vue keeps the first occurrence) at the three places where props objects are materialized: \`transform_element::build_props\`, \`transforms::hoist_static::{create_props_expression, hoist_element_props}\`, and \`codegen::generate::generate_props_expression_to_bytes\`. The parser still keeps both nodes in \`el.props\` so \`vue/no-duplicate-attributes\` and other linter passes still flag the repeat.

## Test plan
- [x] \`cargo test --workspace --lib\` — green; new \`test_codegen_duplicate_attribute_keeps_first_occurrence\` locks the Vue-parity output.
- [x] Smoke-tested with \`<div id=a id=b>x</div>\`: vize now emits the same \`{ id: "a" }\` as \`@vue/compiler-sfc\` (verified locally) instead of zero bytes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/986"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783160565&installation_id=136613492&pr_number=986&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F986&signature=7654f2edfe496a0591fcf76bf53197073fbd8364c5ff43f3fd0403942c616bad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->