### PR TITLE
fix(atelier_vapor): resolve v-for index aliases

### DIFF
--- a/crates/vize_atelier_vapor/src/generate/context.rs
+++ b/crates/vize_atelier_vapor/src/generate/context.rs
@@ -15,8 +15,7 @@ pub(crate) struct ForScope {
     pub(crate) value_alias: Option<String>,
     /// Key alias (e.g., "index" or "key") -> "_for_key{depth}"
     pub(crate) key_alias: Option<String>,
-    /// Index alias -> unused in current vapor
-    #[allow(dead_code)]
+    /// Index alias -> "_for_index{depth}"
     pub(crate) index_alias: Option<String>,
     /// Depth of for nesting (0-based)
     pub(crate) depth: usize,
@@ -223,6 +222,12 @@ impl<'a> GenerateContext<'a> {
                 && name == key_alias.as_str()
             {
                 return Some(cstr!("_for_key{}.value", scope.depth));
+            }
+
+            if let Some(ref index_alias) = scope.index_alias
+                && name == index_alias.as_str()
+            {
+                return Some(cstr!("_for_index{}.value", scope.depth));
             }
         }
 

--- a/crates/vize_atelier_vapor/src/generate/operations/for_loop.rs
+++ b/crates/vize_atelier_vapor/src/generate/operations/for_loop.rs
@@ -29,24 +29,28 @@ pub(super) fn generate_for(
 
     let value_alias = for_node.value.as_ref().map(|v| v.content.clone());
     let key_alias = for_node.key.as_ref().map(|k| k.content.clone());
+    let index_alias = for_node.index.as_ref().map(|i| i.content.clone());
 
     // Build parameter list using _for_item0, _for_key0 naming
     let for_item_var = cstr!("_for_item{}", depth);
     let for_key_var = cstr!("_for_key{}", depth);
+    let for_index_var = cstr!("_for_index{}", depth);
 
-    let params: String = if key_alias.is_some() {
-        [for_item_var.as_str(), ", ", for_key_var.as_str()]
-            .concat()
-            .into()
-    } else {
-        for_item_var.clone()
-    };
+    let mut params = for_item_var.clone();
+    if key_alias.is_some() || index_alias.is_some() {
+        params.push_str(", ");
+        params.push_str(&for_key_var);
+    }
+    if index_alias.is_some() {
+        params.push_str(", ");
+        params.push_str(&for_index_var);
+    }
 
     // Push for scope before generating body
     let scope = ForScope {
         value_alias: value_alias.clone(),
         key_alias: key_alias.clone(),
-        index_alias: for_node.index.as_ref().map(|i| i.content.clone()),
+        index_alias: index_alias.clone(),
         depth,
     };
     ctx.for_scopes.push(scope);
@@ -120,12 +124,17 @@ fn generate_for_key_function(
             .map(|v| v.content.as_str())
             .unwrap_or("_item");
         let key_name = for_node.key.as_ref().map(|k| k.content.as_str());
+        let index_name = for_node.index.as_ref().map(|i| i.content.as_str());
 
-        let params = if let Some(k) = key_name {
-            [value_name, ", ", k].concat()
-        } else {
-            value_name.to_compact_string().into()
-        };
+        let mut params = value_name.to_compact_string();
+        if key_name.is_some() || index_name.is_some() {
+            params.push_str(", ");
+            params.push_str(key_name.unwrap_or("_key"));
+        }
+        if let Some(index) = index_name {
+            params.push_str(", ");
+            params.push_str(index);
+        }
 
         Some(cstr!("({params}) => ({key_expr})"))
     } else {
@@ -155,6 +164,13 @@ fn resolve_key_expression(
             &mut resolved,
             &cstr!("_for_key{}.value", current_scope.depth),
             key.content.as_str(),
+        );
+    }
+    if let Some(index) = for_node.index.as_ref() {
+        restore_current_alias_reference(
+            &mut resolved,
+            &cstr!("_for_index{}.value", current_scope.depth),
+            index.content.as_str(),
         );
     }
 

--- a/tests/expected/vapor/v-for.snap
+++ b/tests/expected/vapor/v-for.snap
@@ -75,6 +75,25 @@ export function render(_ctx) {
 }
 
 ===
+name: v-for object with index
+options: vapor
+--- INPUT ---
+<div v-for="(value, key, idx) in obj" :key="idx">{{ key }}: {{ value }}: {{ idx }}</div>
+--- OUTPUT ---
+import { txt as _txt, toDisplayString as _toDisplayString, setText as _setText, renderEffect as _renderEffect, createFor as _createFor, template as _template } from 'vue';
+const t0 = _template("<div> </div>")
+
+export function render(_ctx) {
+  const n0 = _createFor(() => (_ctx.obj), (_for_item0, _for_key0, _for_index0) => {
+    const n2 = t0()
+    const x2 = _txt(n2)
+    _renderEffect(() => _setText(x2, _toDisplayString(_for_key0.value) + ": " + _toDisplayString(_for_item0.value) + ": " + _toDisplayString(_for_index0.value)))
+    return n2
+  }, (value, key, idx) => (idx))
+  return n0
+}
+
+===
 name: v-for range
 options: vapor
 --- INPUT ---

--- a/tests/fixtures/vapor/v-for.pkl
+++ b/tests/fixtures/vapor/v-for.pkl
@@ -22,6 +22,10 @@ cases {
     input = #"<div v-for="(value, key) in obj" :key="key">{{ key }}: {{ value }}</div>"#
   }
   new {
+    name = "v-for object with index"
+    input = #"<div v-for="(value, key, idx) in obj" :key="idx">{{ key }}: {{ value }}: {{ idx }}</div>"#
+  }
+  new {
     name = "v-for range"
     input = #"<div v-for="n in 10" :key="n">{{ n }}</div>"#
   }


### PR DESCRIPTION
## Summary
- pass the third v-for alias through Vapor createFor callbacks
- resolve index aliases from Vapor for scopes instead of `_ctx`
- add a vapor fixture covering object v-for index usage in text and :key

Fixes #1184

## Verification
- cargo test -p vize_test_runner vapor_v_for -- --ignored --nocapture
- cargo test -p vize_atelier_vapor for_loop::tests -- --nocapture
- cargo fmt --all -- --check
- git diff --check
- cargo clippy -p vize_atelier_vapor -p vize_test_runner -- -D warnings
- cargo semver-checks check-release --package vize_atelier_vapor

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1270"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783593992&installation_id=136613492&pr_number=1270&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1270&signature=b7ebfdf81e4e194bee65ddfcca89cf9770349ac6cb5f0ef444d956078eff9269"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->