### PR TITLE
fix(vscode-vize): verify SHA-256 of downloaded server binary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1111,6 +1111,24 @@ jobs:
         with:
           cosign-release: v2.4.1
 
+      # SHA-256 sums are the simplest integrity check downstream tools
+      # (the VS Code extension's pre-execution download) can verify
+      # without pulling in cosign or sigstore-verify libraries. Cosign
+      # remains the source of truth via the bundle below; the .sha256
+      # files are an easy-to-verify hash pin. (#969)
+      - name: Generate SHA-256 checksums for release artifacts
+        run: |
+          for artifact in \
+            cli-artifacts/*.tar.gz \
+            cli-artifacts/*.zip \
+            editor-extension-artifacts/npm/vscode-vize/dist/*.vsix \
+            editor-extension-artifacts/*.tar.gz; do
+            if [ -f "$artifact" ]; then
+              echo "Hashing $artifact"
+              ( cd "$(dirname "$artifact")" && sha256sum "$(basename "$artifact")" ) > "${artifact}.sha256"
+            fi
+          done
+
       - name: Sign release artifacts (keyless)
         env:
           COSIGN_YES: "true"
@@ -1146,9 +1164,11 @@ jobs:
             editor-extension-artifacts/*.tar.gz
             vize-${{ github.ref_name }}-cyclonedx.sbom.json
             vize-${{ github.ref_name }}-spdx.sbom.json
+            cli-artifacts/*.sha256
             cli-artifacts/*.sig
             cli-artifacts/*.pem
             cli-artifacts/*.cosign.bundle
+            editor-extension-artifacts/**/*.sha256
             editor-extension-artifacts/**/*.sig
             editor-extension-artifacts/**/*.pem
             editor-extension-artifacts/**/*.cosign.bundle

--- a/npm/vscode-vize/src/extension.ts
+++ b/npm/vscode-vize/src/extension.ts
@@ -1,3 +1,4 @@
+import * as crypto from "crypto";
 import * as fs from "fs";
 import * as https from "https";
 import * as path from "path";
@@ -1100,6 +1101,8 @@ async function resolveReleaseServerCandidate(
 
   const archivePath = path.join(installDir, target.archiveName);
   const downloadUrl = createReleaseDownloadUrl(expectedVersion, target.archiveName);
+  const checksumUrl = `${downloadUrl}.sha256`;
+  const checksumPath = `${archivePath}.sha256`;
 
   try {
     updateStatusBar("starting", `Downloading Vize language server ${expectedVersion}`);
@@ -1107,6 +1110,14 @@ async function resolveReleaseServerCandidate(
     fs.rmSync(installDir, { force: true, recursive: true });
     await fs.promises.mkdir(installDir, { recursive: true });
     await downloadFile(downloadUrl, archivePath);
+
+    // Verify integrity: the release pipeline publishes a SHA-256 checksum
+    // alongside each archive. Fetch it and compare against a hash of the
+    // local file; fail closed if the checksum is unavailable or mismatched
+    // so a tampered mirror/CDN/MITM can't get a binary executed. (#969)
+    await downloadFile(checksumUrl, checksumPath);
+    await verifyArchiveChecksum(archivePath, checksumPath);
+
     await extractReleaseArchive(archivePath, installDir, exeName);
 
     const candidate = await inspectServerCandidate({
@@ -1189,6 +1200,36 @@ function releaseTarget(targetName: string, extension: "tar.gz" | "zip"): Release
 
 function createReleaseDownloadUrl(version: string, archiveName: string): string {
   return `https://github.com/ubugeeei-prod/vize/releases/download/v${version}/${archiveName}`;
+}
+
+/// Verify that the SHA-256 of `archivePath` matches the hash declared in
+/// `checksumPath`. The checksum file is the GNU sha256sum format
+/// (`<hex>  <name>`), so we accept either bare hex or that shape. Throws
+/// if the file is missing, malformed, or mismatched — caller's catch
+/// surfaces the failure in the output channel and falls back to other
+/// sources. (#969)
+async function verifyArchiveChecksum(archivePath: string, checksumPath: string): Promise<void> {
+  const declared = (await fs.promises.readFile(checksumPath, "utf8"))
+    .trim()
+    .split(/\s+/)[0]
+    ?.toLowerCase();
+  if (!declared || !/^[0-9a-f]{64}$/.test(declared)) {
+    throw new Error(`malformed SHA-256 checksum file at ${checksumPath}`);
+  }
+  const hash = crypto.createHash("sha256");
+  await new Promise<void>((resolve, reject) => {
+    const stream = fs.createReadStream(archivePath);
+    stream.on("data", (chunk: string | Buffer) => {
+      hash.update(chunk);
+    });
+    stream.on("end", () => resolve());
+    stream.on("error", reject);
+  });
+  const got = hash.digest("hex");
+  if (got !== declared) {
+    throw new Error(`SHA-256 mismatch for ${archivePath}: declared ${declared}, computed ${got}`);
+  }
+  outputChannel.appendLine(`Verified ${path.basename(archivePath)} (SHA-256 ${got}).`);
 }
 
 async function downloadFile(url: string, destination: string, redirectCount = 0): Promise<void> {


### PR DESCRIPTION
## Summary

Closes the remaining surface of #969 — release binaries are now verified against a published SHA-256 before being made executable.

**Release workflow** (\`.github/workflows/release.yml\`): a new "Generate SHA-256 checksums" step runs before the cosign-signing step and emits a sibling \`<archive>.sha256\` for each \`.tar.gz\` / \`.zip\` / \`.vsix\` artifact (GNU \`sha256sum\` format). The checksum files are uploaded alongside the existing \`.sig\` / \`.pem\` / \`.cosign.bundle\` outputs.

**VS Code extension** (\`npm/vscode-vize/src/extension.ts\`): after the existing \`downloadFile(downloadUrl, archivePath)\`, the extension downloads \`<downloadUrl>.sha256\` and calls \`verifyArchiveChecksum\` which:

- reads the checksum file, parses GNU-format \`<hex>  <name>\`,
- rejects non-64-char-hex content as malformed,
- streams the archive through \`crypto.createHash("sha256")\`,
- throws on mismatch; the surrounding catch surfaces the failure in the Vize output channel and falls back to other server sources (cargo, PATH, bundled) without making the binary executable.

A tampered mirror / CDN / MITM (or a corrupted partial download) is now rejected before \`chmod 0o755\` and before \`execFile\` ever runs on the artifact. Cosign-bundle verification remains a follow-up if/when the extension wants to drop the network-trust dependency.

## Test plan
- [x] \`tsgo --noEmit\` — clean.
- [x] \`vp check src\` — clean.
- [ ] Manual: published release exposes \`<artifact>.sha256\`; extension download path rejects a flipped checksum.

Closes #969 once this lands.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/991"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783166504&installation_id=136613492&pr_number=991&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F991&signature=bb26ce56da068d5ccba0ac97accbed7ab1cec0a2b252df8d43859ef00e474057"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->