### PR TITLE
feat(croquis): recognize Vue.extend as options wrapper

### DIFF
--- a/crates/vize_croquis/src/script_parser/process/options_api.rs
+++ b/crates/vize_croquis/src/script_parser/process/options_api.rs
@@ -669,7 +669,7 @@ fn component_options_from_call<'a>(
     call: &'a CallExpression<'a>,
     bindings: &FxHashMap<&'a str, ComponentOptionsRef<'a>>,
 ) -> Option<ComponentOptionsRef<'a>> {
-    if !is_define_component_callee(&call.callee) {
+    if !is_component_options_callee(&call.callee) {
         return None;
     }
 
@@ -811,19 +811,45 @@ fn local_name_from_expression<'a>(expression: &'a Expression<'a>) -> Option<&'a 
     }
 }
 
-fn is_define_component_callee(callee: &Expression<'_>) -> bool {
+/// Whether `callee` is a recognized component-options wrapper whose first
+/// argument is the Options API options object.
+///
+/// Recognizes `defineComponent(...)` (Vue 3) and `Vue.extend(...)` (Vue 2's
+/// component constructor extension). Both wrap a plain options object, so the
+/// data/computed/methods inside are collected exactly like a bare
+/// `export default {...}`. `Vue.extend` is harmless to recognize under any
+/// dialect: it only ever collects additional, otherwise-undefined template
+/// bindings from valid Vue 2 sources.
+fn is_component_options_callee(callee: &Expression<'_>) -> bool {
     match callee {
         Expression::Identifier(callee) => {
-            matches!(callee.name.as_str(), "defineComponent" | "_defineComponent")
+            // `defineComponent({...})` / `_defineComponent({...})` (Vue 3) and
+            // `extend({...})` via a named import `import { extend } from 'vue'`.
+            matches!(
+                callee.name.as_str(),
+                "defineComponent" | "_defineComponent" | "extend"
+            )
         }
         Expression::StaticMemberExpression(member) => {
-            matches!(
-                member.property.name.as_str(),
-                "defineComponent" | "_defineComponent"
-            )
+            // `<obj>.defineComponent({...})` and `Vue.extend({...})`.
+            match member.property.name.as_str() {
+                "defineComponent" | "_defineComponent" => true,
+                "extend" => is_vue_object(&member.object),
+                _ => false,
+            }
         }
         _ => false,
     }
+}
+
+/// Whether `object` references the `Vue` constructor (`Vue.extend(...)` /
+/// `_Vue.extend(...)`), so that an unrelated `<x>.extend(...)` call is not
+/// mistaken for a component-options wrapper.
+fn is_vue_object(object: &Expression<'_>) -> bool {
+    matches!(
+        object,
+        Expression::Identifier(identifier) if matches!(identifier.name.as_str(), "Vue" | "_Vue")
+    )
 }
 
 fn option_object_property<'a>(

--- a/crates/vize_croquis/src/script_parser/tests.rs
+++ b/crates/vize_croquis/src/script_parser/tests.rs
@@ -535,6 +535,76 @@ export default {
 }
 
 #[test]
+fn test_parse_vue_extend_export_default_template_bindings() {
+    let source = r#"
+import Vue from 'vue'
+export default Vue.extend({
+  props: {
+    title: String
+  },
+  data() {
+    return {
+      count: 0
+    }
+  },
+  computed: {
+    doubled() {
+      return this.count * 2
+    }
+  },
+  methods: {
+    save() {}
+  }
+})
+"#;
+    let result = parse_script_with_options(
+        source,
+        ScriptParserOptions {
+            options_api: false,
+            legacy_vue2: true,
+        },
+    );
+
+    for name in ["title", "count", "doubled", "save"] {
+        assert!(result.bindings.contains(name), "missing binding {name}");
+    }
+}
+
+#[test]
+fn test_parse_vue_extend_identifier_bound_template_bindings() {
+    let source = r#"
+import Vue from 'vue'
+const Component = Vue.extend({
+  data() {
+    return {
+      count: 0
+    }
+  },
+  computed: {
+    doubled() {
+      return this.count * 2
+    }
+  },
+  methods: {
+    save() {}
+  }
+})
+export default Component
+"#;
+    let result = parse_script_with_options(
+        source,
+        ScriptParserOptions {
+            options_api: false,
+            legacy_vue2: true,
+        },
+    );
+
+    for name in ["count", "doubled", "save"] {
+        assert!(result.bindings.contains(name), "missing binding {name}");
+    }
+}
+
+#[test]
 fn test_parse_options_api_inject_array_bindings() {
     let source = r#"
 export default {


### PR DESCRIPTION
## Problem

Vue 2 components are commonly defined as `export default Vue.extend({ data() {...}, computed: {...}, ... })` (or `const C = Vue.extend({...})`). croquis resolved `export default {...}`, `defineComponent({...})`, and identifier-bound options to extract Options API template bindings, but `Vue.extend({...})` was **not** recognized as a component-options wrapper (noted gap at `options_api.rs`). As a result, `data`/`computed`/`methods` declared inside `Vue.extend({...})` were never collected, producing false "undefined" diagnostics for those template bindings in Vue 2 code.

## Fix

Broadened the single component-options-callee recognition point (`is_define_component_callee` → `is_component_options_callee`) used by `component_options_from_call` to also accept:

- `Vue.extend({...})` / `_Vue.extend({...})` (member call, object gated to the `Vue` constructor identifier so an unrelated `<x>.extend(...)` is not misclassified)
- `extend({...})` via a named import (`import { extend } from 'vue'`)

Because every resolution path (`export default`, identifier-bound `const`, argument, expression) funnels through `component_options_from_call`, both `export default Vue.extend({...})` and `const C = Vue.extend({...})` are now handled, and the wrapped object's options are collected exactly like `defineComponent({...})`. Recognition is dialect-agnostic and lower-risk: it only ever collects additional, otherwise-undefined bindings from valid Vue 2 sources.

## Verification

- Confirmed the gap first: temporary tests showed `x`/`y` from `Vue.extend({...})` were not collected before the change.
- New tests: `export default Vue.extend({...})` and identifier-bound `const C = Vue.extend({...})` collect `props`/`data`/`computed`/`methods` bindings.
- `cargo test -p vize_croquis`: 201 passed (199 prior + 2 new).
- `cargo fmt -p vize_croquis --check`: clean.
- `cargo clippy -p vize_croquis --lib -D warnings`: clean.
- `cargo run -p vize_test_runner --bin coverage`: VDOM 457/457, SFC 167/167 (byte-identical for non-`Vue.extend` code; the single Vapor failure is the pre-existing known v1-alpha tracked failure).
- Self-contained to `vize_croquis`; no new pub field on `Croquis`.

Refs #1392

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1473"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->