### PR TITLE
fix(atelier): emit diagnostics for invalid template expressions instead of silent passthrough

### DIFF
--- a/crates/vize_atelier_core/src/transform.rs
+++ b/crates/vize_atelier_core/src/transform.rs
@@ -142,14 +142,18 @@ impl<'a> ParentNode<'a> {
     }
 }
 
-/// Transform the root AST node
+/// Transform the root AST node.
+///
+/// Returns the diagnostics collected during the transform (e.g. invalid
+/// directive usage or unparseable expressions) so callers can surface them
+/// alongside parse errors instead of silently dropping them.
 pub fn transform<'a>(
     allocator: &'a Bump,
     root: &mut RootNode<'a>,
     options: TransformOptions,
     analysis: Option<&'a Croquis>,
-) {
-    transform_inner(allocator, root, options, analysis, false, None);
+) -> std::vec::Vec<CompilerError> {
+    transform_inner(allocator, root, options, analysis, false, None)
 }
 
 /// Transform the root AST node with template syntax quirk compatibility enabled.
@@ -158,8 +162,8 @@ pub fn transform_with_template_syntax_quirks<'a>(
     root: &mut RootNode<'a>,
     options: TransformOptions,
     analysis: Option<&'a Croquis>,
-) {
-    transform_inner(allocator, root, options, analysis, true, None);
+) -> std::vec::Vec<CompilerError> {
+    transform_inner(allocator, root, options, analysis, true, None)
 }
 
 /// Transform the root AST node with Vue parser quirk compatibility enabled.
@@ -169,8 +173,8 @@ pub fn transform_with_vue_parser_quirks<'a>(
     root: &mut RootNode<'a>,
     options: TransformOptions,
     analysis: Option<&'a Croquis>,
-) {
-    transform_with_template_syntax_quirks(allocator, root, options, analysis);
+) -> std::vec::Vec<CompilerError> {
+    transform_with_template_syntax_quirks(allocator, root, options, analysis)
 }
 
 /// Transform the root AST node with an explicit scope ID for hoisted VNodes.
@@ -181,8 +185,8 @@ pub fn transform_with_hoisted_scope_id<'a>(
     options: TransformOptions,
     analysis: Option<&'a Croquis>,
     hoisted_scope_id: Option<String>,
-) {
-    transform_inner(allocator, root, options, analysis, false, hoisted_scope_id);
+) -> std::vec::Vec<CompilerError> {
+    transform_inner(allocator, root, options, analysis, false, hoisted_scope_id)
 }
 
 /// Transform the root AST node with template syntax quirks and an explicit hoisted scope ID.
@@ -193,8 +197,8 @@ pub fn transform_with_template_syntax_quirks_and_hoisted_scope_id<'a>(
     options: TransformOptions,
     analysis: Option<&'a Croquis>,
     hoisted_scope_id: Option<String>,
-) {
-    transform_inner(allocator, root, options, analysis, true, hoisted_scope_id);
+) -> std::vec::Vec<CompilerError> {
+    transform_inner(allocator, root, options, analysis, true, hoisted_scope_id)
 }
 
 /// Transform the root AST node with Vue parser quirks and an explicit hoisted scope ID.
@@ -206,14 +210,14 @@ pub fn transform_with_vue_parser_quirks_and_hoisted_scope_id<'a>(
     options: TransformOptions,
     analysis: Option<&'a Croquis>,
     hoisted_scope_id: Option<String>,
-) {
+) -> std::vec::Vec<CompilerError> {
     transform_with_template_syntax_quirks_and_hoisted_scope_id(
         allocator,
         root,
         options,
         analysis,
         hoisted_scope_id,
-    );
+    )
 }
 
 fn transform_inner<'a>(
@@ -223,7 +227,7 @@ fn transform_inner<'a>(
     analysis: Option<&'a Croquis>,
     template_syntax_quirks: bool,
     hoisted_scope_id: Option<String>,
-) {
+) -> std::vec::Vec<CompilerError> {
     let source = root.source.clone();
     let mut ctx = if let Some(analysis) = analysis {
         TransformContext::with_analysis_and_template_syntax_quirks(
@@ -279,6 +283,8 @@ fn transform_inner<'a>(
     }
     root.temps = ctx.temps;
     root.transformed = true;
+
+    ctx.errors
 }
 
 /// Create codegen node for root

--- a/crates/vize_atelier_core/src/transform/context.rs
+++ b/crates/vize_atelier_core/src/transform/context.rs
@@ -384,6 +384,18 @@ impl<'a> TransformContext<'a> {
         self.errors.push(CompilerError::new(code, loc));
     }
 
+    /// Report an error with a custom message (e.g. parser details appended
+    /// to the code's default message, mirroring `@vue/compiler-core`).
+    pub fn on_error_with_message(
+        &mut self,
+        code: ErrorCode,
+        message: impl Into<CompactString>,
+        loc: Option<SourceLocation>,
+    ) {
+        self.errors
+            .push(CompilerError::with_message(code, message, loc));
+    }
+
     /// Replace current node with a new node
     pub fn replace_node(&mut self, new_node: TemplateChildNode<'a>) {
         if let Some(parent) = &self.parent {

--- a/crates/vize_atelier_core/src/transforms/transform_expression.rs
+++ b/crates/vize_atelier_core/src/transforms/transform_expression.rs
@@ -181,6 +181,12 @@ pub fn process_expression<'a>(
         if result.used_unref {
             ctx.helper(crate::ast::RuntimeHelper::Unref);
         }
+        // The expression failed to parse entirely and was passed through
+        // raw — report it instead of silently emitting broken render code.
+        // Matches `@vue/compiler-core`'s `X_INVALID_EXPRESSION`.
+        if let Some(detail) = &result.parse_error {
+            rewrite::report_invalid_expression(ctx, detail, &normalized.loc);
+        }
         result.code
     } else if ctx.options.is_ts {
         // Only strip TypeScript, no prefixing
@@ -430,6 +436,67 @@ mod tests {
         assert_eq!(prefixed.as_str(), deep.as_str());
         let stripped = strip_typescript_from_expression(&deep);
         assert_eq!(stripped.as_str(), deep.as_str());
+    }
+
+    #[test]
+    fn test_process_expression_reports_invalid_expression() {
+        let allocator = Bump::new();
+        let mut ctx = test_context(&allocator);
+        let expr = compound_expression(&allocator, "foo(");
+
+        let result = process_expression(&mut ctx, &expr, false);
+        let ExpressionNode::Simple(result) = result else {
+            panic!("expected simple expression");
+        };
+
+        // Raw passthrough (matches vue-core, which returns the node
+        // unchanged), but with a compile diagnostic instead of silence.
+        assert_eq!(result.content.as_str(), "foo(");
+        assert_eq!(ctx.errors.len(), 1, "errors: {:?}", ctx.errors);
+        assert_eq!(
+            ctx.errors[0].code,
+            crate::errors::ErrorCode::InvalidExpression
+        );
+        assert!(
+            ctx.errors[0]
+                .message
+                .starts_with("Error parsing JavaScript expression: "),
+            "message: {:?}",
+            ctx.errors[0].message
+        );
+        assert!(ctx.errors[0].loc.is_some(), "diagnostic must carry a span");
+    }
+
+    #[test]
+    fn test_process_expression_keyword_identifier_has_no_diagnostic() {
+        // `class` fails to parse as an expression but is a rewritable simple
+        // identifier; vue-core never parses it (simple-identifier fast path)
+        // and emits no error.
+        let allocator = Bump::new();
+        let mut ctx = test_context(&allocator);
+        let expr = compound_expression(&allocator, "class");
+
+        let result = process_expression(&mut ctx, &expr, false);
+        let ExpressionNode::Simple(result) = result else {
+            panic!("expected simple expression");
+        };
+
+        assert_eq!(result.content.as_str(), "_ctx.class");
+        assert!(ctx.errors.is_empty(), "errors: {:?}", ctx.errors);
+    }
+
+    #[test]
+    fn test_process_expression_valid_ts_fallback_has_no_diagnostic() {
+        // `foo<string>` is a TS instantiation expression. The TS-stripping
+        // heuristic does not lower it, so the JS parse fails — but the
+        // official compiler (babel + typescript plugin) accepts it, and the
+        // parity rule forbids rejecting what the official compiler accepts.
+        let allocator = Bump::new();
+        let mut ctx = test_context(&allocator);
+        let expr = compound_expression(&allocator, "foo<string>");
+
+        let _ = process_expression(&mut ctx, &expr, false);
+        assert!(ctx.errors.is_empty(), "errors: {:?}", ctx.errors);
     }
 
     #[test]

--- a/crates/vize_atelier_core/src/transforms/transform_expression/inline_handler.rs
+++ b/crates/vize_atelier_core/src/transforms/transform_expression/inline_handler.rs
@@ -14,7 +14,7 @@ use super::{
     clone_expression, is_event_handler_reference_expression, is_function_expression,
     normalize_expression,
     prefix::{get_identifier_prefix, is_simple_identifier},
-    rewrite::{rewrite_expression, rewrite_props_aliases},
+    rewrite::{report_invalid_expression, rewrite_expression, rewrite_props_aliases},
     typescript::strip_typescript_from_expression,
 };
 
@@ -54,6 +54,9 @@ pub fn process_inline_handler<'a>(
             let result = rewrite_expression(content, ctx, false);
             if result.used_unref {
                 ctx.helper(crate::ast::RuntimeHelper::Unref);
+            }
+            if let Some(detail) = &result.parse_error {
+                report_invalid_expression(ctx, detail, &normalized.loc);
             }
             return ExpressionNode::Simple(Box::new_in(
                 SimpleExpressionNode {
@@ -107,6 +110,9 @@ pub fn process_inline_handler<'a>(
                 if result.used_unref {
                     ctx.helper(crate::ast::RuntimeHelper::Unref);
                 }
+                if let Some(detail) = &result.parse_error {
+                    report_invalid_expression(ctx, detail, &normalized.loc);
+                }
                 result.code
             }
         } else if ctx.options.is_ts {
@@ -138,6 +144,9 @@ pub fn process_inline_handler<'a>(
         let result = rewrite_expression(content, ctx, false);
         if result.used_unref {
             ctx.helper(crate::ast::RuntimeHelper::Unref);
+        }
+        if let Some(detail) = &result.parse_error {
+            report_invalid_expression(ctx, detail, &normalized.loc);
         }
         result.code
     } else if ctx.options.is_ts {

--- a/crates/vize_atelier_core/src/transforms/transform_expression/rewrite.rs
+++ b/crates/vize_atelier_core/src/transforms/transform_expression/rewrite.rs
@@ -9,6 +9,8 @@ use oxc_parser::Parser;
 use oxc_span::SourceType;
 use vize_carton::String;
 
+use crate::ast::SourceLocation;
+use crate::errors::ErrorCode;
 use crate::transform::TransformContext;
 
 use super::{
@@ -91,6 +93,56 @@ pub(super) fn rewrite_props_aliases(code: String, ctx: &TransformContext<'_>) ->
 pub(crate) struct RewriteResult {
     pub(crate) code: String,
     pub(crate) used_unref: bool,
+    /// Set when the expression could not be parsed at all and the raw
+    /// content was passed through. Holds the parser's error detail so the
+    /// caller can emit a compile diagnostic (mirroring `@vue/compiler-core`'s
+    /// `X_INVALID_EXPRESSION`). `None` on every successful rewrite path.
+    pub(crate) parse_error: Option<String>,
+}
+
+/// Emit an `InvalidExpression` compile diagnostic for an expression that
+/// failed to parse, matching `@vue/compiler-core`'s
+/// `Error parsing JavaScript expression: <detail>` message format.
+pub(super) fn report_invalid_expression(
+    ctx: &mut TransformContext<'_>,
+    detail: &str,
+    loc: &SourceLocation,
+) {
+    const PREFIX: &str = "Error parsing JavaScript expression: ";
+    let mut message = String::with_capacity(PREFIX.len() + detail.len());
+    message.push_str(PREFIX);
+    message.push_str(detail);
+    ctx.on_error_with_message(ErrorCode::InvalidExpression, message, Some(loc.clone()));
+}
+
+/// Returns true when `content` parses as a TypeScript expression or program.
+///
+/// Only consulted on the parse-failure path for `is_ts` templates: when the
+/// TypeScript-stripping pass falls back to the original source, the plain-JS
+/// parse below can fail even though the expression is valid TypeScript that
+/// the official compiler (babel with the `typescript` plugin) accepts. The
+/// parity rule is that vize must not reject what the official compiler
+/// accepts, so such expressions keep the silent passthrough behavior.
+fn parses_as_typescript(content: &str) -> bool {
+    let source_type = SourceType::ts().with_module(true);
+
+    let expr_allocator = OxcAllocator::default();
+    let mut wrapped = String::with_capacity(content.len() + 2);
+    wrapped.push('(');
+    wrapped.push_str(content);
+    wrapped.push(')');
+    if Parser::new(&expr_allocator, &wrapped, source_type)
+        .parse_expression()
+        .is_ok()
+    {
+        return true;
+    }
+
+    let program_allocator = OxcAllocator::default();
+    Parser::new(&program_allocator, content, source_type)
+        .parse()
+        .errors
+        .is_empty()
 }
 
 /// Rewrite an expression string, prefixing identifiers with `_ctx.` where needed
@@ -106,6 +158,7 @@ pub(crate) fn rewrite_expression(
         return RewriteResult {
             code: String::new(content),
             used_unref: false,
+            parse_error: None,
         };
     }
     // First, if this is TypeScript, strip type annotations
@@ -171,9 +224,10 @@ pub(crate) fn rewrite_expression(
             RewriteResult {
                 code: rewrite_props_aliases(result, ctx),
                 used_unref,
+                parse_error: None,
             }
         }
-        Err(_) => {
+        Err(expression_errors) => {
             // Expression parsing failed - try parsing as a program (multi-statement handlers)
             let oxc_allocator2 = OxcAllocator::default();
             let parser2 = Parser::new(&oxc_allocator2, &js_content, source_type);
@@ -214,11 +268,17 @@ pub(crate) fn rewrite_expression(
                 return RewriteResult {
                     code: rewrite_props_aliases(result, ctx),
                     used_unref,
+                    parse_error: None,
                 };
             }
 
             // Program parsing also failed - fallback to simple identifier check
+            let mut parse_error = None;
             let code: String = if is_simple_identifier(&js_content) {
+                // Reserved words (`class`, `default`, …) fail to parse as an
+                // expression but are still rewritable identifiers. Vue treats
+                // them through its simple-identifier fast path without ever
+                // parsing, so no diagnostic is emitted here either.
                 if let Some(prefix) = get_identifier_prefix(&js_content, ctx) {
                     let mut s = String::with_capacity(prefix.len() + js_content.len());
                     s.push_str(prefix);
@@ -234,11 +294,26 @@ pub(crate) fn rewrite_expression(
                     js_content
                 }
             } else {
+                // The raw content is passed through unprefixed. The official
+                // compiler reports `X_INVALID_EXPRESSION` here, so surface the
+                // parser detail for the caller to emit a diagnostic — unless
+                // the original source is valid TypeScript that only vize's
+                // TS-stripping fallback failed to lower (the official compiler
+                // accepts it, so vize must not reject it).
+                if !ctx.options.is_ts || !parses_as_typescript(content) {
+                    parse_error = Some(
+                        expression_errors
+                            .first()
+                            .map(|error| String::new(error.message.as_ref()))
+                            .unwrap_or_else(|| String::new("invalid expression")),
+                    );
+                }
                 js_content
             };
             RewriteResult {
                 code: rewrite_props_aliases(code, ctx),
                 used_unref: false,
+                parse_error,
             }
         }
     }

--- a/crates/vize_atelier_core/src/transforms/v_for.rs
+++ b/crates/vize_atelier_core/src/transforms/v_for.rs
@@ -63,7 +63,7 @@ pub fn parse_for_expression<'a>(
 pub fn parse_for_expression_with_options<'a>(
     allocator: &'a Bump,
     content: &str,
-    _loc: &SourceLocation,
+    loc: &SourceLocation,
     template_syntax_quirks: bool,
 ) -> Option<ForParseResult<'a>> {
     let (alias_end, source_start) = find_for_separator(content)?;
@@ -76,8 +76,20 @@ pub fn parse_for_expression_with_options<'a>(
         return None;
     }
 
+    // Give the source expression its real sub-span within the v-for
+    // expression so downstream diagnostics (e.g. an unparseable source)
+    // point at the right characters. `find_for_separator` already skips
+    // whitespace, so `source_start` is the first byte of the source text.
+    let source_loc = if loc.source.is_empty() {
+        SourceLocation::default()
+    } else {
+        let start = advance_position(&loc.start, &content[..source_start]);
+        let end = advance_position(&start, source_str);
+        SourceLocation::new(start, end, source_str)
+    };
+
     let source = ExpressionNode::Simple(Box::new_in(
-        SimpleExpressionNode::new(source_str, false, SourceLocation::default()),
+        SimpleExpressionNode::new(source_str, false, source_loc),
         allocator,
     ));
 
@@ -123,6 +135,21 @@ pub fn parse_for_expression_with_options<'a>(
         index,
         finalized: false,
     })
+}
+
+/// Advance `base` over `text`, tracking byte offset, 1-indexed line and column.
+fn advance_position(base: &Position, text: &str) -> Position {
+    let mut line = base.line;
+    let mut column = base.column;
+    for ch in text.chars() {
+        if ch == '\n' {
+            line += 1;
+            column = 1;
+        } else {
+            column += 1;
+        }
+    }
+    Position::new(base.offset + text.len() as u32, line, column)
 }
 
 fn find_for_separator(content: &str) -> Option<(usize, usize)> {

--- a/crates/vize_atelier_dom/src/compile.rs
+++ b/crates/vize_atelier_dom/src/compile.rs
@@ -172,7 +172,7 @@ fn compile_template_inner<'a>(
     let template_syntax_quirks = template_syntax.is_quirks();
     // Allocate Croquis in the arena so it shares the allocator lifetime
     let analysis: Option<&Croquis> = options.croquis.map(|c| &*allocator.alloc(*c));
-    profile!(
+    let transform_errors = profile!(
         "atelier.dom.template.transform",
         if template_syntax_quirks {
             if hoisted_scope_id.is_some() {
@@ -204,6 +204,12 @@ fn compile_template_inner<'a>(
         }
     );
 
+    // Surface transform diagnostics (e.g. invalid expressions) alongside
+    // parse errors instead of dropping them — the official compiler reports
+    // both through the same `errors` channel.
+    let mut errors = errors.to_vec();
+    errors.extend(transform_errors);
+
     // Codegen
     let codegen_opts = CodegenOptions {
         mode: options.mode,
@@ -222,5 +228,5 @@ fn compile_template_inner<'a>(
         generate(&root, codegen_opts)
     );
 
-    (root, errors.to_vec(), codegen_result)
+    (root, errors, codegen_result)
 }

--- a/crates/vize_atelier_dom/tests/invalid_expression_diagnostics.rs
+++ b/crates/vize_atelier_dom/tests/invalid_expression_diagnostics.rs
@@ -1,0 +1,126 @@
+//! Diagnostics for template expressions that fail to parse.
+//!
+//! The official compiler (`@vue/compiler-core` with `prefixIdentifiers`)
+//! reports `X_INVALID_EXPRESSION` ("Error parsing JavaScript expression: …")
+//! when a template expression cannot be parsed. Vize previously passed the
+//! raw content through with no diagnostic (#1394). These tests pin the new
+//! behavior: exactly one diagnostic per invalid expression, carrying the
+//! expression's source span, and no diagnostics (or output changes) for
+//! valid expressions.
+#![allow(
+    clippy::disallowed_macros,
+    clippy::disallowed_types,
+    clippy::disallowed_methods
+)]
+
+use vize_atelier_core::{CompilerError, ErrorCode};
+use vize_atelier_dom::{DomCompilerOptions, compile_template_with_options};
+use vize_carton::Bump;
+
+fn analyzed_options() -> DomCompilerOptions {
+    DomCompilerOptions {
+        // The analyzed (SFC) pipeline always prefixes identifiers; this is
+        // the mode where vue-core parses expressions and reports errors.
+        prefix_identifiers: true,
+        ..DomCompilerOptions::default()
+    }
+}
+
+fn compile(source: &str) -> (Vec<CompilerError>, String) {
+    let allocator = Bump::new();
+    let (_, errors, result) = compile_template_with_options(&allocator, source, analyzed_options());
+    (errors, result.code.to_string())
+}
+
+fn assert_single_invalid_expression(source: &str, expression: &str) {
+    let (errors, _) = compile(source);
+    assert_eq!(
+        errors.len(),
+        1,
+        "expected exactly one diagnostic for {source:?}, got {errors:?}"
+    );
+    let error = &errors[0];
+    assert_eq!(error.code, ErrorCode::InvalidExpression, "in {source:?}");
+    assert!(
+        error
+            .message
+            .starts_with("Error parsing JavaScript expression: "),
+        "unexpected message {:?}",
+        error.message
+    );
+
+    let loc = error
+        .loc
+        .as_ref()
+        .unwrap_or_else(|| panic!("diagnostic for {source:?} should carry a span"));
+    assert_eq!(
+        loc.source.as_str(),
+        expression,
+        "span text mismatch in {source:?}"
+    );
+    let expected_offset = source
+        .find(expression)
+        .expect("expression must appear in template") as u32;
+    assert_eq!(
+        loc.start.offset, expected_offset,
+        "span start offset mismatch in {source:?}"
+    );
+    assert_eq!(
+        loc.end.offset,
+        expected_offset + expression.len() as u32,
+        "span end offset mismatch in {source:?}"
+    );
+}
+
+#[test]
+fn invalid_interpolation_expression_reports_diagnostic() {
+    assert_single_invalid_expression("<div>{{ foo( }}</div>", "foo(");
+}
+
+#[test]
+fn invalid_v_if_expression_reports_diagnostic() {
+    assert_single_invalid_expression(r#"<div v-if="foo(">x</div>"#, "foo(");
+}
+
+#[test]
+fn invalid_v_for_source_reports_diagnostic() {
+    assert_single_invalid_expression(r#"<div v-for="item in items((">x</div>"#, "items((");
+}
+
+#[test]
+fn invalid_event_handler_reports_diagnostic() {
+    assert_single_invalid_expression(r#"<button @click="count +">x</button>"#, "count +");
+}
+
+#[test]
+fn valid_expressions_compile_without_diagnostics() {
+    let templates = [
+        "<div>{{ foo() }}</div>",
+        r#"<div v-if="ok && items.length">x</div>"#,
+        r#"<div v-for="(item, i) in items">{{ item }}</div>"#,
+        r#"<button @click="count++">x</button>"#,
+        // Multi-statement handler: parses as a program, not an expression.
+        r#"<button @click="a++; b++">x</button>"#,
+        // Reserved words are valid bindings via the simple-identifier path.
+        "<div>{{ class }}</div>",
+    ];
+    for template in templates {
+        let (errors, code) = compile(template);
+        assert!(
+            errors.is_empty(),
+            "expected no diagnostics for {template:?}, got {errors:?}"
+        );
+        assert!(!code.is_empty(), "expected render code for {template:?}");
+    }
+}
+
+#[test]
+fn success_path_output_is_unchanged() {
+    // The diagnostic path only runs on parse failure; a valid template must
+    // produce byte-identical output with zero collected errors.
+    let allocator = Bump::new();
+    let source = r#"<div v-if="show" v-for="item in list" @click="go(item)">{{ item.name }}</div>"#;
+    let (_, errors, result) = compile_template_with_options(&allocator, source, analyzed_options());
+    assert!(errors.is_empty(), "unexpected diagnostics: {errors:?}");
+    insta::assert_snapshot!(result.code.as_str());
+}

--- a/crates/vize_atelier_dom/tests/snapshots/invalid_expression_diagnostics__success_path_output_is_unchanged.snap
+++ b/crates/vize_atelier_dom/tests/snapshots/invalid_expression_diagnostics__success_path_output_is_unchanged.snap
@@ -1,0 +1,11 @@
+---
+source: crates/vize_atelier_dom/tests/invalid_expression_diagnostics.rs
+expression: result.code.as_str()
+---
+function render(_ctx, _cache, $props, $setup, $data, $options) {
+  return (_ctx.show)
+    ? (_openBlock(true), _createElementBlock(_Fragment, { key: 0 }, _renderList(_ctx.list, (item) => {
+      return (_openBlock(), _createElementBlock("div", { onClick: $event => (_ctx.go(item)) }, _toDisplayString(item.name), 9 /* TEXT, PROPS */, ["onClick"]))
+    }), 256 /* UNKEYED_FRAGMENT */))
+    : _createCommentVNode("v-if", true)
+}

--- a/crates/vize_atelier_sfc/src/compile/tests.rs
+++ b/crates/vize_atelier_sfc/src/compile/tests.rs
@@ -114,6 +114,44 @@ export default {
 }
 
 #[test]
+fn test_invalid_template_expression_fails_compile_with_diagnostic() {
+    // An unparseable template expression must surface as a compile error
+    // (matching @vue/compiler-sfc, where X_INVALID_EXPRESSION fails the
+    // build) instead of silently emitting broken render code. (#1394)
+    let source = r#"<script setup>
+const foo = () => {}
+</script>
+
+<template>
+  <div>{{ foo( }}</div>
+</template>"#;
+
+    let descriptor = parse_sfc(source, SfcParseOptions::default()).expect("Failed to parse SFC");
+    let result =
+        compile_sfc(&descriptor, SfcCompileOptions::default()).expect("compile_sfc returns Ok");
+    assert_eq!(
+        result.errors.len(),
+        1,
+        "expected one template error, got: {:?}",
+        result.errors
+    );
+    let error = &result.errors[0];
+    assert_eq!(error.code.as_deref(), Some("TEMPLATE_ERROR"));
+    assert!(
+        error
+            .message
+            .contains("Error parsing JavaScript expression"),
+        "unexpected message: {}",
+        error.message
+    );
+    assert!(
+        error.message.contains("InvalidExpression"),
+        "unexpected message: {}",
+        error.message
+    );
+}
+
+#[test]
 fn test_v_model_on_component_in_sfc() {
     let source = r#"<script setup>
 import { ref } from 'vue'

--- a/crates/vize_atelier_ssr/src/lib.rs
+++ b/crates/vize_atelier_ssr/src/lib.rs
@@ -133,7 +133,7 @@ fn compile_ssr_inner<'a>(
     };
     let analysis = options.croquis.map(|c| &*allocator.alloc(*c));
     let template_syntax_quirks = template_syntax.is_quirks();
-    profile!(
+    let transform_errors = profile!(
         "atelier.ssr.template.transform",
         if template_syntax_quirks {
             transform_with_template_syntax_quirks(allocator, &mut root, transform_opts, analysis)
@@ -142,11 +142,17 @@ fn compile_ssr_inner<'a>(
         }
     );
 
+    // Surface transform diagnostics (e.g. invalid expressions) alongside
+    // parse errors instead of dropping them — same channel as the DOM
+    // compiler.
+    let mut errors = errors.to_vec();
+    errors.extend(transform_errors);
+
     // SSR codegen
     let codegen_ctx = SsrCodegenContext::new(allocator, &codegen_options);
     let codegen_result = profile!("atelier.ssr.template.codegen", codegen_ctx.generate(&root));
 
-    (root, errors.to_vec(), codegen_result)
+    (root, errors, codegen_result)
 }
 
 /// Get the namespace for an element based on its parent

--- a/crates/vize_relief/src/errors.rs
+++ b/crates/vize_relief/src/errors.rs
@@ -106,12 +106,15 @@ pub enum ErrorCode {
     VModelOnProps = 46,
     VModelArgOnElement = 47,
     VShowNoExpression = 48,
+    /// A template expression failed to parse as JavaScript/TypeScript.
+    /// Mirrors `@vue/compiler-core`'s `X_INVALID_EXPRESSION`.
+    InvalidExpression = 49,
 
     // Generic errors
-    PrefixIdNotSupported = 49,
-    ModuleModeNotSupported = 50,
-    CacheHandlerNotSupported = 51,
-    ScopeIdNotSupported = 52,
+    PrefixIdNotSupported = 50,
+    ModuleModeNotSupported = 51,
+    CacheHandlerNotSupported = 52,
+    ScopeIdNotSupported = 53,
 
     // Extended errors
     UnhandledCodePath = 100,
@@ -186,6 +189,7 @@ impl ErrorCode {
             Self::VModelOnProps => "v-model cannot be used on props.",
             Self::VModelArgOnElement => "v-model argument is not supported on plain elements.",
             Self::VShowNoExpression => "v-show is missing expression.",
+            Self::InvalidExpression => "Error parsing JavaScript expression.",
 
             Self::PrefixIdNotSupported => "prefixIdentifiers option is not supported in this mode.",
             Self::ModuleModeNotSupported => "ES module mode is not supported in this mode.",
@@ -315,6 +319,7 @@ mod tests {
             ErrorCode::VOnNoExpression,
             ErrorCode::VModelNoExpression,
             ErrorCode::VShowNoExpression,
+            ErrorCode::InvalidExpression,
         ];
         for code in &transform_errors {
             assert!(
@@ -344,11 +349,11 @@ mod tests {
         assert!(!ErrorCode::VIfNoExpression.is_parse_error());
         assert!(ErrorCode::VIfNoExpression.is_transform_error());
 
-        // VShowNoExpression (48) is the last transform error
-        assert!(ErrorCode::VShowNoExpression.is_transform_error());
-        assert!(!ErrorCode::VShowNoExpression.is_parse_error());
+        // InvalidExpression (49) is the last transform error
+        assert!(ErrorCode::InvalidExpression.is_transform_error());
+        assert!(!ErrorCode::InvalidExpression.is_parse_error());
 
-        // PrefixIdNotSupported (49) is neither
+        // PrefixIdNotSupported (50) is neither
         assert!(!ErrorCode::PrefixIdNotSupported.is_parse_error());
         assert!(!ErrorCode::PrefixIdNotSupported.is_transform_error());
     }
@@ -405,6 +410,7 @@ mod tests {
             ErrorCode::VModelOnProps,
             ErrorCode::VModelArgOnElement,
             ErrorCode::VShowNoExpression,
+            ErrorCode::InvalidExpression,
             ErrorCode::PrefixIdNotSupported,
             ErrorCode::ModuleModeNotSupported,
             ErrorCode::CacheHandlerNotSupported,


### PR DESCRIPTION
## Summary

When a template expression failed to parse both as an expression and as a program, `transform_expression/rewrite.rs` silently passed the raw content through unprefixed — generated render code referenced undefined bare identifiers at runtime with no compile error (issue #1394, atelier item / PR2).

- `rewrite_expression` now returns the parse failure detail (`RewriteResult.parse_error`), and `process_expression` / `process_inline_handler` emit a new `ErrorCode::InvalidExpression` diagnostic — `Error parsing JavaScript expression: <oxc detail>` — carrying the expression's source span.
- Transform diagnostics were previously dropped entirely (`transform_inner` discarded `ctx.errors`). The `transform*` entry points now return the collected errors, and the DOM and SSR compile pipelines append them to the same `errors` channel as parse errors, so `compile_sfc` surfaces them as `TEMPLATE_ERROR` like the rest of the template diagnostics.
- The v-for source expression now carries its real sub-span (previously `SourceLocation::default()`), so the diagnostic points at the actual source characters.

## Official-compiler behavior comparison

- `@vue/compiler-core` with `prefixIdentifiers` (the analyzed pipeline vize implements) parses every non-trivial expression with babel and emits `X_INVALID_EXPRESSION` ("Error parsing JavaScript expression: " + parser detail) on failure, returning the node unchanged. Browser dev builds report the same code via `validateBrowserExpression`. This PR mirrors that: same trigger (parse failure only), same message shape, same raw-passthrough recovery.
- Vue never parses simple identifiers (its `isSimpleIdentifier` fast path), so reserved-word bindings like `{{ class }}` compile to `_ctx.class` without error. Vize's simple-identifier fallback is kept diagnostic-free to match.
- TS templates: babel parses with the `typescript` plugin, so TS-only syntax the official compiler accepts must not be rejected. When vize's TS-stripping falls back and the JS parse fails, the original source is re-checked as TypeScript and the diagnostic is suppressed if it parses (e.g. instantiation expressions like `foo<string>`), covered by a regression test.

## Parity-fixture evidence

- `cargo run -p vize_test_runner --bin coverage`: VDOM 457/457, Vapor 116/117, SFC 167/167 — identical to the pre-change baseline; the single Vapor failure is the tracked v1-alpha known failure (`vapor/parity-core-directives`, #1161). No fixture accepted by the official compiler baseline is newly rejected, and all snapshot outputs are byte-identical.
- Zero-cost on success: the diagnostic (and the TS re-parse guard) only run after both the expression and program parses have already failed; successful parses take the unchanged path.

## Test plan

- New `crates/vize_atelier_dom/tests/invalid_expression_diagnostics.rs`: invalid interpolation (`{{ foo( }}`), invalid `v-if` (`v-if="foo("`), invalid `v-for` source (`item in items((`), and invalid `@click` handler each produce exactly one `InvalidExpression` diagnostic whose span text and start/end offsets match the expression; valid expressions (including multi-statement handlers and reserved-word bindings) produce zero diagnostics, with a snapshot pinning the success-path output.
- Unit tests in `vize_atelier_core`: diagnostic emission with span, keyword-identifier silence, TS-fallback parity guard.
- SFC-level test: an invalid expression now surfaces as a `TEMPLATE_ERROR` in `compile_sfc` results instead of compiling silently.
- `cargo test -p vize_relief -p vize_atelier_core -p vize_atelier_dom -p vize_atelier_sfc -p vize_atelier_ssr -p vize_atelier_vapor` — all green; downstream `vize_canon` / `vize_patina` / `vize_maestro` suites also green.

Part of #1394.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1416"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783756214&installation_id=136613492&pr_number=1416&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1416&signature=782cb6edf9f97dda8ccdace83ee00b11896b9566bc9452afb312add075ff4c8c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->