### PR TITLE
perf(vitrine): collect batch results lock-free in input order at the NAPI boundary

### DIFF
--- a/crates/vize_vitrine/src/napi/sfc/batch_results.rs
+++ b/crates/vize_vitrine/src/napi/sfc/batch_results.rs
@@ -1,11 +1,8 @@
 use napi::{Result, Status};
 use napi_derive::napi;
-use rayon::prelude::{IntoParallelRefIterator, ParallelIterator};
+use rayon::prelude::{IntoParallelIterator, ParallelIterator};
 use std::{
-    sync::{
-        Mutex,
-        atomic::{AtomicUsize, Ordering},
-    },
+    sync::atomic::{AtomicUsize, Ordering},
     time::Instant,
 };
 use vize_carton::cstr;
@@ -35,9 +32,8 @@ pub fn compile_sfc_batch_with_results(
             .build_global();
     }
 
-    let results: Mutex<Vec<BatchFileResultNapi>> = Mutex::new(Vec::with_capacity(files.len()));
+    let total_count = files.len();
     let success_count = AtomicUsize::new(0);
-    let failed_count = AtomicUsize::new(0);
     let ssr = opts.ssr.unwrap_or(false);
     let vapor = opts.vapor.unwrap_or(false);
     let is_ts = opts.is_ts.unwrap_or(false);
@@ -47,25 +43,25 @@ pub fn compile_sfc_batch_with_results(
     let standalone = opts.mode.as_deref() == Some("function");
     let start = Instant::now();
 
-    files.par_iter().for_each(|file| {
-        let filename = &file.path;
-        let source = &file.source;
-        let scope_id = vize_atelier_sfc::generate_bundler_scope_id(filename, None, false, None);
-        let filename_cs: vize_carton::CompactString = filename.clone().into();
-        let descriptor = match sfc_parse(
-            source,
-            SfcParseOptions {
-                filename: filename_cs.clone(),
-                ..Default::default()
-            },
-        ) {
-            Ok(descriptor) => descriptor,
-            Err(error) => {
-                failed_count.fetch_add(1, Ordering::Relaxed);
-                push_result(
-                    &results,
-                    BatchFileResultNapi {
-                        path: filename.clone(),
+    // Indexed parallel map keeps results in input order (deterministic) and
+    // collects lock-free, replacing the previous contended `Mutex<Vec>`.
+    let results: Vec<BatchFileResultNapi> = files
+        .into_par_iter()
+        .map(|file| {
+            let scope_id =
+                vize_atelier_sfc::generate_bundler_scope_id(&file.path, None, false, None);
+            let filename_cs: vize_carton::CompactString = file.path.as_str().into();
+            let descriptor = match sfc_parse(
+                &file.source,
+                SfcParseOptions {
+                    filename: filename_cs.clone(),
+                    ..Default::default()
+                },
+            ) {
+                Ok(descriptor) => descriptor,
+                Err(error) => {
+                    return BatchFileResultNapi {
+                        path: file.path,
                         code: String::new(),
                         css: None,
                         scope_id: scope_id.into(),
@@ -78,61 +74,56 @@ pub fn compile_sfc_batch_with_results(
                         styles: vec![],
                         custom_blocks: vec![],
                         macro_artifacts: vec![],
-                    },
-                );
-                return;
-            }
-        };
+                    };
+                }
+            };
 
-        let template_hash: Option<String> = descriptor.template_hash().map(Into::into);
-        let style_hash: Option<String> = descriptor.style_hash().map(Into::into);
-        let script_hash: Option<String> = descriptor.script_hash().map(Into::into);
-        let styles = style_blocks_to_napi(&descriptor.styles);
-        let custom_blocks = custom_blocks_to_napi(&descriptor.custom_blocks);
-        let has_scoped = descriptor.styles.iter().any(|s| s.scoped);
-        let template_compiler_options = Some(vize_atelier_dom::DomCompilerOptions {
-            scope_id: has_scoped.then(|| cstr!("data-v-{scope_id}")),
-            ..Default::default()
-        });
-        let compile_opts = SfcCompileOptions {
-            parse: SfcParseOptions {
-                filename: filename_cs.clone(),
+            let template_hash: Option<String> = descriptor.template_hash().map(Into::into);
+            let style_hash: Option<String> = descriptor.style_hash().map(Into::into);
+            let script_hash: Option<String> = descriptor.script_hash().map(Into::into);
+            let styles = style_blocks_to_napi(&descriptor.styles);
+            let custom_blocks = custom_blocks_to_napi(&descriptor.custom_blocks);
+            let has_scoped = descriptor.styles.iter().any(|s| s.scoped);
+            let template_compiler_options = Some(vize_atelier_dom::DomCompilerOptions {
+                scope_id: has_scoped.then(|| cstr!("data-v-{scope_id}")),
                 ..Default::default()
-            },
-            script: ScriptCompileOptions {
-                id: Some(filename_cs.clone()),
-                inline_template: standalone,
-                is_ts,
-                ..Default::default()
-            },
-            template: TemplateCompileOptions {
-                id: Some(filename_cs.clone()),
-                scoped: has_scoped,
-                ssr,
-                is_ts,
-                custom_renderer,
-                compiler_options: template_compiler_options,
-                ..Default::default()
-            },
-            style: StyleCompileOptions {
-                id: filename_cs,
-                scoped: has_scoped,
-                ..Default::default()
-            },
-            vapor,
-            scope_id: Some(scope_id.clone()),
-        };
+            });
+            // `parse.filename` is left empty: compile falls back to `script.id`,
+            // which carries the same value, so no per-file clone is needed.
+            // `template.id` is never read by the template compiler.
+            let compile_opts = SfcCompileOptions {
+                parse: SfcParseOptions::default(),
+                script: ScriptCompileOptions {
+                    id: Some(filename_cs.clone()),
+                    inline_template: standalone,
+                    is_ts,
+                    ..Default::default()
+                },
+                template: TemplateCompileOptions {
+                    scoped: has_scoped,
+                    ssr,
+                    is_ts,
+                    custom_renderer,
+                    compiler_options: template_compiler_options,
+                    ..Default::default()
+                },
+                style: StyleCompileOptions {
+                    id: filename_cs,
+                    scoped: has_scoped,
+                    ..Default::default()
+                },
+                vapor,
+                scope_id: Some(scope_id.clone()),
+            };
 
-        let compile_result =
-            sfc_compile_with_template_syntax(&descriptor, compile_opts, template_syntax);
+            let compile_result =
+                sfc_compile_with_template_syntax(&descriptor, compile_opts, template_syntax);
 
-        match compile_result {
-            Ok(result) => {
-                success_count.fetch_add(1, Ordering::Relaxed);
-                push_result(
-                    &results,
+            match compile_result {
+                Ok(result) => {
+                    success_count.fetch_add(1, Ordering::Relaxed);
                     BatchFileResultNapi {
-                        path: filename.clone(),
+                        path: file.path,
                         code: result.code.into(),
                         css: result.css.map(Into::into),
                         scope_id: scope_id.into(),
@@ -147,56 +138,39 @@ pub fn compile_sfc_batch_with_results(
                             .into_iter()
                             .map(|e| e.message.into())
                             .collect(),
-                        template_hash: template_hash.clone(),
-                        style_hash: style_hash.clone(),
-                        script_hash: script_hash.clone(),
-                        styles,
-                        custom_blocks,
-                        macro_artifacts: macro_artifacts_to_napi(result.macro_artifacts),
-                    },
-                );
-            }
-            Err(error) => {
-                failed_count.fetch_add(1, Ordering::Relaxed);
-                push_result(
-                    &results,
-                    BatchFileResultNapi {
-                        path: filename.clone(),
-                        code: String::new(),
-                        css: None,
-                        scope_id: scope_id.into(),
-                        has_scoped,
-                        errors: vec![error.message.into()],
-                        warnings: vec![],
                         template_hash,
                         style_hash,
                         script_hash,
                         styles,
                         custom_blocks,
-                        macro_artifacts: vec![],
-                    },
-                );
+                        macro_artifacts: macro_artifacts_to_napi(result.macro_artifacts),
+                    }
+                }
+                Err(error) => BatchFileResultNapi {
+                    path: file.path,
+                    code: String::new(),
+                    css: None,
+                    scope_id: scope_id.into(),
+                    has_scoped,
+                    errors: vec![error.message.into()],
+                    warnings: vec![],
+                    template_hash,
+                    style_hash,
+                    script_hash,
+                    styles,
+                    custom_blocks,
+                    macro_artifacts: vec![],
+                },
             }
-        }
-    });
+        })
+        .collect();
 
-    let final_results = match results.into_inner() {
-        Ok(results) => results,
-        Err(poisoned) => poisoned.into_inner(),
-    };
+    let success = success_count.load(Ordering::Relaxed);
 
     Ok(BatchCompileResultWithFilesNapi {
-        results: final_results,
-        success_count: success_count.load(Ordering::Relaxed) as u32,
-        failed_count: failed_count.load(Ordering::Relaxed) as u32,
+        results,
+        success_count: success as u32,
+        failed_count: (total_count - success) as u32,
         time_ms: start.elapsed().as_secs_f64() * 1000.0,
     })
-}
-
-fn push_result(results: &Mutex<Vec<BatchFileResultNapi>>, result: BatchFileResultNapi) {
-    let mut guard = match results.lock() {
-        Ok(guard) => guard,
-        Err(poisoned) => poisoned.into_inner(),
-    };
-    guard.push(result);
 }


### PR DESCRIPTION
## Summary

PR2 of the #1387 boundary series: `compileSfcBatchWithResults` previously collected per-file results through a contended `Mutex<Vec>` in completion order (nondeterministic) and paid per-file clones that the audit flagged (`batch_results.rs:38,99-152,196-202`). This PR makes the collection lock-free and deterministic and drops the per-file clones, with zero behavior change visible to JS.

## What changed

- `Mutex<Vec>` + `push_result` replaced with rayon indexed `into_par_iter().map().collect()`: lock-free collection, results returned in input order (deterministic ordering is an acceptance criterion of #1387).
- Per-file clones dropped:
  - `parse.filename`: left empty — `compile_sfc_inner` falls back to `script.id` (`compile.rs:288-292`), which carries the identical value, so the result is byte-identical.
  - `template.id`: never read anywhere in `vize_atelier_sfc` (verified crate-wide).
  - `path`: moved from the owned input instead of `filename.clone()` per result.
  - `template_hash`/`style_hash`/`script_hash`: moved into the single result each file produces instead of `Option<String>` clones.
- `failed_count` atomic removed; derived as `total - success` (every file increments exactly one counter, so the identity holds).
- Boundary format unchanged and decided once; no new branches in the per-file hot path (the parse-error early return existed before).

## Measured overhead (local numbers — authoritative: Actions vite lane / Blacksmith A/B)

Local, 15,000 generated bench SFCs (`bench/generate.mjs`), `ci-opt` profile, both sides built at the same base commit, paired interleaved ABBA runs in one process, Apple Silicon (15 logical cores), macOS:

| | baseline | changed |
|---|---|---|
| median (40 pairs) | 214.7 ms | 216.9 ms |
| min | 198.8 ms | 200.7 ms |

Paired delta median −6.4 ms…+1.6 ms across sessions; a null test (baseline vs a copy of itself, same protocol) shows ±3.5 ms systematic noise, so the change is **performance-neutral locally within the noise floor**. The contended-lock lever this PR removes scales with thread count — the audit attributed it to the 32-vCPU EPYC runner, which the Blacksmith A/B comment will measure authoritatively. Per-file allocation savings: 3 `CompactString`/`String` clones + 3 `Option<String>` hash clones removed per file (~90k allocations over the 15k-file batch).

## JS-compat argument

- Deep-compare harness: all 5,002 per-file results (including a parse-error file exercising the error arm) **byte-identical across all 13 fields** between baseline and changed bindings; `successCount`/`failedCount` identical.
- Result ordering: the vite plugin consumes results keyed by `fileResult.path` (`npm/vite-plugin-vize/src/compiler.ts:216`) and the bench validates counts only, so switching from nondeterministic completion order to input order is strictly compatible.
- Fairness constraints of #1387 respected: results stay eagerly materialized JS strings; all files actually compile (no dedup/lazy getters introduced).

## Test plan

- `cargo test -p vize_vitrine --features napi` — pass
- `cargo test -p vize_atelier_sfc` — 518 passed
- `cargo clippy -p vize_vitrine --features napi` — no warnings in changed code (4 pre-existing elsewhere); `cargo fmt` clean
- JS-side with the changed binding via `NAPI_RS_NATIVE_LIBRARY_PATH`: `npm/vite-plugin-vize` hmr / compiler / utils / virtual / plugin{index, native, state, hmr, css-modules, resolve, quasar, unocss} tests pass. `plugin/load` and `plugin/compat` fail identically with the **baseline** binding (local vite-plus-core import issue, unrelated).
- A/B deep-compare + ordering check on 5,002 files — identical results, input order confirmed.

Part of #1387.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1412"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783755199&installation_id=136613492&pr_number=1412&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1412&signature=5fadcb46fe6791a143d93a7631bc37350533cbefbcfb3ed81ea1f1d2fa45025a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->