### PR TITLE
fix(atelier_core): cache merged v-on handlers

### DIFF
--- a/crates/vize_atelier_core/src/codegen.rs
+++ b/crates/vize_atelier_core/src/codegen.rs
@@ -877,6 +877,47 @@ mod tests {
     }
 
     #[test]
+    fn test_codegen_merged_v_on_handlers_are_cached() {
+        use crate::options::{CodegenOptions, TransformOptions};
+        use crate::parser::parse;
+        use crate::transform::transform;
+        use bumpalo::Bump;
+
+        let allocator = Bump::new();
+        let (mut root, _) = parse(
+            &allocator,
+            r#"<div @click="() => x++" @click.stop="() => y++"></div>"#,
+        );
+
+        transform(
+            &allocator,
+            &mut root,
+            TransformOptions {
+                prefix_identifiers: true,
+                ..Default::default()
+            },
+            None,
+        );
+
+        let result = super::generate(
+            &root,
+            CodegenOptions {
+                prefix_identifiers: true,
+                cache_handlers: true,
+                ..Default::default()
+            },
+        );
+        let output = result_output(&result);
+
+        assert!(
+            output.contains("onClick: [_cache[0] || (_cache[0] = () => _ctx.x++), _cache[1] || (_cache[1] = _withModifiers(() => _ctx.y++, [\"stop\"]))]"),
+            "merged same-event handlers should each be cached. Got:\n{}",
+            output
+        );
+        insta::assert_snapshot!(output.as_str());
+    }
+
+    #[test]
     fn test_codegen_scoped_slot_params_stay_local_in_handlers() {
         use crate::options::{CodegenOptions, TransformOptions};
         use crate::parser::parse;

--- a/crates/vize_atelier_core/src/codegen/props/directives.rs
+++ b/crates/vize_atelier_core/src/codegen/props/directives.rs
@@ -4,7 +4,7 @@ use crate::ast::{DirectiveNode, ExpressionNode, RuntimeHelper};
 
 use super::super::{
     context::CodegenContext,
-    expression::{generate_event_handler, generate_expression, generate_simple_expression},
+    expression::{generate_expression, generate_simple_expression},
     helpers::{camelize, escape_js_string, is_constant_simple_expression, is_valid_js_identifier},
 };
 use vize_carton::String;
@@ -370,54 +370,11 @@ fn generate_vbind_prop(
 
 /// Generate v-on directive as a prop
 fn generate_von_prop(ctx: &mut CodegenContext, dir: &DirectiveNode<'_>) {
-    // Get event name first to determine context for modifiers
-    let (event_name, is_dynamic_event) = if let Some(ExpressionNode::Simple(exp)) = &dir.arg {
-        (exp.content.as_str(), !exp.is_static)
+    let is_dynamic_event = if let Some(ExpressionNode::Simple(exp)) = &dir.arg {
+        !exp.is_static
     } else {
-        ("", false)
+        false
     };
-
-    // Check if this is a keyboard event (for context-dependent modifiers)
-    let is_keyboard_event = matches!(event_name, "keydown" | "keyup" | "keypress");
-
-    // Collect modifiers into categories
-    let mut event_option_modifiers: Vec<&str> = Vec::new();
-    let mut system_modifiers: Vec<&str> = Vec::new();
-    let mut key_modifiers: Vec<&str> = Vec::new();
-
-    for modifier in dir.modifiers.iter() {
-        let mod_name = modifier.content.as_str();
-        match mod_name {
-            // Event option modifiers - appended to event name
-            "capture" | "once" | "passive" => {
-                event_option_modifiers.push(mod_name);
-            }
-            // "native" modifier is a no-op in Vue 3 (removed)
-            "native" => {}
-            // Context-dependent: left/right are arrow keys on keyboard events,
-            // mouse buttons on click events
-            "left" | "right" => {
-                if is_keyboard_event {
-                    key_modifiers.push(mod_name);
-                } else {
-                    system_modifiers.push(mod_name);
-                }
-            }
-            // System modifiers - wrapped with withModifiers
-            "stop" | "prevent" | "self" | "ctrl" | "shift" | "alt" | "meta" | "middle"
-            | "exact" => {
-                system_modifiers.push(mod_name);
-            }
-            // Key modifiers - wrapped with withKeys
-            "enter" | "tab" | "delete" | "esc" | "space" | "up" | "down" => {
-                key_modifiers.push(mod_name);
-            }
-            _ => {
-                // Unknown modifiers (including numeric keycodes) are treated as key modifiers
-                key_modifiers.push(mod_name);
-            }
-        }
-    }
 
     if let Some(ExpressionNode::Simple(exp)) = &dir.arg {
         if is_dynamic_event {
@@ -460,96 +417,7 @@ fn generate_von_prop(ctx: &mut CodegenContext, dir: &DirectiveNode<'_>) {
         }
     }
 
-    // Generate handler with optional withModifiers/withKeys wrappers
-    // Order: _withKeys(_withModifiers(handler, [system_mods]), [key_mods])
-    let has_system_mods = !system_modifiers.is_empty();
-    let has_key_mods = !key_modifiers.is_empty();
-
-    // Check if this handler needs caching.
-    // Scoped params from v-for / slots must disable caching, otherwise the
-    // cached closure captures the first scoped value and gets reused.
-    // Setup-const bindings are already stable references and also skip caching.
-    // Pattern: _cache[n] || (_cache[n] = handler)
-    // Simple identifiers get safety wrapper: (...args) => (_ctx.handler && _ctx.handler(...args))
-    // Inline expressions get: $event => (expression)
-    let is_const_handler = dir.exp.as_ref().is_some_and(|exp| {
-        if let ExpressionNode::Simple(simple) = exp
-            && !simple.is_static
-        {
-            let content = simple.content.trim();
-            // Check if content is a simple identifier that's a setup-const binding
-            if crate::transforms::is_simple_identifier(content)
-                && let Some(ref metadata) = ctx.options.binding_metadata
-            {
-                return matches!(
-                    metadata.bindings.get(content),
-                    Some(crate::options::BindingType::SetupConst)
-                );
-            }
-        }
-        false
-    });
-    let needs_cache =
-        ctx.cache_handlers_in_current_scope() && dir.exp.is_some() && !is_const_handler;
-
-    if needs_cache {
-        let cache_index = ctx.next_cache_index();
-        ctx.push("_cache[");
-        ctx.push(&cache_index.to_compact_string());
-        ctx.push("] || (_cache[");
-        ctx.push(&cache_index.to_compact_string());
-        ctx.push("] = ");
-    }
-
-    if has_key_mods {
-        ctx.use_helper(RuntimeHelper::WithKeys);
-        ctx.push("_withKeys(");
-    }
-
-    if has_system_mods {
-        ctx.use_helper(RuntimeHelper::WithModifiers);
-        ctx.push("_withModifiers(");
-    }
-
-    // Generate the actual handler
-    if let Some(exp) = &dir.exp {
-        generate_event_handler(ctx, exp, needs_cache);
-    } else {
-        ctx.push("() => {}");
-    }
-
-    // Close withModifiers wrapper
-    if has_system_mods {
-        ctx.push(", [");
-        for (i, mod_name) in system_modifiers.iter().enumerate() {
-            if i > 0 {
-                ctx.push(",");
-            }
-            ctx.push("\"");
-            ctx.push(mod_name);
-            ctx.push("\"");
-        }
-        ctx.push("])");
-    }
-
-    // Close withKeys wrapper
-    if has_key_mods {
-        ctx.push(", [");
-        for (i, mod_name) in key_modifiers.iter().enumerate() {
-            if i > 0 {
-                ctx.push(",");
-            }
-            ctx.push("\"");
-            ctx.push(mod_name);
-            ctx.push("\"");
-        }
-        ctx.push("])");
-    }
-
-    // Close cache wrapper
-    if needs_cache {
-        ctx.push(")");
-    }
+    super::events::generate_von_handler_value(ctx, dir);
 }
 
 /// Generate dynamic v-model on component as props

--- a/crates/vize_atelier_core/src/codegen/props/events.rs
+++ b/crates/vize_atelier_core/src/codegen/props/events.rs
@@ -1,6 +1,7 @@
 //! Event-related props generation (v-on merging and handler generation).
 
 use crate::ast::{DirectiveNode, ExpressionNode, PropNode, RuntimeHelper};
+use crate::options::BindingType;
 
 use super::super::{
     context::CodegenContext,
@@ -8,6 +9,7 @@ use super::super::{
     helpers::{camelize, capitalize_first},
 };
 use vize_carton::String;
+use vize_carton::ToCompactString;
 
 /// Compute the prop key for a static v-on event, mirroring Vue's
 /// `transforms/vOn.ts` casing rules.
@@ -137,7 +139,7 @@ pub(super) fn generate_merged_event_handlers(
 }
 
 /// Generate just the handler value part of a v-on directive (without the key name)
-fn generate_von_handler_value(ctx: &mut CodegenContext, dir: &DirectiveNode<'_>) {
+pub(super) fn generate_von_handler_value(ctx: &mut CodegenContext, dir: &DirectiveNode<'_>) {
     // Classify modifiers (same logic as in generate_directive_prop_with_static)
     let event_name = if let Some(ExpressionNode::Simple(exp)) = &dir.arg {
         exp.content.as_str()
@@ -175,6 +177,16 @@ fn generate_von_handler_value(ctx: &mut CodegenContext, dir: &DirectiveNode<'_>)
 
     let has_system_mods = !system_modifiers.is_empty();
     let has_key_mods = !key_modifiers.is_empty();
+    let needs_cache = needs_von_handler_cache(ctx, dir);
+
+    if needs_cache {
+        let cache_index = ctx.next_cache_index();
+        ctx.push("_cache[");
+        ctx.push(&cache_index.to_compact_string());
+        ctx.push("] || (_cache[");
+        ctx.push(&cache_index.to_compact_string());
+        ctx.push("] = ");
+    }
 
     if has_key_mods {
         ctx.use_helper(RuntimeHelper::WithKeys);
@@ -187,7 +199,7 @@ fn generate_von_handler_value(ctx: &mut CodegenContext, dir: &DirectiveNode<'_>)
     }
 
     if let Some(exp) = &dir.exp {
-        generate_event_handler(ctx, exp, false);
+        generate_event_handler(ctx, exp, needs_cache);
     } else {
         ctx.push("() => {}");
     }
@@ -217,4 +229,31 @@ fn generate_von_handler_value(ctx: &mut CodegenContext, dir: &DirectiveNode<'_>)
         }
         ctx.push("])");
     }
+
+    if needs_cache {
+        ctx.push(")");
+    }
+}
+
+fn needs_von_handler_cache(ctx: &CodegenContext, dir: &DirectiveNode<'_>) -> bool {
+    ctx.cache_handlers_in_current_scope() && dir.exp.is_some() && !is_setup_const_handler(ctx, dir)
+}
+
+fn is_setup_const_handler(ctx: &CodegenContext, dir: &DirectiveNode<'_>) -> bool {
+    dir.exp.as_ref().is_some_and(|exp| {
+        if let ExpressionNode::Simple(simple) = exp
+            && !simple.is_static
+        {
+            let content = simple.content.trim();
+            if crate::transforms::is_simple_identifier(content) {
+                return ctx
+                    .options
+                    .binding_metadata
+                    .as_ref()
+                    .and_then(|metadata| metadata.bindings.get(content))
+                    .is_some_and(|binding| *binding == BindingType::SetupConst);
+            }
+        }
+        false
+    })
 }

--- a/crates/vize_atelier_core/src/snapshots/vize_atelier_core__codegen__tests__codegen_merged_v_on_handlers_are_cached.snap
+++ b/crates/vize_atelier_core/src/snapshots/vize_atelier_core__codegen__tests__codegen_merged_v_on_handlers_are_cached.snap
@@ -1,0 +1,11 @@
+---
+source: crates/vize_atelier_core/src/codegen.rs
+expression: output.as_str()
+---
+const { withModifiers: _withModifiers, openBlock: _openBlock, createElementBlock: _createElementBlock } = Vue
+
+function render(_ctx, _cache, $props, $setup, $data, $options) {
+  return (_openBlock(), _createElementBlock("div", {
+    onClick: [_cache[0] || (_cache[0] = () => _ctx.x++), _cache[1] || (_cache[1] = _withModifiers(() => _ctx.y++, ["stop"]))]
+  }))
+}


### PR DESCRIPTION

## Summary

- Refactors v-on handler value emission so single-handler props and merged same-event arrays share the same cache wrapping path.
- Wraps each merged same-event v-on array entry in `_cache[n] || (_cache[n] = ...)` when `cacheHandlers` is enabled.
- Adds a focused snapshot regression for duplicate `@click` handlers with a modifier.

## Change Class

- [ ] Parser or AST
- [x] Compiler and codegen
- [ ] Semantic analysis, lint, and cross-file analysis
- [ ] Virtual TypeScript and type checking
- [ ] Formatter and LSP
- [ ] Runtime packaging, release, or docs
- [ ] Not language-facing

## Behavior Reference

- Fixes #1203
- Matches Vue cacheHandlers behavior for merged same-event v-on handler arrays.

## Verification Evidence

- `INSTA_UPDATE=always cargo test -p vize_atelier_core test_codegen_merged_v_on_handlers_are_cached`
- `cargo test -p vize_atelier_core`
- `cargo fmt -p vize_atelier_core -- --check`
- `cargo clippy -p vize_atelier_core -- -D warnings`

- [x] Minimal fixture or focused regression test added or updated
- [x] Snapshot/baseline changes reviewed and explained
- [x] Parity or real-world fixture coverage considered
- [x] Security/audit impact considered
- [x] Performance status or PR benchmark impact considered
- [ ] Fuzzing target or crash-reproducer coverage considered
- [ ] Editor/LSP scenario coverage considered
- [x] Ecosystem or broad app compatibility impact considered
- [ ] Docs, release, or stability notes updated when public behavior changed

## Risk

Low. The change is limited to v-on handler codegen and reuses the single-handler cache semantics for merged handler arrays.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1276"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783596081&installation_id=136613492&pr_number=1276&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1276&signature=fb5221dec49a024457a37c0f815b6fcddee37506940d2a2bf176007776d7c8ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->