### PR TITLE
test(unplugin): cover Rolldown/esbuild/Webpack bundler entries

### DIFF
--- a/npm/unplugin-vize/src/esbuild-hooks.test.ts
+++ b/npm/unplugin-vize/src/esbuild-hooks.test.ts
@@ -1,0 +1,165 @@
+import { test } from "node:test";
+import { vizeUnplugin } from "./unplugin.ts";
+import { parseVueRequest } from "./request.ts";
+import type { VizeUnpluginOptions } from "./types.ts";
+
+type EsbuildHooks = {
+  onResolveFilter: RegExp;
+  onLoadFilter: RegExp;
+  loader(this: void, code: string, id: string): string;
+  config(this: void, buildOptions: { define?: Record<string, string> }): void;
+};
+
+function esbuildHooks(options: VizeUnpluginOptions): EsbuildHooks {
+  const plugin = vizeUnplugin.raw(options, { framework: "esbuild" });
+  const esbuild = plugin.esbuild;
+  if (!esbuild) {
+    throw new Error("expected esbuild hook object");
+  }
+  return esbuild as unknown as EsbuildHooks;
+}
+
+void test("esbuild hook object exposes the expected members", (t) => {
+  const esbuild = esbuildHooks({ isProduction: true });
+  t.assert.ok(esbuild.onResolveFilter instanceof RegExp);
+  t.assert.ok(esbuild.onLoadFilter instanceof RegExp);
+  t.assert.strictEqual(typeof esbuild.loader, "function");
+  t.assert.strictEqual(typeof esbuild.config, "function");
+});
+
+void test("onResolveFilter matches .vue and .vue style requests but not .ts", (t) => {
+  const { onResolveFilter } = esbuildHooks({ isProduction: true });
+  t.assert.strictEqual(onResolveFilter.test("App.vue"), true);
+  t.assert.strictEqual(onResolveFilter.test("App.vue?vue&type=style"), true);
+  t.assert.strictEqual(onResolveFilter.test("App.ts"), false);
+});
+
+void test("onLoadFilter matches .vue and .vue style requests but not .ts", (t) => {
+  const { onLoadFilter } = esbuildHooks({ isProduction: true });
+  t.assert.strictEqual(onLoadFilter.test("App.vue"), true);
+  t.assert.strictEqual(onLoadFilter.test("App.vue?vue&type=style"), true);
+  t.assert.strictEqual(onLoadFilter.test("App.ts"), false);
+});
+
+void test("onResolveFilter/onLoadFilter are anchored on the .vue boundary", (t) => {
+  const { onResolveFilter, onLoadFilter } = esbuildHooks({ isProduction: true });
+  // `.vue` must be followed by end-of-string or `?`; a longer extension such as
+  // `.vuex` should not match.
+  t.assert.strictEqual(onResolveFilter.test("store.vuex"), false);
+  t.assert.strictEqual(onLoadFilter.test("store.vuex"), false);
+  // Path prefixes are fine as long as a `.vue` boundary appears.
+  t.assert.strictEqual(onResolveFilter.test("/abs/path/App.vue"), true);
+  t.assert.strictEqual(onLoadFilter.test("/abs/path/App.vue?vue&type=template"), true);
+});
+
+void test("parseVueRequest treats module as false only when the param is absent", (t) => {
+  // No `module` param at all -> module === false (boolean).
+  const absent = parseVueRequest("App.vue?vue&type=style").query;
+  t.assert.strictEqual(absent.type, "style");
+  t.assert.strictEqual(absent.module, false);
+
+  // `module=false` -> the param IS present, so module is the truthy string
+  // "false" (NOT the boolean false). This is the subtle parsing behavior the
+  // loader branch keys off of.
+  const present = parseVueRequest("App.vue?vue&type=style&module=false").query;
+  t.assert.strictEqual(present.type, "style");
+  t.assert.strictEqual(present.module, "false");
+  t.assert.strictEqual(typeof present.module, "string");
+
+  // Present-but-empty `module` -> boolean true.
+  const empty = parseVueRequest("App.vue?vue&type=style&module").query;
+  t.assert.strictEqual(empty.module, true);
+});
+
+void test('loader returns "css" for a plain style request (module param absent)', (t) => {
+  const { loader } = esbuildHooks({ isProduction: true });
+  // With no `module` param, parseVueRequest yields query.module === false, so
+  // the `module !== false` test is false -> "css".
+  t.assert.strictEqual(loader("", "App.vue?vue&type=style"), "css");
+});
+
+void test('loader returns "local-css" when the module param is present', (t) => {
+  const { loader } = esbuildHooks({ isProduction: true });
+  // `module=false` keeps the param PRESENT, so query.module is the string
+  // "false" which is `!== false` -> "local-css".
+  t.assert.strictEqual(loader("", "App.vue?vue&type=style&module=false"), "local-css");
+  // present-but-empty `module` -> query.module === true -> "local-css".
+  t.assert.strictEqual(loader("", "App.vue?vue&type=style&module"), "local-css");
+});
+
+void test('loader returns "js" for a non-style request', (t) => {
+  const { loader } = esbuildHooks({ isProduction: true });
+  t.assert.strictEqual(loader("", "App.vue"), "js");
+  t.assert.strictEqual(loader("", "App.vue?vue&type=template"), "js");
+  t.assert.strictEqual(loader("", "App.vue?vue&type=script&setup=true"), "js");
+});
+
+void test("config injects production Vue defines when hostCompiler is off", (t) => {
+  const { config } = esbuildHooks({ isProduction: true });
+  const buildOptions: { define?: Record<string, string> } = {};
+  config(buildOptions);
+
+  t.assert.deepStrictEqual(buildOptions.define, {
+    __VUE_OPTIONS_API__: JSON.stringify(true),
+    __VUE_PROD_DEVTOOLS__: JSON.stringify(false),
+    __VUE_PROD_HYDRATION_MISMATCH_DETAILS__: JSON.stringify(false),
+  });
+});
+
+void test("config injects development Vue defines when isProduction is false", (t) => {
+  const { config } = esbuildHooks({ isProduction: false });
+  const buildOptions: { define?: Record<string, string> } = {};
+  config(buildOptions);
+
+  t.assert.deepStrictEqual(buildOptions.define, {
+    __VUE_OPTIONS_API__: JSON.stringify(true),
+    __VUE_PROD_DEVTOOLS__: JSON.stringify(true),
+    __VUE_PROD_HYDRATION_MISMATCH_DETAILS__: JSON.stringify(true),
+  });
+});
+
+void test("config preserves existing user define entries and lets the user win on conflict", (t) => {
+  const { config } = esbuildHooks({ isProduction: true });
+  const buildOptions: { define?: Record<string, string> } = {
+    define: {
+      // User overrides one Vue define; the user value must win because
+      // `...buildOptions.define` is spread last.
+      __VUE_OPTIONS_API__: JSON.stringify(false),
+      CUSTOM_FLAG: JSON.stringify("kept"),
+    },
+  };
+  config(buildOptions);
+
+  t.assert.deepStrictEqual(buildOptions.define, {
+    __VUE_OPTIONS_API__: JSON.stringify(false),
+    __VUE_PROD_DEVTOOLS__: JSON.stringify(false),
+    __VUE_PROD_HYDRATION_MISMATCH_DETAILS__: JSON.stringify(false),
+    CUSTOM_FLAG: JSON.stringify("kept"),
+  });
+});
+
+void test("config returns early and leaves define untouched when hostCompiler is on", (t) => {
+  const { config } = esbuildHooks({ vueVersion: 2 });
+
+  // No pre-existing define stays undefined.
+  const empty: { define?: Record<string, string> } = {};
+  const result = config(empty);
+  t.assert.strictEqual(result, undefined);
+  t.assert.strictEqual(empty.define, undefined);
+
+  // A pre-existing user define is left exactly as-is.
+  const withDefine: { define?: Record<string, string> } = {
+    define: { CUSTOM_FLAG: JSON.stringify("kept") },
+  };
+  config(withDefine);
+  t.assert.deepStrictEqual(withDefine.define, {
+    CUSTOM_FLAG: JSON.stringify("kept"),
+  });
+});
+
+void test("config respects explicit compatibility.hostCompiler:true on Vue 3", (t) => {
+  const { config } = esbuildHooks({ compatibility: { hostCompiler: true } });
+  const buildOptions: { define?: Record<string, string> } = {};
+  config(buildOptions);
+  t.assert.strictEqual(buildOptions.define, undefined);
+});

--- a/npm/unplugin-vize/src/rolldown.test.ts
+++ b/npm/unplugin-vize/src/rolldown.test.ts
@@ -1,0 +1,137 @@
+import { test } from "node:test";
+import "./test/setup.ts";
+import vize from "./rolldown.ts";
+import vizeRollup from "./rollup.ts";
+import { packageRoot } from "./test/helpers.ts";
+
+// Rolldown consumes Rollup-format plugins, and a Rollup-format hook may be either
+// a bare function or an `{ handler }` object. Normalize so the test works against
+// whichever shape the factory produces.
+type RollupHook = unknown;
+
+function resolveHook(hook: RollupHook): ((...args: never[]) => unknown) | undefined {
+  if (typeof hook === "function") {
+    return hook as (...args: never[]) => unknown;
+  }
+  if (hook && typeof hook === "object" && "handler" in hook) {
+    const handler = (hook as { handler?: unknown }).handler;
+    return typeof handler === "function" ? (handler as (...args: never[]) => unknown) : undefined;
+  }
+  return undefined;
+}
+
+const BASIC_SFC = `<template><div>Hello from Rolldown</div></template>\n<script setup>const n = 1</script>`;
+
+const TS_SFC =
+  `<template><div>Hello from Rolldown</div></template>\n` +
+  `<script setup lang="ts">interface Props { msg: string }\nconst n: number = 1</script>`;
+
+void test("rolldown default export is a factory returning the unplugin-vize plugin", (t) => {
+  t.assert.strictEqual(typeof vize, "function");
+
+  const plugin = vize({ isProduction: true, root: packageRoot });
+  t.assert.ok(plugin && typeof plugin === "object");
+  t.assert.strictEqual(plugin.name, "unplugin-vize");
+  t.assert.ok(resolveHook(plugin.transform), "expected a transform hook");
+});
+
+void test("rolldown and rollup entries are the same underlying factory", (t) => {
+  // Both src/rolldown.ts and src/rollup.ts re-export `vizeUnplugin.rollup`, so they
+  // produce structurally identical Rollup-format plugin objects. (They are NOT the
+  // same function reference because each module re-evaluates the rollup getter.)
+  const rolldownPlugin = vize({ isProduction: true, root: packageRoot });
+  const rollupPlugin = vizeRollup({ isProduction: true, root: packageRoot });
+
+  t.assert.strictEqual(rolldownPlugin.name, rollupPlugin.name);
+  t.assert.strictEqual(rolldownPlugin.name, "unplugin-vize");
+
+  // Assert the hook surface is identical between the two entries.
+  t.assert.deepStrictEqual(Object.keys(rolldownPlugin).sort(), Object.keys(rollupPlugin).sort());
+
+  // The Rollup-format object actually present here exposes these hooks (all as
+  // functions). Assert the ones that are really there, on both entries.
+  for (const hookName of ["transform", "resolveId", "load", "transformInclude", "loadInclude"]) {
+    t.assert.ok(
+      resolveHook((rolldownPlugin as Record<string, unknown>)[hookName]),
+      `rolldown plugin should expose a ${hookName} hook`,
+    );
+    t.assert.ok(
+      resolveHook((rollupPlugin as Record<string, unknown>)[hookName]),
+      `rollup plugin should expose a ${hookName} hook`,
+    );
+  }
+});
+
+void test("rolldown transformInclude matches .vue ids and skips plain JS", (t) => {
+  const plugin = vize({ isProduction: true, root: packageRoot });
+  const transformInclude = resolveHook(plugin.transformInclude);
+  t.assert.ok(transformInclude, "expected a transformInclude hook");
+
+  t.assert.strictEqual(transformInclude!.call({} as never, "/proj/App.vue" as never), true);
+  t.assert.strictEqual(transformInclude!.call({} as never, "/proj/App.js" as never), false);
+});
+
+void test("rolldown transform compiles a basic SFC without leftover bundler runtime", async (t) => {
+  const plugin = vize({ isProduction: true, root: packageRoot });
+  const transform = resolveHook(plugin.transform);
+  t.assert.ok(transform, "expected a transform hook");
+
+  const warnings: string[] = [];
+  const result = await transform!.call(
+    {
+      warn(message: string) {
+        warnings.push(message);
+      },
+    } as never,
+    BASIC_SFC as never,
+    "/proj/App.vue" as never,
+  );
+
+  t.assert.ok(result && typeof result === "object");
+  const code = (result as { code: unknown }).code;
+  t.assert.strictEqual(typeof code, "string");
+  // The rendered template text survives compilation.
+  t.assert.match(code as string, /Hello from Rolldown/);
+  // Compiled output is a real ESM module that pulls runtime helpers from "vue".
+  t.assert.match(code as string, /from "vue"/);
+  t.assert.match(code as string, /export default/);
+  t.assert.deepStrictEqual(warnings, []);
+});
+
+void test("rolldown transform strips TypeScript-only syntax from <script setup lang=ts>", async (t) => {
+  const plugin = vize({ isProduction: true, root: packageRoot });
+  const transform = resolveHook(plugin.transform);
+  t.assert.ok(transform, "expected a transform hook");
+
+  const result = await transform!.call(
+    { warn() {} } as never,
+    TS_SFC as never,
+    "/proj/App.vue" as never,
+  );
+
+  t.assert.ok(result && typeof result === "object");
+  const code = (result as { code: string }).code;
+  t.assert.strictEqual(typeof code, "string");
+  t.assert.match(code, /Hello from Rolldown/);
+  // strip-types ran: the `interface` declaration and the `: number` type annotation
+  // are gone from the emitted JavaScript.
+  t.assert.doesNotMatch(code, /\binterface\b/);
+  t.assert.doesNotMatch(code, /const n\s*:\s*number/);
+});
+
+void test("rolldown transform returns null for non-vue ids", async (t) => {
+  const plugin = vize({ isProduction: true, root: packageRoot });
+  const transform = resolveHook(plugin.transform);
+  t.assert.ok(transform, "expected a transform hook");
+
+  const result = await transform!.call(
+    { warn() {} } as never,
+    "export const n = 1;" as never,
+    "/proj/main.ts" as never,
+  );
+
+  // The raw hook in unplugin.ts returns `null` for non-vue ids, but unplugin's
+  // Rollup-format wrapper normalizes that "no-op" result to `undefined`. Both are
+  // a falsy skip in Rollup semantics; assert the value actually observed here.
+  t.assert.strictEqual(result, undefined);
+});

--- a/npm/unplugin-vize/src/webpack-defines-edge.test.ts
+++ b/npm/unplugin-vize/src/webpack-defines-edge.test.ts
@@ -1,0 +1,282 @@
+import { test } from "node:test";
+import { createRequire } from "node:module";
+import type { Compiler as WebpackCompiler } from "webpack";
+import { injectWebpackVueDefines, vizeUnplugin } from "./unplugin.ts";
+
+// A fake DefinePlugin that records the definitions it was constructed with and
+// pushes them onto a shared log whenever `apply` runs. This mirrors the
+// FakeDefinePlugin pattern in webpack.test.ts so we can assert on what would
+// have been injected without running a real webpack build.
+function createFakeDefinePlugin(log: Array<Record<string, string>>) {
+  return class FakeDefinePlugin {
+    definitions: Record<string, string>;
+
+    constructor(definitions: Record<string, string>) {
+      this.definitions = definitions;
+    }
+
+    apply() {
+      log.push(this.definitions);
+    }
+  };
+}
+
+// Build a minimal fake compiler whose `webpack.DefinePlugin` is used by the
+// Webpack 5 resolution branch (webpackVersion !== 4).
+function createWebpack5Compiler(
+  DefinePlugin: unknown,
+  existingPlugins: Array<{ definitions?: Record<string, unknown> }> = [],
+): WebpackCompiler {
+  return {
+    webpack: { DefinePlugin },
+    options: { plugins: existingPlugins },
+  } as unknown as WebpackCompiler;
+}
+
+// Whether the host environment can resolve real webpack with a DefinePlugin.
+// This determines whether the "missing DefinePlugin" path can ever throw the
+// vize error: when real webpack is resolvable, resolution always succeeds.
+const hostWebpackHasDefinePlugin = (() => {
+  try {
+    const require = createRequire(import.meta.url);
+    const w = require("webpack") as { DefinePlugin?: unknown };
+    return typeof w.DefinePlugin === "function";
+  } catch {
+    return false;
+  }
+})();
+
+void test("webpack 5 shape: injects all three Vue defines via compiler.webpack.DefinePlugin (dev)", (t) => {
+  const applied: Array<Record<string, string>> = [];
+  const FakeDefinePlugin = createFakeDefinePlugin(applied);
+  const compiler = createWebpack5Compiler(FakeDefinePlugin);
+
+  injectWebpackVueDefines(compiler, /* isProduction */ false, 5);
+
+  // Applied exactly once with all three defines. With isProduction:false the two
+  // prod flags become JSON.stringify(!false) === "true" and __VUE_OPTIONS_API__
+  // is always JSON.stringify(true) === "true".
+  t.assert.deepStrictEqual(applied, [
+    {
+      __VUE_OPTIONS_API__: "true",
+      __VUE_PROD_DEVTOOLS__: "true",
+      __VUE_PROD_HYDRATION_MISMATCH_DETAILS__: "true",
+    },
+  ]);
+});
+
+void test("webpack 5 shape: production flips the prod-only defines to false", (t) => {
+  const applied: Array<Record<string, string>> = [];
+  const FakeDefinePlugin = createFakeDefinePlugin(applied);
+  const compiler = createWebpack5Compiler(FakeDefinePlugin);
+
+  injectWebpackVueDefines(compiler, /* isProduction */ true, 5);
+
+  t.assert.deepStrictEqual(applied, [
+    {
+      __VUE_OPTIONS_API__: "true",
+      __VUE_PROD_DEVTOOLS__: "false",
+      __VUE_PROD_HYDRATION_MISMATCH_DETAILS__: "false",
+    },
+  ]);
+});
+
+void test("full dedup: all three defines already present injects nothing", (t) => {
+  const applied: Array<Record<string, string>> = [];
+  const FakeDefinePlugin = createFakeDefinePlugin(applied);
+  const compiler = createWebpack5Compiler(FakeDefinePlugin, [
+    {
+      definitions: {
+        __VUE_OPTIONS_API__: "true",
+        __VUE_PROD_DEVTOOLS__: "false",
+        __VUE_PROD_HYDRATION_MISMATCH_DETAILS__: "false",
+      },
+    },
+  ]);
+
+  injectWebpackVueDefines(compiler, true, 5);
+
+  // No missing defines => DefinePlugin is never constructed/applied.
+  t.assert.strictEqual(applied.length, 0);
+});
+
+void test("full dedup across multiple existing plugins injects nothing", (t) => {
+  const applied: Array<Record<string, string>> = [];
+  const FakeDefinePlugin = createFakeDefinePlugin(applied);
+  // The three keys are spread across separate existing define plugins; the
+  // resolver unions every plugin's `definitions` keys before computing the gap.
+  const compiler = createWebpack5Compiler(FakeDefinePlugin, [
+    { definitions: { __VUE_OPTIONS_API__: "true" } },
+    { definitions: { __VUE_PROD_DEVTOOLS__: "false" } },
+    { definitions: { __VUE_PROD_HYDRATION_MISMATCH_DETAILS__: "false" } },
+  ]);
+
+  injectWebpackVueDefines(compiler, true, 5);
+
+  t.assert.strictEqual(applied.length, 0);
+});
+
+void test("partial dedup: only the missing defines are injected (dev)", (t) => {
+  const applied: Array<Record<string, string>> = [];
+  const FakeDefinePlugin = createFakeDefinePlugin(applied);
+  const compiler = createWebpack5Compiler(FakeDefinePlugin, [
+    { definitions: { __VUE_OPTIONS_API__: "true" } },
+  ]);
+
+  injectWebpackVueDefines(compiler, /* isProduction */ false, 5);
+
+  // __VUE_OPTIONS_API__ already exists, so only the two prod flags are injected.
+  t.assert.deepStrictEqual(applied, [
+    {
+      __VUE_PROD_DEVTOOLS__: "true",
+      __VUE_PROD_HYDRATION_MISMATCH_DETAILS__: "true",
+    },
+  ]);
+});
+
+void test("plugins entries without `definitions` are ignored when computing the gap", (t) => {
+  const applied: Array<Record<string, string>> = [];
+  const FakeDefinePlugin = createFakeDefinePlugin(applied);
+  // Unrelated plugins (no `definitions` field) must not affect dedup.
+  const compiler = createWebpack5Compiler(FakeDefinePlugin, [
+    { name: "some-other-plugin" } as unknown as { definitions?: Record<string, unknown> },
+    { definitions: { __VUE_PROD_DEVTOOLS__: "false" } },
+  ]);
+
+  injectWebpackVueDefines(compiler, /* isProduction */ false, 5);
+
+  // Only __VUE_PROD_DEVTOOLS__ pre-existed, so the other two are injected.
+  t.assert.deepStrictEqual(applied, [
+    {
+      __VUE_OPTIONS_API__: "true",
+      __VUE_PROD_HYDRATION_MISMATCH_DETAILS__: "true",
+    },
+  ]);
+});
+
+void test("explicit constructor is preferred over compiler.webpack.DefinePlugin", (t) => {
+  const compilerLog: Array<Record<string, string>> = [];
+  const explicitLog: Array<Record<string, string>> = [];
+  const CompilerDefinePlugin = createFakeDefinePlugin(compilerLog);
+  const ExplicitDefinePlugin = createFakeDefinePlugin(explicitLog);
+  const compiler = createWebpack5Compiler(CompilerDefinePlugin);
+
+  injectWebpackVueDefines(compiler, false, 5, ExplicitDefinePlugin);
+
+  // The explicit constructor short-circuits resolution entirely.
+  t.assert.strictEqual(compilerLog.length, 0);
+  t.assert.strictEqual(explicitLog.length, 1);
+});
+
+void test("missing DefinePlugin: resolution falls through to host webpack", (t) => {
+  // Webpack 4 path with no explicit constructor and a compiler that lacks
+  // `webpack.DefinePlugin`. The v4 branch skips compiler.webpack and resolves
+  // via host require("webpack"). Behavior depends on the environment:
+  //  - if host webpack is NOT resolvable => throws the vize error;
+  //  - if host webpack IS resolvable => resolution succeeds (no vize error).
+  // We use the full-dedup shape so that, when resolution succeeds, the real
+  // DefinePlugin is never constructed/applied (no missing defines) and the call
+  // completes without touching the fake compiler's (absent) webpack hooks.
+  const compiler = {
+    options: {
+      plugins: [
+        {
+          definitions: {
+            __VUE_OPTIONS_API__: "true",
+            __VUE_PROD_DEVTOOLS__: "false",
+            __VUE_PROD_HYDRATION_MISMATCH_DETAILS__: "false",
+          },
+        },
+      ],
+    },
+  } as unknown as WebpackCompiler;
+
+  if (hostWebpackHasDefinePlugin) {
+    // Resolution succeeds; with all defines present nothing is injected and it
+    // does NOT throw the vize "Could not resolve" error.
+    t.assert.doesNotThrow(() => injectWebpackVueDefines(compiler, true, 4));
+  } else {
+    t.assert.throws(
+      () => injectWebpackVueDefines(compiler, true, 4),
+      /\[vize\] Could not resolve webpack DefinePlugin/,
+    );
+  }
+});
+
+void test("missing DefinePlugin: vize error only when host webpack is unresolvable", (t) => {
+  // A bare compiler (no webpack.DefinePlugin) with missing defines. When host
+  // webpack is unresolvable this is the canonical "Could not resolve" throw.
+  // When it IS resolvable, the real DefinePlugin resolves successfully (so the
+  // vize error never fires) but its `.apply` requires a real compiler with
+  // hooks; on this fake compiler that surfaces as a non-vize TypeError. Either
+  // way, the vize "Could not resolve" message must not appear when resolution
+  // succeeded.
+  const compiler = {
+    options: { plugins: [] },
+  } as unknown as WebpackCompiler;
+
+  if (hostWebpackHasDefinePlugin) {
+    let caught: unknown;
+    try {
+      injectWebpackVueDefines(compiler, false, 4);
+    } catch (error) {
+      caught = error;
+    }
+    // Resolution succeeded => never the vize "Could not resolve" error.
+    const message = caught instanceof Error ? caught.message : String(caught);
+    t.assert.strictEqual(message.includes("[vize] Could not resolve webpack DefinePlugin"), false);
+  } else {
+    t.assert.throws(
+      () => injectWebpackVueDefines(compiler, false, 4),
+      /\[vize\] Could not resolve webpack DefinePlugin/,
+    );
+  }
+});
+
+void test("webpack hook: hostCompiler (vueVersion 2) does not inject defines", (t) => {
+  const applied: Array<Record<string, string>> = [];
+  const SpyDefinePlugin = createFakeDefinePlugin(applied);
+  const compiler = createWebpack5Compiler(SpyDefinePlugin);
+
+  // vueVersion 2 is a legacy version => hostCompiler defaults to true, so the
+  // `webpack` hook's `if (!options.hostCompiler)` guard skips injection.
+  const raw = (
+    vizeUnplugin.raw as (
+      options: unknown,
+      meta: unknown,
+    ) => { webpack?: (compiler: WebpackCompiler) => void }
+  )({ vueVersion: 2 }, { framework: "webpack", webpack: {} });
+  const plugin = Array.isArray(raw) ? raw[0] : raw;
+
+  t.assert.strictEqual(typeof plugin.webpack, "function");
+  plugin.webpack?.(compiler);
+
+  t.assert.strictEqual(applied.length, 0);
+});
+
+void test("webpack hook: non-host (vueVersion 3) injects all three defines", (t) => {
+  const applied: Array<Record<string, string>> = [];
+  const SpyDefinePlugin = createFakeDefinePlugin(applied);
+  const compiler = createWebpack5Compiler(SpyDefinePlugin);
+
+  // vueVersion 3 (default) => hostCompiler false => the hook injects. The hook
+  // forwards compatibility.webpackVersion (undefined here), so the resolver uses
+  // compiler.webpack.DefinePlugin (the webpackVersion !== 4 branch).
+  const raw = (
+    vizeUnplugin.raw as (
+      options: unknown,
+      meta: unknown,
+    ) => { webpack?: (compiler: WebpackCompiler) => void }
+  )({ vueVersion: 3, isProduction: false }, { framework: "webpack", webpack: {} });
+  const plugin = Array.isArray(raw) ? raw[0] : raw;
+
+  plugin.webpack?.(compiler);
+
+  t.assert.deepStrictEqual(applied, [
+    {
+      __VUE_OPTIONS_API__: "true",
+      __VUE_PROD_DEVTOOLS__: "true",
+      __VUE_PROD_HYDRATION_MISMATCH_DETAILS__: "true",
+    },
+  ]);
+});


### PR DESCRIPTION
## What

Adds per-bundler-entry edge-case tests for `@vizejs/unplugin`.

New files (`node --test`):
- `src/rolldown.test.ts` — the Rolldown entry (`vizeUnplugin.rollup`) plugin object + hook surface + transform on inline SFCs. `rolldown` is not a dev dep, so this drives the rollup-format hooks directly (no bundler runtime) (6 cases)
- `src/esbuild-hooks.test.ts` — the esbuild hook object: `onResolveFilter`/`onLoadFilter`, `loader` css/local-css/js branches, `config` define injection/merge/host-compiler early-return (13 cases)
- `src/webpack-defines-edge.test.ts` — `injectWebpackVueDefines` / `resolveWebpackDefinePlugin` / the `webpack(compiler)` hook: Webpack 5 `DefinePlugin` shape, full/partial/multi-plugin dedup, host-compiler guard (11 cases)

Notable pinned behavior: in a vue style query `?module=false` **enables** css-modules (the loader returns `local-css`) because `parseVueRequest` does `get("module") || true`; disabling requires omitting the param.

## Verify
`cd npm/unplugin-vize && node --test 'src/*.test.ts'` → all green; `oxlint`/`oxfmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1112"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783429362&installation_id=136613492&pr_number=1112&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1112&signature=fc8d256c065d74c5733371dc7db4c58c640367f2e4ee3e7299996230f4eac278"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->