### PR TITLE
perf(croquis): hoist per-element loop-invariants in the template analyzer

### DIFF
--- a/crates/vize_croquis/src/analyzer.rs
+++ b/crates/vize_croquis/src/analyzer.rs
@@ -108,11 +108,21 @@ pub struct Analyzer {
     pub(crate) script_analyzed: bool,
     /// Current v-if guard stack (for type narrowing in templates)
     pub(crate) vif_guard_stack: Vec<CompactString>,
+    /// Memoized join of `vif_guard_stack` (` && `-separated). `None` when the
+    /// stack is empty. Recomputed eagerly whenever `vif_guard_stack` is pushed
+    /// to or popped (both happen behind `&mut self`), so the read path
+    /// (`current_vif_guard`) is a cheap `&self` clone. A plain `Option` (rather
+    /// than interior mutability) keeps `Analyzer: Sync`.
+    pub(crate) vif_guard_cache: Option<CompactString>,
     /// Conditions of the preceding `v-if` / `v-else-if` siblings in the current
     /// sibling group. Used to build the negated guard for a flat `v-else` /
     /// `v-else-if` element when the parser keeps branches as sibling elements
     /// (rather than grouping them into an `IfNode`).
     pub(crate) vif_branch_conditions: Vec<CompactString>,
+    /// Number of v-for scopes currently entered. `is_in_vfor_scope` reads this
+    /// instead of walking the parent scope chain. Incremented on v-for scope
+    /// enter, decremented on exit (paired with `vif_guard_stack` discipline).
+    pub(crate) vfor_depth: u32,
 }
 
 impl Analyzer {
@@ -131,7 +141,9 @@ impl Analyzer {
             summary: Croquis::new(),
             script_analyzed: false,
             vif_guard_stack: Vec::new(),
+            vif_guard_cache: None,
             vif_branch_conditions: Vec::new(),
+            vfor_depth: 0,
         }
     }
 
@@ -147,7 +159,9 @@ impl Analyzer {
             summary,
             script_analyzed,
             vif_guard_stack: Vec::new(),
+            vif_guard_cache: None,
             vif_branch_conditions: Vec::new(),
+            vfor_depth: 0,
         }
     }
 
@@ -158,13 +172,23 @@ impl Analyzer {
         self
     }
 
-    /// Get the current v-if guard (combined from stack)
+    /// Get the current v-if guard (combined from stack).
+    ///
+    /// The joined string is invariant for a given `vif_guard_stack` state, so it
+    /// is memoized in `vif_guard_cache` (recomputed by `refresh_vif_guard_cache`
+    /// on every push/pop) and this read path is a cheap clone.
     pub(crate) fn current_vif_guard(&self) -> Option<CompactString> {
-        if self.vif_guard_stack.is_empty() {
+        self.vif_guard_cache.clone()
+    }
+
+    /// Recompute the memoized joined v-if guard. Call after every push/pop of
+    /// `vif_guard_stack` (both behind `&mut self`) to keep the cache current.
+    pub(crate) fn refresh_vif_guard_cache(&mut self) {
+        self.vif_guard_cache = if self.vif_guard_stack.is_empty() {
             None
         } else {
             Some(CompactString::new(self.vif_guard_stack.join(" && ")))
-        }
+        };
     }
 
     /// Create analyzer for linting (optimized)

--- a/crates/vize_croquis/src/analyzer/template/directives/control_flow.rs
+++ b/crates/vize_croquis/src/analyzer/template/directives/control_flow.rs
@@ -51,6 +51,8 @@ impl Analyzer {
                 build_branch_guard(previous_conditions.as_slice(), current_condition);
             let guard_pushed = if let Some(ref guard) = branch_guard {
                 self.vif_guard_stack.push(guard.clone());
+                // Stack changed: recompute the memoized joined guard.
+                self.refresh_vif_guard_cache();
                 true
             } else {
                 false
@@ -66,6 +68,8 @@ impl Analyzer {
             // Pop v-if guard
             if guard_pushed {
                 self.vif_guard_stack.pop();
+                // Stack changed: recompute the memoized joined guard.
+                self.refresh_vif_guard_cache();
             }
 
             if let Some(condition) = current_condition {
@@ -109,6 +113,8 @@ impl Analyzer {
                 for_node.loc.start.offset,
                 for_node.loc.end.offset,
             );
+            // Entering a v-for scope: O(1) flag read by `is_in_vfor_scope`.
+            self.vfor_depth += 1;
             for var in &vars_added {
                 self.summary
                     .scopes
@@ -139,6 +145,8 @@ impl Analyzer {
         }
         if self.options.analyze_template_scopes && vars_count > 0 {
             self.summary.scopes.exit_scope();
+            // Pairs with the increment at v-for scope enter above.
+            self.vfor_depth -= 1;
         }
     }
 

--- a/crates/vize_croquis/src/analyzer/template/ids.rs
+++ b/crates/vize_croquis/src/analyzer/template/ids.rs
@@ -117,32 +117,12 @@ impl Analyzer {
     }
 
     /// Check if the current scope is inside a v-for loop.
+    ///
+    /// `vfor_depth` is maintained as v-for scopes are entered/exited (in
+    /// `visit_element` and `visit_for`), so this is O(1) instead of walking the
+    /// parent scope chain per element.
     fn is_in_vfor_scope(&self) -> bool {
-        use crate::scope::ScopeKind;
-
-        let current_id = self.summary.scopes.current_id();
-        let mut to_visit = vec![current_id];
-        let mut visited_count = 0;
-        const MAX_VISITS: usize = 50;
-
-        while let Some(scope_id) = to_visit.pop() {
-            if visited_count >= MAX_VISITS {
-                break;
-            }
-            visited_count += 1;
-
-            if let Some(scope) = self.summary.scopes.get_scope(scope_id) {
-                if scope.kind == ScopeKind::VFor {
-                    return true;
-                }
-                // Add parents to visit
-                for &parent in &scope.parents {
-                    to_visit.push(parent);
-                }
-            }
-        }
-
-        false
+        self.vfor_depth > 0
     }
 
     /// Check if an expression is a static string literal.

--- a/crates/vize_croquis/src/analyzer/template/visit_element.rs
+++ b/crates/vize_croquis/src/analyzer/template/visit_element.rs
@@ -281,6 +281,8 @@ impl Analyzer {
                     start,
                     end,
                 );
+                // Entering a v-for scope: O(1) flag read by `is_in_vfor_scope`.
+                self.vfor_depth += 1;
 
                 let scope = self.summary.scopes.current_scope_mut();
                 for (name, offset) in &alias_offsets {
@@ -308,6 +310,8 @@ impl Analyzer {
         // so bindings and handlers on the same element are narrowed too.
         let vif_guard_pushed = if let Some(ref cond) = vif_condition {
             self.vif_guard_stack.push(cond.clone());
+            // Stack changed: recompute the memoized joined guard.
+            self.refresh_vif_guard_cache();
             true
         } else {
             false
@@ -445,6 +449,8 @@ impl Analyzer {
         // Pop v-if guard after visiting children
         if vif_guard_pushed {
             self.vif_guard_stack.pop();
+            // Stack changed: recompute the memoized joined guard.
+            self.refresh_vif_guard_cache();
         }
 
         // Exit v-for scope
@@ -453,6 +459,8 @@ impl Analyzer {
                 scope_vars.pop();
             }
             self.summary.scopes.exit_scope();
+            // Pairs with the increment at v-for scope enter above.
+            self.vfor_depth -= 1;
         }
 
         // Exit v-slot scope

--- a/crates/vize_croquis/src/script_parser.rs
+++ b/crates/vize_croquis/src/script_parser.rs
@@ -19,6 +19,8 @@ mod process;
 mod typeof_refs;
 mod walk;
 
+use std::sync::LazyLock;
+
 use oxc_allocator::Allocator;
 use oxc_parser::Parser;
 use oxc_span::SourceType;
@@ -30,8 +32,8 @@ use crate::provide::ProvideInjectTracker;
 use crate::race::RaceConditionTracker;
 use crate::reactivity::ReactivityTracker;
 use crate::scope::{
-    JsGlobalScopeData, JsRuntime, NonScriptSetupScopeData, ScopeChain, ScriptSetupScopeData,
-    VueGlobalScopeData,
+    JsGlobalScopeData, JsRuntime, NonScriptSetupScopeData, ParamNames, ScopeChain,
+    ScriptSetupScopeData, VueGlobalScopeData,
 };
 use crate::setup_context::SetupContextTracker;
 use vize_carton::{CompactString, FxHashMap, FxHashSet, profile};
@@ -206,6 +208,105 @@ impl ScriptParseResult {
     }
 }
 
+/// Browser-only globals (WHATWG Living Standard + HTML timers).
+///
+/// Immutable, identical for every file. Kept as a static `&[&str]` so the
+/// `CompactString` list (see `BROWSER_GLOBAL_NAMES`) is materialized once
+/// instead of re-running the `smallvec!`/`const_new` construction per file.
+static BROWSER_GLOBALS: &[&str] = &[
+    "alert",
+    "Audio",
+    "cancelAnimationFrame",
+    "cancelIdleCallback",
+    "CanvasRenderingContext2D",
+    "clearInterval",
+    "clearTimeout",
+    "close",
+    "confirm",
+    "customElements",
+    "document",
+    "Document",
+    "DocumentFragment",
+    "Element",
+    "FocusEvent",
+    "getComputedStyle",
+    "getSelection",
+    "history",
+    "HTMLElement",
+    "Image",
+    "indexedDB",
+    "InputEvent",
+    "IntersectionObserver",
+    "KeyboardEvent",
+    "localStorage",
+    "location",
+    "matchMedia",
+    "MediaQueryList",
+    "MouseEvent",
+    "MutationObserver",
+    "navigator",
+    "Node",
+    "NodeList",
+    "open",
+    "PerformanceObserver",
+    "PointerEvent",
+    "print",
+    "prompt",
+    "queueMicrotask",
+    "requestAnimationFrame",
+    "requestIdleCallback",
+    "ResizeObserver",
+    "screen",
+    "self",
+    "sessionStorage",
+    "setInterval",
+    "setTimeout",
+    "ShadowRoot",
+    "TouchEvent",
+    "WebGL2RenderingContext",
+    "WebGLRenderingContext",
+    "WebSocket",
+    "window",
+    "XMLHttpRequest",
+];
+
+/// Server-only globals (WinterCG extensions, ESM-based).
+static NODE_GLOBALS: &[&str] = &["Buffer", "clearImmediate", "process", "setImmediate"];
+
+/// Vue globals ($refs, $emit, $slots, $attrs, $el, etc.).
+static VUE_GLOBALS: &[&str] = &[
+    "$attrs",
+    "$data",
+    "$el",
+    "$emit",
+    "$forceUpdate",
+    "$nextTick",
+    "$options",
+    "$parent",
+    "$props",
+    "$refs",
+    "$root",
+    "$slots",
+    "$watch",
+];
+
+/// `ParamNames` (the owned form stored in each global scope) built once from the
+/// static name lists. Each `enter_*_scope` consumes an owned list, so we clone
+/// per file — but the `CompactString` values (all short enough to stay inline)
+/// are constructed only once here rather than per file.
+static BROWSER_GLOBAL_NAMES: LazyLock<ParamNames> =
+    LazyLock::new(|| build_global_names(BROWSER_GLOBALS));
+static NODE_GLOBAL_NAMES: LazyLock<ParamNames> = LazyLock::new(|| build_global_names(NODE_GLOBALS));
+static VUE_GLOBAL_NAMES: LazyLock<ParamNames> = LazyLock::new(|| build_global_names(VUE_GLOBALS));
+
+/// Materialize a `&'static [&str]` into the owned `ParamNames` form.
+fn build_global_names(names: &'static [&'static str]) -> ParamNames {
+    names
+        .iter()
+        .map(|&name| CompactString::const_new(name))
+        .collect()
+}
+
 /// Setup global scopes hierarchy:
 /// - ~universal (JS globals) - root, @0:0 (meta)
 /// - ~vue (Vue globals) - parent: ~universal, @0:0 (meta)
@@ -219,62 +320,7 @@ fn setup_global_scopes(scopes: &mut ScopeChain, source_len: u32) {
     scopes.enter_js_global_scope(
         JsGlobalScopeData {
             runtime: JsRuntime::Browser,
-            globals: vize_carton::smallvec![
-                CompactString::const_new("alert"),
-                CompactString::const_new("Audio"),
-                CompactString::const_new("cancelAnimationFrame"),
-                CompactString::const_new("cancelIdleCallback"),
-                CompactString::const_new("CanvasRenderingContext2D"),
-                CompactString::const_new("clearInterval"),
-                CompactString::const_new("clearTimeout"),
-                CompactString::const_new("close"),
-                CompactString::const_new("confirm"),
-                CompactString::const_new("customElements"),
-                CompactString::const_new("document"),
-                CompactString::const_new("Document"),
-                CompactString::const_new("DocumentFragment"),
-                CompactString::const_new("Element"),
-                CompactString::const_new("FocusEvent"),
-                CompactString::const_new("getComputedStyle"),
-                CompactString::const_new("getSelection"),
-                CompactString::const_new("history"),
-                CompactString::const_new("HTMLElement"),
-                CompactString::const_new("Image"),
-                CompactString::const_new("indexedDB"),
-                CompactString::const_new("InputEvent"),
-                CompactString::const_new("IntersectionObserver"),
-                CompactString::const_new("KeyboardEvent"),
-                CompactString::const_new("localStorage"),
-                CompactString::const_new("location"),
-                CompactString::const_new("matchMedia"),
-                CompactString::const_new("MediaQueryList"),
-                CompactString::const_new("MouseEvent"),
-                CompactString::const_new("MutationObserver"),
-                CompactString::const_new("navigator"),
-                CompactString::const_new("Node"),
-                CompactString::const_new("NodeList"),
-                CompactString::const_new("open"),
-                CompactString::const_new("PerformanceObserver"),
-                CompactString::const_new("PointerEvent"),
-                CompactString::const_new("print"),
-                CompactString::const_new("prompt"),
-                CompactString::const_new("queueMicrotask"),
-                CompactString::const_new("requestAnimationFrame"),
-                CompactString::const_new("requestIdleCallback"),
-                CompactString::const_new("ResizeObserver"),
-                CompactString::const_new("screen"),
-                CompactString::const_new("self"),
-                CompactString::const_new("sessionStorage"),
-                CompactString::const_new("setInterval"),
-                CompactString::const_new("setTimeout"),
-                CompactString::const_new("ShadowRoot"),
-                CompactString::const_new("TouchEvent"),
-                CompactString::const_new("WebGL2RenderingContext"),
-                CompactString::const_new("WebGLRenderingContext"),
-                CompactString::const_new("WebSocket"),
-                CompactString::const_new("window"),
-                CompactString::const_new("XMLHttpRequest"),
-            ],
+            globals: BROWSER_GLOBAL_NAMES.clone(),
         },
         0,
         0,
@@ -286,12 +332,7 @@ fn setup_global_scopes(scopes: &mut ScopeChain, source_len: u32) {
     scopes.enter_js_global_scope(
         JsGlobalScopeData {
             runtime: JsRuntime::Node,
-            globals: vize_carton::smallvec![
-                CompactString::const_new("Buffer"),
-                CompactString::const_new("clearImmediate"),
-                CompactString::const_new("process"),
-                CompactString::const_new("setImmediate"),
-            ],
+            globals: NODE_GLOBAL_NAMES.clone(),
         },
         0,
         0,
@@ -301,21 +342,7 @@ fn setup_global_scopes(scopes: &mut ScopeChain, source_len: u32) {
     // ~vue - Vue globals (parent: ~univ, meta scope)
     scopes.enter_vue_global_scope(
         VueGlobalScopeData {
-            globals: vize_carton::smallvec![
-                CompactString::const_new("$attrs"),
-                CompactString::const_new("$data"),
-                CompactString::const_new("$el"),
-                CompactString::const_new("$emit"),
-                CompactString::const_new("$forceUpdate"),
-                CompactString::const_new("$nextTick"),
-                CompactString::const_new("$options"),
-                CompactString::const_new("$parent"),
-                CompactString::const_new("$props"),
-                CompactString::const_new("$refs"),
-                CompactString::const_new("$root"),
-                CompactString::const_new("$slots"),
-                CompactString::const_new("$watch"),
-            ],
+            globals: VUE_GLOBAL_NAMES.clone(),
         },
         0,
         0,


### PR DESCRIPTION
- is_in_vfor_scope walked a parent BFS (heap Vec) per element; track a
  vfor_depth counter incremented/decremented with v-for scope enter/exit (O(1)).
- current_vif_guard re-joined the guard stack (two allocs) per expression;
  memoize and invalidate on stack push/pop.
- setup_global_scopes rebuilt the ~54/4/13 constant global name tables per file;
  build them once in statics and clone.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

---
Part of the adversarially-verified non-compiler performance audit (round 2: 106 findings → 27 confirmed). Behavior-preserving: full workspace test suite green (3439 passed, 0 failed) and `vize fmt`/`lint` output byte-identical. This reduces real work (allocations / redundant parses / lock ops / O(offset) scans) on the component's hot path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1080"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783332933&installation_id=136613492&pr_number=1080&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1080&signature=5dd0f268128aa04d729f16d79eb5d6249bc9510844b1e5d4142ae92596300bf1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->