### PR TITLE
fix(atelier): prefix Options API template bindings like Vue

### DIFF
--- a/crates/vize_atelier_core/src/codegen/expression/helpers.rs
+++ b/crates/vize_atelier_core/src/codegen/expression/helpers.rs
@@ -137,15 +137,13 @@ pub(crate) fn prefix_identifiers_with_context(content: &str, ctx: &CodegenContex
             let prefix = if let Some(ref metadata) = self.ctx.options.binding_metadata {
                 if let Some(binding) = metadata.bindings.get(name) {
                     binding_type = Some(*binding);
-                    match binding {
-                        BindingType::Props | BindingType::PropsAliased => "$props.",
-                        _ => {
-                            if self.ctx.options.inline {
-                                ""
-                            } else {
-                                "$setup."
-                            }
+                    if self.ctx.options.inline {
+                        match binding {
+                            BindingType::Props | BindingType::PropsAliased => "$props.",
+                            _ => "",
                         }
+                    } else {
+                        binding.non_inline_template_prefix()
                     }
                 } else {
                     "_ctx."
@@ -231,15 +229,13 @@ pub(crate) fn prefix_identifiers_with_context(content: &str, ctx: &CodegenContex
                                 binding_type,
                                 BindingType::SetupLet | BindingType::SetupMaybeRef
                             );
-                        match binding_type {
-                            BindingType::Props | BindingType::PropsAliased => "$props.",
-                            _ => {
-                                if self.ctx.options.inline {
-                                    ""
-                                } else {
-                                    "$setup."
-                                }
+                        if self.ctx.options.inline {
+                            match binding_type {
+                                BindingType::Props | BindingType::PropsAliased => "$props.",
+                                _ => "",
                             }
+                        } else {
+                            binding_type.non_inline_template_prefix()
                         }
                     } else {
                         "_ctx."

--- a/crates/vize_atelier_core/src/transforms/transform_expression/prefix.rs
+++ b/crates/vize_atelier_core/src/transforms/transform_expression/prefix.rs
@@ -53,9 +53,10 @@ pub(crate) fn get_identifier_prefix(
             // In inline mode, setup bindings are accessed directly via closure
             return None;
         } else {
-            // In function mode (inline = false), setup bindings use $setup. prefix
-            // This is the pattern Vue's @vitejs/plugin-vue uses for proper reactivity tracking
-            return Some("$setup.");
+            // In function mode (inline = false), bindings use the render-function
+            // prefix Vue's compiler-core emits: setup-* / literal-const → $setup.,
+            // data → $data., options (computed/methods/inject) → $options.
+            return Some(binding_type.non_inline_template_prefix());
         }
     }
 

--- a/crates/vize_atelier_sfc/src/compile.rs
+++ b/crates/vize_atelier_sfc/src/compile.rs
@@ -22,8 +22,8 @@ use crate::compile_template::{
 use crate::rewrite_default::rewrite_default;
 use crate::script::ScriptCompileContext;
 use crate::types::{
-    BindingType, SfcCompileOptions, SfcCompileResult, SfcDescriptor, SfcError, SfcMacroArtifact,
-    css_modules_object_literal,
+    BindingMetadata, BindingType, SfcCompileOptions, SfcCompileResult, SfcDescriptor, SfcError,
+    SfcMacroArtifact, css_modules_object_literal,
 };
 use vize_atelier_core::TemplateSyntaxMode;
 
@@ -495,6 +495,62 @@ fn compile_sfc_inner(
             final_script = script_with_preamble;
         }
 
+        // Resolve Options API template bindings (data / computed / methods /
+        // props / inject) from the plain `<script>` so the template compiler can
+        // emit the render-function prefixes Vue's compiler-sfc uses
+        // (`$data.`, `$options.`, `$props.`) instead of falling back to `_ctx.`
+        // for everything. This mirrors `@vue/compiler-sfc`, which feeds the
+        // analyzed Options API bindingMetadata to template codegen.
+        //
+        // Only the Options API member kinds are forwarded. `@vue/compiler-sfc`
+        // does NOT register top-level imports, module-local consts, or
+        // `components: {}` registrations from a non-`<script setup>` block as
+        // template bindings — Croquis assigns those `SetupConst`/`LiteralConst`,
+        // which would otherwise rewrite locally-registered components to
+        // `$setup.Foo` instead of leaving them for `_resolveComponent("Foo")`.
+        let options_api_bindings: Option<BindingMetadata> = if has_template {
+            // Parse the `<script>` once for Options API binding extraction only —
+            // this lighter `parse_script_with_options` path skips the full
+            // template/reactivity Croquis analysis the `<script setup>` path runs.
+            let parsed = profile!(
+                "atelier.sfc.normal_script.options_api_bindings",
+                vize_croquis::script_parser::parse_script_with_options(
+                    &script_content,
+                    vize_croquis::script_parser::ScriptParserOptions {
+                        options_api: true,
+                        legacy_vue2: false,
+                    },
+                )
+            );
+            let mut bindings = BindingMetadata::default();
+            for (name, bt) in parsed.bindings.iter() {
+                // Forward only the unambiguous Options API member kinds. Croquis
+                // assigns `SetupConst`/`LiteralConst` to top-level imports and
+                // module-local consts and `SetupMaybeRef` to `setup()` returns —
+                // none of which `@vue/compiler-sfc` registers as template
+                // bindings for a non-`<script setup>` block (forwarding them would
+                // rewrite locally-registered components to `$setup.Foo` instead of
+                // leaving them for `_resolveComponent("Foo")`).
+                if matches!(
+                    bt,
+                    BindingType::Data
+                        | BindingType::Options
+                        | BindingType::Props
+                        | BindingType::PropsAliased
+                ) {
+                    bindings.bindings.insert(name.to_compact_string(), bt);
+                }
+            }
+            for (local, key) in &parsed.bindings.props_aliases {
+                bindings
+                    .props_aliases
+                    .insert(local.to_compact_string(), key.to_compact_string());
+            }
+            (!bindings.bindings.is_empty()).then_some(bindings)
+        } else {
+            None
+        };
+
         // Compile template if present
         if has_template {
             let template = descriptor.template.as_ref().unwrap();
@@ -531,7 +587,7 @@ fn compile_sfc_inner(
                             is_ts: template_is_ts,
                             inline: false,
                             component_name: Some(&component_name),
-                            bindings: None,
+                            bindings: options_api_bindings.as_ref(),
                             croquis: None,
                         },
                         template_syntax,

--- a/crates/vize_atelier_sfc/src/compile/snapshots/vize_atelier_sfc__compile__tests__non_script_setup_typescript_preserved.snap
+++ b/crates/vize_atelier_sfc/src/compile/snapshots/vize_atelier_sfc__compile__tests__non_script_setup_typescript_preserved.snap
@@ -22,7 +22,7 @@ const _sfc_main = {
 
 import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 
-function _sfc_render(_ctx, _cache) {
+function _sfc_render(_ctx, _cache, $props, $setup, $data, $options) {
   return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.message), 1 /* TEXT */))
 }
 _sfc_main.render = _sfc_render

--- a/crates/vize_atelier_sfc/tests/allocation_budget.rs
+++ b/crates/vize_atelier_sfc/tests/allocation_budget.rs
@@ -87,9 +87,16 @@ const show = ref(true)
 
 const FIXTURES: &[Fixture] = &[
     // Budgets carry ~25-30% headroom over the measured steady state
-    // (script_setup 185 / 236_041, options_api 72 / 89_285,
+    // (script_setup 185 / 236_041, options_api 110 / 137_333,
     // template_heavy 262 / 327_764) so toolchain drift stays green while a real
     // regression trips the gate.
+    //
+    // The options_api steady state rose from 72 / 89_285 when the compiler began
+    // resolving Options API template bindings: a non-`<script setup>` component
+    // now parses its `<script>` a second time to extract `data`/`computed`/
+    // `methods`/`props`/`inject` binding metadata for the template prefixer
+    // (`$data.` / `$options.` / `$props.`), mirroring the dedicated binding pass
+    // `@vue/compiler-sfc` runs. Budgets re-blessed to keep ~25% headroom.
     Fixture {
         name: "script_setup",
         source: SCRIPT_SETUP,
@@ -99,8 +106,8 @@ const FIXTURES: &[Fixture] = &[
     Fixture {
         name: "options_api",
         source: OPTIONS_API,
-        max_alloc_calls: 92,
-        max_requested_bytes: 115_000,
+        max_alloc_calls: 140,
+        max_requested_bytes: 174_000,
     },
     Fixture {
         name: "template_heavy",

--- a/crates/vize_croquis/src/script_parser/process/options_api.rs
+++ b/crates/vize_croquis/src/script_parser/process/options_api.rs
@@ -220,12 +220,15 @@ fn collect_options_object_template_bindings<'a>(
         "asyncData",
         BindingType::Data,
     );
+    // Options API `setup()` return values are setup bindings, not `options`
+    // members: `@vue/compiler-sfc` types them `setup-maybe-ref`, so the template
+    // compiler prefixes them with `$setup.` (not `$options.`) in non-inline mode.
     collect_returned_object_option_bindings(
         result,
         options,
         object_bindings,
         "setup",
-        BindingType::Options,
+        BindingType::SetupMaybeRef,
     );
     collect_mixins_bindings(result, options, object_bindings, seen_mixins);
     collect_extends_bindings(result, options, object_bindings, seen_mixins);

--- a/crates/vize_relief/src/options.rs
+++ b/crates/vize_relief/src/options.rs
@@ -251,6 +251,42 @@ impl BindingType {
             Self::ExternalModule => "ext",
         }
     }
+
+    /// Render-function prefix for this binding in non-inline (function) mode,
+    /// matching `@vue/compiler-core`'s `rewriteIdentifier`:
+    ///
+    /// - setup-* bindings and `literal-const` → `$setup.`
+    /// - `props` → `$props.`
+    /// - `data` → `$data.`
+    /// - `options` (computed / methods / inject) → `$options.`
+    ///
+    /// `props-aliased` is intentionally not handled here: it rewrites to
+    /// `$props['<original-key>']` and must be resolved via the props-alias map
+    /// by the caller. Globals/external bindings fall back to `_ctx.` at the call
+    /// site and are not represented here.
+    #[inline]
+    pub const fn non_inline_template_prefix(self) -> &'static str {
+        match self {
+            Self::SetupLet
+            | Self::SetupMaybeRef
+            | Self::SetupRef
+            | Self::SetupReactiveConst
+            | Self::SetupConst
+            | Self::LiteralConst => "$setup.",
+            Self::Props | Self::PropsAliased => "$props.",
+            Self::Data => "$data.",
+            Self::Options => "$options.",
+            // Globals and external-module bindings are resolved to `_ctx.` by the
+            // caller; this arm keeps the match exhaustive and conservative.
+            Self::JsGlobalUniversal
+            | Self::JsGlobalBrowser
+            | Self::JsGlobalNode
+            | Self::JsGlobalDeno
+            | Self::JsGlobalBun
+            | Self::VueGlobal
+            | Self::ExternalModule => "$setup.",
+        }
+    }
 }
 
 /// Codegen options
@@ -416,6 +452,47 @@ mod tests {
         assert_eq!(BindingType::JsGlobalBun.to_vir(), "#bun");
         assert_eq!(BindingType::VueGlobal.to_vir(), "vue");
         assert_eq!(BindingType::ExternalModule.to_vir(), "ext");
+    }
+
+    #[test]
+    fn non_inline_template_prefix_matches_vue_compiler_core() {
+        // Mirrors `@vue/compiler-core`'s `rewriteIdentifier` else-branch:
+        // setup-* / literal-const -> $setup., props -> $props.,
+        // data -> $data., options -> $options.
+        assert_eq!(
+            BindingType::SetupLet.non_inline_template_prefix(),
+            "$setup."
+        );
+        assert_eq!(
+            BindingType::SetupMaybeRef.non_inline_template_prefix(),
+            "$setup."
+        );
+        assert_eq!(
+            BindingType::SetupRef.non_inline_template_prefix(),
+            "$setup."
+        );
+        assert_eq!(
+            BindingType::SetupReactiveConst.non_inline_template_prefix(),
+            "$setup."
+        );
+        assert_eq!(
+            BindingType::SetupConst.non_inline_template_prefix(),
+            "$setup."
+        );
+        assert_eq!(
+            BindingType::LiteralConst.non_inline_template_prefix(),
+            "$setup."
+        );
+        assert_eq!(BindingType::Props.non_inline_template_prefix(), "$props.");
+        assert_eq!(
+            BindingType::PropsAliased.non_inline_template_prefix(),
+            "$props."
+        );
+        assert_eq!(BindingType::Data.non_inline_template_prefix(), "$data.");
+        assert_eq!(
+            BindingType::Options.non_inline_template_prefix(),
+            "$options."
+        );
     }
 
     #[test]

--- a/tests/expected/sfc/basic.snap
+++ b/tests/expected/sfc/basic.snap
@@ -117,8 +117,8 @@ const _sfc_main = {
 
 import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 
-function _sfc_render(_ctx, _cache) {
-  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.msg), 1 /* TEXT */))
+function _sfc_render(_ctx, _cache, $props, $setup, $data, $options) {
+  return (_openBlock(), _createElementBlock("div", null, _toDisplayString($data.msg), 1 /* TEXT */))
 }
 _sfc_main.render = _sfc_render
 export default _sfc_main

--- a/tests/expected/sfc/patches.snap
+++ b/tests/expected/sfc/patches.snap
@@ -1094,8 +1094,8 @@ const _sfc_main = {
 
 import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 
-function _sfc_render(_ctx, _cache) {
-  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.msg) + " - " + _toDisplayString(_ctx.count), 1 /* TEXT */))
+function _sfc_render(_ctx, _cache, $props, $setup, $data, $options) {
+  return (_openBlock(), _createElementBlock("div", null, _toDisplayString($props.msg) + " - " + _toDisplayString($data.count), 1 /* TEXT */))
 }
 _sfc_main.render = _sfc_render
 export default _sfc_main
@@ -2002,10 +2002,10 @@ const _sfc_main = {
 
 import { openBlock as _openBlock, createElementBlock as _createElementBlock, createElementVNode as _createElementVNode, normalizeClass as _normalizeClass, normalizeStyle as _normalizeStyle } from "vue"
 
-function _sfc_render(_ctx, _cache) {
+function _sfc_render(_ctx, _cache, $props, $setup, $data, $options) {
   return (_openBlock(), _createElementBlock("div", { class: "map" }, [
     _createElementVNode("div", {
-      style: _normalizeStyle(_ctx.knobStyle),
+      style: _normalizeStyle($options.knobStyle),
       class: _normalizeClass({ dragging: _ctx.dragging })
     }, null, 6 /* CLASS, STYLE */)
   ]))

--- a/tests/snapshots/sfc/js/options_api__computed_get_set_with_v_model.snap
+++ b/tests/snapshots/sfc/js/options_api__computed_get_set_with_v_model.snap
@@ -23,11 +23,11 @@ const _sfc_main = {
 
 import { vModelText as _vModelText, withDirectives as _withDirectives, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 
-function _sfc_render(_ctx, _cache) {
+function _sfc_render(_ctx, _cache, $props, $setup, $data, $options) {
   return _withDirectives((_openBlock(), _createElementBlock("input", {
-    "onUpdate:modelValue": $event => ((_ctx.fullName) = $event)
+    "onUpdate:modelValue": $event => (($options.fullName) = $event)
   }, null, 8 /* PROPS */, ["onUpdate:modelValue"])), [
-    [_vModelText, _ctx.fullName]
+    [_vModelText, $options.fullName]
   ])
 }
 _sfc_main.render = _sfc_render

--- a/tests/snapshots/sfc/js/options_api__computed_object_form.snap
+++ b/tests/snapshots/sfc/js/options_api__computed_object_form.snap
@@ -16,8 +16,8 @@ const _sfc_main = {
 
 import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 
-function _sfc_render(_ctx, _cache) {
-  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.fullName), 1 /* TEXT */))
+function _sfc_render(_ctx, _cache, $props, $setup, $data, $options) {
+  return (_openBlock(), _createElementBlock("div", null, _toDisplayString($options.fullName), 1 /* TEXT */))
 }
 _sfc_main.render = _sfc_render
 export default _sfc_main

--- a/tests/snapshots/sfc/js/options_api__computed_used_in_class_binding.snap
+++ b/tests/snapshots/sfc/js/options_api__computed_used_in_class_binding.snap
@@ -16,9 +16,9 @@ const _sfc_main = {
 
 import { normalizeClass as _normalizeClass, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 
-function _sfc_render(_ctx, _cache) {
+function _sfc_render(_ctx, _cache, $props, $setup, $data, $options) {
   return (_openBlock(), _createElementBlock("div", {
-    class: _normalizeClass(_ctx.classes)
+    class: _normalizeClass($options.classes)
   }, "content", 2 /* CLASS */))
 }
 _sfc_main.render = _sfc_render

--- a/tests/snapshots/sfc/js/options_api__data_with_multiple_properties.snap
+++ b/tests/snapshots/sfc/js/options_api__data_with_multiple_properties.snap
@@ -11,8 +11,8 @@ const _sfc_main = {
 
 import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 
-function _sfc_render(_ctx, _cache) {
-  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.firstName) + " " + _toDisplayString(_ctx.lastName) + " (" + _toDisplayString(_ctx.count) + ")", 1 /* TEXT */))
+function _sfc_render(_ctx, _cache, $props, $setup, $data, $options) {
+  return (_openBlock(), _createElementBlock("div", null, _toDisplayString($data.firstName) + " " + _toDisplayString($data.lastName) + " (" + _toDisplayString($data.count) + ")", 1 /* TEXT */))
 }
 _sfc_main.render = _sfc_render
 export default _sfc_main

--- a/tests/snapshots/sfc/js/options_api__define_component_options_api_ts.snap
+++ b/tests/snapshots/sfc/js/options_api__define_component_options_api_ts.snap
@@ -14,8 +14,8 @@ const _sfc_main = defineComponent({
 
 import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 
-function _sfc_render(_ctx, _cache) {
-  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.doubled), 1 /* TEXT */))
+function _sfc_render(_ctx, _cache, $props, $setup, $data, $options) {
+  return (_openBlock(), _createElementBlock("div", null, _toDisplayString($options.doubled), 1 /* TEXT */))
 }
 _sfc_main.render = _sfc_render
 export default _sfc_main

--- a/tests/snapshots/sfc/js/options_api__directive_with_full_hooks.snap
+++ b/tests/snapshots/sfc/js/options_api__directive_with_full_hooks.snap
@@ -21,13 +21,13 @@ const _sfc_main = {
 
 import { resolveDirective as _resolveDirective, withDirectives as _withDirectives, openBlock as _openBlock, createElementBlock as _createElementBlock, createTextVNode as _createTextVNode } from "vue"
 
-function _sfc_render(_ctx, _cache) {
+function _sfc_render(_ctx, _cache, $props, $setup, $data, $options) {
   const _directive_color = _resolveDirective("color")
   
   return _withDirectives((_openBlock(), _createElementBlock("p", null, [
     _createTextVNode("text")
   ])), [
-    [_directive_color, _ctx.tint]
+    [_directive_color, $data.tint]
   ])
 }
 _sfc_main.render = _sfc_render

--- a/tests/snapshots/sfc/js/options_api__dynamic_class_and_style_from_data.snap
+++ b/tests/snapshots/sfc/js/options_api__dynamic_class_and_style_from_data.snap
@@ -11,10 +11,10 @@ const _sfc_main = {
 
 import { normalizeClass as _normalizeClass, normalizeStyle as _normalizeStyle, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 
-function _sfc_render(_ctx, _cache) {
+function _sfc_render(_ctx, _cache, $props, $setup, $data, $options) {
   return (_openBlock(), _createElementBlock("div", {
-    class: _normalizeClass({ active: _ctx.active }),
-    style: _normalizeStyle({ color: _ctx.color })
+    class: _normalizeClass({ active: $data.active }),
+    style: _normalizeStyle({ color: $data.color })
   }, "content", 6 /* CLASS, STYLE */))
 }
 _sfc_main.render = _sfc_render

--- a/tests/snapshots/sfc/js/options_api__dynamic_component_is_binding.snap
+++ b/tests/snapshots/sfc/js/options_api__dynamic_component_is_binding.snap
@@ -15,8 +15,8 @@ const _sfc_main = {
 
 import { resolveDynamicComponent as _resolveDynamicComponent, openBlock as _openBlock, createBlock as _createBlock } from "vue"
 
-function _sfc_render(_ctx, _cache) {
-  return (_openBlock(), _createBlock(_resolveDynamicComponent(_ctx.current)))
+function _sfc_render(_ctx, _cache, $props, $setup, $data, $options) {
+  return (_openBlock(), _createBlock(_resolveDynamicComponent($data.current)))
 }
 _sfc_main.render = _sfc_render
 export default _sfc_main

--- a/tests/snapshots/sfc/js/options_api__emits_object_form_with_validator.snap
+++ b/tests/snapshots/sfc/js/options_api__emits_object_form_with_validator.snap
@@ -15,9 +15,9 @@ const _sfc_main = {
 
 import { openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 
-function _sfc_render(_ctx, _cache) {
+function _sfc_render(_ctx, _cache, $props, $setup, $data, $options) {
   return (_openBlock(), _createElementBlock("button", {
-    onClick: $event => (_ctx.$emit('submit', _ctx.value))
+    onClick: $event => (_ctx.$emit('submit', $data.value))
   }, "go", 8 /* PROPS */, ["onClick"]))
 }
 _sfc_main.render = _sfc_render

--- a/tests/snapshots/sfc/js/options_api__emits_with_template_emit.snap
+++ b/tests/snapshots/sfc/js/options_api__emits_with_template_emit.snap
@@ -12,9 +12,9 @@ const _sfc_main = {
 
 import { withModifiers as _withModifiers, createElementVNode as _createElementVNode, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 
-function _sfc_render(_ctx, _cache) {
+function _sfc_render(_ctx, _cache, $props, $setup, $data, $options) {
   return (_openBlock(), _createElementBlock("form", {
-    onSubmit: _withModifiers($event => (_ctx.$emit('submit', _ctx.value)), ["prevent"])
+    onSubmit: _withModifiers($event => (_ctx.$emit('submit', $data.value)), ["prevent"])
   }, [
     _createElementVNode("button", {
       type: "button",

--- a/tests/snapshots/sfc/js/options_api__expose_option.snap
+++ b/tests/snapshots/sfc/js/options_api__expose_option.snap
@@ -17,8 +17,8 @@ const _sfc_main = {
 
 import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 
-function _sfc_render(_ctx, _cache) {
-  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.count), 1 /* TEXT */))
+function _sfc_render(_ctx, _cache, $props, $setup, $data, $options) {
+  return (_openBlock(), _createElementBlock("div", null, _toDisplayString($data.count), 1 /* TEXT */))
 }
 _sfc_main.render = _sfc_render
 export default _sfc_main

--- a/tests/snapshots/sfc/js/options_api__extends_base_component.snap
+++ b/tests/snapshots/sfc/js/options_api__extends_base_component.snap
@@ -14,8 +14,8 @@ const _sfc_main = {
 
 import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 
-function _sfc_render(_ctx, _cache) {
-  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.extra), 1 /* TEXT */))
+function _sfc_render(_ctx, _cache, $props, $setup, $data, $options) {
+  return (_openBlock(), _createElementBlock("div", null, _toDisplayString($data.extra), 1 /* TEXT */))
 }
 _sfc_main.render = _sfc_render
 export default _sfc_main

--- a/tests/snapshots/sfc/js/options_api__fragment_multiple_root_nodes.snap
+++ b/tests/snapshots/sfc/js/options_api__fragment_multiple_root_nodes.snap
@@ -11,10 +11,10 @@ const _sfc_main = {
 
 import { toDisplayString as _toDisplayString, createElementVNode as _createElementVNode, openBlock as _openBlock, createElementBlock as _createElementBlock, Fragment as _Fragment } from "vue"
 
-function _sfc_render(_ctx, _cache) {
+function _sfc_render(_ctx, _cache, $props, $setup, $data, $options) {
   return (_openBlock(), _createElementBlock(_Fragment, null, [
-    _createElementVNode("header", null, _toDisplayString(_ctx.a), 1 /* TEXT */),
-    _createElementVNode("main", null, _toDisplayString(_ctx.b), 1 /* TEXT */)
+    _createElementVNode("header", null, _toDisplayString($data.a), 1 /* TEXT */),
+    _createElementVNode("main", null, _toDisplayString($data.b), 1 /* TEXT */)
   ], 64 /* STABLE_FRAGMENT */))
 }
 _sfc_main.render = _sfc_render

--- a/tests/snapshots/sfc/js/options_api__inject_array_form.snap
+++ b/tests/snapshots/sfc/js/options_api__inject_array_form.snap
@@ -9,8 +9,8 @@ const _sfc_main = {
 
 import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 
-function _sfc_render(_ctx, _cache) {
-  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.theme) + " " + _toDisplayString(_ctx.locale), 1 /* TEXT */))
+function _sfc_render(_ctx, _cache, $props, $setup, $data, $options) {
+  return (_openBlock(), _createElementBlock("div", null, _toDisplayString($options.theme) + " " + _toDisplayString($options.locale), 1 /* TEXT */))
 }
 _sfc_main.render = _sfc_render
 export default _sfc_main

--- a/tests/snapshots/sfc/js/options_api__keep_alive_wrapping_dynamic_component.snap
+++ b/tests/snapshots/sfc/js/options_api__keep_alive_wrapping_dynamic_component.snap
@@ -11,9 +11,9 @@ const _sfc_main = {
 
 import { resolveDynamicComponent as _resolveDynamicComponent, openBlock as _openBlock, createBlock as _createBlock, KeepAlive as _KeepAlive } from "vue"
 
-function _sfc_render(_ctx, _cache) {
+function _sfc_render(_ctx, _cache, $props, $setup, $data, $options) {
   return (_openBlock(), _createBlock(_KeepAlive, null, [
-    (_openBlock(), _createBlock(_resolveDynamicComponent(_ctx.view)))
+    (_openBlock(), _createBlock(_resolveDynamicComponent($data.view)))
   ], 1024 /* DYNAMIC_SLOTS */))
 }
 _sfc_main.render = _sfc_render

--- a/tests/snapshots/sfc/js/options_api__lifecycle_hooks.snap
+++ b/tests/snapshots/sfc/js/options_api__lifecycle_hooks.snap
@@ -20,8 +20,8 @@ const _sfc_main = {
 
 import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 
-function _sfc_render(_ctx, _cache) {
-  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.ready), 1 /* TEXT */))
+function _sfc_render(_ctx, _cache, $props, $setup, $data, $options) {
+  return (_openBlock(), _createElementBlock("div", null, _toDisplayString($data.ready), 1 /* TEXT */))
 }
 _sfc_main.render = _sfc_render
 export default _sfc_main

--- a/tests/snapshots/sfc/js/options_api__method_called_in_interpolation.snap
+++ b/tests/snapshots/sfc/js/options_api__method_called_in_interpolation.snap
@@ -16,8 +16,8 @@ const _sfc_main = {
 
 import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 
-function _sfc_render(_ctx, _cache) {
-  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.greet(_ctx.name)), 1 /* TEXT */))
+function _sfc_render(_ctx, _cache, $props, $setup, $data, $options) {
+  return (_openBlock(), _createElementBlock("div", null, _toDisplayString($options.greet($data.name)), 1 /* TEXT */))
 }
 _sfc_main.render = _sfc_render
 export default _sfc_main

--- a/tests/snapshots/sfc/js/options_api__methods_with_event_handler.snap
+++ b/tests/snapshots/sfc/js/options_api__methods_with_event_handler.snap
@@ -16,8 +16,8 @@ const _sfc_main = {
 
 import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 
-function _sfc_render(_ctx, _cache) {
-  return (_openBlock(), _createElementBlock("button", { onClick: _ctx.increment }, _toDisplayString(_ctx.count), 9 /* TEXT, PROPS */, ["onClick"]))
+function _sfc_render(_ctx, _cache, $props, $setup, $data, $options) {
+  return (_openBlock(), _createElementBlock("button", { onClick: $options.increment }, _toDisplayString($data.count), 9 /* TEXT, PROPS */, ["onClick"]))
 }
 _sfc_main.render = _sfc_render
 export default _sfc_main

--- a/tests/snapshots/sfc/js/options_api__mixins.snap
+++ b/tests/snapshots/sfc/js/options_api__mixins.snap
@@ -14,8 +14,8 @@ const _sfc_main = {
 
 import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 
-function _sfc_render(_ctx, _cache) {
-  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.local) + " " + _toDisplayString(_ctx.sharedValue), 1 /* TEXT */))
+function _sfc_render(_ctx, _cache, $props, $setup, $data, $options) {
+  return (_openBlock(), _createElementBlock("div", null, _toDisplayString($data.local) + " " + _toDisplayString(_ctx.sharedValue), 1 /* TEXT */))
 }
 _sfc_main.render = _sfc_render
 export default _sfc_main

--- a/tests/snapshots/sfc/js/options_api__mixins_and_extends_combined.snap
+++ b/tests/snapshots/sfc/js/options_api__mixins_and_extends_combined.snap
@@ -16,8 +16,8 @@ const _sfc_main = {
 
 import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 
-function _sfc_render(_ctx, _cache) {
-  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.own), 1 /* TEXT */))
+function _sfc_render(_ctx, _cache, $props, $setup, $data, $options) {
+  return (_openBlock(), _createElementBlock("div", null, _toDisplayString($data.own), 1 /* TEXT */))
 }
 _sfc_main.render = _sfc_render
 export default _sfc_main

--- a/tests/snapshots/sfc/js/options_api__name_and_inherit_attrs.snap
+++ b/tests/snapshots/sfc/js/options_api__name_and_inherit_attrs.snap
@@ -11,8 +11,8 @@ const _sfc_main = {
 
 import { toDisplayString as _toDisplayString, normalizeProps as _normalizeProps, guardReactiveProps as _guardReactiveProps, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 
-function _sfc_render(_ctx, _cache) {
-  return (_openBlock(), _createElementBlock("div", _normalizeProps(_guardReactiveProps(_ctx.$attrs)), _toDisplayString(_ctx.label), 17 /* TEXT, FULL_PROPS */))
+function _sfc_render(_ctx, _cache, $props, $setup, $data, $options) {
+  return (_openBlock(), _createElementBlock("div", _normalizeProps(_guardReactiveProps(_ctx.$attrs)), _toDisplayString($props.label), 17 /* TEXT, FULL_PROPS */))
 }
 _sfc_main.render = _sfc_render
 export default _sfc_main

--- a/tests/snapshots/sfc/js/options_api__named_and_scoped_slots_in_child.snap
+++ b/tests/snapshots/sfc/js/options_api__named_and_scoped_slots_in_child.snap
@@ -16,7 +16,7 @@ import { resolveComponent as _resolveComponent, toDisplayString as _toDisplayStr
 
 const _hoisted_1 = /*#__PURE__*/ _createElementVNode("h1", null, "Title")
 
-function _sfc_render(_ctx, _cache) {
+function _sfc_render(_ctx, _cache, $props, $setup, $data, $options) {
   const _component_Layout = _resolveComponent("Layout")
   
   return (_openBlock(), _createBlock(_component_Layout, null, {

--- a/tests/snapshots/sfc/js/options_api__props_array_form.snap
+++ b/tests/snapshots/sfc/js/options_api__props_array_form.snap
@@ -9,8 +9,8 @@ const _sfc_main = {
 
 import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 
-function _sfc_render(_ctx, _cache) {
-  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.title) + ": " + _toDisplayString(_ctx.count), 1 /* TEXT */))
+function _sfc_render(_ctx, _cache, $props, $setup, $data, $options) {
+  return (_openBlock(), _createElementBlock("div", null, _toDisplayString($props.title) + ": " + _toDisplayString($props.count), 1 /* TEXT */))
 }
 _sfc_main.render = _sfc_render
 export default _sfc_main

--- a/tests/snapshots/sfc/js/options_api__props_object_form_with_defaults.snap
+++ b/tests/snapshots/sfc/js/options_api__props_object_form_with_defaults.snap
@@ -22,8 +22,8 @@ const _sfc_main = {
 
 import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 
-function _sfc_render(_ctx, _cache) {
-  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.title) + ": " + _toDisplayString(_ctx.count) + " (" + _toDisplayString(_ctx.items.length) + ")", 1 /* TEXT */))
+function _sfc_render(_ctx, _cache, $props, $setup, $data, $options) {
+  return (_openBlock(), _createElementBlock("div", null, _toDisplayString($props.title) + ": " + _toDisplayString($props.count) + " (" + _toDisplayString($props.items.length) + ")", 1 /* TEXT */))
 }
 _sfc_main.render = _sfc_render
 export default _sfc_main

--- a/tests/snapshots/sfc/js/options_api__props_with_prop_type_typescript.snap
+++ b/tests/snapshots/sfc/js/options_api__props_with_prop_type_typescript.snap
@@ -10,8 +10,8 @@ const _sfc_main = defineComponent({ props: { items: {
 
 import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 
-function _sfc_render(_ctx, _cache) {
-  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.items.length), 1 /* TEXT */))
+function _sfc_render(_ctx, _cache, $props, $setup, $data, $options) {
+  return (_openBlock(), _createElementBlock("div", null, _toDisplayString($props.items.length), 1 /* TEXT */))
 }
 _sfc_main.render = _sfc_render
 export default _sfc_main

--- a/tests/snapshots/sfc/js/options_api__provide_and_inject.snap
+++ b/tests/snapshots/sfc/js/options_api__provide_and_inject.snap
@@ -17,8 +17,8 @@ const _sfc_main = {
 
 import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 
-function _sfc_render(_ctx, _cache) {
-  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.parentTheme), 1 /* TEXT */))
+function _sfc_render(_ctx, _cache, $props, $setup, $data, $options) {
+  return (_openBlock(), _createElementBlock("div", null, _toDisplayString($options.parentTheme), 1 /* TEXT */))
 }
 _sfc_main.render = _sfc_render
 export default _sfc_main

--- a/tests/snapshots/sfc/js/options_api__recursive_self_component.snap
+++ b/tests/snapshots/sfc/js/options_api__recursive_self_component.snap
@@ -10,14 +10,14 @@ const _sfc_main = {
 
 import { resolveComponent as _resolveComponent, toDisplayString as _toDisplayString, openBlock as _openBlock, createBlock as _createBlock, createElementBlock as _createElementBlock, Fragment as _Fragment, createTextVNode as _createTextVNode, createCommentVNode as _createCommentVNode, renderList as _renderList } from "vue"
 
-function _sfc_render(_ctx, _cache) {
+function _sfc_render(_ctx, _cache, $props, $setup, $data, $options) {
   const _component_TreeNode = _resolveComponent("TreeNode")
   
   return (_openBlock(), _createElementBlock("li", null, [
-    _createTextVNode(_toDisplayString(_ctx.node.label) + " ", 1 /* TEXT */),
-    (_ctx.node.children)
+    _createTextVNode(_toDisplayString($props.node.label) + " ", 1 /* TEXT */),
+    ($props.node.children)
       ? (_openBlock(), _createElementBlock("ul", { key: 0 }, [
-        (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(_ctx.node.children, (child) => {
+        (_openBlock(true), _createElementBlock(_Fragment, null, _renderList($props.node.children, (child) => {
           return (_openBlock(), _createBlock(_component_TreeNode, {
             key: child.id,
             node: child

--- a/tests/snapshots/sfc/js/options_api__setup_function_with_options_api.snap
+++ b/tests/snapshots/sfc/js/options_api__setup_function_with_options_api.snap
@@ -17,8 +17,8 @@ const _sfc_main = {
 
 import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 
-function _sfc_render(_ctx, _cache) {
-  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.fromSetup) + " " + _toDisplayString(_ctx.fromData), 1 /* TEXT */))
+function _sfc_render(_ctx, _cache, $props, $setup, $data, $options) {
+  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.fromSetup) + " " + _toDisplayString($data.fromData), 1 /* TEXT */))
 }
 _sfc_main.render = _sfc_render
 export default _sfc_main

--- a/tests/snapshots/sfc/js/options_api__v_for_over_data_array.snap
+++ b/tests/snapshots/sfc/js/options_api__v_for_over_data_array.snap
@@ -11,9 +11,9 @@ const _sfc_main = {
 
 import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock, Fragment as _Fragment, renderList as _renderList } from "vue"
 
-function _sfc_render(_ctx, _cache) {
+function _sfc_render(_ctx, _cache, $props, $setup, $data, $options) {
   return (_openBlock(), _createElementBlock("ul", null, [
-    (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(_ctx.items, (item, index) => {
+    (_openBlock(true), _createElementBlock(_Fragment, null, _renderList($data.items, (item, index) => {
       return (_openBlock(), _createElementBlock("li", { key: index }, _toDisplayString(item), 1 /* TEXT */))
     }), 128 /* KEYED_FRAGMENT */))
   ]))

--- a/tests/snapshots/sfc/js/options_api__v_if_with_computed_condition.snap
+++ b/tests/snapshots/sfc/js/options_api__v_if_with_computed_condition.snap
@@ -16,11 +16,11 @@ const _sfc_main = {
 
 import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock, createCommentVNode as _createCommentVNode } from "vue"
 
-function _sfc_render(_ctx, _cache) {
+function _sfc_render(_ctx, _cache, $props, $setup, $data, $options) {
   return (_openBlock(), _createElementBlock("div", null, [
-    (_ctx.isEmpty)
+    ($options.isEmpty)
       ? (_openBlock(), _createElementBlock("p", { key: 0 }, "empty"))
-      : (_openBlock(), _createElementBlock("p", { key: 1 }, _toDisplayString(_ctx.count), 1 /* TEXT */))
+      : (_openBlock(), _createElementBlock("p", { key: 1 }, _toDisplayString($data.count), 1 /* TEXT */))
   ]))
 }
 _sfc_main.render = _sfc_render

--- a/tests/snapshots/sfc/js/options_api__v_model_on_component.snap
+++ b/tests/snapshots/sfc/js/options_api__v_model_on_component.snap
@@ -14,12 +14,12 @@ const _sfc_main = {
 
 import { resolveComponent as _resolveComponent, openBlock as _openBlock, createBlock as _createBlock } from "vue"
 
-function _sfc_render(_ctx, _cache) {
+function _sfc_render(_ctx, _cache, $props, $setup, $data, $options) {
   const _component_TextField = _resolveComponent("TextField")
   
   return (_openBlock(), _createBlock(_component_TextField, {
-    modelValue: _ctx.name,
-    "onUpdate:modelValue": $event => ((_ctx.name) = $event)
+    modelValue: $data.name,
+    "onUpdate:modelValue": $event => (($data.name) = $event)
   }, null, 8 /* PROPS */, ["modelValue", "onUpdate:modelValue"]))
 }
 _sfc_main.render = _sfc_render

--- a/tests/snapshots/sfc/js/options_api__watch_handlers_object_and_deep.snap
+++ b/tests/snapshots/sfc/js/options_api__watch_handlers_object_and_deep.snap
@@ -23,11 +23,11 @@ const _sfc_main = {
 
 import { vModelText as _vModelText, withDirectives as _withDirectives, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 
-function _sfc_render(_ctx, _cache) {
+function _sfc_render(_ctx, _cache, $props, $setup, $data, $options) {
   return _withDirectives((_openBlock(), _createElementBlock("input", {
-    "onUpdate:modelValue": $event => ((_ctx.question) = $event)
+    "onUpdate:modelValue": $event => (($data.question) = $event)
   }, null, 8 /* PROPS */, ["onUpdate:modelValue"])), [
-    [_vModelText, _ctx.question]
+    [_vModelText, $data.question]
   ])
 }
 _sfc_main.render = _sfc_render

--- a/tests/snapshots/sfc/js/options_api__watch_nested_path_string_key.snap
+++ b/tests/snapshots/sfc/js/options_api__watch_nested_path_string_key.snap
@@ -17,11 +17,11 @@ const _sfc_main = {
 
 import { vModelText as _vModelText, withDirectives as _withDirectives, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 
-function _sfc_render(_ctx, _cache) {
+function _sfc_render(_ctx, _cache, $props, $setup, $data, $options) {
   return _withDirectives((_openBlock(), _createElementBlock("input", {
-    "onUpdate:modelValue": $event => ((_ctx.form.name) = $event)
+    "onUpdate:modelValue": $event => (($data.form.name) = $event)
   }, null, 8 /* PROPS */, ["onUpdate:modelValue"])), [
-    [_vModelText, _ctx.form.name]
+    [_vModelText, $data.form.name]
   ])
 }
 _sfc_main.render = _sfc_render

--- a/tests/snapshots/sfc/js/patches__non_script_setup_component_with_export_default.snap
+++ b/tests/snapshots/sfc/js/patches__non_script_setup_component_with_export_default.snap
@@ -17,8 +17,8 @@ const _sfc_main = {
 
 import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 
-function _sfc_render(_ctx, _cache) {
-  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.msg) + " - " + _toDisplayString(_ctx.count), 1 /* TEXT */))
+function _sfc_render(_ctx, _cache, $props, $setup, $data, $options) {
+  return (_openBlock(), _createElementBlock("div", null, _toDisplayString($props.msg) + " - " + _toDisplayString($data.count), 1 /* TEXT */))
 }
 _sfc_main.render = _sfc_render
 export default _sfc_main

--- a/tests/snapshots/sfc/js/patches__options_api_dynamic_style_and_class_keep_patch_flags.snap
+++ b/tests/snapshots/sfc/js/patches__options_api_dynamic_style_and_class_keep_patch_flags.snap
@@ -13,10 +13,10 @@ const _sfc_main = {
 
 import { createElementVNode as _createElementVNode, normalizeStyle as _normalizeStyle, normalizeClass as _normalizeClass, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 
-function _sfc_render(_ctx, _cache) {
+function _sfc_render(_ctx, _cache, $props, $setup, $data, $options) {
   return (_openBlock(), _createElementBlock("div", { class: "map" }, [
     _createElementVNode("div", {
-      style: _normalizeStyle(_ctx.knobStyle),
+      style: _normalizeStyle($options.knobStyle),
       class: _normalizeClass({ dragging: _ctx.dragging })
     }, null, 6 /* CLASS, STYLE */)
   ]))

--- a/tests/snapshots/sfc/ts/basic__options_api_component.snap
+++ b/tests/snapshots/sfc/ts/basic__options_api_component.snap
@@ -11,8 +11,8 @@ const _sfc_main = {
 
 import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 
-function _sfc_render(_ctx, _cache) {
-  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.msg), 1 /* TEXT */))
+function _sfc_render(_ctx, _cache, $props, $setup, $data, $options) {
+  return (_openBlock(), _createElementBlock("div", null, _toDisplayString($data.msg), 1 /* TEXT */))
 }
 _sfc_main.render = _sfc_render
 export default _sfc_main

--- a/tests/snapshots/sfc/ts/options_api__computed_get_set_with_v_model.snap
+++ b/tests/snapshots/sfc/ts/options_api__computed_get_set_with_v_model.snap
@@ -23,11 +23,11 @@ const _sfc_main = {
 
 import { vModelText as _vModelText, withDirectives as _withDirectives, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 
-function _sfc_render(_ctx, _cache) {
+function _sfc_render(_ctx, _cache, $props, $setup, $data, $options) {
   return _withDirectives((_openBlock(), _createElementBlock("input", {
-    "onUpdate:modelValue": $event => ((_ctx.fullName) = $event)
+    "onUpdate:modelValue": $event => (($options.fullName) = $event)
   }, null, 8 /* PROPS */, ["onUpdate:modelValue"])), [
-    [_vModelText, _ctx.fullName]
+    [_vModelText, $options.fullName]
   ])
 }
 _sfc_main.render = _sfc_render

--- a/tests/snapshots/sfc/ts/options_api__computed_object_form.snap
+++ b/tests/snapshots/sfc/ts/options_api__computed_object_form.snap
@@ -16,8 +16,8 @@ const _sfc_main = {
 
 import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 
-function _sfc_render(_ctx, _cache) {
-  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.fullName), 1 /* TEXT */))
+function _sfc_render(_ctx, _cache, $props, $setup, $data, $options) {
+  return (_openBlock(), _createElementBlock("div", null, _toDisplayString($options.fullName), 1 /* TEXT */))
 }
 _sfc_main.render = _sfc_render
 export default _sfc_main

--- a/tests/snapshots/sfc/ts/options_api__computed_used_in_class_binding.snap
+++ b/tests/snapshots/sfc/ts/options_api__computed_used_in_class_binding.snap
@@ -16,9 +16,9 @@ const _sfc_main = {
 
 import { normalizeClass as _normalizeClass, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 
-function _sfc_render(_ctx, _cache) {
+function _sfc_render(_ctx, _cache, $props, $setup, $data, $options) {
   return (_openBlock(), _createElementBlock("div", {
-    class: _normalizeClass(_ctx.classes)
+    class: _normalizeClass($options.classes)
   }, "content", 2 /* CLASS */))
 }
 _sfc_main.render = _sfc_render

--- a/tests/snapshots/sfc/ts/options_api__data_with_multiple_properties.snap
+++ b/tests/snapshots/sfc/ts/options_api__data_with_multiple_properties.snap
@@ -11,8 +11,8 @@ const _sfc_main = {
 
 import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 
-function _sfc_render(_ctx, _cache) {
-  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.firstName) + " " + _toDisplayString(_ctx.lastName) + " (" + _toDisplayString(_ctx.count) + ")", 1 /* TEXT */))
+function _sfc_render(_ctx, _cache, $props, $setup, $data, $options) {
+  return (_openBlock(), _createElementBlock("div", null, _toDisplayString($data.firstName) + " " + _toDisplayString($data.lastName) + " (" + _toDisplayString($data.count) + ")", 1 /* TEXT */))
 }
 _sfc_main.render = _sfc_render
 export default _sfc_main

--- a/tests/snapshots/sfc/ts/options_api__define_component_options_api_ts.snap
+++ b/tests/snapshots/sfc/ts/options_api__define_component_options_api_ts.snap
@@ -18,8 +18,8 @@ const _sfc_main = defineComponent({
 
 import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 
-function _sfc_render(_ctx, _cache) {
-  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.doubled), 1 /* TEXT */))
+function _sfc_render(_ctx, _cache, $props, $setup, $data, $options) {
+  return (_openBlock(), _createElementBlock("div", null, _toDisplayString($options.doubled), 1 /* TEXT */))
 }
 _sfc_main.render = _sfc_render
 export default _sfc_main

--- a/tests/snapshots/sfc/ts/options_api__directive_with_full_hooks.snap
+++ b/tests/snapshots/sfc/ts/options_api__directive_with_full_hooks.snap
@@ -21,13 +21,13 @@ const _sfc_main = {
 
 import { resolveDirective as _resolveDirective, withDirectives as _withDirectives, openBlock as _openBlock, createElementBlock as _createElementBlock, createTextVNode as _createTextVNode } from "vue"
 
-function _sfc_render(_ctx, _cache) {
+function _sfc_render(_ctx, _cache, $props, $setup, $data, $options) {
   const _directive_color = _resolveDirective("color")
   
   return _withDirectives((_openBlock(), _createElementBlock("p", null, [
     _createTextVNode("text")
   ])), [
-    [_directive_color, _ctx.tint]
+    [_directive_color, $data.tint]
   ])
 }
 _sfc_main.render = _sfc_render

--- a/tests/snapshots/sfc/ts/options_api__dynamic_class_and_style_from_data.snap
+++ b/tests/snapshots/sfc/ts/options_api__dynamic_class_and_style_from_data.snap
@@ -11,10 +11,10 @@ const _sfc_main = {
 
 import { normalizeClass as _normalizeClass, normalizeStyle as _normalizeStyle, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 
-function _sfc_render(_ctx, _cache) {
+function _sfc_render(_ctx, _cache, $props, $setup, $data, $options) {
   return (_openBlock(), _createElementBlock("div", {
-    class: _normalizeClass({ active: _ctx.active }),
-    style: _normalizeStyle({ color: _ctx.color })
+    class: _normalizeClass({ active: $data.active }),
+    style: _normalizeStyle({ color: $data.color })
   }, "content", 6 /* CLASS, STYLE */))
 }
 _sfc_main.render = _sfc_render

--- a/tests/snapshots/sfc/ts/options_api__dynamic_component_is_binding.snap
+++ b/tests/snapshots/sfc/ts/options_api__dynamic_component_is_binding.snap
@@ -15,8 +15,8 @@ const _sfc_main = {
 
 import { resolveDynamicComponent as _resolveDynamicComponent, openBlock as _openBlock, createBlock as _createBlock } from "vue"
 
-function _sfc_render(_ctx, _cache) {
-  return (_openBlock(), _createBlock(_resolveDynamicComponent(_ctx.current)))
+function _sfc_render(_ctx, _cache, $props, $setup, $data, $options) {
+  return (_openBlock(), _createBlock(_resolveDynamicComponent($data.current)))
 }
 _sfc_main.render = _sfc_render
 export default _sfc_main

--- a/tests/snapshots/sfc/ts/options_api__emits_object_form_with_validator.snap
+++ b/tests/snapshots/sfc/ts/options_api__emits_object_form_with_validator.snap
@@ -15,9 +15,9 @@ const _sfc_main = {
 
 import { openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 
-function _sfc_render(_ctx, _cache) {
+function _sfc_render(_ctx, _cache, $props, $setup, $data, $options) {
   return (_openBlock(), _createElementBlock("button", {
-    onClick: $event => (_ctx.$emit('submit', _ctx.value))
+    onClick: $event => (_ctx.$emit('submit', $data.value))
   }, "go", 8 /* PROPS */, ["onClick"]))
 }
 _sfc_main.render = _sfc_render

--- a/tests/snapshots/sfc/ts/options_api__emits_with_template_emit.snap
+++ b/tests/snapshots/sfc/ts/options_api__emits_with_template_emit.snap
@@ -12,9 +12,9 @@ const _sfc_main = {
 
 import { withModifiers as _withModifiers, createElementVNode as _createElementVNode, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 
-function _sfc_render(_ctx, _cache) {
+function _sfc_render(_ctx, _cache, $props, $setup, $data, $options) {
   return (_openBlock(), _createElementBlock("form", {
-    onSubmit: _withModifiers($event => (_ctx.$emit('submit', _ctx.value)), ["prevent"])
+    onSubmit: _withModifiers($event => (_ctx.$emit('submit', $data.value)), ["prevent"])
   }, [
     _createElementVNode("button", {
       type: "button",

--- a/tests/snapshots/sfc/ts/options_api__expose_option.snap
+++ b/tests/snapshots/sfc/ts/options_api__expose_option.snap
@@ -17,8 +17,8 @@ const _sfc_main = {
 
 import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 
-function _sfc_render(_ctx, _cache) {
-  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.count), 1 /* TEXT */))
+function _sfc_render(_ctx, _cache, $props, $setup, $data, $options) {
+  return (_openBlock(), _createElementBlock("div", null, _toDisplayString($data.count), 1 /* TEXT */))
 }
 _sfc_main.render = _sfc_render
 export default _sfc_main

--- a/tests/snapshots/sfc/ts/options_api__extends_base_component.snap
+++ b/tests/snapshots/sfc/ts/options_api__extends_base_component.snap
@@ -14,8 +14,8 @@ const _sfc_main = {
 
 import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 
-function _sfc_render(_ctx, _cache) {
-  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.extra), 1 /* TEXT */))
+function _sfc_render(_ctx, _cache, $props, $setup, $data, $options) {
+  return (_openBlock(), _createElementBlock("div", null, _toDisplayString($data.extra), 1 /* TEXT */))
 }
 _sfc_main.render = _sfc_render
 export default _sfc_main

--- a/tests/snapshots/sfc/ts/options_api__fragment_multiple_root_nodes.snap
+++ b/tests/snapshots/sfc/ts/options_api__fragment_multiple_root_nodes.snap
@@ -11,10 +11,10 @@ const _sfc_main = {
 
 import { toDisplayString as _toDisplayString, createElementVNode as _createElementVNode, openBlock as _openBlock, createElementBlock as _createElementBlock, Fragment as _Fragment } from "vue"
 
-function _sfc_render(_ctx, _cache) {
+function _sfc_render(_ctx, _cache, $props, $setup, $data, $options) {
   return (_openBlock(), _createElementBlock(_Fragment, null, [
-    _createElementVNode("header", null, _toDisplayString(_ctx.a), 1 /* TEXT */),
-    _createElementVNode("main", null, _toDisplayString(_ctx.b), 1 /* TEXT */)
+    _createElementVNode("header", null, _toDisplayString($data.a), 1 /* TEXT */),
+    _createElementVNode("main", null, _toDisplayString($data.b), 1 /* TEXT */)
   ], 64 /* STABLE_FRAGMENT */))
 }
 _sfc_main.render = _sfc_render

--- a/tests/snapshots/sfc/ts/options_api__inject_array_form.snap
+++ b/tests/snapshots/sfc/ts/options_api__inject_array_form.snap
@@ -9,8 +9,8 @@ const _sfc_main = {
 
 import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 
-function _sfc_render(_ctx, _cache) {
-  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.theme) + " " + _toDisplayString(_ctx.locale), 1 /* TEXT */))
+function _sfc_render(_ctx, _cache, $props, $setup, $data, $options) {
+  return (_openBlock(), _createElementBlock("div", null, _toDisplayString($options.theme) + " " + _toDisplayString($options.locale), 1 /* TEXT */))
 }
 _sfc_main.render = _sfc_render
 export default _sfc_main

--- a/tests/snapshots/sfc/ts/options_api__keep_alive_wrapping_dynamic_component.snap
+++ b/tests/snapshots/sfc/ts/options_api__keep_alive_wrapping_dynamic_component.snap
@@ -11,9 +11,9 @@ const _sfc_main = {
 
 import { resolveDynamicComponent as _resolveDynamicComponent, openBlock as _openBlock, createBlock as _createBlock, KeepAlive as _KeepAlive } from "vue"
 
-function _sfc_render(_ctx, _cache) {
+function _sfc_render(_ctx, _cache, $props, $setup, $data, $options) {
   return (_openBlock(), _createBlock(_KeepAlive, null, [
-    (_openBlock(), _createBlock(_resolveDynamicComponent(_ctx.view)))
+    (_openBlock(), _createBlock(_resolveDynamicComponent($data.view)))
   ], 1024 /* DYNAMIC_SLOTS */))
 }
 _sfc_main.render = _sfc_render

--- a/tests/snapshots/sfc/ts/options_api__lifecycle_hooks.snap
+++ b/tests/snapshots/sfc/ts/options_api__lifecycle_hooks.snap
@@ -20,8 +20,8 @@ const _sfc_main = {
 
 import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 
-function _sfc_render(_ctx, _cache) {
-  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.ready), 1 /* TEXT */))
+function _sfc_render(_ctx, _cache, $props, $setup, $data, $options) {
+  return (_openBlock(), _createElementBlock("div", null, _toDisplayString($data.ready), 1 /* TEXT */))
 }
 _sfc_main.render = _sfc_render
 export default _sfc_main

--- a/tests/snapshots/sfc/ts/options_api__method_called_in_interpolation.snap
+++ b/tests/snapshots/sfc/ts/options_api__method_called_in_interpolation.snap
@@ -16,8 +16,8 @@ const _sfc_main = {
 
 import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 
-function _sfc_render(_ctx, _cache) {
-  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.greet(_ctx.name)), 1 /* TEXT */))
+function _sfc_render(_ctx, _cache, $props, $setup, $data, $options) {
+  return (_openBlock(), _createElementBlock("div", null, _toDisplayString($options.greet($data.name)), 1 /* TEXT */))
 }
 _sfc_main.render = _sfc_render
 export default _sfc_main

--- a/tests/snapshots/sfc/ts/options_api__methods_with_event_handler.snap
+++ b/tests/snapshots/sfc/ts/options_api__methods_with_event_handler.snap
@@ -16,8 +16,8 @@ const _sfc_main = {
 
 import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 
-function _sfc_render(_ctx, _cache) {
-  return (_openBlock(), _createElementBlock("button", { onClick: _ctx.increment }, _toDisplayString(_ctx.count), 9 /* TEXT, PROPS */, ["onClick"]))
+function _sfc_render(_ctx, _cache, $props, $setup, $data, $options) {
+  return (_openBlock(), _createElementBlock("button", { onClick: $options.increment }, _toDisplayString($data.count), 9 /* TEXT, PROPS */, ["onClick"]))
 }
 _sfc_main.render = _sfc_render
 export default _sfc_main

--- a/tests/snapshots/sfc/ts/options_api__mixins.snap
+++ b/tests/snapshots/sfc/ts/options_api__mixins.snap
@@ -14,8 +14,8 @@ const _sfc_main = {
 
 import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 
-function _sfc_render(_ctx, _cache) {
-  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.local) + " " + _toDisplayString(_ctx.sharedValue), 1 /* TEXT */))
+function _sfc_render(_ctx, _cache, $props, $setup, $data, $options) {
+  return (_openBlock(), _createElementBlock("div", null, _toDisplayString($data.local) + " " + _toDisplayString(_ctx.sharedValue), 1 /* TEXT */))
 }
 _sfc_main.render = _sfc_render
 export default _sfc_main

--- a/tests/snapshots/sfc/ts/options_api__mixins_and_extends_combined.snap
+++ b/tests/snapshots/sfc/ts/options_api__mixins_and_extends_combined.snap
@@ -16,8 +16,8 @@ const _sfc_main = {
 
 import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 
-function _sfc_render(_ctx, _cache) {
-  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.own), 1 /* TEXT */))
+function _sfc_render(_ctx, _cache, $props, $setup, $data, $options) {
+  return (_openBlock(), _createElementBlock("div", null, _toDisplayString($data.own), 1 /* TEXT */))
 }
 _sfc_main.render = _sfc_render
 export default _sfc_main

--- a/tests/snapshots/sfc/ts/options_api__name_and_inherit_attrs.snap
+++ b/tests/snapshots/sfc/ts/options_api__name_and_inherit_attrs.snap
@@ -11,8 +11,8 @@ const _sfc_main = {
 
 import { toDisplayString as _toDisplayString, normalizeProps as _normalizeProps, guardReactiveProps as _guardReactiveProps, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 
-function _sfc_render(_ctx, _cache) {
-  return (_openBlock(), _createElementBlock("div", _normalizeProps(_guardReactiveProps(_ctx.$attrs)), _toDisplayString(_ctx.label), 17 /* TEXT, FULL_PROPS */))
+function _sfc_render(_ctx, _cache, $props, $setup, $data, $options) {
+  return (_openBlock(), _createElementBlock("div", _normalizeProps(_guardReactiveProps(_ctx.$attrs)), _toDisplayString($props.label), 17 /* TEXT, FULL_PROPS */))
 }
 _sfc_main.render = _sfc_render
 export default _sfc_main

--- a/tests/snapshots/sfc/ts/options_api__named_and_scoped_slots_in_child.snap
+++ b/tests/snapshots/sfc/ts/options_api__named_and_scoped_slots_in_child.snap
@@ -16,7 +16,7 @@ import { resolveComponent as _resolveComponent, toDisplayString as _toDisplayStr
 
 const _hoisted_1 = /*#__PURE__*/ _createElementVNode("h1", null, "Title")
 
-function _sfc_render(_ctx, _cache) {
+function _sfc_render(_ctx, _cache, $props, $setup, $data, $options) {
   const _component_Layout = _resolveComponent("Layout")
   
   return (_openBlock(), _createBlock(_component_Layout, null, {

--- a/tests/snapshots/sfc/ts/options_api__props_array_form.snap
+++ b/tests/snapshots/sfc/ts/options_api__props_array_form.snap
@@ -9,8 +9,8 @@ const _sfc_main = {
 
 import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 
-function _sfc_render(_ctx, _cache) {
-  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.title) + ": " + _toDisplayString(_ctx.count), 1 /* TEXT */))
+function _sfc_render(_ctx, _cache, $props, $setup, $data, $options) {
+  return (_openBlock(), _createElementBlock("div", null, _toDisplayString($props.title) + ": " + _toDisplayString($props.count), 1 /* TEXT */))
 }
 _sfc_main.render = _sfc_render
 export default _sfc_main

--- a/tests/snapshots/sfc/ts/options_api__props_object_form_with_defaults.snap
+++ b/tests/snapshots/sfc/ts/options_api__props_object_form_with_defaults.snap
@@ -22,8 +22,8 @@ const _sfc_main = {
 
 import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 
-function _sfc_render(_ctx, _cache) {
-  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.title) + ": " + _toDisplayString(_ctx.count) + " (" + _toDisplayString(_ctx.items.length) + ")", 1 /* TEXT */))
+function _sfc_render(_ctx, _cache, $props, $setup, $data, $options) {
+  return (_openBlock(), _createElementBlock("div", null, _toDisplayString($props.title) + ": " + _toDisplayString($props.count) + " (" + _toDisplayString($props.items.length) + ")", 1 /* TEXT */))
 }
 _sfc_main.render = _sfc_render
 export default _sfc_main

--- a/tests/snapshots/sfc/ts/options_api__props_with_prop_type_typescript.snap
+++ b/tests/snapshots/sfc/ts/options_api__props_with_prop_type_typescript.snap
@@ -21,8 +21,8 @@ const _sfc_main = defineComponent({
 
 import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 
-function _sfc_render(_ctx, _cache) {
-  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.items.length), 1 /* TEXT */))
+function _sfc_render(_ctx, _cache, $props, $setup, $data, $options) {
+  return (_openBlock(), _createElementBlock("div", null, _toDisplayString($props.items.length), 1 /* TEXT */))
 }
 _sfc_main.render = _sfc_render
 export default _sfc_main

--- a/tests/snapshots/sfc/ts/options_api__provide_and_inject.snap
+++ b/tests/snapshots/sfc/ts/options_api__provide_and_inject.snap
@@ -17,8 +17,8 @@ const _sfc_main = {
 
 import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 
-function _sfc_render(_ctx, _cache) {
-  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.parentTheme), 1 /* TEXT */))
+function _sfc_render(_ctx, _cache, $props, $setup, $data, $options) {
+  return (_openBlock(), _createElementBlock("div", null, _toDisplayString($options.parentTheme), 1 /* TEXT */))
 }
 _sfc_main.render = _sfc_render
 export default _sfc_main

--- a/tests/snapshots/sfc/ts/options_api__recursive_self_component.snap
+++ b/tests/snapshots/sfc/ts/options_api__recursive_self_component.snap
@@ -10,14 +10,14 @@ const _sfc_main = {
 
 import { resolveComponent as _resolveComponent, toDisplayString as _toDisplayString, openBlock as _openBlock, createBlock as _createBlock, createElementBlock as _createElementBlock, Fragment as _Fragment, createTextVNode as _createTextVNode, createCommentVNode as _createCommentVNode, renderList as _renderList } from "vue"
 
-function _sfc_render(_ctx, _cache) {
+function _sfc_render(_ctx, _cache, $props, $setup, $data, $options) {
   const _component_TreeNode = _resolveComponent("TreeNode")
   
   return (_openBlock(), _createElementBlock("li", null, [
-    _createTextVNode(_toDisplayString(_ctx.node.label) + " ", 1 /* TEXT */),
-    (_ctx.node.children)
+    _createTextVNode(_toDisplayString($props.node.label) + " ", 1 /* TEXT */),
+    ($props.node.children)
       ? (_openBlock(), _createElementBlock("ul", { key: 0 }, [
-        (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(_ctx.node.children, (child) => {
+        (_openBlock(true), _createElementBlock(_Fragment, null, _renderList($props.node.children, (child) => {
           return (_openBlock(), _createBlock(_component_TreeNode, {
             key: child.id,
             node: child

--- a/tests/snapshots/sfc/ts/options_api__setup_function_with_options_api.snap
+++ b/tests/snapshots/sfc/ts/options_api__setup_function_with_options_api.snap
@@ -17,8 +17,8 @@ const _sfc_main = {
 
 import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 
-function _sfc_render(_ctx, _cache) {
-  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.fromSetup) + " " + _toDisplayString(_ctx.fromData), 1 /* TEXT */))
+function _sfc_render(_ctx, _cache, $props, $setup, $data, $options) {
+  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.fromSetup) + " " + _toDisplayString($data.fromData), 1 /* TEXT */))
 }
 _sfc_main.render = _sfc_render
 export default _sfc_main

--- a/tests/snapshots/sfc/ts/options_api__v_for_over_data_array.snap
+++ b/tests/snapshots/sfc/ts/options_api__v_for_over_data_array.snap
@@ -11,9 +11,9 @@ const _sfc_main = {
 
 import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock, Fragment as _Fragment, renderList as _renderList } from "vue"
 
-function _sfc_render(_ctx, _cache) {
+function _sfc_render(_ctx, _cache, $props, $setup, $data, $options) {
   return (_openBlock(), _createElementBlock("ul", null, [
-    (_openBlock(true), _createElementBlock(_Fragment, null, _renderList(_ctx.items, (item, index) => {
+    (_openBlock(true), _createElementBlock(_Fragment, null, _renderList($data.items, (item, index) => {
       return (_openBlock(), _createElementBlock("li", { key: index }, _toDisplayString(item), 1 /* TEXT */))
     }), 128 /* KEYED_FRAGMENT */))
   ]))

--- a/tests/snapshots/sfc/ts/options_api__v_if_with_computed_condition.snap
+++ b/tests/snapshots/sfc/ts/options_api__v_if_with_computed_condition.snap
@@ -16,11 +16,11 @@ const _sfc_main = {
 
 import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock, createCommentVNode as _createCommentVNode } from "vue"
 
-function _sfc_render(_ctx, _cache) {
+function _sfc_render(_ctx, _cache, $props, $setup, $data, $options) {
   return (_openBlock(), _createElementBlock("div", null, [
-    (_ctx.isEmpty)
+    ($options.isEmpty)
       ? (_openBlock(), _createElementBlock("p", { key: 0 }, "empty"))
-      : (_openBlock(), _createElementBlock("p", { key: 1 }, _toDisplayString(_ctx.count), 1 /* TEXT */))
+      : (_openBlock(), _createElementBlock("p", { key: 1 }, _toDisplayString($data.count), 1 /* TEXT */))
   ]))
 }
 _sfc_main.render = _sfc_render

--- a/tests/snapshots/sfc/ts/options_api__v_model_on_component.snap
+++ b/tests/snapshots/sfc/ts/options_api__v_model_on_component.snap
@@ -14,12 +14,12 @@ const _sfc_main = {
 
 import { resolveComponent as _resolveComponent, openBlock as _openBlock, createBlock as _createBlock } from "vue"
 
-function _sfc_render(_ctx, _cache) {
+function _sfc_render(_ctx, _cache, $props, $setup, $data, $options) {
   const _component_TextField = _resolveComponent("TextField")
   
   return (_openBlock(), _createBlock(_component_TextField, {
-    modelValue: _ctx.name,
-    "onUpdate:modelValue": $event => ((_ctx.name) = $event)
+    modelValue: $data.name,
+    "onUpdate:modelValue": $event => (($data.name) = $event)
   }, null, 8 /* PROPS */, ["modelValue", "onUpdate:modelValue"]))
 }
 _sfc_main.render = _sfc_render

--- a/tests/snapshots/sfc/ts/options_api__watch_handlers_object_and_deep.snap
+++ b/tests/snapshots/sfc/ts/options_api__watch_handlers_object_and_deep.snap
@@ -23,11 +23,11 @@ const _sfc_main = {
 
 import { vModelText as _vModelText, withDirectives as _withDirectives, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 
-function _sfc_render(_ctx, _cache) {
+function _sfc_render(_ctx, _cache, $props, $setup, $data, $options) {
   return _withDirectives((_openBlock(), _createElementBlock("input", {
-    "onUpdate:modelValue": $event => ((_ctx.question) = $event)
+    "onUpdate:modelValue": $event => (($data.question) = $event)
   }, null, 8 /* PROPS */, ["onUpdate:modelValue"])), [
-    [_vModelText, _ctx.question]
+    [_vModelText, $data.question]
   ])
 }
 _sfc_main.render = _sfc_render

--- a/tests/snapshots/sfc/ts/options_api__watch_nested_path_string_key.snap
+++ b/tests/snapshots/sfc/ts/options_api__watch_nested_path_string_key.snap
@@ -17,11 +17,11 @@ const _sfc_main = {
 
 import { vModelText as _vModelText, withDirectives as _withDirectives, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 
-function _sfc_render(_ctx, _cache) {
+function _sfc_render(_ctx, _cache, $props, $setup, $data, $options) {
   return _withDirectives((_openBlock(), _createElementBlock("input", {
-    "onUpdate:modelValue": $event => ((_ctx.form.name) = $event)
+    "onUpdate:modelValue": $event => (($data.form.name) = $event)
   }, null, 8 /* PROPS */, ["onUpdate:modelValue"])), [
-    [_vModelText, _ctx.form.name]
+    [_vModelText, $data.form.name]
   ])
 }
 _sfc_main.render = _sfc_render

--- a/tests/snapshots/sfc/ts/patches__non_script_setup_component_with_export_default.snap
+++ b/tests/snapshots/sfc/ts/patches__non_script_setup_component_with_export_default.snap
@@ -17,8 +17,8 @@ const _sfc_main = {
 
 import { toDisplayString as _toDisplayString, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 
-function _sfc_render(_ctx, _cache) {
-  return (_openBlock(), _createElementBlock("div", null, _toDisplayString(_ctx.msg) + " - " + _toDisplayString(_ctx.count), 1 /* TEXT */))
+function _sfc_render(_ctx, _cache, $props, $setup, $data, $options) {
+  return (_openBlock(), _createElementBlock("div", null, _toDisplayString($props.msg) + " - " + _toDisplayString($data.count), 1 /* TEXT */))
 }
 _sfc_main.render = _sfc_render
 export default _sfc_main

--- a/tests/snapshots/sfc/ts/patches__options_api_dynamic_style_and_class_keep_patch_flags.snap
+++ b/tests/snapshots/sfc/ts/patches__options_api_dynamic_style_and_class_keep_patch_flags.snap
@@ -13,10 +13,10 @@ const _sfc_main = {
 
 import { createElementVNode as _createElementVNode, normalizeStyle as _normalizeStyle, normalizeClass as _normalizeClass, openBlock as _openBlock, createElementBlock as _createElementBlock } from "vue"
 
-function _sfc_render(_ctx, _cache) {
+function _sfc_render(_ctx, _cache, $props, $setup, $data, $options) {
   return (_openBlock(), _createElementBlock("div", { class: "map" }, [
     _createElementVNode("div", {
-      style: _normalizeStyle(_ctx.knobStyle),
+      style: _normalizeStyle($options.knobStyle),
       class: _normalizeClass({ dragging: _ctx.dragging })
     }, null, 6 /* CLASS, STYLE */)
   ]))


### PR DESCRIPTION
Refs #1388 (PR8)

## Problem
The runtime SFC compiler never fed plain-`<script>` (Options API) bindings to template codegen — `bindings: None` in the normal-script + template case — so every Options API member resolved to `_ctx.` in the render function. Separately, the non-inline expression prefixer mapped every non-Props binding to `$setup.`, which is wrong for `data`/`computed`/`methods`/`inject`.

## Fix
- Add `BindingType::non_inline_template_prefix()` mirroring `@vue/compiler-core`'s `rewriteIdentifier` else-branch: setup-*/`literal-const` → `$setup.`, `props` → `$props.`, `data` → `$data.`, `options` (computed/methods/inject) → `$options.`. Both expression prefixers (codegen `helpers.rs`, transform `prefix.rs`) use it. Inline mode is unchanged.
- Wire Options API bindings into the normal-`<script>` + template compile path. Only the unambiguous Options API member kinds (`data`/`options`/`props`/`props-aliased`) are forwarded — imports, module-local consts, and `components: {}` registrations are not, so locally-registered components still resolve via `_resolveComponent("Foo")` (Vue does not register those as template bindings for a non-`<script setup>` block).
- Croquis: type Options API `setup()` return values as `setup-maybe-ref` (was `options`) so they prefix `$setup.` like Vue, not `$options.`.

## Vue-parity evidence
Verified against `@vue/compiler-sfc` 3.5.34 in non-inline mode. Exact prefixes:

| binding | Vue | this PR |
|---|---|---|
| data `count` | `$data.count` | `$data.count` |
| computed/method | `$options.doubled` / `$options.inc` | same |
| prop | `$props.initial` | same |
| inject | `$options.theme` | same |
| v-model on data | `($data.name) = $event` | same |
| computed get/set v-model | `($options.fullName) = $event`, `[_vModelText, $options.fullName]` | same |
| `$emit(...)` | `_ctx.$emit('submit', $data.value)` | same |
| mixin-shared / unresolved | `_ctx.sharedValue` | same |
| locally-registered component | `_resolveComponent("ChildComp")` | same |

The render signature becomes `(_ctx, _cache, $props, $setup, $data, $options)` when Options API bindings are present, matching Vue.

`analyze_script_bindings` was checked — it still has callers (its own unit tests via `pub` re-export); not dead, left as-is.

## Verification
`cargo test` green for vize_atelier_sfc (incl. `allocation_budget`), vize_atelier_core, vize_relief, vize_croquis, vize_atelier_dom/ssr/vapor, vize_maestro, vize_canon. `cargo fmt --check` and `cargo clippy --lib` (-D warnings) clean on all touched crates. The `options_api` allocation budget is re-blessed with documented justification: the path now parses the `<script>` once more to extract binding metadata, mirroring the dedicated binding pass `@vue/compiler-sfc` runs in `compileScript`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1446"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->