### PR TITLE
perf(maestro): reuse already-materialized document content across LSP handlers

### DIFF
--- a/crates/vize_maestro/src/ide.rs
+++ b/crates/vize_maestro/src/ide.rs
@@ -393,10 +393,27 @@ pub struct IdeContext<'a> {
 
 impl<'a> IdeContext<'a> {
     /// Create a new IDE context.
+    ///
+    /// This re-fetches the document from the store and materializes its content.
+    /// Callers that have already materialized the document content should prefer
+    /// [`IdeContext::with_content`] to avoid a redundant document lookup and a
+    /// second full Rope→String allocation.
     pub fn new(state: &'a ServerState, uri: &'a Url, offset: usize) -> Option<Self> {
-        let doc = state.documents.get(uri)?;
-        let content = doc.text();
+        let content = state.documents.get(uri)?.text();
+        Some(Self::with_content(state, uri, offset, content))
+    }
 
+    /// Create a new IDE context from already-materialized document content.
+    ///
+    /// Reuses the provided `content` instead of re-reading the document from the
+    /// store, avoiding a redundant `DashMap` lookup and a second full
+    /// Rope→String allocation per request.
+    pub fn with_content(
+        state: &'a ServerState,
+        uri: &'a Url,
+        offset: usize,
+        content: String,
+    ) -> Self {
         // Determine block type
         let block_type = if uri.path().ends_with(".art.vue") {
             // For art files, use art-specific block detection
@@ -418,14 +435,14 @@ impl<'a> IdeContext<'a> {
 
         let virtual_docs = state.get_virtual_docs(uri);
 
-        Some(Self {
+        Self {
             state,
             uri,
             content,
             offset,
             block_type,
             virtual_docs,
-        })
+        }
     }
 
     /// Check if cursor is in template block.

--- a/crates/vize_maestro/src/ide/completion/template.rs
+++ b/crates/vize_maestro/src/ide/completion/template.rs
@@ -908,15 +908,12 @@ fn art_component_path(ctx: &IdeContext<'_>, component_name: &str) -> Option<Stri
     )
     .ok()?;
     let component_path = art_desc.metadata.component?;
-    if let Ok(descriptor) = vize_atelier_sfc::parse_sfc(
-        &ctx.content,
-        vize_atelier_sfc::SfcParseOptions {
-            filename: ctx.uri.path().to_string().into(),
-            ..Default::default()
-        },
-    ) && let Some(script_setup) = descriptor.script_setup.as_ref()
+    // Reuse the script_setup already extracted by `parse_art` above instead of
+    // re-parsing the whole buffer with `parse_sfc` just to read the defineArt
+    // component name.
+    if let Some(script_setup) = art_desc.script_setup.as_ref()
         && let Some(defined_component) =
-            crate::virtual_code::find_define_art_component_name(script_setup.content.as_ref())
+            crate::virtual_code::find_define_art_component_name(script_setup.content)
     {
         let pascal_component = kebab_to_pascal(component_name);
         if component_name == defined_component || pascal_component == defined_component {

--- a/crates/vize_maestro/src/server/handlers.rs
+++ b/crates/vize_maestro/src/server/handlers.rs
@@ -154,22 +154,18 @@ impl LanguageServer for MaestroServer {
             return Ok(None);
         };
 
-        let mut hover_result: Option<Hover> = None;
+        let ctx = IdeContext::with_content(&self.state, uri, offset, content);
 
-        if let Some(ctx) = IdeContext::new(&self.state, uri, offset) {
-            #[cfg(feature = "native")]
-            {
-                let corsa_bridge = self.state.get_corsa_bridge().await;
-                hover_result = HoverService::hover_with_corsa(&ctx, corsa_bridge).await;
-            }
+        #[cfg(feature = "native")]
+        let mut hover_result: Option<Hover> = {
+            let corsa_bridge = self.state.get_corsa_bridge().await;
+            HoverService::hover_with_corsa(&ctx, corsa_bridge).await
+        };
 
-            #[cfg(not(feature = "native"))]
-            {
-                hover_result = HoverService::hover(&ctx);
-            }
-        }
+        #[cfg(not(feature = "native"))]
+        let mut hover_result: Option<Hover> = HoverService::hover(&ctx);
 
-        let lint_hover = self.get_lint_hover_at_position(uri, &content, position);
+        let lint_hover = self.get_lint_hover_at_position(uri, &ctx.content, position);
         if let Some(lint_info) = lint_hover {
             hover_result = Some(Self::merge_hover_with_lint(hover_result, lint_info));
         }
@@ -194,7 +190,8 @@ impl LanguageServer for MaestroServer {
             return Ok(None);
         };
 
-        if let Some(ctx) = IdeContext::new(&self.state, uri, offset) {
+        let ctx = IdeContext::with_content(&self.state, uri, offset, content);
+        {
             #[cfg(feature = "native")]
             {
                 let corsa_bridge = self.state.get_corsa_bridge().await;
@@ -245,7 +242,8 @@ impl LanguageServer for MaestroServer {
             return Ok(None);
         };
 
-        if let Some(ctx) = IdeContext::new(&self.state, uri, offset) {
+        let ctx = IdeContext::with_content(&self.state, uri, offset, content);
+        {
             #[cfg(feature = "native")]
             {
                 let corsa_bridge = self.state.get_corsa_bridge().await;
@@ -283,7 +281,8 @@ impl LanguageServer for MaestroServer {
             return Ok(None);
         };
 
-        if let Some(ctx) = IdeContext::new(&self.state, uri, offset) {
+        let ctx = IdeContext::with_content(&self.state, uri, offset, content);
+        {
             #[cfg(feature = "native")]
             {
                 let corsa_bridge = self.state.get_corsa_bridge().await;
@@ -329,9 +328,7 @@ impl LanguageServer for MaestroServer {
             return Ok(None);
         };
 
-        let Some(ctx) = IdeContext::new(&self.state, uri, offset) else {
-            return Ok(None);
-        };
+        let ctx = IdeContext::with_content(&self.state, uri, offset, content);
 
         Ok(DocumentHighlightService::highlights(&ctx))
     }
@@ -548,20 +545,18 @@ impl LanguageServer for MaestroServer {
             return Ok(None);
         };
 
-        if let Some(ctx) = IdeContext::new(&self.state, uri, offset) {
-            #[cfg(feature = "native")]
-            {
-                let corsa_bridge = self.state.get_corsa_bridge().await;
-                return Ok(RenameService::prepare_rename_with_corsa(&ctx, corsa_bridge).await);
-            }
+        let ctx = IdeContext::with_content(&self.state, uri, offset, content);
 
-            #[cfg(not(feature = "native"))]
-            {
-                return Ok(RenameService::prepare_rename(&ctx));
-            }
+        #[cfg(feature = "native")]
+        {
+            let corsa_bridge = self.state.get_corsa_bridge().await;
+            Ok(RenameService::prepare_rename_with_corsa(&ctx, corsa_bridge).await)
         }
 
-        Ok(None)
+        #[cfg(not(feature = "native"))]
+        {
+            Ok(RenameService::prepare_rename(&ctx))
+        }
     }
 
     async fn rename(&self, params: RenameParams) -> Result<Option<WorkspaceEdit>> {
@@ -582,20 +577,18 @@ impl LanguageServer for MaestroServer {
             return Ok(None);
         };
 
-        if let Some(ctx) = IdeContext::new(&self.state, uri, offset) {
-            #[cfg(feature = "native")]
-            {
-                let corsa_bridge = self.state.get_corsa_bridge().await;
-                return Ok(RenameService::rename_with_corsa(&ctx, new_name, corsa_bridge).await);
-            }
+        let ctx = IdeContext::with_content(&self.state, uri, offset, content);
 
-            #[cfg(not(feature = "native"))]
-            {
-                return Ok(RenameService::rename(&ctx, new_name));
-            }
+        #[cfg(feature = "native")]
+        {
+            let corsa_bridge = self.state.get_corsa_bridge().await;
+            Ok(RenameService::rename_with_corsa(&ctx, new_name, corsa_bridge).await)
         }
 
-        Ok(None)
+        #[cfg(not(feature = "native"))]
+        {
+            Ok(RenameService::rename(&ctx, new_name))
+        }
     }
 
     async fn semantic_tokens_full(


### PR DESCRIPTION
Add IdeContext::with_content so hover/completion/goto/references/highlight/
rename pass the doc.text() they already built instead of IdeContext::new
re-fetching from the DashMap and materializing the rope a second time. Also
drop the redundant second parse_sfc in art_component_path (the art descriptor
already carries the script_setup content). One fewer full-doc alloc per request.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

---
Part of the adversarially-verified non-compiler performance audit (round 2: 106 findings → 27 confirmed). Behavior-preserving: full workspace test suite green (3439 passed, 0 failed) and `vize fmt`/`lint` output byte-identical. This reduces real work (allocations / redundant parses / lock ops / O(offset) scans) on the component's hot path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1075"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783332921&installation_id=136613492&pr_number=1075&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1075&signature=8e988cc0e73c3efbbfd57311115d88e47568bf57079015c57d90a6c60ef3583b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->