### PR TITLE
fix(diagnostics): emit columns in UTF-16 code units

### DIFF
--- a/crates/vize_canon/src/batch/executor/diagnostics.rs
+++ b/crates/vize_canon/src/batch/executor/diagnostics.rs
@@ -163,6 +163,8 @@ impl LineIndex {
         }
     }
 
+    /// Convert an LSP (line, character) — where character is in UTF-16 code
+    /// units — back to a byte offset into `content`. (#965)
     fn line_col_to_offset(&self, content: &str, line: u32, col: u32) -> Option<u32> {
         let line = usize::try_from(line).ok()?;
         let start = *self.starts.get(line)?;
@@ -176,8 +178,8 @@ impl LineIndex {
 
         for ch in content[start..end].chars() {
             offset += ch.len_utf8();
-            current_col += 1;
-            if current_col == col {
+            current_col += ch.len_utf16() as u32;
+            if current_col >= col {
                 return u32::try_from(offset).ok();
             }
         }
@@ -189,6 +191,10 @@ impl LineIndex {
         }
     }
 
+    /// Convert a byte offset to LSP (line, character). `character` is in
+    /// UTF-16 code units — astral characters (`len_utf16() == 2`) count as
+    /// two so the column matches what `vue-tsc` / `@vue/language-tools`
+    /// report. (#965)
     fn offset_to_line_col(&self, content: &str, offset: u32) -> Option<(u32, u32)> {
         let offset = usize::try_from(offset).ok()?;
         if offset > self.len {
@@ -199,16 +205,16 @@ impl LineIndex {
         let line = line.saturating_sub(1);
         let start = *self.starts.get(line)?;
         let end = self.line_end(line);
-        let mut col = 0usize;
+        let mut col = 0u32;
         let mut cursor = start;
         for ch in content[start..end].chars() {
             if cursor >= offset {
                 break;
             }
-            col += 1;
+            col += ch.len_utf16() as u32;
             cursor += ch.len_utf8();
         }
-        Some((u32::try_from(line).ok()?, u32::try_from(col).ok()?))
+        Some((u32::try_from(line).ok()?, col))
     }
 
     fn line_end(&self, line: usize) -> usize {
@@ -422,6 +428,23 @@ mod tests {
         let content = "é\n";
         let index = LineIndex::new(content);
         assert_eq!(index.offset_to_line_col(content, 1), Some((0, 1)));
+    }
+
+    #[test]
+    fn line_index_counts_astral_chars_as_two_utf16_units() {
+        // Regression for #965: LSP `Position.character` is in UTF-16 code
+        // units. An emoji (`U+1F600`) is one Unicode scalar but TWO UTF-16
+        // units (encoded as a surrogate pair) — `vue-tsc` /
+        // `@vue/language-tools` report the post-emoji column as `+2`, so
+        // vize must too.
+        let content = "\u{1F600}x\n";
+        let index = LineIndex::new(content);
+
+        // Byte offset 4 is right after the emoji + `x`. The emoji is 4
+        // UTF-8 bytes and counts as 2 UTF-16 units; `x` is 1 of each.
+        assert_eq!(index.offset_to_line_col(content, 5), Some((0, 3)));
+        // The reverse direction must round-trip.
+        assert_eq!(index.line_col_to_offset(content, 0, 3), Some(5));
     }
 
     #[test]

--- a/crates/vize_canon/src/corsa_server.rs
+++ b/crates/vize_canon/src/corsa_server.rs
@@ -742,7 +742,13 @@ fn offset_to_line_column(source: &str, offset: usize) -> (u32, u32) {
             line_start = index + 1;
         }
     }
-    let column = source[line_start..target].chars().count() as u32;
+    // LSP `Position.character` is in UTF-16 code units. Astral characters
+    // (`len_utf16() == 2`) count as two so the column lines up with
+    // `vue-tsc` / `@vue/language-tools`. (#965)
+    let column: u32 = source[line_start..target]
+        .chars()
+        .map(|ch| ch.len_utf16() as u32)
+        .sum();
     (line, column)
 }
 

--- a/crates/vize_maestro/src/ide/diagnostics/collectors.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/collectors.rs
@@ -255,7 +255,7 @@ impl DiagnosticService {
     /// Collect template parser diagnostics.
     pub(super) fn collect_template_diagnostics(
         _uri: &Url,
-        _content: &str,
+        content: &str,
         descriptor: &SfcDescriptor<'_>,
     ) -> Vec<Diagnostic> {
         let Some(ref template) = descriptor.template else {
@@ -270,20 +270,27 @@ impl DiagnosticService {
             .filter_map(|error| {
                 let loc = error.loc.as_ref()?;
 
-                // Adjust line numbers based on template block position
-                let start_line =
-                    (template.loc.start_line as u32) + loc.start.line.saturating_sub(1);
-                let end_line = (template.loc.start_line as u32) + loc.end.line.saturating_sub(1);
+                // The template parser stores `line=1`/`column=byte_offset`
+                // today; translate via the byte `offset` plus the template
+                // block's position in the SFC. `offset_to_line_col` counts
+                // UTF-16 code units so the position lands at the right
+                // editor column for non-ASCII content. (#965)
+                let absolute_start_offset = template.loc.start as u32 + loc.start.offset;
+                let absolute_end_offset = template.loc.start as u32 + loc.end.offset;
+                let (start_line, start_character) =
+                    offset_to_line_col(content, absolute_start_offset as usize);
+                let (end_line, end_character) =
+                    offset_to_line_col(content, absolute_end_offset as usize);
 
                 Some(Diagnostic {
                     range: Range {
                         start: Position {
-                            line: start_line.saturating_sub(1),
-                            character: loc.start.column.saturating_sub(1),
+                            line: start_line,
+                            character: start_character,
                         },
                         end: Position {
-                            line: end_line.saturating_sub(1),
-                            character: loc.end.column.saturating_sub(1),
+                            line: end_line,
+                            character: end_character,
                         },
                     },
                     severity: Some(DiagnosticSeverity::ERROR),


### PR DESCRIPTION
## Summary

Fixes #965 (partial — see follow-up note).

LSP \`Position.character\` is in UTF-16 code units; vize used byte offsets or Unicode-scalar counts in several paths, so squiggles landed on the wrong column once a line contained any non-ASCII (BMP or astral) character.

Fixes:

- **\`vize_canon::batch::executor::diagnostics::LineIndex\`** (\`offset_to_line_col\` / \`line_col_to_offset\`) now counts \`ch.len_utf16()\` per character so an emoji (one Unicode scalar, two UTF-16 units) shifts the column by 2 and \`vize check\` text/JSON output matches \`vue-tsc\` / \`@vue/language-tools\`.
- **\`vize_canon::corsa_server::offset_to_line_column\`** (the JSON-RPC type-check server) gets the same fix.
- **Template parser diagnostics** in \`vize_maestro\` route through the existing UTF-16-aware \`offset_to_line_col\` using the parser's byte offset + the template block's position in the SFC, instead of consuming the parser's stub \`line=1\` / \`column=byte_offset\` directly.

Follow-up: the parser-side line/column tracking (the issue's third bullet — populating the parser's newline table) is a separate change; this PR makes the existing data go through UTF-16-aware conversion on every editor-facing surface.

## Test plan
- [x] \`cargo test --workspace --lib\` — green; added \`line_index_counts_astral_chars_as_two_utf16_units\`.
- [x] \`cargo clippy --workspace -- -D warnings\` — clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/988"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783163176&installation_id=136613492&pr_number=988&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F988&signature=9d99bdb4ad3c8bfa84f2f6635b554b4bcf552f42b5f6492c6c66bf7af45bed15"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->