### PR TITLE
ci(bench): block skipped PR benchmark budgets

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -213,6 +213,7 @@ jobs:
     permissions:
       actions: read
       contents: read
+      issues: read
     steps:
       - name: Checkout head
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -225,8 +226,44 @@ jobs:
         with:
           name: pr-benchmark
 
+      - name: Read current PR labels
+        id: pr-labels
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          node <<'EOF' >> "$GITHUB_OUTPUT"
+          async function main() {
+            const apiUrl = process.env.GITHUB_API_URL ?? "https://api.github.com";
+            const url = `${apiUrl}/repos/${process.env.REPOSITORY}/issues/${process.env.PR_NUMBER}/labels?per_page=100`;
+            const response = await fetch(url, {
+              headers: {
+                accept: "application/vnd.github+json",
+                authorization: `Bearer ${process.env.GITHUB_TOKEN}`,
+              },
+            });
+            if (!response.ok) {
+              throw new Error(`Failed to read PR labels: ${response.status} ${response.statusText}`);
+            }
+            const labels = await response.json();
+            console.log("labels<<JSON");
+            console.log(JSON.stringify(labels.map((label) => label.name)));
+            console.log("JSON");
+          }
+          main().catch((error) => {
+            console.error(error);
+            process.exit(1);
+          });
+          EOF
+
       - name: Enforce benchmark budget
-        run: node head/bench/enforce-pr-budget.mjs --json benchmark-results.json
+        env:
+          PR_LABELS_JSON: ${{ steps.pr-labels.outputs.labels }}
+        run: >-
+          node head/bench/enforce-pr-budget.mjs
+          --json benchmark-results.json
+          --labels-json "$PR_LABELS_JSON"
 
   pr-benchmark-comment:
     name: pr-benchmark-comment

--- a/bench/enforce-pr-budget.mjs
+++ b/bench/enforce-pr-budget.mjs
@@ -9,6 +9,8 @@ import { pathToFileURL } from "node:url";
 
 import { createBenchmarkBudget } from "./compare-pr.mjs";
 
+export const DEFAULT_SKIP_OVERRIDE_LABEL = "ci:allow-skipped-benchmark";
+
 function parseArgs(argv) {
   const args = {};
   for (let i = 0; i < argv.length; i++) {
@@ -51,11 +53,32 @@ function formatRate(value) {
   return `${value.toFixed(3)}x`;
 }
 
-export function enforceBenchmarkBudget(data) {
+function parseLabelsJson(value) {
+  if (!value) {
+    return [];
+  }
+
+  const labels = JSON.parse(value);
+  if (!Array.isArray(labels) || labels.some((label) => typeof label !== "string")) {
+    throw new Error("--labels-json must be a JSON array of label names");
+  }
+  return labels;
+}
+
+export function enforceBenchmarkBudget(data, options = {}) {
   if (data.skipped) {
+    const skipOverrideLabel = options.skipOverrideLabel ?? DEFAULT_SKIP_OVERRIDE_LABEL;
+    const labels = options.labels ?? data.labels ?? [];
+    if (labels.includes(skipOverrideLabel)) {
+      return {
+        ok: true,
+        message: `Benchmark budget skipped with override label '${skipOverrideLabel}': ${data.reason ?? "benchmark skipped"}`,
+      };
+    }
+
     return {
-      ok: true,
-      message: `Benchmark budget skipped: ${data.reason ?? "benchmark skipped"}`,
+      ok: false,
+      message: `Benchmark budget skipped without override label '${skipOverrideLabel}': ${data.reason ?? "benchmark skipped"}`,
     };
   }
 
@@ -84,7 +107,10 @@ export function main(argv = process.argv.slice(2)) {
   const args = parseArgs(argv);
   const jsonPath = resolve(requireArg(args, "json"));
   const data = JSON.parse(readFileSync(jsonPath, "utf8"));
-  const result = enforceBenchmarkBudget(data);
+  const result = enforceBenchmarkBudget(data, {
+    labels: parseLabelsJson(args["labels-json"]),
+    skipOverrideLabel: args["skip-override-label"],
+  });
 
   console.log(result.message);
   if (!result.ok) {

--- a/tests/tooling/benchmark-budget.test.ts
+++ b/tests/tooling/benchmark-budget.test.ts
@@ -2,7 +2,10 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 
 import { createBenchmarkBudget, makeTasks, renderMarkdown } from "../../bench/compare-pr.mjs";
-import { enforceBenchmarkBudget } from "../../bench/enforce-pr-budget.mjs";
+import {
+  DEFAULT_SKIP_OVERRIDE_LABEL,
+  enforceBenchmarkBudget,
+} from "../../bench/enforce-pr-budget.mjs";
 
 const stableResult = {
   id: "compile",
@@ -89,12 +92,29 @@ test("benchmark tasks gate the formatter without mutating the corpus", () => {
   );
 });
 
-test("benchmark budget allows skipped benchmark runs", () => {
+test("benchmark budget blocks skipped benchmark runs without an override label", () => {
   const enforcement = enforceBenchmarkBudget({
     skipped: true,
     reason: "base_metadata_invalid",
   });
 
+  assert.equal(enforcement.ok, false);
+  assert.match(enforcement.message, /base_metadata_invalid/);
+  assert.match(enforcement.message, new RegExp(DEFAULT_SKIP_OVERRIDE_LABEL));
+});
+
+test("benchmark budget allows skipped benchmark runs with an override label", () => {
+  const enforcement = enforceBenchmarkBudget(
+    {
+      skipped: true,
+      reason: "base_metadata_invalid",
+    },
+    {
+      labels: [DEFAULT_SKIP_OVERRIDE_LABEL],
+    },
+  );
+
   assert.equal(enforcement.ok, true);
   assert.match(enforcement.message, /base_metadata_invalid/);
+  assert.match(enforcement.message, new RegExp(DEFAULT_SKIP_OVERRIDE_LABEL));
 });

--- a/tests/tooling/github-workflows.test.ts
+++ b/tests/tooling/github-workflows.test.ts
@@ -518,6 +518,7 @@ test("benchmark workflow comments from trusted code after a read-only benchmark 
   assert.match(budgetJob, /needs:\n\s+- pr-benchmark\b/);
   assert.match(budgetJob, /actions:\s*read/);
   assert.match(budgetJob, /contents:\s*read/);
+  assert.match(budgetJob, /issues:\s*read/);
   assert.doesNotMatch(budgetJob, /issues:\s*write/);
   assert.doesNotMatch(budgetJob, /pull-requests:\s*write/);
   assert.match(
@@ -526,9 +527,13 @@ test("benchmark workflow comments from trusted code after a read-only benchmark 
   );
   assert.match(budgetJob, /uses:\s*actions\/download-artifact@[0-9a-f]{40}\s*# v8\.0\.1/);
   assert.match(budgetJob, /name:\s*pr-benchmark/);
+  assert.match(budgetJob, /name:\s*Read current PR labels/);
+  assert.match(budgetJob, /GITHUB_TOKEN:\s*\$\{\{\s*github\.token\s*\}\}/);
+  assert.match(budgetJob, /process\.env\.GITHUB_API_URL \?\? "https:\/\/api\.github\.com"/);
+  assert.match(budgetJob, /labels\.map\(\(label\) => label\.name\)/);
   assert.match(
     budgetJob,
-    /node head\/bench\/enforce-pr-budget\.mjs --json benchmark-results\.json/,
+    /node head\/bench\/enforce-pr-budget\.mjs[\s\S]*--json benchmark-results\.json[\s\S]*--labels-json "\$PR_LABELS_JSON"/,
   );
 
   assert.match(commentJob, /needs:\n\s+- pr-benchmark\b/);


### PR DESCRIPTION
Takes over #1418 (by @ifer47 — original commit preserved with authorship) which went stale on a conflict with #1411's formatter-lane test.

## Problem

`enforce-pr-budget.mjs` returns `ok: true` for any skipped benchmark run, so a PR whose benchmark silently skips (e.g. unbuildable base, invalid metadata) merges with zero perf verification — a hole in the zero-cost regression gate.

## Approach (unchanged from #1418)

- A skipped benchmark now **fails** the budget gate by default, surfacing the skip reason.
- The `ci:allow-skipped-benchmark` label is the explicit, auditable override (`DEFAULT_SKIP_OVERRIDE_LABEL`).
- Workflow wiring passes PR labels through to the enforcement step.

Conflict resolution on top: kept #1411's "benchmark tasks gate the formatter without mutating the corpus" test alongside the new skip-blocking tests; merged imports accordingly.

Note for reviewers: adding the override label after the run does not retrigger the workflow — re-run the `pr-benchmark-budget` job manually after labeling.

Verified locally: `node --test tests/tooling/benchmark-budget.test.ts` (5 pass) and `tests/tooling/github-workflows.test.ts` (pass). Full verification on Actions.

Part of #1386. Supersedes #1418.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1424"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783764345&installation_id=136613492&pr_number=1424&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1424&signature=0c7bcd1dd9d20376a279f4ddfc261b9703e2b36dac42a84bb1990df2279edcd6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->