### PR TITLE
refactor(canon): reuse batch virtual-TS pipeline in corsa_server

### DIFF
--- a/crates/vize_canon/src/batch.rs
+++ b/crates/vize_canon/src/batch.rs
@@ -23,7 +23,10 @@ pub use type_checker::{
     BatchTypeChecker, BatchTypeCheckerOptions, DeclarationEmitOptions, DeclarationEmitResult,
     DeclarationOutput, TypeCheckResult, TypeChecker,
 };
-pub use virtual_project::{OriginalPosition, VirtualFile, VirtualProject};
+pub use virtual_project::{
+    OriginalPosition, VirtualFile, VirtualProject, VueDocumentVirtualTs,
+    generate_vue_document_virtual_ts,
+};
 pub use virtual_ts::VirtualTsGenerator;
 
 use vize_carton::String;

--- a/crates/vize_canon/src/batch/virtual_project/build.rs
+++ b/crates/vize_canon/src/batch/virtual_project/build.rs
@@ -116,6 +116,7 @@ pub(super) fn build_vue_registered_file(
                 options_api: context.options_api,
                 legacy_vue2: context.legacy_vue2,
                 template_syntax: context.template_syntax,
+                hoist_shared_preamble: true,
             },
         )
     )?;
@@ -149,6 +150,71 @@ pub(super) fn build_vue_registered_file(
             context.virtual_root,
         ),
         diagnostics,
+    })
+}
+
+/// Rewritten virtual TypeScript for a single in-memory `.vue` document,
+/// produced by the same canon batch pipeline (`generate_vue_virtual_ts` +
+/// import rewriting) used by `vize check`. Shared by the Corsa socket server so
+/// the single-document LSP path and the batch path generate identical virtual
+/// TS for the same input (issue #1389).
+pub struct VueDocumentVirtualTs {
+    /// `.vue.ts` source after `.vue -> .vue.ts` import rewriting, i.e. exactly
+    /// what is shipped to Corsa.
+    pub code: CompactString,
+    /// Generated source *before* import rewriting. Used to collect the relative
+    /// `.vue` import specifiers for sibling overlay without re-running codegen.
+    pub pre_rewrite_code: CompactString,
+}
+
+/// Generate the rewritten virtual TypeScript for one in-memory `.vue` document.
+///
+/// This reuses the canon batch generator end-to-end (SFC parse, script/template
+/// parse diagnostics, hard-error fallback stub, Croquis analysis, type-based
+/// prop augmentation, SFC compile diagnostics, and `.vue -> .vue.ts` import
+/// rewriting), so the socket single-document path and `vize check` emit
+/// identical virtual TS for the same input. The document path uses the default
+/// (Composition API) variant and default check options. The only deliberate
+/// single-document difference is `hoist_shared_preamble`: the Corsa socket
+/// session has no program-wide ambient helpers file, so the shared preamble is
+/// kept inline (`hoist_shared_preamble = false`) instead of being hoisted as in
+/// the materialized batch project.
+pub fn generate_vue_document_virtual_ts(
+    path: &Path,
+    content: &str,
+    options: &VirtualTsOptions,
+    rewriter: &ImportRewriter,
+    hoist_shared_preamble: bool,
+) -> CorsaResult<VueDocumentVirtualTs> {
+    let descriptor = parse_sfc(
+        content,
+        SfcParseOptions {
+            filename: path.to_string_lossy().to_compact_string(),
+            ..Default::default()
+        },
+    )
+    .map_err(|error| CorsaError::SfcParse(error.message.to_compact_string()))?;
+
+    let effective_options = virtual_ts_options_for_descriptor(options, &descriptor);
+    let GeneratedVueFile { code, .. } = generate_vue_virtual_ts(
+        path,
+        content,
+        &descriptor,
+        &effective_options,
+        VueCodegenOptions {
+            check_options: VirtualTsCheckOptions::default(),
+            preserve_unused_diagnostics: false,
+            options_api: false,
+            legacy_vue2: false,
+            template_syntax: TemplateSyntaxMode::default(),
+            hoist_shared_preamble,
+        },
+    )?;
+
+    let rewritten = rewriter.rewrite(&code, SourceType::ts());
+    Ok(VueDocumentVirtualTs {
+        code: rewritten.code,
+        pre_rewrite_code: code,
     })
 }
 

--- a/crates/vize_canon/src/batch/virtual_project/mod.rs
+++ b/crates/vize_canon/src/batch/virtual_project/mod.rs
@@ -25,6 +25,7 @@ use super::{Diagnostic, SfcBlockType};
 use crate::virtual_ts::{VirtualTsCheckOptions, VirtualTsOptions};
 
 mod build;
+pub use build::{VueDocumentVirtualTs, generate_vue_document_virtual_ts};
 mod diagnostics;
 mod mapping;
 mod materialize;

--- a/crates/vize_canon/src/batch/virtual_project/tests.rs
+++ b/crates/vize_canon/src/batch/virtual_project/tests.rs
@@ -62,6 +62,49 @@ fn test_materialize_writes_inert_vue_module_stub_file() {
 }
 
 #[test]
+fn shared_document_generator_is_byte_identical_to_batch_pipeline() {
+    // Issue #1389: the Corsa socket single-document path and the `vize check`
+    // batch path must produce identical virtual TS for the same input. With the
+    // shared preamble hoisted (as the batch path materializes it), the shared
+    // single-document generator must match `register_vue_file` byte-for-byte.
+    let case_dir = unique_case_dir("shared-doc-vs-batch");
+    let _ = fs::remove_dir_all(&case_dir);
+    let src_dir = case_dir.join("src");
+    fs::create_dir_all(&src_dir).unwrap();
+    let vue_path = src_dir.join("App.vue");
+    let vue_content = r#"<script setup lang="ts">
+import Child from './Child.vue'
+const count = 1
+const label = 'hi'
+</script>
+
+<template>
+  <Child :count="count" />
+  <span>{{ label }}</span>
+</template>
+"#;
+    fs::write(&vue_path, vue_content).unwrap();
+
+    let mut project = VirtualProject::new(&case_dir).unwrap();
+    project.register_vue_file(&vue_path, vue_content).unwrap();
+    let batch_content = project.find_by_original(&vue_path).unwrap().content.clone();
+
+    let rewriter = super::super::import_rewriter::ImportRewriter::new();
+    let shared = super::generate_vue_document_virtual_ts(
+        &vue_path,
+        vue_content,
+        &VirtualTsOptions::default(),
+        &rewriter,
+        true,
+    )
+    .unwrap();
+
+    assert_eq!(shared.code.as_str(), batch_content.as_str());
+
+    let _ = fs::remove_dir_all(&case_dir);
+}
+
+#[test]
 fn test_register_vue_file_rewrites_child_imports() {
     let case_dir = unique_case_dir("register-vue");
     let _ = fs::remove_dir_all(&case_dir);

--- a/crates/vize_canon/src/batch/virtual_project/vue_codegen.rs
+++ b/crates/vize_canon/src/batch/virtual_project/vue_codegen.rs
@@ -45,6 +45,12 @@ pub(super) struct VueCodegenOptions {
     pub(super) options_api: bool,
     pub(super) legacy_vue2: bool,
     pub(super) template_syntax: TemplateSyntaxMode,
+    /// Whether the shared preamble (ImportMeta augmentation + helper types) is
+    /// hoisted to a program-wide ambient `.d.ts`. The batch path materializes
+    /// `SHARED_HELPERS_FILE` and lists it in every tsconfig, so it hoists
+    /// (`true`); the single-document Corsa socket session has no such shared
+    /// file and must keep the preamble inline (`false`).
+    pub(super) hoist_shared_preamble: bool,
 }
 
 pub(super) fn generate_vue_virtual_ts(
@@ -193,8 +199,9 @@ pub(super) fn generate_vue_virtual_ts(
                 ),
                 // The virtual project materializes SHARED_HELPERS_FILE and
                 // lists it in every generated tsconfig, so per-file output
-                // drops the duplicated preamble.
-                hoist_shared_preamble: true,
+                // drops the duplicated preamble. The single-document Corsa
+                // socket path has no shared file and keeps it inline.
+                hoist_shared_preamble: codegen_options.hoist_shared_preamble,
             },
         )
     );

--- a/crates/vize_canon/src/corsa_server.rs
+++ b/crates/vize_canon/src/corsa_server.rs
@@ -312,73 +312,47 @@ impl CorsaServer {
 
     /// Check a Vue SFC and return diagnostics.
     fn check_vue_sfc(&mut self, uri: &str, content: &str) -> Result<CheckResult, String> {
-        use vize_atelier_core::parser::parse;
-        use vize_atelier_sfc::{
-            SfcParseOptions,
-            croquis::{SfcCroquisOptions, analyze_sfc_descriptor_with_context},
-            parse_sfc,
-        };
-        use vize_carton::Bump;
-        use vize_croquis::virtual_ts::generate_virtual_ts;
+        use vize_atelier_sfc::{SfcParseOptions, parse_sfc};
 
-        // Parse SFC
-        let parse_opts = SfcParseOptions {
-            filename: uri.into(),
-            ..Default::default()
-        };
-
-        let descriptor = parse_sfc(content, parse_opts)
-            .map_err(|e| cstr!("Failed to parse SFC: {}", e.message))?;
-
-        // Create allocator
-        let allocator = Bump::new();
-
-        let template_offset = descriptor
-            .template
-            .as_ref()
-            .map(|t| t.loc.start as u32)
-            .unwrap_or(0);
-
-        let template_ast = if let Some(ref template) = descriptor.template {
-            let (root, _) = parse(&allocator, &template.content);
-            Some(root)
-        } else {
-            None
-        };
-
-        let analysis = analyze_sfc_descriptor_with_context(
-            &descriptor,
-            template_ast.as_ref(),
-            SfcCroquisOptions::full().without_script_merge(),
-        );
-
-        // Generate Virtual TypeScript
-        let output = generate_virtual_ts(
-            analysis.script_content_ref(),
-            template_ast.as_ref(),
-            &analysis.croquis.bindings,
-            None,
-            Some(Path::new(uri)),
-            template_offset,
-        );
-
-        // Issue #752: rewrite `.vue` import specifiers to `.vue.ts` so the
-        // socket-mode Corsa session resolves siblings via the same virtual
-        // mirrors used by the batch path, then overlay each relative
-        // sibling's virtual TS into the session. The cached `virtual_ts`
-        // intentionally reflects what we ship to Corsa (rewritten form), so
-        // consumers that introspect the cache see the same coordinates.
-        let pre_rewrite_ts = output.content;
+        // Reuse the canon batch virtual-TS pipeline (issue #1389) so the
+        // socket-mode single-document path and `vize check` generate identical
+        // virtual TS for the same input. The shared generator keeps the shared
+        // preamble inline (`hoist_shared_preamble = false`) because this session
+        // overlays standalone documents and has no program-wide helpers file.
         let rewriter = crate::batch::ImportRewriter::new();
-        let virtual_ts: String = rewriter
-            .rewrite(pre_rewrite_ts.as_str(), oxc_span::SourceType::ts())
-            .code;
+        let generated = crate::batch::generate_vue_document_virtual_ts(
+            Path::new(uri),
+            content,
+            &crate::virtual_ts::VirtualTsOptions::default(),
+            &rewriter,
+            false,
+        )
+        .map_err(|e| cstr!("Failed to generate virtual TS: {e}"))?;
 
+        // Issue #752: the rewritten form resolves `.vue` siblings via the same
+        // `.vue.ts` virtual mirrors used by the batch path. The cached
+        // `virtual_ts` intentionally reflects what we ship to Corsa (rewritten
+        // form), so consumers that introspect the cache see the same
+        // coordinates.
+        let virtual_ts: String = generated.code;
         self.cache.insert(uri.into(), virtual_ts.clone());
 
+        // The SFC compile diagnostic still needs the descriptor; parse it once
+        // here for that merge below.
+        let descriptor = parse_sfc(
+            content,
+            SfcParseOptions {
+                filename: uri.into(),
+                ..Default::default()
+            },
+        )
+        .map_err(|e| cstr!("Failed to parse SFC: {}", e.message))?;
+
         // Overlay sibling .vue.ts mirrors discovered from the host's imports.
-        let relative_specifiers = rewriter
-            .collect_relative_vue_specifiers(pre_rewrite_ts.as_str(), oxc_span::SourceType::ts());
+        let relative_specifiers = rewriter.collect_relative_vue_specifiers(
+            generated.pre_rewrite_code.as_str(),
+            oxc_span::SourceType::ts(),
+        );
         if !relative_specifiers.is_empty() {
             self.overlay_sibling_vue_mirrors(uri, &relative_specifiers);
         }
@@ -459,15 +433,6 @@ impl CorsaServer {
     /// './app.vue'` (issue #752). Errors are logged and skipped so a missing
     /// sibling still surfaces as TS2307 from the host check.
     fn overlay_sibling_vue_mirrors(&mut self, host_uri: &str, initial_specifiers: &[String]) {
-        use vize_atelier_core::parser::parse;
-        use vize_atelier_sfc::{
-            SfcParseOptions,
-            croquis::{SfcCroquisOptions, analyze_sfc_descriptor_with_context},
-            parse_sfc,
-        };
-        use vize_carton::Bump;
-        use vize_croquis::virtual_ts::generate_virtual_ts;
-
         let Some(host_path) = uri_to_path(host_uri, &self.working_dir()) else {
             tracing::debug!("overlay_sibling_vue_mirrors: cannot resolve host path: {host_uri}");
             return;
@@ -511,41 +476,19 @@ impl CorsaServer {
                 let sibling_uri = crate::file_uri::path_to_file_uri(&canonical);
                 let sibling_virtual_uri = self.virtual_uri_for(&sibling_uri);
 
-                let parse_opts = SfcParseOptions {
-                    filename: sibling_uri.as_str().into(),
-                    ..Default::default()
-                };
-                let Ok(descriptor) = parse_sfc(&sibling_content, parse_opts) else {
+                // Reuse the shared canon batch generator (issue #1389) so
+                // overlaid siblings are byte-identical to the host document and
+                // to `vize check`.
+                let Ok(sibling_generated) = crate::batch::generate_vue_document_virtual_ts(
+                    canonical.as_path(),
+                    &sibling_content,
+                    &crate::virtual_ts::VirtualTsOptions::default(),
+                    &rewriter,
+                    false,
+                ) else {
                     continue;
                 };
-
-                let allocator = Bump::new();
-                let template_offset = descriptor
-                    .template
-                    .as_ref()
-                    .map(|t| t.loc.start as u32)
-                    .unwrap_or(0);
-                let template_ast = descriptor.template.as_ref().map(|template| {
-                    let (root, _) = parse(&allocator, &template.content);
-                    root
-                });
-                let analysis = analyze_sfc_descriptor_with_context(
-                    &descriptor,
-                    template_ast.as_ref(),
-                    SfcCroquisOptions::full().without_script_merge(),
-                );
-                let sibling_output = generate_virtual_ts(
-                    analysis.script_content_ref(),
-                    template_ast.as_ref(),
-                    &analysis.croquis.bindings,
-                    None,
-                    Some(canonical.as_path()),
-                    template_offset,
-                );
-
-                let sibling_rewrite =
-                    rewriter.rewrite(sibling_output.content.as_str(), oxc_span::SourceType::ts());
-                let sibling_virtual_ts: String = sibling_rewrite.code;
+                let sibling_virtual_ts: String = sibling_generated.code;
 
                 let client = match self.corsa_client.as_mut() {
                     Some(client) => client,
@@ -574,7 +517,7 @@ impl CorsaServer {
                 }
 
                 let next_specifiers = rewriter.collect_relative_vue_specifiers(
-                    sibling_output.content.as_str(),
+                    sibling_generated.pre_rewrite_code.as_str(),
                     oxc_span::SourceType::ts(),
                 );
                 if !next_specifiers.is_empty() {


### PR DESCRIPTION
## What

`corsa_server.rs` (the Corsa socket LSP single-document path) generated virtual TS via `vize_croquis::virtual_ts::generate_virtual_ts` plus hand-synced `defineProps<` gates — a separate, weaker pipeline from the canon batch path used by `vize check`. The two could drift, so the same SFC could yield different virtual TS in the LSP single-document path vs the batch path. This is PR9 of #1389.

## Dedup

- Added `generate_vue_document_virtual_ts` in `batch/virtual_project/build.rs`: a shared single-document generator over the canon batch pipeline (`generate_vue_virtual_ts` end-to-end — SFC parse, script/template parse diagnostics, hard-error fallback stub, Croquis analysis, type-based prop augmentation, SFC compile diagnostics — plus `.vue -> .vue.ts` import rewriting). Re-exported from `batch`.
- `corsa_server::check_vue_sfc` and the recursive sibling-overlay path now call the shared function instead of the croquis generator. The croquis generation path and its hand-synced gate are deleted from `corsa_server`.
- Threaded `hoist_shared_preamble` through `VueCodegenOptions` so the one deliberate single-document difference is explicit: the socket session has no program-wide ambient helpers file, so it keeps the shared preamble **inline** (`false`); the materialized batch project hoists it to `__vize_helpers.d.ts` (`true`).
- corsa_server net ~108 lines removed; no behavior change to diagnostics (the shared function's internal diagnostics are dropped — corsa_server keeps surfacing Corsa's diagnostics plus its own SFC compile diagnostic, exactly as before).

## Byte-identical

New test `shared_document_generator_is_byte_identical_to_batch_pipeline` asserts that the shared generator with `hoist_shared_preamble = true` (matching the batch path) produces output byte-identical to `VirtualProject::register_vue_file` for the same input. Passes.

Gates: `cargo test -p vize_canon` (default + `--features native`) 337 pass; `cargo fmt --check` clean; `cargo clippy -p vize_canon --lib -D warnings` clean for both default and `--features native`.

## Remaining

- The socket path keeps the preamble inline rather than materializing a shared ambient helpers file into the session; full convergence there would require teaching the socket session about a program-wide `.d.ts`, which changes its lifecycle and is out of scope here.
- Self-contained to `vize_canon`; no maestro/atelier/croquis/relief changes.

Refs #1389

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1475"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->