### PR TITLE
fix(parser): report abrupt empty comments

### DIFF
--- a/crates/vize_armature/src/parser/element.rs
+++ b/crates/vize_armature/src/parser/element.rs
@@ -371,7 +371,7 @@ impl<'a> Parser<'a> {
     pub(super) fn on_comment_impl(&mut self, start: usize, end: usize) {
         let content = self.get_source(start, end);
         let loc_start = start.saturating_sub(4);
-        let loc_end = end.saturating_add(3).min(self.source.len());
+        let loc_end = self.comment_loc_end(start, end);
         let loc = self.create_loc(loc_start, loc_end); // Include <!-- and --> when present.
 
         // Check for @vize: directive
@@ -387,6 +387,20 @@ impl<'a> Parser<'a> {
         comment.directive = directive.map(|d| d.kind);
         let boxed = Box::new_in(comment, self.allocator);
         self.add_child(TemplateChildNode::Comment(boxed));
+    }
+
+    fn comment_loc_end(&self, start: usize, end: usize) -> usize {
+        let end = self.clamp_to_char_boundary(end);
+        let rest = &self.source[end..];
+        if rest.starts_with("-->") {
+            end + 3
+        } else if start == end && rest.starts_with("->") {
+            end + 2
+        } else if start == end && rest.starts_with('>') {
+            end + 1
+        } else {
+            end.saturating_add(3).min(self.source.len())
+        }
     }
 
     /// Process CDATA

--- a/crates/vize_armature/src/parser/tests.rs
+++ b/crates/vize_armature/src/parser/tests.rs
@@ -1031,6 +1031,29 @@ fn test_parse_incorrectly_closed_comment_reports_error_and_continues() {
 }
 
 #[test]
+fn test_parse_abrupt_empty_comment_reports_error_and_continues() {
+    for comment_source in ["<!-->", "<!--->"] {
+        let allocator = Bump::new();
+        let source = format!("{comment_source}<div></div>");
+        let (root, errors) = parse(&allocator, &source);
+
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.code == ErrorCode::AbruptClosingOfEmptyComment)
+        );
+        assert_eq!(root.children.len(), 2);
+        if let TemplateChildNode::Comment(comment) = &root.children[0] {
+            assert_eq!(comment.content.as_str(), "");
+            assert_eq!(comment.loc.source.as_str(), comment_source);
+        } else {
+            panic!("Expected recovered comment");
+        }
+        assert!(matches!(&root.children[1], TemplateChildNode::Element(_)));
+    }
+}
+
+#[test]
 fn test_parse_unclosed_comment_reports_error_without_losing_comment() {
     let allocator = Bump::new();
     let (root, errors) = parse(&allocator, "before<!-- open");

--- a/crates/vize_armature/src/tokenizer/states.rs
+++ b/crates/vize_armature/src/tokenizer/states.rs
@@ -673,7 +673,20 @@ impl<'a, C: Callbacks> Tokenizer<'a, C> {
             return;
         };
 
-        if c == sequence_bytes[self.sequence_index] {
+        if sequence == Sequence::CommentEnd
+            && self.sequence_index == 2
+            && c == GT
+            && self.index.saturating_sub(self.section_start) < 2
+        {
+            self.callbacks
+                .on_error(ErrorCode::AbruptClosingOfEmptyComment, self.index);
+            self.callbacks
+                .on_comment(self.section_start, self.section_start);
+            self.sequence_index = 0;
+            self.current_sequence = None;
+            self.section_start = self.index + 1;
+            self.state = State::Text;
+        } else if c == sequence_bytes[self.sequence_index] {
             self.sequence_index += 1;
             if self.sequence_index == sequence_bytes.len() {
                 self.finish_comment_like(sequence);

--- a/crates/vize_armature/src/tokenizer/tests.rs
+++ b/crates/vize_armature/src/tokenizer/tests.rs
@@ -340,6 +340,26 @@ fn test_comment() {
     assert!(cb.events.contains(&TokenEvent::Comment(4, 13)));
 }
 
+#[test]
+fn test_comment_abrupt_empty_close_reports_error() {
+    let cb = tokenize("<!-->");
+    assert!(
+        cb.errors
+            .contains(&(ErrorCode::AbruptClosingOfEmptyComment, 4))
+    );
+    assert!(cb.events.contains(&TokenEvent::Comment(4, 4)));
+}
+
+#[test]
+fn test_comment_abrupt_empty_close_after_dash_reports_error() {
+    let cb = tokenize("<!--->");
+    assert!(
+        cb.errors
+            .contains(&(ErrorCode::AbruptClosingOfEmptyComment, 5))
+    );
+    assert!(cb.events.contains(&TokenEvent::Comment(4, 4)));
+}
+
 // ========================================================================
 // CDATA tests (SVG / XML-style `<![CDATA[ ... ]]>`)
 // ========================================================================


### PR DESCRIPTION
## Summary
- report abrupt empty HTML comments as parser errors
- preserve recovered empty comment nodes without including following tags in source locations
- add tokenizer and parser coverage for <!--> and <!--->

## Validation
- cargo fmt --all --check
- cargo test -p vize_armature

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1036"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783280117&installation_id=136613492&pr_number=1036&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1036&signature=5f3d00e399176154900dda808d27d245d1a1fc98c4ffff9bf119598c4b6c1897"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->