### PR TITLE
fix(canon): narrow event handlers with v-if

### DIFF
--- a/crates/vize_canon/src/batch/type_checker/tests.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests.rs
@@ -542,6 +542,44 @@ function editWord() {}
 }
 
 #[test]
+fn batch_type_checker_narrows_same_element_event_handler_with_v_if() {
+    if resolve_test_tsgo_binary().is_none() {
+        return;
+    }
+
+    let project_root = create_project_case_without_node_modules(
+        "same-element-vif-handler-narrowing",
+        &[(
+            "src/SameElementVifHandler.vue",
+            r#"<script setup lang="ts">
+type UnionType = { type: "a" } | { type: "b", bSpecific: () => void }
+
+const val = 0 as unknown as UnionType
+</script>
+
+<template>
+  <div v-if="val.type === 'b'" @click="val.bSpecific"></div>
+</template>
+"#,
+        )],
+    );
+
+    let Some(snapshot) = snapshot_project_diagnostics(&project_root) else {
+        let _ = std::fs::remove_dir_all(&project_root);
+        return;
+    };
+
+    assert!(
+        snapshot.iter().all(|(file, code, _)| {
+            file != "src/SameElementVifHandler.vue" || *code != Some(2339)
+        }),
+        "unexpected union member diagnostic for v-if narrowed event handler: {snapshot:#?}"
+    );
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}
+
+#[test]
 fn batch_type_checker_uses_workspace_vue_runtime_without_node_modules() {
     if resolve_test_tsgo_binary().is_none() {
         return;

--- a/crates/vize_canon/src/virtual_ts.rs
+++ b/crates/vize_canon/src/virtual_ts.rs
@@ -628,6 +628,34 @@ function handleHover() {}
     }
 
     #[test]
+    fn test_v_if_guard_wraps_same_element_event_handler() {
+        use vize_croquis::{Analyzer, AnalyzerOptions};
+
+        let script = r#"type UnionType = { type: "a" } | { type: "b", bSpecific: () => void }
+const val = 0 as unknown as UnionType;
+"#;
+        let template = r#"<div v-if="val.type === 'b'" @click="val.bSpecific"></div>"#;
+
+        let allocator = vize_carton::Bump::new();
+        let (root, _) = vize_armature::parse(&allocator, template);
+
+        let mut analyzer = Analyzer::with_options(AnalyzerOptions::full());
+        analyzer.analyze_script_setup(script);
+        analyzer.analyze_template(&root);
+        let summary = analyzer.finish();
+
+        let output = generate_virtual_ts(&summary, Some(script), Some(&root), 0);
+
+        assert!(
+            output
+                .code
+                .contains("if ((val.type === 'b')) {\n      const __vize_handler"),
+            "same-element event handler should preserve the v-if guard while type-checking the handler:\n{}",
+            output.code
+        );
+    }
+
+    #[test]
     fn test_multiline_statement_event_handler_uses_handler_scope() {
         use vize_croquis::{Analyzer, AnalyzerOptions};
 

--- a/crates/vize_canon/src/virtual_ts/expressions.rs
+++ b/crates/vize_canon/src/virtual_ts/expressions.rs
@@ -214,7 +214,7 @@ fn generate_expression_statement(
     append!(*ts, "{indent}// @vize-map: expr -> {src_start}:{src_end}\n",);
 }
 
-fn rewrite_reserved_template_prop(
+pub(crate) fn rewrite_reserved_template_prop(
     expression: &str,
     template_prop_names: &FxHashSet<String>,
 ) -> Option<String> {

--- a/crates/vize_canon/src/virtual_ts/scope.rs
+++ b/crates/vize_canon/src/virtual_ts/scope.rs
@@ -15,7 +15,9 @@ use vize_croquis::{
 };
 
 use super::{
-    expressions::{generate_component_prop_checks, generate_expressions},
+    expressions::{
+        generate_component_prop_checks, generate_expressions, rewrite_reserved_template_prop,
+    },
     helpers::{
         generated_text_range, get_dom_event_type, to_camel_case, to_safe_identifier,
         to_safe_identifier_fragment,
@@ -48,6 +50,7 @@ struct EventHandlerExprContext<'a> {
     expressions_by_scope: &'a FxHashMap<u32, Vec<&'a vize_croquis::TemplateExpression>>,
     data: &'a EventHandlerScopeData,
     event_type: &'a str,
+    template_prop_names: &'a FxHashSet<String>,
     template_offset: u32,
     indent: &'a str,
 }
@@ -784,6 +787,7 @@ fn generate_scope_node(
                             expressions_by_scope: ctx.expressions_by_scope,
                             data,
                             event_type: event_type.as_str(),
+                            template_prop_names: ctx.template_prop_names,
                             template_offset: ctx.template_offset,
                             indent: &inner_indent,
                         },
@@ -805,6 +809,7 @@ fn generate_scope_node(
                             expressions_by_scope: ctx.expressions_by_scope,
                             data,
                             event_type,
+                            template_prop_names: ctx.template_prop_names,
                             template_offset: ctx.template_offset,
                             indent: &inner_indent,
                         },
@@ -845,6 +850,19 @@ fn generate_event_handler_expressions(
                 ctx.data.has_implicit_event && is_callable_handler_reference(content);
             let src_start = (ctx.template_offset + expr.start) as usize;
             let src_end = (ctx.template_offset + expr.end) as usize;
+            let guard = expr.vif_guard.as_ref().map(|guard| {
+                let trimmed_guard = guard.as_str().trim();
+                rewrite_reserved_template_prop(trimmed_guard, ctx.template_prop_names)
+                    .unwrap_or_else(|| String::from(guard.as_str()))
+            });
+            if let Some(ref guard) = guard {
+                append!(*ts, "{indent}if ({guard}) {{\n", indent = ctx.indent);
+            }
+            let handler_indent = if guard.is_some() {
+                cstr!("{}  ", ctx.indent)
+            } else {
+                String::from(ctx.indent)
+            };
 
             let gen_stmt_start = ts.len();
             if is_implicit_reference {
@@ -852,19 +870,19 @@ fn generate_event_handler_expressions(
                 append!(
                     *ts,
                     "{indent}const {handler_name} = ((handler: ($event: {event_type}) => unknown) => handler)(({content}));\n",
-                    indent = ctx.indent,
+                    indent = handler_indent,
                     event_type = ctx.event_type,
                 );
                 append!(
                     *ts,
                     "{indent}{handler_name}($event);  // handler expression\n",
-                    indent = ctx.indent,
+                    indent = handler_indent,
                 );
             } else {
                 append!(
                     *ts,
                     "{indent}{content};  // handler expression\n",
-                    indent = ctx.indent
+                    indent = handler_indent
                 );
             }
             let gen_stmt_end = ts.len();
@@ -880,8 +898,11 @@ fn generate_event_handler_expressions(
             append!(
                 *ts,
                 "{indent}// @vize-map: handler -> {src_start}:{src_end}\n",
-                indent = ctx.indent,
+                indent = handler_indent,
             );
+            if guard.is_some() {
+                append!(*ts, "{indent}}}\n", indent = ctx.indent);
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- Keep same-element v-if guards in the generated event handler type-checking scope.
- Reuse reserved template prop rewriting for guarded handler conditions.
- Add virtual TS and batch type checker coverage for union narrowing on guarded handlers.

## Validation
- cargo fmt --check
- cargo test -p vize_canon batch_type_checker_narrows_same_element_event_handler_with_v_if
- cargo test -p vize_canon test_v_if_guard_wraps_same_element_event_handler
- cargo test -p vize_canon

Closes #1137

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1142"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783493929&installation_id=136613492&pr_number=1142&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1142&signature=de5479d093af6834546b37435a310e84ce792dc72d960c9b954e05a547751d25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->