### PR TITLE
fix(atelier_vapor): return declared slot outlet node

### DIFF
--- a/crates/vize_atelier_vapor/src/generate/operations/slots.rs
+++ b/crates/vize_atelier_vapor/src/generate/operations/slots.rs
@@ -5,7 +5,8 @@ use super::super::context::GenerateContext;
 
 /// Generate SlotOutlet
 pub(super) fn generate_slot_outlet(ctx: &mut GenerateContext, slot: &SlotOutletIRNode<'_>) {
-    let name = ctx.next_temp();
+    ctx.use_helper("renderSlot");
+    let name = cstr!("n{}", slot.id);
     let slot_name = if slot.name.is_static {
         cstr!("\"{}\"", slot.name.content)
     } else {

--- a/tests/expected/vapor/v-slot.snap
+++ b/tests/expected/vapor/v-slot.snap
@@ -1,4 +1,17 @@
 ===
+name: slot outlet
+options: vapor
+--- INPUT ---
+<slot></slot>
+--- OUTPUT ---
+import { renderSlot as _renderSlot } from 'vue';
+
+export function render(_ctx) {
+  const n0 = _renderSlot($slots, "default")
+  return n0
+}
+
+===
 name: default slot content
 options: vapor
 --- INPUT ---

--- a/tests/fixtures/vapor/v-slot.pkl
+++ b/tests/fixtures/vapor/v-slot.pkl
@@ -6,6 +6,10 @@ mode = "vapor"
 
 cases {
   new {
+    name = "slot outlet"
+    input = "<slot></slot>"
+  }
+  new {
     name = "default slot content"
     input = "<MyComponent>content</MyComponent>"
   }


### PR DESCRIPTION
## Summary

- Bind Vapor slot outlet render results to the returned element variable (`n{id}`) instead of a throwaway temp.
- Import the `renderSlot` helper when slot outlets are generated.
- Add a Vapor slot outlet fixture covering the declared return variable.

Closes #1166

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p vize_test_runner vapor_v_slot -- --ignored --nocapture`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1230"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783584563&installation_id=136613492&pr_number=1230&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1230&signature=e526ce8135809c4e0165431dccebe378db7aa2bcf5b1cc042ee6b2e6f92baef3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->