### PR TITLE
docs: fix vscode extension build commands in install guide

### DIFF
--- a/docs/content/integrations/vscode.md
+++ b/docs/content/integrations/vscode.md
@@ -96,8 +96,8 @@ Install `vp` once from the [Vite+ install guide](https://viteplus.dev/guide/inst
 git clone https://github.com/ubugeeei-prod/vize.git
 cd vize
 cd npm/vscode-vize
-vp install --ignore-workspace
-vp build
+vp install -- --ignore-workspace
+vp pack
 vp exec vsce package --no-dependencies --out dist/vize.vsix
 code --install-extension dist/vize.vsix
 ```


### PR DESCRIPTION
## Summary

The "Installing from Source or VSIX" guide for the VS Code extension lists two commands that fail:

- `vp install --ignore-workspace` — `vp install` rejects the flag (`Unexpected argument '--ignore-workspace'`); it must be passed through to pnpm via `--` → `vp install -- --ignore-workspace`.
- `vp build` — this package builds with `vp pack` (per its `build` script and `main: ./dist/extension.cjs`). `vp build` looks for an `index.html` app entry and fails with `[UNRESOLVED_ENTRY] Error: Cannot resolve entry module index.html`.

* https://viteplus.dev/guide/install
* https://viteplus.dev/guide/build
* https://viteplus.dev/guide/pack

## Change Class

- [x] Runtime packaging, release, or docs

## Behavior Reference

`npm/vscode-vize/package.json` (`"build": "vp pack"`), and `vp install --help` / `vp` error output showing `--` is required to forward args to the package manager.

## Verification Evidence

Ran the corrected sequence in `npm/vscode-vize`:

```
vp install -- --ignore-workspace   # Done
vp pack                            # dist/extension.cjs
vp exec vsce package --no-dependencies --out dist/vize.vsix   # Packaged: dist/vize.vsix
```

- [x] Docs, release, or stability notes updated when public behavior changed

## Risk

Docs-only. No code or behavior change.
