### PR TITLE
fix(atelier_sfc): resolve inherited props for generic interfaces

### DIFF
--- a/crates/vize_atelier_sfc/src/script/type_resolution.rs
+++ b/crates/vize_atelier_sfc/src/script/type_resolution.rs
@@ -9,7 +9,7 @@ pub(crate) fn build_interface_type_source(
     let body = source[body_start..body_end].trim();
     let header = source[name_end..body_start].trim();
 
-    let Some(extends_idx) = header.find("extends") else {
+    let Some(extends_idx) = find_heritage_extends(header) else {
         return body.to_compact_string();
     };
 
@@ -47,6 +47,45 @@ pub(crate) fn build_interface_type_source(
     } else {
         merged
     }
+}
+
+/// Find the heritage-clause `extends` keyword in an interface header,
+/// skipping the generic parameter list. For
+/// `interface Foo<T extends Bar = Bar> extends Pick<Baz, 'x'>` the header is
+/// `<T extends Bar = Bar> extends Pick<Baz, 'x'>`; a naive `find("extends")`
+/// would hit the type-parameter constraint and mangle the whole clause.
+fn find_heritage_extends(header: &str) -> Option<usize> {
+    let bytes = header.as_bytes();
+    let mut depth = 0usize;
+    let mut i = 0;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'<' => depth += 1,
+            b'>' => depth = depth.saturating_sub(1),
+            // `=>` inside a generic default (e.g. `<T = () => void>`) must
+            // not close an angle-bracket level.
+            b'=' if bytes.get(i + 1) == Some(&b'>') => {
+                i += 2;
+                continue;
+            }
+            b'e' if depth == 0 && bytes[i..].starts_with(b"extends") => {
+                let before_ok = i == 0 || !is_identifier_byte(bytes[i - 1]);
+                let after_ok = bytes
+                    .get(i + "extends".len())
+                    .is_none_or(|&b| !is_identifier_byte(b));
+                if before_ok && after_ok {
+                    return Some(i);
+                }
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+    None
+}
+
+fn is_identifier_byte(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || byte == b'_' || byte == b'$'
 }
 
 pub(crate) fn resolve_type_args(
@@ -254,15 +293,66 @@ fn split_generic_call(type_expr: &str) -> Option<(&str, &str)> {
 /// Parse a resolved object-literal member body (`a?: string; b: number`) into
 /// individual members.
 fn parse_members(body: &str) -> Vec<Member> {
+    // JSDoc/line comments would otherwise end up glued to member keys
+    // (`/** ... */ side?`), making Pick/Omit key filtering match nothing.
+    let body = strip_comments(body);
     let mut members = Vec::new();
-    for part in split_top_level(body, ';') {
+    for part in split_top_level(&body, ';') {
         for sub in split_top_level(&part, ',') {
-            if let Some(member) = parse_member(&sub) {
-                members.push(member);
+            // Members may also be newline-separated (no `;`/`,`), which would
+            // otherwise glue every following member into the first one's type.
+            for line in split_top_level(&sub, '\n') {
+                if let Some(member) = parse_member(&line) {
+                    members.push(member);
+                }
             }
         }
     }
     members
+}
+
+/// Remove `/* ... */` and `// ...` comments from a type-literal body while
+/// leaving string literal contents untouched.
+fn strip_comments(body: &str) -> String {
+    let bytes = body.as_bytes();
+    let mut out = String::with_capacity(body.len());
+    let mut keep_start = 0;
+    let mut i = 0;
+    while i < bytes.len() {
+        match bytes[i] {
+            quote @ (b'\'' | b'"' | b'`') => {
+                i += 1;
+                while i < bytes.len() && bytes[i] != quote {
+                    if bytes[i] == b'\\' {
+                        i += 1;
+                    }
+                    i += 1;
+                }
+                i += 1;
+            }
+            b'/' if bytes.get(i + 1) == Some(&b'*') => {
+                out.push_str(&body[keep_start..i]);
+                let close = bytes[i + 2..]
+                    .windows(2)
+                    .position(|w| w == b"*/")
+                    .map_or(bytes.len(), |offset| i + 2 + offset + 2);
+                i = close;
+                keep_start = i;
+            }
+            b'/' if bytes.get(i + 1) == Some(&b'/') => {
+                out.push_str(&body[keep_start..i]);
+                let eol = bytes[i..]
+                    .iter()
+                    .position(|&b| b == b'\n')
+                    .map_or(bytes.len(), |offset| i + offset);
+                i = eol;
+                keep_start = i;
+            }
+            _ => i += 1,
+        }
+    }
+    out.push_str(&body[keep_start..]);
+    out
 }
 
 fn parse_member(part: &str) -> Option<Member> {
@@ -410,4 +500,99 @@ fn split_top_level(input: &str, delimiter: char) -> Vec<String> {
     }
 
     parts
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn build(source: &str) -> String {
+        let name_end = source
+            .find('<')
+            .or_else(|| source.find(" extends"))
+            .map_or(source.find('{').unwrap(), |i| i);
+        let body_start = source.find('{').unwrap();
+        build_interface_type_source(source, name_end, body_start, source.len())
+    }
+
+    #[test]
+    fn merges_heritage_clause_of_plain_interface() {
+        let merged = build("interface Props extends Base { a: string }");
+        assert_eq!(merged.as_str(), "Base & { a: string }");
+    }
+
+    #[test]
+    fn merges_heritage_clause_of_generic_interface() {
+        // Regression: the type-parameter constraint `extends` used to be
+        // mistaken for the heritage clause, dropping the inherited members
+        // (e.g. nuxt-ui DashboardSidebarProps extends Pick<UseResizableProps, ...>).
+        let merged = build(
+            "interface Props<T extends string = string> extends Pick<P, 'side'> { mode?: T }",
+        );
+        assert_eq!(merged.as_str(), "Pick<P, 'side'> & { mode?: T }");
+    }
+
+    #[test]
+    fn generic_interface_without_heritage_returns_body() {
+        let merged = build("interface Props<T extends string = string> { mode?: T }");
+        assert_eq!(merged.as_str(), "{ mode?: T }");
+    }
+
+    #[test]
+    fn heritage_scan_survives_arrow_types_in_generic_defaults() {
+        let merged = build("interface Props<F = () => void> extends Base { cb?: F }");
+        assert_eq!(merged.as_str(), "Base & { cb?: F }");
+    }
+
+    #[test]
+    fn pick_resolves_members_with_jsdoc_comments() {
+        // Regression: JSDoc comments were glued to member keys, so Pick's key
+        // filter matched nothing and the inherited props vanished
+        // (e.g. nuxt-ui UseResizableProps members all carry JSDoc).
+        let mut aliases = FxHashMap::default();
+        aliases.insert(
+            String::from("P"),
+            String::from(
+                "{\n  /**\n   * The side, e.g. 'left' | 'right'.\n   * @defaultValue 'left'\n   */\n  side?: 'left' | 'right'\n  // line comment\n  resizable?: boolean\n}",
+            ),
+        );
+        let resolved = resolve_type_to_object_body(
+            "Pick<P, 'side' | 'resizable'>",
+            &FxHashMap::default(),
+            &aliases,
+        )
+        .unwrap();
+        assert!(resolved.contains("side?:"), "side missing: {resolved}");
+        assert!(
+            resolved.contains("resizable?:"),
+            "resizable missing: {resolved}"
+        );
+    }
+
+    #[test]
+    fn pick_filters_newline_separated_members() {
+        let mut interfaces = FxHashMap::default();
+        let mut aliases = FxHashMap::default();
+        aliases.insert(
+            String::from("UseResizableProps"),
+            String::from("{\n  /**\n   * The id.\n   * @defaultValue useId()\n   */\n  id?: string\n  /**\n   * The side.\n   * @defaultValue 'left'\n   */\n  side?: 'left' | 'right'\n  minSize?: number\n  storage?: 'cookie' | 'local'\n  unit?: '%' | 'rem' | 'px'\n}"),
+        );
+        interfaces.insert(
+            String::from("DashboardSidebarProps"),
+            String::from("Pick<UseResizableProps, 'id' | 'side' | 'minSize'> & {\n  mode?: T\n}"),
+        );
+        let r = resolve_type_args("DashboardSidebarProps<T>", &interfaces, &aliases);
+        assert!(!r.contains("storage"), "storage leaked: {r}");
+        assert!(!r.contains("unit"), "unit leaked: {r}");
+        assert!(r.contains("id?:"), "id missing: {r}");
+        assert!(r.contains("side?:"), "side missing: {r}");
+        assert!(r.contains("minSize?:"), "minSize missing: {r}");
+        assert!(r.contains("mode?:"), "mode missing: {r}");
+    }
+
+    #[test]
+    fn strip_comments_preserves_string_literals() {
+        let stripped = strip_comments("a?: 'http://x' /* c */ | 'b' // tail");
+        assert_eq!(stripped.as_str(), "a?: 'http://x'  | 'b' ");
+    }
 }


### PR DESCRIPTION
## Summary
Root cause of the **nuxt-ui dev SSR 500** seen in nightly e2e (`Cannot read properties of undefined (reading 'type')` + `Property "side"/"collapsed" was accessed during render but is not defined`): type-based props resolution silently dropped every prop inherited through a heritage clause on `DashboardSidebar` (`side`, `resizable`, `collapsible`, `minSize`, ...), so the sidebar SSR render broke and the playground rendered the Error page.

Three stacked defects, each with a regression test:

1. **Generic interfaces lost their heritage clause** — `build_interface_type_source` looked for the first `extends` in the header; for `interface DashboardSidebarProps<T extends DashboardSidebarMode = DashboardSidebarMode> extends Pick<UseResizableProps, ...>` that's the *type-parameter constraint*, mangling the clause. Now scans for the heritage `extends` outside angle brackets (arrow-type aware).
2. **JSDoc comments broke Pick/Omit member filtering** — comments were glued to member keys (`/** ... */ side?`), so no Pick key ever matched. Comments are now stripped (string-literal aware) before member parsing.
3. **Newline-separated members collapsed into one** — without `;`/`,` separators the whole body parsed as a single member whose type swallowed the rest, making Pick keep everything or nothing. Members now also split on top-level newlines.

## Verification
- `vize inspector --format compare --target ssr` on nuxt-ui `DashboardSidebar.vue`: emitted props object now matches `@vue/compiler-sfc` **byte-for-byte** (was: 8 inherited props missing; template compiled `side` to `_ctx.side`, now `$props.side`)
- Minimal repros for all three defects (generic instantiation via separate `<script>` block, JSDoc'd imported type alias)
- `cargo test --workspace`: 3666 passed / 0 failed

Part of #1352 (Production Gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1357"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783659212&installation_id=136613492&pr_number=1357&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1357&signature=983af2777e332114f80bbce3897d943d1a237a2c0f30e501622955a4a4953ac6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->