### PR TITLE
fix: update MoonBit Linux Nix hash

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -50,7 +50,7 @@
           x86_64-linux = {
             version = "0.9.3-2026-05-22";
             url = "https://cli.moonbitlang.com/binaries/latest/moonbit-linux-x86_64.tar.gz";
-            hash = "sha256-tLcdrRjqJDb9hue7M0mnb5+Mq3M9YJu6lZA2CHjNaqY=";
+            hash = "sha256-/FRxLbk/zuLMmMBUbwJVI++fcECnvjsV7jj0itzwa9U=";
           };
           aarch64-linux = {
             version = "0.9.3-2026-05-22";


### PR DESCRIPTION
## Summary\n- Update the MoonBit Linux x86_64 tarball hash used by the Nix flake.\n\n## Verification\n- git diff --check\n- GitHub Actions will validate nix flake check on main.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1088"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783339021&installation_id=136613492&pr_number=1088&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1088&signature=223ac1b58269adc93139dbf131279f9033271c9f45bbb741b80554ebae71883c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->