### PR TITLE
perf(patina): reuse one OxcAllocator + SourceType across template expressions

### DIFF
--- a/crates/vize_patina/src/linter/native_type_aware/template_queries/calls.rs
+++ b/crates/vize_patina/src/linter/native_type_aware/template_queries/calls.rs
@@ -41,6 +41,8 @@ pub(super) struct TemplateCallRanges {
 const TEMPLATE_HANDLER_PREFIX: &str = "function __vize_template_handler(){\n";
 
 pub(super) fn collect_template_call_ranges(
+    allocator: &OxcAllocator,
+    source_type: SourceType,
     source: &str,
     allow_statement_fallback: bool,
     include_callees: bool,
@@ -49,24 +51,25 @@ pub(super) fn collect_template_call_ranges(
     // Parse the template expression once and derive every range family from the
     // same AST. Event handlers can contain statement bodies, so only those callers
     // enable the statement fallback; ordinary bindings stay on the cheaper
-    // expression parse path.
+    // expression parse path. The arena and source type are owned by the caller and
+    // reused across every template expression in the file; each call copies all
+    // needed data into owned ranges before returning, so the caller may reset the
+    // arena afterwards without invalidating the result.
     let mut ranges = TemplateCallRanges::default();
     if !include_callees && !include_floating_promises {
         return ranges;
     }
 
-    let allocator = OxcAllocator::default();
-    let source_type = SourceType::from_path("template.ts").unwrap_or_default();
     if let Ok(expression) = profile!(
         "patina.type_aware.template_queries.parse_expression",
-        OxcParser::new(&allocator, source, source_type).parse_expression()
+        OxcParser::new(allocator, source, source_type).parse_expression()
     ) {
         ranges.probe_expression_binding = expression_prefers_binding_probe(&expression);
         let expression_consumes_source = expression.span().end as usize == source.trim_end().len();
         ranges.expression_consumes_source = expression_consumes_source;
         if allow_statement_fallback && !expression_consumes_source {
             let statement_ranges = collect_statement_template_call_ranges(
-                &allocator,
+                allocator,
                 source_type,
                 source,
                 include_callees,
@@ -112,7 +115,7 @@ pub(super) fn collect_template_call_ranges(
     }
 
     collect_statement_template_call_ranges(
-        &allocator,
+        allocator,
         source_type,
         source,
         include_callees,
@@ -546,7 +549,27 @@ fn is_handled_promise_chain(expression: &Expression<'_>) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::{FloatingPromiseRange, RelativeRange, collect_template_call_ranges};
+    use super::{
+        FloatingPromiseRange, OxcAllocator, RelativeRange, SourceType, TemplateCallRanges,
+    };
+
+    fn collect_template_call_ranges(
+        source: &str,
+        allow_statement_fallback: bool,
+        include_callees: bool,
+        include_floating_promises: bool,
+    ) -> TemplateCallRanges {
+        let allocator = OxcAllocator::default();
+        let source_type = SourceType::from_path("template.ts").unwrap_or_default();
+        super::collect_template_call_ranges(
+            &allocator,
+            source_type,
+            source,
+            allow_statement_fallback,
+            include_callees,
+            include_floating_promises,
+        )
+    }
 
     fn range_slices<'a>(source: &'a str, ranges: &[RelativeRange]) -> Vec<&'a str> {
         ranges

--- a/crates/vize_patina/src/linter/native_type_aware/template_queries/collector.rs
+++ b/crates/vize_patina/src/linter/native_type_aware/template_queries/collector.rs
@@ -4,6 +4,8 @@ use super::{
     calls::{FloatingPromiseProbeTarget, collect_template_call_ranges},
     generated_offset_for_text,
 };
+use oxc_allocator::Allocator as OxcAllocator;
+use oxc_span::SourceType;
 use vize_carton::profile;
 use vize_croquis::virtual_ts::VirtualTsOutput;
 use vize_relief::ast::{
@@ -29,12 +31,21 @@ pub(super) fn collect_template_query_sets(
             .then_some(&mut template_promise_queries),
     };
 
+    // Build the parsing arena and source type once per file. Every template
+    // expression reuses the same allocator (reset between expressions so its
+    // memory is recycled rather than freed and re-reserved) and the same source
+    // type (avoids re-deriving it from a path per expression).
+    let mut allocator = OxcAllocator::default();
+    let source_type = SourceType::from_path("template.ts").unwrap_or_default();
+
     profile!(
         "patina.type_aware.template_query_sets.walk",
         collect_children(
             virtual_ts,
             &template_ast.children,
             template_offset,
+            &mut allocator,
+            source_type,
             &mut sinks,
         )
     );
@@ -106,6 +117,8 @@ fn collect_children(
     virtual_ts: &VirtualTsOutput,
     children: &[TemplateChildNode<'_>],
     template_offset: u32,
+    allocator: &mut OxcAllocator,
+    source_type: SourceType,
     sinks: &mut TemplateQuerySinks<'_>,
 ) {
     for child in children {
@@ -118,13 +131,27 @@ fn collect_children(
                     if sinks.has_queries() {
                         profile!(
                             "patina.type_aware.template_query_sets.directive",
-                            collect_directive(virtual_ts, directive, template_offset, sinks)
+                            collect_directive(
+                                virtual_ts,
+                                directive,
+                                template_offset,
+                                allocator,
+                                source_type,
+                                sinks,
+                            )
                         );
                     }
                 }
                 profile!(
                     "patina.type_aware.template_query_sets.children",
-                    collect_children(virtual_ts, &element.children, template_offset, sinks)
+                    collect_children(
+                        virtual_ts,
+                        &element.children,
+                        template_offset,
+                        allocator,
+                        source_type,
+                        sinks,
+                    )
                 );
             }
             TemplateChildNode::Interpolation(interpolation) => {
@@ -134,13 +161,22 @@ fn collect_children(
                     template_offset,
                     TemplateContext::Interpolation,
                     false,
+                    allocator,
+                    source_type,
                     sinks,
                 );
             }
             TemplateChildNode::If(if_node) => {
                 profile!(
                     "patina.type_aware.template_query_sets.if",
-                    collect_if(virtual_ts, if_node, template_offset, sinks)
+                    collect_if(
+                        virtual_ts,
+                        if_node,
+                        template_offset,
+                        allocator,
+                        source_type,
+                        sinks
+                    )
                 )
             }
             TemplateChildNode::IfBranch(branch) => {
@@ -151,18 +187,34 @@ fn collect_children(
                         template_offset,
                         TemplateContext::Directive,
                         false,
+                        allocator,
+                        source_type,
                         sinks,
                     );
                 }
                 profile!(
                     "patina.type_aware.template_query_sets.children",
-                    collect_children(virtual_ts, &branch.children, template_offset, sinks)
+                    collect_children(
+                        virtual_ts,
+                        &branch.children,
+                        template_offset,
+                        allocator,
+                        source_type,
+                        sinks,
+                    )
                 );
             }
             TemplateChildNode::For(for_node) => {
                 profile!(
                     "patina.type_aware.template_query_sets.for",
-                    collect_for(virtual_ts, for_node, template_offset, sinks)
+                    collect_for(
+                        virtual_ts,
+                        for_node,
+                        template_offset,
+                        allocator,
+                        source_type,
+                        sinks
+                    )
                 )
             }
             TemplateChildNode::TextCall(text_call) => {
@@ -173,6 +225,8 @@ fn collect_children(
                         template_offset,
                         TemplateContext::Interpolation,
                         false,
+                        allocator,
+                        source_type,
                         sinks,
                     );
                 }
@@ -186,6 +240,8 @@ fn collect_if(
     virtual_ts: &VirtualTsOutput,
     if_node: &IfNode<'_>,
     template_offset: u32,
+    allocator: &mut OxcAllocator,
+    source_type: SourceType,
     sinks: &mut TemplateQuerySinks<'_>,
 ) {
     for branch in &if_node.branches {
@@ -196,12 +252,21 @@ fn collect_if(
                 template_offset,
                 TemplateContext::Directive,
                 false,
+                allocator,
+                source_type,
                 sinks,
             );
         }
         profile!(
             "patina.type_aware.template_query_sets.children",
-            collect_children(virtual_ts, &branch.children, template_offset, sinks)
+            collect_children(
+                virtual_ts,
+                &branch.children,
+                template_offset,
+                allocator,
+                source_type,
+                sinks,
+            )
         );
     }
 }
@@ -210,6 +275,8 @@ fn collect_for(
     virtual_ts: &VirtualTsOutput,
     for_node: &ForNode<'_>,
     template_offset: u32,
+    allocator: &mut OxcAllocator,
+    source_type: SourceType,
     sinks: &mut TemplateQuerySinks<'_>,
 ) {
     collect_expression(
@@ -218,20 +285,32 @@ fn collect_for(
         template_offset,
         TemplateContext::Directive,
         false,
+        allocator,
+        source_type,
         sinks,
     );
     profile!(
         "patina.type_aware.template_query_sets.children",
-        collect_children(virtual_ts, &for_node.children, template_offset, sinks)
+        collect_children(
+            virtual_ts,
+            &for_node.children,
+            template_offset,
+            allocator,
+            source_type,
+            sinks,
+        )
     );
 }
 
+#[allow(clippy::too_many_arguments)]
 fn collect_expression(
     virtual_ts: &VirtualTsOutput,
     expression: &ExpressionNode<'_>,
     template_offset: u32,
     context: TemplateContext,
     allow_statement_fallback: bool,
+    allocator: &mut OxcAllocator,
+    source_type: SourceType,
     sinks: &mut TemplateQuerySinks<'_>,
 ) {
     let include_template_queries = sinks.template_queries.is_some();
@@ -245,6 +324,8 @@ fn collect_expression(
                 template_offset,
                 context,
                 allow_statement_fallback,
+                allocator,
+                source_type,
                 sinks,
             )
         );
@@ -255,6 +336,8 @@ fn collect_directive(
     virtual_ts: &VirtualTsOutput,
     directive: &DirectiveNode<'_>,
     template_offset: u32,
+    allocator: &mut OxcAllocator,
+    source_type: SourceType,
     sinks: &mut TemplateQuerySinks<'_>,
 ) {
     let Some(expression) = &directive.exp else {
@@ -271,16 +354,21 @@ fn collect_directive(
         template_offset,
         context,
         matches!(context, TemplateContext::Event),
+        allocator,
+        source_type,
         sinks,
     );
 }
 
+#[allow(clippy::too_many_arguments)]
 fn collect_expression_query_sets(
     virtual_ts: &VirtualTsOutput,
     expression: &ExpressionNode<'_>,
     template_offset: u32,
     context: TemplateContext,
     allow_statement_fallback: bool,
+    allocator: &mut OxcAllocator,
+    source_type: SourceType,
     sinks: &mut TemplateQuerySinks<'_>,
 ) {
     let Some((source_start, source_end)) = absolute_expression_range(expression, template_offset)
@@ -301,12 +389,18 @@ fn collect_expression_query_sets(
     let call_ranges = profile!(
         "patina.type_aware.template_query_sets.call_ranges",
         collect_template_call_ranges(
+            allocator,
+            source_type,
             source_text,
             allow_statement_fallback,
             include_call_callees,
             include_template_promise_queries,
         )
     );
+    // `call_ranges` owns every range (plain integers / bools) and borrows nothing
+    // from the arena, so the arena can be recycled before the ranges are consumed.
+    // Resetting here reuses the parse memory for the next template expression.
+    allocator.reset();
 
     if let Some(queries) = sinks.template_queries.as_deref_mut() {
         if call_ranges.expression_consumes_source


### PR DESCRIPTION
native_type_aware call-range collection built a fresh OxcAllocator and
SourceType::from_path per template expression (both loop-invariant per file).
Build them once and reset the arena between expressions; results are copied to
owned data before reset.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

---
Part of the adversarially-verified non-compiler performance audit (round 2: 106 findings → 27 confirmed). Behavior-preserving: full workspace test suite green (3439 passed, 0 failed) and `vize fmt`/`lint` output byte-identical. This reduces real work (allocations / redundant parses / lock ops / O(offset) scans) on the component's hot path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1079"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783332931&installation_id=136613492&pr_number=1079&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1079&signature=23056846395a3081ff217814f2eb67e15d9c61b20cadb1fda00ccabba04b474c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->