### PR TITLE
fix(check/nuxt): warn when generated .nuxt types are missing

### DIFF
--- a/crates/vize/src/commands/check/nuxt/mod.rs
+++ b/crates/vize/src/commands/check/nuxt/mod.rs
@@ -61,6 +61,12 @@ pub(in crate::commands::check) fn detect_nuxt_auto_imports(
         &mut seen_names,
         &mut external_template_bindings,
     );
+    // Surface the degraded fallback: without generated `.nuxt` types,
+    // auto-imports resolve to permissive `any` stubs that hide real type
+    // errors. detect_nuxt_auto_imports runs once per check, so this warns once.
+    if let Some(message) = missing_generated_types_warning(has_generated_imports) {
+        eprintln!("{message}");
+    }
     collect_plugin_injection_stubs(cwd, &mut collected, &mut seen_names);
     collect_fallback_stubs(&mut collected, &mut seen_names, has_generated_imports);
     if !has_generated_imports {
@@ -91,4 +97,16 @@ fn is_nuxt_project(cwd: &Path) -> bool {
     cwd.join("nuxt.config.ts").exists()
         || cwd.join("nuxt.config.js").exists()
         || cwd.join("nuxt.config.mts").exists()
+}
+
+/// Warning shown once per `vize check` run for a Nuxt project that has no
+/// generated `.nuxt` type artifacts. Without them, auto-imports fall back to
+/// permissive `any` stubs that hide real type errors, so the user is told how
+/// to generate them. Returns `None` when generated types are present (the
+/// checked types are accurate and no warning is warranted).
+fn missing_generated_types_warning(has_generated_imports: bool) -> Option<&'static str> {
+    (!has_generated_imports).then_some(
+        "vize check: no generated `.nuxt` types found; Nuxt auto-imports fall back to `any` \
+         stubs and some type errors will be missed. Run `nuxi prepare` to generate them.",
+    )
 }

--- a/crates/vize/src/commands/check/nuxt/tests.rs
+++ b/crates/vize/src/commands/check/nuxt/tests.rs
@@ -10,9 +10,21 @@ use vize_carton::cstr;
 use super::super::dts::rewrite_relative_specifier;
 use super::detect_nuxt_auto_imports;
 use super::fallback::{fallback_stub_strings, parse_nuxt_config_modules};
+use super::missing_generated_types_warning;
 use super::parsing::{parse_export_names, parse_module_specifier};
 use super::plugins::extract_plugin_provide_keys_from_source;
 use super::stubs::declared_name;
+
+#[test]
+fn warns_only_when_generated_nuxt_types_are_missing() {
+    // Generated `.nuxt` types present -> accurate checking, no warning.
+    assert!(missing_generated_types_warning(true).is_none());
+    // Missing -> degraded `any`-stub fallback, warn with remediation.
+    let message =
+        missing_generated_types_warning(false).expect("missing generated types must warn");
+    assert!(message.contains("nuxi prepare"));
+    assert!(message.contains("`any`"));
+}
 
 #[test]
 fn parses_module_export_lines() {


### PR DESCRIPTION
## Problem

When `vize check` runs on a Nuxt project that has **no generated `.nuxt` type artifacts** (e.g. `nuxi prepare` was never run), `detect_nuxt_auto_imports` silently falls back to permissive `any` stubs for auto-imported composables/components. The check then *looks* clean while quietly missing real type errors — a silent-degradation workaround with no signal to the user.

## Fix

Emit a single, actionable warning to stderr — once per check run (`detect_nuxt_auto_imports` is called once in the runner) — when generated types are absent:

> vize check: no generated `.nuxt` types found; Nuxt auto-imports fall back to `any` stubs and some type errors will be missed. Run `nuxi prepare` to generate them.

The warning condition lives in a small pure helper `missing_generated_types_warning(has_generated_imports)` so it is unit-tested directly. When generated types ARE present, no warning fires (the existing accurate path is unchanged), and non-Nuxt projects are unaffected (early return upstream). The bench corpus is not a Nuxt project, so the perf gate sees no new output.

## Verification

New unit test `warns_only_when_generated_nuxt_types_are_missing`; full nuxt suite green (17 tests); `fmt --check` and `clippy` (lib) clean.

Refs #1390

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1436"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->