### PR TITLE
fix(atelier_sfc): avoid scoped css brace underflow

### DIFF
--- a/crates/vize_atelier_sfc/src/style.rs
+++ b/crates/vize_atelier_sfc/src/style.rs
@@ -130,7 +130,7 @@ pub fn apply_scoped_css(css: &str, scope_id: &str) -> String {
                 }
             }
             '}' => {
-                brace_depth -= 1;
+                brace_depth = brace_depth.saturating_sub(1);
                 output.push(c);
                 // Check @keyframes block end — restore parent at_rule_depth
                 if keyframes_brace_depth.is_some_and(|d| brace_depth < d) {
@@ -684,6 +684,17 @@ mod tests {
         assert_eq!(
             result,
             "@media (min-width: 1px){ /* A <span>, not a <p>; ignore :deep(p). */\n.conferences__venue[data-v-abc]{ display: block; }}"
+        );
+    }
+
+    #[test]
+    fn test_apply_scoped_css_stray_closing_brace_keeps_scoping() {
+        let css = "}.foo { color: red; }.bar { color: blue; }";
+        let result = apply_scoped_css(css, "data-v-123");
+
+        assert_eq!(
+            result,
+            "}.foo[data-v-123]{ color: red; }.bar[data-v-123]{ color: blue; }"
         );
     }
 


### PR DESCRIPTION
## Summary

- Use `saturating_sub` when scoped CSS sees a closing brace so malformed CSS with a stray `}` cannot underflow `brace_depth`.
- Add a regression covering a stray `}` followed by selectors that must continue receiving the scope attribute.

Fixes #1180

## Local verification

- `cargo test -p vize_atelier_sfc style::tests::`
- `cargo test -p vize_atelier_sfc`
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo clippy -p vize_atelier_sfc -- -D warnings`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1253"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783588663&installation_id=136613492&pr_number=1253&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1253&signature=7c2fd3ab360f8f250e130e3de88d5070954343c8bbc9f088261ddd7d67ee5301"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->