### PR TITLE
fix(croquis_cf): honor spread component props

### DIFF
--- a/crates/vize_croquis_cf/src/analyzer/tests_basic.rs
+++ b/crates/vize_croquis_cf/src/analyzer/tests_basic.rs
@@ -110,6 +110,46 @@ fn test_undeclared_on_prefixed_prop_is_reported() {
     assert_eq!(undeclared_props, vec!["online"]);
 }
 
+#[test]
+fn test_spread_attrs_suppress_missing_required_prop_without_hiding_explicit_props() {
+    let mut analyzer =
+        CrossFileAnalyzer::new(CrossFileOptions::default().with_props_validation(true));
+
+    let child_analysis = script_analysis("const props = defineProps<{ id: number }>()");
+    let parent_analysis = script_analysis_with_component_usage(
+        r#"import Child from './Child.vue'
+const formData = { id: 1 }"#,
+        component_usage_with_spread_and_extra_prop("Child"),
+    );
+
+    analyzer.add_file_with_analysis(Path::new("Child.vue"), "", child_analysis);
+    analyzer.add_file_with_analysis(Path::new("Parent.vue"), "", parent_analysis);
+    analyzer.rebuild_component_edges();
+
+    let result = analyzer.analyze();
+    let missing_required_props = result
+        .diagnostics
+        .iter()
+        .filter_map(|diagnostic| match &diagnostic.kind {
+            CrossFileDiagnosticKind::MissingRequiredProp { prop_name, .. } => {
+                Some(prop_name.as_str())
+            }
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    let undeclared_props = result
+        .diagnostics
+        .iter()
+        .filter_map(|diagnostic| match &diagnostic.kind {
+            CrossFileDiagnosticKind::UndeclaredProp { prop_name, .. } => Some(prop_name.as_str()),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+
+    assert!(missing_required_props.is_empty());
+    assert_eq!(undeclared_props, vec!["extra"]);
+}
+
 fn script_analysis(script: &str) -> vize_croquis::Croquis {
     let mut analyzer = vize_croquis::Analyzer::with_options(AnalyzerOptions::full());
     analyzer.analyze_script_setup(script);
@@ -159,6 +199,20 @@ fn component_usage_with_on_prefixed_prop(component: &str) -> ComponentUsage {
         events: smallvec![event_listener("click")],
         slots: smallvec![],
         has_spread_attrs: false,
+        scope_id: ScopeId::ROOT,
+        vif_guard: None,
+    }
+}
+
+fn component_usage_with_spread_and_extra_prop(component: &str) -> ComponentUsage {
+    ComponentUsage {
+        name: CompactString::new(component),
+        start: 0,
+        end: 0,
+        props: smallvec![passed_prop("extra", Some("true"), false)],
+        events: smallvec![],
+        slots: smallvec![],
+        has_spread_attrs: true,
         scope_id: ScopeId::ROOT,
         vif_guard: None,
     }

--- a/crates/vize_croquis_cf/src/analyzers/props_validation.rs
+++ b/crates/vize_croquis_cf/src/analyzers/props_validation.rs
@@ -114,95 +114,100 @@ pub fn analyze_props_validation(
         // This requires parsing the template to find the actual props passed
         // For now, we focus on checking required props from the child's perspective
         let aliases = imported_aliases_for_child(parent_entry, child_entry);
-        let passed_props = extract_passed_props_for_component(
+        let passed_usages = extract_passed_props_for_component(
             &parent_entry.analysis,
             child_component_name.as_str(),
             &aliases,
         );
 
-        // Check for missing required props
-        for (prop_name, prop_info) in &child_props_info.props {
-            if prop_info.required && !passed_props.contains(prop_name.as_str()) {
-                let issue = PropsValidationIssue {
-                    parent_file: parent_id,
-                    child_file: child_id,
-                    component_name: child_component_name.clone(),
-                    kind: PropsValidationIssueKind::MissingRequiredProp {
-                        prop_name: prop_name.clone(),
-                    },
-                    offset: 0,
-                };
-                issues.push(issue);
+        for passed_usage in passed_usages {
+            // Check for missing required props. A spread v-bind can provide any
+            // required prop, so only validate required props for non-spread usages.
+            if !passed_usage.has_spread_attrs {
+                for (prop_name, prop_info) in &child_props_info.props {
+                    if prop_info.required && !passed_usage.props.contains(prop_name.as_str()) {
+                        let issue = PropsValidationIssue {
+                            parent_file: parent_id,
+                            child_file: child_id,
+                            component_name: child_component_name.clone(),
+                            kind: PropsValidationIssueKind::MissingRequiredProp {
+                                prop_name: prop_name.clone(),
+                            },
+                            offset: passed_usage.offset,
+                        };
+                        issues.push(issue);
 
-                let diagnostic = CrossFileDiagnostic::new(
-                    CrossFileDiagnosticKind::MissingRequiredProp {
-                        prop_name: prop_name.clone(),
-                        component_name: child_component_name.clone(),
-                    },
-                    DiagnosticSeverity::Error,
-                    parent_id,
-                    0,
-                    cstr!(
-                        "**Missing Required Prop**: `{}` must be passed to `<{}>`\n\n\
-                        This prop is declared as required in the component's `defineProps`.",
-                        prop_name,
-                        child_component_name
-                    ),
-                )
-                .with_related(
-                    child_id,
-                    0,
-                    cstr!("Prop `{prop_name}` is declared as required here"),
-                );
+                        let diagnostic = CrossFileDiagnostic::new(
+                            CrossFileDiagnosticKind::MissingRequiredProp {
+                                prop_name: prop_name.clone(),
+                                component_name: child_component_name.clone(),
+                            },
+                            DiagnosticSeverity::Error,
+                            parent_id,
+                            passed_usage.offset,
+                            cstr!(
+                                "**Missing Required Prop**: `{}` must be passed to `<{}>`\n\n\
+                                This prop is declared as required in the component's `defineProps`.",
+                                prop_name,
+                                child_component_name
+                            ),
+                        )
+                        .with_related(
+                            child_id,
+                            0,
+                            cstr!("Prop `{prop_name}` is declared as required here"),
+                        );
 
-                diagnostics.push(diagnostic);
-            }
-        }
-
-        // Check for undeclared props (props passed but not in defineProps)
-        for passed_prop in &passed_props {
-            // Skip built-in attributes
-            if is_builtin_attr(passed_prop) {
-                continue;
+                        diagnostics.push(diagnostic);
+                    }
+                }
             }
 
-            // Check if this prop is declared
-            let is_declared = child_props_info.props.contains_key(*passed_prop);
+            // Check for undeclared props (explicit props passed but not in defineProps)
+            for passed_prop in &passed_usage.props {
+                // Skip built-in attributes
+                if is_builtin_attr(passed_prop) {
+                    continue;
+                }
 
-            if !is_declared {
-                let issue = PropsValidationIssue {
-                    parent_file: parent_id,
-                    child_file: child_id,
-                    component_name: child_component_name.clone(),
-                    kind: PropsValidationIssueKind::UndeclaredProp {
-                        prop_name: CompactString::new(*passed_prop),
-                    },
-                    offset: 0,
-                };
-                issues.push(issue);
+                // Check if this prop is declared
+                let is_declared = child_props_info.props.contains_key(*passed_prop);
 
-                let diagnostic = CrossFileDiagnostic::new(
-                    CrossFileDiagnosticKind::UndeclaredProp {
-                        prop_name: CompactString::new(*passed_prop),
+                if !is_declared {
+                    let issue = PropsValidationIssue {
+                        parent_file: parent_id,
+                        child_file: child_id,
                         component_name: child_component_name.clone(),
-                    },
-                    DiagnosticSeverity::Warning, // Warning since it might be intentional $attrs
-                    parent_id,
-                    0,
-                    cstr!(
-                        "**Undeclared Prop**: `{}` is passed to `<{}>` but not declared\n\n\
-                        The prop is not defined in the component's `defineProps`.\n\
-                        If intentional, it will fall through to the root element via `$attrs`.",
-                        passed_prop, child_component_name
-                    ),
-                )
-                .with_suggestion(cstr!(
-                    "Add to defineProps:\n```typescript\ndefineProps<{{\n  {}: unknown\n}}>()\n```\n\n\
-                    Or use `v-bind=\"$attrs\"` in the child component for fallthrough.",
-                    passed_prop
-                ));
+                        kind: PropsValidationIssueKind::UndeclaredProp {
+                            prop_name: CompactString::new(*passed_prop),
+                        },
+                        offset: passed_usage.offset,
+                    };
+                    issues.push(issue);
 
-                diagnostics.push(diagnostic);
+                    let diagnostic = CrossFileDiagnostic::new(
+                        CrossFileDiagnosticKind::UndeclaredProp {
+                            prop_name: CompactString::new(*passed_prop),
+                            component_name: child_component_name.clone(),
+                        },
+                        DiagnosticSeverity::Warning, // Warning since it might be intentional $attrs
+                        parent_id,
+                        passed_usage.offset,
+                        cstr!(
+                            "**Undeclared Prop**: `{}` is passed to `<{}>` but not declared\n\n\
+                            The prop is not defined in the component's `defineProps`.\n\
+                            If intentional, it will fall through to the root element via `$attrs`.",
+                            passed_prop, child_component_name
+                        ),
+                    )
+                    .with_suggestion(cstr!(
+                        "Add to defineProps:\n```typescript\ndefineProps<{{\n  {}: unknown\n}}>()\n```\n\n\
+                        Or use `v-bind=\"$attrs\"` in the child component for fallthrough.",
+                        passed_prop
+                    ));
+
+                    diagnostics.push(diagnostic);
+                }
             }
         }
     }
@@ -210,15 +215,21 @@ pub fn analyze_props_validation(
     (issues, diagnostics)
 }
 
-/// Extract props passed to a specific component from the analysis.
+struct PassedComponentUsage<'a> {
+    props: FxHashSet<&'a str>,
+    has_spread_attrs: bool,
+    offset: u32,
+}
+
+/// Extract matched usages and explicit props passed to a specific component from the analysis.
 ///
 /// Uses component_usages to find props passed to the component.
 fn extract_passed_props_for_component<'a>(
     analysis: &'a vize_croquis::Croquis,
     component_name: &str,
     aliases: &[CompactString],
-) -> FxHashSet<&'a str> {
-    let mut props = FxHashSet::default();
+) -> Vec<PassedComponentUsage<'a>> {
+    let mut usages = Vec::new();
 
     for usage in &analysis.component_usages {
         // Match component name (case-insensitive for kebab-case vs PascalCase)
@@ -227,13 +238,28 @@ fn extract_passed_props_for_component<'a>(
                 .iter()
                 .any(|alias| component_names_match(usage.name.as_str(), alias.as_str()))
         {
+            let mut props = FxHashSet::default();
             for prop in &usage.props {
                 props.insert(prop.name.as_str());
             }
+
+            usages.push(PassedComponentUsage {
+                props,
+                has_spread_attrs: usage.has_spread_attrs,
+                offset: usage.start,
+            });
         }
     }
 
-    props
+    if usages.is_empty() {
+        usages.push(PassedComponentUsage {
+            props: FxHashSet::default(),
+            has_spread_attrs: false,
+            offset: 0,
+        });
+    }
+
+    usages
 }
 
 fn imported_aliases_for_child(


### PR DESCRIPTION
## Summary
- Preserve matched component usage details during props validation so `v-bind="obj"` spread attrs suppress missing required prop diagnostics for that usage.
- Continue validating explicit props on spread usages and add a regression test for that behavior.

Closes #1194

## Validation
- `cargo fmt --package vize_croquis_cf -- --check`
- `CARGO_TARGET_DIR=/tmp/vize-1194-cargo-target cargo test -p vize_croquis_cf test_spread_attrs_suppress_missing_required_prop_without_hiding_explicit_props`
- `CARGO_TARGET_DIR=/tmp/vize-1194-cargo-target cargo test -p vize_croquis_cf`
- `CARGO_TARGET_DIR=/tmp/vize-1194-cargo-target cargo check -p vize_croquis_cf`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1282"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783597755&installation_id=136613492&pr_number=1282&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1282&signature=5986b92f5bcb630a112abdd727e6305e1631a329340bdfb0c94370dd675e400f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->