### PR TITLE
ci(bench): raise PR gate sample count to cover the optimized noise floor

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -13,8 +13,12 @@ env:
   CARGO_TERM_COLOR: always
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
   VIZE_BENCH_FILE_COUNT: 300
-  VIZE_BENCH_RUNS: 5
-  VIZE_BENCH_WARMUPS: 1
+  # Optimized (ci-opt) binaries run fast enough that 5 runs / 1 warmup left the
+  # gate's noise floor above the 5% threshold: an identical-source PR (#1395)
+  # tripped the budget at +5.12% on the compile lane. More samples tighten the
+  # median instead of weakening the threshold.
+  VIZE_BENCH_RUNS: 10
+  VIZE_BENCH_WARMUPS: 2
   VIZE_BENCH_REGRESSION_THRESHOLD_PERCENT: 5
 
 jobs:


### PR DESCRIPTION
## Summary

The first run of the optimized perf gate produced a false positive: PR #1395 changed no Rust code (base and head binaries were built from identical sources and profile settings), yet the budget gate failed with `Compile SFC: 1.051x (+5.12%)` — pure run-to-run noise above the 5% threshold.

Optimized (`ci-opt`) binaries run the lanes fast enough that 5 runs with a single warmup leave the measurement noise floor above the threshold. This raises the gate to **10 runs / 2 warmups**, tightening the median estimate instead of weakening the threshold. The `pr-benchmark` job took ~2m25s at 5 runs, so the doubled sample count stays well inside the 30-minute budget.

Part of #1386 (noise-controlled thresholds for the zero-cost regression gate).

## Test plan

- `node --test tests/tooling/github-workflows.test.ts` — 48/48 pass.
- This PR's own gate run exercises the new sample count; follow-up evidence is the absence of false budget failures on subsequent perf-neutral PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1401"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783753695&installation_id=136613492&pr_number=1401&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1401&signature=5c81a1a62481eeed941e55eb3d675fda7982d10fde1878800e1d4b462649a899"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->