### PR TITLE
fix: preserve Vapor mixed text children

### DIFF
--- a/crates/vize_atelier_sfc/src/compile/snapshots/vize_atelier_sfc__compile__tests__script_setup_sfc_vapor_output_mode.snap
+++ b/crates/vize_atelier_sfc/src/compile/snapshots/vize_atelier_sfc__compile__tests__script_setup_sfc_vapor_output_mode.snap
@@ -5,7 +5,7 @@ expression: result.code.as_str()
 import { defineVaporComponent as _defineVaporComponent, getCurrentInstance as _getCurrentInstance, proxyRefs as _proxyRefs } from 'vue'
 import { txt as _txt, toDisplayString as _toDisplayString, setText as _setText, renderEffect as _renderEffect, template as _template } from 'vue';
 
-const t0 = _template("<div> </div>", true)
+const t0 = _template("<div>   </div>", true)
 
 function render(_ctx, $props, $emit, $attrs, $slots) {
   const n0 = t0()

--- a/crates/vize_atelier_sfc/src/script/define_props_destructure/collector.rs
+++ b/crates/vize_atelier_sfc/src/script/define_props_destructure/collector.rs
@@ -414,17 +414,39 @@ pub(crate) fn collect_from_expression<'a>(
             collect_from_expression(&bin.left, source, local_to_key, local_bindings, rewrites);
             collect_from_expression(&bin.right, source, local_to_key, local_bindings, rewrites);
         }
-        _ if expr.is_member_expression() => {
-            // Handle MemberExpression via helper method
-            if let Some(member) = expr.as_member_expression() {
-                collect_from_expression(
-                    member.object(),
-                    source,
-                    local_to_key,
-                    local_bindings,
-                    rewrites,
-                );
-            }
+        Expression::ComputedMemberExpression(member) => {
+            collect_from_expression(
+                &member.object,
+                source,
+                local_to_key,
+                local_bindings,
+                rewrites,
+            );
+            collect_from_expression(
+                &member.expression,
+                source,
+                local_to_key,
+                local_bindings,
+                rewrites,
+            );
+        }
+        Expression::StaticMemberExpression(member) => {
+            collect_from_expression(
+                &member.object,
+                source,
+                local_to_key,
+                local_bindings,
+                rewrites,
+            );
+        }
+        Expression::PrivateFieldExpression(member) => {
+            collect_from_expression(
+                &member.object,
+                source,
+                local_to_key,
+                local_bindings,
+                rewrites,
+            );
         }
         Expression::ObjectExpression(obj) => {
             for prop in obj.properties.iter() {

--- a/crates/vize_atelier_sfc/src/script/define_props_destructure/tests.rs
+++ b/crates/vize_atelier_sfc/src/script/define_props_destructure/tests.rs
@@ -244,6 +244,18 @@ mod tests {
     }
 
     #[test]
+    fn test_transform_computed_member_key() {
+        let bindings = make_bindings(&["row"]);
+
+        let source = "const phaseLabel = computed(() => DAY_PHASE_LABELS[row.phaseSnapshot.phase])";
+        let result = transform_destructured_props(source, &bindings);
+        assert_eq!(
+            result,
+            "const phaseLabel = computed(() => DAY_PHASE_LABELS[__props.row.phaseSnapshot.phase])"
+        );
+    }
+
+    #[test]
     fn test_transform_call_argument() {
         let bindings = make_bindings(&["count"]);
 

--- a/crates/vize_atelier_vapor/src/snapshots/vize_atelier_vapor__tests__compile_mixed_text_static_and_if_children_preserves_template_shape.snap
+++ b/crates/vize_atelier_vapor/src/snapshots/vize_atelier_vapor__tests__compile_mixed_text_static_and_if_children_preserves_template_shape.snap
@@ -1,0 +1,21 @@
+---
+source: crates/vize_atelier_vapor/src/tests.rs
+expression: code.as_str()
+---
+import { txt as _txt, toDisplayString as _toDisplayString, setText as _setText, setClass as _setClass, setInsertionState as _setInsertionState, renderEffect as _renderEffect, createIf as _createIf, template as _template } from 'vue';
+const t0 = _template("<em class=\"weekend-label\">Weekend</em>", true)
+const t1 = _template("<span>  <em class=\"day-offset\">same day</em></span>", true)
+export function render(_ctx) {
+const n3 = t1()
+const x3 = _txt(n3)
+_setInsertionState(n3, null, true)
+const n0 = _createIf(() => (_ctx.isWeekend), () => {
+const n2 = t0()
+return n2
+})
+_renderEffect(() => {
+_setClass(n3, ["date-line", { weekend: _ctx.isWeekend }])
+_setText(x3, _toDisplayString(_ctx.dateLabel) + " ")
+})
+return n3
+}

--- a/crates/vize_atelier_vapor/src/tests.rs
+++ b/crates/vize_atelier_vapor/src/tests.rs
@@ -351,6 +351,31 @@ fn test_compile_control_flow_uses_parent_specific_insertion_state() {
 }
 
 #[test]
+fn test_compile_mixed_text_static_and_if_children_preserves_template_shape() {
+    let allocator = Bump::new();
+    let result = compile_vapor(
+        &allocator,
+        r#"
+        <span class="date-line" :class="{ weekend: isWeekend }">
+          {{ dateLabel }}
+          <em class="day-offset">same day</em>
+          <em v-if="isWeekend" class="weekend-label">Weekend</em>
+        </span>
+        "#,
+        Default::default(),
+    );
+
+    assert!(
+        result.error_messages.is_empty(),
+        "Expected no errors: {:?}",
+        result.error_messages
+    );
+
+    let code = normalize_code(&result.code);
+    insta::assert_snapshot!(code.as_str());
+}
+
+#[test]
 fn test_compile_nested_control_flow_avoids_unused_root_insertion_state() {
     let allocator = Bump::new();
     let result = compile_vapor(

--- a/crates/vize_atelier_vapor/src/transform/element/deferred.rs
+++ b/crates/vize_atelier_vapor/src/transform/element/deferred.rs
@@ -399,28 +399,37 @@ fn count_rendered_child_nodes(
     end: usize,
 ) -> usize {
     let mut count = 0usize;
+    let mut in_text_run = false;
     for child in &children[start..=end] {
-        count += count_rendered_nodes_for_child(child);
+        count += count_rendered_nodes_for_child(child, &mut in_text_run);
     }
     count
 }
 
-fn count_rendered_nodes_for_child(child: &TemplateChildNode<'_>) -> usize {
+fn count_rendered_nodes_for_child(child: &TemplateChildNode<'_>, in_text_run: &mut bool) -> usize {
     match child {
         TemplateChildNode::Element(child_el) => {
             if child_el.tag_type == ElementType::Template {
                 child_el
                     .children
                     .iter()
-                    .map(count_rendered_nodes_for_child)
+                    .map(|child| count_rendered_nodes_for_child(child, in_text_run))
                     .sum()
             } else if is_template_backed_element(child_el) {
+                *in_text_run = false;
                 1
             } else {
                 0
             }
         }
-        TemplateChildNode::Text(_) | TemplateChildNode::Interpolation(_) => 1,
+        TemplateChildNode::Text(_) | TemplateChildNode::Interpolation(_) => {
+            if *in_text_run {
+                0
+            } else {
+                *in_text_run = true;
+                1
+            }
+        }
         _ => 0,
     }
 }

--- a/crates/vize_atelier_vapor/src/transform/element/template.rs
+++ b/crates/vize_atelier_vapor/src/transform/element/template.rs
@@ -46,31 +46,22 @@ pub(crate) fn generate_element_template(el: &ElementNode<'_>) -> String {
     } else {
         template.push('>');
 
-        // Check if there are any interpolations - if so, use a space placeholder
-        let has_interpolation = el
-            .children
-            .iter()
-            .any(|c| matches!(c, TemplateChildNode::Interpolation(_)));
-
-        if has_interpolation {
-            // Use single space as placeholder for interpolation text content
-            template.push(' ');
-        } else {
-            // Recursively add static children (text and static elements)
-            for child in el.children.iter() {
-                match child {
-                    TemplateChildNode::Text(text) => {
-                        template.push_str(&escape_html_text(&text.content));
-                    }
-                    TemplateChildNode::Element(child_el) => {
-                        if is_template_backed_element(child_el) {
-                            template.push_str(&generate_element_template(child_el));
-                        }
-                    }
-                    _ => {
-                        // Other dynamic content is handled elsewhere
+        // Recursively add template-backed children. Interpolations contribute a
+        // text placeholder while control-flow nodes are inserted at runtime.
+        for child in el.children.iter() {
+            match child {
+                TemplateChildNode::Text(text) => {
+                    template.push_str(&escape_html_text(&text.content));
+                }
+                TemplateChildNode::Interpolation(_) => {
+                    template.push(' ');
+                }
+                TemplateChildNode::Element(child_el) => {
+                    if is_template_backed_element(child_el) {
+                        template.push_str(&generate_element_template(child_el));
                     }
                 }
+                _ => {}
             }
         }
 

--- a/tests/expected/vapor/element.snap
+++ b/tests/expected/vapor/element.snap
@@ -197,7 +197,7 @@ options: vapor
 <div>Hello {{ name }}!</div>
 --- OUTPUT ---
 import { txt as _txt, toDisplayString as _toDisplayString, setText as _setText, renderEffect as _renderEffect, template as _template } from 'vue';
-const t0 = _template("<div> </div>", true)
+const t0 = _template("<div>Hello !</div>", true)
 
 export function render(_ctx) {
   const n0 = t0()

--- a/tests/expected/vapor/v-for.snap
+++ b/tests/expected/vapor/v-for.snap
@@ -43,7 +43,7 @@ options: vapor
 <div v-for="(item, index) in items" :key="index">{{ index }}: {{ item }}</div>
 --- OUTPUT ---
 import { txt as _txt, toDisplayString as _toDisplayString, setText as _setText, renderEffect as _renderEffect, createFor as _createFor, template as _template } from 'vue';
-const t0 = _template("<div> </div>")
+const t0 = _template("<div> : </div>")
 
 export function render(_ctx) {
   const n0 = _createFor(() => (_ctx.items), (_for_item0, _for_key0) => {
@@ -62,7 +62,7 @@ options: vapor
 <div v-for="(value, key) in obj" :key="key">{{ key }}: {{ value }}</div>
 --- OUTPUT ---
 import { txt as _txt, toDisplayString as _toDisplayString, setText as _setText, renderEffect as _renderEffect, createFor as _createFor, template as _template } from 'vue';
-const t0 = _template("<div> </div>")
+const t0 = _template("<div> : </div>")
 
 export function render(_ctx) {
   const n0 = _createFor(() => (_ctx.obj), (_for_item0, _for_key0) => {
@@ -81,7 +81,7 @@ options: vapor
 <div v-for="(value, key, idx) in obj" :key="idx">{{ key }}: {{ value }}: {{ idx }}</div>
 --- OUTPUT ---
 import { txt as _txt, toDisplayString as _toDisplayString, setText as _setText, renderEffect as _renderEffect, createFor as _createFor, template as _template } from 'vue';
-const t0 = _template("<div> </div>")
+const t0 = _template("<div> : : </div>")
 
 export function render(_ctx) {
   const n0 = _createFor(() => (_ctx.obj), (_for_item0, _for_key0, _for_index0) => {


### PR DESCRIPTION
## Summary

- Preserve static template-backed children when a Vapor element also contains interpolations.
- Count contiguous text/interpolation children as one rendered text node for Vapor child offsets.
- Rewrite destructured `defineProps` reads inside computed member keys such as `LABELS[row.foo]`.

Fixes #1377.

## Verification

- `cargo test -p vize_atelier_vapor`
- `cargo test -p vize_atelier_sfc`
- `cargo test -p vize_test_runner vapor_ -- --ignored`
- `cargo fmt --all -- --check`
- CLI Vapor build of the reported SFC pattern with `--template-syntax strict`
