### PR TITLE
feat(oxlint-plugin): support Node 22

### DIFF
--- a/docs/content/blog/releases/2026-03-26-oxlint-plugin-vize-alpha.md
+++ b/docs/content/blog/releases/2026-03-26-oxlint-plugin-vize-alpha.md
@@ -107,7 +107,7 @@ This is still an alpha, and a few limitations are important to call out clearly:
 
 - Oxlint JS plugins currently rely on the extracted Vue script program, so files without `<script>` or `<script setup>` do not invoke the plugin yet.
 - Diagnostic anchors still point at the script program when Oxlint cannot accept the original template range directly.
-- The current package targets Node 24+.
+- The initial alpha package targeted Node 24+; current releases support Node 22 and Node 24+.
 - Oxlint's JS plugin support is itself still evolving, so some rough edges here are upstream constraints rather than Vize-only behavior.
 
 ## Why Alpha Now

--- a/docs/content/stability.md
+++ b/docs/content/stability.md
@@ -32,8 +32,9 @@ The v1 alpha line uses these rules:
 
 ## Runtime Support
 
-The default Node.js floor for public npm runtime packages is Node 22. `oxlint-plugin-vize` is the
-exception and requires Node 24 because it follows Oxlint's JavaScript plugin runtime.
+The default Node.js floor for public npm runtime packages is Node 22, including
+`oxlint-plugin-vize`. The Oxlint plugin declares `^22 || >= 24` so Node 22 and Node 24 or newer are
+allowed while Node 23 stays outside the tested compatibility matrix.
 
 The release workflow builds native packages for macOS, Linux, and Windows across x64 and arm64
 where the package declares support. CI compatibility jobs cover the declared Node floor and the

--- a/examples/oxlint-vize/README.md
+++ b/examples/oxlint-vize/README.md
@@ -5,7 +5,7 @@ The local scripts use the temporary `oxlint-vize` wrapper workflow so scriptless
 
 ## Prerequisites
 
-This example uses the locally built Vize Oxlint plugin bundle and `@vizejs/native`. It assumes Node 24+ and the repository's `.node-version`, and the example scripts rebuild dependencies automatically. If you want to build them up front from the repository root:
+This example uses the locally built Vize Oxlint plugin bundle and `@vizejs/native`. It supports Node 22 and Node 24+, while the repository's `.node-version` remains the default local runtime. The example scripts rebuild dependencies automatically. If you want to build them up front from the repository root:
 
 ```bash
 vp install

--- a/npm/oxlint-plugin-vize/README.md
+++ b/npm/oxlint-plugin-vize/README.md
@@ -28,7 +28,7 @@ The bridge is optimized around Oxlint's per-rule execution model:
 
 ## Installation
 
-`oxlint-plugin-vize` targets Node 24+. In this repository, Vite+ reads `.node-version` for you, so the usual setup is:
+`oxlint-plugin-vize` targets Node 22 and Node 24+ (`^22 || >= 24`). In this repository, Vite+ reads `.node-version` for you, so the usual setup is:
 
 ```bash
 vp install

--- a/npm/oxlint-plugin-vize/package.json
+++ b/npm/oxlint-plugin-vize/package.json
@@ -68,6 +68,6 @@
     "@vizejs/native-win32-x64-msvc": "catalog:native-binaries"
   },
   "engines": {
-    "node": ">=24"
+    "node": "^22 || >= 24"
   }
 }

--- a/tests/tooling/docs-stability.test.ts
+++ b/tests/tooling/docs-stability.test.ts
@@ -12,7 +12,7 @@ test("stability page documents v1 alpha support tiers", () => {
   assert.match(stability, /# Stability/);
   assert.match(stability, /v1 alpha/);
   assert.match(stability, /Node 22/);
-  assert.match(stability, /`oxlint-plugin-vize`[\s\S]*Node 24/);
+  assert.match(stability, /`oxlint-plugin-vize`[\s\S]*`\^22 \|\| >= 24`/);
   assert.match(stability, /linux-arm64-gnu/);
   assert.match(stability, /win32-arm64-msvc/);
   assert.match(stability, /linux-x64-musl/);

--- a/tests/tooling/node-engine-matrix.test.ts
+++ b/tests/tooling/node-engine-matrix.test.ts
@@ -52,7 +52,7 @@ test("current and pinned Node runtimes are represented in the support matrix", (
   assert.ok(supportedNodeMajors.includes(pinnedMajor as (typeof supportedNodeMajors)[number]));
 });
 
-test("Node 22 is the default public package floor and Node 24 is explicit opt-in", () => {
+test("Node 22 is the public package floor", () => {
   const floors = new Map<string, number>();
   for (const { packageJson } of readNpmPackages()) {
     if (packageJson.private === true || packageJson.engines?.vscode != null) {
@@ -65,9 +65,7 @@ test("Node 22 is the default public package floor and Node 24 is explicit opt-in
     floors.set(name, parseNodeEngineFloor(engine) ?? 0);
   }
 
-  assert.equal(floors.get("oxlint-plugin-vize"), 24);
   for (const [name, floor] of floors) {
-    if (name === "oxlint-plugin-vize") continue;
     assert.equal(floor, 22, `${name} should stay on the Node 22 floor`);
   }
 });
@@ -87,9 +85,25 @@ function readNpmPackages(): Array<{ packageDir: string; packageJson: PackageJson
 }
 
 function parseNodeEngineFloor(engine: string): number | null {
-  const match = engine.match(/^>=(\d+)$/);
-  if (match == null) {
+  const floors = engine.split("||").map((part) => parseSimpleNodeEngineRange(part.trim()));
+
+  if (floors.length === 0 || floors.some((floor) => floor == null)) {
     return null;
   }
-  return Number.parseInt(match[1], 10);
+
+  return Math.min(...(floors as number[]));
+}
+
+function parseSimpleNodeEngineRange(range: string): number | null {
+  const gteMatch = range.match(/^>=\s*(\d+)$/);
+  if (gteMatch != null) {
+    return Number.parseInt(gteMatch[1], 10);
+  }
+
+  const caretMatch = range.match(/^\^(\d+)$/);
+  if (caretMatch != null) {
+    return Number.parseInt(caretMatch[1], 10);
+  }
+
+  return null;
 }

--- a/tests/tooling/package-manifests.test.ts
+++ b/tests/tooling/package-manifests.test.ts
@@ -551,8 +551,10 @@ test("workspace TypeScript package builds use vp pack", () => {
   const oxlintPackage = JSON.parse(
     fs.readFileSync(path.join(root, "npm/oxlint-plugin-vize/package.json"), "utf-8"),
   ) as {
+    engines?: Record<string, string>;
     scripts?: Record<string, string>;
   };
+  assert.equal(oxlintPackage.engines?.node, "^22 || >= 24");
   assert.equal(oxlintPackage.scripts?.test, "vp pack && node src/test.ts");
 
   const rootTasks = fs.readFileSync(path.join(root, "tools/vite-plus/tasks/build.ts"), "utf-8");


### PR DESCRIPTION
## Summary

- Allow `oxlint-plugin-vize` to install on Node 22 by changing `engines.node` to `^22 || >= 24`.
- Update Node engine tooling tests to treat the new range as a Node 22 floor.
- Refresh oxlint-plugin docs and stability docs so they no longer describe the package as Node 24-only.

Closes #1108.

## Validation

- `node --test tests/tooling/node-engine-matrix.test.ts tests/tooling/docs-stability.test.ts tests/tooling/package-manifests.test.ts`
- `vp run --filter './npm/oxlint-plugin-vize' check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1110"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783429127&installation_id=136613492&pr_number=1110&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1110&signature=0c6286b0e1e08a4fc5cddfa25eeb41fcfda1b6bfde4af2ee7e7ec0a497730860"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->