### PR TITLE
test(atelier_ssr): add SSR codegen coverage (directives, lists, components, fragments)

### DIFF
--- a/crates/vize_atelier_ssr/src/lib.rs
+++ b/crates/vize_atelier_ssr/src/lib.rs
@@ -365,4 +365,99 @@ mod tests {
             result.code
         );
     }
+
+    #[test]
+    fn test_ssr_v_if_v_else() {
+        let allocator = Bump::new();
+        let (_, errors, result) =
+            compile_ssr(&allocator, r#"<div v-if="ok">yes</div><p v-else>no</p>"#);
+        assert!(errors.is_empty());
+        insta::assert_snapshot!(result.code.as_str());
+    }
+
+    #[test]
+    fn test_ssr_v_for_list() {
+        let allocator = Bump::new();
+        let (_, errors, result) = compile_ssr(
+            &allocator,
+            r#"<ul><li v-for="item in items" :key="item.id">{{ item.name }}</li></ul>"#,
+        );
+        assert!(errors.is_empty());
+        insta::assert_snapshot!(result.code.as_str());
+    }
+
+    #[test]
+    fn test_ssr_static_and_dynamic_attrs() {
+        let allocator = Bump::new();
+        let (_, errors, result) = compile_ssr(
+            &allocator,
+            r#"<a class="link" :href="url" target="_blank">{{ label }}</a>"#,
+        );
+        assert!(errors.is_empty());
+        insta::assert_snapshot!(result.code.as_str());
+    }
+
+    #[test]
+    fn test_ssr_v_bind_object() {
+        let allocator = Bump::new();
+        let (_, errors, result) = compile_ssr(&allocator, r#"<div v-bind="attrs">content</div>"#);
+        assert!(errors.is_empty());
+        insta::assert_snapshot!(result.code.as_str());
+    }
+
+    #[test]
+    fn test_ssr_v_html() {
+        let allocator = Bump::new();
+        let (_, errors, result) = compile_ssr(&allocator, r#"<div v-html="raw"></div>"#);
+        assert!(errors.is_empty());
+        insta::assert_snapshot!(result.code.as_str());
+    }
+
+    #[test]
+    fn test_ssr_dynamic_class_and_style() {
+        let allocator = Bump::new();
+        let (_, errors, result) = compile_ssr(
+            &allocator,
+            r#"<div :class="{ active: isActive }" :style="{ color }">x</div>"#,
+        );
+        assert!(errors.is_empty());
+        insta::assert_snapshot!(result.code.as_str());
+    }
+
+    #[test]
+    fn test_ssr_component_with_props_and_slot() {
+        let allocator = Bump::new();
+        let (_, errors, result) =
+            compile_ssr(&allocator, r#"<MyCard :title="t"><p>body</p></MyCard>"#);
+        assert!(errors.is_empty());
+        insta::assert_snapshot!(result.code.as_str());
+    }
+
+    #[test]
+    fn test_ssr_fragment_multiple_roots() {
+        let allocator = Bump::new();
+        let (_, errors, result) =
+            compile_ssr(&allocator, r#"<header>a</header><main>{{ b }}</main>"#);
+        assert!(errors.is_empty());
+        insta::assert_snapshot!(result.code.as_str());
+    }
+
+    #[test]
+    fn test_ssr_text_and_interpolation_mix() {
+        let allocator = Bump::new();
+        let (_, errors, result) = compile_ssr(
+            &allocator,
+            r#"<p>Hello {{ name }}, you have {{ count }} items</p>"#,
+        );
+        assert!(errors.is_empty());
+        insta::assert_snapshot!(result.code.as_str());
+    }
+
+    #[test]
+    fn test_ssr_v_show() {
+        let allocator = Bump::new();
+        let (_, errors, result) = compile_ssr(&allocator, r#"<div v-show="visible">toggle</div>"#);
+        assert!(errors.is_empty());
+        insta::assert_snapshot!(result.code.as_str());
+    }
 }

--- a/crates/vize_atelier_ssr/src/snapshots/vize_atelier_ssr__tests__ssr_component_with_props_and_slot.snap
+++ b/crates/vize_atelier_ssr/src/snapshots/vize_atelier_ssr__tests__ssr_component_with_props_and_slot.snap
@@ -1,0 +1,16 @@
+---
+source: crates/vize_atelier_ssr/src/lib.rs
+expression: result.code.as_str()
+---
+function ssrRender(_ctx, _push, _parent, _attrs) {
+  _push(_ssrRenderComponent(_resolveComponent("MyCard"), _mergeProps({ title: _ctx.t }, _attrs), {
+    default: _withCtx((_, _push, _parent, _scopeId) => {
+      if (_push) {
+        _push(`<p>body</p>`)
+      } else {
+        return [_createElementVNode("p", null, "body")]
+      }
+    }),
+    _: 1
+  }, _parent))
+}

--- a/crates/vize_atelier_ssr/src/snapshots/vize_atelier_ssr__tests__ssr_dynamic_class_and_style.snap
+++ b/crates/vize_atelier_ssr/src/snapshots/vize_atelier_ssr__tests__ssr_dynamic_class_and_style.snap
@@ -1,0 +1,7 @@
+---
+source: crates/vize_atelier_ssr/src/lib.rs
+expression: result.code.as_str()
+---
+function ssrRender(_ctx, _push, _parent, _attrs) {
+  _push(`<div${_ssrRenderAttrs(_mergeProps({ class: { active: _ctx.isActive }, style: { color: _ctx.color } }, _attrs))}>x</div>`)
+}

--- a/crates/vize_atelier_ssr/src/snapshots/vize_atelier_ssr__tests__ssr_fragment_multiple_roots.snap
+++ b/crates/vize_atelier_ssr/src/snapshots/vize_atelier_ssr__tests__ssr_fragment_multiple_roots.snap
@@ -1,0 +1,7 @@
+---
+source: crates/vize_atelier_ssr/src/lib.rs
+expression: result.code.as_str()
+---
+function ssrRender(_ctx, _push, _parent, _attrs) {
+  _push(`<!--[--><header>a</header><main>${_ssrInterpolate(_ctx.b)}</main><!--]-->`)
+}

--- a/crates/vize_atelier_ssr/src/snapshots/vize_atelier_ssr__tests__ssr_static_and_dynamic_attrs.snap
+++ b/crates/vize_atelier_ssr/src/snapshots/vize_atelier_ssr__tests__ssr_static_and_dynamic_attrs.snap
@@ -1,0 +1,7 @@
+---
+source: crates/vize_atelier_ssr/src/lib.rs
+expression: result.code.as_str()
+---
+function ssrRender(_ctx, _push, _parent, _attrs) {
+  _push(`<a${_ssrRenderAttrs(_mergeProps({ href: _ctx.url, target: "_blank", class: "link" }, _attrs))}>${_ssrInterpolate(_ctx.label)}</a>`)
+}

--- a/crates/vize_atelier_ssr/src/snapshots/vize_atelier_ssr__tests__ssr_text_and_interpolation_mix.snap
+++ b/crates/vize_atelier_ssr/src/snapshots/vize_atelier_ssr__tests__ssr_text_and_interpolation_mix.snap
@@ -1,0 +1,7 @@
+---
+source: crates/vize_atelier_ssr/src/lib.rs
+expression: result.code.as_str()
+---
+function ssrRender(_ctx, _push, _parent, _attrs) {
+  _push(`<p${_ssrRenderAttrs(_attrs)}>Hello ${_ssrInterpolate(_ctx.name)}, you have ${_ssrInterpolate(_ctx.count)} items</p>`)
+}

--- a/crates/vize_atelier_ssr/src/snapshots/vize_atelier_ssr__tests__ssr_v_bind_object.snap
+++ b/crates/vize_atelier_ssr/src/snapshots/vize_atelier_ssr__tests__ssr_v_bind_object.snap
@@ -1,0 +1,7 @@
+---
+source: crates/vize_atelier_ssr/src/lib.rs
+expression: result.code.as_str()
+---
+function ssrRender(_ctx, _push, _parent, _attrs) {
+  _push(`<div${_ssrRenderAttrs(_mergeProps(_normalizeProps(_guardReactiveProps(_ctx.attrs)), _attrs))}>content</div>`)
+}

--- a/crates/vize_atelier_ssr/src/snapshots/vize_atelier_ssr__tests__ssr_v_for_list.snap
+++ b/crates/vize_atelier_ssr/src/snapshots/vize_atelier_ssr__tests__ssr_v_for_list.snap
@@ -1,0 +1,13 @@
+---
+source: crates/vize_atelier_ssr/src/lib.rs
+expression: result.code.as_str()
+---
+function ssrRender(_ctx, _push, _parent, _attrs) {
+  _push(`<ul${_ssrRenderAttrs(_attrs)}>`)
+  _push(`<!--[-->`)
+  _ssrRenderList(_ctx.items, (item) => {
+    _push(`<li${_ssrRenderAttr("key", item.id)}>${_ssrInterpolate(item.name)}</li>`)
+  })
+  _push(`<!--]-->`)
+  _push(`</ul>`)
+}

--- a/crates/vize_atelier_ssr/src/snapshots/vize_atelier_ssr__tests__ssr_v_html.snap
+++ b/crates/vize_atelier_ssr/src/snapshots/vize_atelier_ssr__tests__ssr_v_html.snap
@@ -1,0 +1,7 @@
+---
+source: crates/vize_atelier_ssr/src/lib.rs
+expression: result.code.as_str()
+---
+function ssrRender(_ctx, _push, _parent, _attrs) {
+  _push(`<div${_ssrRenderAttrs(_attrs)}>${(_ctx.raw) ?? ''}</div>`)
+}

--- a/crates/vize_atelier_ssr/src/snapshots/vize_atelier_ssr__tests__ssr_v_if_v_else.snap
+++ b/crates/vize_atelier_ssr/src/snapshots/vize_atelier_ssr__tests__ssr_v_if_v_else.snap
@@ -1,0 +1,11 @@
+---
+source: crates/vize_atelier_ssr/src/lib.rs
+expression: result.code.as_str()
+---
+function ssrRender(_ctx, _push, _parent, _attrs) {
+  if (_ctx.ok) {
+    _push(`<div${_ssrRenderAttrs(_attrs)}>yes</div>`)
+  } else {
+    _push(`<p${_ssrRenderAttrs(_attrs)}>no</p>`)
+  }
+}

--- a/crates/vize_atelier_ssr/src/snapshots/vize_atelier_ssr__tests__ssr_v_show.snap
+++ b/crates/vize_atelier_ssr/src/snapshots/vize_atelier_ssr__tests__ssr_v_show.snap
@@ -1,0 +1,7 @@
+---
+source: crates/vize_atelier_ssr/src/lib.rs
+expression: result.code.as_str()
+---
+function ssrRender(_ctx, _push, _parent, _attrs) {
+  _push(`<div${_ssrRenderAttrs(_mergeProps({ style: ((_ctx.visible) ? null : { display: "none" }) }, _attrs))}>toggle</div>`)
+}


### PR DESCRIPTION
## What

Adds 10 SSR codegen snapshot tests to `vize_atelier_ssr`: `v-if/v-else`, `v-for`, static+dynamic attrs, `v-bind` object, `v-html`, dynamic `:class`/`:style`, component with props+slot, fragment multi-root, text/interpolation mix, and `v-show`.

## Verification

- `cargo test -p vize_atelier_ssr`: 13 pass (10 new + 3 existing `ssr_*`), 0 fail; deterministic.
- Output is correct SSR (`ssrRender` with `_push` template literals; `v-show` emits the `display:none` style merge; `v-if/v-else` emits `if/else`).
- `cargo fmt` clean. CI clippy (`--workspace`, no `--tests`) does not lint `#[cfg(test)]` code.

Test-only; no SSR compiler behavior change. Broadens the SSR (Experimental) surface coverage requested in the roadmap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1103"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783369275&installation_id=136613492&pr_number=1103&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1103&signature=36ee6ff322ca250ab4fefbbc0d32a86c5b182a820eab2c950e63b7d24c76c5eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->