### PR TITLE
test(unplugin): cover request/options/filter/hook core edge cases

### DIFF
--- a/npm/unplugin-vize/src/filter-edge.test.ts
+++ b/npm/unplugin-vize/src/filter-edge.test.ts
@@ -1,0 +1,92 @@
+import { test } from "node:test";
+import { createFilter } from "./filter.ts";
+
+void test("defaults: include .vue, exclude node_modules, ignore non-.vue", (t) => {
+  const filter = createFilter();
+
+  // Matches default include (/\.vue$/), not in node_modules.
+  t.assert.equal(filter("/proj/src/App.vue"), true);
+  // Matches default include but hits default exclude (/node_modules/).
+  t.assert.equal(filter("/proj/node_modules/x/App.vue"), false);
+  // Does not match default include (.ts is not .vue).
+  t.assert.equal(filter("/proj/src/App.ts"), false);
+});
+
+void test("string include uses substring inclusion", (t) => {
+  const filter = createFilter(".custom");
+
+  t.assert.equal(filter("/a/x.custom"), true);
+  t.assert.equal(filter("/a/x.other"), false);
+});
+
+void test("array include with mixed string + regex matches either", (t) => {
+  const filter = createFilter([/\.vue$/, ".md"]);
+
+  t.assert.equal(filter("/a.vue"), true);
+  t.assert.equal(filter("/docs/x.md"), true);
+  // Matches neither pattern.
+  t.assert.equal(filter("/a.ts"), false);
+});
+
+void test("custom include REPLACES the default .vue$ include", (t) => {
+  // A custom include that does not cover .vue makes .vue files NOT match.
+  const filter = createFilter(".md");
+
+  t.assert.equal(filter("/a/x.md"), true);
+  t.assert.equal(filter("/a/App.vue"), false);
+});
+
+void test("custom exclude REPLACES the default node_modules exclude", (t) => {
+  // With a custom exclude that doesn't hit node_modules, a node_modules path
+  // that matches include is now INCLUDED.
+  const filter = createFilter(/\.vue$/, ".cache");
+
+  // node_modules path now passes because default node_modules exclusion is gone.
+  t.assert.equal(filter("/proj/node_modules/x/App.vue"), true);
+  // The custom exclude (".cache") still excludes matching paths.
+  t.assert.equal(filter("/proj/.cache/App.vue"), false);
+});
+
+void test("array exclude: any matching exclude pattern wins", (t) => {
+  const filter = createFilter(/\.vue$/, [/node_modules/, ".generated."]);
+
+  t.assert.equal(filter("/proj/src/App.vue"), true);
+  t.assert.equal(filter("/proj/node_modules/x/App.vue"), false);
+  t.assert.equal(filter("/proj/src/App.generated.vue"), false);
+});
+
+void test("include matches but exclude also matches => excluded", (t) => {
+  // include matches /\.vue$/ but exclude substring "secret" also matches.
+  const filter = createFilter(/\.vue$/, "secret");
+
+  t.assert.equal(filter("/proj/secret/App.vue"), false);
+  t.assert.equal(filter("/proj/public/App.vue"), true);
+});
+
+void test("string-vs-regex precedence: both kinds honored together", (t) => {
+  // string include (substring) plus regex exclude (anchored).
+  const filter = createFilter("src/", /\.spec\.vue$/);
+
+  // In src/ and not a spec file.
+  t.assert.equal(filter("/proj/src/App.vue"), true);
+  // In src/ but excluded by regex.
+  t.assert.equal(filter("/proj/src/App.spec.vue"), false);
+  // Not in src/ at all => not included.
+  t.assert.equal(filter("/proj/lib/App.vue"), false);
+});
+
+void test("empty array include matches nothing", (t) => {
+  // [].some(...) is false, so include never matches.
+  const filter = createFilter([]);
+
+  t.assert.equal(filter("/a/App.vue"), false);
+  t.assert.equal(filter("/a/x.custom"), false);
+});
+
+void test("empty array exclude excludes nothing", (t) => {
+  // [].some(...) is false, so default node_modules guard is gone.
+  const filter = createFilter(/\.vue$/, []);
+
+  t.assert.equal(filter("/proj/node_modules/x/App.vue"), true);
+  t.assert.equal(filter("/proj/src/App.vue"), true);
+});

--- a/npm/unplugin-vize/src/normalize-options.test.ts
+++ b/npm/unplugin-vize/src/normalize-options.test.ts
@@ -1,0 +1,144 @@
+import { test } from "node:test";
+import { normalizeOptions } from "./unplugin.ts";
+
+void test("defaults from an empty options object", (t) => {
+  const options = normalizeOptions({ isProduction: false });
+
+  t.assert.equal(options.ssr, false);
+  t.assert.equal(options.vapor, false);
+  t.assert.equal(options.customRenderer, false);
+  t.assert.equal(options.templateSyntax, "standard");
+  t.assert.equal(options.runtimeModuleName, "vue");
+  t.assert.equal(options.runtimeGlobalName, "Vue");
+  t.assert.equal(options.vueVersion, 3);
+  t.assert.equal(options.hostCompiler, false);
+  t.assert.equal(options.mode, "module");
+  t.assert.equal(options.debug, false);
+  t.assert.equal(options.root, process.cwd());
+  t.assert.deepStrictEqual(options.compatibility, {});
+});
+
+void test("normalizeOptions can be called with no arguments", (t) => {
+  const options = normalizeOptions();
+
+  t.assert.equal(options.vueVersion, 3);
+  t.assert.equal(options.mode, "module");
+  t.assert.equal(options.templateSyntax, "standard");
+  t.assert.equal(options.hostCompiler, false);
+});
+
+void test("legacy vue versions activate the host compiler", (t) => {
+  t.assert.equal(normalizeOptions({ vueVersion: 0.11, isProduction: true }).hostCompiler, true);
+  t.assert.equal(normalizeOptions({ vueVersion: 1, isProduction: true }).hostCompiler, true);
+  t.assert.equal(normalizeOptions({ vueVersion: 2, isProduction: true }).hostCompiler, true);
+  t.assert.equal(normalizeOptions({ vueVersion: "legacy", isProduction: true }).hostCompiler, true);
+});
+
+void test("vue 3 keeps the host compiler off", (t) => {
+  t.assert.equal(normalizeOptions({ vueVersion: 3, isProduction: true }).hostCompiler, false);
+});
+
+void test("explicit compatibility.hostCompiler overrides the inferred value", (t) => {
+  // Legacy version would infer true, but an explicit false wins.
+  t.assert.equal(
+    normalizeOptions({
+      vueVersion: 2,
+      compatibility: { hostCompiler: false },
+      isProduction: true,
+    }).hostCompiler,
+    false,
+  );
+
+  // Vue 3 would infer false, but an explicit true wins.
+  t.assert.equal(
+    normalizeOptions({
+      vueVersion: 3,
+      compatibility: { hostCompiler: true },
+      isProduction: true,
+    }).hostCompiler,
+    true,
+  );
+});
+
+void test("vueVersion falls back to compatibility.vueVersion", (t) => {
+  const options = normalizeOptions({ compatibility: { vueVersion: 2 }, isProduction: true });
+
+  t.assert.equal(options.vueVersion, 2);
+  // The legacy version inferred from compatibility also activates the host compiler.
+  t.assert.equal(options.hostCompiler, true);
+});
+
+void test("top-level vueVersion wins over compatibility.vueVersion", (t) => {
+  const options = normalizeOptions({
+    vueVersion: 3,
+    compatibility: { vueVersion: 2 },
+    isProduction: true,
+  });
+
+  t.assert.equal(options.vueVersion, 3);
+  t.assert.equal(options.hostCompiler, false);
+});
+
+void test("scriptSetupInStandalone switches mode to function", (t) => {
+  const options = normalizeOptions({
+    compatibility: { scriptSetupInStandalone: true },
+    isProduction: true,
+  });
+
+  t.assert.equal(options.mode, "function");
+});
+
+void test("explicit mode wins over scriptSetupInStandalone", (t) => {
+  const options = normalizeOptions({
+    mode: "module",
+    compatibility: { scriptSetupInStandalone: true },
+    isProduction: true,
+  });
+
+  t.assert.equal(options.mode, "module");
+});
+
+void test("sourceMap defaults to the inverse of isProduction", (t) => {
+  t.assert.equal(normalizeOptions({ isProduction: true }).sourceMap, false);
+  t.assert.equal(normalizeOptions({ isProduction: false }).sourceMap, true);
+});
+
+void test("explicit sourceMap is respected regardless of isProduction", (t) => {
+  t.assert.equal(normalizeOptions({ isProduction: true, sourceMap: true }).sourceMap, true);
+  t.assert.equal(normalizeOptions({ isProduction: false, sourceMap: false }).sourceMap, false);
+});
+
+void test("templateSyntax passes through non-standard values", (t) => {
+  t.assert.equal(
+    normalizeOptions({ templateSyntax: "strict", isProduction: true }).templateSyntax,
+    "strict",
+  );
+  t.assert.equal(
+    normalizeOptions({ templateSyntax: "quirks", isProduction: true }).templateSyntax,
+    "quirks",
+  );
+});
+
+void test("runtime module and global names can be overridden", (t) => {
+  const options = normalizeOptions({
+    runtimeModuleName: "@vue/runtime-core",
+    runtimeGlobalName: "VueGlobal",
+    isProduction: true,
+  });
+
+  t.assert.equal(options.runtimeModuleName, "@vue/runtime-core");
+  t.assert.equal(options.runtimeGlobalName, "VueGlobal");
+});
+
+void test("the compatibility object is passed through by reference", (t) => {
+  const compatibility = { scriptSetupInStandalone: false };
+  const options = normalizeOptions({ compatibility, isProduction: true });
+
+  t.assert.equal(options.compatibility, compatibility);
+});
+
+void test("explicit root overrides process.cwd()", (t) => {
+  const options = normalizeOptions({ root: "/custom/root", isProduction: true });
+
+  t.assert.equal(options.root, "/custom/root");
+});

--- a/npm/unplugin-vize/src/plugin-hooks.test.ts
+++ b/npm/unplugin-vize/src/plugin-hooks.test.ts
@@ -1,0 +1,163 @@
+import path from "node:path";
+import { test } from "node:test";
+import { vizeUnplugin } from "./unplugin.ts";
+import { isVirtualStyleId } from "./request.ts";
+import { packageRoot } from "./test/helpers.ts";
+import type { VizeUnpluginOptions } from "./types.ts";
+
+// The bundler-agnostic raw hooks of the unplugin factory. For `framework:
+// "rollup"` the factory yields a Rollup-format plugin whose hooks are bare
+// functions (verified: resolveId/loadInclude/load/transformInclude/transform/
+// watchChange are all `typeof === "function"`), so each is invoked with
+// `.call(ctx, ...args)` exactly like the sibling raw-hook tests.
+type RawCtx = { warn(message: string): void };
+
+function rawPlugin(options: VizeUnpluginOptions) {
+  return vizeUnplugin.raw(options, { framework: "rollup" });
+}
+
+const ctx: RawCtx = { warn() {} };
+
+// A synthetic id is enough: the source is passed straight to transform(), so the
+// .vue file never has to exist on disk. The path only has to end in `.vue` and
+// avoid `node_modules` to satisfy the plugin's request matching.
+const APP_VUE = path.join(packageRoot, "App.vue");
+const BASIC_SFC = `<template><div>Hello</div></template>\n<script setup>const n = 1</script>`;
+
+// ---------------------------------------------------------------------------
+// transformInclude (hostCompiler OFF)
+// ---------------------------------------------------------------------------
+
+void test("transformInclude is true for a plain .vue id", (t) => {
+  const plugin = rawPlugin({ isProduction: true, root: packageRoot });
+  t.assert.strictEqual(plugin.transformInclude?.call(ctx as never, "/p/App.vue" as never), true);
+});
+
+void test("transformInclude is false for a .vue style sub-request (query.vue set)", (t) => {
+  const plugin = rawPlugin({ isProduction: true, root: packageRoot });
+  // `?vue&type=style` carries query.vue === true, so the `!request.query.vue`
+  // guard excludes the request even though the filename is a .vue file.
+  t.assert.strictEqual(
+    plugin.transformInclude?.call(ctx as never, "/p/App.vue?vue&type=style" as never),
+    false,
+  );
+});
+
+void test("transformInclude fast-paths to false for any id without .vue (no throw)", (t) => {
+  const plugin = rawPlugin({ isProduction: true, root: packageRoot });
+  // The `!id.includes(".vue")` fast-path returns false before any
+  // URLSearchParams parsing, so a plain .ts import never throws.
+  t.assert.strictEqual(plugin.transformInclude?.call(ctx as never, "/p/main.ts" as never), false);
+});
+
+void test("transformInclude is false for a node_modules .vue (default exclude)", (t) => {
+  const plugin = rawPlugin({ isProduction: true, root: packageRoot });
+  // The id contains `.vue` and is a .vue file, but the default exclude
+  // `/node_modules/` makes the filter reject it.
+  t.assert.strictEqual(
+    plugin.transformInclude?.call(ctx as never, "/p/node_modules/foo/App.vue" as never),
+    false,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// transform (hostCompiler OFF)
+// ---------------------------------------------------------------------------
+
+void test("transform returns null for a non-.vue id", async (t) => {
+  const plugin = rawPlugin({ isProduction: true, root: packageRoot });
+  const result = await plugin.transform?.call(ctx as never, "const x = 1;", "/p/main.ts");
+  t.assert.strictEqual(result, null);
+});
+
+void test("transform returns null for a node_modules .vue id", async (t) => {
+  const plugin = rawPlugin({ isProduction: true, root: packageRoot });
+  // isVueFile(id) is true here, but filter(id) rejects node_modules -> null.
+  const result = await plugin.transform?.call(
+    ctx as never,
+    "<template><div>x</div></template>",
+    "/p/node_modules/foo/App.vue",
+  );
+  t.assert.strictEqual(result, null);
+});
+
+// ---------------------------------------------------------------------------
+// watchChange (cache eviction)
+// ---------------------------------------------------------------------------
+
+void test("watchChange evicts a cached .vue module so the next transform recompiles", async (t) => {
+  const plugin = rawPlugin({ isProduction: true, root: packageRoot });
+
+  // First transform caches the compiled module.
+  const first = await plugin.transform?.call(ctx as never, BASIC_SFC, APP_VUE);
+  t.assert.ok(first && typeof first === "object" && typeof first.code === "string");
+
+  // watchChange is a void no-op return for a .vue id (it deletes the cache entry
+  // internally) and must not throw.
+  t.assert.strictEqual(plugin.watchChange?.call(ctx as never, APP_VUE), undefined);
+
+  // A second transform after the eviction still succeeds (recompiles cleanly).
+  const second = await plugin.transform?.call(ctx as never, BASIC_SFC, APP_VUE);
+  t.assert.ok(second && typeof second === "object" && typeof second.code === "string");
+  // Deterministic source -> identical output across the recompile.
+  t.assert.strictEqual(second.code, first.code);
+});
+
+void test("watchChange is a no-op for a non-.vue id (no throw)", (t) => {
+  const plugin = rawPlugin({ isProduction: true, root: packageRoot });
+  t.assert.strictEqual(plugin.watchChange?.call(ctx as never, "/p/main.ts"), undefined);
+});
+
+// ---------------------------------------------------------------------------
+// hostCompiler short-circuit (legacy Vue delegates everything to the host)
+// ---------------------------------------------------------------------------
+
+void test("hostCompiler short-circuits every bundler hook (vueVersion: 2)", async (t) => {
+  const plugin = rawPlugin({ vueVersion: 2, isProduction: true, root: packageRoot });
+
+  const styleRequest = "/p/App.vue?vue&type=style&index=0&lang=css";
+
+  // resolveId returns null instead of a virtual style id.
+  t.assert.strictEqual(plugin.resolveId?.call(ctx as never, styleRequest as never), null);
+
+  // loadInclude returns false for anything.
+  t.assert.strictEqual(plugin.loadInclude?.call(ctx as never, styleRequest as never), false);
+  t.assert.strictEqual(plugin.loadInclude?.call(ctx as never, "/p/App.vue" as never), false);
+
+  // load returns null even for what would otherwise be a virtual style id.
+  t.assert.strictEqual(await plugin.load?.call(ctx as never, styleRequest), null);
+
+  // transformInclude returns false for a plain .vue id.
+  t.assert.strictEqual(plugin.transformInclude?.call(ctx as never, "/p/App.vue" as never), false);
+
+  // transform resolves to null for a .vue source.
+  t.assert.strictEqual(
+    await plugin.transform?.call(ctx as never, "<template><div>x</div></template>", "/p/App.vue"),
+    null,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// resolveId / loadInclude with hostCompiler OFF
+// ---------------------------------------------------------------------------
+
+void test("resolveId maps a .vue style request to a virtual id string (hostCompiler off)", (t) => {
+  const plugin = rawPlugin({ isProduction: true, root: packageRoot });
+  const resolved = plugin.resolveId?.call(
+    ctx as never,
+    "/p/App.vue?vue&type=style&index=0&lang=css" as never,
+  );
+  t.assert.strictEqual(typeof resolved, "string");
+  t.assert.strictEqual(isVirtualStyleId(resolved as string), true);
+});
+
+void test("loadInclude is true for a virtual style id and false for a plain id (hostCompiler off)", (t) => {
+  const plugin = rawPlugin({ isProduction: true, root: packageRoot });
+  const virtualId = plugin.resolveId?.call(
+    ctx as never,
+    "/p/App.vue?vue&type=style&index=0&lang=css" as never,
+  ) as string;
+
+  t.assert.strictEqual(plugin.loadInclude?.call(ctx as never, virtualId as never), true);
+  t.assert.strictEqual(plugin.loadInclude?.call(ctx as never, "/p/App.vue" as never), false);
+});

--- a/npm/unplugin-vize/src/request.test.ts
+++ b/npm/unplugin-vize/src/request.test.ts
@@ -1,0 +1,141 @@
+import { test } from "node:test";
+import {
+  createVirtualStyleId,
+  isVirtualStyleId,
+  isVueFile,
+  isVueStyleRequest,
+  parseVueRequest,
+} from "./request.ts";
+
+void test("isVueFile matches only ids ending in .vue (endsWith semantics)", (t) => {
+  t.assert.equal(isVueFile("/a/App.vue"), true);
+  // A style sub-request does NOT end in `.vue`, so endsWith bails.
+  t.assert.equal(isVueFile("/a/App.vue?vue&type=style"), false);
+  // endsWith is case-sensitive: uppercase extension is not a match.
+  t.assert.equal(isVueFile("/a/app.VUE"), false);
+  t.assert.equal(isVueFile(""), false);
+});
+
+void test("isVueStyleRequest fast-path bails without a ?vue marker", (t) => {
+  // No `?vue` substring -> short-circuits before any URLSearchParams parsing.
+  t.assert.equal(isVueStyleRequest("/a/App.vue"), false);
+  t.assert.equal(isVueStyleRequest("/a/App.vue?type=style"), false);
+});
+
+void test("isVueStyleRequest is true only for vue + type=style", (t) => {
+  t.assert.equal(isVueStyleRequest("/a/App.vue?vue&type=style"), true);
+  t.assert.equal(isVueStyleRequest("/a/App.vue?vue&type=style&index=0"), true);
+  // type=template carries `?vue` (passes fast-path) but is not a style request.
+  t.assert.equal(isVueStyleRequest("/a/App.vue?vue&type=template"), false);
+});
+
+void test("isVirtualStyleId detects the STYLE_MARKER substring", (t) => {
+  const vid = createVirtualStyleId("/a/App.vue?vue&type=style");
+  t.assert.equal(isVirtualStyleId(vid), true);
+  t.assert.equal(isVirtualStyleId("/a/App.vue"), false);
+});
+
+void test("parseVueRequest splits on the first ? only", (t) => {
+  // Extra `?`, `=`, `&` after the first `?` stay inside the raw query string.
+  const parsed = parseVueRequest("/a/App.vue?vue&type=style&a=b?c=d");
+  t.assert.equal(parsed.path, "/a/App.vue");
+  t.assert.equal(parsed.query.vue, true);
+  t.assert.equal(parsed.query.type, "style");
+});
+
+void test("parseVueRequest lets vize-file override the path as filename", (t) => {
+  const parsed = parseVueRequest("/a/App.vue?vue&type=style&vize-file=/real/Comp.vue");
+  t.assert.equal(parsed.path, "/a/App.vue");
+  t.assert.equal(parsed.filename, "/real/Comp.vue");
+  // vizeFile query field mirrors the vize-file param.
+  t.assert.equal(parsed.query.vizeFile, "/real/Comp.vue");
+});
+
+void test("parseVueRequest filename falls back to path when vize-file absent", (t) => {
+  const parsed = parseVueRequest("/a/App.vue?vue");
+  t.assert.equal(parsed.filename, "/a/App.vue");
+  t.assert.equal(parsed.query.vizeFile, null);
+});
+
+void test("parseVueRequest module param: present-empty -> true, string -> value, absent -> false", (t) => {
+  // `?module` (no value) -> true.
+  t.assert.equal(parseVueRequest("/a/App.vue?module").query.module, true);
+  // `?module=foo` -> the string value.
+  t.assert.equal(parseVueRequest("/a/App.vue?module=foo").query.module, "foo");
+  // absent -> false.
+  t.assert.equal(parseVueRequest("/a/App.vue?vue").query.module, false);
+});
+
+void test("parseVueRequest index parsing covers numbers, NaN, and absence", (t) => {
+  t.assert.equal(parseVueRequest("/a/App.vue?index=0").query.index, 0);
+  t.assert.equal(parseVueRequest("/a/App.vue?index=3").query.index, 3);
+  t.assert.equal(parseVueRequest("/a/App.vue?index=-1").query.index, -1);
+  // Non-numeric index parses to NaN (Number.parseInt), NOT null.
+  t.assert.equal(Number.isNaN(parseVueRequest("/a/App.vue?index=abc").query.index), true);
+  // Absent index is null.
+  t.assert.equal(parseVueRequest("/a/App.vue?vue").query.index, null);
+});
+
+void test("parseVueRequest leaves lang/type/scoped null when absent", (t) => {
+  const q = parseVueRequest("/a/App.vue").query;
+  t.assert.equal(q.lang, null);
+  t.assert.equal(q.type, null);
+  t.assert.equal(q.scoped, null);
+});
+
+void test("createVirtualStyleId emits the marker, index and .module.<lang> suffix", (t) => {
+  const vid = createVirtualStyleId(
+    "/a/App.vue?vue&type=style&index=1&lang=scss&module&scoped=data-v-z",
+  );
+  t.assert.equal(vid.includes(".__vize_style_1"), true);
+  t.assert.equal(vid.includes(".module.scss?"), true);
+  t.assert.equal(vid.startsWith("/a/App.vue.__vize_style_1.module.scss"), true);
+});
+
+void test("createVirtualStyleId uses .<lang> (no module segment) when module is false", (t) => {
+  const vid = createVirtualStyleId("/a/App.vue?vue&type=style&lang=less");
+  t.assert.equal(vid.includes(".module."), false);
+  t.assert.equal(vid.includes(".__vize_style_0.less?"), true);
+  // No `module` param is emitted when module === false.
+  t.assert.equal(parseVueRequest(vid).query.module, false);
+});
+
+void test("createVirtualStyleId defaults index to 0 and lang to css", (t) => {
+  const vid = createVirtualStyleId("/a/App.vue?vue&type=style");
+  t.assert.equal(vid.includes(".__vize_style_0.css?"), true);
+  const back = parseVueRequest(vid);
+  t.assert.equal(back.query.index, 0);
+  t.assert.equal(back.query.lang, "css");
+});
+
+void test("createVirtualStyleId preserves scoped and a named module", (t) => {
+  const vid = createVirtualStyleId(
+    "/a/App.vue?vue&type=style&index=2&lang=css&module=myMod&scoped=data-v-q",
+  );
+  const back = parseVueRequest(vid);
+  t.assert.equal(back.query.scoped, "data-v-q");
+  // A string module value round-trips as module=<name>.
+  t.assert.equal(back.query.module, "myMod");
+  // Named module still produces the .module.<lang> suffix.
+  t.assert.equal(vid.includes(".module.css?"), true);
+});
+
+void test("createVirtualStyleId sets vize-file to the resolved filename", (t) => {
+  const vid = createVirtualStyleId("/a/App.vue?vue&type=style&vize-file=/real/Comp.vue");
+  const back = parseVueRequest(vid);
+  t.assert.equal(back.query.vizeFile, "/real/Comp.vue");
+  t.assert.equal(back.filename, "/real/Comp.vue");
+  t.assert.equal(vid.startsWith("/real/Comp.vue.__vize_style_"), true);
+});
+
+void test("createVirtualStyleId output round-trips through parseVueRequest", (t) => {
+  const vid = createVirtualStyleId(
+    "/a/App.vue?vue&type=style&index=3&lang=scss&module=mod&scoped=data-v-r",
+  );
+  const back = parseVueRequest(vid);
+  t.assert.equal(back.query.vue, true);
+  t.assert.equal(back.query.type, "style");
+  t.assert.equal(back.query.index, 3);
+  t.assert.equal(back.query.lang, "scss");
+  t.assert.equal(back.filename, "/a/App.vue");
+});


### PR DESCRIPTION
## What

Adds bundler-agnostic edge-case tests for `@vizejs/unplugin` (the shared Vite / Rollup / Webpack / Rspack / Rolldown / esbuild integration core).

New files (`node --test`, no Rust build needed — uses the prebuilt `@vizejs/native`):
- `src/request.test.ts` — `parseVueRequest` / `createVirtualStyleId` / `isVueFile` / `isVueStyleRequest` / `isVirtualStyleId` query-parsing + round-trip (16 cases)
- `src/normalize-options.test.ts` — the compatibility matrix: legacy `vueVersion` → `hostCompiler`, `scriptSetupInStandalone` → `mode:"function"`, sourceMap/ssr defaults, runtime overrides (15 cases)
- `src/filter-edge.test.ts` — `createFilter` defaults, string/regex/array patterns, default-replacement semantics, exclude precedence (10 cases)
- `src/plugin-hooks.test.ts` — raw hook contract `resolveId`/`loadInclude`/`load`/`transformInclude`/`transform`/`watchChange` + the legacy `hostCompiler` short-circuit (11 cases)

All assert against **actual observed behavior**. Notable pinned behavior: a non-numeric `?index=` yields `NaN` (not `null`); custom `include`/`exclude` fully **replace** the defaults rather than extending them.

## Verify
`cd npm/unplugin-vize && node --test 'src/*.test.ts'` → all green; `oxlint`/`oxfmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1111"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783429355&installation_id=136613492&pr_number=1111&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1111&signature=f60559d739214ded8b667b5c3888966a47441aa76ad24401c8abdc90ec752e8d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->