### PR TITLE
fix(atelier_ssr): emit slot outlet fallback content in the vnode branch

### DIFF
--- a/crates/vize_atelier_ssr/src/codegen/element/vnode.rs
+++ b/crates/vize_atelier_ssr/src/codegen/element/vnode.rs
@@ -479,13 +479,20 @@ impl<'a> SsrCodegenContext<'a> {
         out
     }
 
-    fn vnode_slot_outlet_expression(&mut self, el: &ElementNode) -> String {
+    fn vnode_slot_outlet_expression(&mut self, el: &ElementNode<'a>) -> String {
         self.use_core_helper(RuntimeHelper::RenderSlot);
 
         let mut out = String::from("_renderSlot(_ctx.$slots, ");
         out.push_str(&self.slot_outlet_name_expression(el));
         out.push_str(", ");
         out.push_str(&self.build_slot_outlet_props(el));
+        // Slot outlet children are the fallback content rendered when the
+        // parent provides no slot — dropping them loses e.g. nuxt-ui Button's
+        // `<slot>{{ label }}</slot>` label in the vnode branch.
+        if !el.children.is_empty() {
+            out.push_str(", () => ");
+            out.push_str(&self.vnode_children_expression(&el.children));
+        }
         out.push(')');
         out
     }

--- a/crates/vize_atelier_ssr/src/lib.rs
+++ b/crates/vize_atelier_ssr/src/lib.rs
@@ -503,6 +503,35 @@ mod tests {
         insta::assert_snapshot!(result.code.as_str());
     }
 
+    // Regression: a slot outlet's children are its fallback content; the
+    // vnode branch emitted `_renderSlot(slots, name, props)` without the
+    // fallback argument, so e.g. nuxt-ui Button's `<slot>{{ label }}</slot>`
+    // label vanished whenever Button rendered through a parent's vnode
+    // branch.
+    #[test]
+    fn test_ssr_slot_outlet_fallback_survives_vnode_branch() {
+        let allocator = Bump::new();
+        let (_, errors, result) = compile_ssr(
+            &allocator,
+            r#"<Outer>
+  <button>
+    <slot :ui="ui">
+      <span v-if="label">{{ label }}</span>
+    </slot>
+  </button>
+</Outer>"#,
+        );
+        assert!(errors.is_empty());
+        assert!(
+            result
+                .code
+                .contains("_renderSlot(_ctx.$slots, \"default\", { ui: _ctx.ui }, () => ["),
+            "vnode branch must pass the slot fallback:\n{}",
+            result.code
+        );
+        insta::assert_snapshot!(result.code.as_str());
+    }
+
     // Regression: `<template v-if #name>` conditional slots must also flow
     // through createSlots rather than collapse into the default slot.
     #[test]

--- a/crates/vize_atelier_ssr/src/snapshots/vize_atelier_ssr__tests__ssr_slot_outlet_fallback_survives_vnode_branch.snap
+++ b/crates/vize_atelier_ssr/src/snapshots/vize_atelier_ssr__tests__ssr_slot_outlet_fallback_survives_vnode_branch.snap
@@ -1,0 +1,25 @@
+---
+source: crates/vize_atelier_ssr/src/lib.rs
+assertion_line: 532
+expression: result.code.as_str()
+---
+function ssrRender(_ctx, _push, _parent, _attrs) {
+  _push(_ssrRenderComponent(_resolveComponent("Outer"), _attrs, {
+    default: _withCtx((_, _push, _parent, _scopeId) => {
+      if (_push) {
+        _push(`<button>`)
+        _ssrRenderSlot(_ctx.$slots, "default", { ui: _ctx.ui }, () => {
+          if (_ctx.label) {
+            _push(`<span>${_ssrInterpolate(_ctx.label)}</span>`)
+          } else {
+            _push(`<!---->`)
+          }
+        }, _push, _parent)
+        _push(`</button>`)
+      } else {
+        return [_createElementVNode("button", null, [_renderSlot(_ctx.$slots, "default", { ui: _ctx.ui }, () => [(_ctx.label) ? _createElementVNode("span", null, [_createTextVNode(_toDisplayString(_ctx.label))]) : _createCommentVNode("")])])]
+      }
+    }),
+    _: 1
+  }, _parent))
+}


### PR DESCRIPTION
## Summary
Fourth piece of the nuxt-ui dev SSR work (#1357 / #1360 / #1361 / #1362): the vnode (client-render) branch emitted slot outlets as `_renderSlot(slots, name, props)` — without the **fallback** argument, while the push branch correctly passes the fallback closure. Any component rendering through a parent's vnode branch lost its `<slot>...</slot>` fallback content: every `<UButton label="...">` on the playground button page rendered as an empty `<button>` because Button's `<slot>{{ label }}</slot>` fallback vanished.

```js
// before (vnode branch)
_renderSlot(_ctx.$slots, "default", { ui: _ctx.ui })
// after
_renderSlot(_ctx.$slots, "default", { ui: _ctx.ui }, () => [...fallback children])
```

## Testing
- New regression test + insta snapshot (asserts the fallback closure in the vnode branch)
- `cargo test --workspace`: 3674 passed / 0 failed; clippy clean

Part of #1352 (Production Gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1363"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783668718&installation_id=136613492&pr_number=1363&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1363&signature=c2bf4dc79e855c1ddd52b65c843d39cdf35fe0d81fab24be11940c4d699919e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->