### PR TITLE
fix(glyph): converge remaining real-world fmt idempotency cases

### DIFF
--- a/crates/vize_glyph/src/formatter.rs
+++ b/crates/vize_glyph/src/formatter.rs
@@ -388,12 +388,19 @@ fn compute_raw_line_mask(lines: &[&[u8]]) -> Vec<bool> {
     // lines and mark every line that starts inside an open attribute quote.
     let mut in_tag = false;
     let mut open_quote: Option<u8> = None;
+    // A `<pre`/`<textarea` whose opening tag wraps across lines (multi-line
+    // attribute layout) only becomes a raw region once its `>` is consumed;
+    // the attribute lines themselves are normal formatter output.
+    let mut pending_raw_tag: Option<&'static str> = None;
+    // Multi-line HTML comments are also emitted verbatim by the template
+    // formatter, so their inner lines must skip the SFC indent as well.
+    let mut in_comment = false;
     const TAGS: [(&str, &str, &str); 2] = [
         ("pre", "<pre", "</pre>"),
         ("textarea", "<textarea", "</textarea>"),
     ];
     for (i, line) in lines.iter().enumerate() {
-        if !depth_stack.is_empty() || open_quote.is_some() {
+        if !depth_stack.is_empty() || open_quote.is_some() || in_comment {
             mask[i] = true;
         }
         // Walk the line bytes and bump the depth stack on every open/close
@@ -403,6 +410,15 @@ fn compute_raw_line_mask(lines: &[&[u8]]) -> Vec<bool> {
         let bytes = line;
         let mut cursor = 0;
         while cursor < bytes.len() {
+            if in_comment {
+                if bytes[cursor..].starts_with(b"-->") {
+                    in_comment = false;
+                    cursor += 3;
+                } else {
+                    cursor += 1;
+                }
+                continue;
+            }
             if let Some(quote) = open_quote {
                 if bytes[cursor] == quote {
                     open_quote = None;
@@ -413,7 +429,12 @@ fn compute_raw_line_mask(lines: &[&[u8]]) -> Vec<bool> {
             if in_tag {
                 match bytes[cursor] {
                     b'"' | b'\'' => open_quote = Some(bytes[cursor]),
-                    b'>' => in_tag = false,
+                    b'>' => {
+                        in_tag = false;
+                        if let Some(tag) = pending_raw_tag.take() {
+                            depth_stack.push(tag);
+                        }
+                    }
                     _ => {}
                 }
                 cursor += 1;
@@ -421,6 +442,11 @@ fn compute_raw_line_mask(lines: &[&[u8]]) -> Vec<bool> {
             }
             if bytes[cursor] != b'<' {
                 cursor += 1;
+                continue;
+            }
+            if bytes[cursor..].starts_with(b"<!--") {
+                in_comment = true;
+                cursor += 4;
                 continue;
             }
             let mut matched = false;
@@ -434,13 +460,17 @@ fn compute_raw_line_mask(lines: &[&[u8]]) -> Vec<bool> {
                     break;
                 }
                 if starts_with_ascii_ci(&bytes[cursor..], open_needle.as_bytes())
-                    && let Some(after) = bytes.get(cursor + open_needle.len()).copied()
-                    && matches!(after, b'>' | b' ' | b'\t' | b'\n' | b'\r' | b'/')
+                    && bytes
+                        .get(cursor + open_needle.len())
+                        .copied()
+                        // End of line means the opening tag wraps its
+                        // attributes onto the following lines.
+                        .is_none_or(|after| matches!(after, b'>' | b' ' | b'\t' | b'\r' | b'/'))
                 {
-                    depth_stack.push(tag);
-                    // The rest of the `<pre ...>` opening tag may carry quoted
-                    // attributes; scan it as a tag so a multi-line value there
-                    // is tracked too.
+                    // The raw region starts after the opening tag's `>`;
+                    // scan the rest of the tag (possibly multi-line) as a
+                    // normal tag so quoted attributes are tracked too.
+                    pending_raw_tag = Some(tag);
                     in_tag = true;
                     cursor += open_needle.len();
                     matched = true;

--- a/crates/vize_glyph/src/lib.rs
+++ b/crates/vize_glyph/src/lib.rs
@@ -220,6 +220,56 @@ const message = 'hello';
     }
 
     #[test]
+    fn test_format_sfc_multiline_comment_is_idempotent() {
+        // Regression: inner lines of a multi-line HTML comment are emitted
+        // verbatim by the template formatter, but the SFC layer stacked one
+        // extra indent level on them per pass.
+        let source = "<template>\n  <div>\n    <!-- <div v-if=\"result.action\">\n      {{ result.action!.label }}\n    </div> -->\n    <span>hi</span>\n  </div>\n</template>\n";
+        let options = FormatOptions::default();
+        let first = format_sfc(source, &options).unwrap();
+        let second = format_sfc(&first.code, &options).unwrap();
+        let third = format_sfc(&second.code, &options).unwrap();
+        assert_eq!(first.code, second.code, "fmt; fmt must be a no-op");
+        assert_eq!(second.code, third.code, "fmt must stay at its fixed point");
+    }
+
+    #[test]
+    fn test_format_sfc_multiline_interpolation_with_trailing_text_is_idempotent() {
+        let source = "<template>\n  <div>\n    <span>\n      {{ $t(\"compose.drafts\", nonEmptyDrafts.length, { named: { v: formatNumber(nonEmptyDrafts.length) } }) }}&#160;\n    </span>\n  </div>\n</template>\n";
+        let options = FormatOptions::default();
+        let first = format_sfc(source, &options).unwrap();
+        let second = format_sfc(&first.code, &options).unwrap();
+        assert_eq!(first.code, second.code, "fmt; fmt must be a no-op");
+    }
+
+    #[test]
+    fn test_format_sfc_text_between_interpolations_is_idempotent() {
+        // Regression: a text segment between two block-form interpolations
+        // kept its leading space, shifting the line one column per pass.
+        let source = "<template>\n  <span>\n    {{ tsx.compressedToX({ x: bytes(item.compressedSize), yyyyyyyyyyyyyyyy: zzzzzzzzzzzzzz }) }} = {{ tsx.savedXPercent({ x: Math.round((1 - item.compressedSize / item.file.size) * 100) }) }}\n  </span>\n</template>\n";
+        let options = FormatOptions::default();
+        let first = format_sfc(source, &options).unwrap();
+        let second = format_sfc(&first.code, &options).unwrap();
+        let third = format_sfc(&second.code, &options).unwrap();
+        assert_eq!(first.code, second.code, "fmt; fmt must be a no-op");
+        assert_eq!(second.code, third.code, "fmt must stay at its fixed point");
+    }
+
+    #[test]
+    fn test_format_sfc_multiline_pre_open_tag_is_idempotent() {
+        // Regression: a `<pre>` whose opening tag wraps attributes across
+        // lines was not recognized as a raw region by the SFC layer, so the
+        // verbatim content and closing tag gained one indent per pass.
+        let source = "<template>\n  <div>\n    <pre\n      v-else-if=\"parsedJSON\"\n      class=\"overflow-auto max-h-96\"\n    >{{ formattedJSONString }}\n      </pre>\n  </div>\n</template>\n";
+        let options = FormatOptions::default();
+        let first = format_sfc(source, &options).unwrap();
+        let second = format_sfc(&first.code, &options).unwrap();
+        let third = format_sfc(&second.code, &options).unwrap();
+        assert_eq!(first.code, second.code, "fmt; fmt must be a no-op");
+        assert_eq!(second.code, third.code, "fmt must stay at its fixed point");
+    }
+
+    #[test]
     fn test_allocator_reuse() {
         let allocator = Allocator::with_capacity(4096);
         let options = FormatOptions::default();

--- a/crates/vize_glyph/src/template/formatter.rs
+++ b/crates/vize_glyph/src/template/formatter.rs
@@ -368,18 +368,25 @@ impl<'a> TemplateFormatter<'a> {
             while next + 1 < bytes.len() && !(bytes[next] == b'{' && bytes[next + 1] == b'{') {
                 next += 1;
             }
-            if next >= bytes.len() {
-                let leading = &text[cursor..];
-                if !leading.is_empty() {
+            // No further interpolation: everything left is trailing text.
+            // (`next` stops at `len - 1` when the scan runs off the end, so
+            // checking `next >= len` alone would misread trailing text as
+            // another interpolation and bail out of the rewrap.)
+            if next + 1 >= bytes.len() || !(bytes[next] == b'{' && bytes[next + 1] == b'{') {
+                let trailing = text[cursor..].trim();
+                if !trailing.is_empty() {
                     self.write_indent_string(&mut out, depth);
-                    out.push_str(leading);
+                    out.push_str(trailing);
                     out.push_str(self.newline_str());
                 }
                 break;
             }
-            // Emit any text before the interpolation as its own line.
+            // Emit any text before the interpolation as its own line. Trim
+            // both ends: the segment carries the spacing that separated it
+            // from the surrounding `}}`/`{{`, and keeping a leading space
+            // would shift the line one column off its indent on every pass.
             if next > cursor {
-                let leading = text[cursor..next].trim_end_matches([' ', '\t']);
+                let leading = text[cursor..next].trim();
                 if !leading.is_empty() {
                     self.write_indent_string(&mut out, depth);
                     out.push_str(leading);


### PR DESCRIPTION
## Summary
Follow-up to #1354 — three more distinct root causes found by the real-world idempotency gate (format every fixture .vue twice, require run 2 to be a no-op):

- **Multi-line HTML comments** (elk `SearchResult.vue`): inner comment lines are emitted verbatim by the template formatter, but the SFC layer stacked one indent level per pass. The raw-line mask now tracks `<!--`/`-->` across lines.
- **Interpolation rewrap with surrounding text** (elk `PublishWidgetFull.client.vue`, misskey `MkUploaderItems.vue`): trailing text after the last interpolation was misread as another interpolation start, bailing out of the #957 multi-line rewrap entirely — so pass 1 left the wrapped expression mis-indented and pass 2 rewrote it. Text segments between two interpolations also kept a leading space, shifting one column per pass. Both segments are now trimmed and emitted on their own indented line.
- **`<pre>`/`<textarea>` with wrapped attributes** (hoppscotch `Value.vue`): an opening tag that breaks its attributes across lines was not recognized as a raw region (the needle match required a byte after the tag name, but the line ends there). The raw region now begins once the opening tag's `>` is consumed, so attribute lines still format normally while content and the closing tag stay verbatim.

One regression test per cause.

## Result
`vize fmt` is now idempotent on **11/12** real-world fixtures (elk, misskey, npmx, vuefes, reka-ui, ant-design-vue, element-plus, voicevox, vue-vben-admin, hoppscotch, frontend-phpcon). The remaining case (nuxt-ui `ComponentThemeVisualizer.vue`) is an upstream `oxc_formatter` function-signature reflow (pure-TS repro drifts through `format_script` alone) — documented in #1352.

## Testing
- `cargo test -p vize_glyph` (65 green)
- Real-world idempotency gate over all 12 fixtures

Part of #1352 (Production Gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1355"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783657414&installation_id=136613492&pr_number=1355&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1355&signature=c9f64b3ff5cc3c9698e6dd28a85f04050d3d8e8d94c5bf323ff47935468d75ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->