### PR TITLE
fix(flake): correct PATH parameter expansion in moonbit shellHook

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -359,7 +359,7 @@
               fi
               if [ -n "''${HOME:-}" ]; then
                 PATH=":$PATH:"
-                PATH="''${PATH//:$HOME/.moon/bin:/:}"
+                PATH="''${PATH//:$HOME\/.moon\/bin:/:}"
                 PATH="''${PATH#:}"
                 PATH="''${PATH%:}"
               fi


### PR DESCRIPTION
## Summary

The MoonBit `shellHook` strips the user's globally-installed `$HOME/.moon/bin` from `PATH` so the Nix-provided MoonBit wins, but the bash parameter expansion is malformed:

```sh
PATH="${PATH//:$HOME/.moon/bin:/:}"
```

In `${var//pattern/string}` the first unescaped `/` separates pattern from replacement, so this parses as pattern `:$HOME` → replacement `.moon/bin:/:`. It replaces **every** `:$HOME` occurrence, corrupting all `$HOME`-based `PATH` entries (e.g. `~/.atuin/bin`, `~/.vite-plus/bin`) into nonexistent paths like `.atuin/bin.moon/bin` inside the devShell.

Escaping the slashes makes it remove only the intended `:$HOME/.moon/bin:` entry:

```sh
PATH="${PATH//:$HOME\/.moon\/bin:/:}"
```

## Change Class

- [x] Not language-facing

## Behavior Reference

bash parameter expansion `${var//pattern/string}` semantics (`/` delimits pattern from replacement).

## Verification Evidence

Reproduced the substitution in isolation, then applied the fix and reloaded direnv:

```
# before: ~/.atuin/bin etc. mangled; `vp exec vsce ...` -> "Command 'vsce' not found"
# after : PATH clean, $HOME entries intact, `vp exec vsce --version` -> 3.7.1
```

- [x] Minimal fixture or focused regression test added or updated (manual bash repro)

## Risk

devShell-only. Affects any contributor with `$HOME/.moon/bin` (or other `$HOME` bins) on PATH; no impact on CI test jobs, which install MoonBit via `setup-moonbit`, not the flake.
