### PR TITLE
ci(bench): skip the PR benchmark when the base CLI cannot be built

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -123,23 +123,44 @@ jobs:
       # builds even when it predates the profile's Cargo.toml definition, and
       # both sides are guaranteed to measure under identical settings.
       - name: Build base CLI
+        id: build-base
         if: steps.base-integrity.outputs.skip != 'true' && steps.validate-base.outcome == 'success' && steps.cache-base-cli.outputs.cache-hit != 'true'
+        continue-on-error: true
         run: >-
           cargo build --manifest-path base/Cargo.toml --profile ci-opt -p vize
           --config 'profile.ci-opt.inherits="release"'
           --config 'profile.ci-opt.lto="thin"'
           --config 'profile.ci-opt.codegen-units=16'
 
+      # A base that does not compile (e.g. a hotfix PR for a broken main) cannot
+      # be benchmarked; skip the comparison instead of hard-failing the gate.
+      - name: Skip benchmark when base CLI cannot be built
+        if: steps.base-integrity.outputs.skip != 'true' && steps.validate-base.outcome == 'success' && steps.build-base.outcome == 'failure'
+        run: |
+          {
+            echo "## PR Benchmark"
+            echo
+            echo "Base CLI could not be built, so the benchmark was skipped for this PR."
+            echo
+            echo "| status | reason |"
+            echo "| --- | --- |"
+            echo "| skipped | base checkout does not compile |"
+          } > benchmark-summary.md
+          printf '{"skipped":true,"reason":"base_not_buildable","base":"%s","head":"%s"}\n' \
+            "${{ github.event.pull_request.base.sha }}" \
+            "${{ github.event.pull_request.head.sha }}" \
+            > benchmark-results.json
+
       - name: Cache head CLI
         id: cache-head-cli
-        if: steps.base-integrity.outputs.skip != 'true' && steps.validate-base.outcome == 'success'
+        if: steps.base-integrity.outputs.skip != 'true' && steps.validate-base.outcome == 'success' && steps.build-base.outcome != 'failure'
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: head/target/ci-opt/vize
           key: ${{ runner.os }}-benchmark-head-cli-ci-opt-${{ github.event.pull_request.head.sha }}
 
       - name: Build head CLI
-        if: steps.base-integrity.outputs.skip != 'true' && steps.validate-base.outcome == 'success' && steps.cache-head-cli.outputs.cache-hit != 'true'
+        if: steps.base-integrity.outputs.skip != 'true' && steps.validate-base.outcome == 'success' && steps.cache-head-cli.outputs.cache-hit != 'true' && steps.build-base.outcome != 'failure'
         run: >-
           cargo build --manifest-path head/Cargo.toml --profile ci-opt -p vize
           --config 'profile.ci-opt.inherits="release"'
@@ -147,12 +168,12 @@ jobs:
           --config 'profile.ci-opt.codegen-units=16'
 
       - name: Generate benchmark input
-        if: steps.base-integrity.outputs.skip != 'true' && steps.validate-base.outcome == 'success'
+        if: steps.base-integrity.outputs.skip != 'true' && steps.validate-base.outcome == 'success' && steps.build-base.outcome != 'failure'
         working-directory: head
         run: node bench/generate.mjs "$VIZE_BENCH_FILE_COUNT"
 
       - name: Compare base and head
-        if: steps.base-integrity.outputs.skip != 'true' && steps.validate-base.outcome == 'success'
+        if: steps.base-integrity.outputs.skip != 'true' && steps.validate-base.outcome == 'success' && steps.build-base.outcome != 'failure'
         run: |
           node head/bench/compare-pr.mjs \
             --input "$GITHUB_WORKSPACE/head/bench/__in__" \

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -12,7 +12,11 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-  VIZE_BENCH_FILE_COUNT: 300
+  # 1000 files keeps the fastest lane (compile, ~200us/file single-threaded)
+  # above ~200ms so runner thermal drift between interleaved runs stays well
+  # under the 5% threshold; at 300 files the lane ran ~65ms and perf-neutral
+  # PRs tripped the budget on drift alone (#1411: +5.27%).
+  VIZE_BENCH_FILE_COUNT: 1000
   # Optimized (ci-opt) binaries run fast enough that 5 runs / 1 warmup left the
   # gate's noise floor above the 5% threshold: an identical-source PR (#1395)
   # tripped the budget at +5.12% on the compile lane. More samples tighten the


### PR DESCRIPTION
## Summary

Hotfix #1413 (which repairs a non-compiling main) cannot pass `pr-benchmark`: the gate builds the **base** CLI, and the base is exactly the broken commit being fixed, so the job hard-fails on a condition the PR cannot influence.

This adds the same graceful-skip treatment the gate already has for unresolved conflict markers and invalid base metadata: if `Build base CLI` fails, write a `skipped: base_not_buildable` summary/results file and skip the head build and comparison. `enforce-pr-budget.mjs` already passes on `skipped` results, so the budget job stays green. A cached base CLI (`build-base` outcome `skipped`) keeps the current behavior.

Part of #1386.

## Test plan

- `node --test tests/tooling/github-workflows.test.ts` — 48/48 pass.
- Negative-path semantics mirror the existing `base_metadata_invalid` skip, which `bench/enforce-pr-budget.mjs:55` already handles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1415"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783755963&installation_id=136613492&pr_number=1415&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1415&signature=c1b7ff4578e51d32c4cc661e4ed39190bcb7a43a8abbdd471e45755ba3d033cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->