### PR TITLE
fix(atelier_ssr): render component v-show display prop

### DIFF
--- a/crates/vize_atelier_ssr/src/codegen/element/component.rs
+++ b/crates/vize_atelier_ssr/src/codegen/element/component.rs
@@ -447,10 +447,20 @@ impl<'a> SsrCodegenContext<'a> {
                 handler.push_str(") = $event)");
                 entries.push(component_prop_entry(&update_key, &handler, true));
             }
+            "show" => {
+                let Some(exp) = dir.exp.as_ref().map(|exp| self.expression_to_string(exp)) else {
+                    return;
+                };
+                entries.push(component_prop_entry(
+                    "style",
+                    &cstr!("(({exp}) ? null : {{ display: \"none\" }})"),
+                    false,
+                ));
+            }
             // Server-rendered HTML does not need event listener props, and slot/
             // DOM-only/custom directives are handled elsewhere or ignored by Vue's
             // SSR compiler for component prop bags.
-            "on" | "slot" | "show" | "html" | "text" => {}
+            "on" | "slot" | "html" | "text" => {}
             _ => {}
         }
     }

--- a/crates/vize_atelier_ssr/tests/snapshots/ssr_snapshot__component__component_with_v_show.snap
+++ b/crates/vize_atelier_ssr/tests/snapshots/ssr_snapshot__component__component_with_v_show.snap
@@ -1,0 +1,7 @@
+---
+source: crates/vize_atelier_ssr/tests/ssr_snapshot.rs
+expression: "compile_full(r#\"<MyComp v-show=\"ok\" />\"#)"
+---
+function ssrRender(_ctx, _push, _parent, _attrs) {
+  _push(_ssrRenderComponent(_resolveComponent("MyComp"), _mergeProps({ style: ((_ctx.ok) ? null : { display: "none" }) }, _attrs), null, _parent))
+}

--- a/crates/vize_atelier_ssr/tests/snapshots/ssr_snapshot__component__component_with_v_show_merges_style.snap
+++ b/crates/vize_atelier_ssr/tests/snapshots/ssr_snapshot__component__component_with_v_show_merges_style.snap
@@ -1,0 +1,7 @@
+---
+source: crates/vize_atelier_ssr/tests/ssr_snapshot.rs
+expression: "compile_full(r#\"<MyComp style=\"color: red;\" v-show=\"ok\" />\"#)"
+---
+function ssrRender(_ctx, _push, _parent, _attrs) {
+  _push(_ssrRenderComponent(_resolveComponent("MyComp"), _mergeProps({ style: ["color: red;", ((_ctx.ok) ? null : { display: "none" })] }, _attrs), null, _parent))
+}

--- a/crates/vize_atelier_ssr/tests/ssr_snapshot.rs
+++ b/crates/vize_atelier_ssr/tests/ssr_snapshot.rs
@@ -381,6 +381,18 @@ mod component {
     }
 
     #[test]
+    fn component_with_v_show() {
+        insta::assert_snapshot!(compile_full(r#"<MyComp v-show="ok" />"#));
+    }
+
+    #[test]
+    fn component_with_v_show_merges_style() {
+        insta::assert_snapshot!(compile_full(
+            r#"<MyComp style="color: red;" v-show="ok" />"#
+        ));
+    }
+
+    #[test]
     fn dynamic_component_uses_vnode_renderer() {
         insta::assert_snapshot!(compile_full(
             r#"<component :is="headingLevel" class="title">node</component>"#


### PR DESCRIPTION
## Summary
- render component `v-show` as a `style` prop for SSR component attrs
- preserve existing style merging by using the normalized component prop path
- add SSR snapshot regressions for component `v-show` and style merging

Fixes #1206

## Checks
- `cargo test -p vize_atelier_ssr v_show`
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo clippy -p vize_atelier_ssr --all-targets -- -D warnings`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1256"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783590409&installation_id=136613492&pr_number=1256&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1256&signature=3c9a22b68a9aa5dce68601dfb3f15c2df753c4a42adc552a9c11f31cc24ce79b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->