### PR TITLE
feat(atelier_sfc): support complex type-only defineProps

### DIFF
--- a/crates/vize_atelier_sfc/src/compile/snapshots/vize_atelier_sfc__compile__tests__define_props_imported_type_alias_is_exposed_to_template.snap
+++ b/crates/vize_atelier_sfc/src/compile/snapshots/vize_atelier_sfc__compile__tests__define_props_imported_type_alias_is_exposed_to_template.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/vize_atelier_sfc/src/compile/tests.rs
+assertion_line: 1813
 expression: result.code.as_str()
 ---
 import { renderSlot as _renderSlot, normalizeClass as _normalizeClass, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue";
@@ -11,7 +12,7 @@ export default {
       required: false
     },
     size: {
-      type: null,
+      type: String,
       required: false,
       default: "md"
     }

--- a/crates/vize_atelier_sfc/src/compile_script/function_mode/compiler.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/function_mode/compiler.rs
@@ -18,7 +18,8 @@ use super::super::import_utils::extract_import_identifiers;
 use super::super::lazy_hydration::transform_lazy_hydration_macros;
 use super::super::props::{
     add_null_to_runtime_type, extract_emit_names_from_type, extract_prop_types_from_type,
-    normalize_destructure_default_value, validate_props_destructure_default_types,
+    normalize_destructure_default_value, runtime_prop_key,
+    validate_props_destructure_default_types,
 };
 use super::super::statement_sections::extract_script_sections;
 use super::super::typescript::transform_typescript_to_js;
@@ -341,7 +342,8 @@ fn emit_props_definition(
                             if i > 0 {
                                 s.push_str(", ");
                             }
-                            s.push_str(name);
+                            let key = runtime_prop_key(name);
+                            s.push_str(key.as_str());
                             s.push_str(": {}");
                         }
                         s.push_str(" }");
@@ -399,7 +401,8 @@ fn emit_props_definition(
                     names.sort();
                     for name in names {
                         output.extend_from_slice(b"    ");
-                        output.extend_from_slice(name.as_bytes());
+                        let key = runtime_prop_key(name);
+                        output.extend_from_slice(key.as_bytes());
                         output.extend_from_slice(b": {},\n");
                     }
                     output.extend_from_slice(b"  },\n");
@@ -419,7 +422,8 @@ fn emit_props_definition(
                     let runtime_js_type =
                         add_null_to_runtime_type(&prop_type.js_type, prop_type.nullable);
                     output.extend_from_slice(b"    ");
-                    output.extend_from_slice(name.as_bytes());
+                    let key = runtime_prop_key(name);
+                    output.extend_from_slice(key.as_bytes());
                     output.extend_from_slice(b": { type: ");
                     output.extend_from_slice(runtime_js_type.as_bytes());
                     if needs_prop_type && let Some(ref ts_type) = prop_type.ts_type {

--- a/crates/vize_atelier_sfc/src/compile_script/inline/compiler/props.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/inline/compiler/props.rs
@@ -3,8 +3,9 @@ use vize_carton::String;
 use crate::script::{PropsDestructuredBindings, ScriptCompileContext};
 
 use super::super::super::props::{
-    add_null_to_runtime_type, extract_prop_types_from_type, extract_with_defaults_defaults,
-    normalize_destructure_default_value, resolve_prop_js_type,
+    add_null_to_runtime_type, extract_prop_types_from_type_with_context,
+    extract_with_defaults_defaults, normalize_destructure_default_value, resolve_prop_js_type,
+    runtime_prop_key,
 };
 use super::super::type_handling::resolve_type_args;
 
@@ -65,7 +66,11 @@ pub(super) fn build_user_props_decl(
     if let Some(ref type_args) = props_macro.type_args {
         // Resolve type references (interface/type alias names) to their definitions
         let resolved_type_args = resolve_type_args(type_args, &ctx.interfaces, &ctx.type_aliases);
-        let prop_types = extract_prop_types_from_type(&resolved_type_args);
+        let prop_types = extract_prop_types_from_type_with_context(
+            &resolved_type_args,
+            Some(&ctx.interfaces),
+            Some(&ctx.type_aliases),
+        );
         if prop_types.is_empty() {
             if let Some(ref destructure) = ctx.macros.props_destructure {
                 build_unknown_type_destructured_props_decl(&mut decl, destructure);
@@ -92,7 +97,8 @@ pub(super) fn build_user_props_decl(
                 let runtime_js_type =
                     add_null_to_runtime_type(&resolved_js_type, prop_type.nullable);
                 decl.extend_from_slice(b"    ");
-                decl.extend_from_slice(name.as_bytes());
+                let key = runtime_prop_key(name);
+                decl.extend_from_slice(key.as_bytes());
                 let mut has_option = false;
                 if is_prod && runtime_js_type != "Boolean" {
                     decl.extend_from_slice(b": {");

--- a/crates/vize_atelier_sfc/src/compile_script/inline/tests.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/inline/tests.rs
@@ -483,6 +483,66 @@ defineProps<{
     }
 
     #[test]
+    fn test_define_props_type_only_mapped_type_literal_union() {
+        let content = r#"
+type Keys = 'a' | 'b'
+
+defineProps<{ [K in Keys]: number } & { [K in Keys as `prop-${K}`]?: boolean }>()
+"#;
+        let output = compile_setup(content);
+        let normalized: String = output
+            .split_whitespace()
+            .collect::<Vec<_>>()
+            .join(" ")
+            .into();
+        assert!(
+            normalized.contains("a: { type: Number, required: true }"),
+            "expected mapped key `a` to become a runtime prop, got:\n{output}"
+        );
+        assert!(
+            normalized.contains("b: { type: Number, required: true }"),
+            "expected mapped key `b` to become a runtime prop, got:\n{output}"
+        );
+        assert!(
+            normalized.contains("\"prop-a\": { type: Boolean, required: false }"),
+            "expected template-literal remapped key `prop-a` to be quoted and emitted, got:\n{output}"
+        );
+        assert!(
+            normalized.contains("\"prop-b\": { type: Boolean, required: false }"),
+            "expected template-literal remapped key `prop-b` to be quoted and emitted, got:\n{output}"
+        );
+    }
+
+    #[test]
+    fn test_define_props_type_only_conditional_indexed_and_template_key_types() {
+        let content = r#"
+defineProps<{
+  value: 'x' extends string ? string : number
+  indexed: Record<string, number>['a']
+  "templateKey"?: boolean
+}>()
+"#;
+        let output = compile_setup(content);
+        let normalized: String = output
+            .split_whitespace()
+            .collect::<Vec<_>>()
+            .join(" ")
+            .into();
+        assert!(
+            normalized.contains("value: { type: [String, Number], required: true }"),
+            "expected conditional prop type to stay attached to `value`, got:\n{output}"
+        );
+        assert!(
+            normalized.contains("indexed: { type: null, required: true }"),
+            "expected indexed-access prop to be preserved instead of split away, got:\n{output}"
+        );
+        assert!(
+            normalized.contains("templateKey: { type: Boolean, required: false }"),
+            "expected template-literal key prop to be preserved, got:\n{output}"
+        );
+    }
+
+    #[test]
     fn test_non_props_destructure_value_on_next_line() {
         // Ensure regular (non-defineProps) destructures with value on next line
         // still work correctly

--- a/crates/vize_atelier_sfc/src/compile_script/props.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/props.rs
@@ -4,7 +4,11 @@
 //! and processing withDefaults defaults.
 
 use oxc_allocator::Allocator;
-use oxc_ast::ast::{Argument, Expression, ObjectPropertyKind, PropertyKey, Statement};
+use oxc_ast::ast::{
+    Argument, Expression, ObjectPropertyKind, PropertyKey, Statement, TSLiteral,
+    TSMappedTypeModifierOperator, TSSignature, TSType, TSTypeLiteral, TSTypeName,
+    TSTypeOperatorOperator,
+};
 use oxc_parser::Parser;
 use oxc_span::{GetSpan, SourceType};
 use vize_carton::FxHashMap;
@@ -106,6 +110,22 @@ fn join_union_continuation_lines(input: &str) -> String {
 /// Extract prop types from TypeScript type definition.
 /// Returns a Vec to preserve definition order (important for matching Vue's output).
 pub fn extract_prop_types_from_type(type_args: &str) -> Vec<(String, PropTypeInfo)> {
+    extract_prop_types_from_type_with_context(type_args, None, None)
+}
+
+pub(crate) fn extract_prop_types_from_type_with_context(
+    type_args: &str,
+    interfaces: Option<&FxHashMap<String, String>>,
+    type_aliases: Option<&FxHashMap<String, String>>,
+) -> Vec<(String, PropTypeInfo)> {
+    if let Some(props) = extract_prop_types_from_ast(type_args, interfaces, type_aliases) {
+        return props;
+    }
+
+    extract_prop_types_from_type_text(type_args)
+}
+
+fn extract_prop_types_from_type_text(type_args: &str) -> Vec<(String, PropTypeInfo)> {
     let mut props = Vec::new();
 
     // Strip comments before parsing
@@ -171,6 +191,689 @@ pub fn extract_prop_types_from_type(type_args: &str) -> Vec<(String, PropTypeInf
     extract_prop_type_info(&current, &mut props);
 
     props
+}
+
+const TYPE_ALIAS_PREFIX: &str = "type __VizeProps = ";
+
+fn extract_prop_types_from_ast(
+    type_args: &str,
+    interfaces: Option<&FxHashMap<String, String>>,
+    type_aliases: Option<&FxHashMap<String, String>>,
+) -> Option<Vec<(String, PropTypeInfo)>> {
+    let source = wrap_type_alias_source(type_args);
+    let allocator = Allocator::default();
+    let parsed = Parser::new(&allocator, &source, SourceType::ts()).parse();
+    if parsed.panicked || !parsed.errors.is_empty() {
+        return None;
+    }
+
+    let Some(Statement::TSTypeAliasDeclaration(alias)) = parsed.program.body.first() else {
+        return None;
+    };
+
+    let mut props = Vec::new();
+    let mut seen = Vec::new();
+    if collect_props_from_ts_type(
+        &alias.type_annotation,
+        &source,
+        interfaces,
+        type_aliases,
+        &mut seen,
+        &mut props,
+    ) {
+        Some(props)
+    } else {
+        None
+    }
+}
+
+fn wrap_type_alias_source(type_args: &str) -> String {
+    let trimmed = type_args.trim();
+    let mut source = String::with_capacity(TYPE_ALIAS_PREFIX.len() + trimmed.len() + 1);
+    source.push_str(TYPE_ALIAS_PREFIX);
+    source.push_str(trimmed);
+    source.push(';');
+    source
+}
+
+fn collect_props_from_ts_type(
+    ts_type: &TSType<'_>,
+    source: &str,
+    interfaces: Option<&FxHashMap<String, String>>,
+    type_aliases: Option<&FxHashMap<String, String>>,
+    seen: &mut Vec<String>,
+    props: &mut Vec<(String, PropTypeInfo)>,
+) -> bool {
+    match ts_type {
+        TSType::TSTypeLiteral(type_lit) => {
+            collect_props_from_ts_type_literal(type_lit, source, interfaces, type_aliases, props);
+            true
+        }
+        TSType::TSMappedType(mapped) => {
+            collect_props_from_mapped_type(mapped, source, interfaces, type_aliases, seen, props);
+            true
+        }
+        TSType::TSIntersectionType(intersection) => {
+            let mut handled = false;
+            for ty in intersection.types.iter() {
+                handled |=
+                    collect_props_from_ts_type(ty, source, interfaces, type_aliases, seen, props);
+            }
+            handled
+        }
+        TSType::TSUnionType(union) => {
+            let mut handled = false;
+            for ty in union.types.iter() {
+                handled |=
+                    collect_props_from_ts_type(ty, source, interfaces, type_aliases, seen, props);
+            }
+            handled
+        }
+        TSType::TSConditionalType(conditional) => {
+            let true_handled = collect_props_from_ts_type(
+                &conditional.true_type,
+                source,
+                interfaces,
+                type_aliases,
+                seen,
+                props,
+            );
+            let false_handled = collect_props_from_ts_type(
+                &conditional.false_type,
+                source,
+                interfaces,
+                type_aliases,
+                seen,
+                props,
+            );
+            true_handled || false_handled
+        }
+        TSType::TSParenthesizedType(paren) => collect_props_from_ts_type(
+            &paren.type_annotation,
+            source,
+            interfaces,
+            type_aliases,
+            seen,
+            props,
+        ),
+        TSType::TSTypeReference(type_ref) => {
+            let Some(name) = simple_type_name(&type_ref.type_name) else {
+                return false;
+            };
+            let Some(resolved) = resolve_type_reference_text(name, interfaces, type_aliases, seen)
+            else {
+                return false;
+            };
+            let resolved_source = wrap_type_alias_source(&resolved);
+            let allocator = Allocator::default();
+            let parsed = Parser::new(&allocator, &resolved_source, SourceType::ts()).parse();
+            if parsed.panicked || !parsed.errors.is_empty() {
+                finish_resolved_type_reference(name, seen);
+                return false;
+            }
+            let Some(Statement::TSTypeAliasDeclaration(alias)) = parsed.program.body.first() else {
+                finish_resolved_type_reference(name, seen);
+                return false;
+            };
+            let handled = collect_props_from_ts_type(
+                &alias.type_annotation,
+                &resolved_source,
+                interfaces,
+                type_aliases,
+                seen,
+                props,
+            );
+            finish_resolved_type_reference(name, seen);
+            handled
+        }
+        _ => false,
+    }
+}
+
+fn collect_props_from_ts_type_literal(
+    type_lit: &TSTypeLiteral<'_>,
+    source: &str,
+    interfaces: Option<&FxHashMap<String, String>>,
+    type_aliases: Option<&FxHashMap<String, String>>,
+    props: &mut Vec<(String, PropTypeInfo)>,
+) {
+    for member in type_lit.members.iter() {
+        match member {
+            TSSignature::TSPropertySignature(prop) => {
+                let Some(name) = property_key_name(&prop.key) else {
+                    continue;
+                };
+                let (ts_type, js_type, nullable) = if let Some(type_ann) = &prop.type_annotation {
+                    let ts_type = source_for_span(source, type_ann.type_annotation.span())
+                        .unwrap_or("unknown")
+                        .trim()
+                        .to_compact_string();
+                    let js_type = ts_type_to_js_type_from_ast(
+                        &type_ann.type_annotation,
+                        source,
+                        interfaces,
+                        type_aliases,
+                    );
+                    let nullable = type_includes_top_level_null_from_ast(&type_ann.type_annotation);
+                    (Some(ts_type), js_type, nullable)
+                } else {
+                    (None, "null".to_compact_string(), false)
+                };
+                push_prop_type_info(
+                    props,
+                    name,
+                    PropTypeInfo {
+                        js_type,
+                        ts_type,
+                        optional: prop.optional,
+                        nullable,
+                    },
+                );
+            }
+            TSSignature::TSMethodSignature(method) => {
+                let Some(name) = property_key_name(&method.key) else {
+                    continue;
+                };
+                push_prop_type_info(
+                    props,
+                    name,
+                    PropTypeInfo {
+                        js_type: "Function".to_compact_string(),
+                        ts_type: None,
+                        optional: method.optional,
+                        nullable: false,
+                    },
+                );
+            }
+            _ => {}
+        }
+    }
+}
+
+fn collect_props_from_mapped_type(
+    mapped: &oxc_ast::ast::TSMappedType<'_>,
+    source: &str,
+    interfaces: Option<&FxHashMap<String, String>>,
+    type_aliases: Option<&FxHashMap<String, String>>,
+    seen: &mut Vec<String>,
+    props: &mut Vec<(String, PropTypeInfo)>,
+) {
+    let Some(keys) = literal_values_from_ts_type(
+        &mapped.constraint,
+        source,
+        interfaces,
+        type_aliases,
+        None,
+        seen,
+    ) else {
+        return;
+    };
+
+    let key_name = mapped.key.name.as_str();
+    for key in keys {
+        let prop_name = if let Some(name_type) = &mapped.name_type {
+            let mut values = literal_values_from_ts_type(
+                name_type,
+                source,
+                interfaces,
+                type_aliases,
+                Some((key_name, key.as_str())),
+                seen,
+            )
+            .unwrap_or_default();
+            if values.is_empty() {
+                continue;
+            }
+            values.remove(0)
+        } else {
+            key
+        };
+
+        let (ts_type, js_type, nullable) = if let Some(type_ann) = &mapped.type_annotation {
+            let ts_type = source_for_span(source, type_ann.span())
+                .unwrap_or("unknown")
+                .trim()
+                .to_compact_string();
+            let js_type = ts_type_to_js_type_from_ast(type_ann, source, interfaces, type_aliases);
+            let nullable = type_includes_top_level_null_from_ast(type_ann);
+            (Some(ts_type), js_type, nullable)
+        } else {
+            (None, "null".to_compact_string(), false)
+        };
+
+        push_prop_type_info(
+            props,
+            prop_name,
+            PropTypeInfo {
+                js_type,
+                ts_type,
+                optional: matches!(
+                    mapped.optional,
+                    Some(TSMappedTypeModifierOperator::True | TSMappedTypeModifierOperator::Plus)
+                ),
+                nullable,
+            },
+        );
+    }
+}
+
+fn push_prop_type_info(props: &mut Vec<(String, PropTypeInfo)>, name: String, info: PropTypeInfo) {
+    if !props
+        .iter()
+        .any(|(existing, _)| existing.as_str() == name.as_str())
+    {
+        props.push((name, info));
+    }
+}
+
+fn ts_type_to_js_type_from_ast(
+    ts_type: &TSType<'_>,
+    source: &str,
+    interfaces: Option<&FxHashMap<String, String>>,
+    type_aliases: Option<&FxHashMap<String, String>>,
+) -> String {
+    match ts_type {
+        TSType::TSStringKeyword(_) => "String".to_compact_string(),
+        TSType::TSNumberKeyword(_) => "Number".to_compact_string(),
+        TSType::TSBooleanKeyword(_) => "Boolean".to_compact_string(),
+        TSType::TSSymbolKeyword(_) => "Symbol".to_compact_string(),
+        TSType::TSBigIntKeyword(_) => "BigInt".to_compact_string(),
+        TSType::TSObjectKeyword(_) | TSType::TSTypeLiteral(_) | TSType::TSMappedType(_) => {
+            "Object".to_compact_string()
+        }
+        TSType::TSArrayType(_) | TSType::TSTupleType(_) => "Array".to_compact_string(),
+        TSType::TSFunctionType(_) | TSType::TSConstructorType(_) => "Function".to_compact_string(),
+        TSType::TSLiteralType(lit) => js_type_for_ts_literal(&lit.literal),
+        TSType::TSUnionType(union) => {
+            combine_runtime_js_types(union.types.iter().filter_map(|ty| {
+                if matches!(
+                    ty,
+                    TSType::TSUndefinedKeyword(_)
+                        | TSType::TSNullKeyword(_)
+                        | TSType::TSNeverKeyword(_)
+                ) {
+                    None
+                } else {
+                    Some(ts_type_to_js_type_from_ast(
+                        ty,
+                        source,
+                        interfaces,
+                        type_aliases,
+                    ))
+                }
+            }))
+        }
+        TSType::TSConditionalType(conditional) => combine_runtime_js_types([
+            ts_type_to_js_type_from_ast(&conditional.true_type, source, interfaces, type_aliases),
+            ts_type_to_js_type_from_ast(&conditional.false_type, source, interfaces, type_aliases),
+        ]),
+        TSType::TSIntersectionType(intersection) => {
+            if intersection.types.iter().any(|ty| {
+                matches!(
+                    ty,
+                    TSType::TSTypeLiteral(_) | TSType::TSMappedType(_) | TSType::TSTypeReference(_)
+                )
+            }) {
+                "Object".to_compact_string()
+            } else {
+                "null".to_compact_string()
+            }
+        }
+        TSType::TSParenthesizedType(paren) => {
+            ts_type_to_js_type_from_ast(&paren.type_annotation, source, interfaces, type_aliases)
+        }
+        TSType::TSTypeOperatorType(op) => match op.operator {
+            TSTypeOperatorOperator::Readonly => {
+                ts_type_to_js_type_from_ast(&op.type_annotation, source, interfaces, type_aliases)
+            }
+            TSTypeOperatorOperator::Keyof => "String".to_compact_string(),
+            TSTypeOperatorOperator::Unique => "null".to_compact_string(),
+        },
+        TSType::TSTypeReference(type_ref) => {
+            let source_type = source_for_span(source, type_ref.span()).unwrap_or_default();
+            let js_type = ts_type_to_js_type(source_type);
+            if js_type != "null" {
+                return js_type;
+            }
+
+            let Some(name) = simple_type_name(&type_ref.type_name) else {
+                return "null".to_compact_string();
+            };
+            if interfaces.is_some_and(|interfaces| interfaces.contains_key(name)) {
+                return "Object".to_compact_string();
+            }
+            if let Some(type_aliases) = type_aliases
+                && let Some(alias) = type_aliases.get(name)
+            {
+                let alias_source = wrap_type_alias_source(alias);
+                let allocator = Allocator::default();
+                let parsed = Parser::new(&allocator, &alias_source, SourceType::ts()).parse();
+                if !parsed.panicked
+                    && parsed.errors.is_empty()
+                    && let Some(Statement::TSTypeAliasDeclaration(alias_decl)) =
+                        parsed.program.body.first()
+                {
+                    return ts_type_to_js_type_from_ast(
+                        &alias_decl.type_annotation,
+                        &alias_source,
+                        interfaces,
+                        Some(type_aliases),
+                    );
+                }
+            }
+            "null".to_compact_string()
+        }
+        TSType::TSIndexedAccessType(_) => "null".to_compact_string(),
+        _ => "null".to_compact_string(),
+    }
+}
+
+fn js_type_for_ts_literal(literal: &TSLiteral<'_>) -> String {
+    match literal {
+        TSLiteral::StringLiteral(_) | TSLiteral::TemplateLiteral(_) => "String".to_compact_string(),
+        TSLiteral::NumericLiteral(_) => "Number".to_compact_string(),
+        TSLiteral::BigIntLiteral(_) => "BigInt".to_compact_string(),
+        TSLiteral::BooleanLiteral(_) => "Boolean".to_compact_string(),
+        TSLiteral::UnaryExpression(unary) => {
+            if matches!(&unary.argument, Expression::NumericLiteral(_)) {
+                "Number".to_compact_string()
+            } else {
+                "null".to_compact_string()
+            }
+        }
+    }
+}
+
+fn combine_runtime_js_types(types: impl IntoIterator<Item = String>) -> String {
+    let mut js_types: Vec<String> = Vec::new();
+    for js_type in types {
+        if js_type == "null" {
+            return js_type;
+        }
+        if !js_types.contains(&js_type) {
+            js_types.push(js_type);
+        }
+    }
+
+    match js_types.len() {
+        0 => "null".to_compact_string(),
+        1 => js_types.pop().unwrap_or_else(|| "null".to_compact_string()),
+        _ => {
+            let joined = js_types.join(", ");
+            let mut result = String::with_capacity(joined.len() + 2);
+            result.push('[');
+            result.push_str(&joined);
+            result.push(']');
+            result
+        }
+    }
+}
+
+fn type_includes_top_level_null_from_ast(ts_type: &TSType<'_>) -> bool {
+    match ts_type {
+        TSType::TSNullKeyword(_) => true,
+        TSType::TSUnionType(union) => union
+            .types
+            .iter()
+            .any(|ty| matches!(ty, TSType::TSNullKeyword(_))),
+        TSType::TSParenthesizedType(paren) => {
+            type_includes_top_level_null_from_ast(&paren.type_annotation)
+        }
+        _ => false,
+    }
+}
+
+fn literal_values_from_ts_type(
+    ts_type: &TSType<'_>,
+    source: &str,
+    interfaces: Option<&FxHashMap<String, String>>,
+    type_aliases: Option<&FxHashMap<String, String>>,
+    mapped_key: Option<(&str, &str)>,
+    seen: &mut Vec<String>,
+) -> Option<Vec<String>> {
+    match ts_type {
+        TSType::TSLiteralType(lit) => literal_values_from_literal(&lit.literal),
+        TSType::TSUnionType(union) => {
+            let mut values = Vec::new();
+            for ty in union.types.iter() {
+                values.extend(literal_values_from_ts_type(
+                    ty,
+                    source,
+                    interfaces,
+                    type_aliases,
+                    mapped_key,
+                    seen,
+                )?);
+            }
+            Some(values)
+        }
+        TSType::TSParenthesizedType(paren) => literal_values_from_ts_type(
+            &paren.type_annotation,
+            source,
+            interfaces,
+            type_aliases,
+            mapped_key,
+            seen,
+        ),
+        TSType::TSTemplateLiteralType(template) => literal_values_from_template_type(
+            template,
+            source,
+            interfaces,
+            type_aliases,
+            mapped_key,
+            seen,
+        ),
+        TSType::TSTypeOperatorType(op) if op.operator == TSTypeOperatorOperator::Keyof => {
+            literal_values_from_keyof_type(
+                &op.type_annotation,
+                source,
+                interfaces,
+                type_aliases,
+                seen,
+            )
+        }
+        TSType::TSTypeReference(type_ref) => {
+            let name = simple_type_name(&type_ref.type_name)?;
+            if let Some((mapped_name, mapped_value)) = mapped_key
+                && name == mapped_name
+            {
+                return Some(vec![mapped_value.to_compact_string()]);
+            }
+            let resolved = resolve_type_reference_text(name, interfaces, type_aliases, seen)?;
+            let values = literal_values_from_type_text(
+                &resolved,
+                interfaces,
+                type_aliases,
+                mapped_key,
+                seen,
+            );
+            finish_resolved_type_reference(name, seen);
+            values
+        }
+        _ => None,
+    }
+}
+
+fn literal_values_from_literal(literal: &TSLiteral<'_>) -> Option<Vec<String>> {
+    match literal {
+        TSLiteral::StringLiteral(lit) => Some(vec![lit.value.to_compact_string()]),
+        TSLiteral::NumericLiteral(lit) => Some(vec![lit.value.to_compact_string()]),
+        TSLiteral::TemplateLiteral(template) => {
+            literal_value_from_template_literal(template).map(|value| vec![value])
+        }
+        _ => None,
+    }
+}
+
+fn literal_values_from_template_type(
+    template: &oxc_ast::ast::TSTemplateLiteralType<'_>,
+    source: &str,
+    interfaces: Option<&FxHashMap<String, String>>,
+    type_aliases: Option<&FxHashMap<String, String>>,
+    mapped_key: Option<(&str, &str)>,
+    seen: &mut Vec<String>,
+) -> Option<Vec<String>> {
+    let mut values = vec![String::default()];
+    for (idx, quasi) in template.quasis.iter().enumerate() {
+        let text = quasi
+            .value
+            .cooked
+            .as_ref()
+            .unwrap_or(&quasi.value.raw)
+            .as_str();
+        for value in &mut values {
+            value.push_str(text);
+        }
+        let Some(ty) = template.types.get(idx) else {
+            continue;
+        };
+        let parts =
+            literal_values_from_ts_type(ty, source, interfaces, type_aliases, mapped_key, seen)?;
+        let mut expanded = Vec::new();
+        for prefix in &values {
+            for part in &parts {
+                let mut value = prefix.clone();
+                value.push_str(part);
+                expanded.push(value);
+            }
+        }
+        values = expanded;
+    }
+    Some(values)
+}
+
+fn literal_values_from_keyof_type(
+    ts_type: &TSType<'_>,
+    source: &str,
+    interfaces: Option<&FxHashMap<String, String>>,
+    type_aliases: Option<&FxHashMap<String, String>>,
+    seen: &mut Vec<String>,
+) -> Option<Vec<String>> {
+    let mut props = Vec::new();
+    if collect_props_from_ts_type(ts_type, source, interfaces, type_aliases, seen, &mut props) {
+        Some(props.into_iter().map(|(name, _)| name).collect())
+    } else {
+        None
+    }
+}
+
+fn literal_values_from_type_text(
+    type_text: &str,
+    interfaces: Option<&FxHashMap<String, String>>,
+    type_aliases: Option<&FxHashMap<String, String>>,
+    mapped_key: Option<(&str, &str)>,
+    seen: &mut Vec<String>,
+) -> Option<Vec<String>> {
+    let source = wrap_type_alias_source(type_text);
+    let allocator = Allocator::default();
+    let parsed = Parser::new(&allocator, &source, SourceType::ts()).parse();
+    if parsed.panicked || !parsed.errors.is_empty() {
+        return None;
+    }
+    let Some(Statement::TSTypeAliasDeclaration(alias)) = parsed.program.body.first() else {
+        return None;
+    };
+    literal_values_from_ts_type(
+        &alias.type_annotation,
+        &source,
+        interfaces,
+        type_aliases,
+        mapped_key,
+        seen,
+    )
+}
+
+fn property_key_name(key: &PropertyKey<'_>) -> Option<String> {
+    match key {
+        PropertyKey::StaticIdentifier(id) => Some(id.name.to_compact_string()),
+        PropertyKey::StringLiteral(lit) => Some(lit.value.to_compact_string()),
+        PropertyKey::NumericLiteral(lit) => Some(lit.value.to_compact_string()),
+        PropertyKey::TemplateLiteral(template) => literal_value_from_template_literal(template),
+        _ => None,
+    }
+}
+
+fn literal_value_from_template_literal(
+    template: &oxc_ast::ast::TemplateLiteral<'_>,
+) -> Option<String> {
+    if !template.expressions.is_empty() {
+        return None;
+    }
+    let mut value = String::default();
+    for quasi in template.quasis.iter() {
+        value.push_str(
+            quasi
+                .value
+                .cooked
+                .as_ref()
+                .unwrap_or(&quasi.value.raw)
+                .as_str(),
+        );
+    }
+    Some(value)
+}
+
+fn source_for_span(source: &str, span: oxc_span::Span) -> Option<&str> {
+    source.get(span.start as usize..span.end as usize)
+}
+
+fn simple_type_name<'a>(type_name: &'a TSTypeName<'_>) -> Option<&'a str> {
+    match type_name {
+        TSTypeName::IdentifierReference(id) => Some(id.name.as_str()),
+        _ => None,
+    }
+}
+
+fn resolve_type_reference_text(
+    name: &str,
+    interfaces: Option<&FxHashMap<String, String>>,
+    type_aliases: Option<&FxHashMap<String, String>>,
+    seen: &mut Vec<String>,
+) -> Option<String> {
+    if seen.iter().any(|seen_name| seen_name == name) {
+        return None;
+    }
+
+    let resolved = if let Some(type_aliases) = type_aliases
+        && let Some(alias) = type_aliases.get(name)
+    {
+        Some(alias.clone())
+    } else if let Some(interfaces) = interfaces
+        && let Some(body) = interfaces.get(name)
+    {
+        let mut source = String::with_capacity(body.len() + 4);
+        source.push_str("{ ");
+        source.push_str(body);
+        source.push_str(" }");
+        Some(source)
+    } else {
+        None
+    }?;
+
+    seen.push(name.to_compact_string());
+    Some(resolved)
+}
+
+fn finish_resolved_type_reference(name: &str, seen: &mut Vec<String>) {
+    if seen.last().is_some_and(|seen_name| seen_name == name) {
+        seen.pop();
+    }
+}
+
+pub(crate) fn runtime_prop_key(name: &str) -> String {
+    if is_valid_identifier(name) {
+        return name.to_compact_string();
+    }
+
+    serde_json::to_string(name)
+        .map(|escaped| escaped.as_str().to_compact_string())
+        .unwrap_or_else(|_| {
+            let mut escaped = String::with_capacity(name.len() + 2);
+            escaped.push('"');
+            escaped.push_str(name);
+            escaped.push('"');
+            escaped
+        })
 }
 
 fn extract_prop_type_info(segment: &str, props: &mut Vec<(String, PropTypeInfo)>) {
@@ -937,7 +1640,11 @@ pub(crate) fn validate_props_destructure_default_types(
 
     let resolved_type_args =
         crate::script::resolve_type_args(type_args, &ctx.interfaces, &ctx.type_aliases);
-    let prop_types = extract_prop_types_from_type(&resolved_type_args);
+    let prop_types = extract_prop_types_from_type_with_context(
+        &resolved_type_args,
+        Some(&ctx.interfaces),
+        Some(&ctx.type_aliases),
+    );
 
     for (name, prop_type) in &prop_types {
         let Some(binding) = destructure.bindings.get(name.as_str()) else {


### PR DESCRIPTION
## Summary
- Add OXC AST-backed type-only defineProps prop extraction for type literals, mapped types, finite literal/template keys, conditional prop types, and indexed-access prop preservation.
- Pass SFC type context into inline prop extraction and quote generated runtime prop keys when needed.
- Add focused inline tests and update the imported alias snapshot.

## Validation
- cargo fmt --check
- cargo fmt --all -- --check
- CARGO_TARGET_DIR=/tmp/vize-1204-target cargo test -p vize_atelier_sfc test_define_props_type_only
- CARGO_TARGET_DIR=/tmp/vize-1204-target cargo test -p vize_atelier_sfc
- CARGO_TARGET_DIR=/tmp/vize-1204-target cargo clippy -p vize_atelier_sfc --lib -- -D warnings
- CARGO_TARGET_DIR=/tmp/vize-1204-target cargo clippy --workspace -- -D warnings
- CARGO_TARGET_DIR=/tmp/vize-1204-target cargo semver-checks check-release --package vize_atelier_sfc

Fixes #1204

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1278"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783596744&installation_id=136613492&pr_number=1278&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1278&signature=f2a7d906a644ce35a7821109ad916193221b6fa3101126f6dc61e741a75c54d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->