### PR TITLE
fix: preserve statement handlers and SVG bind caches

### DIFF
--- a/crates/vize_atelier_core/src/transforms/hoist_static.rs
+++ b/crates/vize_atelier_core/src/transforms/hoist_static.rs
@@ -31,7 +31,9 @@ fn is_static_element(el: &ElementNode<'_>) -> bool {
     // Check for dynamic props or ref
     for prop in el.props.iter() {
         match prop {
-            PropNode::Directive(_) => return false,
+            PropNode::Directive(_) if el.tag == "svg" => return false,
+            PropNode::Directive(_) if !is_hoistable_static_prop(prop) => return false,
+            PropNode::Directive(_) => {}
             PropNode::Attribute(attr) => {
                 // ref attribute prevents hoisting - refs need runtime owner context
                 if attr.name == "ref" {
@@ -82,11 +84,14 @@ fn get_element_static_type(el: &ElementNode<'_>) -> StaticType {
 
     for prop in el.props.iter() {
         match prop {
-            PropNode::Directive(_) => {
-                // Any directive makes the element dynamic (non-static)
-                // This includes v-bind:class, v-bind:style, v-on:*, etc.
+            PropNode::Directive(_) if el.tag == "svg" => {
                 return StaticType::NotStatic;
             }
+            PropNode::Directive(_) if !is_hoistable_static_prop(prop) => {
+                // Non-constant directives make the element dynamic.
+                return StaticType::NotStatic;
+            }
+            PropNode::Directive(_) => {}
             PropNode::Attribute(attr) => {
                 // ref attribute prevents hoisting - refs need runtime owner context
                 if attr.name == "ref" {
@@ -269,28 +274,62 @@ fn create_props_expression<'a>(
     let mut seen: vize_carton::FxHashSet<vize_carton::String> = vize_carton::FxHashSet::default();
 
     for prop in props {
-        if let PropNode::Attribute(attr) = prop {
-            if seen.contains(attr.name.as_str()) {
-                continue;
+        match prop {
+            PropNode::Attribute(attr) => {
+                if seen.contains(attr.name.as_str()) {
+                    continue;
+                }
+                seen.insert(attr.name.clone());
+
+                let key = ExpressionNode::Simple(Box::new_in(
+                    SimpleExpressionNode::new(attr.name.clone(), true, attr.loc.clone()),
+                    allocator,
+                ));
+                let value_exp = if let Some(v) = &attr.value {
+                    SimpleExpressionNode::new(v.content.clone(), true, v.loc.clone())
+                } else {
+                    SimpleExpressionNode::new("", true, attr.loc.clone())
+                };
+                let value = JsChildNode::SimpleExpression(Box::new_in(value_exp, allocator));
+
+                obj_props.push(Property {
+                    key,
+                    value,
+                    loc: attr.loc.clone(),
+                });
             }
-            seen.insert(attr.name.clone());
+            PropNode::Directive(dir) => {
+                let Some((name, exp)) = hoistable_static_bind_parts(dir) else {
+                    continue;
+                };
+                if seen.contains(name.as_str()) {
+                    continue;
+                }
+                seen.insert(name.clone());
 
-            let key = ExpressionNode::Simple(Box::new_in(
-                SimpleExpressionNode::new(attr.name.clone(), true, attr.loc.clone()),
-                allocator,
-            ));
-            let value_exp = if let Some(v) = &attr.value {
-                SimpleExpressionNode::new(v.content.clone(), true, v.loc.clone())
-            } else {
-                SimpleExpressionNode::new("", true, attr.loc.clone())
-            };
-            let value = JsChildNode::SimpleExpression(Box::new_in(value_exp, allocator));
+                let key = ExpressionNode::Simple(Box::new_in(
+                    SimpleExpressionNode::new(name, true, dir.loc.clone()),
+                    allocator,
+                ));
+                let value_exp = SimpleExpressionNode {
+                    content: exp.content.clone(),
+                    is_static: false,
+                    const_type: exp.const_type,
+                    loc: exp.loc.clone(),
+                    js_ast: None,
+                    hoisted: None,
+                    identifiers: None,
+                    is_handler_key: false,
+                    is_ref_transformed: false,
+                };
+                let value = JsChildNode::SimpleExpression(Box::new_in(value_exp, allocator));
 
-            obj_props.push(Property {
-                key,
-                value,
-                loc: attr.loc.clone(),
-            });
+                obj_props.push(Property {
+                    key,
+                    value,
+                    loc: dir.loc.clone(),
+                });
+            }
         }
     }
 
@@ -489,10 +528,7 @@ fn is_plain_static_nested_element(el: &ElementNode<'_>) -> bool {
 }
 
 fn props_are_static_attrs(el: &ElementNode<'_>) -> bool {
-    el.props.iter().all(|prop| match prop {
-        PropNode::Directive(_) => false,
-        PropNode::Attribute(attr) => attr.name != "ref",
-    })
+    el.props.iter().all(is_hoistable_static_prop)
 }
 
 /// Hoist the props of an element with static props

--- a/crates/vize_atelier_dom/src/lib.rs
+++ b/crates/vize_atelier_dom/src/lib.rs
@@ -529,7 +529,7 @@ mod tests {
         let allocator = Bump::new();
         let (_, errors, result) = compile_template(
             &allocator,
-            r#"<div><svg xmlns="http://www.w3.org/2000/svg" :width="0" /></div>"#,
+            r#"<div><svg xmlns="http://www.w3.org/2000/svg" :width="w" /></div>"#,
         );
         assert!(errors.is_empty());
 
@@ -542,22 +542,31 @@ mod tests {
             !code.contains(r#"_createElementVNode("svg""#),
             "nested SVG elements with dynamic props must not render as plain VNodes:\n{code}"
         );
+    }
+
+    #[test]
+    fn test_svg_constant_bound_children_are_cached_vnodes() {
+        let allocator = Bump::new();
+        let (_, errors, result) = compile_template(
+            &allocator,
+            r#"<svg xmlns="http://www.w3.org/2000/svg"><rect :x="1" /><rect x="1" /></svg>"#,
+        );
+        assert!(errors.is_empty());
+
+        let code = result.code.as_str();
         assert!(
-            result.preamble.contains("const _hoisted_1"),
-            "constant SVG props should be hoisted:\n{}\n{code}",
+            code.contains("[...(_cache[0]"),
+            "static SVG children should be cached together:\n{}\n{code}",
             result.preamble
         );
         assert!(
-            result
-                .preamble
-                .contains(r#"xmlns: "http://www.w3.org/2000/svg""#)
-                && result.preamble.contains("width: 0"),
-            "hoisted SVG props should include static attrs and constant v-bind values:\n{}\n{code}",
+            code.contains(r#"_createElementVNode("rect", { x: 1 }, null, -1 /* CACHED */)"#),
+            "constant v-bind SVG child should compile as a cached VNode:\n{}\n{code}",
             result.preamble
         );
         assert!(
-            code.contains(r#"_createElementBlock("svg", _hoisted_1)"#),
-            "nested SVG block should use the hoisted props object:\n{}\n{code}",
+            !code.contains(r#"_createElementBlock("rect""#),
+            "constant SVG children must not become block roots:\n{}\n{code}",
             result.preamble
         );
     }

--- a/crates/vize_canon/src/batch/type_checker/tests.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests.rs
@@ -498,6 +498,50 @@ function doB(): string { return 'x' }
 }
 
 #[test]
+fn batch_type_checker_multiline_statement_handler_does_not_parse_error() {
+    if resolve_test_tsgo_binary().is_none() {
+        return;
+    }
+
+    let project_root = create_project_case_without_node_modules(
+        "multiline-statement-handler",
+        &[(
+            "src/StatementHandler.vue",
+            r#"<script setup lang="ts">
+const keys = ['a']
+function selectWord(key: string) {}
+function editWord() {}
+</script>
+
+<template>
+  <button
+    v-for="key in keys"
+    @click.stop="
+      selectWord(key);
+      editWord();
+    "
+  >edit</button>
+</template>
+"#,
+        )],
+    );
+
+    let Some(snapshot) = snapshot_project_diagnostics(&project_root) else {
+        let _ = std::fs::remove_dir_all(&project_root);
+        return;
+    };
+
+    assert!(
+        snapshot
+            .iter()
+            .all(|(file, code, _)| { file != "src/StatementHandler.vue" || *code != Some(1005) }),
+        "unexpected TS1005 parse diagnostic for statement-list handler: {snapshot:#?}"
+    );
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}
+
+#[test]
 fn batch_type_checker_uses_workspace_vue_runtime_without_node_modules() {
     if resolve_test_tsgo_binary().is_none() {
         return;

--- a/crates/vize_canon/src/virtual_ts.rs
+++ b/crates/vize_canon/src/virtual_ts.rs
@@ -628,6 +628,50 @@ function handleHover() {}
     }
 
     #[test]
+    fn test_multiline_statement_event_handler_uses_handler_scope() {
+        use vize_croquis::{Analyzer, AnalyzerOptions};
+
+        let script = r#"const keys = ['a']
+function selectWord(key: string) {}
+function editWord() {}
+"#;
+        let template = r#"<button
+  v-for="key in keys"
+  @click.stop="
+    selectWord(key);
+    editWord();
+  "
+>edit</button>"#;
+
+        let allocator = vize_carton::Bump::new();
+        let (root, _) = vize_armature::parse(&allocator, template);
+
+        let mut analyzer = Analyzer::with_options(AnalyzerOptions::full());
+        analyzer.analyze_script_setup(script);
+        analyzer.analyze_template(&root);
+        let summary = analyzer.finish();
+
+        let output = generate_virtual_ts(&summary, Some(script), Some(&root), 0);
+
+        assert!(
+            output.code.contains("// @click handler"),
+            "statement-list handlers should get an event handler scope:\n{}",
+            output.code
+        );
+        assert!(
+            output.code.contains("selectWord(key);") && output.code.contains("editWord();"),
+            "handler statements should be preserved:\n{}",
+            output.code
+        );
+        assert!(
+            !output.code.contains("void (selectWord(key);")
+                && !output.code.contains("void (\n    selectWord(key);"),
+            "statement-list handlers must not be emitted as parenthesized expressions:\n{}",
+            output.code
+        );
+    }
+
+    #[test]
     fn test_object_form_v_on_is_preserved_as_expression() {
         use vize_croquis::{Analyzer, AnalyzerOptions};
 

--- a/crates/vize_croquis/src/analyzer/template/directives/v_on.rs
+++ b/crates/vize_croquis/src/analyzer/template/directives/v_on.rs
@@ -118,10 +118,11 @@ impl Analyzer {
 
                 self.summary.scopes.exit_scope();
             } else {
-                // Simple handler reference
+                // Simple handler reference, or inline statement-list handler.
                 let has_implicit_event = content.contains("$event") || !content.contains('(');
+                let is_statement_list = is_inline_statement_list(content);
 
-                if has_implicit_event && !content.contains("=>") {
+                if (has_implicit_event || is_statement_list) && !content.contains("=>") {
                     self.summary.scopes.enter_event_handler_scope(
                         EventHandlerScopeData {
                             event_name: dir
@@ -136,7 +137,7 @@ impl Analyzer {
                                     }
                                 })
                                 .unwrap_or_else(|| CompactString::const_new("unknown")),
-                            has_implicit_event: true,
+                            has_implicit_event,
                             param_names: smallvec![],
                             handler_expression: Some(CompactString::new(content)),
                             target_component,
@@ -197,4 +198,18 @@ impl Analyzer {
             }
         }
     }
+}
+
+fn is_inline_statement_list(content: &str) -> bool {
+    let trimmed = content.trim_end();
+    if trimmed.ends_with(';') {
+        return true;
+    }
+
+    content
+        .split(';')
+        .take(2)
+        .filter(|part| !part.trim().is_empty())
+        .count()
+        > 1
 }

--- a/tests/snapshots/inspect/elk.ts
+++ b/tests/snapshots/inspect/elk.ts
@@ -10,17 +10,17 @@ describe("elk inspector parity with Vue compiler", () => {
       {
         target: "dom",
         changedFiles: 253,
-        additions: 10_361,
+        additions: 10_451,
         removals: 13_326,
-        officialErrors: 1,
+        officialErrors: 3,
         vizeErrors: 0,
       },
       {
         target: "ssr",
         changedFiles: 253,
-        additions: 8_975,
+        additions: 9_030,
         removals: 24_538,
-        officialErrors: 1,
+        officialErrors: 3,
         vizeErrors: 0,
       },
     ]);


### PR DESCRIPTION
## Summary
- Treat multi-line statement-list `v-on` handlers as handler scopes so generated virtual TS stays parseable.
- Cache SVG children with constant `v-bind` props while keeping SVG roots with directives as blocks.
- Refresh elk inspector budgets against the current Vue compiler behavior.

## Validation
- `cargo fmt --all -- --check`
- `cargo test --workspace`
- `cargo clippy --workspace -- -D warnings`
- `cargo semver-checks -p vize_canon`
- `cargo build -p vize --profile ci`
- `node --test --test-concurrency=1 tests/snapshots/check/ant-design-vue.ts tests/snapshots/check/misskey.ts tests/snapshots/check/npmx.ts tests/snapshots/check/nuxt-ui.ts tests/snapshots/check/reka-ui.ts tests/snapshots/check/vuefes.ts`
- `node --test --test-concurrency=1 tests/snapshots/inspect/npmx.ts tests/snapshots/inspect/elk.ts tests/snapshots/inspect/vuefes.ts`

Local `tests/snapshots/check/elk.ts` was not refreshed because this checkout lacks generated Nuxt/dependency artifacts; it reports missing `masto` and Nuxt auto-imports rather than a compiler regression.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1024"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783273480&installation_id=136613492&pr_number=1024&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1024&signature=55d35a9f29dbba4548900295a25ecc1a91289913928085db24c1e6feaa570702"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->