### PR TITLE
fix(check/nuxt): skip fallback any-stubs when .nuxt generated types are present

### DIFF
--- a/crates/vize/src/commands/check/nuxt/fallback.rs
+++ b/crates/vize/src/commands/check/nuxt/fallback.rs
@@ -9,9 +9,46 @@ use super::stubs::{
     tracked_read_to_string,
 };
 
-pub(super) fn collect_fallback_stubs(stubs: &mut Vec<String>, seen_names: &mut FxHashSet<String>) {
+pub(super) fn collect_fallback_stubs(
+    stubs: &mut Vec<String>,
+    seen_names: &mut FxHashSet<String>,
+    has_generated_imports: bool,
+) {
     let mut fallback_names = FxHashSet::default();
-    for stub in fallback_stub_strings() {
+    push_fallback_stub_group(
+        fallback_type_alias_stubs(),
+        stubs,
+        seen_names,
+        &mut fallback_names,
+    );
+    // The hardcoded `any` ladder silently weakens checking, so only inject it
+    // when the project has no generated `.nuxt` import manifest to rely on.
+    if !has_generated_imports {
+        push_fallback_stub_group(
+            fallback_value_stubs(),
+            stubs,
+            seen_names,
+            &mut fallback_names,
+        );
+    }
+    // Built-in component consts stay name-deduped against the generated
+    // `GlobalComponents` members: `.nuxt/components.d.ts` may omit built-ins,
+    // and dropping these would newly error every `<NuxtLink>` reference.
+    push_fallback_stub_group(
+        fallback_component_stubs(),
+        stubs,
+        seen_names,
+        &mut fallback_names,
+    );
+}
+
+fn push_fallback_stub_group(
+    group: Vec<String>,
+    stubs: &mut Vec<String>,
+    seen_names: &mut FxHashSet<String>,
+    fallback_names: &mut FxHashSet<String>,
+) {
+    for stub in group {
         if let Some(name) = declared_name(&stub) {
             let name = name.to_compact_string();
             if fallback_names.contains(name.as_str()) {
@@ -94,7 +131,18 @@ pub(super) fn nuxt_config_source(cwd: &Path) -> String {
     String::default()
 }
 
+#[cfg(test)]
 pub(super) fn fallback_stub_strings() -> Vec<String> {
+    let mut stubs = fallback_type_alias_stubs();
+    stubs.extend(fallback_value_stubs());
+    stubs.extend(fallback_component_stubs());
+    stubs
+}
+
+/// Type aliases for auto-imported Vue types. Generated `.nuxt` artifacts are
+/// only mined for `declare global` consts and `GlobalComponents` members, so
+/// these aliases have no generated counterpart and are always injected.
+fn fallback_type_alias_stubs() -> Vec<String> {
     vec![
         "type Composer = any;".into(),
         "type Ref<T = any> = import('vue').Ref<T>;".into(),
@@ -106,6 +154,14 @@ pub(super) fn fallback_stub_strings() -> Vec<String> {
         "type MaybeRef<T = any> = import('vue').MaybeRef<T>;".into(),
         "type MaybeRefOrGetter<T = any> = import('vue').MaybeRefOrGetter<T>;".into(),
         "type Component = import('vue').Component;".into(),
+    ]
+}
+
+/// Hardcoded `any`-typed value stubs. Skipped whenever the project ships a
+/// generated `.nuxt` import manifest, which covers all of these names with
+/// real `typeof import(...)` types.
+fn fallback_value_stubs() -> Vec<String> {
+    vec![
         "declare function ref<T>(value: T): Ref<UnwrapRef<T>>;".into(),
         "declare function ref<T = any>(): Ref<T | undefined>;".into(),
         "declare function computed<T>(getter: () => T): ComputedRef<T>;".into(),
@@ -192,6 +248,14 @@ pub(super) fn fallback_stub_strings() -> Vec<String> {
         "declare function useRequestFetch(): typeof globalThis.fetch;".into(),
         "declare function useResponseHeaders(headers?: Record<string, string>): any;".into(),
         "declare function $fetch<T = any>(...args: any[]): Promise<T>;".into(),
+    ]
+}
+
+/// Nuxt built-in component consts. Always injected (name-deduped against the
+/// generated `GlobalComponents` members) because `.nuxt/components.d.ts` may
+/// legitimately omit built-ins.
+fn fallback_component_stubs() -> Vec<String> {
+    vec![
         "declare const NuxtLink: any;".into(),
         "declare const NuxtPage: any;".into(),
         "declare const NuxtLayout: any;".into(),

--- a/crates/vize/src/commands/check/nuxt/mod.rs
+++ b/crates/vize/src/commands/check/nuxt/mod.rs
@@ -62,7 +62,7 @@ pub(in crate::commands::check) fn detect_nuxt_auto_imports(
         &mut external_template_bindings,
     );
     collect_plugin_injection_stubs(cwd, &mut collected, &mut seen_names);
-    collect_fallback_stubs(&mut collected, &mut seen_names);
+    collect_fallback_stubs(&mut collected, &mut seen_names, has_generated_imports);
     if !has_generated_imports {
         collect_module_fallback_stubs(cwd, &mut collected, &mut seen_names);
         collect_source_auto_import_stubs(cwd, &mut collected, &mut seen_names);

--- a/crates/vize/src/commands/check/nuxt/tests.rs
+++ b/crates/vize/src/commands/check/nuxt/tests.rs
@@ -383,6 +383,91 @@ export {}
 }
 
 #[test]
+fn skips_fallback_any_stubs_when_generated_import_manifest_exists() {
+    let project_root = unique_case_dir("nuxt-no-fallback-with-generated");
+    let _ = std::fs::remove_dir_all(&project_root);
+    std::fs::create_dir_all(project_root.join(".nuxt/types")).unwrap();
+    std::fs::write(project_root.join("nuxt.config.ts"), "export default {}").unwrap();
+    std::fs::write(
+        project_root.join(".nuxt/types/imports.d.ts"),
+        r#"declare global {
+  const useRouter: typeof import('vue-router')['useRouter']
+  const navigateTo: typeof import('../../node_modules/nuxt/dist/app/composables/router')['navigateTo']
+}
+export {}
+"#,
+    )
+    .unwrap();
+
+    let mut options = VirtualTsOptions::default();
+    let _ = detect_nuxt_auto_imports(&mut options, &project_root);
+
+    assert!(
+        options
+            .auto_import_stubs
+            .iter()
+            .any(|stub| stub.contains("declare const useRouter: typeof import(")),
+        "expected generated useRouter stub, got: {:#?}",
+        options.auto_import_stubs
+    );
+    let any_ladder = [
+        "declare function useRouter(): any;",
+        "declare function useRoute(name?: string): any;",
+        "declare function navigateTo(to: string | any, options?: any): any;",
+        "declare function useNuxtApp(): any;",
+        "declare function watch(source: any, cb: (...args: any[]) => any, options?: any): any;",
+    ];
+    for fallback in any_ladder {
+        assert!(
+            !options
+                .auto_import_stubs
+                .iter()
+                .any(|stub| stub == fallback),
+            "fallback any-stub {fallback:?} should not be injected when .nuxt generated types exist: {:#?}",
+            options.auto_import_stubs
+        );
+    }
+    assert!(
+        options
+            .auto_import_stubs
+            .iter()
+            .any(|stub| stub == "type Ref<T = any> = import('vue').Ref<T>;"),
+        "auto-imported type aliases should still be injected: {:#?}",
+        options.auto_import_stubs
+    );
+    assert!(
+        options
+            .auto_import_stubs
+            .iter()
+            .any(|stub| stub == "declare const NuxtLink: any;"),
+        "built-in component stubs should still be injected: {:#?}",
+        options.auto_import_stubs
+    );
+
+    // Without generated artifacts the any-ladder remains the last resort.
+    let fallback_root = unique_case_dir("nuxt-fallback-without-generated");
+    let _ = std::fs::remove_dir_all(&fallback_root);
+    std::fs::create_dir_all(&fallback_root).unwrap();
+    std::fs::write(fallback_root.join("nuxt.config.ts"), "export default {}").unwrap();
+
+    let mut fallback_options = VirtualTsOptions::default();
+    let _ = detect_nuxt_auto_imports(&mut fallback_options, &fallback_root);
+    for fallback in any_ladder {
+        assert!(
+            fallback_options
+                .auto_import_stubs
+                .iter()
+                .any(|stub| stub == fallback),
+            "fallback any-stub {fallback:?} should be injected without .nuxt generated types: {:#?}",
+            fallback_options.auto_import_stubs
+        );
+    }
+
+    let _ = std::fs::remove_dir_all(&project_root);
+    let _ = std::fs::remove_dir_all(&fallback_root);
+}
+
+#[test]
 fn detects_module_fallbacks_from_nuxt_config() {
     let project_root = unique_case_dir("nuxt-module-fallbacks");
     let _ = std::fs::remove_dir_all(&project_root);


### PR DESCRIPTION
## Summary
`detect_nuxt_auto_imports` called `collect_fallback_stubs` unconditionally, so the hardcoded ~100-entry `any`-stub ladder in `nuxt/fallback.rs` was injected even when the project's own `.nuxt` generated types had been found. This PR gates the `any`-typed value stubs on the absence of a generated `.nuxt` import manifest, using the same `has_generated_imports` signal that already gates the module/source-scan fallbacks.

## The silent-weakening problem
With a prepared `.nuxt`, every auto-importable composable/function appears in the generated import manifest (`.nuxt/types/imports.d.ts` or `.nuxt/imports.d.ts`) with a real `typeof import(...)` type. Injecting the fallback ladder on top meant any name the manifest legitimately did **not** export (a composable that was removed, renamed, or never existed) silently resolved to `any` instead of producing the same error `nuxi typecheck`/vue-tsc would report. Checking less is not faster checking — the stubs made `vize check` pass code that the project's real types reject.

## Chosen granularity (per-category) and why
The fallback list is split into three categories with different gating, picked by checking which diagnostics would *newly* appear in each case:

1. **Vue type aliases** (`type Ref<T> = import('vue').Ref<T>`, `type ComputedRef<T> = ...`, ...) — **always injected.** The `.nuxt` parsers only mine `declare global` consts and `GlobalComponents` interface members, never type aliases, so these names have no generated counterpart. Skipping them would flood prepared projects with false `Cannot find name 'Ref'` errors for auto-imported types. They are also (almost all) precise re-exports, not `any`.
2. **`any`-typed value/function stubs** (`useRouter(): any`, `navigateTo`, `useFetch`, lifecycle hooks, ...) — **skipped when a generated import manifest exists.** This is the category that silently weakens checking, and it is exactly the category the manifest covers: a name missing from a real manifest is genuinely not auto-importable, so the diagnostics that newly appear are true positives matching `nuxi typecheck`.
3. **Built-in component consts** (`NuxtLink: any`, `ClientOnly: any`, ...) — **unchanged** (still injected, name-deduped against generated `GlobalComponents`). `.nuxt/components.d.ts` can legitimately omit built-ins (the existing CLI test `check_json_reports_nuxt_auto_imports_and_preserves_builtin_components` pins a fixture whose `components.d.ts` lists only project components), and dropping the category would newly error every `<NuxtLink>`/`<ClientOnly>` template reference.

Name-level dedup against generated stubs is preserved, so when the fallback ladder *is* used (no `.nuxt`, tracked by the umbrella issue) behavior is byte-identical to before.

## Test plan
- New unit test `skips_fallback_any_stubs_when_generated_import_manifest_exists`: with `.nuxt/types/imports.d.ts` present, asserts the `any` ladder (`useRouter`, `useRoute`, `navigateTo`, `useNuxtApp`, `watch`) is not injected while generated stubs, type aliases, and built-in component stubs still are; and asserts the ladder is still injected when `.nuxt` is absent.
- `cargo test -p vize` — all green (114 lib + 40 check_cli integration tests, run with a real corsa/tsgo binary), including the partial-coverage guard `check_json_reports_nuxt_auto_imports_and_preserves_builtin_components`.
- Real-world Nuxt snapshot check (`tests/snapshots/check/elk.ts`) run against this branch's binary: output identical to an unmodified baseline binary (the fixtures ship without `.nuxt`, so the unchanged fallback path is exercised; the one pre-existing snapshot drift reproduces identically on baseline).
- `cargo clippy -p vize --all-targets`: warning count unchanged vs baseline (no new warnings); `cargo fmt -- --check` clean.

Part of #1390.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1398"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783753479&installation_id=136613492&pr_number=1398&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1398&signature=d6b3387f6902335a9c3024942192006a6442b0ab3ff44abe4783e778d1241693"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->