### PR TITLE
fix(atelier_core): preserve transform v-if public arity

### DIFF
--- a/crates/vize_atelier_core/src/transform/structural.rs
+++ b/crates/vize_atelier_core/src/transform/structural.rs
@@ -52,6 +52,12 @@ fn directive_expression_to_content(exp: ExpressionNode<'_>) -> SimpleExpressionC
 /// This removes the selected directive from the element in the same pass we discover it.
 pub fn take_structural_directive<'a>(
     el: &mut Box<'a, ElementNode<'a>>,
+) -> Option<(StructuralDirectiveKind, Option<SimpleExpressionContent>)> {
+    take_structural_directive_with_location(el).map(|(kind, exp, _)| (kind, exp))
+}
+
+pub(crate) fn take_structural_directive_with_location<'a>(
+    el: &mut Box<'a, ElementNode<'a>>,
 ) -> Option<(
     StructuralDirectiveKind,
     Option<SimpleExpressionContent>,
@@ -128,9 +134,17 @@ pub fn extract_key_prop<'a>(el: &mut ElementNode<'a>) -> Option<PropNode<'a>> {
 /// Transform v-if directive
 pub fn transform_v_if<'a>(
     ctx: &mut TransformContext<'a>,
+    exp: Option<&SimpleExpressionContent>,
+    is_root: bool,
+) -> Option<ExitFns<'a>> {
+    transform_v_if_with_directive(ctx, StructuralDirectiveKind::If, exp, None, is_root)
+}
+
+pub(crate) fn transform_v_if_with_directive<'a>(
+    ctx: &mut TransformContext<'a>,
     directive_kind: StructuralDirectiveKind,
     exp: Option<&SimpleExpressionContent>,
-    directive_loc: &SourceLocation,
+    directive_loc: Option<&SourceLocation>,
     is_root: bool,
 ) -> Option<ExitFns<'a>> {
     let allocator = ctx.allocator;
@@ -140,7 +154,7 @@ pub fn transform_v_if<'a>(
         StructuralDirectiveKind::If | StructuralDirectiveKind::ElseIf
     ) && exp.is_none()
     {
-        ctx.on_error(ErrorCode::VIfNoExpression, Some(directive_loc.clone()));
+        ctx.on_error(ErrorCode::VIfNoExpression, directive_loc.cloned());
         return None;
     }
 

--- a/crates/vize_atelier_core/src/transform/traverse.rs
+++ b/crates/vize_atelier_core/src/transform/traverse.rs
@@ -6,7 +6,8 @@ use vize_carton::profile;
 
 use super::element::{transform_element, transform_interpolation};
 use super::structural::{
-    StructuralDirectiveKind, take_structural_directive, transform_v_for, transform_v_if,
+    StructuralDirectiveKind, take_structural_directive_with_location, transform_v_for,
+    transform_v_if_with_directive,
 };
 use super::{ExitFns, ParentNode, TransformContext};
 
@@ -78,7 +79,7 @@ pub fn traverse_node<'a>(ctx: &mut TransformContext<'a>, node: &mut TemplateChil
             // Check for structural directives first
             let structural_result = profile!(
                 "atelier.transform.check_structural",
-                take_structural_directive(el)
+                take_structural_directive_with_location(el)
             );
 
             if let Some((directive_kind, exp, directive_loc)) = structural_result {
@@ -87,7 +88,13 @@ pub fn traverse_node<'a>(ctx: &mut TransformContext<'a>, node: &mut TemplateChil
                     StructuralDirectiveKind::If => {
                         if let Some(exits) = profile!(
                             "atelier.transform.v_if",
-                            transform_v_if(ctx, directive_kind, exp.as_ref(), &directive_loc, true)
+                            transform_v_if_with_directive(
+                                ctx,
+                                directive_kind,
+                                exp.as_ref(),
+                                Some(&directive_loc),
+                                true
+                            )
                         ) {
                             exit_fns.extend(exits);
                         }
@@ -95,11 +102,11 @@ pub fn traverse_node<'a>(ctx: &mut TransformContext<'a>, node: &mut TemplateChil
                     StructuralDirectiveKind::ElseIf | StructuralDirectiveKind::Else => {
                         if let Some(exits) = profile!(
                             "atelier.transform.v_if",
-                            transform_v_if(
+                            transform_v_if_with_directive(
                                 ctx,
                                 directive_kind,
                                 exp.as_ref(),
-                                &directive_loc,
+                                Some(&directive_loc),
                                 false
                             )
                         ) {


### PR DESCRIPTION
## Summary
- restore the public `take_structural_directive` and `transform_v_if` signatures that existed in v0.191.0
- add crate-internal helpers that keep the new missing `v-if` / `v-else-if` expression diagnostics using directive locations
- switch traversal to the internal helpers so behavior from #1255 stays intact without breaking semver

## Root cause
#1255 added directive location plumbing directly to public transform APIs. `cargo-semver-checks` then failed downstream PRs with `transform_v_if now takes 5 parameters instead of 3`.

## Verification
- `cargo fmt --package vize_atelier_core`
- `CARGO_TARGET_DIR=/tmp/vize-semver-vif-target cargo test -p vize_atelier_core structural::tests -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/vize-semver-vif-target-clippy cargo clippy -p vize_atelier_core --lib --no-deps -- -D warnings`
- `CARGO_TARGET_DIR=/tmp/vize-semver-vif-semver-target cargo semver-checks check-release --package vize_atelier_core`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1264"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783592905&installation_id=136613492&pr_number=1264&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1264&signature=726889285d16cf2e7922aed67ce16c47aaea106245e46aaeca9fbfe8e1e6352b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->