### PR TITLE
fix: preserve null children for v-for dynamic props

### DIFF
--- a/crates/vize_atelier_core/src/codegen/v_for/generate.rs
+++ b/crates/vize_atelier_core/src/codegen/v_for/generate.rs
@@ -137,15 +137,39 @@ pub fn generate_for_item(ctx: &mut CodegenContext, node: &TemplateChildNode<'_>,
                     }
                 }
 
-                // Add TEXT patch flag if has interpolation
-                let has_interpolation = children_el
-                    .children
-                    .iter()
-                    .any(|c| matches!(c, TemplateChildNode::Interpolation(_)));
                 if gen_is_template {
                     ctx.push(", 64 /* STABLE_FRAGMENT */");
-                } else if has_interpolation {
-                    ctx.push(", 1 /* TEXT */");
+                } else {
+                    let (patch_flag, dynamic_props) = calculate_element_patch_info(
+                        children_el,
+                        ctx.options.binding_metadata.as_ref(),
+                        ctx.cache_handlers_in_current_scope(),
+                    );
+                    let patch_flag = strip_need_patch_for_v_for_item(patch_flag);
+                    if children_el.children.is_empty()
+                        && (patch_flag.is_some() || dynamic_props.is_some())
+                    {
+                        ctx.push(", null");
+                    }
+                    if let Some(flag) = patch_flag {
+                        ctx.push(", ");
+                        ctx.push(&flag.to_compact_string());
+                        ctx.push(" /* ");
+                        ctx.push(&patch_flag_name(flag));
+                        ctx.push(" */");
+                    }
+                    if let Some(props) = dynamic_props {
+                        ctx.push(", [");
+                        for (i, prop) in props.iter().enumerate() {
+                            if i > 0 {
+                                ctx.push(", ");
+                            }
+                            ctx.push("\"");
+                            ctx.push(prop);
+                            ctx.push("\"");
+                        }
+                        ctx.push("]");
+                    }
                 }
 
                 if gen_is_template {
@@ -346,6 +370,11 @@ pub fn generate_for_item(ctx: &mut CodegenContext, node: &TemplateChildNode<'_>,
                         ctx.cache_handlers_in_current_scope(),
                     );
                     let patch_flag = strip_need_patch_for_v_for_item(patch_flag);
+                    if flag_el.children.is_empty()
+                        && (patch_flag.is_some() || dynamic_props.is_some())
+                    {
+                        ctx.push(", null");
+                    }
                     if let Some(flag) = patch_flag {
                         ctx.push(", ");
                         ctx.push(&flag.to_compact_string());

--- a/crates/vize_atelier_core/src/snapshots/vize_atelier_core__codegen__tests__codegen_numeric_template_v_for_uses_fragment.snap
+++ b/crates/vize_atelier_core/src/snapshots/vize_atelier_core__codegen__tests__codegen_numeric_template_v_for_uses_fragment.snap
@@ -13,7 +13,7 @@ function render(_ctx, _cache, $props, $setup, $data, $options) {
           return (_openBlock(), _createElementBlock("span", {
             key: `${n}-${i}`,
             class: _normalizeClass(icon)
-          }, 2 /* CLASS */))
+          }, null, 2 /* CLASS */))
         }), 128 /* KEYED_FRAGMENT */))
       ], 64 /* STABLE_FRAGMENT */))
     }), 64 /* STABLE_FRAGMENT */))

--- a/crates/vize_atelier_sfc/src/lib.rs
+++ b/crates/vize_atelier_sfc/src/lib.rs
@@ -248,6 +248,38 @@ import { Child } from "./components";
     }
 
     #[test]
+    fn test_compile_sfc_v_for_dynamic_prop_without_children_emits_null_children() {
+        let source = r#"
+<template>
+  <div
+    v-for="_, i in ary"
+    :prop="val"
+  />
+</template>
+
+<script setup lang="ts">
+import { ref } from "vue"
+const ary = ref([])
+const val = ref(0)
+</script>
+"#;
+        let descriptor = parse_sfc(source, Default::default()).unwrap();
+        let result = compile_sfc(&descriptor, SfcCompileOptions::default()).unwrap();
+        let normalized = result.code.replace('\n', " ");
+
+        assert!(
+            normalized.contains(r#"_createElementBlock("div", { prop: val.value }, null, 8"#),
+            "v-for element with dynamic props and no children must emit a null children argument. Got:\n{}",
+            result.code
+        );
+        assert!(
+            !normalized.contains(r#"_createElementBlock("div", { prop: val.value }, 8"#),
+            "patch flag must not occupy the children argument. Got:\n{}",
+            result.code
+        );
+    }
+
+    #[test]
     fn test_compile_sfc_ts_ref_condition_and_handler_keep_value_access() {
         use vize_carton::ToCompactString;
 

--- a/tests/expected/vdom/v-for.snap
+++ b/tests/expected/vdom/v-for.snap
@@ -40,6 +40,19 @@ export function render(_ctx, _cache) {
   }), 128 /* KEYED_FRAGMENT */))
 }
 ===
+name: v-for with dynamic prop and no children
+options: vdom
+--- INPUT ---
+<div v-for="(_, i) in ary" :prop="val" />
+--- OUTPUT ---
+import { renderList as _renderList, Fragment as _Fragment, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+export function render(_ctx, _cache) {
+  return (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(_ctx.ary, (_, i) => {
+    return (_openBlock(), _createElementBlock("div", { prop: _ctx.val }, null, 8 /* PROPS */, ["prop"]))
+  }), 256 /* UNKEYED_FRAGMENT */))
+}
+===
 name: v-for object
 options: vdom
 --- INPUT ---
@@ -76,6 +89,19 @@ import { renderList as _renderList, Fragment as _Fragment, openBlock as _openBlo
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock(_Fragment, null, _renderList(10, (n) => {
     return _createElementVNode("div", { key: n }, _toDisplayString(n), 1 /* TEXT */)
+  }), 64 /* STABLE_FRAGMENT */))
+}
+===
+name: v-for range with dynamic prop and no children
+options: vdom
+--- INPUT ---
+<div v-for="n in 10" :prop="val" />
+--- OUTPUT ---
+import { renderList as _renderList, Fragment as _Fragment, openBlock as _openBlock, createElementBlock as _createElementBlock, createElementVNode as _createElementVNode } from "vue"
+
+export function render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock(_Fragment, null, _renderList(10, (n) => {
+    return _createElementVNode("div", { prop: _ctx.val }, null, 8 /* PROPS */, ["prop"])
   }), 64 /* STABLE_FRAGMENT */))
 }
 ===

--- a/tests/fixtures/vdom/v-for.toml
+++ b/tests/fixtures/vdom/v-for.toml
@@ -19,6 +19,10 @@ name = "v-for with index"
 input = '<div v-for="(item, index) in items" :key="index">{{ index }}: {{ item }}</div>'
 
 [[cases]]
+name = "v-for with dynamic prop and no children"
+input = '<div v-for="(_, i) in ary" :prop="val" />'
+
+[[cases]]
 name = "v-for object"
 input = '<div v-for="(value, key) in obj" :key="key">{{ key }}: {{ value }}</div>'
 
@@ -29,6 +33,10 @@ input = '<div v-for="(value, key, index) in obj" :key="index">{{ index }}. {{ ke
 [[cases]]
 name = "v-for range"
 input = '<div v-for="n in 10" :key="n">{{ n }}</div>'
+
+[[cases]]
+name = "v-for range with dynamic prop and no children"
+input = '<div v-for="n in 10" :prop="val" />'
 
 # =============================================================================
 # v-for of syntax


### PR DESCRIPTION
## Summary

Fixes #1063.

- Preserve the `children` argument as `null` when a `v-for` element has no children but still emits patch flags or dynamic props.
- Reuse normal element patch info calculation for stable numeric `v-for` items so dynamic props are emitted with the correct argument positions.
- Add vdom fixture coverage and a focused SFC regression test for the reported `script setup` ref case.

## Root Cause

`v-for` item codegen has a separate path from normal element block codegen. The native element path emitted patch flags and dynamic props without inserting a placeholder `children` argument when the element had no children, so `8 /* PROPS */` could be passed as the third `createElementBlock` argument.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p vize_test_runner vdom_v_for -- --ignored`
- `cargo test -p vize_atelier_sfc test_compile_sfc_v_for_dynamic_prop_without_children_emits_null_children`
- `cargo run -p vize_test_runner --bin coverage -- -v`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1064"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783309146&installation_id=136613492&pr_number=1064&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1064&signature=e97bac0770ae6fb5112abea31f5501aaf1780912a57186c459ab25218a3a5997"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->