### PR TITLE
feat(croquis): extract class component members as template bindings

### DIFF
--- a/crates/vize_croquis/src/croquis.rs
+++ b/crates/vize_croquis/src/croquis.rs
@@ -35,8 +35,9 @@ mod vir;
 
 // Re-export all public croquis data types from their focused modules.
 pub use bindings::{
-    BindingMetadata, COMPILER_MACRO_NAMES, ImportStatementInfo, InvalidExport, InvalidExportKind,
-    ReExportInfo, TypeExport, TypeExportKind, UndefinedRef, UnusedTemplateVar, UnusedVarContext,
+    BindingMetadata, COMPILER_MACRO_NAMES, ComponentShape, ImportStatementInfo, InvalidExport,
+    InvalidExportKind, ReExportInfo, TypeExport, TypeExportKind, UndefinedRef, UnusedTemplateVar,
+    UnusedVarContext,
 };
 pub use model::{AnalysisStats, CroquisStats};
 pub use template::{
@@ -89,6 +90,12 @@ pub struct Croquis {
 
     /// Script binding metadata (for template access)
     pub bindings: BindingMetadata,
+
+    /// API shape of the component's default export.
+    ///
+    /// `ClassApi` when the default export is a class (vue-class-component /
+    /// vue-property-decorator); `Unspecified` otherwise.
+    pub component_shape: ComponentShape,
 
     /// Template-level metadata (root count, $attrs usage, etc.)
     pub template_info: TemplateInfo,

--- a/crates/vize_croquis/src/croquis/bindings.rs
+++ b/crates/vize_croquis/src/croquis/bindings.rs
@@ -102,6 +102,25 @@ impl BindingMetadata {
     }
 }
 
+/// API shape of the component's default export.
+///
+/// Recorded by script analysis so downstream consumers (linter, virtual TS,
+/// LSP) can tell how the component is authored without re-walking the AST.
+/// Purely additive metadata: `Unspecified` preserves pre-existing behavior
+/// for every non-class component.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[repr(u8)]
+pub enum ComponentShape {
+    /// No specific shape detected (script setup, options object, or no
+    /// default export).
+    #[default]
+    Unspecified = 0,
+    /// The default export is a class (vue-class-component /
+    /// vue-property-decorator style), optionally decorated with
+    /// `@Component` / `@Options`.
+    ClassApi = 1,
+}
+
 /// An undefined reference in template
 #[derive(Debug, Clone)]
 pub struct UndefinedRef {

--- a/crates/vize_croquis/src/drawer/tests/snapshots/vize_croquis__drawer__tests__script__drawer_script_bindings.snap
+++ b/crates/vize_croquis/src/drawer/tests/snapshots/vize_croquis__drawer__tests__script__drawer_script_bindings.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/vize_croquis/src/drawer/tests/script.rs
-assertion_line: 19
 expression: summary
 ---
 Croquis {
@@ -1270,6 +1269,7 @@ Croquis {
         is_script_setup: true,
         props_aliases: {},
     },
+    component_shape: Unspecified,
     template_info: TemplateInfo {
         root_element_count: 0,
         uses_attrs: false,

--- a/crates/vize_croquis/src/lib.rs
+++ b/crates/vize_croquis/src/lib.rs
@@ -82,7 +82,7 @@ pub use symbol::{Symbol, SymbolFlags, SymbolId, SymbolTable};
 // Re-export analysis types
 pub use analyzer::{Analyzer, AnalyzerOptions};
 pub use croquis::{
-    AnalysisStats, BindingMetadata, COMPILER_MACRO_NAMES, Croquis, CroquisStats,
+    AnalysisStats, BindingMetadata, COMPILER_MACRO_NAMES, ComponentShape, Croquis, CroquisStats,
     ImportStatementInfo, InvalidExport, InvalidExportKind, ReExportInfo, TemplateExpression,
     TemplateExpressionKind, TypeExport, TypeExportKind, UndefinedRef, UnusedTemplateVar,
     UnusedVarContext,

--- a/crates/vize_croquis/src/script_parser/process/class_component.rs
+++ b/crates/vize_croquis/src/script_parser/process/class_component.rs
@@ -1,0 +1,176 @@
+//! Class component (vue-class-component / vue-property-decorator) extraction.
+//!
+//! In an SFC the default export *is* the component, so a class default export
+//! is unambiguous: it is a class component. Detection is purely shape-based
+//! (a match arm on the export-default AST node) — no configuration flag, and
+//! zero added work for non-class components.
+//!
+//! Class members map onto the same binding model the Options API produces:
+//!
+//! | Class member                  | Binding type | Options API equivalent |
+//! |-------------------------------|--------------|------------------------|
+//! | property field / `accessor`   | `Data`       | `data()`               |
+//! | method                        | `Options`    | `methods`              |
+//! | `get` / `set` accessor        | `Options`    | `computed`             |
+//!
+//! ## Visibility
+//!
+//! TS accessibility modifiers (`private` / `protected`) are erased at runtime,
+//! and the canonical vue-class-component scaffold relies on that (e.g. the Vue
+//! CLI template renders `{{ msg }}` from `@Prop() private msg!: string`), so
+//! TS-private members are still extracted as template bindings: the template
+//! *can* resolve them at runtime. Type-level visibility enforcement is the
+//! virtual-TS checker's job once canon bridges the class instance type.
+//! ECMAScript hard-private members (`#name`) are genuinely unreachable outside
+//! the class body and are skipped, along with `static` members (not on the
+//! instance), `declare` fields, computed keys, and the constructor.
+//!
+//! Member-level decorator semantics (`@Prop`, `@Emit`, `@Watch`, ...) are not
+//! interpreted yet; fields keep the `Data` mapping so templates resolve the
+//! identifiers either way. The `@Component({ ... })` / `@Options({ ... })`
+//! decorator argument is a regular options object and is fed through the
+//! existing Options API collectors (so `components:` registrations and inline
+//! `data`/`computed`/`methods` behave identically to an options component).
+
+use oxc_ast::ast::{
+    Argument, Class, ClassElement, ExportDefaultDeclarationKind, Expression, MethodDefinitionKind,
+    ObjectExpression, PropertyKey,
+};
+use oxc_span::GetSpan;
+
+use vize_carton::FxHashMap;
+use vize_relief::BindingType;
+
+use super::super::ScriptParseResult;
+use super::options_api::{
+    add_template_binding, collect_component_registrations_from_options,
+    collect_options_api_template_bindings_from_options, normalize_template_binding_name,
+    property_key_name,
+};
+use crate::croquis::ComponentShape;
+
+/// Return the class when the default export is a class declaration or a
+/// (possibly TS-wrapped / parenthesized) class expression.
+pub(super) fn class_from_export<'a>(
+    declaration: &'a ExportDefaultDeclarationKind<'a>,
+) -> Option<&'a Class<'a>> {
+    match declaration {
+        ExportDefaultDeclarationKind::ClassDeclaration(class) => Some(class.as_ref()),
+        ExportDefaultDeclarationKind::ParenthesizedExpression(parenthesized) => {
+            class_from_expression(&parenthesized.expression)
+        }
+        ExportDefaultDeclarationKind::TSAsExpression(ts_as) => {
+            class_from_expression(&ts_as.expression)
+        }
+        ExportDefaultDeclarationKind::TSSatisfiesExpression(ts_satisfies) => {
+            class_from_expression(&ts_satisfies.expression)
+        }
+        ExportDefaultDeclarationKind::TSNonNullExpression(ts_non_null) => {
+            class_from_expression(&ts_non_null.expression)
+        }
+        _ => None,
+    }
+}
+
+fn class_from_expression<'a>(expression: &'a Expression<'a>) -> Option<&'a Class<'a>> {
+    match expression {
+        Expression::ClassExpression(class) => Some(class.as_ref()),
+        Expression::ParenthesizedExpression(parenthesized) => {
+            class_from_expression(&parenthesized.expression)
+        }
+        Expression::TSAsExpression(ts_as) => class_from_expression(&ts_as.expression),
+        Expression::TSSatisfiesExpression(ts_satisfies) => {
+            class_from_expression(&ts_satisfies.expression)
+        }
+        Expression::TSNonNullExpression(ts_non_null) => {
+            class_from_expression(&ts_non_null.expression)
+        }
+        _ => None,
+    }
+}
+
+/// Extract template bindings and component registrations from a class
+/// component's members and its `@Component` / `@Options` decorator argument.
+pub(super) fn collect_class_component_metadata<'a>(
+    result: &mut ScriptParseResult,
+    class: &'a Class<'a>,
+    object_bindings: &FxHashMap<&'a str, &'a ObjectExpression<'a>>,
+) {
+    result.component_shape = ComponentShape::ClassApi;
+
+    // `@Component({ ... })` / `@Options({ ... })` take a regular options
+    // object; reuse the Options API collectors so it behaves identically to
+    // an options component.
+    for decorator in &class.decorators {
+        let Some(options) = decorator_options_object(&decorator.expression) else {
+            continue;
+        };
+        collect_component_registrations_from_options(result, options, object_bindings);
+        collect_options_api_template_bindings_from_options(result, options, object_bindings);
+    }
+
+    for element in &class.body.body {
+        match element {
+            ClassElement::MethodDefinition(method) => {
+                if method.r#static
+                    || method.computed
+                    || matches!(method.kind, MethodDefinitionKind::Constructor)
+                {
+                    continue;
+                }
+                // Methods map to `methods`, get/set accessors to `computed`;
+                // both resolve as `Options` bindings.
+                add_class_member_binding(result, &method.key, BindingType::Options);
+            }
+            ClassElement::PropertyDefinition(property) => {
+                if property.r#static || property.computed || property.declare {
+                    continue;
+                }
+                add_class_member_binding(result, &property.key, BindingType::Data);
+            }
+            ClassElement::AccessorProperty(accessor) => {
+                if accessor.r#static || accessor.computed {
+                    continue;
+                }
+                add_class_member_binding(result, &accessor.key, BindingType::Data);
+            }
+            ClassElement::StaticBlock(_) | ClassElement::TSIndexSignature(_) => {}
+        }
+    }
+}
+
+/// Options object passed to a `@Component(...)` / `@Options(...)` decorator.
+fn decorator_options_object<'a>(
+    expression: &'a Expression<'a>,
+) -> Option<&'a ObjectExpression<'a>> {
+    let Expression::CallExpression(call) = expression else {
+        return None;
+    };
+    let Expression::Identifier(callee) = &call.callee else {
+        return None;
+    };
+    if !matches!(callee.name.as_str(), "Component" | "Options") {
+        return None;
+    }
+    let Some(Argument::ObjectExpression(object)) = call.arguments.first() else {
+        return None;
+    };
+    Some(object.as_ref())
+}
+
+fn add_class_member_binding(
+    result: &mut ScriptParseResult,
+    key: &PropertyKey<'_>,
+    binding_type: BindingType,
+) {
+    // `property_key_name` only resolves static identifier / string-literal
+    // keys, so ECMAScript hard-private members (`#name`) drop out here.
+    let Some(raw_name) = property_key_name(key) else {
+        return;
+    };
+    let Some(name) = normalize_template_binding_name(raw_name) else {
+        return;
+    };
+    let span = key.span();
+    add_template_binding(result, name.as_str(), binding_type, span.start, span.end);
+}

--- a/crates/vize_croquis/src/script_parser/process/mod.rs
+++ b/crates/vize_croquis/src/script_parser/process/mod.rs
@@ -9,10 +9,12 @@
 //! This module is split into:
 //! - `statements`: Top-level statement and declaration processing
 //! - `options_api`: Options API component metadata collection
+//! - `class_component`: Class component (vue-class-component) extraction
 //! - `macros`: Variable declarator processing (macros, reactivity, inject)
 //! - `bindings`: Binding pattern helpers and expression classification
 
 mod bindings;
+mod class_component;
 mod macros;
 mod options_api;
 mod statements;

--- a/crates/vize_croquis/src/script_parser/process/options_api.rs
+++ b/crates/vize_croquis/src/script_parser/process/options_api.rs
@@ -40,6 +40,19 @@ pub(in crate::script_parser) fn collect_options_api_component_metadata(
             continue;
         };
 
+        // Class components (vue-class-component / vue-property-decorator):
+        // in an SFC the default export *is* the component, so a class default
+        // export is unambiguous. Auto-detected by AST shape — no flag, and
+        // this arm never executes for non-class components.
+        if let Some(class) = super::class_component::class_from_export(&export.declaration) {
+            super::class_component::collect_class_component_metadata(
+                result,
+                class,
+                &object_bindings,
+            );
+            continue;
+        }
+
         let Some(options) =
             component_options_from_export(&export.declaration, &component_option_bindings)
         else {
@@ -121,7 +134,7 @@ fn collect_component_options_bindings<'a>(
     }
 }
 
-fn collect_component_registrations_from_options<'a>(
+pub(super) fn collect_component_registrations_from_options<'a>(
     result: &mut ScriptParseResult,
     options: &'a ObjectExpression<'a>,
     object_bindings: &FxHashMap<&'a str, &'a ObjectExpression<'a>>,
@@ -140,7 +153,7 @@ fn collect_component_registrations_from_options<'a>(
     );
 }
 
-fn collect_options_api_template_bindings_from_options<'a>(
+pub(super) fn collect_options_api_template_bindings_from_options<'a>(
     result: &mut ScriptParseResult,
     options: &'a ObjectExpression<'a>,
     object_bindings: &FxHashMap<&'a str, &'a ObjectExpression<'a>>,
@@ -340,7 +353,7 @@ fn collect_object_property_bindings(
     }
 }
 
-fn add_template_binding(
+pub(super) fn add_template_binding(
     result: &mut ScriptParseResult,
     name: &str,
     binding_type: BindingType,
@@ -358,7 +371,7 @@ fn add_template_binding(
     );
 }
 
-fn normalize_template_binding_name(name: &str) -> Option<CompactString> {
+pub(super) fn normalize_template_binding_name(name: &str) -> Option<CompactString> {
     if is_valid_template_binding_name(name) {
         return Some(CompactString::new(name));
     }
@@ -706,7 +719,7 @@ fn option_expression_property<'a>(
     })
 }
 
-fn property_key_name<'a>(key: &'a PropertyKey<'a>) -> Option<&'a str> {
+pub(super) fn property_key_name<'a>(key: &'a PropertyKey<'a>) -> Option<&'a str> {
     match key {
         PropertyKey::StaticIdentifier(identifier) => Some(identifier.name.as_str()),
         PropertyKey::StringLiteral(string) => Some(string.value.as_str()),

--- a/crates/vize_croquis/src/script_parser/result.rs
+++ b/crates/vize_croquis/src/script_parser/result.rs
@@ -4,7 +4,7 @@
 //! [`ScriptParserOptions`], and the small metadata enums/structs that back
 //! plain-value and runtime-object tracking.
 
-use crate::croquis::{BindingMetadata, ComponentRegistration, Croquis};
+use crate::croquis::{BindingMetadata, ComponentRegistration, ComponentShape, Croquis};
 use crate::croquis::{ImportStatementInfo, InvalidExport, ReExportInfo, TypeExport};
 use crate::macros::{EmitDefinition, MacroTracker, PropDefinition};
 use crate::provide::ProvideInjectTracker;
@@ -91,6 +91,8 @@ pub struct ScriptParseResult {
     pub re_exports: Vec<ReExportInfo>,
     /// Components registered through Options API `components`.
     pub component_registrations: Vec<ComponentRegistration>,
+    /// API shape of the component's default export (e.g. class component).
+    pub component_shape: ComponentShape,
     /// Definition spans for bindings (name -> (start, end) offset in script)
     pub binding_spans: FxHashMap<CompactString, (u32, u32)>,
     /// Value import source by local binding name.
@@ -186,6 +188,7 @@ impl ScriptParseResult {
         summary.import_statements = self.import_statements;
         summary.re_exports = self.re_exports;
         summary.component_registrations = self.component_registrations;
+        summary.component_shape = self.component_shape;
         summary.binding_spans = self.binding_spans;
     }
 

--- a/crates/vize_croquis/src/script_parser/snapshots/vize_croquis__script_parser__tests__parse_imports.snap
+++ b/crates/vize_croquis/src/script_parser/snapshots/vize_croquis__script_parser__tests__parse_imports.snap
@@ -1299,6 +1299,7 @@ ScriptParseResult {
     ],
     re_exports: [],
     component_registrations: [],
+    component_shape: Unspecified,
     binding_spans: {
         "computed": (
             27,

--- a/crates/vize_croquis/src/script_parser/snapshots/vize_croquis__script_parser__tests__parse_reactivity.snap
+++ b/crates/vize_croquis/src/script_parser/snapshots/vize_croquis__script_parser__tests__parse_reactivity.snap
@@ -1287,6 +1287,7 @@ ScriptParseResult {
     import_statements: [],
     re_exports: [],
     component_registrations: [],
+    component_shape: Unspecified,
     binding_spans: {
         "doubled": (
             52,

--- a/crates/vize_croquis/src/script_parser/tests.rs
+++ b/crates/vize_croquis/src/script_parser/tests.rs
@@ -1,5 +1,7 @@
 use super::{ScriptParserOptions, parse_script, parse_script_setup, parse_script_with_options};
+use crate::croquis::ComponentShape;
 use vize_carton::{CompactString, append, cstr};
+use vize_relief::BindingType;
 
 #[test]
 fn test_parse_define_props_type() {
@@ -484,6 +486,187 @@ export default {
     ] {
         assert!(result.bindings.contains(name), "missing binding {name}");
     }
+}
+
+#[test]
+fn test_parse_class_component_decorated_members() {
+    // Class components are auto-detected by shape (default export is a
+    // class), independent of the `options_api` flag.
+    let source = r#"
+import Vue from 'vue'
+import Component from 'vue-class-component'
+import UserBadge from './UserBadge.vue'
+
+@Component({
+  components: {
+    UserBadge,
+  },
+})
+export default class HelloWorld extends Vue {
+  count = 0
+  private msg!: string
+  protected items: string[] = []
+  #internal = 'hidden'
+  static version = '1.0.0'
+  declare ambient: string
+
+  get doubled() {
+    return this.count * 2
+  }
+
+  set doubled(value: number) {
+    this.count = value / 2
+  }
+
+  save() {}
+
+  private reset() {}
+
+  constructor() {
+    super()
+  }
+}
+"#;
+    let result = parse_script(source);
+
+    assert_eq!(result.component_shape, ComponentShape::ClassApi);
+
+    // Fields -> Data (TS `private`/`protected` are erased at runtime, so the
+    // template still resolves them; the canonical Vue CLI class-component
+    // scaffold renders `private` members).
+    assert_eq!(result.bindings.get("count"), Some(BindingType::Data));
+    assert_eq!(result.bindings.get("msg"), Some(BindingType::Data));
+    assert_eq!(result.bindings.get("items"), Some(BindingType::Data));
+
+    // Methods and get/set accessors -> Options (methods/computed-like).
+    assert_eq!(result.bindings.get("doubled"), Some(BindingType::Options));
+    assert_eq!(result.bindings.get("save"), Some(BindingType::Options));
+    assert_eq!(result.bindings.get("reset"), Some(BindingType::Options));
+
+    // Hard-private (#), static, declare, and constructor never resolve in
+    // templates.
+    assert!(!result.bindings.contains("internal"));
+    assert!(!result.bindings.contains("#internal"));
+    assert!(!result.bindings.contains("version"));
+    assert!(!result.bindings.contains("ambient"));
+    assert!(!result.bindings.contains("constructor"));
+
+    // The `@Component({ components: { ... } })` argument reuses the Options
+    // API registration collector.
+    assert_eq!(result.component_registrations.len(), 1);
+    assert_eq!(result.component_registrations[0].name, "UserBadge");
+    assert_eq!(result.component_registrations[0].local_name, "UserBadge");
+
+    // Members carry definition spans for Go-to-Definition.
+    assert!(result.binding_spans.contains_key("count"));
+    assert!(result.binding_spans.contains_key("doubled"));
+}
+
+#[test]
+fn test_parse_class_component_undecorated_extends_vue() {
+    let source = r#"
+import Vue from 'vue'
+
+export default class Counter extends Vue {
+  count = 0
+
+  get label() {
+    return `count: ${this.count}`
+  }
+
+  increment() {
+    this.count += 1
+  }
+}
+"#;
+    let result = parse_script(source);
+
+    assert_eq!(result.component_shape, ComponentShape::ClassApi);
+    assert_eq!(result.bindings.get("count"), Some(BindingType::Data));
+    assert_eq!(result.bindings.get("label"), Some(BindingType::Options));
+    assert_eq!(result.bindings.get("increment"), Some(BindingType::Options));
+}
+
+#[test]
+fn test_parse_class_component_expression_export() {
+    // Class *expressions* behind parens / TS wrappers are classified too.
+    let source = r#"
+import Vue from 'vue'
+
+export default (class extends Vue {
+  count = 0
+
+  increment() {}
+})
+"#;
+    let result = parse_script(source);
+
+    assert_eq!(result.component_shape, ComponentShape::ClassApi);
+    assert_eq!(result.bindings.get("count"), Some(BindingType::Data));
+    assert_eq!(result.bindings.get("increment"), Some(BindingType::Options));
+}
+
+#[test]
+fn test_parse_class_component_decorator_options_template_bindings() {
+    // Options declared inside the decorator argument behave exactly like an
+    // options component (vue-class-component merges them).
+    let source = r#"
+import { Options, Vue } from 'vue-class-component'
+
+@Options({
+  data() {
+    return { fromDecorator: 1 }
+  },
+  computed: {
+    decoratedComputed() {
+      return 2
+    },
+  },
+  methods: {
+    decoratedMethod() {},
+  },
+})
+export default class App extends Vue {
+  local = 0
+}
+"#;
+    let result = parse_script(source);
+
+    assert_eq!(result.component_shape, ComponentShape::ClassApi);
+    assert_eq!(result.bindings.get("local"), Some(BindingType::Data));
+    assert_eq!(
+        result.bindings.get("fromDecorator"),
+        Some(BindingType::Data)
+    );
+    assert_eq!(
+        result.bindings.get("decoratedComputed"),
+        Some(BindingType::Options)
+    );
+    assert_eq!(
+        result.bindings.get("decoratedMethod"),
+        Some(BindingType::Options)
+    );
+}
+
+#[test]
+fn test_parse_non_class_components_keep_unspecified_shape() {
+    // Options-object and script-setup analysis are untouched by the class
+    // path: shape stays `Unspecified` and no class-style bindings appear.
+    let options_result = parse_script_with_options(
+        "export default { data() { return { count: 0 } } }",
+        ScriptParserOptions {
+            options_api: true,
+            legacy_vue2: false,
+        },
+    );
+    assert_eq!(options_result.component_shape, ComponentShape::Unspecified);
+    assert_eq!(
+        options_result.bindings.get("count"),
+        Some(BindingType::Data)
+    );
+
+    let setup_result = parse_script_setup("const count = ref(0)");
+    assert_eq!(setup_result.component_shape, ComponentShape::Unspecified);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Opener for class component support (#1391): croquis now recognizes a class default export (vue-class-component / vue-property-decorator) and extracts its members as template bindings, so downstream surfaces stop treating class components as opaque.

- New `script_parser/process/class_component.rs` extractor, hooked into the existing export-default classification loop in `options_api.rs`.
- Detection is purely shape-based: in an SFC the default export *is* the component, so a class default export (declaration, or expression behind parens / `as` / `satisfies` / `!` wrappers) is unambiguous. No config flag.
- The `@Component({ ... })` / `@Options({ ... })` decorator argument is a regular options object and is fed through the existing Options API collectors, so `components:` registrations and inline `data`/`computed`/`methods` behave identically to an options component.
- New additive `ComponentShape` enum (`Unspecified` default / `ClassApi`) recorded on `ScriptParseResult` and `Croquis` so downstream PRs (canon virtual TS, patina, maestro) can branch on the API style without re-walking the AST.
- Member-level decorator semantics (`@Prop`, `@Emit`, `@Watch`, ...) are deliberately **out of scope** here; fields keep the `Data` mapping so templates resolve the identifiers either way.

## Binding-model mapping

| Class member | Croquis `BindingType` | Options API equivalent |
|---|---|---|
| property field (`count = 0`, `@Prop() msg!: string`) | `Data` | `data()` |
| `accessor` field | `Data` | `data()` |
| method | `Options` | `methods` |
| `get` / `set` accessor | `Options` | `computed` |
| `#private`, `static`, `declare`, computed key, `constructor` | skipped | — |

## Visibility choice

TS `private` / `protected` members **are** extracted as bindings: TS accessibility is erased at runtime, and the canonical Vue CLI class-component scaffold renders `{{ msg }}` from `@Prop() private msg!: string` — skipping them would false-positive `vue/no-undefined-refs` on the most common real-world shape. Type-level visibility enforcement belongs to the virtual-TS checker once canon bridges the class instance type (`InstanceType<typeof __default__>`, PR3 of #1391). ECMAScript hard-private (`#name`) members are genuinely unreachable outside the class body and are skipped.

## Zero-cost note

The class path is a single additional match arm on the export-default AST node inside the existing (one-pass) statement loop; it returns `None` immediately for every non-class export and adds nothing to hot loops. Non-class components take the exact same code path as before.

## Test plan

- New unit tests in `script_parser/tests.rs`:
  - decorated class with fields / methods / get+set accessors, `#private` / `static` / `declare` / `constructor` skips, decorator `components:` registration, binding spans
  - undecorated `export default class extends Vue`
  - parenthesized class *expression* default export
  - `@Options({ data/computed/methods })` decorator argument reuse
  - sanity: options-object and script-setup analysis keep `ComponentShape::Unspecified` and identical bindings
- `cargo test -p vize_croquis -p vize_croquis_cf` — green (169 + 120 tests)
- `cargo test -p vize_atelier_sfc -p vize_canon -p vize_patina` — green (518 + 321 + 1027 tests), proving the addition is purely additive for downstream consumers
- `cargo clippy -p vize_croquis --all-targets` clean on changed code; `cargo fmt` clean
- Only existing-output change: three insta debug snapshots gain the additive `component_shape: Unspecified,` line (struct field addition); all binding/semantic output is unchanged

Part of #1391.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1399"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783753564&installation_id=136613492&pr_number=1399&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1399&signature=6d4d27cd6cc4828a511a3a1926f24ff35d46872db3e2aaad8db433a9c0baa2fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->