### PR TITLE
feat(playground): copy environment information

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
       "devalue": "5.8.1",
       "dompurify": "3.4.5",
       "h3": "1.15.11",
+      "hono": "4.12.21",
       "nanotar": "0.3.0",
       "nitropack": "2.13.4",
       "node-forge": "1.4.0",

--- a/playground/src/App.vue
+++ b/playground/src/App.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ref, computed, watch, onMounted, shallowRef, provide } from "vue";
+import { mdiClipboardTextOutline } from "@mdi/js";
 import { loadWasm } from "./wasm/index";
 import AtelierPlayground from "./features/atelier/AtelierPlayground.vue";
 import MuseaPlayground from "./features/musea/MuseaPlayground.vue";
@@ -9,6 +10,8 @@ import CroquisPlayground from "./features/croquis/CroquisPlayground.vue";
 import CrossFilePlayground from "./features/cross-file/CrossFilePlayground.vue";
 import TypeCheckPlayground from "./features/canon/TypeCheckPlayground.vue";
 import InspectorPlayground from "./features/inspector/InspectorPlayground.vue";
+import { getPlaygroundEnvironmentInfo } from "./utils/environment";
+import { useClipboard } from "./utils/useClipboard";
 
 // Theme toggle
 const isDark = ref(false);
@@ -18,6 +21,9 @@ function toggleTheme() {
   isDark.value = !isDark.value;
   document.body.dataset.theme = isDark.value ? "dark" : "";
 }
+
+const vizeVersionLabel = ` v${__VIZE_VERSION__}`;
+const { copyToClipboard } = useClipboard();
 
 // Main tab
 type MainTab =
@@ -61,7 +67,21 @@ watch(mainTab, (newTab) => {
 const wasmStatus = ref<"loading" | "ready" | "mock">("loading");
 const compiler = shallowRef<Awaited<ReturnType<typeof loadWasm>> | null>(null);
 
+function copyEnvironmentInfo() {
+  copyToClipboard(
+    getPlaygroundEnvironmentInfo({
+      tab: mainTab.value,
+      wasmStatus: wasmStatus.value,
+    }),
+  );
+}
+
+function updateVersionLabel() {
+  document.getElementById("vize-playground-version")?.replaceChildren(vizeVersionLabel);
+}
+
 onMounted(async () => {
+  updateVersionLabel();
   try {
     const loaded = await loadWasm();
     compiler.value = loaded;
@@ -97,6 +117,7 @@ onMounted(async () => {
                     : " (WASM)"
               }}
             </span>
+            <span id="vize-playground-version" class="version-number"></span>
           </span>
         </div>
       </div>
@@ -149,6 +170,17 @@ onMounted(async () => {
       </div>
 
       <div class="options">
+        <button
+          class="theme-toggle"
+          title="Copy environment information"
+          aria-label="Copy environment information"
+          @click="copyEnvironmentInfo"
+        >
+          <svg viewBox="0 0 24 24" width="18" height="18" aria-hidden="true">
+            <path :d="mdiClipboardTextOutline" fill="currentColor" />
+          </svg>
+        </button>
+
         <button
           class="theme-toggle"
           :title="isDark ? 'Light mode' : 'Dark mode'"

--- a/playground/src/env.d.ts
+++ b/playground/src/env.d.ts
@@ -13,3 +13,4 @@ interface Window {
 }
 
 declare const self: Window & typeof globalThis;
+declare const __VIZE_VERSION__: string;

--- a/playground/src/utils/environment.ts
+++ b/playground/src/utils/environment.ts
@@ -1,0 +1,29 @@
+export interface PlaygroundEnvironmentOptions {
+  tab: string;
+  wasmStatus: string;
+}
+
+export function getPlaygroundEnvironmentInfo(options: PlaygroundEnvironmentOptions): string {
+  const { navigator, screen } = window;
+  const userAgentData = "userAgentData" in navigator ? navigator.userAgentData : undefined;
+  const platform =
+    typeof userAgentData === "object" &&
+    userAgentData !== null &&
+    "platform" in userAgentData &&
+    typeof userAgentData.platform === "string"
+      ? userAgentData.platform
+      : navigator.platform;
+
+  return [
+    `Vize: ${__VIZE_VERSION__}`,
+    `Playground URL: ${window.location.href}`,
+    `Active tab: ${options.tab}`,
+    `WASM status: ${options.wasmStatus}`,
+    `User agent: ${navigator.userAgent}`,
+    `Platform: ${platform || "unknown"}`,
+    `Language: ${navigator.language || "unknown"}`,
+    `Viewport: ${window.innerWidth}x${window.innerHeight}`,
+    `Screen: ${screen.width}x${screen.height}`,
+    `Device pixel ratio: ${window.devicePixelRatio}`,
+  ].join("\n");
+}

--- a/playground/vite.app.config.ts
+++ b/playground/vite.app.config.ts
@@ -1,8 +1,15 @@
+import { createRequire } from "node:module";
 import { defineConfig } from "vite-plus";
 import { vize } from "@vizejs/vite-plugin";
 
+const require = createRequire(import.meta.url);
+const vizePackage = require("../npm/vize/package.json") as { version: string };
+
 export default defineConfig({
   base: process.env.CI ? "/play/" : "/",
+  define: {
+    __VIZE_VERSION__: JSON.stringify(vizePackage.version),
+  },
   plugins: [vize({ vapor: true })],
   resolve: {
     alias: [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -202,6 +202,7 @@ overrides:
   devalue: 5.8.1
   dompurify: 3.4.5
   h3: 1.15.11
+  hono: 4.12.21
   nanotar: 0.3.0
   nitropack: 2.13.4
   node-forge: 1.4.0
@@ -1943,7 +1944,7 @@ packages:
     resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
-      hono: ^4
+      hono: 4.12.21
 
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
@@ -7544,8 +7545,8 @@ packages:
   hoist-non-react-statics@3.3.2:
     resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
 
-  hono@4.12.18:
-    resolution: {integrity: sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==}
+  hono@4.12.21:
+    resolution: {integrity: sha512-uV63apnb0kyPtAUwoWgaGh9HyIFcv8lgmzPZSiTBQAFOFGIzka5EZ1dZocmGnn0XdX0+XTqJ6Tqv7selMuGLRQ==}
     engines: {node: '>=16.9.0'}
 
   hookable@5.5.3:
@@ -11462,9 +11463,9 @@ snapshots:
     dependencies:
       tailwindcss: 3.4.19(tsx@4.21.0)(yaml@2.9.0)
 
-  '@hono/node-server@1.19.14(hono@4.12.18)':
+  '@hono/node-server@1.19.14(hono@4.12.21)':
     dependencies:
-      hono: 4.12.18
+      hono: 4.12.21
 
   '@humanfs/core@0.19.2':
     dependencies:
@@ -11788,7 +11789,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.29.0(zod@3.25.76)':
     dependencies:
-      '@hono/node-server': 1.19.14(hono@4.12.18)
+      '@hono/node-server': 1.19.14(hono@4.12.21)
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
       content-type: 1.0.5
@@ -11798,7 +11799,7 @@ snapshots:
       eventsource-parser: 3.0.8
       express: 5.2.1
       express-rate-limit: 8.5.1(express@5.2.1)
-      hono: 4.12.18
+      hono: 4.12.21
       jose: 6.2.3
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -17080,7 +17081,7 @@ snapshots:
     dependencies:
       react-is: 16.13.1
 
-  hono@4.12.18: {}
+  hono@4.12.21: {}
 
   hookable@5.5.3: {}
 


### PR DESCRIPTION
## Summary
- show the current vize version in the Playground header
- add a header action that copies environment details useful for bug reports
- source the version from npm/vize/package.json at build time

Closes #1004

## Verification
- corepack pnpm --filter ./playground exec vp check src/App.vue src/env.d.ts src/styles.css src/utils/environment.ts vite.app.config.ts
- corepack pnpm --filter ./playground build
- git diff --check
- Browser: verified header version and copied environment payload on http://localhost:5181/?tab=inspector

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1007"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783227951&installation_id=136613492&pr_number=1007&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1007&signature=d0dca8382edcb56a436f3038b3f98efb97443a7b818e6a7af6976bec625e063b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->