### PR TITLE
perf(atelier): record template codegen sections at emission instead of re-scanning output

### DIFF
--- a/crates/vize_atelier_core/src/codegen.rs
+++ b/crates/vize_atelier_core/src/codegen.rs
@@ -24,6 +24,6 @@ mod tests;
 #[cfg(test)]
 use crate::options::CodegenOptions;
 
-pub use context::{CodegenContext, CodegenResult, CodegenSections};
+pub use context::{CodegenContext, CodegenResult, CodegenResultWithSections, CodegenSections};
 pub(crate) use helpers::is_constant_simple_expression;
-pub use pipeline::generate;
+pub use pipeline::{generate, generate_with_sections};

--- a/crates/vize_atelier_core/src/codegen.rs
+++ b/crates/vize_atelier_core/src/codegen.rs
@@ -24,6 +24,6 @@ mod tests;
 #[cfg(test)]
 use crate::options::CodegenOptions;
 
-pub use context::{CodegenContext, CodegenResult};
+pub use context::{CodegenContext, CodegenResult, CodegenSections};
 pub(crate) use helpers::is_constant_simple_expression;
 pub use pipeline::generate;

--- a/crates/vize_atelier_core/src/codegen/context.rs
+++ b/crates/vize_atelier_core/src/codegen/context.rs
@@ -97,9 +97,25 @@ pub struct CodegenResult {
     pub preamble: String,
     /// Source map (JSON)
     pub map: Option<String>,
+}
+
+/// Code generation result with emission-recorded section boundaries.
+///
+/// This is a separate wrapper so the longstanding public [`CodegenResult`]
+/// remains constructible with the same public fields.
+pub struct CodegenResultWithSections {
+    /// Generated code, preamble, and source map.
+    pub result: CodegenResult,
     /// Section boundaries recorded during emission (`None` when codegen
     /// bailed out before producing a render function).
     pub sections: Option<CodegenSections>,
+}
+
+impl CodegenResultWithSections {
+    /// Drop section metadata and keep the public codegen result.
+    pub fn into_result(self) -> CodegenResult {
+        self.result
+    }
 }
 
 impl CodegenContext {

--- a/crates/vize_atelier_core/src/codegen/context.rs
+++ b/crates/vize_atelier_core/src/codegen/context.rs
@@ -66,6 +66,29 @@ pub struct CodegenContext {
     pub(super) v_if_branch_counter: usize,
 }
 
+/// Byte offsets of the structural sections of a generated render module,
+/// recorded at emission time.
+///
+/// SFC inline assembly needs the generated module split back into imports /
+/// hoisted consts / asset preamble / render body. Recording the boundaries
+/// while the code is written lets the caller slice the buffer directly
+/// instead of re-scanning the output line by line.
+#[derive(Debug, Clone, Copy)]
+pub struct CodegenSections {
+    /// Byte length of the import statement section at the start of
+    /// `preamble`. Hoisted declarations (when present) follow after a single
+    /// `'\n'` separator.
+    pub imports_len: usize,
+    /// Byte range in `code` covering the component/directive resolution
+    /// statements inside the render function (raw, including indentation).
+    pub assets_start: usize,
+    pub assets_end: usize,
+    /// Byte range in `code` covering the root `return` expression (the bytes
+    /// after `"return "` up to the closing brace line).
+    pub return_expr_start: usize,
+    pub return_expr_end: usize,
+}
+
 /// Code generation result
 pub struct CodegenResult {
     /// Generated code
@@ -74,6 +97,9 @@ pub struct CodegenResult {
     pub preamble: String,
     /// Source map (JSON)
     pub map: Option<String>,
+    /// Section boundaries recorded during emission (`None` when codegen
+    /// bailed out before producing a render function).
+    pub sections: Option<CodegenSections>,
 }
 
 impl CodegenContext {

--- a/crates/vize_atelier_core/src/codegen/pipeline.rs
+++ b/crates/vize_atelier_core/src/codegen/pipeline.rs
@@ -10,7 +10,7 @@ use crate::{
 use vize_carton::profile;
 
 use super::children::is_directive_comment;
-use super::context::{CodegenContext, CodegenResult};
+use super::context::{CodegenContext, CodegenResult, CodegenSections};
 use super::element::generate_root_node;
 use super::generate::{collect_hoist_helpers, generate_hoists};
 use super::node::generate_node;
@@ -40,10 +40,13 @@ pub fn generate(root: &RootNode<'_>, options: CodegenOptions) -> CodegenResult {
     ctx.newline();
 
     // Generate component/directive resolution
+    let assets_start = ctx.code.len();
     profile!("atelier.codegen.assets", generate_assets(&mut ctx, root));
+    let assets_end = ctx.code.len();
 
     // Generate return statement
     ctx.push("return ");
+    let return_expr_start = ctx.code.len();
 
     // Generate root node
     if root_children.is_empty() {
@@ -91,6 +94,7 @@ pub fn generate(root: &RootNode<'_>, options: CodegenOptions) -> CodegenResult {
             ctx.push("], 64 /* STABLE_FRAGMENT */))");
         }
     }
+    let return_expr_end = ctx.code.len();
 
     ctx.deindent();
     ctx.newline();
@@ -130,6 +134,7 @@ pub fn generate(root: &RootNode<'_>, options: CodegenOptions) -> CodegenResult {
         "atelier.codegen.preamble",
         generate_preamble_from_helpers(&ctx, &ordered_helpers)
     );
+    let imports_len = preamble.len();
 
     // Generate hoisted variable declarations (appended to preamble)
     let hoists_code = profile!("atelier.codegen.hoists", generate_hoists(&ctx, root));
@@ -142,6 +147,13 @@ pub fn generate(root: &RootNode<'_>, options: CodegenOptions) -> CodegenResult {
         code: ctx.into_code(),
         preamble,
         map: None,
+        sections: Some(CodegenSections {
+            imports_len,
+            assets_start,
+            assets_end,
+            return_expr_start,
+            return_expr_end,
+        }),
     }
 }
 

--- a/crates/vize_atelier_core/src/codegen/pipeline.rs
+++ b/crates/vize_atelier_core/src/codegen/pipeline.rs
@@ -10,7 +10,7 @@ use crate::{
 use vize_carton::profile;
 
 use super::children::is_directive_comment;
-use super::context::{CodegenContext, CodegenResult, CodegenSections};
+use super::context::{CodegenContext, CodegenResult, CodegenResultWithSections, CodegenSections};
 use super::element::generate_root_node;
 use super::generate::{collect_hoist_helpers, generate_hoists};
 use super::node::generate_node;
@@ -21,6 +21,14 @@ use super::root::{
 
 /// Generate code from root AST.
 pub fn generate(root: &RootNode<'_>, options: CodegenOptions) -> CodegenResult {
+    generate_with_sections(root, options).into_result()
+}
+
+/// Generate code from root AST and return emission-recorded section boundaries.
+pub fn generate_with_sections(
+    root: &RootNode<'_>,
+    options: CodegenOptions,
+) -> CodegenResultWithSections {
     let mut ctx = CodegenContext::new(options);
     ctx.static_cache = ctx.options.inline || !root.hoists.is_empty();
     let root_children: std::vec::Vec<&TemplateChildNode<'_>> = root
@@ -143,10 +151,12 @@ pub fn generate(root: &RootNode<'_>, options: CodegenOptions) -> CodegenResult {
         preamble.push_str(&hoists_code);
     }
 
-    CodegenResult {
-        code: ctx.into_code(),
-        preamble,
-        map: None,
+    CodegenResultWithSections {
+        result: CodegenResult {
+            code: ctx.into_code(),
+            preamble,
+            map: None,
+        },
         sections: Some(CodegenSections {
             imports_len,
             assets_start,

--- a/crates/vize_atelier_core/src/lib.rs
+++ b/crates/vize_atelier_core/src/lib.rs
@@ -49,7 +49,10 @@ pub use vize_armature::{
     parse_with_options_and_template_syntax,
 };
 
-pub use codegen::{CodegenContext, CodegenResult, CodegenSections, generate};
+pub use codegen::{
+    CodegenContext, CodegenResult, CodegenResultWithSections, CodegenSections, generate,
+    generate_with_sections,
+};
 pub use runtime_helpers::{RuntimeHelpers, get_vnode_block_helper, get_vnode_helper};
 #[allow(deprecated)]
 pub use transform::{

--- a/crates/vize_atelier_core/src/lib.rs
+++ b/crates/vize_atelier_core/src/lib.rs
@@ -49,7 +49,7 @@ pub use vize_armature::{
     parse_with_options_and_template_syntax,
 };
 
-pub use codegen::{CodegenContext, CodegenResult, generate};
+pub use codegen::{CodegenContext, CodegenResult, CodegenSections, generate};
 pub use runtime_helpers::{RuntimeHelpers, get_vnode_block_helper, get_vnode_helper};
 #[allow(deprecated)]
 pub use transform::{

--- a/crates/vize_atelier_dom/src/compile.rs
+++ b/crates/vize_atelier_dom/src/compile.rs
@@ -1,9 +1,9 @@
 //! DOM template compilation: parse, transform, and codegen entry points.
 
-use vize_atelier_core::codegen::CodegenResult;
+use vize_atelier_core::codegen::{CodegenResult, CodegenResultWithSections};
 use vize_atelier_core::{
     CompilerError, RootNode,
-    codegen::generate,
+    codegen::generate_with_sections,
     options::{CodegenOptions, ParserOptions, TemplateSyntaxMode, TransformOptions},
     parser::parse_with_options_and_template_syntax,
     transform::{
@@ -115,6 +115,25 @@ pub fn compile_template_with_template_syntax_and_hoisted_scope_id<'a>(
     )
 }
 
+/// Compile a Vue template for DOM with template syntax mode, hoisted scope ID,
+/// and emission-recorded codegen section boundaries.
+#[doc(hidden)]
+pub fn compile_template_with_template_syntax_and_hoisted_scope_id_with_sections<'a>(
+    allocator: &'a Bump,
+    source: &'a str,
+    options: DomCompilerOptions,
+    template_syntax: TemplateSyntaxMode,
+    hoisted_scope_id: Option<String>,
+) -> (RootNode<'a>, Vec<CompilerError>, CodegenResultWithSections) {
+    compile_template_inner_with_sections(
+        allocator,
+        source,
+        options,
+        template_syntax,
+        hoisted_scope_id,
+    )
+}
+
 fn compile_template_inner<'a>(
     allocator: &'a Bump,
     source: &'a str,
@@ -122,6 +141,23 @@ fn compile_template_inner<'a>(
     template_syntax: TemplateSyntaxMode,
     hoisted_scope_id: Option<String>,
 ) -> (RootNode<'a>, Vec<CompilerError>, CodegenResult) {
+    let (root, errors, codegen_result) = compile_template_inner_with_sections(
+        allocator,
+        source,
+        options,
+        template_syntax,
+        hoisted_scope_id,
+    );
+    (root, errors, codegen_result.into_result())
+}
+
+fn compile_template_inner_with_sections<'a>(
+    allocator: &'a Bump,
+    source: &'a str,
+    options: DomCompilerOptions,
+    template_syntax: TemplateSyntaxMode,
+    hoisted_scope_id: Option<String>,
+) -> (RootNode<'a>, Vec<CompilerError>, CodegenResultWithSections) {
     // Create parser options with DOM-specific settings
     let parser_opts = ParserOptions {
         is_void_tag: vize_carton::is_void_tag,
@@ -151,9 +187,15 @@ fn compile_template_inner<'a>(
             code: String::default(),
             preamble: String::default(),
             map: None,
-            sections: None,
         };
-        return (root, errors.to_vec(), codegen_result);
+        return (
+            root,
+            errors.to_vec(),
+            CodegenResultWithSections {
+                result: codegen_result,
+                sections: None,
+            },
+        );
     }
 
     // Transform with DOM-specific transforms
@@ -226,7 +268,7 @@ fn compile_template_inner<'a>(
     };
     let codegen_result = profile!(
         "atelier.dom.template.codegen",
-        generate(&root, codegen_opts)
+        generate_with_sections(&root, codegen_opts)
     );
 
     (root, errors, codegen_result)

--- a/crates/vize_atelier_dom/src/compile.rs
+++ b/crates/vize_atelier_dom/src/compile.rs
@@ -151,6 +151,7 @@ fn compile_template_inner<'a>(
             code: String::default(),
             preamble: String::default(),
             map: None,
+            sections: None,
         };
         return (root, errors.to_vec(), codegen_result);
     }

--- a/crates/vize_atelier_dom/src/lib.rs
+++ b/crates/vize_atelier_dom/src/lib.rs
@@ -25,6 +25,7 @@ pub use compile::{
     compile_template, compile_template_with_options,
     compile_template_with_options_and_hoisted_scope_id, compile_template_with_template_syntax,
     compile_template_with_template_syntax_and_hoisted_scope_id,
+    compile_template_with_template_syntax_and_hoisted_scope_id_with_sections,
 };
 #[allow(deprecated)]
 pub use compile::{

--- a/crates/vize_atelier_sfc/src/compile.rs
+++ b/crates/vize_atelier_sfc/src/compile.rs
@@ -17,7 +17,7 @@ use crate::compile_script::props::is_valid_identifier;
 use crate::compile_script::{TemplateParts, compile_script_setup_inline_with_context};
 use crate::compile_template::{
     TemplateBlockCompileContext, compile_template_block, compile_template_block_vapor,
-    extract_template_parts, extract_template_parts_full,
+    extract_template_parts, extract_template_parts_full, slice_template_parts,
 };
 use crate::rewrite_default::rewrite_default;
 use crate::script::ScriptCompileContext;
@@ -887,7 +887,12 @@ fn compile_sfc_inner(
             } else {
                 let (imports, hoisted, preamble, body, render_fn_name) = profile!(
                     "atelier.sfc.template.extract_parts",
-                    extract_template_parts(template_code)
+                    match &template_output.sections {
+                        // Emission-recorded offsets: slice the sections out
+                        // directly instead of re-scanning the module.
+                        Some(sections) => slice_template_parts(template_code, sections),
+                        None => extract_template_parts(template_code),
+                    }
                 );
                 (
                     imports,

--- a/crates/vize_atelier_sfc/src/compile_template.rs
+++ b/crates/vize_atelier_sfc/src/compile_template.rs
@@ -11,7 +11,9 @@ mod vapor;
 #[cfg(test)]
 mod tests;
 
-pub(crate) use extraction::{extract_template_parts, extract_template_parts_full};
+pub(crate) use extraction::{
+    extract_template_parts, extract_template_parts_full, slice_template_parts,
+};
 pub(crate) use vapor::compile_template_block_vapor;
 
 use vize_atelier_core::TemplateSyntaxMode;
@@ -22,6 +24,27 @@ use crate::types::{BindingMetadata, SfcError, SfcTemplateBlock, TemplateCompileO
 pub(crate) struct TemplateBlockCompileResult {
     pub(crate) code: String,
     pub(crate) warnings: std::vec::Vec<SfcError>,
+    /// Section boundaries of `code`, recorded while the render module was
+    /// emitted. `None` for the SSR/Vapor lanes (they re-scan via
+    /// `extract_template_parts_full`) and for codegen error paths.
+    pub(crate) sections: Option<TemplateCodeSections>,
+}
+
+/// Byte ranges into [`TemplateBlockCompileResult::code`] marking the sections
+/// the inline SFC assembly consumes. Mirrors what
+/// [`extraction::extract_template_parts`] reconstructs by line scanning, but
+/// recorded at emission so the hot path can slice instead of re-scan.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct TemplateCodeSections {
+    /// `import { ... } from "vue"` line(s), trailing newline included.
+    pub(crate) imports: (usize, usize),
+    /// Hoisted module-level declarations, one per line.
+    pub(crate) hoisted: (usize, usize),
+    /// Component/directive resolution statements inside the render function
+    /// (raw slice; lines carry codegen indentation).
+    pub(crate) assets: (usize, usize),
+    /// The root `return` expression of the render function.
+    pub(crate) return_expr: (usize, usize),
 }
 
 pub(crate) struct TemplateBlockCompileContext<'a> {
@@ -114,6 +137,7 @@ pub(crate) fn compile_template_block(
         return Ok(TemplateBlockCompileResult {
             code: output,
             warnings: recoverable_template_warnings(&errors),
+            sections: None,
         });
     }
 
@@ -196,9 +220,28 @@ pub(crate) fn compile_template_block(
     output.push_str(&result.code);
     output.push('\n');
 
+    // Translate the emission-recorded section offsets into the concatenated
+    // output: `output = preamble + '\n' + code + '\n'`, where `preamble` is
+    // the import statement followed (when hoists exist) by '\n' + hoists.
+    let sections = result.sections.map(|s| {
+        let preamble_len = result.preamble.len();
+        let fn_base = preamble_len + 1;
+        TemplateCodeSections {
+            imports: (0, s.imports_len),
+            hoisted: if preamble_len > s.imports_len {
+                (s.imports_len + 1, preamble_len)
+            } else {
+                (preamble_len, preamble_len)
+            },
+            assets: (fn_base + s.assets_start, fn_base + s.assets_end),
+            return_expr: (fn_base + s.return_expr_start, fn_base + s.return_expr_end),
+        }
+    });
+
     Ok(TemplateBlockCompileResult {
         code: output,
         warnings: recoverable_template_warnings(&errors),
+        sections,
     })
 }
 

--- a/crates/vize_atelier_sfc/src/compile_template.rs
+++ b/crates/vize_atelier_sfc/src/compile_template.rs
@@ -185,7 +185,7 @@ pub(crate) fn compile_template_block(
     // Compile template
     let (_, errors, result) = profile!(
         "atelier.sfc.template.dom",
-        vize_atelier_dom::compile_template_with_template_syntax_and_hoisted_scope_id(
+        vize_atelier_dom::compile_template_with_template_syntax_and_hoisted_scope_id_with_sections(
             &allocator,
             &template.content,
             dom_opts,
@@ -212,19 +212,19 @@ pub(crate) fn compile_template_block(
     let mut output = String::default();
 
     // Add Vue imports
-    output.push_str(&result.preamble);
+    output.push_str(&result.result.preamble);
     output.push('\n');
 
     // The codegen already generates a complete function with closing brace,
     // so we just need to use it directly
-    output.push_str(&result.code);
+    output.push_str(&result.result.code);
     output.push('\n');
 
     // Translate the emission-recorded section offsets into the concatenated
     // output: `output = preamble + '\n' + code + '\n'`, where `preamble` is
     // the import statement followed (when hoists exist) by '\n' + hoists.
     let sections = result.sections.map(|s| {
-        let preamble_len = result.preamble.len();
+        let preamble_len = result.result.preamble.len();
         let fn_base = preamble_len + 1;
         TemplateCodeSections {
             imports: (0, s.imports_len),

--- a/crates/vize_atelier_sfc/src/compile_template/extraction.rs
+++ b/crates/vize_atelier_sfc/src/compile_template/extraction.rs
@@ -2,9 +2,52 @@
 
 use vize_carton::{String, ToCompactString};
 
+use super::TemplateCodeSections;
 use super::string_tracking::{
     StringTrackState, count_braces_with_state, count_delims_with_state, count_parens_with_state,
 };
+
+/// Slice the structural sections out of compiled template code using
+/// emission-recorded byte offsets.
+///
+/// Produces the same `(imports, hoisted, preamble, render_body, name)` tuple
+/// as [`extract_template_parts`], but without re-scanning the whole module
+/// line by line: the codegen pipeline already knows where each section
+/// starts and ends, so this is slicing plus a trim pass over the (tiny)
+/// asset-resolution region.
+pub(crate) fn slice_template_parts(
+    template_code: &str,
+    sections: &TemplateCodeSections,
+) -> (String, String, String, String, &'static str) {
+    let slice = |(start, end): (usize, usize)| template_code.get(start..end).unwrap_or_default();
+
+    let imports = String::new(slice(sections.imports));
+    let hoisted = String::new(slice(sections.hoisted));
+
+    // Asset-resolution statements carry the render function's indentation;
+    // the inline assembly expects them trimmed, one per line. The region also
+    // ends with the blank separator line codegen emits before `return`.
+    let assets_raw = slice(sections.assets);
+    let mut preamble = String::with_capacity(assets_raw.len());
+    for line in assets_raw.lines() {
+        let trimmed = line.trim();
+        if !trimmed.is_empty() {
+            preamble.push_str(trimmed);
+            preamble.push('\n');
+        }
+    }
+
+    // Same trailing cleanup as `finalize_render_body`: drop trailing
+    // whitespace, then at most one `;`.
+    let mut body = slice(sections.return_expr);
+    body = body.trim_end_matches([' ', '\t', '\n', '\r']);
+    if let Some(stripped) = body.strip_suffix(';') {
+        body = stripped;
+    }
+    let render_body = String::new(body);
+
+    (imports, hoisted, preamble, render_body, "render")
+}
 
 fn is_vapor_template_declaration(line: &str) -> bool {
     line.starts_with("const t") && line.contains("_template(")

--- a/crates/vize_atelier_sfc/src/compile_template/tests.rs
+++ b/crates/vize_atelier_sfc/src/compile_template/tests.rs
@@ -497,3 +497,84 @@ export function render(_ctx, _cache) {
         "render function should remain intact:\n{render_fn}"
     );
 }
+
+// --- slice_template_parts equivalence tests ---
+
+/// The emission-recorded section offsets must reproduce exactly what the
+/// line scanner extracts, for every shape of generated render module the
+/// inline SFC path can produce.
+#[test]
+fn test_slice_template_parts_matches_line_scanner() {
+    use super::extraction::slice_template_parts;
+    use super::{TemplateBlockCompileContext, compile_template_block};
+    use crate::types::{BindingMetadata, TemplateCompileOptions};
+
+    let templates = [
+        // Plain element + interpolation
+        "<div>{{ msg }}</div>",
+        // Static-only content (hoistable, may need no assets)
+        "<div><img style=\"position: absolute; top: 0\" alt=\"x\"></div>",
+        // Unresolved component + directive => asset preamble lines
+        "<MyWidget v-focus>{{ count + 1 }}</MyWidget>",
+        // Root-level v-if/v-else => multi-line ternary return
+        "<div v-if=\"shown\">a</div>\n<span v-else>b</span>",
+        // Multi-root fragment
+        "<header>h</header>\n<footer>f</footer>",
+        // v-for with nested interpolation
+        "<ul><li v-for=\"item in items\" :key=\"item.id\">{{ item.name }}</li></ul>",
+        // Slot outlet root
+        "<slot name=\"body\" :row=\"row\" />",
+        // Event handlers (cached) + v-model
+        "<input v-model=\"text\" @keyup.enter=\"submit($event)\">",
+        // Plain text root
+        "hello",
+    ];
+
+    for source in templates {
+        let template = SfcTemplateBlock {
+            content: Cow::Borrowed(source),
+            loc: BlockLocation {
+                start: 0,
+                end: 0,
+                tag_start: 0,
+                tag_end: 0,
+                start_line: 1,
+                start_column: 1,
+                end_line: 1,
+                end_column: 1,
+            },
+            lang: None,
+            src: None,
+            attrs: Default::default(),
+        };
+        let bindings = BindingMetadata::default();
+        let result = compile_template_block(
+            &template,
+            &TemplateCompileOptions::default(),
+            TemplateBlockCompileContext {
+                scope_id: "abc123",
+                apply_scope_id: false,
+                has_scoped: true,
+                is_ts: false,
+                inline: true,
+                component_name: Some("TestComp"),
+                bindings: Some(&bindings),
+                croquis: None,
+            },
+            vize_atelier_core::TemplateSyntaxMode::Standard,
+        )
+        .expect("template should compile");
+
+        let sections = result
+            .sections
+            .expect("DOM lane must record section offsets");
+        let sliced = slice_template_parts(&result.code, &sections);
+        let scanned = extract_template_parts(&result.code);
+
+        assert_eq!(
+            sliced, scanned,
+            "sliced sections must match the line scanner for template:\n{source}\n\ngenerated code:\n{}",
+            result.code
+        );
+    }
+}

--- a/crates/vize_atelier_sfc/src/compile_template/vapor.rs
+++ b/crates/vize_atelier_sfc/src/compile_template/vapor.rs
@@ -71,6 +71,7 @@ pub(crate) fn compile_template_block_vapor(
     Ok(TemplateBlockCompileResult {
         code,
         warnings: recoverable_template_warnings(&diagnostics),
+        sections: None,
     })
 }
 


### PR DESCRIPTION
## Summary

The inline SFC path compiles the template into one module string, then runs `extract_template_parts` — a char-by-char string-tracking line scanner — over that output to split it back into imports / hoisted consts / asset preamble / render body. On a fresh single-thread profile of the 1000-file bench corpus that scrape is **11.3% of compile wall, all self time**. Codegen knows every one of those boundaries while it writes the buffer, so this PR records them at emission and replaces the re-scan with slicing (issue checklist PR7, template side — complements #1422 on the script side).

## Profile breakdown (single-thread, 1000-file corpus, ci-opt, local)

Before (main @ 67d6dd17, `vize build bench/__in__ --format stats --threads 1 --profile`):

| span | total | share |
|---|---|---|
| atelier.sfc.template.compile | 55.06ms | 42.4% |
| atelier.dom.template.transform | ~24ms | ~18% |
| **atelier.sfc.template.extract_parts** | **14.70ms** | **11.3% (all self)** |
| atelier.codegen.root_node (self) | ~15.6ms | ~11.5% |
| atelier.dom.template.parse | ~10ms | ~7.4% |

After: `atelier.sfc.template.extract_parts` **14.70ms → 0.13ms** (~110x on the span; the remaining cost is the section copies the assembly needs anyway).

## What changed

- `vize_atelier_core::codegen`: `generate()` records `CodegenSections` — byte offsets of the asset-resolution region and the root `return` expression as they are emitted, plus the import-statement length before hoists are appended to the preamble. Recording is five `len()` reads; no new allocations or branches on any lane.
- `vize_atelier_sfc::compile_template_block`: translates those offsets into ranges over the concatenated module (`preamble + '\n' + code + '\n'`) and passes them along as `TemplateCodeSections`.
- `vize_atelier_sfc::compile`: the inline lane slices the sections (`slice_template_parts`) when offsets are present; the line scanner remains as the fallback for paths without them (SSR/Vapor lanes via `extract_template_parts_full`, codegen error paths).
- New unit test compiles 9 representative template shapes (interpolation, assets, root ternary, multi-root fragment, v-for, slot, v-model + cached handlers, static-only, bare text) and asserts the slicer's 5-tuple equals the line scanner's byte for byte.

## Before/after (local, Apple Silicon, ci-opt, median of interleaved A/B runs vs main @ 67d6dd17)

| lane | main | branch | delta |
|---|---|---|---|
| `vize build bench/__in__ --format stats --threads 1` (15 runs) | 0.1036s | 0.0893s | **-13.8%** |
| same, default threads (13 runs) | 0.0202s | 0.0191s | **-5.4%** |

(The 1T delta exceeds the 11.3% span share because dropping ~15KB of scanner-built strings per file also relieves allocator pressure; the parallel delta is the same per-file win under thread scheduling noise. Blacksmith A/B numbers to follow from CI.)

## Byte-identical evidence

- `vize build` over the 1000-file corpus with `-f js` for **default, `--ssr`, and `--vapor`** lanes, main binary vs branch binary: `diff -r` reports zero differences for all three.
- Full snapshot suites (`tests/snapshots/sfc/`, dom_snapshot, ssr_snapshot, insta suites) pass unchanged — no snapshot updates in this PR.

## What remains (template side, from the same profile)

- `atelier.dom.template.transform` (~18%): per-expression oxc parses (`transform_expression`, v-for/v-slot helpers) still create a fresh `Allocator` per expression.
- `atelier.codegen.root_node` (~11.5% self): String push/small-Vec churn in vnode emission.
- `extract_template_parts_full` (SSR/Vapor lanes) still line-scans; same sections technique applies but those codegens are separate crates.

## Test plan

- [x] `cargo test --workspace` green (51 suites, post-rebase onto #1422)
- [x] New slice-vs-scanner equivalence test (`test_slice_template_parts_matches_line_scanner`)
- [x] `cargo clippy` — zero warnings on changed code (remaining warnings are pre-existing test-module lints)
- [x] `cargo fmt --check` clean
- [x] `diff -r` byte-identity across default/SSR/Vapor lanes on the bench corpus

Part of #1387.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1423"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783763254&installation_id=136613492&pr_number=1423&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1423&signature=78b1a406c459a4bbebd71ecb8a73bad2617c5e49019e6804a59569939b6201a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
