### PR TITLE
fix(build): respect template syntax config

### DIFF
--- a/crates/vize/src/commands/build/runner.rs
+++ b/crates/vize/src/commands/build/runner.rs
@@ -38,13 +38,18 @@ use super::{
 pub(crate) fn run(args: BuildArgs) {
     let start = Instant::now();
     let slow_threshold = Duration::from_millis(args.slow_threshold);
-    if let Some(config) = args.config.as_ref()
+    if let Some(path) = args.config.as_deref()
         && !args.no_config
-        && !config.exists()
+        && let Err(error) = crate::config::validate_explicit_config_path(path)
     {
-        eprintln!("Could not find config file: {}", config.display());
+        eprintln!("\x1b[31mError:\x1b[0m {}", error);
         std::process::exit(1);
     }
+    let compiler_template_syntax = if args.no_config {
+        None
+    } else {
+        crate::config::load_compiler_template_syntax(args.config.as_deref())
+    };
 
     if let Some(threads) = args.threads
         && let Err(error) = rayon::ThreadPoolBuilder::new()
@@ -88,7 +93,10 @@ pub(crate) fn run(args: BuildArgs) {
         ssr: args.ssr,
         vapor: args.vapor,
         custom_renderer: args.custom_renderer,
-        template_syntax: args.template_syntax.map(Into::into).unwrap_or_default(),
+        template_syntax: args
+            .template_syntax
+            .map(Into::into)
+            .unwrap_or_else(|| template_syntax_mode(compiler_template_syntax)),
         script_ext: args.script_ext,
         record_profile_totals: args.profile,
     };
@@ -611,6 +619,15 @@ fn template_syntax_bits(template_syntax: TemplateSyntaxMode) -> u8 {
         TemplateSyntaxMode::Strict => 1,
         TemplateSyntaxMode::Quirks => 2,
         _ => 3,
+    }
+}
+
+fn template_syntax_mode(template_syntax: Option<&str>) -> TemplateSyntaxMode {
+    match template_syntax {
+        Some("strict") => TemplateSyntaxMode::Strict,
+        Some("quirks") => TemplateSyntaxMode::Quirks,
+        Some("standard") | None => TemplateSyntaxMode::Standard,
+        Some(_) => TemplateSyntaxMode::Standard,
     }
 }
 

--- a/crates/vize/tests/build_cli.rs
+++ b/crates/vize/tests/build_cli.rs
@@ -202,3 +202,55 @@ const props = defineProps<WrapperProps>()
 
     let _ = fs::remove_dir_all(project_root);
 }
+
+#[test]
+fn build_respects_configured_template_syntax_quirks() {
+    let project_root = temp_project_dir("configured-template-syntax-quirks");
+    write_project_file(
+        &project_root,
+        "vize.config.ts",
+        r#"export default {
+  compiler: {
+    templateSyntax: "quirks",
+  },
+}
+"#,
+    );
+    write_project_file(
+        &project_root,
+        "src/App.vue",
+        r#"<template><div /></template>
+"#,
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(&project_root)
+        .args([
+            "build",
+            "--format",
+            "json",
+            "src/App.vue",
+            "--output",
+            "dist",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let json: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(project_root.join("dist/App.json")).unwrap())
+            .unwrap();
+    assert_eq!(
+        json["warnings"].as_array().unwrap().len(),
+        0,
+        "quirks syntax should not warn for invalid self-closing HTML: {json:#}"
+    );
+
+    let _ = fs::remove_dir_all(project_root);
+}

--- a/npm/vite-plugin-vize/src/plugin/state.test.ts
+++ b/npm/vite-plugin-vize/src/plugin/state.test.ts
@@ -162,6 +162,18 @@ assert.deepEqual(
   "Client requests should keep Vapor enabled when the plugin is configured for it",
 );
 
+assert.equal(
+  getCompileOptionsForRequest(
+    {
+      isProduction: true,
+      mergedOptions: { templateSyntax: "quirks" },
+    },
+    false,
+  ).templateSyntax,
+  "quirks",
+  "Request compile options should preserve configured template syntax",
+);
+
 assert.deepEqual(
   getCompileOptionsForRequest(
     {


### PR DESCRIPTION
## Summary

- Load `compiler.templateSyntax` for `vize build` through the shared config loader.
- Keep the CLI `--template-syntax` flag as the highest-priority override.
- Add build and Vite plugin state regression coverage for quirks template syntax.

Follow-up to #1239 / #1243.

## Tests

- `CARGO_TARGET_DIR=/tmp/vize-target-build-template-syntax cargo test -p vize --test build_cli build_respects_configured_template_syntax_quirks`
- `CARGO_TARGET_DIR=/tmp/vize-target-build-template-syntax cargo clippy -p vize --lib --bin vize --no-deps -- -D warnings`
- `node src/plugin/state.test.ts` from `npm/vite-plugin-vize` with workspace node_modules linked
- `cargo fmt`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1252"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783588516&installation_id=136613492&pr_number=1252&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1252&signature=98d2a3b1df9d391d360b733412b501a9a6495cd220823881895a7ff8b18f3c8b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->