### PR TITLE
feat(canon): emit real Props type from Options API props option

### DIFF
--- a/crates/vize_canon/src/virtual_ts/generator/mod.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/mod.rs
@@ -16,7 +16,8 @@ use self::imports::{
     extract_declared_name,
 };
 use self::options_api::{
-    find_default_export_targets, generate_options_api_bridge, generate_options_api_variables,
+    find_default_export_targets, find_options_api_props, generate_options_api_bridge,
+    generate_options_api_variables,
 };
 use self::spans::{
     DEFINE_COMPONENT_HELPER, DEFINE_COMPONENT_REF, collect_template_referenced_names,
@@ -29,8 +30,9 @@ use super::{
         generate_template_context, to_safe_identifier,
     },
     props::{
-        add_generic_defaults, collect_template_prop_names, extract_generic_names,
-        generate_props_type, generate_props_variables, strip_const_modifiers,
+        OptionsApiPropsSource, add_generic_defaults, collect_template_prop_names,
+        extract_generic_names, generate_props_type, generate_props_variables,
+        strip_const_modifiers,
     },
     scope::{ScopeGenerationOptions, generate_scope_closures},
     types::{VirtualTsGenerationOptions, VirtualTsOptions, VirtualTsOutput, VizeMapping},
@@ -436,10 +438,20 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
     );
     ts.push('\n');
 
-    // Props type (defined at module level so it's available inside __setup)
+    // Props type (defined at module level so it's available inside __setup).
+    // For an Options API component with no `defineProps` macro, derive a real
+    // `export type Props` from its runtime `props:` option so cross-file prop
+    // checking is no longer a `{}` no-op. Macro-driven props (script setup) take
+    // precedence and are emitted by `generate_props_type` itself.
+    let options_api_props: Option<OptionsApiPropsSource> =
+        if options_api && summary.macros.props().is_empty() {
+            script_content.and_then(find_options_api_props)
+        } else {
+            None
+        };
     profile!(
         "canon.virtual_ts.generate_props_type",
-        generate_props_type(&mut ts, summary, generic_param)
+        generate_props_type(&mut ts, summary, generic_param, options_api_props.as_ref())
     );
 
     // Setup scope: function that contains setup helpers and script content

--- a/crates/vize_canon/src/virtual_ts/generator/options_api.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/options_api.rs
@@ -467,6 +467,84 @@ pub(super) fn find_default_export_targets(script: &str) -> DefaultExportTargets 
     targets
 }
 
+use crate::virtual_ts::props::OptionsApiPropsSource;
+
+/// Parse a plain `<script>` and extract its Options API `props:` declaration.
+///
+/// Returns `None` when there is no resolvable component options object or no
+/// `props:` option (or it is an unrecognized expression form). Object and array
+/// literals are recognized directly; an identifier whose initializer object can
+/// be resolved is not chased here because the runtime prop ctors would not be in
+/// scope inside the emitted `__RuntimePropShape<...>` reference.
+///
+/// The result feeds canon's real `export type Props` for Options API
+/// components: object form maps through the shared `__RuntimePropShape<...>`
+/// machinery (runtime ctors and `{ type, required }` shapes resolve to TS prop
+/// types with correct optionality), while the array form has no runtime type
+/// info so each prop is emitted as optional `unknown`.
+pub(super) fn find_options_api_props(script: &str) -> Option<OptionsApiPropsSource> {
+    if !script.contains("export default") {
+        return None;
+    }
+    let allocator = Allocator::default();
+    let parsed = Parser::new(&allocator, script, SourceType::ts()).parse();
+    if parsed.panicked {
+        return None;
+    }
+    let options = component_options_from_program(&parsed.program)?;
+    let props = option_expression_property(options, "props")?;
+    options_api_props_from_expression(script, props)
+}
+
+fn options_api_props_from_expression(
+    script: &str,
+    expression: &Expression<'_>,
+) -> Option<OptionsApiPropsSource> {
+    match expression {
+        Expression::ObjectExpression(object) => {
+            let source = source_slice(script, object.span())?;
+            Some(OptionsApiPropsSource::Object(String::from(source)))
+        }
+        Expression::ArrayExpression(array) => {
+            let mut names = Vec::new();
+            for element in &array.elements {
+                if let ArrayExpressionElement::StringLiteral(literal) = element {
+                    names.push(String::from(literal.value.as_str()));
+                }
+            }
+            (!names.is_empty()).then_some(OptionsApiPropsSource::Names(names))
+        }
+        Expression::ParenthesizedExpression(parenthesized) => {
+            options_api_props_from_expression(script, &parenthesized.expression)
+        }
+        Expression::TSAsExpression(ts_as) => {
+            options_api_props_from_expression(script, &ts_as.expression)
+        }
+        Expression::TSSatisfiesExpression(ts_satisfies) => {
+            options_api_props_from_expression(script, &ts_satisfies.expression)
+        }
+        Expression::TSNonNullExpression(ts_non_null) => {
+            options_api_props_from_expression(script, &ts_non_null.expression)
+        }
+        _ => None,
+    }
+}
+
+fn option_expression_property<'a>(
+    object: &'a ObjectExpression<'a>,
+    key_name: &str,
+) -> Option<&'a Expression<'a>> {
+    object.properties.iter().find_map(|property| {
+        let ObjectPropertyKind::ObjectProperty(property) = property else {
+            return None;
+        };
+        if property.computed || property_key_name(&property.key) != Some(key_name) {
+            return None;
+        }
+        Some(&property.value)
+    })
+}
+
 fn component_options_from_program<'a>(
     program: &'a Program<'a>,
 ) -> Option<&'a ObjectExpression<'a>> {

--- a/crates/vize_canon/src/virtual_ts/props.rs
+++ b/crates/vize_canon/src/virtual_ts/props.rs
@@ -284,10 +284,30 @@ fn append_model_props_type_literal(ts: &mut String, models: &[ModelDefinition]) 
     ts.push('}');
 }
 
+/// Source of an Options API `props:` option, used to emit a real `export type
+/// Props` for plain `<script>` (Options API) components. `Object` is a raw
+/// runtime props object literal (`{ initial: Number, ... }`) fed to
+/// `__RuntimePropShape<...>`; `Names` is the array form (`['a', 'b']`) which
+/// carries no runtime type info and is emitted as optional `unknown` members.
+pub(crate) enum OptionsApiPropsSource {
+    Object(String),
+    Names(Vec<String>),
+}
+
 /// Generate Props type definition at module level.
 /// When `generic_param` is present (e.g., `"T extends Foo, P extends Bar"`),
 /// the Props type is emitted with generic parameters: `export type Props<T, P> = ...;`
-pub(crate) fn generate_props_type(ts: &mut String, summary: &Croquis, generic_param: Option<&str>) {
+///
+/// `options_api_props` carries the Options API runtime `props:` declaration when
+/// the component is a plain `<script>` Options API component with no
+/// `defineProps` macro. It lets cross-file prop checking see real prop types
+/// instead of the historical `export type Props = {}` no-op.
+pub(crate) fn generate_props_type(
+    ts: &mut String,
+    summary: &Croquis,
+    generic_param: Option<&str>,
+    options_api_props: Option<&OptionsApiPropsSource>,
+) {
     let props = summary.macros.props();
     let has_props = !props.is_empty();
     let models = summary.macros.models();
@@ -343,11 +363,40 @@ pub(crate) fn generate_props_type(ts: &mut String, summary: &Croquis, generic_pa
             emit_model_prop_member(ts, model);
         }
         ts.push_str("};\n");
+    } else if let Some(options_api_props) = options_api_props {
+        emit_options_api_props_type(ts, &generic_decl, options_api_props);
     } else {
         append!(*ts, "export type Props{generic_decl} = {{}};\n");
     }
 
     ts.push('\n');
+}
+
+/// Emit a real `export type Props` for an Options API component, derived from
+/// its runtime `props:` option. The object form reuses the shared
+/// `__RuntimePropShape<...>` mapped type (the same machinery `defineProps`
+/// runtime forms use), so runtime ctors and `{ type, required }` shapes resolve
+/// to real prop types with correct optionality.
+fn emit_options_api_props_type(
+    ts: &mut String,
+    generic_decl: &str,
+    options_api_props: &OptionsApiPropsSource,
+) {
+    match options_api_props {
+        OptionsApiPropsSource::Object(source) => {
+            append!(
+                *ts,
+                "export type Props{generic_decl} = __RuntimePropShape<{source}>;\n"
+            );
+        }
+        OptionsApiPropsSource::Names(names) => {
+            append!(*ts, "export type Props{generic_decl} = {{\n");
+            for name in names {
+                append!(*ts, "  \"{name}\"?: unknown;\n");
+            }
+            ts.push_str("};\n");
+        }
+    }
 }
 
 /// Generate props variables inside template closure.

--- a/crates/vize_canon/src/virtual_ts/tests.rs
+++ b/crates/vize_canon/src/virtual_ts/tests.rs
@@ -228,6 +228,91 @@ fn test_options_api_template_bindings_use_default_instance_type() {
 }
 
 #[test]
+fn test_options_api_emits_real_props_type_from_object_option() {
+    // A plain `<script>` Options API component with a runtime `props:` object
+    // must produce a real `export type Props` (via the shared
+    // `__RuntimePropShape<...>` machinery) instead of the historical `{}` no-op,
+    // so cross-file prop checking is no longer silently disabled.
+    let script = r#"export default {
+    props: {
+        initial: Number,
+        label: { type: String, required: true },
+    },
+}
+"#;
+    let summary = analyze_options_api_script(script);
+    let output = generate_virtual_ts_with_offsets_options_api(
+        &summary,
+        Some(script),
+        None,
+        0,
+        0,
+        &Default::default(),
+    );
+
+    assert!(
+        output.code.contains(
+            "export type Props = __RuntimePropShape<{\n        initial: Number,\n        label: { type: String, required: true },\n    }>;"
+        ),
+        "expected a real Props type derived from the runtime props option:\n{}",
+        output.code
+    );
+    assert!(
+        !output.code.contains("export type Props = {};"),
+        "Options API props must not fall back to the `{{}}` no-op:\n{}",
+        output.code
+    );
+}
+
+#[test]
+fn test_options_api_emits_props_type_from_array_option() {
+    // The array form carries no runtime type info, so each prop is emitted as an
+    // optional `unknown` member rather than the `{}` no-op.
+    let script = r#"export default {
+    props: ['initial', 'label'],
+}
+"#;
+    let summary = analyze_options_api_script(script);
+    let output = generate_virtual_ts_with_offsets_options_api(
+        &summary,
+        Some(script),
+        None,
+        0,
+        0,
+        &Default::default(),
+    );
+
+    assert!(
+        output.code.contains(
+            "export type Props = {\n  \"initial\"?: unknown;\n  \"label\"?: unknown;\n};"
+        ),
+        "expected array-form props to be emitted as optional unknown members:\n{}",
+        output.code
+    );
+}
+
+#[test]
+fn test_options_api_props_type_skipped_without_options_api_flag() {
+    // Without the Options API opt-in, the historical `{}` no-op is preserved so
+    // existing default behavior (and snapshots) is unchanged.
+    let script = r#"export default {
+    props: {
+        initial: Number,
+    },
+}
+"#;
+    let summary = analyze_options_api_script(script);
+    let output =
+        generate_virtual_ts_with_offsets(&summary, Some(script), None, 0, 0, &Default::default());
+
+    assert!(
+        output.code.contains("export type Props = {};"),
+        "Props derivation must be gated behind the Options API opt-in:\n{}",
+        output.code
+    );
+}
+
+#[test]
 fn test_class_component_default_export_keeps_decorators_on_class() {
     // vue-class-component / vue-property-decorator: a decorated class default
     // export must become a standalone class declaration plus a


### PR DESCRIPTION
## Problem

For Options API components, canon emitted `export type Props = {}` — an empty type — so cross-file prop checking (`vize_croquis_cf` props validation) was a silent no-op. Required/undeclared/type mismatches on a parent passing props to an Options API child were never caught. The `<script setup>` `defineProps` runtime path already produces a real `Props` type via the shared `__RuntimePropShape` machinery; the Options API `props:` option did not.

croquis only surfaces prop *names* for Options API (`BindingType::Props` bindings); `macros.props()` (with type/required/default) is empty for plain `<script>` components. Rather than change croquis (out of this PR's scope — owned elsewhere), canon already re-parses the plain script for its `this`-bridge, so it can recover the `props:` declaration locally.

## Fix

When the Options API mode is enabled and there is no `defineProps` macro, canon now parses the component options object and derives a real `export type Props` from the runtime `props:` option:

- Object form (`props: { initial: Number, label: { type: String, required: true } }`) is fed straight into the existing shared `__RuntimePropShape<...>` mapped type, so runtime ctors and `{ type, required }` shapes resolve to real TS prop types with correct optionality — the same machinery the `defineProps` runtime path uses.
- Array form (`props: ['a', 'b']`) carries no runtime type info, so each prop is emitted as an optional `unknown` member.

`defineProps`/`defineModel`-driven props still take precedence; behavior is gated behind the Options API opt-in, so default `<script setup>` output (and snapshots) is unchanged.

## Verification

- `cargo test -p vize_canon` — 332 passed, 0 failed, no snapshot churn
- `cargo fmt -p vize_canon --check` — clean
- `cargo clippy -p vize_canon --lib` — 0 warnings
- Added 3 unit tests: object-form Props via `__RuntimePropShape`, array-form optional `unknown`, and gating (no derivation without the Options API flag)

Self-contained to `vize_canon`. The matching croquis_cf prop-metadata wiring (the other half of PR5) is intentionally not included here, as it requires a croquis change to surface runtime prop definitions.

Refs #1388

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1447"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->