### PR TITLE
fix(canon): keep vize check on the fast corsa CLI path

### DIFF
--- a/crates/vize/src/commands/check/runner/diagnostics.rs
+++ b/crates/vize/src/commands/check/runner/diagnostics.rs
@@ -20,14 +20,30 @@ pub(super) fn emit_json_output(json_output: JsonOutput) {
 /// Whether a registered file's diagnostics should be reported. For an explicit
 /// subset (`reported` is `Some`), only the requested files are reported; ambient
 /// and transitively-registered files exist only to resolve cross-file types.
+/// Project-level diagnostics (anchored to a tsconfig or the project root, not
+/// a source file) describe the whole check and are always reported.
 pub(super) fn is_reported(reported: &Option<FxHashSet<PathBuf>>, path: &Path) -> bool {
     match reported {
         None => true,
         Some(set) => {
+            if !is_source_path(path) {
+                return true;
+            }
             let canonical = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
             set.contains(&canonical)
         }
     }
+}
+
+fn is_source_path(path: &Path) -> bool {
+    path.extension()
+        .and_then(|extension| extension.to_str())
+        .is_some_and(|extension| {
+            matches!(
+                extension,
+                "vue" | "ts" | "tsx" | "mts" | "cts" | "js" | "jsx"
+            )
+        })
 }
 
 pub(super) fn is_suppressed_false_positive(diagnostic: &vize_canon::BatchDiagnostic) -> bool {

--- a/crates/vize/src/commands/check/runner/mod.rs
+++ b/crates/vize/src/commands/check/runner/mod.rs
@@ -134,7 +134,8 @@ pub(crate) fn run_direct(args: &CheckArgs) {
             .runtime_path()
             .map(|candidate| resolve_from_config_dir(config_dir, candidate))
     });
-    if let Err(error) = validate_corsa_server_count(args.servers.or(config.type_checker.servers)) {
+    let corsa_servers = args.servers.or(config.type_checker.servers);
+    if let Err(error) = validate_corsa_server_count(corsa_servers) {
         eprintln!("\x1b[31mError:\x1b[0m {}", error);
         std::process::exit(2);
     }
@@ -276,6 +277,7 @@ pub(crate) fn run_direct(args: &CheckArgs) {
             std::process::exit(1);
         }
     };
+    checker.set_server_count(corsa_servers);
     if options_api {
         checker.enable_options_api();
     }

--- a/crates/vize/src/commands/check/runner/mod.rs
+++ b/crates/vize/src/commands/check/runner/mod.rs
@@ -513,7 +513,28 @@ pub(crate) fn run_direct(args: &CheckArgs) {
             })
             .collect();
         files_json.sort_by(|left, right| left.file.cmp(&right.file));
+        // `fileCount` counts checked source files; project-level diagnostic
+        // groups (anchored to a tsconfig) are appended to `files` afterwards
+        // so every counted error appears in the output, but they are not
+        // checked files themselves.
         let reported_file_count = files_json.len();
+
+        let virtual_keys: FxHashSet<String> = virtual_files
+            .iter()
+            .map(|file| String::from(file.original_path.to_string_lossy()))
+            .collect();
+        let mut project_level: Vec<JsonFileResult> = diagnostics
+            .iter()
+            .filter(|(key, file_diagnostics)| {
+                !file_diagnostics.is_empty() && !virtual_keys.contains(key.as_str())
+            })
+            .map(|(key, file_diagnostics)| JsonFileResult {
+                file: display_path(&cwd, Path::new(key)).into(),
+                virtual_ts: "".into(),
+                diagnostics: file_diagnostics.clone(),
+            })
+            .collect();
+        files_json.append(&mut project_level);
 
         let declarations = emitted_declarations.as_ref().map(|(_, result)| {
             result
@@ -538,8 +559,10 @@ pub(crate) fn run_direct(args: &CheckArgs) {
     }
 
     if !args.quiet {
+        let mut printed_keys: FxHashSet<String> = FxHashSet::default();
         for file in checker.virtual_files() {
             let key = file.original_path.to_string_lossy();
+            printed_keys.insert(String::from(key.as_ref()));
             let Some(file_diagnostics) = diagnostics.get(key.as_ref()) else {
                 continue;
             };
@@ -547,6 +570,23 @@ pub(crate) fn run_direct(args: &CheckArgs) {
                 continue;
             }
 
+            println!("\n\x1b[4m{}\x1b[0m", key);
+            for diagnostic in file_diagnostics {
+                let color = if diagnostic.starts_with("error") {
+                    "\x1b[31m"
+                } else {
+                    "\x1b[33m"
+                };
+                println!("  {}{}\x1b[0m", color, diagnostic);
+            }
+        }
+
+        // Project-level diagnostics (anchored to a tsconfig, not a checked
+        // source file) — print after the per-file groups.
+        for (key, file_diagnostics) in &diagnostics {
+            if file_diagnostics.is_empty() || printed_keys.contains(key.as_str()) {
+                continue;
+            }
             println!("\n\x1b[4m{}\x1b[0m", key);
             for diagnostic in file_diagnostics {
                 let color = if diagnostic.starts_with("error") {

--- a/crates/vize/src/commands/check/runner/resolve.rs
+++ b/crates/vize/src/commands/check/runner/resolve.rs
@@ -179,6 +179,11 @@ pub(super) fn resolve_from_config_dir(config_dir: &Path, candidate: &str) -> Pat
     config_dir.join(path)
 }
 
+/// Largest accepted `typeChecker.servers` value. Each server is a Corsa CLI
+/// process with its own program; beyond this the duplicated parse/bind work
+/// outweighs any remaining parallelism.
+const MAX_CORSA_SERVERS: usize = 32;
+
 pub(super) fn validate_corsa_server_count(servers: Option<usize>) -> Result<(), String> {
     let Some(servers) = servers else {
         return Ok(());
@@ -186,9 +191,9 @@ pub(super) fn validate_corsa_server_count(servers: Option<usize>) -> Result<(), 
     if servers == 0 {
         return Err("typeChecker.servers must be at least 1.".into());
     }
-    if servers > 1 {
+    if servers > MAX_CORSA_SERVERS {
         return Err(format!(
-            "typeChecker.servers={servers} is not supported by the direct Corsa project-session runner yet; use 1 or omit the option."
+            "typeChecker.servers={servers} exceeds the supported maximum of {MAX_CORSA_SERVERS}."
         )
         .into());
     }

--- a/crates/vize/src/commands/check/runner/tests.rs
+++ b/crates/vize/src/commands/check/runner/tests.rs
@@ -334,9 +334,11 @@ fn writes_nuxt_fallback_tsconfig_without_overwriting_existing_paths() {
 }
 
 #[test]
-fn validates_unsupported_corsa_server_counts() {
+fn validates_corsa_server_counts() {
     assert!(validate_corsa_server_count(None).is_ok());
     assert!(validate_corsa_server_count(Some(1)).is_ok());
+    assert!(validate_corsa_server_count(Some(2)).is_ok());
+    assert!(validate_corsa_server_count(Some(32)).is_ok());
     assert!(validate_corsa_server_count(Some(0)).is_err());
-    assert!(validate_corsa_server_count(Some(2)).is_err());
+    assert!(validate_corsa_server_count(Some(33)).is_err());
 }

--- a/crates/vize/tests/check_cli.rs
+++ b/crates/vize/tests/check_cli.rs
@@ -1753,14 +1753,14 @@ const count = 1;
 
     let output = Command::new(env!("CARGO_BIN_EXE_vize"))
         .current_dir(&project_root)
-        .args(["check", "src/App.vue", "--quiet", "--servers", "2"])
+        .args(["check", "src/App.vue", "--quiet", "--servers", "64"])
         .output()
         .unwrap();
 
     let stderr = std::string::String::from_utf8(output.stderr).unwrap();
     assert_eq!(output.status.code(), Some(2));
     assert!(
-        stderr.contains("typeChecker.servers=2 is not supported"),
+        stderr.contains("typeChecker.servers=64 exceeds the supported maximum"),
         "{stderr}"
     );
 

--- a/crates/vize_canon/src/batch/executor.rs
+++ b/crates/vize_canon/src/batch/executor.rs
@@ -24,7 +24,7 @@ use vize_carton::{String, cstr, profile};
 mod cli;
 mod diagnostics;
 
-use cli::check_with_cli;
+use cli::{auto_server_count, check_with_cli, check_with_cli_sharded};
 use diagnostics::map_batch_diagnostics;
 
 /// Batch executor backed by `corsa`'s project-session diagnostics API.
@@ -96,9 +96,35 @@ impl CorsaExecutor {
         &self.corsa_path
     }
 
-    /// Run type checking on the virtual project.
+    /// Run type checking on the virtual project with an auto-tuned number of
+    /// parallel Corsa CLI processes.
     pub fn check(&self, project: &VirtualProject) -> CorsaResult<TypeCheckResult> {
+        self.check_with_servers(project, None)
+    }
+
+    /// Run type checking on the virtual project. `servers` is the number of
+    /// parallel Corsa CLI processes the project is partitioned across
+    /// (`None` auto-tunes from the machine width and project size).
+    pub fn check_with_servers(
+        &self,
+        project: &VirtualProject,
+        servers: Option<usize>,
+    ) -> CorsaResult<TypeCheckResult> {
         profile!("canon.executor.materialize", project.materialize())?;
+
+        let servers = servers.unwrap_or_else(|| auto_server_count(project));
+        if servers > 1 {
+            match profile!(
+                "canon.corsa.cli",
+                check_with_cli_sharded(&self.corsa_path, project, servers)
+            ) {
+                Ok(result) => return Ok(result),
+                Err(_cli_error) => {
+                    // Degrade to a single CLI program before the session API:
+                    // a shard-specific failure must not cost CLI support.
+                }
+            }
+        }
 
         match profile!("canon.corsa.cli", check_with_cli(&self.corsa_path, project)) {
             Ok(result) => return Ok(result),

--- a/crates/vize_canon/src/batch/executor.rs
+++ b/crates/vize_canon/src/batch/executor.rs
@@ -550,7 +550,8 @@ mod tests {
         // A runtime whose project check exits non-zero with only file-less
         // config diagnostics (e.g. TS2688) ran fine; treating that as a CLI
         // failure would fall back to the far slower project-session API
-        // (`--api` here would hang the test forever).
+        // (`--api` here would hang the test forever). The project-level
+        // diagnostic surfaces attributed to the project's tsconfig anchor.
         let tsgo = cache_dir.join("tsgo");
         fs::write(
             &tsgo,
@@ -566,7 +567,10 @@ mod tests {
 
         assert!(!result.success);
         assert_eq!(result.exit_code, 2);
-        assert!(result.diagnostics.is_empty());
+        assert_eq!(result.diagnostics.len(), 1);
+        assert_eq!(result.diagnostics[0].code, Some(2688));
+        assert_eq!(result.diagnostics[0].severity, 1);
+        assert_eq!(result.diagnostics[0].file, case_dir);
 
         let _ = fs::remove_dir_all(&case_dir);
     }

--- a/crates/vize_canon/src/batch/executor.rs
+++ b/crates/vize_canon/src/batch/executor.rs
@@ -535,6 +535,44 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
+    fn cli_global_diagnostics_do_not_trigger_session_fallback() {
+        use crate::batch::VirtualProject;
+        use std::os::unix::fs::PermissionsExt;
+
+        let case_dir = unique_case_dir("global-diagnostics");
+        let _ = fs::remove_dir_all(&case_dir);
+        let cache_dir = case_dir.join(".cache");
+        let source = case_dir.join("src").join("main.ts");
+        fs::create_dir_all(&cache_dir).unwrap();
+        fs::create_dir_all(source.parent().unwrap()).unwrap();
+        fs::write(&source, "const value: number = 1;\n").unwrap();
+
+        // A runtime whose project check exits non-zero with only file-less
+        // config diagnostics (e.g. TS2688) ran fine; treating that as a CLI
+        // failure would fall back to the far slower project-session API
+        // (`--api` here would hang the test forever).
+        let tsgo = cache_dir.join("tsgo");
+        fs::write(
+            &tsgo,
+            "#!/bin/sh\nif [ \"$1\" = \"--api\" ]; then exec sleep 600; fi\necho \"error TS2688: Cannot find type definition file for 'vite/client'.\"\nexit 2\n",
+        )
+        .unwrap();
+        fs::set_permissions(&tsgo, fs::Permissions::from_mode(0o755)).unwrap();
+
+        let mut project = VirtualProject::new(&case_dir).unwrap();
+        project.register_path(&source).unwrap();
+        let executor = CorsaExecutor::new(&case_dir).unwrap();
+        let result = executor.check(&project).unwrap();
+
+        assert!(!result.success);
+        assert_eq!(result.exit_code, 2);
+        assert!(result.diagnostics.is_empty());
+
+        let _ = fs::remove_dir_all(&case_dir);
+    }
+
+    #[cfg(unix)]
+    #[test]
     fn checks_with_cli_when_project_session_api_is_unavailable() {
         use crate::batch::VirtualProject;
         use std::os::unix::fs::PermissionsExt;

--- a/crates/vize_canon/src/batch/executor/cli.rs
+++ b/crates/vize_canon/src/batch/executor/cli.rs
@@ -36,11 +36,27 @@ pub(super) fn check_with_cli(
             .iter()
             .all(|diagnostic| diagnostic.severity != 1);
 
+    // A non-zero exit is a runner failure only when the output carries no
+    // diagnostic-shaped lines at all (bad invocation, crash, missing CLI
+    // support). Recognizable diagnostics whose every entry was suppressed or
+    // failed source mapping still prove the CLI ran the project; falling back
+    // to the per-file project-session API there costs orders of magnitude
+    // more wall time for the same answer.
     if !output.status.success() && diagnostics.is_empty() {
-        return Err(CorsaError::CorsaExecution {
-            exit_code: output.status.code().unwrap_or(-1),
-            message: output_message(&output),
-        });
+        if !output_contains_diagnostic_lines(&output) {
+            return Err(CorsaError::CorsaExecution {
+                exit_code: output.status.code().unwrap_or(-1),
+                message: output_message(&output),
+            });
+        }
+        // Project-level diagnostics (e.g. `error TS2688: Cannot find type
+        // definition file for 'x'.`) abort the runtime's semantic pass, so an
+        // otherwise clean report may be incomplete. Surface them on stderr so
+        // a green run is never silently built on a broken project config.
+        eprintln!(
+            "\x1b[33mwarning:\x1b[0m corsa reported project-level errors; type checking may be incomplete:\n{}",
+            output_message(&output)
+        );
     }
 
     Ok(TypeCheckResult {
@@ -144,6 +160,32 @@ fn parse_cli_diagnostic_line(
     })
 }
 
+fn output_contains_diagnostic_lines(output: &Output) -> bool {
+    [&output.stdout, &output.stderr].into_iter().any(|stream| {
+        #[allow(clippy::disallowed_types)]
+        let text = std::string::String::from_utf8_lossy(stream);
+        text.lines()
+            .any(|line| is_cli_diagnostic_line(line) || is_global_diagnostic_line(line))
+    })
+}
+
+/// Whether `line` is a file-less project-level diagnostic such as
+/// `error TS2688: Cannot find type definition file for 'vite/client'.`
+fn is_global_diagnostic_line(line: &str) -> bool {
+    let Some(rest) = line
+        .strip_prefix("error ")
+        .or_else(|| line.strip_prefix("warning "))
+        .or_else(|| line.strip_prefix("info "))
+    else {
+        return false;
+    };
+    let Some(code) = rest.strip_prefix("TS") else {
+        return false;
+    };
+    let digits = code.bytes().take_while(u8::is_ascii_digit).count();
+    digits > 0 && code[digits..].starts_with(':')
+}
+
 fn is_cli_diagnostic_line(line: &str) -> bool {
     let Some((prefix, suffix)) = line.split_once("): ") else {
         return false;
@@ -192,7 +234,7 @@ fn output_message(output: &Output) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::parse_cli_diagnostics;
+    use super::{is_cli_diagnostic_line, is_global_diagnostic_line, parse_cli_diagnostics};
     use crate::batch::VirtualProject;
     use crate::batch::executor::diagnostics::DiagnosticMapper;
     use std::{
@@ -214,6 +256,26 @@ mod tests {
                 "cli-fallback-{name}-{}-{case_id}",
                 std::process::id()
             ))
+    }
+
+    #[test]
+    fn recognizes_global_and_positioned_diagnostic_lines() {
+        assert!(is_global_diagnostic_line(
+            "error TS2688: Cannot find type definition file for 'vite/client'."
+        ));
+        assert!(is_global_diagnostic_line("warning TS1: w"));
+        assert!(!is_global_diagnostic_line(
+            "  The file is in the program because:"
+        ));
+        assert!(!is_global_diagnostic_line("error: missing argument"));
+        assert!(!is_global_diagnostic_line("error TSX: nope"));
+
+        assert!(is_cli_diagnostic_line(
+            "src/App.vue.ts(3,7): error TS2322: Type 'string' is not assignable to type 'number'."
+        ));
+        assert!(!is_cli_diagnostic_line(
+            "error TS2688: Cannot find type definition file for 'vite/client'."
+        ));
     }
 
     #[test]

--- a/crates/vize_canon/src/batch/executor/cli.rs
+++ b/crates/vize_canon/src/batch/executor/cli.rs
@@ -42,21 +42,14 @@ pub(super) fn check_with_cli(
     // failed source mapping still prove the CLI ran the project; falling back
     // to the per-file project-session API there costs orders of magnitude
     // more wall time for the same answer.
-    if !output.status.success() && diagnostics.is_empty() {
-        if !output_contains_diagnostic_lines(&output) {
-            return Err(CorsaError::CorsaExecution {
-                exit_code: output.status.code().unwrap_or(-1),
-                message: output_message(&output),
-            });
-        }
-        // Project-level diagnostics (e.g. `error TS2688: Cannot find type
-        // definition file for 'x'.`) abort the runtime's semantic pass, so an
-        // otherwise clean report may be incomplete. Surface them on stderr so
-        // a green run is never silently built on a broken project config.
-        eprintln!(
-            "\x1b[33mwarning:\x1b[0m corsa reported project-level errors; type checking may be incomplete:\n{}",
-            output_message(&output)
-        );
+    if !output.status.success()
+        && diagnostics.is_empty()
+        && !output_contains_diagnostic_lines(&output)
+    {
+        return Err(CorsaError::CorsaExecution {
+            exit_code: output.status.code().unwrap_or(-1),
+            message: output_message(&output),
+        });
     }
 
     Ok(TypeCheckResult {
@@ -89,6 +82,15 @@ fn parse_cli_diagnostics(
             diagnostics.push(diagnostic);
             continue;
         }
+        // Project-level diagnostics carry no file position (`error TS2688:
+        // Cannot find type definition file for 'x'.`). They are real,
+        // user-actionable problems — tsc and vue-tsc report them and the
+        // runtime may skip the semantic pass because of them — so they are
+        // attributed to the project's tsconfig instead of being dropped.
+        if let Some(diagnostic) = parse_global_diagnostic_line(line, project) {
+            diagnostics.push(diagnostic);
+            continue;
+        }
         if is_cli_diagnostic_line(line) {
             continue;
         }
@@ -103,6 +105,33 @@ fn parse_cli_diagnostics(
         last.message.push('\n');
         last.message.push_str(line);
     }
+}
+
+/// Parse a file-less project-level diagnostic such as
+/// `error TS2688: Cannot find type definition file for 'vite/client'.`
+fn parse_global_diagnostic_line(line: &str, project: &VirtualProject) -> Option<Diagnostic> {
+    let (severity, rest) = line.split_once(' ')?;
+    let severity = match severity {
+        "error" => 1,
+        "warning" => 2,
+        "info" => 3,
+        _ => return None,
+    };
+    let (code, message) = rest.split_once(": ")?;
+    let code = code.strip_prefix("TS")?.parse::<u32>().ok()?;
+    if should_skip_diagnostic(Some(code), message) {
+        return None;
+    }
+
+    Some(Diagnostic {
+        file: project.project_diagnostics_anchor(),
+        line: 0,
+        column: 0,
+        message: message.into(),
+        code: Some(code),
+        severity,
+        block_type: None,
+    })
 }
 
 fn parse_cli_diagnostic_line(

--- a/crates/vize_canon/src/batch/executor/cli.rs
+++ b/crates/vize_canon/src/batch/executor/cli.rs
@@ -17,7 +17,13 @@ pub(super) fn check_with_cli(
     project: &VirtualProject,
 ) -> CorsaResult<TypeCheckResult> {
     let config_path = project.virtual_root().join("tsconfig.json");
-    run_cli_for_config(corsa_path, project, &config_path)
+    run_cli_for_config(corsa_path, project, &config_path, Some(available_threads()))
+}
+
+fn available_threads() -> usize {
+    std::thread::available_parallelism()
+        .map(std::num::NonZero::get)
+        .unwrap_or(1)
 }
 
 /// Run the project check sharded across `servers` concurrent Corsa CLI
@@ -49,12 +55,16 @@ pub(super) fn check_with_cli_sharded(
     }
 
     let owners = &plan.owners;
+    // Split the machine's checker budget across the concurrent programs.
+    let checkers = (available_threads() / config_paths.len()).max(4);
     let results = profile!("canon.corsa.cli.sharded", {
         std::thread::scope(|scope| {
             let handles: Vec<_> = config_paths
                 .iter()
                 .map(|config_path| {
-                    scope.spawn(move || run_cli_for_config(corsa_path, project, config_path))
+                    scope.spawn(move || {
+                        run_cli_for_config(corsa_path, project, config_path, Some(checkers))
+                    })
                 })
                 .collect();
             handles
@@ -421,21 +431,39 @@ fn run_cli_for_config(
     corsa_path: &Path,
     project: &VirtualProject,
     config_path: &Path,
+    checkers: Option<usize>,
 ) -> CorsaResult<TypeCheckResult> {
-    let output = profile!(
-        "canon.corsa.cli.command",
-        Command::new(corsa_path)
-            .current_dir(project.virtual_root())
+    let output = profile!("canon.corsa.cli.command", {
+        let mut command = Command::new(corsa_path);
+        command.current_dir(project.virtual_root());
+        // Corsa's checker pool defaults to four workers; size it to the share
+        // of the machine this program gets so wide machines are not idle.
+        if let Some(checkers) = checkers {
+            command.arg("--checkers").arg(cstr!("{checkers}").as_str());
+        }
+        command
             .arg("--pretty")
             .arg("false")
             .arg("--project")
             .arg(config_path)
             .output()
-    )?;
+    })?;
     let diagnostics = profile!(
         "canon.corsa.cli.parse",
         parse_output_diagnostics(&output, project)
     );
+
+    // An older runtime without `--checkers` support rejects the whole
+    // invocation with TS5023; retry once without the option.
+    if checkers.is_some()
+        && !output.status.success()
+        && diagnostics.iter().any(|diagnostic| {
+            diagnostic.code == Some(5023) && diagnostic.message.contains("checkers")
+        })
+    {
+        return run_cli_for_config(corsa_path, project, config_path, None);
+    }
+
     let success = output.status.success()
         && diagnostics
             .iter()

--- a/crates/vize_canon/src/batch/executor/cli.rs
+++ b/crates/vize_canon/src/batch/executor/cli.rs
@@ -9,7 +9,7 @@ use crate::batch::executor::diagnostics::{
     DiagnosticMapper, relative_module_resolves_on_disk, should_skip_diagnostic,
     should_skip_original_diagnostic,
 };
-use vize_carton::profile;
+use vize_carton::{FxHashMap, profile};
 use vize_carton::{String, cstr};
 
 pub(super) fn check_with_cli(
@@ -17,6 +17,411 @@ pub(super) fn check_with_cli(
     project: &VirtualProject,
 ) -> CorsaResult<TypeCheckResult> {
     let config_path = project.virtual_root().join("tsconfig.json");
+    run_cli_for_config(corsa_path, project, &config_path)
+}
+
+/// Run the project check sharded across `servers` concurrent Corsa CLI
+/// processes. Corsa's own checker pool saturates around four cores, so on
+/// wider machines a single process leaves most of the CPU idle; partitioning
+/// the project along the connected components of its import graph restores
+/// the parallelism while keeping each shard's program disjoint.
+///
+/// Ambient `.d.ts` files and sources carrying module/global declarations are
+/// included in every shard so augmentations behave exactly as in the single
+/// program. Each diagnostic is reported by the shard that owns its file, so
+/// the merged result matches an unsharded run.
+pub(super) fn check_with_cli_sharded(
+    corsa_path: &Path,
+    project: &VirtualProject,
+    servers: usize,
+) -> CorsaResult<TypeCheckResult> {
+    let plan = partition_virtual_files(project, servers);
+    if plan.shards.len() <= 1 {
+        return check_with_cli(corsa_path, project);
+    }
+
+    let mut config_paths = Vec::with_capacity(plan.shards.len());
+    for (index, shard) in plan.shards.iter().enumerate() {
+        config_paths.push(profile!(
+            "canon.corsa.cli.write_shard_tsconfig",
+            project.write_shard_tsconfig(index, shard)
+        )?);
+    }
+
+    let owners = &plan.owners;
+    let results = profile!("canon.corsa.cli.sharded", {
+        std::thread::scope(|scope| {
+            let handles: Vec<_> = config_paths
+                .iter()
+                .map(|config_path| {
+                    scope.spawn(move || run_cli_for_config(corsa_path, project, config_path))
+                })
+                .collect();
+            handles
+                .into_iter()
+                .map(|handle| {
+                    handle.join().unwrap_or_else(|_| {
+                        Err(CorsaError::CorsaExecution {
+                            exit_code: -1,
+                            message: "sharded corsa CLI worker panicked".into(),
+                        })
+                    })
+                })
+                .collect::<Vec<_>>()
+        })
+    });
+
+    let mut merged = TypeCheckResult {
+        exit_code: 0,
+        success: true,
+        diagnostics: Vec::new(),
+    };
+    for (index, result) in results.into_iter().enumerate() {
+        let result = result?;
+        merged.exit_code = merged.exit_code.max(result.exit_code);
+        merged.success = merged.success && result.success;
+        merged.diagnostics.extend(
+            result
+                .diagnostics
+                .into_iter()
+                .filter(|diagnostic| owners.get(&diagnostic.file).copied().unwrap_or(0) == index),
+        );
+    }
+    Ok(merged)
+}
+
+/// Pick the shard count for a project when the caller did not request one.
+/// Corsa's checker pool uses ~4 cores per process; sharding only pays off
+/// once there are enough Vue files to amortize each extra program's fixed
+/// parse/bind cost.
+pub(super) fn auto_server_count(project: &VirtualProject) -> usize {
+    let vue_files = project
+        .virtual_files_sorted()
+        .iter()
+        .filter(|file| is_vue_original(&file.original_path))
+        .count();
+    let threads = std::thread::available_parallelism()
+        .map(std::num::NonZero::get)
+        .unwrap_or(1);
+    (threads / 4).min(vue_files / 64).clamp(1, 8)
+}
+
+struct ShardPlan<'a> {
+    /// Virtual paths to include per shard (owned Vue files plus every shared
+    /// file).
+    shards: Vec<Vec<&'a Path>>,
+    /// Original path -> owning shard for partitioned Vue files; files absent
+    /// from the map (shared sources, project-level anchors) belong to shard 0.
+    owners: FxHashMap<PathBuf, usize>,
+}
+
+/// Partition the project's source files into shard programs along the
+/// connected components of their import graph. Files in different components
+/// never load each other, so component-aligned shards check disjoint code and
+/// duplicate no work; interconnected projects collapse into one big component
+/// and degrade to a single, unsharded run instead of paying N near-full
+/// programs. Only ambient `.d.ts` files and sources carrying module/global
+/// declarations stay visible to every shard, since they affect the whole
+/// program without being imported.
+fn partition_virtual_files(project: &VirtualProject, servers: usize) -> ShardPlan<'_> {
+    let files = project.virtual_files_sorted();
+    let mut partitioned: Vec<&super::super::VirtualFile> = Vec::new();
+    let mut shared: Vec<&Path> = Vec::new();
+    for file in files {
+        // The program-wide check reads the original source: the generated Vue
+        // wrapper always contains an identical `declare global` ImportMeta
+        // block of its own.
+        let program_wide = project
+            .original_content_for_virtual(&file.virtual_path)
+            .is_some_and(declares_program_wide_types);
+        if program_wide || is_ambient_declaration(&file.original_path) {
+            shared.push(file.virtual_path.as_path());
+        } else {
+            partitioned.push(file);
+        }
+    }
+
+    let servers = servers.clamp(1, partitioned.len().max(1));
+    let no_sharding = ShardPlan {
+        shards: Vec::new(),
+        owners: FxHashMap::default(),
+    };
+    if servers <= 1 {
+        return no_sharding;
+    }
+
+    // Union files that load each other or the same unresolved modules. The
+    // graph is a cost model, not a correctness requirement — ownership
+    // filtering already deduplicates diagnostics — but files coupled through
+    // shared sources would otherwise be re-checked by every shard whose
+    // program loads them. Relative imports resolve exactly; project path
+    // aliases (`@/…`) and workspace packages symlinked into `node_modules`
+    // couple their importers, while bare npm specifiers are dependency cost
+    // every program pays anyway.
+    let index_by_virtual: FxHashMap<&Path, usize> = partitioned
+        .iter()
+        .enumerate()
+        .map(|(index, file)| (file.virtual_path.as_path(), index))
+        .collect();
+    let alias_prefixes = project.path_alias_prefixes();
+    let mut components = UnionFind::new(partitioned.len());
+    let mut coupling_keys: FxHashMap<String, usize> = FxHashMap::default();
+    let mut workspace_packages: FxHashMap<String, bool> = FxHashMap::default();
+    for (index, file) in partitioned.iter().enumerate() {
+        for specifier in import_specifiers(&file.content) {
+            if specifier.starts_with("./") || specifier.starts_with("../") {
+                let Some(base) = file.virtual_path.parent() else {
+                    continue;
+                };
+                let target = normalize_join(base, specifier);
+                if let Some(target_index) = resolve_virtual_import(&target, &index_by_virtual) {
+                    components.union(index, target_index);
+                } else {
+                    // An unresolved local module: couple its importers.
+                    let key = String::from(target.to_string_lossy());
+                    match coupling_keys.get(key.as_str()) {
+                        Some(&first) => components.union(index, first),
+                        None => {
+                            coupling_keys.insert(key, index);
+                        }
+                    }
+                }
+            } else if let Some(alias) = alias_prefixes
+                .iter()
+                .find(|alias| specifier.starts_with(alias.as_str()))
+            {
+                let key = cstr!("alias:{alias}");
+                match coupling_keys.get(key.as_str()) {
+                    Some(&first) => components.union(index, first),
+                    None => {
+                        coupling_keys.insert(key, index);
+                    }
+                }
+            } else if let Some(package) =
+                workspace_source_package(project.project_root(), specifier, &mut workspace_packages)
+            {
+                let key = cstr!("workspace:{package}");
+                match coupling_keys.get(key.as_str()) {
+                    Some(&first) => components.union(index, first),
+                    None => {
+                        coupling_keys.insert(key, index);
+                    }
+                }
+            }
+        }
+    }
+
+    // Bin-pack components (heaviest first) into the requested shard count and
+    // only keep the plan when it buys real parallelism: a dominant component
+    // means each extra program would mostly re-check the same files. Weights
+    // are generated-content bytes, a usable proxy for parse+check cost.
+    let mut component_files: FxHashMap<usize, Vec<usize>> = FxHashMap::default();
+    for index in 0..partitioned.len() {
+        component_files
+            .entry(components.find(index))
+            .or_default()
+            .push(index);
+    }
+    let weight = |file_indices: &[usize]| -> usize {
+        file_indices
+            .iter()
+            .map(|&index| partitioned[index].content.len())
+            .sum()
+    };
+    let mut component_groups: Vec<Vec<usize>> = component_files.into_values().collect();
+    if component_groups.len() < 2 {
+        return no_sharding;
+    }
+    let total_weight: usize = component_groups.iter().map(|group| weight(group)).sum();
+    component_groups.sort_by(|left, right| {
+        weight(right)
+            .cmp(&weight(left))
+            .then_with(|| left.first().cmp(&right.first()))
+    });
+
+    let servers = servers.min(component_groups.len());
+    let mut bins: Vec<(usize, Vec<usize>)> = vec![(0, Vec::new()); servers];
+    for group in component_groups {
+        let bin = bins
+            .iter_mut()
+            .min_by_key(|(bin_weight, _)| *bin_weight)
+            .expect("at least one shard bin");
+        bin.0 += weight(&group);
+        bin.1.extend(group);
+    }
+    let largest = bins.iter().map(|(bin_weight, _)| *bin_weight).max();
+    // Wall time tracks the heaviest shard; below ~25% savings the duplicated
+    // per-program work on shared and ambient sources outweighs the win.
+    if largest.unwrap_or(0) * 4 >= total_weight * 3 {
+        return no_sharding;
+    }
+
+    let mut shards: Vec<Vec<&Path>> = Vec::with_capacity(bins.len());
+    let mut owners = FxHashMap::default();
+    for (shard_index, (_, file_indices)) in bins.into_iter().enumerate() {
+        let mut include = shared.clone();
+        for file_index in file_indices {
+            let file = partitioned[file_index];
+            include.push(file.virtual_path.as_path());
+            owners.insert(file.original_path.clone(), shard_index);
+        }
+        shards.push(include);
+    }
+
+    ShardPlan { shards, owners }
+}
+
+/// Quoted module specifiers in generated virtual TS: `from '<spec>'`,
+/// `import('<spec>')`, `import '<spec>'`, `require('<spec>')`. A lexical scan
+/// is enough here — the result only feeds the shard cost model.
+fn import_specifiers(content: &str) -> Vec<&str> {
+    let mut specifiers = Vec::new();
+    for token in ["from ", "import(", "import ", "require("] {
+        for (at, _) in content.match_indices(token) {
+            let rest = content[at + token.len()..].trim_start();
+            let Some(quote) = rest.chars().next().filter(|ch| matches!(ch, '\'' | '"')) else {
+                continue;
+            };
+            let rest = &rest[1..];
+            let Some(end) = rest.find(quote) else {
+                continue;
+            };
+            specifiers.push(&rest[..end]);
+        }
+    }
+    specifiers
+}
+
+/// Whether a bare specifier resolves to a workspace package whose source is
+/// symlinked into `node_modules` (pnpm/yarn workspaces): importing it drags
+/// real project source into the program, so its importers are cost-coupled.
+/// Regular npm packages resolve inside `node_modules` and are ambient cost
+/// every program pays anyway. Results are cached per package root.
+fn workspace_source_package<'spec>(
+    project_root: &Path,
+    specifier: &'spec str,
+    cache: &mut FxHashMap<String, bool>,
+) -> Option<&'spec str> {
+    let mut segments = specifier.splitn(3, '/');
+    let first = segments.next()?;
+    let package_end = if first.starts_with('@') {
+        first.len() + 1 + segments.next()?.len()
+    } else {
+        first.len()
+    };
+    let package = &specifier[..package_end];
+
+    if let Some(&is_workspace) = cache.get(package) {
+        return is_workspace.then_some(package);
+    }
+
+    let mut is_workspace = false;
+    let mut dir = Some(project_root);
+    while let Some(current) = dir {
+        let candidate = current.join("node_modules").join(package);
+        if let Ok(metadata) = std::fs::symlink_metadata(&candidate) {
+            if metadata.file_type().is_symlink()
+                && let Ok(target) = std::fs::canonicalize(&candidate)
+            {
+                is_workspace = !target
+                    .components()
+                    .any(|component| component.as_os_str() == "node_modules");
+            }
+            break;
+        }
+        dir = current.parent();
+    }
+
+    cache.insert(String::from(package), is_workspace);
+    is_workspace.then_some(package)
+}
+
+fn normalize_join(base: &Path, specifier: &str) -> PathBuf {
+    let mut normalized = base.to_path_buf();
+    for component in Path::new(specifier).components() {
+        match component {
+            std::path::Component::CurDir => {}
+            std::path::Component::ParentDir => {
+                normalized.pop();
+            }
+            other => normalized.push(other.as_os_str()),
+        }
+    }
+    normalized
+}
+
+struct UnionFind {
+    parent: Vec<usize>,
+}
+
+impl UnionFind {
+    fn new(size: usize) -> Self {
+        Self {
+            parent: (0..size).collect(),
+        }
+    }
+
+    fn find(&mut self, node: usize) -> usize {
+        let mut root = node;
+        while self.parent[root] != root {
+            root = self.parent[root];
+        }
+        let mut current = node;
+        while self.parent[current] != root {
+            let next = self.parent[current];
+            self.parent[current] = root;
+            current = next;
+        }
+        root
+    }
+
+    fn union(&mut self, left: usize, right: usize) {
+        let left_root = self.find(left);
+        let right_root = self.find(right);
+        if left_root != right_root {
+            self.parent[right_root] = left_root;
+        }
+    }
+}
+
+fn is_vue_original(path: &Path) -> bool {
+    path.extension().is_some_and(|extension| extension == "vue")
+}
+
+fn is_ambient_declaration(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name.ends_with(".d.ts"))
+}
+
+fn declares_program_wide_types(content: &str) -> bool {
+    content.contains("declare module") || content.contains("declare global")
+}
+
+/// Resolve a normalized relative import target against the registered virtual
+/// files, trying the extension candidates TypeScript would.
+fn resolve_virtual_import(
+    target: &Path,
+    index_by_virtual: &FxHashMap<&Path, usize>,
+) -> Option<usize> {
+    if let Some(&index) = index_by_virtual.get(target) {
+        return Some(index);
+    }
+    let target_str = target.to_string_lossy();
+    for suffix in [".ts", ".tsx", ".d.ts", "/index.ts", "/index.tsx"] {
+        let candidate = PathBuf::from(cstr!("{target_str}{suffix}").as_str());
+        if let Some(&index) = index_by_virtual.get(candidate.as_path()) {
+            return Some(index);
+        }
+    }
+    None
+}
+
+fn run_cli_for_config(
+    corsa_path: &Path,
+    project: &VirtualProject,
+    config_path: &Path,
+) -> CorsaResult<TypeCheckResult> {
     let output = profile!(
         "canon.corsa.cli.command",
         Command::new(corsa_path)
@@ -24,7 +429,7 @@ pub(super) fn check_with_cli(
             .arg("--pretty")
             .arg("false")
             .arg("--project")
-            .arg(&config_path)
+            .arg(config_path)
             .output()
     )?;
     let diagnostics = profile!(
@@ -285,6 +690,117 @@ mod tests {
                 "cli-fallback-{name}-{}-{case_id}",
                 std::process::id()
             ))
+    }
+
+    #[test]
+    fn partitions_vue_files_and_shares_program_wide_sources() {
+        use super::partition_virtual_files;
+
+        let case_dir = unique_case_dir("shard-partition");
+        let _ = fs::remove_dir_all(&case_dir);
+        let src = case_dir.join("src");
+        fs::create_dir_all(&src).unwrap();
+        for index in 0..4 {
+            fs::write(
+                src.join(cstr!("Comp{index}.vue").as_str()),
+                "<script setup lang=\"ts\">const n = 1</script><template>{{ n }}</template>",
+            )
+            .unwrap();
+        }
+        // A Vue file whose script augments the program must stay shared.
+        fs::write(
+            src.join("Augment.vue"),
+            "<script lang=\"ts\">declare global { interface Window { __x?: number } }\nexport default {}</script>",
+        )
+        .unwrap();
+        fs::write(src.join("util.ts"), "export const util = 1;\n").unwrap();
+
+        let mut project = crate::batch::VirtualProject::new(&case_dir).unwrap();
+        let paths: Vec<_> = fs::read_dir(&src)
+            .unwrap()
+            .map(|entry| entry.unwrap().path())
+            .collect();
+        project.register_paths(&paths).unwrap();
+
+        let plan = partition_virtual_files(&project, 2);
+        assert_eq!(plan.shards.len(), 2);
+        // 4 Vue files and the unimported util.ts partition across both shards.
+        assert_eq!(plan.owners.len(), 5);
+        assert!(plan.owners.values().any(|&shard| shard == 0));
+        assert!(plan.owners.values().any(|&shard| shard == 1));
+        let util_owner = plan.owners.get(&src.join("util.ts")).copied();
+        assert!(util_owner.is_some(), "plain sources are partitioned too");
+        // The augmenting .vue is included in every shard.
+        for shard in &plan.shards {
+            assert!(
+                shard
+                    .iter()
+                    .any(|path| path.to_string_lossy().ends_with("Augment.vue.ts")),
+                "program-wide augmentations must be visible to every shard"
+            );
+        }
+
+        let _ = fs::remove_dir_all(&case_dir);
+    }
+
+    #[test]
+    fn shards_along_import_graph_components() {
+        use super::partition_virtual_files;
+
+        let case_dir = unique_case_dir("shard-components");
+        let _ = fs::remove_dir_all(&case_dir);
+        let src = case_dir.join("src");
+        fs::create_dir_all(&src).unwrap();
+        // A imports B (one component); C and D are isolated.
+        fs::write(
+            src.join("A.vue"),
+            "<script setup lang=\"ts\">import B from './B.vue'\nvoid B</script><template><B /></template>",
+        )
+        .unwrap();
+        for name in ["B", "C", "D"] {
+            fs::write(
+                src.join(cstr!("{name}.vue").as_str()),
+                "<script setup lang=\"ts\">const n = 1</script><template>{{ n }}</template>",
+            )
+            .unwrap();
+        }
+
+        let mut project = crate::batch::VirtualProject::new(&case_dir).unwrap();
+        let paths: Vec<_> = fs::read_dir(&src)
+            .unwrap()
+            .map(|entry| entry.unwrap().path())
+            .collect();
+        project.register_paths(&paths).unwrap();
+
+        let plan = partition_virtual_files(&project, 2);
+        assert_eq!(plan.shards.len(), 2);
+        // Import-connected files must land in the same shard so no shard
+        // re-checks another shard's Vue files through transitive loading.
+        let owner_a = plan.owners.get(&src.join("A.vue")).copied();
+        let owner_b = plan.owners.get(&src.join("B.vue")).copied();
+        assert!(owner_a.is_some());
+        assert_eq!(owner_a, owner_b);
+
+        // A dominant connected component degrades to an unsharded run: link
+        // C into the A/B component so only D stays separate (3 vs 1 files).
+        fs::write(
+            src.join("C.vue"),
+            "<script setup lang=\"ts\">import A from './A.vue'\nvoid A</script><template><A /></template>",
+        )
+        .unwrap();
+        let mut project = crate::batch::VirtualProject::new(&case_dir).unwrap();
+        let paths: Vec<_> = fs::read_dir(&src)
+            .unwrap()
+            .map(|entry| entry.unwrap().path())
+            .collect();
+        project.register_paths(&paths).unwrap();
+        let plan = partition_virtual_files(&project, 2);
+        assert!(
+            plan.shards.is_empty(),
+            "a dominant component must collapse to a single program"
+        );
+
+        let _ = fs::remove_dir_all(&case_dir);
     }
 
     #[test]

--- a/crates/vize_canon/src/batch/type_checker.rs
+++ b/crates/vize_canon/src/batch/type_checker.rs
@@ -107,6 +107,8 @@ pub struct BatchTypeChecker {
     executor: CorsaExecutor,
     /// Whether the project has been scanned.
     scanned: bool,
+    /// Number of parallel Corsa CLI processes; `None` auto-tunes.
+    server_count: Option<usize>,
 }
 
 impl BatchTypeChecker {
@@ -139,7 +141,15 @@ impl BatchTypeChecker {
             project,
             executor,
             scanned: false,
+            server_count: None,
         })
+    }
+
+    /// Set the number of parallel Corsa CLI processes the project check is
+    /// partitioned across. `None` (the default) auto-tunes from the machine
+    /// width and the number of registered Vue files.
+    pub fn set_server_count(&mut self, servers: Option<usize>) {
+        self.server_count = servers;
     }
 
     /// Resolve Vue 3 Options API template bindings (opt-in, standard build).
@@ -251,7 +261,9 @@ impl TypeChecker for BatchTypeChecker {
             return Err(CorsaError::NotInitialized);
         }
 
-        let mut result = self.executor.check(&self.project)?;
+        let mut result = self
+            .executor
+            .check_with_servers(&self.project, self.server_count)?;
         result
             .diagnostics
             .extend(self.project.diagnostics().iter().cloned());

--- a/crates/vize_canon/src/batch/virtual_project/mapping.rs
+++ b/crates/vize_canon/src/batch/virtual_project/mapping.rs
@@ -32,6 +32,13 @@ impl VirtualProject {
         &self.diagnostics
     }
 
+    /// Original source text of a registered file, keyed by its virtual path.
+    pub(crate) fn original_content_for_virtual(&self, virtual_path: &Path) -> Option<&str> {
+        self.original_contents
+            .get(virtual_path)
+            .map(|content| content.as_str())
+    }
+
     /// Map a virtual position to the original position.
     pub fn map_to_original(
         &self,

--- a/crates/vize_canon/src/batch/virtual_project/materialize.rs
+++ b/crates/vize_canon/src/batch/virtual_project/materialize.rs
@@ -182,4 +182,11 @@ impl VirtualProject {
         let tsconfig = self.project_root.join("tsconfig.json");
         tsconfig.exists().then_some(tsconfig)
     }
+
+    /// File that project-level (file-less) diagnostics are attributed to:
+    /// the effective tsconfig when one exists, otherwise the project root.
+    pub(crate) fn project_diagnostics_anchor(&self) -> PathBuf {
+        self.resolved_tsconfig_path()
+            .unwrap_or_else(|| self.project_root.clone())
+    }
 }

--- a/crates/vize_canon/src/batch/virtual_project/tests.rs
+++ b/crates/vize_canon/src/batch/virtual_project/tests.rs
@@ -701,12 +701,18 @@ fn materialized_tsconfig_preserves_original_path_option_bases() {
         compiler_options["allowImportingTsExtensions"],
         serde_json::Value::Bool(true)
     );
-    for option in ["baseUrl", "rootDir", "rootDirs", "typeRoots"] {
+    for option in ["baseUrl", "rootDir", "rootDirs"] {
         assert!(
             !compiler_options.contains_key(option),
-            "{option} should remain owned by the extended tsconfig"
+            "{option} is path-sensitive and must not leak into the mirror"
         );
     }
+    // Custom type roots are re-anchored like `paths`: mirror copy first, real
+    // source tree as fallback, so `types: [...]` entries keep resolving.
+    assert_eq!(
+        compiler_options["typeRoots"],
+        serde_json::json!(["./types", "../../../types"])
+    );
 
     let _ = fs::remove_dir_all(&case_dir);
 }

--- a/crates/vize_canon/src/batch/virtual_project/tests.rs
+++ b/crates/vize_canon/src/batch/virtual_project/tests.rs
@@ -814,6 +814,86 @@ fn materialized_tsconfig_reanchors_extended_paths_from_declaring_config_dir() {
 }
 
 #[test]
+fn materialized_tsconfig_inlines_extends_chain_without_extending_original() {
+    let case_dir = unique_case_dir("tsconfig-inline-extends");
+    let _ = fs::remove_dir_all(&case_dir);
+    let src_dir = case_dir.join("src");
+    fs::create_dir_all(&src_dir).unwrap();
+    fs::create_dir_all(case_dir.join("node_modules/@vue/tsconfig")).unwrap();
+    fs::write(
+        case_dir.join("node_modules/@vue/tsconfig/tsconfig.dom.json"),
+        r#"{
+  "compilerOptions": {
+    "strict": true,
+    "jsx": "preserve",
+    "moduleResolution": "bundler"
+  }
+}"#,
+    )
+    .unwrap();
+    fs::write(
+        case_dir.join("tsconfig.base.json"),
+        r#"{
+  "compilerOptions": {
+    "noUnusedLocals": true,
+    "baseUrl": "."
+  }
+}"#,
+    )
+    .unwrap();
+    fs::write(
+        case_dir.join("tsconfig.json"),
+        r#"{
+  "extends": ["@vue/tsconfig/tsconfig.dom.json", "./tsconfig.base.json"],
+  "compilerOptions": {
+    "jsx": "react-jsx"
+  },
+  "files": ["src/real-tree-only.ts"]
+}"#,
+    )
+    .unwrap();
+    let vue_path = src_dir.join("App.vue");
+    fs::write(
+        &vue_path,
+        "<script setup lang=\"ts\">const count = 1</script>",
+    )
+    .unwrap();
+
+    let mut project = VirtualProject::new(&case_dir).unwrap();
+    project.register_path(&vue_path).unwrap();
+    project.materialize().unwrap();
+
+    let tsconfig_path = case_dir.join("node_modules/.vize/canon/tsconfig.json");
+    let value: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(tsconfig_path).unwrap()).unwrap();
+
+    // The original tsconfig is never `extends`-ed: Corsa would re-parse the
+    // whole chain and fail the CLI run on config diagnostics for options the
+    // mirror already strips (e.g. the removed `baseUrl`), and the real tree's
+    // `files` list must not leak into the virtual program.
+    assert!(value.get("extends").is_none());
+
+    let compiler_options = value["compilerOptions"].as_object().unwrap();
+    // Inherited through the package-style extends entry.
+    assert_eq!(compiler_options["strict"], serde_json::Value::Bool(true));
+    assert_eq!(
+        compiler_options["moduleResolution"],
+        serde_json::json!("bundler")
+    );
+    // Inherited through the relative extends entry.
+    assert_eq!(
+        compiler_options["noUnusedLocals"],
+        serde_json::Value::Bool(true)
+    );
+    // The extending config wins over every extends entry.
+    assert_eq!(compiler_options["jsx"], serde_json::json!("react-jsx"));
+    // Path-sensitive options stay stripped.
+    assert!(!compiler_options.contains_key("baseUrl"));
+
+    let _ = fs::remove_dir_all(&case_dir);
+}
+
+#[test]
 fn test_parse_jsonc_value_handles_comments_and_trailing_commas() {
     let value = parse_jsonc_value(
         r#"{

--- a/crates/vize_canon/src/batch/virtual_project/tsconfig_gen.rs
+++ b/crates/vize_canon/src/batch/virtual_project/tsconfig_gen.rs
@@ -73,11 +73,17 @@ impl VirtualProject {
         // virtual program anyway.
         let mut compiler_options = self.load_compiler_options(original_tsconfig.as_deref())?;
 
-        // Capture the original path-alias map before stripping path-sensitive
-        // options, so it can be re-anchored into the virtual mirror below.
+        // Capture the original path-alias map and type roots before stripping
+        // path-sensitive options, so they can be re-anchored into the virtual
+        // mirror below.
         let original_paths = compiler_options
             .get("paths")
             .and_then(Value::as_object)
+            .cloned()
+            .unwrap_or_default();
+        let original_type_roots = compiler_options
+            .get("typeRoots")
+            .and_then(Value::as_array)
             .cloned()
             .unwrap_or_default();
 
@@ -97,6 +103,18 @@ impl VirtualProject {
             compiler_options.insert(
                 "paths".into(),
                 Value::Object(self.remap_paths(&original_paths)),
+            );
+        }
+
+        // Re-anchor custom `typeRoots` the same way: list the mirror copy and
+        // the real-tree directory. TypeScript scans every listed root and
+        // skips missing directories, so `types: [...]` entries served by a
+        // custom root keep resolving instead of raising a false TS2688 that
+        // only exists inside the mirror.
+        if !original_type_roots.is_empty() {
+            compiler_options.insert(
+                "typeRoots".into(),
+                Value::Array(self.remap_dir_entries(&original_type_roots)),
             );
         }
 
@@ -225,6 +243,26 @@ impl VirtualProject {
         compiler_options: &mut Map<std::string::String, Value>,
         base_dir: &Path,
     ) {
+        // Relative path-ish options resolve against the tsconfig that declares
+        // them; rebase them onto the project root so the flattened option set
+        // keeps the declaring config's meaning.
+        if let Some(type_roots) = compiler_options
+            .get_mut("typeRoots")
+            .and_then(Value::as_array_mut)
+        {
+            for entry in type_roots {
+                let Some(raw_entry) = entry.as_str() else {
+                    continue;
+                };
+                if Path::new(raw_entry).is_absolute() {
+                    continue;
+                }
+                *entry = Value::String(
+                    normalize_tsconfig_path_target(base_dir, &self.project_root, raw_entry).into(),
+                );
+            }
+        }
+
         let Some(paths) = compiler_options
             .get_mut("paths")
             .and_then(Value::as_object_mut)
@@ -282,6 +320,29 @@ impl VirtualProject {
                 candidates.push(Value::String(cstr!("{up}{core}").into()));
             }
             remapped.insert(alias.clone(), Value::Array(candidates));
+        }
+        remapped
+    }
+
+    /// Re-anchor a list of project-root-relative directories (e.g. `typeRoots`)
+    /// into the virtual mirror: each relative entry yields the mirror copy
+    /// followed by the real source-tree directory. Absolute and non-string
+    /// entries pass through unchanged.
+    fn remap_dir_entries(&self, entries: &[Value]) -> Vec<Value> {
+        let up = self.virtual_root_to_project_prefix();
+        let mut remapped = Vec::with_capacity(entries.len() * 2);
+        for entry in entries {
+            let Some(entry_str) = entry.as_str() else {
+                remapped.push(entry.clone());
+                continue;
+            };
+            if Path::new(entry_str).is_absolute() {
+                remapped.push(Value::String(entry_str.to_owned()));
+                continue;
+            }
+            let core = entry_str.strip_prefix("./").unwrap_or(entry_str);
+            remapped.push(Value::String(cstr!("./{core}").into()));
+            remapped.push(Value::String(cstr!("{up}{core}").into()));
         }
         remapped
     }

--- a/crates/vize_canon/src/batch/virtual_project/tsconfig_gen.rs
+++ b/crates/vize_canon/src/batch/virtual_project/tsconfig_gen.rs
@@ -32,6 +32,37 @@ impl VirtualProject {
         self.preserve_unused_diagnostics
     }
 
+    /// Alias prefixes declared in the effective tsconfig `paths` map, with
+    /// wildcard suffixes stripped: `@/*` → `@/`, `@scope/*` → `@scope/`,
+    /// `#imports` → `#imports`. Used as a cost model for shard planning:
+    /// files importing through the same project alias are coupled. Aliases
+    /// whose every target lives under `node_modules` (e.g. a pinned `vue`
+    /// mapping) are dependency cost every program pays anyway and are skipped.
+    pub(crate) fn path_alias_prefixes(&self) -> Vec<CompactString> {
+        let Ok(compiler_options) =
+            self.load_compiler_options(self.resolved_tsconfig_path().as_deref())
+        else {
+            return Vec::new();
+        };
+        let Some(paths) = compiler_options.get("paths").and_then(Value::as_object) else {
+            return Vec::new();
+        };
+        paths
+            .iter()
+            .filter(|(_, targets)| {
+                !targets.as_array().is_some_and(|targets| {
+                    !targets.is_empty()
+                        && targets.iter().all(|target| {
+                            target
+                                .as_str()
+                                .is_some_and(|target| target.contains("node_modules"))
+                        })
+                })
+            })
+            .map(|(alias, _)| alias.trim_end_matches('*').to_compact_string())
+            .collect()
+    }
+
     pub(super) fn resolve_tsconfig_preserves_unused_diagnostics(&self) -> bool {
         let Some(tsconfig_path) = self.resolved_tsconfig_path() else {
             return false;
@@ -50,7 +81,38 @@ impl VirtualProject {
         out_dir: Option<&Path>,
         declaration_map: bool,
     ) -> CorsaResult<()> {
-        let tsconfig = self.generate_tsconfig_value(out_dir, declaration_map)?;
+        self.write_tsconfig_file_with_includes(path, out_dir, declaration_map, None)
+    }
+
+    /// Write a tsconfig whose `include` lists only the given virtual paths
+    /// (plus the shared stub files). Used for shard configs that partition the
+    /// project across parallel Corsa CLI runs.
+    pub(crate) fn write_shard_tsconfig(
+        &self,
+        shard_index: usize,
+        include_virtual_paths: &[&Path],
+    ) -> CorsaResult<PathBuf> {
+        let config_path = self
+            .virtual_root
+            .join(cstr!("tsconfig.shard{shard_index}.json").as_str());
+        self.write_tsconfig_file_with_includes(
+            &config_path,
+            None,
+            false,
+            Some(include_virtual_paths),
+        )?;
+        Ok(config_path)
+    }
+
+    fn write_tsconfig_file_with_includes(
+        &self,
+        path: &Path,
+        out_dir: Option<&Path>,
+        declaration_map: bool,
+        include_virtual_paths: Option<&[&Path]>,
+    ) -> CorsaResult<()> {
+        let tsconfig =
+            self.generate_tsconfig_value(out_dir, declaration_map, include_virtual_paths)?;
         let content = serde_json::to_string_pretty(&tsconfig)?;
         write_if_changed(path, content.as_bytes())?;
         Ok(())
@@ -60,6 +122,7 @@ impl VirtualProject {
         &self,
         out_dir: Option<&Path>,
         declaration_map: bool,
+        include_virtual_paths: Option<&[&Path]>,
     ) -> CorsaResult<Value> {
         let mut config = Map::new();
         let original_tsconfig = self.resolved_tsconfig_path();
@@ -147,7 +210,7 @@ impl VirtualProject {
         config.insert(
             "include".into(),
             Value::Array(
-                self.include_paths()
+                self.include_paths(include_virtual_paths)
                     .into_iter()
                     .map(|path| Value::String(path.into()))
                     .collect(),
@@ -158,13 +221,20 @@ impl VirtualProject {
         Ok(Value::Object(config))
     }
 
-    fn include_paths(&self) -> Vec<CompactString> {
-        let mut includes: Vec<_> = self
-            .virtual_files
-            .keys()
-            .filter_map(|path| path.strip_prefix(&self.virtual_root).ok())
-            .map(|path| path.to_string_lossy().to_compact_string())
-            .collect();
+    fn include_paths(&self, include_virtual_paths: Option<&[&Path]>) -> Vec<CompactString> {
+        let relative = |path: &Path| {
+            path.strip_prefix(&self.virtual_root)
+                .ok()
+                .map(|path| path.to_string_lossy().to_compact_string())
+        };
+        let mut includes: Vec<_> = match include_virtual_paths {
+            Some(paths) => paths.iter().filter_map(|path| relative(path)).collect(),
+            None => self
+                .virtual_files
+                .keys()
+                .filter_map(|path| relative(path))
+                .collect(),
+        };
         if !self.virtual_ts_options.auto_import_stubs.is_empty() {
             includes.push(AUTO_IMPORT_STUBS_FILE.into());
         }

--- a/crates/vize_canon/src/batch/virtual_project/tsconfig_gen.rs
+++ b/crates/vize_canon/src/batch/virtual_project/tsconfig_gen.rs
@@ -63,15 +63,14 @@ impl VirtualProject {
     ) -> CorsaResult<Value> {
         let mut config = Map::new();
         let original_tsconfig = self.resolved_tsconfig_path();
-        if out_dir.is_none()
-            && let Some(ref tsconfig_path) = original_tsconfig
-        {
-            config.insert(
-                "extends".into(),
-                Value::String(tsconfig_path.to_string_lossy().into_owned()),
-            );
-        }
 
+        // The effective compiler options are flattened into the generated
+        // config instead of `extends`-ing the user's tsconfig. Corsa would
+        // otherwise re-parse the whole original chain and fail the entire CLI
+        // run on config-file diagnostics vize already compensates for (e.g.
+        // TS5102 for the removed `baseUrl` the mirror strips and re-anchors),
+        // and the real tree's `files`/`include` lists must not leak into the
+        // virtual program anyway.
         let mut compiler_options = self.load_compiler_options(original_tsconfig.as_deref())?;
 
         // Capture the original path-alias map before stripping path-sensitive
@@ -192,15 +191,30 @@ impl VirtualProject {
         let base_dir = normalized.parent().unwrap_or(self.project_root.as_path());
         self.normalize_paths_for_project_root(&mut compiler_options, base_dir);
 
-        let Some(parent_path) = config
-            .get("extends")
-            .and_then(Value::as_str)
-            .and_then(|extends| resolve_extended_tsconfig_path(&normalized, extends))
-        else {
+        // `extends` may be a single specifier or an array; array entries are
+        // applied in order, with later entries overriding earlier ones, and
+        // the extending file overriding them all.
+        let mut inherited = Map::new();
+        match config.get("extends") {
+            Some(Value::String(extends)) => {
+                if let Some(parent_path) = resolve_extended_tsconfig_path(&normalized, extends) {
+                    inherited = self.load_compiler_options_inner(&parent_path, seen)?;
+                }
+            }
+            Some(Value::Array(entries)) => {
+                for extends in entries.iter().filter_map(Value::as_str) {
+                    if let Some(parent_path) = resolve_extended_tsconfig_path(&normalized, extends)
+                    {
+                        inherited.extend(self.load_compiler_options_inner(&parent_path, seen)?);
+                    }
+                }
+            }
+            _ => {}
+        }
+        if inherited.is_empty() {
             return Ok(compiler_options);
-        };
+        }
 
-        let mut inherited = self.load_compiler_options_inner(&parent_path, seen)?;
         inherited.extend(compiler_options);
         Ok(inherited)
     }

--- a/crates/vize_canon/src/batch/virtual_project/tsconfig_paths.rs
+++ b/crates/vize_canon/src/batch/virtual_project/tsconfig_paths.rs
@@ -21,7 +21,10 @@ pub(super) fn resolve_extended_tsconfig_path(
         || extends == "."
         || extends == "..")
     {
-        return None;
+        // Bare specifier (`@vue/tsconfig/tsconfig.dom.json`): resolved like a
+        // Node import, walking ancestor `node_modules` directories from the
+        // extending config.
+        return resolve_package_tsconfig_path(base_dir, extends);
     }
 
     let base = if extends_path.is_absolute() {
@@ -34,6 +37,22 @@ pub(super) fn resolve_extended_tsconfig_path(
         .into_iter()
         .map(|candidate| normalize_path_lexically(&candidate))
         .find(|candidate| candidate.exists())
+}
+
+fn resolve_package_tsconfig_path(base_dir: &Path, extends: &str) -> Option<PathBuf> {
+    let mut current = Some(base_dir);
+    while let Some(dir) = current {
+        let base = dir.join("node_modules").join(extends);
+        if let Some(found) = tsconfig_path_candidates(base)
+            .into_iter()
+            .map(|candidate| normalize_path_lexically(&candidate))
+            .find(|candidate| candidate.is_file())
+        {
+            return Some(found);
+        }
+        current = dir.parent();
+    }
+    None
 }
 
 fn tsconfig_path_candidates(base: PathBuf) -> Vec<PathBuf> {

--- a/crates/vize_canon/src/tests.rs
+++ b/crates/vize_canon/src/tests.rs
@@ -388,6 +388,42 @@ const activeItem = ref<T | null>(null)
     }
 
     #[test]
+    fn virtual_ts_annotated_slot_props_keep_user_annotation_and_check_it() {
+        // `#item="{ element }: { element: Tag }"` (a typed slot scope, used by
+        // e.g. voicevox) must not get the inferred slot type appended after
+        // the user's own annotation — `pattern: A: B` is a syntax error that
+        // aborts Corsa's semantic pass for the whole project. The user
+        // annotation types the bindings, and a separate assignment asserts the
+        // child's actual slot props are assignable to it.
+        let source = r#"<script setup lang="ts">
+import Draggable from './Draggable.vue'
+type Tag = { id: string }
+</script>
+
+<template>
+  <Draggable>
+    <template #item="{ element }: { element: Tag }">
+      <div>{{ element.id }}</div>
+    </template>
+  </Draggable>
+</template>"#;
+
+        let virtual_ts = generate_virtual_ts_from_sfc(source);
+        assert!(
+            virtual_ts.contains("({ element }: { element: Tag })"),
+            "slot bindings must use the user's own annotation:\n{virtual_ts}"
+        );
+        assert!(
+            virtual_ts.contains("const __slot_annotation_check: { element: Tag } ="),
+            "the child's actual slot props must be checked against the annotation:\n{virtual_ts}"
+        );
+        assert!(
+            !virtual_ts.contains("{ element: Tag }: typeof"),
+            "the inferred slot type must not be appended after the annotation:\n{virtual_ts}"
+        );
+    }
+
+    #[test]
     fn virtual_ts_const_generic_component_strips_const_from_type_positions() {
         // `generic="const T extends ..."` (TS 5.0 const type parameter, used by
         // e.g. misskey's MkTabs) — the parameter NAME is `T`, and the `const`

--- a/crates/vize_canon/src/tests.rs
+++ b/crates/vize_canon/src/tests.rs
@@ -388,6 +388,37 @@ const activeItem = ref<T | null>(null)
     }
 
     #[test]
+    fn virtual_ts_const_generic_component_strips_const_from_type_positions() {
+        // `generic="const T extends ..."` (TS 5.0 const type parameter, used by
+        // e.g. misskey's MkTabs) — the parameter NAME is `T`, and the `const`
+        // modifier is only legal on function/method type parameters, never on
+        // the generated `type Props<...>` alias (TS1277).
+        let source = r#"<script setup lang="ts" generic="const T extends string | number">
+const props = defineProps<{
+  items: T[]
+}>()
+</script>
+
+<template>
+  <div>{{ props.items }}</div>
+</template>"#;
+
+        let virtual_ts = generate_virtual_ts_from_sfc(source);
+        assert!(
+            virtual_ts.contains("export type Props<T extends string | number = any>"),
+            "Props alias must declare `T` without the const modifier:\n{virtual_ts}"
+        );
+        assert!(
+            virtual_ts.contains("function __setup<const T extends string | number>()"),
+            "the setup closure keeps the const modifier (legal on functions):\n{virtual_ts}"
+        );
+        assert!(
+            !virtual_ts.contains("Props<const>"),
+            "the const modifier must never be treated as the parameter name:\n{virtual_ts}"
+        );
+    }
+
+    #[test]
     fn snapshot_virtual_ts_dynamic_component() {
         let source = r#"<script setup lang="ts">
 import { ref, markRaw } from 'vue'

--- a/crates/vize_canon/src/virtual_ts/generator/mod.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/mod.rs
@@ -27,7 +27,7 @@ use super::{
     },
     props::{
         add_generic_defaults, collect_template_prop_names, extract_generic_names,
-        generate_props_type, generate_props_variables,
+        generate_props_type, generate_props_variables, strip_const_modifiers,
     },
     scope::{ScopeGenerationOptions, generate_scope_closures},
     types::{VirtualTsGenerationOptions, VirtualTsOptions, VirtualTsOutput, VizeMapping},
@@ -241,7 +241,10 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
     // reference resolves at module scope while bare uses (`Option[]`) still
     // work via the `= any` defaults.
     let generic_injection: Option<(String, Vec<String>)> = generic_param.map(|g| {
-        let defaults = add_generic_defaults(g);
+        // `const` modifiers are only legal on function/method/class type
+        // parameters (TS1277); the spliced copies live on `type`/`interface`
+        // declarations and must drop them.
+        let defaults = strip_const_modifiers(&add_generic_defaults(g));
         let names = extract_generic_names(g)
             .split(',')
             .map(|n| String::from(n.trim()))

--- a/crates/vize_canon/src/virtual_ts/props.rs
+++ b/crates/vize_canon/src/virtual_ts/props.rs
@@ -301,10 +301,11 @@ pub(crate) fn generate_props_type(ts: &mut String, summary: &Croquis, generic_pa
         .iter()
         .any(|te| te.name.as_str() == "Props");
 
-    // Build generic suffix for Props type declaration (with `= any` defaults)
+    // Build generic suffix for Props type declaration (with `= any` defaults).
+    // `const` modifiers are illegal on type-alias parameters (TS1277).
     let generic_decl = generic_param
         .map(|g| {
-            let with_defaults = add_generic_defaults(g);
+            let with_defaults = strip_const_modifiers(&add_generic_defaults(g));
             cstr!("<{with_defaults}>")
         })
         .unwrap_or_default();
@@ -779,10 +780,22 @@ fn find_matching_brace(s: &str, start: usize) -> usize {
     s.len().saturating_sub(1)
 }
 
+/// First identifier of a generic parameter declaration, skipping the TS 5.0
+/// `const` modifier: `const T extends Tab` declares `T`, not `const`.
+fn generic_param_name(param: &str) -> &str {
+    let mut tokens = param.split_whitespace();
+    match tokens.next() {
+        Some("const") => tokens.next().unwrap_or(param),
+        Some(token) => token,
+        None => param,
+    }
+}
+
 /// Extract just the generic parameter names from a full generic declaration.
 /// e.g., `"T extends Foo, P extends Bar"` → `"T, P"`
 /// e.g., `"T"` → `"T"`
 /// e.g., `"T extends Record<string, any>, U"` → `"T, U"`
+/// e.g., `"const T extends Tab"` → `"T"`
 pub(crate) fn extract_generic_names(generic_param: &str) -> String {
     let mut names = String::default();
     let mut depth = 0i32; // track <> nesting
@@ -797,7 +810,7 @@ pub(crate) fn extract_generic_names(generic_param: &str) -> String {
                 let trimmed = current_name.trim();
                 if !trimmed.is_empty() {
                     // Extract just the name (before "extends")
-                    let name = trimmed.split_whitespace().next().unwrap_or(trimmed);
+                    let name = generic_param_name(trimmed);
                     if !names.is_empty() {
                         names.push_str(", ");
                     }
@@ -817,7 +830,7 @@ pub(crate) fn extract_generic_names(generic_param: &str) -> String {
     // Handle the last parameter
     let trimmed = current_name.trim();
     if !trimmed.is_empty() {
-        let name = trimmed.split_whitespace().next().unwrap_or(trimmed);
+        let name = generic_param_name(trimmed);
         if !names.is_empty() {
             names.push_str(", ");
         }
@@ -826,6 +839,49 @@ pub(crate) fn extract_generic_names(generic_param: &str) -> String {
 
     let _ = in_extends;
     names
+}
+
+/// Drop TS 5.0 `const` modifiers from a generic parameter list.
+/// The modifier is only legal on function/method/class type parameters
+/// (TS1277), so callers that splice parameters into `type`/`interface`
+/// declarations must strip it first.
+/// e.g., `"const T extends Tab = any"` → `"T extends Tab = any"`
+pub(crate) fn strip_const_modifiers(generic_param: &str) -> String {
+    let mut result = String::default();
+    let mut depth = 0i32;
+    let mut current_param = String::default();
+
+    for ch in generic_param.chars() {
+        match ch {
+            '<' => depth += 1,
+            '>' => depth -= 1,
+            ',' if depth == 0 => {
+                append_param_without_const(&mut result, current_param.trim());
+                result.push_str(", ");
+                current_param = String::default();
+                continue;
+            }
+            _ => {}
+        }
+        current_param.push(ch);
+    }
+
+    let trimmed = current_param.trim();
+    if !trimmed.is_empty() {
+        append_param_without_const(&mut result, trimmed);
+    }
+
+    result
+}
+
+/// Append a single generic parameter with its leading `const` modifier removed.
+fn append_param_without_const(result: &mut String, param: &str) {
+    let stripped = param
+        .strip_prefix("const")
+        .filter(|rest| rest.starts_with(|ch: char| ch.is_ascii_whitespace()))
+        .map(str::trim_start)
+        .unwrap_or(param);
+    result.push_str(stripped);
 }
 
 /// Add `= any` defaults to each generic parameter that doesn't already have a default.
@@ -888,10 +944,50 @@ fn append_param_with_default(result: &mut String, param: &str) {
 #[cfg(test)]
 mod tests {
     use super::{
-        collect_with_defaults_default_names_from_source, extract_interface_fields,
+        add_generic_defaults, collect_with_defaults_default_names_from_source,
+        extract_generic_names, extract_interface_fields, strip_const_modifiers,
         template_props_type_ref,
     };
     use vize_carton::{FxHashSet, String};
+
+    #[test]
+    fn extracts_generic_names_skipping_const_modifier() {
+        assert_eq!(
+            extract_generic_names("T extends Foo, P extends Bar"),
+            "T, P"
+        );
+        assert_eq!(extract_generic_names("const T extends Tab"), "T");
+        assert_eq!(
+            extract_generic_names("const T extends Record<string, any>, U"),
+            "T, U"
+        );
+        // A prop named `constant` must not lose its prefix.
+        assert_eq!(extract_generic_names("constant extends Foo"), "constant");
+    }
+
+    #[test]
+    fn strips_const_modifiers_for_type_declarations() {
+        assert_eq!(
+            strip_const_modifiers("const T extends Tab = any").as_str(),
+            "T extends Tab = any"
+        );
+        assert_eq!(
+            strip_const_modifiers("const T extends Record<string, any>, const U = any").as_str(),
+            "T extends Record<string, any>, U = any"
+        );
+        assert_eq!(
+            strip_const_modifiers("T extends Tab = any").as_str(),
+            "T extends Tab = any"
+        );
+        assert_eq!(
+            strip_const_modifiers("constant extends Foo").as_str(),
+            "constant extends Foo"
+        );
+        assert_eq!(
+            strip_const_modifiers(add_generic_defaults("const T extends Tab").as_str()).as_str(),
+            "T extends Tab = any"
+        );
+    }
 
     #[test]
     fn collects_with_defaults_object_keys() {

--- a/crates/vize_canon/src/virtual_ts/scope/closures.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/closures.rs
@@ -20,7 +20,9 @@ use super::component_props::generate_component_props;
 use super::context::{
     ComponentPropsContext, EventHandlerExprContext, ScopeGenContext, ScopeGenerationOptions,
 };
-use super::emit::{append_v_for_comment, emit_v_for_loop_open, slot_props_type};
+use super::emit::{
+    append_v_for_comment, emit_slot_function_open, emit_v_for_loop_open, slot_props_type,
+};
 use super::event_handler::generate_event_handler_expressions;
 use super::globals::{generate_instance_global_refs, generate_undefined_refs};
 
@@ -249,9 +251,12 @@ fn generate_scope_node(
                 data.name.as_str(),
                 ctx.summary.scopes.is_v_slot_name_static(scope.id),
             );
-            append!(
-                *ts,
-                "{indent}void function _slot_{safe_slot_name}({props_pattern}: {props_type}) {{\n",
+            emit_slot_function_open(
+                ts,
+                indent,
+                cstr!("_slot_{safe_slot_name}").as_str(),
+                props_pattern,
+                &props_type,
             );
             // Mark slot prop variables as used
             if data.prop_names.is_empty() {

--- a/crates/vize_canon/src/virtual_ts/scope/component_props.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/component_props.rs
@@ -5,6 +5,7 @@ use vize_carton::FxHashMap;
 use vize_carton::FxHashSet;
 use vize_carton::String;
 use vize_carton::append;
+use vize_carton::cstr;
 use vize_carton::profile;
 
 use vize_croquis::{Croquis, Scope, ScopeData, ScopeKind, analysis::ComponentUsage};
@@ -14,7 +15,9 @@ use crate::virtual_ts::helpers::{to_camel_case, to_safe_identifier, to_safe_iden
 use crate::virtual_ts::types::VizeMapping;
 
 use super::context::{ComponentPropsContext, VForPropsContext};
-use super::emit::{append_v_for_comment, emit_v_for_loop_open, slot_props_type};
+use super::emit::{
+    append_v_for_comment, emit_slot_function_open, emit_v_for_loop_open, slot_props_type,
+};
 
 /// Generate component props type checks (scope-aware).
 /// Type declarations are at template level, value checks are in their scope.
@@ -301,19 +304,22 @@ fn generate_closure_component_props_recursive(
         ScopeData::VSlot(data) => {
             let props_pattern = data.props_pattern.as_deref().unwrap_or("slotProps");
             let safe_slot_name = to_safe_identifier_fragment(data.name.as_str());
-            let props_type = slot_props_type(
-                data.component.as_deref(),
-                data.name.as_str(),
-                ctx.summary.scopes.is_v_slot_name_static(scope.id),
-            );
             append!(
                 *ts,
                 "\n{indent}// Component props in v-slot scope: #{}\n",
                 data.name
             );
-            append!(
-                *ts,
-                "{indent}void function _slot_props_{safe_slot_name}({props_pattern}: {props_type}) {{\n",
+            let props_type = slot_props_type(
+                data.component.as_deref(),
+                data.name.as_str(),
+                ctx.summary.scopes.is_v_slot_name_static(scope.id),
+            );
+            emit_slot_function_open(
+                ts,
+                indent,
+                cstr!("_slot_props_{safe_slot_name}").as_str(),
+                props_pattern,
+                &props_type,
             );
             // Mark slot prop variables as used
             if data.prop_names.is_empty() {

--- a/crates/vize_canon/src/virtual_ts/scope/emit.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/emit.rs
@@ -36,6 +36,74 @@ pub(super) fn slot_props_type(
     }
 }
 
+/// Split a `v-slot` props expression that carries its own TypeScript
+/// annotation (`#item="{ element }: { element: Tag }"`) into the binding
+/// pattern and the annotation. Vue allows the annotation, so emitting the
+/// inferred slot type after the full expression would produce `pattern: A: B`
+/// — a syntax error that aborts Corsa's semantic pass for the whole project.
+/// A `:` separates the annotation only at the top nesting level.
+pub(super) fn split_slot_pattern_annotation(pattern: &str) -> Option<(&str, &str)> {
+    let mut depth = 0i32;
+    let mut quote: Option<char> = None;
+    let mut escaped = false;
+
+    for (at, ch) in pattern.char_indices() {
+        if let Some(open) = quote {
+            if escaped {
+                escaped = false;
+            } else if ch == '\\' {
+                escaped = true;
+            } else if ch == open {
+                quote = None;
+            }
+            continue;
+        }
+        match ch {
+            '\'' | '"' | '`' => quote = Some(ch),
+            '{' | '[' | '(' | '<' => depth += 1,
+            '}' | ']' | ')' | '>' => depth -= 1,
+            ':' if depth == 0 => {
+                let annotation = pattern[at + 1..].trim();
+                if annotation.is_empty() {
+                    return None;
+                }
+                return Some((pattern[..at].trim_end(), annotation));
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+/// Emit the opening of a v-slot scope function. The parameter is annotated
+/// with the slot type inferred from the child's `$slots`; when the user wrote
+/// their own annotation, that annotation is kept for the bindings and a
+/// separate assignment asserts the child's actual slot props are assignable
+/// to it, mirroring how vue-tsc validates annotated slot props.
+pub(super) fn emit_slot_function_open(
+    ts: &mut String,
+    indent: &str,
+    function_name: &str,
+    props_pattern: &str,
+    props_type: &String,
+) {
+    if let Some((pattern, annotation)) = split_slot_pattern_annotation(props_pattern) {
+        append!(
+            *ts,
+            "{indent}void function {function_name}({pattern}: {annotation}) {{\n"
+        );
+        append!(
+            *ts,
+            "{indent}  const __slot_annotation_check: {annotation} = undefined as unknown as ({props_type});\n{indent}  void __slot_annotation_check;\n"
+        );
+    } else {
+        append!(
+            *ts,
+            "{indent}void function {function_name}({props_pattern}: {props_type}) {{\n"
+        );
+    }
+}
+
 pub(super) fn append_v_for_comment(
     ts: &mut String,
     indent: &str,

--- a/crates/vize_croquis/src/declaration_ts.rs
+++ b/crates/vize_croquis/src/declaration_ts.rs
@@ -326,13 +326,22 @@ fn append_generic_name(names: &mut String, param: &str) {
     if param.is_empty() {
         return;
     }
-    let name = param.split_whitespace().next().unwrap_or(param);
+    // Skip the TS 5.0 `const` modifier: `const T extends Tab` declares `T`.
+    let mut tokens = param.split_whitespace();
+    let name = match tokens.next() {
+        Some("const") => tokens.next().unwrap_or(param),
+        Some(token) => token,
+        None => param,
+    };
     if !names.is_empty() {
         names.push_str(", ");
     }
     names.push_str(name);
 }
 
+/// Add `= any` defaults to each generic parameter and drop TS 5.0 `const`
+/// modifiers: the result is spliced into emitted `type` declarations, where
+/// the modifier is illegal (TS1277).
 fn add_generic_defaults(generic_param: &str) -> String {
     let mut result = String::default();
     let mut depth = 0i32;
@@ -365,6 +374,11 @@ fn append_param_with_default(result: &mut String, param: &str) {
     if param.is_empty() {
         return;
     }
+    let param = param
+        .strip_prefix("const")
+        .filter(|rest| rest.starts_with(|ch: char| ch.is_ascii_whitespace()))
+        .map(str::trim_start)
+        .unwrap_or(param);
     result.push_str(param);
 
     let mut depth = 0i32;

--- a/tests/tooling/cli-check-args.test.ts
+++ b/tests/tooling/cli-check-args.test.ts
@@ -60,7 +60,7 @@ function withWorkspace<T>(run: (dir: string) => T): T {
 // the binary never reaches the type checker, so the assertions are stable in a
 // clean checkout with no Corsa/tsgo on disk.
 
-test("vize check rejects --servers 0 and --servers 2 with exit 2 before corsa discovery", () => {
+test("vize check rejects --servers 0 and --servers 64 with exit 2 before corsa discovery", () => {
   withWorkspace((dir) => {
     fs.writeFileSync(path.join(dir, "a.vue"), "<template><p /></template>\n", "utf8");
 
@@ -68,9 +68,9 @@ test("vize check rejects --servers 0 and --servers 2 with exit 2 before corsa di
     assert.equal(zero.status, 2, `${zero.stdout}\n${zero.stderr}`);
     assert.match(zero.stderr, /servers must be at least 1/);
 
-    const two = runCheck(["a.vue", "--servers", "2", "--corsa-path", "/nonexistent"], dir);
-    assert.equal(two.status, 2, `${two.stdout}\n${two.stderr}`);
-    assert.match(two.stderr, /servers=2 is not supported/);
+    const tooMany = runCheck(["a.vue", "--servers", "64", "--corsa-path", "/nonexistent"], dir);
+    assert.equal(tooMany.status, 2, `${tooMany.stdout}\n${tooMany.stderr}`);
+    assert.match(tooMany.stderr, /servers=64 exceeds the supported maximum/);
   });
 });
 


### PR DESCRIPTION
## Summary

`vize check` tries the Corsa CLI first and falls back to the per-file project-session API when the CLI "fails". That fallback is orders of magnitude slower (misskey: **34.7s vs ~1s**), and several classes of real-world projects were unconditionally falling into it. This series removes each cause and makes the remaining failure surface honest instead of silent:

1. **TS 5.0 const generic type parameters** (`<script setup generic="const T extends Tab">`, used by misskey): the `const` modifier was parsed as the parameter name, generating `Props<const>` — invalid TS whose syntax errors aborted Corsa's semantic pass and never mapped back to sources. Parameter names now skip the modifier, and parameter lists spliced into generated `type`/`interface` declarations drop `const` (TS1277) while function positions keep it for inference.
2. **CLI result retention**: a non-zero exit whose parsed diagnostics ended up empty was treated as a runner failure even when the output clearly carried diagnostics. The session fallback is now reserved for genuine runner failures (no diagnostic-shaped output at all).
3. **tsconfig inlining**: the generated mirror tsconfig `extends`-ed the user's tsconfig, so Corsa re-parsed the original chain and failed the entire run on config diagnostics vize already compensates for — most notably TS5102 for the removed `baseUrl` that the mirror strips and re-anchors. The effective compiler options are now flattened into the generated config (as declaration emit already did), with bare `extends` specifiers (`@vue/tsconfig/...`) resolved through ancestor `node_modules` and `extends` arrays applied in order.
4. **Annotated v-slot props** (`#item="{ element }: { element: Tag }"`, used by voicevox): the inferred slot type was appended after the user's own annotation (`pattern: A: B` — syntax error). The user annotation now types the bindings and a separate assignment asserts the child's actual slot props are assignable to it.
5. **typeRoots re-anchoring**: custom `typeRoots` were stripped, so `types: [...]` entries they served raised a mirror-only TS2688. Roots are re-anchored like `paths` (mirror first, real tree fallback).
6. **Project-level diagnostics**: file-less errors such as TS2688 were dropped, letting a run whose semantic pass Corsa skipped report green. They now surface as real diagnostics anchored to the effective tsconfig — counted, rendered, in JSON output, and reflected in the exit code, matching tsc/vue-tsc.

## Real-world fixtures (local)

| fixture | before | after |
|---|---|---|
| misskey frontend (583 SFCs) | 34.7s (session fallback) | **~1.0s** (CLI) |
| voicevox (128 SFCs) | 1.27s (session fallback) | **~0.2s** (CLI) |

Pairs with #1381 (parallel materialization); Blacksmith CI bench numbers on the PR.

Note: `check_node_modules_global_components_are_typed_from_reference_types` fails locally on `main` as well (workspace vue 3.6.0-beta.10 has no `GlobalComponents` export; the test self-skips on CI) — unchanged by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1382"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783709357&installation_id=136613492&pr_number=1382&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1382&signature=5be8081afdc87fbd476442437d37c7017e8c3492def2b6120ffd83397c502eba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

## Update: parallel CLI sharding (`--servers`)

A follow-up commit implements the reserved `--servers N` option (auto-tuned by default). Corsa's checker pool saturates ~4 cores, so a single CLI process leaves most of a wide machine idle — on the 32-core Blacksmith bench runner ~85% of `vize check` sits inside that one process. The project is now partitioned across N concurrent Corsa CLI programs along the **connected components of its import graph** (relative imports resolved exactly; tsconfig path aliases and workspace packages symlinked into node_modules couple their importers):

- Shard programs check disjoint code; merged, ownership-filtered diagnostics are byte-identical to an unsharded run (verified on the bench corpus, element-plus, and misskey).
- Ambient `.d.ts` and sources with `declare module`/`declare global` stay visible to every shard.
- Interconnected projects collapse into a dominant component and automatically degrade to the single-program run — no regression for misskey/element-plus-shaped codebases.
- A shard failure degrades to the unsharded CLI before the session fallback.
- A final commit sizes Corsa's checker pool (`--checkers`, default 4 workers upstream) to the machine's available parallelism — split across programs when sharded, with a one-shot retry without the option for older runtimes (TS5023). This recovers most of the idle CPU even for unsharded runs.