### PR TITLE
fix(atelier_sfc): guard recursive type aliases in runtime prop type resolution

### DIFF
--- a/crates/vize_atelier_sfc/src/compile_script/props.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/props.rs
@@ -472,6 +472,26 @@ fn ts_type_to_js_type_from_ast(
     interfaces: Option<&FxHashMap<String, String>>,
     type_aliases: Option<&FxHashMap<String, String>>,
 ) -> String {
+    let mut seen = Vec::new();
+    ts_type_to_js_type_from_ast_inner(ts_type, source, interfaces, type_aliases, &mut seen)
+}
+
+/// Inner implementation of [`ts_type_to_js_type_from_ast`] that threads a
+/// `seen` stack of type-alias names currently being resolved. Self-referential
+/// or mutually recursive type aliases (e.g. `type NestedItem<T> = T extends
+/// Array<infer I> ? NestedItem<I> : T`, or a recursive `DotPathKeys`) otherwise
+/// re-parse and re-enter the same alias body forever, overflowing the native
+/// stack and aborting the whole `vize build`. The guard stops following an
+/// alias reference once its name is already on the stack and falls back to a
+/// safe `null` runtime type, mirroring the cycle protection already used by
+/// `collect_props_from_ts_type` / `resolve_type_reference_text`.
+fn ts_type_to_js_type_from_ast_inner(
+    ts_type: &TSType<'_>,
+    source: &str,
+    interfaces: Option<&FxHashMap<String, String>>,
+    type_aliases: Option<&FxHashMap<String, String>>,
+    seen: &mut Vec<String>,
+) -> String {
     match ts_type {
         TSType::TSStringKeyword(_) => "String".to_compact_string(),
         TSType::TSNumberKeyword(_) => "Number".to_compact_string(),
@@ -494,18 +514,31 @@ fn ts_type_to_js_type_from_ast(
                 ) {
                     None
                 } else {
-                    Some(ts_type_to_js_type_from_ast(
+                    Some(ts_type_to_js_type_from_ast_inner(
                         ty,
                         source,
                         interfaces,
                         type_aliases,
+                        seen,
                     ))
                 }
             }))
         }
         TSType::TSConditionalType(conditional) => combine_runtime_js_types([
-            ts_type_to_js_type_from_ast(&conditional.true_type, source, interfaces, type_aliases),
-            ts_type_to_js_type_from_ast(&conditional.false_type, source, interfaces, type_aliases),
+            ts_type_to_js_type_from_ast_inner(
+                &conditional.true_type,
+                source,
+                interfaces,
+                type_aliases,
+                seen,
+            ),
+            ts_type_to_js_type_from_ast_inner(
+                &conditional.false_type,
+                source,
+                interfaces,
+                type_aliases,
+                seen,
+            ),
         ]),
         TSType::TSIntersectionType(intersection) => {
             if intersection.types.iter().any(|ty| {
@@ -519,13 +552,21 @@ fn ts_type_to_js_type_from_ast(
                 "null".to_compact_string()
             }
         }
-        TSType::TSParenthesizedType(paren) => {
-            ts_type_to_js_type_from_ast(&paren.type_annotation, source, interfaces, type_aliases)
-        }
+        TSType::TSParenthesizedType(paren) => ts_type_to_js_type_from_ast_inner(
+            &paren.type_annotation,
+            source,
+            interfaces,
+            type_aliases,
+            seen,
+        ),
         TSType::TSTypeOperatorType(op) => match op.operator {
-            TSTypeOperatorOperator::Readonly => {
-                ts_type_to_js_type_from_ast(&op.type_annotation, source, interfaces, type_aliases)
-            }
+            TSTypeOperatorOperator::Readonly => ts_type_to_js_type_from_ast_inner(
+                &op.type_annotation,
+                source,
+                interfaces,
+                type_aliases,
+                seen,
+            ),
             TSTypeOperatorOperator::Keyof => "String".to_compact_string(),
             TSTypeOperatorOperator::Unique => "null".to_compact_string(),
         },
@@ -545,6 +586,14 @@ fn ts_type_to_js_type_from_ast(
             if let Some(type_aliases) = type_aliases
                 && let Some(alias) = type_aliases.get(name)
             {
+                // Stop following recursive / mutually recursive aliases. Without
+                // this guard a self-referential alias body re-parses and
+                // re-enters here forever, overflowing the stack. (nuxt-ui
+                // `CheckboxGroup`/`RadioGroup` hit this via `NestedItem` /
+                // `DotPathKeys`.)
+                if seen.iter().any(|seen_name| seen_name == name) {
+                    return "null".to_compact_string();
+                }
                 let alias_source = wrap_type_alias_source(alias);
                 let allocator = Allocator::default();
                 let parsed = Parser::new(&allocator, &alias_source, SourceType::ts()).parse();
@@ -553,12 +602,16 @@ fn ts_type_to_js_type_from_ast(
                     && let Some(Statement::TSTypeAliasDeclaration(alias_decl)) =
                         parsed.program.body.first()
                 {
-                    return ts_type_to_js_type_from_ast(
+                    seen.push(name.to_compact_string());
+                    let resolved = ts_type_to_js_type_from_ast_inner(
                         &alias_decl.type_annotation,
                         &alias_source,
                         interfaces,
                         Some(type_aliases),
+                        seen,
                     );
+                    seen.pop();
+                    return resolved;
                 }
             }
             "null".to_compact_string()
@@ -1984,7 +2037,49 @@ pub fn is_valid_identifier(s: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::{extract_emit_names_from_type, ts_type_to_js_type};
+    use super::{
+        extract_emit_names_from_type, extract_prop_types_from_type_with_context, ts_type_to_js_type,
+    };
+    use vize_carton::{FxHashMap, ToCompactString};
+
+    #[test]
+    fn recursive_type_alias_prop_does_not_overflow() {
+        // Mirrors nuxt-ui `CheckboxGroup`/`RadioGroup`: a props type whose member
+        // resolves through a self-referential alias (`DotPathKeys`) and a
+        // conditional/mutually-recursive alias (`NestedItem`). Before the cycle
+        // guard in `ts_type_to_js_type_from_ast`, resolving the runtime type of
+        // such a prop re-parsed the same alias body forever and overflowed the
+        // native stack, aborting `vize build`.
+        let mut type_aliases: FxHashMap<vize_carton::String, vize_carton::String> =
+            FxHashMap::default();
+        type_aliases.insert(
+            "NestedItem".to_compact_string(),
+            "T extends Array<infer I> ? NestedItem<I> : T".to_compact_string(),
+        );
+        type_aliases.insert(
+            "DotPathKeys".to_compact_string(),
+            "{ [K in keyof T & string]: K | `${K}.${DotPathKeys<T[K]>}` }[keyof T & string]"
+                .to_compact_string(),
+        );
+
+        let type_args = "{ items?: NestedItem<string>; keys?: DotPathKeys<Record<string, any>> }";
+
+        let props = extract_prop_types_from_type_with_context(type_args, None, Some(&type_aliases));
+
+        let items = props
+            .iter()
+            .find(|(name, _)| name == "items")
+            .expect("items prop should be extracted");
+        // Recursive structural types have no runtime constructor.
+        assert_eq!(items.1.js_type.as_str(), "null");
+        assert!(items.1.optional);
+
+        let keys = props
+            .iter()
+            .find(|(name, _)| name == "keys")
+            .expect("keys prop should be extracted");
+        assert_eq!(keys.1.js_type.as_str(), "null");
+    }
 
     #[test]
     fn extract_emit_names_keeps_quoted_colon_keys() {


### PR DESCRIPTION
## Problem

`vize build` aborts with a native stack overflow (`fatal runtime error: stack overflow, aborting`) when compiling an SFC whose `defineProps` references a **self-referential or mutually recursive type alias**.

Minimal repro from nuxt-ui (`src/runtime/components/CheckboxGroup.vue`, `RadioGroup.vue`):

```
target/ci/vize build CheckboxGroup.vue --ssr   # before: stack overflow / abort
```

The recursion is in `ts_type_to_js_type_from_ast` (`crates/vize_atelier_sfc/src/compile_script/props.rs`). When a prop's type resolves to a `TSTypeReference` naming a type alias, the resolver re-parses the alias body and recurses. nuxt-ui's `NestedItem<T> = T extends Array<infer I> ? NestedItem<I> : T` and the recursive `DotPathKeys` aliases reference themselves, so the resolver re-parses the same body and re-enters forever — unlike the sibling `collect_props_from_ts_type`, this path had **no cycle guard**.

This is the root cause of the nuxt-ui **dev SSR 500** (`Cannot read properties of undefined (reading 'type')`): the failed module transform left the component's render export undefined, so SSR rendered a vnode whose `.type` was `undefined`.

## Fix

Thread a `seen` stack of in-progress alias names through the AST type resolver (private `ts_type_to_js_type_from_ast_inner`) and stop following an alias reference once its name is already being resolved, falling back to a safe `null` runtime type. Mirrors the cycle protection already used by `collect_props_from_ts_type` / `resolve_type_reference_text`.

Recursive structural types correctly resolve to `type: null` (no runtime constructor), matching `@vue/compiler-sfc`.

## Validation

- New regression test `recursive_type_alias_prop_does_not_overflow` (hung/aborted before the fix).
- `cargo test -p vize_atelier_sfc` (505) and `-p vize_atelier_core` (168) pass.
- `cargo clippy -p vize_atelier_sfc -- -D warnings` clean; `cargo fmt --check` clean.
- All 173 nuxt-ui runtime components now compile (DOM + SSR); previously the whole-glob build aborted.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1311"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783618393&installation_id=136613492&pr_number=1311&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1311&signature=05389723e59632b58f5bfe8909ac3edc4cdac7f578f6f4ac0a44aa3bc72f256a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->