### PR TITLE
fix(atelier_vapor): preserve slot outlet name props and fallback

### DIFF
--- a/crates/vize_atelier_vapor/src/generate/operations/slots.rs
+++ b/crates/vize_atelier_vapor/src/generate/operations/slots.rs
@@ -1,20 +1,89 @@
 use crate::ir::SlotOutletIRNode;
-use vize_carton::cstr;
+use vize_carton::{String, cstr};
 
-use super::super::context::GenerateContext;
+use super::super::{context::GenerateContext, generate_block, setup::escape_js_string_literal};
 
 /// Generate SlotOutlet
 pub(super) fn generate_slot_outlet(ctx: &mut GenerateContext, slot: &SlotOutletIRNode<'_>) {
     ctx.use_helper("renderSlot");
     let name = cstr!("n{}", slot.id);
     let slot_name = if slot.name.is_static {
-        cstr!("\"{}\"", slot.name.content)
+        cstr!(
+            "\"{}\"",
+            escape_js_string_literal(slot.name.content.as_str())
+        )
     } else {
-        vize_carton::CompactString::from(slot.name.content.as_str())
+        ctx.resolve_expression(slot.name.content.as_str())
     };
 
-    ctx.push_line_fmt(format_args!(
-        "const {} = _renderSlot($slots, {})",
-        name, slot_name
-    ));
+    let slot_props = build_slot_props(ctx, slot);
+    match (slot_props, slot.fallback.as_ref()) {
+        (None, None) => {
+            ctx.push_line_fmt(format_args!(
+                "const {name} = _renderSlot($slots, {slot_name})"
+            ));
+        }
+        (Some(props), None) => {
+            ctx.push_line_fmt(format_args!(
+                "const {name} = _renderSlot($slots, {slot_name}, {props})"
+            ));
+        }
+        (None, Some(fallback)) => {
+            ctx.push_line_fmt(format_args!(
+                "const {name} = _renderSlot($slots, {slot_name}, {{}}, () => {{"
+            ));
+            ctx.indent();
+            generate_block(ctx, fallback, ctx.element_template_map);
+            ctx.deindent();
+            ctx.push_line("})");
+        }
+        (Some(props), Some(fallback)) => {
+            ctx.push_line_fmt(format_args!(
+                "const {name} = _renderSlot($slots, {slot_name}, {props}, () => {{"
+            ));
+            ctx.indent();
+            generate_block(ctx, fallback, ctx.element_template_map);
+            ctx.deindent();
+            ctx.push_line("})");
+        }
+    }
+}
+
+fn build_slot_props(ctx: &GenerateContext, slot: &SlotOutletIRNode<'_>) -> Option<String> {
+    if slot.props.is_empty() {
+        return None;
+    }
+
+    let props = slot
+        .props
+        .iter()
+        .map(|prop| {
+            let value = prop.values.first().map_or_else(
+                || String::from("undefined"),
+                |first| {
+                    if first.is_static {
+                        cstr!("\"{}\"", escape_js_string_literal(first.content.as_str()))
+                    } else {
+                        ctx.resolve_expression(first.content.as_str())
+                    }
+                },
+            );
+
+            if prop.key.content == "$" {
+                return cstr!("...{value}");
+            }
+
+            if prop.key.is_static {
+                return cstr!(
+                    "\"{}\": {value}",
+                    escape_js_string_literal(prop.key.content.as_str())
+                );
+            }
+
+            let key = ctx.resolve_expression(prop.key.content.as_str());
+            cstr!("[{key}]: {value}")
+        })
+        .collect::<Vec<_>>();
+
+    Some(cstr!("{{ {} }}", props.join(", ")))
 }

--- a/crates/vize_atelier_vapor/src/generate/setup.rs
+++ b/crates/vize_atelier_vapor/src/generate/setup.rs
@@ -24,6 +24,7 @@ pub(crate) fn generate_imports(ctx: &GenerateContext) -> String {
     // Define priority order for helpers (lower = earlier in import)
     fn helper_priority(name: &str) -> u32 {
         match name {
+            "renderSlot" => 1,
             "resolveComponent" => 1,
             "createComponentWithFallback" => 2,
             "createComponent" => 3,

--- a/crates/vize_atelier_vapor/src/lib.rs
+++ b/crates/vize_atelier_vapor/src/lib.rs
@@ -948,6 +948,53 @@ selected</pre>"#,
     }
 
     #[test]
+    fn test_compile_slot_outlet_preserves_static_name_props_and_fallback() {
+        let allocator = Bump::new();
+        let result = compile_vapor(
+            &allocator,
+            r#"<slot name="header" :item="x"><span>fallback</span></slot>"#,
+            Default::default(),
+        );
+
+        assert!(
+            result.error_messages.is_empty(),
+            "Expected no errors: {:?}",
+            result.error_messages
+        );
+
+        let code = normalize_code(&result.code);
+        assert_parses_as_module(&code);
+        insta::assert_snapshot!(code.as_str());
+    }
+
+    #[test]
+    fn test_compile_slot_outlet_preserves_dynamic_name() {
+        let allocator = Bump::new();
+        let result = compile_vapor(
+            &allocator,
+            r#"<slot :name="slotName" :item="x">fallback</slot>"#,
+            Default::default(),
+        );
+
+        assert!(
+            result.error_messages.is_empty(),
+            "Expected no errors: {:?}",
+            result.error_messages
+        );
+
+        let code = normalize_code(&result.code);
+        assert_parses_as_module(&code);
+        assert!(
+            code.contains(
+                r#"const n0 = _renderSlot($slots, _ctx.slotName, { "item": _ctx.x }, () => {"#
+            ),
+            "{}",
+            code
+        );
+        assert!(code.contains(r#"return n1"#), "{}", code);
+    }
+
+    #[test]
     fn test_compile_custom_renderer_intrinsics_with_bound_lowercase_component() {
         let allocator = Bump::new();
         let mut bindings = FxHashMap::default();

--- a/crates/vize_atelier_vapor/src/snapshots/vize_atelier_vapor__tests__compile_slot_outlet_preserves_static_name_props_and_fallback.snap
+++ b/crates/vize_atelier_vapor/src/snapshots/vize_atelier_vapor__tests__compile_slot_outlet_preserves_static_name_props_and_fallback.snap
@@ -1,0 +1,13 @@
+---
+source: crates/vize_atelier_vapor/src/lib.rs
+expression: code.as_str()
+---
+import { renderSlot as _renderSlot, template as _template } from 'vue';
+const t0 = _template("<span>fallback</span>")
+export function render(_ctx) {
+const n0 = _renderSlot($slots, "header", { "item": _ctx.x }, () => {
+const n1 = t0()
+return n1
+})
+return n0
+}

--- a/crates/vize_atelier_vapor/src/transform/element.rs
+++ b/crates/vize_atelier_vapor/src/transform/element.rs
@@ -401,13 +401,14 @@ pub(crate) fn transform_element<'a>(
                 .push(OperationNode::CreateComponent(create_component));
         }
         ElementType::Slot => {
-            // Slot outlet handling
-            let name_exp = SimpleExpressionNode::new("default", true, SourceLocation::STUB);
+            let name = get_slot_outlet_name(ctx, el);
+            let props = get_slot_outlet_props(ctx, el);
+            let fallback = (!el.children.is_empty()).then(|| transform_children(ctx, &el.children));
             let slot_outlet = SlotOutletIRNode {
                 id: element_id,
-                name: Box::new_in(name_exp, ctx.allocator),
-                props: Vec::new_in(ctx.allocator),
-                fallback: None,
+                name,
+                props,
+                fallback,
             };
 
             block.operation.push(OperationNode::SlotOutlet(slot_outlet));
@@ -422,4 +423,149 @@ pub(crate) fn transform_element<'a>(
     }
 
     block.returns.push(element_id);
+}
+
+fn get_slot_outlet_name<'a>(
+    ctx: &TransformContext<'a>,
+    el: &ElementNode<'a>,
+) -> Box<'a, SimpleExpressionNode<'a>> {
+    for prop in el.props.iter() {
+        match prop {
+            PropNode::Attribute(attr) => {
+                if attr.name == "name"
+                    && let Some(ref value) = attr.value
+                {
+                    return Box::new_in(
+                        SimpleExpressionNode::new(
+                            value.content.clone(),
+                            true,
+                            SourceLocation::STUB,
+                        ),
+                        ctx.allocator,
+                    );
+                }
+            }
+            PropNode::Directive(dir) => {
+                if dir.name == "bind"
+                    && let Some(ExpressionNode::Simple(arg)) = dir.arg.as_ref()
+                    && arg.content == "name"
+                    && let Some(ExpressionNode::Simple(exp)) = dir.exp.as_ref()
+                {
+                    return Box::new_in(
+                        SimpleExpressionNode::new(
+                            exp.content.clone(),
+                            exp.is_static,
+                            exp.loc.clone(),
+                        ),
+                        ctx.allocator,
+                    );
+                }
+            }
+        }
+    }
+
+    Box::new_in(
+        SimpleExpressionNode::new("default", true, SourceLocation::STUB),
+        ctx.allocator,
+    )
+}
+
+fn get_slot_outlet_props<'a>(
+    ctx: &TransformContext<'a>,
+    el: &ElementNode<'a>,
+) -> Vec<'a, IRProp<'a>> {
+    let mut props = Vec::new_in(ctx.allocator);
+
+    for prop in el.props.iter() {
+        match prop {
+            PropNode::Attribute(attr) => {
+                if attr.name == "name" {
+                    continue;
+                }
+
+                let key = Box::new_in(
+                    SimpleExpressionNode::new(attr.name.clone(), true, SourceLocation::STUB),
+                    ctx.allocator,
+                );
+                let mut values = Vec::new_in(ctx.allocator);
+                if let Some(ref value) = attr.value {
+                    values.push(Box::new_in(
+                        SimpleExpressionNode::new(
+                            value.content.clone(),
+                            true,
+                            SourceLocation::STUB,
+                        ),
+                        ctx.allocator,
+                    ));
+                }
+
+                props.push(IRProp {
+                    key,
+                    values,
+                    is_component: false,
+                });
+            }
+            PropNode::Directive(dir) => {
+                if dir.name != "bind" {
+                    continue;
+                }
+
+                match (dir.arg.as_ref(), dir.exp.as_ref()) {
+                    (Some(ExpressionNode::Simple(arg)), Some(ExpressionNode::Simple(exp))) => {
+                        if arg.content == "name" {
+                            continue;
+                        }
+
+                        let key = Box::new_in(
+                            SimpleExpressionNode::new(
+                                arg.content.clone(),
+                                arg.is_static,
+                                arg.loc.clone(),
+                            ),
+                            ctx.allocator,
+                        );
+                        let mut values = Vec::new_in(ctx.allocator);
+                        values.push(Box::new_in(
+                            SimpleExpressionNode::new(
+                                exp.content.clone(),
+                                exp.is_static,
+                                exp.loc.clone(),
+                            ),
+                            ctx.allocator,
+                        ));
+
+                        props.push(IRProp {
+                            key,
+                            values,
+                            is_component: false,
+                        });
+                    }
+                    (None, Some(ExpressionNode::Simple(exp))) => {
+                        let key = Box::new_in(
+                            SimpleExpressionNode::new("$", true, SourceLocation::STUB),
+                            ctx.allocator,
+                        );
+                        let mut values = Vec::new_in(ctx.allocator);
+                        values.push(Box::new_in(
+                            SimpleExpressionNode::new(
+                                exp.content.clone(),
+                                exp.is_static,
+                                exp.loc.clone(),
+                            ),
+                            ctx.allocator,
+                        ));
+
+                        props.push(IRProp {
+                            key,
+                            values,
+                            is_component: false,
+                        });
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+
+    props
 }


### PR DESCRIPTION
## Summary
- preserve slot outlet names in the live `atelier_vapor` transform, including static `name` and dynamic `:name`
- forward slot outlet scope props and fallback children through the IR and `_renderSlot` generation path
- add narrow regression coverage for static-name and dynamic-name slot outlets, including a snapshot for fallback output

## Root cause
The live Vapor pipeline handled `ElementType::Slot` by hardcoding the slot name to `"default"`, dropping props, and ignoring fallback children. The corresponding slot generator also emitted `_renderSlot($slots, name)` without props or fallback.

## Validation
- cargo test -p vize_atelier_vapor slot_outlet_preserves

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1235"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783585047&installation_id=136613492&pr_number=1235&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1235&signature=4227620f652ba19bf57e043f3649d2145bc8fee7d1e233fbeebc0027299ecc09"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->