### PR TITLE
feat(armature): add petite-vue HTML document parse mode

### DIFF
--- a/crates/vize_armature/src/parser.rs
+++ b/crates/vize_armature/src/parser.rs
@@ -60,6 +60,11 @@ pub struct Parser<'a> {
     open_a_count: usize,
     open_button_count: usize,
     open_form_count: usize,
+    /// Whether the parser is in full-HTML-document mode (petite-vue / standalone
+    /// HTML). When set, the tokenizer tolerates the leading doctype declaration
+    /// so a real document's `<!DOCTYPE html>` is not reported as a parse error.
+    /// SFC `<template>` parsing leaves this `false` and stays byte-identical.
+    document: bool,
 }
 
 /// Stack entry for tracking parent elements
@@ -178,7 +183,37 @@ impl<'a> Parser<'a> {
             open_a_count: 0,
             open_button_count: 0,
             open_form_count: 0,
+            document: false,
         }
+    }
+
+    /// Create a new parser in full-HTML-document mode.
+    ///
+    /// Document mode is additive: it parses an entire HTML document (doctype +
+    /// `<html>/<head>/<body>`, with `<script>`/`<style>` kept as raw text) into
+    /// the same template AST, so downstream analysis (lint/scope) can run over a
+    /// petite-vue HTML page where directives (`v-scope`, `v-effect`, `@click`)
+    /// live on ordinary elements. The only behavioral difference from
+    /// [`Parser::with_options`] is doctype tolerance; SFC `<template>` parsing is
+    /// unaffected.
+    pub fn new_document(allocator: &'a Bump, source: &'a str) -> Self {
+        Self::document_with_options(allocator, source, ParserOptions::default())
+    }
+
+    /// Create a new document-mode parser with options.
+    pub fn document_with_options(
+        allocator: &'a Bump,
+        source: &'a str,
+        options: ParserOptions,
+    ) -> Self {
+        let mut parser = Self::with_options_and_template_syntax(
+            allocator,
+            source,
+            options,
+            TemplateSyntaxMode::Standard,
+        );
+        parser.document = true;
+        parser
     }
 
     /// Parse the source and return the AST
@@ -195,12 +230,14 @@ impl<'a> Parser<'a> {
 
         // We need to use a struct that implements Callbacks
         // Create a wrapper that can capture the parser
+        let document = self.document;
         let mut tokenizer = Tokenizer::with_delimiters(
             self.source,
             ParserCallbacks { parser: &mut self },
             &delimiter_open,
             &delimiter_close,
         );
+        tokenizer.set_tolerate_declarations(document);
         tokenizer.tokenize();
 
         // Handle any unclosed elements
@@ -348,6 +385,30 @@ impl<'a> Parser<'a> {
 /// Parse a Vue template
 pub fn parse<'a>(allocator: &'a Bump, source: &'a str) -> (RootNode<'a>, Vec<'a, CompilerError>) {
     Parser::new(allocator, source).parse()
+}
+
+/// Parse a full HTML document (petite-vue / standalone HTML) into the template AST.
+///
+/// Unlike [`parse`], which expects an SFC `<template>` block, this entry point
+/// tolerates a leading `<!DOCTYPE html>` declaration and parses the whole
+/// document (`<html>/<head>/<body>`, `<script>`/`<style>` as raw text) so
+/// downstream lint/scope analysis can run on petite-vue pages whose directives
+/// sit on ordinary DOM elements. Additive: existing template parsing is
+/// unchanged.
+pub fn parse_document<'a>(
+    allocator: &'a Bump,
+    source: &'a str,
+) -> (RootNode<'a>, Vec<'a, CompilerError>) {
+    Parser::new_document(allocator, source).parse()
+}
+
+/// Parse a full HTML document with options. See [`parse_document`].
+pub fn parse_document_with_options<'a>(
+    allocator: &'a Bump,
+    source: &'a str,
+    options: ParserOptions,
+) -> (RootNode<'a>, Vec<'a, CompilerError>) {
+    Parser::document_with_options(allocator, source, options).parse()
 }
 
 /// Parse a Vue template with options

--- a/crates/vize_armature/src/parser/tests.rs
+++ b/crates/vize_armature/src/parser/tests.rs
@@ -1,7 +1,10 @@
 //! Tests for the Vue template parser.
 #![allow(clippy::disallowed_macros)]
 
-use super::{parse, parse_with_options, parse_with_options_and_template_syntax};
+use super::{
+    parse, parse_document, parse_document_with_options, parse_with_options,
+    parse_with_options_and_template_syntax,
+};
 use vize_carton::Bump;
 use vize_relief::{
     ast::{ElementType, ExpressionNode, Namespace, PropNode, TemplateChildNode},
@@ -1756,4 +1759,182 @@ fn test_parse_nested_p_without_boundary_still_auto_closes() {
         &root.children[1],
         TemplateChildNode::Element(p) if p.tag.as_str() == "p"
     ));
+}
+
+// --- Document mode (petite-vue / standalone HTML) -------------------------
+
+/// Recursively find the first element with the given tag in a child list.
+fn find_element<'a, 'b>(
+    children: &'b [TemplateChildNode<'a>],
+    tag: &str,
+) -> Option<&'b vize_relief::ast::ElementNode<'a>> {
+    for child in children {
+        if let TemplateChildNode::Element(el) = child {
+            if el.tag.as_str() == tag {
+                return Some(el);
+            }
+            if let Some(found) = find_element(&el.children, tag) {
+                return Some(found);
+            }
+        }
+    }
+    None
+}
+
+/// A full HTML document with a doctype parses without the spurious
+/// `IncorrectlyOpenedComment` error that SFC-template parsing would emit, and
+/// the `<html>/<head>/<body>` tree is available for downstream analysis.
+#[test]
+fn test_document_mode_tolerates_doctype() {
+    let allocator = Bump::new();
+    let src = "<!DOCTYPE html>\n<html><head></head><body><div>hi</div></body></html>";
+    let (root, errors) = parse_document(&allocator, src);
+
+    assert!(
+        !errors
+            .iter()
+            .any(|e| e.code == ErrorCode::IncorrectlyOpenedComment),
+        "doctype should not produce IncorrectlyOpenedComment: {errors:?}"
+    );
+    assert!(find_element(&root.children, "html").is_some());
+    assert!(find_element(&root.children, "head").is_some());
+    assert!(find_element(&root.children, "body").is_some());
+    assert!(find_element(&root.children, "div").is_some());
+}
+
+/// Doctype is case-insensitive and may carry a legacy public identifier; still
+/// tolerated in document mode.
+#[test]
+fn test_document_mode_tolerates_legacy_doctype() {
+    let allocator = Bump::new();
+    let src = r#"<!doctype HTML PUBLIC "-//W3C//DTD HTML 4.01//EN"><html><body></body></html>"#;
+    let (root, errors) = parse_document(&allocator, src);
+
+    assert!(
+        !errors
+            .iter()
+            .any(|e| e.code == ErrorCode::IncorrectlyOpenedComment),
+        "legacy doctype should be tolerated: {errors:?}"
+    );
+    assert!(find_element(&root.children, "body").is_some());
+}
+
+/// petite-vue directives on ordinary DOM elements (`v-scope`, `v-effect`,
+/// `@click`) are parsed as directives, so lint/scope can analyze them.
+#[test]
+fn test_document_mode_parses_petite_directives() {
+    let allocator = Bump::new();
+    let src = concat!(
+        "<!DOCTYPE html>\n",
+        r#"<html><body><div v-scope="{ count: 0 }" v-effect="$el.dataset.c = count">"#,
+        r#"<button @click="count++">inc</button></div></body></html>"#,
+    );
+    let (root, errors) = parse_document(&allocator, src);
+    assert!(errors.is_empty(), "unexpected errors: {errors:?}");
+
+    let div = find_element(&root.children, "div").expect("div present");
+    let mut saw_scope = false;
+    let mut saw_effect = false;
+    for prop in &div.props {
+        if let PropNode::Directive(dir) = prop {
+            match dir.name.as_str() {
+                "scope" => {
+                    saw_scope = true;
+                    if let Some(ExpressionNode::Simple(exp)) = &dir.exp {
+                        assert_eq!(exp.content.as_str(), "{ count: 0 }");
+                    }
+                }
+                "effect" => saw_effect = true,
+                _ => {}
+            }
+        }
+    }
+    assert!(saw_scope, "v-scope directive should be parsed");
+    assert!(saw_effect, "v-effect directive should be parsed");
+
+    let button = find_element(&root.children, "button").expect("button present");
+    let on = button.props.iter().find_map(|p| match p {
+        PropNode::Directive(d) if d.name.as_str() == "on" => Some(d),
+        _ => None,
+    });
+    let on = on.expect("@click should parse as v-on");
+    if let Some(ExpressionNode::Simple(arg)) = &on.arg {
+        assert_eq!(arg.content.as_str(), "click");
+    }
+}
+
+/// `<script>` and `<style>` content is kept as raw text in document mode (no
+/// interpolation/tag parsing inside), matching template-mode RCDATA handling.
+#[test]
+fn test_document_mode_script_and_style_are_raw() {
+    let allocator = Bump::new();
+    let src = concat!(
+        "<!DOCTYPE html>\n",
+        r#"<html><head><style>.a { color: red }</style>"#,
+        r#"<script>if (a < b) { x = "{{ not interpolation }}" }</script>"#,
+        r#"</head><body></body></html>"#,
+    );
+    let (root, errors) = parse_document(&allocator, src);
+    assert!(errors.is_empty(), "unexpected errors: {errors:?}");
+
+    let script = find_element(&root.children, "script").expect("script present");
+    assert_eq!(script.children.len(), 1);
+    assert!(matches!(&script.children[0], TemplateChildNode::Text(_)));
+    let style = find_element(&root.children, "style").expect("style present");
+    assert_eq!(style.children.len(), 1);
+    assert!(matches!(&style.children[0], TemplateChildNode::Text(_)));
+}
+
+/// Document mode is additive: a bare `<!DOCTYPE html>` in SFC-template mode
+/// still reports the recoverable error, proving the existing behavior is
+/// untouched and the toleration is opt-in.
+#[test]
+fn test_template_mode_doctype_still_errors() {
+    let allocator = Bump::new();
+    let (_root, errors) = parse(&allocator, "<!DOCTYPE html><div></div>");
+    assert!(
+        errors
+            .iter()
+            .any(|e| e.code == ErrorCode::IncorrectlyOpenedComment),
+        "template mode must keep reporting the doctype as IncorrectlyOpenedComment"
+    );
+}
+
+/// Real parse errors (e.g. an unclosed element) are still surfaced in document
+/// mode — toleration is scoped to the doctype declaration only.
+#[test]
+fn test_document_mode_reports_real_errors() {
+    let allocator = Bump::new();
+    let src = "<!DOCTYPE html><html><body><div></body></html>";
+    let (_root, errors) = parse_document(&allocator, src);
+    assert!(
+        errors
+            .iter()
+            .any(|e| e.code == ErrorCode::MissingEndTag || e.code == ErrorCode::InvalidEndTag),
+        "unclosed <div> should still produce an error: {errors:?}"
+    );
+}
+
+/// `parse_document_with_options` honors custom parser options (here custom
+/// interpolation delimiters) while still tolerating the doctype.
+#[test]
+fn test_document_mode_with_options() {
+    let allocator = Bump::new();
+    let mut options = ParserOptions::default();
+    options.delimiters = ("[[".into(), "]]".into());
+    let src = "<!DOCTYPE html><html><body><span>[[ msg ]]</span></body></html>";
+    let (root, errors) = parse_document_with_options(&allocator, src, options);
+    assert!(
+        !errors
+            .iter()
+            .any(|e| e.code == ErrorCode::IncorrectlyOpenedComment),
+        "doctype tolerated with options: {errors:?}"
+    );
+    let span = find_element(&root.children, "span").expect("span present");
+    assert!(
+        span.children
+            .iter()
+            .any(|c| matches!(c, TemplateChildNode::Interpolation(_))),
+        "custom delimiters should produce an interpolation node"
+    );
 }

--- a/crates/vize_armature/src/tokenizer.rs
+++ b/crates/vize_armature/src/tokenizer.rs
@@ -56,6 +56,15 @@ pub struct Tokenizer<'a, C: Callbacks> {
     /// The tokenizer needs this one-token memory to report `<div a="b"c>` as
     /// recoverable missing whitespace instead of silently starting `c`.
     after_quoted_attr_value: bool,
+
+    /// Whether to tolerate top-level markup declarations such as `<!DOCTYPE html>`.
+    ///
+    /// In the default (SFC `<template>`) mode this stays `false`, so a stray
+    /// declaration is reported as a recoverable `IncorrectlyOpenedComment` and
+    /// the hot path is byte-identical. Document mode sets it `true` so a real
+    /// HTML document's doctype is skipped silently instead of producing a
+    /// spurious parse error.
+    tolerate_declarations: bool,
 }
 
 impl<'a, C: Callbacks> Tokenizer<'a, C> {
@@ -88,7 +97,14 @@ impl<'a, C: Callbacks> Tokenizer<'a, C> {
             sequence_index: 0,
             in_rcdata: false,
             after_quoted_attr_value: false,
+            tolerate_declarations: false,
         }
+    }
+
+    /// Tolerate top-level markup declarations (e.g. `<!DOCTYPE html>`) instead of
+    /// reporting them as recoverable errors. Used by document parse mode.
+    pub fn set_tolerate_declarations(&mut self, tolerate: bool) {
+        self.tolerate_declarations = tolerate;
     }
 
     /// Get the position for a given index

--- a/crates/vize_armature/src/tokenizer/states.rs
+++ b/crates/vize_armature/src/tokenizer/states.rs
@@ -594,10 +594,16 @@ impl<'a, C: Callbacks> Tokenizer<'a, C> {
             self.state = State::CDATASequence;
             self.section_start = self.index + 1;
         } else {
-            self.callbacks.on_error(
-                ErrorCode::IncorrectlyOpenedComment,
-                self.section_start.saturating_sub(2),
-            );
+            // In document mode a leading `<!DOCTYPE html>` (or any markup
+            // declaration) is expected; skip it silently rather than reporting
+            // a spurious recoverable error. SFC `<template>` mode keeps the
+            // original behavior so existing output stays byte-identical.
+            if !self.tolerate_declarations {
+                self.callbacks.on_error(
+                    ErrorCode::IncorrectlyOpenedComment,
+                    self.section_start.saturating_sub(2),
+                );
+            }
             self.state = State::InDeclaration;
         }
     }


### PR DESCRIPTION
## What

Adds an additive **document parse mode** to `vize_armature` for petite-vue / standalone HTML pages.

petite-vue is used in plain HTML documents (CDN script + `v-scope` on existing DOM), not SFCs, so the source has a `<!DOCTYPE html>`, `<html>/<head>/<body>`, and directives (`v-scope`, `v-effect`, `@click`) on ordinary elements. Until now armature's only entry points expected an SFC `<template>` block, where a leading doctype is reported as a recoverable `IncorrectlyOpenedComment` error.

New entry points parse a full HTML document into the existing template AST so downstream lint/scope analysis can run over a petite-vue page:

- `parser::parse_document(allocator, source)`
- `parser::parse_document_with_options(allocator, source, options)`
- `Parser::new_document` / `Parser::document_with_options`

The only behavioral difference from template mode is **doctype tolerance**: a private `tolerate_declarations` flag on the tokenizer (set via the new pub fn `set_tolerate_declarations`) skips the spurious declaration error when in document mode. `<script>`/`<style>` stay raw text via the existing RCDATA path; real parse errors (unclosed tags, etc.) are still reported.

This implements the **armature slice of PR3** from #1393 (doctype tolerance + body-content extraction into the template AST). The remaining PR3 items — first-class doctype/declaration AST nodes (needs a new `vize_relief` node type, out of this crate's scope), `lint_standalone_html` reporting, and maestro virtual-doc consumption — live in other crates and are deliberately left for follow-up PRs.

## Scope

- `vize_armature` only. No other crates touched.
- No new public fields on published all-pub option structs (semver-safe): added private fields to `Parser`/`Tokenizer` (both already have private fields) plus new pub fns.
- SFC/`<template>` parsing is byte-identical and opt-out (document mode is a separate entry point).

## Verification

- `cargo test -p vize_armature` — 171 passed (8 new document-mode tests covering doctype tolerance incl. legacy/case-insensitive forms, petite directive parsing, raw script/style, custom-delimiter options, and that template mode still errors on a bare doctype + still reports real unclosed-tag errors in document mode).
- `cargo run -p vize_test_runner --bin coverage` — VDOM 457/457, SFC 167/167 green (the 1 Vapor failure is the pre-existing known v1-alpha tracked failure).
- `cargo fmt --check -p vize_armature` clean.
- `cargo clippy -p vize_armature --lib -- -D warnings` clean.

Refs #1393

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1463"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->