### PR TITLE
perf(atelier-core): fast-path escape_js_string for plain strings

### DIFF
--- a/crates/vize_atelier_core/src/codegen/helpers.rs
+++ b/crates/vize_atelier_core/src/codegen/helpers.rs
@@ -18,6 +18,13 @@ use vize_croquis::builtins::is_global_allowed;
 /// Decode HTML entities (numeric character references) in a string
 /// Supports &#xHHHH; (hex) and &#NNNN; (decimal) formats
 pub fn decode_html_entities(s: &str) -> String {
+    // Numeric entity decoding only ever triggers on `&`. Without one, the
+    // result is the input verbatim, so skip the per-char state machine and
+    // its intermediate growth and copy the string in a single pass.
+    if !s.contains('&') {
+        return String::from(s);
+    }
+
     let mut result = String::with_capacity(s.len());
     let mut chars = s.chars().peekable();
 
@@ -75,8 +82,36 @@ pub fn decode_html_entities(s: &str) -> String {
     result
 }
 
+/// Returns true if a byte may belong to a character that `escape_js_string`
+/// would rewrite (an escape-requiring char) or that `decode_html_entities`
+/// might act on (`&`). Used as a cheap fast-path gate: when no byte of the
+/// input matches, the string passes through both stages unchanged.
+///
+/// The control characters the slow path escapes are exactly the Unicode `Cc`
+/// category — C0 (U+0000..=U+001F), DEL (U+007F), and C1 (U+0080..=U+009F) —
+/// because the catch-all arm uses `char::is_control()`. In UTF-8 those are the
+/// bytes `0x00..=0x1F`, `0x7F`, and the two-byte sequences `0xC2 0x80..=0xC2
+/// 0x9F`. We flag every `0xC2` lead byte (a conservative superset of the C1
+/// range) so a C1 control can never slip through the fast path; this is the
+/// subtle case a naive `b < 0x20` check would miss. All other non-ASCII bytes
+/// (lead `>= 0xC3` and continuation bytes) encode characters `>= U+00C0`, none
+/// of which are control characters, so they are safe to pass through.
+#[inline]
+fn byte_may_need_js_escaping(b: u8) -> bool {
+    b < 0x20 || b == b'"' || b == b'&' || b == b'\\' || b == 0x7F || b == 0xC2
+}
+
 /// Escape a string for use in JavaScript string literals
 pub fn escape_js_string(s: &str) -> String {
+    // Fast path: when no byte can require HTML-entity decoding or JS escaping,
+    // the two-pass decode+escape would reproduce the input verbatim. Skip both
+    // passes (and their allocations) and copy once. This is the overwhelmingly
+    // common case — plain text, attribute values, and identifiers — on a path
+    // hit for every text node, prop, comment, and slot name during codegen.
+    if !s.bytes().any(byte_may_need_js_escaping) {
+        return String::from(s);
+    }
+
     // First decode HTML entities, then escape for JS
     let decoded = decode_html_entities(s);
     let mut result = String::with_capacity(decoded.len());
@@ -429,5 +464,114 @@ pub fn is_builtin_component(name: &str) -> Option<RuntimeHelper> {
         "Transition" | "transition" => Some(RuntimeHelper::Transition),
         "TransitionGroup" | "transition-group" => Some(RuntimeHelper::TransitionGroup),
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod escape_tests {
+    use super::{decode_html_entities, escape_js_string};
+
+    /// Reference implementation of the JS-string escape that always runs the
+    /// full char-by-char pass (no fast path). `escape_js_string`'s fast path
+    /// must reproduce this exactly for every input.
+    fn reference_escape(s: &str) -> String {
+        let decoded = decode_html_entities(s);
+        let mut out = String::new();
+        for c in decoded.chars() {
+            match c {
+                '\\' => out.push_str("\\\\"),
+                '"' => out.push_str("\\\""),
+                '\n' => out.push_str("\\n"),
+                '\r' => out.push_str("\\r"),
+                '\t' => out.push_str("\\t"),
+                '\u{08}' => out.push_str("\\b"),
+                '\u{0C}' => out.push_str("\\f"),
+                c if c.is_control() => out.push_str(&format!("\\u{:04x}", c as u32)),
+                c => out.push(c),
+            }
+        }
+        out
+    }
+
+    #[test]
+    fn fast_path_matches_reference_for_every_control_char() {
+        // Every Cc codepoint (C0 0x00..=0x1F, DEL 0x7F, C1 0x80..=0x9F) plus
+        // surrounding printable bytes — the fast path must agree with the slow
+        // path on all of them. This is the case the original fast-path proposal
+        // got wrong (DEL and C1 controls).
+        for cp in 0u32..=0x9Fu32 {
+            let ch = char::from_u32(cp).unwrap();
+            for sample in [
+                format!("{ch}"),
+                format!("a{ch}b"),
+                format!("{ch}{ch}"),
+                format!("pre {ch} post"),
+            ] {
+                assert_eq!(
+                    escape_js_string(&sample),
+                    reference_escape(&sample),
+                    "mismatch for codepoint U+{cp:04X}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn fast_path_matches_reference_for_assorted_strings() {
+        let cases = [
+            "",
+            "hello world",
+            "plain ascii identifier_123",
+            "a\"b",
+            "a\\b",
+            "tab\tnewline\nreturn\r",
+            "back\u{08}space form\u{0C}feed",
+            "del\u{7f}char",
+            "c1\u{80}\u{9f}controls",
+            "café résumé naïve", // accented (0xC3 lead, fast path)
+            "こんにちは世界",    // CJK (0xE3 lead, fast path)
+            "© 2024 ® ±",        // Latin-1 supplement (0xC2 lead, slow path)
+            "amp & without hash",
+            "named &amp; entity",
+            "numeric &#x41;&#66; entities",
+            "quote entity &#34; here",
+            "mix \"q\" & \u{80} \t end",
+            "emoji 😀 passthrough",
+        ];
+        for case in cases {
+            assert_eq!(
+                escape_js_string(case),
+                reference_escape(case),
+                "mismatch for {case:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn plain_strings_pass_through_unchanged() {
+        for s in ["hello", "café", "こんにちは", "a_b$c123", ""] {
+            assert_eq!(escape_js_string(s), s);
+        }
+    }
+
+    #[test]
+    fn escapes_specific_known_outputs() {
+        assert_eq!(escape_js_string("a\"b"), "a\\\"b");
+        assert_eq!(escape_js_string("a\\b"), "a\\\\b");
+        assert_eq!(escape_js_string("\u{7f}"), "\\u007f"); // DEL
+        assert_eq!(escape_js_string("\u{80}"), "\\u0080"); // C1 start
+        assert_eq!(escape_js_string("\u{9f}"), "\\u009f"); // C1 end
+        assert_eq!(escape_js_string("\u{01}"), "\\u0001"); // C0
+        assert_eq!(escape_js_string("&#x22;"), "\\\""); // entity -> quote -> escaped
+    }
+
+    #[test]
+    fn decode_fast_path_matches_full_decode() {
+        // No '&' -> verbatim; entities still decode correctly.
+        assert_eq!(decode_html_entities("plain text"), "plain text");
+        assert_eq!(decode_html_entities("café"), "café");
+        assert_eq!(decode_html_entities("&#x41;&#66;"), "AB");
+        assert_eq!(decode_html_entities("&amp; stays"), "&amp; stays");
+        assert_eq!(decode_html_entities("&#zz; invalid"), "&#zz; invalid");
     }
 }


### PR DESCRIPTION
`escape_js_string` is on the hottest codegen path — invoked for every text node, attribute value, comment, prop value and slot name (63 call sites). It unconditionally ran two passes that each allocate and copy: `decode_html_entities` (walks every char even with no `&`) followed by a char-by-char escape copy. For the overwhelmingly common case of plain text with nothing to decode or escape, that is two heap allocations and two scans of wasted work.

Add a single byte-scan fast path that returns the input verbatim (one copy) when no byte can require entity decoding or JS escaping, and give `decode_html_entities` the same `&`-free fast path.

The fast-path predicate is the subtle part: `char::is_control()` escapes the full Cc category, so DEL (U+007F) and the C1 controls (U+0080..=U+009F) must NOT slip through. The byte gate flags `< 0x20`, quote, `&`, backslash, `0x7F`, and every `0xC2` lead byte, so every escape-requiring char falls back to the slow path while ordinary non-ASCII text (CJK, most accented Latin) stays on the fast path.

Adds tests (previously none) that diff the fast path against a reference slow-path implementation across every Cc codepoint plus assorted strings, locking in byte-for-byte identical output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1026"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783277244&installation_id=136613492&pr_number=1026&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1026&signature=5d112cefc632c7d174374cb271e32fcfb26c370a6920c65630e1856990e4687a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->