### PR TITLE
fix(vize_patina): count LSP columns as UTF-16

### DIFF
--- a/crates/vize_patina/src/telegraph.rs
+++ b/crates/vize_patina/src/telegraph.rs
@@ -422,7 +422,7 @@ fn offset_to_line_col(source: &str, offset: usize) -> (u32, u32) {
             line += 1;
             col = 0;
         } else {
-            col += 1;
+            col += ch.len_utf16() as u32;
         }
         current_offset += ch.len_utf8();
     }
@@ -583,5 +583,19 @@ mod tests {
         assert_eq!(offset_to_line_col(source, 3), (0, 3)); // '\n'
         assert_eq!(offset_to_line_col(source, 4), (1, 0)); // 'd'
         assert_eq!(offset_to_line_col(source, 8), (2, 0)); // 'g'
+    }
+
+    #[test]
+    fn test_offset_to_line_col_counts_utf16_code_units() {
+        let source = "a🦀b\nc";
+        let crab_offset = "a".len();
+        let b_offset = "a🦀".len();
+        let newline_offset = "a🦀b".len();
+        let c_offset = "a🦀b\n".len();
+
+        assert_eq!(offset_to_line_col(source, crab_offset), (0, 1));
+        assert_eq!(offset_to_line_col(source, b_offset), (0, 3));
+        assert_eq!(offset_to_line_col(source, newline_offset), (0, 4));
+        assert_eq!(offset_to_line_col(source, c_offset), (1, 0));
     }
 }


### PR DESCRIPTION
## Summary

- Count non-newline characters by UTF-16 code units when converting lint byte offsets to LSP positions.
- Add coverage for non-BMP characters before diagnostics on the same line.

Closes #1223

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p vize_patina telegraph -- --nocapture`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1228"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783584563&installation_id=136613492&pr_number=1228&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1228&signature=d1aefa2d18ae22e1b96ce5d20d34f21eba78a2081a4e9fd89bc1c79663d24d8f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->