### PR TITLE
fix(patina): replace prefer-computed watch text scanning with AST checks

### DIFF
--- a/crates/vize_patina/src/linter/script_rules.rs
+++ b/crates/vize_patina/src/linter/script_rules.rs
@@ -587,6 +587,9 @@ fn script_rule_may_match(rule_name: &str, source: &str) -> bool {
             memmem::find(bytes, b"toMatchSnapshot").is_some()
                 && memmem::find(bytes, b".html").is_some()
         }
+        // `watch` also appears in any aliased import (`watch as observe`), so
+        // this never skips a block the AST check could flag.
+        RULE_PREFER_COMPUTED => memmem::find(bytes, b"watch").is_some(),
         _ => true,
     }
 }

--- a/crates/vize_patina/src/rules/script/prefer_computed.rs
+++ b/crates/vize_patina/src/rules/script/prefer_computed.rs
@@ -26,7 +26,17 @@
 //! const doubled = computed(() => count.value * 2)
 //! ```
 
-use memchr::memmem;
+use oxc_ast::ast::{
+    AssignmentExpression, AssignmentTarget, CallExpression, Expression, ImportDeclaration,
+    ImportDeclarationSpecifier, Program,
+};
+use oxc_ast_visit::{
+    Visit,
+    walk::{walk_assignment_expression, walk_call_expression, walk_import_declaration},
+};
+use oxc_span::Span;
+use oxc_syntax::operator::AssignmentOperator;
+use vize_carton::{CompactString, FxHashSet};
 
 use crate::diagnostic::{LintDiagnostic, Severity};
 
@@ -46,49 +56,151 @@ impl ScriptRule for PreferComputed {
         &META
     }
 
-    fn check(&self, source: &str, offset: usize, result: &mut ScriptLintResult) {
-        let bytes = source.as_bytes();
+    #[inline]
+    fn uses_ast(&self) -> bool {
+        true
+    }
 
-        // Fast bailout: check if there's a watch call
-        if memmem::find(bytes, b"watch(").is_none() && memmem::find(bytes, b"watch (").is_none() {
-            return;
-        }
+    #[inline]
+    fn check_program<'a>(
+        &self,
+        program: &'a Program<'a>,
+        _source: &str,
+        offset: usize,
+        result: &mut ScriptLintResult,
+    ) {
+        let mut visitor = PreferComputedVisitor {
+            offset,
+            result,
+            watch_aliases: FxHashSet::default(),
+        };
+        visitor.visit_program(program);
+    }
+}
 
-        // Look for patterns like:
-        // watch(source, (val) => { target.value = ... })
-        // This is a heuristic check - we look for .value = inside watch callbacks
+struct PreferComputedVisitor<'result> {
+    offset: usize,
+    result: &'result mut ScriptLintResult,
+    /// Local names bound to Vue's `watch` import (covers `watch as observe`).
+    watch_aliases: FxHashSet<CompactString>,
+}
 
-        let watch_finder = memmem::Finder::new(b"watch(");
-        let mut search_start = 0;
-
-        while let Some(pos) = watch_finder.find(&bytes[search_start..]) {
-            let abs_pos = search_start + pos;
-            search_start = abs_pos + 6;
-
-            // Find the end of the watch call (heuristically by looking for closing })
-            // This is a simplified check
-            let rest = &source[abs_pos..];
-
-            // Look for .value = pattern inside this watch
-            if let Some(value_assign_pos) = rest.find(".value =") {
-                // Check if it's within a reasonable distance (likely in the callback)
-                if value_assign_pos < 200 {
-                    // Likely a pattern where watch is used to sync derived state
-                    result.add_diagnostic(
-                        LintDiagnostic::warn(
-                            META.name,
-                            "Consider using computed() instead of watch() for derived state",
-                            (offset + abs_pos) as u32,
-                            (offset + abs_pos + 5) as u32,
-                        )
-                        .with_help(
-                            "If the watch callback only assigns to a ref based on the watched value, \
-                             use computed() instead: `const derived = computed(() => source.value * 2)`",
-                        ),
-                    );
+impl<'a> Visit<'a> for PreferComputedVisitor<'_> {
+    fn visit_import_declaration(&mut self, it: &ImportDeclaration<'a>) {
+        if it.source.value.as_str() == "vue"
+            && let Some(specifiers) = &it.specifiers
+        {
+            for specifier in specifiers {
+                let ImportDeclarationSpecifier::ImportSpecifier(specifier) = specifier else {
+                    continue;
+                };
+                if specifier.imported.name().as_str() == "watch" {
+                    self.watch_aliases
+                        .insert(CompactString::new(specifier.local.name.as_str()));
                 }
             }
         }
+
+        walk_import_declaration(self, it);
+    }
+
+    fn visit_call_expression(&mut self, it: &CallExpression<'a>) {
+        if let Some(callee_span) = self.watch_callee_span(it)
+            && let Some(callback) = watch_callback(it)
+            && callback_assigns_ref_value(callback)
+        {
+            let start = self.offset as u32 + callee_span.start;
+            let end = self.offset as u32 + callee_span.end;
+            self.result.add_diagnostic(
+                LintDiagnostic::warn(
+                    META.name,
+                    "Consider using computed() instead of watch() for derived state",
+                    start,
+                    end,
+                )
+                .with_help(
+                    "If the watch callback only assigns to a ref based on the watched value, \
+                     use computed() instead: `const derived = computed(() => source.value * 2)`",
+                ),
+            );
+        }
+
+        walk_call_expression(self, it);
+    }
+}
+
+impl PreferComputedVisitor<'_> {
+    /// Span of the callee when this is a `watch(...)` call.
+    ///
+    /// Matches the bare `watch` identifier (Nuxt-style auto-imports) and any
+    /// local alias of Vue's `watch` import (`import { watch as observe }`).
+    fn watch_callee_span(&self, call: &CallExpression<'_>) -> Option<Span> {
+        let Expression::Identifier(identifier) = &call.callee else {
+            return None;
+        };
+        let name = identifier.name.as_str();
+        if name == "watch" || self.watch_aliases.contains(name) {
+            Some(identifier.span)
+        } else {
+            None
+        }
+    }
+}
+
+/// The inline callback of a `watch(source, callback, options?)` call, if any.
+fn watch_callback<'a, 'b>(call: &'b CallExpression<'a>) -> Option<&'b Expression<'a>> {
+    let callback = call.arguments.get(1)?.as_expression()?;
+    Some(unwrap_expression(callback))
+}
+
+/// Strip parentheses and TS-only wrappers so the underlying callback is seen.
+fn unwrap_expression<'a, 'b>(expression: &'b Expression<'a>) -> &'b Expression<'a> {
+    match expression {
+        Expression::ParenthesizedExpression(paren) => unwrap_expression(&paren.expression),
+        Expression::TSAsExpression(ts_as) => unwrap_expression(&ts_as.expression),
+        Expression::TSSatisfiesExpression(ts_satisfies) => {
+            unwrap_expression(&ts_satisfies.expression)
+        }
+        Expression::TSNonNullExpression(ts_non_null) => unwrap_expression(&ts_non_null.expression),
+        _ => expression,
+    }
+}
+
+/// Whether the watch callback contains a plain `<target>.value = ...`
+/// assignment, i.e. it manually syncs derived reactive state.
+fn callback_assigns_ref_value(callback: &Expression<'_>) -> bool {
+    let mut finder = RefValueAssignmentFinder { found: false };
+    match callback {
+        Expression::ArrowFunctionExpression(arrow) => {
+            finder.visit_function_body(&arrow.body);
+        }
+        Expression::FunctionExpression(function) => {
+            if let Some(body) = &function.body {
+                finder.visit_function_body(body);
+            }
+        }
+        _ => return false,
+    }
+    finder.found
+}
+
+struct RefValueAssignmentFinder {
+    found: bool,
+}
+
+impl<'a> Visit<'a> for RefValueAssignmentFinder {
+    fn visit_assignment_expression(&mut self, it: &AssignmentExpression<'a>) {
+        if self.found {
+            return;
+        }
+        if it.operator == AssignmentOperator::Assign
+            && let AssignmentTarget::StaticMemberExpression(member) = &it.left
+            && member.property.name == "value"
+        {
+            self.found = true;
+            return;
+        }
+        walk_assignment_expression(self, it);
     }
 }
 
@@ -142,6 +254,155 @@ watch(count, (val) => {
             r#"
 const count = ref(0)
 const doubled = computed(() => count.value * 2)
+"#,
+            0,
+        );
+        assert_eq!(result.warning_count, 0);
+    }
+
+    #[test]
+    fn test_no_warn_pattern_inside_string_literal() {
+        // The old byte scanner flagged `watch(` + `.value =` even inside a
+        // string literal. The AST check must not.
+        let linter = create_linter();
+        let result = linter.lint(
+            r#"
+const example = "watch(count, (val) => { doubled.value = val * 2 })"
+console.log(example)
+"#,
+            0,
+        );
+        assert_eq!(result.warning_count, 0);
+    }
+
+    #[test]
+    fn test_no_warn_pattern_inside_comment() {
+        // The old byte scanner flagged the pattern inside comments.
+        let linter = create_linter();
+        let result = linter.lint(
+            r#"
+// watch(count, (val) => { doubled.value = val * 2 })
+const doubled = computed(() => count.value * 2)
+"#,
+            0,
+        );
+        assert_eq!(result.warning_count, 0);
+    }
+
+    #[test]
+    fn test_no_warn_value_comparison_in_callback() {
+        // `.value ===` contains the `.value =` substring the old scanner
+        // matched; a comparison is not derived-state syncing.
+        let linter = create_linter();
+        let result = linter.lint(
+            r#"
+watch(count, (val) => {
+  if (doubled.value === val) {
+    console.log(val)
+  }
+})
+"#,
+            0,
+        );
+        assert_eq!(result.warning_count, 0);
+    }
+
+    #[test]
+    fn test_no_warn_value_assignment_after_watch_call() {
+        // The old scanner matched any `.value =` within 200 bytes after
+        // `watch(`, even outside the callback.
+        let linter = create_linter();
+        let result = linter.lint(
+            r#"
+watch(count, (val) => {
+  console.log(val)
+})
+doubled.value = 5
+"#,
+            0,
+        );
+        assert_eq!(result.warning_count, 0);
+    }
+
+    #[test]
+    fn test_warn_aliased_watch_import() {
+        // `import { watch as observe }` never produced the `watch(` byte
+        // pattern, so the old scanner missed it entirely.
+        let linter = create_linter();
+        let result = linter.lint(
+            r#"
+import { watch as observe } from 'vue'
+const doubled = ref(0)
+observe(count, (val) => {
+  doubled.value = val * 2
+})
+"#,
+            0,
+        );
+        assert_eq!(result.warning_count, 1);
+    }
+
+    #[test]
+    fn test_warn_watch_with_space_before_paren() {
+        // `watch (source, cb)` passed the old fast bailout but the finder only
+        // searched for `watch(`, so it was silently missed.
+        let linter = create_linter();
+        let result = linter.lint(
+            r#"
+watch (count, (val) => {
+  doubled.value = val * 2
+})
+"#,
+            0,
+        );
+        assert_eq!(result.warning_count, 1);
+    }
+
+    #[test]
+    fn test_warn_assignment_beyond_200_bytes() {
+        // The old scanner gave up when `.value =` sat more than 200 bytes
+        // after `watch(`; long callbacks were missed.
+        let linter = create_linter();
+        let source = r#"
+watch(count, (val) => {
+  console.log('step 0 of a fairly long watch callback body, padding away')
+  console.log('step 1 of a fairly long watch callback body, padding away')
+  console.log('step 2 of a fairly long watch callback body, padding away')
+  console.log('step 3 of a fairly long watch callback body, padding away')
+  console.log('step 4 of a fairly long watch callback body, padding away')
+  console.log('step 5 of a fairly long watch callback body, padding away')
+  doubled.value = val * 2
+})
+"#;
+        assert!(source.find(".value =").unwrap() > 200);
+        let result = linter.lint(source, 0);
+        assert_eq!(result.warning_count, 1);
+    }
+
+    #[test]
+    fn test_warn_function_expression_callback() {
+        let linter = create_linter();
+        let result = linter.lint(
+            r#"
+watch(count, function (val) {
+  doubled.value = val * 2
+})
+"#,
+            0,
+        );
+        assert_eq!(result.warning_count, 1);
+    }
+
+    #[test]
+    fn test_no_warn_unrelated_function_ending_in_watch() {
+        // Identifiers merely ending in `watch` (e.g. `unwatch(...)`) matched
+        // the old substring finder.
+        let linter = create_linter();
+        let result = linter.lint(
+            r#"
+unwatch(count, (val) => {
+  doubled.value = val * 2
+})
 "#,
             0,
         );


### PR DESCRIPTION
## Summary

Replaces the `script/prefer-computed` byte-scanning heuristic with an AST-backed check on the shared oxc parse (issue #1394, PR6 item: "rewrite `prefer_computed` on the OXC watch-callback AST using the existing script visitor infra").

### Replaced heuristic (before -> after)

- **Before** (`crates/vize_patina/src/rules/script/prefer_computed.rs`): memmem scan for the `watch(` substring, then flag if the `.value =` substring appeared within 200 bytes after it.
- **After**: the rule overrides `check_program`/`uses_ast` and visits the **shared** oxc parse already produced for AST script rules (zero new whole-document scans). It resolves the watch callee (bare `watch` identifier for Nuxt-style auto-imports, or any local alias of Vue's `watch` import), takes the inline callback argument (arrow/function expression, unwrapping parens and TS casts), and walks only that callback body for a plain assignment to a static `.value` member.

### False positives eliminated (tests: must NOT warn)

- pattern inside a **string literal** — `test_no_warn_pattern_inside_string_literal`
- pattern inside a **comment** — `test_no_warn_pattern_inside_comment`
- **comparison** `doubled.value === val` (contains the `.value =` substring) — `test_no_warn_value_comparison_in_callback`
- `.value =` **after the watch call** but within the old 200-byte window — `test_no_warn_value_assignment_after_watch_call`
- identifiers merely **ending in** `watch` (e.g. `unwatch(...)`) — `test_no_warn_unrelated_function_ending_in_watch`

### False negatives eliminated (tests: MUST warn)

- **aliased import** `import { watch as observe } from 'vue'` — `test_warn_aliased_watch_import`
- `watch (source, cb)` with a **space before the paren** (the old finder only searched `watch(`) — `test_warn_watch_with_space_before_paren`
- assignment **beyond 200 bytes** into a long callback — `test_warn_assignment_beyond_200_bytes`
- `function` expression callbacks — `test_warn_function_expression_callback`

### Zero-cost notes

- AST script rules share one oxc parse per block in both `ScriptLinter::lint` and the engine's `append_builtin_script_diagnostics`; this rule piggybacks on it — no new traversal pass.
- Added a `watch` byte prefilter for `RULE_PREFER_COMPUTED` in `script_rule_may_match` (`crates/vize_patina/src/linter/script_rules.rs`) so blocks without `watch` are never parsed on this rule's account, preserving the old fast bailout. `watch` also appears in any aliased import statement, so the prefilter cannot skip a flaggable block.
- The existing diagnostic snapshot is byte-identical (the callee identifier span equals the old `watch(` span).

### Remaining #1394 follow-ups (not taken here)

- PR1 (atelier_vapor legacy slot surface), PR2 (template expression diagnostic), PR3/PR4 (croquis OXC type extraction + TypeResolver registration), PR5 (define_props_destructure panic diagnostic), PR7 (patina template extraction via descriptor), PR8 (croquis_cf virtual paths / per-usage attrs / defineStore tracking), PR9/PR10 (canon span-based rewrite, AST await detection), PR11 (maestro petite-vue detection), PR12 (hoist_static recursion).

## Test plan

- `cargo test -p vize_patina -p vize_croquis` — all green (1036 + 164 + doctests); 12 prefer-computed tests including the 9 new regression tests above; existing insta snapshot unchanged
- `cargo clippy -p vize_patina --all-targets` — no new warnings on changed code
- `cargo fmt -p vize_patina -- --check` — clean

Part of #1394.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1406"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783754388&installation_id=136613492&pr_number=1406&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1406&signature=5276c514525ebd075d98b8f567519730012056eaff5bbe53c20781b93ee9c186"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->