### PR TITLE
fix(canon): avoid global redeclaration for setup dollar bindings

### DIFF
--- a/crates/vize_canon/src/batch/type_checker/tests.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests.rs
@@ -257,6 +257,46 @@ const inputRef = useTemplateRef<HTMLInputElement>('input')
 }
 
 #[test]
+fn batch_type_checker_accepts_setup_binding_named_like_instance_global() {
+    if resolve_test_tsgo_binary().is_none() {
+        return;
+    }
+
+    let project_root = create_project_case_without_node_modules(
+        "setup-binding-instance-global",
+        &[(
+            "src/App.vue",
+            r#"<template>
+  <div v-if="$q">
+    None
+  </div>
+</template>
+
+<script setup lang="ts">
+function functionCall(): any {}
+
+const $q = functionCall()
+</script>
+"#,
+        )],
+    );
+
+    let Some(snapshot) = snapshot_project_diagnostics(&project_root) else {
+        let _ = std::fs::remove_dir_all(&project_root);
+        return;
+    };
+
+    assert!(
+        snapshot
+            .iter()
+            .all(|(file, code, _)| { file != "src/App.vue" || *code != Some(2300) }),
+        "unexpected duplicate identifier diagnostic for setup $ binding: {snapshot:#?}"
+    );
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}
+
+#[test]
 fn batch_type_checker_accepts_nested_ref_value_component_props() {
     if resolve_test_tsgo_binary().is_none() {
         return;

--- a/crates/vize_canon/src/virtual_ts.rs
+++ b/crates/vize_canon/src/virtual_ts.rs
@@ -235,6 +235,39 @@ const count = 1
     }
 
     #[test]
+    fn test_template_instance_globals_skip_setup_bindings() {
+        use vize_croquis::{Analyzer, AnalyzerOptions};
+
+        let script = r#"function functionCall(): any {}
+const $q = functionCall()
+"#;
+        let template = r#"<div v-if="$q">None</div>"#;
+
+        let allocator = vize_carton::Bump::new();
+        let (root, _) = vize_armature::parse(&allocator, template);
+
+        let mut analyzer = Analyzer::with_options(AnalyzerOptions::full());
+        analyzer.analyze_script_setup(script);
+        analyzer.analyze_template(&root);
+        let summary = analyzer.finish();
+
+        let output = generate_virtual_ts(&summary, Some(script), Some(&root), 0);
+
+        assert!(
+            !output
+                .code
+                .contains("const $q: __VizeInstanceGlobal<'$q'> = undefined as any;"),
+            "setup binding named like an instance global must not be redeclared:\n{}",
+            output.code
+        );
+        assert!(
+            output.code.contains("if (($q))"),
+            "template expression should still resolve the setup binding:\n{}",
+            output.code
+        );
+    }
+
+    #[test]
     fn test_kebab_case_component_names_are_sanitized_in_type_helpers() {
         use vize_croquis::{Analyzer, AnalyzerOptions};
 

--- a/crates/vize_canon/src/virtual_ts/scope.rs
+++ b/crates/vize_canon/src/virtual_ts/scope.rs
@@ -10,8 +10,8 @@ use vize_carton::String;
 use vize_carton::profile;
 
 use vize_croquis::{
-    Croquis, EventHandlerScopeData, Scope, ScopeData, ScopeId, ScopeKind, analysis::ComponentUsage,
-    analyzer::extract_identifiers_oxc, naming::to_pascal_case,
+    BindingMetadata, Croquis, EventHandlerScopeData, Scope, ScopeData, ScopeId, ScopeKind,
+    analysis::ComponentUsage, analyzer::extract_identifiers_oxc, naming::to_pascal_case,
 };
 
 use super::{
@@ -289,6 +289,7 @@ struct InstanceGlobalRefsEmitter<'a> {
     ts: &'a mut String,
     mappings: &'a mut Vec<VizeMapping>,
     options: &'a VirtualTsOptions,
+    bindings: &'a BindingMetadata,
     type_export_names: FxHashSet<&'a str>,
     seen_names: FxHashSet<String>,
     emitted_header: bool,
@@ -305,6 +306,7 @@ impl<'a> InstanceGlobalRefsEmitter<'a> {
             ts,
             mappings,
             options,
+            bindings: &summary.bindings,
             type_export_names: summary
                 .type_exports
                 .iter()
@@ -317,6 +319,7 @@ impl<'a> InstanceGlobalRefsEmitter<'a> {
 
     fn emit(&mut self, name: &str, src_start: usize, src_end: usize) {
         if !is_template_instance_global_name(name)
+            || self.bindings.contains(name)
             || self.type_export_names.contains(name)
             || is_declared_template_context_name(name, self.options)
             || !self.seen_names.insert(name.into())


### PR DESCRIPTION
## Summary
- Skip generated instance-global stubs when a template `$` name is already a setup binding.
- Add virtual TS and batch type checker regressions for a setup `$q` binding used in `v-if`.

## Root Cause
The generator emitted a ComponentPublicInstance global stub for `$q` even when script setup already declared `$q`; template shadowing then produced duplicate declarations in the same generated scope.

## Validation
- `cargo fmt --check`
- `cargo test -p vize_canon test_template_instance_globals_skip_setup_bindings`
- `cargo test -p vize_canon batch_type_checker_accepts_setup_binding_named_like_instance_global`
- `cargo test -p vize_canon`
- `cargo clippy -p vize_canon -- -D warnings`

Closes #1136

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1143"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783497963&installation_id=136613492&pr_number=1143&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1143&signature=e0a0dffb4d8f70538853ff3a9799062d866bfde2b2f85094ecb68bec27a595d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->