### PR TITLE
ci(bench): build PR perf-gate binaries with an optimized profile

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -112,24 +112,24 @@ jobs:
         if: steps.base-integrity.outputs.skip != 'true' && steps.validate-base.outcome == 'success'
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
-          path: base/target/ci/vize
-          key: ${{ runner.os }}-benchmark-base-cli-${{ github.event.pull_request.base.sha }}
+          path: base/target/ci-opt/vize
+          key: ${{ runner.os }}-benchmark-base-cli-ci-opt-${{ github.event.pull_request.base.sha }}
 
       - name: Build base CLI
         if: steps.base-integrity.outputs.skip != 'true' && steps.validate-base.outcome == 'success' && steps.cache-base-cli.outputs.cache-hit != 'true'
-        run: cargo build --manifest-path base/Cargo.toml --profile ci -p vize
+        run: cargo build --manifest-path base/Cargo.toml --profile ci-opt -p vize
 
       - name: Cache head CLI
         id: cache-head-cli
         if: steps.base-integrity.outputs.skip != 'true' && steps.validate-base.outcome == 'success'
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
-          path: head/target/ci/vize
-          key: ${{ runner.os }}-benchmark-head-cli-${{ github.event.pull_request.head.sha }}
+          path: head/target/ci-opt/vize
+          key: ${{ runner.os }}-benchmark-head-cli-ci-opt-${{ github.event.pull_request.head.sha }}
 
       - name: Build head CLI
         if: steps.base-integrity.outputs.skip != 'true' && steps.validate-base.outcome == 'success' && steps.cache-head-cli.outputs.cache-hit != 'true'
-        run: cargo build --manifest-path head/Cargo.toml --profile ci -p vize
+        run: cargo build --manifest-path head/Cargo.toml --profile ci-opt -p vize
 
       - name: Generate benchmark input
         if: steps.base-integrity.outputs.skip != 'true' && steps.validate-base.outcome == 'success'
@@ -141,8 +141,8 @@ jobs:
         run: |
           node head/bench/compare-pr.mjs \
             --input "$GITHUB_WORKSPACE/head/bench/__in__" \
-            --base-bin "$GITHUB_WORKSPACE/base/target/ci/vize" \
-            --head-bin "$GITHUB_WORKSPACE/head/target/ci/vize" \
+            --base-bin "$GITHUB_WORKSPACE/base/target/ci-opt/vize" \
+            --head-bin "$GITHUB_WORKSPACE/head/target/ci-opt/vize" \
             --base-label "${{ github.event.pull_request.base.sha }}" \
             --head-label "${{ github.event.pull_request.head.sha }}" \
             --runs "$VIZE_BENCH_RUNS" \

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -115,9 +115,16 @@ jobs:
           path: base/target/ci-opt/vize
           key: ${{ runner.os }}-benchmark-base-cli-ci-opt-${{ github.event.pull_request.base.sha }}
 
+      # The ci-opt profile is also injected via --config so the base checkout
+      # builds even when it predates the profile's Cargo.toml definition, and
+      # both sides are guaranteed to measure under identical settings.
       - name: Build base CLI
         if: steps.base-integrity.outputs.skip != 'true' && steps.validate-base.outcome == 'success' && steps.cache-base-cli.outputs.cache-hit != 'true'
-        run: cargo build --manifest-path base/Cargo.toml --profile ci-opt -p vize
+        run: >-
+          cargo build --manifest-path base/Cargo.toml --profile ci-opt -p vize
+          --config 'profile.ci-opt.inherits="release"'
+          --config 'profile.ci-opt.lto="thin"'
+          --config 'profile.ci-opt.codegen-units=16'
 
       - name: Cache head CLI
         id: cache-head-cli
@@ -129,7 +136,11 @@ jobs:
 
       - name: Build head CLI
         if: steps.base-integrity.outputs.skip != 'true' && steps.validate-base.outcome == 'success' && steps.cache-head-cli.outputs.cache-hit != 'true'
-        run: cargo build --manifest-path head/Cargo.toml --profile ci-opt -p vize
+        run: >-
+          cargo build --manifest-path head/Cargo.toml --profile ci-opt -p vize
+          --config 'profile.ci-opt.inherits="release"'
+          --config 'profile.ci-opt.lto="thin"'
+          --config 'profile.ci-opt.codegen-units=16'
 
       - name: Generate benchmark input
         if: steps.base-integrity.outputs.skip != 'true' && steps.validate-base.outcome == 'success'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -159,3 +159,12 @@ inherits = "dev"
 debug = false
 incremental = false
 codegen-units = 256
+
+# The PR benchmark gate compares base and head CLI performance, so its binaries
+# must be optimized or abstraction-cost regressions stay invisible. Thin LTO
+# with multiple codegen units keeps the gate's per-SHA build cost well below
+# the fat-LTO release profile while staying representative of it.
+[profile.ci-opt]
+inherits = "release"
+lto = "thin"
+codegen-units = 16


### PR DESCRIPTION
## Summary

The PR benchmark gate is the only CI job that can fail a PR for a performance regression, but it currently builds both the base and head CLIs with `--profile ci`, which inherits `dev` — i.e. **opt-level 0**. Measuring unoptimized binaries means:

- Abstraction-cost regressions (the exact class a zero-cost-abstraction policy must catch: a `dyn` dispatch that stops inlining, an extra `clone()` the optimizer would otherwise elide) are largely **invisible**, because nothing is inlined to begin with.
- Debug-grade timings are noisier and can produce false budget failures.

This PR adds a dedicated `ci-opt` profile (`inherits = "release"`, `lto = "thin"`, `codegen-units = 16`) and switches only `benchmark.yml` to it. Thin LTO with 16 codegen units keeps the gate's build cost well below the fat-LTO/1-CGU release profile while remaining representative of it. The per-SHA CLI caches amortize the extra build cost across pushes; cache keys gain a `ci-opt` marker so previously cached opt-level-0 binaries cannot satisfy the new paths.

Functional-test workflows (`check.yml`, `e2e.yml`, `native-smoke.yml`) intentionally keep the fast `ci` profile — correctness jobs don't need optimized binaries.

Part of #1386.

## Test plan

- `node --test tests/tooling/github-workflows.test.ts` — 48/48 pass locally.
- Profile validity checked via cargo manifest parsing.
- This PR's own benchmark run exercises the new path end-to-end on Actions; the build-time delta is visible in the job timings, and the reported absolute timings should drop to release-grade numbers compared to previous PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1395"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783751688&installation_id=136613492&pr_number=1395&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1395&signature=cc56395c41e5b942a2eae793dbf23e82ed8b9b15222fc8042e34d688707e7935"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->