### PR TITLE
fix(atelier_sfc): preserve defineModel tuple bindings

### DIFF
--- a/crates/vize_atelier_sfc/src/compile/snapshots/vize_atelier_sfc__compile__tests__define_model_array_destructure.snap
+++ b/crates/vize_atelier_sfc/src/compile/snapshots/vize_atelier_sfc__compile__tests__define_model_array_destructure.snap
@@ -1,0 +1,38 @@
+---
+source: crates/vize_atelier_sfc/src/compile/tests.rs
+expression: result.code.as_str()
+---
+import { useModel as _useModel } from "vue";
+import { vModelText as _vModelText, withDirectives as _withDirectives, toDisplayString as _toDisplayString, createElementVNode as _createElementVNode, openBlock as _openBlock, createElementBlock as _createElementBlock, Fragment as _Fragment, unref as _unref } from "vue";
+export default {
+  __name: "anonymous",
+  props: {
+    "modelValue": { type: String },
+    "modelModifiers": {}
+  },
+  emits: ["update:modelValue"],
+  setup(__props) {
+    const [model, modifiers] = _useModel(__props, "modelValue");
+    return (_ctx, _cache) => {
+      return _openBlock(), _createElementBlock(
+        _Fragment,
+        null,
+        [_withDirectives(_createElementVNode(
+          "input",
+          { "onUpdate:modelValue": _cache[0] || (_cache[0] = ($event) => model.value = $event) },
+          null,
+          512
+          /* NEED_PATCH */
+        ), [[_vModelText, _unref(model)]]), _createElementVNode(
+          "span",
+          null,
+          _toDisplayString(_unref(modifiers).trim),
+          1
+          /* TEXT */
+        )],
+        64
+        /* STABLE_FRAGMENT */
+      );
+    };
+  }
+};

--- a/crates/vize_atelier_sfc/src/compile/tests.rs
+++ b/crates/vize_atelier_sfc/src/compile/tests.rs
@@ -1671,6 +1671,32 @@ const model = defineModel()
 }
 
 #[test]
+fn test_define_model_array_destructure() {
+    let source = r#"<script setup lang="ts">
+const [model, modifiers] = defineModel<string>()
+</script>
+
+<template>
+  <input v-model="model">
+  <span>{{ modifiers.trim }}</span>
+</template>"#;
+
+    let descriptor = parse_sfc(source, SfcParseOptions::default()).expect("Failed to parse SFC");
+    let opts = SfcCompileOptions::default();
+    let result = compile_sfc(&descriptor, opts).expect("Failed to compile SFC");
+
+    assert!(
+        result
+            .code
+            .contains(r#"const [model, modifiers] = _useModel(__props, "modelValue")"#),
+        "{}",
+        result.code
+    );
+    assert!(!result.code.contains("const modelValue = _useModel"));
+    insta::assert_snapshot!(result.code.as_str());
+}
+
+#[test]
 fn test_define_model_with_name() {
     let source = r#"<script setup>
 const title = defineModel('title')

--- a/crates/vize_atelier_sfc/src/compile_script/function_mode/compiler.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/function_mode/compiler.rs
@@ -9,7 +9,8 @@ use vize_croquis::macros::runtime_erased_macro_names;
 
 use crate::script::{
     PropsDestructuredBindings, ScriptCompileContext, TemplateUsedIdentifiers,
-    resolve_template_used_identifiers, resolve_type_args, transform_destructured_props,
+    model_modifiers_binding_name, resolve_template_used_identifiers, resolve_type_args,
+    transform_destructured_props,
 };
 use crate::types::{BindingType, SfcError};
 
@@ -588,7 +589,17 @@ fn emit_model_bindings(
             };
 
             output.extend_from_slice(b"  const ");
-            output.extend_from_slice(binding_name.as_bytes());
+            if let Some(ref modifiers_binding_name) =
+                model_modifiers_binding_name(ctx.source.as_str(), model_call)
+            {
+                output.push(b'[');
+                output.extend_from_slice(binding_name.as_bytes());
+                output.extend_from_slice(b", ");
+                output.extend_from_slice(modifiers_binding_name.as_bytes());
+                output.extend_from_slice(b"]");
+            } else {
+                output.extend_from_slice(binding_name.as_bytes());
+            }
             output.extend_from_slice(b" = _useModel(__props, \"");
             output.extend_from_slice(model_name.as_bytes());
             output.extend_from_slice(b"\")\n");

--- a/crates/vize_atelier_sfc/src/compile_script/inline/compiler/body.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/inline/compiler/body.rs
@@ -69,7 +69,13 @@ pub(super) fn compile_script_setup_inline_body(
         build_props_emits(&ctx, is_ts, needs_prop_type, needs_merge_defaults, is_prod)
     );
 
-    let model_infos: Vec<(String, String, Option<String>, Option<String>)> = profile!(
+    let model_infos: Vec<(
+        String,
+        String,
+        Option<String>,
+        Option<String>,
+        Option<String>,
+    )> = profile!(
         "atelier.script_inline.collect_model_infos",
         collect_model_infos(&ctx)
     );

--- a/crates/vize_atelier_sfc/src/compile_script/inline/compiler/model.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/inline/compiler/model.rs
@@ -1,6 +1,6 @@
 use vize_carton::{String, ToCompactString, cstr};
 
-use crate::script::ScriptCompileContext;
+use crate::script::{ScriptCompileContext, model_modifiers_binding_name};
 
 use super::super::super::props::{
     extract_emit_names_from_type, resolve_prop_js_type, ts_type_to_js_type,
@@ -203,7 +203,13 @@ fn strip_runtime_accessors(opts: &str) -> Option<String> {
 /// Build model props (and combine props/emits) when defineModel is used.
 pub(super) fn build_model_props_emits(
     ctx: &ScriptCompileContext,
-    model_infos: &[(String, String, Option<String>, Option<String>)],
+    model_infos: &[(
+        String,
+        String,
+        Option<String>,
+        Option<String>,
+        Option<String>,
+    )],
     is_ts: bool,
     needs_prop_type: bool,
     needs_merge_defaults: bool,
@@ -216,7 +222,7 @@ pub(super) fn build_model_props_emits(
         // model props declaration: `{\n    "name": <opts>,\n    "nameModifiers": {},\n  }`
         let mut model_decl: Vec<u8> = Vec::new();
         model_decl.push(b'{');
-        for (model_name, _binding_name, options, type_arg) in model_infos {
+        for (model_name, _binding_name, _modifiers_binding_name, options, type_arg) in model_infos {
             model_decl.extend_from_slice(b"\n    \"");
             model_decl.extend_from_slice(model_name.as_bytes());
             model_decl.extend_from_slice(b"\": ");
@@ -281,7 +287,7 @@ pub(super) fn build_model_props_emits(
     let model_emits: Vec<u8> = {
         let mut v = Vec::new();
         v.push(b'[');
-        for (i, (name, _, _, _)) in model_infos.iter().enumerate() {
+        for (i, (name, _, _, _, _)) in model_infos.iter().enumerate() {
             if i > 0 {
                 v.extend_from_slice(b", ");
             }
@@ -321,10 +327,16 @@ pub(super) fn build_model_props_emits(
 
 /// Collect model info from defineModel calls.
 ///
-/// Returns Vec of (model_name, binding_name, prop_options).
+/// Returns Vec of (model_name, binding_name, modifiers_binding_name, prop_options).
 pub(super) fn collect_model_infos(
     ctx: &ScriptCompileContext,
-) -> Vec<(String, String, Option<String>, Option<String>)> {
+) -> Vec<(
+    String,
+    String,
+    Option<String>,
+    Option<String>,
+    Option<String>,
+)> {
     ctx.macros
         .define_models
         .iter()
@@ -345,6 +357,7 @@ pub(super) fn collect_model_infos(
                 .as_deref()
                 .map(String::from)
                 .unwrap_or_else(|| model_name.clone());
+            let modifiers_binding_name = model_modifiers_binding_name(ctx.source.as_str(), m);
 
             // Locate the options argument (second arg if named, first arg otherwise).
             let raw_options: Option<&str> = if args.is_empty() {
@@ -363,7 +376,13 @@ pub(super) fn collect_model_infos(
                     None
                 }
             });
-            (model_name, binding_name, options, m.type_args.clone())
+            (
+                model_name,
+                binding_name,
+                modifiers_binding_name,
+                options,
+                m.type_args.clone(),
+            )
         })
         .collect()
 }

--- a/crates/vize_atelier_sfc/src/compile_script/inline/compiler/setup_emit.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/inline/compiler/setup_emit.rs
@@ -96,7 +96,13 @@ fn transform_css_var_expression(
 pub(super) fn emit_setup_body(
     output: &mut vize_carton::Vec<u8>,
     ctx: &ScriptCompileContext,
-    model_infos: &[(String, String, Option<String>, Option<String>)],
+    model_infos: &[(
+        String,
+        String,
+        Option<String>,
+        Option<String>,
+        Option<String>,
+    )],
     setup_body_lines: &[String],
     source_is_ts: bool,
     _is_ts: bool,
@@ -134,9 +140,17 @@ pub(super) fn emit_setup_body(
 
     // Model bindings: const model = _useModel<T>(__props, 'modelValue')
     if !model_infos.is_empty() {
-        for (model_name, binding_name, _, type_arg) in model_infos {
+        for (model_name, binding_name, modifiers_binding_name, _, type_arg) in model_infos {
             output.extend_from_slice(b"const ");
-            output.extend_from_slice(binding_name.as_bytes());
+            if let Some(modifiers_binding_name) = modifiers_binding_name {
+                output.push(b'[');
+                output.extend_from_slice(binding_name.as_bytes());
+                output.extend_from_slice(b", ");
+                output.extend_from_slice(modifiers_binding_name.as_bytes());
+                output.extend_from_slice(b"]");
+            } else {
+                output.extend_from_slice(binding_name.as_bytes());
+            }
             output.extend_from_slice(b" = _useModel");
             // Thread an explicit `<T>` type argument through to `useModel` so the
             // model ref's type matches @vue/compiler-sfc in TypeScript output.

--- a/crates/vize_atelier_sfc/src/compile_script/snapshots/vize_atelier_sfc__compile_script__tests__compile_script_tests__compile_script_setup_with_define_model_array_destructure.snap
+++ b/crates/vize_atelier_sfc/src/compile_script/snapshots/vize_atelier_sfc__compile_script__tests__compile_script_tests__compile_script_setup_with_define_model_array_destructure.snap
@@ -1,0 +1,22 @@
+---
+source: crates/vize_atelier_sfc/src/compile_script/tests.rs
+expression: result.code.as_str()
+---
+import { defineComponent as _defineComponent } from 'vue'
+import { useModel as _useModel } from 'vue'
+
+const __sfc__ = /*@__PURE__*/_defineComponent({
+  __name: 'Test',
+  props: {
+    "modelValue": {},
+  },
+  emits: ["update:modelValue"],
+  setup(__props, { expose: __expose, emit: __emit }) {
+  __expose();
+  const [model, modifiers] = _useModel(__props, "modelValue")
+  const __returned__ = { model, modifiers }
+  Object.defineProperty(__returned__, '__isScriptSetup', { enumerable: false, value: true })
+  return __returned__
+  }
+
+});

--- a/crates/vize_atelier_sfc/src/compile_script/tests.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/tests.rs
@@ -110,6 +110,24 @@ const count = ref(0)
     }
 
     #[test]
+    fn test_compile_script_setup_with_define_model_array_destructure() {
+        let content = r#"
+const [model, modifiers] = defineModel<string>()
+"#;
+        let result = compile_script_setup(content, "Test", false, true, None).unwrap();
+
+        assert!(
+            result
+                .code
+                .contains(r#"const [model, modifiers] = _useModel(__props, "modelValue")"#),
+            "{}",
+            result.code
+        );
+        assert!(!result.code.contains("const modelValue = _useModel"));
+        insta::assert_snapshot!(result.code.as_str());
+    }
+
+    #[test]
     fn test_type_only_imports_not_in_bindings() {
         let content = r#"
 import type { AnalysisResult } from './wasm'

--- a/crates/vize_atelier_sfc/src/script.rs
+++ b/crates/vize_atelier_sfc/src/script.rs
@@ -36,6 +36,7 @@ pub use import_usage_check::{
 pub(crate) use type_resolution::{
     build_interface_type_source, resolve_type_args, resolve_type_to_object_body,
 };
+pub(crate) use utils::model_modifiers_binding_name;
 pub use utils::{
     MacroCall, ScriptSetupMacros, get_escaped_prop_name, is_compiler_macro_line,
     is_valid_identifier,

--- a/crates/vize_atelier_sfc/src/script/context/parse.rs
+++ b/crates/vize_atelier_sfc/src/script/context/parse.rs
@@ -210,17 +210,13 @@ impl ScriptCompileContext {
             }
             Statement::VariableDeclaration(var_decl) => {
                 for decl in var_decl.declarations.iter() {
-                    // Extract binding name if this is a simple identifier binding
-                    let binding_name = match &decl.id {
-                        BindingPattern::BindingIdentifier(id) => Some(id.name.to_compact_string()),
-                        _ => None,
-                    };
+                    let binding_name = macro_binding_name(&decl.id);
 
                     // Check if init is a macro call
                     if let Some(init) = &decl.init {
                         if let Some(mut macro_call) = extract_macro_from_expr(init, source) {
                             // Attach binding name to macro call
-                            macro_call.1.binding_name = binding_name.as_deref().map(Into::into);
+                            macro_call.1.binding_name = binding_name.clone();
                             self.register_macro(&macro_call.0, macro_call.1);
                         }
 
@@ -344,11 +340,26 @@ impl ScriptCompileContext {
                                     _ => BindingType::SetupLet,
                                 }
                             };
-                            for elem in arr_pat.elements.iter().flatten() {
-                                if let BindingPattern::BindingIdentifier(id) = &elem {
-                                    self.bindings
-                                        .bindings
-                                        .insert(id.name.to_compact_string(), destructure_type);
+                            let is_define_model = decl
+                                .init
+                                .as_ref()
+                                .and_then(|init| extract_macro_from_expr(init, source))
+                                .is_some_and(|(name, _)| name == "defineModel");
+                            for (index, elem) in arr_pat.elements.iter().enumerate() {
+                                let Some(elem) = elem else {
+                                    continue;
+                                };
+                                if let Some(name) = simple_binding_name(elem) {
+                                    let binding_type = if is_define_model {
+                                        if index == 0 {
+                                            BindingType::SetupRef
+                                        } else {
+                                            BindingType::SetupConst
+                                        }
+                                    } else {
+                                        destructure_type
+                                    };
+                                    self.bindings.bindings.insert(name, binding_type);
                                 }
                             }
                         }
@@ -438,5 +449,25 @@ impl ScriptCompileContext {
             }
             _ => {}
         }
+    }
+}
+
+fn macro_binding_name(id: &BindingPattern<'_>) -> Option<String> {
+    match id {
+        BindingPattern::BindingIdentifier(id) => Some(id.name.to_compact_string()),
+        BindingPattern::ArrayPattern(pattern) => pattern
+            .elements
+            .first()
+            .and_then(|elem| elem.as_ref())
+            .and_then(simple_binding_name),
+        _ => None,
+    }
+}
+
+fn simple_binding_name(id: &BindingPattern<'_>) -> Option<String> {
+    match id {
+        BindingPattern::BindingIdentifier(id) => Some(id.name.to_compact_string()),
+        BindingPattern::AssignmentPattern(pattern) => simple_binding_name(&pattern.left),
+        _ => None,
     }
 }

--- a/crates/vize_atelier_sfc/src/script/utils.rs
+++ b/crates/vize_atelier_sfc/src/script/utils.rs
@@ -44,6 +44,101 @@ pub struct MacroCall {
     pub binding_name: Option<String>,
 }
 
+pub(crate) fn model_modifiers_binding_name(source: &str, call: &MacroCall) -> Option<String> {
+    let before_call = source.get(..call.start)?;
+    let eq_index = before_call.rfind('=')?;
+    let statement = &before_call[..eq_index];
+    let statement_start = statement
+        .rfind(|c| ['\n', ';'].contains(&c))
+        .map_or(0, |index| index + 1);
+    let mut lhs = statement[statement_start..].trim();
+
+    for keyword in ["const ", "let ", "var "] {
+        if let Some(rest) = lhs.strip_prefix(keyword) {
+            lhs = rest.trim_start();
+            break;
+        }
+    }
+
+    if let Some(index) = last_top_level_comma(lhs) {
+        lhs = lhs[index + 1..].trim_start();
+    }
+
+    let inner = lhs.strip_prefix('[')?.trim_end().strip_suffix(']')?.trim();
+    let second = nth_top_level_item(inner, 1)?.trim();
+    simple_binding_name(second).map(String::from)
+}
+
+fn nth_top_level_item(input: &str, target_index: usize) -> Option<&str> {
+    let mut index = 0;
+    let mut start = 0;
+    for (comma, _) in top_level_commas(input) {
+        if index == target_index {
+            return Some(&input[start..comma]);
+        }
+        index += 1;
+        start = comma + 1;
+    }
+    if index == target_index {
+        Some(&input[start..])
+    } else {
+        None
+    }
+}
+
+fn last_top_level_comma(input: &str) -> Option<usize> {
+    top_level_commas(input).map(|(index, _)| index).last()
+}
+
+fn top_level_commas(input: &str) -> impl Iterator<Item = (usize, char)> + '_ {
+    let mut depth = 0usize;
+    let mut in_string = None;
+    let mut escaped = false;
+
+    input.char_indices().filter(move |(_, ch)| {
+        if let Some(quote) = in_string {
+            if escaped {
+                escaped = false;
+                return false;
+            }
+            if *ch == '\\' {
+                escaped = true;
+                return false;
+            }
+            if *ch == quote {
+                in_string = None;
+            }
+            return false;
+        }
+
+        match *ch {
+            '\'' | '"' | '`' => in_string = Some(*ch),
+            '[' | '(' | '{' => depth += 1,
+            ']' | ')' | '}' => depth = depth.saturating_sub(1),
+            ',' if depth == 0 => return true,
+            _ => {}
+        }
+        false
+    })
+}
+
+fn simple_binding_name(input: &str) -> Option<&str> {
+    let input = input.trim();
+    if input.starts_with(['[', '{']) {
+        return None;
+    }
+
+    let name_end = input
+        .find(|c: char| !(c.is_alphanumeric() || c == '_' || c == '$'))
+        .unwrap_or(input.len());
+    let name = &input[..name_end];
+    if is_valid_identifier(name) {
+        Some(name)
+    } else {
+        None
+    }
+}
+
 /// Find matching closing parenthesis
 #[allow(dead_code)]
 pub fn find_matching_paren(s: &str) -> Option<usize> {


### PR DESCRIPTION
## Summary
- Preserve tuple bindings from array-destructured `defineModel()` calls.
- Emit `_useModel` into `[model, modifiers]` instead of deriving a prop-name local like `modelValue`.
- Keep `MacroCall` public API stable and derive modifiers bindings internally from source positions.
- Add SFC and script setup regression snapshots for tuple destructuring.

Closes #1174

## Tests
- `INSTA_UPDATE=always CARGO_TARGET_DIR=/tmp/vize-1174-target cargo test -p vize_atelier_sfc -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/vize-1174-target cargo test -p vize_atelier_sfc -- --nocapture`
- `cargo fmt --check`
- `git diff --check`
- `CARGO_TARGET_DIR=/tmp/vize-1174-target cargo clippy -p vize_atelier_sfc --lib -- -D warnings`
- `CARGO_TARGET_DIR=/tmp/vize-1174-semver-target cargo semver-checks check-release --package vize_atelier_sfc`