### PR TITLE
fix(sfc): emit user imports exactly once when both script blocks are present

### DIFF
--- a/crates/vize_atelier_sfc/src/compile/snapshots/vize_atelier_sfc__compile__tests__compile_both_script_blocks.snap
+++ b/crates/vize_atelier_sfc/src/compile/snapshots/vize_atelier_sfc__compile__tests__compile_both_script_blocks.snap
@@ -1,13 +1,12 @@
 ---
 source: crates/vize_atelier_sfc/src/compile/tests.rs
-assertion_line: 1165
 expression: result.code.as_str()
 ---
 import { defineComponent as _defineComponent } from 'vue'
 import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock, Fragment as _Fragment, renderList as _renderList } from "vue"
 
-
 import type { RouteLocation } from "vue-router";
+
 
 interface TabItem {
   name: string;

--- a/crates/vize_atelier_sfc/src/compile/snapshots/vize_atelier_sfc__compile__tests__compile_both_script_blocks_exposes_normal_script_bindings_to_template.snap
+++ b/crates/vize_atelier_sfc/src/compile/snapshots/vize_atelier_sfc__compile__tests__compile_both_script_blocks_exposes_normal_script_bindings_to_template.snap
@@ -5,8 +5,8 @@ expression: result.code.as_str()
 import { defineComponent as _defineComponent } from 'vue'
 import { toDisplayString as _toDisplayString, normalizeClass as _normalizeClass, openBlock as _openBlock, createElementBlock as _createElementBlock, Fragment as _Fragment, renderList as _renderList } from "vue"
 
-
 import { ref } from "vue";
+
 
 const dragging = ref(false);
 let dropCallback = null;

--- a/crates/vize_atelier_sfc/src/compile/tests.rs
+++ b/crates/vize_atelier_sfc/src/compile/tests.rs
@@ -1166,6 +1166,65 @@ const { items } = defineProps<{
 }
 
 #[test]
+fn test_compile_both_script_blocks_dedupes_imports() {
+    // Regression test for #993: an import present in BOTH blocks must be
+    // emitted exactly once, and a side-effect import that lives only in the
+    // normal `<script>` must survive (exactly once).
+    let source = r#"<script lang="ts">
+import { ref } from "vue";
+import { registerHotkey } from "./hotkey-plugin";
+import "./side-effect-only";
+
+registerHotkey();
+</script>
+
+<script setup lang="ts">
+import { ref } from "vue";
+
+const count = ref(0);
+</script>
+
+<template>{{ count }}</template>"#;
+
+    let descriptor = parse_sfc(source, SfcParseOptions::default()).expect("Failed to parse SFC");
+    let opts = SfcCompileOptions {
+        script: ScriptCompileOptions {
+            is_ts: true,
+            ..Default::default()
+        },
+        template: TemplateCompileOptions {
+            is_ts: true,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let result = compile_sfc(&descriptor, opts).expect("Failed to compile SFC");
+    let code = result.code.as_str();
+
+    assert_eq!(
+        code.matches("import { ref } from \"vue\"").count(),
+        1,
+        "shared import must be emitted exactly once:\n{code}"
+    );
+    assert_eq!(
+        code.matches("registerHotkey } from").count(),
+        1,
+        "normal-script-only import must be emitted exactly once:\n{code}"
+    );
+    assert_eq!(
+        code.matches("import \"./side-effect-only\"").count()
+            + code.matches("import './side-effect-only'").count(),
+        1,
+        "side-effect import must survive exactly once:\n{code}"
+    );
+    assert_eq!(
+        code.matches("registerHotkey();").count(),
+        1,
+        "normal-script statements must survive:\n{code}"
+    );
+}
+
+#[test]
 fn test_compile_both_script_blocks_exposes_normal_script_bindings_to_template() {
     let source = r#"<script lang="ts">
 import { ref } from "vue";

--- a/crates/vize_atelier_sfc/src/compile_script/inline/compiler/preamble.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/inline/compiler/preamble.rs
@@ -110,16 +110,20 @@ pub(super) fn emit_preamble(
         }
     }
 
-    // User imports (after hoisted consts) - deduplicate to avoid "already declared" errors
-    let deduped_imports = profile!(
-        "atelier.script_inline.dedupe_imports",
-        dedupe_imports(user_imports, is_ts)
-    );
+    // User imports (after hoisted consts) - deduplicate to avoid "already declared" errors.
+    // Imports from the preserved normal `<script>` are merged into the same
+    // deduped emit so each user import appears exactly once; their statements
+    // are stripped from the appended normal-script body below (#993).
     let normal_script_imports = preserved_normal_script
         .map(|script| parse_script_content(script, is_ts).0)
         .unwrap_or_default();
-    let mut setup_return_imports = deduped_imports.clone();
-    setup_return_imports.extend(normal_script_imports.iter().cloned());
+    let mut all_user_imports = user_imports.to_vec();
+    all_user_imports.extend(normal_script_imports.iter().cloned());
+    let deduped_imports = profile!(
+        "atelier.script_inline.dedupe_imports",
+        dedupe_imports(&all_user_imports, is_ts)
+    );
+    let setup_return_imports = deduped_imports.clone();
     if !deduped_imports.is_empty() && !template.hoisted.is_empty() {
         ensure_blank_line(output);
     }
@@ -147,7 +151,11 @@ pub(super) fn emit_preamble(
     // This matches Vue's @vue/compiler-sfc output order
     let has_default_export = if let Some(normal_script) = preserved_normal_script {
         output.push(b'\n');
-        output.extend_from_slice(normal_script.as_bytes());
+        // Its `import` statements were already emitted via the deduped
+        // import block above; keeping them here would duplicate them in
+        // the compiled module (#993).
+        let stripped = strip_import_statements(normal_script);
+        output.extend_from_slice(stripped.trim_end_matches('\n').as_bytes());
         output.push(b'\n');
         normal_script.contains("const __default__")
     } else {
@@ -166,4 +174,68 @@ fn ensure_blank_line(output: &mut vize_carton::Vec<u8>) {
         bytes if bytes.ends_with(b"\n") => output.push(b'\n'),
         _ => output.extend_from_slice(b"\n\n"),
     }
+}
+
+/// Remove top-level `import` statements from a preserved normal `<script>`
+/// body. They are emitted through the deduped import block instead, so
+/// leaving them in place would duplicate them in the compiled output (#993).
+/// Mirrors the import detection in `parser::parse_script_content`, including
+/// its template-literal guard.
+fn strip_import_statements(content: &str) -> String {
+    let mut out = String::default();
+    let mut in_import = false;
+    let mut in_template_literal = false;
+
+    for line in content.lines() {
+        let backtick_count = line
+            .chars()
+            .fold((0, false), |(count, escaped), c| {
+                if escaped {
+                    (count, false)
+                } else if c == '\\' {
+                    (count, true)
+                } else if c == '`' {
+                    (count + 1, false)
+                } else {
+                    (count, false)
+                }
+            })
+            .0;
+        let was_in_template_literal = in_template_literal;
+        if backtick_count % 2 == 1 {
+            in_template_literal = !in_template_literal;
+        }
+
+        if was_in_template_literal {
+            out.push_str(line);
+            out.push('\n');
+            continue;
+        }
+
+        let trimmed = line.trim();
+
+        if in_import {
+            if trimmed.ends_with(';') || (trimmed.contains(" from ") && !trimmed.ends_with(',')) {
+                in_import = false;
+            }
+            continue;
+        }
+
+        if trimmed.starts_with("import ") {
+            // Single-line side-effect import (no `from` clause)
+            if !trimmed.contains(" from ") && (trimmed.contains('\'') || trimmed.contains('"')) {
+                continue;
+            }
+            if !(trimmed.ends_with(';') || (trimmed.contains(" from ") && !trimmed.ends_with(',')))
+            {
+                in_import = true;
+            }
+            continue;
+        }
+
+        out.push_str(line);
+        out.push('\n');
+    }
+
+    out
 }

--- a/tests/snapshots/sfc/ts/script_setup__script_with_type_definitions_and_script_setup.snap
+++ b/tests/snapshots/sfc/ts/script_setup__script_with_type_definitions_and_script_setup.snap
@@ -1,13 +1,12 @@
 ---
 source: crates/vize_atelier_sfc/src/snapshot_tests.rs
-assertion_line: 152
 expression: ts_output.as_str()
 ---
 import { defineComponent as _defineComponent } from 'vue'
 import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock, Fragment as _Fragment, renderList as _renderList } from "vue"
 
-
 import type { RouteLocation } from "vue-router";
+
 
 interface TabItem {
   name: string;


### PR DESCRIPTION
## Summary

When an SFC has both a normal `<script>` and a `<script setup>`, the inline preamble now emits each user import exactly once. Previously the `<script setup>` imports went through the deduped block while the preserved normal `<script>` body was appended verbatim with its own `import` statements still inside, so a shared specifier produced duplicate import statements in the compiled module - duplicate named bindings ("already declared") in the strict case, and double-running top-level side effects in the case #993 describes.

Two coordinated changes in `compile_script/inline/compiler/preamble.rs`:
- `normal_script_imports` are merged into the deduped emit (`dedupe_imports` over setup + normal imports) instead of only feeding the template-binding map, so a normal-script-only import (including bare side-effect imports) still lands exactly once
- the appended normal-script body goes through `strip_import_statements`, which mirrors `parser::parse_script_content`'s import detection (single-line side-effect imports, multi-line imports, template-literal guard) and keeps every non-import statement verbatim

## Context

#993 traces the duplication to the exact two sites changed here: the deduped import emit (which only covered `<script setup>` imports) and the verbatim append of the preserved normal `<script>` body. Any top-level side effect in a doubly-imported module - registering a hotkey listener, pushing into a global registry, calling `installPlugin()` - fired twice in the compiled module, and shared named imports produced duplicate bindings.

## Change Class

- [x] Compiler and codegen

## Behavior Reference

Fixes #993 (code-grounded issue; the L118-128/L150 sites it cites are exactly the two changed). Matches `@vue/compiler-sfc`, which hoists and dedupes user imports from both blocks ahead of the component definition.

## Verification Evidence

Commands: `cargo test -p vize_atelier_sfc` (454 passed), `cargo check -p vize_atelier_sfc`, `cargo fmt --check`.

- [x] Minimal fixture or focused regression test added or updated - new `test_compile_both_script_blocks_dedupes_imports` asserts the issue's exact fixture shape: shared `import { ref } from "vue"` in both blocks emitted once, normal-only `registerHotkey` import emitted once, bare `import "./side-effect-only"` survives exactly once, and the `registerHotkey()` call still flows through
- [x] Snapshot/baseline changes reviewed and explained - three snapshots refresh with whitespace-only diffs (blank-line placement around the emitted import block); no content changes, reviewed line by line
- [x] Parity or real-world fixture coverage considered - dual-block fixtures `compile_both_script_blocks*` and `script_setup__script_*` all pass; `<script setup>`-only output is byte-identical (strip path only runs when a normal block exists)
- [ ] Security/audit impact considered - n/a, codegen ordering only
- [ ] Performance status or PR benchmark impact considered - one extra line scan over the (small) preserved normal script per SFC
- [ ] Fuzzing target or crash-reproducer coverage considered - n/a
- [ ] Editor/LSP scenario coverage considered - n/a, inline compile output only
- [ ] Ecosystem or broad app compatibility impact considered - output for single-block SFCs is unchanged
- [ ] Docs, release, or stability notes updated when public behavior changed - no public API change

## Risk

Low. The strip helper intentionally mirrors the existing parser's import detection so the two stay in agreement; if they ever diverge, the worst case is an import emitted twice (the status quo this PR fixes), never a dropped statement, because stripping only removes lines the parser already classified as imports.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/997"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783172961&installation_id=136613492&pr_number=997&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F997&signature=5d62c2ef5fdcd86da644c8a6b7b415eb48d533cd97bbe303973dd0f9bafbf5b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->