### PR TITLE
fix(canon): wrap plain `export default {...}` options objects with defineComponent in virtual TS

### DIFF
--- a/crates/vize_canon/src/batch/type_checker/tests.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests.rs
@@ -987,6 +987,95 @@ void LazyPanel
     });
 }
 
+/// Plain Options API component used by the `defineComponent`-wrap regression
+/// tests: `this.count` (a `data` field) is accessed from a computed. Without
+/// the wrap, `this` binds to the `computed` sub-object literal and TypeScript
+/// reports a TS2339 false positive.
+const OPTIONS_API_THIS_IN_COMPUTED_SFC: &str = r#"<script lang="ts">
+export default {
+  data() {
+    return { count: 0 }
+  },
+  computed: {
+    doubled(): number {
+      return this.count * 2
+    },
+  },
+}
+</script>
+
+<template>
+  <div>static</div>
+</template>
+"#;
+
+#[test]
+fn batch_type_checker_accepts_options_api_this_data_access_in_computed() {
+    if resolve_test_tsgo_binary().is_none() {
+        return;
+    }
+
+    let project_root = create_project_case(
+        "options-api-this-computed",
+        &[("src/App.vue", OPTIONS_API_THIS_IN_COMPUTED_SFC)],
+    );
+
+    // Real instance typing requires the real vue package (full
+    // `defineComponent` overloads with `ThisType`). When the workspace only
+    // provides the erased test stub (`defineComponent(options: any)`), skip —
+    // stub behavior is covered by the facade-fallback test below.
+    if !project_root.join("node_modules/vue/dist").exists() {
+        let _ = std::fs::remove_dir_all(&project_root);
+        return;
+    }
+
+    let Some(snapshot) = snapshot_project_diagnostics(&project_root) else {
+        let _ = std::fs::remove_dir_all(&project_root);
+        return;
+    };
+
+    assert!(
+        snapshot.is_empty(),
+        "expected `this.<dataField>` in a computed of a plain options object to check clean: {snapshot:#?}"
+    );
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}
+
+#[test]
+fn batch_type_checker_options_api_wrap_adds_no_errors_in_facade_fallback() {
+    if resolve_test_tsgo_binary().is_none() {
+        return;
+    }
+
+    // Facade-fallback mode: no resolvable vue package, so the bundled vue
+    // stub is materialized. Its `defineComponent(options: any)` signature
+    // erases `ThisType`, so the pre-existing TS2339 false positive on
+    // `this.count` remains until the stub gains a ThisType-aware signature
+    // (issue #1388 PR6). The wrap must not introduce any NEW diagnostics
+    // beyond that documented one.
+    with_workspace_node_modules_override(Some("__none__"), || {
+        let project_root = create_project_case_without_node_modules(
+            "options-api-wrap-facade-fallback",
+            &[("src/App.vue", OPTIONS_API_THIS_IN_COMPUTED_SFC)],
+        );
+
+        let Some(snapshot) = snapshot_project_diagnostics(&project_root) else {
+            let _ = std::fs::remove_dir_all(&project_root);
+            return;
+        };
+
+        assert!(
+            snapshot
+                .iter()
+                .all(|(file, code, _)| file == "src/App.vue" && *code == Some(2339)),
+            "expected the defineComponent wrap to add no new diagnostics in facade-fallback mode: {snapshot:#?}"
+        );
+
+        let _ = std::fs::remove_dir_all(&project_root);
+    });
+}
+
 #[test]
 fn batch_type_checker_snapshots_cross_file_vue_prop_error() {
     if resolve_test_tsgo_binary().is_none() {

--- a/crates/vize_canon/src/sfc_typecheck/tests.rs
+++ b/crates/vize_canon/src/sfc_typecheck/tests.rs
@@ -1511,3 +1511,85 @@ const props = defineProps<Props>()
 
     let _ = std::fs::remove_dir_all(project);
 }
+
+#[test]
+fn test_plain_script_options_object_is_wrapped_with_define_component() {
+    // A plain <script> options object must be wrapped with defineComponent in
+    // the virtual TS so `this` in computed/methods gets Vue's instance typing
+    // instead of binding to the sub-object literal (TS2339 false positives).
+    let source = r#"<script lang="ts">
+export default {
+  data() {
+    return { count: 0 }
+  },
+  computed: {
+    doubled() {
+      return this.count * 2
+    },
+  },
+}
+</script>
+<template>
+  <div>static</div>
+</template>"#;
+    let options = SfcTypeCheckOptions::new("test.vue").with_virtual_ts();
+    let result = type_check_sfc(source, &options);
+    let virtual_ts = result.virtual_ts.expect("virtual TS should be generated");
+
+    assert!(
+        virtual_ts
+            .contains("declare const __vizeDefineComponent: typeof import('vue').defineComponent;"),
+        "expected the defineComponent helper declaration:\n{virtual_ts}"
+    );
+    assert!(
+        virtual_ts.contains("const __default__ = __vizeDefineComponent({"),
+        "expected the options object to be wrapped with defineComponent:\n{virtual_ts}"
+    );
+}
+
+#[test]
+fn test_dual_block_options_object_is_wrapped_with_define_component() {
+    // The plain <script> block of a dual-block SFC is emitted at module scope
+    // (not inside __setup); its options object must be wrapped there too.
+    let source = r#"<script lang="ts">
+export default {
+  inheritAttrs: false,
+}
+</script>
+<script setup lang="ts">
+const count = 1
+</script>
+<template>
+  <div>{{ count }}</div>
+</template>"#;
+    let options = SfcTypeCheckOptions::new("test.vue").with_virtual_ts();
+    let result = type_check_sfc(source, &options);
+    let virtual_ts = result.virtual_ts.expect("virtual TS should be generated");
+
+    assert!(
+        virtual_ts.contains("const __default__ = __vizeDefineComponent({"),
+        "expected the module-scope options object to be wrapped:\n{virtual_ts}"
+    );
+    assert!(
+        virtual_ts.contains("})"),
+        "expected the wrap to be closed:\n{virtual_ts}"
+    );
+}
+
+#[test]
+fn test_script_setup_only_virtual_ts_has_no_define_component_wrapper() {
+    let source = r#"<script setup lang="ts">
+const count = 1
+</script>
+<template>
+  <div>{{ count }}</div>
+</template>"#;
+    let options = SfcTypeCheckOptions::new("test.vue").with_virtual_ts();
+    let result = type_check_sfc(source, &options);
+    let virtual_ts = result.virtual_ts.expect("virtual TS should be generated");
+
+    assert!(
+        !virtual_ts.contains("__vizeDefineComponent"),
+        "script setup virtual TS must stay untouched:\n{virtual_ts}"
+    );
+}

--- a/crates/vize_canon/src/virtual_ts/generator/mod.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/mod.rs
@@ -15,10 +15,12 @@ use self::imports::{
     collect_imported_names, emit_global_component_stubs, emit_reference_type_directives,
     extract_declared_name,
 };
-use self::options_api::{generate_options_api_bridge, generate_options_api_variables};
+use self::options_api::{
+    find_plain_default_export_object, generate_options_api_bridge, generate_options_api_variables,
+};
 use self::spans::{
-    collect_template_referenced_names, is_local_setup_binding, merge_overlapping_spans,
-    rewrite_export_default_for_module_scope,
+    DEFINE_COMPONENT_HELPER, DEFINE_COMPONENT_REF, collect_template_referenced_names,
+    is_local_setup_binding, merge_overlapping_spans, rewrite_export_default_for_module_scope,
 };
 use super::{
     helpers::{
@@ -200,6 +202,32 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
     ts.push_str(VUE_TYPE_HELPERS);
     ts.push('\n');
 
+    let has_script_setup = summary
+        .scopes
+        .iter()
+        .any(|scope| matches!(scope.kind, ScopeKind::ScriptSetup));
+    let has_plain_script_scope = summary
+        .scopes
+        .iter()
+        .any(|scope| matches!(scope.kind, ScopeKind::NonScriptSetup));
+
+    // Plain `export default { ... }` in the main <script> block (the Options
+    // API shape) gets wrapped with Vue's `defineComponent` so `this` inside
+    // computed/methods is typed by Vue's options machinery. Script setup
+    // virtual TS is never touched: in setup-only SFCs no wrap target exists,
+    // so the helper lookup is skipped entirely.
+    let default_export_object = if !has_script_setup || has_plain_script_scope {
+        profile!(
+            "canon.virtual_ts.find_default_export_object",
+            script_content.and_then(find_plain_default_export_object)
+        )
+    } else {
+        None
+    };
+    if default_export_object.is_some() {
+        ts.push_str(DEFINE_COMPONENT_HELPER);
+    }
+
     // Collect all module-level statement spans from croquis analysis once and
     // keep them sorted. Later script-body emission advances an index through
     // this list, so each source line checks only the overlapping tail instead
@@ -212,10 +240,6 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
         for re in &summary.re_exports {
             module_spans.push((re.start, re.end));
         }
-        let has_script_setup = summary
-            .scopes
-            .iter()
-            .any(|scope| matches!(scope.kind, ScopeKind::ScriptSetup));
         if has_script_setup {
             module_spans.extend(summary.scopes.iter().filter_map(|scope| {
                 matches!(scope.kind, ScopeKind::NonScriptSetup)
@@ -309,7 +333,20 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
 
                 let gen_start = ts.len();
                 if text.contains("export default") {
-                    let text = rewrite_export_default_for_module_scope(text);
+                    // Re-base the script-absolute default-export-object
+                    // offsets onto this module span so the rewrite can wrap
+                    // a plain options object with `defineComponent`.
+                    let span_relative_object = default_export_object.and_then(
+                        |(export_start, object_start, object_end)| {
+                            let span_start = start as usize;
+                            (export_start >= span_start && object_end <= end as usize).then_some((
+                                export_start - span_start,
+                                object_start - span_start,
+                                object_end - span_start,
+                            ))
+                        },
+                    );
+                    let text = rewrite_export_default_for_module_scope(text, span_relative_object);
                     ts.push_str(&text);
                 } else {
                     ts.push_str(text);
@@ -414,6 +451,10 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
             // causing src_byte_offset drift that incorrectly skips user code.
             let mut src_byte_offset: usize = 0; // offset within script content
             let mut module_span_index = 0usize;
+            // Script-absolute offset right after the wrapped options object's
+            // closing brace; the matching `)` for the `defineComponent(` wrap
+            // opened on an earlier line is inserted there.
+            let mut pending_wrap_close: Option<usize> = None;
 
             // Check if script uses import.meta and add a polyfill variable.
             // This avoids TS1343 when module is not set to es2020+.
@@ -452,6 +493,24 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
                 // replace import.meta with polyfill variable
                 let mut output_line = std::borrow::Cow::Borrowed(line);
 
+                // Close the `defineComponent(` wrap right after the wrapped
+                // options object's closing brace.
+                if let Some(close_offset) = pending_wrap_close
+                    && close_offset > line_start
+                    && close_offset <= line_end
+                    && close_offset - line_start <= line.len()
+                    && line.is_char_boundary(close_offset - line_start)
+                {
+                    let column = close_offset - line_start;
+                    #[allow(clippy::disallowed_types)]
+                    {
+                        output_line = std::borrow::Cow::Owned(
+                            cstr!("{}){}", &line[..column], &line[column..]).into(),
+                        );
+                    }
+                    pending_wrap_close = None;
+                }
+
                 // Strip `export` from non-import lines inside setup scope
                 let trimmed_line = output_line.trim_start();
                 if let Some(default_expr) = trimmed_line
@@ -459,8 +518,56 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
                     .filter(|rest| rest.chars().next().is_none_or(char::is_whitespace))
                 {
                     let leading_ws = &output_line[..output_line.len() - trimmed_line.len()];
+                    // Wrap a plain object-literal default export (Options
+                    // API) with `defineComponent` so `this` in
+                    // computed/methods gets Vue's instance typing. Applies
+                    // only to the plain <script> block; any other shape keeps
+                    // the bare `const __default__ =` rewrite.
+                    let wrap_object =
+                        if has_script_setup || matches!(output_line, std::borrow::Cow::Owned(_)) {
+                            None
+                        } else {
+                            default_export_object.filter(|&(export_start, object_start, _)| {
+                                export_start >= line_start
+                                    && object_start >= line_start
+                                    && object_start < line_end
+                                    && object_start - line_start <= line.len()
+                                    && line[object_start - line_start..].starts_with('{')
+                            })
+                        };
                     #[allow(clippy::disallowed_types)]
+                    if let Some((object_column, object_end)) =
+                        wrap_object.and_then(|(_, object_start, object_end)| {
+                            let object_column = object_start - line_start;
+                            (line.len() - default_expr.len() <= object_column)
+                                .then_some((object_column, object_end))
+                        })
                     {
+                        let keyword_end = line.len() - default_expr.len();
+                        if object_end <= line_end && object_end - line_start <= line.len() {
+                            // Single-line `export default { ... }`.
+                            let close_column = object_end - line_start;
+                            output_line = std::borrow::Cow::Owned(
+                                cstr!(
+                                    "{leading_ws}const __default__ ={}{DEFINE_COMPONENT_REF}({}){}",
+                                    &line[keyword_end..object_column],
+                                    &line[object_column..close_column],
+                                    &line[close_column..],
+                                )
+                                .into(),
+                            );
+                        } else {
+                            pending_wrap_close = Some(object_end);
+                            output_line = std::borrow::Cow::Owned(
+                                cstr!(
+                                    "{leading_ws}const __default__ ={}{DEFINE_COMPONENT_REF}({}",
+                                    &line[keyword_end..object_column],
+                                    &line[object_column..],
+                                )
+                                .into(),
+                            );
+                        }
+                    } else {
                         output_line = std::borrow::Cow::Owned(
                             cstr!("{leading_ws}const __default__ ={}", default_expr).into(),
                         );
@@ -504,6 +611,12 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
                 }
                 let _ = gen_line_start; // suppress unused warning
                 src_byte_offset += raw_byte_len;
+            }
+            if pending_wrap_close.take().is_some() {
+                // Defensive: the line carrying the wrapped object's closing
+                // brace was never emitted; close the `defineComponent(` call
+                // so the generated module stays parseable.
+                ts.push_str("  )\n");
             }
             let script_gen_end = ts.len();
             append!(

--- a/crates/vize_canon/src/virtual_ts/generator/options_api.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/options_api.rs
@@ -384,6 +384,39 @@ fn collect_mapped_type(call: &CallExpression<'_>, mapped_types: &mut Vec<String>
     mapped_types.push(mapped_type);
 }
 
+/// Locate a plain object-literal default export (`export default { ... }`) —
+/// the Options API component shape — in `script`.
+///
+/// Returns `(export_start, object_start, object_end)` byte offsets into
+/// `script`. Default exports that are anything else — already-wrapped
+/// `defineComponent({...})` calls, class declarations, identifiers, function
+/// calls, `as`/`satisfies` expressions — return `None` so only the bare
+/// options object gets the `defineComponent` wrap.
+pub(super) fn find_plain_default_export_object(script: &str) -> Option<(usize, usize, usize)> {
+    if !script.contains("export default") {
+        return None;
+    }
+    let allocator = Allocator::default();
+    let parsed = Parser::new(&allocator, script, SourceType::ts()).parse();
+    if parsed.panicked {
+        return None;
+    }
+    parsed.program.body.iter().find_map(|statement| {
+        let Statement::ExportDefaultDeclaration(export) = statement else {
+            return None;
+        };
+        let ExportDefaultDeclarationKind::ObjectExpression(object) = &export.declaration else {
+            return None;
+        };
+        let object_span = object.span();
+        Some((
+            export.span.start as usize,
+            object_span.start as usize,
+            object_span.end as usize,
+        ))
+    })
+}
+
 fn component_options_from_program<'a>(
     program: &'a Program<'a>,
 ) -> Option<&'a ObjectExpression<'a>> {

--- a/crates/vize_canon/src/virtual_ts/generator/spans.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/spans.rs
@@ -83,7 +83,30 @@ pub(super) fn merge_overlapping_spans(mut spans: Vec<(u32, u32)>) -> Vec<(u32, u
     merged
 }
 
-pub(super) fn rewrite_export_default_for_module_scope(text: &str) -> String {
+/// Generated identifier resolving Vue's `defineComponent` (see
+/// `DEFINE_COMPONENT_HELPER`). Plain object-literal default exports are
+/// wrapped in a call to it so TypeScript binds `this` inside
+/// computed/methods via Vue's `ThisType` machinery instead of the bare
+/// object literal (which produced TS2339 false positives).
+pub(super) const DEFINE_COMPONENT_REF: &str = "__vizeDefineComponent";
+
+/// Module-scope declaration for `DEFINE_COMPONENT_REF`. Uses the same
+/// `import('vue')` reference form as the other generated vue helpers so it
+/// never collides with user imports.
+pub(super) const DEFINE_COMPONENT_HELPER: &str =
+    "declare const __vizeDefineComponent: typeof import('vue').defineComponent;\n";
+
+pub(super) fn rewrite_export_default_for_module_scope(
+    text: &str,
+    default_object: Option<(usize, usize, usize)>,
+) -> String {
+    // Plain `export default { ... }` (the Options API shape) is wrapped with
+    // Vue's `defineComponent`; any other default-export shape falls through
+    // to the line-based `const __default__ =` rewrite below.
+    if let Some(output) = wrap_default_export_object(text, default_object) {
+        return output;
+    }
+
     let mut output = String::with_capacity(text.len());
     for segment in text.split_inclusive('\n') {
         let (line_with_optional_cr, newline) = segment
@@ -108,6 +131,45 @@ pub(super) fn rewrite_export_default_for_module_scope(text: &str) -> String {
     }
 
     output
+}
+
+/// Rewrite `export default { ... }` to
+/// `const __default__ = __vizeDefineComponent({ ... })` using the
+/// `(export_start, object_start, object_end)` offsets (relative to `text`)
+/// located by the AST. Returns `None` when the offsets do not describe a
+/// plain object-literal default export inside `text`.
+fn wrap_default_export_object(
+    text: &str,
+    default_object: Option<(usize, usize, usize)>,
+) -> Option<String> {
+    const EXPORT_DEFAULT: &str = "export default";
+
+    let (export_start, object_start, object_end) = default_object?;
+    if object_end > text.len() || object_start >= object_end {
+        return None;
+    }
+    let keyword_end = export_start.checked_add(EXPORT_DEFAULT.len())?;
+    if keyword_end > object_start
+        || !text.is_char_boundary(export_start)
+        || !text.is_char_boundary(object_start)
+        || !text.is_char_boundary(object_end)
+        || !text[export_start..].starts_with(EXPORT_DEFAULT)
+        || !text[object_start..].starts_with('{')
+    {
+        return None;
+    }
+
+    let mut output =
+        String::with_capacity(text.len() + DEFINE_COMPONENT_REF.len() + EXPORT_DEFAULT.len());
+    output.push_str(&text[..export_start]);
+    output.push_str("const __default__ =");
+    output.push_str(&text[keyword_end..object_start]);
+    output.push_str(DEFINE_COMPONENT_REF);
+    output.push('(');
+    output.push_str(&text[object_start..object_end]);
+    output.push(')');
+    output.push_str(&text[object_end..]);
+    Some(output)
 }
 
 pub(super) fn is_local_setup_binding(summary: &Croquis, name: &str) -> bool {

--- a/crates/vize_canon/src/virtual_ts/tests.rs
+++ b/crates/vize_canon/src/virtual_ts/tests.rs
@@ -1297,3 +1297,126 @@ const item = ref<{ name: string } | undefined>()
         output.code.as_str(),
     );
 }
+
+#[test]
+fn test_plain_options_object_default_export_is_wrapped_with_define_component() {
+    use vize_croquis::{Analyzer, AnalyzerOptions};
+
+    let script = r#"export default {
+  data() {
+    return { count: 0 }
+  },
+  computed: {
+    doubled() {
+      return this.count * 2
+    },
+  },
+}
+"#;
+    let mut analyzer = Analyzer::with_options(AnalyzerOptions::full());
+    analyzer.analyze_script_plain(script);
+    let summary = analyzer.finish();
+
+    let output =
+        generate_virtual_ts_with_offsets(&summary, Some(script), None, 0, 0, &Default::default());
+
+    assert!(
+        output
+            .code
+            .contains("declare const __vizeDefineComponent: typeof import('vue').defineComponent;"),
+        "expected the defineComponent helper declaration:\n{}",
+        output.code
+    );
+    assert!(
+        output
+            .code
+            .contains("const __default__ = __vizeDefineComponent({"),
+        "expected the options object to be wrapped with defineComponent:\n{}",
+        output.code
+    );
+    assert!(
+        output.code.contains("\n  })\n"),
+        "expected the wrap to be closed after the options object:\n{}",
+        output.code
+    );
+}
+
+#[test]
+fn test_single_line_options_object_default_export_wrap_keeps_trailing_text() {
+    use vize_croquis::{Analyzer, AnalyzerOptions};
+
+    let script = "export default { name: 'Foo' };\n";
+    let mut analyzer = Analyzer::with_options(AnalyzerOptions::full());
+    analyzer.analyze_script_plain(script);
+    let summary = analyzer.finish();
+
+    let output =
+        generate_virtual_ts_with_offsets(&summary, Some(script), None, 0, 0, &Default::default());
+
+    assert!(
+        output
+            .code
+            .contains("const __default__ = __vizeDefineComponent({ name: 'Foo' });"),
+        "expected a single-line wrap that preserves the trailing semicolon:\n{}",
+        output.code
+    );
+}
+
+#[test]
+fn test_define_component_default_export_is_not_double_wrapped() {
+    use vize_croquis::{Analyzer, AnalyzerOptions};
+
+    let script = r#"import { defineComponent } from 'vue'
+
+export default defineComponent({
+  data() {
+    return { count: 0 }
+  },
+})
+"#;
+    let mut analyzer = Analyzer::with_options(AnalyzerOptions::full());
+    analyzer.analyze_script_plain(script);
+    let summary = analyzer.finish();
+
+    let output =
+        generate_virtual_ts_with_offsets(&summary, Some(script), None, 0, 0, &Default::default());
+
+    assert!(
+        !output.code.contains("__vizeDefineComponent"),
+        "an explicit defineComponent call must not be re-wrapped:\n{}",
+        output.code
+    );
+    assert!(
+        output
+            .code
+            .contains("const __default__ = defineComponent({"),
+        "expected the existing rewrite to stay untouched:\n{}",
+        output.code
+    );
+}
+
+#[test]
+fn test_non_object_default_export_is_not_wrapped() {
+    use vize_croquis::{Analyzer, AnalyzerOptions};
+
+    let script = r#"const component = { name: 'Foo' }
+export default component
+"#;
+    let mut analyzer = Analyzer::with_options(AnalyzerOptions::full());
+    analyzer.analyze_script_plain(script);
+    let summary = analyzer.finish();
+
+    let output =
+        generate_virtual_ts_with_offsets(&summary, Some(script), None, 0, 0, &Default::default());
+
+    assert!(
+        !output.code.contains("__vizeDefineComponent"),
+        "identifier default exports must not be wrapped:\n{}",
+        output.code
+    );
+    assert!(
+        output.code.contains("const __default__ = component"),
+        "expected the existing rewrite to stay untouched:\n{}",
+        output.code
+    );
+}


### PR DESCRIPTION
## Summary

Part of #1388 (PR1 — the defineComponent-wrap opener).

The virtual TS generator rewrote a plain `export default { ... }` (the Options API shape) verbatim to `const __default__ = { ... }`. In a bare object literal, TypeScript binds `this` inside a method to the *containing sub-object literal*, so every `this.<member>` that lives on the real component instance produced a TS2339 false positive:

```vue
<script lang="ts">
export default {
  data() {
    return { count: 0 }
  },
  computed: {
    doubled(): number {
      return this.count * 2   // TS2339: Property 'count' does not exist on type '{ doubled(): number; }'
    },
  },
}
</script>
```

This PR wraps plain object-literal default exports with Vue's `defineComponent` in the generated virtual TS (the same move as Volar's `optionsWrapper`), so TS binds `this` via Vue's `ThisType` machinery and the example above checks clean against the real vue package — verified locally against vue 3.6.0-beta.10.

## What changed

- `virtual_ts/generator/options_api.rs`: new `find_plain_default_export_object` locates `export default { ... }` via the existing oxc parse utilities. Only a **direct** `ObjectExpression` qualifies — already-wrapped `defineComponent(...)` calls, classes, identifiers, function calls, and `as`/`satisfies` expressions are left untouched.
- `virtual_ts/generator/spans.rs`: `rewrite_export_default_for_module_scope` now takes the located object span and emits `const __default__ = __vizeDefineComponent({ ...original options... })` (module-scope path, used for the plain `<script>` block of dual-block SFCs). Other shapes fall through to the existing line-based rewrite. The helper is declared once per module as `declare const __vizeDefineComponent: typeof import('vue').defineComponent;` — the same `import('vue')` reference form the generator already uses for its other vue helpers, so it cannot collide with user imports.
- `virtual_ts/generator/mod.rs`: the setup-scope line emitter applies the same wrap for plain-`<script>`-only SFCs (open on the `export default {` line, matching `)` inserted right after the object's closing brace, single-line exports handled inline). Script setup virtual TS is never touched; the lookup is skipped entirely for setup-only SFCs, so the script-setup path is zero-cost.

The object literal stays lexically inside the `defineComponent(...)` call (required for `ThisType` contextual typing) and its lines are emitted byte-for-byte, so existing source mappings for the options body are unchanged.

## Facade-fallback caveat (known, not fixed here)

In facade-fallback mode (no resolvable real `vue` package) the bundled stub types `defineComponent(options: any)` and its `DefineComponent` discards everything but `Props` (`crates/vize_canon/src/batch/runtime_deps.rs`), so the wrap cannot yield real instance types there — `this` in a computed still infers as the sub-object literal and the pre-existing TS2339 remains. The wrap introduces **no new** errors in fallback mode (regression-tested); a ThisType-aware stub signature is #1388 PR6.

## Snapshot churn

- No `vize_canon` insta snapshots changed — none of the existing snapshots cover a plain options-object default export (ran with `INSTA_UPDATE=always` and diffed).
- The real-world `tests/snapshots/check` baselines for **ant-design-vue, elk, misskey, nuxt-ui** embed `const __default__ = { ...` in their recorded `virtualTs` and will drift. Per repo convention, check-baseline drift from type-resolution improvements is refreshed in a separate `test(check): refresh ...` PR built from main (the fixture apps' node_modules are not installed in this worktree, so the refresh was not cheap to run here).
- The `tests/_fixtures/_projects` parity fixtures contain no plain options-object SFCs (no Options API project exists yet — #1388 PR11), so the fixture parity suite is unaffected.

## LSP

maestro shares this generator path (`vize_maestro/src/ide/diagnostics/corsa/virtual_ts.rs` and the hover/completion/definition services consume the same canon virtual TS), so LSP diagnostics/hover/completion inherit the wrap automatically.

## Test plan

- New regression test `batch_type_checker_accepts_options_api_this_data_access_in_computed`: a plain-options component with `this.count` accessed in a computed checks **clean against real vue types** (BatchTypeChecker + linked real vue; skips gracefully when only the erased test stub is available, like the other workspace-vue tests). Verified locally with `VIZE_TEST_WORKSPACE_NODE_MODULES` pointing at a real vue 3.6.0-beta.10 install — fails on main, passes with this PR.
- New regression test `batch_type_checker_options_api_wrap_adds_no_errors_in_facade_fallback`: in facade-fallback mode the only diagnostic is the documented pre-existing TS2339 (no new errors from the wrap).
- New virtual-TS shape tests (setup-scope path, single-line export, no double-wrap of explicit `defineComponent`, no wrap of identifier exports) and sfc_typecheck shape tests (plain `<script>`, dual-block module-scope path, script-setup untouched).
- `cargo test -p vize_canon`: 330 passed, 0 failed (on top of latest main).
- `cargo test -p vize_maestro`: 0 failed.
- `cargo fmt --check` clean; `cargo clippy -p vize_canon --all-targets` warning count identical to main (35, all pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1407"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783754587&installation_id=136613492&pr_number=1407&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1407&signature=d062b908e570d16d9ccfdb4b8982dd18be128405c9ade1ce08b9db00d6df28d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->