### PR TITLE
ci: fix macOS release checks

### DIFF
--- a/.github/actions/setup-moonbit/install-moonbit.mjs
+++ b/.github/actions/setup-moonbit/install-moonbit.mjs
@@ -82,6 +82,36 @@ export MOON_HOME="${moonHome}"
   fs.chmodSync(shimMoonShell, 0o755);
 }
 
+function patchDarwinMoonbitHeader() {
+  if (os.type() !== "Darwin") {
+    return;
+  }
+
+  const moonbitHeader = path.join(moonHome, "include", "moonbit.h");
+  const memcpyDeclaration = "void *memcpy(void *dst, const void *src, size_t n);";
+  const patchedMemcpyDeclaration = `#ifdef memcpy
+#undef memcpy
+#endif
+${memcpyDeclaration}`;
+
+  if (!fs.existsSync(moonbitHeader)) {
+    console.warn(`MoonBit header not found at ${moonbitHeader}; skipping Darwin memcpy patch`);
+    return;
+  }
+
+  const header = fs.readFileSync(moonbitHeader, "utf8");
+  if (header.includes(patchedMemcpyDeclaration)) {
+    return;
+  }
+
+  if (!header.includes(memcpyDeclaration)) {
+    console.warn("MoonBit header memcpy declaration not found; skipping Darwin memcpy patch");
+    return;
+  }
+
+  fs.writeFileSync(moonbitHeader, header.replace(memcpyDeclaration, patchedMemcpyDeclaration));
+}
+
 function smokeTestMoon() {
   const smokeTestCommand =
     os.type() === "Windows_NT"
@@ -171,6 +201,7 @@ if (!hasExistingMoonInstall()) {
 }
 
 ensureMoonShim();
+patchDarwinMoonbitHeader();
 smokeTestMoon();
 
 fs.appendFileSync(githubPath, `${shimDir}\n`);

--- a/tests/tooling/github-workflows.test.ts
+++ b/tests/tooling/github-workflows.test.ts
@@ -727,6 +727,15 @@ test("setup-moonbit smoke test validates the native async process runtime", () =
   assert.match(installer, /@process\.run/);
 });
 
+test("setup-moonbit patches Darwin secure memcpy macros before smoke testing", () => {
+  const installer = readRepoFile(".github", "actions", "setup-moonbit", "install-moonbit.mjs");
+
+  assert.match(installer, /function patchDarwinMoonbitHeader\(\)/);
+  assert.match(installer, /os\.type\(\) !== "Darwin"/);
+  assert.match(installer, /#undef memcpy/);
+  assert.match(installer, /patchDarwinMoonbitHeader\(\);\nsmokeTestMoon\(\);/);
+});
+
 test("setup-moonbit writes both command and shell shims on Windows so bash steps can resolve moon", () => {
   const installer = readRepoFile(".github", "actions", "setup-moonbit", "install-moonbit.mjs");
 


### PR DESCRIPTION
## Summary
- Patch MoonBit's Darwin header after install/cache restore so Xcode 16.4 secure memcpy macros do not break macOS release/native jobs.
- Run the patch before the setup smoke test so cached and fresh installs are both covered.
- Add tooling coverage for the Darwin MoonBit header patch.

## Verification
- node --check .github/actions/setup-moonbit/install-moonbit.mjs
- node --test tests/tooling/github-workflows.test.ts
- cargo semver-checks check-release --package vize_atelier_core
- vp check .github/actions/setup-moonbit/install-moonbit.mjs tests/tooling/github-workflows.test.ts
- git diff --check
- setup-moonbit local smoke run with RUNNER_TEMP/GITHUB_PATH/GITHUB_ENV