### PR TITLE
perf(croquis_cf): use parent-pointer frames in find_nearest_providers BFS

### DIFF
--- a/crates/vize_croquis_cf/src/analyzers/cross_file_reactivity/flow_provide_inject.rs
+++ b/crates/vize_croquis_cf/src/analyzers/cross_file_reactivity/flow_provide_inject.rs
@@ -129,11 +129,19 @@ impl<'a> CrossFileReactivityAnalyzer<'a> {
     ) -> Vec<ProvideDefinition> {
         let mut providers = Vec::new();
         let mut seen_providers = FxHashSet::default();
-        let mut queue = vec![(consumer_file_id, vec![consumer_file_id])];
+        // Parent-pointer BFS frames: each frame records the visited file and the
+        // index of the frame it was reached from. The visited path (used only for
+        // cycle detection) is recovered by walking `parent` pointers, which avoids
+        // cloning an O(depth) `Vec<FileId>` for every queued node.
+        let mut frames = vec![AncestorFrame {
+            current: consumer_file_id,
+            parent: None,
+        }];
         let mut cursor = 0;
 
-        while cursor < queue.len() {
-            let (current, path) = queue[cursor].clone();
+        while cursor < frames.len() {
+            let frame_index = cursor;
+            let current = frames[frame_index].current;
             cursor += 1;
 
             if current != consumer_file_id
@@ -153,19 +161,43 @@ impl<'a> CrossFileReactivityAnalyzer<'a> {
                 .graph
                 .dependents(current)
                 .filter(|(parent_id, edge_type)| {
-                    *edge_type == DependencyEdge::ComponentUsage && !path.contains(parent_id)
+                    *edge_type == DependencyEdge::ComponentUsage
+                        && !frame_contains(&frames, frame_index, *parent_id)
                 })
                 .collect();
             parents.sort_by_key(|(parent_id, _)| parent_id.as_u32());
 
             for (parent_id, _) in parents {
-                let mut new_path = path.clone();
-                new_path.push(parent_id);
-                queue.push((parent_id, new_path));
+                frames.push(AncestorFrame {
+                    current: parent_id,
+                    parent: Some(frame_index),
+                });
             }
         }
 
         providers.sort_by_key(|provider| (provider.file_id.as_u32(), provider.offset));
         providers
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct AncestorFrame {
+    current: FileId,
+    parent: Option<usize>,
+}
+
+/// Returns true if `needle` appears on the visited path ending at `index`,
+/// walking `parent` pointers to the root. Mirrors `path.contains(..)` over the
+/// path that the original `(FileId, Vec<FileId>)` queue accumulated.
+fn frame_contains(frames: &[AncestorFrame], mut index: usize, needle: FileId) -> bool {
+    loop {
+        let frame = frames[index];
+        if frame.current == needle {
+            return true;
+        }
+        let Some(parent) = frame.parent else {
+            return false;
+        };
+        index = parent;
     }
 }


### PR DESCRIPTION
The BFS cloned an O(depth) path Vec per node for cycle detection. Switch to
AncestorFrame parent-index frames (the pattern already used by the sibling
provide/inject analyzer); walk parent pointers instead. Provider set and final
ordering preserved.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

---
Part of the adversarially-verified non-compiler performance audit (round 2: 106 findings → 27 confirmed). Behavior-preserving: full workspace test suite green (3439 passed, 0 failed) and `vize fmt`/`lint` output byte-identical. This reduces real work (allocations / redundant parses / lock ops / O(offset) scans) on the component's hot path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1083"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783332940&installation_id=136613492&pr_number=1083&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1083&signature=9e7b05c0e6bd503d37e804756669393517242c6323cda0adfac0089745ebc9b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->