### PR TITLE
docs: Add information indicating the size of Misskey codebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Special thanks to:
 
 - [Blacksmith](https://www.blacksmith.sh/) for sponsoring CI/CD runner infrastructure.
 - [かっこかり](https://github.com/kakkokari-gtyih) for regular debugging and monitoring around
-  Misskey, including many compiler-focused bug reports.
+  [Misskey](https://github.com/misskey-dev/misskey) (~103k lines of Vue across 586 SFCs), including many compiler-focused bug reports.
 - [ushironoko](https://github.com/ushironoko) for compiler, linter, and CLI bug reports,
   reference implementations, and reproduction repositories.
 - [dannote](https://github.com/dannote) for Elixier feedback, PRs, and CSS-facing fixes.

--- a/docs/content/credits.md
+++ b/docs/content/credits.md
@@ -11,7 +11,7 @@ tooling, and ecosystem experiments. In particular, thank you to:
 - [Blacksmith](https://www.blacksmith.sh/) for sponsoring the CI/CD runner infrastructure that
   keeps the full workflow matrix practical to run.
 - [かっこかり](https://github.com/kakkokari-gtyih) for regular debugging and monitoring around
-  Misskey, with many reports around compiler behavior and edge cases.
+  [Misskey](https://github.com/misskey-dev/misskey) — a large Vue codebase with ~103k lines of Vue across 586 SFCs — with many reports around compiler behavior and edge cases.
 - [ushironoko](https://github.com/ushironoko) for bug reports from the compiler, linter, and CLI
   sides of the project, along with reference implementations for fixes and reproduction
   repositories for difficult issues.


### PR DESCRIPTION
## Summary
To help those unfamiliar with Misskey understand the scale of its codebase, I've measured the number of lines and files and added this information to the sections where Misskey is mentioned.

```bash
# Run this in /packages/frontend/src
find . -name "node_modules" -prune -o -type f -name "*.vue" -print0 | xargs -0 wc -l | awk 'END {print "ファイル数: " NR-1 "\n総行数: " $1}'
```

Currently Misskey has 586 SFCs with 103,364 lines of code.
<!-- What changed, and why? -->

## Change Class

<!-- Choose the narrowest class from docs/content/architecture/language-engineering-practices.md. -->

- [ ] Parser or AST
- [ ] Compiler and codegen
- [ ] Semantic analysis, lint, and cross-file analysis
- [ ] Virtual TypeScript and type checking
- [ ] Formatter and LSP
- [ ] Runtime packaging, release, or docs
- [x] Not language-facing

## Behavior Reference

<!-- Link the issue, upstream behavior, Vue/TypeScript parity note, or design note used as the source of truth. -->
N/A

## Verification Evidence

N/A
<!-- List the commands run and summarize fixture, snapshot, baseline, parity, benchmark, or smoke-install evidence. -->

- [ ] Minimal fixture or focused regression test added or updated
- [ ] Snapshot/baseline changes reviewed and explained
- [ ] Parity or real-world fixture coverage considered
- [ ] Security/audit impact considered
- [ ] Performance status or PR benchmark impact considered
- [ ] Fuzzing target or crash-reproducer coverage considered
- [ ] Editor/LSP scenario coverage considered
- [ ] Ecosystem or broad app compatibility impact considered
- [ ] Docs, release, or stability notes updated when public behavior changed

## Risk

<!-- Note migration impact, compatibility divergence, skipped gates, or follow-up work. -->
No risk is anticipated

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1092"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783347968&installation_id=136613492&pr_number=1092&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1092&signature=02d278a91b2e2c275f2ed1743a8c8d694525d96ac132e88a5ca9c236a920e894"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->