### PR TITLE
fix: type-check Options API instance bindings

### DIFF
--- a/crates/vize_canon/src/sfc_typecheck/tests.rs
+++ b/crates/vize_canon/src/sfc_typecheck/tests.rs
@@ -601,6 +601,62 @@ export default { data() { return { count: 1 } } }
     );
 }
 
+#[test]
+fn test_type_check_options_api_resolves_this_across_blocks() {
+    let source = r#"<script lang="ts">
+import { defineComponent } from 'vue'
+
+function useFakeStore() {
+  return {
+    ready: false,
+    items: [] as Array<{ id: number; label: string }>,
+  }
+}
+
+export default defineComponent({
+  setup() {
+    const store = useFakeStore()
+    return { store }
+  },
+  data() {
+    return { count: 0 }
+  },
+  computed: {
+    status() {
+      return this.store.ready
+    },
+  },
+  methods: {
+    bump(step: number) {
+      this.count = this.count + step
+      return this.status
+    },
+  },
+})
+</script>
+<template>
+  <button @click="bump(1)">{{ status }} {{ store.ready }} {{ count }}</button>
+</template>"#;
+
+    let result =
+        type_check_sfc_with_options_api(source, &SfcTypeCheckOptions::new("OptionsBridge.vue"));
+    let unexpected: Vec<_> = result
+        .diagnostics
+        .iter()
+        .filter(|diagnostic| {
+            matches!(
+                diagnostic.code.as_deref(),
+                Some("2339" | "7023" | "2304" | "undefined-binding")
+            )
+        })
+        .collect();
+
+    assert!(
+        unexpected.is_empty(),
+        "Options API `this` and template bindings should resolve without type gaps: {unexpected:#?}"
+    );
+}
+
 #[cfg(feature = "legacy")]
 #[test]
 fn test_type_check_legacy_vue2_options_api_opt_in() {

--- a/crates/vize_canon/src/virtual_ts/generator/mod.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/mod.rs
@@ -15,7 +15,7 @@ use self::imports::{
     collect_imported_names, emit_global_component_stubs, emit_reference_type_directives,
     extract_declared_name,
 };
-use self::options_api::generate_options_api_variables;
+use self::options_api::{generate_options_api_bridge, generate_options_api_variables};
 use self::spans::{
     collect_template_referenced_names, is_local_setup_binding, merge_overlapping_spans,
     rewrite_export_default_for_module_scope,
@@ -508,6 +508,13 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
                 "  // @vize-map: {script_gen_start}:{script_gen_end} -> 0:{}\n\n",
                 script.len()
             );
+
+            if options_api {
+                profile!(
+                    "canon.virtual_ts.generate_options_api_bridge",
+                    generate_options_api_bridge(&mut ts, summary, script)
+                );
+            }
         });
     }
 

--- a/crates/vize_canon/src/virtual_ts/generator/options_api.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/options_api.rs
@@ -1,8 +1,17 @@
 //! Options API template-binding emission for the virtual TypeScript generator.
 
+use oxc_allocator::Allocator;
+use oxc_ast::ast::{
+    Argument, ArrayExpressionElement, ArrowFunctionExpression, CallExpression,
+    ExportDefaultDeclarationKind, Expression, Function, ObjectExpression, ObjectPropertyKind,
+    Program, PropertyKey, Statement,
+};
+use oxc_parser::Parser;
+use oxc_span::{GetSpan, SourceType};
 use vize_croquis::{BindingType, Croquis};
 
 use crate::virtual_ts::types::VirtualTsOptions;
+use vize_carton::CompactString;
 use vize_carton::FxHashSet;
 use vize_carton::String;
 use vize_carton::append;
@@ -59,6 +68,475 @@ pub(super) fn generate_options_api_variables(
         append!(ts, "void {name};");
     }
     ts.push('\n');
+}
+
+pub(super) fn generate_options_api_bridge(mut ts: &mut String, summary: &Croquis, script: &str) {
+    let Some(bridge) = collect_options_api_bridge(script) else {
+        return;
+    };
+
+    let mut names: Vec<&str> = summary
+        .bindings
+        .bindings
+        .iter()
+        .filter_map(|(name, binding_type)| {
+            let name = name.as_str();
+            match binding_type {
+                BindingType::Data | BindingType::Options | BindingType::Props => {
+                    is_safe_value_identifier(name).then_some(name)
+                }
+                _ => None,
+            }
+        })
+        .collect();
+    names.sort_unstable();
+    names.dedup();
+
+    if names.is_empty()
+        && bridge.computed.is_empty()
+        && bridge.methods.is_empty()
+        && bridge.mapped_types.is_empty()
+    {
+        return;
+    }
+
+    ts.push_str("  // Options API typed instance bridge\n");
+    for (index, mapped_type) in bridge.mapped_types.iter().enumerate() {
+        append!(
+            ts,
+            "  type __VizeOptionsMap{index} = {{ {mapped_type} }};\n"
+        );
+    }
+    ts.push_str("  type __VizeThis = {\n");
+    for name in names {
+        append!(ts, "    {name}: any;\n");
+    }
+    ts.push_str("  }");
+    for index in 0..bridge.mapped_types.len() {
+        append!(ts, " & __VizeOptionsMap{index}");
+    }
+    ts.push_str(";\n");
+
+    for function in &bridge.computed {
+        emit_bridge_function(ts, "computed", function);
+    }
+    for function in &bridge.methods {
+        emit_bridge_function(ts, "method", function);
+    }
+
+    if !bridge.computed.is_empty() || !bridge.methods.is_empty() {
+        ts.push_str("  ");
+        let mut first = true;
+        for function in bridge.computed.iter().chain(bridge.methods.iter()) {
+            if !first {
+                ts.push(' ');
+            }
+            append!(
+                ts,
+                "void __vize_{}_{};",
+                function.kind_prefix(),
+                function.safe_name
+            );
+            first = false;
+        }
+        ts.push('\n');
+    }
+    ts.push('\n');
+}
+
+fn emit_bridge_function(mut ts: &mut String, kind: &str, function: &OptionsFunction) {
+    let params = if function.params.is_empty() {
+        String::from("this: __VizeThis")
+    } else {
+        let mut params = String::from("this: __VizeThis, ");
+        params.push_str(&function.params);
+        params
+    };
+    append!(
+        ts,
+        "  function __vize_{kind}_{}({params}) ",
+        function.safe_name
+    );
+    ts.push_str(&function.body);
+    ts.push('\n');
+}
+
+#[derive(Debug, Default)]
+struct OptionsApiBridge {
+    computed: Vec<OptionsFunction>,
+    methods: Vec<OptionsFunction>,
+    mapped_types: Vec<String>,
+}
+
+#[derive(Debug)]
+struct OptionsFunction {
+    kind: OptionsFunctionKind,
+    safe_name: CompactString,
+    params: String,
+    body: String,
+}
+
+impl OptionsFunction {
+    fn kind_prefix(&self) -> &'static str {
+        match self.kind {
+            OptionsFunctionKind::Computed => "computed",
+            OptionsFunctionKind::Method => "method",
+        }
+    }
+}
+
+#[derive(Debug)]
+enum OptionsFunctionKind {
+    Computed,
+    Method,
+}
+
+fn collect_options_api_bridge(script: &str) -> Option<OptionsApiBridge> {
+    let allocator = Allocator::default();
+    let parsed = Parser::new(&allocator, script, SourceType::ts()).parse();
+    if parsed.panicked {
+        return None;
+    }
+
+    let options = component_options_from_program(&parsed.program)?;
+    let mut bridge = OptionsApiBridge::default();
+    collect_function_bridge(
+        script,
+        options,
+        "computed",
+        OptionsFunctionKind::Computed,
+        &mut bridge.computed,
+        &mut bridge.mapped_types,
+    );
+    collect_function_bridge(
+        script,
+        options,
+        "methods",
+        OptionsFunctionKind::Method,
+        &mut bridge.methods,
+        &mut bridge.mapped_types,
+    );
+    Some(bridge)
+}
+
+fn collect_function_bridge(
+    script: &str,
+    options: &ObjectExpression<'_>,
+    option_name: &str,
+    kind: OptionsFunctionKind,
+    output: &mut Vec<OptionsFunction>,
+    mapped_types: &mut Vec<String>,
+) {
+    let Some(object) = option_object_property(options, option_name) else {
+        return;
+    };
+
+    for property in &object.properties {
+        match property {
+            ObjectPropertyKind::ObjectProperty(property) => {
+                if property.computed {
+                    continue;
+                }
+                let Some(name) = property_key_name(&property.key) else {
+                    continue;
+                };
+                let Some(function) = options_function_from_expression(
+                    script,
+                    name,
+                    &property.value,
+                    match kind {
+                        OptionsFunctionKind::Computed => OptionsFunctionKind::Computed,
+                        OptionsFunctionKind::Method => OptionsFunctionKind::Method,
+                    },
+                ) else {
+                    continue;
+                };
+                output.push(function);
+            }
+            ObjectPropertyKind::SpreadProperty(spread) => {
+                if let Expression::CallExpression(call) = &spread.argument {
+                    collect_mapped_type(call, mapped_types);
+                }
+            }
+        }
+    }
+}
+
+fn options_function_from_expression(
+    script: &str,
+    name: &str,
+    expression: &Expression<'_>,
+    kind: OptionsFunctionKind,
+) -> Option<OptionsFunction> {
+    let (params, body) = match expression {
+        Expression::FunctionExpression(function) => function_parts(script, function)?,
+        Expression::ArrowFunctionExpression(arrow) => arrow_function_parts(script, arrow)?,
+        Expression::ParenthesizedExpression(parenthesized) => {
+            return options_function_from_expression(script, name, &parenthesized.expression, kind);
+        }
+        Expression::TSAsExpression(ts_as) => {
+            return options_function_from_expression(script, name, &ts_as.expression, kind);
+        }
+        Expression::TSSatisfiesExpression(ts_satisfies) => {
+            return options_function_from_expression(script, name, &ts_satisfies.expression, kind);
+        }
+        Expression::TSNonNullExpression(ts_non_null) => {
+            return options_function_from_expression(script, name, &ts_non_null.expression, kind);
+        }
+        _ => return None,
+    };
+
+    Some(OptionsFunction {
+        kind,
+        safe_name: CompactString::new(safe_identifier(name).as_str()),
+        params,
+        body,
+    })
+}
+
+fn function_parts(script: &str, function: &Function<'_>) -> Option<(String, String)> {
+    let params = params_source(script, &function.params)?;
+    let body = function.body.as_ref()?;
+    let body_source = source_slice(script, body.span())?;
+    Some((params, String::from(body_source.trim())))
+}
+
+fn arrow_function_parts(
+    script: &str,
+    arrow: &ArrowFunctionExpression<'_>,
+) -> Option<(String, String)> {
+    let params = params_source(script, &arrow.params)?;
+    let body_source = source_slice(script, arrow.body.span())?.trim();
+    if arrow.expression {
+        let mut body = String::from("{ return ");
+        body.push_str(body_source.trim_end_matches(';'));
+        body.push_str("; }");
+        Some((params, body))
+    } else {
+        Some((params, String::from(body_source)))
+    }
+}
+
+fn params_source(script: &str, params: &oxc_ast::ast::FormalParameters<'_>) -> Option<String> {
+    let mut result = String::default();
+    let mut first = true;
+    for param in params.items.iter() {
+        if !first {
+            result.push_str(", ");
+        }
+        first = false;
+        result.push_str(source_slice(script, param.span())?.trim());
+    }
+    if let Some(rest) = params.rest.as_ref() {
+        if !first {
+            result.push_str(", ");
+        }
+        result.push_str(source_slice(script, rest.span())?.trim());
+    }
+    Some(result)
+}
+
+fn collect_mapped_type(call: &CallExpression<'_>, mapped_types: &mut Vec<String>) {
+    let Expression::Identifier(callee) = &call.callee else {
+        return;
+    };
+    if !matches!(
+        callee.name.as_str(),
+        "mapState" | "mapGetters" | "mapWritableState" | "mapActions"
+    ) {
+        return;
+    }
+
+    let Some(Argument::Identifier(store)) = call.arguments.first() else {
+        return;
+    };
+    let Some(Argument::ArrayExpression(keys)) = call.arguments.get(1) else {
+        return;
+    };
+    let keys: Vec<&str> = keys
+        .elements
+        .iter()
+        .filter_map(|element| {
+            let ArrayExpressionElement::StringLiteral(literal) = element else {
+                return None;
+            };
+            Some(literal.value.as_str())
+        })
+        .collect();
+    if keys.is_empty() {
+        return;
+    }
+
+    let mut key_union = String::default();
+    for (index, key) in keys.iter().enumerate() {
+        if index > 0 {
+            key_union.push_str(" | ");
+        }
+        append!(key_union, "'{key}'");
+    }
+
+    let mut mapped_type = String::default();
+    append!(
+        mapped_type,
+        "[K in {key_union}]: ReturnType<typeof {}>[K]",
+        store.name.as_str()
+    );
+    mapped_types.push(mapped_type);
+}
+
+fn component_options_from_program<'a>(
+    program: &'a Program<'a>,
+) -> Option<&'a ObjectExpression<'a>> {
+    program.body.iter().find_map(|statement| {
+        let Statement::ExportDefaultDeclaration(export) = statement else {
+            return None;
+        };
+        component_options_from_export(&export.declaration)
+    })
+}
+
+fn component_options_from_export<'a>(
+    declaration: &'a ExportDefaultDeclarationKind<'a>,
+) -> Option<&'a ObjectExpression<'a>> {
+    match declaration {
+        ExportDefaultDeclarationKind::ObjectExpression(object) => Some(object.as_ref()),
+        ExportDefaultDeclarationKind::CallExpression(call) => component_options_from_call(call),
+        ExportDefaultDeclarationKind::ParenthesizedExpression(parenthesized) => {
+            component_options_from_expression(&parenthesized.expression)
+        }
+        ExportDefaultDeclarationKind::TSAsExpression(ts_as) => {
+            component_options_from_expression(&ts_as.expression)
+        }
+        ExportDefaultDeclarationKind::TSSatisfiesExpression(ts_satisfies) => {
+            component_options_from_expression(&ts_satisfies.expression)
+        }
+        ExportDefaultDeclarationKind::TSNonNullExpression(ts_non_null) => {
+            component_options_from_expression(&ts_non_null.expression)
+        }
+        _ => None,
+    }
+}
+
+fn component_options_from_expression<'a>(
+    expression: &'a Expression<'a>,
+) -> Option<&'a ObjectExpression<'a>> {
+    match expression {
+        Expression::ObjectExpression(object) => Some(object.as_ref()),
+        Expression::CallExpression(call) => component_options_from_call(call),
+        Expression::ParenthesizedExpression(parenthesized) => {
+            component_options_from_expression(&parenthesized.expression)
+        }
+        Expression::TSAsExpression(ts_as) => component_options_from_expression(&ts_as.expression),
+        Expression::TSSatisfiesExpression(ts_satisfies) => {
+            component_options_from_expression(&ts_satisfies.expression)
+        }
+        Expression::TSNonNullExpression(ts_non_null) => {
+            component_options_from_expression(&ts_non_null.expression)
+        }
+        _ => None,
+    }
+}
+
+fn component_options_from_call<'a>(
+    call: &'a CallExpression<'a>,
+) -> Option<&'a ObjectExpression<'a>> {
+    if !is_define_component_callee(&call.callee) {
+        return None;
+    }
+    let first = call.arguments.first()?;
+    match first {
+        Argument::ObjectExpression(object) => Some(object.as_ref()),
+        Argument::CallExpression(call) => component_options_from_call(call),
+        Argument::ParenthesizedExpression(parenthesized) => {
+            component_options_from_expression(&parenthesized.expression)
+        }
+        Argument::TSAsExpression(ts_as) => component_options_from_expression(&ts_as.expression),
+        Argument::TSSatisfiesExpression(ts_satisfies) => {
+            component_options_from_expression(&ts_satisfies.expression)
+        }
+        Argument::TSNonNullExpression(ts_non_null) => {
+            component_options_from_expression(&ts_non_null.expression)
+        }
+        _ => None,
+    }
+}
+
+fn is_define_component_callee(callee: &Expression<'_>) -> bool {
+    match callee {
+        Expression::Identifier(callee) => {
+            matches!(callee.name.as_str(), "defineComponent" | "_defineComponent")
+        }
+        Expression::StaticMemberExpression(member) => {
+            matches!(
+                member.property.name.as_str(),
+                "defineComponent" | "_defineComponent"
+            )
+        }
+        _ => false,
+    }
+}
+
+fn option_object_property<'a>(
+    object: &'a ObjectExpression<'a>,
+    key_name: &str,
+) -> Option<&'a ObjectExpression<'a>> {
+    object.properties.iter().find_map(|property| {
+        let ObjectPropertyKind::ObjectProperty(property) = property else {
+            return None;
+        };
+        if property.computed || property_key_name(&property.key) != Some(key_name) {
+            return None;
+        }
+        object_expression_from_expression(&property.value)
+    })
+}
+
+fn object_expression_from_expression<'a>(
+    expression: &'a Expression<'a>,
+) -> Option<&'a ObjectExpression<'a>> {
+    match expression {
+        Expression::ObjectExpression(object) => Some(object.as_ref()),
+        Expression::ParenthesizedExpression(parenthesized) => {
+            object_expression_from_expression(&parenthesized.expression)
+        }
+        Expression::TSAsExpression(ts_as) => object_expression_from_expression(&ts_as.expression),
+        Expression::TSSatisfiesExpression(ts_satisfies) => {
+            object_expression_from_expression(&ts_satisfies.expression)
+        }
+        Expression::TSNonNullExpression(ts_non_null) => {
+            object_expression_from_expression(&ts_non_null.expression)
+        }
+        _ => None,
+    }
+}
+
+fn property_key_name<'a>(key: &'a PropertyKey<'a>) -> Option<&'a str> {
+    match key {
+        PropertyKey::StaticIdentifier(identifier) => Some(identifier.name.as_str()),
+        PropertyKey::StringLiteral(string) => Some(string.value.as_str()),
+        _ => None,
+    }
+}
+
+fn source_slice(script: &str, span: oxc_span::Span) -> Option<&str> {
+    script.get(span.start as usize..span.end as usize)
+}
+
+fn safe_identifier(name: &str) -> String {
+    let mut result = String::default();
+    for (index, ch) in name.chars().enumerate() {
+        if (index == 0 && (ch.is_ascii_alphabetic() || ch == '_' || ch == '$'))
+            || (index > 0 && (ch.is_ascii_alphanumeric() || ch == '_' || ch == '$'))
+        {
+            result.push(ch);
+        } else {
+            result.push('_');
+        }
+    }
+    if result.is_empty() {
+        result.push('_');
+    }
+    result
 }
 
 fn is_safe_value_identifier(name: &str) -> bool {

--- a/crates/vize_canon/src/virtual_ts/tests.rs
+++ b/crates/vize_canon/src/virtual_ts/tests.rs
@@ -7,7 +7,7 @@ use super::helpers::{VUE_SETUP_HELPERS, generate_template_context, get_dom_event
 use super::{
     TemplateGlobal, VirtualTsCheckOptions, VirtualTsGenerationOptions, VirtualTsOptions,
     generate_virtual_ts, generate_virtual_ts_with_offsets,
-    generate_virtual_ts_with_offsets_and_checks,
+    generate_virtual_ts_with_offsets_and_checks, generate_virtual_ts_with_offsets_options_api,
 };
 
 fn assert_virtual_ts_snapshot(name: &str, value: &str) {
@@ -50,6 +50,151 @@ fn test_vue_template_context_with_globals() {
     };
     let ctx = generate_template_context(&options);
     assert_virtual_ts_snapshot("virtual_ts_vue_template_context_with_globals", ctx.as_str());
+}
+
+fn analyze_options_api_script(script: &str) -> vize_croquis::Croquis {
+    use vize_croquis::{Analyzer, AnalyzerOptions};
+
+    let mut analyzer = Analyzer::with_options(AnalyzerOptions::full()).with_options_api();
+    analyzer.analyze_script_plain(script);
+    analyzer.finish()
+}
+
+#[test]
+fn test_options_api_virtual_ts_emits_this_bridge() {
+    let script = r#"import { defineComponent } from 'vue'
+
+function useFakeStore() {
+    return {
+        ready: false,
+        items: [] as Array<{ id: number; label: string }>,
+    }
+}
+
+export default defineComponent({
+    setup() {
+        const store = useFakeStore()
+        return { store }
+    },
+    data() {
+        return { count: 0 }
+    },
+    computed: {
+        status() {
+            return this.store.ready
+        },
+    },
+    methods: {
+        bump(step: number) {
+            this.count = this.count + step
+            return this.status
+        },
+    },
+    props: {
+        initial: { type: Number, default: 0 },
+    },
+})
+"#;
+    let summary = analyze_options_api_script(script);
+    let output = generate_virtual_ts_with_offsets_options_api(
+        &summary,
+        Some(script),
+        None,
+        0,
+        0,
+        &Default::default(),
+    );
+
+    assert!(
+        output.code.contains("type __VizeThis ="),
+        "expected typed Options API `this` bridge:\n{}",
+        output.code
+    );
+    assert!(
+        output.code.contains("__vize_method_bump"),
+        "expected method body to be checked through a typed wrapper:\n{}",
+        output.code
+    );
+    assert!(
+        output.code.contains("__vize_computed_status"),
+        "expected computed body to be checked through a typed wrapper:\n{}",
+        output.code
+    );
+}
+
+#[test]
+fn test_options_api_virtual_ts_emits_typed_shape_for_pinia_spread_helpers() {
+    let script = r#"import { defineComponent } from 'vue'
+import { mapState, mapActions } from 'pinia'
+
+function useFakeStore() {
+    return {
+        ready: false,
+        items: [] as Array<{ id: number; label: string }>,
+        setReady(_v: boolean) {},
+    }
+}
+
+export default defineComponent({
+    computed: {
+        ...mapState(useFakeStore, ['items', 'ready']),
+        localComputed() { return 1 },
+    },
+    methods: {
+        ...mapActions(useFakeStore, ['setReady']),
+    },
+})
+"#;
+    let summary = analyze_options_api_script(script);
+    let output = generate_virtual_ts_with_offsets_options_api(
+        &summary,
+        Some(script),
+        None,
+        0,
+        0,
+        &Default::default(),
+    );
+
+    assert!(
+        output
+            .code
+            .contains("[K in 'items' | 'ready']: ReturnType<typeof useFakeStore>[K]"),
+        "expected precise mapped type for mapState spread keys:\n{}",
+        output.code
+    );
+    assert!(
+        output
+            .code
+            .contains("[K in 'setReady']: ReturnType<typeof useFakeStore>[K]"),
+        "expected precise mapped type for mapActions spread keys:\n{}",
+        output.code
+    );
+}
+
+#[test]
+fn test_script_setup_output_does_not_emit_options_api_bridge() {
+    use vize_croquis::{Analyzer, AnalyzerOptions};
+
+    let script = r#"import { ref } from 'vue'
+const count = ref(0)
+"#;
+    let mut analyzer = Analyzer::with_options(AnalyzerOptions::full());
+    analyzer.analyze_script_setup(script);
+    let summary = analyzer.finish();
+
+    let output =
+        generate_virtual_ts_with_offsets(&summary, Some(script), None, 0, 0, &Default::default());
+
+    assert!(
+        !output.code.contains("__VizeThis"),
+        "`<script setup>` output must not contain the Options API bridge:\n{}",
+        output.code
+    );
+    assert!(
+        !output.code.contains("__vize_method_") && !output.code.contains("__vize_computed_"),
+        "`<script setup>` output must not contain Options API wrappers:\n{}",
+        output.code
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Add an Options API typed instance bridge to the virtual TypeScript output so `this` references in `computed` and `methods` are checked with setup/data/props/template bindings available.
- Preserve normal `<script setup>` output by emitting the bridge only for Options API generation.
- Add regression coverage for Options API `this` resolution and Pinia `mapState` / `mapActions` spread helpers.

## Context

This implements the production-side fix for the failing test coverage proposed in https://github.com/ushironoko/vize/pull/9.

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p vize_canon`
- `cargo clippy --workspace -- -D warnings`
- `cargo test --workspace`
- `vp exec pnpm audit --prod --audit-level moderate`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1366"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783671206&installation_id=136613492&pr_number=1366&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1366&signature=ddc83ce4c38c4f39c6cc0673620f5fbf5d4ab0577cd204d4ea4ae60957bf15d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->