### PR TITLE
fix(sfc): dedupe imports across <script> and <script setup> blocks (#993)

### DIFF
--- a/crates/vize_atelier_sfc/src/compile/snapshots/vize_atelier_sfc__compile__tests__compile_both_script_blocks.snap
+++ b/crates/vize_atelier_sfc/src/compile/snapshots/vize_atelier_sfc__compile__tests__compile_both_script_blocks.snap
@@ -6,7 +6,6 @@ expression: result.code.as_str()
 import { defineComponent as _defineComponent } from 'vue'
 import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock, Fragment as _Fragment, renderList as _renderList } from "vue"
 
-
 import type { RouteLocation } from "vue-router";
 
 interface TabItem {

--- a/crates/vize_atelier_sfc/src/compile/snapshots/vize_atelier_sfc__compile__tests__compile_both_script_blocks_exposes_normal_script_bindings_to_template.snap
+++ b/crates/vize_atelier_sfc/src/compile/snapshots/vize_atelier_sfc__compile__tests__compile_both_script_blocks_exposes_normal_script_bindings_to_template.snap
@@ -1,10 +1,10 @@
 ---
 source: crates/vize_atelier_sfc/src/compile/tests.rs
+assertion_line: 1210
 expression: result.code.as_str()
 ---
 import { defineComponent as _defineComponent } from 'vue'
 import { toDisplayString as _toDisplayString, normalizeClass as _normalizeClass, openBlock as _openBlock, createElementBlock as _createElementBlock, Fragment as _Fragment, renderList as _renderList } from "vue"
-
 
 import { ref } from "vue";
 

--- a/crates/vize_atelier_sfc/src/compile/tests.rs
+++ b/crates/vize_atelier_sfc/src/compile/tests.rs
@@ -1233,6 +1233,141 @@ function start() {
     );
 }
 
+/// #993: when both `<script>` and `<script setup>` import from the SAME module, the
+/// import must be emitted exactly once. Otherwise the module's top-level side effects run
+/// twice in the bundled output.
+#[test]
+fn test_dual_script_dedupes_shared_module_import() {
+    let source = r#"<script lang="ts">
+import { registerHotkey } from './hotkey-plugin'
+registerHotkey()
+</script>
+
+<script setup lang="ts">
+import { registerHotkey } from './hotkey-plugin'
+import { ref } from 'vue'
+const count = ref(0)
+registerHotkey()
+</script>
+
+<template>{{ count }}</template>"#;
+
+    let descriptor = parse_sfc(source, SfcParseOptions::default()).expect("Failed to parse SFC");
+    let opts = SfcCompileOptions {
+        script: ScriptCompileOptions {
+            is_ts: true,
+            ..Default::default()
+        },
+        template: TemplateCompileOptions {
+            is_ts: true,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let result = compile_sfc(&descriptor, opts).expect("Failed to compile SFC");
+    let code = result.code.as_str();
+
+    let occurrences = code.matches("from './hotkey-plugin'").count();
+    assert_eq!(
+        occurrences, 1,
+        "import from './hotkey-plugin' must appear exactly once, got {occurrences}:\n{code}"
+    );
+}
+
+/// #993: imports from DIFFERENT modules in the two blocks must both survive, each emitted
+/// exactly once.
+#[test]
+fn test_dual_script_keeps_distinct_module_imports() {
+    let source = r#"<script lang="ts">
+import { installPlugin } from './plugin'
+installPlugin()
+</script>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+const count = ref(0)
+</script>
+
+<template>{{ count }}</template>"#;
+
+    let descriptor = parse_sfc(source, SfcParseOptions::default()).expect("Failed to parse SFC");
+    let opts = SfcCompileOptions {
+        script: ScriptCompileOptions {
+            is_ts: true,
+            ..Default::default()
+        },
+        template: TemplateCompileOptions {
+            is_ts: true,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let result = compile_sfc(&descriptor, opts).expect("Failed to compile SFC");
+    let code = result.code.as_str();
+
+    assert_eq!(
+        code.matches("from './plugin'").count(),
+        1,
+        "normal-script import must appear exactly once:\n{code}"
+    );
+    assert_eq!(
+        code.matches("installPlugin").count(),
+        2,
+        "installPlugin should appear once in its import and once at the call site:\n{code}"
+    );
+    // `installPlugin()` (the call) must still flow through from the normal-script body.
+    assert!(
+        code.contains("installPlugin()"),
+        "normal-script side-effect call must be preserved:\n{code}"
+    );
+}
+
+/// #993: a module-scope side effect in the normal `<script>` block must appear exactly once
+/// in the output (it would run twice if the import line were duplicated).
+#[test]
+fn test_dual_script_side_effect_emitted_once() {
+    let source = r#"<script lang="ts">
+import { ref } from 'vue'
+console.log("once")
+const seed = ref(1)
+</script>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+const count = ref(0)
+void seed
+</script>
+
+<template>{{ count }}</template>"#;
+
+    let descriptor = parse_sfc(source, SfcParseOptions::default()).expect("Failed to parse SFC");
+    let opts = SfcCompileOptions {
+        script: ScriptCompileOptions {
+            is_ts: true,
+            ..Default::default()
+        },
+        template: TemplateCompileOptions {
+            is_ts: true,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let result = compile_sfc(&descriptor, opts).expect("Failed to compile SFC");
+    let code = result.code.as_str();
+
+    assert_eq!(
+        code.matches(r#"console.log("once")"#).count(),
+        1,
+        "module-scope side effect must be emitted exactly once:\n{code}"
+    );
+    // The shared `ref` import collapses to a single user statement.
+    assert_eq!(
+        code.matches("import { ref } from 'vue'").count(),
+        1,
+        "shared `ref` import must be deduplicated to one line:\n{code}"
+    );
+}
+
 #[test]
 fn test_script_setup_typescript_downcompiles_to_javascript_by_default() {
     let source = r#"<script setup lang="ts">

--- a/crates/vize_atelier_sfc/src/compile_script/inline/compiler/preamble.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/inline/compiler/preamble.rs
@@ -110,16 +110,24 @@ pub(super) fn emit_preamble(
         }
     }
 
-    // User imports (after hoisted consts) - deduplicate to avoid "already declared" errors
-    let deduped_imports = profile!(
-        "atelier.script_inline.dedupe_imports",
-        dedupe_imports(user_imports, is_ts)
-    );
+    // User imports (after hoisted consts) - deduplicate to avoid "already declared" errors.
+    //
+    // Imports from BOTH the normal `<script>` block and `<script setup>` are merged and
+    // deduplicated here. `dedupe_imports` keys on `source::local`, so an import that appears
+    // in both blocks (or the same side-effect import) is emitted exactly once. The normal
+    // script's own `import` statements are stripped from its preserved body below, so this is
+    // the single emission point for every user import. See #993 (side-effect imports running
+    // twice when an SFC has both `<script>` and `<script setup>`).
     let normal_script_imports = preserved_normal_script
         .map(|script| parse_script_content(script, is_ts).0)
         .unwrap_or_default();
-    let mut setup_return_imports = deduped_imports.clone();
-    setup_return_imports.extend(normal_script_imports.iter().cloned());
+    let mut combined_imports: Vec<String> = normal_script_imports;
+    combined_imports.extend_from_slice(user_imports);
+    let deduped_imports = profile!(
+        "atelier.script_inline.dedupe_imports",
+        dedupe_imports(&combined_imports, is_ts)
+    );
+    let setup_return_imports = deduped_imports.clone();
     if !deduped_imports.is_empty() && !template.hoisted.is_empty() {
         ensure_blank_line(output);
     }
@@ -146,8 +154,12 @@ pub(super) fn emit_preamble(
     // Normal script content goes AFTER imports/hoisted, BEFORE component definition
     // This matches Vue's @vue/compiler-sfc output order
     let has_default_export = if let Some(normal_script) = preserved_normal_script {
+        // Strip the block's own `import` statements: they were already merged into the
+        // deduplicated import emission above. Leaving them here would emit each import twice,
+        // re-running any top-level side effects in the imported module (#993).
+        let body = strip_import_statements(normal_script);
         output.push(b'\n');
-        output.extend_from_slice(normal_script.as_bytes());
+        output.extend_from_slice(body.as_bytes());
         output.push(b'\n');
         normal_script.contains("const __default__")
     } else {
@@ -158,6 +170,47 @@ pub(super) fn emit_preamble(
         setup_return_imports,
         has_default_export,
     }
+}
+
+/// Remove top-level `import` statements (single-line, multi-line, and side-effect forms)
+/// from a preserved `<script>` body, keeping every other line verbatim. Import detection
+/// mirrors the logic in [`parse_script_content`]; surrounding blank lines left behind by a
+/// removed leading/trailing import are trimmed so the emitted body keeps the same spacing
+/// the verbatim block had (the caller frames the body with its own newlines).
+fn strip_import_statements(content: &str) -> String {
+    let mut out = String::with_capacity(content.len());
+    let mut in_import = false;
+    for line in content.lines() {
+        let trimmed = line.trim();
+
+        if in_import {
+            // Continuation lines of a multi-line import: an import ends on a line that
+            // terminates with `;` or contains the `from` clause without a trailing comma.
+            if trimmed.ends_with(';') || (trimmed.contains(" from ") && !trimmed.ends_with(',')) {
+                in_import = false;
+            }
+            continue;
+        }
+
+        if trimmed.starts_with("import ") {
+            // Side-effect import (no `from`, single-line): `import './reset.css'`.
+            if !trimmed.contains(" from ") && (trimmed.contains('\'') || trimmed.contains('"')) {
+                continue;
+            }
+            // Single-line named/default import completes on this line.
+            if trimmed.ends_with(';') || (trimmed.contains(" from ") && !trimmed.ends_with(',')) {
+                continue;
+            }
+            // Otherwise the import spans multiple lines; skip until it closes.
+            in_import = true;
+            continue;
+        }
+
+        out.push_str(line);
+        out.push('\n');
+    }
+
+    out.trim_matches('\n').into()
 }
 
 fn ensure_blank_line(output: &mut vize_carton::Vec<u8>) {

--- a/tests/snapshots/sfc/ts/script_setup__script_with_type_definitions_and_script_setup.snap
+++ b/tests/snapshots/sfc/ts/script_setup__script_with_type_definitions_and_script_setup.snap
@@ -6,7 +6,6 @@ expression: ts_output.as_str()
 import { defineComponent as _defineComponent } from 'vue'
 import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock, Fragment as _Fragment, renderList as _renderList } from "vue"
 
-
 import type { RouteLocation } from "vue-router";
 
 interface TabItem {


### PR DESCRIPTION
Closes #993

## Problem

When an SFC has both a normal `<script>` block and a `<script setup>` block, the inline-script preamble emitted the normal block's body **verbatim** — including its `import` statements — while the same specifiers were *also* emitted through the deduplicated import path. Any import shared by both blocks ended up emitted twice, so a top-level side effect in the imported module (`registerHotkey()`, `installPlugin()`, pushing into a global registry) ran **twice** in the bundled output.

## Fix

`crates/vize_atelier_sfc/src/compile_script/inline/compiler/preamble.rs`:

- Merge the imports from **both** blocks into a single `dedupe_imports` call. `dedupe_imports` keys on `source::local`, so a shared specifier collapses to exactly one line, while distinct specifiers (even from the same module) all survive.
- Strip `import` statements from the preserved normal-script body (`strip_import_statements`) before appending it — they're now emitted once through the deduped path. Non-import statements still flow through unchanged.

This matches `@vue/compiler-sfc`, which hoists all imports to the top of the module.

## Tests

- `test_dual_script_dedupes_shared_module_import` — same import in both blocks → emitted once.
- `test_dual_script_keeps_distinct_module_imports` — different modules → both survive, each once; the side-effect call is preserved.
- `test_dual_script_side_effect_emitted_once` — a module-scope `console.log("once")` appears exactly once.

Refreshed the two dual-block snapshots + one TS snapshot to reflect imports hoisting to module top. Full `vize_atelier_sfc` suite green (456 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/998"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783176989&installation_id=136613492&pr_number=998&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F998&signature=7f423ef4fcb08acc82957e9bcb5119d7ca4178b97f5b94cfe0ecba957c3d03d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->