### PR TITLE
fix(armature): treat literal less-than text without errors

### DIFF
--- a/crates/vize_armature/src/parser/element.rs
+++ b/crates/vize_armature/src/parser/element.rs
@@ -49,9 +49,16 @@ impl<'a> Parser<'a> {
             return;
         }
 
-        let merge_start_off = match self.stack.last().and_then(|e| e.element.children.last()) {
-            Some(TemplateChildNode::Text(t)) => Some(t.loc.start.offset as usize),
-            _ => None,
+        let merge_start_off = if let Some(entry) = self.stack.last() {
+            match entry.element.children.last() {
+                Some(TemplateChildNode::Text(t)) => Some(t.loc.start.offset as usize),
+                _ => None,
+            }
+        } else {
+            match self.root.as_ref().and_then(|root| root.children.last()) {
+                Some(TemplateChildNode::Text(t)) => Some(t.loc.start.offset as usize),
+                _ => None,
+            }
         };
 
         if let Some(merge_start) = merge_start_off {
@@ -59,6 +66,12 @@ impl<'a> Parser<'a> {
             let source_span = self.get_source(merge_start, end).into();
             if let Some(entry) = self.stack.last_mut()
                 && let Some(TemplateChildNode::Text(text_node)) = entry.element.children.last_mut()
+            {
+                text_node.content.push_str(content);
+                text_node.loc.end = end_pos;
+                text_node.loc.source = source_span;
+            } else if let Some(root) = self.root.as_mut()
+                && let Some(TemplateChildNode::Text(text_node)) = root.children.last_mut()
             {
                 text_node.content.push_str(content);
                 text_node.loc.end = end_pos;

--- a/crates/vize_armature/src/parser/tests.rs
+++ b/crates/vize_armature/src/parser/tests.rs
@@ -54,6 +54,40 @@ fn test_parse_text() {
 }
 
 #[test]
+fn test_parse_less_than_before_non_tag_start_keeps_root_text_merged() {
+    for source in ["a < b", "< b", "5 < 3 && 3 > 1", "<1div>"] {
+        let allocator = Bump::new();
+        let (root, errors) = parse(&allocator, source);
+
+        assert!(errors.is_empty(), "{source}: {errors:?}");
+        assert_eq!(root.children.len(), 1, "{source}");
+        if let TemplateChildNode::Text(text) = &root.children[0] {
+            assert_eq!(text.content.as_str(), source);
+        } else {
+            panic!("{source}: expected text node");
+        }
+    }
+}
+
+#[test]
+fn test_parse_less_than_before_non_tag_start_inside_element_has_no_error() {
+    let allocator = Bump::new();
+    let (root, errors) = parse(&allocator, "<div>price < 100</div>");
+
+    assert!(errors.is_empty(), "{errors:?}");
+    if let TemplateChildNode::Element(el) = &root.children[0] {
+        assert_eq!(el.children.len(), 1);
+        if let TemplateChildNode::Text(text) = &el.children[0] {
+            assert_eq!(text.content.as_str(), "price < 100");
+        } else {
+            panic!("expected text child, got {:?}", el.children[0]);
+        }
+    } else {
+        panic!("expected element root");
+    }
+}
+
+#[test]
 fn test_parse_condense_whitespace_collapses_runs_inside_text_nodes() {
     // Regression for #960: `whitespace: 'condense'` (the default) must
     // collapse runs of `[ \t\n\f\r]` to a single U+0020 inside text
@@ -966,9 +1000,9 @@ fn test_parse_unfinished_interpolation_reports_error_but_keeps_text() {
 }
 
 #[test]
-fn test_parse_invalid_tag_name_reports_error_and_continues() {
+fn test_parse_invalid_closing_tag_name_reports_error_and_continues() {
     let allocator = Bump::new();
-    let (root, errors) = parse(&allocator, "<1div></1div><span></span>");
+    let (root, errors) = parse(&allocator, "</1div><span></span>");
 
     assert!(
         errors
@@ -994,11 +1028,6 @@ fn test_parse_mixed_broken_input_keeps_later_nodes() {
             MissingDirectiveName,
             "Directive `v-` is missing a name. Ignoring it so the rest of the tag can be parsed.",
             "v-",
-        ),
-        (
-            InvalidFirstCharacterOfTagName,
-            "Tag name starts with an invalid character; treating the malformed tag as text.",
-            "1",
         ),
         (
             InvalidFirstCharacterOfTagName,

--- a/crates/vize_armature/src/tokenizer/states.rs
+++ b/crates/vize_armature/src/tokenizer/states.rs
@@ -269,8 +269,6 @@ impl<'a, C: Callbacks> Tokenizer<'a, C> {
         } else if c == SLASH {
             self.state = State::BeforeClosingTagName;
         } else {
-            self.callbacks
-                .on_error(ErrorCode::InvalidFirstCharacterOfTagName, self.index);
             self.state = State::Text;
             self.state_text(c);
         }

--- a/crates/vize_armature/src/tokenizer/tests.rs
+++ b/crates/vize_armature/src/tokenizer/tests.rs
@@ -183,6 +183,23 @@ fn test_text() {
     assert!(cb.events.contains(&TokenEvent::End));
 }
 
+#[test]
+fn test_less_than_before_non_tag_start_is_literal_text() {
+    let cb = tokenize("a < b");
+
+    assert!(cb.errors.is_empty(), "{:?}", cb.errors);
+    assert!(cb.events.contains(&TokenEvent::Text(0, 2)));
+    assert!(cb.events.contains(&TokenEvent::Text(2, 5)));
+}
+
+#[test]
+fn test_less_than_digit_is_literal_text() {
+    let cb = tokenize("<1div>");
+
+    assert!(cb.errors.is_empty(), "{:?}", cb.errors);
+    assert!(cb.events.contains(&TokenEvent::Text(0, 6)));
+}
+
 // ========================================================================
 // Element tests
 // ========================================================================


### PR DESCRIPTION
## Summary
- Treat `<` followed by a non-tag-start character as literal text without emitting `InvalidFirstCharacterOfTagName`.
- Merge adjacent root-level text runs so tokenizer fallback text remains a single root text node.
- Add tokenizer and parser regressions for literal less-than text.

## Tests
- `cargo test -p vize_armature`
- `cargo fmt --all -- --check`

Fixes #1182