### PR TITLE
feat(maestro): complete v-scope bindings in petite-vue HTML

### DIFF
--- a/crates/vize_maestro/src/ide/completion/template/bindings.rs
+++ b/crates/vize_maestro/src/ide/completion/template/bindings.rs
@@ -102,6 +102,14 @@ pub(crate) fn analyzed_template_binding_completions(
     ctx: &IdeContext,
     include_vue3_details: bool,
 ) -> Vec<CompletionItem> {
+    // petite-vue standalone HTML documents have no SFC `<template>` block, so
+    // `parse_sfc` yields nothing and the scope chain below stays empty. Route
+    // them through the document parser + Croquis so `v-scope` keys resolve as
+    // template-scope completions inside `{{ }}` and directive expressions.
+    if crate::utils::is_standalone_html_path(ctx.uri.path()) && ctx.dialect().is_petite_vue() {
+        return petite_vue_scope_binding_completions(ctx);
+    }
+
     let options = vize_atelier_sfc::SfcParseOptions {
         filename: ctx.uri.path().to_string().into(),
         ..Default::default()
@@ -269,6 +277,39 @@ pub(crate) fn analyzed_template_binding_completions(
         }
     }
 
+    items_vec
+}
+
+/// Template-scope completions for a petite-vue standalone HTML document.
+///
+/// The whole document is the template, so we parse it with the document parser
+/// (`<!DOCTYPE>`-tolerant, raw-text `<script>`/`<style>`) and run Croquis over
+/// the resulting AST. `v-scope` keys are modeled as `v-slot`-kind scopes, so
+/// they surface through the same `bindings_visible_at` walk the SFC path uses.
+/// Offsets are document-absolute here (no `<template>` block offset to
+/// subtract), and there is no `<script setup>` binding set to merge.
+fn petite_vue_scope_binding_completions(ctx: &IdeContext) -> Vec<CompletionItem> {
+    use vize_croquis::{Drawer, DrawerOptions};
+
+    let allocator = vize_carton::Bump::new();
+    let (root, _errors) = vize_armature::parse_document(&allocator, &ctx.content);
+
+    let mut drawer = Drawer::with_options(DrawerOptions::full());
+    drawer.draw_template(&root);
+    let croquis = drawer.finish();
+
+    let offset = ctx.offset.min(ctx.content.len()) as u32;
+    let mut items_vec = Vec::new();
+    let mut seen = BTreeSet::new();
+    for (name, _binding, scope_kind) in croquis.scopes.bindings_visible_at(offset) {
+        if !is_template_scope_kind(scope_kind) {
+            continue;
+        }
+        if !seen.insert(name.to_string()) {
+            continue;
+        }
+        items_vec.push(template_scope_completion_item(name, scope_kind));
+    }
     items_vec
 }
 

--- a/crates/vize_maestro/src/ide/completion/tests.rs
+++ b/crates/vize_maestro/src/ide/completion/tests.rs
@@ -169,6 +169,66 @@ fn test_standalone_html_completion_includes_petite_vue_directives() {
 }
 
 #[test]
+fn test_standalone_html_completion_includes_v_scope_bindings_in_expression() {
+    let dir = tempfile::tempdir().unwrap();
+    let source_path = dir.path().join("index.html");
+    let source = r#"<script src="https://unpkg.com/petite-vue" defer init></script>
+<div v-scope="{ count: 0, msg: 'x' }">{{ count }}</div>
+"#;
+    fs::write(&source_path, source).unwrap();
+
+    let uri = Url::from_file_path(&source_path).unwrap();
+    let state = ServerState::new();
+    state
+        .documents
+        .open(uri.clone(), source.to_string(), 1, "html".to_string());
+    state.update_virtual_docs(&uri, source);
+
+    // Cursor inside the `{{ count }}` interpolation expression.
+    let offset = source.find("{{ count").unwrap() + "{{ co".len();
+    let ctx = IdeContext::new(&state, &uri, offset).unwrap();
+    let labels = completion_labels(CompletionService::complete(&ctx).unwrap());
+
+    // `v-scope` keys resolve as template-scope completions inside expressions.
+    assert!(
+        has_label(&labels, "count"),
+        "v-scope key `count` should be offered inside the expression; got {labels:?}"
+    );
+    assert!(
+        has_label(&labels, "msg"),
+        "v-scope key `msg` should be offered inside the expression; got {labels:?}"
+    );
+}
+
+#[test]
+fn test_standalone_html_completion_v_scope_bindings_do_not_leak_to_sibling() {
+    let dir = tempfile::tempdir().unwrap();
+    let source_path = dir.path().join("index.html");
+    let source = r#"<script src="https://unpkg.com/petite-vue" defer init></script>
+<span v-scope="{ count: 0 }">{{ count }}</span><p>{{ count }}</p>
+"#;
+    fs::write(&source_path, source).unwrap();
+
+    let uri = Url::from_file_path(&source_path).unwrap();
+    let state = ServerState::new();
+    state
+        .documents
+        .open(uri.clone(), source.to_string(), 1, "html".to_string());
+    state.update_virtual_docs(&uri, source);
+
+    // Cursor inside the sibling `<p>` interpolation, outside the v-scope subtree.
+    let p_start = source.find("<p>").unwrap();
+    let offset = source[p_start..].find("{{ count").unwrap() + p_start + "{{ co".len();
+    let ctx = IdeContext::new(&state, &uri, offset).unwrap();
+    let labels = completion_labels(CompletionService::complete(&ctx).unwrap());
+
+    assert!(
+        !has_label(&labels, "count"),
+        "v-scope binding must not leak to a sibling subtree; got {labels:?}"
+    );
+}
+
+#[test]
 fn test_standalone_html_completion_ignores_petite_vue_mention_in_comment() {
     let dir = tempfile::tempdir().unwrap();
     let source_path = dir.path().join("index.html");


### PR DESCRIPTION
## What

Surface `v-scope` keys as expression completions inside petite-vue standalone HTML documents in the maestro LSP.

Previously, the template binding completion path (`analyzed_template_binding_completions`) always parsed the document with `parse_sfc`. petite-vue `.html` files have no SFC `<template>` block, so that parse found no template, ran no scope analysis, and offered no scope bindings — inside `{{ }}` and directive-attribute expressions, `v-scope` keys never appeared as completions.

This PR adds a petite-vue HTML branch that parses the whole document with `armature::parse_document` (DOCTYPE-tolerant, raw-text `<script>`/`<style>`) and runs a Croquis `Drawer` over the resulting AST. `v-scope` keys (already modeled in croquis as v-slot-kind template scopes, #1468) then resolve through the same `bindings_visible_at` visibility walk the SFC path uses, with correct nesting/shadowing and no leakage to sibling subtrees.

This is the expression-completion slice of #1393 PR6 ("rebuild standalone-HTML IDE features on the scope model").

## Scope

- Self-contained to `vize_maestro`. Reads armature (`parse_document`) and croquis (`Drawer`/`DrawerOptions`/`ScopeChain::bindings_visible_at`) public APIs only; no other crate modified.
- Gated on `is_standalone_html_path(uri)` + `dialect().is_petite_vue()`, so `.vue` SFC IDE behavior is byte-for-byte unchanged (offsets are document-absolute, no `<script setup>` binding set to merge).
- petite-vue directive completions (`v-scope`, `v-effect`, `@vue:mounted`, …) already existed; this fills the remaining gap of completing the keys *introduced by* `v-scope` inside expressions.

Not in this slice (left for follow-up PR6 work): hover on the four petite constructs and v-scope keys (template hover still uses `parse_sfc`); definition/references/rename already have a separate petite path.

## Verification

- `cargo test -p vize_maestro` — 310 pass (2 new: v-scope keys completed inside an expression; v-scope bindings do not leak to a sibling subtree)
- `cargo fmt -p vize_maestro --check` — clean
- `cargo clippy -p vize_maestro --lib -- -D warnings` — clean

Refs #1393

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1474"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->