### PR TITLE
fix(croquis_cf): attribute fallthrough attrs to the correct child usage

### DIFF
--- a/crates/vize_croquis_cf/src/analyzers/fallthrough.rs
+++ b/crates/vize_croquis_cf/src/analyzers/fallthrough.rs
@@ -116,10 +116,10 @@ pub fn analyze_fallthrough(
 
             // Get the parent's analysis to find what attrs are passed
             if let Some(parent_entry) = registry.get(node.file_id) {
-                // In a real implementation, we'd parse the template to find
-                // exactly which attributes are passed. For now, we'll use
-                // a simplified approach based on used_directives.
-                let attrs = extract_passed_attrs(&parent_entry.analysis, child_id);
+                // Only collect the attributes from the usages that actually
+                // target this specific child component, so two distinct usage
+                // sites of different children are not conflated.
+                let attrs = extract_passed_attrs(&parent_entry.analysis, *child_id, graph);
 
                 passed_attrs_map
                     .entry(*child_id)
@@ -235,17 +235,28 @@ fn check_inherit_attrs_disabled(analysis: &vize_croquis::Croquis) -> bool {
     })
 }
 
-/// Extract attributes passed to a child component.
-/// Uses component_usages for precise static analysis.
+/// Extract attributes passed to a specific child component.
+///
+/// Uses `component_usages` for precise static analysis. Each usage carries the
+/// component name as written in the template; we resolve that name to a
+/// `FileId` through the dependency graph and only keep the props from usages
+/// that target `child_id`. This ensures distinct usage sites of different
+/// children are attributed independently, rather than merging every prop the
+/// parent passes to any child onto a single component.
 fn extract_passed_attrs(
     analysis: &vize_croquis::Croquis,
-    _child_id: &FileId,
+    child_id: FileId,
+    graph: &DependencyGraph,
 ) -> FxHashSet<CompactString> {
     let mut attrs = FxHashSet::default();
 
-    // Get the child component name from registry (if available)
-    // For now, we'll collect all passed props from component usages
     for usage in &analysis.component_usages {
+        // Resolve the usage's component name to the file it refers to and skip
+        // usages that target a different child component.
+        if graph.find_by_component(usage.name.as_str()) != Some(child_id) {
+            continue;
+        }
+
         for prop in &usage.props {
             attrs.insert(prop.name.clone());
         }
@@ -275,9 +286,134 @@ fn is_standard_html_attr(attr: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::FallthroughInfo;
-    use crate::registry::FileId;
-    use vize_carton::FxHashSet;
+    use super::{FallthroughInfo, analyze_fallthrough};
+    use crate::graph::{DependencyEdge, DependencyGraph, ModuleNode};
+    use crate::registry::{FileId, ModuleRegistry};
+    use vize_carton::{CompactString, FxHashSet, smallvec};
+    use vize_croquis::analysis::{ComponentUsage, PassedProp};
+    use vize_croquis::{Croquis, ScopeId};
+
+    fn passed_prop(name: &str) -> PassedProp {
+        PassedProp {
+            name: CompactString::new(name),
+            value: None,
+            start: 0,
+            end: 0,
+            is_dynamic: false,
+        }
+    }
+
+    fn usage_with_prop(name: &str, prop: &str) -> ComponentUsage {
+        ComponentUsage {
+            name: CompactString::new(name),
+            start: 0,
+            end: 0,
+            props: smallvec![passed_prop(prop)],
+            events: smallvec![],
+            slots: smallvec![],
+            has_spread_attrs: false,
+            scope_id: ScopeId::ROOT,
+            vif_guard: None,
+        }
+    }
+
+    fn graph_node(id: FileId, path: &str, component: &str) -> ModuleNode {
+        let mut node = ModuleNode::new(id, path);
+        node.component_name = Some(CompactString::new(component));
+        node
+    }
+
+    /// A parent that uses two distinct child components, each receiving a
+    /// different prop, must attribute each prop only to the child it was passed
+    /// to. Previously `extract_passed_attrs` ignored the child identity and
+    /// merged every passed prop onto every child.
+    #[test]
+    fn passed_attrs_are_attributed_per_child() {
+        let mut registry = ModuleRegistry::new();
+
+        let parent_analysis = {
+            let mut analysis = Croquis::new();
+            analysis
+                .component_usages
+                .push(usage_with_prop("ChildA", "foo"));
+            analysis
+                .component_usages
+                .push(usage_with_prop("ChildB", "bar"));
+            analysis
+        };
+
+        let (parent_id, _) = registry.register("Parent.vue", "", parent_analysis);
+        let (child_a, _) = registry.register("ChildA.vue", "", Croquis::new());
+        let (child_b, _) = registry.register("ChildB.vue", "", Croquis::new());
+
+        let mut graph = DependencyGraph::new();
+        graph.add_node(graph_node(parent_id, "Parent.vue", "Parent"));
+        graph.add_node(graph_node(child_a, "ChildA.vue", "ChildA"));
+        graph.add_node(graph_node(child_b, "ChildB.vue", "ChildB"));
+        graph.add_edge(parent_id, child_a, DependencyEdge::ComponentUsage);
+        graph.add_edge(parent_id, child_b, DependencyEdge::ComponentUsage);
+
+        let (infos, _diags) = analyze_fallthrough(&registry, &graph);
+
+        let attrs_for = |id: FileId| -> Vec<&str> {
+            let info = infos.iter().find(|i| i.file_id == id).unwrap();
+            let mut names: Vec<&str> = info.passed_attrs.iter().map(|s| s.as_str()).collect();
+            names.sort_unstable();
+            names
+        };
+
+        // Each child only sees the prop passed to its own usage site.
+        assert_eq!(attrs_for(child_a), vec!["foo"]);
+        assert_eq!(attrs_for(child_b), vec!["bar"]);
+    }
+
+    /// The same child component used at two sites with different props must not
+    /// have its attributes conflated with a sibling child's attributes.
+    #[test]
+    fn same_child_used_twice_does_not_leak_sibling_attrs() {
+        let mut registry = ModuleRegistry::new();
+
+        let parent_analysis = {
+            let mut analysis = Croquis::new();
+            // Two usages of the same child, each passing its own prop.
+            analysis
+                .component_usages
+                .push(usage_with_prop("Card", "title"));
+            analysis
+                .component_usages
+                .push(usage_with_prop("Card", "subtitle"));
+            // An unrelated sibling child receiving a different prop.
+            analysis
+                .component_usages
+                .push(usage_with_prop("Banner", "color"));
+            analysis
+        };
+
+        let (parent_id, _) = registry.register("Parent.vue", "", parent_analysis);
+        let (card_id, _) = registry.register("Card.vue", "", Croquis::new());
+        let (banner_id, _) = registry.register("Banner.vue", "", Croquis::new());
+
+        let mut graph = DependencyGraph::new();
+        graph.add_node(graph_node(parent_id, "Parent.vue", "Parent"));
+        graph.add_node(graph_node(card_id, "Card.vue", "Card"));
+        graph.add_node(graph_node(banner_id, "Banner.vue", "Banner"));
+        graph.add_edge(parent_id, card_id, DependencyEdge::ComponentUsage);
+        graph.add_edge(parent_id, banner_id, DependencyEdge::ComponentUsage);
+
+        let (infos, _diags) = analyze_fallthrough(&registry, &graph);
+
+        let attrs_for = |id: FileId| -> Vec<&str> {
+            let info = infos.iter().find(|i| i.file_id == id).unwrap();
+            let mut names: Vec<&str> = info.passed_attrs.iter().map(|s| s.as_str()).collect();
+            names.sort_unstable();
+            names
+        };
+
+        // Card aggregates props from both of its usage sites, but never picks
+        // up `color`, which only the Banner sibling received.
+        assert_eq!(attrs_for(card_id), vec!["subtitle", "title"]);
+        assert_eq!(attrs_for(banner_id), vec!["color"]);
+    }
 
     #[test]
     fn test_fallthrough_info_issues() {


### PR DESCRIPTION
## Problem

In `vize_croquis_cf`, cross-file fallthrough analysis attributed prop/event diagnostics to the wrong component usage site. `extract_passed_attrs` in `analyzers/fallthrough.rs` took a `_child_id` parameter but ignored it, then collected props from **every** `ComponentUsage` in the parent. Because `passed_attrs_map` is keyed by child `FileId`, every child of a parent ended up with the union of all props the parent passed to any child. A child used at two sites with different props collapsed, and props meant for a sibling child leaked onto unrelated components, misattributing diagnostics (`UnusedFallthroughAttrs`, `MultiRootMissingAttrs`).

This is the croquis_cf per-usage/identity remnant flagged in #1394 (PR8), after the relative-import (#1443) and Pinia defineStore (#1449) fixes.

## Fix

Thread the child identity through `extract_passed_attrs`: resolve each usage's component name to its `FileId` via the dependency graph's `find_by_component` (which already normalizes PascalCase/kebab-case) and only keep props from usages that target the requested child. The function now takes `child_id: FileId` and `graph: &DependencyGraph` instead of dropping the argument.

Self-contained to `vize_croquis_cf`; no other crates touched.

## Verification

- Added two regression tests in `analyzers/fallthrough.rs`:
  - `passed_attrs_are_attributed_per_child`: parent uses `ChildA` (prop `foo`) and `ChildB` (prop `bar`); each child sees only its own prop.
  - `same_child_used_twice_does_not_leak_sibling_attrs`: same child at two sites aggregates both its props but never picks up a sibling's prop.
  - Both tests fail on the pre-fix code (verified by temporarily reverting the filter) and pass with the fix.
- `cargo test -p vize_croquis_cf`: 134 passed, 0 failed.
- `cargo fmt -p vize_croquis_cf --check`: clean.
- `cargo clippy -p vize_croquis_cf --lib`: 0 warnings.

Refs #1394

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1462"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->