### PR TITLE
fix(atelier): emit diagnostic on defineProps destructure parse failure

### DIFF
--- a/crates/vize_atelier_sfc/src/compile_script/function_mode/compiler.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/function_mode/compiler.rs
@@ -220,7 +220,7 @@ pub fn compile_script_setup(
     let model_binding_names = emit_model_bindings(&mut output, &ctx);
 
     let transformed_setup: String = if let Some(ref destructure) = ctx.macros.props_destructure {
-        transform_destructured_props(&setup_code, destructure)
+        transform_destructured_props(&setup_code, destructure)?
     } else {
         setup_code.into()
     };

--- a/crates/vize_atelier_sfc/src/compile_script/inline/compiler/body.rs
+++ b/crates/vize_atelier_sfc/src/compile_script/inline/compiler/body.rs
@@ -100,7 +100,7 @@ pub(super) fn compile_script_setup_inline_body(
         profile!(
             "atelier.script_inline.transform_props_destructure",
             transform_destructured_props(&setup_code, destructure)
-        )
+        )?
     } else {
         setup_code
     };

--- a/crates/vize_atelier_sfc/src/script/define_props_destructure/helpers.rs
+++ b/crates/vize_atelier_sfc/src/script/define_props_destructure/helpers.rs
@@ -1,9 +1,8 @@
 //! Helper functions for props destructure handling.
 //!
-//! Provides utility functions for generating props access expressions
-//! and text-based identifier replacement.
+//! Provides utility functions for generating props access expressions.
 
-use vize_carton::{FxHashMap, String, ToCompactString};
+use vize_carton::{String, ToCompactString};
 
 /// Sentinel value for rest spread identifiers in local_to_key map.
 /// When `gen_props_access_exp` receives this, it returns just `__props`.
@@ -43,61 +42,4 @@ pub(crate) fn is_simple_identifier(s: &str) -> bool {
     }
 
     chars.all(|c| c.is_alphanumeric() || c == '_' || c == '$')
-}
-
-/// Check if character can be part of an identifier
-pub(crate) fn is_identifier_char(c: char) -> bool {
-    c.is_alphanumeric() || c == '_' || c == '$'
-}
-
-/// Replace identifier occurrences with proper word boundary checking
-pub(crate) fn replace_identifier(source: &str, name: &str, replacement: &str) -> String {
-    let mut result = String::default();
-    let chars: Vec<char> = source.chars().collect();
-    let name_chars: Vec<char> = name.chars().collect();
-    let mut i = 0;
-
-    while i < chars.len() {
-        // Check if we're at the start of the identifier
-        if i + name_chars.len() <= chars.len() {
-            let potential_match: String = chars[i..i + name_chars.len()].iter().copied().collect();
-            if potential_match.as_str() == name {
-                // Check word boundaries
-                let before_ok = i == 0 || !is_identifier_char(chars[i - 1]);
-                let after_ok = i + name_chars.len() >= chars.len()
-                    || !is_identifier_char(chars[i + name_chars.len()]);
-
-                // Check not preceded by . (member access) or __props already
-                let not_member = i == 0 || chars[i - 1] != '.';
-
-                if before_ok && after_ok && not_member {
-                    result.push_str(replacement);
-                    i += name_chars.len();
-                    continue;
-                }
-            }
-        }
-        result.push(chars[i]);
-        i += 1;
-    }
-
-    result
-}
-
-/// Text-based transformation fallback
-pub(crate) fn transform_props_text_based(
-    source: &str,
-    local_to_key: &FxHashMap<&str, &str>,
-) -> String {
-    let mut result = source.to_compact_string();
-
-    // Sort by length (longest first) to avoid partial replacements
-    let mut props: Vec<(&str, &str)> = local_to_key.iter().map(|(k, v)| (*k, *v)).collect();
-    props.sort_by_key(|prop| std::cmp::Reverse(prop.0.len()));
-
-    for (local, key) in props {
-        result = replace_identifier(&result, local, &gen_props_access_exp(key));
-    }
-
-    result
 }

--- a/crates/vize_atelier_sfc/src/script/define_props_destructure/tests.rs
+++ b/crates/vize_atelier_sfc/src/script/define_props_destructure/tests.rs
@@ -33,7 +33,7 @@ mod tests {
     fn test_transform_simple() {
         let bindings = make_bindings(&["msg"]);
         let source = "console.log(msg)";
-        let result = transform_destructured_props(source, &bindings);
+        let result = transform_destructured_props(source, &bindings).unwrap();
         insta::assert_snapshot!(result.as_str());
     }
 
@@ -43,7 +43,7 @@ mod tests {
 
         // msg is shadowed by the arrow function parameter
         let source = "const fn = (msg) => console.log(msg)";
-        let result = transform_destructured_props(source, &bindings);
+        let result = transform_destructured_props(source, &bindings).unwrap();
         insta::assert_snapshot!(result.as_str());
     }
 
@@ -53,7 +53,7 @@ mod tests {
 
         // count inside computed arrow function should be rewritten
         let source = "const double = computed(() => count * 2)";
-        let result = transform_destructured_props(source, &bindings);
+        let result = transform_destructured_props(source, &bindings).unwrap();
         assert_eq!(result, "const double = computed(() => __props.count * 2)");
     }
 
@@ -62,7 +62,7 @@ mod tests {
         let bindings = make_bindings(&["foo", "bar"]);
 
         let source = "const result = foo + bar";
-        let result = transform_destructured_props(source, &bindings);
+        let result = transform_destructured_props(source, &bindings).unwrap();
         insta::assert_snapshot!(result.as_str());
     }
 
@@ -76,7 +76,7 @@ mod tests {
         let source = r#"function double() {
     return count * 2
 }"#;
-        let result = transform_destructured_props(source, &bindings);
+        let result = transform_destructured_props(source, &bindings).unwrap();
         insta::assert_snapshot!(result.as_str());
     }
 
@@ -89,7 +89,7 @@ mod tests {
     const inner = () => msg
     return inner()
 }"#;
-        let result = transform_destructured_props(source, &bindings);
+        let result = transform_destructured_props(source, &bindings).unwrap();
         insta::assert_snapshot!(result.as_str());
     }
 
@@ -101,7 +101,7 @@ mod tests {
         let source = r#"const obj = {
     getCount: function() { return count }
 }"#;
-        let result = transform_destructured_props(source, &bindings);
+        let result = transform_destructured_props(source, &bindings).unwrap();
         insta::assert_snapshot!(result.as_str());
     }
 
@@ -112,7 +112,7 @@ mod tests {
         let source = r#"watch(() => count, (newVal) => {
     console.log(newVal)
 })"#;
-        let result = transform_destructured_props(source, &bindings);
+        let result = transform_destructured_props(source, &bindings).unwrap();
         insta::assert_snapshot!(result.as_str());
     }
 
@@ -124,7 +124,7 @@ mod tests {
         let source = r#"for (const item of items) {
     console.log(item)
 }"#;
-        let result = transform_destructured_props(source, &bindings);
+        let result = transform_destructured_props(source, &bindings).unwrap();
         insta::assert_snapshot!(result.as_str());
     }
 
@@ -136,7 +136,7 @@ mod tests {
         let source = r#"for (const key in obj) {
     console.log(key)
 }"#;
-        let result = transform_destructured_props(source, &bindings);
+        let result = transform_destructured_props(source, &bindings).unwrap();
         insta::assert_snapshot!(result.as_str());
     }
 
@@ -150,7 +150,7 @@ mod tests {
 } catch (error) {
     console.log(error)
 }"#;
-        let result = transform_destructured_props(source, &bindings);
+        let result = transform_destructured_props(source, &bindings).unwrap();
         insta::assert_snapshot!(result.as_str());
     }
 
@@ -163,7 +163,7 @@ mod tests {
     const doubled = count * 2
     console.log(doubled)
 }"#;
-        let result = transform_destructured_props(source, &bindings);
+        let result = transform_destructured_props(source, &bindings).unwrap();
         insta::assert_snapshot!(result.as_str());
     }
 
@@ -176,7 +176,7 @@ mod tests {
     const count = 10
     console.log(count)
 }"#;
-        let result = transform_destructured_props(source, &bindings);
+        let result = transform_destructured_props(source, &bindings).unwrap();
         insta::assert_snapshot!(result.as_str());
     }
 
@@ -185,7 +185,7 @@ mod tests {
         let bindings = make_bindings(&["name"]);
 
         let source = "const greeting = `Hello, ${name}!`";
-        let result = transform_destructured_props(source, &bindings);
+        let result = transform_destructured_props(source, &bindings).unwrap();
         insta::assert_snapshot!(result.as_str());
     }
 
@@ -194,7 +194,7 @@ mod tests {
         let bindings = make_bindings(&["show"]);
 
         let source = "const display = show ? 'visible' : 'hidden'";
-        let result = transform_destructured_props(source, &bindings);
+        let result = transform_destructured_props(source, &bindings).unwrap();
         insta::assert_snapshot!(result.as_str());
     }
 
@@ -203,7 +203,7 @@ mod tests {
         let bindings = make_bindings(&["enabled", "active"]);
 
         let source = "const isOn = enabled && active";
-        let result = transform_destructured_props(source, &bindings);
+        let result = transform_destructured_props(source, &bindings).unwrap();
         insta::assert_snapshot!(result.as_str());
     }
 
@@ -212,7 +212,7 @@ mod tests {
         let bindings = make_bindings(&["foo"]);
 
         let source = "const obj = { foo }";
-        let result = transform_destructured_props(source, &bindings);
+        let result = transform_destructured_props(source, &bindings).unwrap();
         insta::assert_snapshot!(result.as_str());
     }
 
@@ -221,7 +221,7 @@ mod tests {
         let bindings = make_bindings(&["items"]);
 
         let source = "const first = items[0]";
-        let result = transform_destructured_props(source, &bindings);
+        let result = transform_destructured_props(source, &bindings).unwrap();
         insta::assert_snapshot!(result.as_str());
     }
 
@@ -230,7 +230,7 @@ mod tests {
         let bindings = make_bindings(&["user"]);
 
         let source = "const name = user.name";
-        let result = transform_destructured_props(source, &bindings);
+        let result = transform_destructured_props(source, &bindings).unwrap();
         insta::assert_snapshot!(result.as_str());
     }
 
@@ -239,7 +239,7 @@ mod tests {
         let bindings = make_bindings(&["data"]);
 
         let source = "const value = data.nested.value";
-        let result = transform_destructured_props(source, &bindings);
+        let result = transform_destructured_props(source, &bindings).unwrap();
         insta::assert_snapshot!(result.as_str());
     }
 
@@ -248,7 +248,7 @@ mod tests {
         let bindings = make_bindings(&["row"]);
 
         let source = "const phaseLabel = computed(() => DAY_PHASE_LABELS[row.phaseSnapshot.phase])";
-        let result = transform_destructured_props(source, &bindings);
+        let result = transform_destructured_props(source, &bindings).unwrap();
         assert_eq!(
             result,
             "const phaseLabel = computed(() => DAY_PHASE_LABELS[__props.row.phaseSnapshot.phase])"
@@ -260,7 +260,7 @@ mod tests {
         let bindings = make_bindings(&["count"]);
 
         let source = "doSomething(count, 'test')";
-        let result = transform_destructured_props(source, &bindings);
+        let result = transform_destructured_props(source, &bindings).unwrap();
         insta::assert_snapshot!(result.as_str());
     }
 
@@ -271,7 +271,7 @@ mod tests {
         let source = r#"console.log(msg)
 const double = count * 2
 return { msg, count }"#;
-        let result = transform_destructured_props(source, &bindings);
+        let result = transform_destructured_props(source, &bindings).unwrap();
         insta::assert_snapshot!(result.as_str());
     }
 
@@ -281,7 +281,7 @@ return { msg, count }"#;
 
         // msg as property key should NOT be rewritten
         let source = "const obj = { msg: 'hello' }";
-        let result = transform_destructured_props(source, &bindings);
+        let result = transform_destructured_props(source, &bindings).unwrap();
         insta::assert_snapshot!(result.as_str());
     }
 
@@ -291,7 +291,7 @@ return { msg, count }"#;
 
         // .name should NOT be rewritten (it's property access, not reference)
         let source = "const userName = user.name";
-        let result = transform_destructured_props(source, &bindings);
+        let result = transform_destructured_props(source, &bindings).unwrap();
         insta::assert_snapshot!(result.as_str());
     }
 
@@ -309,8 +309,27 @@ return { msg, count }"#;
         );
 
         let source = "console.log(msg)";
-        let result = transform_destructured_props(source, &bindings);
+        let result = transform_destructured_props(source, &bindings).unwrap();
         insta::assert_snapshot!(result.as_str());
+    }
+
+    #[test]
+    fn test_transform_unparsable_source_emits_diagnostic() {
+        let bindings = make_bindings(&["foo"]);
+
+        // Setup body that OXC cannot parse. Previously this silently fell back
+        // to a text rewrite (masking the parse error); now it must surface a
+        // structured compile diagnostic instead of best-effort rewriting.
+        let source = "const x = foo +++ ===";
+        let result = transform_destructured_props(source, &bindings);
+
+        let err = result.expect_err("malformed setup body must produce a diagnostic");
+        assert_eq!(err.code.as_deref(), Some("DEFINE_PROPS_DESTRUCTURE_PARSE"));
+        assert!(
+            err.message.contains("defineProps"),
+            "diagnostic should mention defineProps, got: {}",
+            err.message
+        );
     }
 
     // ==================== Snapshot tests ====================
@@ -327,7 +346,7 @@ return { msg, count }"#;
         fn test_basic_usage() {
             let bindings = make_bindings(&["foo"]);
             let source = "console.log(foo)";
-            let result = transform_destructured_props(source, &bindings);
+            let result = transform_destructured_props(source, &bindings).unwrap();
             insta::assert_snapshot!(result);
         }
 
@@ -338,7 +357,7 @@ return { msg, count }"#;
     console.log(foo)
     console.log(bar)
 }"#;
-            let result = transform_destructured_props(source, &bindings);
+            let result = transform_destructured_props(source, &bindings).unwrap();
             insta::assert_snapshot!(result);
         }
 
@@ -347,7 +366,7 @@ return { msg, count }"#;
             let bindings = make_bindings(&["foo"]);
             let source = r#"const bar = 'fish', hello = 'world'
 console.log(foo)"#;
-            let result = transform_destructured_props(source, &bindings);
+            let result = transform_destructured_props(source, &bindings).unwrap();
             insta::assert_snapshot!(result);
         }
 
@@ -360,7 +379,7 @@ console.log(foo)"#;
     }
 }
 console.log(value)"#;
-            let result = transform_destructured_props(source, &bindings);
+            let result = transform_destructured_props(source, &bindings).unwrap();
             insta::assert_snapshot!(result);
         }
 
@@ -385,7 +404,7 @@ console.log(value)"#;
             );
             let source = r#"let a = x
 let b = y"#;
-            let result = transform_destructured_props(source, &bindings);
+            let result = transform_destructured_props(source, &bindings).unwrap();
             insta::assert_snapshot!(result);
         }
 
@@ -394,7 +413,7 @@ let b = y"#;
             let bindings = make_bindings(&["count"]);
             let source = r#"const double = computed(() => count * 2)
 const triple = computed(function() { return count * 3 })"#;
-            let result = transform_destructured_props(source, &bindings);
+            let result = transform_destructured_props(source, &bindings).unwrap();
             insta::assert_snapshot!(result);
         }
 
@@ -404,7 +423,7 @@ const triple = computed(function() { return count * 3 })"#;
             let source = r#"watch(() => count, (newVal, oldVal) => {
     console.log('changed from', oldVal, 'to', newVal)
 })"#;
-            let result = transform_destructured_props(source, &bindings);
+            let result = transform_destructured_props(source, &bindings).unwrap();
             insta::assert_snapshot!(result);
         }
 
@@ -412,7 +431,7 @@ const triple = computed(function() { return count * 3 })"#;
         fn test_template_literal() {
             let bindings = make_bindings(&["name", "age"]);
             let source = r#"const greeting = `Hello ${name}, you are ${age} years old`"#;
-            let result = transform_destructured_props(source, &bindings);
+            let result = transform_destructured_props(source, &bindings).unwrap();
             insta::assert_snapshot!(result);
         }
 
@@ -420,7 +439,7 @@ const triple = computed(function() { return count * 3 })"#;
         fn test_object_shorthand_props() {
             let bindings = make_bindings(&["foo", "bar"]);
             let source = r#"const obj = { foo, bar, baz: 123 }"#;
-            let result = transform_destructured_props(source, &bindings);
+            let result = transform_destructured_props(source, &bindings).unwrap();
             insta::assert_snapshot!(result);
         }
 
@@ -434,7 +453,7 @@ const triple = computed(function() { return count * 3 })"#;
     })
     return result
 }"#;
-            let result = transform_destructured_props(source, &bindings);
+            let result = transform_destructured_props(source, &bindings).unwrap();
             insta::assert_snapshot!(result);
         }
 
@@ -450,7 +469,7 @@ for (const item of items) {
 for (const index in items) {
     console.log(index)
 }"#;
-            let result = transform_destructured_props(source, &bindings);
+            let result = transform_destructured_props(source, &bindings).unwrap();
             insta::assert_snapshot!(result);
         }
 
@@ -464,7 +483,7 @@ for (const index in items) {
 } finally {
     console.log(error)
 }"#;
-            let result = transform_destructured_props(source, &bindings);
+            let result = transform_destructured_props(source, &bindings).unwrap();
             insta::assert_snapshot!(result);
         }
 
@@ -473,7 +492,7 @@ for (const index in items) {
             let bindings = make_bindings(&["show", "msg"]);
             let source = r#"const display = show ? msg : 'hidden'
 const result = show && msg || 'default'"#;
-            let result = transform_destructured_props(source, &bindings);
+            let result = transform_destructured_props(source, &bindings).unwrap();
             insta::assert_snapshot!(result);
         }
 
@@ -483,7 +502,7 @@ const result = show && msg || 'default'"#;
             let source = r#"const name = user.profile.name
 const email = user?.contact?.email
 const id = user['id']"#;
-            let result = transform_destructured_props(source, &bindings);
+            let result = transform_destructured_props(source, &bindings).unwrap();
             insta::assert_snapshot!(result);
         }
 
@@ -493,7 +512,7 @@ const id = user['id']"#;
             let source = r#"const filtered = items.filter(x => x > 0)
 const mapped = items.map(x => x * 2)
 const reduced = items.reduce((acc, x) => acc + x, 0)"#;
-            let result = transform_destructured_props(source, &bindings);
+            let result = transform_destructured_props(source, &bindings).unwrap();
             insta::assert_snapshot!(result);
         }
 
@@ -502,7 +521,7 @@ const reduced = items.reduce((acc, x) => acc + x, 0)"#;
             let bindings = make_bindings(&["data"]);
             let source = r#"const fn = ({ x, y }) => x + y
 console.log(data)"#;
-            let result = transform_destructured_props(source, &bindings);
+            let result = transform_destructured_props(source, &bindings).unwrap();
             insta::assert_snapshot!(result);
         }
 
@@ -519,7 +538,7 @@ console.log(data)"#;
     default:
         console.log(value)
 }"#;
-            let result = transform_destructured_props(source, &bindings);
+            let result = transform_destructured_props(source, &bindings).unwrap();
             insta::assert_snapshot!(result);
         }
 
@@ -532,7 +551,7 @@ console.log(data)"#;
 do {
     console.log(count)
 } while (count > 0)"#;
-            let result = transform_destructured_props(source, &bindings);
+            let result = transform_destructured_props(source, &bindings).unwrap();
             insta::assert_snapshot!(result);
         }
 
@@ -557,7 +576,7 @@ do {
 })
 const rebloggedBy = computed(() => props.status.reblog ? props.status.account : null)
 console.log(actions)"#;
-            let result = transform_destructured_props(source, &bindings);
+            let result = transform_destructured_props(source, &bindings).unwrap();
             insta::assert_snapshot!(result);
         }
 
@@ -578,7 +597,7 @@ console.log(actions)"#;
 
             let source = r#"console.log(rest)
 const b = rest"#;
-            let result = transform_destructured_props(source, &bindings);
+            let result = transform_destructured_props(source, &bindings).unwrap();
             insta::assert_snapshot!(result);
         }
     }

--- a/crates/vize_atelier_sfc/src/script/define_props_destructure/transform.rs
+++ b/crates/vize_atelier_sfc/src/script/define_props_destructure/transform.rs
@@ -1,8 +1,11 @@
 //! Source code transformation for destructured props.
 //!
 //! Rewrites identifier references to destructured props
-//! (e.g., `foo` becomes `__props.foo`) using AST-based analysis
-//! with a text-based fallback.
+//! (e.g., `foo` becomes `__props.foo`) using AST-based analysis.
+//!
+//! When the source cannot be parsed by OXC, the transform does **not** fall
+//! back to a text rewrite (which would silently produce wrong code); instead it
+//! surfaces a structured compile diagnostic so the failure is visible.
 
 use oxc_allocator::Allocator;
 use oxc_parser::Parser;
@@ -11,17 +14,22 @@ use vize_carton::FxHashMap;
 
 use super::PropsDestructuredBindings;
 use super::collector::collect_identifier_rewrites;
-use super::helpers::{PROPS_REST_SENTINEL, transform_props_text_based};
+use super::helpers::PROPS_REST_SENTINEL;
+use crate::types::SfcError;
 use vize_carton::{String, ToCompactString, profile};
 
 /// Transform destructured props references in source code.
-/// Rewrites `foo` to `__props.foo` for destructured props.
+///
+/// Rewrites `foo` to `__props.foo` for destructured props using AST-based
+/// analysis. Returns `Err(SfcError)` (code `DEFINE_PROPS_DESTRUCTURE_PARSE`)
+/// when the setup body cannot be parsed, rather than silently text-rewriting
+/// identifiers and masking the real parse error.
 pub fn transform_destructured_props(
     source: &str,
     destructured: &PropsDestructuredBindings,
-) -> String {
+) -> Result<String, SfcError> {
     if destructured.is_empty() {
-        return source.to_compact_string();
+        return Ok(source.to_compact_string());
     }
 
     // Build map of local name -> prop key
@@ -37,7 +45,7 @@ pub fn transform_destructured_props(
         local_to_key.insert(rest_id.as_str(), PROPS_REST_SENTINEL);
     }
 
-    // Try AST-based transformation first
+    // AST-based transformation.
     let allocator = Allocator::default();
     let source_type = SourceType::from_path("script.ts").unwrap_or_default();
     let ret = profile!(
@@ -45,36 +53,41 @@ pub fn transform_destructured_props(
         Parser::new(&allocator, source, source_type).parse()
     );
 
-    if !ret.panicked {
-        // Collect rewrites: (start, end, replacement)
-        let mut rewrites: Vec<(usize, usize, String)> = Vec::new();
-
-        // Walk the AST to find identifier references
-        profile!(
-            "atelier.props_destructure.collect_rewrites",
-            collect_identifier_rewrites(&ret.program, source, &local_to_key, &mut rewrites)
-        );
-
-        // Apply rewrites if any found (empty rewrites means all props are shadowed or unused)
-        if !rewrites.is_empty() {
-            // Apply rewrites in reverse order to preserve positions
-            rewrites.sort_by_key(|rewrite| std::cmp::Reverse(rewrite.0));
-
-            let mut result = source.to_compact_string();
-            for (start, end, replacement) in rewrites {
-                result.replace_range(start..end, &replacement);
-            }
-            return result;
-        }
-
-        // AST parsing succeeded but no rewrites needed (props are shadowed or unused)
-        return source.to_compact_string();
+    if ret.panicked {
+        // Parsing failed: emit a structured diagnostic and skip the transform
+        // instead of falling back to a text rewrite that would silently emit
+        // wrong code (referencing un-prefixed destructured props at runtime).
+        return Err(SfcError {
+            message: String::from(
+                "Failed to parse <script setup> while rewriting destructured props from \
+                 defineProps(). The destructured prop references could not be transformed.",
+            ),
+            code: Some("DEFINE_PROPS_DESTRUCTURE_PARSE".to_compact_string()),
+            loc: None,
+        });
     }
 
-    // Fallback: Simple text-based transformation
-    // This handles cases where AST parsing failed
+    // Collect rewrites: (start, end, replacement)
+    let mut rewrites: Vec<(usize, usize, String)> = Vec::new();
+
+    // Walk the AST to find identifier references
     profile!(
-        "atelier.props_destructure.text_fallback",
-        transform_props_text_based(source, &local_to_key)
-    )
+        "atelier.props_destructure.collect_rewrites",
+        collect_identifier_rewrites(&ret.program, source, &local_to_key, &mut rewrites)
+    );
+
+    // Apply rewrites if any found (empty rewrites means all props are shadowed
+    // or unused).
+    if rewrites.is_empty() {
+        return Ok(source.to_compact_string());
+    }
+
+    // Apply rewrites in reverse order to preserve positions
+    rewrites.sort_by_key(|rewrite| std::cmp::Reverse(rewrite.0));
+
+    let mut result = source.to_compact_string();
+    for (start, end, replacement) in rewrites {
+        result.replace_range(start..end, &replacement);
+    }
+    Ok(result)
 }


### PR DESCRIPTION
## Problem
`transform_destructured_props` (the rewriter that turns destructured `defineProps()` references like `foo` into `__props.foo`) silently fell back to a word-boundary **text rewrite** when OXC failed to parse the `<script setup>` body (`transform.rs:74-79`, helpers `transform_props_text_based` / `replace_identifier`). This masked the real parse error and could emit wrong code (un-prefixed prop references that are `undefined` at runtime) with no compile-time signal. This is PR5 of #1394.

## Fix
- `transform_destructured_props` now returns `Result<String, SfcError>`. On `ret.panicked`, it emits a structured diagnostic (`code = DEFINE_PROPS_DESTRUCTURE_PARSE`) and skips the transform instead of text-rewriting — mirroring the existing `DEFINE_PROPS_DESTRUCTURE_DEFAULT_TYPE` validator, which already flows `SfcError` up via `?`.
- Both callers (inline `compiler/body.rs`, function-mode `compiler.rs`) propagate the error with `?`; both already return `Result<_, SfcError>`.
- Deleted the now-dead text-rewrite helpers (`transform_props_text_based`, `replace_identifier`, `is_identifier_char`) and their `FxHashMap`/`ToCompactString` imports.

## Verification
- `cargo test -p vize_atelier_sfc` — 521 passed, 0 failed; allocation_budget passes (no regression).
- New unit test in the module's own `#[cfg(test)]`: `test_transform_unparsable_source_emits_diagnostic` asserts an unparsable setup body yields `Err` with code `DEFINE_PROPS_DESTRUCTURE_PARSE`.
- `cargo run -p vize_test_runner --bin coverage` — SFC 167/167, props-destructure 4/4; exits 0 (only the pre-existing tracked `vapor/parity-core-directives` known failure).
- `cargo clippy -p vize_atelier_sfc --lib` — 0 warnings; `cargo fmt --check` clean.

Refs #1394