### PR TITLE
docs: prefer npm package scripts for vize usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,10 @@ for single-file components. A single shared parser powers compilation, linting, 
 formatting, and editor tooling, so your whole Vue workflow runs on the same high-performance core
 instead of a patchwork of disconnected tools.
 
-It plugs into where you already work: `@vizejs/vite-plugin` (Vite), `vize` (npm CLI), the native
-`vize` binary (full CLI / LSP / profiling), `@vizejs/vite-plugin-musea` (Musea), and
-`oxlint-plugin-vize` (Oxlint).
+It plugs into where you already work: `@vizejs/vite-plugin` (Vite), the `vize` npm package
+(project scripts and shared config helpers), the native `vize` binary (LSP / profiling /
+specialized CLI workflows), `@vizejs/vite-plugin-musea` (Musea), and `oxlint-plugin-vize`
+(Oxlint).
 
 **Everything lives in the [documentation](https://vizejs.dev)** — start with
 [Getting Started](https://vizejs.dev/getting-started).

--- a/docs/content/getting-started.md
+++ b/docs/content/getting-started.md
@@ -11,15 +11,15 @@ title: Getting Started
 Vize (_/viːz/_) is an unofficial Vue.js toolchain written in Rust. The workspace contains shared
 building blocks for:
 
-| Area            | Main Rust crate(s)                                                                                                                                                                                                                                                                                                                                                                                                                                                                              | User-facing package / command            |
-| --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------- |
-| Compilation     | [`vize_atelier_core`](https://github.com/ubugeeei-prod/vize/tree/main/crates/vize_atelier_core), [`vize_atelier_dom`](https://github.com/ubugeeei-prod/vize/tree/main/crates/vize_atelier_dom), [`vize_atelier_vapor`](https://github.com/ubugeeei-prod/vize/tree/main/crates/vize_atelier_vapor), [`vize_atelier_ssr`](https://github.com/ubugeeei-prod/vize/tree/main/crates/vize_atelier_ssr), [`vize_atelier_sfc`](https://github.com/ubugeeei-prod/vize/tree/main/crates/vize_atelier_sfc) | `@vizejs/vite-plugin`, Rust `vize build` |
-| Lint            | [`vize_patina`](https://github.com/ubugeeei-prod/vize/tree/main/crates/vize_patina)                                                                                                                                                                                                                                                                                                                                                                                                             | `vize lint`, `oxlint-plugin-vize`        |
-| Format          | [`vize_glyph`](https://github.com/ubugeeei-prod/vize/tree/main/crates/vize_glyph)                                                                                                                                                                                                                                                                                                                                                                                                               | Rust `vize fmt`                          |
-| Type check      | [`vize_canon`](https://github.com/ubugeeei-prod/vize/tree/main/crates/vize_canon)                                                                                                                                                                                                                                                                                                                                                                                                               | Rust `vize check`                        |
-| Editor support  | [`vize_maestro`](https://github.com/ubugeeei-prod/vize/tree/main/crates/vize_maestro)                                                                                                                                                                                                                                                                                                                                                                                                           | `vize lsp`, VS Code, Zed                 |
-| Musea art tools | [`vize_musea`](https://github.com/ubugeeei-prod/vize/tree/main/crates/vize_musea)                                                                                                                                                                                                                                                                                                                                                                                                               | `@vizejs/vite-plugin-musea`              |
-| Bindings        | [`vize_vitrine`](https://github.com/ubugeeei-prod/vize/tree/main/crates/vize_vitrine)                                                                                                                                                                                                                                                                                                                                                                                                           | `@vizejs/native`, `@vizejs/wasm`         |
+| Area            | Main Rust crate(s)                                                                                                                                                                                                                                                                                                                                                                                                                                                                              | User-facing entry point                        |
+| --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
+| Compilation     | [`vize_atelier_core`](https://github.com/ubugeeei-prod/vize/tree/main/crates/vize_atelier_core), [`vize_atelier_dom`](https://github.com/ubugeeei-prod/vize/tree/main/crates/vize_atelier_dom), [`vize_atelier_vapor`](https://github.com/ubugeeei-prod/vize/tree/main/crates/vize_atelier_vapor), [`vize_atelier_ssr`](https://github.com/ubugeeei-prod/vize/tree/main/crates/vize_atelier_ssr), [`vize_atelier_sfc`](https://github.com/ubugeeei-prod/vize/tree/main/crates/vize_atelier_sfc) | `@vizejs/vite-plugin`, npm `vize:build` script |
+| Lint            | [`vize_patina`](https://github.com/ubugeeei-prod/vize/tree/main/crates/vize_patina)                                                                                                                                                                                                                                                                                                                                                                                                             | npm `vize:lint` script, `oxlint-plugin-vize`   |
+| Format          | [`vize_glyph`](https://github.com/ubugeeei-prod/vize/tree/main/crates/vize_glyph)                                                                                                                                                                                                                                                                                                                                                                                                               | npm `vize:fmt` script                          |
+| Type check      | [`vize_canon`](https://github.com/ubugeeei-prod/vize/tree/main/crates/vize_canon)                                                                                                                                                                                                                                                                                                                                                                                                               | npm `vize:check` script                        |
+| Editor support  | [`vize_maestro`](https://github.com/ubugeeei-prod/vize/tree/main/crates/vize_maestro)                                                                                                                                                                                                                                                                                                                                                                                                           | VS Code, Zed, Rust `vize lsp`                  |
+| Musea art tools | [`vize_musea`](https://github.com/ubugeeei-prod/vize/tree/main/crates/vize_musea)                                                                                                                                                                                                                                                                                                                                                                                                               | `@vizejs/vite-plugin-musea`                    |
+| Bindings        | [`vize_vitrine`](https://github.com/ubugeeei-prod/vize/tree/main/crates/vize_vitrine)                                                                                                                                                                                                                                                                                                                                                                                                           | `@vizejs/native`, `@vizejs/wasm`               |
 
 This guide recommends [Vite+](https://viteplus.dev/) (`vp`) for JavaScript package management and project commands. It keeps the install and exec flow consistent across package managers while still using the workspace's underlying tool.
 
@@ -35,14 +35,14 @@ See the [Vite+ docs](https://viteplus.dev/) and the [Installing Dependencies gui
 
 At a high level, Vize is split into a few reusable pipelines:
 
-| Pipeline          | Command or package                       | What you get                                                                               |
+| Pipeline          | Package or script                        | What you get                                                                               |
 | ----------------- | ---------------------------------------- | ------------------------------------------------------------------------------------------ |
-| Compile           | `@vizejs/vite-plugin`, `vize build`      | Rust-native Vue SFC compilation, SSR output, Vapor mode, scoped CSS handling               |
-| Static analysis   | `vize lint`, `oxlint-plugin-vize`        | Vue template, script, CSS, a11y, SSR, Vapor, Musea, cross-file, and type-aware diagnostics |
-| Type check        | `vize check`                             | Virtual TypeScript generation, project diagnostics, Vue-to-source diagnostic mapping       |
-| Format            | `vize fmt`                               | Vue SFC formatting with project and CLI options                                            |
+| Compile           | `@vizejs/vite-plugin`, `vize:build`      | Rust-native Vue SFC compilation, SSR output, Vapor mode, scoped CSS handling               |
+| Static analysis   | `vize:lint`, `oxlint-plugin-vize`        | Vue template, script, CSS, a11y, SSR, Vapor, Musea, cross-file, and type-aware diagnostics |
+| Type check        | `vize:check`                             | Virtual TypeScript generation, project diagnostics, Vue-to-source diagnostic mapping       |
+| Format            | `vize:fmt`                               | Vue SFC formatting with project and CLI options                                            |
 | Component gallery | `@vizejs/vite-plugin-musea`, `musea-vrt` | Art files, component variants, preview setup, design tokens, a11y, VRT                     |
-| Editor support    | `vize lsp`, VS Code, Zed                 | Opt-in diagnostics and editor features                                                     |
+| Editor support    | VS Code, Zed, Rust `vize lsp`            | Opt-in diagnostics and editor features                                                     |
 
 See [Static Analysis](./guide/static-analysis.md) for the lint and type-checking model,
 [Rules](./rules/index.md) for concrete rule output, and
@@ -59,7 +59,7 @@ vp install -D @vizejs/vite-plugin
 ```
 
 Install `vize` as a direct dependency only when you want to import shared config helpers from
-`"vize"` or run the npm CLI through `vp exec vize`.
+`"vize"` or add Vize package scripts such as `vize:lint` and `vize:check`.
 
 ```ts
 // vite.config.ts
@@ -71,8 +71,8 @@ export default defineConfig({
 });
 ```
 
-Add compiler options in `vize.config.ts` when you want the same settings available to the npm CLI
-and plugin:
+Add compiler options in `vize.config.ts` when you want the same settings available to package
+scripts and the plugin:
 
 ```ts
 import { defineConfig } from "vize";
@@ -113,42 +113,47 @@ compilation while preserving Nuxt auto-imports, components, middleware, and SSR 
 
 See the [Nuxt Integration](./integrations/nuxt.md) guide for Musea setup and Nuxt-specific notes.
 
-### 3. npm CLI + Shared Config
+### 3. npm Package Scripts + Shared Config
 
-Use the `vize` npm package when you want shared config utilities and native CLI commands available
-in package scripts.
+Use the `vize` npm package when you want shared config utilities and native commands available from
+project scripts.
 
 ```bash
 vp install -D vize
-vp exec vize fmt --write src
-vp exec vize lint --preset happy-path src
-vp exec vize check src
-vp exec vize build src
-vp exec vize ready src
 ```
-
-The npm `vize check` command uses the packaged NAPI checker and can emit Vue component declarations
-with `--declaration --declaration-dir dist/types`. Use the Rust CLI when you need the Corsa-backed
-project diagnostics path across Vue, TS, TSX, and `.d.ts` inputs.
 
 Recommended package scripts:
 
 ```json
 {
   "scripts": {
-    "vue:fmt": "vize fmt --write src",
-    "vue:lint": "vize lint --preset happy-path src",
-    "vue:check": "vize check src",
-    "vue:ready": "vize ready src"
+    "vize:build": "vize build src",
+    "vize:fmt": "vize fmt --write src",
+    "vize:lint": "vize lint --preset happy-path src",
+    "vize:check": "vize check src",
+    "vize:ready": "vize ready src"
   }
 }
 ```
 
+```bash
+vp run vize:fmt
+vp run vize:lint
+vp run vize:check
+vp run vize:build
+vp run vize:ready
+```
+
+The npm package's `vize check` command uses the packaged NAPI checker and can emit Vue component
+declarations with `--declaration --declaration-dir dist/types`. Use the Rust CLI when you need
+`check-server`, LSP, IDE management, or project diagnostics across Vue, TS, TSX, and `.d.ts` inputs.
+
 ### 4. Full Rust CLI
 
-Use the Rust binary when you want the full native CLI today. For v1 alpha, the supported public
-channels are GitHub release binaries and the Nix entry point; the Rust CLI is not published through
-crates.io yet.
+Most application workflows should use the npm package scripts above. Use the Rust binary when you
+need the full native CLI today: LSP, IDE management, profiling, or `check-server`. For v1 alpha, the
+supported public channels are GitHub release binaries and the Nix entry point; the Rust CLI is not
+published through crates.io yet.
 
 ```bash
 nix run github:ubugeeei-prod/vize#vize -- --help
@@ -170,21 +175,33 @@ vize lsp
 This path is still maturing, so editor type checking remains an opt-in capability for now. The
 runtime stack is the `@typescript/native-preview` package, Corsa/corsa-bind is the API layer Vize
 talks to, and the executable installed by the TypeScript native preview is still commonly named
-`tsgo`. Use `typeChecker.corsaPath` or `vize check --corsa-path /path/to/tsgo` when you want to pin
-that runtime. `typeChecker.tsgoPath` remains a deprecated compatibility alias.
+`tsgo`. Use `typeChecker.corsaPath`, or a package script that runs
+`vize check --corsa-path /path/to/tsgo`, when you want to pin that runtime.
+`typeChecker.tsgoPath` remains a deprecated compatibility alias.
 
-Useful type-checking commands:
+Useful package-script targets:
+
+```json
+{
+  "scripts": {
+    "vize:check": "vize check",
+    "vize:check:app": "vize check --tsconfig tsconfig.app.json",
+    "vize:check:virtual-ts": "vize check --show-virtual-ts src/components/App.vue",
+    "vize:check:declarations": "vize check --declaration --declaration-dir dist/types"
+  }
+}
+```
 
 ```bash
-vize check
-vize check --tsconfig tsconfig.app.json
-vize check --show-virtual-ts src/components/App.vue
-vize check --declaration --declaration-dir dist/types
+vp run vize:check
+vp run vize:check:app
+vp run vize:check:virtual-ts
+vp run vize:check:declarations
 ```
 
 ## Shared `vize.config.*`
 
-The npm CLI and `@vizejs/vite-plugin` share config discovery:
+The npm package commands and `@vizejs/vite-plugin` share config discovery:
 
 - `vize.config.pkl`
 - `vize.config.ts`

--- a/docs/content/guide/cli.md
+++ b/docs/content/guide/cli.md
@@ -6,14 +6,43 @@ title: CLI
 
 > **⚠️ Work in Progress:** Vize is under active development and the CLI surface is still evolving.
 
-This page describes the Rust-native `vize` binary.
-The npm `vize` package exposes shared config helpers plus NAPI-backed `build`, `fmt`, `lint`,
-`check`, `clean`, `ready`, and `upgrade` commands. Install the Rust binary when you need LSP, IDE,
-`check-server`, or Corsa project diagnostics.
+Most application workflows should install the `vize` npm package and run it through `package.json`
+scripts. This page describes the lower-level Rust-native `vize` binary for LSP, IDE management,
+`check-server`, profiling, and other direct CLI workflows. The npm package exposes shared config
+helpers plus NAPI-backed `build`, `fmt`, `lint`, `check`, `clean`, `ready`, and `upgrade` commands.
 
 For a higher-level explanation of the analysis pipeline, see [Static Analysis](./static-analysis.md).
 
-## Installation
+## Application Package Scripts
+
+For apps, install from npm and wire stable commands into project scripts:
+
+```bash
+vp install -D vize
+```
+
+```json
+{
+  "scripts": {
+    "vize:build": "vize build src",
+    "vize:fmt": "vize fmt --write src",
+    "vize:lint": "vize lint --preset happy-path src",
+    "vize:check": "vize check src",
+    "vize:ready": "vize ready src"
+  }
+}
+```
+
+```bash
+vp run vize:lint
+vp run vize:check
+vp run vize:ready
+```
+
+Use `vp exec vize ...` for one-off local debugging, but prefer named scripts for documented
+workflows and CI.
+
+## Rust Binary Installation
 
 For v1 alpha, use the prebuilt GitHub release binaries or the Nix entry point. The Rust CLI is not a
 supported crates.io install channel yet.
@@ -31,14 +60,14 @@ For local development inside this repository, install the workspace build:
 cargo install --path crates/vize --force --locked
 ```
 
-## Rust CLI vs npm CLI
+## npm Package Scripts vs Rust CLI
 
-| Need                                                                   | Recommended entry point                 |
-| ---------------------------------------------------------------------- | --------------------------------------- |
-| Package scripts for build, format, lint, check, ready, and upgrade     | `vp exec vize ...` from the npm package |
-| Project-backed type checking across `.vue`, `.ts`, `.tsx`, and `.d.ts` | Rust `vize check`                       |
-| LSP, IDE setup, `check-server`, and profiling artifacts                | Rust `vize` binary                      |
-| Shared Vite plugin, npm CLI, and Rust CLI settings                     | `vize.config.*`                         |
+| Need                                                                   | Recommended entry point              |
+| ---------------------------------------------------------------------- | ------------------------------------ |
+| Package scripts for build, format, lint, check, ready, and upgrade     | `vp run vize:*` from the npm package |
+| Project-backed type checking across `.vue`, `.ts`, `.tsx`, and `.d.ts` | Rust `vize check`                    |
+| LSP, IDE setup, `check-server`, and profiling artifacts                | Rust `vize` binary                   |
+| Shared Vite plugin, npm package command, and Rust CLI settings         | `vize.config.*`                      |
 
 ## Commands
 
@@ -320,8 +349,8 @@ The `musea` subcommand currently focuses on scaffolding and experimental entry p
 For day-to-day gallery development, the recommended workflow today is
 `@vizejs/vite-plugin-musea`.
 
-The npm CLI also exposes a convenience `vize musea` command that runs Vite with the Musea plugin
-installed in your project:
+The npm package also exposes a convenience `vize musea` command that runs Vite with the Musea
+plugin installed in your project:
 
 ```bash
 vp exec vize musea

--- a/docs/content/guide/configuration.md
+++ b/docs/content/guide/configuration.md
@@ -4,12 +4,12 @@ title: Configuration
 
 # Configuration
 
-Vize uses `vize.config.*` for shared npm CLI, Vite plugin, and Rust CLI settings.
+Vize uses `vize.config.*` for shared npm package commands, Vite plugin, and Rust CLI settings.
 
 ## Config Files
 
-The npm CLI and `@vizejs/vite-plugin` load these files from the project root in this priority
-order:
+The npm package commands and `@vizejs/vite-plugin` load these files from the project root in this
+priority order:
 
 - `vize.config.pkl`
 - `vize.config.ts`
@@ -281,13 +281,13 @@ export default defineConfig({
 `typeChecker.tsconfig` and `typeChecker.corsaPath` are part of the shared schema, but the
 project-backed Corsa path is the Rust CLI surface today. `typeChecker.corsaPath` is shared by
 `vize check`, type-aware `vize lint`, and `vize lsp`; `typeChecker.tsgoPath` is a deprecated alias
-for older configs. Use `vize check --tsconfig ...` and `vize check --corsa-path ...` when you need
-command-line overrides.
+for older configs. Use package scripts such as `vize:check:app` or `vize:check:corsa` when you need
+command-line overrides for `--tsconfig` or `--corsa-path`.
 
 The runtime stack is `@typescript/native-preview`, the Corsa/corsa-bind API layer, and the installed
 `tsgo` executable name. Keep ambient declarations, generated auto-import files, path aliases, and
-Vue `ComponentCustomProperties` declarations in your project `tsconfig.json`; use
-`vize check --tsconfig ...` to select that project file.
+Vue `ComponentCustomProperties` declarations in your project `tsconfig.json`; use a package script
+that runs `vize check --tsconfig ...` to select that project file.
 
 ```json
 {

--- a/docs/content/guide/static-analysis.md
+++ b/docs/content/guide/static-analysis.md
@@ -8,6 +8,9 @@ Vize's analysis stack is shared by the compiler, linter, type checker, editor se
 tooling. The goal is to parse a Vue SFC once, keep rich semantic information around, and reuse it
 for diagnostics and code generation instead of treating each command as a separate tool.
 
+The examples below assume the `vize` npm package is installed and called from project scripts, which
+is the recommended workflow for applications.
+
 ## Pipeline
 
 | Layer    | What it does                                                              | Used by                                        |
@@ -29,26 +32,54 @@ For the concrete rule names, defaults, and cross-file diagnostic codes that can 
 
 Start with the default preset:
 
+```json
+{
+  "scripts": {
+    "vize:lint": "vize lint src"
+  }
+}
+```
+
 ```bash
-vize lint src
+vp run vize:lint
 ```
 
 Use `essential` for correctness-only CI, `happy-path` for the default recommended bundle,
 `opinionated` when you want stronger conventions, `nuxt` for Nuxt-aware assumptions, and
 `incremental` when you only want explicitly configured rules to run.
 
+```json
+{
+  "scripts": {
+    "vize:lint:ci": "vize lint --preset essential --max-warnings 0 src",
+    "vize:lint:opinionated": "vize lint --preset opinionated --help-level short src",
+    "vize:lint:json": "vize lint --format json src"
+  }
+}
+```
+
 ```bash
-vize lint --preset essential src
-vize lint --preset opinionated --help-level short src
-vize lint --format json --max-warnings 0 src
+vp run vize:lint:ci
+vp run vize:lint:opinionated
+vp run vize:lint:json
 ```
 
 Opt into cross-file and type-aware checks only after the basic lint path is stable:
 
+```json
+{
+  "scripts": {
+    "vize:lint:cross-file": "vize lint --cross-file src",
+    "vize:lint:cross-file-tree": "vize lint --cross-file --cross-file-tree src",
+    "vize:lint:strict-reactivity": "vize lint --strict-reactivity src"
+  }
+}
+```
+
 ```bash
-vize lint --cross-file src
-vize lint --cross-file --cross-file-tree src
-vize lint --strict-reactivity src
+vp run vize:lint:cross-file
+vp run vize:lint:cross-file-tree
+vp run vize:lint:strict-reactivity
 ```
 
 Cross-file linting analyzes relationships such as provide/inject and reactivity flow across a set of
@@ -97,8 +128,8 @@ reactivity tracking, and async race-condition analysis. `--cross-file-tree` prin
 provide/inject tree on top of those diagnostics.
 
 ```bash
-vize lint --cross-file src
-vize lint --cross-file --cross-file-tree src
+vp run vize:lint:cross-file
+vp run vize:lint:cross-file-tree
 ```
 
 The lower-level analyzer is broader than the current CLI surface:
@@ -128,11 +159,26 @@ CLI, Oxlint bridge, and editor server.
 diagnostics. It checks `.vue`, `.ts`, `.tsx`, and `.d.ts` inputs and maps diagnostics back to the
 original source files.
 
+```json
+{
+  "scripts": {
+    "vize:check": "vize check",
+    "vize:check:src": "vize check src",
+    "vize:check:app": "vize check --tsconfig tsconfig.app.json",
+    "vize:check:json": "vize check --format json --quiet",
+    "vize:check:virtual-ts": "vize check --show-virtual-ts src/components/App.vue",
+    "vize:check:profile": "vize check --profile src",
+    "vize:check:single-server": "vize check --servers 1 src",
+    "vize:check:declarations": "vize check --declaration --declaration-dir dist/types"
+  }
+}
+```
+
 ```bash
-vize check
-vize check src
-vize check --tsconfig tsconfig.app.json
-vize check --format json --quiet
+vp run vize:check
+vp run vize:check:src
+vp run vize:check:app
+vp run vize:check:json
 ```
 
 When no paths are provided, `vize check` reads `tsconfig.json` `files`, `include`, and `exclude`
@@ -140,15 +186,15 @@ fields if a project config is available. Use `--show-virtual-ts` when debugging 
 `--profile` when you need timing and virtual-file artifacts under `node_modules/.vize`.
 
 ```bash
-vize check --show-virtual-ts src/components/App.vue
-vize check --profile src
-vize check --servers 1 src
+vp run vize:check:virtual-ts
+vp run vize:check:profile
+vp run vize:check:single-server
 ```
 
 Declaration output is available from the materialized checker project:
 
 ```bash
-vize check --declaration --declaration-dir dist/types
+vp run vize:check:declarations
 ```
 
 Project-wide template values and generated declaration files should be visible through TypeScript
@@ -172,17 +218,27 @@ declare module "vue" {
 ```
 
 ```bash
-vize check --tsconfig tsconfig.app.json
+vp run vize:check:app
 ```
 
-## npm CLI vs Rust CLI
+## npm Package Scripts vs Rust CLI
 
 The npm `vize` package is intended for package scripts and uses the packaged NAPI binding:
 
+```json
+{
+  "scripts": {
+    "vize:lint": "vize lint src",
+    "vize:check": "vize check src --strict",
+    "vize:ready": "vize ready src"
+  }
+}
+```
+
 ```bash
-vp exec vize lint src
-vp exec vize check src --strict
-vp exec vize ready src
+vp run vize:lint
+vp run vize:check
+vp run vize:ready
 ```
 
 The Rust CLI currently has the fuller project-backed type-checking surface:
@@ -193,9 +249,9 @@ vize check --tsconfig tsconfig.app.json --profile src
 vize lsp
 ```
 
-Use the npm CLI when you want installable scripts in an application. Use the Rust CLI when you need
-`check-server`, LSP, IDE management, or the Corsa-backed project diagnostics path across Vue and
-TypeScript files.
+Use npm package scripts when you want installable workflows in an application. Use the Rust CLI when
+you need `check-server`, LSP, IDE management, or the Corsa-backed project diagnostics path across
+Vue and TypeScript files.
 
 ## Oxlint
 
@@ -227,11 +283,11 @@ vp exec oxlint-vize -c .oxlintrc.json -f stylish src
 
 ## Adoption Path
 
-1. Add `vize lint --preset essential src` to CI.
+1. Add a `vize:lint:ci` package script such as `vize lint --preset essential src` to CI.
 2. Switch to `happy-path` or `opinionated` after correctness diagnostics are clean.
-3. Add `vize check` with your project `tsconfig.json`.
+3. Add a `vize:check` package script with your project `tsconfig.json`.
 4. Enable editor linting first, then type checking once CI output is stable.
 5. Add cross-file and strict reactivity checks for projects that benefit from deeper analysis.
 
-For a single quality gate, `vize ready src` runs `fmt --write`, `lint`, `check`, and `build` in
-order and stops at the first failing step.
+For a single quality gate, a `vize:ready` package script running `vize ready src` runs `fmt
+--write`, `lint`, `check`, and `build` in order and stops at the first failing step.

--- a/docs/content/guide/vite-plugin.md
+++ b/docs/content/guide/vite-plugin.md
@@ -21,7 +21,7 @@ vp install -D @vizejs/vite-plugin
 ```
 
 Add `vize` as a direct dependency only if your project imports shared config helpers from `"vize"`
-or runs the npm CLI through `vp exec vize`.
+or exposes package scripts such as `vize:lint` and `vize:check`.
 
 ## Basic Usage
 
@@ -67,7 +67,8 @@ For most projects, keep direct plugin options small and put stable compiler sett
 
 ## Shared Config
 
-The recommended shared entry point is `vize`. A single `vize.config.*` file is read by both the npm CLI and `@vizejs/vite-plugin`.
+The recommended shared entry point is `vize`. A single `vize.config.*` file is read by both the npm
+package commands and `@vizejs/vite-plugin`.
 
 ```bash
 vp install -D vize

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -33,10 +33,10 @@ features:
     details: Configure compiler options, Vite scanning, lint presets, type checking, formatting, LSP features, and Musea from `vize.config.*`.
     link: guide/configuration.md
   - title: Native Type Checking
-    details: "`vize check` runs through `vize_canon` and Corsa project sessions backed by `corsa-bind`, keeping Vue-aware diagnostics on a native path."
+    details: "`vize:check` package scripts run through `vize_canon` and Corsa project sessions backed by `corsa-bind`, keeping Vue-aware diagnostics on a native path."
     link: guide/static-analysis.md
-  - title: CLI Reference
-    details: Compile, format, lint, and type-check Vue SFC files from native commands when scripts or terminal workflows are the right entry point.
+  - title: Package Scripts and CLI Reference
+    details: Use the npm package from project scripts for app workflows, with the Rust CLI documented for LSP, profiling, and direct binary use.
     link: guide/cli.md
   - title: Compiler Inspector
     details: Inspect Vue output, Vize output, Virtual TS, VIR, and cross-file graphs, then share permalinked repros or agent reports.
@@ -72,7 +72,10 @@ features:
 
 ## Current Direction
 
-One of the biggest recent shifts in Vize is native type checking. `vize check` and the editor-facing type-check pipeline are moving onto `vize_canon` plus [`corsa-bind`](https://github.com/ubugeeei/corsa-bind), which lets Vize keep Vue virtual files and TypeScript project diagnostics on a native path for longer.
+One of the biggest recent shifts in Vize is native type checking. The `vize check` command used by
+npm package scripts and the editor-facing type-check pipeline are moving onto `vize_canon` plus
+[`corsa-bind`](https://github.com/ubugeeei/corsa-bind), which lets Vize keep Vue virtual files and
+TypeScript project diagnostics on a native path for longer.
 
 That matters for more than raw speed. It gives Vize a tighter loop between template analysis, diagnostics, navigation, and future editor features, while reducing the amount of work that has to bounce back through a JavaScript-hosted compiler process. The fidelity story is still catching up, but this is the direction the toolchain is clearly heading.
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -10,7 +10,8 @@ Run the following from the project root before using the examples:
 nix develop
 vp env install
 vp install
-vp run --workspace-root cli  # Enable the vize CLI command
+vp run --workspace-root build:native
+vp run --filter './npm/vize' build
 ```
 
 Or build directly with Cargo:
@@ -21,9 +22,11 @@ cargo build --release
 
 ---
 
-## CLI Examples
+## npm Package Command Examples
 
-The `examples/cli/` directory contains sample Vue files for trying the CLI tools.
+The `examples/cli/` directory contains sample Vue files for trying the `vize` npm package commands.
+In application projects, prefer package scripts. In this workspace, use `vp exec vize ...` after
+building the local package.
 
 ### File Structure
 
@@ -37,16 +40,16 @@ The `examples/cli/` directory contains sample Vue files for trying the CLI tools
 
 ```bash
 # Check whether formatting is needed
-vize fmt examples/cli/src/*.vue --check
+vp exec vize fmt examples/cli/src/*.vue --check
 
 # Print the formatted result without changing files
-vize fmt examples/cli/src/Unformatted.vue
+vp exec vize fmt examples/cli/src/Unformatted.vue
 
 # Write changes to the file
-vize fmt examples/cli/src/Unformatted.vue --write
+vp exec vize fmt examples/cli/src/Unformatted.vue --write
 
 # With options
-vize fmt examples/cli/src/*.vue --single-quote --no-semi --print-width 80
+vp exec vize fmt examples/cli/src/*.vue --single-quote --no-semi --print-width 80
 ```
 
 **Options:**
@@ -65,22 +68,22 @@ vize fmt examples/cli/src/*.vue --single-quote --no-semi --print-width 80
 
 ```bash
 # Show lint errors
-vize lint examples/cli/src/*.vue
+vp exec vize lint examples/cli/src/*.vue
 
 # Output as JSON
-vize lint examples/cli/src/HasErrors.vue --format json
+vp exec vize lint examples/cli/src/HasErrors.vue --format json
 
 # Output as plain text for hooks and agents
-vize lint examples/cli/src/HasErrors.vue --format plain
+vp exec vize lint examples/cli/src/HasErrors.vue --format plain
 
 # Set a warning limit
-vize lint examples/cli/src/*.vue --max-warnings 5
+vp exec vize lint examples/cli/src/*.vue --max-warnings 5
 
 # Show only the summary
-vize lint examples/cli/src/*.vue --quiet
+vp exec vize lint examples/cli/src/*.vue --quiet
 
 # Print rule and file timing
-vize lint examples/cli/src/*.vue --profile
+vp exec vize lint examples/cli/src/*.vue --profile
 ```
 
 `src/HasErrors.vue` intentionally includes missing `v-for` keys, a `v-if`/`v-for` conflict, a
@@ -97,7 +100,10 @@ The SSR rule docs include extra boundary examples for `typeof window`, comments,
 | `--quiet`, `-q`  | Show only the summary                                                            | false   |
 | `--fix`          | Auto-fix (not implemented yet)                                                   | false   |
 
-### LSP Server (`vize lsp`)
+### Rust LSP Server (`vize lsp`)
+
+The npm package does not provide the LSP server. Use the Rust binary when you need editor protocol
+experiments from the command line.
 
 ```bash
 # Start with stdio (for editor integration)
@@ -256,13 +262,14 @@ Current observed behavior in this repository: that probe reports `0` findings on
 
 ## Troubleshooting
 
-### `vize` Command Not Found
+### `vp exec vize` Command Not Found
 
 ```bash
-# Enable the CLI from vp run
-vp run --workspace-root cli
+# Build the local native binding and npm package
+vp run --workspace-root build:native
+vp run --filter './npm/vize' build
 
-# Or use cargo run directly
+# Or use the Rust CLI directly for CLI-only debugging
 cargo run --release -- fmt examples/cli/src/*.vue
 ```
 

--- a/npm/vize/README.md
+++ b/npm/vize/README.md
@@ -1,14 +1,12 @@
 # Vize
 
-The `vize` npm package provides:
+The `vize` npm package is the default application-facing entry point for package scripts and shared
+configuration. It provides:
 
 - shared config utilities (`defineConfig`, `loadConfig`)
-- the native `vize build` command
-- the native `vize fmt` command
-- the native `vize lint` command
-- the native `vize check` command for package scripts
-- `vize ready` for `fmt --write -> lint -> check -> build`
-- `vize upgrade` for updating the npm package
+- package-script commands backed by the native binding: `build`, `fmt`, `lint`, and `check`
+- `ready` for `fmt --write -> lint -> check -> build`
+- `upgrade` for updating the npm package
 
 For Vite integration, pair it with `@vizejs/vite-plugin`.
 For the full Rust-native CLI (`lsp`, `ide`, project-backed `check`, and `check-server`), use the
@@ -27,34 +25,41 @@ The package declares the `@typescript/native-preview` Corsa runtime as an option
 standard installs include the runtime needed by `vize check`. The `--corsa-path` CLI option remains
 available for custom native TypeScript builds.
 
-## CLI
+## Package Scripts
 
-The npm CLI exposes the common package-script commands:
-
-```bash
-vp exec vize build src
-vp exec vize fmt --write src
-vp exec vize lint --preset happy-path src
-vp exec vize check src
-vp exec vize ready src
-vp exec vize upgrade
-```
-
-Recommended scripts:
+Add scripts to your project and run Vize through your package manager:
 
 ```json
 {
   "scripts": {
-    "vue:build": "vize build src",
-    "vue:fmt": "vize fmt --write src",
-    "vue:lint": "vize lint --preset happy-path src",
-    "vue:check": "vize check src",
-    "vue:ready": "vize ready src"
+    "vize:build": "vize build src",
+    "vize:fmt": "vize fmt --write src",
+    "vize:lint": "vize lint --preset happy-path src",
+    "vize:check": "vize check src",
+    "vize:ready": "vize ready src",
+    "vize:upgrade": "vize upgrade"
   }
 }
 ```
 
-Shared config discovery is supported for the npm CLI:
+Then run:
+
+```bash
+vp run vize:build
+vp run vize:fmt
+vp run vize:lint
+vp run vize:check
+vp run vize:ready
+vp run vize:upgrade
+```
+
+For one-off local debugging, the installed binary is also available through npm exec:
+
+```bash
+vp exec vize lint --preset essential src
+```
+
+Shared config discovery is supported for the npm package commands:
 
 - `vize.config.pkl`
 - `vize.config.ts`
@@ -93,15 +98,29 @@ Override config discovery with `--config`, or disable it with `--no-config`.
 
 ## Static Analysis
 
-`vize lint` runs Vue-aware Patina diagnostics through the native binding:
+`vize lint` runs Vue-aware Patina diagnostics through the native binding. Prefer named package
+scripts for the presets your project uses:
+
+```json
+{
+  "scripts": {
+    "vize:lint:ci": "vize lint --preset essential --max-warnings 0 src",
+    "vize:lint:ecosystem": "vize lint --preset ecosystem src",
+    "vize:lint:opinionated": "vize lint --preset opinionated --help-level short src",
+    "vize:lint:json": "vize lint --format json src",
+    "vize:lint:plain": "vize lint --format plain src",
+    "vize:lint:agent": "vize lint --format agent src"
+  }
+}
+```
 
 ```bash
-vp exec vize lint --preset essential --max-warnings 0 src
-vp exec vize lint --preset ecosystem src
-vp exec vize lint --preset opinionated --help-level short src
-vp exec vize lint --format json src
-vp exec vize lint --format plain src
-vp exec vize lint --format agent src
+vp run vize:lint:ci
+vp run vize:lint:ecosystem
+vp run vize:lint:opinionated
+vp run vize:lint:json
+vp run vize:lint:plain
+vp run vize:lint:agent
 ```
 
 Lint output supports `text`, `ansi`, `plain`, `json`, `stylish`, `markdown`, `html`, and `agent`.
@@ -111,10 +130,20 @@ The human and agent-friendly formats include local rule documentation paths such
 `vize check` in the npm package uses the packaged NAPI checker and the `@typescript/native-preview`
 Corsa runtime, so it can run from `package.json` scripts after installing `vize`:
 
+```json
+{
+  "scripts": {
+    "vize:check:strict": "vize check src --strict",
+    "vize:check:virtual-ts": "vize check src --show-virtual-ts",
+    "vize:check:declarations": "vize check src --declaration --declaration-dir dist/types"
+  }
+}
+```
+
 ```bash
-vp exec vize check src --strict
-vp exec vize check src --show-virtual-ts
-vp exec vize check src --declaration --declaration-dir dist/types
+vp run vize:check:strict
+vp run vize:check:virtual-ts
+vp run vize:check:declarations
 ```
 
 Use the Rust CLI when you need Corsa project diagnostics across Vue, TS, TSX, and `.d.ts` inputs.


### PR DESCRIPTION
## Summary

- Reposition the public Vize docs around npm package scripts as the default application workflow.
- Update Getting Started, package README, static-analysis guidance, examples, and related config/plugin docs to prefer `vp run vize:*` package scripts.
- Keep the Rust binary documented for LSP, profiling, `check-server`, and other direct CLI workflows.

## Change Class

- [ ] Parser or AST
- [ ] Compiler and codegen
- [ ] Semantic analysis, lint, and cross-file analysis
- [ ] Virtual TypeScript and type checking
- [ ] Formatter and LSP
- [x] Runtime packaging, release, or docs
- [ ] Not language-facing

## Behavior Reference

Requested docs direction: direct Vize CLI usage is not the common path, so user-facing guidance should assume npm-based usage.

## Verification Evidence

- [ ] Minimal fixture or focused regression test added or updated
- [ ] Snapshot/baseline changes reviewed and explained
- [ ] Parity or real-world fixture coverage considered
- [ ] Security/audit impact considered
- [ ] Performance status or PR benchmark impact considered
- [ ] Fuzzing target or crash-reproducer coverage considered
- [ ] Editor/LSP scenario coverage considered
- [ ] Ecosystem or broad app compatibility impact considered
- [x] Docs, release, or stability notes updated when public behavior changed

Commands run:

- `vp fmt --check README.md npm/vize/README.md examples/README.md docs/content/index.md docs/content/getting-started.md docs/content/guide/cli.md docs/content/guide/static-analysis.md docs/content/guide/vite-plugin.md docs/content/guide/configuration.md`
- `git diff --check`
- `vp run --filter './npm/vite-plugin-vize' build`
- `vp run --filter './docs' build` exited 0 and generated docs output. The existing OG image step still logs `[ox-content:og-image] @vizejs/vite-plugin is required when vuePlugin is 'vizejs'`, but the docs build command completes successfully.

## Risk

Docs-only change. No runtime behavior, package manifest, or generated snapshot changes are included.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1118"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783429916&installation_id=136613492&pr_number=1118&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1118&signature=0a5cb12b4e6898e678c22b14636c6ddc05847401bee218587322c2677dc22c7a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->