### PR TITLE
fix(canon): skip renamed props destructure keys

### DIFF
--- a/crates/vize_canon/src/batch/type_checker/tests.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests.rs
@@ -297,6 +297,41 @@ const $q = functionCall()
 }
 
 #[test]
+fn batch_type_checker_reports_original_key_for_renamed_props_destructure() {
+    if resolve_test_tsgo_binary().is_none() {
+        return;
+    }
+
+    let project_root = create_project_case_without_node_modules(
+        "renamed-props-destructure-original-key",
+        &[(
+            "src/App.vue",
+            r#"<script setup lang="ts">
+const { foo: bar } = defineProps<{ foo: string }>()
+void bar
+</script>
+
+<template>{{ foo }} {{ bar }}</template>
+"#,
+        )],
+    );
+
+    let Some(snapshot) = snapshot_project_diagnostics(&project_root) else {
+        let _ = std::fs::remove_dir_all(&project_root);
+        return;
+    };
+
+    assert!(
+        snapshot.iter().any(|(file, code, message)| {
+            file == "src/App.vue" && *code == Some(2304) && message.contains("foo")
+        }),
+        "expected original prop key to report TS2304, got: {snapshot:#?}"
+    );
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}
+
+#[test]
 fn batch_type_checker_reports_user_ts6133_with_no_unused_locals() {
     if resolve_test_tsgo_binary().is_none() {
         return;

--- a/crates/vize_canon/src/sfc_typecheck.rs
+++ b/crates/vize_canon/src/sfc_typecheck.rs
@@ -200,6 +200,31 @@ const { thickness, label } = props;
     }
 
     #[test]
+    fn test_type_check_renamed_props_destructure_does_not_emit_original_prop_binding() {
+        let source = r#"<script setup lang="ts">
+const { foo: bar } = defineProps<{ foo: string }>()
+void bar
+</script>
+<template><div>{{ foo }} {{ bar }}</div></template>"#;
+        let options = SfcTypeCheckOptions::new("test.vue").with_virtual_ts();
+        let result = type_check_sfc(source, &options);
+        let virtual_ts = result.virtual_ts.expect("virtual ts should be generated");
+
+        assert!(
+            !virtual_ts.contains(r#"const foo = props["foo"];"#),
+            "renamed props destructure must not emit a phantom original-key binding:\n{virtual_ts}"
+        );
+        assert!(
+            virtual_ts.contains("void bar;"),
+            "renamed props destructure local should still be referenced:\n{virtual_ts}"
+        );
+        assert!(
+            virtual_ts.contains("void (foo);"),
+            "template reference to original key should remain unresolved in virtual TS:\n{virtual_ts}"
+        );
+    }
+
+    #[test]
     fn test_type_check_with_defaults_narrows_direct_template_prop_identifiers() {
         let source = r#"<script setup lang="ts">
 const props = withDefaults(

--- a/crates/vize_canon/src/virtual_ts/props.rs
+++ b/crates/vize_canon/src/virtual_ts/props.rs
@@ -24,7 +24,7 @@ fn should_skip_template_prop_binding(summary: &Croquis, prop_name: &str) -> bool
         .macros
         .props_destructure()
         .and_then(|destructure| destructure.get(prop_name))
-        .is_some_and(|binding| binding.local.as_str() == prop_name)
+        .is_some()
     {
         return true;
     }


### PR DESCRIPTION
## Summary
- Skip original prop-key template bindings whenever `defineProps` destructuring already registered that key.
- Keep renamed destructure locals visible from setup scope while leaving original-key template references unresolved.
- Add virtual TS and batch type checker regressions for `const { foo: bar } = defineProps<...>()`.

## Tests
- `cargo fmt --check`
- `git diff --check HEAD~1..HEAD`
- `CARGO_TARGET_DIR=/tmp/vize-1208-target cargo test -p vize_canon renamed_props_destructure -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/vize-1208-target cargo clippy -p vize_canon --lib -- -D warnings`

Closes #1208

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1277"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783596151&installation_id=136613492&pr_number=1277&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1277&signature=3a79748bb492c0ea1962ddd4150fb036c22024703304f262ec4a5e1d6b4d78d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->