### PR TITLE
refactor(croquis): unify options walkers behind shared OptionsDescriptor

### DIFF
--- a/crates/vize_croquis/src/croquis.rs
+++ b/crates/vize_croquis/src/croquis.rs
@@ -145,29 +145,14 @@ pub struct Croquis {
     /// Authoritative Options API options-object descriptor, when the script
     /// resolves to an Options API component.
     ///
-    /// Private (with the [`Croquis::options_descriptor`] accessor) so adding it
-    /// does not introduce a new public field on the otherwise all-`pub`
-    /// `Croquis` struct, which `cargo-semver-checks` would flag.
-    options_descriptor: Option<OptionsDescriptor>,
-}
-
-impl Croquis {
-    /// The resolved Options API options-object descriptor, if the script
-    /// defines an Options API component.
-    ///
     /// Spans are relative to the script content the component was parsed from;
     /// add the script block's offset before reporting.
-    #[inline]
-    pub fn options_descriptor(&self) -> Option<&OptionsDescriptor> {
-        self.options_descriptor.as_ref()
-    }
-
-    /// Set the Options API options-object descriptor. Used by the script parser
-    /// when populating a summary.
-    #[inline]
-    pub(crate) fn set_options_descriptor(&mut self, descriptor: Option<OptionsDescriptor>) {
-        self.options_descriptor = descriptor;
-    }
+    ///
+    /// `pub` to match the rest of the struct: every other field on `Croquis`
+    /// is `pub`, so a private field here would break struct-literal
+    /// construction (`cargo-semver-checks`'s
+    /// `constructible_struct_adds_private_field` lint).
+    pub options_descriptor: Option<OptionsDescriptor>,
 }
 
 #[cfg(test)]

--- a/crates/vize_croquis/src/croquis.rs
+++ b/crates/vize_croquis/src/croquis.rs
@@ -30,6 +30,7 @@
 
 mod bindings;
 mod model;
+mod options_descriptor;
 mod template;
 mod vir;
 
@@ -40,6 +41,7 @@ pub use bindings::{
     UnusedVarContext,
 };
 pub use model::{AnalysisStats, CroquisStats};
+pub use options_descriptor::{OptionGroup, OptionKey, OptionMember, OptionsDescriptor};
 pub use template::{
     ComponentRegistration, ComponentUsage, ElementIdInfo, ElementIdKind, EventListener, PassedProp,
     SlotUsage, TemplateExpression, TemplateExpressionKind, TemplateInfo,
@@ -139,6 +141,33 @@ pub struct Croquis {
     /// Definition spans for bindings (name -> (start, end) offset in script)
     /// Used for Go-to-Definition support.
     pub binding_spans: FxHashMap<CompactString, (u32, u32)>,
+
+    /// Authoritative Options API options-object descriptor, when the script
+    /// resolves to an Options API component.
+    ///
+    /// Private (with the [`Croquis::options_descriptor`] accessor) so adding it
+    /// does not introduce a new public field on the otherwise all-`pub`
+    /// `Croquis` struct, which `cargo-semver-checks` would flag.
+    options_descriptor: Option<OptionsDescriptor>,
+}
+
+impl Croquis {
+    /// The resolved Options API options-object descriptor, if the script
+    /// defines an Options API component.
+    ///
+    /// Spans are relative to the script content the component was parsed from;
+    /// add the script block's offset before reporting.
+    #[inline]
+    pub fn options_descriptor(&self) -> Option<&OptionsDescriptor> {
+        self.options_descriptor.as_ref()
+    }
+
+    /// Set the Options API options-object descriptor. Used by the script parser
+    /// when populating a summary.
+    #[inline]
+    pub(crate) fn set_options_descriptor(&mut self, descriptor: Option<OptionsDescriptor>) {
+        self.options_descriptor = descriptor;
+    }
 }
 
 #[cfg(test)]

--- a/crates/vize_croquis/src/croquis/options_descriptor.rs
+++ b/crates/vize_croquis/src/croquis/options_descriptor.rs
@@ -1,0 +1,104 @@
+//! Shared Options API options-object descriptor.
+//!
+//! [`OptionsDescriptor`] is croquis's single, authoritative view of an Options
+//! API component's options object: the resolved options-object span, every
+//! top-level option key (name + span), and the per-group members
+//! (`props`/`inject`/`computed`/`methods`/`data`/`setup`) with the raw key span
+//! each was declared at.
+//!
+//! It is built by the croquis script parser using the *same* `export default` /
+//! `defineComponent(...)` / identifier-bound / `as`/`satisfies`/non-null/paren
+//! resolution that drives template-binding collection, so downstream consumers
+//! (patina lint rules today; canon/maestro later) no longer maintain their own
+//! divergent options-object walkers.
+//!
+//! Spans are **program-relative** (relative to the script content the options
+//! object was parsed from); consumers add their own block offset. Member names
+//! and spans are recorded **verbatim** — no kebab→camel normalization and, for
+//! array-form `props`/`inject` entries, the span covers the full string literal
+//! including its quotes — so byte-for-byte diagnostics are preserved.
+
+use vize_carton::CompactString;
+
+/// The Options API group a member was declared in.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OptionGroup {
+    /// `props: ['a'] | { a: ... }`
+    Props,
+    /// `inject: ['a'] | { a: ... }`
+    Inject,
+    /// `computed: { a() {} }`
+    Computed,
+    /// `methods: { a() {} }`
+    Methods,
+    /// `data() { return { a: 1 } }`
+    Data,
+    /// `setup() { return { a: 1 } }`
+    Setup,
+}
+
+impl OptionGroup {
+    /// Lower-case option name (`"props"`, `"data"`, ...). Stable identifier used
+    /// by consumers for human-readable labels.
+    #[inline]
+    pub fn label(self) -> &'static str {
+        match self {
+            OptionGroup::Props => "props",
+            OptionGroup::Inject => "inject",
+            OptionGroup::Computed => "computed",
+            OptionGroup::Methods => "methods",
+            OptionGroup::Data => "data",
+            OptionGroup::Setup => "setup",
+        }
+    }
+}
+
+/// A single top-level option key (e.g. `data`, `computed`, `name`) and the span
+/// of its key in the options object.
+#[derive(Debug, Clone)]
+pub struct OptionKey {
+    /// Verbatim key name as written.
+    pub name: CompactString,
+    /// Program-relative start of the key.
+    pub start: u32,
+    /// Program-relative end of the key.
+    pub end: u32,
+}
+
+/// A single member declared within a tracked option group, with the raw span it
+/// should be reported at.
+#[derive(Debug, Clone)]
+pub struct OptionMember {
+    /// Verbatim member name as written (no kebab→camel normalization).
+    pub name: CompactString,
+    /// Program-relative start of the member's key (full string literal,
+    /// including quotes, for array-form `props`/`inject` entries).
+    pub start: u32,
+    /// Program-relative end of the member's key.
+    pub end: u32,
+    /// The group this member belongs to.
+    pub group: OptionGroup,
+}
+
+/// Authoritative descriptor of a resolved Options API options object.
+#[derive(Debug, Clone)]
+pub struct OptionsDescriptor {
+    /// Program-relative span of the resolved options object (`{ ... }`).
+    pub options_start: u32,
+    /// Program-relative end of the resolved options object.
+    pub options_end: u32,
+    /// Every top-level option key, in source order.
+    pub option_keys: Vec<OptionKey>,
+    /// Members of the tracked groups
+    /// (`props`/`inject`/`computed`/`methods`/`data`/`setup`), in source order.
+    pub members: Vec<OptionMember>,
+}
+
+impl OptionsDescriptor {
+    /// Members belonging to a specific group.
+    pub fn members_in(&self, group: OptionGroup) -> impl Iterator<Item = &OptionMember> {
+        self.members
+            .iter()
+            .filter(move |member| member.group == group)
+    }
+}

--- a/crates/vize_croquis/src/drawer/tests/snapshots/vize_croquis__drawer__tests__script__drawer_script_bindings.snap
+++ b/crates/vize_croquis/src/drawer/tests/snapshots/vize_croquis__drawer__tests__script__drawer_script_bindings.snap
@@ -1308,4 +1308,5 @@ Croquis {
             127,
         ),
     },
+    options_descriptor: None,
 }

--- a/crates/vize_croquis/src/lib.rs
+++ b/crates/vize_croquis/src/lib.rs
@@ -83,9 +83,9 @@ pub use symbol::{Symbol, SymbolFlags, SymbolId, SymbolTable};
 pub use analyzer::{Analyzer, AnalyzerOptions};
 pub use croquis::{
     AnalysisStats, BindingMetadata, COMPILER_MACRO_NAMES, ComponentShape, Croquis, CroquisStats,
-    ImportStatementInfo, InvalidExport, InvalidExportKind, ReExportInfo, TemplateExpression,
-    TemplateExpressionKind, TypeExport, TypeExportKind, UndefinedRef, UnusedTemplateVar,
-    UnusedVarContext,
+    ImportStatementInfo, InvalidExport, InvalidExportKind, OptionGroup, OptionKey, OptionMember,
+    OptionsDescriptor, ReExportInfo, TemplateExpression, TemplateExpressionKind, TypeExport,
+    TypeExportKind, UndefinedRef, UnusedTemplateVar, UnusedVarContext,
 };
 pub use drawer::{Drawer, DrawerOptions};
 

--- a/crates/vize_croquis/src/script_parser.rs
+++ b/crates/vize_croquis/src/script_parser.rs
@@ -29,7 +29,7 @@ pub use parse::{
     analyze_script_setup_program, parse_script, parse_script_setup,
     parse_script_setup_with_generic, parse_script_with_options,
 };
-pub use process::process_statement;
+pub use process::{collect_options_descriptor, process_statement};
 pub(crate) use result::{ReactiveGetterContext, ReactiveValueOrigin, RuntimeObjectLiteral};
 pub use result::{ScriptParseResult, ScriptParserOptions};
 

--- a/crates/vize_croquis/src/script_parser/process/mod.rs
+++ b/crates/vize_croquis/src/script_parser/process/mod.rs
@@ -20,4 +20,5 @@ mod options_api;
 mod statements;
 
 pub(in crate::script_parser) use options_api::collect_options_api_component_metadata;
+pub use options_api::collect_options_descriptor;
 pub use statements::process_statement;

--- a/crates/vize_croquis/src/script_parser/process/options_api.rs
+++ b/crates/vize_croquis/src/script_parser/process/options_api.rs
@@ -13,7 +13,9 @@ use oxc_ast::ast::{
 use oxc_span::GetSpan;
 
 use crate::ScopeBinding;
-use crate::croquis::ComponentRegistration;
+use crate::croquis::{
+    ComponentRegistration, OptionGroup, OptionKey, OptionMember, OptionsDescriptor,
+};
 use vize_carton::{CompactString, FxHashMap, FxHashSet, String};
 use vize_relief::BindingType;
 
@@ -59,6 +61,9 @@ pub(in crate::script_parser) fn collect_options_api_component_metadata(
         else {
             continue;
         };
+        if result.options_descriptor.is_none() {
+            result.options_descriptor = Some(build_options_descriptor(options.object));
+        }
         collect_component_registrations_from_options(result, options.object, &object_bindings);
         // Options API template bindings are valid in Vue 3 too; legacy Vue 2.7
         // implies them and additionally pulls in the Nuxt 2 globals below.
@@ -857,5 +862,303 @@ pub(super) fn property_key_name<'a>(key: &'a PropertyKey<'a>) -> Option<&'a str>
         PropertyKey::StaticIdentifier(identifier) => Some(identifier.name.as_str()),
         PropertyKey::StringLiteral(string) => Some(string.value.as_str()),
         _ => None,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Options descriptor (shared single-source-of-truth options-object view).
+// ---------------------------------------------------------------------------
+
+/// Resolve the component's Options API options object from `program` and build
+/// its [`OptionsDescriptor`], reusing the same authoritative
+/// `export default` / `defineComponent(...)` / identifier-bound /
+/// `as`/`satisfies`/non-null/paren resolution that drives template-binding
+/// collection.
+///
+/// Returns the descriptor for the first resolved options object (matching the
+/// resolution order of the existing collectors), or `None` when the script does
+/// not declare an Options API component via `export default`.
+///
+/// Spans are program-relative; callers add their block offset.
+pub fn collect_options_descriptor(program: &Program<'_>) -> Option<OptionsDescriptor> {
+    let mut component_option_bindings = FxHashMap::default();
+    collect_component_options_bindings(program, &mut component_option_bindings);
+
+    for statement in program.body.iter() {
+        let Statement::ExportDefaultDeclaration(export) = statement else {
+            continue;
+        };
+        // Class components are not Options API options objects.
+        if super::class_component::class_from_export(&export.declaration).is_some() {
+            continue;
+        }
+        let Some(options) =
+            component_options_from_export(&export.declaration, &component_option_bindings)
+        else {
+            continue;
+        };
+        return Some(build_options_descriptor(options.object));
+    }
+
+    None
+}
+
+/// Build an [`OptionsDescriptor`] from an already-resolved options object.
+///
+/// Member names and spans are recorded verbatim (no kebab→camel normalization);
+/// array-form `props`/`inject` entries record the full string-literal span
+/// including quotes, matching how lint diagnostics point at the declaration.
+fn build_options_descriptor(object: &ObjectExpression<'_>) -> OptionsDescriptor {
+    let mut option_keys = Vec::new();
+    let mut members = Vec::new();
+
+    for property in &object.properties {
+        let ObjectPropertyKind::ObjectProperty(property) = property else {
+            continue;
+        };
+        if property.computed {
+            continue;
+        }
+        let Some(name) = property_key_name(&property.key) else {
+            continue;
+        };
+        let key_span = property.key.span();
+        option_keys.push(OptionKey {
+            name: CompactString::new(name),
+            start: key_span.start,
+            end: key_span.end,
+        });
+
+        if let Some(group) = descriptor_group(name) {
+            collect_descriptor_members(group, &property.value, &mut members);
+        }
+    }
+
+    OptionsDescriptor {
+        options_start: object.span.start,
+        options_end: object.span.end,
+        option_keys,
+        members,
+    }
+}
+
+fn descriptor_group(name: &str) -> Option<OptionGroup> {
+    match name {
+        "props" => Some(OptionGroup::Props),
+        "inject" => Some(OptionGroup::Inject),
+        "computed" => Some(OptionGroup::Computed),
+        "methods" => Some(OptionGroup::Methods),
+        "data" => Some(OptionGroup::Data),
+        "setup" => Some(OptionGroup::Setup),
+        _ => None,
+    }
+}
+
+fn collect_descriptor_members(
+    group: OptionGroup,
+    value: &Expression<'_>,
+    members: &mut Vec<OptionMember>,
+) {
+    match group {
+        // `props`/`inject` accept either `['a', 'b']` or `{ a: ..., b: ... }`.
+        OptionGroup::Props | OptionGroup::Inject => match value {
+            Expression::ArrayExpression(array) => {
+                for element in &array.elements {
+                    let Some(Expression::StringLiteral(string)) = element.as_expression() else {
+                        continue;
+                    };
+                    members.push(OptionMember {
+                        name: CompactString::new(string.value.as_str()),
+                        start: string.span.start,
+                        end: string.span.end,
+                        group,
+                    });
+                }
+            }
+            Expression::ObjectExpression(object) => {
+                push_object_key_members(object, group, members);
+            }
+            _ => {}
+        },
+        OptionGroup::Computed | OptionGroup::Methods => {
+            if let Expression::ObjectExpression(object) = value {
+                push_object_key_members(object, group, members);
+            }
+        }
+        // `data`/`setup` are functions whose returned object literal declares
+        // members.
+        OptionGroup::Data | OptionGroup::Setup => {
+            if let Some(object) = descriptor_returned_object(value) {
+                push_object_key_members(object, group, members);
+            }
+        }
+    }
+}
+
+fn push_object_key_members(
+    object: &ObjectExpression<'_>,
+    group: OptionGroup,
+    members: &mut Vec<OptionMember>,
+) {
+    for property in &object.properties {
+        let ObjectPropertyKind::ObjectProperty(property) = property else {
+            continue;
+        };
+        if property.computed {
+            continue;
+        }
+        let Some(name) = property_key_name(&property.key) else {
+            continue;
+        };
+        let span = property.key.span();
+        members.push(OptionMember {
+            name: CompactString::new(name),
+            start: span.start,
+            end: span.end,
+            group,
+        });
+    }
+}
+
+/// Returned object literal of a `data`/`setup` function value: function
+/// expression `return`, arrow concise body `() => ({ ... })`, or arrow block
+/// `return`. Parentheses are unwrapped; identifier-bound returns are not
+/// resolved (matching the lint walkers being unified).
+fn descriptor_returned_object<'a>(value: &'a Expression<'a>) -> Option<&'a ObjectExpression<'a>> {
+    match value {
+        Expression::FunctionExpression(function) => {
+            descriptor_returned_object_in_body(&function.body.as_ref()?.statements)
+        }
+        Expression::ArrowFunctionExpression(arrow) => {
+            if arrow.expression {
+                let Statement::ExpressionStatement(expr) = arrow.body.statements.first()? else {
+                    return None;
+                };
+                descriptor_object_expression(&expr.expression)
+            } else {
+                descriptor_returned_object_in_body(&arrow.body.statements)
+            }
+        }
+        _ => None,
+    }
+}
+
+fn descriptor_returned_object_in_body<'a>(
+    statements: &'a oxc_allocator::Vec<'a, Statement<'a>>,
+) -> Option<&'a ObjectExpression<'a>> {
+    for statement in statements.iter() {
+        if let Statement::ReturnStatement(ret) = statement
+            && let Some(argument) = ret.argument.as_ref()
+        {
+            return descriptor_object_expression(argument);
+        }
+    }
+    None
+}
+
+fn descriptor_object_expression<'a>(
+    expression: &'a Expression<'a>,
+) -> Option<&'a ObjectExpression<'a>> {
+    match expression {
+        Expression::ObjectExpression(object) => Some(object.as_ref()),
+        Expression::ParenthesizedExpression(paren) => {
+            descriptor_object_expression(&paren.expression)
+        }
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod descriptor_tests {
+    use super::collect_options_descriptor;
+    use oxc_allocator::Allocator;
+    use oxc_parser::Parser;
+    use oxc_span::SourceType;
+    use vize_carton::{CompactString, cstr};
+
+    /// Parse `source` and return `(member_name, group_label)` pairs in order.
+    /// Labels are compared instead of the enum to keep names borrowed (the
+    /// workspace disallows `ToString::to_string`).
+    fn members(allocator: &Allocator, source: &str) -> Vec<(CompactString, &'static str)> {
+        let source_type = SourceType::from_path("script.ts").unwrap();
+        let ret = Parser::new(allocator, source, source_type).parse();
+        let descriptor = collect_options_descriptor(&ret.program).expect("descriptor");
+        descriptor
+            .members
+            .iter()
+            .map(|member| (member.name.clone(), member.group.label()))
+            .collect()
+    }
+
+    #[test]
+    fn collects_members_across_groups_in_source_order() {
+        let source = r#"
+export default {
+  props: ['foo'],
+  data() { return { bar: 1 } },
+  computed: { baz() { return 2 } },
+  methods: { qux() {} },
+  inject: { wiz: { from: 'w' } },
+  setup() { return { zap: 0 } },
+}
+"#;
+        let allocator = Allocator::default();
+        assert_eq!(
+            members(&allocator, source),
+            vec![
+                (cstr!("foo"), "props"),
+                (cstr!("bar"), "data"),
+                (cstr!("baz"), "computed"),
+                (cstr!("qux"), "methods"),
+                (cstr!("wiz"), "inject"),
+                (cstr!("zap"), "setup"),
+            ]
+        );
+    }
+
+    #[test]
+    fn records_array_prop_span_including_quotes_and_all_option_keys() {
+        let allocator = Allocator::default();
+        let source = "export default { props: ['foo'], name: 'C' }";
+        let source_type = SourceType::from_path("script.ts").unwrap();
+        let ret = Parser::new(&allocator, source, source_type).parse();
+        let descriptor = collect_options_descriptor(&ret.program).expect("descriptor");
+
+        // Array-form prop member span covers the full string literal incl. quotes.
+        let prop = &descriptor.members[0];
+        assert_eq!(&source[prop.start as usize..prop.end as usize], "'foo'");
+
+        // Every top-level option key is recorded (props + name), verbatim.
+        let keys: Vec<&str> = descriptor
+            .option_keys
+            .iter()
+            .map(|k| k.name.as_str())
+            .collect();
+        assert_eq!(keys, vec!["props", "name"]);
+    }
+
+    #[test]
+    fn resolves_define_component_and_identifier_export() {
+        let allocator = Allocator::default();
+        let from_define = members(
+            &allocator,
+            "export default defineComponent({ methods: { a() {} } })",
+        );
+        assert_eq!(from_define, vec![(cstr!("a"), "methods")]);
+
+        let from_ident = members(
+            &allocator,
+            "const c = { computed: { b() { return 1 } } }\nexport default c",
+        );
+        assert_eq!(from_ident, vec![(cstr!("b"), "computed")]);
+    }
+
+    #[test]
+    fn no_options_for_script_setup_style() {
+        let allocator = Allocator::default();
+        let source = "import { ref } from 'vue'\nconst x = ref(0)";
+        let source_type = SourceType::from_path("script.ts").unwrap();
+        let ret = Parser::new(&allocator, source, source_type).parse();
+        assert!(collect_options_descriptor(&ret.program).is_none());
     }
 }

--- a/crates/vize_croquis/src/script_parser/result.rs
+++ b/crates/vize_croquis/src/script_parser/result.rs
@@ -194,7 +194,7 @@ impl ScriptParseResult {
         summary.component_registrations = self.component_registrations;
         summary.component_shape = self.component_shape;
         summary.binding_spans = self.binding_spans;
-        summary.set_options_descriptor(self.options_descriptor);
+        summary.options_descriptor = self.options_descriptor;
     }
 
     /// Convert script analysis into a `Croquis` summary.

--- a/crates/vize_croquis/src/script_parser/result.rs
+++ b/crates/vize_croquis/src/script_parser/result.rs
@@ -5,7 +5,9 @@
 //! plain-value and runtime-object tracking.
 
 use crate::croquis::{BindingMetadata, ComponentRegistration, ComponentShape, Croquis};
-use crate::croquis::{ImportStatementInfo, InvalidExport, ReExportInfo, TypeExport};
+use crate::croquis::{
+    ImportStatementInfo, InvalidExport, OptionsDescriptor, ReExportInfo, TypeExport,
+};
 use crate::macros::{EmitDefinition, MacroTracker, PropDefinition};
 use crate::provide::ProvideInjectTracker;
 use crate::race::RaceConditionTracker;
@@ -105,6 +107,8 @@ pub struct ScriptParseResult {
     pub(crate) type_export_typeof_refs: Vec<FxHashSet<CompactString>>,
     /// Static runtime object literal metadata available to macro spread args.
     pub(crate) runtime_object_literals: FxHashMap<CompactString, RuntimeObjectLiteral>,
+    /// Authoritative Options API options-object descriptor, when resolved.
+    pub(crate) options_descriptor: Option<OptionsDescriptor>,
 }
 
 /// Options for plain script parsing.
@@ -190,6 +194,7 @@ impl ScriptParseResult {
         summary.component_registrations = self.component_registrations;
         summary.component_shape = self.component_shape;
         summary.binding_spans = self.binding_spans;
+        summary.set_options_descriptor(self.options_descriptor);
     }
 
     /// Convert script analysis into a `Croquis` summary.

--- a/crates/vize_croquis/src/script_parser/snapshots/vize_croquis__script_parser__tests__parse_imports.snap
+++ b/crates/vize_croquis/src/script_parser/snapshots/vize_croquis__script_parser__tests__parse_imports.snap
@@ -1321,4 +1321,5 @@ ScriptParseResult {
     },
     type_export_typeof_refs: [],
     runtime_object_literals: {},
+    options_descriptor: None,
 }

--- a/crates/vize_croquis/src/script_parser/snapshots/vize_croquis__script_parser__tests__parse_reactivity.snap
+++ b/crates/vize_croquis/src/script_parser/snapshots/vize_croquis__script_parser__tests__parse_reactivity.snap
@@ -1305,4 +1305,5 @@ ScriptParseResult {
     import_sources: {},
     type_export_typeof_refs: [],
     runtime_object_literals: {},
+    options_descriptor: None,
 }

--- a/crates/vize_patina/src/rules/script/no_dupe_keys.rs
+++ b/crates/vize_patina/src/rules/script/no_dupe_keys.rs
@@ -44,12 +44,10 @@
 
 use super::{ScriptLintResult, ScriptRule, ScriptRuleMeta};
 use crate::diagnostic::{LintDiagnostic, Severity};
-use oxc_ast::ast::{
-    Argument, BindingPattern, ExportDefaultDeclarationKind, Expression, Function, ObjectExpression,
-    ObjectPropertyKind, Program, PropertyKey, Statement,
-};
-use oxc_span::GetSpan;
+use oxc_ast::ast::Program;
 use vize_carton::{CompactString, FxHashMap};
+use vize_croquis::OptionMember;
+use vize_croquis::script_parser::collect_options_descriptor;
 
 static META: ScriptRuleMeta = ScriptRuleMeta {
     name: "script/no-dupe-keys",
@@ -78,10 +76,10 @@ impl ScriptRule for NoDupeKeys {
         offset: usize,
         result: &mut ScriptLintResult,
     ) {
-        let Some(options) = find_component_options(program) else {
+        let Some(descriptor) = collect_options_descriptor(program) else {
             return;
         };
-        check_options_object(options, offset, result);
+        check_descriptor_members(&descriptor.members, offset, result);
     }
 }
 
@@ -94,8 +92,8 @@ struct KeyOrigin {
     end: u32,
 }
 
-fn check_options_object(
-    object: &ObjectExpression<'_>,
+fn check_descriptor_members(
+    members: &[OptionMember],
     offset: usize,
     result: &mut ScriptLintResult,
 ) {
@@ -103,27 +101,15 @@ fn check_options_object(
     // group are reported as duplicates pointing back at the original.
     let mut seen: FxHashMap<CompactString, KeyOrigin> = FxHashMap::default();
 
-    for property in &object.properties {
-        let ObjectPropertyKind::ObjectProperty(property) = property else {
-            continue;
-        };
-        if property.computed {
-            continue;
-        }
-        let Some(group) = property_key_name(&property.key).and_then(option_group) else {
-            continue;
-        };
-
-        for member in collect_group_member_keys(group, &property.value) {
-            record_key(&mut seen, group.label, member, offset, result);
-        }
+    for member in members {
+        record_key(&mut seen, member.group.label(), member, offset, result);
     }
 }
 
 fn record_key(
     seen: &mut FxHashMap<CompactString, KeyOrigin>,
     group: &'static str,
-    member: MemberKey,
+    member: &OptionMember,
     offset: usize,
     result: &mut ScriptLintResult,
 ) {
@@ -151,7 +137,7 @@ fn record_key(
         return;
     }
 
-    seen.insert(member.name, KeyOrigin { group, start, end });
+    seen.insert(member.name.clone(), KeyOrigin { group, start, end });
 }
 
 fn group_label(group: &'static str) -> CompactString {
@@ -166,276 +152,6 @@ fn first_declaration_label(group: &'static str) -> CompactString {
     label.push_str("first declared in ");
     label.push_str(group);
     label
-}
-
-/// A single collected member name and the span it should be reported at.
-struct MemberKey {
-    name: CompactString,
-    start: u32,
-    end: u32,
-}
-
-#[derive(Clone, Copy)]
-struct OptionGroup {
-    label: &'static str,
-    kind: GroupKind,
-}
-
-#[derive(Clone, Copy)]
-enum GroupKind {
-    /// `props`: array of strings or object of declarations.
-    Props,
-    /// `inject`: array of strings or object of declarations.
-    Inject,
-    /// `computed` / `methods`: object of declarations.
-    Object,
-    /// `data` / `setup`: a function returning an object literal.
-    ReturnObject,
-}
-
-fn option_group(name: &str) -> Option<OptionGroup> {
-    let (label, kind) = match name {
-        "props" => ("props", GroupKind::Props),
-        "inject" => ("inject", GroupKind::Inject),
-        "computed" => ("computed", GroupKind::Object),
-        "methods" => ("methods", GroupKind::Object),
-        "data" => ("data", GroupKind::ReturnObject),
-        "setup" => ("setup", GroupKind::ReturnObject),
-        _ => return None,
-    };
-    Some(OptionGroup { label, kind })
-}
-
-fn collect_group_member_keys(group: OptionGroup, value: &Expression<'_>) -> Vec<MemberKey> {
-    match group.kind {
-        GroupKind::Props | GroupKind::Inject => collect_array_or_object_keys(value),
-        GroupKind::Object => collect_object_keys(value),
-        GroupKind::ReturnObject => collect_returned_object_keys(value),
-    }
-}
-
-/// `props`/`inject` accept either `['a', 'b']` or `{ a: ..., b: ... }`.
-fn collect_array_or_object_keys(value: &Expression<'_>) -> Vec<MemberKey> {
-    match value {
-        Expression::ArrayExpression(array) => {
-            let mut keys = Vec::new();
-            for element in &array.elements {
-                if let Some(string) = element.as_expression().and_then(string_literal) {
-                    keys.push(MemberKey {
-                        name: string.value.as_str().into(),
-                        start: string.span.start,
-                        end: string.span.end,
-                    });
-                }
-            }
-            keys
-        }
-        _ => collect_object_keys(value),
-    }
-}
-
-fn collect_object_keys(value: &Expression<'_>) -> Vec<MemberKey> {
-    let Expression::ObjectExpression(object) = value else {
-        return Vec::new();
-    };
-    object_property_keys(object)
-}
-
-/// `data`/`setup` are functions whose returned object literal declares members.
-fn collect_returned_object_keys<'a>(value: &'a Expression<'a>) -> Vec<MemberKey> {
-    let object = match value {
-        Expression::FunctionExpression(function) => function_return_object(function),
-        Expression::ArrowFunctionExpression(arrow) => {
-            if arrow.expression {
-                // `data: () => ({ ... })`
-                arrow
-                    .body
-                    .statements
-                    .first()
-                    .and_then(|statement| match statement {
-                        Statement::ExpressionStatement(expr) => {
-                            as_object(unwrap_parenthesized(&expr.expression))
-                        }
-                        _ => None,
-                    })
-            } else {
-                find_returned_object(&arrow.body.statements)
-            }
-        }
-        _ => None,
-    };
-    object.map(object_property_keys).unwrap_or_default()
-}
-
-fn function_return_object<'a>(function: &'a Function<'a>) -> Option<&'a ObjectExpression<'a>> {
-    let body = function.body.as_ref()?;
-    find_returned_object(&body.statements)
-}
-
-fn find_returned_object<'a>(statements: &'a [Statement<'a>]) -> Option<&'a ObjectExpression<'a>> {
-    for statement in statements {
-        if let Statement::ReturnStatement(ret) = statement
-            && let Some(argument) = ret.argument.as_ref()
-        {
-            return as_object(unwrap_parenthesized(argument));
-        }
-    }
-    None
-}
-
-fn object_property_keys(object: &ObjectExpression<'_>) -> Vec<MemberKey> {
-    let mut keys = Vec::new();
-    for property in &object.properties {
-        match property {
-            ObjectPropertyKind::ObjectProperty(property) => {
-                if property.computed {
-                    continue;
-                }
-                if let Some(name) = property_key_name(&property.key) {
-                    keys.push(MemberKey {
-                        name: name.into(),
-                        start: property.key.span().start,
-                        end: property.key.span().end,
-                    });
-                }
-            }
-            ObjectPropertyKind::SpreadProperty(_) => {}
-        }
-    }
-    keys
-}
-
-fn as_object<'a>(expression: &'a Expression<'a>) -> Option<&'a ObjectExpression<'a>> {
-    match expression {
-        Expression::ObjectExpression(object) => Some(object),
-        _ => None,
-    }
-}
-
-fn unwrap_parenthesized<'a>(expression: &'a Expression<'a>) -> &'a Expression<'a> {
-    match expression {
-        Expression::ParenthesizedExpression(paren) => unwrap_parenthesized(&paren.expression),
-        other => other,
-    }
-}
-
-fn string_literal<'a>(
-    expression: &'a Expression<'a>,
-) -> Option<&'a oxc_ast::ast::StringLiteral<'a>> {
-    match expression {
-        Expression::StringLiteral(string) => Some(string),
-        _ => None,
-    }
-}
-
-fn property_key_name<'a>(key: &'a PropertyKey<'a>) -> Option<&'a str> {
-    match key {
-        PropertyKey::StaticIdentifier(id) => Some(id.name.as_str()),
-        PropertyKey::StringLiteral(string) => Some(string.value.as_str()),
-        _ => None,
-    }
-}
-
-// ---------------------------------------------------------------------------
-// Component options resolution (export default / defineComponent).
-// ---------------------------------------------------------------------------
-
-fn find_component_options<'a>(program: &'a Program<'a>) -> Option<&'a ObjectExpression<'a>> {
-    let mut bindings: FxHashMap<&'a str, &'a ObjectExpression<'a>> = FxHashMap::default();
-
-    for statement in program.body.iter() {
-        let Statement::VariableDeclaration(declaration) = statement else {
-            continue;
-        };
-        for declarator in &declaration.declarations {
-            let Some(init) = declarator.init.as_ref() else {
-                continue;
-            };
-            if let BindingPattern::BindingIdentifier(id) = &declarator.id
-                && let Some(object) = options_from_expression(init, &bindings)
-            {
-                bindings.insert(id.name.as_str(), object);
-            }
-        }
-    }
-
-    for statement in program.body.iter() {
-        let Statement::ExportDefaultDeclaration(export) = statement else {
-            continue;
-        };
-        if let Some(object) = options_from_export(&export.declaration, &bindings) {
-            return Some(object);
-        }
-    }
-
-    None
-}
-
-fn options_from_export<'a>(
-    declaration: &'a ExportDefaultDeclarationKind<'a>,
-    bindings: &FxHashMap<&'a str, &'a ObjectExpression<'a>>,
-) -> Option<&'a ObjectExpression<'a>> {
-    match declaration {
-        ExportDefaultDeclarationKind::ObjectExpression(object) => Some(object),
-        ExportDefaultDeclarationKind::CallExpression(call) => options_from_call(call, bindings),
-        ExportDefaultDeclarationKind::Identifier(identifier) => {
-            bindings.get(identifier.name.as_str()).copied()
-        }
-        ExportDefaultDeclarationKind::ParenthesizedExpression(paren) => {
-            options_from_expression(&paren.expression, bindings)
-        }
-        ExportDefaultDeclarationKind::TSAsExpression(ts_as) => {
-            options_from_expression(&ts_as.expression, bindings)
-        }
-        ExportDefaultDeclarationKind::TSSatisfiesExpression(ts_satisfies) => {
-            options_from_expression(&ts_satisfies.expression, bindings)
-        }
-        ExportDefaultDeclarationKind::TSNonNullExpression(ts_non_null) => {
-            options_from_expression(&ts_non_null.expression, bindings)
-        }
-        _ => None,
-    }
-}
-
-fn options_from_expression<'a>(
-    expression: &'a Expression<'a>,
-    bindings: &FxHashMap<&'a str, &'a ObjectExpression<'a>>,
-) -> Option<&'a ObjectExpression<'a>> {
-    match expression {
-        Expression::ObjectExpression(object) => Some(object),
-        Expression::CallExpression(call) => options_from_call(call, bindings),
-        Expression::Identifier(identifier) => bindings.get(identifier.name.as_str()).copied(),
-        Expression::ParenthesizedExpression(paren) => {
-            options_from_expression(&paren.expression, bindings)
-        }
-        Expression::TSAsExpression(ts_as) => options_from_expression(&ts_as.expression, bindings),
-        Expression::TSSatisfiesExpression(ts_satisfies) => {
-            options_from_expression(&ts_satisfies.expression, bindings)
-        }
-        Expression::TSNonNullExpression(ts_non_null) => {
-            options_from_expression(&ts_non_null.expression, bindings)
-        }
-        _ => None,
-    }
-}
-
-fn options_from_call<'a>(
-    call: &'a oxc_ast::ast::CallExpression<'a>,
-    bindings: &FxHashMap<&'a str, &'a ObjectExpression<'a>>,
-) -> Option<&'a ObjectExpression<'a>> {
-    let Expression::Identifier(callee) = &call.callee else {
-        return None;
-    };
-    if !matches!(callee.name.as_str(), "defineComponent" | "_defineComponent") {
-        return None;
-    }
-    match call.arguments.first()? {
-        Argument::ObjectExpression(object) => Some(object),
-        Argument::Identifier(identifier) => bindings.get(identifier.name.as_str()).copied(),
-        argument => argument
-            .as_expression()
-            .and_then(|expression| options_from_expression(expression, bindings)),
-    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## What

Consolidate the divergent Options API options-object walkers behind a single, authoritative `OptionsDescriptor` in `vize_croquis`, and migrate the patina `script/no-dupe-keys` rule to consume it. This is the low-risk, name-level half of issue #1388 PR9.

The descriptor captures, for a resolved Options API component:
- the resolved options-object span (`options_start`/`options_end`),
- every top-level option key (`OptionKey { name, start, end }`), in source order,
- per-group members (`OptionMember { name, start, end, group }`) for `props`/`inject`/`computed`/`methods`/`data`/`setup`, in source order.

Names and spans are recorded **verbatim** (no kebab→camel normalization; array-form `props`/`inject` entries keep the full string-literal span including quotes) so consumers' diagnostics stay byte-identical. Spans are program-relative; consumers add their own block offset.

## Walkers unified

- `OptionsDescriptor` is built with croquis's **existing** authoritative options-object resolution (`export default` / `defineComponent(...)` / identifier-bound options / `as`/`satisfies`/non-null/paren), keeping croquis the single source of truth.
- Exposed on `Croquis` via a new `pub options_descriptor: Option<OptionsDescriptor>` field (matching every other field on the all-`pub` struct, so struct-literal construction stays available to external crates), and via `vize_croquis::script_parser::collect_options_descriptor(program)` for AST-only consumers. Adding a `pub` field is a minor (non-breaking) change; an earlier draft used a private field with an accessor, but that trips `cargo-semver-checks`'s `constructible_struct_adds_private_field` (a major-break lint) because the struct was previously constructible by struct literal.
- patina `script/no-dupe-keys` now reads the descriptor's `members`, deleting its ~280-line bespoke options walker (component-options resolution + per-group key collection). Diagnostics are byte-identical.

## Remaining (canon PR-B and the rest of PR9)

- **`script/no-options-api` is intentionally not migrated.** It resolves `createApp` / `Vue.createApp` entry points with a petite-vue exclusion that croquis does not model; folding that linter-specific entry-point logic into the shared descriptor would exceed the low-risk bar and risk the petite-vue snapshots. Left as-is (a clean partial), noted for a follow-up.
- The canon source-slicer unification is a separate, higher-risk PR-B (not attempted here).
- canon/atelier/maestro consumers of the new descriptor (incl. PR10 \`this.*\` LSP) are future PRs; the descriptor is shaped to serve them (raw names + spans + all option keys).

## Verification

- \`cargo test -p vize_croquis -p vize_patina\`: green (croquis 190, patina 1069 + doctests).
- **Byte-identical snapshots**: all patina insta snapshots unchanged. \`no-dupe-keys\` diagnostics are identical. The only croquis snapshot changes are the additive \`options_descriptor: None\` line in three whole-struct \`Debug\` dumps (no behavioral change).
- \`cargo run -p vize_test_runner --bin coverage\`: green (740/741; the single failure is the pre-existing \`vapor/parity-core-directives\` known failure tracked for v1 alpha, unrelated to this change).
- \`cargo fmt --check\` clean; \`cargo clippy --lib -D warnings\` clean for both crates.
- Touches \`vize_croquis\` + \`vize_patina\` only.

Refs #1388

<!-- codesmith:footer -->
---
<a href=\"https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1466\"><picture><source media=\"(prefers-color-scheme: dark)\" srcset=\"https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg\"><source media=\"(prefers-color-scheme: light)\" srcset=\"https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg\"><img alt=\"View with Codesmith\" src=\"https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg\"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->