### PR TITLE
test(tooling): cover Neovim/Helix/Emacs/Vim configs and cross-editor profiles

### DIFF
--- a/tests/tooling/editor-integrations-emacs.test.ts
+++ b/tests/tooling/editor-integrations-emacs.test.ts
@@ -1,0 +1,76 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+
+function readRepoFile(relativePath: string): string {
+  return fs.readFileSync(path.join(root, relativePath), "utf-8");
+}
+
+test("emacs vize.el defines the eglot command default and customizable profile", () => {
+  const el = readRepoFile("npm/emacs-vize/vize.el");
+
+  // The LSP launch command defaults to running the `vize lsp` subcommand.
+  assert.match(el, /\(defcustom\s+vize-eglot-command\s+'\("vize"\s+"lsp"\)/);
+
+  // The default feature profile is `lint`.
+  assert.match(el, /\(defcustom\s+vize-eglot-profile\s+'lint\b/);
+
+  // The profile is a customizable choice exposing lint / recommended / off.
+  assert.match(
+    el,
+    /:type\s+'\(choice\b[\s\S]*?vize-eglot-profile|defcustom\s+vize-eglot-profile[\s\S]*?:type\s+'\(choice/,
+  );
+  assert.match(el, /\(const[^)]*\blint\b\)/);
+  assert.match(el, /\(const[^)]*\brecommended\b\)/);
+  assert.match(el, /\(const[^)]*\boff\b\)/);
+});
+
+test("emacs vize.el maps each profile to its initialization options", () => {
+  const el = readRepoFile("npm/emacs-vize/vize.el");
+
+  // The profiles are defined in a single alist constant.
+  assert.match(el, /\(defconst\s+vize--profiles\b/);
+
+  // lint => (:lint t)
+  assert.match(el, /\(lint\s*\.\s*\(:lint\s+t\)\)/);
+
+  // off => nil
+  assert.match(el, /\(off\s*\.\s*nil\)/);
+
+  // recommended => (:editor t :ecosystem t :lint t :typecheck t)
+  assert.match(
+    el,
+    /\(recommended\s*\.\s*\(:editor\s+t\s+:ecosystem\s+t\s+:lint\s+t\s+:typecheck\s+t\)\)/,
+  );
+});
+
+test("emacs vize.el associates the .vue and .art.vue file patterns with derived modes", () => {
+  const el = readRepoFile("npm/emacs-vize/vize.el");
+
+  // auto-mode-alist: "\.vue\'" => vize-vue-mode
+  assert.match(el, /add-to-list\s+'auto-mode-alist\s+'\("\\\\\.vue\\\\'"\s*\.\s*vize-vue-mode\)/);
+
+  // auto-mode-alist: "\.art\.vue\'" => vize-art-vue-mode
+  assert.match(
+    el,
+    /add-to-list\s+'auto-mode-alist\s+'\("\\\\\.art\\\\\.vue\\\\'"\s*\.\s*vize-art-vue-mode\)/,
+  );
+});
+
+test("emacs vize.el defines vue / art-vue fallback modes deriving from prog-mode", () => {
+  const el = readRepoFile("npm/emacs-vize/vize.el");
+
+  assert.match(el, /\(define-derived-mode\s+vize-vue-mode\s+prog-mode\b/);
+  assert.match(el, /\(define-derived-mode\s+vize-art-vue-mode\s+prog-mode\b/);
+});
+
+test("emacs vize.el setup registers the server with eglot-server-programs", () => {
+  const el = readRepoFile("npm/emacs-vize/vize.el");
+
+  assert.match(el, /\(defun\s+vize-setup-eglot\b/);
+  assert.match(el, /add-to-list\s+'eglot-server-programs/);
+});

--- a/tests/tooling/editor-integrations-helix.test.ts
+++ b/tests/tooling/editor-integrations-helix.test.ts
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+
+function readRepoFile(relativePath: string): string {
+  return fs.readFileSync(path.join(root, relativePath), "utf-8");
+}
+
+test("helix languages.toml registers the vize language server with the lsp command", () => {
+  const config = readRepoFile("npm/helix-vize/languages.toml");
+
+  // Language server registration: command `vize` invoked with the `lsp` subcommand.
+  assert.match(config, /^\[language-server\.vize\]$/m);
+  assert.match(config, /^command = "vize"$/m);
+  assert.match(config, /^args = \["lsp"\]$/m);
+
+  // Server-level config enables linting.
+  assert.match(config, /^\[language-server\.vize\.config\]$/m);
+  assert.match(config, /^lint = true$/m);
+});
+
+test("helix languages.toml declares the vue language wired to the vize server", () => {
+  const config = readRepoFile("npm/helix-vize/languages.toml");
+
+  // The plain `vue` language entry: scope, file-types and language-servers.
+  const vueEntry = config.match(
+    /^\[\[language\]\]\nname = "vue"\n(?:.*\n)*?language-servers = \[[^\]]*\]/m,
+  )?.[0];
+  assert.ok(vueEntry, "languages.toml must contain a [[language]] entry named vue");
+  assert.match(vueEntry, /^scope = "source\.vue"$/m);
+  assert.match(vueEntry, /^file-types = \["vue"\]$/m);
+  assert.match(vueEntry, /^language-servers = \["vize"\]$/m);
+});
+
+test("helix languages.toml declares the art-vue language with a glob file-type", () => {
+  const config = readRepoFile("npm/helix-vize/languages.toml");
+
+  // The `art-vue` language entry: language-id, scope, glob file-type and server.
+  const artEntry = config.match(
+    /^\[\[language\]\]\nname = "art-vue"\n(?:.*\n)*?language-servers = \[[^\]]*\]/m,
+  )?.[0];
+  assert.ok(artEntry, "languages.toml must contain a [[language]] entry named art-vue");
+  assert.match(artEntry, /^language-id = "art-vue"$/m);
+  assert.match(artEntry, /^scope = "source\.art-vue"$/m);
+  assert.match(artEntry, /^file-types = \[\{ glob = "\*\.art\.vue" \}\]$/m);
+  assert.match(artEntry, /^language-servers = \["vize"\]$/m);
+});
+
+test("helix languages.toml root markers cover vize config, package.json and .git", () => {
+  const config = readRepoFile("npm/helix-vize/languages.toml");
+
+  // Both language entries declare the same set of project root markers via `roots`.
+  const rootsLines = config.match(/^roots = \[[^\]]*\]$/gm) ?? [];
+  assert.equal(rootsLines.length, 2, "both vue and art-vue entries must declare roots");
+  for (const roots of rootsLines) {
+    assert.match(roots, /"vize\.config\.pkl"/);
+    assert.match(roots, /"vize\.config\.json"/);
+    assert.match(roots, /"package\.json"/);
+    assert.match(roots, /"\.git"/);
+  }
+});

--- a/tests/tooling/editor-integrations-neovim.test.ts
+++ b/tests/tooling/editor-integrations-neovim.test.ts
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+
+function readRepoFile(relativePath: string): string {
+  return fs.readFileSync(path.join(root, relativePath), "utf-8");
+}
+
+test("nvim ftdetect maps .vue -> vue and .art.vue -> art-vue", () => {
+  const ftdetect = readRepoFile("npm/nvim-vize/ftdetect/vize.lua");
+
+  // *.vue files are detected as the "vue" filetype.
+  assert.match(ftdetect, /pattern\s*=\s*["']\*\.vue["']/);
+  assert.match(ftdetect, /vim\.bo\.filetype\s*=\s*["']vue["']/);
+
+  // *.art.vue files override to the "art-vue" filetype.
+  assert.match(ftdetect, /pattern\s*=\s*["']\*\.art\.vue["']/);
+  assert.match(ftdetect, /vim\.bo\.filetype\s*=\s*["']art-vue["']/);
+
+  // Detection is wired through BufNewFile/BufRead autocommands.
+  assert.match(
+    ftdetect,
+    /nvim_create_autocmd\(\s*\{\s*["']BufNewFile["']\s*,\s*["']BufRead["']\s*\}/,
+  );
+});
+
+test("nvim config default cmd, filetypes and root_markers declare the canonical LSP wiring", () => {
+  const config = readRepoFile("npm/nvim-vize/lua/vize/config.lua");
+
+  // Default launch command is `vize lsp`.
+  assert.match(config, /cmd\s*=\s*\{\s*["']vize["']\s*,\s*["']lsp["']\s*\}/);
+
+  // Both Vue dialects are registered as default filetypes.
+  assert.match(config, /filetypes\s*=\s*\{\s*["']vue["']\s*,\s*["']art-vue["']\s*\}/);
+
+  // Root markers are declared with vize.config.pkl FIRST, then json/package.json/.git.
+  assert.match(
+    config,
+    /root_markers\s*=\s*\{\s*["']vize\.config\.pkl["']\s*,\s*["']vize\.config\.json["']\s*,\s*["']package\.json["']\s*,\s*["']\.git["']\s*\}/,
+  );
+});
+
+test("nvim config defines the lint, recommended and off profiles, defaulting init_options to lint", () => {
+  const config = readRepoFile("npm/nvim-vize/lua/vize/config.lua");
+
+  // All three named profiles are defined inside the profiles table.
+  assert.match(config, /\blint\s*=\s*\{/);
+  assert.match(config, /\brecommended\s*=\s*\{/);
+  assert.match(config, /\boff\s*=\s*\{\s*\}/);
+
+  // Default init_options points at the lint profile.
+  assert.match(config, /init_options\s*=\s*profiles\.lint/);
+});
+
+test("nvim plugin entrypoint wires the plugin via guard + setup command", () => {
+  const plugin = readRepoFile("npm/nvim-vize/plugin/vize.lua");
+
+  // Load-guard prevents double sourcing.
+  assert.match(plugin, /vim\.g\.loaded_vize/);
+
+  // A user command exposes setup, which calls into the vize module's setup().
+  assert.match(plugin, /nvim_create_user_command\(\s*["']VizeSetup["']/);
+  assert.match(plugin, /require\(\s*["']vize["']\s*\)\.setup\(\)/);
+});

--- a/tests/tooling/editor-integrations-vim.test.ts
+++ b/tests/tooling/editor-integrations-vim.test.ts
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+
+function readRepoFile(relativePath: string): string {
+  return fs.readFileSync(path.join(root, relativePath), "utf-8");
+}
+
+test("vim ftdetect maps *.vue -> vue and *.art.vue -> art-vue inside an augroup", () => {
+  const ftdetect = readRepoFile("npm/vim-vize/ftdetect/vize.vim");
+
+  // Detection lives inside a named augroup that clears itself first so re-sourcing
+  // does not stack duplicate autocommands.
+  assert.match(ftdetect, /^augroup vize_filetypes$/m);
+  assert.match(ftdetect, /^\s*autocmd!\s*$/m);
+  assert.match(ftdetect, /^augroup END$/m);
+
+  // *.vue files are detected as the "vue" filetype. The real implementation uses
+  // `setlocal filetype=vue` (not `setf`/`set filetype`), so assert what it actually does.
+  assert.match(ftdetect, /autocmd\s+BufNewFile,BufRead\s+\*\.vue\s+setlocal\s+filetype=vue/);
+
+  // *.art.vue files override to the "art-vue" filetype.
+  assert.match(
+    ftdetect,
+    /autocmd\s+BufNewFile,BufRead\s+\*\.art\.vue\s+setlocal\s+filetype=art-vue/,
+  );
+});
+
+test("vim ftdetect autocommands are scoped only to *.vue / *.art.vue (no clobbering)", () => {
+  const ftdetect = readRepoFile("npm/vim-vize/ftdetect/vize.vim");
+
+  // Collect every real autocommand definition (excluding the bare `autocmd!` clear).
+  const autocmds = ftdetect
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => /^autocmd\s+\S/.test(line));
+
+  // Exactly the two Vue-dialect detectors, nothing more.
+  assert.equal(autocmds.length, 2);
+
+  // Every autocommand pattern must target a *.vue or *.art.vue glob — never a bare
+  // catch-all like `*` or an unrelated extension.
+  for (const cmd of autocmds) {
+    assert.match(cmd, /\*(\.art)?\.vue\s/, `autocommand must be scoped to a vue glob: ${cmd}`);
+  }
+
+  // Guard: no autocommand silently grabs `*` (which would clobber every filetype).
+  assert.doesNotMatch(ftdetect, /BufNewFile,BufRead\s+\*\s/);
+});
+
+test("vim autoload wires the vize LSP server registration (vize + lsp tokens)", () => {
+  const autoload = readRepoFile("npm/vim-vize/autoload/vize.vim");
+
+  // The default launch command is `vize lsp`.
+  assert.match(autoload, /'cmd':\s*\['vize',\s*'lsp'\]/);
+
+  // setup() registers the server through vim-lsp's lsp#register_server.
+  assert.match(autoload, /lsp#register_server\(/);
+
+  // The server is registered under the canonical "vize" name and is gated on both
+  // Vue dialects via the allowlist.
+  assert.match(autoload, /'name':\s*'vize'/);
+  assert.match(autoload, /'allowlist':\s*\['vue',\s*'art-vue'\]/);
+});
+
+test("vim plugin entrypoint guards double-sourcing and exposes the VizeSetup command", () => {
+  const plugin = readRepoFile("npm/vim-vize/plugin/vize.vim");
+
+  // Load-guard prevents the plugin from being sourced twice.
+  assert.match(plugin, /exists\('g:loaded_vize'\)/);
+  assert.match(plugin, /let g:loaded_vize = 1/);
+
+  // A user command exposes setup, which calls into the vize#setup() autoload function.
+  assert.match(plugin, /command!\s+VizeSetup\s+call\s+vize#setup\(\)/);
+});

--- a/tests/tooling/editor-profiles-consistency.test.ts
+++ b/tests/tooling/editor-profiles-consistency.test.ts
@@ -1,0 +1,257 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+
+function readText(relativePath: string): string {
+  return fs.readFileSync(path.join(root, relativePath), "utf-8");
+}
+
+// The canonical language ids and the canonical LSP feature-profile names that
+// every editor integration must agree on. editor-integrations-consistency.test.ts
+// already reconciles VS Code <-> Zed for *language identity*; this file extends
+// the invariant to the OTHER editors and adds the *profile-name* invariant.
+const CANONICAL_LANGUAGE_IDS = ["art-vue", "vue"];
+const CANONICAL_PROFILES = new Set(["lint", "recommended", "off"]);
+
+// Each editor that declares Vue languages, with a parser that extracts the set
+// of canonical ids ("vue" / "art-vue") it references. We collect a per-editor
+// set and assert it contains BOTH ids, so no editor silently drops one variant.
+type LanguageDeclaration = {
+  editor: string;
+  file: string;
+  extract: (text: string) => Set<string>;
+};
+
+function collectCanonicalIds(text: string): Set<string> {
+  const found = new Set<string>();
+  // Match "art-vue" before "vue" by checking the longer token first; we scan for
+  // each canonical id as a whole token wrapped in common delimiters (quotes,
+  // brackets, equals, whitespace) so "vue" inside "art-vue" is not double counted
+  // for the bare "vue" id.
+  for (const id of CANONICAL_LANGUAGE_IDS) {
+    const escaped = id.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    // A token boundary that is NOT a hyphen/word char on the left (so "art-vue"
+    // does not satisfy the bare "vue" probe) and not a word char on the right.
+    const re = new RegExp(`(?<![\\w-])${escaped}(?![\\w-])`);
+    if (re.test(text)) {
+      found.add(id);
+    }
+  }
+  return found;
+}
+
+const LANGUAGE_DECLARATIONS: LanguageDeclaration[] = [
+  // VS Code declares ids in contributes.languages[].id; the JSON is read as text
+  // and probed for the canonical id tokens.
+  {
+    editor: "vscode",
+    file: "npm/vscode-vize/package.json",
+    extract: collectCanonicalIds,
+  },
+  // Zed maps display name -> id in [language_servers.vize.language_ids].
+  {
+    editor: "zed",
+    file: "npm/zed-vize/extension.toml",
+    extract: collectCanonicalIds,
+  },
+  // Neovim lists filetypes = { "vue", "art-vue" }.
+  {
+    editor: "neovim",
+    file: "npm/nvim-vize/lua/vize/config.lua",
+    extract: collectCanonicalIds,
+  },
+  // Emacs declares auto-mode-alist patterns and derived modes for both variants.
+  // Unlike the other editors it never writes the bare "art-vue" token: the id
+  // surface is the derived mode name fragment (vize-vue-mode / vize-art-vue-mode)
+  // and the auto-mode-alist file patterns (\\.vue\\' / \\.art\\.vue\\'). We map
+  // those Emacs-native conventions onto the canonical id set.
+  {
+    editor: "emacs",
+    file: "npm/emacs-vize/vize.el",
+    extract: (text) => {
+      const found = new Set<string>();
+      // vize-vue-mode (vue) requires "vize-vue-mode" with no extra leading "-art".
+      if (/\bvize-vue-mode\b/.test(text) && /\\\\\.vue\\\\'/.test(text)) {
+        found.add("vue");
+      }
+      // vize-art-vue-mode (art-vue) + the \\.art\\.vue\\' auto-mode pattern.
+      if (/\bvize-art-vue-mode\b/.test(text) && /\\\\\.art\\\\\.vue\\\\'/.test(text)) {
+        found.add("art-vue");
+      }
+      return found;
+    },
+  },
+  // Helix declares [[language]] name = "vue" / "art-vue".
+  {
+    editor: "helix",
+    file: "npm/helix-vize/languages.toml",
+    extract: collectCanonicalIds,
+  },
+  // Vim's ftdetect sets filetype=vue / filetype=art-vue.
+  {
+    editor: "vim",
+    file: "npm/vim-vize/ftdetect/vize.vim",
+    extract: collectCanonicalIds,
+  },
+];
+
+// Each editor that declares an LSP feature-PROFILE table, with a parser that
+// extracts the set of profile names it defines. VS Code and Zed/Helix/Vim's
+// ftdetect deliberately do NOT carry a lint/recommended/off profile table, so
+// they are excluded from the profile invariant (see PROFILE_LESS_EDITORS).
+type ProfileDeclaration = {
+  editor: string;
+  file: string;
+  extract: (text: string) => string[];
+};
+
+const PROFILE_DECLARATIONS: ProfileDeclaration[] = [
+  // Neovim: `local profiles = { lint = {...}, off = {}, recommended = {...} }`.
+  {
+    editor: "neovim",
+    file: "npm/nvim-vize/lua/vize/config.lua",
+    extract: (text) => {
+      const block = /local profiles = \{([\s\S]*?)\n\}/.exec(text);
+      assert.ok(block, "neovim config.lua should declare a `local profiles` table");
+      // Only top-level keys: exactly two leading spaces of indentation inside the
+      // table (nested feature flags like `lint = true` sit at four spaces).
+      const names = [...block[1].matchAll(/^ {2}([A-Za-z_][\w]*)\s*=/gm)].map((m) => m[1]);
+      return names;
+    },
+  },
+  // Emacs: `(defconst vize--profiles '((lint . ...) (off . nil) (recommended . ...)))`.
+  {
+    editor: "emacs",
+    file: "npm/emacs-vize/vize.el",
+    extract: (text) => {
+      const block = /\(defconst vize--profiles\s*'\(([\s\S]*?)\)\s*"Vize/.exec(text);
+      assert.ok(block, "emacs vize.el should declare a vize--profiles constant");
+      const names = [...block[1].matchAll(/\(([A-Za-z][\w-]*)\s*\./g)].map((m) => m[1]);
+      return names;
+    },
+  },
+];
+
+// Vim keeps its profile table in autoload/vize.vim (not ftdetect), so it also
+// carries the profile invariant; include it explicitly here.
+PROFILE_DECLARATIONS.push({
+  editor: "vim",
+  file: "npm/vim-vize/autoload/vize.vim",
+  extract: (text) => {
+    const block = /let s:profiles = \{([\s\S]*?)\n\s*\\ \}/.exec(text);
+    assert.ok(block, "vim autoload/vize.vim should declare an s:profiles dictionary");
+    // Only top-level keys: VimL line-continuation `\ 'name':` (single space after
+    // the backslash); nested feature flags use `\   'name':` (three spaces).
+    const names = [...block[1].matchAll(/^\s*\\ '([A-Za-z][\w-]*)'\s*:/gm)].map((m) => m[1]);
+    return names;
+  },
+});
+
+// Editors that legitimately declare NO profile table: VS Code (it exposes
+// per-feature `*.enable` settings plus Recommended/Lint-only *commands*, not a
+// canonical profile table), Zed and Helix (single `lint = true` config, no
+// named profiles).
+const PROFILE_LESS_EDITORS = new Set(["vscode", "zed", "helix"]);
+
+test("every editor that declares Vue languages references both canonical ids", () => {
+  const perEditor = LANGUAGE_DECLARATIONS.map((decl) => ({
+    editor: decl.editor,
+    ids: [...decl.extract(readText(decl.file))].sort(),
+  }));
+
+  // Every listed editor must declare BOTH "vue" and "art-vue".
+  for (const { editor, ids } of perEditor) {
+    assert.deepEqual(
+      ids,
+      CANONICAL_LANGUAGE_IDS,
+      `${editor} should reference exactly the canonical ids vue & art-vue`,
+    );
+  }
+
+  // Sanity: all six editors were checked.
+  assert.equal(perEditor.length, 6);
+  assert.deepEqual(perEditor.map((entry) => entry.editor).sort(), [
+    "emacs",
+    "helix",
+    "neovim",
+    "vim",
+    "vscode",
+    "zed",
+  ]);
+});
+
+test("every editor that declares LSP profiles uses exactly lint/recommended/off", () => {
+  const perEditor = PROFILE_DECLARATIONS.map((decl) => ({
+    editor: decl.editor,
+    file: decl.file,
+    profiles: decl.extract(readText(decl.file)),
+  }));
+
+  // At least the editors that actually carry profile tables are present.
+  assert.deepEqual(perEditor.map((entry) => entry.editor).sort(), ["emacs", "neovim", "vim"]);
+
+  for (const { editor, profiles } of perEditor) {
+    const profileSet = new Set(profiles);
+
+    // No rogue / duplicate names: the parsed list has no duplicates...
+    assert.equal(
+      profiles.length,
+      profileSet.size,
+      `${editor} should not declare a duplicate profile name`,
+    );
+
+    // ...and every declared profile is one of the canonical three.
+    for (const name of profileSet) {
+      assert.ok(
+        CANONICAL_PROFILES.has(name),
+        `${editor} declares rogue profile "${name}" (allowed: lint/recommended/off)`,
+      );
+    }
+
+    // The profile set is a subset of the canonical set...
+    assert.ok(
+      [...profileSet].every((name) => CANONICAL_PROFILES.has(name)),
+      `${editor} profile set must be a subset of {lint, recommended, off}`,
+    );
+
+    // ...and must include at least "lint" (the default/baseline profile).
+    assert.ok(profileSet.has("lint"), `${editor} must declare the baseline "lint" profile`);
+  }
+
+  // The three editors that DO declare profiles each declare all three canonical
+  // names (current behavior: nvim/emacs/vim are fully aligned).
+  for (const { editor, profiles } of perEditor) {
+    assert.deepEqual(
+      [...new Set(profiles)].sort(),
+      ["lint", "off", "recommended"],
+      `${editor} should declare all three canonical profiles`,
+    );
+  }
+});
+
+test("profile-less editors are intentionally excluded from the profile invariant", () => {
+  // Guard against accidental drift: editors we excluded from the profile check
+  // must NOT be ones that actually ship a profile table. We re-derive which
+  // editors carry profiles and confirm the exclusion list is disjoint from them.
+  const profileEditors = new Set(PROFILE_DECLARATIONS.map((decl) => decl.editor));
+  for (const excluded of PROFILE_LESS_EDITORS) {
+    assert.ok(
+      !profileEditors.has(excluded),
+      `${excluded} is excluded from profiles yet declares a profile table`,
+    );
+  }
+
+  // VS Code exposes the profile *concept* as commands rather than a canonical
+  // lint/recommended/off table, so it is excluded from the profile-name check
+  // but the recommended & lint-only command surface still exists.
+  const vscode = readText("npm/vscode-vize/package.json");
+  assert.match(vscode, /"command":\s*"vize\.enableRecommendedProfile"/);
+  assert.match(vscode, /"command":\s*"vize\.enableLintOnlyProfile"/);
+  // VS Code has no "off" profile command — confirming why it is excluded from
+  // the exact lint/recommended/off table invariant.
+  assert.doesNotMatch(vscode, /"command":\s*"vize\.enableOffProfile"/);
+});


### PR DESCRIPTION
## What

Adds editor-integration manifest tests under `tests/tooling` (`node --test tooling/<file>.test.ts`), mirroring the existing `editor-integrations-*.test.ts` text-assertion style.

New files:
- `tooling/editor-integrations-neovim.test.ts` — nvim-vize ftdetect + config (cmd/filetypes/root_markers/profiles) + plugin wiring
- `tooling/editor-integrations-helix.test.ts` — helix `languages.toml` LSP registration for vue + art-vue
- `tooling/editor-integrations-emacs.test.ts` — emacs `vize.el` Eglot wiring, profiles, derived modes
- `tooling/editor-integrations-vim.test.ts` — vim ftdetect + autoload LSP registration
- `tooling/editor-profiles-consistency.test.ts` — cross-editor invariant: every editor references the canonical `vue`/`art-vue` ids, and nvim/emacs/vim profile tables are exactly `{lint, recommended, off}`

Pinned divergence (not a runtime bug): VS Code exposes profiles only as commands (`enableRecommendedProfile`/`enableLintOnlyProfile`, no `off` profile command), so it's excluded from the exact-profile-name check.

## Verify
`cd tests && node --test tooling/editor-integrations-{neovim,helix,emacs,vim}.test.ts tooling/editor-profiles-consistency.test.ts` → all green; coexists with existing `editor-integrations-*` tests; `oxlint`/`oxfmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1116"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783429395&installation_id=136613492&pr_number=1116&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1116&signature=a1acc80676206282e5292c1cdee18722947a0a8b3f4e375a6544a42d0f1d0cf6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->