### PR TITLE
fix(canon): gate real-path overlays on confirmed runtime overlay support

### DIFF
--- a/crates/vize_canon/src/corsa_bridge/bridge.rs
+++ b/crates/vize_canon/src/corsa_bridge/bridge.rs
@@ -74,18 +74,22 @@ impl CorsaBridge {
             .as_ref()
             .map(|path| path.to_string_lossy().into_owned());
 
-        // Root the session at the real workspace whenever one is known: the
-        // project's own tsconfig (paths, baseUrl) then drives module
+        // Root the session at the real workspace when it is a TypeScript
+        // project: its own tsconfig (paths, baseUrl) then drives module
         // resolution and virtual `.vue.ts` overlays can live at their real
         // paths, so relative imports in `<script>` resolve exactly like
-        // `vize check`. The isolated scratch session remains the fallback
-        // for rootless (single-file) usage.
-        let client = match working_dir.as_deref() {
-            Some(dir) => CorsaProjectClient::new_for_workspace(
-                corsa_path.as_deref(),
-                std::path::Path::new(dir),
-            ),
-            None => CorsaProjectClient::new(corsa_path.as_deref(), None),
+        // `vize check`. The isolated scratch session — which synthesizes a
+        // tsconfig and `*.vue` stubs — remains the fallback for rootless or
+        // tsconfig-less usage.
+        let workspace_root = working_dir
+            .as_deref()
+            .map(std::path::Path::new)
+            .filter(|dir| {
+                dir.join("tsconfig.json").is_file() || dir.join("jsconfig.json").is_file()
+            });
+        let client = match workspace_root {
+            Some(dir) => CorsaProjectClient::new_for_workspace(corsa_path.as_deref(), dir),
+            None => CorsaProjectClient::new(corsa_path.as_deref(), working_dir.as_deref()),
         }
         .map_err(CorsaBridgeError::SpawnFailed)?;
         *guard = Some(client);

--- a/crates/vize_canon/src/lsp_client/session.rs
+++ b/crates/vize_canon/src/lsp_client/session.rs
@@ -138,6 +138,15 @@ impl CorsaProjectClient {
         !self.trusts_capabilities() || self.capabilities.overlay.update_snapshot_overlay_changes
     }
 
+    /// True only when the runtime has positively advertised in-memory overlay
+    /// support. `supports_overlay_api` is optimistic for runtimes without a
+    /// capability endpoint; routing a document through the overlay path on
+    /// such a runtime fails at request time, so path-keeping decisions must
+    /// use this confirmed variant.
+    fn overlay_api_confirmed(&self) -> bool {
+        self.trusts_capabilities() && self.capabilities.overlay.update_snapshot_overlay_changes
+    }
+
     pub(super) fn supports_project_diagnostics_api(&self) -> bool {
         !self.trusts_capabilities() || self.capabilities.diagnostics.project
     }
@@ -172,12 +181,6 @@ impl CorsaProjectClient {
 
     pub(super) fn sync_overlay_document(&mut self, uri: &str, content: &str) -> Result<(), String> {
         let previous = self.document_texts.insert(uri.into(), content.into());
-        if !self.supports_overlay_api() {
-            return Err(
-                "Corsa overlay changes are unavailable for this project-session runtime".into(),
-            );
-        }
-
         let document_uri = self.session_document_uri(uri);
         if previous.as_deref() == Some(content) {
             return Ok(());
@@ -185,8 +188,16 @@ impl CorsaProjectClient {
 
         let file_changes = materialize_session_document(uri, document_uri.as_str(), content);
         if document_uri != uri {
+            // Remapped documents are materialized to disk; no overlay API is
+            // required, so runtimes without overlay support stay functional.
             return block_on(self.session.refresh(file_changes))
                 .map_err(|error| cstr!("Failed to refresh Corsa snapshot: {error}"));
+        }
+
+        if !self.supports_overlay_api() {
+            return Err(
+                "Corsa overlay changes are unavailable for this project-session runtime".into(),
+            );
         }
 
         let version = next_overlay_version(&mut self.overlay_versions, uri);
@@ -249,7 +260,8 @@ impl CorsaProjectClient {
             return mapped.clone();
         }
 
-        let mapped = build_session_document_uri(uri, &self.project_root);
+        let mapped =
+            build_session_document_uri(uri, &self.project_root, self.overlay_api_confirmed());
         self.session_document_uris
             .insert(uri.into(), mapped.clone());
         self.external_document_uris
@@ -278,13 +290,22 @@ fn load_file_text(uri: &str) -> Option<String> {
     std::fs::read_to_string(path).ok().map(Into::into)
 }
 
-pub(super) fn build_session_document_uri(uri: &str, project_root: &Path) -> String {
+pub(super) fn build_session_document_uri(
+    uri: &str,
+    project_root: &Path,
+    overlay_confirmed: bool,
+) -> String {
     let Some(external_path) = external_document_path(uri) else {
         return uri.into();
     };
 
+    // A virtual overlay (`.vue.ts`) may only keep its real path when the
+    // runtime positively supports in-memory overlays: the file never exists
+    // on disk, so without overlay support it must be materialized into the
+    // session mirror instead.
     if external_path.starts_with(project_root)
-        && (external_path.exists() || virtual_overlay_target_exists(&external_path))
+        && (external_path.exists()
+            || (overlay_confirmed && virtual_overlay_target_exists(&external_path)))
     {
         return path_to_file_uri(&external_path);
     }
@@ -460,13 +481,18 @@ mod tests {
 
         let virtual_path = components.join("Button.vue.ts");
         let uri = path_to_file_uri(&virtual_path);
-        let mapped = build_session_document_uri(&uri, &project);
+        let mapped = build_session_document_uri(&uri, &project, true);
         assert_eq!(mapped, uri, "in-project .vue.ts overlay must keep its path");
+
+        // Without confirmed overlay support the overlay must be materialized
+        // into the session mirror instead (the file never exists on disk).
+        let mapped_no_overlay = build_session_document_uri(&uri, &project, false);
+        assert_ne!(mapped_no_overlay, uri);
 
         // A path outside the project is still remapped into the overlay tree.
         let outside = std::env::temp_dir().join(format!("vize-outside-{nonce}/Other.vue.ts"));
         let outside_uri = path_to_file_uri(&outside);
-        let mapped_outside = build_session_document_uri(&outside_uri, &project);
+        let mapped_outside = build_session_document_uri(&outside_uri, &project, true);
         assert_ne!(mapped_outside, outside_uri);
 
         let _ = std::fs::remove_dir_all(project);

--- a/crates/vize_canon/src/lsp_client/tests.rs
+++ b/crates/vize_canon/src/lsp_client/tests.rs
@@ -85,7 +85,7 @@ fn overlay_documents_materialize_under_node_modules_vize() {
     fs::create_dir_all(&project_root).unwrap();
 
     let external_uri = "file:///external/App.vue.setup.ts";
-    let document_uri = build_session_document_uri(external_uri, &project_root);
+    let document_uri = build_session_document_uri(external_uri, &project_root, false);
     let test_output_fragment = PathBuf::from("target")
         .join("vize-tests")
         .to_string_lossy()
@@ -107,7 +107,7 @@ fn internal_vize_sessions_keep_overlays_inside_session_root() {
     fs::create_dir_all(&project_root).unwrap();
 
     let external_uri = "file:///external/App.vue.setup.ts";
-    let document_uri = build_session_document_uri(external_uri, &project_root);
+    let document_uri = build_session_document_uri(external_uri, &project_root, false);
     let test_output_fragment = PathBuf::from("target")
         .join("vize-tests")
         .to_string_lossy()


### PR DESCRIPTION
## Summary
**Urgent follow-up to #1371** (as flagged in its comments): keeping a virtual `.vue.ts` document at its real path requires the in-memory overlay API, but `supports_overlay_api` is *optimistic* for runtimes without a capability endpoint. On such a runtime (e.g. the native msgpack tsgo build), the overlay request fails with `updateSnapshot.overlayChanges is not supported` — and editor type checking goes **silent**. `lsp_corsa_smoke_publishes_diagnostics_and_hover` caught this locally (it is skipped on CI when the corsa runtime is unavailable, which is why #1371 was green).

Fix:
- Real paths are kept only when the runtime **positively advertises** overlay support via `describeCapabilities`; otherwise the document falls back to the materialized session mirror exactly as before #1371.
- The overlay-unavailable error moved below the remap branch, so mirror-backed documents never require the overlay API.
- Workspace-rooted sessions are additionally gated on a `tsconfig.json`/`jsconfig.json` actually existing; tsconfig-less projects keep the scratch session's synthetic config.

## Verification
- `lsp_corsa_smoke_publishes_diagnostics_and_hover` passes again (native runtime → mirror fallback → TS2322 published)
- Positive control on the JSON-RPC tsgo runtime: real path kept, TS2322 flows, relative imports resolve — #1371's behavior preserved where supported
- Unit test extended: overlay path kept only with confirmed support
- `cargo test --workspace`: green; clippy clean

Part of #1352 (Production Gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1372"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783690389&installation_id=136613492&pr_number=1372&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1372&signature=cee0eeeb320f14983d316f102eeaa91b909d1339e265cecb5cbf3903b75fcaa7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->