### PR TITLE
feat(playground): add vapor inspector target

### DIFF
--- a/crates/vize/src/commands/inspector.rs
+++ b/crates/vize/src/commands/inspector.rs
@@ -44,6 +44,8 @@ pub enum InspectorTarget {
     Dom,
     /// Compare SSR compiler output
     Ssr,
+    /// Compare Vapor compiler output
+    Vapor,
 }
 
 impl From<InspectorTarget> for curator_inspector::InspectorTarget {
@@ -51,6 +53,7 @@ impl From<InspectorTarget> for curator_inspector::InspectorTarget {
         match target {
             InspectorTarget::Dom => Self::Dom,
             InspectorTarget::Ssr => Self::Ssr,
+            InspectorTarget::Vapor => Self::Vapor,
         }
     }
 }
@@ -60,6 +63,7 @@ impl InspectorTarget {
         match self {
             Self::Dom => "dom",
             Self::Ssr => "ssr",
+            Self::Vapor => "vapor",
         }
     }
 }
@@ -415,6 +419,8 @@ fn compile_vize_for_compare(
 
     let has_scoped = descriptor.styles.iter().any(|style| style.scoped);
     let is_ts = descriptor_uses_type_script(&descriptor);
+    let is_ssr = matches!(args.target, InspectorTarget::Ssr);
+    let is_vapor = matches!(args.target, InspectorTarget::Vapor);
     let compile_options = SfcCompileOptions {
         parse: SfcParseOptions {
             filename: filename.clone(),
@@ -428,7 +434,7 @@ fn compile_vize_for_compare(
         template: TemplateCompileOptions {
             id: Some(filename.clone()),
             scoped: has_scoped,
-            ssr: matches!(args.target, InspectorTarget::Ssr),
+            ssr: is_ssr,
             is_prod: true,
             is_ts,
             custom_renderer: args.custom_renderer,
@@ -439,6 +445,7 @@ fn compile_vize_for_compare(
             scoped: has_scoped,
             ..Default::default()
         },
+        vapor: is_vapor,
         ..Default::default()
     };
 
@@ -667,6 +674,7 @@ async function formatCode(source, parser, formatter) {
 async function compileOfficialVue(file, target, compiler, formatter) {
   const start = performance.now();
   try {
+    const officialTarget = target === "ssr" ? "ssr" : "dom";
     const parsed = compiler.parse(file.source, { filename: file.path });
     const descriptor = parsed.descriptor;
     const isTypeScript = descriptorUsesTypeScript(descriptor);
@@ -676,7 +684,7 @@ async function compileOfficialVue(file, target, compiler, formatter) {
     let scriptCode = "";
     const scoped = descriptor.styles.some((style) => style.scoped);
     const inlineTemplate = Boolean(
-      descriptor.scriptSetup && descriptor.template && target === "dom",
+      descriptor.scriptSetup && descriptor.template && officialTarget === "dom",
     );
 
     if (descriptor.script || descriptor.scriptSetup) {
@@ -708,7 +716,7 @@ async function compileOfficialVue(file, target, compiler, formatter) {
         id: file.path,
         scoped,
         isProd: true,
-        ssr: target === "ssr",
+        ssr: officialTarget === "ssr",
         compilerOptions: {
           bindingMetadata,
           expressionPlugins: isTypeScript ? ["typescript"] : undefined,

--- a/crates/vize/src/snapshots/vize__cli__tests__cli_inspector_help.snap
+++ b/crates/vize/src/snapshots/vize__cli__tests__cli_inspector_help.snap
@@ -33,8 +33,9 @@ Options:
           Compiler target to compare
 
           Possible values:
-          - dom: Compare DOM compiler output
-          - ssr: Compare SSR compiler output
+          - dom:   Compare DOM compiler output
+          - ssr:   Compare SSR compiler output
+          - vapor: Compare Vapor compiler output
 
           [default: dom]
 

--- a/crates/vize/tests/inspector_cli.rs
+++ b/crates/vize/tests/inspector_cli.rs
@@ -104,6 +104,42 @@ fn inspector_url_supports_batch_payloads() {
 }
 
 #[test]
+fn inspector_json_supports_vapor_target_payloads() {
+    let project = tempfile::tempdir().unwrap();
+    let src = project.path().join("src");
+    fs::create_dir_all(&src).unwrap();
+    fs::write(
+        src.join("App.vue"),
+        "<template><div>vapor</div></template>\n",
+    )
+    .unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(project.path())
+        .args([
+            "inspector",
+            "src/App.vue",
+            "--format",
+            "json",
+            "--target",
+            "vapor",
+        ])
+        .output()
+        .unwrap();
+
+    let stdout = std::string::String::from_utf8(output.stdout).unwrap();
+    let stderr = std::string::String::from_utf8(output.stderr).unwrap();
+    assert!(
+        output.status.success(),
+        "stdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+
+    let json: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(json["target"], "vapor");
+    assert_eq!(json["selectedFile"], "src/App.vue");
+}
+
+#[test]
 fn inspector_default_glob_respects_gitignore() {
     let project = tempfile::tempdir().unwrap();
     let src = project.path().join("src");

--- a/crates/vize_curator/src/inspector.rs
+++ b/crates/vize_curator/src/inspector.rs
@@ -8,6 +8,7 @@ use vize_carton::{String, ToCompactString};
 pub enum InspectorTarget {
     Dom,
     Ssr,
+    Vapor,
 }
 
 impl InspectorTarget {
@@ -15,6 +16,7 @@ impl InspectorTarget {
         match self {
             Self::Dom => "dom",
             Self::Ssr => "ssr",
+            Self::Vapor => "vapor",
         }
     }
 }
@@ -816,6 +818,24 @@ mod tests {
             build_playground_url("https://vizejs.dev/play/?foo=bar#old", json.as_str()).as_str(),
             "https://vizejs.dev/play/?foo=bar&tab=inspector#inspector=%7B%22version%22%3A1%2C%22target%22%3A%22dom%22%2C%22selectedFile%22%3A%22src%2FApp.vue%22%2C%22options%22%3A%7B%22customRenderer%22%3Afalse%2C%22templateSyntax%22%3A%22quirks%22%7D%2C%22files%22%3A%5B%7B%22path%22%3A%22src%2FApp.vue%22%2C%22source%22%3A%22%3Ctemplate%3E%3Cdiv%3Emsg%3C%2Fdiv%3E%3C%2Ftemplate%3E%22%7D%5D%7D"
         );
+    }
+
+    #[test]
+    fn builds_vapor_inspector_payload_json() {
+        let payload = build_payload(
+            InspectorTarget::Vapor,
+            InspectorOptions {
+                custom_renderer: false,
+                template_syntax: InspectorTemplateSyntax::Standard,
+            },
+            vec![InspectorSourceFile {
+                path: cstr!("src/App.vue"),
+                source: cstr!("<template><div>msg</div></template>"),
+            }],
+        );
+        let json = serialize_payload(&payload).expect("payload serializes");
+
+        assert!(json.contains(r#""target":"vapor""#));
     }
 
     #[test]

--- a/playground/src/features/inspector/InspectorPlayground.vue
+++ b/playground/src/features/inspector/InspectorPlayground.vue
@@ -55,6 +55,7 @@ const activeOutputTab = ref<
 const diffViewMode = ref<"merged" | "split">("merged");
 const highlightedDiffLines = ref<HighlightedDiffLine[]>([]);
 let latestDiffHighlightId = 0;
+const inspectorTargets = ["dom", "ssr", "vapor"] as const satisfies readonly InspectorTarget[];
 
 const selectedFile = computed(() => files.value[selectedFileIndex.value] ?? files.value[0]!);
 const source = computed({
@@ -136,12 +137,16 @@ function graphEdgesFor(path: string): InspectorGraphEdge[] {
   return graphEdgesBySource.value[path] ?? [];
 }
 
+function normalizeInspectorTarget(value: unknown): InspectorTarget {
+  return inspectorTargets.includes(value as InspectorTarget) ? (value as InspectorTarget) : "dom";
+}
+
 function applyPayload(nextPayload: InspectorPayload) {
   files.value = nextPayload.files.map((file, index) => ({
     path: file.path || `repro-${index + 1}.vue`,
     source: file.source,
   }));
-  target.value = nextPayload.target === "ssr" ? "ssr" : "dom";
+  target.value = normalizeInspectorTarget(nextPayload.target);
   options.value = {
     customRenderer: nextPayload.options?.customRenderer ?? false,
     templateSyntax: nextPayload.options?.templateSyntax ?? "standard",
@@ -315,6 +320,12 @@ onUnmounted(() => {
             @click="target = 'ssr'"
           >
             SSR
+          </button>
+          <button
+            :class="['inspector-target', { active: target === 'vapor' }]"
+            @click="target = 'vapor'"
+          >
+            Vapor
           </button>
         </div>
         <label class="inspector-option">

--- a/playground/src/features/inspector/compareCompilers.test.ts
+++ b/playground/src/features/inspector/compareCompilers.test.ts
@@ -193,6 +193,24 @@ describe("compileInspectorReport", () => {
       },
     ]);
     expect(buildInspectorDiff).toHaveBeenCalled();
+
+    compileSfc.mockClear();
+    await compileInspectorReport({
+      compiler,
+      file: {
+        path: "src/App.vue",
+        source: "<template><div>{{ msg }}</div></template>",
+      },
+      target: "vapor",
+    });
+
+    expect(compileSfc).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        ssr: false,
+        outputMode: "vapor",
+      }),
+    );
   });
 
   it("compares script setup DOM output with Vue's inline production render shape", async () => {

--- a/playground/src/features/inspector/compareCompilers.ts
+++ b/playground/src/features/inspector/compareCompilers.ts
@@ -46,6 +46,10 @@ function descriptorUsesTypeScript(descriptor: SFCDescriptor): boolean {
   return langs.some((lang) => lang === "ts" || lang === "tsx");
 }
 
+function officialTargetFor(target: InspectorTarget): "dom" | "ssr" {
+  return target === "ssr" ? "ssr" : "dom";
+}
+
 function outputText(run: CompilerRun): string {
   return run.error ?? run.formattedCode ?? run.code;
 }
@@ -72,6 +76,7 @@ async function compileOfficialVue(
   const start = performance.now();
 
   try {
+    const officialTarget = officialTargetFor(target);
     const parsed = parse(file.source, { filename: file.path });
     const descriptor = parsed.descriptor;
     const isTypeScript = descriptorUsesTypeScript(descriptor);
@@ -81,7 +86,7 @@ async function compileOfficialVue(
     let scriptCode = "";
     const scoped = descriptor.styles.some((style) => style.scoped);
     const inlineTemplate = Boolean(
-      descriptor.scriptSetup && descriptor.template && target === "dom",
+      descriptor.scriptSetup && descriptor.template && officialTarget === "dom",
     );
 
     if (descriptor.script || descriptor.scriptSetup) {
@@ -113,7 +118,7 @@ async function compileOfficialVue(
         id: file.path,
         scoped,
         isProd: true,
-        ssr: target === "ssr",
+        ssr: officialTarget === "ssr",
         compilerOptions: {
           bindingMetadata,
           expressionPlugins: isTypeScript ? ["typescript"] : undefined,
@@ -162,12 +167,15 @@ async function compileVize(
       filename: file.path,
       ssr: target === "ssr",
       scriptExt: "preserve",
-      outputMode: "vdom",
+      outputMode: target === "vapor" ? "vapor" : "vdom",
       customRenderer: options.customRenderer,
       templateSyntax: options.templateSyntax,
     };
     const result = compiler.compileSfc(file.source, compileOptions);
-    const code = result.script?.code || result.template?.code || "";
+    const code =
+      target === "vapor"
+        ? result.template?.code || result.script?.code || ""
+        : result.script?.code || result.template?.code || "";
     const parser = descriptorUsesTypeScript(result.descriptor as SFCDescriptor)
       ? "typescript"
       : "babel";

--- a/playground/src/features/inspector/share.test.ts
+++ b/playground/src/features/inspector/share.test.ts
@@ -66,4 +66,18 @@ Playground permalink: https://vizejs.dev/play/?tab=inspector#inspector=abc
 
 Generated from the Vize playground compiler inspector. Please add the minimized fixture or full snapshot that explains the parity change.`);
   });
+
+  it("labels vapor PR bodies", () => {
+    const body = createPullRequestBody({
+      permalink: "https://vizejs.dev/play/?tab=inspector#inspector=abc",
+      payload: { ...payload, target: "vapor" },
+      stats: {
+        additions: 0,
+        removals: 0,
+        unchanged: 1,
+      },
+    });
+
+    expect(body).toContain("- Target: Vapor");
+  });
 });

--- a/playground/src/features/inspector/share.ts
+++ b/playground/src/features/inspector/share.ts
@@ -47,7 +47,7 @@ export function createPullRequestBody({
   stats: DiffStats;
 }): string {
   const files = payload.files.map((file) => `- \`${file.path}\``).join("\n");
-  const target = payload.target === "ssr" ? "SSR" : "DOM";
+  const target = payload.target === "ssr" ? "SSR" : payload.target === "vapor" ? "Vapor" : "DOM";
 
   return [
     "## Compiler inspector",

--- a/playground/src/features/inspector/types.ts
+++ b/playground/src/features/inspector/types.ts
@@ -1,6 +1,6 @@
 import type { CrossFileDiagnostic, CrossFileStats } from "../../wasm/index";
 
-export type InspectorTarget = "dom" | "ssr";
+export type InspectorTarget = "dom" | "ssr" | "vapor";
 
 export interface InspectorOptions {
   customRenderer: boolean;


### PR DESCRIPTION
## Summary
- add `vapor` as an Inspector target in CLI payloads and curator helpers
- preserve Vapor target in playground Inspector permalinks and PR bodies
- compile Vize Inspector output with `outputMode: "vapor"` while keeping Vue output as the DOM baseline

## Validation
- `cargo test -p vize inspector_json_supports_vapor_target_payloads --test inspector_cli`
- `cargo test -p vize cli::tests::inspector_help_snapshot`
- `cargo test -p vize_curator inspector::tests::builds_vapor_inspector_payload_json`
- `CI=1 pnpm --dir playground exec vp test run --config vite.test.config.ts src/features/inspector/compareCompilers.test.ts src/features/inspector/share.test.ts`
- `ROOT="$(pwd -P)" pnpm --dir playground exec vp check src/features/inspector/InspectorPlayground.vue src/features/inspector/compareCompilers.ts src/features/inspector/share.ts src/features/inspector/types.ts`

Closes #1148

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1154"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783526011&installation_id=136613492&pr_number=1154&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1154&signature=71328a61e9180047b994220ff564300f10dbea0b3d758bcf579682a10e7e229e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->