### PR TITLE
fix: camelize slot outlet prop keys

### DIFF
--- a/crates/vize_atelier_core/src/codegen/props.rs
+++ b/crates/vize_atelier_core/src/codegen/props.rs
@@ -9,7 +9,10 @@ use crate::ast::{PropNode, RuntimeHelper};
 
 use super::{context::CodegenContext, expression::generate_expression};
 
-pub use directives::{StaticMerge, generate_directive_prop_with_static, is_supported_directive};
+pub use directives::{
+    StaticMerge, generate_directive_prop_with_static,
+    generate_slot_outlet_directive_prop_with_static, is_supported_directive,
+};
 pub use events::von_event_key_for;
 pub use generate::generate_props;
 

--- a/crates/vize_atelier_core/src/codegen/props/directives.rs
+++ b/crates/vize_atelier_core/src/codegen/props/directives.rs
@@ -88,9 +88,45 @@ pub fn generate_directive_prop_with_static(
     dir: &DirectiveNode<'_>,
     static_merge: StaticMerge<'_>,
 ) {
+    generate_directive_prop_with_static_key_casing(
+        ctx,
+        dir,
+        static_merge,
+        StaticBindKeyCasing::Preserve,
+    );
+}
+
+/// Generate a directive prop for a `<slot>` outlet.
+///
+/// Vue camelizes static slot prop keys before passing them to renderSlot.
+pub fn generate_slot_outlet_directive_prop_with_static(
+    ctx: &mut CodegenContext,
+    dir: &DirectiveNode<'_>,
+    static_merge: StaticMerge<'_>,
+) {
+    generate_directive_prop_with_static_key_casing(
+        ctx,
+        dir,
+        static_merge,
+        StaticBindKeyCasing::Camelize,
+    );
+}
+
+#[derive(Clone, Copy)]
+enum StaticBindKeyCasing {
+    Preserve,
+    Camelize,
+}
+
+fn generate_directive_prop_with_static_key_casing(
+    ctx: &mut CodegenContext,
+    dir: &DirectiveNode<'_>,
+    static_merge: StaticMerge<'_>,
+    static_key_casing: StaticBindKeyCasing,
+) {
     match dir.name.as_str() {
         "bind" => {
-            generate_vbind_prop(ctx, dir, static_merge);
+            generate_vbind_prop(ctx, dir, static_merge, static_key_casing);
         }
         "on" => {
             generate_von_prop(ctx, dir);
@@ -132,6 +168,7 @@ fn generate_vbind_prop(
     ctx: &mut CodegenContext,
     dir: &DirectiveNode<'_>,
     static_merge: StaticMerge<'_>,
+    static_key_casing: StaticBindKeyCasing,
 ) {
     let static_class = static_merge.class;
     let static_style = static_merge.style;
@@ -207,23 +244,27 @@ fn generate_vbind_prop(
             is_style = key == "style";
 
             // Transform key based on modifiers
-            let transformed_key: vize_carton::String = if has_camel {
-                // Convert kebab-case to camelCase
-                camelize(key)
-            } else if has_prop {
+            let base_key: vize_carton::String =
+                if has_camel || matches!(static_key_casing, StaticBindKeyCasing::Camelize) {
+                    camelize(key)
+                } else {
+                    key.to_compact_string()
+                };
+
+            let transformed_key: vize_carton::String = if has_prop {
                 // Add . prefix for DOM property binding
-                let mut name = String::with_capacity(1 + key.len());
+                let mut name = String::with_capacity(1 + base_key.len());
                 name.push('.');
-                name.push_str(key);
+                name.push_str(&base_key);
                 name
             } else if has_attr {
                 // Add ^ prefix for attribute binding
-                let mut name = String::with_capacity(1 + key.len());
+                let mut name = String::with_capacity(1 + base_key.len());
                 name.push('^');
-                name.push_str(key);
+                name.push_str(&base_key);
                 name
             } else {
-                key.to_compact_string()
+                base_key
             };
 
             let needs_quotes = !is_valid_js_identifier(&transformed_key);

--- a/crates/vize_atelier_core/src/codegen/slots.rs
+++ b/crates/vize_atelier_core/src/codegen/slots.rs
@@ -7,11 +7,11 @@ use crate::transforms::v_slot::{collect_slots, get_slot_name, has_v_slot};
 
 use super::context::CodegenContext;
 use super::expression::generate_expression;
-use super::helpers::{escape_js_string, is_valid_js_identifier};
+use super::helpers::{camelize, escape_js_string, is_valid_js_identifier};
 use super::node::generate_node;
 use super::props::{
-    generate_directive_prop_with_static, generate_vbind_object_exp, generate_von_object_exp,
-    is_supported_directive,
+    generate_slot_outlet_directive_prop_with_static, generate_vbind_object_exp,
+    generate_von_object_exp, is_supported_directive,
 };
 use vize_carton::String;
 use vize_carton::ToCompactString;
@@ -242,11 +242,12 @@ pub(crate) fn generate_slot_outlet_props_entries(ctx: &mut CodegenContext, el: &
                     ctx.push(", ");
                 }
 
-                if is_valid_js_identifier(&attr.name) {
-                    ctx.push(&attr.name);
+                let key = camelize(&attr.name);
+                if is_valid_js_identifier(&key) {
+                    ctx.push(&key);
                 } else {
                     ctx.push("\"");
-                    ctx.push(&escape_js_string(&attr.name));
+                    ctx.push(&escape_js_string(&key));
                     ctx.push("\"");
                 }
                 ctx.push(": ");
@@ -270,7 +271,7 @@ pub(crate) fn generate_slot_outlet_props_entries(ctx: &mut CodegenContext, el: &
                 if !first {
                     ctx.push(", ");
                 }
-                generate_directive_prop_with_static(ctx, dir, static_merge);
+                generate_slot_outlet_directive_prop_with_static(ctx, dir, static_merge);
                 first = false;
             }
         }

--- a/crates/vize_atelier_ssr/src/codegen/element/props.rs
+++ b/crates/vize_atelier_ssr/src/codegen/element/props.rs
@@ -114,6 +114,25 @@ pub(super) fn transform_bound_prop_key(key: &str, dir: &DirectiveNode) -> String
     key.to_compact_string()
 }
 
+pub(super) fn static_slot_outlet_prop_key(key: &str) -> String {
+    vize_carton::camelize(key)
+}
+
+pub(super) fn transform_slot_outlet_bound_prop_key(key: &str, dir: &DirectiveNode) -> String {
+    let base = vize_carton::camelize(key);
+    if dir.modifiers.iter().any(|m| m.content == "prop") {
+        let mut out = String::from(".");
+        out.push_str(&base);
+        return out;
+    }
+    if dir.modifiers.iter().any(|m| m.content == "attr") {
+        let mut out = String::from("^");
+        out.push_str(&base);
+        return out;
+    }
+    base
+}
+
 pub(super) fn push_js_object_key(out: &mut String, key: &str) {
     if is_valid_js_identifier(key) {
         out.push_str(key);

--- a/crates/vize_atelier_ssr/src/codegen/element/slot.rs
+++ b/crates/vize_atelier_ssr/src/codegen/element/slot.rs
@@ -64,7 +64,8 @@ impl<'a> SsrCodegenContext<'a> {
                         .as_ref()
                         .map(|v| quoted_js_string(&v.content))
                         .unwrap_or_else(|| "true".to_compact_string());
-                    entries.push(component_prop_entry(&attr.name, &value, false));
+                    let key = static_slot_outlet_prop_key(&attr.name);
+                    entries.push(component_prop_entry(&key, &value, false));
                 }
                 PropNode::Directive(dir) if dir.name == "bind" => {
                     let value = dir
@@ -91,7 +92,12 @@ impl<'a> SsrCodegenContext<'a> {
                         continue;
                     }
 
-                    entries.push(component_prop_entry(&arg.content, &value, !arg.is_static));
+                    let key = if arg.is_static {
+                        transform_slot_outlet_bound_prop_key(&arg.content, dir)
+                    } else {
+                        arg.content.clone()
+                    };
+                    entries.push(component_prop_entry(&key, &value, !arg.is_static));
                 }
                 _ => {}
             }

--- a/crates/vize_atelier_ssr/tests/snapshots/ssr_snapshot__slot__slot_with_camelized_prop.snap
+++ b/crates/vize_atelier_ssr/tests/snapshots/ssr_snapshot__slot__slot_with_camelized_prop.snap
@@ -1,0 +1,9 @@
+---
+source: crates/vize_atelier_ssr/tests/ssr_snapshot.rs
+expression: "get_compiled_string(r#\"<slot :slot-key=\"slotValue\"></slot>\"#)"
+---
+function ssrRender(_ctx, _push, _parent, _attrs) {
+  _push(`<div${_ssrRenderAttrs(_attrs)}>`)
+  _ssrRenderSlot(_ctx.$slots, "default", { slotKey: _ctx.slotValue }, null, _push, _parent)
+  _push(`</div>`)
+}

--- a/crates/vize_atelier_ssr/tests/ssr_snapshot.rs
+++ b/crates/vize_atelier_ssr/tests/ssr_snapshot.rs
@@ -437,6 +437,13 @@ mod slot {
             r#"<slot v-bind="formState" :status="status">fallback content</slot>"#
         ));
     }
+
+    #[test]
+    fn slot_with_camelized_prop() {
+        insta::assert_snapshot!(get_compiled_string(
+            r#"<slot :slot-key="slotValue"></slot>"#
+        ));
+    }
 }
 
 // =============================================================================

--- a/tests/expected/vdom/element.snap
+++ b/tests/expected/vdom/element.snap
@@ -391,6 +391,17 @@ export function render(_ctx, _cache) {
   ])
 }
 ===
+name: slot with camelized prop
+options: vdom
+--- INPUT ---
+<slot :slot-key="slotValue"></slot>
+--- OUTPUT ---
+import { renderSlot as _renderSlot } from "vue"
+
+export function render(_ctx, _cache) {
+  return _renderSlot(_ctx.$slots, "default", { slotKey: _ctx.slotValue })
+}
+===
 name: svg element
 options: vdom
 --- INPUT ---

--- a/tests/fixtures/vdom/element.toml
+++ b/tests/fixtures/vdom/element.toml
@@ -158,6 +158,10 @@ input = '<slot name="header"></slot>'
 name = "slot with fallback"
 input = "<slot>fallback content</slot>"
 
+[[cases]]
+name = "slot with camelized prop"
+input = '<slot :slot-key="slotValue"></slot>'
+
 # =============================================================================
 # SVG elements
 # =============================================================================


### PR DESCRIPTION
## Summary

- Camelize static slot outlet prop keys before emitting renderSlot props.
- Apply the same casing rule to SSR slot outlet props.
- Add vdom and SSR regression coverage for `<slot :slot-key="slotValue">`.

## Root Cause

Vize emitted static `<slot>` prop keys exactly as authored, so kebab-case keys such as `slot-key` reached runtime as `"slot-key"` instead of Vue compiler-compatible `slotKey`.

## Validation

- `cargo test -p vize_test_runner vdom_element -- --ignored --nocapture`
- `cargo test -p vize_atelier_ssr slot --test ssr_snapshot -- --nocapture`
- `cargo test -p vize_atelier_core codegen::slots -- --nocapture`

Fixes #1067

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1069"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783324003&installation_id=136613492&pr_number=1069&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1069&signature=a3222c3abcee474d6fb3a64f73785b936c54f42e93610d174493d81c3b5fd0a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->