### PR TITLE
test(config): cover normalizeGlobalTypes shorthand/wrapper expansion

### DIFF
--- a/tests/tooling/normalize-global-types.test.ts
+++ b/tests/tooling/normalize-global-types.test.ts
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { normalizeGlobalTypes } from "../../npm/vize/src/config.ts";
+
+/**
+ * `normalizeGlobalTypes` is a pure, IO-free helper exported from
+ * npm/vize/src/config.ts. It expands shorthand string declarations into
+ * `{ type }` objects and, when the input is a single-key `{ types: {...} }`
+ * wrapper (plain non-array object), unwraps that nested map before expanding.
+ *
+ * These are characterization tests of the current implementation: every
+ * expected value below was observed by running the real function against the
+ * fixtures, so they double as regression guards.
+ */
+
+test("expands string shorthands to {type} and preserves object form", () => {
+  // A bare string value is shorthand for a GlobalTypeDeclaration { type }.
+  assert.deepEqual(normalizeGlobalTypes({ Foo: "FooType" }), {
+    Foo: { type: "FooType" },
+  });
+
+  // A value that is already an object passes through unchanged (including any
+  // extra fields such as defaultValue).
+  assert.deepEqual(
+    normalizeGlobalTypes({ Bar: { type: "BarType", defaultValue: "x" } }),
+    { Bar: { type: "BarType", defaultValue: "x" } },
+  );
+});
+
+test("unwraps a nested {types:{...}} object wrapper", () => {
+  // When the top-level config is a wrapper whose `types` key holds a plain
+  // (non-array, non-null) object, that nested map is used as the source and
+  // each entry is normalized: strings expand, objects pass through.
+  assert.deepEqual(
+    normalizeGlobalTypes({
+      types: { A: "AT", B: { type: "BT", defaultValue: "1" } },
+    }),
+    {
+      A: { type: "AT" },
+      B: { type: "BT", defaultValue: "1" },
+    },
+  );
+});
+
+test("treats a `types` array/string value as NOT a wrapper", () => {
+  // Wrapper detection requires the `types` value to be a non-array object.
+  // An array value is not a wrapper, so `types` is treated as an ordinary
+  // global-type name. Its value is an array (not a string), so it passes
+  // through unchanged.
+  assert.deepEqual(normalizeGlobalTypes({ types: ["A", "B"] }), {
+    types: ["A", "B"],
+  });
+
+  // A string `types` value is likewise an ordinary entry, and being a string
+  // it expands to the { type } shorthand form.
+  assert.deepEqual(normalizeGlobalTypes({ types: "S" }), {
+    types: { type: "S" },
+  });
+});
+
+test("a top-level key literally named `type` is shorthand-expanded, not a wrapper", () => {
+  // Only the plural `types` key triggers unwrapping. The singular `type` is an
+  // ordinary global-type name; its string value expands to { type }.
+  assert.deepEqual(normalizeGlobalTypes({ type: "X" }), {
+    type: { type: "X" },
+  });
+});

--- a/tests/tooling/normalize-global-types.test.ts
+++ b/tests/tooling/normalize-global-types.test.ts
@@ -22,10 +22,9 @@ test("expands string shorthands to {type} and preserves object form", () => {
 
   // A value that is already an object passes through unchanged (including any
   // extra fields such as defaultValue).
-  assert.deepEqual(
-    normalizeGlobalTypes({ Bar: { type: "BarType", defaultValue: "x" } }),
-    { Bar: { type: "BarType", defaultValue: "x" } },
-  );
+  assert.deepEqual(normalizeGlobalTypes({ Bar: { type: "BarType", defaultValue: "x" } }), {
+    Bar: { type: "BarType", defaultValue: "x" },
+  });
 });
 
 test("unwraps a nested {types:{...}} object wrapper", () => {


### PR DESCRIPTION
Deterministic coverage for `tests/tooling/normalize-global-types.test.ts`, authored against the real vize toolchain and verified with `node --test` (grounded in observed behavior, no build-artifact or type-checker-text dependence). Part of the broader project/config/LSP/editor test expansion.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1038"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783280125&installation_id=136613492&pr_number=1038&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1038&signature=2b7281e2a70aa04b1c934a551d6e67f766610726719a2d28bce19c2c1696449b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->