### PR TITLE
feat(croquis): interpret class-component @Emit and @Inject decorators

### DIFF
--- a/crates/vize_croquis/src/script_parser/process/class_component.rs
+++ b/crates/vize_croquis/src/script_parser/process/class_component.rs
@@ -26,21 +26,33 @@
 //! the class body and are skipped, along with `static` members (not on the
 //! instance), `declare` fields, computed keys, and the constructor.
 //!
-//! Member-level `@Prop`-style decorators map fields/accessors to prop bindings.
-//! Other member decorators (`@Emit`, `@Watch`, ...) are not interpreted yet;
-//! the members keep the same template binding names either way. The
-//! `@Component({ ... })` / `@Options({ ... })` decorator argument is a regular
-//! options object and is fed through the existing Options API collectors (so
-//! `components:` registrations and inline `data`/`computed`/`methods` behave
-//! identically to an options component).
+//! Member-level decorators are interpreted as follows:
+//!
+//! - `@Prop`-style decorators (`@Prop`/`@PropSync`/`@Model`/`@VModel`) map a
+//!   field/accessor to a prop binding (see #1431).
+//! - `@Emit('name')` on a method declares an emitted event, mirroring an
+//!   Options API `emits` entry / a `defineEmits` declaration: the event name
+//!   defaults to the method name kebab-cased when no string argument is given.
+//! - `@Inject`-style decorators (`@Inject`/`@InjectReactive`) mark a field as
+//!   an injected binding, resolved like an Options API `inject` member
+//!   (`BindingType::Options`) rather than reactive `data`.
+//!
+//! `@Watch` (watcher registration) and `@Provide` have no direct template /
+//! type-resolution effect — the watched/provided members keep their ordinary
+//! binding classification — so they are deliberately not interpreted here.
+//!
+//! The `@Component({ ... })` / `@Options({ ... })` decorator argument is a
+//! regular options object and is fed through the existing Options API
+//! collectors (so `components:` registrations and inline
+//! `data`/`computed`/`methods` behave identically to an options component).
 
 use oxc_ast::ast::{
     Argument, Class, ClassElement, Decorator, ExportDefaultDeclarationKind, Expression,
-    MethodDefinitionKind, ObjectExpression, PropertyKey,
+    MethodDefinition, MethodDefinitionKind, ObjectExpression, PropertyKey,
 };
 use oxc_span::GetSpan;
 
-use vize_carton::FxHashMap;
+use vize_carton::{CompactString, FxHashMap, hyphenate};
 use vize_relief::BindingType;
 
 use super::super::ScriptParseResult;
@@ -50,6 +62,7 @@ use super::options_api::{
     property_key_name,
 };
 use crate::croquis::ComponentShape;
+use crate::macros::EmitDefinition;
 
 /// Return the class when the default export is a class declaration or a
 /// (possibly TS-wrapped / parenthesized) class expression.
@@ -120,6 +133,9 @@ pub(super) fn collect_class_component_metadata<'a>(
                 {
                     continue;
                 }
+                // `@Emit` on a method declares an emitted event (the method
+                // body still runs and its return value is the payload).
+                collect_emit_decorator(result, method);
                 // Methods map to `methods`, get/set accessors to `computed`;
                 // both resolve as `Options` bindings.
                 add_class_member_binding(result, &method.key, BindingType::Options);
@@ -150,28 +166,87 @@ pub(super) fn collect_class_component_metadata<'a>(
 }
 
 fn class_field_binding_type(decorators: &[Decorator<'_>]) -> BindingType {
-    if decorators.iter().any(is_prop_like_member_decorator) {
+    // `@Prop`-style decorators win over `@Inject` (a field is never both), and
+    // a plain field falls back to reactive `data`.
+    if decorators
+        .iter()
+        .any(|decorator| member_decorator_name(decorator).is_some_and(is_prop_like_decorator_name))
+    {
         BindingType::Props
+    } else if decorators
+        .iter()
+        .any(|decorator| member_decorator_name(decorator).is_some_and(is_inject_decorator_name))
+    {
+        // `@Inject`/`@InjectReactive` members are injected bindings, resolved
+        // like an Options API `inject` entry (`BindingType::Options`).
+        BindingType::Options
     } else {
         BindingType::Data
     }
 }
 
-fn is_prop_like_member_decorator(decorator: &Decorator<'_>) -> bool {
+/// Identifier name of a member decorator, unwrapping a call form
+/// (`@Emit('x')`) to its callee. Returns `None` for non-identifier callees.
+fn member_decorator_name<'a>(decorator: &'a Decorator<'a>) -> Option<&'a str> {
     match &decorator.expression {
-        Expression::Identifier(identifier) => is_prop_like_decorator_name(identifier.name.as_str()),
-        Expression::CallExpression(call) => {
-            let Expression::Identifier(identifier) = &call.callee else {
-                return false;
-            };
-            is_prop_like_decorator_name(identifier.name.as_str())
-        }
-        _ => false,
+        Expression::Identifier(identifier) => Some(identifier.name.as_str()),
+        Expression::CallExpression(call) => match &call.callee {
+            Expression::Identifier(identifier) => Some(identifier.name.as_str()),
+            _ => None,
+        },
+        _ => None,
     }
 }
 
 fn is_prop_like_decorator_name(name: &str) -> bool {
     matches!(name, "Prop" | "PropSync" | "Model" | "ModelSync" | "VModel")
+}
+
+fn is_inject_decorator_name(name: &str) -> bool {
+    matches!(name, "Inject" | "InjectReactive")
+}
+
+/// Record an `@Emit(...)` decorator on a method as an emitted event.
+///
+/// vue-property-decorator's `@Emit` emits the event named by the decorator's
+/// string argument, defaulting to the method name kebab-cased when omitted
+/// (`@Emit() onReset()` -> `on-reset`). The payload type is left unresolved
+/// here: the method body is a real method whose return value is the payload,
+/// so payload typing is the virtual-TS bridge's job, not the binding pass.
+fn collect_emit_decorator(result: &mut ScriptParseResult, method: &MethodDefinition<'_>) {
+    for decorator in &method.decorators {
+        if member_decorator_name(decorator) != Some("Emit") {
+            continue;
+        }
+
+        let name = match emit_decorator_event_name(&decorator.expression) {
+            Some(name) => name,
+            None => {
+                let Some(method_name) = property_key_name(&method.key) else {
+                    continue;
+                };
+                CompactString::new(hyphenate(method_name))
+            }
+        };
+
+        result.macros.add_emit(EmitDefinition {
+            name,
+            payload_type: None,
+        });
+        // A method carries at most one meaningful `@Emit`; stop after the first.
+        break;
+    }
+}
+
+/// The explicit string-literal event name from `@Emit('name')`, if any.
+fn emit_decorator_event_name(expression: &Expression<'_>) -> Option<CompactString> {
+    let Expression::CallExpression(call) = expression else {
+        return None;
+    };
+    match call.arguments.first()? {
+        Argument::StringLiteral(literal) => Some(CompactString::new(literal.value.as_str())),
+        _ => None,
+    }
 }
 
 /// Options object passed to a `@Component(...)` / `@Options(...)` decorator.

--- a/crates/vize_croquis/src/script_parser/tests.rs
+++ b/crates/vize_croquis/src/script_parser/tests.rs
@@ -883,6 +883,82 @@ export default class App extends Vue {
 }
 
 #[test]
+fn test_parse_class_component_member_decorator_semantics() {
+    // `@Emit` declares emitted events; `@Inject` members resolve like Options
+    // API `inject` (template-referenceable, not reactive data).
+    let source = r#"
+import { Vue, Component, Emit, Inject } from 'vue-property-decorator'
+
+@Component
+export default class Widget extends Vue {
+  @Inject() readonly svc!: Svc
+  @Inject('themeKey') readonly theme!: Theme
+
+  count = 0
+
+  @Emit()
+  onChange() {
+    return this.count
+  }
+
+  @Emit('reset-all')
+  reset() {}
+}
+"#;
+    let result = parse_script(source);
+
+    assert_eq!(result.component_shape, ComponentShape::ClassApi);
+
+    // `@Inject` members are injected bindings, classified like an Options API
+    // `inject` entry (`Options`), and remain template-referenceable.
+    assert_eq!(result.bindings.get("svc"), Some(BindingType::Options));
+    assert_eq!(result.bindings.get("theme"), Some(BindingType::Options));
+
+    // Undecorated field stays reactive data.
+    assert_eq!(result.bindings.get("count"), Some(BindingType::Data));
+
+    // The `@Emit` methods are still ordinary `Options` (methods) bindings.
+    assert_eq!(result.bindings.get("onChange"), Some(BindingType::Options));
+    assert_eq!(result.bindings.get("reset"), Some(BindingType::Options));
+
+    // `@Emit()` without an argument defaults to the method name kebab-cased;
+    // `@Emit('reset-all')` uses the explicit event name.
+    let emits: Vec<&str> = result
+        .macros
+        .emits()
+        .iter()
+        .map(|e| e.name.as_str())
+        .collect();
+    assert!(
+        emits.contains(&"on-change"),
+        "expected `on-change` emit, got {emits:?}"
+    );
+    assert!(
+        emits.contains(&"reset-all"),
+        "expected `reset-all` emit, got {emits:?}"
+    );
+    assert_eq!(result.macros.emits().len(), 2);
+}
+
+#[test]
+fn test_parse_class_component_no_emit_decorator_no_emits() {
+    // Plain methods (no `@Emit`) declare no emitted events.
+    let source = r#"
+import { Vue, Component } from 'vue-property-decorator'
+
+@Component
+export default class Plain extends Vue {
+  save() {}
+}
+"#;
+    let result = parse_script(source);
+
+    assert_eq!(result.component_shape, ComponentShape::ClassApi);
+    assert_eq!(result.bindings.get("save"), Some(BindingType::Options));
+    assert!(result.macros.emits().is_empty());
+}
+
+#[test]
 fn test_parse_non_class_components_keep_unspecified_shape() {
     // Options-object and script-setup analysis are untouched by the class
     // path: shape stays `Unspecified` and no class-style bindings appear.


### PR DESCRIPTION
## Problem

vue-property-decorator member decorators were not interpreted by croquis. `@Emit` produced no emitted-event metadata (so the component's emits omitted decorator-declared events, and template `@event` handler / `defineEmits`-equivalent resolution couldn't see them), and `@Inject` members were classified as reactive `data` rather than injected bindings.

## Scope

Bounded to the croquis binding/emits model (`vize_croquis` only). Implements the two high-value, template/type-affecting decorators:

- `@Emit('name')` on a method -> emitted event. Default name = method name kebab-cased (via `vize_carton::hyphenate`, matching vue-property-decorator).
- `@Inject` / `@InjectReactive` member -> injected binding classified as `BindingType::Options`, mirroring the Options API `inject` path (template-referenceable).

`@Watch` (watcher registration) and `@Provide` have no direct template/type-resolution effect and are deliberately left uninterpreted — noted in the module docs. `@Model`/`@VModel` were already classified as Props (#1431) and are unchanged.

## Fix

`crates/vize_croquis/src/script_parser/process/class_component.rs`:
- `collect_emit_decorator` records an `EmitDefinition` into `result.macros` for each `@Emit`-decorated method (explicit string arg, else kebab-cased method name). Payload type is left `None` — payload typing is the virtual-TS bridge's job.
- `class_field_binding_type` now routes `@Inject`/`@InjectReactive` fields to `BindingType::Options`; `@Prop`-style still wins, plain fields still fall back to `Data`.
- Shared `member_decorator_name` helper unwraps identifier and call-form decorators.

## Verification

- `cargo test -p vize_croquis` — 186 lib tests pass (2 new: `test_parse_class_component_member_decorator_semantics`, `test_parse_class_component_no_emit_decorator_no_emits`).
- `cargo fmt -p vize_croquis --check` — clean.
- `cargo clippy -p vize_croquis --lib` — 0 warnings.

Refs #1391

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1460"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->