### PR TITLE
docs: fix credits rendering

### DIFF
--- a/docs/content/credits.md
+++ b/docs/content/credits.md
@@ -8,38 +8,15 @@ description: People and community feedback that have shaped Vize.
 Vize is shaped by practical feedback from people using it against real applications, adjacent
 tooling, and ecosystem experiments. In particular, thank you to:
 
-- [Blacksmith](https://www.blacksmith.sh/) for sponsoring high-performance CI/CD runners and
-  Testbox infrastructure, giving Vize the compute needed to run frequent benchmarks and
-  compatibility checks across real projects.
-- [Mates Inc.](https://eng.mates.education/) for allowing ubugeeei, its employee, to dedicate
-  discretionary work time to OSS and for adopting Vize in the build for the company's engineering
-  website.
-- [OpenAI Codex for Open Source](https://openai.com/form/codex-for-oss/) for supporting
-  open-source maintainers through a program that helps keep critical OSS development moving.
-- [かっこかり](https://github.com/kakkokari-gtyih) for continuously testing Vize's compiler and
-  Vite Plugin on [Misskey](https://github.com/misskey-dev/misskey) — a Vue application with
-  ~103k lines of Vue across 586 SFCs — and sending timely reports as the implementation changed
-  ([report](https://github.com/ubugeeei-prod/vize/discussions/71)).
-- [ushironoko](https://github.com/ushironoko) for bug reports from the compiler, linter, and CLI
-  sides of the project, along with reference implementations for fixes and reproduction
-  repositories for difficult issues.
-- [dannote](https://github.com/dannote) for bringing Vize into the Elixir community through
-  [Volt](https://hexdocs.pm/volt/readme.html), an Elixir-native frontend toolchain built on Vize,
-  and for reporting missing pieces and sending PRs as Volt adopted Vize as a foundation.
-- [umbrella22](https://github.com/umbrella22) for shaping the Rspack Plugin integration through
-  real-project validation, reports about native CSS handling, compatibility feedback across Rspack
-  1.x and 2.x, and guidance on defaults that keep newer native CSS behavior usable without
-  regressing older Rspack setups.
-- [n13u](https://x.com/%5Fn13u%5F) and the `#frontend_phpcon_do` team for persistently reporting
-  bugs while building a Nuxt-based conference website with Vize, then carrying that validation all
-  the way to production adoption
-  ([report](https://x.com/%5Fn13u%5F/status/2061408599788892230?s=20),
-  [write-up](https://www.n13u.dev/ja/blog/detail/nYZKQ3UmslmWfXaP)).
-- [sevenc-nanashi](https://github.com/sevenc-nanashi) for using the
-  [VOICEVOX](https://github.com/VOICEVOX/voicevox) editor — an Electron-based Vue application with
-  ~26k lines of Vue across 128 SFCs — as a real-world target for improving compiler precision and
-  turning production-app gaps into concrete feedback
-  ([report](https://github.com/ubugeeei-prod/vize/discussions/955)).
+- [Blacksmith](https://www.blacksmith.sh/) for sponsoring high-performance CI/CD runners and Testbox infrastructure, giving Vize the compute needed to run frequent benchmarks and compatibility checks across real projects.
+- [Mates Inc.](https://eng.mates.education/) for allowing ubugeeei, its employee, to dedicate discretionary work time to OSS and for adopting Vize in the build for the company's engineering website.
+- [OpenAI Codex for Open Source](https://openai.com/form/codex-for-oss/) for supporting open-source maintainers through a program that helps keep critical OSS development moving.
+- [かっこかり](https://github.com/kakkokari-gtyih) for continuously testing Vize's compiler and Vite Plugin on [Misskey](https://github.com/misskey-dev/misskey) — a Vue application with ~103k lines of Vue across 586 SFCs — and sending timely reports as the implementation changed ([report](https://github.com/ubugeeei-prod/vize/discussions/71)).
+- [ushironoko](https://github.com/ushironoko) for bug reports from the compiler, linter, and CLI sides of the project, along with reference implementations for fixes and reproduction repositories for difficult issues.
+- [dannote](https://github.com/dannote) for bringing Vize into the Elixir community through [Volt](https://hexdocs.pm/volt/readme.html), an Elixir-native frontend toolchain built on Vize, and for reporting missing pieces and sending PRs as Volt adopted Vize as a foundation.
+- [umbrella22](https://github.com/umbrella22) for shaping the Rspack Plugin integration through real-project validation, reports about native CSS handling, compatibility feedback across Rspack 1.x and 2.x, and guidance on defaults that keep newer native CSS behavior usable without regressing older Rspack setups.
+- [n13u](https://x.com/%5Fn13u%5F) and the `#frontend_phpcon_do` team for persistently reporting bugs while building a Nuxt-based conference website with Vize, then carrying that validation all the way to production adoption ([report](https://x.com/%5Fn13u%5F/status/2061408599788892230?s=20), [write-up](https://www.n13u.dev/ja/blog/detail/nYZKQ3UmslmWfXaP)).
+- [sevenc-nanashi](https://github.com/sevenc-nanashi) for using the [VOICEVOX](https://github.com/VOICEVOX/voicevox) editor — an Electron-based Vue application with ~26k lines of Vue across 128 SFCs — as a real-world target for improving compiler precision and turning production-app gaps into concrete feedback ([report](https://github.com/ubugeeei-prod/vize/discussions/955)).
 
 Thanks also to everyone who has mentioned, shared, tested, or amplified Vize in the community, and
 to everyone connected to that work. Those signals make it easier to see where the toolchain is


### PR DESCRIPTION
## Summary

- keep Credits page list items on a single physical Markdown line so Ox Content renders full item text
- preserve the credits content from the previous merged PR without relying on Markdown list continuation lines
- opened upstream Ox Content issue: https://github.com/ubugeeei-prod/ox-content/issues/341

## Validation

- `pnpm --filter vize-docs build`
- verified generated `docs/dist/credits/index.html` contains the full list item text

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1122"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783435816&installation_id=136613492&pr_number=1122&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1122&signature=faf0a90cbcc96970ed6778311e89260abeaf92170dd86d74b609116e4da2b3bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->