### PR TITLE
perf(fresco): cut per-node/per-frame allocations in the render+layout loop

### DIFF
--- a/crates/vize_fresco/src/layout/engine.rs
+++ b/crates/vize_fresco/src/layout/engine.rs
@@ -192,30 +192,27 @@ impl LayoutEngine {
             );
         }
 
-        // Collect children sizes and margins from style
+        // Collect children to release the `&self` borrow before recursing.
         let children: Vec<_> = self.tree.children(node_id).unwrap_or_default();
-        let child_info: Vec<(NodeId, f32, f32, f32, f32, f32, f32)> = children
-            .iter()
-            .map(|&cid| {
-                // Panic path by child invariant: `cid` came directly from
-                // `tree.children(node_id)`, so layout/style lookup should be
-                // available after the successful compute pass above.
-                let cl = self.tree.layout(cid).expect("child layout");
-                let cs = self.tree.style(cid).expect("child style");
-                // Get margin from style (not layout) to avoid auto-margin issues
-                let mt = resolve_margin(cs.margin.top);
-                let mr = resolve_margin(cs.margin.right);
-                let mb = resolve_margin(cs.margin.bottom);
-                let ml = resolve_margin(cs.margin.left);
-                (cid, cl.size.width, cl.size.height, mt, mr, mb, ml)
-            })
-            .collect();
 
         // Position children manually based on flex_direction
         let mut offset_x = parent_x + padding_left;
         let mut offset_y = parent_y + padding_top;
 
-        for (child_id, child_width, child_height, mt, mr, mb, ml) in child_info {
+        for child_id in children {
+            // Panic path by child invariant: `child_id` came directly from
+            // `tree.children(node_id)`, so layout/style lookup should be
+            // available after the successful compute pass above.
+            let cl = self.tree.layout(child_id).expect("child layout");
+            let cs = self.tree.style(child_id).expect("child style");
+            // Get margin from style (not layout) to avoid auto-margin issues
+            let mt = resolve_margin(cs.margin.top);
+            let mr = resolve_margin(cs.margin.right);
+            let mb = resolve_margin(cs.margin.bottom);
+            let ml = resolve_margin(cs.margin.left);
+            let child_width = cl.size.width;
+            let child_height = cl.size.height;
+
             // Apply margin to position
             let child_x = offset_x + ml;
             let child_y = offset_y + mt;

--- a/crates/vize_fresco/src/napi/render.rs
+++ b/crates/vize_fresco/src/napi/render.rs
@@ -625,25 +625,57 @@ fn parse_color(s: &str) -> Option<Color> {
         return Some(color);
     }
 
-    // Try named color
-    match s.to_lowercase().as_str() {
-        "black" => Some(Color::Black),
-        "red" => Some(Color::Red),
-        "green" => Some(Color::Green),
-        "yellow" => Some(Color::Yellow),
-        "blue" => Some(Color::Blue),
-        "magenta" => Some(Color::Magenta),
-        "cyan" => Some(Color::Cyan),
-        "white" => Some(Color::White),
-        "gray" | "grey" => Some(Color::Gray),
-        "lightred" => Some(Color::LightRed),
-        "lightgreen" => Some(Color::LightGreen),
-        "lightyellow" => Some(Color::LightYellow),
-        "lightblue" => Some(Color::LightBlue),
-        "lightmagenta" => Some(Color::LightMagenta),
-        "lightcyan" => Some(Color::LightCyan),
-        "lightwhite" => Some(Color::LightWhite),
-        "reset" => Some(Color::Reset),
-        _ => None,
+    // Try named color (alloc-free, case-insensitive ASCII match)
+    if s.eq_ignore_ascii_case("black") {
+        return Some(Color::Black);
     }
+    if s.eq_ignore_ascii_case("red") {
+        return Some(Color::Red);
+    }
+    if s.eq_ignore_ascii_case("green") {
+        return Some(Color::Green);
+    }
+    if s.eq_ignore_ascii_case("yellow") {
+        return Some(Color::Yellow);
+    }
+    if s.eq_ignore_ascii_case("blue") {
+        return Some(Color::Blue);
+    }
+    if s.eq_ignore_ascii_case("magenta") {
+        return Some(Color::Magenta);
+    }
+    if s.eq_ignore_ascii_case("cyan") {
+        return Some(Color::Cyan);
+    }
+    if s.eq_ignore_ascii_case("white") {
+        return Some(Color::White);
+    }
+    if s.eq_ignore_ascii_case("gray") || s.eq_ignore_ascii_case("grey") {
+        return Some(Color::Gray);
+    }
+    if s.eq_ignore_ascii_case("lightred") {
+        return Some(Color::LightRed);
+    }
+    if s.eq_ignore_ascii_case("lightgreen") {
+        return Some(Color::LightGreen);
+    }
+    if s.eq_ignore_ascii_case("lightyellow") {
+        return Some(Color::LightYellow);
+    }
+    if s.eq_ignore_ascii_case("lightblue") {
+        return Some(Color::LightBlue);
+    }
+    if s.eq_ignore_ascii_case("lightmagenta") {
+        return Some(Color::LightMagenta);
+    }
+    if s.eq_ignore_ascii_case("lightcyan") {
+        return Some(Color::LightCyan);
+    }
+    if s.eq_ignore_ascii_case("lightwhite") {
+        return Some(Color::LightWhite);
+    }
+    if s.eq_ignore_ascii_case("reset") {
+        return Some(Color::Reset);
+    }
+    None
 }

--- a/crates/vize_fresco/src/render/painter.rs
+++ b/crates/vize_fresco/src/render/painter.rs
@@ -11,12 +11,17 @@ use super::{BorderStyle, NodeKind, RenderNode, RenderTree};
 /// Painter renders nodes to a terminal buffer.
 pub struct Painter<'a> {
     buffer: &'a mut Buffer,
+    /// Reusable scratch buffer for wrapped lines (cleared per use).
+    wrap_scratch: Vec<CompactString>,
 }
 
 impl<'a> Painter<'a> {
     /// Create a new painter.
     pub fn new(buffer: &'a mut Buffer) -> Self {
-        Self { buffer }
+        Self {
+            buffer,
+            wrap_scratch: Vec::new(),
+        }
     }
 
     /// Paint the entire tree to the buffer.
@@ -122,9 +127,17 @@ impl<'a> Painter<'a> {
             return;
         }
 
-        let lines = TextWrap::wrap(text, area.width as usize, mode);
+        // Fast path: NoWrap is a single line clipped to the buffer width, which
+        // is exactly what `set_string` does. Bypass wrapping entirely so we
+        // avoid allocating a Vec + a CompactString copy of the whole string.
+        if mode == WrapMode::NoWrap {
+            self.buffer.set_string(area.x, area.y, text, style);
+            return;
+        }
 
-        for (i, line) in lines.iter().enumerate() {
+        TextWrap::wrap_into(text, area.width as usize, mode, &mut self.wrap_scratch);
+
+        for (i, line) in self.wrap_scratch.iter().enumerate() {
             if i >= area.height as usize {
                 break;
             }
@@ -160,10 +173,15 @@ impl<'a> Painter<'a> {
 
         // Wrap text to fit area width
         let area_width = area.width as usize;
-        let wrapped_lines = TextWrap::wrap(&display_text, area_width, WrapMode::Char);
+        TextWrap::wrap_into(
+            &display_text,
+            area_width,
+            WrapMode::Char,
+            &mut self.wrap_scratch,
+        );
 
         // Render each wrapped line
-        for (i, line) in wrapped_lines.iter().enumerate() {
+        for (i, line) in self.wrap_scratch.iter().enumerate() {
             if i >= area.height as usize {
                 break;
             }

--- a/crates/vize_fresco/src/text/wrap.rs
+++ b/crates/vize_fresco/src/text/wrap.rs
@@ -30,13 +30,27 @@ pub struct TextWrap;
 impl TextWrap {
     /// Wrap text to fit within max_width columns.
     pub fn wrap(text: &str, max_width: usize, mode: WrapMode) -> Vec<CompactString> {
+        let mut out = Vec::new();
+        Self::wrap_into(text, max_width, mode, &mut out);
+        out
+    }
+
+    /// Wrap text into a reusable buffer, clearing it first.
+    ///
+    /// Produces the same lines as [`Self::wrap`] but lets callers reuse the
+    /// outer `Vec` allocation across frames; only the per-line `CompactString`s
+    /// are allocated.
+    pub fn wrap_into(text: &str, max_width: usize, mode: WrapMode, out: &mut Vec<CompactString>) {
+        out.clear();
         match mode {
-            WrapMode::NoWrap => vec![CompactString::from(text)],
-            WrapMode::Word => Self::wrap_word(text, max_width),
-            WrapMode::Char => Self::wrap_char(text, max_width),
-            WrapMode::Truncate | WrapMode::TruncateEnd => vec![Self::truncate_end(text, max_width)],
-            WrapMode::TruncateStart => vec![Self::truncate_start(text, max_width)],
-            WrapMode::TruncateMiddle => vec![Self::truncate_middle(text, max_width)],
+            WrapMode::NoWrap => out.push(CompactString::from(text)),
+            WrapMode::Word => Self::wrap_word_into(text, max_width, out),
+            WrapMode::Char => Self::wrap_char_into(text, max_width, out),
+            WrapMode::Truncate | WrapMode::TruncateEnd => {
+                out.push(Self::truncate_end(text, max_width))
+            }
+            WrapMode::TruncateStart => out.push(Self::truncate_start(text, max_width)),
+            WrapMode::TruncateMiddle => out.push(Self::truncate_middle(text, max_width)),
         }
     }
 
@@ -143,13 +157,13 @@ impl TextWrap {
         prefix
     }
 
-    /// Wrap at word boundaries.
-    fn wrap_word(text: &str, max_width: usize) -> Vec<CompactString> {
+    /// Wrap at word boundaries into a (pre-cleared) buffer.
+    fn wrap_word_into(text: &str, max_width: usize, lines: &mut Vec<CompactString>) {
         if max_width == 0 {
-            return vec![];
+            return;
         }
 
-        let mut lines = Vec::new();
+        let start_len = lines.len();
         let mut current_line = CompactString::default();
         let mut current_width = 0;
 
@@ -192,20 +206,25 @@ impl TextWrap {
             lines.push(CompactString::from(current_line.trim_end()));
         }
 
-        if lines.is_empty() {
+        if lines.len() == start_len {
             lines.push(CompactString::new(""));
         }
-
-        lines
     }
 
     /// Wrap at character boundaries.
     fn wrap_char(text: &str, max_width: usize) -> Vec<CompactString> {
+        let mut lines = Vec::new();
+        Self::wrap_char_into(text, max_width, &mut lines);
+        lines
+    }
+
+    /// Wrap at character boundaries into a (pre-cleared) buffer.
+    fn wrap_char_into(text: &str, max_width: usize, lines: &mut Vec<CompactString>) {
         if max_width == 0 {
-            return vec![];
+            return;
         }
 
-        let mut lines = Vec::new();
+        let start_len = lines.len();
         let mut current_line = CompactString::default();
         let mut current_width = 0;
 
@@ -236,11 +255,9 @@ impl TextWrap {
             lines.push(current_line);
         }
 
-        if lines.is_empty() {
+        if lines.len() == start_len {
             lines.push(CompactString::new(""));
         }
-
-        lines
     }
 
     /// Split text into lines (preserving existing newlines).


### PR DESCRIPTION
- cache_layouts dropped the intermediate child_info Vec (inline the reads).
- paint_text/paint_input special-case NoWrap to write directly via set_string
  and reuse a scratch Vec for wrapping modes (was a Vec+CompactString/line/frame).
- parse_color matches named colors via eq_ignore_ascii_case instead of
  allocating a lowercased String per color per node per frame.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

---
Part of the adversarially-verified non-compiler performance audit (round 2: 106 findings → 27 confirmed). Behavior-preserving: full workspace test suite green (3439 passed, 0 failed) and `vize fmt`/`lint` output byte-identical. This reduces real work (allocations / redundant parses / lock ops / O(offset) scans) on the component's hot path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1082"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783332938&installation_id=136613492&pr_number=1082&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1082&signature=c315eb72fac0bab3f1242d798cd3a1744a329e56b3de2f6a6f3a509594e957f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->