### PR TITLE
fix(check): show shared virtual TS helpers

### DIFF
--- a/crates/vize/src/commands/check/runner/diagnostics.rs
+++ b/crates/vize/src/commands/check/runner/diagnostics.rs
@@ -1,7 +1,7 @@
 //! Diagnostic reporting, JSON serialization, and profile artifacts for the
 //! `check` runner.
 
-use std::{fmt::Write as _, fs, path::Path, path::PathBuf};
+use std::{fs, path::Path, path::PathBuf};
 
 use vize_carton::{FxHashSet, String as CompactString, cstr, profile, profiler::global_profiler};
 
@@ -20,8 +20,8 @@ pub(super) fn emit_json_output(json_output: JsonOutput) {
 
 pub(super) fn render_virtual_ts_output<'a>(
     files: impl IntoIterator<Item = (&'a Path, &'a str)>,
-) -> std::string::String {
-    let mut output = std::string::String::new();
+) -> CompactString {
+    let mut output = CompactString::default();
     append_virtual_ts_section(
         &mut output,
         Path::new(vize_canon::virtual_ts::SHARED_PREAMBLE_FILE_NAME),
@@ -33,10 +33,10 @@ pub(super) fn render_virtual_ts_output<'a>(
     output
 }
 
-fn append_virtual_ts_section(output: &mut std::string::String, path: &Path, content: &str) {
+fn append_virtual_ts_section(output: &mut CompactString, path: &Path, content: &str) {
     output.push('\n');
     output.push_str("=== ");
-    let _ = write!(output, "{}", path.display());
+    output.push_str(cstr!("{}", path.display()).as_str());
     output.push_str(" ===\n");
     output.push_str(content);
     output.push('\n');

--- a/crates/vize/src/commands/check/runner/diagnostics.rs
+++ b/crates/vize/src/commands/check/runner/diagnostics.rs
@@ -1,7 +1,7 @@
 //! Diagnostic reporting, JSON serialization, and profile artifacts for the
 //! `check` runner.
 
-use std::{fs, path::Path, path::PathBuf};
+use std::{fmt::Write as _, fs, path::Path, path::PathBuf};
 
 use vize_carton::{FxHashSet, String as CompactString, cstr, profile, profiler::global_profiler};
 
@@ -16,6 +16,30 @@ pub(super) fn emit_json_output(json_output: JsonOutput) {
             std::process::exit(1);
         }
     }
+}
+
+pub(super) fn render_virtual_ts_output<'a>(
+    files: impl IntoIterator<Item = (&'a Path, &'a str)>,
+) -> std::string::String {
+    let mut output = std::string::String::new();
+    append_virtual_ts_section(
+        &mut output,
+        Path::new(vize_canon::virtual_ts::SHARED_PREAMBLE_FILE_NAME),
+        vize_canon::virtual_ts::SHARED_PREAMBLE_DTS,
+    );
+    for (path, content) in files {
+        append_virtual_ts_section(&mut output, path, content);
+    }
+    output
+}
+
+fn append_virtual_ts_section(output: &mut std::string::String, path: &Path, content: &str) {
+    output.push('\n');
+    output.push_str("=== ");
+    let _ = write!(output, "{}", path.display());
+    output.push_str(" ===\n");
+    output.push_str(content);
+    output.push('\n');
 }
 
 /// Whether a registered file's diagnostics should be reported. For an explicit
@@ -237,7 +261,24 @@ pub(super) fn write_profile_virtual_ts(files: &[&vize_canon::VirtualFile]) {
 
 #[cfg(test)]
 mod tests {
-    use super::{save_virtual_ts_for_path, virtual_ts_save_path};
+    use super::{render_virtual_ts_output, save_virtual_ts_for_path, virtual_ts_save_path};
+
+    #[test]
+    fn render_virtual_ts_output_includes_shared_helpers_before_source_files() {
+        let output =
+            render_virtual_ts_output([(std::path::Path::new("App.vue"), "const value = 1;\n")]);
+
+        let helpers_header = format!(
+            "=== {} ===",
+            vize_canon::virtual_ts::SHARED_PREAMBLE_FILE_NAME
+        );
+        let source_header = "=== App.vue ===";
+        assert!(output.contains(&helpers_header));
+        assert!(output.contains("Shared ambient helpers for vize virtual TypeScript"));
+        assert!(output.contains("declare function __vize_defineProps"));
+        assert!(output.contains(source_header));
+        assert!(output.find(&helpers_header).unwrap() < output.find(source_header).unwrap());
+    }
 
     #[test]
     fn virtual_ts_save_path_appends_virtual_ts_after_full_file_name() {

--- a/crates/vize/src/commands/check/runner/mod.rs
+++ b/crates/vize/src/commands/check/runner/mod.rs
@@ -43,7 +43,7 @@ mod tests;
 use collect::collect_check_files;
 use diagnostics::{
     emit_json_output, is_reported, is_suppressed_false_positive, render_diagnostics,
-    save_virtual_ts_for_path, write_profile_virtual_ts,
+    render_virtual_ts_output, save_virtual_ts_for_path, write_profile_virtual_ts,
 };
 use global_components::{
     build_virtual_ts_options, collect_project_global_component_stubs, template_syntax_mode,
@@ -333,10 +333,14 @@ pub(crate) fn run_direct(args: &CheckArgs) {
     }
 
     if args.show_virtual_ts {
-        for file in &virtual_files {
-            eprintln!("\n=== {} ===", file.original_path.display());
-            eprintln!("{}", file.content);
-        }
+        eprint!(
+            "{}",
+            render_virtual_ts_output(
+                virtual_files
+                    .iter()
+                    .map(|file| (file.original_path.as_path(), file.content.as_str()))
+            )
+        );
     }
 
     if let Some(path) = args.save_virtual_ts_for.as_deref() {

--- a/crates/vize/src/commands/check/runner/socket.rs
+++ b/crates/vize/src/commands/check/runner/socket.rs
@@ -22,7 +22,11 @@ use crate::{
     profile_support,
 };
 
-use super::{collect::collect_vue_files, diagnostics::save_virtual_ts_for_path, display_path};
+use super::{
+    collect::collect_vue_files,
+    diagnostics::{render_virtual_ts_output, save_virtual_ts_for_path},
+    display_path,
+};
 use vize_curator::profile::{ProfilePhase, ProfilePhaseKind, ProfileReport, print_profile_report};
 
 /// Run type checking via Unix socket connection to check-server.
@@ -162,14 +166,19 @@ pub(crate) fn run_with_socket(args: &CheckArgs, socket_path: &str) {
                 .iter()
                 .filter(|diagnostic| diagnostic.severity == "warning")
                 .count();
-            if args.show_virtual_ts {
-                eprintln!("\n=== {} ===", filename);
-                eprintln!("{}", result.virtual_ts);
-            }
             results.push((filename, result));
         }
     }
     let request_time = request_start.elapsed();
+
+    if args.show_virtual_ts {
+        eprint!(
+            "{}",
+            render_virtual_ts_output(results.iter().map(|(filename, result)| {
+                (std::path::Path::new(filename), result.virtual_ts.as_str())
+            }))
+        );
+    }
 
     if let Some(path) = args.save_virtual_ts_for.as_deref() {
         let cwd = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));


### PR DESCRIPTION
## Summary
- include the program-wide `__vize_helpers.d.ts` section in `vize check --show-virtual-ts`
- reuse the same renderer for direct and socket check paths so the debug output shape stays consistent
- cover the renderer to keep the shared helpers ahead of per-file virtual TS output

## Why
The batch checker materializes `__vize_helpers.d.ts` into the Corsa virtual project, and generated `.vue.ts` files can reference the helper declarations hoisted there. When `--show-virtual-ts` only prints per-source virtual files, debugging type inference can miss the ambient helper declarations that TypeScript actually sees.

Refs #1439

## Verification
- `rustfmt --edition 2024 --check crates/vize/src/commands/check/runner/diagnostics.rs crates/vize/src/commands/check/runner/mod.rs crates/vize/src/commands/check/runner/socket.rs`
- `git diff --check`

I also attempted:
- `cargo test -p vize --lib commands::check::runner::diagnostics::tests::render_virtual_ts_output_includes_shared_helpers_before_source_files`

but the local run did not reach compilation because cargo stayed in `Downloading crates ...`; I stopped the lingering cargo process after confirming no rustc process had started.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1450"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783785467&installation_id=136613492&pr_number=1450&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1450&signature=be835fa89244765aa9f98d5dac25461ee1799d2f5e4b28e9e51f59d9bec5278f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->