### PR TITLE
perf(js-plugins): avoid redundant request classification on hot hooks

### DIFF
--- a/npm/unplugin-vize/src/request.ts
+++ b/npm/unplugin-vize/src/request.ts
@@ -7,6 +7,12 @@ export function isVueFile(id: string): boolean {
 }
 
 export function isVueStyleRequest(id: string): boolean {
+  // Style requests always carry the `?vue&type=style` query (the `vue` param is
+  // serialized first, so the id always contains `?vue`). Skip URLSearchParams
+  // parsing for the overwhelmingly common ids that cannot be a style request.
+  if (!id.includes("?vue")) {
+    return false;
+  }
   const { query } = parseVueRequest(id);
   return query.vue && query.type === "style";
 }

--- a/npm/unplugin-vize/src/unplugin.ts
+++ b/npm/unplugin-vize/src/unplugin.ts
@@ -207,6 +207,12 @@ export const vizeUnplugin = createUnplugin<VizeUnpluginOptions | undefined>((raw
       if (options.hostCompiler) {
         return false;
       }
+      // A `.vue` filename (from the path or a `vize-file` query) is required for a
+      // match, so ids without a `.vue` substring can never be transformed. Skip
+      // URLSearchParams parsing for the common plain-JS imports.
+      if (!id.includes(".vue")) {
+        return false;
+      }
       const request = parseVueRequest(id);
       return !request.query.vue && isVueFile(request.filename) && filter(request.filename);
     },

--- a/npm/vite-plugin-vize/src/plugin/resolve.ts
+++ b/npm/vite-plugin-vize/src/plugin/resolve.ts
@@ -667,7 +667,16 @@ function isPotentialVizeResolveId(id: string): boolean {
   );
 }
 
-function isPotentialVizeImporter(importer: string | undefined): boolean {
+function classifyImporterRequest(
+  importer: string | undefined,
+): ReturnType<typeof classifyVitePluginRequest> | null {
+  return importer ? classifyVitePluginRequest(importer) : null;
+}
+
+function isPotentialVizeImporter(
+  importer: string | undefined,
+  importerRequest: ReturnType<typeof classifyVitePluginRequest> | null,
+): boolean {
   // Imports from Vize virtual modules still need custom resolution even when the
   // requested id itself is a regular-looking relative or bare specifier.
   if (importer === undefined) {
@@ -677,8 +686,7 @@ function isPotentialVizeImporter(importer: string | undefined): boolean {
     return true;
   }
 
-  const request = classifyVitePluginRequest(importer);
-  return request.isVueSfcPath;
+  return importerRequest?.isVueSfcPath ?? false;
 }
 
 function shouldCompileVueSfcRequest(
@@ -789,13 +797,20 @@ export async function resolveIdHook(
   // the id nor importer can involve a Vue SFC or Vize virtual module. This was
   // added after profiles showed ordinary dependency graph edges dominating the
   // plugin hook cost in dev servers.
-  if (!isPotentialVizeResolveId(id) && !isPotentialVizeImporter(importer)) {
+  //
+  // Classify the importer at most once: the importer gate (`isPotentialVizeImporter`)
+  // and the later `importerRequest` derivations both need the same classification,
+  // so crossing the NAPI boundary twice for the same importer string is pure
+  // overhead. Classify the defined importer once here and reuse the result for
+  // both the gate below and the rest of the hook; `isPotentialVizeImporter` reads
+  // its `isVueSfcPath` rather than re-classifying.
+  const importerRequest = classifyImporterRequest(importer);
+  if (!isPotentialVizeResolveId(id) && !isPotentialVizeImporter(importer, importerRequest)) {
     return null;
   }
 
   const isBuild = state.server === null;
   const isDependencyScan = !!options?.scan;
-  const importerRequest = importer ? classifyVitePluginRequest(importer) : null;
   const isSsrRequest =
     !!options?.ssr ||
     (importerRequest?.isVizeSsrVirtual ?? false) ||


### PR DESCRIPTION
- vite-plugin resolveId classified the importer twice (gate + importerRequest);
  classify once and reuse, removing a NAPI crossing per import edge.
- unplugin isVueStyleRequest/transformInclude built URLSearchParams for every
  module; add cheap '?vue'/'.vue' string pre-gates before parseVueRequest.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

---
Part of the adversarially-verified non-compiler performance audit (round 2: 106 findings → 27 confirmed). Behavior-preserving: full workspace test suite green (3439 passed, 0 failed) and `vize fmt`/`lint` output byte-identical. This reduces real work (allocations / redundant parses / lock ops / O(offset) scans) on the component's hot path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1084"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783332942&installation_id=136613492&pr_number=1084&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1084&signature=64cfaaf0dfc5dfb7d6a7c627ca37ce5db2ac8e9bebc0647a85cc9a2ee4373132"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->