### PR TITLE
ci(native-smoke): fix Corsa executable discovery on Windows fresh installs

### DIFF
--- a/crates/vize/tests/check_cli.rs
+++ b/crates/vize/tests/check_cli.rs
@@ -3328,7 +3328,11 @@ fn native_preview_platform_suffix() -> &'static str {
             "linux-x64"
         }
     } else if cfg!(target_os = "windows") {
-        "win32-x64"
+        if cfg!(target_arch = "aarch64") {
+            "win32-arm64"
+        } else {
+            "win32-x64"
+        }
     } else {
         ""
     }

--- a/crates/vize_carton/src/corsa_resolver.rs
+++ b/crates/vize_carton/src/corsa_resolver.rs
@@ -21,6 +21,10 @@
 //!      reading its platform `optionalDependencies` entry
 //!    - the platform package / meta package under `node_modules/@typescript`
 //!    - the pnpm virtual store (`node_modules/.pnpm`) as a legacy fallback
+//!
+//!      Every native-binary probe accepts both `{corsa,tsgo}` and
+//!      `{corsa,tsgo}.exe` — npm's Windows platform packages ship
+//!      `lib/tsgo.exe`.
 //!    - `node_modules/.bin` wrappers (used only when no native binary is
 //!      found anywhere in the walk)
 //! 4. Common global install locations under `$HOME` plus `npm root -g`.
@@ -135,7 +139,11 @@ pub fn platform_suffix() -> &'static str {
             "linux-x64"
         }
     } else if cfg!(target_os = "windows") {
-        "win32-x64"
+        if cfg!(target_arch = "aarch64") {
+            "win32-arm64"
+        } else {
+            "win32-x64"
+        }
     } else {
         ""
     }
@@ -300,17 +308,26 @@ fn find_project_cache(dir: &Path, dev_paths: bool) -> Option<PathBuf> {
 
     for cache_dir in cache_dirs {
         for executable in CORSA_EXECUTABLE_NAMES {
-            let plain = cache_dir.join(executable);
-            if plain.exists() {
-                return Some(plain);
-            }
-            let windows = cache_dir.join(&*crate::cstr!("{executable}.exe"));
-            if windows.exists() {
-                return Some(windows);
+            if let Some(found) = existing_executable(&cache_dir, executable) {
+                return Some(found);
             }
         }
     }
 
+    None
+}
+
+/// Probe `dir/{name}` and `dir/{name}.exe`. npm's Windows platform packages
+/// ship `lib/tsgo.exe`; every other platform ships an extensionless binary.
+fn existing_executable(dir: &Path, executable: &str) -> Option<PathBuf> {
+    let plain = dir.join(executable);
+    if plain.exists() {
+        return Some(plain);
+    }
+    let windows = dir.join(&*crate::cstr!("{executable}.exe"));
+    if windows.exists() {
+        return Some(windows);
+    }
     None
 }
 
@@ -325,24 +342,21 @@ fn find_node_modules_native(dir: &Path) -> Option<PathBuf> {
             return Some(path);
         }
 
+        let lib_dir = platform_package_root(&node_modules, suffix).join("lib");
         for executable in CORSA_EXECUTABLE_NAMES {
-            let candidate = platform_package_root(&node_modules, suffix)
-                .join("lib")
-                .join(executable);
-            if candidate.exists() {
-                return Some(candidate);
+            if let Some(found) = existing_executable(&lib_dir, executable) {
+                return Some(found);
             }
         }
     }
 
+    let meta_lib_dir = node_modules
+        .join("@typescript")
+        .join("native-preview")
+        .join("lib");
     for executable in CORSA_EXECUTABLE_NAMES {
-        let candidate = node_modules
-            .join("@typescript")
-            .join("native-preview")
-            .join("lib")
-            .join(executable);
-        if candidate.exists() {
-            return Some(candidate);
+        if let Some(found) = existing_executable(&meta_lib_dir, executable) {
+            return Some(found);
         }
     }
 
@@ -378,10 +392,10 @@ fn resolve_platform_package(node_modules: &Path, suffix: &str) -> Option<PathBuf
         if !package_root.is_dir() {
             continue;
         }
+        let lib_dir = package_root.join("lib");
         for executable in CORSA_EXECUTABLE_NAMES {
-            let candidate = package_root.join("lib").join(executable);
-            if candidate.exists() {
-                return Some(candidate);
+            if let Some(found) = existing_executable(&lib_dir, executable) {
+                return Some(found);
             }
         }
     }
@@ -407,12 +421,10 @@ fn scrape_pnpm_store(node_modules: &Path, suffix: &str) -> Option<PathBuf> {
         if !name.starts_with("@typescript+native-preview-") || !name.contains(suffix) {
             continue;
         }
+        let lib_dir = platform_package_root(&entry.path().join("node_modules"), suffix).join("lib");
         for executable in CORSA_EXECUTABLE_NAMES {
-            let candidate = platform_package_root(&entry.path().join("node_modules"), suffix)
-                .join("lib")
-                .join(executable);
-            if candidate.exists() {
-                return Some(candidate);
+            if let Some(found) = existing_executable(&lib_dir, executable) {
+                return Some(found);
             }
         }
     }
@@ -806,6 +818,61 @@ mod tests {
         // Node-style resolution canonicalizes the meta package directory, so
         // compare canonicalized paths (macOS tempdirs live behind a symlink).
         assert_eq!(resolved, Some(platform_binary.canonicalize().unwrap()));
+    }
+
+    // Regression for the native-smoke fresh-install matrix on Windows: npm's
+    // platform packages ship `lib/tsgo.exe` (no extensionless sibling), and
+    // `node_modules/.bin/tsgo` is a POSIX sh shim that CreateProcess rejects
+    // with "%1 is not a valid Win32 application" (os error 193). The resolver
+    // must find the `.exe` and never fall back to the sh shim.
+    #[test]
+    fn resolves_platform_package_exe_binary_over_bin_wrapper() {
+        let suffix = platform_suffix();
+        let temp_dir = TempDir::new().unwrap();
+        let root = temp_dir.path().join("project");
+        let node_modules = root.join("node_modules");
+        let manifest = node_modules
+            .join("@typescript")
+            .join("native-preview")
+            .join("package.json");
+        let platform_binary = node_modules
+            .join("@typescript")
+            .join(&*crate::cstr!("native-preview-{suffix}"))
+            .join("lib")
+            .join("tsgo.exe");
+        let wrapper = node_modules.join(".bin").join("tsgo");
+
+        fs::create_dir_all(manifest.parent().unwrap()).unwrap();
+        fs::write(
+            &manifest,
+            &*crate::cstr!(
+                r#"{{"name":"@typescript/native-preview","optionalDependencies":{{"@typescript/native-preview-{suffix}":"7.0.0"}}}}"#
+            ),
+        )
+        .unwrap();
+        write_file(&platform_binary);
+        write_file(&wrapper);
+
+        let resolved = discover_in_walk(&[root], false);
+
+        assert_eq!(resolved, Some(platform_binary.canonicalize().unwrap()));
+    }
+
+    #[test]
+    fn resolves_meta_package_exe_binary() {
+        let temp_dir = TempDir::new().unwrap();
+        let root = temp_dir.path().join("project");
+        let native = root
+            .join("node_modules")
+            .join("@typescript")
+            .join("native-preview")
+            .join("lib")
+            .join("tsgo.exe");
+        write_file(&native);
+
+        let resolved = discover_in_walk(&[root], false);
+
+        assert_eq!(resolved, Some(native));
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
## Failure chain

The weekly `native-smoke.yml` run has failed 3/3 times since it went schedule-only (2026-05-25, 06-01, 06-08; runs 26383825228, 26735992208, 27125070950). The Windows half of those failures is identical every time — all four fresh-install jobs (win32-x64-msvc / win32-arm64-msvc x Node 22 / 24) die at **Fresh install and runtime smoke published tarballs**:

```
Error: ...\node_modules\vize\bin\vize check src/App.vue --format json --quiet --no-config failed with exit 1
Error: corsa error (exit code -1): Failed to start Corsa API session: %1 is not a valid Win32 application. (os error 193)
```

Chain:

1. The smoke project installs the packed `vize` tarball with `--include=optional`, so `@typescript/native-preview` plus its platform package (`...-win32-x64` / `...-win32-arm64`) are present. Those Windows platform packages ship the binary as `lib/tsgo.exe`.
2. The shared Corsa resolver (`crates/vize_carton/src/corsa_resolver.rs`) probed every `node_modules` location with extensionless names only (`lib/tsgo`), so it never found `tsgo.exe`. On win32-arm64 it additionally probed the wrong package entirely: `platform_suffix()` hard-coded `win32-x64` for all Windows hosts.
3. Discovery then fell through to the `node_modules/.bin/tsgo` wrapper. On Windows npm writes that extensionless file as a POSIX sh shim (the real entry points are `tsgo.cmd`/`tsgo.ps1`), and `CreateProcess` rejects it with **os error 193** — the exact message in the logs.
4. Linux/macos-arm64 pass because their platform packages ship an extensionless `lib/tsgo`, which the resolver finds before the wrapper fallback.

The job has never been green in its current shape: #532 (2026-05-20) added the `vize check`/`vize lint` runtime checks and the win32-arm64 matrix entry in the same commit that removed the `pull_request` trigger, so the first time this path ever executed was the first failing scheduled run. Classification: real product bug on Windows (both arches — not arm64-specific, and not an infra flake), surfaced by CI.

## Fix

- Probe `{corsa,tsgo}.exe` beside every extensionless candidate in the resolver's `node_modules` discovery (platform package, meta package, Node-style manifest resolution, pnpm store) via a shared `existing_executable` helper — the project-cache probe already did this.
- Return `win32-arm64` from `platform_suffix()` on aarch64 Windows.
- Mirror the suffix fix in the `check_cli.rs` test helper that duplicates it.

Regression tests reproduce the exact failing layout (`lib/tsgo.exe` + sh-shim wrapper) and assert the `.exe` wins; they run on all hosts since the `.exe` probe is unconditional.

## Validation

- `cargo test -p vize_carton corsa_resolver` (20 passed, incl. 2 new regression tests)
- `cargo test -p vize_canon --lib` (322 passed), `cargo test -p vize_patina corsa` (14 passed)
- `cargo fmt --check`, `cargo clippy -p vize_carton --all-targets` clean
- `node --test tests/tooling/github-workflows.test.ts` (48 passed)

## Not fixed here (separate issue)

The darwin-x64 jobs fail independently: MoonBit's upstream `unix.sh` installer aborts with `error: Unsupported platform: Darwin x86_64` — MoonBit ships no Intel-mac toolchain, so the `macos-15-intel` matrix entries can never pass with the current setup-moonbit action. That needs a matrix/policy decision (drop the entry + update `docs/content/stability.md`, or stage moonbit differently) and is deliberately left out of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1420"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783758689&installation_id=136613492&pr_number=1420&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1420&signature=46b232998feaf72ed7e26ebe43bb12cb0348ab0ed7b67e27256016c7d4cca69b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->