### PR TITLE
test(compiler): add backend parity coverage for core directives

### DIFF
--- a/tests/expected/vapor/parity-core-directives.snap
+++ b/tests/expected/vapor/parity-core-directives.snap
@@ -1,0 +1,128 @@
+===
+name: parity v-pre
+options: vapor
+--- INPUT ---
+<div v-pre :id="raw" @click="raw">{{ raw }}</div>
+--- OUTPUT ---
+import { template as _template } from 'vue';
+const t0 = _template("<div :id=\"raw\" @click=\"raw\">{{ raw }}</div>", true)
+
+export function render(_ctx) {
+  const n0 = t0()
+  return n0
+}
+===
+name: parity v-cloak
+options: vapor
+--- INPUT ---
+<div v-cloak>{{ msg }}</div>
+--- OUTPUT ---
+import { txt as _txt, toDisplayString as _toDisplayString, setText as _setText, renderEffect as _renderEffect, template as _template } from 'vue';
+const t0 = _template("<div> </div>", true)
+
+export function render(_ctx) {
+  const n0 = t0()
+  const x0 = _txt(n0)
+  n0.removeAttribute("v-cloak")
+  _renderEffect(() => _setText(x0, _toDisplayString(_ctx.msg)))
+  return n0
+}
+===
+name: parity custom directive with arg and modifiers
+options: vapor
+--- INPUT ---
+<div v-focus:top.lazy="value" />
+--- OUTPUT ---
+import { resolveDirective as _resolveDirective, withDirectives as _withDirectives, template as _template } from 'vue';
+const t0 = _template("<div></div>", true)
+
+export function render(_ctx) {
+  const _directive_focus = _resolveDirective("focus")
+  const n0 = t0()
+  _withDirectives(n0, [[_directive_focus, _ctx.value, "top", { lazy: true }]])
+  return n0
+}
+===
+name: parity custom directive on component (payload loss)
+options: vapor
+--- INPUT ---
+<MyComp v-focus:top.lazy="value" />
+--- OUTPUT ---
+import { resolveDirective as _resolveDirective, resolveComponent as _resolveComponent, withDirectives as _withDirectives, createComponentWithFallback as _createComponentWithFallback } from 'vue';
+
+export function render(_ctx) {
+  const _component_MyComp = _resolveComponent("MyComp")
+  const _directive_focus = _resolveDirective("focus")
+  const n0 = _createComponentWithFallback(_component_MyComp, null, null, true)
+  _withDirectives(n0, [[_directive_focus, _ctx.value, "top", { lazy: true }]])
+  return n0
+}
+===
+name: parity v-once
+options: vapor
+--- INPUT ---
+<div v-once>{{ msg }}</div>
+--- OUTPUT ---
+import { txt as _txt, toDisplayString as _toDisplayString, setText as _setText, template as _template } from 'vue';
+const t0 = _template("<div> </div>", true)
+
+export function render(_ctx) {
+  const n0 = t0()
+  const x0 = _txt(n0)
+  _setText(x0, _toDisplayString(_ctx.msg))
+  return n0
+}
+===
+name: parity Teleport
+options: vapor
+--- INPUT ---
+<Teleport to="body"><span /></Teleport>
+--- OUTPUT ---
+import { createComponent as _createComponent, VaporTeleport as _VaporTeleport, template as _template } from 'vue';
+const t0 = _template("<span></span>")
+
+export function render(_ctx) {
+  const n1 = _createComponent(_VaporTeleport, { to: () => ("body") }, {
+    "default": () => {
+      const n0 = t0()
+      return n0
+    }
+  }, true)
+  return n1
+}
+===
+name: parity KeepAlive
+options: vapor
+--- INPUT ---
+<KeepAlive><component :is="current" /></KeepAlive>
+--- OUTPUT ---
+import { createComponent as _createComponent, createDynamicComponent as _createDynamicComponent, VaporKeepAlive as _VaporKeepAlive, withVaporCtx as _withVaporCtx } from 'vue';
+
+export function render(_ctx) {
+  const n1 = _createComponent(_VaporKeepAlive, null, {
+    "default": _withVaporCtx(() => {
+      const n0 = _createDynamicComponent(() => (_ctx.current), null, null, true)
+      return n0
+    })
+  }, true)
+  return n1
+}
+===
+name: parity Suspense
+options: vapor
+--- INPUT ---
+<Suspense><AsyncComponent /></Suspense>
+--- OUTPUT ---
+import { resolveComponent as _resolveComponent, createComponentWithFallback as _createComponentWithFallback, withVaporCtx as _withVaporCtx } from 'vue';
+
+export function render(_ctx) {
+  const _component_AsyncComponent = _resolveComponent("AsyncComponent")
+  const _component_Suspense = _resolveComponent("Suspense")
+  const n1 = _createComponentWithFallback(_component_Suspense, null, {
+    "default": _withVaporCtx(() => {
+      const n0 = _createComponentWithFallback(_component_AsyncComponent)
+      return n0
+    })
+  }, true)
+  return n1
+}

--- a/tests/expected/vdom/parity-core-directives.snap
+++ b/tests/expected/vdom/parity-core-directives.snap
@@ -1,0 +1,115 @@
+===
+name: parity v-pre
+options: vdom
+--- INPUT ---
+<div v-pre :id="raw" @click="raw">{{ raw }}</div>
+--- OUTPUT ---
+import { openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+export function render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("div", {
+    ":id": "raw",
+    "@click": "raw"
+  }, "{{ raw }}"))
+}
+===
+name: parity v-cloak
+options: vdom
+--- INPUT ---
+<div v-cloak>{{ msg }}</div>
+--- OUTPUT ---
+import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+export function render(_ctx, _cache) {
+  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.msg), 1 /* TEXT */))
+}
+===
+name: parity custom directive with arg and modifiers
+options: vdom
+--- INPUT ---
+<div v-focus:top.lazy="value" />
+--- OUTPUT ---
+import { resolveDirective as _resolveDirective, withDirectives as _withDirectives, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
+
+export function render(_ctx, _cache) {
+  const _directive_focus = _resolveDirective("focus")
+
+  return _withDirectives((_openBlock(), _createElementBlock("div", null, null, 512 /* NEED_PATCH */)), [
+    [_directive_focus, _ctx.value, "top", { lazy: true }]
+  ])
+}
+===
+name: parity v-once
+options: vdom
+--- INPUT ---
+<div v-once>{{ msg }}</div>
+--- OUTPUT ---
+import { toDisplayString as _toDisplayString, createElementVNode as _createElementVNode, createTextVNode as _createTextVNode, setBlockTracking as _setBlockTracking } from "vue"
+
+export function render(_ctx, _cache) {
+  return _cache[0] || (
+    _setBlockTracking(-1, true),
+    (_cache[0] = _createElementVNode("div", null, [
+      _createTextVNode(_toDisplayString(_ctx.msg), 1 /* TEXT */)
+    ])).cacheIndex = 0,
+    _setBlockTracking(1),
+    _cache[0]
+  )
+}
+===
+name: parity v-memo
+options: vdom
+--- INPUT ---
+<div v-memo="[id]">{{ msg }}</div>
+--- OUTPUT ---
+import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock, createTextVNode as _createTextVNode, withMemo as _withMemo } from "vue"
+
+export function render(_ctx, _cache) {
+  return _withMemo([_ctx.id], () => (_openBlock(), _createElementBlock("div", null, [
+    _createTextVNode(_toDisplayString(_ctx.msg), 1 /* TEXT */)
+  ])), _cache, 0)
+}
+===
+name: parity Teleport
+options: vdom
+--- INPUT ---
+<Teleport to="body"><span /></Teleport>
+--- OUTPUT ---
+import { createElementVNode as _createElementVNode, openBlock as _openBlock, createBlock as _createBlock, Teleport as _Teleport } from "vue"
+
+export function render(_ctx, _cache) {
+  return (_openBlock(), _createBlock(_Teleport, { to: "body" }, [
+    _createElementVNode("span")
+  ]))
+}
+===
+name: parity KeepAlive
+options: vdom
+--- INPUT ---
+<KeepAlive><component :is="current" /></KeepAlive>
+--- OUTPUT ---
+import { resolveDynamicComponent as _resolveDynamicComponent, openBlock as _openBlock, createBlock as _createBlock, KeepAlive as _KeepAlive } from "vue"
+
+export function render(_ctx, _cache) {
+  return (_openBlock(), _createBlock(_KeepAlive, null, [
+    (_openBlock(), _createBlock(_resolveDynamicComponent(_ctx.current)))
+  ], 1024 /* DYNAMIC_SLOTS */))
+}
+===
+name: parity Suspense
+options: vdom
+--- INPUT ---
+<Suspense><AsyncComponent /></Suspense>
+--- OUTPUT ---
+import { resolveComponent as _resolveComponent, createVNode as _createVNode, openBlock as _openBlock, createBlock as _createBlock, Suspense as _Suspense, withCtx as _withCtx } from "vue"
+
+export function render(_ctx, _cache) {
+  const _component_AsyncComponent = _resolveComponent("AsyncComponent")
+
+  return (_openBlock(), _createBlock(_Suspense, null, {
+    default: _withCtx(() => [
+      _createVNode(_component_AsyncComponent)
+    ]),
+    _: 1 /* STABLE */
+  }))
+}

--- a/tests/fixtures/PARITY.md
+++ b/tests/fixtures/PARITY.md
@@ -1,0 +1,59 @@
+# Core-directive backend parity matrix (issue #1161)
+
+This table documents which core directives / built-in components are exercised
+per backend, and where backend behavior intentionally differs. The shared input
+matrix comes from issue #1161.
+
+The fixtures live in:
+
+- VDOM: `tests/fixtures/vdom/parity-core-directives.pkl`
+  (expected: `tests/expected/vdom/parity-core-directives.snap`)
+- Vapor: `tests/fixtures/vapor/parity-core-directives.pkl`
+  (expected: `tests/expected/vapor/parity-core-directives.snap`)
+- SSR: `crates/vize_atelier_ssr/tests/ssr_snapshot.rs`
+  (insta snapshots in `crates/vize_atelier_ssr/tests/snapshots/`)
+
+All three are run by the existing compiler test suite / CI: VDOM and Vapor via
+the `coverage` runner (`cargo run -p vize_test_runner --bin coverage`), SSR via
+`cargo test -p vize_atelier_ssr`.
+
+| Input                                            | VDOM | Vapor                | SSR  |
+| ------------------------------------------------ | ---- | -------------------- | ---- |
+| `<div v-pre :id="raw" @click="raw">{{ raw }}</div>` | yes  | yes                  | n/a* |
+| `<div v-cloak>{{ msg }}</div>`                   | yes  | yes                  | n/a* |
+| `<div v-focus:top.lazy="value" />` (element)     | yes  | yes                  | n/a* |
+| `<MyComp v-focus:top.lazy="value" />` (component) | yes  | KNOWN FAILURE (#1161)| n/a* |
+| `<div v-once>{{ msg }}</div>`                    | yes  | yes                  | n/a* |
+| `<div v-memo="[id]">{{ msg }}</div>`             | yes  | not applicable**     | n/a* |
+| `<Teleport to="body"><span /></Teleport>`        | yes  | yes (VaporTeleport)  | yes  |
+| `<KeepAlive><component :is="current" /></KeepAlive>` | yes  | yes (VaporKeepAlive) | n/a* |
+| `<Suspense><AsyncComponent /></Suspense>`        | yes  | yes (fallback)       | yes  |
+
+`yes` = a parity snapshot asserts the compiled output.
+
+\* SSR has its own dedicated snapshot surface and a different output model
+(string-concatenation render fns). The directive-payload cases (`v-pre`,
+`v-cloak`, custom directives, `v-once`, `v-memo`, `KeepAlive`) are runtime/VDOM
+concerns that do not have meaningful SSR-specific output, so they are not
+duplicated in the SSR matrix. `Teleport` and `Suspense` use dedicated SSR
+helpers and are already covered in `ssr_snapshot.rs`
+(`teleport_uses_ssr_helper`, `suspense_uses_ssr_helper`).
+
+\*\* `v-memo` is a VDOM block-caching optimization with no equivalent in the
+Vapor backend (Vapor uses fine-grained effects instead of memoized vnode
+sub-trees), so it is intentionally omitted from the Vapor matrix rather than
+marked as a failure.
+
+## Tracked known failure
+
+`vapor/parity-core-directives :: parity custom directive on component (payload
+loss)` is registered in `tests/vize_test_runner/src/coverage.rs`
+(`KNOWN_FAILURES`). When a custom directive is applied to a **component**, the
+Vapor backend currently drops the directive entirely: it emits the component
+creation with no `_resolveDirective` / `_withDirectives`, losing the binding
+value, argument, and modifiers. The expected snapshot encodes the desired
+payload-preserving output (mirroring the VDOM backend) and therefore fails
+against today's compiler. This is intentional per the #1161 acceptance criteria
+("at least one snapshot fails on current Vapor custom-directive payload loss
+before the implementation fix"). The element-level custom-directive case
+(`v-focus:top.lazy` on a `<div>`) already preserves its payload and passes.

--- a/tests/fixtures/PARITY.md
+++ b/tests/fixtures/PARITY.md
@@ -17,17 +17,17 @@ All three are run by the existing compiler test suite / CI: VDOM and Vapor via
 the `coverage` runner (`cargo run -p vize_test_runner --bin coverage`), SSR via
 `cargo test -p vize_atelier_ssr`.
 
-| Input                                            | VDOM | Vapor                | SSR  |
-| ------------------------------------------------ | ---- | -------------------- | ---- |
-| `<div v-pre :id="raw" @click="raw">{{ raw }}</div>` | yes  | yes                  | n/a* |
-| `<div v-cloak>{{ msg }}</div>`                   | yes  | yes                  | n/a* |
-| `<div v-focus:top.lazy="value" />` (element)     | yes  | yes                  | n/a* |
-| `<MyComp v-focus:top.lazy="value" />` (component) | yes  | KNOWN FAILURE (#1161)| n/a* |
-| `<div v-once>{{ msg }}</div>`                    | yes  | yes                  | n/a* |
-| `<div v-memo="[id]">{{ msg }}</div>`             | yes  | not applicable**     | n/a* |
-| `<Teleport to="body"><span /></Teleport>`        | yes  | yes (VaporTeleport)  | yes  |
-| `<KeepAlive><component :is="current" /></KeepAlive>` | yes  | yes (VaporKeepAlive) | n/a* |
-| `<Suspense><AsyncComponent /></Suspense>`        | yes  | yes (fallback)       | yes  |
+| Input                                                | VDOM | Vapor                 | SSR   |
+| ---------------------------------------------------- | ---- | --------------------- | ----- |
+| `<div v-pre :id="raw" @click="raw">{{ raw }}</div>`  | yes  | yes                   | n/a\* |
+| `<div v-cloak>{{ msg }}</div>`                       | yes  | yes                   | n/a\* |
+| `<div v-focus:top.lazy="value" />` (element)         | yes  | yes                   | n/a\* |
+| `<MyComp v-focus:top.lazy="value" />` (component)    | yes  | KNOWN FAILURE (#1161) | n/a\* |
+| `<div v-once>{{ msg }}</div>`                        | yes  | yes                   | n/a\* |
+| `<div v-memo="[id]">{{ msg }}</div>`                 | yes  | not applicable\*\*    | n/a\* |
+| `<Teleport to="body"><span /></Teleport>`            | yes  | yes (VaporTeleport)   | yes   |
+| `<KeepAlive><component :is="current" /></KeepAlive>` | yes  | yes (VaporKeepAlive)  | n/a\* |
+| `<Suspense><AsyncComponent /></Suspense>`            | yes  | yes (fallback)        | yes   |
 
 `yes` = a parity snapshot asserts the compiled output.
 

--- a/tests/fixtures/vapor/parity-core-directives.pkl
+++ b/tests/fixtures/vapor/parity-core-directives.pkl
@@ -1,0 +1,55 @@
+// Vapor: core-directive backend-parity matrix (issue #1161)
+//
+// Mirrors the shared parity matrix in tests/fixtures/PARITY.md. These cases
+// capture what the Vapor backend currently emits for the core-directive surface
+// so backend-specific regressions are caught alongside VDOM and SSR.
+//
+// NOTE: "parity custom directive on component (payload loss)" intentionally
+// exposes the Vapor custom-directive payload-loss gap tracked in #1161: when a
+// custom directive is applied to a component the Vapor backend currently drops
+// the whole directive (no _resolveDirective / _withDirectives is emitted),
+// losing the binding value, argument and modifiers. The matching expected
+// snapshot encodes the desired payload-preserving output (mirroring the VDOM
+// backend), so it FAILS against today's compiler. It is registered as a
+// documented KNOWN_FAILURE in tests/vize_test_runner/src/coverage.rs so CI stays
+// green while the gap stays visible. Do NOT rewrite the expected snapshot to
+// match current output; it must keep failing until the compiler bug is fixed.
+
+amends "CompilerFixture.pkl"
+
+mode = "vapor"
+
+cases {
+  new {
+    name = "parity v-pre"
+    input = #"<div v-pre :id="raw" @click="raw">{{ raw }}</div>"#
+  }
+  new {
+    name = "parity v-cloak"
+    input = "<div v-cloak>{{ msg }}</div>"
+  }
+  new {
+    name = "parity custom directive with arg and modifiers"
+    input = #"<div v-focus:top.lazy="value" />"#
+  }
+  new {
+    name = "parity custom directive on component (payload loss)"
+    input = #"<MyComp v-focus:top.lazy="value" />"#
+  }
+  new {
+    name = "parity v-once"
+    input = "<div v-once>{{ msg }}</div>"
+  }
+  new {
+    name = "parity Teleport"
+    input = #"<Teleport to="body"><span /></Teleport>"#
+  }
+  new {
+    name = "parity KeepAlive"
+    input = #"<KeepAlive><component :is="current" /></KeepAlive>"#
+  }
+  new {
+    name = "parity Suspense"
+    input = "<Suspense><AsyncComponent /></Suspense>"
+  }
+}

--- a/tests/fixtures/vdom/parity-core-directives.pkl
+++ b/tests/fixtures/vdom/parity-core-directives.pkl
@@ -1,0 +1,44 @@
+// VDom: core-directive backend-parity matrix (issue #1161)
+//
+// Mirrors the shared parity matrix in tests/fixtures/PARITY.md so that the same
+// core-directive surface is exercised against the VDOM backend that Vapor and
+// SSR are also measured against.
+
+amends "CompilerFixture.pkl"
+
+mode = "vdom"
+
+cases {
+  new {
+    name = "parity v-pre"
+    input = #"<div v-pre :id="raw" @click="raw">{{ raw }}</div>"#
+  }
+  new {
+    name = "parity v-cloak"
+    input = "<div v-cloak>{{ msg }}</div>"
+  }
+  new {
+    name = "parity custom directive with arg and modifiers"
+    input = #"<div v-focus:top.lazy="value" />"#
+  }
+  new {
+    name = "parity v-once"
+    input = "<div v-once>{{ msg }}</div>"
+  }
+  new {
+    name = "parity v-memo"
+    input = #"<div v-memo="[id]">{{ msg }}</div>"#
+  }
+  new {
+    name = "parity Teleport"
+    input = #"<Teleport to="body"><span /></Teleport>"#
+  }
+  new {
+    name = "parity KeepAlive"
+    input = #"<KeepAlive><component :is="current" /></KeepAlive>"#
+  }
+  new {
+    name = "parity Suspense"
+    input = "<Suspense><AsyncComponent /></Suspense>"
+  }
+}

--- a/tests/vize_test_runner/src/coverage.rs
+++ b/tests/vize_test_runner/src/coverage.rs
@@ -10,15 +10,25 @@ use std::path::PathBuf;
 use vize_carton::String;
 use vize_test_runner::{CompilerMode, run_fixture_tests};
 
-const MIN_VDOM_PASSED: usize = 439;
-const MIN_VAPOR_PASSED: usize = 104;
-const MIN_SFC_PASSED: usize = 166;
-const MIN_TOTAL_PASSED: usize = 709;
+const MIN_VDOM_PASSED: usize = 457;
+const MIN_VAPOR_PASSED: usize = 116;
+const MIN_SFC_PASSED: usize = 167;
+const MIN_TOTAL_PASSED: usize = 740;
 
 // Known v1 alpha fixture debt. CI allows these exact failures so existing gaps
 // do not block unrelated work, but any new failure or pass-count regression
 // fails the coverage job.
-const KNOWN_FAILURES: &[(&str, &str)] = &[];
+//
+// Core-directive backend-parity matrix (#1161): the Vapor backend drops the
+// entire directive when a custom directive is applied to a *component*
+// (no _resolveDirective / _withDirectives is emitted), losing the binding value,
+// argument and modifiers. The matching expected snapshot encodes the desired
+// payload-preserving output (mirroring the VDOM backend), so it intentionally
+// FAILS until the compiler bug is fixed. See tests/fixtures/PARITY.md.
+const KNOWN_FAILURES: &[(&str, &str)] = &[(
+    "vapor/parity-core-directives",
+    "parity custom directive on component (payload loss)",
+)];
 
 fn is_known_failure(path: &str, name: &str) -> bool {
     KNOWN_FAILURES
@@ -51,6 +61,7 @@ fn main() {
         ("vdom/v-once", CompilerMode::Vdom),
         ("vdom/dynamic-component", CompilerMode::Vdom),
         ("vdom/html-entities", CompilerMode::Vdom),
+        ("vdom/parity-core-directives", CompilerMode::Vdom),
         ("vapor/element", CompilerMode::Vapor),
         ("vapor/component", CompilerMode::Vapor),
         ("vapor/v-if", CompilerMode::Vapor),
@@ -61,6 +72,7 @@ fn main() {
         ("vapor/v-slot", CompilerMode::Vapor),
         ("vapor/v-show", CompilerMode::Vapor),
         ("vapor/edge-cases", CompilerMode::Vapor),
+        ("vapor/parity-core-directives", CompilerMode::Vapor),
         ("sfc/basic", CompilerMode::Sfc),
         ("sfc/script-setup", CompilerMode::Sfc),
         ("sfc/script-setup-advanced", CompilerMode::Sfc),
@@ -264,9 +276,15 @@ mod tests {
 
     #[test]
     fn tracks_the_current_known_failure_budget() {
-        assert_eq!(KNOWN_FAILURES.len(), 0);
+        // Exactly one tracked failure: the #1161 Vapor custom-directive
+        // payload-loss case on components. See tests/fixtures/PARITY.md.
+        assert_eq!(KNOWN_FAILURES.len(), 1);
         let unique_failures: FxHashSet<_> = KNOWN_FAILURES.iter().collect();
         assert_eq!(unique_failures.len(), KNOWN_FAILURES.len());
+        assert!(is_known_failure(
+            "vapor/parity-core-directives",
+            "parity custom directive on component (payload loss)"
+        ));
         assert!(!is_known_failure(
             "sfc/script-setup",
             "generic component with extends"


### PR DESCRIPTION
## Summary

Adds a per-backend core-directive **parity matrix** so backend-specific gaps and regressions are caught alongside each other, addressing #1161. This is a **test-only** change — no compiler behavior is modified.

New fixtures (Apple Pkl, amending `CompilerFixture.pkl`), registered in the `coverage` runner so CI runs them as part of the existing compiler test suite:

- `tests/fixtures/vdom/parity-core-directives.pkl` + `tests/expected/vdom/parity-core-directives.snap`
- `tests/fixtures/vapor/parity-core-directives.pkl` + `tests/expected/vapor/parity-core-directives.snap`

A documented parity table lives in `tests/fixtures/PARITY.md`.

## Parity matrix

| Input | VDOM | Vapor | SSR |
| --- | --- | --- | --- |
| `v-pre` (`<div v-pre :id="raw" @click="raw">{{ raw }}</div>`) | yes | yes | n/a* |
| `v-cloak` | yes | yes | n/a* |
| custom directive on element (`v-focus:top.lazy`) | yes | yes | n/a* |
| custom directive on **component** (`<MyComp v-focus:top.lazy>`) | yes | **KNOWN FAILURE (#1161)** | n/a* |
| `v-once` | yes | yes | n/a* |
| `v-memo` | yes | not applicable** | n/a* |
| `Teleport` | yes | yes (`VaporTeleport`) | yes (existing) |
| `KeepAlive` | yes | yes (`VaporKeepAlive`) | n/a* |
| `Suspense` | yes | yes (fallback) | yes (existing) |

\* SSR has a distinct string-concat output model; directive-payload cases are VDOM/runtime concerns with no meaningful SSR-specific output. `Teleport`/`Suspense` already have dedicated SSR snapshots in `crates/vize_atelier_ssr/tests/ssr_snapshot.rs`.
\*\* `v-memo` is a VDOM block-caching optimization with no Vapor equivalent, so it's intentionally omitted from the Vapor matrix rather than marked as a failure.

## Tracked known failure

`vapor/parity-core-directives :: parity custom directive on component (payload loss)` is registered in `KNOWN_FAILURES` in `tests/vize_test_runner/src/coverage.rs`. When a custom directive is applied to a **component**, the Vapor backend currently drops the directive entirely (it emits `_createComponentWithFallback(...)` with no `_resolveDirective` / `_withDirectives`), losing the binding value, argument, and modifiers. The expected snapshot encodes the **desired** payload-preserving output (mirroring the VDOM backend), so it fails against today's compiler — satisfying the #1161 acceptance criterion that "at least one snapshot fails on current Vapor custom-directive payload loss before the implementation fix." The element-level custom-directive case already preserves its payload and passes.

All other expected outputs were captured from the actual compiler, not hand-written.

## Validation

- `cargo run -p vize_test_runner --bin coverage` → exit 0; VDOM 457/457, Vapor 116/117 (1 tracked known failure), SFC 167/167, TOTAL 740/741. `MIN_*` floors updated to match.
- `cargo test -p vize_test_runner` passes (known-failure budget unit test updated to assert the one tracked entry).
- `cargo clippy -p vize_test_runner --all-targets -- -D warnings` clean; `cargo fmt --all -- --check` clean.

Closes #1161

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1300"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783602753&installation_id=136613492&pr_number=1300&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1300&signature=f705ca2c7298e1e2260a7b1aa5b7b142413a4ba1473b9c7aa713e9199571b66c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->