### PR TITLE
fix: preserve need patch for scroll refs

### DIFF
--- a/crates/vize_atelier_core/src/codegen/patch_flag.rs
+++ b/crates/vize_atelier_core/src/codegen/patch_flag.rs
@@ -455,12 +455,16 @@ fn calculate_element_patch_info_inner(
         }
     }
 
-    // Add NEED_PATCH for v-show, custom directives, or ref only if no other dynamic bindings exist
+    // Add NEED_PATCH for v-show, custom directives, v-model, or refs when no
+    // normal prop patch flag will already force runtime patching. Vue still
+    // combines NEED_PATCH with TEXT and NEED_HYDRATION because neither updates
+    // refs/directives on its own.
     // Custom directives only need NEED_PATCH when the element has no children
     // (children already cause the element to be tracked for patching by the runtime)
-    // This must come after TEXT flag check so we don't add NEED_PATCH when TEXT is about to be set
     let custom_dir_needs_patch = has_custom_directive && el.children.is_empty();
-    if (has_vshow || has_vmodel || custom_dir_needs_patch || has_ref) && flag == 0 {
+    let has_normal_prop_patch_flag = flag & (2 | 4 | 8 | 16) != 0;
+    if (has_vshow || has_vmodel || custom_dir_needs_patch || has_ref) && !has_normal_prop_patch_flag
+    {
         flag |= 512; // NEED_PATCH
     }
 

--- a/crates/vize_atelier_core/src/codegen/v_for/generate.rs
+++ b/crates/vize_atelier_core/src/codegen/v_for/generate.rs
@@ -30,6 +30,13 @@ use super::super::{
 use super::helpers::{get_element_key, has_other_props, should_skip_prop};
 use vize_carton::ToCompactString;
 
+fn strip_need_patch_for_v_for_item(patch_flag: Option<i32>) -> Option<i32> {
+    patch_flag.and_then(|flag| {
+        let next = flag & !512;
+        (next > 0).then_some(next)
+    })
+}
+
 /// Generate item for v-for (as block, not regular vnode)
 pub fn generate_for_item(ctx: &mut CodegenContext, node: &TemplateChildNode<'_>, is_stable: bool) {
     match node {
@@ -288,6 +295,7 @@ pub fn generate_for_item(ctx: &mut CodegenContext, node: &TemplateChildNode<'_>,
                         let dynamic_slots_flag = 1024;
                         patch_flag = Some(patch_flag.unwrap_or(0) | dynamic_slots_flag);
                     }
+                    patch_flag = strip_need_patch_for_v_for_item(patch_flag);
                     if el.children.is_empty() && (patch_flag.is_some() || dynamic_props.is_some()) {
                         ctx.push(", null");
                     }
@@ -320,6 +328,7 @@ pub fn generate_for_item(ctx: &mut CodegenContext, node: &TemplateChildNode<'_>,
                         ctx.options.binding_metadata.as_ref(),
                         ctx.cache_handlers_in_current_scope(),
                     );
+                    let patch_flag = strip_need_patch_for_v_for_item(patch_flag);
                     if let Some(flag) = patch_flag {
                         ctx.push(", ");
                         ctx.push(&flag.to_compact_string());

--- a/crates/vize_atelier_dom/src/lib.rs
+++ b/crates/vize_atelier_dom/src/lib.rs
@@ -526,6 +526,75 @@ mod tests {
     }
 
     #[test]
+    fn test_ref_scroll_keeps_need_patch_with_need_hydration() {
+        use vize_atelier_core::options::{BindingMetadata, BindingType};
+        use vize_carton::FxHashMap;
+
+        let allocator = Bump::new();
+        let mut bindings = FxHashMap::default();
+        bindings.insert("onScroll".into(), BindingType::SetupConst);
+
+        let options = DomCompilerOptions {
+            mode: CodegenMode::Module,
+            prefix_identifiers: true,
+            inline: true,
+            cache_handlers: true,
+            binding_metadata: Some(BindingMetadata {
+                bindings,
+                props_aliases: FxHashMap::default(),
+                is_script_setup: true,
+            }),
+            ..Default::default()
+        };
+
+        let (_, errors, result) = compile_template_with_options(
+            &allocator,
+            r#"<div ref="container" @scroll="onScroll"></div>"#,
+            options,
+        );
+
+        assert!(errors.is_empty(), "Errors: {:?}", errors);
+        let full = full_output(&result.preamble, &result.code);
+        assert!(
+            full.contains("544 /* NEED_HYDRATION, NEED_PATCH */"),
+            "{full}"
+        );
+    }
+
+    #[test]
+    fn test_ref_text_keeps_need_patch_with_text_flag() {
+        use vize_atelier_core::options::{BindingMetadata, BindingType};
+        use vize_carton::FxHashMap;
+
+        let allocator = Bump::new();
+        let mut bindings = FxHashMap::default();
+        bindings.insert("message".into(), BindingType::SetupRef);
+
+        let options = DomCompilerOptions {
+            mode: CodegenMode::Module,
+            prefix_identifiers: true,
+            inline: true,
+            cache_handlers: true,
+            binding_metadata: Some(BindingMetadata {
+                bindings,
+                props_aliases: FxHashMap::default(),
+                is_script_setup: true,
+            }),
+            ..Default::default()
+        };
+
+        let (_, errors, result) = compile_template_with_options(
+            &allocator,
+            r#"<div ref="container">{{ message }}</div>"#,
+            options,
+        );
+
+        assert!(errors.is_empty(), "Errors: {:?}", errors);
+        let full = full_output(&result.preamble, &result.code);
+        assert!(full.contains("513 /* TEXT, NEED_PATCH */"), "{full}");
+    }
+
+    #[test]
     fn test_inline_hoisted_bare_static_attrs_are_empty_strings() {
         let allocator = Bump::new();
         let options = DomCompilerOptions {

--- a/crates/vize_atelier_sfc/src/compile/tests.rs
+++ b/crates/vize_atelier_sfc/src/compile/tests.rs
@@ -851,6 +851,40 @@ const activeTab = ref<'a' | 'b'>('a');
 }
 
 #[test]
+fn test_script_setup_scroll_ref_keeps_need_patch_with_need_hydration() {
+    let source = r#"<script setup lang="ts">
+import { nextTick, onMounted, ref } from 'vue';
+
+const container = ref<HTMLElement | null>(null);
+
+function onScroll() {
+  console.log(container.value?.scrollTop ?? 0);
+}
+
+onMounted(async () => {
+  await nextTick();
+  container.value?.scrollTo({ top: 240 });
+});
+</script>
+
+<template>
+  <div ref="container" class="piano-roll" @scroll="onScroll">
+    <div v-for="note in 88" :key="note" class="key">{{ note }}</div>
+  </div>
+</template>"#;
+
+    let descriptor = parse_sfc(source, SfcParseOptions::default()).expect("Failed to parse SFC");
+    let result =
+        compile_sfc(&descriptor, SfcCompileOptions::default()).expect("Failed to compile SFC");
+
+    assert!(
+        result.code.contains("544") && result.code.contains("NEED_HYDRATION, NEED_PATCH"),
+        "{}",
+        result.code
+    );
+}
+
+#[test]
 fn test_inline_component_dynamic_prop_keeps_props_patch_flag() {
     let source = r#"<script setup lang="ts">
 import { ref } from 'vue';


### PR DESCRIPTION
## Summary
- preserve NEED_PATCH when refs/directives only had TEXT or NEED_HYDRATION flags
- keep v-for branch roots aligned with Vue by stripping NEED_PATCH there
- add DOM and SFC regressions for ref + @scroll + mounted scrollTo-style usage

Fixes #996

## Verification
- cargo test -p vize_atelier_core
- cargo test -p vize_atelier_dom
- cargo test -p vize_atelier_sfc
- cargo run -p vize_test_runner --bin coverage -- -vv
- cargo fmt --check
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1009"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783230674&installation_id=136613492&pr_number=1009&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1009&signature=a306b9c2179dce83c16e1f1366f0812018c14569889bd54a32fabd787cd1b6ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->