### PR TITLE
fix(atelier_core): report missing v-if expressions

### DIFF
--- a/crates/vize_atelier_core/src/transform/structural.rs
+++ b/crates/vize_atelier_core/src/transform/structural.rs
@@ -52,7 +52,11 @@ fn directive_expression_to_content(exp: ExpressionNode<'_>) -> SimpleExpressionC
 /// This removes the selected directive from the element in the same pass we discover it.
 pub fn take_structural_directive<'a>(
     el: &mut Box<'a, ElementNode<'a>>,
-) -> Option<(StructuralDirectiveKind, Option<SimpleExpressionContent>)> {
+) -> Option<(
+    StructuralDirectiveKind,
+    Option<SimpleExpressionContent>,
+    SourceLocation,
+)> {
     let mut selected_if = None;
     let mut selected_for = None;
 
@@ -94,6 +98,7 @@ pub fn take_structural_directive<'a>(
     Some((
         directive_kind,
         directive.exp.map(directive_expression_to_content),
+        directive.loc,
     ))
 }
 
@@ -123,10 +128,21 @@ pub fn extract_key_prop<'a>(el: &mut ElementNode<'a>) -> Option<PropNode<'a>> {
 /// Transform v-if directive
 pub fn transform_v_if<'a>(
     ctx: &mut TransformContext<'a>,
+    directive_kind: StructuralDirectiveKind,
     exp: Option<&SimpleExpressionContent>,
+    directive_loc: &SourceLocation,
     is_root: bool,
 ) -> Option<ExitFns<'a>> {
     let allocator = ctx.allocator;
+
+    if matches!(
+        directive_kind,
+        StructuralDirectiveKind::If | StructuralDirectiveKind::ElseIf
+    ) && exp.is_none()
+    {
+        ctx.on_error(ErrorCode::VIfNoExpression, Some(directive_loc.clone()));
+        return None;
+    }
 
     if is_root {
         // Take the current element from parent
@@ -474,6 +490,53 @@ pub fn transform_v_for<'a>(
     ctx.helper(RuntimeHelper::Fragment);
 
     None
+}
+
+#[cfg(test)]
+#[allow(clippy::disallowed_macros)]
+mod tests {
+    use bumpalo::Bump;
+
+    use super::super::traverse::traverse_children;
+    use super::*;
+    use crate::errors::CompilerError;
+    use crate::options::TransformOptions;
+    use crate::parser::parse;
+    use crate::transform::{ParentNode, TransformContext};
+
+    fn transform_errors(source: &str) -> std::vec::Vec<CompilerError> {
+        let allocator = Bump::new();
+        let (mut root, errors) = parse(&allocator, source);
+        assert!(errors.is_empty(), "Parse errors: {:?}", errors);
+
+        let mut ctx =
+            TransformContext::new(&allocator, root.source.clone(), TransformOptions::default());
+        traverse_children(&mut ctx, ParentNode::Root(&mut root as *mut _));
+        ctx.errors
+    }
+
+    #[test]
+    fn test_v_if_without_expression_reports_error() {
+        let errors = transform_errors(r#"<div v-if>always</div>"#);
+
+        assert_eq!(errors.len(), 1);
+        assert_eq!(errors[0].code, ErrorCode::VIfNoExpression);
+    }
+
+    #[test]
+    fn test_v_else_if_without_expression_reports_error() {
+        let errors = transform_errors(r#"<div v-if="ok">yes</div><div v-else-if>maybe</div>"#);
+
+        assert_eq!(errors.len(), 1);
+        assert_eq!(errors[0].code, ErrorCode::VIfNoExpression);
+    }
+
+    #[test]
+    fn test_v_else_without_expression_stays_valid() {
+        let errors = transform_errors(r#"<div v-if="ok">yes</div><div v-else>no</div>"#);
+
+        assert!(errors.is_empty(), "Unexpected errors: {:?}", errors);
+    }
 }
 
 /// Extract key value string from a PropNode for comparison

--- a/crates/vize_atelier_core/src/transform/traverse.rs
+++ b/crates/vize_atelier_core/src/transform/traverse.rs
@@ -81,13 +81,13 @@ pub fn traverse_node<'a>(ctx: &mut TransformContext<'a>, node: &mut TemplateChil
                 take_structural_directive(el)
             );
 
-            if let Some((directive_kind, exp)) = structural_result {
+            if let Some((directive_kind, exp, directive_loc)) = structural_result {
                 // Handle the structural directive
                 match directive_kind {
                     StructuralDirectiveKind::If => {
                         if let Some(exits) = profile!(
                             "atelier.transform.v_if",
-                            transform_v_if(ctx, exp.as_ref(), true)
+                            transform_v_if(ctx, directive_kind, exp.as_ref(), &directive_loc, true)
                         ) {
                             exit_fns.extend(exits);
                         }
@@ -95,7 +95,13 @@ pub fn traverse_node<'a>(ctx: &mut TransformContext<'a>, node: &mut TemplateChil
                     StructuralDirectiveKind::ElseIf | StructuralDirectiveKind::Else => {
                         if let Some(exits) = profile!(
                             "atelier.transform.v_if",
-                            transform_v_if(ctx, exp.as_ref(), false)
+                            transform_v_if(
+                                ctx,
+                                directive_kind,
+                                exp.as_ref(),
+                                &directive_loc,
+                                false
+                            )
                         ) {
                             exit_fns.extend(exits);
                         }


### PR DESCRIPTION
Fixes #1200.

## Summary
- thread the structural directive kind and location into v-if transforms
- report VIfNoExpression for bare v-if and v-else-if
- keep bare v-else valid

## Verification
- cargo fmt --all -- --check
- cargo test -p vize_atelier_core structural::tests::test_v_ -- --nocapture
- cargo test -p vize_atelier_core test_transform_v_for -- --nocapture
- cargo clippy -p vize_atelier_core --lib -- -D warnings
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1255"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783589903&installation_id=136613492&pr_number=1255&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1255&signature=d31398b439d215b9da00445c948c3a6d50b79ea52dc9221cb354c389c4857cb4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->