### PR TITLE
perf(croquis): memoize template identifier extraction by expression text

### DIFF
--- a/crates/vize_croquis/src/analyzer.rs
+++ b/crates/vize_croquis/src/analyzer.rs
@@ -35,7 +35,7 @@ pub use helpers::{
 };
 
 use crate::analysis::Croquis;
-use vize_carton::{CompactString, profile};
+use vize_carton::{CompactString, FxHashMap, profile};
 
 /// Analysis options for controlling what gets analyzed.
 ///
@@ -123,6 +123,14 @@ pub struct Analyzer {
     /// instead of walking the parent scope chain. Incremented on v-for scope
     /// enter, decremented on exit (paired with `vif_guard_stack` discipline).
     pub(crate) vfor_depth: u32,
+    /// Memoized identifier extraction keyed by expression text. Template
+    /// expressions repeat heavily (e.g. the same `:to`/`@click`/`{{ }}` across
+    /// every `v-for` iteration's rendered element), and `extract_identifiers_oxc`
+    /// is a pure function of the expression string, so the parse+walk is done
+    /// once per distinct expression instead of once per occurrence. The cached
+    /// `Vec` is read by reference (disjoint field borrow), so cache hits avoid
+    /// both the parse and any clone.
+    pub(crate) ident_cache: FxHashMap<CompactString, Vec<CompactString>>,
 }
 
 impl Analyzer {
@@ -144,6 +152,7 @@ impl Analyzer {
             vif_guard_cache: None,
             vif_branch_conditions: Vec::new(),
             vfor_depth: 0,
+            ident_cache: FxHashMap::default(),
         }
     }
 
@@ -162,6 +171,7 @@ impl Analyzer {
             vif_guard_cache: None,
             vif_branch_conditions: Vec::new(),
             vfor_depth: 0,
+            ident_cache: FxHashMap::default(),
         }
     }
 

--- a/crates/vize_croquis/src/analyzer/template/ids.rs
+++ b/crates/vize_croquis/src/analyzer/template/ids.rs
@@ -158,10 +158,23 @@ impl Analyzer {
         };
         let base_offset = expr.loc().start.offset;
 
-        for ident in profile!(
-            "croquis.template.expression.extract_identifiers",
-            extract_identifiers_oxc(content)
-        ) {
+        // Identifier extraction is a pure function of the expression text, and
+        // template expressions repeat heavily (the same bindings/handlers across
+        // every v-for iteration's rendered element). Memoize the parse+walk per
+        // distinct expression; scope resolution below still runs per call. The
+        // cached idents are read by reference (disjoint from `self.summary`), so
+        // a hit costs neither a parse nor a clone.
+        if !self.ident_cache.contains_key(content) {
+            let computed = profile!(
+                "croquis.template.expression.extract_identifiers",
+                extract_identifiers_oxc(content)
+            );
+            self.ident_cache
+                .insert(CompactString::new(content), computed);
+        }
+        let idents = &self.ident_cache[content];
+
+        for ident in idents {
             let ident_str = ident.as_str();
 
             let in_scope_vars = scope_vars.iter().any(|v| v.as_str() == ident_str);
@@ -180,7 +193,7 @@ impl Analyzer {
             } else if !is_defined {
                 let ident_offset_in_content = content.find(ident_str).unwrap_or(0) as u32;
                 self.summary.undefined_refs.push(UndefinedRef {
-                    name: ident,
+                    name: ident.clone(),
                     offset: base_offset + ident_offset_in_content,
                     context: CompactString::new("template expression"),
                 });


### PR DESCRIPTION
`extract_identifiers_oxc` runs a full oxc parse + AST walk and is a **pure function of the expression string**, but is called once per template directive/interpolation. Cache its result per distinct expression on the `Analyzer` so repeated expressions skip the re-parse.

- Cached idents are read **by reference** (a disjoint field borrow from `self.summary`), so a cache hit costs neither a parse nor a clone.
- Cache value is a plain `Vec<CompactString>` (no `Rc`/`Arc` — both are disallowed types here), so `Analyzer` stays `Sync`.

**Honest scope:** this is a win on repetition-heavy / generated templates (and repeated bindings); on templates where every expression is unique it is near-neutral (short expressions keep the `CompactString` key inline, so no heap alloc).

From the profile-guided hot-phase audit (the #1 cost, `template_parse` 83ms, is the `vize_armature` whole-template parse = compiler, out of scope).

Behavior-preserving: croquis + patina + canon test suites green (1417 passed). fmt/clippy(-D warnings) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1091"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783347274&installation_id=136613492&pr_number=1091&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1091&signature=d43435ca56724e52f08578e9651ff746187196f802f42d6d102861b82778f53f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->