### PR TITLE
feat(type-checker): standard-build Options API opt-in (decoupled from legacy)

### DIFF
--- a/crates/vize/src/commands/check/runner.rs
+++ b/crates/vize/src/commands/check/runner.rs
@@ -76,6 +76,9 @@ pub(crate) fn run_direct(args: &CheckArgs) {
     } else {
         crate::config::load_config_with_features_and_source(args.config.as_deref())
     };
+    // Vue 3 Options API binding resolution is officially supported and is a
+    // standard-build opt-in (not the `legacy` feature).
+    let options_api = loaded_config.features.type_checker_options_api;
     // Legacy Vue 2.7 / Nuxt 2 Options-API type checking is opt-in and compiled out
     // of the default Vue 3 binary. Without the `legacy` feature, honor the config
     // flag by warning instead of silently ignoring it.
@@ -245,6 +248,9 @@ pub(crate) fn run_direct(args: &CheckArgs) {
             std::process::exit(1);
         }
     };
+    if options_api {
+        checker.enable_options_api();
+    }
     #[cfg(feature = "legacy")]
     if legacy_vue2 {
         checker.enable_legacy_vue2();

--- a/crates/vize_atelier_sfc/src/croquis.rs
+++ b/crates/vize_atelier_sfc/src/croquis.rs
@@ -108,31 +108,54 @@ pub fn analyze_sfc_descriptor_with_context(
     template_ast: Option<&RootNode<'_>>,
     options: SfcCroquisOptions,
 ) -> SfcCroquisAnalysis {
-    analyze_sfc_descriptor_with_context_impl(descriptor, template_ast, options, false)
+    analyze_sfc_descriptor_with_context_impl(descriptor, template_ast, options, false, false)
 }
 
-/// Analyze an SFC descriptor with Vue 2.7 / Nuxt 2 Options API compatibility enabled.
+/// Analyze an SFC descriptor with Vue 3 Options API binding resolution enabled
+/// (opt-in, standard build — no `legacy` feature required).
+pub fn analyze_sfc_descriptor_with_context_options_api(
+    descriptor: &SfcDescriptor<'_>,
+    template_ast: Option<&RootNode<'_>>,
+    options: SfcCroquisOptions,
+) -> SfcCroquisAnalysis {
+    analyze_sfc_descriptor_with_context_impl(descriptor, template_ast, options, true, false)
+}
+
+/// Analyze an SFC descriptor with legacy Vue 2.7 / Nuxt 2 compatibility enabled
+/// (implies Options API binding resolution plus Nuxt 2 template globals).
 pub fn analyze_sfc_descriptor_with_context_legacy_vue2(
     descriptor: &SfcDescriptor<'_>,
     template_ast: Option<&RootNode<'_>>,
     options: SfcCroquisOptions,
 ) -> SfcCroquisAnalysis {
-    analyze_sfc_descriptor_with_context_impl(descriptor, template_ast, options, true)
+    analyze_sfc_descriptor_with_context_impl(descriptor, template_ast, options, false, true)
+}
+
+/// Apply the Options API / legacy binding-resolution mode to an analyzer.
+/// `legacy_vue2` implies Options API resolution and additionally pulls in the
+/// Nuxt 2 globals; `options_api` alone resolves only the Options API bindings.
+fn apply_options_api_mode(analyzer: Analyzer, options_api: bool, legacy_vue2: bool) -> Analyzer {
+    if legacy_vue2 {
+        analyzer.with_legacy_vue2()
+    } else if options_api {
+        analyzer.with_options_api()
+    } else {
+        analyzer
+    }
 }
 
 fn analyze_sfc_descriptor_with_context_impl(
     descriptor: &SfcDescriptor<'_>,
     template_ast: Option<&RootNode<'_>>,
     options: SfcCroquisOptions,
+    options_api: bool,
     legacy_vue2: bool,
 ) -> SfcCroquisAnalysis {
     let script_analyzed = options.analyzer_options.analyze_script
         && (descriptor.script.is_some() || descriptor.script_setup.is_some());
-    let summary = analyze_scripts(descriptor, options, legacy_vue2);
-    let mut analyzer = Analyzer::with_summary(options.analyzer_options, summary, script_analyzed);
-    if legacy_vue2 {
-        analyzer = analyzer.with_legacy_vue2();
-    }
+    let summary = analyze_scripts(descriptor, options, options_api, legacy_vue2);
+    let analyzer = Analyzer::with_summary(options.analyzer_options, summary, script_analyzed);
+    let mut analyzer = apply_options_api_mode(analyzer, options_api, legacy_vue2);
 
     if let Some(root) = template_ast {
         profile!(
@@ -174,6 +197,7 @@ pub fn script_content_for_descriptor(
 fn analyze_scripts(
     descriptor: &SfcDescriptor<'_>,
     options: SfcCroquisOptions,
+    options_api: bool,
     legacy_vue2: bool,
 ) -> Croquis {
     if !options.analyzer_options.analyze_script {
@@ -182,20 +206,18 @@ fn analyze_scripts(
 
     match (descriptor.script.as_ref(), descriptor.script_setup.as_ref()) {
         (Some(script), Some(script_setup)) if options.merge_scripts => {
-            let mut plain_analyzer = Analyzer::with_options(options.analyzer_options);
-            if legacy_vue2 {
-                plain_analyzer = plain_analyzer.with_legacy_vue2();
-            }
+            let plain_analyzer = Analyzer::with_options(options.analyzer_options);
+            let mut plain_analyzer =
+                apply_options_api_mode(plain_analyzer, options_api, legacy_vue2);
             profile!(
                 "atelier.sfc.croquis.script_plain",
                 plain_analyzer.analyze_script_plain(script.content.as_ref())
             );
             let plain = plain_analyzer.finish();
 
-            let mut setup_analyzer = Analyzer::with_options(options.analyzer_options);
-            if legacy_vue2 {
-                setup_analyzer = setup_analyzer.with_legacy_vue2();
-            }
+            let setup_analyzer = Analyzer::with_options(options.analyzer_options);
+            let mut setup_analyzer =
+                apply_options_api_mode(setup_analyzer, options_api, legacy_vue2);
             let generic = script_setup
                 .attrs
                 .get("generic")
@@ -213,10 +235,8 @@ fn analyze_scripts(
             summary
         }
         (_, Some(script_setup)) => {
-            let mut analyzer = Analyzer::with_options(options.analyzer_options);
-            if legacy_vue2 {
-                analyzer = analyzer.with_legacy_vue2();
-            }
+            let analyzer = Analyzer::with_options(options.analyzer_options);
+            let mut analyzer = apply_options_api_mode(analyzer, options_api, legacy_vue2);
             let generic = script_setup
                 .attrs
                 .get("generic")
@@ -228,10 +248,8 @@ fn analyze_scripts(
             analyzer.finish()
         }
         (Some(script), None) => {
-            let mut analyzer = Analyzer::with_options(options.analyzer_options);
-            if legacy_vue2 {
-                analyzer = analyzer.with_legacy_vue2();
-            }
+            let analyzer = Analyzer::with_options(options.analyzer_options);
+            let mut analyzer = apply_options_api_mode(analyzer, options_api, legacy_vue2);
             profile!(
                 "atelier.sfc.croquis.script_plain",
                 analyzer.analyze_script_plain(script.content.as_ref())

--- a/crates/vize_canon/src/batch/type_checker.rs
+++ b/crates/vize_canon/src/batch/type_checker.rs
@@ -142,7 +142,13 @@ impl BatchTypeChecker {
         })
     }
 
-    /// Enable Vue 2.7 / Nuxt 2 Options API compatibility for generated virtual files.
+    /// Resolve Vue 3 Options API template bindings (opt-in, standard build).
+    pub fn enable_options_api(&mut self) {
+        self.project.set_options_api(true);
+    }
+
+    /// Enable Vue 2.7 / Nuxt 2 Options API compatibility for generated virtual
+    /// files (implies Options API binding resolution plus Nuxt 2 globals).
     pub fn enable_legacy_vue2(&mut self) {
         self.project.set_legacy_vue2(true);
     }

--- a/crates/vize_canon/src/batch/virtual_project.rs
+++ b/crates/vize_canon/src/batch/virtual_project.rs
@@ -29,6 +29,7 @@ use vize_atelier_sfc::{
     croquis::{
         SfcCroquisOptions, analyze_sfc_descriptor_with_context,
         analyze_sfc_descriptor_with_context_legacy_vue2,
+        analyze_sfc_descriptor_with_context_options_api,
     },
     parse_sfc,
     script::ScriptCompileContext,
@@ -95,6 +96,7 @@ pub struct VirtualProject {
     virtual_ts_check_options: VirtualTsCheckOptions,
 
     /// Enable Vue 2.7 / Nuxt 2 Options API compatibility for virtual files.
+    options_api: bool,
     legacy_vue2: bool,
 
     /// Virtual files keyed by materialized path.
@@ -142,6 +144,7 @@ impl VirtualProject {
             tsconfig_path: None,
             virtual_ts_options: VirtualTsOptions::default(),
             virtual_ts_check_options: VirtualTsCheckOptions::default(),
+            options_api: false,
             legacy_vue2: false,
             virtual_files: FxHashMap::default(),
             passthrough_files: FxHashMap::default(),
@@ -164,6 +167,10 @@ impl VirtualProject {
 
     pub(crate) fn set_virtual_ts_check_options(&mut self, options: VirtualTsCheckOptions) {
         self.virtual_ts_check_options = options;
+    }
+
+    pub(crate) fn set_options_api(&mut self, enabled: bool) {
+        self.options_api = enabled;
     }
 
     pub(crate) fn set_legacy_vue2(&mut self, enabled: bool) {
@@ -196,6 +203,7 @@ impl VirtualProject {
                 virtual_root: &self.virtual_root,
                 virtual_ts_options: &self.virtual_ts_options,
                 virtual_ts_check_options: self.virtual_ts_check_options,
+                options_api: self.options_api,
                 legacy_vue2: self.legacy_vue2,
                 rewriter: &self.rewriter,
             },
@@ -237,6 +245,7 @@ impl VirtualProject {
             virtual_root: self.virtual_root.as_path(),
             virtual_ts_options: &self.virtual_ts_options,
             virtual_ts_check_options: self.virtual_ts_check_options,
+            options_api: self.options_api,
             legacy_vue2: self.legacy_vue2,
             rewriter: &self.rewriter,
         };
@@ -266,6 +275,7 @@ impl VirtualProject {
                 virtual_root: &self.virtual_root,
                 virtual_ts_options: &self.virtual_ts_options,
                 virtual_ts_check_options: self.virtual_ts_check_options,
+                options_api: self.options_api,
                 legacy_vue2: self.legacy_vue2,
                 rewriter: &self.rewriter,
             },
@@ -855,6 +865,7 @@ fn generate_vue_virtual_ts(
     descriptor: &SfcDescriptor,
     options: &VirtualTsOptions,
     check_options: VirtualTsCheckOptions,
+    options_api: bool,
     legacy_vue2: bool,
 ) -> CorsaResult<GeneratedVueFile> {
     let allocator = Bump::new();
@@ -940,6 +951,12 @@ fn generate_vue_virtual_ts(
                 template_ast.as_ref(),
                 croquis_options,
             )
+        } else if options_api {
+            analyze_sfc_descriptor_with_context_options_api(
+                descriptor,
+                template_ast.as_ref(),
+                croquis_options,
+            )
         } else {
             analyze_sfc_descriptor_with_context(descriptor, template_ast.as_ref(), croquis_options)
         }
@@ -965,6 +982,7 @@ fn generate_vue_virtual_ts(
             options,
             VirtualTsGenerationOptions {
                 check_options,
+                options_api,
                 legacy_vue2,
             },
         )
@@ -1278,6 +1296,7 @@ struct VirtualBuildContext<'a> {
     virtual_root: &'a Path,
     virtual_ts_options: &'a VirtualTsOptions,
     virtual_ts_check_options: VirtualTsCheckOptions,
+    options_api: bool,
     legacy_vue2: bool,
     rewriter: &'a ImportRewriter,
 }
@@ -1346,6 +1365,7 @@ fn build_vue_registered_file(
             &descriptor,
             &effective_options,
             context.virtual_ts_check_options,
+            context.options_api,
             context.legacy_vue2,
         )
     )?;

--- a/crates/vize_canon/src/sfc_typecheck.rs
+++ b/crates/vize_canon/src/sfc_typecheck.rs
@@ -46,14 +46,17 @@ mod virtual_ts;
 pub use analysis::{
     SfcRelatedLocation, SfcTypeCheckOptions, SfcTypeCheckResult, SfcTypeDiagnostic, SfcTypeSeverity,
 };
-pub use runner::{type_check_sfc, type_check_sfc_with_legacy_vue2};
+pub use runner::{
+    type_check_sfc, type_check_sfc_with_legacy_vue2, type_check_sfc_with_options_api,
+};
 
 #[cfg(test)]
 mod tests {
     #[cfg(feature = "legacy")]
     use super::type_check_sfc_with_legacy_vue2;
     use super::{
-        SfcTypeCheckOptions, SfcTypeCheckResult, SfcTypeDiagnostic, SfcTypeSeverity, type_check_sfc,
+        SfcTypeCheckOptions, SfcTypeCheckResult, SfcTypeDiagnostic, SfcTypeSeverity,
+        type_check_sfc, type_check_sfc_with_options_api,
     };
 
     fn stable_snapshot_result(mut result: SfcTypeCheckResult) -> SfcTypeCheckResult {
@@ -410,6 +413,77 @@ export const buttonId =
                 .any(|d| d.code.as_deref() == Some("undefined-binding")),
             "unexpected diagnostics: {:#?}",
             result.diagnostics
+        );
+    }
+
+    #[test]
+    fn test_type_check_options_api_opt_in_standard_build() {
+        // Vue 3 Options API in a normal <script> — officially supported, opt-in,
+        // and resolvable in the standard build (no `legacy` feature).
+        let source = r#"<script lang="ts">
+export default {
+  props: ['message'],
+  data() {
+    return { count: 1 }
+  },
+  computed: {
+    doubled() {
+      return this.count * 2
+    }
+  },
+  methods: {
+    save() {}
+  }
+}
+</script>
+<template>
+  <div>{{ message }} {{ count }} {{ doubled }}<button @click="save">go</button></div>
+</template>"#;
+
+        // Without the opt-in, the Options API members are unknown in the template.
+        let default_result = type_check_sfc(source, &SfcTypeCheckOptions::new("Options.vue"));
+        let _oa = type_check_sfc_with_options_api(source, &SfcTypeCheckOptions::new("Options.vue"));
+        eprintln!(
+            "OPTIONS_API codes: {:?}",
+            _oa.diagnostics
+                .iter()
+                .map(|d| (d.code.clone(), d.message.clone()))
+                .collect::<Vec<_>>()
+        );
+        assert!(
+            default_result
+                .diagnostics
+                .iter()
+                .any(|d| d.code.as_deref() == Some("undefined-binding")),
+            "expected default mode to leave Options API bindings unresolved"
+        );
+
+        // With the opt-in, the Options API bindings resolve — no undefined-binding.
+        let options_api_result =
+            type_check_sfc_with_options_api(source, &SfcTypeCheckOptions::new("Options.vue"));
+        assert!(
+            !options_api_result
+                .diagnostics
+                .iter()
+                .any(|d| d.code.as_deref() == Some("undefined-binding")),
+            "unexpected diagnostics: {:#?}",
+            options_api_result.diagnostics
+        );
+
+        // Nuxt 2 globals stay legacy-only: `$route` is NOT resolved by the
+        // standard Options API opt-in.
+        let nuxt_source = r#"<script lang="ts">
+export default { data() { return { count: 1 } } }
+</script>
+<template><div>{{ count }}{{ $route.path }}</div></template>"#;
+        let nuxt_result =
+            type_check_sfc_with_options_api(nuxt_source, &SfcTypeCheckOptions::new("Nuxt.vue"));
+        assert!(
+            nuxt_result
+                .diagnostics
+                .iter()
+                .any(|d| d.code.as_deref() == Some("undefined-binding")),
+            "expected $route to remain unresolved without legacy mode"
         );
     }
 

--- a/crates/vize_canon/src/sfc_typecheck/runner.rs
+++ b/crates/vize_canon/src/sfc_typecheck/runner.rs
@@ -28,7 +28,16 @@ use super::{
 ///
 /// For full TypeScript type checking with Corsa, use `TypeCheckService`.
 pub fn type_check_sfc(source: &str, options: &SfcTypeCheckOptions) -> SfcTypeCheckResult {
-    type_check_sfc_impl(source, options, false)
+    type_check_sfc_impl(source, options, false, false)
+}
+
+/// Perform type checking on a Vue SFC with Vue 3 Options API binding resolution
+/// enabled (opt-in, standard build — no `legacy` feature required).
+pub fn type_check_sfc_with_options_api(
+    source: &str,
+    options: &SfcTypeCheckOptions,
+) -> SfcTypeCheckResult {
+    type_check_sfc_impl(source, options, true, false)
 }
 
 /// Perform type checking on a Vue SFC with Vue 2.7 / Nuxt 2 compatibility enabled.
@@ -36,12 +45,13 @@ pub fn type_check_sfc_with_legacy_vue2(
     source: &str,
     options: &SfcTypeCheckOptions,
 ) -> SfcTypeCheckResult {
-    type_check_sfc_impl(source, options, true)
+    type_check_sfc_impl(source, options, false, true)
 }
 
 fn type_check_sfc_impl(
     source: &str,
     options: &SfcTypeCheckOptions,
+    options_api: bool,
     legacy_vue2: bool,
 ) -> SfcTypeCheckResult {
     use vize_atelier_core::parser::parse;
@@ -50,6 +60,7 @@ fn type_check_sfc_impl(
         croquis::{
             SfcCroquisOptions, analyze_sfc_descriptor_with_context,
             analyze_sfc_descriptor_with_context_legacy_vue2,
+            analyze_sfc_descriptor_with_context_options_api,
         },
         parse_sfc,
     };
@@ -147,6 +158,12 @@ fn type_check_sfc_impl(
             template_ast.as_ref(),
             croquis_options,
         )
+    } else if options_api {
+        analyze_sfc_descriptor_with_context_options_api(
+            &descriptor,
+            template_ast.as_ref(),
+            croquis_options,
+        )
     } else {
         analyze_sfc_descriptor_with_context(&descriptor, template_ast.as_ref(), croquis_options)
     };
@@ -193,6 +210,16 @@ fn type_check_sfc_impl(
     if options.include_virtual_ts && !has_template_parse_errors && !has_script_parse_errors {
         result.virtual_ts = Some(if legacy_vue2 {
             generate_virtual_ts_with_offsets_legacy_vue2(
+                &summary,
+                script_content.as_deref(),
+                template_ast.as_ref(),
+                script_offset,
+                template_offset,
+                &crate::virtual_ts::VirtualTsOptions::default(),
+            )
+            .code
+        } else if options_api {
+            crate::virtual_ts::generate_virtual_ts_with_offsets_options_api(
                 &summary,
                 script_content.as_deref(),
                 template_ast.as_ref(),

--- a/crates/vize_canon/src/virtual_ts.rs
+++ b/crates/vize_canon/src/virtual_ts.rs
@@ -19,7 +19,7 @@ mod types;
 pub(crate) use generator::generate_virtual_ts_with_offsets_and_checks;
 pub use generator::{
     generate_virtual_ts, generate_virtual_ts_with_offsets,
-    generate_virtual_ts_with_offsets_legacy_vue2,
+    generate_virtual_ts_with_offsets_legacy_vue2, generate_virtual_ts_with_offsets_options_api,
 };
 pub(crate) use props::extract_interface_fields;
 pub use types::{TemplateGlobal, VirtualTsOptions, VirtualTsOutput, VizeMapping};

--- a/crates/vize_canon/src/virtual_ts/generator.rs
+++ b/crates/vize_canon/src/virtual_ts/generator.rs
@@ -71,6 +71,30 @@ pub fn generate_virtual_ts_with_offsets(
     )
 }
 
+/// Generate virtual TypeScript with Vue 3 Options API binding resolution
+/// enabled (opt-in, standard build — no `legacy` feature required).
+pub fn generate_virtual_ts_with_offsets_options_api(
+    summary: &Croquis,
+    script_content: Option<&str>,
+    template_ast: Option<&vize_relief::ast::RootNode<'_>>,
+    script_offset: u32,
+    template_offset: u32,
+    options: &VirtualTsOptions,
+) -> VirtualTsOutput {
+    generate_virtual_ts_with_offsets_and_checks(
+        summary,
+        script_content,
+        template_ast,
+        script_offset,
+        template_offset,
+        options,
+        VirtualTsGenerationOptions {
+            options_api: true,
+            ..Default::default()
+        },
+    )
+}
+
 /// Generate virtual TypeScript with Vue 2.7 / Nuxt 2 compatibility enabled.
 pub fn generate_virtual_ts_with_offsets_legacy_vue2(
     summary: &Croquis,
@@ -105,6 +129,7 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
 ) -> VirtualTsOutput {
     let check_options = generation_options.check_options;
     let legacy_vue2 = generation_options.legacy_vue2;
+    let options_api = generation_options.options_api || legacy_vue2;
     let mut ts = String::default();
     let mut mappings: Vec<VizeMapping> = Vec::new();
 
@@ -518,10 +543,10 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
                 "canon.virtual_ts.generate_props_variables",
                 generate_props_variables(&mut ts, summary, script_content, generic_param)
             );
-            if legacy_vue2 {
+            if options_api {
                 profile!(
-                    "canon.virtual_ts.generate_legacy_vue2_variables",
-                    generate_legacy_vue2_variables(&mut ts, summary, options)
+                    "canon.virtual_ts.generate_options_api_variables",
+                    generate_options_api_variables(&mut ts, summary, options)
                 );
             }
             let template_prop_names = profile!(
@@ -929,8 +954,12 @@ fn is_local_setup_binding(summary: &Croquis, name: &str) -> bool {
         .any(|import| start >= import.start && end <= import.end)
 }
 
-#[cfg(feature = "legacy")]
-fn generate_legacy_vue2_variables(
+// Emit `const <name>: any` declarations for Options API template bindings
+// (`data`/`computed`/`methods`/`inject`/`setup`/`props`, plus any Nuxt 2 globals
+// the legacy path collected). Options API is officially supported in Vue 3, so
+// this is part of the standard build and driven by a runtime opt-in — it costs
+// nothing unless the caller enables Options API / legacy checking.
+fn generate_options_api_variables(
     mut ts: &mut String,
     summary: &Croquis,
     options: &VirtualTsOptions,
@@ -968,7 +997,7 @@ fn generate_legacy_vue2_variables(
         return;
     }
 
-    ts.push_str("  // Vue 2.7 / Nuxt 2 Options API template bindings\n");
+    ts.push_str("  // Options API template bindings\n");
     for name in &names {
         append!(ts, "  const {name}: any = undefined as any;\n");
     }
@@ -979,17 +1008,6 @@ fn generate_legacy_vue2_variables(
     ts.push('\n');
 }
 
-// No-op stub: legacy Vue (v0/v1/v2) Options-API variable generation is compiled
-// out without the `legacy` feature, so the default Vue 3 build carries none of it.
-#[cfg(not(feature = "legacy"))]
-fn generate_legacy_vue2_variables(
-    _ts: &mut String,
-    _summary: &Croquis,
-    _options: &VirtualTsOptions,
-) {
-}
-
-#[cfg(feature = "legacy")]
 fn is_safe_value_identifier(name: &str) -> bool {
     let mut chars = name.chars();
     let Some(first) = chars.next() else {

--- a/crates/vize_canon/src/virtual_ts/types.rs
+++ b/crates/vize_canon/src/virtual_ts/types.rs
@@ -107,6 +107,9 @@ impl Default for VirtualTsCheckOptions {
 #[derive(Debug, Clone, Copy, Default)]
 pub(crate) struct VirtualTsGenerationOptions {
     pub(crate) check_options: VirtualTsCheckOptions,
+    /// Resolve Vue 3 Options API template bindings (opt-in, standard build).
+    pub(crate) options_api: bool,
+    /// Legacy Vue 2.7 / Nuxt 2 (implies `options_api` plus Nuxt 2 globals).
     pub(crate) legacy_vue2: bool,
 }
 

--- a/crates/vize_carton/src/config/model.rs
+++ b/crates/vize_carton/src/config/model.rs
@@ -53,6 +53,9 @@ pub struct VizeConfig {
 /// model fields.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct ConfigFeatureFlags {
+    /// Resolve Vue 3 Options API template bindings during type checking. Opt-in
+    /// and available in the standard build (not a legacy feature).
+    pub type_checker_options_api: bool,
     pub type_checker_legacy_vue2: bool,
     pub language_server_legacy_vue2: Option<bool>,
 }
@@ -84,6 +87,7 @@ pub(crate) struct RawVizeConfig {
 struct RawTypeCheckerConfig {
     #[serde(flatten)]
     config: TypeCheckerConfig,
+    options_api: bool,
     legacy_vue2: bool,
 }
 
@@ -121,6 +125,7 @@ impl RawVizeConfig {
             legacy_lsp,
         } = self;
 
+        let type_checker_options_api = raw_type_checker.options_api;
         let type_checker_legacy_vue2 = raw_type_checker.legacy_vue2;
         let mut type_checker = raw_type_checker.config;
         if let Some(legacy_check) = legacy_check {
@@ -145,6 +150,7 @@ impl RawVizeConfig {
         };
         let language_server = language_server_raw.config;
         let features = ConfigFeatureFlags {
+            type_checker_options_api,
             type_checker_legacy_vue2,
             language_server_legacy_vue2: language_server_raw.legacy_vue2,
         };

--- a/crates/vize_croquis/src/analyzer.rs
+++ b/crates/vize_croquis/src/analyzer.rs
@@ -102,6 +102,9 @@ impl AnalyzerOptions {
 /// Uses lazy evaluation and efficient data structures to minimize overhead.
 pub struct Analyzer {
     pub(crate) options: AnalyzerOptions,
+    /// Resolve Vue 3 Options API template bindings (opt-in, standard build).
+    pub(crate) options_api: bool,
+    /// Legacy Vue 2.7 / Nuxt 2: implies `options_api` plus Nuxt 2 globals.
     pub(crate) legacy_vue2: bool,
     pub(crate) summary: Croquis,
     /// Track if script was analyzed (for undefined detection)
@@ -145,6 +148,7 @@ impl Analyzer {
     pub fn with_options(options: AnalyzerOptions) -> Self {
         Self {
             options,
+            options_api: false,
             legacy_vue2: false,
             summary: Croquis::new(),
             script_analyzed: false,
@@ -164,6 +168,7 @@ impl Analyzer {
     pub fn with_summary(options: AnalyzerOptions, summary: Croquis, script_analyzed: bool) -> Self {
         Self {
             options,
+            options_api: false,
             legacy_vue2: false,
             summary,
             script_analyzed,
@@ -175,7 +180,14 @@ impl Analyzer {
         }
     }
 
-    /// Enable Vue 2.7 / Nuxt 2 compatibility helpers.
+    /// Resolve Vue 3 Options API template bindings (opt-in, standard build).
+    #[inline]
+    pub fn with_options_api(mut self) -> Self {
+        self.options_api = true;
+        self
+    }
+
+    /// Enable Vue 2.7 / Nuxt 2 compatibility helpers (implies Options API).
     #[inline]
     pub fn with_legacy_vue2(mut self) -> Self {
         self.legacy_vue2 = true;
@@ -270,6 +282,7 @@ impl Analyzer {
             crate::script_parser::parse_script_with_options(
                 source,
                 crate::script_parser::ScriptParserOptions {
+                    options_api: self.options_api,
                     legacy_vue2: self.legacy_vue2,
                 }
             )

--- a/crates/vize_croquis/src/script_parser.rs
+++ b/crates/vize_croquis/src/script_parser.rs
@@ -125,7 +125,13 @@ pub struct ScriptParseResult {
 /// Options for plain script parsing.
 #[derive(Debug, Clone, Copy, Default)]
 pub struct ScriptParserOptions {
-    /// Extract Vue 2.7 / Nuxt 2 Options API template bindings.
+    /// Resolve Options API template bindings (`data`/`computed`/`methods`/
+    /// `inject`/`setup`/`props`). This is officially supported in Vue 3 and is
+    /// an opt-in for the standard build — it does **not** require the `legacy`
+    /// feature.
+    pub options_api: bool,
+    /// Additionally treat the component as legacy Vue 2.7 / Nuxt 2: implies
+    /// `options_api` binding resolution and adds Nuxt 2 template globals.
     pub legacy_vue2: bool,
 }
 
@@ -468,7 +474,12 @@ pub fn parse_script_with_options(source: &str, options: ScriptParserOptions) -> 
         source_len,
     );
 
-    process::collect_options_api_component_metadata(&mut result, &ret.program, options.legacy_vue2);
+    process::collect_options_api_component_metadata(
+        &mut result,
+        &ret.program,
+        options.options_api,
+        options.legacy_vue2,
+    );
 
     // Process all statements
     profile!("croquis.script_plain.walk_statements", {
@@ -865,7 +876,13 @@ export default {
   }
 }
 "#;
-        let result = parse_script_with_options(source, ScriptParserOptions { legacy_vue2: true });
+        let result = parse_script_with_options(
+            source,
+            ScriptParserOptions {
+                options_api: false,
+                legacy_vue2: true,
+            },
+        );
 
         for name in [
             "message",

--- a/crates/vize_croquis/src/script_parser/process.rs
+++ b/crates/vize_croquis/src/script_parser/process.rs
@@ -342,6 +342,7 @@ struct ComponentOptionsRef<'a> {
 pub(in crate::script_parser) fn collect_options_api_component_metadata(
     result: &mut ScriptParseResult,
     program: &Program<'_>,
+    options_api: bool,
     legacy_vue2: bool,
 ) {
     let mut object_bindings = FxHashMap::default();
@@ -361,8 +362,10 @@ pub(in crate::script_parser) fn collect_options_api_component_metadata(
             continue;
         };
         collect_component_registrations_from_options(result, options.object, &object_bindings);
-        if legacy_vue2 {
-            collect_legacy_vue2_template_bindings_from_options(
+        // Options API template bindings are valid in Vue 3 too; legacy Vue 2.7
+        // implies them and additionally pulls in the Nuxt 2 globals below.
+        if options_api || legacy_vue2 {
+            collect_options_api_template_bindings_from_options(
                 result,
                 options.object,
                 &object_bindings,
@@ -453,7 +456,7 @@ fn collect_component_registrations_from_options<'a>(
     );
 }
 
-fn collect_legacy_vue2_template_bindings_from_options<'a>(
+fn collect_options_api_template_bindings_from_options<'a>(
     result: &mut ScriptParseResult,
     options: &'a ObjectExpression<'a>,
     object_bindings: &FxHashMap<&'a str, &'a ObjectExpression<'a>>,

--- a/docs/content/guide/configuration.md
+++ b/docs/content/guide/configuration.md
@@ -274,9 +274,21 @@ export default defineConfig({
     checkProps: true,
     checkEmits: true,
     checkTemplateBindings: true,
+    // Resolve Vue 3 Options API template bindings (data/computed/methods/
+    // inject/setup/props). Officially supported in Vue 3, opt-in, default off.
+    optionsApi: false,
   },
 });
 ```
+
+`typeChecker.optionsApi` opts the type checker into resolving Vue 3 Options API
+template bindings (`data`/`computed`/`methods`/`inject`/`setup`/`props` declared
+on a normal `<script> export default { ... }`). Options API is officially
+supported in Vue 3, so this lives in the standard build (it is **not** the
+`legacy` feature). It is off by default because most Vize projects use
+`<script setup>`. Legacy Vue 2.7 / Nuxt 2 support — `typeChecker.legacyVue2`,
+which additionally adds the Nuxt 2 template globals — remains a separate opt-in
+that requires a `legacy` build.
 
 `typeChecker.tsconfig` and `typeChecker.corsaPath` are part of the shared schema, but the
 project-backed Corsa path is the Rust CLI surface today. `typeChecker.corsaPath` is shared by

--- a/npm/vize/pkl/TypeCheckerConfig.pkl
+++ b/npm/vize/pkl/TypeCheckerConfig.pkl
@@ -29,6 +29,11 @@ class TypeCheckerConfig {
   /// Check fallthrough attrs on multi-root templates.
   checkFallthroughAttrs: Boolean = true
 
+  /// Resolve Vue 3 Options API template bindings (`data`/`computed`/`methods`/
+  /// `inject`/`setup`/`props`) during type checking. Officially supported in
+  /// Vue 3; opt-in and available in the standard build (not a legacy feature).
+  optionsApi: Boolean = false
+
   /// Enable Vue 2.7 / Nuxt 2 Options API template binding support.
   legacyVue2: Boolean = false
 

--- a/npm/vize/schemas/vize.config.schema.json
+++ b/npm/vize/schemas/vize.config.schema.json
@@ -279,6 +279,11 @@
           "default": true,
           "type": "boolean"
         },
+        "optionsApi": {
+          "description": "Resolve Vue 3 Options API template bindings (data/computed/methods/inject/setup/props) during type checking. Opt-in; available in the standard build (not a legacy feature).",
+          "default": false,
+          "type": "boolean"
+        },
         "legacyVue2": {
           "description": "Enable Vue 2.7 / Nuxt 2 Options API template binding support",
           "default": false,

--- a/npm/vize/src/types/generated.ts
+++ b/npm/vize/src/types/generated.ts
@@ -236,6 +236,10 @@ export interface TypeCheckerConfig {
    */
   checkFallthroughAttrs?: boolean;
   /**
+   * Resolve Vue 3 Options API template bindings (data/computed/methods/inject/setup/props) during type checking. Opt-in; available in the standard build (not a legacy feature).
+   */
+  optionsApi?: boolean;
+  /**
    * Enable Vue 2.7 / Nuxt 2 Options API template binding support
    */
   legacyVue2?: boolean;


### PR DESCRIPTION
## What

Makes **Vue 3 Options API** type-checking a first-class, opt-in feature of the **standard** `vize` build — decoupled from the `legacy` cargo feature. Options API (`data`/`computed`/`methods`/`inject`/`setup`/`props` on a normal `<script> export default { … }`) is officially supported by Vue 3, so resolving its template bindings should not require a legacy build.

Add `typeChecker.optionsApi` (default `false`, documented). When enabled, `vize check` resolves Options API template bindings so e.g. `{{ count }}` from `data()` is no longer reported as an undefined binding.

The taxonomy is now:
- **Options API** — official Vue 3, standard build, runtime opt-in (`typeChecker.optionsApi`).
- **legacy Vue 2.7 / Nuxt 2** (`typeChecker.legacyVue2`, `legacy` cargo feature) — *implies* Options API binding resolution **and** additionally adds the Nuxt 2 template globals (`$route`, `$nuxt`, `asyncData`, …). Those globals stay legacy-only.

Mechanically: the Options API binding collection (croquis) and the `const <name>: any` virtual-TS emission (canon) are now compiled into the standard build and gated by a runtime flag (`options_api`), threaded through the single-file and batch type-check paths; `legacy_vue2` implies `options_api`. The legacy path is otherwise unchanged.

## Zero cost when off
The opt-in is a runtime flag that defaults off, so the standard Vue 3 path pays nothing unless a project enables it. `legacy` remains a cargo feature compiled out of the v3 binary.

## Heads-up: intentional SemVer break
Exposing a cross-crate config opt-in requires new public fields (`ConfigFeatureFlags::type_checker_options_api`, `ScriptParserOptions::options_api`). `cargo-semver-checks` will flag these on `vize_carton` / `vize_croquis`. This break is **intentional** and expected to be absorbed by the release version bump (per maintainer direction).

## Verify
- New `vize_canon` test `test_type_check_options_api_opt_in_standard_build`: in the **standard** build, `type_check_sfc` leaves `data`/`computed`/`methods` unresolved, `type_check_sfc_with_options_api` resolves them, and `$route` stays unresolved (legacy-only).
- `cargo test -p vize_canon` (268) and `-p vize_carton` green; `cargo build --workspace` green; `cargo clippy -- -D warnings` clean; `--features legacy` build + legacy tests green.
- Config surface updated in lockstep: `TypeCheckerConfig.pkl`, `vize.config.schema.json`, generated `types/generated.ts`, and the configuration guide.

Follow-ups (not in this PR): wire `optionsApi` into the LSP (`vize_maestro`) and the editor settings, and deepen the emitted types beyond `any` (semver-safe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1124"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783439976&installation_id=136613492&pr_number=1124&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1124&signature=2219c8b40247b6b2f2b92a663cbd4b2341337ecd3dace5ff93e545f473f22e6b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->