### PR TITLE
perf(atelier-sfc): split the Vite request id once in classify

### DIFF
--- a/crates/vize_atelier_sfc/src/vite_plugin/request.rs
+++ b/crates/vize_atelier_sfc/src/vite_plugin/request.rs
@@ -2,7 +2,7 @@ use vize_carton::String;
 
 use super::{
     boundary::boundary_kind,
-    query::{query_has_key, query_value_is, split_request},
+    query::{SplitRequest, query_has_key, query_value_is, split_request},
     style::classify_style,
 };
 
@@ -61,7 +61,7 @@ pub fn classify_vite_plugin_request(id: &str) -> VitePluginRequest {
     let has_macro_query = query_value_is(split.query, "macro", "true");
     let has_define_page_query = query_has_key(split.query, "definePage");
     let style = classify_style(split.query);
-    let is_vize_virtual = is_vize_virtual_vue_module_id(id);
+    let is_vize_virtual = is_vize_virtual_vue_module_id(id, split.path);
     let is_vize_ssr_virtual = id.starts_with(VIZE_SSR_PREFIX);
 
     VitePluginRequest {
@@ -72,7 +72,7 @@ pub fn classify_vite_plugin_request(id: &str) -> VitePluginRequest {
         is_vize_virtual,
         is_vize_ssr_virtual,
         vize_virtual_path: is_vize_virtual.then(|| vize_virtual_path(id)),
-        normalized_fs_id: normalized_fs_id(id),
+        normalized_fs_id: normalized_fs_id(&split),
         has_macro_query,
         has_define_page_query,
         is_macro_virtual_id: id.starts_with('\0') && (has_macro_query || has_define_page_query),
@@ -151,8 +151,8 @@ fn stripped_virtual_query_path(id: &str) -> Option<String> {
     })
 }
 
-fn is_vize_virtual_vue_module_id(id: &str) -> bool {
-    id.starts_with('\0') && split_request(id).path.ends_with(".vue.ts")
+fn is_vize_virtual_vue_module_id(id: &str, path: &str) -> bool {
+    id.starts_with('\0') && path.ends_with(".vue.ts")
 }
 
 fn vize_virtual_path(id: &str) -> String {
@@ -166,8 +166,7 @@ fn vize_virtual_path(id: &str) -> String {
     String::from(normalize_vue_path(split.path))
 }
 
-fn normalized_fs_id(id: &str) -> Option<String> {
-    let split = split_request(id);
+fn normalized_fs_id(split: &SplitRequest<'_>) -> Option<String> {
     let path = split.path.strip_prefix("/@fs")?;
     let mut normalized = String::with_capacity(path.len() + split.query_suffix.len());
     normalized.push_str(path);

--- a/crates/vize_atelier_sfc/src/vite_plugin/tests.rs
+++ b/crates/vize_atelier_sfc/src/vite_plugin/tests.rs
@@ -124,6 +124,36 @@ fn snapshots_style_virtual_queries() {
 }
 
 #[test]
+fn classifies_virtual_vue_ts_with_query_consistently() {
+    // Exercises the fields that are now all derived from a single split of the
+    // id: is_vize_virtual (from split.path), the query suffix, and
+    // normalized_fs_id (None for a non-/@fs path).
+    let request = classify_vite_plugin_request("\0/src/App.vue.ts?foo=bar");
+
+    assert!(request.is_vize_virtual);
+    assert!(!request.is_vize_ssr_virtual);
+    assert_eq!(request.query_suffix.as_str(), "?foo=bar");
+    assert_eq!(request.path.as_str(), "\0/src/App.vue.ts");
+    assert_eq!(request.vize_virtual_path.as_deref(), Some("/src/App.vue"));
+    assert!(request.normalized_fs_id.is_none());
+}
+
+#[test]
+fn classifies_fs_prefixed_vue_request() {
+    // A /@fs path that is also a .vue request: normalized_fs_id strips the
+    // prefix and keeps the query, while the .vue (not .vue.ts) path is not a
+    // Vize virtual module — both read off the same single split.
+    let request = classify_vite_plugin_request("/@fs/abs/src/App.vue?vue&type=template");
+
+    assert_eq!(
+        request.normalized_fs_id.as_deref(),
+        Some("/abs/src/App.vue?vue&type=template")
+    );
+    assert!(!request.is_vize_virtual);
+    assert!(request.is_vue_sfc_path);
+}
+
+#[test]
 fn classifies_vue_boundaries() {
     assert_eq!(
         classify_vite_plugin_request("/src/Foo.client.vue")


### PR DESCRIPTION
`classify_vite_plugin_request` is the native entry point the Vite plugin calls several times per load/resolve/transform hook for each module id. It re-ran `split_request` (a `?`-scan over the whole id) three times on the same id: once at the top, again inside `is_vize_virtual_vue_module_id`, and again inside `normalized_fs_id`.

Thread the single top-level `SplitRequest` into both helpers so the id is scanned once. Pure refactor — output is identical (the existing fs-id / virtual / ssr / style / macro tests all still pass), with added cases covering a virtual `.vue.ts?query` id and a `/@fs` .vue request that read several fields off the shared split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1028"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783277249&installation_id=136613492&pr_number=1028&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1028&signature=b9b77143ad1d6a8aff3777b425e7989dee49eade965275b6606c92d03a0bd0b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->