### PR TITLE
fix(atelier_ssr): route dynamic/looped/conditional slots through createSlots

### DIFF
--- a/crates/vize_atelier_ssr/src/codegen/element.rs
+++ b/crates/vize_atelier_ssr/src/codegen/element.rs
@@ -10,8 +10,8 @@ mod slot;
 mod vnode;
 
 use vize_atelier_core::ast::{
-    DirectiveNode, ElementNode, ElementType, ExpressionNode, PropNode, RuntimeHelper,
-    TemplateChildNode,
+    DirectiveNode, ElementNode, ElementType, ExpressionNode, ForNode, IfNode, PropNode,
+    RuntimeHelper, TemplateChildNode,
 };
 use vize_carton::{FxHashSet, String, ToCompactString};
 

--- a/crates/vize_atelier_ssr/src/codegen/element/component.rs
+++ b/crates/vize_atelier_ssr/src/codegen/element/component.rs
@@ -107,6 +107,20 @@ impl<'a> SsrCodegenContext<'a> {
     }
 
     fn process_component_slots<'node>(&mut self, children: &'node [TemplateChildNode<'a>]) {
+        // Dynamically-named (`#[name]`) or conditional/looped (`v-if`/`v-for`)
+        // slot templates cannot be expressed as a static slots object. Vue's SSR
+        // compiler wraps them in `createSlots(staticBase, [dynamicEntries])`, so
+        // detect them up front and switch to that form to avoid collapsing them
+        // into the `default` slot (which drops the component reference and yields
+        // an undefined vnode `.type` at render time).
+        if children
+            .iter()
+            .any(|child| self.is_dynamic_slot_source(child))
+        {
+            self.process_dynamic_component_slots(children);
+            return;
+        }
+
         let mut default_children: std::vec::Vec<&'node TemplateChildNode<'a>> =
             std::vec::Vec::new();
         let mut named_slots: std::vec::Vec<ComponentTemplateSlot<'node, 'a>> = std::vec::Vec::new();
@@ -147,6 +161,243 @@ impl<'a> SsrCodegenContext<'a> {
         self.push("}");
     }
 
+    /// True when a component child must be rendered through `createSlots`:
+    /// a `<template v-for #...>` / `<template v-if #...>` slot, or a
+    /// `<template #[name]>` whose slot name is a dynamic expression.
+    pub(super) fn is_dynamic_slot_source(&self, child: &TemplateChildNode<'a>) -> bool {
+        match child {
+            TemplateChildNode::For(for_node) => {
+                slot_template_in_children(&for_node.children).is_some()
+            }
+            TemplateChildNode::If(if_node) => if_node
+                .branches
+                .iter()
+                .any(|branch| slot_template_in_children(&branch.children).is_some()),
+            TemplateChildNode::Element(el) => {
+                el.tag_type == ElementType::Template && template_slot_is_dynamic(el)
+            }
+            _ => false,
+        }
+    }
+
+    /// Emit a `createSlots(base, [entries])` call for components that carry
+    /// dynamic, conditional, or looped slots.
+    fn process_dynamic_component_slots<'node>(&mut self, children: &'node [TemplateChildNode<'a>]) {
+        self.use_core_helper(RuntimeHelper::CreateSlots);
+        self.use_core_helper(RuntimeHelper::WithCtx);
+
+        // Static slots and default children form the `createSlots` base object.
+        let mut default_children: std::vec::Vec<&'node TemplateChildNode<'a>> =
+            std::vec::Vec::new();
+        let mut static_slots: std::vec::Vec<ComponentTemplateSlot<'node, 'a>> =
+            std::vec::Vec::new();
+        for child in children {
+            if self.is_dynamic_slot_source(child) {
+                continue;
+            }
+            if let Some(slot) = self.component_template_slot(child) {
+                static_slots.push(slot);
+            } else {
+                default_children.push(child);
+            }
+        }
+
+        self.push("_createSlots({\n");
+        self.indent_level += 1;
+        if !default_children.is_empty() {
+            self.process_component_slot_property(
+                "default",
+                None,
+                &FxHashSet::default(),
+                ComponentSlotChildren::Refs(default_children),
+            );
+        }
+        for slot in static_slots {
+            self.process_component_slot_property(
+                &slot.name,
+                slot.props_pattern.as_deref(),
+                &slot.params,
+                ComponentSlotChildren::Slice(slot.children),
+            );
+        }
+        self.push_indent();
+        self.push("_: 2 /* DYNAMIC */\n");
+        self.indent_level -= 1;
+        self.push_indent();
+        self.push("}, [\n");
+        self.indent_level += 1;
+
+        let mut first = true;
+        for child in children {
+            match child {
+                TemplateChildNode::For(for_node)
+                    if slot_template_in_children(&for_node.children).is_some() =>
+                {
+                    self.push_dynamic_slot_separator(&mut first);
+                    self.process_looped_slot_entry(for_node);
+                }
+                TemplateChildNode::If(if_node)
+                    if if_node
+                        .branches
+                        .iter()
+                        .any(|branch| slot_template_in_children(&branch.children).is_some()) =>
+                {
+                    self.push_dynamic_slot_separator(&mut first);
+                    self.process_conditional_slot_entry(if_node);
+                }
+                TemplateChildNode::Element(el)
+                    if el.tag_type == ElementType::Template && template_slot_is_dynamic(el) =>
+                {
+                    self.push_dynamic_slot_separator(&mut first);
+                    self.process_dynamic_slot_entry(el);
+                }
+                _ => {}
+            }
+        }
+
+        self.indent_level -= 1;
+        if !first {
+            self.push("\n");
+            self.push_indent();
+        }
+        self.push("])");
+    }
+
+    fn push_dynamic_slot_separator(&mut self, first: &mut bool) {
+        if !*first {
+            self.push(",\n");
+        }
+        *first = false;
+        self.push_indent();
+    }
+
+    /// `_renderList(source, (alias...) => { return { name, fn } })`
+    fn process_looped_slot_entry(&mut self, for_node: &ForNode<'a>) {
+        let Some(template_el) = slot_template_in_children(&for_node.children) else {
+            return;
+        };
+
+        self.use_ssr_helper(RuntimeHelper::SsrRenderList);
+        self.push("_renderList(");
+        self.push_expression(&for_node.source);
+        self.push(", (");
+        if let Some(value) = &for_node.value_alias {
+            self.push_expression(value);
+        }
+        if let Some(key) = &for_node.key_alias {
+            self.push(", ");
+            self.push_expression(key);
+        }
+        if let Some(index) = &for_node.object_index_alias {
+            self.push(", ");
+            self.push_expression(index);
+        }
+        self.push(") => {\n");
+        self.indent_level += 1;
+
+        let params = super::super::helpers::collect_for_scoped_params(for_node);
+        self.push_scoped_params(params);
+        self.push_indent();
+        self.push("return ");
+        self.push_slot_object_entry(template_el, None);
+        self.push("\n");
+        self.pop_scoped_params();
+
+        self.indent_level -= 1;
+        self.push_indent();
+        self.push("})");
+    }
+
+    /// `(cond) ? { name, fn, key } : undefined`
+    fn process_conditional_slot_entry(&mut self, if_node: &IfNode<'a>) {
+        for (index, branch) in if_node.branches.iter().enumerate() {
+            if index > 0 {
+                self.push(" : ");
+            }
+            if let Some(condition) = &branch.condition {
+                let cond = self.expression_to_string(condition);
+                self.push("(");
+                self.push(&cond);
+                self.push(") ? ");
+            }
+            if let Some(template_el) = slot_template_in_children(&branch.children) {
+                self.push_slot_object_entry(template_el, Some(index));
+            } else {
+                self.push("undefined");
+            }
+        }
+        if if_node
+            .branches
+            .last()
+            .is_none_or(|branch| branch.condition.is_some())
+        {
+            self.push(" : undefined");
+        }
+    }
+
+    fn process_dynamic_slot_entry(&mut self, template_el: &ElementNode<'a>) {
+        self.push_slot_object_entry(template_el, None);
+    }
+
+    /// `{ name: <expr>, fn: _withCtx(...), key: "N" }`
+    fn push_slot_object_entry(&mut self, template_el: &ElementNode<'a>, key_index: Option<usize>) {
+        let Some(dir) = template_el.props.iter().find_map(|p| match p {
+            PropNode::Directive(dir) if dir.name == "slot" => Some(dir),
+            _ => None,
+        }) else {
+            self.push("undefined");
+            return;
+        };
+
+        let name = self.slot_entry_name(dir);
+        let props_pattern = dir.exp.as_ref().map(slot_props_pattern_to_string);
+        let mut params = FxHashSet::default();
+        if let Some(pattern) = props_pattern.as_deref() {
+            extract_destructure_params(pattern.trim(), &mut params);
+        }
+
+        self.push("{\n");
+        self.indent_level += 1;
+        self.push_indent();
+        self.push("name: ");
+        self.push(&name);
+        self.push(",\n");
+        self.push_indent();
+        self.push("fn: ");
+        self.emit_slot_fn(
+            props_pattern.as_deref(),
+            &params,
+            ComponentSlotChildren::Slice(&template_el.children),
+        );
+        if let Some(key) = key_index {
+            self.push(",\n");
+            self.push_indent();
+            self.push("key: \"");
+            self.push(&key.to_compact_string());
+            self.push("\"");
+        }
+        self.push("\n");
+        self.indent_level -= 1;
+        self.push_indent();
+        self.push("}");
+    }
+
+    /// The slot-name expression for a `createSlots` entry: a quoted literal for
+    /// static names, or the raw bound expression for dynamic `#[name]` slots.
+    pub(super) fn slot_entry_name(&mut self, dir: &DirectiveNode<'a>) -> String {
+        match &dir.arg {
+            Some(ExpressionNode::Simple(arg)) if arg.is_static => quoted_js_string(&arg.content),
+            Some(arg) => {
+                // The dynamic slot name often references a `v-for` callback alias
+                // (`#[name]`), which is a local binding rather than a `_ctx.`
+                // member, so strip the prefix for any in-scope scoped param.
+                let raw = self.dynamic_arg_to_string(arg);
+                self.strip_ctx_for_scoped_params(&raw)
+            }
+            None => quoted_js_string("default"),
+        }
+    }
+
     fn process_component_slot_property<'node>(
         &mut self,
         name: &str,
@@ -160,7 +411,22 @@ impl<'a> SsrCodegenContext<'a> {
         } else {
             self.push(&quoted_js_string(name));
         }
-        self.push(": _withCtx((");
+        self.push(": ");
+        self.emit_slot_fn(props_pattern, params, children);
+        self.push(",\n");
+    }
+
+    /// Emit a `_withCtx((params, _push, _parent, _scopeId) => { if (_push) {...}
+    /// else { return [...] } })` slot function, shared by static slot properties
+    /// and `createSlots` entries.
+    fn emit_slot_fn<'node>(
+        &mut self,
+        props_pattern: Option<&str>,
+        params: &FxHashSet<String>,
+        children: ComponentSlotChildren<'node, 'a>,
+    ) {
+        self.use_core_helper(RuntimeHelper::WithCtx);
+        self.push("_withCtx((");
         self.push(props_pattern.unwrap_or("_"));
         self.push(", _push, _parent, _scopeId) => {\n");
         self.indent_level += 1;
@@ -202,7 +468,7 @@ impl<'a> SsrCodegenContext<'a> {
         self.push("}\n");
         self.indent_level -= 1;
         self.push_indent();
-        self.push("}),\n");
+        self.push("})");
     }
 
     fn process_component_slot_children<'node>(
@@ -694,4 +960,38 @@ impl<'a> SsrCodegenContext<'a> {
     fn process_transition(&mut self, el: &ElementNode<'a>) {
         self.process_children(&el.children, false, false, false);
     }
+}
+
+/// Locate the `<template v-slot>` element among a `v-for`/`v-if` branch body.
+pub(super) fn slot_template_in_children<'node, 'a>(
+    children: &'node [TemplateChildNode<'a>],
+) -> Option<&'node ElementNode<'a>> {
+    children.iter().find_map(|child| match child {
+        TemplateChildNode::Element(el)
+            if el.tag_type == ElementType::Template && has_slot_directive(el) =>
+        {
+            Some(el.as_ref())
+        }
+        _ => None,
+    })
+}
+
+/// True when a `<template>` carries a `v-slot` directive.
+pub(super) fn has_slot_directive(el: &ElementNode) -> bool {
+    el.props.iter().any(|prop| match prop {
+        PropNode::Directive(dir) => dir.name == "slot",
+        _ => false,
+    })
+}
+
+/// True when a `<template #[name]>` slot name is a dynamic expression.
+pub(super) fn template_slot_is_dynamic(el: &ElementNode) -> bool {
+    el.props.iter().any(|prop| match prop {
+        PropNode::Directive(dir) if dir.name == "slot" => match &dir.arg {
+            Some(ExpressionNode::Simple(arg)) => !arg.is_static,
+            Some(ExpressionNode::Compound(_)) => true,
+            None => false,
+        },
+        _ => false,
+    })
 }

--- a/crates/vize_atelier_ssr/src/codegen/element/vnode.rs
+++ b/crates/vize_atelier_ssr/src/codegen/element/vnode.rs
@@ -1,12 +1,13 @@
 //! VNode fallback expression generation used by slot fallback paths.
 
 use super::super::helpers::collect_for_scoped_params;
+use super::component::{has_slot_directive, slot_template_in_children, template_slot_is_dynamic};
 use super::props::*;
 use super::*;
 use vize_atelier_core::ast::ForNode;
 
 impl<'a> SsrCodegenContext<'a> {
-    fn vnode_children_expression(&mut self, children: &[TemplateChildNode]) -> String {
+    fn vnode_children_expression(&mut self, children: &[TemplateChildNode<'a>]) -> String {
         let expressions = self.vnode_child_expressions(children);
         let has_array_child = has_vnode_array_child(children);
         if has_array_child && expressions.len() == 1 {
@@ -39,7 +40,10 @@ impl<'a> SsrCodegenContext<'a> {
         }
     }
 
-    fn vnode_children_expression_from_refs(&mut self, children: &[&TemplateChildNode]) -> String {
+    fn vnode_children_expression_from_refs(
+        &mut self,
+        children: &[&TemplateChildNode<'a>],
+    ) -> String {
         let expressions = self.vnode_child_expressions_from_refs(children);
         let has_array_child = has_vnode_array_child_ref(children);
         if has_array_child && expressions.len() == 1 {
@@ -60,7 +64,10 @@ impl<'a> SsrCodegenContext<'a> {
         out
     }
 
-    fn vnode_child_expressions(&mut self, children: &[TemplateChildNode]) -> std::vec::Vec<String> {
+    fn vnode_child_expressions(
+        &mut self,
+        children: &[TemplateChildNode<'a>],
+    ) -> std::vec::Vec<String> {
         let mut expressions = std::vec::Vec::new();
         for child in children {
             if let Some(expr) = self.vnode_child_expression(child) {
@@ -72,7 +79,7 @@ impl<'a> SsrCodegenContext<'a> {
 
     fn vnode_child_expressions_from_refs(
         &mut self,
-        children: &[&TemplateChildNode],
+        children: &[&TemplateChildNode<'a>],
     ) -> std::vec::Vec<String> {
         let mut expressions = std::vec::Vec::new();
         for child in children {
@@ -83,7 +90,7 @@ impl<'a> SsrCodegenContext<'a> {
         expressions
     }
 
-    fn vnode_child_expression(&mut self, child: &TemplateChildNode) -> Option<String> {
+    fn vnode_child_expression(&mut self, child: &TemplateChildNode<'a>) -> Option<String> {
         match child {
             TemplateChildNode::Element(el) => self.vnode_element_expression(el),
             TemplateChildNode::Text(text) => {
@@ -121,7 +128,7 @@ impl<'a> SsrCodegenContext<'a> {
         }
     }
 
-    fn vnode_element_expression(&mut self, el: &ElementNode) -> Option<String> {
+    fn vnode_element_expression(&mut self, el: &ElementNode<'a>) -> Option<String> {
         match el.tag_type {
             ElementType::Element => Some(self.vnode_plain_element_expression(el)),
             ElementType::Component => Some(self.vnode_component_expression(el)),
@@ -130,7 +137,7 @@ impl<'a> SsrCodegenContext<'a> {
         }
     }
 
-    fn vnode_plain_element_expression(&mut self, el: &ElementNode) -> String {
+    fn vnode_plain_element_expression(&mut self, el: &ElementNode<'a>) -> String {
         self.use_core_helper(RuntimeHelper::CreateElementVNode);
 
         let props = self.build_plain_vnode_props(el);
@@ -146,7 +153,7 @@ impl<'a> SsrCodegenContext<'a> {
         out
     }
 
-    fn vnode_component_expression(&mut self, el: &ElementNode) -> String {
+    fn vnode_component_expression(&mut self, el: &ElementNode<'a>) -> String {
         self.use_core_helper(RuntimeHelper::CreateVNode);
 
         let mut out = String::from("_createVNode(");
@@ -192,12 +199,19 @@ impl<'a> SsrCodegenContext<'a> {
         out
     }
 
-    pub(super) fn vnode_component_slots_expression(
+    pub(super) fn vnode_component_slots_expression<'node>(
         &mut self,
-        children: &[TemplateChildNode],
+        children: &'node [TemplateChildNode<'a>],
     ) -> String {
         if children.is_empty() {
             return "null".to_compact_string();
+        }
+
+        if children
+            .iter()
+            .any(|child| self.is_dynamic_slot_source(child))
+        {
+            return self.vnode_create_slots_expression(children);
         }
 
         self.use_core_helper(RuntimeHelper::WithCtx);
@@ -207,7 +221,228 @@ impl<'a> SsrCodegenContext<'a> {
         out
     }
 
-    fn vnode_fragment_expression(&mut self, children: &[TemplateChildNode]) -> String {
+    /// `createSlots(base, [entries])` for the vnode (client-render) fallback path
+    /// of a component carrying dynamic/conditional/looped slots. Mirrors the
+    /// push-based SSR slots emission, but emits the vnode form of slot functions
+    /// (`fn: _withCtx((params) => [children])`).
+    fn vnode_create_slots_expression<'node>(
+        &mut self,
+        children: &'node [TemplateChildNode<'a>],
+    ) -> String {
+        self.use_core_helper(RuntimeHelper::CreateSlots);
+        self.use_core_helper(RuntimeHelper::WithCtx);
+
+        // Base object: default children plus static named slots.
+        let mut default_children: std::vec::Vec<&'node TemplateChildNode<'a>> =
+            std::vec::Vec::new();
+        let mut static_slots: std::vec::Vec<&'node ElementNode<'a>> = std::vec::Vec::new();
+        for child in children {
+            if self.is_dynamic_slot_source(child) {
+                continue;
+            }
+            if let TemplateChildNode::Element(el) = child
+                && el.tag_type == ElementType::Template
+                && has_slot_directive(el)
+            {
+                static_slots.push(el.as_ref());
+            } else {
+                default_children.push(child);
+            }
+        }
+
+        let mut out = String::from("_createSlots({ ");
+        let mut wrote = false;
+        if !default_children.is_empty() {
+            out.push_str("default: _withCtx(() => ");
+            out.push_str(&self.vnode_children_expression_from_refs(&default_children));
+            out.push_str("), ");
+            wrote = true;
+        }
+        for el in static_slots {
+            out.push_str(&self.vnode_slot_entry_fn_property(el));
+            out.push_str(", ");
+            wrote = true;
+        }
+        let _ = wrote;
+        out.push_str("_: 2 /* DYNAMIC */ }, [");
+
+        let mut first = true;
+        for child in children {
+            match child {
+                TemplateChildNode::For(for_node)
+                    if slot_template_in_children(&for_node.children).is_some() =>
+                {
+                    if !first {
+                        out.push_str(", ");
+                    }
+                    first = false;
+                    out.push_str(&self.vnode_looped_slot_entry(for_node));
+                }
+                TemplateChildNode::If(if_node)
+                    if if_node
+                        .branches
+                        .iter()
+                        .any(|branch| slot_template_in_children(&branch.children).is_some()) =>
+                {
+                    if !first {
+                        out.push_str(", ");
+                    }
+                    first = false;
+                    out.push_str(&self.vnode_conditional_slot_entry(if_node));
+                }
+                TemplateChildNode::Element(el)
+                    if el.tag_type == ElementType::Template && template_slot_is_dynamic(el) =>
+                {
+                    if !first {
+                        out.push_str(", ");
+                    }
+                    first = false;
+                    out.push_str(&self.vnode_slot_object_entry(el, None));
+                }
+                _ => {}
+            }
+        }
+
+        out.push_str("])");
+        out
+    }
+
+    /// `name: _withCtx((params) => [children])` for a static slot inside the
+    /// vnode `createSlots` base object.
+    fn vnode_slot_entry_fn_property(&mut self, el: &ElementNode<'a>) -> String {
+        let name = self
+            .slot_directive(el)
+            .map(|dir| self.slot_entry_name(dir))
+            .unwrap_or_else(|| quoted_js_string("default"));
+        let mut out = String::default();
+        if name.starts_with('"') {
+            // Unquote when it is a valid identifier for readability/parity.
+            let inner = &name[1..name.len() - 1];
+            if is_valid_js_identifier(inner) {
+                out.push_str(inner);
+            } else {
+                out.push_str(&name);
+            }
+        } else {
+            out.push('[');
+            out.push_str(&name);
+            out.push(']');
+        }
+        out.push_str(": ");
+        out.push_str(&self.vnode_slot_fn(el));
+        out
+    }
+
+    fn vnode_looped_slot_entry(&mut self, for_node: &ForNode<'a>) -> String {
+        let Some(template_el) = slot_template_in_children(&for_node.children) else {
+            return "undefined".to_compact_string();
+        };
+        self.use_core_helper(RuntimeHelper::RenderList);
+
+        let mut out = String::from("_renderList(");
+        out.push_str(&self.expression_to_string(&for_node.source));
+        out.push_str(", (");
+        append_for_aliases(self, &mut out, for_node);
+        out.push_str(") => {");
+
+        self.push_scoped_params(collect_for_scoped_params(for_node));
+        out.push_str(" return ");
+        out.push_str(&self.vnode_slot_object_entry(template_el, None));
+        self.pop_scoped_params();
+
+        out.push_str(" })");
+        out
+    }
+
+    fn vnode_conditional_slot_entry(
+        &mut self,
+        if_node: &vize_atelier_core::ast::IfNode<'a>,
+    ) -> String {
+        let mut out = String::default();
+        for (index, branch) in if_node.branches.iter().enumerate() {
+            if index > 0 {
+                out.push_str(" : ");
+            }
+            if let Some(condition) = &branch.condition {
+                out.push('(');
+                out.push_str(&self.expression_to_string(condition));
+                out.push_str(") ? ");
+            }
+            if let Some(template_el) = slot_template_in_children(&branch.children) {
+                out.push_str(&self.vnode_slot_object_entry(template_el, Some(index)));
+            } else {
+                out.push_str("undefined");
+            }
+        }
+        if if_node
+            .branches
+            .last()
+            .is_none_or(|branch| branch.condition.is_some())
+        {
+            out.push_str(" : undefined");
+        }
+        out
+    }
+
+    /// `{ name: <expr>, fn: _withCtx((params) => [children]), key: "N" }`
+    fn vnode_slot_object_entry(
+        &mut self,
+        template_el: &ElementNode<'a>,
+        key_index: Option<usize>,
+    ) -> String {
+        let Some(dir) = self.slot_directive(template_el) else {
+            return "undefined".to_compact_string();
+        };
+        let name = self.slot_entry_name(dir);
+
+        let mut out = String::from("{ name: ");
+        out.push_str(&name);
+        out.push_str(", fn: ");
+        out.push_str(&self.vnode_slot_fn(template_el));
+        if let Some(key) = key_index {
+            out.push_str(", key: \"");
+            out.push_str(&key.to_compact_string());
+            out.push('"');
+        }
+        out.push_str(" }");
+        out
+    }
+
+    /// `_withCtx((params) => [children])` for a slot template's vnode form.
+    fn vnode_slot_fn(&mut self, template_el: &ElementNode<'a>) -> String {
+        let dir = self.slot_directive(template_el);
+        let props_pattern = dir.and_then(|d| d.exp.as_ref().map(slot_props_pattern_to_string));
+        let mut params = FxHashSet::default();
+        if let Some(pattern) = props_pattern.as_deref() {
+            extract_destructure_params(pattern.trim(), &mut params);
+        }
+
+        let mut out = String::from("_withCtx((");
+        out.push_str(props_pattern.as_deref().unwrap_or("_"));
+        out.push_str(") => ");
+
+        if !params.is_empty() {
+            self.push_scoped_params(params.clone());
+        }
+        out.push_str(&self.vnode_children_expression(&template_el.children));
+        if !params.is_empty() {
+            self.pop_scoped_params();
+        }
+        out.push(')');
+        out
+    }
+
+    fn slot_directive<'node>(
+        &self,
+        el: &'node ElementNode<'a>,
+    ) -> Option<&'node vize_atelier_core::ast::DirectiveNode<'a>> {
+        el.props.iter().find_map(|prop| match prop {
+            PropNode::Directive(dir) if dir.name == "slot" => Some(dir.as_ref()),
+            _ => None,
+        })
+    }
+
+    fn vnode_fragment_expression(&mut self, children: &[TemplateChildNode<'a>]) -> String {
         self.use_core_helper(RuntimeHelper::CreateVNode);
         self.use_core_helper(RuntimeHelper::Fragment);
 
@@ -228,7 +463,7 @@ impl<'a> SsrCodegenContext<'a> {
         out
     }
 
-    fn vnode_element_children_expression(&mut self, children: &[TemplateChildNode]) -> String {
+    fn vnode_element_children_expression(&mut self, children: &[TemplateChildNode<'a>]) -> String {
         if children.is_empty() {
             return "null".to_compact_string();
         }
@@ -242,7 +477,7 @@ impl<'a> SsrCodegenContext<'a> {
         self.vnode_children_expression(children)
     }
 
-    fn vnode_if_expression(&mut self, if_node: &vize_atelier_core::ast::IfNode) -> String {
+    fn vnode_if_expression(&mut self, if_node: &vize_atelier_core::ast::IfNode<'a>) -> String {
         self.use_core_helper(RuntimeHelper::CreateComment);
 
         let mut out = String::default();
@@ -271,7 +506,7 @@ impl<'a> SsrCodegenContext<'a> {
         out
     }
 
-    fn vnode_for_expression(&mut self, for_node: &ForNode) -> String {
+    fn vnode_for_expression(&mut self, for_node: &ForNode<'a>) -> String {
         self.use_core_helper(RuntimeHelper::RenderList);
 
         let mut out = String::from("_renderList(");
@@ -289,7 +524,7 @@ impl<'a> SsrCodegenContext<'a> {
         out
     }
 
-    fn vnode_branch_expression(&mut self, children: &[TemplateChildNode]) -> String {
+    fn vnode_branch_expression(&mut self, children: &[TemplateChildNode<'a>]) -> String {
         let expressions = self.vnode_child_expressions(children);
         let has_array_child = has_vnode_array_child(children);
         if expressions.is_empty() {

--- a/crates/vize_atelier_ssr/src/lib.rs
+++ b/crates/vize_atelier_ssr/src/lib.rs
@@ -460,4 +460,104 @@ mod tests {
         assert!(errors.is_empty());
         insta::assert_snapshot!(result.code.as_str());
     }
+
+    // Regression: `<template v-for #[name]>` (dynamically-named looped slots, as
+    // used by `@nuxt/ui`'s DashboardSearchButton) must compile to
+    // `createSlots(base, [renderList(...)])`. Previously these slots were
+    // collapsed into the component's `default` slot, dropping the named-slot
+    // routing and leaking the scoped slot param as `_ctx.slotData`, which made
+    // the SSR renderer read `.type` off an undefined vnode and return a 500.
+    #[test]
+    fn test_ssr_dynamic_v_for_slot_uses_create_slots() {
+        let allocator = Bump::new();
+        let (_, errors, result) = compile_ssr(
+            &allocator,
+            r#"<Child>
+  <template v-for="(_, name) in slots" #[name]="slotData">
+    <slot :name="name" v-bind="slotData" />
+  </template>
+  <template #trailing="{ ui }">
+    <div>{{ ui }}</div>
+  </template>
+</Child>"#,
+        );
+        assert!(errors.is_empty());
+        // Must route the dynamic slots through createSlots, not `default`.
+        assert!(
+            result.code.contains("_createSlots("),
+            "expected createSlots for dynamic v-for slot:\n{}",
+            result.code
+        );
+        // The looped entry exposes `{ name, fn }` with the local `name` alias
+        // (no `_ctx.` prefix) and the in-scope `slotData` param.
+        assert!(
+            result.code.contains("name,") || result.code.contains("name: name"),
+            "expected local `name` alias in looped slot entry:\n{}",
+            result.code
+        );
+        assert!(
+            !result.code.contains("_ctx.slotData"),
+            "scoped slot param `slotData` must not leak as `_ctx.slotData`:\n{}",
+            result.code
+        );
+        insta::assert_snapshot!(result.code.as_str());
+    }
+
+    // Regression: `<template v-if #name>` conditional slots must also flow
+    // through createSlots rather than collapse into the default slot.
+    #[test]
+    fn test_ssr_conditional_slot_uses_create_slots() {
+        let allocator = Bump::new();
+        let (_, errors, result) = compile_ssr(
+            &allocator,
+            r#"<Child>
+  <template v-if="ok" #header>
+    <span>head</span>
+  </template>
+</Child>"#,
+        );
+        assert!(errors.is_empty());
+        assert!(
+            result.code.contains("_createSlots("),
+            "expected createSlots for conditional slot:\n{}",
+            result.code
+        );
+        insta::assert_snapshot!(result.code.as_str());
+    }
+
+    // Regression: when a component with dynamic slots is nested inside another
+    // component's slot, its vnode (client-render) fallback branch must also emit
+    // `createSlots` rather than collapse the dynamic slots into `default`. This
+    // mirrors `@nuxt/ui`'s `<DefineButtonTemplate><UButton><template v-for #[name]
+    // />>` shape where both the push and fallback branches are generated.
+    #[test]
+    fn test_ssr_dynamic_slot_vnode_fallback_uses_create_slots() {
+        let allocator = Bump::new();
+        let (_, errors, result) = compile_ssr(
+            &allocator,
+            r#"<Outer>
+  <Inner>
+    <template v-for="(_, name) in slots" #[name]="slotData">
+      <slot :name="name" v-bind="slotData" />
+    </template>
+    <template #trailing>x</template>
+  </Inner>
+</Outer>"#,
+        );
+        assert!(errors.is_empty());
+        // The nested Inner component is emitted both in the push branch and in
+        // the vnode fallback (`else { return [...] }`) of Outer's default slot;
+        // both must use createSlots, never `_ctx.slotData`.
+        assert!(
+            result.code.matches("_createSlots(").count() >= 2,
+            "expected createSlots in both push and vnode fallback branches:\n{}",
+            result.code
+        );
+        assert!(
+            !result.code.contains("_ctx.slotData"),
+            "scoped slot param must not leak as `_ctx.slotData`:\n{}",
+            result.code
+        );
+        insta::assert_snapshot!(result.code.as_str());
+    }
 }

--- a/crates/vize_atelier_ssr/src/snapshots/vize_atelier_ssr__tests__ssr_conditional_slot_uses_create_slots.snap
+++ b/crates/vize_atelier_ssr/src/snapshots/vize_atelier_ssr__tests__ssr_conditional_slot_uses_create_slots.snap
@@ -1,0 +1,21 @@
+---
+source: crates/vize_atelier_ssr/src/lib.rs
+expression: result.code.as_str()
+---
+function ssrRender(_ctx, _push, _parent, _attrs) {
+  _push(_ssrRenderComponent(_resolveComponent("Child"), _attrs, _createSlots({
+    _: 2 /* DYNAMIC */
+  }, [
+    (_ctx.ok) ? {
+      name: "header",
+      fn: _withCtx((_, _push, _parent, _scopeId) => {
+        if (_push) {
+          _push(`<span>head</span>`)
+        } else {
+          return [_createElementVNode("span", null, "head")]
+        }
+      }),
+      key: "0"
+    } : undefined
+  ]), _parent))
+}

--- a/crates/vize_atelier_ssr/src/snapshots/vize_atelier_ssr__tests__ssr_dynamic_slot_vnode_fallback_uses_create_slots.snap
+++ b/crates/vize_atelier_ssr/src/snapshots/vize_atelier_ssr__tests__ssr_dynamic_slot_vnode_fallback_uses_create_slots.snap
@@ -1,0 +1,38 @@
+---
+source: crates/vize_atelier_ssr/src/lib.rs
+expression: result.code.as_str()
+---
+function ssrRender(_ctx, _push, _parent, _attrs) {
+  _push(_ssrRenderComponent(_resolveComponent("Outer"), _attrs, {
+    default: _withCtx((_, _push, _parent, _scopeId) => {
+      if (_push) {
+        _push(_ssrRenderComponent(_resolveComponent("Inner"), null, _createSlots({
+          trailing: _withCtx((_, _push, _parent, _scopeId) => {
+            if (_push) {
+              _push(`x`)
+            } else {
+              return [_createTextVNode("x")]
+            }
+          }),
+          _: 2 /* DYNAMIC */
+        }, [
+          _renderList(_ctx.slots, (_, name) => {
+            return {
+              name: name,
+              fn: _withCtx((slotData, _push, _parent, _scopeId) => {
+                if (_push) {
+                  _ssrRenderSlot(_ctx.$slots, name, _mergeProps(slotData), null, _push, _parent)
+                } else {
+                  return [_renderSlot(_ctx.$slots, name, _mergeProps(slotData))]
+                }
+              })
+            }
+          })
+        ]), _parent))
+      } else {
+        return [_createVNode(_resolveComponent("Inner"), null, _createSlots({ trailing: _withCtx((_) => [_createTextVNode("x")]), _: 2 /* DYNAMIC */ }, [_renderList(_ctx.slots, (_, name) => { return { name: name, fn: _withCtx((slotData) => [_renderSlot(_ctx.$slots, name, _mergeProps(slotData))]) } })]))]
+      }
+    }),
+    _: 1
+  }, _parent))
+}

--- a/crates/vize_atelier_ssr/src/snapshots/vize_atelier_ssr__tests__ssr_dynamic_v_for_slot_uses_create_slots.snap
+++ b/crates/vize_atelier_ssr/src/snapshots/vize_atelier_ssr__tests__ssr_dynamic_v_for_slot_uses_create_slots.snap
@@ -1,0 +1,29 @@
+---
+source: crates/vize_atelier_ssr/src/lib.rs
+expression: result.code.as_str()
+---
+function ssrRender(_ctx, _push, _parent, _attrs) {
+  _push(_ssrRenderComponent(_resolveComponent("Child"), _attrs, _createSlots({
+    trailing: _withCtx(({ ui }, _push, _parent, _scopeId) => {
+      if (_push) {
+        _push(`<div>${_ssrInterpolate(ui)}</div>`)
+      } else {
+        return [_createElementVNode("div", null, [_createTextVNode(_toDisplayString(ui))])]
+      }
+    }),
+    _: 2 /* DYNAMIC */
+  }, [
+    _renderList(_ctx.slots, (_, name) => {
+      return {
+        name: name,
+        fn: _withCtx((slotData, _push, _parent, _scopeId) => {
+          if (_push) {
+            _ssrRenderSlot(_ctx.$slots, name, _mergeProps(slotData), null, _push, _parent)
+          } else {
+            return [_renderSlot(_ctx.$slots, name, _mergeProps(slotData))]
+          }
+        })
+      }
+    })
+  ]), _parent))
+}


### PR DESCRIPTION
## Root cause

The nuxt-ui dev app's home page (`/`) deterministically returned an SSR **500** with `Cannot read properties of undefined (reading 'type')`.

The crash originates in vize's **SSR slot codegen** (`vize_atelier_ssr`). When a component child is a slot `<template>` with a **dynamic name** (`#[name]`), or a slot `<template>` carrying **`v-for`/`v-if`**, vize collapsed it into the component's static `default` slot object. `@vue/compiler-sfc` instead wraps these in `createSlots(staticBase, [dynamicEntries])`.

Concretely, for `@nuxt/ui`'s `DashboardSearchButton.vue` (rendered on the home page via `UDashboardSearchButton`):

```vue
<UButton ...>
  <template v-for="(_, name) in getProxySlots()" #[name]="slotData">
    <slot :name="name" v-bind="slotData" />
  </template>
  <template #trailing="{ ui }">…</template>
</UButton>
```

vize emitted the v-for dynamic slots under the `default` key and referenced the scoped slot param as `_ctx.slotData` (undefined at that scope). The malformed slot object produced a vnode whose `.type` was `undefined`, which Vue's server renderer dereferences → 500.

The codegen sites: `process_component_slots` (the push-based SSR branch) and `vnode_component_slots_expression` (the vnode / client-render fallback branch), both in `crates/vize_atelier_ssr/src/codegen/element/`.

## Fix

Detect dynamic/looped/conditional slot sources up front and emit `createSlots(base, [entries])`, matching Vue's SSR oracle, in **both** branches:
- looped: `_renderList(src, (…) => ({ name, fn }))`
- conditional: `cond ? { name, fn, key } : undefined`
- dynamic name: `{ name: <expr>, fn }`

The v-for callback alias used as the slot name is kept as a local binding (e.g. `name`) instead of `_ctx.name`, and the scoped slot param (`slotData`) stays in scope.

## Minimal repro

```vue
<Child>
  <template v-for="(_, name) in slots" #[name]="slotData">
    <slot :name="name" v-bind="slotData" />
  </template>
  <template #trailing="{ ui }"><div>{{ ui }}</div></template>
</Child>
```

**Before:** dynamic slots collapsed into `default: _withCtx(...)`, with `_ctx.slotData` leaking → undefined vnode `.type`.

**After:** `_ssrRenderComponent(Child, _attrs, _createSlots({ trailing: …, _: 2 }, [_renderList(slots, (_, name) => ({ name, fn: _withCtx((slotData, …) => { … }) }))]))` — byte-structurally equivalent to `@vue/compiler-sfc`.

## Validation

- Recompiled all 173 nuxt-ui runtime components in SSR mode: `_ctx.slotData` leaks went from 8 components to **0**; 18 components now correctly use `createSlots`. The output structurally matches the `@vue/compiler-sfc` 3.6.0-beta oracle for the dynamic-slot pattern (verified against `DashboardSearchButton`, `DashboardSearch`, `DropdownMenu`, `ContextMenu`, `BlogPosts`).
- `cargo test -p vize_atelier_ssr` (43 unit tests, +3 new regression tests/snapshots), `cargo test -p vize_atelier_core -p vize_atelier_sfc` green.
- `cargo clippy -p vize_atelier_ssr --all-targets -- -D warnings` and `cargo fmt --all -- --check` clean.

### Note

A separate, pre-existing issue remains (out of scope here): the vnode (client-hydration) fallback branch of `_renderSlot` omits its default fallback content, so a couple of components show one fewer `createSlots` than the oracle in the `else` branch only. The SSR-executed `if (_push)` branch — the one that produced the 500 — is fully correct.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1349"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783644971&installation_id=136613492&pr_number=1349&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1349&signature=f3de482ed896582c3467aeb78cc4b5779be2db50e8c6ffffb6de57c4c7f2c078"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->