### PR TITLE
perf(glyph): render each attribute once + alloc-free attr sort/void-tag/static-text

### DIFF
--- a/crates/vize_glyph/src/template/attributes.rs
+++ b/crates/vize_glyph/src/template/attributes.rs
@@ -23,21 +23,17 @@ pub(crate) struct ParsedAttribute {
 pub(crate) fn sort_attributes(attrs: &mut [ParsedAttribute], options: &FormatOptions) {
     match options.attribute_sort_order {
         AttributeSortOrder::Alphabetical => {
-            attrs.sort_by(|a, b| {
-                // Primary: priority group
-                let cmp = a.priority.cmp(&b.priority);
-                if cmp != std::cmp::Ordering::Equal {
-                    return cmp;
-                }
-                // Secondary: alphabetical within same group
-                let a_key = attr_sort_key(&a.name, options.merge_bind_and_non_bind_attrs);
-                let b_key = attr_sort_key(&b.name, options.merge_bind_and_non_bind_attrs);
-                let alpha_cmp = a_key.cmp(&b_key);
-                if alpha_cmp != std::cmp::Ordering::Equal {
-                    return alpha_cmp;
-                }
-                // Tertiary: original order for stability
-                a.original_index.cmp(&b.original_index)
+            // Decorate-sort-undecorate: `attr_sort_key` lowercases the name,
+            // so computing it inside a comparator re-allocates O(n log n)
+            // times. `sort_by_cached_key` evaluates the key closure exactly
+            // once per attribute and caches it, then sorts on the cached
+            // tuples. The composite key `(priority, group, lowercased base,
+            // original index)` reproduces the previous comparator (including
+            // the stable original-index tie-break) exactly.
+            let merge_bind = options.merge_bind_and_non_bind_attrs;
+            attrs.sort_by_cached_key(|attr| {
+                let (group, base) = attr_sort_key(&attr.name, merge_bind);
+                (attr.priority, group, base, attr.original_index)
             });
         }
         AttributeSortOrder::AsWritten => {

--- a/crates/vize_glyph/src/template/formatter.rs
+++ b/crates/vize_glyph/src/template/formatter.rs
@@ -125,8 +125,13 @@ impl<'a> TemplateFormatter<'a> {
 
                     let mut closing_bracket_on_own_line = false;
                     if !sorted_attrs.is_empty() {
+                        // Render each attribute exactly once; both the
+                        // multiline decision and emission below reuse this.
+                        let mut rendered: Vec<String> = Vec::with_capacity(sorted_attrs.len());
+                        rendered.extend(sorted_attrs.iter().map(render_attribute));
+
                         let use_multiline =
-                            self.should_use_multiline_attrs(&tag_name, &sorted_attrs, depth);
+                            self.should_use_multiline_attrs(&tag_name, &rendered, depth);
 
                         if use_multiline {
                             let max_per_line = self
@@ -136,7 +141,7 @@ impl<'a> TemplateFormatter<'a> {
                                 .max(1) as usize;
 
                             let mut line_count = 0;
-                            for attr in &sorted_attrs {
+                            for attr in &rendered {
                                 if line_count == 0 {
                                     // Start a new attribute line
                                     output.extend_from_slice(self.newline);
@@ -144,7 +149,7 @@ impl<'a> TemplateFormatter<'a> {
                                 } else {
                                     output.push(b' ');
                                 }
-                                output.extend_from_slice(render_attribute(attr).as_bytes());
+                                output.extend_from_slice(attr.as_bytes());
                                 line_count += 1;
                                 if line_count >= max_per_line {
                                     line_count = 0;
@@ -156,20 +161,23 @@ impl<'a> TemplateFormatter<'a> {
                                 closing_bracket_on_own_line = true;
                             }
                         } else {
-                            for attr in &sorted_attrs {
+                            for attr in &rendered {
                                 output.push(b' ');
-                                output.extend_from_slice(render_attribute(attr).as_bytes());
+                                output.extend_from_slice(attr.as_bytes());
                             }
                         }
                     }
 
+                    // Compute once per opening tag; consumed in the two
+                    // void-element branches below.
+                    let is_void = is_void_element_str(&tag_name);
                     if is_self_closing {
                         if closing_bracket_on_own_line {
                             output.extend_from_slice(b"/>");
                         } else {
                             output.extend_from_slice(b" />");
                         }
-                    } else if !is_void_element_str(&tag_name)
+                    } else if !is_void
                         && let Some(closing_end_pos) =
                             self.parse_immediate_empty_closing_tag(source, end_pos, &tag_name)
                     {
@@ -206,7 +214,7 @@ impl<'a> TemplateFormatter<'a> {
                         }
                     } else {
                         output.push(b'>');
-                        if !is_void_element_str(&tag_name) {
+                        if !is_void {
                             depth += 1;
                         }
                     }
@@ -455,19 +463,22 @@ impl<'a> TemplateFormatter<'a> {
     }
 
     /// Determine whether attributes should be rendered in multiline mode.
+    ///
+    /// Takes the pre-rendered attribute strings so each attribute is rendered
+    /// exactly once on the common path (shared with the emission loop).
     fn should_use_multiline_attrs(
         &self,
         tag_name: &str,
-        attrs: &[ParsedAttribute],
+        rendered: &[String],
         depth: usize,
     ) -> bool {
-        if attrs.len() <= 1 {
+        if rendered.len() <= 1 {
             return false;
         }
 
         // Explicit max_attributes_per_line takes priority
         if let Some(max) = self.options.max_attributes_per_line {
-            return attrs.len() > max as usize;
+            return rendered.len() > max as usize;
         }
 
         // single_attribute_per_line
@@ -478,9 +489,9 @@ impl<'a> TemplateFormatter<'a> {
         // Check if all attributes on one line would exceed print_width
         let indent_len = self.indent.len() * depth;
         let tag_len = 1 + tag_name.len(); // '<' + tag_name
-        let attrs_len: usize = attrs
+        let attrs_len: usize = rendered
             .iter()
-            .map(|a| 1 + render_attribute(a).len()) // ' ' + attr
+            .map(|a| 1 + a.len()) // ' ' + attr
             .sum();
         let closing_len = 1; // '>'
         let total = indent_len + tag_len + attrs_len + closing_len;
@@ -677,8 +688,17 @@ impl<'a> TemplateFormatter<'a> {
 pub(crate) fn format_interpolations(text: &str, options: &FormatOptions) -> String {
     let bytes = text.as_bytes();
     let len = bytes.len();
+
+    // Fast path: no `{` at all means no interpolations and no special bytes,
+    // so the text is returned verbatim with a single allocation.
+    let Some(first_brace) = memchr::memchr(b'{', bytes) else {
+        return text.to_compact_string();
+    };
+
     let mut result = String::with_capacity(len + 16);
-    let mut pos = 0;
+    // Everything before the first `{` is ordinary text; copy it in one shot.
+    result.push_str(&text[..first_brace]);
+    let mut pos = first_brace;
 
     while pos < len {
         if pos + 1 < len && bytes[pos] == b'{' && bytes[pos + 1] == b'{' {
@@ -715,13 +735,14 @@ pub(crate) fn format_interpolations(text: &str, options: &FormatOptions) -> Stri
                 pos += 1;
             }
         } else {
-            // Push one UTF-8 character
-            if let Some(ch) = text[pos..].chars().next() {
-                result.push(ch);
-                pos += ch.len_utf8();
-            } else {
-                pos += 1;
-            }
+            // Ordinary text. Copy the run up to (but not including) the next
+            // `{` in a single push instead of char-by-char. A lone `{` (one
+            // not starting a `{{`) is emitted and stepped over individually,
+            // exactly as before.
+            let rest = &bytes[pos + 1..];
+            let next = memchr::memchr(b'{', rest).map_or(len, |off| pos + 1 + off);
+            result.push_str(&text[pos..next]);
+            pos = next;
         }
     }
 

--- a/crates/vize_glyph/src/template/helpers.rs
+++ b/crates/vize_glyph/src/template/helpers.rs
@@ -51,22 +51,13 @@ pub(crate) fn is_whitespace(b: u8) -> bool {
 }
 
 /// Check if an element is a void element (self-closing in HTML).
+///
+/// Alloc-free: void element names are 2..=6 ASCII bytes, so a length guard
+/// plus case-insensitive comparison avoids the lowercasing allocation.
 pub(crate) fn is_void_element_str(tag: &str) -> bool {
-    matches!(
-        tag.to_ascii_lowercase().as_str(),
-        "area"
-            | "base"
-            | "br"
-            | "col"
-            | "embed"
-            | "hr"
-            | "img"
-            | "input"
-            | "link"
-            | "meta"
-            | "param"
-            | "source"
-            | "track"
-            | "wbr"
-    )
+    const VOID_ELEMENTS: [&str; 14] = [
+        "area", "base", "br", "col", "embed", "hr", "img", "input", "link", "meta", "param",
+        "source", "track", "wbr",
+    ];
+    matches!(tag.len(), 2..=6) && VOID_ELEMENTS.iter().any(|v| tag.eq_ignore_ascii_case(v))
 }


### PR DESCRIPTION
- render_attribute was called 2x/attr (length probe + write), each format!()
  heap-allocating; render once into a Vec and reuse for both.
- sort_attributes recomputed a lowercased key per comparison; use
  sort_by_cached_key so each key is built once.
- is_void_element_str matched via to_ascii_lowercase(); use eq_ignore_ascii_case.
- format_interpolations rebuilt static text char-by-char; bulk-copy via memchr.
Formatter output unchanged.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

---
Part of the adversarially-verified non-compiler performance audit (round 2: 106 findings → 27 confirmed). Behavior-preserving: full workspace test suite green (3439 passed, 0 failed) and `vize fmt`/`lint` output byte-identical. This reduces real work (allocations / redundant parses / lock ops / O(offset) scans) on the component's hot path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1077"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783332926&installation_id=136613492&pr_number=1077&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1077&signature=e28c2e78a97b2c0c7ba76c89c97229d98babc491966a2df53ec0808f138563f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->