### PR TITLE
fix(vize_patina): validate literal bound aria roles

### DIFF
--- a/crates/vize_patina/src/rules/a11y/aria_role.rs
+++ b/crates/vize_patina/src/rules/a11y/aria_role.rs
@@ -16,6 +16,8 @@ use crate::diagnostic::Severity;
 use crate::rule::{Rule, RuleCategory, RuleMeta};
 use vize_relief::ast::{ElementNode, PropNode, SourceLocation};
 
+use super::helpers::string_literal_value;
+
 static META: RuleMeta = RuleMeta {
     name: "a11y/aria-role",
     description: "Elements with ARIA roles must use a valid, non-abstract ARIA role",
@@ -256,16 +258,12 @@ impl Rule for AriaRole {
                         && let Some(vize_relief::ast::ExpressionNode::Simple(arg)) = &dir.arg
                         && arg.content.as_str() == "role"
                     {
-                        // For dynamic roles, we can only check if it's a static string
-                        if let Some(vize_relief::ast::ExpressionNode::Simple(expr)) = &dir.exp {
-                            let content = expr.content.as_str().trim();
-                            // Check if it's a string literal like "'button'" or "\"button\""
-                            if (content.starts_with('\'') && content.ends_with('\''))
-                                || (content.starts_with('"') && content.ends_with('"'))
-                            {
-                                let role = &content[1..content.len() - 1];
-                                self.check_role(ctx, role, &dir.loc);
-                            }
+                        // For dynamic roles, we can only check if the entire
+                        // expression is a single string/template literal.
+                        if let Some(vize_relief::ast::ExpressionNode::Simple(expr)) = &dir.exp
+                            && let Some(role) = string_literal_value(expr.content.as_str())
+                        {
+                            self.check_role(ctx, role, &dir.loc);
                         }
                     }
                 }
@@ -351,6 +349,20 @@ mod tests {
         let linter = create_linter();
         let result = linter.lint_template(r#"<div :role="role"></div>"#, "test.vue");
         // Dynamic roles with variable values are not checked
+        assert_eq!(result.error_count, 0);
+    }
+
+    #[test]
+    fn test_invalid_bound_template_literal_role() {
+        let linter = create_linter();
+        let result = linter.lint_template(r#"<div :role="`buton`"></div>"#, "test.vue");
+        assert_eq!(result.error_count, 1);
+    }
+
+    #[test]
+    fn test_bound_compound_expression_role_is_dynamic() {
+        let linter = create_linter();
+        let result = linter.lint_template(r#"<div :role="'a' + 'b'"></div>"#, "test.vue");
         assert_eq!(result.error_count, 0);
     }
 

--- a/crates/vize_patina/src/rules/a11y/helpers.rs
+++ b/crates/vize_patina/src/rules/a11y/helpers.rs
@@ -150,17 +150,45 @@ pub fn get_static_or_bound_literal_attribute_value<'a>(
     None
 }
 
-fn string_literal_value(content: &str) -> Option<&str> {
+pub fn string_literal_value(content: &str) -> Option<&str> {
     let content = content.trim();
     let quote = content.as_bytes().first()?;
     if content.len() < 2
-        || !matches!(quote, b'\'' | b'"')
+        || !matches!(quote, b'\'' | b'"' | b'`')
         || content.as_bytes().last() != Some(quote)
     {
         return None;
     }
 
+    let inner = &content[1..content.len() - 1];
+    if !is_single_literal_body(inner, *quote) {
+        return None;
+    }
+
     Some(&content[1..content.len() - 1])
+}
+
+fn is_single_literal_body(inner: &str, quote: u8) -> bool {
+    let mut escaped = false;
+    let mut bytes = inner.as_bytes().iter().copied().peekable();
+    while let Some(byte) = bytes.next() {
+        if escaped {
+            escaped = false;
+            continue;
+        }
+        if byte == b'\\' {
+            escaped = true;
+            continue;
+        }
+        if byte == quote {
+            return false;
+        }
+        if quote == b'`' && byte == b'$' && bytes.peek() == Some(&b'{') {
+            return false;
+        }
+    }
+
+    true
 }
 
 /// Check if an element has a specific event handler (v-on directive)


### PR DESCRIPTION
## Summary

- Reuse the shared literal attribute parser for bound `role` values.
- Treat backtick literals as checkable role values while skipping compound expressions.
- Add coverage for a typo in a template-literal role and for a compound expression false positive.

Closes #1225

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p vize_patina aria_role -- --nocapture`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1233"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783584911&installation_id=136613492&pr_number=1233&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1233&signature=07770dd512c4dea2eda6ea6d1c36fff90e9784a2c9295be8b8802f31104e5ce2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->