### PR TITLE
fix(patina): skip HTML comments when scanning for </template>

### DIFF
--- a/crates/vize_patina/src/linter/engine/template_extract.rs
+++ b/crates/vize_patina/src/linter/engine/template_extract.rs
@@ -24,6 +24,17 @@ pub(crate) fn extract_template_fast(source: &str) -> Option<(String, u32)> {
             None => break,
         };
 
+        // Skip HTML comments wholesale. A comment can legitimately contain
+        // `</template>` or `<template>` text (e.g. a commented-out template
+        // fragment); counting those as real tags would close the block early
+        // and truncate the extracted template. An unterminated comment runs to
+        // EOF, leaving no trustworthy closing tag, so the scan ends.
+        if bytes[next_lt..].starts_with(b"<!--") {
+            pos = memchr::memmem::find(&bytes[next_lt + 4..], b"-->")
+                .map_or(bytes.len(), |offset| next_lt + 4 + offset + 3);
+            continue;
+        }
+
         // Check if it's <template or </template
         if tag_name_at(bytes, next_lt)
             .is_some_and(|(name, _)| name.eq_ignore_ascii_case(b"template"))
@@ -124,5 +135,37 @@ mod tests {
             extract(source).as_deref(),
             Some("<template #default><slot /></template>")
         );
+    }
+
+    #[test]
+    fn extract_template_fast_ignores_closing_tag_inside_comment() {
+        // A commented-out `</template>` must not close the block early.
+        let source = "<template><div /><!-- </template> --><span /></template>";
+
+        assert_eq!(
+            extract(source).as_deref(),
+            Some("<div /><!-- </template> --><span />")
+        );
+    }
+
+    #[test]
+    fn extract_template_fast_ignores_opening_tag_inside_comment() {
+        // A commented-out `<template>` must not inflate the nesting depth and
+        // swallow the real closing tag.
+        let source = "<template><!-- <template> --><div /></template><script>x</script>";
+
+        assert_eq!(
+            extract(source).as_deref(),
+            Some("<!-- <template> --><div />")
+        );
+    }
+
+    #[test]
+    fn extract_template_fast_handles_unterminated_comment() {
+        // An unterminated comment leaves no trustworthy closing tag; extraction
+        // bails rather than returning a truncated or corrupt template.
+        let source = "<template><div /><!-- no end";
+
+        assert_eq!(extract(source), None);
     }
 }


### PR DESCRIPTION
## Problem

patina's fast `<template>` block extractor (`extract_template_fast`) skipped HTML comments only while locating the **opening** `<template>` tag (`find_template_block_start`), but **not** while matching the **closing** `</template>`. So a comment inside the template body containing tag-like text corrupted extraction:

```vue
<template>
  <div />
  <!-- <button>old</button> </template> -->
  <span />
</template>
```

The scanner hit the `</template>` *inside the comment*, decremented the depth to zero, and returned a **truncated** template (everything after the comment dropped). A commented-out `<template>` had the mirror bug — it inflated the depth and swallowed the real closing tag. The linter then analyzed a corrupt template, producing wrong/missing diagnostics.

This is exactly the text-scanning fragility #1394 targets.

## Fix

Skip comments wholesale in the closing-tag scan too, mirroring the existing block-start logic: on `<!--`, jump past the matching `-->`. An unterminated comment runs to EOF, leaving no trustworthy closing tag, so the scan ends (no extraction) rather than guessing.

## Verification

Three new unit tests cover a `</template>` inside a comment, a `<template>` inside a comment, and an unterminated comment. Full patina suite green (1038 tests); `fmt --check` and `clippy` (lib) clean.

Refs #1394

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1435"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->