### PR TITLE
fix(atelier_sfc): require CSS v-bind left boundary

### DIFF
--- a/crates/vize_atelier_sfc/src/css/tests.rs
+++ b/crates/vize_atelier_sfc/src/css/tests.rs
@@ -230,6 +230,25 @@ fn test_v_bind_extraction_ignores_strings_and_comments() {
 }
 
 #[test]
+fn test_v_bind_extraction_requires_left_boundary() {
+    let bump = Bump::new();
+    let css =
+        ".foo { transition: my-v-bind(x); animation: -webkit-v-bind(y); color: v-bind(color); }";
+
+    let (transformed, vars) =
+        extract_and_transform_v_bind_with_scope(&bump, css, Some("data-v-test"));
+
+    assert_eq!(
+        transformed,
+        ".foo { transition: my-v-bind(x); animation: -webkit-v-bind(y); color: var(--test-color); }"
+    );
+    assert_eq!(
+        vars.iter().map(|var| var.as_str()).collect::<Vec<_>>(),
+        vec!["color"]
+    );
+}
+
+#[test]
 fn test_scope_deep() {
     let bump = Bump::new();
     let mut out = BumpVec::new_in(&bump);

--- a/crates/vize_atelier_sfc/src/css/transform.rs
+++ b/crates/vize_atelier_sfc/src/css/transform.rs
@@ -370,10 +370,22 @@ fn find_next_v_bind(css: &str, start: usize) -> Option<usize> {
                 in_line_comment = true;
                 pos += 2;
             }
-            b'v' if bytes[pos..].starts_with(b"v-bind(") => return Some(pos),
+            b'v' if bytes[pos..].starts_with(b"v-bind(")
+                && has_v_bind_left_boundary(bytes, pos) =>
+            {
+                return Some(pos);
+            }
             _ => pos += 1,
         }
     }
 
     None
+}
+
+fn has_v_bind_left_boundary(bytes: &[u8], pos: usize) -> bool {
+    pos == 0 || !is_css_identifier_byte(bytes[pos - 1])
+}
+
+fn is_css_identifier_byte(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-')
 }


### PR DESCRIPTION
## Summary

- Require `v-bind(` CSS matches to start at a standalone token boundary.
- Leave identifiers such as `my-v-bind(x)` and `-webkit-v-bind(y)` untouched.
- Add focused CSS transform coverage for the token-boundary case.

Closes #1219

## Verification

- `cargo test -p vize_atelier_sfc css -- --nocapture`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1229"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783584563&installation_id=136613492&pr_number=1229&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1229&signature=75be62f74545a9792f32107d3ae489e18bb433f123773f87a8eed543d9836337"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->