### PR TITLE
fix(atelier_vapor): lower nested slot outlets

### DIFF
--- a/crates/vize_atelier_vapor/src/generate/operations/refs.rs
+++ b/crates/vize_atelier_vapor/src/generate/operations/refs.rs
@@ -31,6 +31,7 @@ pub(super) fn generate_set_template_ref(
 
 /// Generate InsertNode
 pub(super) fn generate_insert_node(ctx: &mut GenerateContext, insert: &InsertNodeIRNode) {
+    ctx.use_helper("insert");
     let parent = cstr!("n{}", insert.parent);
     let elements = insert
         .elements

--- a/crates/vize_atelier_vapor/src/generate/setup.rs
+++ b/crates/vize_atelier_vapor/src/generate/setup.rs
@@ -34,6 +34,7 @@ pub(crate) fn generate_imports(ctx: &GenerateContext) -> String {
             "VaporKeepAlive" => 6,
             "withVaporCtx" => 7,
             "withDirectives" => 46,
+            "insert" => 9,
             "child" => 10,
             "next" => 11,
             "txt" => 20,

--- a/crates/vize_atelier_vapor/src/lib.rs
+++ b/crates/vize_atelier_vapor/src/lib.rs
@@ -383,6 +383,26 @@ mod tests {
     }
 
     #[test]
+    fn test_compile_nested_slot_outlet_child() {
+        let allocator = Bump::new();
+        let result = compile_vapor(
+            &allocator,
+            r#"<div><slot :row="item" :index="i"></slot></div>"#,
+            Default::default(),
+        );
+
+        assert!(
+            result.error_messages.is_empty(),
+            "Expected no errors: {:?}",
+            result.error_messages
+        );
+
+        let code = normalize_code(&result.code);
+        assert_parses_as_module(&code);
+        insta::assert_snapshot!(code.as_str());
+    }
+
+    #[test]
     fn test_compile_component_v_model_uses_update_listener_getter() {
         let allocator = Bump::new();
         let result = compile_vapor(

--- a/crates/vize_atelier_vapor/src/snapshots/vize_atelier_vapor__tests__compile_nested_slot_outlet_child.snap
+++ b/crates/vize_atelier_vapor/src/snapshots/vize_atelier_vapor__tests__compile_nested_slot_outlet_child.snap
@@ -1,0 +1,12 @@
+---
+source: crates/vize_atelier_vapor/src/lib.rs
+expression: code.as_str()
+---
+import { renderSlot as _renderSlot, insert as _insert, template as _template } from 'vue';
+const t0 = _template("<div></div>", true)
+export function render(_ctx) {
+const n1 = t0()
+const n0 = _renderSlot($slots, "default", { "row": _ctx.item, "index": _ctx.i })
+_insert(n1, [n0])
+return n1
+}

--- a/crates/vize_atelier_vapor/src/transform/element/deferred.rs
+++ b/crates/vize_atelier_vapor/src/transform/element/deferred.rs
@@ -1,6 +1,6 @@
 //! Deferred child ID allocation for dynamic and control-flow descendants.
 
-use crate::ir::{ForIRNode, IfIRNode, NegativeBranch};
+use crate::ir::{ForIRNode, IfIRNode, InsertNodeIRNode, NegativeBranch};
 
 use super::component::transform_component;
 use super::template::*;
@@ -221,6 +221,8 @@ fn transform_dynamic_children_with_ids<'a>(
 
             prev_template_backed_child = Some((child_id, child_index));
             transform_existing_element(ctx, child_el, child_id, block);
+        } else if child_el.tag_type == ElementType::Slot {
+            transform_slot_outlet_child(ctx, child_el, child_id, parent_id, block);
         } else {
             transform_component(
                 ctx,
@@ -233,6 +235,33 @@ fn transform_dynamic_children_with_ids<'a>(
             );
         }
     }
+}
+
+fn transform_slot_outlet_child<'a>(
+    ctx: &mut TransformContext<'a>,
+    el: &ElementNode<'a>,
+    element_id: usize,
+    parent_id: usize,
+    block: &mut BlockIRNode<'a>,
+) {
+    let name = get_slot_outlet_name(ctx, el);
+    let props = get_slot_outlet_props(ctx, el);
+    let fallback = (!el.children.is_empty()).then(|| transform_children(ctx, &el.children));
+    block
+        .operation
+        .push(OperationNode::SlotOutlet(SlotOutletIRNode {
+            id: element_id,
+            name,
+            props,
+            fallback,
+        }));
+    block
+        .operation
+        .push(OperationNode::InsertNode(InsertNodeIRNode {
+            elements: std::vec![element_id],
+            parent: parent_id,
+            anchor: None,
+        }));
 }
 
 fn transform_existing_element<'a>(

--- a/tests/expected/vapor/v-slot.snap
+++ b/tests/expected/vapor/v-slot.snap
@@ -12,6 +12,22 @@ export function render(_ctx) {
 }
 
 ===
+name: nested slot outlet
+options: vapor
+--- INPUT ---
+<div><slot :row="item" :index="i"></slot></div>
+--- OUTPUT ---
+import { renderSlot as _renderSlot, insert as _insert, template as _template } from 'vue';
+const t0 = _template("<div></div>", true)
+
+export function render(_ctx) {
+  const n1 = t0()
+  const n0 = _renderSlot($slots, "default", { "row": _ctx.item, "index": _ctx.i })
+  _insert(n1, [n0])
+  return n1
+}
+
+===
 name: default slot content
 options: vapor
 --- INPUT ---

--- a/tests/fixtures/vapor/v-slot.pkl
+++ b/tests/fixtures/vapor/v-slot.pkl
@@ -10,6 +10,10 @@ cases {
     input = "<slot></slot>"
   }
   new {
+    name = "nested slot outlet"
+    input = #"<div><slot :row="item" :index="i"></slot></div>"#
+  }
+  new {
     name = "default slot content"
     input = "<MyComponent>content</MyComponent>"
   }


### PR DESCRIPTION
## Summary
- lower nested `<slot>` children in Vapor dynamic element paths as slot outlets instead of user components
- insert nested slot outlet results into the parent with existing Vapor IR, preserving public `SlotOutletIRNode` struct-literal compatibility
- add crate and fixture regression snapshots for a `<slot>` inside a normal element

Fixes #1185

## Validation
- `cargo test -p vize_atelier_vapor slot_outlet -- --nocapture`
- `cargo test -p vize_test_runner vapor_v_slot -- --ignored --nocapture`
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo clippy -p vize_atelier_vapor -p vize_test_runner -- -D warnings`
- `cargo semver-checks check-release --package vize_atelier_vapor`