### PR TITLE
fix(croquis_cf): kebab-case prop bindings (:user-name) emit false MissingRequiredProp + UndeclaredProp vs camelCase declared prop

### DIFF
--- a/crates/vize_croquis_cf/src/analyzer/tests_basic.rs
+++ b/crates/vize_croquis_cf/src/analyzer/tests_basic.rs
@@ -258,6 +258,107 @@ fn test_props_validation_emits_type_mismatch_for_static_literal() {
     assert_eq!(diagnostic, ("count", "number", "string", 27, 42));
 }
 
+#[test]
+fn test_kebab_case_prop_binding_matches_camel_case_declared_prop() {
+    let mut analyzer =
+        CrossFileAnalyzer::new(CrossFileOptions::default().with_props_validation(true));
+
+    let child_analysis = script_analysis("const props = defineProps<{ userName: string }>()");
+    let parent_analysis = script_analysis_with_component_usage(
+        r#"import Child from './Child.vue'"#,
+        component_usage_with_kebab_prop("Child", true),
+    );
+
+    analyzer.add_file_with_analysis(Path::new("Child.vue"), "", child_analysis);
+    analyzer.add_file_with_analysis(Path::new("Parent.vue"), "", parent_analysis);
+    analyzer.rebuild_component_edges();
+
+    let result = analyzer.analyze();
+
+    let missing_required = result.diagnostics.iter().any(|diagnostic| {
+        matches!(
+            diagnostic.kind,
+            CrossFileDiagnosticKind::MissingRequiredProp { .. }
+        )
+    });
+    let undeclared = result.diagnostics.iter().any(|diagnostic| {
+        matches!(
+            diagnostic.kind,
+            CrossFileDiagnosticKind::UndeclaredProp { .. }
+        )
+    });
+
+    assert!(
+        !missing_required,
+        "kebab :user-name should satisfy required camelCase userName"
+    );
+    assert!(
+        !undeclared,
+        "kebab :user-name should match declared userName (not undeclared)"
+    );
+
+    // Same for a static kebab attribute (user-name="x").
+    let mut analyzer =
+        CrossFileAnalyzer::new(CrossFileOptions::default().with_props_validation(true));
+    let child_analysis = script_analysis("const props = defineProps<{ userName: string }>()");
+    let parent_analysis = script_analysis_with_component_usage(
+        r#"import Child from './Child.vue'"#,
+        component_usage_with_kebab_prop("Child", false),
+    );
+    analyzer.add_file_with_analysis(Path::new("Child.vue"), "", child_analysis);
+    analyzer.add_file_with_analysis(Path::new("Parent.vue"), "", parent_analysis);
+    analyzer.rebuild_component_edges();
+
+    let result = analyzer.analyze();
+    assert!(
+        !result.diagnostics.iter().any(|diagnostic| matches!(
+            diagnostic.kind,
+            CrossFileDiagnosticKind::MissingRequiredProp { .. }
+                | CrossFileDiagnosticKind::UndeclaredProp { .. }
+        )),
+        "static kebab user-name should match declared camelCase userName"
+    );
+}
+
+#[test]
+fn test_genuinely_missing_required_prop_still_reported() {
+    let mut analyzer =
+        CrossFileAnalyzer::new(CrossFileOptions::default().with_props_validation(true));
+
+    let child_analysis = script_analysis("const props = defineProps<{ userName: string }>()");
+    let parent_analysis = script_analysis_with_component_usage(
+        r#"import Child from './Child.vue'"#,
+        ComponentUsage {
+            name: CompactString::new("Child"),
+            start: 0,
+            end: 0,
+            props: smallvec![],
+            events: smallvec![],
+            slots: smallvec![],
+            has_spread_attrs: false,
+            scope_id: ScopeId::ROOT,
+            vif_guard: None,
+        },
+    );
+
+    analyzer.add_file_with_analysis(Path::new("Child.vue"), "", child_analysis);
+    analyzer.add_file_with_analysis(Path::new("Parent.vue"), "", parent_analysis);
+    analyzer.rebuild_component_edges();
+
+    let result = analyzer.analyze();
+    let missing = result
+        .diagnostics
+        .iter()
+        .filter_map(|diagnostic| match &diagnostic.kind {
+            CrossFileDiagnosticKind::MissingRequiredProp { prop_name, .. } => {
+                Some(prop_name.as_str())
+            }
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(missing, vec!["userName"]);
+}
+
 fn script_analysis(script: &str) -> vize_croquis::Croquis {
     let mut analyzer = vize_croquis::Analyzer::with_options(AnalyzerOptions::full());
     analyzer.analyze_script_setup(script);
@@ -368,6 +469,20 @@ fn component_usage_with_count_string_at(
             prop_start,
             prop_end,
         )],
+        events: smallvec![],
+        slots: smallvec![],
+        has_spread_attrs: false,
+        scope_id: ScopeId::ROOT,
+        vif_guard: None,
+    }
+}
+
+fn component_usage_with_kebab_prop(component: &str, is_dynamic: bool) -> ComponentUsage {
+    ComponentUsage {
+        name: CompactString::new(component),
+        start: 0,
+        end: 0,
+        props: smallvec![passed_prop("user-name", Some("'x'"), is_dynamic)],
         events: smallvec![],
         slots: smallvec![],
         has_spread_attrs: false,

--- a/crates/vize_croquis_cf/src/analyzers/props_validation.rs
+++ b/crates/vize_croquis_cf/src/analyzers/props_validation.rs
@@ -172,7 +172,9 @@ pub fn analyze_props_validation(
                 }
 
                 // Check if this prop is declared
-                let Some(prop_info) = child_props_info.props.get(passed_prop.name) else {
+                let Some(prop_info) =
+                    lookup_declared_prop(&child_props_info.props, passed_prop.name)
+                else {
                     let issue = PropsValidationIssue {
                         parent_file: parent_id,
                         child_file: child_id,
@@ -335,7 +337,23 @@ fn define_props_offset(entry: &ModuleEntry) -> u32 {
 }
 
 fn has_passed_prop(usage: &PassedComponentUsage<'_>, name: &str) -> bool {
-    usage.props.iter().any(|prop| prop.name == name)
+    // Vue normalizes kebab-case attribute names to camelCase props, so compare
+    // the camelized written name against the declared (camelCase) key.
+    usage
+        .props
+        .iter()
+        .any(|prop| prop.name == name || to_camel_case(prop.name) == name)
+}
+
+/// Look up a declared prop by name, normalizing the written attribute name
+/// from kebab-case to camelCase (Vue's attribute-to-prop convention).
+fn lookup_declared_prop<'a>(
+    props: &'a FxHashMap<CompactString, PropInfo>,
+    written_name: &str,
+) -> Option<&'a PropInfo> {
+    props
+        .get(written_name)
+        .or_else(|| props.get(to_camel_case(written_name).as_str()))
 }
 
 fn actual_literal_type(prop: &PassedPropInfo<'_>) -> Option<CompactString> {
@@ -498,6 +516,21 @@ fn to_pascal_case(s: &str) -> String {
             }
         })
         .collect()
+}
+
+/// Convert kebab-case to camelCase (Vue's attribute-name-to-prop convention).
+#[inline]
+fn to_camel_case(s: &str) -> String {
+    let mut parts = s.split('-');
+    let mut result = String::from(parts.next().unwrap_or_default());
+    for part in parts {
+        let mut chars = part.chars();
+        if let Some(c) = chars.next() {
+            result.extend(c.to_uppercase());
+            result.extend(chars);
+        }
+    }
+    result
 }
 
 /// Check if an attribute name is a built-in HTML/Vue attribute.


### PR DESCRIPTION
## Summary
Kebab-case prop bindings like `:user-name` (and static `user-name="x"`) against a camelCase-declared prop (`userName`) emitted two false diagnostics on the parent: an Error `MissingRequiredProp(userName)` and a Warning `UndeclaredProp(user-name)`.

Vue normalizes kebab-case attribute names to camelCase props, but the required-prop check and the undeclared-prop lookup in `props_validation.rs` compared the raw written attribute name against the camelCase declared key with no normalization. (The component-NAME comparison in the same file already normalizes via `component_names_match` / `to_pascal_case`.)

## Fix
- Added a `to_camel_case` helper alongside the existing `to_pascal_case`.
- `has_passed_prop` now also matches the camelized written name against the declared key (required-prop check).
- New `lookup_declared_prop` camelizes the written name before looking up declared keys (undeclared-prop check), preserving the downstream type-mismatch behavior.

Both fixes cover dynamic (`:user-name`) and static (`user-name="x"`) attributes. Genuinely-missing required props are still reported.

## Tests
- `test_kebab_case_prop_binding_matches_camel_case_declared_prop`: `:user-name` and `user-name="x"` vs declared `userName` produce no MissingRequiredProp/UndeclaredProp.
- `test_genuinely_missing_required_prop_still_reported`: omitting `userName` entirely still reports MissingRequiredProp(userName).

`cargo test -p vize_croquis_cf` passes (121 tests); lib clippy clean; fmt clean.

Closes #1193

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1296"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783602494&installation_id=136613492&pr_number=1296&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1296&signature=090010026e38b47fe560821a0c6de3a54500b4d1c5ec5c39600123a041208dcb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->