### PR TITLE
fix(maestro): stop running the SFC formatter on standalone HTML documents

### DIFF
--- a/crates/vize_maestro/src/server/handlers.rs
+++ b/crates/vize_maestro/src/server/handlers.rs
@@ -823,6 +823,13 @@ impl LanguageServer for MaestroServer {
 
         let uri = &params.text_document.uri;
 
+        // Standalone (petite-vue) HTML documents are not SFCs: running the SFC
+        // formatter over them corrupts the file. Skip until a dedicated HTML
+        // formatter lands (#1393).
+        if crate::utils::is_standalone_html_path(uri.path()) {
+            return Ok(None);
+        }
+
         let Some(doc) = self.state.documents.get(uri) else {
             return Ok(None);
         };
@@ -847,6 +854,11 @@ impl LanguageServer for MaestroServer {
 
         let uri = &params.text_document.uri;
 
+        // See `formatting`: standalone HTML must not go through the SFC formatter.
+        if crate::utils::is_standalone_html_path(uri.path()) {
+            return Ok(None);
+        }
+
         let Some(doc) = self.state.documents.get(uri) else {
             return Ok(None);
         };
@@ -859,5 +871,73 @@ impl LanguageServer for MaestroServer {
         }
         #[cfg(not(feature = "glyph"))]
         Ok(None)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tower_lsp::{
+        LspService,
+        lsp_types::{FormattingOptions, TextDocumentIdentifier, Url, WorkDoneProgressParams},
+    };
+
+    fn formatting_params(uri: Url) -> DocumentFormattingParams {
+        DocumentFormattingParams {
+            text_document: TextDocumentIdentifier { uri },
+            options: FormattingOptions::default(),
+            work_done_progress_params: WorkDoneProgressParams::default(),
+        }
+    }
+
+    #[test]
+    fn formatting_returns_no_edits_for_standalone_html() {
+        let (service, _socket) = LspService::new(MaestroServer::new);
+        let server = service.inner();
+        server
+            .state
+            .apply_lsp_initialization_options(Some(&serde_json::json!({ "formatting": true })));
+
+        let uri = Url::parse("file:///index.html").unwrap();
+        let source = "<!DOCTYPE html>\n<html><body>\n<div   v-scope=\"{ count: 0 }\" >{{ count }}</div>\n</body></html>\n";
+        server
+            .state
+            .documents
+            .open(uri.clone(), source.to_string(), 1, "html".to_string());
+
+        let edits =
+            futures::executor::block_on(server.formatting(formatting_params(uri.clone()))).unwrap();
+        assert!(
+            edits.is_none(),
+            "the SFC formatter must not touch standalone HTML documents"
+        );
+
+        let range_params = DocumentRangeFormattingParams {
+            text_document: TextDocumentIdentifier { uri },
+            range: Range::new(Position::new(0, 0), Position::new(0, 1)),
+            options: FormattingOptions::default(),
+            work_done_progress_params: WorkDoneProgressParams::default(),
+        };
+        let edits = futures::executor::block_on(server.range_formatting(range_params)).unwrap();
+        assert!(
+            edits.is_none(),
+            "range formatting must not touch standalone HTML documents"
+        );
+
+        // Guard against the gate over-matching: SFC formatting must still work.
+        #[cfg(feature = "glyph")]
+        {
+            let vue_uri = Url::parse("file:///App.vue").unwrap();
+            let vue_source = "<template>\n<div>hello</div>\n</template>\n";
+            server.state.documents.open(
+                vue_uri.clone(),
+                vue_source.to_string(),
+                1,
+                "vue".to_string(),
+            );
+            let edits =
+                futures::executor::block_on(server.formatting(formatting_params(vue_uri))).unwrap();
+            assert!(edits.is_some(), "Vue SFC formatting must keep working");
+        }
     }
 }


### PR DESCRIPTION
## Problem

VS Code registers the `html` language id with the vize LSP, so format-on-save runs the Vue SFC formatter over standalone petite-vue HTML documents. The SFC formatter does not understand plain HTML and can mangle the file — a user-data-corruption bug.

## Approach

- Gate the `formatting` and `range_formatting` LSP handlers on the existing `crate::utils::is_standalone_html_path`, returning `Ok(None)` (no edits) for `.html`/`.htm` URIs before the document is fetched or formatted.
- Add a regression test that opens an `.html` document with formatting enabled and asserts both handlers return no edits, plus a guard that `.vue` SFC formatting keeps working. The test fails without the gate.

This is an explicit stopgap: the real fix is a dedicated HTML document formatter, tracked in #1393's later items. This PR only stops the SFC formatter from corrupting standalone HTML.

## Verification

- `cargo fmt`
- `cargo clippy -p vize_maestro --all-targets` (no new warnings)
- `cargo test -p vize_maestro` (305 tests pass)

Part of #1393

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1427"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783764532&installation_id=136613492&pr_number=1427&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1427&signature=fec582c51239d54db9014ac3c259b5bfdb2249e0951b85de4ec12119fc6179ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->