### PR TITLE
fix(atelier_core): escape and paren-aware split merged static style

### DIFF
--- a/crates/vize_atelier_core/src/codegen.rs
+++ b/crates/vize_atelier_core/src/codegen.rs
@@ -1135,4 +1135,35 @@ mod tests {
             output
         );
     }
+
+    #[test]
+    fn test_codegen_static_style_merged_with_dynamic_escapes_values() {
+        // Issue #1171: a static `style` merged with `:style` must JSON-escape
+        // key/value so a `"` does not terminate the JS string early.
+        let output = result_output(&compile!(r#"<div style='content:"x"' :style="s"></div>"#));
+        assert!(
+            output.contains(r#"_normalizeStyle([{"content":"\"x\""}, s])"#),
+            "static style values must be escaped. Got:\n{}",
+            output
+        );
+    }
+
+    #[test]
+    fn test_codegen_static_style_merged_with_dynamic_does_not_split_inside_parens() {
+        // Issue #1171: a `;` inside `url(...)` must not be treated as a
+        // declaration separator, and no orphan double comma must appear.
+        let output = result_output(&compile!(
+            r#"<div style="background:url(a;b);color:red" :style="s"></div>"#
+        ));
+        assert!(
+            output.contains(r#"_normalizeStyle([{"background":"url(a;b)","color":"red"}, s])"#),
+            "`;` inside parens must not split the declaration. Got:\n{}",
+            output
+        );
+        assert!(
+            !output.contains(",,"),
+            "orphan parts must not produce a double comma. Got:\n{}",
+            output
+        );
+    }
 }

--- a/crates/vize_atelier_core/src/codegen/props/directives.rs
+++ b/crates/vize_atelier_core/src/codegen/props/directives.rs
@@ -327,24 +327,29 @@ fn generate_vbind_prop(
             if let Some(static_val) = static_style {
                 let emit_static_style = |ctx: &mut CodegenContext| {
                     ctx.push("{");
-                    for (i, part) in static_val
-                        .split(';')
-                        .filter(|s| !s.trim().is_empty())
-                        .enumerate()
-                    {
-                        if i > 0 {
+                    // Mirror Vue's `parseStringStyle` (regex `/;(?![^(]*\))/`): a `;`
+                    // inside parentheses (e.g. `url(a;b)`) is not a declaration
+                    // separator, and only the first `:` separates key from value.
+                    let mut emitted = 0;
+                    for declaration in split_style_declarations(static_val) {
+                        let declaration = declaration.trim();
+                        if declaration.is_empty() {
+                            continue;
+                        }
+                        // Skip orphan parts with no `:`; only push the separating
+                        // comma once a valid key/value pair is confirmed.
+                        let Some((key, value)) = declaration.split_once(':') else {
+                            continue;
+                        };
+                        if emitted > 0 {
                             ctx.push(",");
                         }
-                        let parts: Vec<&str> = part.splitn(2, ':').collect();
-                        if parts.len() == 2 {
-                            let key = parts[0].trim();
-                            let value = parts[1].trim();
-                            ctx.push("\"");
-                            ctx.push(key);
-                            ctx.push("\":\"");
-                            ctx.push(value);
-                            ctx.push("\"");
-                        }
+                        emitted += 1;
+                        ctx.push("\"");
+                        ctx.push(&escape_js_string(key.trim()));
+                        ctx.push("\":\"");
+                        ctx.push(&escape_js_string(value.trim()));
+                        ctx.push("\"");
                     }
                     ctx.push("}");
                 };
@@ -371,6 +376,29 @@ fn generate_vbind_prop(
     } else {
         ctx.push("undefined");
     }
+}
+
+/// Split a static `style` attribute value into declarations on each `;` that is
+/// not inside parentheses, mirroring Vue's `parseStringStyle` regex
+/// `/;(?![^(]*\))/`. A `;` inside `url(a;b)` therefore stays within one
+/// declaration instead of being treated as a separator.
+fn split_style_declarations(value: &str) -> Vec<&str> {
+    let mut declarations = Vec::new();
+    let mut depth: i32 = 0;
+    let mut start = 0;
+    for (i, ch) in value.char_indices() {
+        match ch {
+            '(' => depth += 1,
+            ')' if depth > 0 => depth -= 1,
+            ';' if depth == 0 => {
+                declarations.push(&value[start..i]);
+                start = i + ch.len_utf8();
+            }
+            _ => {}
+        }
+    }
+    declarations.push(&value[start..]);
+    declarations
 }
 
 /// Generate v-on directive as a prop


### PR DESCRIPTION
## Problem
When a static `style` attribute co-exists with a dynamic `:style` binding, `emit_static_style` (codegen/props/directives.rs) built the static object by splitting the raw value on every `;` and pushing keys/values into JS string literals with no escaping. Three defects:
1. No escaping: a `"` in a value terminated the JS string early — a syntax error (`{"content":""x""}`).
2. Split on bare `;` inside parens: a `;` inside `url(...)` was treated as a separator, dropping content (`{"background":"url(a",,"color":"red"}`).
3. Comma before length check: an orphan part with no `:` still pushed a comma, yielding `,,`.

## Fix
Mirror Vue's `parseStringStyle` (regex `/;(?![^(]*\))/`):
- New `split_style_declarations` helper splits on `;` only when not inside `(...)`.
- Split key/value on the first `:` only (`split_once`).
- Run both key and value through `escape_js_string` (already used for class merging in the same file).
- Track an `emitted` counter and only push the separating comma after a valid key/value pair is confirmed.

Output now matches Vue:
```js
style: _normalizeStyle([{"content":"\"x\""}, s])
style: _normalizeStyle([{"background":"url(a;b)","color":"red"}, s])
```

## Tests
Added in codegen.rs:
- `test_codegen_static_style_merged_with_dynamic_escapes_values` — `style='content:"x"'` emits the escaped `{"content":"\"x\""}`.
- `test_codegen_static_style_merged_with_dynamic_does_not_split_inside_parens` — `style="background:url(a;b);color:red"` keeps `url(a;b)` intact and produces no `,,`.

Closes #1171