### PR TITLE
fix(typecheck): expand fallback Vue runtime stubs

### DIFF
--- a/crates/vize/tests/check_cli.rs
+++ b/crates/vize/tests/check_cli.rs
@@ -3409,22 +3409,41 @@ export interface Ref<T = unknown, _Raw = T> {
   value: T;
 }
 
+export interface ComputedRef<T = unknown> extends Ref<T> {
+  readonly value: T;
+}
+
+export interface WritableComputedRef<T = unknown> extends Ref<T> {
+  value: T;
+}
+
 export interface ShallowRef<T = unknown, _Raw = T> extends Ref<T, _Raw> {
   readonly __v_isShallow?: true;
 }
 
+export type InjectionKey<T> = symbol & { readonly __v_vlsInjection?: T };
 export type PropType<T> = { new (...args: any[]): T & {} } | { (): T } | null;
 
 export declare const Transition: DefineComponent;
 export declare function defineComponent(options: any): DefineComponent;
+export declare function defineAsyncComponent(source: any): DefineComponent;
 export declare function defineProps<T = {}>(): T;
+export declare function computed<T>(getter: () => T): ComputedRef<T>;
+export declare function computed<T>(options: { get: () => T; set: (value: T) => void }): WritableComputedRef<T>;
 export declare function ref<T>(value: T): Ref<T>;
+export declare function reactive<T extends object>(target: T): T;
 export declare function shallowRef<T>(value: T): ShallowRef<T>;
+export declare function toRef<T extends object, K extends keyof T>(object: T, key: K): Ref<T[K]>;
 export declare function useTemplateRef<T = unknown>(key: string): ShallowRef<T | null>;
 export declare function useId(): string;
 export declare function watch<T>(source: T, callback: (...args: any[]) => void, options?: any): void;
 export declare function watchEffect(effect: (onCleanup: (cleanupFn: () => void) => void) => void): void;
 export declare function onMounted(callback: () => void): void;
+export declare function customRef<T>(factory: any): Ref<T>;
+export declare function provide<T>(key: InjectionKey<T> | string | symbol, value: T): void;
+export declare function inject<T>(key: InjectionKey<T> | string | symbol): T | undefined;
+export declare function inject<T>(key: InjectionKey<T> | string | symbol, defaultValue: T): T;
+export declare function markRaw<T extends object>(value: T): T;
 export declare function createApp(root: any): {
   config: {
     globalProperties: { [key: string]: any };

--- a/crates/vize_canon/src/batch/runtime_deps.rs
+++ b/crates/vize_canon/src/batch/runtime_deps.rs
@@ -58,22 +58,41 @@ export interface Ref<T = unknown, _Raw = T> {
   value: T;
 }
 
+export interface ComputedRef<T = unknown> extends Ref<T> {
+  readonly value: T;
+}
+
+export interface WritableComputedRef<T = unknown> extends Ref<T> {
+  value: T;
+}
+
 export interface ShallowRef<T = unknown, _Raw = T> extends Ref<T, _Raw> {
   readonly __v_isShallow?: true;
 }
 
+export type InjectionKey<T> = symbol & { readonly __v_vlsInjection?: T };
 export type PropType<T> = { new (...args: any[]): T & {} } | { (): T } | null;
 
 export declare const Transition: DefineComponent;
 export declare function defineComponent(options: any): DefineComponent;
+export declare function defineAsyncComponent(source: any): DefineComponent;
 export declare function defineProps<T = {}>(): T;
+export declare function computed<T>(getter: () => T): ComputedRef<T>;
+export declare function computed<T>(options: { get: () => T; set: (value: T) => void }): WritableComputedRef<T>;
 export declare function ref<T>(value: T): Ref<T>;
+export declare function reactive<T extends object>(target: T): T;
 export declare function shallowRef<T>(value: T): ShallowRef<T>;
+export declare function toRef<T extends object, K extends keyof T>(object: T, key: K): Ref<T[K]>;
 export declare function useTemplateRef<T = unknown>(key: string): ShallowRef<T | null>;
 export declare function useId(): string;
 export declare function watch<T>(source: T, callback: (...args: any[]) => void, options?: any): void;
 export declare function watchEffect(effect: (onCleanup: (cleanupFn: () => void) => void) => void): void;
 export declare function onMounted(callback: () => void): void;
+export declare function customRef<T>(factory: any): Ref<T>;
+export declare function provide<T>(key: InjectionKey<T> | string | symbol, value: T): void;
+export declare function inject<T>(key: InjectionKey<T> | string | symbol): T | undefined;
+export declare function inject<T>(key: InjectionKey<T> | string | symbol, defaultValue: T): T;
+export declare function markRaw<T extends object>(value: T): T;
 export declare function createApp(root: any): {
   config: {
     globalProperties: { [key: string]: any };

--- a/crates/vize_canon/src/batch/type_checker/tests.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests.rs
@@ -695,6 +695,74 @@ onMounted(() => {
 }
 
 #[test]
+fn batch_type_checker_expands_vue_runtime_stubs_without_node_modules() {
+    if resolve_test_tsgo_binary().is_none() {
+        return;
+    }
+
+    with_workspace_node_modules_override(Some("__none__"), || {
+        let project_root = create_project_case_without_node_modules(
+            "vue-runtime-stub-expanded",
+            &[(
+                "src/FallbackVueRuntime.vue",
+                r#"<script setup lang="ts">
+import {
+  computed,
+  defineAsyncComponent,
+  inject,
+  markRaw,
+  provide,
+  reactive,
+  type InjectionKey,
+} from 'vue'
+
+const countKey: InjectionKey<number> = Symbol('count')
+provide(countKey, 1)
+
+const count = inject(countKey, 0)
+const state = reactive({ count })
+const doubled = computed(() => state.count * 2)
+const LazyPanel = markRaw(defineAsyncComponent(() => Promise.resolve({})))
+
+const badCount: string = count
+const badDoubled: string = doubled.value
+
+void LazyPanel
+</script>
+
+<template>{{ doubled }}</template>
+"#,
+            )],
+        );
+
+        let Some(snapshot) = snapshot_project_diagnostics(&project_root) else {
+            let _ = std::fs::remove_dir_all(&project_root);
+            return;
+        };
+
+        assert!(
+            snapshot
+                .iter()
+                .all(|(_, code, message)| *code != Some(2305)
+                    && !message.contains("no exported member")),
+            "unexpected bundled vue runtime export diagnostic: {snapshot:#?}"
+        );
+        assert!(
+            snapshot
+                .iter()
+                .filter(|(file, code, _)| {
+                    file == "src/FallbackVueRuntime.vue" && *code == Some(2322)
+                })
+                .count()
+                >= 2,
+            "expected typed fallback mismatches to remain reported, got: {snapshot:#?}"
+        );
+
+        let _ = std::fs::remove_dir_all(&project_root);
+    });
+}
+
+#[test]
 fn batch_type_checker_snapshots_cross_file_vue_prop_error() {
     if resolve_test_tsgo_binary().is_none() {
         return;
@@ -1811,6 +1879,33 @@ fn resolve_workspace_node_modules(workspace_root: &Path) -> Option<PathBuf> {
         .then_some(workspace_node_modules)
 }
 
+fn with_workspace_node_modules_override<T>(value: Option<&str>, run: impl FnOnce() -> T) -> T {
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    struct EnvOverrideGuard {
+        previous: Option<std::ffi::OsString>,
+    }
+
+    impl Drop for EnvOverrideGuard {
+        fn drop(&mut self) {
+            if let Some(previous) = self.previous.take() {
+                unsafe { std::env::set_var("VIZE_TEST_WORKSPACE_NODE_MODULES", previous) };
+            } else {
+                unsafe { std::env::remove_var("VIZE_TEST_WORKSPACE_NODE_MODULES") };
+            }
+        }
+    }
+
+    let _lock = ENV_LOCK.lock().unwrap();
+    let previous = std::env::var_os("VIZE_TEST_WORKSPACE_NODE_MODULES");
+    match value {
+        Some(value) => unsafe { std::env::set_var("VIZE_TEST_WORKSPACE_NODE_MODULES", value) },
+        None => unsafe { std::env::remove_var("VIZE_TEST_WORKSPACE_NODE_MODULES") },
+    }
+    let _guard = EnvOverrideGuard { previous };
+    run()
+}
+
 fn write_test_vue_stub(target: &Path) -> std::io::Result<()> {
     let vue_dir = target.join("vue");
     std::fs::create_dir_all(&vue_dir)?;
@@ -1873,22 +1968,41 @@ export interface Ref<T = unknown, _Raw = T> {
   value: T;
 }
 
+export interface ComputedRef<T = unknown> extends Ref<T> {
+  readonly value: T;
+}
+
+export interface WritableComputedRef<T = unknown> extends Ref<T> {
+  value: T;
+}
+
 export interface ShallowRef<T = unknown, _Raw = T> extends Ref<T, _Raw> {
   readonly __v_isShallow?: true;
 }
 
+export type InjectionKey<T> = symbol & { readonly __v_vlsInjection?: T };
 export type PropType<T> = { new (...args: any[]): T & {} } | { (): T } | null;
 
 export declare const Transition: DefineComponent;
 export declare function defineComponent(options: any): DefineComponent;
+export declare function defineAsyncComponent(source: any): DefineComponent;
 export declare function defineProps<T = {}>(): T;
+export declare function computed<T>(getter: () => T): ComputedRef<T>;
+export declare function computed<T>(options: { get: () => T; set: (value: T) => void }): WritableComputedRef<T>;
 export declare function ref<T>(value: T): Ref<T>;
+export declare function reactive<T extends object>(target: T): T;
 export declare function shallowRef<T>(value: T): ShallowRef<T>;
+export declare function toRef<T extends object, K extends keyof T>(object: T, key: K): Ref<T[K]>;
 export declare function useTemplateRef<T = unknown>(key: string): ShallowRef<T | null>;
 export declare function useId(): string;
 export declare function watch<T>(source: T, callback: (...args: any[]) => void, options?: any): void;
 export declare function watchEffect(effect: (onCleanup: (cleanupFn: () => void) => void) => void): void;
 export declare function onMounted(callback: () => void): void;
+export declare function customRef<T>(factory: any): Ref<T>;
+export declare function provide<T>(key: InjectionKey<T> | string | symbol, value: T): void;
+export declare function inject<T>(key: InjectionKey<T> | string | symbol): T | undefined;
+export declare function inject<T>(key: InjectionKey<T> | string | symbol, defaultValue: T): T;
+export declare function markRaw<T extends object>(value: T): T;
 export declare function createApp(root: any): {
   config: {
     globalProperties: { [key: string]: any };


### PR DESCRIPTION
## Summary
- expand the fallback `@vue/runtime-dom` stub surface with typed `computed`, `reactive`, `toRef`, `customRef`, `provide`/`inject`, `InjectionKey`, `defineAsyncComponent`, and `markRaw`
- add a no-`node_modules` batch typechecker regression test that forces the fallback path and verifies real type mismatches still surface
- keep the CLI test helper Vue runtime stub aligned with the runtime fallback surface used by batch typecheck

## Why
When Vue runtime packages cannot be resolved from the project or workspace, the batch typechecker fell back to a very narrow stub. That produced `no exported member` noise for Vue APIs Vize already recognizes instead of the intended type diagnostics.

## Validation
- `cargo test -p vize_canon batch_type_checker_expands_vue_runtime_stubs_without_node_modules`
- `cargo test -p vize_canon batch_type_checker_uses_workspace_vue_runtime_without_node_modules`
- `cargo test -p vize --test check_cli check_options_api_can_import_define_component_from_bundled_vue`

Closes #1165

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1237"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783585138&installation_id=136613492&pr_number=1237&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1237&signature=7aba83f39a22956fb49385b3e582c8d3f101d202e723921bb4819ec408efcc5f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->