### PR TITLE
fix(atelier_sfc): handle slotted selectors in vite css scoping

### DIFF
--- a/crates/vize_atelier_sfc/src/vite_plugin/css_scope.rs
+++ b/crates/vize_atelier_sfc/src/vite_plugin/css_scope.rs
@@ -8,7 +8,15 @@ pub(super) fn scope_css_for_pipeline(css: &str, scope_id: &str) -> String {
 pub(super) fn unwrap_deep_selectors(css: &str) -> String {
     unwrap_pseudo_functions(
         css,
-        &["::v-deep(", "::deep(", ":deep(", "::v-global(", ":global("],
+        &[
+            "::v-deep(",
+            "::deep(",
+            ":deep(",
+            "::v-slotted(",
+            ":slotted(",
+            "::v-global(",
+            ":global(",
+        ],
     )
 }
 
@@ -367,7 +375,16 @@ fn scope_selector(selector: &str, scope_id: &str) -> String {
         &["::v-global(", ":global("],
     );
 
-    if let Some(deep) = find_pseudo_function_any(body.as_str(), &["::v-deep(", "::deep(", ":deep("])
+    if let Some(slotted) = find_pseudo_function_any(body.as_str(), &["::v-slotted(", ":slotted("]) {
+        let inner = &body[slotted.inner_start..slotted.inner_end];
+        let after = &body[slotted.end..];
+        let mut scoped = String::with_capacity(inner.len() + scope_id.len() + after.len() + 4);
+        scoped.push_str(inner);
+        push_slotted_scope_attr(&mut scoped, scope_id);
+        scoped.push_str(after);
+        body = scoped;
+    } else if let Some(deep) =
+        find_pseudo_function_any(body.as_str(), &["::v-deep(", "::deep(", ":deep("])
     {
         let before = body[..deep.start].trim_end();
         let inner = &body[deep.inner_start..deep.inner_end];
@@ -638,6 +655,12 @@ fn push_scope_attr(output: &mut String, scope_id: &str) {
     output.push(']');
 }
 
+fn push_slotted_scope_attr(output: &mut String, scope_id: &str) {
+    output.push('[');
+    output.push_str(scope_id);
+    output.push_str("-s]");
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -676,11 +699,43 @@ mod tests {
 
     #[test]
     fn unwraps_preprocessor_special_selectors() {
-        let css = "[data-v-x] .parent > ::v-deep(.child), [data-v-x] .foo:global(.bar) {}";
+        let css = "[data-v-x] .parent > ::v-deep(.child), [data-v-x] :slotted(.slot), [data-v-x] .foo:global(.bar) {}";
 
         assert_eq!(
             unwrap_deep_selectors(css).as_str(),
-            "[data-v-x] .parent > .child, [data-v-x] .foo.bar {}"
+            "[data-v-x] .parent > .child, [data-v-x] .slot, [data-v-x] .foo.bar {}"
+        );
+    }
+
+    #[test]
+    fn scopes_slotted_selector_with_slotted_scope_id() {
+        assert_eq!(
+            scope_css_for_pipeline(":slotted(.foo) { color: red; }", "data-v-x").as_str(),
+            ".foo[data-v-x-s]{color: red;}"
+        );
+    }
+
+    #[test]
+    fn scopes_legacy_v_slotted_selector_with_slotted_scope_id() {
+        assert_eq!(
+            scope_css_for_pipeline("::v-slotted(.foo) { color: red; }", "data-v-x").as_str(),
+            ".foo[data-v-x-s]{color: red;}"
+        );
+    }
+
+    #[test]
+    fn scopes_slotted_selector_with_pseudo_suffix() {
+        assert_eq!(
+            scope_css_for_pipeline(":slotted(.foo):hover { color: red; }", "data-v-x").as_str(),
+            ".foo[data-v-x-s]:hover{color: red;}"
+        );
+    }
+
+    #[test]
+    fn scopes_nested_slotted_selector_with_slotted_scope_id() {
+        assert_eq!(
+            scope_css_for_pipeline(".host { :slotted(.foo) { color: red; } }", "data-v-x").as_str(),
+            " .foo[data-v-x-s]{color: red;}"
         );
     }
 


### PR DESCRIPTION
## Summary
- handle modern `:slotted()` and legacy `::v-slotted()` selectors in the Vite CSS scoping path
- emit the slotted scope attribute on the inner selector instead of producing invalid scoped pseudo output
- add regressions for slotted selectors, pseudo suffixes, nested CSS, and preprocessor unwrapping

Closes #1205

## Verification
- `cargo fmt --check`
- `git diff --check`
- `CARGO_TARGET_DIR=/tmp/vize-issue-1205-target-rebased cargo test -p vize_atelier_sfc vite_plugin::css_scope -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/vize-issue-1205-target-rebased cargo clippy -p vize_atelier_sfc --lib -- -D warnings`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1267"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783593732&installation_id=136613492&pr_number=1267&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1267&signature=d1a92787f7928e7ac0b879979519aa64b280ddfd2088076c200292db4e55a576"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->