### PR TITLE
fix(croquis_cf): report props validation locations

### DIFF
--- a/crates/vize_croquis_cf/src/analyzer/tests_basic.rs
+++ b/crates/vize_croquis_cf/src/analyzer/tests_basic.rs
@@ -1,5 +1,5 @@
 use super::{CrossFileAnalyzer, CrossFileOptions, CrossFileResult};
-use crate::CrossFileDiagnosticKind;
+use crate::{CrossFileDiagnosticKind, PropsValidationIssueKind};
 use std::path::Path;
 use vize_carton::{CompactString, smallvec};
 use vize_croquis::analysis::{ComponentUsage, EventListener, PassedProp};
@@ -150,6 +150,114 @@ const formData = { id: 1 }"#,
     assert_eq!(undeclared_props, vec!["extra"]);
 }
 
+#[test]
+fn test_props_validation_uses_component_and_prop_offsets() {
+    let mut analyzer =
+        CrossFileAnalyzer::new(CrossFileOptions::default().with_props_validation(true));
+
+    let child_analysis = script_analysis("const props = defineProps<{ id: number }>()");
+    let parent_analysis = script_analysis_with_component_usage(
+        r#"import Child from './Child.vue'"#,
+        component_usage_with_extra_prop_at("Child", 80, 89, 96),
+    );
+
+    analyzer.add_file_with_analysis(Path::new("Child.vue"), "", child_analysis);
+    analyzer.add_file_with_analysis(Path::new("Parent.vue"), "", parent_analysis);
+    analyzer.rebuild_component_edges();
+
+    let result = analyzer.analyze();
+
+    let missing_required = result
+        .diagnostics
+        .iter()
+        .find(|diagnostic| {
+            matches!(
+                diagnostic.kind,
+                CrossFileDiagnosticKind::MissingRequiredProp { .. }
+            )
+        })
+        .expect("missing required prop diagnostic");
+    assert_eq!(missing_required.primary_offset, 80);
+    assert_eq!(missing_required.primary_end_offset, 96);
+    assert_eq!(missing_required.related_files.len(), 1);
+    assert!(
+        missing_required.related_files[0].1 > 0,
+        "related defineProps offset should not be hardcoded to zero"
+    );
+
+    let undeclared = result
+        .diagnostics
+        .iter()
+        .find(|diagnostic| {
+            matches!(
+                diagnostic.kind,
+                CrossFileDiagnosticKind::UndeclaredProp { .. }
+            )
+        })
+        .expect("undeclared prop diagnostic");
+    assert_eq!(undeclared.primary_offset, 89);
+    assert_eq!(undeclared.primary_end_offset, 96);
+}
+
+#[test]
+fn test_props_validation_emits_type_mismatch_for_static_literal() {
+    let mut analyzer =
+        CrossFileAnalyzer::new(CrossFileOptions::default().with_props_validation(true));
+
+    let child_analysis =
+        script_analysis("const props = defineProps({ count: { type: Number, required: true } })");
+    let parent_analysis = script_analysis_with_component_usage(
+        r#"import Child from './Child.vue'"#,
+        component_usage_with_count_string_at("Child", 20, 27, 42),
+    );
+
+    analyzer.add_file_with_analysis(Path::new("Child.vue"), "", child_analysis);
+    analyzer.add_file_with_analysis(Path::new("Parent.vue"), "", parent_analysis);
+    analyzer.rebuild_component_edges();
+
+    let result = analyzer.analyze();
+
+    let issue = result
+        .props_validation_issues
+        .iter()
+        .find_map(|issue| match &issue.kind {
+            PropsValidationIssueKind::TypeMismatch {
+                prop_name,
+                expected,
+                actual,
+            } => Some((
+                prop_name.as_str(),
+                expected.as_str(),
+                actual.as_str(),
+                issue.offset,
+            )),
+            _ => None,
+        })
+        .expect("type mismatch issue");
+    assert_eq!(issue, ("count", "number", "string", 27));
+
+    let diagnostic = result
+        .diagnostics
+        .iter()
+        .find_map(|diagnostic| match &diagnostic.kind {
+            CrossFileDiagnosticKind::PropTypeMismatch {
+                prop_name,
+                expected_type,
+                actual_type,
+            } => Some((
+                prop_name.as_str(),
+                expected_type.as_str(),
+                actual_type.as_str(),
+                diagnostic.primary_offset,
+                diagnostic.primary_end_offset,
+            )),
+            _ => None,
+        })
+        .expect("type mismatch diagnostic");
+
+    assert_eq!(diagnostic, ("count", "number", "string", 27, 42));
+}
+
 fn script_analysis(script: &str) -> vize_croquis::Croquis {
     let mut analyzer = vize_croquis::Analyzer::with_options(AnalyzerOptions::full());
     analyzer.analyze_script_setup(script);
@@ -218,12 +326,72 @@ fn component_usage_with_spread_and_extra_prop(component: &str) -> ComponentUsage
     }
 }
 
+fn component_usage_with_extra_prop_at(
+    component: &str,
+    usage_start: u32,
+    prop_start: u32,
+    prop_end: u32,
+) -> ComponentUsage {
+    ComponentUsage {
+        name: CompactString::new(component),
+        start: usage_start,
+        end: prop_end,
+        props: smallvec![passed_prop_at(
+            "extra",
+            Some("true"),
+            false,
+            prop_start,
+            prop_end
+        )],
+        events: smallvec![],
+        slots: smallvec![],
+        has_spread_attrs: false,
+        scope_id: ScopeId::ROOT,
+        vif_guard: None,
+    }
+}
+
+fn component_usage_with_count_string_at(
+    component: &str,
+    usage_start: u32,
+    prop_start: u32,
+    prop_end: u32,
+) -> ComponentUsage {
+    ComponentUsage {
+        name: CompactString::new(component),
+        start: usage_start,
+        end: prop_end,
+        props: smallvec![passed_prop_at(
+            "count",
+            Some("'not a number'"),
+            true,
+            prop_start,
+            prop_end,
+        )],
+        events: smallvec![],
+        slots: smallvec![],
+        has_spread_attrs: false,
+        scope_id: ScopeId::ROOT,
+        vif_guard: None,
+    }
+}
+
 fn passed_prop(name: &str, value: Option<&str>, is_dynamic: bool) -> PassedProp {
+    passed_prop_at(name, value, is_dynamic, 0, 0)
+}
+
+fn passed_prop_at(
+    name: &str,
+    value: Option<&str>,
+    is_dynamic: bool,
+    start: u32,
+    end: u32,
+) -> PassedProp {
     PassedProp {
         name: CompactString::new(name),
         value: value.map(CompactString::new),
-        start: 0,
-        end: 0,
+        start,
+        end,
         is_dynamic,
     }
 }

--- a/crates/vize_croquis_cf/src/analyzers.rs
+++ b/crates/vize_croquis_cf/src/analyzers.rs
@@ -30,7 +30,9 @@ pub use element_id::{UniqueIdIssue, analyze_element_ids};
 pub use emit::{EmitFlow, analyze_emits};
 pub use event_bubbling::{EventBubble, analyze_event_bubbling};
 pub use fallthrough::{FallthroughInfo, analyze_fallthrough};
-pub use props_validation::{PropsValidationIssue, analyze_props_validation};
+pub use props_validation::{
+    PropsValidationIssue, PropsValidationIssueKind, analyze_props_validation,
+};
 pub(crate) use provide_inject::{
     ProvideInjectIndex, analyze_provide_inject_with_index, build_provide_inject_tree_with_index,
 };

--- a/crates/vize_croquis_cf/src/analyzers/props_validation.rs
+++ b/crates/vize_croquis_cf/src/analyzers/props_validation.rs
@@ -6,7 +6,8 @@ use crate::diagnostics::{CrossFileDiagnostic, CrossFileDiagnosticKind, Diagnosti
 use crate::graph::DependencyGraph;
 use crate::registry::{FileId, ModuleEntry, ModuleRegistry};
 use std::path::{Component, Path, PathBuf};
-use vize_carton::{CompactString, FxHashMap, FxHashSet, String, cstr};
+use vize_carton::{CompactString, FxHashMap, String, cstr};
+use vize_croquis::macros::MacroKind;
 
 /// Information about a props validation issue.
 #[derive(Debug, Clone)]
@@ -48,7 +49,6 @@ struct ComponentPropsInfo {
 #[derive(Debug, Clone)]
 struct PropInfo {
     required: bool,
-    #[allow(dead_code)] // Will be used for type checking in future
     prop_type: Option<CompactString>,
 }
 
@@ -125,7 +125,7 @@ pub fn analyze_props_validation(
             // required prop, so only validate required props for non-spread usages.
             if !passed_usage.has_spread_attrs {
                 for (prop_name, prop_info) in &child_props_info.props {
-                    if prop_info.required && !passed_usage.props.contains(prop_name.as_str()) {
+                    if prop_info.required && !has_passed_prop(&passed_usage, prop_name.as_str()) {
                         let issue = PropsValidationIssue {
                             parent_file: parent_id,
                             child_file: child_id,
@@ -133,18 +133,19 @@ pub fn analyze_props_validation(
                             kind: PropsValidationIssueKind::MissingRequiredProp {
                                 prop_name: prop_name.clone(),
                             },
-                            offset: passed_usage.offset,
+                            offset: passed_usage.start,
                         };
                         issues.push(issue);
 
-                        let diagnostic = CrossFileDiagnostic::new(
+                        let diagnostic = CrossFileDiagnostic::with_span(
                             CrossFileDiagnosticKind::MissingRequiredProp {
                                 prop_name: prop_name.clone(),
                                 component_name: child_component_name.clone(),
                             },
                             DiagnosticSeverity::Error,
                             parent_id,
-                            passed_usage.offset,
+                            passed_usage.start,
+                            passed_usage.end,
                             cstr!(
                                 "**Missing Required Prop**: `{}` must be passed to `<{}>`\n\n\
                                 This prop is declared as required in the component's `defineProps`.",
@@ -154,7 +155,7 @@ pub fn analyze_props_validation(
                         )
                         .with_related(
                             child_id,
-                            0,
+                            define_props_offset(child_entry),
                             cstr!("Prop `{prop_name}` is declared as required here"),
                         );
 
@@ -166,45 +167,88 @@ pub fn analyze_props_validation(
             // Check for undeclared props (explicit props passed but not in defineProps)
             for passed_prop in &passed_usage.props {
                 // Skip built-in attributes
-                if is_builtin_attr(passed_prop) {
+                if is_builtin_attr(passed_prop.name) {
                     continue;
                 }
 
                 // Check if this prop is declared
-                let is_declared = child_props_info.props.contains_key(*passed_prop);
-
-                if !is_declared {
+                let Some(prop_info) = child_props_info.props.get(passed_prop.name) else {
                     let issue = PropsValidationIssue {
                         parent_file: parent_id,
                         child_file: child_id,
                         component_name: child_component_name.clone(),
                         kind: PropsValidationIssueKind::UndeclaredProp {
-                            prop_name: CompactString::new(*passed_prop),
+                            prop_name: CompactString::new(passed_prop.name),
                         },
-                        offset: passed_usage.offset,
+                        offset: passed_prop.start,
                     };
                     issues.push(issue);
 
-                    let diagnostic = CrossFileDiagnostic::new(
+                    let diagnostic = CrossFileDiagnostic::with_span(
                         CrossFileDiagnosticKind::UndeclaredProp {
-                            prop_name: CompactString::new(*passed_prop),
+                            prop_name: CompactString::new(passed_prop.name),
                             component_name: child_component_name.clone(),
                         },
                         DiagnosticSeverity::Warning, // Warning since it might be intentional $attrs
                         parent_id,
-                        passed_usage.offset,
+                        passed_prop.start,
+                        passed_prop.end,
                         cstr!(
                             "**Undeclared Prop**: `{}` is passed to `<{}>` but not declared\n\n\
                             The prop is not defined in the component's `defineProps`.\n\
                             If intentional, it will fall through to the root element via `$attrs`.",
-                            passed_prop, child_component_name
+                            passed_prop.name, child_component_name
                         ),
                     )
                     .with_suggestion(cstr!(
                         "Add to defineProps:\n```typescript\ndefineProps<{{\n  {}: unknown\n}}>()\n```\n\n\
                         Or use `v-bind=\"$attrs\"` in the child component for fallthrough.",
-                        passed_prop
+                        passed_prop.name
                     ));
+
+                    diagnostics.push(diagnostic);
+                    continue;
+                };
+
+                if let (Some(expected), Some(actual)) = (
+                    prop_info.prop_type.as_ref(),
+                    actual_literal_type(passed_prop),
+                ) && !prop_type_accepts_actual(expected.as_str(), actual.as_str())
+                {
+                    let issue = PropsValidationIssue {
+                        parent_file: parent_id,
+                        child_file: child_id,
+                        component_name: child_component_name.clone(),
+                        kind: PropsValidationIssueKind::TypeMismatch {
+                            prop_name: CompactString::new(passed_prop.name),
+                            expected: expected.clone(),
+                            actual: actual.clone(),
+                        },
+                        offset: passed_prop.start,
+                    };
+                    issues.push(issue);
+
+                    let diagnostic = CrossFileDiagnostic::with_span(
+                        CrossFileDiagnosticKind::PropTypeMismatch {
+                            prop_name: CompactString::new(passed_prop.name),
+                            expected_type: expected.clone(),
+                            actual_type: actual.clone(),
+                        },
+                        DiagnosticSeverity::Error,
+                        parent_id,
+                        passed_prop.start,
+                        passed_prop.end,
+                        cstr!(
+                            "**Prop Type Mismatch**: `{}` expects `{}` but received `{}`\n\n\
+                            The static prop value does not match the child component's declared runtime prop type.",
+                            passed_prop.name, expected, actual
+                        ),
+                    )
+                    .with_related(
+                        child_id,
+                        define_props_offset(child_entry),
+                        cstr!("Prop `{}` is declared with type `{}` here", passed_prop.name, expected),
+                    );
 
                     diagnostics.push(diagnostic);
                 }
@@ -216,9 +260,18 @@ pub fn analyze_props_validation(
 }
 
 struct PassedComponentUsage<'a> {
-    props: FxHashSet<&'a str>,
+    props: Vec<PassedPropInfo<'a>>,
     has_spread_attrs: bool,
-    offset: u32,
+    start: u32,
+    end: u32,
+}
+
+struct PassedPropInfo<'a> {
+    name: &'a str,
+    value: Option<&'a str>,
+    start: u32,
+    end: u32,
+    is_dynamic: bool,
 }
 
 /// Extract matched usages and explicit props passed to a specific component from the analysis.
@@ -238,28 +291,95 @@ fn extract_passed_props_for_component<'a>(
                 .iter()
                 .any(|alias| component_names_match(usage.name.as_str(), alias.as_str()))
         {
-            let mut props = FxHashSet::default();
-            for prop in &usage.props {
-                props.insert(prop.name.as_str());
-            }
+            let props = usage
+                .props
+                .iter()
+                .map(|prop| PassedPropInfo {
+                    name: prop.name.as_str(),
+                    value: prop.value.as_deref(),
+                    start: prop.start,
+                    end: prop.end,
+                    is_dynamic: prop.is_dynamic,
+                })
+                .collect();
 
             usages.push(PassedComponentUsage {
                 props,
                 has_spread_attrs: usage.has_spread_attrs,
-                offset: usage.start,
+                start: usage.start,
+                end: usage.end,
             });
         }
     }
 
     if usages.is_empty() {
         usages.push(PassedComponentUsage {
-            props: FxHashSet::default(),
+            props: Vec::new(),
             has_spread_attrs: false,
-            offset: 0,
+            start: 0,
+            end: 0,
         });
     }
 
     usages
+}
+
+fn define_props_offset(entry: &ModuleEntry) -> u32 {
+    entry
+        .analysis
+        .macros
+        .all_calls()
+        .iter()
+        .find(|call| call.kind == MacroKind::DefineProps)
+        .map_or(0, |call| call.start)
+}
+
+fn has_passed_prop(usage: &PassedComponentUsage<'_>, name: &str) -> bool {
+    usage.props.iter().any(|prop| prop.name == name)
+}
+
+fn actual_literal_type(prop: &PassedPropInfo<'_>) -> Option<CompactString> {
+    if !prop.is_dynamic {
+        return Some(if prop.value.is_some() {
+            CompactString::const_new("string")
+        } else {
+            CompactString::const_new("boolean")
+        });
+    }
+
+    let value = prop.value?.trim();
+    if is_string_literal(value) {
+        Some(CompactString::const_new("string"))
+    } else if is_boolean_literal(value) {
+        Some(CompactString::const_new("boolean"))
+    } else if is_numeric_literal(value) {
+        Some(CompactString::const_new("number"))
+    } else {
+        None
+    }
+}
+
+fn prop_type_accepts_actual(expected: &str, actual: &str) -> bool {
+    expected
+        .split('|')
+        .map(str::trim)
+        .any(|variant| variant == actual || variant == "unknown" || variant == "any")
+}
+
+fn is_string_literal(value: &str) -> bool {
+    let bytes = value.as_bytes();
+    matches!(
+        (bytes.first(), bytes.last()),
+        (Some(b'\''), Some(b'\'')) | (Some(b'"'), Some(b'"'))
+    )
+}
+
+fn is_boolean_literal(value: &str) -> bool {
+    matches!(value, "true" | "false")
+}
+
+fn is_numeric_literal(value: &str) -> bool {
+    value.parse::<f64>().is_ok()
 }
 
 fn imported_aliases_for_child(

--- a/crates/vize_croquis_cf/src/lib.rs
+++ b/crates/vize_croquis_cf/src/lib.rs
@@ -64,6 +64,7 @@ pub use suppression::{SuppressionDirective, SuppressionError, SuppressionMap};
 
 // Re-export analyzer types
 pub use analyzers::{
-    BoundaryInfo, BoundaryKind, EmitFlow, EventBubble, FallthroughInfo, ProvideInjectMatch,
-    ReactivityIssue, ReactivityIssueKind, UniqueIdIssue,
+    BoundaryInfo, BoundaryKind, EmitFlow, EventBubble, FallthroughInfo, PropsValidationIssue,
+    PropsValidationIssueKind, ProvideInjectMatch, ReactivityIssue, ReactivityIssueKind,
+    UniqueIdIssue,
 };


### PR DESCRIPTION
## Summary
- use component usage spans for missing required prop diagnostics
- use passed prop attribute spans for undeclared prop diagnostics
- emit `PropTypeMismatch` for statically detectable runtime prop type mismatches
- add focused regression tests for offsets and type mismatch emission

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p vize_croquis_cf props_validation -- --nocapture`
- `cargo test -p vize_croquis_cf`
- `cargo clippy -p vize_croquis_cf -- -D warnings`

Fixes #1195

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1288"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783599888&installation_id=136613492&pr_number=1288&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1288&signature=098e7cca1fa42e4d0e5779cba2ac6f9c3bb701dadc4ae95d36874af4e20393e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->