### PR TITLE
feat(patina): port vue/no-dupe-keys Options API lint rule

### DIFF
--- a/crates/vize_patina/src/linter/script_rules.rs
+++ b/crates/vize_patina/src/linter/script_rules.rs
@@ -1,11 +1,11 @@
 use super::{LintResult, Linter};
 use crate::rules::script::{
-    NoAsyncInComputed, NoDeepDestructureInProps, NoGetCurrentInstance, NoImportCompilerMacros,
-    NoInternalImports, NoNextTick, NoOptionsApi, NoReactiveDestructure, NoReservedIdentifiers,
-    NoTopLevelRefInScript, NoWithDefaults, PiniaPreferStoreToRefs, PreferComputed,
-    PreferImportFromVue, PreferRefOverReactive, PreferUseAttrs, PreferUseId, PreferUseSlots,
-    PreferUseTemplateRef, RequireFunctionReturnType, RequireSymbolProvide, ScriptRule,
-    VueRouterPreferNamedPush, VueTestUtilsNoHtmlSnapshot, script_source_type,
+    NoAsyncInComputed, NoDeepDestructureInProps, NoDupeKeys, NoGetCurrentInstance,
+    NoImportCompilerMacros, NoInternalImports, NoNextTick, NoOptionsApi, NoReactiveDestructure,
+    NoReservedIdentifiers, NoTopLevelRefInScript, NoWithDefaults, PiniaPreferStoreToRefs,
+    PreferComputed, PreferImportFromVue, PreferRefOverReactive, PreferUseAttrs, PreferUseId,
+    PreferUseSlots, PreferUseTemplateRef, RequireFunctionReturnType, RequireSymbolProvide,
+    ScriptRule, VueRouterPreferNamedPush, VueTestUtilsNoHtmlSnapshot, script_source_type,
 };
 use memchr::memmem;
 use oxc_allocator::Allocator;
@@ -41,7 +41,7 @@ impl BuiltinScriptRuleEntry {
     }
 }
 
-const BUILTIN_SCRIPT_RULE_COUNT: usize = 23;
+const BUILTIN_SCRIPT_RULE_COUNT: usize = 24;
 static NO_DEEP_DESTRUCTURE_IN_PROPS_RULE: NoDeepDestructureInProps =
     NoDeepDestructureInProps { max_depth: 1 };
 
@@ -235,6 +235,14 @@ static BUILTIN_SCRIPT_RULES: [BuiltinScriptRuleEntry; BUILTIN_SCRIPT_RULE_COUNT]
         presets: OPT_IN_SCRIPT_PRESETS,
         rule: &RequireFunctionReturnType,
     },
+    BuiltinScriptRuleEntry {
+        rule_name: RULE_NO_DUPE_KEYS,
+        profile_name: "patina.script_rule.no_dupe_keys",
+        category: "Script",
+        fixable: false,
+        presets: OPT_IN_SCRIPT_PRESETS,
+        rule: &NoDupeKeys,
+    },
 ];
 
 pub(crate) const RULE_NO_OPTIONS_API: &str = "script/no-options-api";
@@ -261,6 +269,7 @@ pub(crate) const RULE_NO_IMPORT_COMPILER_MACROS: &str = "script/no-import-compil
 pub(crate) const RULE_NO_RESERVED_IDENTIFIERS: &str = "script/no-reserved-identifiers";
 pub(crate) const RULE_REQUIRE_SYMBOL_PROVIDE: &str = "script/require-symbol-provide";
 pub(crate) const RULE_REQUIRE_FUNCTION_RETURN_TYPE: &str = "script/require-function-return-type";
+pub(crate) const RULE_NO_DUPE_KEYS: &str = "script/no-dupe-keys";
 const OPINIONATED_SCRIPT_PRESETS: &[&str] = &["opinionated", "nuxt"];
 const ECOSYSTEM_SCRIPT_PRESETS: &[&str] = &["ecosystem"];
 const OPT_IN_SCRIPT_PRESETS: &[&str] = &[];
@@ -288,6 +297,7 @@ const ALL_BUILTIN_SCRIPT_RULE_NAMES: &[&str] = &[
     RULE_NO_RESERVED_IDENTIFIERS,
     RULE_REQUIRE_SYMBOL_PROVIDE,
     RULE_REQUIRE_FUNCTION_RETURN_TYPE,
+    RULE_NO_DUPE_KEYS,
 ];
 #[cfg(test)]
 const OPT_IN_SCRIPT_RULE_NAMES: &[&str] = &[
@@ -311,6 +321,7 @@ const OPT_IN_SCRIPT_RULE_NAMES: &[&str] = &[
     RULE_NO_RESERVED_IDENTIFIERS,
     RULE_REQUIRE_SYMBOL_PROVIDE,
     RULE_REQUIRE_FUNCTION_RETURN_TYPE,
+    RULE_NO_DUPE_KEYS,
 ];
 
 pub struct BuiltinScriptRuleMeta {
@@ -378,6 +389,7 @@ fn builtin_script_rule_entry(rule_name: &str) -> Option<&'static BuiltinScriptRu
         RULE_NO_RESERVED_IDENTIFIERS => 20,
         RULE_REQUIRE_SYMBOL_PROVIDE => 21,
         RULE_REQUIRE_FUNCTION_RETURN_TYPE => 22,
+        RULE_NO_DUPE_KEYS => 23,
         _ => return None,
     };
     Some(&BUILTIN_SCRIPT_RULES[index])

--- a/crates/vize_patina/src/rules/script.rs
+++ b/crates/vize_patina/src/rules/script.rs
@@ -23,6 +23,7 @@
 
 mod no_async_in_computed;
 mod no_deep_destructure_in_props;
+mod no_dupe_keys;
 mod no_get_current_instance;
 mod no_import_compiler_macros;
 mod no_internal_imports;
@@ -56,6 +57,7 @@ use vize_carton::profile;
 
 pub use no_async_in_computed::NoAsyncInComputed;
 pub use no_deep_destructure_in_props::NoDeepDestructureInProps;
+pub use no_dupe_keys::NoDupeKeys;
 pub use no_get_current_instance::NoGetCurrentInstance;
 pub use no_import_compiler_macros::NoImportCompilerMacros;
 pub use no_internal_imports::NoInternalImports;
@@ -218,6 +220,7 @@ impl ScriptLinter {
                 Box::new(PreferImportFromVue),
                 Box::new(NoWithDefaults),
                 Box::new(NoDeepDestructureInProps::default()),
+                Box::new(NoDupeKeys),
                 Box::new(NoInternalImports),
                 Box::new(NoImportCompilerMacros),
                 Box::new(NoReservedIdentifiers),

--- a/crates/vize_patina/src/rules/script/no_dupe_keys.rs
+++ b/crates/vize_patina/src/rules/script/no_dupe_keys.rs
@@ -1,0 +1,639 @@
+//! script/no-dupe-keys
+//!
+//! Disallow duplicate keys across Options API groups.
+//!
+//! A key declared as a `prop` must not be re-declared in `data`, `computed`,
+//! `methods`, `setup`, or `inject` (and vice versa). All of these groups expose
+//! their members on the component instance via `this`, so a duplicate name
+//! silently shadows one declaration with another and is almost always a bug.
+//!
+//! This is a port of [`vue/no-dupe-keys`](https://eslint.vuejs.org/rules/no-dupe-keys.html)
+//! from eslint-plugin-vue, covering the `props`, `data`, `computed`, `methods`,
+//! `setup`, and `inject` groups.
+//!
+//! ## Examples
+//!
+//! ### Invalid
+//! ```ts
+//! export default {
+//!   props: ['foo'],
+//!   data() {
+//!     return { foo: 1 } // duplicate of prop `foo`
+//!   },
+//!   computed: {
+//!     bar() { return 2 }
+//!   },
+//!   methods: {
+//!     bar() {} // duplicate of computed `bar`
+//!   }
+//! }
+//! ```
+//!
+//! ### Valid
+//! ```ts
+//! export default {
+//!   props: ['foo'],
+//!   data() {
+//!     return { bar: 1 }
+//!   },
+//!   computed: {
+//!     baz() { return 2 }
+//!   }
+//! }
+//! ```
+
+use super::{ScriptLintResult, ScriptRule, ScriptRuleMeta};
+use crate::diagnostic::{LintDiagnostic, Severity};
+use oxc_ast::ast::{
+    Argument, BindingPattern, ExportDefaultDeclarationKind, Expression, Function, ObjectExpression,
+    ObjectPropertyKind, Program, PropertyKey, Statement,
+};
+use oxc_span::GetSpan;
+use vize_carton::{CompactString, FxHashMap};
+
+static META: ScriptRuleMeta = ScriptRuleMeta {
+    name: "script/no-dupe-keys",
+    description: "Disallow duplicate keys across Options API props/data/computed/methods/setup/inject",
+    default_severity: Severity::Error,
+};
+
+/// Disallow duplicate keys across Options API groups.
+pub struct NoDupeKeys;
+
+impl ScriptRule for NoDupeKeys {
+    fn meta(&self) -> &'static ScriptRuleMeta {
+        &META
+    }
+
+    #[inline]
+    fn uses_ast(&self) -> bool {
+        true
+    }
+
+    #[inline]
+    fn check_program<'a>(
+        &self,
+        program: &'a Program<'a>,
+        _source: &str,
+        offset: usize,
+        result: &mut ScriptLintResult,
+    ) {
+        let Some(options) = find_component_options(program) else {
+            return;
+        };
+        check_options_object(options, offset, result);
+    }
+}
+
+/// The Options API group a key was declared in. Stored alongside the first span
+/// so a later duplicate can point back at the original declaration.
+#[derive(Clone, Copy)]
+struct KeyOrigin {
+    group: &'static str,
+    start: u32,
+    end: u32,
+}
+
+fn check_options_object(
+    object: &ObjectExpression<'_>,
+    offset: usize,
+    result: &mut ScriptLintResult,
+) {
+    // First declaration wins; subsequent declarations of the same key in any
+    // group are reported as duplicates pointing back at the original.
+    let mut seen: FxHashMap<CompactString, KeyOrigin> = FxHashMap::default();
+
+    for property in &object.properties {
+        let ObjectPropertyKind::ObjectProperty(property) = property else {
+            continue;
+        };
+        if property.computed {
+            continue;
+        }
+        let Some(group) = property_key_name(&property.key).and_then(option_group) else {
+            continue;
+        };
+
+        for member in collect_group_member_keys(group, &property.value) {
+            record_key(&mut seen, group.label, member, offset, result);
+        }
+    }
+}
+
+fn record_key(
+    seen: &mut FxHashMap<CompactString, KeyOrigin>,
+    group: &'static str,
+    member: MemberKey,
+    offset: usize,
+    result: &mut ScriptLintResult,
+) {
+    let start = offset as u32 + member.start;
+    let end = offset as u32 + member.end;
+
+    if let Some(origin) = seen.get(&member.name) {
+        let mut message = CompactString::with_capacity(member.name.len() + 48);
+        message.push_str("Duplicated key '");
+        message.push_str(&member.name);
+        message.push('\'');
+
+        let diagnostic = LintDiagnostic::error(META.name, message, start, end)
+            .with_label(group_label(group), start, end)
+            .with_label(
+                first_declaration_label(origin.group),
+                origin.start,
+                origin.end,
+            )
+            .with_help(
+                "props, data, computed, methods, setup, and inject share the component \
+                 instance namespace; give each member a unique name.",
+            );
+        result.add_diagnostic(diagnostic);
+        return;
+    }
+
+    seen.insert(member.name, KeyOrigin { group, start, end });
+}
+
+fn group_label(group: &'static str) -> CompactString {
+    let mut label = CompactString::with_capacity(group.len() + 24);
+    label.push_str("declared again in ");
+    label.push_str(group);
+    label
+}
+
+fn first_declaration_label(group: &'static str) -> CompactString {
+    let mut label = CompactString::with_capacity(group.len() + 24);
+    label.push_str("first declared in ");
+    label.push_str(group);
+    label
+}
+
+/// A single collected member name and the span it should be reported at.
+struct MemberKey {
+    name: CompactString,
+    start: u32,
+    end: u32,
+}
+
+#[derive(Clone, Copy)]
+struct OptionGroup {
+    label: &'static str,
+    kind: GroupKind,
+}
+
+#[derive(Clone, Copy)]
+enum GroupKind {
+    /// `props`: array of strings or object of declarations.
+    Props,
+    /// `inject`: array of strings or object of declarations.
+    Inject,
+    /// `computed` / `methods`: object of declarations.
+    Object,
+    /// `data` / `setup`: a function returning an object literal.
+    ReturnObject,
+}
+
+fn option_group(name: &str) -> Option<OptionGroup> {
+    let (label, kind) = match name {
+        "props" => ("props", GroupKind::Props),
+        "inject" => ("inject", GroupKind::Inject),
+        "computed" => ("computed", GroupKind::Object),
+        "methods" => ("methods", GroupKind::Object),
+        "data" => ("data", GroupKind::ReturnObject),
+        "setup" => ("setup", GroupKind::ReturnObject),
+        _ => return None,
+    };
+    Some(OptionGroup { label, kind })
+}
+
+fn collect_group_member_keys(group: OptionGroup, value: &Expression<'_>) -> Vec<MemberKey> {
+    match group.kind {
+        GroupKind::Props | GroupKind::Inject => collect_array_or_object_keys(value),
+        GroupKind::Object => collect_object_keys(value),
+        GroupKind::ReturnObject => collect_returned_object_keys(value),
+    }
+}
+
+/// `props`/`inject` accept either `['a', 'b']` or `{ a: ..., b: ... }`.
+fn collect_array_or_object_keys(value: &Expression<'_>) -> Vec<MemberKey> {
+    match value {
+        Expression::ArrayExpression(array) => {
+            let mut keys = Vec::new();
+            for element in &array.elements {
+                if let Some(string) = element.as_expression().and_then(string_literal) {
+                    keys.push(MemberKey {
+                        name: string.value.as_str().into(),
+                        start: string.span.start,
+                        end: string.span.end,
+                    });
+                }
+            }
+            keys
+        }
+        _ => collect_object_keys(value),
+    }
+}
+
+fn collect_object_keys(value: &Expression<'_>) -> Vec<MemberKey> {
+    let Expression::ObjectExpression(object) = value else {
+        return Vec::new();
+    };
+    object_property_keys(object)
+}
+
+/// `data`/`setup` are functions whose returned object literal declares members.
+fn collect_returned_object_keys<'a>(value: &'a Expression<'a>) -> Vec<MemberKey> {
+    let object = match value {
+        Expression::FunctionExpression(function) => function_return_object(function),
+        Expression::ArrowFunctionExpression(arrow) => {
+            if arrow.expression {
+                // `data: () => ({ ... })`
+                arrow
+                    .body
+                    .statements
+                    .first()
+                    .and_then(|statement| match statement {
+                        Statement::ExpressionStatement(expr) => {
+                            as_object(unwrap_parenthesized(&expr.expression))
+                        }
+                        _ => None,
+                    })
+            } else {
+                find_returned_object(&arrow.body.statements)
+            }
+        }
+        _ => None,
+    };
+    object.map(object_property_keys).unwrap_or_default()
+}
+
+fn function_return_object<'a>(function: &'a Function<'a>) -> Option<&'a ObjectExpression<'a>> {
+    let body = function.body.as_ref()?;
+    find_returned_object(&body.statements)
+}
+
+fn find_returned_object<'a>(statements: &'a [Statement<'a>]) -> Option<&'a ObjectExpression<'a>> {
+    for statement in statements {
+        if let Statement::ReturnStatement(ret) = statement
+            && let Some(argument) = ret.argument.as_ref()
+        {
+            return as_object(unwrap_parenthesized(argument));
+        }
+    }
+    None
+}
+
+fn object_property_keys(object: &ObjectExpression<'_>) -> Vec<MemberKey> {
+    let mut keys = Vec::new();
+    for property in &object.properties {
+        match property {
+            ObjectPropertyKind::ObjectProperty(property) => {
+                if property.computed {
+                    continue;
+                }
+                if let Some(name) = property_key_name(&property.key) {
+                    keys.push(MemberKey {
+                        name: name.into(),
+                        start: property.key.span().start,
+                        end: property.key.span().end,
+                    });
+                }
+            }
+            ObjectPropertyKind::SpreadProperty(_) => {}
+        }
+    }
+    keys
+}
+
+fn as_object<'a>(expression: &'a Expression<'a>) -> Option<&'a ObjectExpression<'a>> {
+    match expression {
+        Expression::ObjectExpression(object) => Some(object),
+        _ => None,
+    }
+}
+
+fn unwrap_parenthesized<'a>(expression: &'a Expression<'a>) -> &'a Expression<'a> {
+    match expression {
+        Expression::ParenthesizedExpression(paren) => unwrap_parenthesized(&paren.expression),
+        other => other,
+    }
+}
+
+fn string_literal<'a>(
+    expression: &'a Expression<'a>,
+) -> Option<&'a oxc_ast::ast::StringLiteral<'a>> {
+    match expression {
+        Expression::StringLiteral(string) => Some(string),
+        _ => None,
+    }
+}
+
+fn property_key_name<'a>(key: &'a PropertyKey<'a>) -> Option<&'a str> {
+    match key {
+        PropertyKey::StaticIdentifier(id) => Some(id.name.as_str()),
+        PropertyKey::StringLiteral(string) => Some(string.value.as_str()),
+        _ => None,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Component options resolution (export default / defineComponent).
+// ---------------------------------------------------------------------------
+
+fn find_component_options<'a>(program: &'a Program<'a>) -> Option<&'a ObjectExpression<'a>> {
+    let mut bindings: FxHashMap<&'a str, &'a ObjectExpression<'a>> = FxHashMap::default();
+
+    for statement in program.body.iter() {
+        let Statement::VariableDeclaration(declaration) = statement else {
+            continue;
+        };
+        for declarator in &declaration.declarations {
+            let Some(init) = declarator.init.as_ref() else {
+                continue;
+            };
+            if let BindingPattern::BindingIdentifier(id) = &declarator.id
+                && let Some(object) = options_from_expression(init, &bindings)
+            {
+                bindings.insert(id.name.as_str(), object);
+            }
+        }
+    }
+
+    for statement in program.body.iter() {
+        let Statement::ExportDefaultDeclaration(export) = statement else {
+            continue;
+        };
+        if let Some(object) = options_from_export(&export.declaration, &bindings) {
+            return Some(object);
+        }
+    }
+
+    None
+}
+
+fn options_from_export<'a>(
+    declaration: &'a ExportDefaultDeclarationKind<'a>,
+    bindings: &FxHashMap<&'a str, &'a ObjectExpression<'a>>,
+) -> Option<&'a ObjectExpression<'a>> {
+    match declaration {
+        ExportDefaultDeclarationKind::ObjectExpression(object) => Some(object),
+        ExportDefaultDeclarationKind::CallExpression(call) => options_from_call(call, bindings),
+        ExportDefaultDeclarationKind::Identifier(identifier) => {
+            bindings.get(identifier.name.as_str()).copied()
+        }
+        ExportDefaultDeclarationKind::ParenthesizedExpression(paren) => {
+            options_from_expression(&paren.expression, bindings)
+        }
+        ExportDefaultDeclarationKind::TSAsExpression(ts_as) => {
+            options_from_expression(&ts_as.expression, bindings)
+        }
+        ExportDefaultDeclarationKind::TSSatisfiesExpression(ts_satisfies) => {
+            options_from_expression(&ts_satisfies.expression, bindings)
+        }
+        ExportDefaultDeclarationKind::TSNonNullExpression(ts_non_null) => {
+            options_from_expression(&ts_non_null.expression, bindings)
+        }
+        _ => None,
+    }
+}
+
+fn options_from_expression<'a>(
+    expression: &'a Expression<'a>,
+    bindings: &FxHashMap<&'a str, &'a ObjectExpression<'a>>,
+) -> Option<&'a ObjectExpression<'a>> {
+    match expression {
+        Expression::ObjectExpression(object) => Some(object),
+        Expression::CallExpression(call) => options_from_call(call, bindings),
+        Expression::Identifier(identifier) => bindings.get(identifier.name.as_str()).copied(),
+        Expression::ParenthesizedExpression(paren) => {
+            options_from_expression(&paren.expression, bindings)
+        }
+        Expression::TSAsExpression(ts_as) => options_from_expression(&ts_as.expression, bindings),
+        Expression::TSSatisfiesExpression(ts_satisfies) => {
+            options_from_expression(&ts_satisfies.expression, bindings)
+        }
+        Expression::TSNonNullExpression(ts_non_null) => {
+            options_from_expression(&ts_non_null.expression, bindings)
+        }
+        _ => None,
+    }
+}
+
+fn options_from_call<'a>(
+    call: &'a oxc_ast::ast::CallExpression<'a>,
+    bindings: &FxHashMap<&'a str, &'a ObjectExpression<'a>>,
+) -> Option<&'a ObjectExpression<'a>> {
+    let Expression::Identifier(callee) = &call.callee else {
+        return None;
+    };
+    if !matches!(callee.name.as_str(), "defineComponent" | "_defineComponent") {
+        return None;
+    }
+    match call.arguments.first()? {
+        Argument::ObjectExpression(object) => Some(object),
+        Argument::Identifier(identifier) => bindings.get(identifier.name.as_str()).copied(),
+        argument => argument
+            .as_expression()
+            .and_then(|expression| options_from_expression(expression, bindings)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::NoDupeKeys;
+    use crate::rules::script::ScriptLinter;
+
+    fn create_linter() -> ScriptLinter {
+        let mut linter = ScriptLinter::new();
+        linter.add_rule(Box::new(NoDupeKeys));
+        linter
+    }
+
+    #[test]
+    fn test_valid_unique_keys() {
+        let source = r#"
+export default {
+  props: ['foo'],
+  data() {
+    return { bar: 1 }
+  },
+  computed: {
+    baz() { return 2 }
+  },
+  methods: {
+    qux() {}
+  }
+}
+"#;
+        let result = create_linter().lint(source, 0);
+        assert_eq!(result.error_count, 0);
+    }
+
+    #[test]
+    fn test_valid_no_options_object() {
+        let source = r#"
+import { ref } from 'vue'
+const foo = ref(0)
+const foo2 = ref(1)
+"#;
+        let result = create_linter().lint(source, 0);
+        assert_eq!(result.error_count, 0);
+    }
+
+    #[test]
+    fn test_prop_duplicated_in_data() {
+        let source = r#"
+export default {
+  props: ['foo'],
+  data() {
+    return { foo: 1 }
+  }
+}
+"#;
+        let result = create_linter().lint(source, 0);
+        assert_eq!(result.error_count, 1);
+        insta::assert_debug_snapshot!(result.diagnostics);
+    }
+
+    #[test]
+    fn test_computed_duplicated_in_methods() {
+        let source = r#"
+export default {
+  computed: {
+    bar() { return 2 }
+  },
+  methods: {
+    bar() {}
+  }
+}
+"#;
+        let result = create_linter().lint(source, 0);
+        assert_eq!(result.error_count, 1);
+        insta::assert_debug_snapshot!(result.diagnostics);
+    }
+
+    #[test]
+    fn test_prop_object_form_duplicated_in_computed() {
+        let source = r#"
+export default {
+  props: {
+    count: Number
+  },
+  computed: {
+    count() { return 1 }
+  }
+}
+"#;
+        let result = create_linter().lint(source, 0);
+        assert_eq!(result.error_count, 1);
+    }
+
+    #[test]
+    fn test_define_component_duplicate() {
+        let source = r#"
+import { defineComponent } from 'vue'
+
+export default defineComponent({
+  data() {
+    return { value: 1 }
+  },
+  methods: {
+    value() {}
+  }
+})
+"#;
+        let result = create_linter().lint(source, 0);
+        assert_eq!(result.error_count, 1);
+    }
+
+    #[test]
+    fn test_identifier_export_duplicate() {
+        let source = r#"
+const component = {
+  props: ['name'],
+  methods: {
+    name() {}
+  }
+}
+
+export default component
+"#;
+        let result = create_linter().lint(source, 0);
+        assert_eq!(result.error_count, 1);
+    }
+
+    #[test]
+    fn test_arrow_data_concise_body_duplicate() {
+        let source = r#"
+export default {
+  inject: ['theme'],
+  data: () => ({ theme: 'dark' })
+}
+"#;
+        let result = create_linter().lint(source, 0);
+        assert_eq!(result.error_count, 1);
+    }
+
+    #[test]
+    fn test_setup_return_duplicated_in_data() {
+        let source = r#"
+export default {
+  data() {
+    return { open: false }
+  },
+  setup() {
+    return { open: true }
+  }
+}
+"#;
+        let result = create_linter().lint(source, 0);
+        assert_eq!(result.error_count, 1);
+    }
+
+    #[test]
+    fn test_multiple_duplicates_reported() {
+        let source = r#"
+export default {
+  props: ['a', 'b'],
+  computed: {
+    a() { return 1 }
+  },
+  methods: {
+    b() {}
+  }
+}
+"#;
+        let result = create_linter().lint(source, 0);
+        assert_eq!(result.error_count, 2);
+    }
+
+    #[test]
+    fn test_inject_object_form_duplicate() {
+        let source = r#"
+export default {
+  inject: {
+    foo: { from: 'bar' }
+  },
+  computed: {
+    foo() { return 1 }
+  }
+}
+"#;
+        let result = create_linter().lint(source, 0);
+        assert_eq!(result.error_count, 1);
+    }
+
+    #[test]
+    fn test_spread_in_object_is_ignored() {
+        let source = r#"
+export default {
+  props: ['foo'],
+  computed: {
+    ...mapGetters(['count'])
+  }
+}
+"#;
+        let result = create_linter().lint(source, 0);
+        assert_eq!(result.error_count, 0);
+    }
+}

--- a/crates/vize_patina/src/rules/script/snapshots/vize_patina__rules__script__no_dupe_keys__tests__computed_duplicated_in_methods.snap
+++ b/crates/vize_patina/src/rules/script/snapshots/vize_patina__rules__script__no_dupe_keys__tests__computed_duplicated_in_methods.snap
@@ -1,0 +1,29 @@
+---
+source: crates/vize_patina/src/rules/script/no_dupe_keys.rs
+expression: result.diagnostics
+---
+[
+    LintDiagnostic {
+        rule_name: "script/no-dupe-keys",
+        severity: Error,
+        message: "Duplicated key 'bar'",
+        start: 77,
+        end: 80,
+        help: Some(
+            "props, data, computed, methods, setup, and inject share the component instance namespace; give each member a unique name.",
+        ),
+        labels: [
+            Label {
+                message: "declared again in methods",
+                start: 77,
+                end: 80,
+            },
+            Label {
+                message: "first declared in computed",
+                start: 36,
+                end: 39,
+            },
+        ],
+        fix: None,
+    },
+]

--- a/crates/vize_patina/src/rules/script/snapshots/vize_patina__rules__script__no_dupe_keys__tests__prop_duplicated_in_data.snap
+++ b/crates/vize_patina/src/rules/script/snapshots/vize_patina__rules__script__no_dupe_keys__tests__prop_duplicated_in_data.snap
@@ -1,0 +1,29 @@
+---
+source: crates/vize_patina/src/rules/script/no_dupe_keys.rs
+expression: result.diagnostics
+---
+[
+    LintDiagnostic {
+        rule_name: "script/no-dupe-keys",
+        severity: Error,
+        message: "Duplicated key 'foo'",
+        start: 60,
+        end: 63,
+        help: Some(
+            "props, data, computed, methods, setup, and inject share the component instance namespace; give each member a unique name.",
+        ),
+        labels: [
+            Label {
+                message: "declared again in data",
+                start: 60,
+                end: 63,
+            },
+            Label {
+                message: "first declared in props",
+                start: 28,
+                end: 33,
+            },
+        ],
+        fix: None,
+    },
+]

--- a/crates/vize_patina/src/snapshots/vize_patina__preset__tests__lint_preset_rule_membership.snap
+++ b/crates/vize_patina/src/snapshots/vize_patina__preset__tests__lint_preset_rule_membership.snap
@@ -473,6 +473,7 @@ expression: "serde_json::to_string_pretty(&snapshot).unwrap()"
     "script/no-import-compiler-macros",
     "script/no-reserved-identifiers",
     "script/require-symbol-provide",
-    "script/require-function-return-type"
+    "script/require-function-return-type",
+    "script/no-dupe-keys"
   ]
 }

--- a/npm/vize/src/types/rules.ts
+++ b/npm/vize/src/types/rules.ts
@@ -62,6 +62,7 @@ export const LINT_RULE_NAMES = [
   "html/require-datetime",
   "script/no-async-in-computed",
   "script/no-deep-destructure-in-props",
+  "script/no-dupe-keys",
   "script/no-get-current-instance",
   "script/no-import-compiler-macros",
   "script/no-internal-imports",


### PR DESCRIPTION
## Rule

`script/no-dupe-keys` — a port of [`vue/no-dupe-keys`](https://eslint.vuejs.org/rules/no-dupe-keys.html) from eslint-plugin-vue, scoped to the Options API groups that share the component instance namespace: `props`, `data`, `computed`, `methods`, `setup`, and `inject`.

- Category: `Script`
- Default severity: `Error`
- Preset membership: opt-in (`OPT_IN_SCRIPT_PRESETS`) — not enabled by any shipping preset, so existing preset/snapshot behavior is unchanged apart from one new entry appended to the `opt_in` membership list (the established pattern for new opt-in script rules).

## Rationale

`props`, `data`, `computed`, `methods`, `setup` returns, and `inject` all expose their members on the component instance via `this`. Declaring the same key in two of these groups silently shadows one declaration with another and is almost always a bug. This is the lint follow-up portion of #1388 PR12; the existing options-object walker in `script/no-options-api` already proves the lint path can resolve and traverse the Options API options object, so no new binding-collection infrastructure was required.

## Examples

Invalid:
```ts
export default {
  props: ['foo'],
  data() { return { foo: 1 } },   // duplicate of prop `foo`
  computed: { bar() { return 2 } },
  methods: { bar() {} }           // duplicate of computed `bar`
}
```

Valid:
```ts
export default {
  props: ['foo'],
  data() { return { bar: 1 } },
  computed: { baz() { return 2 } }
}
```

The rule resolves the options object from `export default {...}`, `export default defineComponent({...})`, and `export default <identifier>` bound to a local object. It handles `props`/`inject` in both array (`['a']`) and object (`{ a: ... }`) forms, `data`/`setup` via the returned object literal (block body or arrow concise body), and ignores spread properties and computed keys.

## Verification

- `cargo test -p vize_patina` — 1052 passed, 0 failed (includes 12 new unit tests + 2 diagnostic snapshots)
- `cargo fmt -p vize_patina --check` — clean
- `cargo clippy -p vize_patina --lib` — 0 warnings

Self-contained to `vize_patina`. Refs #1388.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1448"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->