### PR TITLE
fix(canon): derive async setup from script AST

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3607,6 +3607,7 @@ dependencies = [
  "oxc_ast_visit",
  "oxc_parser",
  "oxc_span",
+ "oxc_syntax",
  "phf 0.13.1",
  "regex",
  "rustc-hash",

--- a/crates/vize_canon/src/virtual_ts/generator/mod.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/mod.rs
@@ -172,7 +172,7 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
     ts.push_str("// ============================================\n\n");
 
     // Check for generic type parameter from <script setup generic="T">
-    let (generic_param, mut is_async) = summary
+    let (generic_param, is_async) = summary
         .scopes
         .iter()
         .find(|s| matches!(s.kind, ScopeKind::ScriptSetup))
@@ -184,14 +184,6 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
             }
         })
         .unwrap_or((None, false));
-
-    // Also detect top-level await in script content (Vue 3 script setup supports this)
-    if let Some(script) = script_content
-        && script.contains("await ")
-        && !is_async
-    {
-        is_async = true;
-    }
 
     if hoist_shared_preamble {
         // ImportMeta augmentation and shared type helpers live once per

--- a/crates/vize_canon/src/virtual_ts/tests.rs
+++ b/crates/vize_canon/src/virtual_ts/tests.rs
@@ -197,6 +197,69 @@ const count = ref(0)
     );
 }
 
+fn generate_script_setup_virtual_ts(script: &str) -> String {
+    use vize_croquis::{Analyzer, AnalyzerOptions};
+
+    let mut analyzer = Analyzer::with_options(AnalyzerOptions::full());
+    analyzer.analyze_script_setup(script);
+    let summary = analyzer.finish();
+
+    generate_virtual_ts_with_offsets(&summary, Some(script), None, 0, 0, &Default::default())
+        .code
+        .to_string()
+}
+
+#[test]
+fn test_script_setup_top_level_await_emits_async_setup() {
+    let output = generate_script_setup_virtual_ts("const data = await fetchData()\n");
+
+    assert!(
+        output.contains("async function __setup()"),
+        "expected top-level await to emit async setup:\n{output}"
+    );
+}
+
+#[test]
+fn test_script_setup_top_level_for_await_emits_async_setup() {
+    let output = generate_script_setup_virtual_ts(
+        r#"
+for await (const item of items) {
+    console.log(item)
+}
+"#,
+    );
+
+    assert!(
+        output.contains("async function __setup()"),
+        "expected top-level for-await to emit async setup:\n{output}"
+    );
+}
+
+#[test]
+fn test_script_setup_nested_await_and_text_do_not_emit_async_setup() {
+    let output = generate_script_setup_virtual_ts(
+        r#"
+const message = "await should not force async setup"
+// await should not force async setup
+async function load() {
+    await fetchData()
+}
+const run = async () => {
+    await fetchData()
+}
+"#,
+    );
+
+    assert!(
+        output.contains("function __setup()"),
+        "expected setup function to be emitted:\n{output}"
+    );
+    assert!(
+        !output.contains("async function __setup()"),
+        "nested/text await must not force async setup:\n{output}"
+    );
+}
+
 #[test]
 fn test_const_auto_import_stubs_skip_imported_names() {
     use vize_croquis::{Analyzer, AnalyzerOptions};

--- a/crates/vize_croquis/Cargo.toml
+++ b/crates/vize_croquis/Cargo.toml
@@ -22,6 +22,7 @@ regex.workspace = true
 oxc_parser.workspace = true
 oxc_ast.workspace = true
 oxc_ast_visit.workspace = true
+oxc_syntax.workspace = true
 oxc_span.workspace = true
 oxc_allocator.workspace = true
 

--- a/crates/vize_croquis/src/script_parser/parse.rs
+++ b/crates/vize_croquis/src/script_parser/parse.rs
@@ -2,8 +2,11 @@
 
 use oxc_allocator::Allocator;
 use oxc_ast::ast::Program;
+use oxc_ast_visit::Visit;
+use oxc_ast_visit::walk::{walk_arrow_function_expression, walk_for_of_statement, walk_function};
 use oxc_parser::Parser;
 use oxc_span::SourceType;
+use oxc_syntax::scope::ScopeFlags;
 
 use super::globals::setup_global_scopes;
 use super::process;
@@ -64,7 +67,7 @@ pub fn analyze_script_setup_program(
     result.scopes.enter_script_setup_scope(
         ScriptSetupScopeData {
             is_ts: true,
-            is_async: false,
+            is_async: contains_top_level_await(program),
             generic: generic.map(CompactString::new),
         },
         0,
@@ -87,6 +90,53 @@ pub fn analyze_script_setup_program(
     );
 
     result
+}
+
+/// Detect script-setup top-level await from an already parsed AST.
+///
+/// A script setup block needs an async setup wrapper when `await` or
+/// `for await` appears in the setup execution flow. Awaits inside nested
+/// functions are not top-level and must not force the wrapper async.
+fn contains_top_level_await(program: &Program<'_>) -> bool {
+    #[derive(Default)]
+    struct TopLevelAwaitVisitor {
+        function_depth: usize,
+        found: bool,
+    }
+
+    impl<'a> Visit<'a> for TopLevelAwaitVisitor {
+        fn visit_function(&mut self, it: &oxc_ast::ast::Function<'a>, flags: ScopeFlags) {
+            self.function_depth += 1;
+            walk_function(self, it, flags);
+            self.function_depth = self.function_depth.saturating_sub(1);
+        }
+
+        fn visit_arrow_function_expression(
+            &mut self,
+            it: &oxc_ast::ast::ArrowFunctionExpression<'a>,
+        ) {
+            self.function_depth += 1;
+            walk_arrow_function_expression(self, it);
+            self.function_depth = self.function_depth.saturating_sub(1);
+        }
+
+        fn visit_await_expression(&mut self, _it: &oxc_ast::ast::AwaitExpression<'a>) {
+            if self.function_depth == 0 {
+                self.found = true;
+            }
+        }
+
+        fn visit_for_of_statement(&mut self, it: &oxc_ast::ast::ForOfStatement<'a>) {
+            if self.function_depth == 0 && it.r#await {
+                self.found = true;
+            }
+            walk_for_of_statement(self, it);
+        }
+    }
+
+    let mut visitor = TopLevelAwaitVisitor::default();
+    visitor.visit_program(program);
+    visitor.found
 }
 
 /// Parse script setup source code using OXC parser.

--- a/crates/vize_croquis/src/script_parser/tests.rs
+++ b/crates/vize_croquis/src/script_parser/tests.rs
@@ -1,7 +1,53 @@
 use super::{ScriptParserOptions, parse_script, parse_script_setup, parse_script_with_options};
 use crate::croquis::ComponentShape;
+use crate::scope::{ScopeData, ScopeKind};
 use vize_carton::{CompactString, append, cstr};
 use vize_relief::BindingType;
+
+fn script_setup_is_async(source: &str) -> bool {
+    let result = parse_script_setup(source);
+    result
+        .scopes
+        .iter()
+        .find(|scope| matches!(scope.kind, ScopeKind::ScriptSetup))
+        .and_then(|scope| match scope.data() {
+            ScopeData::ScriptSetup(data) => Some(data.is_async),
+            _ => None,
+        })
+        .unwrap_or(false)
+}
+
+#[test]
+fn test_parse_script_setup_marks_top_level_await_async() {
+    assert!(script_setup_is_async("const data = await fetchData()"));
+}
+
+#[test]
+fn test_parse_script_setup_marks_top_level_for_await_async() {
+    assert!(script_setup_is_async(
+        r#"
+for await (const item of items) {
+    console.log(item)
+}
+"#,
+    ));
+}
+
+#[test]
+fn test_parse_script_setup_ignores_non_top_level_awaits() {
+    assert!(!script_setup_is_async(
+        r#"
+const message = "await should not force async setup"
+// await should not force async setup
+async function load() {
+    await fetchData()
+}
+const run = async () => {
+    await fetchData()
+}
+"#,
+    ));
+}
 
 #[test]
 fn test_parse_define_props_type() {


### PR DESCRIPTION
## Summary
- Detect script-setup top-level `await` and `for await` from the Croquis OXC AST.
- Remove Canon's `script.contains("await ")` async setup fallback.
- Cover top-level await, top-level for-await, and nested/string/comment false positives.

Refs #1394.

## Validation
- `cargo fmt --check`
- `cargo test -p vize_croquis test_parse_script_setup -- --nocapture`
- `cargo test -p vize_canon test_script_setup_ -- --nocapture`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1432"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->