### PR TITLE
fix(atelier_sfc): preserve multi-line hoisted object/array consts in script setup

### DIFF
--- a/crates/vize_atelier_sfc/src/compile_template/extraction.rs
+++ b/crates/vize_atelier_sfc/src/compile_template/extraction.rs
@@ -2,10 +2,28 @@
 
 use vize_carton::{String, ToCompactString};
 
-use super::string_tracking::{StringTrackState, count_braces_with_state, count_parens_with_state};
+use super::string_tracking::{
+    StringTrackState, count_braces_with_state, count_delims_with_state, count_parens_with_state,
+};
 
 fn is_vapor_template_declaration(line: &str) -> bool {
     line.starts_with("const t") && line.contains("_template(")
+}
+
+/// A hoisted const declaration may span multiple lines when its value is a multi-line
+/// object/array/paren literal, e.g.
+///
+/// ```text
+/// const _hoisted_1 = { style: {
+///   position: 'absolute',
+/// } }
+/// ```
+///
+/// Returns the net delimiter depth opened by `line` (over all of `{} [] ()`), so the caller
+/// can keep appending continuation lines to `hoisted` until the depth returns to zero. Without
+/// this the continuation lines were dropped, truncating the declaration into invalid JS.
+fn hoisted_line_open_depth(line: &str, state: &mut StringTrackState) -> i32 {
+    count_delims_with_state(line, state)
 }
 
 fn detect_render_export_name(trimmed: &str) -> Option<&'static str> {
@@ -49,9 +67,21 @@ pub(crate) fn extract_template_parts_full(
     let mut in_render = false;
     let mut brace_depth = 0;
     let mut brace_state = StringTrackState::default();
+    // Depth/state for a hoisted declaration whose value spans multiple lines.
+    let mut hoisted_depth = 0;
+    let mut hoisted_state = StringTrackState::default();
 
     for line in template_code.lines() {
         let trimmed = line.trim();
+
+        // Continuation lines of a multi-line hoisted declaration: keep collecting until the
+        // value's delimiters are balanced so the declaration is emitted intact.
+        if hoisted_depth > 0 {
+            hoisted_depth += hoisted_line_open_depth(line, &mut hoisted_state);
+            hoisted.push_str(line);
+            hoisted.push('\n');
+            continue;
+        }
 
         if trimmed.starts_with("import ") {
             imports.push_str(line);
@@ -68,6 +98,8 @@ pub(crate) fn extract_template_parts_full(
             || is_vapor_template_declaration(trimmed)
             || (!trimmed.is_empty() && !in_render)
         {
+            hoisted_state = StringTrackState::default();
+            hoisted_depth = hoisted_line_open_depth(line, &mut hoisted_state);
             hoisted.push_str(line);
             hoisted.push('\n');
         } else if in_render {
@@ -104,15 +136,30 @@ pub(crate) fn extract_template_parts(
     let mut paren_state = StringTrackState::default();
     let mut return_paren_depth = 0;
     let mut pending_ternary_continuation = false;
+    // Depth/state for a hoisted declaration whose value spans multiple lines.
+    let mut hoisted_depth = 0;
+    let mut hoisted_state = StringTrackState::default();
 
     for line in template_code.lines() {
         let trimmed = line.trim();
+
+        // Continuation lines of a multi-line hoisted declaration: keep collecting until the
+        // value's delimiters are balanced so the declaration is emitted intact. Previously
+        // these lines fell through and were dropped, truncating the const into invalid JS.
+        if hoisted_depth > 0 {
+            hoisted_depth += hoisted_line_open_depth(line, &mut hoisted_state);
+            hoisted.push_str(line);
+            hoisted.push('\n');
+            continue;
+        }
 
         if trimmed.starts_with("import ") {
             imports.push_str(line);
             imports.push('\n');
         } else if trimmed.starts_with("const _hoisted_") || is_vapor_template_declaration(trimmed) {
-            // Hoisted template variables
+            // Hoisted template variables (value may span multiple lines).
+            hoisted_state = StringTrackState::default();
+            hoisted_depth = hoisted_line_open_depth(line, &mut hoisted_state);
             hoisted.push_str(line);
             hoisted.push('\n');
         } else if let Some(name) = detect_render_export_name(trimmed) {

--- a/crates/vize_atelier_sfc/src/compile_template/string_tracking.rs
+++ b/crates/vize_atelier_sfc/src/compile_template/string_tracking.rs
@@ -163,6 +163,116 @@ pub(super) fn count_braces_outside_strings(line: &str) -> i32 {
     count_braces_with_state(line, &mut state)
 }
 
+/// Count net delimiter depth change for ALL of `{ [ (` (each +1) and `} ] )` (each -1)
+/// in a line, properly tracking string literals, block comments, and template literal
+/// `${...}` expressions. State is carried across lines so a declaration whose value spans
+/// multiple lines (e.g. a hoisted object/array literal) can be detected as balanced.
+///
+/// This complements [`count_braces_with_state`] (which only counts `{}`). Hoisted consts
+/// can wrap their value in any of object/array/paren delimiters, so the extractor needs
+/// the combined depth to know where a multi-line declaration actually ends.
+pub(super) fn count_delims_with_state(line: &str, state: &mut StringTrackState) -> i32 {
+    let mut count: i32 = 0;
+    let bytes = line.as_bytes();
+    let len = bytes.len();
+    let mut i = 0;
+
+    while i < len {
+        let ch = bytes[i];
+
+        if state.escape {
+            state.escape = false;
+            i += 1;
+            continue;
+        }
+
+        if state.in_block_comment {
+            if ch == b'*' && i + 1 < len && bytes[i + 1] == b'/' {
+                state.in_block_comment = false;
+                i += 2;
+                continue;
+            }
+            i += 1;
+            continue;
+        }
+
+        if state.in_string {
+            if ch == b'\\' {
+                state.escape = true;
+                i += 1;
+                continue;
+            }
+
+            if state.string_char == b'`' {
+                if ch == b'`' {
+                    state.in_string = false;
+                } else if ch == b'$' && i + 1 < len && bytes[i + 1] == b'{' {
+                    state.in_string = false;
+                    state.template_expr_brace_stack.push(0);
+                    // The `${` opens a code-mode region; the `{` counts as an open delimiter.
+                    count += 1;
+                    i += 2;
+                    continue;
+                }
+            } else if ch == state.string_char {
+                state.in_string = false;
+            }
+        } else {
+            match ch {
+                b'/' if i + 1 < len && bytes[i + 1] == b'*' => {
+                    state.in_block_comment = true;
+                    i += 2;
+                    continue;
+                }
+                b'/' if i + 1 < len && bytes[i + 1] == b'/' => {
+                    break;
+                }
+                b'\'' | b'"' => {
+                    state.in_string = true;
+                    state.string_char = ch;
+                }
+                b'`' => {
+                    state.in_string = true;
+                    state.string_char = b'`';
+                }
+                b'{' => {
+                    if let Some(depth) = state.template_expr_brace_stack.last_mut() {
+                        *depth += 1;
+                    }
+                    count += 1;
+                }
+                b'}' => {
+                    if let Some(&depth) = state.template_expr_brace_stack.last() {
+                        if depth == 0 {
+                            // This `}` closes a `${...}` expression: balance the `{` from `${`.
+                            state.template_expr_brace_stack.pop();
+                            state.in_string = true;
+                            state.string_char = b'`';
+                            count -= 1;
+                            i += 1;
+                            continue;
+                        } else if let Some(depth) = state.template_expr_brace_stack.last_mut() {
+                            *depth -= 1;
+                        }
+                    }
+                    count -= 1;
+                }
+                b'[' | b'(' => {
+                    count += 1;
+                }
+                b']' | b')' => {
+                    count -= 1;
+                }
+                _ => {}
+            }
+        }
+
+        i += 1;
+    }
+
+    count
+}
+
 /// Count net paren depth change (( minus )) in a line, properly tracking
 /// string literals, block comments, and template literal `${...}` expressions.
 /// State is carried across lines to handle multiline template literals and comments.

--- a/crates/vize_atelier_sfc/src/compile_template/tests.rs
+++ b/crates/vize_atelier_sfc/src/compile_template/tests.rs
@@ -3,6 +3,7 @@
 use super::extraction::{extract_template_parts, extract_template_parts_full};
 use super::string_tracking::{
     StringTrackState, count_braces_outside_strings, count_braces_with_state,
+    count_delims_with_state,
 };
 use super::vapor::{add_scope_id_to_template, transform_vapor_template_output};
 use crate::types::{BlockLocation, SfcTemplateBlock};
@@ -414,4 +415,85 @@ export function render(_ctx, _cache) {
         render_fn
     );
     insta::assert_snapshot!(render_fn.as_str());
+}
+
+/// Net delimiter depth must equal zero for a balanced object literal that spans lines,
+/// treating `{} [] ()` uniformly and ignoring delimiters inside strings.
+#[test]
+fn test_count_delims_with_state_multiline_object() {
+    let mut state = StringTrackState::default();
+    let mut depth = 0;
+    depth += count_delims_with_state("const _hoisted_1 = { style: {", &mut state);
+    assert_eq!(depth, 2);
+    depth += count_delims_with_state("  position: 'absolute',", &mut state);
+    assert_eq!(depth, 2);
+    depth += count_delims_with_state("  content: '({[',", &mut state);
+    assert_eq!(depth, 2, "delimiters inside strings must not affect depth");
+    depth += count_delims_with_state("} }", &mut state);
+    assert_eq!(depth, 0, "declaration is balanced after the closing line");
+}
+
+/// Regression for the `<script setup>` inline path truncating a multi-line hoisted
+/// object literal at its first newline (producing invalid JS). The whole declaration
+/// must be collected into `hoisted` intact, with balanced braces.
+#[test]
+fn test_extract_template_parts_multiline_hoisted_object() {
+    let template_code = r#"import { createElementVNode as _createElementVNode } from "vue"
+
+const _hoisted_1 = { style: {
+  position: 'absolute',
+  top: 0,
+  left: 0,
+  objectFit: 'cover',
+} }
+
+export function render(_ctx, _cache) {
+  return _createElementVNode("img", _hoisted_1)
+}"#;
+
+    let (_imports, hoisted, _preamble, render_body, render_fn_name) =
+        extract_template_parts(template_code);
+
+    assert_eq!(render_fn_name, "render");
+    assert!(
+        hoisted.contains("objectFit: 'cover'"),
+        "continuation lines of the hoisted const must be preserved, got:\n{hoisted}"
+    );
+    let opens = hoisted.matches('{').count();
+    let closes = hoisted.matches('}').count();
+    assert_eq!(opens, closes, "hoisted braces must be balanced:\n{hoisted}");
+    assert!(
+        render_body.contains("_hoisted_1"),
+        "render body should still reference the hoist"
+    );
+}
+
+/// Same regression for the vapor/ssr extraction path.
+#[test]
+fn test_extract_template_parts_full_multiline_hoisted_object() {
+    let template_code = r#"import { createElementVNode as _createElementVNode } from "vue"
+
+const _hoisted_1 = { style: {
+  position: 'absolute',
+  objectFit: 'cover',
+} }
+
+export function render(_ctx, _cache) {
+  return _createElementVNode("img", _hoisted_1)
+}"#;
+
+    let (_imports, hoisted, render_fn, render_fn_name) = extract_template_parts_full(template_code);
+
+    assert_eq!(render_fn_name, "render");
+    assert!(
+        hoisted.contains("objectFit: 'cover'"),
+        "continuation lines of the hoisted const must be preserved, got:\n{hoisted}"
+    );
+    let opens = hoisted.matches('{').count();
+    let closes = hoisted.matches('}').count();
+    assert_eq!(opens, closes, "hoisted braces must be balanced:\n{hoisted}");
+    assert!(
+        render_fn.trim().ends_with('}'),
+        "render function should remain intact:\n{render_fn}"
+    );
 }


### PR DESCRIPTION
## Problem

In `<script setup>` SFCs, a **multi-line** hoisted static object/array literal was **truncated at its first newline**, producing invalid JavaScript.

Repro (`B.vue`):
```vue
<script setup lang="ts">
import { useRuntimeConfig, computed } from "#imports";
defineProps<{ titleJa: string }>();
const x = computed(() => useRuntimeConfig().siteUrl);
</script>
<template>
  <div :style="{ position: 'relative', height: '100%' }">a</div>
  <img :style="{
    position: 'absolute',
    top: 0,
    left: 0,
    objectFit: 'cover',
  }">
</template>
```

Before, the emitted `.js` contained:
```js
const _hoisted_2 = { style: {
import { useRuntimeConfig, computed } from '#imports'
```
The continuation lines were dropped, leaving an unbalanced declaration. `node --check` failed and the E2E build suite broke. Single-line hoists and the template-only path (no `<script setup>`) were unaffected, which masked the bug.

## Root cause

`extract_template_parts` / `extract_template_parts_full` in `compile_template/extraction.rs` split the compiled render preamble line by line. They captured a `const _hoisted_X = ...` declaration as a **single line**. When the value spanned multiple lines, the continuation lines matched neither the `import` nor the `const _hoisted_` prefix and were not inside the render function, so they fell through every branch and vanished.

## Fix

Both extractors now track the net delimiter depth (`{} [] ()`, string/template-literal/block-comment aware) opened by a hoisted declaration and keep appending continuation lines until the value's delimiters are balanced, emitting the whole declaration as one unit. A new `count_delims_with_state` helper provides the combined depth, reusing the existing `StringTrackState` machine. Single-line consts and the existing multi-line template-literal handling are unchanged.

## Tests

- `test_count_delims_with_state_multiline_object` — combined `{}[]()` depth, ignoring delimiters inside strings.
- `test_extract_template_parts_multiline_hoisted_object` — asserts continuation lines preserved + balanced braces (inline path).
- `test_extract_template_parts_full_multiline_hoisted_object` — same for the vapor/ssr path.

## Verification (`node --input-type=module --check`)

| File | Before | After |
| --- | --- | --- |
| `B.vue` | FAIL (truncated `_hoisted_2`) | PASS |
| `tests/_fixtures/_git/vuefes-2025/app/components/OgImage/OgDefault.vue` | FAIL (truncated hoisted styles) | PASS |

`cargo test -p vize_atelier_sfc` (504 passed), `cargo clippy -p vize_atelier_sfc --lib -- -D warnings`, and `cargo fmt --all -- --check` are all clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1310"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783609708&installation_id=136613492&pr_number=1310&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1310&signature=345af611a8d8817f7bc4a1d39fde9ea6812f57ad783ca26a7679893c259a1950"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->