### PR TITLE
feat(atelier_sfc): support `<style module>` — inject _useCssModule() and hash classes

### DIFF
--- a/crates/vize_atelier_sfc/src/compile.rs
+++ b/crates/vize_atelier_sfc/src/compile.rs
@@ -691,6 +691,26 @@ fn compile_sfc_inner(
         }
     }
 
+    // CSS Modules: every `<style module>` / `<style module="name">` block
+    // contributes a setup binding (`$style` by default) bound to
+    // `_useCssModule()`. Register it so the template compiler emits the bare
+    // binding (`$style.root`) instead of `_ctx.$style.root`, then thread the
+    // names into the inline compiler for the import + setup injection. Names are
+    // de-duplicated in source order.
+    let mut css_module_names: Vec<String> = Vec::new();
+    for style in &descriptor.styles {
+        if let Some(name) = style.module.as_ref() {
+            let name: String = name.as_ref().into();
+            if !css_module_names.contains(&name) {
+                script_bindings
+                    .bindings
+                    .entry(name.clone())
+                    .or_insert(BindingType::SetupConst);
+                css_module_names.push(name);
+            }
+        }
+    }
+
     // Register bindings from normal <script> block.
     // When both <script> and <script setup> exist, top-level imports and
     // declarations from the normal script are accessible in the template.
@@ -865,6 +885,7 @@ fn compile_sfc_inner(
             &scope_id,
             filename,
             options.template.is_prod,
+            &css_module_names,
         )
     )?;
 

--- a/crates/vize_atelier_sfc/src/compile/snapshots/vize_atelier_sfc__compile__tests__script_setup_css_v_bind_reads_define_props.snap
+++ b/crates/vize_atelier_sfc/src/compile/snapshots/vize_atelier_sfc__compile__tests__script_setup_css_v_bind_reads_define_props.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/vize_atelier_sfc/src/compile/tests.rs
-assertion_line: 336
 expression: "sfc_compile_snapshot(&descriptor.css_vars, &result)"
 ---
 css vars:
@@ -8,19 +7,17 @@ css vars:
 - offset + 'px'
 
 css:
-
-.root {
-  background: linear-gradient(
-    180deg,
-    color(from var(--test-color) srgb r g b / 0.1),
-    color(from var(--test-color) srgb r g b / 0)
-  );
+.QgAX8G_root {
+  background: linear-gradient(180deg,
+    color(from var(--test-color) srgb r g b / .1),
+    color(from var(--test-color) srgb r g b / 0));
   padding-top: var(--test-offset\ \+\ \'px\');
 }
 
 
 code:
 import { useCssVars as _useCssVars } from "vue";
+import { useCssModule as _useCssModule } from "vue";
 import { resolveDirective as _resolveDirective, withDirectives as _withDirectives, createElementVNode as _createElementVNode, normalizeClass as _normalizeClass, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue";
 export default {
   __name: "MkFeatureBanner",
@@ -39,6 +36,7 @@ export default {
     }
   },
   setup(__props) {
+    const $style = _useCssModule();
     _useCssVars((_ctx) => ({
       "test-color": __props.color,
       "test-offset + 'px'": __props.offset + "px"
@@ -47,7 +45,7 @@ export default {
       const _directive_panel = _resolveDirective("panel");
       return _withDirectives((_openBlock(), _createElementBlock(
         "div",
-        { class: _normalizeClass(_ctx.$style.root) },
+        { class: _normalizeClass($style.root) },
         [_createElementVNode("img", { src: __props.icon }, null, 8, ["src"])],
         2
         /* CLASS */

--- a/crates/vize_atelier_sfc/src/compile/styles.rs
+++ b/crates/vize_atelier_sfc/src/compile/styles.rs
@@ -6,7 +6,12 @@
 use crate::types::{SfcError, SfcStyleBlock, StyleCompileOptions};
 
 use vize_carton::{String, profile};
-/// Helper to compile all style blocks
+
+/// Helper to compile all style blocks.
+///
+/// Returns the concatenated CSS. `<style module>` blocks have their class names
+/// localized (hashed) here; the matching `$style` setup binding is injected by
+/// the script-setup compiler from `SfcStyleBlock.module`.
 pub(super) fn compile_styles(
     styles: &[SfcStyleBlock],
     scope_id: &str,

--- a/crates/vize_atelier_sfc/src/compile/tests.rs
+++ b/crates/vize_atelier_sfc/src/compile/tests.rs
@@ -501,6 +501,80 @@ withDefaults(defineProps<{
 }
 
 #[test]
+fn test_style_module_injects_use_css_module_and_hashes_classes() {
+    // #1179: `<style module>` must inject `const $style = _useCssModule()`,
+    // import useCssModule, hash class names, and let the template reference
+    // `$style.red` as a setup binding (not `_ctx.$style.red`).
+    let source = r#"<script setup></script>
+<template><div :class="$style.red">x</div></template>
+<style module>.red { color: red }</style>"#;
+
+    let descriptor = parse_sfc(source, SfcParseOptions::default()).expect("Failed to parse SFC");
+    let mut opts = SfcCompileOptions {
+        scope_id: Some("test".into()),
+        ..Default::default()
+    };
+    opts.script.id = Some("src/Demo.vue".into());
+    let result = compile_sfc(&descriptor, opts).expect("Failed to compile SFC");
+
+    assert!(
+        result
+            .code
+            .contains("import { useCssModule as _useCssModule } from"),
+        "expected useCssModule import, got:\n{}",
+        result.code
+    );
+    assert!(
+        result.code.contains("const $style = _useCssModule()"),
+        "expected `const $style = _useCssModule()` injection, got:\n{}",
+        result.code
+    );
+    assert!(
+        result.code.contains("$style.red") && !result.code.contains("_ctx.$style.red"),
+        "expected `$style.red` to be a bare setup binding, got:\n{}",
+        result.code
+    );
+    let css = result.css.expect("expected compiled CSS");
+    assert!(
+        !css.contains(".red {") && !css.contains(".red{"),
+        "expected `.red` class name to be hashed, got:\n{css}"
+    );
+    assert!(
+        css.contains("_red") && css.contains("color"),
+        "expected hashed `_red` class with declarations preserved, got:\n{css}"
+    );
+}
+
+#[test]
+fn test_style_module_named_uses_named_binding() {
+    // `<style module="classes">` must inject `const classes = _useCssModule("classes")`.
+    let source = r#"<script setup></script>
+<template><div :class="classes.red">x</div></template>
+<style module="classes">.red { color: red }</style>"#;
+
+    let descriptor = parse_sfc(source, SfcParseOptions::default()).expect("Failed to parse SFC");
+    let mut opts = SfcCompileOptions {
+        scope_id: Some("test".into()),
+        ..Default::default()
+    };
+    opts.script.id = Some("src/Demo.vue".into());
+    let result = compile_sfc(&descriptor, opts).expect("Failed to compile SFC");
+
+    assert!(
+        result
+            .code
+            .contains("const classes = _useCssModule(\"classes\")"),
+        "expected named module binding, got:\n{}",
+        result.code
+    );
+    assert!(
+        result.code.contains("classes.red") && !result.code.contains("_ctx.classes.red"),
+        "expected `classes.red` to be a bare setup binding, got:\n{}",
+        result.code
+    );
+}
+
+#[test]
 fn test_script_setup_css_v_bind_reads_destructured_prop_aliases() {
     let source = r#"<script setup lang="ts">
 const { color: bannerColor } = defineProps<{

--- a/crates/vize_atelier_sfc/src/compile_script/inline/compiler.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/inline/compiler.rs
@@ -62,6 +62,7 @@ pub fn compile_script_setup_inline(
         scope_id,
         scope_id,
         false,
+        &[],
     )?;
     if let Some(transformed) = transformed {
         let mut code = transformed.preamble;
@@ -85,6 +86,7 @@ pub(crate) fn compile_script_setup_inline_with_context(
     scope_id: &str,
     css_vars_id: &str,
     is_prod: bool,
+    css_modules: &[String],
 ) -> Result<ScriptCompileResult, SfcError> {
     // Extract user imports and setup lines from script content once; await detection
     // and output assembly share the same split.
@@ -181,6 +183,7 @@ pub(crate) fn compile_script_setup_inline_with_context(
         needs_vapor_setup_context,
         vapor_render_alias,
         is_async,
+        css_modules,
     )
 }
 

--- a/crates/vize_atelier_sfc/src/compile_script/inline/compiler/body.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/inline/compiler/body.rs
@@ -43,6 +43,7 @@ pub(super) fn compile_script_setup_inline_body(
     needs_vapor_setup_context: bool,
     vapor_render_alias: Option<String>,
     is_async: bool,
+    css_modules: &[String],
 ) -> Result<ScriptCompileResult, SfcError> {
     let has_css_vars = !css_vars.is_empty();
     let needs_prop_type = false;
@@ -57,6 +58,7 @@ pub(super) fn compile_script_setup_inline_body(
         needs_merge_models,
         has_define_slots,
         has_css_vars,
+        !css_modules.is_empty(),
         needs_vapor_setup_context,
         vapor_render_alias.as_deref(),
         is_vapor,
@@ -143,6 +145,7 @@ pub(super) fn compile_script_setup_inline_body(
         css_vars_id,
         is_prod,
         has_css_vars,
+        css_modules,
     );
 
     output.push(b'\n');

--- a/crates/vize_atelier_sfc/src/compile_script/inline/compiler/preamble.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/inline/compiler/preamble.rs
@@ -22,6 +22,7 @@ pub(super) fn emit_preamble(
     needs_merge_models: bool,
     has_define_slots: bool,
     has_css_vars: bool,
+    has_css_modules: bool,
     needs_vapor_setup_context: bool,
     vapor_render_alias: Option<&str>,
     is_vapor: bool,
@@ -70,6 +71,11 @@ pub(super) fn emit_preamble(
                 b"import { useCssVars as _useCssVars, unref as _unref } from 'vue'\n",
             );
         }
+    }
+
+    // useCssModule import for `<style module>` blocks
+    if has_css_modules {
+        output.extend_from_slice(b"import { useCssModule as _useCssModule } from 'vue'\n");
     }
 
     // Component helper import (skip if already emitted with withAsyncContext)

--- a/crates/vize_atelier_sfc/src/compile_script/inline/compiler/setup_emit.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/inline/compiler/setup_emit.rs
@@ -112,6 +112,7 @@ pub(super) fn emit_setup_body(
     css_vars_id: &str,
     is_prod: bool,
     has_css_vars: bool,
+    css_modules: &[String],
 ) {
     // Emit binding: const emit = __emit
     if let Some(ref emits_macro) = ctx.macros.define_emits
@@ -175,6 +176,20 @@ pub(super) fn emit_setup_body(
         output.extend_from_slice(b"const ");
         output.extend_from_slice(binding_name.as_bytes());
         output.extend_from_slice(b" = _useSlots()\n");
+    }
+
+    // CSS Modules injection: `const $style = _useCssModule()` for `<style
+    // module>` (default name) or `_useCssModule("name")` for a custom name.
+    for module_name in css_modules {
+        output.extend_from_slice(b"const ");
+        output.extend_from_slice(module_name.as_bytes());
+        output.extend_from_slice(b" = _useCssModule(");
+        if module_name != "$style" {
+            output.push(b'"');
+            output.extend_from_slice(module_name.as_bytes());
+            output.push(b'"');
+        }
+        output.extend_from_slice(b")\n");
     }
 
     // useCssVars injection for v-bind() in <style>

--- a/crates/vize_atelier_sfc/src/style.rs
+++ b/crates/vize_atelier_sfc/src/style.rs
@@ -4,7 +4,11 @@ use vize_carton::{String, ToCompactString};
 
 use crate::types::{SfcError, SfcStyleBlock, StyleCompileOptions};
 
-/// Compile a style block
+/// Compile a style block.
+///
+/// `<style module>` blocks (when `style.module` / `options.module` is set) have
+/// their class names localized (hashed) via LightningCSS so the resulting CSS
+/// matches the `$style` map exposed in setup.
 pub fn compile_style(
     style: &SfcStyleBlock,
     options: &StyleCompileOptions,
@@ -14,6 +18,23 @@ pub fn compile_style(
     // Apply scoped transformation if needed
     if style.scoped || options.scoped {
         output = apply_scoped_css(&output, &options.id);
+    }
+
+    // CSS Modules: localize (hash) class names by running LightningCSS over the
+    // already v-bind/scoped-transformed CSS. The `$style` setup binding is
+    // injected separately by the script-setup compiler.
+    if style.module.is_some() {
+        let result = crate::css::compile_css(
+            &output,
+            &crate::css::CssCompileOptions {
+                css_modules: true,
+                filename: Some(options.id.clone()),
+                ..Default::default()
+            },
+        );
+        if result.errors.is_empty() {
+            output = result.code;
+        }
     }
 
     // Trim if requested


### PR DESCRIPTION
## Summary
The parser captured `<style module>` into `SfcStyleBlock.module`, but the compile path ignored it entirely: class names were left un-hashed, no `useCssModule`/`$style` was injected, and a component using `$style.foo` referenced an undefined `_ctx.$style` binding (TypeError at runtime).

## Fix
Thread the `module` attribute through the SFC compile pipeline:
- `compile_style` (style.rs) runs LightningCSS with `css_modules` enabled for `<style module>` blocks, after the existing v-bind / scoped transforms, localizing (hashing) the class names.
- `compile_sfc_inner` (compile.rs) collects each module's binding name (`$style` by default, or the custom `module="name"`) and registers it as a setup const, so the template compiler emits the bare binding (`$style.root`) instead of `_ctx.$style.root`.
- The inline script compiler imports `useCssModule` and injects `const $style = _useCssModule()` (or `_useCssModule("name")`) into setup.

No public API signatures change (`compile_style` still returns the compiled CSS string; the module flag is read from `SfcStyleBlock.module`). `cargo semver-checks` reports no semver update required.

## Snapshot
The committed snapshot `script_setup_css_v_bind_reads_define_props.snap` froze the broken output (un-hashed `.root`, `_ctx.$style.root`, no `useCssModule`). It is updated to the corrected output: hashed class name, `import { useCssModule as _useCssModule }`, `const $style = _useCssModule()`, and `_normalizeClass($style.root)`.

## Tests
- `test_style_module_injects_use_css_module_and_hashes_classes` — verifies the import, the `const $style = _useCssModule()` injection, the bare `$style.red` template binding, and that `.red` is hashed.
- `test_style_module_named_uses_named_binding` — verifies `<style module="classes">` emits `const classes = _useCssModule("classes")` and `classes.red`.

Closes #1179

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1305"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783603702&installation_id=136613492&pr_number=1305&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1305&signature=d8b9bc3ebfdb2f74f3bed1f8a2a82e3b85a64741e1e098d46ec60ee4edf74e92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->