### PR TITLE
perf(maestro): collect only lint diagnostics for hover

### DIFF
--- a/crates/vize_maestro/src/ide/diagnostics.rs
+++ b/crates/vize_maestro/src/ide/diagnostics.rs
@@ -230,6 +230,77 @@ impl DiagnosticService {
         diagnostics
     }
 
+    /// Collect only the lint-sourced diagnostics (`vize/lint`, `vize/musea`)
+    /// for a document.
+    ///
+    /// This is a fast subset of [`Self::collect`] used by the hover handler,
+    /// which only ever reads diagnostics whose source is `vize/lint` or
+    /// `vize/musea`. It reproduces exactly the lint/musea diagnostics that the
+    /// full pipeline would publish — including the parser-error short-circuit
+    /// that gates them — while skipping the expensive SFC compile, ecosystem,
+    /// and (per-call, uncached) SFC type-check passes that hover discards. The
+    /// returned set is byte-for-byte the lint/musea subset of `collect`'s
+    /// output for every document shape (Art file, standalone HTML, SFC).
+    pub fn collect_lint_only(state: &ServerState, uri: &Url) -> Vec<Diagnostic> {
+        let Some(doc) = state.documents.get(uri) else {
+            return vec![];
+        };
+
+        let content = doc.text();
+        let features = state.lsp_features();
+        let mut diagnostics = Vec::new();
+
+        if !features.has_diagnostics() || !features.lint {
+            return diagnostics;
+        }
+
+        // Art files (*.art.vue): Musea-specific lint only.
+        let path = uri.path();
+        if path.ends_with(".art.vue") {
+            diagnostics.extend(Self::collect_musea_diagnostics(uri, &content));
+            return diagnostics;
+        }
+
+        // Standalone HTML: patina lint only.
+        if is_standalone_html_path(path) {
+            let linter_config = state.get_linter_config();
+            diagnostics.extend(Self::collect_lint_diagnostics(
+                uri,
+                &content,
+                features.ecosystem,
+                &linter_config,
+            ));
+            return diagnostics;
+        }
+
+        // Standard SFC: parse once, then mirror `collect`'s parser-error
+        // short-circuit so lint only surfaces when the full pipeline would
+        // also surface it.
+        let Ok(descriptor) = Self::parse_sfc_for_collect(uri, &content) else {
+            return diagnostics;
+        };
+        let has_block_parse_error = !Self::collect_script_diagnostics(uri, &content, &descriptor)
+            .is_empty()
+            || !Self::collect_template_diagnostics(uri, &content, &descriptor).is_empty();
+        if has_block_parse_error {
+            return diagnostics;
+        }
+
+        let linter_config = state.get_linter_config();
+        diagnostics.extend(Self::collect_lint_diagnostics(
+            uri,
+            &content,
+            features.ecosystem,
+            &linter_config,
+        ));
+        diagnostics.extend(Self::collect_inline_art_diagnostics(
+            uri,
+            &content,
+            &descriptor,
+        ));
+        diagnostics
+    }
+
     /// Collect diagnostics asynchronously (includes Corsa diagnostics when available).
     #[cfg(feature = "native")]
     pub async fn collect_async(state: &ServerState, uri: &Url) -> Vec<Diagnostic> {
@@ -452,7 +523,7 @@ mod tests {
 
     use super::{DiagnosticBuilder, DiagnosticService, Severity, offset_to_line_col, sources};
     use crate::server::ServerState;
-    use tower_lsp::lsp_types::{DiagnosticSeverity, NumberOrString, Url};
+    use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, NumberOrString, Url};
 
     fn state_with_lsp_diagnostics(lint: bool, typecheck: bool) -> ServerState {
         let state = ServerState::new();
@@ -944,6 +1015,97 @@ const title = t("auth.missing")
                 .iter()
                 .any(|diagnostic| diagnostic.source.as_deref() == Some(sources::SCRIPT_PARSER))
         );
+    }
+
+    fn lint_subset(diagnostics: &[Diagnostic]) -> Vec<Diagnostic> {
+        diagnostics
+            .iter()
+            .filter(|d| {
+                matches!(
+                    d.source.as_deref(),
+                    Some(sources::LINTER) | Some(sources::MUSEA)
+                )
+            })
+            .cloned()
+            .collect()
+    }
+
+    #[test]
+    fn collect_lint_only_equals_lint_subset_of_collect() {
+        // With both lint and typecheck enabled, collect() produces LINTER and
+        // TYPE_CHECKER diagnostics; collect_lint_only() must return exactly the
+        // LINTER/MUSEA subset (same diagnostics, same order) and nothing else.
+        let state = state_with_lsp_diagnostics(true, true);
+        let uri = Url::parse("file:///OutOfOrder.vue").unwrap();
+        state.documents.open(
+            uri.clone(),
+            "<template><div /></template>\n<script setup>const count = 1</script>".to_string(),
+            1,
+            "vue".to_string(),
+        );
+
+        let full = DiagnosticService::collect(&state, &uri);
+        let lint_only = DiagnosticService::collect_lint_only(&state, &uri);
+
+        // Sanity: the full pipeline really did surface a lint diagnostic here.
+        assert!(
+            full.iter()
+                .any(|d| d.source.as_deref() == Some(sources::LINTER)),
+            "expected a lint diagnostic from the full pipeline"
+        );
+        // The lint-only result is byte-for-byte the lint/musea subset.
+        assert_eq!(lint_only, lint_subset(&full));
+        // And it carries no non-lint sources (no type-check / parser / sfc-compile).
+        assert!(
+            lint_only.iter().all(|d| {
+                matches!(
+                    d.source.as_deref(),
+                    Some(sources::LINTER) | Some(sources::MUSEA)
+                )
+            }),
+            "collect_lint_only must only return lint/musea diagnostics, got: {:?}",
+            lint_only
+                .iter()
+                .map(|d| d.source.as_deref())
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn collect_lint_only_short_circuits_on_parse_error() {
+        // A block parse error gates lint in the full pipeline, so the lint-only
+        // path must also return nothing — matching what hover would otherwise see.
+        let state = state_with_lsp_diagnostics(true, true);
+        let uri = Url::parse("file:///BrokenTemplateLintOnly.vue").unwrap();
+        state.documents.open(
+            uri.clone(),
+            "<script setup lang=\"ts\">const count = 1</script>\n<template><div>{{ count }}</template>"
+                .to_string(),
+            1,
+            "vue".to_string(),
+        );
+
+        let full = DiagnosticService::collect(&state, &uri);
+        let lint_only = DiagnosticService::collect_lint_only(&state, &uri);
+
+        assert_eq!(lint_only, lint_subset(&full));
+        assert!(lint_only.is_empty());
+    }
+
+    #[test]
+    fn collect_lint_only_is_empty_when_lint_disabled() {
+        // Hover gates on is_lsp_lint_enabled, but the collector is defensively
+        // empty when lint is off even if typecheck is on.
+        let state = state_with_lsp_diagnostics(false, true);
+        let uri = Url::parse("file:///NoLint.vue").unwrap();
+        state.documents.open(
+            uri.clone(),
+            "<script setup>const props = defineProps(['count'])</script><template>{{ props.count }}</template>".to_string(),
+            1,
+            "vue".to_string(),
+        );
+
+        assert!(DiagnosticService::collect_lint_only(&state, &uri).is_empty());
     }
 
     #[test]

--- a/crates/vize_maestro/src/server/helpers.rs
+++ b/crates/vize_maestro/src/server/helpers.rs
@@ -140,7 +140,10 @@ impl MaestroServer {
             return None;
         }
 
-        let diagnostics = DiagnosticService::collect(&self.state, uri);
+        // Hover only surfaces `vize/lint` / `vize/musea` diagnostics at the
+        // cursor, so collect just that subset instead of re-running the entire
+        // pipeline (full SFC type-check + ecosystem passes) on every hover.
+        let diagnostics = DiagnosticService::collect_lint_only(&self.state, uri);
 
         let lint_diags: Vec<_> = diagnostics
             .iter()


### PR DESCRIPTION
The hover handler only ever surfaces `vize/lint` / `vize/musea` diagnostics overlapping the cursor, but it called `DiagnosticService::collect`, which re-ran the entire diagnostics pipeline on every hover — SFC parse, script/template parse, SFC compile, full patina lint, ecosystem passes, and (since typecheck defaults to on) a complete, uncached SFC type check — then threw all of it away except the lint subset.

Add `DiagnosticService::collect_lint_only`, which reproduces exactly the lint/musea subset the full pipeline would publish (same parser-error short-circuit, same per-document-shape branching) while skipping the SFC-compile, ecosystem, and type-check passes. Hover output is unchanged; the per-hover cost drops from a full lint+typecheck to a parse+lint.

Tests assert the lint-only result is byte-for-byte the lint/musea subset of `collect`, that it short-circuits on block parse errors, and that it is empty when lint is disabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1025"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783277241&installation_id=136613492&pr_number=1025&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1025&signature=30a3dcaff00aef04acf89e2d625515bc6e34b48b85dc6b65656c7d20aa1b221f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->