### PR TITLE
test(nuxt): cover options/components/i18n/utils/dev-html/unocss edge cases

### DIFF
--- a/npm/nuxt/src/components-edge.test.ts
+++ b/npm/nuxt/src/components-edge.test.ts
@@ -1,0 +1,467 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  createNuxtComponentResolver,
+  injectNuxtComponentImports,
+  type NuxtComponentImport,
+} from "./components.ts";
+
+// All injection tests below use a hand-written resolve stub so they are entirely
+// filesystem-free: injectNuxtComponentImports never touches disk, it only calls
+// back into the supplied resolver. The descriptor shape is exactly the
+// NuxtComponentImport interface declared in components.ts.
+function stubResolver(
+  table: Record<string, NuxtComponentImport>,
+): (name: string) => NuxtComponentImport | null {
+  return (name) => table[name] ?? null;
+}
+
+void test("injection leaves code without component usage unchanged", () => {
+  const code = "export const x = 1;\nconst y = x + 1;\n";
+  const resolve = stubResolver({
+    Foo: { exportName: "default", filePath: "/virtual/Foo.vue" },
+  });
+
+  const transformed = injectNuxtComponentImports(code, resolve);
+
+  assert.equal(
+    transformed,
+    code,
+    "code with no resolveComponent() and no #components import should be returned verbatim",
+  );
+});
+
+void test("injection replaces literal resolveComponent() but not a dynamic argument", () => {
+  const resolve = stubResolver({
+    Foo: { exportName: "default", filePath: "/virtual/Foo.vue" },
+  });
+
+  const literal = injectNuxtComponentImports(`const c = resolveComponent("Foo");`, resolve);
+  assert.match(
+    literal,
+    /import __nuxt_component_0 from "\/virtual\/Foo\.vue";/,
+    "literal-string resolveComponent should become a direct import binding",
+  );
+  assert.equal(
+    literal.includes('resolveComponent("Foo")'),
+    false,
+    "the resolveComponent() call should be replaced by the bound variable",
+  );
+  assert.match(literal, /const c = __nuxt_component_0;/, "the call site should use the binding");
+
+  // A non-literal argument cannot be statically resolved, so it is left intact.
+  const dynamicSource = `const c = resolveComponent(dynamicVar);`;
+  const dynamic = injectNuxtComponentImports(dynamicSource, resolve);
+  assert.equal(
+    dynamic,
+    dynamicSource,
+    "resolveComponent(<identifier>) with a non-literal argument should be left untouched",
+  );
+});
+
+void test("injection resolves _resolveComponent and a second-argument call", () => {
+  const resolve = stubResolver({
+    Foo: { exportName: "default", filePath: "/virtual/Foo.vue" },
+  });
+
+  // The compiler often emits the private _resolveComponent helper name.
+  const underscored = injectNuxtComponentImports(`const c = _resolveComponent("Foo");`, resolve);
+  assert.match(
+    underscored,
+    /import __nuxt_component_0 from "\/virtual\/Foo\.vue";/,
+    "_resolveComponent should be rewritten the same as resolveComponent",
+  );
+
+  // resolveComponent("Foo", maybeSelfReference) is also matched.
+  const withSecondArg = injectNuxtComponentImports(
+    `const c = resolveComponent("Foo", true);`,
+    resolve,
+  );
+  assert.match(
+    withSecondArg,
+    /import __nuxt_component_0 from "\/virtual\/Foo\.vue";/,
+    "resolveComponent() with a trailing argument should still be rewritten",
+  );
+  assert.equal(
+    withSecondArg.includes("resolveComponent"),
+    false,
+    "the entire resolveComponent(...) call (including the second argument) should be replaced",
+  );
+});
+
+void test("injection resolves a named (non-default) export via aliased import", () => {
+  const resolve = stubResolver({
+    Named: { exportName: "MyNamed", filePath: "/virtual/Named.js" },
+  });
+
+  const transformed = injectNuxtComponentImports(`const c = resolveComponent("Named");`, resolve);
+  assert.match(
+    transformed,
+    /import \{ MyNamed as __nuxt_component_0 \} from "\/virtual\/Named\.js";/,
+    "a non-default exportName should be imported as a named binding aliased to the component var",
+  );
+});
+
+void test("injection dedupes repeated resolveComponent() of the same component", () => {
+  const resolve = stubResolver({
+    AppHeader: { exportName: "default", filePath: "/virtual/AppHeader.vue" },
+  });
+
+  const transformed = injectNuxtComponentImports(
+    `const first = resolveComponent("AppHeader");\n` +
+      `const second = resolveComponent("AppHeader");\n` +
+      `const third = resolveComponent("AppHeader");\n`,
+    resolve,
+  );
+
+  assert.equal(
+    transformed.match(/import __nuxt_component_0 from "\/virtual\/AppHeader\.vue";/g)?.length,
+    1,
+    "a reused component should emit exactly one import statement",
+  );
+  assert.equal(
+    transformed.match(/__nuxt_component_0\b/g)?.length,
+    4,
+    "the shared binding name appears once in the single import plus at each of the three call sites",
+  );
+});
+
+void test("injection wraps a .client component with createClientOnly", () => {
+  const resolve = stubResolver({
+    Widget: {
+      exportName: "default",
+      filePath: "/virtual/Widget.client.vue",
+      mode: "client",
+    },
+  });
+
+  const transformed = injectNuxtComponentImports(`const c = resolveComponent("Widget");`, resolve);
+
+  assert.match(
+    transformed,
+    /import \{ createClientOnly as __nuxt_create_client_only \} from "#app\/components\/client-only";/,
+    "client-mode components should import the createClientOnly helper",
+  );
+  assert.match(
+    transformed,
+    /import __nuxt_component_0_raw from "\/virtual\/Widget\.client\.vue";/,
+    "the raw default export should be imported under a _raw binding",
+  );
+  assert.match(
+    transformed,
+    /const __nuxt_component_0 = __nuxt_create_client_only\(__nuxt_component_0_raw\);/,
+    "the bound component variable should be the wrapped client-only component",
+  );
+});
+
+void test("injection does NOT wrap a NuxtRouteAnnouncer-style .js client component", () => {
+  // Mode is client, but the file matches the nuxt-route-announcer special case,
+  // so it must be imported directly to preserve its own scoped default slot.
+  const resolve = stubResolver({
+    NuxtRouteAnnouncer: {
+      exportName: "default",
+      filePath: "/pkg/nuxt/dist/app/components/nuxt-route-announcer.js",
+      mode: "client",
+    },
+  });
+
+  const transformed = injectNuxtComponentImports(
+    `const c = resolveComponent("NuxtRouteAnnouncer");`,
+    resolve,
+  );
+
+  assert.match(
+    transformed,
+    /import __nuxt_component_0 from ".*nuxt-route-announcer\.js";/,
+    "NuxtRouteAnnouncer should be imported directly",
+  );
+  assert.equal(
+    transformed.includes("__nuxt_create_client_only"),
+    false,
+    "NuxtRouteAnnouncer must not be wrapped with createClientOnly even though mode is client",
+  );
+});
+
+void test("injection wraps a lazy component with defineAsyncComponent", () => {
+  const resolve = stubResolver({
+    Lazy: { exportName: "default", filePath: "/virtual/Lazy.vue", lazy: true },
+  });
+
+  const transformed = injectNuxtComponentImports(`const c = resolveComponent("Lazy");`, resolve);
+
+  assert.match(
+    transformed,
+    /import \{ defineAsyncComponent as __nuxt_define_async_component \} from "vue";/,
+    "lazy components should import the defineAsyncComponent helper",
+  );
+  assert.match(
+    transformed,
+    /const __nuxt_component_0 = __nuxt_define_async_component\(\(\) => import\("\/virtual\/Lazy\.vue"\)\.then\(\(module\) => module\.default\)\);/,
+    "lazy resolution should defer the import and read the default export from the module",
+  );
+  assert.equal(
+    transformed.includes("__nuxt_create_client_only"),
+    false,
+    "a lazy non-client component should not pull in the createClientOnly helper",
+  );
+});
+
+void test("injection wraps a lazy client component with both async and client helpers", () => {
+  const resolve = stubResolver({
+    LazyWidget: {
+      exportName: "default",
+      filePath: "/virtual/Widget.client.vue",
+      lazy: true,
+      mode: "client",
+    },
+  });
+
+  const transformed = injectNuxtComponentImports(
+    `const c = resolveComponent("LazyWidget");`,
+    resolve,
+  );
+
+  assert.match(
+    transformed,
+    /import \{ defineAsyncComponent as __nuxt_define_async_component \} from "vue";/,
+    "a lazy client component should import defineAsyncComponent",
+  );
+  assert.match(
+    transformed,
+    /import \{ createClientOnly as __nuxt_create_client_only \} from "#app\/components\/client-only";/,
+    "a lazy client component should import createClientOnly",
+  );
+  assert.match(
+    transformed,
+    /const __nuxt_component_0 = __nuxt_define_async_component\(\(\) => import\("\/virtual\/Widget\.client\.vue"\)\.then\(\(module\) => __nuxt_create_client_only\(module\.default\)\)\);/,
+    "the async payload should be wrapped with createClientOnly inside the .then()",
+  );
+});
+
+void test("injection rewrites import { Foo } from #components to a direct import", () => {
+  const resolve = stubResolver({
+    Foo: { exportName: "default", filePath: "/virtual/Foo.vue" },
+  });
+
+  const transformed = injectNuxtComponentImports(
+    `import { Foo } from "#components";\nconst use = Foo;\n`,
+    resolve,
+  );
+
+  assert.match(
+    transformed,
+    /import Foo from "\/virtual\/Foo\.vue";/,
+    "a resolved #components import should become a direct default import keeping the local name",
+  );
+  assert.equal(
+    transformed.includes('from "#components"'),
+    false,
+    "when every imported component resolves, the #components import should be fully removed",
+  );
+});
+
+void test("injection rewrites an aliased #components specifier (Foo as Bar)", () => {
+  const resolve = stubResolver({
+    Foo: { exportName: "default", filePath: "/virtual/Foo.vue" },
+  });
+
+  const transformed = injectNuxtComponentImports(
+    `import { Foo as Bar } from "#components";\nconst use = Bar;\n`,
+    resolve,
+  );
+
+  assert.match(
+    transformed,
+    /import Bar from "\/virtual\/Foo\.vue";/,
+    "the local alias (Bar) should be preserved as the direct import binding",
+  );
+  assert.equal(
+    transformed.includes('"#components"'),
+    false,
+    "the fully-resolved aliased import should be removed",
+  );
+});
+
+void test("injection leaves an empty #components import untouched", () => {
+  const source = `import {} from "#components";\nconst z = 1;\n`;
+  const resolve = stubResolver({
+    Foo: { exportName: "default", filePath: "/virtual/Foo.vue" },
+  });
+
+  const transformed = injectNuxtComponentImports(source, resolve);
+
+  assert.equal(
+    transformed,
+    source,
+    "an empty #components import has no specifiers to resolve, so nothing changes",
+  );
+});
+
+void test("injection leaves a type-only #components import untouched", () => {
+  const source = `import type { Foo } from "#components";\nconst z = 1;\n`;
+  const resolve = stubResolver({
+    Foo: { exportName: "default", filePath: "/virtual/Foo.vue" },
+  });
+
+  const transformed = injectNuxtComponentImports(source, resolve);
+
+  assert.equal(
+    transformed,
+    source,
+    "import type { ... } from #components is excluded by the import regex and stays as-is",
+  );
+});
+
+void test("injection keeps an all-unresolved #components import unchanged", () => {
+  const source = `import { Unknown } from "#components";\nconst z = 1;\n`;
+  const resolve = stubResolver({
+    Foo: { exportName: "default", filePath: "/virtual/Foo.vue" },
+  });
+
+  const transformed = injectNuxtComponentImports(source, resolve);
+
+  assert.equal(
+    transformed,
+    source,
+    "if no specifier resolves, the #components import (and the whole module) is returned verbatim",
+  );
+});
+
+void test("injection partially rewrites a mixed #components import, keeping the rest", () => {
+  const resolve = stubResolver({
+    Foo: { exportName: "default", filePath: "/virtual/Foo.vue" },
+  });
+
+  const transformed = injectNuxtComponentImports(
+    `import { Foo, Unknown } from "#components";\nconst z = 1;\n`,
+    resolve,
+  );
+
+  // Resolved specifier becomes a direct import emitted in the preamble.
+  assert.match(
+    transformed,
+    /import Foo from "\/virtual\/Foo\.vue";/,
+    "the resolved specifier should be lifted to a direct import",
+  );
+  // Unresolved specifier is re-emitted as a (regenerated) #components import.
+  assert.match(
+    transformed,
+    /import \{ Unknown \} from "#components";/,
+    "the unresolved specifier should remain a #components import",
+  );
+  // The regenerated leftover import always uses double quotes for #components,
+  // and the lifted direct import precedes the leftover import.
+  assert.ok(
+    transformed.indexOf('import Foo from "/virtual/Foo.vue";') <
+      transformed.indexOf('from "#components"'),
+    "the lifted direct import should precede the leftover #components import",
+  );
+});
+
+void test("injection re-emits a single-quoted #components import with double quotes", () => {
+  const resolve = stubResolver({
+    Foo: { exportName: "default", filePath: "/virtual/Foo.vue" },
+  });
+
+  const transformed = injectNuxtComponentImports(
+    `import { Foo, Unknown } from '#components';\nconst z = 1;\n`,
+    resolve,
+  );
+
+  assert.match(
+    transformed,
+    /import \{ Unknown \} from "#components";/,
+    "the regenerated leftover import normalizes the quote style to double quotes",
+  );
+  assert.equal(
+    transformed.includes("'#components'"),
+    false,
+    "the original single-quoted #components import should no longer be present",
+  );
+});
+
+void test("injection handles an inline-type specifier mixed with a value specifier", () => {
+  const resolve = stubResolver({
+    Foo: { exportName: "default", filePath: "/virtual/Foo.vue" },
+    Named: { exportName: "MyNamed", filePath: "/virtual/Named.js" },
+  });
+
+  const transformed = injectNuxtComponentImports(
+    `import { type Foo, Named } from "#components";\nconst z = 1;\n`,
+    resolve,
+  );
+
+  // `type Foo` is treated as type-only and left in #components; `Named` is lifted.
+  assert.match(
+    transformed,
+    /import \{ MyNamed as Named \} from "\/virtual\/Named\.js";/,
+    "the value specifier should be lifted to a direct named import",
+  );
+  assert.match(
+    transformed,
+    /import \{ type Foo \} from "#components";/,
+    "the inline type-only specifier should remain in the #components import",
+  );
+});
+
+void test("createNuxtComponentResolver register/resolve works without any filesystem", () => {
+  // buildDir/rootDir point at a path that does not exist; loadDtsComponents and
+  // loadRuntimeComponents simply find nothing, so register()/resolve() of a
+  // directly-registered component never touches disk.
+  const resolver = createNuxtComponentResolver({
+    buildDir: "/nonexistent-vize-test/.nuxt",
+    rootDir: "/nonexistent-vize-test",
+  });
+
+  resolver.register([
+    { pascalName: "AppHeader", filePath: "/virtual/AppHeader.vue", export: "default" },
+    {
+      pascalName: "MyWidget",
+      filePath: "/virtual/MyWidget.client.vue",
+      export: "default",
+      mode: "client",
+    },
+    { pascalName: "Detected", filePath: "/virtual/Detected.client.vue", export: "default" },
+  ]);
+
+  assert.deepEqual(
+    resolver.resolve("AppHeader"),
+    { exportName: "default", filePath: "/virtual/AppHeader.vue" },
+    "a registered component resolves by its pascal name",
+  );
+  assert.deepEqual(
+    resolver.resolve("app-header"),
+    { exportName: "default", filePath: "/virtual/AppHeader.vue" },
+    "register() should add a kebab-case alias",
+  );
+  assert.deepEqual(
+    resolver.resolve("LazyAppHeader"),
+    { exportName: "default", filePath: "/virtual/AppHeader.vue", lazy: true },
+    "register() should add a Lazy-prefixed alias flagged lazy",
+  );
+  assert.deepEqual(
+    resolver.resolve("MyWidget"),
+    { exportName: "default", filePath: "/virtual/MyWidget.client.vue", mode: "client" },
+    "an explicit client mode should be preserved on the registered import",
+  );
+  assert.deepEqual(
+    resolver.resolve("Detected"),
+    { exportName: "default", filePath: "/virtual/Detected.client.vue", mode: "client" },
+    "a .client.vue filePath should auto-detect client mode even without an explicit mode",
+  );
+
+  // Unknown lowercase names short-circuit to null before any filesystem fallback.
+  assert.equal(
+    resolver.resolve("zz-unknown"),
+    null,
+    "an unknown lowercase name should resolve to null without a runtime/dts lookup",
+  );
+  // Unknown uppercase names trigger the runtime fallback, which fails to require
+  // from the nonexistent rootDir and returns null (it must not throw).
+  assert.equal(
+    resolver.resolve("ZZUnknownComp"),
+    null,
+    "an unknown uppercase name should resolve to null when no runtime package is found",
+  );
+});

--- a/npm/nuxt/src/dev-html-edge.test.ts
+++ b/npm/nuxt/src/dev-html-edge.test.ts
@@ -1,0 +1,170 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { sanitizeNuxtDevStylesheetLinks } from "./dev-html.ts";
+
+void test("HTML without any <link> tags is returned unchanged", () => {
+  const html = `<!DOCTYPE html><html><head><title>x</title></head><body>hi</body></html>`;
+  assert.equal(
+    sanitizeNuxtDevStylesheetLinks(html),
+    html,
+    "markup without stylesheet links should pass through untouched",
+  );
+});
+
+void test("non-stylesheet <link> tags are never processed", () => {
+  // Only rel="stylesheet" links are matched by the sanitizer, so even an
+  // obviously unsafe href on a preload/icon link is left exactly as-is.
+  const preload = `<link rel="preload" href="/_nuxt/../etc.js">`;
+  assert.equal(
+    sanitizeNuxtDevStylesheetLinks(preload),
+    preload,
+    "rel=preload links should be ignored entirely",
+  );
+
+  const icon = `<link rel="icon" href="/_nuxt/../favicon.ico">`;
+  assert.equal(
+    sanitizeNuxtDevStylesheetLinks(icon),
+    icon,
+    "rel=icon links should be ignored entirely",
+  );
+});
+
+void test("single and double quotes on rel/href are both handled", () => {
+  const single = `<link rel='stylesheet' href='/_nuxt/assets/main.css'>`;
+  assert.equal(
+    sanitizeNuxtDevStylesheetLinks(single),
+    single,
+    "single-quoted valid stylesheet links should be kept verbatim",
+  );
+
+  const double = `<link rel="stylesheet" href="/_nuxt/assets/main.css">`;
+  assert.equal(
+    sanitizeNuxtDevStylesheetLinks(double),
+    double,
+    "double-quoted valid stylesheet links should be kept verbatim",
+  );
+});
+
+void test("allow-listed dev stylesheet paths are kept", () => {
+  const cases = [
+    `<link rel="stylesheet" href="/_nuxt/assets/main.css">`,
+    `<link rel="stylesheet" href="/_nuxt/@fs/Users/me/project/node_modules/pkg/style.css">`,
+    `<link rel="stylesheet" href="/_nuxt/@id/foo.css">`,
+    `<link rel="stylesheet" href="/_nuxt/virtual:uno.css">`,
+    `<link rel="stylesheet" href="/_nuxt/__uno.css">`,
+    `<link rel="stylesheet" href="/_nuxt/style.css">`,
+  ];
+  for (const tag of cases) {
+    assert.equal(
+      sanitizeNuxtDevStylesheetLinks(tag),
+      tag,
+      `allow-listed href should be preserved: ${tag}`,
+    );
+  }
+});
+
+void test("non-allow-listed sub-path under the assets dir is stripped", () => {
+  // A nested, non-css-named path under /_nuxt/ matches none of the allow-list
+  // prefixes (@fs/, @id/, assets/, virtual:) nor the single-segment *.css rule.
+  assert.equal(
+    sanitizeNuxtDevStylesheetLinks(`<link rel="stylesheet" href="/_nuxt/pkg/style.css">`),
+    "",
+    "an unrecognized nested path under the assets dir should be removed",
+  );
+});
+
+void test("duplicate identical hrefs are de-duplicated", () => {
+  assert.equal(
+    sanitizeNuxtDevStylesheetLinks(
+      `<link rel="stylesheet" href="/_nuxt/assets/main.css"><link rel="stylesheet" href="/_nuxt/assets/main.css">`,
+    ),
+    `<link rel="stylesheet" href="/_nuxt/assets/main.css">`,
+    "a repeated stylesheet href should only survive once",
+  );
+
+  // Dedupe is keyed on the raw href and applies even to external links that
+  // are otherwise always kept.
+  assert.equal(
+    sanitizeNuxtDevStylesheetLinks(
+      `<link rel="stylesheet" href="https://cdn.example.com/x.css"><link rel="stylesheet" href="https://cdn.example.com/x.css">`,
+    ),
+    `<link rel="stylesheet" href="https://cdn.example.com/x.css">`,
+    "duplicate external stylesheet hrefs are also collapsed",
+  );
+});
+
+void test("'..' traversal segments under the assets dir are stripped", () => {
+  assert.equal(
+    sanitizeNuxtDevStylesheetLinks(`<link rel="stylesheet" href="/_nuxt/assets/../secret.css">`),
+    "",
+    "a '..' segment in a sub-path should be rejected",
+  );
+  assert.equal(
+    sanitizeNuxtDevStylesheetLinks(`<link rel="stylesheet" href="/_nuxt/../etc.css">`),
+    "",
+    "a '..' segment directly after the assets dir should be rejected",
+  );
+});
+
+void test("URL-encoded traversal and encoded null bytes are decoded then rejected", () => {
+  assert.equal(
+    sanitizeNuxtDevStylesheetLinks(
+      `<link rel="stylesheet" href="/_nuxt/assets/%2e%2e/server.css">`,
+    ),
+    "",
+    "percent-encoded '..' should be decoded and rejected as traversal",
+  );
+  assert.equal(
+    sanitizeNuxtDevStylesheetLinks(`<link rel="stylesheet" href="/_nuxt/assets/%00secret.css">`),
+    "",
+    "a decoded null byte should be rejected",
+  );
+});
+
+void test("a fragment-only suffix is ignored when validating the path", () => {
+  // The path part is validated after stripping ?query and #fragment, so a
+  // valid css href with a fragment is kept and the fragment stays in the tag.
+  const tag = `<link rel="stylesheet" href="/_nuxt/assets/main.css#x">`;
+  assert.equal(
+    sanitizeNuxtDevStylesheetLinks(tag),
+    tag,
+    "a fragment should not change keep/strip outcome and should be preserved",
+  );
+});
+
+void test("custom buildAssetsDir is filtered while paths under other dirs pass through", () => {
+  // Only hrefs under the (normalized) custom dir are validated. A non-allow-listed
+  // sub-path under /_app/ is stripped; an allow-listed one is kept.
+  assert.equal(
+    sanitizeNuxtDevStylesheetLinks(
+      `<link rel="stylesheet" href="/_app/pkg/style.css"><link rel="stylesheet" href="/_app/assets/main.css">`,
+      "/_app/",
+    ),
+    `<link rel="stylesheet" href="/_app/assets/main.css">`,
+    "custom buildAssetsDir should gate sub-paths under that dir",
+  );
+
+  // SURPRISING: an href under the *default* /_nuxt/ dir is NOT under the custom
+  // /_app/ prefix, so it is treated as "external" and kept untouched rather than
+  // being stripped. The sanitizer only validates hrefs under the configured dir.
+  assert.equal(
+    sanitizeNuxtDevStylesheetLinks(
+      `<link rel="stylesheet" href="/_nuxt/assets/main.css">`,
+      "/_app/",
+    ),
+    `<link rel="stylesheet" href="/_nuxt/assets/main.css">`,
+    "an href outside the configured assets dir is left as-is, even if it looks like a Nuxt path",
+  );
+});
+
+void test("empty href is kept (treated as not under the assets dir)", () => {
+  // SURPRISING: href="" does not start with the normalized assets dir, so
+  // shouldKeepHref returns true and the empty stylesheet link survives.
+  const tag = `<link rel="stylesheet" href="">`;
+  assert.equal(
+    sanitizeNuxtDevStylesheetLinks(tag),
+    tag,
+    "an empty href is not stripped by the current implementation",
+  );
+});

--- a/npm/nuxt/src/i18n-edge.test.ts
+++ b/npm/nuxt/src/i18n-edge.test.ts
@@ -1,0 +1,143 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { injectNuxtI18nHelpers } from "./i18n.ts";
+
+// No i18n usage inside setup() => code returned completely unchanged.
+void test("leaves code untouched when no runtime i18n helper is used", () => {
+  const input = `
+export default {
+  setup(__props) {
+    const x = 1;
+  }
+}
+`;
+  assert.equal(injectNuxtI18nHelpers(input), input);
+});
+
+// No setup(__props) at all => code returned unchanged.
+void test("leaves code untouched when there is no setup(__props)", () => {
+  const input = `export default { data() { return {}; } }`;
+  assert.equal(injectNuxtI18nHelpers(input), input);
+});
+
+// Every helper maps to its destructure specifier exactly once, in source order.
+void test("injects all six helpers with the correct specifiers exactly once", () => {
+  const out = injectNuxtI18nHelpers(`
+export default {
+  setup(__props) {
+    $t("a"); $rt("b"); $d(new Date()); $n(1); $tm("c"); $te("d");
+  }
+}
+`);
+
+  assert.match(
+    out,
+    /const \{ t: \$t, rt: \$rt, d: \$d, n: \$n, tm: \$tm, te: \$te \} = useI18n\(\);/,
+    "all six helpers should be destructured with their canonical specifiers",
+  );
+  // Each specifier appears exactly once, and only a single useI18n() call is injected.
+  assert.equal(out.match(/useI18n\(\)/g)?.length, 1);
+  assert.equal(out.match(/t: \$t/g)?.length, 1);
+  assert.equal(out.match(/rt: \$rt/g)?.length, 1);
+  assert.equal(out.match(/te: \$te/g)?.length, 1);
+  assert.equal(out.match(/tm: \$tm/g)?.length, 1);
+});
+
+// Repeated uses of the same helper still produce a single specifier.
+void test("deduplicates repeated uses of the same helper", () => {
+  const out = injectNuxtI18nHelpers(`
+export default {
+  setup(__props) {
+    $t("a");
+    $t("b");
+    $t("c");
+  }
+}
+`);
+  assert.match(out, /const \{ t: \$t \} = useI18n\(\);/);
+  assert.equal(out.match(/t: \$t/g)?.length, 1);
+});
+
+// _ctx.$t(...) and this.$t(...) are template/options globals (preceded by "."),
+// excluded by the (?<![.\w]) lookbehind => no injection happens.
+void test("does not trigger on _ctx.$t or this.$t member access", () => {
+  const out = injectNuxtI18nHelpers(`
+export default {
+  setup(__props) {
+    return (_ctx) => _ctx.$t("x") + this.$t("y");
+  }
+}
+`);
+  assert.equal(out.includes("useI18n()"), false);
+  // Any "$t(" preceded by a word char (e.g. a custom member like foo.$t) is also ignored.
+  const memberOut = injectNuxtI18nHelpers(`
+export default {
+  setup(__props) {
+    foo.$t("x");
+  }
+}
+`);
+  assert.equal(memberOut.includes("useI18n()"), false);
+});
+
+// Existing destructure, then a NEW helper used AFTER it => merged into the existing
+// destructure rather than emitting a second useI18n() call.
+void test("merges a later helper into an existing useI18n destructure", () => {
+  const out = injectNuxtI18nHelpers(`
+export default {
+  setup(__props) {
+    const { t: $t } = useI18n();
+    $d(new Date());
+  }
+}
+`);
+  assert.match(out, /const \{ t: \$t, d: \$d \} = useI18n\(\);/);
+  assert.equal(out.match(/useI18n\(\)/g)?.length, 1, "no duplicate useI18n() should be emitted");
+});
+
+// Existing destructure but the helper use appears BEFORE it => a new const is injected
+// at the top of setup, and the user-authored destructure below is left in place.
+// Observed ordering side effect: this yields TWO useI18n() calls.
+void test("injects above setup when a helper is used before the existing destructure", () => {
+  const out = injectNuxtI18nHelpers(`
+export default {
+  setup(__props) {
+    $d(new Date());
+    const { t: $t } = useI18n();
+  }
+}
+`);
+  // Injected const sits right after the setup signature, before the first use.
+  assert.match(out, /setup\(__props\) \{\nconst \{ d: \$d \} = useI18n\(\);\n/);
+  // The pre-existing destructure is preserved untouched.
+  assert.match(out, /const \{ t: \$t \} = useI18n\(\);/);
+  // Observed behavior: the early-use branch does not merge, so two calls coexist.
+  assert.equal(out.match(/useI18n\(\)/g)?.length, 2);
+});
+
+// SURPRISING (text-based regex): a "$t(" that lives only inside a string literal still
+// matches and triggers injection, because the transform never parses JS.
+void test("matches helper-looking text inside a string literal (no JS parsing)", () => {
+  const out = injectNuxtI18nHelpers(`
+export default {
+  setup(__props) {
+    const s = "call $t() here";
+  }
+}
+`);
+  assert.match(out, /const \{ t: \$t \} = useI18n\(\);/);
+});
+
+// SURPRISING (text-based regex): a "$d(" inside a line comment also triggers injection.
+void test("matches helper-looking text inside a comment (no JS parsing)", () => {
+  const out = injectNuxtI18nHelpers(`
+export default {
+  setup(__props) {
+    // use $d() somewhere
+    const x = 1;
+  }
+}
+`);
+  assert.match(out, /const \{ d: \$d \} = useI18n\(\);/);
+});

--- a/npm/nuxt/src/options-edge.test.ts
+++ b/npm/nuxt/src/options-edge.test.ts
@@ -1,0 +1,253 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  DEFAULT_NUXT_BRIDGE_OPTIONS,
+  NUXT_OG_IMAGE_RENDERER_SFC_EXCLUDE,
+  resolveNuxtBridgeOptions,
+  resolveNuxtCompilerOptions,
+  resolveNuxtDevOptions,
+  resolveNuxtMuseaOptions,
+  resolveNuxtUnoCssOptions,
+} from "./options.ts";
+
+void test("resolveNuxtCompilerOptions merges an internal baseURL with buildAssetsDir into devUrlBase", () => {
+  const resolved = resolveNuxtCompilerOptions("/repo/app", "/2025/docs/", "_nuxt", true);
+  assert.notEqual(resolved, false, "compiler should stay enabled");
+  assert.deepEqual(
+    resolved,
+    {
+      devUrlBase: "/2025/docs/_nuxt/",
+      exclude: NUXT_OG_IMAGE_RENDERER_SFC_EXCLUDE,
+      root: "/repo/app",
+      scanPatterns: [],
+    },
+    "an internal baseURL should prefix the normalized buildAssetsDir",
+  );
+});
+
+void test("resolveNuxtCompilerOptions defaults buildAssetsDir only when undefined, not when empty", () => {
+  assert.deepEqual(
+    resolveNuxtCompilerOptions("/repo/app", "/", undefined, true),
+    {
+      devUrlBase: "/_nuxt/",
+      exclude: NUXT_OG_IMAGE_RENDERER_SFC_EXCLUDE,
+      root: "/repo/app",
+      scanPatterns: [],
+    },
+    "undefined buildAssetsDir should fall back to /_nuxt/",
+  );
+
+  assert.deepEqual(
+    resolveNuxtCompilerOptions("/repo/app", "/", "", true),
+    {
+      devUrlBase: "/",
+      exclude: NUXT_OG_IMAGE_RENDERER_SFC_EXCLUDE,
+      root: "/repo/app",
+      scanPatterns: [],
+    },
+    "an empty buildAssetsDir normalizes to a bare / instead of /_nuxt/",
+  );
+});
+
+void test("resolveNuxtCompilerOptions treats Vue 0.11 as host-compiler legacy", () => {
+  assert.deepEqual(
+    resolveNuxtCompilerOptions("/repo/app", "/", "/_nuxt/", true, {
+      supportsViteCompiler: true,
+      vueVersion: 0.11,
+    }),
+    {
+      compatibility: {
+        vueVersion: 0.11,
+        hostCompiler: true,
+      },
+      devUrlBase: "/_nuxt/",
+      exclude: NUXT_OG_IMAGE_RENDERER_SFC_EXCLUDE,
+      root: "/repo/app",
+      scanPatterns: [],
+      vueVersion: 0.11,
+    },
+    "the oldest legacy Vue version should enable host-compiler mode",
+  );
+});
+
+void test("resolveNuxtCompilerOptions treats the legacy string Vue version as host-compiler", () => {
+  assert.deepEqual(
+    resolveNuxtCompilerOptions("/repo/app", "/", "/_nuxt/", true, {
+      supportsViteCompiler: true,
+      vueVersion: "legacy",
+    }),
+    {
+      compatibility: {
+        vueVersion: "legacy",
+        hostCompiler: true,
+      },
+      devUrlBase: "/_nuxt/",
+      exclude: NUXT_OG_IMAGE_RENDERER_SFC_EXCLUDE,
+      root: "/repo/app",
+      scanPatterns: [],
+      vueVersion: "legacy",
+    },
+    "the legacy string Vue version should enable host-compiler mode",
+  );
+});
+
+void test("resolveNuxtCompilerOptions disables Vite for Nuxt 2 without a Vite builder", () => {
+  assert.equal(
+    resolveNuxtCompilerOptions("/repo/app", "/", "/_nuxt/", true, {
+      supportsViteCompiler: false,
+      nuxtVersion: 2,
+    }),
+    false,
+    "Nuxt 2 without supportsViteCompiler and without forceViteCompiler should not register Vite",
+  );
+});
+
+void test("resolveNuxtCompilerOptions keeps the Takumi exclude when overrides.exclude is an empty array", () => {
+  assert.deepEqual(
+    resolveNuxtCompilerOptions("/repo/app", "/", "/_nuxt/", { exclude: [] }),
+    {
+      devUrlBase: "/_nuxt/",
+      exclude: [NUXT_OG_IMAGE_RENDERER_SFC_EXCLUDE],
+      root: "/repo/app",
+      scanPatterns: [],
+    },
+    "an empty user exclude array still merges the Takumi OG-image exclude",
+  );
+});
+
+void test("resolveNuxtCompilerOptions drops the Takumi exclude when customRenderer is true", () => {
+  const resolved = resolveNuxtCompilerOptions("/repo/app", "/", "/_nuxt/", {
+    customRenderer: true,
+  });
+  assert.deepEqual(
+    resolved,
+    {
+      customRenderer: true,
+      devUrlBase: "/_nuxt/",
+      root: "/repo/app",
+      scanPatterns: [],
+    },
+    "customRenderer without a user exclude should omit exclude entirely",
+  );
+  assert.equal(
+    Object.prototype.hasOwnProperty.call(resolved, "exclude"),
+    false,
+    "no exclude key should be present for a custom renderer",
+  );
+});
+
+void test("resolveNuxtCompilerOptions with empty overrides preserves the bare Takumi exclude default", () => {
+  assert.deepEqual(
+    resolveNuxtCompilerOptions("/repo/app", "/", "/_nuxt/", {}),
+    {
+      devUrlBase: "/_nuxt/",
+      exclude: NUXT_OG_IMAGE_RENDERER_SFC_EXCLUDE,
+      root: "/repo/app",
+      scanPatterns: [],
+    },
+    "empty overrides should not clobber the default Takumi exclude (kept as the bare regex)",
+  );
+});
+
+void test("resolveNuxtBridgeOptions returns every flag false when bridge is false", () => {
+  assert.deepEqual(
+    resolveNuxtBridgeOptions(false),
+    {
+      autoImports: false,
+      components: false,
+      i18n: false,
+      stableInjectedKeys: false,
+    },
+    "bridge=false should disable all four transform bridges",
+  );
+});
+
+void test("resolveNuxtBridgeOptions returns enabled defaults for true, null, and undefined", () => {
+  const expected = { ...DEFAULT_NUXT_BRIDGE_OPTIONS };
+  assert.deepEqual(resolveNuxtBridgeOptions(true), expected, "bridge=true uses defaults");
+  assert.deepEqual(resolveNuxtBridgeOptions(null), expected, "bridge=null uses defaults");
+  assert.deepEqual(resolveNuxtBridgeOptions(undefined), expected, "bridge=undefined uses defaults");
+});
+
+void test("resolveNuxtBridgeOptions merges a partial object and treats explicit undefined as default", () => {
+  assert.deepEqual(
+    resolveNuxtBridgeOptions({ autoImports: false }),
+    {
+      autoImports: false,
+      components: true,
+      i18n: true,
+      stableInjectedKeys: true,
+    },
+    "a single false flag should merge while the rest stay defaulted to true",
+  );
+
+  assert.deepEqual(
+    resolveNuxtBridgeOptions({ i18n: undefined }),
+    { ...DEFAULT_NUXT_BRIDGE_OPTIONS },
+    "an explicitly undefined flag should fall back to its default",
+  );
+});
+
+void test("resolveNuxtUnoCssOptions resolves false, true/null, and originalSource variants", () => {
+  assert.equal(resolveNuxtUnoCssOptions(false), false, "false disables the UnoCSS bridge");
+  assert.deepEqual(resolveNuxtUnoCssOptions(true), { originalSource: {} }, "true enables defaults");
+  assert.deepEqual(resolveNuxtUnoCssOptions(null), { originalSource: {} }, "null enables defaults");
+  assert.deepEqual(
+    resolveNuxtUnoCssOptions({ originalSource: false }),
+    { originalSource: false },
+    "originalSource=false is preserved verbatim",
+  );
+  assert.deepEqual(
+    resolveNuxtUnoCssOptions({ originalSource: true }),
+    { originalSource: {} },
+    "originalSource=true normalizes to an empty options object",
+  );
+  assert.deepEqual(
+    resolveNuxtUnoCssOptions({ originalSource: null }),
+    { originalSource: {} },
+    "originalSource=null normalizes to an empty options object",
+  );
+});
+
+void test("resolveNuxtUnoCssOptions passes an originalSource object through, including maxBytes 0", () => {
+  assert.deepEqual(
+    resolveNuxtUnoCssOptions({ originalSource: { maxBytes: 0 } }),
+    { originalSource: { maxBytes: 0 } },
+    "a falsy-but-present maxBytes:0 should survive the passthrough",
+  );
+});
+
+void test("resolveNuxtDevOptions defaults for null, undefined, and empty object", () => {
+  const expected = { stylesheetLinks: true };
+  assert.deepEqual(resolveNuxtDevOptions(null), expected, "null yields defaults");
+  assert.deepEqual(resolveNuxtDevOptions(undefined), expected, "undefined yields defaults");
+  assert.deepEqual(resolveNuxtDevOptions({}), expected, "empty object yields defaults");
+});
+
+void test("resolveNuxtDevOptions honors explicit stylesheetLinks and spreads unknown fields through", () => {
+  assert.deepEqual(
+    resolveNuxtDevOptions({ stylesheetLinks: false }),
+    { stylesheetLinks: false },
+    "explicit stylesheetLinks:false should be honored",
+  );
+
+  // Observed behavior: unknown fields are NOT stripped despite the Required<VizeNuxtDevOptions>
+  // return type; the implementation spreads `...dev` so extra keys leak through at runtime.
+  assert.deepEqual(
+    resolveNuxtDevOptions({ stylesheetLinks: true, unknownField: 123 } as never),
+    { stylesheetLinks: true, unknownField: 123 },
+    "extra unknown fields are spread through unchanged",
+  );
+});
+
+void test("resolveNuxtMuseaOptions resolves true, false/null, and object passthrough", () => {
+  assert.deepEqual(resolveNuxtMuseaOptions(true), {}, "true enables Musea with empty defaults");
+  assert.equal(resolveNuxtMuseaOptions(false), false, "false disables Musea");
+  assert.equal(resolveNuxtMuseaOptions(null), false, "null disables Musea");
+  assert.deepEqual(
+    resolveNuxtMuseaOptions({ include: ["**/*.art.vue"] }),
+    { include: ["**/*.art.vue"] },
+    "an object should pass through unchanged",
+  );
+});

--- a/npm/nuxt/src/unocss-edge.test.ts
+++ b/npm/nuxt/src/unocss-edge.test.ts
@@ -1,0 +1,164 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { appendOriginalVueSourceForUnoCss, MAX_UNOCSS_ORIGINAL_SOURCE_BYTES } from "./unocss.ts";
+
+void test("UnoCSS bridge strips multi-param query and reads the bare path", () => {
+  let seenPath: string | undefined;
+  const result = appendOriginalVueSourceForUnoCss("compiled", "/path/App.vue?foo=1&bar=2", {
+    maxBytes: 1024,
+    readSize: (filePath) => {
+      seenPath = filePath;
+      return 8;
+    },
+    readFile: (filePath) => {
+      // readFile must also receive the path stripped of the query.
+      assert.equal(filePath, "/path/App.vue");
+      return "<template/>";
+    },
+  });
+
+  assert.equal(seenPath, "/path/App.vue", "path is taken from before the '?'");
+  assert.equal(result, "compiled\n<template/>");
+});
+
+void test("UnoCSS bridge returns code unchanged for an empty id without reading", () => {
+  let touched = false;
+  const result = appendOriginalVueSourceForUnoCss("compiled", "", {
+    readSize: () => {
+      touched = true;
+      return 1;
+    },
+    readFile: () => {
+      touched = true;
+      return "x";
+    },
+  });
+
+  assert.equal(result, "compiled", "empty id yields a falsy filePath and short-circuits");
+  assert.equal(touched, false, "neither readSize nor readFile is invoked");
+});
+
+void test("UnoCSS bridge returns code unchanged for a pure '?query' id", () => {
+  // "?vue".split("?")[0] === "" -> falsy filePath -> short circuit.
+  let touched = false;
+  const result = appendOriginalVueSourceForUnoCss("compiled", "?vue", {
+    readSize: () => {
+      touched = true;
+      return 1;
+    },
+  });
+
+  assert.equal(result, "compiled");
+  assert.equal(touched, false);
+});
+
+void test("UnoCSS bridge appends when size is exactly at the maxBytes boundary", () => {
+  const result = appendOriginalVueSourceForUnoCss("compiled", "/src/Edge.vue", {
+    maxBytes: 10,
+    readSize: () => 10,
+    readFile: () => "SRC",
+  });
+
+  assert.equal(result, "compiled\nSRC", "size == maxBytes is appended (strict '>' comparison)");
+});
+
+void test("UnoCSS bridge skips when size is one byte over maxBytes", () => {
+  let didRead = false;
+  const result = appendOriginalVueSourceForUnoCss("compiled", "/src/Edge.vue", {
+    maxBytes: 10,
+    readSize: () => 11,
+    readFile: () => {
+      didRead = true;
+      return "SRC";
+    },
+  });
+
+  assert.equal(result, "compiled", "size == maxBytes + 1 is skipped");
+  assert.equal(didRead, false, "oversized source is never read");
+});
+
+void test("UnoCSS bridge default maxBytes equals MAX_UNOCSS_ORIGINAL_SOURCE_BYTES", () => {
+  assert.equal(MAX_UNOCSS_ORIGINAL_SOURCE_BYTES, 2 * 1024 * 1024);
+
+  // Exactly at the default cap -> appended.
+  const atCap = appendOriginalVueSourceForUnoCss("compiled", "/src/Big.vue", {
+    readSize: () => MAX_UNOCSS_ORIGINAL_SOURCE_BYTES,
+    readFile: () => "SRC",
+  });
+  assert.equal(atCap, "compiled\nSRC", "default cap is the exported constant and is inclusive");
+
+  // One over the default cap -> skipped.
+  const overCap = appendOriginalVueSourceForUnoCss("compiled", "/src/Big.vue", {
+    readSize: () => MAX_UNOCSS_ORIGINAL_SOURCE_BYTES + 1,
+    readFile: () => "SRC",
+  });
+  assert.equal(overCap, "compiled", "default cap rejects sources one byte larger");
+});
+
+void test("UnoCSS bridge with Infinity maxBytes never skips on size", () => {
+  const result = appendOriginalVueSourceForUnoCss("compiled", "/src/Huge.vue", {
+    maxBytes: Infinity,
+    readSize: () => Number.MAX_SAFE_INTEGER,
+    readFile: () => "SRC",
+  });
+
+  assert.equal(result, "compiled\nSRC", "Infinity cap means no size value can exceed it");
+});
+
+void test("UnoCSS bridge swallows a throwing readSize and leaves code intact", () => {
+  let didRead = false;
+  const result = appendOriginalVueSourceForUnoCss("compiled", "/src/Fail.vue", {
+    maxBytes: 1024,
+    readSize: () => {
+      throw new Error("stat failed");
+    },
+    readFile: () => {
+      didRead = true;
+      return "SRC";
+    },
+  });
+
+  assert.equal(result, "compiled", "a thrown size error is caught and code is returned");
+  assert.equal(didRead, false, "readFile is not reached when readSize throws");
+});
+
+void test("UnoCSS bridge swallows a throwing readFile and leaves code intact", () => {
+  const result = appendOriginalVueSourceForUnoCss("compiled", "/src/Fail.vue", {
+    maxBytes: 1024,
+    readSize: () => 5,
+    readFile: () => {
+      throw new Error("read failed");
+    },
+  });
+
+  assert.equal(result, "compiled", "a thrown read error is caught and code is returned");
+});
+
+void test("UnoCSS bridge appends the exact stub source after a newline", () => {
+  const original = '<template><div text-red @click="x" /></template>';
+  const result = appendOriginalVueSourceForUnoCss(
+    "compiled-output",
+    "/src/App.vue?vue&type=style",
+    {
+      maxBytes: 4096,
+      readSize: () => original.length,
+      readFile: () => original,
+    },
+  );
+
+  assert.equal(result, `compiled-output\n${original}`);
+  assert.ok(result.includes(original), "the original source is present in the output");
+  assert.ok(result.startsWith("compiled-output\n"), "code precedes the appended source");
+});
+
+void test("UnoCSS bridge with empty code yields just the newline-prefixed source", () => {
+  const result = appendOriginalVueSourceForUnoCss("", "/src/Empty.vue", {
+    maxBytes: 1024,
+    readSize: () => 3,
+    readFile: () => "SRC",
+  });
+
+  // Empty code still gets the leading "\n" separator from the template literal.
+  assert.equal(result, "\nSRC", "empty code produces a leading newline before the source");
+});

--- a/npm/nuxt/src/utils-edge.test.ts
+++ b/npm/nuxt/src/utils-edge.test.ts
@@ -1,0 +1,203 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import test from "node:test";
+
+import {
+  NUXT_OG_IMAGE_RENDERER_SFC_EXCLUDE,
+  buildNuxtCompilerOptions,
+  buildNuxtDevAssetBase,
+  isVizeGeneratedVueModuleId,
+  isVizeVirtualVueModuleId,
+  normalizeNuxtInjectedKeysForVizeVirtualModule,
+  normalizeVizeGeneratedVueModuleId,
+  normalizeVizeVirtualVueModuleId,
+  preserveExplicitVueImportsFromNuxtAutoImports,
+  stabilizeNuxtInjectedKeysForVizeVirtualModule,
+} from "./utils.ts";
+
+function stableNuxtKey(normalizedId: string, index: number): string {
+  return createHash("sha256")
+    .update(normalizedId)
+    .update(":")
+    .update(String(index))
+    .digest("base64url")
+    .slice(0, 10);
+}
+
+void test("buildNuxtDevAssetBase keeps the default /_nuxt/ asset base", () => {
+  assert.equal(buildNuxtDevAssetBase("/", "/_nuxt/"), "/_nuxt/");
+});
+
+void test("buildNuxtDevAssetBase treats an empty baseURL like the root base", () => {
+  // "" normalizes to "/", so the asset dir is returned unprefixed.
+  assert.equal(buildNuxtDevAssetBase("", "/_nuxt/"), "/_nuxt/");
+});
+
+void test("buildNuxtDevAssetBase collapses an empty buildAssetsDir under the root base", () => {
+  // "" buildAssetsDir normalizes to "/", and root base "/" short-circuits to that.
+  assert.equal(buildNuxtDevAssetBase("/", ""), "/");
+});
+
+void test("buildNuxtDevAssetBase merges a baseURL with no trailing slash before /_nuxt/", () => {
+  assert.equal(buildNuxtDevAssetBase("/docs", "/_nuxt/"), "/docs/_nuxt/");
+});
+
+void test("buildNuxtDevAssetBase does NOT collapse internal double slashes", () => {
+  // normalizeUrlPrefix only guards the leading/trailing slash; interior "//" survive.
+  // This is surprising for a URL builder and is recorded as a possible bug.
+  assert.equal(buildNuxtDevAssetBase("//docs//", "//_nuxt//"), "//docs///_nuxt//");
+});
+
+void test("buildNuxtCompilerOptions sets defaults and prepends the Takumi exclude", () => {
+  assert.deepEqual(buildNuxtCompilerOptions("/root"), {
+    devUrlBase: "/_nuxt/",
+    root: "/root",
+    scanPatterns: [],
+    exclude: NUXT_OG_IMAGE_RENDERER_SFC_EXCLUDE,
+  });
+});
+
+void test("buildNuxtCompilerOptions merges a user exclude without double-merging the Takumi default", () => {
+  const a = /\.a\.vue$/;
+  const b = /\.b\.vue$/;
+  const result = buildNuxtCompilerOptions("/root", "/", "/_nuxt/", { exclude: [a, b] });
+  // Takumi default is prepended exactly once, followed by the user's patterns.
+  assert.deepEqual(result.exclude, [NUXT_OG_IMAGE_RENDERER_SFC_EXCLUDE, a, b]);
+});
+
+void test("buildNuxtCompilerOptions with customRenderer:true and no exclude omits the exclude key", () => {
+  const result = buildNuxtCompilerOptions("/root", "/", "/_nuxt/", { customRenderer: true });
+  assert.equal("exclude" in result, false);
+  assert.deepEqual(result, {
+    devUrlBase: "/_nuxt/",
+    root: "/root",
+    scanPatterns: [],
+    customRenderer: true,
+  });
+});
+
+void test("isVizeVirtualVueModuleId requires a NUL prefix while generated does not", () => {
+  assert.equal(isVizeVirtualVueModuleId("\0/App.vue.ts"), true);
+  assert.equal(isVizeGeneratedVueModuleId("\0/App.vue.ts"), true);
+  // Without the NUL byte it is a generated id but not a virtual one.
+  assert.equal(isVizeVirtualVueModuleId("/App.vue.ts"), false);
+  assert.equal(isVizeGeneratedVueModuleId("/App.vue.ts"), true);
+});
+
+void test("the .vue.tsx extension is neither virtual nor generated", () => {
+  // The regex anchors ".vue.ts" to "?" or end-of-string, so the trailing "x" excludes it.
+  assert.equal(isVizeVirtualVueModuleId("\0/App.vue.tsx"), false);
+  assert.equal(isVizeGeneratedVueModuleId("/App.vue.tsx"), false);
+});
+
+void test("ids without .vue are rejected and a query after .vue.ts is accepted", () => {
+  assert.equal(isVizeVirtualVueModuleId("\0/App.ts"), false);
+  assert.equal(isVizeGeneratedVueModuleId("/App.ts"), false);
+  assert.equal(isVizeVirtualVueModuleId("\0/App.vue.ts?vue"), true);
+  assert.equal(isVizeGeneratedVueModuleId("/App.vue.ts?vue"), true);
+});
+
+void test("normalizeVizeVirtualVueModuleId strips the NUL and the optional vize-ssr prefix", () => {
+  assert.equal(normalizeVizeVirtualVueModuleId("\0/App.vue.ts"), "/App.vue");
+  assert.equal(normalizeVizeVirtualVueModuleId("\0vize-ssr:/App.vue.ts"), "/App.vue");
+});
+
+void test("normalizeVizeVirtualVueModuleId preserves the query string but only strips the suffix .ts", () => {
+  assert.equal(normalizeVizeVirtualVueModuleId("\0/App.vue.ts?vue"), "/App.vue?vue");
+  // A ".ts" living inside the query must NOT be stripped.
+  assert.equal(normalizeVizeVirtualVueModuleId("\0/App.vue.ts?v=1.ts"), "/App.vue?v=1.ts");
+});
+
+void test("normalizeVizeGeneratedVueModuleId handles the /@id/__x00__ and __x00__ wrappers", () => {
+  assert.equal(normalizeVizeGeneratedVueModuleId("/@id/__x00__/App.vue.ts?vue"), "/App.vue?vue");
+  assert.equal(normalizeVizeGeneratedVueModuleId("__x00__/App.vue.ts"), "/App.vue");
+  assert.equal(normalizeVizeGeneratedVueModuleId("/App.vue.ts?vue&vize"), "/App.vue?vue&vize");
+  // A ".ts" inside the query is preserved here too.
+  assert.equal(normalizeVizeGeneratedVueModuleId("/App.vue.ts?v=1.ts"), "/App.vue?v=1.ts");
+});
+
+void test("normalizeNuxtInjectedKeysForVizeVirtualModule replaces every marker with a deterministic 10-char key", () => {
+  const code = "a('$x1' /* nuxt-injected */); b('$x2' /* nuxt-injected */)";
+  const id = "\0/repo/App.vue.ts";
+  const normalizedId = "/repo/App.vue";
+
+  const out = normalizeNuxtInjectedKeysForVizeVirtualModule(code, id);
+  const expected = `a('$${stableNuxtKey(normalizedId, 1)}' /* nuxt-injected */); b('$${stableNuxtKey(normalizedId, 2)}' /* nuxt-injected */)`;
+  assert.equal(out, expected);
+
+  const keys = [...out.matchAll(/'\$([^']+)'/g)].map((m) => m[1]!);
+  assert.deepEqual(
+    keys.map((k) => k.length),
+    [10, 10],
+  );
+
+  // Same id + index pair is stable across repeated calls.
+  assert.equal(out, normalizeNuxtInjectedKeysForVizeVirtualModule(code, id));
+});
+
+void test("normalizeNuxtInjectedKeysForVizeVirtualModule leaves code without markers untouched", () => {
+  const code = "const x = doThing();";
+  assert.equal(normalizeNuxtInjectedKeysForVizeVirtualModule(code, "\0/repo/App.vue.ts"), code);
+});
+
+void test("stabilizeNuxtInjectedKeysForVizeVirtualModule injects a stable key into an unkeyed useFetch", () => {
+  const id = "\0/repo/App.vue.ts";
+  const normalizedId = "/repo/App.vue";
+  const out = stabilizeNuxtInjectedKeysForVizeVirtualModule("useFetch('/api')", id);
+  assert.equal(out, `useFetch('/api', '$${stableNuxtKey(normalizedId, 1)}' /* nuxt-injected */)`);
+});
+
+void test("stabilizeNuxtInjectedKeysForVizeVirtualModule does not double-inject an already-keyed call", () => {
+  const id = "\0/repo/App.vue.ts";
+  const normalizedId = "/repo/App.vue";
+  // Already-keyed: no extra argument is appended, but the key is re-stabilized.
+  const out = stabilizeNuxtInjectedKeysForVizeVirtualModule(
+    "useFetch('/api', {}, '$abc' /* nuxt-injected */)",
+    id,
+  );
+  assert.equal(
+    out,
+    `useFetch('/api', {}, '$${stableNuxtKey(normalizedId, 1)}' /* nuxt-injected */)`,
+  );
+  // Exactly one nuxt-injected marker remains.
+  assert.equal(out.match(/nuxt-injected/g)?.length, 1);
+});
+
+void test("preserveExplicitVueImportsFromNuxtAutoImports restores a plain vue import moved to #imports", () => {
+  const original = `import { ref } from "vue";\nconst x = ref(0);`;
+  const injected = `import { ref, useState } from "#imports";\nconst x = ref(0);\nconst s = useState();`;
+  assert.equal(
+    preserveExplicitVueImportsFromNuxtAutoImports(original, injected),
+    `import { ref } from "vue";\nimport { useState } from "#imports";\nconst x = ref(0);\nconst s = useState();`,
+  );
+});
+
+void test("preserveExplicitVueImportsFromNuxtAutoImports restores an aliased import by its local name", () => {
+  const original = `import { ref as _ref } from "vue";\nconst x = _ref(0);`;
+  const injected = `import { ref as _ref, useState } from "#imports";\nconst x = _ref(0);\nconst s = useState();`;
+  assert.equal(
+    preserveExplicitVueImportsFromNuxtAutoImports(original, injected),
+    `import { ref as _ref } from "vue";\nimport { useState } from "#imports";\nconst x = _ref(0);\nconst s = useState();`,
+  );
+});
+
+void test("preserveExplicitVueImportsFromNuxtAutoImports drops the type modifier when restoring a type-only original specifier", () => {
+  const original = `import { type Ref, ref } from "vue";\nconst x = ref(0);`;
+  const injected = `import { Ref, ref, useState } from "#imports";\nconst x = ref(0);`;
+  // The original "type Ref" is matched by local "Ref"; its restored raw drops the "type " prefix.
+  assert.equal(
+    preserveExplicitVueImportsFromNuxtAutoImports(original, injected),
+    `import { Ref, ref } from "vue";\nimport { useState } from "#imports";\nconst x = ref(0);`,
+  );
+});
+
+void test("preserveExplicitVueImportsFromNuxtAutoImports is a no-op when nothing needs restoring", () => {
+  // No explicit vue import in the original => injected code is returned unchanged.
+  const noVue = `import { ref } from "#imports";\nconst x = ref(0);`;
+  assert.equal(preserveExplicitVueImportsFromNuxtAutoImports(`const x = 1;`, noVue), noVue);
+
+  // Original has a vue import, but the injected code never moved it into #imports.
+  const original = `import { ref } from "vue";`;
+  const injected = `import { useState } from "#imports";\nconst s = useState();`;
+  assert.equal(preserveExplicitVueImportsFromNuxtAutoImports(original, injected), injected);
+});


### PR DESCRIPTION
## What

Adds pure-function edge-case tests for `@vizejs/nuxt` (Nuxt + Vue Router integration). All filesystem-free (`node --test`).

New files:
- `src/options-edge.test.ts` — the 5 resolvers (`resolveNuxtCompilerOptions`/`Bridge`/`UnoCss`/`Dev`/`Musea`): baseURL/buildAssetsDir merge, legacy vueVersion, customRenderer exclude, defaults vs overrides (16 cases)
- `src/components-edge.test.ts` — `injectNuxtComponentImports` literal-vs-dynamic `resolveComponent`, dedupe, client-only wrap, `NuxtRouteAnnouncer` exception, lazy helpers, `#components` rewrite/empty/type-only + `createNuxtComponentResolver` aliasing (18 cases)
- `src/i18n-edge.test.ts` — `injectNuxtI18nHelpers` six specifier mappings, `_ctx`/`this` exclusion, merge-vs-inject ordering (9 cases)
- `src/utils-edge.test.ts` — id normalization, injected-key stabilization, explicit-vue-import preservation, dev asset base (22 cases)
- `src/dev-html-edge.test.ts` — `sanitizeNuxtDevStylesheetLinks` allow-list, traversal/null-byte rejection, dedupe, custom assets dir (11 cases)
- `src/unocss-edge.test.ts` — `appendOriginalVueSourceForUnoCss` maxBytes boundary, Infinity cap, read-error swallowing (11 cases)

Behavior pinned by these tests (surprising-but-current): `buildNuxtDevAssetBase` doesn't collapse interior `//`; an empty `href=""` and `/_nuxt/` paths under a custom `buildAssetsDir` are kept by the dev-html sanitizer; an i18n helper used *before* an existing `useI18n()` destructure injects a second `useI18n()` instead of merging.

## Verify
`cd npm/nuxt && node --test 'src/*.test.ts'` → all green; `oxlint`/`oxfmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1115"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783429390&installation_id=136613492&pr_number=1115&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1115&signature=419221eaca6612e31f0881be697c54f5400614288b93fb59c831e95a36336406"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->