### PR TITLE
docs: expand credits descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,9 @@ Special thanks to:
   ([report](https://github.com/ubugeeei-prod/vize/discussions/71)).
 - [ushironoko](https://github.com/ushironoko) for compiler, linter, and CLI bug reports,
   reference implementations, and reproduction repositories.
-- [dannote](https://github.com/dannote) for Elixier feedback, PRs, and CSS-facing fixes.
+- [dannote](https://github.com/dannote) for bringing Vize into the Elixir community through
+  [Volt](https://hexdocs.pm/volt/readme.html), an Elixir-native frontend toolchain built on Vize,
+  and for reporting missing pieces and sending PRs as Volt adopted Vize as a foundation.
 - [n13u](https://x.com/%5Fn13u%5F) and `#frontend_phpcon_do` for persistently reporting bugs while
   building a Nuxt-based conference website with Vize, then carrying that validation all the way to
   production adoption

--- a/README.md
+++ b/README.md
@@ -82,18 +82,24 @@ This project draws inspiration from [Volar.js](https://github.com/volarjs/volar.
 
 Special thanks to:
 
-- [Blacksmith](https://www.blacksmith.sh/) for sponsoring CI/CD runner infrastructure.
-- [かっこかり](https://github.com/kakkokari-gtyih) for regular debugging and monitoring around
-  [Misskey](https://github.com/misskey-dev/misskey) (~103k lines of Vue across 586 SFCs), including many compiler-focused bug reports.
+- [Blacksmith](https://www.blacksmith.sh/) for sponsoring high-performance CI/CD runners and
+  Testbox infrastructure for frequent benchmarks and real-project compatibility checks.
+- [かっこかり](https://github.com/kakkokari-gtyih) for continuously testing Vize's compiler and
+  Vite Plugin on [Misskey](https://github.com/misskey-dev/misskey) (~103k lines of Vue across 586
+  SFCs), with timely reports as the implementation changed
+  ([report](https://github.com/ubugeeei-prod/vize/discussions/71)).
 - [ushironoko](https://github.com/ushironoko) for compiler, linter, and CLI bug reports,
   reference implementations, and reproduction repositories.
 - [dannote](https://github.com/dannote) for Elixier feedback, PRs, and CSS-facing fixes.
-- [n13u](https://x.com/%5Fn13u%5F) and `#frontend_phpcon_do` for Nuxt build debugging, reports,
-  and production validation
-  ([report](https://x.com/%5Fn13u%5F/status/2061408599788892230?s=20)).
-- [sevenc-nanashi](https://github.com/sevenc-nanashi) for building the
-  [VOICEVOX](https://github.com/VOICEVOX/voicevox) editor (~26k lines of Vue across 128 SFCs)
-  against Vize as a real-world milestone and compatibility feedback.
+- [n13u](https://x.com/%5Fn13u%5F) and `#frontend_phpcon_do` for persistently reporting bugs while
+  building a Nuxt-based conference website with Vize, then carrying that validation all the way to
+  production adoption
+  ([report](https://x.com/%5Fn13u%5F/status/2061408599788892230?s=20),
+  [write-up](https://www.n13u.dev/ja/blog/detail/nYZKQ3UmslmWfXaP)).
+- [sevenc-nanashi](https://github.com/sevenc-nanashi) for using the
+  [VOICEVOX](https://github.com/VOICEVOX/voicevox) editor (~26k lines of Vue across 128 SFCs) as a
+  real-world target for improving compiler precision
+  ([report](https://github.com/ubugeeei-prod/vize/discussions/955)).
 - Everyone who has mentioned, shared, tested, or amplified Vize across the community.
 
 ## License

--- a/README.md
+++ b/README.md
@@ -84,6 +84,11 @@ Special thanks to:
 
 - [Blacksmith](https://www.blacksmith.sh/) for sponsoring high-performance CI/CD runners and
   Testbox infrastructure for frequent benchmarks and real-project compatibility checks.
+- [Mates Inc.](https://eng.mates.education/) for allowing ubugeeei, its employee, to dedicate
+  discretionary work time to OSS and for adopting Vize in the build for the company's engineering
+  website.
+- [OpenAI Codex for Open Source](https://openai.com/form/codex-for-oss/) for supporting
+  open-source maintainers through a program that helps keep critical OSS development moving.
 - [かっこかり](https://github.com/kakkokari-gtyih) for continuously testing Vize's compiler and
   Vite Plugin on [Misskey](https://github.com/misskey-dev/misskey) (~103k lines of Vue across 586
   SFCs), with timely reports as the implementation changed
@@ -103,6 +108,10 @@ Special thanks to:
   real-world target for improving compiler precision
   ([report](https://github.com/ubugeeei-prod/vize/discussions/955)).
 - Everyone who has mentioned, shared, tested, or amplified Vize across the community.
+
+Vize is a personal project by ubugeeei, licensed under the MIT License and maintained as a
+non-commercial OSS effort. It is not owned by any specific company, is intended to remain open, and
+is not being built with a buyout in mind.
 
 ## License
 

--- a/docs/content/credits.md
+++ b/docs/content/credits.md
@@ -11,6 +11,11 @@ tooling, and ecosystem experiments. In particular, thank you to:
 - [Blacksmith](https://www.blacksmith.sh/) for sponsoring high-performance CI/CD runners and
   Testbox infrastructure, giving Vize the compute needed to run frequent benchmarks and
   compatibility checks across real projects.
+- [Mates Inc.](https://eng.mates.education/) for allowing ubugeeei, its employee, to dedicate
+  discretionary work time to OSS and for adopting Vize in the build for the company's engineering
+  website.
+- [OpenAI Codex for Open Source](https://openai.com/form/codex-for-oss/) for supporting
+  open-source maintainers through a program that helps keep critical OSS development moving.
 - [かっこかり](https://github.com/kakkokari-gtyih) for continuously testing Vize's compiler and
   Vite Plugin on [Misskey](https://github.com/misskey-dev/misskey) — a Vue application with
   ~103k lines of Vue across 586 SFCs — and sending timely reports as the implementation changed
@@ -39,3 +44,7 @@ tooling, and ecosystem experiments. In particular, thank you to:
 Thanks also to everyone who has mentioned, shared, tested, or amplified Vize in the community, and
 to everyone connected to that work. Those signals make it easier to see where the toolchain is
 useful, where it breaks, and what it should become next.
+
+Vize is a personal project by ubugeeei, licensed under the MIT License and maintained as a
+non-commercial OSS effort. It is not owned by any specific company, is intended to remain open, and
+is not being built with a buyout in mind.

--- a/docs/content/credits.md
+++ b/docs/content/credits.md
@@ -18,8 +18,9 @@ tooling, and ecosystem experiments. In particular, thank you to:
 - [ushironoko](https://github.com/ushironoko) for bug reports from the compiler, linter, and CLI
   sides of the project, along with reference implementations for fixes and reproduction
   repositories for difficult issues.
-- [dannote](https://github.com/dannote) for feedback and pull requests from the Elixier ecosystem,
-  especially for CSS-facing APIs and bug fixes.
+- [dannote](https://github.com/dannote) for bringing Vize into the Elixir community through
+  [Volt](https://hexdocs.pm/volt/readme.html), an Elixir-native frontend toolchain built on Vize,
+  and for reporting missing pieces and sending PRs as Volt adopted Vize as a foundation.
 - [umbrella22](https://github.com/umbrella22) for shaping the Rspack Plugin integration through
   real-project validation, reports about native CSS handling, compatibility feedback across Rspack
   1.x and 2.x, and guidance on defaults that keep newer native CSS behavior usable without

--- a/docs/content/credits.md
+++ b/docs/content/credits.md
@@ -8,10 +8,13 @@ description: People and community feedback that have shaped Vize.
 Vize is shaped by practical feedback from people using it against real applications, adjacent
 tooling, and ecosystem experiments. In particular, thank you to:
 
-- [Blacksmith](https://www.blacksmith.sh/) for sponsoring the CI/CD runner infrastructure that
-  keeps the full workflow matrix practical to run.
-- [かっこかり](https://github.com/kakkokari-gtyih) for regular debugging and monitoring around
-  [Misskey](https://github.com/misskey-dev/misskey) — a large Vue codebase with ~103k lines of Vue across 586 SFCs — with many reports around compiler behavior and edge cases.
+- [Blacksmith](https://www.blacksmith.sh/) for sponsoring high-performance CI/CD runners and
+  Testbox infrastructure, giving Vize the compute needed to run frequent benchmarks and
+  compatibility checks across real projects.
+- [かっこかり](https://github.com/kakkokari-gtyih) for continuously testing Vize's compiler and
+  Vite Plugin on [Misskey](https://github.com/misskey-dev/misskey) — a Vue application with
+  ~103k lines of Vue across 586 SFCs — and sending timely reports as the implementation changed
+  ([report](https://github.com/ubugeeei-prod/vize/discussions/71)).
 - [ushironoko](https://github.com/ushironoko) for bug reports from the compiler, linter, and CLI
   sides of the project, along with reference implementations for fixes and reproduction
   repositories for difficult issues.
@@ -21,14 +24,16 @@ tooling, and ecosystem experiments. In particular, thank you to:
   real-project validation, reports about native CSS handling, compatibility feedback across Rspack
   1.x and 2.x, and guidance on defaults that keep newer native CSS behavior usable without
   regressing older Rspack setups.
-- [n13u](https://x.com/%5Fn13u%5F) and the `#frontend_phpcon_do` team for debugging and reporting Vize
-  compiler and Nuxt project build pipeline issues on a conference website, and for validating Vize
-  in a production conference site deployment
-  ([report](https://x.com/%5Fn13u%5F/status/2061408599788892230?s=20)).
-- [sevenc-nanashi](https://github.com/sevenc-nanashi) for building the
+- [n13u](https://x.com/%5Fn13u%5F) and the `#frontend_phpcon_do` team for persistently reporting
+  bugs while building a Nuxt-based conference website with Vize, then carrying that validation all
+  the way to production adoption
+  ([report](https://x.com/%5Fn13u%5F/status/2061408599788892230?s=20),
+  [write-up](https://www.n13u.dev/ja/blog/detail/nYZKQ3UmslmWfXaP)).
+- [sevenc-nanashi](https://github.com/sevenc-nanashi) for using the
   [VOICEVOX](https://github.com/VOICEVOX/voicevox) editor — an Electron-based Vue application with
-  ~26k lines of Vue across 128 SFCs — against Vize as a real-world milestone and example, surfacing
-  valuable compatibility feedback from a large production codebase.
+  ~26k lines of Vue across 128 SFCs — as a real-world target for improving compiler precision and
+  turning production-app gaps into concrete feedback
+  ([report](https://github.com/ubugeeei-prod/vize/discussions/955)).
 
 Thanks also to everyone who has mentioned, shared, tested, or amplified Vize in the community, and
 to everyone connected to that work. Those signals make it easier to see where the toolchain is


### PR DESCRIPTION
## Summary

- expand the Credits page descriptions for Blacksmith, Mates Inc., OpenAI Codex for Open Source, kakkokari-gtyih, dannote, n13u, and sevenc-nanashi
- add Misskey, VOICEVOX, n13u, Volt, Mates, and OpenAI program links to both the docs page and README credits
- clarify that Vize is ubugeeei's personal MIT-licensed non-commercial OSS project, not owned by a specific company, and not being built for a buyout
- clarify the real-world testing context for Misskey, VOICEVOX, Volt, and the Nuxt conference site

## Validation

- `pnpm --filter vize-docs build`