### PR TITLE
test(atelier_sfc): expand Options API SFC fixtures (slots, dynamic/recursive components, more)

### DIFF
--- a/tests/fixtures/sfc/options-api.toml
+++ b/tests/fixtures/sfc/options-api.toml
@@ -528,3 +528,280 @@ const count = ref(0)
   <div>{{ count }}</div>
 </template>
 """
+
+[[cases]]
+name = "named and scoped slots in child"
+input = """
+<script>
+import Layout from './Layout.vue'
+
+export default {
+  components: { Layout },
+  data() {
+    return { items: ['a', 'b'] }
+  }
+}
+</script>
+
+<template>
+  <Layout>
+    <template #header>
+      <h1>Title</h1>
+    </template>
+    <template #default="{ item }">
+      <span>{{ item }}</span>
+    </template>
+  </Layout>
+</template>
+"""
+
+[[cases]]
+name = "dynamic component is binding"
+input = """
+<script>
+import Foo from './Foo.vue'
+import Bar from './Bar.vue'
+
+export default {
+  components: { Foo, Bar },
+  data() {
+    return { current: 'Foo' }
+  }
+}
+</script>
+
+<template>
+  <component :is="current" />
+</template>
+"""
+
+[[cases]]
+name = "keep alive wrapping dynamic component"
+input = """
+<script>
+export default {
+  data() {
+    return { view: 'home' }
+  }
+}
+</script>
+
+<template>
+  <KeepAlive>
+    <component :is="view" />
+  </KeepAlive>
+</template>
+"""
+
+[[cases]]
+name = "async setup in options api"
+input = """
+<script>
+export default {
+  async setup() {
+    const data = await Promise.resolve({ title: 'Hello' })
+    return { data }
+  }
+}
+</script>
+
+<template>
+  <div>{{ data.title }}</div>
+</template>
+"""
+
+[[cases]]
+name = "inject array form"
+input = """
+<script>
+export default {
+  inject: ['theme', 'locale']
+}
+</script>
+
+<template>
+  <div>{{ theme }} {{ locale }}</div>
+</template>
+"""
+
+[[cases]]
+name = "emits object form with validator"
+input = """
+<script>
+export default {
+  emits: {
+    submit: (payload) => typeof payload === 'string',
+    cancel: null
+  },
+  data() {
+    return { value: '' }
+  }
+}
+</script>
+
+<template>
+  <button @click="$emit('submit', value)">go</button>
+</template>
+"""
+
+[[cases]]
+name = "v-model on component"
+input = """
+<script>
+import TextField from './TextField.vue'
+
+export default {
+  components: { TextField },
+  data() {
+    return { name: '' }
+  }
+}
+</script>
+
+<template>
+  <TextField v-model="name" />
+</template>
+"""
+
+[[cases]]
+name = "fragment multiple root nodes"
+input = """
+<script>
+export default {
+  data() {
+    return { a: 1, b: 2 }
+  }
+}
+</script>
+
+<template>
+  <header>{{ a }}</header>
+  <main>{{ b }}</main>
+</template>
+"""
+
+[[cases]]
+name = "template ref usage"
+input = """
+<script>
+export default {
+  mounted() {
+    this.$refs.input.focus()
+  }
+}
+</script>
+
+<template>
+  <input ref="input" />
+</template>
+"""
+
+[[cases]]
+name = "recursive self component"
+input = """
+<script>
+export default {
+  name: 'TreeNode',
+  props: ['node']
+}
+</script>
+
+<template>
+  <li>
+    {{ node.label }}
+    <ul v-if="node.children">
+      <TreeNode v-for="child in node.children" :key="child.id" :node="child" />
+    </ul>
+  </li>
+</template>
+"""
+
+[[cases]]
+name = "directive with full hooks"
+input = """
+<script>
+export default {
+  directives: {
+    color: {
+      mounted(el, binding) {
+        el.style.color = binding.value
+      },
+      updated(el, binding) {
+        el.style.color = binding.value
+      }
+    }
+  },
+  data() {
+    return { tint: 'red' }
+  }
+}
+</script>
+
+<template>
+  <p v-color="tint">text</p>
+</template>
+"""
+
+[[cases]]
+name = "mixins and extends combined"
+input = """
+<script>
+import Base from './Base.vue'
+import { sharedMixin } from './mixins.js'
+
+export default {
+  extends: Base,
+  mixins: [sharedMixin],
+  data() {
+    return { own: true }
+  }
+}
+</script>
+
+<template>
+  <div>{{ own }}</div>
+</template>
+"""
+
+[[cases]]
+name = "watch nested path string key"
+input = """
+<script>
+export default {
+  emits: ['changed'],
+  data() {
+    return { form: { name: '' } }
+  },
+  watch: {
+    'form.name'(value) {
+      this.$emit('changed', value)
+    }
+  }
+}
+</script>
+
+<template>
+  <input v-model="form.name" />
+</template>
+"""
+
+[[cases]]
+name = "computed used in class binding"
+input = """
+<script>
+export default {
+  data() {
+    return { active: true }
+  },
+  computed: {
+    classes() {
+      return { 'is-active': this.active }
+    }
+  }
+}
+</script>
+
+<template>
+  <div :class="classes">content</div>
+</template>
+"""

--- a/tests/snapshots/sfc/js/options_api__async_setup_in_options_api.snap
+++ b/tests/snapshots/sfc/js/options_api__async_setup_in_options_api.snap
@@ -1,0 +1,19 @@
+---
+source: crates/vize_atelier_sfc/src/snapshot_tests.rs
+expression: output.as_str()
+---
+
+const _sfc_main = {
+  async setup() {
+    const data = await Promise.resolve({ title: 'Hello' })
+    return { data }
+  }
+}
+
+import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+function _sfc_render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.data.title), 1 /* TEXT */))
+}
+_sfc_main.render = _sfc_render
+export default _sfc_main

--- a/tests/snapshots/sfc/js/options_api__computed_used_in_class_binding.snap
+++ b/tests/snapshots/sfc/js/options_api__computed_used_in_class_binding.snap
@@ -1,0 +1,25 @@
+---
+source: crates/vize_atelier_sfc/src/snapshot_tests.rs
+expression: output.as_str()
+---
+
+const _sfc_main = {
+  data() {
+    return { active: true }
+  },
+  computed: {
+    classes() {
+      return { 'is-active': this.active }
+    }
+  }
+}
+
+import { normalizeClass as _normalizeClass, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+function _sfc_render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("div", {
+    class: _normalizeClass(_ctx.classes)
+  }, "content", 2 /* CLASS */))
+}
+_sfc_main.render = _sfc_render
+export default _sfc_main

--- a/tests/snapshots/sfc/js/options_api__directive_with_full_hooks.snap
+++ b/tests/snapshots/sfc/js/options_api__directive_with_full_hooks.snap
@@ -1,0 +1,34 @@
+---
+source: crates/vize_atelier_sfc/src/snapshot_tests.rs
+expression: output.as_str()
+---
+
+const _sfc_main = {
+  directives: {
+    color: {
+      mounted(el, binding) {
+        el.style.color = binding.value
+      },
+      updated(el, binding) {
+        el.style.color = binding.value
+      }
+    }
+  },
+  data() {
+    return { tint: 'red' }
+  }
+}
+
+import { resolveDirective as _resolveDirective, withDirectives as _withDirectives, openBlock as _openBlock, createElementBlock as _createElementBlock, createTextVNode as _createTextVNode } from "vue"
+
+function _sfc_render(_ctx, _cache) {
+  const _directive_color = _resolveDirective("color")
+  
+  return _withDirectives((_openBlock(), _createElementBlock("p", null, [
+    _createTextVNode("text")
+  ])), [
+    [_directive_color, _ctx.tint]
+  ])
+}
+_sfc_main.render = _sfc_render
+export default _sfc_main

--- a/tests/snapshots/sfc/js/options_api__dynamic_component_is_binding.snap
+++ b/tests/snapshots/sfc/js/options_api__dynamic_component_is_binding.snap
@@ -1,0 +1,22 @@
+---
+source: crates/vize_atelier_sfc/src/snapshot_tests.rs
+expression: output.as_str()
+---
+
+import Foo from './Foo.vue'
+import Bar from './Bar.vue'
+
+const _sfc_main = {
+  components: { Foo, Bar },
+  data() {
+    return { current: 'Foo' }
+  }
+}
+
+import { resolveDynamicComponent as _resolveDynamicComponent, openBlock as _openBlock, createBlock as _createBlock } from "vue"
+
+function _sfc_render(_ctx, _cache) {
+  return (_openBlock(), _createBlock(_resolveDynamicComponent(_ctx.current)))
+}
+_sfc_main.render = _sfc_render
+export default _sfc_main

--- a/tests/snapshots/sfc/js/options_api__emits_object_form_with_validator.snap
+++ b/tests/snapshots/sfc/js/options_api__emits_object_form_with_validator.snap
@@ -1,0 +1,24 @@
+---
+source: crates/vize_atelier_sfc/src/snapshot_tests.rs
+expression: output.as_str()
+---
+
+const _sfc_main = {
+  emits: {
+    submit: (payload) => typeof payload === 'string',
+    cancel: null
+  },
+  data() {
+    return { value: '' }
+  }
+}
+
+import { openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+function _sfc_render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("button", {
+    onClick: $event => (_ctx.$emit('submit', _ctx.value))
+  }, "go", 8 /* PROPS */, ["onClick"]))
+}
+_sfc_main.render = _sfc_render
+export default _sfc_main

--- a/tests/snapshots/sfc/js/options_api__fragment_multiple_root_nodes.snap
+++ b/tests/snapshots/sfc/js/options_api__fragment_multiple_root_nodes.snap
@@ -1,0 +1,21 @@
+---
+source: crates/vize_atelier_sfc/src/snapshot_tests.rs
+expression: output.as_str()
+---
+
+const _sfc_main = {
+  data() {
+    return { a: 1, b: 2 }
+  }
+}
+
+import { toDisplayString as _toDisplayString, createElementVNode as _createElementVNode, openBlock as _openBlock, createElementBlock as _createElementBlock, Fragment as _Fragment } from "vue"
+
+function _sfc_render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock(_Fragment, null, [
+    _createElementVNode("header", null, _toDisplayString(_ctx.a), 1 /* TEXT */),
+    _createElementVNode("main", null, _toDisplayString(_ctx.b), 1 /* TEXT */)
+  ], 64 /* STABLE_FRAGMENT */))
+}
+_sfc_main.render = _sfc_render
+export default _sfc_main

--- a/tests/snapshots/sfc/js/options_api__inject_array_form.snap
+++ b/tests/snapshots/sfc/js/options_api__inject_array_form.snap
@@ -1,0 +1,16 @@
+---
+source: crates/vize_atelier_sfc/src/snapshot_tests.rs
+expression: output.as_str()
+---
+
+const _sfc_main = {
+  inject: ['theme', 'locale']
+}
+
+import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+function _sfc_render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.theme) + " " + _toDisplayString(_ctx.locale), 1 /* TEXT */))
+}
+_sfc_main.render = _sfc_render
+export default _sfc_main

--- a/tests/snapshots/sfc/js/options_api__keep_alive_wrapping_dynamic_component.snap
+++ b/tests/snapshots/sfc/js/options_api__keep_alive_wrapping_dynamic_component.snap
@@ -1,0 +1,20 @@
+---
+source: crates/vize_atelier_sfc/src/snapshot_tests.rs
+expression: output.as_str()
+---
+
+const _sfc_main = {
+  data() {
+    return { view: 'home' }
+  }
+}
+
+import { resolveDynamicComponent as _resolveDynamicComponent, openBlock as _openBlock, createBlock as _createBlock, KeepAlive as _KeepAlive } from "vue"
+
+function _sfc_render(_ctx, _cache) {
+  return (_openBlock(), _createBlock(_KeepAlive, null, [
+    (_openBlock(), _createBlock(_resolveDynamicComponent(_ctx.view)))
+  ], 1024 /* DYNAMIC_SLOTS */))
+}
+_sfc_main.render = _sfc_render
+export default _sfc_main

--- a/tests/snapshots/sfc/js/options_api__mixins_and_extends_combined.snap
+++ b/tests/snapshots/sfc/js/options_api__mixins_and_extends_combined.snap
@@ -1,0 +1,23 @@
+---
+source: crates/vize_atelier_sfc/src/snapshot_tests.rs
+expression: output.as_str()
+---
+
+import Base from './Base.vue'
+import { sharedMixin } from './mixins.js'
+
+const _sfc_main = {
+  extends: Base,
+  mixins: [sharedMixin],
+  data() {
+    return { own: true }
+  }
+}
+
+import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+function _sfc_render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.own), 1 /* TEXT */))
+}
+_sfc_main.render = _sfc_render
+export default _sfc_main

--- a/tests/snapshots/sfc/js/options_api__named_and_scoped_slots_in_child.snap
+++ b/tests/snapshots/sfc/js/options_api__named_and_scoped_slots_in_child.snap
@@ -1,0 +1,33 @@
+---
+source: crates/vize_atelier_sfc/src/snapshot_tests.rs
+expression: output.as_str()
+---
+
+import Layout from './Layout.vue'
+
+const _sfc_main = {
+  components: { Layout },
+  data() {
+    return { items: ['a', 'b'] }
+  }
+}
+
+import { resolveComponent as _resolveComponent, toDisplayString as _toDisplayString, createElementVNode as _createElementVNode, openBlock as _openBlock, createBlock as _createBlock, withCtx as _withCtx } from "vue"
+
+const _hoisted_1 = /*#__PURE__*/ _createElementVNode("h1", null, "Title")
+
+function _sfc_render(_ctx, _cache) {
+  const _component_Layout = _resolveComponent("Layout")
+  
+  return (_openBlock(), _createBlock(_component_Layout, null, {
+    header: _withCtx(() => [
+      _hoisted_1
+    ]),
+    default: _withCtx(({ item }) => [
+      _createElementVNode("span", null, _toDisplayString(item), 1 /* TEXT */)
+    ]),
+    _: 1 /* STABLE */
+  }))
+}
+_sfc_main.render = _sfc_render
+export default _sfc_main

--- a/tests/snapshots/sfc/js/options_api__recursive_self_component.snap
+++ b/tests/snapshots/sfc/js/options_api__recursive_self_component.snap
@@ -1,0 +1,31 @@
+---
+source: crates/vize_atelier_sfc/src/snapshot_tests.rs
+expression: output.as_str()
+---
+
+const _sfc_main = {
+  name: 'TreeNode',
+  props: ['node']
+}
+
+import { resolveComponent as _resolveComponent, toDisplayString as _toDisplayString, openBlock as _openBlock, createBlock as _createBlock, createElementBlock as _createElementBlock, Fragment as _Fragment, createTextVNode as _createTextVNode, createCommentVNode as _createCommentVNode, renderList as _renderList } from "vue"
+
+function _sfc_render(_ctx, _cache) {
+  const _component_TreeNode = _resolveComponent("TreeNode")
+  
+  return (_openBlock(), _createElementBlock("li", null, [
+    _createTextVNode(_toDisplayString(_ctx.node.label) + " ", 1 /* TEXT */),
+    (_ctx.node.children)
+      ? (_openBlock(), _createElementBlock("ul", { key: 0 }, [
+        (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(_ctx.node.children, (child) => {
+          return (_openBlock(), _createBlock(_component_TreeNode, {
+            key: child.id,
+            node: child
+          }, null, 8 /* PROPS */, ["node"]))
+        }), 128 /* KEYED_FRAGMENT */))
+      ]))
+      : _createCommentVNode("v-if", true)
+  ]))
+}
+_sfc_main.render = _sfc_render
+export default _sfc_main

--- a/tests/snapshots/sfc/js/options_api__template_ref_usage.snap
+++ b/tests/snapshots/sfc/js/options_api__template_ref_usage.snap
@@ -1,0 +1,18 @@
+---
+source: crates/vize_atelier_sfc/src/snapshot_tests.rs
+expression: output.as_str()
+---
+
+const _sfc_main = {
+  mounted() {
+    this.$refs.input.focus()
+  }
+}
+
+import { openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+function _sfc_render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("input", { ref: "input" }, null, 512 /* NEED_PATCH */))
+}
+_sfc_main.render = _sfc_render
+export default _sfc_main

--- a/tests/snapshots/sfc/js/options_api__v_model_on_component.snap
+++ b/tests/snapshots/sfc/js/options_api__v_model_on_component.snap
@@ -1,0 +1,26 @@
+---
+source: crates/vize_atelier_sfc/src/snapshot_tests.rs
+expression: output.as_str()
+---
+
+import TextField from './TextField.vue'
+
+const _sfc_main = {
+  components: { TextField },
+  data() {
+    return { name: '' }
+  }
+}
+
+import { resolveComponent as _resolveComponent, openBlock as _openBlock, createBlock as _createBlock } from "vue"
+
+function _sfc_render(_ctx, _cache) {
+  const _component_TextField = _resolveComponent("TextField")
+  
+  return (_openBlock(), _createBlock(_component_TextField, {
+    modelValue: _ctx.name,
+    "onUpdate:modelValue": $event => ((_ctx.name) = $event)
+  }, null, 8 /* PROPS */, ["modelValue", "onUpdate:modelValue"]))
+}
+_sfc_main.render = _sfc_render
+export default _sfc_main

--- a/tests/snapshots/sfc/js/options_api__watch_nested_path_string_key.snap
+++ b/tests/snapshots/sfc/js/options_api__watch_nested_path_string_key.snap
@@ -1,0 +1,28 @@
+---
+source: crates/vize_atelier_sfc/src/snapshot_tests.rs
+expression: output.as_str()
+---
+
+const _sfc_main = {
+  emits: ['changed'],
+  data() {
+    return { form: { name: '' } }
+  },
+  watch: {
+    'form.name'(value) {
+      this.$emit('changed', value)
+    }
+  }
+}
+
+import { vModelText as _vModelText, withDirectives as _withDirectives, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+function _sfc_render(_ctx, _cache) {
+  return _withDirectives((_openBlock(), _createElementBlock("input", {
+    "onUpdate:modelValue": $event => ((_ctx.form.name) = $event)
+  }, null, 8 /* PROPS */, ["onUpdate:modelValue"])), [
+    [_vModelText, _ctx.form.name]
+  ])
+}
+_sfc_main.render = _sfc_render
+export default _sfc_main

--- a/tests/snapshots/sfc/ts/options_api__async_setup_in_options_api.snap
+++ b/tests/snapshots/sfc/ts/options_api__async_setup_in_options_api.snap
@@ -1,0 +1,19 @@
+---
+source: crates/vize_atelier_sfc/src/snapshot_tests.rs
+expression: output.as_str()
+---
+
+const _sfc_main = {
+  async setup() {
+    const data = await Promise.resolve({ title: 'Hello' })
+    return { data }
+  }
+}
+
+import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+function _sfc_render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.data.title), 1 /* TEXT */))
+}
+_sfc_main.render = _sfc_render
+export default _sfc_main

--- a/tests/snapshots/sfc/ts/options_api__computed_used_in_class_binding.snap
+++ b/tests/snapshots/sfc/ts/options_api__computed_used_in_class_binding.snap
@@ -1,0 +1,25 @@
+---
+source: crates/vize_atelier_sfc/src/snapshot_tests.rs
+expression: output.as_str()
+---
+
+const _sfc_main = {
+  data() {
+    return { active: true }
+  },
+  computed: {
+    classes() {
+      return { 'is-active': this.active }
+    }
+  }
+}
+
+import { normalizeClass as _normalizeClass, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+function _sfc_render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("div", {
+    class: _normalizeClass(_ctx.classes)
+  }, "content", 2 /* CLASS */))
+}
+_sfc_main.render = _sfc_render
+export default _sfc_main

--- a/tests/snapshots/sfc/ts/options_api__directive_with_full_hooks.snap
+++ b/tests/snapshots/sfc/ts/options_api__directive_with_full_hooks.snap
@@ -1,0 +1,34 @@
+---
+source: crates/vize_atelier_sfc/src/snapshot_tests.rs
+expression: output.as_str()
+---
+
+const _sfc_main = {
+  directives: {
+    color: {
+      mounted(el, binding) {
+        el.style.color = binding.value
+      },
+      updated(el, binding) {
+        el.style.color = binding.value
+      }
+    }
+  },
+  data() {
+    return { tint: 'red' }
+  }
+}
+
+import { resolveDirective as _resolveDirective, withDirectives as _withDirectives, openBlock as _openBlock, createElementBlock as _createElementBlock, createTextVNode as _createTextVNode } from "vue"
+
+function _sfc_render(_ctx, _cache) {
+  const _directive_color = _resolveDirective("color")
+  
+  return _withDirectives((_openBlock(), _createElementBlock("p", null, [
+    _createTextVNode("text")
+  ])), [
+    [_directive_color, _ctx.tint]
+  ])
+}
+_sfc_main.render = _sfc_render
+export default _sfc_main

--- a/tests/snapshots/sfc/ts/options_api__dynamic_component_is_binding.snap
+++ b/tests/snapshots/sfc/ts/options_api__dynamic_component_is_binding.snap
@@ -1,0 +1,22 @@
+---
+source: crates/vize_atelier_sfc/src/snapshot_tests.rs
+expression: output.as_str()
+---
+
+import Foo from './Foo.vue'
+import Bar from './Bar.vue'
+
+const _sfc_main = {
+  components: { Foo, Bar },
+  data() {
+    return { current: 'Foo' }
+  }
+}
+
+import { resolveDynamicComponent as _resolveDynamicComponent, openBlock as _openBlock, createBlock as _createBlock } from "vue"
+
+function _sfc_render(_ctx, _cache) {
+  return (_openBlock(), _createBlock(_resolveDynamicComponent(_ctx.current)))
+}
+_sfc_main.render = _sfc_render
+export default _sfc_main

--- a/tests/snapshots/sfc/ts/options_api__emits_object_form_with_validator.snap
+++ b/tests/snapshots/sfc/ts/options_api__emits_object_form_with_validator.snap
@@ -1,0 +1,24 @@
+---
+source: crates/vize_atelier_sfc/src/snapshot_tests.rs
+expression: output.as_str()
+---
+
+const _sfc_main = {
+  emits: {
+    submit: (payload) => typeof payload === 'string',
+    cancel: null
+  },
+  data() {
+    return { value: '' }
+  }
+}
+
+import { openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+function _sfc_render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("button", {
+    onClick: $event => (_ctx.$emit('submit', _ctx.value))
+  }, "go", 8 /* PROPS */, ["onClick"]))
+}
+_sfc_main.render = _sfc_render
+export default _sfc_main

--- a/tests/snapshots/sfc/ts/options_api__fragment_multiple_root_nodes.snap
+++ b/tests/snapshots/sfc/ts/options_api__fragment_multiple_root_nodes.snap
@@ -1,0 +1,21 @@
+---
+source: crates/vize_atelier_sfc/src/snapshot_tests.rs
+expression: output.as_str()
+---
+
+const _sfc_main = {
+  data() {
+    return { a: 1, b: 2 }
+  }
+}
+
+import { toDisplayString as _toDisplayString, createElementVNode as _createElementVNode, openBlock as _openBlock, createElementBlock as _createElementBlock, Fragment as _Fragment } from "vue"
+
+function _sfc_render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock(_Fragment, null, [
+    _createElementVNode("header", null, _toDisplayString(_ctx.a), 1 /* TEXT */),
+    _createElementVNode("main", null, _toDisplayString(_ctx.b), 1 /* TEXT */)
+  ], 64 /* STABLE_FRAGMENT */))
+}
+_sfc_main.render = _sfc_render
+export default _sfc_main

--- a/tests/snapshots/sfc/ts/options_api__inject_array_form.snap
+++ b/tests/snapshots/sfc/ts/options_api__inject_array_form.snap
@@ -1,0 +1,16 @@
+---
+source: crates/vize_atelier_sfc/src/snapshot_tests.rs
+expression: output.as_str()
+---
+
+const _sfc_main = {
+  inject: ['theme', 'locale']
+}
+
+import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+function _sfc_render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.theme) + " " + _toDisplayString(_ctx.locale), 1 /* TEXT */))
+}
+_sfc_main.render = _sfc_render
+export default _sfc_main

--- a/tests/snapshots/sfc/ts/options_api__keep_alive_wrapping_dynamic_component.snap
+++ b/tests/snapshots/sfc/ts/options_api__keep_alive_wrapping_dynamic_component.snap
@@ -1,0 +1,20 @@
+---
+source: crates/vize_atelier_sfc/src/snapshot_tests.rs
+expression: output.as_str()
+---
+
+const _sfc_main = {
+  data() {
+    return { view: 'home' }
+  }
+}
+
+import { resolveDynamicComponent as _resolveDynamicComponent, openBlock as _openBlock, createBlock as _createBlock, KeepAlive as _KeepAlive } from "vue"
+
+function _sfc_render(_ctx, _cache) {
+  return (_openBlock(), _createBlock(_KeepAlive, null, [
+    (_openBlock(), _createBlock(_resolveDynamicComponent(_ctx.view)))
+  ], 1024 /* DYNAMIC_SLOTS */))
+}
+_sfc_main.render = _sfc_render
+export default _sfc_main

--- a/tests/snapshots/sfc/ts/options_api__mixins_and_extends_combined.snap
+++ b/tests/snapshots/sfc/ts/options_api__mixins_and_extends_combined.snap
@@ -1,0 +1,23 @@
+---
+source: crates/vize_atelier_sfc/src/snapshot_tests.rs
+expression: output.as_str()
+---
+
+import Base from './Base.vue'
+import { sharedMixin } from './mixins.js'
+
+const _sfc_main = {
+  extends: Base,
+  mixins: [sharedMixin],
+  data() {
+    return { own: true }
+  }
+}
+
+import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+function _sfc_render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.own), 1 /* TEXT */))
+}
+_sfc_main.render = _sfc_render
+export default _sfc_main

--- a/tests/snapshots/sfc/ts/options_api__named_and_scoped_slots_in_child.snap
+++ b/tests/snapshots/sfc/ts/options_api__named_and_scoped_slots_in_child.snap
@@ -1,0 +1,33 @@
+---
+source: crates/vize_atelier_sfc/src/snapshot_tests.rs
+expression: output.as_str()
+---
+
+import Layout from './Layout.vue'
+
+const _sfc_main = {
+  components: { Layout },
+  data() {
+    return { items: ['a', 'b'] }
+  }
+}
+
+import { resolveComponent as _resolveComponent, toDisplayString as _toDisplayString, createElementVNode as _createElementVNode, openBlock as _openBlock, createBlock as _createBlock, withCtx as _withCtx } from "vue"
+
+const _hoisted_1 = /*#__PURE__*/ _createElementVNode("h1", null, "Title")
+
+function _sfc_render(_ctx, _cache) {
+  const _component_Layout = _resolveComponent("Layout")
+  
+  return (_openBlock(), _createBlock(_component_Layout, null, {
+    header: _withCtx(() => [
+      _hoisted_1
+    ]),
+    default: _withCtx(({ item }) => [
+      _createElementVNode("span", null, _toDisplayString(item), 1 /* TEXT */)
+    ]),
+    _: 1 /* STABLE */
+  }))
+}
+_sfc_main.render = _sfc_render
+export default _sfc_main

--- a/tests/snapshots/sfc/ts/options_api__recursive_self_component.snap
+++ b/tests/snapshots/sfc/ts/options_api__recursive_self_component.snap
@@ -1,0 +1,31 @@
+---
+source: crates/vize_atelier_sfc/src/snapshot_tests.rs
+expression: output.as_str()
+---
+
+const _sfc_main = {
+  name: 'TreeNode',
+  props: ['node']
+}
+
+import { resolveComponent as _resolveComponent, toDisplayString as _toDisplayString, openBlock as _openBlock, createBlock as _createBlock, createElementBlock as _createElementBlock, Fragment as _Fragment, createTextVNode as _createTextVNode, createCommentVNode as _createCommentVNode, renderList as _renderList } from "vue"
+
+function _sfc_render(_ctx, _cache) {
+  const _component_TreeNode = _resolveComponent("TreeNode")
+  
+  return (_openBlock(), _createElementBlock("li", null, [
+    _createTextVNode(_toDisplayString(_ctx.node.label) + " ", 1 /* TEXT */),
+    (_ctx.node.children)
+      ? (_openBlock(), _createElementBlock("ul", { key: 0 }, [
+        (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(_ctx.node.children, (child) => {
+          return (_openBlock(), _createBlock(_component_TreeNode, {
+            key: child.id,
+            node: child
+          }, null, 8 /* PROPS */, ["node"]))
+        }), 128 /* KEYED_FRAGMENT */))
+      ]))
+      : _createCommentVNode("v-if", true)
+  ]))
+}
+_sfc_main.render = _sfc_render
+export default _sfc_main

--- a/tests/snapshots/sfc/ts/options_api__template_ref_usage.snap
+++ b/tests/snapshots/sfc/ts/options_api__template_ref_usage.snap
@@ -1,0 +1,18 @@
+---
+source: crates/vize_atelier_sfc/src/snapshot_tests.rs
+expression: output.as_str()
+---
+
+const _sfc_main = {
+  mounted() {
+    this.$refs.input.focus()
+  }
+}
+
+import { openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+function _sfc_render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("input", { ref: "input" }, null, 512 /* NEED_PATCH */))
+}
+_sfc_main.render = _sfc_render
+export default _sfc_main

--- a/tests/snapshots/sfc/ts/options_api__v_model_on_component.snap
+++ b/tests/snapshots/sfc/ts/options_api__v_model_on_component.snap
@@ -1,0 +1,26 @@
+---
+source: crates/vize_atelier_sfc/src/snapshot_tests.rs
+expression: output.as_str()
+---
+
+import TextField from './TextField.vue'
+
+const _sfc_main = {
+  components: { TextField },
+  data() {
+    return { name: '' }
+  }
+}
+
+import { resolveComponent as _resolveComponent, openBlock as _openBlock, createBlock as _createBlock } from "vue"
+
+function _sfc_render(_ctx, _cache) {
+  const _component_TextField = _resolveComponent("TextField")
+  
+  return (_openBlock(), _createBlock(_component_TextField, {
+    modelValue: _ctx.name,
+    "onUpdate:modelValue": $event => ((_ctx.name) = $event)
+  }, null, 8 /* PROPS */, ["modelValue", "onUpdate:modelValue"]))
+}
+_sfc_main.render = _sfc_render
+export default _sfc_main

--- a/tests/snapshots/sfc/ts/options_api__watch_nested_path_string_key.snap
+++ b/tests/snapshots/sfc/ts/options_api__watch_nested_path_string_key.snap
@@ -1,0 +1,28 @@
+---
+source: crates/vize_atelier_sfc/src/snapshot_tests.rs
+expression: output.as_str()
+---
+
+const _sfc_main = {
+  emits: ['changed'],
+  data() {
+    return { form: { name: '' } }
+  },
+  watch: {
+    'form.name'(value) {
+      this.$emit('changed', value)
+    }
+  }
+}
+
+import { vModelText as _vModelText, withDirectives as _withDirectives, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+function _sfc_render(_ctx, _cache) {
+  return _withDirectives((_openBlock(), _createElementBlock("input", {
+    "onUpdate:modelValue": $event => ((_ctx.form.name) = $event)
+  }, null, 8 /* PROPS */, ["onUpdate:modelValue"])), [
+    [_vModelText, _ctx.form.name]
+  ])
+}
+_sfc_main.render = _sfc_render
+export default _sfc_main


### PR DESCRIPTION
## What

Extends the Options API parity fixtures from 25 to **39 cases** (78 snapshots, JS+TS).

New coverage: named/scoped slots, dynamic `:is` components, `KeepAlive`, async `setup()`, `inject` array form, `emits` object form with validators, component `v-model`, fragment (multi-root), template refs, recursive self-component, full-hook custom directives, `mixins`+`extends` combined, nested watch path key (`form.name`), and computed-driven `:class`.

## Verification

- All 39 cases compile with no parse/compile errors.
- Output resolves as expected (`resolveComponent`, `resolveDynamicComponent`, `withCtx`, recursive self-resolve by name) and follows the script-first ordering from #1097.
- `cargo test -p vize_atelier_sfc` deterministic; `cargo fmt` clean.

Test-only; no compiler behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1102"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783369118&installation_id=136613492&pr_number=1102&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1102&signature=ff7e0845372db4a725b0fd82d73f709c38c895086b2f54fb4a87d1bb8451f7f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->