### PR TITLE
feat(legacy): gate vize CLI legacy Vue activation behind the legacy feature

### DIFF
--- a/crates/vize/Cargo.toml
+++ b/crates/vize/Cargo.toml
@@ -20,6 +20,9 @@ path = "src/lib.rs"
 default = ["glyph", "maestro"]
 glyph = ["dep:vize_glyph", "vize_maestro?/glyph"]
 maestro = ["dep:vize_maestro"]
+# Opt-in legacy Vue (v0 / v1 / v2) support. Off by default so the Vue 3 binary
+# never activates or compiles it; turns on the legacy feature across the stack.
+legacy = ["vize_canon/legacy", "vize_maestro?/legacy"]
 
 [dependencies]
 # Vize crates (re-exported for unified documentation)

--- a/crates/vize/src/commands/check/runner.rs
+++ b/crates/vize/src/commands/check/runner.rs
@@ -76,7 +76,19 @@ pub(crate) fn run_direct(args: &CheckArgs) {
     } else {
         crate::config::load_config_with_features_and_source(args.config.as_deref())
     };
+    // Legacy Vue 2.7 / Nuxt 2 Options-API type checking is opt-in and compiled out
+    // of the default Vue 3 binary. Without the `legacy` feature, honor the config
+    // flag by warning instead of silently ignoring it.
+    #[cfg(feature = "legacy")]
     let legacy_vue2 = loaded_config.features.type_checker_legacy_vue2;
+    #[cfg(not(feature = "legacy"))]
+    if loaded_config.features.type_checker_legacy_vue2 {
+        eprintln!(
+            "\x1b[33mwarning:\x1b[0m `type_checker_legacy_vue2` is set but this `vize` build \
+             has no legacy Vue support; rebuild with `--features legacy` to enable Vue 2 \
+             Options API type checking."
+        );
+    }
     let config = loaded_config.config;
     let config_dir = loaded_config
         .source_path
@@ -233,6 +245,7 @@ pub(crate) fn run_direct(args: &CheckArgs) {
             std::process::exit(1);
         }
     };
+    #[cfg(feature = "legacy")]
     if legacy_vue2 {
         checker.enable_legacy_vue2();
     }


### PR DESCRIPTION
## What

Adds a `legacy` cargo feature to the `vize` crate (chaining `vize_canon/legacy` + `vize_maestro?/legacy`) and gates the `vize check` legacy Vue 2.7 / Nuxt 2 activation behind it.

- **Default Vue 3 binary**: does not activate legacy type checking. If `type_checker_legacy_vue2` is set in config, it prints a clear stderr warning pointing at `--features legacy` (instead of silently ignoring the flag).
- **`vize --features legacy`**: full legacy activation as before.

With the canon codegen gate, this completes \"drop legacy from the v3 binary, keep it opt-in.\"

## Verification

- `cargo clippy -p vize -- -D warnings` (default): clean
- `cargo build -p vize --features legacy`: ok
- `cargo tree -p vize`: `vize_canon` legacy NOT enabled by default
- `cargo fmt` clean
- `vize` is `publish = false`, so not a `cargo semver-checks` surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1104"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783369515&installation_id=136613492&pr_number=1104&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1104&signature=5b4e7cdc2f5118cf5da7722e415dbe228dc9ca8bd2bf288e8b9cfc3e7a907867"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->