### PR TITLE
fix(croquis_cf): track Pinia stores via defineStore AST not use*Store naming

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3625,6 +3625,10 @@ version = "0.204.0"
 dependencies = [
  "criterion",
  "insta",
+ "oxc_allocator",
+ "oxc_ast",
+ "oxc_parser",
+ "oxc_span",
  "rustc-hash",
  "vize_armature",
  "vize_carton",

--- a/crates/vize_croquis_cf/Cargo.toml
+++ b/crates/vize_croquis_cf/Cargo.toml
@@ -11,6 +11,10 @@ description = "Cross-file semantic analysis for Vize Croquis"
 vize_carton.workspace = true
 vize_croquis.workspace = true
 rustc-hash.workspace = true
+oxc_allocator.workspace = true
+oxc_ast.workspace = true
+oxc_parser.workspace = true
+oxc_span.workspace = true
 
 [dev-dependencies]
 vize_armature.workspace = true

--- a/crates/vize_croquis_cf/src/analyzers.rs
+++ b/crates/vize_croquis_cf/src/analyzers.rs
@@ -12,7 +12,7 @@
 
 mod boundary;
 mod component_resolution;
-mod cross_file_reactivity;
+pub(crate) mod cross_file_reactivity;
 mod element_id;
 mod emit;
 mod event_bubbling;

--- a/crates/vize_croquis_cf/src/analyzers/cross_file_reactivity.rs
+++ b/crates/vize_croquis_cf/src/analyzers/cross_file_reactivity.rs
@@ -36,6 +36,7 @@ mod name_helpers;
 mod path_helpers;
 mod prop_helpers;
 mod provide_helpers;
+pub(crate) mod store_detection;
 mod types;
 
 pub use analyzer::CrossFileReactivityAnalyzer;

--- a/crates/vize_croquis_cf/src/analyzers/cross_file_reactivity/issues.rs
+++ b/crates/vize_croquis_cf/src/analyzers/cross_file_reactivity/issues.rs
@@ -38,10 +38,17 @@ impl<'a> CrossFileReactivityAnalyzer<'a> {
                 let has_store_to_refs = scope.bindings().any(|(name, _)| name == "storeToRefs");
 
                 if !has_store_to_refs {
-                    // Check if there are store calls that might be destructured
-                    // This is a heuristic - stores are usually named `use*Store`
+                    // Resolve store usages against the `defineStore(...)`
+                    // declarations tracked for this module, rather than the old
+                    // `use*Store` naming heuristic. A function coincidentally
+                    // named like a store is not flagged; a `defineStore` factory
+                    // with a non-conforming name still is.
+                    let stores = &self.registry.get(file_id).map(|entry| &entry.pinia_stores);
                     for composable in analysis.provide_inject.composables() {
-                        if composable.name.ends_with("Store") && composable.local_name.is_none() {
+                        let is_store = stores
+                            .map(|s| s.contains(composable.name.as_str()))
+                            .unwrap_or(false);
+                        if is_store && composable.local_name.is_none() {
                             self.issues.push(CrossFileReactivityIssue {
                                 file_id,
                                 kind: CrossFileReactivityIssueKind::StoreDestructured {

--- a/crates/vize_croquis_cf/src/analyzers/cross_file_reactivity/store_detection.rs
+++ b/crates/vize_croquis_cf/src/analyzers/cross_file_reactivity/store_detection.rs
@@ -1,0 +1,176 @@
+//! Structured detection of Pinia store factories.
+//!
+//! Replaces the legacy `use*Store` naming heuristic with AST tracking of
+//! `defineStore(...)` declarations. We collect the local identifiers that are
+//! bound to a `defineStore(...)` call (resolving the `defineStore` import from
+//! `pinia`, including `as` aliases) so that:
+//!
+//! - a function coincidentally named `useThingStore` that is *not* a
+//!   `defineStore` result is never classified as a store, and
+//! - a store factory bound with a non-conforming name (e.g. `const auth =
+//!   defineStore(...)`) *is* recognized.
+
+use oxc_allocator::Allocator;
+use oxc_ast::ast::{
+    BindingPattern, Declaration, Expression, ImportDeclarationSpecifier, Program, Statement,
+};
+use oxc_parser::Parser;
+use oxc_span::SourceType;
+use vize_carton::{CompactString, FxHashSet};
+
+/// Identifiers bound to `defineStore(...)` calls in a single module.
+#[derive(Debug, Default, Clone)]
+pub struct StoreFactories {
+    names: FxHashSet<CompactString>,
+}
+
+impl StoreFactories {
+    /// Whether `name` is a `defineStore`-bound store factory in this module.
+    #[inline]
+    pub fn contains(&self, name: &str) -> bool {
+        self.names.contains(name)
+    }
+
+    /// Whether any `defineStore` factory was found.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.names.is_empty()
+    }
+}
+
+/// Parse `source` and collect the identifiers bound to `defineStore(...)` calls.
+///
+/// `source` is parsed as TypeScript, matching how `vize_croquis_cf` feeds module
+/// content to `vize_croquis`. A parse failure yields an empty set rather than a
+/// best-effort guess.
+pub fn collect_store_factories(source: &str) -> StoreFactories {
+    let allocator = Allocator::default();
+    let source_type = SourceType::from_path("module.ts").unwrap_or_default();
+    let ret = Parser::new(&allocator, source, source_type).parse();
+    if ret.panicked {
+        return StoreFactories::default();
+    }
+    collect_from_program(&ret.program)
+}
+
+fn collect_from_program(program: &Program<'_>) -> StoreFactories {
+    // Local names that resolve to pinia's `defineStore`.
+    let mut define_store_aliases: FxHashSet<&str> = FxHashSet::default();
+    for stmt in program.body.iter() {
+        if let Statement::ImportDeclaration(import) = stmt
+            && import.source.value.as_str() == "pinia"
+            && let Some(specifiers) = &import.specifiers
+        {
+            for spec in specifiers.iter() {
+                if let ImportDeclarationSpecifier::ImportSpecifier(s) = spec
+                    && s.imported.name().as_str() == "defineStore"
+                {
+                    define_store_aliases.insert(s.local.name.as_str());
+                }
+            }
+        }
+    }
+
+    // If `defineStore` was never imported from pinia, fall back to recognizing
+    // the bare `defineStore` callee. This keeps detection working for modules
+    // that re-export or globally register the helper while still requiring an
+    // actual `defineStore(...)` call (not just a `use*Store` name).
+    let mut names: FxHashSet<CompactString> = FxHashSet::default();
+    for stmt in program.body.iter() {
+        let decl = match stmt {
+            Statement::VariableDeclaration(decl) => Some(&**decl),
+            Statement::ExportNamedDeclaration(export) => match &export.declaration {
+                Some(Declaration::VariableDeclaration(decl)) => Some(&**decl),
+                _ => None,
+            },
+            _ => None,
+        };
+
+        let Some(decl) = decl else { continue };
+        for declarator in decl.declarations.iter() {
+            let BindingPattern::BindingIdentifier(ident) = &declarator.id else {
+                continue;
+            };
+            let Some(Expression::CallExpression(call)) = &declarator.init else {
+                continue;
+            };
+            let Expression::Identifier(callee) = &call.callee else {
+                continue;
+            };
+            let callee_name = callee.name.as_str();
+            let is_define_store = if define_store_aliases.is_empty() {
+                callee_name == "defineStore"
+            } else {
+                define_store_aliases.contains(callee_name)
+            };
+            if is_define_store {
+                names.insert(CompactString::new(ident.name.as_str()));
+            }
+        }
+    }
+
+    StoreFactories { names }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detects_conventional_store() {
+        let factories = collect_store_factories(
+            "import { defineStore } from 'pinia'\nconst useUserStore = defineStore('user', {})",
+        );
+        assert!(factories.contains("useUserStore"));
+    }
+
+    #[test]
+    fn detects_exported_store() {
+        let factories = collect_store_factories(
+            "import { defineStore } from 'pinia'\nexport const useCart = defineStore('cart', () => ({}))",
+        );
+        assert!(factories.contains("useCart"));
+    }
+
+    #[test]
+    fn detects_nonconforming_store_name() {
+        // Bound to defineStore but does NOT follow the use*Store convention.
+        let factories = collect_store_factories(
+            "import { defineStore } from 'pinia'\nconst auth = defineStore('auth', {})",
+        );
+        assert!(factories.contains("auth"));
+    }
+
+    #[test]
+    fn resolves_aliased_import() {
+        let factories = collect_store_factories(
+            "import { defineStore as ds } from 'pinia'\nconst useThingStore = ds('thing', {})",
+        );
+        assert!(factories.contains("useThingStore"));
+    }
+
+    #[test]
+    fn ignores_same_named_non_store_function() {
+        // Named like a store but bound to a plain function, not defineStore.
+        let factories = collect_store_factories(
+            "import { defineStore } from 'pinia'\nconst useThingStore = () => ({})",
+        );
+        assert!(!factories.contains("useThingStore"));
+        assert!(factories.is_empty());
+    }
+
+    #[test]
+    fn ignores_store_named_call_that_is_not_define_store() {
+        // `useThingStore` assigned from an unrelated call must not be a store.
+        let factories = collect_store_factories(
+            "import { defineStore } from 'pinia'\nconst useThingStore = createSomething('x')",
+        );
+        assert!(!factories.contains("useThingStore"));
+    }
+
+    #[test]
+    fn empty_when_define_store_not_imported_and_no_call() {
+        let factories = collect_store_factories("const useThingStore = () => ({})");
+        assert!(factories.is_empty());
+    }
+}

--- a/crates/vize_croquis_cf/src/lib.rs
+++ b/crates/vize_croquis_cf/src/lib.rs
@@ -53,7 +53,7 @@ mod registry;
 mod suppression;
 
 // Analyzer implementations
-mod analyzers;
+pub(crate) mod analyzers;
 
 // Re-exports
 pub use analyzer::{CrossFileAnalyzer, CrossFileOptions, CrossFileResult, CrossFileStats};

--- a/crates/vize_croquis_cf/src/registry.rs
+++ b/crates/vize_croquis_cf/src/registry.rs
@@ -10,6 +10,9 @@
 //! - Lazy file metadata loading to avoid unnecessary I/O
 //! - Source hashing for change detection without file I/O
 
+use crate::analyzers::cross_file_reactivity::store_detection::{
+    StoreFactories, collect_store_factories,
+};
 use std::path::{Path, PathBuf};
 use std::time::SystemTime;
 use vize_carton::{CompactString, FxHashMap, FxHashSet};
@@ -59,6 +62,11 @@ pub struct ModuleEntry {
     pub is_vue_sfc: bool,
     /// Component name (extracted from filename or defineComponent).
     pub component_name: Option<CompactString>,
+    /// Identifiers bound to `defineStore(...)` calls in this module.
+    ///
+    /// Computed from the AST at registration time so that Pinia store usages
+    /// can be resolved structurally rather than by `use*Store` naming.
+    pub pinia_stores: StoreFactories,
 }
 
 /// Registry for tracking all analyzed files in a project.
@@ -127,6 +135,7 @@ impl ModuleRegistry {
             if let Some(entry) = self.entries.get_mut(&existing_id) {
                 entry.source_hash = source_hash;
                 entry.analysis = analysis;
+                entry.pinia_stores = collect_store_factories(source);
                 entry.mtime = std::fs::metadata(&abs_path)
                     .ok()
                     .and_then(|m| m.modified().ok());
@@ -165,6 +174,7 @@ impl ModuleRegistry {
             source_hash,
             is_vue_sfc,
             component_name,
+            pinia_stores: collect_store_factories(source),
         };
 
         self.path_to_id.insert(abs_path, id);
@@ -368,5 +378,42 @@ mod tests {
         assert!(source_renders_slot("<slot>fallback</slot>"));
         assert!(!source_renders_slot("<template><slotter /></template>"));
         assert!(!source_renders_slot("<template></template>"));
+    }
+
+    #[test]
+    fn test_register_tracks_define_store_factories() {
+        let mut registry = ModuleRegistry::new();
+        let (id, _) = registry.register(
+            "stores/user.ts",
+            "import { defineStore } from 'pinia'\n\
+             export const useUserStore = defineStore('user', {})\n\
+             export function useNotAStore() { return 1 }",
+            Croquis::new(),
+        );
+
+        let entry = registry.get(id).expect("entry");
+        // The `defineStore` factory is recognized structurally...
+        assert!(entry.pinia_stores.contains("useUserStore"));
+        // ...while a plainly-declared function is not, even if it is `use*`.
+        assert!(!entry.pinia_stores.contains("useNotAStore"));
+    }
+
+    #[test]
+    fn test_register_ignores_non_define_store_named_store() {
+        let mut registry = ModuleRegistry::new();
+        let (id, _) = registry.register(
+            "stores/fake.ts",
+            "const useThingStore = () => ({})",
+            Croquis::new(),
+        );
+
+        // Coincidental `use*Store` name, but not a `defineStore` result.
+        assert!(
+            !registry
+                .get(id)
+                .unwrap()
+                .pinia_stores
+                .contains("useThingStore")
+        );
     }
 }


### PR DESCRIPTION
## Problem

`vize_croquis_cf` classified Pinia stores by a naming heuristic: any composable
whose name ended with `Store` was treated as a store
(`cross_file_reactivity/issues.rs`, `composable.name.ends_with("Store")`). This
misclassifies a function coincidentally named like a store (e.g. a plain
`useThingStore` helper that is not a `defineStore` result) and misses a store
factory bound with a non-conforming name (e.g. `const auth = defineStore(...)`).

## Fix

Track `defineStore(...)` declarations structurally via the OXC AST, scoped
entirely to `vize_croquis_cf`:

- New `analyzers/cross_file_reactivity/store_detection.rs` parses module source
  and collects the identifiers bound to `defineStore(...)` calls, resolving the
  `defineStore` import from `pinia` (including `import { defineStore as ds }`
  aliases). It requires an actual `defineStore(...)` call, not a name match.
- `ModuleRegistry` computes this set (`ModuleEntry::pinia_stores`) once at
  registration time from the source it already receives.
- `detect_pinia_issues` now classifies store usages against that set instead of
  the `use*Store` name suffix.

A bare-`defineStore` callee fallback is kept only for modules that did not
import `defineStore` from `pinia` (re-export / global registration); it still
requires a real `defineStore(...)` call.

No other crates are touched.

## Verification

- `cargo test -p vize_croquis_cf` — 134 pass (7 new `store_detection` unit tests
  + 2 new registry tests covering: defineStore factory detected; same-named
  non-defineStore function not misclassified; aliased import; non-conforming
  store name recognized).
- `cargo fmt -p vize_croquis_cf --check` — clean.
- `cargo clippy -p vize_croquis_cf --lib` — 0 warnings.

Refs #1394

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1449"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->