### PR TITLE
fix(canon): decode percent-escapes as UTF-8 bytes in corsa_server URI handling

### DIFF
--- a/crates/vize_canon/src/corsa_server.rs
+++ b/crates/vize_canon/src/corsa_server.rs
@@ -628,12 +628,14 @@ impl Default for CorsaServer {
 /// `DEFINE_PROPS_DESTRUCTURE_DEFAULT_TYPE`). Uses the lightweight validator
 /// entry point so the socket-mode check stays as fast as the Virtual TS path.
 /// Resolve a URI (file:// or plain path) to an absolute filesystem path.
-/// Returns None when the URI is a non-`file` scheme or the path cannot be
-/// extracted. Used by socket-mode sibling overlay to read siblings from disk.
+/// Returns None when the URI is a non-`file` scheme, the path cannot be
+/// extracted, or percent-decoding yields invalid UTF-8. Used by socket-mode
+/// sibling overlay to read siblings from disk. `file://` URIs go through the
+/// shared converter in `crate::file_uri` so percent-escapes are decoded as
+/// UTF-8 byte sequences (not per-byte chars, which garbles non-ASCII paths).
 fn uri_to_path(uri: &str, working_dir: &Path) -> Option<PathBuf> {
-    if let Some(stripped) = uri.strip_prefix("file://") {
-        let decoded = percent_decode(stripped);
-        return Some(PathBuf::from(decoded));
+    if uri.starts_with("file://") {
+        return crate::file_uri::file_uri_to_path(uri);
     }
     if uri.contains("://") {
         return None;
@@ -644,28 +646,6 @@ fn uri_to_path(uri: &str, working_dir: &Path) -> Option<PathBuf> {
     } else {
         Some(working_dir.join(path))
     }
-}
-
-/// Minimal `%`-decoder for `file://` URIs. Only handles the small set of
-/// characters TypeScript and Corsa typically encode (space, special chars).
-fn percent_decode(input: &str) -> String {
-    let bytes = input.as_bytes();
-    let mut out = String::with_capacity(input.len());
-    let mut i = 0;
-    while i < bytes.len() {
-        if bytes[i] == b'%' && i + 2 < bytes.len() {
-            let hi = (bytes[i + 1] as char).to_digit(16);
-            let lo = (bytes[i + 2] as char).to_digit(16);
-            if let (Some(hi), Some(lo)) = (hi, lo) {
-                out.push(((hi * 16 + lo) as u8) as char);
-                i += 3;
-                continue;
-            }
-        }
-        out.push(bytes[i] as char);
-        i += 1;
-    }
-    out
 }
 
 fn collect_sfc_compile_diagnostic(
@@ -754,7 +734,9 @@ fn offset_to_line_column(source: &str, offset: usize) -> (u32, u32) {
 
 #[cfg(test)]
 mod tests {
-    use super::{CorsaServer, JsonRpcRequest, ServerConfig};
+    use std::path::{Path, PathBuf};
+
+    use super::{CorsaServer, JsonRpcRequest, ServerConfig, uri_to_path};
     use vize_carton::String;
 
     #[test]
@@ -796,5 +778,47 @@ mod tests {
             server.virtual_uri_for("file:///workspace/src/App.vue"),
             String::from("file:///workspace/src/App.vue.ts")
         );
+    }
+
+    #[test]
+    fn uri_to_path_decodes_multi_byte_utf8_escapes() {
+        // %E3%83%86%E3%82%B9%E3%83%88 is "テスト"; per-byte char pushes
+        // would turn it into mojibake instead of the original segment.
+        assert_eq!(
+            uri_to_path(
+                "file:///Users/foo/%E3%83%86%E3%82%B9%E3%83%88/App.vue",
+                Path::new("/wd")
+            ),
+            Some(PathBuf::from("/Users/foo/テスト/App.vue"))
+        );
+    }
+
+    #[test]
+    fn uri_to_path_decodes_spaces() {
+        assert_eq!(
+            uri_to_path("file:///work/my%20app/App.vue", Path::new("/wd")),
+            Some(PathBuf::from("/work/my app/App.vue"))
+        );
+    }
+
+    #[test]
+    fn uri_to_path_rejects_invalid_utf8_escapes() {
+        assert_eq!(
+            uri_to_path("file:///work/%FF%FE/App.vue", Path::new("/wd")),
+            None
+        );
+    }
+
+    #[test]
+    fn uri_to_path_resolves_relative_paths_against_working_dir() {
+        assert_eq!(
+            uri_to_path("src/App.vue", Path::new("/workspace/project")),
+            Some(PathBuf::from("/workspace/project/src/App.vue"))
+        );
+    }
+
+    #[test]
+    fn uri_to_path_rejects_non_file_schemes() {
+        assert_eq!(uri_to_path("untitled://buffer-1", Path::new("/wd")), None);
     }
 }

--- a/crates/vize_canon/src/file_uri.rs
+++ b/crates/vize_canon/src/file_uri.rs
@@ -88,4 +88,42 @@ mod tests {
             Some(PathBuf::from("/workspace/pages/[[org]]/[name] #1.vue.ts"))
         );
     }
+
+    #[test]
+    fn decodes_multi_byte_utf8_escapes() {
+        // Multi-byte sequences must be assembled from the decoded bytes;
+        // pushing each byte as a `char` would produce mojibake.
+        assert_eq!(
+            file_uri_to_path("file:///Users/foo/%E3%83%86%E3%82%B9%E3%83%88/App.vue"),
+            Some(PathBuf::from("/Users/foo/テスト/App.vue"))
+        );
+    }
+
+    #[test]
+    fn round_trips_non_ascii_paths() {
+        let path = Path::new("/Users/foo/テスト/App.vue");
+        assert_eq!(
+            path_to_file_uri(path),
+            "file:///Users/foo/%E3%83%86%E3%82%B9%E3%83%88/App.vue"
+        );
+        assert_eq!(
+            file_uri_to_path(&path_to_file_uri(path)),
+            Some(path.to_path_buf())
+        );
+    }
+
+    #[test]
+    fn decodes_windows_drive_letter_uris() {
+        // The escaped drive colon must decode; the leading slash is kept
+        // as-is (drive-letter normalization is out of scope here).
+        assert_eq!(
+            file_uri_to_path("file:///c%3A/work/App.vue"),
+            Some(PathBuf::from("/c:/work/App.vue"))
+        );
+    }
+
+    #[test]
+    fn rejects_escape_sequences_that_are_not_valid_utf8() {
+        assert_eq!(file_uri_to_path("file:///work/%FF%FE/App.vue"), None);
+    }
 }


### PR DESCRIPTION
## Summary
- The hand-rolled `percent_decode` in `crates/vize_canon/src/corsa_server.rs` pushed each decoded byte as a `char`. A percent-escape decodes to a single **byte** of a UTF-8 sequence, so casting it to `char` reinterprets it as a Latin-1 code point: `%E3%81%82` (あ) became `Ã£ÂÂ` instead of あ. Any project path or filename with non-ASCII characters broke socket-mode checking.
- Fix: decode escapes into a byte buffer and validate with `from_utf8` — which `crate::file_uri::file_uri_to_path` already does correctly. `corsa_server::uri_to_path` now delegates its `file://` branch to that shared converter and the duplicate `percent_decode` is deleted, so canon has exactly one uri<->path converter.
- Invalid UTF-8 escape sequences now propagate as `None` (matching how `uri_to_path` callers already handle unresolvable URIs: log and skip).

## Consolidation
- `corsa_server.rs`: `uri_to_path` `file://` branch -> `crate::file_uri::file_uri_to_path`; `percent_decode` removed. Plain-path handling (absolute / relative-to-working-dir) unchanged.
- `file_uri.rs`: no behavior change; tests added.

## Test plan
- New unit tests in `file_uri.rs`: Japanese path segments (`file:///Users/foo/%E3%83%86%E3%82%B9%E3%83%88/App.vue` -> `/Users/foo/テスト/App.vue`), non-ASCII round-trip via `path_to_file_uri`, Windows drive-letter URI (`file:///c%3A/work/App.vue` -> `/c:/work/App.vue`, colon decoded, leading slash kept as-is), and invalid-UTF-8 escapes (`%FF%FE` -> `None`).
- New unit tests in `corsa_server.rs` for `uri_to_path`: Japanese segments, spaces (`%20`), invalid-UTF-8 -> `None`, relative paths against working dir, non-`file` scheme rejection.
- Ran `cargo test -p vize_canon --lib`: 321 passed, 0 failed. `cargo clippy -p vize_canon --all-targets`: no warnings in changed files (remaining warnings are pre-existing in untouched files). `cargo fmt` applied.

Part of #1389.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1396"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783751879&installation_id=136613492&pr_number=1396&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1396&signature=78527cdd71d454df96d8001f173e8da70b0f7acbabf6d51f3896740a74aea20e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->