### PR TITLE
fix(atelier_sfc): scope functional CSS selectors in compile_css

### DIFF
--- a/crates/vize_atelier_sfc/src/css/scoped.rs
+++ b/crates/vize_atelier_sfc/src/css/scoped.rs
@@ -5,7 +5,7 @@
 
 use vize_carton::{Bump, BumpVec};
 
-use super::transform::{find_bytes, find_matching_paren, rfind_byte};
+use super::transform::find_matching_paren;
 
 /// Apply scoped CSS transformation
 pub(crate) fn apply_scoped_css<'a>(bump: &'a Bump, css: &str, scope_id: &str) -> &'a str {
@@ -241,15 +241,40 @@ fn scope_selector(out: &mut BumpVec<u8>, selector: &str, attr_selector: &[u8]) {
         return;
     }
 
-    // Handle multiple selectors separated by comma
+    // Handle multiple selectors separated by top-level commas. Commas inside
+    // functional pseudo-class arguments belong to the same selector.
     let mut first = true;
-    for part in selector.split(',') {
+    for part in split_top_level_commas(selector) {
         if !first {
             out.extend_from_slice(b", ");
         }
         first = false;
         scope_single_selector(out, part.trim(), attr_selector);
     }
+}
+
+fn split_top_level_commas(s: &str) -> Vec<&str> {
+    let bytes = s.as_bytes();
+    let mut out = Vec::new();
+    let mut depth: i32 = 0;
+    let mut last = 0;
+    let mut i = 0;
+
+    while i < bytes.len() {
+        match bytes[i] {
+            b'(' | b'[' => depth += 1,
+            b')' | b']' => depth -= 1,
+            b',' if depth == 0 => {
+                out.push(&s[last..i]);
+                last = i + 1;
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+
+    out.push(&s[last..]);
+    out
 }
 
 /// Add scope attribute to a single selector
@@ -274,8 +299,8 @@ fn scope_single_selector(out: &mut BumpVec<u8>, selector: &str, attr_selector: &
         return;
     }
 
-    // Find the last simple selector to append the attribute
-    let parts: Vec<&str> = selector.split_whitespace().collect();
+    // Find the last top-level compound selector to append the attribute.
+    let parts: Vec<&str> = split_top_level_whitespace(selector);
     if parts.is_empty() {
         out.extend_from_slice(selector.as_bytes());
         return;
@@ -296,31 +321,80 @@ fn scope_single_selector(out: &mut BumpVec<u8>, selector: &str, attr_selector: &
     }
 }
 
+fn split_top_level_whitespace(s: &str) -> Vec<&str> {
+    let bytes = s.as_bytes();
+    let mut out = Vec::new();
+    let mut depth: i32 = 0;
+    let mut start: Option<usize> = None;
+    let mut i = 0;
+
+    while i < bytes.len() {
+        let byte = bytes[i];
+        match byte {
+            b'(' | b'[' => {
+                if start.is_none() {
+                    start = Some(i);
+                }
+                depth += 1;
+            }
+            b')' | b']' => {
+                depth -= 1;
+            }
+            b' ' | b'\t' | b'\n' | b'\r' if depth == 0 => {
+                if let Some(start_pos) = start.take() {
+                    out.push(&s[start_pos..i]);
+                }
+            }
+            _ => {
+                if start.is_none() {
+                    start = Some(i);
+                }
+            }
+        }
+        i += 1;
+    }
+
+    if let Some(start_pos) = start {
+        out.push(&s[start_pos..]);
+    }
+
+    out
+}
+
 /// Add scope attribute to an element selector
 pub(super) fn add_scope_to_element(out: &mut BumpVec<u8>, selector: &str, attr_selector: &[u8]) {
-    let bytes = selector.as_bytes();
-
-    // Handle pseudo-elements (::before, ::after, etc.)
-    if let Some(pseudo_pos) = find_bytes(bytes, b"::") {
-        out.extend_from_slice(&bytes[..pseudo_pos]);
-        out.extend_from_slice(attr_selector);
-        out.extend_from_slice(&bytes[pseudo_pos..]);
-        return;
-    }
-
-    // Handle pseudo-classes (:hover, :focus, etc.)
-    if let Some(pseudo_pos) = rfind_byte(bytes, b':')
-        && pseudo_pos > 0
-        && bytes[pseudo_pos - 1] != b'\\'
+    // Find the first top-level pseudo-element or pseudo-class so the scope
+    // attribute lands on the compound selector, not inside a functional
+    // pseudo-class argument.
+    if let Some(pseudo_pos) = find_top_level_pseudo(selector)
+        && !selector[..pseudo_pos].ends_with('\\')
     {
-        out.extend_from_slice(&bytes[..pseudo_pos]);
+        out.extend_from_slice(&selector.as_bytes()[..pseudo_pos]);
         out.extend_from_slice(attr_selector);
-        out.extend_from_slice(&bytes[pseudo_pos..]);
+        out.extend_from_slice(&selector.as_bytes()[pseudo_pos..]);
         return;
     }
 
-    out.extend_from_slice(bytes);
+    out.extend_from_slice(selector.as_bytes());
     out.extend_from_slice(attr_selector);
+}
+
+fn find_top_level_pseudo(selector: &str) -> Option<usize> {
+    let bytes = selector.as_bytes();
+    let mut depth: i32 = 0;
+    let mut i = 0;
+
+    while i < bytes.len() {
+        match bytes[i] {
+            b'(' | b'[' => depth += 1,
+            b')' | b']' => depth -= 1,
+            b':' if depth == 0 => return Some(i),
+            _ => {}
+        }
+        i += 1;
+    }
+
+    None
 }
 
 /// Transform :deep() to descendant selector

--- a/crates/vize_atelier_sfc/src/css/tests.rs
+++ b/crates/vize_atelier_sfc/src/css/tests.rs
@@ -13,7 +13,9 @@ use super::scoped::{
 use super::transform::{
     extract_and_transform_v_bind, extract_and_transform_v_bind_with_scope, prod_scoped_v_bind_name,
 };
-use super::{CssCompileOptions, bundle_css, compile_css, parse_css_ast, print_css_ast};
+use super::{CssCompileOptions, bundle_css, compile_css};
+#[cfg(feature = "native")]
+use super::{parse_css_ast, print_css_ast};
 
 fn test_utf8(bytes: &[u8]) -> &str {
     match std::str::from_utf8(bytes) {
@@ -29,6 +31,29 @@ fn v_bind_snapshot<T: AsRef<str>>(transformed: &str, vars: &[T]) -> String {
         .collect::<Vec<_>>()
         .join("\n");
     format!("vars:\n{vars}\n\ncss:\n{transformed}")
+}
+
+fn css_without_ascii_whitespace(css: &str) -> String {
+    css.chars()
+        .filter(|char| !char.is_ascii_whitespace())
+        .collect()
+}
+
+fn compile_scoped_css_without_whitespace(css: &str) -> String {
+    let result = compile_css(
+        css,
+        &CssCompileOptions {
+            scoped: true,
+            scope_id: Some("data-v-123".to_compact_string()),
+            ..Default::default()
+        },
+    );
+    assert!(
+        result.errors.is_empty(),
+        "Unexpected errors: {:?}",
+        result.errors
+    );
+    css_without_ascii_whitespace(&result.code)
 }
 
 #[test]
@@ -52,6 +77,27 @@ fn test_compile_scoped_css() {
     );
     assert!(result.errors.is_empty());
     insta::assert_debug_snapshot!(result);
+}
+
+#[test]
+fn test_compile_scoped_css_keeps_functional_pseudo_selector_list_intact() {
+    let code = compile_scoped_css_without_whitespace(".btn:is(.a, .b) { color: red; }");
+
+    assert_eq!(code, ".btn[data-v-123]:is(.a,.b){color:red;}");
+}
+
+#[test]
+fn test_compile_scoped_css_scopes_before_functional_pseudo() {
+    let code = compile_scoped_css_without_whitespace(".foo:not(:hover) { color: red; }");
+
+    assert_eq!(code, ".foo[data-v-123]:not(:hover){color:red;}");
+}
+
+#[test]
+fn test_compile_scoped_css_keeps_functional_pseudo_whitespace_intact() {
+    let code = compile_scoped_css_without_whitespace(".card:has(.icon + .label) { color: red; }");
+
+    assert_eq!(code, ".card[data-v-123]:has(.icon+.label){color:red;}");
 }
 
 #[cfg(feature = "native")]

--- a/crates/vize_atelier_sfc/src/css/transform.rs
+++ b/crates/vize_atelier_sfc/src/css/transform.rs
@@ -228,18 +228,6 @@ fn write_hex_u32(out: &mut BumpVec<u8>, val: u32) {
     out.push(HEX[(val & 0xF) as usize]);
 }
 
-/// Find byte sequence in slice
-#[inline]
-pub(crate) fn find_bytes(haystack: &[u8], needle: &[u8]) -> Option<usize> {
-    haystack.windows(needle.len()).position(|w| w == needle)
-}
-
-/// Reverse find single byte in slice
-#[inline]
-pub(crate) fn rfind_byte(haystack: &[u8], needle: u8) -> Option<usize> {
-    haystack.iter().rposition(|&b| b == needle)
-}
-
 /// Find the matching closing parenthesis
 pub(crate) fn find_matching_paren(s: &str) -> Option<usize> {
     let mut depth = 1u32;


### PR DESCRIPTION
## Summary
- Port top-level selector splitting to the public compile_css scoped CSS path so commas and whitespace inside functional pseudo-classes stay intact.
- Insert the scope attribute before the first top-level pseudo instead of searching inside pseudo arguments.
- Add focused compile_css coverage for :is(), :not(), and :has() scoped selectors.

## Verification
- cargo test -p vize_atelier_sfc test_compile_scoped_css -- --nocapture
- cargo test -p vize_atelier_sfc --no-default-features test_compile_scoped_css_keeps_functional_pseudo -- --nocapture
- cargo test -p vize_atelier_sfc --no-default-features test_compile_scoped_css_scopes_before_functional_pseudo -- --nocapture
- cargo test -p vize_atelier_sfc

Fixes #1178

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1272"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783594104&installation_id=136613492&pr_number=1272&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1272&signature=678132bf7890972ec20f6da24dd795ba2a0b39524358da206f5e5330e30425f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->