### PR TITLE
fix(atelier_vapor): lower v-once and v-memo without custom directives

### DIFF
--- a/crates/vize_atelier_vapor/src/generate.rs
+++ b/crates/vize_atelier_vapor/src/generate.rs
@@ -218,24 +218,15 @@ fn generate_block(
         }
     }
 
-    // Generate text node references for effects in this block.
+    // Generate text node references for any SetText operations in this block.
     // Skip _txt() for standalone text elements (interpolations with their own template)
     // since the element itself IS the text node.
+    for op in block.operation.iter() {
+        maybe_generate_text_ref(ctx, op);
+    }
     for effect in block.effect.iter() {
         for op in effect.operations.iter() {
-            if let OperationNode::SetText(set_text) = op
-                && !ctx.standalone_text_elements.contains(&set_text.element)
-            {
-                ctx.use_helper("txt");
-                let var_name = ctx.next_text_node(set_text.element);
-                let mut line = String::with_capacity(32);
-                line.push_str("const ");
-                line.push_str(&var_name);
-                line.push_str(" = _txt(n");
-                line.push_str(&set_text.element.to_compact_string());
-                line.push(')');
-                ctx.push_line(&line);
-            }
+            maybe_generate_text_ref(ctx, op);
         }
     }
 
@@ -277,6 +268,23 @@ fn generate_block(
         } else {
             ctx.push_line(&["return [", &returns, "]"].concat());
         }
+    }
+}
+
+fn maybe_generate_text_ref(ctx: &mut GenerateContext, op: &OperationNode<'_>) {
+    if let OperationNode::SetText(set_text) = op
+        && !ctx.standalone_text_elements.contains(&set_text.element)
+        && !ctx.text_nodes.contains_key(&set_text.element)
+    {
+        ctx.use_helper("txt");
+        let var_name = ctx.next_text_node(set_text.element);
+        let mut line = String::with_capacity(32);
+        line.push_str("const ");
+        line.push_str(&var_name);
+        line.push_str(" = _txt(n");
+        line.push_str(&set_text.element.to_compact_string());
+        line.push(')');
+        ctx.push_line(&line);
     }
 }
 

--- a/crates/vize_atelier_vapor/src/lib.rs
+++ b/crates/vize_atelier_vapor/src/lib.rs
@@ -160,7 +160,7 @@ fn compile_vapor_inner<'a>(
     };
     let (mut root, errors) =
         parse_with_options_and_template_syntax(allocator, source, parser_opts, template_syntax);
-    let diagnostics = errors.to_vec();
+    let parser_diagnostics = errors.to_vec();
 
     let fatal: std::vec::Vec<_> = errors.iter().filter(|e| !e.is_recoverable()).collect();
     if !fatal.is_empty() {
@@ -170,7 +170,7 @@ fn compile_vapor_inner<'a>(
                 templates: Vec::new(),
                 error_messages: fatal.iter().map(|e| e.message.clone()).collect(),
             },
-            diagnostics,
+            parser_diagnostics,
         );
     }
 
@@ -192,7 +192,7 @@ fn compile_vapor_inner<'a>(
     }
 
     // Transform to Vapor IR
-    let ir = transform_to_ir(allocator, &root);
+    let (ir, transform_diagnostics) = transform::transform_to_ir_with_diagnostics(allocator, &root);
 
     // Generate Vapor code
     let result = generate_vapor(&ir, binding_metadata.as_ref());
@@ -201,9 +201,9 @@ fn compile_vapor_inner<'a>(
         VaporCompileResult {
             code: result.code,
             templates: result.templates,
-            error_messages: Vec::new(),
+            error_messages: transform_diagnostics,
         },
-        diagnostics,
+        parser_diagnostics,
     )
 }
 
@@ -976,5 +976,69 @@ selected</pre>"#,
         assert!(code.contains("const _component_primitive = _ctx.Primitive"));
         assert!(!code.contains(r#"_resolveComponent("group")"#));
         assert!(!code.contains(r#"_resolveComponent("primitive")"#));
+    }
+
+    #[test]
+    fn test_compile_v_once_lowers_without_runtime_directives() {
+        let allocator = Bump::new();
+        let result = compile_vapor(
+            &allocator,
+            r#"<div v-once>{{ msg }}</div>"#,
+            Default::default(),
+        );
+
+        assert!(
+            result.error_messages.is_empty(),
+            "Expected no errors: {:?}",
+            result.error_messages
+        );
+        assert_parses_as_module(&result.code);
+
+        let code = normalize_code(&result.code);
+        assert!(!code.contains("_withDirectives"), "{code}");
+        assert!(!code.contains("_renderEffect"), "{code}");
+        insta::assert_snapshot!(code.as_str());
+    }
+
+    #[test]
+    fn test_compile_v_memo_empty_array_lowers_without_runtime_directives() {
+        let allocator = Bump::new();
+        let result = compile_vapor(
+            &allocator,
+            r#"<div v-memo="[]">{{ msg }}</div>"#,
+            Default::default(),
+        );
+
+        assert!(
+            result.error_messages.is_empty(),
+            "Expected no errors: {:?}",
+            result.error_messages
+        );
+        assert_parses_as_module(&result.code);
+
+        let code = normalize_code(&result.code);
+        assert!(!code.contains("_withDirectives"), "{code}");
+        assert!(!code.contains("_renderEffect"), "{code}");
+        insta::assert_snapshot!(code.as_str());
+    }
+
+    #[test]
+    fn test_compile_v_memo_with_dependencies_reports_diagnostic() {
+        let allocator = Bump::new();
+        let result = compile_vapor(
+            &allocator,
+            r#"<div v-memo="[msg]">{{ msg }}</div>"#,
+            Default::default(),
+        );
+
+        assert_eq!(
+            result.error_messages,
+            vec![String::from(
+                "v-memo with dependencies is not supported in Vapor yet. Use v-once or v-memo=\"[]\" until memo guards are implemented.",
+            )]
+        );
+        assert_parses_as_module(&result.code);
+        assert!(!result.code.contains("_withDirectives"), "{}", result.code);
+        assert!(!result.code.contains("_memo"), "{}", result.code);
     }
 }

--- a/crates/vize_atelier_vapor/src/snapshots/vize_atelier_vapor__tests__compile_v_memo_empty_array_lowers_without_runtime_directives.snap
+++ b/crates/vize_atelier_vapor/src/snapshots/vize_atelier_vapor__tests__compile_v_memo_empty_array_lowers_without_runtime_directives.snap
@@ -1,0 +1,13 @@
+---
+source: crates/vize_atelier_vapor/src/lib.rs
+assertion_line: 1014
+expression: code.as_str()
+---
+import { txt as _txt, toDisplayString as _toDisplayString, setText as _setText, template as _template } from 'vue';
+const t0 = _template("<div> </div>", true)
+export function render(_ctx) {
+const n0 = t0()
+const x0 = _txt(n0)
+_setText(x0, _toDisplayString(_ctx.msg))
+return n0
+}

--- a/crates/vize_atelier_vapor/src/snapshots/vize_atelier_vapor__tests__compile_v_once_lowers_without_runtime_directives.snap
+++ b/crates/vize_atelier_vapor/src/snapshots/vize_atelier_vapor__tests__compile_v_once_lowers_without_runtime_directives.snap
@@ -1,0 +1,13 @@
+---
+source: crates/vize_atelier_vapor/src/lib.rs
+assertion_line: 996
+expression: code.as_str()
+---
+import { txt as _txt, toDisplayString as _toDisplayString, setText as _setText, template as _template } from 'vue';
+const t0 = _template("<div> </div>", true)
+export function render(_ctx) {
+const n0 = t0()
+const x0 = _txt(n0)
+_setText(x0, _toDisplayString(_ctx.msg))
+return n0
+}

--- a/crates/vize_atelier_vapor/src/transform.rs
+++ b/crates/vize_atelier_vapor/src/transform.rs
@@ -20,26 +20,36 @@ use text::{transform_interpolation, transform_text};
 
 /// Transform AST to Vapor IR
 pub fn transform_to_ir<'a>(allocator: &'a Bump, root: &RootNode<'a>) -> RootIRNode<'a> {
+    transform_to_ir_with_diagnostics(allocator, root).0
+}
+
+pub(crate) fn transform_to_ir_with_diagnostics<'a>(
+    allocator: &'a Bump,
+    root: &RootNode<'a>,
+) -> (RootIRNode<'a>, std::vec::Vec<String>) {
     let mut ctx = TransformContext::new(allocator);
 
     // Create block for root
     let block = transform_children(&mut ctx, &root.children);
 
-    RootIRNode {
-        node: RootNode::new(allocator, ""),
-        source: String::from(""),
-        template: Default::default(),
-        template_index_map: Default::default(),
-        root_template_indexes: Vec::new_in(allocator),
-        component: Vec::new_in(allocator),
-        directive: Vec::new_in(allocator),
-        block,
-        has_template_ref: false,
-        has_deferred_v_show: false,
-        templates: ctx.templates,
-        element_template_map: ctx.element_template_map,
-        standalone_text_elements: ctx.standalone_text_elements,
-    }
+    (
+        RootIRNode {
+            node: RootNode::new(allocator, ""),
+            source: String::from(""),
+            template: Default::default(),
+            template_index_map: Default::default(),
+            root_template_indexes: Vec::new_in(allocator),
+            component: Vec::new_in(allocator),
+            directive: Vec::new_in(allocator),
+            block,
+            has_template_ref: false,
+            has_deferred_v_show: false,
+            templates: ctx.templates,
+            element_template_map: ctx.element_template_map,
+            standalone_text_elements: ctx.standalone_text_elements,
+        },
+        ctx.diagnostics,
+    )
 }
 
 /// Transform children nodes
@@ -103,7 +113,7 @@ fn transform_combined_block_text<'a>(
     children: &[TemplateChildNode<'a>],
     block: &mut BlockIRNode<'a>,
 ) {
-    use crate::ir::{IREffect, OperationNode, SetTextIRNode};
+    use crate::ir::{OperationNode, SetTextIRNode};
     use vize_atelier_core::{ExpressionNode, SimpleExpressionNode, SourceLocation};
     use vize_carton::{Box, Vec};
 
@@ -146,11 +156,7 @@ fn transform_combined_block_text<'a>(
         element: element_id,
         values,
     };
-    let mut effect_ops = Vec::new_in(ctx.allocator);
-    effect_ops.push(OperationNode::SetText(set_text));
-    block.effect.push(IREffect {
-        operations: effect_ops,
-    });
+    ctx.push_dynamic_operation(block, OperationNode::SetText(set_text));
     block.returns.push(element_id);
 }
 

--- a/crates/vize_atelier_vapor/src/transform/context.rs
+++ b/crates/vize_atelier_vapor/src/transform/context.rs
@@ -1,5 +1,6 @@
 //! Transform context for tracking state during AST-to-IR transformation.
 
+use crate::ir::{BlockIRNode, IREffect, OperationNode};
 use vize_carton::{Bump, FxHashMap, FxHashSet, String, Vec};
 
 /// Transform context
@@ -9,6 +10,8 @@ pub(crate) struct TransformContext<'a> {
     pub(crate) templates: Vec<'a, String>,
     pub(crate) element_template_map: FxHashMap<usize, usize>,
     pub(crate) standalone_text_elements: FxHashSet<usize>,
+    non_reactive_scopes: usize,
+    pub(crate) diagnostics: std::vec::Vec<String>,
 }
 
 impl<'a> TransformContext<'a> {
@@ -19,6 +22,8 @@ impl<'a> TransformContext<'a> {
             templates: Vec::new_in(allocator),
             element_template_map: FxHashMap::default(),
             standalone_text_elements: FxHashSet::default(),
+            non_reactive_scopes: 0,
+            diagnostics: std::vec::Vec::new(),
         }
     }
 
@@ -33,5 +38,38 @@ impl<'a> TransformContext<'a> {
         self.templates.push(template);
         self.element_template_map.insert(element_id, template_index);
         template_index
+    }
+
+    pub(crate) fn enter_non_reactive_scope(&mut self) {
+        self.non_reactive_scopes += 1;
+    }
+
+    pub(crate) fn exit_non_reactive_scope(&mut self) {
+        self.non_reactive_scopes = self.non_reactive_scopes.saturating_sub(1);
+    }
+
+    pub(crate) fn is_non_reactive(&self) -> bool {
+        self.non_reactive_scopes > 0
+    }
+
+    pub(crate) fn push_dynamic_operation(
+        &mut self,
+        block: &mut BlockIRNode<'a>,
+        operation: OperationNode<'a>,
+    ) {
+        if self.is_non_reactive() {
+            block.operation.push(operation);
+            return;
+        }
+
+        let mut effect_ops = Vec::new_in(self.allocator);
+        effect_ops.push(operation);
+        block.effect.push(IREffect {
+            operations: effect_ops,
+        });
+    }
+
+    pub(crate) fn push_diagnostic(&mut self, message: impl Into<String>) {
+        self.diagnostics.push(message.into());
     }
 }

--- a/crates/vize_atelier_vapor/src/transform/directive.rs
+++ b/crates/vize_atelier_vapor/src/transform/directive.rs
@@ -5,8 +5,8 @@
 use vize_carton::{Box, Vec};
 
 use crate::ir::{
-    BlockIRNode, DirectiveIRNode, ForIRNode, IREffect, IRProp, IfIRNode, OperationNode,
-    SetEventIRNode, SetHtmlIRNode, SetPropIRNode, SetTextIRNode,
+    BlockIRNode, DirectiveIRNode, ForIRNode, IRProp, IfIRNode, OperationNode, SetEventIRNode,
+    SetHtmlIRNode, SetPropIRNode, SetTextIRNode,
 };
 use vize_atelier_core::{
     DirectiveNode, ElementNode, ElementType, ExpressionNode, PropNode, SimpleExpressionNode,
@@ -69,11 +69,10 @@ pub(crate) fn transform_directive<'a>(
                                 props,
                                 is_event: false,
                             };
-                            let mut effect_ops = Vec::new_in(ctx.allocator);
-                            effect_ops.push(OperationNode::SetDynamicProps(set_dynamic));
-                            block.effect.push(IREffect {
-                                operations: effect_ops,
-                            });
+                            ctx.push_dynamic_operation(
+                                block,
+                                OperationNode::SetDynamicProps(set_dynamic),
+                            );
                         }
                         return;
                     }
@@ -129,11 +128,7 @@ pub(crate) fn transform_directive<'a>(
                     };
 
                     // Reactive prop - add to effects
-                    let mut effect_ops = Vec::new_in(ctx.allocator);
-                    effect_ops.push(OperationNode::SetProp(set_prop));
-                    block.effect.push(IREffect {
-                        operations: effect_ops,
-                    });
+                    ctx.push_dynamic_operation(block, OperationNode::SetProp(set_prop));
                 }
             } else {
                 // v-bind without arg = v-bind object (v-bind="attrs")
@@ -153,11 +148,7 @@ pub(crate) fn transform_directive<'a>(
                         props,
                         is_event: false,
                     };
-                    let mut effect_ops = Vec::new_in(ctx.allocator);
-                    effect_ops.push(OperationNode::SetDynamicProps(set_dynamic));
-                    block.effect.push(IREffect {
-                        operations: effect_ops,
-                    });
+                    ctx.push_dynamic_operation(block, OperationNode::SetDynamicProps(set_dynamic));
                 }
             }
         }
@@ -245,11 +236,7 @@ pub(crate) fn transform_directive<'a>(
                         props: values,
                         is_event: true,
                     };
-                    let mut effect_ops = Vec::new_in(ctx.allocator);
-                    effect_ops.push(OperationNode::SetDynamicProps(set_dynamic));
-                    block.effect.push(IREffect {
-                        operations: effect_ops,
-                    });
+                    ctx.push_dynamic_operation(block, OperationNode::SetDynamicProps(set_dynamic));
                 }
             }
         }
@@ -330,11 +317,7 @@ pub(crate) fn transform_directive<'a>(
                     value,
                 };
 
-                let mut effect_ops = Vec::new_in(ctx.allocator);
-                effect_ops.push(OperationNode::SetHtml(set_html));
-                block.effect.push(IREffect {
-                    operations: effect_ops,
-                });
+                ctx.push_dynamic_operation(block, OperationNode::SetHtml(set_html));
             }
         }
         "text" => {
@@ -355,13 +338,11 @@ pub(crate) fn transform_directive<'a>(
                     values,
                 };
 
-                let mut effect_ops = Vec::new_in(ctx.allocator);
-                effect_ops.push(OperationNode::SetText(set_text));
-                block.effect.push(IREffect {
-                    operations: effect_ops,
-                });
+                ctx.push_dynamic_operation(block, OperationNode::SetText(set_text));
             }
         }
+        "once" => {}
+        "memo" => {}
         "show" => {
             // v-show - builtin directive
             let mut new_dir = DirectiveNode::new(ctx.allocator, dir.name.clone(), dir.loc.clone());

--- a/crates/vize_atelier_vapor/src/transform/element.rs
+++ b/crates/vize_atelier_vapor/src/transform/element.rs
@@ -44,6 +44,15 @@ pub(crate) fn transform_element<'a>(
     el: &ElementNode<'a>,
     block: &mut BlockIRNode<'a>,
 ) {
+    let non_reactive = classify_non_reactive_directive(el);
+    if let Some(ref memo_error) = non_reactive.memo_error {
+        ctx.push_diagnostic(memo_error.clone());
+    }
+    let entered_non_reactive = non_reactive.should_lower_as_once;
+    if entered_non_reactive {
+        ctx.enter_non_reactive_scope();
+    }
+
     // Template elements don't consume an ID - they just wrap children
     if el.tag_type == ElementType::Template {
         for child in el.children.iter() {
@@ -66,6 +75,9 @@ pub(crate) fn transform_element<'a>(
                 _ => {}
             }
         }
+        if entered_non_reactive {
+            ctx.exit_non_reactive_scope();
+        }
         return;
     }
 
@@ -86,6 +98,9 @@ pub(crate) fn transform_element<'a>(
         // Dynamic element children: allocate child IDs first, then parent ID.
         // Use child/next navigation instead of separate templates.
         transform_element_with_dynamic_children(ctx, el, block);
+        if entered_non_reactive {
+            ctx.exit_non_reactive_scope();
+        }
         return;
     }
 
@@ -93,6 +108,9 @@ pub(crate) fn transform_element<'a>(
         // Control flow children (v-if/v-for): defer parent ID and template
         // allocation until after children, so inner IDs/templates come first.
         transform_element_with_control_flow_children(ctx, el, block);
+        if entered_non_reactive {
+            ctx.exit_non_reactive_scope();
+        }
         return;
     }
 
@@ -100,6 +118,9 @@ pub(crate) fn transform_element<'a>(
     // Also handle <component :is="..."> (dynamic component) which the parser classifies as Element
     if el.tag_type == ElementType::Component || el.tag.as_str() == "component" {
         transform_component(ctx, el, block, None, None, None, true);
+        if entered_non_reactive {
+            ctx.exit_non_reactive_scope();
+        }
         return;
     }
 
@@ -422,4 +443,63 @@ pub(crate) fn transform_element<'a>(
     }
 
     block.returns.push(element_id);
+
+    if entered_non_reactive {
+        ctx.exit_non_reactive_scope();
+    }
+}
+
+struct NonReactiveDirective {
+    should_lower_as_once: bool,
+    memo_error: Option<String>,
+}
+
+fn classify_non_reactive_directive(el: &ElementNode<'_>) -> NonReactiveDirective {
+    let has_once = el
+        .props
+        .iter()
+        .any(|prop| matches!(prop, PropNode::Directive(dir) if dir.name.as_str() == "once"));
+    if has_once {
+        return NonReactiveDirective {
+            should_lower_as_once: true,
+            memo_error: None,
+        };
+    }
+
+    for prop in el.props.iter() {
+        let PropNode::Directive(dir) = prop else {
+            continue;
+        };
+        if dir.name.as_str() != "memo" {
+            continue;
+        }
+
+        let Some(ExpressionNode::Simple(exp)) = dir.exp.as_ref() else {
+            return NonReactiveDirective {
+                should_lower_as_once: false,
+                memo_error: Some(vize_carton::String::from(
+                    "v-memo is not supported in Vapor yet. Use v-once or v-memo=\"[]\" until memo guards are implemented.",
+                )),
+            };
+        };
+
+        if exp.content.trim() == "[]" {
+            return NonReactiveDirective {
+                should_lower_as_once: true,
+                memo_error: None,
+            };
+        }
+
+        return NonReactiveDirective {
+            should_lower_as_once: false,
+            memo_error: Some(vize_carton::String::from(
+                "v-memo with dependencies is not supported in Vapor yet. Use v-once or v-memo=\"[]\" until memo guards are implemented.",
+            )),
+        };
+    }
+
+    NonReactiveDirective {
+        should_lower_as_once: false,
+        memo_error: None,
+    }
 }

--- a/crates/vize_atelier_vapor/src/transform/text.rs
+++ b/crates/vize_atelier_vapor/src/transform/text.rs
@@ -4,7 +4,7 @@
 
 use vize_carton::{Box, Vec};
 
-use crate::ir::{BlockIRNode, IREffect, OperationNode, SetTextIRNode};
+use crate::ir::{BlockIRNode, OperationNode, SetTextIRNode};
 use vize_atelier_core::{
     ExpressionNode, InterpolationNode, SimpleExpressionNode, SourceLocation, TemplateChildNode,
     TextNode,
@@ -57,13 +57,7 @@ pub(crate) fn transform_interpolation<'a>(
         values,
     };
 
-    // Add to effects (reactive)
-    let mut effect_ops = Vec::new_in(ctx.allocator);
-    effect_ops.push(OperationNode::SetText(set_text));
-
-    block.effect.push(IREffect {
-        operations: effect_ops,
-    });
+    ctx.push_dynamic_operation(block, OperationNode::SetText(set_text));
 
     block.returns.push(element_id);
 }
@@ -110,11 +104,6 @@ pub(crate) fn transform_text_children<'a>(
             values,
         };
 
-        let mut effect_ops = Vec::new_in(ctx.allocator);
-        effect_ops.push(OperationNode::SetText(set_text));
-
-        block.effect.push(IREffect {
-            operations: effect_ops,
-        });
+        ctx.push_dynamic_operation(block, OperationNode::SetText(set_text));
     }
 }


### PR DESCRIPTION
## Summary
- lower `v-once` in Vapor as one-time setup work instead of a custom runtime directive
- lower `v-memo="[]"` through the same non-reactive path and stop emitting `_withDirectives` / `_memo`
- surface an explicit Vapor diagnostic for dependency-based `v-memo` while adding focused snapshots/tests

## Root cause
Vapor only had dedicated lowering for `v-show` and `v-model`. `v-once` and `v-memo` fell through the custom-directive fallback, which emitted bare `_withDirectives`, `_once`, and `_memo` identifiers and dropped `v-memo` dependencies entirely.

## Verification
- `cargo test -p vize_atelier_vapor compile_v_ -- --nocapture`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1236"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783585122&installation_id=136613492&pr_number=1236&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1236&signature=dde51777cf7135c09cc3cfb995aa119887a67cace250cd648b524b6b5e891281"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->