### PR TITLE
perf(musea): skip the OXC script parse when defineArt is absent

### DIFF
--- a/crates/vize_musea/src/parse.rs
+++ b/crates/vize_musea/src/parse.rs
@@ -202,6 +202,11 @@ fn parse_define_art_metadata<'a>(
     allocator: &'a Bump,
     script: &'a str,
 ) -> Option<DefineArtMetadata<'a>> {
+    // Cheap pre-check: defineArt() can only return Some if the literal token
+    // "defineArt" appears in the source (it is a compiler macro recognized by
+    // name and cannot be aliased), so skip the heavyweight OXC parse otherwise.
+    memmem::find(script.as_bytes(), b"defineArt")?;
+
     let parsed = vize_croquis::script_parser::parse_script_setup(script);
     let art = parsed.macros.define_art()?;
     let mut meta = DefineArtMetadata::new(allocator);


### PR DESCRIPTION
parse_define_art_metadata unconditionally ran a full oxc parse + scope build
even when art metadata comes from <art> tag attributes. Add a cheap memmem
pre-check for the defineArt token (the macro is name-recognized, so it can
only match if the literal appears) before parsing.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

---
Part of the adversarially-verified non-compiler performance audit (round 2: 106 findings → 27 confirmed). Behavior-preserving: full workspace test suite green (3439 passed, 0 failed) and `vize fmt`/`lint` output byte-identical. This reduces real work (allocations / redundant parses / lock ops / O(offset) scans) on the component's hot path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1076"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783332924&installation_id=136613492&pr_number=1076&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1076&signature=10f0a9f766d2c5c331110f7ce2d220fdef6054c335476641d60a2a8a1465f274"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->