### PR TITLE
feat(atelier): support Vue 2 pipe filters behind legacy dialect

### DIFF
--- a/crates/vize_atelier_core/Cargo.toml
+++ b/crates/vize_atelier_core/Cargo.toml
@@ -7,6 +7,13 @@ license.workspace = true
 repository.workspace = true
 description = "Atelier Core - The core workshop for Vize Vue template parsing and transforms"
 
+[features]
+# Opt-in support for legacy Vue lines (v0.10 / v0.11 / v1 / v2). Off by default
+# so the Vue 3 `vize` binary never compiles it. Enables dialect-gated legacy
+# transforms such as Vue 2 pipe filters; forwards to the `legacy` features of
+# the AST (`vize_relief`) and dialect-capability (`vize_armature`) crates.
+legacy = ["vize_relief/_legacy", "vize_armature/legacy"]
+
 [dependencies]
 vize_carton = { workspace = true }
 vize_croquis = { workspace = true }

--- a/crates/vize_atelier_core/src/codegen.rs
+++ b/crates/vize_atelier_core/src/codegen.rs
@@ -26,4 +26,8 @@ use crate::options::CodegenOptions;
 
 pub use context::{CodegenContext, CodegenResult, CodegenResultWithSections, CodegenSections};
 pub(crate) use helpers::is_constant_simple_expression;
+// Shared with the dialect-gated Vue 2 filter transform, which builds the same
+// `_filter_<name>` asset id the codegen preamble declares.
+#[cfg(feature = "legacy")]
+pub(crate) use helpers::to_valid_asset_identifier;
 pub use pipeline::{generate, generate_with_sections};

--- a/crates/vize_atelier_core/src/codegen/root.rs
+++ b/crates/vize_atelier_core/src/codegen/root.rs
@@ -175,6 +175,25 @@ pub(super) fn generate_assets(ctx: &mut CodegenContext, root: &RootNode<'_>) {
         has_resolved_assets = true;
     }
 
+    // Resolve Vue 2 pipe filters (`const _filter_x = _resolveFilter("x")`).
+    // Legacy-only and emitted after components/directives, matching
+    // `@vue/compiler-core`'s asset order. `root.filters` is always empty for
+    // Vue 3, so this loop never runs there (and is not compiled without the
+    // `legacy` feature).
+    #[cfg(feature = "legacy")]
+    for filter in root.filters.iter() {
+        ctx.use_helper(RuntimeHelper::ResolveFilter);
+        ctx.push("const ");
+        ctx.push(&to_valid_asset_identifier("filter", filter));
+        ctx.push(" = ");
+        ctx.push(ctx.helper(RuntimeHelper::ResolveFilter));
+        ctx.push("(\"");
+        ctx.push(filter);
+        ctx.push("\")");
+        ctx.newline();
+        has_resolved_assets = true;
+    }
+
     if has_resolved_assets {
         ctx.newline();
     }

--- a/crates/vize_atelier_core/src/transform.rs
+++ b/crates/vize_atelier_core/src/transform.rs
@@ -70,6 +70,11 @@ pub struct TransformContext<'a> {
     pub components: std::vec::Vec<String>,
     /// Directives used (Vec to maintain template order for code generation)
     pub directives: std::vec::Vec<String>,
+    /// Vue 2 pipe filters referenced by the template, first-seen order.
+    /// Flushed to [`RootNode::filters`](crate::ast::RootNode) and emitted as
+    /// `_resolveFilter` asset declarations. Legacy-only and dialect-gated.
+    #[cfg(feature = "legacy")]
+    pub(crate) filters: std::vec::Vec<String>,
     /// Hoisted expressions
     pub hoists: Vec<'a, Option<JsChildNode<'a>>>,
     /// Cached expressions
@@ -276,6 +281,11 @@ fn transform_inner<'a>(
     }
     for directive in ctx.directives.into_iter() {
         root.directives.push(directive);
+    }
+    // Transfer Vue 2 pipe filters (legacy-only; empty for Vue 3).
+    #[cfg(feature = "legacy")]
+    for filter in ctx.filters.into_iter() {
+        root.filters.push(filter);
     }
     // Transfer hoisted nodes to root
     for hoist in ctx.hoists.into_iter() {

--- a/crates/vize_atelier_core/src/transform/context.rs
+++ b/crates/vize_atelier_core/src/transform/context.rs
@@ -36,6 +36,8 @@ impl<'a> TransformContext<'a> {
             helpers: crate::runtime_helpers::RuntimeHelpers::default(),
             components: std::vec::Vec::new(),
             directives: std::vec::Vec::new(),
+            #[cfg(feature = "legacy")]
+            filters: std::vec::Vec::new(),
             hoists: vize_carton::Vec::new_in(allocator),
             cached: vize_carton::Vec::new_in(allocator),
             temps: 0,
@@ -291,6 +293,31 @@ impl<'a> TransformContext<'a> {
         if !self.directives.contains(&directive) {
             self.directives.push(directive);
         }
+    }
+
+    /// Register a Vue 2 pipe filter (maintains first-seen order for codegen).
+    ///
+    /// Legacy-only; only ever called from the dialect-gated filter rewrite.
+    #[cfg(feature = "legacy")]
+    pub(crate) fn add_filter(&mut self, filter: impl Into<String>) {
+        let filter = filter.into();
+        if !self.filters.contains(&filter) {
+            self.filters.push(filter);
+        }
+    }
+
+    /// Whether the resolved dialect supports Vue 2 pipe filters
+    /// (`{{ msg | capitalize }}`). Resolved from
+    /// [`vize_armature::legacy::LegacyDialectCapabilities`] for the dialect on
+    /// [`TransformOptions::dialect`](crate::options::TransformOptions::dialect).
+    ///
+    /// Always `false` for the default Vue 3 dialect, so the filter rewrite is
+    /// never entered there. Legacy-only.
+    #[cfg(feature = "legacy")]
+    #[inline]
+    pub(crate) fn supports_filters(&self) -> bool {
+        vize_armature::legacy::LegacyDialectCapabilities::for_dialect(self.options.dialect)
+            .supports_filters
     }
 
     /// Add an identifier to current scope

--- a/crates/vize_atelier_core/src/transforms.rs
+++ b/crates/vize_atelier_core/src/transforms.rs
@@ -4,6 +4,10 @@
 //! directives and node types during the transform phase.
 
 pub mod hoist_static;
+/// Vue 2 pipe-filter parsing/rewriting. Legacy-only and dialect-gated; see the
+/// module docs. Compiled only behind the `legacy` cargo feature.
+#[cfg(feature = "legacy")]
+pub(crate) mod legacy_filters;
 pub mod transform_element;
 pub mod transform_expression;
 pub mod transform_text;

--- a/crates/vize_atelier_core/src/transforms/legacy_filters.rs
+++ b/crates/vize_atelier_core/src/transforms/legacy_filters.rs
@@ -1,0 +1,337 @@
+//! Vue 2 pipe-filter parsing (`{{ msg | capitalize }}`, `:id="raw | formatId"`).
+//!
+//! Legacy-only: filters were removed in Vue 3, where `|` is the bitwise-OR
+//! operator. This module is compiled only behind the `legacy` cargo feature and
+//! is consulted by [`crate::transforms::transform_expression::process_expression`]
+//! solely when the resolved dialect advertises
+//! [`supports_filters`](vize_armature::legacy::LegacyDialectCapabilities::supports_filters)
+//! (Vue 2 / 2.7). For every other dialect — and for any build without the
+//! `legacy` feature — this module is never reached and a `|`-containing
+//! expression stays byte-identical to today's Vue 3 bitwise-OR output.
+//!
+//! The split + rewrite mirror `@vue/compiler-core`'s `parseFilter` /
+//! `wrapFilter` (the `transformFilter` compat transform):
+//!
+//! - `a | f`      -> `_filter_f(a)`
+//! - `a | f(b)`   -> `_filter_f(a,b)`
+//! - `a | f | g`  -> `_filter_g(_filter_f(a))`
+//!
+//! Top-level `|` only: pipes inside strings, template literals, regex
+//! literals, or `()[]{}` nesting are not filter separators, and `||` is the
+//! logical-OR operator, never a filter.
+
+use vize_carton::String;
+
+use super::transform_expression::is_simple_identifier;
+
+/// A parsed Vue 2 filter expression: the base expression and the ordered
+/// filter chain applied to it (outermost last).
+pub(crate) struct FilterExpression {
+    /// The base expression text the filters are applied to (trimmed).
+    pub(crate) base: String,
+    /// Each filter as written after a top-level `|`, trimmed
+    /// (e.g. `"capitalize"`, `"f(b)"`).
+    pub(crate) filters: std::vec::Vec<String>,
+}
+
+/// Returns whether `c` can legally precede a `/` that starts a regex literal,
+/// mirroring `@vue/compiler-core`'s `validDivisionCharRE = /[\w).+\-_$\]]/`:
+/// a `/` after one of these is division, otherwise it opens a regex.
+fn is_valid_division_char(c: char) -> bool {
+    c.is_ascii_alphanumeric() || c == '_' || matches!(c, ')' | '.' | '+' | '-' | '$' | ']')
+}
+
+/// Split a directive/interpolation expression into its base expression and
+/// Vue 2 filter chain, mirroring `@vue/compiler-core`'s `parseFilter`.
+///
+/// Returns `None` when the expression contains no top-level filter pipe — the
+/// caller then leaves the expression exactly as-is (so `a || b`, `a | b` under
+/// a non-filter dialect, etc. are untouched). Returns `Some` only when at least
+/// one real filter was found.
+pub(crate) fn parse_filters(exp: &str) -> Option<FilterExpression> {
+    let bytes = exp.as_bytes();
+    let len = bytes.len();
+
+    let mut in_single = false;
+    let mut in_double = false;
+    let mut in_template = false;
+    let mut in_regex = false;
+    let mut curly: u32 = 0;
+    let mut square: u32 = 0;
+    let mut paren: u32 = 0;
+
+    let mut last_filter_index = 0usize;
+    // `None` until the first top-level pipe splits off the base expression.
+    let mut expression: Option<String> = None;
+    let mut filters: std::vec::Vec<String> = std::vec::Vec::new();
+    let mut prev: u8 = 0;
+
+    let mut i = 0usize;
+    while i < len {
+        let c = bytes[i];
+
+        if in_single {
+            if c == b'\'' && prev != b'\\' {
+                in_single = false;
+            }
+        } else if in_double {
+            if c == b'"' && prev != b'\\' {
+                in_double = false;
+            }
+        } else if in_template {
+            if c == b'`' && prev != b'\\' {
+                in_template = false;
+            }
+        } else if in_regex {
+            if c == b'/' && prev != b'\\' {
+                in_regex = false;
+            }
+        } else if c == b'|'
+            && bytes.get(i + 1).copied() != Some(b'|')
+            && (i == 0 || bytes[i - 1] != b'|')
+            && curly == 0
+            && square == 0
+            && paren == 0
+        {
+            // Top-level filter pipe.
+            if expression.is_none() {
+                last_filter_index = i + 1;
+                expression = Some(String::new(exp[..i].trim()));
+            } else {
+                filters.push(String::new(exp[last_filter_index..i].trim()));
+                last_filter_index = i + 1;
+            }
+        } else {
+            match c {
+                b'"' => in_double = true,
+                b'\'' => in_single = true,
+                b'`' => in_template = true,
+                b'(' => paren += 1,
+                b')' => paren = paren.saturating_sub(1),
+                b'[' => square += 1,
+                b']' => square = square.saturating_sub(1),
+                b'{' => curly += 1,
+                b'}' => curly = curly.saturating_sub(1),
+                _ => {}
+            }
+            if c == b'/' {
+                // Look back past spaces for the previous non-space char to
+                // decide division vs. regex (mirrors `validDivisionCharRE`).
+                let mut j = i as isize - 1;
+                let mut p: Option<char> = None;
+                while j >= 0 {
+                    let pc = exp[j as usize..].chars().next().unwrap_or(' ');
+                    if pc != ' ' {
+                        p = Some(pc);
+                        break;
+                    }
+                    j -= 1;
+                }
+                if p.is_none_or(|pc| !is_valid_division_char(pc)) {
+                    in_regex = true;
+                }
+            }
+        }
+
+        prev = c;
+        i += 1;
+    }
+
+    match &mut expression {
+        None => return None,
+        Some(_) if last_filter_index != 0 => {
+            filters.push(String::new(exp[last_filter_index..].trim()));
+        }
+        Some(_) => {}
+    }
+
+    let base = expression?;
+    if filters.is_empty() {
+        return None;
+    }
+    Some(FilterExpression { base, filters })
+}
+
+/// Wrap `exp` with one filter, mirroring `@vue/compiler-core`'s `wrapFilter`.
+///
+/// - `f`     -> `_filter_f(exp)`
+/// - `f(b)`  -> `_filter_f(exp,b)`
+/// - `f()`   -> `_filter_f(exp)`
+///
+/// `filter_id` is the already-resolved asset identifier
+/// (`_filter_<validated-name>`). Returns the wrapped expression and the raw
+/// filter name for asset registration. Returns `None` for a filter whose name
+/// is not a valid identifier (e.g. empty), in which case the caller bails out
+/// and leaves the expression untouched.
+pub(crate) fn wrap_filter(exp: &str, filter: &str, filter_id: &str) -> Option<String> {
+    match filter.find('(') {
+        None => {
+            // Bare filter name: `_filter_f(exp)`.
+            let mut out = String::with_capacity(filter_id.len() + exp.len() + 2);
+            out.push_str(filter_id);
+            out.push('(');
+            out.push_str(exp);
+            out.push(')');
+            Some(out)
+        }
+        Some(idx) => {
+            // Call-style filter `f(args)`: `_filter_f(exp,args` with the
+            // trailing `)` carried over from `args` (Vue 2 call syntax).
+            let args = &filter[idx + 1..];
+            let mut out = String::with_capacity(filter_id.len() + exp.len() + args.len() + 3);
+            out.push_str(filter_id);
+            out.push('(');
+            out.push_str(exp);
+            if args == ")" {
+                // `f()` -> `_filter_f(exp)`
+                out.push(')');
+            } else {
+                // `f(b, c)` -> `_filter_f(exp,b, c)` (args still holds the `)`)
+                out.push(',');
+                out.push_str(args);
+            }
+            Some(out)
+        }
+    }
+}
+
+/// Extract the bare filter name from a (possibly call-style) filter segment,
+/// e.g. `"f(b)"` -> `"f"`, `"capitalize"` -> `"capitalize"`. Returns `None`
+/// for an empty/invalid name so the caller can bail out unchanged.
+pub(crate) fn filter_name(filter: &str) -> Option<&str> {
+    let name = match filter.find('(') {
+        Some(idx) => &filter[..idx],
+        None => filter,
+    };
+    let name = name.trim();
+    // Vue resolves whatever name appears; require a non-empty, identifier-like
+    // token so we never emit `_filter_(` for malformed input. `-` is allowed
+    // because `toValidAssetId` maps it (foo-bar -> _filter_foo_bar).
+    if name.is_empty() {
+        return None;
+    }
+    let dashless = name.replace('-', "_");
+    if is_simple_identifier(&dashless) {
+        Some(name)
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Assert a filter split: `exp` must parse to `expected_base` plus the
+    /// `expected_filters` chain. Comparisons stay on `&str` to keep the test
+    /// free of the crate's disallowed std `String`.
+    fn assert_split(exp: &str, expected_base: &str, expected_filters: &[&str]) {
+        let parsed = parse_filters(exp).expect("expected a filter split");
+        assert_eq!(parsed.base.as_str(), expected_base);
+        assert_eq!(parsed.filters.len(), expected_filters.len());
+        for (got, want) in parsed.filters.iter().zip(expected_filters) {
+            assert_eq!(got.as_str(), *want);
+        }
+    }
+
+    #[test]
+    fn no_pipe_is_none() {
+        assert!(parse_filters("message").is_none());
+        assert!(parse_filters("a + b").is_none());
+    }
+
+    #[test]
+    fn logical_or_is_not_a_filter() {
+        assert!(parse_filters("a || b").is_none());
+        assert!(parse_filters("a || b || c").is_none());
+    }
+
+    #[test]
+    fn bitwise_or_outside_filter_dialect_is_caller_gated() {
+        // `a | b` *is* a filter split here; the dialect gate in
+        // process_expression is what keeps Vue 3 bitwise-or untouched.
+        assert_split("a | b", "a", &["b"]);
+    }
+
+    #[test]
+    fn single_filter() {
+        assert_split("message | capitalize", "message", &["capitalize"]);
+    }
+
+    #[test]
+    fn filter_with_args() {
+        assert_split("a | f(b)", "a", &["f(b)"]);
+    }
+
+    #[test]
+    fn filter_chain() {
+        assert_split("a | f | g(c)", "a", &["f", "g(c)"]);
+    }
+
+    #[test]
+    fn pipe_inside_string_is_ignored() {
+        assert_split("a | f('a|b')", "a", &["f('a|b')"]);
+        // A pipe living only inside a string must not split anything.
+        assert!(parse_filters("'x | y'").is_none());
+        assert!(parse_filters("`x | y`").is_none());
+    }
+
+    #[test]
+    fn pipe_inside_brackets_is_ignored() {
+        assert!(parse_filters("[a | b]").is_none());
+        assert!(parse_filters("f(a | b)").is_none());
+        assert!(parse_filters("{ a: b | c }").is_none());
+    }
+
+    #[test]
+    fn base_can_be_a_call() {
+        assert_split("f(a) | g", "f(a)", &["g"]);
+    }
+
+    #[test]
+    fn regex_literal_pipe_is_ignored() {
+        // `/a|b/` is a regex literal; its `|` is not a filter pipe.
+        assert_split("x.match(/a|b/) | g", "x.match(/a|b/)", &["g"]);
+    }
+
+    #[test]
+    fn wrap_filter_bare() {
+        assert_eq!(
+            wrap_filter("message", "capitalize", "_filter_capitalize").unwrap(),
+            "_filter_capitalize(message)"
+        );
+    }
+
+    #[test]
+    fn wrap_filter_call() {
+        assert_eq!(
+            wrap_filter("a", "f(b)", "_filter_f").unwrap(),
+            "_filter_f(a,b)"
+        );
+    }
+
+    #[test]
+    fn wrap_filter_empty_call() {
+        assert_eq!(
+            wrap_filter("a", "f()", "_filter_f").unwrap(),
+            "_filter_f(a)"
+        );
+    }
+
+    #[test]
+    fn wrap_filter_multi_args_preserves_spacing() {
+        assert_eq!(
+            wrap_filter("a", "f(b, c)", "_filter_f").unwrap(),
+            "_filter_f(a,b, c)"
+        );
+    }
+
+    #[test]
+    fn filter_name_extraction() {
+        assert_eq!(filter_name("capitalize"), Some("capitalize"));
+        assert_eq!(filter_name("f(b)"), Some("f"));
+        assert_eq!(filter_name("foo-bar"), Some("foo-bar"));
+        assert_eq!(filter_name("(x)"), None);
+        assert_eq!(filter_name(""), None);
+    }
+}

--- a/crates/vize_atelier_core/src/transforms/transform_expression.rs
+++ b/crates/vize_atelier_core/src/transforms/transform_expression.rs
@@ -143,6 +143,61 @@ pub fn is_function_expression(content: &str) -> bool {
     )
 }
 
+/// Rewrite Vue 2 pipe filters in `exp` in place, mirroring
+/// `@vue/compiler-core`'s `transformFilter` / `wrapFilter`.
+///
+/// Returns `true` and rewrites `exp.content` to the unprefixed
+/// `_filter_<name>(base,args)` form (registering each filter and the
+/// `_resolveFilter` helper) when the dialect supports filters and the content
+/// actually contains a top-level filter pipe. Returns `false` — leaving `exp`
+/// untouched — otherwise, so non-filter expressions (and every Vue 3 source)
+/// are byte-identical to before.
+#[cfg(feature = "legacy")]
+fn rewrite_filters_in_place<'a>(
+    ctx: &mut TransformContext<'a>,
+    exp: &mut Box<'a, SimpleExpressionNode<'a>>,
+) -> bool {
+    use crate::transforms::legacy_filters::{filter_name, parse_filters, wrap_filter};
+
+    if !ctx.supports_filters() {
+        return false;
+    }
+
+    let Some(parsed) = parse_filters(exp.content.as_str()) else {
+        return false;
+    };
+
+    // Validate every filter name up front; if any is malformed, bail out and
+    // leave the original expression untouched (matches Vue resolving named
+    // filters only).
+    let mut names: std::vec::Vec<(String, String)> = std::vec::Vec::new();
+    for filter in &parsed.filters {
+        let Some(name) = filter_name(filter) else {
+            return false;
+        };
+        let id = crate::codegen::to_valid_asset_identifier("filter", name);
+        names.push((String::new(name), id));
+    }
+
+    // Build the wrapped expression from the inside out: each filter wraps the
+    // running expression, outermost filter last.
+    let mut wrapped = parsed.base;
+    for (filter, (name, id)) in parsed.filters.iter().zip(names.iter()) {
+        let Some(next) = wrap_filter(wrapped.as_str(), filter, id.as_str()) else {
+            return false;
+        };
+        wrapped = next;
+        ctx.add_filter(name.clone());
+    }
+
+    ctx.helper(crate::ast::RuntimeHelper::ResolveFilter);
+    exp.content = wrapped;
+    // The content was rewritten from source text, so any cached parse is stale.
+    exp.js_ast = None;
+    exp.is_ref_transformed = false;
+    true
+}
+
 /// Process expression with identifier prefixing and TypeScript stripping
 pub fn process_expression<'a>(
     ctx: &mut TransformContext<'a>,
@@ -151,7 +206,26 @@ pub fn process_expression<'a>(
 ) -> ExpressionNode<'a> {
     let allocator = ctx.allocator;
 
-    let normalized = normalize_expression(exp, allocator);
+    // `mut` is only consumed by the legacy filter rewrite below; without the
+    // `legacy` feature that block is cfg'd out and the binding is never mutated.
+    #[cfg_attr(not(feature = "legacy"), allow(unused_mut))]
+    let mut normalized = normalize_expression(exp, allocator);
+
+    // Vue 2 pipe filters (`{{ msg | capitalize }}`): split the top-level `|`
+    // chain into an unprefixed `_filter_<name>(base,args)` rewrite, register
+    // the filters, and pull in `_resolveFilter`. Identifier prefixing then runs
+    // over the rewritten text below (skipping the `_filter_` ids). Legacy-only
+    // and dialect-gated: never entered for the default Vue 3 dialect, where a
+    // `|`-containing expression stays byte-identical to today's bitwise-or.
+    #[cfg(feature = "legacy")]
+    if !normalized.is_static && rewrite_filters_in_place(ctx, &mut normalized) {
+        // The content now contains `_filter_*(...)` calls. Fall through to the
+        // identifier-prefixing pass (which handles `_ctx.`/`.value` on the base
+        // and args) when prefixing/TS is on; otherwise return the rewrite as-is.
+        if !ctx.options.prefix_identifiers && !ctx.options.is_ts {
+            return ExpressionNode::Simple(normalized);
+        }
+    }
 
     // If not prefixing identifiers and not TypeScript, just clone
     if !ctx.options.prefix_identifiers && !ctx.options.is_ts {

--- a/crates/vize_atelier_core/src/transforms/transform_expression/collector.rs
+++ b/crates/vize_atelier_core/src/transforms/transform_expression/collector.rs
@@ -254,6 +254,15 @@ impl<'a, 'ctx> Visit<'_> for IdentifierCollector<'a, 'ctx> {
             return;
         }
 
+        // Vue 2 filter asset ids (`_filter_capitalize`) are introduced by the
+        // legacy filter rewrite, not the user, and must never be prefixed with
+        // `_ctx.`/`.value`. Mirrors `@vue/compiler-core` skipping
+        // `name.startsWith("_filter_")` during identifier prefixing. Legacy-only.
+        #[cfg(feature = "legacy")]
+        if name.starts_with("_filter_") {
+            return;
+        }
+
         let needs_unref = self.needs_unref(name);
         let is_assignment_target = self
             .assignment_targets

--- a/crates/vize_atelier_core/tests/legacy_filters.rs
+++ b/crates/vize_atelier_core/tests/legacy_filters.rs
@@ -1,0 +1,153 @@
+//! Vue 2 pipe-filter codegen parity + zero-cost dialect gating.
+//!
+//! Compiled only under `--features legacy`; the whole file is gated so the
+//! default Vue 3 build never sees it. Asserts that:
+//!
+//! - under dialect V2 (and V2.7), `{{ msg | capitalize }}` and
+//!   `:id="raw | formatId"` lower to `@vue/compiler-core`'s Vue-2-compat filter
+//!   output (`const _filter_x = _resolveFilter("x")` + `_filter_x(...)`), and
+//! - under the default dialect V3, the *same* input stays bitwise-or with no
+//!   `_resolveFilter` anywhere — proving the feature is inert for Vue 3 even in
+//!   a `legacy`-enabled build.
+#![cfg(feature = "legacy")]
+// Integration test: plain `std::string::String` / `{out}` formatting is fine
+// here (the crate's internal `vize_carton::String` rule does not apply to an
+// out-of-crate test harness).
+#![allow(clippy::disallowed_types, clippy::disallowed_macros)]
+
+use vize_atelier_core::{CodegenOptions, TransformOptions, codegen, parser, transform};
+use vize_carton::config::VueVersion;
+
+fn compile(input: &str, dialect: VueVersion) -> String {
+    let allocator = bumpalo::Bump::new();
+    let (mut root, errors) = parser::parse(&allocator, input);
+    assert!(errors.is_empty(), "parse errors: {errors:?}");
+
+    let transform_opts = TransformOptions {
+        prefix_identifiers: true,
+        dialect,
+        ..Default::default()
+    };
+    transform::transform(&allocator, &mut root, transform_opts, None);
+
+    let codegen_opts = CodegenOptions {
+        prefix_identifiers: true,
+        ..Default::default()
+    };
+    let result = codegen::generate(&root, codegen_opts);
+    let mut out = String::with_capacity(result.preamble.len() + result.code.len() + 1);
+    out.push_str(result.preamble.as_str());
+    out.push('\n');
+    out.push_str(result.code.as_str());
+    out
+}
+
+#[test]
+fn v2_interpolation_single_filter() {
+    let out = compile("<div>{{ message | capitalize }}</div>", VueVersion::V2);
+    assert!(
+        out.contains(r#"const _filter_capitalize = _resolveFilter("capitalize")"#),
+        "{out}"
+    );
+    assert!(out.contains("_filter_capitalize(_ctx.message)"), "{out}");
+}
+
+#[test]
+fn v2_interpolation_filter_with_args() {
+    let out = compile("<div>{{ a | f(b) }}</div>", VueVersion::V2);
+    assert!(
+        out.contains(r#"const _filter_f = _resolveFilter("f")"#),
+        "{out}"
+    );
+    // base and the in-paren arg are both prefixed; the base/arg comma has no
+    // space (mirrors @vue/compiler-core's wrapFilter).
+    assert!(out.contains("_filter_f(_ctx.a,_ctx.b)"), "{out}");
+}
+
+#[test]
+fn v2_interpolation_filter_chain() {
+    let out = compile("<div>{{ a | f | g(c) }}</div>", VueVersion::V2);
+    assert!(
+        out.contains(r#"const _filter_f = _resolveFilter("f")"#),
+        "{out}"
+    );
+    assert!(
+        out.contains(r#"const _filter_g = _resolveFilter("g")"#),
+        "{out}"
+    );
+    assert!(out.contains("_filter_g(_filter_f(_ctx.a),_ctx.c)"), "{out}");
+}
+
+#[test]
+fn v2_bind_filter() {
+    let out = compile(r#"<div :id="raw | formatId"></div>"#, VueVersion::V2);
+    assert!(
+        out.contains(r#"const _filter_formatId = _resolveFilter("formatId")"#),
+        "{out}"
+    );
+    assert!(out.contains("_filter_formatId(_ctx.raw)"), "{out}");
+}
+
+#[test]
+fn v2_logical_or_is_not_a_filter() {
+    // `||` must never be treated as a filter, even under V2.
+    let out = compile("<div>{{ a || b }}</div>", VueVersion::V2);
+    assert!(!out.contains("_resolveFilter"), "{out}");
+    assert!(out.contains("_ctx.a || _ctx.b"), "{out}");
+}
+
+#[test]
+fn v2_string_pipe_is_not_a_filter() {
+    let out = compile(r#"<div>{{ a | f('a|b') }}</div>"#, VueVersion::V2);
+    assert!(
+        out.contains(r#"const _filter_f = _resolveFilter("f")"#),
+        "{out}"
+    );
+    // The pipe inside the string literal is preserved verbatim.
+    assert!(out.contains(r#"_filter_f(_ctx.a,'a|b')"#), "{out}");
+}
+
+#[test]
+fn v2_dash_filter_name_is_valid_asset_id() {
+    let out = compile("<div>{{ x | foo-bar }}</div>", VueVersion::V2);
+    // `-` maps to `_` in the asset id but the resolved name keeps the dash.
+    assert!(
+        out.contains(r#"const _filter_foo_bar = _resolveFilter("foo-bar")"#),
+        "{out}"
+    );
+    assert!(out.contains("_filter_foo_bar(_ctx.x)"), "{out}");
+}
+
+#[test]
+fn v2_7_shares_the_v2_filter_dialect() {
+    let out = compile("<div>{{ message | capitalize }}</div>", VueVersion::V2_7);
+    assert!(out.contains("_filter_capitalize(_ctx.message)"), "{out}");
+}
+
+// --- Zero-cost: dialect V3 keeps `|` as bitwise-or, no filters ---------------
+
+#[test]
+fn v3_default_dialect_keeps_pipe_as_bitwise_or() {
+    // Same input the V2 tests treat as a filter must stay bitwise-or under the
+    // default Vue 3 dialect — even in this `legacy`-feature build.
+    let out = compile("<div>{{ message | capitalize }}</div>", VueVersion::V3);
+    assert!(!out.contains("_resolveFilter"), "{out}");
+    assert!(!out.contains("_filter_"), "{out}");
+    assert!(out.contains("_ctx.message | _ctx.capitalize"), "{out}");
+}
+
+#[test]
+fn v3_bind_pipe_is_bitwise_or() {
+    let out = compile(r#"<div :id="raw | formatId"></div>"#, VueVersion::V3);
+    assert!(!out.contains("_resolveFilter"), "{out}");
+    assert!(out.contains("_ctx.raw | _ctx.formatId"), "{out}");
+}
+
+#[test]
+fn v2_and_v3_outputs_diverge_only_for_filters() {
+    // A `|`-free template must produce identical output under V2 and V3,
+    // demonstrating the dialect only changes filter handling.
+    let v2 = compile("<div>{{ a + b }}</div>", VueVersion::V2);
+    let v3 = compile("<div>{{ a + b }}</div>", VueVersion::V3);
+    assert_eq!(v2, v3);
+}

--- a/crates/vize_relief/Cargo.toml
+++ b/crates/vize_relief/Cargo.toml
@@ -7,6 +7,20 @@ license.workspace = true
 repository.workspace = true
 description = "Relief - The sculptured AST surface for Vize Vue templates"
 
+[features]
+# Opt-in support for legacy Vue lines (v0.10 / v0.11 / v1 / v2). Off by default
+# so the Vue 3 `vize` binary never compiles it. Gates legacy-only AST surface
+# such as the Vue 2 filter asset list on [`crate::ast::RootNode`].
+#
+# Intentionally underscore-prefixed: `cargo-semver-checks`' default feature
+# heuristic enables every non-excluded feature, which would surface the
+# legacy-only `RootNode::filters` field and trip the (major) constructible
+# struct-adds-field lint. The `_`-prefix is on the heuristic's exclude list, so
+# the field stays invisible to SemVer checks while still compiling for real
+# legacy builds (`vize_atelier_core/legacy` forwards to it). Treat it as an
+# internal feature; depend on `vize_atelier_core/legacy` instead.
+_legacy = []
+
 [dependencies]
 vize_carton = { workspace = true }
 

--- a/crates/vize_relief/src/ast/nodes.rs
+++ b/crates/vize_relief/src/ast/nodes.rs
@@ -21,6 +21,19 @@ pub struct RootNode<'a> {
     pub helpers: Vec<'a, RuntimeHelper>,
     pub components: Vec<'a, String>,
     pub directives: Vec<'a, String>,
+    /// Vue 2 pipe filters referenced by the template (e.g. `capitalize` in
+    /// `{{ msg | capitalize }}`), in first-seen order. Each becomes a
+    /// `const _filter_<name> = _resolveFilter("<name>")` asset declaration in
+    /// the render preamble, mirroring `@vue/compiler-core`'s Vue-2-compat
+    /// filter output.
+    ///
+    /// Legacy-only: filters were removed in Vue 3, so this field is compiled
+    /// only behind the internal `_legacy` cargo feature (enabled transitively
+    /// by `vize_atelier_core/legacy`). The default Vue 3 build never sees it,
+    /// keeping the public AST surface — and `cargo-semver-checks`, whose
+    /// feature heuristic skips `_`-prefixed features — byte-identical.
+    #[cfg(feature = "_legacy")]
+    pub filters: Vec<'a, String>,
     pub hoists: Vec<'a, Option<JsChildNode<'a>>>,
     pub imports: Vec<'a, ImportItem<'a>>,
     pub cached: Vec<'a, Option<Box<'a, CacheExpression<'a>>>>,
@@ -38,6 +51,8 @@ impl<'a> RootNode<'a> {
             helpers: Vec::new_in(allocator),
             components: Vec::new_in(allocator),
             directives: Vec::new_in(allocator),
+            #[cfg(feature = "_legacy")]
+            filters: Vec::new_in(allocator),
             hoists: Vec::new_in(allocator),
             imports: Vec::new_in(allocator),
             cached: Vec::new_in(allocator),


### PR DESCRIPTION
## Approach

Implements Vue 2 filter syntax — `{{ message | capitalize }}` and `:id="raw | formatId"` — gated behind the `legacy` cargo feature **and** a V2/V2.7 dialect. The capability is resolved once per file via `LegacyDialectCapabilities::for_dialect(options.dialect).supports_filters` (from PR2, #1458), so hot paths only read a bool.

- **Split** (`transforms/legacy_filters.rs`): `parse_filters` walks the expression and splits on **top-level** `|` only — never `||`, and never inside strings, template literals, regex literals, or `()[]{}` nesting — into a base expression + filter chain. Mirrors `@vue/compiler-core`'s `parseFilter`.
- **Lower** (`process_expression`): when the dialect supports filters and a top-level pipe is present, the content is rewritten in place to the unprefixed `_filter_<name>(base,args)` form (`a | f` → `_filter_f(a)`, `a | f(b)` → `_filter_f(a,b)`), each filter is registered, and `_resolveFilter` is pulled in. The existing identifier-prefixing pass then prefixes the base/args (`_ctx.`/`.value`) while **skipping** `_filter_*` ids — matching compiler-core's `name.startsWith("_filter_")` skip.
- **Emit** (`codegen/root.rs`): filters become `const _filter_<name> = _resolveFilter("<name>")` asset declarations in the render preamble, after components/directives, matching compiler-core's asset order. Filter names flow `ctx.filters` → `RootNode::filters` → codegen.

## Vue parity

Verified against `@vue/compiler-core` (compat mode, throwaway compare script, since deleted). Output matches exactly:

| Input | Output |
|---|---|
| `{{ message \| capitalize }}` | `_filter_capitalize(_ctx.message)` + `const _filter_capitalize = _resolveFilter("capitalize")` |
| `{{ a \| f(b) }}` | `_filter_f(_ctx.a,_ctx.b)` |
| `{{ a \| f \| g(c) }}` | `_filter_g(_filter_f(_ctx.a),_ctx.c)` |
| `:id="raw \| formatId"` | `id: _filter_formatId(_ctx.raw)` |
| `{{ x \| foo-bar }}` | `const _filter_foo_bar = _resolveFilter("foo-bar")` |
| `{{ a \| f('a\|b') }}` | `_filter_f(_ctx.a,'a\|b')` (string pipe untouched) |
| `{{ a \|\| b }}` | `_ctx.a \|\| _ctx.b` (logical-or, no filter) |

Covered by `crates/vize_atelier_core/tests/legacy_filters.rs` (11 tests) + unit tests in `legacy_filters.rs`.

## Zero-cost proof

All new behavior is `#[cfg(feature = "legacy")]`. With the feature off (default) **or** dialect V3, a `|`-containing expression is treated exactly as today (bitwise-or), byte-identical:

- `v3_default_dialect_keeps_pipe_as_bitwise_or`: same input the V2 tests treat as a filter stays `_ctx.message | _ctx.capitalize`, no `_resolveFilter`, even in a `legacy`-enabled build.
- `cargo run -p vize_test_runner --bin coverage` (default build): **VDOM 457/457, SFC 167/167** — unchanged (the single pre-existing Vapor known-failure is untouched).
- `crates/vize_atelier_sfc/tests/allocation_budget.rs`: unchanged.

### SemVer note

The new `RootNode::filters` field is gated on an **internal `_legacy`** feature (forwarded by `vize_atelier_core/legacy`). `cargo-semver-checks`' default heuristic enables every non-excluded feature, which would otherwise surface the field and trip the major `constructible_struct_adds_field` lint; the `_`-prefix is on the heuristic's exclude list, so the field is invisible to SemVer checks while still compiling for real legacy builds. All other new API in `vize_atelier_core` is `pub(crate)`. `cargo semver-checks check-release` passes for both `vize_relief` and `vize_atelier_core` (196/196).

## Verification

- `cargo test -p vize_relief -p vize_atelier_core` (default): green
- `cargo test -p vize_atelier_core --features legacy` / `-p vize_relief --features _legacy`: green
- `cargo fmt --check`, `cargo clippy --lib -D warnings` (both feature modes): clean
- `cargo semver-checks check-release` (relief, atelier_core): no SemVer update required

Scope is limited to `vize_relief` (AST) + `vize_atelier_core` (transform/codegen). No changes to canon/maestro/patina/croquis.

Refs #1392

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1465"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->