### PR TITLE
perf(vize): use mimalloc by default and gate allocation profiling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1408,6 +1408,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a45a52f43e1c16f667ccfe4dd8c85b7f7c204fd5e3bf46c5b0db9a5c3c0b8e9"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "libredox"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1544,6 +1553,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "mimalloc"
+version = "0.1.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d4139bb28d14ad1facf21d5eb8825051b326e172d216b39f6d31df53cc97862"
+dependencies = [
+ "libmimalloc-sys",
 ]
 
 [[package]]
@@ -3381,6 +3399,7 @@ dependencies = [
  "glob",
  "ignore",
  "insta",
+ "mimalloc",
  "oxc_allocator",
  "oxc_ast",
  "oxc_codegen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,6 +122,9 @@ sha2 = "=0.11.0"
 htmlize = { version = "=1.1.0", features = ["unescape"] }
 libc = "=0.2.186"
 
+# Allocator
+mimalloc = "=0.1.52"
+
 # CSS
 lightningcss = "=1.0.0-alpha.71"
 

--- a/crates/vize/Cargo.toml
+++ b/crates/vize/Cargo.toml
@@ -20,6 +20,7 @@ path = "src/lib.rs"
 default = ["glyph", "maestro"]
 glyph = ["dep:vize_glyph", "vize_maestro?/glyph"]
 maestro = ["dep:vize_maestro"]
+profiling = []
 # Opt-in legacy Vue (v0 / v1 / v2) support. Off by default so the Vue 3 binary
 # never activates or compiles it; turns on the legacy feature across the stack.
 legacy = ["vize_canon/legacy", "vize_maestro?/legacy"]
@@ -72,6 +73,9 @@ oxc_transformer = { workspace = true }
 
 # Home/config directory detection
 dirs.workspace = true
+
+# Process allocator for native CLI hot paths
+mimalloc.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/vize/src/commands/build/runner/mod.rs
+++ b/crates/vize/src/commands/build/runner/mod.rs
@@ -19,8 +19,9 @@ use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 use vize_carton::String;
 use vize_carton::cstr;
 use vize_carton::profile;
-use vize_carton::profiler::{allocation_snapshot, global_profiler};
+use vize_carton::profiler::global_profiler;
 
+use crate::profile_support;
 use vize_curator::profile::{
     ProfileFileRow, ProfilePhase, ProfilePhaseKind, ProfileReport, print_profile_report,
 };
@@ -345,7 +346,7 @@ pub(crate) fn run(args: BuildArgs) {
     // Profile breakdown
     if args.profile {
         let profiler = global_profiler();
-        let allocation_summary = allocation_snapshot();
+        let allocation_summary = profile_support::allocation_snapshot();
         let counter_summary = profiler.counter_summary();
         let operation_summary = profiler.summary();
         profiler.disable();
@@ -462,7 +463,7 @@ pub(crate) fn run(args: BuildArgs) {
             throughput_bytes: Some(total_bytes),
             operations: Some(&operation_summary),
             counters: Some(&counter_summary),
-            allocations: Some(allocation_summary),
+            allocations: allocation_summary,
             recommendations: &recommendations,
         };
         print_profile_report(&report);

--- a/crates/vize/src/commands/check/runner/mod.rs
+++ b/crates/vize/src/commands/check/runner/mod.rs
@@ -15,11 +15,9 @@ use serde_json::{Map, Value};
 use vize_canon::{
     BatchTypeChecker, BatchTypeCheckerOptions, batch::TypeChecker as BatchTypeCheckerTrait,
 };
-use vize_carton::{
-    FxHashSet, String, cstr,
-    profiler::{allocation_snapshot, global_profiler},
-};
+use vize_carton::{FxHashSet, String, cstr, profiler::global_profiler};
 
+use crate::profile_support;
 use vize_curator::profile::{ProfilePhase, ProfilePhaseKind, ProfileReport, print_profile_report};
 
 use super::{
@@ -431,7 +429,7 @@ pub(crate) fn run_direct(args: &CheckArgs) {
 
     if args.profile {
         let profiler = global_profiler();
-        let allocation_summary = allocation_snapshot();
+        let allocation_summary = profile_support::allocation_snapshot();
         let counter_summary = profiler.counter_summary();
         let operation_summary = profiler.summary();
         profiler.disable();
@@ -515,7 +513,7 @@ pub(crate) fn run_direct(args: &CheckArgs) {
             throughput_bytes: Some(virtual_bytes),
             operations: Some(&operation_summary),
             counters: Some(&counter_summary),
-            allocations: Some(allocation_summary),
+            allocations: allocation_summary,
             recommendations: &recommendations,
         };
         print_profile_report(&report);

--- a/crates/vize/src/commands/check/runner/socket.rs
+++ b/crates/vize/src/commands/check/runner/socket.rs
@@ -12,14 +12,14 @@ use std::{
     time::{Duration, Instant},
 };
 
-use vize_carton::{
-    String, cstr, profile,
-    profiler::{allocation_snapshot, global_profiler},
-};
+use vize_carton::{String, cstr, profile, profiler::global_profiler};
 
-use crate::commands::check::{
-    CheckArgs, JsonRpcResponse, ServerCheckResult,
-    reporting::{JsonFileResult, JsonOutput},
+use crate::{
+    commands::check::{
+        CheckArgs, JsonRpcResponse, ServerCheckResult,
+        reporting::{JsonFileResult, JsonOutput},
+    },
+    profile_support,
 };
 
 use super::{collect::collect_vue_files, diagnostics::save_virtual_ts_for_path, display_path};
@@ -273,7 +273,7 @@ pub(crate) fn run_with_socket(args: &CheckArgs, socket_path: &str) {
     );
     if args.profile {
         let profiler = global_profiler();
-        let allocation_summary = allocation_snapshot();
+        let allocation_summary = profile_support::allocation_snapshot();
         let counter_summary = profiler.counter_summary();
         let operation_summary = profiler.summary();
         profiler.disable();
@@ -326,7 +326,7 @@ pub(crate) fn run_with_socket(args: &CheckArgs, socket_path: &str) {
             throughput_bytes: None,
             operations: Some(&operation_summary),
             counters: Some(&counter_summary),
-            allocations: Some(allocation_summary),
+            allocations: allocation_summary,
             recommendations: &recommendations,
         };
         print_profile_report(&report);

--- a/crates/vize/src/commands/fmt.rs
+++ b/crates/vize/src/commands/fmt.rs
@@ -11,13 +11,10 @@ use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::time::{Duration, Instant};
-use vize_carton::{
-    cstr, profile,
-    profiler::{allocation_snapshot, global_profiler},
-};
+use vize_carton::{cstr, profile, profiler::global_profiler};
 use vize_glyph::{Allocator, FormatOptions, format_sfc_with_allocator};
 
-use crate::config;
+use crate::{config, profile_support};
 use vize_curator::profile::{
     ProfileFileRow, ProfilePhase, ProfilePhaseKind, ProfileReport, print_profile_report,
 };
@@ -296,7 +293,7 @@ pub fn run(args: FmtArgs) {
             errored
         );
         let profiler = global_profiler();
-        let allocation_summary = allocation_snapshot();
+        let allocation_summary = profile_support::allocation_snapshot();
         let counter_summary = profiler.counter_summary();
         let operation_summary = profiler.summary();
         profiler.disable();
@@ -311,7 +308,7 @@ pub fn run(args: FmtArgs) {
             throughput_bytes: Some(total_bytes),
             operations: Some(&operation_summary),
             counters: Some(&counter_summary),
-            allocations: Some(allocation_summary),
+            allocations: allocation_summary,
             recommendations: &recommendations,
         };
         print_profile_report(&report);

--- a/crates/vize/src/commands/lint/mod.rs
+++ b/crates/vize/src/commands/lint/mod.rs
@@ -20,12 +20,10 @@ use std::sync::Mutex;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 use std::time::Instant;
-use vize_carton::{
-    String, ToCompactString, cstr, profile,
-    profiler::{allocation_snapshot, global_profiler},
-};
+use vize_carton::{String, ToCompactString, cstr, profile, profiler::global_profiler};
 use vize_patina::{HelpLevel, LintPreset, Linter, OutputFormat, format_results, format_summary};
 
+use crate::profile_support;
 use vize_curator::profile::{
     ProfileFileRow, ProfilePhase, ProfilePhaseKind, ProfileReport, print_profile_report,
 };
@@ -248,11 +246,11 @@ pub fn run(args: LintArgs) {
     let output_time = output_start.elapsed();
     let (operation_summary, counter_summary, allocation_summary) = if args.profile {
         let profiler = global_profiler();
-        let allocation = allocation_snapshot();
+        let allocation = profile_support::allocation_snapshot();
         let counters = profiler.counter_summary();
         let operations = profiler.summary();
         profiler.disable();
-        (Some(operations), Some(counters), Some(allocation))
+        (Some(operations), Some(counters), allocation)
     } else {
         (None, None, None)
     };

--- a/crates/vize/src/lib.rs
+++ b/crates/vize/src/lib.rs
@@ -21,6 +21,7 @@
 
 mod commands;
 mod config;
+mod profile_support;
 
 /// Shared native CLI entrypoint.
 pub mod cli;

--- a/crates/vize/src/main.rs
+++ b/crates/vize/src/main.rs
@@ -1,8 +1,13 @@
 //! Native CLI binary for Vize.
 
+#[cfg(not(feature = "profiling"))]
 #[global_allocator]
-static GLOBAL_ALLOCATOR: vize_carton::profiler::ProfilingAllocator =
-    vize_carton::profiler::ProfilingAllocator::new();
+static GLOBAL_ALLOCATOR: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
+#[cfg(feature = "profiling")]
+#[global_allocator]
+static GLOBAL_ALLOCATOR: vize_carton::profiler::ProfilingAllocator<mimalloc::MiMalloc> =
+    vize_carton::profiler::ProfilingAllocator::from_allocator(mimalloc::MiMalloc);
 
 fn main() {
     vize::cli::run_from_env();

--- a/crates/vize/src/profile_support.rs
+++ b/crates/vize/src/profile_support.rs
@@ -1,0 +1,16 @@
+//! CLI profile helpers whose behavior depends on binary build features.
+
+use vize_carton::profiler::AllocationSnapshot;
+
+#[inline]
+pub(crate) fn allocation_snapshot() -> Option<AllocationSnapshot> {
+    #[cfg(feature = "profiling")]
+    {
+        Some(vize_carton::profiler::allocation_snapshot())
+    }
+
+    #[cfg(not(feature = "profiling"))]
+    {
+        None
+    }
+}


### PR DESCRIPTION
## Summary
- use mimalloc as the default native vize CLI allocator
- move allocation-pressure profiling behind the opt-in `profiling` cargo feature
- hide allocation tables in default profile reports so timing/counter profiling stays accurate without misleading zero allocation snapshots

Refs #1385.

## Local checks
- `cargo fmt --check`
- `cargo check -p vize`
- `cargo check -p vize --no-default-features`
- `cargo check -p vize --features profiling`
- `cargo check -p vize --no-default-features --features profiling`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1429"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->