### PR TITLE
fix(carton): preserve non-word hyphens in camelize

### DIFF
--- a/crates/vize_carton/src/general.rs
+++ b/crates/vize_carton/src/general.rs
@@ -67,14 +67,16 @@ pub fn is_model_listener(key: &str) -> bool {
 #[inline]
 pub fn camelize(s: &str) -> String {
     let mut result = String::with_capacity(s.len());
-    let mut capitalize_next = false;
+    let mut chars = s.chars().peekable();
 
-    for c in s.chars() {
+    while let Some(c) = chars.next() {
         if c == '-' {
-            capitalize_next = true;
-        } else if capitalize_next {
-            result.push(c.to_ascii_uppercase());
-            capitalize_next = false;
+            match chars.peek() {
+                Some(next) if next.is_ascii_alphanumeric() || *next == '_' => {
+                    result.push(chars.next().unwrap().to_ascii_uppercase());
+                }
+                _ => result.push(c),
+            }
         } else {
             result.push(c);
         }
@@ -235,6 +237,10 @@ mod tests {
         assert_eq!(camelize("foo-bar"), "fooBar");
         assert_eq!(camelize("foo-bar-baz"), "fooBarBaz");
         assert_eq!(camelize("foo"), "foo");
+        assert_eq!(camelize("foo-"), "foo-");
+        assert_eq!(camelize("a--b"), "a-B");
+        assert_eq!(camelize("foo-.bar"), "foo-.bar");
+        assert_eq!(camelize("-foo"), "Foo");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- update `camelize()` to only consume hyphens that precede ASCII word characters
- preserve trailing and standalone hyphens to match Vue's `/(\w)/` camelize semantics
- add focused unit coverage for trailing, consecutive, and non-word hyphen cases

Closes #1220

## Verification
- cargo test -p vize_carton test_camelize

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1227"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783584378&installation_id=136613492&pr_number=1227&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1227&signature=39ae39f2dd576b63d9b5f6cebdd61ffcc5a75d1b4c0984ee685f7054c6a70545"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->