### PR TITLE
fix(vapor): emit valid multiline event handlers

### DIFF
--- a/crates/vize_atelier_vapor/src/generate/operations/events.rs
+++ b/crates/vize_atelier_vapor/src/generate/operations/events.rs
@@ -18,7 +18,13 @@ pub(super) fn generate_set_event(ctx: &mut GenerateContext, set_event: &SetEvent
 
     let resolved_handler = ctx.resolve_expression(&handler);
     // Determine handler format based on content
-    let invoker_body: String = if handler.contains("$event") {
+    let invoker_body: String = if is_inline_statement_block(&handler) {
+        if handler.contains("$event") {
+            cstr!("$event => {{ {} }}", resolved_handler)
+        } else {
+            cstr!("() => {{ {} }}", resolved_handler)
+        }
+    } else if handler.contains("$event") {
         cstr!("$event => ({})", resolved_handler)
     } else if handler.contains("?.") {
         cstr!("(...args) => ({})", resolved_handler)
@@ -123,4 +129,11 @@ pub(super) fn is_inline_statement(handler: &str) -> bool {
         || handler.contains("+=")
         || handler.contains("-=")
         || (handler.contains('=') && !handler.contains("==") && !handler.contains("=>"))
+}
+
+fn is_inline_statement_block(handler: &str) -> bool {
+    let trimmed = handler.trim();
+    !trimmed.contains("=>")
+        && !trimmed.starts_with("function")
+        && (trimmed.contains(';') || trimmed.contains('\n'))
 }

--- a/tests/expected/vapor/v-on.snap
+++ b/tests/expected/vapor/v-on.snap
@@ -31,6 +31,25 @@ export function render(_ctx) {
 }
 
 ===
+name: multi-line inline handler
+options: vapor
+--- INPUT ---
+<button @click="hoge();
+fuga();
+">Hoge</button>
+--- OUTPUT ---
+import { createInvoker as _createInvoker, delegateEvents as _delegateEvents, template as _template } from 'vue';
+const t0 = _template("<button>Hoge</button>", true)
+_delegateEvents("click")
+
+export function render(_ctx) {
+  const n0 = t0()
+  n0.$evtclick = _createInvoker(() => { _ctx.hoge();
+_ctx.fuga(); })
+  return n0
+}
+
+===
 name: method call
 options: vapor
 --- INPUT ---

--- a/tests/fixtures/vapor/v-on.pkl
+++ b/tests/fixtures/vapor/v-on.pkl
@@ -14,6 +14,14 @@ cases {
     input = #"<button @click="count++"></button>"#
   }
   new {
+    name = "multi-line inline handler"
+    input = """
+    <button @click="hoge();
+    fuga();
+    ">Hoge</button>
+    """
+  }
+  new {
     name = "method call"
     input = #"<button @click="handler()"></button>"#
   }


### PR DESCRIPTION
## Summary
- emit statement-style inline event handlers as arrow function blocks
- keep expression and function handlers on the existing expression path
- add v-on fixture coverage for multiline handlers

Fixes #1128

## Validation
- `git diff --check`
- Previously passed before PR split: `cargo test -p vize_atelier_vapor`
- Previously passed before PR split: `cargo test -p vize_test_runner vapor_v_on -- --ignored`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1132"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783486161&installation_id=136613492&pr_number=1132&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1132&signature=e83717facae8551cce8ae0d590d34509f12f350946bc576e227c2e31bd2266ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->