### PR TITLE
ci: use Blacksmith sticky disks for Rust caches

### DIFF
--- a/.github/actions/setup-rust-sticky-cache/action.yml
+++ b/.github/actions/setup-rust-sticky-cache/action.yml
@@ -1,0 +1,54 @@
+name: Setup Rust sticky cache
+description: Mount Blacksmith sticky disks for Cargo and Rust build artifacts
+
+inputs:
+  key:
+    description: Stable cache namespace for this job
+    required: true
+  cache-key-suffix:
+    description: Runner and dependency suffix to separate incompatible disks
+    required: true
+  target-path:
+    description: Rust target directory to mount
+    required: false
+    default: target
+  secondary-key:
+    description: Stable cache namespace for an optional second target directory
+    required: false
+    default: ""
+  secondary-target-path:
+    description: Optional second Rust target directory to mount
+    required: false
+    default: ""
+  secondary-cache-key-suffix:
+    description: Runner and dependency suffix for the optional second target directory
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - name: Mount Cargo registry sticky disk
+      uses: useblacksmith/stickydisk@d58829ad6f9be8822ec5efe74256c82cd62915ab # v1
+      with:
+        key: ${{ github.repository }}-${{ inputs.key }}-cargo-registry-${{ inputs.cache-key-suffix }}
+        path: ~/.cargo/registry
+
+    - name: Mount Cargo git sticky disk
+      uses: useblacksmith/stickydisk@d58829ad6f9be8822ec5efe74256c82cd62915ab # v1
+      with:
+        key: ${{ github.repository }}-${{ inputs.key }}-cargo-git-${{ inputs.cache-key-suffix }}
+        path: ~/.cargo/git
+
+    - name: Mount Rust target sticky disk
+      uses: useblacksmith/stickydisk@d58829ad6f9be8822ec5efe74256c82cd62915ab # v1
+      with:
+        key: ${{ github.repository }}-${{ inputs.key }}-target-${{ inputs.cache-key-suffix }}
+        path: ${{ inputs.target-path }}
+
+    - name: Mount secondary Rust target sticky disk
+      if: ${{ inputs.secondary-target-path != '' }}
+      uses: useblacksmith/stickydisk@d58829ad6f9be8822ec5efe74256c82cd62915ab # v1
+      with:
+        key: ${{ github.repository }}-${{ inputs.secondary-key }}-target-${{ inputs.secondary-cache-key-suffix }}
+        path: ${{ inputs.secondary-target-path }}

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -65,13 +65,14 @@ jobs:
         with:
           wild-version: "0.9.0"
 
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: ./head/.github/actions/setup-rust-sticky-cache
         with:
-          shared-key: "benchmark"
-          cache-workspace-crates: "true"
-          workspaces: |
-            head -> target
-            base -> target
+          key: benchmark-head
+          cache-key-suffix: ${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('head/Cargo.lock') }}
+          target-path: head/target
+          secondary-key: benchmark-base
+          secondary-target-path: base/target
+          secondary-cache-key-suffix: ${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('base/Cargo.lock') }}
 
       - uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1
         with:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -117,10 +117,10 @@ jobs:
       - uses: wild-linker/action@0bbbfa5df4380cab8e63cb8505a1ce65e1d10203 # v0.9.0
         with:
           wild-version: "0.9.0"
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: ./.github/actions/setup-rust-sticky-cache
         with:
-          shared-key: "semver-checks"
-          cache-workspace-crates: "true"
+          key: semver-checks
+          cache-key-suffix: ${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('Cargo.lock') }}
       - name: Install cargo-semver-checks
         uses: taiki-e/install-action@184183c2401be73c3bf42c2e61268aa5855379c1 # v2
         with:
@@ -191,10 +191,10 @@ jobs:
       - uses: wild-linker/action@0bbbfa5df4380cab8e63cb8505a1ce65e1d10203 # v0.9.0
         with:
           wild-version: "0.9.0"
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: ./.github/actions/setup-rust-sticky-cache
         with:
-          shared-key: "native"
-          cache-workspace-crates: "true"
+          key: check-vize-apps
+          cache-key-suffix: ${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('Cargo.lock') }}
       - name: Install JS dependencies
         run: vp install --frozen-lockfile --prefer-offline
       - name: Build vize CLI
@@ -220,10 +220,10 @@ jobs:
       - uses: wild-linker/action@0bbbfa5df4380cab8e63cb8505a1ce65e1d10203 # v0.9.0
         with:
           wild-version: "0.9.0"
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: ./.github/actions/setup-rust-sticky-cache
         with:
-          shared-key: "vue-parity"
-          cache-workspace-crates: "true"
+          key: vue-parity
+          cache-key-suffix: ${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('Cargo.lock') }}
       - name: Install JS dependencies
         run: vp install --frozen-lockfile --prefer-offline
       - name: Build vize CLI
@@ -255,10 +255,10 @@ jobs:
       - uses: wild-linker/action@0bbbfa5df4380cab8e63cb8505a1ce65e1d10203 # v0.9.0
         with:
           wild-version: "0.9.0"
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: ./.github/actions/setup-rust-sticky-cache
         with:
-          shared-key: "native"
-          cache-workspace-crates: "true"
+          key: test-scripts
+          cache-key-suffix: ${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('Cargo.lock') }}
       - name: Install JS dependencies
         run: vp install --frozen-lockfile --prefer-offline
       - name: Build vize CLI
@@ -281,10 +281,10 @@ jobs:
           cache: true
           run-install: false
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: ./.github/actions/setup-rust-sticky-cache
         with:
-          shared-key: "native"
-          cache-workspace-crates: "true"
+          key: editor-extensions
+          cache-key-suffix: ${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('Cargo.lock') }}
       - name: Install JS dependencies
         run: vp install --frozen-lockfile --prefer-offline
       - name: Check and package editor extensions
@@ -307,10 +307,10 @@ jobs:
       - uses: wild-linker/action@0bbbfa5df4380cab8e63cb8505a1ce65e1d10203 # v0.9.0
         with:
           wild-version: "0.9.0"
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: ./.github/actions/setup-rust-sticky-cache
         with:
-          shared-key: "native"
-          cache-workspace-crates: "true"
+          key: build-js-packages
+          cache-key-suffix: ${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('Cargo.lock') }}
       - name: Install JS dependencies
         run: vp install --frozen-lockfile --prefer-offline
       - name: Build native package
@@ -351,10 +351,10 @@ jobs:
       - uses: wild-linker/action@0bbbfa5df4380cab8e63cb8505a1ce65e1d10203 # v0.9.0
         with:
           wild-version: "0.9.0"
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: ./.github/actions/setup-rust-sticky-cache
         with:
-          shared-key: "native"
-          cache-workspace-crates: "true"
+          key: test-js-packages
+          cache-key-suffix: ${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('Cargo.lock') }}
       - name: Install JS dependencies
         run: vp install --frozen-lockfile --prefer-offline
       - name: Test JS packages
@@ -376,23 +376,10 @@ jobs:
           node-version-file: ".node-version"
           run-install: false
 
-      - name: Mount Cargo registry sticky disk
-        uses: useblacksmith/stickydisk@d58829ad6f9be8822ec5efe74256c82cd62915ab # v1
+      - uses: ./.github/actions/setup-rust-sticky-cache
         with:
-          key: ${{ github.repository }}-clippy-test-cargo-registry-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('Cargo.lock') }}
-          path: ~/.cargo/registry
-
-      - name: Mount Cargo git sticky disk
-        uses: useblacksmith/stickydisk@d58829ad6f9be8822ec5efe74256c82cd62915ab # v1
-        with:
-          key: ${{ github.repository }}-clippy-test-cargo-git-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('Cargo.lock') }}
-          path: ~/.cargo/git
-
-      - name: Mount Rust target sticky disk
-        uses: useblacksmith/stickydisk@d58829ad6f9be8822ec5efe74256c82cd62915ab # v1
-        with:
-          key: ${{ github.repository }}-clippy-test-target-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('Cargo.lock') }}
-          path: target
+          key: clippy-test
+          cache-key-suffix: ${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('Cargo.lock') }}
 
       - name: Clippy
         run: cargo clippy --workspace -- -D warnings
@@ -411,10 +398,10 @@ jobs:
 
       - uses: ./.github/actions/setup-moonbit
 
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: ./.github/actions/setup-rust-sticky-cache
         with:
-          shared-key: "native"
-          cache-workspace-crates: "true"
+          key: coverage
+          cache-key-suffix: ${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('Cargo.lock') }}
 
       - uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1
         with:
@@ -457,10 +444,10 @@ jobs:
         with:
           wild-version: "0.9.0"
 
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: ./.github/actions/setup-rust-sticky-cache
         with:
-          shared-key: "coverage-source"
-          cache-workspace-crates: "true"
+          key: coverage-source
+          cache-key-suffix: ${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('Cargo.lock') }}
 
       - name: Install JS dependencies
         run: vp install --frozen-lockfile --prefer-offline
@@ -512,10 +499,10 @@ jobs:
         with:
           wild-version: "0.9.0"
 
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: ./.github/actions/setup-rust-sticky-cache
         with:
-          shared-key: "coverage-branch"
-          cache-workspace-crates: "true"
+          key: coverage-branch
+          cache-key-suffix: ${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('Cargo.lock') }}
 
       - name: Install JS dependencies
         run: vp install --frozen-lockfile --prefer-offline
@@ -557,11 +544,10 @@ jobs:
 
       - uses: ./.github/actions/setup-moonbit
 
-      - name: Cache Rust
-        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: ./.github/actions/setup-rust-sticky-cache
         with:
-          shared-key: "wasm"
-          cache-workspace-crates: "true"
+          key: playground-test
+          cache-key-suffix: ${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('Cargo.lock') }}
 
       - name: Cache WASM build
         id: cache-wasm

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -30,12 +30,10 @@ jobs:
         with:
           wild-version: "0.9.0"
 
-      - name: Cache Rust
-        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: ./.github/actions/setup-rust-sticky-cache
         with:
-          prefix-key: "v1-rust"
-          shared-key: "napi"
-          cache-workspace-crates: "true"
+          key: docs-napi
+          cache-key-suffix: ${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('Cargo.lock') }}
 
       - name: Setup Vite+ and Node.js
         uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1
@@ -77,12 +75,10 @@ jobs:
 
       - uses: ./.github/actions/setup-moonbit
 
-      - name: Cache Rust
-        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: ./.github/actions/setup-rust-sticky-cache
         with:
-          prefix-key: "v1-rust"
-          shared-key: "wasm"
-          cache-workspace-crates: "true"
+          key: docs-wasm
+          cache-key-suffix: ${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('Cargo.lock') }}
 
       - name: Cache WASM build
         id: cache-wasm

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -70,11 +70,10 @@ jobs:
         with:
           targets: wasm32-unknown-unknown
 
-      - name: Cache Rust
-        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: ./.github/actions/setup-rust-sticky-cache
         with:
-          shared-key: "testbox"
-          cache-workspace-crates: "true"
+          key: testbox
+          cache-key-suffix: ${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('Cargo.lock') }}
 
       - name: Install JS dependencies
         run: vp install --frozen-lockfile --prefer-offline
@@ -118,11 +117,10 @@ jobs:
         with:
           wild-version: "0.9.0"
 
-      - name: Cache Rust
-        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2.9.1
+      - uses: ./.github/actions/setup-rust-sticky-cache
         with:
-          shared-key: "native"
-          cache-workspace-crates: "true"
+          key: app-e2e-${{ matrix.suite }}
+          cache-key-suffix: ${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('Cargo.lock') }}
 
       - name: Setup Vite+ and Node.js
         uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -84,10 +84,11 @@ jobs:
           toolchain: nightly
           components: rust-src
 
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: ./.github/actions/setup-rust-sticky-cache
         with:
-          shared-key: fuzz-${{ matrix.target }}
-          workspaces: "tests/fuzz -> target"
+          key: fuzz-${{ matrix.target }}
+          cache-key-suffix: ${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('Cargo.lock', 'tests/fuzz/Cargo.toml') }}
+          target-path: tests/fuzz/target
 
       - name: Install cargo-fuzz
         run: cargo install cargo-fuzz --locked --version "^0.13"

--- a/.github/workflows/native-smoke.yml
+++ b/.github/workflows/native-smoke.yml
@@ -67,7 +67,13 @@ jobs:
         if: runner.os == 'Linux'
         with:
           wild-version: "0.9.0"
+      - uses: ./.github/actions/setup-rust-sticky-cache
+        if: runner.os == 'Linux'
+        with:
+          key: native-smoke-${{ matrix.target }}
+          cache-key-suffix: ${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('Cargo.lock') }}
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        if: runner.os != 'Linux'
         with:
           shared-key: native-smoke-${{ matrix.target }}
           cache-workspace-crates: "true"
@@ -151,7 +157,13 @@ jobs:
         if: runner.os == 'Linux'
         with:
           wild-version: "0.9.0"
+      - uses: ./.github/actions/setup-rust-sticky-cache
+        if: runner.os == 'Linux'
+        with:
+          key: fresh-install-smoke-${{ matrix.platform.target }}-node-${{ matrix.node-version }}
+          cache-key-suffix: ${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('Cargo.lock') }}
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        if: runner.os != 'Linux'
         with:
           shared-key: fresh-install-smoke-${{ matrix.platform.target }}
           cache-workspace-crates: "true"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,7 +74,15 @@ jobs:
         if: matrix.settings.target == 'aarch64-unknown-linux-gnu'
         run: moon run --target native - -- < tools/moon/scripts/github/install_cross_compile_tools.mbtx
 
-      - name: Cache Rust
+      - name: Mount Rust sticky disks (Linux)
+        if: runner.os == 'Linux'
+        uses: ./.github/actions/setup-rust-sticky-cache
+        with:
+          key: release-cli-${{ matrix.settings.target }}
+          cache-key-suffix: ${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('Cargo.lock') }}
+
+      - name: Cache Rust (non-Linux)
+        if: runner.os != 'Linux'
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: release-cli-${{ matrix.settings.target }}
@@ -133,12 +141,10 @@ jobs:
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
-      - name: Cache Rust
-        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: ./.github/actions/setup-rust-sticky-cache
         with:
-          shared-key: release-tools
-          cache-workspace-crates: "true"
-          save-if: "false"
+          key: release-tools
+          cache-key-suffix: ${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('Cargo.lock') }}
 
       - name: Package VS Code extension
         run: vp run --workspace-root package:vscode-extension
@@ -322,12 +328,10 @@ jobs:
         with:
           targets: wasm32-unknown-unknown
 
-      - name: Cache Rust
-        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: ./.github/actions/setup-rust-sticky-cache
         with:
-          shared-key: release-wasm
-          cache-workspace-crates: "true"
-          save-if: "false"
+          key: release-wasm
+          cache-key-suffix: ${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('Cargo.lock') }}
 
       - name: Cache WASM package build
         id: cache-wasm
@@ -405,7 +409,15 @@ jobs:
         with:
           wild-version: "0.9.0"
 
-      - name: Cache Rust
+      - name: Mount Rust sticky disks (Linux)
+        if: runner.os == 'Linux'
+        uses: ./.github/actions/setup-rust-sticky-cache
+        with:
+          key: release-native-${{ matrix.settings.target }}
+          cache-key-suffix: ${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('Cargo.lock') }}
+
+      - name: Cache Rust (non-Linux)
+        if: runner.os != 'Linux'
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: release-native-${{ matrix.settings.target }}
@@ -1009,12 +1021,10 @@ jobs:
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
-      - name: Cache Rust
-        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: ./.github/actions/setup-rust-sticky-cache
         with:
-          shared-key: release-crates
-          cache-workspace-crates: "true"
-          save-if: "false"
+          key: release-crates
+          cache-key-suffix: ${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('Cargo.lock') }}
 
       - name: Get crates.io token via Trusted Publishing
         id: crates-io-auth

--- a/.github/workflows/tool-benchmark.yml
+++ b/.github/workflows/tool-benchmark.yml
@@ -74,10 +74,10 @@ jobs:
         with:
           wild-version: "0.9.0"
 
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: ./.github/actions/setup-rust-sticky-cache
         with:
-          shared-key: "tool-benchmark"
-          cache-workspace-crates: "true"
+          key: tool-benchmark
+          cache-key-suffix: ${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('Cargo.lock') }}
 
       - uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1
         with:

--- a/tests/tooling/github-workflows.test.ts
+++ b/tests/tooling/github-workflows.test.ts
@@ -85,6 +85,7 @@ test("GitHub workflows opt JavaScript actions into Node 24", () => {
 
 test("GitHub workflows use the current cache action", () => {
   for (const relativePath of [
+    ".github/actions/setup-rust-sticky-cache/action.yml",
     ".github/actions/setup-moonbit/action.yml",
     ".github/workflows/benchmark.yml",
     ".github/workflows/check.yml",
@@ -331,6 +332,54 @@ test("Linux Rust CI installs Wild linker before cargo builds", () => {
       `${workflowName} should install the pinned Wild linker action`,
     );
     assert.match(workflow, /wild-version:\s*"0\.9\.0"/);
+  }
+});
+
+test("Blacksmith Rust CI uses sticky disks for Cargo and target caches", () => {
+  const action = readRepoFile(".github", "actions", "setup-rust-sticky-cache", "action.yml");
+
+  assert.match(action, /uses:\s*useblacksmith\/stickydisk@[0-9a-f]{40}\s*# v1/);
+  assert.match(action, /path:\s*~\/\.cargo\/registry/);
+  assert.match(action, /path:\s*~\/\.cargo\/git/);
+  assert.match(action, /path:\s*\$\{\{\s*inputs\.target-path\s*\}\}/);
+  assert.match(action, /secondary-target-path/);
+
+  for (const workflowName of [
+    "check.yml",
+    "deploy-docs.yml",
+    "e2e.yml",
+    "fuzz.yml",
+    "tool-benchmark.yml",
+  ]) {
+    const workflow = readRepoFile(".github", "workflows", workflowName);
+    assert.match(
+      workflow,
+      /uses:\s*\.\/\.github\/actions\/setup-rust-sticky-cache/,
+      `${workflowName} should mount Blacksmith sticky disks for Rust work`,
+    );
+    assert.doesNotMatch(
+      workflow,
+      /Swatinem\/rust-cache/,
+      `${workflowName} should avoid network Rust cache on Linux-only Blacksmith jobs`,
+    );
+  }
+
+  const benchmarkWorkflow = readRepoFile(".github", "workflows", "benchmark.yml");
+  assert.match(benchmarkWorkflow, /uses:\s*\.\/head\/\.github\/actions\/setup-rust-sticky-cache/);
+  assert.match(benchmarkWorkflow, /target-path:\s*head\/target/);
+  assert.match(benchmarkWorkflow, /secondary-target-path:\s*base\/target/);
+  assert.doesNotMatch(benchmarkWorkflow, /Swatinem\/rust-cache/);
+
+  for (const workflowName of ["native-smoke.yml", "release.yml"]) {
+    const workflow = readRepoFile(".github", "workflows", workflowName);
+    assert.match(
+      workflow,
+      /(?:if:\s*runner\.os == 'Linux'[\s\S]{0,240}setup-rust-sticky-cache|setup-rust-sticky-cache[\s\S]{0,240}if:\s*runner\.os == 'Linux')/,
+    );
+    assert.match(
+      workflow,
+      /(?:if:\s*runner\.os != 'Linux'[\s\S]{0,240}Swatinem\/rust-cache|Swatinem\/rust-cache[\s\S]{0,240}if:\s*runner\.os != 'Linux')/,
+    );
   }
 });
 
@@ -953,7 +1002,7 @@ test("check workflow runs JS package unit tests and production dependency audit"
   const auditJob = workflowJobBody(workflow, "security-audit");
 
   assert.match(jsPackageJob, /vp run --workspace-root test:js/);
-  assert.match(jsPackageJob, /shared-key:\s*"native"/);
+  assert.match(jsPackageJob, /key:\s*test-js-packages/);
   assert.match(auditJob, /vp exec pnpm audit --prod --audit-level moderate/);
   assert.match(auditJob, /tool:\s*cargo-audit/);
   assert.match(auditJob, /cargo audit --deny warnings/);


### PR DESCRIPTION
## Summary
- Add a local Rust sticky-cache action that mounts Cargo registry, Cargo git, and Rust target directories on Blacksmith.
- Replace Linux Blacksmith Rust cache usage in CI, benchmarks, docs, e2e, fuzz, native smoke, and release jobs with sticky disks.
- Keep the existing Rust cache only for non-Linux release/native-smoke matrix legs.

## Validation
- `node --test tests/tooling/github-workflows.test.ts`
- `vp check --fix .github/actions/setup-rust-sticky-cache/action.yml .github/workflows/benchmark.yml .github/workflows/check.yml .github/workflows/deploy-docs.yml .github/workflows/e2e.yml .github/workflows/fuzz.yml .github/workflows/native-smoke.yml .github/workflows/release.yml .github/workflows/tool-benchmark.yml tests/tooling/github-workflows.test.ts`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1378"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783703131&installation_id=136613492&pr_number=1378&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1378&signature=7b9c9223484340fa4ea175f5f50862b9421241756c28571b1d4b5f21b1480d70"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->