### PR TITLE
fix(atelier_ssr): render v-for slot fallback vnodes

### DIFF
--- a/crates/vize_atelier_ssr/src/codegen/element/vnode.rs
+++ b/crates/vize_atelier_ssr/src/codegen/element/vnode.rs
@@ -1,11 +1,17 @@
 //! VNode fallback expression generation used by slot fallback paths.
 
+use super::super::helpers::collect_for_scoped_params;
 use super::props::*;
 use super::*;
+use vize_atelier_core::ast::ForNode;
 
 impl<'a> SsrCodegenContext<'a> {
     fn vnode_children_expression(&mut self, children: &[TemplateChildNode]) -> String {
         let expressions = self.vnode_child_expressions(children);
+        let has_array_child = has_vnode_array_child(children);
+        if has_array_child && expressions.len() == 1 {
+            return expressions.into_iter().next().unwrap_or_default();
+        }
 
         let mut out = String::from("[");
         for (index, expr) in expressions.iter().enumerate() {
@@ -15,6 +21,9 @@ impl<'a> SsrCodegenContext<'a> {
             out.push_str(expr);
         }
         out.push(']');
+        if has_array_child {
+            out.push_str(".flat()");
+        }
         out
     }
 
@@ -32,6 +41,10 @@ impl<'a> SsrCodegenContext<'a> {
 
     fn vnode_children_expression_from_refs(&mut self, children: &[&TemplateChildNode]) -> String {
         let expressions = self.vnode_child_expressions_from_refs(children);
+        let has_array_child = has_vnode_array_child_ref(children);
+        if has_array_child && expressions.len() == 1 {
+            return expressions.into_iter().next().unwrap_or_default();
+        }
 
         let mut out = String::from("[");
         for (index, expr) in expressions.iter().enumerate() {
@@ -41,6 +54,9 @@ impl<'a> SsrCodegenContext<'a> {
             out.push_str(expr);
         }
         out.push(']');
+        if has_array_child {
+            out.push_str(".flat()");
+        }
         out
     }
 
@@ -97,7 +113,7 @@ impl<'a> SsrCodegenContext<'a> {
                 Some(out)
             }
             TemplateChildNode::If(if_node) => Some(self.vnode_if_expression(if_node)),
-            TemplateChildNode::For(_) => None,
+            TemplateChildNode::For(for_node) => Some(self.vnode_for_expression(for_node)),
             TemplateChildNode::IfBranch(_)
             | TemplateChildNode::TextCall(_)
             | TemplateChildNode::CompoundExpression(_)
@@ -255,8 +271,27 @@ impl<'a> SsrCodegenContext<'a> {
         out
     }
 
+    fn vnode_for_expression(&mut self, for_node: &ForNode) -> String {
+        self.use_core_helper(RuntimeHelper::RenderList);
+
+        let mut out = String::from("_renderList(");
+        out.push_str(&self.expression_to_string(&for_node.source));
+        out.push_str(", (");
+        append_for_aliases(self, &mut out, for_node);
+        out.push_str(") => ");
+
+        self.push_scoped_params(collect_for_scoped_params(for_node));
+        let body = self.vnode_branch_expression(&for_node.children);
+        self.pop_scoped_params();
+
+        out.push_str(&body);
+        out.push_str(").flat()");
+        out
+    }
+
     fn vnode_branch_expression(&mut self, children: &[TemplateChildNode]) -> String {
         let expressions = self.vnode_child_expressions(children);
+        let has_array_child = has_vnode_array_child(children);
         if expressions.is_empty() {
             return "_createCommentVNode(\"\")".to_compact_string();
         }
@@ -272,6 +307,9 @@ impl<'a> SsrCodegenContext<'a> {
             out.push_str(expr);
         }
         out.push(']');
+        if has_array_child {
+            out.push_str(".flat()");
+        }
         out
     }
 
@@ -360,4 +398,34 @@ impl<'a> SsrCodegenContext<'a> {
         out.push(')');
         out
     }
+}
+
+fn append_for_aliases(ctx: &mut SsrCodegenContext<'_>, out: &mut String, for_node: &ForNode) {
+    let mut has_alias = false;
+    for alias in [
+        for_node.value_alias.as_ref(),
+        for_node.key_alias.as_ref(),
+        for_node.object_index_alias.as_ref(),
+    ]
+    .into_iter()
+    .flatten()
+    {
+        if has_alias {
+            out.push_str(", ");
+        }
+        out.push_str(&ctx.expression_to_string(alias));
+        has_alias = true;
+    }
+}
+
+fn has_vnode_array_child(children: &[TemplateChildNode]) -> bool {
+    children
+        .iter()
+        .any(|child| matches!(child, TemplateChildNode::For(_)))
+}
+
+fn has_vnode_array_child_ref(children: &[&TemplateChildNode]) -> bool {
+    children
+        .iter()
+        .any(|child| matches!(**child, TemplateChildNode::For(_)))
 }

--- a/crates/vize_atelier_ssr/src/codegen/helpers.rs
+++ b/crates/vize_atelier_ssr/src/codegen/helpers.rs
@@ -305,7 +305,7 @@ impl<'a> SsrCodegenContext<'a> {
     }
 }
 
-fn collect_for_scoped_params(for_node: &ForNode) -> FxHashSet<String> {
+pub(crate) fn collect_for_scoped_params(for_node: &ForNode) -> FxHashSet<String> {
     let mut params = FxHashSet::default();
 
     if let Some(value) = &for_node.value_alias {

--- a/crates/vize_atelier_ssr/tests/snapshots/ssr_snapshot__component__component_slot_v_for_aliases_stay_local.snap
+++ b/crates/vize_atelier_ssr/tests/snapshots/ssr_snapshot__component__component_slot_v_for_aliases_stay_local.snap
@@ -12,7 +12,7 @@ function ssrRender(_ctx, _push, _parent, _attrs) {
         })
         _push(`<!--]-->`)
       } else {
-        return []
+        return _renderList(_ctx.deps, ([dep, version]) => _createElementVNode("div", { key: dep }, [_createTextVNode(_toDisplayString(dep)), _createTextVNode(" "), _createTextVNode(_toDisplayString(version))])).flat()
       }
     }),
     _: 1

--- a/crates/vize_atelier_ssr/tests/snapshots/ssr_snapshot__component__dynamic_component_slot_v_for_returns_vnodes.snap
+++ b/crates/vize_atelier_ssr/tests/snapshots/ssr_snapshot__component__dynamic_component_slot_v_for_returns_vnodes.snap
@@ -1,0 +1,7 @@
+---
+source: crates/vize_atelier_ssr/tests/ssr_snapshot.rs
+expression: "compile_full(r#\"<component :is=\"tag\"><li v-for=\"item in items\">{{ item }}</li></component>\"#)"
+---
+function ssrRender(_ctx, _push, _parent, _attrs) {
+  _ssrRenderVNode(_push, _createVNode(_resolveDynamicComponent(_ctx.tag), _attrs, { default: _withCtx(() => _renderList(_ctx.items, (item) => _createElementVNode("li", null, [_createTextVNode(_toDisplayString(item))])).flat()), _: 1 }), _parent)
+}

--- a/crates/vize_atelier_ssr/tests/ssr_snapshot.rs
+++ b/crates/vize_atelier_ssr/tests/ssr_snapshot.rs
@@ -374,6 +374,13 @@ mod component {
     }
 
     #[test]
+    fn dynamic_component_slot_v_for_returns_vnodes() {
+        insta::assert_snapshot!(compile_full(
+            r#"<component :is="tag"><li v-for="item in items">{{ item }}</li></component>"#
+        ));
+    }
+
+    #[test]
     fn component_scoped_slot_props_are_local() {
         insta::assert_snapshot!(compile_full(
             r#"<Carousel><template #item="{ data: speaker }"><div :style="{ backgroundImage: `url(${speaker.avatarUrl})` }">{{ speaker.name }}</div></template></Carousel>"#


### PR DESCRIPTION
Closes #1187

## Summary
- Render SSR slot fallback v-for children as vnode arrays instead of dropping them
- Preserve v-for aliases as local scoped params while building fallback vnode expressions
- Flatten mixed vnode children when v-for contributes arrays

## Validation
- CARGO_TARGET_DIR=/tmp/vize-1187-target cargo test -p vize_atelier_ssr slot_v_for -- --nocapture
- cargo fmt --check
- git diff --check HEAD~1..HEAD
- CARGO_TARGET_DIR=/tmp/vize-1187-target cargo clippy -p vize_atelier_ssr --lib -- -D warnings

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1287"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783599803&installation_id=136613492&pr_number=1287&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1287&signature=39dd05bd30c81c9c343bcbadf8cf73127c82475f66b17072d20c6a556c53a177"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->