### PR TITLE
feat(cli): include __vize_helpers.d.ts in --show-virtual-ts

### DIFF
--- a/crates/vize/src/commands/check/runner/mod.rs
+++ b/crates/vize/src/commands/check/runner/mod.rs
@@ -333,6 +333,11 @@ pub(crate) fn run_direct(args: &CheckArgs) {
     }
 
     if args.show_virtual_ts {
+        eprintln!(
+            "\n=== {} ===",
+            vize_canon::virtual_ts::SHARED_PREAMBLE_FILE_NAME
+        );
+        eprintln!("{}", vize_canon::virtual_ts::SHARED_PREAMBLE_DTS);
         for file in &virtual_files {
             eprintln!("\n=== {} ===", file.original_path.display());
             eprintln!("{}", file.content);

--- a/crates/vize/src/commands/check/runner/socket.rs
+++ b/crates/vize/src/commands/check/runner/socket.rs
@@ -72,6 +72,7 @@ pub(crate) fn run_with_socket(args: &CheckArgs, socket_path: &str) {
 
     let mut total_errors = 0usize;
     let mut total_warnings = 0usize;
+    let mut shown_shared_helpers = false;
     #[allow(clippy::disallowed_types, clippy::disallowed_methods)]
     let mut results: Vec<(std::string::String, ServerCheckResult)> = Vec::new();
 
@@ -162,6 +163,14 @@ pub(crate) fn run_with_socket(args: &CheckArgs, socket_path: &str) {
                 .iter()
                 .filter(|diagnostic| diagnostic.severity == "warning")
                 .count();
+            if args.show_virtual_ts && !shown_shared_helpers {
+                eprintln!(
+                    "\n=== {} ===",
+                    vize_canon::virtual_ts::SHARED_PREAMBLE_FILE_NAME
+                );
+                eprintln!("{}", vize_canon::virtual_ts::SHARED_PREAMBLE_DTS);
+                shown_shared_helpers = true;
+            }
             if args.show_virtual_ts {
                 eprintln!("\n=== {} ===", filename);
                 eprintln!("{}", result.virtual_ts);

--- a/crates/vize/tests/check_cli.rs
+++ b/crates/vize/tests/check_cli.rs
@@ -2185,6 +2185,82 @@ const count: string = 0;
     let _ = std::fs::remove_dir_all(&project_root);
 }
 
+#[cfg(unix)]
+#[test]
+fn check_socket_show_virtual_ts_includes_shared_helpers() {
+    use std::os::unix::net::UnixListener;
+
+    let project_root = create_cli_project(
+        "socket-show-virtual-ts-helpers",
+        &[(
+            "src/App.vue",
+            r#"<script setup lang="ts">
+const count = 0;
+</script>
+"#,
+        )],
+    );
+    let socket_path = std::path::PathBuf::from(
+        cstr!(
+            "/tmp/vize-check-{}-show-virtual-ts-helpers.sock",
+            std::process::id()
+        )
+        .as_str(),
+    );
+    let _ = std::fs::remove_file(&socket_path);
+    let listener = UnixListener::bind(&socket_path).unwrap();
+    let server = std::thread::spawn(move || {
+        let (mut stream, _) = listener.accept().unwrap();
+        let mut line = std::string::String::new();
+        std::io::BufReader::new(stream.try_clone().unwrap())
+            .read_line(&mut line)
+            .unwrap();
+        let request: serde_json::Value = serde_json::from_str(&line).unwrap();
+
+        let response = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": request["id"],
+            "result": {
+                "diagnostics": [],
+                "virtualTs": "const count = 0;",
+                "errorCount": 0
+            }
+        });
+        writeln!(stream, "{response}").unwrap();
+    });
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(&project_root)
+        .args([
+            "check",
+            "src",
+            "--socket",
+            socket_path.to_str().unwrap(),
+            "--show-virtual-ts",
+        ])
+        .output()
+        .unwrap();
+
+    server.join().unwrap();
+    let _ = std::fs::remove_file(&socket_path);
+    let stderr = std::string::String::from_utf8(output.stderr).unwrap();
+
+    assert!(
+        stderr.contains(vize_canon::virtual_ts::SHARED_PREAMBLE_FILE_NAME),
+        "expected shared helpers header in --show-virtual-ts output, got:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("declare function __vize_defineProps"),
+        "expected shared helpers content in --show-virtual-ts output, got:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("const count = 0;"),
+        "expected per-file virtual TS in --show-virtual-ts output, got:\n{stderr}"
+    );
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}
+
 #[test]
 fn check_can_emit_declarations() {
     let Some(corsa_path) = resolve_test_corsa_path() else {


### PR DESCRIPTION
## Problem

The shared ambient helpers (`VUE_TYPE_HELPERS`, the `__vize_*` setup-macro signatures, and the `ImportMeta` augmentation) are hoisted out of every generated `.vue.ts` into a single program-wide `__vize_helpers.d.ts` (the #1419 preamble-hoist work). `--show-virtual-ts` only dumped the per-file virtual modules and omitted that ambient file, so the shown output was not self-contained — it referenced `__vize_defineProps`, `__RuntimePropShape`, etc. without their declarations and could not be type-checked standalone.

## Fix

Emit the shared helpers file alongside the per-file virtual TS in both the direct (`runner/mod.rs`) and socket (`runner/socket.rs`) check runners, delimited by a `=== __vize_helpers.d.ts ===` header before the per-file dumps. The content comes from the already-public `vize_canon::virtual_ts::{SHARED_PREAMBLE_FILE_NAME, SHARED_PREAMBLE_DTS}` constants (the same ones materialized into the virtual project), so the dump now matches what the type checker actually sees.

## Verification

- New test `check_socket_show_virtual_ts_includes_shared_helpers` (mock socket server, no corsa required) asserts the helpers header, helper declarations, and per-file virtual TS all appear in `--show-virtual-ts` stderr.
- `cargo test -p vize --test check_cli check_socket_show_virtual_ts_includes_shared_helpers` — pass
- `cargo test -p vize --lib` — 123 passed
- `cargo fmt -p vize --check` — clean
- `cargo clippy -p vize --lib --all-features` — 0 warnings

Closes #1439

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1451"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->