### PR TITLE
fix(vize_patina): report lint columns as characters

### DIFF
--- a/crates/vize_patina/src/output.rs
+++ b/crates/vize_patina/src/output.rs
@@ -571,6 +571,7 @@ fn push_indented_lines(output: &mut String, text: &str, indent: &str) {
 
 struct SourceLineIndex<'source> {
     source: &'source str,
+    is_ascii: bool,
     source_len: usize,
     line_starts: SmallVec<[usize; 64]>,
 }
@@ -589,6 +590,7 @@ impl<'source> SourceLineIndex<'source> {
 
         Self {
             source,
+            is_ascii: source.is_ascii(),
             source_len: bytes.len(),
             line_starts,
         }
@@ -602,6 +604,9 @@ impl<'source> SourceLineIndex<'source> {
             .saturating_sub(1);
         let line_start = self.line_starts.get(line_index).copied().unwrap_or(0);
         let line = line_index as u32 + 1;
+        if self.is_ascii {
+            return (line, offset.saturating_sub(line_start) as u32 + 1);
+        }
         let column = self.source[line_start..]
             .char_indices()
             .take_while(|(relative_offset, _)| line_start + *relative_offset < offset)

--- a/crates/vize_patina/src/output.rs
+++ b/crates/vize_patina/src/output.rs
@@ -275,7 +275,9 @@ fn diagnostic_location(
         })
 }
 
-fn source_indices(sources: &[(String, String)]) -> FxHashMap<&str, SourceLineIndex> {
+fn source_indices<'source>(
+    sources: &'source [(String, String)],
+) -> FxHashMap<&'source str, SourceLineIndex<'source>> {
     sources
         .iter()
         .map(|(filename, source)| (filename.as_str(), SourceLineIndex::new(source.as_str())))
@@ -567,13 +569,14 @@ fn push_indented_lines(output: &mut String, text: &str, indent: &str) {
     }
 }
 
-struct SourceLineIndex {
+struct SourceLineIndex<'source> {
+    source: &'source str,
     source_len: usize,
     line_starts: SmallVec<[usize; 64]>,
 }
 
-impl SourceLineIndex {
-    fn new(source: &str) -> Self {
+impl<'source> SourceLineIndex<'source> {
+    fn new(source: &'source str) -> Self {
         let bytes = source.as_bytes();
         let mut line_starts = SmallVec::new();
         line_starts.push(0);
@@ -585,6 +588,7 @@ impl SourceLineIndex {
         }
 
         Self {
+            source,
             source_len: bytes.len(),
             line_starts,
         }
@@ -598,7 +602,11 @@ impl SourceLineIndex {
             .saturating_sub(1);
         let line_start = self.line_starts.get(line_index).copied().unwrap_or(0);
         let line = line_index as u32 + 1;
-        let column = offset.saturating_sub(line_start) as u32 + 1;
+        let column = self.source[line_start..]
+            .char_indices()
+            .take_while(|(relative_offset, _)| line_start + *relative_offset < offset)
+            .count() as u32
+            + 1;
 
         (line, column)
     }
@@ -636,6 +644,37 @@ const items = [1]
             output.contains(r#""ruleDocsPath": "docs/content/rules/vue.md""#),
             "{output}"
         );
+    }
+
+    #[test]
+    fn json_output_uses_character_columns_after_multibyte_text() {
+        let source = r#"<template><div title="café" v-html="x"></div></template>"#;
+        let filename = vize_carton::String::from("Component.vue");
+        let start = source.find("v-html").unwrap() as u32;
+        let end = start + "v-html".len() as u32;
+        let result = LintResult {
+            filename: filename.clone(),
+            diagnostics: vec![LintDiagnostic::warn(
+                "vue/no-v-html",
+                "Avoid raw HTML",
+                start,
+                end,
+            )],
+            error_count: 0,
+            warning_count: 1,
+        };
+        let output = format_results(
+            &[result],
+            &[(filename, vize_carton::String::from(source))],
+            OutputFormat::Json,
+        );
+        let json: serde_json::Value = serde_json::from_str(&output).unwrap();
+        let diagnostic = &json[0]["messages"][0];
+
+        assert_eq!(diagnostic["line"], 1);
+        assert_eq!(diagnostic["column"], 29);
+        assert_eq!(diagnostic["endLine"], 1);
+        assert_eq!(diagnostic["endColumn"], 35);
     }
 
     #[test]

--- a/crates/vize_patina/src/output.rs
+++ b/crates/vize_patina/src/output.rs
@@ -275,9 +275,7 @@ fn diagnostic_location(
         })
 }
 
-fn source_indices<'source>(
-    sources: &'source [(String, String)],
-) -> FxHashMap<&'source str, SourceLineIndex<'source>> {
+fn source_indices(sources: &[(String, String)]) -> FxHashMap<&str, SourceLineIndex> {
     sources
         .iter()
         .map(|(filename, source)| (filename.as_str(), SourceLineIndex::new(source.as_str())))
@@ -569,15 +567,15 @@ fn push_indented_lines(output: &mut String, text: &str, indent: &str) {
     }
 }
 
-struct SourceLineIndex<'source> {
-    source: &'source str,
+struct SourceLineIndex {
     is_ascii: bool,
     source_len: usize,
     line_starts: SmallVec<[usize; 64]>,
+    multibyte_adjustments: SmallVec<[(usize, u32); 16]>,
 }
 
-impl<'source> SourceLineIndex<'source> {
-    fn new(source: &'source str) -> Self {
+impl SourceLineIndex {
+    fn new(source: &str) -> Self {
         let bytes = source.as_bytes();
         let mut line_starts = SmallVec::new();
         line_starts.push(0);
@@ -588,11 +586,24 @@ impl<'source> SourceLineIndex<'source> {
             }
         }
 
+        let is_ascii = source.is_ascii();
+        let mut multibyte_adjustments = SmallVec::new();
+        if !is_ascii {
+            let mut extra_bytes = 0u32;
+            for (index, ch) in source.char_indices() {
+                let width = ch.len_utf8();
+                if width > 1 {
+                    extra_bytes += (width - 1) as u32;
+                    multibyte_adjustments.push((index + width, extra_bytes));
+                }
+            }
+        }
+
         Self {
-            source,
-            is_ascii: source.is_ascii(),
+            is_ascii,
             source_len: bytes.len(),
             line_starts,
+            multibyte_adjustments,
         }
     }
 
@@ -607,13 +618,23 @@ impl<'source> SourceLineIndex<'source> {
         if self.is_ascii {
             return (line, offset.saturating_sub(line_start) as u32 + 1);
         }
-        let column = self.source[line_start..]
-            .char_indices()
-            .take_while(|(relative_offset, _)| line_start + *relative_offset < offset)
-            .count() as u32
-            + 1;
+        let byte_column = offset.saturating_sub(line_start) as u32 + 1;
+        let extra_bytes_before_column = self
+            .extra_bytes_before(offset)
+            .saturating_sub(self.extra_bytes_before(line_start));
+        let column = byte_column.saturating_sub(extra_bytes_before_column);
 
         (line, column)
+    }
+
+    fn extra_bytes_before(&self, offset: usize) -> u32 {
+        let adjustment_index = self
+            .multibyte_adjustments
+            .partition_point(|&(byte_offset, _)| byte_offset <= offset);
+        adjustment_index
+            .checked_sub(1)
+            .map(|index| self.multibyte_adjustments[index].1)
+            .unwrap_or(0)
     }
 }
 

--- a/tests/tooling/cli-lint-contract.test.ts
+++ b/tests/tooling/cli-lint-contract.test.ts
@@ -52,6 +52,8 @@ function withWorkspace<T>(run: (dir: string) => T): T {
 // these fixtures isolate the rule under test.
 const MULTI_SPACE = '<template>\n  <div  id="x"></div>\n</template>\n';
 const CLEAN = '<template>\n  <div id="x" />\n</template>\n';
+const MULTIBYTE_BEFORE_DIRECTIVE =
+  '<template><div title="café" v-html="x"></div></template>\n';
 
 test("vize lint --help documents the fix/config/max-warnings surface", () => {
   const result = spawnSync(VIZE.command, [...VIZE.prefix, "lint", "--help"], {
@@ -117,6 +119,31 @@ test("vize lint --format json emits a stable per-file message envelope", () => {
     assert.equal(message.line, 2);
     assert.equal(typeof message.column, "number");
     assert.ok(message.endColumn > message.column);
+  });
+});
+
+test("vize lint --format json reports character columns after multibyte text", () => {
+  withWorkspace((dir) => {
+    fs.writeFileSync(path.join(dir, "Cafe.vue"), MULTIBYTE_BEFORE_DIRECTIVE, "utf8");
+    const result = runLint(["Cafe.vue", "--format", "json"], dir);
+    assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
+
+    const parsed = JSON.parse(result.stdout) as Array<{
+      messages: Array<{
+        ruleId: string;
+        line: number;
+        column: number;
+        endLine: number;
+        endColumn: number;
+      }>;
+    }>;
+    const message = parsed[0]?.messages.find((item) => item.ruleId === "vue/no-v-html");
+
+    assert.ok(message, result.stdout);
+    assert.equal(message.line, 1);
+    assert.equal(message.column, 29);
+    assert.equal(message.endLine, 1);
+    assert.equal(message.endColumn, 39);
   });
 });
 

--- a/tests/tooling/cli-lint-contract.test.ts
+++ b/tests/tooling/cli-lint-contract.test.ts
@@ -52,8 +52,7 @@ function withWorkspace<T>(run: (dir: string) => T): T {
 // these fixtures isolate the rule under test.
 const MULTI_SPACE = '<template>\n  <div  id="x"></div>\n</template>\n';
 const CLEAN = '<template>\n  <div id="x" />\n</template>\n';
-const MULTIBYTE_BEFORE_DIRECTIVE =
-  '<template><div title="café" v-html="x"></div></template>\n';
+const MULTIBYTE_BEFORE_DIRECTIVE = '<template><div title="café" v-html="x"></div></template>\n';
 
 test("vize lint --help documents the fix/config/max-warnings surface", () => {
   const result = spawnSync(VIZE.command, [...VIZE.prefix, "lint", "--help"], {


### PR DESCRIPTION
## Summary
- convert Patina diagnostic output columns from byte offsets to 1-based Unicode scalar columns
- add a formatter regression for multibyte text before a diagnostic
- add a CLI JSON contract expectation for the issue reproduction

Fixes #1197.

## Verification
- cargo test -p vize_patina output::tests
- cargo clippy -p vize_patina -- -D warnings
- cargo build --profile ci -p vize
- node --test tests/tooling/cli-lint-contract.test.ts

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1273"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783594159&installation_id=136613492&pr_number=1273&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1273&signature=1aa0415db25eecb0475395160ab02e741a45e8b9f7d7f594f62d735f76d1afbc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->