### PR TITLE
perf(patina): share one oxc parse across AST script rules + skip casing alloc

### DIFF
--- a/crates/vize_patina/src/linter/script_rules.rs
+++ b/crates/vize_patina/src/linter/script_rules.rs
@@ -1,11 +1,60 @@
 use super::{LintResult, Linter};
 use crate::rules::script::{
     NoGetCurrentInstance, NoNextTick, NoOptionsApi, PiniaPreferStoreToRefs, ScriptRule,
-    VueRouterPreferNamedPush, VueTestUtilsNoHtmlSnapshot,
+    VueRouterPreferNamedPush, VueTestUtilsNoHtmlSnapshot, script_source_type,
 };
 use memchr::memmem;
+use oxc_allocator::Allocator;
+use oxc_parser::Parser;
 use vize_atelier_sfc::{SfcDescriptor, SfcParseOptions, parse_sfc};
 use vize_carton::profile;
+
+/// A built-in script rule paired with its registry name and profiling label.
+///
+/// All built-in script rules are AST-based, so a single oxc parse per script
+/// block can be shared across every enabled rule.
+struct BuiltinScriptRuleEntry {
+    rule_name: &'static str,
+    profile_name: &'static str,
+    rule: &'static (dyn ScriptRule + 'static),
+}
+
+/// The full ordered set of built-in script rules.
+///
+/// Order matches the previous sequence of `append_builtin_script_rule` calls so
+/// emitted diagnostics keep the same ordering.
+static BUILTIN_SCRIPT_RULES: &[BuiltinScriptRuleEntry] = &[
+    BuiltinScriptRuleEntry {
+        rule_name: RULE_NO_OPTIONS_API,
+        profile_name: "patina.script_rule.no_options_api",
+        rule: &NoOptionsApi,
+    },
+    BuiltinScriptRuleEntry {
+        rule_name: RULE_NO_GET_CURRENT_INSTANCE,
+        profile_name: "patina.script_rule.no_get_current_instance",
+        rule: &NoGetCurrentInstance,
+    },
+    BuiltinScriptRuleEntry {
+        rule_name: RULE_NO_NEXT_TICK,
+        profile_name: "patina.script_rule.no_next_tick",
+        rule: &NoNextTick,
+    },
+    BuiltinScriptRuleEntry {
+        rule_name: RULE_PINIA_PREFER_STORE_TO_REFS,
+        profile_name: "patina.script_rule.pinia_prefer_store_to_refs",
+        rule: &PiniaPreferStoreToRefs,
+    },
+    BuiltinScriptRuleEntry {
+        rule_name: RULE_VUE_ROUTER_PREFER_NAMED_PUSH,
+        profile_name: "patina.script_rule.vue_router_prefer_named_push",
+        rule: &VueRouterPreferNamedPush,
+    },
+    BuiltinScriptRuleEntry {
+        rule_name: RULE_VUE_TEST_UTILS_NO_HTML_SNAPSHOT,
+        profile_name: "patina.script_rule.vue_test_utils_no_html_snapshot",
+        rule: &VueTestUtilsNoHtmlSnapshot,
+    },
+];
 
 pub(crate) const RULE_NO_OPTIONS_API: &str = "script/no-options-api";
 pub(crate) const RULE_NO_GET_CURRENT_INSTANCE: &str = "script/no-get-current-instance";
@@ -169,54 +218,94 @@ pub(crate) fn append_builtin_script_diagnostics<'a>(
         return;
     }
 
-    append_builtin_script_rule(
-        linter,
-        descriptor,
-        result,
-        RULE_NO_OPTIONS_API,
-        "patina.script_rule.no_options_api",
-        NoOptionsApi,
+    // Parse each block at most once and reuse the program across every rule.
+    // A block is only parsed if at least one enabled rule could match it (the
+    // same `is_rule_enabled` + `script_rules.contains` + `script_rule_may_match`
+    // gate the previous per-rule path applied before parsing). Diagnostics are
+    // emitted rule-major / block-minor to preserve the exact ordering of the
+    // previous per-rule call sequence (which iterated `script` then
+    // `script_setup` inside each rule).
+    let script_alloc = Allocator::default();
+    let script = descriptor
+        .script
+        .as_ref()
+        .filter(|block| block_has_active_rule(linter, block.content.as_ref()))
+        .map(|block| {
+            let source = block.content.as_ref();
+            let parsed = profile!(
+                "patina.script_rule.parse",
+                Parser::new(&script_alloc, source, script_source_type()).parse()
+            );
+            (source, block.loc.start, parsed)
+        });
+
+    let setup_alloc = Allocator::default();
+    let script_setup = descriptor
+        .script_setup
+        .as_ref()
+        .filter(|block| block_has_active_rule(linter, block.content.as_ref()))
+        .map(|block| {
+            let source = block.content.as_ref();
+            let parsed = profile!(
+                "patina.script_rule.parse",
+                Parser::new(&setup_alloc, source, script_source_type()).parse()
+            );
+            (source, block.loc.start, parsed)
+        });
+
+    for entry in BUILTIN_SCRIPT_RULES {
+        if !linter.is_rule_enabled(entry.rule_name)
+            || !linter.script_rules.contains(&entry.rule_name)
+        {
+            continue;
+        }
+        if let Some((source, offset, parsed)) = script.as_ref() {
+            run_builtin_script_rule_on_parsed(entry, source, *offset, parsed, result);
+        }
+        if let Some((source, offset, parsed)) = script_setup.as_ref() {
+            run_builtin_script_rule_on_parsed(entry, source, *offset, parsed, result);
+        }
+    }
+}
+
+/// Whether any enabled built-in script rule could match `source`.
+///
+/// Mirrors the per-rule `is_rule_enabled` + `script_rules.contains` +
+/// `script_rule_may_match` gate so a block matching no rule is never parsed.
+fn block_has_active_rule(linter: &Linter, source: &str) -> bool {
+    BUILTIN_SCRIPT_RULES.iter().any(|entry| {
+        linter.is_rule_enabled(entry.rule_name)
+            && linter.script_rules.contains(&entry.rule_name)
+            && script_rule_may_match(entry.rule_name, source)
+    })
+}
+
+/// Run a single built-in script rule against a pre-parsed script block.
+///
+/// Applies the same `script_rule_may_match` byte prefilter and parse-failure
+/// guard the per-rule `check` used to apply, then dispatches to `check_program`
+/// with the shared program.
+fn run_builtin_script_rule_on_parsed(
+    entry: &BuiltinScriptRuleEntry,
+    source: &str,
+    offset: usize,
+    parsed: &oxc_parser::ParserReturn<'_>,
+    result: &mut LintResult,
+) {
+    if parsed.panicked || !parsed.errors.is_empty() {
+        return;
+    }
+    if !script_rule_may_match(entry.rule_name, source) {
+        return;
+    }
+    let mut lint = crate::rules::script::ScriptLintResult::default();
+    profile!(
+        entry.profile_name,
+        entry
+            .rule
+            .check_program(&parsed.program, source, offset, &mut lint)
     );
-    append_builtin_script_rule(
-        linter,
-        descriptor,
-        result,
-        RULE_NO_GET_CURRENT_INSTANCE,
-        "patina.script_rule.no_get_current_instance",
-        NoGetCurrentInstance,
-    );
-    append_builtin_script_rule(
-        linter,
-        descriptor,
-        result,
-        RULE_NO_NEXT_TICK,
-        "patina.script_rule.no_next_tick",
-        NoNextTick,
-    );
-    append_builtin_script_rule(
-        linter,
-        descriptor,
-        result,
-        RULE_PINIA_PREFER_STORE_TO_REFS,
-        "patina.script_rule.pinia_prefer_store_to_refs",
-        PiniaPreferStoreToRefs,
-    );
-    append_builtin_script_rule(
-        linter,
-        descriptor,
-        result,
-        RULE_VUE_ROUTER_PREFER_NAMED_PUSH,
-        "patina.script_rule.vue_router_prefer_named_push",
-        VueRouterPreferNamedPush,
-    );
-    append_builtin_script_rule(
-        linter,
-        descriptor,
-        result,
-        RULE_VUE_TEST_UTILS_NO_HTML_SNAPSHOT,
-        "patina.script_rule.vue_test_utils_no_html_snapshot",
-        VueTestUtilsNoHtmlSnapshot,
-    );
+    merge_script_result(result, lint);
 }
 
 pub(crate) fn append_builtin_script_diagnostics_from_html(
@@ -229,60 +318,7 @@ pub(crate) fn append_builtin_script_diagnostics_from_html(
     }
 
     for (script, offset) in extract_inline_scripts(source) {
-        append_builtin_script_rule_for_source(
-            linter,
-            script,
-            offset,
-            result,
-            RULE_NO_OPTIONS_API,
-            "patina.script_rule.no_options_api",
-            &NoOptionsApi,
-        );
-        append_builtin_script_rule_for_source(
-            linter,
-            script,
-            offset,
-            result,
-            RULE_NO_GET_CURRENT_INSTANCE,
-            "patina.script_rule.no_get_current_instance",
-            &NoGetCurrentInstance,
-        );
-        append_builtin_script_rule_for_source(
-            linter,
-            script,
-            offset,
-            result,
-            RULE_NO_NEXT_TICK,
-            "patina.script_rule.no_next_tick",
-            &NoNextTick,
-        );
-        append_builtin_script_rule_for_source(
-            linter,
-            script,
-            offset,
-            result,
-            RULE_PINIA_PREFER_STORE_TO_REFS,
-            "patina.script_rule.pinia_prefer_store_to_refs",
-            &PiniaPreferStoreToRefs,
-        );
-        append_builtin_script_rule_for_source(
-            linter,
-            script,
-            offset,
-            result,
-            RULE_VUE_ROUTER_PREFER_NAMED_PUSH,
-            "patina.script_rule.vue_router_prefer_named_push",
-            &VueRouterPreferNamedPush,
-        );
-        append_builtin_script_rule_for_source(
-            linter,
-            script,
-            offset,
-            result,
-            RULE_VUE_TEST_UTILS_NO_HTML_SNAPSHOT,
-            "patina.script_rule.vue_test_utils_no_html_snapshot",
-            &VueTestUtilsNoHtmlSnapshot,
-        );
+        append_builtin_script_rules_for_source(linter, script, offset, result);
     }
 }
 
@@ -295,61 +331,40 @@ fn merge_script_result(
     result.diagnostics.extend(script_result.diagnostics);
 }
 
-fn append_builtin_script_rule<'a, R: ScriptRule>(
-    linter: &Linter,
-    descriptor: &SfcDescriptor<'a>,
-    result: &mut LintResult,
-    rule_name: &str,
-    profile_name: &'static str,
-    rule: R,
-) {
-    if !linter.is_rule_enabled(rule_name) || !linter.script_rules.contains(&rule_name) {
-        return;
-    }
-
-    if let Some(script) = descriptor.script.as_ref() {
-        append_builtin_script_rule_for_source(
-            linter,
-            script.content.as_ref(),
-            script.loc.start,
-            result,
-            rule_name,
-            profile_name,
-            &rule,
-        );
-    }
-    if let Some(script_setup) = descriptor.script_setup.as_ref() {
-        append_builtin_script_rule_for_source(
-            linter,
-            script_setup.content.as_ref(),
-            script_setup.loc.start,
-            result,
-            rule_name,
-            profile_name,
-            &rule,
-        );
-    }
-}
-
-fn append_builtin_script_rule_for_source<R: ScriptRule>(
+/// Run every enabled built-in script rule against a single script block,
+/// sharing **one** oxc parse across all of them.
+///
+/// Mirrors the previous per-rule flow exactly: each rule is gated on
+/// `is_rule_enabled` + `script_rules.contains` and on its `script_rule_may_match`
+/// byte prefilter, runs into its own [`ScriptLintResult`], and is merged in the
+/// original rule order. The only change is that the oxc parse happens once here
+/// instead of once inside every rule's `check`.
+fn append_builtin_script_rules_for_source(
     linter: &Linter,
     source: &str,
     offset: usize,
     result: &mut LintResult,
-    rule_name: &str,
-    profile_name: &'static str,
-    rule: &R,
 ) {
-    if !linter.is_rule_enabled(rule_name) || !linter.script_rules.contains(&rule_name) {
-        return;
-    }
-    if !script_rule_may_match(rule_name, source) {
+    // Skip parsing entirely when no enabled rule could match this block.
+    if !block_has_active_rule(linter, source) {
         return;
     }
 
-    let mut lint = crate::rules::script::ScriptLintResult::default();
-    profile!(profile_name, rule.check(source, offset, &mut lint));
-    merge_script_result(result, lint);
+    // Parse the script block exactly once and share the program with each rule.
+    let allocator = Allocator::default();
+    let parsed = profile!(
+        "patina.script_rule.parse",
+        Parser::new(&allocator, source, script_source_type()).parse()
+    );
+
+    for entry in BUILTIN_SCRIPT_RULES {
+        if !linter.is_rule_enabled(entry.rule_name)
+            || !linter.script_rules.contains(&entry.rule_name)
+        {
+            continue;
+        }
+        run_builtin_script_rule_on_parsed(entry, source, offset, &parsed, result);
+    }
 }
 
 fn script_rule_may_match(rule_name: &str, source: &str) -> bool {

--- a/crates/vize_patina/src/rules/opinionated/vue/component_name_in_template_casing.rs
+++ b/crates/vize_patina/src/rules/opinionated/vue/component_name_in_template_casing.rs
@@ -64,14 +64,25 @@ impl Rule for ComponentNameInTemplateCasing {
     fn enter_element<'a>(&self, ctx: &mut LintContext<'a>, element: &ElementNode<'a>) {
         let tag = element.tag.as_str();
 
-        // Skip HTML elements, SVG elements, and Vue built-ins
-        let tag_lower = tag.to_lowercase();
-        if is_html_tag(&tag_lower)
-            || is_svg_tag(tag)
-            || is_builtin_component(tag)
-            || is_builtin_component(&tag_lower)
-        {
-            return;
+        // Skip HTML elements, SVG elements, and Vue built-ins.
+        //
+        // Fast path: native tags (div/span/...) contain no uppercase bytes, so
+        // their lowercased form is identical. Only allocate via `to_lowercase()`
+        // when the tag actually has an uppercase byte, sparing an allocation for
+        // every native element (the overwhelmingly common case).
+        if tag.bytes().all(|b| !b.is_ascii_uppercase()) {
+            if is_html_tag(tag) || is_svg_tag(tag) || is_builtin_component(tag) {
+                return;
+            }
+        } else {
+            let tag_lower = tag.to_lowercase();
+            if is_html_tag(&tag_lower)
+                || is_svg_tag(tag)
+                || is_builtin_component(tag)
+                || is_builtin_component(&tag_lower)
+            {
+                return;
+            }
         }
 
         match self.casing {

--- a/crates/vize_patina/src/rules/script.rs
+++ b/crates/vize_patina/src/rules/script.rs
@@ -46,6 +46,10 @@ mod vue_router_prefer_named_push;
 mod vue_test_utils_no_html_snapshot;
 
 use memchr::memmem;
+use oxc_allocator::Allocator;
+use oxc_ast::ast::Program;
+use oxc_parser::Parser;
+use oxc_span::SourceType;
 
 use crate::diagnostic::{LintDiagnostic, Severity};
 use vize_carton::profile;
@@ -110,17 +114,75 @@ impl ScriptLintResult {
     }
 }
 
+/// Resolve the [`SourceType`] used for parsing script blocks.
+///
+/// All built-in script rules parse with TypeScript semantics (`component.ts`),
+/// which yields a non-JSX standard TypeScript source type. This is shared so a
+/// single oxc parse can be reused across every rule.
+#[inline]
+pub(crate) fn script_source_type() -> SourceType {
+    SourceType::from_path("component.ts").unwrap_or_else(|_| SourceType::ts())
+}
+
 /// Trait for script-level lint rules
 pub trait ScriptRule: Send + Sync {
     /// Get rule metadata
     fn meta(&self) -> &'static ScriptRuleMeta;
 
-    /// Check the script content
+    /// Check the script content.
+    ///
+    /// This is a thin wrapper that parses the source once and delegates to
+    /// [`ScriptRule::check_program`]. Rules that rely on an oxc parse should
+    /// override `check_program` instead so a shared parse can be reused by
+    /// [`ScriptLinter::lint`]. Rules that operate purely on the raw bytes (no
+    /// oxc AST) override `check` directly and leave `check_program` empty.
     ///
     /// * `source` - The script block content
     /// * `offset` - The offset of the script block in the original file
     /// * `result` - Accumulator for diagnostics
-    fn check(&self, source: &str, offset: usize, result: &mut ScriptLintResult);
+    fn check(&self, source: &str, offset: usize, result: &mut ScriptLintResult) {
+        let allocator = Allocator::default();
+        let parsed = Parser::new(&allocator, source, script_source_type()).parse();
+        if parsed.panicked || !parsed.errors.is_empty() {
+            return;
+        }
+        self.check_program(&parsed.program, source, offset, result);
+    }
+
+    /// Check an already-parsed script program.
+    ///
+    /// Rules that need an oxc AST implement their visitor logic here, dropping
+    /// their per-rule `Parser::new`, and override [`ScriptRule::uses_ast`] to
+    /// return `true`. The default implementation does nothing so that byte-only
+    /// rules (which override `check`) need not implement it.
+    ///
+    /// The program reference and the AST allocation share a single lifetime
+    /// (`&'a Program<'a>`) so rules can hand out AST node references that live as
+    /// long as the program (required by some rules' binding maps).
+    ///
+    /// * `program` - The parsed oxc program (parsed with [`script_source_type`])
+    /// * `source` - The script block content
+    /// * `offset` - The offset of the script block in the original file
+    /// * `result` - Accumulator for diagnostics
+    fn check_program<'a>(
+        &self,
+        program: &'a Program<'a>,
+        source: &str,
+        offset: usize,
+        result: &mut ScriptLintResult,
+    ) {
+        let _ = (program, source, offset, result);
+    }
+
+    /// Whether this rule consumes the oxc AST via [`ScriptRule::check_program`].
+    ///
+    /// Rules that parse the script return `true` so callers can feed them a
+    /// shared, pre-parsed program. Byte-only rules leave this `false` and are
+    /// driven through [`ScriptRule::check`].
+    #[inline]
+    fn uses_ast(&self) -> bool {
+        false
+    }
 }
 
 /// Linter for script blocks
@@ -169,12 +231,50 @@ impl ScriptLinter {
     }
 
     /// Lint a script block
+    ///
+    /// AST-based rules share a **single** oxc parse of the source (one
+    /// [`Allocator`] + one [`Program`]) via [`ScriptRule::check_program`],
+    /// collapsing what used to be N redundant parses (one per rule) into one.
+    /// Byte-only rules continue to scan the raw source directly via
+    /// [`ScriptRule::check`].
     pub fn lint(&self, source: &str, offset: usize) -> ScriptLintResult {
         let mut result = ScriptLintResult::default();
 
+        if self.rules.is_empty() {
+            return result;
+        }
+
+        // Parse once only if at least one rule actually consumes the AST.
+        let needs_ast = self.rules.iter().any(|rule| rule.uses_ast());
+        let allocator;
+        let parsed = if needs_ast {
+            allocator = Allocator::default();
+            Some(profile!(
+                "patina.script_linter.parse",
+                Parser::new(&allocator, source, script_source_type()).parse()
+            ))
+        } else {
+            None
+        };
+        // AST rules only run when parsing succeeded (matching the previous
+        // per-rule `parsed.panicked || !errors.is_empty()` early-return).
+        let program = parsed.as_ref().and_then(|parsed| {
+            if parsed.panicked || !parsed.errors.is_empty() {
+                None
+            } else {
+                Some(&parsed.program)
+            }
+        });
+
         for rule in &self.rules {
             profile!("patina.script_linter.rule.check", {
-                rule.check(source, offset, &mut result);
+                if rule.uses_ast() {
+                    if let Some(program) = program {
+                        rule.check_program(program, source, offset, &mut result);
+                    }
+                } else {
+                    rule.check(source, offset, &mut result);
+                }
             });
         }
 

--- a/crates/vize_patina/src/rules/script/no_get_current_instance.rs
+++ b/crates/vize_patina/src/rules/script/no_get_current_instance.rs
@@ -25,14 +25,14 @@
 
 use super::{ScriptLintResult, ScriptRule, ScriptRuleMeta};
 use crate::diagnostic::{LintDiagnostic, Severity};
-use oxc_allocator::Allocator;
-use oxc_ast::ast::{CallExpression, Expression, ImportDeclaration, ImportDeclarationSpecifier};
+use oxc_ast::ast::{
+    CallExpression, Expression, ImportDeclaration, ImportDeclarationSpecifier, Program,
+};
 use oxc_ast_visit::{
     Visit,
     walk::{walk_call_expression, walk_import_declaration},
 };
-use oxc_parser::Parser;
-use oxc_span::{GetSpan, SourceType, Span};
+use oxc_span::{GetSpan, Span};
 use vize_carton::{CompactString, FxHashSet};
 
 static META: ScriptRuleMeta = ScriptRuleMeta {
@@ -50,22 +50,25 @@ impl ScriptRule for NoGetCurrentInstance {
     }
 
     #[inline]
-    fn check(&self, source: &str, offset: usize, result: &mut ScriptLintResult) {
-        let allocator = Allocator::default();
-        let source_type =
-            SourceType::from_path("component.ts").unwrap_or_else(|_| SourceType::ts());
-        let parsed = Parser::new(&allocator, source, source_type).parse();
-        if parsed.panicked || !parsed.errors.is_empty() {
-            return;
-        }
+    fn uses_ast(&self) -> bool {
+        true
+    }
 
+    #[inline]
+    fn check_program<'a>(
+        &self,
+        program: &'a Program<'a>,
+        _source: &str,
+        offset: usize,
+        result: &mut ScriptLintResult,
+    ) {
         let mut visitor = NoGetCurrentInstanceVisitor {
             offset,
             result,
             imported_aliases: FxHashSet::default(),
             namespace_aliases: FxHashSet::default(),
         };
-        visitor.visit_program(&parsed.program);
+        visitor.visit_program(program);
     }
 }
 

--- a/crates/vize_patina/src/rules/script/no_next_tick.rs
+++ b/crates/vize_patina/src/rules/script/no_next_tick.rs
@@ -27,14 +27,14 @@
 
 use super::{ScriptLintResult, ScriptRule, ScriptRuleMeta};
 use crate::diagnostic::{LintDiagnostic, Severity};
-use oxc_allocator::Allocator;
-use oxc_ast::ast::{CallExpression, Expression, ImportDeclaration, ImportDeclarationSpecifier};
+use oxc_ast::ast::{
+    CallExpression, Expression, ImportDeclaration, ImportDeclarationSpecifier, Program,
+};
 use oxc_ast_visit::{
     Visit,
     walk::{walk_call_expression, walk_import_declaration},
 };
-use oxc_parser::Parser;
-use oxc_span::{GetSpan, SourceType, Span};
+use oxc_span::{GetSpan, Span};
 use vize_carton::{CompactString, FxHashSet};
 
 static META: ScriptRuleMeta = ScriptRuleMeta {
@@ -52,21 +52,24 @@ impl ScriptRule for NoNextTick {
     }
 
     #[inline]
-    fn check(&self, source: &str, offset: usize, result: &mut ScriptLintResult) {
-        let allocator = Allocator::default();
-        let source_type =
-            SourceType::from_path("component.ts").unwrap_or_else(|_| SourceType::ts());
-        let parsed = Parser::new(&allocator, source, source_type).parse();
-        if parsed.panicked || !parsed.errors.is_empty() {
-            return;
-        }
+    fn uses_ast(&self) -> bool {
+        true
+    }
 
+    #[inline]
+    fn check_program<'a>(
+        &self,
+        program: &'a Program<'a>,
+        _source: &str,
+        offset: usize,
+        result: &mut ScriptLintResult,
+    ) {
         let mut visitor = NoNextTickVisitor {
             offset,
             result,
             imported_aliases: FxHashSet::default(),
         };
-        visitor.visit_program(&parsed.program);
+        visitor.visit_program(program);
     }
 }
 

--- a/crates/vize_patina/src/rules/script/no_options_api.rs
+++ b/crates/vize_patina/src/rules/script/no_options_api.rs
@@ -32,13 +32,11 @@
 
 use super::{ScriptLintResult, ScriptRule, ScriptRuleMeta};
 use crate::diagnostic::{LintDiagnostic, Severity};
-use oxc_allocator::Allocator;
 use oxc_ast::ast::{
     Argument, BindingPattern, ExportDefaultDeclarationKind, Expression, ImportDeclarationSpecifier,
-    ObjectExpression, ObjectPropertyKind, PropertyKey, Statement,
+    ObjectExpression, ObjectPropertyKind, Program, PropertyKey, Statement,
 };
-use oxc_parser::Parser;
-use oxc_span::{GetSpan, SourceType};
+use oxc_span::GetSpan;
 use vize_carton::{CompactString, FxHashMap, FxHashSet};
 
 static META: ScriptRuleMeta = ScriptRuleMeta {
@@ -56,8 +54,19 @@ impl ScriptRule for NoOptionsApi {
     }
 
     #[inline]
-    fn check(&self, source: &str, offset: usize, result: &mut ScriptLintResult) {
-        let Some(component_options) = find_component_options(source) else {
+    fn uses_ast(&self) -> bool {
+        true
+    }
+
+    #[inline]
+    fn check_program<'a>(
+        &self,
+        program: &'a Program<'a>,
+        _source: &str,
+        offset: usize,
+        result: &mut ScriptLintResult,
+    ) {
+        let Some(component_options) = find_component_options(program) else {
             return;
         };
 
@@ -113,22 +122,15 @@ struct OptionLabel {
     end: u32,
 }
 
-fn find_component_options(source: &str) -> Option<ComponentOptionsMatch> {
-    let allocator = Allocator::default();
-    let source_type = SourceType::from_path("component.ts").unwrap_or_else(|_| SourceType::ts());
-    let parsed = Parser::new(&allocator, source, source_type).parse();
-    if parsed.panicked || !parsed.errors.is_empty() {
-        return None;
-    }
-
+fn find_component_options<'a>(program: &'a Program<'a>) -> Option<ComponentOptionsMatch> {
     let mut bindings = FxHashMap::default();
     let mut petite_vue = PetiteVueBindings::default();
 
-    for statement in parsed.program.body.iter() {
+    for statement in program.body.iter() {
         collect_petite_vue_imports(statement, &mut petite_vue);
     }
 
-    for statement in parsed.program.body.iter() {
+    for statement in program.body.iter() {
         let Statement::VariableDeclaration(declaration) = statement else {
             continue;
         };
@@ -148,7 +150,7 @@ fn find_component_options(source: &str) -> Option<ComponentOptionsMatch> {
         }
     }
 
-    for statement in parsed.program.body.iter() {
+    for statement in program.body.iter() {
         let Statement::ExportDefaultDeclaration(export) = statement else {
             continue;
         };
@@ -160,7 +162,7 @@ fn find_component_options(source: &str) -> Option<ComponentOptionsMatch> {
         return Some(build_component_options_match(options.object));
     }
 
-    for statement in parsed.program.body.iter() {
+    for statement in program.body.iter() {
         let Some(options) =
             extract_create_app_options_from_statement(statement, &bindings, &petite_vue)
         else {

--- a/crates/vize_patina/src/rules/script/pinia_prefer_store_to_refs.rs
+++ b/crates/vize_patina/src/rules/script/pinia_prefer_store_to_refs.rs
@@ -9,11 +9,9 @@
 use super::{ScriptLintResult, ScriptRule, ScriptRuleMeta};
 use crate::diagnostic::{LintDiagnostic, Severity};
 use memchr::memmem;
-use oxc_allocator::Allocator;
-use oxc_ast::ast::{BindingPattern, CallExpression, Expression, VariableDeclarator};
+use oxc_ast::ast::{BindingPattern, CallExpression, Expression, Program, VariableDeclarator};
 use oxc_ast_visit::{Visit, walk::walk_variable_declarator};
-use oxc_parser::Parser;
-use oxc_span::{GetSpan, SourceType, Span};
+use oxc_span::{GetSpan, Span};
 use vize_carton::{CompactString, FxHashSet};
 
 static META: ScriptRuleMeta = ScriptRuleMeta {
@@ -29,16 +27,19 @@ impl ScriptRule for PiniaPreferStoreToRefs {
         &META
     }
 
-    fn check(&self, source: &str, offset: usize, result: &mut ScriptLintResult) {
-        if memmem::find(source.as_bytes(), b"Store").is_none() {
-            return;
-        }
+    #[inline]
+    fn uses_ast(&self) -> bool {
+        true
+    }
 
-        let allocator = Allocator::default();
-        let source_type =
-            SourceType::from_path("component.ts").unwrap_or_else(|_| SourceType::ts());
-        let parsed = Parser::new(&allocator, source, source_type).parse();
-        if parsed.panicked || !parsed.errors.is_empty() {
+    fn check_program<'a>(
+        &self,
+        program: &'a Program<'a>,
+        source: &str,
+        offset: usize,
+        result: &mut ScriptLintResult,
+    ) {
+        if memmem::find(source.as_bytes(), b"Store").is_none() {
             return;
         }
 
@@ -47,7 +48,7 @@ impl ScriptRule for PiniaPreferStoreToRefs {
             result,
             store_bindings: FxHashSet::default(),
         };
-        visitor.visit_program(&parsed.program);
+        visitor.visit_program(program);
     }
 }
 

--- a/crates/vize_patina/src/rules/script/vue_router_prefer_named_push.rs
+++ b/crates/vize_patina/src/rules/script/vue_router_prefer_named_push.rs
@@ -9,13 +9,12 @@
 use super::{ScriptLintResult, ScriptRule, ScriptRuleMeta};
 use crate::diagnostic::{LintDiagnostic, Severity};
 use memchr::memmem;
-use oxc_allocator::Allocator;
 use oxc_ast::ast::{
-    Argument, CallExpression, Expression, ObjectExpression, ObjectPropertyKind, PropertyKey,
+    Argument, CallExpression, Expression, ObjectExpression, ObjectPropertyKind, Program,
+    PropertyKey,
 };
 use oxc_ast_visit::{Visit, walk::walk_call_expression};
-use oxc_parser::Parser;
-use oxc_span::{SourceType, Span};
+use oxc_span::Span;
 
 static META: ScriptRuleMeta = ScriptRuleMeta {
     name: "ecosystem/vue-router-prefer-named-push",
@@ -30,7 +29,18 @@ impl ScriptRule for VueRouterPreferNamedPush {
         &META
     }
 
-    fn check(&self, source: &str, offset: usize, result: &mut ScriptLintResult) {
+    #[inline]
+    fn uses_ast(&self) -> bool {
+        true
+    }
+
+    fn check_program<'a>(
+        &self,
+        program: &'a Program<'a>,
+        source: &str,
+        offset: usize,
+        result: &mut ScriptLintResult,
+    ) {
         let bytes = source.as_bytes();
         if (memmem::find(bytes, b".push").is_none() && memmem::find(bytes, b".replace").is_none())
             || (memmem::find(bytes, b"'/").is_none() && memmem::find(bytes, b"\"/").is_none())
@@ -40,16 +50,8 @@ impl ScriptRule for VueRouterPreferNamedPush {
             return;
         }
 
-        let allocator = Allocator::default();
-        let source_type =
-            SourceType::from_path("component.ts").unwrap_or_else(|_| SourceType::ts());
-        let parsed = Parser::new(&allocator, source, source_type).parse();
-        if parsed.panicked || !parsed.errors.is_empty() {
-            return;
-        }
-
         let mut visitor = RouterPushVisitor { offset, result };
-        visitor.visit_program(&parsed.program);
+        visitor.visit_program(program);
     }
 }
 

--- a/crates/vize_patina/src/rules/script/vue_test_utils_no_html_snapshot.rs
+++ b/crates/vize_patina/src/rules/script/vue_test_utils_no_html_snapshot.rs
@@ -9,11 +9,8 @@
 use super::{ScriptLintResult, ScriptRule, ScriptRuleMeta};
 use crate::diagnostic::{LintDiagnostic, Severity};
 use memchr::memmem;
-use oxc_allocator::Allocator;
-use oxc_ast::ast::{Argument, CallExpression, Expression};
+use oxc_ast::ast::{Argument, CallExpression, Expression, Program};
 use oxc_ast_visit::{Visit, walk::walk_call_expression};
-use oxc_parser::Parser;
-use oxc_span::SourceType;
 
 static META: ScriptRuleMeta = ScriptRuleMeta {
     name: "ecosystem/vue-test-utils-no-html-snapshot",
@@ -28,7 +25,18 @@ impl ScriptRule for VueTestUtilsNoHtmlSnapshot {
         &META
     }
 
-    fn check(&self, source: &str, offset: usize, result: &mut ScriptLintResult) {
+    #[inline]
+    fn uses_ast(&self) -> bool {
+        true
+    }
+
+    fn check_program<'a>(
+        &self,
+        program: &'a Program<'a>,
+        source: &str,
+        offset: usize,
+        result: &mut ScriptLintResult,
+    ) {
         let bytes = source.as_bytes();
         if memmem::find(bytes, b"toMatchSnapshot").is_none()
             || memmem::find(bytes, b".html").is_none()
@@ -36,16 +44,8 @@ impl ScriptRule for VueTestUtilsNoHtmlSnapshot {
             return;
         }
 
-        let allocator = Allocator::default();
-        let source_type =
-            SourceType::from_path("component.test.ts").unwrap_or_else(|_| SourceType::ts());
-        let parsed = Parser::new(&allocator, source, source_type).parse();
-        if parsed.panicked || !parsed.errors.is_empty() {
-            return;
-        }
-
         let mut visitor = HtmlSnapshotVisitor { offset, result };
-        visitor.visit_program(&parsed.program);
+        visitor.visit_program(program);
     }
 }
 


### PR DESCRIPTION
Each AST-based ScriptRule re-parsed the identical script bytes (oxc parsing
dominates their cost). Mirror the CSS rules' design: parse once per block and
pass &Program to every rule via check_program; byte-scanner rules still run
without a parse. Also: component-name casing rule no longer allocates a
lowercased tag for native elements (only when the tag has an uppercase byte).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

---
Part of the adversarially-verified non-compiler performance audit (round 2: 106 findings → 27 confirmed). Behavior-preserving: full workspace test suite green (3439 passed, 0 failed) and `vize fmt`/`lint` output byte-identical. This reduces real work (allocations / redundant parses / lock ops / O(offset) scans) on the component's hot path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1078"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783332928&installation_id=136613492&pr_number=1078&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1078&signature=e265383ac99c4d096b63b5a3ff12a2237d11b1eeae4f1c0582c8b3d03233de46"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->