### PR TITLE
refactor(carton): unify offset->line/column mapping into one UTF-16-correct utility

### DIFF
--- a/crates/vize_canon/src/batch.rs
+++ b/crates/vize_canon/src/batch.rs
@@ -37,6 +37,43 @@ pub enum SfcBlockType {
     Style,
 }
 
+impl SfcBlockType {
+    /// The SFC block name as it appears in a `.vue` file / `@vue/compiler-sfc`
+    /// descriptor (`scriptSetup`, `script`, `template`, `style`).
+    pub fn block_name(self) -> &'static str {
+        match self {
+            SfcBlockType::Template => "template",
+            SfcBlockType::Script => "script",
+            SfcBlockType::ScriptSetup => "scriptSetup",
+            SfcBlockType::Style => "style",
+        }
+    }
+}
+
+/// Best-effort fallback byte offset for SFC diagnostics that ship without a
+/// `loc`. Returns the start of the most relevant block (`<script setup>`, then
+/// `<script>`, then `<template>`) so the diagnostic lands somewhere clickable
+/// instead of at file offset 0.
+///
+/// Shared by the canon batch pipeline, the `corsa_server` transport, and the
+/// maestro diagnostic collectors so the fallback location is computed in one
+/// place (#1389). Returns `None` when the descriptor has none of those blocks;
+/// callers fall back to `(0, _)`.
+pub fn sfc_block_fallback_offset(
+    descriptor: &vize_atelier_sfc::SfcDescriptor<'_>,
+) -> Option<(usize, SfcBlockType)> {
+    if let Some(setup) = descriptor.script_setup.as_ref() {
+        return Some((setup.loc.start, SfcBlockType::ScriptSetup));
+    }
+    if let Some(script) = descriptor.script.as_ref() {
+        return Some((script.loc.start, SfcBlockType::Script));
+    }
+    if let Some(template) = descriptor.template.as_ref() {
+        return Some((template.loc.start, SfcBlockType::Template));
+    }
+    None
+}
+
 /// Diagnostic reported by Corsa.
 #[derive(Debug, Clone)]
 pub struct Diagnostic {

--- a/crates/vize_canon/src/batch/virtual_project/diagnostics.rs
+++ b/crates/vize_canon/src/batch/virtual_project/diagnostics.rs
@@ -86,17 +86,14 @@ fn sfc_error_to_diagnostic(
 /// Best-effort fallback location for SFC compile errors that carry no `loc`.
 /// Points at the start of the most relevant block so the diagnostic lands
 /// somewhere clickable instead of at file offset 0.
+///
+/// Block selection is shared with the rest of the toolchain via
+/// [`crate::batch::sfc_block_fallback_offset`] (#1389); when the descriptor has
+/// no blocks we keep the historical `(0, Script)` default.
 fn default_diagnostic_offset(descriptor: &SfcDescriptor) -> (u32, SfcBlockType) {
-    if let Some(setup) = descriptor.script_setup.as_ref() {
-        return (setup.loc.start as u32, SfcBlockType::ScriptSetup);
-    }
-    if let Some(script) = descriptor.script.as_ref() {
-        return (script.loc.start as u32, SfcBlockType::Script);
-    }
-    if let Some(template) = descriptor.template.as_ref() {
-        return (template.loc.start as u32, SfcBlockType::Template);
-    }
-    (0, SfcBlockType::Script)
+    crate::batch::sfc_block_fallback_offset(descriptor)
+        .map(|(offset, block_type)| (offset as u32, block_type))
+        .unwrap_or((0, SfcBlockType::Script))
 }
 
 pub(super) fn invalid_sfc_fallback_virtual_ts() -> CompactString {
@@ -123,21 +120,12 @@ pub(super) fn diagnostic_for_offset(
 }
 
 fn line_column_for_offset(source: &str, offset: u32) -> (u32, u32) {
-    let target = (offset as usize).min(source.len());
-    let mut line = 0;
-    let mut line_start = 0;
-
-    for (index, character) in source.char_indices() {
-        if index >= target {
-            break;
-        }
-        if character == '\n' {
-            line += 1;
-            line_start = index + 1;
-        }
-    }
-
-    (line, target.saturating_sub(line_start) as u32)
+    // LSP `Position.character` is in UTF-16 code units. Shared, UTF-16-correct
+    // implementation lives in `vize_carton::line_index` (#1389). The previous
+    // local copy emitted *byte* columns, which mismatched the editor's
+    // coordinate system on any line containing multi-byte characters (the
+    // #1223 class of bug).
+    vize_carton::line_index::offset_to_line_col(source, offset as usize)
 }
 
 pub(super) fn collect_sfc_block_ranges(descriptor: &SfcDescriptor) -> Vec<SfcBlockRange> {

--- a/crates/vize_canon/src/corsa_server.rs
+++ b/crates/vize_canon/src/corsa_server.rs
@@ -697,39 +697,14 @@ fn script_setup_has_validator_candidates(content: &str) -> bool {
 }
 
 fn sfc_block_fallback_offset(descriptor: &vize_atelier_sfc::SfcDescriptor<'_>) -> usize {
-    if let Some(setup) = descriptor.script_setup.as_ref() {
-        return setup.loc.start;
-    }
-    if let Some(script) = descriptor.script.as_ref() {
-        return script.loc.start;
-    }
-    if let Some(template) = descriptor.template.as_ref() {
-        return template.loc.start;
-    }
-    0
+    // Shared block-selection logic lives in `crate::batch` (#1389).
+    crate::batch::sfc_block_fallback_offset(descriptor).map_or(0, |(offset, _block)| offset)
 }
 
 fn offset_to_line_column(source: &str, offset: usize) -> (u32, u32) {
-    let target = offset.min(source.len());
-    let mut line: u32 = 0;
-    let mut line_start: usize = 0;
-    for (index, ch) in source.char_indices() {
-        if index >= target {
-            break;
-        }
-        if ch == '\n' {
-            line += 1;
-            line_start = index + 1;
-        }
-    }
-    // LSP `Position.character` is in UTF-16 code units. Astral characters
-    // (`len_utf16() == 2`) count as two so the column lines up with
-    // `vue-tsc` / `@vue/language-tools`. (#965)
-    let column: u32 = source[line_start..target]
-        .chars()
-        .map(|ch| ch.len_utf16() as u32)
-        .sum();
-    (line, column)
+    // LSP `Position.character` is in UTF-16 code units. Shared, UTF-16-correct
+    // implementation lives in `vize_carton::line_index` (#1389).
+    vize_carton::line_index::offset_to_line_col(source, offset)
 }
 
 #[cfg(test)]

--- a/crates/vize_canon/src/lib.rs
+++ b/crates/vize_canon/src/lib.rs
@@ -119,7 +119,7 @@ pub use batch::{
     DeclarationEmitOptions, DeclarationEmitResult, DeclarationOutput,
     Diagnostic as BatchDiagnostic, ImportRewriter, ImportSourceMap, PackageManager, SfcBlockType,
     TypeCheckResult as BatchTypeCheckResult, TypeChecker as BatchTypeCheckerTrait, VirtualFile,
-    VirtualProject, VirtualTsGenerator,
+    VirtualProject, VirtualTsGenerator, sfc_block_fallback_offset,
 };
 
 #[cfg(feature = "native")]

--- a/crates/vize_carton/src/lib.rs
+++ b/crates/vize_carton/src/lib.rs
@@ -49,6 +49,7 @@ pub mod flags;
 pub mod general;
 pub mod hash;
 pub mod i18n;
+pub mod line_index;
 pub mod lsp;
 pub mod profiler;
 pub mod source_range;

--- a/crates/vize_carton/src/line_index.rs
+++ b/crates/vize_carton/src/line_index.rs
@@ -1,0 +1,179 @@
+//! Byte-offset to (line, UTF-16 column) mapping for LSP coordinates.
+//!
+//! LSP `Position.character` is measured in **UTF-16 code units**, not bytes and
+//! not Unicode scalar values. Astral (non-BMP) characters such as emoji encode
+//! as a UTF-16 surrogate pair (`char::len_utf16() == 2`) and therefore advance
+//! the column by two, matching what `vue-tsc` / `@vue/language-tools` report.
+//!
+//! This module is the single home for that column math. Several diagnostic and
+//! semantic-token collectors across `vize_canon` and `vize_maestro` used to
+//! hand-roll it; at least one copy counted **bytes** instead of UTF-16 code
+//! units (the #1223 class of bug). Centralizing it here keeps the conversion
+//! correct in one place. See issue #1389.
+
+use crate::lsp::Position;
+
+/// Precomputed byte offsets of every line start in a source string.
+///
+/// Building this once and reusing it turns the per-call `O(offset)` scan of
+/// [`offset_to_line_col`] into a binary search over line starts plus a short
+/// UTF-16 column scan within the target line. Callers that map many offsets
+/// against the same `content` (diagnostics collectors, semantic-token
+/// collectors) build it once and thread it through.
+pub struct LineIndex<'a> {
+    source: &'a str,
+    /// Byte offset of the start of each line. `line_starts[0]` is always `0`.
+    line_starts: Vec<usize>,
+}
+
+impl<'a> LineIndex<'a> {
+    /// Build a line index in a single pass over `source`.
+    pub fn new(source: &'a str) -> Self {
+        let mut line_starts = Vec::with_capacity(source.len() / 32 + 1);
+        line_starts.push(0);
+        for (idx, byte) in source.bytes().enumerate() {
+            if byte == b'\n' {
+                line_starts.push(idx + 1);
+            }
+        }
+        Self {
+            source,
+            line_starts,
+        }
+    }
+
+    /// Convert a byte offset to `(line, column)`, both 0-indexed for LSP.
+    ///
+    /// `column` is measured in UTF-16 code units. Offsets past the end of the
+    /// source are clamped. An offset that falls mid-character counts the partial
+    /// character (so it never panics), matching the legacy break-at-top scans.
+    ///
+    /// `\r\n` is handled naturally: the `\r` is an ordinary character preceding
+    /// the `\n`, so the column at end-of-line includes it and the next line
+    /// starts immediately after the `\n`.
+    pub fn line_col(&self, offset: usize) -> (u32, u32) {
+        let offset = offset.min(self.source.len());
+
+        // Greatest line start <= offset.
+        let line = match self.line_starts.binary_search(&offset) {
+            Ok(line) => line,
+            Err(next) => next - 1,
+        };
+        let line_start = self.line_starts[line];
+
+        // Sum UTF-16 code units of every character on this line whose byte
+        // start is before `offset`.
+        let mut col = 0u32;
+        for (i, ch) in self.source[line_start..].char_indices() {
+            if line_start + i >= offset {
+                break;
+            }
+            col += ch.len_utf16() as u32;
+        }
+
+        (line as u32, col)
+    }
+
+    /// Convert a byte offset to an LSP [`Position`].
+    pub fn position(&self, offset: usize) -> Position {
+        let (line, character) = self.line_col(offset);
+        Position { line, character }
+    }
+}
+
+/// Convert a byte offset to `(line, column)`, both 0-indexed for LSP, with
+/// `column` in UTF-16 code units.
+///
+/// Thin wrapper over [`LineIndex`] for single-shot callers. Hot paths that map
+/// many offsets against the same content should build a [`LineIndex`] once and
+/// call [`LineIndex::line_col`] instead.
+pub fn offset_to_line_col(source: &str, offset: usize) -> (u32, u32) {
+    LineIndex::new(source).line_col(offset)
+}
+
+/// Convert a byte offset to an LSP [`Position`] (single-shot convenience).
+pub fn offset_to_position(source: &str, offset: usize) -> Position {
+    LineIndex::new(source).position(offset)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{LineIndex, offset_to_line_col};
+
+    #[test]
+    fn zero_indexed_for_lsp() {
+        assert_eq!(offset_to_line_col("one\ntwo", 0), (0, 0));
+        assert_eq!(offset_to_line_col("one\ntwo", 3), (0, 3));
+        assert_eq!(offset_to_line_col("one\ntwo", 4), (1, 0));
+        assert_eq!(offset_to_line_col("one\ntwo", 6), (1, 2));
+    }
+
+    #[test]
+    fn clamps_offset_past_end() {
+        assert_eq!(offset_to_line_col("ab", 99), (0, 2));
+    }
+
+    #[test]
+    fn counts_utf16_code_units_for_non_bmp_char() {
+        // U+1F600 GRINNING FACE: 4 UTF-8 bytes, 2 UTF-16 code units (surrogate
+        // pair). The column at the byte just after it must be 2, not 1 (chars)
+        // and not 4 (bytes).
+        let source = "😀x";
+        let emoji_bytes = '😀'.len_utf8();
+        assert_eq!(emoji_bytes, 4);
+        // Just after the emoji: 2 UTF-16 code units.
+        assert_eq!(offset_to_line_col(source, emoji_bytes), (0, 2));
+        // Just after the trailing 'x': 3 UTF-16 code units.
+        assert_eq!(offset_to_line_col(source, emoji_bytes + 1), (0, 3));
+    }
+
+    #[test]
+    fn non_bmp_char_after_text() {
+        let source = "const icon = \"😀\"; missing";
+        let offset = source.find("missing").unwrap();
+        // 13 chars `const icon = ` + `"` (1) + emoji (2 UTF-16 units) + `"; ` (3)
+        // = 13 + 1 + 2 + 3 = 19.
+        assert_eq!(offset_to_line_col(source, offset), (0, 19));
+    }
+
+    #[test]
+    fn crlf_line_endings() {
+        let source = "ab\r\ncd";
+        // End of first line, on the '\r'.
+        assert_eq!(offset_to_line_col(source, 2), (0, 2));
+        // On the '\n' itself: still line 0, column counts the '\r' too.
+        assert_eq!(offset_to_line_col(source, 3), (0, 3));
+        // Start of the second line, immediately after '\n'.
+        assert_eq!(offset_to_line_col(source, 4), (1, 0));
+        // 'd'.
+        assert_eq!(offset_to_line_col(source, 5), (1, 1));
+    }
+
+    #[test]
+    fn crlf_with_non_bmp_char() {
+        let source = "😀\r\n😀";
+        let first = '😀'.len_utf8(); // 4
+        // After the first emoji, before '\r'.
+        assert_eq!(offset_to_line_col(source, first), (0, 2));
+        // Start of second line.
+        assert_eq!(offset_to_line_col(source, first + 2), (1, 0));
+        // After the second emoji.
+        assert_eq!(offset_to_line_col(source, first + 2 + first), (1, 2));
+    }
+
+    #[test]
+    fn line_index_matches_single_shot() {
+        let source = "alpha\nβγ😀δ\r\nlast line";
+        let index = LineIndex::new(source);
+        for offset in 0..=source.len() {
+            // Skip offsets that fall inside a multi-byte char boundary for the
+            // single-shot helper's char_indices alignment; both implementations
+            // share the same break-at-top semantics, so compare directly.
+            assert_eq!(
+                index.line_col(offset),
+                offset_to_line_col(source, offset),
+                "mismatch at offset {offset}"
+            );
+        }
+    }
+}

--- a/crates/vize_maestro/src/ide/code_action.rs
+++ b/crates/vize_maestro/src/ide/code_action.rs
@@ -10,6 +10,8 @@ use super::IdeContext;
 use tower_lsp::lsp_types::{
     CodeAction, CodeActionKind, CodeActionOrCommand, Position, Range, TextEdit, WorkspaceEdit,
 };
+// Shared, UTF-16-correct offset->(line, column) conversion (#1389).
+use vize_carton::line_index::offset_to_line_col;
 
 /// Code action service for providing quick fixes and refactorings.
 pub struct CodeActionService;
@@ -564,28 +566,6 @@ impl CodeActionService {
             change_annotations: None,
         })
     }
-}
-
-/// Convert byte offset to (line, column) - both 0-indexed for LSP.
-fn offset_to_line_col(source: &str, offset: usize) -> (u32, u32) {
-    let mut line = 0u32;
-    let mut col = 0u32;
-    let mut current_offset = 0;
-
-    for ch in source.chars() {
-        if current_offset >= offset {
-            break;
-        }
-        if ch == '\n' {
-            line += 1;
-            col = 0;
-        } else {
-            col += ch.len_utf16() as u32;
-        }
-        current_offset += ch.len_utf8();
-    }
-
-    (line, col)
 }
 
 fn template_position(template_start_line: u32, line: u32, character: u32) -> Position {

--- a/crates/vize_maestro/src/ide/diagnostics/collectors.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/collectors.rs
@@ -347,7 +347,8 @@ impl DiagnosticService {
         } else {
             // Fall back to the start of the most relevant block so the
             // diagnostic lands somewhere clickable in the editor.
-            let (offset, _block) = sfc_block_fallback_offset(descriptor);
+            let offset = vize_canon::sfc_block_fallback_offset(descriptor)
+                .map_or(0, |(offset, _block)| offset);
             let (line, column) = line_index.line_col(offset);
             Range {
                 start: Position {
@@ -626,21 +627,6 @@ fn script_source_type(lang: Option<&str>) -> Option<SourceType> {
 /// `crates/vize_canon/src/batch/virtual_project.rs`.
 fn script_setup_has_validator_candidates(content: &str) -> bool {
     content.contains("defineProps<") && content.contains("= defineProps")
-}
-
-/// Best-effort fallback offset (byte) for SFC compile errors that ship
-/// without a `loc`. Returns the start of the most relevant block.
-fn sfc_block_fallback_offset(descriptor: &SfcDescriptor<'_>) -> (usize, &'static str) {
-    if let Some(setup) = descriptor.script_setup.as_ref() {
-        return (setup.loc.start, "scriptSetup");
-    }
-    if let Some(script) = descriptor.script.as_ref() {
-        return (script.loc.start, "script");
-    }
-    if let Some(template) = descriptor.template.as_ref() {
-        return (template.loc.start, "template");
-    }
-    (0, "")
 }
 
 fn diagnostic_span(error: &oxc_diagnostics::OxcDiagnostic, source_len: usize) -> (usize, usize) {

--- a/crates/vize_maestro/src/ide/diagnostics/line_index.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/line_index.rs
@@ -1,75 +1,9 @@
 //! Byte-offset to (line, UTF-16 column) mapping for LSP coordinates.
+//!
+//! Re-exports the shared, UTF-16-correct utility from `vize_carton`. The column
+//! math (UTF-16 code units, so astral characters count as two) lives in exactly
+//! one place; see `vize_carton::line_index` and issue #1389.
 
-/// Precomputed byte offsets of every line start in a source string.
-///
-/// Building this once and reusing it turns the per-call O(offset) scan of
-/// [`offset_to_line_col`] into a binary search over line starts plus a short
-/// UTF-16 column scan within the target line. Callers that map many offsets
-/// against the same `content` (the diagnostics collectors, the semantic-token
-/// collectors) build it once and thread it through.
-///
-/// `line_col` reproduces [`offset_to_line_col`] byte-for-byte, including the
-/// UTF-16 code-unit column semantics LSP requires.
-pub(in crate::ide) struct LineIndex<'a> {
-    source: &'a str,
-    /// Byte offset of the start of each line. `line_starts[0]` is always `0`.
-    line_starts: Vec<usize>,
-}
-
-impl<'a> LineIndex<'a> {
-    /// Build a line index in a single pass over `source`.
-    pub(in crate::ide) fn new(source: &'a str) -> Self {
-        let mut line_starts = Vec::with_capacity(source.len() / 32 + 1);
-        line_starts.push(0);
-        for (idx, byte) in source.bytes().enumerate() {
-            if byte == b'\n' {
-                line_starts.push(idx + 1);
-            }
-        }
-        Self {
-            source,
-            line_starts,
-        }
-    }
-
-    /// Convert a byte offset to (line, column), both 0-indexed for LSP.
-    ///
-    /// `column` is measured in UTF-16 code units, matching the editor's
-    /// coordinate system. Offsets past the end of the source are clamped,
-    /// matching the natural EOF behavior of the legacy scan.
-    pub(in crate::ide) fn line_col(&self, offset: usize) -> (u32, u32) {
-        let offset = offset.min(self.source.len());
-
-        // Greatest line start <= offset.
-        let line = match self.line_starts.binary_search(&offset) {
-            Ok(line) => line,
-            Err(next) => next - 1,
-        };
-        let line_start = self.line_starts[line];
-
-        // Sum UTF-16 code units of every character on this line whose byte
-        // start is before `offset`. Bounded to the target line, and tolerant of
-        // an `offset` that falls mid-character (it counts the partial char,
-        // matching the legacy scan's break-at-top behavior) so it never panics.
-        let mut col = 0u32;
-        for (i, ch) in self.source[line_start..].char_indices() {
-            if line_start + i >= offset {
-                break;
-            }
-            col += ch.len_utf16() as u32;
-        }
-
-        (line as u32, col)
-    }
-}
-
-/// Convert byte offset to (line, column) - both 0-indexed for LSP.
-///
-/// Thin wrapper over [`LineIndex`] for single-shot callers. Hot paths that map
-/// many offsets against the same content build a [`LineIndex`] once and call
-/// [`LineIndex::line_col`] instead, so the only remaining caller is the parity
-/// unit test below.
+pub(in crate::ide) use vize_carton::line_index::LineIndex;
 #[cfg(test)]
-pub(in crate::ide) fn offset_to_line_col(source: &str, offset: usize) -> (u32, u32) {
-    LineIndex::new(source).line_col(offset)
-}
+pub(in crate::ide) use vize_carton::line_index::offset_to_line_col;

--- a/crates/vize_maestro/src/ide/semantic_tokens/encoding.rs
+++ b/crates/vize_maestro/src/ide/semantic_tokens/encoding.rs
@@ -6,75 +6,11 @@ use tower_lsp::lsp_types::SemanticToken;
 
 use super::types::AbsoluteToken;
 
-/// Precomputed byte offsets of every line start in a source string.
-///
-/// Building this once and reusing it turns the per-call O(offset) scan of
-/// [`offset_to_line_col`] into a binary search over line starts plus a short
-/// UTF-16 column scan within the target line. Token collectors that map many
-/// offsets against the same `content` build it once and thread it through.
-///
-/// `line_col` reproduces [`offset_to_line_col`] byte-for-byte, including the
-/// UTF-16 code-unit column semantics LSP requires.
-pub(crate) struct LineIndex<'a> {
-    source: &'a str,
-    /// Byte offset of the start of each line. `line_starts[0]` is always `0`.
-    line_starts: Vec<usize>,
-}
-
-impl<'a> LineIndex<'a> {
-    /// Build a line index in a single pass over `source`.
-    pub(crate) fn new(source: &'a str) -> Self {
-        let mut line_starts = Vec::with_capacity(source.len() / 32 + 1);
-        line_starts.push(0);
-        for (idx, byte) in source.bytes().enumerate() {
-            if byte == b'\n' {
-                line_starts.push(idx + 1);
-            }
-        }
-        Self {
-            source,
-            line_starts,
-        }
-    }
-
-    /// Convert a byte offset to (line, column), both 0-indexed for LSP.
-    ///
-    /// `column` is measured in UTF-16 code units. Offsets past the end of the
-    /// source are clamped, matching the natural EOF behavior of the legacy scan.
-    pub(crate) fn line_col(&self, offset: usize) -> (u32, u32) {
-        let offset = offset.min(self.source.len());
-
-        // Greatest line start <= offset.
-        let line = match self.line_starts.binary_search(&offset) {
-            Ok(line) => line,
-            Err(next) => next - 1,
-        };
-        let line_start = self.line_starts[line];
-
-        // Sum UTF-16 code units of every character on this line whose byte
-        // start is before `offset`. Bounded to the target line, and tolerant of
-        // an `offset` that falls mid-character (it counts the partial char,
-        // matching the legacy scan's break-at-top behavior) so it never panics.
-        let mut col = 0u32;
-        for (i, ch) in self.source[line_start..].char_indices() {
-            if line_start + i >= offset {
-                break;
-            }
-            col += ch.len_utf16() as u32;
-        }
-
-        (line as u32, col)
-    }
-}
-
-/// Convert byte offset to (line, column), both 0-indexed for LSP.
-///
-/// Thin wrapper over [`LineIndex`] for single-shot callers. Hot paths that map
-/// many offsets against the same content should build a [`LineIndex`] once and
-/// call [`LineIndex::line_col`] instead.
-pub(crate) fn offset_to_line_col(source: &str, offset: usize) -> (u32, u32) {
-    LineIndex::new(source).line_col(offset)
-}
+// Shared, UTF-16-correct line-index utility lives in `vize_carton::line_index`
+// (#1389). Both the binary-search [`LineIndex`] and the single-shot
+// [`offset_to_line_col`] helper are re-exported here so existing call sites and
+// the perf characteristics are unchanged.
+pub(crate) use vize_carton::line_index::{LineIndex, offset_to_line_col};
 
 /// Return the LSP token length for text, measured in UTF-16 code units.
 pub(crate) fn utf16_len(text: &str) -> u32 {

--- a/crates/vize_maestro/src/ide/type_service/diagnostics.rs
+++ b/crates/vize_maestro/src/ide/type_service/diagnostics.rs
@@ -290,26 +290,9 @@ impl TypeService {
 }
 
 /// Convert byte offset to (line, column), both 0-indexed for LSP.
-pub(super) fn offset_to_line_col(source: &str, offset: usize) -> (u32, u32) {
-    let mut line = 0u32;
-    let mut col = 0u32;
-    let mut current_offset = 0;
-
-    for ch in source.chars() {
-        if current_offset >= offset {
-            break;
-        }
-        if ch == '\n' {
-            line += 1;
-            col = 0;
-        } else {
-            col += ch.len_utf16() as u32;
-        }
-        current_offset += ch.len_utf8();
-    }
-
-    (line, col)
-}
+///
+/// Shared, UTF-16-correct implementation in `vize_carton::line_index` (#1389).
+pub(super) use vize_carton::line_index::offset_to_line_col;
 
 #[cfg(test)]
 mod diagnostics_tests {


### PR DESCRIPTION
## What

The byte-offset → `(line, column)` conversion used at the LSP diagnostic
boundary was hand-rolled in several places across `vize_canon` and
`vize_maestro`. This PR consolidates it into one shared, UTF-16-correct
utility, `vize_carton::line_index` (per #1389 PR7).

New module `vize_carton::line_index`:
- `LineIndex<'a>` — binary-search line-start index for hot paths that map
  many offsets against the same content (diagnostics + semantic-token
  collectors).
- `offset_to_line_col` / `offset_to_position` — single-shot helpers.

## Copies unified

offset → (line, UTF-16 column):
- `vize_canon::corsa_server::offset_to_line_column` → delegates to carton
- `vize_canon::batch::virtual_project::diagnostics::line_column_for_offset` →
  delegates to carton (**was buggy** — see below)
- `vize_maestro::ide::code_action::offset_to_line_col` → carton
- `vize_maestro::ide::type_service::diagnostics::offset_to_line_col` → carton
- `vize_maestro::ide::semantic_tokens::encoding::{LineIndex, offset_to_line_col}`
  → re-export carton (byte-for-byte identical struct)
- `vize_maestro::ide::diagnostics::line_index::{LineIndex, offset_to_line_col}`
  → re-export carton

`sfc_block_fallback_offset` (block-selection fallback): three copies
(`corsa_server`, `batch/virtual_project/diagnostics`, maestro `collectors`)
unified into one `vize_canon::batch::sfc_block_fallback_offset` returning
`Option<(usize, SfcBlockType)>`, plus a shared `SfcBlockType::block_name()`.
It takes an atelier `SfcDescriptor`, so it lives in canon (which already
depends on `vize_atelier_sfc`) rather than carton, which cannot depend on
atelier. atelier was not touched.

Out of scope / intentionally left: `vize_canon::batch::source_map`
(`offset_to_line_col` + its `line_col_to_offset` inverse) and the
`batch::executor::diagnostics::LineIndex` (also a paired
offset↔line/col coordinate system with an inverse). These are
self-consistent roundtrip pairs, not the LSP-boundary fallbacks #1389
flags; touching them risks changing roundtrip behavior.

## UTF-16 correctness

Columns are counted in **UTF-16 code units** (`char::len_utf16()`), the
LSP convention, so astral/non-BMP characters such as emoji advance the
column by 2 — matching `vue-tsc` / `@vue/language-tools`.

The `batch/virtual_project/diagnostics` copy previously emitted **byte**
columns (`target - line_start`), so SFC-compile diagnostics without a
`loc` landed at the wrong column on any line containing a multi-byte
character (the #1223 class of bug). Migrating it to the shared utility
fixes this; it had no dedicated unit test asserting the buggy behavior.

New unit tests in `vize_carton::line_index` prove correctness for a
non-BMP char (U+1F600 grinning face: 4 UTF-8 bytes, 2 UTF-16 code units),
CRLF line endings, CRLF interleaved with non-BMP chars, EOF clamping, and
`LineIndex`/single-shot parity across every offset.

## Verification

- `cargo test -p vize_carton -p vize_canon -p vize_maestro --lib` — 144 / 336 / 308 pass
- `cargo fmt --check` clean
- `cargo clippy --lib -D warnings` clean for all three crates
- No semver-breaking changes: only new `pub fn`s / a new `pub mod`; no new
  pub fields on all-pub structs.

Refs #1389

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1469"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783796743&installation_id=136613492&pr_number=1469&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1469&signature=db69d13343c28d5e81a37dd2f084df98efd3d1d874d75c2ee237a58f084ea829"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->