### PR TITLE
fix(atelier_ssr): keep named scoped slot entries in vnode fallback

### DIFF
--- a/crates/vize_atelier_ssr/src/codegen/element/vnode.rs
+++ b/crates/vize_atelier_ssr/src/codegen/element/vnode.rs
@@ -215,9 +215,36 @@ impl<'a> SsrCodegenContext<'a> {
         }
 
         self.use_core_helper(RuntimeHelper::WithCtx);
-        let mut out = String::from("{ default: _withCtx(() => ");
-        out.push_str(&self.vnode_children_expression(children));
-        out.push_str("), _: 1 }");
+
+        // Named `<template #...>` slots must keep their own entry so their
+        // slot-props pattern (e.g. `#header="{ collapsed }"`) stays bound;
+        // collapsing them into `default:` compiles the body against the
+        // instance and breaks scoped slots at runtime.
+        let mut default_children: std::vec::Vec<&'node TemplateChildNode<'a>> =
+            std::vec::Vec::new();
+        let mut named_slots: std::vec::Vec<&'node ElementNode<'a>> = std::vec::Vec::new();
+        for child in children {
+            if let TemplateChildNode::Element(el) = child
+                && el.tag_type == ElementType::Template
+                && has_slot_directive(el)
+            {
+                named_slots.push(el.as_ref());
+            } else {
+                default_children.push(child);
+            }
+        }
+
+        let mut out = String::from("{ ");
+        for el in named_slots {
+            out.push_str(&self.vnode_slot_entry_fn_property(el));
+            out.push_str(", ");
+        }
+        if !default_children.is_empty() {
+            out.push_str("default: _withCtx(() => ");
+            out.push_str(&self.vnode_children_expression_from_refs(&default_children));
+            out.push_str("), ");
+        }
+        out.push_str("_: 1 }");
         out
     }
 

--- a/crates/vize_atelier_ssr/src/lib.rs
+++ b/crates/vize_atelier_ssr/src/lib.rs
@@ -525,6 +525,42 @@ mod tests {
         insta::assert_snapshot!(result.code.as_str());
     }
 
+    // Regression: static named slots with slot props must keep their own slot
+    // entry (with the props pattern bound) in the vnode fallback branch of a
+    // nested component. Collapsing them into `default: _withCtx(() => ...)`
+    // compiles the body against the instance, so `collapsed` resolves to
+    // undefined at runtime (nuxt-ui `<UDashboardSidebar>` inside
+    // `<UDashboardGroup>`: `#header="{ collapsed }"`).
+    #[test]
+    fn test_ssr_named_scoped_slot_keeps_props_in_vnode_fallback() {
+        let allocator = Bump::new();
+        let (_, errors, result) = compile_ssr(
+            &allocator,
+            r#"<Outer>
+  <Inner>
+    <template #header="{ collapsed }">
+      <span>{{ collapsed }}</span>
+    </template>
+    <template #default="{ collapsed }">
+      <Leaf :collapsed="collapsed" />
+    </template>
+  </Inner>
+</Outer>"#,
+        );
+        assert!(errors.is_empty());
+        assert!(
+            result.code.contains("header: _withCtx(({ collapsed })"),
+            "vnode fallback must bind the header slot props:\n{}",
+            result.code
+        );
+        assert!(
+            !result.code.contains("_ctx.collapsed"),
+            "scoped slot param `collapsed` must not leak as `_ctx.collapsed`:\n{}",
+            result.code
+        );
+        insta::assert_snapshot!(result.code.as_str());
+    }
+
     // Regression: when a component with dynamic slots is nested inside another
     // component's slot, its vnode (client-render) fallback branch must also emit
     // `createSlots` rather than collapse the dynamic slots into `default`. This

--- a/crates/vize_atelier_ssr/src/snapshots/vize_atelier_ssr__tests__ssr_named_scoped_slot_keeps_props_in_vnode_fallback.snap
+++ b/crates/vize_atelier_ssr/src/snapshots/vize_atelier_ssr__tests__ssr_named_scoped_slot_keeps_props_in_vnode_fallback.snap
@@ -1,0 +1,33 @@
+---
+source: crates/vize_atelier_ssr/src/lib.rs
+assertion_line: 561
+expression: result.code.as_str()
+---
+function ssrRender(_ctx, _push, _parent, _attrs) {
+  _push(_ssrRenderComponent(_resolveComponent("Outer"), _attrs, {
+    default: _withCtx((_, _push, _parent, _scopeId) => {
+      if (_push) {
+        _push(_ssrRenderComponent(_resolveComponent("Inner"), null, {
+          header: _withCtx(({ collapsed }, _push, _parent, _scopeId) => {
+            if (_push) {
+              _push(`<span>${_ssrInterpolate(collapsed)}</span>`)
+            } else {
+              return [_createElementVNode("span", null, [_createTextVNode(_toDisplayString(collapsed))])]
+            }
+          }),
+          default: _withCtx(({ collapsed }, _push, _parent, _scopeId) => {
+            if (_push) {
+              _push(_ssrRenderComponent(_resolveComponent("Leaf"), { collapsed: collapsed }, null, _parent))
+            } else {
+              return [_createVNode(_resolveComponent("Leaf"), { collapsed: collapsed }, null)]
+            }
+          }),
+          _: 1
+        }, _parent))
+      } else {
+        return [_createVNode(_resolveComponent("Inner"), null, { header: _withCtx(({ collapsed }) => [_createElementVNode("span", null, [_createTextVNode(_toDisplayString(collapsed))])]), default: _withCtx(({ collapsed }) => [_createVNode(_resolveComponent("Leaf"), { collapsed: collapsed }, null)]), _: 1 })]
+      }
+    }),
+    _: 1
+  }, _parent))
+}


### PR DESCRIPTION
## Summary
Second half of the **nuxt-ui dev SSR failure** (with #1357): in the vnode (client-render) fallback branch of a component nested inside another component's slot, ALL children — including named `<template #...>` slots — were collapsed into `default: _withCtx(() => ...)`. The slot-props pattern was dropped, so slot bodies compiled against the instance: `#header="{ collapsed }"` on `UDashboardSidebar` produced `Property "collapsed" was accessed during render but is not defined on instance` and a broken page.

The push branch and the dynamic-slot `createSlots` path (#1349) were already correct; only the static named-slot vnode fallback was missing. Named slot templates are now partitioned from plain default children and emitted via the existing `vnode_slot_entry_fn_property` / `vnode_slot_fn` (which bind the props pattern and scope the params), mirroring the official compiler's vnode slot object:

```js
// before
{ default: _withCtx(() => [/* templates, params unbound */]), _: 1 }
// after
{ header: _withCtx(({ collapsed }) => [...]), default: _withCtx(({ collapsed }) => [...]), _: 1 }
```

## Testing
- New regression test + insta snapshot (asserts the bound pattern and that `collapsed` does not leak as `_ctx.collapsed`)
- `cargo test --workspace`: 3660 passed / 0 failed

Part of #1352 (Production Gate); pairs with #1357 to fix the nightly nuxt-ui e2e.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1360"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783661369&installation_id=136613492&pr_number=1360&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1360&signature=fa922a7052216afb581041bbcf3dd7e86d957c1763015bc37e1bb790071954ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->