### PR TITLE
fix(flake): refresh blacksmith linux/amd64 hash for upstream binary update

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -140,7 +140,7 @@
           };
           x86_64-linux = {
             url = "https://clireleases.blacksmith.sh/cli/latest/linux/amd64/blacksmith";
-            hash = "sha256-W8ljKPdzda1SCCpg8FbxlsioKA8GlNqueLtePYb/XZg=";
+            hash = "sha256-m9pQ9hQUjzfrNrLOa3NQrrxVP9J9Ing2Rwnp5B9LCsw=";
           };
           aarch64-linux = {
             url = "https://clireleases.blacksmith.sh/cli/latest/linux/arm64/blacksmith";


### PR DESCRIPTION
## Summary

\`blacksmith\` is published on a mutable \`latest\` channel and self-updates in the background. The flake's pinned hash for the x86_64-linux binary stopped matching the upstream content today, so \`nix flake check\` on push-to-main now fails:

\`\`\`
hash mismatch in fixed-output derivation '/nix/store/.../blacksmith.drv':
  specified: sha256-W8ljKPdzda1SCCpg8FbxlsioKA8GlNqueLtePYb/XZg=
  got:       sha256-m9pQ9hQUjzfrNrLOa3NQrrxVP9J9Ing2Rwnp5B9LCsw=
\`\`\`

This started failing before any of the recent issue fixes landed (first failure ~2026-06-04T06:30 UTC); the runs at PRs #977 / #978 pass on the PR check (\`nix-flake\` is gated to push-only), and only the push-to-main run after merge hits this.

Bump the linux/amd64 hash to the new upstream value, matching the documented "refresh the hashes here" maintenance path in \`flake.nix\` (the other platforms aren't covered by CI today; they'll be refreshed the next time they need to build).

## Test plan
- nix-flake on this branch's push job goes green.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/989"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783164103&installation_id=136613492&pr_number=989&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F989&signature=0ecba6d3121fd2806124a6d5ee47f80a7c3cb6f6e52846b1a6eef0d3d9d76ef7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->