### PR TITLE
fix(vize_patina): detect bound aria on unsupported elements

### DIFF
--- a/crates/vize_patina/src/rules/a11y/aria_unsupported_elements.rs
+++ b/crates/vize_patina/src/rules/a11y/aria_unsupported_elements.rs
@@ -11,7 +11,7 @@
 use crate::context::LintContext;
 use crate::diagnostic::Severity;
 use crate::rule::{Rule, RuleCategory, RuleMeta};
-use vize_relief::ast::{ElementNode, ElementType, PropNode};
+use vize_relief::ast::{ElementNode, ElementType, ExpressionNode, PropNode, SourceLocation};
 
 use super::helpers;
 
@@ -42,19 +42,43 @@ impl Rule for AriaUnsupportedElements {
         }
 
         for prop in &element.props {
-            if let PropNode::Attribute(attr) = prop
-                && (attr.name.starts_with("aria-") || attr.name == "role")
-            {
-                ctx.error_with_help(
-                    ctx.t_fmt(
-                        "a11y/aria-unsupported-elements.message",
-                        &[("tag", element.tag.as_str()), ("attr", attr.name.as_str())],
-                    ),
-                    &attr.loc,
-                    ctx.t("a11y/aria-unsupported-elements.help"),
-                );
+            match prop {
+                PropNode::Attribute(attr) if Self::is_aria_or_role(attr.name.as_str()) => {
+                    self.report_unsupported_attr(ctx, element, attr.name.as_str(), &attr.loc);
+                }
+                PropNode::Directive(dir)
+                    if dir.name == "bind"
+                        && let Some(ExpressionNode::Simple(arg)) = &dir.arg
+                        && Self::is_aria_or_role(arg.content.as_str()) =>
+                {
+                    self.report_unsupported_attr(ctx, element, arg.content.as_str(), &dir.loc);
+                }
+                _ => {}
             }
         }
+    }
+}
+
+impl AriaUnsupportedElements {
+    fn is_aria_or_role(name: &str) -> bool {
+        name.starts_with("aria-") || name == "role"
+    }
+
+    fn report_unsupported_attr(
+        &self,
+        ctx: &mut LintContext<'_>,
+        element: &ElementNode<'_>,
+        attr: &str,
+        loc: &SourceLocation,
+    ) {
+        ctx.error_with_help(
+            ctx.t_fmt(
+                "a11y/aria-unsupported-elements.message",
+                &[("tag", element.tag.as_str()), ("attr", attr)],
+            ),
+            loc,
+            ctx.t("a11y/aria-unsupported-elements.help"),
+        );
     }
 }
 
@@ -88,6 +112,20 @@ mod tests {
     fn test_invalid_script_with_role() {
         let linter = create_linter();
         let result = linter.lint_template(r#"<script role="presentation"></script>"#, "test.vue");
+        assert_eq!(result.error_count, 1);
+    }
+
+    #[test]
+    fn test_invalid_meta_with_bound_aria_hidden() {
+        let linter = create_linter();
+        let result = linter.lint_template(r#"<meta :aria-hidden="hidden" />"#, "test.vue");
+        assert_eq!(result.error_count, 1);
+    }
+
+    #[test]
+    fn test_invalid_script_with_bound_role() {
+        let linter = create_linter();
+        let result = linter.lint_template(r#"<script :role="role"></script>"#, "test.vue");
         assert_eq!(result.error_count, 1);
     }
 }


### PR DESCRIPTION
## Summary
- Treat `v-bind` / shorthand bound `aria-*` and `role` props like static attributes on ARIA-unsupported elements.
- Add regressions for bound `aria-hidden` on `meta` and bound `role` on `script`.

Fixes #1212

## Verification
- `cargo fmt --all -- --check`
- `cargo test -p vize_patina aria_unsupported_elements -- --nocapture`
- `cargo clippy -p vize_patina --lib -- -D warnings`
- `git diff --check origin/main..HEAD`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1251"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783588413&installation_id=136613492&pr_number=1251&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1251&signature=cdff5205479c45b392bdb6f19e7ac7095c832a22e6bcbd4dd93e4d0fbd7328e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->