### PR TITLE
fix(croquis): extract type definitions via OXC AST instead of text scanning

### DIFF
--- a/crates/vize_croquis/src/import_resolver.rs
+++ b/crates/vize_croquis/src/import_resolver.rs
@@ -14,8 +14,14 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use dashmap::DashMap;
+use oxc_allocator::Allocator;
+use oxc_ast::ast::{Declaration, Statement, TSInterfaceDeclaration, TSTypeAliasDeclaration};
+use oxc_parser::Parser;
+use oxc_span::{GetSpan, SourceType};
 use serde::Deserialize;
-use vize_carton::{CompactString, FxHashMap, String, ToCompactString, cstr, profiler::CacheStats};
+use vize_carton::{
+    CompactString, FxHashMap, String, ToCompactString, profile, profiler::CacheStats,
+};
 
 /// Resolved module information
 #[derive(Debug, Clone)]
@@ -377,42 +383,65 @@ impl ImportResolver {
 
     /// Extract type definitions from a module's content
     ///
-    /// Extracts interface and type alias definitions that can be used
-    /// for type resolution in defineProps/defineEmits.
+    /// Parses the module with OXC and collects exported `interface` and
+    /// `type` alias declarations — including locally declared types that are
+    /// surfaced through `export { ... }` / `export type { ... }` specifiers —
+    /// so they can be used for type resolution in defineProps/defineEmits.
+    ///
+    /// The parse is lazy: it only runs when a caller actually requests
+    /// cross-file type definitions for a resolved module, so sources without
+    /// type imports never pay for it. The resolved module's content is not
+    /// parsed anywhere else, so this is its first and only parse.
     pub fn extract_type_definitions(
         &self,
         content: &str,
     ) -> FxHashMap<CompactString, CompactString> {
         let mut definitions = FxHashMap::default();
 
-        // Simple regex-based extraction for common patterns
-        // TODO: Use OXC for more accurate parsing
-
-        // Extract interface definitions
-        let interface_re = regex::Regex::new(
-            r"(?s)export\s+interface\s+(\w+)(?:<[^>]*>)?\s*\{([^}]*(?:\{[^}]*\}[^}]*)*)\}",
+        let allocator = Allocator::default();
+        let source_type = SourceType::from_path("module.ts").unwrap_or_default();
+        let ret = profile!(
+            "croquis.import_resolver.oxc_parse",
+            Parser::new(&allocator, content, source_type).parse()
         );
-        if let Ok(re) = interface_re {
-            for cap in re.captures_iter(content) {
-                if let (Some(name), Some(body)) = (cap.get(1), cap.get(2)) {
-                    definitions.insert(
-                        CompactString::new(name.as_str()),
-                        cstr!("{{ {} }}", body.as_str().trim()),
-                    );
+        if ret.panicked {
+            return definitions;
+        }
+
+        // Locally declared (non-exported) types, kept so export specifiers
+        // (`export { Name }`, possibly renamed) can surface them afterwards.
+        let mut local_definitions: FxHashMap<CompactString, CompactString> = FxHashMap::default();
+        // `(exported name, local name)` pairs from export specifiers.
+        let mut export_specifiers: Vec<(CompactString, CompactString)> = Vec::new();
+
+        for stmt in &ret.program.body {
+            match stmt {
+                Statement::ExportNamedDeclaration(export) => {
+                    if let Some(decl) = &export.declaration {
+                        record_type_declaration(decl, content, &mut definitions);
+                    }
+                    for spec in &export.specifiers {
+                        export_specifiers.push((
+                            CompactString::new(spec.exported.name().as_str()),
+                            CompactString::new(spec.local.name().as_str()),
+                        ));
+                    }
                 }
+                Statement::TSTypeAliasDeclaration(alias) => {
+                    record_type_alias(alias, content, &mut local_definitions);
+                }
+                Statement::TSInterfaceDeclaration(interface) => {
+                    record_interface(interface, content, &mut local_definitions);
+                }
+                _ => {}
             }
         }
 
-        // Extract type alias definitions
-        let type_re = regex::Regex::new(r"export\s+type\s+(\w+)(?:<[^>]*>)?\s*=\s*([^;]+);");
-        if let Ok(re) = type_re {
-            for cap in re.captures_iter(content) {
-                if let (Some(name), Some(body)) = (cap.get(1), cap.get(2)) {
-                    definitions.insert(
-                        CompactString::new(name.as_str()),
-                        CompactString::new(body.as_str().trim()),
-                    );
-                }
+        // Export specifiers may appear before or after the declaration they
+        // reference, so resolve them once the whole module body is walked.
+        for (exported, local) in export_specifiers {
+            if let Some(body) = local_definitions.get(&local) {
+                definitions.insert(exported, body.clone());
             }
         }
 
@@ -455,6 +484,47 @@ impl Default for ImportResolver {
     fn default() -> Self {
         Self::new(std::env::current_dir().unwrap_or_default())
     }
+}
+
+/// Record an exported `interface` / `type` alias declaration.
+fn record_type_declaration(
+    decl: &Declaration<'_>,
+    content: &str,
+    definitions: &mut FxHashMap<CompactString, CompactString>,
+) {
+    match decl {
+        Declaration::TSTypeAliasDeclaration(alias) => {
+            record_type_alias(alias, content, definitions);
+        }
+        Declaration::TSInterfaceDeclaration(interface) => {
+            record_interface(interface, content, definitions);
+        }
+        _ => {}
+    }
+}
+
+/// Record a `type Name = ...` alias as `Name -> RHS source text`.
+fn record_type_alias(
+    alias: &TSTypeAliasDeclaration<'_>,
+    content: &str,
+    definitions: &mut FxHashMap<CompactString, CompactString>,
+) {
+    definitions.insert(
+        CompactString::new(alias.id.name.as_str()),
+        CompactString::new(alias.type_annotation.span().source_text(content).trim()),
+    );
+}
+
+/// Record an `interface Name { ... }` declaration as `Name -> { body } source text`.
+fn record_interface(
+    interface: &TSInterfaceDeclaration<'_>,
+    content: &str,
+    definitions: &mut FxHashMap<CompactString, CompactString>,
+) {
+    definitions.insert(
+        CompactString::new(interface.id.name.as_str()),
+        CompactString::new(interface.body.span.source_text(content)),
+    );
 }
 
 #[cfg(test)]
@@ -530,6 +600,125 @@ mod tests {
         let defs = resolver.extract_type_definitions(content);
         assert!(defs.contains_key("Props"));
         assert!(defs.contains_key("Emits"));
+    }
+
+    #[test]
+    fn test_extract_ignores_strings_and_comments() {
+        let resolver = ImportResolver::default();
+        let content = r#"
+            // export interface FakeComment { a: string }
+            /* export interface FakeBlock { b: number }
+               export type FakeBlockAlias = string; */
+            const snippet = "export interface FakeString { c: boolean }";
+            export const tpl = `export type FakeTemplate = number;`;
+            export interface Real { value: number }
+        "#;
+
+        let defs = resolver.extract_type_definitions(content);
+        assert!(defs.contains_key("Real"));
+        assert!(!defs.contains_key("FakeComment"));
+        assert!(!defs.contains_key("FakeBlock"));
+        assert!(!defs.contains_key("FakeBlockAlias"));
+        assert!(!defs.contains_key("FakeString"));
+        assert!(!defs.contains_key("FakeTemplate"));
+    }
+
+    #[test]
+    fn test_extract_generic_interface() {
+        let resolver = ImportResolver::default();
+        // Nested generics (`Record<string, unknown>`) defeat naive `<[^>]*>`
+        // scanning because the first `>` is not the end of the param list.
+        let content = r#"
+            export interface Box<T extends Record<string, unknown>> {
+                value: T;
+                items: Array<T>;
+            }
+        "#;
+
+        let defs = resolver.extract_type_definitions(content);
+        let body = defs.get("Box").expect("generic interface extracted");
+        assert!(body.contains("value: T"));
+        assert!(body.contains("items: Array<T>"));
+    }
+
+    #[test]
+    fn test_extract_multi_line_nested_interface() {
+        let resolver = ImportResolver::default();
+        // Two levels of brace nesting break one-level-deep text scanning.
+        let content = r#"
+            export interface Outer {
+                nested: {
+                    deep: { a: string };
+                };
+                sibling: number;
+            }
+        "#;
+
+        let defs = resolver.extract_type_definitions(content);
+        let body = defs.get("Outer").expect("nested interface extracted");
+        assert!(body.contains("deep: { a: string }"));
+        assert!(body.contains("sibling: number"));
+    }
+
+    #[test]
+    fn test_extract_union_and_intersection_aliases() {
+        let resolver = ImportResolver::default();
+        let content = r#"
+            export type Status =
+                | 'active'
+                | 'inactive'
+                | 'pending';
+            export type Mixed = { base: string } & { extra: boolean };
+            export type Handlers = { (e: 'click'): void; (e: 'change', v: string): void };
+        "#;
+
+        let defs = resolver.extract_type_definitions(content);
+
+        let status = defs.get("Status").expect("union alias extracted");
+        assert!(status.contains("'active'"));
+        assert!(status.contains("'pending'"));
+
+        let mixed = defs.get("Mixed").expect("intersection alias extracted");
+        assert!(mixed.contains("{ base: string }"));
+        assert!(mixed.contains('&'));
+        assert!(mixed.contains("{ extra: boolean }"));
+
+        // Semicolon-terminated scanning truncated the body at the first `;`
+        // inside the object type; the AST keeps both call signatures.
+        let handlers = defs.get("Handlers").expect("object alias extracted");
+        assert!(handlers.contains("(e: 'click'): void"));
+        assert!(handlers.contains("(e: 'change', v: string): void"));
+    }
+
+    #[test]
+    fn test_extract_reexported_local_types() {
+        let resolver = ImportResolver::default();
+        let content = r#"
+            export type { Emits as PublicEmits };
+            interface Props { msg: string }
+            type Emits = (e: 'click') => void;
+            export { Props };
+        "#;
+
+        let defs = resolver.extract_type_definitions(content);
+        assert!(defs.contains_key("Props"));
+        assert!(defs.contains_key("PublicEmits"));
+        assert!(!defs.contains_key("Emits"));
+    }
+
+    #[test]
+    fn test_extract_skips_non_exported_types() {
+        let resolver = ImportResolver::default();
+        let content = r#"
+            interface Hidden { a: string }
+            type AlsoHidden = number;
+            export interface Visible { b: string }
+        "#;
+
+        let defs = resolver.extract_type_definitions(content);
+        assert!(defs.contains_key("Visible"));
+        assert!(!defs.contains_key("Hidden"));
+        assert!(!defs.contains_key("AlsoHidden"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Replaces the regex/text-scanning `extract_type_definitions` in `vize_croquis::import_resolver` (the explicit `TODO: Use OXC` flagged in the #1394 audit) with an OXC AST walk over the module program. Names map to exact source-span text: interface bodies (`{ ... }` via the body span) and type-alias right-hand sides (via the type-annotation span). Locally declared types surfaced through `export { Name }` / `export type { Name as Alias }` specifiers are now extracted too, regardless of declaration/specifier order — the regex could never see those at all.

## Eliminated failure modes (each locked by a regression test)

- `export interface` inside line/block comments, string literals, or template literals was extracted as a real type — now ignored (`test_extract_ignores_strings_and_comments`)
- Nested generic params (`Box<T extends Record<string, unknown>>`) defeated the `<[^>]*>` scan, dropping the interface entirely — now extracted (`test_extract_generic_interface`)
- Two-plus levels of brace nesting truncated interface bodies (the regex handled exactly one level) — now exact (`test_extract_multi_line_nested_interface`)
- Aliases were captured as "everything up to the first `;`", so `type Handlers = { (e: 'click'): void; (e: 'change', v: string): void }` lost its second signature, and multi-line unions/intersections relied on a trailing `;` — now span-exact (`test_extract_union_and_intersection_aliases`)
- Re-exported local types (`interface Props {...}; export { Props }`) were invisible — now extracted, including renames, while non-exported types stay excluded (`test_extract_reexported_local_types`, `test_extract_skips_non_exported_types`)

## Zero-cost argument

Nothing new runs on default paths. `extract_type_definitions` is only invoked when a caller resolves a cross-file type import and explicitly asks for that module's definitions; plain-JS sources (and any source without type imports) never reach it, consistent with #1397. The content parsed here is the *imported* module's — read lazily by the resolver and parsed nowhere else in croquis — so this is that source's first and only parse, not a duplicate. (The old code additionally compiled two regexes on every call; that's gone.)

## What remains for follow-ups (tracked in #1394)

- `resolve_uncached` still rejects bare/node_modules specifiers (`import_resolver.rs` "Node module resolution not supported") — routing through the canon virtual-project logic or `oxc_resolver` is a separate PR (new dependency / cross-crate plumbing)
- PR4 of the checklist: registering local interfaces into croquis `TypeResolver` and deleting the `vize_canon` `props.rs` text scanner is untouched here
- `virtual_ts/generator/script.rs` still has one unrelated regex (import rewriting), out of scope for this slice

## Test plan

- `cargo test -p vize_croquis -p vize_croquis_cf` — 175 + 120 (+ doc/integration) passed, 0 failed
- Downstream proof: `cargo test -p vize_atelier_sfc -p vize_canon` — 518 + 321 passed, 0 failed
- `cargo clippy -p vize_croquis --all-targets` — no diagnostics in changed code (two pre-existing warnings in `drawer/template/tests.rs` untouched); `cargo fmt --check` clean

Part of #1394.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1409"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783754909&installation_id=136613492&pr_number=1409&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1409&signature=1822abf76dada355963eca6d8a84df3e40377498825c6c77fedad16c606a2a22"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->