### PR TITLE
perf(canon): parallelize virtual project file materialization

### DIFF
--- a/crates/vize_canon/src/batch/virtual_project/materialize.rs
+++ b/crates/vize_canon/src/batch/virtual_project/materialize.rs
@@ -4,6 +4,7 @@
 
 use std::path::{Path, PathBuf};
 
+use rayon::prelude::*;
 use vize_carton::{FxHashSet, String as CompactString, profile};
 
 use crate::batch::error::CorsaResult;
@@ -48,31 +49,47 @@ impl VirtualProject {
         profile!(
             "canon.project.write_files",
             (|| -> CorsaResult<()> {
+                // Directory creation stays sequential and de-duplicated; the file
+                // writes themselves fan out across rayon workers because each
+                // write is an independent syscall-bound operation and large
+                // projects pay hundreds of milliseconds when they run serially.
                 let mut created_dirs: FxHashSet<&Path> = FxHashSet::default();
-                let mut write_calls = 0u64;
-                let mut written_bytes = 0u64;
                 for file in self.virtual_files.values() {
                     if let Some(parent) = file.virtual_path.parent()
                         && created_dirs.insert(parent)
                     {
                         ensure_dir(parent)?;
                     }
-                    write_file_untracked(&file.virtual_path, file.content.as_bytes())?;
-                    write_calls += 1;
-                    written_bytes += file.content.len() as u64;
                 }
-                for (virtual_path, original_path) in &self.passthrough_files {
+                for virtual_path in self.passthrough_files.keys() {
                     if let Some(parent) = virtual_path.parent()
                         && created_dirs.insert(parent)
                     {
                         ensure_dir(parent)?;
                     }
-                    let content = std::fs::read(original_path)?;
-                    write_file_untracked(virtual_path, &content)?;
-                    write_calls += 1;
-                    written_bytes += content.len() as u64;
                 }
-                record_write_batch(write_calls, written_bytes);
+
+                let virtual_written = self
+                    .virtual_files
+                    .par_iter()
+                    .map(|(_, file)| -> CorsaResult<u64> {
+                        write_file_untracked(&file.virtual_path, file.content.as_bytes())?;
+                        Ok(file.content.len() as u64)
+                    })
+                    .try_reduce(|| 0u64, |acc, bytes| Ok(acc + bytes))?;
+                let passthrough_written = self
+                    .passthrough_files
+                    .par_iter()
+                    .map(|(virtual_path, original_path)| -> CorsaResult<u64> {
+                        let content = std::fs::read(original_path)?;
+                        write_file_untracked(virtual_path, &content)?;
+                        Ok(content.len() as u64)
+                    })
+                    .try_reduce(|| 0u64, |acc, bytes| Ok(acc + bytes))?;
+                record_write_batch(
+                    (self.virtual_files.len() + self.passthrough_files.len()) as u64,
+                    virtual_written + passthrough_written,
+                );
                 Ok(())
             })()
         )?;


### PR DESCRIPTION
## Summary

`vize check`'s batch type checker wrote every materialized virtual file and passthrough module serially. On the 300-SFC generated bench corpus that costs ~70ms of check wall time, and ~300ms on misskey-sized projects — pure syscall-bound work sitting between virtual-TS generation and the Corsa run.

Directory creation stays sequential and de-duplicated per parent; the independent file writes fan out across rayon workers (the same pool that already parallelizes SFC parse / virtual-TS generation in `register_paths`).

## Measurements (local, M-series 12-core)

| | before | after |
|---|---|---|
| `canon.project.write_files` (300 SFCs) | ~70ms | ~10ms |
| misskey frontend (583 SFCs) | ~295ms | ~40ms |

Part of a series with #1382 raising the `vue-tsc` → `vize check` speedup on the generated corpus (6–7x → ~10x locally; Blacksmith CI numbers on the PR bench).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1381"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783709331&installation_id=136613492&pr_number=1381&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1381&signature=418050e1067881204b9b970b10a09c37e58ede92277e7c8e3087f63f53924b21"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->