### PR TITLE
fix: respect list item scope for nested lists

### DIFF
--- a/crates/vize_armature/src/parser/element.rs
+++ b/crates/vize_armature/src/parser/element.rs
@@ -601,7 +601,7 @@ impl<'a> Parser<'a> {
         }
 
         if tag.eq_ignore_ascii_case("li") {
-            if let Some(index) = self.find_open_element_index("li") {
+            if let Some(index) = self.find_open_li_element_in_list_item_scope() {
                 self.close_stack_element_at(index, false);
             }
         } else if Self::tag_in(tag, &["dt", "dd"]) {
@@ -637,6 +637,30 @@ impl<'a> Parser<'a> {
         (0..self.stack.len())
             .rev()
             .find(|&i| Self::tag_in(self.stack[i].element.tag.as_str(), tags))
+    }
+
+    fn find_open_li_element_in_list_item_scope(&self) -> Option<usize> {
+        for i in (0..self.stack.len()).rev() {
+            let tag = self.stack[i].element.tag.as_str();
+            if tag.eq_ignore_ascii_case("li") {
+                return Some(i);
+            }
+            if Self::is_list_item_scope_boundary(tag) {
+                return None;
+            }
+        }
+
+        None
+    }
+
+    fn is_list_item_scope_boundary(tag: &str) -> bool {
+        Self::tag_in(
+            tag,
+            &[
+                "applet", "caption", "html", "table", "td", "th", "marquee", "object", "template",
+                "ol", "ul",
+            ],
+        )
     }
 
     fn should_ignore_start_tag(&self, element: &ElementNode<'a>) -> bool {

--- a/crates/vize_armature/src/parser/tests.rs
+++ b/crates/vize_armature/src/parser/tests.rs
@@ -1346,6 +1346,46 @@ fn test_parse_in_body_omits_p_and_li_end_tags() {
 }
 
 #[test]
+fn test_parse_nested_list_items_respect_list_item_scope() {
+    for list_tag in ["ol", "ul"] {
+        let allocator = Bump::new();
+        let source = format!(
+            "<{list_tag}><li><span>outer</span><{list_tag}><li>inner</li></{list_tag}></li></{list_tag}>"
+        );
+        let (root, errors) = parse(&allocator, &source);
+
+        assert!(
+            errors.is_empty(),
+            "unexpected errors for {list_tag}: {errors:?}"
+        );
+        assert_eq!(root.children.len(), 1);
+        let TemplateChildNode::Element(list) = &root.children[0] else {
+            panic!("Expected {list_tag}");
+        };
+        assert_eq!(list.tag.as_str(), list_tag);
+        assert_eq!(list.children.len(), 1);
+
+        let TemplateChildNode::Element(outer_li) = &list.children[0] else {
+            panic!("Expected outer li");
+        };
+        assert_eq!(outer_li.tag.as_str(), "li");
+        assert_eq!(outer_li.children.len(), 2);
+        assert!(
+            matches!(&outer_li.children[0], TemplateChildNode::Element(span) if span.tag.as_str() == "span")
+        );
+
+        let TemplateChildNode::Element(inner_list) = &outer_li.children[1] else {
+            panic!("Expected nested {list_tag}");
+        };
+        assert_eq!(inner_list.tag.as_str(), list_tag);
+        assert_eq!(inner_list.children.len(), 1);
+        assert!(
+            matches!(&inner_list.children[0], TemplateChildNode::Element(li) if li.tag.as_str() == "li")
+        );
+    }
+}
+
+#[test]
 fn test_parse_nested_anchor_and_button_are_split() {
     let allocator = Bump::new();
     let (anchor_root, anchor_errors) = parse(

--- a/crates/vize_atelier_sfc/src/compile/tests.rs
+++ b/crates/vize_atelier_sfc/src/compile/tests.rs
@@ -219,6 +219,39 @@ const items = [{ name: 'dist', children: [{ name: 'file.js', children: [] }] }]
 }
 
 #[test]
+fn test_script_setup_nested_list_items_compile() {
+    let source = r#"<script setup lang="ts">
+const groups = [{ year: "2024", items: ["a", "b"] }];
+</script>
+
+<template>
+  <ol>
+    <li v-for="g in groups" :key="g.year">
+      <span>{{ g.year }}</span>
+      <ol>
+        <li v-for="item in g.items" :key="item">{{ item }}</li>
+      </ol>
+    </li>
+  </ol>
+</template>"#;
+
+    let descriptor = parse_sfc(source, SfcParseOptions::default()).expect("Failed to parse SFC");
+    let result = compile_sfc(&descriptor, SfcCompileOptions::default())
+        .expect("Failed to compile nested list SFC");
+
+    assert!(
+        result.code.contains("_renderList(groups"),
+        "outer list should compile with renderList:\n{}",
+        result.code
+    );
+    assert!(
+        result.code.contains("_renderList(g.items"),
+        "inner list should compile with renderList:\n{}",
+        result.code
+    );
+}
+
+#[test]
 fn test_scoped_hoisted_static_vnode_carries_scope_id() {
     // Regression: module-level hoisted static vnodes are created at import time,
     // when the runtime's `currentScopeId` is null, so the runtime cannot stamp


### PR DESCRIPTION
## Summary
- Respect list item scope when auto-closing `<li>`, so nested `<ol>`/`<ul>` contents do not close the outer list item.
- Add parser and SFC compile regressions for nested lists with `v-for`.

## Verification
- `cargo fmt --all --check`
- `cargo test -p vize_armature`
- `cargo test -p vize_atelier_sfc`

Closes #1089

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1090"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783342737&installation_id=136613492&pr_number=1090&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1090&signature=cdc7dd0f841d7ceb58b1a5e20e014ad5879d9a8a57f0fb0e48148dbe7bd90751"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->