### PR TITLE
fix(check): respect quirks template syntax config

### DIFF
--- a/crates/vize/src/commands/check/runner.rs
+++ b/crates/vize/src/commands/check/runner.rs
@@ -76,6 +76,10 @@ pub(crate) fn run_direct(args: &CheckArgs) {
     } else {
         crate::config::load_config_with_features_and_source(args.config.as_deref())
     };
+    let compiler_template_syntax = loaded_config
+        .source_path
+        .as_deref()
+        .and_then(|path| crate::config::load_compiler_template_syntax(Some(path)));
     // Vue 3 Options API binding resolution is officially supported and is a
     // standard-build opt-in (not the `legacy` feature).
     let options_api = loaded_config.features.type_checker_options_api;
@@ -261,6 +265,7 @@ pub(crate) fn run_direct(args: &CheckArgs) {
     if legacy_vue2 {
         checker.enable_legacy_vue2();
     }
+    checker.set_template_syntax(template_syntax_mode(compiler_template_syntax));
     checker.set_virtual_ts_checks(
         config.type_checker.check_props && !args.no_check_props,
         config.type_checker.check_template_bindings && !args.no_check_template_bindings,
@@ -982,6 +987,15 @@ fn build_virtual_ts_options(
     vize_canon::virtual_ts::VirtualTsOptions {
         template_globals,
         ..Default::default()
+    }
+}
+
+fn template_syntax_mode(template_syntax: Option<&str>) -> vize_atelier_core::TemplateSyntaxMode {
+    match template_syntax {
+        Some("strict") => vize_atelier_core::TemplateSyntaxMode::Strict,
+        Some("quirks") => vize_atelier_core::TemplateSyntaxMode::Quirks,
+        Some("standard") | None => vize_atelier_core::TemplateSyntaxMode::Standard,
+        Some(_) => vize_atelier_core::TemplateSyntaxMode::Standard,
     }
 }
 

--- a/crates/vize/tests/check_cli.rs
+++ b/crates/vize/tests/check_cli.rs
@@ -1504,6 +1504,63 @@ const count = 1;
 }
 
 #[test]
+fn check_respects_configured_template_syntax_quirks() {
+    let Some(corsa_path) = resolve_test_corsa_path() else {
+        return;
+    };
+    let project_root = create_cli_project(
+        "configured-template-syntax-quirks",
+        &[(
+            "src/App.vue",
+            r#"<script setup lang="ts">
+defineProps<{
+  test: string
+}>()
+</script>
+
+<template>
+  <div />
+</template>
+"#,
+        )],
+    );
+    std::fs::write(
+        project_root.join("vize.config.json"),
+        r#"{
+  "compiler": {
+    "templateSyntax": "quirks"
+  }
+}"#,
+    )
+    .unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(&project_root)
+        .env("CORSA_PATH", corsa_path)
+        .args(["check", "src/App.vue", "--format", "json"])
+        .output()
+        .unwrap();
+
+    let stdout = std::string::String::from_utf8(output.stdout).unwrap();
+    let stderr = std::string::String::from_utf8(output.stderr).unwrap();
+    let json: serde_json::Value = serde_json::from_str(&stdout).unwrap_or_else(|error| {
+        panic!("failed to parse stdout as JSON: {error}\nstdout:\n{stdout}\nstderr:\n{stderr}")
+    });
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "stdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert_eq!(
+        json["errorCount"], 0,
+        "stdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}
+
+#[test]
 fn lint_type_aware_rules_respect_configured_corsa_path() {
     let project_root = create_cli_project(
         "lint-configured-corsa-path",

--- a/crates/vize_canon/src/batch/type_checker.rs
+++ b/crates/vize_canon/src/batch/type_checker.rs
@@ -168,6 +168,11 @@ impl BatchTypeChecker {
             });
     }
 
+    /// Configure template syntax compatibility for Vue template parsing.
+    pub fn set_template_syntax(&mut self, template_syntax: vize_atelier_core::TemplateSyntaxMode) {
+        self.project.set_template_syntax(template_syntax);
+    }
+
     /// Scan an explicit set of project files.
     ///
     /// The underlying virtual project parallelizes registration for multi-file

--- a/crates/vize_canon/src/batch/virtual_project/build.rs
+++ b/crates/vize_canon/src/batch/virtual_project/build.rs
@@ -6,6 +6,7 @@
 use std::path::{Path, PathBuf};
 
 use oxc_span::SourceType;
+use vize_atelier_core::TemplateSyntaxMode;
 use vize_carton::{String as CompactString, ToCompactString, cstr, profile};
 
 use vize_atelier_sfc::{SfcDescriptor, SfcParseOptions, parse_sfc};
@@ -19,7 +20,7 @@ use crate::virtual_ts::{VirtualTsCheckOptions, VirtualTsOptions};
 use super::VirtualFile;
 use super::diagnostics::collect_sfc_block_ranges;
 use super::passthrough::collect_passthrough_json_modules;
-use super::vue_codegen::{GeneratedVueFile, generate_vue_virtual_ts};
+use super::vue_codegen::{GeneratedVueFile, VueCodegenOptions, generate_vue_virtual_ts};
 
 /// Result of building a virtual file for a registered path, owned and
 /// independent of any `&mut VirtualProject` so it can be produced in parallel.
@@ -41,6 +42,7 @@ pub(super) struct VirtualBuildContext<'a> {
     pub(super) virtual_ts_check_options: VirtualTsCheckOptions,
     pub(super) options_api: bool,
     pub(super) legacy_vue2: bool,
+    pub(super) template_syntax: TemplateSyntaxMode,
     pub(super) rewriter: &'a ImportRewriter,
 }
 
@@ -107,9 +109,12 @@ pub(super) fn build_vue_registered_file(
             content,
             &descriptor,
             &effective_options,
-            context.virtual_ts_check_options,
-            context.options_api,
-            context.legacy_vue2,
+            VueCodegenOptions {
+                check_options: context.virtual_ts_check_options,
+                options_api: context.options_api,
+                legacy_vue2: context.legacy_vue2,
+                template_syntax: context.template_syntax,
+            },
         )
     )?;
     let GeneratedVueFile {

--- a/crates/vize_canon/src/batch/virtual_project/mod.rs
+++ b/crates/vize_canon/src/batch/virtual_project/mod.rs
@@ -16,6 +16,7 @@
 
 use std::path::PathBuf;
 
+use vize_atelier_core::TemplateSyntaxMode;
 use vize_carton::{FxHashMap, String as CompactString};
 
 use super::import_rewriter::ImportRewriter;
@@ -85,6 +86,9 @@ pub struct VirtualProject {
     /// Enable Vue 2.7 / Nuxt 2 Options API compatibility for virtual files.
     options_api: bool,
     legacy_vue2: bool,
+
+    /// Template syntax compatibility used when parsing SFC templates.
+    template_syntax: TemplateSyntaxMode,
 
     /// Virtual files keyed by materialized path.
     virtual_files: FxHashMap<PathBuf, VirtualFile>,

--- a/crates/vize_canon/src/batch/virtual_project/project.rs
+++ b/crates/vize_canon/src/batch/virtual_project/project.rs
@@ -7,6 +7,7 @@ use std::path::{Path, PathBuf};
 
 use oxc_span::SourceType;
 use rayon::prelude::*;
+use vize_atelier_core::TemplateSyntaxMode;
 use vize_carton::{FxHashMap, profile};
 
 use crate::batch::error::{CorsaError, CorsaResult};
@@ -38,6 +39,7 @@ impl VirtualProject {
             virtual_ts_check_options: VirtualTsCheckOptions::default(),
             options_api: false,
             legacy_vue2: false,
+            template_syntax: TemplateSyntaxMode::default(),
             virtual_files: FxHashMap::default(),
             passthrough_files: FxHashMap::default(),
             original_index: FxHashMap::default(),
@@ -69,6 +71,10 @@ impl VirtualProject {
         self.legacy_vue2 = enabled;
     }
 
+    pub(crate) fn set_template_syntax(&mut self, template_syntax: TemplateSyntaxMode) {
+        self.template_syntax = template_syntax;
+    }
+
     /// Get the project root.
     pub fn project_root(&self) -> &Path {
         &self.project_root
@@ -97,6 +103,7 @@ impl VirtualProject {
                 virtual_ts_check_options: self.virtual_ts_check_options,
                 options_api: self.options_api,
                 legacy_vue2: self.legacy_vue2,
+                template_syntax: self.template_syntax,
                 rewriter: &self.rewriter,
             },
         )?;
@@ -139,6 +146,7 @@ impl VirtualProject {
             virtual_ts_check_options: self.virtual_ts_check_options,
             options_api: self.options_api,
             legacy_vue2: self.legacy_vue2,
+            template_syntax: self.template_syntax,
             rewriter: &self.rewriter,
         };
 
@@ -169,6 +177,7 @@ impl VirtualProject {
                 virtual_ts_check_options: self.virtual_ts_check_options,
                 options_api: self.options_api,
                 legacy_vue2: self.legacy_vue2,
+                template_syntax: self.template_syntax,
                 rewriter: &self.rewriter,
             },
         )?;

--- a/crates/vize_canon/src/batch/virtual_project/tests.rs
+++ b/crates/vize_canon/src/batch/virtual_project/tests.rs
@@ -5,6 +5,7 @@ use crate::batch::SfcBlockType;
 use crate::virtual_ts::VirtualTsOptions;
 use std::fs;
 use std::path::{Path, PathBuf};
+use vize_atelier_core::TemplateSyntaxMode;
 use vize_carton::cstr;
 
 fn unique_case_dir(name: &str) -> PathBuf {
@@ -114,6 +115,39 @@ export default defineComponent({
     let virtual_file = project.find_by_original(&vue_path).unwrap();
     insta::assert_snapshot!(virtual_file.content.as_str());
     assert_ts_parses(virtual_file.content.as_str());
+
+    let _ = fs::remove_dir_all(&case_dir);
+}
+
+#[test]
+fn test_register_vue_file_respects_template_syntax_quirks() {
+    let case_dir = unique_case_dir("template-syntax-quirks");
+    let _ = fs::remove_dir_all(&case_dir);
+    let src_dir = case_dir.join("src");
+    fs::create_dir_all(&src_dir).unwrap();
+    let vue_path = src_dir.join("App.vue");
+    let vue_content = r#"<script setup lang="ts">
+defineProps<{
+  test: string
+}>()
+</script>
+
+<template>
+  <div />
+</template>
+"#;
+    fs::write(&vue_path, vue_content).unwrap();
+
+    let mut project = VirtualProject::new(&case_dir).unwrap();
+    project.set_template_syntax(TemplateSyntaxMode::Quirks);
+    project.register_path(&vue_path).unwrap();
+
+    assert!(
+        project.diagnostics().is_empty(),
+        "{:#?}",
+        project.diagnostics()
+    );
+    assert!(project.find_by_original(&vue_path).is_some());
 
     let _ = fs::remove_dir_all(&case_dir);
 }

--- a/crates/vize_canon/src/batch/virtual_project/vue_codegen.rs
+++ b/crates/vize_canon/src/batch/virtual_project/vue_codegen.rs
@@ -7,7 +7,9 @@ use std::path::Path;
 
 use vize_carton::{Bump, FxHashSet, String as CompactString, cstr, profile};
 
-use vize_atelier_core::parser::parse;
+use vize_atelier_core::{
+    ParserOptions, TemplateSyntaxMode, parser::parse_with_options_and_template_syntax,
+};
 use vize_atelier_sfc::{
     SfcDescriptor,
     croquis::{
@@ -36,14 +38,20 @@ pub(super) struct GeneratedVueFile {
     pub(super) diagnostics: Vec<Diagnostic>,
 }
 
+#[derive(Clone, Copy)]
+pub(super) struct VueCodegenOptions {
+    pub(super) check_options: VirtualTsCheckOptions,
+    pub(super) options_api: bool,
+    pub(super) legacy_vue2: bool,
+    pub(super) template_syntax: TemplateSyntaxMode,
+}
+
 pub(super) fn generate_vue_virtual_ts(
     path: &Path,
     source: &str,
     descriptor: &SfcDescriptor,
     options: &VirtualTsOptions,
-    check_options: VirtualTsCheckOptions,
-    options_api: bool,
-    legacy_vue2: bool,
+    codegen_options: VueCodegenOptions,
 ) -> CorsaResult<GeneratedVueFile> {
     let allocator = Bump::new();
     let mut diagnostics = Vec::new();
@@ -87,7 +95,12 @@ pub(super) fn generate_vue_virtual_ts(
         .unwrap_or(0);
     let template_ast = descriptor.template.as_ref().and_then(|template| {
         profile!("canon.template.parse", {
-            let (root, errors) = parse(&allocator, &template.content);
+            let (root, errors) = parse_with_options_and_template_syntax(
+                &allocator,
+                &template.content,
+                ParserOptions::default(),
+                codegen_options.template_syntax,
+            );
             if errors.is_empty() {
                 Some(root)
             } else {
@@ -122,13 +135,13 @@ pub(super) fn generate_vue_virtual_ts(
 
     let analysis = profile!(
         "canon.croquis.analyze_sfc",
-        if legacy_vue2 {
+        if codegen_options.legacy_vue2 {
             analyze_sfc_descriptor_with_context_legacy_vue2(
                 descriptor,
                 template_ast.as_ref(),
                 croquis_options,
             )
-        } else if options_api {
+        } else if codegen_options.options_api {
             analyze_sfc_descriptor_with_context_options_api(
                 descriptor,
                 template_ast.as_ref(),
@@ -158,9 +171,9 @@ pub(super) fn generate_vue_virtual_ts(
             template_offset,
             options,
             VirtualTsGenerationOptions {
-                check_options,
-                options_api,
-                legacy_vue2,
+                check_options: codegen_options.check_options,
+                options_api: codegen_options.options_api,
+                legacy_vue2: codegen_options.legacy_vue2,
             },
         )
     );

--- a/crates/vize_carton/src/config.rs
+++ b/crates/vize_carton/src/config.rs
@@ -5,7 +5,7 @@ mod model;
 mod normalize;
 
 pub use loader::{
-    LoadedConfig, LoadedConfigWithFeatures, load_config,
+    LoadedConfig, LoadedConfigWithFeatures, load_compiler_template_syntax, load_config,
     load_config_and_linter_with_features_and_source, load_config_and_linter_with_source,
     load_config_with_features_and_source, load_config_with_source, load_linter_config,
     validate_explicit_config_path,

--- a/crates/vize_carton/src/config/loader.rs
+++ b/crates/vize_carton/src/config/loader.rs
@@ -118,6 +118,15 @@ pub fn load_config_with_features_and_source(path: Option<&Path>) -> LoadedConfig
     }
 }
 
+/// Load the configured `compiler.templateSyntax` value from a directory or file path.
+pub fn load_compiler_template_syntax(path: Option<&Path>) -> Option<&'static str> {
+    load_raw_config_with_source(path)
+        .config
+        .compiler
+        .template_syntax
+        .map(|template_syntax| template_syntax.as_str())
+}
+
 /// Load configuration and linter settings from a directory or file path in one pass.
 ///
 /// The lint/check CLIs call this on every invocation. Keeping the raw config

--- a/crates/vize_carton/src/config/loader/tests.rs
+++ b/crates/vize_carton/src/config/loader/tests.rs
@@ -1,6 +1,6 @@
 use super::{
-    load_config_and_linter_with_source, load_config_with_source, load_linter_config,
-    validate_explicit_config_path,
+    load_compiler_template_syntax, load_config_and_linter_with_source, load_config_with_source,
+    load_linter_config, validate_explicit_config_path,
 };
 
 #[test]
@@ -62,6 +62,22 @@ fn load_config_uses_explicit_file_path() {
     let loaded = load_config_with_source(Some(&config_path));
     assert_eq!(loaded.source_path.as_deref(), Some(config_path.as_path()));
     assert!(loaded.config.formatter.single_quote);
+}
+
+#[test]
+fn load_config_reads_compiler_template_syntax() {
+    let dir = tempfile::tempdir().unwrap();
+    let config_path = dir.path().join("vize.config.json");
+    std::fs::write(
+        &config_path,
+        r#"{ "compiler": { "templateSyntax": "quirks" } }"#,
+    )
+    .unwrap();
+
+    assert_eq!(
+        load_compiler_template_syntax(Some(&config_path)),
+        Some("quirks")
+    );
 }
 
 #[test]

--- a/crates/vize_carton/src/config/model.rs
+++ b/crates/vize_carton/src/config/model.rs
@@ -1,5 +1,6 @@
 //! Shared config model.
 
+mod compiler;
 mod formatter;
 mod global_types;
 mod language_server;
@@ -8,8 +9,9 @@ mod type_checker;
 
 use serde::{Deserialize, Serialize};
 
-use crate::String;
+use compiler::RawCompilerConfig;
 
+use crate::String;
 pub use formatter::{
     ArrowParens, AttributeSortOrder, EndOfLine, FormatterConfig, QuoteProps, TrailingComma,
 };
@@ -67,6 +69,7 @@ pub(crate) struct RawVizeConfig {
     #[serde(rename = "$schema")]
     pub schema: Option<String>,
     pub formatter: FormatterConfig,
+    pub(crate) compiler: RawCompilerConfig,
     pub linter: LinterConfig,
     #[serde(rename = "typeChecker")]
     type_checker: RawTypeCheckerConfig,
@@ -116,6 +119,7 @@ impl RawVizeConfig {
         let RawVizeConfig {
             schema,
             formatter,
+            compiler: _,
             linter: _,
             type_checker: raw_type_checker,
             language_server: raw_language_server,

--- a/crates/vize_carton/src/config/model/compiler.rs
+++ b/crates/vize_carton/src/config/model/compiler.rs
@@ -1,0 +1,28 @@
+//! Compiler config model.
+
+use serde::Deserialize;
+
+/// Template syntax compatibility mode from `compiler.templateSyntax`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub(crate) enum RawTemplateSyntaxConfig {
+    Standard,
+    Strict,
+    Quirks,
+}
+
+impl RawTemplateSyntaxConfig {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Standard => "standard",
+            Self::Strict => "strict",
+            Self::Quirks => "quirks",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default, rename_all = "camelCase")]
+pub(crate) struct RawCompilerConfig {
+    pub(crate) template_syntax: Option<RawTemplateSyntaxConfig>,
+}


### PR DESCRIPTION
## Summary

- Parse compiler.templateSyntax from vize config files.
- Pass quirks/strict/standard through vize check virtual TS generation.
- Parse check templates with the configured template syntax so quirks accepts out-of-spec self-closing HTML tags.

Fixes #1239

## Tests

- cargo test -p vize_carton load_config_reads_compiler_template_syntax
- cargo test -p vize_canon test_register_vue_file_respects_template_syntax_quirks
- cargo test -p vize --test check_cli check_respects_configured_template_syntax_quirks
- cargo fmt --all -- --check