### PR TITLE
perf(maestro): build a LineIndex once per content for diagnostics + semantic tokens

### DIFF
--- a/crates/vize_maestro/src/ide/diagnostics.rs
+++ b/crates/vize_maestro/src/ide/diagnostics.rs
@@ -106,12 +106,17 @@ impl DiagnosticService {
             return diagnostics;
         }
 
+        // Build the line index once for this document. Every collector below
+        // maps byte offsets in `content` to (line, utf16_col) against it, so
+        // sharing one index avoids re-scanning the whole document per offset.
+        let line_index = LineIndex::new(&content);
+
         // Check if this is an Art file (*.art.vue)
         let path = uri.path();
         if path.ends_with(".art.vue") {
             // Musea-specific diagnostics for Art files
             if features.lint {
-                diagnostics.extend(Self::collect_musea_diagnostics(uri, &content));
+                diagnostics.extend(Self::collect_musea_diagnostics(uri, &content, &line_index));
             }
             // Don't return early here; async collection still adds Corsa diagnostics.
             return diagnostics;
@@ -125,6 +130,7 @@ impl DiagnosticService {
                     &content,
                     features.ecosystem,
                     &linter_config,
+                    &line_index,
                 );
                 tracing::info!(
                     "collect: standalone HTML patina lint diagnostics: {}",
@@ -149,12 +155,14 @@ impl DiagnosticService {
         // Collect parser diagnostics for script and template blocks before
         // dependent analyzers, so broken blocks do not fan out into noisy
         // lint/type/Corsa diagnostics.
-        let script_diags = Self::collect_script_diagnostics(uri, &content, &descriptor);
+        let script_diags =
+            Self::collect_script_diagnostics(uri, &content, &descriptor, &line_index);
         let has_script_parse_error = !script_diags.is_empty();
         tracing::info!("collect: script parser diagnostics: {}", script_diags.len());
         diagnostics.extend(script_diags);
 
-        let template_diags = Self::collect_template_diagnostics(uri, &content, &descriptor);
+        let template_diags =
+            Self::collect_template_diagnostics(uri, &content, &descriptor, &line_index);
         let has_template_parse_error = !template_diags.is_empty();
         tracing::info!(
             "collect: template parser diagnostics: {}",
@@ -169,7 +177,8 @@ impl DiagnosticService {
         // Surface Vue-specific compile errors (e.g. DEFINE_PROPS_DESTRUCTURE_DEFAULT_TYPE)
         // that the TypeScript checker cannot derive on its own. Mirrors the
         // canon path used by `vize check` so editor and CLI stay aligned.
-        let sfc_compile_diags = Self::collect_sfc_compile_diagnostics(uri, &content, &descriptor);
+        let sfc_compile_diags =
+            Self::collect_sfc_compile_diagnostics(uri, &content, &descriptor, &line_index);
         tracing::info!(
             "collect: sfc compile diagnostics: {}",
             sfc_compile_diags.len()
@@ -179,8 +188,13 @@ impl DiagnosticService {
         if features.lint {
             // Collect linter diagnostics (vize_patina)
             let linter_config = state.get_linter_config();
-            let lint_diags =
-                Self::collect_lint_diagnostics(uri, &content, features.ecosystem, &linter_config);
+            let lint_diags = Self::collect_lint_diagnostics(
+                uri,
+                &content,
+                features.ecosystem,
+                &linter_config,
+                &line_index,
+            );
             tracing::info!("collect: patina lint diagnostics: {}", lint_diags.len());
             diagnostics.extend(lint_diags);
             if features.cross_file {
@@ -219,7 +233,8 @@ impl DiagnosticService {
 
         // Also lint inline <art> blocks in regular .vue files
         if features.lint {
-            let inline_art_diags = Self::collect_inline_art_diagnostics(uri, &content, &descriptor);
+            let inline_art_diags =
+                Self::collect_inline_art_diagnostics(uri, &content, &descriptor, &line_index);
             tracing::info!(
                 "collect: inline art diagnostics: {}",
                 inline_art_diags.len()
@@ -254,10 +269,14 @@ impl DiagnosticService {
             return diagnostics;
         }
 
+        // Build the line index once for this document, shared by every
+        // collector below (mirrors `collect`).
+        let line_index = LineIndex::new(&content);
+
         // Art files (*.art.vue): Musea-specific lint only.
         let path = uri.path();
         if path.ends_with(".art.vue") {
-            diagnostics.extend(Self::collect_musea_diagnostics(uri, &content));
+            diagnostics.extend(Self::collect_musea_diagnostics(uri, &content, &line_index));
             return diagnostics;
         }
 
@@ -269,6 +288,7 @@ impl DiagnosticService {
                 &content,
                 features.ecosystem,
                 &linter_config,
+                &line_index,
             ));
             return diagnostics;
         }
@@ -279,9 +299,10 @@ impl DiagnosticService {
         let Ok(descriptor) = Self::parse_sfc_for_collect(uri, &content) else {
             return diagnostics;
         };
-        let has_block_parse_error = !Self::collect_script_diagnostics(uri, &content, &descriptor)
-            .is_empty()
-            || !Self::collect_template_diagnostics(uri, &content, &descriptor).is_empty();
+        let has_block_parse_error =
+            !Self::collect_script_diagnostics(uri, &content, &descriptor, &line_index).is_empty()
+                || !Self::collect_template_diagnostics(uri, &content, &descriptor, &line_index)
+                    .is_empty();
         if has_block_parse_error {
             return diagnostics;
         }
@@ -292,11 +313,13 @@ impl DiagnosticService {
             &content,
             features.ecosystem,
             &linter_config,
+            &line_index,
         ));
         diagnostics.extend(Self::collect_inline_art_diagnostics(
             uri,
             &content,
             &descriptor,
+            &line_index,
         ));
         diagnostics
     }
@@ -495,26 +518,78 @@ impl DiagnosticBuilder {
     }
 }
 
-/// Convert byte offset to (line, column) - both 0-indexed for LSP.
-pub(super) fn offset_to_line_col(source: &str, offset: usize) -> (u32, u32) {
-    let mut line = 0u32;
-    let mut col = 0u32;
-    let mut current_offset = 0;
+/// Precomputed byte offsets of every line start in a source string.
+///
+/// Building this once and reusing it turns the per-call O(offset) scan of
+/// [`offset_to_line_col`] into a binary search over line starts plus a short
+/// UTF-16 column scan within the target line. Callers that map many offsets
+/// against the same `content` (the diagnostics collectors, the semantic-token
+/// collectors) build it once and thread it through.
+///
+/// `line_col` reproduces [`offset_to_line_col`] byte-for-byte, including the
+/// UTF-16 code-unit column semantics LSP requires.
+pub(super) struct LineIndex<'a> {
+    source: &'a str,
+    /// Byte offset of the start of each line. `line_starts[0]` is always `0`.
+    line_starts: Vec<usize>,
+}
 
-    for ch in source.chars() {
-        if current_offset >= offset {
-            break;
+impl<'a> LineIndex<'a> {
+    /// Build a line index in a single pass over `source`.
+    pub(super) fn new(source: &'a str) -> Self {
+        let mut line_starts = Vec::with_capacity(source.len() / 32 + 1);
+        line_starts.push(0);
+        for (idx, byte) in source.bytes().enumerate() {
+            if byte == b'\n' {
+                line_starts.push(idx + 1);
+            }
         }
-        if ch == '\n' {
-            line += 1;
-            col = 0;
-        } else {
-            col += ch.len_utf16() as u32;
+        Self {
+            source,
+            line_starts,
         }
-        current_offset += ch.len_utf8();
     }
 
-    (line, col)
+    /// Convert a byte offset to (line, column), both 0-indexed for LSP.
+    ///
+    /// `column` is measured in UTF-16 code units, matching the editor's
+    /// coordinate system. Offsets past the end of the source are clamped,
+    /// matching the natural EOF behavior of the legacy scan.
+    pub(super) fn line_col(&self, offset: usize) -> (u32, u32) {
+        let offset = offset.min(self.source.len());
+
+        // Greatest line start <= offset.
+        let line = match self.line_starts.binary_search(&offset) {
+            Ok(line) => line,
+            Err(next) => next - 1,
+        };
+        let line_start = self.line_starts[line];
+
+        // Sum UTF-16 code units of every character on this line whose byte
+        // start is before `offset`. Bounded to the target line, and tolerant of
+        // an `offset` that falls mid-character (it counts the partial char,
+        // matching the legacy scan's break-at-top behavior) so it never panics.
+        let mut col = 0u32;
+        for (i, ch) in self.source[line_start..].char_indices() {
+            if line_start + i >= offset {
+                break;
+            }
+            col += ch.len_utf16() as u32;
+        }
+
+        (line as u32, col)
+    }
+}
+
+/// Convert byte offset to (line, column) - both 0-indexed for LSP.
+///
+/// Thin wrapper over [`LineIndex`] for single-shot callers. Hot paths that map
+/// many offsets against the same content build a [`LineIndex`] once and call
+/// [`LineIndex::line_col`] instead, so the only remaining caller is the parity
+/// unit test below.
+#[cfg(test)]
+pub(super) fn offset_to_line_col(source: &str, offset: usize) -> (u32, u32) {
+    LineIndex::new(source).line_col(offset)
 }
 
 #[cfg(test)]

--- a/crates/vize_maestro/src/ide/diagnostics/collectors.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/collectors.rs
@@ -16,12 +16,16 @@ use vize_atelier_sfc::SfcDescriptor;
 use vize_carton::config::LinterConfig;
 use vize_patina::{HelpRenderTarget, LintPreset, render_help};
 
-use super::{DiagnosticService, offset_to_line_col, sources};
+use super::{DiagnosticService, LineIndex, sources};
 use vize_carton::append;
 
 impl DiagnosticService {
     /// Collect diagnostics for Art files (*.art.vue) using vize_patina's MuseaLinter.
-    pub(super) fn collect_musea_diagnostics(uri: &Url, content: &str) -> Vec<Diagnostic> {
+    pub(super) fn collect_musea_diagnostics(
+        uri: &Url,
+        content: &str,
+        line_index: &LineIndex<'_>,
+    ) -> Vec<Diagnostic> {
         use vize_patina::rules::musea::MuseaLinter;
 
         let linter = MuseaLinter::new();
@@ -32,8 +36,8 @@ impl DiagnosticService {
             .into_iter()
             .map(|lint_diag| {
                 // Convert byte offset to line/column
-                let (start_line, start_col) = offset_to_line_col(content, lint_diag.start as usize);
-                let (end_line, end_col) = offset_to_line_col(content, lint_diag.end as usize);
+                let (start_line, start_col) = line_index.line_col(lint_diag.start as usize);
+                let (end_line, end_col) = line_index.line_col(lint_diag.end as usize);
 
                 // Build the diagnostic message with help text (render as plain text for LSP)
                 #[allow(clippy::disallowed_macros)]
@@ -85,6 +89,7 @@ impl DiagnosticService {
         _uri: &Url,
         content: &str,
         descriptor: &SfcDescriptor<'_>,
+        line_index: &LineIndex<'_>,
     ) -> Vec<Diagnostic> {
         use vize_patina::rules::musea::MuseaLinter;
 
@@ -122,9 +127,9 @@ impl DiagnosticService {
                 // Only process diagnostics that fall within the content area
                 if (lint_diag.start as usize) < art_tag_prefix_len {
                     // Diagnostic is on the <art> tag itself - map to the original tag
-                    let (start_line, start_col) = offset_to_line_col(content, custom.loc.tag_start);
+                    let (start_line, start_col) = line_index.line_col(custom.loc.tag_start);
                     let (end_line, end_col) =
-                        offset_to_line_col(content, custom.loc.tag_end.min(content.len()));
+                        line_index.line_col(custom.loc.tag_end.min(content.len()));
 
                     #[allow(clippy::disallowed_macros)]
                     let message = if let Some(ref help) = lint_diag.help {
@@ -167,10 +172,8 @@ impl DiagnosticService {
                     let sfc_start = block_content_start + content_relative_start;
                     let sfc_end = block_content_start + content_relative_end;
 
-                    let (start_line, start_col) =
-                        offset_to_line_col(content, sfc_start.min(content.len()));
-                    let (end_line, end_col) =
-                        offset_to_line_col(content, sfc_end.min(content.len()));
+                    let (start_line, start_col) = line_index.line_col(sfc_start.min(content.len()));
+                    let (end_line, end_col) = line_index.line_col(sfc_end.min(content.len()));
 
                     #[allow(clippy::disallowed_macros)]
                     let message = if let Some(ref help) = lint_diag.help {
@@ -255,8 +258,9 @@ impl DiagnosticService {
     /// Collect template parser diagnostics.
     pub(super) fn collect_template_diagnostics(
         _uri: &Url,
-        content: &str,
+        _content: &str,
         descriptor: &SfcDescriptor<'_>,
+        line_index: &LineIndex<'_>,
     ) -> Vec<Diagnostic> {
         let Some(ref template) = descriptor.template else {
             return vec![];
@@ -272,15 +276,14 @@ impl DiagnosticService {
 
                 // The template parser stores `line=1`/`column=byte_offset`
                 // today; translate via the byte `offset` plus the template
-                // block's position in the SFC. `offset_to_line_col` counts
+                // block's position in the SFC. `LineIndex::line_col` counts
                 // UTF-16 code units so the position lands at the right
                 // editor column for non-ASCII content. (#965)
                 let absolute_start_offset = template.loc.start as u32 + loc.start.offset;
                 let absolute_end_offset = template.loc.start as u32 + loc.end.offset;
                 let (start_line, start_character) =
-                    offset_to_line_col(content, absolute_start_offset as usize);
-                let (end_line, end_character) =
-                    offset_to_line_col(content, absolute_end_offset as usize);
+                    line_index.line_col(absolute_start_offset as usize);
+                let (end_line, end_character) = line_index.line_col(absolute_end_offset as usize);
 
                 Some(Diagnostic {
                     range: Range {
@@ -313,6 +316,7 @@ impl DiagnosticService {
         _uri: &Url,
         content: &str,
         descriptor: &SfcDescriptor<'_>,
+        line_index: &LineIndex<'_>,
     ) -> Vec<Diagnostic> {
         let Some(script_setup) = descriptor.script_setup.as_ref() else {
             return Vec::new();
@@ -344,7 +348,7 @@ impl DiagnosticService {
             // Fall back to the start of the most relevant block so the
             // diagnostic lands somewhere clickable in the editor.
             let (offset, _block) = sfc_block_fallback_offset(descriptor);
-            let (line, column) = offset_to_line_col(content, offset);
+            let (line, column) = line_index.line_col(offset);
             Range {
                 start: Position {
                     line,
@@ -380,14 +384,15 @@ impl DiagnosticService {
     /// Collect script parser diagnostics.
     pub(super) fn collect_script_diagnostics(
         _uri: &Url,
-        content: &str,
+        _content: &str,
         descriptor: &SfcDescriptor<'_>,
+        line_index: &LineIndex<'_>,
     ) -> Vec<Diagnostic> {
         let mut diagnostics = Vec::new();
 
         if let Some(ref script) = descriptor.script {
             diagnostics.extend(collect_script_block_diagnostics(
-                content,
+                line_index,
                 &script.content,
                 script.loc.start,
                 script.lang.as_deref(),
@@ -396,7 +401,7 @@ impl DiagnosticService {
 
         if let Some(ref script_setup) = descriptor.script_setup {
             diagnostics.extend(collect_script_block_diagnostics(
-                content,
+                line_index,
                 &script_setup.content,
                 script_setup.loc.start,
                 script_setup.lang.as_deref(),
@@ -412,6 +417,7 @@ impl DiagnosticService {
         content: &str,
         ecosystem_enabled: bool,
         linter_config: &LinterConfig,
+        line_index: &LineIndex<'_>,
     ) -> Vec<Diagnostic> {
         if !linter_config.enabled {
             return vec![];
@@ -459,8 +465,8 @@ impl DiagnosticService {
             .map(|lint_diag| {
                 // Convert byte offsets directly in the SFC. vize_patina::lint_sfc
                 // already maps template diagnostics back to source coordinates.
-                let (start_line, start_col) = offset_to_line_col(content, lint_diag.start as usize);
-                let (end_line, end_col) = offset_to_line_col(content, lint_diag.end as usize);
+                let (start_line, start_col) = line_index.line_col(lint_diag.start as usize);
+                let (end_line, end_col) = line_index.line_col(lint_diag.end as usize);
 
                 // Build the diagnostic message with help text (render as plain text for LSP)
                 #[allow(clippy::disallowed_macros)]
@@ -559,7 +565,7 @@ fn collect_define_art_source_diagnostics(uri: &Url, content: &str) -> Vec<Diagno
 }
 
 fn collect_script_block_diagnostics(
-    sfc_content: &str,
+    line_index: &LineIndex<'_>,
     script_content: &str,
     script_offset: usize,
     lang: Option<&str>,
@@ -578,8 +584,8 @@ fn collect_script_block_diagnostics(
             let (local_start, local_end) = diagnostic_span(error, script_content.len());
             let start = script_offset + local_start;
             let end = script_offset + local_end;
-            let (start_line, start_col) = offset_to_line_col(sfc_content, start);
-            let (end_line, end_col) = offset_to_line_col(sfc_content, end);
+            let (start_line, start_col) = line_index.line_col(start);
+            let (end_line, end_col) = line_index.line_col(end);
 
             Diagnostic {
                 range: Range {

--- a/crates/vize_maestro/src/ide/semantic_tokens.rs
+++ b/crates/vize_maestro/src/ide/semantic_tokens.rs
@@ -19,11 +19,130 @@ use tower_lsp::lsp_types::{
     Range, SemanticTokens, SemanticTokensRangeResult, SemanticTokensResult,
 };
 
-use encoding::{encode_tokens, offset_to_line_col, utf16_len};
+use encoding::{LineIndex, encode_tokens, utf16_len};
 use types::AbsoluteToken;
 
 /// Semantic tokens service.
 pub struct SemanticTokensService;
+
+/// Art-specific attribute names highlighted as `name="value"` in `.art.vue`
+/// files. Combines the `<art>` block attributes with the `<variant>` block
+/// attributes (including the valued `default="..."` form). Built once as a
+/// `const` instead of allocating a `format!("{name}=")` string per attribute
+/// on every request.
+///
+/// Invariant: no entry is a suffix of another, so at most one name matches a
+/// given `=`. This keeps the single-pass scan equivalent to the previous
+/// per-attribute `content.find` loops.
+const ART_FILE_ATTR_NAMES: &[&str] = &[
+    "title",
+    "description",
+    "component",
+    "category",
+    "tags",
+    "status",
+    "order",
+    "name",
+    "default",
+    "args",
+    "viewport",
+    "skip-vrt",
+];
+
+/// Art-specific attribute names highlighted as `name="value"` in inline
+/// `<art>` blocks of regular `.vue` files. Unlike [`ART_FILE_ATTR_NAMES`],
+/// the inline path never treats `default="..."` as a valued attribute (it is
+/// only ever highlighted as a boolean modifier), matching prior behavior.
+const INLINE_ART_ATTR_NAMES: &[&str] = &[
+    "title",
+    "description",
+    "component",
+    "category",
+    "tags",
+    "status",
+    "order",
+    "name",
+    "args",
+    "viewport",
+    "skip-vrt",
+];
+
+/// Scan `slice` once for `name="value"` art attributes, emitting a `Property`
+/// token for each known attribute name preceded by whitespace and a `String`
+/// token for its quoted value. `range_start` is the byte offset of `slice`
+/// within the document `line_index` was built for (0 when `slice` is the whole
+/// document).
+///
+/// This collapses the previous N full `slice.find("{name}=")` scans (one per
+/// attribute) into a single pass over the `=` bytes: on each `=` it looks
+/// backward for a known attribute name from `attr_names`. Because no attribute
+/// name is a suffix of another, at most one name matches a given `=`, so the
+/// emitted token set is identical to the per-attribute loops.
+fn collect_named_attribute_tokens(
+    slice: &str,
+    range_start: usize,
+    attr_names: &[&str],
+    line_index: &LineIndex<'_>,
+    tokens: &mut Vec<AbsoluteToken>,
+) {
+    let bytes = slice.as_bytes();
+    for (eq, &byte) in bytes.iter().enumerate() {
+        if byte != b'=' {
+            continue;
+        }
+
+        for attr in attr_names {
+            let len = attr.len();
+            // Attribute name must end exactly at `=` and have a whitespace
+            // character before it (so `eq` must be at least `len + 1`).
+            if eq < len + 1 {
+                continue;
+            }
+            let name_start = eq - len;
+            // Compare bytes (attribute names are ASCII) so a `name_start` that
+            // happens to fall inside a multi-byte UTF-8 character never panics
+            // the way string slicing would; non-matching bytes simply skip.
+            if &bytes[name_start..eq] != attr.as_bytes() {
+                continue;
+            }
+            let before = bytes[name_start - 1];
+            if before != b' ' && before != b'\n' && before != b'\t' {
+                continue;
+            }
+
+            // Highlight attribute name.
+            let (line, col) = line_index.line_col(range_start + name_start);
+            tokens.push(AbsoluteToken {
+                line,
+                start: col,
+                length: utf16_len(attr),
+                token_type: TokenType::Property as u32,
+                modifiers: 0,
+            });
+
+            // Highlight quoted string value, if present.
+            let value_start = eq + 1; // after `=`
+            if value_start < slice.len() {
+                let quote_char = bytes[value_start];
+                if (quote_char == b'"' || quote_char == b'\'')
+                    && let Some(end) = slice[value_start + 1..].find(quote_char as char)
+                {
+                    let (val_line, val_col) = line_index.line_col(range_start + value_start);
+                    tokens.push(AbsoluteToken {
+                        line: val_line,
+                        start: val_col,
+                        length: utf16_len(&slice[value_start..value_start + end + 2]),
+                        token_type: TokenType::String as u32,
+                        modifiers: 0,
+                    });
+                }
+            }
+
+            // At most one attribute name matches a given `=`.
+            break;
+        }
+    }
+}
 
 fn token_overlaps_range(token: &AbsoluteToken, range: Range) -> bool {
     if token.line < range.start.line || token.line > range.end.line {
@@ -128,10 +247,19 @@ impl SemanticTokensService {
             );
         }
 
-        // Collect tokens from inline <art> custom blocks
-        for custom in &descriptor.custom_blocks {
-            if custom.block_type == "art" {
-                Self::collect_inline_art_tokens(content, &mut tokens, &custom.loc);
+        // Collect tokens from inline <art> custom blocks. Build the line index
+        // once and share it across every art block instead of re-scanning the
+        // document per offset.
+        let has_art_block = descriptor
+            .custom_blocks
+            .iter()
+            .any(|custom| custom.block_type == "art");
+        if has_art_block {
+            let line_index = LineIndex::new(content);
+            for custom in &descriptor.custom_blocks {
+                if custom.block_type == "art" {
+                    Self::collect_inline_art_tokens(content, &mut tokens, &custom.loc, &line_index);
+                }
             }
         }
 
@@ -144,12 +272,15 @@ impl SemanticTokensService {
     fn collect_art_tokens(content: &str) -> Vec<AbsoluteToken> {
         let mut tokens: Vec<AbsoluteToken> = Vec::new();
 
+        // Build the line index once and share it across every collector below.
+        let line_index = LineIndex::new(content);
+
         // Collect Art-specific tokens
-        Self::collect_art_block_tokens(content, &mut tokens);
-        Self::collect_variant_block_tokens(content, &mut tokens);
-        Self::collect_art_attribute_tokens(content, &mut tokens);
-        Self::collect_art_variant_template_tokens(content, &mut tokens);
-        Self::collect_art_script_tokens(content, &mut tokens);
+        Self::collect_art_block_tokens(content, &mut tokens, &line_index);
+        Self::collect_variant_block_tokens(content, &mut tokens, &line_index);
+        Self::collect_art_attribute_tokens(content, &mut tokens, &line_index);
+        Self::collect_art_variant_template_tokens(content, &mut tokens, &line_index);
+        Self::collect_art_script_tokens(content, &mut tokens, &line_index);
 
         // Sort by position
         tokens.sort_by_key(|token| (token.line, token.start));
@@ -158,7 +289,11 @@ impl SemanticTokensService {
     }
 
     /// Collect <art> and </art> tag tokens.
-    fn collect_art_block_tokens(content: &str, tokens: &mut Vec<AbsoluteToken>) {
+    fn collect_art_block_tokens(
+        content: &str,
+        tokens: &mut Vec<AbsoluteToken>,
+        line_index: &LineIndex<'_>,
+    ) {
         // Find <art ...> opening tags
         let mut pos = 0;
         while let Some(start) = content[pos..].find("<art") {
@@ -172,7 +307,7 @@ impl SemanticTokensService {
                     || next_char == b'\t'
                     || next_char == b'>'
                 {
-                    let (line, col) = offset_to_line_col(content, abs_start);
+                    let (line, col) = line_index.line_col(abs_start);
                     tokens.push(AbsoluteToken {
                         line,
                         start: col,
@@ -189,7 +324,7 @@ impl SemanticTokensService {
         pos = 0;
         while let Some(start) = content[pos..].find("</art>") {
             let abs_start = pos + start;
-            let (line, col) = offset_to_line_col(content, abs_start);
+            let (line, col) = line_index.line_col(abs_start);
             tokens.push(AbsoluteToken {
                 line,
                 start: col,
@@ -202,7 +337,11 @@ impl SemanticTokensService {
     }
 
     /// Collect <variant> and </variant> tag tokens.
-    fn collect_variant_block_tokens(content: &str, tokens: &mut Vec<AbsoluteToken>) {
+    fn collect_variant_block_tokens(
+        content: &str,
+        tokens: &mut Vec<AbsoluteToken>,
+        line_index: &LineIndex<'_>,
+    ) {
         // Find <variant ...> opening tags
         let mut pos = 0;
         while let Some(start) = content[pos..].find("<variant") {
@@ -215,7 +354,7 @@ impl SemanticTokensService {
                     || next_char == b'\t'
                     || next_char == b'>'
                 {
-                    let (line, col) = offset_to_line_col(content, abs_start);
+                    let (line, col) = line_index.line_col(abs_start);
                     tokens.push(AbsoluteToken {
                         line,
                         start: col,
@@ -232,7 +371,7 @@ impl SemanticTokensService {
         pos = 0;
         while let Some(start) = content[pos..].find("</variant>") {
             let abs_start = pos + start;
-            let (line, col) = offset_to_line_col(content, abs_start);
+            let (line, col) = line_index.line_col(abs_start);
             tokens.push(AbsoluteToken {
                 line,
                 start: col,
@@ -245,66 +384,15 @@ impl SemanticTokensService {
     }
 
     /// Collect Art-specific attribute tokens.
-    fn collect_art_attribute_tokens(content: &str, tokens: &mut Vec<AbsoluteToken>) {
-        // Art block attributes
-        let art_attrs = [
-            "title",
-            "description",
-            "component",
-            "category",
-            "tags",
-            "status",
-            "order",
-        ];
-        // Variant block attributes
-        let variant_attrs = ["name", "default", "args", "viewport", "skip-vrt"];
-
-        // Find attributes and their values
-        for attr in art_attrs.iter().chain(variant_attrs.iter()) {
-            #[allow(clippy::disallowed_macros)]
-            let pattern_eq = format!("{}=", attr);
-            let mut pos = 0;
-            while let Some(start) = content[pos..].find(pattern_eq.as_str()) {
-                let abs_start = pos + start;
-
-                // Check if preceded by whitespace (attribute context)
-                if abs_start > 0 {
-                    let before = content.as_bytes()[abs_start - 1];
-                    if before == b' ' || before == b'\n' || before == b'\t' {
-                        let (line, col) = offset_to_line_col(content, abs_start);
-
-                        // Highlight attribute name
-                        tokens.push(AbsoluteToken {
-                            line,
-                            start: col,
-                            length: utf16_len(attr),
-                            token_type: TokenType::Property as u32,
-                            modifiers: 0,
-                        });
-
-                        // Find and highlight string value
-                        let value_start = abs_start + attr.len() + 1; // after =
-                        if value_start < content.len() {
-                            let quote_char = content.as_bytes()[value_start];
-                            if (quote_char == b'"' || quote_char == b'\'')
-                                && let Some(end) =
-                                    content[value_start + 1..].find(quote_char as char)
-                            {
-                                let (val_line, val_col) = offset_to_line_col(content, value_start);
-                                tokens.push(AbsoluteToken {
-                                    line: val_line,
-                                    start: val_col,
-                                    length: utf16_len(&content[value_start..value_start + end + 2]),
-                                    token_type: TokenType::String as u32,
-                                    modifiers: 0,
-                                });
-                            }
-                        }
-                    }
-                }
-                pos = abs_start + attr.len();
-            }
-        }
+    fn collect_art_attribute_tokens(
+        content: &str,
+        tokens: &mut Vec<AbsoluteToken>,
+        line_index: &LineIndex<'_>,
+    ) {
+        // Find attributes and their values in a single pass (see
+        // `collect_named_attribute_tokens`). `content` is the whole document,
+        // so the slice offset is 0.
+        collect_named_attribute_tokens(content, 0, ART_FILE_ATTR_NAMES, line_index, tokens);
 
         // Highlight 'default' as boolean attribute (no value)
         let mut pos = 0;
@@ -321,7 +409,7 @@ impl SemanticTokensService {
                     || after == b'\t'
                     || after == b'/'
                 {
-                    let (line, col) = offset_to_line_col(content, abs_start);
+                    let (line, col) = line_index.line_col(abs_start);
                     tokens.push(AbsoluteToken {
                         line,
                         start: col,
@@ -336,7 +424,11 @@ impl SemanticTokensService {
     }
 
     /// Collect Vue template semantic tokens from each `<variant>` body in an `.art.vue` file.
-    fn collect_art_variant_template_tokens(content: &str, tokens: &mut Vec<AbsoluteToken>) {
+    fn collect_art_variant_template_tokens(
+        content: &str,
+        tokens: &mut Vec<AbsoluteToken>,
+        line_index: &LineIndex<'_>,
+    ) {
         let allocator = vize_carton::Bump::new();
         let Ok(art_desc) =
             vize_musea::parse_art(&allocator, content, vize_musea::ArtParseOptions::default())
@@ -345,7 +437,7 @@ impl SemanticTokensService {
         };
 
         for variant in art_desc.variants.iter() {
-            Self::collect_template_slice_tokens(content, variant.template, tokens);
+            Self::collect_template_slice_tokens(content, variant.template, tokens, line_index);
         }
     }
 
@@ -353,6 +445,7 @@ impl SemanticTokensService {
         full_content: &str,
         template_slice: &str,
         tokens: &mut Vec<AbsoluteToken>,
+        line_index: &LineIndex<'_>,
     ) {
         if template_slice.trim().is_empty() {
             return;
@@ -367,7 +460,7 @@ impl SemanticTokensService {
             return;
         }
 
-        let (base_line, base_col) = offset_to_line_col(full_content, start_offset);
+        let (base_line, base_col) = line_index.line_col(start_offset);
         let mut local_tokens = Vec::new();
         template::collect_template_tokens(template_slice, 0, &mut local_tokens);
 
@@ -381,7 +474,11 @@ impl SemanticTokensService {
     }
 
     /// Collect tokens from script in Art files.
-    fn collect_art_script_tokens(content: &str, tokens: &mut Vec<AbsoluteToken>) {
+    fn collect_art_script_tokens(
+        content: &str,
+        tokens: &mut Vec<AbsoluteToken>,
+        line_index: &LineIndex<'_>,
+    ) {
         // Find script setup block
         if let Some(script_start) = content.find("<script")
             && let Some(script_end) = content[script_start..].find("</script>")
@@ -400,7 +497,7 @@ impl SemanticTokensService {
                 let mut pos = 0;
                 while let Some(start) = script_content[pos..].find("import ") {
                     let abs_start = base_offset + pos + start;
-                    let (line, col) = offset_to_line_col(content, abs_start);
+                    let (line, col) = line_index.line_col(abs_start);
                     tokens.push(AbsoluteToken {
                         line,
                         start: col,
@@ -415,7 +512,7 @@ impl SemanticTokensService {
                 pos = 0;
                 while let Some(start) = script_content[pos..].find(" from ") {
                     let abs_start = base_offset + pos + start + 1; // skip leading space
-                    let (line, col) = offset_to_line_col(content, abs_start);
+                    let (line, col) = line_index.line_col(abs_start);
                     tokens.push(AbsoluteToken {
                         line,
                         start: col,
@@ -436,7 +533,7 @@ impl SemanticTokensService {
                         let after_quote = &remaining[start + 1..];
                         if let Some(end) = after_quote.find(quote_char as char) {
                             let abs_start = base_offset + pos + start;
-                            let (line, col) = offset_to_line_col(content, abs_start);
+                            let (line, col) = line_index.line_col(abs_start);
                             tokens.push(AbsoluteToken {
                                 line,
                                 start: col,
@@ -464,6 +561,7 @@ impl SemanticTokensService {
         content: &str,
         tokens: &mut Vec<AbsoluteToken>,
         loc: &vize_atelier_sfc::BlockLocation,
+        line_index: &LineIndex<'_>,
     ) {
         let range_start = loc.tag_start;
         let range_end = loc.end;
@@ -489,7 +587,7 @@ impl SemanticTokensService {
                         || next_char == b'\t'
                         || next_char == b'>'
                     {
-                        let (line, col) = offset_to_line_col(content, abs_pos);
+                        let (line, col) = line_index.line_col(abs_pos);
                         tokens.push(AbsoluteToken {
                             line,
                             start: col,
@@ -505,7 +603,7 @@ impl SemanticTokensService {
             pos = 0;
             while let Some(start) = slice[pos..].find("</art>") {
                 let abs_pos = range_start + pos + start;
-                let (line, col) = offset_to_line_col(content, abs_pos);
+                let (line, col) = line_index.line_col(abs_pos);
                 tokens.push(AbsoluteToken {
                     line,
                     start: col,
@@ -530,7 +628,7 @@ impl SemanticTokensService {
                         || next_char == b'\t'
                         || next_char == b'>'
                     {
-                        let (line, col) = offset_to_line_col(content, abs_pos);
+                        let (line, col) = line_index.line_col(abs_pos);
                         tokens.push(AbsoluteToken {
                             line,
                             start: col,
@@ -546,7 +644,7 @@ impl SemanticTokensService {
             pos = 0;
             while let Some(start) = slice[pos..].find("</variant>") {
                 let abs_pos = range_start + pos + start;
-                let (line, col) = offset_to_line_col(content, abs_pos);
+                let (line, col) = line_index.line_col(abs_pos);
                 tokens.push(AbsoluteToken {
                     line,
                     start: col,
@@ -558,61 +656,16 @@ impl SemanticTokensService {
             }
         }
 
-        // Collect art-specific attribute tokens in the slice
-        let art_attrs = [
-            "title",
-            "description",
-            "component",
-            "category",
-            "tags",
-            "status",
-            "order",
-        ];
-        let variant_attrs = ["name", "args", "viewport", "skip-vrt"];
-
-        for attr in art_attrs.iter().chain(variant_attrs.iter()) {
-            #[allow(clippy::disallowed_macros)]
-            let pattern_eq = format!("{}=", attr);
-            let mut pos = 0;
-            while let Some(start) = slice[pos..].find(pattern_eq.as_str()) {
-                let rel_pos = pos + start;
-                let abs_pos = range_start + rel_pos;
-
-                if rel_pos > 0 {
-                    let before = slice.as_bytes()[rel_pos - 1];
-                    if before == b' ' || before == b'\n' || before == b'\t' {
-                        let (line, col) = offset_to_line_col(content, abs_pos);
-                        tokens.push(AbsoluteToken {
-                            line,
-                            start: col,
-                            length: utf16_len(attr),
-                            token_type: TokenType::Property as u32,
-                            modifiers: 0,
-                        });
-
-                        // Highlight string value
-                        let value_start = rel_pos + attr.len() + 1;
-                        if value_start < slice.len() {
-                            let quote_char = slice.as_bytes()[value_start];
-                            if (quote_char == b'"' || quote_char == b'\'')
-                                && let Some(end) = slice[value_start + 1..].find(quote_char as char)
-                            {
-                                let abs_val = range_start + value_start;
-                                let (val_line, val_col) = offset_to_line_col(content, abs_val);
-                                tokens.push(AbsoluteToken {
-                                    line: val_line,
-                                    start: val_col,
-                                    length: utf16_len(&slice[value_start..value_start + end + 2]),
-                                    token_type: TokenType::String as u32,
-                                    modifiers: 0,
-                                });
-                            }
-                        }
-                    }
-                }
-                pos = rel_pos + attr.len();
-            }
-        }
+        // Collect art-specific attribute tokens in the slice in a single pass
+        // (see `collect_named_attribute_tokens`). Inline blocks never treat
+        // `default="..."` as a valued attribute, so use `INLINE_ART_ATTR_NAMES`.
+        collect_named_attribute_tokens(
+            slice,
+            range_start,
+            INLINE_ART_ATTR_NAMES,
+            line_index,
+            tokens,
+        );
 
         // Highlight 'default' boolean attribute
         {
@@ -630,7 +683,7 @@ impl SemanticTokensService {
                         || after == b'\t'
                         || after == b'/'
                     {
-                        let (line, col) = offset_to_line_col(content, abs_pos);
+                        let (line, col) = line_index.line_col(abs_pos);
                         tokens.push(AbsoluteToken {
                             line,
                             start: col,
@@ -666,7 +719,7 @@ impl SemanticTokensService {
             }
 
             let absolute_start = range_start + relative_start;
-            let (base_line, base_col) = offset_to_line_col(content, absolute_start);
+            let (base_line, base_col) = line_index.line_col(absolute_start);
             let mut local_tokens = Vec::new();
             template::collect_template_tokens(variant.template, 0, &mut local_tokens);
 
@@ -684,8 +737,8 @@ impl SemanticTokensService {
 #[cfg(test)]
 mod tests {
     use super::{
-        SemanticTokensService, TokenModifier, TokenType, encoding::offset_to_line_col, expressions,
-        template,
+        LineIndex, SemanticTokensService, TokenModifier, TokenType, encoding::offset_to_line_col,
+        expressions, template,
     };
     use tower_lsp::lsp_types::{
         Position, Range, SemanticToken, SemanticTokensRangeResult, SemanticTokensResult,
@@ -808,7 +861,8 @@ import Button from './Button.vue'
     fn test_art_block_tokens() {
         let content = "<art title=\"Test\">\n</art>";
         let mut tokens = Vec::new();
-        SemanticTokensService::collect_art_block_tokens(content, &mut tokens);
+        let line_index = LineIndex::new(content);
+        SemanticTokensService::collect_art_block_tokens(content, &mut tokens, &line_index);
 
         // Should find <art and </art>
         assert_eq!(tokens.len(), 2);
@@ -820,7 +874,8 @@ import Button from './Button.vue'
     fn test_variant_block_tokens() {
         let content = "<variant name=\"Primary\">\n</variant>";
         let mut tokens = Vec::new();
-        SemanticTokensService::collect_variant_block_tokens(content, &mut tokens);
+        let line_index = LineIndex::new(content);
+        SemanticTokensService::collect_variant_block_tokens(content, &mut tokens, &line_index);
 
         // Should find <variant and </variant>
         assert_eq!(tokens.len(), 2);
@@ -832,7 +887,8 @@ import Button from './Button.vue'
     fn test_art_attribute_tokens() {
         let content = r#"<art title="Button" component="./Button.vue">"#;
         let mut tokens = Vec::new();
-        SemanticTokensService::collect_art_attribute_tokens(content, &mut tokens);
+        let line_index = LineIndex::new(content);
+        SemanticTokensService::collect_art_attribute_tokens(content, &mut tokens, &line_index);
 
         // Should find title, "Button", component, "./Button.vue"
         assert!(tokens.len() >= 4);
@@ -846,7 +902,12 @@ import Button from './Button.vue'
   </variant>
 </art>"#;
         let mut tokens = Vec::new();
-        SemanticTokensService::collect_art_variant_template_tokens(content, &mut tokens);
+        let line_index = LineIndex::new(content);
+        SemanticTokensService::collect_art_variant_template_tokens(
+            content,
+            &mut tokens,
+            &line_index,
+        );
 
         assert!(
             tokens
@@ -874,7 +935,8 @@ import Button from './Button.vue'
 import Button from './Button.vue'
 </script>"#;
         let mut tokens = Vec::new();
-        SemanticTokensService::collect_art_script_tokens(content, &mut tokens);
+        let line_index = LineIndex::new(content);
+        SemanticTokensService::collect_art_script_tokens(content, &mut tokens, &line_index);
 
         // Should find import, from, and string literal
         assert!(tokens.len() >= 3);

--- a/crates/vize_maestro/src/ide/semantic_tokens/encoding.rs
+++ b/crates/vize_maestro/src/ide/semantic_tokens/encoding.rs
@@ -6,26 +6,74 @@ use tower_lsp::lsp_types::SemanticToken;
 
 use super::types::AbsoluteToken;
 
-/// Convert byte offset to (line, column), both 0-indexed for LSP.
-pub(crate) fn offset_to_line_col(source: &str, offset: usize) -> (u32, u32) {
-    let mut line = 0u32;
-    let mut col = 0u32;
-    let mut current = 0;
+/// Precomputed byte offsets of every line start in a source string.
+///
+/// Building this once and reusing it turns the per-call O(offset) scan of
+/// [`offset_to_line_col`] into a binary search over line starts plus a short
+/// UTF-16 column scan within the target line. Token collectors that map many
+/// offsets against the same `content` build it once and thread it through.
+///
+/// `line_col` reproduces [`offset_to_line_col`] byte-for-byte, including the
+/// UTF-16 code-unit column semantics LSP requires.
+pub(crate) struct LineIndex<'a> {
+    source: &'a str,
+    /// Byte offset of the start of each line. `line_starts[0]` is always `0`.
+    line_starts: Vec<usize>,
+}
 
-    for ch in source.chars() {
-        if current >= offset {
-            break;
+impl<'a> LineIndex<'a> {
+    /// Build a line index in a single pass over `source`.
+    pub(crate) fn new(source: &'a str) -> Self {
+        let mut line_starts = Vec::with_capacity(source.len() / 32 + 1);
+        line_starts.push(0);
+        for (idx, byte) in source.bytes().enumerate() {
+            if byte == b'\n' {
+                line_starts.push(idx + 1);
+            }
         }
-        if ch == '\n' {
-            line += 1;
-            col = 0;
-        } else {
-            col += ch.len_utf16() as u32;
+        Self {
+            source,
+            line_starts,
         }
-        current += ch.len_utf8();
     }
 
-    (line, col)
+    /// Convert a byte offset to (line, column), both 0-indexed for LSP.
+    ///
+    /// `column` is measured in UTF-16 code units. Offsets past the end of the
+    /// source are clamped, matching the natural EOF behavior of the legacy scan.
+    pub(crate) fn line_col(&self, offset: usize) -> (u32, u32) {
+        let offset = offset.min(self.source.len());
+
+        // Greatest line start <= offset.
+        let line = match self.line_starts.binary_search(&offset) {
+            Ok(line) => line,
+            Err(next) => next - 1,
+        };
+        let line_start = self.line_starts[line];
+
+        // Sum UTF-16 code units of every character on this line whose byte
+        // start is before `offset`. Bounded to the target line, and tolerant of
+        // an `offset` that falls mid-character (it counts the partial char,
+        // matching the legacy scan's break-at-top behavior) so it never panics.
+        let mut col = 0u32;
+        for (i, ch) in self.source[line_start..].char_indices() {
+            if line_start + i >= offset {
+                break;
+            }
+            col += ch.len_utf16() as u32;
+        }
+
+        (line as u32, col)
+    }
+}
+
+/// Convert byte offset to (line, column), both 0-indexed for LSP.
+///
+/// Thin wrapper over [`LineIndex`] for single-shot callers. Hot paths that map
+/// many offsets against the same content should build a [`LineIndex`] once and
+/// call [`LineIndex::line_col`] instead.
+pub(crate) fn offset_to_line_col(source: &str, offset: usize) -> (u32, u32) {
+    LineIndex::new(source).line_col(offset)
 }
 
 /// Return the LSP token length for text, measured in UTF-16 code units.


### PR DESCRIPTION
offset_to_line_col walked source.chars() from byte 0 (O(offset)), invoked
~2x per diagnostic and ~1x per token, re-scanning the whole document tens to
hundreds of times per keystroke. Build a LineIndex once and binary-search +
short in-line UTF-16 scan instead. Also collapse the per-attribute format!()
+ ~12 full-content scans in the art token collectors into static patterns and
a single backward-lookup pass. UTF-16 columns identical.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

---
Part of the adversarially-verified non-compiler performance audit (round 2: 106 findings → 27 confirmed). Behavior-preserving: full workspace test suite green (3439 passed, 0 failed) and `vize fmt`/`lint` output byte-identical. This reduces real work (allocations / redundant parses / lock ops / O(offset) scans) on the component's hot path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1074"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783332919&installation_id=136613492&pr_number=1074&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1074&signature=cf9a31e36d5ffb59a20a99d7c2a0272b489570094131f269cdb163eea5bef9d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->