### PR TITLE
fix(atelier_core): emit v-slot compiler errors

### DIFF
--- a/crates/vize_atelier_core/src/transform/element.rs
+++ b/crates/vize_atelier_core/src/transform/element.rs
@@ -5,6 +5,7 @@ use vize_carton::{Box, String, Vec, capitalize, is_builtin_directive, is_native_
 use crate::ast::*;
 use crate::errors::ErrorCode;
 use crate::transforms::transform_expression::process_inline_handler;
+use crate::transforms::v_slot::validate_v_slot_usage;
 
 use super::{ExitFns, TransformContext};
 
@@ -18,6 +19,7 @@ pub fn transform_element<'a>(
     el: &mut Box<'a, ElementNode<'a>>,
 ) -> Option<ExitFns<'a>> {
     maybe_promote_element_to_component(ctx, el);
+    validate_v_slot_usage(ctx, el);
 
     // Process props and directives
     process_element_props(ctx, el);

--- a/crates/vize_atelier_core/src/transforms/v_slot.rs
+++ b/crates/vize_atelier_core/src/transforms/v_slot.rs
@@ -6,9 +6,10 @@ use oxc_allocator::Allocator;
 use oxc_ast::ast::BindingPattern;
 use oxc_parser::Parser;
 use oxc_span::SourceType;
-use vize_carton::String;
+use vize_carton::{String, is_builtin_directive};
 
 use crate::ast::*;
+use crate::errors::ErrorCode;
 use crate::transform::TransformContext;
 
 /// Check if element has v-slot directive
@@ -16,6 +17,13 @@ pub fn has_v_slot(el: &ElementNode<'_>) -> bool {
     el.props
         .iter()
         .any(|prop| matches!(prop, PropNode::Directive(dir) if dir.name == "slot"))
+}
+
+fn find_v_slot<'a, 'b>(el: &'b ElementNode<'a>) -> Option<&'b DirectiveNode<'a>> {
+    el.props.iter().find_map(|prop| match prop {
+        PropNode::Directive(dir) if dir.name == "slot" => Some(dir.as_ref()),
+        _ => None,
+    })
 }
 
 /// Get slot name from v-slot directive
@@ -122,6 +130,125 @@ pub fn is_dynamic_slot(dir: &DirectiveNode<'_>) -> bool {
     }
 }
 
+fn is_slot_template(el: &ElementNode<'_>) -> bool {
+    el.tag.as_str() == "template" && has_v_slot(el)
+}
+
+fn has_structural_slot_directive(el: &ElementNode<'_>) -> bool {
+    el.props.iter().any(|prop| {
+        matches!(
+            prop,
+            PropNode::Directive(dir)
+                if matches!(dir.name.as_str(), "if" | "else-if" | "else" | "for")
+        )
+    })
+}
+
+fn has_meaningful_implicit_default_child(child: &TemplateChildNode<'_>) -> bool {
+    match child {
+        TemplateChildNode::Comment(_) => false,
+        TemplateChildNode::Text(text) => !text.content.trim().is_empty(),
+        TemplateChildNode::Element(el) if is_slot_template(el) => false,
+        _ => true,
+    }
+}
+
+fn slot_name_is_static(dir: &DirectiveNode<'_>) -> bool {
+    dir.arg.as_ref().is_none_or(|arg| match arg {
+        ExpressionNode::Simple(exp) => exp.is_static,
+        ExpressionNode::Compound(_) => false,
+    })
+}
+
+/// Validate v-slot placement and slot-template structure.
+pub(crate) fn validate_v_slot_usage(ctx: &mut TransformContext<'_>, el: &ElementNode<'_>) {
+    let own_slot = find_v_slot(el);
+
+    if let Some(dir) = own_slot
+        && el.tag_type != ElementType::Component
+        && el.tag.as_str() != "template"
+    {
+        ctx.on_error(ErrorCode::VSlotMisplaced, Some(dir.loc.clone()));
+    }
+
+    if el.tag_type == ElementType::Slot || el.tag.as_str() == "slot" {
+        for prop in el.props.iter() {
+            if let PropNode::Directive(dir) = prop
+                && !is_builtin_directive(dir.name.as_str())
+            {
+                ctx.on_error(
+                    ErrorCode::VSlotUnexpectedDirectiveOnSlotOutlet,
+                    Some(dir.loc.clone()),
+                );
+            }
+        }
+    }
+
+    if el.tag_type != ElementType::Component || el.children.is_empty() {
+        return;
+    }
+
+    let mut seen_static_slots: std::vec::Vec<String> = std::vec::Vec::new();
+    let mut has_template_slots = false;
+    let mut has_named_default_slot = false;
+    let mut first_implicit_default_loc: Option<SourceLocation> = None;
+
+    for child in el.children.iter() {
+        let TemplateChildNode::Element(child_el) = child else {
+            if first_implicit_default_loc.is_none() && has_meaningful_implicit_default_child(child)
+            {
+                first_implicit_default_loc = Some(child.loc().clone());
+            }
+            continue;
+        };
+
+        let Some(slot_dir) = find_v_slot(child_el) else {
+            if first_implicit_default_loc.is_none() && has_meaningful_implicit_default_child(child)
+            {
+                first_implicit_default_loc = Some(child.loc().clone());
+            }
+            continue;
+        };
+
+        if child_el.tag.as_str() != "template" {
+            continue;
+        }
+
+        if own_slot.is_some() {
+            ctx.on_error(ErrorCode::VSlotMixedSlotUsage, Some(slot_dir.loc.clone()));
+            break;
+        }
+
+        has_template_slots = true;
+
+        if !has_structural_slot_directive(child_el) && slot_name_is_static(slot_dir) {
+            let slot_name = get_slot_name(slot_dir);
+            if seen_static_slots
+                .iter()
+                .any(|seen| seen.as_str() == slot_name.as_str())
+            {
+                ctx.on_error(
+                    ErrorCode::VSlotDuplicateSlotNames,
+                    Some(slot_dir.loc.clone()),
+                );
+                continue;
+            }
+            if slot_name.as_str() == "default" {
+                has_named_default_slot = true;
+            }
+            seen_static_slots.push(slot_name);
+        }
+    }
+
+    if own_slot.is_none()
+        && has_template_slots
+        && has_named_default_slot
+        && let Some(loc) = first_implicit_default_loc
+    {
+        ctx.on_error(ErrorCode::VSlotExtraneousDefaultSlotChildren, Some(loc));
+    }
+}
+
 /// Slot outlet info for codegen
 #[derive(Debug)]
 pub struct SlotOutletInfo {
@@ -165,6 +292,7 @@ pub struct SlotInfo {
 /// Collect slot information from component children
 pub fn collect_slots<'a>(el: &ElementNode<'a>) -> Vec<SlotInfo> {
     let mut slots = Vec::new();
+    let mut seen_static_slots: std::vec::Vec<String> = std::vec::Vec::new();
 
     for child in el.children.iter() {
         if let TemplateChildNode::Element(child_el) = child
@@ -178,6 +306,17 @@ pub fn collect_slots<'a>(el: &ElementNode<'a>) -> Vec<SlotInfo> {
                     let name = get_slot_name(dir);
                     let params_expr = get_slot_props_string(dir);
                     let is_dynamic = is_dynamic_slot(dir);
+
+                    if !is_dynamic
+                        && seen_static_slots
+                            .iter()
+                            .any(|seen| seen.as_str() == name.as_str())
+                    {
+                        continue;
+                    }
+                    if !is_dynamic {
+                        seen_static_slots.push(name.clone());
+                    }
 
                     slots.push(SlotInfo {
                         name,
@@ -234,8 +373,23 @@ mod tests {
         DirectiveNode, SourceLocation, TemplateChildNode, collect_slots, extract_slot_prop_names,
         get_slot_name, get_slot_prop_names, has_v_slot,
     };
+    use crate::errors::{CompilerError, ErrorCode};
+    use crate::options::TransformOptions;
     use crate::parser::parse;
+    use crate::transform::traverse::traverse_children;
+    use crate::transform::{ParentNode, TransformContext};
     use bumpalo::Bump;
+
+    fn transform_errors(source: &str) -> std::vec::Vec<CompilerError> {
+        let allocator = Bump::new();
+        let (mut root, errors) = parse(&allocator, source);
+        assert!(errors.is_empty(), "Parse errors: {:?}", errors);
+
+        let mut ctx =
+            TransformContext::new(&allocator, root.source.clone(), TransformOptions::default());
+        traverse_children(&mut ctx, ParentNode::Root(&mut root as *mut _));
+        ctx.errors
+    }
 
     #[test]
     fn test_has_v_slot() {
@@ -268,6 +422,86 @@ mod tests {
             assert!(slots.iter().any(|s| s.name == "header"));
             assert!(slots.iter().any(|s| s.name == "footer"));
         }
+    }
+
+    #[test]
+    fn test_collect_slots_dedupes_static_duplicate_slot_names() {
+        let allocator = Bump::new();
+        let (root, _) = parse(
+            &allocator,
+            r#"<Comp><template #header>H1</template><template #header>H2</template></Comp>"#,
+        );
+
+        if let TemplateChildNode::Element(el) = &root.children[0] {
+            let slots = collect_slots(el);
+            assert_eq!(slots.len(), 1);
+            assert_eq!(slots[0].name, "header");
+        }
+    }
+
+    #[test]
+    fn test_v_slot_on_plain_element_reports_misplaced() {
+        let errors = transform_errors(r#"<div v-slot="{ item }">Text</div>"#);
+
+        assert_eq!(errors.len(), 1);
+        assert_eq!(errors[0].code, ErrorCode::VSlotMisplaced);
+    }
+
+    #[test]
+    fn test_v_slot_on_empty_plain_element_reports_misplaced() {
+        let errors = transform_errors(r#"<div v-slot></div>"#);
+
+        assert_eq!(errors.len(), 1);
+        assert_eq!(errors[0].code, ErrorCode::VSlotMisplaced);
+    }
+
+    #[test]
+    fn test_duplicate_slot_names_report_error() {
+        let errors = transform_errors(
+            r#"<Comp><template #header>H1</template><template #header>H2</template></Comp>"#,
+        );
+
+        assert_eq!(errors.len(), 1);
+        assert_eq!(errors[0].code, ErrorCode::VSlotDuplicateSlotNames);
+    }
+
+    #[test]
+    fn test_mixed_component_and_template_slot_usage_reports_error() {
+        let errors = transform_errors(r#"<Comp v-slot><template #header>Header</template></Comp>"#);
+
+        assert_eq!(errors.len(), 1);
+        assert_eq!(errors[0].code, ErrorCode::VSlotMixedSlotUsage);
+    }
+
+    #[test]
+    fn test_explicit_default_slot_with_children_reports_error() {
+        let errors = transform_errors(
+            r#"<Comp><template #default>Default</template><span>Extra</span></Comp>"#,
+        );
+
+        assert_eq!(errors.len(), 1);
+        assert_eq!(
+            errors[0].code,
+            ErrorCode::VSlotExtraneousDefaultSlotChildren
+        );
+    }
+
+    #[test]
+    fn test_explicit_default_slot_allows_whitespace_children() {
+        let errors = transform_errors("<Comp><template #default>Default</template>\n  \t\n</Comp>");
+
+        assert!(errors.is_empty(), "Unexpected errors: {:?}", errors);
+    }
+
+    #[test]
+    fn test_custom_directive_on_slot_outlet_reports_error() {
+        let errors = transform_errors(r#"<slot v-custom />"#);
+
+        assert_eq!(errors.len(), 1);
+        assert_eq!(
+            errors[0].code,
+            ErrorCode::VSlotUnexpectedDirectiveOnSlotOutlet
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- emit atelier_core VSlot* diagnostics for misplaced v-slot, mixed component/template slots, duplicate static slot names, extraneous default children, and custom directives on slot outlets
- dedupe static duplicate slot names in collect_slots so duplicate SlotInfo entries are not produced
- add transform regression coverage for the v-slot error cases from #1202

## Root cause
atelier_core skipped v-slot during props codegen and only entered v-slot scopes for components/templates, but it had no transform validation pass that reported Vue-compatible VSlot* errors.

Closes #1202.

## Verification
- CARGO_TARGET_DIR=/tmp/vize-1202-target cargo fmt --check
- CARGO_TARGET_DIR=/tmp/vize-1202-target cargo test -p vize_atelier_core
- CARGO_TARGET_DIR=/tmp/vize-1202-target cargo test -p vize_atelier_dom
- CARGO_TARGET_DIR=/tmp/vize-1202-target cargo clippy -p vize_atelier_core --lib -- -D warnings
- CARGO_TARGET_DIR=/tmp/vize-1202-target cargo clippy --workspace -- -D warnings
- CARGO_TARGET_DIR=/tmp/vize-1202-target cargo semver-checks check-release --package vize_atelier_core

Note: CARGO_TARGET_DIR=/tmp/vize-1202-target cargo clippy -p vize_atelier_core --all-targets -- -D warnings still fails on existing test-only lint issues in crates/vize_atelier_core/src/codegen/helpers.rs and crates/vize_atelier_core/src/transform/structural.rs.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1280"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783597545&installation_id=136613492&pr_number=1280&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1280&signature=edd54bc3b0b1eb41679aa3f0e0dd0aa267306ffcd6e9f4a792a961eab3d4576f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->