### PR TITLE
feat(maestro): wire Vue 3 Options API opt-in into the LSP

### DIFF
--- a/crates/vize_canon/src/lib.rs
+++ b/crates/vize_canon/src/lib.rs
@@ -95,6 +95,7 @@ pub use intelligence::{
 pub use sfc_typecheck::{
     SfcRelatedLocation, SfcTypeCheckOptions, SfcTypeCheckResult, SfcTypeDiagnostic,
     SfcTypeSeverity, type_check_sfc, type_check_sfc_with_legacy_vue2,
+    type_check_sfc_with_options_api,
 };
 pub use source_map::{
     Mapping, MappingFlags, MappingKind, Position, SourceMap, Span, offset_to_position,

--- a/crates/vize_maestro/src/ide/completion/template.rs
+++ b/crates/vize_maestro/src/ide/completion/template.rs
@@ -16,6 +16,7 @@ use tower_lsp::lsp_types::{
 };
 use vize_atelier_sfc::croquis::{
     SfcCroquisOptions, analyze_sfc_descriptor, analyze_sfc_descriptor_with_context_legacy_vue2,
+    analyze_sfc_descriptor_with_context_options_api,
 };
 use vize_croquis::{Analyzer, AnalyzerOptions, ScopeKind};
 use vize_relief::BindingType;
@@ -146,6 +147,15 @@ fn is_class_ident_byte(b: u8) -> bool {
     b.is_ascii_alphanumeric() || b == b'-' || b == b'_'
 }
 
+/// Corsa-path supplement for Vue 2.7 / Nuxt 2 constructs that the TypeScript
+/// virtual document cannot express: Nuxt 2 built-in components (`<nuxt-link>`,
+/// `<client-only>`, …) and the legacy-filtered Options API bindings. This stays
+/// gated on `legacy_vue2` deliberately — it has no Vue 3 Options API counterpart
+/// because Options API `data`/`computed`/`methods`/`props` ARE emitted into the
+/// virtual TS as accessible bindings (see `generate_options_api_variables`), so
+/// Corsa already surfaces them; the synchronous fallback covers them via
+/// [`analyzed_template_binding_completions`]. Options API is standard Vue 3 and
+/// is treated like the default path here, not like legacy.
 pub(crate) fn legacy_vue2_template_completions(ctx: &IdeContext) -> Vec<CompletionItem> {
     if !ctx.state.lsp_features().legacy_vue2 {
         return Vec::new();
@@ -433,8 +443,15 @@ fn analyzed_template_binding_completions(
         template_block.map(|tb| (vize_armature::parse(&allocator, &tb.content), tb.loc.start));
 
     let croquis_options = SfcCroquisOptions::full();
-    let croquis = if ctx.state.lsp_features().legacy_vue2 {
+    let croquis = if ctx.state.legacy_vue2_enabled() {
         analyze_sfc_descriptor_with_context_legacy_vue2(
+            &descriptor,
+            template_parse.as_ref().map(|((ast, _), _)| ast),
+            croquis_options,
+        )
+        .croquis
+    } else if ctx.state.options_api_enabled() {
+        analyze_sfc_descriptor_with_context_options_api(
             &descriptor,
             template_parse.as_ref().map(|((ast, _), _)| ast),
             croquis_options,
@@ -882,7 +899,8 @@ fn cached_component_metadata(
     let metadata = std::sync::Arc::new(extract_component_metadata(
         &component_content,
         &resolved.to_string_lossy(),
-        ctx.state.lsp_features().legacy_vue2,
+        ctx.state.options_api_enabled(),
+        ctx.state.legacy_vue2_enabled(),
     ));
     cache.insert(
         resolved.to_path_buf(),
@@ -933,6 +951,7 @@ fn art_component_path(ctx: &IdeContext<'_>, component_name: &str) -> Option<Stri
 fn extract_component_metadata(
     content: &str,
     filename: &str,
+    options_api: bool,
     legacy_vue2: bool,
 ) -> ComponentMetadata {
     let options = vize_atelier_sfc::SfcParseOptions {
@@ -969,6 +988,8 @@ fn extract_component_metadata(
         let mut analyzer = Analyzer::with_options(analyzer_options);
         if legacy_vue2 {
             analyzer = analyzer.with_legacy_vue2();
+        } else if options_api {
+            analyzer = analyzer.with_options_api();
         }
         if descriptor.script_setup.is_some() {
             analyzer.analyze_script_setup(script_content);
@@ -1755,6 +1776,62 @@ mod cache_tests {
             "recomputed metadata should reflect the added prop ({} -> {})",
             first_prop_count,
             third.props.len(),
+        );
+    }
+}
+
+#[cfg(test)]
+mod options_api_tests {
+    use super::analyzed_template_binding_completions;
+    use crate::ide::IdeContext;
+    use crate::server::ServerState;
+    use tower_lsp::lsp_types::Url;
+
+    const OPTIONS_API_SFC: &str = "<script>\nexport default {\n  data() {\n    return { greeting: 'hello' }\n  },\n}\n</script>\n<template>\n  <p>{{ greeting }}</p>\n</template>\n";
+
+    fn binding_labels(options_api: bool) -> Vec<String> {
+        let state = ServerState::new();
+        if options_api {
+            let dir = tempfile::tempdir().unwrap();
+            std::fs::write(
+                dir.path().join("vize.config.json"),
+                r#"{ "typeChecker": { "optionsApi": true } }"#,
+            )
+            .unwrap();
+            state.load_workspace_config(dir.path());
+        }
+        let uri = Url::parse("file:///comp.vue").unwrap();
+        state.documents.open(
+            uri.clone(),
+            OPTIONS_API_SFC.to_string(),
+            1,
+            "vue".to_string(),
+        );
+        let offset = OPTIONS_API_SFC.find("greeting }}").unwrap();
+        let ctx = IdeContext::new(&state, &uri, offset).unwrap();
+        analyzed_template_binding_completions(&ctx, true)
+            .into_iter()
+            .map(|item| item.label)
+            .collect()
+    }
+
+    #[test]
+    fn options_api_data_binding_completed_when_enabled() {
+        let labels = binding_labels(true);
+        assert!(
+            labels.iter().any(|label| label == "greeting"),
+            "the Options API data() binding should be offered as a template completion \
+             when optionsApi is enabled; got {labels:?}"
+        );
+    }
+
+    #[test]
+    fn options_api_data_binding_absent_by_default() {
+        let labels = binding_labels(false);
+        assert!(
+            !labels.iter().any(|label| label == "greeting"),
+            "without optionsApi the Options API data() binding must not resolve \
+             (opt-in keeps the default <script setup> path zero cost); got {labels:?}"
         );
     }
 }

--- a/crates/vize_maestro/src/ide/definition/script.rs
+++ b/crates/vize_maestro/src/ide/definition/script.rs
@@ -76,8 +76,8 @@ pub(crate) fn definition_in_script(ctx: &IdeContext) -> Option<GotoDefinitionRes
         }
     }
 
-    if ctx.state.lsp_features().legacy_vue2
-        && let Some(location) = find_analyzed_binding_location(ctx, &word, true)
+    if ctx.state.options_api_enabled()
+        && let Some(location) = find_analyzed_binding_location(ctx, &word)
     {
         return Some(GotoDefinitionResponse::Scalar(location));
     }
@@ -86,16 +86,13 @@ pub(crate) fn definition_in_script(ctx: &IdeContext) -> Option<GotoDefinitionRes
 }
 
 /// Find a binding location from Croquis analysis, including opt-in Options API spans.
-pub(crate) fn find_analyzed_binding_location(
-    ctx: &IdeContext,
-    word: &str,
-    legacy_vue2: bool,
-) -> Option<Location> {
+pub(crate) fn find_analyzed_binding_location(ctx: &IdeContext, word: &str) -> Option<Location> {
     use vize_atelier_sfc::{
         SfcParseOptions,
         croquis::{
             SfcCroquisOptions, analyze_sfc_descriptor_with_context,
             analyze_sfc_descriptor_with_context_legacy_vue2,
+            analyze_sfc_descriptor_with_context_options_api,
         },
         parse_sfc,
     };
@@ -110,8 +107,10 @@ pub(crate) fn find_analyzed_binding_location(
     .ok()?;
 
     let croquis_options = SfcCroquisOptions::full();
-    let analysis = if legacy_vue2 {
+    let analysis = if ctx.state.legacy_vue2_enabled() {
         analyze_sfc_descriptor_with_context_legacy_vue2(&descriptor, None, croquis_options)
+    } else if ctx.state.options_api_enabled() {
+        analyze_sfc_descriptor_with_context_options_api(&descriptor, None, croquis_options)
     } else {
         analyze_sfc_descriptor_with_context(&descriptor, None, croquis_options)
     };

--- a/crates/vize_maestro/src/ide/definition/template.rs
+++ b/crates/vize_maestro/src/ide/definition/template.rs
@@ -46,8 +46,8 @@ pub(crate) fn definition_in_template(ctx: &IdeContext) -> Option<GotoDefinitionR
         return Some(def);
     }
 
-    if ctx.state.lsp_features().legacy_vue2
-        && let Some(location) = super::script::find_analyzed_binding_location(ctx, &word, true)
+    if ctx.state.options_api_enabled()
+        && let Some(location) = super::script::find_analyzed_binding_location(ctx, &word)
     {
         return Some(GotoDefinitionResponse::Scalar(location));
     }
@@ -458,16 +458,25 @@ pub(crate) fn find_component_prop_definition(
         }
     }
 
-    if ctx.state.lsp_features().legacy_vue2 {
+    if ctx.state.options_api_enabled() {
         use vize_atelier_sfc::croquis::{
             SfcCroquisOptions, analyze_sfc_descriptor_with_context_legacy_vue2,
+            analyze_sfc_descriptor_with_context_options_api,
         };
 
-        let analysis = analyze_sfc_descriptor_with_context_legacy_vue2(
-            &descriptor,
-            None,
-            SfcCroquisOptions::full(),
-        );
+        let analysis = if ctx.state.legacy_vue2_enabled() {
+            analyze_sfc_descriptor_with_context_legacy_vue2(
+                &descriptor,
+                None,
+                SfcCroquisOptions::full(),
+            )
+        } else {
+            analyze_sfc_descriptor_with_context_options_api(
+                &descriptor,
+                None,
+                SfcCroquisOptions::full(),
+            )
+        };
         if let Some(&(start, end)) = analysis.croquis.binding_spans.get(prop_name.as_str())
             && end > start
         {

--- a/crates/vize_maestro/src/ide/diagnostics/corsa.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/corsa.rs
@@ -51,6 +51,7 @@ async fn overlay_sibling_vue_mirrors(
     bridge: &std::sync::Arc<vize_canon::CorsaBridge>,
     host_uri: &Url,
     initial_specifiers: &[std::string::String],
+    options_api: bool,
     legacy_vue2: bool,
 ) {
     use std::collections::HashSet;
@@ -105,7 +106,12 @@ async fn overlay_sibling_vue_mirrors(
             let sibling_virtual = if canonical.to_string_lossy().ends_with(".art.vue") {
                 DiagnosticService::generate_virtual_ts_for_art(&sibling_uri, &sibling_content)
             } else {
-                DiagnosticService::generate_virtual_ts(&sibling_uri, &sibling_content, legacy_vue2)
+                DiagnosticService::generate_virtual_ts(
+                    &sibling_uri,
+                    &sibling_content,
+                    options_api,
+                    legacy_vue2,
+                )
             };
             let Some(sibling_virtual) = sibling_virtual else {
                 continue;
@@ -164,11 +170,12 @@ impl DiagnosticService {
 
         // Generate virtual TypeScript
         let is_art_file = uri.path().ends_with(".art.vue");
+        let options_api = state.options_api_enabled();
         let legacy_vue2 = state.legacy_vue2_enabled();
         let virtual_result = if is_art_file {
             Self::generate_virtual_ts_for_art(uri, &content)
         } else {
-            Self::generate_virtual_ts(uri, &content, legacy_vue2)
+            Self::generate_virtual_ts(uri, &content, options_api, legacy_vue2)
         };
         let Some(virtual_result) = virtual_result else {
             tracing::warn!("failed to generate virtual ts for {}", uri);
@@ -201,6 +208,7 @@ impl DiagnosticService {
             &bridge,
             uri,
             &virtual_result.relative_vue_imports,
+            options_api,
             legacy_vue2,
         )
         .await;
@@ -401,6 +409,7 @@ impl DiagnosticService {
     pub(super) fn generate_virtual_ts(
         uri: &Url,
         content: &str,
+        options_api: bool,
         legacy_vue2: bool,
     ) -> Option<VirtualTsResult> {
         use vize_atelier_sfc::{
@@ -408,12 +417,14 @@ impl DiagnosticService {
             croquis::{
                 SfcCroquisOptions, analyze_sfc_descriptor_with_context,
                 analyze_sfc_descriptor_with_context_legacy_vue2,
+                analyze_sfc_descriptor_with_context_options_api,
             },
             parse_sfc,
         };
         use vize_canon::virtual_ts::{
             VirtualTsOptions, generate_virtual_ts_with_offsets,
             generate_virtual_ts_with_offsets_legacy_vue2,
+            generate_virtual_ts_with_offsets_options_api,
         };
 
         let options = SfcParseOptions {
@@ -436,6 +447,12 @@ impl DiagnosticService {
                 Some(&template_ast),
                 croquis_options,
             )
+        } else if options_api {
+            analyze_sfc_descriptor_with_context_options_api(
+                &descriptor,
+                Some(&template_ast),
+                croquis_options,
+            )
         } else {
             analyze_sfc_descriptor_with_context(&descriptor, Some(&template_ast), croquis_options)
         };
@@ -447,6 +464,8 @@ impl DiagnosticService {
         let virtual_ts_options = VirtualTsOptions::default();
         let generate_virtual_ts = if legacy_vue2 {
             generate_virtual_ts_with_offsets_legacy_vue2
+        } else if options_api {
+            generate_virtual_ts_with_offsets_options_api
         } else {
             generate_virtual_ts_with_offsets
         };
@@ -1003,7 +1022,7 @@ mod tests {
                        </script>\n\
                        <template><div></div></template>";
 
-        let result = DiagnosticService::generate_virtual_ts(&uri, content, false)
+        let result = DiagnosticService::generate_virtual_ts(&uri, content, false, false)
             .expect("virtual ts generated");
 
         assert!(

--- a/crates/vize_maestro/src/ide/hover/script.rs
+++ b/crates/vize_maestro/src/ide/hover/script.rs
@@ -138,6 +138,8 @@ impl HoverService {
         let mut analyzer = Analyzer::with_options(analyzer_options);
         if ctx.state.lsp_features().legacy_vue2 {
             analyzer = analyzer.with_legacy_vue2();
+        } else if ctx.state.options_api_enabled() {
+            analyzer = analyzer.with_options_api();
         }
 
         if let Some(ref script) = descriptor.script {

--- a/crates/vize_maestro/src/ide/hover/template.rs
+++ b/crates/vize_maestro/src/ide/hover/template.rs
@@ -171,6 +171,8 @@ impl HoverService {
         let mut analyzer = Analyzer::with_options(analyzer_options);
         if ctx.state.lsp_features().legacy_vue2 {
             analyzer = analyzer.with_legacy_vue2();
+        } else if ctx.state.options_api_enabled() {
+            analyzer = analyzer.with_options_api();
         }
 
         if let Some(ref script) = descriptor.script {

--- a/crates/vize_maestro/src/ide/references/script.rs
+++ b/crates/vize_maestro/src/ide/references/script.rs
@@ -14,9 +14,9 @@ impl ReferencesService {
         let options = vize_atelier_sfc::SfcParseOptions::default();
         let descriptor = vize_atelier_sfc::parse_sfc(&ctx.content, options).ok()?;
 
-        if ctx.state.lsp_features().legacy_vue2
+        if ctx.state.options_api_enabled()
             && let Some(location) =
-                crate::ide::definition::script::find_analyzed_binding_location(ctx, word, true)
+                crate::ide::definition::script::find_analyzed_binding_location(ctx, word)
         {
             return Some(location);
         }

--- a/crates/vize_maestro/src/ide/type_service.rs
+++ b/crates/vize_maestro/src/ide/type_service.rs
@@ -43,6 +43,8 @@ pub struct LspTypeCheckOptions {
     pub check_invalid_exports: bool,
     /// Check fallthrough attrs with multi-root
     pub check_fallthrough_attrs: bool,
+    /// Resolve Vue 3 Options API template bindings (opt-in, standard build).
+    pub options_api: bool,
     /// Include Vue 2.7 / Nuxt 2 Options API template bindings.
     pub legacy_vue2: bool,
 }
@@ -58,6 +60,7 @@ impl Default for LspTypeCheckOptions {
             check_setup_context: true,
             check_invalid_exports: true,
             check_fallthrough_attrs: true,
+            options_api: false,
             legacy_vue2: false,
         }
     }

--- a/crates/vize_maestro/src/ide/type_service/diagnostics.rs
+++ b/crates/vize_maestro/src/ide/type_service/diagnostics.rs
@@ -11,7 +11,7 @@ use tower_lsp::lsp_types::{
 };
 use vize_canon::{
     SfcTypeCheckOptions as TypeCheckOptions, SfcTypeSeverity as TypeSeverity, type_check_sfc,
-    type_check_sfc_with_legacy_vue2,
+    type_check_sfc_with_legacy_vue2, type_check_sfc_with_options_api,
 };
 
 use super::{LspTypeCheckOptions, TypeService};
@@ -33,6 +33,7 @@ impl TypeService {
                 check_setup_context: cfg.check_setup_context,
                 check_invalid_exports: cfg.check_invalid_exports,
                 check_fallthrough_attrs: cfg.check_fallthrough_attrs,
+                options_api: state.options_api_enabled(),
                 legacy_vue2: state.legacy_vue2_enabled(),
             },
         )
@@ -66,6 +67,8 @@ impl TypeService {
 
         let result = if lsp_options.legacy_vue2 {
             type_check_sfc_with_legacy_vue2(&content, &options)
+        } else if lsp_options.options_api {
+            type_check_sfc_with_options_api(&content, &options)
         } else {
             type_check_sfc(&content, &options)
         };

--- a/crates/vize_maestro/src/server/capabilities.rs
+++ b/crates/vize_maestro/src/server/capabilities.rs
@@ -226,6 +226,7 @@ mod tests {
             lint: true,
             typecheck: true,
             ecosystem: true,
+            options_api: true,
             legacy_vue2: true,
             completion: true,
             hover: true,

--- a/crates/vize_maestro/src/server/state.rs
+++ b/crates/vize_maestro/src/server/state.rs
@@ -38,6 +38,7 @@ struct LspConfigSection {
     typecheck: Option<bool>,
     editor: Option<bool>,
     ecosystem: Option<bool>,
+    options_api: Option<bool>,
     legacy_vue2: Option<bool>,
     completion: Option<bool>,
     hover: Option<bool>,
@@ -90,6 +91,10 @@ impl LspConfigSection {
 
         if let Some(enabled) = self.ecosystem {
             features.ecosystem = enabled;
+        }
+
+        if let Some(enabled) = self.options_api {
+            features.options_api = enabled;
         }
 
         if let Some(enabled) = self.legacy_vue2 {
@@ -156,6 +161,7 @@ impl From<LanguageServerConfig> for LspConfigSection {
             typecheck: config.typecheck,
             editor: config.editor,
             ecosystem: config.ecosystem,
+            options_api: None,
             legacy_vue2: None,
             completion: config.completion,
             hover: config.hover,
@@ -188,6 +194,7 @@ pub struct LspFeatureConfig {
     pub(crate) lint: bool,
     pub(crate) typecheck: bool,
     pub(crate) ecosystem: bool,
+    pub(crate) options_api: bool,
     pub(crate) legacy_vue2: bool,
     pub(crate) completion: bool,
     pub(crate) hover: bool,
@@ -213,6 +220,7 @@ impl LspFeatureConfig {
             lint: false,
             typecheck: false,
             ecosystem: false,
+            options_api: false,
             legacy_vue2: false,
             completion: false,
             hover: false,
@@ -261,6 +269,7 @@ impl Default for LspFeatureConfig {
             lint: true,
             typecheck: true,
             ecosystem: true,
+            options_api: false,
             legacy_vue2: false,
             completion: true,
             hover: true,
@@ -362,6 +371,8 @@ pub struct ServerState {
     lsp_typecheck_enabled: AtomicBool,
     /// Type checker options shared by LSP diagnostics.
     type_checker_config: RwLock<TypeCheckerConfig>,
+    /// Vue 3 Options API binding-resolution opt-in from config.
+    type_checker_options_api: RwLock<bool>,
     /// Vue 2.7 / Nuxt 2 type checker compatibility flag from config.
     type_checker_legacy_vue2: RwLock<bool>,
     /// Linter options shared by LSP diagnostics.
@@ -417,6 +428,7 @@ impl ServerState {
             lsp_features: RwLock::new(default_features),
             lsp_typecheck_enabled: AtomicBool::new(default_features.typecheck),
             type_checker_config: RwLock::new(TypeCheckerConfig::default()),
+            type_checker_options_api: RwLock::new(false),
             type_checker_legacy_vue2: RwLock::new(false),
             linter_config: RwLock::new(LinterConfig::default()),
             #[cfg(feature = "glyph")]
@@ -476,6 +488,14 @@ impl ServerState {
         *self.type_checker_legacy_vue2.read() || self.lsp_features().legacy_vue2
     }
 
+    /// Resolve Vue 3 Options API template bindings. Implied by legacy mode.
+    #[inline]
+    pub(crate) fn options_api_enabled(&self) -> bool {
+        *self.type_checker_options_api.read()
+            || self.lsp_features().options_api
+            || self.legacy_vue2_enabled()
+    }
+
     /// Check whether LSP lint diagnostics are enabled.
     #[inline]
     pub fn is_lsp_lint_enabled(&self) -> bool {
@@ -517,6 +537,7 @@ impl ServerState {
     }
 
     fn apply_config_features(&self, features: vize_carton::config::ConfigFeatureFlags) {
+        *self.type_checker_options_api.write() = features.type_checker_options_api;
         *self.type_checker_legacy_vue2.write() = features.type_checker_legacy_vue2;
         if let Some(enabled) = features.language_server_legacy_vue2 {
             let mut lsp_features = self.lsp_features.write();
@@ -603,6 +624,9 @@ impl ServerState {
             corsa_path.as_deref(),
         ) {
             Ok(mut checker) => {
+                if self.options_api_enabled() {
+                    checker.enable_options_api();
+                }
                 if self.legacy_vue2_enabled() {
                     checker.enable_legacy_vue2();
                 }
@@ -1247,6 +1271,53 @@ mod tests {
         assert!(!config.check_emits);
         assert_eq!(config.tsconfig.as_deref(), Some("tsconfig.app.json"));
         assert_eq!(config.runtime_path(), Some("./node_modules/.bin/corsa"));
+    }
+
+    #[test]
+    fn options_api_disabled_by_default() {
+        let state = ServerState::new();
+        assert!(
+            !state.options_api_enabled(),
+            "Options API resolution must be opt-in: zero cost on the default Vue 3 path"
+        );
+    }
+
+    #[test]
+    fn type_checker_options_api_opt_in_from_config() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("vize.config.json"),
+            r#"{ "typeChecker": { "optionsApi": true } }"#,
+        )
+        .unwrap();
+
+        let state = ServerState::new();
+        state.load_workspace_config(dir.path());
+        assert!(
+            state.options_api_enabled(),
+            "typeChecker.optionsApi should enable Options API binding resolution in the LSP"
+        );
+    }
+
+    #[test]
+    fn legacy_vue2_config_implies_options_api() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("vize.config.json"),
+            r#"{ "typeChecker": { "legacyVue2": true } }"#,
+        )
+        .unwrap();
+
+        let state = ServerState::new();
+        state.load_workspace_config(dir.path());
+        assert!(
+            state.legacy_vue2_enabled(),
+            "typeChecker.legacyVue2 should enable Vue 2 compatibility"
+        );
+        assert!(
+            state.options_api_enabled(),
+            "legacy Vue 2 mode is a superset of Options API binding resolution"
+        );
     }
 
     #[test]

--- a/npm/vscode-vize/README.md
+++ b/npm/vscode-vize/README.md
@@ -89,6 +89,10 @@ individual switches, make sure to include `vize.completion.enable`, `vize.hover.
 diagnostics for `useRoute()`, Vue I18n key completions, workspace key validation, inlay previews,
 Void Vue route completions, and ecosystem lint diagnostics.
 
+Vue 3 Options API support is opt-in. Set `vize.optionsApi.enable: true` to resolve `data`,
+`computed`, `methods`, `props`, and `inject` template bindings in type checking and hover. It is
+officially supported on Vue 3 and stays zero cost when left off for `<script setup>`-only projects.
+
 Vue 2.7 / Nuxt 2 support is opt-in. Set `vize.legacyVue2.enable: true` to include Options API
 template bindings and Nuxt 2 globals in type checking, completion, hover, definition, and references.
 

--- a/npm/vscode-vize/package.json
+++ b/npm/vscode-vize/package.json
@@ -176,6 +176,11 @@
           "default": true,
           "description": "Enable Vue ecosystem diagnostics and editor helpers for Vue Router route names and file-route params, Vue I18n catalogs, Nuxt, and Void Vue."
         },
+        "vize.optionsApi.enable": {
+          "type": "boolean",
+          "default": false,
+          "description": "Resolve Vue 3 Options API template bindings (data, computed, methods, props, inject) in typecheck and hover. Opt-in; officially supported on Vue 3 and zero cost when off."
+        },
         "vize.legacyVue2.enable": {
           "type": "boolean",
           "default": false,

--- a/npm/vscode-vize/src/extension.ts
+++ b/npm/vscode-vize/src/extension.ts
@@ -89,6 +89,7 @@ const FEATURE_SETTING_KEYS = [
   "typecheck.enable",
   "editor.enable",
   "ecosystem.enable",
+  "optionsApi.enable",
   "legacyVue2.enable",
   "completion.enable",
   "hover.enable",
@@ -110,6 +111,7 @@ const CAPABILITY_LABELS: Record<string, string> = {
   lint: "lint",
   typecheck: "type check",
   editor: "editor bundle",
+  optionsApi: "Vue 3 Options API",
   legacyVue2: "Vue 2.7 / Nuxt 2",
   completion: "completion",
   hover: "hover",
@@ -709,6 +711,7 @@ function getInitializationOptions(
   setFeatureOption(options, config, "typecheck.enable", "typecheck", true);
   setFeatureOption(options, config, "editor.enable", "editor", true);
   setFeatureOption(options, config, "ecosystem.enable", "ecosystem", true);
+  setFeatureOption(options, config, "optionsApi.enable", "optionsApi", false);
   setFeatureOption(options, config, "legacyVue2.enable", "legacyVue2", false);
   setFeatureOption(options, config, "completion.enable", "completion", true);
   setFeatureOption(options, config, "hover.enable", "hover", true);

--- a/npm/zed-vize/README.md
+++ b/npm/zed-vize/README.md
@@ -77,6 +77,10 @@ Use this only when you are ready to let Vize overlap with the existing Vue langu
 for `useRoute()`, Vue I18n key completions, workspace key validation and inlay previews, Void Vue
 route completions, and ecosystem lint diagnostics.
 
+`optionsApi` resolves Vue 3 Options API template bindings (`data`, `computed`, `methods`, `props`,
+`inject`) during typecheck and hover. It is opt-in and officially supported on Vue 3; leave it off
+(the default) for `<script setup>`-only projects to keep analysis zero cost.
+
 To make Vize the only Vue language server, replace the existing Vue server entry in your `language_servers` list with its disabled form, such as `"!server-id"`.
 
 If you only want Vize on `*.art.vue`, keep your existing `Vue` language servers unchanged and

--- a/tools/vscode-vize/assert-vsix-package.mjs
+++ b/tools/vscode-vize/assert-vsix-package.mjs
@@ -152,6 +152,7 @@ for (const [key, property] of Object.entries(configurationProperties)) {
   const expectedDefault =
     key === "vize.diagnostics.enable" ||
     key === "vize.formatting.enable" ||
+    key === "vize.optionsApi.enable" ||
     key === "vize.legacyVue2.enable"
       ? false
       : true;


### PR DESCRIPTION
## Summary

Wires the Vue 3 **Options API** opt-in (introduced for the standard build in #1124) into the **maestro language server**, so Options API template bindings (`data`, `computed`, `methods`, `props`, `inject`) resolve across the LSP — not just the CLI type checker.

`options_api` is threaded in parallel to the existing `legacy_vue2` flag and reaches **exactly the IDE surfaces where legacy Vue 2 is wired**:

| Surface | Behavior when `optionsApi` is on |
| --- | --- |
| Type-check diagnostics | Options API bindings resolved (no false "cannot find name") |
| Hover | Options API binding types shown |
| Completion | `data`/`computed`/`methods`/`props` offered in template expressions |
| Go-to-definition | Jumps to Options API bindings, incl. imported-component prop jumps |
| Find-references | Resolves Options API binding locations |

## How it's enabled

- **Config**: `typeChecker.optionsApi: true` in `vize.config` → `apply_config_features` → `ServerState::options_api_enabled()`.
- **LSP init option**: `optionsApi` (camelCase) in `initializationOptions`.
- **VS Code**: new `vize.optionsApi.enable` setting (mirrors `vize.legacyVue2.enable`).
- **Zed**: documented `optionsApi` initialization option (Zed passes init options through).

`options_api_enabled()` = config flag **OR** LSP feature **OR** implied by legacy Vue 2 mode (legacy ⊃ options_api ⊃ default).

## Design notes

- **Uniform analyzer-mode selection** everywhere: `if legacy_vue2_enabled() {…} else if options_api_enabled() {…} else { default }`. Legacy keeps priority since it's a superset.
- `find_analyzed_binding_location` now **derives its mode from `ServerState`** instead of a threaded `bool`, so all three callers (definition/script, definition/template, references) stay consistent.
- The Corsa-path `legacy_vue2_template_completions` supplement **stays legacy-only by design** (documented inline): Nuxt 2 components/globals aren't TS-visible, but Options API bindings *are* emitted into the virtual TS (`generate_options_api_variables`), so Corsa and the synchronous path already surface them. Options API is standard Vue 3 and is treated like the default path here, not like legacy.

## Zero cost

Opt-in and **off by default** — the standard Vue 3 `<script setup>` path is behaviorally unchanged and pays no extra cost. The `legacy` cargo feature is unaffected and still compiles.

## Testing

- `ServerState` wiring: `optionsApi` disabled by default, enabled from config, and implied by `legacyVue2`.
- Completion: Options API `data()` binding completes **only** when the flag is enabled (proves both the wiring and the opt-in/zero-cost contract).
- `cargo test -p vize_maestro` (300) and `-p vize_canon` (268) green; `clippy --workspace -D warnings` scope clean; `fmt --check` clean; `--features legacy` builds; VS Code manifest test + `tsgo`/`vp check` clean.

## Out of scope / follow-up

The auto-import, inlay-hint, and workspace-symbol analyzer surfaces don't branch on component mode at all today (no legacy wiring either); enabling Options API analysis there is a separate, broader change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1126"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783472981&installation_id=136613492&pr_number=1126&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1126&signature=d73250264d7056265057baa737a1581c98aab70ac44dc21aaa8f2a9ef3fdd29d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->