### PR TITLE
fix(atelier_ssr): bind v-slot props declared directly on a component

### DIFF
--- a/crates/vize_atelier_ssr/src/codegen/element/component.rs
+++ b/crates/vize_atelier_ssr/src/codegen/element/component.rs
@@ -71,7 +71,7 @@ impl<'a> SsrCodegenContext<'a> {
         if el.children.is_empty() {
             self.push("null");
         } else {
-            self.process_component_slots(&el.children);
+            self.process_component_slots(el);
         }
 
         self.push(", _parent");
@@ -89,7 +89,7 @@ impl<'a> SsrCodegenContext<'a> {
         let slots = if el.children.is_empty() {
             "null".to_compact_string()
         } else {
-            self.vnode_component_slots_expression(&el.children)
+            self.vnode_component_slots_expression(el)
         };
 
         self.push_indent();
@@ -106,7 +106,30 @@ impl<'a> SsrCodegenContext<'a> {
         self.push(")\n");
     }
 
-    fn process_component_slots<'node>(&mut self, children: &'node [TemplateChildNode<'a>]) {
+    fn process_component_slots<'node>(&mut self, el: &'node ElementNode<'a>) {
+        let children: &'node [TemplateChildNode<'a>] = &el.children;
+
+        // `v-slot` directly on the component (`<Comp v-slot="{ item }">`)
+        // makes every child part of that single slot; dropping the directive
+        // would compile its params against the instance (`_ctx.item`).
+        if let Some(slot) = self.component_self_slot(el) {
+            self.use_core_helper(RuntimeHelper::WithCtx);
+            self.push("{\n");
+            self.indent_level += 1;
+            self.process_component_slot_property(
+                &slot.name,
+                slot.props_pattern.as_deref(),
+                &slot.params,
+                ComponentSlotChildren::Slice(slot.children),
+            );
+            self.push_indent();
+            self.push("_: 1\n");
+            self.indent_level -= 1;
+            self.push_indent();
+            self.push("}");
+            return;
+        }
+
         // Dynamically-named (`#[name]`) or conditional/looped (`v-if`/`v-for`)
         // slot templates cannot be expressed as a static slots object. Vue's SSR
         // compiler wraps them in `createSlots(staticBase, [dynamicEntries])`, so
@@ -497,7 +520,16 @@ impl<'a> SsrCodegenContext<'a> {
         if el.tag_type != ElementType::Template {
             return None;
         }
+        self.component_self_slot(el)
+    }
 
+    /// Build the slot description carried by a `v-slot` directive on `el`
+    /// itself — either a `<template v-slot>` child or a component carrying
+    /// `v-slot` directly (`<Comp v-slot="{ item }">`).
+    pub(super) fn component_self_slot<'node>(
+        &self,
+        el: &'node ElementNode<'a>,
+    ) -> Option<ComponentTemplateSlot<'node, 'a>> {
         for prop in &el.props {
             let PropNode::Directive(dir) = prop else {
                 continue;

--- a/crates/vize_atelier_ssr/src/codegen/element/vnode.rs
+++ b/crates/vize_atelier_ssr/src/codegen/element/vnode.rs
@@ -161,7 +161,7 @@ impl<'a> SsrCodegenContext<'a> {
         out.push_str(", ");
         out.push_str(&self.build_component_props(el, false, is_dynamic_component_tag(&el.tag)));
         out.push_str(", ");
-        out.push_str(&self.vnode_component_slots_expression(&el.children));
+        out.push_str(&self.vnode_component_slots_expression(el));
         out.push(')');
         out
     }
@@ -201,10 +201,21 @@ impl<'a> SsrCodegenContext<'a> {
 
     pub(super) fn vnode_component_slots_expression<'node>(
         &mut self,
-        children: &'node [TemplateChildNode<'a>],
+        el: &'node ElementNode<'a>,
     ) -> String {
+        let children: &'node [TemplateChildNode<'a>] = &el.children;
         if children.is_empty() {
             return "null".to_compact_string();
+        }
+
+        // `v-slot` on the component itself: every child belongs to that
+        // single slot and its props pattern must stay bound.
+        if has_slot_directive(el) {
+            self.use_core_helper(RuntimeHelper::WithCtx);
+            let mut out = String::from("{ ");
+            out.push_str(&self.vnode_slot_entry_fn_property(el));
+            out.push_str(", _: 1 }");
+            return out;
         }
 
         if children

--- a/crates/vize_atelier_ssr/src/lib.rs
+++ b/crates/vize_atelier_ssr/src/lib.rs
@@ -525,6 +525,33 @@ mod tests {
         insta::assert_snapshot!(result.code.as_str());
     }
 
+    // Regression: `v-slot` directly on a component (`<Comp v-slot="{ item }">`)
+    // was dropped entirely, so the slot body compiled its params against the
+    // instance (`_ctx.item`) in both the push and vnode branches (nuxt-ui
+    // `<ULink v-slot="{ active, ...slotProps }">` inside NavigationMenu).
+    #[test]
+    fn test_ssr_component_level_v_slot_binds_props() {
+        let allocator = Bump::new();
+        let (_, errors, result) = compile_ssr(
+            &allocator,
+            r#"<Comp v-slot="{ item }">
+  <span>{{ item.label }}</span>
+</Comp>"#,
+        );
+        assert!(errors.is_empty());
+        assert!(
+            result.code.contains("default: _withCtx(({ item }"),
+            "component-level v-slot must bind its props pattern:\n{}",
+            result.code
+        );
+        assert!(
+            !result.code.contains("_ctx.item"),
+            "scoped slot param `item` must not leak as `_ctx.item`:\n{}",
+            result.code
+        );
+        insta::assert_snapshot!(result.code.as_str());
+    }
+
     // Regression: static named slots with slot props must keep their own slot
     // entry (with the props pattern bound) in the vnode fallback branch of a
     // nested component. Collapsing them into `default: _withCtx(() => ...)`

--- a/crates/vize_atelier_ssr/src/snapshots/vize_atelier_ssr__tests__ssr_component_level_v_slot_binds_props.snap
+++ b/crates/vize_atelier_ssr/src/snapshots/vize_atelier_ssr__tests__ssr_component_level_v_slot_binds_props.snap
@@ -1,0 +1,17 @@
+---
+source: crates/vize_atelier_ssr/src/lib.rs
+assertion_line: 552
+expression: result.code.as_str()
+---
+function ssrRender(_ctx, _push, _parent, _attrs) {
+  _push(_ssrRenderComponent(_resolveComponent("Comp"), _attrs, {
+    default: _withCtx(({ item }, _push, _parent, _scopeId) => {
+      if (_push) {
+        _push(`<span>${_ssrInterpolate(item.label)}</span>`)
+      } else {
+        return [_createElementVNode("span", null, [_createTextVNode(_toDisplayString(item.label))])]
+      }
+    }),
+    _: 1
+  }, _parent))
+}


### PR DESCRIPTION
## Summary
Follow-up to #1360 and the remaining cause of the nuxt-ui dev SSR 500: a `v-slot` placed **directly on a component element** (`<Comp v-slot="{ item }">`) was invisible to SSR slot emission, which only inspects the children. The slot body compiled its params against the instance (`_ctx.item`) in **both** the push and vnode branches:

```js
// before
{ default: _withCtx((_, _push, ...) => { _push(`<span>${_ssrInterpolate(_ctx.item.label)}</span>`) ... }), _: 1 }
// after
{ default: _withCtx(({ item }, _push, ...) => { _push(`<span>${_ssrInterpolate(item.label)}</span>`) ... }), _: 1 }
```

This is nuxt-ui's `<ULink v-slot="{ active, ...slotProps }">` / `<DefineItemTemplate v-slot="{ item, index }">` shape in `NavigationMenu.vue`, which crashed SSR with `Cannot read properties of undefined (reading 'type')` at the `_renderSlot(..., _ctx.item.slot ...)` call.

The directive is now extracted into the shared `ComponentTemplateSlot` description (`component_self_slot`, reused by the `<template v-slot>` path) and emitted through the existing slot property emitters in `process_component_slots` (push) and `vnode_component_slots_expression` (vnode fallback).

## Testing
- New regression test + insta snapshot (asserts the bound pattern in both branches and no `_ctx.item` leak)
- `cargo test --workspace`: 3668 passed / 0 failed; clippy clean

Part of #1352 (Production Gate); with #1357 + #1360 this targets the nightly nuxt-ui e2e failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1361"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783663679&installation_id=136613492&pr_number=1361&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1361&signature=bd544657d64bcc9119ba36e061c51af33f99af4b52ae7cd61580c2f3535dba16"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->