### PR TITLE
ci(bench): gate formatter performance in the PR benchmark

### DIFF
--- a/bench/compare-pr.mjs
+++ b/bench/compare-pr.mjs
@@ -202,7 +202,7 @@ export function createBenchmarkBudget(results) {
   };
 }
 
-function makeTasks(inputDir, taskFilter) {
+export function makeTasks(inputDir, taskFilter) {
   const tsconfig = join(inputDir, "tsconfig.json");
   const pattern = ".";
   const allTasks = [
@@ -219,8 +219,28 @@ function makeTasks(inputDir, taskFilter) {
       allowNonZeroExit: true,
     },
     {
+      id: "fmt",
+      label: "Format",
+      // `*.vue` instead of `.`: fmt expands `.` into a gitignore-aware walk
+      // and bench/__in__ is gitignored, so that walk finds zero files; the
+      // plain glob matches the corpus directly (same invocation as
+      // bench/fmt.ts and compare-tools.mjs). `--check` formats in memory and
+      // never writes, so the corpus stays byte-identical between the
+      // alternating base/head runs. The generated corpus is intentionally
+      // unformatted, so the non-zero "would reformat" exit is expected.
+      // fmt has no --threads flag; the RAYON_NUM_THREADS=1 set by runCommand
+      // pins it to a single thread like the other lanes.
+      args: ["fmt", "*.vue", "--check"],
+      allowNonZeroExit: true,
+    },
+    {
       id: "check",
       label: "Type check",
+      // --servers 1 pins the lane to a single Corsa server so it isolates
+      // single-program performance and stays deterministic on shared CI
+      // runners. The trade-off is that multi-server sharding regressions are
+      // not covered here; a dedicated multi-server lane is tracked in #1386
+      // (PR3) and needs its own noise validation before it can gate PRs.
       args: ["check", pattern, "--quiet", "--servers", "1", "--tsconfig", tsconfig],
       allowNonZeroExit: true,
       enabled: existsSync(tsconfig),

--- a/tests/tooling/benchmark-budget.test.ts
+++ b/tests/tooling/benchmark-budget.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
-import { createBenchmarkBudget, renderMarkdown } from "../../bench/compare-pr.mjs";
+import { createBenchmarkBudget, makeTasks, renderMarkdown } from "../../bench/compare-pr.mjs";
 import { enforceBenchmarkBudget } from "../../bench/enforce-pr-budget.mjs";
 
 const stableResult = {
@@ -63,6 +63,30 @@ test("benchmark markdown reports the active regression budget", () => {
   assert.match(markdown, /Budget: failed \(1 regression\)\./);
   assert.match(markdown, /Regression budget failures:/);
   assert.match(markdown, /Type check: 1\.150x \(\+15\.00%\)/);
+});
+
+test("benchmark tasks gate the formatter without mutating the corpus", () => {
+  const tasks = makeTasks("/nonexistent-input-dir", "");
+  const ids = tasks.map((task) => task.id);
+
+  assert.ok(ids.includes("fmt"), "default task set must include the fmt lane");
+
+  const fmt = tasks.find((task) => task.id === "fmt");
+  assert.ok(fmt);
+  assert.ok(fmt.args.includes("--check"), "fmt lane must run in non-destructive check mode");
+  assert.ok(!fmt.args.includes("--write"), "fmt lane must never rewrite the shared corpus");
+  assert.equal(
+    fmt.allowNonZeroExit,
+    true,
+    "unformatted corpus exits non-zero in check mode; the lane only measures time",
+  );
+
+  // Filtering still works for the new lane.
+  const onlyFmt = makeTasks("/nonexistent-input-dir", "fmt");
+  assert.deepEqual(
+    onlyFmt.map((task) => task.id),
+    ["fmt"],
+  );
 });
 
 test("benchmark budget allows skipped benchmark runs", () => {


### PR DESCRIPTION
## Summary

The PR benchmark gate covers compile, lint, and check, but has no formatter lane — glyph perf regressions are invisible to CI (#1386, PR3 coverage gap). This adds a `fmt` task to `makeTasks` in `bench/compare-pr.mjs` so formatter regressions fail `pr-benchmark-budget` like every other lane. `enforce-pr-budget.mjs` derives the budget from `data.results`, so the new lane is enforced automatically with no workflow changes.

## Lane definition (and why non-destructive)

```
vize fmt *.vue --check
```

- `--check` formats in memory and only reports differences — it never writes, so the corpus stays byte-identical between the alternating base/head runs. A `--write` lane would hand every run after the first an already-formatted (cheaper) input and skew the comparison.
- The generated corpus is intentionally unformatted, so check mode exits non-zero ("would reformat"); the lane sets `allowNonZeroExit: true` like the lint/check lanes and only measures wall time.
- `*.vue` instead of the `.` pattern used by other lanes: `fmt` expands `.` into a gitignore-aware walk, and `bench/__in__/` is gitignored — that walk finds zero files in CI. The plain glob takes the non-gitignore path and matches the corpus directly, same invocation shape as `bench/fmt.ts` and `bench/compare-tools.mjs`.
- `fmt` has no `--threads` flag; the `RAYON_NUM_THREADS=1` that `runCommand` already exports pins it to a single thread, matching the other lanes (and matching how `bench/fmt.ts` runs its 1T variant).

## The `--servers 1` decision

Kept the check lane pinned to `--servers 1`, now with a comment documenting why: the pin isolates single-program performance and keeps the lane deterministic on shared CI runners. Issue #1386 (PR3) also asks for a multi-server check lane to cover sharding regressions; I deliberately deferred that to a dedicated follow-up rather than bundling it here, because a multi-process lane that can hard-fail PRs needs its own noise validation on the Blacksmith runners first (multiple concurrent Corsa servers contend for cores, and a flaky gate lane is worse than a missing one), and it roughly doubles the cost of the slowest lane, which interacts with the gate wall-time budget in the issue's acceptance criteria. That sub-item of PR3 remains open in #1386.

## Local validation

ci-opt binary (same build flags as `benchmark.yml`), `node bench/generate.mjs 100`, then `compare-pr.mjs` with the **same binary as base and head** (`--runs 10 --warmups 2`, mirroring CI):

```
compile  base     5.503  head     5.706  rate 1.037  stable
lint     base    11.315  head    11.268  rate 0.996  stable
fmt      base    13.344  head    13.096  rate 0.981  stable
check    base    78.690  head    78.304  rate 0.995  stable
budget: passed
```

- Corpus aggregate md5 identical before and after the run (`05915dd502039ee7bd140981e38faf73`) — the fmt lane does not mutate inputs.
- `Format` row present in both the markdown summary and `benchmark-results.json`.
- Synthetic check: flipping the fmt result to a +12% regression in the JSON makes `enforce-pr-budget.mjs` exit 1 (`Format: 1.120x (+12.00%)`) — the lane is gated with no enforcement changes.

## Test plan

- `node --test tests/tooling/benchmark-budget.test.ts` — 4 pass, including a new test asserting the default task set contains the fmt lane, that it runs in non-destructive `--check` mode (never `--write`), tolerates the expected non-zero exit, and that `--tasks fmt` filtering works.
- Local same-binary gate run above (all lanes stable at ~1.00x, budget passed, corpus unmutated).
- No workflow files touched; `pr-benchmark-budget` picks the lane up via `data.results`.

Part of #1386.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1411"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783755098&installation_id=136613492&pr_number=1411&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1411&signature=86aca1a404db57cb1a20ab0225658a4de31688d3f49663d5c265f4f943498ce1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->