### PR TITLE
perf(vitrine): make heavy NAPI batch payloads opt-in

### DIFF
--- a/crates/vize_vitrine/src/napi/sfc/batch_results.rs
+++ b/crates/vize_vitrine/src/napi/sfc/batch_results.rs
@@ -41,6 +41,14 @@ pub fn compile_sfc_batch_with_results(
     let template_syntax = resolve_template_syntax(opts.template_syntax.as_deref())
         .map_err(|message| napi::Error::new(Status::InvalidArg, message))?;
     let standalone = opts.mode.as_deref() == Some("function");
+    // Heavy/optional payloads are opt-in so the default boundary stays lean:
+    // `code`/`css` are always materialized eagerly (fairness), but the per-block
+    // `styles` (which re-sends the CSS `css` already carries), custom blocks,
+    // macro artifacts and content hashes are skipped unless the caller asks.
+    let include_styles = opts.include_styles.unwrap_or(false);
+    let include_custom_blocks = opts.include_custom_blocks.unwrap_or(false);
+    let include_macro_artifacts = opts.include_macro_artifacts.unwrap_or(false);
+    let include_hashes = opts.include_hashes.unwrap_or(false);
     let start = Instant::now();
 
     // Indexed parallel map keeps results in input order (deterministic) and
@@ -78,11 +86,25 @@ pub fn compile_sfc_batch_with_results(
                 }
             };
 
-            let template_hash: Option<String> = descriptor.template_hash().map(Into::into);
-            let style_hash: Option<String> = descriptor.style_hash().map(Into::into);
-            let script_hash: Option<String> = descriptor.script_hash().map(Into::into);
-            let styles = style_blocks_to_napi(&descriptor.styles);
-            let custom_blocks = custom_blocks_to_napi(&descriptor.custom_blocks);
+            let (template_hash, style_hash, script_hash) = if include_hashes {
+                (
+                    descriptor.template_hash().map(Into::into),
+                    descriptor.style_hash().map(Into::into),
+                    descriptor.script_hash().map(Into::into),
+                )
+            } else {
+                (None, None, None)
+            };
+            let styles = if include_styles {
+                style_blocks_to_napi(&descriptor.styles)
+            } else {
+                vec![]
+            };
+            let custom_blocks = if include_custom_blocks {
+                custom_blocks_to_napi(&descriptor.custom_blocks)
+            } else {
+                vec![]
+            };
             let has_scoped = descriptor.styles.iter().any(|s| s.scoped);
             let template_compiler_options = Some(vize_atelier_dom::DomCompilerOptions {
                 scope_id: has_scoped.then(|| cstr!("data-v-{scope_id}")),
@@ -122,28 +144,46 @@ pub fn compile_sfc_batch_with_results(
             match compile_result {
                 Ok(result) => {
                     success_count.fetch_add(1, Ordering::Relaxed);
+                    // Empty diagnostic vectors are the common case; skip the
+                    // per-element map/collect (and the empty-array boundary
+                    // crossing) when there is nothing to report.
+                    let errors = if result.errors.is_empty() {
+                        vec![]
+                    } else {
+                        result
+                            .errors
+                            .into_iter()
+                            .map(|e| e.message.into())
+                            .collect()
+                    };
+                    let warnings = if result.warnings.is_empty() {
+                        vec![]
+                    } else {
+                        result
+                            .warnings
+                            .into_iter()
+                            .map(|e| e.message.into())
+                            .collect()
+                    };
+                    let macro_artifacts = if include_macro_artifacts {
+                        macro_artifacts_to_napi(result.macro_artifacts)
+                    } else {
+                        vec![]
+                    };
                     BatchFileResultNapi {
                         path: file.path,
                         code: result.code.into(),
                         css: result.css.map(Into::into),
                         scope_id: scope_id.into(),
                         has_scoped,
-                        errors: result
-                            .errors
-                            .into_iter()
-                            .map(|e| e.message.into())
-                            .collect(),
-                        warnings: result
-                            .warnings
-                            .into_iter()
-                            .map(|e| e.message.into())
-                            .collect(),
+                        errors,
+                        warnings,
                         template_hash,
                         style_hash,
                         script_hash,
                         styles,
                         custom_blocks,
-                        macro_artifacts: macro_artifacts_to_napi(result.macro_artifacts),
+                        macro_artifacts,
                     }
                 }
                 Err(error) => BatchFileResultNapi {

--- a/crates/vize_vitrine/src/napi/sfc/types.rs
+++ b/crates/vize_vitrine/src/napi/sfc/types.rs
@@ -109,6 +109,19 @@ pub struct BatchCompileOptionsNapi {
     /// Preserve TypeScript in output when true
     pub is_ts: Option<bool>,
     pub threads: Option<u32>,
+    /// Include per-block style metadata (incl. `styles[].content`). Default OFF.
+    ///
+    /// `code`/`css` are always materialized; the per-block `styles` payload
+    /// re-sends the raw CSS that `css` already carries, so the default boundary
+    /// omits it to avoid duplicate UTF-8 -> V8 copies. Consumers that need the
+    /// preprocessor/CSS-modules metadata opt in explicitly.
+    pub include_styles: Option<bool>,
+    /// Include parsed custom blocks. Default OFF.
+    pub include_custom_blocks: Option<bool>,
+    /// Include compile-time macro artifacts. Default OFF.
+    pub include_macro_artifacts: Option<bool>,
+    /// Include template/style/script content hashes (for HMR). Default OFF.
+    pub include_hashes: Option<bool>,
 }
 
 #[napi(object)]

--- a/npm/vite-plugin-vize/src/compile-options.ts
+++ b/npm/vite-plugin-vize/src/compile-options.ts
@@ -52,6 +52,12 @@ export function buildCompileBatchOptions(options: CompileBatchOptions): BatchCom
     ssr: options.ssr,
     vapor: options.vapor,
     customRenderer: options.customRenderer ?? false,
+    // Opt into exactly the optional payloads the bundler pipeline consumes:
+    // per-block style metadata, macro artifacts, and HMR content hashes.
+    // Custom blocks are not used in the batch path, so they stay omitted.
+    includeStyles: true,
+    includeMacroArtifacts: true,
+    includeHashes: true,
     ...(options.mode === undefined ? {} : { mode: options.mode }),
     ...(options.templateSyntax === undefined ? {} : { templateSyntax: options.templateSyntax }),
     ...(options.runtimeModuleName === undefined

--- a/npm/vite-plugin-vize/src/types.ts
+++ b/npm/vite-plugin-vize/src/types.ts
@@ -313,6 +313,18 @@ export interface BatchCompileOptionsNapi {
   runtimeGlobalName?: string;
   vueVersion?: string;
   threads?: number;
+  /**
+   * Include per-block style metadata (incl. `styles[].content`). Default OFF.
+   * `code`/`css` are always returned; this opts into the extra CSS-modules /
+   * preprocessor metadata the bundler pipeline needs.
+   */
+  includeStyles?: boolean;
+  /** Include parsed custom blocks. Default OFF. */
+  includeCustomBlocks?: boolean;
+  /** Include compile-time macro artifacts. Default OFF. */
+  includeMacroArtifacts?: boolean;
+  /** Include template/style/script content hashes (for HMR). Default OFF. */
+  includeHashes?: boolean;
 }
 
 export interface BatchCompileResultWithFiles {


### PR DESCRIPTION
## Problem

The batch SFC compile boundary (`compileSfcBatchWithResults`) eagerly converts ~13 properties per file. Several are heavy and usually unwanted:

- `styles[].content` re-sends the raw CSS that `css` already carries (duplicate UTF-8 -> V8 copy).
- `custom_blocks`, `macro_artifacts`, and the three content hashes (`template_hash`/`style_hash`/`script_hash`) are materialized for every file even when the consumer never reads them.

On the 15,000-file benchmark these copies dominate the single-threaded boundary, ~30% of the 40x-target wall time. Empty `errors`/`warnings` arrays were also map/collected per file.

## Fix

- Add opt-in flags to `BatchCompileOptionsNapi` — `include_styles`, `include_custom_blocks`, `include_macro_artifacts`, `include_hashes` — all default **OFF**, so the default boundary is lean.
- Skip the per-element map/collect for empty `errors`/`warnings`.
- Vite plugin (`buildCompileBatchOptions`) opts in to exactly what its bundler pipeline consumes: `styles` (preprocessor / CSS-modules metadata + per-block content used by the fallback CSS pipeline), `macroArtifacts`, and the HMR content hashes. Custom blocks are not consumed in the batch path, so they stay omitted.

## Fairness preserved

- `code`/`css` stay **eagerly materialized JS strings** regardless of flags.
- No lazy getters; no source-hash dedup in the with-results lane.
- All files still actually compile — only the optional metadata is gated.

## Verification

- `cargo fmt -p vize_vitrine --check`: clean.
- `cargo clippy -p vize_vitrine --lib` (default features): no warnings from changed files; the only remaining warning is pre-existing in `vize_canon`. Under `--features napi` the warning count is unchanged vs. main (5), none in the changed files.
- `cargo test -p vize_vitrine`: pass.
- `npx vp check` on the changed TS (oxfmt + oxlint defaults): pass.
- **Native rebuild note:** the plugin's JS integration tests import `@vizejs/native` (prebuilt) and the `test` script runs `pnpm --dir ../vize-native build:debug` first. Exercising the new flags end-to-end in JS therefore requires rebuilding the native addon; the Rust unit-test path cannot link standalone (no Node N-API runtime symbols), so the behavioral assertions live on the JS side after a native rebuild.

Refs #1387

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1453"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->