### PR TITLE
fix(vize_patina): check bound literal roles for required aria props

### DIFF
--- a/crates/vize_patina/src/rules/a11y/role_has_required_aria_props.rs
+++ b/crates/vize_patina/src/rules/a11y/role_has_required_aria_props.rs
@@ -24,7 +24,7 @@ use crate::diagnostic::Severity;
 use crate::rule::{Rule, RuleCategory, RuleMeta};
 use vize_relief::ast::{ElementNode, ElementType, ExpressionNode, PropNode};
 
-use super::helpers::{get_required_aria_props, get_static_attribute_value};
+use super::helpers::{get_required_aria_props, get_static_or_bound_literal_attribute_value};
 
 static META: RuleMeta = RuleMeta {
     name: "a11y/role-has-required-aria-props",
@@ -64,7 +64,7 @@ impl Rule for RoleHasRequiredAriaProps {
             return;
         }
 
-        let role = match get_static_attribute_value(element, "role") {
+        let role = match get_static_or_bound_literal_attribute_value(element, "role") {
             Some(r) => r,
             None => return,
         };
@@ -128,6 +128,13 @@ mod tests {
     fn test_invalid_checkbox_missing_checked() {
         let linter = create_linter();
         let result = linter.lint_template(r#"<div role="checkbox">Check</div>"#, "test.vue");
+        assert_eq!(result.warning_count, 1);
+    }
+
+    #[test]
+    fn test_invalid_bound_literal_checkbox_missing_checked() {
+        let linter = create_linter();
+        let result = linter.lint_template(r#"<div :role="'checkbox'">Check</div>"#, "test.vue");
         assert_eq!(result.warning_count, 1);
     }
 


### PR DESCRIPTION
## Summary

- Resolve literal `:role`/`v-bind:role` values before checking role-required ARIA properties.
- Add coverage for `:role="'checkbox'"` missing `aria-checked`.

Closes #1224

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p vize_patina role_has_required_aria_props -- --nocapture`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1231"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783584751&installation_id=136613492&pr_number=1231&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1231&signature=cb91cabe453544d0f06a109cd7ba47b9b7e2196fe8314502f201e48ccc359855"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->