### PR TITLE
fix: hoist constant SVG bind props

### DIFF
--- a/crates/vize_atelier_core/src/codegen.rs
+++ b/crates/vize_atelier_core/src/codegen.rs
@@ -26,6 +26,7 @@ use children::is_directive_comment;
 pub use context::{CodegenContext, CodegenResult};
 use element::generate_root_node;
 use generate::{collect_hoist_helpers, generate_hoists};
+pub(crate) use helpers::is_constant_simple_expression;
 use node::generate_node;
 use root::{
     generate_assets, generate_function_signature, generate_preamble_from_helpers,

--- a/crates/vize_atelier_core/src/transforms/hoist_static.rs
+++ b/crates/vize_atelier_core/src/transforms/hoist_static.rs
@@ -2,9 +2,10 @@
 //!
 //! Hoists static nodes to reduce runtime overhead.
 
-use vize_carton::{Box, Bump, String, Vec};
+use vize_carton::{Box, Bump, String, ToCompactString, Vec, camelize};
 
 use crate::ast::*;
+use crate::codegen::is_constant_simple_expression;
 use crate::transform::TransformContext;
 
 /// Check if a node is fully static (can be hoisted)
@@ -196,6 +197,7 @@ fn hoist_static_inner<'a>(
                             && ((is_root
                                 && ctx.options.inline
                                 && has_only_native_element_descendants(el))
+                                || el.ns != Namespace::Html
                                 || has_only_static_nested_children(el))
                         {
                             hoist_element_props(ctx, el, allocator);
@@ -369,27 +371,77 @@ fn create_children_expression<'a>(
     None
 }
 
-/// Check if an element has static props (all attributes, no dynamic bindings)
+/// Check if an element has static props that can be hoisted as an object.
 fn has_static_props(el: &ElementNode<'_>) -> bool {
     if el.props.is_empty() {
         return false;
     }
 
-    for prop in el.props.iter() {
-        match prop {
-            PropNode::Directive(_) => {
-                return false;
-            }
-            PropNode::Attribute(attr) => {
-                // `ref` attribute must not be hoisted - it needs runtime resolution
-                if attr.name == "ref" {
-                    return false;
-                }
-            }
-        }
+    el.props.iter().all(is_hoistable_static_prop)
+}
+
+fn is_hoistable_static_prop(prop: &PropNode<'_>) -> bool {
+    match prop {
+        PropNode::Attribute(attr) => attr.name != "ref",
+        PropNode::Directive(dir) => hoistable_static_bind_parts(dir).is_some(),
+    }
+}
+
+fn hoistable_static_bind_parts<'a>(
+    dir: &'a DirectiveNode<'a>,
+) -> Option<(String, &'a SimpleExpressionNode<'a>)> {
+    if dir.name != "bind" {
+        return None;
     }
 
-    true
+    let Some(ExpressionNode::Simple(arg)) = &dir.arg else {
+        return None;
+    };
+    if !arg.is_static {
+        return None;
+    }
+
+    let has_camel = dir.modifiers.iter().any(|m| m.content == "camel");
+    let has_prop = dir.modifiers.iter().any(|m| m.content == "prop");
+    let has_attr = dir.modifiers.iter().any(|m| m.content == "attr");
+    if dir
+        .modifiers
+        .iter()
+        .any(|m| !matches!(m.content.as_str(), "camel" | "prop" | "attr"))
+    {
+        return None;
+    }
+
+    let key = if has_camel {
+        camelize(&arg.content)
+    } else if has_prop {
+        let mut name = String::with_capacity(1 + arg.content.len());
+        name.push('.');
+        name.push_str(&arg.content);
+        name
+    } else if has_attr {
+        let mut name = String::with_capacity(1 + arg.content.len());
+        name.push('^');
+        name.push_str(&arg.content);
+        name
+    } else {
+        arg.content.to_compact_string()
+    };
+
+    // Refs require runtime owner context. Class bindings need normalizeClass,
+    // which this hoisted object path does not serialize yet.
+    if matches!(key.as_str(), "ref" | "class") {
+        return None;
+    }
+
+    let Some(ExpressionNode::Simple(exp)) = &dir.exp else {
+        return None;
+    };
+    if !is_constant_simple_expression(exp, None) {
+        return None;
+    }
+
+    Some((key, exp))
 }
 
 fn has_directives(el: &ElementNode<'_>) -> bool {
@@ -449,36 +501,70 @@ fn hoist_element_props<'a>(
     el: &mut ElementNode<'a>,
     allocator: &'a Bump,
 ) {
-    // Build props object from element attributes. Vue keeps the first
-    // occurrence on duplicate attributes (parser records both for
-    // linters); dedupe here so a hoisted `_hoisted_N` literal doesn't
+    // Build props object from static attributes and constant v-bind props.
+    // Vue keeps the first occurrence on duplicate attributes (parser records
+    // both for linters); dedupe here so a hoisted `_hoisted_N` literal doesn't
     // emit `{ id: "a", id: "b" }`. (#958)
     let mut obj_props = Vec::new_in(allocator);
     let mut seen: vize_carton::FxHashSet<vize_carton::String> = vize_carton::FxHashSet::default();
 
     for prop in el.props.iter() {
-        if let PropNode::Attribute(attr) = prop {
-            if seen.contains(attr.name.as_str()) {
-                continue;
+        match prop {
+            PropNode::Attribute(attr) => {
+                if seen.contains(attr.name.as_str()) {
+                    continue;
+                }
+                seen.insert(attr.name.clone());
+
+                let key = ExpressionNode::Simple(Box::new_in(
+                    SimpleExpressionNode::new(attr.name.clone(), true, attr.loc.clone()),
+                    allocator,
+                ));
+                let value_exp = if let Some(v) = &attr.value {
+                    SimpleExpressionNode::new(v.content.clone(), true, v.loc.clone())
+                } else {
+                    SimpleExpressionNode::new("", true, attr.loc.clone())
+                };
+                let value = JsChildNode::SimpleExpression(Box::new_in(value_exp, allocator));
+
+                obj_props.push(Property {
+                    key,
+                    value,
+                    loc: attr.loc.clone(),
+                });
             }
-            seen.insert(attr.name.clone());
+            PropNode::Directive(dir) => {
+                let Some((name, exp)) = hoistable_static_bind_parts(dir) else {
+                    continue;
+                };
+                if seen.contains(name.as_str()) {
+                    continue;
+                }
+                seen.insert(name.clone());
 
-            let key = ExpressionNode::Simple(Box::new_in(
-                SimpleExpressionNode::new(attr.name.clone(), true, attr.loc.clone()),
-                allocator,
-            ));
-            let value_exp = if let Some(v) = &attr.value {
-                SimpleExpressionNode::new(v.content.clone(), true, v.loc.clone())
-            } else {
-                SimpleExpressionNode::new("", true, attr.loc.clone())
-            };
-            let value = JsChildNode::SimpleExpression(Box::new_in(value_exp, allocator));
+                let key = ExpressionNode::Simple(Box::new_in(
+                    SimpleExpressionNode::new(name, true, dir.loc.clone()),
+                    allocator,
+                ));
+                let value_exp = SimpleExpressionNode {
+                    content: exp.content.clone(),
+                    is_static: false,
+                    const_type: exp.const_type,
+                    loc: exp.loc.clone(),
+                    js_ast: None,
+                    hoisted: None,
+                    identifiers: None,
+                    is_handler_key: false,
+                    is_ref_transformed: false,
+                };
+                let value = JsChildNode::SimpleExpression(Box::new_in(value_exp, allocator));
 
-            obj_props.push(Property {
-                key,
-                value,
-                loc: attr.loc.clone(),
-            });
+                obj_props.push(Property {
+                    key,
+                    value,
+                    loc: dir.loc.clone(),
+                });
+            }
         }
     }
 

--- a/crates/vize_atelier_dom/src/lib.rs
+++ b/crates/vize_atelier_dom/src/lib.rs
@@ -542,6 +542,24 @@ mod tests {
             !code.contains(r#"_createElementVNode("svg""#),
             "nested SVG elements with dynamic props must not render as plain VNodes:\n{code}"
         );
+        assert!(
+            result.preamble.contains("const _hoisted_1"),
+            "constant SVG props should be hoisted:\n{}\n{code}",
+            result.preamble
+        );
+        assert!(
+            result
+                .preamble
+                .contains(r#"xmlns: "http://www.w3.org/2000/svg""#)
+                && result.preamble.contains("width: 0"),
+            "hoisted SVG props should include static attrs and constant v-bind values:\n{}\n{code}",
+            result.preamble
+        );
+        assert!(
+            code.contains(r#"_createElementBlock("svg", _hoisted_1)"#),
+            "nested SVG block should use the hoisted props object:\n{}\n{code}",
+            result.preamble
+        );
     }
 
     #[test]

--- a/crates/vize_atelier_sfc/src/compile/tests.rs
+++ b/crates/vize_atelier_sfc/src/compile/tests.rs
@@ -260,6 +260,43 @@ const active = ref(false)
 }
 
 #[test]
+fn test_template_only_sfc_hoists_constant_svg_bind_props() {
+    let source = r#"<template>
+  <div>
+    <svg xmlns="http://www.w3.org/2000/svg" :width="0"></svg>
+  </div>
+</template>"#;
+    let descriptor = parse_sfc(source, SfcParseOptions::default()).expect("parse");
+    let result = compile_sfc(&descriptor, SfcCompileOptions::default()).expect("compile");
+
+    assert!(
+        result.code.contains("const _hoisted_1"),
+        "constant SVG props should be hoisted:\n{}",
+        result.code
+    );
+    assert!(
+        result
+            .code
+            .contains(r#"xmlns: "http://www.w3.org/2000/svg""#)
+            && result.code.contains("width: 0"),
+        "hoisted SVG props should include the static attr and constant v-bind:\n{}",
+        result.code
+    );
+    assert!(
+        result
+            .code
+            .contains(r#"_createElementBlock("svg", _hoisted_1)"#),
+        "nested SVG block should use the hoisted props object:\n{}",
+        result.code
+    );
+    assert!(
+        !result.code.contains(r#"_createElementVNode("svg""#),
+        "nested SVG with constant v-bind should not render as a plain VNode:\n{}",
+        result.code
+    );
+}
+
+#[test]
 fn test_script_setup_css_v_bind_uses_scoped_vars() {
     let source = r#"<script setup>
 const height = 12


### PR DESCRIPTION
## Summary
- Hoist static attributes together with constant `v-bind` props for foreign-namespace elements such as SVG/MathML.
- Keep nested SVG blocks using the hoisted props object so Vue parity is preserved for `:width="0"`.
- Add DOM and template-only SFC regression coverage for the SVG bind-props hoisting case.

## Root cause
The block-shape fix for SVG was present, but static hoisting only treated plain attributes as hoistable props. Constant `v-bind` props such as `:width="0"` therefore stayed inline instead of being included in `_hoisted_1`.

## Validation
- `cargo test -p vize_atelier_core`
- `cargo test -p vize_atelier_dom`
- `cargo test -p vize_atelier_sfc`

Addresses #1013

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1015"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783251271&installation_id=136613492&pr_number=1015&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1015&signature=d3e4893c93a73f71f20c2ea2b82b89aadb9db986d90d84544050387ab93e03dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->