### PR TITLE
ci(bench): gate sharded typecheck in PR benchmark

### DIFF
--- a/bench/compare-pr.mjs
+++ b/bench/compare-pr.mjs
@@ -235,13 +235,22 @@ export function makeTasks(inputDir, taskFilter) {
     },
     {
       id: "check",
-      label: "Type check",
+      label: "Type check (1T)",
       // --servers 1 pins the lane to a single Corsa server so it isolates
       // single-program performance and stays deterministic on shared CI
-      // runners. The trade-off is that multi-server sharding regressions are
-      // not covered here; a dedicated multi-server lane is tracked in #1386
-      // (PR3) and needs its own noise validation before it can gate PRs.
+      // runners. Keep this id stable so `--tasks check` still selects the
+      // single-program lane.
       args: ["check", pattern, "--quiet", "--servers", "1", "--tsconfig", tsconfig],
+      allowNonZeroExit: true,
+      enabled: existsSync(tsconfig),
+    },
+    {
+      id: "check-max",
+      label: "Type check (max)",
+      // Omit --servers so vize uses the same auto-tuned Corsa sharding path
+      // measured by the tool benchmark. This catches regressions hidden by the
+      // single-server lane without weakening the single-program signal above.
+      args: ["check", pattern, "--quiet", "--tsconfig", tsconfig],
       allowNonZeroExit: true,
       enabled: existsSync(tsconfig),
     },

--- a/tests/tooling/benchmark-budget.test.ts
+++ b/tests/tooling/benchmark-budget.test.ts
@@ -1,4 +1,7 @@
 import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { test } from "node:test";
 
 import { createBenchmarkBudget, makeTasks, renderMarkdown } from "../../bench/compare-pr.mjs";
@@ -90,6 +93,51 @@ test("benchmark tasks gate the formatter without mutating the corpus", () => {
     onlyFmt.map((task) => task.id),
     ["fmt"],
   );
+});
+
+test("benchmark tasks gate both single-server and sharded typecheck paths", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "vize-bench-tasks-"));
+  try {
+    const tsconfig = path.join(tempDir, "tsconfig.json");
+    fs.writeFileSync(tsconfig, "{}\n");
+
+    const tasks = makeTasks(tempDir, "");
+    const checkTasks = tasks.filter((task) => task.id.startsWith("check"));
+
+    assert.deepEqual(
+      checkTasks.map((task) => task.id),
+      ["check", "check-max"],
+    );
+
+    const singleServer = checkTasks.find((task) => task.id === "check");
+    assert.ok(singleServer);
+    assert.deepEqual(singleServer.args, [
+      "check",
+      ".",
+      "--quiet",
+      "--servers",
+      "1",
+      "--tsconfig",
+      tsconfig,
+    ]);
+
+    const sharded = checkTasks.find((task) => task.id === "check-max");
+    assert.ok(sharded);
+    assert.deepEqual(sharded.args, ["check", ".", "--quiet", "--tsconfig", tsconfig]);
+    assert.equal(
+      sharded.allowNonZeroExit,
+      true,
+      "type-check diagnostics are benchmarked even when the corpus reports errors",
+    );
+
+    const onlySharded = makeTasks(tempDir, "check-max");
+    assert.deepEqual(
+      onlySharded.map((task) => task.id),
+      ["check-max"],
+    );
+  } finally {
+    fs.rmSync(tempDir, { force: true, recursive: true });
+  }
 });
 
 test("benchmark budget blocks skipped benchmark runs without an override label", () => {


### PR DESCRIPTION
## Summary
- add a PR benchmark lane for the auto-tuned sharded `vize check` path
- keep the existing `check` task id pinned to the single-server lane for filter compatibility
- cover both task selections in the benchmark budget tooling test

Part of #1386.

## Verification
- `node --test tests/tooling/benchmark-budget.test.ts tests/tooling/github-workflows.test.ts`
- `vp run --workspace-root check:ci`

The benchmark latency and noise profile should be validated by this PR's Actions run.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1428"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783772075&installation_id=136613492&pr_number=1428&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1428&signature=85a2790ddb7e0eed66f6d197d2e486cb170751dc6da53aea3f1d957debdfe4a7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->