### PR TITLE
fix(vize_patina): suppress template diagnostics with directives

### DIFF
--- a/crates/vize_patina/src/linter/tests/directives.rs
+++ b/crates/vize_patina/src/linter/tests/directives.rs
@@ -123,6 +123,51 @@ fn test_vize_ignore_start_end_region() {
 }
 
 #[test]
+fn test_vize_ignore_start_end_suppresses_run_on_template_diagnostic() {
+    // Regression for #1196: `@vize:ignore-start` / `@vize:ignore-end`
+    // regions must already be known before `run_on_template` rules report.
+    let linter = Linter::new();
+    let result = linter.lint_template(
+        r#"<!-- @vize:ignore-start -->
+<div v-if="a"></div>
+<div v-else-if="a"></div>
+<!-- @vize:ignore-end -->"#,
+        "test.vue",
+    );
+    assert_eq!(
+        result
+            .diagnostics
+            .iter()
+            .filter(|d| d.rule_name == "vue/no-dupe-v-else-if")
+            .count(),
+        0,
+        "run_on_template-phase rule must be suppressed by @vize:ignore-start/end"
+    );
+}
+
+#[test]
+fn test_vize_forget_suppresses_run_on_template_diagnostic() {
+    // Regression for #1196: `@vize:forget` suppresses the next template
+    // child, including the branches in its v-if / v-else-if chain.
+    let linter = Linter::new();
+    let result = linter.lint_template(
+        r#"<!-- @vize:forget duplicate condition is intentional -->
+<div v-if="a"></div>
+<div v-else-if="a"></div>"#,
+        "test.vue",
+    );
+    assert_eq!(
+        result
+            .diagnostics
+            .iter()
+            .filter(|d| d.rule_name == "vue/no-dupe-v-else-if")
+            .count(),
+        0,
+        "run_on_template-phase rule must be suppressed by @vize:forget"
+    );
+}
+
+#[test]
 fn test_vize_docs_no_lint_effect() {
     let linter = Linter::new();
     let result = linter.lint_template(

--- a/crates/vize_patina/src/visitor.rs
+++ b/crates/vize_patina/src/visitor.rs
@@ -7,7 +7,7 @@ use crate::rule::Rule;
 use vize_carton::directive::{DirectiveKind, parse_level_severity, parse_vize_directive};
 use vize_carton::{CompactString, cstr, profile};
 use vize_relief::ast::{
-    CommentNode, ElementNode, ExpressionNode, PropNode, RootNode, TemplateChildNode,
+    CommentNode, ElementNode, ExpressionNode, PropNode, RootNode, SourceLocation, TemplateChildNode,
 };
 
 /// Visit the AST and run all rules
@@ -41,12 +41,12 @@ impl<'a, 'ctx, 'rules> LintVisitor<'a, 'ctx, 'rules> {
     /// Visit the root node and traverse the AST
     #[inline]
     pub fn visit_root(&mut self, root: &RootNode<'a>) {
-        // Pre-scan for `@vize:expected` / `@vize:level` directives so they
-        // can suppress diagnostics produced by `run_on_template` rules
-        // (which fire before per-element traversal would register them).
-        // Without this pass, directives are registered too late and
-        // template-phase rules — `vue/no-dupe-v-else-if`,
-        // `vue/no-mutating-props`, etc. — can't be suppressed. (#968)
+        // Pre-scan suppression directives so they can suppress diagnostics
+        // produced by `run_on_template` rules (which fire before per-element
+        // traversal would register them). Without this pass, directives are
+        // registered too late and template-phase rules —
+        // `vue/no-dupe-v-else-if`, `vue/no-mutating-props`, etc. — can't be
+        // suppressed. (#968, #1196)
         self.prescan_suppression_directives(root);
 
         // Run template-level checks under one profiling span. Rule dispatch
@@ -65,23 +65,36 @@ impl<'a, 'ctx, 'rules> LintVisitor<'a, 'ctx, 'rules> {
         }
     }
 
-    /// Walk the AST and register every `@vize:expected` / `@vize:level`
-    /// directive into the context up-front. Other directive kinds (Todo,
-    /// Fixme, IgnoreStart/End, Forget, Deprecated) are intentionally NOT
-    /// processed here — they may emit diagnostics and rely on the existing
-    /// ordering and ignore-region bookkeeping that runs during the main
-    /// traversal. (#968)
+    /// Walk the AST and register every suppression-only directive into the
+    /// context up-front. Directive kinds that emit diagnostics (Todo, Fixme,
+    /// Deprecated) are intentionally NOT processed here; they rely on the
+    /// existing ordering that runs during the main traversal.
     fn prescan_suppression_directives(&mut self, root: &RootNode<'a>) {
-        for child in root.children.iter() {
-            self.prescan_suppression_in_child(child);
+        let mut forget_next_child = false;
+        self.prescan_suppression_in_children(&root.children, &mut forget_next_child);
+    }
+
+    fn prescan_suppression_in_children(
+        &mut self,
+        children: &[TemplateChildNode<'a>],
+        forget_next_child: &mut bool,
+    ) {
+        for (index, node) in children.iter().enumerate() {
+            self.prescan_suppression_in_child(children, index, node, forget_next_child);
         }
     }
 
-    fn prescan_suppression_in_child(&mut self, node: &TemplateChildNode<'a>) {
+    fn prescan_suppression_in_child(
+        &mut self,
+        siblings: &[TemplateChildNode<'a>],
+        index: usize,
+        node: &TemplateChildNode<'a>,
+        forget_next_child: &mut bool,
+    ) {
         match node {
             TemplateChildNode::Comment(comment) => {
                 if let Some(kind) = comment.directive {
-                    let line = comment.loc.start.line;
+                    let line = self.ctx.offset_to_line(comment.loc.start.offset);
                     match kind {
                         DirectiveKind::Expected => {
                             self.ctx.expect_error_next_line(line);
@@ -96,22 +109,77 @@ impl<'a, 'ctx, 'rules> LintVisitor<'a, 'ctx, 'rules> {
                                 self.ctx.set_severity_override_next_line(line, severity);
                             }
                         }
+                        DirectiveKind::IgnoreStart => {
+                            self.ctx.push_ignore_region(line);
+                        }
+                        DirectiveKind::IgnoreEnd => {
+                            self.ctx.pop_ignore_region(line);
+                        }
+                        DirectiveKind::Forget => {
+                            *forget_next_child = true;
+                        }
                         _ => {}
                     }
                 }
             }
             TemplateChildNode::Element(el) => {
-                for child in el.children.iter() {
-                    self.prescan_suppression_in_child(child);
+                if *forget_next_child {
+                    *forget_next_child = false;
+                    self.disable_forgotten_element(siblings, index, el);
+                }
+                self.prescan_suppression_in_children(&el.children, forget_next_child);
+            }
+            TemplateChildNode::If(if_node) => {
+                if *forget_next_child {
+                    *forget_next_child = false;
+                    self.disable_loc_range(&if_node.loc);
+                }
+                for branch in if_node.branches.iter() {
+                    self.prescan_suppression_in_children(&branch.children, forget_next_child);
                 }
             }
             TemplateChildNode::For(for_node) => {
-                for child in for_node.children.iter() {
-                    self.prescan_suppression_in_child(child);
+                if *forget_next_child {
+                    *forget_next_child = false;
+                    self.disable_loc_range(&for_node.loc);
                 }
+                self.prescan_suppression_in_children(&for_node.children, forget_next_child);
             }
             _ => {}
         }
+    }
+
+    fn disable_forgotten_element(
+        &mut self,
+        siblings: &[TemplateChildNode<'a>],
+        index: usize,
+        el: &ElementNode<'a>,
+    ) {
+        self.disable_loc_range(&el.loc);
+
+        if !element_has_directive(el, "if") {
+            return;
+        }
+
+        for sibling in siblings.iter().skip(index + 1) {
+            let TemplateChildNode::Element(branch) = sibling else {
+                continue;
+            };
+            if element_has_directive(branch, "else-if") {
+                self.disable_loc_range(&branch.loc);
+                continue;
+            }
+            if element_has_directive(branch, "else") {
+                self.disable_loc_range(&branch.loc);
+            }
+            break;
+        }
+    }
+
+    fn disable_loc_range(&mut self, loc: &SourceLocation) {
+        let start_line = self.ctx.offset_to_line(loc.start.offset);
+        let end_line = self.ctx.offset_to_line(loc.end.offset);
+        self.ctx.disable_all(start_line, Some(end_line));
     }
 
     #[inline]
@@ -168,7 +236,7 @@ impl<'a, 'ctx, 'rules> LintVisitor<'a, 'ctx, 'rules> {
 
     /// Process `@vize:` directives on comment nodes.
     fn process_vize_directive(&mut self, comment: &CommentNode, kind: DirectiveKind) {
-        let line = comment.loc.start.line;
+        let line = self.ctx.offset_to_line(comment.loc.start.offset);
         let loc = &comment.loc;
 
         match kind {
@@ -353,6 +421,12 @@ impl<'a, 'ctx, 'rules> LintVisitor<'a, 'ctx, 'rules> {
         }
         Vec::new()
     }
+}
+
+fn element_has_directive(el: &ElementNode, name: &str) -> bool {
+    el.props
+        .iter()
+        .any(|p| matches!(p, PropNode::Directive(d) if d.name.as_str() == name))
 }
 
 /// Parse v-for expression to extract variable names.


### PR DESCRIPTION
## Summary
- Pre-scan `@vize:ignore-start` / `@vize:ignore-end` and `@vize:forget` suppression ranges before `run_on_template` rules execute.
- Resolve directive comment line numbers from source offsets so multi-line ignore regions close on the actual comment line.
- Add regression coverage for `vue/no-dupe-v-else-if` suppression through ignore regions and `@vize:forget`.

Closes #1196.

## Verification
- `CARGO_TARGET_DIR=/tmp/vize-1196-target cargo test -p vize_patina`
- `CARGO_TARGET_DIR=/tmp/vize-1196-target cargo fmt --check`
- `CARGO_TARGET_DIR=/tmp/vize-1196-target cargo clippy -p vize_patina --lib -- -D warnings`
- `CARGO_TARGET_DIR=/tmp/vize-1196-target cargo semver-checks check-release -p vize_patina`

Note: `CARGO_TARGET_DIR=/tmp/vize-1196-target cargo clippy -p vize_patina --all-targets -- -D warnings` currently fails on pre-existing bench/test lints such as deprecated `criterion::black_box` in `crates/vize_patina/benches/lint_bench.rs` and existing `insta` snapshot macro disallowed-macro warnings.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1281"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783597576&installation_id=136613492&pr_number=1281&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1281&signature=684a7fb3685c58966d983ddc48d01ad3c696929cbf8f3dc1e373e71eb11057d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->