### PR TITLE
fix(canon): type options api template bindings from instance

### DIFF
--- a/crates/vize_canon/src/batch/type_checker/tests.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests.rs
@@ -1043,6 +1043,51 @@ fn batch_type_checker_accepts_options_api_this_data_access_in_computed() {
 }
 
 #[test]
+fn batch_type_checker_reports_options_api_template_type_mismatch() {
+    if resolve_test_tsgo_binary().is_none() {
+        return;
+    }
+
+    let project_root = create_project_case(
+        "options-api-template-binding-type",
+        &[(
+            "src/App.vue",
+            r#"<script lang="ts">
+export default {
+  data() {
+    return { count: 0 }
+  },
+}
+</script>
+
+<template>
+  <div>{{ count.toFixed(true) }}</div>
+</template>
+"#,
+        )],
+    );
+
+    if !project_root.join("node_modules/vue/dist").exists() {
+        let _ = std::fs::remove_dir_all(&project_root);
+        return;
+    }
+
+    let Some(snapshot) = snapshot_project_diagnostics(&project_root) else {
+        let _ = std::fs::remove_dir_all(&project_root);
+        return;
+    };
+
+    assert!(
+        snapshot
+            .iter()
+            .any(|(file, code, _)| { file == "src/App.vue" && *code == Some(2345) }),
+        "expected Options API data binding to keep its number type in the template: {snapshot:#?}"
+    );
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}
+
+#[test]
 fn batch_type_checker_options_api_wrap_adds_no_errors_in_facade_fallback() {
     if resolve_test_tsgo_binary().is_none() {
         return;

--- a/crates/vize_canon/src/virtual_ts/generator/options_api.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/options_api.rs
@@ -16,7 +16,7 @@ use vize_carton::FxHashSet;
 use vize_carton::String;
 use vize_carton::append;
 
-// Emit `const <name>: any` declarations for Options API template bindings
+// Emit declarations for Options API template bindings
 // (`data`/`computed`/`methods`/`inject`/`setup`/`props`, plus any Nuxt 2 globals
 // the legacy path collected). Options API is officially supported in Vue 3, so
 // this is part of the standard build and driven by a runtime opt-in — it costs
@@ -60,8 +60,17 @@ pub(super) fn generate_options_api_variables(
     }
 
     ts.push_str("  // Options API template bindings\n");
+    ts.push_str(
+        "  type __VizeOptionsInstance<T> = T extends abstract new (...args: any) => infer I ? I : any;\n",
+    );
+    ts.push_str(
+        "  type __VizeOptionsBinding<T, K extends string> = K extends keyof __VizeOptionsInstance<T> ? __VizeOptionsInstance<T>[K] : any;\n",
+    );
     for name in &names {
-        append!(ts, "  const {name}: any = undefined as any;\n");
+        append!(
+            ts,
+            "  const {name}: __VizeOptionsBinding<typeof __default__, \"{name}\"> = undefined as any;\n"
+        );
     }
     ts.push_str("  ");
     for name in &names {

--- a/crates/vize_canon/src/virtual_ts/tests.rs
+++ b/crates/vize_canon/src/virtual_ts/tests.rs
@@ -172,6 +172,62 @@ export default defineComponent({
 }
 
 #[test]
+fn test_options_api_template_bindings_use_default_instance_type() {
+    let script = r#"export default {
+    props: {
+        initial: Number,
+    },
+    data() {
+        return { count: 0 }
+    },
+    computed: {
+        doubled() {
+            return this.count * 2
+        },
+    },
+    methods: {
+        bump() {
+            return this.count + 1
+        },
+    },
+}
+"#;
+    let allocator = vize_carton::Bump::new();
+    let (root, _) = vize_armature::parse(&allocator, "<div>{{ count }}</div>");
+    let mut analyzer = vize_croquis::Analyzer::with_options(vize_croquis::AnalyzerOptions::full())
+        .with_options_api();
+    analyzer.analyze_script_plain(script);
+    analyzer.analyze_template(&root);
+    let summary = analyzer.finish();
+    let output = generate_virtual_ts_with_offsets_options_api(
+        &summary,
+        Some(script),
+        Some(&root),
+        0,
+        0,
+        &Default::default(),
+    );
+
+    assert!(
+        output.code.contains("type __VizeOptionsInstance<T>"),
+        "expected Options API instance helper:\n{}",
+        output.code
+    );
+    assert!(
+        output
+            .code
+            .contains("const count: __VizeOptionsBinding<typeof __default__, \"count\">"),
+        "expected data binding to reference the default component instance:\n{}",
+        output.code
+    );
+    assert!(
+        !output.code.contains("const count: any = undefined as any;"),
+        "template data binding must not be emitted as a fixed any:\n{}",
+        output.code
+    );
+}
+
+#[test]
 fn test_script_setup_output_does_not_emit_options_api_bridge() {
     use vize_croquis::{Analyzer, AnalyzerOptions};
 


### PR DESCRIPTION
## Summary
- Emit Options API template bindings from `typeof __default__` public instance types instead of fixed `any`.
- Keep non-constructable/stub fallback as `any` to preserve current fallback behavior.
- Add generator and Corsa-backed batch coverage for typed Options API template usage.

Refs #1388.

## Validation
- `cargo fmt --check`
- `cargo test -p vize_canon options_api -- --nocapture`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1433"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->