### PR TITLE
fix: infer generic union props as unknown

### DIFF
--- a/crates/vize_atelier_sfc/src/compile/tests.rs
+++ b/crates/vize_atelier_sfc/src/compile/tests.rs
@@ -1625,6 +1625,42 @@ const title = defineModel('title')
 }
 
 #[test]
+fn test_generic_union_props_and_model_do_not_emit_null_array_runtime_type() {
+    let source = r#"<template>
+</template>
+
+<script setup lang="ts" generic="T extends string">
+defineProps<{
+  title: T | T[];
+}>();
+
+const model = defineModel<T | T[]>({
+  required: true,
+});
+</script>"#;
+
+    let descriptor = parse_sfc(source, SfcParseOptions::default()).expect("Failed to parse SFC");
+    let result =
+        compile_sfc(&descriptor, SfcCompileOptions::default()).expect("Failed to compile SFC");
+
+    assert!(!result.code.contains("[null, Array]"), "{}", result.code);
+    assert!(
+        result
+            .code
+            .contains("title: {\n    type: null,\n    required: true\n  }"),
+        "{}",
+        result.code
+    );
+    assert!(
+        result
+            .code
+            .contains("\"modelValue\": {\n      type: null,\n      ...{ required: true }"),
+        "{}",
+        result.code
+    );
+}
+
+#[test]
 fn test_non_script_setup_typescript_preserved() {
     // Non-script-setup SFC with is_ts=true preserves TypeScript in the output
     // (matching Vue's @vue/compiler-sfc behavior - TS stripping is the bundler's job)

--- a/crates/vize_atelier_sfc/src/compile_script/props.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/props.rs
@@ -409,7 +409,7 @@ pub(crate) fn ts_type_to_js_type(ts_type: &str) -> String {
             let meaningful: Vec<&str> = parts
                 .iter()
                 .map(|p| p.trim())
-                .filter(|p| *p != "undefined" && *p != "null")
+                .filter(|p| !p.is_empty() && *p != "undefined" && *p != "null")
                 .collect();
 
             if meaningful.is_empty() {
@@ -420,6 +420,9 @@ pub(crate) fn ts_type_to_js_type(ts_type: &str) -> String {
             let mut js_types: Vec<String> = Vec::new();
             for part in &meaningful {
                 let jt = ts_type_to_js_type(part);
+                if jt == "null" {
+                    return jt;
+                }
                 if !js_types.contains(&jt) {
                     js_types.push(jt);
                 }
@@ -1119,7 +1122,7 @@ pub fn is_valid_identifier(s: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::extract_emit_names_from_type;
+    use super::{extract_emit_names_from_type, ts_type_to_js_type};
 
     #[test]
     fn extract_emit_names_keeps_quoted_colon_keys() {
@@ -1132,5 +1135,20 @@ mod tests {
         );
 
         assert_eq!(names, vec!["update:open", "select:item", "close"]);
+    }
+
+    #[test]
+    fn generic_union_with_array_falls_back_to_unknown_runtime_type() {
+        assert_eq!(ts_type_to_js_type("T | T[]"), "null");
+    }
+
+    #[test]
+    fn leading_union_separator_does_not_add_null_runtime_type() {
+        let ty = r#"
+          | { type: "link"; href: string }
+          | { type: "button"; onClick: () => void }
+        "#;
+
+        assert_eq!(ts_type_to_js_type(ty), "Object");
     }
 }

--- a/tests/expected/sfc/script-setup.snap
+++ b/tests/expected/sfc/script-setup.snap
@@ -1434,7 +1434,7 @@ type ButtonVariant =
 export default /*@__PURE__*/_defineComponent({
   __name: 'test',
   props: {
-    variant: { type: [null, Object], required: true }
+    variant: { type: Object, required: true }
   },
   setup(__props: any) {
 

--- a/tests/snapshots/sfc/ts/script_setup__props_with_union_types.snap
+++ b/tests/snapshots/sfc/ts/script_setup__props_with_union_types.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/vize_atelier_sfc/src/snapshot_tests.rs
-assertion_line: 152
 expression: ts_output.as_str()
 ---
 import { defineComponent as _defineComponent } from 'vue'
@@ -15,7 +14,7 @@ type ButtonVariant =
 export default /*@__PURE__*/_defineComponent({
   __name: 'test',
   props: {
-    variant: { type: [null, Object], required: true }
+    variant: { type: Object, required: true }
   },
   setup(__props: any) {
 


### PR DESCRIPTION
## Summary
- Treat unions containing unresolved generic/user-defined runtime types as unknown instead of building arrays like [null, Array]
- Ignore empty union parts from leading-pipe type aliases so object unions infer Object
- Add regression coverage for generic defineProps and defineModel runtime prop output

## Validation
- cargo test -p vize_atelier_sfc --profile ci
- cargo run -p vize_test_runner --bin coverage --profile ci -- -v
- cargo fmt --all -- --check

Closes #1016

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1021"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783263458&installation_id=136613492&pr_number=1021&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1021&signature=55a032b26415e2b865764c6775e6c7226f37d2d5cde2a7daafec9082131257ab"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->