### PR TITLE
fix(atelier_core): preserve transform_v_if api

### DIFF
--- a/crates/vize_atelier_core/src/transform/structural.rs
+++ b/crates/vize_atelier_core/src/transform/structural.rs
@@ -128,6 +128,24 @@ pub fn extract_key_prop<'a>(el: &mut ElementNode<'a>) -> Option<PropNode<'a>> {
 /// Transform v-if directive
 pub fn transform_v_if<'a>(
     ctx: &mut TransformContext<'a>,
+    exp: Option<&SimpleExpressionContent>,
+    is_root: bool,
+) -> Option<ExitFns<'a>> {
+    let directive_loc = exp
+        .map(|exp| exp.loc.clone())
+        .unwrap_or(SourceLocation::STUB);
+
+    transform_v_if_with_directive(
+        ctx,
+        StructuralDirectiveKind::If,
+        exp,
+        &directive_loc,
+        is_root,
+    )
+}
+
+pub(crate) fn transform_v_if_with_directive<'a>(
+    ctx: &mut TransformContext<'a>,
     directive_kind: StructuralDirectiveKind,
     exp: Option<&SimpleExpressionContent>,
     directive_loc: &SourceLocation,

--- a/crates/vize_atelier_core/src/transform/traverse.rs
+++ b/crates/vize_atelier_core/src/transform/traverse.rs
@@ -6,7 +6,8 @@ use vize_carton::profile;
 
 use super::element::{transform_element, transform_interpolation};
 use super::structural::{
-    StructuralDirectiveKind, take_structural_directive, transform_v_for, transform_v_if,
+    StructuralDirectiveKind, take_structural_directive, transform_v_for,
+    transform_v_if_with_directive,
 };
 use super::{ExitFns, ParentNode, TransformContext};
 
@@ -87,7 +88,13 @@ pub fn traverse_node<'a>(ctx: &mut TransformContext<'a>, node: &mut TemplateChil
                     StructuralDirectiveKind::If => {
                         if let Some(exits) = profile!(
                             "atelier.transform.v_if",
-                            transform_v_if(ctx, directive_kind, exp.as_ref(), &directive_loc, true)
+                            transform_v_if_with_directive(
+                                ctx,
+                                directive_kind,
+                                exp.as_ref(),
+                                &directive_loc,
+                                true
+                            )
                         ) {
                             exit_fns.extend(exits);
                         }
@@ -95,7 +102,7 @@ pub fn traverse_node<'a>(ctx: &mut TransformContext<'a>, node: &mut TemplateChil
                     StructuralDirectiveKind::ElseIf | StructuralDirectiveKind::Else => {
                         if let Some(exits) = profile!(
                             "atelier.transform.v_if",
-                            transform_v_if(
+                            transform_v_if_with_directive(
                                 ctx,
                                 directive_kind,
                                 exp.as_ref(),


### PR DESCRIPTION
## Summary
- restore the public `transform_v_if(ctx, exp, is_root)` signature
- move directive-kind aware traversal calls to an internal helper
- keep missing v-if / v-else-if expression diagnostics intact

## Verification
- cargo fmt --all -- --check
- git diff --check
- cargo test -p vize_atelier_core structural::tests::test_v_ -- --nocapture
- cargo clippy -p vize_atelier_core --lib -- -D warnings
- cargo semver-checks check-release --package vize_atelier_core

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1263"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783592718&installation_id=136613492&pr_number=1263&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1263&signature=ca7a9460e1148abf6839360525f9c7978a735c82661e7473feff338ce13015c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->