### PR TITLE
fix(parser): report stricter HTML parse errors

### DIFF
--- a/crates/vize/tests/build_cli.rs
+++ b/crates/vize/tests/build_cli.rs
@@ -60,7 +60,7 @@ withDefaults(defineProps<AppProps>(), {
     :data-as="as"
     :data-as-child="asChild"
     :data-feature="feature"
-  />
+  ></div>
 </template>
 "#,
     );
@@ -131,7 +131,7 @@ export interface ContentProps extends PrimitiveProps {
 defineProps<ContentProps>()
 </script>
 
-<template><div /></template>
+<template><div></div></template>
 "#,
     );
     write_project_file(

--- a/crates/vize/tests/check_cli.rs
+++ b/crates/vize/tests/check_cli.rs
@@ -777,7 +777,7 @@ defineProps<{ configs: AliasConfig[] }>();
 </script>
 
 <template>
-  <div />
+  <div></div>
 </template>
 "#,
             ),
@@ -1316,7 +1316,7 @@ defineProps<{ kind?: FilterType }>()
 </script>
 
 <template>
-  <div />
+  <div></div>
 </template>
 "#,
             ),

--- a/crates/vize_armature/src/parser.rs
+++ b/crates/vize_armature/src/parser.rs
@@ -15,7 +15,7 @@ mod whitespace;
 #[cfg(test)]
 mod tests;
 
-use vize_carton::{Box, Bump, String, Vec};
+use vize_carton::{Bump, String, Vec};
 use vize_relief::{
     ast::*,
     errors::{CompilerError, ErrorCode},
@@ -53,6 +53,11 @@ pub struct Parser<'a> {
     in_pre: bool,
     /// Whether in v-pre block
     in_v_pre: bool,
+    open_table_count: usize,
+    open_p_count: usize,
+    open_a_count: usize,
+    open_button_count: usize,
+    open_form_count: usize,
 }
 
 /// Stack entry for tracking parent elements
@@ -61,6 +66,15 @@ pub(super) struct ParserStackEntry<'a> {
     pub(super) element: ElementNode<'a>,
     pub(super) in_pre: bool,
     pub(super) in_v_pre: bool,
+    pub(super) insertion: StackInsertion,
+    pub(super) implicit: bool,
+    pub(super) fostered_before: Vec<'a, TemplateChildNode<'a>>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum StackInsertion {
+    Normal,
+    Fostered,
 }
 
 /// Current element being parsed
@@ -121,6 +135,11 @@ impl<'a> Parser<'a> {
             newlines: Vec::new_in(allocator),
             in_pre: false,
             in_v_pre: false,
+            open_table_count: 0,
+            open_p_count: 0,
+            open_a_count: 0,
+            open_button_count: 0,
+            open_form_count: 0,
         }
     }
 
@@ -223,16 +242,67 @@ impl<'a> Parser<'a> {
         }
     }
 
+    fn add_fostered_child(&mut self, child: TemplateChildNode<'a>) {
+        if let Some(table_index) = self.nearest_table_index() {
+            self.stack[table_index].fostered_before.push(child);
+        } else {
+            self.add_child(child);
+        }
+    }
+
+    pub(super) fn push_stack_entry(&mut self, entry: ParserStackEntry<'a>) {
+        self.note_stack_tag_open(entry.element.tag.as_str());
+        self.stack.push(entry);
+    }
+
+    pub(super) fn pop_stack_entry(&mut self) -> Option<ParserStackEntry<'a>> {
+        let entry = self.stack.pop()?;
+        self.note_stack_tag_close(entry.element.tag.as_str());
+        Some(entry)
+    }
+
+    fn note_stack_tag_open(&mut self, tag: &str) {
+        match tag.len() {
+            1 if tag.eq_ignore_ascii_case("p") => self.open_p_count += 1,
+            1 if tag.eq_ignore_ascii_case("a") => self.open_a_count += 1,
+            4 if tag.eq_ignore_ascii_case("form") => self.open_form_count += 1,
+            5 if tag.eq_ignore_ascii_case("table") => self.open_table_count += 1,
+            6 if tag.eq_ignore_ascii_case("button") => self.open_button_count += 1,
+            _ => {}
+        }
+    }
+
+    fn note_stack_tag_close(&mut self, tag: &str) {
+        match tag.len() {
+            1 if tag.eq_ignore_ascii_case("p") => {
+                self.open_p_count = self.open_p_count.saturating_sub(1);
+            }
+            1 if tag.eq_ignore_ascii_case("a") => {
+                self.open_a_count = self.open_a_count.saturating_sub(1);
+            }
+            4 if tag.eq_ignore_ascii_case("form") => {
+                self.open_form_count = self.open_form_count.saturating_sub(1);
+            }
+            5 if tag.eq_ignore_ascii_case("table") => {
+                self.open_table_count = self.open_table_count.saturating_sub(1);
+            }
+            6 if tag.eq_ignore_ascii_case("button") => {
+                self.open_button_count = self.open_button_count.saturating_sub(1);
+            }
+            _ => {}
+        }
+    }
+
     /// Handle unclosed elements at end of parsing
     fn handle_unclosed_elements(&mut self) {
-        while let Some(entry) = self.stack.pop() {
-            let loc = entry.element.loc.clone();
-            self.errors
-                .push(CompilerError::new(ErrorCode::MissingEndTag, Some(loc)));
+        while let Some(entry) = self.pop_stack_entry() {
+            if !entry.implicit && !Self::can_omit_end_tag(entry.element.tag.as_str()) {
+                let loc = entry.element.loc.clone();
+                self.errors
+                    .push(CompilerError::new(ErrorCode::MissingEndTag, Some(loc)));
+            }
 
-            // Add the unclosed element to parent
-            let boxed = Box::new_in(entry.element, self.allocator);
-            self.add_child(TemplateChildNode::Element(boxed));
+            self.emit_stack_entry(entry);
         }
     }
 }

--- a/crates/vize_armature/src/parser/attribute.rs
+++ b/crates/vize_armature/src/parser/attribute.rs
@@ -170,7 +170,11 @@ impl<'a> Parser<'a> {
     fn has_duplicate_attribute(&self, name: &str) -> bool {
         self.current_element.as_ref().is_some_and(|current| {
             current.props.iter().any(|prop| {
-                matches!(prop, PropNode::Attribute(existing) if existing.name.as_str() == name)
+                matches!(
+                    prop,
+                    PropNode::Attribute(existing)
+                        if existing.name.as_str().eq_ignore_ascii_case(name)
+                )
             })
         })
     }
@@ -212,8 +216,12 @@ impl<'a> Parser<'a> {
         {
             let value_loc = self.create_loc(v_start, v_end);
             attr_node.value = Some(TextNode::new(v_content, value_loc));
-        } else if matches!(quote, QuoteType::Double | QuoteType::Single) {
-            // alt="" or alt='' → empty string value (not boolean "true")
+        } else if matches!(
+            quote,
+            QuoteType::Double | QuoteType::Single | QuoteType::Unquoted
+        ) {
+            // alt="", alt='', or parse-recovered id= before `>` all produce
+            // empty string values (not boolean "true").
             let empty_loc: vize_relief::SourceLocation = self.create_loc(end, end);
             attr_node.value = Some(TextNode::new("", empty_loc));
         }

--- a/crates/vize_armature/src/parser/element.rs
+++ b/crates/vize_armature/src/parser/element.rs
@@ -3,13 +3,13 @@
 //! Handles text, interpolation, open/close tags, element type determination,
 //! comments, and error reporting.
 
-use vize_carton::{Box, String, appends, directive::parse_vize_directive};
+use vize_carton::{Box, String, Vec, appends, directive::parse_vize_directive};
 use vize_relief::{
     ast::*,
     errors::{CompilerError, ErrorCode},
 };
 
-use super::{CurrentElement, Parser, ParserStackEntry};
+use super::{CurrentElement, Parser, ParserStackEntry, StackInsertion};
 
 /// Maximum element nesting depth retained by the parser.
 ///
@@ -43,6 +43,11 @@ impl<'a> Parser<'a> {
 
     /// Append or merge text node
     fn append_or_merge_text(&mut self, content: &str, start: usize, end: usize) {
+        if self.should_foster_text(content) {
+            self.append_or_merge_fostered_text(content, start, end);
+            return;
+        }
+
         let merge_start_off = match self.stack.last().and_then(|e| e.element.children.last()) {
             Some(TemplateChildNode::Text(t)) => Some(t.loc.start.offset as usize),
             _ => None,
@@ -63,6 +68,37 @@ impl<'a> Parser<'a> {
             let text_node = TextNode::new(content, loc);
             let boxed = Box::new_in(text_node, self.allocator);
             self.add_child(TemplateChildNode::Text(boxed));
+        }
+    }
+
+    fn append_or_merge_fostered_text(&mut self, content: &str, start: usize, end: usize) {
+        let Some(table_index) = self.nearest_table_index() else {
+            self.append_or_merge_text(content, start, end);
+            return;
+        };
+
+        let merge_start_off = match self.stack[table_index].fostered_before.last() {
+            Some(TemplateChildNode::Text(t)) => Some(t.loc.start.offset as usize),
+            _ => None,
+        };
+
+        if let Some(merge_start) = merge_start_off {
+            let end_pos = self.get_pos(end);
+            let source_span = self.get_source(merge_start, end).into();
+            if let Some(TemplateChildNode::Text(text_node)) =
+                self.stack[table_index].fostered_before.last_mut()
+            {
+                text_node.content.push_str(content);
+                text_node.loc.end = end_pos;
+                text_node.loc.source = source_span;
+            }
+        } else {
+            let loc = self.create_loc(start, end);
+            let text_node = TextNode::new(content, loc);
+            let boxed = Box::new_in(text_node, self.allocator);
+            self.stack[table_index]
+                .fostered_before
+                .push(TemplateChildNode::Text(boxed));
         }
     }
 
@@ -127,6 +163,17 @@ impl<'a> Parser<'a> {
             // Determine element type
             element.tag_type = self.determine_element_type(&element);
 
+            if self.should_ignore_start_tag(&element) {
+                self.report_tree_construction_recovery(
+                    &element.loc,
+                    "HTML tree construction ignored this start tag because an equivalent element is already open.",
+                );
+                return;
+            }
+
+            self.handle_in_body_start_tag(element.tag.as_str(), tag_start);
+            self.handle_in_table_start_tag(element.tag.as_str(), tag_start);
+
             // Check for pre tags
             let is_pre = (self.options.is_pre_tag)(element.tag.as_str());
             let has_v_pre = element
@@ -189,10 +236,32 @@ impl<'a> Parser<'a> {
                 }
             }
 
-            if current.is_self_closing || (self.options.is_void_tag)(element.tag.as_str()) {
+            let html_non_void_self_closing =
+                current.is_self_closing && self.should_ignore_self_closing_flag(&element);
+
+            if html_non_void_self_closing {
+                self.report_tree_construction_recovery(
+                    &element.loc,
+                    "Self-closing flag is ignored for non-void HTML elements; treating this as a start tag.",
+                );
+                element.is_self_closing = false;
+            }
+
+            if (current.is_self_closing && !html_non_void_self_closing)
+                || (self.options.is_void_tag)(element.tag.as_str())
+            {
+                let should_foster_direct = self.should_foster_start_tag(
+                    element.tag.as_str(),
+                    element.ns == Namespace::Html && element.tag_type == ElementType::Element,
+                );
                 // Self-closing or void tag, add directly
                 let boxed = Box::new_in(element, self.allocator);
-                self.add_child(TemplateChildNode::Element(boxed));
+                let child = TemplateChildNode::Element(boxed);
+                if should_foster_direct {
+                    self.add_fostered_child(child);
+                } else {
+                    self.add_child(child);
+                }
             } else if self.stack.len() >= MAX_ELEMENT_NESTING_DEPTH {
                 // Nesting limit reached: keep the element but do not descend any
                 // further, so the resulting tree depth stays bounded. The
@@ -206,11 +275,23 @@ impl<'a> Parser<'a> {
                 let boxed = Box::new_in(element, self.allocator);
                 self.add_child(TemplateChildNode::Element(boxed));
             } else {
+                let insertion = if self.should_foster_start_tag(element.tag.as_str(), true) {
+                    self.report_tree_construction_recovery(
+                        &element.loc,
+                        "Foster parenting moved this element before the nearest open table.",
+                    );
+                    StackInsertion::Fostered
+                } else {
+                    StackInsertion::Normal
+                };
                 // Push to stack
-                self.stack.push(ParserStackEntry {
+                self.push_stack_entry(ParserStackEntry {
                     element,
                     in_pre: self.in_pre,
                     in_v_pre: self.in_v_pre,
+                    insertion,
+                    implicit: false,
+                    fostered_before: Vec::new_in(self.allocator),
                 });
                 self.in_pre = is_pre || self.in_pre;
                 self.in_v_pre = has_v_pre || self.in_v_pre;
@@ -227,53 +308,470 @@ impl<'a> Parser<'a> {
 
     /// Process close tag
     pub(super) fn on_close_tag_impl(&mut self, start: usize, end: usize) {
-        let tag = self.get_source(start, end);
+        let tag = self.get_source(start, end).to_owned();
+
+        if self.handle_formatting_end_tag(tag.as_str(), start, end) {
+            return;
+        }
 
         // Find matching open tag
-        let mut found = false;
-        for i in (0..self.stack.len()).rev() {
-            if self.stack[i].element.tag.eq_ignore_ascii_case(tag) {
-                found = true;
+        if let Some(i) = self.find_open_element_index(tag.as_str()) {
+            self.close_stack_element_at(i, true);
+            return;
+        }
 
-                // Pop all elements up to and including the match
-                let mut elements: vize_carton::Vec<'a, ParserStackEntry<'a>> =
-                    vize_carton::Vec::new_in(self.allocator);
-                while self.stack.len() > i {
-                    if let Some(entry) = self.stack.pop() {
-                        elements.push(entry);
-                    } else {
-                        break;
-                    }
-                }
+        let loc = self.create_loc(start.saturating_sub(2), end + 1); // Include </ and >
+        self.errors
+            .push(CompilerError::new(ErrorCode::InvalidEndTag, Some(loc)));
+    }
 
-                // Report errors for unclosed elements (except the matching one)
-                for entry in elements.iter().skip(1) {
+    pub(super) fn emit_stack_entry(&mut self, entry: ParserStackEntry<'a>) {
+        let insertion = entry.insertion;
+        let mut nodes = entry.fostered_before;
+        let boxed = Box::new_in(entry.element, self.allocator);
+        nodes.push(TemplateChildNode::Element(boxed));
+
+        for node in nodes {
+            if insertion == StackInsertion::Fostered {
+                self.add_fostered_child(node);
+            } else {
+                self.add_child(node);
+            }
+        }
+    }
+
+    fn close_stack_element_at(&mut self, index: usize, report_unclosed: bool) {
+        let mut entries = Vec::new_in(self.allocator);
+        while self.stack.len() > index {
+            if let Some(entry) = self.pop_stack_entry() {
+                entries.push(entry);
+            }
+        }
+
+        let Some(target) = entries.last() else {
+            return;
+        };
+        let restored_in_pre = target.in_pre;
+        let restored_in_v_pre = target.in_v_pre;
+
+        if report_unclosed {
+            for entry in entries.iter().take(entries.len().saturating_sub(1)) {
+                if !entry.implicit && !Self::can_omit_end_tag(entry.element.tag.as_str()) {
                     let loc = entry.element.loc.clone();
                     self.errors
                         .push(CompilerError::new(ErrorCode::MissingEndTag, Some(loc)));
                 }
-
-                // Add all popped elements back as children
-                for entry in elements.into_iter().rev() {
-                    let in_pre = entry.in_pre;
-                    let in_v_pre = entry.in_v_pre;
-
-                    let boxed = Box::new_in(entry.element, self.allocator);
-                    self.add_child(TemplateChildNode::Element(boxed));
-
-                    self.in_pre = in_pre;
-                    self.in_v_pre = in_v_pre;
-                }
-
-                break;
             }
         }
 
-        if !found {
-            let loc = self.create_loc(start.saturating_sub(2), end + 1); // Include </ and >
-            self.errors
-                .push(CompilerError::new(ErrorCode::InvalidEndTag, Some(loc)));
+        let mut child: Option<ParserStackEntry<'a>> = None;
+        for mut entry in entries {
+            if let Some(child_entry) = child.take() {
+                self.push_entry_as_child(&mut entry.element.children, child_entry);
+            }
+            child = Some(entry);
         }
+
+        if let Some(entry) = child {
+            self.emit_stack_entry(entry);
+        }
+
+        self.in_pre = restored_in_pre;
+        self.in_v_pre = restored_in_v_pre;
+    }
+
+    fn push_entry_as_child(
+        &mut self,
+        children: &mut Vec<'a, TemplateChildNode<'a>>,
+        entry: ParserStackEntry<'a>,
+    ) {
+        for node in entry.fostered_before {
+            children.push(node);
+        }
+        let boxed = Box::new_in(entry.element, self.allocator);
+        children.push(TemplateChildNode::Element(boxed));
+    }
+
+    fn find_open_element_index(&self, tag: &str) -> Option<usize> {
+        (0..self.stack.len())
+            .rev()
+            .find(|&i| self.stack[i].element.tag.eq_ignore_ascii_case(tag))
+    }
+
+    pub(super) fn nearest_table_index(&self) -> Option<usize> {
+        if self.open_table_count == 0 {
+            return None;
+        }
+
+        (0..self.stack.len())
+            .rev()
+            .find(|&i| self.stack[i].element.tag.eq_ignore_ascii_case("table"))
+    }
+
+    fn should_foster_text(&self, content: &str) -> bool {
+        self.open_table_count > 0
+            && content
+                .chars()
+                .any(|c| !matches!(c, ' ' | '\t' | '\n' | '\r' | '\u{000C}'))
+            && self.is_in_table_insertion_context()
+    }
+
+    fn should_foster_start_tag(&self, tag: &str, is_html_element: bool) -> bool {
+        is_html_element
+            && self.open_table_count > 0
+            && self.is_in_table_insertion_context()
+            && !self.is_allowed_in_table_insertion_context(tag)
+    }
+
+    fn is_in_table_insertion_context(&self) -> bool {
+        let Some(table_index) = self.nearest_table_index() else {
+            return false;
+        };
+
+        for entry in self.stack.iter().skip(table_index + 1) {
+            if entry.insertion == StackInsertion::Fostered
+                || Self::tag_in(entry.element.tag.as_str(), &["caption", "td", "th"])
+            {
+                return false;
+            }
+        }
+
+        true
+    }
+
+    fn is_allowed_in_table_insertion_context(&self, tag: &str) -> bool {
+        let current = self.stack.last().map(|entry| entry.element.tag.as_str());
+        match current {
+            Some(current) if Self::tag_in(current, &["tbody", "thead", "tfoot"]) => {
+                Self::tag_in(tag, &["tr", "script", "style", "template"])
+            }
+            Some(current) if current.eq_ignore_ascii_case("tr") => {
+                Self::tag_in(tag, &["td", "th", "script", "style", "template"])
+            }
+            _ => Self::tag_in(
+                tag,
+                &[
+                    "caption", "colgroup", "col", "tbody", "thead", "tfoot", "tr", "td", "th",
+                    "script", "style", "template",
+                ],
+            ),
+        }
+    }
+
+    fn handle_in_table_start_tag(&mut self, tag: &str, offset: usize) {
+        if self.open_table_count == 0 {
+            return;
+        }
+
+        if !self.is_in_table_insertion_context() {
+            return;
+        }
+
+        if Self::tag_in(tag, &["tbody", "thead", "tfoot"])
+            && self.stack.last().is_some_and(|entry| {
+                Self::tag_in(entry.element.tag.as_str(), &["tbody", "thead", "tfoot"])
+            })
+        {
+            let last = self.stack.len() - 1;
+            self.close_stack_element_at(last, false);
+        }
+
+        if tag.eq_ignore_ascii_case("tr") {
+            if self
+                .stack
+                .last()
+                .is_some_and(|entry| entry.element.tag.eq_ignore_ascii_case("tr"))
+            {
+                let last = self.stack.len() - 1;
+                self.close_stack_element_at(last, false);
+            }
+            self.ensure_table_section(offset);
+        } else if Self::tag_in(tag, &["td", "th"]) {
+            if self
+                .stack
+                .last()
+                .is_some_and(|entry| Self::tag_in(entry.element.tag.as_str(), &["td", "th"]))
+            {
+                let last = self.stack.len() - 1;
+                self.close_stack_element_at(last, false);
+            }
+            self.ensure_table_section(offset);
+            self.ensure_table_row(offset);
+        }
+    }
+
+    fn ensure_table_section(&mut self, offset: usize) {
+        let Some(table_index) = self.nearest_table_index() else {
+            return;
+        };
+        if self
+            .stack
+            .iter()
+            .skip(table_index + 1)
+            .any(|entry| Self::tag_in(entry.element.tag.as_str(), &["tbody", "thead", "tfoot"]))
+        {
+            return;
+        }
+        self.push_implicit_element("tbody", offset);
+    }
+
+    fn ensure_table_row(&mut self, offset: usize) {
+        if self
+            .stack
+            .last()
+            .is_some_and(|entry| entry.element.tag.eq_ignore_ascii_case("tr"))
+        {
+            return;
+        }
+        self.push_implicit_element("tr", offset);
+    }
+
+    fn push_implicit_element(&mut self, tag: &str, offset: usize) {
+        let loc = self.create_loc(offset, offset);
+        let mut element = ElementNode::new(self.allocator, tag, loc);
+        element.tag_type = self.determine_element_type(&element);
+        self.push_stack_entry(ParserStackEntry {
+            element,
+            in_pre: self.in_pre,
+            in_v_pre: self.in_v_pre,
+            insertion: StackInsertion::Normal,
+            implicit: true,
+            fostered_before: Vec::new_in(self.allocator),
+        });
+    }
+
+    fn handle_in_body_start_tag(&mut self, tag: &str, offset: usize) {
+        if tag.eq_ignore_ascii_case("html") || tag.eq_ignore_ascii_case("body") {
+            return;
+        }
+
+        if self.open_a_count == 0
+            && self.open_button_count == 0
+            && self.open_p_count == 0
+            && !Self::starts_optional_end_tag_scope(tag)
+        {
+            return;
+        }
+
+        if tag.eq_ignore_ascii_case("a") {
+            if self.open_a_count > 0
+                && let Some(index) = self.find_open_element_index("a")
+            {
+                self.report_tree_construction_recovery(
+                    &self.stack[index].element.loc.clone(),
+                    "Nested anchor start tag closed the previous anchor before inserting the new one.",
+                );
+                self.close_stack_element_at(index, false);
+            }
+            return;
+        }
+
+        if tag.eq_ignore_ascii_case("button") {
+            if self.open_button_count > 0
+                && let Some(index) = self.find_open_element_index("button")
+            {
+                self.report_tree_construction_recovery(
+                    &self.stack[index].element.loc.clone(),
+                    "Nested button start tag closed the previous button before inserting the new one.",
+                );
+                self.close_stack_element_at(index, false);
+            }
+            return;
+        }
+
+        if tag.eq_ignore_ascii_case("li") {
+            if let Some(index) = self.find_open_element_index("li") {
+                self.close_stack_element_at(index, false);
+            }
+        } else if Self::tag_in(tag, &["dt", "dd"]) {
+            if let Some(index) = self.find_last_open_element_index(&["dt", "dd"]) {
+                self.close_stack_element_at(index, false);
+            }
+        } else if tag.eq_ignore_ascii_case("option") {
+            if let Some(index) = self.find_open_element_index("option") {
+                self.close_stack_element_at(index, false);
+            }
+        } else if tag.eq_ignore_ascii_case("optgroup")
+            && let Some(index) = self.find_last_open_element_index(&["option", "optgroup"])
+        {
+            self.close_stack_element_at(index, false);
+        }
+
+        if self.open_p_count > 0 {
+            if tag.eq_ignore_ascii_case("p") {
+                if let Some(index) = self.find_open_element_index("p") {
+                    self.close_stack_element_at(index, false);
+                }
+            } else if Self::closes_open_p_before_start(tag)
+                && let Some(index) = self.find_open_element_index("p")
+            {
+                self.close_stack_element_at(index, false);
+            }
+        }
+
+        let _ = offset;
+    }
+
+    fn find_last_open_element_index(&self, tags: &[&str]) -> Option<usize> {
+        (0..self.stack.len())
+            .rev()
+            .find(|&i| Self::tag_in(self.stack[i].element.tag.as_str(), tags))
+    }
+
+    fn should_ignore_start_tag(&self, element: &ElementNode<'a>) -> bool {
+        element.tag.eq_ignore_ascii_case("form") && self.open_form_count > 0
+    }
+
+    fn should_ignore_self_closing_flag(&self, element: &ElementNode<'a>) -> bool {
+        element.ns == Namespace::Html
+            && element.tag_type == ElementType::Element
+            && (!self.options.custom_renderer || vize_carton::is_html_tag(element.tag.as_str()))
+            && !(self.options.is_void_tag)(element.tag.as_str())
+    }
+
+    fn handle_formatting_end_tag(&mut self, tag: &str, start: usize, end: usize) -> bool {
+        if !Self::is_formatting_tag(tag) {
+            return false;
+        }
+        if self
+            .stack
+            .last()
+            .is_some_and(|entry| entry.element.tag.eq_ignore_ascii_case(tag))
+        {
+            return false;
+        }
+        let Some(index) = self.find_open_element_index(tag) else {
+            return false;
+        };
+        if index + 1 == self.stack.len() {
+            return false;
+        }
+
+        let loc = self.create_loc(start.saturating_sub(2), end + 1);
+        self.report_tree_construction_recovery(
+            &loc,
+            "Misnested formatting end tag was repaired using the adoption agency recovery path.",
+        );
+
+        let mut reopened = Vec::new_in(self.allocator);
+        while self.stack.len() > index + 1 {
+            if let Some(entry) = self.pop_stack_entry() {
+                if Self::is_formatting_tag(entry.element.tag.as_str()) {
+                    reopened.push(Self::formatting_shell(
+                        self.allocator,
+                        &entry.element,
+                        self.in_pre,
+                        self.in_v_pre,
+                    ));
+                }
+                let mut parent = self
+                    .pop_stack_entry()
+                    .expect("formatting match is still open");
+                self.push_entry_as_child(&mut parent.element.children, entry);
+                self.push_stack_entry(parent);
+            }
+        }
+
+        let match_index = self.stack.len() - 1;
+        self.close_stack_element_at(match_index, false);
+
+        for mut entry in reopened.into_iter().rev() {
+            entry.in_pre = self.in_pre;
+            entry.in_v_pre = self.in_v_pre;
+            self.push_stack_entry(entry);
+        }
+
+        true
+    }
+
+    fn formatting_shell(
+        allocator: &'a vize_carton::Bump,
+        element: &ElementNode<'a>,
+        in_pre: bool,
+        in_v_pre: bool,
+    ) -> ParserStackEntry<'a> {
+        let mut reopened = ElementNode::new(allocator, element.tag.clone(), element.loc.clone());
+        reopened.ns = element.ns;
+        reopened.tag_type = element.tag_type;
+        ParserStackEntry {
+            element: reopened,
+            in_pre,
+            in_v_pre,
+            insertion: StackInsertion::Normal,
+            implicit: true,
+            fostered_before: Vec::new_in(allocator),
+        }
+    }
+
+    fn report_tree_construction_recovery(&mut self, loc: &SourceLocation, message: &str) {
+        self.errors.push(CompilerError::with_message(
+            ErrorCode::ExtendPoint,
+            message,
+            Some(loc.clone()),
+        ));
+    }
+
+    fn tag_in(tag: &str, candidates: &[&str]) -> bool {
+        candidates
+            .iter()
+            .any(|candidate| tag.eq_ignore_ascii_case(candidate))
+    }
+
+    fn is_formatting_tag(tag: &str) -> bool {
+        Self::tag_in(
+            tag,
+            &[
+                "a", "b", "big", "code", "em", "font", "i", "nobr", "s", "small", "strike",
+                "strong", "tt", "u",
+            ],
+        )
+    }
+
+    pub(super) fn can_omit_end_tag(tag: &str) -> bool {
+        Self::tag_in(
+            tag,
+            &[
+                "li", "dt", "dd", "p", "rt", "rp", "optgroup", "option", "thead", "tbody", "tfoot",
+                "tr", "td", "th",
+            ],
+        )
+    }
+
+    fn closes_open_p_before_start(tag: &str) -> bool {
+        Self::tag_in(
+            tag,
+            &[
+                "address",
+                "article",
+                "aside",
+                "blockquote",
+                "div",
+                "dl",
+                "fieldset",
+                "footer",
+                "form",
+                "h1",
+                "h2",
+                "h3",
+                "h4",
+                "h5",
+                "h6",
+                "header",
+                "hr",
+                "main",
+                "nav",
+                "ol",
+                "p",
+                "pre",
+                "section",
+                "table",
+                "ul",
+            ],
+        )
+    }
+
+    fn starts_optional_end_tag_scope(tag: &str) -> bool {
+        Self::tag_in(tag, &["li", "dt", "dd", "option", "optgroup"])
     }
 
     /// Determine element type (element, component, slot, template)

--- a/crates/vize_armature/src/parser/tests.rs
+++ b/crates/vize_armature/src/parser/tests.rs
@@ -206,37 +206,35 @@ fn test_parse_self_closing() {
 }
 
 #[test]
-fn test_parse_self_closing_textarea_keeps_following_elements() {
+fn test_parse_self_closing_textarea_uses_raw_text_recovery() {
     let allocator = Bump::new();
     let source = r#"<Primitive :class="ui.root({ class: [uiProp?.root, props.class] })"><textarea :class="ui.base({ class: uiProp?.base })" /><slot :ui="ui" /><span v-if="isLeading || !!avatar || !!slots.leading"><slot><UIcon v-if="isLeading && leadingIconName" /><UAvatar v-else-if="!!avatar" /></slot></span></Primitive>"#;
     let (root, errors) = parse(&allocator, source);
 
-    assert!(errors.is_empty(), "unexpected errors: {errors:?}");
+    assert!(
+        errors.iter().any(|e| e.code == ErrorCode::ExtendPoint
+            && e.message.contains("Self-closing flag is ignored")),
+        "unexpected errors: {errors:?}"
+    );
+    assert!(errors.iter().any(|e| e.code == ErrorCode::MissingEndTag));
     assert_eq!(root.children.len(), 1);
 
     if let TemplateChildNode::Element(el) = &root.children[0] {
         assert_eq!(el.tag.as_str(), "Primitive");
-        assert_eq!(el.children.len(), 3);
+        assert_eq!(el.children.len(), 1);
 
         if let TemplateChildNode::Element(textarea) = &el.children[0] {
             assert_eq!(textarea.tag.as_str(), "textarea");
-            assert!(textarea.is_self_closing);
+            assert!(!textarea.is_self_closing);
+            assert_eq!(textarea.children.len(), 1);
+            if let TemplateChildNode::Text(text) = &textarea.children[0] {
+                assert!(text.content.contains("<slot"));
+                assert!(text.content.contains("</Primitive>"));
+            } else {
+                panic!("Expected textarea raw text");
+            }
         } else {
             panic!("Expected textarea element");
-        }
-
-        if let TemplateChildNode::Element(slot) = &el.children[1] {
-            assert_eq!(slot.tag.as_str(), "slot");
-            assert!(slot.is_self_closing);
-        } else {
-            panic!("Expected slot element");
-        }
-
-        if let TemplateChildNode::Element(span) = &el.children[2] {
-            assert_eq!(span.tag.as_str(), "span");
-            assert_eq!(span.children.len(), 1);
-        } else {
-            panic!("Expected span element");
         }
     } else {
         panic!("Expected Primitive element");
@@ -490,7 +488,7 @@ fn test_parse_v_for() {
 #[test]
 fn test_no_value_directive_loc_excludes_trailing_whitespace() {
     let allocator = Bump::new();
-    let (root, errors) = parse(&allocator, "<div v-if />");
+    let (root, errors) = parse(&allocator, "<input v-if />");
     assert!(errors.is_empty());
 
     if let TemplateChildNode::Element(el) = &root.children[0] {
@@ -505,7 +503,7 @@ fn test_no_value_directive_loc_excludes_trailing_whitespace() {
 #[test]
 fn test_quoted_attribute_loc_includes_closing_quote_with_spaced_equals() {
     let allocator = Bump::new();
-    let (root, errors) = parse(&allocator, r#"<div class ="w-100" />"#);
+    let (root, errors) = parse(&allocator, r#"<input class ="w-100" />"#);
     assert!(errors.is_empty());
 
     if let TemplateChildNode::Element(el) = &root.children[0] {
@@ -522,7 +520,7 @@ fn test_quoted_attribute_loc_includes_closing_quote_with_spaced_equals() {
 #[test]
 fn test_quoted_directive_loc_includes_closing_quote_with_spaced_equals() {
     let allocator = Bump::new();
-    let (root, errors) = parse(&allocator, r#"<div v-if ="ok" />"#);
+    let (root, errors) = parse(&allocator, r#"<input v-if ="ok" />"#);
     assert!(errors.is_empty());
 
     if let TemplateChildNode::Element(el) = &root.children[0] {
@@ -572,7 +570,7 @@ fn test_parse_whitespace_condense_skips_comment_gaps_when_comments_disabled() {
     let allocator = Bump::new();
     let (root, errors) = parse_with_options(
         &allocator,
-        "<div><Foo />\n<!-- gap -->\n<div /></div>",
+        "<div><Foo />\n<!-- gap -->\n<input /></div>",
         ParserOptions {
             comments: false,
             ..ParserOptions::default()
@@ -629,6 +627,21 @@ fn test_parse_error_duplicate_attribute() {
     // non-fatal and emits valid render code for the first occurrence.
     let allocator = Bump::new();
     let (root, errors) = parse(&allocator, r#"<div id="a" id="b"></div>"#);
+    assert!(
+        errors
+            .iter()
+            .any(|e| e.code == ErrorCode::DuplicateAttribute)
+    );
+    if let TemplateChildNode::Element(el) = &root.children[0] {
+        assert_eq!(el.props.len(), 2);
+    }
+}
+
+#[test]
+fn test_parse_error_duplicate_attribute_is_ascii_case_insensitive() {
+    let allocator = Bump::new();
+    let (root, errors) = parse(&allocator, r#"<div id="a" ID="b"></div>"#);
+
     assert!(
         errors
             .iter()
@@ -834,7 +847,7 @@ fn test_parse_recovers_missing_attribute_value() {
     if let TemplateChildNode::Element(el) = &root.children[0] {
         if let PropNode::Attribute(attr) = &el.props[0] {
             assert_eq!(attr.name.as_str(), "id");
-            assert!(attr.value.is_none());
+            assert_eq!(attr.value.as_ref().unwrap().content.as_str(), "");
         } else {
             panic!("Expected recovered attribute");
         }
@@ -1051,6 +1064,289 @@ fn test_parse_abrupt_empty_comment_reports_error_and_continues() {
         }
         assert!(matches!(&root.children[1], TemplateChildNode::Element(_)));
     }
+}
+
+#[test]
+fn test_parse_nested_comment_reports_error_and_closes_at_first_end() {
+    let allocator = Bump::new();
+    let (root, errors) = parse(&allocator, "<!-- <!-- nested --> -->");
+
+    assert!(errors.iter().any(|e| e.code == ErrorCode::NestedComment));
+    assert_eq!(root.children.len(), 2);
+    if let TemplateChildNode::Comment(comment) = &root.children[0] {
+        assert_eq!(comment.content.as_str(), " <!-- nested ");
+    } else {
+        panic!("Expected first node to be the recovered comment");
+    }
+    if let TemplateChildNode::Text(text) = &root.children[1] {
+        assert_eq!(text.content.as_str(), " -->");
+    } else {
+        panic!("Expected trailing close marker text");
+    }
+}
+
+#[test]
+fn test_parse_processing_instruction_reports_error_and_continues() {
+    let allocator = Bump::new();
+    let (root, errors) = parse(&allocator, r#"<?xml version="1.0"?><div></div>"#);
+
+    assert!(
+        errors
+            .iter()
+            .any(|e| e.code == ErrorCode::UnexpectedQuestionMarkInsteadOfTagName)
+    );
+    assert!(
+        root.children.iter().any(
+            |child| matches!(child, TemplateChildNode::Element(el) if el.tag.as_str() == "div")
+        )
+    );
+}
+
+#[test]
+fn test_parse_unexpected_solidus_before_attribute_reports_error_and_continues() {
+    let allocator = Bump::new();
+    let (root, errors) = parse(&allocator, "<div / id=foo></div>");
+
+    assert!(
+        errors
+            .iter()
+            .any(|e| e.code == ErrorCode::UnexpectedSolidusInTag)
+    );
+    if let TemplateChildNode::Element(el) = &root.children[0] {
+        assert!(!el.is_self_closing);
+        if let PropNode::Attribute(attr) = &el.props[0] {
+            assert_eq!(attr.name.as_str(), "id");
+            assert_eq!(attr.value.as_ref().unwrap().content.as_str(), "foo");
+        } else {
+            panic!("Expected recovered attribute");
+        }
+    } else {
+        panic!("Expected element");
+    }
+}
+
+#[test]
+fn test_parse_self_closing_non_void_html_element_ignores_flag() {
+    let allocator = Bump::new();
+    let (root, errors) = parse(&allocator, "<div /><span></span>");
+
+    assert!(
+        errors.iter().any(|e| e.code == ErrorCode::ExtendPoint
+            && e.message.contains("Self-closing flag is ignored"))
+    );
+    assert!(errors.iter().any(|e| e.code == ErrorCode::MissingEndTag));
+    assert_eq!(root.children.len(), 1);
+    if let TemplateChildNode::Element(div) = &root.children[0] {
+        assert_eq!(div.tag.as_str(), "div");
+        assert!(!div.is_self_closing);
+        assert_eq!(div.children.len(), 1);
+        assert!(
+            matches!(&div.children[0], TemplateChildNode::Element(span) if span.tag.as_str() == "span")
+        );
+    } else {
+        panic!("Expected div");
+    }
+}
+
+#[test]
+fn test_parse_custom_renderer_non_html_element_keeps_self_closing_flag() {
+    let allocator = Bump::new();
+    let (root, errors) = parse_with_options(
+        &allocator,
+        "<primitive />",
+        ParserOptions {
+            custom_renderer: true,
+            ..ParserOptions::default()
+        },
+    );
+
+    assert!(errors.is_empty(), "unexpected errors: {errors:?}");
+    assert_eq!(root.children.len(), 1);
+    if let TemplateChildNode::Element(primitive) = &root.children[0] {
+        assert_eq!(primitive.tag.as_str(), "primitive");
+        assert_eq!(primitive.tag_type, ElementType::Element);
+        assert!(primitive.is_self_closing);
+    } else {
+        panic!("Expected primitive");
+    }
+}
+
+#[test]
+fn test_parse_table_inserts_implicit_tbody() {
+    let allocator = Bump::new();
+    let (root, errors) = parse(&allocator, "<table><tr><td>x</td></tr></table>");
+
+    assert!(errors.is_empty(), "unexpected errors: {errors:?}");
+    let TemplateChildNode::Element(table) = &root.children[0] else {
+        panic!("Expected table");
+    };
+    assert_eq!(table.children.len(), 1);
+    let TemplateChildNode::Element(tbody) = &table.children[0] else {
+        panic!("Expected implicit tbody");
+    };
+    assert_eq!(tbody.tag.as_str(), "tbody");
+    let TemplateChildNode::Element(tr) = &tbody.children[0] else {
+        panic!("Expected tr");
+    };
+    let TemplateChildNode::Element(td) = &tr.children[0] else {
+        panic!("Expected td");
+    };
+    assert!(
+        matches!(&td.children[0], TemplateChildNode::Text(text) if text.content.as_str() == "x")
+    );
+}
+
+#[test]
+fn test_parse_table_foster_parents_unexpected_element() {
+    let allocator = Bump::new();
+    let (root, errors) = parse(&allocator, "<table><div>hello</div></table>");
+
+    assert!(
+        errors
+            .iter()
+            .any(|e| e.code == ErrorCode::ExtendPoint && e.message.contains("Foster parenting"))
+    );
+    assert_eq!(root.children.len(), 2);
+    assert!(
+        matches!(&root.children[0], TemplateChildNode::Element(div) if div.tag.as_str() == "div")
+    );
+    assert!(
+        matches!(&root.children[1], TemplateChildNode::Element(table) if table.tag.as_str() == "table")
+    );
+}
+
+#[test]
+fn test_parse_table_cell_keeps_normal_body_content() {
+    let allocator = Bump::new();
+    let (root, errors) = parse(&allocator, "<table><tr><td><div>ok</div></td></tr></table>");
+
+    assert!(errors.is_empty(), "unexpected errors: {errors:?}");
+    let TemplateChildNode::Element(table) = &root.children[0] else {
+        panic!("Expected table");
+    };
+    let TemplateChildNode::Element(tbody) = &table.children[0] else {
+        panic!("Expected tbody");
+    };
+    let TemplateChildNode::Element(tr) = &tbody.children[0] else {
+        panic!("Expected tr");
+    };
+    let TemplateChildNode::Element(td) = &tr.children[0] else {
+        panic!("Expected td");
+    };
+    assert!(
+        matches!(&td.children[0], TemplateChildNode::Element(div) if div.tag.as_str() == "div")
+    );
+}
+
+#[test]
+fn test_parse_adoption_agency_repairs_misnested_formatting() {
+    let allocator = Bump::new();
+    let (root, errors) = parse(&allocator, "<b>aaa<i>bbb</b>ccc</i>");
+
+    assert!(
+        errors
+            .iter()
+            .any(|e| e.code == ErrorCode::ExtendPoint && e.message.contains("adoption agency"))
+    );
+    assert_eq!(root.children.len(), 2);
+    let TemplateChildNode::Element(b) = &root.children[0] else {
+        panic!("Expected b");
+    };
+    assert_eq!(b.tag.as_str(), "b");
+    assert!(
+        matches!(&b.children[0], TemplateChildNode::Text(text) if text.content.as_str() == "aaa")
+    );
+    let TemplateChildNode::Element(inner_i) = &b.children[1] else {
+        panic!("Expected nested i");
+    };
+    assert_eq!(inner_i.tag.as_str(), "i");
+    assert!(
+        matches!(&inner_i.children[0], TemplateChildNode::Text(text) if text.content.as_str() == "bbb")
+    );
+
+    let TemplateChildNode::Element(reopened_i) = &root.children[1] else {
+        panic!("Expected reopened i");
+    };
+    assert_eq!(reopened_i.tag.as_str(), "i");
+    assert!(
+        matches!(&reopened_i.children[0], TemplateChildNode::Text(text) if text.content.as_str() == "ccc")
+    );
+}
+
+#[test]
+fn test_parse_in_body_omits_p_and_li_end_tags() {
+    let allocator = Bump::new();
+    let (root, errors) = parse(&allocator, "<p>a<p>b<ul><li>c<li>d</ul>");
+
+    assert!(errors.is_empty(), "unexpected errors: {errors:?}");
+    assert_eq!(root.children.len(), 3);
+    assert!(matches!(&root.children[0], TemplateChildNode::Element(p) if p.tag.as_str() == "p"));
+    assert!(matches!(&root.children[1], TemplateChildNode::Element(p) if p.tag.as_str() == "p"));
+    let TemplateChildNode::Element(ul) = &root.children[2] else {
+        panic!("Expected ul");
+    };
+    assert_eq!(ul.children.len(), 2);
+    assert!(matches!(&ul.children[0], TemplateChildNode::Element(li) if li.tag.as_str() == "li"));
+    assert!(matches!(&ul.children[1], TemplateChildNode::Element(li) if li.tag.as_str() == "li"));
+}
+
+#[test]
+fn test_parse_nested_anchor_and_button_are_split() {
+    let allocator = Bump::new();
+    let (anchor_root, anchor_errors) = parse(
+        &allocator,
+        r#"<a href="/">outer<a href="/foo">inner</a></a>"#,
+    );
+
+    assert!(
+        anchor_errors
+            .iter()
+            .any(|e| e.code == ErrorCode::ExtendPoint && e.message.contains("Nested anchor"))
+    );
+    assert_eq!(anchor_root.children.len(), 2);
+    assert!(
+        matches!(&anchor_root.children[0], TemplateChildNode::Element(a) if a.tag.as_str() == "a")
+    );
+    assert!(
+        matches!(&anchor_root.children[1], TemplateChildNode::Element(a) if a.tag.as_str() == "a")
+    );
+
+    let (button_root, button_errors) =
+        parse(&allocator, "<button>aaa<button>bbb</button></button>");
+    assert!(
+        button_errors
+            .iter()
+            .any(|e| e.code == ErrorCode::ExtendPoint && e.message.contains("Nested button"))
+    );
+    assert_eq!(button_root.children.len(), 2);
+    assert!(
+        matches!(&button_root.children[0], TemplateChildNode::Element(button) if button.tag.as_str() == "button")
+    );
+    assert!(
+        matches!(&button_root.children[1], TemplateChildNode::Element(button) if button.tag.as_str() == "button")
+    );
+}
+
+#[test]
+fn test_parse_nested_form_start_tag_is_ignored() {
+    let allocator = Bump::new();
+    let (root, errors) = parse(&allocator, "<form><input><form><input></form></form>");
+
+    assert!(
+        errors
+            .iter()
+            .any(|e| e.code == ErrorCode::ExtendPoint
+                && e.message.contains("ignored this start tag"))
+    );
+    assert_eq!(root.children.len(), 1);
+    let TemplateChildNode::Element(form) = &root.children[0] else {
+        panic!("Expected form");
+    };
+    assert_eq!(form.tag.as_str(), "form");
+    assert_eq!(form.children.len(), 2);
+    assert!(form.children.iter().all(
+        |child| matches!(child, TemplateChildNode::Element(input) if input.tag.as_str() == "input")
+    ));
 }
 
 #[test]

--- a/crates/vize_armature/src/tokenizer/states.rs
+++ b/crates/vize_armature/src/tokenizer/states.rs
@@ -23,6 +23,9 @@ impl<'a, C: Callbacks> Tokenizer<'a, C> {
             State::Text if has_section => {
                 self.callbacks.on_text(self.section_start, self.index);
             }
+            State::InRCDATA if has_section => {
+                self.callbacks.on_text(self.section_start, self.index);
+            }
             State::Interpolation | State::InterpolationClose if has_section => {
                 self.callbacks
                     .on_error(ErrorCode::MissingInterpolationEnd, self.index);
@@ -248,6 +251,10 @@ impl<'a, C: Callbacks> Tokenizer<'a, C> {
             self.state = State::BeforeDeclaration;
             self.section_start = self.index + 1;
         } else if c == QUESTION_MARK {
+            self.callbacks.on_error(
+                ErrorCode::UnexpectedQuestionMarkInsteadOfTagName,
+                self.index,
+            );
             self.state = State::InProcessingInstruction;
             self.section_start = self.index + 1;
         } else if is_tag_start_char(c) {
@@ -282,12 +289,17 @@ impl<'a, C: Callbacks> Tokenizer<'a, C> {
     pub(super) fn state_in_self_closing_tag(&mut self, c: u8) {
         if c == GT {
             self.callbacks.on_self_closing_tag(self.index);
-            self.in_rcdata = false;
-            self.current_sequence = None;
-            self.sequence_index = 0;
-            self.state = State::Text;
+            if self.in_rcdata {
+                self.state = State::InRCDATA;
+            } else {
+                self.current_sequence = None;
+                self.sequence_index = 0;
+                self.state = State::Text;
+            }
             self.section_start = self.index + 1;
         } else if !is_whitespace(c) {
+            self.callbacks
+                .on_error(ErrorCode::UnexpectedSolidusInTag, self.section_start);
             self.state = State::BeforeAttrName;
             self.state_before_attr_name(c);
         }
@@ -520,7 +532,8 @@ impl<'a, C: Callbacks> Tokenizer<'a, C> {
         } else if c == GT {
             self.callbacks
                 .on_error(ErrorCode::MissingAttributeValue, self.index);
-            self.callbacks.on_attrib_end(QuoteType::NoValue, self.index);
+            self.callbacks
+                .on_attrib_end(QuoteType::Unquoted, self.index);
             self.state = State::BeforeAttrName;
             self.state_before_attr_name(c);
         } else if !is_whitespace(c) {
@@ -692,8 +705,12 @@ impl<'a, C: Callbacks> Tokenizer<'a, C> {
                 self.finish_comment_like(sequence);
             }
         } else if self.sequence_index == 0 {
-            // Fast-forward to the first character of the sequence
-            if self.fast_forward_to(sequence_bytes[0]) {
+            if sequence == Sequence::CommentEnd
+                && self.input.get(self.index..self.index + 4) == Some(b"<!--")
+            {
+                self.callbacks
+                    .on_error(ErrorCode::NestedComment, self.index);
+            } else if sequence != Sequence::CommentEnd && self.fast_forward_to(sequence_bytes[0]) {
                 self.sequence_index = 1;
             }
         } else if sequence == Sequence::CommentEnd

--- a/crates/vize_armature/src/tokenizer/tests.rs
+++ b/crates/vize_armature/src/tokenizer/tests.rs
@@ -414,6 +414,18 @@ fn test_comment_extra_hyphens_before_close() {
     assert!(cb.events.contains(&TokenEvent::Comment(4, 9)));
 }
 
+#[test]
+fn test_comment_nested_opener_reports_error_and_closes_at_first_end() {
+    let cb = tokenize("<!-- <!-- nested --> -->");
+    assert!(
+        cb.errors
+            .iter()
+            .any(|(code, _)| *code == ErrorCode::NestedComment)
+    );
+    assert!(cb.events.contains(&TokenEvent::Comment(4, 17)));
+    assert!(cb.events.contains(&TokenEvent::Text(20, 24)));
+}
+
 // ========================================================================
 // Error tests
 // ========================================================================
@@ -458,6 +470,29 @@ fn test_error_eof_in_empty_cdata() {
             .any(|(code, _)| *code == ErrorCode::EofInCdata)
     );
     assert!(cb.events.contains(&TokenEvent::Cdata(9, 9)));
+}
+
+#[test]
+fn test_error_processing_instruction_reports_question_mark() {
+    let cb = tokenize(r#"<?xml version="1.0"?><div></div>"#);
+    assert!(
+        cb.errors
+            .iter()
+            .any(|(code, _)| *code == ErrorCode::UnexpectedQuestionMarkInsteadOfTagName)
+    );
+    assert!(cb.events.contains(&TokenEvent::OpenTagName(22, 25)));
+}
+
+#[test]
+fn test_error_unexpected_solidus_before_attribute() {
+    let cb = tokenize("<div / id=foo></div>");
+    assert!(
+        cb.errors
+            .iter()
+            .any(|(code, _)| *code == ErrorCode::UnexpectedSolidusInTag)
+    );
+    assert!(cb.events.contains(&TokenEvent::AttribName(7, 9)));
+    assert!(cb.events.contains(&TokenEvent::AttribData(10, 13)));
 }
 
 // ========================================================================
@@ -586,14 +621,13 @@ fn test_special_opening_textarea_text_and_close() {
 }
 
 #[test]
-fn test_self_closing_textarea_returns_to_text_state() {
+fn test_self_closing_textarea_stays_in_rcdata() {
     let cb = tokenize("<textarea /><span>ok</span>");
     assert!(cb.errors.is_empty());
     assert!(cb.events.contains(&TokenEvent::OpenTagName(1, 9)));
     assert!(cb.events.contains(&TokenEvent::SelfClosingTag(11)));
-    assert!(cb.events.contains(&TokenEvent::OpenTagName(13, 17)));
-    assert!(cb.events.contains(&TokenEvent::Text(18, 20)));
-    assert!(cb.events.contains(&TokenEvent::CloseTag(22, 26)));
+    assert!(cb.events.contains(&TokenEvent::Text(12, 27)));
+    assert!(!cb.events.contains(&TokenEvent::OpenTagName(13, 17)));
 }
 
 #[test]

--- a/crates/vize_atelier_core/src/codegen.rs
+++ b/crates/vize_atelier_core/src/codegen.rs
@@ -404,8 +404,9 @@ mod tests {
 
     #[test]
     fn test_root_directive_comment_does_not_create_fragment_hole() {
-        let result =
-            compile!("<!-- @vize:forget sections are labeled by their headings --><section />");
+        let result = compile!(
+            "<!-- @vize:forget sections are labeled by their headings --><section></section>"
+        );
 
         assert_codegen_snapshot!(result);
     }
@@ -796,7 +797,7 @@ mod tests {
     #[test]
     fn test_codegen_numeric_template_v_for_uses_fragment() {
         let result = compile!(
-            r#"<div><template v-for="n in 4" :key="`set-${n}`"><button /><span v-for="(icon, i) in icons" :key="`${n}-${i}`" :class="icon" /></template></div>"#
+            r#"<div><template v-for="n in 4" :key="`set-${n}`"><button></button><span v-for="(icon, i) in icons" :key="`${n}-${i}`" :class="icon"></span></template></div>"#
         );
 
         assert!(

--- a/crates/vize_atelier_dom/src/lib.rs
+++ b/crates/vize_atelier_dom/src/lib.rs
@@ -322,7 +322,7 @@ mod tests {
         let allocator = Bump::new();
         let (_, errors, result) = compile_template(
             &allocator,
-            r#"<span v-for="item in items" ref="itemEls" />"#,
+            r#"<span v-for="item in items" ref="itemEls"></span>"#,
         );
         assert!(errors.is_empty());
         let code = result.code.as_str();
@@ -355,7 +355,7 @@ mod tests {
 
         let (_, errors, result) = compile_template_with_options(
             &allocator,
-            r#"<button v-for="button in buttons" ref="buttons" :key="button" />"#,
+            r#"<button v-for="button in buttons" ref="buttons" :key="button"></button>"#,
             options,
         );
 
@@ -794,7 +794,7 @@ mod tests {
 
         let (_, errors, result) = compile_template_with_options(
             &allocator,
-            r#"<section><h2 sr-only font-bold flex="~ gap-1"><span block /></h2></section>"#,
+            r#"<section><h2 sr-only font-bold flex="~ gap-1"><span block></span></h2></section>"#,
             options,
         );
 

--- a/crates/vize_atelier_sfc/src/compile/tests.rs
+++ b/crates/vize_atelier_sfc/src/compile/tests.rs
@@ -1854,7 +1854,7 @@ export interface ContentProps extends PrimitiveProps {
 defineProps<ContentProps>()
 </script>
 
-<template><div /></template>"#,
+<template><div></div></template>"#,
     )
     .unwrap();
     fs::write(
@@ -2688,7 +2688,7 @@ const visible = true
 <template>
   <mesh>
     <group v-if="visible">
-      <primitive />
+      <primitive></primitive>
     </group>
   </mesh>
 </template>"#;
@@ -2722,7 +2722,7 @@ const visible = true
 <template>
   <mesh>
     <group v-if="visible">
-      <primitive />
+      <primitive></primitive>
     </group>
   </mesh>
 </template>"#;

--- a/crates/vize_atelier_sfc/src/lib.rs
+++ b/crates/vize_atelier_sfc/src/lib.rs
@@ -254,7 +254,7 @@ import { Child } from "./components";
   <div
     v-for="_, i in ary"
     :prop="val"
-  />
+  ></div>
 </template>
 
 <script setup lang="ts">

--- a/crates/vize_atelier_ssr/tests/snapshots/ssr_snapshot__element__empty_div.snap
+++ b/crates/vize_atelier_ssr/tests/snapshots/ssr_snapshot__element__empty_div.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/vize_atelier_ssr/tests/ssr_snapshot.rs
-expression: "get_compiled_string(\"<div/>\")"
+assertion_line: 96
+expression: "get_compiled_string(\"<div></div>\")"
 ---
 function ssrRender(_ctx, _push, _parent, _attrs) {
   _push(`<div${_ssrRenderAttrs(_attrs)}><div></div></div>`)

--- a/crates/vize_atelier_ssr/tests/snapshots/ssr_snapshot__element__should_ignore_v_on.snap
+++ b/crates/vize_atelier_ssr/tests/snapshots/ssr_snapshot__element__should_ignore_v_on.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/vize_atelier_ssr/tests/ssr_snapshot.rs
-expression: "get_compiled_string(r#\"<div id=\"foo\" @click=\"bar\"/>\"#)"
+expression: "get_compiled_string(r#\"<div id=\"foo\" @click=\"bar\"></div>\"#)"
 ---
 function ssrRender(_ctx, _push, _parent, _attrs) {
   _push(`<div${_ssrRenderAttrs(_attrs)}><div id="foo"></div></div>`)

--- a/crates/vize_atelier_ssr/tests/ssr_snapshot.rs
+++ b/crates/vize_atelier_ssr/tests/ssr_snapshot.rs
@@ -92,8 +92,8 @@ mod element {
     }
 
     #[test]
-    fn self_closing_div() {
-        insta::assert_snapshot!(get_compiled_string("<div/>"));
+    fn empty_div() {
+        insta::assert_snapshot!(get_compiled_string("<div></div>"));
     }
 
     #[test]
@@ -147,7 +147,7 @@ mod element {
 
     #[test]
     fn should_ignore_v_on() {
-        insta::assert_snapshot!(get_compiled_string(r#"<div id="foo" @click="bar"/>"#));
+        insta::assert_snapshot!(get_compiled_string(r#"<div id="foo" @click="bar"></div>"#));
     }
 }
 

--- a/crates/vize_atelier_vapor/src/lib.rs
+++ b/crates/vize_atelier_vapor/src/lib.rs
@@ -823,7 +823,7 @@ selected</pre>"#,
         bindings.insert("Primitive".into(), BindingType::SetupConst);
         let result = compile_vapor(
             &allocator,
-            r#"<mesh><group v-if="visible"><primitive /></group></mesh>"#,
+            r#"<mesh><group v-if="visible"><primitive></primitive></group></mesh>"#,
             super::VaporCompilerOptions {
                 custom_renderer: true,
                 binding_metadata: Some(BindingMetadata {

--- a/crates/vize_canon/src/batch/type_checker/tests.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests.rs
@@ -928,7 +928,7 @@ export interface BaseProps {
 }
 </script>
 
-<template><div /></template>
+<template><div></div></template>
 "#,
             ),
             (
@@ -944,7 +944,7 @@ defineProps<{
 }>()
 </script>
 
-<template><div /></template>
+<template><div></div></template>
 "#,
             ),
             (
@@ -1017,7 +1017,7 @@ export interface ContentProps extends PrimitiveProps {
 defineProps<ContentProps>()
 </script>
 
-<template><div /></template>
+<template><div></div></template>
 "#,
             ),
             (

--- a/crates/vize_canon/src/batch/virtual_project.rs
+++ b/crates/vize_canon/src/batch/virtual_project.rs
@@ -2070,7 +2070,7 @@ export interface BaseProps {
   asChild?: boolean;
 }
 </script>
-<template><div /></template>"#,
+<template><div></div></template>"#,
         )
         .unwrap();
         fs::write(&index, r#"export { type BaseProps } from "./Base.vue";"#).unwrap();
@@ -2079,7 +2079,7 @@ export interface BaseProps {
             r#"<script setup lang="ts">
 defineProps<{ as?: string; asChild?: boolean }>();
 </script>
-<template><div /></template>"#,
+<template><div></div></template>"#,
         )
         .unwrap();
         fs::write(
@@ -2162,7 +2162,7 @@ const onFocus = (target: HTMLElement) => {
         onFocus(event.target as HTMLElement)
       },
     }"
-  />
+  ></div>
 </template>
 "#,
         )

--- a/crates/vize_canon/src/sfc_typecheck.rs
+++ b/crates/vize_canon/src/sfc_typecheck.rs
@@ -154,7 +154,7 @@ const props = defineProps<Props>();
     fn test_type_check_with_defaults_template_props_are_default_resolved() {
         let source = r#"<template>
   <svg>
-    <line :stroke-width="props.thickness / 2" />
+    <line :stroke-width="props.thickness / 2"></line>
     <text>{{ label.toUpperCase() }} {{ props.label.toUpperCase() }}</text>
   </svg>
 </template>
@@ -397,7 +397,7 @@ export const buttonId =
   "button-id";
 </script>
 <template>
-    <button :id="buttonId" />
+    <button :id="buttonId"></button>
 </template>"#;
         let options = SfcTypeCheckOptions::new("test.vue");
         let result = type_check_sfc(source, &options);
@@ -465,7 +465,7 @@ export default {
     fn test_type_check_template_undefined_binding_uses_expression_offset() {
         let source = r#"<script lang="ts"></script>
 <template>
-    <button :id="missingButtonId" />
+    <button :id="missingButtonId"></button>
 </template>"#;
         let options = SfcTypeCheckOptions::new("test.vue");
         let result = type_check_sfc(source, &options);
@@ -592,7 +592,7 @@ const onFocus = (target: HTMLElement) => {
         onFocus(event.target as HTMLElement)
       },
     }"
-  />
+  ></div>
 </template>"#;
         let options = SfcTypeCheckOptions::new("test.vue").with_virtual_ts();
         let result = type_check_sfc(source, &options);

--- a/crates/vize_canon/src/snapshots/vize_canon__tests__virtual_ts_tests__virtual_ts_dynamic_component.snap
+++ b/crates/vize_canon/src/snapshots/vize_canon__tests__virtual_ts_tests__virtual_ts_dynamic_component.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/vize_canon/src/tests.rs
+assertion_line: 361
 expression: virtual_ts
 ---
 /// <reference lib="es2022" />
@@ -102,9 +103,9 @@ function __setup() {
 
   // @click handler
   (($event: PointerEvent) => {
-    const __vize_handler_10_70 = ((handler: ($event: PointerEvent) => unknown) => handler)((switchComponent));
-    __vize_handler_10_70($event);  // handler expression
-    // @vize-map: handler -> 387:402
+    const __vize_handler_10_80 = ((handler: ($event: PointerEvent) => unknown) => handler)((switchComponent));
+    __vize_handler_10_80($event);  // handler expression
+    // @vize-map: handler -> 397:412
   })({} as PointerEvent);
 
   // Reference setup bindings (used in template/CSS v-bind)

--- a/crates/vize_canon/src/tests.rs
+++ b/crates/vize_canon/src/tests.rs
@@ -352,7 +352,7 @@ function switchComponent() {
 
 <template>
   <div>
-    <component :is="currentComponent" />
+    <component :is="currentComponent"></component>
     <button @click="switchComponent">Switch</button>
   </div>
 </template>"#;

--- a/crates/vize_maestro/src/ide/definition.rs
+++ b/crates/vize_maestro/src/ide/definition.rs
@@ -261,7 +261,7 @@ import MyComponent from './MyComponent.vue'
 
         fs::write(
             &component_path,
-            "<script setup lang=\"ts\"></script>\n<template><button /></template>\n",
+            "<script setup lang=\"ts\"></script>\n<template><button></button></template>\n",
         )
         .unwrap();
 
@@ -298,7 +298,7 @@ import MyButton from './MyButton.vue'
         let component_path = dir.path().join("Button.vue");
         let source_path = dir.path().join("Button.art.vue");
 
-        fs::write(&component_path, "<template><button /></template>\n").unwrap();
+        fs::write(&component_path, "<template><button></button></template>\n").unwrap();
 
         let source = r#"<script setup lang="ts">
 defineArt("./Button.vue", {

--- a/crates/vize_maestro/src/ide/diagnostics.rs
+++ b/crates/vize_maestro/src/ide/diagnostics.rs
@@ -726,7 +726,7 @@ const { msg = "ok" } = defineProps<{ msg?: string }>();
         let uri = Url::parse("file:///OutOfOrder.vue").unwrap();
         state.documents.open(
             uri.clone(),
-            "<template><div /></template>\n<script setup>const count = 1</script>".to_string(),
+            "<template><div></div></template>\n<script setup>const count = 1</script>".to_string(),
             1,
             "vue".to_string(),
         );
@@ -1039,7 +1039,7 @@ const title = t("auth.missing")
         let uri = Url::parse("file:///OutOfOrder.vue").unwrap();
         state.documents.open(
             uri.clone(),
-            "<template><div /></template>\n<script setup>const count = 1</script>".to_string(),
+            "<template><div></div></template>\n<script setup>const count = 1</script>".to_string(),
             1,
             "vue".to_string(),
         );

--- a/crates/vize_maestro/src/ide/diagnostics/corsa.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/corsa.rs
@@ -1001,7 +1001,7 @@ mod tests {
                        const _w = Aliased\n\
                        const _r = ref(0)\n\
                        </script>\n\
-                       <template><div /></template>";
+                       <template><div></div></template>";
 
         let result = DiagnosticService::generate_virtual_ts(&uri, content, false)
             .expect("virtual ts generated");

--- a/crates/vize_patina/src/rules/vue/permitted_contents.rs
+++ b/crates/vize_patina/src/rules/vue/permitted_contents.rs
@@ -332,10 +332,10 @@ mod tests {
     // ===== Invalid: Block in inline =====
 
     #[test]
-    fn test_invalid_div_in_p() {
+    fn test_repaired_div_after_p() {
         let linter = create_linter();
         let result = linter.lint_template(r#"<p><div>block</div></p>"#, "test.vue");
-        assert_eq!(result.error_count, 1);
+        assert_eq!(result.error_count, 0);
     }
 
     #[test]
@@ -346,10 +346,10 @@ mod tests {
     }
 
     #[test]
-    fn test_invalid_h1_in_p() {
+    fn test_repaired_h1_after_p() {
         let linter = create_linter();
         let result = linter.lint_template(r#"<p><h1>heading</h1></p>"#, "test.vue");
-        assert_eq!(result.error_count, 1);
+        assert_eq!(result.error_count, 0);
     }
 
     #[test]
@@ -362,29 +362,29 @@ mod tests {
     }
 
     #[test]
-    fn test_invalid_flow_content_in_anchor_when_outer_context_is_phrasing() {
+    fn test_repaired_flow_content_in_anchor_when_outer_context_is_phrasing() {
         let linter = create_linter();
         let result =
             linter.lint_template(r##"<p><a href="#"><div>block</div></a></p>"##, "test.vue");
-        assert_eq!(result.error_count, 1);
+        assert_eq!(result.error_count, 0);
     }
 
     // ===== Invalid: Interactive nesting =====
 
     #[test]
-    fn test_invalid_a_in_a() {
+    fn test_repaired_a_in_a() {
         let linter = create_linter();
         let result =
             linter.lint_template(r##"<a href="#"><a href="#">nested</a></a>"##, "test.vue");
-        assert_eq!(result.error_count, 1);
+        assert_eq!(result.error_count, 0);
     }
 
     #[test]
-    fn test_invalid_button_in_button() {
+    fn test_repaired_button_in_button() {
         let linter = create_linter();
         let result =
             linter.lint_template(r#"<button><button>nested</button></button>"#, "test.vue");
-        assert_eq!(result.error_count, 1);
+        assert_eq!(result.error_count, 0);
     }
 
     #[test]
@@ -435,20 +435,20 @@ mod tests {
     // ===== Invalid: Table content model =====
 
     #[test]
-    fn test_invalid_div_in_table() {
+    fn test_repaired_div_in_table() {
         let linter = create_linter();
         let result = linter.lint_template(r#"<table><div>not valid</div></table>"#, "test.vue");
-        assert_eq!(result.error_count, 1);
+        assert_eq!(result.error_count, 0);
     }
 
     #[test]
-    fn test_invalid_span_in_tr() {
+    fn test_repaired_span_in_tr() {
         let linter = create_linter();
         let result = linter.lint_template(
             r#"<table><tr><span>not td/th</span></tr></table>"#,
             "test.vue",
         );
-        assert_eq!(result.error_count, 1);
+        assert_eq!(result.error_count, 0);
     }
 
     // ===== Invalid: Select content model =====

--- a/npm/vite-plugin-vize/src/plugin/load.test.ts
+++ b/npm/vite-plugin-vize/src/plugin/load.test.ts
@@ -304,7 +304,7 @@ fs.writeFileSync(
 const { t } = useI18n()
 useSeoMeta({ title: () => t("site.name") })
 </script>
-<template><div /></template>`,
+<template><div></div></template>`,
 );
 
 const emptyPageMetaLoad = loadHook(

--- a/playground/src/features/atelier/AtelierPlayground.vue
+++ b/playground/src/features/atelier/AtelierPlayground.vue
@@ -166,7 +166,7 @@ onUnmounted(() => {
 
     <div class="output-content">
       <div v-if="isCompiling" class="compiling">
-        <div class="spinner" />
+        <div class="spinner"></div>
         <span>Compiling...</span>
       </div>
 

--- a/playground/src/features/inspector/InspectorPlayground.vue
+++ b/playground/src/features/inspector/InspectorPlayground.vue
@@ -399,7 +399,7 @@ onUnmounted(() => {
 
     <div class="output-content">
       <div v-if="isCompiling" class="compiling">
-        <div class="spinner" />
+        <div class="spinner"></div>
         <span>Compiling...</span>
       </div>
 

--- a/tests/expected/sfc/define-model.snap
+++ b/tests/expected/sfc/define-model.snap
@@ -597,7 +597,7 @@ const cb = defineModel<() => void>()
 </script>
 
 <template>
-  <div />
+  <div></div>
 </template>
 --- OUTPUT ---
 import { useModel as _useModel, defineComponent as _defineComponent } from 'vue'

--- a/tests/fixtures/sfc/define-model.toml
+++ b/tests/fixtures/sfc/define-model.toml
@@ -219,6 +219,6 @@ const cb = defineModel<() => void>()
 </script>
 
 <template>
-  <div />
+  <div></div>
 </template>
 """

--- a/tests/fixtures/sfc/patches.toml
+++ b/tests/fixtures/sfc/patches.toml
@@ -329,7 +329,7 @@ import { vElementHover } from '@vueuse/components'
 </script>
 
 <template>
-  <div v-element-hover="() => {}" />
+  <div v-element-hover="() => {}"></div>
 </template>
 """
 
@@ -396,7 +396,7 @@ defineProps<{
 </script>
 
 <template>
-  <div />
+  <div></div>
 </template>
 """
 

--- a/tests/vize_test_runner/src/lib.rs
+++ b/tests/vize_test_runner/src/lib.rs
@@ -7,6 +7,7 @@
 use serde::Deserialize;
 use std::path::Path;
 use vize_atelier_core::{
+    Namespace,
     codegen::generate,
     options::{CodegenMode, CodegenOptions, ParserOptions, TransformOptions},
     parser::parse_with_options,
@@ -162,6 +163,7 @@ pub fn compile_vdom(input: &str, options: &TestOptions) -> String {
         is_void_tag: vize_carton::is_void_tag,
         is_native_tag: Some(vize_carton::is_native_tag),
         is_pre_tag: |tag| tag == "pre",
+        get_namespace: get_dom_namespace,
         ..Default::default()
     };
 
@@ -191,6 +193,32 @@ pub fn compile_vdom(input: &str, options: &TestOptions) -> String {
     } else {
         format!("{}\n\n{}", preamble, result.code).into()
     }
+}
+
+fn get_dom_namespace(tag: &str, parent: Option<&str>) -> Namespace {
+    if vize_carton::is_svg_tag(tag) {
+        return Namespace::Svg;
+    }
+    if vize_carton::is_math_ml_tag(tag) {
+        return Namespace::MathMl;
+    }
+
+    if let Some(parent_tag) = parent {
+        let svg_to_html = matches!(parent_tag, "foreignObject" | "desc" | "title");
+        if vize_carton::is_svg_tag(parent_tag) && !svg_to_html {
+            return Namespace::Svg;
+        }
+
+        let mathml_to_html = matches!(
+            parent_tag,
+            "annotation-xml" | "mi" | "mo" | "mn" | "ms" | "mtext"
+        );
+        if vize_carton::is_math_ml_tag(parent_tag) && !mathml_to_html {
+            return Namespace::MathMl;
+        }
+    }
+
+    Namespace::Html
 }
 
 /// Compile a template with Vapor mode


### PR DESCRIPTION
## Summary
- report/recover more HTML tokenizer parse errors: processing instructions, unexpected solidus, missing attribute values, duplicate attributes ignoring ASCII case, nested comments
- align tree construction with browser-like HTML behavior for non-void self-closing tags, implicit table sections, foster parenting, in-body optional closures, nested form/a/button handling, and a focused adoption-agency repair path
- update downstream fixtures/snapshots that relied on self-closing non-void HTML elements, and adjust permitted-content lint tests for parser-repaired trees

## Validation
- cargo test --workspace

## Notes
- Vue directives, components, and mustache syntax remain supported. Component self-closing syntax is kept where the parser classifies the tag as a component.
- SFC templates are parsed as fragments, so document-level quirks mode/doctype state is not represented in the AST in this PR.