### PR TITLE
test(atelier): lock class-component registered components to Options API parity

### DIFF
--- a/crates/vize_atelier_sfc/src/compile/tests.rs
+++ b/crates/vize_atelier_sfc/src/compile/tests.rs
@@ -2929,3 +2929,113 @@ export default {
 
     insta::assert_snapshot!(result.code.as_str());
 }
+/// A class component's `@Component({ components: { Foo } })` registration and
+/// its members must thread through compile output exactly like the equivalent
+/// Options API component: `<Foo/>` resolves via `_resolveComponent("Foo")`
+/// (the registration is resolved from the instance's `components` option at
+/// runtime, matching `@vue/compiler-sfc`), and template member usages are
+/// prefixed from binding metadata (`$props.` / `$data.` / `$options.`) rather
+/// than falling back to `_ctx.` for everything.
+#[test]
+fn test_class_component_registered_component_and_member_bindings() {
+    let class_src = r#"<script lang="ts">
+import { Vue, Component, Prop } from 'vue-property-decorator'
+import Foo from './Foo.vue'
+
+@Component({ components: { Foo } })
+export default class MyComp extends Vue {
+  @Prop() msg!: string
+  count = 0
+  get doubled() { return this.count * 2 }
+  greet() { return 'hi' }
+}
+</script>
+
+<template>
+  <Foo />
+  <p>{{ msg }}{{ count }}{{ doubled }}{{ greet() }}</p>
+</template>"#;
+    let descriptor = crate::parse_sfc(class_src, crate::SfcParseOptions::default()).expect("parse");
+    let result = super::compile_sfc(&descriptor, crate::types::SfcCompileOptions::default())
+        .expect("compile");
+
+    // `<Foo/>` resolves as a registered component, not via an arbitrary
+    // `_ctx.Foo` / `$setup.Foo` rewrite.
+    assert!(
+        result
+            .code
+            .contains(r#"_component_Foo = _resolveComponent("Foo")"#),
+        "expected <Foo/> to resolve from the @Component registration:\n{}",
+        result.code
+    );
+
+    // Class members thread through binding metadata with the Options API
+    // prefixes Vue's compiler-sfc emits.
+    assert!(
+        result.code.contains("_toDisplayString($props.msg)"),
+        "@Prop member should be prefixed `$props.`:\n{}",
+        result.code
+    );
+    assert!(
+        result.code.contains("_toDisplayString($data.count)"),
+        "plain field should be prefixed `$data.`:\n{}",
+        result.code
+    );
+    assert!(
+        result.code.contains("_toDisplayString($options.doubled)"),
+        "getter should be prefixed `$options.`:\n{}",
+        result.code
+    );
+    assert!(
+        result.code.contains("_toDisplayString($options.greet())"),
+        "method should be prefixed `$options.`:\n{}",
+        result.code
+    );
+    assert!(
+        !result.code.contains("_ctx.msg")
+            && !result.code.contains("_ctx.count")
+            && !result.code.contains("_ctx.doubled")
+            && !result.code.contains("_ctx.greet"),
+        "class members must not fall back to `_ctx.`:\n{}",
+        result.code
+    );
+
+    // The class component output must match the equivalent Options API
+    // component's render function exactly (only the script body differs).
+    let options_src = r#"<script lang="ts">
+import { defineComponent } from 'vue'
+import Foo from './Foo.vue'
+
+export default defineComponent({
+  components: { Foo },
+  props: { msg: String },
+  data() { return { count: 0 } },
+  computed: { doubled() { return this.count * 2 } },
+  methods: { greet() { return 'hi' } },
+})
+</script>
+
+<template>
+  <Foo />
+  <p>{{ msg }}{{ count }}{{ doubled }}{{ greet() }}</p>
+</template>"#;
+    let options_descriptor =
+        crate::parse_sfc(options_src, crate::SfcParseOptions::default()).expect("parse");
+    let options_result = super::compile_sfc(
+        &options_descriptor,
+        crate::types::SfcCompileOptions::default(),
+    )
+    .expect("compile");
+
+    fn render_fn(code: &str) -> &str {
+        let start = code
+            .find("function _sfc_render(")
+            .expect("render function present");
+        &code[start..]
+    }
+    assert_eq!(
+        render_fn(&result.code),
+        render_fn(&options_result.code),
+        "class component render function must match the Options API equivalent"
+    );
+}


### PR DESCRIPTION
## Problem

#1391 PR6 asks to thread a class component's `@Component({ components: { Foo } })` (or `@Options({...})`) registrations and prop names into used-component resolution and binding metadata, so `<Foo/>` resolves like an Options API `components: {}` registration rather than always falling back to runtime `_resolveComponent` with un-prefixed `_ctx.` member access.

## Fix

Investigation shows the threading is **already in place** end-to-end, with no codegen gap:

- Croquis dispatches class default exports to `collect_class_component_metadata` (`script_parser/process/class_component.rs`), which feeds the `@Component`/`@Options` decorator argument through the existing Options API collectors (`collect_component_registrations_from_options` + `collect_options_api_template_bindings_from_options`) and maps class members to `Props`/`Data`/`Options` bindings.
- The atelier compile path (`compile.rs` Case 2: `<script>` + template) already forwards those Options API member bindings to the template compiler via the `options_api_bindings` block (landed in #1446), so class members are prefixed `$props.`/`$data.`/`$options.`.
- `<Foo/>` emits `_resolveComponent("Foo")` — byte-for-byte identical to the equivalent Options API `components: { Foo }` component. This is correct `@vue/compiler-sfc` parity: the registration is resolved from the instance `components` option at runtime (the issue's own analysis notes the fallback is "parity-neutral with upstream so codegen needs no new strategy").

Since the behavior is already correct, this PR adds a regression test (no production code change) locking in the parity, including an exact render-function equality assertion against the equivalent Options API component.

## Verification

- `cargo test -p vize_atelier_sfc` — 521 passed (new test included)
- `tests/allocation_budget.rs` — passes, no regression
- `cargo fmt --check` clean, `cargo clippy --lib` 0 warnings
- No compile-output change, so no snapshot/coverage regeneration needed

Refs #1391

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1452"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->