### PR TITLE
fix(atelier_sfc): avoid defineEmits payload literals in runtime emits

### DIFF
--- a/crates/vize_atelier_sfc/src/compile_script/props.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/props.rs
@@ -1322,29 +1322,184 @@ pub fn extract_emit_names_from_type(type_args: &str) -> Vec<String> {
         }
     }
 
-    // Fall back to call signature format:
-    //   (e: 'eventName'): void; (e: 'otherEvent', value: string): void
-    // Match quoted string literals in (e: 'name') patterns
-    let mut in_string = false;
-    let mut quote_char = ' ';
-    let mut current_string = String::default();
+    extract_call_signature_emit_names(type_args, &mut emits);
+    emits
+}
 
-    for c in type_args.chars() {
-        if !in_string && (c == '\'' || c == '"') {
-            in_string = true;
-            quote_char = c;
-            current_string.clear();
-        } else if in_string && c == quote_char {
-            in_string = false;
-            if !current_string.is_empty() {
-                emits.push(current_string.clone());
+fn extract_call_signature_emit_names(type_args: &str, emits: &mut Vec<String>) {
+    let bytes = type_args.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] != b'(' {
+            i += 1;
+            continue;
+        }
+
+        let Some(close) = find_matching_paren(type_args, i) else {
+            i += 1;
+            continue;
+        };
+
+        if is_emit_call_signature(type_args, i, close) {
+            let params = &type_args[i + 1..close];
+            if let Some(first_param) = first_parameter(params)
+                && let Some(type_annotation) = parameter_type_annotation(first_param)
+            {
+                extract_string_literals(type_annotation, emits);
             }
-        } else if in_string {
-            current_string.push(c);
+        }
+
+        i = close + 1;
+    }
+}
+
+fn find_matching_paren(input: &str, open: usize) -> Option<usize> {
+    let bytes = input.as_bytes();
+    let mut depth = 0;
+    let mut i = open;
+    let mut quote: Option<u8> = None;
+
+    while i < bytes.len() {
+        let byte = bytes[i];
+        if let Some(quote_byte) = quote {
+            if byte == b'\\' {
+                i += 2;
+                continue;
+            }
+            if byte == quote_byte {
+                quote = None;
+            }
+            i += 1;
+            continue;
+        }
+
+        match byte {
+            b'\'' | b'"' => quote = Some(byte),
+            b'(' => depth += 1,
+            b')' => {
+                depth -= 1;
+                if depth == 0 {
+                    return Some(i);
+                }
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+
+    None
+}
+
+fn is_emit_call_signature(input: &str, open: usize, close: usize) -> bool {
+    let after = input[close + 1..].trim_start();
+    if after.starts_with(':') {
+        return true;
+    }
+
+    // Direct function type form: defineEmits<(e: 'change') => void>().
+    after.starts_with("=>") && input[..open].trim().is_empty()
+}
+
+fn first_parameter(params: &str) -> Option<&str> {
+    let mut depth = 0;
+    let mut quote: Option<char> = None;
+    let mut prev_escape = false;
+
+    for (idx, ch) in params.char_indices() {
+        if let Some(quote_char) = quote {
+            if prev_escape {
+                prev_escape = false;
+                continue;
+            }
+            if ch == '\\' {
+                prev_escape = true;
+                continue;
+            }
+            if ch == quote_char {
+                quote = None;
+            }
+            continue;
+        }
+
+        match ch {
+            '\'' | '"' => quote = Some(ch),
+            '(' | '[' | '{' | '<' => depth += 1,
+            ')' | ']' | '}' | '>' if depth > 0 => depth -= 1,
+            ',' if depth == 0 => return Some(params[..idx].trim()),
+            _ => {}
         }
     }
 
-    emits
+    let first = params.trim();
+    (!first.is_empty()).then_some(first)
+}
+
+fn parameter_type_annotation(param: &str) -> Option<&str> {
+    let mut depth = 0;
+    let mut quote: Option<char> = None;
+    let mut prev_escape = false;
+
+    for (idx, ch) in param.char_indices() {
+        if let Some(quote_char) = quote {
+            if prev_escape {
+                prev_escape = false;
+                continue;
+            }
+            if ch == '\\' {
+                prev_escape = true;
+                continue;
+            }
+            if ch == quote_char {
+                quote = None;
+            }
+            continue;
+        }
+
+        match ch {
+            '\'' | '"' => quote = Some(ch),
+            '(' | '[' | '{' | '<' => depth += 1,
+            ')' | ']' | '}' | '>' if depth > 0 => depth -= 1,
+            ':' if depth == 0 => return Some(param[idx + 1..].trim()),
+            _ => {}
+        }
+    }
+
+    None
+}
+
+fn extract_string_literals(input: &str, output: &mut Vec<String>) {
+    let bytes = input.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        let quote = bytes[i];
+        if !matches!(quote, b'\'' | b'"') {
+            i += 1;
+            continue;
+        }
+
+        let mut literal = String::default();
+        i += 1;
+        while i < bytes.len() {
+            let byte = bytes[i];
+            if byte == b'\\' {
+                if i + 1 < bytes.len() {
+                    literal.push(bytes[i + 1] as char);
+                    i += 2;
+                    continue;
+                }
+                break;
+            }
+            if byte == quote {
+                if !literal.is_empty() {
+                    output.push(literal);
+                }
+                i += 1;
+                break;
+            }
+            literal.push(byte as char);
+            i += 1;
+        }
+    }
 }
 
 fn extract_emit_shorthand_key(segment: &str) -> Option<String> {
@@ -1842,6 +1997,39 @@ mod tests {
         );
 
         assert_eq!(names, vec!["update:open", "select:item", "close"]);
+    }
+
+    #[test]
+    fn extract_emit_names_ignores_payload_literal_union_in_call_signature() {
+        let names = extract_emit_names_from_type("{ (e: 'change', mode: 'x' | 'y'): void }");
+
+        assert_eq!(names, vec!["change"]);
+    }
+
+    #[test]
+    fn extract_emit_names_ignores_payload_literal_union_in_function_type() {
+        let names = extract_emit_names_from_type("(e: 'change', mode: 'x' | 'y') => void");
+
+        assert_eq!(names, vec!["change"]);
+    }
+
+    #[test]
+    fn extract_emit_names_supports_custom_first_parameter_name() {
+        let names = extract_emit_names_from_type("{ (evt: 'change', val: 'a' | 'b'): void }");
+
+        assert_eq!(names, vec!["change"]);
+    }
+
+    #[test]
+    fn extract_emit_names_ignores_payload_literals_across_multiple_call_signatures() {
+        let names = extract_emit_names_from_type(
+            r#"{
+              (e: 'change', mode: 'x' | 'y'): void
+              (evt: 'submit', val: 'a' | 'b'): void
+            }"#,
+        );
+
+        assert_eq!(names, vec!["change", "submit"]);
     }
 
     #[test]

--- a/crates/vize_atelier_sfc/src/compile_script/snapshots/vize_atelier_sfc__compile_script__tests__compile_script_tests__compile_script_setup_with_define_emits_custom_event_parameter.snap
+++ b/crates/vize_atelier_sfc/src/compile_script/snapshots/vize_atelier_sfc__compile_script__tests__compile_script_tests__compile_script_setup_with_define_emits_custom_event_parameter.snap
@@ -1,0 +1,19 @@
+---
+source: crates/vize_atelier_sfc/src/compile_script/tests.rs
+expression: result.code.as_str()
+---
+import { defineComponent as _defineComponent } from "vue";
+const __sfc__ = /* @__PURE__ */ _defineComponent({
+  __name: "Test",
+  emits: ["change"],
+  setup(__props, { expose: __expose, emit: __emit }) {
+    __expose();
+    const emit = __emit;
+    const __returned__ = { emit };
+    Object.defineProperty(__returned__, "__isScriptSetup", {
+      enumerable: false,
+      value: true
+    });
+    return __returned__;
+  }
+});

--- a/crates/vize_atelier_sfc/src/compile_script/snapshots/vize_atelier_sfc__compile_script__tests__compile_script_tests__compile_script_setup_with_define_emits_literal_union_payload.snap
+++ b/crates/vize_atelier_sfc/src/compile_script/snapshots/vize_atelier_sfc__compile_script__tests__compile_script_tests__compile_script_setup_with_define_emits_literal_union_payload.snap
@@ -1,0 +1,19 @@
+---
+source: crates/vize_atelier_sfc/src/compile_script/tests.rs
+expression: result.code.as_str()
+---
+import { defineComponent as _defineComponent } from "vue";
+const __sfc__ = /* @__PURE__ */ _defineComponent({
+  __name: "Test",
+  emits: ["change"],
+  setup(__props, { expose: __expose, emit: __emit }) {
+    __expose();
+    const emit = __emit;
+    const __returned__ = { emit };
+    Object.defineProperty(__returned__, "__isScriptSetup", {
+      enumerable: false,
+      value: true
+    });
+    return __returned__;
+  }
+});

--- a/crates/vize_atelier_sfc/src/compile_script/snapshots/vize_atelier_sfc__compile_script__tests__compile_script_tests__compile_script_setup_with_define_emits_multiple_literal_payloads.snap
+++ b/crates/vize_atelier_sfc/src/compile_script/snapshots/vize_atelier_sfc__compile_script__tests__compile_script_tests__compile_script_setup_with_define_emits_multiple_literal_payloads.snap
@@ -1,0 +1,19 @@
+---
+source: crates/vize_atelier_sfc/src/compile_script/tests.rs
+expression: result.code.as_str()
+---
+import { defineComponent as _defineComponent } from "vue";
+const __sfc__ = /* @__PURE__ */ _defineComponent({
+  __name: "Test",
+  emits: ["change", "submit"],
+  setup(__props, { expose: __expose, emit: __emit }) {
+    __expose();
+    const emit = __emit;
+    const __returned__ = { emit };
+    Object.defineProperty(__returned__, "__isScriptSetup", {
+      enumerable: false,
+      value: true
+    });
+    return __returned__;
+  }
+});

--- a/crates/vize_atelier_sfc/src/compile_script/tests.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/tests.rs
@@ -520,6 +520,43 @@ const emit = defineEmits<(e: 'click') => void>()
     }
 
     #[test]
+    fn test_compile_script_setup_with_define_emits_literal_union_payload() {
+        let content = r#"
+const emit = defineEmits<{
+  (e: 'change', mode: 'x' | 'y'): void
+}>()
+"#;
+        let result = compile_script_setup(content, "Test", false, false, None).unwrap();
+
+        insta::assert_snapshot!(result.code.as_str());
+    }
+
+    #[test]
+    fn test_compile_script_setup_with_define_emits_custom_event_parameter() {
+        let content = r#"
+const emit = defineEmits<{
+  (evt: 'change', val: 'a' | 'b'): void
+}>()
+"#;
+        let result = compile_script_setup(content, "Test", false, false, None).unwrap();
+
+        insta::assert_snapshot!(result.code.as_str());
+    }
+
+    #[test]
+    fn test_compile_script_setup_with_define_emits_multiple_literal_payloads() {
+        let content = r#"
+const emit = defineEmits<{
+  (e: 'change', mode: 'x' | 'y'): void
+  (evt: 'submit', val: 'a' | 'b'): void
+}>()
+"#;
+        let result = compile_script_setup(content, "Test", false, false, None).unwrap();
+
+        insta::assert_snapshot!(result.code.as_str());
+    }
+
+    #[test]
     fn test_compile_script_setup_with_define_emits_named_type() {
         for content in [
             r#"


### PR DESCRIPTION
## Summary
- replace the quoted-string fallback for typed defineEmits call signatures with first-parameter-only extraction
- support custom event parameter names, direct function types, and multiple call signatures without leaking payload literal unions
- add compile-script regression snapshots for literal-union payload cases

Closes #1177

## Validation
- cargo fmt --check
- cargo test -p vize_atelier_sfc compile_script --lib
- cargo test -p vize_atelier_sfc
- git diff --check
- cargo clippy -p vize_atelier_sfc --lib -- -D warnings

Note: cargo clippy -p vize_atelier_sfc --all-targets -- -D warnings was attempted but fails on existing unrelated test/bench lints such as deprecated criterion::black_box and disallowed insta format macro expansions.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1289"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783600145&installation_id=136613492&pr_number=1289&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1289&signature=ab2885c821da04c8b2e58b07931a5390f7dd7abcbe70fd542ef266043f185cf3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->