### PR TITLE
fix(vscode-vize): gate workspace binaries on Workspace Trust

### DIFF
--- a/npm/vscode-vize/package.json
+++ b/npm/vscode-vize/package.json
@@ -52,6 +52,12 @@
     "typescript": "6.0.3",
     "vite-plus": "0.1.19"
   },
+  "capabilities": {
+    "untrustedWorkspaces": {
+      "supported": "limited",
+      "description": "Vize runs a native language-server binary. In untrusted workspaces it ignores workspace-controlled server paths and skips workspace-local server binaries to prevent code execution from cloned repositories. Enable Workspace Trust to use the full feature set."
+    }
+  },
   "contributes": {
     "languages": [
       {

--- a/npm/vscode-vize/package.json
+++ b/npm/vscode-vize/package.json
@@ -52,12 +52,6 @@
     "typescript": "6.0.3",
     "vite-plus": "0.1.19"
   },
-  "capabilities": {
-    "untrustedWorkspaces": {
-      "supported": "limited",
-      "description": "Vize runs a native language-server binary. In untrusted workspaces it ignores workspace-controlled server paths and skips workspace-local server binaries to prevent code execution from cloned repositories. Enable Workspace Trust to use the full feature set."
-    }
-  },
   "contributes": {
     "languages": [
       {
@@ -400,5 +394,11 @@
   "icon": "icons/logo.png",
   "engines": {
     "vscode": "^1.75.0"
+  },
+  "capabilities": {
+    "untrustedWorkspaces": {
+      "supported": "limited",
+      "description": "Vize runs a native language-server binary. In untrusted workspaces it ignores workspace-controlled server paths and skips workspace-local server binaries to prevent code execution from cloned repositories. Enable Workspace Trust to use the full feature set."
+    }
   }
 }

--- a/npm/vscode-vize/src/extension.ts
+++ b/npm/vscode-vize/src/extension.ts
@@ -789,7 +789,7 @@ async function findServerPath(
   const expectedVersion = getExtensionVersion(context);
   selectedServerCandidate = undefined;
 
-  const configuredPath = config.get<string>("serverPath")?.trim();
+  const configuredPath = resolveTrustedServerPath(config);
   if (configuredPath) {
     if (fs.existsSync(configuredPath)) {
       const candidate = await inspectServerCandidate({
@@ -1041,6 +1041,12 @@ async function warnAboutVersionMismatch(
 }
 
 function getWorkspaceDevPaths(exeName: string): string[] {
+  // Skip workspace-derived server paths in untrusted workspaces — a cloned
+  // repo that ships a malicious binary at `target/{release,debug}/vize`
+  // would otherwise be executed when the workspace was opened. (#969)
+  if (!workspace.isTrusted) {
+    return [];
+  }
   const paths: string[] = [];
   const workspaceFolders = workspace.workspaceFolders;
   if (workspaceFolders) {
@@ -1050,6 +1056,35 @@ function getWorkspaceDevPaths(exeName: string): string[] {
     }
   }
   return paths;
+}
+
+/// Resolve the user-/machine-scoped value of `vize.serverPath` only.
+/// Workspace-scoped values (e.g. a `.vscode/settings.json` shipped in a
+/// cloned repo) are intentionally ignored — that file is repo-controlled
+/// and could otherwise point the extension at any executable. The
+/// untrusted-workspace branch declared in `package.json::capabilities`
+/// covers the first defense in depth; this is the second. (#969)
+function resolveTrustedServerPath(
+  config: ReturnType<typeof workspace.getConfiguration>,
+): string | undefined {
+  const inspected = config.inspect<string>("serverPath");
+  if (!inspected) {
+    return undefined;
+  }
+  const candidates: Array<string | undefined> = [
+    inspected.globalValue,
+    inspected.workspaceValue && workspace.isTrusted ? inspected.workspaceValue : undefined,
+    inspected.workspaceFolderValue && workspace.isTrusted
+      ? inspected.workspaceFolderValue
+      : undefined,
+  ];
+  for (const raw of candidates) {
+    const trimmed = raw?.trim();
+    if (trimmed) {
+      return trimmed;
+    }
+  }
+  return undefined;
 }
 
 function getImplicitPathDirs(): string[] {


### PR DESCRIPTION
## Summary

Partial fix for #969 (p0) — closes the most exploitable surface (workspace-controlled local binaries / \`serverPath\`).

Opening a workspace that ships a binary at \`target/{release,debug}/vize\` or that points \`vize.serverPath\` to an arbitrary executable used to launch that binary on activation — untrusted-workspace RCE in already-public extension code.

Two defenses:

- **\`capabilities.untrustedWorkspaces\`** in \`package.json\` (\`supported: "limited"\`) so VS Code shows the trust prompt and gates language-server activation. The description explains the limited-mode behavior.
- **\`getWorkspaceDevPaths\`** returns \`[]\` when \`workspace.isTrusted\` is false — a cloned repo's \`target/release/vize\` is no longer considered.
- **\`resolveTrustedServerPath\`** reads \`vize.serverPath\` via \`config.inspect\` and honors only the user/machine-scoped value in an untrusted workspace, ignoring repo-shipped \`.vscode/settings.json\`.

The binary-download integrity check (cosign bundle verification, SHA256 pinning) is a larger follow-up tracked in the issue. The Workspace Trust gate already closes the highest-impact path (RCE on workspace open).

## Test plan
- [x] \`vp check src\` — clean (no lint/format issues).
- [x] \`tsgo --noEmit\` — clean.
- [ ] Manual: opening an untrusted workspace surfaces the trust prompt; \`vize.serverPath\` from \`.vscode/settings.json\` is ignored until trusted.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/987"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783160755&installation_id=136613492&pr_number=987&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F987&signature=668bbd59cee9fc6844e823fdf945a99299c5f628148af02ac0c8a236e089f01b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->