### PR TITLE
fix: render svg child elements as vnodes

### DIFF
--- a/crates/vize_atelier_core/src/codegen/element/inline.rs
+++ b/crates/vize_atelier_core/src/codegen/element/inline.rs
@@ -36,6 +36,11 @@ use vize_carton::ToCompactString;
 
 /// Generate element code (non-block)
 pub fn generate_element(ctx: &mut CodegenContext, el: &ElementNode<'_>) {
+    if el.tag_type == ElementType::Element && el.ns != Namespace::Html && el.tag == "svg" {
+        super::block::generate_element_block(ctx, el);
+        return;
+    }
+
     if el.tag_type == ElementType::Component
         && (is_dynamic_component(el)
             || matches!(

--- a/crates/vize_atelier_core/src/codegen/element/inline.rs
+++ b/crates/vize_atelier_core/src/codegen/element/inline.rs
@@ -36,11 +36,6 @@ use vize_carton::ToCompactString;
 
 /// Generate element code (non-block)
 pub fn generate_element(ctx: &mut CodegenContext, el: &ElementNode<'_>) {
-    if el.tag_type == ElementType::Element && el.ns != Namespace::Html {
-        super::block::generate_element_block(ctx, el);
-        return;
-    }
-
     if el.tag_type == ElementType::Component
         && (is_dynamic_component(el)
             || matches!(

--- a/crates/vize_atelier_dom/src/snapshots/vize_atelier_dom__tests__svg_codegen_shape_keeps_children_nested.snap
+++ b/crates/vize_atelier_dom/src/snapshots/vize_atelier_dom__tests__svg_codegen_shape_keeps_children_nested.snap
@@ -1,18 +1,17 @@
 ---
 source: crates/vize_atelier_dom/src/lib.rs
-assertion_line: 504
 expression: full.as_str()
 ---
 const { createElementVNode: _createElementVNode, openBlock: _openBlock, createElementBlock: _createElementBlock } = Vue
 
 function render(_ctx, _cache, $props, $setup, $data, $options) {
   return (_openBlock(), _createElementBlock("svg", null, [
-    (_openBlock(), _createElementBlock("foreignObject", null, [
+    _createElementVNode("foreignObject", null, [
       _createElementVNode("div", null, "hi")
-    ])),
-    (_openBlock(), _createElementBlock("rect", {
+    ]),
+    _createElementVNode("rect", {
       x: "1",
       y: "1"
-    }))
+    })
   ]))
 }

--- a/tests/expected/vdom/v-bind.snap
+++ b/tests/expected/vdom/v-bind.snap
@@ -343,6 +343,20 @@ export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("svg", { viewBox: _ctx.viewBox }, null, 8 /* PROPS */, ["viewBox"]))
 }
 ===
+name: svg child constant binding
+options: vdom
+--- INPUT ---
+<svg xmlns="http://www.w3.org/2000/svg"><rect :x="1" /><rect x="1" /></svg>
+--- OUTPUT ---
+import { createElementVNode as _createElementVNode, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+export function render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("svg", { xmlns: "http://www.w3.org/2000/svg" }, [
+    _createElementVNode("rect", { x: 1 }),
+    _createElementVNode("rect", { x: "1" })
+  ]))
+}
+===
 name: v-bind.prop
 options: vdom
 --- INPUT ---

--- a/tests/fixtures/vdom/v-bind.toml
+++ b/tests/fixtures/vdom/v-bind.toml
@@ -139,6 +139,10 @@ name = "v-bind.camel"
 input = '<svg :view-box.camel="viewBox"></svg>'
 
 [[cases]]
+name = "svg child constant binding"
+input = '<svg xmlns="http://www.w3.org/2000/svg"><rect :x="1" /><rect x="1" /></svg>'
+
+[[cases]]
 name = "v-bind.prop"
 input = '<div :text-content.prop="text"></div>'
 


### PR DESCRIPTION
## Summary
- render nested SVG/native child elements with `createElementVNode` instead of forcing block output
- add a Vue parity regression case for constant bindings inside SVG

## Root cause
Nested non-HTML elements were routed through block codegen unconditionally, which diverged from Vue for SVG children.

## Validation
- `cargo test -p vize_test_runner vdom_v_bind --profile ci -- --ignored`
- `cargo fmt --all -- --check`

Closes #1017

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1019"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783262187&installation_id=136613492&pr_number=1019&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1019&signature=e9954c34f39cbd0cbf0155c0da7664636db282b0baa669e0ab091087b99563d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->