### PR TITLE
fix(codegen): drop empty object before v-bind on dynamic component

### DIFF
--- a/crates/vize_atelier_core/src/codegen/props/generate.rs
+++ b/crates/vize_atelier_core/src/codegen/props/generate.rs
@@ -69,7 +69,18 @@ pub fn generate_props(ctx: &mut CodegenContext, props: &[PropNode<'_>]) {
                     let has_renderable = segment.iter().any(|p| match p {
                         PropNode::Attribute(attr) => !(ctx.skip_is_prop && attr.name == "is"),
                         PropNode::Directive(dir) => {
-                            !(dir.arg.is_none() && (dir.name == "bind" || dir.name == "on"))
+                            // A `:is`/`v-bind:is` directive on a dynamic component is consumed
+                            // as the component tag and skipped during generation (mirrors the
+                            // skip_is_prop branch in generate_props_object_inner). It must not
+                            // count as renderable, or an empty `{}` is flushed into mergeProps.
+                            let is_skipped_is = ctx.skip_is_prop
+                                && dir.name == "bind"
+                                && matches!(
+                                    &dir.arg,
+                                    Some(ExpressionNode::Simple(exp)) if exp.content == "is"
+                                );
+                            !is_skipped_is
+                                && !(dir.arg.is_none() && (dir.name == "bind" || dir.name == "on"))
                                 && is_supported_directive(dir)
                                 && dir.name != "slot"
                         }

--- a/crates/vize_atelier_dom/src/lib.rs
+++ b/crates/vize_atelier_dom/src/lib.rs
@@ -260,6 +260,29 @@ mod tests {
         }
     }
 
+    /// A dynamic component whose `:is` is written as `v-bind:is` must not flush an empty
+    /// `{}` segment into `mergeProps`: `:is` is consumed as the component tag, so the first
+    /// real merge argument is the `v-bind="obj"` spread — matching @vue/compiler-dom's
+    /// `_mergeProps(obj, { ... })` rather than `_mergeProps({}, obj, { ... })`.
+    #[test]
+    fn test_dynamic_component_vbind_is_no_empty_merge_object() {
+        let allocator = Bump::new();
+        let (_, errors, result) = compile_template(
+            &allocator,
+            r#"<component :is="popup.component" v-bind="popup.props" :key="popup.id" @closed="onClose"/>"#,
+        );
+        assert!(errors.is_empty());
+        let code = result.code.as_str();
+        assert!(
+            code.contains("_mergeProps(popup.props, {"),
+            "merge should start with the spread, not an empty object:\n{code}"
+        );
+        assert!(
+            !code.contains("_mergeProps({ }") && !code.contains("_mergeProps({  }"),
+            "no empty object literal should be flushed into mergeProps:\n{code}"
+        );
+    }
+
     #[test]
     fn test_compile_with_options() {
         let allocator = Bump::new();


### PR DESCRIPTION
Surfaced by the Misskey build in discussion #71.

## Problem

A dynamic component written with `v-bind:is`:

```vue
<component :is="popup.component" v-bind="popup.props" :key="popup.id" @closed="onClose"/>
```

compiled to `_mergeProps({ }, popup.props, { key, onClosed })` — an empty object literal flushed ahead of the spread — instead of `@vue/compiler-dom`'s `_mergeProps(popup.props, { key, onClosed })`. (Valid JS, but a parity divergence; the older plugin version in #71 produced an outright parse error for related shapes, since fixed.)

## Cause

`:is` is consumed as the component tag and skipped during prop generation (`skip_is_prop`). But the `has_renderable` guard in `generate_props` that decides whether to flush an accumulated prop object into `mergeProps` only recognised the **attribute** form (`is="..."`), not the `v-bind:is` **directive** form. So the leading segment holding only `:is` was judged renderable and flushed as an empty `{}`.

## Fix

`crates/vize_atelier_core/src/codegen/props/generate.rs` — mirror the `skip_is_prop` skip in `has_renderable`: a `bind:is` directive on a dynamic component no longer counts as renderable.

`vize inspector --format compare` now reports `changed: false` for this template. Adds a regression test (`test_dynamic_component_vbind_is_no_empty_merge_object`); `vize_atelier_core` / `vize_atelier_dom` suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1000"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783178987&installation_id=136613492&pr_number=1000&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1000&signature=2055c6f2d8f2ad862b3547fe2c1955c8c6645ac4f458c30bf18df71cd0e3afe4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->