### PR TITLE
feat(glyph): degrade gracefully on script parse error for class components

### DIFF
--- a/crates/vize_glyph/src/formatter.rs
+++ b/crates/vize_glyph/src/formatter.rs
@@ -176,8 +176,17 @@ impl<'a> GlyphFormatter<'a> {
         output: &mut Vec<u8>,
         block: &vize_atelier_sfc::SfcScriptBlock<'_>,
     ) -> Result<(), FormatError> {
+        // Degrade gracefully on a script parse error: emit the original script
+        // body trimmed but otherwise unchanged, rather than failing the whole
+        // SFC format and dropping the template/style work. The script formatter
+        // delegates to oxc, which round-trips decorated class components
+        // (`@Component`/`@Prop()`/`@Emit()`) fine; this fallback only triggers
+        // on genuinely unparseable TS, mirroring the style block's fallback to
+        // trimmed content. (#1391)
+        let trimmed = block.content.trim();
         let formatted_content =
-            script::format_script_content(block.content.trim(), self.options, self.allocator)?;
+            script::format_script_content(trimmed, self.options, self.allocator)
+                .unwrap_or_else(|_| trimmed.to_compact_string());
 
         // Build the opening tag using byte operations
         output.extend_from_slice(b"<script");

--- a/crates/vize_glyph/src/lib.rs
+++ b/crates/vize_glyph/src/lib.rs
@@ -270,6 +270,127 @@ const message = 'hello';
     }
 
     #[test]
+    fn test_format_sfc_class_component_preserves_decorators() {
+        // #1391 PR8: a decorated class-component SFC (vue-property-decorator
+        // style) must round-trip through the script formatter without losing
+        // or mangling decorators, the class body, or member decorators. oxc
+        // formats the class verbatim apart from quote/semicolon normalization.
+        let source = r#"<script lang="ts">
+import { Vue, Component, Prop, Emit } from 'vue-property-decorator'
+
+@Component
+export default class MyComponent extends Vue {
+  @Prop({ default: 0 }) readonly value!: number
+  count = 0
+  get doubled(): number {
+    return this.count * 2
+  }
+  increment(): void {
+    this.count++
+  }
+  @Emit('change')
+  onChange(): number {
+    return this.count
+  }
+}
+</script>
+
+<template>
+  <div>{{ doubled }}</div>
+</template>
+"#;
+        let options = FormatOptions::default();
+        let first = format_sfc(source, &options).unwrap();
+        let code = first.code.as_str();
+
+        // Decorators and class structure preserved.
+        assert!(code.contains("@Component"), "@Component decorator dropped");
+        assert!(
+            code.contains("export default class MyComponent extends Vue"),
+            "class declaration mangled"
+        );
+        assert!(
+            code.contains("@Prop({ default: 0 }) readonly value!: number;"),
+            "@Prop member decorator dropped or mangled"
+        );
+        assert!(
+            code.contains("@Emit(\"change\")"),
+            "@Emit member decorator dropped or mangled"
+        );
+        assert!(code.contains("get doubled(): number"), "getter dropped");
+        assert!(code.contains("increment(): void"), "method dropped");
+
+        // Idempotent: a second pass is a no-op.
+        let second = format_sfc(code, &options).unwrap();
+        assert_eq!(
+            first.code, second.code,
+            "fmt; fmt must be a no-op for class components"
+        );
+    }
+
+    #[test]
+    fn test_format_sfc_class_component_options_decorator() {
+        // #1391 PR8: the vue-class-component v8 `@Options({...})` form is also
+        // preserved, including the decorator-argument options object.
+        let source = r#"<script lang="ts">
+import { Vue, Options } from 'vue-class-component'
+
+@Options({
+  components: { Foo },
+})
+export default class MyComponent extends Vue {
+  count = 0
+}
+</script>
+"#;
+        let options = FormatOptions::default();
+        let first = format_sfc(source, &options).unwrap();
+        let code = first.code.as_str();
+        assert!(code.contains("@Options({"), "@Options decorator dropped");
+        assert!(
+            code.contains("components: { Foo },"),
+            "decorator-argument options object mangled"
+        );
+        let second = format_sfc(code, &options).unwrap();
+        assert_eq!(first.code, second.code, "fmt; fmt must be a no-op");
+    }
+
+    #[test]
+    fn test_format_sfc_script_parse_error_degrades_to_unchanged_script() {
+        // #1391 PR8: an unparseable script body must NOT fail the whole-SFC
+        // format. The script is left unchanged (trimmed) and the template is
+        // still formatted, mirroring the style block's fallback behaviour.
+        let source = r#"<script lang="ts">
+const x = ;
+@@@ not valid typescript
+</script>
+
+<template>
+<div>{{ x }}</div>
+</template>
+"#;
+        let options = FormatOptions::default();
+        let result =
+            format_sfc(source, &options).expect("parse error must not abort the SFC format");
+        let code = result.code.as_str();
+        // Unparseable script preserved verbatim (trimmed).
+        assert!(
+            code.contains("const x = ;"),
+            "unparseable script body should be left unchanged"
+        );
+        assert!(
+            code.contains("@@@ not valid typescript"),
+            "unparseable script body should be left unchanged"
+        );
+        // Template still got formatted/indented (the interpolation expands
+        // onto its own indented line instead of being left untouched).
+        assert!(
+            code.contains("  <div>\n    {{ x }}\n  </div>"),
+            "template should still be formatted when script fails to parse, got:\n{code}"
+        );
+    }
+
+    #[test]
     fn test_allocator_reuse() {
         let allocator = Allocator::with_capacity(4096);
         let options = FormatOptions::default();


### PR DESCRIPTION
## Finding

`vize_glyph` formats the `<script>` block by delegating to oxc's formatter (`crates/vize_glyph/src/script.rs:18`). Verified against a class-component SFC (`@Component` / `@Prop({...})` / getter / method / `@Emit('change')`, plus the vue-class-component v8 `@Options({...})` form): oxc **already round-trips decorated classes correctly** — decorators, the class body, and member decorators are all preserved, and the output is idempotent (only quote/semicolon normalization, as expected).

The one real gap PR8 calls out: an unparseable script body produced a `ScriptParseError` that propagated via `?` through `format_script_block_fast` (`formatter.rs:180`) and **aborted the entire SFC format**, throwing away the template/style work too.

## Change

- `format_script_block_fast`: fall back to the trimmed-but-unchanged script body on a parse error instead of failing the whole SFC, mirroring the style block's existing `.unwrap_or_else(...)` fallback to trimmed content. Self-contained to `vize_glyph`.
- Added 3 regression tests in `lib.rs`:
  - `test_format_sfc_class_component_preserves_decorators` — `@Component`/`@Prop()`/`@Emit()`/getter/method preserved + idempotent.
  - `test_format_sfc_class_component_options_decorator` — `@Options({...})` form preserved + idempotent.
  - `test_format_sfc_script_parse_error_degrades_to_unchanged_script` — unparseable script left verbatim while the template still formats.

## Verification

- `cargo test -p vize_glyph` — all pass (68 tests).
- `cargo fmt -p vize_glyph --check` — clean.
- `cargo clippy -p vize_glyph --lib` — 0 warnings.

Refs #1391

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1459"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->