### PR TITLE
fix(croquis_cf): normalize kebab-case prop bindings

### DIFF
--- a/crates/vize_croquis_cf/src/analyzer/tests_basic.rs
+++ b/crates/vize_croquis_cf/src/analyzer/tests_basic.rs
@@ -151,6 +151,45 @@ const formData = { id: 1 }"#,
 }
 
 #[test]
+fn test_props_validation_normalizes_kebab_case_prop_bindings() {
+    for (case, value, is_dynamic) in [
+        ("static attr", Some("x"), false),
+        ("dynamic bind", Some("'x'"), true),
+    ] {
+        let mut analyzer =
+            CrossFileAnalyzer::new(CrossFileOptions::default().with_props_validation(true));
+
+        let child_analysis = script_analysis("const props = defineProps<{ userName: string }>()");
+        let parent_analysis = script_analysis_with_component_usage(
+            r#"import Child from './Child.vue'"#,
+            component_usage_with_prop("Child", "user-name", value, is_dynamic),
+        );
+
+        analyzer.add_file_with_analysis(Path::new("Child.vue"), "", child_analysis);
+        analyzer.add_file_with_analysis(Path::new("Parent.vue"), "", parent_analysis);
+        analyzer.rebuild_component_edges();
+
+        let result = analyzer.analyze();
+        let prop_validation_diagnostics = result
+            .diagnostics
+            .iter()
+            .filter(|diagnostic| {
+                matches!(
+                    diagnostic.kind,
+                    CrossFileDiagnosticKind::MissingRequiredProp { .. }
+                        | CrossFileDiagnosticKind::UndeclaredProp { .. }
+                )
+            })
+            .collect::<Vec<_>>();
+
+        assert!(
+            prop_validation_diagnostics.is_empty(),
+            "{case} should match camelCase defineProps without missing/undeclared diagnostics"
+        );
+    }
+}
+
+#[test]
 fn test_props_validation_uses_component_and_prop_offsets() {
     let mut analyzer =
         CrossFileAnalyzer::new(CrossFileOptions::default().with_props_validation(true));
@@ -368,6 +407,25 @@ fn component_usage_with_count_string_at(
             prop_start,
             prop_end,
         )],
+        events: smallvec![],
+        slots: smallvec![],
+        has_spread_attrs: false,
+        scope_id: ScopeId::ROOT,
+        vif_guard: None,
+    }
+}
+
+fn component_usage_with_prop(
+    component: &str,
+    prop_name: &str,
+    value: Option<&str>,
+    is_dynamic: bool,
+) -> ComponentUsage {
+    ComponentUsage {
+        name: CompactString::new(component),
+        start: 0,
+        end: 0,
+        props: smallvec![passed_prop(prop_name, value, is_dynamic)],
         events: smallvec![],
         slots: smallvec![],
         has_spread_attrs: false,

--- a/crates/vize_croquis_cf/src/analyzers/props_validation.rs
+++ b/crates/vize_croquis_cf/src/analyzers/props_validation.rs
@@ -6,7 +6,7 @@ use crate::diagnostics::{CrossFileDiagnostic, CrossFileDiagnosticKind, Diagnosti
 use crate::graph::DependencyGraph;
 use crate::registry::{FileId, ModuleEntry, ModuleRegistry};
 use std::path::{Component, Path, PathBuf};
-use vize_carton::{CompactString, FxHashMap, String, cstr};
+use vize_carton::{CompactString, FxHashMap, String, camelize, cstr};
 use vize_croquis::macros::MacroKind;
 
 /// Information about a props validation issue.
@@ -172,7 +172,9 @@ pub fn analyze_props_validation(
                 }
 
                 // Check if this prop is declared
-                let Some(prop_info) = child_props_info.props.get(passed_prop.name) else {
+                let Some((declared_prop_name, prop_info)) =
+                    declared_prop(&child_props_info.props, passed_prop.name)
+                else {
                     let issue = PropsValidationIssue {
                         parent_file: parent_id,
                         child_file: child_id,
@@ -241,13 +243,13 @@ pub fn analyze_props_validation(
                         cstr!(
                             "**Prop Type Mismatch**: `{}` expects `{}` but received `{}`\n\n\
                             The static prop value does not match the child component's declared runtime prop type.",
-                            passed_prop.name, expected, actual
+                            declared_prop_name, expected, actual
                         ),
                     )
                     .with_related(
                         child_id,
                         define_props_offset(child_entry),
-                        cstr!("Prop `{}` is declared with type `{}` here", passed_prop.name, expected),
+                        cstr!("Prop `{declared_prop_name}` is declared with type `{expected}` here"),
                     );
 
                     diagnostics.push(diagnostic);
@@ -335,7 +337,25 @@ fn define_props_offset(entry: &ModuleEntry) -> u32 {
 }
 
 fn has_passed_prop(usage: &PassedComponentUsage<'_>, name: &str) -> bool {
-    usage.props.iter().any(|prop| prop.name == name)
+    usage
+        .props
+        .iter()
+        .any(|prop| prop_names_match(prop.name, name))
+}
+
+fn declared_prop<'a>(
+    props: &'a FxHashMap<CompactString, PropInfo>,
+    name: &str,
+) -> Option<(&'a CompactString, &'a PropInfo)> {
+    props.get_key_value(name).or_else(|| {
+        props
+            .iter()
+            .find(|(prop_name, _)| prop_names_match(name, prop_name.as_str()))
+    })
+}
+
+fn prop_names_match(left: &str, right: &str) -> bool {
+    left == right || camelize(left) == camelize(right)
 }
 
 fn actual_literal_type(prop: &PassedPropInfo<'_>) -> Option<CompactString> {


### PR DESCRIPTION
## Summary
- Normalize props validation so kebab-case template props match camelCase `defineProps` keys.
- Use normalized declared-prop lookup for missing-required and undeclared-prop validation.
- Add regression coverage for both static `user-name="x"` and dynamic `:user-name="'x'"` bindings.

## Local verification
- `cargo fmt --check`
- `CARGO_TARGET_DIR=/tmp/vize-1193-target cargo test -p vize_croquis_cf test_props_validation_normalizes_kebab_case_prop_bindings`
- `CARGO_TARGET_DIR=/tmp/vize-1193-target cargo test -p vize_croquis_cf`
- `CARGO_TARGET_DIR=/tmp/vize-1193-target cargo clippy -p vize_croquis_cf -- -D warnings`

Closes #1193

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1293"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783602134&installation_id=136613492&pr_number=1293&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1293&signature=4503ea9bc8a7382e1532b7dadd93ad0815cc4a194d9f8b52cf5916a4321ef4d4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->