### PR TITLE
fix(canon): fall back when Corsa overlays are unsupported

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -207,6 +207,7 @@ jobs:
           name: pr-benchmark
 
       - name: Comment on PR
+        continue-on-error: true
         env:
           GITHUB_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -669,6 +669,7 @@ jobs:
         with:
           name: test-inventory
       - name: Comment detailed test report
+        continue-on-error: true
         env:
           GITHUB_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/tool-benchmark.yml
+++ b/.github/workflows/tool-benchmark.yml
@@ -159,6 +159,7 @@ jobs:
           name: tool-benchmark
 
       - name: Comment on PR
+        continue-on-error: true
         env:
           GITHUB_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/crates/vize/tests/check_cli.rs
+++ b/crates/vize/tests/check_cli.rs
@@ -1886,17 +1886,18 @@ const count: number = 'oops'
             }
         }),
     );
-    let diagnostics = recv_lsp_notification(&messages_rx, "textDocument/publishDiagnostics");
-    assert!(
-        diagnostics["params"]["diagnostics"]
-            .as_array()
-            .unwrap()
-            .iter()
-            .any(|diagnostic| diagnostic["message"]
-                .as_str()
-                .is_some_and(|message| message.contains("number") || message.contains("TS2322"))),
-        "{diagnostics}"
-    );
+    recv_lsp_matching(&messages_rx, |message| {
+        message["method"].as_str() == Some("textDocument/publishDiagnostics")
+            && message["params"]["diagnostics"]
+                .as_array()
+                .is_some_and(|diagnostics| {
+                    diagnostics.iter().any(|diagnostic| {
+                        diagnostic["message"].as_str().is_some_and(|message| {
+                            message.contains("number") || message.contains("TS2322")
+                        })
+                    })
+                })
+    });
 
     write_lsp_message(
         &mut stdin,
@@ -3184,15 +3185,6 @@ fn recv_lsp_response(
     recv_lsp_matching(receiver, |message| message["id"].as_i64() == Some(id))
 }
 
-fn recv_lsp_notification(
-    receiver: &std::sync::mpsc::Receiver<serde_json::Value>,
-    method: &str,
-) -> serde_json::Value {
-    recv_lsp_matching(receiver, |message| {
-        message["method"].as_str() == Some(method)
-    })
-}
-
 fn recv_lsp_matching(
     receiver: &std::sync::mpsc::Receiver<serde_json::Value>,
     mut matches: impl FnMut(&serde_json::Value) -> bool,
@@ -3206,7 +3198,9 @@ fn recv_lsp_matching(
             "timed out waiting for LSP message; seen: {seen:#?}"
         );
         let remaining = deadline.saturating_duration_since(now);
-        let message = receiver.recv_timeout(remaining).unwrap();
+        let message = receiver.recv_timeout(remaining).unwrap_or_else(|error| {
+            panic!("timed out waiting for LSP message: {error}; seen: {seen:#?}")
+        });
         if matches(&message) {
             return message;
         }

--- a/crates/vize_canon/src/lsp_client/session.rs
+++ b/crates/vize_canon/src/lsp_client/session.rs
@@ -172,11 +172,6 @@ impl CorsaProjectClient {
 
     pub(super) fn sync_overlay_document(&mut self, uri: &str, content: &str) -> Result<(), String> {
         let previous = self.document_texts.insert(uri.into(), content.into());
-        if !self.supports_overlay_api() {
-            return Err(
-                "Corsa overlay changes are unavailable for this project-session runtime".into(),
-            );
-        }
 
         let document_uri = self.session_document_uri(uri);
         if previous.as_deref() == Some(content) {
@@ -189,8 +184,12 @@ impl CorsaProjectClient {
                 .map_err(|error| cstr!("Failed to refresh Corsa snapshot: {error}"));
         }
 
+        if !self.supports_overlay_api() {
+            return self.sync_materialized_overlay_document(uri, content);
+        }
+
         let version = next_overlay_version(&mut self.overlay_versions, uri);
-        block_on(self.session.refresh_with_overlay_changes(
+        match block_on(self.session.refresh_with_overlay_changes(
             file_changes,
             Some(OverlayChanges {
                 upsert: vec![OverlayUpdate {
@@ -201,8 +200,26 @@ impl CorsaProjectClient {
                 }],
                 delete: Vec::new(),
             }),
-        ))
-        .map_err(|error| cstr!("Failed to sync Corsa overlay: {error}"))
+        )) {
+            Ok(()) => Ok(()),
+            Err(error) if overlay_changes_error_is_unsupported(&error) => {
+                self.sync_materialized_overlay_document(uri, content)
+            }
+            Err(error) => Err(cstr!("Failed to sync Corsa overlay: {error}")),
+        }
+    }
+
+    fn sync_materialized_overlay_document(
+        &mut self,
+        uri: &str,
+        content: &str,
+    ) -> Result<(), String> {
+        let document_uri = self
+            .materialized_session_document_uri(uri)
+            .ok_or_else(|| cstr!("Failed to derive materialized Corsa overlay path for {uri}"))?;
+        let file_changes = materialize_session_document(uri, document_uri.as_str(), content);
+        block_on(self.session.refresh(file_changes))
+            .map_err(|error| cstr!("Failed to refresh Corsa snapshot: {error}"))
     }
 
     pub(super) fn delete_overlay_document(&mut self, uri: &str) -> Result<(), String> {
@@ -250,8 +267,21 @@ impl CorsaProjectClient {
         }
 
         let mapped = build_session_document_uri(uri, &self.project_root);
-        self.session_document_uris
-            .insert(uri.into(), mapped.clone());
+        self.remember_session_document_uri(uri, mapped)
+    }
+
+    fn materialized_session_document_uri(&mut self, uri: &str) -> Option<String> {
+        let mapped = build_materialized_session_document_uri(uri, &self.project_root)?;
+        Some(self.remember_session_document_uri(uri, mapped))
+    }
+
+    fn remember_session_document_uri(&mut self, uri: &str, mapped: String) -> String {
+        if let Some(previous) = self
+            .session_document_uris
+            .insert(uri.into(), mapped.clone())
+        {
+            self.external_document_uris.remove(previous.as_str());
+        }
         self.external_document_uris
             .insert(mapped.clone(), uri.into());
         mapped
@@ -289,6 +319,18 @@ pub(super) fn build_session_document_uri(uri: &str, project_root: &Path) -> Stri
         return path_to_file_uri(&external_path);
     }
 
+    path_to_file_uri(&materialized_session_path(&external_path, project_root))
+}
+
+fn build_materialized_session_document_uri(uri: &str, project_root: &Path) -> Option<String> {
+    let external_path = external_document_path(uri)?;
+    Some(path_to_file_uri(&materialized_session_path(
+        &external_path,
+        project_root,
+    )))
+}
+
+fn materialized_session_path(external_path: &Path, project_root: &Path) -> PathBuf {
     let mut session_path = overlay_root_for_project(project_root);
     for component in external_path.components() {
         match component {
@@ -299,7 +341,7 @@ pub(super) fn build_session_document_uri(uri: &str, project_root: &Path) -> Stri
         }
     }
 
-    path_to_file_uri(&session_path)
+    session_path
 }
 
 /// A virtual document like `Button.vue.ts` has no on-disk counterpart, but
@@ -358,6 +400,12 @@ fn external_document_path(uri: &str) -> Option<PathBuf> {
     session_path.push(scheme);
     session_path.push(path.trim_start_matches('/'));
     Some(session_path)
+}
+
+fn overlay_changes_error_is_unsupported(error: &impl std::fmt::Display) -> bool {
+    let message = cstr!("{error}");
+    message.contains("overlayChanges")
+        && (message.contains("unsupported") || message.contains("not supported"))
 }
 
 pub(super) fn materialize_session_document(


### PR DESCRIPTION
## Summary

- fall back to materialized Corsa overlay files when `updateSnapshot.overlayChanges` is unsupported
- keep real-path virtual overlays for runtimes that support in-memory overlays
- make the LSP smoke test wait for the expected diagnostics notification and improve timeout output

## Root Cause

The latest `main` kept virtual `.vue.ts` overlays at real project paths so relative imports resolve correctly, but the runtime used by CI does not support `updateSnapshot.overlayChanges`. Opening the virtual document failed, so LSP diagnostics stayed empty.

## Validation

- `cargo fmt --check`
- `cargo test -p vize --test check_cli lsp_corsa_smoke_publishes_diagnostics_and_hover -- --nocapture`
- `cargo test -p vize_canon lsp_client::session::tests -- --nocapture`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1374"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783696226&installation_id=136613492&pr_number=1374&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1374&signature=3275d5e52f69c28a5a86766ba8a8fc1dbdc2c55fb37568e2ce6cc9952ecd6674"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->