### PR TITLE
fix: align Vue codegen for VOICEVOX

### DIFF
--- a/crates/vize/tests/check_cli.rs
+++ b/crates/vize/tests/check_cli.rs
@@ -1875,6 +1875,89 @@ const count =
     let _ = std::fs::remove_dir_all(&project_root);
 }
 
+#[test]
+fn check_define_emits_quoted_colon_key_accepts_valid_payload_and_reports_invalid_payload() {
+    let Some(corsa_path) = resolve_test_corsa_path() else {
+        return;
+    };
+    let project_root = create_cli_project(
+        "define-emits-quoted-colon-key",
+        &[
+            (
+                "src/Good.vue",
+                r#"<script setup lang="ts">
+const emit = defineEmits<{
+  "update:open": [value: boolean]
+}>()
+
+emit("update:open", true)
+</script>
+"#,
+            ),
+            (
+                "src/Bad.vue",
+                r#"<script setup lang="ts">
+const emit = defineEmits<{
+  "update:open": [value: boolean]
+}>()
+
+emit("update:open", "bad")
+</script>
+"#,
+            ),
+        ],
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(&project_root)
+        .env("CORSA_PATH", corsa_path)
+        .args([
+            "check",
+            "src",
+            "--tsconfig",
+            "tsconfig.json",
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+
+    let stdout = std::string::String::from_utf8(output.stdout).unwrap();
+    let stderr = std::string::String::from_utf8(output.stderr).unwrap();
+    let json: serde_json::Value = serde_json::from_str(&stdout).unwrap_or_else(|error| {
+        panic!("failed to parse stdout as JSON: {error}\nstdout:\n{stdout}\nstderr:\n{stderr}")
+    });
+    let files = json["files"].as_array().unwrap();
+    let diagnostics: Vec<_> = files
+        .iter()
+        .flat_map(|file| file["diagnostics"].as_array().unwrap().iter())
+        .filter_map(|diagnostic| diagnostic.as_str())
+        .collect();
+    let bad_file = files
+        .iter()
+        .find(|file| file["file"] == "src/Bad.vue")
+        .expect("Bad.vue should be present");
+    let good_file = files
+        .iter()
+        .find(|file| file["file"] == "src/Good.vue")
+        .expect("Good.vue should be present");
+
+    assert_eq!(output.status.code(), Some(1), "stderr:\n{stderr}");
+    assert_eq!(json["errorCount"], 1, "diagnostics: {diagnostics:#?}");
+    assert_eq!(bad_file["diagnostics"].as_array().unwrap().len(), 1);
+    assert_eq!(good_file["diagnostics"].as_array().unwrap().len(), 0);
+    assert!(
+        diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.contains("[TS2345]")
+                && diagnostic.contains("string")
+                && diagnostic.contains("boolean")),
+        "expected invalid payload diagnostic, got: {diagnostics:#?}"
+    );
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}
+
 #[cfg(unix)]
 #[test]
 fn check_socket_json_preserves_json_output_contract() {

--- a/crates/vize_atelier_core/src/codegen/element/block.rs
+++ b/crates/vize_atelier_core/src/codegen/element/block.rs
@@ -3,9 +3,7 @@
 //! Generates elements that open a new block scope using `openBlock()` and
 //! `createElementBlock()` / `createBlock()` for efficient patching.
 
-use crate::ast::{
-    ElementNode, ElementType, ExpressionNode, PropNode, RuntimeHelper, TemplateChildNode,
-};
+use crate::ast::{ElementNode, ElementType, ExpressionNode, PropNode, RuntimeHelper};
 use crate::transforms::v_memo::{get_memo_exp, has_v_memo};
 
 use super::{
@@ -372,9 +370,8 @@ pub fn generate_element_block(ctx: &mut CodegenContext, el: &ElementNode<'_>) {
                 ctx.push(", ");
                 generate_slots(ctx, el);
             } else if el.children.iter().any(|c| !is_whitespace_or_comment(c)) {
-                // Teleport, KeepAlive: pass children as array, not slot object
+                // Teleport passes children as an array, not a slot object.
                 // (whitespace-only children are skipped to match Vue's behavior)
-                let is_keep_alive = matches!(el.tag.as_str(), "KeepAlive" | "keep-alive");
                 ctx.push(", [");
                 ctx.indent();
                 let filtered: Vec<_> = el
@@ -387,16 +384,6 @@ pub fn generate_element_block(ctx: &mut CodegenContext, el: &ElementNode<'_>) {
                         ctx.push(",");
                     }
                     ctx.newline();
-                    // KeepAlive: dynamic components (<component :is="...">) are
-                    // rendered as blocks so KeepAlive can track their identity
-                    if is_keep_alive
-                        && let TemplateChildNode::Element(child_el) = child
-                        && child_el.tag_type == ElementType::Component
-                        && is_dynamic_component(child_el)
-                    {
-                        generate_element_block(ctx, child_el);
-                        continue;
-                    }
                     generate_node(ctx, child);
                 }
                 ctx.deindent();

--- a/crates/vize_atelier_core/src/codegen/element/inline.rs
+++ b/crates/vize_atelier_core/src/codegen/element/inline.rs
@@ -36,6 +36,22 @@ use vize_carton::ToCompactString;
 
 /// Generate element code (non-block)
 pub fn generate_element(ctx: &mut CodegenContext, el: &ElementNode<'_>) {
+    if el.tag_type == ElementType::Element && el.ns != Namespace::Html {
+        super::block::generate_element_block(ctx, el);
+        return;
+    }
+
+    if el.tag_type == ElementType::Component
+        && (is_dynamic_component(el)
+            || matches!(
+                el.tag.as_str(),
+                "Teleport" | "teleport" | "Suspense" | "suspense" | "KeepAlive" | "keep-alive"
+            ))
+    {
+        super::block::generate_element_block(ctx, el);
+        return;
+    }
+
     // Check for v-once directive - handle it specially with cache
     if super::helpers::has_v_once(el) {
         super::v_once::generate_v_once_element(ctx, el);
@@ -300,7 +316,6 @@ pub fn generate_element(ctx: &mut CodegenContext, el: &ElementNode<'_>) {
                 ctx.push(", ");
                 generate_slots(ctx, el);
             } else if el.children.iter().any(|c| !is_whitespace_or_comment(c)) {
-                let is_keep_alive = matches!(el.tag.as_str(), "KeepAlive" | "keep-alive");
                 ctx.push(", [");
                 ctx.indent();
                 let filtered: Vec<_> = el
@@ -313,14 +328,6 @@ pub fn generate_element(ctx: &mut CodegenContext, el: &ElementNode<'_>) {
                         ctx.push(",");
                     }
                     ctx.newline();
-                    if is_keep_alive
-                        && let TemplateChildNode::Element(child_el) = child
-                        && child_el.tag_type == ElementType::Component
-                        && is_dynamic_component(child_el)
-                    {
-                        super::block::generate_element_block(ctx, child_el);
-                        continue;
-                    }
                     generate_node(ctx, child);
                 }
                 ctx.deindent();

--- a/crates/vize_atelier_core/src/codegen/props/generate.rs
+++ b/crates/vize_atelier_core/src/codegen/props/generate.rs
@@ -222,6 +222,13 @@ fn try_generate_static_attrs(
     if ctx.skip_is_prop || ctx.options.inline {
         return false;
     }
+    if ctx.in_v_for
+        && props
+            .iter()
+            .any(|prop| matches!(prop, PropNode::Attribute(attr) if attr.name == "ref"))
+    {
+        return false;
+    }
     if !props
         .iter()
         .all(|prop| matches!(prop, PropNode::Attribute(_)))
@@ -422,23 +429,30 @@ fn generate_props_object_inner(
                 } else {
                     None
                 };
-                let needs_ref_key = matches!(
+                let should_ref_runtime_binding = matches!(
                     ref_binding_type,
                     Some(
                         BindingType::SetupLet | BindingType::SetupRef | BindingType::SetupMaybeRef
                     )
                 );
+                let needs_ref_for = attr.name == "ref" && ctx.in_v_for;
 
-                if let (true, Some(ref_value)) = (needs_ref_key, ref_value) {
+                if let (true, Some(ref_value)) = (should_ref_runtime_binding, ref_value) {
                     // Emit ref_key + ref pair for setup-let/ref/maybe-ref bindings.
                     // Vue's runtime setRef() needs ref_key to write to instance.refs,
                     // which is essential for useTemplateRef to receive the element.
                     let ref_name = &ref_value.content;
+                    if needs_ref_for {
+                        ctx.push("ref_for: true, ");
+                    }
                     ctx.push("ref_key: \"");
                     ctx.push(ref_name);
                     ctx.push("\", ref: ");
                     ctx.push(ref_name);
                 } else {
+                    if needs_ref_for {
+                        ctx.push("ref_for: true, ");
+                    }
                     // Normal attribute output
                     let needs_quotes = !is_valid_js_identifier(&attr.name);
                     if needs_quotes {
@@ -450,9 +464,9 @@ fn generate_props_object_inner(
                     }
                     ctx.push(": ");
                     if let Some(value) = &attr.value {
-                        // In inline mode, ref="refName" should reference the setup variable
-                        // instead of being a string literal, if refName is a known binding
-                        if ref_binding_type.is_some() {
+                        // In inline mode, ref="refName" should reference a mutable/setup-ref
+                        // binding. Other bindings (notably props) are still string refs.
+                        if should_ref_runtime_binding {
                             ctx.push(&value.content);
                         } else {
                             ctx.push("\"");

--- a/crates/vize_atelier_core/src/codegen/slots.rs
+++ b/crates/vize_atelier_core/src/codegen/slots.rs
@@ -384,7 +384,8 @@ pub fn has_slot_children(el: &ElementNode<'_>) -> bool {
         return false;
     }
 
-    // Teleport and KeepAlive pass children as arrays, not slot objects
+    // Teleport and KeepAlive consume raw children rather than a slot object.
+    // KeepAlive still gets DYNAMIC_SLOTS at the vnode patch-flag layer.
     if matches!(
         el.tag.as_str(),
         "Teleport" | "teleport" | "KeepAlive" | "keep-alive"

--- a/crates/vize_atelier_core/src/codegen/v_for/generate.rs
+++ b/crates/vize_atelier_core/src/codegen/v_for/generate.rs
@@ -290,8 +290,11 @@ pub fn generate_for_item(ctx: &mut CodegenContext, node: &TemplateChildNode<'_>,
                         let new_flag = flag & !1;
                         patch_flag = if new_flag > 0 { Some(new_flag) } else { None };
                     }
-                    // Inside v-for, component slots are always dynamic
-                    if ctx.in_v_for && has_slot_children(el) {
+                    // KeepAlive always gets DYNAMIC_SLOTS, and component
+                    // slots inside v-for are dynamic by construction.
+                    if matches!(el.tag.as_str(), "KeepAlive" | "keep-alive")
+                        || (ctx.in_v_for && has_slot_children(el))
+                    {
                         let dynamic_slots_flag = 1024;
                         patch_flag = Some(patch_flag.unwrap_or(0) | dynamic_slots_flag);
                     }
@@ -746,6 +749,42 @@ fn generate_single_prop(
 ) {
     match prop {
         PropNode::Attribute(attr) => {
+            let ref_value = if attr.name == "ref" && ctx.options.inline {
+                attr.value.as_ref()
+            } else {
+                None
+            };
+            let ref_binding_type = ref_value.and_then(|v| {
+                ctx.options
+                    .binding_metadata
+                    .as_ref()
+                    .and_then(|m| m.bindings.get(v.content.as_str()).copied())
+            });
+            let should_ref_runtime_binding = matches!(
+                ref_binding_type,
+                Some(
+                    crate::options::BindingType::SetupLet
+                        | crate::options::BindingType::SetupRef
+                        | crate::options::BindingType::SetupMaybeRef
+                )
+            );
+            let needs_ref_for = attr.name == "ref" && ctx.in_v_for;
+
+            if let (true, Some(ref_value)) = (should_ref_runtime_binding, ref_value) {
+                let ref_name = &ref_value.content;
+                if needs_ref_for {
+                    ctx.push("ref_for: true, ");
+                }
+                ctx.push("ref_key: \"");
+                ctx.push(ref_name);
+                ctx.push("\", ref: ");
+                ctx.push(ref_name);
+                return;
+            }
+
+            if needs_ref_for {
+                ctx.push("ref_for: true, ");
+            }
             let needs_quotes = !super::super::helpers::is_valid_js_identifier(&attr.name);
             if needs_quotes {
                 ctx.push("\"");
@@ -756,9 +795,13 @@ fn generate_single_prop(
             }
             ctx.push(": ");
             if let Some(value) = &attr.value {
-                ctx.push("\"");
-                ctx.push(&escape_js_string(&value.content));
-                ctx.push("\"");
+                if should_ref_runtime_binding {
+                    ctx.push(&value.content);
+                } else {
+                    ctx.push("\"");
+                    ctx.push(&escape_js_string(&value.content));
+                    ctx.push("\"");
+                }
             } else {
                 ctx.push("\"\"");
             }

--- a/crates/vize_atelier_core/src/codegen/v_if/branch.rs
+++ b/crates/vize_atelier_core/src/codegen/v_if/branch.rs
@@ -300,6 +300,7 @@ fn generate_if_branch_component(
             static_merge,
             has_dyn_class,
             has_dyn_style,
+            is_dynamic,
         );
         ctx.push(")");
     } else {
@@ -312,6 +313,7 @@ fn generate_if_branch_component(
             static_merge,
             has_dyn_class,
             has_dyn_style,
+            is_dynamic,
         );
     }
 
@@ -322,7 +324,7 @@ fn generate_if_branch_component(
         ctx.push(", ");
         generate_slots(ctx, el);
     } else if el.children.iter().any(|c| !is_whitespace_or_comment(c)) {
-        // Teleport/KeepAlive: pass children as array, not slot object
+        // Teleport passes children as an array, not a slot object.
         ctx.push(", [");
         let filtered: Vec<_> = el
             .children
@@ -475,6 +477,7 @@ fn generate_if_branch_element(
             static_merge,
             has_dyn_class,
             has_dyn_style,
+            false,
         );
         ctx.push(")");
     } else {
@@ -487,6 +490,7 @@ fn generate_if_branch_element(
             static_merge,
             has_dyn_class,
             has_dyn_style,
+            false,
         );
     }
 

--- a/crates/vize_atelier_core/src/codegen/v_if/generate.rs
+++ b/crates/vize_atelier_core/src/codegen/v_if/generate.rs
@@ -7,6 +7,7 @@ use crate::ast::{DirectiveNode, ElementNode, ExpressionNode, IfBranchNode, PropN
 
 use super::super::{
     context::CodegenContext,
+    element::helpers::is_is_prop,
     helpers::{camelize, capitalize_first, escape_js_string, is_valid_js_identifier},
     props::{StaticMerge, generate_directive_prop_with_static, is_supported_directive},
 };
@@ -99,7 +100,7 @@ pub(super) fn generate_single_prop_for_if(
                     .as_ref()
                     .and_then(|m| m.bindings.get(v.content.as_str()).copied())
             });
-            let needs_ref_key = matches!(
+            let should_ref_runtime_binding = matches!(
                 ref_binding_type,
                 Some(
                     crate::options::BindingType::SetupLet
@@ -107,9 +108,13 @@ pub(super) fn generate_single_prop_for_if(
                         | crate::options::BindingType::SetupMaybeRef
                 )
             );
+            let needs_ref_for = attr.name == "ref" && ctx.in_v_for;
 
-            if let (true, Some(ref_value)) = (needs_ref_key, ref_value) {
+            if let (true, Some(ref_value)) = (should_ref_runtime_binding, ref_value) {
                 let ref_name = &ref_value.content;
+                if needs_ref_for {
+                    ctx.push("ref_for: true, ");
+                }
                 ctx.push("ref_key: \"");
                 ctx.push(ref_name);
                 ctx.push("\", ref: ");
@@ -117,6 +122,9 @@ pub(super) fn generate_single_prop_for_if(
                 return;
             }
 
+            if needs_ref_for {
+                ctx.push("ref_for: true, ");
+            }
             let needs_quotes = !is_valid_js_identifier(&attr.name);
             if needs_quotes {
                 ctx.push("\"");
@@ -127,7 +135,7 @@ pub(super) fn generate_single_prop_for_if(
             }
             ctx.push(": ");
             if let Some(value) = &attr.value {
-                if ref_binding_type.is_some() {
+                if should_ref_runtime_binding {
                     ctx.push(&value.content);
                 } else {
                     ctx.push("\"");
@@ -154,6 +162,7 @@ pub(super) fn generate_if_branch_props_object(
     static_merge: StaticMerge<'_>,
     has_dynamic_class: bool,
     has_dynamic_style: bool,
+    skip_is_prop: bool,
 ) {
     // Check if there are other props besides key (skip excluded ones)
     let has_other_props = el.props.iter().any(|p| {
@@ -161,6 +170,9 @@ pub(super) fn generate_if_branch_props_object(
         if let PropNode::Directive(dir) = p
             && !is_supported_directive(dir)
         {
+            return false;
+        }
+        if skip_is_prop && is_is_prop(p) {
             return false;
         }
         !should_skip_prop_for_if(p, has_dynamic_class, has_dynamic_style)
@@ -197,6 +209,9 @@ pub(super) fn generate_if_branch_props_object(
         if let PropNode::Directive(dir) = prop
             && !is_supported_directive(dir)
         {
+            continue;
+        }
+        if skip_is_prop && is_is_prop(prop) {
             continue;
         }
         if should_skip_prop_for_if(prop, has_dynamic_class, has_dynamic_style) {

--- a/crates/vize_atelier_dom/src/lib.rs
+++ b/crates/vize_atelier_dom/src/lib.rs
@@ -294,6 +294,81 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_dynamic_component_v_if_does_not_emit_is_prop() {
+        let allocator = Bump::new();
+        let (_, errors, result) = compile_template(
+            &allocator,
+            r#"<Component :is="current" v-if="ok" :foo="foo" />"#,
+        );
+        assert!(errors.is_empty());
+        let code = result.code.as_str();
+        assert!(
+            code.contains("_resolveDynamicComponent(current)"),
+            "dynamic component should be resolved from the :is binding:\n{code}"
+        );
+        assert!(
+            !code.contains("is:"),
+            "v-if dynamic component branch must not pass consumed :is as a prop:\n{code}"
+        );
+        assert!(
+            !code.contains(r#""is""#),
+            "v-if dynamic component branch must not track consumed :is as a dynamic prop:\n{code}"
+        );
+    }
+
+    #[test]
+    fn test_template_ref_in_v_for_emits_ref_for() {
+        let allocator = Bump::new();
+        let (_, errors, result) = compile_template(
+            &allocator,
+            r#"<span v-for="item in items" ref="itemEls" />"#,
+        );
+        assert!(errors.is_empty());
+        let code = result.code.as_str();
+        assert!(
+            code.contains("ref_for: true"),
+            "template refs inside v-for must be marked as ref_for so Vue stores an array:\n{code}"
+        );
+    }
+
+    #[test]
+    fn test_static_ref_matching_prop_name_stays_string_ref() {
+        use vize_atelier_core::options::{BindingMetadata, BindingType};
+        use vize_carton::FxHashMap;
+
+        let allocator = Bump::new();
+        let mut bindings = FxHashMap::default();
+        bindings.insert("buttons".into(), BindingType::Props);
+
+        let options = DomCompilerOptions {
+            mode: CodegenMode::Module,
+            prefix_identifiers: true,
+            inline: true,
+            binding_metadata: Some(BindingMetadata {
+                bindings,
+                props_aliases: FxHashMap::default(),
+                is_script_setup: true,
+            }),
+            ..Default::default()
+        };
+
+        let (_, errors, result) = compile_template_with_options(
+            &allocator,
+            r#"<button v-for="button in buttons" ref="buttons" :key="button" />"#,
+            options,
+        );
+
+        assert!(errors.is_empty(), "Errors: {:?}", errors);
+        let code = result.code.as_str();
+        assert!(code.contains("ref_for: true"), "{code}");
+        assert!(code.contains(r#"ref: "buttons""#), "{code}");
+        assert!(
+            !code.contains("ref: buttons"),
+            "props bindings must not be emitted as runtime ref identifiers:\n{code}"
+        );
+    }
+
     /// Recursively find the first element with the given tag, descending through `v-if`
     /// branches and `v-for` bodies so the search works on the transformed tree as well.
     fn find_element<'a, 'b>(
@@ -427,6 +502,46 @@ mod tests {
         assert!(errors.is_empty());
         let full = full_output(&result.preamble, &result.code);
         insta::assert_snapshot!(full.as_str());
+    }
+
+    #[test]
+    fn test_inline_svg_dynamic_subtree_uses_own_block() {
+        let allocator = Bump::new();
+        let (_, errors, result) = compile_template(
+            &allocator,
+            "<div><svg :width=\"w\"><g v-if=\"ok\"><rect :x=\"x\"/></g></svg></div>",
+        );
+        assert!(errors.is_empty());
+
+        let code = result.code.as_str();
+        assert!(
+            code.contains(r#"_createElementBlock("svg""#),
+            "inline <svg> must be a block so dynamic descendants patch with SVG namespace:\n{code}"
+        );
+        assert!(
+            code.contains(r#"_createElementBlock("g""#),
+            "dynamic SVG branch should keep its own block under the SVG namespace:\n{code}"
+        );
+    }
+
+    #[test]
+    fn test_nested_svg_with_v_bind_uses_own_block() {
+        let allocator = Bump::new();
+        let (_, errors, result) = compile_template(
+            &allocator,
+            r#"<div><svg xmlns="http://www.w3.org/2000/svg" :width="0" /></div>"#,
+        );
+        assert!(errors.is_empty());
+
+        let code = result.code.as_str();
+        assert!(
+            code.contains(r#"_createElementBlock("svg""#),
+            "nested SVG elements with dynamic props must render as blocks:\n{code}"
+        );
+        assert!(
+            !code.contains(r#"_createElementVNode("svg""#),
+            "nested SVG elements with dynamic props must not render as plain VNodes:\n{code}"
+        );
     }
 
     #[test]

--- a/crates/vize_atelier_dom/src/snapshots/vize_atelier_dom__tests__svg_codegen_shape_keeps_children_nested.snap
+++ b/crates/vize_atelier_dom/src/snapshots/vize_atelier_dom__tests__svg_codegen_shape_keeps_children_nested.snap
@@ -1,18 +1,18 @@
 ---
 source: crates/vize_atelier_dom/src/lib.rs
-assertion_line: 402
+assertion_line: 504
 expression: full.as_str()
 ---
 const { createElementVNode: _createElementVNode, openBlock: _openBlock, createElementBlock: _createElementBlock } = Vue
 
 function render(_ctx, _cache, $props, $setup, $data, $options) {
   return (_openBlock(), _createElementBlock("svg", null, [
-    _createElementVNode("foreignObject", null, [
+    (_openBlock(), _createElementBlock("foreignObject", null, [
       _createElementVNode("div", null, "hi")
-    ]),
-    _createElementVNode("rect", {
+    ])),
+    (_openBlock(), _createElementBlock("rect", {
       x: "1",
       y: "1"
-    })
+    }))
   ]))
 }

--- a/crates/vize_atelier_sfc/src/compile/tests.rs
+++ b/crates/vize_atelier_sfc/src/compile/tests.rs
@@ -133,6 +133,29 @@ const msg = ref('')
 }
 
 #[test]
+fn test_define_emits_quoted_update_event_in_sfc() {
+    let source = r#"<script setup lang="ts">
+const emit = defineEmits<{
+  "update:open": [value: boolean]
+}>()
+</script>
+
+<template>
+  <button @click="emit('update:open', false)">close</button>
+</template>"#;
+
+    let descriptor = parse_sfc(source, SfcParseOptions::default()).expect("Failed to parse SFC");
+    let opts = SfcCompileOptions::default();
+    let result = compile_sfc(&descriptor, opts).expect("Failed to compile SFC");
+
+    assert!(
+        result.code.contains(r#"emits: ["update:open"]"#),
+        "quoted emits keys containing ':' must be preserved:\n{}",
+        result.code
+    );
+}
+
+#[test]
 fn test_script_setup_inject_component_props_are_unwrapped() {
     let source = r#"<template>
   <SubComponent

--- a/crates/vize_atelier_sfc/src/compile_script/props.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/props.rs
@@ -604,24 +604,10 @@ pub fn extract_emit_names_from_type(type_args: &str) -> Vec<String> {
             trimmed
         };
 
-        // Split by lines or semicolons and extract property names
+        // Split by lines or semicolons and extract property names.
         for segment in inner.split([';', '\n']) {
-            let seg = segment.trim();
-            if seg.is_empty() {
-                continue;
-            }
-            // Find the property name before the first ':'
-            if let Some(colon_pos) = seg.find(':') {
-                let name = seg[..colon_pos].trim();
-                // Remove quotes if present
-                let name = name.trim_matches(|c| c == '\'' || c == '"');
-                if !name.is_empty()
-                    && name
-                        .chars()
-                        .all(|c| c.is_alphanumeric() || c == '_' || c == '-')
-                {
-                    emits.push(name.to_compact_string());
-                }
+            if let Some(name) = extract_emit_shorthand_key(segment) {
+                emits.push(name);
             }
         }
 
@@ -653,6 +639,60 @@ pub fn extract_emit_names_from_type(type_args: &str) -> Vec<String> {
     }
 
     emits
+}
+
+fn extract_emit_shorthand_key(segment: &str) -> Option<String> {
+    let seg = segment.trim();
+    if seg.is_empty() || seg.starts_with("...") {
+        return None;
+    }
+
+    let bytes = seg.as_bytes();
+    let first = *bytes.first()?;
+    if matches!(first, b'\'' | b'"' | b'`') {
+        let quote = first;
+        let mut key = String::default();
+        let mut i = 1;
+        while i < bytes.len() {
+            let c = bytes[i];
+            if c == b'\\' {
+                if i + 1 < bytes.len() {
+                    key.push(bytes[i + 1] as char);
+                    i += 2;
+                    continue;
+                }
+                return None;
+            }
+            if c == quote {
+                let rest = seg[i + 1..].trim_start();
+                if rest.starts_with(':') && !key.is_empty() {
+                    return Some(key);
+                }
+                return None;
+            }
+            key.push(c as char);
+            i += 1;
+        }
+        return None;
+    }
+
+    let mut colon_pos = None;
+    for (idx, ch) in seg.char_indices() {
+        if ch == ':' {
+            colon_pos = Some(idx);
+            break;
+        }
+    }
+    let name = seg[..colon_pos?].trim().trim_end_matches('?').trim();
+    if !name.is_empty()
+        && name
+            .chars()
+            .all(|c| c.is_alphanumeric() || c == '_' || c == '-' || c == '$')
+    {
+        Some(name.to_compact_string())
+    } else {
+        None
+    }
 }
 
 /// Extract default values from withDefaults second argument
@@ -1075,4 +1115,22 @@ pub fn is_valid_identifier(s: &str) -> bool {
     }
 
     chars.all(|c| c.is_alphanumeric() || c == '_' || c == '$')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::extract_emit_names_from_type;
+
+    #[test]
+    fn extract_emit_names_keeps_quoted_colon_keys() {
+        let names = extract_emit_names_from_type(
+            r#"{
+              "update:open": [value: boolean]
+              'select:item': [id: string]
+              close: []
+            }"#,
+        );
+
+        assert_eq!(names, vec!["update:open", "select:item", "close"]);
+    }
 }

--- a/crates/vize_patina/src/linter/native_type_aware/tests.rs
+++ b/crates/vize_patina/src/linter/native_type_aware/tests.rs
@@ -64,6 +64,40 @@ defineEmits(['save'])
 }
 
 #[test]
+fn require_typed_emits_accepts_quoted_colon_key_and_reports_runtime_array() {
+    if !corsa_available() {
+        return;
+    }
+
+    let linter = Linter::with_preset(LintPreset::Opinionated);
+    let typed_source = r#"<script setup lang="ts">
+defineEmits<{ "update:open": [value: boolean] }>()
+</script>"#;
+    let typed_result = lint_sfc_with_corsa(&linter, typed_source, "TypedDialog.vue");
+    assert!(
+        !typed_result
+            .diagnostics
+            .iter()
+            .any(|diag| diag.rule_name == RULE_REQUIRE_TYPED_EMITS),
+        "quoted colon emit keys should be treated as typed: {:?}",
+        typed_result.diagnostics
+    );
+
+    let runtime_source = r#"<script setup lang="ts">
+defineEmits(["update:open"])
+</script>"#;
+    let runtime_result = lint_sfc_with_corsa(&linter, runtime_source, "RuntimeDialog.vue");
+    assert!(
+        runtime_result
+            .diagnostics
+            .iter()
+            .any(|diag| diag.rule_name == RULE_REQUIRE_TYPED_EMITS),
+        "runtime-only emits should still be reported: {:?}",
+        runtime_result.diagnostics
+    );
+}
+
+#[test]
 fn no_floating_promises_uses_corsa() {
     if !corsa_available() {
         return;

--- a/npm/vite-plugin-vize/src/plugin/index.ts
+++ b/npm/vite-plugin-vize/src/plugin/index.ts
@@ -28,6 +28,7 @@ import {
   createVueCompatPlugin,
 } from "./compat.ts";
 import { patchUnoCssBridge } from "./unocss.ts";
+import { patchQuasarBridge } from "./quasar.ts";
 import { patchCssModuleGenerateScopedName } from "./css-modules.ts";
 import { installVirtualAssetMiddleware } from "./dev-middleware.ts";
 import {
@@ -331,6 +332,12 @@ export function vize(options: VizeOptions = {}): Plugin[] {
         ...DEFAULT_PRECOMPILE_IGNORE_PATTERNS,
       ];
       patchUnoCssBridge(
+        resolvedConfig.plugins as Array<{
+          name?: string;
+          transform?: Function;
+        }>,
+      );
+      patchQuasarBridge(
         resolvedConfig.plugins as Array<{
           name?: string;
           transform?: Function;

--- a/npm/vite-plugin-vize/src/plugin/quasar.test.ts
+++ b/npm/vite-plugin-vize/src/plugin/quasar.test.ts
@@ -1,0 +1,125 @@
+import assert from "node:assert/strict";
+import path from "node:path";
+
+import { patchQuasarBridge } from "./quasar.ts";
+
+const sourcePath = path.resolve(process.cwd(), "target", "vize-tests", "quasar", "App.vue");
+const virtualId = `\0${sourcePath}.ts`;
+const queriedClientVirtualId = `${sourcePath}.ts?vue&vize`;
+const queriedSsrVirtualId = `\0vize-ssr:${sourcePath}.ts?vue&type=template`;
+const legacyVirtualId = `\0vize:${sourcePath}.ts`;
+
+{
+  let receivedId = "";
+
+  const plugins = [
+    {
+      name: "vite:quasar:script",
+      transform(code: string, id: string) {
+        receivedId = id;
+        return id.includes(".vue")
+          ? {
+              code: `import { QBtn } from "quasar";\n${code.replace(/_resolveComponent\("QBtn"\)/g, "QBtn")}`,
+              map: null,
+            }
+          : null;
+      },
+    },
+  ];
+
+  patchQuasarBridge(plugins);
+  const result = plugins[0]!.transform!(
+    `const _component_QBtn = _resolveComponent("QBtn");`,
+    virtualId,
+  );
+
+  assert.equal(receivedId, sourcePath);
+  assert.ok(result && typeof result === "object");
+  assert.match(result.code, /import \{ QBtn \} from "quasar"/);
+  assert.doesNotMatch(result.code, /_resolveComponent\("QBtn"\)/);
+}
+
+{
+  const receivedIds: string[] = [];
+
+  const plugins = [
+    {
+      name: "vite:quasar:script",
+      transform(_code: string, id: string) {
+        receivedIds.push(id);
+        return null;
+      },
+    },
+  ];
+
+  patchQuasarBridge(plugins);
+  plugins[0]!.transform!("export default {}", queriedClientVirtualId);
+  plugins[0]!.transform!("export default {}", queriedSsrVirtualId);
+  plugins[0]!.transform!("export default {}", legacyVirtualId);
+
+  assert.deepEqual(receivedIds, [
+    `${sourcePath}?vue&vize`,
+    `${sourcePath}?vue&type=template`,
+    sourcePath,
+  ]);
+}
+
+{
+  let receivedId = "";
+
+  const plugins = [
+    {
+      name: "vite:quasar:script",
+      transform(_code: string, id: string) {
+        receivedId = id;
+        return null;
+      },
+    },
+  ];
+
+  patchQuasarBridge(plugins);
+  plugins[0]!.transform!("export default {}", "/project/src/plain.ts");
+
+  assert.equal(receivedId, "/project/src/plain.ts");
+}
+
+{
+  let callCount = 0;
+
+  const plugins = [
+    {
+      name: "vite:quasar:script",
+      transform() {
+        callCount += 1;
+        return null;
+      },
+    },
+  ];
+
+  patchQuasarBridge(plugins);
+  patchQuasarBridge(plugins);
+  plugins[0]!.transform!("export default {}", virtualId);
+
+  assert.equal(callCount, 1);
+}
+
+{
+  let receivedId = "";
+
+  const plugins = [
+    {
+      name: "vite:other",
+      transform(_code: string, id: string) {
+        receivedId = id;
+        return null;
+      },
+    },
+  ];
+
+  patchQuasarBridge(plugins);
+  plugins[0]!.transform!("export default {}", virtualId);
+
+  assert.equal(receivedId, virtualId);
+}
+
+console.log("✅ vite-plugin-vize Quasar bridge tests passed!");

--- a/npm/vite-plugin-vize/src/plugin/quasar.ts
+++ b/npm/vite-plugin-vize/src/plugin/quasar.ts
@@ -1,0 +1,68 @@
+const bridgePatched = Symbol("vize.quasarBridgePatched");
+
+type QuasarLikePlugin = {
+  name?: string;
+  transform?: (...args: unknown[]) => unknown;
+  [bridgePatched]?: boolean;
+};
+
+const VIZE_SSR_PREFIX = "\0vize-ssr:";
+const LEGACY_VIZE_PREFIX = "\0vize:";
+const plainSsrPrefix = VIZE_SSR_PREFIX.slice(1);
+const plainLegacyPrefix = LEGACY_VIZE_PREFIX.slice(1);
+
+function stripBridgePrefix(id: string): string {
+  if (id.startsWith(VIZE_SSR_PREFIX)) {
+    return id.slice(VIZE_SSR_PREFIX.length);
+  }
+  if (id.startsWith(LEGACY_VIZE_PREFIX)) {
+    return id.slice(LEGACY_VIZE_PREFIX.length);
+  }
+  if (id.startsWith(plainSsrPrefix)) {
+    return id.slice(plainSsrPrefix.length);
+  }
+  if (id.startsWith(plainLegacyPrefix)) {
+    return id.slice(plainLegacyPrefix.length);
+  }
+  if (id.startsWith("\0")) {
+    return id.slice(1);
+  }
+  return id;
+}
+
+function isQuasarBridgeModuleId(id: string): boolean {
+  return /\.vue\.ts(?:[?#]|$)/.test(stripBridgePrefix(id));
+}
+
+function normalizeQuasarBridgeModuleId(id: string): string {
+  return stripBridgePrefix(id).replace(/\.vue\.ts(?=[?#]|$)/, ".vue");
+}
+
+export function patchQuasarBridge(plugins: QuasarLikePlugin[]): void {
+  for (const plugin of plugins) {
+    if (
+      plugin.name !== "vite:quasar:script" ||
+      typeof plugin.transform !== "function" ||
+      plugin[bridgePatched]
+    ) {
+      continue;
+    }
+
+    const originalTransform = plugin.transform;
+
+    plugin.transform = function (
+      this: unknown,
+      code: string,
+      id: string,
+      ...args: unknown[]
+    ): unknown {
+      if (!isQuasarBridgeModuleId(id)) {
+        return originalTransform.call(this, code, id, ...args);
+      }
+
+      return originalTransform.call(this, code, normalizeQuasarBridgeModuleId(id), ...args);
+    };
+
+    plugin[bridgePatched] = true;
+  }
+}

--- a/npm/vite-plugin-vize/src/test.ts
+++ b/npm/vite-plugin-vize/src/test.ts
@@ -7,6 +7,7 @@ import "./plugin/hmr.test.ts";
 import "./plugin/index.test.ts";
 import "./plugin/load.test.ts";
 import "./plugin/native.test.ts";
+import "./plugin/quasar.test.ts";
 import "./plugin/resolve.test.ts";
 import "./plugin/state.test.ts";
 import "./plugin/unocss.test.ts";

--- a/tests/expected/sfc/patches.snap
+++ b/tests/expected/sfc/patches.snap
@@ -1390,7 +1390,7 @@ import { RouterView } from 'vue-router'
   </RouterView>
 </template>
 --- OUTPUT ---
-import { openBlock as _openBlock, createBlock as _createBlock, createVNode as _createVNode, resolveDynamicComponent as _resolveDynamicComponent, withCtx as _withCtx } from "vue"
+import { openBlock as _openBlock, createBlock as _createBlock, resolveDynamicComponent as _resolveDynamicComponent, withCtx as _withCtx } from "vue"
 
 import { RouterView } from 'vue-router'
 
@@ -1402,7 +1402,7 @@ export default {
 return (_ctx, _cache) => {
   return (_openBlock(), _createBlock(RouterView, null, {
     default: _withCtx(({ Component }) => [
-      _createVNode(_resolveDynamicComponent(Component))
+      (_openBlock(), _createBlock(_resolveDynamicComponent(Component)))
     ]),
     _: 1 /* STABLE */
   }))
@@ -1468,7 +1468,7 @@ const tabs = ref([{ id: 1, component: 'TabA' }])
   </keep-alive>
 </template>
 --- OUTPUT ---
-import { Fragment as _Fragment, KeepAlive as _KeepAlive, openBlock as _openBlock, createBlock as _createBlock, createElementBlock as _createElementBlock, createVNode as _createVNode, resolveDynamicComponent as _resolveDynamicComponent, renderList as _renderList } from "vue"
+import { Fragment as _Fragment, KeepAlive as _KeepAlive, openBlock as _openBlock, createBlock as _createBlock, createElementBlock as _createElementBlock, resolveDynamicComponent as _resolveDynamicComponent, renderList as _renderList } from "vue"
 
 import { ref } from 'vue'
 
@@ -1481,8 +1481,8 @@ const tabs = ref([{ id: 1, component: 'TabA' }])
 return (_ctx, _cache) => {
   return (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(tabs.value, (tab) => {
     return (_openBlock(), _createBlock(_KeepAlive, { key: tab.id }, [
-      _createVNode(_resolveDynamicComponent(tab.component))
-    ]))
+      (_openBlock(), _createBlock(_resolveDynamicComponent(tab.component)))
+    ], 1024 /* DYNAMIC_SLOTS */))
   }), 128 /* KEYED_FRAGMENT */))
 }
 }

--- a/tests/expected/vdom/dynamic-component.snap
+++ b/tests/expected/vdom/dynamic-component.snap
@@ -62,6 +62,19 @@ export function render(_ctx, _cache) {
   }))
 }
 ===
+name: nested dynamic component
+options: vdom
+--- INPUT ---
+<div><component :is="foo" /></div>
+--- OUTPUT ---
+import { resolveDynamicComponent as _resolveDynamicComponent, openBlock as _openBlock, createBlock as _createBlock, createElementBlock as _createElementBlock } from "vue"
+
+export function render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("div", null, [
+    (_openBlock(), _createBlock(_resolveDynamicComponent(_ctx.foo)))
+  ]))
+}
+===
 name: dynamic component with slot content
 options: vdom
 --- INPUT ---

--- a/tests/expected/vdom/v-slot.snap
+++ b/tests/expected/vdom/v-slot.snap
@@ -1,6 +1,6 @@
 ===
 name: default slot content
-options: default
+options: vdom
 --- INPUT ---
 <MyComponent>content</MyComponent>
 --- OUTPUT ---
@@ -16,10 +16,9 @@ export function render(_ctx, _cache) {
     _: 1 /* STABLE */
   }))
 }
-
 ===
 name: default slot with element
-options: default
+options: vdom
 --- INPUT ---
 <MyComponent><div>content</div></MyComponent>
 --- OUTPUT ---
@@ -35,10 +34,9 @@ export function render(_ctx, _cache) {
     _: 1 /* STABLE */
   }))
 }
-
 ===
 name: default slot with interpolation
-options: default
+options: vdom
 --- INPUT ---
 <MyComponent>{{ msg }}</MyComponent>
 --- OUTPUT ---
@@ -54,10 +52,9 @@ export function render(_ctx, _cache) {
     _: 1 /* STABLE */
   }))
 }
-
 ===
 name: default slot multiple children
-options: default
+options: vdom
 --- INPUT ---
 <MyComponent><div>A</div><div>B</div></MyComponent>
 --- OUTPUT ---
@@ -74,10 +71,9 @@ export function render(_ctx, _cache) {
     _: 1 /* STABLE */
   }))
 }
-
 ===
 name: named slot
-options: default
+options: vdom
 --- INPUT ---
 <MyComponent><template #header>Header</template></MyComponent>
 --- OUTPUT ---
@@ -93,10 +89,9 @@ export function render(_ctx, _cache) {
     _: 1 /* STABLE */
   }))
 }
-
 ===
 name: named slot v-slot syntax
-options: default
+options: vdom
 --- INPUT ---
 <MyComponent><template v-slot:header>Header</template></MyComponent>
 --- OUTPUT ---
@@ -112,10 +107,9 @@ export function render(_ctx, _cache) {
     _: 1 /* STABLE */
   }))
 }
-
 ===
 name: multiple named slots
-options: default
+options: vdom
 --- INPUT ---
 <MyComponent><template #header>H</template><template #footer>F</template></MyComponent>
 --- OUTPUT ---
@@ -134,10 +128,9 @@ export function render(_ctx, _cache) {
     _: 1 /* STABLE */
   }))
 }
-
 ===
 name: named slot with default
-options: default
+options: vdom
 --- INPUT ---
 <MyComponent><template #header>Header</template>Default content</MyComponent>
 --- OUTPUT ---
@@ -156,10 +149,9 @@ export function render(_ctx, _cache) {
     _: 1 /* STABLE */
   }))
 }
-
 ===
 name: default slot explicit
-options: default
+options: vdom
 --- INPUT ---
 <MyComponent><template #default>Default</template></MyComponent>
 --- OUTPUT ---
@@ -175,10 +167,9 @@ export function render(_ctx, _cache) {
     _: 1 /* STABLE */
   }))
 }
-
 ===
 name: scoped slot
-options: default
+options: vdom
 --- INPUT ---
 <MyComponent v-slot="{ item }">{{ item }}</MyComponent>
 --- OUTPUT ---
@@ -194,10 +185,9 @@ export function render(_ctx, _cache) {
     _: 1 /* STABLE */
   }))
 }
-
 ===
 name: scoped slot with props
-options: default
+options: vdom
 --- INPUT ---
 <MyComponent v-slot="slotProps">{{ slotProps.item }}</MyComponent>
 --- OUTPUT ---
@@ -213,10 +203,9 @@ export function render(_ctx, _cache) {
     _: 1 /* STABLE */
   }))
 }
-
 ===
 name: named scoped slot
-options: default
+options: vdom
 --- INPUT ---
 <MyComponent><template #item="{ data }">{{ data }}</template></MyComponent>
 --- OUTPUT ---
@@ -232,10 +221,9 @@ export function render(_ctx, _cache) {
     _: 1 /* STABLE */
   }))
 }
-
 ===
 name: scoped slot destructure
-options: default
+options: vdom
 --- INPUT ---
 <MyComponent v-slot="{ item, index }">{{ index }}: {{ item }}</MyComponent>
 --- OUTPUT ---
@@ -251,10 +239,9 @@ export function render(_ctx, _cache) {
     _: 1 /* STABLE */
   }))
 }
-
 ===
 name: scoped slot default value
-options: default
+options: vdom
 --- INPUT ---
 <MyComponent v-slot="{ item = defaultItem }">{{ item }}</MyComponent>
 --- OUTPUT ---
@@ -270,10 +257,9 @@ export function render(_ctx, _cache) {
     _: 1 /* STABLE */
   }))
 }
-
 ===
 name: scoped slot nested destructure
-options: default
+options: vdom
 --- INPUT ---
 <MyComponent v-slot="{ user: { name } }">{{ name }}</MyComponent>
 --- OUTPUT ---
@@ -289,10 +275,9 @@ export function render(_ctx, _cache) {
     _: 1 /* STABLE */
   }))
 }
-
 ===
 name: dynamic slot name
-options: default
+options: vdom
 --- INPUT ---
 <MyComponent><template #[slotName]>content</template></MyComponent>
 --- OUTPUT ---
@@ -308,10 +293,9 @@ export function render(_ctx, _cache) {
     _: 2 /* DYNAMIC */
   }, 1024 /* DYNAMIC_SLOTS */))
 }
-
 ===
 name: dynamic slot name with scoped
-options: default
+options: vdom
 --- INPUT ---
 <MyComponent><template #[slotName]="props">{{ props }}</template></MyComponent>
 --- OUTPUT ---
@@ -327,10 +311,9 @@ export function render(_ctx, _cache) {
     _: 2 /* DYNAMIC */
   }, 1024 /* DYNAMIC_SLOTS */))
 }
-
 ===
 name: v-slot on component
-options: default
+options: vdom
 --- INPUT ---
 <MyComponent v-slot>Default</MyComponent>
 --- OUTPUT ---
@@ -346,10 +329,9 @@ export function render(_ctx, _cache) {
     _: 1 /* STABLE */
   }))
 }
-
 ===
 name: v-slot with props on component
-options: default
+options: vdom
 --- INPUT ---
 <MyComponent v-slot="{ item }">{{ item }}</MyComponent>
 --- OUTPUT ---
@@ -365,10 +347,9 @@ export function render(_ctx, _cache) {
     _: 1 /* STABLE */
   }))
 }
-
 ===
 name: slot with v-if
-options: default
+options: vdom
 --- INPUT ---
 <MyComponent><template #header v-if="show">Header</template></MyComponent>
 --- OUTPUT ---
@@ -389,10 +370,9 @@ export function render(_ctx, _cache) {
       : undefined
   ]), 1024 /* DYNAMIC_SLOTS */))
 }
-
 ===
 name: conditional named slot with default
-options: default
+options: vdom
 --- INPUT ---
 <MyComponent>Default content<template #header v-if="show">Header</template></MyComponent>
 --- OUTPUT ---
@@ -418,10 +398,9 @@ export function render(_ctx, _cache) {
       : undefined
   ]), 1024 /* DYNAMIC_SLOTS */))
 }
-
 ===
 name: slot with v-for
-options: default
+options: vdom
 --- INPUT ---
 <MyComponent><template #item v-for="item in items" :key="item.id">{{ item }}</template></MyComponent>
 --- OUTPUT ---
@@ -441,10 +420,9 @@ export function render(_ctx, _cache) {
     })
   ]), 1024 /* DYNAMIC_SLOTS */))
 }
-
 ===
 name: nested components with slots
-options: default
+options: vdom
 --- INPUT ---
 <Outer><template #default><Inner><template #content>Nested</template></Inner></template></Outer>
 --- OUTPUT ---
@@ -466,10 +444,9 @@ export function render(_ctx, _cache) {
     _: 1 /* STABLE */
   }))
 }
-
 ===
 name: Transition slot
-options: default
+options: vdom
 --- INPUT ---
 <Transition><div v-if="show">Content</div></Transition>
 --- OUTPUT ---
@@ -485,10 +462,9 @@ export function render(_ctx, _cache) {
     _: 1 /* STABLE */
   }))
 }
-
 ===
 name: KeepAlive slot
-options: default
+options: vdom
 --- INPUT ---
 <KeepAlive><component :is="current" /></KeepAlive>
 --- OUTPUT ---
@@ -499,10 +475,59 @@ export function render(_ctx, _cache) {
     (_openBlock(), _createBlock(_resolveDynamicComponent(_ctx.current)))
   ], 1024 /* DYNAMIC_SLOTS */))
 }
+===
+name: nested KeepAlive block
+options: vdom
+--- INPUT ---
+<div><KeepAlive><component :is="current" /></KeepAlive></div>
+--- OUTPUT ---
+import { resolveDynamicComponent as _resolveDynamicComponent, openBlock as _openBlock, createBlock as _createBlock, KeepAlive as _KeepAlive, createElementBlock as _createElementBlock } from "vue"
 
+export function render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("div", null, [
+    (_openBlock(), _createBlock(_KeepAlive, null, [
+      (_openBlock(), _createBlock(_resolveDynamicComponent(_ctx.current)))
+    ], 1024 /* DYNAMIC_SLOTS */))
+  ]))
+}
+===
+name: nested Teleport block
+options: vdom
+--- INPUT ---
+<div><Teleport to="body"><span /></Teleport></div>
+--- OUTPUT ---
+import { createElementVNode as _createElementVNode, Teleport as _Teleport, openBlock as _openBlock, createBlock as _createBlock, createElementBlock as _createElementBlock } from "vue"
+
+export function render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("div", null, [
+    (_openBlock(), _createBlock(_Teleport, { to: "body" }, [
+      _createElementVNode("span")
+    ]))
+  ]))
+}
+===
+name: nested Suspense block
+options: vdom
+--- INPUT ---
+<div><Suspense><AsyncComponent /></Suspense></div>
+--- OUTPUT ---
+import { resolveComponent as _resolveComponent, createVNode as _createVNode, Suspense as _Suspense, withCtx as _withCtx, openBlock as _openBlock, createBlock as _createBlock, createElementBlock as _createElementBlock } from "vue"
+
+export function render(_ctx, _cache) {
+  const _component_AsyncComponent = _resolveComponent("AsyncComponent")
+
+  return (_openBlock(), _createElementBlock("div", null, [
+    (_openBlock(), _createBlock(_Suspense, null, {
+      default: _withCtx(() => [
+        _createVNode(_component_AsyncComponent)
+      ]),
+      _: 1 /* STABLE */
+    }))
+  ]))
+}
 ===
 name: Suspense slots
-options: default
+options: vdom
 --- INPUT ---
 <Suspense><template #default><AsyncComponent /></template><template #fallback>Loading...</template></Suspense>
 --- OUTPUT ---

--- a/tests/fixtures/vdom/dynamic-component.toml
+++ b/tests/fixtures/vdom/dynamic-component.toml
@@ -25,6 +25,10 @@ name = "dynamic component with children"
 input = '<component :is="foo"><span>hi</span></component>'
 
 [[cases]]
+name = "nested dynamic component"
+input = '<div><component :is="foo" /></div>'
+
+[[cases]]
 name = "dynamic component with slot content"
 input = '<component :is="tab"><template #header>H</template></component>'
 

--- a/tests/fixtures/vdom/v-slot.toml
+++ b/tests/fixtures/vdom/v-slot.toml
@@ -131,5 +131,17 @@ name = "KeepAlive slot"
 input = '<KeepAlive><component :is="current" /></KeepAlive>'
 
 [[cases]]
+name = "nested KeepAlive block"
+input = '<div><KeepAlive><component :is="current" /></KeepAlive></div>'
+
+[[cases]]
+name = "nested Teleport block"
+input = '<div><Teleport to="body"><span /></Teleport></div>'
+
+[[cases]]
+name = "nested Suspense block"
+input = '<div><Suspense><AsyncComponent /></Suspense></div>'
+
+[[cases]]
 name = "Suspense slots"
 input = '<Suspense><template #default><AsyncComponent /></template><template #fallback>Loading...</template></Suspense>'

--- a/tests/snapshots/sfc/js/patches__dynamic_component_with_v_slot_destructure.snap
+++ b/tests/snapshots/sfc/js/patches__dynamic_component_with_v_slot_destructure.snap
@@ -1,8 +1,9 @@
 ---
 source: crates/vize_atelier_sfc/src/snapshot_tests.rs
+assertion_line: 221
 expression: js_output.as_str()
 ---
-import { resolveDynamicComponent as _resolveDynamicComponent, createVNode as _createVNode, openBlock as _openBlock, createBlock as _createBlock, withCtx as _withCtx } from "vue"
+import { resolveDynamicComponent as _resolveDynamicComponent, openBlock as _openBlock, createBlock as _createBlock, withCtx as _withCtx } from "vue"
 
 import { RouterView } from 'vue-router'
 
@@ -15,7 +16,7 @@ export default {
 return (_ctx, _cache) => {
   return (_openBlock(), _createBlock(RouterView, null, {
     default: _withCtx(({ Component }) => [
-      _createVNode(_resolveDynamicComponent(Component))
+      (_openBlock(), _createBlock(_resolveDynamicComponent(Component)))
     ]),
     _: 1 /* STABLE */
   }))

--- a/tests/snapshots/sfc/js/patches__keep_alive_inside_v_for_should_use_builtin.snap
+++ b/tests/snapshots/sfc/js/patches__keep_alive_inside_v_for_should_use_builtin.snap
@@ -1,8 +1,9 @@
 ---
 source: crates/vize_atelier_sfc/src/snapshot_tests.rs
+assertion_line: 221
 expression: js_output.as_str()
 ---
-import { resolveDynamicComponent as _resolveDynamicComponent, createVNode as _createVNode, openBlock as _openBlock, createBlock as _createBlock, createElementBlock as _createElementBlock, Fragment as _Fragment, renderList as _renderList, KeepAlive as _KeepAlive } from "vue"
+import { resolveDynamicComponent as _resolveDynamicComponent, openBlock as _openBlock, createBlock as _createBlock, createElementBlock as _createElementBlock, Fragment as _Fragment, renderList as _renderList, KeepAlive as _KeepAlive } from "vue"
 
 import { ref } from 'vue'
 
@@ -16,8 +17,8 @@ const tabs = ref([{ id: 1, component: 'TabA' }])
 return (_ctx, _cache) => {
   return (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(tabs.value, (tab) => {
     return (_openBlock(), _createBlock(_KeepAlive, { key: tab.id }, [
-      _createVNode(_resolveDynamicComponent(tab.component))
-    ]))
+      (_openBlock(), _createBlock(_resolveDynamicComponent(tab.component)))
+    ], 1024 /* DYNAMIC_SLOTS */))
   }), 128 /* KEYED_FRAGMENT */))
 }
 }

--- a/tests/snapshots/sfc/ts/patches__dynamic_component_with_v_slot_destructure.snap
+++ b/tests/snapshots/sfc/ts/patches__dynamic_component_with_v_slot_destructure.snap
@@ -1,9 +1,10 @@
 ---
 source: crates/vize_atelier_sfc/src/snapshot_tests.rs
+assertion_line: 198
 expression: ts_output.as_str()
 ---
 import { defineComponent as _defineComponent } from 'vue'
-import { resolveDynamicComponent as _resolveDynamicComponent, createVNode as _createVNode, openBlock as _openBlock, createBlock as _createBlock, withCtx as _withCtx } from "vue"
+import { resolveDynamicComponent as _resolveDynamicComponent, openBlock as _openBlock, createBlock as _createBlock, withCtx as _withCtx } from "vue"
 
 import { RouterView } from 'vue-router'
 
@@ -16,7 +17,7 @@ export default /*@__PURE__*/_defineComponent({
 return (_ctx: any,_cache: any) => {
   return (_openBlock(), _createBlock(RouterView, null, {
     default: _withCtx(({ Component }) => [
-      _createVNode(_resolveDynamicComponent(Component))
+      (_openBlock(), _createBlock(_resolveDynamicComponent(Component)))
     ]),
     _: 1 /* STABLE */
   }))

--- a/tests/snapshots/sfc/ts/patches__keep_alive_inside_v_for_should_use_builtin.snap
+++ b/tests/snapshots/sfc/ts/patches__keep_alive_inside_v_for_should_use_builtin.snap
@@ -1,9 +1,10 @@
 ---
 source: crates/vize_atelier_sfc/src/snapshot_tests.rs
+assertion_line: 198
 expression: ts_output.as_str()
 ---
 import { defineComponent as _defineComponent } from 'vue'
-import { resolveDynamicComponent as _resolveDynamicComponent, createVNode as _createVNode, openBlock as _openBlock, createBlock as _createBlock, createElementBlock as _createElementBlock, Fragment as _Fragment, renderList as _renderList, KeepAlive as _KeepAlive } from "vue"
+import { resolveDynamicComponent as _resolveDynamicComponent, openBlock as _openBlock, createBlock as _createBlock, createElementBlock as _createElementBlock, Fragment as _Fragment, renderList as _renderList, KeepAlive as _KeepAlive } from "vue"
 
 import { ref } from 'vue'
 
@@ -17,8 +18,8 @@ const tabs = ref([{ id: 1, component: 'TabA' }])
 return (_ctx: any,_cache: any) => {
   return (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(tabs.value, (tab) => {
     return (_openBlock(), _createBlock(_KeepAlive, { key: tab.id }, [
-      _createVNode(_resolveDynamicComponent(tab.component))
-    ]))
+      (_openBlock(), _createBlock(_resolveDynamicComponent(tab.component)))
+    ], 1024 /* DYNAMIC_SLOTS */))
   }), 128 /* KEYED_FRAGMENT */))
 }
 }


### PR DESCRIPTION
## Summary

- Align VDOM codegen with Vue for nested SVG/MathML, dynamic components, KeepAlive, Teleport, and Suspense so VOICEVOX's song editor patches under the correct runtime shape.
- Add a Quasar vite plugin bridge so Quasar's script transform sees Vize virtual Vue module ids as normal `.vue` ids.
- Fix related `defineEmits` quoted colon keys, template ref handling in `v-for`, static ref false positives for prop names, and dynamic component `:is` prop emission in `v-if`.
- Add typechecker and linter regressions that verify false positives stay fixed while real diagnostics still report.

Fixes #1012.
Fixes #1013.

## Root cause

Vize emitted some nested non-HTML and dynamic component nodes as plain VNodes where Vue opens a block. In VOICEVOX this broke SVG/dynamic component patching and KeepAlive identity tracking, which surfaced as song editor interaction failures. Quasar also missed transforms because the plugin saw Vize's virtual `.vue.ts` ids instead of normalized `.vue` ids.

## Validation

- `cargo fmt --all`
- `git diff --check`
- `cargo run -p vize_test_runner --bin coverage -- -vv` (713/713)
- `cargo test -p vize_atelier_dom -p vize_atelier_sfc -p vize_patina`
- `cargo test -p vize --test check_cli`
- `npx -y pnpm@10 --dir npm/vite-plugin-vize test`
- `npx -y pnpm@10 --dir npm/vite-plugin-vize check`
- `npx -y pnpm@10 --dir npm/vite-plugin-vize build`
- `npx -y pnpm@10 --dir npm/vize build`
- VOICEVOX browser E2E with this branch linked: 35 passed, 3 skipped
- Browser manual check on VOICEVOX song editor: notes increased 0 -> 1 -> 2; no console errors observed
