### PR TITLE
fix(croquis): classify class prop decorators as props

### DIFF
--- a/crates/vize_croquis/src/script_parser/process/class_component.rs
+++ b/crates/vize_croquis/src/script_parser/process/class_component.rs
@@ -9,7 +9,8 @@
 //!
 //! | Class member                  | Binding type | Options API equivalent |
 //! |-------------------------------|--------------|------------------------|
-//! | property field / `accessor`   | `Data`       | `data()`               |
+//! | `@Prop`-style field/accessor  | `Props`      | `props`                |
+//! | other property field/accessor | `Data`       | `data()`               |
 //! | method                        | `Options`    | `methods`              |
 //! | `get` / `set` accessor        | `Options`    | `computed`             |
 //!
@@ -25,16 +26,17 @@
 //! the class body and are skipped, along with `static` members (not on the
 //! instance), `declare` fields, computed keys, and the constructor.
 //!
-//! Member-level decorator semantics (`@Prop`, `@Emit`, `@Watch`, ...) are not
-//! interpreted yet; fields keep the `Data` mapping so templates resolve the
-//! identifiers either way. The `@Component({ ... })` / `@Options({ ... })`
-//! decorator argument is a regular options object and is fed through the
-//! existing Options API collectors (so `components:` registrations and inline
-//! `data`/`computed`/`methods` behave identically to an options component).
+//! Member-level `@Prop`-style decorators map fields/accessors to prop bindings.
+//! Other member decorators (`@Emit`, `@Watch`, ...) are not interpreted yet;
+//! the members keep the same template binding names either way. The
+//! `@Component({ ... })` / `@Options({ ... })` decorator argument is a regular
+//! options object and is fed through the existing Options API collectors (so
+//! `components:` registrations and inline `data`/`computed`/`methods` behave
+//! identically to an options component).
 
 use oxc_ast::ast::{
-    Argument, Class, ClassElement, ExportDefaultDeclarationKind, Expression, MethodDefinitionKind,
-    ObjectExpression, PropertyKey,
+    Argument, Class, ClassElement, Decorator, ExportDefaultDeclarationKind, Expression,
+    MethodDefinitionKind, ObjectExpression, PropertyKey,
 };
 use oxc_span::GetSpan;
 
@@ -126,17 +128,50 @@ pub(super) fn collect_class_component_metadata<'a>(
                 if property.r#static || property.computed || property.declare {
                     continue;
                 }
-                add_class_member_binding(result, &property.key, BindingType::Data);
+                add_class_member_binding(
+                    result,
+                    &property.key,
+                    class_field_binding_type(&property.decorators),
+                );
             }
             ClassElement::AccessorProperty(accessor) => {
                 if accessor.r#static || accessor.computed {
                     continue;
                 }
-                add_class_member_binding(result, &accessor.key, BindingType::Data);
+                add_class_member_binding(
+                    result,
+                    &accessor.key,
+                    class_field_binding_type(&accessor.decorators),
+                );
             }
             ClassElement::StaticBlock(_) | ClassElement::TSIndexSignature(_) => {}
         }
     }
+}
+
+fn class_field_binding_type(decorators: &[Decorator<'_>]) -> BindingType {
+    if decorators.iter().any(is_prop_like_member_decorator) {
+        BindingType::Props
+    } else {
+        BindingType::Data
+    }
+}
+
+fn is_prop_like_member_decorator(decorator: &Decorator<'_>) -> bool {
+    match &decorator.expression {
+        Expression::Identifier(identifier) => is_prop_like_decorator_name(identifier.name.as_str()),
+        Expression::CallExpression(call) => {
+            let Expression::Identifier(identifier) = &call.callee else {
+                return false;
+            };
+            is_prop_like_decorator_name(identifier.name.as_str())
+        }
+        _ => false,
+    }
+}
+
+fn is_prop_like_decorator_name(name: &str) -> bool {
+    matches!(name, "Prop" | "PropSync" | "Model" | "ModelSync" | "VModel")
 }
 
 /// Options object passed to a `@Component(...)` / `@Options(...)` decorator.

--- a/crates/vize_croquis/src/script_parser/tests.rs
+++ b/crates/vize_croquis/src/script_parser/tests.rs
@@ -672,6 +672,7 @@ fn test_parse_class_component_decorated_members() {
     let source = r#"
 import Vue from 'vue'
 import Component from 'vue-class-component'
+import { Model, ModelSync, Prop, PropSync, VModel } from 'vue-property-decorator'
 import UserBadge from './UserBadge.vue'
 
 @Component({
@@ -681,7 +682,11 @@ import UserBadge from './UserBadge.vue'
 })
 export default class HelloWorld extends Vue {
   count = 0
-  private msg!: string
+  @Prop() private msg!: string
+  @PropSync('title') syncedTitle!: string
+  @Model('change') modelValue!: string
+  @ModelSync('checked') checked!: boolean
+  @VModel() selected!: string
   protected items: string[] = []
   #internal = 'hidden'
   static version = '1.0.0'
@@ -708,11 +713,17 @@ export default class HelloWorld extends Vue {
 
     assert_eq!(result.component_shape, ComponentShape::ClassApi);
 
-    // Fields -> Data (TS `private`/`protected` are erased at runtime, so the
-    // template still resolves them; the canonical Vue CLI class-component
-    // scaffold renders `private` members).
+    // Prop-like member decorators -> Props.
+    assert_eq!(result.bindings.get("msg"), Some(BindingType::Props));
+    assert_eq!(result.bindings.get("syncedTitle"), Some(BindingType::Props));
+    assert_eq!(result.bindings.get("modelValue"), Some(BindingType::Props));
+    assert_eq!(result.bindings.get("checked"), Some(BindingType::Props));
+    assert_eq!(result.bindings.get("selected"), Some(BindingType::Props));
+
+    // Undecorated fields -> Data (TS `private`/`protected` are erased at
+    // runtime, so the template still resolves them; the canonical Vue CLI
+    // class-component scaffold renders `private` members).
     assert_eq!(result.bindings.get("count"), Some(BindingType::Data));
-    assert_eq!(result.bindings.get("msg"), Some(BindingType::Data));
     assert_eq!(result.bindings.get("items"), Some(BindingType::Data));
 
     // Methods and get/set accessors -> Options (methods/computed-like).


### PR DESCRIPTION
## Summary
- Classify prop-like Vue class component decorators as prop bindings instead of data bindings.
- Cover `@Prop`, `@PropSync`, `@Model`, `@ModelSync`, and `@VModel` in the class component parser tests.

Refs #1391.

## Validation
- `cargo fmt --check`
- `cargo test -p vize_croquis test_parse_class_component -- --nocapture`
- `cargo test -p vize_patina no_mutating_props -- --nocapture`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1431"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->