### PR TITLE
fix(atelier_sfc): defineProps with built-in utility types (Partial/Pick/Omit/Required/Readonly/Record) silently emits no props declaration

### DIFF
--- a/crates/vize_atelier_sfc/src/compile_script/inline/tests.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/inline/tests.rs
@@ -535,6 +535,79 @@ defineProps<{ [K in Keys]: number } & { [K in Keys as `prop-${K}`]?: boolean }>(
     }
 
     #[test]
+    fn test_define_props_type_only_builtin_utility_types() {
+        // Regression for #1176: built-in TS utility types over a referenced
+        // interface/alias must resolve to a runtime props declaration instead
+        // of silently emitting nothing.
+        let cases: &[(&str, &[&str])] = &[
+            (
+                "interface Props { a: string; b: number }\ndefineProps<Partial<Props>>()",
+                &[
+                    "a: { type: String, required: false }",
+                    "b: { type: Number, required: false }",
+                ],
+            ),
+            (
+                "interface Props { a?: string; b?: number }\ndefineProps<Required<Props>>()",
+                &[
+                    "a: { type: String, required: true }",
+                    "b: { type: Number, required: true }",
+                ],
+            ),
+            (
+                "interface Props { a: string; b: number }\ndefineProps<Readonly<Props>>()",
+                &[
+                    "a: { type: String, required: true }",
+                    "b: { type: Number, required: true }",
+                ],
+            ),
+            (
+                "interface Props { a: string; b: number }\ndefineProps<Pick<Props, 'a'>>()",
+                &["a: { type: String, required: true }"],
+            ),
+            (
+                "interface Props { a: string; b: number }\ndefineProps<Omit<Props, 'a'>>()",
+                &["b: { type: Number, required: true }"],
+            ),
+            (
+                "defineProps<Record<'a' | 'b', string>>()",
+                &[
+                    "a: { type: String, required: true }",
+                    "b: { type: String, required: true }",
+                ],
+            ),
+        ];
+
+        for (content, expected) in cases {
+            let output = compile_setup(content);
+            let normalized: String = output
+                .split_whitespace()
+                .collect::<Vec<_>>()
+                .join(" ")
+                .into();
+            assert!(
+                normalized.contains("props:"),
+                "expected a props declaration for `{content}`, got:\n{output}"
+            );
+            for needle in *expected {
+                assert!(
+                    normalized.contains(needle),
+                    "expected `{needle}` for `{content}`, got:\n{output}"
+                );
+            }
+        }
+
+        // `Pick`/`Omit` must drop the filtered-out keys entirely.
+        let pick = compile_setup(
+            "interface Props { a: string; b: number }\ndefineProps<Pick<Props, 'a'>>()",
+        );
+        assert!(
+            !pick.contains("b:"),
+            "expected `b` to be dropped by Pick, got:\n{pick}"
+        );
+    }
+
+    #[test]
     fn test_define_props_type_only_conditional_indexed_and_template_key_types() {
         let content = r#"
 defineProps<{

--- a/crates/vize_atelier_sfc/src/script/type_resolution.rs
+++ b/crates/vize_atelier_sfc/src/script/type_resolution.rs
@@ -144,6 +144,13 @@ fn resolve_type_to_object_body_inner(
         return Some(merged);
     }
 
+    // Built-in TS utility types (`Partial<T>`, `Pick<T, K>`, ...) are not stored
+    // in the interface/alias maps, so resolve them structurally by transforming
+    // the member set of their inner type argument.
+    if let Some(body) = resolve_utility_type(trimmed, interfaces, type_aliases, stack) {
+        return Some(body);
+    }
+
     let base_name = strip_generic_params(trimmed);
     if !stack.insert(base_name.to_compact_string()) {
         return None;
@@ -154,6 +161,203 @@ fn resolve_type_to_object_body_inner(
 
     stack.remove(base_name);
     resolved
+}
+
+/// A single object member parsed out of a resolved type-literal body, e.g. the
+/// `a?: string` in `{ a?: string; b: number }`.
+struct Member {
+    key: String,
+    optional: bool,
+    readonly: bool,
+    ty: String,
+}
+
+/// Resolve a TS built-in utility type (`Partial`/`Required`/`Readonly`/`Pick`/
+/// `Omit`/`Record`) to an object-literal member body, or `None` when `type_expr`
+/// is not one of those (or its argument can't be resolved structurally).
+fn resolve_utility_type(
+    type_expr: &str,
+    interfaces: &FxHashMap<String, String>,
+    type_aliases: &FxHashMap<String, String>,
+    stack: &mut FxHashSet<String>,
+) -> Option<String> {
+    let (name, args) = split_generic_call(type_expr)?;
+    let type_args = split_top_level(args, ',');
+
+    match name {
+        "Partial" | "Required" | "Readonly" => {
+            let inner = type_args.first()?;
+            let body = resolve_type_to_object_body_inner(inner, interfaces, type_aliases, stack)?;
+            let mut members = parse_members(&body);
+            for member in &mut members {
+                match name {
+                    "Partial" => member.optional = true,
+                    "Required" => member.optional = false,
+                    "Readonly" => member.readonly = true,
+                    _ => unreachable!(),
+                }
+            }
+            Some(render_members(&members))
+        }
+        "Pick" | "Omit" => {
+            let inner = type_args.first()?;
+            let keys_arg = type_args.get(1)?;
+            let body = resolve_type_to_object_body_inner(inner, interfaces, type_aliases, stack)?;
+            let keys = parse_string_literal_union(keys_arg);
+            let members: Vec<Member> = parse_members(&body)
+                .into_iter()
+                .filter(|m| {
+                    let contains = keys.iter().any(|k| k == m.key.as_str());
+                    if name == "Pick" { contains } else { !contains }
+                })
+                .collect();
+            Some(render_members(&members))
+        }
+        "Record" => {
+            let keys_arg = type_args.first()?;
+            let value_arg = type_args.get(1)?;
+            let keys = parse_string_literal_union(keys_arg);
+            if keys.is_empty() {
+                return None;
+            }
+            let value = value_arg.trim();
+            let members: Vec<Member> = keys
+                .into_iter()
+                .map(|key| Member {
+                    key,
+                    optional: false,
+                    readonly: false,
+                    ty: value.to_compact_string(),
+                })
+                .collect();
+            Some(render_members(&members))
+        }
+        _ => None,
+    }
+}
+
+/// Split a generic type reference `Name<args>` into `("Name", "args")`.
+fn split_generic_call(type_expr: &str) -> Option<(&str, &str)> {
+    let open = type_expr.find('<')?;
+    if !type_expr.trim_end().ends_with('>') {
+        return None;
+    }
+    let close = type_expr.rfind('>')?;
+    if close <= open {
+        return None;
+    }
+    let name = type_expr[..open].trim();
+    let args = type_expr[open + 1..close].trim();
+    Some((name, args))
+}
+
+/// Parse a resolved object-literal member body (`a?: string; b: number`) into
+/// individual members.
+fn parse_members(body: &str) -> Vec<Member> {
+    let mut members = Vec::new();
+    for part in split_top_level(body, ';') {
+        for sub in split_top_level(&part, ',') {
+            if let Some(member) = parse_member(&sub) {
+                members.push(member);
+            }
+        }
+    }
+    members
+}
+
+fn parse_member(part: &str) -> Option<Member> {
+    let mut text = part.trim();
+    if text.is_empty() {
+        return None;
+    }
+
+    let mut readonly = false;
+    if let Some(rest) = text.strip_prefix("readonly ") {
+        readonly = true;
+        text = rest.trim();
+    }
+
+    let colon = find_top_level_colon(text)?;
+    let mut key = text[..colon].trim();
+    let ty = text[colon + 1..].trim();
+
+    let optional = key.ends_with('?');
+    if optional {
+        key = key[..key.len() - 1].trim();
+    }
+    if key.is_empty() || ty.is_empty() {
+        return None;
+    }
+
+    Some(Member {
+        key: key.to_compact_string(),
+        optional,
+        readonly,
+        ty: ty.to_compact_string(),
+    })
+}
+
+fn find_top_level_colon(text: &str) -> Option<usize> {
+    let mut depth = 0i32;
+    let mut prev = '\0';
+    for (idx, ch) in text.char_indices() {
+        match ch {
+            '{' | '<' | '(' | '[' => depth += 1,
+            '}' | ')' | ']' => {
+                if depth > 0 {
+                    depth -= 1;
+                }
+            }
+            '>' => {
+                if prev != '=' && depth > 0 {
+                    depth -= 1;
+                }
+            }
+            ':' if depth == 0 => return Some(idx),
+            _ => {}
+        }
+        prev = ch;
+    }
+    None
+}
+
+/// Render members back into a `key: type; ...` body matching the resolver's
+/// existing output shape.
+fn render_members(members: &[Member]) -> String {
+    let mut out = String::default();
+    for member in members {
+        if !out.is_empty() {
+            out.push_str("; ");
+        }
+        if member.readonly {
+            out.push_str("readonly ");
+        }
+        out.push_str(&member.key);
+        if member.optional {
+            out.push('?');
+        }
+        out.push_str(": ");
+        out.push_str(&member.ty);
+    }
+    out
+}
+
+/// Parse a string-literal key argument (`'a'` or `'a' | 'b'`) into the set of
+/// bare key names. Returns empty when the argument isn't a string-literal union.
+fn parse_string_literal_union(arg: &str) -> Vec<String> {
+    let mut keys = Vec::new();
+    for part in split_top_level(arg, '|') {
+        let trimmed = part.trim();
+        let unquoted = trimmed
+            .strip_prefix('\'')
+            .and_then(|s| s.strip_suffix('\''))
+            .or_else(|| trimmed.strip_prefix('"').and_then(|s| s.strip_suffix('"')));
+        match unquoted {
+            Some(key) => keys.push(key.to_compact_string()),
+            None => return Vec::new(),
+        }
+    }
+    keys
 }
 
 fn strip_generic_params(name: &str) -> &str {


### PR DESCRIPTION
## Summary
Type-only `defineProps` resolution stripped generic params and looked up only the bare name in the interfaces/type_aliases maps. Built-in TS utility types (`Partial`, `Pick`, `Omit`, `Required`, `Readonly`, `Record`) are not in those maps, so resolution returned `None` and no `props:` declaration was emitted — props silently became fallthrough attributes.

## Fix
In `script/type_resolution.rs`, resolve built-in utility types structurally before falling back to the name lookup:
- `Partial` / `Required` / `Readonly` resolve the inner type and toggle the optional/readonly modifier on every member.
- `Pick` / `Omit` resolve the inner type and filter members by the string-literal key union.
- `Record` synthesizes members from the literal key union with the value type.

The resolved object-literal body flows through the existing prop extraction path unchanged.

## Test
Added `test_define_props_type_only_builtin_utility_types` covering all six utility types (including that `Pick`/`Omit` drop filtered keys), asserting the expected `props:` declarations are emitted.

Closes #1176

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1297"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783602628&installation_id=136613492&pr_number=1297&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1297&signature=b5dcc1569eb635ffe851932e92f9ef29e7ce1a451d5fdac45f9ac1408ec05d8b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->