### PR TITLE
fix(atelier_ssr): render dynamic fallthrough input models

### DIFF
--- a/crates/vize_atelier_ssr/src/codegen/element/plain.rs
+++ b/crates/vize_atelier_ssr/src/codegen/element/plain.rs
@@ -140,6 +140,7 @@ impl<'a> SsrCodegenContext<'a> {
         let mut entries: std::vec::Vec<VNodePropEntry> = std::vec::Vec::new();
         let mut spreads: std::vec::Vec<String> = std::vec::Vec::new();
         let mut needs_normalize = false;
+        let mut dynamic_model_exp = None;
 
         for prop in &el.props {
             match prop {
@@ -158,6 +159,7 @@ impl<'a> SsrCodegenContext<'a> {
                         &mut entries,
                         &mut spreads,
                         &mut needs_normalize,
+                        &mut dynamic_model_exp,
                     );
                 }
             }
@@ -191,6 +193,14 @@ impl<'a> SsrCodegenContext<'a> {
             args.push("_attrs".to_compact_string());
         }
 
+        if let Some(model_exp) = dynamic_model_exp {
+            self.use_ssr_helper(RuntimeHelper::SsrGetDynamicModelProps);
+            let existing_props = self.merge_props_args_expression(&args);
+            args.push(cstr!(
+                "_ssrGetDynamicModelProps({existing_props}, {model_exp})"
+            ));
+        }
+
         if args.is_empty() {
             return "null".to_compact_string();
         }
@@ -212,6 +222,25 @@ impl<'a> SsrCodegenContext<'a> {
         out
     }
 
+    fn merge_props_args_expression(&mut self, args: &[String]) -> String {
+        match args {
+            [] => "{}".to_compact_string(),
+            [arg] => arg.clone(),
+            _ => {
+                self.use_core_helper(RuntimeHelper::MergeProps);
+                let mut out = String::from("_mergeProps(");
+                for (index, arg) in args.iter().enumerate() {
+                    if index > 0 {
+                        out.push_str(", ");
+                    }
+                    out.push_str(arg);
+                }
+                out.push(')');
+                out
+            }
+        }
+    }
+
     fn collect_element_directive_attr(
         &mut self,
         el: &ElementNode,
@@ -219,6 +248,7 @@ impl<'a> SsrCodegenContext<'a> {
         entries: &mut std::vec::Vec<VNodePropEntry>,
         spreads: &mut std::vec::Vec<String>,
         needs_normalize: &mut bool,
+        dynamic_model_exp: &mut Option<String>,
     ) {
         match dir.name.as_str() {
             "bind" => {
@@ -245,7 +275,7 @@ impl<'a> SsrCodegenContext<'a> {
                 }
             }
             "model" => {
-                self.collect_v_model_element_attr(el, dir, entries);
+                self.collect_v_model_element_attr(el, dir, entries, dynamic_model_exp);
             }
             "show" => {
                 let Some(exp) = dir.exp.as_ref().map(|exp| self.expression_to_string(exp)) else {
@@ -273,18 +303,18 @@ impl<'a> SsrCodegenContext<'a> {
         el: &ElementNode,
         dir: &DirectiveNode,
         entries: &mut std::vec::Vec<VNodePropEntry>,
+        dynamic_model_exp: &mut Option<String>,
     ) {
         let Some(exp) = dir.exp.as_ref().map(|exp| self.expression_to_string(exp)) else {
             return;
         };
 
         if el.tag == "input" {
-            // Dynamic `:type` — fall back to `value` for now, but flag the
-            // direct-process path (called when inherit_attrs=false) so
-            // checkbox/radio at runtime render `checked`. The merged-attrs
-            // path here still emits `value=...` rather than Vue's `_temp0`
-            // trick because the surrounding merge expression isn't shaped
-            // for the dynamic helper yet. (#962)
+            if self.get_dynamic_bind_exp(el, "type").is_some() {
+                *dynamic_model_exp = Some(exp);
+                return;
+            }
+
             let input_type = self.get_element_attr_value(el, "type");
             match input_type.as_deref() {
                 Some("checkbox") => {

--- a/crates/vize_atelier_ssr/tests/snapshots/ssr_snapshot__v_model__v_model_dynamic_type_fallthrough_root.snap
+++ b/crates/vize_atelier_ssr/tests/snapshots/ssr_snapshot__v_model__v_model_dynamic_type_fallthrough_root.snap
@@ -1,0 +1,7 @@
+---
+source: crates/vize_atelier_ssr/tests/ssr_snapshot.rs
+expression: "compile_full(r#\"<input :type=\"t\" v-model=\"val\">\"#)"
+---
+function ssrRender(_ctx, _push, _parent, _attrs) {
+  _push(`<input${_ssrRenderAttrs(_mergeProps({ type: _ctx.t }, _attrs, _ssrGetDynamicModelProps(_mergeProps({ type: _ctx.t }, _attrs), _ctx.val)))}>`)
+}

--- a/crates/vize_atelier_ssr/tests/ssr_snapshot.rs
+++ b/crates/vize_atelier_ssr/tests/ssr_snapshot.rs
@@ -238,7 +238,7 @@ mod v_for {
 // =============================================================================
 
 mod v_model {
-    use super::get_compiled_string;
+    use super::{compile_full, get_compiled_string};
 
     #[test]
     fn v_model_text_input() {
@@ -257,6 +257,11 @@ mod v_model {
         insta::assert_snapshot!(get_compiled_string(
             r#"<input type="radio" v-model="picked" value="a">"#
         ));
+    }
+
+    #[test]
+    fn v_model_dynamic_type_fallthrough_root() {
+        insta::assert_snapshot!(compile_full(r#"<input :type="t" v-model="val">"#));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Fix fallthrough-root `<input :type v-model>` SSR attrs to append dynamic model props instead of hardcoding `value`.
- Add a root-level SSR snapshot for the inherit-attrs path.

## Root cause
The merged-attrs path only checked static `type` attributes, so dynamic `:type` fell through to `{ value: model }`. Runtime checkbox/radio inputs therefore missed the `checked` model handling.

## Validation
- `cargo fmt -p vize_atelier_ssr --check`
- `cargo test -p vize_atelier_ssr v_model_dynamic_type_fallthrough_root`
- `cargo test -p vize_atelier_ssr`
- `cargo clippy -p vize_atelier_ssr --all-targets -- -D warnings`

Closes #1188

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1274"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783595802&installation_id=136613492&pr_number=1274&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1274&signature=8eb931e98191b2a116efe2e7d7a122f64292c46b842203585347d0217f1981d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->