### PR TITLE
fix: compile dynamic key children as blocks

### DIFF
--- a/crates/vize_atelier_core/src/codegen.rs
+++ b/crates/vize_atelier_core/src/codegen.rs
@@ -725,6 +725,21 @@ mod tests {
     }
 
     #[test]
+    fn test_codegen_dynamic_keyed_slot_child_uses_block() {
+        let result = compile!(
+            r#"<PageWithHeader>
+  <div :key="tab">
+    <MkPagination :paginator="paginator">
+      <template #default="{ items }">{{ items.length }}</template>
+    </MkPagination>
+  </div>
+</PageWithHeader>"#
+        );
+
+        assert_codegen_snapshot!(result);
+    }
+
+    #[test]
     fn test_codegen_forwarded_default_slot_is_marked_forwarded() {
         let result = compile!(r#"<MkSwiper><slot /></MkSwiper>"#);
 

--- a/crates/vize_atelier_core/src/codegen/element/helpers.rs
+++ b/crates/vize_atelier_core/src/codegen/element/helpers.rs
@@ -142,6 +142,23 @@ pub fn has_renderable_props(el: &ElementNode<'_>) -> bool {
     el.props.iter().any(|prop| is_renderable_prop(prop))
 }
 
+/// Check if an element has a static-arg dynamic key binding (`:key="..."`).
+pub(crate) fn has_dynamic_key_binding(el: &ElementNode<'_>) -> bool {
+    el.props.iter().any(|prop| {
+        matches!(
+            prop,
+            PropNode::Directive(dir)
+                if dir.name == "bind"
+                    && dir.exp.is_some()
+                    && matches!(
+                        dir.arg.as_ref(),
+                        Some(ExpressionNode::Simple(arg))
+                            if arg.is_static && arg.content.as_str() == "key"
+                    )
+        )
+    })
+}
+
 /// Check whether a native element needs its own block to enter or leave an
 /// SVG/MathML namespace boundary. Descendants already inside the same
 /// namespace can stay as inline VNodes, matching Vue's DOM compiler output.

--- a/crates/vize_atelier_core/src/codegen/element/inline.rs
+++ b/crates/vize_atelier_core/src/codegen/element/inline.rs
@@ -28,9 +28,9 @@ use super::{
         generate_custom_directives_closing, generate_vmodel_closing, generate_vshow_closing,
     },
     helpers::{
-        child_namespace, crosses_namespace_boundary, has_custom_directives, has_renderable_props,
-        has_vmodel_directive, has_vshow_directive, is_dynamic_component, is_is_prop,
-        is_renderable_prop, is_whitespace_or_comment,
+        child_namespace, crosses_namespace_boundary, has_custom_directives,
+        has_dynamic_key_binding, has_renderable_props, has_vmodel_directive, has_vshow_directive,
+        is_dynamic_component, is_is_prop, is_renderable_prop, is_whitespace_or_comment,
     },
 };
 use vize_carton::ToCompactString;
@@ -38,6 +38,13 @@ use vize_carton::ToCompactString;
 /// Generate element code (non-block)
 pub fn generate_element(ctx: &mut CodegenContext, el: &ElementNode<'_>) {
     if crosses_namespace_boundary(ctx, el) {
+        super::block::generate_element_block(ctx, el);
+        return;
+    }
+
+    if matches!(el.tag_type, ElementType::Element | ElementType::Component)
+        && has_dynamic_key_binding(el)
+    {
         super::block::generate_element_block(ctx, el);
         return;
     }

--- a/crates/vize_atelier_core/src/snapshots/vize_atelier_core__codegen__tests__codegen_dynamic_keyed_slot_child_uses_block.snap
+++ b/crates/vize_atelier_core/src/snapshots/vize_atelier_core__codegen__tests__codegen_dynamic_keyed_slot_child_uses_block.snap
@@ -1,0 +1,24 @@
+---
+source: crates/vize_atelier_core/src/codegen.rs
+expression: output.as_str()
+---
+const { resolveComponent: _resolveComponent, toDisplayString: _toDisplayString, createVNode: _createVNode, openBlock: _openBlock, createBlock: _createBlock, createElementBlock: _createElementBlock, createTextVNode: _createTextVNode, withCtx: _withCtx } = Vue
+
+function render(_ctx, _cache, $props, $setup, $data, $options) {
+  const _component_MkPagination = _resolveComponent("MkPagination")
+  const _component_PageWithHeader = _resolveComponent("PageWithHeader")
+  
+  return (_openBlock(), _createBlock(_component_PageWithHeader, null, {
+    default: _withCtx(() => [
+      (_openBlock(), _createElementBlock("div", { key: tab }, [
+        _createVNode(_component_MkPagination, { paginator: paginator }, {
+          default: _withCtx(({ items }) => [
+            _createTextVNode(_toDisplayString(items.length), 1 /* TEXT */)
+          ]),
+          _: 1 /* STABLE */
+        }, 8 /* PROPS */, ["paginator"])
+      ]))
+    ]),
+    _: 1 /* STABLE */
+  }))
+}

--- a/tests/expected/vdom/v-bind.snap
+++ b/tests/expected/vdom/v-bind.snap
@@ -390,6 +390,34 @@ export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("div", { key: _ctx.id }))
 }
 ===
+name: nested v-bind key
+options: vdom
+--- INPUT ---
+<section><div :key="id">content</div></section>
+--- OUTPUT ---
+import { openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+export function render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("section", null, [
+    (_openBlock(), _createElementBlock("div", { key: _ctx.id }, "content"))
+  ]))
+}
+===
+name: nested component v-bind key
+options: vdom
+--- INPUT ---
+<section><MyComponent :key="id" /></section>
+--- OUTPUT ---
+import { resolveComponent as _resolveComponent, openBlock as _openBlock, createBlock as _createBlock, createElementBlock as _createElementBlock } from "vue"
+
+export function render(_ctx, _cache) {
+  const _component_MyComponent = _resolveComponent("MyComponent")
+
+  return (_openBlock(), _createElementBlock("section", null, [
+    (_openBlock(), _createBlock(_component_MyComponent, { key: _ctx.id }))
+  ]))
+}
+===
 name: v-bind ref
 options: vdom
 --- INPUT ---

--- a/tests/fixtures/vdom/v-bind.toml
+++ b/tests/fixtures/vdom/v-bind.toml
@@ -159,6 +159,14 @@ name = "v-bind key"
 input = '<div :key="id"></div>'
 
 [[cases]]
+name = "nested v-bind key"
+input = '<section><div :key="id">content</div></section>'
+
+[[cases]]
+name = "nested component v-bind key"
+input = '<section><MyComponent :key="id" /></section>'
+
+[[cases]]
 name = "v-bind ref"
 input = '<div :ref="refName"></div>'
 


### PR DESCRIPTION
## Summary
- Compile non-root native and component nodes with static-arg dynamic `:key` through block generation.
- Preserve existing v-for stable-fragment handling.
- Add VDOM parity cases and a slot regression snapshot for keyed pagination-style wrappers.

Discussion: https://github.com/ubugeeei-prod/vize/discussions/71#discussioncomment-17200426

## Tests
- `cargo fmt --check`
- `cargo test -p vize_test_runner vdom_v_bind -- --ignored --nocapture`
- `cargo test -p vize_test_runner vdom_v_for -- --ignored --nocapture`
- `cargo test -p vize_test_runner vdom_v_slot -- --ignored --nocapture`
- `cargo test -p vize_atelier_core codegen::tests -- --nocapture`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1070"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783325210&installation_id=136613492&pr_number=1070&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1070&signature=a998c7da166258143c63d38e1a77576d481fbf0e5c7238471ef0ce51894f06eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->