### PR TITLE
fix(atelier_core): reject v-model with an arg on a plain element

### DIFF
--- a/crates/vize_atelier_core/src/transform/element.rs
+++ b/crates/vize_atelier_core/src/transform/element.rs
@@ -270,6 +270,16 @@ fn process_element_props<'a>(ctx: &mut TransformContext<'a>, el: &mut Box<'a, El
                 invalid_model_indices.push(idx);
                 continue;
             }
+
+            // v-model with an argument (static or dynamic) is a component-only
+            // feature. On a plain element Vue raises a hard compile error and
+            // generates no binding, so reject it here before emitting anything.
+            if !is_component && dir.arg.is_some() {
+                ctx.on_error(ErrorCode::VModelArgOnElement, Some(dir.loc.clone()));
+                invalid_model_indices.push(idx);
+                continue;
+            }
+
             let value_exp = String::new(value_exp);
 
             // Check if arg is dynamic
@@ -717,5 +727,57 @@ mod tests {
             transform_errors(r#"<div v-for="item in items"><input v-model="item.value" /></div>"#);
 
         assert!(errors.is_empty(), "Unexpected errors: {:?}", errors);
+    }
+
+    fn assert_v_model_arg_on_element_rejected(source: &str) {
+        let allocator = Bump::new();
+        let (mut root, errors) = parse(&allocator, source);
+        assert!(errors.is_empty(), "Parse errors: {:?}", errors);
+
+        let mut ctx =
+            TransformContext::new(&allocator, root.source.clone(), TransformOptions::default());
+        match &mut root.children[0] {
+            TemplateChildNode::Element(el) => {
+                transform_element(&mut ctx, el);
+
+                // No v-model binding is generated: the directive itself is
+                // dropped and no `onUpdate:*` handler is emitted.
+                assert!(
+                    !el.props.iter().any(|prop| matches!(
+                        prop,
+                        PropNode::Directive(dir) if dir.name == "model"
+                    )),
+                    "v-model directive should be removed for {source}"
+                );
+                assert!(
+                    !el.props.iter().any(|prop| matches!(
+                        prop,
+                        PropNode::Directive(dir) if dir.name == "on"
+                    )),
+                    "no update handler should be emitted for {source}"
+                );
+            }
+            other => panic!(
+                "Expected ElementNode, got {:?}",
+                std::mem::discriminant(other)
+            ),
+        }
+
+        assert_eq!(ctx.errors.len(), 1, "expected one error for {source}");
+        assert_eq!(ctx.errors[0].code, ErrorCode::VModelArgOnElement);
+    }
+
+    #[test]
+    fn test_transform_v_model_static_arg_on_element_reports_error() {
+        // Issue #1169: v-model with an argument is component-only; on a plain
+        // element it must be a hard error with no binding generated.
+        assert_v_model_arg_on_element_rejected(r#"<input v-model:foo="bar" />"#);
+    }
+
+    #[test]
+    fn test_transform_v_model_dynamic_arg_on_element_reports_error() {
+        // Issue #1169: a dynamic arg on a plain element is rejected too, so the
+        // three competing update mechanisms never fire.
+        assert_v_model_arg_on_element_rejected(r#"<input v-model:[dynKey]="value" />"#);
     }
 }


### PR DESCRIPTION
## Problem
v-model with an argument is a component-only feature. On a plain element Vue raises the hard compile error `X_V_MODEL_ARG_ON_ELEMENT` and generates no binding. vize silently accepted it:
- Static arg (`v-model:foo="bar"`): the native branch hardcoded the handler key to `update:modelValue` and never read the `foo` arg, so the arg was dropped and no diagnostic produced.
- Dynamic arg (`v-model:[dynKey]="value"`): `generate_vmodel_prop` emitted the dynamic-arg prop pair, the native branch still emitted `onUpdate:modelValue`, and `has_vmodel_directive` still added the `_vModelText` directive — three competing update mechanisms on one element.

`ErrorCode::VModelArgOnElement` already existed in vize_relief but was never emitted from any transform.

## Fix
In the native v-model collection path (transform/element.rs), detect a present `dir.arg`, report `ErrorCode::VModelArgOnElement`, and push the directive index onto `invalid_model_indices` so it is removed from the element's props (the same mechanism used for `VModelNoExpression`/`VModelOnScope`).

Removing the directive means the downstream codegen paths (`generate_vmodel_prop`, `has_vmodel_directive`) no longer find it, so none of the competing update mechanisms are emitted — no separate gating needed. No vize_relief change was required; the error code was already fully defined there.

## Tests
Added in transform/element.rs (shared `assert_v_model_arg_on_element_rejected` helper):
- `test_transform_v_model_static_arg_on_element_reports_error` — `<input v-model:foo="bar" />` emits exactly one `VModelArgOnElement` error and leaves no `model` directive and no `on` update handler.
- `test_transform_v_model_dynamic_arg_on_element_reports_error` — `<input v-model:[dynKey]="value" />` likewise.

Closes #1169

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1303"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783603146&installation_id=136613492&pr_number=1303&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1303&signature=cb0cbcb9e37d7a7e7753e0f787a3bbf36021685b56c24642aa0bb22ec9ac1435"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->