### PR TITLE
fix(compiler): preserve Vapor directive payloads and v-cloak lowering

### DIFF
--- a/crates/vize_atelier_vapor/src/generate.rs
+++ b/crates/vize_atelier_vapor/src/generate.rs
@@ -11,7 +11,7 @@ mod setup;
 
 use std::fmt::Write;
 
-use crate::ir::{BlockIRNode, OperationNode, RootIRNode};
+use crate::ir::{BlockIRNode, CreateComponentIRNode, NegativeBranch, OperationNode, RootIRNode};
 use vize_atelier_core::options::BindingMetadata;
 use vize_carton::{FxHashMap, FxHashSet, String, ToCompactString};
 
@@ -111,6 +111,18 @@ pub fn generate_vapor(
         ctx.push_line("const _setRef = _ctx.vaporTemplateRefSetter || _createTemplateRefSetter()");
     }
 
+    let custom_directives = collect_custom_directives(&ir.block);
+    if !custom_directives.is_empty() {
+        ctx.use_helper("resolveDirective");
+        for directive in custom_directives {
+            ctx.push_line(&vize_carton::cstr!(
+                "const _directive_{} = _resolveDirective(\"{}\")",
+                directive_resolution_ident(directive.as_str()),
+                directive
+            ));
+        }
+    }
+
     // Generate block content (includes template instantiation, text nodes, operations, effects, return)
     generate_block(&mut ctx, &ir.block, &ir.element_template_map);
 
@@ -189,6 +201,90 @@ fn negative_branch_has_template_refs(branch: &crate::ir::NegativeBranch<'_>) -> 
                     .is_some_and(negative_branch_has_template_refs)
         }
     }
+}
+
+fn collect_custom_directives(block: &BlockIRNode<'_>) -> std::vec::Vec<String> {
+    let mut directives = FxHashSet::default();
+    collect_custom_directives_from_block(block, &mut directives);
+
+    let mut directives: std::vec::Vec<_> = directives.into_iter().collect();
+    directives.sort();
+    directives
+}
+
+fn collect_custom_directives_from_block(
+    block: &BlockIRNode<'_>,
+    directives: &mut FxHashSet<String>,
+) {
+    for operation in block.operation.iter() {
+        collect_custom_directives_from_operation(operation, directives);
+    }
+
+    for effect in block.effect.iter() {
+        for operation in effect.operations.iter() {
+            collect_custom_directives_from_operation(operation, directives);
+        }
+    }
+}
+
+fn collect_custom_directives_from_component(
+    component: &CreateComponentIRNode<'_>,
+    directives: &mut FxHashSet<String>,
+) {
+    for slot in component.slots.iter() {
+        collect_custom_directives_from_block(&slot.block, directives);
+    }
+}
+
+fn collect_custom_directives_from_negative_branch(
+    branch: &NegativeBranch<'_>,
+    directives: &mut FxHashSet<String>,
+) {
+    match branch {
+        NegativeBranch::Block(block) => collect_custom_directives_from_block(block, directives),
+        NegativeBranch::If(if_node) => {
+            collect_custom_directives_from_block(&if_node.positive, directives);
+            if let Some(negative) = &if_node.negative {
+                collect_custom_directives_from_negative_branch(negative, directives);
+            }
+        }
+    }
+}
+
+fn collect_custom_directives_from_operation(
+    operation: &OperationNode<'_>,
+    directives: &mut FxHashSet<String>,
+) {
+    match operation {
+        OperationNode::Directive(directive) if !directive.builtin => {
+            directives.insert(directive.name.clone());
+        }
+        OperationNode::If(if_node) => {
+            collect_custom_directives_from_block(&if_node.positive, directives);
+            if let Some(negative) = &if_node.negative {
+                collect_custom_directives_from_negative_branch(negative, directives);
+            }
+        }
+        OperationNode::For(for_node) => {
+            collect_custom_directives_from_block(&for_node.render, directives);
+        }
+        OperationNode::CreateComponent(component) => {
+            collect_custom_directives_from_component(component, directives);
+        }
+        _ => {}
+    }
+}
+
+fn directive_resolution_ident(name: &str) -> String {
+    let mut ident = String::with_capacity(name.len());
+    for ch in name.chars() {
+        if ch.is_ascii_alphanumeric() || ch == '_' {
+            ident.push(ch);
+        } else {
+            ident.push('_');
+        }
+    }
+    ident
 }
 
 /// Generate block

--- a/crates/vize_atelier_vapor/src/generate/operations/directives.rs
+++ b/crates/vize_atelier_vapor/src/generate/operations/directives.rs
@@ -4,6 +4,73 @@ use vize_carton::{String, cstr};
 
 use super::super::context::GenerateContext;
 
+fn directive_resolution_var(name: &str) -> String {
+    let mut ident = String::with_capacity(name.len() + 11);
+    ident.push_str("_directive_");
+    for ch in name.chars() {
+        if ch.is_ascii_alphanumeric() || ch == '_' {
+            ident.push(ch);
+        } else {
+            ident.push('_');
+        }
+    }
+    ident
+}
+
+fn directive_arg(ctx: &GenerateContext, directive: &DirectiveIRNode<'_>) -> String {
+    if let Some(ref arg) = directive.dir.arg {
+        match arg {
+            ExpressionNode::Simple(exp) => {
+                if exp.is_static {
+                    cstr!("\"{}\"", exp.content)
+                } else {
+                    ctx.resolve_expression(exp.content.as_str())
+                }
+            }
+            ExpressionNode::Compound(compound) => {
+                ctx.resolve_expression(compound.loc.source.as_str())
+            }
+        }
+    } else {
+        vize_carton::CompactString::from("undefined")
+    }
+}
+
+fn directive_value(ctx: &GenerateContext, directive: &DirectiveIRNode<'_>) -> String {
+    if let Some(ref exp) = directive.dir.exp {
+        match exp {
+            ExpressionNode::Simple(e) => {
+                if e.is_static {
+                    cstr!("\"{}\"", e.content)
+                } else {
+                    ctx.resolve_expression(e.content.as_str())
+                }
+            }
+            ExpressionNode::Compound(compound) => {
+                ctx.resolve_expression(compound.loc.source.as_str())
+            }
+        }
+    } else {
+        vize_carton::CompactString::from("undefined")
+    }
+}
+
+fn directive_modifiers(directive: &DirectiveIRNode<'_>) -> Option<String> {
+    if directive.dir.modifiers.is_empty() {
+        return None;
+    }
+
+    let modifiers = directive
+        .dir
+        .modifiers
+        .iter()
+        .map(|modifier| cstr!("{}: true", modifier.content))
+        .collect::<std::vec::Vec<_>>()
+        .join(", ");
+
+    Some(cstr!("{{ {} }}", modifiers))
+}
+
 /// Generate Directive
 pub(super) fn generate_directive(ctx: &mut GenerateContext, directive: &DirectiveIRNode<'_>) {
     let element = cstr!("n{}", directive.element);
@@ -29,48 +96,48 @@ pub(super) fn generate_directive(ctx: &mut GenerateContext, directive: &Directiv
         return;
     }
 
+    if directive.name.as_str() == "vCloak" {
+        ctx.push_line_fmt(format_args!("{element}.removeAttribute(\"v-cloak\")"));
+        return;
+    }
+
     // Handle v-model on elements
     if directive.name.as_str() == "model" {
         generate_v_model(ctx, directive);
         return;
     }
 
-    let name = &directive.name;
+    let value = directive_value(ctx, directive);
+    let arg = directive_arg(ctx, directive);
+    let modifiers = directive_modifiers(directive);
 
-    let arg = if let Some(ref arg) = directive.dir.arg {
-        match arg {
-            ExpressionNode::Simple(exp) => {
-                if exp.is_static {
-                    cstr!("\"{}\"", exp.content)
-                } else {
-                    vize_carton::CompactString::from(exp.content.as_str())
-                }
-            }
-            _ => vize_carton::CompactString::from("undefined"),
+    if directive.builtin {
+        let name = &directive.name;
+        match modifiers {
+            Some(modifiers) => ctx.push_line_fmt(format_args!(
+                "_withDirectives({}, [[_{}, {}, {}, {}]])",
+                element, name, value, arg, modifiers
+            )),
+            None => ctx.push_line_fmt(format_args!(
+                "_withDirectives({}, [[_{}, {}, {}]])",
+                element, name, value, arg
+            )),
         }
-    } else {
-        vize_carton::CompactString::from("undefined")
-    };
+        return;
+    }
 
-    let value = if let Some(ref exp) = directive.dir.exp {
-        match exp {
-            ExpressionNode::Simple(e) => {
-                if e.is_static {
-                    cstr!("\"{}\"", e.content)
-                } else {
-                    vize_carton::CompactString::from(e.content.as_str())
-                }
-            }
-            _ => vize_carton::CompactString::from("undefined"),
-        }
-    } else {
-        vize_carton::CompactString::from("undefined")
-    };
-
-    ctx.push_line_fmt(format_args!(
-        "_withDirectives({}, [[_{}, {}, {}]])",
-        element, name, value, arg
-    ));
+    ctx.use_helper("withDirectives");
+    let resolved = directive_resolution_var(directive.name.as_str());
+    match modifiers {
+        Some(modifiers) => ctx.push_line_fmt(format_args!(
+            "_withDirectives({}, [[{}, {}, {}, {}]])",
+            element, resolved, value, arg, modifiers
+        )),
+        None => ctx.push_line_fmt(format_args!(
+            "_withDirectives({}, [[{}, {}, {}]])",
+            element, resolved, value, arg
+        )),
+    }
 }
 
 /// Generate v-model for element

--- a/crates/vize_atelier_vapor/src/generate/setup.rs
+++ b/crates/vize_atelier_vapor/src/generate/setup.rs
@@ -24,6 +24,7 @@ pub(crate) fn generate_imports(ctx: &GenerateContext) -> String {
     // Define priority order for helpers (lower = earlier in import)
     fn helper_priority(name: &str) -> u32 {
         match name {
+            "resolveDirective" => 8,
             "resolveComponent" => 1,
             "createComponentWithFallback" => 2,
             "createComponent" => 3,
@@ -31,6 +32,7 @@ pub(crate) fn generate_imports(ctx: &GenerateContext) -> String {
             "VaporTeleport" => 5,
             "VaporKeepAlive" => 6,
             "withVaporCtx" => 7,
+            "withDirectives" => 46,
             "child" => 10,
             "next" => 11,
             "txt" => 20,

--- a/crates/vize_atelier_vapor/src/lib.rs
+++ b/crates/vize_atelier_vapor/src/lib.rs
@@ -948,6 +948,46 @@ selected</pre>"#,
     }
 
     #[test]
+    fn test_compile_custom_directive_preserves_payloads() {
+        let allocator = Bump::new();
+        let result = compile_vapor(
+            &allocator,
+            r#"<div v-focus:[placement].lazy="handler" />"#,
+            Default::default(),
+        );
+
+        assert!(
+            result.error_messages.is_empty(),
+            "Expected no errors: {:?}",
+            result.error_messages
+        );
+        assert_parses_as_module(&result.code);
+
+        let code = normalize_code(&result.code);
+        insta::assert_snapshot!(code.as_str());
+    }
+
+    #[test]
+    fn test_compile_v_cloak_uses_builtin_lowering() {
+        let allocator = Bump::new();
+        let result = compile_vapor(
+            &allocator,
+            r#"<div v-cloak>{{ msg }}</div>"#,
+            Default::default(),
+        );
+
+        assert!(
+            result.error_messages.is_empty(),
+            "Expected no errors: {:?}",
+            result.error_messages
+        );
+        assert_parses_as_module(&result.code);
+
+        let code = normalize_code(&result.code);
+        insta::assert_snapshot!(code.as_str());
+    }
+
+    #[test]
     fn test_compile_custom_renderer_intrinsics_with_bound_lowercase_component() {
         let allocator = Bump::new();
         let mut bindings = FxHashMap::default();

--- a/crates/vize_atelier_vapor/src/snapshots/vize_atelier_vapor__tests__compile_custom_directive_preserves_payloads.snap
+++ b/crates/vize_atelier_vapor/src/snapshots/vize_atelier_vapor__tests__compile_custom_directive_preserves_payloads.snap
@@ -1,0 +1,12 @@
+---
+source: crates/vize_atelier_vapor/src/lib.rs
+expression: code.as_str()
+---
+import { resolveDirective as _resolveDirective, withDirectives as _withDirectives, template as _template } from 'vue';
+const t0 = _template("<div></div>", true)
+export function render(_ctx) {
+const _directive_focus = _resolveDirective("focus")
+const n0 = t0()
+_withDirectives(n0, [[_directive_focus, _ctx.handler, _ctx.placement, { lazy: true }]])
+return n0
+}

--- a/crates/vize_atelier_vapor/src/snapshots/vize_atelier_vapor__tests__compile_v_cloak_uses_builtin_lowering.snap
+++ b/crates/vize_atelier_vapor/src/snapshots/vize_atelier_vapor__tests__compile_v_cloak_uses_builtin_lowering.snap
@@ -1,0 +1,13 @@
+---
+source: crates/vize_atelier_vapor/src/lib.rs
+expression: code.as_str()
+---
+import { txt as _txt, toDisplayString as _toDisplayString, setText as _setText, renderEffect as _renderEffect, template as _template } from 'vue';
+const t0 = _template("<div> </div>", true)
+export function render(_ctx) {
+const n0 = t0()
+const x0 = _txt(n0)
+n0.removeAttribute("v-cloak")
+_renderEffect(() => _setText(x0, _toDisplayString(_ctx.msg)))
+return n0
+}

--- a/crates/vize_atelier_vapor/src/transform/directive.rs
+++ b/crates/vize_atelier_vapor/src/transform/directive.rs
@@ -364,13 +364,7 @@ pub(crate) fn transform_directive<'a>(
         }
         "show" => {
             // v-show - builtin directive
-            let mut new_dir = DirectiveNode::new(ctx.allocator, dir.name.clone(), dir.loc.clone());
-            if let Some(ref exp) = dir.exp
-                && let ExpressionNode::Simple(s) = exp
-            {
-                let node = SimpleExpressionNode::new(s.content.clone(), s.is_static, s.loc.clone());
-                new_dir.exp = Some(ExpressionNode::Simple(Box::new_in(node, ctx.allocator)));
-            }
+            let new_dir = clone_directive(ctx, dir);
 
             let dir_node = DirectiveIRNode {
                 element: element_id,
@@ -383,28 +377,23 @@ pub(crate) fn transform_directive<'a>(
 
             block.operation.push(OperationNode::Directive(dir_node));
         }
+        "cloak" => {
+            let new_dir = clone_directive(ctx, dir);
+
+            let dir_node = DirectiveIRNode {
+                element: element_id,
+                dir: Box::new_in(new_dir, ctx.allocator),
+                name: vize_carton::String::from("vCloak"),
+                builtin: true,
+                tag: el.tag.clone(),
+                input_type: get_static_attr(el, "type"),
+            };
+
+            block.operation.push(OperationNode::Directive(dir_node));
+        }
         "model" => {
             // v-model - builtin directive
-            let mut new_dir = DirectiveNode::new(ctx.allocator, dir.name.clone(), dir.loc.clone());
-            if let Some(ref exp) = dir.exp
-                && let ExpressionNode::Simple(s) = exp
-            {
-                let node = SimpleExpressionNode::new(s.content.clone(), s.is_static, s.loc.clone());
-                new_dir.exp = Some(ExpressionNode::Simple(Box::new_in(node, ctx.allocator)));
-            }
-            if let Some(ref arg) = dir.arg
-                && let ExpressionNode::Simple(s) = arg
-            {
-                let node = SimpleExpressionNode::new(s.content.clone(), s.is_static, s.loc.clone());
-                new_dir.arg = Some(ExpressionNode::Simple(Box::new_in(node, ctx.allocator)));
-            }
-            for m in dir.modifiers.iter() {
-                new_dir.modifiers.push(SimpleExpressionNode::new(
-                    m.content.clone(),
-                    m.is_static,
-                    m.loc.clone(),
-                ));
-            }
+            let new_dir = clone_directive(ctx, dir);
 
             let dir_node = DirectiveIRNode {
                 element: element_id,
@@ -418,8 +407,8 @@ pub(crate) fn transform_directive<'a>(
             block.operation.push(OperationNode::Directive(dir_node));
         }
         _ => {
-            // Custom directive - create a copy of the directive
-            let new_dir = DirectiveNode::new(ctx.allocator, dir.name.clone(), dir.loc.clone());
+            // Custom directive - preserve the original payload for codegen parity.
+            let new_dir = clone_directive(ctx, dir);
 
             let dir_node = DirectiveIRNode {
                 element: element_id,
@@ -433,6 +422,47 @@ pub(crate) fn transform_directive<'a>(
             block.operation.push(OperationNode::Directive(dir_node));
         }
     }
+}
+
+fn clone_directive<'a>(ctx: &TransformContext<'a>, dir: &DirectiveNode<'a>) -> DirectiveNode<'a> {
+    let mut new_dir = DirectiveNode::new(ctx.allocator, dir.name.clone(), dir.loc.clone());
+    new_dir.raw_name = dir.raw_name.clone();
+    new_dir.shorthand = dir.shorthand;
+    new_dir.exp = clone_expression(ctx, dir.exp.as_ref());
+    new_dir.arg = clone_expression(ctx, dir.arg.as_ref());
+
+    for modifier in dir.modifiers.iter() {
+        new_dir.modifiers.push(SimpleExpressionNode::new(
+            modifier.content.clone(),
+            modifier.is_static,
+            modifier.loc.clone(),
+        ));
+    }
+
+    new_dir
+}
+
+fn clone_expression<'a>(
+    ctx: &TransformContext<'a>,
+    expr: Option<&ExpressionNode<'a>>,
+) -> Option<ExpressionNode<'a>> {
+    let expr = expr?;
+
+    Some(match expr {
+        ExpressionNode::Simple(simple) => {
+            let cloned = SimpleExpressionNode::new(
+                simple.content.clone(),
+                simple.is_static,
+                simple.loc.clone(),
+            );
+            ExpressionNode::Simple(Box::new_in(cloned, ctx.allocator))
+        }
+        ExpressionNode::Compound(compound) => {
+            let cloned =
+                SimpleExpressionNode::new(compound.loc.source.clone(), false, compound.loc.clone());
+            ExpressionNode::Simple(Box::new_in(cloned, ctx.allocator))
+        }
+    })
 }
 
 /// Check if an event can use delegation


### PR DESCRIPTION
## Summary
- preserve custom directive value, arg, and modifiers when lowering Vapor directives
- lower `v-cloak` as Vapor built-in behavior instead of resolving it as a user directive
- add focused Vapor snapshots for custom directive payloads and `v-cloak`

## Root cause
The Vapor directive transform rebuilt custom directives without copying their payload fields, and `v-cloak` fell through the custom-directive path instead of using built-in lowering.

## Verification
- `cargo test -p vize_atelier_vapor custom_directive_preserves_payloads`
- `cargo test -p vize_atelier_vapor v_cloak_uses_builtin_lowering`
- `cargo test -p vize_atelier_vapor`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1238"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783585161&installation_id=136613492&pr_number=1238&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1238&signature=d8c8ff85f7e44062f99dac084285d5e8a76372092949dae73352bce202984e3b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->