### PR TITLE
fix(canon): ignore nested interface fields

### DIFF
--- a/crates/vize_canon/src/batch/type_checker/tests.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests.rs
@@ -332,6 +332,47 @@ void bar
 }
 
 #[test]
+fn batch_type_checker_reports_nested_interface_member_as_unknown_template_name() {
+    if resolve_test_tsgo_binary().is_none() {
+        return;
+    }
+
+    let project_root = create_project_case_without_node_modules(
+        "nested-interface-member-template-name",
+        &[(
+            "src/App.vue",
+            r#"<script setup lang="ts">
+interface Props {
+  config: {
+    inner: string
+  }
+  name: string
+}
+
+defineProps<Props>()
+</script>
+
+<template>{{ config.inner }} {{ inner }} {{ name }}</template>
+"#,
+        )],
+    );
+
+    let Some(snapshot) = snapshot_project_diagnostics(&project_root) else {
+        let _ = std::fs::remove_dir_all(&project_root);
+        return;
+    };
+
+    assert!(
+        snapshot.iter().any(|(file, code, message)| {
+            file == "src/App.vue" && *code == Some(2304) && message.contains("inner")
+        }),
+        "expected nested object member to report TS2304, got: {snapshot:#?}"
+    );
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}
+
+#[test]
 fn batch_type_checker_reports_user_ts6133_with_no_unused_locals() {
     if resolve_test_tsgo_binary().is_none() {
         return;

--- a/crates/vize_canon/src/sfc_typecheck.rs
+++ b/crates/vize_canon/src/sfc_typecheck.rs
@@ -225,6 +225,44 @@ void bar
     }
 
     #[test]
+    fn test_type_check_nested_interface_members_are_not_template_props() {
+        let source = r#"<script setup lang="ts">
+interface Props {
+  config: {
+    inner: string
+  }
+  name: string
+}
+
+defineProps<Props>()
+</script>
+
+<template>
+  {{ config.inner }} {{ inner }} {{ name }}
+</template>"#;
+        let options = SfcTypeCheckOptions::new("test.vue").with_virtual_ts();
+        let result = type_check_sfc(source, &options);
+        let virtual_ts = result.virtual_ts.expect("virtual ts should be generated");
+
+        assert!(
+            virtual_ts.contains(r#"const config = props["config"];"#),
+            "{virtual_ts}"
+        );
+        assert!(
+            virtual_ts.contains(r#"const name = props["name"];"#),
+            "{virtual_ts}"
+        );
+        assert!(
+            !virtual_ts.contains(r#"const inner = props["inner"];"#),
+            "nested object members must not be emitted as top-level props:\n{virtual_ts}"
+        );
+        assert!(
+            virtual_ts.contains("void (inner);"),
+            "nested member shorthand should remain unresolved in virtual TS:\n{virtual_ts}"
+        );
+    }
+
+    #[test]
     fn test_type_check_with_defaults_narrows_direct_template_prop_identifiers() {
         let source = r#"<script setup lang="ts">
 const props = withDefaults(

--- a/crates/vize_canon/src/virtual_ts/props.rs
+++ b/crates/vize_canon/src/virtual_ts/props.rs
@@ -564,31 +564,145 @@ pub(crate) fn extract_interface_fields(script: &str, type_name: &str) -> Vec<Str
             body
         };
 
-        for line in inner.lines() {
-            let trimmed = line.trim();
-            if trimmed.is_empty()
-                || trimmed.starts_with("//")
-                || trimmed.starts_with("/*")
-                || trimmed == "}"
-                || trimmed == "};"
-            {
-                continue;
-            }
-            let trimmed = trimmed.strip_prefix("readonly ").unwrap_or(trimmed);
-            if let Some(colon_pos) = trimmed.find(':') {
-                let field_name = trimmed[..colon_pos].trim().trim_end_matches('?');
-                if !field_name.is_empty()
-                    && field_name
-                        .chars()
-                        .all(|c| c.is_alphanumeric() || c == '_' || c == '$')
-                {
-                    fields.push(field_name.into());
+        fields.extend(extract_top_level_type_fields(inner));
+    }
+
+    fields
+}
+
+fn extract_top_level_type_fields(inner: &str) -> Vec<String> {
+    let mut fields = Vec::new();
+    let mut member_start = 0usize;
+    let mut collecting_name = true;
+    let mut brace_depth = 0u32;
+    let mut bracket_depth = 0u32;
+    let mut paren_depth = 0u32;
+    let mut angle_depth = 0u32;
+    let mut quote = None;
+    let mut escaped = false;
+    let mut line_comment = false;
+    let mut block_comment = false;
+    let mut chars = inner.char_indices().peekable();
+
+    while let Some((idx, ch)) = chars.next() {
+        if line_comment {
+            if ch == '\n' {
+                line_comment = false;
+                if brace_depth == 0 && bracket_depth == 0 && paren_depth == 0 && angle_depth == 0 {
+                    collecting_name = true;
+                    member_start = idx + ch.len_utf8();
                 }
             }
+            continue;
+        }
+
+        if block_comment {
+            if ch == '*'
+                && let Some(&(slash_idx, '/')) = chars.peek()
+            {
+                chars.next();
+                block_comment = false;
+                if collecting_name
+                    && brace_depth == 0
+                    && bracket_depth == 0
+                    && paren_depth == 0
+                    && angle_depth == 0
+                    && inner[member_start..idx].trim().is_empty()
+                {
+                    member_start = slash_idx + 1;
+                }
+            }
+            continue;
+        }
+
+        if let Some(quote_ch) = quote {
+            if escaped {
+                escaped = false;
+            } else if ch == '\\' {
+                escaped = true;
+            } else if ch == quote_ch {
+                quote = None;
+            }
+            continue;
+        }
+
+        if ch == '/'
+            && let Some(&(_, next)) = chars.peek()
+        {
+            match next {
+                '/' => {
+                    chars.next();
+                    line_comment = true;
+                    continue;
+                }
+                '*' => {
+                    chars.next();
+                    block_comment = true;
+                    continue;
+                }
+                _ => {}
+            }
+        }
+
+        match ch {
+            '\'' | '"' | '`' => {
+                quote = Some(ch);
+                escaped = false;
+                continue;
+            }
+            '{' => brace_depth += 1,
+            '}' => brace_depth = brace_depth.saturating_sub(1),
+            '[' => bracket_depth += 1,
+            ']' => bracket_depth = bracket_depth.saturating_sub(1),
+            '(' => paren_depth += 1,
+            ')' => paren_depth = paren_depth.saturating_sub(1),
+            '<' => angle_depth += 1,
+            '>' if angle_depth > 0 => angle_depth -= 1,
+            _ => {}
+        }
+
+        if brace_depth != 0 || bracket_depth != 0 || paren_depth != 0 || angle_depth != 0 {
+            continue;
+        }
+
+        match ch {
+            ':' if collecting_name => {
+                if let Some(field_name) = parse_top_level_field_name(&inner[member_start..idx]) {
+                    fields.push(field_name);
+                }
+                collecting_name = false;
+            }
+            ';' | ',' => {
+                collecting_name = true;
+                member_start = idx + ch.len_utf8();
+            }
+            '\n' if !collecting_name => {
+                collecting_name = true;
+                member_start = idx + ch.len_utf8();
+            }
+            '\n' if inner[member_start..idx].trim().is_empty() => {
+                member_start = idx + ch.len_utf8();
+            }
+            _ => {}
         }
     }
 
     fields
+}
+
+fn parse_top_level_field_name(candidate: &str) -> Option<String> {
+    let candidate = candidate.trim();
+    let candidate = candidate.strip_prefix("readonly ").unwrap_or(candidate);
+    let field_name = candidate.trim().trim_end_matches('?').trim();
+    if !field_name.is_empty()
+        && field_name
+            .chars()
+            .all(|c| c.is_alphanumeric() || c == '_' || c == '$')
+    {
+        Some(field_name.into())
+    } else {
+        None
+    }
 }
 
 /// Strip the outermost `<...>` pair from a type_args string, handling nested generics.
@@ -773,7 +887,10 @@ fn append_param_with_default(result: &mut String, param: &str) {
 
 #[cfg(test)]
 mod tests {
-    use super::{collect_with_defaults_default_names_from_source, template_props_type_ref};
+    use super::{
+        collect_with_defaults_default_names_from_source, extract_interface_fields,
+        template_props_type_ref,
+    };
     use vize_carton::{FxHashSet, String};
 
     #[test]
@@ -817,6 +934,28 @@ mod tests {
         assert_eq!(
             template_props_type_ref("Props", &names),
             r#"__WithDefaultsResult<Props, Pick<Props, "label" | "thickness">>"#
+        );
+    }
+
+    #[test]
+    fn extracts_only_top_level_interface_fields() {
+        let script = r#"
+interface Props {
+  config: {
+    inner: string
+    nested: { value: number }
+  }
+  readonly name?: string
+  handler: (event: { inner: string }) => void
+  items: Array<{ id: string }>
+  method(): void
+  [key: string]: unknown
+}
+"#;
+
+        assert_eq!(
+            extract_interface_fields(script, "Props"),
+            vec!["config", "name", "handler", "items"]
         );
     }
 }


### PR DESCRIPTION
Closes #1189.

## Summary
- parse fallback props interface fields with top-level depth tracking
- keep nested object members unresolved in virtual TS instead of emitting phantom prop bindings
- add unit, virtual TS, and batch checker regressions

## Validation
- cargo fmt --check
- git diff --check HEAD~1..HEAD
- CARGO_TARGET_DIR=/tmp/vize-1189-target cargo test -p vize_canon extracts_only_top_level_interface_fields -- --nocapture
- CARGO_TARGET_DIR=/tmp/vize-1189-target cargo test -p vize_canon nested_interface -- --nocapture
- CARGO_TARGET_DIR=/tmp/vize-1189-target cargo clippy -p vize_canon --lib -- -D warnings

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1279"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783597275&installation_id=136613492&pr_number=1279&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1279&signature=6324ee807e86f808cb472dc44c89c648f32138584e9db70c8bedb369a81b96ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->