### PR TITLE
test(tooling): normalize workflow fixture line endings

### DIFF
--- a/tests/tooling/github-workflows.test.ts
+++ b/tests/tooling/github-workflows.test.ts
@@ -10,8 +10,12 @@ import { buildComment } from "../../bench/comment-test-report.mjs";
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
 
+function normalizeRepoText(content: string): string {
+  return content.replace(/\r\n?/g, "\n");
+}
+
 function readRepoFile(...segments: string[]): string {
-  return fs.readFileSync(path.join(root, ...segments), "utf8");
+  return normalizeRepoText(fs.readFileSync(path.join(root, ...segments), "utf8"));
 }
 
 function readGithubYamlFiles(): Array<{ relativePath: string; content: string }> {
@@ -28,7 +32,7 @@ function readGithubYamlFiles(): Array<{ relativePath: string; content: string }>
       }
       files.push({
         relativePath: path.relative(root, fullPath),
-        content: fs.readFileSync(fullPath, "utf8"),
+        content: normalizeRepoText(fs.readFileSync(fullPath, "utf8")),
       });
     }
   };
@@ -68,6 +72,12 @@ function hostedOrBlacksmith(hostedLabel: string): string {
   }
   return escapeRegExp(hostedLabel);
 }
+
+test("repo text helpers normalize line endings before workflow matching", () => {
+  const workflow = normalizeRepoText("jobs:\r\n  check-js:\r\n    runs-on: ubuntu-24.04\r\n");
+
+  assert.equal(workflowJobBody(workflow, "check-js"), "  check-js:\n    runs-on: ubuntu-24.04\n");
+});
 
 test("GitHub workflows opt JavaScript actions into Node 24", () => {
   for (const workflowName of [


### PR DESCRIPTION
## Summary
- normalize repository text fixtures read by `github-workflows.test.ts` to LF
- cover the helper with a CRLF workflow snippet before exercising the existing job matcher

## Why
The workflow-shape tests match job boundaries with `\n`-anchored patterns. On Windows checkouts that materialize workflow files with CRLF, those assertions can fail even though the workflow content is semantically identical. Normalizing at the test fixture boundary keeps the tests focused on workflow structure instead of checkout line endings.

## Tests
- `node --test --test-name-pattern "repo text helpers normalize line endings before workflow matching" tests/tooling/github-workflows.test.ts`
- `node --test tests/tooling/github-workflows.test.ts`
- `pnpm exec vp check tests/tooling/github-workflows.test.ts`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1437"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783781345&installation_id=136613492&pr_number=1437&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1437&signature=6a25022193360f2af602b68d8ebcae6763b747b3e07ab60dd6fb0f0748659691"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->