### PR TITLE
perf(canon): resolve parent scope by O(1) index in closure-set passes

### DIFF
--- a/crates/vize_canon/src/virtual_ts/scope.rs
+++ b/crates/vize_canon/src/virtual_ts/scope.rs
@@ -101,8 +101,11 @@ pub(crate) fn generate_scope_closures(
                 .iter()
                 .filter(|scope| {
                     scope.parent().is_some_and(|pid| {
-                        summary.scopes.iter().any(|s| {
-                            s.id == pid && matches!(s.kind, ScopeKind::VFor | ScopeKind::VSlot)
+                        // Scope ids are arena indices, so resolve the parent
+                        // with the O(1) indexed lookup instead of rescanning
+                        // every scope (was O(n^2) over the scope arena).
+                        summary.scopes.get_scope(pid).is_some_and(|parent| {
+                            matches!(parent.kind, ScopeKind::VFor | ScopeKind::VSlot)
                         })
                     })
                 })
@@ -557,10 +560,11 @@ fn generate_component_props(
         .filter(|s| {
             matches!(s.kind, ScopeKind::VFor | ScopeKind::VSlot)
                 && s.parent().is_none_or(|pid| {
+                    // O(1) arena lookup of the parent scope rather than a
+                    // linear find per scope (was O(n^2) over the arena).
                     summary
                         .scopes
-                        .iter()
-                        .find(|p| p.id == pid)
+                        .get_scope(pid)
                         .is_none_or(|p| !matches!(p.kind, ScopeKind::VFor | ScopeKind::VSlot))
                 })
         })


### PR DESCRIPTION
`generate_scope_closures` and `generate_component_props` each built an `FxHashSet` by iterating every scope and, for each one, running a full inner linear scan over the whole scope arena to find its parent (`scopes.iter().any(|s| s.id == pid ...)` / `.find(|p| p.id == pid)`). That is O(n^2) in the scope count, recomputed once per SFC during virtual-TS generation (every `vize check` file and every LSP keystroke).

Scope ids are arena indices and the arena is never reordered, so `ScopeChain::get_scope(pid)` — already used elsewhere in this file — resolves the parent in O(1). Swap both inner scans for it, turning each pass into O(n). Behavior is identical: a missing/out-of-range id yields None, matching the previous `find(...)` fallback exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1027"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783277246&installation_id=136613492&pr_number=1027&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1027&signature=f249eaf6c82d2e48c52bcece95754f694d1d4f24989d002ad123b16b86a66590"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->