### PR TITLE
fix(glyph): make multi-line attribute values idempotent under fmt

### DIFF
--- a/crates/vize_glyph/src/formatter.rs
+++ b/crates/vize_glyph/src/formatter.rs
@@ -381,12 +381,19 @@ fn write_remaining_attrs(
 fn compute_raw_line_mask(lines: &[&[u8]]) -> Vec<bool> {
     let mut mask = vec![false; lines.len()];
     let mut depth_stack: Vec<&'static str> = Vec::new();
+    // Attribute values may span lines (e.g. multi-line `class` strings). The
+    // template formatter emits those value lines byte-for-byte, so the SFC
+    // layer must not stack an extra indent on them each pass — otherwise
+    // `fmt` never reaches a fixed point. Track open-tag/quote state across
+    // lines and mark every line that starts inside an open attribute quote.
+    let mut in_tag = false;
+    let mut open_quote: Option<u8> = None;
     const TAGS: [(&str, &str, &str); 2] = [
         ("pre", "<pre", "</pre>"),
         ("textarea", "<textarea", "</textarea>"),
     ];
     for (i, line) in lines.iter().enumerate() {
-        if !depth_stack.is_empty() {
+        if !depth_stack.is_empty() || open_quote.is_some() {
             mask[i] = true;
         }
         // Walk the line bytes and bump the depth stack on every open/close
@@ -396,6 +403,22 @@ fn compute_raw_line_mask(lines: &[&[u8]]) -> Vec<bool> {
         let bytes = line;
         let mut cursor = 0;
         while cursor < bytes.len() {
+            if let Some(quote) = open_quote {
+                if bytes[cursor] == quote {
+                    open_quote = None;
+                }
+                cursor += 1;
+                continue;
+            }
+            if in_tag {
+                match bytes[cursor] {
+                    b'"' | b'\'' => open_quote = Some(bytes[cursor]),
+                    b'>' => in_tag = false,
+                    _ => {}
+                }
+                cursor += 1;
+                continue;
+            }
             if bytes[cursor] != b'<' {
                 cursor += 1;
                 continue;
@@ -415,14 +438,28 @@ fn compute_raw_line_mask(lines: &[&[u8]]) -> Vec<bool> {
                     && matches!(after, b'>' | b' ' | b'\t' | b'\n' | b'\r' | b'/')
                 {
                     depth_stack.push(tag);
+                    // The rest of the `<pre ...>` opening tag may carry quoted
+                    // attributes; scan it as a tag so a multi-line value there
+                    // is tracked too.
+                    in_tag = true;
                     cursor += open_needle.len();
                     matched = true;
                     break;
                 }
             }
-            if !matched {
-                cursor += 1;
+            if matched {
+                continue;
             }
+            // Generic opening/closing tag: only track quote state outside
+            // whitespace-significant regions (their content is arbitrary and
+            // already masked verbatim above).
+            if depth_stack.is_empty()
+                && let Some(after) = bytes.get(cursor + 1).copied()
+                && (after.is_ascii_alphabetic() || after == b'/')
+            {
+                in_tag = true;
+            }
+            cursor += 1;
         }
     }
     mask

--- a/crates/vize_glyph/src/lib.rs
+++ b/crates/vize_glyph/src/lib.rs
@@ -205,6 +205,21 @@ const message = 'hello';
     }
 
     #[test]
+    fn test_format_sfc_multiline_attribute_value_is_idempotent() {
+        // Regression: lines inside a multi-line attribute value (e.g. a
+        // wrapped `class` string) are emitted verbatim by the template
+        // formatter, but the SFC layer stacked one extra indent level on
+        // them per pass, so `fmt` never reached a fixed point.
+        let source = "<template>\n  <button\n    class=\"\n      flex items-center gap-2\n      text-start text-lg\n    \"\n    @click=\"go\"\n  >\n    hi\n  </button>\n</template>\n";
+        let options = FormatOptions::default();
+        let first = format_sfc(source, &options).unwrap();
+        let second = format_sfc(&first.code, &options).unwrap();
+        let third = format_sfc(&second.code, &options).unwrap();
+        assert_eq!(first.code, second.code, "fmt; fmt must be a no-op");
+        assert_eq!(second.code, third.code, "fmt must stay at its fixed point");
+    }
+
+    #[test]
     fn test_allocator_reuse() {
         let allocator = Allocator::with_capacity(4096);
         let options = FormatOptions::default();


### PR DESCRIPTION
## Summary
- `vize fmt` never reached a fixed point on files with multi-line attribute values (e.g. wrapped `class` strings in elk/nuxt-ui): the template formatter emits those value lines verbatim, but the SFC assembly layer added one indent level to every line on every pass, so continuation lines drifted +2 spaces per run — eventually even flipping the inline/multi-line attribute layout decision.
- Extends the existing raw-line mask (#963, pre/textarea/v-pre) with open-tag/attribute-quote state tracking across lines: any line that *starts* inside an open attribute quote is left byte-for-byte.
- Regression test: `fmt; fmt; fmt` over a wrapped class attribute must be a fixed point.

## Testing
- `cargo test -p vize_glyph` (61 green)
- Real-world idempotency gate (format twice over all fixture .vue files, compare trees): vuefes-2025 and frontend-phpcon now converge; remaining projects have further distinct root causes, tracked separately in #1352.

Part of #1352 (Production Gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1354"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783656031&installation_id=136613492&pr_number=1354&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1354&signature=c1537966d262fd3769603aeb01a5e00a9c1be871c5c8dff45d2fd53104b1d03b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->