### PR TITLE
fix(vite-plugin): bundle SFC src imports

### DIFF
--- a/npm/vite-plugin-vize/src/compiler.test.ts
+++ b/npm/vite-plugin-vize/src/compiler.test.ts
@@ -372,6 +372,87 @@ assert.deepEqual(
   "Batch compilation should cache style metadata emitted by native SFC parsing",
 );
 
+const srcImportRoot = fs.mkdtempSync(path.join(os.tmpdir(), "vize-src-imports-"));
+const srcImportDir = path.join(srcImportRoot, "src");
+fs.mkdirSync(srcImportDir, { recursive: true });
+
+const srcImportFile = path.join(srcImportDir, "App.vue");
+const scriptSrc = path.join(srcImportDir, "setup.ts");
+const templateSrc = path.join(srcImportDir, "template.html");
+const styleSrc = path.join(srcImportDir, "styles.css");
+
+fs.writeFileSync(
+  scriptSrc,
+  `export default {
+  setup() {
+    const label = "src import works";
+    return { label };
+  },
+};
+`,
+);
+fs.writeFileSync(templateSrc, `<p class="root">{{ label }}</p>`);
+fs.writeFileSync(styleSrc, `.root { color: seagreen; }\n`);
+
+const srcImportSource = `<script lang="ts" src="./setup.ts"></script>
+<template src="./template.html"></template>
+<style scoped src="./styles.css"></style>`;
+
+const srcImportCompiled = compileFile(
+  srcImportFile,
+  new Map(),
+  { sourceMap: false, ssr: false, vapor: false },
+  srcImportSource,
+);
+
+assert.match(
+  srcImportCompiled.code,
+  /src import works/,
+  "Single-file compilation should inline script src content",
+);
+assert.match(
+  srcImportCompiled.code,
+  /label/,
+  "Single-file compilation should inline template src content",
+);
+assert.match(
+  srcImportCompiled.css ?? "",
+  /color:\s*seagreen/,
+  "Single-file compilation should inline style src content",
+);
+assert.deepEqual(
+  srcImportCompiled.dependencies?.map((dependency) => path.basename(dependency)).sort(),
+  ["setup.ts", "styles.css", "template.html"],
+  "Single-file compilation should expose SFC src dependencies",
+);
+
+const srcImportBatchCache = new Map();
+const srcImportBatchResult = compileBatch(
+  [{ path: srcImportFile, source: srcImportSource }],
+  srcImportBatchCache,
+  { ssr: false, vapor: false },
+);
+
+assert.equal(srcImportBatchResult.failedCount, 0, "Batch src import compilation should succeed");
+assert.match(
+  srcImportBatchCache.get(srcImportFile)?.code ?? "",
+  /src import works/,
+  "Batch compilation should inline script src content",
+);
+assert.match(
+  srcImportBatchCache.get(srcImportFile)?.css ?? "",
+  /color:\s*seagreen/,
+  "Batch compilation should inline style src content",
+);
+assert.deepEqual(
+  srcImportBatchCache
+    .get(srcImportFile)
+    ?.dependencies?.map((dependency) => path.basename(dependency))
+    .sort(),
+  ["setup.ts", "styles.css", "template.html"],
+  "Batch compilation should cache SFC src dependencies",
+);
+
 const definePageSource = `<script setup lang="ts">
 definePage({
   name: "home",

--- a/npm/vite-plugin-vize/src/compiler.ts
+++ b/npm/vite-plugin-vize/src/compiler.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import path from "node:path";
 import * as native from "@vizejs/native";
 import type {
   CompiledModule,
@@ -44,11 +45,108 @@ function normalizeStyleBlocks(styles: NativeStyleBlockInfo[] | undefined): Style
 
   return styles.map((block) => ({
     content: block.content,
+    src: block.src ?? null,
     lang: block.lang ?? null,
     scoped: block.scoped,
     module: block.module ? (block.moduleName ?? true) : false,
     index: block.index,
   }));
+}
+
+export interface ResolvedSfcSrcImports {
+  source: string;
+  dependencies: string[];
+}
+
+function resolveRelativeSrc(filePath: string, src: string): string {
+  return path.isAbsolute(src) ? src : path.resolve(path.dirname(filePath), src);
+}
+
+function readSrcImport(
+  filePath: string,
+  tag: string,
+  src: string,
+): { path: string; content: string } {
+  const resolvedPath = resolveRelativeSrc(filePath, src);
+  try {
+    return {
+      path: resolvedPath,
+      content: fs.readFileSync(resolvedPath, "utf-8"),
+    };
+  } catch {
+    throw new Error(
+      `[vize] <${tag} src="${src}"> not found (resolved: ${resolvedPath}) in ${filePath}`,
+    );
+  }
+}
+
+function stripSrcAttribute(attrs: string): string {
+  return attrs.replace(/\s*\bsrc\s*=\s*(?:"[^"]*"|'[^']*')/i, "");
+}
+
+function inlineSingleSrcBlock(
+  source: string,
+  filePath: string,
+  tag: "script" | "template",
+  src: string | undefined,
+  dependencies: string[],
+): string {
+  if (!src) {
+    return source;
+  }
+
+  const imported = readSrcImport(filePath, tag, src);
+  dependencies.push(imported.path);
+  const pattern = new RegExp(
+    `<${tag}\\b([^>]*)\\bsrc\\s*=\\s*(['"])[^'"]+\\2([^>]*)>[\\s\\S]*?<\\/${tag}>`,
+    "i",
+  );
+
+  return source.replace(pattern, (_match, beforeSrc: string, _quote: string, afterSrc: string) => {
+    const attrs = stripSrcAttribute(`${beforeSrc}${afterSrc}`);
+    return `<${tag}${attrs}>\n${imported.content}\n</${tag}>`;
+  });
+}
+
+function inlineStyleSrcBlocks(source: string, filePath: string, dependencies: string[]): string {
+  const pattern = /<style\b([^>]*)\bsrc\s*=\s*(['"])([^'"]+)\2([^>]*)>[\s\S]*?<\/style>/gi;
+
+  return source.replace(
+    pattern,
+    (_match, beforeSrc: string, _quote: string, src: string, afterSrc: string) => {
+      const imported = readSrcImport(filePath, "style", src);
+      dependencies.push(imported.path);
+      const attrs = stripSrcAttribute(`${beforeSrc}${afterSrc}`);
+      return `<style${attrs}>\n${imported.content}\n</style>`;
+    },
+  );
+}
+
+export function resolveSfcSrcImports(filePath: string, source: string): ResolvedSfcSrcImports {
+  const dependencies: string[] = [];
+  const srcInfo = native.extractSfcSrcInfo(source, filePath);
+  let resolvedSource = source;
+
+  resolvedSource = inlineSingleSrcBlock(
+    resolvedSource,
+    filePath,
+    "script",
+    srcInfo.scriptSrc,
+    dependencies,
+  );
+  resolvedSource = inlineSingleSrcBlock(
+    resolvedSource,
+    filePath,
+    "template",
+    srcInfo.templateSrc,
+    dependencies,
+  );
+  resolvedSource = inlineStyleSrcBlocks(resolvedSource, filePath, dependencies);
+
+  return {
+    source: resolvedSource,
+    dependencies,
+  };
 }
 
 export function compileFile(
@@ -58,9 +156,10 @@ export function compileFile(
   source?: string,
 ): CompiledModule {
   const content = source ?? fs.readFileSync(filePath, "utf-8");
+  const resolved = resolveSfcSrcImports(filePath, content);
   const scopeId = generateScopeId(filePath);
 
-  const result = compileSfc(content, buildCompileFileOptions(filePath, options));
+  const result = compileSfc(resolved.source, buildCompileFileOptions(filePath, options));
 
   if (result.errors.length > 0) {
     throw new VizeSfcCompileError(filePath, result.errors);
@@ -82,6 +181,7 @@ export function compileFile(
     scriptHash: result.scriptHash,
     macroArtifacts: result.macroArtifacts ?? [],
     styles: normalizeStyleBlocks(result.styles),
+    dependencies: resolved.dependencies,
   };
 
   cache.set(filePath, compiled);
@@ -97,8 +197,18 @@ export function compileBatch(
   cache: Map<string, CompiledModule>,
   options: CompileBatchOptions,
 ): BatchCompileResultWithFiles {
+  const dependenciesByPath = new Map<string, string[]>();
+  const resolvedFiles = files.map((file) => {
+    const resolved = resolveSfcSrcImports(file.path, file.source);
+    dependenciesByPath.set(file.path, resolved.dependencies);
+    return {
+      path: file.path,
+      source: resolved.source,
+    };
+  });
+
   const result = compileSfcBatchWithResults(
-    files satisfies BatchFileInput[],
+    resolvedFiles satisfies BatchFileInput[],
     buildCompileBatchOptions(options),
   );
 
@@ -115,6 +225,7 @@ export function compileBatch(
         scriptHash: fileResult.scriptHash,
         macroArtifacts: fileResult.macroArtifacts ?? [],
         styles: normalizeStyleBlocks(fileResult.styles),
+        dependencies: dependenciesByPath.get(fileResult.path) ?? [],
       });
     }
 

--- a/npm/vite-plugin-vize/src/plugin/hmr.test.ts
+++ b/npm/vite-plugin-vize/src/plugin/hmr.test.ts
@@ -1,12 +1,15 @@
 import assert from "node:assert/strict";
+import type { HmrContext } from "vite";
 
 import type { VizePluginState } from "./state.ts";
 import {
+  handleHotUpdateHook,
   handleGenerateBundleHook,
   resolveComponentsCssFileName,
   VIZE_COMPONENTS_CSS_BASENAME,
   VIZE_COMPONENTS_CSS_FILE,
 } from "./hmr.ts";
+import { toVirtualId } from "../virtual.ts";
 
 function createState(): VizePluginState {
   return {
@@ -37,6 +40,70 @@ assert.equal(
   VIZE_COMPONENTS_CSS_BASENAME,
   "assetless builds should place component CSS beside chunks",
 );
+
+{
+  const vueFile = "/src/App.vue";
+  const dependencyFile = "/src/imported.css";
+  const module = { url: toVirtualId(vueFile) };
+  let invalidatedModule: unknown;
+  const state = {
+    cache: new Map([
+      [
+        vueFile,
+        {
+          code: "export default {}",
+          scopeId: "app12345",
+          hasScoped: false,
+          dependencies: [dependencyFile],
+        },
+      ],
+    ]),
+    ssrCache: new Map(),
+    collectedCss: new Map([[vueFile, ".app { color: red; }"]]),
+    precompileMetadata: new Map([[vueFile, { mtimeMs: 1, size: 1 }]]),
+    pendingHmrUpdateTypes: new Map(),
+    root: "/src",
+    logger: {
+      log() {},
+    },
+  } as unknown as VizePluginState;
+  const ctx = {
+    file: dependencyFile,
+    server: {
+      moduleGraph: {
+        getModulesByFile(id: string) {
+          return id === toVirtualId(vueFile) ? new Set([module]) : undefined;
+        },
+        invalidateModule(receivedModule: unknown) {
+          invalidatedModule = receivedModule;
+        },
+      },
+    },
+    read: async () => "",
+  } as unknown as HmrContext;
+
+  const modules = await handleHotUpdateHook(state, ctx);
+
+  assert.deepEqual(modules, [module], "SFC src dependency updates should reload the owner module");
+  assert.equal(state.cache.has(vueFile), false, "Dependency updates should clear the client cache");
+  assert.equal(state.ssrCache.has(vueFile), false, "Dependency updates should clear the SSR cache");
+  assert.equal(
+    state.collectedCss.has(vueFile),
+    false,
+    "Dependency updates should clear collected CSS",
+  );
+  assert.equal(
+    state.precompileMetadata.has(vueFile),
+    false,
+    "Dependency updates should clear precompile metadata",
+  );
+  assert.equal(
+    state.pendingHmrUpdateTypes.get(vueFile),
+    "full-reload",
+    "Dependency updates should force full reload HMR for the owner SFC",
+  );
+  assert.equal(invalidatedModule, module, "Dependency updates should invalidate the owner module");
+}
 
 {
   const emitted: Array<{ type: "asset"; fileName: string; source: string }> = [];

--- a/npm/vite-plugin-vize/src/plugin/hmr.ts
+++ b/npm/vite-plugin-vize/src/plugin/hmr.ts
@@ -28,11 +28,64 @@ type GenerateBundleItem =
 
 type GenerateBundle = Record<string, GenerateBundleItem>;
 
+function getVueFilesDependingOn(state: VizePluginState, dependencyFile: string): string[] {
+  const normalizedDependency = path.resolve(dependencyFile);
+  const owners = new Set<string>();
+
+  for (const cache of [state.cache, state.ssrCache]) {
+    for (const [vueFile, compiled] of cache) {
+      if (
+        compiled.dependencies?.some(
+          (dependency) => path.resolve(dependency) === normalizedDependency,
+        )
+      ) {
+        owners.add(vueFile);
+      }
+    }
+  }
+
+  return [...owners];
+}
+
 export async function handleHotUpdateHook(
   state: VizePluginState,
   ctx: HmrContext,
 ): Promise<import("vite").ModuleNode[] | void> {
   const { file, server, read } = ctx;
+
+  const dependencyOwners = getVueFilesDependingOn(state, file);
+  if (dependencyOwners.length > 0) {
+    const affectedModules: Set<import("vite").ModuleNode> = new Set();
+
+    for (const vueFile of dependencyOwners) {
+      state.cache.delete(vueFile);
+      state.ssrCache.delete(vueFile);
+      state.collectedCss.delete(vueFile);
+      state.precompileMetadata.delete(vueFile);
+      state.pendingHmrUpdateTypes.set(vueFile, "full-reload");
+
+      const virtualId = toVirtualId(vueFile);
+      const modules =
+        server.moduleGraph.getModulesByFile(virtualId) ??
+        server.moduleGraph.getModulesByFile(vueFile);
+
+      if (modules) {
+        for (const module of modules) {
+          server.moduleGraph.invalidateModule(module);
+          affectedModules.add(module);
+        }
+      }
+
+      state.logger.log(
+        `Invalidated ${path.relative(state.root, vueFile)} because ${path.relative(
+          state.root,
+          file,
+        )} changed`,
+      );
+    }
+
+    return [...affectedModules];
+  }
 
   if (file.endsWith(".vue") && state.filter(file)) {
     try {

--- a/npm/vite-plugin-vize/src/plugin/index.ts
+++ b/npm/vite-plugin-vize/src/plugin/index.ts
@@ -370,7 +370,10 @@ export function vize(options: VizeOptions = {}): Plugin[] {
     },
 
     load(id, loadOptions) {
-      return loadHook(state, id, loadOptions);
+      return loadHook(state, id, {
+        ...loadOptions,
+        addWatchFile: this.addWatchFile.bind(this),
+      });
     },
 
     async transform(code, id, transformOptions) {

--- a/npm/vite-plugin-vize/src/plugin/load.test.ts
+++ b/npm/vite-plugin-vize/src/plugin/load.test.ts
@@ -373,6 +373,39 @@ assert.match(
   "Consumed pending updates must fall back to the default HMR mode",
 );
 
+const watchedDependency = "/src/external.css";
+const watchedPath = "/src/Watched.vue";
+const watchedState: VizePluginState = {
+  ...hmrState,
+  cache: new Map([
+    [
+      watchedPath,
+      {
+        code: `export function render() { return null }
+const _sfc_main = {}
+_sfc_main.render = render
+export default _sfc_main`,
+        scopeId: "watch1234",
+        hasScoped: false,
+        styles: [],
+        dependencies: [watchedDependency],
+      },
+    ],
+  ]),
+  pendingHmrUpdateTypes: new Map(),
+};
+const watchedFiles: string[] = [];
+const watchedLoad = loadHook(watchedState, toVirtualId(watchedPath), {
+  ssr: false,
+  addWatchFile: (id) => watchedFiles.push(id),
+});
+assert.ok(watchedLoad && typeof watchedLoad === "object", "Watched SFC should load");
+assert.deepEqual(
+  watchedFiles,
+  [watchedDependency],
+  "SFC src dependencies should be registered with Vite's watcher",
+);
+
 const inlinePath = "/src/InlineHmr.vue";
 const inlineState: VizePluginState = {
   ...hmrState,

--- a/npm/vite-plugin-vize/src/plugin/load.ts
+++ b/npm/vite-plugin-vize/src/plugin/load.ts
@@ -146,7 +146,7 @@ function loadCompiledSfcModule(
   realPath: string,
   isSsr: boolean,
   currentBase: string,
-  loadOptions?: { ssr?: boolean },
+  loadOptions?: { ssr?: boolean; addWatchFile?: (id: string) => void },
 ): { code: string; map: null } | string | null {
   const placeholderCode = getBoundaryPlaceholderCode(realPath, !!loadOptions?.ssr);
   if (placeholderCode) {
@@ -170,6 +170,10 @@ function loadCompiledSfcModule(
 
   if (!compiled) {
     return null;
+  }
+
+  for (const dependency of compiled.dependencies ?? []) {
+    loadOptions?.addWatchFile?.(dependency);
   }
 
   const hasDelegated = hasDelegatedStyles(compiled);
@@ -237,7 +241,7 @@ function loadDefinePageMetaArtifact(
 export function loadHook(
   state: VizePluginState,
   id: string,
-  loadOptions?: { ssr?: boolean },
+  loadOptions?: { ssr?: boolean; addWatchFile?: (id: string) => void },
 ): string | { code: string; map: null } | null {
   const request = classifyVitePluginRequest(id);
   const pluginVisibleVirtualPath = fromPluginVisibleVirtualId(id);

--- a/npm/vite-plugin-vize/src/types.ts
+++ b/npm/vite-plugin-vize/src/types.ts
@@ -236,6 +236,8 @@ export interface VizeOptions {
 export interface StyleBlockInfo {
   /** Raw style content (uncompiled for preprocessor langs) */
   content: string;
+  /** External source path from `<style src>`, when present */
+  src?: string | null;
   /** Language of the style block (e.g., "css", "scss", "less", "sass", "stylus") */
   lang: string | null;
   /** Whether the style block has the scoped attribute */
@@ -249,6 +251,8 @@ export interface StyleBlockInfo {
 export interface NativeStyleBlockInfo {
   /** Raw style content (uncompiled for preprocessor langs) */
   content: string;
+  /** External source path from `<style src>`, when present */
+  src?: string | null;
   /** Language of the style block (e.g., "css", "scss", "less", "sass", "stylus") */
   lang?: string | null;
   /** Whether the style block has the scoped attribute */
@@ -273,6 +277,8 @@ export interface CompiledModule {
   macroArtifacts?: MacroArtifact[];
   /** Per-block style metadata extracted from the source SFC */
   styles?: StyleBlockInfo[];
+  /** Files loaded through SFC `src` imports */
+  dependencies?: string[];
 }
 
 export interface BatchFileInput {


### PR DESCRIPTION
## Summary
- inline external SFC `src` blocks before native compilation
- register external SFC files as Vite watch dependencies
- invalidate owning Vue modules when those dependencies change

Fixes #1127

## Validation
- `node_modules/.bin/vp check npm/vite-plugin-vize/src npm/vite-plugin-vize/vite.config.ts`
- `node npm/vite-plugin-vize/src/test.ts`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1131"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783486151&installation_id=136613492&pr_number=1131&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1131&signature=f8bf2eff879895b8d3c247eb487017a7806c58b64e05ee1f4b625872130633c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->