### PR TITLE
test(app): stabilize flaky npmx org VRT and nuxt-ui dev specs

### DIFF
--- a/tests/_helpers/mocking.ts
+++ b/tests/_helpers/mocking.ts
@@ -584,6 +584,203 @@ export async function setupMisskeyMocks(page: Page): Promise<void> {
   }, MISSKEY_API_FIXTURES);
 }
 
+// --- npmx.dev VRT mocks ---
+//
+// The `/org/[org]` route renders LIVE data fetched from external services: the
+// npm registry org endpoint (proxied through `/api/registry/org/<org>/packages`)
+// and the Algolia `npm-search` index (`getObjects` via
+// `https://<appId>-dsn.algolia.net/1/indexes/*/objects`). Two independent dev
+// servers (reference Vue vs candidate vize) issue these requests separately, and
+// under CI/sandbox rate-limiting they receive different payloads (one shows
+// packages, the other empty/loading), so the screenshots diverge. That is a test
+// nondeterminism, not a render bug.
+//
+// To make the route deterministic we intercept both endpoints (mirroring the
+// misskey `/api/**` approach) and return a fixed fixture payload for BOTH the
+// reference and candidate pages so they render an identical package-list state.
+
+interface NpmxAlgoliaHit {
+  objectID: string;
+  name: string;
+  version: string;
+  description: string | null;
+  modified: number;
+  homepage: string | null;
+  repository: {
+    url: string;
+    host: string;
+    user: string;
+    project: string;
+    path: string;
+  } | null;
+  owners: { name: string; email?: string; avatar?: string; link?: string }[] | null;
+  downloadsLast30Days: number;
+  downloadsRatio: number;
+  popular: boolean;
+  keywords: string[];
+  deprecated: boolean | string;
+  isDeprecated: boolean;
+  license: string | null;
+}
+
+// A fixed point in time so `modified`-derived dates render identically.
+const NPMX_FIXTURE_MODIFIED = Date.parse("2026-01-01T00:00:00.000Z");
+
+function npmxAlgoliaHit(name: string, overrides: Partial<NpmxAlgoliaHit> = {}): NpmxAlgoliaHit {
+  return {
+    objectID: name,
+    name,
+    version: "3.5.29",
+    description: `Fixture package ${name} for the npmx VRT.`,
+    modified: NPMX_FIXTURE_MODIFIED,
+    homepage: "https://github.com/vuejs/core",
+    repository: {
+      url: "https://github.com/vuejs/core",
+      host: "github.com",
+      user: "vuejs",
+      project: "core",
+      path: "",
+    },
+    owners: [{ name: "vuejs", email: "fixture@example.com" }],
+    downloadsLast30Days: 43_000_000,
+    downloadsRatio: 1,
+    popular: true,
+    keywords: ["vue", "framework"],
+    deprecated: false,
+    isDeprecated: false,
+    license: "MIT",
+    ...overrides,
+  };
+}
+
+// Deterministic package roster for `@vue` (sorted so list ordering is stable).
+const NPMX_ORG_FIXTURES: Record<string, NpmxAlgoliaHit[]> = {
+  vue: [
+    npmxAlgoliaHit("@vue/compiler-core", { downloadsLast30Days: 41_000_000 }),
+    npmxAlgoliaHit("@vue/compiler-dom", { downloadsLast30Days: 40_000_000 }),
+    npmxAlgoliaHit("@vue/compiler-sfc", { downloadsLast30Days: 39_000_000 }),
+    npmxAlgoliaHit("@vue/reactivity", { downloadsLast30Days: 42_000_000 }),
+    npmxAlgoliaHit("@vue/runtime-core", { downloadsLast30Days: 41_500_000 }),
+    npmxAlgoliaHit("@vue/runtime-dom", { downloadsLast30Days: 41_200_000 }),
+    npmxAlgoliaHit("@vue/server-renderer", { downloadsLast30Days: 30_000_000 }),
+    npmxAlgoliaHit("@vue/shared", { downloadsLast30Days: 43_500_000 }),
+  ],
+};
+
+function npmxOrgHits(org: string): NpmxAlgoliaHit[] {
+  return NPMX_ORG_FIXTURES[org.toLowerCase()] ?? NPMX_ORG_FIXTURES.vue;
+}
+
+/**
+ * Make the npmx `/org/[org]` route deterministic for visual parity by returning
+ * fixed package data for both the npm-registry org proxy and the Algolia
+ * `getObjects` lookup. Wire this into BOTH the reference and candidate pages.
+ */
+export async function setupNpmxOrgMocks(page: Page): Promise<void> {
+  // 1) npm-registry org package list (server proxy, hit client-side after
+  //    hydration because the page uses `useLazyAsyncData`).
+  await page.context().route("**/api/registry/org/**/packages", async (route) => {
+    const match = /\/api\/registry\/org\/([^/]+)\/packages/.exec(
+      new URL(route.request().url()).pathname,
+    );
+    const org = match ? decodeURIComponent(match[1]) : "vue";
+    const hits = npmxOrgHits(org);
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ packages: hits.map((hit) => hit.name), count: hits.length }),
+    });
+  });
+
+  // 2) All Algolia traffic (matched by a host regex to avoid URL-glob quirks).
+  //    There are two shapes used by npmx:
+  //      - `getObjects` multi-get by objectID  -> `{ results: (Hit|null)[] }`
+  //        (used by `getPackagesByName`, the algolia provider path for orgs)
+  //      - the lite client multi-query `search` -> `{ results: [{ hits, ... }] }`
+  //        (used by the npm-search box / suggestion checks)
+  //    Return the fixed org roster in whichever shape the request expects.
+  await page.context().route(/\.algolia(net\.com|\.net)\//, async (route) => {
+    const request = route.request();
+    const pathname = new URL(request.url()).pathname;
+
+    if (pathname.includes("/objects")) {
+      let requested: string[] = [];
+      try {
+        const payload = request.postDataJSON() as
+          | { requests?: { objectID?: string }[] }
+          | undefined;
+        requested = (payload?.requests ?? [])
+          .map((entry) => entry.objectID)
+          .filter((id): id is string => typeof id === "string");
+      } catch {
+        requested = [];
+      }
+
+      const byName = new Map<string, NpmxAlgoliaHit>();
+      for (const hits of Object.values(NPMX_ORG_FIXTURES)) {
+        for (const hit of hits) byName.set(hit.name, hit);
+      }
+
+      const results =
+        requested.length > 0
+          ? requested.map((name) => byName.get(name) ?? null)
+          : npmxOrgHits("vue");
+
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ results }),
+      });
+      return;
+    }
+
+    const hits = npmxOrgHits("vue");
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        results: [
+          {
+            hits,
+            nbHits: hits.length,
+            page: 0,
+            nbPages: 1,
+            hitsPerPage: hits.length,
+            query: "",
+            params: "",
+            index: "npm-search",
+          },
+        ],
+      }),
+    });
+  });
+
+  // 3) npm-provider fallback path (`?p=npm`) hits the lightweight package-meta
+  //    proxy; keep it deterministic as well.
+  await page.context().route("**/api/registry/package-meta/**", async (route) => {
+    const pathname = new URL(route.request().url()).pathname;
+    const name = decodeURIComponent(
+      pathname.slice(pathname.indexOf("/package-meta/") + "/package-meta/".length),
+    );
+    const hit = npmxOrgHits("vue").find((entry) => entry.name === name) ?? npmxAlgoliaHit(name);
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        name: hit.name,
+        version: hit.version,
+        description: hit.description ?? "",
+        keywords: hit.keywords,
+        license: hit.license,
+        date: new Date(hit.modified).toISOString(),
+        links: { npm: `https://www.npmjs.com/package/${hit.name}` },
+        maintainers: hit.owners?.map((owner) => ({ name: owner.name, email: owner.email })) ?? [],
+        weeklyDownloads: Math.round(hit.downloadsLast30Days / 4.3),
+      }),
+    });
+  });
+}
+
 export async function mockRoute(
   page: Page,
   pattern: string | RegExp,

--- a/tests/app/dev/nuxt-ui.spec.ts
+++ b/tests/app/dev/nuxt-ui.spec.ts
@@ -19,11 +19,83 @@ import {
 
 const app = nuxtUiApp;
 
+// Routes the suite navigates to. We pre-warm these once before the tests so Vite
+// finishes optimize-deps pre-bundling for the (very heavy) nuxt-ui playground
+// before the timed `toBeVisible` assertions run.
+const WARMUP_PATHS = ["/", "/components/button"] as const;
+
+// Signatures of the transient Vite optimize-deps churn that produces a broken
+// initial load (504 Outdated Optimize Dep -> failed dynamic import -> SSR 500).
+// These are dev-server infra hiccups, not vize render bugs, and resolve on reload
+// once pre-bundling settles.
+const OPTIMIZE_DEP_ERROR =
+  /Outdated Optimize Dep|Failed to fetch dynamically imported module|504|new dependencies optimized/i;
+
+/**
+ * Hit the dev server for each warmup path until it returns a healthy SSR page
+ * (no optimize-dep error markup), so Vite has finished pre-bundling before the
+ * browser-driven assertions start.
+ */
+async function warmUpNuxtUi(): Promise<void> {
+  const deadline = Date.now() + 120_000;
+  for (const pathname of WARMUP_PATHS) {
+    const target = new URL(pathname, app.url).toString();
+    let settled = false;
+    while (Date.now() < deadline) {
+      try {
+        const res = await fetch(target, { signal: AbortSignal.timeout(20_000) });
+        const body = await res.text();
+        const churning = res.status >= 500 || res.status === 504 || OPTIMIZE_DEP_ERROR.test(body);
+        if (!churning && body.includes("__nuxt")) {
+          settled = true;
+          break;
+        }
+      } catch {
+        // Server still pre-bundling / restarting; retry.
+      }
+      await new Promise((r) => setTimeout(r, 2_000));
+    }
+    if (!settled) {
+      console.log(`[${app.name}] warmup for ${pathname} did not fully settle; continuing`);
+    }
+  }
+}
+
+/**
+ * Navigate to a nuxt-ui route, reloading if the dev server serves a transient
+ * optimize-deps error (504 / failed dynamic import / SSR 500) instead of the
+ * playground. Bounded retries keep this from masking real failures.
+ */
 async function gotoNuxtUi(page: Page, pathname = "/") {
-  return page.goto(new URL(pathname, app.url).toString(), {
-    waitUntil: app.waitUntil ?? "networkidle",
-    timeout: 30_000,
-  });
+  const target = new URL(pathname, app.url).toString();
+  const maxAttempts = 4;
+  let response: Awaited<ReturnType<Page["goto"]>> = null;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    response = await page.goto(target, {
+      waitUntil: app.waitUntil ?? "networkidle",
+      timeout: 30_000,
+    });
+
+    const status = response?.status() ?? 0;
+    const html = await page.content().catch(() => "");
+    const churning = status === 504 || status >= 500 || OPTIMIZE_DEP_ERROR.test(html);
+
+    if (!churning) {
+      return response;
+    }
+
+    if (attempt < maxAttempts) {
+      console.log(
+        `[${app.name}] transient optimize-deps error on ${pathname} ` +
+          `(status ${status}, attempt ${attempt}); reloading...`,
+      );
+      // Give Vite a moment to finish re-bundling before retrying.
+      await page.waitForTimeout(2_000);
+    }
+  }
+
+  return response;
 }
 
 function normalizeNuxtUiSnapshotHtml(html: string): string {
@@ -42,6 +114,9 @@ test.describe("nuxt-ui dev", () => {
   let devServer: ChildProcess;
 
   test.beforeAll(async () => {
+    // setup + install + dev:prepare + server start + route warmup can exceed the
+    // default hook timeout for this heavy playground.
+    test.setTimeout(600_000);
     if (app.setup) app.setup();
     await ensurePortFree(app.port);
 
@@ -61,6 +136,13 @@ test.describe("nuxt-ui dev", () => {
     );
     await waitForHttpReady(app.url, app.port);
     console.log(`${app.name} server is ready`);
+
+    // Pre-bundle the routes the suite visits so Vite finishes optimize-deps churn
+    // (504 Outdated Optimize Dep / failed dynamic import / SSR 500) before the
+    // timed browser assertions run.
+    console.log(`Warming up ${app.name} routes...`);
+    await warmUpNuxtUi();
+    console.log(`${app.name} warmup complete`);
   });
 
   test.afterAll(async () => {

--- a/tests/app/vrt/npmx.spec.ts
+++ b/tests/app/vrt/npmx.spec.ts
@@ -16,10 +16,14 @@ import {
   prepareStableVisualState,
 } from "../../_helpers/visual-parity";
 import { waitForMountedAppContent } from "../../_helpers/assertions";
+import { setupNpmxOrgMocks } from "../../_helpers/mocking";
 
 interface VisualRoute {
   action?: (page: Page) => Promise<void>;
   maxDiffRatio?: number;
+  // Per-route request mocking applied identically to reference and candidate
+  // pages, so routes that render LIVE external data stay deterministic.
+  mocks?: (page: Page) => Promise<void>;
   name: string;
   path: string;
   storage?: Record<string, string>;
@@ -62,7 +66,14 @@ const routes: VisualRoute[] = [
     path: "/package/@vue/compiler-sfc",
     maxDiffRatio: 0.004,
   },
-  { name: "org-vue", path: "/org/vue", maxDiffRatio: 0.004 },
+  {
+    name: "org-vue",
+    path: "/org/vue",
+    maxDiffRatio: 0.004,
+    // `/org/vue` fetches live npm-registry + Algolia data; mock both endpoints so
+    // the reference and candidate servers render an identical package list.
+    mocks: setupNpmxOrgMocks,
+  },
   { name: "user-sindresorhus", path: "/~sindresorhus?p=npm", maxDiffRatio: 0.004 },
   { name: "user-orgs-disconnected", path: "/~sindresorhus/orgs", maxDiffRatio: 0.004 },
   { name: "profile-sindresorhus", path: "/profile/sindresorhus.com", maxDiffRatio: 0.004 },
@@ -153,6 +164,12 @@ async function compareRoute(
 
     await Promise.all([setupPage(referencePage), setupPage(candidatePage)]);
     await Promise.all([setupRoute(referencePage, route), setupRoute(candidatePage, route)]);
+    if (route.mocks) {
+      // Mocks are registered at the (shared) browser-context level via
+      // `page.context().route(...)`, so they apply to both the reference and
+      // candidate pages; registering once is enough.
+      await route.mocks(referencePage);
+    }
     await Promise.all([
       openRoute(referencePage, apps.reference.url, route),
       openRoute(candidatePage, apps.candidate.url, route),


### PR DESCRIPTION
Two flaky App E2E cases are stabilized via **test-only** changes. Both are confirmed test-infrastructure issues (external-API network nondeterminism and Vite optimize-deps churn), not vize compiler/render bugs. No Rust/compiler code touched.

## Task A — npmx VRT \`org-vue\` determinism
`tests/app/vrt/npmx.spec.ts › npmx.dev visual parity › dev › org-vue` failed with a deterministic ~0.96 visual diff.

**Root cause:** `/org/vue` renders LIVE data fetched from external services — the npm registry org endpoint (proxied as `/api/registry/org/<org>/packages`) and the Algolia `npm-search` index (`getObjects`). The reference (Vue) and candidate (vize) dev servers fetch this independently; under CI/sandbox rate-limiting they get different payloads (one shows packages, the other empty/loading), so screenshots diverge.

**Fix:** Added `setupNpmxOrgMocks(page)` in `tests/_helpers/mocking.ts`, mirroring the misskey `/api/**` mocking approach. It intercepts (at the shared browser-context level, so reference + candidate both see it):
- `**/api/registry/org/**/packages` → fixed `{ packages, count }` for a deterministic `@vue/*` roster.
- All Algolia hosts (`*.algolia.net` / `*.algolianet.com`) — branches on path: `getObjects` (`/objects`) returns `{ results: (Hit|null)[] }` echoing the requested objectIDs; the lite-client multi-`queries` returns `{ results: [{ hits, ... }] }`.
- `**/api/registry/package-meta/**` → deterministic meta for the `?p=npm` provider fallback.

Wired into `npmx.spec.ts` via a new per-route `mocks` hook, attached only to `org-vue`. Both pages then render an identical package-list state. Verified the route-match regexes and objectID/org/pkg-name extraction against the real npmx data layer (`useOrgPackages` / `useAlgoliaSearch`) and the live URLs.

## Task B — nuxt-ui dev server stability (best-effort)
`tests/app/dev/nuxt-ui.spec.ts` (`/`, `/components/button`) failed because the very heavy nuxt-ui playground dev server hits transient Vite `504 Outdated Optimize Dep` → `Failed to fetch dynamically imported module .../entry.js` → SSR 500 during initial load, so navigation never finished within the 30s assertion.

**Fix (test-only):**
1. `warmUpNuxtUi()` in `beforeAll` hits each visited route until it serves healthy SSR markup (no optimize-dep error), letting Vite finish pre-bundling before the timed assertions run. `beforeAll` timeout raised to accommodate.
2. `gotoNuxtUi()` now detects the transient 504/500/optimize-dep markup and reloads with bounded retries (max 4) before returning.

## Verification
- `oxfmt --check` and `oxlint` clean on all three changed files.
- Validated all route-matching regexes, the Algolia `objects` vs `queries` branch, and the org/package-name extraction against the actual fixture URLs (npmx submodule inspected).
- Full two-server VRT / nuxt-ui dev runs were **not** executed locally: they require building all vize packages + two pnpm installs + nuxt prepare + two long-running heavy dev servers, and depend on the same npm/Algolia network that is rate-limited in this sandbox (the failure being fixed). Changes are test-only and logic-verified.

## Residual risk
- **Task A:** High confidence. Mocking is comprehensive (registry proxy + both Algolia shapes + npm fallback) and deterministic for both servers; this should fully resolve the diff.
- **Task B:** Best-effort. Warmup + reload-on-504 substantially reduces the optimize-deps flake, but cannot fully eliminate it if Vite re-triggers pre-bundling mid-test on first cold navigation. If it still flakes in CI, recommend tracking nuxt-ui dev separately rather than blocking, and consider configuring the playground's `optimizeDeps` (include heavy entry deps / `holdUntilCrawlEnd`) as a follow-up.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1314"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783622932&installation_id=136613492&pr_number=1314&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1314&signature=37dcd79b0ba559656727026ca182c15514b546f9ce7b6d113c3894745e52f6ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->