### PR TITLE
fix(ssr): emit selected attribute on matching option for <select v-model>

### DIFF
--- a/crates/vize_atelier_ssr/src/codegen.rs
+++ b/crates/vize_atelier_ssr/src/codegen.rs
@@ -51,6 +51,11 @@ pub struct SsrCodegenContext<'a> {
     pub(crate) with_slot_scope_id: bool,
     /// Template-local identifiers from v-for and scoped slots.
     pub(crate) scoped_params: std::vec::Vec<FxHashSet<String>>,
+    /// Stack of `v-model` expressions on currently-open `<select>` ancestors.
+    /// When non-empty, an `<option>` child uses the top entry to render
+    /// `selected` for the matching value. Vue's SSR runtime tracks the same
+    /// state in JS via `_temp`; we thread it through codegen instead. (#962)
+    pub(crate) select_v_model_stack: std::vec::Vec<String>,
 }
 
 impl<'a> SsrCodegenContext<'a> {
@@ -66,6 +71,7 @@ impl<'a> SsrCodegenContext<'a> {
             has_open_push: false,
             with_slot_scope_id: false,
             scoped_params: std::vec::Vec::new(),
+            select_v_model_stack: std::vec::Vec::new(),
         }
     }
 

--- a/crates/vize_atelier_ssr/src/codegen/element/plain.rs
+++ b/crates/vize_atelier_ssr/src/codegen/element/plain.rs
@@ -29,6 +29,28 @@ impl<'a> SsrCodegenContext<'a> {
             self.push_string_part_static(scope_id);
         }
 
+        // `<option>` inside a `<select v-model>` ancestor needs a runtime
+        // `selected` injection. The option's `value` (a static attribute
+        // here — dynamic `:value` falls through and gets `selected`
+        // emitted via the bind path). (#962)
+        if tag.as_str() == "option"
+            && let Some(model_exp) = self.select_v_model_stack.last().cloned()
+        {
+            self.use_ssr_helper(RuntimeHelper::SsrIncludeBooleanAttr);
+            self.use_ssr_helper(RuntimeHelper::SsrLooseContain);
+            self.use_ssr_helper(RuntimeHelper::SsrLooseEqual);
+            let value_exp = if let Some(value) = self.get_element_attr_value(el, "value") {
+                quoted_js_string(&value)
+            } else if let Some(dyn_value) = self.get_dynamic_bind_exp(el, "value") {
+                dyn_value
+            } else {
+                "null".to_compact_string()
+            };
+            self.push_string_part_dynamic(&cstr!(
+                "((_ssrIncludeBooleanAttr(Array.isArray({model_exp}) ? _ssrLooseContain({model_exp}, {value_exp}) : _ssrLooseEqual({model_exp}, {value_exp}))) ? \" selected\" : \"\")"
+            ));
+        }
+
         // Check if void element
         if vize_carton::is_void_tag(tag) {
             self.push_string_part_static(">");
@@ -54,6 +76,20 @@ impl<'a> SsrCodegenContext<'a> {
             self.use_ssr_helper(RuntimeHelper::SsrInterpolate);
             let exp = self.expression_to_string(exp);
             self.push_string_part_dynamic(&cstr!("_ssrInterpolate({exp})"));
+        } else if tag.as_str() == "select"
+            && let Some(exp) = crate::get_v_model_exp(el)
+        {
+            // SSR `<select v-model>` marks the matching `<option>` as
+            // `selected` while emitting children. Push the model
+            // expression onto a stack so each child option can read it,
+            // and pop after the subtree. Matches Vue's SSR output:
+            //   `${_ssrIncludeBooleanAttr((Array.isArray(M)) ?
+            //       _ssrLooseContain(M, V) : _ssrLooseEqual(M, V)))
+            //       ? " selected" : ""}`. (#962)
+            let exp = self.expression_to_string(exp);
+            self.select_v_model_stack.push(exp);
+            self.process_children(&el.children, false, false, false);
+            self.select_v_model_stack.pop();
         } else {
             self.process_children(&el.children, false, false, false);
         }

--- a/crates/vize_atelier_ssr/src/lib.rs
+++ b/crates/vize_atelier_ssr/src/lib.rs
@@ -256,6 +256,34 @@ mod tests {
     }
 
     #[test]
+    fn test_ssr_v_model_select_marks_matching_option_selected() {
+        // Regression for #962: `<select v-model="x">` must render the
+        // matching `<option>` with `selected` set, not silently drop the
+        // bound value.
+        let allocator = Bump::new();
+        let (_, errors, result) = compile_ssr(
+            &allocator,
+            r#"<select v-model="x"><option value="a">A</option><option value="b">B</option></select>"#,
+        );
+        assert!(errors.is_empty(), "{errors:?}");
+        assert!(
+            result.code.contains("_ssrLooseEqual(_ctx.x, \"a\")"),
+            "expected loose-equal for option a, got:\n{}",
+            result.code
+        );
+        assert!(
+            result.code.contains("_ssrLooseEqual(_ctx.x, \"b\")"),
+            "expected loose-equal for option b, got:\n{}",
+            result.code
+        );
+        assert!(
+            result.code.contains("\" selected\""),
+            "expected ` selected` literal, got:\n{}",
+            result.code
+        );
+    }
+
+    #[test]
     fn test_dynamic_slot_outlet_name_stays_expression() {
         let allocator = Bump::new();
         let (_, errors, result) = compile_ssr_with_options(


### PR DESCRIPTION
## Summary

Completes the remaining surface of #962. SSR codegen for \`<select v-model="x">\` previously dropped the bound value — Vue marks the matching \`<option>\` as \`selected\` with \`_ssrIncludeBooleanAttr(Array.isArray(x) ? _ssrLooseContain(x, V) : _ssrLooseEqual(x, V))\`, but vize emitted neither.

The select's v-model expression now threads through a per-context stack (\`SsrCodegenContext::select_v_model_stack\`): when \`process_plain_element\` encounters a \`<select>\` carrying \`v-model\`, push the model expression, process children (which now see it), and pop after the subtree. When the element is \`<option>\`, look at the top of the stack and emit the \`selected\` boolean-attr expression — taking the option's \`value\` from a static attribute or a \`:value\` binding (falling back to \`null\` for an option without a value).

Combined with the earlier textarea + dynamic-type input fix, all three SSR v-model gaps from the issue are now closed.

## Test plan
- [x] \`cargo test --workspace --lib\` — green; new \`test_ssr_v_model_select_marks_matching_option_selected\` covers the exact \`<select v-model><option value=...>\` case from the issue and asserts the \`_ssrLooseEqual(_ctx.x, ...)\` / \` selected\` emit.
- [x] \`cargo clippy --workspace -- -D warnings\` — clean.

Closes #962 once this lands.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/990"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783166315&installation_id=136613492&pr_number=990&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F990&signature=b883f5e65c6b04641624c7affc8273325a005a5370d29511ce52aba61c8518cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->