### PR TITLE
fix(croquis_cf): ignore custom elements in component resolution

### DIFF
--- a/crates/vize_croquis_cf/src/analyzer/tests_basic.rs
+++ b/crates/vize_croquis_cf/src/analyzer/tests_basic.rs
@@ -1,4 +1,4 @@
-use super::{CrossFileAnalyzer, CrossFileOptions};
+use super::{CrossFileAnalyzer, CrossFileOptions, CrossFileResult};
 use crate::CrossFileDiagnosticKind;
 use std::path::Path;
 use vize_carton::{CompactString, smallvec};
@@ -43,19 +43,33 @@ fn test_analyzer_basic() {
 }
 
 #[test]
-fn test_component_resolution_error() {
+fn test_component_resolution_reports_unregistered_pascal_case_component() {
     let mut analyzer = CrossFileAnalyzer::new(CrossFileOptions::strict());
 
-    // Add a file that uses an unregistered component
-    analyzer.add_file(
+    analyzer.add_file_with_analysis(
         Path::new("Parent.vue"),
-        r#"<script setup>
-// No import of ChildComponent
-</script>"#,
+        "",
+        script_analysis_with_used_component("// No import of ChildWidget", "ChildWidget"),
     );
 
-    // When template analysis is added, this test will verify
-    // that unregistered components produce errors
+    let result = analyzer.analyze();
+
+    assert_eq!(unregistered_components(&result), vec!["ChildWidget"]);
+}
+
+#[test]
+fn test_component_resolution_ignores_custom_element_tag() {
+    let mut analyzer = CrossFileAnalyzer::new(CrossFileOptions::strict());
+
+    analyzer.add_file_with_analysis(
+        Path::new("Parent.vue"),
+        "",
+        script_analysis_with_used_component("", "my-widget"),
+    );
+
+    let result = analyzer.analyze();
+
+    assert!(unregistered_components(&result).is_empty());
 }
 
 #[test]
@@ -110,6 +124,27 @@ fn script_analysis_with_component_usage(
     analysis.used_components.insert(usage.name.clone());
     analysis.component_usages.push(usage);
     analysis
+}
+
+fn script_analysis_with_used_component(script: &str, component: &str) -> vize_croquis::Croquis {
+    let mut analysis = script_analysis(script);
+    analysis
+        .used_components
+        .insert(CompactString::new(component));
+    analysis
+}
+
+fn unregistered_components(result: &CrossFileResult) -> Vec<&str> {
+    result
+        .diagnostics
+        .iter()
+        .filter_map(|diagnostic| match &diagnostic.kind {
+            CrossFileDiagnosticKind::UnregisteredComponent { component_name, .. } => {
+                Some(component_name.as_str())
+            }
+            _ => None,
+        })
+        .collect()
 }
 
 fn component_usage_with_on_prefixed_prop(component: &str) -> ComponentUsage {

--- a/crates/vize_croquis_cf/src/analyzers/component_resolution.rs
+++ b/crates/vize_croquis_cf/src/analyzers/component_resolution.rs
@@ -60,6 +60,12 @@ pub fn analyze_component_resolution(
                 continue;
             }
 
+            // Lowercase hyphenated tags can be native custom elements configured
+            // through Vue's compilerOptions.isCustomElement.
+            if is_custom_element_tag(component_name.as_str()) {
+                continue;
+            }
+
             // Check if component is imported as a binding. Vue templates can
             // use either PascalCase (`UserCard`) or kebab-case (`user-card`).
             let is_imported = imported_identifiers
@@ -201,6 +207,29 @@ fn is_builtin_component(name: &str) -> bool {
     )
 }
 
+fn is_custom_element_tag(name: &str) -> bool {
+    name.contains('-')
+        && name.chars().next().is_some_and(|c| c.is_ascii_lowercase())
+        && !is_reserved_custom_element_name(name)
+        && name
+            .chars()
+            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || matches!(c, '-' | '_' | '.'))
+}
+
+fn is_reserved_custom_element_name(name: &str) -> bool {
+    matches!(
+        name,
+        "annotation-xml"
+            | "color-profile"
+            | "font-face"
+            | "font-face-src"
+            | "font-face-uri"
+            | "font-face-format"
+            | "font-face-name"
+            | "missing-glyph"
+    )
+}
+
 fn component_names_match(left: &str, right: &str) -> bool {
     left == right || to_pascal_case(left) == to_pascal_case(right)
 }
@@ -294,7 +323,7 @@ fn resolve_import(
 
 #[cfg(test)]
 mod tests {
-    use super::is_builtin_component;
+    use super::{is_builtin_component, is_custom_element_tag};
 
     #[test]
     fn test_is_builtin_component() {
@@ -312,5 +341,18 @@ mod tests {
         assert!(is_builtin_component("slot"));
         assert!(!is_builtin_component("MyComponent"));
         assert!(!is_builtin_component("UserCard"));
+    }
+
+    #[test]
+    fn test_is_custom_element_tag() {
+        assert!(is_custom_element_tag("my-widget"));
+        assert!(is_custom_element_tag("ion-button"));
+        assert!(is_custom_element_tag("sl-icon2"));
+        assert!(is_custom_element_tag("my_widget-button"));
+        assert!(!is_custom_element_tag("MyWidget"));
+        assert!(!is_custom_element_tag("myWidget"));
+        assert!(!is_custom_element_tag("ChildWidget"));
+        assert!(!is_custom_element_tag("font-face"));
+        assert!(!is_custom_element_tag("div"));
     }
 }


### PR DESCRIPTION
## Summary
- Skip lowercase custom-element-shaped tags when reporting `UnregisteredComponent` from `component_resolution`.
- Add regression coverage for custom elements and keep PascalCase unregistered component diagnostics covered.

## Validation
- `cargo test -p vize_croquis_cf component_resolution`
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo clippy --workspace -- -D warnings`

Fixes #1210

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1261"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783590602&installation_id=136613492&pr_number=1261&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1261&signature=90af97aeb27913c107a4ca5ec5835fc94a2b54cbb165e983aa15d3d531472a91"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->