### PR TITLE
docs(readme): simplify into a docs-pointing entry point

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,33 +17,29 @@
 </p>
 
 > [!WARNING]
-> Vize is under active development. It is not a completely production-ready toolchain yet; see the
-> [production-readiness checklist](./docs/release/production-readiness.md),
+> Vize is experimental and in its **Real World Testing** phase — not a completely
+> production-ready toolchain yet. Breaking changes and behavior that diverges from Vue are
+> expected. Review the [production-readiness checklist](./docs/release/production-readiness.md),
 > [support policy](./docs/release/support-policy.md), and [stability guide](./docs/content/stability.md)
-> before adopting it in production.
+> before adopting it.
 
 > [!IMPORTANT]
-> For day-to-day editor support, keep using the official Vue language tools (`vuejs/language-tools`)
-> for now. Vize's VS Code extension, Zed extension, and `vize lsp` remain opt-in while the editor
-> surface matures.
+> For day-to-day editor support, keep using the official Vue language tools
+> (`vuejs/language-tools`) for now. Vize's editor extensions and `vize lsp` stay opt-in while the
+> editor surface matures.
 
 ## What Is Vize?
 
-Vize is an unofficial Rust-native Vue toolchain. It experiments with a shared parser, semantic
-analysis, compiler, lint, type-checking, formatting, and editor pipeline for Vue single-file
-components.
+Vize is an unofficial, Rust-native Vue toolchain: a shared parser, semantic analysis, compiler,
+lint, type-checking, formatting, and editor pipeline for Vue single-file components. The main
+entry points are `@vizejs/vite-plugin` (Vite), `vize` (npm CLI), the native `vize` binary
+(full CLI / LSP / profiling), `@vizejs/vite-plugin-musea` (Musea), and `oxlint-plugin-vize`
+(Oxlint).
 
-The main entry points today are:
-
-- `@vizejs/vite-plugin` for Rust-native Vue SFC compilation in Vite.
-- `vize` on npm for package scripts such as `build`, `fmt`, `lint`, `check`, and `ready`.
-- the Rust `vize` binary for the full native CLI, LSP, profiling, and project-backed checking.
-- `@vizejs/vite-plugin-musea` for Musea component gallery workflows.
-- `oxlint-plugin-vize` for running Vize diagnostics inside Oxlint.
+For everything beyond the quick start below, see the
+[documentation](https://vizejs.dev) — starting with [Getting Started](./docs/content/getting-started.md).
 
 ## Quick Start
-
-Need `vp` first? Install Vite+ once from the [Vite+ install guide](https://viteplus.dev/guide/install).
 
 ```bash
 vp install -D @vizejs/vite-plugin
@@ -54,25 +50,12 @@ vp install -D @vizejs/vite-plugin
 import { defineConfig } from "vite";
 import vize from "@vizejs/vite-plugin";
 
-export default defineConfig({
-  plugins: [vize()],
-});
+export default defineConfig({ plugins: [vize()] });
 ```
 
-Add the npm CLI when you want package scripts:
-
-```bash
-vp install -D vize
-vp exec vize lint src
-vp exec vize check src
-vp exec vize fmt --check src
-```
-
-Use the native binary when you need the full CLI:
-
-```bash
-nix run github:ubugeeei-prod/vize#vize -- --help
-```
+That covers the Vite path. For the npm CLI, the native binary, and everything else, follow
+[Getting Started](./docs/content/getting-started.md). (Need `vp` first? See the
+[Vite+ install guide](https://viteplus.dev/guide/install).)
 
 ## Documentation Map
 
@@ -92,20 +75,21 @@ nix run github:ubugeeei-prod/vize#vize -- --help
 
 ## Local Development
 
-The primary local setup is `Nix + vp`:
-
 ```bash
 nix develop
 vp install --frozen-lockfile
-vp check
-vp fmt
-vp dev
+vp check && vp fmt && vp dev
 ```
 
 See [CONTRIBUTING.md](./CONTRIBUTING.md) for repository setup, pull-request expectations, and
 language-facing change-class guidance.
 
 ## Community
+
+Vize is in its **Real World Testing** phase, and the most useful contributions right now are
+real-world signal. We are waiting for plenty of issues and PRs, and we are actively looking for
+reasonably large Vue projects to use as test beds — bug reports, reproductions, benchmarks, and
+compatibility findings all help move the project toward its first stable release.
 
 - [Governance](./GOVERNANCE.md)
 - [Support](./SUPPORT.md)


### PR DESCRIPTION
## What

Makes the README a leaner entry point that sends people to the docs, per request.

- **Quick Start**: trimmed from three code paths to the single Vite path + a pointer to [Getting Started](./docs/content/getting-started.md) for CLI / native / everything else.
- **What Is Vize?** and **Local Development**: condensed.
- **Community**: adds the Real World Testing call — issues/PRs welcome, and seeking reasonably large Vue projects as test beds.
- Reflects the **Real World Testing** phase in the warning callout.

## Kept (per request)

- **Credits** and **Sponsor** content are kept in full (header Sponsor link, Community sponsor link, and the full Credits / Special thanks list).
- All required README sections and every Documentation Map link retained.

## Verification

- `node --test tests/tooling/readme-boundary.test.ts`: both tests pass (required sections present, no over-detailed sections, all doc-map links exist).
- `vp check --fix` formatted; 143 -> 127 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1106"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783394124&installation_id=136613492&pr_number=1106&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1106&signature=f07ff42611f43cf80b3a3cda9bf7c66e9b2aa8899a6aa1ee24094f2d813497b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->