### PR TITLE
feat(carton/maestro/patina): explicit petite-vue dialect detection

### DIFF
--- a/crates/vize_carton/src/config.rs
+++ b/crates/vize_carton/src/config.rs
@@ -16,3 +16,5 @@ pub use model::{
     LspConfig, QuoteProps, TrailingComma, TypeCheckerConfig, VizeConfig,
 };
 pub use normalize::normalize_public_config_value;
+
+pub use crate::dialect::VueDialect;

--- a/crates/vize_carton/src/config/loader/tests.rs
+++ b/crates/vize_carton/src/config/loader/tests.rs
@@ -65,6 +65,29 @@ fn load_config_uses_explicit_file_path() {
 }
 
 #[test]
+fn load_config_reads_dialect_key() {
+    let dir = tempfile::tempdir().unwrap();
+    let config_path = dir.path().join("vize.config.json");
+    std::fs::write(&config_path, r#"{ "dialect": "petite-vue" }"#).unwrap();
+
+    let loaded = load_config_with_source(Some(&config_path));
+    assert_eq!(
+        loaded.config.dialect,
+        Some(crate::dialect::VueDialect::PetiteVue)
+    );
+}
+
+#[test]
+fn load_config_defaults_dialect_to_unset() {
+    let dir = tempfile::tempdir().unwrap();
+    let config_path = dir.path().join("vize.config.json");
+    std::fs::write(&config_path, r#"{ "formatter": { "singleQuote": true } }"#).unwrap();
+
+    let loaded = load_config_with_source(Some(&config_path));
+    assert_eq!(loaded.config.dialect, None);
+}
+
+#[test]
 fn load_config_reads_compiler_template_syntax() {
     let dir = tempfile::tempdir().unwrap();
     let config_path = dir.path().join("vize.config.json");

--- a/crates/vize_carton/src/config/model.rs
+++ b/crates/vize_carton/src/config/model.rs
@@ -12,6 +12,7 @@ use serde::{Deserialize, Serialize};
 use compiler::RawCompilerConfig;
 
 use crate::String;
+use crate::dialect::VueDialect;
 pub use formatter::{
     ArrowParens, AttributeSortOrder, EndOfLine, FormatterConfig, QuoteProps, TrailingComma,
 };
@@ -28,6 +29,11 @@ pub struct VizeConfig {
     /// JSON Schema reference for legacy JSON editor autocompletion.
     #[serde(rename = "$schema", skip_serializing_if = "Option::is_none")]
     pub schema: Option<String>,
+    /// Vue dialect profile for standalone HTML documents (`"vue"` or
+    /// `"petite-vue"`). When absent, the dialect is detected structurally per
+    /// document (see [`crate::dialect::standalone_html_dialect`]).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub dialect: Option<VueDialect>,
     /// Formatter settings shared by CLI and IDE formatting.
     #[serde(skip_serializing_if = "FormatterConfig::is_default")]
     pub formatter: FormatterConfig,
@@ -68,6 +74,7 @@ pub struct ConfigFeatureFlags {
 pub(crate) struct RawVizeConfig {
     #[serde(rename = "$schema")]
     pub schema: Option<String>,
+    pub dialect: Option<VueDialect>,
     pub formatter: FormatterConfig,
     pub(crate) compiler: RawCompilerConfig,
     pub linter: LinterConfig,
@@ -118,6 +125,7 @@ impl RawVizeConfig {
     pub(crate) fn into_config_and_features(self) -> (VizeConfig, ConfigFeatureFlags) {
         let RawVizeConfig {
             schema,
+            dialect,
             formatter,
             compiler: _,
             linter: _,
@@ -161,6 +169,7 @@ impl RawVizeConfig {
 
         let config = VizeConfig {
             schema,
+            dialect,
             formatter,
             type_checker,
             language_server,

--- a/crates/vize_carton/src/dialect.rs
+++ b/crates/vize_carton/src/dialect.rs
@@ -1,0 +1,486 @@
+//! Vue dialect profiles and structural petite-vue detection.
+//!
+//! A document's dialect decides which directive set, completions, and lint
+//! gating apply. The dialect is resolved once per document from an explicit
+//! config key when present, otherwise from a structural scan of the document's
+//! `<script>` tags (petite-vue CDN/module `src`, an ES import of the
+//! petite-vue package, or a `PetiteVue.createApp` global call). Raw substring
+//! sniffing over the whole document is deliberately avoided so that prose or
+//! comments merely mentioning "petite-vue" never flip the dialect.
+
+use serde::{Deserialize, Serialize};
+
+/// The Vue template dialect a document is written in.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum VueDialect {
+    /// Standard Vue 3 (SFCs and full-build templates).
+    #[default]
+    Vue,
+    /// [petite-vue](https://github.com/vuejs/petite-vue) standalone HTML documents.
+    PetiteVue,
+}
+
+impl VueDialect {
+    /// Returns true for the petite-vue dialect.
+    #[inline]
+    pub fn is_petite_vue(self) -> bool {
+        matches!(self, Self::PetiteVue)
+    }
+}
+
+/// Resolve the dialect for a standalone HTML document.
+///
+/// An explicit config value always wins; otherwise the document is scanned
+/// structurally with [`detect_petite_vue_document`].
+#[inline]
+pub fn standalone_html_dialect(configured: Option<VueDialect>, content: &str) -> VueDialect {
+    match configured {
+        Some(dialect) => dialect,
+        None if detect_petite_vue_document(content) => VueDialect::PetiteVue,
+        None => VueDialect::Vue,
+    }
+}
+
+/// Returns true when a module specifier resolves to the petite-vue package.
+///
+/// Accepts the bare specifier (`petite-vue`), deep imports
+/// (`petite-vue/dist/...`), and URL or path specifiers whose path contains a
+/// petite-vue segment (`https://unpkg.com/petite-vue@0.4.1/dist/petite-vue.es.js`,
+/// `/node_modules/petite-vue/...`). Query strings and fragments are ignored.
+/// Lookalike packages such as `petite-vuex` do not match.
+pub fn is_petite_vue_module(specifier: &str) -> bool {
+    let path = specifier
+        .split(['?', '#'])
+        .next()
+        .unwrap_or(specifier)
+        .trim();
+    if path == "petite-vue" || path.starts_with("petite-vue/") {
+        return true;
+    }
+    path.split('/').any(|segment| {
+        segment
+            .strip_prefix("petite-vue")
+            .is_some_and(|rest| rest.is_empty() || rest.starts_with('@') || rest.starts_with('.'))
+    })
+}
+
+/// Structurally detect petite-vue usage in a standalone HTML document.
+///
+/// The scan only inspects `<script>` start tags and inline script bodies:
+///
+/// - `<script src="...">` where the `src` resolves to the petite-vue package
+///   (CDN URL, node_modules path, or bare specifier), e.g.
+///   `<script src="https://unpkg.com/petite-vue" defer init>`.
+/// - Inline scripts containing an ES import (static, side-effect, or dynamic)
+///   whose specifier resolves to the petite-vue package.
+/// - Inline scripts calling the `PetiteVue.createApp` IIFE global.
+///
+/// HTML comments are skipped, and inside inline scripts JS comments and string
+/// literals are skipped, so a document merely *mentioning* petite-vue is never
+/// detected as petite-vue.
+pub fn detect_petite_vue_document(content: &str) -> bool {
+    let bytes = content.as_bytes();
+    let mut pos = 0;
+
+    while pos < bytes.len() {
+        let Some(relative) = content[pos..].find('<') else {
+            return false;
+        };
+        let start = pos + relative;
+        let rest = &content[start..];
+
+        if let Some(comment) = rest.strip_prefix("<!--") {
+            // Skip HTML comments entirely.
+            match comment.find("-->") {
+                Some(end) => pos = start + 4 + end + 3,
+                None => return false,
+            }
+            continue;
+        }
+
+        if !starts_with_script_tag(rest) {
+            pos = start + 1;
+            continue;
+        }
+
+        let tag_body_start = start + "<script".len();
+        let Some((attrs_end, src)) = parse_start_tag_attributes(content, tag_body_start) else {
+            return false;
+        };
+
+        if let Some(src) = src {
+            if is_petite_vue_module(src) {
+                return true;
+            }
+            // External script: no inline body to inspect.
+            pos = attrs_end;
+            continue;
+        }
+
+        // Inline script: scan the body up to the closing tag.
+        let body_start = attrs_end;
+        let body_end = find_script_close(content, body_start).unwrap_or(content.len());
+        if inline_script_uses_petite_vue(&content[body_start..body_end]) {
+            return true;
+        }
+        pos = body_end;
+    }
+
+    false
+}
+
+/// Returns true when `rest` starts a `<script` start tag (case-insensitive,
+/// followed by whitespace, `>`, or `/`).
+fn starts_with_script_tag(rest: &str) -> bool {
+    let bytes = rest.as_bytes();
+    if bytes.len() < 7 || !bytes[1..7].eq_ignore_ascii_case(b"script") {
+        return false;
+    }
+    matches!(
+        bytes.get(7),
+        Some(b'>' | b'/' | b' ' | b'\t' | b'\n' | b'\r')
+    )
+}
+
+/// Parse the attributes of a start tag beginning right after the tag name.
+///
+/// Returns the offset just past the closing `>` and the value of the `src`
+/// attribute, if any. Quoted attribute values are honoured so a `>` inside a
+/// value does not terminate the tag. Returns `None` when the tag is unclosed.
+fn parse_start_tag_attributes(content: &str, mut pos: usize) -> Option<(usize, Option<&str>)> {
+    let bytes = content.as_bytes();
+    let mut src = None;
+
+    while pos < bytes.len() {
+        match bytes[pos] {
+            b'>' => return Some((pos + 1, src)),
+            b'/' | b' ' | b'\t' | b'\n' | b'\r' => {
+                pos += 1;
+            }
+            _ => {
+                // Attribute name.
+                let name_start = pos;
+                while pos < bytes.len()
+                    && !matches!(
+                        bytes[pos],
+                        b'=' | b'>' | b'/' | b' ' | b'\t' | b'\n' | b'\r'
+                    )
+                {
+                    pos += 1;
+                }
+                let name = &content[name_start..pos];
+
+                while pos < bytes.len() && bytes[pos].is_ascii_whitespace() {
+                    pos += 1;
+                }
+                if bytes.get(pos) != Some(&b'=') {
+                    // Boolean attribute (e.g. `defer`, `init`).
+                    continue;
+                }
+                pos += 1;
+                while pos < bytes.len() && bytes[pos].is_ascii_whitespace() {
+                    pos += 1;
+                }
+
+                let value = match bytes.get(pos) {
+                    Some(&quote @ (b'"' | b'\'')) => {
+                        let value_start = pos + 1;
+                        let relative_end = content[value_start..].find(quote as char)?;
+                        pos = value_start + relative_end + 1;
+                        &content[value_start..value_start + relative_end]
+                    }
+                    _ => {
+                        let value_start = pos;
+                        while pos < bytes.len()
+                            && !matches!(bytes[pos], b'>' | b' ' | b'\t' | b'\n' | b'\r')
+                        {
+                            pos += 1;
+                        }
+                        &content[value_start..pos]
+                    }
+                };
+                if name.eq_ignore_ascii_case("src") {
+                    src = Some(value);
+                }
+            }
+        }
+    }
+
+    None
+}
+
+/// Find the offset of the next `</script` close tag (case-insensitive).
+fn find_script_close(content: &str, from: usize) -> Option<usize> {
+    let bytes = content.as_bytes();
+    let mut pos = from;
+    while pos < bytes.len() {
+        let relative = content[pos..].find('<')?;
+        let start = pos + relative;
+        let rest = &bytes[start..];
+        if rest.len() >= 9 && rest[1] == b'/' && rest[2..8].eq_ignore_ascii_case(b"script") {
+            return Some(start);
+        }
+        pos = start + 1;
+    }
+    None
+}
+
+/// Scan an inline script body for structural petite-vue usage.
+///
+/// Detects ES imports of the petite-vue package (static `import ... from`,
+/// side-effect `import "..."`, dynamic `import("...")`) and the
+/// `PetiteVue.createApp` IIFE global. Comments and unrelated string literals
+/// are skipped so mentions of petite-vue in prose never match.
+fn inline_script_uses_petite_vue(script: &str) -> bool {
+    let bytes = script.as_bytes();
+    let mut pos = 0;
+
+    while pos < bytes.len() {
+        match bytes[pos] {
+            b'/' if bytes.get(pos + 1) == Some(&b'/') => {
+                pos = match script[pos..].find('\n') {
+                    Some(end) => pos + end + 1,
+                    None => bytes.len(),
+                };
+            }
+            b'/' if bytes.get(pos + 1) == Some(&b'*') => {
+                pos = match script[pos + 2..].find("*/") {
+                    Some(end) => pos + 2 + end + 2,
+                    None => bytes.len(),
+                };
+            }
+            b'"' | b'\'' | b'`' => {
+                pos = skip_string_literal(bytes, pos);
+            }
+            byte if is_ident_start(byte) => {
+                let word_start = pos;
+                while pos < bytes.len() && is_ident_char(bytes[pos]) {
+                    pos += 1;
+                }
+                match &script[word_start..pos] {
+                    "import" | "from" if import_specifier_is_petite_vue(script, pos) => {
+                        return true;
+                    }
+                    "PetiteVue" if followed_by_create_app(script, pos) => return true,
+                    _ => {}
+                }
+            }
+            _ => pos += 1,
+        }
+    }
+
+    false
+}
+
+/// Check whether an `import`/`from` keyword at `pos` introduces a petite-vue
+/// module specifier (`from "spec"`, `import "spec"`, or `import("spec")`).
+fn import_specifier_is_petite_vue(script: &str, mut pos: usize) -> bool {
+    let bytes = script.as_bytes();
+    while pos < bytes.len() && bytes[pos].is_ascii_whitespace() {
+        pos += 1;
+    }
+    // Dynamic import: import("spec")
+    if bytes.get(pos) == Some(&b'(') {
+        pos += 1;
+        while pos < bytes.len() && bytes[pos].is_ascii_whitespace() {
+            pos += 1;
+        }
+    }
+    let Some(&quote @ (b'"' | b'\'')) = bytes.get(pos) else {
+        return false;
+    };
+    let value_start = pos + 1;
+    let Some(relative_end) = script[value_start..].find(quote as char) else {
+        return false;
+    };
+    is_petite_vue_module(&script[value_start..value_start + relative_end])
+}
+
+/// Check for `.createApp` (allowing whitespace) after a `PetiteVue` token.
+fn followed_by_create_app(script: &str, mut pos: usize) -> bool {
+    let bytes = script.as_bytes();
+    while pos < bytes.len() && bytes[pos].is_ascii_whitespace() {
+        pos += 1;
+    }
+    if bytes.get(pos) != Some(&b'.') {
+        return false;
+    }
+    pos += 1;
+    while pos < bytes.len() && bytes[pos].is_ascii_whitespace() {
+        pos += 1;
+    }
+    let word_start = pos;
+    while pos < bytes.len() && is_ident_char(bytes[pos]) {
+        pos += 1;
+    }
+    &script[word_start..pos] == "createApp"
+}
+
+/// Skip a JS string literal starting at `pos`; returns the offset past it.
+fn skip_string_literal(bytes: &[u8], pos: usize) -> usize {
+    let quote = bytes[pos];
+    let mut pos = pos + 1;
+    while pos < bytes.len() {
+        match bytes[pos] {
+            b'\\' => pos += 2,
+            byte if byte == quote => return pos + 1,
+            _ => pos += 1,
+        }
+    }
+    pos
+}
+
+#[inline]
+fn is_ident_start(byte: u8) -> bool {
+    byte.is_ascii_alphabetic() || byte == b'_' || byte == b'$'
+}
+
+#[inline]
+fn is_ident_char(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || byte == b'_' || byte == b'$'
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        VueDialect, detect_petite_vue_document, is_petite_vue_module, standalone_html_dialect,
+    };
+
+    #[test]
+    fn module_specifier_matches_petite_vue_forms() {
+        assert!(is_petite_vue_module("petite-vue"));
+        assert!(is_petite_vue_module("petite-vue/dist/petite-vue.es.js"));
+        assert!(is_petite_vue_module("https://unpkg.com/petite-vue"));
+        assert!(is_petite_vue_module("https://unpkg.com/petite-vue?module"));
+        assert!(is_petite_vue_module(
+            "https://unpkg.com/petite-vue@0.4.1/dist/petite-vue.iife.js"
+        ));
+        assert!(is_petite_vue_module(
+            "/node_modules/petite-vue/dist/petite-vue.es.js"
+        ));
+        assert!(is_petite_vue_module(
+            "https://cdn.jsdelivr.net/npm/petite-vue@0.4/dist/petite-vue.min.js"
+        ));
+    }
+
+    #[test]
+    fn module_specifier_rejects_lookalikes() {
+        assert!(!is_petite_vue_module("vue"));
+        assert!(!is_petite_vue_module("petite-vuex"));
+        assert!(!is_petite_vue_module("https://unpkg.com/petite-vuex"));
+        assert!(!is_petite_vue_module("my-petite-vue"));
+        assert!(!is_petite_vue_module("./libs/petite-vue-helpers.js"));
+    }
+
+    #[test]
+    fn detects_cdn_script_src() {
+        let content = r#"<!doctype html>
+<html>
+<body>
+  <div v-scope>{{ count }}</div>
+  <script src="https://unpkg.com/petite-vue" defer init></script>
+</body>
+</html>"#;
+        assert!(detect_petite_vue_document(content));
+    }
+
+    #[test]
+    fn detects_unquoted_script_src() {
+        let content = r#"<script src=https://unpkg.com/petite-vue defer init></script>"#;
+        assert!(detect_petite_vue_document(content));
+    }
+
+    #[test]
+    fn detects_inline_module_import() {
+        let content = r#"<script type="module">
+  import { createApp } from 'https://unpkg.com/petite-vue?module'
+  createApp({ count: 0 }).mount()
+</script>"#;
+        assert!(detect_petite_vue_document(content));
+    }
+
+    #[test]
+    fn detects_side_effect_and_dynamic_imports() {
+        assert!(detect_petite_vue_document(
+            r#"<script type="module">import "petite-vue"</script>"#
+        ));
+        assert!(detect_petite_vue_document(
+            r#"<script type="module">const m = await import("petite-vue")</script>"#
+        ));
+    }
+
+    #[test]
+    fn detects_petite_vue_global_create_app() {
+        let content = r#"<script src="/js/vendor.js"></script>
+<script>
+PetiteVue.createApp({ count: 0 }).mount()
+</script>"#;
+        assert!(detect_petite_vue_document(content));
+    }
+
+    #[test]
+    fn ignores_mentions_in_html_comments_and_text() {
+        let content = r#"<!doctype html>
+<!-- This page is NOT using petite-vue, see PetiteVue.createApp docs -->
+<!-- <script src="https://unpkg.com/petite-vue" defer init></script> -->
+<body>
+  <p>petite-vue is a 6kb subset of Vue.</p>
+  <script src="https://unpkg.com/vue@3/dist/vue.global.js"></script>
+</body>"#;
+        assert!(!detect_petite_vue_document(content));
+    }
+
+    #[test]
+    fn ignores_mentions_in_script_comments_and_strings() {
+        let content = r#"<script>
+// import { createApp } from 'petite-vue'
+/* PetiteVue.createApp() is the IIFE entrypoint */
+const docs = "https://unpkg.com/petite-vue";
+const note = 'PetiteVue.createApp';
+</script>"#;
+        assert!(!detect_petite_vue_document(content));
+    }
+
+    #[test]
+    fn ignores_plain_vue_documents() {
+        let content = r#"<script src="https://unpkg.com/vue@3"></script>
+<script>
+Vue.createApp({ data: () => ({ count: 0 }) }).mount('#app')
+</script>"#;
+        assert!(!detect_petite_vue_document(content));
+    }
+
+    #[test]
+    fn config_overrides_detection() {
+        let petite = r#"<script src="https://unpkg.com/petite-vue" defer init></script>"#;
+        let plain = "<div>{{ count }}</div>";
+
+        assert_eq!(
+            standalone_html_dialect(Some(VueDialect::Vue), petite),
+            VueDialect::Vue
+        );
+        assert_eq!(
+            standalone_html_dialect(Some(VueDialect::PetiteVue), plain),
+            VueDialect::PetiteVue
+        );
+        assert_eq!(standalone_html_dialect(None, petite), VueDialect::PetiteVue);
+        assert_eq!(standalone_html_dialect(None, plain), VueDialect::Vue);
+    }
+
+    #[test]
+    fn dialect_serde_uses_kebab_case() {
+        assert_eq!(
+            serde_json::from_str::<VueDialect>("\"petite-vue\"").unwrap(),
+            VueDialect::PetiteVue
+        );
+        assert_eq!(
+            serde_json::from_str::<VueDialect>("\"vue\"").unwrap(),
+            VueDialect::Vue
+        );
+        assert_eq!(
+            serde_json::to_string(&VueDialect::PetiteVue).unwrap(),
+            "\"petite-vue\""
+        );
+    }
+}

--- a/crates/vize_carton/src/lib.rs
+++ b/crates/vize_carton/src/lib.rs
@@ -40,6 +40,7 @@ mod vec;
 
 // Shared modules
 pub mod config;
+pub mod dialect;
 pub mod directive;
 pub mod dom_tag_config;
 pub mod flags;

--- a/crates/vize_maestro/src/document/store.rs
+++ b/crates/vize_maestro/src/document/store.rs
@@ -1,6 +1,8 @@
 //! Document store implementation using Rope for efficient text operations.
 #![allow(clippy::disallowed_types, clippy::disallowed_methods)]
 
+use std::sync::OnceLock;
+
 use dashmap::DashMap;
 use ropey::Rope;
 use tower_lsp::lsp_types::{TextDocumentContentChangeEvent, Url};
@@ -18,6 +20,10 @@ pub struct Document {
     pub content: Rope,
     /// Language ID (e.g., "vue", "typescript")
     pub language_id: String,
+    /// Lazily computed structural petite-vue detection result, memoized per
+    /// document version so per-request consumers (completion, definition, ...)
+    /// never re-scan the content. Reset on every edit.
+    petite_vue_detected: OnceLock<bool>,
 }
 
 impl Document {
@@ -28,7 +34,18 @@ impl Document {
             version,
             content: Rope::from_str(&content),
             language_id,
+            petite_vue_detected: OnceLock::new(),
         }
+    }
+
+    /// Whether the document structurally uses petite-vue (see
+    /// [`vize_carton::dialect::detect_petite_vue_document`]).
+    ///
+    /// Computed at most once per document version; edits invalidate the cache.
+    pub fn petite_vue_detected(&self) -> bool {
+        *self
+            .petite_vue_detected
+            .get_or_init(|| vize_carton::dialect::detect_petite_vue_document(&self.text()))
     }
 
     /// Get the document content as a string.
@@ -52,6 +69,7 @@ impl Document {
     /// Apply an incremental change to the document.
     pub fn apply_change(&mut self, change: &TextDocumentContentChangeEvent, new_version: i32) {
         self.version = new_version;
+        self.petite_vue_detected = OnceLock::new();
 
         if let Some(range) = change.range {
             // Incremental change
@@ -297,6 +315,31 @@ mod tests {
 
         assert_eq!(doc.text(), "a😀b");
         assert_eq!(doc.version, 2);
+    }
+
+    #[test]
+    fn test_petite_vue_detection_is_memoized_and_reset_on_change() {
+        let mut doc = Document::new(
+            test_uri(),
+            "<div id=\"app\">{{ count }}</div>".to_string(),
+            1,
+            "html".to_string(),
+        );
+        assert!(!doc.petite_vue_detected());
+        // Memoized: repeated queries are answered from the cache.
+        assert!(!doc.petite_vue_detected());
+
+        let change = TextDocumentContentChangeEvent {
+            range: None,
+            range_length: None,
+            text: "<script src=\"https://unpkg.com/petite-vue\" defer init></script>\n\
+                   <div v-scope>{{ count }}</div>"
+                .to_string(),
+        };
+        doc.apply_change(&change, 2);
+
+        // Edits invalidate the cached detection result.
+        assert!(doc.petite_vue_detected());
     }
 
     #[test]

--- a/crates/vize_maestro/src/ide.rs
+++ b/crates/vize_maestro/src/ide.rs
@@ -445,6 +445,16 @@ impl<'a> IdeContext<'a> {
         }
     }
 
+    /// Effective Vue dialect for this document.
+    ///
+    /// Delegates to [`ServerState::document_dialect`]: an explicit `dialect`
+    /// config key wins, otherwise the structural petite-vue detection memoized
+    /// on the open document is used (no per-request re-scan).
+    #[inline]
+    pub fn dialect(&self) -> vize_carton::dialect::VueDialect {
+        self.state.document_dialect(self.uri, &self.content)
+    }
+
     /// Check if cursor is in template block.
     #[inline]
     pub fn is_in_template(&self) -> bool {

--- a/crates/vize_maestro/src/ide/completion/template/directives.rs
+++ b/crates/vize_maestro/src/ide/completion/template/directives.rs
@@ -34,9 +34,7 @@ pub(crate) fn directive_completions() -> Vec<CompletionItem> {
 /// Vue directive completions, extended with opt-in document-specific directives.
 pub(crate) fn contextual_directive_completions(ctx: &IdeContext) -> Vec<CompletionItem> {
     let mut completions = directive_completions();
-    if crate::utils::is_standalone_html_path(ctx.uri.path())
-        && crate::utils::is_petite_vue_document(&ctx.content)
-    {
+    if ctx.dialect().is_petite_vue() {
         completions.extend(petite_vue_directive_completions());
     }
     completions

--- a/crates/vize_maestro/src/ide/completion/tests.rs
+++ b/crates/vize_maestro/src/ide/completion/tests.rs
@@ -169,6 +169,74 @@ fn test_standalone_html_completion_includes_petite_vue_directives() {
 }
 
 #[test]
+fn test_standalone_html_completion_ignores_petite_vue_mention_in_comment() {
+    let dir = tempfile::tempdir().unwrap();
+    let source_path = dir.path().join("index.html");
+    let source = r#"<!-- TODO: maybe migrate to petite-vue (PetiteVue.createApp, v-scope) -->
+<script src="https://unpkg.com/vue@3/dist/vue.global.js"></script>
+<div id="app" >{{ count }}</div>
+"#;
+    fs::write(&source_path, source).unwrap();
+
+    let uri = Url::from_file_path(&source_path).unwrap();
+    let state = ServerState::new();
+    state
+        .documents
+        .open(uri.clone(), source.to_string(), 1, "html".to_string());
+    state.update_virtual_docs(&uri, source);
+
+    let offset = source.find("<div ").unwrap() + "<div ".len();
+    let ctx = IdeContext::new(&state, &uri, offset).unwrap();
+    let labels = completion_labels(CompletionService::complete(&ctx).unwrap());
+
+    assert!(!has_label(&labels, "v-scope"));
+    assert!(!has_label(&labels, "v-effect"));
+    assert!(has_label(&labels, "v-if"));
+}
+
+#[test]
+fn test_standalone_html_completion_respects_dialect_config() {
+    let dir = tempfile::tempdir().unwrap();
+    let source_path = dir.path().join("index.html");
+    let source = "<div id=\"app\" >{{ count }}</div>\n";
+    fs::write(&source_path, source).unwrap();
+
+    let uri = Url::from_file_path(&source_path).unwrap();
+    let state = ServerState::new();
+    state
+        .documents
+        .open(uri.clone(), source.to_string(), 1, "html".to_string());
+    state.update_virtual_docs(&uri, source);
+    state.set_dialect_config(Some(vize_carton::dialect::VueDialect::PetiteVue));
+
+    let offset = source.find("<div ").unwrap() + "<div ".len();
+    let ctx = IdeContext::new(&state, &uri, offset).unwrap();
+    let labels = completion_labels(CompletionService::complete(&ctx).unwrap());
+
+    // No petite-vue markers in the document; the config key alone opts in.
+    assert!(has_label(&labels, "v-scope"));
+    assert!(has_label(&labels, "v-effect"));
+
+    // And an explicit `vue` dialect suppresses detection-based opt-in.
+    state.set_dialect_config(Some(vize_carton::dialect::VueDialect::Vue));
+    let petite_source = r#"<script src="https://unpkg.com/petite-vue" defer init></script>
+<div v-scope="{ count: 0 }" >{{ count }}</div>
+"#;
+    state.documents.open(
+        uri.clone(),
+        petite_source.to_string(),
+        2,
+        "html".to_string(),
+    );
+    let offset = petite_source.find("<div ").unwrap() + "<div ".len();
+    let ctx = IdeContext::new(&state, &uri, offset).unwrap();
+    let labels = completion_labels(CompletionService::complete(&ctx).unwrap());
+
+    assert!(!has_label(&labels, "v-scope"));
+    assert!(!has_label(&labels, "v-effect"));
+}
+
+#[test]
 fn test_script_ref_member_completion_includes_value() {
     let source = r#"<script setup lang="ts">
 import { ref, computed } from 'vue'

--- a/crates/vize_maestro/src/ide/definition/template.rs
+++ b/crates/vize_maestro/src/ide/definition/template.rs
@@ -114,7 +114,7 @@ fn find_standalone_html_scope_definition(
     ctx: &IdeContext<'_>,
     word: &str,
 ) -> Option<GotoDefinitionResponse> {
-    if !crate::utils::is_petite_vue_document(&ctx.content) {
+    if !ctx.dialect().is_petite_vue() {
         return None;
     }
 

--- a/crates/vize_maestro/src/server/state/config.rs
+++ b/crates/vize_maestro/src/server/state/config.rs
@@ -41,6 +41,18 @@ impl ServerState {
         self.linter_config.read().clone()
     }
 
+    /// Get the configured Vue dialect override, if any.
+    #[inline]
+    pub fn get_dialect_config(&self) -> Option<vize_carton::dialect::VueDialect> {
+        *self.dialect_config.read()
+    }
+
+    /// Set the Vue dialect override (`None` re-enables structural detection).
+    #[inline]
+    pub fn set_dialect_config(&self, dialect: Option<vize_carton::dialect::VueDialect>) {
+        *self.dialect_config.write() = dialect;
+    }
+
     fn apply_type_checker_config(&self, config: TypeCheckerConfig, source: &str) {
         *self.type_checker_config.write() = config;
         tracing::info!("Loaded type checker config from {}", source);
@@ -84,6 +96,7 @@ impl ServerState {
             self.apply_type_checker_config(config.type_checker, &source);
             self.apply_lsp_config(config.language_server.into(), &source);
             self.apply_config_features(loaded.features);
+            self.set_dialect_config(config.dialect);
         }
     }
 
@@ -97,6 +110,7 @@ impl ServerState {
             self.apply_type_checker_config(loaded.config.type_checker, &source);
             self.apply_lsp_config(loaded.config.language_server.into(), &source);
             self.apply_config_features(loaded.features);
+            self.set_dialect_config(loaded.config.dialect);
         }
     }
 

--- a/crates/vize_maestro/src/server/state/mod.rs
+++ b/crates/vize_maestro/src/server/state/mod.rs
@@ -20,6 +20,7 @@ use dashmap::DashMap;
 use parking_lot::RwLock;
 use tower_lsp::lsp_types::Url;
 use vize_carton::config::{LinterConfig, TypeCheckerConfig};
+use vize_carton::dialect::VueDialect;
 
 #[cfg(feature = "native")]
 use std::sync::Arc;
@@ -66,6 +67,9 @@ pub struct ServerState {
     type_checker_legacy_vue2: RwLock<bool>,
     /// Linter options shared by LSP diagnostics.
     linter_config: RwLock<LinterConfig>,
+    /// Explicit Vue dialect from config (`dialect` key). `None` means the
+    /// dialect is detected structurally per document.
+    dialect_config: RwLock<Option<VueDialect>>,
     /// Formatting options (loaded from vize.config.json)
     #[cfg(feature = "glyph")]
     format_options: RwLock<vize_glyph::FormatOptions>,
@@ -120,6 +124,7 @@ impl ServerState {
             type_checker_options_api: RwLock::new(false),
             type_checker_legacy_vue2: RwLock::new(false),
             linter_config: RwLock::new(LinterConfig::default()),
+            dialect_config: RwLock::new(None),
             #[cfg(feature = "glyph")]
             format_options: RwLock::new(vize_glyph::FormatOptions::default()),
             #[cfg(feature = "native")]
@@ -153,6 +158,27 @@ impl ServerState {
     #[inline]
     pub fn is_lsp_typecheck_enabled(&self) -> bool {
         self.lsp_typecheck_enabled.load(Ordering::SeqCst)
+    }
+
+    /// Effective Vue dialect for a document, decided once per document version.
+    ///
+    /// Non-HTML documents (SFCs, scripts) always use the standard Vue dialect.
+    /// For standalone HTML documents an explicit `dialect` config key wins;
+    /// otherwise the structural petite-vue detection memoized on the open
+    /// document is used. `content` is only consulted as a fallback when the
+    /// document is not in the store.
+    pub fn document_dialect(&self, uri: &Url, content: &str) -> VueDialect {
+        if !crate::utils::is_standalone_html_path(uri.path()) {
+            return VueDialect::Vue;
+        }
+        if let Some(configured) = *self.dialect_config.read() {
+            return configured;
+        }
+        match self.documents.get(uri) {
+            Some(document) if document.petite_vue_detected() => VueDialect::PetiteVue,
+            Some(_) => VueDialect::Vue,
+            None => vize_carton::dialect::standalone_html_dialect(None, content),
+        }
     }
 
     /// Get the enabled LSP feature set.

--- a/crates/vize_maestro/src/utils.rs
+++ b/crates/vize_maestro/src/utils.rs
@@ -13,12 +13,3 @@ pub fn is_standalone_html_path(path: &str) -> bool {
     let path = path.to_ascii_lowercase();
     path.ends_with(".html") || path.ends_with(".htm")
 }
-
-/// Returns true when a standalone HTML document appears to use petite-vue.
-#[inline]
-pub fn is_petite_vue_document(content: &str) -> bool {
-    content.contains("petite-vue")
-        || content.contains("PetiteVue")
-        || content.contains("v-scope")
-        || content.contains("v-effect")
-}

--- a/crates/vize_patina/src/rules/script/no_options_api.rs
+++ b/crates/vize_patina/src/rules/script/no_options_api.rs
@@ -37,6 +37,7 @@ use oxc_ast::ast::{
     ObjectExpression, ObjectPropertyKind, Program, PropertyKey, Statement,
 };
 use oxc_span::GetSpan;
+use vize_carton::dialect::is_petite_vue_module;
 use vize_carton::{CompactString, FxHashMap, FxHashSet};
 
 static META: ScriptRuleMeta = ScriptRuleMeta {
@@ -468,10 +469,6 @@ fn is_petite_vue_namespace_expression(
         }
         _ => false,
     }
-}
-
-fn is_petite_vue_module(value: &str) -> bool {
-    value == "petite-vue" || value.starts_with("petite-vue/") || value.contains("/petite-vue")
 }
 
 fn binding_pattern_name<'a>(pattern: &'a BindingPattern<'a>) -> Option<&'a str> {

--- a/docs/content/guide/configuration.md
+++ b/docs/content/guide/configuration.md
@@ -247,6 +247,27 @@ Vue upstream implementation:
 See [Troubleshooting](./troubleshooting.md) for the HTML strict-mode behavior behind invalid
 self-closing tags.
 
+## Vue Dialect
+
+`dialect` selects the Vue dialect profile for standalone HTML documents (`.html`/`.htm`):
+
+```json
+{
+  "dialect": "petite-vue"
+}
+```
+
+- `"vue"` treats standalone HTML documents as plain Vue-from-CDN documents.
+- `"petite-vue"` opts standalone HTML documents into the
+  [petite-vue](https://github.com/vuejs/petite-vue) dialect (`v-scope`/`v-effect`
+  completions and petite-vue-aware IDE features).
+
+When the key is absent, the dialect is detected structurally per document: a
+`<script src>` resolving to the petite-vue package, an inline ES import of
+`petite-vue`, or a `PetiteVue.createApp` call. Mentions of petite-vue in
+comments or prose never switch the dialect. Single-file components always use
+the standard Vue dialect.
+
 ## Static Analysis Options
 
 Use `linter` for the npm lint path:

--- a/npm/vize/pkl/VizeConfig.pkl
+++ b/npm/vize/pkl/VizeConfig.pkl
@@ -25,6 +25,10 @@ import "GlobalTypesConfig.pkl"
 
 typealias ConfigExtends = String | Listing<String>
 
+/// Vue dialect profile for standalone HTML documents.
+/// When absent, the dialect is detected structurally per document.
+typealias VueDialect = "vue" | "petite-vue"
+
 class ConfigEntry {
   /// Human-readable entry name for inspect output and diagnostics.
   name: String? = null
@@ -40,6 +44,10 @@ class ConfigEntry {
 
   /// Base config files or presets amended by this entry.
   `extends`: ConfigExtends? = null
+
+  /// Vue dialect profile for standalone HTML documents (`"vue"` or `"petite-vue"`).
+  /// When absent, the dialect is detected structurally per document.
+  dialect: VueDialect? = null
 
   /// Vue compiler options.
   compiler: CompilerConfig.CompilerConfig = new CompilerConfig.CompilerConfig {}
@@ -87,6 +95,10 @@ ignores: Listing<String>? = null
 
 /// Base config files or presets amended by this config.
 `extends`: ConfigExtends? = null
+
+/// Vue dialect profile for standalone HTML documents (`"vue"` or `"petite-vue"`).
+/// When absent, the dialect is detected structurally per document.
+dialect: VueDialect? = null
 
 /// Vue compiler options.
 compiler: CompilerConfig.CompilerConfig = new CompilerConfig.CompilerConfig {}

--- a/npm/vize/schemas/vize.config.schema.json
+++ b/npm/vize/schemas/vize.config.schema.json
@@ -730,6 +730,11 @@
             }
           ]
         },
+        "dialect": {
+          "description": "Vue dialect profile for standalone HTML documents; when absent the dialect is detected structurally per document",
+          "type": "string",
+          "enum": ["vue", "petite-vue"]
+        },
         "compiler": {
           "$ref": "#/definitions/CompilerConfig"
         },
@@ -804,6 +809,11 @@
           }
         }
       ]
+    },
+    "dialect": {
+      "description": "Vue dialect profile for standalone HTML documents; when absent the dialect is detected structurally per document",
+      "type": "string",
+      "enum": ["vue", "petite-vue"]
     },
     "compiler": {
       "$ref": "#/definitions/CompilerConfig"


### PR DESCRIPTION
## Summary

PR1 of the petite-vue umbrella (#1393): replace the substring-based petite-vue sniff with an explicit dialect/profile mechanism.

- **`vize_carton::dialect`** (new module, single source of truth):
  - `VueDialect` enum (`"vue"` / `"petite-vue"`, serde kebab-case) shared across crates.
  - `detect_petite_vue_document`: structural detection that only inspects parsed `<script>` start tags and inline script bodies — `<script src>` resolving to the petite-vue package (CDN/path/bare specifier, e.g. `<script src="https://unpkg.com/petite-vue" defer init>`), inline ES imports (static/side-effect/dynamic) of the petite-vue package, and `PetiteVue.createApp` IIFE-global calls. HTML comments, JS comments, and JS string literals are skipped.
  - `is_petite_vue_module`: segment-aware specifier check (rejects lookalikes such as `petite-vuex`), now shared with patina.
- **Config key**: top-level `dialect` in the vize config (Rust model, pkl template, JSON schema, docs). Explicit config always wins; when absent, the structural detection decides per document. SFCs always stay on the standard Vue dialect.
- **maestro**: `is_petite_vue_document` deleted from `utils.rs`; completion (`contextual_directive_completions`) and definition (`find_standalone_html_scope_definition`) are rewired through `IdeContext::dialect()` → `ServerState::document_dialect`.
- **patina**: `script/no-options-api` drops its local `is_petite_vue_module` copy and reuses the carton one.

## Why substring sniffing is wrong

`is_petite_vue_document` was `content.contains("petite-vue") || contains("PetiteVue") || contains("v-scope") || contains("v-effect")` over the raw document:

- **False positives**: any HTML comment, prose, or attribute merely *mentioning* petite-vue (or containing `v-scope` in a code sample) flipped the whole document into petite-vue mode.
- **Scattered duplication**: maestro sniffed raw content per request while patina kept its own `is_petite_vue_module` copy — two divergent notions of "petite-vue" with no config escape hatch.
- **Re-sniffed per request**: the 4× O(n) scan ran on every completion and every go-to-definition request. The detection result is now memoized per document version on the LSP `Document` (`OnceLock`, invalidated on edit), so the dialect is decided once per document, not re-sniffed per feature request.

The substring heuristic is deleted rather than kept as a fallback: every existing test fixture (maestro completion/definition, patina standalone HTML) already uses a real `<script src=...petite-vue>` tag, so structural detection covers them, and documents that load petite-vue invisibly (bundlers) now have the explicit `dialect: "petite-vue"` config key instead of a comment-triggerable guess.

## Test plan

- `cargo test -p vize_maestro -p vize_patina -p vize_carton` — all green (12 new dialect unit tests, 2 config-loading tests, completion tests for comment-mention false positive + config override both ways, document-store memoization/invalidation test).
- Detection unit tests cover: config on/off override, CDN `src` (quoted/unquoted, versioned, jsdelivr/unpkg), inline module/side-effect/dynamic imports, `PetiteVue.createApp` global, and no false positive when "petite-vue"/`PetiteVue.createApp`/`v-scope` appear only in HTML comments, JS comments, JS strings, or prose.
- `cargo clippy` clean on changed code; `cargo fmt --check` clean; full workspace build passes.

Part of #1393.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1402"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783753817&installation_id=136613492&pr_number=1402&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1402&signature=edb2ea00b837985d07274ccb2b8ef92482e5fe1cc30107747d49315a9abcaf08"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->