### PR TITLE
fix(vapor): wrap multiline component event handlers

### DIFF
--- a/crates/vize_atelier_vapor/src/generate/operations/component_props.rs
+++ b/crates/vize_atelier_vapor/src/generate/operations/component_props.rs
@@ -1,7 +1,10 @@
 use crate::ir::{CreateComponentIRNode, IRProp};
 use vize_carton::{String, ToCompactString, cstr};
 
-use super::{super::context::GenerateContext, events::is_inline_statement};
+use super::{
+    super::context::GenerateContext,
+    events::{is_inline_statement, is_inline_statement_block},
+};
 
 /// Generate props object string for a component
 pub(super) fn generate_component_props_str(
@@ -186,7 +189,9 @@ fn component_prop_getter_value(ctx: &GenerateContext, prop: &IRProp<'_>) -> Stri
         }
         let resolved = ctx.resolve_expression(first.content.as_str());
         if is_event {
-            if is_inline_statement(first.content.as_str()) {
+            if is_inline_statement_block(first.content.as_str()) {
+                cstr!("() => ($event => {{ {} }})", resolved)
+            } else if is_inline_statement(first.content.as_str()) {
                 cstr!("() => ($event => ({}))", resolved)
             } else {
                 cstr!("() => {}", resolved)

--- a/crates/vize_atelier_vapor/src/generate/operations/events.rs
+++ b/crates/vize_atelier_vapor/src/generate/operations/events.rs
@@ -131,7 +131,7 @@ pub(super) fn is_inline_statement(handler: &str) -> bool {
         || (handler.contains('=') && !handler.contains("==") && !handler.contains("=>"))
 }
 
-fn is_inline_statement_block(handler: &str) -> bool {
+pub(super) fn is_inline_statement_block(handler: &str) -> bool {
     let trimmed = handler.trim();
     !trimmed.contains("=>")
         && !trimmed.starts_with("function")

--- a/crates/vize_atelier_vapor/src/lib.rs
+++ b/crates/vize_atelier_vapor/src/lib.rs
@@ -421,6 +421,33 @@ mod tests {
     }
 
     #[test]
+    fn test_compile_component_multiline_event_handler_parses() {
+        let allocator = Bump::new();
+        let result = compile_vapor(
+            &allocator,
+            r#"
+            <AnotherComponent
+              @click.stop="
+                hoge();
+                hoge();
+              "
+            />
+            "#,
+            Default::default(),
+        );
+
+        assert!(
+            result.error_messages.is_empty(),
+            "Expected no errors: {:?}",
+            result.error_messages
+        );
+        assert_parses_as_module(&result.code);
+
+        let code = normalize_code(&result.code);
+        insta::assert_snapshot!(code.as_str());
+    }
+
+    #[test]
     fn test_compile_branch_component_under_existing_parent() {
         let allocator = Bump::new();
         let result = compile_vapor(

--- a/crates/vize_atelier_vapor/src/snapshots/vize_atelier_vapor__tests__compile_component_multiline_event_handler_parses.snap
+++ b/crates/vize_atelier_vapor/src/snapshots/vize_atelier_vapor__tests__compile_component_multiline_event_handler_parses.snap
@@ -1,0 +1,12 @@
+---
+source: crates/vize_atelier_vapor/src/lib.rs
+assertion_line: 447
+expression: code.as_str()
+---
+import { resolveComponent as _resolveComponent, createComponentWithFallback as _createComponentWithFallback } from 'vue';
+export function render(_ctx) {
+const _component_AnotherComponent = _resolveComponent("AnotherComponent")
+const n0 = _createComponentWithFallback(_component_AnotherComponent, { onClick: () => ($event => { _ctx.hoge();
+_ctx.hoge(); }) }, null, true)
+return n0
+}

--- a/tests/expected/vapor/component.snap
+++ b/tests/expected/vapor/component.snap
@@ -55,6 +55,26 @@ export function render(_ctx) {
 }
 
 ===
+name: component with multi-line event handler
+options: vapor
+--- INPUT ---
+<MyComponent
+  @click.stop="
+    hoge();
+    hoge();
+  "
+/>
+--- OUTPUT ---
+import { resolveComponent as _resolveComponent, createComponentWithFallback as _createComponentWithFallback } from 'vue';
+
+export function render(_ctx) {
+  const _component_MyComponent = _resolveComponent("MyComponent")
+  const n0 = _createComponentWithFallback(_component_MyComponent, { onClick: () => ($event => { _ctx.hoge();
+_ctx.hoge(); }) }, null, true)
+  return n0
+}
+
+===
 name: component merges static and dynamic class
 options: vapor
 --- INPUT ---

--- a/tests/fixtures/vapor/component.pkl
+++ b/tests/fixtures/vapor/component.pkl
@@ -22,6 +22,17 @@ cases {
     input = #"<MyComponent @update="onUpdate" />"#
   }
   new {
+    name = "component with multi-line event handler"
+    input = """
+    <MyComponent
+      @click.stop="
+        hoge();
+        hoge();
+      "
+    />
+    """
+  }
+  new {
     name = "component merges static and dynamic class"
     input = #"<MyComponent class="a" :class="cls" />"#
   }


### PR DESCRIPTION
## Summary
- treat Component event props with semicolon/newline handlers as inline blocks
- wrap multi-line Component handlers in a returned arrow function so generated Vapor code is valid JS
- add unit and fixture coverage for the reproduction

## Validation
- `cargo test -p vize_atelier_vapor test_compile_component_multiline_event_handler_parses`
- `cargo test -p vize_test_runner vapor_component -- --ignored`

Closes #1147

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1152"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783523952&installation_id=136613492&pr_number=1152&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1152&signature=ad5a758ae34ba3f1603a9d92519b992b8e24a55556b8e260ec958445e6fe1590"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->