### PR TITLE
perf(check): memoize tsconfig input specs and canonicalized paths in the explicit-subset path

### DIFF
--- a/crates/vize/src/commands/check.rs
+++ b/crates/vize/src/commands/check.rs
@@ -6,6 +6,7 @@
 mod dts;
 mod imports;
 mod nuxt;
+mod path_cache;
 mod reporting;
 mod runner;
 mod tsconfig_inputs;

--- a/crates/vize/src/commands/check/imports.rs
+++ b/crates/vize/src/commands/check/imports.rs
@@ -13,6 +13,8 @@ use std::path::{Path, PathBuf};
 
 use vize_carton::{FxHashSet, String, ToCompactString, cstr};
 
+use super::path_cache::CanonicalPathCache;
+
 /// Source extensions whose imports carry TypeScript types worth pulling into the
 /// virtual project, in module-resolution precedence order.
 ///
@@ -25,13 +27,17 @@ const RESOLVE_EXTENSIONS: &[&str] = &[".ts", ".tsx", ".vue", ".mts", ".cts"];
 /// Walk the relative-import graph reachable from `roots` and return the extra
 /// on-disk source files that should be registered alongside them. The roots
 /// themselves are excluded from the result; every returned path is absolute.
-pub(super) fn collect_transitive_local_imports(roots: &[PathBuf], cwd: &Path) -> Vec<PathBuf> {
+pub(super) fn collect_transitive_local_imports(
+    roots: &[PathBuf],
+    cwd: &Path,
+    canonical_paths: &mut CanonicalPathCache,
+) -> Vec<PathBuf> {
     let mut visited: FxHashSet<PathBuf> = FxHashSet::default();
     let mut queue: Vec<PathBuf> = Vec::new();
 
     // Seed the visited set with the roots so they are never re-registered.
     for root in roots {
-        if let Some(absolute) = absolutize(root, cwd)
+        if let Some(absolute) = absolutize(root, cwd, canonical_paths)
             && visited.insert(absolute.clone())
         {
             queue.push(absolute);
@@ -51,7 +57,7 @@ pub(super) fn collect_transitive_local_imports(roots: &[PathBuf], cwd: &Path) ->
         // `import`/`from` string operands, so an SFC's `<template>`/`<style>`
         // are inert and no `.vue` parse is needed on this hot path.
         for specifier in extract_relative_specifiers(&source) {
-            let Some(resolved) = resolve_relative_import(dir, &specifier) else {
+            let Some(resolved) = resolve_relative_import(dir, &specifier, canonical_paths) else {
                 continue;
             };
             // Never register an ambient declaration file — its `declare module`
@@ -71,13 +77,17 @@ pub(super) fn collect_transitive_local_imports(roots: &[PathBuf], cwd: &Path) ->
 
 /// Resolve `path` against `cwd` and canonicalize it so duplicate registrations
 /// of the same file under different spellings collapse.
-fn absolutize(path: &Path, cwd: &Path) -> Option<PathBuf> {
+fn absolutize(
+    path: &Path,
+    cwd: &Path,
+    canonical_paths: &mut CanonicalPathCache,
+) -> Option<PathBuf> {
     let joined = if path.is_absolute() {
         path.to_path_buf()
     } else {
         cwd.join(path)
     };
-    Some(joined.canonicalize().unwrap_or(joined))
+    Some(canonical_paths.canonicalize(&joined))
 }
 
 /// Collect the relative (`./`, `../`) module specifiers of `source`'s `import` /
@@ -161,16 +171,20 @@ fn is_relative_specifier(specifier: &str) -> bool {
 /// Resolve a relative module specifier against `dir` to an existing on-disk
 /// source file, mirroring TypeScript's extension and `index` probing (including
 /// the `.js` → `.ts` rewrite used under bundler/Node-ESM resolution).
-fn resolve_relative_import(dir: &Path, specifier: &str) -> Option<PathBuf> {
+fn resolve_relative_import(
+    dir: &Path,
+    specifier: &str,
+    canonical_paths: &mut CanonicalPathCache,
+) -> Option<PathBuf> {
     let base = dir.join(specifier);
 
     // 1. The specifier already points at an existing source file.
     if has_source_extension(&base) && base.is_file() {
-        return canonicalize(&base);
+        return Some(canonical_paths.canonicalize(&base));
     }
 
     // 2. A `.js`/`.mjs`/`.cjs` specifier resolving to its `.ts`/`.tsx` sibling.
-    if let Some(rewritten) = rewrite_js_to_ts(&base) {
+    if let Some(rewritten) = rewrite_js_to_ts(&base, canonical_paths) {
         return Some(rewritten);
     }
 
@@ -178,7 +192,7 @@ fn resolve_relative_import(dir: &Path, specifier: &str) -> Option<PathBuf> {
     for ext in RESOLVE_EXTENSIONS {
         let candidate = append_extension(&base, ext);
         if candidate.is_file() {
-            return canonicalize(&candidate);
+            return Some(canonical_paths.canonicalize(&candidate));
         }
     }
 
@@ -186,14 +200,14 @@ fn resolve_relative_import(dir: &Path, specifier: &str) -> Option<PathBuf> {
     for ext in RESOLVE_EXTENSIONS {
         let candidate = base.join(cstr_index(ext));
         if candidate.is_file() {
-            return canonicalize(&candidate);
+            return Some(canonical_paths.canonicalize(&candidate));
         }
     }
 
     None
 }
 
-fn rewrite_js_to_ts(base: &Path) -> Option<PathBuf> {
+fn rewrite_js_to_ts(base: &Path, canonical_paths: &mut CanonicalPathCache) -> Option<PathBuf> {
     let name = base.file_name()?.to_str()?;
     let stem = name
         .strip_suffix(".js")
@@ -202,7 +216,7 @@ fn rewrite_js_to_ts(base: &Path) -> Option<PathBuf> {
     for ext in [".ts", ".tsx", ".mts", ".cts"] {
         let candidate = base.with_file_name(cstr!("{stem}{ext}"));
         if candidate.is_file() {
-            return canonicalize(&candidate);
+            return Some(canonical_paths.canonicalize(&candidate));
         }
     }
     None
@@ -236,10 +250,6 @@ fn append_extension(base: &Path, ext: &str) -> PathBuf {
 
 fn cstr_index(ext: &str) -> String {
     cstr!("index{ext}")
-}
-
-fn canonicalize(path: &Path) -> Option<PathBuf> {
-    Some(path.canonicalize().unwrap_or_else(|_| path.to_path_buf()))
 }
 
 #[cfg(test)]
@@ -278,7 +288,11 @@ mod tests {
         );
         let util = write(&root, "src/nested/util.ts", "export const helper = 1\n");
 
-        let discovered = collect_transitive_local_imports(&[app.clone()], &root);
+        let discovered = collect_transitive_local_imports(
+            std::slice::from_ref(&app),
+            &root,
+            &mut CanonicalPathCache::default(),
+        );
 
         let canon = |p: &Path| p.canonicalize().unwrap();
         assert!(discovered.contains(&canon(&types)));
@@ -302,7 +316,8 @@ mod tests {
             "import { ref } from 'vue'\nimport { gone } from './missing'\nexport const a = ref(0)\nvoid gone\n",
         );
 
-        let discovered = collect_transitive_local_imports(&[entry], &root);
+        let discovered =
+            collect_transitive_local_imports(&[entry], &root, &mut CanonicalPathCache::default());
         assert!(discovered.is_empty());
 
         let _ = std::fs::remove_dir_all(&root);

--- a/crates/vize/src/commands/check/path_cache.rs
+++ b/crates/vize/src/commands/check/path_cache.rs
@@ -1,0 +1,55 @@
+//! Run-scoped memoization of `Path::canonicalize` results.
+
+use std::path::{Path, PathBuf};
+
+use vize_carton::FxHashMap;
+
+/// Run-scoped cache of `Path::canonicalize` results.
+///
+/// Canonicalization hits the filesystem on every call, and the explicit-subset
+/// check path canonicalizes the same paths repeatedly: once to build the
+/// reported-file set, once per diagnostic when filtering, and once per
+/// resolution while walking transitive relative imports. Sharing one per-run
+/// cache across those sites keeps each unique path at a single syscall.
+///
+/// Paths that fail to canonicalize (e.g. not on disk) memoize their original
+/// spelling, matching the previous per-call `unwrap_or` fallback.
+#[derive(Default)]
+pub(super) struct CanonicalPathCache {
+    cache: FxHashMap<PathBuf, PathBuf>,
+}
+
+impl CanonicalPathCache {
+    /// Canonicalize `path`, falling back to the original spelling when the
+    /// path cannot be resolved on disk.
+    pub(super) fn canonicalize(&mut self, path: &Path) -> PathBuf {
+        if let Some(cached) = self.cache.get(path) {
+            return cached.clone();
+        }
+        let canonical = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+        self.cache.insert(path.to_path_buf(), canonical.clone());
+        canonical
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::CanonicalPathCache;
+
+    #[test]
+    fn canonicalizes_existing_paths_and_memoizes_missing_ones() {
+        let temp = tempfile::tempdir().unwrap();
+        let file = temp.path().join("a.ts");
+        std::fs::write(&file, "export const a = 1;\n").unwrap();
+
+        let mut cache = CanonicalPathCache::default();
+        let canonical = cache.canonicalize(&file);
+        assert_eq!(canonical, file.canonicalize().unwrap());
+        // Cached lookups return the same result.
+        assert_eq!(cache.canonicalize(&file), canonical);
+
+        let missing = temp.path().join("missing.ts");
+        assert_eq!(cache.canonicalize(&missing), missing);
+        assert_eq!(cache.canonicalize(&missing), missing);
+    }
+}

--- a/crates/vize/src/commands/check/runner/diagnostics.rs
+++ b/crates/vize/src/commands/check/runner/diagnostics.rs
@@ -5,6 +5,7 @@ use std::{fs, path::Path, path::PathBuf};
 
 use vize_carton::{FxHashSet, String as CompactString, cstr, profile, profiler::global_profiler};
 
+use crate::commands::check::path_cache::CanonicalPathCache;
 use crate::commands::check::reporting::JsonOutput;
 
 pub(super) fn emit_json_output(json_output: JsonOutput) {
@@ -22,15 +23,18 @@ pub(super) fn emit_json_output(json_output: JsonOutput) {
 /// and transitively-registered files exist only to resolve cross-file types.
 /// Project-level diagnostics (anchored to a tsconfig or the project root, not
 /// a source file) describe the whole check and are always reported.
-pub(super) fn is_reported(reported: &Option<FxHashSet<PathBuf>>, path: &Path) -> bool {
+pub(super) fn is_reported(
+    reported: &Option<FxHashSet<PathBuf>>,
+    path: &Path,
+    canonical_paths: &mut CanonicalPathCache,
+) -> bool {
     match reported {
         None => true,
         Some(set) => {
             if !is_source_path(path) {
                 return true;
             }
-            let canonical = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
-            set.contains(&canonical)
+            set.contains(&canonical_paths.canonicalize(path))
         }
     }
 }

--- a/crates/vize/src/commands/check/runner/mod.rs
+++ b/crates/vize/src/commands/check/runner/mod.rs
@@ -24,9 +24,11 @@ use vize_curator::profile::{ProfilePhase, ProfilePhaseKind, ProfileReport, print
 
 use super::{
     CheckArgs,
+    path_cache::CanonicalPathCache,
     reporting::{JsonFileResult, JsonOutput},
     tsconfig_inputs::{
-        collect_ambient_declaration_files, collect_default_check_files, resolve_tsconfig_for_files,
+        TsconfigInputCache, collect_ambient_declaration_files, collect_default_check_files,
+        resolve_tsconfig_for_files,
     },
 };
 
@@ -142,9 +144,19 @@ pub(crate) fn run_direct(args: &CheckArgs) {
     let project_root = resolve_project_root(effective_tsconfig.as_deref(), &cwd, &[]);
     let tsconfig_path =
         resolve_tsconfig_path(effective_tsconfig.as_deref(), &cwd, &project_root, &[]);
+    // Run-scoped caches: tsconfig chains are parsed (and their include/exclude
+    // globs compiled) once per run, and each unique path is canonicalized at
+    // most once across reported-file bookkeeping, diagnostic filtering, and
+    // transitive import resolution.
+    let mut tsconfig_input_cache = TsconfigInputCache::default();
+    let mut canonical_paths = CanonicalPathCache::default();
     let collect_start = Instant::now();
     let mut files = if args.patterns.is_empty() {
-        collect_default_check_files(&project_root, tsconfig_path.as_deref())
+        collect_default_check_files(
+            &project_root,
+            tsconfig_path.as_deref(),
+            &mut tsconfig_input_cache,
+        )
     } else {
         collect_check_files(&args.patterns)
     };
@@ -166,7 +178,7 @@ pub(crate) fn run_direct(args: &CheckArgs) {
         Some(
             files
                 .iter()
-                .map(|path| path.canonicalize().unwrap_or_else(|_| path.clone()))
+                .map(|path| canonical_paths.canonicalize(path))
                 .collect(),
         )
     };
@@ -197,7 +209,9 @@ pub(crate) fn run_direct(args: &CheckArgs) {
     // Do this before root resolution so cwd-external files without tsconfig can
     // still choose a materialization root covering all registered source files.
     if !args.patterns.is_empty() {
-        for path in super::imports::collect_transitive_local_imports(&files, &cwd) {
+        for path in
+            super::imports::collect_transitive_local_imports(&files, &cwd, &mut canonical_paths)
+        {
             if !files.contains(&path) {
                 files.push(path);
             }
@@ -212,7 +226,11 @@ pub(crate) fn run_direct(args: &CheckArgs) {
     let program_tsconfig_path = if args.patterns.is_empty() {
         tsconfig_path.clone()
     } else {
-        resolve_tsconfig_for_files(tsconfig_path.as_deref(), &explicit_files)
+        resolve_tsconfig_for_files(
+            tsconfig_path.as_deref(),
+            &explicit_files,
+            &mut tsconfig_input_cache,
+        )
     };
 
     // An explicit file subset (`vize check src/App.vue`) omits ambient
@@ -220,9 +238,11 @@ pub(crate) fn run_direct(args: &CheckArgs) {
     // would then be missing and surface as false `TS2304` errors. Pull the
     // tsconfig program's `.d.ts` files back in so global types stay in scope.
     if !args.patterns.is_empty() && program_tsconfig_path.is_some() {
-        for path in
-            collect_ambient_declaration_files(&project_root, program_tsconfig_path.as_deref())
-        {
+        for path in collect_ambient_declaration_files(
+            &project_root,
+            program_tsconfig_path.as_deref(),
+            &mut tsconfig_input_cache,
+        ) {
             if !files.contains(&path) {
                 files.push(path);
             }
@@ -390,7 +410,7 @@ pub(crate) fn run_direct(args: &CheckArgs) {
         .diagnostics
         .iter()
         .filter(|diagnostic| {
-            if !is_reported(&reported_files, &diagnostic.file) {
+            if !is_reported(&reported_files, &diagnostic.file, &mut canonical_paths) {
                 return false;
             }
             !is_suppressed_false_positive(diagnostic)
@@ -504,7 +524,7 @@ pub(crate) fn run_direct(args: &CheckArgs) {
     if args.format == "json" {
         let mut files_json: Vec<JsonFileResult> = virtual_files
             .iter()
-            .filter(|file| is_reported(&reported_files, &file.original_path))
+            .filter(|file| is_reported(&reported_files, &file.original_path, &mut canonical_paths))
             .map(|file| {
                 let key = file.original_path.to_string_lossy().into_owned();
                 JsonFileResult {

--- a/crates/vize/src/commands/check/tsconfig_inputs/ambient.rs
+++ b/crates/vize/src/commands/check/tsconfig_inputs/ambient.rs
@@ -10,6 +10,7 @@ use vize_carton::FxHashSet;
 use super::NODE_MODULES_DIR;
 use super::collect_default_check_files_inner;
 use super::glob::normalize_input_path;
+use super::loader::TsconfigInputCache;
 use super::matching::path_has_component;
 
 /// Collect ambient declaration (`.d.ts`) files that belong to the tsconfig
@@ -30,9 +31,10 @@ use super::matching::path_has_component;
 pub(crate) fn collect_ambient_declaration_files(
     project_root: &Path,
     tsconfig_path: Option<&Path>,
+    cache: &mut TsconfigInputCache,
 ) -> Vec<PathBuf> {
     let project_root = normalize_input_path(project_root);
-    let mut files = collect_default_check_files_inner(&project_root, tsconfig_path, true);
+    let mut files = collect_default_check_files_inner(&project_root, tsconfig_path, true, cache);
     let mut seen = files.iter().cloned().collect::<FxHashSet<_>>();
     let mut index = 0;
     while index < files.len() {

--- a/crates/vize/src/commands/check/tsconfig_inputs/collect.rs
+++ b/crates/vize/src/commands/check/tsconfig_inputs/collect.rs
@@ -6,7 +6,7 @@ use ignore::WalkBuilder;
 use vize_carton::FxHashSet;
 
 use super::glob::{default_exclude_specs, normalize_input_path, normalize_walked_path};
-use super::loader::{collect_tsconfig_project_paths, load_tsconfig_inputs};
+use super::loader::{TsconfigInputCache, collect_tsconfig_project_paths};
 use super::matching::{
     is_generated_path, is_hidden_path_segment, is_supported_check_file, matches_tsconfig_patterns,
     should_skip_generated_for_root,
@@ -122,6 +122,7 @@ fn hidden_pattern_root(base_dir: &Path, pattern: &str) -> Option<PathBuf> {
 pub(crate) fn resolve_tsconfig_for_files(
     tsconfig_path: Option<&Path>,
     files: &[PathBuf],
+    cache: &mut TsconfigInputCache,
 ) -> Option<PathBuf> {
     let tsconfig_path = tsconfig_path?;
     let projects = collect_tsconfig_project_paths(tsconfig_path);
@@ -138,63 +139,106 @@ pub(crate) fn resolve_tsconfig_for_files(
         return Some(root_project);
     }
 
-    if let Some(owner) = projects
+    // Load each candidate project's input spec exactly once and precompile its
+    // ownership matcher, so the per-file checks below are pure in-memory glob
+    // matches instead of re-reading the tsconfig chain for every file.
+    let matchers = projects
         .iter()
-        .find(|project| files.iter().all(|file| tsconfig_owns_file(project, file)))
+        .map(|project| TsconfigOwnershipMatcher::load(project, cache))
+        .collect::<Vec<_>>();
+
+    if let Some((owner, _)) = projects
+        .iter()
+        .zip(&matchers)
+        .find(|(_, matcher)| files.iter().all(|file| matcher.owns(file)))
     {
         return Some(owner.clone());
     }
 
-    let mut shared_owner = None::<PathBuf>;
+    let mut shared_owner = None::<&PathBuf>;
     for file in &files {
-        let Some(owner) = projects
+        let Some((owner, _)) = projects
             .iter()
-            .find(|project| tsconfig_owns_file(project, file))
+            .zip(&matchers)
+            .find(|(_, matcher)| matcher.owns(file))
         else {
             return Some(root_project);
         };
-        match &shared_owner {
+        match shared_owner {
             Some(shared) if shared != owner => return Some(root_project),
             Some(_) => {}
-            None => shared_owner = Some(owner.clone()),
+            None => shared_owner = Some(owner),
         }
     }
 
-    shared_owner.or(Some(root_project))
+    shared_owner.cloned().or(Some(root_project))
 }
 
-fn tsconfig_owns_file(tsconfig_path: &Path, file: &Path) -> bool {
-    let Some(spec) = load_tsconfig_inputs(tsconfig_path) else {
-        return false;
-    };
-    let file = normalize_input_path(file);
-    if spec
-        .files
-        .iter()
-        .any(|entry| normalize_input_path(&entry.resolve()) == file)
-    {
-        return true;
+/// Precompiled ownership matcher for one tsconfig project: the canonicalized
+/// `files` entries plus the effective include/exclude globs (with tsc's
+/// defaults applied), built once per project so matching N files needs no
+/// further I/O or glob compilation.
+struct TsconfigOwnershipMatcher {
+    /// Whether the tsconfig chain loaded; an unreadable tsconfig owns nothing.
+    loaded: bool,
+    files: FxHashSet<PathBuf>,
+    includes: Vec<GlobSpec>,
+    excludes: Vec<GlobSpec>,
+}
+
+impl TsconfigOwnershipMatcher {
+    fn load(tsconfig_path: &Path, cache: &mut TsconfigInputCache) -> Self {
+        let Some(spec) = cache.load(tsconfig_path) else {
+            return Self {
+                loaded: false,
+                files: FxHashSet::default(),
+                includes: Vec::new(),
+                excludes: Vec::new(),
+            };
+        };
+
+        let files = spec
+            .files
+            .iter()
+            .map(|entry| normalize_input_path(&entry.resolve()))
+            .collect();
+        let default_base_dir = tsconfig_path
+            .parent()
+            .map(Path::to_path_buf)
+            .unwrap_or_default();
+        let includes = if !spec.has_includes && !spec.has_files {
+            GlobSpec::new(&default_base_dir, "**/*")
+                .into_iter()
+                .collect::<Vec<_>>()
+        } else {
+            spec.includes.clone()
+        };
+        let excludes = if !spec.has_excludes {
+            default_exclude_specs(&default_base_dir)
+        } else {
+            spec.excludes.clone()
+        };
+
+        Self {
+            loaded: true,
+            files,
+            includes,
+            excludes,
+        }
     }
 
-    let default_base_dir = tsconfig_path
-        .parent()
-        .map(Path::to_path_buf)
-        .unwrap_or_default();
-    let includes = if !spec.has_includes && !spec.has_files {
-        GlobSpec::new(&default_base_dir, "**/*")
-            .into_iter()
-            .collect::<Vec<_>>()
-    } else {
-        spec.includes
-    };
-    if includes.is_empty() || !is_supported_check_file(&file) {
-        return false;
+    /// Whether this project owns `file`, which must already be normalized via
+    /// `normalize_input_path`.
+    fn owns(&self, file: &Path) -> bool {
+        if !self.loaded {
+            return false;
+        }
+        if self.files.contains(file) {
+            return true;
+        }
+        if self.includes.is_empty() || !is_supported_check_file(file) {
+            return false;
+        }
+        matches_tsconfig_patterns(file, &self.includes, &self.excludes)
     }
-    let excludes = if !spec.has_excludes {
-        default_exclude_specs(&default_base_dir)
-    } else {
-        spec.excludes
-    };
-
-    matches_tsconfig_patterns(&file, &includes, &excludes)
 }

--- a/crates/vize/src/commands/check/tsconfig_inputs/loader.rs
+++ b/crates/vize/src/commands/check/tsconfig_inputs/loader.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use serde_json::Value;
-use vize_carton::{FxHashSet, profile, profiler::global_profiler};
+use vize_carton::{FxHashMap, FxHashSet, profile, profiler::global_profiler};
 
 use super::glob::normalize_input_path;
 use super::jsonc::parse_jsonc_value;
@@ -42,7 +42,33 @@ fn collect_tsconfig_project_paths_inner(
     }
 }
 
-pub(super) fn load_tsconfig_inputs(tsconfig_path: &Path) -> Option<TsconfigInputSpec> {
+/// Run-scoped memo for merged tsconfig input specs, keyed by canonical
+/// tsconfig path.
+///
+/// Resolving tsconfig ownership for an explicit file subset asks the same
+/// tsconfig chain about every checked file; without a cache each question
+/// re-reads and re-parses the chain and recompiles every include/exclude
+/// `GlobSpec`. One cache per `vize check` run keeps that work at once per
+/// tsconfig with no cross-run staleness.
+#[derive(Default)]
+pub(crate) struct TsconfigInputCache {
+    specs: FxHashMap<PathBuf, Option<TsconfigInputSpec>>,
+}
+
+impl TsconfigInputCache {
+    /// Load (or reuse) the merged input spec for `tsconfig_path`. Returns
+    /// `None` when the tsconfig chain cannot be read, exactly like an uncached
+    /// `load_tsconfig_inputs` call.
+    pub(super) fn load(&mut self, tsconfig_path: &Path) -> Option<&TsconfigInputSpec> {
+        let resolved = normalize_input_path(tsconfig_path);
+        self.specs
+            .entry(resolved)
+            .or_insert_with_key(|resolved| load_tsconfig_inputs(resolved))
+            .as_ref()
+    }
+}
+
+fn load_tsconfig_inputs(tsconfig_path: &Path) -> Option<TsconfigInputSpec> {
     let mut seen = FxHashSet::default();
     load_tsconfig_inputs_inner(tsconfig_path, &mut seen).ok()
 }

--- a/crates/vize/src/commands/check/tsconfig_inputs/mod.rs
+++ b/crates/vize/src/commands/check/tsconfig_inputs/mod.rs
@@ -24,7 +24,7 @@ mod tests;
 pub(crate) use ambient::collect_ambient_declaration_files;
 pub(crate) use collect::resolve_tsconfig_for_files;
 pub(super) use jsonc::parse_jsonc_value;
-pub(crate) use loader::load_tsconfig_declaration_options;
+pub(crate) use loader::{TsconfigInputCache, load_tsconfig_declaration_options};
 pub(super) use loader::{read_extends_entries, resolve_extended_tsconfig};
 pub(crate) use spec::TsconfigDeclarationOptions;
 
@@ -32,9 +32,9 @@ use collect::{
     collect_supported_files, collect_supported_files_with_options, explicit_hidden_include_roots,
 };
 use glob::{default_exclude_specs, normalize_input_path};
-use loader::{collect_tsconfig_project_paths, load_tsconfig_inputs};
+use loader::collect_tsconfig_project_paths;
 use matching::is_supported_check_file;
-use spec::{FileCollectionOptions, GlobSpec};
+use spec::{FileCollectionOptions, GlobSpec, TsconfigInputSpec};
 
 const TARGET_DIR: &str = "target";
 const NODE_MODULES_DIR: &str = "node_modules";
@@ -43,14 +43,16 @@ const VIZE_CACHE_DIR: &str = ".vize";
 pub(crate) fn collect_default_check_files(
     project_root: &Path,
     tsconfig_path: Option<&Path>,
+    cache: &mut TsconfigInputCache,
 ) -> Vec<PathBuf> {
-    collect_default_check_files_inner(project_root, tsconfig_path, false)
+    collect_default_check_files_inner(project_root, tsconfig_path, false, cache)
 }
 
 fn collect_default_check_files_inner(
     project_root: &Path,
     tsconfig_path: Option<&Path>,
     include_hidden_tsconfig_roots: bool,
+    cache: &mut TsconfigInputCache,
 ) -> Vec<PathBuf> {
     let Some(tsconfig_path) = tsconfig_path else {
         return collect_supported_files(project_root, &[], &[]);
@@ -63,6 +65,7 @@ fn collect_default_check_files_inner(
             project_root,
             &tsconfig_path,
             include_hidden_tsconfig_roots,
+            cache,
             &mut files,
             &mut seen,
         );
@@ -76,12 +79,14 @@ fn collect_default_check_files_for_tsconfig(
     project_root: &Path,
     tsconfig_path: &Path,
     include_hidden_tsconfig_roots: bool,
+    cache: &mut TsconfigInputCache,
     files: &mut Vec<PathBuf>,
     seen: &mut FxHashSet<PathBuf>,
 ) {
-    let spec = load_tsconfig_inputs(tsconfig_path).unwrap_or_default();
+    let default_spec = TsconfigInputSpec::default();
+    let spec = cache.load(tsconfig_path).unwrap_or(&default_spec);
 
-    for file in spec.files {
+    for file in &spec.files {
         let resolved = normalize_input_path(&file.resolve());
         if resolved.starts_with(project_root)
             && resolved.is_file()
@@ -97,33 +102,37 @@ fn collect_default_check_files_for_tsconfig(
         .map(Path::to_path_buf)
         .unwrap_or_else(|| project_root.to_path_buf());
 
-    let includes = if !spec.has_includes && !spec.has_files && files.is_empty() {
-        GlobSpec::new(&default_base_dir, "**/*")
+    let default_includes;
+    let includes: &[GlobSpec] = if !spec.has_includes && !spec.has_files && files.is_empty() {
+        default_includes = GlobSpec::new(&default_base_dir, "**/*")
             .into_iter()
-            .collect::<Vec<_>>()
+            .collect::<Vec<_>>();
+        &default_includes
     } else {
-        spec.includes
+        &spec.includes
     };
 
-    let excludes = if !spec.has_excludes {
-        default_exclude_specs(&default_base_dir)
+    let default_excludes;
+    let excludes: &[GlobSpec] = if !spec.has_excludes {
+        default_excludes = default_exclude_specs(&default_base_dir);
+        &default_excludes
     } else {
-        spec.excludes
+        &spec.excludes
     };
 
     if !includes.is_empty() {
-        let collected = collect_supported_files(project_root, &includes, &excludes);
+        let collected = collect_supported_files(project_root, includes, excludes);
         for path in collected {
             if seen.insert(path.clone()) {
                 files.push(path);
             }
         }
         if include_hidden_tsconfig_roots {
-            for root in explicit_hidden_include_roots(project_root, &includes) {
+            for root in explicit_hidden_include_roots(project_root, includes) {
                 for path in collect_supported_files_with_options(
                     &root,
-                    &includes,
-                    &excludes,
+                    includes,
+                    excludes,
                     FileCollectionOptions {
                         include_hidden: true,
                     },

--- a/crates/vize/src/commands/check/tsconfig_inputs/tests.rs
+++ b/crates/vize/src/commands/check/tsconfig_inputs/tests.rs
@@ -2,13 +2,35 @@
 
 #![allow(clippy::disallowed_macros, clippy::disallowed_types)]
 
-use super::{
-    collect_ambient_declaration_files, collect_default_check_files,
-    load_tsconfig_declaration_options, resolve_extended_tsconfig, resolve_tsconfig_for_files,
-};
+use super::{TsconfigInputCache, load_tsconfig_declaration_options, resolve_extended_tsconfig};
 use std::fs;
 use std::path::{Path, PathBuf};
 use vize_carton::cstr;
+
+// Each call uses a fresh run-scoped cache, mirroring how an actual `vize
+// check` run constructs one `TsconfigInputCache` per invocation.
+fn collect_default_check_files(project_root: &Path, tsconfig_path: Option<&Path>) -> Vec<PathBuf> {
+    super::collect_default_check_files(
+        project_root,
+        tsconfig_path,
+        &mut TsconfigInputCache::default(),
+    )
+}
+
+fn collect_ambient_declaration_files(
+    project_root: &Path,
+    tsconfig_path: Option<&Path>,
+) -> Vec<PathBuf> {
+    super::collect_ambient_declaration_files(
+        project_root,
+        tsconfig_path,
+        &mut TsconfigInputCache::default(),
+    )
+}
+
+fn resolve_tsconfig_for_files(tsconfig_path: Option<&Path>, files: &[PathBuf]) -> Option<PathBuf> {
+    super::resolve_tsconfig_for_files(tsconfig_path, files, &mut TsconfigInputCache::default())
+}
 
 fn unique_case_dir(name: &str) -> PathBuf {
     static NEXT_CASE_ID: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
@@ -1079,6 +1101,63 @@ fn owner_resolution_falls_back_to_root_for_an_unowned_file() {
     let owner = resolve_tsconfig_for_files(Some(&root), &[unowned]);
 
     assert_eq!(owner, Some(root.canonicalize().unwrap_or(root.clone())));
+
+    let _ = fs::remove_dir_all(&case_dir);
+}
+
+#[test]
+fn shared_run_cache_matches_fresh_cache_results() {
+    let case_dir = unique_case_dir("tsconfig-shared-cache");
+    let _ = fs::remove_dir_all(&case_dir);
+    fs::create_dir_all(case_dir.join("src")).unwrap();
+    let app = case_dir.join("src/App.vue");
+    let main = case_dir.join("src/main.ts");
+    fs::write(&app, "<template />").unwrap();
+    fs::write(&main, "export const ok = true").unwrap();
+    fs::write(
+        case_dir.join("src/globals.d.ts"),
+        "declare const FLAG: boolean",
+    )
+    .unwrap();
+    fs::write(
+        case_dir.join("tsconfig.json"),
+        r#"{ "include": ["src/**/*.ts", "src/**/*.vue", "src/**/*.d.ts"] }"#,
+    )
+    .unwrap();
+    let tsconfig = case_dir.join("tsconfig.json");
+
+    // One run-scoped cache shared across owner resolution (twice), default
+    // collection, and ambient collection must match per-call fresh caches.
+    let mut cache = TsconfigInputCache::default();
+    let owner_shared = super::resolve_tsconfig_for_files(
+        Some(&tsconfig),
+        &[app.clone(), main.clone()],
+        &mut cache,
+    );
+    let owner_shared_again =
+        super::resolve_tsconfig_for_files(Some(&tsconfig), &[app.clone()], &mut cache);
+    let files_shared = super::collect_default_check_files(&case_dir, Some(&tsconfig), &mut cache);
+    let ambient_shared =
+        super::collect_ambient_declaration_files(&case_dir, Some(&tsconfig), &mut cache);
+
+    assert_eq!(
+        owner_shared,
+        resolve_tsconfig_for_files(Some(&tsconfig), &[app.clone(), main])
+    );
+    assert_eq!(
+        owner_shared_again,
+        resolve_tsconfig_for_files(Some(&tsconfig), &[app])
+    );
+    assert_eq!(
+        files_shared,
+        collect_default_check_files(&case_dir, Some(&tsconfig))
+    );
+    assert_eq!(
+        ambient_shared,
+        collect_ambient_declaration_files(&case_dir, Some(&tsconfig))
+    );
+    assert_eq!(files_shared.len(), 3);
+    assert_eq!(ambient_shared.len(), 1);
 
     let _ = fs::remove_dir_all(&case_dir);
 }


### PR DESCRIPTION
## Summary

`vize check .` (the explicit-subset path the PR-bench check lane exercises) resolved tsconfig ownership with O(files × include-entries) work and redundant I/O: every checked file re-read and re-parsed the whole tsconfig chain and recompiled every include/exclude `GlobSpec`, and the same paths were `canonicalize`d again and again across reported-file bookkeeping, diagnostic filtering, and transitive import resolution. This PR removes that waste with two run-scoped caches; behavior is unchanged.

Part of #1385 (item 1, "Explicit-subset bookkeeping").

## What changed

- **`TsconfigInputCache`** (`tsconfig_inputs/loader.rs`): run-scoped memo of merged `TsconfigInputSpec`s keyed by canonical tsconfig path, so each chain is read/parsed and its `GlobSpec`s compiled once per run. `run_direct` creates one cache per run and threads it explicitly through `collect_default_check_files`, `resolve_tsconfig_for_files`, and `collect_ambient_declaration_files` — no global state, no cross-run staleness.
- **Batch ownership matching** (`tsconfig_inputs/collect.rs`): `resolve_tsconfig_for_files` now builds a precompiled `TsconfigOwnershipMatcher` per candidate project once (canonicalized `files` set + effective include/exclude globs with tsc defaults applied) and matches all N files against it in one pass. The per-file `tsconfig_owns_file` → uncached `load_tsconfig_inputs` round-trip is gone.
- **`CanonicalPathCache`** (`check/path_cache.rs`): one shared `FxHashMap<PathBuf, PathBuf>` canonicalize memo reused by the `reported_files` set construction, `is_reported` (previously one `canonicalize` syscall per diagnostic), and transitive relative-import resolution.

## Semantics unchanged

- The ownership matcher preserves `tsconfig_owns_file`'s exact decision order: unreadable tsconfig owns nothing → `files` entry match → `**/*` default when neither `files` nor `include` present → supported-extension gate → include/exclude glob match with the same `MatchOptions`. Project iteration order and the shared-owner/root fallback logic in `resolve_tsconfig_for_files` are untouched.
- Caches are constructed per `run_direct` invocation, so no state survives a run; failed canonicalizations memoize the original spelling, matching the previous `unwrap_or` fallback per call site.
- Verified byte-identical output on the 300-file bench corpus, base vs head:
  - explicit-subset path (`check . --tsconfig` with a 300-entry include list): full text diagnostics and `--format json` output identical (1850 diagnostics, 3.2 MB JSON byte-for-byte).
  - default-collection path (`check` with no patterns in the corpus dir): `--format json` identical.

## Local measurements (local machine — the authoritative gate is the PR benchmark on Actions)

Setup: `node bench/generate.mjs 300`, check dir prepared exactly like `bench/compare-tools.mjs#prepareCheckDir` (tsconfig extending the corpus tsconfig with `include` listing all 300 files), measured with `bench/compare-pr.mjs --tasks check` (`check . --quiet --servers 1 --tsconfig …`, `RAYON_NUM_THREADS=1`). Binaries built with `--profile ci-opt` (`inherits=release`, `lto=thin`, `codegen-units=16`). Base = `334fd2fe`.

| Task | Base | Head | Rate |
| --- | ---: | ---: | ---: |
| Type check (median of 9, 2 warmups) | 248.779ms | 185.801ms | **0.747x (−25.3%)** |

Raw runs — base: 275.0, 269.7, 260.4, 240.2, 247.4, 261.5, 238.5, 248.8, 241.5 ms; head: 197.6, 197.1, 176.8, 184.4, 183.5, 187.0, 185.8, 183.7, 195.4 ms.

`--profile` attribution on the same corpus (single run): `cli.check.tsconfig.read` 604 → 4 samples; allocations 878,242 → 227,838 (−74%); alloc bytes 113.55 MiB → 77.73 MiB.

## Test plan

- `cargo test -p vize` (166 tests, all green) — includes existing tsconfig-inputs/owner-resolution/imports suites plus new tests: `shared_run_cache_matches_fresh_cache_results` (one run-scoped cache across owner resolution, default collection, and ambient collection matches fresh-cache results) and `canonicalizes_existing_paths_and_memoizes_missing_ones`.
- `cargo clippy -p vize --all-targets`: no warnings in changed code; `cargo fmt` clean.
- Byte-identical diagnostics base vs head as described above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1400"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783753642&installation_id=136613492&pr_number=1400&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1400&signature=3258c026144e50b3fe62171873279c510a30c9aecadcd277f0726b10326b21e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->