### PR TITLE
perf(carton): drop global RwLock string caches from camelize/hyphenate/capitalize

### DIFF
--- a/crates/vize_carton/src/general.rs
+++ b/crates/vize_carton/src/general.rs
@@ -1,10 +1,7 @@
 //! General utility functions shared across the compiler.
 
 use crate::String;
-use once_cell::sync::Lazy;
 use phf::phf_set;
-use rustc_hash::FxHashMap;
-use std::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 
 /// Reserved props that should not be passed to components
 pub static RESERVED_PROPS: phf::Set<&'static str> = phf_set! {
@@ -65,57 +62,10 @@ pub fn is_model_listener(key: &str) -> bool {
     key.starts_with("onUpdate:")
 }
 
-// String transformation caches
-static CAMELIZE_CACHE: Lazy<RwLock<FxHashMap<String, String>>> =
-    Lazy::new(|| RwLock::new(FxHashMap::default()));
-static HYPHENATE_CACHE: Lazy<RwLock<FxHashMap<String, String>>> =
-    Lazy::new(|| RwLock::new(FxHashMap::default()));
-static CAPITALIZE_CACHE: Lazy<RwLock<FxHashMap<String, String>>> =
-    Lazy::new(|| RwLock::new(FxHashMap::default()));
-
-#[inline]
-fn read_cache(
-    cache: &RwLock<FxHashMap<String, String>>,
-) -> RwLockReadGuard<'_, FxHashMap<String, String>> {
-    match cache.read() {
-        Ok(guard) => guard,
-        Err(poisoned) => poisoned.into_inner(),
-    }
-}
-
-#[inline]
-fn write_cache(
-    cache: &RwLock<FxHashMap<String, String>>,
-) -> RwLockWriteGuard<'_, FxHashMap<String, String>> {
-    match cache.write() {
-        Ok(guard) => guard,
-        Err(poisoned) => poisoned.into_inner(),
-    }
-}
-
 /// Convert kebab-case to camelCase
 /// Example: "foo-bar" -> "fooBar"
+#[inline]
 pub fn camelize(s: &str) -> String {
-    // Check cache first
-    {
-        let cache = read_cache(&CAMELIZE_CACHE);
-        if let Some(cached) = cache.get(s) {
-            return cached.clone();
-        }
-    }
-
-    let result = camelize_uncached(s);
-
-    // Store in cache
-    {
-        let mut cache = write_cache(&CAMELIZE_CACHE);
-        cache.insert(String::from(s), result.clone());
-    }
-
-    result
-}
-
-fn camelize_uncached(s: &str) -> String {
     let mut result = String::with_capacity(s.len());
     let mut capitalize_next = false;
 
@@ -135,27 +85,8 @@ fn camelize_uncached(s: &str) -> String {
 
 /// Convert camelCase to kebab-case
 /// Example: "fooBar" -> "foo-bar"
+#[inline]
 pub fn hyphenate(s: &str) -> String {
-    // Check cache first
-    {
-        let cache = read_cache(&HYPHENATE_CACHE);
-        if let Some(cached) = cache.get(s) {
-            return cached.clone();
-        }
-    }
-
-    let result = hyphenate_uncached(s);
-
-    // Store in cache
-    {
-        let mut cache = write_cache(&HYPHENATE_CACHE);
-        cache.insert(String::from(s), result.clone());
-    }
-
-    result
-}
-
-fn hyphenate_uncached(s: &str) -> String {
     let mut result = String::with_capacity(s.len() + 4);
 
     for (i, c) in s.chars().enumerate() {
@@ -172,31 +103,12 @@ fn hyphenate_uncached(s: &str) -> String {
 
 /// Capitalize the first letter
 /// Example: "foo" -> "Foo"
+#[inline]
 pub fn capitalize(s: &str) -> String {
     if s.is_empty() {
         return String::new("");
     }
 
-    // Check cache first
-    {
-        let cache = read_cache(&CAPITALIZE_CACHE);
-        if let Some(cached) = cache.get(s) {
-            return cached.clone();
-        }
-    }
-
-    let result = capitalize_uncached(s);
-
-    // Store in cache
-    {
-        let mut cache = write_cache(&CAPITALIZE_CACHE);
-        cache.insert(String::from(s), result.clone());
-    }
-
-    result
-}
-
-fn capitalize_uncached(s: &str) -> String {
     let mut chars = s.chars();
     match chars.next() {
         None => String::new(""),


### PR DESCRIPTION
CompactString stores <=24 bytes inline, so for short identifiers the cache
did strictly more work (RwLock acquire + hash/probe + clone, plus owned-key
alloc on miss) and created a process-global contention point under parallel
compilation. These are pure functions; call them directly.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

---
Part of the adversarially-verified non-compiler performance audit (round 2: 106 findings → 27 confirmed). Behavior-preserving: full workspace test suite green (3439 passed, 0 failed) and `vize fmt`/`lint` output byte-identical. This reduces real work (allocations / redundant parses / lock ops / O(offset) scans) on the component's hot path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1072"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783332914&installation_id=136613492&pr_number=1072&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1072&signature=943bed9f0e2deb54996cda5af7f32cf88432eb14da933d0b691b312a83c629ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->