### PR TITLE
fix(atelier_sfc): resolve named defineEmits types

### DIFF
--- a/crates/vize_atelier_sfc/src/compile_script/function_mode/compiler.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/function_mode/compiler.rs
@@ -9,7 +9,7 @@ use vize_croquis::macros::runtime_erased_macro_names;
 
 use crate::script::{
     PropsDestructuredBindings, ScriptCompileContext, TemplateUsedIdentifiers,
-    resolve_template_used_identifiers, transform_destructured_props,
+    resolve_template_used_identifiers, resolve_type_args, transform_destructured_props,
 };
 use crate::types::{BindingType, SfcError};
 
@@ -504,7 +504,9 @@ fn emit_emits_definition(
     // Add emits from defineEmits
     if let Some(ref emits_macro) = ctx.macros.define_emits {
         if let Some(ref type_args) = emits_macro.type_args {
-            let emit_names = extract_emit_names_from_type(type_args);
+            let resolved_type_args =
+                resolve_type_args(type_args, &ctx.interfaces, &ctx.type_aliases);
+            let emit_names = extract_emit_names_from_type(&resolved_type_args);
             all_emits.extend(emit_names);
         } else if !emits_macro.args.is_empty() {
             // Runtime args - we'll output separately

--- a/crates/vize_atelier_sfc/src/compile_script/inline/compiler/model.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/inline/compiler/model.rs
@@ -5,6 +5,7 @@ use crate::script::ScriptCompileContext;
 use super::super::super::props::{
     extract_emit_names_from_type, resolve_prop_js_type, ts_type_to_js_type,
 };
+use super::super::type_handling::resolve_type_args;
 use super::props::build_user_props_decl;
 
 /// Resolve a defineModel `<T>` type argument to its runtime constructor,
@@ -252,7 +253,9 @@ pub(super) fn build_model_props_emits(
         if !m.args.is_empty() {
             Some(m.args.trim().as_bytes().to_vec())
         } else if let Some(ref type_args) = m.type_args {
-            let names = extract_emit_names_from_type(type_args);
+            let resolved_type_args =
+                resolve_type_args(type_args, &ctx.interfaces, &ctx.type_aliases);
+            let names = extract_emit_names_from_type(&resolved_type_args);
             if names.is_empty() {
                 None
             } else {

--- a/crates/vize_atelier_sfc/src/compile_script/inline/tests.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/inline/tests.rs
@@ -313,6 +313,27 @@ const doubled = computed(() => count.value * 2)
     }
 
     #[test]
+    fn test_define_emits_named_type_merges_with_define_model() {
+        let content = r#"
+type Emits = {
+  (e: 'change', id: number): void
+  (e: 'submit'): void
+}
+const emit = defineEmits<Emits>()
+const model = defineModel<string>()
+"#;
+
+        let output = compile_setup(content);
+
+        assert!(
+            output.contains(
+                r#"emits: /* @__PURE__ */ _mergeModels(["change", "submit"], ["update:modelValue"])"#
+            ),
+            "named defineEmits type should merge with model emits:\n{output}"
+        );
+    }
+
+    #[test]
     fn test_no_template_returns_imported_bindings() {
         // Imported bindings should also be returned for runtime template compilation
         let content = r#"

--- a/crates/vize_atelier_sfc/src/compile_script/tests.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/tests.rs
@@ -520,6 +520,34 @@ const emit = defineEmits<(e: 'click') => void>()
     }
 
     #[test]
+    fn test_compile_script_setup_with_define_emits_named_type() {
+        for content in [
+            r#"
+type Emits = {
+  (e: 'change', id: number): void
+  (e: 'submit'): void
+}
+const emit = defineEmits<Emits>()
+"#,
+            r#"
+interface Emits {
+  (e: 'change', id: number): void
+  (e: 'submit'): void
+}
+const emit = defineEmits<Emits>()
+"#,
+        ] {
+            let result = compile_script_setup(content, "Test", false, false, None).unwrap();
+
+            assert!(
+                result.code.contains(r#"emits: ["change", "submit"]"#),
+                "named defineEmits type should emit runtime declaration:\n{}",
+                result.code
+            );
+        }
+    }
+
+    #[test]
     fn test_compile_script_setup_with_next_line_define_props_assignment() {
         let content = r#"
 import { computed } from 'vue'


### PR DESCRIPTION
Closes #1175.

## Summary
- resolve defineEmits type arguments through local type aliases/interfaces before extracting runtime emit names
- apply the same resolution in function mode and inline defineModel emit merging
- add regression coverage for type aliases and interfaces

## Validation
- cargo fmt --check
- git diff --check
- git diff --check HEAD~1..HEAD
- CARGO_TARGET_DIR=/tmp/vize-1175-target cargo test -p vize_atelier_sfc test_compile_script_setup_with_define_emits_named_type -- --nocapture
- CARGO_TARGET_DIR=/tmp/vize-1175-target cargo test -p vize_atelier_sfc test_define_emits_named_type_merges_with_define_model -- --nocapture
- CARGO_TARGET_DIR=/tmp/vize-1175-target cargo clippy -p vize_atelier_sfc --lib -- -D warnings