### PR TITLE
fix(canon): resolve editor imports against the real workspace

### DIFF
--- a/crates/vize_canon/src/corsa_bridge/bridge.rs
+++ b/crates/vize_canon/src/corsa_bridge/bridge.rs
@@ -74,8 +74,20 @@ impl CorsaBridge {
             .as_ref()
             .map(|path| path.to_string_lossy().into_owned());
 
-        let client = CorsaProjectClient::new(corsa_path.as_deref(), working_dir.as_deref())
-            .map_err(CorsaBridgeError::SpawnFailed)?;
+        // Root the session at the real workspace whenever one is known: the
+        // project's own tsconfig (paths, baseUrl) then drives module
+        // resolution and virtual `.vue.ts` overlays can live at their real
+        // paths, so relative imports in `<script>` resolve exactly like
+        // `vize check`. The isolated scratch session remains the fallback
+        // for rootless (single-file) usage.
+        let client = match working_dir.as_deref() {
+            Some(dir) => CorsaProjectClient::new_for_workspace(
+                corsa_path.as_deref(),
+                std::path::Path::new(dir),
+            ),
+            None => CorsaProjectClient::new(corsa_path.as_deref(), None),
+        }
+        .map_err(CorsaBridgeError::SpawnFailed)?;
         *guard = Some(client);
 
         self.initialized.store(true, Ordering::SeqCst);

--- a/crates/vize_canon/src/lsp_client/session.rs
+++ b/crates/vize_canon/src/lsp_client/session.rs
@@ -283,7 +283,9 @@ pub(super) fn build_session_document_uri(uri: &str, project_root: &Path) -> Stri
         return uri.into();
     };
 
-    if external_path.starts_with(project_root) && external_path.exists() {
+    if external_path.starts_with(project_root)
+        && (external_path.exists() || virtual_overlay_target_exists(&external_path))
+    {
         return path_to_file_uri(&external_path);
     }
 
@@ -298,6 +300,26 @@ pub(super) fn build_session_document_uri(uri: &str, project_root: &Path) -> Stri
     }
 
     path_to_file_uri(&session_path)
+}
+
+/// A virtual document like `Button.vue.ts` has no on-disk counterpart, but
+/// its underlying source (`Button.vue`) does. Keeping such overlays at their
+/// real path lets the session resolve their relative imports against the
+/// real project tree (in-memory, via `refresh_with_overlay_changes` —
+/// nothing is written next to the user's sources). Remapping them into the
+/// overlay mirror instead made every relative `<script>` import report
+/// "Cannot find module" in the editor while `vize check` was clean.
+fn virtual_overlay_target_exists(external_path: &Path) -> bool {
+    let Some(name) = external_path.file_name().and_then(|name| name.to_str()) else {
+        return false;
+    };
+    let Some(real_name) = name.strip_suffix(".ts") else {
+        return false;
+    };
+    if !real_name.ends_with(".vue") && !real_name.ends_with(".html") {
+        return false;
+    }
+    external_path.with_file_name(real_name).is_file()
 }
 
 fn overlay_root_for_project(project_root: &Path) -> PathBuf {
@@ -410,11 +432,45 @@ pub(super) fn line_character_to_utf16_offset(text: &str, line: u32, character: u
 #[cfg(test)]
 mod tests {
     use super::{
-        api_mode_for_executable, line_character_to_utf16_offset, should_retry_json_rpc,
-        uri_document_identifier,
+        api_mode_for_executable, build_session_document_uri, line_character_to_utf16_offset,
+        path_to_file_uri, should_retry_json_rpc, uri_document_identifier,
     };
     use corsa::CorsaError;
     use corsa::api::{ApiMode, DocumentIdentifier};
+
+    // Regression: a `.vue.ts` virtual overlay has no on-disk counterpart, but
+    // remapping it into the overlay mirror broke relative `<script>` import
+    // resolution in the editor ("Cannot find module" while `vize check` was
+    // clean). When the underlying `.vue` exists inside the project, the
+    // overlay must keep its real path.
+    #[test]
+    fn keeps_vue_virtual_overlay_at_real_path_inside_project() {
+        let nonce = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let project = std::env::temp_dir().join(format!(
+            "vize-canon-session-uri-{}-{nonce}",
+            std::process::id()
+        ));
+        let components = project.join("src/components");
+        std::fs::create_dir_all(&components).unwrap();
+        let real = components.join("Button.vue");
+        std::fs::write(&real, "<template><div /></template>").unwrap();
+
+        let virtual_path = components.join("Button.vue.ts");
+        let uri = path_to_file_uri(&virtual_path);
+        let mapped = build_session_document_uri(&uri, &project);
+        assert_eq!(mapped, uri, "in-project .vue.ts overlay must keep its path");
+
+        // A path outside the project is still remapped into the overlay tree.
+        let outside = std::env::temp_dir().join(format!("vize-outside-{nonce}/Other.vue.ts"));
+        let outside_uri = path_to_file_uri(&outside);
+        let mapped_outside = build_session_document_uri(&outside_uri, &project);
+        assert_ne!(mapped_outside, outside_uri);
+
+        let _ = std::fs::remove_dir_all(project);
+    }
 
     #[test]
     fn uses_async_json_rpc_for_node_modules_bin_wrappers() {


### PR DESCRIPTION
## Summary
User report: the editor shows **`Cannot find module`** type errors on `<script>` imports in `.vue` files — including plain relative imports like `../types` — while `vize check` reports nothing.

Root cause (two stacked defects in the LSP→corsa path):
1. The corsa session behind the LSP bridge was rooted in an **isolated scratch directory** (`CorsaProjectClient::new`), not the workspace.
2. `build_session_document_uri` kept a document's real path only when the path **exists on disk** — a virtual `.vue.ts` overlay never does — so every open document was remapped into an overlay mirror where none of the project's real `.ts` neighbors exist. TypeScript then failed every relative import (and the project's tsconfig `paths` never applied).

Fix:
- Root the bridge session at the workspace whenever one is known (project tsconfig drives resolution, matching `vize check`); the scratch session remains the rootless fallback.
- Keep `.vue.ts`/`.html.ts` overlays whose **underlying real file** exists at their real path. These sync as pure in-memory overlays (`refresh_with_overlay_changes`) — nothing is written into the user's source tree.

## Verification
- LSP harness against nuxt-ui `Button.vue` (typecheck enabled): `Cannot find module` diagnostics **5 → 0** (parity with the CLI baseline, which reports none for relative imports)
- New unit test: in-project `.vue.ts` overlay keeps its real path; out-of-project paths still remap
- `cargo test -p vize_canon -p vize_maestro`: green; clippy clean

Part of #1352 (Production Gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1371"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783688812&installation_id=136613492&pr_number=1371&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1371&signature=9a217375b0858fb6005caaecbdc418c06f772efd783c90ff886dfce3888314f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->