### PR TITLE
fix(atelier_core): register looped slot key/index aliases

### DIFF
--- a/crates/vize_atelier_core/src/codegen.rs
+++ b/crates/vize_atelier_core/src/codegen.rs
@@ -730,6 +730,63 @@ mod tests {
     }
 
     #[test]
+    fn test_codegen_looped_slot_key_and_index_aliases_stay_local_in_dynamic_args() {
+        use crate::options::{CodegenOptions, TransformOptions};
+        use crate::parser::parse;
+        use crate::transform::transform;
+        use bumpalo::Bump;
+
+        let allocator = Bump::new();
+        let (mut root, _) = parse(
+            &allocator,
+            r#"<Comp>
+  <template v-for="(item, idx) in list" #default>
+    <div :[idx]="item"></div>
+  </template>
+  <template v-for="(val, key) in obj" #item>
+    <button @[key]="val"></button>
+  </template>
+</Comp>"#,
+        );
+
+        transform(
+            &allocator,
+            &mut root,
+            TransformOptions {
+                prefix_identifiers: true,
+                ..Default::default()
+            },
+            None,
+        );
+
+        let result = super::generate(
+            &root,
+            CodegenOptions {
+                prefix_identifiers: true,
+                ..Default::default()
+            },
+        );
+        let output = result_output(&result);
+
+        assert!(
+            output.contains("[idx || \"\"]"),
+            "looped slot index alias should remain local in dynamic prop args:\n{}",
+            output
+        );
+        assert!(
+            output.contains("_toHandlerKey(key)"),
+            "looped slot key alias should remain local in dynamic event args:\n{}",
+            output
+        );
+        assert!(
+            !output.contains("_ctx.idx") && !output.contains("_ctx.key"),
+            "looped slot key/index aliases must not be prefixed as outer scope refs:\n{}",
+            output
+        );
+        assert_codegen_snapshot!(result);
+    }
+
+    #[test]
     fn test_codegen_default_slot_with_v_if_is_stable() {
         let result = compile!(
             r#"<PageWithHeader>

--- a/crates/vize_atelier_core/src/codegen/props/directives.rs
+++ b/crates/vize_atelier_core/src/codegen/props/directives.rs
@@ -190,7 +190,12 @@ fn generate_vbind_prop(
             let emit_key_expr = |ctx: &mut CodegenContext| {
                 // If the expression doesn't already have a prefix, add _ctx.
                 let content = exp.content.as_str();
-                if content.contains('.')
+                if let Some(local) = content
+                    .strip_prefix("_ctx.")
+                    .filter(|local| ctx.is_slot_param(local))
+                {
+                    ctx.push(local);
+                } else if content.contains('.')
                     || content.starts_with('_')
                     || content.starts_with('$')
                     || content.contains('`')
@@ -384,8 +389,16 @@ fn generate_von_prop(ctx: &mut CodegenContext, dir: &DirectiveNode<'_>) {
             ctx.push(ctx.helper(RuntimeHelper::ToHandlerKey));
             ctx.push("(");
             let content = exp.content.as_str();
-            if content.contains('.') || content.starts_with('_') || content.starts_with('$') {
+            if let Some(local) = content
+                .strip_prefix("_ctx.")
+                .filter(|local| ctx.is_slot_param(local))
+            {
+                ctx.push(local);
+            } else if content.contains('.') || content.starts_with('_') || content.starts_with('$')
+            {
                 generate_simple_expression(ctx, exp);
+            } else if ctx.is_slot_param(content) {
+                ctx.push(content);
             } else {
                 ctx.push("_ctx.");
                 ctx.push(content);

--- a/crates/vize_atelier_core/src/codegen/slots.rs
+++ b/crates/vize_atelier_core/src/codegen/slots.rs
@@ -881,10 +881,12 @@ fn generate_looped_slot(ctx: &mut CodegenContext, for_node: &ForNode<'_>) {
     if let Some(key) = &for_node.key_alias {
         ctx.push(", ");
         generate_expression(ctx, key);
+        super::v_for::helpers::extract_for_params(key, &mut callback_params);
     }
     if let Some(index) = &for_node.object_index_alias {
         ctx.push(", ");
         generate_expression(ctx, index);
+        super::v_for::helpers::extract_for_params(index, &mut callback_params);
     }
 
     ctx.add_slot_params(&callback_params);

--- a/crates/vize_atelier_core/src/snapshots/vize_atelier_core__codegen__tests__codegen_looped_slot_key_and_index_aliases_stay_local_in_dynamic_args.snap
+++ b/crates/vize_atelier_core/src/snapshots/vize_atelier_core__codegen__tests__codegen_looped_slot_key_and_index_aliases_stay_local_in_dynamic_args.snap
@@ -1,0 +1,28 @@
+---
+source: crates/vize_atelier_core/src/codegen.rs
+expression: output.as_str()
+---
+const { resolveComponent: _resolveComponent, createElementVNode: _createElementVNode, normalizeProps: _normalizeProps, toHandlerKey: _toHandlerKey, openBlock: _openBlock, createBlock: _createBlock, renderList: _renderList, createSlots: _createSlots, withCtx: _withCtx } = Vue
+
+function render(_ctx, _cache, $props, $setup, $data, $options) {
+  const _component_Comp = _resolveComponent("Comp")
+  
+  return (_openBlock(), _createBlock(_component_Comp, null, _createSlots({ _: 2 /* DYNAMIC */ }, [
+    _renderList(_ctx.list, (item, idx) => {
+      return {
+        name: "default",
+        fn: _withCtx(() => [
+          _createElementVNode("div", _normalizeProps({ [idx || ""]: item }), null, 16 /* FULL_PROPS */)
+        ])
+      }
+    }),
+    _renderList(_ctx.obj, (val, key) => {
+      return {
+        name: "item",
+        fn: _withCtx(() => [
+          _createElementVNode("button", { [_toHandlerKey(key)]: val }, null, 16 /* FULL_PROPS */)
+        ])
+      }
+    })
+  ]), 1024 /* DYNAMIC_SLOTS */))
+}


### PR DESCRIPTION
## Summary
- Register key and index aliases from looped slot templates as local slot params.
- Preserve local slot v-for aliases in dynamic prop and dynamic event arguments instead of emitting `_ctx.idx` / `_ctx.key`.
- Add a regression snapshot covering dynamic `:[idx]` and `@[key]` inside looped slots.

Closes #1173

## Tests
- `INSTA_UPDATE=always CARGO_TARGET_DIR=/tmp/vize-1173-target cargo test -p vize_atelier_core test_codegen_looped_slot_key_and_index_aliases_stay_local_in_dynamic_args -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/vize-1173-target cargo test -p vize_atelier_core -- --nocapture`
- `cargo fmt --check`
- `git diff --check`
- `CARGO_TARGET_DIR=/tmp/vize-1173-target cargo clippy -p vize_atelier_core --lib -- -D warnings`
- `CARGO_TARGET_DIR=/tmp/vize-1173-semver-target cargo semver-checks check-release --package vize_atelier_core`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1294"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783602354&installation_id=136613492&pr_number=1294&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1294&signature=481afd53d4417ed4758f9b2de48a6b3b856013c1dcef446773037ecce196f8ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->