### PR TITLE
fix(patina): avoid mid-character slice panic in no_hydration_mismatch

### DIFF
--- a/crates/vize_patina/src/rules/ssr/no_hydration_mismatch.rs
+++ b/crates/vize_patina/src/rules/ssr/no_hydration_mismatch.rs
@@ -438,7 +438,8 @@ mod tests {
     fn test_multibyte_content_does_not_panic() {
         // Regression: byte-wise scanning used to slice mid-character and panic
         // on non-ASCII expressions (e.g. Japanese comments in misskey).
-        let content = "[\n\t// 行が選択されているときは範囲選択色の適用を行側に任せる\n\tcell.row,\n]";
+        let content =
+            "[\n\t// 行が選択されているときは範囲選択色の適用を行側に任せる\n\tcell.row,\n]";
         assert!(NoHydrationMismatch::check_expression(content).is_none());
     }
 

--- a/crates/vize_patina/src/rules/ssr/no_hydration_mismatch.rs
+++ b/crates/vize_patina/src/rules/ssr/no_hydration_mismatch.rs
@@ -170,6 +170,11 @@ fn scan_expression_code(content: &str) -> Option<(&'static str, &'static str)> {
 }
 
 fn match_pattern_at(content: &str, index: usize) -> Option<(&'static str, &'static str)> {
+    // Match on bytes: `index` advances byte-wise, so it may sit inside a
+    // multibyte character where `content[index..]` would panic. All patterns
+    // are ASCII, so byte comparison is equivalent.
+    let bytes = content.as_bytes();
+
     for pattern in [
         "Math.random",
         "crypto.randomUUID",
@@ -179,18 +184,18 @@ fn match_pattern_at(content: &str, index: usize) -> Option<(&'static str, &'stat
         "process.env",
         "import.meta.env",
     ] {
-        if content[index..].starts_with(pattern)
-            && has_member_left_boundary(content.as_bytes(), index)
-            && has_member_right_boundary(content.as_bytes(), index + pattern.len())
+        if bytes[index..].starts_with(pattern.as_bytes())
+            && has_member_left_boundary(bytes, index)
+            && has_member_right_boundary(bytes, index + pattern.len())
         {
             return pattern_match(pattern);
         }
     }
 
     for pattern in ["uuid()", "nanoid()", "new Date()"] {
-        if content[index..].starts_with(pattern)
-            && has_identifier_left_boundary(content.as_bytes(), index)
-            && has_identifier_right_boundary(content.as_bytes(), index + pattern.len())
+        if bytes[index..].starts_with(pattern.as_bytes())
+            && has_identifier_left_boundary(bytes, index)
+            && has_identifier_right_boundary(bytes, index + pattern.len())
         {
             return pattern_match(pattern);
         }
@@ -202,8 +207,8 @@ fn match_pattern_at(content: &str, index: usize) -> Option<(&'static str, &'stat
         ".toLocaleDateString()",
         ".toLocaleTimeString()",
     ] {
-        if content[index..].starts_with(pattern)
-            && has_identifier_right_boundary(content.as_bytes(), index + pattern.len())
+        if bytes[index..].starts_with(pattern.as_bytes())
+            && has_identifier_right_boundary(bytes, index + pattern.len())
         {
             return pattern_match(pattern);
         }
@@ -427,6 +432,20 @@ mod tests {
     fn test_allows_safe_code() {
         let content = "items.map(item => item.name)";
         assert!(NoHydrationMismatch::check_expression(content).is_none());
+    }
+
+    #[test]
+    fn test_multibyte_content_does_not_panic() {
+        // Regression: byte-wise scanning used to slice mid-character and panic
+        // on non-ASCII expressions (e.g. Japanese comments in misskey).
+        let content = "[\n\t// 行が選択されているときは範囲選択色の適用を行側に任せる\n\tcell.row,\n]";
+        assert!(NoHydrationMismatch::check_expression(content).is_none());
+    }
+
+    #[test]
+    fn test_detects_pattern_after_multibyte_text() {
+        let content = "// 乱数を使う\nMath.random()";
+        assert!(NoHydrationMismatch::check_expression(content).is_some());
     }
 
     #[test]

--- a/tests/snapshots/lint/__snapshots__/misskey-lint.snap
+++ b/tests/snapshots/lint/__snapshots__/misskey-lint.snap
@@ -33945,7 +33945,7 @@
         "line": 23,
         "column": 84,
         "endLine": 23,
-        "endColumn": 134,
+        "endColumn": 133,
         "help": "Use kebab-case for attribute names"
       },
       {
@@ -33956,7 +33956,7 @@
         "line": 23,
         "column": 84,
         "endLine": 23,
-        "endColumn": 134,
+        "endColumn": 133,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
       },
       {


### PR DESCRIPTION
## Summary
- `vize lint` panicked on Misskey (`start byte index 134 is not a char boundary`): the `no_hydration_mismatch` expression scanner advances its cursor one **byte** at a time but sliced the source with `content[index..]`, which panics when the cursor lands inside a multibyte character (Japanese comments in `MkGrid` cell expressions).
- Match on bytes instead. All patterns are ASCII, so byte comparison is semantically identical.
- Added two regression tests: multibyte content must not panic, and patterns following multibyte text are still detected.
- Refreshed two `misskey-lint.snap` end columns (134 → 133): the old values were recorded with byte-based counting; the linter emits character-based columns (verified against the source line, which contains `°`).

## Testing
- `cargo test -p vize_patina` (1027 tests green)
- Real-world lint snapshot suite: 11/11 projects pass, including Misskey (583 files, crash-free)

Part of #1352 (Production Gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1353"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783655998&installation_id=136613492&pr_number=1353&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1353&signature=90b9dc6765dbe4279e3ffc4b5848b26a10e34827ce3c0651c62a4b5fc095dd6b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->