### PR TITLE
fix(linter): surface template parser errors

### DIFF
--- a/crates/vize/src/commands/lint.rs
+++ b/crates/vize/src/commands/lint.rs
@@ -752,8 +752,13 @@ fn analyze_sfc_for_cross_file(
         offsets.template = template.loc.start as u32;
         let allocator = Allocator::with_capacity((template.content.len() * 4).max(64 * 1024));
         let parser = Parser::new(allocator.as_bump(), template.content.as_ref());
-        let (root, _parse_errors) = parser.parse();
-        analyze_sfc_descriptor(&descriptor, Some(&root), SfcCroquisOptions::full())
+        let (root, parse_errors) = parser.parse();
+        let template_ast = if parse_errors.iter().any(|error| !error.is_recoverable()) {
+            None
+        } else {
+            Some(&root)
+        };
+        analyze_sfc_descriptor(&descriptor, template_ast, SfcCroquisOptions::full())
     } else {
         analyze_sfc_descriptor(&descriptor, None, SfcCroquisOptions::full())
     };
@@ -1047,6 +1052,49 @@ const ready = true
         let expected_start = first_source.find("id=\"email\"").unwrap() as u32;
         assert_eq!(diagnostic.start, expected_start);
         assert!(diagnostic.end > diagnostic.start);
+    }
+
+    #[test]
+    fn cross_file_opt_in_skips_template_ast_after_fatal_parse_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let malformed = dir.path().join("Malformed.vue");
+        let valid = dir.path().join("Valid.vue");
+
+        fs::write(
+            &malformed,
+            r#"<template>
+  <div>
+    <input id="email">
+</template>
+"#,
+        )
+        .unwrap();
+        fs::write(
+            &valid,
+            r#"<template>
+  <input id="email" />
+</template>
+"#,
+        )
+        .unwrap();
+
+        let files = [&malformed, &valid]
+            .into_iter()
+            .map(|path| (path.to_path_buf(), fs::read_to_string(path).unwrap()))
+            .collect::<Vec<_>>();
+        let output = build_cross_file_lint_output(&files, vize_patina::HelpLevel::Short, false);
+
+        let diagnostics = output
+            .results
+            .iter()
+            .flat_map(|result| result.diagnostics.iter())
+            .collect::<Vec<_>>();
+        assert!(
+            diagnostics
+                .iter()
+                .all(|diagnostic| !diagnostic.message.contains("duplicate-id")),
+            "malformed templates should not contribute cross-file template facts: {diagnostics:?}"
+        );
     }
 
     #[test]

--- a/crates/vize_patina/src/linter/engine.rs
+++ b/crates/vize_patina/src/linter/engine.rs
@@ -4,7 +4,10 @@
 //! full SFC linting with template extraction, and batch file processing.
 
 use crate::{
-    context::LintContext, diagnostic::LintSummary, preset::LintPreset, visitor::LintVisitor,
+    context::LintContext,
+    diagnostic::{LintDiagnostic, LintSummary, Severity},
+    preset::LintPreset,
+    visitor::LintVisitor,
 };
 use vize_armature::Parser;
 use vize_atelier_sfc::croquis::{SfcCroquisOptions, analyze_sfc_descriptor};
@@ -14,9 +17,67 @@ use vize_carton::String;
 use vize_carton::ToCompactString;
 use vize_carton::profile;
 use vize_croquis::{Analyzer, Croquis};
-use vize_relief::ast::RootNode;
+use vize_relief::{CompilerError, ErrorCode, ast::RootNode};
 
 use super::config::{LintResult, Linter};
+
+const TEMPLATE_PARSE_RULE: &str = "parser/template";
+const INVALID_SELF_CLOSING_HTML_MESSAGE: &str =
+    "Invalid self-closing syntax on non-void HTML element";
+
+pub(crate) enum TemplateAnalysis<'a> {
+    Disabled,
+    Precomputed(&'a Croquis),
+    Lazy,
+}
+
+pub(crate) struct SfcTemplateLintInput<'a> {
+    pub filename: &'a str,
+    pub template: &'a vize_atelier_sfc::SfcTemplateBlock<'a>,
+    pub allocator: &'a Allocator,
+    pub root: &'a RootNode<'a>,
+    pub descriptor: Option<&'a vize_atelier_sfc::SfcDescriptor<'a>>,
+    pub analysis: TemplateAnalysis<'a>,
+}
+
+fn template_parse_diagnostic(parse_error: &CompilerError, source_len: usize) -> LintDiagnostic {
+    let (start, end) = template_parse_span(parse_error, source_len);
+    if parse_error.is_recoverable() {
+        LintDiagnostic::warn(TEMPLATE_PARSE_RULE, parse_error.message.clone(), start, end)
+    } else {
+        LintDiagnostic::error(TEMPLATE_PARSE_RULE, parse_error.message.clone(), start, end)
+    }
+}
+
+fn should_report_template_parse_diagnostic(parse_error: &CompilerError) -> bool {
+    // Standard mode rewrites invalid HTML self-closing syntax as a compatibility
+    // warning. Lint surfaces parser errors, but should not turn this rewrite
+    // notice into a project warning budget failure.
+    !(parse_error.code == ErrorCode::ExtendPoint
+        && parse_error
+            .message
+            .starts_with(INVALID_SELF_CLOSING_HTML_MESSAGE))
+}
+
+fn template_parse_span(parse_error: &CompilerError, source_len: usize) -> (u32, u32) {
+    if source_len == 0 {
+        return (0, 0);
+    }
+
+    let source_len = source_len as u32;
+    let (raw_start, raw_end) = parse_error
+        .loc
+        .as_ref()
+        .map(|loc| (loc.start.offset, loc.end.offset))
+        .unwrap_or((0, 0));
+    let start = raw_start.min(source_len.saturating_sub(1));
+    let end = raw_end
+        .max(raw_start.saturating_add(1))
+        .max(start.saturating_add(1))
+        .min(source_len);
+
+    (start, end)
+}
 
 const SEMANTIC_TEMPLATE_RULES: &[&str] = &[
     "vue/no-unused-vars",
@@ -126,7 +187,7 @@ impl Linter {
         }
     }
 
-    fn merge_lint_results(
+    pub(crate) fn merge_lint_results(
         mut template_result: LintResult,
         mut sfc_result: LintResult,
     ) -> LintResult {
@@ -149,7 +210,7 @@ impl Linter {
         template_result
     }
 
-    fn offset_result(result: &mut LintResult, byte_offset: u32) {
+    pub(crate) fn offset_result(result: &mut LintResult, byte_offset: u32) {
         if byte_offset == 0 {
             return;
         }
@@ -162,6 +223,39 @@ impl Linter {
                 label.end += byte_offset;
             }
         }
+    }
+
+    pub(crate) fn template_parse_lint_result(
+        filename: &str,
+        source_len: usize,
+        parse_errors: &[CompilerError],
+    ) -> LintResult {
+        let mut diagnostics = Vec::with_capacity(parse_errors.len());
+        let mut error_count = 0;
+        let mut warning_count = 0;
+
+        for parse_error in parse_errors {
+            if !should_report_template_parse_diagnostic(parse_error) {
+                continue;
+            }
+            let diagnostic = template_parse_diagnostic(parse_error, source_len);
+            match diagnostic.severity {
+                Severity::Error => error_count += 1,
+                Severity::Warning => warning_count += 1,
+            }
+            diagnostics.push(diagnostic);
+        }
+
+        LintResult {
+            filename: filename.to_compact_string(),
+            diagnostics,
+            error_count,
+            warning_count,
+        }
+    }
+
+    pub(crate) fn has_fatal_template_parse_errors(parse_errors: &[CompilerError]) -> bool {
+        parse_errors.iter().any(|error| !error.is_recoverable())
     }
 
     fn has_active_semantic_template_rules(&self) -> bool {
@@ -256,9 +350,11 @@ impl Linter {
         filename: &'a str,
         root: &RootNode<'a>,
         sfc_descriptor: Option<&'a vize_atelier_sfc::SfcDescriptor<'a>>,
-        analysis: Option<&'a Croquis>,
+        analysis: TemplateAnalysis<'a>,
     ) -> LintResult {
-        if !self.has_active_semantic_template_rules() {
+        if matches!(analysis, TemplateAnalysis::Disabled)
+            || !self.has_active_semantic_template_rules()
+        {
             return self.run_template_rules(
                 allocator,
                 source,
@@ -269,15 +365,17 @@ impl Linter {
             );
         }
         let owned_analysis;
-        let analysis = if let Some(analysis) = analysis {
-            analysis
-        } else {
-            owned_analysis = profile!("patina.template.croquis", {
-                let mut analyzer = Analyzer::for_lint();
-                analyzer.analyze_template(root);
-                analyzer.finish()
-            });
-            &owned_analysis
+        let analysis = match analysis {
+            TemplateAnalysis::Disabled => unreachable!(),
+            TemplateAnalysis::Precomputed(analysis) => analysis,
+            TemplateAnalysis::Lazy => {
+                owned_analysis = profile!("patina.template.croquis", {
+                    let mut analyzer = Analyzer::for_lint();
+                    analyzer.analyze_template(root);
+                    analyzer.finish()
+                });
+                &owned_analysis
+            }
         };
 
         self.run_template_rules(
@@ -307,11 +405,41 @@ impl Linter {
         source: &str,
         filename: &str,
     ) -> LintResult {
+        self.lint_template_with_allocator_config(allocator, source, filename, true, true)
+    }
+
+    fn lint_template_with_allocator_config(
+        &self,
+        allocator: &Allocator,
+        source: &str,
+        filename: &str,
+        report_parse_errors: bool,
+        gate_semantic_on_fatal_parse: bool,
+    ) -> LintResult {
         // Parse the template
         let parser = Parser::new(allocator.as_bump(), source);
-        let (root, _parse_errors) = profile!("patina.template.parse", parser.parse());
+        let (root, parse_errors) = profile!("patina.template.parse", parser.parse());
+        let has_fatal_parse_errors = Self::has_fatal_template_parse_errors(&parse_errors);
 
-        self.lint_template_root(allocator, source, filename, &root, None, None)
+        let parse_result = Self::template_parse_lint_result(filename, source.len(), &parse_errors);
+        let lint_result = self.lint_template_root(
+            allocator,
+            source,
+            filename,
+            &root,
+            None,
+            if gate_semantic_on_fatal_parse && has_fatal_parse_errors {
+                TemplateAnalysis::Disabled
+            } else {
+                TemplateAnalysis::Lazy
+            },
+        );
+
+        if report_parse_errors {
+            Self::merge_lint_results(parse_result, lint_result)
+        } else {
+            lint_result
+        }
     }
 
     /// Lint multiple files and aggregate results.
@@ -336,24 +464,16 @@ impl Linter {
         (results, summary)
     }
 
-    pub(crate) fn lint_sfc_template_root<'a>(
-        &self,
-        filename: &str,
-        template: &'a vize_atelier_sfc::SfcTemplateBlock<'a>,
-        allocator: &'a Allocator,
-        root: &RootNode<'a>,
-        descriptor: Option<&'a vize_atelier_sfc::SfcDescriptor<'a>>,
-        analysis: Option<&'a Croquis>,
-    ) -> LintResult {
+    pub(crate) fn lint_sfc_template_root<'a>(&self, input: SfcTemplateLintInput<'a>) -> LintResult {
         let mut result = self.lint_template_root(
-            allocator,
-            &template.content,
-            filename,
-            root,
-            descriptor,
-            analysis,
+            input.allocator,
+            &input.template.content,
+            input.filename,
+            input.root,
+            input.descriptor,
+            input.analysis,
         );
-        Self::offset_result(&mut result, template.loc.start as u32);
+        Self::offset_result(&mut result, input.template.loc.start as u32);
         result
     }
 
@@ -374,10 +494,10 @@ impl Linter {
         let allocator =
             Allocator::with_capacity((template.content.len() * 4).max(self.initial_capacity));
         let parser = Parser::new(allocator.as_bump(), &template.content);
-        let (root, _parse_errors) =
-            profile!("patina.sfc.descriptor.template_parse", parser.parse());
+        let (root, parse_errors) = profile!("patina.sfc.descriptor.template_parse", parser.parse());
+        let has_fatal_parse_errors = Self::has_fatal_template_parse_errors(&parse_errors);
 
-        let analysis = if self.has_active_semantic_template_rules() {
+        let analysis = if !has_fatal_parse_errors && self.has_active_semantic_template_rules() {
             Some(profile!(
                 "patina.sfc.descriptor.croquis",
                 analyze_descriptor_for_lint(descriptor, Some(&root))
@@ -386,14 +506,25 @@ impl Linter {
             None
         };
 
-        self.lint_sfc_template_root(
+        let mut parse_result =
+            Self::template_parse_lint_result(filename, template.content.len(), &parse_errors);
+        Self::offset_result(&mut parse_result, template.loc.start as u32);
+        let lint_result = self.lint_sfc_template_root(SfcTemplateLintInput {
             filename,
             template,
-            &allocator,
-            &root,
-            Some(descriptor),
-            analysis.as_ref(),
-        )
+            allocator: &allocator,
+            root: &root,
+            descriptor: Some(descriptor),
+            analysis: if has_fatal_parse_errors {
+                TemplateAnalysis::Disabled
+            } else if let Some(analysis) = analysis.as_ref() {
+                TemplateAnalysis::Precomputed(analysis)
+            } else {
+                TemplateAnalysis::Lazy
+            },
+        });
+
+        Self::merge_lint_results(parse_result, lint_result)
     }
 
     /// Lint a full Vue SFC file.
@@ -490,7 +621,10 @@ impl Linter {
     /// Lint a standalone HTML document that may use Vue from a CDN.
     #[inline]
     pub fn lint_standalone_html(&self, source: &str, filename: &str) -> LintResult {
-        let mut result = self.lint_template(source, filename);
+        let capacity = (source.len() * 4).max(self.initial_capacity);
+        let allocator = Allocator::with_capacity(capacity);
+        let mut result =
+            self.lint_template_with_allocator_config(&allocator, source, filename, false, false);
 
         if super::script_rules::has_active_builtin_script_rules(self) {
             super::script_rules::append_builtin_script_diagnostics_from_html(

--- a/crates/vize_patina/src/linter/engine.rs
+++ b/crates/vize_patina/src/linter/engine.rs
@@ -408,6 +408,14 @@ impl Linter {
         self.lint_template_with_allocator_config(allocator, source, filename, true, true)
     }
 
+    #[cfg(test)]
+    pub(crate) fn lint_template_rules_only(&self, source: &str, filename: &str) -> LintResult {
+        let capacity = (source.len() * 4).max(self.initial_capacity);
+        let allocator = Allocator::with_capacity(capacity);
+
+        self.lint_template_with_allocator_config(&allocator, source, filename, false, true)
+    }
+
     fn lint_template_with_allocator_config(
         &self,
         allocator: &Allocator,

--- a/crates/vize_patina/src/linter/native_type_aware/driver.rs
+++ b/crates/vize_patina/src/linter/native_type_aware/driver.rs
@@ -14,6 +14,7 @@ use vize_croquis::{
     virtual_ts::{VirtualTsConfig, generate_virtual_ts_with_croquis},
 };
 
+use super::super::engine::{SfcTemplateLintInput, TemplateAnalysis};
 use super::{
     markers::{QueryKind, push_promise_marker},
     parsing::{collect_floating_candidates, is_runtime_array_macro},
@@ -32,31 +33,50 @@ pub(super) fn lint_with_descriptor<'a>(
         vize_carton::Allocator::with_capacity((source.len() * 4).max(linter.initial_capacity));
     let template_ast = descriptor.template.as_ref().map(|template| {
         let parser = TemplateParser::new(allocator.as_bump(), &template.content);
-        let (root, _) = profile!("patina.type_aware.template_parse", parser.parse());
-        (root, template.loc.start as u32)
+        let (root, parse_errors) = profile!("patina.type_aware.template_parse", parser.parse());
+        let has_fatal_parse_errors = Linter::has_fatal_template_parse_errors(&parse_errors);
+        (
+            root,
+            template.loc.start as u32,
+            parse_errors,
+            has_fatal_parse_errors,
+        )
     });
+    let template_has_fatal_parse_errors = template_ast
+        .as_ref()
+        .is_some_and(|(_, _, _, has_fatal)| *has_fatal);
 
     let analysis = profile!("patina.type_aware.croquis", {
         super::super::engine::analyze_descriptor_for_lint(
             descriptor,
-            template_ast.as_ref().map(|(root, _)| root),
+            template_ast
+                .as_ref()
+                .and_then(|(root, _, _, has_fatal)| (!*has_fatal).then_some(root)),
         )
     });
 
-    let mut result = if let (Some((root, _)), Some(template)) =
+    let mut result = if let (Some((root, _, parse_errors, has_fatal)), Some(template)) =
         (template_ast.as_ref(), descriptor.template.as_ref())
     {
-        profile!(
+        let lint_result = profile!(
             "patina.type_aware.template_rules",
-            linter.lint_sfc_template_root(
+            linter.lint_sfc_template_root(SfcTemplateLintInput {
                 filename,
                 template,
-                &allocator,
+                allocator: &allocator,
                 root,
-                Some(descriptor),
-                Some(&analysis),
-            )
-        )
+                descriptor: Some(descriptor),
+                analysis: if *has_fatal {
+                    TemplateAnalysis::Disabled
+                } else {
+                    TemplateAnalysis::Precomputed(&analysis)
+                },
+            })
+        );
+        let mut parse_result =
+            Linter::template_parse_lint_result(filename, template.content.len(), parse_errors);
+        Linter::offset_result(&mut parse_result, template.loc.start as u32);
+        Linter::merge_lint_results(parse_result, lint_result)
     } else {
         LintResult {
             filename: filename.into(),
@@ -90,8 +110,10 @@ pub(super) fn lint_with_descriptor<'a>(
     let needs_emit_probe = profile!("patina.type_aware.plan_emit_queries", {
         collect_emit_static_warning_or_probe_need(linter, &analysis, &mut result, script_block)
     });
-    let include_template_queries = is_type_rule_active(linter, RULE_NO_UNSAFE_TEMPLATE_BINDING);
-    let include_template_promise_queries = is_type_rule_active(linter, RULE_NO_FLOATING_PROMISES);
+    let include_template_queries = !template_has_fatal_parse_errors
+        && is_type_rule_active(linter, RULE_NO_UNSAFE_TEMPLATE_BINDING);
+    let include_template_promise_queries =
+        !template_has_fatal_parse_errors && is_type_rule_active(linter, RULE_NO_FLOATING_PROMISES);
     let include_reactivity_queries = is_type_rule_active(linter, RULE_NO_REACTIVITY_LOSS);
     if !needs_prop_probe
         && !needs_emit_probe
@@ -104,7 +126,7 @@ pub(super) fn lint_with_descriptor<'a>(
 
     let template_offset = template_ast
         .as_ref()
-        .map(|(_, offset)| *offset)
+        .map(|(_, offset, _, _)| *offset)
         .unwrap_or(0);
     let from_file = Path::new(filename).parent();
     let parse_result = profile!("patina.type_aware.script_parse", {
@@ -128,7 +150,9 @@ pub(super) fn lint_with_descriptor<'a>(
         generate_virtual_ts_with_croquis(
             script_content,
             &parse_result,
-            template_ast.as_ref().map(|(root, _)| root),
+            template_ast
+                .as_ref()
+                .and_then(|(root, _, _, has_fatal)| (!*has_fatal).then_some(root)),
             &config,
             None,
             from_file,
@@ -198,14 +222,18 @@ pub(super) fn lint_with_descriptor<'a>(
             if include_template_queries || include_template_promise_queries {
                 template_ast.as_ref().map_or_else(
                     || (Vec::new(), Vec::new()),
-                    |(root, _)| {
-                        collect_template_query_sets(
-                            &virtual_ts,
-                            root,
-                            template_offset,
-                            include_template_queries,
-                            include_template_promise_queries,
-                        )
+                    |(root, _, _, has_fatal)| {
+                        if *has_fatal {
+                            (Vec::new(), Vec::new())
+                        } else {
+                            collect_template_query_sets(
+                                &virtual_ts,
+                                root,
+                                template_offset,
+                                include_template_queries,
+                                include_template_promise_queries,
+                            )
+                        }
                     },
                 )
             } else {

--- a/crates/vize_patina/src/linter/tests/basic.rs
+++ b/crates/vize_patina/src/linter/tests/basic.rs
@@ -1,4 +1,5 @@
 use super::{Allocator, LintPreset, Linter, ToCompactString};
+use crate::Severity;
 
 #[test]
 fn test_lint_empty_template() {
@@ -13,6 +14,70 @@ fn test_lint_simple_template() {
     let linter = Linter::new();
     let result = linter.lint_template("<div>Hello</div>", "test.vue");
     assert!(!result.has_errors());
+}
+
+#[test]
+fn test_lint_template_reports_fatal_parser_errors_and_gates_semantic_rules() {
+    let linter =
+        Linter::new().with_enabled_rules(Some(vec!["vue/no-unused-vars".to_compact_string()]));
+    let source = r#"<ul>
+  <li v-for="(item, index) in items" :key="item">{{ item }}</li>
+"#;
+    let result = linter.lint_template(source, "test.vue");
+
+    let parser_diagnostic = result
+        .diagnostics
+        .iter()
+        .find(|diagnostic| diagnostic.rule_name == "parser/template")
+        .expect("template parser error should be reported");
+    assert_eq!(parser_diagnostic.severity, Severity::Error);
+    assert!(parser_diagnostic.message.contains("missing end tag"));
+    assert!(parser_diagnostic.end > parser_diagnostic.start);
+    assert!(
+        result
+            .diagnostics
+            .iter()
+            .all(|diagnostic| diagnostic.rule_name != "vue/no-unused-vars"),
+        "semantic diagnostics should be gated by fatal template parse errors: {:?}",
+        result.diagnostics
+    );
+}
+
+#[test]
+fn test_lint_template_reports_recoverable_parser_errors_without_gating_rules() {
+    let linter = Linter::new();
+    let result = linter.lint_template(r#"<div id="a" id="b"></div>"#, "test.vue");
+
+    let parser_diagnostic = result
+        .diagnostics
+        .iter()
+        .find(|diagnostic| diagnostic.rule_name == "parser/template")
+        .expect("recoverable template parser diagnostic should be reported");
+    assert_eq!(parser_diagnostic.severity, Severity::Warning);
+    assert!(parser_diagnostic.message.contains("Duplicate attribute"));
+    assert!(
+        result
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.rule_name == "vue/no-duplicate-attributes"),
+        "ordinary lint rules should still run after recoverable parser diagnostics"
+    );
+}
+
+#[test]
+fn test_lint_template_ignores_compat_self_closing_rewrite_warning() {
+    let linter = Linter::new();
+    let result = linter.lint_template(r#"<div />"#, "test.vue");
+
+    assert_eq!(result.warning_count, 0);
+    assert!(
+        result
+            .diagnostics
+            .iter()
+            .all(|diagnostic| diagnostic.rule_name != "parser/template"),
+        "compatibility rewrite warnings should not consume lint warning budget: {:?}",
+        result.diagnostics
+    );
 }
 
 #[test]
@@ -244,6 +309,32 @@ interface Props {
     let result = linter.lint_sfc(sfc, "test.vue");
     assert_eq!(result.error_count, 0);
     assert_eq!(result.warning_count, 0);
+}
+
+#[test]
+fn test_lint_sfc_reports_template_parser_errors_at_sfc_offsets() {
+    let linter = Linter::new();
+    let source = r#"<script setup lang="ts">
+const msg = "hello";
+</script>
+
+<template>
+  <div>
+    <span>{{ msg }}
+  </div>
+</template>
+"#;
+    let result = linter.lint_sfc(source, "test.vue");
+    let parser_diagnostic = result
+        .diagnostics
+        .iter()
+        .find(|diagnostic| diagnostic.rule_name == "parser/template")
+        .expect("template parser error should be reported for SFC templates");
+
+    let template_start = source.find("<template>").unwrap() as u32;
+    assert_eq!(parser_diagnostic.severity, Severity::Error);
+    assert!(parser_diagnostic.start > template_start);
+    assert!(parser_diagnostic.end > parser_diagnostic.start);
 }
 
 #[test]

--- a/crates/vize_patina/src/output.rs
+++ b/crates/vize_patina/src/output.rs
@@ -639,6 +639,45 @@ const items = [1]
     }
 
     #[test]
+    fn json_output_includes_template_parser_diagnostic_locations() {
+        let source = r#"<script setup lang="ts">
+const msg = "hello";
+</script>
+
+<template>
+  <div>
+    <span>{{ msg }}
+  </div>
+</template>
+"#;
+        let filename = vize_carton::String::from("Component.vue");
+        let result = Linter::new().lint_sfc(source, &filename);
+        let output = format_results(
+            &[result],
+            &[(filename, vize_carton::String::from(source))],
+            OutputFormat::Json,
+        );
+        let json: serde_json::Value = serde_json::from_str(&output).unwrap();
+        let messages = json[0]["messages"].as_array().unwrap();
+        let diagnostic = messages
+            .iter()
+            .find(|message| message["ruleId"] == "parser/template")
+            .expect("parser/template diagnostic should be present");
+
+        assert_eq!(diagnostic["severity"], 2);
+        assert_eq!(diagnostic["line"], 7);
+        assert!(diagnostic["column"].as_u64().unwrap() > 1);
+        assert!(
+            diagnostic["endLine"].as_u64().unwrap() >= diagnostic["line"].as_u64().unwrap(),
+            "{output}"
+        );
+        assert!(
+            diagnostic["endColumn"].as_u64().unwrap() > diagnostic["column"].as_u64().unwrap(),
+            "{output}"
+        );
+    }
+
+    #[test]
     fn output_format_parses_report_formats() {
         assert_eq!(OutputFormat::parse("stylish"), Some(OutputFormat::Stylish));
         assert_eq!(OutputFormat::parse("ansi"), Some(OutputFormat::Ansi));

--- a/crates/vize_patina/src/rules/vue/no_duplicate_attributes.rs
+++ b/crates/vize_patina/src/rules/vue/no_duplicate_attributes.rs
@@ -228,14 +228,16 @@ mod tests {
     #[test]
     fn test_valid_unique_attributes() {
         let linter = create_linter();
-        let result = linter.lint_template(r#"<div id="foo" class="bar"></div>"#, "test.vue");
+        let result =
+            linter.lint_template_rules_only(r#"<div id="foo" class="bar"></div>"#, "test.vue");
         assert_eq!(result.error_count, 0);
     }
 
     #[test]
     fn test_invalid_duplicate_id() {
         let linter = create_linter();
-        let result = linter.lint_template(r#"<div id="foo" id="bar"></div>"#, "test.vue");
+        let result =
+            linter.lint_template_rules_only(r#"<div id="foo" id="bar"></div>"#, "test.vue");
         assert_eq!(result.error_count, 1);
         insta::assert_debug_snapshot!(result.diagnostics);
     }
@@ -243,7 +245,8 @@ mod tests {
     #[test]
     fn test_valid_class_coexist() {
         let linter = create_linter();
-        let result = linter.lint_template(r#"<div :class="foo" class="bar"></div>"#, "test.vue");
+        let result =
+            linter.lint_template_rules_only(r#"<div :class="foo" class="bar"></div>"#, "test.vue");
         // Default allows coexistence
         assert_eq!(result.error_count, 0);
     }
@@ -251,14 +254,15 @@ mod tests {
     #[test]
     fn test_invalid_duplicate_v_bind() {
         let linter = create_linter();
-        let result = linter.lint_template(r#"<div :id="foo" :id="bar"></div>"#, "test.vue");
+        let result =
+            linter.lint_template_rules_only(r#"<div :id="foo" :id="bar"></div>"#, "test.vue");
         assert_eq!(result.error_count, 1);
     }
 
     #[test]
     fn test_valid_different_event_modifiers() {
         let linter = create_linter();
-        let result = linter.lint_template(
+        let result = linter.lint_template_rules_only(
             r#"<div @keydown.left="goLeft" @keydown.right="goRight"></div>"#,
             "test.vue",
         );
@@ -268,7 +272,7 @@ mod tests {
     #[test]
     fn test_valid_different_event_modifiers_multiple() {
         let linter = create_linter();
-        let result = linter.lint_template(
+        let result = linter.lint_template_rules_only(
             r#"<div @click.stop="a" @click.prevent="b" @click.stop.prevent="c"></div>"#,
             "test.vue",
         );
@@ -278,8 +282,8 @@ mod tests {
     #[test]
     fn test_invalid_duplicate_event_same_modifiers() {
         let linter = create_linter();
-        let result =
-            linter.lint_template(r#"<div @click.stop="a" @click.stop="b"></div>"#, "test.vue");
+        let result = linter
+            .lint_template_rules_only(r#"<div @click.stop="a" @click.stop="b"></div>"#, "test.vue");
         assert_eq!(result.error_count, 1);
         insta::assert_debug_snapshot!(result.diagnostics);
     }
@@ -287,7 +291,8 @@ mod tests {
     #[test]
     fn test_invalid_duplicate_event_no_modifiers() {
         let linter = create_linter();
-        let result = linter.lint_template(r#"<div @click="a" @click="b"></div>"#, "test.vue");
+        let result =
+            linter.lint_template_rules_only(r#"<div @click="a" @click="b"></div>"#, "test.vue");
         assert_eq!(result.error_count, 1);
     }
 }

--- a/crates/vize_patina/src/rules/vue/permitted_contents.rs
+++ b/crates/vize_patina/src/rules/vue/permitted_contents.rs
@@ -238,35 +238,36 @@ mod tests {
     #[test]
     fn test_valid_inline_in_inline() {
         let linter = create_linter();
-        let result = linter.lint_template(r#"<p><span>text</span></p>"#, "test.vue");
+        let result = linter.lint_template_rules_only(r#"<p><span>text</span></p>"#, "test.vue");
         assert_eq!(result.error_count, 0);
     }
 
     #[test]
     fn test_valid_block_in_block() {
         let linter = create_linter();
-        let result = linter.lint_template(r#"<div><p>text</p></div>"#, "test.vue");
+        let result = linter.lint_template_rules_only(r#"<div><p>text</p></div>"#, "test.vue");
         assert_eq!(result.error_count, 0);
     }
 
     #[test]
     fn test_valid_list_with_li() {
         let linter = create_linter();
-        let result = linter.lint_template(r#"<ul><li>item</li></ul>"#, "test.vue");
+        let result = linter.lint_template_rules_only(r#"<ul><li>item</li></ul>"#, "test.vue");
         assert_eq!(result.error_count, 0);
     }
 
     #[test]
     fn test_valid_list_with_known_intrinsic_member_component_li() {
         let linter = create_linter();
-        let result = linter.lint_template(r#"<ul><motion.li>item</motion.li></ul>"#, "test.vue");
+        let result =
+            linter.lint_template_rules_only(r#"<ul><motion.li>item</motion.li></ul>"#, "test.vue");
         assert_eq!(result.error_count, 0);
     }
 
     #[test]
     fn test_valid_table_structure() {
         let linter = create_linter();
-        let result = linter.lint_template(
+        let result = linter.lint_template_rules_only(
             r#"<table><thead><tr><th>Head</th></tr></thead><tbody><tr><td>Cell</td></tr></tbody></table>"#,
             "test.vue",
         );
@@ -277,7 +278,7 @@ mod tests {
     fn test_valid_template_wrapper_in_list() {
         let linter = create_linter();
         // <template> is allowed as a transparent wrapper inside lists
-        let result = linter.lint_template(
+        let result = linter.lint_template_rules_only(
             r#"<ul><template v-for="item in items"><li>{{ item }}</li></template></ul>"#,
             "test.vue",
         );
@@ -288,21 +289,22 @@ mod tests {
     fn test_valid_component_in_any_context() {
         let linter = create_linter();
         // Components are skipped — can render anything
-        let result = linter.lint_template(r#"<p><MyComponent /></p>"#, "test.vue");
+        let result = linter.lint_template_rules_only(r#"<p><MyComponent /></p>"#, "test.vue");
         assert_eq!(result.error_count, 0);
     }
 
     #[test]
     fn test_valid_nested_non_interactive() {
         let linter = create_linter();
-        let result = linter.lint_template(r##"<a href="#"><span>text</span></a>"##, "test.vue");
+        let result =
+            linter.lint_template_rules_only(r##"<a href="#"><span>text</span></a>"##, "test.vue");
         assert_eq!(result.error_count, 0);
     }
 
     #[test]
     fn test_valid_flow_content_in_anchor_when_context_allows_flow() {
         let linter = create_linter();
-        let result = linter.lint_template(
+        let result = linter.lint_template_rules_only(
             r##"<main><a href="#"><h2>Documentation</h2><div>Read the guide</div></a></main>"##,
             "test.vue",
         );
@@ -312,7 +314,7 @@ mod tests {
     #[test]
     fn test_valid_select_with_options() {
         let linter = create_linter();
-        let result = linter.lint_template(
+        let result = linter.lint_template_rules_only(
             r#"<select><option>A</option><option>B</option></select>"#,
             "test.vue",
         );
@@ -322,7 +324,7 @@ mod tests {
     #[test]
     fn test_valid_select_with_optgroup() {
         let linter = create_linter();
-        let result = linter.lint_template(
+        let result = linter.lint_template_rules_only(
             r#"<select><optgroup label="Group"><option>A</option></optgroup></select>"#,
             "test.vue",
         );
@@ -334,28 +336,30 @@ mod tests {
     #[test]
     fn test_repaired_div_after_p() {
         let linter = create_linter();
-        let result = linter.lint_template(r#"<p><div>block</div></p>"#, "test.vue");
+        let result = linter.lint_template_rules_only(r#"<p><div>block</div></p>"#, "test.vue");
         assert_eq!(result.error_count, 0);
     }
 
     #[test]
     fn test_invalid_div_in_span() {
         let linter = create_linter();
-        let result = linter.lint_template(r#"<span><div>block</div></span>"#, "test.vue");
+        let result =
+            linter.lint_template_rules_only(r#"<span><div>block</div></span>"#, "test.vue");
         assert_eq!(result.error_count, 1);
     }
 
     #[test]
     fn test_repaired_h1_after_p() {
         let linter = create_linter();
-        let result = linter.lint_template(r#"<p><h1>heading</h1></p>"#, "test.vue");
+        let result = linter.lint_template_rules_only(r#"<p><h1>heading</h1></p>"#, "test.vue");
         assert_eq!(result.error_count, 0);
     }
 
     #[test]
     fn test_invalid_ul_in_span() {
         let linter = create_linter();
-        let result = linter.lint_template(r#"<span><ul><li>item</li></ul></span>"#, "test.vue");
+        let result =
+            linter.lint_template_rules_only(r#"<span><ul><li>item</li></ul></span>"#, "test.vue");
         // ul in span: block_in_inline error
         // But li in ul is valid
         assert_eq!(result.error_count, 1);
@@ -364,8 +368,8 @@ mod tests {
     #[test]
     fn test_repaired_flow_content_in_anchor_when_outer_context_is_phrasing() {
         let linter = create_linter();
-        let result =
-            linter.lint_template(r##"<p><a href="#"><div>block</div></a></p>"##, "test.vue");
+        let result = linter
+            .lint_template_rules_only(r##"<p><a href="#"><div>block</div></a></p>"##, "test.vue");
         assert_eq!(result.error_count, 0);
     }
 
@@ -374,24 +378,24 @@ mod tests {
     #[test]
     fn test_repaired_a_in_a() {
         let linter = create_linter();
-        let result =
-            linter.lint_template(r##"<a href="#"><a href="#">nested</a></a>"##, "test.vue");
+        let result = linter
+            .lint_template_rules_only(r##"<a href="#"><a href="#">nested</a></a>"##, "test.vue");
         assert_eq!(result.error_count, 0);
     }
 
     #[test]
     fn test_repaired_button_in_button() {
         let linter = create_linter();
-        let result =
-            linter.lint_template(r#"<button><button>nested</button></button>"#, "test.vue");
+        let result = linter
+            .lint_template_rules_only(r#"<button><button>nested</button></button>"#, "test.vue");
         assert_eq!(result.error_count, 0);
     }
 
     #[test]
     fn test_invalid_button_in_a() {
         let linter = create_linter();
-        let result =
-            linter.lint_template(r##"<a href="#"><button>click</button></a>"##, "test.vue");
+        let result = linter
+            .lint_template_rules_only(r##"<a href="#"><button>click</button></a>"##, "test.vue");
         assert_eq!(result.error_count, 1);
     }
 
@@ -400,35 +404,37 @@ mod tests {
     #[test]
     fn test_invalid_div_in_ul() {
         let linter = create_linter();
-        let result = linter.lint_template(r#"<ul><div>not li</div></ul>"#, "test.vue");
+        let result = linter.lint_template_rules_only(r#"<ul><div>not li</div></ul>"#, "test.vue");
         assert_eq!(result.error_count, 1);
     }
 
     #[test]
     fn test_invalid_span_in_ol() {
         let linter = create_linter();
-        let result = linter.lint_template(r#"<ol><span>not li</span></ol>"#, "test.vue");
+        let result = linter.lint_template_rules_only(r#"<ol><span>not li</span></ol>"#, "test.vue");
         assert_eq!(result.error_count, 1);
     }
 
     #[test]
     fn test_invalid_unknown_component_in_ul() {
         let linter = create_linter();
-        let result = linter.lint_template(r#"<ul><MyItem /></ul>"#, "test.vue");
+        let result = linter.lint_template_rules_only(r#"<ul><MyItem /></ul>"#, "test.vue");
         assert_eq!(result.error_count, 1);
     }
 
     #[test]
     fn test_invalid_unknown_member_component_in_ul() {
         let linter = create_linter();
-        let result = linter.lint_template(r#"<ul><foo.li>item</foo.li></ul>"#, "test.vue");
+        let result =
+            linter.lint_template_rules_only(r#"<ul><foo.li>item</foo.li></ul>"#, "test.vue");
         assert_eq!(result.error_count, 1);
     }
 
     #[test]
     fn test_invalid_known_intrinsic_member_component_div_in_ul() {
         let linter = create_linter();
-        let result = linter.lint_template(r#"<ul><motion.div>item</motion.div></ul>"#, "test.vue");
+        let result = linter
+            .lint_template_rules_only(r#"<ul><motion.div>item</motion.div></ul>"#, "test.vue");
         assert_eq!(result.error_count, 1);
     }
 
@@ -437,14 +443,15 @@ mod tests {
     #[test]
     fn test_repaired_div_in_table() {
         let linter = create_linter();
-        let result = linter.lint_template(r#"<table><div>not valid</div></table>"#, "test.vue");
+        let result =
+            linter.lint_template_rules_only(r#"<table><div>not valid</div></table>"#, "test.vue");
         assert_eq!(result.error_count, 0);
     }
 
     #[test]
     fn test_repaired_span_in_tr() {
         let linter = create_linter();
-        let result = linter.lint_template(
+        let result = linter.lint_template_rules_only(
             r#"<table><tr><span>not td/th</span></tr></table>"#,
             "test.vue",
         );
@@ -456,7 +463,8 @@ mod tests {
     #[test]
     fn test_invalid_div_in_select() {
         let linter = create_linter();
-        let result = linter.lint_template(r#"<select><div>not option</div></select>"#, "test.vue");
+        let result = linter
+            .lint_template_rules_only(r#"<select><div>not option</div></select>"#, "test.vue");
         assert_eq!(result.error_count, 1);
     }
 


### PR DESCRIPTION
## Summary
- Surface template parser diagnostics as parser/template lint diagnostics.
- Gate semantic, type-aware, and cross-file template analysis when template parsing has fatal errors.
- Preserve recoverable parser warnings and standalone HTML lint behavior.

## Tests
- cargo test -p vize_patina linter::tests::basic
- cargo test -p vize_patina output::tests::json_output
- cargo test -p vize cross_file_opt_in_skips_template_ast_after_fatal_parse_error
- cargo fmt --all -- --check

Fixes #1162

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1250"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783588382&installation_id=136613492&pr_number=1250&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1250&signature=45e020f76cb00d8131719978614a5ab26840c0f8d9673566a05147dc1a3478d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->