### PR TITLE
fix(cli): load package global components

### DIFF
--- a/crates/vize/src/commands/check/dts.rs
+++ b/crates/vize/src/commands/check/dts.rs
@@ -49,6 +49,31 @@ pub(super) fn parse_interface_members_with_rewritten_imports(
         .collect())
 }
 
+pub(super) fn parse_global_component_members_with_rewritten_imports(
+    path: &Path,
+) -> Result<Vec<(String, String)>, std::io::Error> {
+    let content = match profile!("cli.check.dts.read", fs::read_to_string(path)) {
+        Ok(content) => {
+            global_profiler().record_fs_read_to_string(content.len());
+            content
+        }
+        Err(error) => {
+            global_profiler().record_fs_read_to_string_failure();
+            return Err(error);
+        }
+    };
+    let source_dir = path.parent().unwrap_or_else(|| Path::new("."));
+    Ok(parse_global_component_members_content(&content)
+        .into_iter()
+        .map(|(name, type_annotation)| {
+            (
+                name,
+                normalize_rewritten_type(type_annotation.as_str(), source_dir),
+            )
+        })
+        .collect())
+}
+
 pub(super) fn parse_interface_members_content(
     content: &str,
     interface_name: &str,
@@ -64,8 +89,12 @@ pub(super) fn parse_interface_members_content(
 
         if !in_interface {
             if trimmed.contains(interface_name) {
+                let delta = brace_delta(trimmed);
+                if delta <= 0 && trimmed.contains('{') {
+                    continue;
+                }
                 in_interface = true;
-                brace_depth += brace_delta(trimmed);
+                brace_depth = delta;
             }
             continue;
         }
@@ -100,6 +129,82 @@ pub(super) fn parse_interface_members_content(
 
     flush_pending_member(&mut members, &mut current_name, &mut current_type);
     members
+}
+
+fn parse_global_component_members_content(content: &str) -> Vec<(String, String)> {
+    let mut members = parse_interface_members_content(content, "interface GlobalComponents");
+
+    for extended in extended_interface_names(content, "GlobalComponents") {
+        let interface_name = format!("interface {extended}");
+        for member in parse_interface_members_content(content, &interface_name) {
+            if !members
+                .iter()
+                .any(|(name, _)| name.as_str() == member.0.as_str())
+            {
+                members.push(member);
+            }
+        }
+    }
+
+    members
+}
+
+fn extended_interface_names(content: &str, interface_name: &str) -> Vec<String> {
+    let needle = format!("interface {interface_name}");
+    let mut names = Vec::new();
+
+    for line in content.lines() {
+        let trimmed = line.trim();
+        let Some(index) = trimmed.find(&needle) else {
+            continue;
+        };
+        if !interface_needle_has_boundary(trimmed, index, needle.len()) {
+            continue;
+        }
+
+        let after_name = &trimmed[index + needle.len()..];
+        let Some((_, after_extends)) = after_name.split_once("extends") else {
+            continue;
+        };
+        let extends_clause = after_extends.split('{').next().unwrap_or(after_extends);
+        for raw_name in extends_clause.split(',') {
+            let name = raw_name
+                .trim()
+                .split(|ch: char| ch.is_whitespace() || ch == '<')
+                .next()
+                .unwrap_or_default()
+                .trim();
+            if is_interface_reference_name(name) && !names.iter().any(|existing| existing == name) {
+                names.push(name.to_compact_string());
+            }
+        }
+    }
+
+    names
+}
+
+fn interface_needle_has_boundary(line: &str, index: usize, needle_len: usize) -> bool {
+    let before = line[..index]
+        .chars()
+        .next_back()
+        .is_none_or(|ch| !is_identifier_char(ch));
+    let after = line[index + needle_len..]
+        .chars()
+        .next()
+        .is_none_or(|ch| !is_identifier_char(ch));
+    before && after
+}
+
+fn is_interface_reference_name(name: &str) -> bool {
+    let mut chars = name.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    (first == '_' || first == '$' || first.is_ascii_alphabetic()) && chars.all(is_identifier_char)
+}
+
+fn is_identifier_char(ch: char) -> bool {
+    ch == '_' || ch == '$' || ch.is_ascii_alphanumeric()
 }
 
 pub(super) fn parse_declared_global_values(
@@ -401,7 +506,10 @@ fn normalize_path(path: &Path) -> String {
 mod tests {
     use std::path::Path;
 
-    use super::{parse_declared_global_values_content, parse_interface_members_content};
+    use super::{
+        parse_declared_global_values_content, parse_global_component_members_content,
+        parse_interface_members_content,
+    };
 
     #[test]
     fn parses_interface_members_with_multiline_types() {
@@ -444,6 +552,35 @@ declare module 'vue' {
         assert_eq!(members[0].1.as_str(), "typeof import('./config').config");
         assert_eq!(members[1].0.as_str(), "quoted-key");
         assert_eq!(members[1].1.as_str(), "string");
+    }
+
+    #[test]
+    fn parses_global_components_from_extended_interface() {
+        let content = r#"
+interface _GlobalComponents {
+  GlobalButton: GlobalComponentConstructor<GlobalButtonProps>
+  GlobalInput:
+    GlobalComponentConstructor<GlobalInputProps>
+}
+
+declare module "vue" {
+  interface GlobalComponents extends _GlobalComponents {}
+}
+"#;
+
+        let members = parse_global_component_members_content(content);
+
+        assert_eq!(members.len(), 2);
+        assert_eq!(members[0].0.as_str(), "GlobalButton");
+        assert_eq!(
+            members[0].1.as_str(),
+            "GlobalComponentConstructor<GlobalButtonProps>"
+        );
+        assert_eq!(members[1].0.as_str(), "GlobalInput");
+        assert_eq!(
+            members[1].1.as_str(),
+            "GlobalComponentConstructor<GlobalInputProps>"
+        );
     }
 
     #[test]

--- a/crates/vize/src/commands/check/runner.rs
+++ b/crates/vize/src/commands/check/runner.rs
@@ -210,7 +210,12 @@ pub(crate) fn run_direct(args: &CheckArgs) {
 
     let mut virtual_ts_options = build_virtual_ts_options(&config, config_dir);
     let nuxt_path_aliases = nuxt::detect_nuxt_auto_imports(&mut virtual_ts_options, &project_root);
-    collect_project_global_component_stubs(&mut virtual_ts_options, &files, &project_root);
+    collect_project_global_component_stubs(
+        &mut virtual_ts_options,
+        &files,
+        &project_root,
+        program_tsconfig_path.as_deref(),
+    );
     let checker_tsconfig_path = match resolve_checker_tsconfig_path(
         program_tsconfig_path.as_deref(),
         &project_root,
@@ -984,6 +989,7 @@ fn collect_project_global_component_stubs(
     options: &mut vize_canon::virtual_ts::VirtualTsOptions,
     files: &[PathBuf],
     project_root: &Path,
+    tsconfig_path: Option<&Path>,
 ) {
     let mut seen_names = options
         .auto_import_stubs
@@ -997,15 +1003,31 @@ fn collect_project_global_component_stubs(
         .cloned()
         .collect::<FxHashSet<_>>();
     let mut collected = Vec::new();
+    let mut package_reference_stubs = Vec::new();
+    let mut seen_package_references = FxHashSet::default();
 
-    for path in files {
-        if !is_declaration_path(path) {
-            continue;
+    let mut declaration_sources = files
+        .iter()
+        .filter(|path| is_declaration_path(path))
+        .map(|path| GlobalComponentDeclarationSource {
+            path: path.clone(),
+            type_package: None,
+        })
+        .collect::<Vec<_>>();
+
+    for package in collect_global_component_type_packages(files, tsconfig_path) {
+        for path in resolve_type_package_declaration_files(project_root, package.as_str()) {
+            declaration_sources.push(GlobalComponentDeclarationSource {
+                path,
+                type_package: Some(package.clone()),
+            });
         }
-        let Ok(components) = super::dts::parse_interface_members_with_rewritten_imports(
-            path,
-            "interface GlobalComponents",
-        ) else {
+    }
+
+    for source in declaration_sources {
+        let Ok(components) =
+            super::dts::parse_global_component_members_with_rewritten_imports(&source.path)
+        else {
             continue;
         };
 
@@ -1018,15 +1040,32 @@ fn collect_project_global_component_stubs(
                 continue;
             }
 
-            let type_annotation = rewrite_global_component_imports_for_virtual_project(
-                type_annotation.as_str(),
-                project_root,
-            );
-            collected.push(cstr!("declare const {name}: {type_annotation};"));
+            if let Some(package) = source.type_package.as_deref() {
+                if seen_package_references.insert(String::from(package)) {
+                    package_reference_stubs.push(cstr!("/// <reference types=\"{package}\" />"));
+                }
+                collected.push(cstr!(
+                    "declare const {name}: import(\"vue\").GlobalComponents[\"{name}\"];"
+                ));
+            } else {
+                let type_annotation = rewrite_global_component_imports_for_virtual_project(
+                    type_annotation.as_str(),
+                    project_root,
+                );
+                collected.push(cstr!("declare const {name}: {type_annotation};"));
+            }
         }
     }
 
-    if !collected.is_empty() {
+    if !package_reference_stubs.is_empty() {
+        let mut stubs = Vec::with_capacity(
+            package_reference_stubs.len() + options.auto_import_stubs.len() + collected.len(),
+        );
+        stubs.extend(package_reference_stubs);
+        stubs.append(&mut options.auto_import_stubs);
+        stubs.extend(collected);
+        options.auto_import_stubs = stubs;
+    } else if !collected.is_empty() {
         options.auto_import_stubs.extend(collected);
     }
     let mut external_template_bindings = external_template_bindings.into_iter().collect::<Vec<_>>();
@@ -1034,10 +1073,280 @@ fn collect_project_global_component_stubs(
     options.external_template_bindings = external_template_bindings;
 }
 
+struct GlobalComponentDeclarationSource {
+    path: PathBuf,
+    type_package: Option<String>,
+}
+
 fn is_declaration_path(path: &Path) -> bool {
     path.file_name()
         .and_then(|name| name.to_str())
         .is_some_and(|name| name.ends_with(".d.ts"))
+}
+
+fn collect_global_component_type_packages(
+    files: &[PathBuf],
+    tsconfig_path: Option<&Path>,
+) -> Vec<String> {
+    let mut packages = Vec::new();
+    let mut seen = FxHashSet::default();
+
+    for package in collect_tsconfig_type_packages(tsconfig_path) {
+        push_unique_type_package(&mut packages, &mut seen, package);
+    }
+
+    for path in files {
+        let Ok(content) = fs::read_to_string(path) else {
+            continue;
+        };
+        for package in reference_type_packages(&content) {
+            push_unique_type_package(&mut packages, &mut seen, package);
+        }
+    }
+
+    packages
+}
+
+fn push_unique_type_package(
+    packages: &mut Vec<String>,
+    seen: &mut FxHashSet<String>,
+    package: String,
+) {
+    if seen.insert(package.clone()) {
+        packages.push(package);
+    }
+}
+
+fn collect_tsconfig_type_packages(tsconfig_path: Option<&Path>) -> Vec<String> {
+    let Some(tsconfig_path) = tsconfig_path else {
+        return Vec::new();
+    };
+
+    let mut seen = FxHashSet::default();
+    load_tsconfig_type_packages(tsconfig_path, &mut seen).unwrap_or_default()
+}
+
+fn load_tsconfig_type_packages(
+    tsconfig_path: &Path,
+    seen: &mut FxHashSet<PathBuf>,
+) -> Option<Vec<String>> {
+    let resolved = tsconfig_path
+        .canonicalize()
+        .unwrap_or_else(|_| tsconfig_path.to_path_buf());
+    if !seen.insert(resolved.clone()) {
+        return None;
+    }
+
+    let content = fs::read_to_string(&resolved).ok()?;
+    let value = parse_jsonc_value(&content).ok()?;
+
+    let mut inherited = Vec::new();
+    for extends in read_extends_entries(&value) {
+        let Some(extends_path) = resolve_extended_tsconfig(&resolved, &extends) else {
+            continue;
+        };
+        if let Some(parent_types) = load_tsconfig_type_packages(&extends_path, seen) {
+            inherited.extend(parent_types);
+        }
+    }
+
+    if let Some(types) = value
+        .get("compilerOptions")
+        .and_then(Value::as_object)
+        .and_then(|compiler_options| compiler_options.get("types"))
+        .and_then(Value::as_array)
+    {
+        return Some(
+            types
+                .iter()
+                .filter_map(Value::as_str)
+                .map(String::from)
+                .collect(),
+        );
+    }
+
+    (!inherited.is_empty()).then_some(inherited)
+}
+
+fn reference_type_packages(content: &str) -> Vec<String> {
+    content
+        .lines()
+        .filter_map(reference_types_attribute)
+        .map(String::from)
+        .collect()
+}
+
+fn reference_types_attribute(line: &str) -> Option<&str> {
+    let line = line.trim_start();
+    if !line.starts_with("///") || !line.contains("<reference") {
+        return None;
+    }
+    attribute_value(line, "types")
+}
+
+fn reference_path_attribute(line: &str) -> Option<&str> {
+    let line = line.trim_start();
+    if !line.starts_with("///") || !line.contains("<reference") {
+        return None;
+    }
+    attribute_value(line, "path")
+}
+
+fn attribute_value<'a>(line: &'a str, name: &str) -> Option<&'a str> {
+    let needle = cstr!("{name}=");
+    let start = line.find(needle.as_str())? + needle.len();
+    let quote = line[start..].chars().next()?;
+    if quote != '"' && quote != '\'' {
+        return None;
+    }
+    let value_start = start + quote.len_utf8();
+    let value_end = line[value_start..].find(quote)? + value_start;
+    line.get(value_start..value_end)
+}
+
+fn resolve_type_package_declaration_files(project_root: &Path, package: &str) -> Vec<PathBuf> {
+    let Some(package_root) = resolve_type_package_root(project_root, package) else {
+        return Vec::new();
+    };
+
+    for entry in package_declaration_entry_candidates(&package_root) {
+        if is_declaration_path(&entry) && entry.is_file() {
+            return collect_package_declaration_graph(&entry, &package_root);
+        }
+    }
+
+    Vec::new()
+}
+
+fn resolve_type_package_root(project_root: &Path, package: &str) -> Option<PathBuf> {
+    let mut current = Some(project_root);
+    while let Some(dir) = current {
+        let node_modules = dir.join("node_modules");
+        let direct = node_modules.join(package);
+        if direct.is_dir() {
+            return Some(direct);
+        }
+
+        if let Some(types_package) = fallback_types_package_name(package) {
+            let fallback = node_modules.join(types_package);
+            if fallback.is_dir() {
+                return Some(fallback);
+            }
+        }
+
+        current = dir.parent();
+    }
+
+    None
+}
+
+fn fallback_types_package_name(package: &str) -> Option<String> {
+    if package.starts_with("@types/") {
+        return None;
+    }
+    if let Some(scoped) = package.strip_prefix('@') {
+        let mut parts = scoped.split('/');
+        let scope = parts.next()?;
+        let name = parts.next()?;
+        return Some(cstr!("@types/{scope}__{name}"));
+    }
+    Some(cstr!("@types/{package}"))
+}
+
+fn package_declaration_entry_candidates(package_root: &Path) -> Vec<PathBuf> {
+    let mut candidates = Vec::new();
+    let package_json_path = package_root.join("package.json");
+    if let Ok(content) = fs::read_to_string(&package_json_path)
+        && let Ok(package_json) = parse_jsonc_value(&content)
+    {
+        for field in ["types", "typings"] {
+            if let Some(types) = package_json.get(field).and_then(Value::as_str) {
+                push_declaration_entry_candidate(&mut candidates, package_root.join(types));
+            }
+        }
+
+        if let Some(exports) = package_json.get("exports") {
+            let root_export = exports.get(".").unwrap_or(exports);
+            collect_export_type_entries(root_export, package_root, &mut candidates);
+        }
+    }
+
+    push_declaration_entry_candidate(&mut candidates, package_root.join("index.d.ts"));
+    candidates
+}
+
+fn collect_export_type_entries(value: &Value, package_root: &Path, candidates: &mut Vec<PathBuf>) {
+    match value {
+        Value::String(path) => {
+            push_declaration_entry_candidate(candidates, package_root.join(path))
+        }
+        Value::Array(values) => {
+            for value in values {
+                collect_export_type_entries(value, package_root, candidates);
+            }
+        }
+        Value::Object(map) => {
+            if let Some(types) = map.get("types").and_then(Value::as_str) {
+                push_declaration_entry_candidate(candidates, package_root.join(types));
+            }
+            for value in map.values() {
+                collect_export_type_entries(value, package_root, candidates);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn push_declaration_entry_candidate(candidates: &mut Vec<PathBuf>, path: PathBuf) {
+    if !candidates.contains(&path) {
+        candidates.push(path.clone());
+    }
+    if path.extension().is_none() {
+        let with_extension = path.with_extension("d.ts");
+        if !candidates.contains(&with_extension) {
+            candidates.push(with_extension);
+        }
+    }
+    let index = path.join("index.d.ts");
+    if !candidates.contains(&index) {
+        candidates.push(index);
+    }
+}
+
+fn collect_package_declaration_graph(entry: &Path, package_root: &Path) -> Vec<PathBuf> {
+    let package_root = package_root
+        .canonicalize()
+        .unwrap_or_else(|_| package_root.to_path_buf());
+    let mut files = Vec::new();
+    let mut seen = FxHashSet::default();
+    let mut queue = vec![entry.to_path_buf()];
+
+    while let Some(path) = queue.pop() {
+        let path = path.canonicalize().unwrap_or(path);
+        if !seen.insert(path.clone()) {
+            continue;
+        }
+        files.push(path.clone());
+
+        let Ok(content) = fs::read_to_string(&path) else {
+            continue;
+        };
+        let Some(base_dir) = path.parent() else {
+            continue;
+        };
+        for reference in content.lines().filter_map(reference_path_attribute) {
+            let referenced = base_dir.join(reference);
+            let referenced = referenced.canonicalize().unwrap_or(referenced);
+            if referenced.starts_with(&package_root)
+                && is_declaration_path(&referenced)
+                && referenced.is_file()
+            {
+                queue.push(referenced);
+            }
+        }
+    }
+
+    files
 }
 
 fn declared_stub_name(stub: &str) -> Option<&str> {
@@ -1416,6 +1725,7 @@ export {};
             &mut options,
             std::slice::from_ref(&dts_path),
             &project_root,
+            None,
         );
 
         assert_eq!(options.external_template_bindings, ["GlobalComponent"]);

--- a/crates/vize/tests/check_cli.rs
+++ b/crates/vize/tests/check_cli.rs
@@ -2334,6 +2334,115 @@ export {};
 }
 
 #[test]
+fn check_node_modules_global_components_are_typed_from_reference_types() {
+    let Some(corsa_path) = resolve_test_corsa_path() else {
+        return;
+    };
+    let project_root = create_cli_project(
+        "global-components-node-modules-types",
+        &[(
+            "src/UserComponent.vue",
+            r#"<template>
+  <QBtn :disable="'string'" />
+  <QBtn @click="clickHandler" />
+</template>
+
+<script setup lang="ts">
+/// <reference types="quasar" />
+
+function clickHandler(event: Event) {
+  console.log(event)
+}
+</script>
+"#,
+        )],
+    );
+    let quasar_dir = project_root.join("node_modules/quasar");
+    std::fs::create_dir_all(quasar_dir.join("dist/types")).unwrap();
+    std::fs::write(
+        quasar_dir.join("package.json"),
+        r#"{
+  "name": "quasar",
+  "version": "0.0.0-test",
+  "typings": "dist/types/index.d.ts"
+}
+"#,
+    )
+    .unwrap();
+    std::fs::write(
+        quasar_dir.join("dist/types/index.d.ts"),
+        r#"export interface QBtnProps {
+  disable?: boolean | undefined;
+  onClick?: (event: Event) => void;
+}
+
+export type GlobalComponentConstructor<Props> = {
+  new (): { $props: Props };
+};
+
+interface _GlobalComponents {
+  QBtn: GlobalComponentConstructor<QBtnProps>;
+}
+
+declare module "vue" {
+  interface GlobalComponents extends _GlobalComponents {}
+}
+
+export const QBtn: GlobalComponentConstructor<QBtnProps>;
+"#,
+    )
+    .unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(&project_root)
+        .env("CORSA_PATH", corsa_path)
+        .args([
+            "check",
+            "src/UserComponent.vue",
+            "--tsconfig",
+            "tsconfig.json",
+            "--format",
+            "json",
+            "--no-config",
+        ])
+        .output()
+        .unwrap();
+
+    let stdout = std::string::String::from_utf8(output.stdout).unwrap();
+    let stderr = std::string::String::from_utf8(output.stderr).unwrap();
+    let json: serde_json::Value = serde_json::from_str(&stdout).unwrap_or_else(|error| {
+        panic!("failed to parse stdout as JSON: {error}\nstdout:\n{stdout}\nstderr:\n{stderr}")
+    });
+    let diagnostics = json["files"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .flat_map(|file| file["diagnostics"].as_array().unwrap().iter())
+        .filter_map(|diagnostic| diagnostic.as_str())
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "stdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert!(
+        diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.contains("[TS2322]") && diagnostic.contains("boolean")),
+        "expected QBtn prop type error, got: {diagnostics:#?}"
+    );
+    assert!(
+        diagnostics.iter().all(|diagnostic| {
+            !diagnostic.contains("Cannot find name 'QBtn'") && !diagnostic.contains("unknown")
+        }),
+        "QBtn should be typed from node_modules GlobalComponents, got: {diagnostics:#?}"
+    );
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}
+
+#[test]
 fn check_nuxt_import_meta_augmentations_do_not_conflict() {
     let Some(corsa_path) = resolve_test_corsa_path() else {
         return;


### PR DESCRIPTION
## Summary

- load `GlobalComponents` declarations from package type entries referenced by `/// <reference types="..." />` and `compilerOptions.types`
- support package declarations that expose `GlobalComponents` through an extended helper interface such as `_GlobalComponents`
- add a CLI regression covering a Quasar-style node_modules global component

## Root Cause

Vize check only derived template component stubs from declaration files already present in the checked project file list. Package-provided Vue module augmentations under `node_modules`, like Quasar global components, were available to TypeScript but were not scanned before virtual template generation, so template props were skipped and component events fell back to `unknown`.

## Validation

- `cargo test -p vize parses_global_components_from_extended_interface`
- `cargo test -p vize check_node_modules_global_components_are_typed_from_reference_types`
- `cargo test -p vize check_project_global_components_are_typed_from_ambient_dts`
- `cargo test -p vize check_json_reports_nuxt_auto_imports_and_preserves_builtin_components`

Fixes #1157

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1158"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783576761&installation_id=136613492&pr_number=1158&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1158&signature=4779d782024825d3aaa97cf5518b9456bf2dcbc239718e513c90e41997c6053b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->