### PR TITLE
fix(vize_patina): avoid hydration mismatch substring false positives

### DIFF
--- a/crates/vize_patina/src/rules/ssr/no_hydration_mismatch.rs
+++ b/crates/vize_patina/src/rules/ssr/no_hydration_mismatch.rs
@@ -202,7 +202,9 @@ fn match_pattern_at(content: &str, index: usize) -> Option<(&'static str, &'stat
         ".toLocaleDateString()",
         ".toLocaleTimeString()",
     ] {
-        if content[index..].starts_with(pattern) {
+        if content[index..].starts_with(pattern)
+            && has_identifier_right_boundary(content.as_bytes(), index + pattern.len())
+        {
             return pattern_match(pattern);
         }
     }
@@ -434,6 +436,12 @@ mod tests {
     }
 
     #[test]
+    fn test_ignores_double_quoted_raw_interpolation_text() {
+        let content = r#""see the Date.now() docs for details""#;
+        assert!(NoHydrationMismatch::check_expression(content).is_none());
+    }
+
+    #[test]
     fn test_ignores_template_literal_raw_text_false_positive() {
         let content = r#"`Date.now and import.meta.env are just text`"#;
         assert!(NoHydrationMismatch::check_expression(content).is_none());
@@ -452,6 +460,27 @@ mod tests {
     fn test_ignores_unrelated_member_chain() {
         let content = "globals.Date.now";
         assert!(NoHydrationMismatch::check_expression(content).is_none());
+    }
+
+    #[test]
+    fn test_ignores_process_env_substring_in_member_chain() {
+        let content = "config.process.envName";
+        assert!(NoHydrationMismatch::check_expression(content).is_none());
+    }
+
+    #[test]
+    fn test_ignores_method_call_substring_in_longer_member_name() {
+        let content = "clock.getTime()zone";
+        assert!(NoHydrationMismatch::check_expression(content).is_none());
+    }
+
+    #[test]
+    fn test_detects_member_method_call() {
+        let content = "createdAt.getTime()";
+        assert_eq!(
+            NoHydrationMismatch::check_expression(content).map(|(pattern, _)| pattern),
+            Some(".getTime()")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add identifier-boundary checking for hydration mismatch member-call patterns
- avoid SSR hydration false positives from longer member names and raw string text
- add regressions for raw text, member-chain substrings, and real member method detection

Closes #1218

## Verification
- `cargo fmt --check`
- `git diff --check`
- `CARGO_TARGET_DIR=/tmp/vize-issue-1218-target-rebased cargo test -p vize_patina rules::ssr::no_hydration_mismatch -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/vize-issue-1218-target-rebased cargo clippy -p vize_patina --lib -- -D warnings`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1268"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783593735&installation_id=136613492&pr_number=1268&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1268&signature=e88d30f31aabe38a20859a31e813adda573142c62089b59faa514cdf1c7cf3df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->