### PR TITLE
perf: avoid repeated null checks in union props

### DIFF
--- a/crates/vize_atelier_sfc/src/compile_script/props.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/props.rs
@@ -420,10 +420,10 @@ pub(crate) fn ts_type_to_js_type(ts_type: &str) -> String {
             let mut js_types: Vec<String> = Vec::new();
             for part in &meaningful {
                 let jt = ts_type_to_js_type(part);
-                if jt == "null" {
-                    return jt;
-                }
                 if !js_types.contains(&jt) {
+                    if jt == "null" {
+                        return jt;
+                    }
                     js_types.push(jt);
                 }
             }


### PR DESCRIPTION
## Summary
- Skip duplicate union runtime constructors before checking the unknown fallback
- Preserve `type: null` fallback for generic unions from #1021

## Verification
- `cargo test -p vize_atelier_sfc generic_union --profile ci`
- `cargo fmt --all -- --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1022"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783264248&installation_id=136613492&pr_number=1022&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1022&signature=b58c730db36bf5962d4fc35216b870d222c1de6dd62a1df1bcaa214f92e3d9b1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->