### PR TITLE
fix(canon): check computed event handler references

### DIFF
--- a/crates/vize_canon/src/batch/type_checker/tests.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests.rs
@@ -462,6 +462,17 @@ function handleName(name: string): void {
 "#,
             ),
             (
+                "src/ComputedMemberHandler.vue",
+                r#"<script setup lang="ts">
+const handlers = { x: 42 } as const
+</script>
+
+<template>
+  <button @click="handlers['x']">Click me</button>
+</template>
+"#,
+            ),
+            (
                 "src/ZeroArgButton.vue",
                 r#"<script setup lang="ts">
 const emit = defineEmits<{
@@ -533,6 +544,12 @@ function toggle(open = false): void {
                 && message.contains("PointerEvent")
         }),
         "expected WrongEventHandler.vue to report PointerEvent mismatch, got: {snapshot:#?}"
+    );
+    assert!(
+        snapshot.iter().any(|(file, code, _)| {
+            file == "src/ComputedMemberHandler.vue" && *code == Some(2345)
+        }),
+        "expected ComputedMemberHandler.vue to report TS2345, got: {snapshot:#?}"
     );
     assert!(
         snapshot

--- a/crates/vize_canon/src/virtual_ts.rs
+++ b/crates/vize_canon/src/virtual_ts.rs
@@ -751,6 +751,49 @@ const val = 0 as unknown as UnionType;
     }
 
     #[test]
+    fn test_computed_member_event_handler_reference_is_called_with_event() {
+        use vize_croquis::{Analyzer, AnalyzerOptions};
+
+        let script = r#"const handlers = { x: 42 } as const
+const arr = [(event: PointerEvent) => event.preventDefault()]
+"#;
+        let template =
+            r#"<button @click="handlers['x']">Bad</button><button @click="arr[0]">Good</button>"#;
+
+        let allocator = vize_carton::Bump::new();
+        let (root, _) = vize_armature::parse(&allocator, template);
+
+        let mut analyzer = Analyzer::with_options(AnalyzerOptions::full());
+        analyzer.analyze_script_setup(script);
+        analyzer.analyze_template(&root);
+        let summary = analyzer.finish();
+
+        let output = generate_virtual_ts(&summary, Some(script), Some(&root), 0);
+
+        assert!(
+            output.code.contains(
+                "((handler: ($event: PointerEvent) => unknown) => handler)((handlers['x']));"
+            ),
+            "computed-member handler references should be checked as callable:\n{}",
+            output.code
+        );
+        assert!(
+            output
+                .code
+                .contains("((handler: ($event: PointerEvent) => unknown) => handler)((arr[0]));"),
+            "index handler references should be checked as callable:\n{}",
+            output.code
+        );
+        assert!(
+            !output
+                .code
+                .contains("handlers['x'];  // handler expression"),
+            "computed-member handler must not be emitted as a bare statement:\n{}",
+            output.code
+        );
+    }
+
+    #[test]
     fn test_multiline_statement_event_handler_uses_handler_scope() {
         use vize_croquis::{Analyzer, AnalyzerOptions};
 

--- a/crates/vize_canon/src/virtual_ts/scope.rs
+++ b/crates/vize_canon/src/virtual_ts/scope.rs
@@ -1045,7 +1045,42 @@ fn is_callable_handler_reference(content: &str) -> bool {
         return false;
     }
 
-    trimmed.split('.').all(is_identifier_segment)
+    let Some(mut idx) = parse_identifier_segment(trimmed, 0) else {
+        return false;
+    };
+
+    loop {
+        idx = skip_ascii_whitespace(trimmed, idx);
+        if idx == trimmed.len() {
+            return true;
+        }
+
+        let rest = &trimmed[idx..];
+        if rest.starts_with("?.[") {
+            idx += 2;
+            let Some(next_idx) = parse_bracket_member(trimmed, idx) else {
+                return false;
+            };
+            idx = next_idx;
+        } else if rest.starts_with("?.") {
+            let Some(next_idx) = parse_identifier_segment(trimmed, idx + 2) else {
+                return false;
+            };
+            idx = next_idx;
+        } else if rest.starts_with('.') {
+            let Some(next_idx) = parse_identifier_segment(trimmed, idx + 1) else {
+                return false;
+            };
+            idx = next_idx;
+        } else if rest.starts_with('[') {
+            let Some(next_idx) = parse_bracket_member(trimmed, idx) else {
+                return false;
+            };
+            idx = next_idx;
+        } else {
+            return false;
+        }
+    }
 }
 
 fn is_identifier_segment(segment: &str) -> bool {
@@ -1059,6 +1094,81 @@ fn is_identifier_segment(segment: &str) -> bool {
     }
 
     chars.all(|ch| ch == '_' || ch == '$' || ch.is_alphanumeric())
+}
+
+fn parse_identifier_segment(input: &str, start: usize) -> Option<usize> {
+    let mut chars = input.get(start..)?.char_indices();
+    let (_, first) = chars.next()?;
+    if !is_identifier_start(first) {
+        return None;
+    }
+
+    let mut end = start + first.len_utf8();
+    for (offset, ch) in chars {
+        if !is_identifier_continue(ch) {
+            break;
+        }
+        end = start + offset + ch.len_utf8();
+    }
+    Some(end)
+}
+
+fn is_identifier_start(ch: char) -> bool {
+    ch == '_' || ch == '$' || ch.is_alphabetic()
+}
+
+fn is_identifier_continue(ch: char) -> bool {
+    ch == '_' || ch == '$' || ch.is_alphanumeric()
+}
+
+fn skip_ascii_whitespace(input: &str, mut idx: usize) -> usize {
+    while input
+        .as_bytes()
+        .get(idx)
+        .is_some_and(|byte| byte.is_ascii_whitespace())
+    {
+        idx += 1;
+    }
+    idx
+}
+
+fn parse_bracket_member(input: &str, open_index: usize) -> Option<usize> {
+    if input.as_bytes().get(open_index) != Some(&b'[') {
+        return None;
+    }
+
+    let mut depth = 0u32;
+    let mut quote = None;
+    let mut escaped = false;
+    for (idx, ch) in input
+        .char_indices()
+        .skip_while(|(idx, _)| *idx < open_index)
+    {
+        if let Some(quote_ch) = quote {
+            if escaped {
+                escaped = false;
+            } else if ch == '\\' {
+                escaped = true;
+            } else if ch == quote_ch {
+                quote = None;
+            }
+            continue;
+        }
+
+        match ch {
+            '\'' | '"' | '`' => quote = Some(ch),
+            '[' => depth += 1,
+            ']' => {
+                depth = depth.checked_sub(1)?;
+                if depth == 0 {
+                    return Some(idx + ch.len_utf8());
+                }
+            }
+            _ => {}
+        }
+    }
+
+    None
 }
 
 /// Recursively generate child scopes that are VFor/VSlot/EventHandler.


### PR DESCRIPTION
## Summary
- Treat computed/index/optional member event handler references as callable listener references in virtual TS.
- Add virtual TS and batch type checker regressions for `@click="handlers['x']"`.

## Tests
- `cargo fmt --check`
- `git diff --check HEAD~1..HEAD`
- `CARGO_TARGET_DIR=/tmp/vize-1207-target cargo test -p vize_canon computed_member_event_handler -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/vize-1207-target cargo test -p vize_canon batch_type_checker_reports_template_handler_mismatches_without_node_modules -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/vize-1207-target cargo clippy -p vize_canon --lib -- -D warnings`

Closes #1207

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1275"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783595843&installation_id=136613492&pr_number=1275&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1275&signature=5c0393cd0f9f199808e6e3ff7475ddbcde337fa491c53190698bb3201acbd54c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->