### PR TITLE
fix(atelier_core): register looped slot v-for key/index aliases as slot params

### DIFF
--- a/crates/vize_atelier_core/src/codegen.rs
+++ b/crates/vize_atelier_core/src/codegen.rs
@@ -987,4 +987,65 @@ mod tests {
         );
         assert_codegen_snapshot!(result);
     }
+
+    fn compile_prefixed(source: &str) -> vize_carton::String {
+        let allocator = bumpalo::Bump::new();
+        let (mut root, errors) = crate::parse(&allocator, source);
+        assert!(errors.is_empty(), "Parse errors: {:?}", errors);
+        crate::transform::transform(
+            &allocator,
+            &mut root,
+            crate::TransformOptions {
+                prefix_identifiers: true,
+                ..Default::default()
+            },
+            None,
+        );
+        result_output(&super::generate(
+            &root,
+            crate::CodegenOptions {
+                prefix_identifiers: true,
+                ..Default::default()
+            },
+        ))
+    }
+
+    #[test]
+    fn test_codegen_looped_slot_index_alias_is_slot_param_for_dynamic_arg() {
+        // Issue #1173: the index alias of a v-for on a slot template must be
+        // registered as a slot param so a dynamic arg derived from it is not
+        // wrongly _ctx-prefixed.
+        let output = compile_prefixed(
+            r#"<Comp><template v-for="(item, idx) in list" #default><div :[idx]="item"></div></template></Comp>"#,
+        );
+        assert!(
+            output.contains("[idx || \"\"]"),
+            "index alias should be a local slot param, not _ctx-prefixed. Got:\n{}",
+            output
+        );
+        assert!(
+            !output.contains("_ctx.idx"),
+            "index alias must not be _ctx-prefixed. Got:\n{}",
+            output
+        );
+    }
+
+    #[test]
+    fn test_codegen_looped_slot_key_alias_is_slot_param_for_dynamic_arg() {
+        // Issue #1173: the key alias (object iteration) of a v-for on a slot
+        // template must be registered as a slot param.
+        let output = compile_prefixed(
+            r#"<Comp><template v-for="(val, key) in obj" #default><div :[key]="val"></div></template></Comp>"#,
+        );
+        assert!(
+            output.contains("[key || \"\"]"),
+            "key alias should be a local slot param, not _ctx-prefixed. Got:\n{}",
+            output
+        );
+        assert!(
+            !output.contains("_ctx.key"),
+            "key alias must not be _ctx-prefixed. Got:\n{}",
+            output
+        );
+    }
 }

--- a/crates/vize_atelier_core/src/codegen/slots.rs
+++ b/crates/vize_atelier_core/src/codegen/slots.rs
@@ -881,10 +881,12 @@ fn generate_looped_slot(ctx: &mut CodegenContext, for_node: &ForNode<'_>) {
     if let Some(key) = &for_node.key_alias {
         ctx.push(", ");
         generate_expression(ctx, key);
+        super::v_for::helpers::extract_for_params(key, &mut callback_params);
     }
     if let Some(index) = &for_node.object_index_alias {
         ctx.push(", ");
         generate_expression(ctx, index);
+        super::v_for::helpers::extract_for_params(index, &mut callback_params);
     }
 
     ctx.add_slot_params(&callback_params);


### PR DESCRIPTION
## Problem
In `generate_looped_slot` (codegen/slots.rs), only the value alias was passed to `extract_for_params`/`add_slot_params`. The key and index aliases were generated into the `renderList` callback signature but never registered as slot params. Because the dynamic-argument codegen path decides identifier prefixing solely from `ctx.is_slot_param(...)`, a dynamic arg derived from the key/index alias was wrongly emitted as `_ctx.idx` / `_ctx.key` (undefined at runtime).

## Fix
Mirror the main v-for codegen (v_for.rs:104-115) by calling `extract_for_params` for the key and index aliases, feeding them into `add_slot_params`. Now all three v-for aliases are treated as local bindings.

## Tests
Added two tests in codegen.rs (compiled with `prefix_identifiers: true`):
- `test_codegen_looped_slot_index_alias_is_slot_param_for_dynamic_arg` — `:[idx]` inside `v-for="(item, idx) in list"` emits `[idx || ""]`, never `_ctx.idx`.
- `test_codegen_looped_slot_key_alias_is_slot_param_for_dynamic_arg` — `:[key]` inside `v-for="(val, key) in obj"` emits `[key || ""]`, never `_ctx.key`.

Closes #1173

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1295"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783602481&installation_id=136613492&pr_number=1295&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1295&signature=be01330b3d8fc9301c2d166410bf15729712d3ecee053a382916976ab1549c33"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->