### PR TITLE
fix(bench): make every generated SFC body unique

### DIFF
--- a/bench/generate.mjs
+++ b/bench/generate.mjs
@@ -353,8 +353,23 @@ for (const file of readdirSync(benchDir)) {
   }
 }
 
+// Every generated body must be unique. Repeating identical bodies lets
+// content-addressed compile caches (e.g. the `vize build --format stats`
+// dedup cache) serve most of the corpus from a hash lookup, so the benchmark
+// measures cache hits instead of compilation. A per-file token inside an
+// existing string literal keeps each complexity tier intact while forcing a
+// real compile per file.
+function uniquify(template, index) {
+  const id = String(index).padStart(4, "0");
+  const marked = template.replace(/ref\('([^']*)'\)/, (_, text) => `ref('${text} ${id}')`);
+  if (marked === template) {
+    throw new Error("template has no ref('...') anchor to uniquify");
+  }
+  return marked;
+}
+
 for (let i = 0; i < FILE_COUNT; i++) {
-  const template = templates[i % templates.length];
+  const template = uniquify(templates[i % templates.length], i);
   const filename = `Component${String(i).padStart(4, "0")}.vue`;
   const filepath = join(benchDir, filename);
   writeFileSync(filepath, template);


### PR DESCRIPTION
## Summary

`bench/generate.mjs` wrote the same 6 template bodies round-robin, so benchmark corpora contained only 6 unique bodies regardless of file count. Combined with the content-addressed dedup cache in `vize build --format stats` (`crates/vize/src/commands/build/runner/cache.rs`), the Compile SFC lane measured 6 real compiles plus N−6 hash lookups: the 300-file PR-gate lane ran in ~4.5ms, which is why perf-neutral PRs tripped the budget gate on spawn jitter (#1395 +5.12%, #1401 +13.61%), and the 15,000-file headline lane compared ~6 real vize compiles against 15,000 real `@vue/compiler-sfc` compiles.

This PR injects a per-file token into an existing `ref('...')` string literal in each generated body. Every file now costs a real compile; the 6 complexity tiers are otherwise unchanged. The generator fails loudly if a future template lacks the anchor.

Locally (M-series, single-threaded, release binary): the 300-file compile lane goes from ~4.5ms to ~60–90ms — real compilation at ~200µs/file — which also collapses the gate's noise-floor percentage at its root.

Note for reviewers: the next Blacksmith snapshot refresh after this merges will report a lower (honest) headline compile speedup — that is the point. See the issue for the full analysis and the follow-up decision on the dedup cache itself.

Part of #1403.

## Test plan

- `node bench/generate.mjs 300` → `md5 -q bench/__in__/*.vue | sort -u | wc -l` = 300 (was 6).
- `vize build . --format stats --threads 1` over the regenerated corpus: success, 300 files compiled.
- The PR's own benchmark run exercises the new corpus end-to-end (expect visibly larger absolute lane times on both base and head — base regenerates the corpus too, so the comparison stays apples-to-apples).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1405"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783754325&installation_id=136613492&pr_number=1405&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1405&signature=b6b70fe9dd381ed50fb39da4cb8661f876551703491d7c1347c6f449cb84cbf8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->