### PR TITLE
test(lsp): cover initialize capability advertisement and per-feature gating

### DIFF
--- a/tests/tooling/lsp-capabilities.test.ts
+++ b/tests/tooling/lsp-capabilities.test.ts
@@ -1,0 +1,201 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+import { testOutputRoot } from "./support/lsp/paths.ts";
+import type { LspInitializationOptions } from "./support/lsp/protocol.ts";
+import { LspSession } from "./support/lsp/session.ts";
+
+// Capability-advertisement suite for `vize lsp`.
+//
+// These tests inspect ONLY the `initialize` result: no document features and no
+// corsa are exercised, so every assertion is a pure, deterministic function of
+// the initialization options. The smoke suite asserts a handful of default
+// providers (`hoverProvider`, `definitionProvider`, `referencesProvider`,
+// `semanticTokensProvider.range`, `completionProvider.triggerCharacters` has
+// "."); here we pin the full provider set and the per-feature gating shapes for
+// distinct option bundles, which the smoke suite does not cover.
+
+/**
+ * Granular initialization options accepted by the server's camelCase config
+ * section. The shared `LspInitializationOptions` type only models the common
+ * bundle flags, so this test widens it with the per-feature toggles it needs.
+ */
+type GranularInitOptions = LspInitializationOptions & {
+  inlayHints?: boolean;
+  foldingRanges?: boolean;
+  documentSymbols?: boolean;
+  codeLens?: boolean;
+};
+
+type ServerCapabilities = {
+  documentSymbolProvider?: unknown;
+  foldingRangeProvider?: unknown;
+  inlayHintProvider?: unknown;
+  documentHighlightProvider?: unknown;
+  workspaceSymbolProvider?: unknown;
+  semanticTokensProvider?: unknown;
+  completionProvider?: {
+    triggerCharacters?: string[];
+    resolveProvider?: boolean;
+  };
+  codeLensProvider?: { resolveProvider?: boolean };
+  documentLinkProvider?: { resolveProvider?: boolean };
+  renameProvider?: { prepareProvider?: boolean };
+  codeActionProvider?: {
+    codeActionKinds?: string[];
+    resolveProvider?: boolean;
+  };
+  hoverProvider?: unknown;
+  textDocumentSync?: {
+    change?: number;
+    openClose?: boolean;
+    save?: { includeText?: boolean };
+  };
+  signatureHelpProvider?: unknown;
+  selectionRangeProvider?: unknown;
+  documentRangeFormattingProvider?: unknown;
+};
+
+async function withCapabilities(
+  label: string,
+  initializationOptions: GranularInitOptions,
+  run: (capabilities: ServerCapabilities) => void,
+): Promise<void> {
+  const testRootDir = path.join(testOutputRoot, `lsp-capabilities-${label}`);
+  fs.mkdirSync(testRootDir, { recursive: true });
+  const workspaceDir = fs.mkdtempSync(path.join(testRootDir, "workspace-"));
+  const session = new LspSession();
+
+  try {
+    const init = (await session.initialize(
+      workspaceDir,
+      initializationOptions as LspInitializationOptions,
+    )) as { capabilities?: ServerCapabilities };
+    assert.ok(init.capabilities, "initialize result should advertise capabilities");
+    run(init.capabilities);
+  } finally {
+    await session.shutdown();
+    fs.rmSync(workspaceDir, { recursive: true, force: true });
+    fs.rmSync(testRootDir, { recursive: true, force: true });
+  }
+}
+
+test("vize lsp advertises the full editor-feature provider set with exact shapes", async () => {
+  await withCapabilities("editor-full", { editor: true, lint: true }, (capabilities) => {
+    // Boolean providers advertised as plain `true`.
+    assert.equal(capabilities.documentSymbolProvider, true);
+    assert.equal(capabilities.foldingRangeProvider, true);
+    assert.equal(capabilities.inlayHintProvider, true);
+    assert.equal(capabilities.documentHighlightProvider, true);
+    assert.equal(capabilities.workspaceSymbolProvider, true);
+
+    // Resolve-provider shapes.
+    assert.equal(capabilities.codeLensProvider?.resolveProvider, false);
+    assert.equal(capabilities.documentLinkProvider?.resolveProvider, false);
+
+    // Rename advertises prepareRename support.
+    assert.equal(capabilities.renameProvider?.prepareProvider, true);
+
+    // Code actions: kinds plus no resolve step.
+    assert.deepEqual(capabilities.codeActionProvider?.codeActionKinds, [
+      "quickfix",
+      "refactor",
+      "source",
+    ]);
+    assert.equal(capabilities.codeActionProvider?.resolveProvider, false);
+
+    // Document sync: incremental (2), open/close on, save without text.
+    assert.equal(capabilities.textDocumentSync?.change, 2);
+    assert.equal(capabilities.textDocumentSync?.openClose, true);
+    assert.equal(capabilities.textDocumentSync?.save?.includeText, false);
+
+    // Completion trigger characters, exact ordered set.
+    assert.deepEqual(capabilities.completionProvider?.triggerCharacters, [
+      ".",
+      ":",
+      "@",
+      "#",
+      "<",
+      "/",
+      '"',
+      "'",
+      " ",
+    ]);
+
+    // Providers that are intentionally not yet advertised stay absent.
+    assert.equal(capabilities.signatureHelpProvider, undefined);
+    assert.equal(capabilities.selectionRangeProvider, undefined);
+    assert.equal(capabilities.documentRangeFormattingProvider, undefined);
+  });
+});
+
+test("vize lsp editor:false strips editor providers but keeps lint-driven codeAction", async () => {
+  await withCapabilities(
+    "editor-off",
+    { editor: false, lint: true, typecheck: false },
+    (capabilities) => {
+      // Editor bundle providers are all gone.
+      assert.equal(capabilities.semanticTokensProvider, undefined);
+      assert.equal(capabilities.documentSymbolProvider, undefined);
+      assert.equal(capabilities.foldingRangeProvider, undefined);
+      assert.equal(capabilities.inlayHintProvider, undefined);
+      assert.equal(capabilities.completionProvider, undefined);
+      assert.equal(capabilities.codeLensProvider, undefined);
+      assert.equal(capabilities.documentLinkProvider, undefined);
+      assert.equal(capabilities.workspaceSymbolProvider, undefined);
+      assert.equal(capabilities.hoverProvider, undefined);
+
+      // Lint code actions survive without the editor bundle.
+      assert.ok(capabilities.codeActionProvider, "codeActionProvider should remain present");
+      assert.deepEqual(capabilities.codeActionProvider?.codeActionKinds, [
+        "quickfix",
+        "refactor",
+        "source",
+      ]);
+    },
+  );
+});
+
+test("vize lsp per-feature init flags toggle individual providers independently", async () => {
+  await withCapabilities(
+    "granular-four-off",
+    {
+      editor: true,
+      inlayHints: false,
+      foldingRanges: false,
+      documentSymbols: false,
+      semanticTokens: false,
+    },
+    (capabilities) => {
+      assert.equal(capabilities.inlayHintProvider, undefined);
+      assert.equal(capabilities.foldingRangeProvider, undefined);
+      assert.equal(capabilities.documentSymbolProvider, undefined);
+      assert.equal(capabilities.semanticTokensProvider, undefined);
+      // A sibling editor provider is untouched.
+      assert.equal(capabilities.hoverProvider, true);
+    },
+  );
+
+  await withCapabilities(
+    "granular-codelens-off",
+    { editor: true, codeLens: false },
+    (capabilities) => {
+      assert.equal(capabilities.codeLensProvider, undefined);
+      // The rest of the editor bundle is intact.
+      assert.equal(capabilities.inlayHintProvider, true);
+      assert.equal(capabilities.foldingRangeProvider, true);
+      assert.equal(capabilities.documentSymbolProvider, true);
+      assert.ok(capabilities.semanticTokensProvider, "semanticTokensProvider should remain");
+      assert.equal(capabilities.hoverProvider, true);
+    },
+  );
+
+  await withCapabilities("granular-lint-off", { editor: true, lint: false }, (capabilities) => {
+    // Code actions are gated on lint, so disabling lint removes only them.
+    assert.equal(capabilities.codeActionProvider, undefined);
+    assert.equal(capabilities.hoverProvider, true);
+    assert.equal(capabilities.codeLensProvider?.resolveProvider, false);
+    assert.ok(capabilities.semanticTokensProvider, "semanticTokensProvider should remain");
+  });
+});


### PR DESCRIPTION
Deterministic coverage for `tests/tooling/lsp-capabilities.test.ts`, authored against the real vize toolchain and verified with `node --test` + oxlint + formatting (grounded in observed behavior; no build-artifact or type-checker-text dependence; LSP coordinates UTF-16-safe; CLI workspaces under os.tmpdir()). De-duplicated against existing lsp-smoke / cli-check-contract suites. Part of the broader project/config/LSP/editor test expansion.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1048"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783281585&installation_id=136613492&pr_number=1048&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1048&signature=8b477c2bfde3fd74b0ddd1a3842c73057b4a6c9b0f74e607c0e882d301f0de1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->