### PR TITLE
fix(canon,maestro): resolve inherited props before template analysis

### DIFF
--- a/crates/vize_atelier_sfc/src/croquis.rs
+++ b/crates/vize_atelier_sfc/src/croquis.rs
@@ -151,9 +151,58 @@ fn analyze_sfc_descriptor_with_context_impl(
     options_api: bool,
     legacy_vue2: bool,
 ) -> SfcCroquisAnalysis {
+    analyze_sfc_descriptor_resolved_impl(
+        descriptor,
+        template_ast,
+        options,
+        options_api,
+        legacy_vue2,
+        None,
+    )
+}
+
+/// Analyze an SFC descriptor with externally-resolved props merged in before
+/// template analysis.
+///
+/// Croquis alone cannot resolve props inherited through imported or heritage
+/// types (`interface Props extends Omit<ImportedProps, ...>`); the script
+/// compile context can (cross-file and node_modules type resolution), and the
+/// merge must land before the template pass or its undefined-reference
+/// detection flags those props as editor-only false positives that
+/// `vize check` never reported.
+pub fn analyze_sfc_descriptor_resolved(
+    descriptor: &SfcDescriptor<'_>,
+    template_ast: Option<&RootNode<'_>>,
+    options: SfcCroquisOptions,
+    options_api: bool,
+    legacy_vue2: bool,
+    filename: &str,
+) -> SfcCroquisAnalysis {
+    analyze_sfc_descriptor_resolved_impl(
+        descriptor,
+        template_ast,
+        options,
+        options_api,
+        legacy_vue2,
+        Some(filename),
+    )
+}
+
+fn analyze_sfc_descriptor_resolved_impl(
+    descriptor: &SfcDescriptor<'_>,
+    template_ast: Option<&RootNode<'_>>,
+    options: SfcCroquisOptions,
+    options_api: bool,
+    legacy_vue2: bool,
+    resolve_filename: Option<&str>,
+) -> SfcCroquisAnalysis {
     let script_analyzed = options.analyzer_options.analyze_script
         && (descriptor.script.is_some() || descriptor.script_setup.is_some());
-    let summary = analyze_scripts(descriptor, options, options_api, legacy_vue2);
+    let mut summary = analyze_scripts(descriptor, options, options_api, legacy_vue2);
+    if let Some(filename) = resolve_filename {
+        merge_resolved_props_into_croquis(&mut summary, descriptor, filename);
+    }
+    let summary = summary;
     let analyzer = Analyzer::with_summary(options.analyzer_options, summary, script_analyzed);
     let mut analyzer = apply_options_api_mode(analyzer, options_api, legacy_vue2);
 
@@ -257,6 +306,47 @@ fn analyze_scripts(
             analyzer.finish()
         }
         (None, None) => Croquis::new(),
+    }
+}
+
+/// Merge props resolved by the script compile context — which performs
+/// cross-file and node_modules type resolution — into a Croquis summary.
+///
+/// Croquis alone cannot resolve props inherited through imported or heritage
+/// types (`interface Props extends Omit<ImportedProps, ...>`), so
+/// template-binding checks and virtual TS generation would treat those props
+/// as undefined references. This mirrors the merge the compiler performs in
+/// `compile.rs`.
+pub fn merge_resolved_props_into_croquis(
+    croquis: &mut Croquis,
+    descriptor: &SfcDescriptor<'_>,
+    filename: &str,
+) {
+    use crate::script::ScriptCompileContext;
+    use crate::types::BindingType;
+
+    let Some(script_setup) = descriptor.script_setup.as_ref() else {
+        return;
+    };
+
+    let mut ctx = ScriptCompileContext::new(&script_setup.content);
+    if let Some(ref script) = descriptor.script {
+        ctx.collect_types_from(&script.content);
+    }
+    if !filename.is_empty() {
+        ctx.collect_imported_types_from_path(&script_setup.content, filename);
+        if let Some(ref script) = descriptor.script {
+            ctx.collect_imported_types_from_path(&script.content, filename);
+        }
+    }
+    ctx.analyze();
+
+    for (name, binding_type) in &ctx.bindings.bindings {
+        if matches!(binding_type, BindingType::Props | BindingType::PropsAliased)
+            && !croquis.bindings.contains(name.as_str())
+        {
+            croquis.bindings.add(name.as_str(), *binding_type);
+        }
     }
 }
 

--- a/crates/vize_canon/src/sfc_typecheck/runner.rs
+++ b/crates/vize_canon/src/sfc_typecheck/runner.rs
@@ -55,15 +55,7 @@ fn type_check_sfc_impl(
     legacy_vue2: bool,
 ) -> SfcTypeCheckResult {
     use vize_atelier_core::parser::parse;
-    use vize_atelier_sfc::{
-        SfcParseOptions,
-        croquis::{
-            SfcCroquisOptions, analyze_sfc_descriptor_with_context,
-            analyze_sfc_descriptor_with_context_legacy_vue2,
-            analyze_sfc_descriptor_with_context_options_api,
-        },
-        parse_sfc,
-    };
+    use vize_atelier_sfc::{SfcParseOptions, croquis::SfcCroquisOptions, parse_sfc};
 
     // Use Instant for timing on native, skip on WASM
     #[cfg(not(target_arch = "wasm32"))]
@@ -152,21 +144,18 @@ fn type_check_sfc_impl(
 
     let croquis_options = SfcCroquisOptions::full();
 
-    let analysis = if legacy_vue2 {
-        analyze_sfc_descriptor_with_context_legacy_vue2(
-            &descriptor,
-            template_ast.as_ref(),
-            croquis_options,
-        )
-    } else if options_api {
-        analyze_sfc_descriptor_with_context_options_api(
-            &descriptor,
-            template_ast.as_ref(),
-            croquis_options,
-        )
-    } else {
-        analyze_sfc_descriptor_with_context(&descriptor, template_ast.as_ref(), croquis_options)
-    };
+    // Croquis cannot resolve props inherited through imported/heritage types;
+    // the resolved analysis merges the script compile context's props before
+    // the template pass so undefined-reference detection doesn't flag them
+    // (editor-only false positives that `vize check` never reported).
+    let analysis = vize_atelier_sfc::croquis::analyze_sfc_descriptor_resolved(
+        &descriptor,
+        template_ast.as_ref(),
+        croquis_options,
+        options_api,
+        legacy_vue2,
+        options.filename.as_str(),
+    );
     let script_content = analysis.script_content;
     let script_offset = analysis.script_offset;
     let summary = analysis.croquis;

--- a/crates/vize_canon/src/sfc_typecheck/snapshots/vize_canon__sfc_typecheck__tests__type_check_component_with_props_and_events.snap
+++ b/crates/vize_canon/src/sfc_typecheck/snapshots/vize_canon__sfc_typecheck__tests__type_check_component_with_props_and_events.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/vize_canon/src/sfc_typecheck/tests.rs
+assertion_line: 1300
 expression: vts.as_str()
 ---
 /// <reference lib="es2022" />
@@ -109,7 +110,7 @@ function __setup() {
   // @vize-map: expr -> 343:357
 
   // Reference setup bindings (used in template/CSS v-bind)
-  void emit; void props;
+  void disabled; void emit; void props; void title;
   })();
 }
 

--- a/crates/vize_canon/src/sfc_typecheck/tests.rs
+++ b/crates/vize_canon/src/sfc_typecheck/tests.rs
@@ -1456,3 +1456,58 @@ const msg = 'hello'
     });
     assert!(has_error, "Strict mode should report as Error");
 }
+
+#[test]
+fn imported_heritage_props_are_not_undefined_bindings() {
+    // Regression: props inherited through an imported type
+    // (`interface Props extends Pick<ImportedProps, ...>`) were flagged as
+    // undefined references in template expressions by the editor while
+    // `vize check` was clean — croquis alone cannot resolve imported types,
+    // so the script compile context's resolved props must be merged in.
+    let nonce = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let project = std::env::temp_dir().join(format!(
+        "vize-canon-heritage-props-{}-{nonce}",
+        std::process::id()
+    ));
+    let src = project.join("src");
+    std::fs::create_dir_all(&src).unwrap();
+    std::fs::write(
+        src.join("types.ts"),
+        "export interface RootProps { side?: 'left' | 'right'; resizable?: boolean }",
+    )
+    .unwrap();
+
+    let component = src.join("Comp.vue");
+    let source = r#"<script setup lang="ts">
+import type { RootProps } from './types'
+
+interface Props extends Pick<RootProps, 'side' | 'resizable'> {
+  label?: string
+}
+
+const props = defineProps<Props>()
+</script>
+
+<template>
+  <div v-if="side === 'left'">{{ label }} {{ resizable }}</div>
+</template>
+"#;
+
+    let options = SfcTypeCheckOptions::new(component.to_string_lossy().as_ref());
+    let result = type_check_sfc(source, &options);
+    let undefined: Vec<_> = result
+        .diagnostics
+        .iter()
+        .filter(|d| d.code.as_deref() == Some("undefined-binding"))
+        .map(|d| d.message.clone())
+        .collect();
+    assert!(
+        undefined.is_empty(),
+        "inherited props flagged as undefined: {undefined:?}"
+    );
+
+    let _ = std::fs::remove_dir_all(project);
+}

--- a/crates/vize_canon/src/snapshots/vize_canon__tests__virtual_ts_tests__virtual_ts_complex_component.snap
+++ b/crates/vize_canon/src/snapshots/vize_canon__tests__virtual_ts_tests__virtual_ts_complex_component.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/vize_canon/src/tests.rs
+assertion_line: 169
 expression: virtual_ts
 ---
 /// <reference lib="es2022" />
@@ -141,7 +142,7 @@ function __setup() {
   })({} as PointerEvent);
 
   // Reference setup bindings (used in template/CSS v-bind)
-  void computed; void count; void doubled; void emit; void increment; void props; void ref; void watch;
+  void computed; void count; void doubled; void emit; void increment; void initialCount; void props; void ref; void title; void watch;
   })();
 }
 

--- a/crates/vize_canon/src/snapshots/vize_canon__tests__virtual_ts_tests__virtual_ts_with_props.snap
+++ b/crates/vize_canon/src/snapshots/vize_canon__tests__virtual_ts_tests__virtual_ts_with_props.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/vize_canon/src/tests.rs
+assertion_line: 59
 expression: virtual_ts
 ---
 /// <reference lib="es2022" />
@@ -108,7 +109,7 @@ function __setup() {
   }
 
   // Reference setup bindings (used in template/CSS v-bind)
-  void props;
+  void count; void props; void title;
   })();
 }
 

--- a/crates/vize_canon/src/typecheck_service.rs
+++ b/crates/vize_canon/src/typecheck_service.rs
@@ -129,14 +129,7 @@ impl TypeCheckService {
     ) -> Result<SfcTypeCheckResult, CorsaBridgeError> {
         use std::time::Instant;
         use vize_atelier_core::parser::parse;
-        use vize_atelier_sfc::{
-            SfcParseOptions,
-            croquis::{
-                SfcCroquisOptions, analyze_sfc_descriptor_with_context,
-                analyze_sfc_descriptor_with_context_legacy_vue2,
-            },
-            parse_sfc,
-        };
+        use vize_atelier_sfc::{SfcParseOptions, croquis::SfcCroquisOptions, parse_sfc};
         use vize_carton::Bump;
 
         let start_time = Instant::now();
@@ -225,15 +218,18 @@ impl TypeCheckService {
         };
 
         let croquis_options = SfcCroquisOptions::full();
-        let analysis = if legacy_vue2 {
-            analyze_sfc_descriptor_with_context_legacy_vue2(
-                &descriptor,
-                template_ast.as_ref(),
-                croquis_options,
-            )
-        } else {
-            analyze_sfc_descriptor_with_context(&descriptor, template_ast.as_ref(), croquis_options)
-        };
+        // Croquis cannot resolve props inherited through imported/heritage
+        // types; the resolved analysis merges the script compile context's
+        // props before the template pass so virtual TS generation and
+        // undefined-reference detection see the full prop set.
+        let analysis = vize_atelier_sfc::croquis::analyze_sfc_descriptor_resolved(
+            &descriptor,
+            template_ast.as_ref(),
+            croquis_options,
+            false,
+            legacy_vue2,
+            filename,
+        );
 
         if has_template_parse_errors || has_script_parse_errors {
             result.analysis_time_ms = Some(start_time.elapsed().as_secs_f64() * 1000.0);

--- a/crates/vize_maestro/src/ide/diagnostics/corsa/virtual_ts.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/corsa/virtual_ts.rs
@@ -39,15 +39,7 @@ impl DiagnosticService {
         options_api: bool,
         legacy_vue2: bool,
     ) -> Option<VirtualTsResult> {
-        use vize_atelier_sfc::{
-            SfcParseOptions,
-            croquis::{
-                SfcCroquisOptions, analyze_sfc_descriptor_with_context,
-                analyze_sfc_descriptor_with_context_legacy_vue2,
-                analyze_sfc_descriptor_with_context_options_api,
-            },
-            parse_sfc,
-        };
+        use vize_atelier_sfc::{SfcParseOptions, croquis::SfcCroquisOptions, parse_sfc};
         use vize_canon::virtual_ts::{
             VirtualTsOptions, generate_virtual_ts_with_offsets,
             generate_virtual_ts_with_offsets_legacy_vue2,
@@ -68,21 +60,19 @@ impl DiagnosticService {
         let (template_ast, _) = vize_armature::parse(&allocator, &template_block.content);
 
         let croquis_options = SfcCroquisOptions::full();
-        let analysis = if legacy_vue2 {
-            analyze_sfc_descriptor_with_context_legacy_vue2(
-                &descriptor,
-                Some(&template_ast),
-                croquis_options,
-            )
-        } else if options_api {
-            analyze_sfc_descriptor_with_context_options_api(
-                &descriptor,
-                Some(&template_ast),
-                croquis_options,
-            )
-        } else {
-            analyze_sfc_descriptor_with_context(&descriptor, Some(&template_ast), croquis_options)
-        };
+        // Croquis cannot resolve props inherited through imported/heritage
+        // types; the resolved analysis merges the script compile context's
+        // props before the template pass so the virtual TS fed to Corsa sees
+        // the full prop set.
+        let analysis = vize_atelier_sfc::croquis::analyze_sfc_descriptor_resolved(
+            &descriptor,
+            Some(&template_ast),
+            croquis_options,
+            options_api,
+            legacy_vue2,
+            uri.path(),
+        );
+
         let script_content = analysis.script_content?;
         let script_offset = analysis.script_offset;
         let sfc_script_start_line =


### PR DESCRIPTION
## Summary
Second editor-only false-positive family found while verifying the `Cannot find module` fix: props inherited through imported/heritage types (`interface Props extends Omit<ImportedProps, ...>`) — and even same-interface props declared next to them — were flagged as **`Undefined reference '...' in template expression`** (`vize/types/undefined-binding`) in the editor, while `vize check` was clean. The virtual TS fed to Corsa was missing those props too.

Croquis alone cannot resolve imported types. The compiler already merges the script compile context's resolved props (cross-file + node_modules resolution, #1357/#1362) in `compile.rs` — but the canon/maestro analysis paths didn't, and crucially the merge must land **before** the template pass: undefined-reference detection runs during template analysis, so a post-merge cannot retract the false positives (the first implementation attempt proved this via the new regression test).

- New `analyze_sfc_descriptor_resolved` in `atelier_sfc::croquis` merges resolved props into the script summary before template analysis.
- Wired into canon's `sfc_typecheck` runner, `TypeCheckService`, and maestro's virtual TS generation.

## Verification
- nuxt-ui `Button.vue` in the editor: **13 undefined-binding false positives → 0** (with zero `Cannot find module`)
- New end-to-end regression test (imported `Pick<...>` heritage props must not be undefined bindings)
- 3 virtual-ts snapshots refreshed — they now reference the resolved props (strictly additive)
- `cargo test --workspace` green; clippy clean

Part of #1352 (Production Gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1373"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783690438&installation_id=136613492&pr_number=1373&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1373&signature=42d214959d4ca2d237477c33299f64ab78fcc1600f7754aaf8a735e094b29809"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->