### PR TITLE
feat(armature): model legacy Vue dialects as per-file capability sets

### DIFF
--- a/crates/vize_armature/Cargo.toml
+++ b/crates/vize_armature/Cargo.toml
@@ -8,7 +8,7 @@ repository.workspace = true
 description = "Armature - The structural parser framework for Vize Vue templates"
 
 [features]
-# Opt-in support for legacy Vue lines (v0 / v1 / v2). Off by default so the
+# Opt-in support for legacy Vue lines (v0.10 / v0.11 / v1 / v2). Off by default so the
 # Vue 3 `vize` binary never compiles it. See the `legacy` module.
 legacy = []
 

--- a/crates/vize_armature/src/legacy.rs
+++ b/crates/vize_armature/src/legacy.rs
@@ -1,4 +1,4 @@
-//! Legacy Vue (v0 / v1 / v2) support surface.
+//! Legacy Vue (v0.10 / v0.11 / v1 / v2) support surface.
 //!
 //! This module is the consolidation point for pre-Vue-3 ("legacy") parsing and
 //! tokenization in `vize_armature`. It is gated behind the `legacy` cargo
@@ -8,42 +8,273 @@
 //! The companion `legacy` modules in `vize_canon` (type checking) and
 //! `vize_maestro` (editor / LSP) build on the [`LegacyVueVersion`] model
 //! defined here, so all three layers agree on which legacy line is in play.
+//!
+//! # Dialect resolution model
+//!
+//! A document's dialect is selected by config (`vue.version`, normalized to
+//! [`VueDialect`] in `vize_carton`) and resolved **once per file** into a
+//! [`LegacyDialectCapabilities`] set via [`LegacyDialectCapabilities::for_dialect`].
+//! Hot paths (tokenizer states, attribute classification, directive
+//! finalization, transforms) must only read capability fields; they must never
+//! re-match on [`LegacyVueVersion`] per token or per node. This keeps legacy
+//! support zero-cost for the default dialect: the Vue 3 capability set is the
+//! all-off [`LegacyDialectCapabilities::VUE3`], so every capability test
+//! short-circuits exactly like today's unconditional Vue 3 code paths — and
+//! without the `legacy` feature this module is not compiled at all.
 
-/// A legacy (pre-Vue-3) major line that Vize can opt into supporting.
+use vize_carton::config::VueDialect;
+
+/// A legacy (pre-Vue-3) version line that Vize can opt into supporting.
 ///
 /// Vize targets Vue 3 by default. These variants name the older runtimes whose
 /// template syntax, reactivity, and component model differ enough from Vue 3 to
 /// require a dedicated parsing / analysis path behind the `legacy` feature:
 ///
-/// - [`V0`](Self::V0): the Vue 0.x (0.11-era) line, predating the modern SFC
-///   toolchain.
-/// - [`V1`](Self::V1): Vue 1.x (`v-repeat`, `track-by`, `$index`, `v-el`, …).
+/// - [`V0_10`](Self::V0_10): Vue 0.10.x, the last pre-rewrite 0.x line.
+/// - [`V0_11`](Self::V0_11): the 0.11-era post-rewrite 0.x line (previously
+///   modeled as `V0`).
+/// - [`V1`](Self::V1): Vue 1.x (`v-for`, `track-by`, `$index`, `v-el`, …).
 /// - [`V2`](Self::V2): Vue 2.x, including 2.7 (Options-API-first; `slot-scope`,
 ///   `.sync`, filters, functional components, single root, …).
+///
+/// Vue 0.10 and the 0.11-era line are deliberately distinct: 0.11.0 was a
+/// ground-up rewrite with documented breaking changes (see the per-variant
+/// docs), so the two cannot share one dialect entry.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum LegacyVueVersion {
-    /// Vue 0.x (the 0.11-era line).
-    V0,
+    /// Vue 0.10.x — the last pre-rewrite 0.x line.
+    ///
+    /// Templates iterate with `v-repeat` (no `v-for`; that arrives in 1.0),
+    /// inherit parent data with `v-with`, mount components with
+    /// `v-component`, and bind events with directive-value clauses
+    /// (`v-on="click: onClick"`); the 1.0+ colon-argument forms
+    /// (`v-on:click`, `@click`, `:prop`) do not exist yet. Computed
+    /// properties use the `$get` / `$set` object form, which the Vue 0.11.0
+    /// rewrite renamed to plain `get` / `set` (Vue 0.11 `changes.md`,
+    /// "Computed Properties"). That rename, plus the 0.11 instantiation and
+    /// scope-inheritance rework, is why this line is modeled separately from
+    /// [`V0_11`](Self::V0_11).
+    V0_10,
+    /// Vue 0.11-era — the post-rewrite 0.x line (0.11.x and the transitional
+    /// 0.12.x releases). Previously modeled as `V0`.
+    ///
+    /// Shares the clause-style directive surface with 0.10 (`v-repeat`,
+    /// `v-with`, `v-component`, `v-on="click: onClick"`), but the 0.11.0
+    /// rewrite changed instantiation/scope semantics and renamed computed
+    /// `$get` / `$set` to `get` / `set` (Vue 0.11 `changes.md`). During 0.12
+    /// the line began migrating to `props`, deprecating `v-with` and
+    /// `v-component` (Vue 0.12 release notes) ahead of Vue 1.0's new
+    /// directive syntax.
+    V0_11,
     /// Vue 1.x.
+    ///
+    /// The 1.0 migration replaced `v-repeat` with `v-for` (`track-by`,
+    /// `$index`) and introduced colon-argument directive syntax with
+    /// shorthands (`v-bind:prop` / `:prop`, `v-on:click` / `@click`) per the
+    /// "Migrating from 0.12" guide in the Vue 1.0 docs. Mustache
+    /// interpolation still works inside plain attribute values
+    /// (`href="{{ url }}"`), and filters take space-separated arguments
+    /// (`{{ msg | filterBy 'a' }}`).
     V1,
-    /// Vue 2.x (including 2.7).
+    /// Vue 2.x, including 2.7.
+    ///
+    /// Options-API-first. Keeps pipe filters but switches their arguments to
+    /// call-style (`{{ msg | filterBy('a') }}`; Vue 2 migration guide,
+    /// "Filter Argument Syntax") and removes attribute-value mustache
+    /// interpolation in favor of `v-bind` ("Interpolation within
+    /// Attributes"). Adds scoped-slot sugar (`scope` in 2.1, `slot-scope` in
+    /// 2.5), the `.sync` and `.native` modifiers, numeric key modifiers
+    /// (`@keyup.13`), functional components, and the single-root template
+    /// requirement. Vue 2.7 backports `<script setup>` but shares this
+    /// template dialect.
     V2,
 }
 
 impl LegacyVueVersion {
     /// Every supported legacy line, oldest first.
-    pub const ALL: [LegacyVueVersion; 3] = [Self::V0, Self::V1, Self::V2];
+    pub const ALL: [LegacyVueVersion; 4] = [Self::V0_10, Self::V0_11, Self::V1, Self::V2];
 
-    /// A short, stable identifier for the line (`"v0"`, `"v1"`, `"v2"`).
+    /// A short, stable identifier for the line (`"v0.10"`, `"v0.11"`, `"v1"`,
+    /// `"v2"`).
     ///
-    /// Kept stable so it can be used in config values, diagnostics, and feature
-    /// reporting without churning across releases.
+    /// Kept stable so it can be used in diagnostics and feature reporting
+    /// without churning across releases. Config-side parsing lives on
+    /// [`VueDialect`] in `vize_carton`, which accepts these identifiers as
+    /// well as the bare `vue.version` numbers.
     pub fn as_str(self) -> &'static str {
         match self {
-            Self::V0 => "v0",
+            Self::V0_10 => "v0.10",
+            Self::V0_11 => "v0.11",
             Self::V1 => "v1",
             Self::V2 => "v2",
         }
+    }
+
+    /// Resolve a config-selected [`VueDialect`] into a legacy line.
+    ///
+    /// Returns `None` for [`VueDialect::V3`]: modern Vue 3 is not a legacy
+    /// line and must take the default (non-legacy) code paths. Vue 2.7 and
+    /// Vue 2 share the [`V2`](Self::V2) template dialect.
+    pub const fn from_dialect(dialect: VueDialect) -> Option<Self> {
+        match dialect {
+            VueDialect::V3 => None,
+            VueDialect::V2_7 | VueDialect::V2 => Some(Self::V2),
+            VueDialect::V1 => Some(Self::V1),
+            VueDialect::V0_11 => Some(Self::V0_11),
+            VueDialect::V0_10 => Some(Self::V0_10),
+        }
+    }
+
+    /// Resolve this line into its template-syntax capability set.
+    ///
+    /// Call this once per file/document when building parser or transform
+    /// options; see [`LegacyDialectCapabilities`] for the zero-cost contract.
+    pub const fn capabilities(self) -> LegacyDialectCapabilities {
+        match self {
+            Self::V0_10 => LegacyDialectCapabilities {
+                supports_filters: true,
+                space_separated_filter_args: true,
+                v_repeat_syntax: true,
+                directive_arg_style: DirectiveArgStyle::Clause,
+                v_with_directive: true,
+                v_component_directive: true,
+                computed_dollar_get_set: true,
+                attr_value_interpolation: true,
+                scoped_slot_attrs: false,
+            },
+            Self::V0_11 => LegacyDialectCapabilities {
+                supports_filters: true,
+                space_separated_filter_args: true,
+                v_repeat_syntax: true,
+                directive_arg_style: DirectiveArgStyle::Clause,
+                v_with_directive: true,
+                v_component_directive: true,
+                computed_dollar_get_set: false,
+                attr_value_interpolation: true,
+                scoped_slot_attrs: false,
+            },
+            Self::V1 => LegacyDialectCapabilities {
+                supports_filters: true,
+                space_separated_filter_args: true,
+                v_repeat_syntax: false,
+                directive_arg_style: DirectiveArgStyle::Colon,
+                v_with_directive: false,
+                v_component_directive: false,
+                computed_dollar_get_set: false,
+                attr_value_interpolation: true,
+                scoped_slot_attrs: false,
+            },
+            Self::V2 => LegacyDialectCapabilities {
+                supports_filters: true,
+                space_separated_filter_args: false,
+                v_repeat_syntax: false,
+                directive_arg_style: DirectiveArgStyle::Colon,
+                v_with_directive: false,
+                v_component_directive: false,
+                computed_dollar_get_set: false,
+                attr_value_interpolation: false,
+                scoped_slot_attrs: true,
+            },
+        }
+    }
+}
+
+/// How a dialect spells directive arguments.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
+pub enum DirectiveArgStyle {
+    /// 0.x clause syntax: the directive *value* carries `arg: expression`
+    /// clauses, comma-separable (`v-on="click: onClick, keyup: onKeyup"`).
+    Clause,
+    /// Colon-argument syntax (`v-on:click="onClick"`) with the `@` / `:`
+    /// shorthands, introduced by Vue 1.0's directive-syntax rework and kept
+    /// through Vue 2 and Vue 3. This is the default (Vue 3) style.
+    #[default]
+    Colon,
+}
+
+/// Template-syntax capabilities of a dialect, resolved once per document.
+///
+/// # Zero-cost contract
+///
+/// Resolve this set exactly once per file — when parser/transform options are
+/// built — via [`LegacyDialectCapabilities::for_dialect`] or
+/// [`LegacyVueVersion::capabilities`]. Hot paths only read these fields (a
+/// field read of a `Copy` struct), and must never re-match on
+/// [`LegacyVueVersion`] per token or per node. The default dialect resolves to
+/// the all-off [`VUE3`](Self::VUE3) set, so every capability check
+/// short-circuits to the same branch the unconditional Vue 3 code takes today;
+/// without the `legacy` cargo feature none of this is compiled at all.
+///
+/// Each field documents the version lines it covers and the upstream Vue
+/// changelog / migration-guide entry that introduced or removed the surface.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct LegacyDialectCapabilities {
+    /// Pipe filters in text interpolations and binding values
+    /// (`{{ msg | capitalize }}`). All legacy lines; removed in Vue 3
+    /// (Vue 3 migration guide, "Filters").
+    pub supports_filters: bool,
+    /// Space-separated filter arguments (`{{ msg | filterBy 'a' }}`), the
+    /// 0.x / 1.x form. Vue 2 switched filters to call-style arguments
+    /// (Vue 2 migration guide, "Filter Argument Syntax").
+    pub space_separated_filter_args: bool,
+    /// List rendering via `v-repeat` (with implicit `$index`). 0.x lines
+    /// only; Vue 1.0 replaced it with `v-for` ("Migrating from 0.12").
+    pub v_repeat_syntax: bool,
+    /// How directive arguments are spelled; see [`DirectiveArgStyle`].
+    pub directive_arg_style: DirectiveArgStyle,
+    /// Parent-data inheritance via the `v-with` directive. 0.x lines only;
+    /// deprecated during 0.12 in favor of `props`.
+    pub v_with_directive: bool,
+    /// Component mounting via the `v-component` directive. 0.x lines only;
+    /// deprecated during 0.12 in favor of component elements / `is`.
+    pub v_component_directive: bool,
+    /// Computed properties using the `$get` / `$set` object form. Vue 0.10
+    /// only; the 0.11.0 rewrite renamed them to plain `get` / `set`
+    /// (Vue 0.11 `changes.md`).
+    pub computed_dollar_get_set: bool,
+    /// Mustache interpolation inside plain attribute values
+    /// (`href="{{ url }}"`). 0.x / 1.x; removed in Vue 2 in favor of
+    /// `v-bind` (Vue 2 migration guide, "Interpolation within Attributes").
+    pub attr_value_interpolation: bool,
+    /// Scoped-slot attribute sugar: `scope` (added in 2.1) and `slot-scope`
+    /// (added in 2.5). Vue 2 only; superseded by `v-slot` in 2.6 and Vue 3.
+    pub scoped_slot_attrs: bool,
+}
+
+impl LegacyDialectCapabilities {
+    /// The default (modern Vue 3) capability set: every legacy surface off,
+    /// colon-style directive arguments.
+    ///
+    /// This is the set a `legacy`-enabled build resolves for Vue 3 sources,
+    /// guaranteeing they take branch-identical paths to a build without the
+    /// feature.
+    pub const VUE3: LegacyDialectCapabilities = LegacyDialectCapabilities {
+        supports_filters: false,
+        space_separated_filter_args: false,
+        v_repeat_syntax: false,
+        directive_arg_style: DirectiveArgStyle::Colon,
+        v_with_directive: false,
+        v_component_directive: false,
+        computed_dollar_get_set: false,
+        attr_value_interpolation: false,
+        scoped_slot_attrs: false,
+    };
+
+    /// Resolve a config-selected [`VueDialect`] straight to its capability
+    /// set ([`VUE3`](Self::VUE3) for the default dialect).
+    ///
+    /// This is the once-per-file entry point for option builders.
+    pub const fn for_dialect(dialect: VueDialect) -> LegacyDialectCapabilities {
+        match LegacyVueVersion::from_dialect(dialect) {
+            None => Self::VUE3,
+            Some(version) => version.capabilities(),
+        }
+    }
+}
+
+impl Default for LegacyDialectCapabilities {
+    fn default() -> Self {
+        Self::VUE3
     }
 }
 
@@ -52,10 +283,87 @@ mod tests {
     use super::*;
 
     #[test]
-    fn as_str_round_trips_all_variants() {
-        assert_eq!(LegacyVueVersion::ALL.len(), 3);
-        assert_eq!(LegacyVueVersion::V0.as_str(), "v0");
-        assert_eq!(LegacyVueVersion::V1.as_str(), "v1");
-        assert_eq!(LegacyVueVersion::V2.as_str(), "v2");
+    fn as_str_round_trips_all_variants_through_config_parsing() {
+        assert_eq!(LegacyVueVersion::ALL.len(), 4);
+        for version in LegacyVueVersion::ALL {
+            let dialect = VueDialect::from_config_str(version.as_str())
+                .unwrap_or_else(|error| panic!("{}: {error}", version.as_str()));
+            assert_eq!(LegacyVueVersion::from_dialect(dialect), Some(version));
+        }
+    }
+
+    #[test]
+    fn config_string_resolves_to_version_and_capabilities() {
+        // The full plumbing a config consumer runs once per file:
+        // raw string -> dialect -> legacy line -> capability set.
+        let dialect = VueDialect::from_config_str("0.10").unwrap();
+        let version = LegacyVueVersion::from_dialect(dialect).unwrap();
+        assert_eq!(version, LegacyVueVersion::V0_10);
+        let caps = version.capabilities();
+        assert!(caps.computed_dollar_get_set);
+        assert_eq!(caps, LegacyDialectCapabilities::for_dialect(dialect));
+    }
+
+    #[test]
+    fn v0_10_differs_from_v0_11_only_in_documented_surfaces() {
+        let v0_10 = LegacyVueVersion::V0_10.capabilities();
+        let v0_11 = LegacyVueVersion::V0_11.capabilities();
+        // 0.10 keeps the pre-rewrite computed `$get`/`$set` form.
+        assert!(v0_10.computed_dollar_get_set);
+        assert!(!v0_11.computed_dollar_get_set);
+        // Both 0.x lines share the clause-style directive surface.
+        assert_eq!(v0_10.directive_arg_style, DirectiveArgStyle::Clause);
+        assert_eq!(v0_11.directive_arg_style, DirectiveArgStyle::Clause);
+        assert!(v0_10.v_repeat_syntax && v0_11.v_repeat_syntax);
+        assert!(v0_10.v_with_directive && v0_11.v_with_directive);
+        assert!(v0_10.v_component_directive && v0_11.v_component_directive);
+    }
+
+    #[test]
+    fn v1_modernizes_directive_surface_but_keeps_old_filters() {
+        let v0_11 = LegacyVueVersion::V0_11.capabilities();
+        let v1 = LegacyVueVersion::V1.capabilities();
+        assert!(v0_11.v_repeat_syntax && !v1.v_repeat_syntax);
+        assert_eq!(v0_11.directive_arg_style, DirectiveArgStyle::Clause);
+        assert_eq!(v1.directive_arg_style, DirectiveArgStyle::Colon);
+        assert!(!v1.v_with_directive && !v1.v_component_directive);
+        assert!(v1.supports_filters && v1.space_separated_filter_args);
+        assert!(v1.attr_value_interpolation);
+    }
+
+    #[test]
+    fn v2_keeps_filters_but_drops_v1_interpolation_surfaces() {
+        let v1 = LegacyVueVersion::V1.capabilities();
+        let v2 = LegacyVueVersion::V2.capabilities();
+        assert!(v2.supports_filters);
+        assert!(v1.space_separated_filter_args && !v2.space_separated_filter_args);
+        assert!(v1.attr_value_interpolation && !v2.attr_value_interpolation);
+        assert!(!v1.scoped_slot_attrs && v2.scoped_slot_attrs);
+    }
+
+    #[test]
+    fn v2_and_v2_7_share_the_template_dialect() {
+        let v2 = LegacyVueVersion::from_dialect(VueDialect::V2).unwrap();
+        let v2_7 = LegacyVueVersion::from_dialect(VueDialect::V2_7).unwrap();
+        assert_eq!(v2, v2_7);
+        assert_eq!(
+            LegacyDialectCapabilities::for_dialect(VueDialect::V2),
+            LegacyDialectCapabilities::for_dialect(VueDialect::V2_7),
+        );
+    }
+
+    #[test]
+    fn default_dialect_resolves_to_the_all_off_vue3_set() {
+        let caps = LegacyDialectCapabilities::for_dialect(VueDialect::V3);
+        assert_eq!(caps, LegacyDialectCapabilities::VUE3);
+        assert_eq!(caps, LegacyDialectCapabilities::default());
+        assert!(!caps.supports_filters);
+        assert!(!caps.v_repeat_syntax);
+        assert_eq!(caps.directive_arg_style, DirectiveArgStyle::Colon);
+        // Every legacy line differs from the default set, so a capability
+        // check can never confuse a legacy document with a Vue 3 one.
+        for version in LegacyVueVersion::ALL {
+            assert_ne!(version.capabilities(), LegacyDialectCapabilities::VUE3);
+        }
     }
 }

--- a/crates/vize_armature/src/lib.rs
+++ b/crates/vize_armature/src/lib.rs
@@ -19,7 +19,7 @@
 pub mod parser;
 pub mod tokenizer;
 
-/// Legacy Vue (v0 / v1 / v2) support. Gated behind the `legacy` feature and
+/// Legacy Vue (v0.10 / v0.11 / v1 / v2) support. Gated behind the `legacy` feature and
 /// dropped from the default Vue 3 build; opt-in only.
 #[cfg(feature = "legacy")]
 pub mod legacy;

--- a/crates/vize_canon/Cargo.toml
+++ b/crates/vize_canon/Cargo.toml
@@ -10,7 +10,7 @@ description = "Canon - The standard of correctness for Vize type checking"
 [features]
 default = ["native"]
 native = ["dep:which", "dep:walkdir", "dep:dirs", "dep:corsa", "dep:lsp-types"]
-# Opt-in legacy Vue (v0 / v1 / v2) type-checking surface. Not enabled by the
+# Opt-in legacy Vue (v0.10 / v0.11 / v1 / v2) type-checking surface. Not enabled by the
 # default Vue 3 build; turns on the parser-side legacy feature too.
 legacy = ["vize_armature/legacy"]
 

--- a/crates/vize_canon/src/legacy.rs
+++ b/crates/vize_canon/src/legacy.rs
@@ -1,4 +1,4 @@
-//! Legacy Vue (v0 / v1 / v2) type-checking surface.
+//! Legacy Vue (v0.10 / v0.11 / v1 / v2) type-checking surface.
 //!
 //! This module is the consolidation point for pre-Vue-3 ("legacy") type
 //! checking and virtual-TS generation in `vize_canon`. It is gated behind the
@@ -7,6 +7,8 @@
 //! strictly opt-in.
 //!
 //! The version model is shared from [`vize_armature::legacy`] so the parser,
-//! type checker, and editor layers all agree on which legacy line is in play.
+//! type checker, and editor layers all agree on which legacy line is in play,
+//! and dialects are resolved once per file into a
+//! [`LegacyDialectCapabilities`] set rather than re-matched in hot paths.
 
-pub use vize_armature::legacy::LegacyVueVersion;
+pub use vize_armature::legacy::{DirectiveArgStyle, LegacyDialectCapabilities, LegacyVueVersion};

--- a/crates/vize_canon/src/lib.rs
+++ b/crates/vize_canon/src/lib.rs
@@ -56,7 +56,7 @@ pub mod source_map;
 mod types;
 pub mod virtual_ts;
 
-/// Legacy Vue (v0 / v1 / v2) type-checking surface. Gated behind the `legacy`
+/// Legacy Vue (v0.10 / v0.11 / v1 / v2) type-checking surface. Gated behind the `legacy`
 /// feature and dropped from the default Vue 3 build; opt-in only.
 #[cfg(feature = "legacy")]
 pub mod legacy;

--- a/crates/vize_carton/src/config.rs
+++ b/crates/vize_carton/src/config.rs
@@ -13,6 +13,7 @@ pub use loader::{
 pub use model::{
     ArrowParens, AttributeSortOrder, ConfigFeatureFlags, EndOfLine, FormatterConfig,
     GlobalTypeDeclaration, GlobalTypesConfig, LanguageServerConfig, LintRuleSeverity, LinterConfig,
-    LspConfig, QuoteProps, TrailingComma, TypeCheckerConfig, VizeConfig,
+    LspConfig, ParseVueDialectError, QuoteProps, TrailingComma, TypeCheckerConfig, VizeConfig,
+    VueDialect,
 };
 pub use normalize::normalize_public_config_value;

--- a/crates/vize_carton/src/config/model.rs
+++ b/crates/vize_carton/src/config/model.rs
@@ -6,10 +6,12 @@ mod global_types;
 mod language_server;
 mod linter;
 mod type_checker;
+mod vue;
 
 use serde::{Deserialize, Serialize};
 
 use compiler::RawCompilerConfig;
+use vue::RawVueConfig;
 
 use crate::String;
 pub use formatter::{
@@ -20,6 +22,7 @@ pub use language_server::{LanguageServerConfig, LspConfig};
 #[allow(unused_imports)]
 pub use linter::{LintRuleSeverity, LinterConfig};
 pub use type_checker::TypeCheckerConfig;
+pub use vue::{ParseVueDialectError, VueDialect};
 
 /// Effective shared configuration.
 #[derive(Debug, Clone, Default, Serialize)]
@@ -60,6 +63,12 @@ pub struct ConfigFeatureFlags {
     pub type_checker_options_api: bool,
     pub type_checker_legacy_vue2: bool,
     pub language_server_legacy_vue2: Option<bool>,
+    /// Dialect selected by `vue.version`; `None` when the key is absent
+    /// (modern Vue 3). Validated at parse time — unknown or ambiguous values
+    /// fail config loading instead of silently picking a line. Groundwork for
+    /// legacy Vue support (#1392): consumers thread this into parser and
+    /// transform options in follow-ups.
+    pub vue_dialect: Option<VueDialect>,
 }
 
 /// Raw config representation with legacy aliases preserved for migration.
@@ -70,6 +79,7 @@ pub(crate) struct RawVizeConfig {
     pub schema: Option<String>,
     pub formatter: FormatterConfig,
     pub(crate) compiler: RawCompilerConfig,
+    pub(crate) vue: RawVueConfig,
     pub linter: LinterConfig,
     #[serde(rename = "typeChecker")]
     type_checker: RawTypeCheckerConfig,
@@ -120,6 +130,7 @@ impl RawVizeConfig {
             schema,
             formatter,
             compiler: _,
+            vue,
             linter: _,
             type_checker: raw_type_checker,
             language_server: raw_language_server,
@@ -157,6 +168,7 @@ impl RawVizeConfig {
             type_checker_options_api,
             type_checker_legacy_vue2,
             language_server_legacy_vue2: language_server_raw.legacy_vue2,
+            vue_dialect: vue.version,
         };
 
         let config = VizeConfig {

--- a/crates/vize_carton/src/config/model/vue.rs
+++ b/crates/vize_carton/src/config/model/vue.rs
@@ -1,0 +1,237 @@
+//! Vue dialect selection (`vue.version`) config model.
+//!
+//! `vue.version` names the Vue language dialect a project is written in.
+//! `"3"` — the default — is modern Vue 3; every other value selects a legacy
+//! line whose toolchain support is opt-in (the `legacy` cargo feature in the
+//! downstream crates). This module only owns parsing and validation of the
+//! selector; resolving a dialect into parser/transform behavior happens once
+//! per file in the legacy-capable crates (`vize_armature::legacy`).
+//!
+//! Parsing is strict on purpose: a version selector that silently fell back to
+//! "some" line would mis-lint or mis-compile every file in the project, so
+//! unknown or ambiguous values (such as `"0"`, which does not distinguish the
+//! Vue 0.10 line from the 0.11-era line) are configuration errors with
+//! actionable messages instead.
+
+use serde::{Deserialize, Deserializer, de};
+
+/// Vue language dialect selected by the `vue.version` config key.
+///
+/// Accepted config values are the bare version numbers `"3"` (default),
+/// `"2.7"`, `"2"`, `"1"`, `"0.11"`, and `"0.10"`; a leading `v` (as printed in
+/// diagnostics, e.g. `"v0.10"`) is also tolerated. Anything else fails config
+/// parsing — see [`VueDialect::from_config_str`].
+///
+/// Vue 2.7 is kept distinct from Vue 2 because the lines differ on the script
+/// side (2.7 backports `<script setup>` / composition APIs) even though they
+/// share a template dialect downstream.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
+pub enum VueDialect {
+    /// Modern Vue 3 — the default dialect; not a legacy line.
+    #[default]
+    V3,
+    /// Vue 2.7 (Vue 2 with the `<script setup>` / composition API backport).
+    V2_7,
+    /// Vue 2.x below 2.7.
+    V2,
+    /// Vue 1.x.
+    V1,
+    /// The Vue 0.11-era post-rewrite 0.x line.
+    V0_11,
+    /// Vue 0.10.x, the last pre-rewrite 0.x line (distinct from 0.11-era).
+    V0_10,
+}
+
+impl VueDialect {
+    /// Every selectable dialect, newest first.
+    pub const ALL: [VueDialect; 6] = [
+        Self::V3,
+        Self::V2_7,
+        Self::V2,
+        Self::V1,
+        Self::V0_11,
+        Self::V0_10,
+    ];
+
+    /// The canonical `vue.version` config value for this dialect.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::V3 => "3",
+            Self::V2_7 => "2.7",
+            Self::V2 => "2",
+            Self::V1 => "1",
+            Self::V0_11 => "0.11",
+            Self::V0_10 => "0.10",
+        }
+    }
+
+    /// Whether this dialect is a legacy (pre-Vue-3) line.
+    pub const fn is_legacy(self) -> bool {
+        !matches!(self, Self::V3)
+    }
+
+    /// Parse a `vue.version` config value.
+    ///
+    /// Unknown values are rejected rather than rounded to a nearby line, and
+    /// `"0"` is rejected as ambiguous: the Vue 0.10 line and the 0.11-era
+    /// line are distinct dialects (the 0.11.0 rewrite changed computed
+    /// `$get`/`$set`, instantiation, and scope semantics), so the config must
+    /// say which one it means.
+    pub fn from_config_str(raw: &str) -> Result<Self, ParseVueDialectError> {
+        let trimmed = raw.trim();
+        let bare = trimmed.strip_prefix(['v', 'V']).unwrap_or(trimmed);
+        match bare {
+            "3" => Ok(Self::V3),
+            "2.7" => Ok(Self::V2_7),
+            "2" => Ok(Self::V2),
+            "1" => Ok(Self::V1),
+            "0.11" => Ok(Self::V0_11),
+            "0.10" => Ok(Self::V0_10),
+            "0" => Err(ParseVueDialectError {
+                raw: raw.into(),
+                kind: ParseVueDialectErrorKind::AmbiguousZero,
+            }),
+            _ => Err(ParseVueDialectError {
+                raw: raw.into(),
+                kind: ParseVueDialectErrorKind::Unknown,
+            }),
+        }
+    }
+}
+
+/// Error produced when a `vue.version` value does not name a dialect.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParseVueDialectError {
+    raw: crate::String,
+    kind: ParseVueDialectErrorKind,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ParseVueDialectErrorKind {
+    /// `"0"` / `"v0"`: does not distinguish the 0.10 line from the 0.11-era
+    /// line.
+    AmbiguousZero,
+    /// Any other unrecognized value.
+    Unknown,
+}
+
+impl std::fmt::Display for ParseVueDialectError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let raw = self.raw.as_str();
+        match self.kind {
+            ParseVueDialectErrorKind::AmbiguousZero => write!(
+                f,
+                "ambiguous vue.version \"{raw}\": Vue 0.10 and the 0.11-era line are \
+                 distinct dialects; use \"0.10\" or \"0.11\""
+            ),
+            ParseVueDialectErrorKind::Unknown => write!(
+                f,
+                "unknown vue.version \"{raw}\": expected \"3\" (default), \"2.7\", \
+                 \"2\", \"1\", \"0.11\", or \"0.10\""
+            ),
+        }
+    }
+}
+
+impl std::error::Error for ParseVueDialectError {}
+
+impl<'de> Deserialize<'de> for VueDialect {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct VueDialectVisitor;
+
+        impl de::Visitor<'_> for VueDialectVisitor {
+            type Value = VueDialect;
+
+            fn expecting(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                // Reached for non-string values, e.g. `"version": 2.7` in
+                // JSON: steer the user toward the quoted string form.
+                f.write_str(
+                    "a Vue version string: \"3\", \"2.7\", \"2\", \"1\", \"0.11\", or \"0.10\" \
+                     (quote the value; 0.10 and 0.11 are not representable as numbers)",
+                )
+            }
+
+            fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                VueDialect::from_config_str(value).map_err(E::custom)
+            }
+        }
+
+        deserializer.deserialize_str(VueDialectVisitor)
+    }
+}
+
+/// Raw `vue` config section.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default)]
+pub(crate) struct RawVueConfig {
+    /// `vue.version` dialect selector; `None` when the key is absent.
+    pub(crate) version: Option<VueDialect>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_canonical_and_v_prefixed_values() {
+        for dialect in VueDialect::ALL {
+            assert_eq!(VueDialect::from_config_str(dialect.as_str()), Ok(dialect));
+            let prefixed = crate::cstr!("v{}", dialect.as_str());
+            assert_eq!(VueDialect::from_config_str(&prefixed), Ok(dialect));
+        }
+        assert_eq!(
+            VueDialect::from_config_str(" 2.7 "),
+            Ok(VueDialect::V2_7),
+            "values are trimmed"
+        );
+    }
+
+    #[test]
+    fn only_vue3_is_not_legacy() {
+        for dialect in VueDialect::ALL {
+            assert_eq!(dialect.is_legacy(), dialect != VueDialect::V3);
+        }
+    }
+
+    #[test]
+    fn rejects_bare_zero_as_ambiguous() {
+        for raw in ["0", "v0", "V0"] {
+            let error = VueDialect::from_config_str(raw).unwrap_err();
+            let message = crate::cstr!("{error}");
+            assert!(message.contains("ambiguous"), "{message}");
+            assert!(message.contains("\"0.10\""), "{message}");
+            assert!(message.contains("\"0.11\""), "{message}");
+        }
+    }
+
+    #[test]
+    fn rejects_unknown_values_with_expected_list() {
+        for raw in ["2.6", "4", "vue2", ""] {
+            let error = VueDialect::from_config_str(raw).unwrap_err();
+            let message = crate::cstr!("{error}");
+            assert!(message.contains("unknown vue.version"), "{message}");
+            assert!(message.contains("\"2.7\""), "{message}");
+            assert!(message.contains("\"0.10\""), "{message}");
+        }
+    }
+
+    #[test]
+    fn deserializes_strings_and_rejects_numbers() {
+        let dialect: VueDialect = serde_json::from_str("\"0.10\"").unwrap();
+        assert_eq!(dialect, VueDialect::V0_10);
+
+        let error = serde_json::from_str::<VueDialect>("2.7").unwrap_err();
+        let message = crate::cstr!("{error}");
+        assert!(message.contains("Vue version string"), "{message}");
+
+        let error = serde_json::from_str::<VueDialect>("\"0\"").unwrap_err();
+        let message = crate::cstr!("{error}");
+        assert!(message.contains("ambiguous"), "{message}");
+    }
+}

--- a/crates/vize_carton/tests/loading.rs
+++ b/crates/vize_carton/tests/loading.rs
@@ -1,7 +1,8 @@
 #![allow(clippy::disallowed_macros)]
 
 use vize_carton::config::{
-    load_config, load_config_with_features_and_source, load_config_with_source,
+    VueDialect, load_config, load_config_with_features_and_source, load_config_with_source,
+    validate_explicit_config_path,
 };
 
 #[test]
@@ -78,6 +79,77 @@ fn loads_json_legacy_vue2_feature_flags() {
     assert!(loaded.features.type_checker_legacy_vue2);
     assert_eq!(loaded.features.language_server_legacy_vue2, Some(true));
     assert!(loaded.config.type_checker.enabled);
+}
+
+#[test]
+fn loads_json_vue_version_dialect() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(
+        dir.path().join("vize.config.json"),
+        r#"{
+          "vue": {
+            "version": "0.10"
+          }
+        }"#,
+    )
+    .unwrap();
+
+    let loaded = load_config_with_features_and_source(Some(dir.path()));
+
+    assert_eq!(loaded.features.vue_dialect, Some(VueDialect::V0_10));
+}
+
+#[test]
+fn vue_version_defaults_to_unset() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("vize.config.json"), r#"{}"#).unwrap();
+
+    let loaded = load_config_with_features_and_source(Some(dir.path()));
+
+    assert_eq!(loaded.features.vue_dialect, None);
+}
+
+#[test]
+fn rejects_ambiguous_vue_version() {
+    let dir = tempfile::tempdir().unwrap();
+    let config_path = dir.path().join("vize.config.json");
+    std::fs::write(
+        &config_path,
+        r#"{
+          "vue": {
+            "version": "0"
+          }
+        }"#,
+    )
+    .unwrap();
+
+    // Explicit --config must hard-error with the actionable message.
+    let error = validate_explicit_config_path(&config_path).unwrap_err();
+    assert!(error.contains("ambiguous"), "{error}");
+    assert!(error.contains("0.10") && error.contains("0.11"), "{error}");
+
+    // Auto-discovery warns and falls back to defaults: it must never resolve
+    // an ambiguous selector to some 0.x line.
+    let loaded = load_config_with_features_and_source(Some(dir.path()));
+    assert_eq!(loaded.features.vue_dialect, None);
+}
+
+#[test]
+fn rejects_unquoted_vue_version_numbers() {
+    let dir = tempfile::tempdir().unwrap();
+    let config_path = dir.path().join("vize.config.json");
+    std::fs::write(
+        &config_path,
+        r#"{
+          "vue": {
+            "version": 2.7
+          }
+        }"#,
+    )
+    .unwrap();
+
+    let error = validate_explicit_config_path(&config_path).unwrap_err();
+    assert!(error.contains("Vue version string"), "{error}");
 }
 
 #[test]

--- a/crates/vize_maestro/Cargo.toml
+++ b/crates/vize_maestro/Cargo.toml
@@ -12,7 +12,7 @@ publish = false
 default = ["native", "glyph"]
 glyph = ["dep:vize_glyph"]
 native = ["vize_canon/native"]
-# Opt-in legacy Vue (v0 / v1 / v2) editor / LSP surface. Not enabled by the
+# Opt-in legacy Vue (v0.10 / v0.11 / v1 / v2) editor / LSP surface. Not enabled by the
 # default Vue 3 build; turns on the type-checker-side legacy feature too.
 legacy = ["vize_canon/legacy"]
 

--- a/crates/vize_maestro/src/legacy.rs
+++ b/crates/vize_maestro/src/legacy.rs
@@ -1,4 +1,4 @@
-//! Legacy Vue (v0 / v1 / v2) editor / LSP surface.
+//! Legacy Vue (v0.10 / v0.11 / v1 / v2) editor / LSP surface.
 //!
 //! This module is the consolidation point for pre-Vue-3 ("legacy") editor
 //! features (hover, completion, definitions, diagnostics) in `vize_maestro`. It
@@ -8,6 +8,8 @@
 //!
 //! The version model is shared from [`vize_canon::legacy`] (re-exported from
 //! [`vize_armature::legacy`]) so the parser, type checker, and editor layers all
-//! agree on which legacy line is in play.
+//! agree on which legacy line is in play, and dialects are resolved once per
+//! document into a [`LegacyDialectCapabilities`] set rather than re-matched in
+//! hot paths.
 
-pub use vize_canon::legacy::LegacyVueVersion;
+pub use vize_canon::legacy::{DirectiveArgStyle, LegacyDialectCapabilities, LegacyVueVersion};

--- a/crates/vize_maestro/src/lib.rs
+++ b/crates/vize_maestro/src/lib.rs
@@ -66,7 +66,7 @@ pub mod server;
 pub mod utils;
 pub mod virtual_code;
 
-/// Legacy Vue (v0 / v1 / v2) editor / LSP surface. Gated behind the `legacy`
+/// Legacy Vue (v0.10 / v0.11 / v1 / v2) editor / LSP surface. Gated behind the `legacy`
 /// feature and dropped from the default Vue 3 build; opt-in only.
 #[cfg(feature = "legacy")]
 pub mod legacy;


### PR DESCRIPTION
## Summary

Opener PR for the legacy Vue umbrella: cleans up the dialect model so later parse/transform work lands on a sound, zero-cost foundation. No parsing behavior changes — only the model, capabilities, config plumbing, and doc comments.

- **`LegacyVueVersion` now models v0.10 distinctly from the 0.11-era line.** The old `V0` was documented as "the 0.11-era line", which cannot represent the mandated v0.10 support: Vue 0.11.0 was a ground-up rewrite whose `changes.md` renamed computed `$get`/`$set` to plain `get`/`set` and reworked instantiation/scope semantics. `V0` is replaced by `V0_10` (computed `$get`/`$set`, `v-repeat`, `v-with`, `v-component`, clause-style `v-on="click: onClick"`) and `V0_11` (same clause-style directive surface, post-rewrite semantics). Each variant carries doc comments listing its syntax surfaces, sourced from Vue 0.11 `changes.md`, the Vue 1.0 "Migrating from 0.12" guide (`v-repeat` -> `v-for`, colon-argument directive syntax with `@`/`:` shorthands), and the Vue 2 migration guide (call-style filter arguments, attribute-interpolation removal, scoped-slot sugar).
- **Dialects resolve once per file into `LegacyDialectCapabilities`.** A small `Copy` struct of bools plus a `DirectiveArgStyle` enum (`supports_filters`, `space_separated_filter_args`, `v_repeat_syntax`, `directive_arg_style`, `v_with_directive`, `v_component_directive`, `computed_dollar_get_set`, `attr_value_interpolation`, `scoped_slot_attrs`), computed by `LegacyVueVersion::capabilities()` / `LegacyDialectCapabilities::for_dialect()` at option-build time. Hot paths read fields; they never re-match the version enum per token or node.
- **Config plumbing:** new `vue.version` key in `vize_carton`, normalized to a `VueDialect` enum (`"3"` default | `"2.7"` | `"2"` | `"1"` | `"0.11"` | `"0.10"`) and exposed as `ConfigFeatureFlags::vue_dialect`. Parsed and validated here; threading into parser/transform options is the next umbrella PR (which also deprecates `legacyVue2`).

## Zero-cost argument

Dialect dispatch happens once per file/document at cold points (config -> `VueDialect` -> `LegacyVueVersion` -> capability set when options are built). After that, every legacy decision is a field read of a `Copy` struct. The default dialect resolves to the all-off `LegacyDialectCapabilities::VUE3` const, so in a `legacy`-enabled build every capability check on Vue 3 sources short-circuits to the same branch today's unconditional Vue 3 code takes — and the default binary is byte-identical because the whole module stays behind `#[cfg(feature = "legacy")]` with zero consumers in default paths (verified: `cargo test`/`cargo check` across the workspace unchanged).

## Config behavior

- `vue.version` accepts the bare version strings (a leading `v` is tolerated, values are trimmed); it is strict otherwise.
- `"0"` / `"v0"` errors as **ambiguous** with guidance to pick `"0.10"` or `"0.11"` — it never silently picks a 0.x line.
- Unknown values error listing the accepted set; unquoted numbers (`version: 2.7`) error asking for the quoted string form (`0.10`/`0.11` are not representable as JSON numbers anyway).
- Errors surface as hard failures for explicit `--config` (via `validate_explicit_config_path`) and as the standard parse warning + full fallback-to-defaults during auto-discovery, matching existing config semantics.
- Vue 2.7 stays distinct from Vue 2 in `VueDialect` (script-side differences) while both map to the shared `LegacyVueVersion::V2` template dialect.

## Test plan

- `cargo test -p vize_armature -p vize_carton` — all green (164 + 101/11 + doctests), proving no behavior change for the default dialect.
- `cargo test -p vize_armature --features legacy` — 171 passed, including new tests: config-string -> dialect -> version -> capabilities round-trip, per-line capability assertions (v0.10 vs 0.11 `$get`/`$set` split, 0.x clause style vs v1 colon style, v1 vs v2 filter-arg/attr-interpolation/scoped-slot differences, v2 == v2.7, Vue 3 all-off default distinct from every legacy line).
- `cargo test -p vize_atelier_core -p vize_atelier_dom` — green (they do not consume the enum).
- `cargo check -p vize_canon --features legacy`, `cargo check -p vize_maestro --features legacy`, `cargo check --workspace` — green.
- `cargo clippy` on the changed crates: zero warnings in changed code; `cargo fmt` clean.

Part of #1392.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1408"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783754788&installation_id=136613492&pr_number=1408&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1408&signature=f596b39e6d69c6959802a9d66bb81f30fcaa4cd78268ca257c7b3f7094ee5415"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->