### PR TITLE
test(lsp): cover template hover for script ref bindings (non-corsa)

### DIFF
--- a/tests/tooling/lsp-hover-template.test.ts
+++ b/tests/tooling/lsp-hover-template.test.ts
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+import { pathToFileURL } from "node:url";
+import { hoverToText, isDiagnosticsForUri, offsetToPosition } from "./support/lsp/assertions.ts";
+import { testOutputRoot } from "./support/lsp/paths.ts";
+import { LspSession } from "./support/lsp/session.ts";
+
+// Hover over a template interpolation of a script `ref` is vize-native
+// analysis (typecheck:false, no corsa). The lsp-smoke suite already covers
+// hover inside `.art.vue` variants; this case covers a plain `.vue` template
+// interpolation and asserts the "Template binding from script" provenance note
+// that the smoke suite does not check.
+test("vize lsp hovers template interpolation of a script ref", async () => {
+  const testRootDir = path.join(testOutputRoot, "lsp-hover-template");
+  fs.mkdirSync(testRootDir, { recursive: true });
+  const workspaceDir = fs.mkdtempSync(path.join(testRootDir, "workspace-"));
+  const session = new LspSession();
+
+  try {
+    await session.initialize(workspaceDir, {
+      editor: true,
+      lint: true,
+      typecheck: false,
+    });
+
+    const source = `<script setup lang="ts">
+import { ref } from 'vue'
+const greeting = ref('hello')
+</script>
+
+<template>
+  <p>{{ greeting }}</p>
+</template>
+`;
+    const filePath = path.join(workspaceDir, "HoverTemplate.vue");
+    const uri = pathToFileURL(filePath).href;
+    fs.writeFileSync(filePath, source, "utf8");
+
+    session.notify("textDocument/didOpen", {
+      textDocument: {
+        uri,
+        languageId: "vue",
+        version: 1,
+        text: source,
+      },
+    });
+
+    await session.waitForNotification("textDocument/publishDiagnostics", (params) =>
+      isDiagnosticsForUri(params, uri),
+    );
+
+    const usageOffset = source.lastIndexOf("greeting") + "greeting".length;
+
+    const hover = (await session.request("textDocument/hover", {
+      textDocument: { uri },
+      position: offsetToPosition(source, usageOffset),
+    })) as { contents?: unknown } | null;
+
+    const hoverText = hoverToText(hover);
+    assert.match(hoverText, /greeting/);
+    assert.match(hoverText, /Ref<string>/);
+    assert.match(hoverText, /Template binding from script/);
+  } finally {
+    await session.shutdown();
+    fs.rmSync(workspaceDir, { recursive: true, force: true });
+    fs.rmSync(testRootDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Deterministic coverage for `tests/tooling/lsp-hover-template.test.ts`, authored against the real vize toolchain and verified with `node --test` + oxlint + formatting (grounded in observed behavior; no build-artifact or type-checker-text dependence; LSP coordinates UTF-16-safe; CLI workspaces under os.tmpdir()). De-duplicated against existing lsp-smoke / cli-check-contract suites. Part of the broader project/config/LSP/editor test expansion.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1052"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783281620&installation_id=136613492&pr_number=1052&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1052&signature=a2d70bf2b7f59141e076439bc7213fd2521032e89ebfd9575f5add15b1757ed9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->