### PR TITLE
fix(atelier_sfc): emit <script> before render for non-setup SFCs

### DIFF
--- a/crates/vize_atelier_sfc/src/compile.rs
+++ b/crates/vize_atelier_sfc/src/compile.rs
@@ -514,13 +514,23 @@ fn compile_sfc_inner(
                     // 3. _sfc_main.render = _sfc_render / _sfc_main.ssrRender = ssrRender
                     // 4. export default _sfc_main
                     if is_vapor || options.template.ssr {
+                        // Vapor / SSR keep the render block first, then the script.
                         code.push_str(&template_code);
+                        code.push_str(&final_script);
+                        code.push('\n');
                     } else {
+                        // Client render: match @vue/compiler-sfc / plugin-vue ordering —
+                        // the <script> block (and its own imports) comes first, then the
+                        // template render block. This keeps user imports at the top of the
+                        // module instead of after the generated render function.
                         let template_code = rewrite_client_render_for_sfc_main(&template_code);
+                        code.push_str(&final_script);
+                        code.push('\n');
                         code.push_str(&template_code);
+                        if !code.ends_with('\n') {
+                            code.push('\n');
+                        }
                     }
-                    code.push_str(&final_script);
-                    code.push('\n');
 
                     // Export the component with render attached
                     if is_vapor {

--- a/crates/vize_atelier_sfc/src/compile/snapshots/vize_atelier_sfc__compile__tests__non_script_setup_typescript_preserved.snap
+++ b/crates/vize_atelier_sfc/src/compile/snapshots/vize_atelier_sfc__compile__tests__non_script_setup_typescript_preserved.snap
@@ -2,11 +2,6 @@
 source: crates/vize_atelier_sfc/src/compile/tests.rs
 expression: result.code.as_str()
 ---
-import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
-
-function _sfc_render(_ctx, _cache) {
-  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.message), 1 /* TEXT */))
-}
 
 interface Props {
     name: string;
@@ -25,5 +20,10 @@ const _sfc_main = {
     }
 }
 
+import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+function _sfc_render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.message), 1 /* TEXT */))
+}
 _sfc_main.render = _sfc_render
 export default _sfc_main

--- a/crates/vize_atelier_sfc/src/compile/snapshots/vize_atelier_sfc__compile__tests__non_script_setup_typescript_preserved_when_is_ts.snap
+++ b/crates/vize_atelier_sfc/src/compile/snapshots/vize_atelier_sfc__compile__tests__non_script_setup_typescript_preserved_when_is_ts.snap
@@ -1,13 +1,7 @@
 ---
 source: crates/vize_atelier_sfc/src/compile/tests.rs
-assertion_line: 890
 expression: result.code.as_str()
 ---
-import { openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
-
-function _sfc_render(_ctx, _cache) {
-  return (_openBlock(), _createElementBlock("div"))
-}
 
 interface Props {
     name: string;
@@ -17,5 +11,10 @@ const _sfc_main = {
     props: {} as Props
 }
 
+import { openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+function _sfc_render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("div"))
+}
 _sfc_main.render = _sfc_render
 export default _sfc_main

--- a/tests/expected/sfc/basic.snap
+++ b/tests/expected/sfc/basic.snap
@@ -109,18 +109,17 @@ export default {
   <div>{{ msg }}</div>
 </template>
 --- OUTPUT ---
-import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
-
-function _sfc_render(_ctx, _cache) {
-  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.msg), 1 /* TEXT */))
-}
-
 const _sfc_main = {
   data() {
     return { msg: 'hello' }
   }
 }
 
+import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+function _sfc_render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.msg), 1 /* TEXT */))
+}
 _sfc_main.render = _sfc_render
 export default _sfc_main
 ===
@@ -148,14 +147,13 @@ export default { name: 'MyComponent' }
   <div>Component</div>
 </template>
 --- OUTPUT ---
+const _sfc_main = { name: 'MyComponent' }
+
 import { openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 
 function _sfc_render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("div", null, "Component"))
 }
-
-const _sfc_main = { name: 'MyComponent' }
-
 _sfc_main.render = _sfc_render
 export default _sfc_main
 ===

--- a/tests/expected/sfc/patches.snap
+++ b/tests/expected/sfc/patches.snap
@@ -1080,12 +1080,6 @@ export default {
   <div>{{ msg }} - {{ count }}</div>
 </template>
 --- OUTPUT ---
-import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
-
-function _sfc_render(_ctx, _cache) {
-  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.msg) + " - " + _toDisplayString(_ctx.count), 1 /* TEXT */))
-}
-
 const _sfc_main = {
   name: 'MyComponent',
   props: {
@@ -1098,6 +1092,11 @@ const _sfc_main = {
   }
 }
 
+import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+function _sfc_render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.msg) + " - " + _toDisplayString(_ctx.count), 1 /* TEXT */))
+}
 _sfc_main.render = _sfc_render
 export default _sfc_main
 ===
@@ -1120,12 +1119,6 @@ export default {
   <div>{{ count }}</div>
 </template>
 --- OUTPUT ---
-import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
-
-function _sfc_render(_ctx, _cache) {
-  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.count), 1 /* TEXT */))
-}
-
 import { ref } from 'vue'
 
 const _sfc_main = {
@@ -1136,6 +1129,11 @@ const _sfc_main = {
   }
 }
 
+import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+function _sfc_render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.count), 1 /* TEXT */))
+}
 _sfc_main.render = _sfc_render
 export default _sfc_main
 ===
@@ -1994,6 +1992,14 @@ export default {
   </div>
 </template>
 --- OUTPUT ---
+const _sfc_main = {
+  computed: {
+    knobStyle() {
+      return { transform: 'translate(10px, 20px)' }
+    },
+  },
+}
+
 import { openBlock as _openBlock, createElementBlock as _createElementBlock, createElementVNode as _createElementVNode, normalizeClass as _normalizeClass, normalizeStyle as _normalizeStyle } from "vue"
 
 function _sfc_render(_ctx, _cache) {
@@ -2004,15 +2010,6 @@ function _sfc_render(_ctx, _cache) {
     }, null, 6 /* CLASS, STYLE */)
   ]))
 }
-
-const _sfc_main = {
-  computed: {
-    knobStyle() {
-      return { transform: 'translate(10px, 20px)' }
-    },
-  },
-}
-
 _sfc_main.render = _sfc_render
 export default _sfc_main
 ===

--- a/tests/snapshots/sfc/js/options_api__computed_get_set_with_v_model.snap
+++ b/tests/snapshots/sfc/js/options_api__computed_get_set_with_v_model.snap
@@ -2,15 +2,6 @@
 source: crates/vize_atelier_sfc/src/snapshot_tests.rs
 expression: output.as_str()
 ---
-import { vModelText as _vModelText, withDirectives as _withDirectives, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
-
-function _sfc_render(_ctx, _cache) {
-  return _withDirectives((_openBlock(), _createElementBlock("input", {
-    "onUpdate:modelValue": $event => ((_ctx.fullName) = $event)
-  }, null, 8 /* PROPS */, ["onUpdate:modelValue"])), [
-    [_vModelText, _ctx.fullName]
-  ])
-}
 
 const _sfc_main = {
   data() {
@@ -30,5 +21,14 @@ const _sfc_main = {
   }
 }
 
+import { vModelText as _vModelText, withDirectives as _withDirectives, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+function _sfc_render(_ctx, _cache) {
+  return _withDirectives((_openBlock(), _createElementBlock("input", {
+    "onUpdate:modelValue": $event => ((_ctx.fullName) = $event)
+  }, null, 8 /* PROPS */, ["onUpdate:modelValue"])), [
+    [_vModelText, _ctx.fullName]
+  ])
+}
 _sfc_main.render = _sfc_render
 export default _sfc_main

--- a/tests/snapshots/sfc/js/options_api__computed_object_form.snap
+++ b/tests/snapshots/sfc/js/options_api__computed_object_form.snap
@@ -2,11 +2,6 @@
 source: crates/vize_atelier_sfc/src/snapshot_tests.rs
 expression: output.as_str()
 ---
-import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
-
-function _sfc_render(_ctx, _cache) {
-  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.fullName), 1 /* TEXT */))
-}
 
 const _sfc_main = {
   data() {
@@ -19,5 +14,10 @@ const _sfc_main = {
   }
 }
 
+import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+function _sfc_render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.fullName), 1 /* TEXT */))
+}
 _sfc_main.render = _sfc_render
 export default _sfc_main

--- a/tests/snapshots/sfc/js/options_api__data_with_multiple_properties.snap
+++ b/tests/snapshots/sfc/js/options_api__data_with_multiple_properties.snap
@@ -2,11 +2,6 @@
 source: crates/vize_atelier_sfc/src/snapshot_tests.rs
 expression: output.as_str()
 ---
-import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
-
-function _sfc_render(_ctx, _cache) {
-  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.firstName) + " " + _toDisplayString(_ctx.lastName) + " (" + _toDisplayString(_ctx.count) + ")", 1 /* TEXT */))
-}
 
 const _sfc_main = {
   data() {
@@ -14,5 +9,10 @@ const _sfc_main = {
   }
 }
 
+import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+function _sfc_render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.firstName) + " " + _toDisplayString(_ctx.lastName) + " (" + _toDisplayString(_ctx.count) + ")", 1 /* TEXT */))
+}
 _sfc_main.render = _sfc_render
 export default _sfc_main

--- a/tests/snapshots/sfc/js/options_api__define_component_options_api_ts.snap
+++ b/tests/snapshots/sfc/js/options_api__define_component_options_api_ts.snap
@@ -2,11 +2,6 @@
 source: crates/vize_atelier_sfc/src/snapshot_tests.rs
 expression: output.as_str()
 ---
-import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
-
-function _sfc_render(_ctx, _cache) {
-  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.doubled), 1 /* TEXT */))
-}
 import { defineComponent } from "vue";
 const _sfc_main = defineComponent({
   data() {
@@ -17,5 +12,10 @@ const _sfc_main = defineComponent({
   } }
 });
 
+import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+function _sfc_render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.doubled), 1 /* TEXT */))
+}
 _sfc_main.render = _sfc_render
 export default _sfc_main

--- a/tests/snapshots/sfc/js/options_api__dynamic_class_and_style_from_data.snap
+++ b/tests/snapshots/sfc/js/options_api__dynamic_class_and_style_from_data.snap
@@ -2,6 +2,13 @@
 source: crates/vize_atelier_sfc/src/snapshot_tests.rs
 expression: output.as_str()
 ---
+
+const _sfc_main = {
+  data() {
+    return { active: true, color: 'red' }
+  }
+}
+
 import { normalizeClass as _normalizeClass, normalizeStyle as _normalizeStyle, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 
 function _sfc_render(_ctx, _cache) {
@@ -10,12 +17,5 @@ function _sfc_render(_ctx, _cache) {
     style: _normalizeStyle({ color: _ctx.color })
   }, "content", 6 /* CLASS, STYLE */))
 }
-
-const _sfc_main = {
-  data() {
-    return { active: true, color: 'red' }
-  }
-}
-
 _sfc_main.render = _sfc_render
 export default _sfc_main

--- a/tests/snapshots/sfc/js/options_api__emits_with_template_emit.snap
+++ b/tests/snapshots/sfc/js/options_api__emits_with_template_emit.snap
@@ -2,6 +2,14 @@
 source: crates/vize_atelier_sfc/src/snapshot_tests.rs
 expression: output.as_str()
 ---
+
+const _sfc_main = {
+  emits: ['submit', 'cancel'],
+  data() {
+    return { value: '' }
+  }
+}
+
 import { withModifiers as _withModifiers, createElementVNode as _createElementVNode, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 
 function _sfc_render(_ctx, _cache) {
@@ -14,13 +22,5 @@ function _sfc_render(_ctx, _cache) {
     }, "Cancel", 8 /* PROPS */, ["onClick"])
   ], 40 /* PROPS, NEED_HYDRATION */, ["onSubmit"]))
 }
-
-const _sfc_main = {
-  emits: ['submit', 'cancel'],
-  data() {
-    return { value: '' }
-  }
-}
-
 _sfc_main.render = _sfc_render
 export default _sfc_main

--- a/tests/snapshots/sfc/js/options_api__expose_option.snap
+++ b/tests/snapshots/sfc/js/options_api__expose_option.snap
@@ -2,11 +2,6 @@
 source: crates/vize_atelier_sfc/src/snapshot_tests.rs
 expression: output.as_str()
 ---
-import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
-
-function _sfc_render(_ctx, _cache) {
-  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.count), 1 /* TEXT */))
-}
 
 const _sfc_main = {
   data() {
@@ -20,5 +15,10 @@ const _sfc_main = {
   }
 }
 
+import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+function _sfc_render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.count), 1 /* TEXT */))
+}
 _sfc_main.render = _sfc_render
 export default _sfc_main

--- a/tests/snapshots/sfc/js/options_api__extends_base_component.snap
+++ b/tests/snapshots/sfc/js/options_api__extends_base_component.snap
@@ -2,11 +2,6 @@
 source: crates/vize_atelier_sfc/src/snapshot_tests.rs
 expression: output.as_str()
 ---
-import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
-
-function _sfc_render(_ctx, _cache) {
-  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.extra), 1 /* TEXT */))
-}
 
 import Base from './Base.vue'
 
@@ -17,5 +12,10 @@ const _sfc_main = {
   }
 }
 
+import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+function _sfc_render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.extra), 1 /* TEXT */))
+}
 _sfc_main.render = _sfc_render
 export default _sfc_main

--- a/tests/snapshots/sfc/js/options_api__lifecycle_hooks.snap
+++ b/tests/snapshots/sfc/js/options_api__lifecycle_hooks.snap
@@ -2,11 +2,6 @@
 source: crates/vize_atelier_sfc/src/snapshot_tests.rs
 expression: output.as_str()
 ---
-import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
-
-function _sfc_render(_ctx, _cache) {
-  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.ready), 1 /* TEXT */))
-}
 
 const _sfc_main = {
   data() {
@@ -23,5 +18,10 @@ const _sfc_main = {
   }
 }
 
+import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+function _sfc_render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.ready), 1 /* TEXT */))
+}
 _sfc_main.render = _sfc_render
 export default _sfc_main

--- a/tests/snapshots/sfc/js/options_api__local_component_registration.snap
+++ b/tests/snapshots/sfc/js/options_api__local_component_registration.snap
@@ -2,13 +2,6 @@
 source: crates/vize_atelier_sfc/src/snapshot_tests.rs
 expression: output.as_str()
 ---
-import { resolveComponent as _resolveComponent, openBlock as _openBlock, createBlock as _createBlock } from "vue"
-
-function _sfc_render(_ctx, _cache) {
-  const _component_ChildComp = _resolveComponent("ChildComp")
-  
-  return (_openBlock(), _createBlock(_component_ChildComp))
-}
 
 import ChildComp from './Child.vue'
 
@@ -16,5 +9,12 @@ const _sfc_main = {
   components: { ChildComp }
 }
 
+import { resolveComponent as _resolveComponent, openBlock as _openBlock, createBlock as _createBlock } from "vue"
+
+function _sfc_render(_ctx, _cache) {
+  const _component_ChildComp = _resolveComponent("ChildComp")
+  
+  return (_openBlock(), _createBlock(_component_ChildComp))
+}
 _sfc_main.render = _sfc_render
 export default _sfc_main

--- a/tests/snapshots/sfc/js/options_api__local_custom_directive.snap
+++ b/tests/snapshots/sfc/js/options_api__local_custom_directive.snap
@@ -2,15 +2,6 @@
 source: crates/vize_atelier_sfc/src/snapshot_tests.rs
 expression: output.as_str()
 ---
-import { resolveDirective as _resolveDirective, withDirectives as _withDirectives, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
-
-function _sfc_render(_ctx, _cache) {
-  const _directive_focus = _resolveDirective("focus")
-  
-  return _withDirectives((_openBlock(), _createElementBlock("input", null, null, 512 /* NEED_PATCH */)), [
-    [_directive_focus]
-  ])
-}
 
 const _sfc_main = {
   directives: {
@@ -22,5 +13,14 @@ const _sfc_main = {
   }
 }
 
+import { resolveDirective as _resolveDirective, withDirectives as _withDirectives, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+function _sfc_render(_ctx, _cache) {
+  const _directive_focus = _resolveDirective("focus")
+  
+  return _withDirectives((_openBlock(), _createElementBlock("input", null, null, 512 /* NEED_PATCH */)), [
+    [_directive_focus]
+  ])
+}
 _sfc_main.render = _sfc_render
 export default _sfc_main

--- a/tests/snapshots/sfc/js/options_api__method_called_in_interpolation.snap
+++ b/tests/snapshots/sfc/js/options_api__method_called_in_interpolation.snap
@@ -2,11 +2,6 @@
 source: crates/vize_atelier_sfc/src/snapshot_tests.rs
 expression: output.as_str()
 ---
-import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
-
-function _sfc_render(_ctx, _cache) {
-  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.greet(_ctx.name)), 1 /* TEXT */))
-}
 
 const _sfc_main = {
   data() {
@@ -19,5 +14,10 @@ const _sfc_main = {
   }
 }
 
+import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+function _sfc_render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.greet(_ctx.name)), 1 /* TEXT */))
+}
 _sfc_main.render = _sfc_render
 export default _sfc_main

--- a/tests/snapshots/sfc/js/options_api__methods_with_event_handler.snap
+++ b/tests/snapshots/sfc/js/options_api__methods_with_event_handler.snap
@@ -2,11 +2,6 @@
 source: crates/vize_atelier_sfc/src/snapshot_tests.rs
 expression: output.as_str()
 ---
-import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
-
-function _sfc_render(_ctx, _cache) {
-  return (_openBlock(), _createElementBlock("button", { onClick: _ctx.increment }, _toDisplayString(_ctx.count), 9 /* TEXT, PROPS */, ["onClick"]))
-}
 
 const _sfc_main = {
   data() {
@@ -19,5 +14,10 @@ const _sfc_main = {
   }
 }
 
+import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+function _sfc_render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("button", { onClick: _ctx.increment }, _toDisplayString(_ctx.count), 9 /* TEXT, PROPS */, ["onClick"]))
+}
 _sfc_main.render = _sfc_render
 export default _sfc_main

--- a/tests/snapshots/sfc/js/options_api__mixins.snap
+++ b/tests/snapshots/sfc/js/options_api__mixins.snap
@@ -2,11 +2,6 @@
 source: crates/vize_atelier_sfc/src/snapshot_tests.rs
 expression: output.as_str()
 ---
-import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
-
-function _sfc_render(_ctx, _cache) {
-  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.local) + " " + _toDisplayString(_ctx.sharedValue), 1 /* TEXT */))
-}
 
 import { loggerMixin } from './mixins.js'
 
@@ -17,5 +12,10 @@ const _sfc_main = {
   }
 }
 
+import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+function _sfc_render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.local) + " " + _toDisplayString(_ctx.sharedValue), 1 /* TEXT */))
+}
 _sfc_main.render = _sfc_render
 export default _sfc_main

--- a/tests/snapshots/sfc/js/options_api__name_and_inherit_attrs.snap
+++ b/tests/snapshots/sfc/js/options_api__name_and_inherit_attrs.snap
@@ -2,11 +2,6 @@
 source: crates/vize_atelier_sfc/src/snapshot_tests.rs
 expression: output.as_str()
 ---
-import { toDisplayString as _toDisplayString, normalizeProps as _normalizeProps, guardReactiveProps as _guardReactiveProps, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
-
-function _sfc_render(_ctx, _cache) {
-  return (_openBlock(), _createElementBlock("div", _normalizeProps(_guardReactiveProps(_ctx.$attrs)), _toDisplayString(_ctx.label), 17 /* TEXT, FULL_PROPS */))
-}
 
 const _sfc_main = {
   name: 'MyWidget',
@@ -14,5 +9,10 @@ const _sfc_main = {
   props: ['label']
 }
 
+import { toDisplayString as _toDisplayString, normalizeProps as _normalizeProps, guardReactiveProps as _guardReactiveProps, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+function _sfc_render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("div", _normalizeProps(_guardReactiveProps(_ctx.$attrs)), _toDisplayString(_ctx.label), 17 /* TEXT, FULL_PROPS */))
+}
 _sfc_main.render = _sfc_render
 export default _sfc_main

--- a/tests/snapshots/sfc/js/options_api__props_array_form.snap
+++ b/tests/snapshots/sfc/js/options_api__props_array_form.snap
@@ -2,15 +2,15 @@
 source: crates/vize_atelier_sfc/src/snapshot_tests.rs
 expression: output.as_str()
 ---
-import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
-
-function _sfc_render(_ctx, _cache) {
-  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.title) + ": " + _toDisplayString(_ctx.count), 1 /* TEXT */))
-}
 
 const _sfc_main = {
   props: ['title', 'count']
 }
 
+import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+function _sfc_render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.title) + ": " + _toDisplayString(_ctx.count), 1 /* TEXT */))
+}
 _sfc_main.render = _sfc_render
 export default _sfc_main

--- a/tests/snapshots/sfc/js/options_api__props_object_form_with_defaults.snap
+++ b/tests/snapshots/sfc/js/options_api__props_object_form_with_defaults.snap
@@ -2,11 +2,6 @@
 source: crates/vize_atelier_sfc/src/snapshot_tests.rs
 expression: output.as_str()
 ---
-import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
-
-function _sfc_render(_ctx, _cache) {
-  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.title) + ": " + _toDisplayString(_ctx.count) + " (" + _toDisplayString(_ctx.items.length) + ")", 1 /* TEXT */))
-}
 
 const _sfc_main = {
   props: {
@@ -25,5 +20,10 @@ const _sfc_main = {
   }
 }
 
+import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+function _sfc_render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.title) + ": " + _toDisplayString(_ctx.count) + " (" + _toDisplayString(_ctx.items.length) + ")", 1 /* TEXT */))
+}
 _sfc_main.render = _sfc_render
 export default _sfc_main

--- a/tests/snapshots/sfc/js/options_api__props_with_prop_type_typescript.snap
+++ b/tests/snapshots/sfc/js/options_api__props_with_prop_type_typescript.snap
@@ -2,16 +2,16 @@
 source: crates/vize_atelier_sfc/src/snapshot_tests.rs
 expression: output.as_str()
 ---
-import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
-
-function _sfc_render(_ctx, _cache) {
-  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.items.length), 1 /* TEXT */))
-}
 import { defineComponent } from "vue";
 const _sfc_main = defineComponent({ props: { items: {
   type: Array,
   default: () => []
 } } });
 
+import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+function _sfc_render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.items.length), 1 /* TEXT */))
+}
 _sfc_main.render = _sfc_render
 export default _sfc_main

--- a/tests/snapshots/sfc/js/options_api__provide_and_inject.snap
+++ b/tests/snapshots/sfc/js/options_api__provide_and_inject.snap
@@ -2,11 +2,6 @@
 source: crates/vize_atelier_sfc/src/snapshot_tests.rs
 expression: output.as_str()
 ---
-import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
-
-function _sfc_render(_ctx, _cache) {
-  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.parentTheme), 1 /* TEXT */))
-}
 
 const _sfc_main = {
   provide() {
@@ -20,5 +15,10 @@ const _sfc_main = {
   }
 }
 
+import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+function _sfc_render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.parentTheme), 1 /* TEXT */))
+}
 _sfc_main.render = _sfc_render
 export default _sfc_main

--- a/tests/snapshots/sfc/js/options_api__setup_function_with_options_api.snap
+++ b/tests/snapshots/sfc/js/options_api__setup_function_with_options_api.snap
@@ -2,11 +2,6 @@
 source: crates/vize_atelier_sfc/src/snapshot_tests.rs
 expression: output.as_str()
 ---
-import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
-
-function _sfc_render(_ctx, _cache) {
-  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.fromSetup) + " " + _toDisplayString(_ctx.fromData), 1 /* TEXT */))
-}
 
 import { ref } from 'vue'
 
@@ -20,5 +15,10 @@ const _sfc_main = {
   }
 }
 
+import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+function _sfc_render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.fromSetup) + " " + _toDisplayString(_ctx.fromData), 1 /* TEXT */))
+}
 _sfc_main.render = _sfc_render
 export default _sfc_main

--- a/tests/snapshots/sfc/js/options_api__v_for_over_data_array.snap
+++ b/tests/snapshots/sfc/js/options_api__v_for_over_data_array.snap
@@ -2,6 +2,13 @@
 source: crates/vize_atelier_sfc/src/snapshot_tests.rs
 expression: output.as_str()
 ---
+
+const _sfc_main = {
+  data() {
+    return { items: ['a', 'b', 'c'] }
+  }
+}
+
 import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock, Fragment as _Fragment, renderList as _renderList } from "vue"
 
 function _sfc_render(_ctx, _cache) {
@@ -11,12 +18,5 @@ function _sfc_render(_ctx, _cache) {
     }), 128 /* KEYED_FRAGMENT */))
   ]))
 }
-
-const _sfc_main = {
-  data() {
-    return { items: ['a', 'b', 'c'] }
-  }
-}
-
 _sfc_main.render = _sfc_render
 export default _sfc_main

--- a/tests/snapshots/sfc/js/options_api__v_if_with_computed_condition.snap
+++ b/tests/snapshots/sfc/js/options_api__v_if_with_computed_condition.snap
@@ -2,15 +2,6 @@
 source: crates/vize_atelier_sfc/src/snapshot_tests.rs
 expression: output.as_str()
 ---
-import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock, createCommentVNode as _createCommentVNode } from "vue"
-
-function _sfc_render(_ctx, _cache) {
-  return (_openBlock(), _createElementBlock("div", null, [
-    (_ctx.isEmpty)
-      ? (_openBlock(), _createElementBlock("p", { key: 0 }, "empty"))
-      : (_openBlock(), _createElementBlock("p", { key: 1 }, _toDisplayString(_ctx.count), 1 /* TEXT */))
-  ]))
-}
 
 const _sfc_main = {
   data() {
@@ -23,5 +14,14 @@ const _sfc_main = {
   }
 }
 
+import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock, createCommentVNode as _createCommentVNode } from "vue"
+
+function _sfc_render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("div", null, [
+    (_ctx.isEmpty)
+      ? (_openBlock(), _createElementBlock("p", { key: 0 }, "empty"))
+      : (_openBlock(), _createElementBlock("p", { key: 1 }, _toDisplayString(_ctx.count), 1 /* TEXT */))
+  ]))
+}
 _sfc_main.render = _sfc_render
 export default _sfc_main

--- a/tests/snapshots/sfc/js/options_api__watch_handlers_object_and_deep.snap
+++ b/tests/snapshots/sfc/js/options_api__watch_handlers_object_and_deep.snap
@@ -2,15 +2,6 @@
 source: crates/vize_atelier_sfc/src/snapshot_tests.rs
 expression: output.as_str()
 ---
-import { vModelText as _vModelText, withDirectives as _withDirectives, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
-
-function _sfc_render(_ctx, _cache) {
-  return _withDirectives((_openBlock(), _createElementBlock("input", {
-    "onUpdate:modelValue": $event => ((_ctx.question) = $event)
-  }, null, 8 /* PROPS */, ["onUpdate:modelValue"])), [
-    [_vModelText, _ctx.question]
-  ])
-}
 
 const _sfc_main = {
   data() {
@@ -30,5 +21,14 @@ const _sfc_main = {
   }
 }
 
+import { vModelText as _vModelText, withDirectives as _withDirectives, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+function _sfc_render(_ctx, _cache) {
+  return _withDirectives((_openBlock(), _createElementBlock("input", {
+    "onUpdate:modelValue": $event => ((_ctx.question) = $event)
+  }, null, 8 /* PROPS */, ["onUpdate:modelValue"])), [
+    [_vModelText, _ctx.question]
+  ])
+}
 _sfc_main.render = _sfc_render
 export default _sfc_main

--- a/tests/snapshots/sfc/js/patches__non_script_setup_component_with_export_default.snap
+++ b/tests/snapshots/sfc/js/patches__non_script_setup_component_with_export_default.snap
@@ -1,12 +1,7 @@
 ---
 source: crates/vize_atelier_sfc/src/snapshot_tests.rs
-expression: js_output.as_str()
+expression: output.as_str()
 ---
-import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
-
-function _sfc_render(_ctx, _cache) {
-  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.msg) + " - " + _toDisplayString(_ctx.count), 1 /* TEXT */))
-}
 
 const _sfc_main = {
   name: 'MyComponent',
@@ -20,5 +15,10 @@ const _sfc_main = {
   }
 }
 
+import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+function _sfc_render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.msg) + " - " + _toDisplayString(_ctx.count), 1 /* TEXT */))
+}
 _sfc_main.render = _sfc_render
 export default _sfc_main

--- a/tests/snapshots/sfc/js/patches__options_api_dynamic_style_and_class_keep_patch_flags.snap
+++ b/tests/snapshots/sfc/js/patches__options_api_dynamic_style_and_class_keep_patch_flags.snap
@@ -1,7 +1,16 @@
 ---
 source: crates/vize_atelier_sfc/src/snapshot_tests.rs
-expression: js_output.as_str()
+expression: output.as_str()
 ---
+
+const _sfc_main = {
+  computed: {
+    knobStyle() {
+      return { transform: 'translate(10px, 20px)' }
+    },
+  },
+}
+
 import { createElementVNode as _createElementVNode, normalizeStyle as _normalizeStyle, normalizeClass as _normalizeClass, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 
 function _sfc_render(_ctx, _cache) {
@@ -12,14 +21,5 @@ function _sfc_render(_ctx, _cache) {
     }, null, 6 /* CLASS, STYLE */)
   ]))
 }
-
-const _sfc_main = {
-  computed: {
-    knobStyle() {
-      return { transform: 'translate(10px, 20px)' }
-    },
-  },
-}
-
 _sfc_main.render = _sfc_render
 export default _sfc_main

--- a/tests/snapshots/sfc/js/patches__script_with_setup_function.snap
+++ b/tests/snapshots/sfc/js/patches__script_with_setup_function.snap
@@ -1,12 +1,7 @@
 ---
 source: crates/vize_atelier_sfc/src/snapshot_tests.rs
-expression: js_output.as_str()
+expression: output.as_str()
 ---
-import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
-
-function _sfc_render(_ctx, _cache) {
-  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.count), 1 /* TEXT */))
-}
 
 import { ref } from 'vue'
 
@@ -18,5 +13,10 @@ const _sfc_main = {
   }
 }
 
+import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+function _sfc_render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.count), 1 /* TEXT */))
+}
 _sfc_main.render = _sfc_render
 export default _sfc_main

--- a/tests/snapshots/sfc/ts/basic__options_api_component.snap
+++ b/tests/snapshots/sfc/ts/basic__options_api_component.snap
@@ -1,12 +1,7 @@
 ---
 source: crates/vize_atelier_sfc/src/snapshot_tests.rs
-expression: ts_output.as_str()
+expression: output.as_str()
 ---
-import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
-
-function _sfc_render(_ctx, _cache) {
-  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.msg), 1 /* TEXT */))
-}
 
 const _sfc_main = {
   data() {
@@ -14,5 +9,10 @@ const _sfc_main = {
   }
 }
 
+import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+function _sfc_render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.msg), 1 /* TEXT */))
+}
 _sfc_main.render = _sfc_render
 export default _sfc_main

--- a/tests/snapshots/sfc/ts/basic__script_and_template.snap
+++ b/tests/snapshots/sfc/ts/basic__script_and_template.snap
@@ -1,15 +1,14 @@
 ---
 source: crates/vize_atelier_sfc/src/snapshot_tests.rs
-assertion_line: 175
-expression: ts_output.as_str()
+expression: output.as_str()
 ---
+
+const _sfc_main = { name: 'MyComponent' }
+
 import { openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 
 function _sfc_render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("div", null, "Component"))
 }
-
-const _sfc_main = { name: 'MyComponent' }
-
 _sfc_main.render = _sfc_render
 export default _sfc_main

--- a/tests/snapshots/sfc/ts/options_api__computed_get_set_with_v_model.snap
+++ b/tests/snapshots/sfc/ts/options_api__computed_get_set_with_v_model.snap
@@ -2,15 +2,6 @@
 source: crates/vize_atelier_sfc/src/snapshot_tests.rs
 expression: output.as_str()
 ---
-import { vModelText as _vModelText, withDirectives as _withDirectives, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
-
-function _sfc_render(_ctx, _cache) {
-  return _withDirectives((_openBlock(), _createElementBlock("input", {
-    "onUpdate:modelValue": $event => ((_ctx.fullName) = $event)
-  }, null, 8 /* PROPS */, ["onUpdate:modelValue"])), [
-    [_vModelText, _ctx.fullName]
-  ])
-}
 
 const _sfc_main = {
   data() {
@@ -30,5 +21,14 @@ const _sfc_main = {
   }
 }
 
+import { vModelText as _vModelText, withDirectives as _withDirectives, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+function _sfc_render(_ctx, _cache) {
+  return _withDirectives((_openBlock(), _createElementBlock("input", {
+    "onUpdate:modelValue": $event => ((_ctx.fullName) = $event)
+  }, null, 8 /* PROPS */, ["onUpdate:modelValue"])), [
+    [_vModelText, _ctx.fullName]
+  ])
+}
 _sfc_main.render = _sfc_render
 export default _sfc_main

--- a/tests/snapshots/sfc/ts/options_api__computed_object_form.snap
+++ b/tests/snapshots/sfc/ts/options_api__computed_object_form.snap
@@ -2,11 +2,6 @@
 source: crates/vize_atelier_sfc/src/snapshot_tests.rs
 expression: output.as_str()
 ---
-import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
-
-function _sfc_render(_ctx, _cache) {
-  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.fullName), 1 /* TEXT */))
-}
 
 const _sfc_main = {
   data() {
@@ -19,5 +14,10 @@ const _sfc_main = {
   }
 }
 
+import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+function _sfc_render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.fullName), 1 /* TEXT */))
+}
 _sfc_main.render = _sfc_render
 export default _sfc_main

--- a/tests/snapshots/sfc/ts/options_api__data_with_multiple_properties.snap
+++ b/tests/snapshots/sfc/ts/options_api__data_with_multiple_properties.snap
@@ -2,11 +2,6 @@
 source: crates/vize_atelier_sfc/src/snapshot_tests.rs
 expression: output.as_str()
 ---
-import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
-
-function _sfc_render(_ctx, _cache) {
-  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.firstName) + " " + _toDisplayString(_ctx.lastName) + " (" + _toDisplayString(_ctx.count) + ")", 1 /* TEXT */))
-}
 
 const _sfc_main = {
   data() {
@@ -14,5 +9,10 @@ const _sfc_main = {
   }
 }
 
+import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+function _sfc_render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.firstName) + " " + _toDisplayString(_ctx.lastName) + " (" + _toDisplayString(_ctx.count) + ")", 1 /* TEXT */))
+}
 _sfc_main.render = _sfc_render
 export default _sfc_main

--- a/tests/snapshots/sfc/ts/options_api__define_component_options_api_ts.snap
+++ b/tests/snapshots/sfc/ts/options_api__define_component_options_api_ts.snap
@@ -2,11 +2,6 @@
 source: crates/vize_atelier_sfc/src/snapshot_tests.rs
 expression: output.as_str()
 ---
-import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
-
-function _sfc_render(_ctx, _cache) {
-  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.doubled), 1 /* TEXT */))
-}
 
 import { defineComponent } from 'vue'
 
@@ -21,5 +16,10 @@ const _sfc_main = defineComponent({
   }
 })
 
+import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+function _sfc_render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.doubled), 1 /* TEXT */))
+}
 _sfc_main.render = _sfc_render
 export default _sfc_main

--- a/tests/snapshots/sfc/ts/options_api__dynamic_class_and_style_from_data.snap
+++ b/tests/snapshots/sfc/ts/options_api__dynamic_class_and_style_from_data.snap
@@ -2,6 +2,13 @@
 source: crates/vize_atelier_sfc/src/snapshot_tests.rs
 expression: output.as_str()
 ---
+
+const _sfc_main = {
+  data() {
+    return { active: true, color: 'red' }
+  }
+}
+
 import { normalizeClass as _normalizeClass, normalizeStyle as _normalizeStyle, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 
 function _sfc_render(_ctx, _cache) {
@@ -10,12 +17,5 @@ function _sfc_render(_ctx, _cache) {
     style: _normalizeStyle({ color: _ctx.color })
   }, "content", 6 /* CLASS, STYLE */))
 }
-
-const _sfc_main = {
-  data() {
-    return { active: true, color: 'red' }
-  }
-}
-
 _sfc_main.render = _sfc_render
 export default _sfc_main

--- a/tests/snapshots/sfc/ts/options_api__emits_with_template_emit.snap
+++ b/tests/snapshots/sfc/ts/options_api__emits_with_template_emit.snap
@@ -2,6 +2,14 @@
 source: crates/vize_atelier_sfc/src/snapshot_tests.rs
 expression: output.as_str()
 ---
+
+const _sfc_main = {
+  emits: ['submit', 'cancel'],
+  data() {
+    return { value: '' }
+  }
+}
+
 import { withModifiers as _withModifiers, createElementVNode as _createElementVNode, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 
 function _sfc_render(_ctx, _cache) {
@@ -14,13 +22,5 @@ function _sfc_render(_ctx, _cache) {
     }, "Cancel", 8 /* PROPS */, ["onClick"])
   ], 40 /* PROPS, NEED_HYDRATION */, ["onSubmit"]))
 }
-
-const _sfc_main = {
-  emits: ['submit', 'cancel'],
-  data() {
-    return { value: '' }
-  }
-}
-
 _sfc_main.render = _sfc_render
 export default _sfc_main

--- a/tests/snapshots/sfc/ts/options_api__expose_option.snap
+++ b/tests/snapshots/sfc/ts/options_api__expose_option.snap
@@ -2,11 +2,6 @@
 source: crates/vize_atelier_sfc/src/snapshot_tests.rs
 expression: output.as_str()
 ---
-import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
-
-function _sfc_render(_ctx, _cache) {
-  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.count), 1 /* TEXT */))
-}
 
 const _sfc_main = {
   data() {
@@ -20,5 +15,10 @@ const _sfc_main = {
   }
 }
 
+import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+function _sfc_render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.count), 1 /* TEXT */))
+}
 _sfc_main.render = _sfc_render
 export default _sfc_main

--- a/tests/snapshots/sfc/ts/options_api__extends_base_component.snap
+++ b/tests/snapshots/sfc/ts/options_api__extends_base_component.snap
@@ -2,11 +2,6 @@
 source: crates/vize_atelier_sfc/src/snapshot_tests.rs
 expression: output.as_str()
 ---
-import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
-
-function _sfc_render(_ctx, _cache) {
-  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.extra), 1 /* TEXT */))
-}
 
 import Base from './Base.vue'
 
@@ -17,5 +12,10 @@ const _sfc_main = {
   }
 }
 
+import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+function _sfc_render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.extra), 1 /* TEXT */))
+}
 _sfc_main.render = _sfc_render
 export default _sfc_main

--- a/tests/snapshots/sfc/ts/options_api__lifecycle_hooks.snap
+++ b/tests/snapshots/sfc/ts/options_api__lifecycle_hooks.snap
@@ -2,11 +2,6 @@
 source: crates/vize_atelier_sfc/src/snapshot_tests.rs
 expression: output.as_str()
 ---
-import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
-
-function _sfc_render(_ctx, _cache) {
-  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.ready), 1 /* TEXT */))
-}
 
 const _sfc_main = {
   data() {
@@ -23,5 +18,10 @@ const _sfc_main = {
   }
 }
 
+import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+function _sfc_render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.ready), 1 /* TEXT */))
+}
 _sfc_main.render = _sfc_render
 export default _sfc_main

--- a/tests/snapshots/sfc/ts/options_api__local_component_registration.snap
+++ b/tests/snapshots/sfc/ts/options_api__local_component_registration.snap
@@ -2,13 +2,6 @@
 source: crates/vize_atelier_sfc/src/snapshot_tests.rs
 expression: output.as_str()
 ---
-import { resolveComponent as _resolveComponent, openBlock as _openBlock, createBlock as _createBlock } from "vue"
-
-function _sfc_render(_ctx, _cache) {
-  const _component_ChildComp = _resolveComponent("ChildComp")
-  
-  return (_openBlock(), _createBlock(_component_ChildComp))
-}
 
 import ChildComp from './Child.vue'
 
@@ -16,5 +9,12 @@ const _sfc_main = {
   components: { ChildComp }
 }
 
+import { resolveComponent as _resolveComponent, openBlock as _openBlock, createBlock as _createBlock } from "vue"
+
+function _sfc_render(_ctx, _cache) {
+  const _component_ChildComp = _resolveComponent("ChildComp")
+  
+  return (_openBlock(), _createBlock(_component_ChildComp))
+}
 _sfc_main.render = _sfc_render
 export default _sfc_main

--- a/tests/snapshots/sfc/ts/options_api__local_custom_directive.snap
+++ b/tests/snapshots/sfc/ts/options_api__local_custom_directive.snap
@@ -2,15 +2,6 @@
 source: crates/vize_atelier_sfc/src/snapshot_tests.rs
 expression: output.as_str()
 ---
-import { resolveDirective as _resolveDirective, withDirectives as _withDirectives, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
-
-function _sfc_render(_ctx, _cache) {
-  const _directive_focus = _resolveDirective("focus")
-  
-  return _withDirectives((_openBlock(), _createElementBlock("input", null, null, 512 /* NEED_PATCH */)), [
-    [_directive_focus]
-  ])
-}
 
 const _sfc_main = {
   directives: {
@@ -22,5 +13,14 @@ const _sfc_main = {
   }
 }
 
+import { resolveDirective as _resolveDirective, withDirectives as _withDirectives, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+function _sfc_render(_ctx, _cache) {
+  const _directive_focus = _resolveDirective("focus")
+  
+  return _withDirectives((_openBlock(), _createElementBlock("input", null, null, 512 /* NEED_PATCH */)), [
+    [_directive_focus]
+  ])
+}
 _sfc_main.render = _sfc_render
 export default _sfc_main

--- a/tests/snapshots/sfc/ts/options_api__method_called_in_interpolation.snap
+++ b/tests/snapshots/sfc/ts/options_api__method_called_in_interpolation.snap
@@ -2,11 +2,6 @@
 source: crates/vize_atelier_sfc/src/snapshot_tests.rs
 expression: output.as_str()
 ---
-import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
-
-function _sfc_render(_ctx, _cache) {
-  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.greet(_ctx.name)), 1 /* TEXT */))
-}
 
 const _sfc_main = {
   data() {
@@ -19,5 +14,10 @@ const _sfc_main = {
   }
 }
 
+import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+function _sfc_render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.greet(_ctx.name)), 1 /* TEXT */))
+}
 _sfc_main.render = _sfc_render
 export default _sfc_main

--- a/tests/snapshots/sfc/ts/options_api__methods_with_event_handler.snap
+++ b/tests/snapshots/sfc/ts/options_api__methods_with_event_handler.snap
@@ -2,11 +2,6 @@
 source: crates/vize_atelier_sfc/src/snapshot_tests.rs
 expression: output.as_str()
 ---
-import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
-
-function _sfc_render(_ctx, _cache) {
-  return (_openBlock(), _createElementBlock("button", { onClick: _ctx.increment }, _toDisplayString(_ctx.count), 9 /* TEXT, PROPS */, ["onClick"]))
-}
 
 const _sfc_main = {
   data() {
@@ -19,5 +14,10 @@ const _sfc_main = {
   }
 }
 
+import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+function _sfc_render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("button", { onClick: _ctx.increment }, _toDisplayString(_ctx.count), 9 /* TEXT, PROPS */, ["onClick"]))
+}
 _sfc_main.render = _sfc_render
 export default _sfc_main

--- a/tests/snapshots/sfc/ts/options_api__mixins.snap
+++ b/tests/snapshots/sfc/ts/options_api__mixins.snap
@@ -2,11 +2,6 @@
 source: crates/vize_atelier_sfc/src/snapshot_tests.rs
 expression: output.as_str()
 ---
-import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
-
-function _sfc_render(_ctx, _cache) {
-  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.local) + " " + _toDisplayString(_ctx.sharedValue), 1 /* TEXT */))
-}
 
 import { loggerMixin } from './mixins.js'
 
@@ -17,5 +12,10 @@ const _sfc_main = {
   }
 }
 
+import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+function _sfc_render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.local) + " " + _toDisplayString(_ctx.sharedValue), 1 /* TEXT */))
+}
 _sfc_main.render = _sfc_render
 export default _sfc_main

--- a/tests/snapshots/sfc/ts/options_api__name_and_inherit_attrs.snap
+++ b/tests/snapshots/sfc/ts/options_api__name_and_inherit_attrs.snap
@@ -2,11 +2,6 @@
 source: crates/vize_atelier_sfc/src/snapshot_tests.rs
 expression: output.as_str()
 ---
-import { toDisplayString as _toDisplayString, normalizeProps as _normalizeProps, guardReactiveProps as _guardReactiveProps, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
-
-function _sfc_render(_ctx, _cache) {
-  return (_openBlock(), _createElementBlock("div", _normalizeProps(_guardReactiveProps(_ctx.$attrs)), _toDisplayString(_ctx.label), 17 /* TEXT, FULL_PROPS */))
-}
 
 const _sfc_main = {
   name: 'MyWidget',
@@ -14,5 +9,10 @@ const _sfc_main = {
   props: ['label']
 }
 
+import { toDisplayString as _toDisplayString, normalizeProps as _normalizeProps, guardReactiveProps as _guardReactiveProps, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+function _sfc_render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("div", _normalizeProps(_guardReactiveProps(_ctx.$attrs)), _toDisplayString(_ctx.label), 17 /* TEXT, FULL_PROPS */))
+}
 _sfc_main.render = _sfc_render
 export default _sfc_main

--- a/tests/snapshots/sfc/ts/options_api__props_array_form.snap
+++ b/tests/snapshots/sfc/ts/options_api__props_array_form.snap
@@ -2,15 +2,15 @@
 source: crates/vize_atelier_sfc/src/snapshot_tests.rs
 expression: output.as_str()
 ---
-import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
-
-function _sfc_render(_ctx, _cache) {
-  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.title) + ": " + _toDisplayString(_ctx.count), 1 /* TEXT */))
-}
 
 const _sfc_main = {
   props: ['title', 'count']
 }
 
+import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+function _sfc_render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.title) + ": " + _toDisplayString(_ctx.count), 1 /* TEXT */))
+}
 _sfc_main.render = _sfc_render
 export default _sfc_main

--- a/tests/snapshots/sfc/ts/options_api__props_object_form_with_defaults.snap
+++ b/tests/snapshots/sfc/ts/options_api__props_object_form_with_defaults.snap
@@ -2,11 +2,6 @@
 source: crates/vize_atelier_sfc/src/snapshot_tests.rs
 expression: output.as_str()
 ---
-import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
-
-function _sfc_render(_ctx, _cache) {
-  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.title) + ": " + _toDisplayString(_ctx.count) + " (" + _toDisplayString(_ctx.items.length) + ")", 1 /* TEXT */))
-}
 
 const _sfc_main = {
   props: {
@@ -25,5 +20,10 @@ const _sfc_main = {
   }
 }
 
+import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+function _sfc_render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.title) + ": " + _toDisplayString(_ctx.count) + " (" + _toDisplayString(_ctx.items.length) + ")", 1 /* TEXT */))
+}
 _sfc_main.render = _sfc_render
 export default _sfc_main

--- a/tests/snapshots/sfc/ts/options_api__props_with_prop_type_typescript.snap
+++ b/tests/snapshots/sfc/ts/options_api__props_with_prop_type_typescript.snap
@@ -2,11 +2,6 @@
 source: crates/vize_atelier_sfc/src/snapshot_tests.rs
 expression: output.as_str()
 ---
-import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
-
-function _sfc_render(_ctx, _cache) {
-  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.items.length), 1 /* TEXT */))
-}
 
 import { defineComponent, PropType } from 'vue'
 
@@ -24,5 +19,10 @@ const _sfc_main = defineComponent({
   }
 })
 
+import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+function _sfc_render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.items.length), 1 /* TEXT */))
+}
 _sfc_main.render = _sfc_render
 export default _sfc_main

--- a/tests/snapshots/sfc/ts/options_api__provide_and_inject.snap
+++ b/tests/snapshots/sfc/ts/options_api__provide_and_inject.snap
@@ -2,11 +2,6 @@
 source: crates/vize_atelier_sfc/src/snapshot_tests.rs
 expression: output.as_str()
 ---
-import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
-
-function _sfc_render(_ctx, _cache) {
-  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.parentTheme), 1 /* TEXT */))
-}
 
 const _sfc_main = {
   provide() {
@@ -20,5 +15,10 @@ const _sfc_main = {
   }
 }
 
+import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+function _sfc_render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.parentTheme), 1 /* TEXT */))
+}
 _sfc_main.render = _sfc_render
 export default _sfc_main

--- a/tests/snapshots/sfc/ts/options_api__setup_function_with_options_api.snap
+++ b/tests/snapshots/sfc/ts/options_api__setup_function_with_options_api.snap
@@ -2,11 +2,6 @@
 source: crates/vize_atelier_sfc/src/snapshot_tests.rs
 expression: output.as_str()
 ---
-import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
-
-function _sfc_render(_ctx, _cache) {
-  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.fromSetup) + " " + _toDisplayString(_ctx.fromData), 1 /* TEXT */))
-}
 
 import { ref } from 'vue'
 
@@ -20,5 +15,10 @@ const _sfc_main = {
   }
 }
 
+import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+function _sfc_render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.fromSetup) + " " + _toDisplayString(_ctx.fromData), 1 /* TEXT */))
+}
 _sfc_main.render = _sfc_render
 export default _sfc_main

--- a/tests/snapshots/sfc/ts/options_api__v_for_over_data_array.snap
+++ b/tests/snapshots/sfc/ts/options_api__v_for_over_data_array.snap
@@ -2,6 +2,13 @@
 source: crates/vize_atelier_sfc/src/snapshot_tests.rs
 expression: output.as_str()
 ---
+
+const _sfc_main = {
+  data() {
+    return { items: ['a', 'b', 'c'] }
+  }
+}
+
 import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock, Fragment as _Fragment, renderList as _renderList } from "vue"
 
 function _sfc_render(_ctx, _cache) {
@@ -11,12 +18,5 @@ function _sfc_render(_ctx, _cache) {
     }), 128 /* KEYED_FRAGMENT */))
   ]))
 }
-
-const _sfc_main = {
-  data() {
-    return { items: ['a', 'b', 'c'] }
-  }
-}
-
 _sfc_main.render = _sfc_render
 export default _sfc_main

--- a/tests/snapshots/sfc/ts/options_api__v_if_with_computed_condition.snap
+++ b/tests/snapshots/sfc/ts/options_api__v_if_with_computed_condition.snap
@@ -2,15 +2,6 @@
 source: crates/vize_atelier_sfc/src/snapshot_tests.rs
 expression: output.as_str()
 ---
-import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock, createCommentVNode as _createCommentVNode } from "vue"
-
-function _sfc_render(_ctx, _cache) {
-  return (_openBlock(), _createElementBlock("div", null, [
-    (_ctx.isEmpty)
-      ? (_openBlock(), _createElementBlock("p", { key: 0 }, "empty"))
-      : (_openBlock(), _createElementBlock("p", { key: 1 }, _toDisplayString(_ctx.count), 1 /* TEXT */))
-  ]))
-}
 
 const _sfc_main = {
   data() {
@@ -23,5 +14,14 @@ const _sfc_main = {
   }
 }
 
+import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock, createCommentVNode as _createCommentVNode } from "vue"
+
+function _sfc_render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("div", null, [
+    (_ctx.isEmpty)
+      ? (_openBlock(), _createElementBlock("p", { key: 0 }, "empty"))
+      : (_openBlock(), _createElementBlock("p", { key: 1 }, _toDisplayString(_ctx.count), 1 /* TEXT */))
+  ]))
+}
 _sfc_main.render = _sfc_render
 export default _sfc_main

--- a/tests/snapshots/sfc/ts/options_api__watch_handlers_object_and_deep.snap
+++ b/tests/snapshots/sfc/ts/options_api__watch_handlers_object_and_deep.snap
@@ -2,15 +2,6 @@
 source: crates/vize_atelier_sfc/src/snapshot_tests.rs
 expression: output.as_str()
 ---
-import { vModelText as _vModelText, withDirectives as _withDirectives, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
-
-function _sfc_render(_ctx, _cache) {
-  return _withDirectives((_openBlock(), _createElementBlock("input", {
-    "onUpdate:modelValue": $event => ((_ctx.question) = $event)
-  }, null, 8 /* PROPS */, ["onUpdate:modelValue"])), [
-    [_vModelText, _ctx.question]
-  ])
-}
 
 const _sfc_main = {
   data() {
@@ -30,5 +21,14 @@ const _sfc_main = {
   }
 }
 
+import { vModelText as _vModelText, withDirectives as _withDirectives, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+function _sfc_render(_ctx, _cache) {
+  return _withDirectives((_openBlock(), _createElementBlock("input", {
+    "onUpdate:modelValue": $event => ((_ctx.question) = $event)
+  }, null, 8 /* PROPS */, ["onUpdate:modelValue"])), [
+    [_vModelText, _ctx.question]
+  ])
+}
 _sfc_main.render = _sfc_render
 export default _sfc_main

--- a/tests/snapshots/sfc/ts/patches__non_script_setup_component_with_export_default.snap
+++ b/tests/snapshots/sfc/ts/patches__non_script_setup_component_with_export_default.snap
@@ -1,12 +1,7 @@
 ---
 source: crates/vize_atelier_sfc/src/snapshot_tests.rs
-expression: ts_output.as_str()
+expression: output.as_str()
 ---
-import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
-
-function _sfc_render(_ctx, _cache) {
-  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.msg) + " - " + _toDisplayString(_ctx.count), 1 /* TEXT */))
-}
 
 const _sfc_main = {
   name: 'MyComponent',
@@ -20,5 +15,10 @@ const _sfc_main = {
   }
 }
 
+import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+function _sfc_render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.msg) + " - " + _toDisplayString(_ctx.count), 1 /* TEXT */))
+}
 _sfc_main.render = _sfc_render
 export default _sfc_main

--- a/tests/snapshots/sfc/ts/patches__options_api_dynamic_style_and_class_keep_patch_flags.snap
+++ b/tests/snapshots/sfc/ts/patches__options_api_dynamic_style_and_class_keep_patch_flags.snap
@@ -1,7 +1,16 @@
 ---
 source: crates/vize_atelier_sfc/src/snapshot_tests.rs
-expression: ts_output.as_str()
+expression: output.as_str()
 ---
+
+const _sfc_main = {
+  computed: {
+    knobStyle() {
+      return { transform: 'translate(10px, 20px)' }
+    },
+  },
+}
+
 import { createElementVNode as _createElementVNode, normalizeStyle as _normalizeStyle, normalizeClass as _normalizeClass, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 
 function _sfc_render(_ctx, _cache) {
@@ -12,14 +21,5 @@ function _sfc_render(_ctx, _cache) {
     }, null, 6 /* CLASS, STYLE */)
   ]))
 }
-
-const _sfc_main = {
-  computed: {
-    knobStyle() {
-      return { transform: 'translate(10px, 20px)' }
-    },
-  },
-}
-
 _sfc_main.render = _sfc_render
 export default _sfc_main

--- a/tests/snapshots/sfc/ts/patches__script_with_setup_function.snap
+++ b/tests/snapshots/sfc/ts/patches__script_with_setup_function.snap
@@ -1,12 +1,7 @@
 ---
 source: crates/vize_atelier_sfc/src/snapshot_tests.rs
-expression: ts_output.as_str()
+expression: output.as_str()
 ---
-import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
-
-function _sfc_render(_ctx, _cache) {
-  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.count), 1 /* TEXT */))
-}
 
 import { ref } from 'vue'
 
@@ -18,5 +13,10 @@ const _sfc_main = {
   }
 }
 
+import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+function _sfc_render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.count), 1 /* TEXT */))
+}
 _sfc_main.render = _sfc_render
 export default _sfc_main

--- a/tests/tooling/support/generate-expected.ts
+++ b/tests/tooling/support/generate-expected.ts
@@ -131,10 +131,18 @@ function compileSFC(source: string, filename: string = "test.vue"): string {
     const rewritten = scriptContent.replace(/export\s+default\s+\{/, "const _sfc_main = {");
 
     if (templateResult) {
+      // The render function is attached as `_sfc_main.render` instead of being
+      // exported, so rename `export function render` to `function _sfc_render`.
+      const renderCode = templateResult.code.replace(
+        "export function render(",
+        "function _sfc_render(",
+      );
+      // Match @vue/compiler-sfc / plugin-vue ordering: the <script> block (and
+      // its imports) comes first, then the template render block.
       code =
-        templateResult.code +
-        "\n" +
         rewritten +
+        "\n" +
+        renderCode +
         "\n_sfc_main.render = _sfc_render\nexport default _sfc_main";
     } else {
       code = rewritten + "\nexport default _sfc_main";


### PR DESCRIPTION
## What

Non-`<script setup>` (Options API) SFCs emitted the template render block before
the `<script>` block, so user `import`s appeared *after* the generated
`_sfc_render` function. The official `@vue/compiler-sfc` (@vue/repl / plugin-vue
assembly) emits the `<script>` block — and its imports — first, then the render
block.

This reorders the client (non-vapor, non-SSR) assembly in `compile_sfc` to
**script-first**, matching the official compiler so user imports stay at the top
of the module.

```diff
- import { resolveComponent as _resolveComponent, ... } from "vue"
- function _sfc_render(_ctx, _cache) { ... }
- import ChildComp from './Child.vue'
- const _sfc_main = { components: { ChildComp } }
+ import ChildComp from './Child.vue'
+ const _sfc_main = { components: { ChildComp } }
+ import { resolveComponent as _resolveComponent, ... } from "vue"
+ function _sfc_render(_ctx, _cache) { ... }
  _sfc_main.render = _sfc_render
  export default _sfc_main
```

## Verification

- Output now matches the official `@vue/compiler-sfc@3.6.0-beta.10` assembly
  ordering. The only remaining difference is the unused extra render params in
  the official output (`$props, $setup, $data, $options`), unrelated to import
  ordering.
- Parity corpus: **720/720** (SFC 167/167, above the 166 floor).
- `cargo test -p vize_atelier_sfc`: 474 passed; repo-wide check confirms no
  non-setup snapshot is left in the old order.
- Vapor/SSR output unchanged.

## Notes

- Stacked on #1096 (Options API fixtures); review/merge that first.
- The corpus baseline generator (`generate-expected.ts`) is aligned to
  script-first and its `export function render` → `function _sfc_render` rename
  restored. A full baseline regeneration is intentionally out of scope: the
  generator has unrelated **pre-existing drift** on `<script setup>` cases
  (regenerating drifts `script-setup.snap`/`patches.snap` by hundreds/thousands
  of lines), so the affected expected fixtures were updated surgically instead.
  That generator staleness is worth a separate cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1097"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783366143&installation_id=136613492&pr_number=1097&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1097&signature=0b85f071b1ff5f8c702d6e22db0239d1c1a4f3b09f31dbb6314240611b1ee693"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->