### PR TITLE
feat(croquis): collect array-form inject and same-file mixins/extends bindings

### DIFF
--- a/crates/vize_croquis/src/script_parser/process/options_api.rs
+++ b/crates/vize_croquis/src/script_parser/process/options_api.rs
@@ -2,7 +2,8 @@
 //!
 //! Walks `export default { ... }` / `defineComponent({ ... })` options objects
 //! to collect component registrations and template bindings (props, data,
-//! computed, methods, inject, setup) for the Options API and legacy Vue 2.7.
+//! computed, methods, inject, setup, same-file mixins/extends) for the
+//! Options API and legacy Vue 2.7.
 
 use oxc_ast::ast::{
     Argument, ArrayExpression, ArrayExpressionElement, BindingPattern, CallExpression,
@@ -158,7 +159,30 @@ pub(super) fn collect_options_api_template_bindings_from_options<'a>(
     options: &'a ObjectExpression<'a>,
     object_bindings: &FxHashMap<&'a str, &'a ObjectExpression<'a>>,
 ) {
-    collect_props_bindings(result, options, object_bindings);
+    let mut seen_mixins = FxHashSet::default();
+    collect_options_object_template_bindings(result, options, object_bindings, &mut seen_mixins);
+}
+
+/// Collects Options API template bindings from a single options
+/// `ObjectExpression`, recursing into same-file `mixins`/`extends` targets.
+///
+/// Deliberately dialect-agnostic: this helper only requires a plain
+/// `ObjectExpression`, so the upcoming legacy-Vue work (`Vue.extend({...})`
+/// callee recognition, issue #1392) can reuse it by unwrapping the call
+/// expression to its options-object argument before recursing.
+fn collect_options_object_template_bindings<'a>(
+    result: &mut ScriptParseResult,
+    options: &'a ObjectExpression<'a>,
+    object_bindings: &FxHashMap<&'a str, &'a ObjectExpression<'a>>,
+    seen_mixins: &mut FxHashSet<&'a str>,
+) {
+    collect_array_or_object_option_bindings(
+        result,
+        options,
+        object_bindings,
+        "props",
+        BindingType::Props,
+    );
     collect_object_option_bindings(
         result,
         options,
@@ -173,7 +197,9 @@ pub(super) fn collect_options_api_template_bindings_from_options<'a>(
         "methods",
         BindingType::Options,
     );
-    collect_object_option_bindings(
+    // `inject` accepts both the array form (`inject: ['foo']`) and the object
+    // form, so it is routed through the array-or-object collector like props.
+    collect_array_or_object_option_bindings(
         result,
         options,
         object_bindings,
@@ -201,6 +227,100 @@ pub(super) fn collect_options_api_template_bindings_from_options<'a>(
         "setup",
         BindingType::Options,
     );
+    collect_mixins_bindings(result, options, object_bindings, seen_mixins);
+    collect_extends_bindings(result, options, object_bindings, seen_mixins);
+}
+
+/// Merges template bindings contributed by same-file `mixins` entries.
+///
+/// Only same-file targets are resolved: inline object literals and
+/// identifiers whose `const` initializer is an object literal in this module.
+/// Imported mixins are deliberately ignored — resolving them requires
+/// cross-file analysis, which is deferred.
+fn collect_mixins_bindings<'a>(
+    result: &mut ScriptParseResult,
+    options: &'a ObjectExpression<'a>,
+    object_bindings: &FxHashMap<&'a str, &'a ObjectExpression<'a>>,
+    seen_mixins: &mut FxHashSet<&'a str>,
+) {
+    let Some(Expression::ArrayExpression(array)) = option_expression_property(options, "mixins")
+    else {
+        return;
+    };
+
+    for element in &array.elements {
+        let Some(expression) = element.as_expression() else {
+            continue;
+        };
+        collect_mixin_target_bindings(result, expression, object_bindings, seen_mixins);
+    }
+}
+
+/// Merges template bindings contributed by a same-file `extends` target.
+/// Same resolution rules and deferral as [`collect_mixins_bindings`].
+fn collect_extends_bindings<'a>(
+    result: &mut ScriptParseResult,
+    options: &'a ObjectExpression<'a>,
+    object_bindings: &FxHashMap<&'a str, &'a ObjectExpression<'a>>,
+    seen_mixins: &mut FxHashSet<&'a str>,
+) {
+    let Some(expression) = option_expression_property(options, "extends") else {
+        return;
+    };
+    collect_mixin_target_bindings(result, expression, object_bindings, seen_mixins);
+}
+
+/// Resolves a single mixin/extends target expression and merges its option
+/// bindings. The seen-set guards against mixin cycles (A mixes B mixes A);
+/// inline object literals cannot cycle because the AST is a tree.
+fn collect_mixin_target_bindings<'a>(
+    result: &mut ScriptParseResult,
+    expression: &'a Expression<'a>,
+    object_bindings: &FxHashMap<&'a str, &'a ObjectExpression<'a>>,
+    seen_mixins: &mut FxHashSet<&'a str>,
+) {
+    match expression {
+        Expression::ObjectExpression(object) => {
+            collect_options_object_template_bindings(result, object, object_bindings, seen_mixins);
+        }
+        Expression::Identifier(identifier) => {
+            let name = identifier.name.as_str();
+            if !seen_mixins.insert(name) {
+                return;
+            }
+            if let Some(object) = object_bindings.get(name).copied() {
+                collect_options_object_template_bindings(
+                    result,
+                    object,
+                    object_bindings,
+                    seen_mixins,
+                );
+            }
+        }
+        Expression::ParenthesizedExpression(parenthesized) => collect_mixin_target_bindings(
+            result,
+            &parenthesized.expression,
+            object_bindings,
+            seen_mixins,
+        ),
+        Expression::TSAsExpression(ts_as) => {
+            collect_mixin_target_bindings(result, &ts_as.expression, object_bindings, seen_mixins)
+        }
+        Expression::TSSatisfiesExpression(ts_satisfies) => collect_mixin_target_bindings(
+            result,
+            &ts_satisfies.expression,
+            object_bindings,
+            seen_mixins,
+        ),
+        Expression::TSNonNullExpression(ts_non_null) => collect_mixin_target_bindings(
+            result,
+            &ts_non_null.expression,
+            object_bindings,
+            seen_mixins,
+        ),
+        // Imported mixins, call expressions, etc. — deferred.
+        _ => {}
+    }
 }
 
 fn add_nuxt2_template_globals(result: &mut ScriptParseResult) {
@@ -216,65 +336,75 @@ fn add_nuxt2_template_globals(result: &mut ScriptParseResult) {
     }
 }
 
-fn collect_props_bindings<'a>(
+/// Collects bindings from an option whose value may be an array of string
+/// literals (`['foo', 'bar']`), an object literal keyed by binding name, or a
+/// same-file identifier resolving to such an object. Used by `props` and
+/// `inject`, which both accept the array and object forms.
+fn collect_array_or_object_option_bindings<'a>(
     result: &mut ScriptParseResult,
     options: &'a ObjectExpression<'a>,
     object_bindings: &FxHashMap<&'a str, &'a ObjectExpression<'a>>,
+    key_name: &str,
+    binding_type: BindingType,
 ) {
-    let Some(props) = option_expression_property(options, "props") else {
+    let Some(expression) = option_expression_property(options, key_name) else {
         return;
     };
-
-    match props {
-        Expression::ArrayExpression(array) => {
-            collect_array_string_bindings(result, array, BindingType::Props);
-        }
-        Expression::ObjectExpression(object) => {
-            collect_object_property_bindings(result, object, BindingType::Props);
-        }
-        Expression::Identifier(identifier) => {
-            if let Some(object) = object_bindings.get(identifier.name.as_str()).copied() {
-                collect_object_property_bindings(result, object, BindingType::Props);
-            }
-        }
-        Expression::ParenthesizedExpression(parenthesized) => {
-            collect_props_bindings_from_expression(
-                result,
-                &parenthesized.expression,
-                object_bindings,
-            )
-        }
-        Expression::TSAsExpression(ts_as) => {
-            collect_props_bindings_from_expression(result, &ts_as.expression, object_bindings)
-        }
-        Expression::TSSatisfiesExpression(ts_satisfies) => collect_props_bindings_from_expression(
-            result,
-            &ts_satisfies.expression,
-            object_bindings,
-        ),
-        Expression::TSNonNullExpression(ts_non_null) => {
-            collect_props_bindings_from_expression(result, &ts_non_null.expression, object_bindings)
-        }
-        _ => {}
-    }
+    collect_array_or_object_bindings_from_expression(
+        result,
+        expression,
+        object_bindings,
+        binding_type,
+    );
 }
 
-fn collect_props_bindings_from_expression<'a>(
+fn collect_array_or_object_bindings_from_expression<'a>(
     result: &mut ScriptParseResult,
     expression: &'a Expression<'a>,
     object_bindings: &FxHashMap<&'a str, &'a ObjectExpression<'a>>,
+    binding_type: BindingType,
 ) {
     match expression {
         Expression::ArrayExpression(array) => {
-            collect_array_string_bindings(result, array, BindingType::Props);
+            collect_array_string_bindings(result, array, binding_type);
         }
         Expression::ObjectExpression(object) => {
-            collect_object_property_bindings(result, object, BindingType::Props);
+            collect_object_property_bindings(result, object, binding_type);
         }
         Expression::Identifier(identifier) => {
             if let Some(object) = object_bindings.get(identifier.name.as_str()).copied() {
-                collect_object_property_bindings(result, object, BindingType::Props);
+                collect_object_property_bindings(result, object, binding_type);
             }
+        }
+        Expression::ParenthesizedExpression(parenthesized) => {
+            collect_array_or_object_bindings_from_expression(
+                result,
+                &parenthesized.expression,
+                object_bindings,
+                binding_type,
+            )
+        }
+        Expression::TSAsExpression(ts_as) => collect_array_or_object_bindings_from_expression(
+            result,
+            &ts_as.expression,
+            object_bindings,
+            binding_type,
+        ),
+        Expression::TSSatisfiesExpression(ts_satisfies) => {
+            collect_array_or_object_bindings_from_expression(
+                result,
+                &ts_satisfies.expression,
+                object_bindings,
+                binding_type,
+            )
+        }
+        Expression::TSNonNullExpression(ts_non_null) => {
+            collect_array_or_object_bindings_from_expression(
+                result,
+                &ts_non_null.expression,
+                object_bindings,
+                binding_type,
+            )
         }
         _ => {}
     }

--- a/crates/vize_croquis/src/script_parser/tests.rs
+++ b/crates/vize_croquis/src/script_parser/tests.rs
@@ -489,6 +489,183 @@ export default {
 }
 
 #[test]
+fn test_parse_options_api_inject_array_bindings() {
+    let source = r#"
+export default {
+  inject: ['theme', 'apiClient'],
+}
+"#;
+    let result = parse_script_with_options(
+        source,
+        ScriptParserOptions {
+            options_api: true,
+            legacy_vue2: false,
+        },
+    );
+
+    assert!(result.bindings.contains("theme"));
+    assert!(result.bindings.contains("apiClient"));
+}
+
+#[test]
+fn test_parse_options_api_inject_object_bindings() {
+    // Regression: the object form must keep working now that `inject` is
+    // routed through the array-or-object collector.
+    let source = r#"
+export default {
+  inject: {
+    localTheme: { from: 'theme', default: 'light' },
+    api: 'apiKey',
+  },
+}
+"#;
+    let result = parse_script_with_options(
+        source,
+        ScriptParserOptions {
+            options_api: true,
+            legacy_vue2: false,
+        },
+    );
+
+    assert!(result.bindings.contains("localTheme"));
+    assert!(result.bindings.contains("api"));
+}
+
+#[test]
+fn test_parse_options_api_mixins_same_file_bindings() {
+    let source = r#"
+const CounterMixin = {
+  inject: ['injectedFromMixin'],
+  data() {
+    return { count: 0 }
+  },
+  methods: {
+    increment() {},
+  },
+}
+
+export default {
+  mixins: [CounterMixin, { computed: { inlineDoubled() { return 2 } } }],
+  methods: {
+    save() {},
+  },
+}
+"#;
+    let result = parse_script_with_options(
+        source,
+        ScriptParserOptions {
+            options_api: true,
+            legacy_vue2: false,
+        },
+    );
+
+    for name in [
+        "count",
+        "increment",
+        "injectedFromMixin",
+        "inlineDoubled",
+        "save",
+    ] {
+        assert!(result.bindings.contains(name), "missing binding {name}");
+    }
+}
+
+#[test]
+fn test_parse_options_api_extends_same_file_bindings() {
+    let source = r#"
+const BaseComponent = {
+  props: ['baseLabel'],
+  methods: {
+    baseMethod() {},
+  },
+}
+
+export default {
+  extends: BaseComponent,
+  data() {
+    return { own: 1 }
+  },
+}
+"#;
+    let result = parse_script_with_options(
+        source,
+        ScriptParserOptions {
+            options_api: true,
+            legacy_vue2: false,
+        },
+    );
+
+    for name in ["baseLabel", "baseMethod", "own"] {
+        assert!(result.bindings.contains(name), "missing binding {name}");
+    }
+}
+
+#[test]
+fn test_parse_options_api_mixin_cycle_terminates() {
+    // A and B reference each other; the seen-set guard must stop the
+    // recursion while still merging bindings from both sides.
+    let source = r#"
+const MixinA = {
+  mixins: [MixinB],
+  data() {
+    return { fromA: 1 }
+  },
+}
+
+const MixinB = {
+  mixins: [MixinA],
+  data() {
+    return { fromB: 2 }
+  },
+}
+
+export default {
+  mixins: [MixinA],
+}
+"#;
+    let result = parse_script_with_options(
+        source,
+        ScriptParserOptions {
+            options_api: true,
+            legacy_vue2: false,
+        },
+    );
+
+    assert!(result.bindings.contains("fromA"));
+    assert!(result.bindings.contains("fromB"));
+}
+
+#[test]
+fn test_parse_options_api_imported_mixin_ignored() {
+    // Imported mixins require cross-file resolution, which is deferred:
+    // they must not contribute bindings and must not break collection of
+    // the component's own options.
+    let source = r#"
+import SharedMixin from './shared-mixin'
+
+export default {
+  mixins: [SharedMixin],
+  data() {
+    return { own: 1 }
+  },
+}
+"#;
+    let result = parse_script_with_options(
+        source,
+        ScriptParserOptions {
+            options_api: true,
+            legacy_vue2: false,
+        },
+    );
+
+    assert!(result.bindings.contains("own"));
+    // The import identifier itself stays an ordinary script binding (imports
+    // are always template-usable); the mixin pass must simply not resolve
+    // into the imported module.
+    assert!(result.bindings.contains("SharedMixin"));
+}
+
+#[test]
 fn test_parse_class_component_decorated_members() {
     // Class components are auto-detected by shape (default export is a
     // class), independent of the `options_api` flag.


### PR DESCRIPTION
## Problem

croquis drops Options API bindings that templates legitimately reference, causing TS2304 false positives in `vize check`, missing LSP completions, and gaps for future codegen wiring:

- `inject` was routed through the object-only collector (`collect_object_option_bindings`), so the array form `inject: ['foo', 'bar']` was silently dropped.
- `mixins: [SomeMixin]` and `extends: Base` contributed no bindings at all, even when the target is an object declared in the same file.

## Approach

- Route `inject` through `option_expression_property` like `props`: an `ArrayExpression` now hits the existing `collect_array_string_bindings`, while the object form (and same-file identifier indirection, parens, and TS wrappers) keeps working. The previously duplicated props match arms are consolidated into one shared `collect_array_or_object_option_bindings` helper parameterized by `BindingType`, so props and inject share a single code path.
- Add a mixins/extends pass: for each `mixins` array entry and the `extends` value, inline object literals and identifiers resolving to a same-file `const` object declaration (via the existing `object_bindings` map) are merged through the regular options-object collector, recursively (a mixin's own `mixins`/`extends` are honored). A seen-set of identifier names guards against cycles (A mixes B mixes A); inline literals cannot cycle since the AST is a tree.
- The recursive collector (`collect_options_object_template_bindings`) is deliberately dialect-agnostic — a plain helper over an `ObjectExpression` — so the upcoming legacy-Vue work (`Vue.extend(...)` callee recognition, #1392) can reuse it by just adding a callee unwrap. Noted in a doc comment on the helper.

## Deferred scope

Imported-mixin resolution (`import SharedMixin from './mixin'`) is deferred entirely — it requires cross-file analysis. Imported mixin targets are silently ignored by the mixin pass (the import identifier itself remains an ordinary script binding, as before).

## Tests

- array-form `inject`
- object-form `inject` (regression)
- same-file mixin via const + inline object mixin (incl. mixin-provided `inject`)
- same-file `extends`
- mixin cycle (A mixes B mixes A) terminates and merges both sides
- imported mixin is ignored without breaking own-options collection

## Verification

- `cargo fmt`
- `cargo clippy -p vize_croquis` — clean
- `cargo test -p vize_croquis` — 181 passed, 0 failed (no snapshot churn)

Part of #1388

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1426"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783764501&installation_id=136613492&pr_number=1426&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1426&signature=d07b14c201ba6669d7d7dd8abf71e2ffe05baea4265374ecc4caa4a528b7cc48"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->