### PR TITLE
feat(legacy): gate canon Vue 2 Options-API codegen behind the legacy feature

### DIFF
--- a/crates/vize_canon/src/sfc_typecheck.rs
+++ b/crates/vize_canon/src/sfc_typecheck.rs
@@ -50,9 +50,10 @@ pub use runner::{type_check_sfc, type_check_sfc_with_legacy_vue2};
 
 #[cfg(test)]
 mod tests {
+    #[cfg(feature = "legacy")]
+    use super::type_check_sfc_with_legacy_vue2;
     use super::{
-        SfcTypeCheckOptions, SfcTypeCheckResult, SfcTypeDiagnostic, SfcTypeSeverity,
-        type_check_sfc, type_check_sfc_with_legacy_vue2,
+        SfcTypeCheckOptions, SfcTypeCheckResult, SfcTypeDiagnostic, SfcTypeSeverity, type_check_sfc,
     };
 
     fn stable_snapshot_result(mut result: SfcTypeCheckResult) -> SfcTypeCheckResult {
@@ -412,6 +413,7 @@ export const buttonId =
         );
     }
 
+    #[cfg(feature = "legacy")]
     #[test]
     fn test_type_check_legacy_vue2_options_api_opt_in() {
         let source = r#"<script lang="ts">

--- a/crates/vize_canon/src/virtual_ts/generator.rs
+++ b/crates/vize_canon/src/virtual_ts/generator.rs
@@ -929,6 +929,7 @@ fn is_local_setup_binding(summary: &Croquis, name: &str) -> bool {
         .any(|import| start >= import.start && end <= import.end)
 }
 
+#[cfg(feature = "legacy")]
 fn generate_legacy_vue2_variables(
     mut ts: &mut String,
     summary: &Croquis,
@@ -978,6 +979,17 @@ fn generate_legacy_vue2_variables(
     ts.push('\n');
 }
 
+// No-op stub: legacy Vue (v0/v1/v2) Options-API variable generation is compiled
+// out without the `legacy` feature, so the default Vue 3 build carries none of it.
+#[cfg(not(feature = "legacy"))]
+fn generate_legacy_vue2_variables(
+    _ts: &mut String,
+    _summary: &Croquis,
+    _options: &VirtualTsOptions,
+) {
+}
+
+#[cfg(feature = "legacy")]
 fn is_safe_value_identifier(name: &str) -> bool {
     let mut chars = name.chars();
     let Some(first) = chars.next() else {


### PR DESCRIPTION
## What

Compiles the legacy Vue 2.7 / Nuxt 2 Options-API virtual-TS variable generation
(`generate_legacy_vue2_variables` + its `is_safe_value_identifier` helper) only
when the `legacy` feature is enabled. Without it (the default Vue 3 build) the
function is a **zero-cost no-op stub**, so none of that legacy codegen ships in
the v3 binary.

Builds on the `legacy` feature scaffold from #1098.

## Semver / behavior

- **Public API unchanged** — `type_check_sfc_with_legacy_vue2` and
  `generate_virtual_ts_with_offsets_legacy_vue2` keep their signatures, so
  `cargo semver-checks` (run on default features) stays green.
- Default-feature behavior change: without `--features legacy`, the legacy
  Options-API variable injection is no longer emitted (it is opt-in). The opt-in
  unit test is gated to the feature.

## Verification

- `cargo clippy -p vize_canon -- -D warnings` (default, legacy off): clean
- `cargo test -p vize_canon` (default): 267 passed
- `cargo test -p vize_canon --features legacy` (gated legacy test): 1 passed

## Follow-up

Gate the croquis legacy analyzer call + the `vize` CLI activation so the whole
legacy type-check path (not just codegen) is compiled out of v3, and have the CLI
warn when `type_checker_legacy_vue2` is set without the feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1099"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783368153&installation_id=136613492&pr_number=1099&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1099&signature=13964194dcd765f772d67de1f252e378586bc881ae85cfd7647b59991c536bea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->