### PR TITLE
fix: handle vite resolve edge cases

### DIFF
--- a/crates/vize_atelier_sfc/src/script/context/external_types.rs
+++ b/crates/vize_atelier_sfc/src/script/context/external_types.rs
@@ -196,6 +196,10 @@ fn resolve_candidate_path(candidate: PathBuf) -> Option<PathBuf> {
         return canonicalize_or_original(candidate);
     }
 
+    if let Some(ts_source_path) = resolve_ts_source_path_for_js_specifier(&candidate) {
+        return Some(ts_source_path);
+    }
+
     for ext in RESOLVE_EXTENSIONS {
         let mut with_ext = candidate.clone().into_os_string();
         with_ext.push(ext);
@@ -211,6 +215,26 @@ fn resolve_candidate_path(candidate: PathBuf) -> Option<PathBuf> {
             if path.is_file() {
                 return canonicalize_or_original(path);
             }
+        }
+    }
+
+    None
+}
+
+fn resolve_ts_source_path_for_js_specifier(candidate: &Path) -> Option<PathBuf> {
+    let extension = candidate.extension()?.to_str()?;
+    let source_extensions: &[&str] = match extension {
+        "js" => &["ts", "tsx"],
+        "jsx" => &["tsx", "ts"],
+        "mjs" => &["mts", "ts"],
+        "cjs" => &["cts", "ts"],
+        _ => return None,
+    };
+
+    for source_extension in source_extensions {
+        let source_candidate = candidate.with_extension(source_extension);
+        if source_candidate.is_file() {
+            return canonicalize_or_original(source_candidate);
         }
     }
 
@@ -316,6 +340,29 @@ mod tests {
         let current = Path::new("/repo/src/components/Child.vue");
 
         assert!(resolve_import_path(current, "vue").is_none());
+    }
+
+    #[test]
+    fn resolves_js_type_specifiers_to_ts_sources() {
+        let project = temp_project_dir("js-to-ts-type-import");
+        let utility = project.join("src/utility");
+        let components = project.join("src/components");
+        std::fs::create_dir_all(&utility).unwrap();
+        std::fs::create_dir_all(&components).unwrap();
+        let target = utility.join("paginator.ts");
+        std::fs::write(
+            &target,
+            "export type ExtractorFunction<T> = (item: T) => T;",
+        )
+        .unwrap();
+
+        let current = components.join("UserList.vue");
+        let resolved = resolve_import_path(&current, "@/utility/paginator.js");
+        let target = target.canonicalize().unwrap();
+
+        assert_eq!(resolved.as_deref(), Some(target.as_path()));
+
+        let _ = std::fs::remove_dir_all(project);
     }
 
     #[test]

--- a/npm/vite-plugin-vize/src/compiler.test.ts
+++ b/npm/vite-plugin-vize/src/compiler.test.ts
@@ -1,4 +1,7 @@
 import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 
 import { compileBatch, compileFile } from "./compiler.ts";
 
@@ -85,6 +88,46 @@ assert.match(
   readonlyInterfacePropsCompiled.code,
   /__props\.minScale/,
   "readonly type props should compile as props access in inline render",
+);
+
+const importedFunctionTypeRoot = fs.mkdtempSync(
+  path.join(os.tmpdir(), "vize-imported-function-type-"),
+);
+const importedFunctionTypeSource = path.join(
+  importedFunctionTypeRoot,
+  "src",
+  "components",
+  "UserList.vue",
+);
+fs.mkdirSync(path.join(importedFunctionTypeRoot, "src", "utility"), { recursive: true });
+fs.mkdirSync(path.dirname(importedFunctionTypeSource), { recursive: true });
+fs.writeFileSync(
+  path.join(importedFunctionTypeRoot, "src", "utility", "paginator.ts"),
+  "export type ExtractorFunction<P, T> = (item: P) => T;\n",
+);
+const importedFunctionTypeCompiled = compileFile(
+  importedFunctionTypeSource,
+  new Map(),
+  { sourceMap: false, ssr: false, vapor: false },
+  `<script setup lang="ts" generic="P">
+import type { ExtractorFunction } from "@/utility/paginator.js";
+
+const props = withDefaults(defineProps<{
+  extractor?: ExtractorFunction<P, string>;
+}>(), {
+  extractor: (item: any) => item,
+});
+</script>
+
+<template>
+  <span>{{ props.extractor("value") }}</span>
+</template>`,
+);
+
+assert.match(
+  importedFunctionTypeCompiled.code,
+  /extractor: \{\s*type: Function,\s*required: false,\s*default: \(item\) => item\s*\}/,
+  "Function props imported through .js TypeScript specifiers should keep Function runtime type so defaults are not invoked as factories",
 );
 
 const hoistedScopedSource = `<script setup>

--- a/npm/vite-plugin-vize/src/plugin/index.ts
+++ b/npm/vite-plugin-vize/src/plugin/index.ts
@@ -136,6 +136,7 @@ export function vize(options: VizeOptions = {}): Plugin[] {
     collectedCss: new Map(),
     precompileMetadata: new Map(),
     pendingHmrUpdateTypes: new Map(),
+    viteResolveCache: new Map(),
     isProduction: false,
     root: "",
     clientViteBase: "/",
@@ -353,6 +354,7 @@ export function vize(options: VizeOptions = {}): Plugin[] {
     },
 
     async buildStart() {
+      state.viteResolveCache?.clear();
       if (!state.scanPatterns || state.scanPatterns.length === 0) {
         // Running in standalone rolldown context (e.g., ox-content OG image)
         // where configResolved is not called, or a framework integration has

--- a/npm/vite-plugin-vize/src/plugin/resolve.test.ts
+++ b/npm/vite-plugin-vize/src/plugin/resolve.test.ts
@@ -827,6 +827,52 @@ function expectResolvedId(resolved: Awaited<ReturnType<typeof resolveIdHook>>): 
 }
 
 {
+  const projectRoot = createTempProject("build-vite-resolve-cache");
+  const importer = path.join(projectRoot, "app", "pages", "index.vue");
+  const dependencyEntry = path.join(projectRoot, "node_modules", "vize-cache-fixture", "index.js");
+  writeFixtureFile(dependencyEntry, "export default {};");
+
+  const state = createState(projectRoot);
+  state.server = null;
+  let resolverCalls = 0;
+  let resolverImporter: string | undefined;
+  const ctx = {
+    resolve: async (id: string, importerArg?: string) => {
+      resolverCalls++;
+      resolverImporter = importerArg;
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      return id === "vize-cache-fixture" ? { id: dependencyEntry } : null;
+    },
+  };
+
+  const [first, second] = await Promise.all([
+    resolveIdHook(ctx, state, "vize-cache-fixture", toVirtualId(importer), undefined),
+    resolveIdHook(ctx, state, "vize-cache-fixture", toVirtualId(importer), undefined),
+  ]);
+  const third = await resolveIdHook(
+    ctx,
+    state,
+    "vize-cache-fixture",
+    toVirtualId(importer),
+    undefined,
+  );
+
+  assert.equal(
+    resolverImporter,
+    importer,
+    "Build fallback resolution from virtual SFC modules should use the real importer path",
+  );
+  assert.equal(
+    resolverCalls,
+    1,
+    "Build fallback resolution should cache duplicate Vite resolver calls",
+  );
+  assert.equal(expectResolvedId(first), dependencyEntry);
+  assert.equal(expectResolvedId(second), dependencyEntry);
+  assert.equal(expectResolvedId(third), dependencyEntry);
+}
+
+{
   const projectRoot = createTempProject("preserve-vite-vue");
   const importer = path.join(projectRoot, "app", "pages", "index.vue");
   const optimizedVueEntry = path.join(projectRoot, "node_modules", ".vite", "deps", "vue.js");

--- a/npm/vite-plugin-vize/src/plugin/resolve.ts
+++ b/npm/vite-plugin-vize/src/plugin/resolve.ts
@@ -37,11 +37,59 @@ const VUE_PEER_RUNTIME_ESM_ENTRIES = new Map<string, string[]>([
 ]);
 
 interface ResolveContext {
+  environment?: { name?: string };
   resolve(
     id: string,
     importer?: string,
     options?: { skipSelf: boolean },
   ): Promise<{ id: string; external?: boolean } | null>;
+}
+
+type ViteResolveOptions = { skipSelf: boolean };
+type ViteResolveResult = { id: string; external?: boolean } | null;
+
+function getViteResolveCache(state: VizePluginState): Map<string, Promise<ViteResolveResult>> {
+  return (state.viteResolveCache ??= new Map());
+}
+
+function createViteResolveCacheKey(
+  id: string,
+  importer: string | undefined,
+  options: ViteResolveOptions | undefined,
+  environmentName: string | undefined,
+): string {
+  return JSON.stringify([
+    environmentName ?? null,
+    id,
+    importer ?? null,
+    options?.skipSelf ?? false,
+  ]);
+}
+
+function resolveWithVite(
+  ctx: ResolveContext,
+  state: VizePluginState,
+  id: string,
+  importer?: string,
+  options?: ViteResolveOptions,
+): Promise<ViteResolveResult> {
+  if (state.server !== null) {
+    return ctx.resolve(id, importer, options);
+  }
+
+  const cache = getViteResolveCache(state);
+  const key = createViteResolveCacheKey(id, importer, options, ctx.environment?.name);
+  const cached = cache.get(key);
+  if (cached) {
+    return cached;
+  }
+
+  const pending = ctx.resolve(id, importer, options).catch((error: unknown) => {
+    cache.delete(key);
+    throw error;
+  });
+  cache.set(key, pending);
+  return pending;
 }
 
 function resolveAliasRequest(
@@ -617,7 +665,7 @@ async function resolveProjectVueRuntime(
   }
 
   try {
-    const resolved = await ctx.resolve(id, viteImporter, { skipSelf: true });
+    const resolved = await resolveWithVite(ctx, state, id, viteImporter, { skipSelf: true });
     if (resolved && !isOptimizedVueDependency(resolved.id)) {
       const projectLocalEntry = resolveProjectLocalPnpmVueRuntime(state, resolved.id);
       if (projectLocalEntry) {
@@ -757,7 +805,7 @@ async function resolveAliasedVueImport(
   }
 
   const viteImporter = normalizeViteRequireBase(importer) ?? importer;
-  const viteResolved = await ctx.resolve(id, viteImporter, { skipSelf: true });
+  const viteResolved = await resolveWithVite(ctx, state, id, viteImporter, { skipSelf: true });
   const realPath = viteResolved ? normalizeResolvedVuePath(viteResolved.id) : null;
   if (!realPath) {
     return null;
@@ -879,7 +927,7 @@ export async function resolveIdHook(
       realPath = realPath.slice(0, -3);
     }
     state.logger.log(`resolveId: redirecting stale vize: ID to ${realPath}`);
-    const resolved = await ctx.resolve(realPath, importer, { skipSelf: true });
+    const resolved = await resolveWithVite(ctx, state, realPath, importer, { skipSelf: true });
     const normalizedFsId = resolved ? classifyVitePluginRequest(resolved.id).normalizedFsId : null;
     if (resolved && isBuild && normalizedFsId) {
       return { ...resolved, id: normalizedFsId };
@@ -941,7 +989,7 @@ export async function resolveIdHook(
     // Subpath imports (e.g., #imports/entry from Nuxt)
     if (id.startsWith("#")) {
       try {
-        return await ctx.resolve(id, cleanImporter, { skipSelf: true });
+        return await resolveWithVite(ctx, state, id, cleanImporter, { skipSelf: true });
       } catch {
         return null;
       }
@@ -989,7 +1037,9 @@ export async function resolveIdHook(
         }
 
         try {
-          const resolved = await ctx.resolve(id, cleanImporter, { skipSelf: true });
+          const resolved = await resolveWithVite(ctx, state, id, cleanImporter, {
+            skipSelf: true,
+          });
           if (resolved) {
             state.logger.log(`resolveId: resolved bare ${id} to ${resolved.id} via Vite resolver`);
             const normalizedFsId = classifyVitePluginRequest(resolved.id).normalizedFsId;
@@ -1105,7 +1155,9 @@ export async function resolveIdHook(
 
         if (aliasRequest && aliasRequest !== id && !isViteBareSpecifier(aliasRequest)) {
           try {
-            const resolved = await ctx.resolve(aliasRequest, cleanImporter, { skipSelf: true });
+            const resolved = await resolveWithVite(ctx, state, aliasRequest, cleanImporter, {
+              skipSelf: true,
+            });
             if (resolved) {
               state.logger.log(
                 `resolveId: resolved aliased bare ${id} to ${resolved.id} via Vite resolver`,
@@ -1154,7 +1206,7 @@ export async function resolveIdHook(
 
       // Delegate to Vite's full resolver pipeline with the real importer
       try {
-        const resolved = await ctx.resolve(id, cleanImporter, { skipSelf: true });
+        const resolved = await resolveWithVite(ctx, state, id, cleanImporter, { skipSelf: true });
         if (resolved) {
           state.logger.log(`resolveId: resolved ${id} to ${resolved.id} via Vite resolver`);
           const normalizedFsId = classifyVitePluginRequest(resolved.id).normalizedFsId;

--- a/npm/vite-plugin-vize/src/plugin/state.test.ts
+++ b/npm/vite-plugin-vize/src/plugin/state.test.ts
@@ -279,6 +279,7 @@ const retainedBuildState = {
   collectedCss: new Map([["/src/App.vue", ".app{}"]]),
   precompileMetadata: new Map([["/src/App.vue", { mtimeMs: 1, size: 100 }]]),
   pendingHmrUpdateTypes: new Map([["/src/App.vue", "template-only" as const]]),
+  viteResolveCache: new Map([["vue\u0000/src/App.vue\u00001", Promise.resolve({ id: "vue" })]]),
 };
 
 clearBuildCaches(retainedBuildState);
@@ -302,6 +303,11 @@ assert.equal(
   retainedBuildState.pendingHmrUpdateTypes.size,
   0,
   "build-only HMR bookkeeping should be released after build",
+);
+assert.equal(
+  retainedBuildState.viteResolveCache.size,
+  0,
+  "build fallback resolver cache should be released after bundling",
 );
 
 console.log("✅ vite-plugin-vize state tests passed!");

--- a/npm/vite-plugin-vize/src/plugin/state.ts
+++ b/npm/vite-plugin-vize/src/plugin/state.ts
@@ -38,6 +38,7 @@ export interface VizePluginState {
   collectedCss: Map<string, string>;
   precompileMetadata: Map<string, PrecompileFileMetadata>;
   pendingHmrUpdateTypes: Map<string, HmrUpdateType>;
+  viteResolveCache?: Map<string, Promise<{ id: string; external?: boolean } | null>>;
   isProduction: boolean;
   root: string;
   clientViteBase: string;
@@ -140,7 +141,12 @@ export function shouldExtractCssForRequest(
 export function clearBuildCaches(
   state: Pick<
     VizePluginState,
-    "cache" | "collectedCss" | "pendingHmrUpdateTypes" | "precompileMetadata" | "ssrCache"
+    | "cache"
+    | "collectedCss"
+    | "pendingHmrUpdateTypes"
+    | "precompileMetadata"
+    | "ssrCache"
+    | "viteResolveCache"
   >,
 ): void {
   state.cache.clear();
@@ -148,6 +154,7 @@ export function clearBuildCaches(
   state.collectedCss.clear();
   state.precompileMetadata.clear();
   state.pendingHmrUpdateTypes.clear();
+  state.viteResolveCache?.clear();
 }
 
 /**


### PR DESCRIPTION
## Summary

- Resolve `.js` type import specifiers to adjacent TypeScript source files while collecting SFC external types.
- Preserve imported function prop runtime types for cases like Misskey `ExtractorFunction` defaults.
- Cache build-time Vite fallback resolves per environment, request, importer, and options to reduce duplicate `resolveId` work.

## Validation

- `pnpm --dir npm/vite-plugin-vize test`
- `pnpm --dir npm/vite-plugin-vize check`
- `node src/test.ts`
- `cargo test -p vize_atelier_sfc script::context::external_types`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1107"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783410613&installation_id=136613492&pr_number=1107&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1107&signature=decb25891b6d048a1e1d5f17b027477c4ff7f952921c1ad7cb1942b10379b880"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->