### PR TITLE
fix(canon): gate corsa fallbacks on typed Unsupported capability error

### DIFF
--- a/crates/vize_canon/src/lsp_client/diagnostics.rs
+++ b/crates/vize_canon/src/lsp_client/diagnostics.rs
@@ -6,6 +6,7 @@ use super::{
 };
 use crate::file_uri::{file_uri_to_path, path_to_file_uri};
 use corsa::{
+    CorsaError,
     jsonrpc::InboundEvent,
     lsp::{LspClient, LspSpawnConfig, VirtualDocument},
     runtime::block_on,
@@ -110,7 +111,7 @@ impl CorsaProjectClient {
     ) -> Result<Option<DiagnosticBatch>, String> {
         let report = match block_on(self.session.get_diagnostics_for_project()) {
             Ok(report) => report,
-            Err(error) if diagnostics_api_error_is_unsupported(&error) => return Ok(None),
+            Err(error) if corsa_diagnostics_error_is_unsupported(&error) => return Ok(None),
             Err(error) => {
                 return Err(cstr!(
                     "Failed to request Corsa project diagnostics: {error}"
@@ -143,7 +144,7 @@ impl CorsaProjectClient {
         );
         let response = match response {
             Ok(response) => response,
-            Err(error) if diagnostics_api_error_is_unsupported(&error) => return Ok(None),
+            Err(error) if corsa_diagnostics_error_is_unsupported(&error) => return Ok(None),
             Err(error) => return Err(cstr!("Failed to request Corsa file diagnostics: {error}")),
         };
         Ok(Some(Ok(self.store_file_diagnostics(
@@ -158,7 +159,7 @@ impl CorsaProjectClient {
     ) -> Result<Option<Result<DiagnosticFetch, String>>, String> {
         let report = match block_on(self.session.get_diagnostics_for_project()) {
             Ok(report) => report,
-            Err(error) if diagnostics_api_error_is_unsupported(&error) => return Ok(None),
+            Err(error) if corsa_diagnostics_error_is_unsupported(&error) => return Ok(None),
             Err(error) => {
                 return Err(cstr!(
                     "Failed to request Corsa project diagnostics: {error}"
@@ -318,7 +319,7 @@ impl CorsaProjectClient {
     ) -> Result<Option<DiagnosticBatch>, String> {
         let report = match block_on(self.session.get_diagnostics_for_project()) {
             Ok(report) => report,
-            Err(error) if diagnostics_api_error_is_unsupported(&error) => return Ok(None),
+            Err(error) if corsa_diagnostics_error_is_unsupported(&error) => return Ok(None),
             Err(error) => {
                 return Err(cstr!(
                     "Failed to request Corsa project diagnostics: {error}"
@@ -484,6 +485,18 @@ impl CorsaProjectClient {
     }
 }
 
+/// The corsa `ProjectSession` reports a missing diagnostics endpoint through
+/// the typed `CorsaError::Unsupported` variant: corsa-bind raises it directly
+/// when a scope is unavailable and normalizes "unknown method" RPC errors to
+/// it as well. Gating the diagnostics fallback on the variant keeps the
+/// capability handshake typed instead of sniffing the rendered message text.
+fn corsa_diagnostics_error_is_unsupported(error: &CorsaError) -> bool {
+    matches!(error, CorsaError::Unsupported(_))
+}
+
+/// Message-text fallback used only on the legacy LSP transport, whose
+/// `textDocument/diagnostic` errors arrive as an opaque `String` with no typed
+/// variant to match against.
 fn diagnostics_api_is_unsupported(error: &str) -> bool {
     error.contains("unknown API method")
         || error.contains("method not found")
@@ -670,7 +683,26 @@ fn language_id_for_uri(uri: &str) -> &'static str {
 
 #[cfg(test)]
 mod tests {
-    use super::{diagnostics_api_is_unsupported, lsp_diagnostics_error_is_transient};
+    use super::{
+        CorsaError, corsa_diagnostics_error_is_unsupported, diagnostics_api_is_unsupported,
+        lsp_diagnostics_error_is_transient,
+    };
+
+    // Regression: a missing diagnostics scope on the corsa `ProjectSession`
+    // must be detected through the typed `CorsaError::Unsupported` variant
+    // (corsa-bind raises it directly and normalizes "unknown method" RPC
+    // errors into it), so the project/file-diagnostics fallback gates on the
+    // variant rather than sniffing the rendered message. A genuine failure on
+    // a different variant must propagate instead of being silently swallowed.
+    #[test]
+    fn corsa_diagnostics_unsupported_uses_typed_capability_error() {
+        assert!(corsa_diagnostics_error_is_unsupported(
+            &CorsaError::Unsupported("file diagnostics are not supported")
+        ));
+        assert!(!corsa_diagnostics_error_is_unsupported(
+            &CorsaError::Protocol("diagnostics request failed: process exited".into())
+        ));
+    }
 
     #[test]
     fn recognizes_unsupported_diagnostics_api_errors() {

--- a/crates/vize_canon/src/lsp_client/session.rs
+++ b/crates/vize_canon/src/lsp_client/session.rs
@@ -423,10 +423,14 @@ fn external_document_path(uri: &str) -> Option<PathBuf> {
     Some(session_path)
 }
 
-fn overlay_changes_error_is_unsupported(error: &impl std::fmt::Display) -> bool {
-    let message = cstr!("{error}");
-    message.contains("overlayChanges")
-        && (message.contains("unsupported") || message.contains("not supported"))
+/// The runtime advertised overlay support through `describeCapabilities`, but
+/// rejected the overlay write at request time. corsa-bind surfaces this as the
+/// typed `CorsaError::Unsupported` variant (also for runtimes that lack the
+/// `updateSnapshot.overlayChanges` method entirely, normalized from the RPC
+/// "method not found" error), so we gate the materialized fallback on the
+/// variant rather than sniffing the human-readable message text.
+fn overlay_changes_error_is_unsupported(error: &CorsaError) -> bool {
+    matches!(error, CorsaError::Unsupported(_))
 }
 
 pub(super) fn materialize_session_document(
@@ -502,7 +506,8 @@ pub(super) fn line_character_to_utf16_offset(text: &str, line: u32, character: u
 mod tests {
     use super::{
         api_mode_for_executable, build_session_document_uri, line_character_to_utf16_offset,
-        path_to_file_uri, should_retry_json_rpc, uri_document_identifier,
+        overlay_changes_error_is_unsupported, path_to_file_uri, should_retry_json_rpc,
+        uri_document_identifier,
     };
     use corsa::CorsaError;
     use corsa::api::{ApiMode, DocumentIdentifier};
@@ -578,6 +583,27 @@ mod tests {
 
         assert!(should_retry_json_rpc(ApiMode::SyncMsgpackStdio, &error));
         assert!(!should_retry_json_rpc(ApiMode::AsyncJsonRpcStdio, &error));
+    }
+
+    // Regression: the materialized-overlay fallback must be gated on the typed
+    // `CorsaError::Unsupported` variant that corsa-bind raises when a runtime
+    // rejects `updateSnapshot.overlayChanges`, not on sniffing the rendered
+    // error message. A runtime that fails an overlay write for an unrelated
+    // reason (e.g. a transport/protocol fault) must surface as an error rather
+    // than silently degrading to the slower materialized path.
+    #[test]
+    fn overlay_unsupported_uses_typed_capability_error() {
+        assert!(overlay_changes_error_is_unsupported(
+            &CorsaError::Unsupported(
+                "updateSnapshot.overlayChanges is not supported by this runtime",
+            )
+        ));
+
+        // A look-alike message routed through a different (protocol) variant
+        // must NOT be treated as an overlay-capability gap.
+        assert!(!overlay_changes_error_is_unsupported(
+            &CorsaError::Protocol("overlayChanges write failed: connection unsupported".into())
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Finding

The Corsa typed capability handshake in `vize_canon` was already largely in place: `lsp_client/session.rs` queries `describe_capabilities()` on spawn, stores a typed `CapabilitiesResponse`, and gates overlay / diagnostics / editor features through `trusts_capabilities()` + the per-feature `supports_*_api()` helpers. The discovery-triplication and `overlayChanges` marker strings in `batch/executor.rs` called out in #1389 have already been removed in earlier PRs.

The residual gap was at *request time*: two fallback predicates still inferred a missing capability by **string-sniffing the rendered error message** rather than matching the typed error:

- `session.rs::overlay_changes_error_is_unsupported` matched `Display` text `overlayChanges` + (`unsupported`|`not supported`) to decide whether to drop to the materialized-overlay path.
- `diagnostics.rs::diagnostics_api_error_is_unsupported` matched the same kind of substrings on the corsa `ProjectSession` diagnostics calls.

corsa 0.36 surfaces an unavailable endpoint through the typed `CorsaError::Unsupported(_)` variant — raised directly by `require_overlay_update_capability` / the diagnostics methods, and normalized from "unknown method" RPC errors via `map_missing_method`. Sniffing the message was fragile (a transport/protocol fault whose text happened to contain "unsupported" would silently degrade instead of erroring).

## Change

- Match the typed `CorsaError::Unsupported(_)` variant in both fallback predicates on the corsa `ProjectSession` paths (overlay write + project/file diagnostics, 7 call sites).
- Keep the message-text check **only** for the legacy LSP transport, whose `textDocument/diagnostic` errors arrive as an opaque `String` with no typed variant to match — documented as such.
- Add two regression tests pinning the typed gating: an `Unsupported` error triggers the fallback, while a look-alike message on a `Protocol` variant does **not** (so genuine failures propagate).

Self-contained to `vize_canon`; no other crates touched. Not a rewrite — a hardening pass on the existing handshake.

## Verification

- `cargo test -p vize_canon --lib` and `--features native` — 338 passed, incl. the two new tests.
- `cargo fmt --check -p vize_canon` — clean.
- `cargo clippy -p vize_canon --lib -- -D warnings` (default + `--features native`) — clean.

Refs #1389

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1476"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->