### PR TITLE
perf(atelier): gate type-import collection on TS scripts

### DIFF
--- a/crates/vize_atelier_sfc/src/compile.rs
+++ b/crates/vize_atelier_sfc/src/compile.rs
@@ -76,7 +76,7 @@ fn create_standalone_import_warning() -> SfcError {
     }
 }
 
-fn is_ts_lang(lang: Option<&str>) -> bool {
+pub(crate) fn is_ts_lang(lang: Option<&str>) -> bool {
     matches!(lang, Some("ts" | "tsx"))
 }
 
@@ -681,15 +681,20 @@ fn compile_sfc_inner(
             ctx.collect_types_from(&script.content)
         );
     }
+    let source_is_ts = is_ts_lang(script_setup.lang.as_deref());
     profile!(
         "atelier.sfc.script_context.collect_setup_import_types",
-        ctx.collect_imported_types_from_path(&script_setup_content, source_filename)
+        ctx.collect_imported_types_from_path(&script_setup_content, source_filename, source_is_ts)
     );
     if has_script {
         let script = descriptor.script.as_ref().unwrap();
         profile!(
             "atelier.sfc.script_context.collect_normal_import_types",
-            ctx.collect_imported_types_from_path(&script.content, source_filename)
+            ctx.collect_imported_types_from_path(
+                &script.content,
+                source_filename,
+                is_ts_lang(script.lang.as_deref()),
+            )
         );
     }
     profile!("atelier.sfc.script_context.analyze", ctx.analyze());
@@ -780,11 +785,6 @@ fn compile_sfc_inner(
             ));
         }
     }
-
-    let source_is_ts = script_setup
-        .lang
-        .as_ref()
-        .is_some_and(|l| l == "ts" || l == "tsx");
 
     // Compile template with bindings (if present) to get the render function
     let template_result = if let Some(template) = &descriptor.template {

--- a/crates/vize_atelier_sfc/src/compile_script/inline/compiler.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/inline/compiler.rs
@@ -48,7 +48,7 @@ pub fn compile_script_setup_inline(
         .as_ref()
         .map(|result| result.code.as_str())
         .unwrap_or(content);
-    let ctx = build_script_setup_context(content, normal_script_content, filename);
+    let ctx = build_script_setup_context(content, normal_script_content, filename, source_is_ts);
     let mut result = compile_script_setup_inline_with_context(
         ctx,
         content,
@@ -194,6 +194,7 @@ fn build_script_setup_context(
     content: &str,
     normal_script_content: Option<&str>,
     filename: Option<&str>,
+    source_is_ts: bool,
 ) -> ScriptCompileContext {
     let mut ctx = profile!(
         "atelier.script_inline.context.new",
@@ -213,14 +214,14 @@ fn build_script_setup_context(
     if let Some(path) = filename {
         profile!(
             "atelier.script_inline.collect_setup_import_types",
-            ctx.collect_imported_types_from_path(content, path)
+            ctx.collect_imported_types_from_path(content, path, source_is_ts)
         );
         if let Some(normal_src) = normal_script_content
             && !normal_src.is_empty()
         {
             profile!(
                 "atelier.script_inline.collect_normal_import_types",
-                ctx.collect_imported_types_from_path(normal_src, path)
+                ctx.collect_imported_types_from_path(normal_src, path, source_is_ts)
             );
         }
     }

--- a/crates/vize_atelier_sfc/src/croquis.rs
+++ b/crates/vize_atelier_sfc/src/croquis.rs
@@ -322,6 +322,7 @@ pub fn merge_resolved_props_into_croquis(
     descriptor: &SfcDescriptor<'_>,
     filename: &str,
 ) {
+    use crate::compile::is_ts_lang;
     use crate::script::ScriptCompileContext;
     use crate::types::BindingType;
 
@@ -334,9 +335,17 @@ pub fn merge_resolved_props_into_croquis(
         ctx.collect_types_from(&script.content);
     }
     if !filename.is_empty() {
-        ctx.collect_imported_types_from_path(&script_setup.content, filename);
+        ctx.collect_imported_types_from_path(
+            &script_setup.content,
+            filename,
+            is_ts_lang(script_setup.lang.as_deref()),
+        );
         if let Some(ref script) = descriptor.script {
-            ctx.collect_imported_types_from_path(&script.content, filename);
+            ctx.collect_imported_types_from_path(
+                &script.content,
+                filename,
+                is_ts_lang(script.lang.as_deref()),
+            );
         }
     }
     ctx.analyze();

--- a/crates/vize_atelier_sfc/src/script/context/external_types.rs
+++ b/crates/vize_atelier_sfc/src/script/context/external_types.rs
@@ -176,13 +176,35 @@ const INDEX_CANDIDATES: &[&str] = &[
 ];
 
 impl ScriptCompileContext {
-    pub fn collect_imported_types_from_path(&mut self, source: &str, filename: &str) {
+    /// Walk the script's type-bearing imports/re-exports on disk and merge the
+    /// interfaces/type aliases they declare into this context.
+    ///
+    /// `is_ts` must reflect whether the script block is TypeScript
+    /// (`lang="ts"`/`"tsx"`, computed once per compile at the call site).
+    /// Imported *types* can only be referenced from TypeScript
+    /// (`defineProps<Props>()`), so for plain JS the walk would only burn
+    /// stat/realpath syscalls — the substring pre-check below misfires on JS
+    /// object keys like `type: 'text'` next to any `import`, which is exactly
+    /// what the `is_ts` gate cuts off.
+    pub fn collect_imported_types_from_path(&mut self, source: &str, filename: &str, is_ts: bool) {
+        if !is_ts {
+            return;
+        }
         if !source.contains("type") || (!source.contains("import") && !source.contains("export")) {
             return;
         }
 
-        let owned_base = canonicalize_or_original(PathBuf::from(filename))
-            .unwrap_or_else(|| PathBuf::from(filename));
+        // The root source lives in memory (possibly unsaved editor state), so
+        // parse it directly; only files read from disk go through the cache.
+        let mut root = FileTypeSummary::default();
+        extract_script_summary(source, &mut root);
+        if root.specifiers.is_empty() {
+            // Nothing to resolve — skip base-file canonicalization entirely
+            // (the common case: scripts with only runtime imports).
+            return;
+        }
+
+        let owned_base = canonical_base_file(filename);
         let base_file = owned_base.as_path();
         let Some(base_dir) = base_file.parent() else {
             return;
@@ -192,10 +214,6 @@ impl ScriptCompileContext {
         }
 
         let mut visited = FxHashSet::default();
-        // The root source lives in memory (possibly unsaved editor state), so
-        // parse it directly; only files read from disk go through the cache.
-        let mut root = FileTypeSummary::default();
-        extract_script_summary(source, &mut root);
         for specifier in &root.specifiers {
             self.collect_types_from_specifier(specifier, base_file, &mut visited);
         }
@@ -260,6 +278,47 @@ impl ScriptCompileContext {
                 .entry(name.clone())
                 .or_insert_with(|| body.clone());
         }
+    }
+}
+
+/// Base-file canonicalization cache: `(cwd, filename) -> canonical path`.
+/// The same SFC filename is canonicalized by several passes per compile
+/// (script setup + normal script, croquis prop merge, inline compile) and
+/// `canonicalize` walks every path component; a hit is revalidated with a
+/// single `is_file` check so a deleted file falls back to a fresh
+/// canonicalization, and failures are never cached so files created later
+/// are picked up.
+static BASE_CANON_CACHE: LazyLock<RwLock<FxHashMap<(PathBuf, String), PathBuf>>> =
+    LazyLock::new(|| RwLock::new(FxHashMap::default()));
+
+/// Canonicalize the compiled file's own path, falling back to the original
+/// path for virtual filenames (in-memory compiles) that don't exist on disk.
+fn canonical_base_file(filename: &str) -> PathBuf {
+    let path = PathBuf::from(filename);
+    // The canonical form of a relative path depends on the process cwd, so
+    // the cache key includes it; absolute paths (the batch-compile case) use
+    // an empty component and never pay the `getcwd` call.
+    let cwd = if path.is_absolute() {
+        PathBuf::new()
+    } else {
+        std::env::current_dir().unwrap_or_default()
+    };
+    let key = (cwd, filename.to_compact_string());
+    if let Ok(cache) = BASE_CANON_CACHE.read()
+        && let Some(canonical) = cache.get(&key)
+        && canonical.is_file()
+    {
+        return canonical.clone();
+    }
+
+    match path.canonicalize() {
+        Ok(canonical) => {
+            if let Ok(mut cache) = BASE_CANON_CACHE.write() {
+                cache.insert(key, canonical.clone());
+            }
+            canonical
+        }
+        Err(_) => path,
     }
 }
 
@@ -629,7 +688,7 @@ const props = defineProps<SelectProps>();
 "#;
 
         let mut ctx = super::ScriptCompileContext::new(source);
-        ctx.collect_imported_types_from_path(source, current.to_string_lossy().as_ref());
+        ctx.collect_imported_types_from_path(source, current.to_string_lossy().as_ref(), true);
         ctx.analyze();
 
         assert!(ctx.interfaces.contains_key("RootProps"));
@@ -696,7 +755,7 @@ const props = defineProps<ParentProps>();
 "#;
 
         let mut ctx = super::ScriptCompileContext::new(source);
-        ctx.collect_imported_types_from_path(source, parent.to_string_lossy().as_ref());
+        ctx.collect_imported_types_from_path(source, parent.to_string_lossy().as_ref(), true);
         ctx.analyze();
 
         assert!(ctx.interfaces.contains_key("BaseProps"));
@@ -747,7 +806,7 @@ const props = defineProps<ParentProps>();
 "#;
 
         let mut ctx = super::ScriptCompileContext::new(source);
-        ctx.collect_imported_types_from_path(source, parent.to_string_lossy().as_ref());
+        ctx.collect_imported_types_from_path(source, parent.to_string_lossy().as_ref(), true);
         ctx.analyze();
 
         assert!(ctx.interfaces.contains_key("ContentProps"));
@@ -759,6 +818,43 @@ const props = defineProps<ParentProps>();
             ctx.bindings.bindings.get("asChild"),
             Some(&crate::types::BindingType::Props)
         );
+
+        let _ = std::fs::remove_dir_all(project);
+    }
+
+    #[test]
+    fn skips_type_import_collection_for_plain_js_scripts() {
+        // Regression: the substring pre-check matches plain-JS object keys
+        // like `type: 'text'` next to any `import`/`export`, which used to
+        // fire the whole stat/realpath resolution walk for every generated
+        // JS script. Non-TS blocks must skip collection entirely.
+        let project = temp_project_dir("plain-js-gate");
+        let components = project.join("src/components");
+        std::fs::create_dir_all(&components).unwrap();
+        std::fs::write(
+            components.join("shared.ts"),
+            "export interface InjectedProps { injected?: boolean }",
+        )
+        .unwrap();
+
+        let current = components.join("Field.vue");
+        let source = r#"
+import { reactive } from 'vue'
+export * from './shared'
+
+const field = reactive({ type: 'text', name: 'email' })
+"#;
+
+        let mut ctx = super::ScriptCompileContext::new(source);
+        ctx.collect_imported_types_from_path(source, current.to_string_lossy().as_ref(), false);
+        assert!(ctx.interfaces.is_empty());
+        assert!(ctx.type_aliases.is_empty());
+
+        // Sanity: the same source *would* pull the interface in for a TS
+        // block, so the assertions above genuinely exercise the gate.
+        let mut ts_ctx = super::ScriptCompileContext::new(source);
+        ts_ctx.collect_imported_types_from_path(source, current.to_string_lossy().as_ref(), true);
+        assert!(ts_ctx.interfaces.contains_key("InjectedProps"));
 
         let _ = std::fs::remove_dir_all(project);
     }
@@ -803,7 +899,7 @@ const props = defineProps<ButtonProps>();
 "#;
 
         let mut ctx = super::ScriptCompileContext::new(source);
-        ctx.collect_imported_types_from_path(source, parent.to_string_lossy().as_ref());
+        ctx.collect_imported_types_from_path(source, parent.to_string_lossy().as_ref(), true);
         ctx.analyze();
 
         assert!(ctx.interfaces.contains_key("LinkProps"));

--- a/crates/vize_canon/src/batch/virtual_project/vue_codegen.rs
+++ b/crates/vize_canon/src/batch/virtual_project/vue_codegen.rs
@@ -235,9 +235,17 @@ fn augment_type_based_props_from_script_context(
         && !script.content.is_empty()
     {
         ctx.collect_types_from(&script.content);
-        ctx.collect_imported_types_from_path(&script.content, path_string.as_ref());
+        ctx.collect_imported_types_from_path(
+            &script.content,
+            path_string.as_ref(),
+            matches!(script.lang.as_deref(), Some("ts" | "tsx")),
+        );
     }
-    ctx.collect_imported_types_from_path(&script_setup.content, path_string.as_ref());
+    ctx.collect_imported_types_from_path(
+        &script_setup.content,
+        path_string.as_ref(),
+        matches!(script_setup.lang.as_deref(), Some("ts" | "tsx")),
+    );
     ctx.analyze();
 
     let known_props = known_type_based_prop_names(croquis, &script_setup.content);


### PR DESCRIPTION
## Summary

Part of #1387.

A syscall profile of the 15k-SFC benchmark showed **37.2% of single-threaded busy compute** spent in `stat`/`getcwd`/`realpath` fired by `collect_imported_types_from_path`. The function guarded itself with a substring pre-check — `source.contains("type") && (contains("import") || contains("export"))` — which misfires on plain-JS object keys like `type: 'text'` next to any `import`. On that bench, ~2,500 generated JS files hit this path on every compile pass, paying base-file canonicalization (a full `realpath` component walk) plus resolution probing for nothing: imported *types* can only ever be referenced from TypeScript (`defineProps<Props>()`).

## What changed

- `ScriptCompileContext::collect_imported_types_from_path` now takes an `is_ts: bool` and returns immediately (before the substring pre-check) when the script block is not TypeScript. The flag is derived from the block's `lang` attribute (`ts`/`tsx`) once per compile at each call site — never per import — so the gate is a single predictable branch (zero-cost rule).
- All call sites pass their already-computed lang: `compile.rs` (script setup + normal script, each gated on its own block's lang), `croquis.rs` (`merge_resolved_props_into_croquis`), the inline script compiler (`build_script_setup_context`), and `vize_canon`'s virtual-project codegen.
- **Lazy canonicalization** (secondary win, small enough to include here): the compiled file's own path is now canonicalized only after the in-memory parse finds at least one type-bearing specifier to resolve — TS scripts with only runtime imports (the common case) no longer touch the filesystem at all — and goes through a new `(cwd, filename) -> canonical path` cache (`BASE_CANON_CACHE`), since the same SFC is canonicalized by several passes per compile (script setup + normal script, croquis prop merge, inline compile). Hits are revalidated with a single `is_file` check and failures are never cached, matching the existing `RESOLVE_CACHE` semantics.

## Why behavior is unchanged

The collection's only outputs are `ctx.interfaces` / `ctx.type_aliases`, consumed exclusively to resolve type references in `defineProps<T>()` / `withDefaults(defineProps<T>(), ...)` / emits type args — TypeScript-only syntax that cannot occur in a valid plain-JS script block. I traced every consumer (props `ast_resolve`/`text_resolve`/`runtime_type`/`validation`, croquis prop merge, canon's `augment_type_based_props_from_script_context`); none can observe a difference for JS inputs, so the entire collection is gated rather than just the fs-touching part. The lazy-canonicalization reorder is also output-equivalent: the base path is only ever used to resolve specifiers, and the early returns (no parent dir / empty parent) still apply before any specifier is followed.

## Test plan

- New regression test `skips_type_import_collection_for_plain_js_scripts`: a plain-JS-style script with `type: 'text'` object keys plus import/re-export statements produces empty `interfaces`/`type_aliases` when gated as non-TS, with a sanity assertion that the identical source *does* collect when flagged TS (so the test genuinely exercises the gate). No test-only instrumentation added to production code.
- `cargo test -p vize_atelier_sfc`: 518 passed (includes the crate's snapshot/fixture tests, JS and TS).
- `cargo test -p vize_canon`: 312 passed.
- `cargo clippy --all-targets` for both crates: warning count identical to `main` baseline (no new lints); `cargo fmt` applied; `cargo check --workspace` clean.
- The PR benchmark workflow on Actions will quantify the win on the 15k-SFC bench.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1397"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783752322&installation_id=136613492&pr_number=1397&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1397&signature=a1b2cd4717490cc2bfc9bc5d5ec57f759e215de8fa1f83c4d4b45b8ee878d58e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->