### PR TITLE
fix(atelier_ssr): keep component event listeners and v-model handlers

### DIFF
--- a/crates/vize_atelier_ssr/src/codegen/element/component.rs
+++ b/crates/vize_atelier_ssr/src/codegen/element/component.rs
@@ -421,31 +421,52 @@ impl<'a> SsrCodegenContext<'a> {
                 }
             }
             "model" => {
-                let Some(arg) = &dir.arg else {
-                    return;
-                };
-                let arg_is_static =
-                    matches!(arg, ExpressionNode::Simple(simple) if simple.is_static);
-                if arg_is_static {
-                    return;
-                }
-
-                *needs_normalize = true;
-                let key = self.dynamic_arg_to_string(arg);
                 let value = dir
                     .exp
                     .as_ref()
                     .map(|exp| self.expression_to_string(exp))
                     .unwrap_or_else(|| "undefined".to_compact_string());
 
-                entries.push(component_prop_entry(&key, &value, true));
+                match &dir.arg {
+                    // Static argument: `v-model:foo="x"` emits `foo` plus its
+                    // matching `onUpdate:foo` listener, mirroring Vue's SSR
+                    // compiler so components receive the update handler.
+                    Some(ExpressionNode::Simple(arg)) if arg.is_static => {
+                        let prop_key = vize_carton::camelize(&arg.content);
+                        entries.push(component_prop_entry(&prop_key, &value, false));
 
-                let mut update_key = String::from("\"onUpdate:\" + ");
-                update_key.push_str(&key);
-                let mut handler = String::from("$event => ((");
-                handler.push_str(&value);
-                handler.push_str(") = $event)");
-                entries.push(component_prop_entry(&update_key, &handler, true));
+                        let mut update_key = String::from("onUpdate:");
+                        update_key.push_str(&prop_key);
+                        let mut handler = String::from("$event => ((");
+                        handler.push_str(&value);
+                        handler.push_str(") = $event)");
+                        entries.push(component_prop_entry(&update_key, &handler, false));
+                    }
+                    // No argument: `v-model="x"` maps to `modelValue` plus
+                    // `onUpdate:modelValue`.
+                    None => {
+                        entries.push(component_prop_entry("modelValue", &value, false));
+
+                        let mut handler = String::from("$event => ((");
+                        handler.push_str(&value);
+                        handler.push_str(") = $event)");
+                        entries.push(component_prop_entry("onUpdate:modelValue", &handler, false));
+                    }
+                    // Dynamic argument: `v-model:[name]="x"`.
+                    Some(arg) => {
+                        *needs_normalize = true;
+                        let key = self.dynamic_arg_to_string(arg);
+
+                        entries.push(component_prop_entry(&key, &value, true));
+
+                        let mut update_key = String::from("\"onUpdate:\" + ");
+                        update_key.push_str(&key);
+                        let mut handler = String::from("$event => ((");
+                        handler.push_str(&value);
+                        handler.push_str(") = $event)");
+                        entries.push(component_prop_entry(&update_key, &handler, true));
+                    }
+                }
             }
             "show" => {
                 let Some(exp) = dir.exp.as_ref().map(|exp| self.expression_to_string(exp)) else {
@@ -457,12 +478,86 @@ impl<'a> SsrCodegenContext<'a> {
                     false,
                 ));
             }
-            // Server-rendered HTML does not need event listener props, and slot/
-            // DOM-only/custom directives are handled elsewhere or ignored by Vue's
-            // SSR compiler for component prop bags.
-            "on" | "slot" | "html" | "text" => {}
+            // Components receive event listeners as props during SSR (Vue's SSR
+            // compiler keeps `onXxx` handlers on component vnodes, unlike plain
+            // elements where listeners never affect server-rendered HTML). This
+            // also covers desugared `v-model` update handlers (`onUpdate:foo`).
+            "on" => self.collect_component_event_handler(dir, entries, spreads, needs_normalize),
+            // Slot/DOM-only/custom directives are handled elsewhere or ignored by
+            // Vue's SSR compiler for component prop bags.
+            "slot" | "html" | "text" => {}
             _ => {}
         }
+    }
+
+    /// Emit a `v-on` listener as a component prop (`onXxx: handler`).
+    ///
+    /// Mirrors Vue's base `transformOn` as used by the SSR compiler: the event
+    /// name is converted to a handler key, and inline statements are wrapped in
+    /// an `$event => (...)` arrow while function/member references pass through.
+    /// DOM-only event modifiers (`.stop`, `.enter`, ...) do not apply to
+    /// component listeners and are intentionally ignored.
+    fn collect_component_event_handler(
+        &mut self,
+        dir: &DirectiveNode,
+        entries: &mut std::vec::Vec<VNodePropEntry>,
+        spreads: &mut std::vec::Vec<String>,
+        needs_normalize: &mut bool,
+    ) {
+        // `v-on="obj"` object syntax: merge the listener object via `_toHandlers`.
+        let Some(arg) = &dir.arg else {
+            let obj = dir
+                .exp
+                .as_ref()
+                .map(|exp| self.expression_to_string(exp))
+                .unwrap_or_else(|| "{}".to_compact_string());
+            self.use_core_helper(RuntimeHelper::ToHandlers);
+            spreads.push(wrap_call("_toHandlers", &obj));
+            return;
+        };
+
+        let handler = dir
+            .exp
+            .as_ref()
+            .map(|exp| self.event_handler_to_string(exp))
+            .unwrap_or_else(|| "() => {}".to_compact_string());
+
+        match arg {
+            // `@click`, `@custom-event`, desugared `onUpdate:foo` (`Update:foo`).
+            ExpressionNode::Simple(arg) if arg.is_static => {
+                let key = vize_atelier_core::transforms::create_on_name(&arg.content);
+                entries.push(component_prop_entry(&key, &handler, false));
+            }
+            // Dynamic event name: `@[name]="handler"`.
+            _ => {
+                *needs_normalize = true;
+                self.use_core_helper(RuntimeHelper::ToHandlerKey);
+                let name = self.dynamic_arg_to_string(arg);
+                let key = cstr!("_toHandlerKey({name})");
+                entries.push(component_prop_entry(&key, &handler, true));
+            }
+        }
+    }
+
+    /// Render a `v-on` handler expression, wrapping inline statements in an
+    /// arrow function the way Vue's compiler does for component listeners.
+    fn event_handler_to_string(&mut self, exp: &ExpressionNode) -> String {
+        let rendered = self.expression_to_string(exp);
+
+        if matches!(exp, ExpressionNode::Simple(simple) if simple.is_static) {
+            return rendered;
+        }
+
+        if vize_atelier_core::transforms::transform_expression::is_function_expression(&rendered)
+            || vize_atelier_core::transforms::is_event_handler_reference_expression(&rendered)
+        {
+            return rendered;
+        }
+
+        let mut out = String::from("$event => (");
+        out.push_str(&rendered);
+        out.push(')');
+        out
     }
 
     /// Render a dynamic directive argument while preserving scoped slot locals.

--- a/crates/vize_atelier_ssr/tests/snapshots/ssr_snapshot__component__component_event_listeners_are_kept.snap
+++ b/crates/vize_atelier_ssr/tests/snapshots/ssr_snapshot__component__component_event_listeners_are_kept.snap
@@ -1,0 +1,7 @@
+---
+source: crates/vize_atelier_ssr/tests/ssr_snapshot.rs
+expression: "compile_full(r#\"<Foo @click=\"onClick\" @custom-event=\"onClick\" @bump=\"count++\" @key-up.enter=\"onKey\" />\"#)"
+---
+function ssrRender(_ctx, _push, _parent, _attrs) {
+  _push(_ssrRenderComponent(_resolveComponent("Foo"), _mergeProps({ onClick: _ctx.onClick, onCustomEvent: _ctx.onClick, onBump: $event => (_ctx.count++), onKeyUp: _ctx.onKey }, _attrs), null, _parent))
+}

--- a/crates/vize_atelier_ssr/tests/snapshots/ssr_snapshot__component__component_v_model_keeps_update_listener.snap
+++ b/crates/vize_atelier_ssr/tests/snapshots/ssr_snapshot__component__component_v_model_keeps_update_listener.snap
@@ -1,0 +1,7 @@
+---
+source: crates/vize_atelier_ssr/tests/ssr_snapshot.rs
+expression: "compile_full(r#\"<Foo v-model=\"value\" />\"#)"
+---
+function ssrRender(_ctx, _push, _parent, _attrs) {
+  _push(_ssrRenderComponent(_resolveComponent("Foo"), _mergeProps({ modelValue: _ctx.value, "onUpdate:modelValue": $event => ((_ctx.value) = $event) }, _attrs), null, _parent))
+}

--- a/crates/vize_atelier_ssr/tests/snapshots/ssr_snapshot__component__component_v_model_with_argument_keeps_update_listener.snap
+++ b/crates/vize_atelier_ssr/tests/snapshots/ssr_snapshot__component__component_v_model_with_argument_keeps_update_listener.snap
@@ -1,0 +1,7 @@
+---
+source: crates/vize_atelier_ssr/tests/ssr_snapshot.rs
+expression: "compile_full(r#\"<Foo v-model:sort-option=\"sort\" />\"#)"
+---
+function ssrRender(_ctx, _push, _parent, _attrs) {
+  _push(_ssrRenderComponent(_resolveComponent("Foo"), _mergeProps({ "sort-option": _ctx.sort, "onUpdate:sortOption": $event => ((_ctx.sort) = $event) }, _attrs), null, _parent))
+}

--- a/crates/vize_atelier_ssr/tests/snapshots/ssr_snapshot__component__component_v_on_object_syntax_merges_handlers.snap
+++ b/crates/vize_atelier_ssr/tests/snapshots/ssr_snapshot__component__component_v_on_object_syntax_merges_handlers.snap
@@ -1,0 +1,7 @@
+---
+source: crates/vize_atelier_ssr/tests/ssr_snapshot.rs
+expression: "compile_full(r#\"<Foo v-on=\"handlers\" :id=\"id\" />\"#)"
+---
+function ssrRender(_ctx, _push, _parent, _attrs) {
+  _push(_ssrRenderComponent(_resolveComponent("Foo"), _mergeProps(_mergeProps(_normalizeProps(_guardReactiveProps(_toHandlers(_ctx.handlers))), { id: _ctx.id }), _attrs), null, _parent))
+}

--- a/crates/vize_atelier_ssr/tests/ssr_snapshot.rs
+++ b/crates/vize_atelier_ssr/tests/ssr_snapshot.rs
@@ -348,6 +348,31 @@ mod component {
     }
 
     #[test]
+    fn component_event_listeners_are_kept() {
+        // Components receive `onXxx` listeners as props during SSR (unlike plain
+        // elements where listeners do not affect the rendered HTML). Inline
+        // statements wrap in `$event => (...)`; DOM-only modifiers are ignored.
+        insta::assert_snapshot!(compile_full(
+            r#"<Foo @click="onClick" @custom-event="onClick" @bump="count++" @key-up.enter="onKey" />"#
+        ));
+    }
+
+    #[test]
+    fn component_v_model_keeps_update_listener() {
+        insta::assert_snapshot!(compile_full(r#"<Foo v-model="value" />"#));
+    }
+
+    #[test]
+    fn component_v_model_with_argument_keeps_update_listener() {
+        insta::assert_snapshot!(compile_full(r#"<Foo v-model:sort-option="sort" />"#));
+    }
+
+    #[test]
+    fn component_v_on_object_syntax_merges_handlers() {
+        insta::assert_snapshot!(compile_full(r#"<Foo v-on="handlers" :id="id" />"#));
+    }
+
+    #[test]
     fn component_with_slot_content() {
         insta::assert_snapshot!(compile_full(r#"<Foo><div>slot content</div></Foo>"#));
     }


### PR DESCRIPTION
## Problem

The SSR component prop codegen dropped **all** `v-on` handlers and the `onUpdate:*` listener half of `v-model` on component vnodes:

```js
// vize SSR (before) — listeners gone
_ssrRenderComponent(_resolveComponent("Child"), { foo: $setup.val }, null, _parent)
```

Vue's SSR compiler keeps `onXxx`/`onUpdate:*` props on **component** vnodes (only plain-element listeners are omitted, since they never affect rendered HTML):

```js
// @vue/compiler-sfc SSR
_ssrRenderComponent(_component_Child, {
  foo: val.value,
  "onUpdate:foo": $event => ((val).value = $event),
  onBar: onClick
}, null, _parent)
```

This was surfaced while investigating the npmx `org-vue` VRT and nuxt-ui dev failures. On `app/pages/org/[org].vue`, `<PackageListToolbar>` / `<PaginationControls>` lost every `@toggle-column`, `@clear-filter`, `v-model:sort-option`, etc. handler in the SSR output, diverging from `@vue/compiler-sfc` and breaking listener parity through hydration.

## Fix

In `collect_component_directive_prop`, emit component listeners as props, mirroring Vue's base `transformOn`:

- event name → handler key via `create_on_name` (`@custom-event` → `onCustomEvent`, desugared `Update:foo` → `onUpdate:foo`)
- inline statements wrapped in `$event => (...)`; function/member refs passed through
- DOM-only modifiers (`.stop`, `.enter`, ...) ignored (they don't apply to component listeners)
- `v-on="obj"` merged via `_toHandlers`
- restored the `onUpdate:modelValue` / `onUpdate:foo` handler for no-arg and static-arg `v-model`

Plain-element SSR behavior is unchanged (listeners still correctly omitted; `<input v-model>` still renders only `value`).

## Validation

- New regression snapshots: component event listeners, `v-model`, `v-model:arg`, `v-on="obj"` — all match `@vue/compiler-sfc` SSR output.
- `cargo test -p vize_atelier_ssr` (76 snapshot + 72 unit) and `-p vize_atelier_sfc` pass.
- `cargo clippy -D warnings` and `cargo fmt --check` clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1313"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783622252&installation_id=136613492&pr_number=1313&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1313&signature=f19e355f980f9adf2f4d16cc8e0f0f0aaf7037bce8d6cec25ffb505ca46b6c89"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->