### PR TITLE
fix(armature): stop flagging self-closing SVG and <p>-across-<template>; gate SFC fallback on hard errors

### DIFF
--- a/crates/vize_armature/src/parser/element.rs
+++ b/crates/vize_armature/src/parser/element.rs
@@ -147,10 +147,24 @@ impl<'a> Parser<'a> {
     /// Process open tag name
     pub(super) fn on_open_tag_name_impl(&mut self, start: usize, end: usize) {
         let tag = self.get_source(start, end);
+        let parent = self.stack.last().map(|e| e.element.tag.as_str());
         let ns = if self.should_force_html_namespace(tag) {
             Namespace::Html
         } else {
-            (self.options.get_namespace)(tag, self.stack.last().map(|e| e.element.tag.as_str()))
+            let resolved = (self.options.get_namespace)(tag, parent);
+            // Resolve the foreign (SVG/MathML) namespace even when the
+            // configured `get_namespace` callback is namespace-unaware (the
+            // default callback always returns HTML). Without this, the
+            // `vize_canon` virtual-TS path — which parses with
+            // `ParserOptions::default()` — leaves `<svg>`/`<math>` and their
+            // self-closing children such as `<path d="…" />` in the HTML
+            // namespace and then flags them as invalid self-closing non-void
+            // HTML elements.
+            if resolved == Namespace::Html {
+                self.foreign_namespace_for(tag).unwrap_or(Namespace::Html)
+            } else {
+                resolved
+            }
         };
 
         self.current_element = Some(CurrentElement {
@@ -631,16 +645,17 @@ impl<'a> Parser<'a> {
             self.close_stack_element_at(index, false);
         }
 
-        if self.open_p_count > 0 {
-            if tag.eq_ignore_ascii_case("p") {
-                if let Some(index) = self.find_open_element_index("p") {
-                    self.close_stack_element_at(index, false);
-                }
-            } else if Self::closes_open_p_before_start(tag)
-                && let Some(index) = self.find_open_element_index("p")
-            {
-                self.close_stack_element_at(index, false);
-            }
+        if self.open_p_count > 0
+            && (tag.eq_ignore_ascii_case("p") || Self::closes_open_p_before_start(tag))
+            && let Some(index) = self.find_open_p_element_in_button_scope()
+        {
+            // Only auto-close a `<p>` that is in button scope of the current
+            // insertion point. A `<template>` (or other scope-terminating
+            // element) between the open `<p>` and the new start tag is a scope
+            // boundary, so the `<p>` must NOT be auto-closed across it —
+            // otherwise valid markup like `<p><template>…<p>…</p></template></p>`
+            // wrongly reports an `InvalidEndTag` for the outer `</p>`.
+            self.close_stack_element_at(index, false);
         }
 
         let _ = offset;
@@ -664,6 +679,38 @@ impl<'a> Parser<'a> {
         }
 
         None
+    }
+
+    fn find_open_p_element_in_button_scope(&self) -> Option<usize> {
+        for i in (0..self.stack.len()).rev() {
+            let tag = self.stack[i].element.tag.as_str();
+            if tag.eq_ignore_ascii_case("p") {
+                return Some(i);
+            }
+            // Components and structural `<template>` blocks (the latter is also
+            // a button-scope boundary in the HTML spec) confine `<p>`
+            // auto-closing, so stop the search rather than reaching across them.
+            if self.stack[i].element.tag_type != ElementType::Element
+                || Self::is_button_scope_boundary(tag)
+            {
+                return None;
+            }
+        }
+
+        None
+    }
+
+    /// HTML "button scope" terminating elements (the default scope set plus
+    /// `<button>`). A `<p>` start tag (or a `<p>`-closing block start tag) only
+    /// auto-closes an open `<p>` that sits within this scope.
+    fn is_button_scope_boundary(tag: &str) -> bool {
+        Self::tag_in(
+            tag,
+            &[
+                "applet", "button", "caption", "html", "table", "td", "th", "marquee", "object",
+                "template",
+            ],
+        )
     }
 
     fn is_list_item_scope_boundary(tag: &str) -> bool {
@@ -899,6 +946,41 @@ impl<'a> Parser<'a> {
         }
 
         false
+    }
+
+    /// Resolve the foreign (SVG/MathML) namespace for a start tag whose
+    /// configured `get_namespace` callback returned HTML. An `<svg>`/`<math>`
+    /// root (or any SVG/MathML tag) seeds the namespace; otherwise descendants
+    /// inherit the nearest open ancestor's foreign namespace unless that
+    /// ancestor is an HTML integration point (`<foreignObject>`/`<desc>`/
+    /// `<title>` for SVG, `<annotation-xml>` and the MathML text containers for
+    /// MathML), which switch their subtree back to HTML. Mirrors the boundary
+    /// handling in the DOM compiler's `get_namespace` so namespace-unaware
+    /// callbacks still classify foreign elements correctly.
+    fn foreign_namespace_for(&self, tag: &str) -> Option<Namespace> {
+        if vize_carton::is_svg_tag(tag) {
+            return Some(Namespace::Svg);
+        }
+        if vize_carton::is_math_ml_tag(tag) {
+            return Some(Namespace::MathMl);
+        }
+
+        let parent = self.stack.last()?;
+        let parent_tag = parent.element.tag.as_str();
+        match parent.element.ns {
+            Namespace::Svg => {
+                let svg_to_html = matches!(parent_tag, "foreignObject" | "desc" | "title");
+                (!svg_to_html).then_some(Namespace::Svg)
+            }
+            Namespace::MathMl => {
+                let mathml_to_html = matches!(
+                    parent_tag,
+                    "annotation-xml" | "mi" | "mo" | "mn" | "ms" | "mtext"
+                );
+                (!mathml_to_html).then_some(Namespace::MathMl)
+            }
+            Namespace::Html => None,
+        }
     }
 
     fn should_force_html_namespace(&self, tag: &str) -> bool {

--- a/crates/vize_armature/src/parser/tests.rs
+++ b/crates/vize_armature/src/parser/tests.rs
@@ -1646,3 +1646,114 @@ fn test_parse_directive_value_entity_is_decoded() {
         }
     }
 }
+
+/// Regression (#1065/#1090): a self-closing SVG child such as `<path d="…" />`
+/// inside `<svg>` must NOT be flagged as an invalid self-closing non-void HTML
+/// element. This holds even with the default, namespace-unaware
+/// `get_namespace` callback used by the `vize_canon` virtual-TS path — the
+/// parser inherits the foreign (SVG) namespace from the open `<svg>` ancestor.
+#[test]
+fn test_parse_self_closing_svg_path_inside_svg_is_not_flagged() {
+    let allocator = Bump::new();
+    let (root, errors) = parse(
+        &allocator,
+        r#"<svg viewBox="0 0 24 24"><path d="M0 0h24v24H0z" /></svg>"#,
+    );
+
+    assert!(
+        errors.is_empty(),
+        "self-closing SVG child should not error: {errors:?}"
+    );
+
+    let TemplateChildNode::Element(svg) = &root.children[0] else {
+        panic!("expected svg element");
+    };
+    assert_eq!(svg.tag.as_str(), "svg");
+    assert_eq!(svg.ns, Namespace::Svg);
+    let TemplateChildNode::Element(path) = &svg.children[0] else {
+        panic!("expected path child");
+    };
+    assert_eq!(path.tag.as_str(), "path");
+    assert_eq!(path.ns, Namespace::Svg);
+    // The element stays self-closing; it was never rewritten as an invalid
+    // non-void HTML element.
+    assert!(path.is_self_closing);
+}
+
+/// A `<div>` inside `<foreignObject>` (an HTML integration point) must switch
+/// back to the HTML namespace, so a self-closing non-void HTML element there is
+/// still rewritten (recovery), confirming the inheritance honours boundaries.
+#[test]
+fn test_parse_foreign_object_resets_namespace_for_self_closing_check() {
+    let allocator = Bump::new();
+    let (_root, errors) = parse(
+        &allocator,
+        "<svg><foreignObject><div /></foreignObject></svg>",
+    );
+
+    assert!(
+        errors.iter().any(|e| {
+            e.code == ErrorCode::ExtendPoint
+                && e.message
+                    .contains("Invalid self-closing syntax on non-void HTML element")
+        }),
+        "div inside foreignObject is HTML and must be rewritten: {errors:?}"
+    );
+    assert!(errors.iter().all(CompilerError::is_recoverable));
+}
+
+/// Regression (#1065/#1090): HTML `<p>` auto-closing must not leak across an
+/// intervening `<template>` block. `<p><template>…<p>…</p></template></p>` is
+/// accepted by `@vue/compiler-sfc`; vize must not emit a false `InvalidEndTag`
+/// for the outer `</p>`.
+#[test]
+fn test_parse_p_auto_close_does_not_cross_template_boundary() {
+    let allocator = Bump::new();
+    let (root, errors) = parse(&allocator, "<p><template><p>inner</p></template>outer</p>");
+
+    assert!(
+        !errors.iter().any(|e| e.code == ErrorCode::InvalidEndTag),
+        "outer </p> must not be reported as an invalid end tag: {errors:?}"
+    );
+    // The inner `<p>` did not auto-close the outer one across `<template>`, so
+    // the outer `<p>` remains the single root element and still contains the
+    // `<template>` (the inner `<p>` lives inside it).
+    assert_eq!(root.children.len(), 1);
+    let TemplateChildNode::Element(outer_p) = &root.children[0] else {
+        panic!("expected outer <p>");
+    };
+    assert_eq!(outer_p.tag.as_str(), "p");
+    assert!(
+        outer_p
+            .children
+            .iter()
+            .any(|c| matches!(c, TemplateChildNode::Element(t) if t.tag.as_str() == "template")),
+        "outer <p> should still contain the <template>: {:?}",
+        outer_p.children
+    );
+}
+
+/// A nested `<p>` directly inside another `<p>` (no scope boundary between
+/// them) still auto-closes the outer `<p>` — the button-scope guard must not
+/// suppress the legitimate recovery.
+#[test]
+fn test_parse_nested_p_without_boundary_still_auto_closes() {
+    let allocator = Bump::new();
+    let (root, errors) = parse(&allocator, "<p>first<p>second</p>");
+
+    assert!(
+        !errors.iter().any(|e| e.code == ErrorCode::InvalidEndTag),
+        "well-formed nested <p> should not produce an invalid end tag: {errors:?}"
+    );
+    // The two paragraphs are siblings: the first <p> was implicitly closed
+    // before the second one opened.
+    assert_eq!(root.children.len(), 2);
+    assert!(matches!(
+        &root.children[0],
+        TemplateChildNode::Element(p) if p.tag.as_str() == "p"
+    ));
+    assert!(matches!(
+        &root.children[1],
+        TemplateChildNode::Element(p) if p.tag.as_str() == "p"
+    ));
+}

--- a/crates/vize_canon/src/batch/virtual_project/tests.rs
+++ b/crates/vize_canon/src/batch/virtual_project/tests.rs
@@ -292,6 +292,59 @@ const count = 1
 }
 
 #[test]
+fn test_register_vue_file_recovery_diagnostic_does_not_collapse_to_fallback() {
+    // Regression (#1065/#1090): the template here triggers only recovery-level
+    // parser diagnostics — a self-closing non-void HTML element (`<div />`,
+    // rewritten as an empty element) and a self-closing SVG `<path/>` inside
+    // `<svg>` (which must not be flagged at all). Neither is a hard error, so
+    // the virtual TS must remain real codegen, NOT the
+    // `declare const __vize_component: any` stub.
+    let case_dir = unique_case_dir("template-recovery-no-fallback");
+    let _ = fs::remove_dir_all(&case_dir);
+    let src_dir = case_dir.join("src");
+    fs::create_dir_all(&src_dir).unwrap();
+    let vue_path = src_dir.join("Recoverable.vue");
+    let vue_content = r#"<script setup lang="ts">
+const count = 1
+</script>
+
+<template>
+  <div />
+  <svg viewBox="0 0 24 24"><path d="M0 0h24v24H0z" /></svg>
+  <span>{{ count }}</span>
+</template>
+"#;
+
+    let mut project = VirtualProject::new(&case_dir).unwrap();
+    project.register_vue_file(&vue_path, vue_content).unwrap();
+
+    assert!(
+        project.diagnostics().is_empty(),
+        "recovery-level template diagnostics must not surface, got: {:?}",
+        project.diagnostics()
+    );
+
+    let virtual_file = project.find_by_original(&vue_path).unwrap();
+    // The exact fallback stub is `declare const __vize_component: any;` — real
+    // codegen instead emits a typed `__vize_component__` instance constructor.
+    assert!(
+        !virtual_file
+            .content
+            .contains("declare const __vize_component: any"),
+        "file must not collapse to the fallback stub: {}",
+        virtual_file.content
+    );
+    // Real codegen ran: the template-check binding for `count` is present.
+    assert!(
+        virtual_file.content.contains("count"),
+        "expected real virtual TS referencing `count`: {}",
+        virtual_file.content
+    );
+
+    let _ = fs::remove_dir_all(&case_dir);
+}
+
+#[test]
 fn test_virtual_ts_exposes_props_from_reexported_vue_interface() {
     let case_dir = unique_case_dir("reexported-vue-interface-props");
     let _ = fs::remove_dir_all(&case_dir);

--- a/crates/vize_canon/src/batch/virtual_project/vue_codegen.rs
+++ b/crates/vize_canon/src/batch/virtual_project/vue_codegen.rs
@@ -94,6 +94,13 @@ pub(super) fn generate_vue_virtual_ts(
         .as_ref()
         .map(|template| template.loc.start as u32)
         .unwrap_or(0);
+    // Track whether the template produced any *hard* parse error. Only hard
+    // errors abort codegen and collapse the file to the fallback stub;
+    // recovery-level diagnostics (`ErrorCode::ExtendPoint`, pushed by the HTML
+    // tree-construction recovery path for self-closing rewrites, fostered
+    // elements, auto-closed `<p>`, etc.) describe repairs the parser already
+    // applied and must keep the real virtual TS (#1065/#1090 regression).
+    let mut template_hard_error = false;
     let template_ast = descriptor.template.as_ref().and_then(|template| {
         profile!("canon.template.parse", {
             let (root, errors) = parse_with_options_and_template_syntax(
@@ -102,28 +109,32 @@ pub(super) fn generate_vue_virtual_ts(
                 ParserOptions::default(),
                 codegen_options.template_syntax,
             );
-            if errors.is_empty() {
-                Some(root)
-            } else {
-                diagnostics.extend(errors.into_iter().map(|error| {
-                    let start = error
-                        .loc
-                        .as_ref()
-                        .map(|loc| template_offset + loc.start.offset)
-                        .unwrap_or(template_offset);
-                    diagnostic_for_offset(
-                        path,
-                        source,
-                        start,
-                        cstr!("Template parse error: {}", error.message),
-                        SfcBlockType::Template,
-                    )
-                }));
-                None
+            for error in errors {
+                if error.code.is_recovery() {
+                    continue;
+                }
+                template_hard_error = true;
+                let start = error
+                    .loc
+                    .as_ref()
+                    .map(|loc| template_offset + loc.start.offset)
+                    .unwrap_or(template_offset);
+                diagnostics.push(diagnostic_for_offset(
+                    path,
+                    source,
+                    start,
+                    cstr!("Template parse error: {}", error.message),
+                    SfcBlockType::Template,
+                ));
             }
+            // Drop the AST only when a hard error occurred; recovery-level
+            // diagnostics leave a fully usable tree.
+            (!template_hard_error).then_some(root)
         })
     });
 
+    // Abort to the fallback stub only on hard errors — from any block. Pure
+    // recovery-level template diagnostics must not suppress real codegen.
     if !diagnostics.is_empty() {
         return Ok(GeneratedVueFile {
             code: invalid_sfc_fallback_virtual_ts(),

--- a/crates/vize_relief/src/errors.rs
+++ b/crates/vize_relief/src/errors.rs
@@ -205,6 +205,18 @@ impl ErrorCode {
         let code = *self as u16;
         code >= (Self::VIfNoExpression as u16) && code < (Self::PrefixIdNotSupported as u16)
     }
+
+    /// Returns true when this code is a recovery-level diagnostic (a warning)
+    /// rather than a hard error. `ExtendPoint` is the code the parser uses for
+    /// HTML tree-construction recovery notes (e.g. self-closing rewrites,
+    /// fostered elements, auto-closed `<p>`). These describe spec-compliant
+    /// repairs the parser already applied, so downstream consumers — notably
+    /// the `vize_canon` virtual-TS codegen — must NOT treat them as a reason to
+    /// abort and fall back to a stub component.
+    #[must_use]
+    pub fn is_recovery(&self) -> bool {
+        matches!(self, Self::ExtendPoint)
+    }
 }
 
 /// Result type for compiler operations
@@ -256,6 +268,15 @@ mod tests {
         for code in &codes {
             assert!(!code.message().is_empty(), "{:?} has empty message", code);
         }
+    }
+
+    #[test]
+    fn is_recovery_only_for_extend_point() {
+        assert!(ErrorCode::ExtendPoint.is_recovery());
+        assert!(!ErrorCode::InvalidEndTag.is_recovery());
+        assert!(!ErrorCode::UnexpectedSolidusInTag.is_recovery());
+        assert!(!ErrorCode::DuplicateAttribute.is_recovery());
+        assert!(!ErrorCode::UnhandledCodePath.is_recovery());
     }
 
     #[test]


### PR DESCRIPTION
Parser strictness PRs #1065/#1090 introduced false template-parse errors that, combined with an over-aggressive codegen fallback, collapsed valid SFCs in the App E2E suite to the stub virtual TS (`declare const __vize_component: any`). This fixes three coupled defects.

## Defects

1. **SVG/MathML self-closing false positive.** The `vize_canon` virtual-TS path parses with `ParserOptions::default()`, whose `get_namespace` callback is namespace-unaware (always returns HTML). As a result `<svg>` and its self-closing children (e.g. `<path d="…" />`) stayed in the HTML namespace and were flagged *"Invalid self-closing syntax on non-void HTML element"*. The parser now resolves the foreign namespace itself when the callback returns HTML — seeding SVG/MathML roots and inheriting from foreign ancestors while honouring `foreignObject`/`desc`/`title` and the MathML integration points — mirroring the DOM compiler's `get_namespace` boundary handling.

2. **`<p>` auto-close crossing `<template>`.** `<p>` auto-closing searched the whole open-element stack and closed an open `<p>` even across an intervening `<template>`, producing false `Invalid end tag` errors for markup like `<p><template>…<p>…</p></template></p>`. Auto-close is now scoped to the HTML *button scope*: components and scope-terminating elements (`<template>`, table cells, etc.) confine it.

3. **Codegen fallback amplifier.** The virtual-TS gate replaced the whole file with the fallback stub whenever *any* template diagnostic existed, including recovery-level `ErrorCode::ExtendPoint` warnings pushed by the HTML tree-construction recovery path. Added `ErrorCode::is_recovery` and changed the gate so only hard errors abort codegen; recovery-level diagnostics keep the real virtual TS.

## E2E impact (real fixtures, before → after)

- `elk/app/app.vue`: 1 false template-parse error (`32:9 Invalid self-closing syntax…`) → **clean**.
- `vuefes-2025 .../sponsors/[sponsorId]/index.vue`: 3 false `Invalid end tag` errors (149/153/154) → **gone**; the file no longer collapses to the stub and now type-checks real virtual TS.

Both files stop collapsing to the `__vize_component` stub.

## Tests
- `vize_armature`: self-closing SVG `<path/>` inside `<svg>` produces no error; `<div/>` inside `<foreignObject>` still rewrites (HTML reset); `<p>`/`<template>` boundary produces no `InvalidEndTag`; nested `<p>` without a boundary still auto-closes.
- `vize_relief`: `ErrorCode::is_recovery` is true only for `ExtendPoint`.
- `vize_canon`: a recovery-level template diagnostic does not collapse the file to the fallback stub.

All pass; `cargo clippy --lib -- -D warnings` and `cargo fmt --check` clean for the touched crates. (`--tests`/`--all-targets` clippy trips a pre-existing `disallowed-types` lint in `parser/tests.rs:723`, unrelated to this change.)

Does **not** regenerate the large `tests/snapshots/**` E2E baselines — that is a separate follow-up.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1307"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783607090&installation_id=136613492&pr_number=1307&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1307&signature=2a88f6b67cb6cc76d90a157e357ade6f2b6b574ba7670982eb88d17eaac87a0a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->