### PR TITLE
feat(croquis): model petite-vue v-scope bindings in the scope chain

### DIFF
--- a/crates/vize_croquis/src/drawer/helpers.rs
+++ b/crates/vize_croquis/src/drawer/helpers.rs
@@ -5,11 +5,13 @@
 //! - Identifier extraction from expressions (`identifiers`)
 //! - v-for expression parsing (`v_for`)
 //! - v-slot and inline callback parameter extraction (`slots`)
+//! - petite-vue `v-scope` object-key extraction (`v_scope`)
 
 mod identifiers;
 mod keywords;
 mod slots;
 mod v_for;
+mod v_scope;
 
 pub use identifiers::{
     IdentifierRef, extract_identifier_refs_oxc, extract_identifiers_oxc, strip_js_comments,
@@ -17,6 +19,7 @@ pub use identifiers::{
 pub use keywords::{is_builtin_directive, is_component_tag, is_keyword};
 pub use slots::{extract_inline_callback_params, extract_slot_props};
 pub use v_for::{VForScopeAliases, parse_v_for_expression, parse_v_for_scope_expression};
+pub use v_scope::extract_v_scope_bindings;
 
 use vize_carton::{CompactString, String};
 

--- a/crates/vize_croquis/src/drawer/helpers/v_scope.rs
+++ b/crates/vize_croquis/src/drawer/helpers/v_scope.rs
@@ -1,0 +1,164 @@
+//! petite-vue `v-scope` object-literal key extraction.
+//!
+//! `v-scope="{ count: 0, msg: 'x' }"` introduces the object's **top-level**
+//! keys as in-scope names for the element's subtree. This module parses the
+//! object expression and returns each key together with the byte offset of its
+//! key token (relative to the expression source), so the binding can carry an
+//! accurate declaration offset for go-to-definition.
+
+use oxc_allocator::Allocator;
+use oxc_ast::ast::{Expression, PropertyKey};
+use oxc_parser::Parser;
+use oxc_span::SourceType;
+use vize_carton::{CompactString, SmallVec};
+
+/// A v-scope binding: the introduced name and the offset of its key token
+/// relative to the start of the v-scope expression source.
+pub type VScopeBinding = (CompactString, u32);
+
+/// Extract the top-level keys of a `v-scope` object expression.
+///
+/// Returns an empty list when the expression is not an object literal (e.g.
+/// `v-scope` with no value, or a non-object expression), so non-object usages
+/// simply introduce no bindings rather than erroring.
+pub fn extract_v_scope_bindings(expr: &str) -> SmallVec<[VScopeBinding; 4]> {
+    let trimmed = expr.trim();
+    if trimmed.is_empty() {
+        return SmallVec::new();
+    }
+
+    // Wrap as the initializer of a declaration so the object literal parses as
+    // an expression (a bare leading `{` would be a block statement). The prefix
+    // length is fixed, so subtracting it recovers offsets within `trimmed`.
+    const PREFIX: &str = "const __vize_scope = ";
+    #[allow(clippy::disallowed_macros)]
+    let wrapped = format!("{PREFIX}{trimmed}");
+    // Offset of `trimmed` within `wrapped`, plus the original expression's own
+    // leading whitespace that `trim` removed (callers pass absolute offsets
+    // relative to the raw expression source).
+    let leading_ws = (expr.len() - expr.trim_start().len()) as u32;
+    let base = PREFIX.len() as u32 - leading_ws;
+
+    let allocator = Allocator::default();
+    let source_type = SourceType::default().with_typescript(true);
+    let ret = Parser::new(&allocator, &wrapped, source_type).parse();
+
+    let Some(oxc_ast::ast::Statement::VariableDeclaration(var_decl)) = ret.program.body.first()
+    else {
+        return SmallVec::new();
+    };
+    let Some(init) = var_decl.declarations.first().and_then(|d| d.init.as_ref()) else {
+        return SmallVec::new();
+    };
+
+    // Unwrap any parentheses the source carried (`v-scope="({ ... })"`).
+    let mut expr_node = init;
+    while let Expression::ParenthesizedExpression(paren) = expr_node {
+        expr_node = &paren.expression;
+    }
+
+    let Expression::ObjectExpression(obj) = expr_node else {
+        return SmallVec::new();
+    };
+
+    let mut bindings: SmallVec<[VScopeBinding; 4]> = SmallVec::new();
+    for property in obj.properties.iter() {
+        let oxc_ast::ast::ObjectPropertyKind::ObjectProperty(prop) = property else {
+            // Spread elements (`...rest`) do not introduce statically known keys.
+            continue;
+        };
+
+        // Computed keys (`[expr]: ...`) are not statically resolvable names.
+        if prop.computed {
+            continue;
+        }
+
+        let (name, span) = match &prop.key {
+            PropertyKey::StaticIdentifier(ident) => {
+                (CompactString::new(ident.name.as_str()), ident.span)
+            }
+            PropertyKey::StringLiteral(lit) => {
+                let name = lit.value.as_str();
+                if !is_identifier(name) {
+                    continue;
+                }
+                (CompactString::new(name), lit.span)
+            }
+            _ => continue,
+        };
+
+        // `span.start` is relative to `wrapped`; subtracting `base` maps it
+        // back onto the original (untrimmed) expression source.
+        let key_offset = span.start.saturating_sub(base);
+        bindings.push((name, key_offset));
+    }
+
+    bindings
+}
+
+/// Whether `name` is a valid JavaScript identifier (so a quoted key like
+/// `"count"` can become a scope binding, but `"a-b"` cannot).
+fn is_identifier(name: &str) -> bool {
+    let mut chars = name.chars();
+    match chars.next() {
+        Some(c) if c == '_' || c == '$' || c.is_ascii_alphabetic() => {}
+        _ => return false,
+    }
+    chars.all(|c| c == '_' || c == '$' || c.is_ascii_alphanumeric())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::extract_v_scope_bindings;
+
+    fn names(expr: &str) -> Vec<vize_carton::CompactString> {
+        extract_v_scope_bindings(expr)
+            .into_iter()
+            .map(|(n, _)| n)
+            .collect()
+    }
+
+    fn assert_names(expr: &str, expected: &[&str]) {
+        let got = names(expr);
+        let got_strs: Vec<&str> = got.iter().map(|n| n.as_str()).collect();
+        assert_eq!(got_strs, expected, "for expression `{expr}`");
+    }
+
+    #[test]
+    fn extracts_top_level_keys_with_offsets() {
+        let bindings = extract_v_scope_bindings("{ count: 0, msg: 'x' }");
+        assert_eq!(bindings.len(), 2);
+        assert_eq!(bindings[0].0.as_str(), "count");
+        assert_eq!(bindings[0].1, 2); // `count` starts at byte 2
+        assert_eq!(bindings[1].0.as_str(), "msg");
+        assert_eq!(bindings[1].1, 12); // `msg` starts at byte 12
+    }
+
+    #[test]
+    fn handles_quoted_shorthand_and_methods() {
+        assert_names(
+            "{ 'count': 0, inc() { this.count++ }, total }",
+            &["count", "inc", "total"],
+        );
+    }
+
+    #[test]
+    fn ignores_spread_and_computed_keys() {
+        assert_names("{ ...state, [key]: 1, ok: true }", &["ok"]);
+    }
+
+    #[test]
+    fn non_object_yields_no_bindings() {
+        assert!(names("count").is_empty());
+        assert!(names("").is_empty());
+        assert!(names("[1, 2, 3]").is_empty());
+    }
+
+    #[test]
+    fn tolerates_leading_whitespace_offsets() {
+        let bindings = extract_v_scope_bindings("  { count: 0 }");
+        assert_eq!(bindings.len(), 1);
+        // `count` is at byte 4 in the untrimmed source.
+        assert_eq!(bindings[0].1, 4);
+    }
+}

--- a/crates/vize_croquis/src/drawer/template/tests.rs
+++ b/crates/vize_croquis/src/drawer/template/tests.rs
@@ -32,6 +32,103 @@ fn interpolation_guards(template: &str) -> Vec<(std::string::String, Option<std:
         .collect()
 }
 
+/// Draw an (empty) `<script setup>` then the template so undefined-reference
+/// detection is active, returning the names flagged as undefined.
+fn undefined_refs_with_empty_script(template: &str) -> Vec<vize_carton::CompactString> {
+    use vize_armature::parse;
+    use vize_carton::Bump;
+
+    let allocator = Bump::new();
+    let (root, _errors) = parse(&allocator, template);
+    let mut drawer = Drawer::with_options(DrawerOptions::full());
+    // Marks the script as drawn so `detect_undefined` runs over the template.
+    drawer.draw_script_setup("");
+    drawer.draw_template(&root);
+    let summary = drawer.finish();
+
+    summary
+        .undefined_refs
+        .iter()
+        .map(|r| r.name.clone())
+        .collect()
+}
+
+#[test]
+fn v_scope_keys_resolve_in_subtree() {
+    // petite-vue: `count` and `msg` are introduced by v-scope and must not be
+    // reported as undefined inside the element's subtree.
+    let undefined = undefined_refs_with_empty_script(
+        r#"<div v-scope="{ count: 0, msg: 'x' }">{{ count }} {{ msg }}</div>"#,
+    );
+    assert!(
+        !undefined.iter().any(|n| n == "count" || n == "msg"),
+        "v-scope keys should resolve, got undefined refs: {undefined:?}"
+    );
+}
+
+#[test]
+fn v_scope_does_not_leak_outside_subtree() {
+    // `count` is only in scope inside the v-scope element; the sibling
+    // interpolation must still flag it as undefined.
+    let undefined = undefined_refs_with_empty_script(
+        r#"<div><span v-scope="{ count: 0 }">{{ count }}</span><p>{{ count }}</p></div>"#,
+    );
+    assert_eq!(
+        undefined.iter().filter(|n| n.as_str() == "count").count(),
+        1,
+        "v-scope binding must not leak to siblings, got: {undefined:?}"
+    );
+}
+
+#[test]
+fn v_effect_references_resolve_against_v_scope() {
+    // `v-effect` expressions reference v-scope keys; they must resolve.
+    let undefined = undefined_refs_with_empty_script(
+        r#"<div v-scope="{ count: 0 }" v-effect="count > 0"></div>"#,
+    );
+    assert!(
+        !undefined.iter().any(|n| n == "count"),
+        "v-effect should see v-scope key, got: {undefined:?}"
+    );
+}
+
+#[test]
+fn nested_v_scope_shadows_outer() {
+    use vize_armature::parse;
+    use vize_carton::Bump;
+
+    let template = r#"<div v-scope="{ count: 0 }"><span v-scope="{ count: 1, msg: 'x' }">{{ count }}{{ msg }}</span></div>"#;
+
+    let allocator = Bump::new();
+    let (root, _errors) = parse(&allocator, template);
+    let mut drawer = Drawer::with_options(DrawerOptions::full());
+    drawer.draw_script_setup("");
+    drawer.draw_template(&root);
+    let summary = drawer.finish();
+
+    // Offset of the inner `{{ count }}` interpolation.
+    let inner_count_offset = template.find("{{ count }}").unwrap() as u32 + 3;
+    let visible = summary.scopes.bindings_visible_at(inner_count_offset);
+
+    // Inner v-scope's `count` (the first occurrence) shadows the outer one and
+    // its declaration offset points at the inner key, not the outer.
+    let inner_key_offset = template.find("{ count: 1").unwrap() as u32 + "{ ".len() as u32;
+    let count_binding = visible
+        .iter()
+        .find(|(name, _, _)| *name == "count")
+        .expect("count must be visible at inner interpolation");
+    assert_eq!(
+        count_binding.1.declaration_offset, inner_key_offset,
+        "inner v-scope count should shadow outer; visible bindings: {visible:?}"
+    );
+
+    // `msg` from the inner scope is also visible.
+    assert!(
+        visible.iter().any(|(name, _, _)| *name == "msg"),
+        "inner v-scope msg should be visible: {visible:?}"
+    );
+}
+
 #[test]
 fn flat_v_else_branch_gets_negated_guard() {
     // Regression for vuejs/language-tools#5850 / #3787-style narrowing: when the

--- a/crates/vize_croquis/src/drawer/template/visit_element.rs
+++ b/crates/vize_croquis/src/drawer/template/visit_element.rs
@@ -50,6 +50,7 @@ impl Drawer {
             directive_state.key_expression,
             scope_vars,
         );
+        let v_scope_vars_count = self.enter_element_v_scope(directive_state.v_scope, scope_vars);
 
         if let Some(ref mut usage) = component_usage {
             usage.scope_id = self.croquis.scopes.current_id();
@@ -78,6 +79,7 @@ impl Drawer {
             self.pop_element_vif_guard();
         }
 
+        self.exit_element_v_scope(v_scope_vars_count, scope_vars);
         self.exit_element_for_scope(for_vars_count, scope_vars);
         self.exit_element_slot_scope(slot_vars_count, scope_vars);
 

--- a/crates/vize_croquis/src/drawer/template/visit_element/first_pass.rs
+++ b/crates/vize_croquis/src/drawer/template/visit_element/first_pass.rs
@@ -1,8 +1,9 @@
 use crate::drawer::Drawer;
 use crate::drawer::helpers::{
-    ConditionalKind, extract_slot_props, is_builtin_directive, parse_v_for_scope_expression,
+    ConditionalKind, extract_slot_props, extract_v_scope_bindings, is_builtin_directive,
+    parse_v_for_scope_expression,
 };
-use vize_carton::{CompactString, profile, smallvec};
+use vize_carton::{CompactString, SmallVec, profile, smallvec};
 use vize_relief::ast::{ElementNode, ExpressionNode, PropNode};
 
 use super::bounds::element_subtree_end;
@@ -102,6 +103,25 @@ impl Drawer {
                         props_pattern,
                         dir.loc.start.offset,
                     ));
+                } else if dir.name == "scope" && self.options.analyze_template_scopes {
+                    // petite-vue `v-scope="{ ... }"`: the object's top-level
+                    // keys become in-scope names for this element's subtree.
+                    if let Some(ref exp) = dir.exp {
+                        let content = expression_content(exp);
+                        let base = exp.loc().start.offset;
+                        let bindings: SmallVec<[(CompactString, u32); 4]> = profile!(
+                            "croquis.template.v_scope.extract_keys",
+                            extract_v_scope_bindings(content)
+                        )
+                        .into_iter()
+                        .map(|(name, key_offset)| (name, base + key_offset))
+                        .collect();
+
+                        if !bindings.is_empty() {
+                            let end = *subtree_end.get_or_insert_with(|| element_subtree_end(el));
+                            state.v_scope = Some((bindings, el.loc.start.offset, end));
+                        }
+                    }
                 }
             }
         });

--- a/crates/vize_croquis/src/drawer/template/visit_element/scopes.rs
+++ b/crates/vize_croquis/src/drawer/template/visit_element/scopes.rs
@@ -22,10 +22,15 @@ pub(super) type ForScopeInfo = (
     u32,
 );
 
+/// petite-vue `v-scope` info: introduced (name, key_offset) bindings plus the
+/// element subtree span the bindings are visible across.
+pub(super) type VScopeInfo = (SmallVec<[(CompactString, u32); 4]>, u32, u32);
+
 #[derive(Default)]
 pub(super) struct ElementDirectiveState {
     pub(super) slot_scope: Option<SlotScopeInfo>,
     pub(super) for_scope: Option<ForScopeInfo>,
+    pub(super) v_scope: Option<VScopeInfo>,
     pub(super) key_expression: Option<CompactString>,
     pub(super) conditional: Option<(ConditionalKind, Option<CompactString>)>,
 }
@@ -147,6 +152,74 @@ impl Drawer {
         }
 
         for _ in 0..slot_vars_count {
+            scope_vars.pop();
+        }
+        self.croquis.scopes.exit_scope();
+    }
+
+    /// Enter a petite-vue `v-scope` scope, introducing the object's top-level
+    /// keys as bindings for the element subtree.
+    ///
+    /// Modeled on the existing template-scope mechanism (a `v-slot`-kind scope
+    /// with synthetic data) so it nests and shadows like any other template
+    /// scope without adding new public scope types. `v-scope` is petite-vue
+    /// only: when no element carries it, this is never reached and behavior for
+    /// ordinary Vue SFCs is unchanged.
+    pub(super) fn enter_element_v_scope(
+        &mut self,
+        v_scope: Option<VScopeInfo>,
+        scope_vars: &mut Vec<CompactString>,
+    ) -> usize {
+        let Some((bindings, start, end)) = v_scope else {
+            return 0;
+        };
+
+        let count = bindings.len();
+        if count == 0 {
+            return 0;
+        }
+
+        let prop_names: SmallVec<[CompactString; 4]> =
+            bindings.iter().map(|(name, _)| name.clone()).collect();
+
+        self.croquis.scopes.enter_v_slot_scope_with_name_kind(
+            VSlotScopeData {
+                name: CompactString::const_new("v-scope"),
+                props_pattern: None,
+                prop_names: prop_names.iter().cloned().collect(),
+                component: None,
+            },
+            true,
+            start,
+            end,
+        );
+
+        // Point each binding's declaration offset at its key token so
+        // go-to-definition lands on the `v-scope` key.
+        let scope = self.croquis.scopes.current_scope_mut();
+        for (name, key_offset) in &bindings {
+            if let Some(binding) = scope.get_binding_mut(name.as_str()) {
+                binding.declaration_offset = *key_offset;
+            }
+        }
+
+        for name in prop_names {
+            scope_vars.push(name);
+        }
+
+        count
+    }
+
+    pub(super) fn exit_element_v_scope(
+        &mut self,
+        v_scope_vars_count: usize,
+        scope_vars: &mut Vec<CompactString>,
+    ) {
+        if v_scope_vars_count == 0 {
+            return;
+        }
+
+        for _ in 0..v_scope_vars_count {
             scope_vars.pop();
         }
         self.croquis.scopes.exit_scope();


### PR DESCRIPTION
## Problem

petite-vue introduces template-local bindings via `v-scope="{ count: 0, msg: 'x' }"`: the object's top-level keys become in-scope names for that element's subtree. croquis models template scopes (v-for, v-slot) in its scope chain but did **not** model `v-scope`, so references to v-scope keys — and `v-effect` expressions that read them — were treated as undefined, and completion/lint could not see them.

## Fix

Scoped entirely to `vize_croquis`:

- New helper `drawer/helpers/v_scope.rs::extract_v_scope_bindings` parses a `v-scope` object expression with OXC and returns each **top-level** key together with its key-token offset (for go-to-definition). Spread (`...x`), computed (`[k]`), and non-identifier keys are ignored; non-object expressions yield no bindings.
- `first_pass.rs` collects a `v-scope` directive's bindings + subtree span (gated on `analyze_template_scopes`, exactly like v-for/v-slot).
- `visit_element` enters a nested template scope for the subtree (reusing the existing v-slot scope mechanism with synthetic data) and exits it afterward, so bindings **nest and shadow** correctly. No new public scope type / no new field on `Croquis`.

`v-scope` is a petite-vue directive: when no element carries it, the new branch is never reached, so ordinary Vue 3 SFC analysis is byte-for-byte unchanged. `v-effect` expressions are ref-checked generically and now resolve against the v-scope bindings.

## Verification

- `cargo test -p vize_croquis`: 195 passed (9 new tests — key extraction incl. quoted/method/spread/computed, subtree resolution, no sibling leak, v-effect resolution, nested shadowing via `bindings_visible_at`).
- `cargo fmt -p vize_croquis --check`: clean.
- `cargo clippy -p vize_croquis --lib -D warnings`: clean.
- `cargo run -p vize_test_runner --bin coverage`: VDOM 457/457, SFC 167/167 (unchanged); the single Vapor parity miss is a pre-existing v1-alpha tracked failure, unrelated.
- Diff touches only `vize_croquis`.

Refs #1393

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1468"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->