### PR TITLE
feat(legacy): scaffold opt-in legacy Vue (v0/v1/v2) feature

### DIFF
--- a/crates/vize_armature/Cargo.toml
+++ b/crates/vize_armature/Cargo.toml
@@ -7,6 +7,11 @@ license.workspace = true
 repository.workspace = true
 description = "Armature - The structural parser framework for Vize Vue templates"
 
+[features]
+# Opt-in support for legacy Vue lines (v0 / v1 / v2). Off by default so the
+# Vue 3 `vize` binary never compiles it. See the `legacy` module.
+legacy = []
+
 [dependencies]
 vize_carton = { workspace = true }
 vize_relief = { workspace = true }

--- a/crates/vize_armature/src/legacy.rs
+++ b/crates/vize_armature/src/legacy.rs
@@ -1,0 +1,61 @@
+//! Legacy Vue (v0 / v1 / v2) support surface.
+//!
+//! This module is the consolidation point for pre-Vue-3 ("legacy") parsing and
+//! tokenization in `vize_armature`. It is gated behind the `legacy` cargo
+//! feature and is **not** compiled into the default Vue 3 (`vize`) binary:
+//! legacy support is strictly opt-in.
+//!
+//! The companion `legacy` modules in `vize_canon` (type checking) and
+//! `vize_maestro` (editor / LSP) build on the [`LegacyVueVersion`] model
+//! defined here, so all three layers agree on which legacy line is in play.
+
+/// A legacy (pre-Vue-3) major line that Vize can opt into supporting.
+///
+/// Vize targets Vue 3 by default. These variants name the older runtimes whose
+/// template syntax, reactivity, and component model differ enough from Vue 3 to
+/// require a dedicated parsing / analysis path behind the `legacy` feature:
+///
+/// - [`V0`](Self::V0): the Vue 0.x (0.11-era) line, predating the modern SFC
+///   toolchain.
+/// - [`V1`](Self::V1): Vue 1.x (`v-repeat`, `track-by`, `$index`, `v-el`, …).
+/// - [`V2`](Self::V2): Vue 2.x, including 2.7 (Options-API-first; `slot-scope`,
+///   `.sync`, filters, functional components, single root, …).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum LegacyVueVersion {
+    /// Vue 0.x (the 0.11-era line).
+    V0,
+    /// Vue 1.x.
+    V1,
+    /// Vue 2.x (including 2.7).
+    V2,
+}
+
+impl LegacyVueVersion {
+    /// Every supported legacy line, oldest first.
+    pub const ALL: [LegacyVueVersion; 3] = [Self::V0, Self::V1, Self::V2];
+
+    /// A short, stable identifier for the line (`"v0"`, `"v1"`, `"v2"`).
+    ///
+    /// Kept stable so it can be used in config values, diagnostics, and feature
+    /// reporting without churning across releases.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::V0 => "v0",
+            Self::V1 => "v1",
+            Self::V2 => "v2",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn as_str_round_trips_all_variants() {
+        assert_eq!(LegacyVueVersion::ALL.len(), 3);
+        assert_eq!(LegacyVueVersion::V0.as_str(), "v0");
+        assert_eq!(LegacyVueVersion::V1.as_str(), "v1");
+        assert_eq!(LegacyVueVersion::V2.as_str(), "v2");
+    }
+}

--- a/crates/vize_armature/src/lib.rs
+++ b/crates/vize_armature/src/lib.rs
@@ -19,6 +19,11 @@
 pub mod parser;
 pub mod tokenizer;
 
+/// Legacy Vue (v0 / v1 / v2) support. Gated behind the `legacy` feature and
+/// dropped from the default Vue 3 build; opt-in only.
+#[cfg(feature = "legacy")]
+pub mod legacy;
+
 pub use parser::*;
 pub use tokenizer::*;
 

--- a/crates/vize_canon/Cargo.toml
+++ b/crates/vize_canon/Cargo.toml
@@ -10,6 +10,9 @@ description = "Canon - The standard of correctness for Vize type checking"
 [features]
 default = ["native"]
 native = ["dep:which", "dep:walkdir", "dep:dirs", "dep:corsa", "dep:lsp-types"]
+# Opt-in legacy Vue (v0 / v1 / v2) type-checking surface. Not enabled by the
+# default Vue 3 build; turns on the parser-side legacy feature too.
+legacy = ["vize_armature/legacy"]
 
 [dependencies]
 vize_carton.workspace = true

--- a/crates/vize_canon/src/legacy.rs
+++ b/crates/vize_canon/src/legacy.rs
@@ -1,0 +1,12 @@
+//! Legacy Vue (v0 / v1 / v2) type-checking surface.
+//!
+//! This module is the consolidation point for pre-Vue-3 ("legacy") type
+//! checking and virtual-TS generation in `vize_canon`. It is gated behind the
+//! `legacy` cargo feature (which also turns on `vize_armature/legacy`) and is
+//! **not** compiled into the default Vue 3 (`vize`) binary: legacy support is
+//! strictly opt-in.
+//!
+//! The version model is shared from [`vize_armature::legacy`] so the parser,
+//! type checker, and editor layers all agree on which legacy line is in play.
+
+pub use vize_armature::legacy::LegacyVueVersion;

--- a/crates/vize_canon/src/lib.rs
+++ b/crates/vize_canon/src/lib.rs
@@ -56,6 +56,11 @@ pub mod source_map;
 mod types;
 pub mod virtual_ts;
 
+/// Legacy Vue (v0 / v1 / v2) type-checking surface. Gated behind the `legacy`
+/// feature and dropped from the default Vue 3 build; opt-in only.
+#[cfg(feature = "legacy")]
+pub mod legacy;
+
 // Batch type checking module (requires native feature)
 #[cfg(feature = "native")]
 pub mod batch;

--- a/crates/vize_maestro/Cargo.toml
+++ b/crates/vize_maestro/Cargo.toml
@@ -12,6 +12,9 @@ publish = false
 default = ["native", "glyph"]
 glyph = ["dep:vize_glyph"]
 native = ["vize_canon/native"]
+# Opt-in legacy Vue (v0 / v1 / v2) editor / LSP surface. Not enabled by the
+# default Vue 3 build; turns on the type-checker-side legacy feature too.
+legacy = ["vize_canon/legacy"]
 
 [dependencies]
 # LSP Framework

--- a/crates/vize_maestro/src/legacy.rs
+++ b/crates/vize_maestro/src/legacy.rs
@@ -1,0 +1,13 @@
+//! Legacy Vue (v0 / v1 / v2) editor / LSP surface.
+//!
+//! This module is the consolidation point for pre-Vue-3 ("legacy") editor
+//! features (hover, completion, definitions, diagnostics) in `vize_maestro`. It
+//! is gated behind the `legacy` cargo feature (which also turns on
+//! `vize_canon/legacy`) and is **not** compiled into the default Vue 3 (`vize`)
+//! binary: legacy support is strictly opt-in.
+//!
+//! The version model is shared from [`vize_canon::legacy`] (re-exported from
+//! [`vize_armature::legacy`]) so the parser, type checker, and editor layers all
+//! agree on which legacy line is in play.
+
+pub use vize_canon::legacy::LegacyVueVersion;

--- a/crates/vize_maestro/src/lib.rs
+++ b/crates/vize_maestro/src/lib.rs
@@ -66,6 +66,11 @@ pub mod server;
 pub mod utils;
 pub mod virtual_code;
 
+/// Legacy Vue (v0 / v1 / v2) editor / LSP surface. Gated behind the `legacy`
+/// feature and dropped from the default Vue 3 build; opt-in only.
+#[cfg(feature = "legacy")]
+pub mod legacy;
+
 pub use ide::{
     CodeActionService, CodeLensService, CompletionService, DefinitionService, DiagnosticService,
     HoverService, IdeContext, ReferencesService, RenameService, SemanticTokensService, TypeService,


### PR DESCRIPTION
## What

Establishes the architecture for legacy Vue (**v0 / v1 / v2**) support: a
`legacy` cargo feature + `legacy` module in the parser (`vize_armature`), type
checker (`vize_canon`), and editor/LSP (`vize_maestro`) crates.

- **Off by default**, chained `armature → canon → maestro`.
- The Vue 3 `vize` binary never enables it — verified with `cargo tree` (vize
  resolves only `native` for these crates). Legacy support is **opt-in** via
  `--features legacy`.
- Shared version model `LegacyVueVersion { V0, V1, V2 }` lives in
  `vize_armature::legacy` and is re-exported from `vize_canon::legacy` /
  `vize_maestro::legacy` so the parser, type checker, and editor layers agree
  on the line in play.

## Scope

Foundation only. This is intentionally additive (new feature + new gated
module), so it does not touch the default API and is semver-safe.

**Follow-up (separate PR):** move the existing opt-in `legacy_vue2`
type-check/IDE implementation into these `legacy` modules behind the feature and
drop it from the default `vize` build. That changes the default public API of
`vize_canon` (the `*_legacy_vue2` items move behind the non-default feature), so
it needs a deliberate `cargo semver-checks` pass plus call-site gating in the
`vize` CLI.

## Verification

- `cargo check -p vize_maestro --features legacy` (chains canon + armature): OK
- `cargo test -p vize_armature --features legacy`: 1 passed
- `cargo check -p vize_maestro` (default, legacy off): OK
- `cargo tree -p vize`: legacy NOT enabled for armature/canon/maestro
- clippy (`--features legacy`) + fmt: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1098"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783366554&installation_id=136613492&pr_number=1098&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1098&signature=468b533e3d1d950512576c25f9947bda42d754783cde40a7bd31f655427815d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->