### PR TITLE
fix(carton): resolve VueDialect name collision breaking main

### DIFF
--- a/crates/vize_carton/src/config.rs
+++ b/crates/vize_carton/src/config.rs
@@ -13,8 +13,8 @@ pub use loader::{
 pub use model::{
     ArrowParens, AttributeSortOrder, ConfigFeatureFlags, EndOfLine, FormatterConfig,
     GlobalTypeDeclaration, GlobalTypesConfig, LanguageServerConfig, LintRuleSeverity, LinterConfig,
-    LspConfig, ParseVueDialectError, QuoteProps, TrailingComma, TypeCheckerConfig, VizeConfig,
-    VueDialect,
+    LspConfig, ParseVueVersionError, QuoteProps, TrailingComma, TypeCheckerConfig, VizeConfig,
+    VueVersion,
 };
 pub use normalize::normalize_public_config_value;
 

--- a/crates/vize_carton/src/config/model.rs
+++ b/crates/vize_carton/src/config/model.rs
@@ -23,7 +23,7 @@ pub use language_server::{LanguageServerConfig, LspConfig};
 #[allow(unused_imports)]
 pub use linter::{LintRuleSeverity, LinterConfig};
 pub use type_checker::TypeCheckerConfig;
-pub use vue::{ParseVueDialectError, VueDialect};
+pub use vue::{ParseVueVersionError, VueVersion};
 
 /// Effective shared configuration.
 #[derive(Debug, Clone, Default, Serialize)]
@@ -74,7 +74,7 @@ pub struct ConfigFeatureFlags {
     /// fail config loading instead of silently picking a line. Groundwork for
     /// legacy Vue support (#1392): consumers thread this into parser and
     /// transform options in follow-ups.
-    pub vue_dialect: Option<VueDialect>,
+    pub vue_version: Option<VueVersion>,
 }
 
 /// Raw config representation with legacy aliases preserved for migration.
@@ -176,7 +176,7 @@ impl RawVizeConfig {
             type_checker_options_api,
             type_checker_legacy_vue2,
             language_server_legacy_vue2: language_server_raw.legacy_vue2,
-            vue_dialect: vue.version,
+            vue_version: vue.version,
         };
 
         let config = VizeConfig {

--- a/crates/vize_carton/src/config/model/vue.rs
+++ b/crates/vize_carton/src/config/model/vue.rs
@@ -20,13 +20,13 @@ use serde::{Deserialize, Deserializer, de};
 /// Accepted config values are the bare version numbers `"3"` (default),
 /// `"2.7"`, `"2"`, `"1"`, `"0.11"`, and `"0.10"`; a leading `v` (as printed in
 /// diagnostics, e.g. `"v0.10"`) is also tolerated. Anything else fails config
-/// parsing — see [`VueDialect::from_config_str`].
+/// parsing — see [`VueVersion::from_config_str`].
 ///
 /// Vue 2.7 is kept distinct from Vue 2 because the lines differ on the script
 /// side (2.7 backports `<script setup>` / composition APIs) even though they
 /// share a template dialect downstream.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
-pub enum VueDialect {
+pub enum VueVersion {
     /// Modern Vue 3 — the default dialect; not a legacy line.
     #[default]
     V3,
@@ -42,9 +42,9 @@ pub enum VueDialect {
     V0_10,
 }
 
-impl VueDialect {
+impl VueVersion {
     /// Every selectable dialect, newest first.
-    pub const ALL: [VueDialect; 6] = [
+    pub const ALL: [VueVersion; 6] = [
         Self::V3,
         Self::V2_7,
         Self::V2,
@@ -77,7 +77,7 @@ impl VueDialect {
     /// line are distinct dialects (the 0.11.0 rewrite changed computed
     /// `$get`/`$set`, instantiation, and scope semantics), so the config must
     /// say which one it means.
-    pub fn from_config_str(raw: &str) -> Result<Self, ParseVueDialectError> {
+    pub fn from_config_str(raw: &str) -> Result<Self, ParseVueVersionError> {
         let trimmed = raw.trim();
         let bare = trimmed.strip_prefix(['v', 'V']).unwrap_or(trimmed);
         match bare {
@@ -87,13 +87,13 @@ impl VueDialect {
             "1" => Ok(Self::V1),
             "0.11" => Ok(Self::V0_11),
             "0.10" => Ok(Self::V0_10),
-            "0" => Err(ParseVueDialectError {
+            "0" => Err(ParseVueVersionError {
                 raw: raw.into(),
-                kind: ParseVueDialectErrorKind::AmbiguousZero,
+                kind: ParseVueVersionErrorKind::AmbiguousZero,
             }),
-            _ => Err(ParseVueDialectError {
+            _ => Err(ParseVueVersionError {
                 raw: raw.into(),
-                kind: ParseVueDialectErrorKind::Unknown,
+                kind: ParseVueVersionErrorKind::Unknown,
             }),
         }
     }
@@ -101,13 +101,13 @@ impl VueDialect {
 
 /// Error produced when a `vue.version` value does not name a dialect.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ParseVueDialectError {
+pub struct ParseVueVersionError {
     raw: crate::String,
-    kind: ParseVueDialectErrorKind,
+    kind: ParseVueVersionErrorKind,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum ParseVueDialectErrorKind {
+enum ParseVueVersionErrorKind {
     /// `"0"` / `"v0"`: does not distinguish the 0.10 line from the 0.11-era
     /// line.
     AmbiguousZero,
@@ -115,16 +115,16 @@ enum ParseVueDialectErrorKind {
     Unknown,
 }
 
-impl std::fmt::Display for ParseVueDialectError {
+impl std::fmt::Display for ParseVueVersionError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let raw = self.raw.as_str();
         match self.kind {
-            ParseVueDialectErrorKind::AmbiguousZero => write!(
+            ParseVueVersionErrorKind::AmbiguousZero => write!(
                 f,
                 "ambiguous vue.version \"{raw}\": Vue 0.10 and the 0.11-era line are \
                  distinct dialects; use \"0.10\" or \"0.11\""
             ),
-            ParseVueDialectErrorKind::Unknown => write!(
+            ParseVueVersionErrorKind::Unknown => write!(
                 f,
                 "unknown vue.version \"{raw}\": expected \"3\" (default), \"2.7\", \
                  \"2\", \"1\", \"0.11\", or \"0.10\""
@@ -133,17 +133,17 @@ impl std::fmt::Display for ParseVueDialectError {
     }
 }
 
-impl std::error::Error for ParseVueDialectError {}
+impl std::error::Error for ParseVueVersionError {}
 
-impl<'de> Deserialize<'de> for VueDialect {
+impl<'de> Deserialize<'de> for VueVersion {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
     {
-        struct VueDialectVisitor;
+        struct VueVersionVisitor;
 
-        impl de::Visitor<'_> for VueDialectVisitor {
-            type Value = VueDialect;
+        impl de::Visitor<'_> for VueVersionVisitor {
+            type Value = VueVersion;
 
             fn expecting(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 // Reached for non-string values, e.g. `"version": 2.7` in
@@ -158,11 +158,11 @@ impl<'de> Deserialize<'de> for VueDialect {
             where
                 E: de::Error,
             {
-                VueDialect::from_config_str(value).map_err(E::custom)
+                VueVersion::from_config_str(value).map_err(E::custom)
             }
         }
 
-        deserializer.deserialize_str(VueDialectVisitor)
+        deserializer.deserialize_str(VueVersionVisitor)
     }
 }
 
@@ -171,7 +171,7 @@ impl<'de> Deserialize<'de> for VueDialect {
 #[serde(default)]
 pub(crate) struct RawVueConfig {
     /// `vue.version` dialect selector; `None` when the key is absent.
-    pub(crate) version: Option<VueDialect>,
+    pub(crate) version: Option<VueVersion>,
 }
 
 #[cfg(test)]
@@ -180,29 +180,29 @@ mod tests {
 
     #[test]
     fn parses_canonical_and_v_prefixed_values() {
-        for dialect in VueDialect::ALL {
-            assert_eq!(VueDialect::from_config_str(dialect.as_str()), Ok(dialect));
+        for dialect in VueVersion::ALL {
+            assert_eq!(VueVersion::from_config_str(dialect.as_str()), Ok(dialect));
             let prefixed = crate::cstr!("v{}", dialect.as_str());
-            assert_eq!(VueDialect::from_config_str(&prefixed), Ok(dialect));
+            assert_eq!(VueVersion::from_config_str(&prefixed), Ok(dialect));
         }
         assert_eq!(
-            VueDialect::from_config_str(" 2.7 "),
-            Ok(VueDialect::V2_7),
+            VueVersion::from_config_str(" 2.7 "),
+            Ok(VueVersion::V2_7),
             "values are trimmed"
         );
     }
 
     #[test]
     fn only_vue3_is_not_legacy() {
-        for dialect in VueDialect::ALL {
-            assert_eq!(dialect.is_legacy(), dialect != VueDialect::V3);
+        for dialect in VueVersion::ALL {
+            assert_eq!(dialect.is_legacy(), dialect != VueVersion::V3);
         }
     }
 
     #[test]
     fn rejects_bare_zero_as_ambiguous() {
         for raw in ["0", "v0", "V0"] {
-            let error = VueDialect::from_config_str(raw).unwrap_err();
+            let error = VueVersion::from_config_str(raw).unwrap_err();
             let message = crate::cstr!("{error}");
             assert!(message.contains("ambiguous"), "{message}");
             assert!(message.contains("\"0.10\""), "{message}");
@@ -213,7 +213,7 @@ mod tests {
     #[test]
     fn rejects_unknown_values_with_expected_list() {
         for raw in ["2.6", "4", "vue2", ""] {
-            let error = VueDialect::from_config_str(raw).unwrap_err();
+            let error = VueVersion::from_config_str(raw).unwrap_err();
             let message = crate::cstr!("{error}");
             assert!(message.contains("unknown vue.version"), "{message}");
             assert!(message.contains("\"2.7\""), "{message}");
@@ -223,14 +223,14 @@ mod tests {
 
     #[test]
     fn deserializes_strings_and_rejects_numbers() {
-        let dialect: VueDialect = serde_json::from_str("\"0.10\"").unwrap();
-        assert_eq!(dialect, VueDialect::V0_10);
+        let dialect: VueVersion = serde_json::from_str("\"0.10\"").unwrap();
+        assert_eq!(dialect, VueVersion::V0_10);
 
-        let error = serde_json::from_str::<VueDialect>("2.7").unwrap_err();
+        let error = serde_json::from_str::<VueVersion>("2.7").unwrap_err();
         let message = crate::cstr!("{error}");
         assert!(message.contains("Vue version string"), "{message}");
 
-        let error = serde_json::from_str::<VueDialect>("\"0\"").unwrap_err();
+        let error = serde_json::from_str::<VueVersion>("\"0\"").unwrap_err();
         let message = crate::cstr!("{error}");
         assert!(message.contains("ambiguous"), "{message}");
     }

--- a/crates/vize_carton/tests/loading.rs
+++ b/crates/vize_carton/tests/loading.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::disallowed_macros)]
 
 use vize_carton::config::{
-    VueDialect, load_config, load_config_with_features_and_source, load_config_with_source,
+    VueVersion, load_config, load_config_with_features_and_source, load_config_with_source,
     validate_explicit_config_path,
 };
 
@@ -96,7 +96,7 @@ fn loads_json_vue_version_dialect() {
 
     let loaded = load_config_with_features_and_source(Some(dir.path()));
 
-    assert_eq!(loaded.features.vue_dialect, Some(VueDialect::V0_10));
+    assert_eq!(loaded.features.vue_version, Some(VueVersion::V0_10));
 }
 
 #[test]
@@ -106,7 +106,7 @@ fn vue_version_defaults_to_unset() {
 
     let loaded = load_config_with_features_and_source(Some(dir.path()));
 
-    assert_eq!(loaded.features.vue_dialect, None);
+    assert_eq!(loaded.features.vue_version, None);
 }
 
 #[test]
@@ -131,7 +131,7 @@ fn rejects_ambiguous_vue_version() {
     // Auto-discovery warns and falls back to defaults: it must never resolve
     // an ambiguous selector to some 0.x line.
     let loaded = load_config_with_features_and_source(Some(dir.path()));
-    assert_eq!(loaded.features.vue_dialect, None);
+    assert_eq!(loaded.features.vue_version, None);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

`main` does not compile since #1408 merged: #1402 introduced `vize_carton::dialect::VueDialect` (Vue vs petite-vue, for the `dialect` config key) and #1408 — branched before #1402 landed — introduced a second `VueDialect` in `config/model/vue.rs` (Vue version lines, for the `vue.version` config key). The two merged cleanly textually but collide semantically:

- `error[E0252]`: `VueDialect` defined multiple times in `config/model.rs`
- `error[E0603]`: private re-import surfaced through `config.rs`
- `error[E0308]`: the `ConfigFeatureFlags` field typed against the wrong enum

This renames the version-line enum to **`VueVersion`** (and `ParseVueDialectError` → `ParseVueVersionError`, flags field `vue_dialect` → `vue_version`), which also matches its config key `vue.version`. `VueDialect` stays the Vue/petite-vue flavor enum from #1402. Both features are days old, so no external consumers are affected.

## Test plan

- `cargo check --workspace` — compiles again (fails on current main).
- `cargo test -p vize_carton` — 135 passed (including #1408's config round-trip tests, now against `VueVersion`).
- `cargo test -p vize_armature -p vize_maestro` — green (capability sets and petite-vue dialect plumbing untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1413"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783755208&installation_id=136613492&pr_number=1413&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1413&signature=9b7654d71ebd189c36388f58950563dbd296985a4d59a4366b884526ca434282"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->