### PR TITLE
fix(croquis): resolve runtime object macro spreads

### DIFF
--- a/crates/vize_canon/src/sfc_typecheck.rs
+++ b/crates/vize_canon/src/sfc_typecheck.rs
@@ -155,6 +155,25 @@ const props = defineProps<Props>();
     }
 
     #[test]
+    fn test_type_check_runtime_props_object_spread_template_binding() {
+        let source = r#"<script setup lang="ts">
+const common = { bar: String } as const;
+const props = defineProps({ ...common, foo: String });
+</script>
+<template>{{ bar }} {{ foo }} {{ props.bar }}</template>"#;
+        let options = SfcTypeCheckOptions::new("test.vue").with_virtual_ts();
+        let result = type_check_sfc(source, &options);
+        assert!(
+            !result
+                .diagnostics
+                .iter()
+                .any(|d| d.message.as_str().contains("Cannot find name 'bar'")),
+            "{:#?}",
+            result.diagnostics
+        );
+    }
+
+    #[test]
     fn test_type_check_with_defaults_template_props_are_default_resolved() {
         let source = r#"<template>
   <svg>

--- a/crates/vize_croquis/src/script_parser.rs
+++ b/crates/vize_croquis/src/script_parser.rs
@@ -27,7 +27,7 @@ use oxc_span::SourceType;
 
 use crate::croquis::{BindingMetadata, ComponentRegistration, Croquis};
 use crate::croquis::{ImportStatementInfo, InvalidExport, ReExportInfo, TypeExport};
-use crate::macros::MacroTracker;
+use crate::macros::{EmitDefinition, MacroTracker, PropDefinition};
 use crate::provide::ProvideInjectTracker;
 use crate::race::RaceConditionTracker;
 use crate::reactivity::ReactivityTracker;
@@ -72,6 +72,13 @@ pub(crate) enum ReactiveValueOrigin {
 pub(crate) struct ReactiveGetterContext {
     pub callee_name: CompactString,
     pub getters: FxHashMap<CompactString, CompactString>,
+}
+
+/// Static metadata extracted from a top-level runtime object literal.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct RuntimeObjectLiteral {
+    pub props: Vec<PropDefinition>,
+    pub emits: Vec<EmitDefinition>,
 }
 
 /// Result of parsing a script setup block
@@ -120,6 +127,8 @@ pub struct ScriptParseResult {
     /// setup-scope values they depend on. Pushed to in lockstep with
     /// `type_exports` via `record_type_export`.
     pub(crate) type_export_typeof_refs: Vec<FxHashSet<CompactString>>,
+    /// Static runtime object literal metadata available to macro spread args.
+    pub(crate) runtime_object_literals: FxHashMap<CompactString, RuntimeObjectLiteral>,
 }
 
 /// Options for plain script parsing.
@@ -539,6 +548,35 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_define_props_runtime_object_spread_local_literal() {
+        let result = parse_script_setup(
+            r#"
+            const common = {
+                bar: String,
+                count: { type: Number, required: true, default: 1 },
+            } as const
+            const props = defineProps({ ...common, foo: Boolean })
+        "#,
+        );
+
+        let props = result.macros.props();
+        assert_eq!(props.len(), 3);
+        assert!(props.iter().any(|prop| prop.name == "bar"));
+        assert!(props.iter().any(|prop| prop.name == "foo"));
+
+        let count = props
+            .iter()
+            .find(|prop| prop.name == "count")
+            .expect("spread prop should be extracted");
+        assert!(count.required);
+        assert_eq!(count.prop_type.as_deref(), Some("number"));
+        assert_eq!(count.default_value.as_deref(), Some("1"));
+
+        assert!(result.bindings.contains("bar"));
+        assert!(result.bindings.contains("count"));
+    }
+
+    #[test]
     fn test_parse_define_emits() {
         let result = parse_script_setup(
             r#"
@@ -681,6 +719,46 @@ defineSlots<{
             .find(|emit| emit.name == "cancel")
             .expect("cancel emit should be extracted");
         assert_eq!(cancel.payload_type, None);
+    }
+
+    #[test]
+    fn test_parse_define_emits_runtime_object_spread_local_literal() {
+        let result = parse_script_setup(
+            r#"
+            type SavePayload = { id: number }
+            const commonEmits = {
+                save: (payload: SavePayload) => payload.id > 0,
+                close() { return true },
+            } as const
+            const emit = defineEmits({ ...commonEmits, cancel: null })
+        "#,
+        );
+
+        assert_eq!(result.macros.emits().len(), 3);
+
+        let save = result
+            .macros
+            .emits()
+            .iter()
+            .find(|emit| emit.name == "save")
+            .expect("spread emit should be extracted");
+        assert_eq!(save.payload_type.as_deref(), Some("[payload: SavePayload]"));
+
+        let close = result
+            .macros
+            .emits()
+            .iter()
+            .find(|emit| emit.name == "close")
+            .expect("method spread emit should be extracted");
+        assert_eq!(close.payload_type.as_deref(), Some("[]"));
+
+        assert!(
+            result
+                .macros
+                .emits()
+                .iter()
+                .any(|emit| emit.name == "cancel")
+        );
     }
 
     #[test]

--- a/crates/vize_croquis/src/script_parser/extract.rs
+++ b/crates/vize_croquis/src/script_parser/extract.rs
@@ -9,6 +9,7 @@ mod props;
 mod provide;
 mod race;
 mod reactivity;
+mod runtime_objects;
 mod slots;
 
 pub use common::{extract_call_expression, get_binding_type_from_kind};
@@ -23,3 +24,4 @@ pub use plain_values::{
 pub use provide::{detect_provide_inject_call, extract_argument_source, extract_provide_key};
 pub use race::detect_race_condition_call;
 pub use reactivity::{detect_reactivity_call, detect_setup_context_violation};
+pub(in crate::script_parser) use runtime_objects::record_static_runtime_object_literal;

--- a/crates/vize_croquis/src/script_parser/extract/emits.rs
+++ b/crates/vize_croquis/src/script_parser/extract/emits.rs
@@ -104,23 +104,39 @@ fn extract_emits_from_object(
     source: &str,
 ) {
     for prop in obj.properties.iter() {
-        let ObjectPropertyKind::ObjectProperty(prop) = prop else {
-            continue;
-        };
-        let name = match &prop.key {
-            PropertyKey::StaticIdentifier(id) => id.name.as_str(),
-            PropertyKey::StringLiteral(s) => s.value.as_str(),
-            _ => continue,
-        };
+        match prop {
+            ObjectPropertyKind::ObjectProperty(prop) => {
+                let name = match &prop.key {
+                    PropertyKey::StaticIdentifier(id) => id.name.as_str(),
+                    PropertyKey::StringLiteral(s) => s.value.as_str(),
+                    _ => continue,
+                };
 
-        result.macros.add_emit(EmitDefinition {
-            name: CompactString::new(name),
-            payload_type: extract_runtime_emit_payload_type(&prop.value, source),
-        });
+                result.macros.add_emit(EmitDefinition {
+                    name: CompactString::new(name),
+                    payload_type: extract_runtime_emit_payload_type(&prop.value, source),
+                });
+            }
+            ObjectPropertyKind::SpreadProperty(spread) => {
+                let Expression::Identifier(identifier) = &spread.argument else {
+                    continue;
+                };
+                let Some(emits) = result
+                    .runtime_object_literals
+                    .get(identifier.name.as_str())
+                    .map(|literal| literal.emits.clone())
+                else {
+                    continue;
+                };
+                for emit in emits {
+                    result.macros.add_emit(emit);
+                }
+            }
+        }
     }
 }
 
-fn extract_runtime_emit_payload_type(
+pub(super) fn extract_runtime_emit_payload_type(
     value: &Expression<'_>,
     source: &str,
 ) -> Option<CompactString> {

--- a/crates/vize_croquis/src/script_parser/extract/props.rs
+++ b/crates/vize_croquis/src/script_parser/extract/props.rs
@@ -1,4 +1,6 @@
-use oxc_ast::ast::{Argument, Expression, ObjectPropertyKind, PropertyKey, TSType};
+use oxc_ast::ast::{
+    Argument, Expression, ObjectExpression, ObjectPropertyKind, PropertyKey, TSType,
+};
 use oxc_span::{GetSpan, Span};
 
 use crate::macros::PropDefinition;
@@ -57,32 +59,120 @@ pub fn extract_props_from_runtime(
 
         // Object syntax: { prop1: Type, prop2: { type: Type, required: true } }
         Argument::ObjectExpression(obj) => {
-            for prop in obj.properties.iter() {
-                if let ObjectPropertyKind::ObjectProperty(p) = prop {
-                    let name = match &p.key {
-                        PropertyKey::StaticIdentifier(id) => id.name.as_str(),
-                        PropertyKey::StringLiteral(s) => s.value.as_str(),
-                        _ => continue,
-                    };
-                    let required = detect_required_prop(&p.value);
-                    let prop_type = extract_runtime_prop_type(&p.value, source);
-                    let default_value = extract_runtime_prop_default(&p.value, source);
-                    result.macros.add_prop(PropDefinition {
-                        name: CompactString::new(name),
-                        required,
-                        prop_type,
-                        default_value,
-                    });
-                    result.bindings.add(name, BindingType::Props);
-                }
-            }
+            extract_props_from_object(result, obj, source);
+        }
+
+        Argument::TSAsExpression(ts_as) => {
+            extract_props_from_runtime_expression(result, &ts_as.expression, source);
+        }
+        Argument::TSSatisfiesExpression(ts_satisfies) => {
+            extract_props_from_runtime_expression(result, &ts_satisfies.expression, source);
+        }
+        Argument::TSNonNullExpression(ts_non_null) => {
+            extract_props_from_runtime_expression(result, &ts_non_null.expression, source);
+        }
+        Argument::ParenthesizedExpression(paren) => {
+            extract_props_from_runtime_expression(result, &paren.expression, source);
         }
 
         _ => {}
     }
 }
 
-fn extract_runtime_prop_type(value: &Expression<'_>, source: &str) -> Option<CompactString> {
+fn extract_props_from_runtime_expression(
+    result: &mut ScriptParseResult,
+    expr: &Expression<'_>,
+    source: &str,
+) {
+    match expr {
+        Expression::ArrayExpression(arr) => {
+            for elem in arr.elements.iter() {
+                if let oxc_ast::ast::ArrayExpressionElement::StringLiteral(s) = elem {
+                    let name = s.value.as_str();
+                    result.macros.add_prop(PropDefinition {
+                        name: CompactString::new(name),
+                        required: false,
+                        prop_type: None,
+                        default_value: None,
+                    });
+                    result.bindings.add(name, BindingType::Props);
+                }
+            }
+        }
+        Expression::ObjectExpression(obj) => extract_props_from_object(result, obj, source),
+        Expression::TSAsExpression(ts_as) => {
+            extract_props_from_runtime_expression(result, &ts_as.expression, source);
+        }
+        Expression::TSSatisfiesExpression(ts_satisfies) => {
+            extract_props_from_runtime_expression(result, &ts_satisfies.expression, source);
+        }
+        Expression::TSNonNullExpression(ts_non_null) => {
+            extract_props_from_runtime_expression(result, &ts_non_null.expression, source);
+        }
+        Expression::ParenthesizedExpression(paren) => {
+            extract_props_from_runtime_expression(result, &paren.expression, source);
+        }
+        _ => {}
+    }
+}
+
+fn extract_props_from_object(
+    result: &mut ScriptParseResult,
+    obj: &ObjectExpression<'_>,
+    source: &str,
+) {
+    for prop in obj.properties.iter() {
+        match prop {
+            ObjectPropertyKind::ObjectProperty(p) => {
+                let Some(name) = runtime_object_property_name(&p.key) else {
+                    continue;
+                };
+                add_runtime_prop(
+                    result,
+                    PropDefinition {
+                        name: CompactString::new(name),
+                        required: detect_required_prop(&p.value),
+                        prop_type: extract_runtime_prop_type(&p.value, source),
+                        default_value: extract_runtime_prop_default(&p.value, source),
+                    },
+                );
+            }
+            ObjectPropertyKind::SpreadProperty(spread) => {
+                let Expression::Identifier(identifier) = &spread.argument else {
+                    continue;
+                };
+                let Some(props) = result
+                    .runtime_object_literals
+                    .get(identifier.name.as_str())
+                    .map(|literal| literal.props.clone())
+                else {
+                    continue;
+                };
+                for prop in props {
+                    add_runtime_prop(result, prop);
+                }
+            }
+        }
+    }
+}
+
+fn add_runtime_prop(result: &mut ScriptParseResult, prop: PropDefinition) {
+    result.bindings.add(prop.name.as_str(), BindingType::Props);
+    result.macros.add_prop(prop);
+}
+
+pub(super) fn runtime_object_property_name<'a>(key: &'a PropertyKey<'a>) -> Option<&'a str> {
+    match key {
+        PropertyKey::StaticIdentifier(id) => Some(id.name.as_str()),
+        PropertyKey::StringLiteral(s) => Some(s.value.as_str()),
+        _ => None,
+    }
+}
+
+pub(super) fn extract_runtime_prop_type(
+    value: &Expression<'_>,
+    source: &str,
+) -> Option<CompactString> {
     match value {
         Expression::Identifier(id) => runtime_ctor_type(id.name.as_str()).map(CompactString::new),
         Expression::ArrayExpression(arr) => {
@@ -201,7 +291,10 @@ fn extract_prop_type_generic(annotation: &str, type_name: &str) -> Option<Compac
     None
 }
 
-fn extract_runtime_prop_default(value: &Expression<'_>, source: &str) -> Option<CompactString> {
+pub(super) fn extract_runtime_prop_default(
+    value: &Expression<'_>,
+    source: &str,
+) -> Option<CompactString> {
     let Expression::ObjectExpression(obj) = value else {
         return None;
     };
@@ -237,7 +330,7 @@ fn runtime_ctor_type(name: &str) -> Option<&'static str> {
 }
 
 /// Detect if a prop has required: true
-fn detect_required_prop(value: &Expression<'_>) -> bool {
+pub(super) fn detect_required_prop(value: &Expression<'_>) -> bool {
     if let Expression::ObjectExpression(obj) = value {
         for prop in obj.properties.iter() {
             if let ObjectPropertyKind::ObjectProperty(p) = prop

--- a/crates/vize_croquis/src/script_parser/extract/runtime_objects.rs
+++ b/crates/vize_croquis/src/script_parser/extract/runtime_objects.rs
@@ -1,0 +1,84 @@
+use oxc_ast::ast::{Expression, ObjectExpression, ObjectPropertyKind};
+
+use crate::macros::{EmitDefinition, PropDefinition};
+use vize_carton::CompactString;
+
+use super::super::{RuntimeObjectLiteral, ScriptParseResult};
+use super::{emits, props};
+
+pub(in crate::script_parser) fn record_static_runtime_object_literal(
+    result: &mut ScriptParseResult,
+    name: &str,
+    expr: &Expression<'_>,
+    source: &str,
+) {
+    let Some(object) = unwrap_runtime_object_expression(expr) else {
+        return;
+    };
+
+    let literal = collect_runtime_object_literal(result, object, source);
+    result
+        .runtime_object_literals
+        .insert(CompactString::new(name), literal);
+}
+
+fn collect_runtime_object_literal(
+    result: &ScriptParseResult,
+    object: &ObjectExpression<'_>,
+    source: &str,
+) -> RuntimeObjectLiteral {
+    let mut literal = RuntimeObjectLiteral::default();
+
+    for property in object.properties.iter() {
+        match property {
+            ObjectPropertyKind::ObjectProperty(property) => {
+                let Some(name) = props::runtime_object_property_name(&property.key) else {
+                    continue;
+                };
+                literal.props.push(PropDefinition {
+                    name: CompactString::new(name),
+                    required: props::detect_required_prop(&property.value),
+                    prop_type: props::extract_runtime_prop_type(&property.value, source),
+                    default_value: props::extract_runtime_prop_default(&property.value, source),
+                });
+                literal.emits.push(EmitDefinition {
+                    name: CompactString::new(name),
+                    payload_type: emits::extract_runtime_emit_payload_type(&property.value, source),
+                });
+            }
+            ObjectPropertyKind::SpreadProperty(spread) => {
+                let Expression::Identifier(identifier) = &spread.argument else {
+                    continue;
+                };
+                let Some(spread_literal) =
+                    result.runtime_object_literals.get(identifier.name.as_str())
+                else {
+                    continue;
+                };
+                literal.props.extend(spread_literal.props.iter().cloned());
+                literal.emits.extend(spread_literal.emits.iter().cloned());
+            }
+        }
+    }
+
+    literal
+}
+
+fn unwrap_runtime_object_expression<'a>(
+    expr: &'a Expression<'a>,
+) -> Option<&'a ObjectExpression<'a>> {
+    match expr {
+        Expression::ObjectExpression(object) => Some(object),
+        Expression::TSAsExpression(ts_as) => unwrap_runtime_object_expression(&ts_as.expression),
+        Expression::TSSatisfiesExpression(ts_satisfies) => {
+            unwrap_runtime_object_expression(&ts_satisfies.expression)
+        }
+        Expression::TSNonNullExpression(ts_non_null) => {
+            unwrap_runtime_object_expression(&ts_non_null.expression)
+        }
+        Expression::ParenthesizedExpression(paren) => {
+            unwrap_runtime_object_expression(&paren.expression)
+        }
+        _ => None,
+    }
+}

--- a/crates/vize_croquis/src/script_parser/process/macros.rs
+++ b/crates/vize_croquis/src/script_parser/process/macros.rs
@@ -23,7 +23,7 @@ use super::super::extract::{
     check_reactive_property_extraction, check_ref_value_extraction, detect_reactivity_call,
     detect_setup_context_violation, extract_argument_source, extract_call_expression,
     extract_provide_key, get_binding_type_from_kind, process_call_expression,
-    record_getter_context_from_call,
+    record_getter_context_from_call, record_static_runtime_object_literal,
 };
 use super::super::walk::{walk_call_arguments, walk_expression};
 use super::super::{ReactiveValueOrigin, ScriptParseResult};
@@ -150,6 +150,10 @@ pub(in crate::script_parser) fn process_variable_declarator(
             } else {
                 false
             };
+
+            if let Some(init) = &declarator.init {
+                record_static_runtime_object_literal(result, name, init, source);
+            }
 
             // Walk other expression types for nested scopes
             // Skip if we already extracted and processed a call expression to avoid double processing

--- a/crates/vize_croquis/src/snapshots/vize_croquis__script_parser__tests__parse_imports.snap
+++ b/crates/vize_croquis/src/snapshots/vize_croquis__script_parser__tests__parse_imports.snap
@@ -1319,4 +1319,5 @@ ScriptParseResult {
         "MyComponent": "./MyComponent.vue",
     },
     type_export_typeof_refs: [],
+    runtime_object_literals: {},
 }

--- a/crates/vize_croquis/src/snapshots/vize_croquis__script_parser__tests__parse_reactivity.snap
+++ b/crates/vize_croquis/src/snapshots/vize_croquis__script_parser__tests__parse_reactivity.snap
@@ -1303,4 +1303,5 @@ ScriptParseResult {
     },
     import_sources: {},
     type_export_typeof_refs: [],
+    runtime_object_literals: {},
 }


### PR DESCRIPTION
Closes #1192

## Summary
- Track top-level runtime object literals during script parsing
- Expand statically-known local object spreads in runtime defineProps and defineEmits declarations
- Preserve prop metadata, prop bindings, and emit payload metadata when spreads are expanded
- Add parser and canon type-check regressions for spread-contributed runtime props/emits

## Validation
- CARGO_TARGET_DIR=/tmp/vize-1192-target cargo test -p vize_croquis runtime_object_spread -- --nocapture
- CARGO_TARGET_DIR=/tmp/vize-1192-target cargo test -p vize_canon test_type_check_runtime_props_object_spread_template_binding -- --nocapture
- INSTA_UPDATE=always CARGO_TARGET_DIR=/tmp/vize-1192-target cargo test -p vize_croquis -- --nocapture
- CARGO_TARGET_DIR=/tmp/vize-1192-target cargo test -p vize_croquis -- --nocapture
- CARGO_TARGET_DIR=/tmp/vize-1192-target cargo clippy -p vize_croquis -p vize_canon --lib -- -D warnings
- cargo fmt --check
- git diff --check
- git diff --check HEAD~1..HEAD

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1290"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783600387&installation_id=136613492&pr_number=1290&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1290&signature=85d48dd8510357637a439218b88c36fee91093de4b411004942b903b0d68925a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->