### PR TITLE
test(unplugin): cover TypeScript strip, Pug template, and Vapor

### DIFF
--- a/npm/unplugin-vize/src/strip-types-edge.test.ts
+++ b/npm/unplugin-vize/src/strip-types-edge.test.ts
@@ -1,0 +1,100 @@
+import { test } from "node:test";
+import { stripTypeScript } from "./strip-types.ts";
+
+void test("stripTypeScript elides type-only imports and type annotations", async (t) => {
+  const result = await stripTypeScript(
+    "fixture.ts",
+    'import type { Foo } from "./x";\nconst a: number = 1;\n',
+    false,
+  );
+
+  t.assert.equal(result.code.includes("import type"), false);
+  t.assert.equal(result.code.includes(": number"), false);
+  t.assert.equal(result.code.includes("Foo"), false);
+  t.assert.match(result.code, /const a = 1/);
+});
+
+void test("stripTypeScript removes the satisfies operator", async (t) => {
+  const result = await stripTypeScript(
+    "fixture.ts",
+    "const x = { a: 1 } satisfies Record<string, number>;\n",
+    false,
+  );
+
+  t.assert.equal(result.code.includes("satisfies"), false);
+  t.assert.equal(result.code.includes("Record"), false);
+  t.assert.match(result.code, /const x = \{ a: 1 \}/);
+});
+
+void test("stripTypeScript strips as-casts and non-null assertions", async (t) => {
+  const result = await stripTypeScript("fixture.ts", "const y = (z as string)!;\n", false);
+
+  t.assert.equal(result.code.includes(" as "), false);
+  t.assert.equal(result.code.includes("!"), false);
+  t.assert.equal(result.code.includes("string"), false);
+  t.assert.match(result.code, /const y = z/);
+});
+
+void test("stripTypeScript removes generics, interfaces, and type aliases", async (t) => {
+  const result = await stripTypeScript(
+    "fixture.ts",
+    "interface I { a: number }\ntype T = string;\nfunction id<X>(v: X): X { return v; }\nconst r = id<number>(1);\n",
+    false,
+  );
+
+  t.assert.equal(result.code.includes("interface"), false);
+  t.assert.equal(result.code.includes("type T"), false);
+  // generic type parameters and arguments are removed
+  t.assert.equal(result.code.includes("<X>"), false);
+  t.assert.equal(result.code.includes("<number>"), false);
+  t.assert.match(result.code, /function id\(v\)/);
+  t.assert.match(result.code, /const r = id\(1\)/);
+});
+
+void test("stripTypeScript downlevels enum to a runtime object without the enum keyword", async (t) => {
+  const result = await stripTypeScript("fixture.ts", "enum E { A, B }\nconst v = E.A;\n", false);
+
+  // oxc downlevels enums to a runtime IIFE rather than removing them entirely.
+  t.assert.equal(/\benum\b/.test(result.code), false);
+  t.assert.match(result.code, /var E/);
+  t.assert.match(result.code, /const v = E\.A/);
+});
+
+void test("stripTypeScript downlevels namespace to runtime code without the namespace keyword", async (t) => {
+  const result = await stripTypeScript(
+    "fixture.ts",
+    "namespace N { export const x = 1; }\nconst z = N.x;\n",
+    false,
+  );
+
+  // oxc downlevels namespaces to a runtime IIFE rather than removing them entirely.
+  t.assert.equal(/\bnamespace\b/.test(result.code), false);
+  t.assert.match(result.code, /const z = N\.x/);
+});
+
+void test("stripTypeScript keeps used value imports while eliding type-only imports", async (t) => {
+  const result = await stripTypeScript(
+    "fixture.ts",
+    'import { foo } from "./x";\nimport type { Bar } from "./y";\nconst a = foo();\n',
+    false,
+  );
+
+  t.assert.match(result.code, /import \{ foo \} from "\.\/x"/);
+  t.assert.equal(result.code.includes("Bar"), false);
+  t.assert.equal(result.code.includes("./y"), false);
+});
+
+void test("stripTypeScript returns a source map only when sourceMap is true", async (t) => {
+  const withMap = await stripTypeScript("fixture.ts", "const count: number = 1;\n", true);
+  const withoutMap = await stripTypeScript("fixture.ts", "const count: number = 1;\n", false);
+
+  t.assert.notEqual(withMap.map, null);
+  t.assert.equal(withoutMap.map, null);
+  // code is identical regardless of the sourceMap flag
+  t.assert.equal(withMap.code, withoutMap.code);
+  t.assert.match(withMap.code, /const count = 1/);
+});
+
+void test("stripTypeScript rejects on syntactically invalid TypeScript", async (t) => {
+  await t.assert.rejects(() => stripTypeScript("fixture.ts", "const a: = ;\n", false), /Error/);
+});

--- a/npm/unplugin-vize/src/template-preprocessors.test.ts
+++ b/npm/unplugin-vize/src/template-preprocessors.test.ts
@@ -1,0 +1,147 @@
+import { test } from "node:test";
+import "./test/setup.ts";
+import { vizeUnplugin } from "./unplugin.ts";
+import { packageRoot } from "./test/helpers.ts";
+
+function createPlugin() {
+  return vizeUnplugin.raw(
+    {
+      isProduction: true,
+      root: packageRoot,
+    },
+    {
+      framework: "rollup",
+    },
+  );
+}
+
+// Runs the full transform pipeline (compileSfc -> generateOutput -> oxc strip-types)
+// against an inline SFC source. The `.vue` path only has to end in `.vue` and stay
+// out of `node_modules`; the source is passed directly, so no fixture file is needed.
+async function transformSfc(source: string, fileName: string) {
+  const plugin = createPlugin();
+  const warnings: string[] = [];
+  const result = await plugin.transform?.call(
+    {
+      warn(message: string) {
+        warnings.push(message);
+      },
+    } as never,
+    source,
+    `${packageRoot}/${fileName}`,
+  );
+  return { result, warnings };
+}
+
+// NOTE on observed behavior: the native compiler accepts `<template lang="pug">`
+// without throwing or warning, but it does NOT actually parse the Pug grammar.
+// Pug element/attribute markup (e.g. `div.box`, `span(:title="msg")`) leaks through
+// verbatim as plain template text, while `{{ }}` interpolation is still resolved.
+// These tests therefore assert what the pipeline REALLY produces today: it compiles
+// cleanly (no throw, no warnings), strips TypeScript, and emits a Vue render output.
+// They intentionally do NOT assert that Pug markup is gone, because it is not.
+
+void test("pug template flows through the transform without warnings or errors", async (t) => {
+  const source = `<template lang="pug">
+div.box Hello {{ msg }}
+  span(:title="msg") world
+</template>
+<script setup>
+const msg = "x"
+</script>
+`;
+  const { result, warnings } = await transformSfc(source, "pug-basic.vue");
+
+  t.assert.ok(result && typeof result === "object", "transform should return a result object");
+  t.assert.equal(typeof result.code, "string");
+  t.assert.ok(result.code.length > 0, "generated code should be non-empty");
+
+  // No warnings were collected during compilation.
+  t.assert.deepStrictEqual(warnings, []);
+
+  // A render output is produced: the SFC descriptor object plus a runtime render
+  // helper import. (Vize inlines the render fn inside `setup`; there is no top-level
+  // `render` identifier, so we assert on the actual shape.)
+  t.assert.match(result.code, /_sfc_main/);
+  t.assert.match(result.code, /setup\(__props\)/);
+  t.assert.match(result.code, /_createElementBlock/);
+  t.assert.match(result.code, /from "vue"/);
+
+  // `{{ msg }}` interpolation was resolved into a real binding reference.
+  t.assert.match(result.code, /_toDisplayString\(msg\)/);
+
+  // No leftover TS-only syntax in this JS `<script setup>` case.
+  t.assert.doesNotMatch(result.code, /\binterface\b/);
+});
+
+void test("pug template with script setup lang=ts strips all TypeScript", async (t) => {
+  const source = `<template lang="pug">
+div.box Hello {{ msg }}
+  span(:title="msg") world
+</template>
+<script setup lang="ts">
+interface Foo { a: number }
+const msg: string = "x"
+const f: Foo = { a: 1 }
+</script>
+`;
+  const { result, warnings } = await transformSfc(source, "pug-ts.vue");
+
+  t.assert.ok(result && typeof result === "object");
+  t.assert.ok(result.code.length > 0, "generated code should be non-empty");
+  t.assert.deepStrictEqual(warnings, []);
+
+  // The `interface` declaration and all type annotations must be gone after oxc strip.
+  t.assert.doesNotMatch(result.code, /\binterface\b/);
+  t.assert.doesNotMatch(result.code, /:\s*string/);
+  t.assert.doesNotMatch(result.code, /:\s*Foo/);
+
+  // Runtime values survive the strip.
+  t.assert.match(result.code, /const msg = "x"/);
+  t.assert.match(result.code, /const f = \{ a: 1 \}/);
+
+  // Still produces a render output.
+  t.assert.match(result.code, /_sfc_main/);
+  t.assert.match(result.code, /_createElementBlock/);
+});
+
+void test("pug template with a scoped style compiles successfully", async (t) => {
+  const source = `<template lang="pug">
+div.box Hello {{ msg }}
+</template>
+<script setup>
+const msg = "x"
+</script>
+<style scoped>
+.box { color: red; }
+</style>
+`;
+  const { result, warnings } = await transformSfc(source, "pug-scoped.vue");
+
+  t.assert.ok(result && typeof result === "object");
+  t.assert.ok(result.code.length > 0, "generated code should be non-empty");
+  t.assert.deepStrictEqual(warnings, []);
+
+  // A scope id is wired up for the scoped style; we do not over-assert the CSS itself.
+  t.assert.match(result.code, /__scopeId/);
+});
+
+void test("the same markup as a standard (non-pug) template also compiles", async (t) => {
+  const source = `<template>
+<div class="box">Hello {{ msg }}<span :title="msg">world</span></div>
+</template>
+<script setup>
+const msg = "x"
+</script>
+`;
+  const { result, warnings } = await transformSfc(source, "standard.vue");
+
+  t.assert.ok(result && typeof result === "object");
+  t.assert.ok(result.code.length > 0, "generated code should be non-empty");
+  t.assert.deepStrictEqual(warnings, []);
+
+  // The standard parser produces a real `div` element (contrast with the pug path,
+  // where `div.box` is emitted as plain text).
+  t.assert.match(result.code, /_createElementBlock\("div"/);
+  t.assert.match(result.code, /_toDisplayString\(msg\)/);
+});

--- a/npm/unplugin-vize/src/vapor.test.ts
+++ b/npm/unplugin-vize/src/vapor.test.ts
@@ -1,0 +1,123 @@
+import { test } from "node:test";
+import { vizeUnplugin } from "./unplugin.ts";
+import { packageRoot } from "./test/helpers.ts";
+
+interface TransformResult {
+  code: string;
+  map?: unknown;
+}
+
+function createPlugin(vapor: boolean) {
+  return vizeUnplugin.raw(
+    {
+      isProduction: true,
+      root: packageRoot,
+      vapor,
+    },
+    {
+      framework: "rollup",
+    },
+  );
+}
+
+async function runTransform(
+  vapor: boolean,
+  source: string,
+  id: string,
+): Promise<{ result: TransformResult | null; warnings: string[] }> {
+  const plugin = createPlugin(vapor);
+  const warnings: string[] = [];
+  const transform = plugin.transform;
+  if (typeof transform !== "function") {
+    throw new Error("plugin.transform is not a function");
+  }
+  const result = (await transform.call(
+    {
+      warn(message: string) {
+        warnings.push(message);
+      },
+    } as never,
+    source,
+    id,
+  )) as TransformResult | null;
+  return { result, warnings };
+}
+
+const VAPOR_SFC =
+  "<template><div>{{ n }}</div></template>\n" + "<script setup>\nconst n = 1\n</script>";
+
+void test("vapor:true flows through the transform and emits non-empty code without warnings", async (t) => {
+  const { result, warnings } = await runTransform(true, VAPOR_SFC, "/proj/Vapor.vue");
+
+  t.assert.ok(result && typeof result === "object", "transform returns a result object");
+  t.assert.equal(typeof result.code, "string");
+  t.assert.ok(result.code.length > 0, "emitted code is non-empty");
+  t.assert.deepStrictEqual(warnings, [], "no warnings are emitted");
+
+  // Concrete vapor markers observed in the compiled output: the vapor runtime
+  // entry helper and the static template helper.
+  t.assert.match(
+    result.code,
+    /defineVaporComponent/,
+    "vapor output imports the vapor component helper",
+  );
+  t.assert.match(result.code, /_template\(/, "vapor output uses the static template helper");
+});
+
+void test("vapor codegen differs from vdom codegen for the same SFC", async (t) => {
+  const vapor = await runTransform(true, VAPOR_SFC, "/proj/Vapor.vue");
+  const vdom = await runTransform(false, VAPOR_SFC, "/proj/Vapor.vue");
+
+  t.assert.ok(vapor.result && typeof vapor.result === "object");
+  t.assert.ok(vdom.result && typeof vdom.result === "object");
+
+  const vaporCode = vapor.result.code;
+  const vdomCode = vdom.result.code;
+
+  // The two distinct codegen backends must not produce identical output.
+  t.assert.notEqual(vaporCode, vdomCode, "vapor and vdom outputs differ");
+
+  // Vapor-specific marker present only in the vapor output.
+  t.assert.match(vaporCode, /defineVaporComponent/, "vapor output has defineVaporComponent");
+  t.assert.doesNotMatch(
+    vdomCode,
+    /defineVaporComponent/,
+    "vdom output does not have defineVaporComponent",
+  );
+
+  // vdom-specific marker present only in the vdom output: the block-based
+  // element factory from the virtual-DOM runtime.
+  t.assert.match(vdomCode, /createElementBlock/, "vdom output uses createElementBlock");
+  t.assert.doesNotMatch(
+    vaporCode,
+    /createElementBlock/,
+    "vapor output does not use createElementBlock",
+  );
+});
+
+void test('vapor SFC with <script setup lang="ts"> compiles and strips TS', async (t) => {
+  const tsSource =
+    "<template><div>{{ n }}</div></template>\n" +
+    '<script setup lang="ts">\n' +
+    "const n: number = 1\n" +
+    "const label = (x: number): string => String(x)\n" +
+    "</script>";
+
+  const { result, warnings } = await runTransform(true, tsSource, "/proj/VaporTs.vue");
+
+  t.assert.ok(result && typeof result === "object", "typed vapor SFC compiles");
+  t.assert.ok(result.code.length > 0, "emitted code is non-empty");
+  t.assert.deepStrictEqual(warnings, [], "no warnings are emitted");
+
+  // Still a vapor build.
+  t.assert.match(result.code, /defineVaporComponent/, "typed vapor output is vapor codegen");
+
+  // TS type annotations are stripped from the emitted JS.
+  t.assert.doesNotMatch(result.code, /:\s*number/, "type annotation on const is stripped");
+  t.assert.doesNotMatch(result.code, /:\s*string/, "return type annotation is stripped");
+  t.assert.doesNotMatch(result.code, /lang="ts"/, "lang attribute does not leak into output");
+
+  // The runtime bindings survive the strip.
+  t.assert.match(result.code, /const n = 1/, "value binding is preserved after stripping types");
+  t.assert.match(result.code, /String\(x\)/, "arrow body is preserved after stripping types");
+});


### PR DESCRIPTION
## What

Adds TypeScript / template-preprocessor / Vapor edge-case tests for `@vizejs/unplugin`.

New files (`node --test`):
- `src/strip-types-edge.test.ts` — `stripTypeScript` (oxc-transform): type elision, `satisfies`/`as`/non-null `!`, generics/interface/alias removal, enum + namespace downleveling, value-import retention, sourceMap toggle, invalid-TS reject path (9 cases)
- `src/template-preprocessors.test.ts` — Pug SFCs through the full transform (4 cases)
- `src/vapor.test.ts` — `vapor:true` flows through transform, produces codegen distinct from vdom, strips TS (3 cases)

> [!NOTE]
> **Finding pinned by these tests:** `<template lang="pug">` is currently accepted (no error/warning) but **not actually parsed** — Pug element/attribute syntax (`div.box`, `span(:title=…)`) leaks through as plain text; only `{{ }}` interpolation resolves. The standard (non-pug) equivalent compiles to a real element block. The test asserts the current behavior; if Pug support is implemented, this test should be updated.

## Verify
`cd npm/unplugin-vize && node --test 'src/*.test.ts'` → all green; `oxlint`/`oxfmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1114"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783429373&installation_id=136613492&pr_number=1114&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1114&signature=de6c113d4710291145821aa159194a908d2f41d681bd7f7bd702c9a2f43bcfa6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->