### PR TITLE
perf(atelier): compute is_static_expression lazily, only for :style v-bind

### DIFF
--- a/crates/vize_atelier_core/src/codegen/props/directives.rs
+++ b/crates/vize_atelier_core/src/codegen/props/directives.rs
@@ -279,9 +279,6 @@ fn generate_vbind_prop(
         }
     }
     if let Some(exp) = &dir.exp {
-        // Check if expression is a static literal (no runtime references)
-        let is_static_literal = is_static_expression(exp, ctx);
-
         if is_class {
             if !ctx.skip_normalize {
                 ctx.use_helper(RuntimeHelper::NormalizeClass);
@@ -311,8 +308,11 @@ fn generate_vbind_prop(
                 ctx.push(")");
             }
         } else if is_style {
-            // Skip normalizeStyle for static literal expressions (e.g., { color: 'red' })
-            let needs_normalize = !ctx.skip_normalize && !is_static_literal;
+            // Skip normalizeStyle for static literal expressions (e.g., { color: 'red' }).
+            // `is_static_expression` runs a full oxc parse, so the `&&` short-circuit
+            // keeps it off the hot path for every non-:style v-bind (the common case)
+            // and even for :style when normalization is already skipped.
+            let needs_normalize = !ctx.skip_normalize && !is_static_expression(exp, ctx);
             if needs_normalize {
                 ctx.use_helper(RuntimeHelper::NormalizeStyle);
                 ctx.push("_normalizeStyle(");


### PR DESCRIPTION
`generate_vbind_prop` (codegen/props/directives.rs) computed `is_static_expression(exp, ctx)` **unconditionally** for every `v-bind` with an expression, but the result is consumed **only** on the `:style` branch (to skip `_normalizeStyle` for static literals). On `:class` and the default branch it was computed then discarded.

`is_static_expression` runs a **full oxc parse** on every call (the cheap string early-out always misses in inline `<script setup>` mode), so this was an oxc parse per `v-bind` prop. The fix moves it behind the `:style` branch's `&&` short-circuit, so it runs only when its result is used — and not even then when `skip_normalize` is set.

- **Output byte-identical**: the value was provably dead on the class/default branches; on `:style` the `&&` yields the identical `needs_normalize`. `cargo test -p vize_atelier_core -p vize_atelier_sfc` (614) green, codegen snapshots unchanged.
- **~5.6% faster** full compile on a binding-heavy SFC (big varied component): 325.8ms → 307.5ms, eliminating ~one oxc parse per non-:style v-bind.

From the profile-guided whole-pipeline audit (target span: `atelier.codegen.root_node` 19.2ms self). fmt/clippy(-D warnings) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1093"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783352003&installation_id=136613492&pr_number=1093&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1093&signature=8f4a21c8036fd447fd3a7acdf789f101f4e001a33b4b66dbcdebf1b49ce903e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->