### PR TITLE
test(cli): cover vize check CLI contract (exit codes, parse errors, missing config)

### DIFF
--- a/tests/tooling/cli-check-contract.test.ts
+++ b/tests/tooling/cli-check-contract.test.ts
@@ -1,0 +1,121 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+
+/**
+ * Resolves how to launch the `vize` CLI for contract tests, mirroring the LSP
+ * smoke-test launcher: a prebuilt binary wins, otherwise fall back to cargo so
+ * fresh checkouts still work.
+ */
+function resolveVizeCommand(): { command: string; prefix: string[] } {
+  const candidates = [
+    path.join(root, "target/ci/vize"),
+    path.join(root, "target/release/vize"),
+    path.join(root, "target/debug/vize"),
+    "vize",
+  ];
+  for (const candidate of candidates) {
+    const probe = spawnSync(candidate, ["--version"], { cwd: root, encoding: "utf8" });
+    if (probe.status === 0) {
+      return { command: candidate, prefix: [] };
+    }
+  }
+  return { command: "cargo", prefix: ["run", "-q", "-p", "vize", "--"] };
+}
+
+const VIZE = resolveVizeCommand();
+
+type CheckResult = { status: number | null; stdout: string; stderr: string };
+
+function runCheck(args: string[], cwd: string): CheckResult {
+  const result = spawnSync(VIZE.command, [...VIZE.prefix, "check", ...args], {
+    cwd,
+    encoding: "utf8",
+  });
+  if (result.error) {
+    throw result.error;
+  }
+  return { status: result.status, stdout: result.stdout, stderr: result.stderr };
+}
+
+// The workspace must live outside the repository tree: `vize check` with no
+// explicit inputs walks up looking for a tsconfig.json, and a repo-local temp
+// dir would inherit the workspace tsconfig and start type-checking the repo.
+function withWorkspace<T>(run: (dir: string) => T): T {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "vize-cli-check-"));
+  try {
+    return run(dir);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+test("vize check --help documents the input contract and key flags", () => {
+  const result = spawnSync(VIZE.command, [...VIZE.prefix, "check", "--help"], {
+    cwd: root,
+    encoding: "utf8",
+  });
+  assert.equal(result.status, 0, result.stderr);
+  const help = result.stdout;
+  for (const flag of ["--format", "--no-config", "--tsconfig", "--max-warnings", "--quiet"]) {
+    assert.match(help, new RegExp(flag.replace(/-/g, "\\-")), `help should document ${flag}`);
+  }
+  assert.match(help, /PATTERNS/, "help should describe the positional PATTERNS argument");
+});
+
+test("vize check exits 1 and reports SFC parse errors before type checking", () => {
+  withWorkspace((dir) => {
+    fs.writeFileSync(path.join(dir, "Broken.vue"), "<template><div></div>", "utf8");
+    const result = runCheck(["Broken.vue"], dir);
+    assert.equal(result.status, 1, `${result.stdout}\n${result.stderr}`);
+    assert.match(result.stderr, /SFC parse error/);
+  });
+});
+
+test("vize check reports parse errors even with config loading disabled", () => {
+  // The parse failure must short-circuit before the Corsa type-check stage, so
+  // this assertion holds without a type-checker present.
+  withWorkspace((dir) => {
+    fs.writeFileSync(path.join(dir, "Bad.vue"), "<template><div>", "utf8");
+    const result = runCheck(["Bad.vue", "--no-config"], dir);
+    assert.equal(result.status, 1, `${result.stdout}\n${result.stderr}`);
+    assert.match(result.stderr, /SFC parse error/);
+  });
+});
+
+test("vize check exits 2 when an explicit config file is missing", () => {
+  withWorkspace((dir) => {
+    fs.writeFileSync(path.join(dir, "Ok.vue"), "<template><p /></template>\n", "utf8");
+    const result = runCheck(["Ok.vue", "-c", "./does-not-exist.json"], dir);
+    assert.equal(result.status, 2, `${result.stdout}\n${result.stderr}`);
+    assert.match(result.stderr, /config file not found/);
+  });
+});
+
+test("vize check exits 0 when explicit inputs match no supported files", () => {
+  withWorkspace((dir) => {
+    const result = runCheck(["does-not-exist.vue"], dir);
+    assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
+    assert.match(
+      `${result.stdout}${result.stderr}`,
+      /No Vue or TypeScript files found matching inputs/,
+    );
+  });
+});
+
+test("vize check exits 0 in an empty project with no inputs", () => {
+  withWorkspace((dir) => {
+    const result = runCheck([], dir);
+    assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
+    assert.match(
+      `${result.stdout}${result.stderr}`,
+      /No Vue or TypeScript files found matching inputs/,
+    );
+  });
+});


### PR DESCRIPTION
## What

Adds an end-to-end suite for the `vize check` **command-line contract**, driven through the real binary. Previously the CLI surface (exit codes, error messaging, argument handling) had no tooling coverage — only the type-checker output is exercised, in the separate Corsa-backed snapshot suites.

## Why

The exit-code contract is load-bearing for scripts and CI (`vize check` in `package.json`, `vize ready`, editor integrations). A regression that flips a "no files found" into a non-zero exit, or drops the distinct config-error code, would break downstream automation invisibly. This pins each code with a deterministic, checker-independent test.

## Coverage

| Scenario | Exit | Signal |
| --- | --- | --- |
| Malformed SFC (`<template><div></div>`) | `1` | `SFC parse error` |
| Malformed SFC with `--no-config` | `1` | `SFC parse error` (short-circuits before the type-check stage) |
| Missing `-c ./does-not-exist.json` | `2` | `config file not found` |
| Unmatched explicit input | `0` | `No Vue or TypeScript files found` |
| Empty project, no inputs | `0` | `No Vue or TypeScript files found` |
| `--help` | `0` | documents `PATTERNS` + `--format`/`--no-config`/`--tsconfig`/`--max-warnings`/`--quiet` |

## Notes

- Parse errors short-circuit before Corsa, so the parse-error cases are fully checker-independent.
- Workspaces are created under `os.tmpdir()` (not inside the repo) so `vize check`'s upward `tsconfig.json` discovery can't escape and start type-checking the repository — verified against the actual binary.
- Binary resolution mirrors the existing LSP launcher (prebuilt binary → cargo fallback). Ran clean across repeated invocations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1032"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783279215&installation_id=136613492&pr_number=1032&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1032&signature=d7b81b96103037d0e19fefb0a1f297930d94d4d7971731619fb3fd36c37fc449"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->