### PR TITLE
feat(cli): add curator env command

### DIFF
--- a/crates/vize/src/cli.rs
+++ b/crates/vize/src/cli.rs
@@ -10,6 +10,7 @@ struct Cli {
     /// Print version
     #[arg(short = 'v', short_alias = 'V', long, action = clap::ArgAction::Version)]
     version: (),
+
     #[command(subcommand)]
     command: Option<Commands>,
 }
@@ -34,6 +35,9 @@ enum Commands {
 
     /// Create playground compiler inspector payloads and agent reports
     Inspector(crate::commands::inspector::InspectorArgs),
+
+    /// Curator utilities for diagnostics and reports
+    Curator(crate::commands::curator::CuratorArgs),
 
     /// Remove Vize-generated cache artifacts
     Clean(crate::commands::clean::CleanArgs),
@@ -81,6 +85,7 @@ fn run(cli: Cli) {
         Some(Commands::Lint(args)) => crate::commands::lint::run(args),
         Some(Commands::Check(args)) => crate::commands::check::run(args),
         Some(Commands::Inspector(args)) => crate::commands::inspector::run(args),
+        Some(Commands::Curator(args)) => crate::commands::curator::run(args),
         Some(Commands::Clean(args)) => crate::commands::clean::run(args),
         #[cfg(unix)]
         Some(Commands::CheckServer(args)) => crate::commands::check_server::run(args),
@@ -134,6 +139,11 @@ mod tests {
     #[test]
     fn inspector_help_snapshot() {
         insta::assert_snapshot!("cli_inspector_help", command_help("inspector"));
+    }
+
+    #[test]
+    fn curator_help_snapshot() {
+        insta::assert_snapshot!("cli_curator_help", command_help("curator"));
     }
 
     fn command_help(command_name: &str) -> String {

--- a/crates/vize/src/commands.rs
+++ b/crates/vize/src/commands.rs
@@ -3,6 +3,8 @@ pub mod check;
 #[cfg(unix)]
 pub mod check_server;
 pub mod clean;
+pub mod curator;
+pub mod env_info;
 #[cfg(feature = "glyph")]
 pub mod fmt;
 #[cfg(feature = "maestro")]

--- a/crates/vize/src/commands/curator.rs
+++ b/crates/vize/src/commands/curator.rs
@@ -1,0 +1,21 @@
+//! Curator command - diagnostics and reporting utilities.
+
+use clap::{Args, Subcommand};
+
+#[derive(Args)]
+pub struct CuratorArgs {
+    #[command(subcommand)]
+    pub command: CuratorCommands,
+}
+
+#[derive(Subcommand)]
+pub enum CuratorCommands {
+    /// Print environment information for bug reports
+    Env,
+}
+
+pub fn run(args: CuratorArgs) {
+    match args.command {
+        CuratorCommands::Env => crate::commands::env_info::run(),
+    }
+}

--- a/crates/vize/src/commands/env_info.rs
+++ b/crates/vize/src/commands/env_info.rs
@@ -1,0 +1,99 @@
+use std::process::Command;
+use vize_carton::{String, cstr};
+
+pub fn run() {
+    println!("{}", collect().join("\n"));
+}
+
+fn collect() -> Vec<String> {
+    vec![
+        cstr!("Vize: {}", env!("CARGO_PKG_VERSION")),
+        cstr!("OS: {}", os()),
+        cstr!("Architecture: {}", std::env::consts::ARCH),
+        cstr!("Node.js: {}", command_version("node", &["--version"])),
+        cstr!("Package manager: {}", package_manager()),
+        cstr!("Rust: {}", command_version("rustc", &["--version"])),
+    ]
+}
+
+fn os() -> String {
+    let os = std::env::consts::OS;
+    let version = match os {
+        "macos" => command_version("sw_vers", &["-productVersion"]),
+        "linux" => command_version("uname", &["-r"]),
+        "windows" => command_version("cmd", &["/C", "ver"]),
+        _ => "unknown".into(),
+    };
+
+    if version == "not found" || version == "unknown" {
+        os.into()
+    } else {
+        cstr!("{os} {version}")
+    }
+}
+
+fn package_manager() -> String {
+    if let Ok(user_agent) = std::env::var("npm_config_user_agent")
+        && !user_agent.trim().is_empty()
+    {
+        return user_agent.into();
+    }
+
+    let candidates = [
+        ("aube", ["--version"].as_slice()),
+        ("pnpm", ["--version"].as_slice()),
+        ("yarn", ["--version"].as_slice()),
+        ("npm", ["--version"].as_slice()),
+    ];
+
+    for (program, args) in candidates {
+        let version = command_version(program, args);
+        if version != "not found" && version != "unknown" {
+            return cstr!("{program} {version}");
+        }
+    }
+
+    "not found".into()
+}
+
+fn command_version(program: &str, args: &[&str]) -> String {
+    let Ok(output) = Command::new(program).args(args).output() else {
+        return "not found".into();
+    };
+
+    if !output.status.success() {
+        return "unknown".into();
+    }
+
+    let stdout = std::str::from_utf8(&output.stdout).unwrap_or("");
+    let stderr = std::str::from_utf8(&output.stderr).unwrap_or("");
+    let version = stdout
+        .lines()
+        .chain(stderr.lines())
+        .map(str::trim)
+        .find(|line| !line.is_empty());
+
+    version.unwrap_or("unknown").into()
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn collect_prints_bug_report_fields() {
+        let lines = super::collect();
+
+        for prefix in [
+            "Vize: ",
+            "OS: ",
+            "Architecture: ",
+            "Node.js: ",
+            "Package manager: ",
+            "Rust: ",
+        ] {
+            assert!(
+                lines.iter().any(|line| line.starts_with(prefix)),
+                "missing {prefix} in {lines:?}"
+            );
+        }
+    }
+}

--- a/crates/vize/src/snapshots/vize__cli__tests__cli_curator_help.snap
+++ b/crates/vize/src/snapshots/vize__cli__tests__cli_curator_help.snap
@@ -1,0 +1,15 @@
+---
+source: crates/vize/src/cli.rs
+expression: "command_help(\"curator\")"
+---
+Curator utilities for diagnostics and reports
+
+Usage: curator <COMMAND>
+
+Commands:
+  env   Print environment information for bug reports
+  help  Print this message or the help of the given subcommand(s)
+
+Options:
+  -h, --help
+          Print help

--- a/crates/vize/src/snapshots/vize__cli__tests__cli_long_help.snap
+++ b/crates/vize/src/snapshots/vize__cli__tests__cli_long_help.snap
@@ -12,6 +12,7 @@ Commands:
   lint          Lint Vue SFC files [aliases: patina]
   check         Type check Vue SFC files
   inspector     Create playground compiler inspector payloads and agent reports
+  curator       Curator utilities for diagnostics and reports
   clean         Remove Vize-generated cache artifacts
   check-server  Start type check JSON-RPC server (Unix only)
   musea         Start component gallery server

--- a/crates/vize/tests/env_info_cli.rs
+++ b/crates/vize/tests/env_info_cli.rs
@@ -1,0 +1,28 @@
+use std::process::Command;
+
+#[test]
+fn curator_env_outputs_bug_report_fields() {
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .args(["curator", "env"])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    for prefix in [
+        "Vize: ",
+        "OS: ",
+        "Architecture: ",
+        "Node.js: ",
+        "Package manager: ",
+        "Rust: ",
+    ] {
+        assert!(stdout.contains(prefix), "missing {prefix} in:\n{stdout}");
+    }
+}


### PR DESCRIPTION
## Summary
- add `vize curator env` for bug report environment output
- add focused CLI coverage for the nested curator command
- update root and curator help snapshots

## Validation
- `cargo test -p vize curator_env_outputs_bug_report_fields --test env_info_cli`
- `cargo test -p vize cli::tests`

Closes #1146