### PR TITLE
feat(atelier): desugar Vue 2 .native and numeric keycode v-on modifiers

### DIFF
--- a/crates/vize_atelier_core/src/transform/context.rs
+++ b/crates/vize_atelier_core/src/transform/context.rs
@@ -320,6 +320,25 @@ impl<'a> TransformContext<'a> {
             .supports_filters
     }
 
+    /// Whether the resolved dialect is the Vue 2 / 2.7 template line, which
+    /// carried the removed v-on event-modifier sugar (`@click.native`, numeric
+    /// keycodes such as `@keyup.13`). Resolved from
+    /// [`vize_armature::legacy::LegacyVueVersion::from_dialect`] for the dialect
+    /// on [`TransformOptions::dialect`](crate::options::TransformOptions::dialect).
+    ///
+    /// Always `false` for the default Vue 3 dialect (and every other legacy
+    /// line), so the Vue 2 event-modifier desugaring is never entered there and
+    /// the directive's modifiers stay byte-identical to today's output.
+    /// Legacy-only.
+    #[cfg(feature = "legacy")]
+    #[inline]
+    pub(crate) fn supports_v2_event_sugar(&self) -> bool {
+        matches!(
+            vize_armature::legacy::LegacyVueVersion::from_dialect(self.options.dialect),
+            Some(vize_armature::legacy::LegacyVueVersion::V2)
+        )
+    }
+
     /// Add an identifier to current scope
     pub fn add_identifier(&mut self, id: impl Into<CompactString>) {
         self.scope_chain

--- a/crates/vize_atelier_core/src/transform/element.rs
+++ b/crates/vize_atelier_core/src/transform/element.rs
@@ -200,6 +200,22 @@ fn process_element_props<'a>(ctx: &mut TransformContext<'a>, el: &mut Box<'a, El
     let allocator = ctx.allocator;
     let is_component = el.tag_type == ElementType::Component;
 
+    // Vue 2 v-on event-modifier sugar (`@click.native`, numeric keycodes such
+    // as `@keyup.13`). Legacy-only and dialect-gated: a no-op for the default
+    // Vue 3 dialect (and every other legacy line), so the directive modifiers
+    // stay byte-identical there. Runs before any modifier classification so
+    // `.native` is stripped and numeric keycodes are rewritten to key names.
+    #[cfg(feature = "legacy")]
+    if ctx.supports_v2_event_sugar() {
+        for prop in el.props.iter_mut() {
+            if let PropNode::Directive(dir) = prop
+                && dir.name == "on"
+            {
+                crate::transforms::legacy::desugar_v2_v_on_modifiers(dir);
+            }
+        }
+    }
+
     // Process directive expressions with _ctx prefix if needed
     if ctx.options.prefix_identifiers || ctx.options.is_ts {
         process_directive_expressions(ctx, el);

--- a/crates/vize_atelier_core/src/transforms.rs
+++ b/crates/vize_atelier_core/src/transforms.rs
@@ -4,8 +4,10 @@
 //! directives and node types during the transform phase.
 
 pub mod hoist_static;
-/// Legacy Vue (v2 / v2.7) template-sugar pre-transforms. Compiled only with the
-/// `legacy` cargo feature; a no-op for the default Vue 3 dialect.
+/// Legacy Vue (v2 / v2.7) template-sugar pre-transforms (`.sync`, scoped-slot
+/// attributes) and v-on event-modifier sugar (`.native`, numeric keycodes).
+/// Compiled only with the `legacy` cargo feature; a no-op for the default Vue 3
+/// dialect.
 #[cfg(feature = "legacy")]
 pub mod legacy;
 /// Vue 2 pipe-filter parsing/rewriting. Legacy-only and dialect-gated; see the

--- a/crates/vize_atelier_core/src/transforms/legacy.rs
+++ b/crates/vize_atelier_core/src/transforms/legacy.rs
@@ -2,9 +2,8 @@
 //!
 //! Vue 2 carried a handful of template-syntax conveniences that Vue 3 removed in
 //! favor of more explicit forms. This module desugars the high-value, cleanly
-//! bounded subset into their Vue 3 equivalents **once, before the main transform
-//! traversal**, so the rest of the pipeline only ever sees modern Vue 3 AST and
-//! needs no per-node legacy branches:
+//! bounded subset into their Vue 3 equivalents so the rest of the pipeline only
+//! ever sees modern Vue 3 AST and needs no per-node legacy branches:
 //!
 //! - **`.sync` modifier** — `:foo.sync="bar"` is Vue 2 sugar for a two-way bind.
 //!   It expands to `:foo="bar"` plus an `@update:foo="bar = $event"` listener,
@@ -19,6 +18,18 @@
 //!   2.1, is the older alias for `slot-scope`, added in 2.5). The companion
 //!   `slot="name"` static attribute supplies the slot argument and is consumed.
 //!
+//! The `.sync` and scoped-slot rewrites run **once, before the main transform
+//! traversal**, via [`desugar_legacy_template`].
+//!
+//! - **v-on event-modifier sugar** (`@click.native`, numeric keycodes such as
+//!   `@keyup.13`) — both surfaces were removed in Vue 3. Unlike the rewrites
+//!   above, this one is applied per v-on directive during element processing
+//!   (see [`desugar_v2_v_on_modifiers`]), gated by
+//!   [`supports_v2_event_sugar`](crate::transform::TransformContext::supports_v2_event_sugar).
+//!   `.native` is stripped (Vue 3 lets component listeners fall through to the
+//!   root by default) and numeric keyCodes are rewritten to their Vue 3 key
+//!   names (`13` -> `enter`), so `@keyup.13` behaves like `@keyup.enter`.
+//!
 //! # Zero-cost contract
 //!
 //! This module is compiled only under the `legacy` cargo feature, and even then
@@ -27,7 +38,9 @@
 //! dialect (`LegacyDialectCapabilities::VUE3`) the entry point is a single
 //! capability-field read that short-circuits before touching the tree — so a
 //! `legacy`-enabled build compiling Vue 3 sources takes a branch-identical path
-//! to the default build, which never compiles this file at all.
+//! to the default build, which never compiles this file at all. The per-element
+//! [`desugar_v2_v_on_modifiers`] is likewise only reached under the Vue 2
+//! dialect (its call site is guarded by `supports_v2_event_sugar`).
 
 use vize_armature::legacy::LegacyDialectCapabilities;
 use vize_carton::{Box, Bump, String, Vec};
@@ -228,15 +241,65 @@ fn desugar_scoped_slot_attrs<'a>(allocator: &'a Bump, el: &mut ElementNode<'a>) 
     el.props.push(v_slot);
 }
 
+/// Map a Vue 2 numeric `keyCode` modifier to its Vue 3 key name, mirroring
+/// `@vue/compiler-dom`'s removed `keyCodes` table (the aliases Vue 2 shipped as
+/// `config.keyCodes` defaults).
+///
+/// Returns `None` for any number Vue 2 had no built-in alias for; the caller
+/// leaves such a modifier unchanged.
+fn keycode_to_key_name(code: &str) -> Option<&'static str> {
+    // Mirrors Vue 2's `genGuard` keyCodes plus the `keyNames` map used by
+    // `withKeys`: enter/tab/delete/esc/space/up/down/left/right, with `delete`
+    // covering both Backspace (8) and Delete (46) as Vue 2 did.
+    Some(match code {
+        "8" => "delete", // Backspace — Vue 2 grouped 8 and 46 under `delete`.
+        "9" => "tab",
+        "13" => "enter",
+        "27" => "esc",
+        "32" => "space",
+        "37" => "left",
+        "38" => "up",
+        "39" => "right",
+        "40" => "down",
+        "46" => "delete",
+        _ => return None,
+    })
+}
+
+/// Desugar Vue 2 v-on event-modifier sugar on one directive, in place.
+///
+/// Strips `.native` and rewrites built-in numeric keyCode modifiers to their
+/// Vue 3 key names. Only ever called for v-on (`name == "on"`) directives under
+/// the Vue 2 dialect; a no-op for any directive that carries neither surface.
+pub(crate) fn desugar_v2_v_on_modifiers(dir: &mut DirectiveNode<'_>) {
+    if dir.modifiers.is_empty() {
+        return;
+    }
+
+    // `.native` is removed wholesale; everything else is kept (with numeric
+    // keycodes rewritten in place). `retain_mut` keeps the arena `Vec` order.
+    dir.modifiers.retain_mut(|modifier| {
+        if modifier.content.as_str() == "native" {
+            return false;
+        }
+        if let Some(name) = keycode_to_key_name(modifier.content.as_str()) {
+            modifier.content = String::new(name);
+        }
+        true
+    });
+}
+
 #[cfg(test)]
 #[allow(clippy::disallowed_macros)]
 mod tests {
     use super::*;
+    use crate::ast::{SimpleExpressionNode, SourceLocation};
     use crate::codegen::generate;
     use crate::options::{CodegenOptions, TransformOptions};
     use crate::parser::parse;
     use crate::transform::transform;
     use vize_armature::legacy::{LegacyDialectCapabilities, LegacyVueVersion};
+    use vize_carton::Vec as ArenaVec;
     use vize_carton::config::VueVersion;
 
     /// Full pipeline (parse -> transform -> codegen) under a given dialect.
@@ -471,5 +534,96 @@ mod tests {
         // dialect is V3 or V2 (the pre-transform leaves it untouched).
         let src = r#"<div :id="x" @click="go">{{ msg }}</div>"#;
         assert_eq!(compile(src, VueVersion::V3), compile(src, VueVersion::V2));
+    }
+
+    // --- v-on event-modifier sugar (`.native`, numeric keycodes) ---
+
+    fn directive_with_modifiers<'a>(allocator: &'a Bump, modifiers: &[&str]) -> DirectiveNode<'a> {
+        let mut dir = DirectiveNode::new(allocator, "on", SourceLocation::STUB);
+        let mut mods = ArenaVec::new_in(allocator);
+        for m in modifiers {
+            mods.push(SimpleExpressionNode::new(*m, false, SourceLocation::STUB));
+        }
+        dir.modifiers = mods;
+        dir
+    }
+
+    /// Assert the directive's modifier list (by content, in order) equals
+    /// `expected`. Stays on `&str` to avoid the crate's disallowed std
+    /// `String`.
+    fn assert_modifiers(dir: &DirectiveNode<'_>, expected: &[&str]) {
+        assert_eq!(dir.modifiers.len(), expected.len());
+        for (got, want) in dir.modifiers.iter().zip(expected) {
+            assert_eq!(got.content.as_str(), *want);
+        }
+    }
+
+    #[test]
+    fn strips_native_modifier() {
+        let allocator = Bump::new();
+        let mut dir = directive_with_modifiers(&allocator, &["native"]);
+        desugar_v2_v_on_modifiers(&mut dir);
+        assert!(dir.modifiers.is_empty());
+    }
+
+    #[test]
+    fn strips_native_keeps_other_modifiers() {
+        let allocator = Bump::new();
+        let mut dir = directive_with_modifiers(&allocator, &["native", "stop"]);
+        desugar_v2_v_on_modifiers(&mut dir);
+        assert_modifiers(&dir, &["stop"]);
+    }
+
+    #[test]
+    fn maps_common_numeric_keycodes() {
+        let allocator = Bump::new();
+        for (code, name) in [
+            ("8", "delete"),
+            ("9", "tab"),
+            ("13", "enter"),
+            ("27", "esc"),
+            ("32", "space"),
+            ("37", "left"),
+            ("38", "up"),
+            ("39", "right"),
+            ("40", "down"),
+            ("46", "delete"),
+        ] {
+            let mut dir = directive_with_modifiers(&allocator, &[code]);
+            desugar_v2_v_on_modifiers(&mut dir);
+            assert_modifiers(&dir, &[name]);
+        }
+    }
+
+    #[test]
+    fn leaves_unmapped_numeric_keycode_untouched() {
+        let allocator = Bump::new();
+        let mut dir = directive_with_modifiers(&allocator, &["65"]);
+        desugar_v2_v_on_modifiers(&mut dir);
+        assert_modifiers(&dir, &["65"]);
+    }
+
+    #[test]
+    fn leaves_named_modifiers_untouched() {
+        let allocator = Bump::new();
+        let mut dir = directive_with_modifiers(&allocator, &["stop", "prevent", "enter"]);
+        desugar_v2_v_on_modifiers(&mut dir);
+        assert_modifiers(&dir, &["stop", "prevent", "enter"]);
+    }
+
+    #[test]
+    fn combined_native_and_keycode() {
+        let allocator = Bump::new();
+        let mut dir = directive_with_modifiers(&allocator, &["native", "13"]);
+        desugar_v2_v_on_modifiers(&mut dir);
+        assert_modifiers(&dir, &["enter"]);
+    }
+
+    #[test]
+    fn no_modifiers_is_noop() {
+        let allocator = Bump::new();
+        let mut dir = directive_with_modifiers(&allocator, &[]);
+        desugar_v2_v_on_modifiers(&mut dir);
+        assert!(dir.modifiers.is_empty());
     }
 }

--- a/crates/vize_atelier_core/tests/legacy_event_modifiers.rs
+++ b/crates/vize_atelier_core/tests/legacy_event_modifiers.rs
@@ -1,0 +1,153 @@
+//! Vue 2 v-on event-modifier sugar codegen parity + zero-cost dialect gating.
+//!
+//! Compiled only under `--features legacy`; the whole file is gated so the
+//! default Vue 3 build never sees it. Asserts that:
+//!
+//! - under dialect V2 (and V2.7), `@keyup.13="x"` lowers to the same key-name
+//!   guard Vue 3 emits for `@keyup.enter` (`_withKeys(..., ["enter"])`), and
+//!   `@click.native="x"` on a component drops the removed `.native` modifier;
+//! - under the default dialect V3, the *same* numeric keycode stays a raw
+//!   `["13"]` guard — proving the feature is inert for Vue 3 even in a
+//!   `legacy`-enabled build.
+#![cfg(feature = "legacy")]
+// Integration test: plain `std::string::String` / `{out}` formatting is fine
+// here (the crate's internal `vize_carton::String` rule does not apply to an
+// out-of-crate test harness).
+#![allow(clippy::disallowed_types, clippy::disallowed_macros)]
+
+use vize_atelier_core::{CodegenOptions, TransformOptions, codegen, parser, transform};
+use vize_carton::config::VueVersion;
+
+fn compile(input: &str, dialect: VueVersion) -> String {
+    let allocator = bumpalo::Bump::new();
+    let (mut root, errors) = parser::parse(&allocator, input);
+    assert!(errors.is_empty(), "parse errors: {errors:?}");
+
+    let transform_opts = TransformOptions {
+        prefix_identifiers: true,
+        dialect,
+        ..Default::default()
+    };
+    transform::transform(&allocator, &mut root, transform_opts, None);
+
+    let codegen_opts = CodegenOptions {
+        prefix_identifiers: true,
+        ..Default::default()
+    };
+    let result = codegen::generate(&root, codegen_opts);
+    let mut out = String::with_capacity(result.preamble.len() + result.code.len() + 1);
+    out.push_str(result.preamble.as_str());
+    out.push('\n');
+    out.push_str(result.code.as_str());
+    out
+}
+
+// --- Numeric keycode modifiers (`@keyup.13` -> `@keyup.enter`) ---------------
+
+#[test]
+fn v2_numeric_keycode_maps_to_key_name() {
+    // `@keyup.13` must lower exactly like `@keyup.enter` does under any dialect.
+    let v2_13 = compile(r#"<input @keyup.13="onEnter" />"#, VueVersion::V2);
+    let v2_enter = compile(r#"<input @keyup.enter="onEnter" />"#, VueVersion::V2);
+    assert!(v2_13.contains(r#"_withKeys"#), "{v2_13}");
+    assert!(v2_13.contains(r#"["enter"]"#), "{v2_13}");
+    assert!(!v2_13.contains(r#"["13"]"#), "{v2_13}");
+    assert_eq!(v2_13, v2_enter);
+}
+
+#[test]
+fn v2_maps_all_builtin_numeric_keycodes() {
+    for (code, name) in [
+        ("9", "tab"),
+        ("13", "enter"),
+        ("27", "esc"),
+        ("32", "space"),
+        ("37", "left"),
+        ("38", "up"),
+        ("39", "right"),
+        ("40", "down"),
+        ("8", "delete"),
+        ("46", "delete"),
+    ] {
+        let src = format!(r#"<input @keyup.{code}="onKey" />"#);
+        let out = compile(&src, VueVersion::V2);
+        let expected = format!(r#"["{name}"]"#);
+        assert!(out.contains(&expected), "keycode {code}: {out}");
+    }
+}
+
+#[test]
+fn v2_unmapped_numeric_keycode_is_left_as_is() {
+    // `65` (the `a` key) has no Vue 2 built-in alias, so it stays verbatim.
+    let out = compile(r#"<input @keyup.65="onA" />"#, VueVersion::V2);
+    assert!(out.contains(r#"["65"]"#), "{out}");
+}
+
+#[test]
+fn v2_7_shares_the_v2_event_dialect() {
+    let out = compile(r#"<input @keyup.13="onEnter" />"#, VueVersion::V2_7);
+    assert!(out.contains(r#"["enter"]"#), "{out}");
+}
+
+// --- `.native` modifier ------------------------------------------------------
+
+#[test]
+fn v2_native_on_component_is_stripped_to_plain_listener() {
+    // `@click.native` on a component drops `.native`; the result is a plain
+    // `onClick` handler with no leftover modifier guard.
+    let out = compile(r#"<MyComp @click.native="onClick" />"#, VueVersion::V2);
+    assert!(out.contains("onClick"), "{out}");
+    assert!(!out.contains("native"), "{out}");
+    // `.native` is not a key/system modifier, so no guard helper is emitted.
+    assert!(!out.contains("_withModifiers"), "{out}");
+    assert!(!out.contains("_withKeys"), "{out}");
+    // The plain `@click` equivalent compiles to the same handler prop.
+    let plain = compile(r#"<MyComp @click="onClick" />"#, VueVersion::V2);
+    assert_eq!(out, plain);
+}
+
+#[test]
+fn v2_native_with_other_modifiers_keeps_the_rest() {
+    // `.native` is removed but a co-located `.stop` survives as a guard.
+    let out = compile(r#"<MyComp @click.native.stop="onClick" />"#, VueVersion::V2);
+    assert!(out.contains("_withModifiers"), "{out}");
+    assert!(out.contains(r#"["stop"]"#), "{out}");
+    assert!(!out.contains("native"), "{out}");
+}
+
+// --- Zero-cost: dialect V3 leaves the modifiers untouched --------------------
+
+#[test]
+fn v3_default_dialect_keeps_numeric_keycode_raw() {
+    // The same input the V2 test maps to `enter` must stay a raw `["13"]`
+    // guard under the default Vue 3 dialect — even in this `legacy` build.
+    let out = compile(r#"<input @keyup.13="onEnter" />"#, VueVersion::V3);
+    assert!(out.contains(r#"["13"]"#), "{out}");
+    assert!(!out.contains(r#"["enter"]"#), "{out}");
+}
+
+#[test]
+fn v2_and_v3_outputs_diverge_only_for_numeric_keycodes() {
+    // A keycode-free, `.native`-free template must produce identical output
+    // under V2 and V3, demonstrating the dialect only changes the two sugars.
+    let v2 = compile(r#"<input @keyup.enter="onEnter" />"#, VueVersion::V2);
+    let v3 = compile(r#"<input @keyup.enter="onEnter" />"#, VueVersion::V3);
+    assert_eq!(v2, v3);
+}
+
+#[test]
+fn v3_native_on_component_keeps_the_modifier_in_the_ast() {
+    // Under V3 the `.native` modifier is retained on the directive. The
+    // generated handler value is the same (`.native` is a codegen no-op), but
+    // the retained modifier flips the props object to the multi-line "has
+    // modifiers" form, so the V2-stripped output (compact, single-line —
+    // byte-identical to plain `@click`) genuinely diverges from V3 here. This
+    // pins the observable effect of the V2 strip.
+    let v3 = compile(r#"<MyComp @click.native="onClick" />"#, VueVersion::V3);
+    let v3_plain = compile(r#"<MyComp @click="onClick" />"#, VueVersion::V3);
+    let v2 = compile(r#"<MyComp @click.native="onClick" />"#, VueVersion::V2);
+    // V3 keeps `.native` and so does NOT collapse to the plain-`@click` form;
+    // V2 strips it and does.
+    assert_ne!(v3, v3_plain);
+    assert_eq!(v2, v3_plain);
+}


### PR DESCRIPTION
## Sugar covered

Implements the remaining bounded Vue 2 v-on event-modifier sugar (the pieces left after the v2 filters work), behind the `legacy` cargo feature + V2/V2.7 dialect:

- **`.native`** — `@click.native="x"`: Vue 2 bound a native DOM listener on the component root; Vue 3 removed it (listeners fall through by default). Under V2 the `.native` modifier is stripped from the directive, so `@click.native` on a component lowers to the byte-identical compact form of a plain `@click`. On a plain element `.native` was already a Vue 3 codegen no-op, so stripping there changes nothing.
- **Numeric keyCodes** — `@keyup.13="x"`: Vue 2 accepted raw `keyCode` numbers; Vue 3 removed them. Under V2 the built-in numeric keycodes are mapped to their Vue 3 key names so `@keyup.13` behaves like `@keyup.enter`.

## Vue parity

Numeric keycode map mirrors Vue 2's built-in `keyCodes` defaults:

`8`→delete (Backspace), `9`→tab, `13`→enter, `27`→esc, `32`→space, `37`→left, `38`→up, `39`→right, `40`→down, `46`→delete. Numbers with no Vue 2 alias (e.g. `65`) are left untouched, exactly as Vue 2 did.

`@keyup.13` and `@keyup.enter` produce identical render output under V2. `@click.native` on a component produces output identical to plain `@click` under V2.

## Zero-cost

- Entire surface is `#[cfg(feature = "legacy")]`-gated; the default Vue 3 build never compiles it.
- Dialect-gated through a new `pub(crate)` `supports_v2_event_sugar()` resolved once per file from `LegacyVueVersion::from_dialect`. For dialect V3 (the default) the desugaring is never entered, so modifiers stay byte-identical to today's output even in a `legacy`-enabled build.
- No new public API or struct field added, so `cargo-semver-checks` requires no version bump.
- Scope confined to `vize_atelier_core` (no `vize_armature`/`vize_relief`/canon/maestro/patina/croquis changes).

## Verification

- `cargo run -p vize_test_runner --bin coverage` (default build): VDOM 457/457, SFC 167/167 green (single pre-existing Vapor v1-alpha known failure, unrelated).
- `vize_atelier_sfc` `allocation_budget` test unchanged/passing.
- `cargo test -p vize_atelier_core` green in both default (176) and `--features legacy` (198 lib + 11 filters + 9 new event-modifier integration tests).
- `cargo fmt --check` clean; `cargo clippy --lib -D warnings` clean in default, `--features`, and `--all-features` modes.
- `cargo semver-checks check-release` for `vize_atelier_core` / `vize_armature` / `vize_relief` against `main`: no semver update required.

Refs #1392

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1471"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783799140&installation_id=136613492&pr_number=1471&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1471&signature=77d9deb393a3ffdc240b438b03528fc007383115278537d934b79bd6c81ffea4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->