### PR TITLE
fix: preserve SVG namespace boundary blocks

### DIFF
--- a/crates/vize_atelier_core/src/codegen/children.rs
+++ b/crates/vize_atelier_core/src/codegen/children.rs
@@ -4,7 +4,7 @@ use crate::ast::*;
 use crate::transforms::hoist_static::is_static_node;
 
 use super::context::CodegenContext;
-use super::element::helpers::has_renderable_props;
+use super::element::helpers::{child_namespace, has_renderable_props};
 use super::expression::generate_expression;
 use super::helpers::escape_js_string;
 use super::node::generate_node;
@@ -282,7 +282,9 @@ fn generate_cached_static_vnode(ctx: &mut CodegenContext, el: &ElementNode<'_>) 
 
     if !el.children.is_empty() {
         ctx.push(", ");
-        generate_children(ctx, &el.children);
+        ctx.with_parent_namespace(child_namespace(el), |ctx| {
+            generate_children(ctx, &el.children);
+        });
     } else {
         ctx.push(", null");
     }

--- a/crates/vize_atelier_core/src/codegen/context.rs
+++ b/crates/vize_atelier_core/src/codegen/context.rs
@@ -1,6 +1,6 @@
 //! Code generation context and result types.
 
-use crate::ast::RuntimeHelper;
+use crate::ast::{Namespace, RuntimeHelper};
 use crate::options::CodegenOptions;
 use crate::runtime_helpers::RuntimeHelpers;
 
@@ -52,6 +52,10 @@ pub struct CodegenContext {
     /// event-name casing rules (Vue preserves case via `on:` for plain
     /// elements that have uppercase letters in the raw event name).
     pub(super) props_is_plain_element: bool,
+    /// Namespace of the native parent currently generating children. Vue only
+    /// needs block creation at SVG/MathML namespace boundaries, not for every
+    /// descendant inside the same namespace.
+    pub(super) parent_ns: Namespace,
     /// Whether static child VNodes should be cached in the render function.
     pub(super) static_cache: bool,
     /// Template-wide counter for v-if branch keys. Each branch in any
@@ -93,9 +97,23 @@ impl CodegenContext {
             in_v_for: false,
             skip_v_memo: false,
             props_is_plain_element: false,
+            parent_ns: Namespace::Html,
             static_cache: false,
             v_if_branch_counter: 0,
         }
+    }
+
+    /// Run codegen while treating `ns` as the current native parent namespace.
+    pub(super) fn with_parent_namespace<T>(
+        &mut self,
+        ns: Namespace,
+        f: impl FnOnce(&mut Self) -> T,
+    ) -> T {
+        let prev = self.parent_ns;
+        self.parent_ns = ns;
+        let result = f(self);
+        self.parent_ns = prev;
+        result
     }
 
     /// Allocate the next v-if branch key for the current template.

--- a/crates/vize_atelier_core/src/codegen/element/block.rs
+++ b/crates/vize_atelier_core/src/codegen/element/block.rs
@@ -26,8 +26,9 @@ use super::{
         generate_custom_directives_closing, generate_vmodel_closing, generate_vshow_closing,
     },
     helpers::{
-        has_custom_directives, has_renderable_props, has_vmodel_directive, has_vshow_directive,
-        is_dynamic_component, is_is_prop, is_renderable_prop, is_whitespace_or_comment,
+        child_namespace, has_custom_directives, has_renderable_props, has_vmodel_directive,
+        has_vshow_directive, is_dynamic_component, is_is_prop, is_renderable_prop,
+        is_whitespace_or_comment,
     },
     v_once::generate_v_once_element,
 };
@@ -194,9 +195,13 @@ pub fn generate_element_block(ctx: &mut CodegenContext, el: &ElementNode<'_>) {
                 ctx.push(", ");
                 // Custom directives and v-memo require array children with createTextVNode
                 if has_custom_dirs || memo_cache_index.is_some() {
-                    generate_children_force_array(ctx, &el.children);
+                    ctx.with_parent_namespace(child_namespace(el), |ctx| {
+                        generate_children_force_array(ctx, &el.children);
+                    });
                 } else {
-                    generate_children(ctx, &el.children);
+                    ctx.with_parent_namespace(child_namespace(el), |ctx| {
+                        generate_children(ctx, &el.children);
+                    });
                 }
             } else if effective_has_patch_info {
                 ctx.push(", null");

--- a/crates/vize_atelier_core/src/codegen/element/helpers.rs
+++ b/crates/vize_atelier_core/src/codegen/element/helpers.rs
@@ -4,7 +4,7 @@
 //! renderable props, and special element types.
 
 use crate::ast::{
-    DirectiveNode, ElementNode, ElementType, ExpressionNode, PropNode, TemplateChildNode,
+    DirectiveNode, ElementNode, ElementType, ExpressionNode, Namespace, PropNode, TemplateChildNode,
 };
 use vize_carton::is_builtin_directive;
 
@@ -140,6 +140,55 @@ pub(crate) fn is_renderable_prop(prop: &PropNode<'_>) -> bool {
 /// Check if element has any renderable props
 pub fn has_renderable_props(el: &ElementNode<'_>) -> bool {
     el.props.iter().any(|prop| is_renderable_prop(prop))
+}
+
+/// Check whether a native element needs its own block to enter or leave an
+/// SVG/MathML namespace boundary. Descendants already inside the same
+/// namespace can stay as inline VNodes, matching Vue's DOM compiler output.
+pub(crate) fn crosses_namespace_boundary(ctx: &CodegenContext, el: &ElementNode<'_>) -> bool {
+    el.tag_type == ElementType::Element
+        && (el.ns != ctx.parent_ns || children_cross_namespace_boundary(el.ns, &el.children))
+}
+
+pub(crate) fn child_namespace(el: &ElementNode<'_>) -> Namespace {
+    match el.ns {
+        Namespace::Svg if matches!(el.tag.as_str(), "foreignObject" | "desc" | "title") => {
+            Namespace::Html
+        }
+        Namespace::MathMl
+            if matches!(
+                el.tag.as_str(),
+                "annotation-xml" | "mi" | "mo" | "mn" | "ms" | "mtext"
+            ) =>
+        {
+            Namespace::Html
+        }
+        _ => el.ns,
+    }
+}
+
+fn children_cross_namespace_boundary(ns: Namespace, children: &[TemplateChildNode<'_>]) -> bool {
+    children
+        .iter()
+        .any(|child| child_crosses_namespace_boundary(ns, child))
+}
+
+fn child_crosses_namespace_boundary(ns: Namespace, child: &TemplateChildNode<'_>) -> bool {
+    match child {
+        TemplateChildNode::Element(el) => match el.tag_type {
+            ElementType::Element => el.ns != ns,
+            ElementType::Template => children_cross_namespace_boundary(ns, &el.children),
+            _ => false,
+        },
+        TemplateChildNode::If(if_node) => if_node
+            .branches
+            .iter()
+            .any(|branch| children_cross_namespace_boundary(ns, &branch.children)),
+        TemplateChildNode::For(for_node) => {
+            children_cross_namespace_boundary(ns, &for_node.children)
+        }
+        _ => false,
+    }
 }
 
 /// Generate root node (wrapped in block)

--- a/crates/vize_atelier_core/src/codegen/element/inline.rs
+++ b/crates/vize_atelier_core/src/codegen/element/inline.rs
@@ -28,15 +28,16 @@ use super::{
         generate_custom_directives_closing, generate_vmodel_closing, generate_vshow_closing,
     },
     helpers::{
-        has_custom_directives, has_renderable_props, has_vmodel_directive, has_vshow_directive,
-        is_dynamic_component, is_is_prop, is_renderable_prop, is_whitespace_or_comment,
+        child_namespace, crosses_namespace_boundary, has_custom_directives, has_renderable_props,
+        has_vmodel_directive, has_vshow_directive, is_dynamic_component, is_is_prop,
+        is_renderable_prop, is_whitespace_or_comment,
     },
 };
 use vize_carton::ToCompactString;
 
 /// Generate element code (non-block)
 pub fn generate_element(ctx: &mut CodegenContext, el: &ElementNode<'_>) {
-    if el.tag_type == ElementType::Element && el.ns != Namespace::Html && el.tag == "svg" {
+    if crosses_namespace_boundary(ctx, el) {
         super::block::generate_element_block(ctx, el);
         return;
     }
@@ -138,7 +139,9 @@ pub fn generate_element(ctx: &mut CodegenContext, el: &ElementNode<'_>) {
             // Generate children
             if !el.children.is_empty() {
                 ctx.push(", ");
-                generate_children(ctx, &el.children);
+                ctx.with_parent_namespace(child_namespace(el), |ctx| {
+                    generate_children(ctx, &el.children);
+                });
             } else if has_patch_info {
                 ctx.push(", null");
             }

--- a/crates/vize_atelier_core/src/codegen/v_for/generate.rs
+++ b/crates/vize_atelier_core/src/codegen/v_for/generate.rs
@@ -11,7 +11,7 @@ use crate::{
 use super::super::{
     children::{generate_children, generate_children_force_array, is_directive_comment},
     context::CodegenContext,
-    element::helpers::{is_dynamic_component, is_is_prop},
+    element::helpers::{child_namespace, is_dynamic_component, is_is_prop},
     element::{
         generate_custom_directives_closing, generate_vmodel_closing, generate_vshow_closing,
         has_custom_directives, has_vmodel_directive, has_vshow_directive,
@@ -131,7 +131,9 @@ pub fn generate_for_item(ctx: &mut CodegenContext, node: &TemplateChildNode<'_>,
                         ctx.newline();
                         ctx.push("]");
                     } else {
-                        generate_children(ctx, &children_el.children);
+                        ctx.with_parent_namespace(child_namespace(children_el), |ctx| {
+                            generate_children(ctx, &children_el.children);
+                        });
                     }
                 }
 
@@ -262,9 +264,21 @@ pub fn generate_for_item(ctx: &mut CodegenContext, node: &TemplateChildNode<'_>,
                         ctx.push("]");
                     } else if ctx.skip_v_memo {
                         // v-for + v-memo: force array form for children
-                        generate_children_force_array(ctx, &children_el.children);
+                        if children_el.tag_type == ElementType::Element {
+                            ctx.with_parent_namespace(child_namespace(children_el), |ctx| {
+                                generate_children_force_array(ctx, &children_el.children);
+                            });
+                        } else {
+                            generate_children_force_array(ctx, &children_el.children);
+                        }
                     } else {
-                        generate_children(ctx, &children_el.children);
+                        if children_el.tag_type == ElementType::Element {
+                            ctx.with_parent_namespace(child_namespace(children_el), |ctx| {
+                                generate_children(ctx, &children_el.children);
+                            });
+                        } else {
+                            generate_children(ctx, &children_el.children);
+                        }
                     }
                 }
 

--- a/crates/vize_atelier_core/src/codegen/v_if/branch.rs
+++ b/crates/vize_atelier_core/src/codegen/v_if/branch.rs
@@ -17,7 +17,10 @@ use super::{
             generate_custom_directives_closing, generate_vmodel_closing, generate_vshow_closing,
             has_custom_directives, has_vmodel_directive, has_vshow_directive,
         },
-        element::{helpers::is_dynamic_component, is_whitespace_or_comment},
+        element::{
+            helpers::{child_namespace, is_dynamic_component},
+            is_whitespace_or_comment,
+        },
         expression::generate_expression,
         helpers::{escape_js_string, is_builtin_component, to_valid_asset_identifier},
         node::generate_node,
@@ -503,10 +506,14 @@ fn generate_if_branch_element(
                 ctx.push(&escape_js_string(text.content.as_str()));
                 ctx.push("\"");
             } else {
-                generate_if_branch_children(ctx, &el.children);
+                ctx.with_parent_namespace(child_namespace(el), |ctx| {
+                    generate_if_branch_children(ctx, &el.children);
+                });
             }
         } else {
-            generate_if_branch_children(ctx, &el.children);
+            ctx.with_parent_namespace(child_namespace(el), |ctx| {
+                generate_if_branch_children(ctx, &el.children);
+            });
         }
     } else if has_patch_info {
         ctx.push(", null");

--- a/crates/vize_atelier_dom/src/lib.rs
+++ b/crates/vize_atelier_dom/src/lib.rs
@@ -525,6 +525,52 @@ mod tests {
     }
 
     #[test]
+    fn test_inline_svg_descendants_inside_same_namespace_stay_vnodes() {
+        let allocator = Bump::new();
+        let (_, errors, result) = compile_template(
+            &allocator,
+            r#"<div><svg><defs><pattern :x="0"><line :x1="w"/></pattern></defs></svg></div>"#,
+        );
+        assert!(errors.is_empty());
+
+        let code = result.code.as_str();
+        assert!(
+            code.contains(r#"_createElementBlock("svg""#),
+            "inline <svg> must still enter the SVG namespace with a block:\n{code}"
+        );
+        for tag in ["defs", "pattern", "line"] {
+            assert!(
+                code.contains(&format!(r#"_createElementVNode("{tag}""#)),
+                "SVG descendants inside the same namespace should be VNodes:\n{code}"
+            );
+            assert!(
+                !code.contains(&format!(r#"_createElementBlock("{tag}""#)),
+                "SVG descendants inside the same namespace should not be blocks:\n{code}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_svg_foreign_object_namespace_exit_uses_boundary_block() {
+        let allocator = Bump::new();
+        let (_, errors, result) = compile_template(
+            &allocator,
+            r#"<svg><foreignObject><div :id="id">hi</div></foreignObject></svg>"#,
+        );
+        assert!(errors.is_empty());
+
+        let code = result.code.as_str();
+        assert!(
+            code.contains(r#"_createElementBlock("foreignObject""#),
+            "<foreignObject> must keep its own block when descendants leave SVG namespace:\n{code}"
+        );
+        assert!(
+            code.contains(r#"_createElementVNode("div""#),
+            "HTML descendants after the namespace exit should remain VNodes:\n{code}"
+        );
+    }
+
+    #[test]
     fn test_nested_svg_with_v_bind_uses_own_block() {
         let allocator = Bump::new();
         let (_, errors, result) = compile_template(

--- a/crates/vize_atelier_dom/src/snapshots/vize_atelier_dom__tests__svg_codegen_shape_keeps_children_nested.snap
+++ b/crates/vize_atelier_dom/src/snapshots/vize_atelier_dom__tests__svg_codegen_shape_keeps_children_nested.snap
@@ -1,14 +1,15 @@
 ---
 source: crates/vize_atelier_dom/src/lib.rs
+assertion_line: 504
 expression: full.as_str()
 ---
 const { createElementVNode: _createElementVNode, openBlock: _openBlock, createElementBlock: _createElementBlock } = Vue
 
 function render(_ctx, _cache, $props, $setup, $data, $options) {
   return (_openBlock(), _createElementBlock("svg", null, [
-    _createElementVNode("foreignObject", null, [
+    (_openBlock(), _createElementBlock("foreignObject", null, [
       _createElementVNode("div", null, "hi")
-    ]),
+    ])),
     _createElementVNode("rect", {
       x: "1",
       y: "1"


### PR DESCRIPTION
## Summary
- keep inline SVG descendants as VNodes when they remain in the same namespace
- preserve block generation at SVG/MathML namespace entry and HTML integration-point exits such as `foreignObject`
- add DOM regressions for same-namespace SVG descendants and `foreignObject` namespace exits

## Context
Follow-up to #1015 and #1019 while checking https://github.com/ubugeeei-prod/vize/issues/1013#issuecomment-4630605391.

## Validation
- `cargo fmt`
- `git diff --check`
- `cargo test -p vize_atelier_core`
- `cargo test -p vize_atelier_dom`
- `cargo test -p vize_atelier_sfc`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1029"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783278568&installation_id=136613492&pr_number=1029&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1029&signature=8b07c63671ac379b930255d24b26c6848a63d6eae3f59c9747ab523ebf8682b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->