### PR TITLE
test(unplugin): cover CSS preprocessor delegation and style output

### DIFF
--- a/npm/unplugin-vize/src/css-preprocessors.test.ts
+++ b/npm/unplugin-vize/src/css-preprocessors.test.ts
@@ -1,0 +1,193 @@
+import path from "node:path";
+import { test } from "node:test";
+import "./test/setup.ts";
+import { vizeUnplugin } from "./unplugin.ts";
+import { packageRoot } from "./test/helpers.ts";
+
+const STYLE_MARKER = ".__vize_style_";
+
+// A synthetic id is enough: the SFC source is passed directly to transform(),
+// which caches the compiled module + styles in-memory, so the .vue file never
+// needs to exist on disk. The path only has to end in `.vue` and avoid
+// `node_modules` to satisfy the plugin's request matching.
+const SYNTHETIC_ID = path.join(packageRoot, "App.vue");
+
+function createPlugin() {
+  return vizeUnplugin.raw(
+    {
+      isProduction: true,
+      root: packageRoot,
+    },
+    {
+      framework: "rollup",
+    },
+  );
+}
+
+// Drives the full virtual-style delegation pipeline against ONE fresh plugin
+// instance so the in-memory transform cache is clean:
+//   transform(source, id)  -> caches compiled module + style blocks
+//   resolveId(importId)    -> STYLE_MARKER virtual id (carries vize-file)
+//   load(virtualId)        -> { code } read back from the cache
+async function runPipeline(source: string, importRegex: RegExp) {
+  const plugin = createPlugin();
+  const ctx = { warn() {} };
+
+  const transformed = await plugin.transform?.call(ctx as never, source, SYNTHETIC_ID);
+  if (!transformed || typeof transformed !== "object") {
+    throw new Error("transform() returned no result");
+  }
+
+  const match = transformed.code.match(importRegex);
+  if (!match) {
+    throw new Error(`no style import matched ${importRegex} in:\n${transformed.code}`);
+  }
+  const importId = match[1];
+
+  const resolvedId = await plugin.resolveId?.call({} as never, importId, SYNTHETIC_ID, {
+    isEntry: false,
+  });
+  if (typeof resolvedId !== "string") {
+    throw new Error(`resolveId() returned non-string: ${String(resolvedId)}`);
+  }
+
+  const loaded = await plugin.load?.call({} as never, resolvedId);
+  if (!loaded || typeof loaded !== "object") {
+    throw new Error("load() returned no result");
+  }
+
+  return {
+    transformCode: transformed.code,
+    importId,
+    resolvedId,
+    loadInclude: plugin.loadInclude?.call({} as never, resolvedId),
+    loadedCss: loaded.code,
+  };
+}
+
+void test("scss scoped style is delegated through transform -> resolveId -> load", async (t) => {
+  const { transformCode, importId, resolvedId, loadInclude, loadedCss } = await runPipeline(
+    `<template><div class="a">x</div></template>
+<style scoped lang="scss">$c: red; .a { color: $c; }</style>`,
+    /import "([^"]+)";/,
+  );
+
+  // transform() emits a side-effect style import with the right query.
+  t.assert.match(transformCode, /import "[^"]+\.vue\?[^"]*type=style[^"]*";/);
+  t.assert.match(importId, /type=style/);
+  t.assert.match(importId, /lang=scss/);
+  // Scoped preprocessor styles carry a scoped=data-v-<id> query.
+  t.assert.match(importId, /scoped=data-v-[0-9a-f]+/);
+  const scopeMatch = importId.match(/scoped=(data-v-[0-9a-f]+)/);
+  t.assert.ok(scopeMatch, "expected a data-v scope id in the import query");
+  const scopeId = scopeMatch[1];
+
+  // resolveId() hands back the STYLE_MARKER virtual id.
+  t.assert.ok(resolvedId.includes(STYLE_MARKER), "resolved id contains the STYLE_MARKER");
+  t.assert.match(resolvedId, /\.scss\?/);
+  t.assert.equal(loadInclude, true);
+
+  // load() returns the wrapScopedPreprocessorStyle output: the original
+  // (un-compiled) scss is wrapped in the scope-attribute selector so the
+  // downstream preprocessor sees the scope.
+  t.assert.ok(loadedCss.includes(`[${scopeId}]`), "scoped selector present in loaded css");
+  t.assert.ok(loadedCss.includes("$c: red"), "raw scss content preserved for the preprocessor");
+});
+
+void test("less style (non-scoped) is delegated and returned verbatim", async (t) => {
+  const { importId, resolvedId, loadInclude, loadedCss } = await runPipeline(
+    `<template><div class="a">x</div></template>
+<style lang="less">@c: red; .a { color: @c; }</style>`,
+    /import "([^"]+)";/,
+  );
+
+  t.assert.match(importId, /type=style/);
+  t.assert.match(importId, /lang=less/);
+  // Not scoped: no scope query is emitted.
+  t.assert.ok(!/scoped=/.test(importId), "non-scoped style has no scoped query");
+
+  t.assert.ok(resolvedId.includes(STYLE_MARKER), "resolved id contains the STYLE_MARKER");
+  t.assert.match(resolvedId, /\.less\?/);
+  t.assert.equal(loadInclude, true);
+
+  // Non-scoped preprocessor content passes through untouched (no scope wrapper).
+  t.assert.ok(loadedCss.includes("@c: red"), "raw less content preserved");
+  t.assert.ok(!/\[data-v-/.test(loadedCss), "no scope wrapper for a non-scoped block");
+});
+
+void test("stylus scoped style is delegated and scope-wrapped", async (t) => {
+  const { importId, resolvedId, loadInclude, loadedCss } = await runPipeline(
+    `<template><div class="a">x</div></template>
+<style scoped lang="stylus">.a
+  color red</style>`,
+    /import "([^"]+)";/,
+  );
+
+  t.assert.match(importId, /type=style/);
+  t.assert.match(importId, /lang=stylus/);
+  t.assert.match(importId, /scoped=data-v-[0-9a-f]+/);
+  const scopeMatch = importId.match(/scoped=(data-v-[0-9a-f]+)/);
+  t.assert.ok(scopeMatch, "expected a data-v scope id in the import query");
+  const scopeId = scopeMatch[1];
+
+  t.assert.ok(resolvedId.includes(STYLE_MARKER), "resolved id contains the STYLE_MARKER");
+  t.assert.match(resolvedId, /\.stylus\?/);
+  t.assert.equal(loadInclude, true);
+
+  t.assert.ok(loadedCss.includes(`[${scopeId}]`), "scoped selector present in loaded stylus");
+  t.assert.ok(loadedCss.includes("color red"), "raw stylus content preserved");
+});
+
+void test("css-module style is delegated via a default import binding", async (t) => {
+  const { transformCode, importId, resolvedId, loadInclude, loadedCss } = await runPipeline(
+    `<template><div :class="$style.root">x</div></template>
+<style module>.root { color: seagreen; }</style>`,
+    /import \$style from "([^"]+)";/,
+  );
+
+  // css-modules produce a default import bound to $style, not a side-effect import.
+  t.assert.match(transformCode, /import \$style from "[^"]+";/);
+  // The compiled module also registers the binding on __cssModules.
+  t.assert.match(transformCode, /__cssModules\["\$style"\] = \$style;/);
+
+  t.assert.match(importId, /type=style/);
+  t.assert.match(importId, /module=/);
+
+  t.assert.ok(resolvedId.includes(STYLE_MARKER), "resolved id contains the STYLE_MARKER");
+  t.assert.match(resolvedId, /\.module\.css\?/);
+  t.assert.equal(loadInclude, true);
+
+  // The loaded css is the (plain css) module content, non-empty.
+  t.assert.ok(loadedCss.length > 0, "css-module load returns non-empty css");
+  t.assert.ok(loadedCss.includes(".root"), "css-module selector present in loaded css");
+});
+
+void test("plain non-module css is inlined, not delegated", async (t) => {
+  const plugin = createPlugin();
+  const ctx = { warn() {} };
+
+  const transformed = await plugin.transform?.call(
+    ctx as never,
+    `<template><div class="a">x</div></template>
+<style>.a{color:red}</style>`,
+    SYNTHETIC_ID,
+  );
+  t.assert.ok(transformed && typeof transformed === "object");
+
+  // Plain css is injected inline via the __vize_css__ runtime, not delegated.
+  t.assert.match(transformed.code, /export const __vize_css__ = "\.a\{color:red\}";/);
+  t.assert.match(transformed.code, /__vize_css_id__/);
+
+  // No delegated style import / css-module import is emitted.
+  t.assert.ok(
+    !/\?[^"]*type=style/.test(transformed.code),
+    "plain css emits no delegated style import",
+  );
+  t.assert.ok(
+    !/import \$style from/.test(transformed.code),
+    "plain css emits no css-module import",
+  );
+
+  // And resolveId on a would-be style request for this plain css is moot: the
+  // transform never produced one, confirming the inline path was taken.
+});

--- a/npm/unplugin-vize/src/style-output.test.ts
+++ b/npm/unplugin-vize/src/style-output.test.ts
@@ -1,0 +1,321 @@
+import { test } from "node:test";
+import {
+  extractStyleBlocks,
+  generateOutput,
+  generateScopeId,
+  hasDelegatedStyles,
+  toStyleBlockInfo,
+} from "./style.ts";
+import type { CompiledModule, StyleBlockInfo, StyleBlockNapi } from "./types.ts";
+
+function makeBlock(over: Partial<StyleBlockInfo> = {}): StyleBlockInfo {
+  return {
+    content: "",
+    src: null,
+    lang: null,
+    scoped: false,
+    module: false,
+    index: 0,
+    ...over,
+  };
+}
+
+function makeCompiled(over: Partial<CompiledModule> = {}): CompiledModule {
+  return {
+    code: "export default {}",
+    scopeId: "abc123",
+    hasScoped: false,
+    styles: [],
+    ...over,
+  };
+}
+
+void test("extractStyleBlocks returns ordered StyleBlockInfo for scoped scss + css module", (t) => {
+  const source = [
+    `<template><div class="a">hi</div></template>`,
+    `<style scoped lang="scss">`,
+    `.a { color: red; }`,
+    `</style>`,
+    `<style module>`,
+    `.b { color: blue; }`,
+    `</style>`,
+  ].join("\n");
+
+  const blocks = extractStyleBlocks(source);
+
+  t.assert.equal(blocks.length, 2);
+
+  // first block: scoped scss
+  t.assert.equal(blocks[0].index, 0);
+  t.assert.equal(blocks[0].lang, "scss");
+  t.assert.equal(blocks[0].scoped, true);
+  t.assert.equal(blocks[0].module, false);
+  t.assert.match(blocks[0].content, /\.a \{ color: red; \}/);
+
+  // second block: unnamed css module (module === true), plain css lang (null)
+  t.assert.equal(blocks[1].index, 1);
+  t.assert.equal(blocks[1].lang, null);
+  t.assert.equal(blocks[1].scoped, false);
+  t.assert.equal(blocks[1].module, true);
+  t.assert.match(blocks[1].content, /\.b \{ color: blue; \}/);
+});
+
+void test("extractStyleBlocks surfaces a named css module as the module name string", (t) => {
+  const source = [
+    `<template><div class="b">hi</div></template>`,
+    `<style module="cls">`,
+    `.b { color: blue; }`,
+    `</style>`,
+  ].join("\n");
+
+  const blocks = extractStyleBlocks(source);
+
+  t.assert.equal(blocks.length, 1);
+  t.assert.equal(blocks[0].module, "cls");
+  t.assert.equal(blocks[0].scoped, false);
+  t.assert.equal(blocks[0].index, 0);
+});
+
+void test("toStyleBlockInfo maps napi block module flag to boolean|string", (t) => {
+  const base: StyleBlockNapi = {
+    content: ".x{}",
+    scoped: true,
+    module: false,
+    index: 3,
+  };
+
+  // plain block
+  const plain = toStyleBlockInfo(base);
+  t.assert.equal(plain.module, false);
+  t.assert.equal(plain.lang, null);
+  t.assert.equal(plain.src, null);
+  t.assert.equal(plain.scoped, true);
+  t.assert.equal(plain.index, 3);
+
+  // unnamed module -> true
+  const unnamed = toStyleBlockInfo({ ...base, module: true });
+  t.assert.equal(unnamed.module, true);
+
+  // named module -> name string
+  const named = toStyleBlockInfo({ ...base, module: true, moduleName: "foo" });
+  t.assert.equal(named.module, "foo");
+
+  // src + lang preserved
+  const withSrc = toStyleBlockInfo({ ...base, src: "./a.css", lang: "scss" });
+  t.assert.equal(withSrc.src, "./a.css");
+  t.assert.equal(withSrc.lang, "scss");
+});
+
+void test("generateScopeId is deterministic and returns an 8-char hex id", (t) => {
+  const source = `<template><div>x</div></template><style scoped>.a{}</style>`;
+  const a = generateScopeId("/project/src/App.vue", "/project", false, source);
+  const b = generateScopeId("/project/src/App.vue", "/project", false, source);
+
+  t.assert.equal(a, b);
+  t.assert.match(a, /^[0-9a-f]{8}$/);
+});
+
+void test("hasDelegatedStyles is false for a single plain non-module css block", (t) => {
+  t.assert.equal(hasDelegatedStyles(makeCompiled({ styles: [makeBlock()] })), false);
+  // explicit lang "css" is also plain
+  t.assert.equal(hasDelegatedStyles(makeCompiled({ styles: [makeBlock({ lang: "css" })] })), false);
+  // no styles at all
+  t.assert.equal(hasDelegatedStyles(makeCompiled({ styles: [] })), false);
+});
+
+void test("hasDelegatedStyles is true when any block needs a preprocessor", (t) => {
+  for (const lang of ["scss", "sass", "less", "stylus", "styl"]) {
+    t.assert.equal(
+      hasDelegatedStyles(makeCompiled({ styles: [makeBlock({ lang })] })),
+      true,
+      `lang=${lang} should delegate`,
+    );
+  }
+});
+
+void test("hasDelegatedStyles is true for css-module blocks (unnamed or named)", (t) => {
+  t.assert.equal(hasDelegatedStyles(makeCompiled({ styles: [makeBlock({ module: true })] })), true);
+  t.assert.equal(
+    hasDelegatedStyles(makeCompiled({ styles: [makeBlock({ module: "cls" })] })),
+    true,
+  );
+});
+
+void test("hasDelegatedStyles is true when one of several blocks delegates", (t) => {
+  const compiled = makeCompiled({
+    styles: [makeBlock({ index: 0 }), makeBlock({ index: 1, lang: "less" })],
+  });
+  t.assert.equal(hasDelegatedStyles(compiled), true);
+});
+
+void test("generateOutput (a): export default with hasScoped and no _sfc_main rewrites and appends scopeId", (t) => {
+  const out = generateOutput(
+    makeCompiled({ code: "export default { name: 'A' }", scopeId: "abc123", hasScoped: true }),
+    { isProduction: true, isDev: false },
+  );
+
+  // rewritten declaration
+  t.assert.match(out, /const _sfc_main = \{ name: 'A' \}/);
+  // no leftover original export-default-of-object
+  t.assert.equal(/^export default \{/m.test(out), false);
+  // appended scopeId assignment
+  t.assert.match(out, /_sfc_main\.__scopeId = "data-v-abc123";/);
+  // re-exported default
+  t.assert.match(out, /export default _sfc_main;/);
+  // no style injection IIFE (no css)
+  t.assert.equal(out.includes("document.createElement"), false);
+});
+
+void test("generateOutput (a'): export default WITHOUT hasScoped does not append __scopeId", (t) => {
+  const out = generateOutput(makeCompiled({ code: "export default {}", hasScoped: false }), {
+    isProduction: true,
+    isDev: false,
+  });
+
+  t.assert.match(out, /const _sfc_main = \{\}/);
+  t.assert.match(out, /export default _sfc_main;/);
+  t.assert.equal(out.includes("__scopeId"), false);
+});
+
+void test("generateOutput (b): plain css in non-production injects the __vize_css__ style IIFE", (t) => {
+  const out = generateOutput(
+    makeCompiled({
+      code: "export default {}",
+      scopeId: "abc123",
+      css: ".x{color:red}",
+      styles: [makeBlock()],
+    }),
+    { isProduction: false, isDev: false },
+  );
+
+  t.assert.match(out, /export const __vize_css__ = ".x\{color:red\}";/);
+  t.assert.match(out, /const __vize_css_id__ = "vize-style-abc123";/);
+  t.assert.match(out, /document\.createElement\("style"\)/);
+  t.assert.match(out, /document\.head\.appendChild\(style\)/);
+  // the original module body still follows the IIFE
+  t.assert.match(out, /export default _sfc_main;/);
+});
+
+void test("generateOutput (b'): plain css is also injected in production when extractCss is falsy", (t) => {
+  const out = generateOutput(makeCompiled({ css: ".y{}", styles: [makeBlock()] }), {
+    isProduction: true,
+    isDev: false,
+    extractCss: false,
+  });
+  t.assert.match(out, /export const __vize_css__ = ".y\{\}";/);
+  t.assert.match(out, /document\.createElement/);
+});
+
+void test("generateOutput (b''): plain css is NOT injected in production when extractCss is true", (t) => {
+  const out = generateOutput(makeCompiled({ css: ".z{}", styles: [makeBlock()] }), {
+    isProduction: true,
+    isDev: false,
+    extractCss: true,
+  });
+  t.assert.equal(out.includes("__vize_css__"), false);
+  t.assert.equal(out.includes("document.createElement"), false);
+});
+
+void test("generateOutput (c): delegated scss (scoped) + css module emits style imports + __cssModules setup", (t) => {
+  const out = generateOutput(
+    makeCompiled({
+      code: "export default {}",
+      scopeId: "abc123",
+      hasScoped: true,
+      styles: [
+        makeBlock({ lang: "scss", scoped: true, index: 0 }),
+        makeBlock({ module: true, index: 1 }),
+      ],
+    }),
+    { isProduction: true, isDev: false, filePath: "/proj/App.vue" },
+  );
+
+  // scoped scss block -> side-effect style import carrying scoped=data-v-<scopeId>
+  t.assert.match(
+    out,
+    /import "\/proj\/App\.vue\?vue=&type=style&index=0&lang=scss&scoped=data-v-abc123";/,
+  );
+  // unnamed css module -> default-binding import using $style, lang defaults to css, module= (empty)
+  t.assert.match(
+    out,
+    /import \$style from "\/proj\/App\.vue\?vue=&type=style&index=1&lang=css&module=";/,
+  );
+  // __cssModules wiring
+  t.assert.match(out, /_sfc_main\.__cssModules = _sfc_main\.__cssModules \|\| \{\};/);
+  t.assert.match(out, /_sfc_main\.__cssModules\["\$style"\] = \$style;/);
+  // setup is placed before export default _sfc_main
+  t.assert.match(out, /__cssModules\["\$style"\] = \$style;\nexport default _sfc_main;/);
+  // delegated path means the inline css IIFE is NOT used
+  t.assert.equal(out.includes("document.createElement"), false);
+  // scoped scopeId still applied to the component
+  t.assert.match(out, /_sfc_main\.__scopeId = "data-v-abc123";/);
+});
+
+void test("generateOutput (c'): named css module uses its name as binding and url module value", (t) => {
+  const out = generateOutput(
+    makeCompiled({
+      code: "export default {}",
+      scopeId: "zzz",
+      hasScoped: false,
+      styles: [makeBlock({ module: "cls", index: 0 })],
+    }),
+    { isProduction: true, isDev: false, filePath: "/proj/App.vue" },
+  );
+
+  t.assert.match(
+    out,
+    /import cls from "\/proj\/App\.vue\?vue=&type=style&index=0&lang=css&module=cls";/,
+  );
+  t.assert.match(out, /_sfc_main\.__cssModules\["cls"\] = cls;/);
+});
+
+void test("generateOutput (c''): delegated styles require filePath; without it falls back (no style imports)", (t) => {
+  const out = generateOutput(
+    makeCompiled({
+      code: "export default {}",
+      scopeId: "abc123",
+      styles: [makeBlock({ lang: "scss", scoped: true, index: 0 })],
+    }),
+    { isProduction: true, isDev: false },
+  );
+
+  // no filePath => no delegated style import is emitted
+  t.assert.equal(out.includes("?vue=&type=style"), false);
+  t.assert.equal(out.includes("__cssModules"), false);
+});
+
+void test("generateOutput (d): named render export with no export default and no _sfc_main appends component shell", (t) => {
+  const out = generateOutput(
+    makeCompiled({
+      code: "export function render() { return 1; }",
+      scopeId: "rrr",
+      hasScoped: true,
+      styles: [],
+    }),
+    { isProduction: true, isDev: false },
+  );
+
+  // original named export preserved
+  t.assert.match(out, /export function render\(\) \{ return 1; \}/);
+  // appended component shell
+  t.assert.match(out, /const _sfc_main = \{\};/);
+  t.assert.match(out, /_sfc_main\.__scopeId = "data-v-rrr";/);
+  t.assert.match(out, /_sfc_main\.render = render;/);
+  t.assert.match(out, /export default _sfc_main;/);
+});
+
+void test("generateOutput (d'): named render export without scoping skips __scopeId", (t) => {
+  const out = generateOutput(
+    makeCompiled({
+      code: "export function render() { return 1; }",
+      scopeId: "rrr",
+      hasScoped: false,
+      styles: [],
+    }),
+    { isProduction: true, isDev: false },
+  );
+
+  t.assert.match(out, /const _sfc_main = \{\};/);
+  t.assert.match(out, /_sfc_main\.render = render;/);
+  t.assert.equal(out.includes("__scopeId"), false);
+});


### PR DESCRIPTION
## What

Adds CSS edge-case tests for `@vizejs/unplugin`.

New files (`node --test`):
- `src/css-preprocessors.test.ts` — end-to-end scss/less/stylus + css-module virtual-style **delegation** through the raw hooks (`transform` → `resolveId` → `load`), plus the plain-css inline path (5 cases)
- `src/style-output.test.ts` — `style.ts` pure functions: `extractStyleBlocks`, `hasDelegatedStyles`, `generateScopeId`, `toStyleBlockInfo`, and all `generateOutput` branches (scoped scopeId injection, css-module setup, named-render-export, plain-css IIFE injection) (18 cases)

Pinned detail: `wrapScopedPreprocessorStyle` wraps the whole raw block once as `[data-v-<id>] { … }` (per-selector scoping happens after the host preprocessor compiles) — intentional, now documented by tests.

## Verify
`cd npm/unplugin-vize && node --test 'src/*.test.ts'` → all green; `oxlint`/`oxfmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1113"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783429367&installation_id=136613492&pr_number=1113&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1113&signature=47eecc6c7e41531c5ca797f905193ebe484c7a1f344cd60fdafa881fd0cbabd3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->