### PR TITLE
feat(patina): gate require-v-for-key off petite-vue documents

### DIFF
--- a/crates/vize_patina/src/context.rs
+++ b/crates/vize_patina/src/context.rs
@@ -16,6 +16,7 @@ use vize_atelier_sfc::SfcDescriptor;
 use vize_carton::String;
 use vize_carton::{
     Allocator, CompactString, FxHashMap, FxHashSet,
+    dialect::VueDialect,
     directive::DirectiveSeverity,
     i18n::{Locale, t, t_fmt},
 };
@@ -63,6 +64,8 @@ pub struct LintContext<'a> {
     analysis_excluded_rules: Option<&'static [&'static str]>,
     /// SSR mode for linting.
     ssr_mode: SsrMode,
+    /// Vue dialect of the document being linted (gates dialect-specific rules).
+    dialect: VueDialect,
     /// Help display level.
     pub(crate) help_level: HelpLevel,
     /// Lines where `@vize:expected` expects an error on the next line.
@@ -111,6 +114,7 @@ impl<'a> LintContext<'a> {
             sfc_descriptor: None,
             analysis_excluded_rules: None,
             ssr_mode: SsrMode::default(),
+            dialect: VueDialect::default(),
             help_level: HelpLevel::default(),
             expected_error_lines: FxHashSet::default(),
             severity_overrides: FxHashMap::default(),
@@ -145,6 +149,7 @@ impl<'a> LintContext<'a> {
             sfc_descriptor: None,
             analysis_excluded_rules: None,
             ssr_mode: SsrMode::default(),
+            dialect: VueDialect::default(),
             help_level: HelpLevel::default(),
             expected_error_lines: FxHashSet::default(),
             severity_overrides: FxHashMap::default(),
@@ -209,6 +214,24 @@ impl<'a> LintContext<'a> {
     #[inline]
     pub fn is_ssr_enabled(&self) -> bool {
         self.ssr_mode == SsrMode::Enabled
+    }
+
+    /// Set the Vue dialect of the document being linted.
+    #[inline]
+    pub fn set_dialect(&mut self, dialect: VueDialect) {
+        self.dialect = dialect;
+    }
+
+    /// Get the Vue dialect of the document being linted.
+    #[inline]
+    pub fn dialect(&self) -> VueDialect {
+        self.dialect
+    }
+
+    /// Check if the document being linted uses the petite-vue dialect.
+    #[inline]
+    pub fn is_petite_vue(&self) -> bool {
+        self.dialect.is_petite_vue()
     }
 
     /// Set help display level.

--- a/crates/vize_patina/src/linter/engine.rs
+++ b/crates/vize_patina/src/linter/engine.rs
@@ -25,6 +25,7 @@ use vize_atelier_sfc::{SfcParseOptions, parse_sfc};
 use vize_carton::Allocator;
 use vize_carton::String;
 use vize_carton::ToCompactString;
+use vize_carton::dialect::{VueDialect, standalone_html_dialect};
 use vize_carton::profile;
 use vize_croquis::{Analyzer, Croquis};
 use vize_relief::ast::RootNode;
@@ -46,6 +47,17 @@ pub(crate) struct SfcTemplateLintInput<'a> {
     pub root: &'a RootNode<'a>,
     pub descriptor: Option<&'a vize_atelier_sfc::SfcDescriptor<'a>>,
     pub analysis: TemplateAnalysis<'a>,
+}
+
+/// Document-level inputs shared by the template-rule passes.
+///
+/// Bundles the optional SFC descriptor with the resolved [`VueDialect`] so the
+/// rule context can gate dialect-specific rules (e.g. petite-vue keyless
+/// `v-for`) without growing the already-wide pass signatures.
+#[derive(Clone, Copy)]
+pub(crate) struct TemplateRuleEnv<'a> {
+    pub sfc_descriptor: Option<&'a vize_atelier_sfc::SfcDescriptor<'a>>,
+    pub dialect: VueDialect,
 }
 
 const SEMANTIC_TEMPLATE_RULES: &[&str] = &[
@@ -235,14 +247,15 @@ impl Linter {
         source: &'a str,
         filename: &'a str,
         root: &RootNode<'a>,
-        sfc_descriptor: Option<&'a vize_atelier_sfc::SfcDescriptor<'a>>,
         analysis: Option<&'a Croquis>,
+        env: TemplateRuleEnv<'a>,
     ) -> LintResult {
         let mut ctx = LintContext::with_locale(allocator, source, filename, self.locale);
         ctx.set_enabled_rules(self.enabled_rules.clone());
         ctx.set_config_disabled_rules(self.disabled_rules.clone());
         ctx.set_help_level(self.help_level);
-        if let Some(descriptor) = sfc_descriptor {
+        ctx.set_dialect(env.dialect);
+        if let Some(descriptor) = env.sfc_descriptor {
             ctx.set_sfc_descriptor(descriptor);
         }
         #[cfg(not(target_arch = "wasm32"))]
@@ -258,7 +271,8 @@ impl Linter {
 
         let rule_count = self.template_rule_count_for_source(
             source,
-            sfc_descriptor.map(|descriptor| descriptor.source.as_ref()),
+            env.sfc_descriptor
+                .map(|descriptor| descriptor.source.as_ref()),
         );
         let mut visitor = LintVisitor::new(
             &mut ctx,
@@ -286,20 +300,13 @@ impl Linter {
         source: &'a str,
         filename: &'a str,
         root: &RootNode<'a>,
-        sfc_descriptor: Option<&'a vize_atelier_sfc::SfcDescriptor<'a>>,
         analysis: TemplateAnalysis<'a>,
+        env: TemplateRuleEnv<'a>,
     ) -> LintResult {
         if matches!(analysis, TemplateAnalysis::Disabled)
             || !self.has_active_semantic_template_rules()
         {
-            return self.run_template_rules(
-                allocator,
-                source,
-                filename,
-                root,
-                sfc_descriptor,
-                None,
-            );
+            return self.run_template_rules(allocator, source, filename, root, None, env);
         }
         let owned_analysis;
         let analysis = match analysis {
@@ -315,14 +322,7 @@ impl Linter {
             }
         };
 
-        self.run_template_rules(
-            allocator,
-            source,
-            filename,
-            root,
-            sfc_descriptor,
-            Some(analysis),
-        )
+        self.run_template_rules(allocator, source, filename, root, Some(analysis), env)
     }
 
     /// Lint a Vue template source.
@@ -342,7 +342,14 @@ impl Linter {
         source: &str,
         filename: &str,
     ) -> LintResult {
-        self.lint_template_with_allocator_config(allocator, source, filename, true, true)
+        self.lint_template_with_allocator_config(
+            allocator,
+            source,
+            filename,
+            true,
+            true,
+            VueDialect::Vue,
+        )
     }
 
     #[cfg(test)]
@@ -350,7 +357,14 @@ impl Linter {
         let capacity = (source.len() * 4).max(self.initial_capacity);
         let allocator = Allocator::with_capacity(capacity);
 
-        self.lint_template_with_allocator_config(&allocator, source, filename, false, true)
+        self.lint_template_with_allocator_config(
+            &allocator,
+            source,
+            filename,
+            false,
+            true,
+            VueDialect::Vue,
+        )
     }
 
     fn lint_template_with_allocator_config(
@@ -360,6 +374,7 @@ impl Linter {
         filename: &str,
         report_parse_errors: bool,
         gate_semantic_on_fatal_parse: bool,
+        dialect: VueDialect,
     ) -> LintResult {
         // Parse the template
         let parser = Parser::new(allocator.as_bump(), source);
@@ -372,11 +387,14 @@ impl Linter {
             source,
             filename,
             &root,
-            None,
             if gate_semantic_on_fatal_parse && has_fatal_parse_errors {
                 TemplateAnalysis::Disabled
             } else {
                 TemplateAnalysis::Lazy
+            },
+            TemplateRuleEnv {
+                sfc_descriptor: None,
+                dialect,
             },
         );
 
@@ -415,8 +433,11 @@ impl Linter {
             &input.template.content,
             input.filename,
             input.root,
-            input.descriptor,
             input.analysis,
+            TemplateRuleEnv {
+                sfc_descriptor: input.descriptor,
+                dialect: VueDialect::Vue,
+            },
         );
         Self::offset_result(&mut result, input.template.loc.start as u32);
         result
@@ -596,8 +617,13 @@ impl Linter {
     pub fn lint_standalone_html(&self, source: &str, filename: &str) -> LintResult {
         let capacity = (source.len() * 4).max(self.initial_capacity);
         let allocator = Allocator::with_capacity(capacity);
-        let mut result =
-            self.lint_template_with_allocator_config(&allocator, source, filename, false, false);
+        // Resolve the document dialect so dialect-specific rules (e.g.
+        // require-v-for-key, which petite-vue does not require) can gate
+        // themselves on petite-vue documents.
+        let dialect = standalone_html_dialect(None, source);
+        let mut result = self.lint_template_with_allocator_config(
+            &allocator, source, filename, false, false, dialect,
+        );
 
         if super::script_rules::has_active_builtin_script_rules(self) {
             super::script_rules::append_builtin_script_diagnostics_from_html(

--- a/crates/vize_patina/src/rules/vue/require_v_for_key.rs
+++ b/crates/vize_patina/src/rules/vue/require_v_for_key.rs
@@ -50,6 +50,12 @@ impl Rule for RequireVForKey {
             return;
         }
 
+        // petite-vue does not require a :key on v-for, so this Vue-3-only rule
+        // must not fire on petite-vue documents.
+        if ctx.is_petite_vue() {
+            return;
+        }
+
         // Skip <template> tags - key should be on children instead
         // (though on <template v-for>, the key can be on the template itself)
         if element.tag.as_str() == "template" {
@@ -127,6 +133,45 @@ mod tests {
             "test.vue",
         );
         assert_eq!(result.error_count, 0);
+    }
+
+    #[test]
+    fn test_petite_vue_keyless_v_for_allowed() {
+        let linter = create_linter();
+        // Structurally detected petite-vue document (script src resolves to the
+        // petite-vue package). petite-vue allows keyless v-for.
+        let result = linter.lint_standalone_html(
+            r#"<!DOCTYPE html>
+<html>
+  <body>
+    <ul v-scope="{ items: [1, 2, 3] }">
+      <li v-for="item in items">{{ item }}</li>
+    </ul>
+    <script src="https://unpkg.com/petite-vue" init></script>
+  </body>
+</html>"#,
+            "index.html",
+        );
+        assert_eq!(result.error_count, 0);
+    }
+
+    #[test]
+    fn test_non_petite_html_keyless_v_for_still_reports() {
+        let linter = create_linter();
+        // A plain HTML document (no petite-vue) keeps the Vue-3 requirement.
+        let result = linter.lint_standalone_html(
+            r#"<!DOCTYPE html>
+<html>
+  <body>
+    <ul>
+      <li v-for="item in items">{{ item }}</li>
+    </ul>
+    <script src="https://unpkg.com/vue"></script>
+  </body>
+</html>"#,
+            "index.html",
+        );
+        assert_eq!(result.error_count, 1);
     }
 
     #[test]


### PR DESCRIPTION
## Problem

petite-vue does not require a `:key` on `v-for`, but `vize_patina`'s Vue-3-only `vue/require-v-for-key` rule (Essential/Error) fires unconditionally on every `v-for` without a key — a guaranteed false positive on petite-vue documents. The lint context had no way to tell rules which dialect the document uses, so `require-v-for-key` could not gate itself.

## Fix

- Expose the document dialect to rules: add a `VueDialect` field on `LintContext` with `set_dialect`/`dialect()`/`is_petite_vue()` (defaults to `VueDialect::Vue`).
- Thread the resolved dialect through the template-rule passes. The optional SFC descriptor and dialect are bundled into a small `Copy` `TemplateRuleEnv` so the (already wide) pass signatures don't grow past clippy's `too_many_arguments` limit.
- `lint_standalone_html` resolves the dialect structurally via `vize_carton::dialect::standalone_html_dialect` (no substring sniffing — reuses the PR #1402 detector); SFC and normal-template paths pass `VueDialect::Vue`.
- `vue/require-v-for-key` short-circuits when `ctx.is_petite_vue()`.

Self-contained to `vize_patina`; no cross-crate plumbing beyond consuming the existing `vize_carton::dialect` API.

## Verification

- `cargo test -p vize_patina --lib` — 1040 passed, 0 failed. New tests:
  - `test_petite_vue_keyless_v_for_allowed`: petite-vue HTML doc (detected via `<script src="https://unpkg.com/petite-vue" init>`) with keyless `v-for` produces 0 diagnostics.
  - `test_non_petite_html_keyless_v_for_still_reports`: plain HTML doc with keyless `v-for` still reports 1 error.
- `cargo fmt --check -p vize_patina` — clean.
- `cargo clippy -p vize_patina --lib` — 0 warnings.

Refs #1393

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1442"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->