### PR TITLE
test(config): cover JSON config shape normalization (nullish/empty/unknown)

### DIFF
--- a/tests/tooling/config-json-shape.test.ts
+++ b/tests/tooling/config-json-shape.test.ts
@@ -1,0 +1,84 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+
+import { loadConfig } from "../../npm/vize/src/config.ts";
+
+type JsonConfigResult = Awaited<ReturnType<typeof loadConfig>>;
+
+/**
+ * Write `content` as `vize.config.json` inside a fresh temp dir, load it through
+ * the public config API in `root` mode, then clean up. The loader reads the file
+ * and routes JSON through parseJsonConfig -> normalizeLoadedConfig, so this
+ * exercises the real JSON-shape normalization path.
+ */
+async function loadJsonConfig(content: string): Promise<JsonConfigResult> {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "vize-config-json-shape-"));
+  try {
+    fs.writeFileSync(path.join(tempDir, "vize.config.json"), content);
+    return await loadConfig(tempDir, { mode: "root" });
+  } finally {
+    fs.rmSync(tempDir, { force: true, recursive: true });
+  }
+}
+
+test("JSON config with unknown keys is preserved (not stripped/validated)", async () => {
+  const result = await loadJsonConfig(
+    JSON.stringify({ unknownKey: 123, formatter: { printWidth: 9 } }),
+  );
+
+  // normalizeLoadedConfig does not validate against any schema: unknown
+  // top-level keys survive onto both the resolved root and the root entry.
+  const resolved = result as Record<string, unknown> | null;
+  assert.equal(resolved?.unknownKey, 123);
+  assert.deepEqual(resolved?.formatter, { printWidth: 9 });
+
+  const entries = resolved?.entries as Array<Record<string, unknown>>;
+  assert.equal(entries.length, 1);
+  assert.equal(entries[0].unknownKey, 123);
+  assert.deepEqual(entries[0].formatter, { printWidth: 9 });
+});
+
+test("empty JSON object config yields {entries: []}", async () => {
+  const result = await loadJsonConfig("{}");
+
+  // An empty {} produces an empty root entry that isEmptyConfigEntry filters out.
+  assert.deepEqual(result, { entries: [] });
+});
+
+test("top-level JSON null normalizes to {entries: []} (stripNullish)", async () => {
+  const result = await loadJsonConfig("null");
+
+  // stripNullish maps top-level null to undefined; normalizeConfigObject({})
+  // then yields the empty-entries shape.
+  assert.deepEqual(result, { entries: [] });
+});
+
+test("empty JSON array config yields {entries: []}", async () => {
+  const result = await loadJsonConfig("[]");
+
+  // Top-level [] goes through normalizeConfigEntries producing entries: [].
+  assert.deepEqual(result, { entries: [] });
+});
+
+test("nested null values are stripped from object config", async () => {
+  const result = await loadJsonConfig(
+    JSON.stringify({ formatter: { printWidth: 5, useTabs: null }, linter: null }),
+  );
+
+  // stripNullish recursively removes null-valued keys (nested useTabs) and
+  // whole null sections (linter) before normalization.
+  const resolved = result as Record<string, unknown> | null;
+  const formatter = resolved?.formatter as Record<string, unknown>;
+  assert.equal(formatter.printWidth, 5);
+  assert.equal("useTabs" in formatter, false);
+  assert.equal("linter" in (resolved ?? {}), false);
+
+  // The full resolved shape: stripped root mirrored into a single entry.
+  assert.deepEqual(result, {
+    formatter: { printWidth: 5 },
+    entries: [{ formatter: { printWidth: 5 } }],
+  });
+});


### PR DESCRIPTION
Deterministic coverage for `tests/tooling/config-json-shape.test.ts`, authored against the real vize toolchain and verified with `node --test` (grounded in observed behavior, no build-artifact or type-checker-text dependence). Part of the broader project/config/LSP/editor test expansion.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1034"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783280105&installation_id=136613492&pr_number=1034&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1034&signature=eefd674b5b48f55afc37f7bf4eca0e27004fca68a30be058536917fd52c136f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->