### PR TITLE
perf(relief): stop cloning loc into AttributeNode::new name_loc

### DIFF
--- a/crates/vize_relief/src/ast/elements.rs
+++ b/crates/vize_relief/src/ast/elements.rs
@@ -86,7 +86,7 @@ impl AttributeNode {
     pub fn new(name: impl Into<String>, loc: SourceLocation) -> Self {
         Self {
             name: name.into(),
-            name_loc: loc.clone(),
+            name_loc: SourceLocation::default(),
             value: None,
             loc,
         }


### PR DESCRIPTION
The sole caller overwrites name_loc on the next line, so the clone (which
heap-allocates for attribute spans >24 bytes) was dead. Initialize to the
empty SourceLocation stub instead.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

---
Part of the adversarially-verified non-compiler performance audit (round 2: 106 findings → 27 confirmed). Behavior-preserving: full workspace test suite green (3439 passed, 0 failed) and `vize fmt`/`lint` output byte-identical. This reduces real work (allocations / redundant parses / lock ops / O(offset) scans) on the component's hot path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1073"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783332917&installation_id=136613492&pr_number=1073&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1073&signature=2d7ffecdd25fffe752436bef3c8730a276cb81d90fffbe787aa1b9b1291a8631"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->