### PR TITLE
feat(legacy): type literal Vue 2 data() bindings in the virtual TS

### DIFF
--- a/crates/vize_canon/Cargo.toml
+++ b/crates/vize_canon/Cargo.toml
@@ -12,7 +12,7 @@ default = ["native"]
 native = ["dep:which", "dep:walkdir", "dep:dirs", "dep:corsa", "dep:lsp-types"]
 # Opt-in legacy Vue (v0 / v1 / v2) type-checking surface. Not enabled by the
 # default Vue 3 build; turns on the parser-side legacy feature too.
-legacy = ["vize_armature/legacy"]
+legacy = ["vize_armature/legacy", "vize_croquis/legacy"]
 
 [dependencies]
 vize_carton.workspace = true

--- a/crates/vize_canon/src/sfc_typecheck.rs
+++ b/crates/vize_canon/src/sfc_typecheck.rs
@@ -463,6 +463,38 @@ export default {
         );
     }
 
+    #[cfg(feature = "legacy")]
+    #[test]
+    fn test_legacy_vue2_data_literal_types_in_virtual_ts() {
+        let source = r#"<script lang="ts">
+export default {
+  data() {
+    return { count: 1, label: 'x', flag: true, other: window.foo }
+  }
+}
+</script>
+<template>
+  <div>{{ count }} {{ label }} {{ flag }} {{ other }}</div>
+</template>"#;
+
+        let mut options = SfcTypeCheckOptions::new("Legacy.vue");
+        options.include_virtual_ts = true;
+        let result = type_check_sfc_with_legacy_vue2(source, &options);
+        let ts = result
+            .virtual_ts
+            .expect("virtual TypeScript should be generated");
+
+        // Literal `data()` initializers now carry precise types instead of `any`,
+        // so the type checker can flag misuse (e.g. `count.toUpperCase()`).
+        assert!(ts.contains("const count: number"), "virtual ts:\n{ts}");
+        assert!(ts.contains("const label: string"), "virtual ts:\n{ts}");
+        assert!(ts.contains("const flag: boolean"), "virtual ts:\n{ts}");
+
+        // A non-literal initializer keeps the permissive `any` fallback, so the
+        // deepened typing never introduces a false template type error.
+        assert!(ts.contains("const other: any"), "virtual ts:\n{ts}");
+    }
+
     #[test]
     fn test_type_check_template_undefined_binding_uses_expression_offset() {
         let source = r#"<script lang="ts"></script>

--- a/crates/vize_canon/src/virtual_ts/generator.rs
+++ b/crates/vize_canon/src/virtual_ts/generator.rs
@@ -970,7 +970,15 @@ fn generate_legacy_vue2_variables(
 
     ts.push_str("  // Vue 2.7 / Nuxt 2 Options API template bindings\n");
     for name in &names {
-        append!(ts, "  const {name}: any = undefined as any;\n");
+        // Prefer a type inferred from a literal `data()` initializer when one
+        // was recorded during analysis; otherwise fall back to the permissive
+        // `any` that keeps templates type-checking loosely.
+        let ty = summary
+            .bindings
+            .legacy_template_binding_types
+            .get(*name)
+            .map_or("any", |ts_type| ts_type.as_str());
+        append!(ts, "  const {name}: {ty} = undefined as any;\n");
     }
     ts.push_str("  ");
     for name in &names {

--- a/crates/vize_croquis/Cargo.toml
+++ b/crates/vize_croquis/Cargo.toml
@@ -7,6 +7,11 @@ license.workspace = true
 repository.workspace = true
 description = "Croquis - Semantic analysis layer for Vize. Quick sketches of meaning from Vue templates"
 
+[features]
+# Opt-in legacy Vue (v0 / v1 / v2) analysis surface. Compiled out of the default
+# Vue 3 build, so legacy support adds zero cost to the standard pipeline.
+legacy = []
+
 [dependencies]
 vize_carton.workspace = true
 vize_relief.workspace = true

--- a/crates/vize_croquis/src/analysis/bindings.rs
+++ b/crates/vize_croquis/src/analysis/bindings.rs
@@ -30,7 +30,7 @@ use vize_relief::BindingType;
 ///
 /// This is compatible with the existing BindingMetadata in atelier_core
 /// but uses CompactString for efficiency.
-#[derive(Debug, Default, Clone)]
+#[derive(Default, Clone)]
 pub struct BindingMetadata {
     /// Binding name to type mapping
     pub bindings: FxHashMap<CompactString, BindingType>,
@@ -40,6 +40,32 @@ pub struct BindingMetadata {
 
     /// Props aliases (local name -> prop key)
     pub props_aliases: FxHashMap<CompactString, CompactString>,
+
+    /// Inferred TypeScript types for legacy Vue 2.7 / Nuxt 2 Options API
+    /// template bindings (currently `data()` properties), keyed by binding name.
+    ///
+    /// Lets the virtual-TS generator emit a precise declaration
+    /// (`const count: number`) instead of `const count: any` for the common
+    /// case of literal-initialized data. Gated behind the `legacy` feature, so
+    /// the field — and every write to it — is compiled out of the default Vue 3
+    /// build and never touches the standard pipeline.
+    #[cfg(feature = "legacy")]
+    pub legacy_template_binding_types: FxHashMap<CompactString, CompactString>,
+}
+
+// `Debug` is hand-written (rather than derived) so the optional, legacy-only
+// `legacy_template_binding_types` side-table never leaks into Debug output or
+// snapshots. It is an internal type-inference cache, not part of a binding
+// set's identity, and the default Vue 3 build does not compile the field at all
+// — keeping the derived-equivalent output stable across both feature configs.
+impl core::fmt::Debug for BindingMetadata {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("BindingMetadata")
+            .field("bindings", &self.bindings)
+            .field("is_script_setup", &self.is_script_setup)
+            .field("props_aliases", &self.props_aliases)
+            .finish()
+    }
 }
 
 impl BindingMetadata {
@@ -63,6 +89,16 @@ impl BindingMetadata {
     pub fn add(&mut self, name: impl AsRef<str>, binding_type: BindingType) {
         self.bindings
             .insert(CompactString::new(name.as_ref()), binding_type);
+    }
+
+    /// Record an inferred TypeScript type for a legacy Vue 2 template binding.
+    ///
+    /// Legacy-only: compiled out of the default Vue 3 build.
+    #[cfg(feature = "legacy")]
+    #[inline]
+    pub fn set_legacy_template_binding_type(&mut self, name: &str, ts_type: &str) {
+        self.legacy_template_binding_types
+            .insert(CompactString::new(name), CompactString::new(ts_type));
     }
 
     /// Get binding type for a name

--- a/crates/vize_croquis/src/script_parser.rs
+++ b/crates/vize_croquis/src/script_parser.rs
@@ -882,6 +882,48 @@ export default {
         }
     }
 
+    #[cfg(feature = "legacy")]
+    #[test]
+    fn test_legacy_vue2_data_literal_types_are_inferred() {
+        let source = r#"
+export default {
+  data() {
+    return {
+      count: 0,
+      label: 'hello',
+      flag: true,
+      big: 10n,
+      tpl: `plain`,
+      computedish: this.count,
+      arr: [],
+      obj: {}
+    }
+  }
+}
+"#;
+        let result = parse_script_with_options(source, ScriptParserOptions { legacy_vue2: true });
+        let types = &result.bindings.legacy_template_binding_types;
+
+        // Literal initializers get a precise TS type instead of `any`.
+        assert_eq!(types.get("count").map(|t| t.as_str()), Some("number"));
+        assert_eq!(types.get("label").map(|t| t.as_str()), Some("string"));
+        assert_eq!(types.get("flag").map(|t| t.as_str()), Some("boolean"));
+        assert_eq!(types.get("big").map(|t| t.as_str()), Some("bigint"));
+        assert_eq!(types.get("tpl").map(|t| t.as_str()), Some("string"));
+
+        // Non-literal / structural initializers are intentionally left untyped,
+        // so the virtual TS keeps emitting the permissive `any` fallback and
+        // deepening the types can never introduce a false template type error.
+        assert_eq!(types.get("computedish"), None);
+        assert_eq!(types.get("arr"), None);
+        assert_eq!(types.get("obj"), None);
+
+        // The bindings themselves are still collected for template resolution.
+        for name in ["count", "computedish", "arr", "obj"] {
+            assert!(result.bindings.contains(name), "missing binding {name}");
+        }
+    }
+
     #[test]
     fn test_deeply_nested_callbacks() {
         let result = parse_script_setup(

--- a/crates/vize_croquis/src/script_parser/process.rs
+++ b/crates/vize_croquis/src/script_parser/process.rs
@@ -650,6 +650,40 @@ fn collect_object_property_bindings(
         };
         let span = property.key.span();
         add_template_binding(result, name.as_str(), binding_type, span.start, span.end);
+
+        // Legacy Vue 2: when a `data()` property is initialized with a literal,
+        // record its precise TS type so the virtual TS can declare
+        // `const x: number` instead of `const x: any`. Gated behind `legacy`, so
+        // this — and the side-table it writes to — is compiled out of the
+        // default Vue 3 build and adds no cost to the standard pipeline.
+        #[cfg(feature = "legacy")]
+        if matches!(binding_type, BindingType::Data)
+            && let Some(ts_type) = infer_legacy_literal_ts_type(&property.value)
+        {
+            result
+                .bindings
+                .set_legacy_template_binding_type(name.as_str(), ts_type);
+        }
+    }
+}
+
+/// Infer a precise TypeScript type for a literal-initialized legacy Vue 2
+/// `data()` property.
+///
+/// Returns `None` — keeping the permissive `any` fallback — for anything whose
+/// type cannot be derived soundly from a literal initializer, so deepening the
+/// types can never introduce a false template type error (a strict superset of
+/// the previous `any` behavior).
+#[cfg(feature = "legacy")]
+fn infer_legacy_literal_ts_type(value: &Expression<'_>) -> Option<&'static str> {
+    match value {
+        Expression::NumericLiteral(_) => Some("number"),
+        Expression::StringLiteral(_) => Some("string"),
+        Expression::BooleanLiteral(_) => Some("boolean"),
+        Expression::BigIntLiteral(_) => Some("bigint"),
+        // A template literal with no `${...}` substitutions is always a string.
+        Expression::TemplateLiteral(template) if template.expressions.is_empty() => Some("string"),
+        _ => None,
     }
 }
 


### PR DESCRIPTION
## What

Deepens opt-in legacy **Vue 2.7 / Nuxt 2** Options API type-checking: a `data()` property initialized with a literal now gets a precise TypeScript type in the generated virtual TS instead of the blanket `any`.

```vue
<script>
export default { data() { return { count: 1, label: 'x', flag: true } } }
</script>
```

Virtual TS, before → after:

```diff
- const count: any = undefined as any;
- const label: any = undefined as any;
- const flag: any = undefined as any;
+ const count: number = undefined as any;
+ const label: string = undefined as any;
+ const flag: boolean = undefined as any;
```

So the type checker can now catch e.g. `{{ count.toUpperCase() }}` in a Vue 2 template. Inference is sound-by-construction: only number / string / boolean / bigint / substitution-free template literals are typed; **anything else falls back to `any`**, so this is a strict superset of the previous behavior and can never introduce a false template type error. (`computed` / `methods` return-type inference are natural follow-ups built on the same plumbing.)

## Zero-cost for the default Vue 3 build

The whole feature is gated behind the `legacy` cargo feature and **compiled out** of the standard pipeline — no runtime branch, no struct growth, no memory on the Vue 3 path:

- New `vize_croquis` `legacy` feature (wired from `vize_canon/legacy`).
- The type side-table (`BindingMetadata::legacy_template_binding_types`), the inference (`infer_legacy_literal_ts_type`), the capture in `data()` collection, and the precise-type emission in the virtual-TS generator are **all `#[cfg(feature = "legacy")]`** — they do not exist in the default binary.
- `BindingMetadata`'s `Debug` is hand-written to omit the legacy-only side-table, so the field is invisible to snapshots/diagnostics and the default and legacy builds produce identical debug output.

## Verification

- **Default (Vue 3): zero regression** — `cargo test -p vize_croquis -p vize_canon -p vize_atelier_sfc` all green, output byte-identical (the new code is cfg'd out).
- **Legacy** — `cargo test -p vize_croquis -p vize_canon --features legacy` green, incl. two new tests: literal inference in `vize_croquis`, and end-to-end `const count: number` in the generated virtual TS (`vize_canon`).
- `cargo clippy --features legacy -- -D warnings` clean; `cargo fmt --check` clean; `vize` CLI builds with and without `--features legacy`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1119"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783432877&installation_id=136613492&pr_number=1119&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1119&signature=e64aa2e2f10e163aff07c8c730b56271db2ac385c6203d5e56dd2bc84a3db467"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->