### PR TITLE
perf(canon): skip unchanged virtual and passthrough writes in materialization

### DIFF
--- a/crates/vize_canon/src/batch/materialize_fs.rs
+++ b/crates/vize_canon/src/batch/materialize_fs.rs
@@ -32,10 +32,11 @@ pub(super) fn ensure_materialize_root(path: &Path) -> io::Result<()> {
 }
 
 pub(super) fn write_if_changed(path: &Path, content: &[u8]) -> io::Result<()> {
-    // For stable control files, skipping same-content writes matters more than
-    // saving the write syscall itself: TypeScript/Corsa watch file mtimes and may
-    // invalidate internal state when `tsconfig.json` or stubs are touched. The
-    // length check avoids reading most stale files before the byte comparison.
+    // Skipping same-content writes matters more than saving the write syscall
+    // itself: TypeScript/Corsa watch file mtimes and may invalidate internal
+    // state when `tsconfig.json`, stubs, or materialized sources are touched.
+    // The length check avoids reading most stale files before the byte
+    // comparison.
     match fs::symlink_metadata(path) {
         Ok(metadata) if !metadata.file_type().is_file() || metadata.file_type().is_symlink() => {
             remove_path(path)?;
@@ -69,21 +70,6 @@ pub(super) fn write_file(path: &Path, content: &[u8]) -> io::Result<()> {
             Err(error)
         }
     }
-}
-
-pub(super) fn write_file_untracked(path: &Path, content: &[u8]) -> io::Result<()> {
-    fs::write(path, content)
-}
-
-pub(super) fn record_write_batch(calls: u64, bytes: u64) {
-    if calls == 0 {
-        return;
-    }
-    let profiler = global_profiler();
-    profiler.record_counter("io.write.calls", calls);
-    profiler.record_counter("io.write.attempted_bytes", bytes);
-    profiler.record_counter("io.write.bytes", bytes);
-    profiler.record_counter("syscall.fs.write.calls", calls);
 }
 
 fn file_bytes_match(path: &Path, expected: &[u8]) -> io::Result<bool> {

--- a/crates/vize_canon/src/batch/virtual_project/materialize.rs
+++ b/crates/vize_canon/src/batch/virtual_project/materialize.rs
@@ -9,8 +9,7 @@ use vize_carton::{FxHashSet, String as CompactString, profile};
 
 use crate::batch::error::CorsaResult;
 use crate::batch::materialize_fs::{
-    ensure_dir, ensure_materialize_root, prune_unexpected_entries, record_write_batch,
-    write_file_untracked, write_if_changed,
+    ensure_dir, ensure_materialize_root, prune_unexpected_entries, write_if_changed,
 };
 use crate::batch::runtime_deps::materialize_runtime_dependencies;
 
@@ -21,10 +20,11 @@ impl VirtualProject {
     ///
     /// The materialized tree is a cache, but Corsa observes it as a real project.
     /// We therefore prune only entries outside the expected file/dir set and
-    /// preserve nested runtime dependencies under `node_modules`. File writes are
-    /// batched with directory creation de-duplicated per parent path; tsconfig and
-    /// other stable control files still use `write_if_changed` because touching
-    /// them can invalidate TypeScript's own filesystem caches.
+    /// preserve nested runtime dependencies under `node_modules`. Directory
+    /// creation is de-duplicated per parent path, and every file write goes
+    /// through `write_if_changed`: warm reruns with unchanged content skip the
+    /// rewrite entirely, which avoids needless write IO and keeps mtimes stable
+    /// so TypeScript's own filesystem caches are not invalidated.
     pub fn materialize(&self) -> CorsaResult<()> {
         let expected_files = self.expected_materialized_files();
         profile!(
@@ -69,27 +69,23 @@ impl VirtualProject {
                     }
                 }
 
-                let virtual_written = self
-                    .virtual_files
+                // `write_if_changed` records IO counters per call: actually
+                // performed writes land in `io.write.*` (the curator audit
+                // consumes actually-written bytes), skipped same-content
+                // rewrites in `io.write.skipped.*`.
+                self.virtual_files
                     .par_iter()
-                    .map(|(_, file)| -> CorsaResult<u64> {
-                        write_file_untracked(&file.virtual_path, file.content.as_bytes())?;
-                        Ok(file.content.len() as u64)
-                    })
-                    .try_reduce(|| 0u64, |acc, bytes| Ok(acc + bytes))?;
-                let passthrough_written = self
-                    .passthrough_files
-                    .par_iter()
-                    .map(|(virtual_path, original_path)| -> CorsaResult<u64> {
+                    .try_for_each(|(_, file)| -> CorsaResult<()> {
+                        write_if_changed(&file.virtual_path, file.content.as_bytes())?;
+                        Ok(())
+                    })?;
+                self.passthrough_files.par_iter().try_for_each(
+                    |(virtual_path, original_path)| -> CorsaResult<()> {
                         let content = std::fs::read(original_path)?;
-                        write_file_untracked(virtual_path, &content)?;
-                        Ok(content.len() as u64)
-                    })
-                    .try_reduce(|| 0u64, |acc, bytes| Ok(acc + bytes))?;
-                record_write_batch(
-                    (self.virtual_files.len() + self.passthrough_files.len()) as u64,
-                    virtual_written + passthrough_written,
-                );
+                        write_if_changed(virtual_path, &content)?;
+                        Ok(())
+                    },
+                )?;
                 Ok(())
             })()
         )?;

--- a/crates/vize_canon/src/batch/virtual_project/tests.rs
+++ b/crates/vize_canon/src/batch/virtual_project/tests.rs
@@ -583,6 +583,70 @@ fn test_materialize_writes_relative_json_modules() {
 }
 
 #[test]
+fn materialize_skips_rewriting_unchanged_files() {
+    let case_dir = unique_case_dir("materialize-skip-unchanged");
+    let _ = fs::remove_dir_all(&case_dir);
+    let src_dir = case_dir.join("src");
+    fs::create_dir_all(&src_dir).unwrap();
+    let vue_path = src_dir.join("App.vue");
+    fs::write(
+        &vue_path,
+        r#"<script setup lang="ts">
+const message = 'Hello'
+</script>
+
+<template>
+  <div>{{ message }}</div>
+</template>
+"#,
+    )
+    .unwrap();
+    let ts_path = src_dir.join("tokens.ts");
+    fs::write(
+        &ts_path,
+        "import colors from './colors.tokens.json'\nvoid colors\n",
+    )
+    .unwrap();
+    fs::write(
+        src_dir.join("colors.tokens.json"),
+        "{\"primary\":\"#0057ff\"}\n",
+    )
+    .unwrap();
+
+    let mut project = VirtualProject::new(&case_dir).unwrap();
+    project.register_path(&vue_path).unwrap();
+    project.register_path(&ts_path).unwrap();
+    project.materialize().unwrap();
+
+    // One bulk virtual file and one passthrough mirror; rewriting either on
+    // the warm rerun below would bump its mtime back to "now".
+    let virtual_root = project.virtual_root().to_path_buf();
+    let tracked = [
+        virtual_root.join("src/App.vue.ts"),
+        virtual_root.join("src/colors.tokens.json"),
+    ];
+    let stale_mtime =
+        std::time::SystemTime::UNIX_EPOCH + std::time::Duration::from_secs(1_000_000_000);
+    for path in &tracked {
+        let file = fs::File::options().write(true).open(path).unwrap();
+        file.set_modified(stale_mtime).unwrap();
+    }
+
+    project.materialize().unwrap();
+
+    for path in &tracked {
+        assert_eq!(
+            fs::metadata(path).unwrap().modified().unwrap(),
+            stale_mtime,
+            "unchanged file should not be rewritten on warm rerun: {}",
+            path.display()
+        );
+    }
+
+    let _ = fs::remove_dir_all(&case_dir);
+}
+
+#[test]
 fn materialize_prunes_stale_virtual_project_entries() {
     let case_dir = unique_case_dir("materialize-gc");
     let _ = fs::remove_dir_all(&case_dir);


### PR DESCRIPTION
## Problem

`VirtualProject::materialize` rewrote every bulk virtual file and passthrough mirror unconditionally via `write_file_untracked` on each materialization. On warm reruns with unchanged content this costs roughly 1000 redundant write syscalls (~9.5MiB, ~26-37ms) and churns mtimes, which both invalidates TypeScript/Corsa filesystem caches and blocks future `.tsbuildinfo` incremental work.

## Approach

- Route the two bulk write call sites in `crates/vize_canon/src/batch/virtual_project/materialize.rs` through the existing `write_if_changed` helper, so same-content rewrites are skipped exactly like the tsconfig/stub control files already are. The tsconfig, stubs, and runtime-deps materialization paths are untouched.
- Counter semantics: `write_if_changed` records IO counters per call, so the external `record_write_batch` call would have double-counted and is removed (along with the now-unused `write_file_untracked`; this was their only caller). `io.write.calls`/`io.write.bytes` keep meaning actually-performed writes / actually-written bytes — consistent with the curator profile audit, which consumes `io.write.bytes` as real write volume — while skipped same-content rewrites are tracked separately under `io.write.skipped.*`.
- Updated the `materialize` doc comment, which previously described the unconditional batched writes.

## Test

`materialize_skips_rewriting_unchanged_files`: materializes a project containing both a virtual `.vue.ts` file and a passthrough JSON mirror, pins their mtimes to a fixed past timestamp, materializes again, and asserts the mtimes are unchanged (any rewrite would bump them to "now").

Verified locally with `cargo fmt`, `cargo clippy -p vize_canon --all-targets`, and `cargo test -p vize_canon` (323 passed). No measurements taken locally; the CI bench gate will quantify the warm-rerun saving.

Part of #1385

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1425"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783764482&installation_id=136613492&pr_number=1425&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1425&signature=0e239e9b43d02dce0a3f54f8ec6a770e3a7d29666a73f12bb5bed1aee65f0d17"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->