### PR TITLE
perf(canon): stop cloning the shared global Vecs per .vue file

### DIFF
--- a/crates/vize_canon/src/batch/virtual_project.rs
+++ b/crates/vize_canon/src/batch/virtual_project.rs
@@ -1336,9 +1336,8 @@ fn build_vue_registered_file(
         .map_err(|error| CorsaError::SfcParse(error.message.to_compact_string()))
     )?;
 
-    let mut effective_options =
+    let effective_options =
         virtual_ts_options_for_descriptor(context.virtual_ts_options, &descriptor);
-    effective_options.auto_import_stubs.clear();
     let generated = profile!(
         "canon.vue.virtual_ts",
         generate_vue_virtual_ts(
@@ -1545,6 +1544,11 @@ fn virtual_ts_options_for_descriptor(
     base: &VirtualTsOptions,
     descriptor: &SfcDescriptor,
 ) -> VirtualTsOptions {
+    // Per-file generation never re-emits the global auto-import stubs inline:
+    // they are written once to a shared ambient `.d.ts` (see
+    // `write_auto_import_stubs`). Build the per-file options with an empty
+    // `auto_import_stubs` instead of deep-cloning the (potentially large,
+    // Nuxt/auto-import) global Vec only to clear it again at the call site.
     let css_modules: Vec<CompactString> = descriptor
         .styles
         .iter()
@@ -1555,13 +1559,20 @@ fn virtual_ts_options_for_descriptor(
                 .map(|module| module.to_compact_string())
         })
         .collect();
-    if css_modules.is_empty() {
-        return base.clone();
-    }
+    let css_modules = if css_modules.is_empty() {
+        // No `<style module>` blocks: reuse the global css_modules (typically
+        // also empty) rather than the freshly collected empty Vec.
+        base.css_modules.clone()
+    } else {
+        css_modules
+    };
 
-    let mut options = base.clone();
-    options.css_modules = css_modules;
-    options
+    VirtualTsOptions {
+        template_globals: base.template_globals.clone(),
+        css_modules,
+        auto_import_stubs: Vec::new(),
+        external_template_bindings: base.external_template_bindings.clone(),
+    }
 }
 
 fn mirrored_virtual_path(


### PR DESCRIPTION
virtual_ts_options_for_descriptor deep-cloned all four global option Vecs
(auto_import_stubs has hundreds of entries for Nuxt/auto-import) and the caller
immediately cleared auto_import_stubs. Construct the per-file options with an
empty auto_import_stubs directly and only collect css_modules when present.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

---
Part of the adversarially-verified non-compiler performance audit (round 2: 106 findings → 27 confirmed). Behavior-preserving: full workspace test suite green (3439 passed, 0 failed) and `vize fmt`/`lint` output byte-identical. This reduces real work (allocations / redundant parses / lock ops / O(offset) scans) on the component's hot path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1081"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783332935&installation_id=136613492&pr_number=1081&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1081&signature=61e4d403f7ae1c26bf530c27b19feaec067841d3b174cdafecfadc36cd628221"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->