### PR TITLE
fix(croquis-cf): resolve relative component imports by canonical path

### DIFF
--- a/crates/vize_croquis_cf/src/analyzers/component_resolution.rs
+++ b/crates/vize_croquis_cf/src/analyzers/component_resolution.rs
@@ -277,65 +277,97 @@ fn resolve_import(
         return false;
     }
 
-    // Handle relative imports
+    // Handle relative imports.
+    //
+    // Resolve the specifier against the importing file's directory and
+    // normalize `.`/`..` segments to a canonical path. Matching only the
+    // canonical path ensures `./Button.vue` resolves to the sibling file and
+    // never to a different directory's same-named file (e.g. `admin/Button.vue`).
     if specifier.starts_with('.') {
-        // First, try to resolve using the directory path
-        if let Some(dir) = from_dir {
-            // Try with common extensions
-            for ext in &[
-                "",
-                ".vue",
-                ".ts",
-                ".tsx",
-                ".js",
-                ".jsx",
-                "/index.ts",
-                "/index.vue",
-            ] {
-                let resolved = dir.join(format!("{}{}", specifier, ext));
-                if registry.get_by_path(&resolved).is_some() {
-                    return true;
-                }
-            }
-        }
-
-        // Fallback: try to match by filename only (for flat file structures like playground presets)
-        // Extract the filename from the specifier (e.g., "./ChildComponent.vue" -> "ChildComponent.vue")
-        let filename = specifier
-            .strip_prefix("./")
-            .or_else(|| specifier.strip_prefix("../"))
-            .unwrap_or(specifier);
-
-        // Try with common extensions if no extension is provided
-        let extensions = if filename.contains('.') {
-            vec![""]
-        } else {
-            vec![".vue", ".ts", ".tsx", ".js", ".jsx", ""]
-        };
-
-        for ext in extensions {
-            let target = format!("{}{}", filename, ext);
-            // Check if any file in the registry ends with this filename
-            for entry in registry.iter() {
-                let entry_path = entry.path.to_string_lossy();
-                if entry_path.ends_with(&target) || entry_path == target {
-                    return true;
-                }
-            }
-        }
-
-        return false;
+        let candidates = import_candidates(specifier, from_dir);
+        return registry.iter().any(|entry| {
+            let entry_path = normalize_logical_path(entry.path.clone());
+            candidates.contains(&entry_path)
+        });
     }
 
     // For absolute or other paths, check directly
     registry.get_by_path(specifier).is_some()
 }
 
+/// Build the set of canonical candidate paths a relative import specifier may
+/// resolve to, trying the common module extensions and `index` files.
+fn import_candidates(
+    specifier: &str,
+    from_dir: Option<&std::path::Path>,
+) -> Vec<std::path::PathBuf> {
+    use std::path::PathBuf;
+
+    let base = from_dir
+        .filter(|dir| !dir.as_os_str().is_empty())
+        .map_or_else(|| PathBuf::from(specifier), |dir| dir.join(specifier));
+
+    let mut candidates = Vec::new();
+    let has_extension = base.extension().is_some();
+    candidates.push(normalize_logical_path(base.clone()));
+
+    if !has_extension {
+        for suffix in [
+            ".vue",
+            ".ts",
+            ".tsx",
+            ".js",
+            ".jsx",
+            "/index.vue",
+            "/index.ts",
+            "/index.tsx",
+            "/index.js",
+            "/index.jsx",
+        ] {
+            candidates.push(normalize_logical_path(path_with_suffix(&base, suffix)));
+        }
+    }
+
+    candidates
+}
+
+fn path_with_suffix(base: &std::path::Path, suffix: &str) -> std::path::PathBuf {
+    if let Some(index_file) = suffix.strip_prefix('/') {
+        base.join(index_file)
+    } else {
+        let mut value = base.as_os_str().to_os_string();
+        value.push(suffix);
+        std::path::PathBuf::from(value)
+    }
+}
+
+/// Normalize a path by collapsing `.`/`..` segments without touching the
+/// filesystem, yielding a canonical logical path for comparison.
+fn normalize_logical_path(path: std::path::PathBuf) -> std::path::PathBuf {
+    use std::path::{Component, Path, PathBuf};
+
+    let mut normalized = PathBuf::new();
+
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                normalized.pop();
+            }
+            Component::Normal(part) => normalized.push(part),
+            Component::RootDir => normalized.push(Path::new("/")),
+            Component::Prefix(prefix) => normalized.push(prefix.as_os_str()),
+        }
+    }
+
+    normalized
+}
+
 #[cfg(test)]
 mod tests {
     use super::{
         ComponentResolutionIssueKind, analyze_component_resolution, is_builtin_component,
-        is_custom_element_tag,
+        is_custom_element_tag, resolve_import,
     };
     use crate::CrossFileDiagnosticKind;
     use crate::graph::DependencyGraph;
@@ -417,5 +449,44 @@ mod tests {
                 template_offset: 12,
             }
         );
+    }
+
+    #[test]
+    fn relative_import_resolves_to_sibling_not_same_named_file_elsewhere() {
+        let mut registry = ModuleRegistry::new();
+
+        // Two components named `Button.vue` in different directories.
+        registry.register("pages/Button.vue", "", Croquis::new());
+        registry.register("admin/Button.vue", "", Croquis::new());
+
+        // `./Button.vue` imported from `pages/Home.vue` must resolve to the
+        // sibling `pages/Button.vue`.
+        let from_dir = std::path::Path::new("pages/Home.vue").parent();
+        assert!(resolve_import("./Button.vue", &registry, from_dir));
+    }
+
+    #[test]
+    fn relative_import_does_not_cross_directories() {
+        let mut registry = ModuleRegistry::new();
+
+        // Only the `admin/` variant exists; the sibling does not.
+        registry.register("admin/Button.vue", "", Croquis::new());
+
+        // `./Button.vue` imported from `pages/Home.vue` must NOT resolve to
+        // `admin/Button.vue` via a suffix match.
+        let from_dir = std::path::Path::new("pages/Home.vue").parent();
+        assert!(!resolve_import("./Button.vue", &registry, from_dir));
+    }
+
+    #[test]
+    fn relative_import_resolves_parent_directory() {
+        let mut registry = ModuleRegistry::new();
+
+        registry.register("components/Button.vue", "", Croquis::new());
+
+        // `../Button.vue` from `components/forms/Field.vue` resolves to
+        // `components/Button.vue`.
+        let from_dir = std::path::Path::new("components/forms/Field.vue").parent();
+        assert!(resolve_import("../Button.vue", &registry, from_dir));
     }
 }


### PR DESCRIPTION
## Problem

`vize_croquis_cf`'s component-resolution analyzer resolved relative import specifiers (`./Button.vue`, `../Foo.vue`) with a filename suffix match:

```rust
let entry_path = entry.path.to_string_lossy();
if entry_path.ends_with(&target) || entry_path == target { ... }
```

This crosses directory boundaries. An import of `./Button.vue` from `pages/Home.vue` would happily match a completely different `admin/Button.vue`, so cross-file diagnostics (props validation, event bubbling) could be attributed to the wrong child component.

## Fix

Replace the suffix-match fallback with correct relative-path resolution:

- Resolve the specifier against the importing file's directory (`from_dir.join(specifier)`).
- Normalize `.`/`..` segments to a canonical logical path (no filesystem access), matching the existing `normalize_logical_path` pattern already used in this crate's other path helpers.
- Match candidates against the canonical form of each registry entry's path, trying the usual module extensions and `index` files.

`./Button.vue` now resolves only to the sibling file, never to a same-named file in another directory. The change is self-contained to `crates/vize_croquis_cf`.

## Verification

- `cargo test -p vize_croquis_cf` — 123 passed (incl. 3 new regression tests: sibling resolves, cross-directory does not, parent-dir resolves).
- `cargo fmt --check -p vize_croquis_cf` — clean.
- `cargo clippy -p vize_croquis_cf --lib` — 0 warnings.

Refs #1394

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1443"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->