### PR TITLE
refactor: move config normalization to Rust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3479,6 +3479,7 @@ dependencies = [
  "oxc_span",
  "oxc_syntax",
  "oxc_transformer",
+ "pklrust",
  "regex",
  "serde",
  "serde_json",

--- a/crates/vize_atelier_sfc/Cargo.toml
+++ b/crates/vize_atelier_sfc/Cargo.toml
@@ -41,6 +41,7 @@ sha2 = { workspace = true }
 [dev-dependencies]
 insta = { workspace = true }
 criterion = { workspace = true }
+pklrust = { workspace = true }
 toml = { workspace = true }
 
 [[bench]]

--- a/crates/vize_atelier_sfc/src/snapshot_tests.rs
+++ b/crates/vize_atelier_sfc/src/snapshot_tests.rs
@@ -4,16 +4,17 @@
 //! It uses the insta crate for snapshot testing, with snapshots stored
 //! in tests/snapshots/sfc/ts/.
 //!
-//! The test cases are loaded from TOML fixtures in tests/fixtures/sfc/.
+//! The test cases are loaded from PKL or TOML fixtures in tests/fixtures/sfc/.
 #![allow(clippy::disallowed_macros)]
 
 use crate::{SfcCompileOptions, compile_sfc, parse_sfc};
+use pklrust::{EvaluatorManager, EvaluatorOptions, ModuleSource};
 use serde::Deserialize;
 use std::fmt::Write;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use vize_carton::{String, ToCompactString};
 
-/// A test case from a TOML fixture
+/// A test case from a snapshot fixture.
 #[derive(Debug, Deserialize)]
 struct TestCase {
     name: String,
@@ -22,7 +23,7 @@ struct TestCase {
     expected: Option<String>,
 }
 
-/// A fixture file containing multiple test cases
+/// A fixture file containing multiple test cases.
 #[derive(Debug, Deserialize)]
 struct Fixture {
     #[allow(dead_code)]
@@ -54,11 +55,70 @@ fn snapshots_path() -> PathBuf {
         .join("snapshots")
 }
 
-/// Load a fixture from a TOML file
-fn load_fixture(path: &PathBuf) -> Result<Fixture, Box<dyn std::error::Error>> {
+/// Resolve an SFC snapshot fixture by preferring PKL over legacy TOML.
+///
+/// PKL is the preferred authoring format because it gives fixture files a real
+/// typed module language instead of a flat data encoding. TOML remains as a
+/// fallback so existing fixtures can migrate gradually without widening this
+/// test harness change.
+fn fixture_file(name: &str) -> PathBuf {
+    let base = fixtures_path().join("sfc").join(name);
+    let pkl = base.with_extension("pkl");
+    if pkl.exists() {
+        pkl
+    } else {
+        base.with_extension("toml")
+    }
+}
+
+/// Load a fixture from a PKL or TOML file.
+fn load_fixture(path: &Path) -> Result<Fixture, Box<dyn std::error::Error>> {
+    if path.extension().and_then(|ext| ext.to_str()) == Some("pkl") {
+        return load_pkl_fixture(path);
+    }
+
     let content = std::fs::read_to_string(path)?;
     let fixture: Fixture = toml::from_str(&content)?;
     Ok(fixture)
+}
+
+/// Evaluate a PKL fixture with a project-local `pkl` binary when available.
+///
+/// Cargo test does not automatically put `node_modules/.bin` on PATH, so the
+/// loader checks ancestor directories before falling back to the user's PATH.
+fn load_pkl_fixture(path: &Path) -> Result<Fixture, Box<dyn std::error::Error>> {
+    let command = pkl_command(path);
+    let command = command.to_string_lossy();
+    let mut manager = EvaluatorManager::with_command(command.as_ref())?;
+    let options = pkl_evaluator_options(path);
+    let evaluator = manager.new_evaluator(options)?;
+    let result = manager.evaluate_module_typed::<Fixture>(&evaluator, ModuleSource::file(path));
+    let _ = manager.close_evaluator(&evaluator);
+    Ok(result?)
+}
+
+fn pkl_evaluator_options(path: &Path) -> EvaluatorOptions {
+    let Some(root_dir) = path.parent() else {
+        return EvaluatorOptions::preconfigured();
+    };
+
+    let root_dir = root_dir.to_string_lossy();
+    EvaluatorOptions::preconfigured().root_dir(root_dir.as_ref())
+}
+
+fn pkl_command(path: &Path) -> PathBuf {
+    for ancestor in path.ancestors() {
+        for candidate in [
+            ancestor.join("node_modules/.bin/pkl"),
+            ancestor.join("node_modules/@pkl-community/pkl/pkl"),
+        ] {
+            if candidate.exists() {
+                return candidate;
+            }
+        }
+    }
+
+    PathBuf::from("pkl")
 }
 
 /// Normalize a test case name to a valid snapshot file name
@@ -131,140 +191,57 @@ fn compile_sfc_js(input: &str) -> String {
     }
 }
 
-#[test]
-fn test_script_setup_ts_snapshots() {
-    let snapshot_path = snapshots_path().join("sfc").join("ts");
+fn assert_sfc_snapshots(fixture_name: &str, snapshot_kind: &str, prefix: &str) {
+    let snapshot_path = snapshots_path().join("sfc").join(snapshot_kind);
     std::fs::create_dir_all(&snapshot_path).ok();
 
-    let fixture_path = fixtures_path().join("sfc").join("script-setup.toml");
+    let fixture_path = fixture_file(fixture_name);
     let fixture = load_fixture(&fixture_path).expect("Failed to load fixture");
 
     for case in &fixture.cases {
         let normalized_name = normalize_name(&case.name);
-        let ts_output = compile_sfc_ts(&case.input);
+        let output = match snapshot_kind {
+            "js" => compile_sfc_js(&case.input),
+            _ => compile_sfc_ts(&case.input),
+        };
 
         insta::with_settings!({
             snapshot_path => &snapshot_path,
             prepend_module_to_snapshot => false,
             snapshot_suffix => "",
         }, {
-            let snapshot_name = build_snapshot_name("script_setup__", &normalized_name);
-            insta::assert_snapshot!(snapshot_name.as_str(), ts_output.as_str());
+            let snapshot_name = build_snapshot_name(prefix, &normalized_name);
+            insta::assert_snapshot!(snapshot_name.as_str(), output.as_str());
         });
     }
+}
+
+#[test]
+fn test_script_setup_ts_snapshots() {
+    assert_sfc_snapshots("script-setup", "ts", "script_setup__");
 }
 
 #[test]
 fn test_basic_sfc_ts_snapshots() {
-    let snapshot_path = snapshots_path().join("sfc").join("ts");
-    std::fs::create_dir_all(&snapshot_path).ok();
-
-    let fixture_path = fixtures_path().join("sfc").join("basic.toml");
-    let fixture = load_fixture(&fixture_path).expect("Failed to load fixture");
-
-    for case in &fixture.cases {
-        let normalized_name = normalize_name(&case.name);
-        let ts_output = compile_sfc_ts(&case.input);
-
-        insta::with_settings!({
-            snapshot_path => &snapshot_path,
-            prepend_module_to_snapshot => false,
-            snapshot_suffix => "",
-        }, {
-            let snapshot_name = build_snapshot_name("basic__", &normalized_name);
-            insta::assert_snapshot!(snapshot_name.as_str(), ts_output.as_str());
-        });
-    }
+    assert_sfc_snapshots("basic", "ts", "basic__");
 }
 
 #[test]
 fn test_patches_ts_snapshots() {
-    let snapshot_path = snapshots_path().join("sfc").join("ts");
-    std::fs::create_dir_all(&snapshot_path).ok();
-
-    let fixture_path = fixtures_path().join("sfc").join("patches.toml");
-    let fixture = load_fixture(&fixture_path).expect("Failed to load fixture");
-
-    for case in &fixture.cases {
-        let normalized_name = normalize_name(&case.name);
-        let ts_output = compile_sfc_ts(&case.input);
-
-        insta::with_settings!({
-            snapshot_path => &snapshot_path,
-            prepend_module_to_snapshot => false,
-            snapshot_suffix => "",
-        }, {
-            let snapshot_name = build_snapshot_name("patches__", &normalized_name);
-            insta::assert_snapshot!(snapshot_name.as_str(), ts_output.as_str());
-        });
-    }
+    assert_sfc_snapshots("patches", "ts", "patches__");
 }
 
 #[test]
 fn test_patches_js_snapshots() {
-    let snapshot_path = snapshots_path().join("sfc").join("js");
-    std::fs::create_dir_all(&snapshot_path).ok();
-
-    let fixture_path = fixtures_path().join("sfc").join("patches.toml");
-    let fixture = load_fixture(&fixture_path).expect("Failed to load patches fixture");
-
-    for case in &fixture.cases {
-        let normalized_name = normalize_name(&case.name);
-        let js_output = compile_sfc_js(&case.input);
-
-        insta::with_settings!({
-            snapshot_path => &snapshot_path,
-            prepend_module_to_snapshot => false,
-            snapshot_suffix => "",
-        }, {
-            let snapshot_name = build_snapshot_name("patches__", &normalized_name);
-            insta::assert_snapshot!(snapshot_name.as_str(), js_output.as_str());
-        });
-    }
+    assert_sfc_snapshots("patches", "js", "patches__");
 }
 
 #[test]
 fn test_directives_ts_snapshots() {
-    let snapshot_path = snapshots_path().join("sfc").join("ts");
-    std::fs::create_dir_all(&snapshot_path).ok();
-
-    let fixture_path = fixtures_path().join("sfc").join("directives.toml");
-    let fixture = load_fixture(&fixture_path).expect("Failed to load directives fixture");
-
-    for case in &fixture.cases {
-        let normalized_name = normalize_name(&case.name);
-        let ts_output = compile_sfc_ts(&case.input);
-
-        insta::with_settings!({
-            snapshot_path => &snapshot_path,
-            prepend_module_to_snapshot => false,
-            snapshot_suffix => "",
-        }, {
-            let snapshot_name = build_snapshot_name("directives__", &normalized_name);
-            insta::assert_snapshot!(snapshot_name.as_str(), ts_output.as_str());
-        });
-    }
+    assert_sfc_snapshots("directives", "ts", "directives__");
 }
 
 #[test]
 fn test_directives_js_snapshots() {
-    let snapshot_path = snapshots_path().join("sfc").join("js");
-    std::fs::create_dir_all(&snapshot_path).ok();
-
-    let fixture_path = fixtures_path().join("sfc").join("directives.toml");
-    let fixture = load_fixture(&fixture_path).expect("Failed to load directives fixture");
-
-    for case in &fixture.cases {
-        let normalized_name = normalize_name(&case.name);
-        let js_output = compile_sfc_js(&case.input);
-
-        insta::with_settings!({
-            snapshot_path => &snapshot_path,
-            prepend_module_to_snapshot => false,
-            snapshot_suffix => "",
-        }, {
-            let snapshot_name = build_snapshot_name("directives__", &normalized_name);
-            insta::assert_snapshot!(snapshot_name.as_str(), js_output.as_str());
-        });
-    }
+    assert_sfc_snapshots("directives", "js", "directives__");
 }

--- a/crates/vize_carton/src/config.rs
+++ b/crates/vize_carton/src/config.rs
@@ -2,6 +2,7 @@
 
 mod loader;
 mod model;
+mod normalize;
 
 pub use loader::{
     LoadedConfig, LoadedConfigWithFeatures, load_config,
@@ -14,3 +15,4 @@ pub use model::{
     GlobalTypeDeclaration, GlobalTypesConfig, LanguageServerConfig, LintRuleSeverity, LinterConfig,
     LspConfig, QuoteProps, TrailingComma, TypeCheckerConfig, VizeConfig,
 };
+pub use normalize::normalize_public_config_value;

--- a/crates/vize_carton/src/config/loader.rs
+++ b/crates/vize_carton/src/config/loader.rs
@@ -1,12 +1,21 @@
 //! Config loading helpers.
+//!
+//! This module owns discovery and high-level loading while the format-specific
+//! readers live in sibling modules. The split keeps the public contract visible
+//! here and avoids letting JavaScript, PKL, and path-search details crowd the
+//! main flow.
 
-use std::{
-    io::{Error as IoError, ErrorKind},
-    path::{Path, PathBuf},
-    process::Command,
-};
+mod discovery;
+mod js;
+mod parse;
+mod pkl;
+#[cfg(test)]
+mod tests;
 
-use pklrust::{Error as PklError, EvaluatorManager, EvaluatorOptions, ModuleSource};
+use std::path::{Path, PathBuf};
+
+use discovery::{resolve_dir_path, resolve_file_path};
+use parse::{parse_raw_config_file, try_parse_raw_candidate};
 
 use super::model::{ConfigFeatureFlags, LinterConfig, RawVizeConfig, VizeConfig};
 
@@ -177,7 +186,7 @@ fn load_raw_config_with_source(path: Option<&Path>) -> LoadedRawConfig {
             continue;
         }
 
-        if let Some(config) = try_parse_candidate(&candidate) {
+        if let Some(config) = try_parse_raw_candidate(&candidate) {
             return LoadedRawConfig {
                 config,
                 source_path: Some(candidate),
@@ -188,295 +197,5 @@ fn load_raw_config_with_source(path: Option<&Path>) -> LoadedRawConfig {
     LoadedRawConfig {
         config: RawVizeConfig::default(),
         source_path: None,
-    }
-}
-
-fn resolve_file_path(base: &Path) -> Option<PathBuf> {
-    if base.is_file() {
-        Some(base.to_path_buf())
-    } else {
-        None
-    }
-}
-
-fn resolve_dir_path(base: &Path) -> Option<PathBuf> {
-    if base.is_dir() {
-        return Some(base.to_path_buf());
-    }
-
-    if base.extension().is_none() {
-        return Some(base.to_path_buf());
-    }
-
-    None
-}
-
-fn try_parse_candidate(path: &Path) -> Option<RawVizeConfig> {
-    try_parse_raw_candidate(path)
-}
-
-fn try_parse_raw_candidate(path: &Path) -> Option<RawVizeConfig> {
-    match parse_raw_config_file(path) {
-        Ok(config) => Some(config),
-        Err(error) => {
-            let should_try_next = should_try_next_config(path, error.as_ref());
-            eprintln!(
-                "\x1b[33mWarning:\x1b[0m Failed to parse {}: {}",
-                path.display(),
-                error
-            );
-            if should_try_next {
-                None
-            } else {
-                Some(RawVizeConfig::default())
-            }
-        }
-    }
-}
-
-fn should_try_next_config(path: &Path, error: &(dyn std::error::Error + 'static)) -> bool {
-    if path.extension().and_then(|ext| ext.to_str()) != Some("pkl") {
-        return true;
-    }
-
-    error
-        .downcast_ref::<PklError>()
-        .is_some_and(is_process_error)
-}
-
-fn parse_raw_config_file(path: &Path) -> Result<RawVizeConfig, Box<dyn std::error::Error>> {
-    let config = match path.extension().and_then(|ext| ext.to_str()) {
-        Some("pkl") => parse_pkl_config(path)?,
-        Some("ts" | "js" | "mjs") => parse_js_config(path)?,
-        Some("json") => {
-            let content = std::fs::read_to_string(path)?;
-            serde_json::from_str::<RawVizeConfig>(&content)?
-        }
-        _ => return Ok(RawVizeConfig::default()),
-    };
-
-    Ok(config)
-}
-
-fn parse_js_config(path: &Path) -> Result<RawVizeConfig, Box<dyn std::error::Error>> {
-    let script = r#"
-import { pathToFileURL } from "node:url";
-
-const configPath = process.argv[1];
-const module = await import(pathToFileURL(configPath).href);
-const exported = module.default ?? module;
-const config = typeof exported === "function"
-  ? await exported({ mode: "development", command: "serve" })
-  : exported;
-process.stdout.write(JSON.stringify(config ?? {}));
-"#;
-    let output = Command::new("node")
-        .arg("--input-type=module")
-        .arg("-e")
-        .arg(script)
-        .arg(path)
-        .current_dir(path.parent().unwrap_or_else(|| Path::new(".")))
-        .output()?;
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(Box::new(IoError::new(
-            ErrorKind::InvalidData,
-            crate::cstr!("node failed to load config: {}", stderr.trim()).to_string(),
-        )));
-    }
-
-    Ok(serde_json::from_slice::<RawVizeConfig>(&output.stdout)?)
-}
-
-fn parse_pkl_config(path: &Path) -> Result<RawVizeConfig, Box<dyn std::error::Error>> {
-    let mut last_process_error = None;
-
-    for command in pkl_command_candidates(path) {
-        match parse_pkl_config_with_command(path, &command) {
-            Ok(config) => return Ok(config),
-            Err(error) if is_process_error(&error) => {
-                last_process_error = Some(error);
-            }
-            Err(error) => return Err(Box::new(error)),
-        }
-    }
-
-    Err(last_process_error
-        .map(|error| Box::new(error) as Box<dyn std::error::Error>)
-        .unwrap_or_else(|| {
-            Box::new(std::io::Error::new(
-                std::io::ErrorKind::NotFound,
-                "failed to locate a usable pkl command",
-            ))
-        }))
-}
-
-fn parse_pkl_config_with_command(path: &Path, command: &Path) -> Result<RawVizeConfig, PklError> {
-    let command = command.to_string_lossy();
-    let mut manager = EvaluatorManager::with_command(command.as_ref())?;
-    let options = pkl_evaluator_options(path);
-    let evaluator = manager.new_evaluator(options)?;
-    let result =
-        manager.evaluate_module_typed::<RawVizeConfig>(&evaluator, ModuleSource::file(path));
-    let _ = manager.close_evaluator(&evaluator);
-
-    result
-}
-
-fn pkl_evaluator_options(path: &Path) -> EvaluatorOptions {
-    let Some(root_dir) = path.parent() else {
-        return EvaluatorOptions::preconfigured();
-    };
-
-    let root_dir = root_dir.to_string_lossy();
-    EvaluatorOptions::preconfigured().root_dir(root_dir.as_ref())
-}
-
-fn is_process_error(error: &PklError) -> bool {
-    matches!(error, PklError::Io(_) | PklError::Process(_))
-}
-
-fn pkl_command_candidates(path: &Path) -> Vec<PathBuf> {
-    let mut commands = Vec::with_capacity(9);
-
-    push_pkl_command_candidates(&mut commands, path);
-
-    if let Ok(current_dir) = std::env::current_dir() {
-        push_pkl_command_candidates(&mut commands, &current_dir);
-    }
-
-    commands.push(PathBuf::from("pkl"));
-    commands
-}
-
-fn push_pkl_command_candidates(commands: &mut Vec<PathBuf>, path: &Path) {
-    let search_root = if path.is_dir() {
-        path
-    } else {
-        path.parent().unwrap_or(path)
-    };
-
-    for ancestor in search_root.ancestors() {
-        for binary in local_pkl_candidates(ancestor) {
-            if binary.exists() && !commands.iter().any(|command| command == &binary) {
-                commands.push(binary);
-            }
-        }
-    }
-}
-
-fn local_pkl_candidates(base: &Path) -> [PathBuf; 6] {
-    [
-        base.join("node_modules/.bin/pkl"),
-        base.join("node_modules/.bin/pkl.cmd"),
-        base.join("node_modules/.pnpm/node_modules/.bin/pkl"),
-        base.join("node_modules/.pnpm/node_modules/.bin/pkl.cmd"),
-        base.join("node_modules/@pkl-community/pkl/pkl"),
-        base.join("node_modules/@pkl-community/pkl/pkl.exe"),
-    ]
-}
-#[cfg(test)]
-mod tests {
-    use super::{
-        load_config_and_linter_with_source, load_config_with_source, load_linter_config,
-        validate_explicit_config_path,
-    };
-
-    #[test]
-    fn validate_explicit_config_path_missing_errors() {
-        let dir = tempfile::tempdir().unwrap();
-        let missing = dir.path().join("does-not-exist.toml");
-
-        let result = validate_explicit_config_path(&missing);
-        assert!(result.is_err());
-        assert!(result.unwrap_err().contains("config file not found"));
-    }
-
-    #[test]
-    fn validate_explicit_config_path_malformed_errors() {
-        let dir = tempfile::tempdir().unwrap();
-        let config_path = dir.path().join("vize.config.json");
-        std::fs::write(&config_path, "this is { not valid json ===").unwrap();
-
-        let result = validate_explicit_config_path(&config_path);
-        assert!(result.is_err());
-        assert!(result.unwrap_err().contains("failed to parse"));
-    }
-
-    #[test]
-    fn validate_explicit_config_path_valid_ok() {
-        let dir = tempfile::tempdir().unwrap();
-        let config_path = dir.path().join("vize.config.json");
-        std::fs::write(&config_path, r#"{ "formatter": { "singleQuote": true } }"#).unwrap();
-
-        assert!(validate_explicit_config_path(&config_path).is_ok());
-    }
-
-    #[test]
-    fn validate_explicit_config_path_dir_with_config_ok() {
-        let dir = tempfile::tempdir().unwrap();
-        std::fs::write(
-            dir.path().join("vize.config.json"),
-            r#"{ "formatter": {} }"#,
-        )
-        .unwrap();
-
-        assert!(validate_explicit_config_path(dir.path()).is_ok());
-    }
-
-    #[test]
-    fn validate_explicit_config_path_empty_dir_errors() {
-        let dir = tempfile::tempdir().unwrap();
-        let result = validate_explicit_config_path(dir.path());
-        assert!(result.is_err());
-        assert!(result.unwrap_err().contains("no vize config file found"));
-    }
-
-    #[test]
-    fn load_config_uses_explicit_file_path() {
-        let dir = tempfile::tempdir().unwrap();
-        let config_path = dir.path().join("custom.json");
-        std::fs::write(&config_path, r#"{ "formatter": { "singleQuote": true } }"#).unwrap();
-
-        let loaded = load_config_with_source(Some(&config_path));
-        assert_eq!(loaded.source_path.as_deref(), Some(config_path.as_path()));
-        assert!(loaded.config.formatter.single_quote);
-    }
-
-    #[test]
-    fn load_config_uses_typescript_config() {
-        let dir = tempfile::tempdir().unwrap();
-        let config_path = dir.path().join("vize.config.ts");
-        std::fs::write(
-            &config_path,
-            r#"
-export default {
-  linter: {
-    rules: {
-      "vue/prop-name-casing": "off",
-      "script/no-options-api": "error",
-    },
-  },
-}
-"#,
-        )
-        .unwrap();
-
-        let (loaded, linter_from_loaded_config) =
-            load_config_and_linter_with_source(Some(dir.path()));
-        let linter = load_linter_config(Some(dir.path()));
-
-        assert_eq!(loaded.source_path.as_deref(), Some(config_path.as_path()));
-        assert_eq!(
-            linter_from_loaded_config.disabled_rules(),
-            ["vue/prop-name-casing"]
-        );
-        assert_eq!(
-            linter_from_loaded_config.enabled_rules(),
-            ["script/no-options-api"]
-        );
-        assert_eq!(linter.disabled_rules(), ["vue/prop-name-casing"]);
-        assert_eq!(linter.enabled_rules(), ["script/no-options-api"]);
     }
 }

--- a/crates/vize_carton/src/config/loader/discovery.rs
+++ b/crates/vize_carton/src/config/loader/discovery.rs
@@ -1,0 +1,33 @@
+//! Config path discovery helpers.
+//!
+//! Loading accepts either a direct file path or a root-like directory path. The
+//! checks here stay intentionally shallow; config precedence and parse fallback
+//! are handled by the parent loader.
+
+use std::path::{Path, PathBuf};
+
+/// Return a direct config file path when the user supplied a file.
+pub(super) fn resolve_file_path(base: &Path) -> Option<PathBuf> {
+    if base.is_file() {
+        Some(base.to_path_buf())
+    } else {
+        None
+    }
+}
+
+/// Return a directory root for config auto-discovery.
+///
+/// Nonexistent extensionless paths are treated as directory roots so callers can
+/// ask for a project location before it has been created. Paths with an
+/// extension are assumed to be explicit files and are not searched as dirs.
+pub(super) fn resolve_dir_path(base: &Path) -> Option<PathBuf> {
+    if base.is_dir() {
+        return Some(base.to_path_buf());
+    }
+
+    if base.extension().is_none() {
+        return Some(base.to_path_buf());
+    }
+
+    None
+}

--- a/crates/vize_carton/src/config/loader/js.rs
+++ b/crates/vize_carton/src/config/loader/js.rs
@@ -1,0 +1,46 @@
+//! JavaScript and TypeScript config evaluation.
+//!
+//! Native CLI commands still need to support `vize.config.ts` / `.mjs`. Rather
+//! than embed a JS runtime, the loader shells out to the local Node runtime,
+//! imports the config as ESM, calls function exports with the default env, and
+//! returns JSON for Rust deserialization.
+
+use std::{
+    io::{Error as IoError, ErrorKind},
+    path::Path,
+    process::Command,
+};
+
+use crate::config::model::RawVizeConfig;
+
+/// Evaluate a JS-like config file through Node and deserialize the result.
+pub(super) fn parse_js_config(path: &Path) -> Result<RawVizeConfig, Box<dyn std::error::Error>> {
+    let script = r#"
+import { pathToFileURL } from "node:url";
+
+const configPath = process.argv[1];
+const module = await import(pathToFileURL(configPath).href);
+const exported = module.default ?? module;
+const config = typeof exported === "function"
+  ? await exported({ mode: "development", command: "serve" })
+  : exported;
+process.stdout.write(JSON.stringify(config ?? {}));
+"#;
+    let output = Command::new("node")
+        .arg("--input-type=module")
+        .arg("-e")
+        .arg(script)
+        .arg(path)
+        .current_dir(path.parent().unwrap_or_else(|| Path::new(".")))
+        .output()?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(Box::new(IoError::new(
+            ErrorKind::InvalidData,
+            crate::cstr!("node failed to load config: {}", stderr.trim()).to_string(),
+        )));
+    }
+
+    Ok(serde_json::from_slice::<RawVizeConfig>(&output.stdout)?)
+}

--- a/crates/vize_carton/src/config/loader/parse.rs
+++ b/crates/vize_carton/src/config/loader/parse.rs
@@ -1,0 +1,57 @@
+//! Config format dispatch.
+//!
+//! Discovery feeds candidate paths into this module. It picks the concrete
+//! reader from the file extension and implements the fallback rule used during
+//! auto-discovery: malformed configs warn, while an unavailable PKL runtime can
+//! continue to the next lower-priority config format.
+
+use std::path::Path;
+
+use crate::config::model::RawVizeConfig;
+
+use super::{js::parse_js_config, pkl};
+
+/// Parse a single config file path without discovery fallback.
+pub(super) fn parse_raw_config_file(
+    path: &Path,
+) -> Result<RawVizeConfig, Box<dyn std::error::Error>> {
+    let config = match path.extension().and_then(|ext| ext.to_str()) {
+        Some("pkl") => pkl::parse_pkl_config(path)?,
+        Some("ts" | "js" | "mjs") => parse_js_config(path)?,
+        Some("json") => {
+            let content = std::fs::read_to_string(path)?;
+            serde_json::from_str::<RawVizeConfig>(&content)?
+        }
+        _ => return Ok(RawVizeConfig::default()),
+    };
+
+    Ok(config)
+}
+
+/// Parse a discovered candidate and map recoverable failures to `None`.
+pub(super) fn try_parse_raw_candidate(path: &Path) -> Option<RawVizeConfig> {
+    match parse_raw_config_file(path) {
+        Ok(config) => Some(config),
+        Err(error) => {
+            let should_try_next = should_try_next_config(path, error.as_ref());
+            eprintln!(
+                "\x1b[33mWarning:\x1b[0m Failed to parse {}: {}",
+                path.display(),
+                error
+            );
+            if should_try_next {
+                None
+            } else {
+                Some(RawVizeConfig::default())
+            }
+        }
+    }
+}
+
+fn should_try_next_config(path: &Path, error: &(dyn std::error::Error + 'static)) -> bool {
+    if path.extension().and_then(|ext| ext.to_str()) != Some("pkl") {
+        return true;
+    }
+
+    pkl::is_process_error_box(error)
+}

--- a/crates/vize_carton/src/config/loader/pkl.rs
+++ b/crates/vize_carton/src/config/loader/pkl.rs
@@ -1,0 +1,108 @@
+//! PKL config evaluation.
+//!
+//! PKL support prefers project-local binaries so workspaces get reproducible
+//! evaluation without requiring a globally installed `pkl`. Process startup
+//! failures are reported separately from module evaluation failures because only
+//! the former should let config discovery fall through to lower-priority files.
+
+use std::path::{Path, PathBuf};
+
+use pklrust::{Error as PklError, EvaluatorManager, EvaluatorOptions, ModuleSource};
+
+use crate::config::model::RawVizeConfig;
+
+/// Evaluate a PKL config and deserialize it into the raw config model.
+pub(super) fn parse_pkl_config(path: &Path) -> Result<RawVizeConfig, Box<dyn std::error::Error>> {
+    let mut last_process_error = None;
+
+    for command in pkl_command_candidates(path) {
+        match parse_pkl_config_with_command(path, &command) {
+            Ok(config) => return Ok(config),
+            Err(error) if is_process_error(&error) => {
+                last_process_error = Some(error);
+            }
+            Err(error) => return Err(Box::new(error)),
+        }
+    }
+
+    Err(last_process_error
+        .map(|error| Box::new(error) as Box<dyn std::error::Error>)
+        .unwrap_or_else(|| {
+            Box::new(std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                "failed to locate a usable pkl command",
+            ))
+        }))
+}
+
+/// Return true when a boxed parse error came from PKL process startup.
+pub(super) fn is_process_error_box(error: &(dyn std::error::Error + 'static)) -> bool {
+    error
+        .downcast_ref::<PklError>()
+        .is_some_and(is_process_error)
+}
+
+fn parse_pkl_config_with_command(path: &Path, command: &Path) -> Result<RawVizeConfig, PklError> {
+    let command = command.to_string_lossy();
+    let mut manager = EvaluatorManager::with_command(command.as_ref())?;
+    let options = pkl_evaluator_options(path);
+    let evaluator = manager.new_evaluator(options)?;
+    let result =
+        manager.evaluate_module_typed::<RawVizeConfig>(&evaluator, ModuleSource::file(path));
+    let _ = manager.close_evaluator(&evaluator);
+
+    result
+}
+
+fn pkl_evaluator_options(path: &Path) -> EvaluatorOptions {
+    let Some(root_dir) = path.parent() else {
+        return EvaluatorOptions::preconfigured();
+    };
+
+    let root_dir = root_dir.to_string_lossy();
+    EvaluatorOptions::preconfigured().root_dir(root_dir.as_ref())
+}
+
+fn is_process_error(error: &PklError) -> bool {
+    matches!(error, PklError::Io(_) | PklError::Process(_))
+}
+
+fn pkl_command_candidates(path: &Path) -> Vec<PathBuf> {
+    let mut commands = Vec::with_capacity(9);
+
+    push_pkl_command_candidates(&mut commands, path);
+
+    if let Ok(current_dir) = std::env::current_dir() {
+        push_pkl_command_candidates(&mut commands, &current_dir);
+    }
+
+    commands.push(PathBuf::from("pkl"));
+    commands
+}
+
+fn push_pkl_command_candidates(commands: &mut Vec<PathBuf>, path: &Path) {
+    let search_root = if path.is_dir() {
+        path
+    } else {
+        path.parent().unwrap_or(path)
+    };
+
+    for ancestor in search_root.ancestors() {
+        for binary in local_pkl_candidates(ancestor) {
+            if binary.exists() && !commands.iter().any(|command| command == &binary) {
+                commands.push(binary);
+            }
+        }
+    }
+}
+
+fn local_pkl_candidates(base: &Path) -> [PathBuf; 6] {
+    [
+        base.join("node_modules/.bin/pkl"),
+        base.join("node_modules/.bin/pkl.cmd"),
+        base.join("node_modules/.pnpm/node_modules/.bin/pkl"),
+        base.join("node_modules/.pnpm/node_modules/.bin/pkl.cmd"),
+        base.join("node_modules/@pkl-community/pkl/pkl"),
+        base.join("node_modules/@pkl-community/pkl/pkl.exe"),
+    ]
+}

--- a/crates/vize_carton/src/config/loader/tests.rs
+++ b/crates/vize_carton/src/config/loader/tests.rs
@@ -1,0 +1,100 @@
+use super::{
+    load_config_and_linter_with_source, load_config_with_source, load_linter_config,
+    validate_explicit_config_path,
+};
+
+#[test]
+fn validate_explicit_config_path_missing_errors() {
+    let dir = tempfile::tempdir().unwrap();
+    let missing = dir.path().join("does-not-exist.toml");
+
+    let result = validate_explicit_config_path(&missing);
+    assert!(result.is_err());
+    assert!(result.unwrap_err().contains("config file not found"));
+}
+
+#[test]
+fn validate_explicit_config_path_malformed_errors() {
+    let dir = tempfile::tempdir().unwrap();
+    let config_path = dir.path().join("vize.config.json");
+    std::fs::write(&config_path, "this is { not valid json ===").unwrap();
+
+    let result = validate_explicit_config_path(&config_path);
+    assert!(result.is_err());
+    assert!(result.unwrap_err().contains("failed to parse"));
+}
+
+#[test]
+fn validate_explicit_config_path_valid_ok() {
+    let dir = tempfile::tempdir().unwrap();
+    let config_path = dir.path().join("vize.config.json");
+    std::fs::write(&config_path, r#"{ "formatter": { "singleQuote": true } }"#).unwrap();
+
+    assert!(validate_explicit_config_path(&config_path).is_ok());
+}
+
+#[test]
+fn validate_explicit_config_path_dir_with_config_ok() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(
+        dir.path().join("vize.config.json"),
+        r#"{ "formatter": {} }"#,
+    )
+    .unwrap();
+
+    assert!(validate_explicit_config_path(dir.path()).is_ok());
+}
+
+#[test]
+fn validate_explicit_config_path_empty_dir_errors() {
+    let dir = tempfile::tempdir().unwrap();
+    let result = validate_explicit_config_path(dir.path());
+    assert!(result.is_err());
+    assert!(result.unwrap_err().contains("no vize config file found"));
+}
+
+#[test]
+fn load_config_uses_explicit_file_path() {
+    let dir = tempfile::tempdir().unwrap();
+    let config_path = dir.path().join("custom.json");
+    std::fs::write(&config_path, r#"{ "formatter": { "singleQuote": true } }"#).unwrap();
+
+    let loaded = load_config_with_source(Some(&config_path));
+    assert_eq!(loaded.source_path.as_deref(), Some(config_path.as_path()));
+    assert!(loaded.config.formatter.single_quote);
+}
+
+#[test]
+fn load_config_uses_typescript_config() {
+    let dir = tempfile::tempdir().unwrap();
+    let config_path = dir.path().join("vize.config.ts");
+    std::fs::write(
+        &config_path,
+        r#"
+export default {
+  linter: {
+    rules: {
+      "vue/prop-name-casing": "off",
+      "script/no-options-api": "error",
+    },
+  },
+}
+"#,
+    )
+    .unwrap();
+
+    let (loaded, linter_from_loaded_config) = load_config_and_linter_with_source(Some(dir.path()));
+    let linter = load_linter_config(Some(dir.path()));
+
+    assert_eq!(loaded.source_path.as_deref(), Some(config_path.as_path()));
+    assert_eq!(
+        linter_from_loaded_config.disabled_rules(),
+        ["vue/prop-name-casing"]
+    );
+    assert_eq!(
+        linter_from_loaded_config.enabled_rules(),
+        ["script/no-options-api"]
+    );
+    assert_eq!(linter.disabled_rules(), ["vue/prop-name-casing"]);
+    assert_eq!(linter.enabled_rules(), ["script/no-options-api"]);
+}

--- a/crates/vize_carton/src/config/normalize.rs
+++ b/crates/vize_carton/src/config/normalize.rs
@@ -1,0 +1,207 @@
+//! Public JavaScript-facing config normalization.
+//!
+//! The Rust CLI deserializes config into strongly typed structs, but the npm
+//! `vize/config` API intentionally behaves like a lightweight loader: unknown
+//! keys are preserved, `entries` can model monorepos, and legacy aliases are
+//! normalized without schema validation. This module keeps that public shape in
+//! Rust so JS callers do not need to reimplement the merge and alias rules.
+
+use serde_json::{Map, Value};
+
+/// Normalize a raw user config value into the public `ResolvedVizeConfig` shape.
+///
+/// The operation mirrors the historical TypeScript API:
+///
+/// - `null` values are removed recursively.
+/// - A top-level array becomes `entries`, with global entries merged into the
+///   resolved root object.
+/// - A top-level object with `entries` becomes one root entry plus explicit
+///   entries, unless the root entry is empty.
+/// - The legacy `lsp` key is rewritten to `languageServer`, while an explicit
+///   `languageServer` value wins when both are present.
+///
+/// The function deliberately does not validate against the generated schema.
+/// Config consumers may carry package-local keys through this API, so unknown
+/// object members are retained.
+pub fn normalize_public_config_value(value: Value) -> Result<Value, String> {
+    match strip_nullish(value) {
+        Some(Value::Array(entries)) => normalize_config_entries(entries),
+        Some(Value::Object(config)) => normalize_config_object(config),
+        Some(_) | None => normalize_config_object(Map::new()),
+    }
+}
+
+fn normalize_config_object(mut config: Map<String, Value>) -> Result<Value, String> {
+    normalize_config_aliases(&mut config);
+
+    let raw_entries = config.remove("entries");
+    let root_entry = config;
+    let mut entries = Vec::new();
+
+    if !root_entry.is_empty() {
+        entries.push(Value::Object(root_entry.clone()));
+    }
+
+    match raw_entries {
+        Some(Value::Array(raw_entries)) => {
+            for entry in raw_entries {
+                entries.push(normalize_entry(entry)?);
+            }
+        }
+        Some(Value::Null) | None => {}
+        Some(_) => return Err("config.entries must be an array when provided".into()),
+    }
+
+    let mut resolved = root_entry;
+    resolved.insert("entries".into(), Value::Array(entries));
+    Ok(Value::Object(resolved))
+}
+
+fn normalize_config_entries(raw_entries: Vec<Value>) -> Result<Value, String> {
+    let mut entries = Vec::with_capacity(raw_entries.len());
+    for entry in raw_entries {
+        entries.push(normalize_entry(entry)?);
+    }
+
+    let mut global_config = Map::new();
+    for entry in &entries {
+        if let Value::Object(entry) = entry
+            && is_global_config_entry(entry)
+        {
+            deep_merge(&mut global_config, strip_entry_metadata(entry));
+        }
+    }
+
+    global_config.insert("entries".into(), Value::Array(entries));
+    Ok(Value::Object(global_config))
+}
+
+fn normalize_entry(entry: Value) -> Result<Value, String> {
+    match entry {
+        Value::Object(mut entry) => {
+            normalize_config_aliases(&mut entry);
+            Ok(Value::Object(entry))
+        }
+        Value::Null => Ok(Value::Object(Map::new())),
+        _ => Err("config entries must be objects".into()),
+    }
+}
+
+fn normalize_config_aliases(config: &mut Map<String, Value>) {
+    let Some(lsp) = config.remove("lsp") else {
+        return;
+    };
+
+    if !config.contains_key("languageServer") {
+        config.insert("languageServer".into(), lsp);
+    }
+}
+
+fn strip_nullish(value: Value) -> Option<Value> {
+    match value {
+        Value::Null => None,
+        Value::Array(values) => Some(Value::Array(
+            values.into_iter().filter_map(strip_nullish).collect(),
+        )),
+        Value::Object(values) => {
+            let values = values
+                .into_iter()
+                .filter_map(|(key, value)| strip_nullish(value).map(|value| (key, value)))
+                .collect();
+            Some(Value::Object(values))
+        }
+        value => Some(value),
+    }
+}
+
+fn is_global_config_entry(entry: &Map<String, Value>) -> bool {
+    !entry.contains_key("basePath")
+        && !entry.contains_key("files")
+        && !entry.contains_key("ignores")
+}
+
+fn strip_entry_metadata(entry: &Map<String, Value>) -> Map<String, Value> {
+    entry
+        .iter()
+        .filter(|(key, _)| {
+            !matches!(
+                key.as_str(),
+                "name" | "basePath" | "files" | "ignores" | "extends"
+            )
+        })
+        .map(|(key, value)| (key.clone(), value.clone()))
+        .collect()
+}
+
+fn deep_merge(target: &mut Map<String, Value>, source: Map<String, Value>) {
+    for (key, value) in source {
+        match (target.get_mut(&key), value) {
+            (Some(Value::Object(target_object)), Value::Object(source_object)) => {
+                deep_merge(target_object, source_object);
+            }
+            (_, value) => {
+                target.insert(key, value);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::normalize_public_config_value;
+
+    #[test]
+    fn empty_object_produces_empty_entries() {
+        assert_eq!(
+            normalize_public_config_value(json!({})).unwrap(),
+            json!({ "entries": [] })
+        );
+    }
+
+    #[test]
+    fn nullish_values_are_removed_recursively() {
+        assert_eq!(
+            normalize_public_config_value(json!({
+                "formatter": { "printWidth": 5, "useTabs": null },
+                "linter": null
+            }))
+            .unwrap(),
+            json!({
+                "formatter": { "printWidth": 5 },
+                "entries": [{ "formatter": { "printWidth": 5 } }]
+            })
+        );
+    }
+
+    #[test]
+    fn lsp_alias_is_normalized() {
+        assert_eq!(
+            normalize_public_config_value(json!({ "lsp": { "enabled": true } })).unwrap(),
+            json!({
+                "languageServer": { "enabled": true },
+                "entries": [{ "languageServer": { "enabled": true } }]
+            })
+        );
+    }
+
+    #[test]
+    fn array_entries_merge_global_config_into_root() {
+        assert_eq!(
+            normalize_public_config_value(json!([
+                { "formatter": { "printWidth": 50 }, "linter": { "enabled": true } },
+                { "name": "scoped", "files": ["src/**"], "formatter": { "printWidth": 80 } }
+            ]))
+            .unwrap(),
+            json!({
+                "formatter": { "printWidth": 50 },
+                "linter": { "enabled": true },
+                "entries": [
+                    { "formatter": { "printWidth": 50 }, "linter": { "enabled": true } },
+                    { "name": "scoped", "files": ["src/**"], "formatter": { "printWidth": 80 } }
+                ]
+            })
+        );
+    }
+}

--- a/crates/vize_vitrine/src/napi.rs
+++ b/crates/vize_vitrine/src/napi.rs
@@ -6,9 +6,11 @@
 //! - `art`: Art file parsing, CSF transform, docs, palette, and autogen
 //! - `format`: Vue SFC formatting
 //! - `lint`: Vue SFC linting
+//! - `config`: Public config normalization helpers
 
 mod art;
 mod cli;
+mod config;
 mod format;
 mod lint;
 mod plugin;
@@ -22,6 +24,7 @@ pub use napi_typecheck::*;
 
 pub use art::*;
 pub use cli::*;
+pub use config::*;
 pub use format::*;
 pub use lint::*;
 pub use plugin::*;

--- a/crates/vize_vitrine/src/napi/config.rs
+++ b/crates/vize_vitrine/src/napi/config.rs
@@ -1,0 +1,22 @@
+//! NAPI bindings for public config helpers.
+//!
+//! The npm package still owns dynamic module loading for `.ts` / `.mjs`
+//! configs because it must execute user JavaScript with the caller-provided
+//! environment. Once that raw value is available, normalization is pure shape
+//! work, so it is handled here in Rust and shared with native callers.
+
+mod js_value;
+
+use napi::bindgen_prelude::{Result, Unknown};
+use napi_derive::napi;
+
+/// Normalize a raw `vize.config.*` export into the public resolved shape.
+///
+/// The implementation works directly with NAPI values instead of serializing
+/// through JSON. That keeps JavaScript-only values such as `RegExp` filters
+/// intact while still moving the merge, null stripping, and legacy alias
+/// handling out of the TypeScript loader.
+#[napi(js_name = "normalizeVizeConfig")]
+pub fn normalize_vize_config(value: Unknown<'_>) -> Result<Unknown<'_>> {
+    js_value::normalize_vize_config(value)
+}

--- a/crates/vize_vitrine/src/napi/config/js_value.rs
+++ b/crates/vize_vitrine/src/napi/config/js_value.rs
@@ -1,0 +1,208 @@
+//! JavaScript-value preserving config normalization for the public NAPI API.
+//!
+//! Configs loaded from `.ts`, `.js`, and `.mjs` may contain values that cannot
+//! round-trip through JSON, most notably `RegExp` instances used by Vite-style
+//! include/exclude filters. The normalization below therefore copies only the
+//! public config container objects and arrays while preserving every nested
+//! non-plain JavaScript value by reference.
+
+mod raw;
+
+use napi::{
+    JsValue,
+    bindgen_prelude::{Result, Unknown, ValueType, sys},
+};
+
+use raw::*;
+
+const ENTRY_METADATA_KEYS: &[&str] = &["name", "basePath", "files", "ignores", "extends"];
+
+/// Normalize a raw JavaScript config export into the resolved public shape.
+pub fn normalize_vize_config(value: Unknown<'_>) -> Result<Unknown<'_>> {
+    match strip_nullish(value)? {
+        Some(value) if is_array(value)? => normalize_config_entries(value),
+        Some(value) if is_plain_object(value)? => normalize_config_object(value),
+        Some(value) => empty_config(value.value().env),
+        None => empty_config(value.value().env),
+    }
+}
+
+fn normalize_config_object(config: Unknown<'_>) -> Result<Unknown<'_>> {
+    let env = config.value().env;
+    let config = normalize_config_aliases(config)?;
+    let raw_entries = get_own_named_property(config, "entries")?;
+    let root_entry = copy_without_keys(config, &["entries"])?;
+    let entries = create_array(env, 0)?;
+    let mut entry_count = 0;
+
+    if !is_empty_object(root_entry)? {
+        set_element(entries, entry_count, root_entry)?;
+        entry_count += 1;
+    }
+
+    if let Some(raw_entries) = raw_entries {
+        if !is_array(raw_entries)? {
+            return Err(invalid_arg("config.entries must be an array when provided"));
+        }
+
+        for index in 0..array_len(raw_entries)? {
+            let entry = normalize_entry(get_element(raw_entries, index)?)?;
+            set_element(entries, entry_count, entry)?;
+            entry_count += 1;
+        }
+    }
+
+    let resolved = clone_object(root_entry)?;
+    set_named_property(resolved, "entries", entries)?;
+    Ok(resolved)
+}
+
+fn normalize_config_entries(raw_entries: Unknown<'_>) -> Result<Unknown<'_>> {
+    let env = raw_entries.value().env;
+    let global_config = create_object(env)?;
+    let entries = create_array(env, 0)?;
+    let mut entry_count = 0;
+
+    for index in 0..array_len(raw_entries)? {
+        let entry = normalize_entry(get_element(raw_entries, index)?)?;
+        if is_global_config_entry(entry)? {
+            deep_merge(global_config, strip_entry_metadata(entry)?)?;
+        }
+        set_element(entries, entry_count, entry)?;
+        entry_count += 1;
+    }
+
+    set_named_property(global_config, "entries", entries)?;
+    Ok(global_config)
+}
+
+fn normalize_entry(entry: Unknown<'_>) -> Result<Unknown<'_>> {
+    match strip_nullish(entry)? {
+        Some(entry) if is_plain_object(entry)? => normalize_config_aliases(entry),
+        Some(_) => Err(invalid_arg("config entries must be objects")),
+        None => create_object(entry.value().env),
+    }
+}
+
+fn normalize_config_aliases(config: Unknown<'_>) -> Result<Unknown<'_>> {
+    let env = config.value().env;
+    let output = create_object(env)?;
+    let mut lsp = None;
+    let mut has_language_server = false;
+
+    for (key, key_value) in enumerable_keys(config)? {
+        let value = get_property(config, key_value)?;
+        match key.as_str() {
+            "lsp" => lsp = Some(value),
+            "languageServer" => {
+                has_language_server = true;
+                set_property(output, key_value, value)?;
+            }
+            _ => set_property(output, key_value, value)?,
+        }
+    }
+
+    if let Some(lsp) = lsp
+        && !has_language_server
+    {
+        set_named_property(output, "languageServer", lsp)?;
+    }
+
+    Ok(output)
+}
+
+fn strip_nullish(value: Unknown<'_>) -> Result<Option<Unknown<'_>>> {
+    match value.get_type()? {
+        ValueType::Null | ValueType::Undefined => Ok(None),
+        ValueType::Object if is_array(value)? => strip_array(value).map(Some),
+        ValueType::Object if is_plain_object(value)? => strip_object(value).map(Some),
+        _ => Ok(Some(value)),
+    }
+}
+
+fn strip_array(value: Unknown<'_>) -> Result<Unknown<'_>> {
+    let env = value.value().env;
+    let output = create_array(env, 0)?;
+    let mut next_index = 0;
+
+    for index in 0..array_len(value)? {
+        if let Some(entry) = strip_nullish(get_element(value, index)?)? {
+            set_element(output, next_index, entry)?;
+            next_index += 1;
+        }
+    }
+
+    Ok(output)
+}
+
+fn strip_object(value: Unknown<'_>) -> Result<Unknown<'_>> {
+    let output = create_object(value.value().env)?;
+
+    for (_, key_value) in enumerable_keys(value)? {
+        if let Some(entry) = strip_nullish(get_property(value, key_value)?)? {
+            set_property(output, key_value, entry)?;
+        }
+    }
+
+    Ok(output)
+}
+
+fn deep_merge(target: Unknown<'_>, source: Unknown<'_>) -> Result<()> {
+    for (_, key_value) in enumerable_keys(source)? {
+        let value = get_property(source, key_value)?;
+        let current = get_property(target, key_value)?;
+        if is_plain_object(current)? && is_plain_object(value)? {
+            deep_merge(current, value)?;
+        } else {
+            set_property(target, key_value, value)?;
+        }
+    }
+    Ok(())
+}
+
+fn strip_entry_metadata(entry: Unknown<'_>) -> Result<Unknown<'_>> {
+    copy_without_keys(entry, ENTRY_METADATA_KEYS)
+}
+
+fn copy_without_keys<'js>(value: Unknown<'js>, ignored: &[&str]) -> Result<Unknown<'js>> {
+    let output = create_object(value.value().env)?;
+    for (key, key_value) in enumerable_keys(value)? {
+        if !ignored.contains(&key.as_str()) {
+            set_property(output, key_value, get_property(value, key_value)?)?;
+        }
+    }
+    Ok(output)
+}
+
+fn clone_object(value: Unknown<'_>) -> Result<Unknown<'_>> {
+    copy_without_keys(value, &[])
+}
+
+fn is_global_config_entry(entry: Unknown<'_>) -> Result<bool> {
+    Ok(!has_own_property(entry, "basePath")?
+        && !has_own_property(entry, "files")?
+        && !has_own_property(entry, "ignores")?)
+}
+
+fn is_empty_object(value: Unknown<'_>) -> Result<bool> {
+    Ok(enumerable_keys(value)?.is_empty())
+}
+
+fn is_plain_object(value: Unknown<'_>) -> Result<bool> {
+    if value.get_type()? != ValueType::Object || is_array(value)? {
+        return Ok(false);
+    }
+
+    let prototype = get_prototype(value)?;
+    if prototype.get_type()? == ValueType::Null {
+        return Ok(true);
+    }
+
+    strict_equals(prototype, object_prototype(value.value().env)?)
+}
+
+fn empty_config(env: sys::napi_env) -> Result<Unknown<'static>> {
+    let output = create_object(env)?;
+    set_named_property(output, "entries", create_array(env, 0)?)?;
+    Ok(output)
+}

--- a/crates/vize_vitrine/src/napi/config/js_value/raw.rs
+++ b/crates/vize_vitrine/src/napi/config/js_value/raw.rs
@@ -1,0 +1,153 @@
+//! Small NAPI helpers used by the config normalizer.
+//!
+//! Keeping the raw calls here lets the normalizer read like config logic while
+//! still avoiding a JSON conversion boundary. All helpers return `Unknown`
+//! handles that point at values owned by the active JavaScript environment.
+
+use std::ffi::CString;
+
+use napi::{
+    JsValue,
+    bindgen_prelude::{Error, FromNapiValue, Result, Unknown, check_status, sys},
+};
+
+pub(super) fn enumerable_keys(value: Unknown<'_>) -> Result<Vec<(String, sys::napi_value)>> {
+    let env = value.value().env;
+    let mut keys = std::ptr::null_mut();
+    check_status!(unsafe { sys::napi_get_property_names(env, value.raw(), &mut keys) })?;
+    let keys = unsafe { Unknown::from_raw_unchecked(env, keys) };
+    let mut result = Vec::with_capacity(array_len(keys)? as usize);
+
+    for index in 0..array_len(keys)? {
+        let key_value = get_element(keys, index)?.raw();
+        let key = unsafe { String::from_napi_value(env, key_value)? };
+        result.push((key, key_value));
+    }
+
+    Ok(result)
+}
+
+pub(super) fn create_object(env: sys::napi_env) -> Result<Unknown<'static>> {
+    let mut value = std::ptr::null_mut();
+    check_status!(unsafe { sys::napi_create_object(env, &mut value) })?;
+    Ok(unsafe { Unknown::from_raw_unchecked(env, value) })
+}
+
+pub(super) fn create_array(env: sys::napi_env, len: u32) -> Result<Unknown<'static>> {
+    let mut value = std::ptr::null_mut();
+    check_status!(unsafe { sys::napi_create_array_with_length(env, len as usize, &mut value) })?;
+    Ok(unsafe { Unknown::from_raw_unchecked(env, value) })
+}
+
+pub(super) fn array_len(value: Unknown<'_>) -> Result<u32> {
+    let mut len = 0;
+    check_status!(unsafe { sys::napi_get_array_length(value.value().env, value.raw(), &mut len) })?;
+    Ok(len)
+}
+
+pub(super) fn is_array(value: Unknown<'_>) -> Result<bool> {
+    let mut result = false;
+    check_status!(unsafe { sys::napi_is_array(value.value().env, value.raw(), &mut result) })?;
+    Ok(result)
+}
+
+pub(super) fn get_element(value: Unknown<'_>, index: u32) -> Result<Unknown<'_>> {
+    let env = value.value().env;
+    let mut result = std::ptr::null_mut();
+    check_status!(unsafe { sys::napi_get_element(env, value.raw(), index, &mut result) })?;
+    Ok(unsafe { Unknown::from_raw_unchecked(env, result) })
+}
+
+pub(super) fn set_element(array: Unknown<'_>, index: u32, value: Unknown<'_>) -> Result<()> {
+    check_status!(unsafe {
+        sys::napi_set_element(array.value().env, array.raw(), index, value.raw())
+    })
+}
+
+pub(super) fn get_property<'js>(
+    object: Unknown<'js>,
+    key: sys::napi_value,
+) -> Result<Unknown<'js>> {
+    let env = object.value().env;
+    let mut result = std::ptr::null_mut();
+    check_status!(unsafe { sys::napi_get_property(env, object.raw(), key, &mut result) })?;
+    Ok(unsafe { Unknown::from_raw_unchecked(env, result) })
+}
+
+pub(super) fn set_property(
+    object: Unknown<'_>,
+    key: sys::napi_value,
+    value: Unknown<'_>,
+) -> Result<()> {
+    check_status!(unsafe {
+        sys::napi_set_property(object.value().env, object.raw(), key, value.raw())
+    })
+}
+
+pub(super) fn get_own_named_property<'js>(
+    object: Unknown<'js>,
+    name: &str,
+) -> Result<Option<Unknown<'js>>> {
+    if !has_own_property(object, name)? {
+        return Ok(None);
+    }
+    Ok(Some(get_named_property(object, name)?))
+}
+
+pub(super) fn get_named_property<'js>(object: Unknown<'js>, name: &str) -> Result<Unknown<'js>> {
+    let env = object.value().env;
+    let name = CString::new(name)?;
+    let mut result = std::ptr::null_mut();
+    check_status!(unsafe {
+        sys::napi_get_named_property(env, object.raw(), name.as_ptr(), &mut result)
+    })?;
+    Ok(unsafe { Unknown::from_raw_unchecked(env, result) })
+}
+
+pub(super) fn set_named_property(
+    object: Unknown<'_>,
+    name: &str,
+    value: Unknown<'_>,
+) -> Result<()> {
+    let name = CString::new(name)?;
+    check_status!(unsafe {
+        sys::napi_set_named_property(object.value().env, object.raw(), name.as_ptr(), value.raw())
+    })
+}
+
+pub(super) fn has_own_property(object: Unknown<'_>, name: &str) -> Result<bool> {
+    let env = object.value().env;
+    let mut result = false;
+    let mut key = std::ptr::null_mut();
+    check_status!(unsafe {
+        sys::napi_create_string_utf8(env, name.as_ptr().cast(), name.len() as isize, &mut key)
+    })?;
+    check_status!(unsafe { sys::napi_has_own_property(env, object.raw(), key, &mut result) })?;
+    Ok(result)
+}
+
+pub(super) fn get_prototype(value: Unknown<'_>) -> Result<Unknown<'_>> {
+    let env = value.value().env;
+    let mut result = std::ptr::null_mut();
+    check_status!(unsafe { sys::napi_get_prototype(env, value.raw(), &mut result) })?;
+    Ok(unsafe { Unknown::from_raw_unchecked(env, result) })
+}
+
+pub(super) fn object_prototype(env: sys::napi_env) -> Result<Unknown<'static>> {
+    let mut global = std::ptr::null_mut();
+    check_status!(unsafe { sys::napi_get_global(env, &mut global) })?;
+    let global = unsafe { Unknown::from_raw_unchecked(env, global) };
+    get_named_property(get_named_property(global, "Object")?, "prototype")
+}
+
+pub(super) fn strict_equals(left: Unknown<'_>, right: Unknown<'_>) -> Result<bool> {
+    let mut result = false;
+    check_status!(unsafe {
+        sys::napi_strict_equals(left.value().env, left.raw(), right.raw(), &mut result)
+    })?;
+    Ok(result)
+}
+
+pub(super) fn invalid_arg(message: &str) -> Error {
+    Error::new(napi::Status::InvalidArg, message)
+}

--- a/npm/vize-native/index.d.ts
+++ b/npm/vize-native/index.d.ts
@@ -61,10 +61,14 @@ export interface AutogenOutputNapi {
 }
 
 export interface BatchCompileOptionsNapi {
+  mode?: string;
   ssr?: boolean;
   vapor?: boolean;
   customRenderer?: boolean;
   vueParserQuirks?: boolean;
+  runtimeModuleName?: string;
+  runtimeGlobalName?: string;
+  vueVersion?: string;
   /** Preserve TypeScript in output when true */
   isTs?: boolean;
   threads?: number;
@@ -205,6 +209,10 @@ export interface CompilerOptions {
   customRenderer?: boolean;
   /** Enable Vue parser quirk compatibility for known edge cases. */
   vueParserQuirks?: boolean;
+  /** Module name for runtime imports. */
+  runtimeModuleName?: string;
+  /** Global variable name for standalone/function mode. */
+  runtimeGlobalName?: string;
   /**
    * Script extension handling: "preserve" (keep TypeScript) or "downcompile" (transpile to JS)
    * Defaults to "downcompile"
@@ -576,6 +584,16 @@ export declare function normalizeViteResolvedVuePath(id: string): string | null;
 
 export declare function normalizeViteVirtualVueModuleId(id: string): string;
 
+/**
+ * Normalize a raw `vize.config.*` export into the public resolved shape.
+ *
+ * The implementation works directly with NAPI values instead of serializing
+ * through JSON. That keeps JavaScript-only values such as `RegExp` filters
+ * intact while still moving the merge, null stripping, and legacy alias
+ * handling out of the TypeScript loader.
+ */
+export declare function normalizeVizeConfig(value: unknown): unknown;
+
 /** Palette options for NAPI */
 export interface PaletteOptionsNapi {
   inferOptions?: boolean;
@@ -728,11 +746,15 @@ export interface SfcBlockAttributeNapi {
 
 export interface SfcCompileOptionsNapi {
   filename?: string;
+  mode?: string;
   sourceMap?: boolean;
   ssr?: boolean;
   vapor?: boolean;
   customRenderer?: boolean;
   vueParserQuirks?: boolean;
+  runtimeModuleName?: string;
+  runtimeGlobalName?: string;
+  vueVersion?: string;
   /** Preserve TypeScript in output when true */
   isTs?: boolean;
   /** Scope ID for scoped CSS (e.g., "data-v-abc123") */

--- a/npm/vize-native/index.js
+++ b/npm/vize-native/index.js
@@ -80,12 +80,12 @@ function requireNative() {
         const binding = require("@vizejs/native-android-arm64");
         const bindingPackageVersion = require("@vizejs/native-android-arm64/package.json").version;
         if (
-          bindingPackageVersion !== "0.165.0" &&
+          bindingPackageVersion !== "0.174.0" &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== "0"
         ) {
           throw new Error(
-            `Native binding package version mismatch, expected 0.165.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+            `Native binding package version mismatch, expected 0.174.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
           );
         }
         return binding;
@@ -103,12 +103,12 @@ function requireNative() {
         const bindingPackageVersion =
           require("@vizejs/native-android-arm-eabi/package.json").version;
         if (
-          bindingPackageVersion !== "0.165.0" &&
+          bindingPackageVersion !== "0.174.0" &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== "0"
         ) {
           throw new Error(
-            `Native binding package version mismatch, expected 0.165.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+            `Native binding package version mismatch, expected 0.174.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
           );
         }
         return binding;
@@ -134,12 +134,12 @@ function requireNative() {
           const bindingPackageVersion =
             require("@vizejs/native-win32-x64-gnu/package.json").version;
           if (
-            bindingPackageVersion !== "0.165.0" &&
+            bindingPackageVersion !== "0.174.0" &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== "0"
           ) {
             throw new Error(
-              `Native binding package version mismatch, expected 0.165.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+              `Native binding package version mismatch, expected 0.174.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
             );
           }
           return binding;
@@ -157,12 +157,12 @@ function requireNative() {
           const bindingPackageVersion =
             require("@vizejs/native-win32-x64-msvc/package.json").version;
           if (
-            bindingPackageVersion !== "0.165.0" &&
+            bindingPackageVersion !== "0.174.0" &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== "0"
           ) {
             throw new Error(
-              `Native binding package version mismatch, expected 0.165.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+              `Native binding package version mismatch, expected 0.174.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
             );
           }
           return binding;
@@ -181,12 +181,12 @@ function requireNative() {
         const bindingPackageVersion =
           require("@vizejs/native-win32-ia32-msvc/package.json").version;
         if (
-          bindingPackageVersion !== "0.165.0" &&
+          bindingPackageVersion !== "0.174.0" &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== "0"
         ) {
           throw new Error(
-            `Native binding package version mismatch, expected 0.165.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+            `Native binding package version mismatch, expected 0.174.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
           );
         }
         return binding;
@@ -204,12 +204,12 @@ function requireNative() {
         const bindingPackageVersion =
           require("@vizejs/native-win32-arm64-msvc/package.json").version;
         if (
-          bindingPackageVersion !== "0.165.0" &&
+          bindingPackageVersion !== "0.174.0" &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== "0"
         ) {
           throw new Error(
-            `Native binding package version mismatch, expected 0.165.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+            `Native binding package version mismatch, expected 0.174.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
           );
         }
         return binding;
@@ -229,12 +229,12 @@ function requireNative() {
       const binding = require("@vizejs/native-darwin-universal");
       const bindingPackageVersion = require("@vizejs/native-darwin-universal/package.json").version;
       if (
-        bindingPackageVersion !== "0.165.0" &&
+        bindingPackageVersion !== "0.174.0" &&
         process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
         process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== "0"
       ) {
         throw new Error(
-          `Native binding package version mismatch, expected 0.165.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+          `Native binding package version mismatch, expected 0.174.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
         );
       }
       return binding;
@@ -251,12 +251,12 @@ function requireNative() {
         const binding = require("@vizejs/native-darwin-x64");
         const bindingPackageVersion = require("@vizejs/native-darwin-x64/package.json").version;
         if (
-          bindingPackageVersion !== "0.165.0" &&
+          bindingPackageVersion !== "0.174.0" &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== "0"
         ) {
           throw new Error(
-            `Native binding package version mismatch, expected 0.165.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+            `Native binding package version mismatch, expected 0.174.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
           );
         }
         return binding;
@@ -273,12 +273,12 @@ function requireNative() {
         const binding = require("@vizejs/native-darwin-arm64");
         const bindingPackageVersion = require("@vizejs/native-darwin-arm64/package.json").version;
         if (
-          bindingPackageVersion !== "0.165.0" &&
+          bindingPackageVersion !== "0.174.0" &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== "0"
         ) {
           throw new Error(
-            `Native binding package version mismatch, expected 0.165.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+            `Native binding package version mismatch, expected 0.174.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
           );
         }
         return binding;
@@ -299,12 +299,12 @@ function requireNative() {
         const binding = require("@vizejs/native-freebsd-x64");
         const bindingPackageVersion = require("@vizejs/native-freebsd-x64/package.json").version;
         if (
-          bindingPackageVersion !== "0.165.0" &&
+          bindingPackageVersion !== "0.174.0" &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== "0"
         ) {
           throw new Error(
-            `Native binding package version mismatch, expected 0.165.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+            `Native binding package version mismatch, expected 0.174.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
           );
         }
         return binding;
@@ -321,12 +321,12 @@ function requireNative() {
         const binding = require("@vizejs/native-freebsd-arm64");
         const bindingPackageVersion = require("@vizejs/native-freebsd-arm64/package.json").version;
         if (
-          bindingPackageVersion !== "0.165.0" &&
+          bindingPackageVersion !== "0.174.0" &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== "0"
         ) {
           throw new Error(
-            `Native binding package version mismatch, expected 0.165.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+            `Native binding package version mismatch, expected 0.174.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
           );
         }
         return binding;
@@ -349,12 +349,12 @@ function requireNative() {
           const bindingPackageVersion =
             require("@vizejs/native-linux-x64-musl/package.json").version;
           if (
-            bindingPackageVersion !== "0.165.0" &&
+            bindingPackageVersion !== "0.174.0" &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== "0"
           ) {
             throw new Error(
-              `Native binding package version mismatch, expected 0.165.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+              `Native binding package version mismatch, expected 0.174.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
             );
           }
           return binding;
@@ -372,12 +372,12 @@ function requireNative() {
           const bindingPackageVersion =
             require("@vizejs/native-linux-x64-gnu/package.json").version;
           if (
-            bindingPackageVersion !== "0.165.0" &&
+            bindingPackageVersion !== "0.174.0" &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== "0"
           ) {
             throw new Error(
-              `Native binding package version mismatch, expected 0.165.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+              `Native binding package version mismatch, expected 0.174.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
             );
           }
           return binding;
@@ -397,12 +397,12 @@ function requireNative() {
           const bindingPackageVersion =
             require("@vizejs/native-linux-arm64-musl/package.json").version;
           if (
-            bindingPackageVersion !== "0.165.0" &&
+            bindingPackageVersion !== "0.174.0" &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== "0"
           ) {
             throw new Error(
-              `Native binding package version mismatch, expected 0.165.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+              `Native binding package version mismatch, expected 0.174.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
             );
           }
           return binding;
@@ -420,12 +420,12 @@ function requireNative() {
           const bindingPackageVersion =
             require("@vizejs/native-linux-arm64-gnu/package.json").version;
           if (
-            bindingPackageVersion !== "0.165.0" &&
+            bindingPackageVersion !== "0.174.0" &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== "0"
           ) {
             throw new Error(
-              `Native binding package version mismatch, expected 0.165.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+              `Native binding package version mismatch, expected 0.174.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
             );
           }
           return binding;
@@ -445,12 +445,12 @@ function requireNative() {
           const bindingPackageVersion =
             require("@vizejs/native-linux-arm-musleabihf/package.json").version;
           if (
-            bindingPackageVersion !== "0.165.0" &&
+            bindingPackageVersion !== "0.174.0" &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== "0"
           ) {
             throw new Error(
-              `Native binding package version mismatch, expected 0.165.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+              `Native binding package version mismatch, expected 0.174.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
             );
           }
           return binding;
@@ -468,12 +468,12 @@ function requireNative() {
           const bindingPackageVersion =
             require("@vizejs/native-linux-arm-gnueabihf/package.json").version;
           if (
-            bindingPackageVersion !== "0.165.0" &&
+            bindingPackageVersion !== "0.174.0" &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== "0"
           ) {
             throw new Error(
-              `Native binding package version mismatch, expected 0.165.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+              `Native binding package version mismatch, expected 0.174.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
             );
           }
           return binding;
@@ -493,12 +493,12 @@ function requireNative() {
           const bindingPackageVersion =
             require("@vizejs/native-linux-loong64-musl/package.json").version;
           if (
-            bindingPackageVersion !== "0.165.0" &&
+            bindingPackageVersion !== "0.174.0" &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== "0"
           ) {
             throw new Error(
-              `Native binding package version mismatch, expected 0.165.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+              `Native binding package version mismatch, expected 0.174.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
             );
           }
           return binding;
@@ -516,12 +516,12 @@ function requireNative() {
           const bindingPackageVersion =
             require("@vizejs/native-linux-loong64-gnu/package.json").version;
           if (
-            bindingPackageVersion !== "0.165.0" &&
+            bindingPackageVersion !== "0.174.0" &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== "0"
           ) {
             throw new Error(
-              `Native binding package version mismatch, expected 0.165.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+              `Native binding package version mismatch, expected 0.174.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
             );
           }
           return binding;
@@ -541,12 +541,12 @@ function requireNative() {
           const bindingPackageVersion =
             require("@vizejs/native-linux-riscv64-musl/package.json").version;
           if (
-            bindingPackageVersion !== "0.165.0" &&
+            bindingPackageVersion !== "0.174.0" &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== "0"
           ) {
             throw new Error(
-              `Native binding package version mismatch, expected 0.165.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+              `Native binding package version mismatch, expected 0.174.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
             );
           }
           return binding;
@@ -564,12 +564,12 @@ function requireNative() {
           const bindingPackageVersion =
             require("@vizejs/native-linux-riscv64-gnu/package.json").version;
           if (
-            bindingPackageVersion !== "0.165.0" &&
+            bindingPackageVersion !== "0.174.0" &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
             process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== "0"
           ) {
             throw new Error(
-              `Native binding package version mismatch, expected 0.165.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+              `Native binding package version mismatch, expected 0.174.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
             );
           }
           return binding;
@@ -588,12 +588,12 @@ function requireNative() {
         const bindingPackageVersion =
           require("@vizejs/native-linux-ppc64-gnu/package.json").version;
         if (
-          bindingPackageVersion !== "0.165.0" &&
+          bindingPackageVersion !== "0.174.0" &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== "0"
         ) {
           throw new Error(
-            `Native binding package version mismatch, expected 0.165.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+            `Native binding package version mismatch, expected 0.174.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
           );
         }
         return binding;
@@ -611,12 +611,12 @@ function requireNative() {
         const bindingPackageVersion =
           require("@vizejs/native-linux-s390x-gnu/package.json").version;
         if (
-          bindingPackageVersion !== "0.165.0" &&
+          bindingPackageVersion !== "0.174.0" &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== "0"
         ) {
           throw new Error(
-            `Native binding package version mismatch, expected 0.165.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+            `Native binding package version mismatch, expected 0.174.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
           );
         }
         return binding;
@@ -638,12 +638,12 @@ function requireNative() {
         const bindingPackageVersion =
           require("@vizejs/native-openharmony-arm64/package.json").version;
         if (
-          bindingPackageVersion !== "0.165.0" &&
+          bindingPackageVersion !== "0.174.0" &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== "0"
         ) {
           throw new Error(
-            `Native binding package version mismatch, expected 0.165.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+            `Native binding package version mismatch, expected 0.174.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
           );
         }
         return binding;
@@ -661,12 +661,12 @@ function requireNative() {
         const bindingPackageVersion =
           require("@vizejs/native-openharmony-x64/package.json").version;
         if (
-          bindingPackageVersion !== "0.165.0" &&
+          bindingPackageVersion !== "0.174.0" &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== "0"
         ) {
           throw new Error(
-            `Native binding package version mismatch, expected 0.165.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+            `Native binding package version mismatch, expected 0.174.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
           );
         }
         return binding;
@@ -684,12 +684,12 @@ function requireNative() {
         const bindingPackageVersion =
           require("@vizejs/native-openharmony-arm/package.json").version;
         if (
-          bindingPackageVersion !== "0.165.0" &&
+          bindingPackageVersion !== "0.174.0" &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK &&
           process.env.NAPI_RS_ENFORCE_VERSION_CHECK !== "0"
         ) {
           throw new Error(
-            `Native binding package version mismatch, expected 0.165.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
+            `Native binding package version mismatch, expected 0.174.0 but got ${bindingPackageVersion}. You can reinstall dependencies to fix this issue.`,
           );
         }
         return binding;
@@ -810,6 +810,7 @@ module.exports.normalizeVitePrecompileBatchSize = nativeBinding.normalizeVitePre
 module.exports.normalizeViteRequireBase = nativeBinding.normalizeViteRequireBase;
 module.exports.normalizeViteResolvedVuePath = nativeBinding.normalizeViteResolvedVuePath;
 module.exports.normalizeViteVirtualVueModuleId = nativeBinding.normalizeViteVirtualVueModuleId;
+module.exports.normalizeVizeConfig = nativeBinding.normalizeVizeConfig;
 module.exports.parseArt = nativeBinding.parseArt;
 module.exports.parseCssAst = nativeBinding.parseCssAst;
 module.exports.parseDesignTokensFromJson = nativeBinding.parseDesignTokensFromJson;

--- a/npm/vize/src/config.ts
+++ b/npm/vize/src/config.ts
@@ -1,13 +1,10 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { execFileSync } from "node:child_process";
 import { randomUUID } from "node:crypto";
+import { createRequire } from "node:module";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { transform } from "oxc-transform";
 import type {
-  LanguageServerConfig,
-  VizeConfig,
-  VizeConfigEntry,
   ResolvedVizeConfig,
   LoadConfigOptions,
   UserConfigExport,
@@ -15,6 +12,14 @@ import type {
   GlobalTypesConfig,
   GlobalTypeDeclaration,
 } from "./types/index.js";
+import { loadPklConfigJson } from "./config/pkl.js";
+
+type NativeConfigHelpers = {
+  normalizeVizeConfig(value: unknown): unknown;
+};
+
+const require = createRequire(import.meta.url);
+const native = require("@vizejs/native") as NativeConfigHelpers;
 
 export const CONFIG_FILE_NAMES = [
   "vize.config.pkl",
@@ -38,17 +43,6 @@ export const VIZE_CONFIG_JSON_SCHEMA_PATH = path.join(
 );
 
 export const VIZE_CONFIG_PKL_SCHEMA_PATH = path.join(PACKAGE_ROOT, "pkl", "vize.pkl");
-
-const DOCUMENTED_PKL_SCHEMA_IMPORT_RE =
-  /^(\s*(?:amends|import)\s+)(["'])node_modules\/vize\/pkl\/(VizeConfig\.pkl|vize\.pkl)\2/gm;
-
-type CompatVizeConfig = VizeConfig & {
-  lsp?: LanguageServerConfig;
-};
-
-type CompatVizeConfigEntry = VizeConfigEntry & {
-  lsp?: LanguageServerConfig;
-};
 
 /**
  * Define a Vize configuration with type checking.
@@ -149,104 +143,9 @@ async function loadConfigFile(
   return loadESMConfig(absolutePath, env);
 }
 
-function findPklBinary(): string | null {
-  try {
-    const pklPkgPath = import.meta.resolve?.("@pkl-community/pkl");
-    if (pklPkgPath) {
-      const pklLibDir = path.dirname(fileURLToPath(pklPkgPath));
-      const pklPackageDir = path.dirname(pklLibDir);
-      const candidates = [
-        path.join(pklLibDir, "main.js"),
-        path.join(pklPackageDir, "pkl"),
-        path.join(pklPackageDir, "pkl.exe"),
-      ];
-
-      for (const candidate of candidates) {
-        if (fs.existsSync(candidate)) {
-          try {
-            execFileSync(candidate, ["--version"], { stdio: "ignore" });
-            return candidate;
-          } catch {
-            // Keep looking: the bundled shim can exist even when its runtime is unavailable.
-          }
-        }
-      }
-    }
-  } catch {
-    // Fall back to PATH below.
-  }
-
-  try {
-    execFileSync("pkl", ["--version"], { stdio: "ignore" });
-    return "pkl";
-  } catch {
-    return null;
-  }
-}
-
 function loadPklConfig(filePath: string): ResolvedVizeConfig | null {
-  const pklBin = findPklBinary();
-  if (!pklBin) {
-    console.warn(
-      "[vize] pkl CLI not found. Install @pkl-community/pkl or add pkl to PATH. " +
-        "Falling back to the next config format.",
-    );
-    return null;
-  }
-
-  let output: string;
-  const patchedFilePath = createPklConfigWithBundledSchemaImports(filePath);
-  const evalFilePath = patchedFilePath ?? filePath;
-  try {
-    output = execFileSync(pklBin, ["eval", "-f", "json", evalFilePath], {
-      cwd: path.dirname(filePath),
-      encoding: "utf-8",
-      stdio: ["ignore", "pipe", "pipe"],
-      timeout: 30_000,
-    });
-  } catch (error) {
-    throw new Error(`Failed to evaluate vize PKL config at ${filePath}: ${getErrorMessage(error)}`);
-  } finally {
-    if (patchedFilePath) {
-      fs.rmSync(patchedFilePath, { force: true });
-    }
-  }
-  return parseJsonConfig(output, filePath);
-}
-
-function createPklConfigWithBundledSchemaImports(filePath: string): string | null {
-  const configDir = path.dirname(filePath);
-  const source = fs.readFileSync(filePath, "utf-8");
-  let patched = false;
-
-  const content = source.replace(
-    DOCUMENTED_PKL_SCHEMA_IMPORT_RE,
-    (match, prefix, quote, schemaFile) => {
-      const projectSchemaPath = path.join(configDir, "node_modules", "vize", "pkl", schemaFile);
-      if (fs.existsSync(projectSchemaPath)) {
-        return match;
-      }
-
-      const bundledSchemaPath = path.join(PACKAGE_ROOT, "pkl", schemaFile);
-      if (!fs.existsSync(bundledSchemaPath)) {
-        return match;
-      }
-
-      patched = true;
-      return `${prefix}${quote}${pathToFileURL(bundledSchemaPath).href}${quote}`;
-    },
-  );
-
-  if (!patched) {
-    return null;
-  }
-
-  const tempFile = path.join(
-    configDir,
-    `.vize-config-${process.pid}-${Date.now()}-${randomUUID()}.pkl`,
-  );
-  fs.writeFileSync(tempFile, content, { flag: "wx", mode: 0o600 });
-  return tempFile;
+  const output = loadPklConfigJson(filePath);
+  return output === null ? null : parseJsonConfig(output, filePath);
 }
 
 export async function resolveConfigExport(
@@ -307,113 +206,7 @@ function parseJsonConfig(content: string, filePath: string): ResolvedVizeConfig 
 }
 
 function normalizeLoadedConfig(config: unknown): ResolvedVizeConfig {
-  const normalized = stripNullish(config);
-  if (Array.isArray(normalized)) {
-    return normalizeConfigEntries(normalized as CompatVizeConfigEntry[]);
-  }
-
-  return normalizeConfigObject((normalized ?? {}) as CompatVizeConfig);
-}
-
-function normalizeConfigObject(config: CompatVizeConfig): ResolvedVizeConfig {
-  const { entries: rawEntries, ...rootConfig } = normalizeConfigAliases(config) as VizeConfig & {
-    entries?: CompatVizeConfigEntry[];
-  };
-  const rootEntry = rootConfig as VizeConfigEntry;
-  const entries = [
-    ...(isEmptyConfigEntry(rootEntry) ? [] : [rootEntry]),
-    ...(rawEntries ?? []).map((entry) => normalizeConfigAliases(entry) as VizeConfigEntry),
-  ];
-
-  return {
-    ...rootEntry,
-    entries,
-  };
-}
-
-function normalizeConfigEntries(entries: CompatVizeConfigEntry[]): ResolvedVizeConfig {
-  const normalizedEntries = entries.map(
-    (entry) => normalizeConfigAliases(entry) as VizeConfigEntry,
-  );
-  const globalConfig = mergeConfigEntries(normalizedEntries.filter(isGlobalConfigEntry));
-
-  return {
-    ...globalConfig,
-    entries: normalizedEntries,
-  };
-}
-
-function mergeConfigEntries(entries: VizeConfigEntry[]): VizeConfigEntry {
-  const result: Record<string, unknown> = {};
-  for (const entry of entries) {
-    deepMerge(result, stripEntryMetadata(entry));
-  }
-  return result as VizeConfigEntry;
-}
-
-function stripEntryMetadata(entry: VizeConfigEntry): Partial<VizeConfigEntry> {
-  const { name, basePath, files, ignores, extends: extendsConfig, ...config } = entry;
-  void name;
-  void basePath;
-  void files;
-  void ignores;
-  void extendsConfig;
-  return config;
-}
-
-function deepMerge(target: Record<string, unknown>, source: Record<string, unknown>): void {
-  for (const [key, value] of Object.entries(source)) {
-    if (value === undefined) {
-      continue;
-    }
-
-    const current = target[key];
-    if (isPlainObject(current) && isPlainObject(value)) {
-      deepMerge(current, value);
-    } else {
-      target[key] = value;
-    }
-  }
-}
-
-function isGlobalConfigEntry(entry: VizeConfigEntry): boolean {
-  return entry.basePath === undefined && entry.files === undefined && entry.ignores === undefined;
-}
-
-function isEmptyConfigEntry(entry: VizeConfigEntry): boolean {
-  return Object.keys(entry).length === 0;
-}
-
-function stripNullish(value: unknown): unknown {
-  if (value === null) {
-    return undefined;
-  }
-
-  if (Array.isArray(value)) {
-    return value.map((entry) => stripNullish(entry)).filter((entry) => entry !== undefined);
-  }
-
-  if (isPlainObject(value)) {
-    const result: Record<string, unknown> = {};
-    for (const [key, entry] of Object.entries(value)) {
-      const normalizedEntry = stripNullish(entry);
-      if (normalizedEntry !== undefined) {
-        result[key] = normalizedEntry;
-      }
-    }
-    return result;
-  }
-
-  return value;
-}
-
-function isPlainObject(value: unknown): value is Record<string, unknown> {
-  if (typeof value !== "object" || value === null || Array.isArray(value)) {
-    return false;
-  }
-
-  const prototype = Object.getPrototypeOf(value);
-  return prototype === Object.prototype || prototype === null;
+  return native.normalizeVizeConfig(config ?? null) as ResolvedVizeConfig;
 }
 
 function getErrorMessage(error: unknown): string {
@@ -447,20 +240,4 @@ export function normalizeGlobalTypes(
     }
   }
   return result;
-}
-
-function normalizeConfigAliases(config: CompatVizeConfig): VizeConfig {
-  if (config.lsp === undefined) {
-    return config;
-  }
-
-  const { lsp, ...rest } = config;
-  if (config.languageServer !== undefined) {
-    return rest;
-  }
-
-  return {
-    ...rest,
-    languageServer: lsp,
-  };
 }

--- a/npm/vize/src/config/pkl.d.ts
+++ b/npm/vize/src/config/pkl.d.ts
@@ -1,0 +1,1 @@
+export function loadPklConfigJson(filePath: string): string | null;

--- a/npm/vize/src/config/pkl.js
+++ b/npm/vize/src/config/pkl.js
@@ -1,0 +1,126 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { execFileSync } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const PACKAGE_ROOT = path.resolve(fileURLToPath(new URL(".", import.meta.url)), "../..");
+
+const DOCUMENTED_PKL_SCHEMA_IMPORT_RE =
+  /^(\s*(?:amends|import)\s+)(["'])node_modules\/vize\/pkl\/(VizeConfig\.pkl|vize\.pkl)\2/gm;
+
+/**
+ * Evaluate a `vize.config.pkl` file and return its JSON representation.
+ *
+ * The npm-facing loader keeps PKL execution in Node because it needs package
+ * resolution for `@pkl-community/pkl`, but all structural config normalization
+ * happens in Rust after this function returns. A missing PKL runtime returns
+ * `null` so config discovery can fall through to lower-priority formats; an
+ * evaluation failure throws because a present PKL config should not silently be
+ * ignored.
+ */
+export function loadPklConfigJson(filePath) {
+  const pklBin = findPklBinary();
+  if (!pklBin) {
+    console.warn(
+      "[vize] pkl CLI not found. Install @pkl-community/pkl or add pkl to PATH. " +
+        "Falling back to the next config format.",
+    );
+    return null;
+  }
+
+  const patchedFilePath = createPklConfigWithBundledSchemaImports(filePath);
+  const evalFilePath = patchedFilePath ?? filePath;
+  try {
+    return execFileSync(pklBin, ["eval", "-f", "json", evalFilePath], {
+      cwd: path.dirname(filePath),
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "pipe"],
+      timeout: 30_000,
+    });
+  } catch (error) {
+    throw new Error(`Failed to evaluate vize PKL config at ${filePath}: ${getErrorMessage(error)}`);
+  } finally {
+    if (patchedFilePath) {
+      fs.rmSync(patchedFilePath, { force: true });
+    }
+  }
+}
+
+function findPklBinary() {
+  try {
+    const pklPkgPath = import.meta.resolve?.("@pkl-community/pkl");
+    if (pklPkgPath) {
+      const pklLibDir = path.dirname(fileURLToPath(pklPkgPath));
+      const pklPackageDir = path.dirname(pklLibDir);
+      const candidates = [
+        path.join(pklLibDir, "main.js"),
+        path.join(pklPackageDir, "pkl"),
+        path.join(pklPackageDir, "pkl.exe"),
+      ];
+
+      for (const candidate of candidates) {
+        if (fs.existsSync(candidate)) {
+          try {
+            execFileSync(candidate, ["--version"], { stdio: "ignore" });
+            return candidate;
+          } catch {
+            // Keep looking: the shim can exist when its runtime is unavailable.
+          }
+        }
+      }
+    }
+  } catch {
+    // Fall back to PATH below.
+  }
+
+  try {
+    execFileSync("pkl", ["--version"], { stdio: "ignore" });
+    return "pkl";
+  } catch {
+    return null;
+  }
+}
+
+function createPklConfigWithBundledSchemaImports(filePath) {
+  const configDir = path.dirname(filePath);
+  const source = fs.readFileSync(filePath, "utf-8");
+  let patched = false;
+
+  const content = source.replace(
+    DOCUMENTED_PKL_SCHEMA_IMPORT_RE,
+    (match, prefix, quote, schemaFile) => {
+      const projectSchemaPath = path.join(configDir, "node_modules", "vize", "pkl", schemaFile);
+      if (fs.existsSync(projectSchemaPath)) {
+        return match;
+      }
+
+      const bundledSchemaPath = path.join(PACKAGE_ROOT, "pkl", schemaFile);
+      if (!fs.existsSync(bundledSchemaPath)) {
+        return match;
+      }
+
+      patched = true;
+      return `${prefix}${quote}${pathToFileURL(bundledSchemaPath).href}${quote}`;
+    },
+  );
+
+  if (!patched) {
+    return null;
+  }
+
+  const tempFile = path.join(
+    configDir,
+    `.vize-config-${process.pid}-${Date.now()}-${randomUUID()}.pkl`,
+  );
+  fs.writeFileSync(tempFile, content, { flag: "wx", mode: 0o600 });
+  return tempFile;
+}
+
+function getErrorMessage(error) {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  return String(error);
+}

--- a/tests/fixtures/sfc/basic.pkl
+++ b/tests/fixtures/sfc/basic.pkl
@@ -1,0 +1,204 @@
+// SFC tests: Basic SFC parsing and compilation
+
+mode = "sfc"
+
+cases = new Listing {
+  new {
+    name = "script setup with template"
+    input = """
+    <script setup>
+    import { ref } from 'vue'
+    const count = ref(0)
+    </script>
+
+    <template>
+      <div>{{ count }}</div>
+    </template>
+
+    """
+  }
+  new {
+    name = "script setup with style"
+    input = """
+    <script setup>
+    const msg = 'hello'
+    </script>
+
+    <template>
+      <div class="text">{{ msg }}</div>
+    </template>
+
+    <style>
+    .text { color: red; }
+    </style>
+
+    """
+  }
+  new {
+    name = "script setup with scoped style"
+    input = """
+    <script setup>
+    const msg = 'hello'
+    </script>
+
+    <template>
+      <div class="text">{{ msg }}</div>
+    </template>
+
+    <style scoped>
+    .text { color: red; }
+    </style>
+
+    """
+  }
+  new {
+    name = "options API component"
+    input = """
+    <script>
+    export default {
+      data() {
+        return { msg: 'hello' }
+      }
+    }
+    </script>
+
+    <template>
+      <div>{{ msg }}</div>
+    </template>
+
+    """
+  }
+  new {
+    name = "template only"
+    input = """
+    <template>
+      <div>Hello World</div>
+    </template>
+
+    """
+  }
+  new {
+    name = "script and template"
+    input = """
+    <script>
+    export default { name: 'MyComponent' }
+    </script>
+
+    <template>
+      <div>Component</div>
+    </template>
+
+    """
+  }
+  new {
+    name = "multiple style blocks"
+    input = """
+    <template>
+      <div class="a b">Test</div>
+    </template>
+
+    <style>
+    .a { color: red; }
+    </style>
+
+    <style scoped>
+    .b { color: blue; }
+    </style>
+
+    """
+  }
+  new {
+    name = "lang attributes"
+    input = """
+    <script setup lang="ts">
+    const count: number = 0
+    </script>
+
+    <template>
+      <div>{{ count }}</div>
+    </template>
+
+    <style lang="scss">
+    .text { color: red; }
+    </style>
+
+    """
+  }
+  new {
+    name = "custom blocks"
+    input = """
+    <template>
+      <div>Test</div>
+    </template>
+
+    <i18n>
+    {
+      "en": { "hello": "Hello" },
+      "ja": { "hello": "こんにちは" }
+    }
+    </i18n>
+
+    """
+  }
+  new {
+    name = "defineProps"
+    input = """
+    <script setup>
+    const props = defineProps(['msg'])
+    </script>
+
+    <template>
+      <div>{{ props.msg }}</div>
+    </template>
+
+    """
+  }
+  new {
+    name = "defineEmits"
+    input = """
+    <script setup>
+    const emit = defineEmits(['update'])
+    function onClick() {
+      emit('update', 1)
+    }
+    </script>
+
+    <template>
+      <button @click="onClick">Click</button>
+    </template>
+
+    """
+  }
+  new {
+    name = "computed and watch"
+    input = """
+    <script setup>
+    import { ref, computed, watch } from 'vue'
+    const count = ref(0)
+    const double = computed(() => count.value * 2)
+    watch(count, (n) => console.log(n))
+    </script>
+
+    <template>
+      <div>{{ double }}</div>
+    </template>
+
+    """
+  }
+  new {
+    name = "script setup function handler"
+    input = """
+    <script setup>
+    const count = 0
+    function onClick() {
+      console.log(count)
+    }
+    </script>
+
+    <template>
+      <button @click="onClick">Click</button>
+    </template>
+
+    """
+  }
+}

--- a/tools/vite-plus/tasks/test-benchmark.ts
+++ b/tools/vite-plus/tasks/test-benchmark.ts
@@ -69,7 +69,9 @@ export const testAndBenchmarkTasks = defineTasks({
   // overwritten by vite-plugin-vize's pretest hook, which also rebuilds in
   // dev profile (~1m20s). Building once in the CI profile saves both legs.
   "test:js": noCacheTask(`${runTask("build:native:test")} && ${jsPackageTestCommand}`),
-  "test:scripts": noCacheTask("node --test --test-concurrency=1 tests/tooling/*.test.ts"),
+  "test:scripts": noCacheTask(
+    `${runTask("build:native:test")} && node --test --test-concurrency=1 tests/tooling/*.test.ts`,
+  ),
   "test:vscode-extension:vsix": noCacheTask(
     runInVscodeExtension(
       "pnpm exec vsce package --no-dependencies --out dist/vize.vsix",


### PR DESCRIPTION
## Summary

- Move public `vize/config` normalization into Rust and expose it through `@vizejs/native` as `normalizeVizeConfig`, preserving JS-only values such as `RegExp` across the NAPI boundary.
- Split the Rust config loader into smaller discovery, parse, JS, PKL, and test modules, keeping edited implementation files under 250 lines where practical.
- Add PKL fixture loading for SFC snapshot tests and introduce `tests/fixtures/sfc/basic.pkl` as the first PKL-authored fixture.

## Validation

- `cargo fmt --check`
- `cargo check -p vize_carton -p vize_vitrine --features vize_vitrine/napi`
- `cargo test -p vize_carton --lib config::`
- `cargo test -p vize_atelier_sfc snapshot_tests --features native`
- `pnpm --filter ./npm/vize-native build:ci`
- `node --test --test-concurrency=1 tests/tooling/*.test.ts`
- `pnpm --filter ./npm/vite-plugin-vize test`
- `pnpm --filter ./npm/vize check`
- `pnpm exec vp check crates/vize_vitrine/src/napi/config.rs crates/vize_vitrine/src/napi/config/js_value.rs crates/vize_vitrine/src/napi/config/js_value/raw.rs tools/vite-plus/tasks/test-benchmark.ts npm/vize-native/index.js npm/vize-native/index.d.ts`
- `git diff --check`

## Notes

- `pnpm --filter ./npm/vize build` was attempted earlier, but `generate:rule-types` stayed silent for several minutes and was terminated before completion. The package check, native build, tooling tests, and plugin tests passed.
