### PR TITLE
ci(bench): block skipped PR benchmark budgets

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -188,6 +188,7 @@ jobs:
     permissions:
       actions: read
       contents: read
+      issues: read
     steps:
       - name: Checkout head
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -200,8 +201,44 @@ jobs:
         with:
           name: pr-benchmark
 
+      - name: Read current PR labels
+        id: pr-labels
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          node <<'EOF' >> "$GITHUB_OUTPUT"
+          async function main() {
+            const apiUrl = process.env.GITHUB_API_URL ?? "https://api.github.com";
+            const url = `${apiUrl}/repos/${process.env.REPOSITORY}/issues/${process.env.PR_NUMBER}/labels?per_page=100`;
+            const response = await fetch(url, {
+              headers: {
+                accept: "application/vnd.github+json",
+                authorization: `Bearer ${process.env.GITHUB_TOKEN}`,
+              },
+            });
+            if (!response.ok) {
+              throw new Error(`Failed to read PR labels: ${response.status} ${response.statusText}`);
+            }
+            const labels = await response.json();
+            console.log("labels<<JSON");
+            console.log(JSON.stringify(labels.map((label) => label.name)));
+            console.log("JSON");
+          }
+          main().catch((error) => {
+            console.error(error);
+            process.exit(1);
+          });
+          EOF
+
       - name: Enforce benchmark budget
-        run: node head/bench/enforce-pr-budget.mjs --json benchmark-results.json
+        env:
+          PR_LABELS_JSON: ${{ steps.pr-labels.outputs.labels }}
+        run: >-
+          node head/bench/enforce-pr-budget.mjs
+          --json benchmark-results.json
+          --labels-json "$PR_LABELS_JSON"
 
   pr-benchmark-comment:
     name: pr-benchmark-comment

--- a/bench/enforce-pr-budget.mjs
+++ b/bench/enforce-pr-budget.mjs
@@ -9,6 +9,8 @@ import { pathToFileURL } from "node:url";
 
 import { createBenchmarkBudget } from "./compare-pr.mjs";
 
+export const DEFAULT_SKIP_OVERRIDE_LABEL = "ci:allow-skipped-benchmark";
+
 function parseArgs(argv) {
   const args = {};
   for (let i = 0; i < argv.length; i++) {
@@ -51,11 +53,32 @@ function formatRate(value) {
   return `${value.toFixed(3)}x`;
 }
 
-export function enforceBenchmarkBudget(data) {
+function parseLabelsJson(value) {
+  if (!value) {
+    return [];
+  }
+
+  const labels = JSON.parse(value);
+  if (!Array.isArray(labels) || labels.some((label) => typeof label !== "string")) {
+    throw new Error("--labels-json must be a JSON array of label names");
+  }
+  return labels;
+}
+
+export function enforceBenchmarkBudget(data, options = {}) {
   if (data.skipped) {
+    const skipOverrideLabel = options.skipOverrideLabel ?? DEFAULT_SKIP_OVERRIDE_LABEL;
+    const labels = options.labels ?? data.labels ?? [];
+    if (labels.includes(skipOverrideLabel)) {
+      return {
+        ok: true,
+        message: `Benchmark budget skipped with override label '${skipOverrideLabel}': ${data.reason ?? "benchmark skipped"}`,
+      };
+    }
+
     return {
-      ok: true,
-      message: `Benchmark budget skipped: ${data.reason ?? "benchmark skipped"}`,
+      ok: false,
+      message: `Benchmark budget skipped without override label '${skipOverrideLabel}': ${data.reason ?? "benchmark skipped"}`,
     };
   }
 
@@ -84,7 +107,10 @@ export function main(argv = process.argv.slice(2)) {
   const args = parseArgs(argv);
   const jsonPath = resolve(requireArg(args, "json"));
   const data = JSON.parse(readFileSync(jsonPath, "utf8"));
-  const result = enforceBenchmarkBudget(data);
+  const result = enforceBenchmarkBudget(data, {
+    labels: parseLabelsJson(args["labels-json"]),
+    skipOverrideLabel: args["skip-override-label"],
+  });
 
   console.log(result.message);
   if (!result.ok) {

--- a/tests/tooling/benchmark-budget.test.ts
+++ b/tests/tooling/benchmark-budget.test.ts
@@ -2,7 +2,10 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 
 import { createBenchmarkBudget, renderMarkdown } from "../../bench/compare-pr.mjs";
-import { enforceBenchmarkBudget } from "../../bench/enforce-pr-budget.mjs";
+import {
+  DEFAULT_SKIP_OVERRIDE_LABEL,
+  enforceBenchmarkBudget,
+} from "../../bench/enforce-pr-budget.mjs";
 
 const stableResult = {
   id: "compile",
@@ -65,12 +68,29 @@ test("benchmark markdown reports the active regression budget", () => {
   assert.match(markdown, /Type check: 1\.150x \(\+15\.00%\)/);
 });
 
-test("benchmark budget allows skipped benchmark runs", () => {
+test("benchmark budget blocks skipped benchmark runs without an override label", () => {
   const enforcement = enforceBenchmarkBudget({
     skipped: true,
     reason: "base_metadata_invalid",
   });
 
+  assert.equal(enforcement.ok, false);
+  assert.match(enforcement.message, /base_metadata_invalid/);
+  assert.match(enforcement.message, new RegExp(DEFAULT_SKIP_OVERRIDE_LABEL));
+});
+
+test("benchmark budget allows skipped benchmark runs with an override label", () => {
+  const enforcement = enforceBenchmarkBudget(
+    {
+      skipped: true,
+      reason: "base_metadata_invalid",
+    },
+    {
+      labels: [DEFAULT_SKIP_OVERRIDE_LABEL],
+    },
+  );
+
   assert.equal(enforcement.ok, true);
   assert.match(enforcement.message, /base_metadata_invalid/);
+  assert.match(enforcement.message, new RegExp(DEFAULT_SKIP_OVERRIDE_LABEL));
 });

--- a/tests/tooling/github-workflows.test.ts
+++ b/tests/tooling/github-workflows.test.ts
@@ -518,6 +518,7 @@ test("benchmark workflow comments from trusted code after a read-only benchmark 
   assert.match(budgetJob, /needs:\n\s+- pr-benchmark\b/);
   assert.match(budgetJob, /actions:\s*read/);
   assert.match(budgetJob, /contents:\s*read/);
+  assert.match(budgetJob, /issues:\s*read/);
   assert.doesNotMatch(budgetJob, /issues:\s*write/);
   assert.doesNotMatch(budgetJob, /pull-requests:\s*write/);
   assert.match(
@@ -526,9 +527,13 @@ test("benchmark workflow comments from trusted code after a read-only benchmark 
   );
   assert.match(budgetJob, /uses:\s*actions\/download-artifact@[0-9a-f]{40}\s*# v8\.0\.1/);
   assert.match(budgetJob, /name:\s*pr-benchmark/);
+  assert.match(budgetJob, /name:\s*Read current PR labels/);
+  assert.match(budgetJob, /GITHUB_TOKEN:\s*\$\{\{\s*github\.token\s*\}\}/);
+  assert.match(budgetJob, /process\.env\.GITHUB_API_URL \?\? "https:\/\/api\.github\.com"/);
+  assert.match(budgetJob, /labels\.map\(\(label\) => label\.name\)/);
   assert.match(
     budgetJob,
-    /node head\/bench\/enforce-pr-budget\.mjs --json benchmark-results\.json/,
+    /node head\/bench\/enforce-pr-budget\.mjs[\s\S]*--json benchmark-results\.json[\s\S]*--labels-json "\$PR_LABELS_JSON"/,
   );
 
   assert.match(commentJob, /needs:\n\s+- pr-benchmark\b/);


### PR DESCRIPTION
## Summary
- make skipped PR benchmark budgets fail by default instead of passing silently
- allow an explicit maintainer override label (`ci:allow-skipped-benchmark`) to pass a skipped benchmark gate
- have the budget job read current PR labels before enforcing the budget

Part of #1386 PR2.

## Verification
- `pnpm exec vp check .github/workflows/benchmark.yml bench/enforce-pr-budget.mjs tests/tooling/benchmark-budget.test.ts tests/tooling/github-workflows.test.ts`
- `node --test tests/tooling/benchmark-budget.test.ts`
- `node --test --test-name-pattern "benchmark workflow comments" tests/tooling/github-workflows.test.ts`
- CLI probe: skipped benchmark exits 1 without the label and 0 with `ci:allow-skipped-benchmark`