### PR TITLE
fix(croquis): reduce undefined ref offset overhead

### DIFF
--- a/crates/vize_canon/src/virtual_ts/scope.rs
+++ b/crates/vize_canon/src/virtual_ts/scope.rs
@@ -11,7 +11,7 @@ use vize_carton::profile;
 
 use vize_croquis::{
     BindingMetadata, Croquis, EventHandlerScopeData, Scope, ScopeData, ScopeId, ScopeKind,
-    analysis::ComponentUsage, analyzer::extract_identifier_refs_oxc, naming::to_pascal_case,
+    analysis::ComponentUsage, analyzer::extract_identifiers_oxc, naming::to_pascal_case,
 };
 
 use super::{
@@ -299,9 +299,12 @@ fn generate_instance_global_refs(
     }
 
     for expr in &summary.template_expressions {
-        for ident in extract_identifier_refs_oxc(expr.content.as_str()) {
-            let name = ident.name.as_str();
-            let src_start = (template_offset + expr.start + ident.offset) as usize;
+        for ident in extract_identifiers_oxc(expr.content.as_str()) {
+            let name = ident.as_str();
+            let Some(relative_offset) = expr.content.find(name) else {
+                continue;
+            };
+            let src_start = (template_offset + expr.start) as usize + relative_offset;
             let src_end = src_start + name.len();
             emitter.emit(name, src_start, src_end);
         }

--- a/crates/vize_croquis/src/drawer/core.rs
+++ b/crates/vize_croquis/src/drawer/core.rs
@@ -1,7 +1,7 @@
 use crate::croquis::Croquis;
 use vize_carton::{CompactString, FxHashMap, profile};
 
-use super::{DrawerOptions, helpers::IdentifierRef};
+use super::DrawerOptions;
 
 /// High-performance Vue SFC drawer.
 ///
@@ -34,12 +34,12 @@ pub struct Drawer {
     pub(crate) vfor_depth: u32,
     /// Memoized identifier extraction keyed by expression text. Template
     /// expressions repeat heavily (e.g. the same `:to`/`@click`/`{{ }}` across
-    /// every `v-for` iteration's rendered element), and identifier extraction
+    /// every `v-for` iteration's rendered element), and `extract_identifiers_oxc`
     /// is a pure function of the expression string, so the parse+walk is done
     /// once per distinct expression instead of once per occurrence. The cached
     /// `Vec` is read by reference (disjoint field borrow), so cache hits avoid
     /// both the parse and any clone.
-    pub(crate) ident_cache: FxHashMap<CompactString, Vec<IdentifierRef>>,
+    pub(crate) ident_cache: FxHashMap<CompactString, Vec<CompactString>>,
 }
 
 impl Drawer {

--- a/crates/vize_croquis/src/drawer/template/ids.rs
+++ b/crates/vize_croquis/src/drawer/template/ids.rs
@@ -10,7 +10,7 @@ use vize_carton::{CompactString, profile};
 use vize_relief::ast::{ElementNode, ExpressionNode, PropNode};
 
 use super::super::Drawer;
-use super::super::helpers::{extract_identifier_refs_oxc, is_keyword};
+use super::super::helpers::{extract_identifiers_oxc, is_keyword};
 
 /// Attributes that take ID references (not the ID itself).
 const ID_REFERENCE_ATTRIBUTES: &[&str] = &[
@@ -167,7 +167,7 @@ impl Drawer {
         if !self.ident_cache.contains_key(content) {
             let computed = profile!(
                 "croquis.template.expression.extract_identifiers",
-                extract_identifier_refs_oxc(content)
+                extract_identifiers_oxc(content)
             );
             self.ident_cache
                 .insert(CompactString::new(content), computed);
@@ -175,7 +175,7 @@ impl Drawer {
         let idents = &self.ident_cache[content];
 
         for ident in idents {
-            let ident_str = ident.name.as_str();
+            let ident_str = ident.as_str();
 
             let in_scope_vars = scope_vars.iter().any(|v| v.as_str() == ident_str);
             let in_bindings = self.croquis.bindings.contains(ident_str);
@@ -191,12 +191,57 @@ impl Drawer {
             if is_defined && !is_builtin {
                 self.croquis.scopes.mark_used(ident_str);
             } else if !is_defined {
+                let ident_offset_in_content = find_identifier_offset(content, ident_str, 0)
+                    .or_else(|| content.find(ident_str))
+                    .unwrap_or(0);
                 self.croquis.undefined_refs.push(UndefinedRef {
-                    name: ident.name.clone(),
-                    offset: base_offset + ident.offset,
+                    name: ident.clone(),
+                    offset: base_offset + ident_offset_in_content as u32,
                     context: CompactString::new("template expression"),
                 });
             }
         }
     }
+}
+
+fn find_identifier_offset(content: &str, ident: &str, start: usize) -> Option<usize> {
+    let bytes = content.as_bytes();
+    let ident_bytes = ident.as_bytes();
+    let mut search_start = start.min(content.len());
+
+    while search_start <= content.len() {
+        let found = content[search_start..].find(ident)?;
+        let offset = search_start + found;
+        if is_identifier_match(bytes, offset, ident_bytes.len()) {
+            return Some(offset);
+        }
+        search_start = offset + ident.len();
+    }
+
+    None
+}
+
+fn is_identifier_match(bytes: &[u8], offset: usize, len: usize) -> bool {
+    let before_is_ident = offset > 0 && is_ident_byte(bytes[offset - 1]);
+    let after = offset + len;
+    let after_is_ident = after < bytes.len() && is_ident_byte(bytes[after]);
+    if before_is_ident || after_is_ident {
+        return false;
+    }
+
+    let mut idx = offset;
+    while idx > 0 {
+        idx -= 1;
+        match bytes[idx] {
+            b' ' | b'\t' | b'\n' | b'\r' => continue,
+            b'.' => return false,
+            _ => break,
+        }
+    }
+
+    true
+}
+
+fn is_ident_byte(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || byte == b'_' || byte == b'$'
 }


### PR DESCRIPTION
Follow-up to #1283.

## Summary
- keep the public span-aware identifier API added in #1283 for semver compatibility
- switch template undefined-ref checking back to the cached name-only extractor
- compute undefined-binding offsets only when emitting an undefined ref, skipping member properties and partial identifier matches
- restore instance-global virtual TS mapping to the existing name-only extractor path

## Validation
- cargo fmt --check
- git diff --check
- git diff --check HEAD~1..HEAD
- cargo semver-checks check-release -p vize_croquis
- CARGO_TARGET_DIR=/tmp/vize-1191-target cargo test -p vize_croquis test_extract_identifier_refs_preserve_root_offsets -- --nocapture
- CARGO_TARGET_DIR=/tmp/vize-1191-target cargo test -p vize_croquis test_extract_identifiers_oxc -- --nocapture
- CARGO_TARGET_DIR=/tmp/vize-1191-target cargo test -p vize_canon test_type_check_template_undefined_binding_skips_member_property_offsets -- --nocapture
- CARGO_TARGET_DIR=/tmp/vize-1191-target cargo test -p vize_canon test_type_check_template_undefined_binding_uses_expression_offset -- --nocapture
- CARGO_TARGET_DIR=/tmp/vize-1191-target cargo clippy -p vize_croquis -p vize_canon --lib -- -D warnings