### PR TITLE
fix(croquis): preserve undefined reference offsets

### DIFF
--- a/crates/vize_canon/src/sfc_typecheck.rs
+++ b/crates/vize_canon/src/sfc_typecheck.rs
@@ -699,6 +699,31 @@ export default {
     }
 
     #[test]
+    fn test_type_check_template_undefined_binding_skips_member_property_offsets() {
+        let source = r#"<script setup>
+const user = {}
+</script>
+<template>{{ user.name + name }}</template>"#;
+        let options = SfcTypeCheckOptions::new("test.vue");
+        let result = type_check_sfc(source, &options);
+
+        let diagnostic = result
+            .diagnostics
+            .iter()
+            .find(|d| {
+                d.code.as_deref() == Some("undefined-binding")
+                    && d.message.contains("Undefined reference 'name'")
+            })
+            .expect("expected an undefined-binding diagnostic for trailing name");
+
+        let expected_start = source.rfind("name").unwrap() as u32;
+        let expected_end = expected_start + "name".len() as u32;
+
+        assert_eq!(diagnostic.start, expected_start);
+        assert_eq!(diagnostic.end, expected_end);
+    }
+
+    #[test]
     fn test_type_check_typeof_setup_const_stays_in_setup_scope() {
         // Regression: vize check used to lift `type Name = ...` to module
         // scope while the `const names` it referenced via `typeof` stayed

--- a/crates/vize_canon/src/virtual_ts/scope.rs
+++ b/crates/vize_canon/src/virtual_ts/scope.rs
@@ -11,7 +11,7 @@ use vize_carton::profile;
 
 use vize_croquis::{
     BindingMetadata, Croquis, EventHandlerScopeData, Scope, ScopeData, ScopeId, ScopeKind,
-    analysis::ComponentUsage, analyzer::extract_identifiers_oxc, naming::to_pascal_case,
+    analysis::ComponentUsage, analyzer::extract_identifier_refs_oxc, naming::to_pascal_case,
 };
 
 use super::{
@@ -299,12 +299,9 @@ fn generate_instance_global_refs(
     }
 
     for expr in &summary.template_expressions {
-        for ident in extract_identifiers_oxc(expr.content.as_str()) {
-            let name = ident.as_str();
-            let Some(relative_offset) = expr.content.find(name) else {
-                continue;
-            };
-            let src_start = (template_offset + expr.start) as usize + relative_offset;
+        for ident in extract_identifier_refs_oxc(expr.content.as_str()) {
+            let name = ident.name.as_str();
+            let src_start = (template_offset + expr.start + ident.offset) as usize;
             let src_end = src_start + name.len();
             emitter.emit(name, src_start, src_end);
         }

--- a/crates/vize_croquis/src/analyzer.rs
+++ b/crates/vize_croquis/src/analyzer.rs
@@ -5,8 +5,8 @@
 //! keep working.
 
 pub use crate::drawer::{
-    Drawer as Analyzer, DrawerOptions as AnalyzerOptions, VForScopeAliases,
-    extract_identifiers_oxc, extract_inline_callback_params, extract_slot_props,
-    is_builtin_directive, is_component_tag, is_keyword, parse_v_for_expression,
+    Drawer as Analyzer, DrawerOptions as AnalyzerOptions, IdentifierRef, VForScopeAliases,
+    extract_identifier_refs_oxc, extract_identifiers_oxc, extract_inline_callback_params,
+    extract_slot_props, is_builtin_directive, is_component_tag, is_keyword, parse_v_for_expression,
     parse_v_for_scope_expression, strip_js_comments,
 };

--- a/crates/vize_croquis/src/drawer.rs
+++ b/crates/vize_croquis/src/drawer.rs
@@ -14,8 +14,8 @@ mod tests;
 
 pub use core::Drawer;
 pub use helpers::{
-    VForScopeAliases, extract_identifiers_oxc, extract_inline_callback_params, extract_slot_props,
-    is_builtin_directive, is_component_tag, is_keyword, parse_v_for_expression,
-    parse_v_for_scope_expression, strip_js_comments,
+    IdentifierRef, VForScopeAliases, extract_identifier_refs_oxc, extract_identifiers_oxc,
+    extract_inline_callback_params, extract_slot_props, is_builtin_directive, is_component_tag,
+    is_keyword, parse_v_for_expression, parse_v_for_scope_expression, strip_js_comments,
 };
 pub use options::DrawerOptions;

--- a/crates/vize_croquis/src/drawer/core.rs
+++ b/crates/vize_croquis/src/drawer/core.rs
@@ -1,7 +1,7 @@
 use crate::croquis::Croquis;
 use vize_carton::{CompactString, FxHashMap, profile};
 
-use super::DrawerOptions;
+use super::{DrawerOptions, helpers::IdentifierRef};
 
 /// High-performance Vue SFC drawer.
 ///
@@ -34,12 +34,12 @@ pub struct Drawer {
     pub(crate) vfor_depth: u32,
     /// Memoized identifier extraction keyed by expression text. Template
     /// expressions repeat heavily (e.g. the same `:to`/`@click`/`{{ }}` across
-    /// every `v-for` iteration's rendered element), and `extract_identifiers_oxc`
+    /// every `v-for` iteration's rendered element), and identifier extraction
     /// is a pure function of the expression string, so the parse+walk is done
     /// once per distinct expression instead of once per occurrence. The cached
     /// `Vec` is read by reference (disjoint field borrow), so cache hits avoid
     /// both the parse and any clone.
-    pub(crate) ident_cache: FxHashMap<CompactString, Vec<CompactString>>,
+    pub(crate) ident_cache: FxHashMap<CompactString, Vec<IdentifierRef>>,
 }
 
 impl Drawer {

--- a/crates/vize_croquis/src/drawer/helpers.rs
+++ b/crates/vize_croquis/src/drawer/helpers.rs
@@ -11,7 +11,9 @@ mod keywords;
 mod slots;
 mod v_for;
 
-pub use identifiers::{extract_identifiers_oxc, strip_js_comments};
+pub use identifiers::{
+    IdentifierRef, extract_identifier_refs_oxc, extract_identifiers_oxc, strip_js_comments,
+};
 pub use keywords::{is_builtin_directive, is_component_tag, is_keyword};
 pub use slots::{extract_inline_callback_params, extract_slot_props};
 pub use v_for::{VForScopeAliases, parse_v_for_expression, parse_v_for_scope_expression};

--- a/crates/vize_croquis/src/drawer/helpers/identifiers.rs
+++ b/crates/vize_croquis/src/drawer/helpers/identifiers.rs
@@ -19,8 +19,26 @@ pub use comments::strip_js_comments;
 
 use vize_carton::{CompactString, profile};
 
-use fast::extract_identifiers_fast;
-use slow::extract_identifiers_oxc_slow;
+use fast::{extract_identifier_refs_fast, extract_identifiers_fast};
+use slow::{extract_identifier_refs_oxc_slow, extract_identifiers_oxc_slow};
+
+/// Root identifier reference extracted from a template expression.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct IdentifierRef {
+    pub name: CompactString,
+    /// Byte offset relative to the expression source.
+    pub offset: u32,
+}
+
+impl IdentifierRef {
+    #[inline]
+    pub(super) fn new(name: &str, offset: u32) -> Self {
+        Self {
+            name: CompactString::new(name),
+            offset,
+        }
+    }
+}
 
 /// Hybrid identifier extraction - fast path for simple expressions, OXC for complex ones.
 /// Only extracts "root" identifiers - identifiers that are references, not:
@@ -47,5 +65,24 @@ pub fn extract_identifiers_oxc(expr: &str) -> Vec<CompactString> {
     profile!(
         "croquis.helpers.identifiers.fast",
         extract_identifiers_fast(expr)
+    )
+}
+
+/// Hybrid root identifier extraction with byte offsets in the original expression.
+#[inline]
+pub fn extract_identifier_refs_oxc(expr: &str) -> Vec<IdentifierRef> {
+    // Use OXC for constructs where a string scanner cannot cheaply preserve
+    // semantic identifier spans. Comments contain `/`, so this keeps offsets in
+    // the original expression instead of using `strip_js_comments`.
+    if expr.contains('{') || expr.contains(" as ") || expr.contains("=>") || expr.contains('/') {
+        return profile!(
+            "croquis.helpers.identifier_refs.slow",
+            extract_identifier_refs_oxc_slow(expr)
+        );
+    }
+
+    profile!(
+        "croquis.helpers.identifier_refs.fast",
+        extract_identifier_refs_fast(expr)
     )
 }

--- a/crates/vize_croquis/src/drawer/helpers/identifiers/fast.rs
+++ b/crates/vize_croquis/src/drawer/helpers/identifiers/fast.rs
@@ -1,8 +1,21 @@
+use super::IdentifierRef;
 use vize_carton::CompactString;
 
 /// Fast string-based identifier extraction for simple expressions.
 #[inline]
 pub(super) fn extract_identifiers_fast(expr: &str) -> Vec<CompactString> {
+    extract_identifier_refs_fast(expr)
+        .into_iter()
+        .map(|identifier| identifier.name)
+        .collect()
+}
+
+#[inline]
+pub(super) fn extract_identifier_refs_fast(expr: &str) -> Vec<IdentifierRef> {
+    extract_identifier_refs_fast_with_base(expr, 0)
+}
+
+fn extract_identifier_refs_fast_with_base(expr: &str, base_offset: u32) -> Vec<IdentifierRef> {
     let mut identifiers = Vec::with_capacity(4);
     let bytes = expr.as_bytes();
     let len = bytes.len();
@@ -71,7 +84,10 @@ pub(super) fn extract_identifiers_fast(expr: &str) -> Vec<CompactString> {
                     }
                     if interp_start < i {
                         let interp_content = &expr[interp_start..i];
-                        for ident in extract_identifiers_fast(interp_content) {
+                        for ident in extract_identifier_refs_fast_with_base(
+                            interp_content,
+                            base_offset + interp_start as u32,
+                        ) {
                             identifiers.push(ident);
                         }
                     }
@@ -83,6 +99,27 @@ pub(super) fn extract_identifiers_fast(expr: &str) -> Vec<CompactString> {
                 i += 1;
             }
             continue;
+        }
+
+        if c == b'/' && i + 1 < len {
+            match bytes[i + 1] {
+                b'/' => {
+                    i += 2;
+                    while i < len && bytes[i] != b'\n' {
+                        i += 1;
+                    }
+                    continue;
+                }
+                b'*' => {
+                    i += 2;
+                    while i + 1 < len && !(bytes[i] == b'*' && bytes[i + 1] == b'/') {
+                        i += 1;
+                    }
+                    i = (i + 2).min(len);
+                    continue;
+                }
+                _ => {}
+            }
         }
 
         // Start of identifier
@@ -114,7 +151,10 @@ pub(super) fn extract_identifiers_fast(expr: &str) -> Vec<CompactString> {
             };
 
             if !is_property_access {
-                identifiers.push(CompactString::new(&expr[start..i]));
+                identifiers.push(IdentifierRef::new(
+                    &expr[start..i],
+                    base_offset + start as u32,
+                ));
             }
         } else {
             i += 1;

--- a/crates/vize_croquis/src/drawer/helpers/identifiers/slow.rs
+++ b/crates/vize_croquis/src/drawer/helpers/identifiers/slow.rs
@@ -5,9 +5,19 @@ use oxc_parser::Parser;
 use oxc_span::SourceType;
 use vize_carton::{CompactString, profile};
 
+use super::IdentifierRef;
+
 /// OXC-based identifier extraction for expressions with object literals.
 #[inline]
 pub(super) fn extract_identifiers_oxc_slow(expr: &str) -> Vec<CompactString> {
+    extract_identifier_refs_oxc_slow(expr)
+        .into_iter()
+        .map(|identifier| identifier.name)
+        .collect()
+}
+
+#[inline]
+pub(super) fn extract_identifier_refs_oxc_slow(expr: &str) -> Vec<IdentifierRef> {
     let allocator = Allocator::default();
     let source_type = SourceType::from_path("expr.ts").unwrap_or_default();
 

--- a/crates/vize_croquis/src/drawer/helpers/identifiers/slow/walk.rs
+++ b/crates/vize_croquis/src/drawer/helpers/identifiers/slow/walk.rs
@@ -1,12 +1,13 @@
 use oxc_ast::ast::{
     ArrayExpressionElement, BindingPattern, Expression, ObjectPropertyKind, PropertyKey,
 };
-use vize_carton::CompactString;
 
-pub(super) fn walk_expr(expr: &Expression<'_>, identifiers: &mut Vec<CompactString>) {
+use super::super::IdentifierRef;
+
+pub(super) fn walk_expr(expr: &Expression<'_>, identifiers: &mut Vec<IdentifierRef>) {
     match expr {
         Expression::Identifier(id) => {
-            identifiers.push(CompactString::new(id.name.as_str()));
+            identifiers.push(IdentifierRef::new(id.name.as_str(), id.span.start));
         }
         Expression::StaticMemberExpression(member) => {
             walk_expr(&member.object, identifiers);
@@ -29,7 +30,8 @@ pub(super) fn walk_expr(expr: &Expression<'_>, identifiers: &mut Vec<CompactStri
                         }
                         if p.shorthand {
                             if let PropertyKey::StaticIdentifier(id) = &p.key {
-                                identifiers.push(CompactString::new(id.name.as_str()));
+                                identifiers
+                                    .push(IdentifierRef::new(id.name.as_str(), id.span.start));
                             }
                         } else {
                             walk_expr(&p.value, identifiers);
@@ -74,7 +76,7 @@ pub(super) fn walk_expr(expr: &Expression<'_>, identifiers: &mut Vec<CompactStri
         }
         Expression::UpdateExpression(update) => match &update.argument {
             oxc_ast::ast::SimpleAssignmentTarget::AssignmentTargetIdentifier(id) => {
-                identifiers.push(CompactString::new(id.name.as_str()));
+                identifiers.push(IdentifierRef::new(id.name.as_str(), id.span.start));
             }
             oxc_ast::ast::SimpleAssignmentTarget::StaticMemberExpression(member) => {
                 walk_expr(&member.object, identifiers);
@@ -117,7 +119,7 @@ pub(super) fn walk_expr(expr: &Expression<'_>, identifiers: &mut Vec<CompactStri
                 let mut body_idents = Vec::new();
                 walk_expr(&expr_stmt.expression, &mut body_idents);
                 for ident in body_idents {
-                    if !param_names.contains(&ident.as_str()) {
+                    if !param_names.contains(&ident.name.as_str()) {
                         identifiers.push(ident);
                     }
                 }

--- a/crates/vize_croquis/src/drawer/helpers/identifiers/tests.rs
+++ b/crates/vize_croquis/src/drawer/helpers/identifiers/tests.rs
@@ -1,4 +1,4 @@
-use super::extract_identifiers_oxc;
+use super::{IdentifierRef, extract_identifier_refs_oxc, extract_identifiers_oxc};
 use vize_carton::CompactString;
 
 #[test]
@@ -52,4 +52,39 @@ fn test_extract_identifiers_ignores_regex_literals() {
 
     let ids = to_strings(extract_identifiers_oxc("count / divisor"));
     assert_eq!(ids, vec!["count", "divisor"]);
+}
+
+#[test]
+fn test_extract_identifier_refs_preserve_root_offsets() {
+    fn to_pairs(ids: Vec<IdentifierRef>) -> Vec<(CompactString, u32)> {
+        ids.into_iter()
+            .map(|identifier| (identifier.name, identifier.offset))
+            .collect()
+    }
+
+    let ids = to_pairs(extract_identifier_refs_oxc("user.name + name"));
+    assert_eq!(ids, vec![("user".into(), 0), ("name".into(), 12)]);
+
+    let ids = to_pairs(extract_identifier_refs_oxc("{ active: isActive }"));
+    assert_eq!(ids, vec![("isActive".into(), 10)]);
+
+    let division = "count / divisor";
+    let ids = to_pairs(extract_identifier_refs_oxc(division));
+    assert_eq!(
+        ids,
+        vec![
+            ("count".into(), division.find("count").unwrap() as u32),
+            ("divisor".into(), division.find("divisor").unwrap() as u32),
+        ]
+    );
+
+    let with_comment = "/** hidden */ disabled";
+    let ids = to_pairs(extract_identifier_refs_oxc(with_comment));
+    assert_eq!(
+        ids,
+        vec![(
+            "disabled".into(),
+            with_comment.find("disabled").unwrap() as u32
+        )]
+    );
 }

--- a/crates/vize_croquis/src/drawer/template/ids.rs
+++ b/crates/vize_croquis/src/drawer/template/ids.rs
@@ -10,7 +10,7 @@ use vize_carton::{CompactString, profile};
 use vize_relief::ast::{ElementNode, ExpressionNode, PropNode};
 
 use super::super::Drawer;
-use super::super::helpers::{extract_identifiers_oxc, is_keyword};
+use super::super::helpers::{extract_identifier_refs_oxc, is_keyword};
 
 /// Attributes that take ID references (not the ID itself).
 const ID_REFERENCE_ATTRIBUTES: &[&str] = &[
@@ -167,7 +167,7 @@ impl Drawer {
         if !self.ident_cache.contains_key(content) {
             let computed = profile!(
                 "croquis.template.expression.extract_identifiers",
-                extract_identifiers_oxc(content)
+                extract_identifier_refs_oxc(content)
             );
             self.ident_cache
                 .insert(CompactString::new(content), computed);
@@ -175,7 +175,7 @@ impl Drawer {
         let idents = &self.ident_cache[content];
 
         for ident in idents {
-            let ident_str = ident.as_str();
+            let ident_str = ident.name.as_str();
 
             let in_scope_vars = scope_vars.iter().any(|v| v.as_str() == ident_str);
             let in_bindings = self.croquis.bindings.contains(ident_str);
@@ -191,10 +191,9 @@ impl Drawer {
             if is_defined && !is_builtin {
                 self.croquis.scopes.mark_used(ident_str);
             } else if !is_defined {
-                let ident_offset_in_content = content.find(ident_str).unwrap_or(0) as u32;
                 self.croquis.undefined_refs.push(UndefinedRef {
-                    name: ident.clone(),
-                    offset: base_offset + ident_offset_in_content,
+                    name: ident.name.clone(),
+                    offset: base_offset + ident.offset,
                     context: CompactString::new("template expression"),
                 });
             }


### PR DESCRIPTION
Closes #1191.

## Summary
- add span-aware template identifier extraction while keeping the existing name-only API
- use identifier spans for undefined template references instead of `content.find()`
- align instance-global virtual TS mappings with the same span-aware extractor

## Validation
- cargo fmt --check
- git diff --check HEAD~1..HEAD
- CARGO_TARGET_DIR=/tmp/vize-1191-target cargo test -p vize_croquis test_extract_identifier_refs_preserve_root_offsets -- --nocapture
- CARGO_TARGET_DIR=/tmp/vize-1191-target cargo test -p vize_croquis test_extract_identifiers_oxc -- --nocapture
- CARGO_TARGET_DIR=/tmp/vize-1191-target cargo test -p vize_canon test_type_check_template_undefined_binding_uses_expression_offset -- --nocapture
- CARGO_TARGET_DIR=/tmp/vize-1191-target cargo test -p vize_canon test_type_check_template_undefined_binding_skips_member_property_offsets -- --nocapture
- CARGO_TARGET_DIR=/tmp/vize-1191-target cargo clippy -p vize_croquis -p vize_canon --lib -- -D warnings

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1283"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783597837&installation_id=136613492&pr_number=1283&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1283&signature=d3f0963b373a767fa11831645f9e80c24c0a338efbbaa5a34a4bb21e8e889274"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->