### PR TITLE
feat(maestro): resolve class-component template members in go-to-definition

### DIFF
--- a/crates/vize_maestro/src/ide/completion/template/bindings.rs
+++ b/crates/vize_maestro/src/ide/completion/template/bindings.rs
@@ -396,4 +396,39 @@ mod options_api_tests {
              (opt-in keeps the default <script setup> path zero cost); got {labels:?}"
         );
     }
+
+    // A vue-class-component SFC. Class members are auto-detected by AST shape,
+    // so they populate template completion with NO optionsApi flag.
+    const CLASS_COMPONENT_SFC: &str = "<script lang=\"ts\">\nimport { Vue, Component, Prop } from 'vue-property-decorator'\n@Component\nexport default class Counter extends Vue {\n  count = 0\n  @Prop() readonly title!: string\n  get doubled() { return this.count * 2 }\n  inc() { this.count++ }\n}\n</script>\n<template>\n  <p>{{ count }}</p>\n</template>\n";
+
+    fn class_component_labels() -> Vec<String> {
+        let state = ServerState::new();
+        let uri = Url::parse("file:///counter.vue").unwrap();
+        state.documents.open(
+            uri.clone(),
+            CLASS_COMPONENT_SFC.to_string(),
+            1,
+            "vue".to_string(),
+        );
+        let offset = CLASS_COMPONENT_SFC.find("count }}").unwrap();
+        let ctx = IdeContext::new(&state, &uri, offset).unwrap();
+        // optionsApi stays disabled: class components require no flag.
+        assert!(!ctx.state.options_api_enabled());
+        analyzed_template_binding_completions(&ctx, true)
+            .into_iter()
+            .map(|item| item.label)
+            .collect()
+    }
+
+    #[test]
+    fn class_component_members_completed_without_flag() {
+        let labels = class_component_labels();
+        for member in ["count", "title", "doubled", "inc"] {
+            assert!(
+                labels.iter().any(|label| label == member),
+                "class-component member `{member}` should be offered as a template \
+                 completion with no optionsApi flag; got {labels:?}"
+            );
+        }
+    }
 }

--- a/crates/vize_maestro/src/ide/definition.rs
+++ b/crates/vize_maestro/src/ide/definition.rs
@@ -644,6 +644,91 @@ const color = 'red'
         let _ = DefinitionService::definition(&ctx);
     }
 
+    // A vue-class-component SFC: a decorated class default export whose
+    // members (fields, getters, methods, `@Prop`s) are the template scope.
+    const CLASS_COMPONENT_SFC: &str = r#"<script lang="ts">
+import { Vue, Component, Prop } from 'vue-property-decorator'
+@Component
+export default class Counter extends Vue {
+  count = 0
+  @Prop() readonly title!: string
+  get doubled() { return this.count * 2 }
+  inc() { this.count++ }
+}
+</script>
+<template><p>{{ count }} {{ title }} {{ doubled }} {{ inc }}</p></template>
+"#;
+
+    fn open_doc(state: &ServerState, source: &str, name: &str) -> Url {
+        let dir = tempfile::tempdir().unwrap();
+        // Leak the tempdir so the file outlives the call; tests are short-lived.
+        let path = Box::leak(Box::new(dir)).path().join(name);
+        fs::write(&path, source).unwrap();
+        let uri = Url::from_file_path(&path).unwrap();
+        state
+            .documents
+            .open(uri.clone(), source.to_string(), 1, "vue".to_string());
+        state.update_virtual_docs(&uri, source);
+        uri
+    }
+
+    /// Class-component members are auto-detected by AST shape, so go-to-definition
+    /// on a class member used in the template must resolve to its class-body
+    /// declaration with **no** `optionsApi` flag enabled (plain Vue 3 project).
+    #[test]
+    fn definition_resolves_class_component_member_in_template_without_flag() {
+        let state = ServerState::new();
+        let uri = open_doc(&state, CLASS_COMPONENT_SFC, "Counter.vue");
+        assert!(
+            !state.options_api_enabled(),
+            "class-component support must not require the optionsApi flag"
+        );
+
+        for (member, decl) in [
+            ("count", "count = 0"),
+            ("doubled", "doubled()"),
+            ("inc", "inc()"),
+            ("title", "title!"),
+        ] {
+            let needle = format!("{member} }}}}");
+            let offset = CLASS_COMPONENT_SFC.find(&needle).unwrap();
+            let ctx = IdeContext::new(&state, &uri, offset).unwrap();
+            let location = scalar_location(
+                DefinitionService::definition(&ctx)
+                    .unwrap_or_else(|| panic!("no definition for class member `{member}`")),
+            );
+            assert_eq!(location.uri, uri);
+            let decl_offset = CLASS_COMPONENT_SFC.find(decl).unwrap();
+            let (line, _) = crate::ide::offset_to_position(CLASS_COMPONENT_SFC, decl_offset);
+            assert_eq!(
+                location.range.start.line, line,
+                "definition for `{member}` should point at its class-body declaration"
+            );
+        }
+    }
+
+    /// `find_analyzed_binding_location` self-gates: Options API object bindings
+    /// must remain opt-in (flag off => no resolution), so the zero-cost
+    /// `<script setup>` default path is unaffected.
+    #[test]
+    fn definition_options_api_data_requires_flag() {
+        let source = r#"<script>
+export default {
+  data() { return { greeting: 'hello' } },
+}
+</script>
+<template><p>{{ greeting }}</p></template>
+"#;
+        let state = ServerState::new();
+        let uri = open_doc(&state, source, "Greeting.vue");
+        let offset = source.find("greeting }}").unwrap();
+        let ctx = IdeContext::new(&state, &uri, offset).unwrap();
+        assert!(
+            script::find_analyzed_binding_location(&ctx, "greeting").is_none(),
+            "Options API data() binding must not resolve while optionsApi is disabled"
+        );
+    }
+
     fn scalar_location(response: GotoDefinitionResponse) -> Location {
         match response {
             GotoDefinitionResponse::Scalar(location) => location,

--- a/crates/vize_maestro/src/ide/definition/script.rs
+++ b/crates/vize_maestro/src/ide/definition/script.rs
@@ -76,16 +76,26 @@ pub(crate) fn definition_in_script(ctx: &IdeContext) -> Option<GotoDefinitionRes
         }
     }
 
-    if ctx.state.options_api_enabled()
-        && let Some(location) = find_analyzed_binding_location(ctx, &word)
-    {
+    // Options API object bindings (when enabled) and class-component members
+    // (always, auto-detected by shape) resolve through Croquis analysis.
+    if let Some(location) = find_analyzed_binding_location(ctx, &word) {
         return Some(GotoDefinitionResponse::Scalar(location));
     }
 
     None
 }
 
-/// Find a binding location from Croquis analysis, including opt-in Options API spans.
+/// Find a binding location from Croquis analysis.
+///
+/// Resolves three families of `<script>` template bindings:
+/// - opt-in Options API spans (`data`/`computed`/`methods`/`props`/`inject`),
+///   gated on [`ServerState::options_api_enabled`];
+/// - class-component members (vue-class-component / vue-property-decorator),
+///   which Croquis records shape-based with **no flag** — so they resolve in
+///   plain Vue 3 projects that never enable the Options API mode.
+///
+/// Returns `None` for ordinary `<script setup>` files without either signal,
+/// leaving the raw-text binding lookup untouched.
 pub(crate) fn find_analyzed_binding_location(ctx: &IdeContext, word: &str) -> Option<Location> {
     use vize_atelier_sfc::{
         SfcParseOptions,
@@ -96,6 +106,7 @@ pub(crate) fn find_analyzed_binding_location(ctx: &IdeContext, word: &str) -> Op
         },
         parse_sfc,
     };
+    use vize_croquis::ComponentShape;
 
     let descriptor = parse_sfc(
         &ctx.content,
@@ -107,13 +118,24 @@ pub(crate) fn find_analyzed_binding_location(ctx: &IdeContext, word: &str) -> Op
     .ok()?;
 
     let croquis_options = SfcCroquisOptions::full();
+    let options_api = ctx.state.options_api_enabled();
     let analysis = if ctx.state.legacy_vue2_enabled() {
         analyze_sfc_descriptor_with_context_legacy_vue2(&descriptor, None, croquis_options)
-    } else if ctx.state.options_api_enabled() {
+    } else if options_api {
         analyze_sfc_descriptor_with_context_options_api(&descriptor, None, croquis_options)
     } else {
         analyze_sfc_descriptor_with_context(&descriptor, None, croquis_options)
     };
+
+    // Class-component members are collected unconditionally (auto-detected by
+    // AST shape); Options API object bindings only when the mode is enabled.
+    // Without either signal, defer to the caller's raw-text lookup so plain
+    // `<script setup>` go-to-definition keeps its existing behavior.
+    let is_class = analysis.croquis.component_shape == ComponentShape::ClassApi;
+    if !options_api && !is_class {
+        return None;
+    }
+
     let &(start, end) = analysis.croquis.binding_spans.get(word)?;
     if end <= start {
         return None;

--- a/crates/vize_maestro/src/ide/definition/template.rs
+++ b/crates/vize_maestro/src/ide/definition/template.rs
@@ -46,9 +46,9 @@ pub(crate) fn definition_in_template(ctx: &IdeContext) -> Option<GotoDefinitionR
         return Some(def);
     }
 
-    if ctx.state.options_api_enabled()
-        && let Some(location) = super::script::find_analyzed_binding_location(ctx, &word)
-    {
+    // Resolve Options API bindings (when enabled) and class-component members
+    // (auto-detected by AST shape, no flag) to their `<script>` declaration.
+    if let Some(location) = super::script::find_analyzed_binding_location(ctx, &word) {
         return Some(GotoDefinitionResponse::Scalar(location));
     }
 


### PR DESCRIPTION
## Problem
Go-to-definition on a **vue-class-component** member (`count`, `@Prop`, getter, method) used inside a `<template>` returned nothing in a plain Vue 3 project. Class components require no opt-in flag, yet definition resolution was gated behind `optionsApi`.

## Current behavior (investigated)
Croquis records class-component members shape-based with **no flag** (`collect_class_component_metadata` runs unconditionally; sets `ComponentShape::ClassApi`). Verified across the three maestro template surfaces:
- **Completion** (`completion/template/bindings.rs`): already lists class members without a flag — works.
- **Hover** (`hover/template.rs::hover_ts_binding`): already resolves class members without a flag (runs croquis unconditionally) — works.
- **Definition** (`definition/template.rs`, `definition/script.rs`): gated the `find_analyzed_binding_location` call behind `ctx.state.options_api_enabled()` — **broken** for class components, even though the span lookup itself succeeds.

## Fix
Self-contained to `vize_maestro`. Move the gating into `find_analyzed_binding_location`: resolve a binding span when the Options API mode is enabled **or** the default export is a class component (`ComponentShape::ClassApi`); otherwise return `None` early so the zero-cost `<script setup>` raw-text path is unchanged. The two call sites now call it unconditionally (as a fallback after the raw-text lookup). Options API object bindings stay opt-in.

## Verification
- New tests:
  - `definition_resolves_class_component_member_in_template_without_flag` — go-to-definition resolves `count`/`title`/`doubled`/`inc` to their class-body declarations with the flag off.
  - `definition_options_api_data_requires_flag` — Options API `data()` binding still does not resolve while `optionsApi` is disabled (no accidental enablement).
  - `class_component_members_completed_without_flag` — regression coverage for the already-working completion path.
- `cargo test -p vize_maestro` — 307 passed, 0 failed.
- `cargo fmt -p vize_maestro --check` — clean.
- `cargo clippy -p vize_maestro --lib` — 0 warnings.

Refs #1388
Refs #1391

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1445"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->