### PR TITLE
fix(check/nuxt): parse nuxt.config modules with OXC instead of substring matching

### DIFF
--- a/crates/vize/src/commands/check/nuxt/fallback.rs
+++ b/crates/vize/src/commands/check/nuxt/fallback.rs
@@ -1,9 +1,22 @@
 //! Built-in fallback stubs and `nuxt.config` module-driven fallbacks.
+//!
+//! Module detection parses the `modules` array out of the default-exported
+//! config object with OXC instead of substring-matching the raw source, so
+//! commented-out entries and module names inside unrelated strings no longer
+//! count as installed modules.
 
 use std::path::Path;
 
+use oxc_allocator::Allocator;
+use oxc_ast::ast::{ArrayExpressionElement, Expression, ObjectExpression, Statement};
+use oxc_parser::Parser;
+use oxc_span::SourceType;
 use vize_carton::{FxHashSet, String, ToCompactString};
 
+use super::parsing::{
+    extract_call_expression_from_export, extract_expression, extract_object_expression,
+    find_object_property,
+};
 use super::stubs::{
     declared_name, push_generic_function_stub, push_named_overload_stubs, push_stub,
     tracked_read_to_string,
@@ -74,8 +87,9 @@ pub(super) fn collect_module_fallback_stubs(
     if config_source.is_empty() {
         return;
     }
+    let modules = parse_nuxt_config_modules(&config_source);
 
-    if config_source.contains("@nuxtjs/i18n") || config_source.contains("@nuxt/i18n") {
+    if modules.might_include(&["@nuxtjs/i18n", "@nuxt/i18n"]) {
         push_stub(
             stubs,
             seen_names,
@@ -87,7 +101,7 @@ pub(super) fn collect_module_fallback_stubs(
         stubs.push("declare module \"@nuxtjs/i18n\" { export type Directions = any; }".into());
     }
 
-    if config_source.contains("@vueuse/nuxt") {
+    if modules.might_include(&["@vueuse/nuxt"]) {
         for name in ["useClipboard", "usePreferredDark", "useScrollLock"] {
             push_generic_function_stub(stubs, seen_names, name);
         }
@@ -107,7 +121,7 @@ pub(super) fn collect_module_fallback_stubs(
         );
     }
 
-    if config_source.contains("@nuxtjs/color-mode") {
+    if modules.might_include(&["@nuxtjs/color-mode"]) {
         push_stub(
             stubs,
             seen_names,
@@ -116,9 +130,136 @@ pub(super) fn collect_module_fallback_stubs(
         );
     }
 
-    if config_source.contains("nuxt-og-image") {
+    if modules.might_include(&["nuxt-og-image"]) {
         push_generic_function_stub(stubs, seen_names, "defineOgImageComponent");
     }
+}
+
+/// Statically-resolved view of the `modules` array in `nuxt.config`.
+#[derive(Debug, Default)]
+pub(super) struct NuxtConfigModules {
+    /// Module names found as static entries: string literals,
+    /// no-substitution template literals, and the first element of
+    /// `['module-name', { ...options }]` tuples.
+    names: FxHashSet<String>,
+    /// Set when the module list cannot be fully resolved statically: spread
+    /// or computed entries, a non-literal tuple head, a non-array `modules`
+    /// value, or a default export we cannot see through (identifier
+    /// reference, unknown wrapper call, CommonJS config).
+    has_unresolved_entries: bool,
+}
+
+impl NuxtConfigModules {
+    fn unresolved() -> Self {
+        Self {
+            names: FxHashSet::default(),
+            has_unresolved_entries: true,
+        }
+    }
+
+    fn insert(&mut self, name: &str) {
+        self.names.insert(name.to_compact_string());
+    }
+
+    /// Conservative membership test: an unresolved entry may name any module,
+    /// so it counts as a potential match for every candidate. Missing a
+    /// module here would surface false "undefined name" diagnostics, while
+    /// over-matching only injects a few extra `any` stubs on the (already
+    /// `.nuxt`-less) fallback path.
+    pub(super) fn might_include(&self, candidates: &[&str]) -> bool {
+        self.has_unresolved_entries
+            || candidates
+                .iter()
+                .any(|candidate| self.names.contains(*candidate))
+    }
+}
+
+/// Parses `nuxt.config` source and extracts the `modules` array from the
+/// default-exported config object, handling both
+/// `export default defineNuxtConfig({ ... })` and `export default { ... }`.
+pub(super) fn parse_nuxt_config_modules(config_source: &str) -> NuxtConfigModules {
+    let allocator = Allocator::default();
+    let source_type = SourceType::default()
+        .with_module(true)
+        .with_typescript(true);
+    let ret = Parser::new(&allocator, config_source, source_type).parse();
+    if ret.panicked {
+        return NuxtConfigModules::unresolved();
+    }
+
+    let Some(config_object) = default_export_config_object(&ret.program.body) else {
+        return NuxtConfigModules::unresolved();
+    };
+
+    let Some(modules_value) = find_object_property(config_object, "modules") else {
+        // A statically-visible config without a `modules` key registers no
+        // modules, so nothing needs stubbing.
+        return NuxtConfigModules::default();
+    };
+
+    let Some(Expression::ArrayExpression(modules)) = extract_expression(modules_value) else {
+        return NuxtConfigModules::unresolved();
+    };
+
+    let mut resolved = NuxtConfigModules::default();
+    for element in &modules.elements {
+        match element {
+            ArrayExpressionElement::Elision(_) => {}
+            ArrayExpressionElement::SpreadElement(_) => resolved.has_unresolved_entries = true,
+            _ => match element.as_expression().and_then(extract_expression) {
+                Some(Expression::StringLiteral(literal)) => resolved.insert(&literal.value),
+                Some(Expression::TemplateLiteral(template)) => match template.single_quasi() {
+                    Some(name) => resolved.insert(&name),
+                    None => resolved.has_unresolved_entries = true,
+                },
+                // `['module-name', { ...options }]` tuple form.
+                Some(Expression::ArrayExpression(tuple)) => {
+                    match tuple
+                        .elements
+                        .first()
+                        .and_then(ArrayExpressionElement::as_expression)
+                        .and_then(extract_expression)
+                    {
+                        Some(Expression::StringLiteral(literal)) => resolved.insert(&literal.value),
+                        _ => resolved.has_unresolved_entries = true,
+                    }
+                }
+                _ => resolved.has_unresolved_entries = true,
+            },
+        }
+    }
+    resolved
+}
+
+/// Finds the config object behind the default export, looking through the
+/// `defineNuxtConfig(...)` wrapper as well as parenthesized/`as`/`satisfies`
+/// wrappers on either form. Returns `None` for anything else (identifier
+/// references, unknown wrapper calls, missing default export), which callers
+/// treat as an unresolved module list.
+fn default_export_config_object<'a>(
+    statements: &'a [Statement<'a>],
+) -> Option<&'a ObjectExpression<'a>> {
+    let export = statements.iter().find_map(|statement| match statement {
+        Statement::ExportDefaultDeclaration(export) => Some(export),
+        _ => None,
+    })?;
+
+    if let Some(call) = extract_call_expression_from_export(&export.declaration) {
+        if !matches!(&call.callee, Expression::Identifier(callee) if callee.name == "defineNuxtConfig")
+        {
+            return None;
+        }
+        return call
+            .arguments
+            .first()
+            .and_then(|argument| argument.as_expression())
+            .and_then(extract_object_expression);
+    }
+
+    export
+        .declaration
+        .as_expression()
+        .and_then(extract_object_expression)
 }
 
 pub(super) fn nuxt_config_source(cwd: &Path) -> String {

--- a/crates/vize/src/commands/check/nuxt/tests.rs
+++ b/crates/vize/src/commands/check/nuxt/tests.rs
@@ -9,7 +9,7 @@ use vize_carton::cstr;
 
 use super::super::dts::rewrite_relative_specifier;
 use super::detect_nuxt_auto_imports;
-use super::fallback::fallback_stub_strings;
+use super::fallback::{fallback_stub_strings, parse_nuxt_config_modules};
 use super::parsing::{parse_export_names, parse_module_specifier};
 use super::plugins::extract_plugin_provide_keys_from_source;
 use super::stubs::declared_name;
@@ -510,6 +510,123 @@ export default defineNuxtConfig({
         "expected i18n template globals, got: {:#?}",
         options.template_globals
     );
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}
+
+#[test]
+fn nuxt_config_modules_ignores_comments_and_unrelated_strings() {
+    let modules = parse_nuxt_config_modules(
+        r#"
+export default defineNuxtConfig({
+  // modules: ['@nuxtjs/i18n'],
+  /* '@vueuse/nuxt' would be nice */
+  modules: [
+    // '@nuxtjs/color-mode',
+    '@nuxtjs/i18n',
+  ],
+  runtimeConfig: { public: { hint: "enable nuxt-og-image later" } },
+})
+"#,
+    );
+
+    assert!(modules.might_include(&["@nuxtjs/i18n", "@nuxt/i18n"]));
+    assert!(!modules.might_include(&["@vueuse/nuxt"]));
+    assert!(!modules.might_include(&["@nuxtjs/color-mode"]));
+    assert!(!modules.might_include(&["nuxt-og-image"]));
+}
+
+#[test]
+fn nuxt_config_modules_parses_tuple_entries_and_plain_object_export() {
+    let modules = parse_nuxt_config_modules(
+        r#"
+export default {
+  modules: [
+    ['@nuxtjs/i18n', { locales: ['en'] }],
+    'nuxt-og-image',
+  ],
+}
+"#,
+    );
+
+    assert!(modules.might_include(&["@nuxtjs/i18n", "@nuxt/i18n"]));
+    assert!(modules.might_include(&["nuxt-og-image"]));
+    assert!(!modules.might_include(&["@vueuse/nuxt"]));
+
+    let empty = parse_nuxt_config_modules("export default defineNuxtConfig({})");
+    assert!(!empty.might_include(&["@nuxtjs/i18n", "@nuxt/i18n"]));
+}
+
+#[test]
+fn nuxt_config_modules_falls_back_conservatively_for_dynamic_entries() {
+    // A spread may contribute any module name, so unmatched candidates stay
+    // conservatively "maybe present" while static entries still resolve.
+    let spread = parse_nuxt_config_modules(
+        r#"
+const extras = ['@vueuse/nuxt']
+export default defineNuxtConfig({
+  modules: ['@nuxtjs/color-mode', ...extras],
+})
+"#,
+    );
+    assert!(spread.might_include(&["@nuxtjs/color-mode"]));
+    assert!(spread.might_include(&["@vueuse/nuxt"]));
+    assert!(spread.might_include(&["@nuxtjs/i18n", "@nuxt/i18n"]));
+
+    // Computed entries and opaque default exports are equally unresolved.
+    let computed =
+        parse_nuxt_config_modules("export default { modules: [resolveModule('nuxt-og-image')] }");
+    assert!(computed.might_include(&["nuxt-og-image"]));
+    assert!(computed.might_include(&["@vueuse/nuxt"]));
+
+    let opaque = parse_nuxt_config_modules("export default buildConfig()");
+    assert!(opaque.might_include(&["nuxt-og-image"]));
+}
+
+#[test]
+fn skips_module_fallbacks_for_commented_out_modules() {
+    let project_root = unique_case_dir("nuxt-commented-modules");
+    let _ = std::fs::remove_dir_all(&project_root);
+    std::fs::create_dir_all(&project_root).unwrap();
+    std::fs::write(
+        project_root.join("nuxt.config.ts"),
+        r#"
+export default defineNuxtConfig({
+  // modules: ['@nuxtjs/i18n', '@vueuse/nuxt'],
+  modules: [
+    // '@nuxtjs/color-mode',
+    'nuxt-og-image',
+  ],
+})
+"#,
+    )
+    .unwrap();
+
+    let mut options = VirtualTsOptions::default();
+    let _ = detect_nuxt_auto_imports(&mut options, &project_root);
+
+    assert!(
+        options
+            .auto_import_stubs
+            .iter()
+            .any(|stub| stub.starts_with("declare function defineOgImageComponent<T = any")),
+        "expected nuxt-og-image fallback stub, got: {:#?}",
+        options.auto_import_stubs
+    );
+    for absent in [
+        "declare function useI18n():",
+        "declare function useColorMode():",
+        "declare function useClipboard<T = any",
+    ] {
+        assert!(
+            !options
+                .auto_import_stubs
+                .iter()
+                .any(|stub| stub.starts_with(absent)),
+            "commented-out module must not inject {absent:?}, got: {:#?}",
+            options.auto_import_stubs
+        );
+    }
 
     let _ = std::fs::remove_dir_all(&project_root);
 }


### PR DESCRIPTION
## Summary
- Replace the raw `config_source.contains(...)` checks in `collect_module_fallback_stubs` (crates/vize/src/commands/check/nuxt/fallback.rs) with a real OXC parse of the `modules` array extracted from the default-exported config object.
- Handles both `export default defineNuxtConfig({ ... })` and plain `export default { ... }` (including parenthesized/`as`/`satisfies` wrappers via the shared `parsing.rs` helpers), string-literal entries, no-substitution template-literal entries, and tuple entries `['module-name', { ...options }]`.
- No `contains()` matching on nuxt.config source remains; `nuxt_config_source` is now only read to feed the parser.

## False-positive/negative classes eliminated
- Commented-out modules (`// '@nuxtjs/i18n',`) no longer count as installed — previously this injected i18n/any stubs and weakened checking.
- Module names appearing in unrelated strings (e.g. `runtimeConfig` values, hints, docs text) no longer count as installed.
- Tuple-form registrations `['@nuxtjs/i18n', { ... }]` are now correctly detected (they already matched by substring before, but now survive once substring matching is gone).

## Conservative-fallback behavior
Entries that cannot be resolved statically — spreads (`...extras`), identifier/call/conditional entries, a non-literal tuple head, a non-array `modules` value, or a default export we cannot see through (identifier reference, unknown wrapper call, CommonJS config, parser panic) — mark the module list as *unresolved*. An unresolved list conservatively matches every candidate module: missing a module would surface false "undefined name" diagnostics, while over-matching only injects a few extra `any` stubs on the already `.nuxt`-less fallback path. Statically resolved entries still contribute exact names alongside the unresolved flag.

## Test plan
- New unit tests on `parse_nuxt_config_modules`: commented-out/string-embedded names are NOT detected; tuple entries and plain-object default export ARE detected; spread/computed/opaque configs fall back conservatively.
- New integration test `skips_module_fallbacks_for_commented_out_modules` through `detect_nuxt_auto_imports`.
- Existing `detects_module_fallbacks_from_nuxt_config` covers the `defineNuxtConfig` wrapper end to end (now exercising the parser).
- `cargo test -p vize`: 171 passed, 0 failed. `cargo clippy -p vize --all-targets`: no warnings in changed files. `cargo fmt --check` clean.

Part of #1390.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1410"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783754936&installation_id=136613492&pr_number=1410&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1410&signature=d7252c5521ea99cf4a37d7ae496e4b7d811cf5d8e7886aeb553874edb3551cc8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->