### PR TITLE
fix(vize_patina): require href for anchor focusability

### DIFF
--- a/crates/vize_patina/src/rules/a11y/helpers.rs
+++ b/crates/vize_patina/src/rules/a11y/helpers.rs
@@ -77,11 +77,12 @@ pub fn is_interactive_role(role: &str) -> bool {
 pub fn is_focusable_element(element: &ElementNode) -> bool {
     let tag = element.tag.as_str();
 
+    if matches!(tag, "a" | "area") && has_named_prop(element, "href") {
+        return true;
+    }
+
     // Natively focusable elements
-    if matches!(
-        tag,
-        "a" | "button" | "input" | "select" | "textarea" | "summary"
-    ) {
+    if matches!(tag, "button" | "input" | "select" | "textarea" | "summary") {
         return true;
     }
 
@@ -102,6 +103,19 @@ pub fn is_focusable_element(element: &ElementNode) -> bool {
     }
 
     false
+}
+
+fn has_named_prop(element: &ElementNode, name: &str) -> bool {
+    element.props.iter().any(|prop| match prop {
+        PropNode::Attribute(attr) => attr.name == name,
+        PropNode::Directive(dir) if dir.name == "bind" => {
+            matches!(
+                dir.arg.as_ref(),
+                Some(ExpressionNode::Simple(arg)) if arg.content == name
+            )
+        }
+        _ => false,
+    })
 }
 
 /// Get the static (non-dynamic) value of an attribute on an element.

--- a/crates/vize_patina/src/rules/a11y/no_aria_hidden_on_focusable.rs
+++ b/crates/vize_patina/src/rules/a11y/no_aria_hidden_on_focusable.rs
@@ -70,6 +70,28 @@ mod tests {
     }
 
     #[test]
+    fn test_valid_aria_hidden_on_anchor_without_href() {
+        let linter = create_linter();
+        let result = linter.lint_template(r#"<a aria-hidden="true">decorative</a>"#, "test.vue");
+        assert_eq!(result.error_count, 0);
+    }
+
+    #[test]
+    fn test_invalid_aria_hidden_on_anchor_with_href() {
+        let linter = create_linter();
+        let result = linter.lint_template(r#"<a href="/" aria-hidden="true">Home</a>"#, "test.vue");
+        assert_eq!(result.error_count, 1);
+    }
+
+    #[test]
+    fn test_invalid_aria_hidden_on_anchor_with_bound_href() {
+        let linter = create_linter();
+        let result =
+            linter.lint_template(r#"<a :href="url" aria-hidden="true">Home</a>"#, "test.vue");
+        assert_eq!(result.error_count, 1);
+    }
+
+    #[test]
     fn test_invalid_aria_hidden_on_button() {
         let linter = create_linter();
         let result =

--- a/crates/vize_patina/src/rules/a11y/no_role_presentation_on_focusable.rs
+++ b/crates/vize_patina/src/rules/a11y/no_role_presentation_on_focusable.rs
@@ -70,6 +70,29 @@ mod tests {
     }
 
     #[test]
+    fn test_valid_role_presentation_on_anchor_without_href() {
+        let linter = create_linter();
+        let result = linter.lint_template(r#"<a role="presentation">decorative</a>"#, "test.vue");
+        assert_eq!(result.error_count, 0);
+    }
+
+    #[test]
+    fn test_invalid_role_presentation_on_anchor_with_href() {
+        let linter = create_linter();
+        let result =
+            linter.lint_template(r#"<a href="/" role="presentation">Home</a>"#, "test.vue");
+        assert_eq!(result.error_count, 1);
+    }
+
+    #[test]
+    fn test_invalid_role_presentation_on_anchor_with_bound_href() {
+        let linter = create_linter();
+        let result =
+            linter.lint_template(r#"<a :href="url" role="presentation">Home</a>"#, "test.vue");
+        assert_eq!(result.error_count, 1);
+    }
+
+    #[test]
     fn test_invalid_role_presentation_on_button() {
         let linter = create_linter();
         let result =


### PR DESCRIPTION
## Summary
- Treat `<a>` and `<area>` as focusable only when they declare `href` or `:href`.
- Keep other native focusable elements unchanged.
- Add regressions for hrefless anchors and href-bound anchors in both focusable a11y rules.

## Verification
- `cargo fmt --all -- --check`
- `cargo test -p vize_patina no_aria_hidden_on_focusable -- --nocapture`
- `cargo test -p vize_patina no_role_presentation_on_focusable -- --nocapture`
- `cargo clippy -p vize_patina --lib -- -D warnings`

Fixes #1199
