### PR TITLE
fix(canon): keep decorators on class-component default exports

### DIFF
--- a/crates/vize_canon/src/virtual_ts/generator/mod.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/mod.rs
@@ -16,7 +16,7 @@ use self::imports::{
     extract_declared_name,
 };
 use self::options_api::{
-    find_plain_default_export_object, generate_options_api_bridge, generate_options_api_variables,
+    find_default_export_targets, generate_options_api_bridge, generate_options_api_variables,
 };
 use self::spans::{
     DEFINE_COMPONENT_HELPER, DEFINE_COMPONENT_REF, collect_template_referenced_names,
@@ -214,19 +214,27 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
         .iter()
         .any(|scope| matches!(scope.kind, ScopeKind::NonScriptSetup));
 
-    // Plain `export default { ... }` in the main <script> block (the Options
-    // API shape) gets wrapped with Vue's `defineComponent` so `this` inside
-    // computed/methods is typed by Vue's options machinery. Script setup
-    // virtual TS is never touched: in setup-only SFCs no wrap target exists,
-    // so the helper lookup is skipped entirely.
-    let default_export_object = if !has_script_setup || has_plain_script_scope {
+    // Classify the main `<script>` default export in one parse. A plain
+    // `export default { ... }` (Options API shape) gets wrapped with Vue's
+    // `defineComponent` so `this` inside computed/methods is typed by Vue's
+    // options machinery; a class default export (class-component shape) keeps
+    // its decorators on a standalone class declaration plus a
+    // `const __default__ =` alias (a bare `const __default__ = class {}`
+    // rewrite would move the decorators onto a class expression — TS1206).
+    // Script setup virtual TS is never touched: in setup-only SFCs no rewrite
+    // target exists, so the lookup is skipped entirely.
+    let default_export_targets = if !has_script_setup || has_plain_script_scope {
         profile!(
-            "canon.virtual_ts.find_default_export_object",
-            script_content.and_then(find_plain_default_export_object)
+            "canon.virtual_ts.find_default_export_targets",
+            script_content
+                .map(find_default_export_targets)
+                .unwrap_or_default()
         )
     } else {
-        None
+        Default::default()
     };
+    let default_export_object = default_export_targets.object;
+    let default_export_class = default_export_targets.class;
     if default_export_object.is_some() {
         ts.push_str(DEFINE_COMPONENT_HELPER);
     }
@@ -462,6 +470,11 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
             // closing brace; the matching `)` for the `defineComponent(` wrap
             // opened on an earlier line is inserted there.
             let mut pending_wrap_close: Option<usize> = None;
+            // A class default export (class component) keeps its decorators on
+            // a real class declaration; the `const __default__ = <Name>` alias
+            // is appended once the class body closes. Holds `(class_end, name)`
+            // (script-absolute end offset + class identifier).
+            let mut pending_class_alias: Option<(usize, &str)> = None;
 
             // Check if script uses import.meta and add a polyfill variable.
             // This avoids TS1343 when module is not set to es2020+.
@@ -525,25 +538,59 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
                     .filter(|rest| rest.chars().next().is_none_or(char::is_whitespace))
                 {
                     let leading_ws = &output_line[..output_line.len() - trimmed_line.len()];
+                    // A class default export (the class-component shape) stays
+                    // a real class declaration so `@Component()` decorators
+                    // remain valid (a bare `const __default__ = class {}`
+                    // rewrite moves them onto a class expression — TS1206). The
+                    // `const __default__ = <Name>` alias is deferred until the
+                    // class body closes.
+                    let class_default =
+                        if has_script_setup || matches!(output_line, std::borrow::Cow::Owned(_)) {
+                            None
+                        } else {
+                            default_export_class.filter(
+                                |&(export_start, class_start, class_end, _, _)| {
+                                    export_start >= line_start
+                                        && class_start >= line_start
+                                        && class_start < line_end
+                                        && class_end > line_start
+                                        && class_start - line_start <= line.len()
+                                        && line.is_char_boundary(class_start - line_start)
+                                },
+                            )
+                        };
                     // Wrap a plain object-literal default export (Options
                     // API) with `defineComponent` so `this` in
                     // computed/methods gets Vue's instance typing. Applies
                     // only to the plain <script> block; any other shape keeps
                     // the bare `const __default__ =` rewrite.
-                    let wrap_object =
-                        if has_script_setup || matches!(output_line, std::borrow::Cow::Owned(_)) {
-                            None
-                        } else {
-                            default_export_object.filter(|&(export_start, object_start, _)| {
-                                export_start >= line_start
-                                    && object_start >= line_start
-                                    && object_start < line_end
-                                    && object_start - line_start <= line.len()
-                                    && line[object_start - line_start..].starts_with('{')
-                            })
-                        };
+                    let wrap_object = if class_default.is_some()
+                        || has_script_setup
+                        || matches!(output_line, std::borrow::Cow::Owned(_))
+                    {
+                        None
+                    } else {
+                        default_export_object.filter(|&(export_start, object_start, _)| {
+                            export_start >= line_start
+                                && object_start >= line_start
+                                && object_start < line_end
+                                && object_start - line_start <= line.len()
+                                && line[object_start - line_start..].starts_with('{')
+                        })
+                    };
                     #[allow(clippy::disallowed_types)]
-                    if let Some((object_column, object_end)) =
+                    if let Some((class_start, class_end, name_start, name_end)) =
+                        class_default.map(|(_, cs, ce, ns, ne)| (cs, ce, ns, ne))
+                    {
+                        // Drop the `export default ` keyword, keep the class
+                        // (and any same-line trailing decorator) verbatim.
+                        let class_column = class_start - line_start;
+                        let name = &script[name_start..name_end];
+                        output_line = std::borrow::Cow::Owned(
+                            cstr!("{leading_ws}{}", &line[class_column..]).into(),
+                        );
+                        pending_class_alias = Some((class_end, name));
+                    } else if let Some((object_column, object_end)) =
                         wrap_object.and_then(|(_, object_start, object_end)| {
                             let object_column = object_start - line_start;
                             (line.len() - default_expr.len() <= object_column)
@@ -616,8 +663,22 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
                         sub_spans: Vec::new(),
                     });
                 }
+                // Once the class body has closed, append the deferred
+                // `const __default__ = <Name>` alias for the class component.
+                if let Some((class_end, name)) = pending_class_alias
+                    && class_end <= line_end
+                {
+                    append!(ts, "  const __default__ = {name};\n");
+                    pending_class_alias = None;
+                }
                 let _ = gen_line_start; // suppress unused warning
                 src_byte_offset += raw_byte_len;
+            }
+            if let Some((_, name)) = pending_class_alias.take() {
+                // Defensive: the line carrying the class body's closing brace
+                // was never seen; still emit the alias so `__default__` (and the
+                // template bindings that read `typeof __default__`) resolve.
+                append!(ts, "  const __default__ = {name};\n");
             }
             if pending_wrap_close.take().is_some() {
                 // Defensive: the line carrying the wrapped object's closing

--- a/crates/vize_canon/src/virtual_ts/generator/options_api.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/options_api.rs
@@ -393,37 +393,78 @@ fn collect_mapped_type(call: &CallExpression<'_>, mapped_types: &mut Vec<String>
     mapped_types.push(mapped_type);
 }
 
-/// Locate a plain object-literal default export (`export default { ... }`) —
-/// the Options API component shape — in `script`.
+/// Byte offsets locating the rewriteable shape of a `<script>` default export.
 ///
-/// Returns `(export_start, object_start, object_end)` byte offsets into
-/// `script`. Default exports that are anything else — already-wrapped
-/// `defineComponent({...})` calls, class declarations, identifiers, function
-/// calls, `as`/`satisfies` expressions — return `None` so only the bare
-/// options object gets the `defineComponent` wrap.
-pub(super) fn find_plain_default_export_object(script: &str) -> Option<(usize, usize, usize)> {
+/// Both fields are offsets into the parsed `script`. A single default export is
+/// at most one of these (an SFC module has one default export), so at most one
+/// field is `Some`.
+#[derive(Default, Clone, Copy)]
+pub(super) struct DefaultExportTargets {
+    /// A plain object-literal default export (`export default { ... }`) — the
+    /// Options API shape — as `(export_start, object_start, object_end)`. Used
+    /// to wrap the object in `defineComponent` so `this` in computed/methods
+    /// gets Vue's instance typing. Anything else (already-wrapped
+    /// `defineComponent({...})`, identifiers, calls, `as`/`satisfies`) stays
+    /// `None` so only the bare options object is wrapped.
+    pub object: Option<(usize, usize, usize)>,
+    /// A class-declaration default export (`export default class Foo {}`, the
+    /// class-component shape — vue-class-component / vue-property-decorator) as
+    /// `(export_start, class_start, class_end, name_start, name_end)`.
+    /// `export_start..class_start` is the `export default ` keyword (stripped);
+    /// `class_start..class_end` is the class declaration; `name_start..name_end`
+    /// is the class identifier. Decorators written before `export default` sit
+    /// ahead of `export_start`; decorators after it fall inside the class span —
+    /// so stripping only the keyword run keeps `@Component()` on a real class
+    /// declaration either way (the line-based fallback would move it onto a
+    /// `const`, which TypeScript rejects with TS1206). Anonymous default classes
+    /// stay `None` (no name to alias by) and fall through to the existing
+    /// rewrite.
+    pub class: Option<(usize, usize, usize, usize, usize)>,
+}
+
+/// Classify a `<script>` default export in a single parse. Parsing once keeps
+/// the virtual-TS hot path free of a second full OXC parse per plain-`<script>`
+/// component.
+pub(super) fn find_default_export_targets(script: &str) -> DefaultExportTargets {
+    let mut targets = DefaultExportTargets::default();
     if !script.contains("export default") {
-        return None;
+        return targets;
     }
     let allocator = Allocator::default();
     let parsed = Parser::new(&allocator, script, SourceType::ts()).parse();
     if parsed.panicked {
-        return None;
+        return targets;
     }
-    parsed.program.body.iter().find_map(|statement| {
+    for statement in parsed.program.body.iter() {
         let Statement::ExportDefaultDeclaration(export) = statement else {
-            return None;
+            continue;
         };
-        let ExportDefaultDeclarationKind::ObjectExpression(object) = &export.declaration else {
-            return None;
-        };
-        let object_span = object.span();
-        Some((
-            export.span.start as usize,
-            object_span.start as usize,
-            object_span.end as usize,
-        ))
-    })
+        match &export.declaration {
+            ExportDefaultDeclarationKind::ObjectExpression(object) => {
+                let object_span = object.span();
+                targets.object = Some((
+                    export.span.start as usize,
+                    object_span.start as usize,
+                    object_span.end as usize,
+                ));
+            }
+            ExportDefaultDeclarationKind::ClassDeclaration(class) => {
+                if let Some(id) = class.id.as_ref() {
+                    targets.class = Some((
+                        export.span.start as usize,
+                        class.span.start as usize,
+                        class.span.end as usize,
+                        id.span.start as usize,
+                        id.span.end as usize,
+                    ));
+                }
+            }
+            _ => {}
+        }
+        // A module has a single default export; stop at the first one.
+        break;
+    }
+    targets
 }
 
 fn component_options_from_program<'a>(

--- a/crates/vize_canon/src/virtual_ts/tests.rs
+++ b/crates/vize_canon/src/virtual_ts/tests.rs
@@ -228,6 +228,79 @@ fn test_options_api_template_bindings_use_default_instance_type() {
 }
 
 #[test]
+fn test_class_component_default_export_keeps_decorators_on_class() {
+    // vue-class-component / vue-property-decorator: a decorated class default
+    // export must become a standalone class declaration plus a
+    // `const __default__ = Foo` alias. The decorator must stay on a real class
+    // declaration (never on a `const`/class expression — TS1206).
+    let script = r#"import { Vue } from 'vue-class-component'
+import { Component, Prop } from 'vue-property-decorator'
+
+@Component
+export default class Counter extends Vue {
+  @Prop() readonly initial!: number
+  count = 0
+  get doubled() {
+    return this.count * 2
+  }
+  bump() {
+    this.count += 1
+  }
+}
+"#;
+    let allocator = vize_carton::Bump::new();
+    let (root, _) = vize_armature::parse(&allocator, "<div>{{ count }}{{ doubled }}</div>");
+    let mut analyzer = vize_croquis::Analyzer::with_options(vize_croquis::AnalyzerOptions::full())
+        .with_options_api();
+    analyzer.analyze_script_plain(script);
+    analyzer.analyze_template(&root);
+    let summary = analyzer.finish();
+    let output = generate_virtual_ts_with_offsets_options_api(
+        &summary,
+        Some(script),
+        Some(&root),
+        0,
+        0,
+        &Default::default(),
+    );
+
+    assert!(
+        output.code.contains("@Component"),
+        "the class-level decorator must be preserved:\n{}",
+        output.code
+    );
+    assert!(
+        output.code.contains("class Counter extends Vue {"),
+        "the class must stay a standalone class declaration:\n{}",
+        output.code
+    );
+    assert!(
+        output.code.contains("const __default__ = Counter"),
+        "the class must be aliased to __default__ by name:\n{}",
+        output.code
+    );
+    assert!(
+        !output.code.contains("__default__ = class"),
+        "the class must not become a class expression assigned to a const (TS1206):\n{}",
+        output.code
+    );
+    assert!(
+        !output.code.contains("export default class"),
+        "the `export default` keyword must be stripped off the class declaration:\n{}",
+        output.code
+    );
+    // The instance-type bridge resolves template bindings against the class
+    // instance (`typeof __default__` -> InstanceType), not bare `any`.
+    assert!(
+        output
+            .code
+            .contains("const count: __VizeOptionsBinding<typeof __default__, \"count\">"),
+        "class members must be typed from the class instance:\n{}",
+        output.code
+    );
+}
+
+#[test]
 fn test_script_setup_output_does_not_emit_options_api_bridge() {
     use vize_croquis::{Analyzer, AnalyzerOptions};
 


### PR DESCRIPTION
## Problem

A class-component default export keeps its `@Component()` decorator **before** `export default`:

```ts
@Component
export default class Counter extends Vue { /* ... */ }
```

canon's virtual-TS generator emitted the `<script>` body line-by-line and rewrote the `export default` line with a bare `const __default__ =`, producing:

```ts
@Component
const __default__ = class Counter extends Vue { /* ... */ }
```

A decorator on a `const`/class **expression** is invalid — TypeScript rejects it with **TS1206 ("Decorators are not valid here")**. So *every* decorated class component (vue-class-component / vue-property-decorator) failed to type-check. This is the blocker preventing basic class-component support under #1391.

## Fix

Strip **only** the `export default ` keyword off the class declaration, leaving the class (and any decorators) verbatim, and defer the `const __default__ = <Name>` alias until the class body closes — reusing the same pending-emit pattern as the existing `defineComponent(` wrap-close:

```ts
@Component
class Counter extends Vue { /* ... */ }
const __default__ = Counter
```

The empirically-verified oxc span layout makes this uniform across decorator placement: decorators written **before** `export default` sit ahead of the export keyword; decorators written **after** it fall inside the class span — stripping just the keyword run keeps them on a real class declaration either way.

Template bindings keep resolving through `typeof __default__` (the `__VizeOptionsInstance` bridge resolves the class constructor to its instance type), so `count`/`doubled`/methods/`@Prop` fields type correctly instead of `any`.

## Zero-cost

The two default-export lookups (object shape + class shape) are folded into a **single** OXC parse (`find_default_export_targets`), so the virtual-TS hot path gains no extra parse versus before — the object case already parsed once. Pure `<script setup>` SFCs skip the lookup entirely, as before.

## Verification

- New unit test `test_class_component_default_export_keeps_decorators_on_class` asserts the decorator stays on a class declaration, the alias is by name, no class-expression rewrite occurs, and bindings type from the instance.
- Full canon suite green (329 tests); `fmt --check` and `clippy` (lib) clean.

Refs #1391

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1434"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->