### PR TITLE
fix(dom): reset namespace at SVG/MathML HTML integration points (#992)

### DIFF
--- a/crates/vize_atelier_dom/src/lib.rs
+++ b/crates/vize_atelier_dom/src/lib.rs
@@ -196,7 +196,12 @@ fn compile_template_inner<'a>(
     (root, errors.to_vec(), codegen_result)
 }
 
-/// Get the namespace for an element based on its parent
+/// Get the namespace for an element based on its parent.
+///
+/// Mirrors the HTML tree-construction namespace rules used by `@vue/compiler-dom`: a tag
+/// that names a foreign root (`<svg>`/`<math>`) always (re)enters that namespace, otherwise
+/// the element inherits its parent's namespace — except across the HTML integration points
+/// where SVG/MathML hand their descendants back to the HTML namespace.
 fn get_namespace(tag: &str, parent: Option<&str>) -> Namespace {
     if vize_carton::is_svg_tag(tag) {
         return Namespace::Svg;
@@ -205,15 +210,19 @@ fn get_namespace(tag: &str, parent: Option<&str>) -> Namespace {
         return Namespace::MathMl;
     }
 
-    // Inherit namespace from parent
+    // Inherit namespace from the parent, honouring the integration-point boundaries.
     if let Some(parent_tag) = parent {
-        if vize_carton::is_svg_tag(parent_tag) && tag != "foreignObject" {
+        // Inside SVG, <foreignObject>/<desc>/<title> switch their descendants back to HTML
+        // (e.g. a <div> inside <foreignObject> must NOT be in the SVG namespace).
+        let svg_to_html = matches!(parent_tag, "foreignObject" | "desc" | "title");
+        if vize_carton::is_svg_tag(parent_tag) && !svg_to_html {
             return Namespace::Svg;
         }
-        if vize_carton::is_math_ml_tag(parent_tag)
-            && tag != "annotation-xml"
-            && tag != "foreignObject"
-        {
+        // Inside MathML, <annotation-xml> and the text containers (<mi>/<mo>/<mn>/<ms>/
+        // <mtext>) are HTML integration points; their descendants are HTML.
+        let mathml_to_html =
+            matches!(parent_tag, "annotation-xml" | "mi" | "mo" | "mn" | "ms" | "mtext");
+        if vize_carton::is_math_ml_tag(parent_tag) && !mathml_to_html {
             return Namespace::MathMl;
         }
     }
@@ -281,6 +290,139 @@ mod tests {
             !code.contains("_mergeProps({ }") && !code.contains("_mergeProps({  }"),
             "no empty object literal should be flushed into mergeProps:\n{code}"
         );
+    }
+
+    /// Recursively find the first element with the given tag, descending through `v-if`
+    /// branches and `v-for` bodies so the search works on the transformed tree as well.
+    fn find_element<'a, 'b>(
+        children: &'b [TemplateChildNode<'a>],
+        tag: &str,
+    ) -> Option<&'b super::ast::ElementNode<'a>> {
+        for child in children {
+            match child {
+                TemplateChildNode::Element(el) => {
+                    if el.tag.as_str() == tag {
+                        return Some(el);
+                    }
+                    if let Some(found) = find_element(&el.children, tag) {
+                        return Some(found);
+                    }
+                }
+                TemplateChildNode::If(node) => {
+                    for branch in &node.branches {
+                        if let Some(found) = find_element(&branch.children, tag) {
+                            return Some(found);
+                        }
+                    }
+                }
+                TemplateChildNode::IfBranch(branch) => {
+                    if let Some(found) = find_element(&branch.children, tag) {
+                        return Some(found);
+                    }
+                }
+                TemplateChildNode::For(node) => {
+                    if let Some(found) = find_element(&node.children, tag) {
+                        return Some(found);
+                    }
+                }
+                _ => {}
+            }
+        }
+        None
+    }
+
+    /// #992: the SVG namespace must propagate from `<svg>` into every descendant so the
+    /// runtime mounts them with `setAttributeNS`/the SVG namespace URI. This locks the
+    /// parser-side propagation that codegen relies on (vize, like @vue/compiler-sfc, emits
+    /// no namespace argument and depends on the runtime inferring it from a contiguous tree).
+    #[test]
+    fn test_svg_namespace_propagates_to_descendants() {
+        let allocator = Bump::new();
+        let (root, errors, _) = compile_template(
+            &allocator,
+            "<svg><g><path d=\"M0 0\"/></g><rect x=\"0\" y=\"0\"/></svg>",
+        );
+        assert!(errors.is_empty());
+
+        let svg = find_element(&root.children, "svg").expect("svg present");
+        assert_eq!(svg.ns, Namespace::Svg);
+        assert_eq!(
+            find_element(&root.children, "g").unwrap().ns,
+            Namespace::Svg,
+            "direct child <g> inherits svg namespace"
+        );
+        assert_eq!(
+            find_element(&root.children, "path").unwrap().ns,
+            Namespace::Svg,
+            "nested <path> keeps svg namespace"
+        );
+        assert_eq!(
+            find_element(&root.children, "rect").unwrap().ns,
+            Namespace::Svg,
+            "sibling <rect> inherits svg namespace"
+        );
+    }
+
+    /// #992: `<foreignObject>` is the one boundary where the SVG namespace must NOT
+    /// propagate further — its HTML descendants go back to the HTML namespace, while a
+    /// `<rect>` sibling after the `<foreignObject>` stays in the SVG namespace.
+    #[test]
+    fn test_svg_foreign_object_resets_namespace() {
+        let allocator = Bump::new();
+        let (root, errors, _) = compile_template(
+            &allocator,
+            "<svg><foreignObject><div>hi</div></foreignObject><rect x=\"1\" y=\"1\"/></svg>",
+        );
+        assert!(errors.is_empty());
+
+        assert_eq!(
+            find_element(&root.children, "foreignObject").unwrap().ns,
+            Namespace::Svg,
+            "<foreignObject> itself is in the svg namespace"
+        );
+        assert_eq!(
+            find_element(&root.children, "div").unwrap().ns,
+            Namespace::Html,
+            "<div> inside <foreignObject> returns to the HTML namespace"
+        );
+        assert_eq!(
+            find_element(&root.children, "rect").unwrap().ns,
+            Namespace::Svg,
+            "<rect> after <foreignObject> is still in the svg namespace"
+        );
+    }
+
+    /// #992: namespace propagation must survive the codegen shapes that could otherwise
+    /// detach a child from its `<svg>` ancestor in the vnode tree — a `v-if` branch
+    /// (re-entered via `createElementBlock`) keeps the `<rect>` nested inside the `<svg>`
+    /// element call, so the runtime still threads the svg namespace into it.
+    #[test]
+    fn test_svg_namespace_with_v_if_branch() {
+        let allocator = Bump::new();
+        let (root, errors, _) =
+            compile_template(&allocator, "<svg><rect v-if=\"show\" x=\"0\" y=\"0\"/></svg>");
+        assert!(errors.is_empty());
+        assert_eq!(
+            find_element(&root.children, "rect").unwrap().ns,
+            Namespace::Svg,
+            "v-if <rect> still carries the svg namespace"
+        );
+    }
+
+    /// #992: lock the emitted shape for an SVG tree with a `<foreignObject>` exit. The SVG
+    /// children must stay nested inside the `<svg>` `createElementVNode`/`createElementBlock`
+    /// call so the runtime threads the SVG namespace into them at patch time (vize, like
+    /// @vue/compiler-sfc, emits no explicit namespace argument).
+    #[test]
+    fn test_svg_codegen_shape_keeps_children_nested() {
+        let allocator = Bump::new();
+        let (_, errors, result) = compile_template(
+            &allocator,
+            "<svg><foreignObject><div>hi</div></foreignObject><rect x=\"1\" y=\"1\"/></svg>",
+        );
+        assert!(errors.is_empty());
+        let full = full_output(&result.preamble, &result.code);
+        insta::assert_snapshot!(full.as_str());
     }
 
     #[test]

--- a/crates/vize_atelier_dom/src/lib.rs
+++ b/crates/vize_atelier_dom/src/lib.rs
@@ -220,8 +220,10 @@ fn get_namespace(tag: &str, parent: Option<&str>) -> Namespace {
         }
         // Inside MathML, <annotation-xml> and the text containers (<mi>/<mo>/<mn>/<ms>/
         // <mtext>) are HTML integration points; their descendants are HTML.
-        let mathml_to_html =
-            matches!(parent_tag, "annotation-xml" | "mi" | "mo" | "mn" | "ms" | "mtext");
+        let mathml_to_html = matches!(
+            parent_tag,
+            "annotation-xml" | "mi" | "mo" | "mn" | "ms" | "mtext"
+        );
         if vize_carton::is_math_ml_tag(parent_tag) && !mathml_to_html {
             return Namespace::MathMl;
         }
@@ -399,8 +401,10 @@ mod tests {
     #[test]
     fn test_svg_namespace_with_v_if_branch() {
         let allocator = Bump::new();
-        let (root, errors, _) =
-            compile_template(&allocator, "<svg><rect v-if=\"show\" x=\"0\" y=\"0\"/></svg>");
+        let (root, errors, _) = compile_template(
+            &allocator,
+            "<svg><rect v-if=\"show\" x=\"0\" y=\"0\"/></svg>",
+        );
         assert!(errors.is_empty());
         assert_eq!(
             find_element(&root.children, "rect").unwrap().ns,

--- a/crates/vize_atelier_dom/src/snapshots/vize_atelier_dom__tests__svg_codegen_shape_keeps_children_nested.snap
+++ b/crates/vize_atelier_dom/src/snapshots/vize_atelier_dom__tests__svg_codegen_shape_keeps_children_nested.snap
@@ -1,0 +1,18 @@
+---
+source: crates/vize_atelier_dom/src/lib.rs
+assertion_line: 402
+expression: full.as_str()
+---
+const { createElementVNode: _createElementVNode, openBlock: _openBlock, createElementBlock: _createElementBlock } = Vue
+
+function render(_ctx, _cache, $props, $setup, $data, $options) {
+  return (_openBlock(), _createElementBlock("svg", null, [
+    _createElementVNode("foreignObject", null, [
+      _createElementVNode("div", null, "hi")
+    ]),
+    _createElementVNode("rect", {
+      x: "1",
+      y: "1"
+    })
+  ]))
+}


### PR DESCRIPTION
Closes #992

## Investigation

#992 hypothesised that vize children of `<svg>` render blank because codegen never consumes the namespace. I verified the runtime behaviour directly: compiling representative SVG templates and mounting vize's output through Vue's own renderer with a namespace-recording `nodeOps`. In **every** shape — simple `svg>rect`, `v-if` branch, `_cache`-spread, component-slot bridge, module-hoisted vnode, and the `<foreignObject>` exit — the runtime threads the correct namespace (`rect` → `svg`, `<div>` inside `<foreignObject>` → HTML). vize, exactly like `@vue/compiler-sfc`, emits **no** namespace argument and relies on the runtime inferring it from the contiguous vnode tree, which vize's output preserves. So the "blank rect" does **not** reproduce through the namespace path.

## The real bug found

Writing the regression guards surfaced a genuine AST bug: `get_namespace` keyed the SVG-inheritance decision on the **child** tag (`tag != "foreignObject"`) instead of the **parent**. Since `is_svg_tag("foreignObject")` is true, a `<div>` inside `<foreignObject>` was tagged `Namespace::Svg` instead of returning to HTML. The MathML branch had the same shape.

`crates/vize_atelier_dom/src/lib.rs` — `get_namespace` now inherits the parent namespace and applies the HTML integration-point boundaries on the **parent**:
- SVG → HTML across `<foreignObject>` / `<desc>` / `<title>`
- MathML → HTML across `<annotation-xml>` / `<mi>` / `<mo>` / `<mn>` / `<ms>` / `<mtext>`
- `<svg>` / `<math>` still (re)enter their namespace anywhere.

`el.ns` is currently AST-only metadata (no codegen consumer), so emitted code is unchanged — but the metadata now matches `@vue/compiler-dom`, and the boundary is correct for the `custom_renderer` path that reads parent `ns`.

## Tests

- `test_svg_namespace_propagates_to_descendants` — `<g>`/`<path>`/sibling `<rect>` inherit svg.
- `test_svg_foreign_object_resets_namespace` — `<div>` inside `<foreignObject>` → HTML, `<rect>` after it → svg (was failing before the fix).
- `test_svg_namespace_with_v_if_branch` — v-if `<rect>` keeps svg.
- `test_svg_codegen_shape_keeps_children_nested` — snapshot locking that SVG children stay nested inside the `<svg>` element call.

Full `vize_atelier_dom` / `vize_armature` / `vize_atelier_ssr` / `vize_atelier_core` / `vize_atelier_vapor` suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/999"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783178364&installation_id=136613492&pr_number=999&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F999&signature=a95158dada228be7c72857f7352798b60bf527a3013f74d17f0f6ac97b72df52"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->