### PR TITLE
fix(atelier): hoist nested static subtrees as one recursive VNodeCall

### DIFF
--- a/crates/vize_atelier_core/src/codegen/children.rs
+++ b/crates/vize_atelier_core/src/codegen/children.rs
@@ -99,7 +99,8 @@ fn generate_children_inner(
         return;
     }
 
-    let can_cache_static = ctx.static_cache && !ctx.in_v_for && !ctx.has_slot_params();
+    let can_cache_static =
+        ctx.static_cache && !ctx.in_v_for && !ctx.has_slot_params() && !ctx.in_cached_static;
     if !force_array
         && can_cache_static
         && !effective.is_empty()
@@ -210,6 +211,11 @@ fn generate_children_inner(
                 if let TemplateChildNode::Element(el) = effective[i] {
                     generate_cached_static_element(ctx, el);
                 }
+            } else if ctx.in_cached_static && is_static_cacheable_element(effective[i]) {
+                // Plain descendant inside an already-cached static subtree.
+                if let TemplateChildNode::Element(el) = effective[i] {
+                    generate_cached_static_vnode(ctx, el, false);
+                }
             } else {
                 generate_node(ctx, effective[i]);
             }
@@ -244,7 +250,7 @@ fn generate_cached_static_children_array(
         }
         ctx.newline();
         if let TemplateChildNode::Element(el) = child {
-            generate_cached_static_vnode(ctx, el);
+            generate_cached_static_vnode(ctx, el, true);
         }
     }
 
@@ -260,11 +266,18 @@ fn generate_cached_static_element(ctx: &mut CodegenContext, el: &ElementNode<'_>
     ctx.push("] || (_cache[");
     ctx.push(&cache_index.to_compact_string());
     ctx.push("] = ");
-    generate_cached_static_vnode(ctx, el);
+    generate_cached_static_vnode(ctx, el, true);
     ctx.push(")");
 }
 
-fn generate_cached_static_vnode(ctx: &mut CodegenContext, el: &ElementNode<'_>) {
+/// Emit one static element as `createElementVNode(...)`.
+///
+/// `cached` controls whether this vnode is the top-most cached node of a static
+/// subtree (gets the `-1 /* CACHED */` patch flag) or a descendant inside an
+/// already-cached subtree (plain vnode, no flag), matching how
+/// @vue/compiler-core serializes a cached static subtree: a single cache entry
+/// whose children are plain recursive `createElementVNode` calls.
+fn generate_cached_static_vnode(ctx: &mut CodegenContext, el: &ElementNode<'_>, cached: bool) {
     ctx.use_helper(RuntimeHelper::CreateElementVNode);
     ctx.push(ctx.helper(RuntimeHelper::CreateElementVNode));
     ctx.push("(\"");
@@ -282,14 +295,23 @@ fn generate_cached_static_vnode(ctx: &mut CodegenContext, el: &ElementNode<'_>) 
 
     if !el.children.is_empty() {
         ctx.push(", ");
+        // Descendants of a cached subtree are emitted as plain vnodes: suppress
+        // the cache wrapper and the per-descendant CACHED flag while recursing.
+        let prev_in_cached = ctx.in_cached_static;
+        ctx.in_cached_static = true;
         ctx.with_parent_namespace(child_namespace(el), |ctx| {
             generate_children(ctx, &el.children);
         });
+        ctx.in_cached_static = prev_in_cached;
     } else {
         ctx.push(", null");
     }
 
-    ctx.push(", -1 /* CACHED */)");
+    if cached {
+        ctx.push(", -1 /* CACHED */)");
+    } else {
+        ctx.push(")");
+    }
 }
 
 /// Generate text node

--- a/crates/vize_atelier_core/src/codegen/context.rs
+++ b/crates/vize_atelier_core/src/codegen/context.rs
@@ -58,6 +58,12 @@ pub struct CodegenContext {
     pub(super) parent_ns: Namespace,
     /// Whether static child VNodes should be cached in the render function.
     pub(super) static_cache: bool,
+    /// True while emitting the children of an already-cached static VNode.
+    /// Vue caches the top-most static element of a subtree as one entry and
+    /// renders its descendants as plain `createElementVNode(...)` calls inside
+    /// the cached array — no nested `_cache[...]` wrappers and no per-descendant
+    /// `CACHED` patch flag. This flag suppresses re-caching inside that subtree.
+    pub(super) in_cached_static: bool,
     /// Template-wide counter for v-if branch keys. Each branch in any
     /// conditional chain in the template consumes one value, so sibling
     /// `v-if`/`v-else` blocks do not reuse the same `{ key: n }` and a
@@ -141,6 +147,7 @@ impl CodegenContext {
             props_is_plain_element: false,
             parent_ns: Namespace::Html,
             static_cache: false,
+            in_cached_static: false,
             v_if_branch_counter: 0,
         }
     }

--- a/crates/vize_atelier_core/src/codegen/generate.rs
+++ b/crates/vize_atelier_core/src/codegen/generate.rs
@@ -5,7 +5,7 @@
 
 use crate::ast::{
     DynamicProps, ExpressionNode, JsChildNode, PropsExpression, RootNode, RuntimeHelper,
-    TemplateTextChildNode, VNodeCall, VNodeChildren, VNodeTag,
+    TemplateChildNode, TemplateTextChildNode, VNodeCall, VNodeChildren, VNodeTag,
 };
 
 use super::{context::CodegenContext, helpers::escape_js_string};
@@ -78,6 +78,39 @@ fn collect_helpers_from_vnode_call(vnode: &VNodeCall<'_>, helpers: &mut Vec<Runt
     // Recurse into props (may contain nested VNodeCalls)
     if let Some(props) = &vnode.props {
         collect_helpers_from_props(props, helpers);
+    }
+
+    // Recurse into a hoisted nested-static subtree's children so the helpers
+    // used by descendant `createElementVNode` / `createTextVNode` calls are
+    // declared in the import preamble.
+    if let Some(VNodeChildren::Multiple(children)) = &vnode.children {
+        collect_helpers_from_static_children(children, helpers);
+    }
+}
+
+/// Collect helpers for a hoisted static children list, matching exactly what
+/// [`generate_static_element_to_bytes`] / the `Multiple` codegen branch emit:
+/// element children always need `createElementVNode`; a text child only needs
+/// `createTextVNode` when it is emitted in array form (i.e. siblings include an
+/// element), since a single/all-text run collapses to a string literal.
+fn collect_helpers_from_static_children(
+    children: &[TemplateChildNode<'_>],
+    helpers: &mut Vec<RuntimeHelper>,
+) {
+    let has_element = children
+        .iter()
+        .any(|c| matches!(c, TemplateChildNode::Element(_)));
+    for child in children.iter() {
+        match child {
+            TemplateChildNode::Element(el) => {
+                helpers.push(RuntimeHelper::CreateElementVNode);
+                collect_helpers_from_static_children(&el.children, helpers);
+            }
+            TemplateChildNode::Text(_) if has_element => {
+                helpers.push(RuntimeHelper::CreateText);
+            }
+            _ => {}
+        }
     }
 }
 
@@ -283,7 +316,7 @@ fn generate_props_expression_to_bytes(
 
 /// Generate `VNodeChildren` to bytes.
 fn generate_vnode_children_to_bytes(
-    _ctx: &CodegenContext,
+    ctx: &CodegenContext,
     children: &VNodeChildren<'_>,
     out: &mut String,
 ) {
@@ -307,6 +340,157 @@ fn generate_vnode_children_to_bytes(
                 out.push_str(exp.content.as_str());
             }
         }
+        // A fully-static nested subtree hoisted as one recursive VNodeCall:
+        // render the moved children as `[createElementVNode(...), "text", ...]`.
+        VNodeChildren::Multiple(children) => {
+            out.push('[');
+            let mut emitted = 0usize;
+            for child in children.iter() {
+                match child {
+                    TemplateChildNode::Element(el) => {
+                        if emitted > 0 {
+                            out.push_str(", ");
+                        }
+                        emitted += 1;
+                        generate_static_element_to_bytes(ctx, el, out);
+                    }
+                    TemplateChildNode::Text(text) => {
+                        if emitted > 0 {
+                            out.push_str(", ");
+                        }
+                        emitted += 1;
+                        let helper = ctx.helper(RuntimeHelper::CreateText);
+                        out.push_str(helper);
+                        out.push_str("(\"");
+                        out.push_str(escape_js_string(&text.content).as_str());
+                        out.push_str("\")");
+                    }
+                    _ => {}
+                }
+            }
+            out.push(']');
+        }
         _ => out.push_str("null"),
     }
+}
+
+/// Serialize a fully-static element as a nested `createElementVNode(...)` for a
+/// hoisted subtree. Children recurse the same way; text children collapse to a
+/// string literal, matching @vue/compiler-core's hoisted static output.
+fn generate_static_element_to_bytes(
+    ctx: &CodegenContext,
+    el: &crate::ast::ElementNode<'_>,
+    out: &mut String,
+) {
+    out.push_str(ctx.helper(RuntimeHelper::CreateElementVNode));
+    out.push_str("(\"");
+    out.push_str(el.tag.as_str());
+    out.push('"');
+
+    // Props: static attributes and constant v-bind only (the subtree is static).
+    let props = build_static_props(el);
+    if let Some(props) = &props {
+        out.push_str(", ");
+        out.push_str(props.as_str());
+    } else if !el.children.is_empty() {
+        out.push_str(", null");
+    }
+
+    if !el.children.is_empty() {
+        out.push_str(", ");
+        // Single text child collapses to a string literal.
+        if el.children.len() == 1
+            && let TemplateChildNode::Text(text) = &el.children[0]
+        {
+            out.push('"');
+            out.push_str(escape_js_string(&text.content).as_str());
+            out.push('"');
+        } else if el
+            .children
+            .iter()
+            .all(|c| matches!(c, TemplateChildNode::Text(_)))
+        {
+            let mut combined = String::default();
+            for c in el.children.iter() {
+                if let TemplateChildNode::Text(t) = c {
+                    combined.push_str(t.content.as_str());
+                }
+            }
+            out.push('"');
+            out.push_str(escape_js_string(&combined).as_str());
+            out.push('"');
+        } else {
+            out.push('[');
+            let mut emitted = 0usize;
+            for c in el.children.iter() {
+                match c {
+                    TemplateChildNode::Element(child_el) => {
+                        if emitted > 0 {
+                            out.push_str(", ");
+                        }
+                        emitted += 1;
+                        generate_static_element_to_bytes(ctx, child_el, out);
+                    }
+                    TemplateChildNode::Text(text) => {
+                        if emitted > 0 {
+                            out.push_str(", ");
+                        }
+                        emitted += 1;
+                        out.push_str(ctx.helper(RuntimeHelper::CreateText));
+                        out.push_str("(\"");
+                        out.push_str(escape_js_string(&text.content).as_str());
+                        out.push_str("\")");
+                    }
+                    _ => {}
+                }
+            }
+            out.push(']');
+        }
+    }
+
+    out.push(')');
+}
+
+/// Build the props-object literal for a static element, or `None` when it has
+/// no renderable static props. Mirrors the dedupe and quoting rules used by the
+/// main props codegen.
+fn build_static_props(el: &crate::ast::ElementNode<'_>) -> Option<String> {
+    use crate::ast::PropNode;
+
+    let mut buf = String::default();
+    buf.push_str("{ ");
+    let mut seen: vize_carton::FxHashSet<vize_carton::String> = vize_carton::FxHashSet::default();
+    let mut emitted = 0usize;
+
+    for prop in el.props.iter() {
+        if let PropNode::Attribute(attr) = prop {
+            if attr.name == "ref" || seen.contains(attr.name.as_str()) {
+                continue;
+            }
+            seen.insert(attr.name.clone());
+            if emitted > 0 {
+                buf.push_str(", ");
+            }
+            emitted += 1;
+            let needs_quote = !crate::codegen::helpers::is_valid_js_identifier(&attr.name);
+            if needs_quote {
+                buf.push('"');
+                buf.push_str(attr.name.as_str());
+                buf.push('"');
+            } else {
+                buf.push_str(attr.name.as_str());
+            }
+            buf.push_str(": \"");
+            if let Some(v) = &attr.value {
+                buf.push_str(escape_js_string(&v.content).as_str());
+            }
+            buf.push('"');
+        }
+    }
+
+    if emitted == 0 {
+        return None;
+    }
+    buf.push_str(" }");
+    Some(buf)
 }

--- a/crates/vize_atelier_core/src/transforms/hoist_static.rs
+++ b/crates/vize_atelier_core/src/transforms/hoist_static.rs
@@ -43,16 +43,13 @@ fn is_static_element(el: &ElementNode<'_>) -> bool {
         }
     }
 
-    // Check children recursively
-    // Comments are not hoisted because create_children_expression doesn't handle them
+    // Check children recursively. Nested fully-static element subtrees are
+    // hoistable: `create_children_expression` builds them into a single
+    // recursive VNodeCall, matching @vue/compiler-core's static caching of a
+    // top-most static element with its whole subtree as one cached vnode.
     for child in el.children.iter() {
         // Comments prevent hoisting since they can't be serialized to VNodeCall children
         if matches!(child, TemplateChildNode::Comment(_)) {
-            return false;
-        }
-        // Nested elements cannot be fully hoisted yet because create_children_expression
-        // doesn't recursively create VNodeCalls for them - this would cause children to be omitted
-        if matches!(child, TemplateChildNode::Element(_)) {
             return false;
         }
         if !is_static_node(child) {
@@ -107,11 +104,14 @@ fn get_element_static_type(el: &ElementNode<'_>) -> StaticType {
             TemplateChildNode::Interpolation(_) => {
                 has_dynamic_text = true;
             }
-            // Nested elements cannot be fully hoisted yet because create_children_expression
-            // doesn't recursively create VNodeCalls for them - this would cause children to be omitted
-            TemplateChildNode::Element(_) => {
-                return StaticType::NotStatic;
-            }
+            // A nested element keeps the parent fully static only when the
+            // child subtree is itself fully static (no dynamic text either):
+            // such a subtree is serialized into one recursive VNodeCall by
+            // `create_children_expression`. Any dynamic content disqualifies it.
+            TemplateChildNode::Element(child_el) => match get_element_static_type(child_el) {
+                StaticType::FullyStatic => {}
+                _ => return StaticType::NotStatic,
+            },
             TemplateChildNode::If(_) | TemplateChildNode::For(_) => {
                 return StaticType::NotStatic;
             }
@@ -173,12 +173,15 @@ fn hoist_static_inner<'a>(
                     && has_static_props(el)
                 {
                     hoist_element_props(ctx, el, allocator);
-                } else if hoist_static_vnodes && let TemplateChildNode::Element(el) = &children[i] {
+                } else if hoist_static_vnodes
+                    && let TemplateChildNode::Element(el) = &mut children[i]
+                {
                     let scope_id = ctx
                         .hoisted_scope_id
-                        .as_ref()
-                        .or(ctx.options.scope_id.as_ref());
-                    let vnode_call = create_vnode_call_from_element(allocator, el, scope_id);
+                        .clone()
+                        .or_else(|| ctx.options.scope_id.clone());
+                    let vnode_call =
+                        create_vnode_call_from_element(allocator, el, scope_id.as_ref());
                     let hoist_index = ctx.hoist(vnode_call);
                     children[i] = TemplateChildNode::Hoisted(hoist_index);
                     ctx.helper(RuntimeHelper::CreateElementVNode);
@@ -235,15 +238,20 @@ fn hoist_static_inner<'a>(
     }
 }
 
-/// Create a VNodeCall from an ElementNode for hoisting
+/// Create a VNodeCall from an ElementNode for hoisting.
+///
+/// Takes the element by `&mut` because the caller replaces it with a
+/// `Hoisted` reference immediately afterwards; this lets the nested-children
+/// case move the (already fully-static) child subtree into the VNodeCall
+/// instead of deep-cloning it.
 fn create_vnode_call_from_element<'a>(
     allocator: &'a Bump,
-    el: &ElementNode<'a>,
+    el: &mut ElementNode<'a>,
     scope_id: Option<&vize_carton::String>,
 ) -> JsChildNode<'a> {
     let tag = VNodeTag::String(el.tag.clone());
     let props = create_props_expression(allocator, &el.props, scope_id);
-    let children = create_children_expression(allocator, &el.children);
+    let children = create_children_expression(allocator, &mut el.children, scope_id);
 
     let vnode_call = VNodeCall {
         tag,
@@ -363,10 +371,14 @@ fn create_props_expression<'a>(
     )))
 }
 
-/// Create children expression from template children
+/// Create children expression from template children.
+///
+/// `scope_id` is threaded so nested hoisted elements carry the same scoped-CSS
+/// attribute their parent does.
 fn create_children_expression<'a>(
     allocator: &'a Bump,
-    children: &Vec<'a, TemplateChildNode<'a>>,
+    children: &mut Vec<'a, TemplateChildNode<'a>>,
+    scope_id: Option<&vize_carton::String>,
 ) -> Option<VNodeChildren<'a>> {
     if children.is_empty() {
         return None;
@@ -382,32 +394,73 @@ fn create_children_expression<'a>(
         )));
     }
 
-    // For multiple text children, combine them
-    let mut all_text = true;
-    let mut text_content = String::default();
-
-    for child in children.iter() {
-        match child {
-            TemplateChildNode::Text(text) => {
+    // For all-text children, combine them into one text node.
+    if children
+        .iter()
+        .all(|c| matches!(c, TemplateChildNode::Text(_)))
+    {
+        let mut text_content = String::default();
+        for child in children.iter() {
+            if let TemplateChildNode::Text(text) = child {
                 text_content.push_str(&text.content);
             }
-            _ => {
-                all_text = false;
-                break;
-            }
+        }
+        if !text_content.is_empty() {
+            let text_node = TextNode::new(text_content, SourceLocation::STUB);
+            return Some(VNodeChildren::Single(TemplateTextChildNode::Text(
+                Box::new_in(text_node, allocator),
+            )));
         }
     }
 
-    if all_text && !text_content.is_empty() {
-        let text_node = TextNode::new(text_content, SourceLocation::STUB);
-        return Some(VNodeChildren::Single(TemplateTextChildNode::Text(
-            Box::new_in(text_node, allocator),
-        )));
+    // Nested elements (and mixed element/text) children. Move the child nodes
+    // into a `Multiple` so a fully-static subtree hoists into a single
+    // recursive `createElementVNode(...)`, matching @vue/compiler-core. The
+    // subtree is already known to be fully static (the caller only reaches this
+    // path for `StaticType::FullyStatic` elements), so codegen serializes each
+    // element child recursively as a nested `createElementVNode`. Moving rather
+    // than cloning is sound because the caller replaces this element with a
+    // `Hoisted` reference right after, so the original children are unreachable.
+    let mut moved = std::mem::replace(children, Vec::new_in(allocator));
+
+    // Scoped CSS: every native element in the hoisted subtree needs the
+    // `data-v-xxxxxxxx` attribute, so inject it into each nested element.
+    if let Some(scope_id) = scope_id {
+        for child in moved.iter_mut() {
+            inject_scope_id(allocator, child, scope_id);
+        }
     }
 
-    // For complex children with nested elements, return as Simple expression for now
-    // A full implementation would recursively create VNodeCalls
-    None
+    Some(VNodeChildren::Multiple(moved))
+}
+
+/// Recursively add the scoped-CSS attribute to a static element subtree so
+/// hoisted nested vnodes carry `data-v-xxxxxxxx` like their parent.
+fn inject_scope_id<'a>(
+    allocator: &'a Bump,
+    node: &mut TemplateChildNode<'a>,
+    scope_id: &vize_carton::String,
+) {
+    if let TemplateChildNode::Element(el) = node {
+        let already = el.props.iter().any(|p| match p {
+            PropNode::Attribute(a) => a.name == *scope_id,
+            PropNode::Directive(_) => false,
+        });
+        if !already {
+            el.props.push(PropNode::Attribute(Box::new_in(
+                AttributeNode {
+                    name: scope_id.clone(),
+                    name_loc: SourceLocation::STUB,
+                    value: None,
+                    loc: SourceLocation::STUB,
+                },
+                allocator,
+            )));
+        }
+        for child in el.children.iter_mut() {
+            inject_scope_id(allocator, child, scope_id);
+        }
+    }
 }
 
 /// Check if an element has static props that can be hoisted as an object.
@@ -763,5 +816,87 @@ mod tests {
         }
 
         assert!(!is_static_node(&root.children[0]));
+    }
+
+    #[test]
+    fn test_nested_static_element_is_static() {
+        // A fully-static nested element subtree is hoistable as one recursive
+        // VNodeCall, matching @vue/compiler-core.
+        let allocator = Bump::new();
+        let (root, _) = parse(
+            &allocator,
+            r#"<div class="outer"><span class="a">x</span></div>"#,
+        );
+        assert!(is_static_node(&root.children[0]));
+        assert_eq!(
+            get_static_type(&root.children[0]),
+            super::StaticType::FullyStatic
+        );
+    }
+
+    #[test]
+    fn test_deeply_nested_static_element_is_static() {
+        let allocator = Bump::new();
+        let (root, _) = parse(
+            &allocator,
+            r#"<div class="outer"><div class="inner"><span>deep</span></div></div>"#,
+        );
+        assert!(is_static_node(&root.children[0]));
+    }
+
+    #[test]
+    fn test_nested_with_dynamic_text_not_fully_static() {
+        // Interpolation in a nested child means the subtree is not fully static
+        // (has dynamic text), so it must not be hoisted as a static vnode.
+        let allocator = Bump::new();
+        let (root, _) = parse(
+            &allocator,
+            r#"<div class="outer"><span>{{ msg }}</span></div>"#,
+        );
+        assert_eq!(
+            get_static_type(&root.children[0]),
+            super::StaticType::NotStatic
+        );
+    }
+
+    fn compile_hoisted(src: &str) -> (String, String) {
+        let allocator = Bump::new();
+        let (mut root, _errors) = parse(&allocator, src);
+        let mut opts = crate::options::TransformOptions::default();
+        opts.hoist_static = true;
+        crate::transform::transform(&allocator, &mut root, opts, None);
+        let r = crate::codegen::generate(&root, crate::options::CodegenOptions::default());
+        (r.preamble.to_string(), r.code.to_string())
+    }
+
+    #[test]
+    fn test_codegen_nested_static_subtree_caches_recursively() {
+        // Matches @vue/compiler-core: the inner subtree is cached as ONE vnode
+        // with its descendant rendered as a plain recursive createElementVNode
+        // (no nested _cache, no per-descendant CACHED flag).
+        let (_pre, code) = compile_hoisted(
+            r#"<div class="outer"><div class="inner"><span>deep</span></div></div>"#,
+        );
+        assert!(
+            code.contains(
+                "_createElementVNode(\"div\", { class: \"inner\" }, [\n      _createElementVNode(\"span\", null, \"deep\")\n    ], -1 /* CACHED */)"
+            ),
+            "unexpected codegen:\n{code}"
+        );
+    }
+
+    #[test]
+    fn test_codegen_hoisted_nested_vnode_keeps_descendant() {
+        // Inside a v-if branch the subtree hoists to a `_hoisted_N` const built
+        // as a recursive createElementVNode; the nested <b> must be preserved
+        // (previously dropped by the unimplemented create_children_expression).
+        let (preamble, _code) =
+            compile_hoisted(r#"<div><p v-if="ok"><span class="a"><b>x</b></span></p></div>"#);
+        assert!(
+            preamble.contains(
+                "_createElementVNode(\"span\", { class: \"a\" }, [_createElementVNode(\"b\", null, \"x\")])"
+            ),
+            "nested <b> was dropped from hoisted subtree:\n{preamble}"
+        );
     }
 }


### PR DESCRIPTION
## Problem

A fully-static *nested* element subtree was not hoisted/cached as a single recursive vnode the way `@vue/compiler-core` does (#1394, PR12).

Two coupled gaps:
- `is_static_element` / `get_element_static_type` (`hoist_static.rs`) returned `NotStatic` for **any** element that had an element child, so the static-cache codegen path never captured a whole subtree.
- The legacy `_hoisted_N` path's `create_children_expression` carried a `// A full implementation would recursively create VNodeCalls` TODO and returned `None` for nested-element children — so a hoisted `<span><b>x</b></span>` dropped the `<b>` entirely (e.g. inside a `v-if`/`v-for` branch), emitting wrong output.

## Fix

- Staticness now recurses into element children, but still requires the *whole* subtree to be fully static (a dynamic descendant, interpolation, comment, or control-flow node disqualifies it).
- The static-cache codegen path caches the top-most static element as one `_cache` entry and renders descendants as plain recursive `createElementVNode(...)` — no nested `_cache` wrapper and no per-descendant `CACHED` flag — via a new `in_cached_static` context flag.
- The legacy `_hoisted_N` path moves the (already-static) children into a `VNodeChildren::Multiple` and serializes them recursively, preserving nested elements and threading `scope_id` into the subtree. Hoist-helper collection mirrors the emitted output exactly (no spurious `createTextVNode` import).

No VNode-IR changes; self-contained to `vize_atelier_core`. Moving (not cloning) the children is sound because the caller replaces the element with a `Hoisted` reference immediately after.

## Vue parity

Verified byte-for-byte against `@vue/compiler-sfc` (3.5.34, `hoistStatic` + `prefixIdentifiers`, module mode) for representative templates:

| template | result |
| --- | --- |
| `<div class="outer"><div class="inner"><span>deep</span></div></div>` | matches (inner subtree cached as one vnode, `-1 /* CACHED */`) |
| `<div class="o"><div class="m"><span class="i"><b>x</b></span></div></div>` | matches (3-level recursion) |
| `<div class="o"><p>a<b>bold</b>c</p></div>` | matches (mixed `createTextVNode`/`createElementVNode`) |
| `v-if` / `v-for` branch with nested static subtree | nested `<b>` preserved in the recursive `_hoisted_N` const (was dropped before) |

## Verification

- `cargo test -p vize_atelier_core` — 171 + new unit/codegen tests green
- coverage suite — VDOM 457/457, SFC 167/167; the only failing case is the pre-existing known `vapor/parity-core-directives` failure (vapor, unrelated)
- `vize_atelier_sfc` allocation_budget — within budget
- `vize_atelier_sfc` / `vize_atelier_dom` suites green
- `cargo fmt --check` clean, `cargo clippy -p vize_atelier_core --lib` 0 warnings

Refs #1394

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1454"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->