### PR TITLE
fix(atelier_ssr): preserve v-show style prop on components

### DIFF
--- a/crates/vize_atelier_ssr/src/codegen/element/component.rs
+++ b/crates/vize_atelier_ssr/src/codegen/element/component.rs
@@ -447,10 +447,20 @@ impl<'a> SsrCodegenContext<'a> {
                 handler.push_str(") = $event)");
                 entries.push(component_prop_entry(&update_key, &handler, true));
             }
+            "show" => {
+                let Some(exp) = dir.exp.as_ref().map(|exp| self.expression_to_string(exp)) else {
+                    return;
+                };
+                entries.push(component_prop_entry(
+                    "style",
+                    &cstr!("(({exp}) ? null : {{ display: \"none\" }})"),
+                    false,
+                ));
+            }
             // Server-rendered HTML does not need event listener props, and slot/
             // DOM-only/custom directives are handled elsewhere or ignored by Vue's
             // SSR compiler for component prop bags.
-            "on" | "slot" | "show" | "html" | "text" => {}
+            "on" | "slot" | "html" | "text" => {}
             _ => {}
         }
     }

--- a/crates/vize_atelier_ssr/tests/snapshots/ssr_snapshot__component__component_v_show_adds_style_prop.snap
+++ b/crates/vize_atelier_ssr/tests/snapshots/ssr_snapshot__component__component_v_show_adds_style_prop.snap
@@ -1,0 +1,7 @@
+---
+source: crates/vize_atelier_ssr/tests/ssr_snapshot.rs
+expression: "compile_full(r#\"<MyComp v-show=\"ok\" />\"#)"
+---
+function ssrRender(_ctx, _push, _parent, _attrs) {
+  _push(_ssrRenderComponent(_resolveComponent("MyComp"), _mergeProps({ style: ((_ctx.ok) ? null : { display: "none" }) }, _attrs), null, _parent))
+}

--- a/crates/vize_atelier_ssr/tests/snapshots/ssr_snapshot__component__component_v_show_merges_with_style_prop.snap
+++ b/crates/vize_atelier_ssr/tests/snapshots/ssr_snapshot__component__component_v_show_merges_with_style_prop.snap
@@ -1,0 +1,7 @@
+---
+source: crates/vize_atelier_ssr/tests/ssr_snapshot.rs
+expression: "compile_full(r#\"<MyComp :style=\"{ color }\" v-show=\"ok\" />\"#)"
+---
+function ssrRender(_ctx, _push, _parent, _attrs) {
+  _push(_ssrRenderComponent(_resolveComponent("MyComp"), _mergeProps({ style: [{ color: _ctx.color }, ((_ctx.ok) ? null : { display: "none" })] }, _attrs), null, _parent))
+}

--- a/crates/vize_atelier_ssr/tests/ssr_snapshot.rs
+++ b/crates/vize_atelier_ssr/tests/ssr_snapshot.rs
@@ -381,6 +381,16 @@ mod component {
     }
 
     #[test]
+    fn component_v_show_adds_style_prop() {
+        insta::assert_snapshot!(compile_full(r#"<MyComp v-show="ok" />"#));
+    }
+
+    #[test]
+    fn component_v_show_merges_with_style_prop() {
+        insta::assert_snapshot!(compile_full(r#"<MyComp :style="{ color }" v-show="ok" />"#));
+    }
+
+    #[test]
     fn dynamic_component_uses_vnode_renderer() {
         insta::assert_snapshot!(compile_full(
             r#"<component :is="headingLevel" class="title">node</component>"#


### PR DESCRIPTION
## Summary
- emit `v-show` on SSR components as a generated `style` prop
- keep generated `display: none` style merged with existing component `:style` props
- add SSR snapshot coverage for component `v-show`

Closes #1206

## Verification
- `cargo fmt`
- `git diff --check`
- `CARGO_TARGET_DIR=/tmp/vize-1206-target cargo test -p vize_atelier_ssr`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1257"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783590444&installation_id=136613492&pr_number=1257&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1257&signature=4663203502e4ba7e562f1d5b3760ece37f8189f7217030972e70ba255d708c56"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->