### PR TITLE
fix(atelier_core): keep option-modified v-on events as distinct props

### DIFF
--- a/crates/vize_atelier_core/src/codegen.rs
+++ b/crates/vize_atelier_core/src/codegen.rs
@@ -918,6 +918,36 @@ mod tests {
     }
 
     #[test]
+    fn test_codegen_v_on_option_modifier_events_are_not_merged() {
+        // Issue #1172: events differing only by an option modifier
+        // (.once/.capture/.passive) must compile to distinct props and never
+        // be merged under one key.
+        let once = result_output(&compile!(r#"<div @click="a" @click.once="b"></div>"#));
+        assert!(
+            once.contains("onClick: a") && once.contains("onClickOnce: b"),
+            "@click and @click.once should be distinct props. Got:\n{}",
+            once
+        );
+        assert!(
+            !once.contains("onClick: ["),
+            "@click and @click.once must not be merged into an array. Got:\n{}",
+            once
+        );
+
+        let capture = result_output(&compile!(r#"<div @click.capture="a" @click="b"></div>"#));
+        assert!(
+            capture.contains("onClickCapture: a") && capture.contains("onClick: b"),
+            "@click.capture and @click should be distinct props. Got:\n{}",
+            capture
+        );
+        assert!(
+            !capture.contains("onClick: ["),
+            "@click.capture and @click must not be merged into an array. Got:\n{}",
+            capture
+        );
+    }
+
+    #[test]
     fn test_codegen_scoped_slot_params_stay_local_in_handlers() {
         use crate::options::{CodegenOptions, TransformOptions};
         use crate::parser::parse;

--- a/crates/vize_atelier_core/src/codegen/props/events.rs
+++ b/crates/vize_atelier_core/src/codegen/props/events.rs
@@ -78,20 +78,27 @@ pub fn von_event_key_for(
     name
 }
 
-/// Get the event key for a v-on directive (e.g., "onClick", "onKeyupEnter")
-pub(super) fn get_von_event_key(dir: &DirectiveNode<'_>) -> Option<String> {
+/// Get the event key for a v-on directive (e.g., "onClick", "onClickOnce").
+///
+/// Delegates to [`von_event_key_for`] so the merge key includes the
+/// capitalized option modifiers (`capture`/`once`/`passive`). This keeps the
+/// scan/merge path consistent with the single-handler emission path, so events
+/// differing only by an option modifier (`@click` vs `@click.once`) get
+/// distinct keys and are never merged into one prop.
+pub(super) fn get_von_event_key(dir: &DirectiveNode<'_>, is_plain_element: bool) -> Option<String> {
     if dir.name != "on" {
         return None;
     }
     if let Some(ExpressionNode::Simple(exp)) = &dir.arg {
         if exp.is_static {
-            let camelized = camelize(exp.content.as_str());
-            let mut key = String::from("on");
-            if let Some(first) = camelized.chars().next() {
-                key.push(first.to_uppercase().next().unwrap_or(first));
-                key.push_str(&camelized[first.len_utf8()..]);
-            }
-            Some(key)
+            // The `on:` case-preserving form only applies to user-authored v-on
+            // directives (those carry a `raw_name`).
+            let on_plain_element = is_plain_element && dir.raw_name.is_some();
+            Some(von_event_key_for(
+                exp.content.as_str(),
+                on_plain_element,
+                dir.modifiers.iter().map(|m| m.content.as_str()),
+            ))
         } else {
             None // Dynamic events can't be merged
         }
@@ -124,7 +131,7 @@ pub(super) fn generate_merged_event_handlers(
     let mut handler_idx = 0;
     for p in props {
         if let PropNode::Directive(dir) = p
-            && let Some(key) = get_von_event_key(dir)
+            && let Some(key) = get_von_event_key(dir, ctx.props_is_plain_element)
             && key == target_event_key
         {
             if handler_idx > 0 {

--- a/crates/vize_atelier_core/src/codegen/props/generate.rs
+++ b/crates/vize_atelier_core/src/codegen/props/generate.rs
@@ -490,7 +490,7 @@ fn generate_props_object_inner(
                 if is_supported_directive(dir) {
                     // Check for duplicate v-on events that should be merged into arrays
                     if dir.name == "on"
-                        && let Some(event_key) = get_von_event_key(dir)
+                        && let Some(event_key) = get_von_event_key(dir, ctx.props_is_plain_element)
                     {
                         let count = scan.event_counts.count(&event_key);
                         if count > 1 {

--- a/crates/vize_atelier_core/src/codegen/props/scan.rs
+++ b/crates/vize_atelier_core/src/codegen/props/scan.rs
@@ -260,7 +260,7 @@ impl<'props> PropsScan<'props> {
                 if !self.has_inline_handler && has_inline_handler(ctx, dir) {
                     self.has_inline_handler = true;
                 }
-                if let Some(event_key) = get_von_event_key(dir) {
+                if let Some(event_key) = get_von_event_key(dir, ctx.props_is_plain_element) {
                     self.event_counts.observe(event_key);
                 }
             }


### PR DESCRIPTION
## Problem
`get_von_event_key` (codegen/props/events.rs) computed the v-on merge key by camelizing only the event argument and ignoring the option modifiers (`capture`/`once`/`passive`), while the single-handler emission path uses `von_event_key_for`, which appends the capitalized modifier. The scan counted events with the modifier-blind key, so `@click` and `@click.once` collided and were merged into `{ onClick: [a, b] }` — dropping the `.once` (it fired on every event) and corrupting the emitted `dynamicProps` array.

## Fix
Make `get_von_event_key` delegate to `von_event_key_for` (the shared key function), threading the plain-element flag through the scan/merge callsites (scan.rs, generate.rs, the merged-handler matcher). Option-modified events now get distinct keys (`onClick`, `onClickOnce`, `onClickCapture`) and are never merged.

System modifiers like `.stop` still produce the same key (no key change), so legitimate same-event merging (`@click` + `@click.stop`) is unaffected.

## Tests
Added `test_codegen_v_on_option_modifier_events_are_not_merged`:
- `<div @click="a" @click.once="b">` -> `onClick: a` and `onClickOnce: b`, never `onClick: [`.
- `<div @click.capture="a" @click="b">` -> `onClickCapture: a` and `onClick: b`, never `onClick: [`.

The existing `@click` + `@click.stop` merge test continues to pass.

Closes #1172

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1299"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783602711&installation_id=136613492&pr_number=1299&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1299&signature=2dbee3fbdb755d33d0b677d3b389f70bc2896b36175c78d2f30881f9c21f2cef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->