### PR TITLE
fix(patina): ignore </template> inside quoted attribute values during fast scan

### DIFF
--- a/crates/vize_patina/src/linter/engine/tag_scan.rs
+++ b/crates/vize_patina/src/linter/engine/tag_scan.rs
@@ -5,6 +5,34 @@ pub(super) fn find_tag_end(bytes: &[u8], start: usize) -> Option<usize> {
     memchr::memchr(b'>', &bytes[start..]).map(|offset| start + offset)
 }
 
+/// Find the `>` that ends the start tag beginning at `lt_idx` (the `<`),
+/// skipping over single- and double-quoted attribute values so a `>` or `<`
+/// embedded in a quoted value (e.g. `<div title="</template>">`) is not
+/// mistaken for the tag end or a nested tag. Returns the index of the closing
+/// `>`, or `None` if the tag is unterminated.
+pub(super) fn find_start_tag_end(bytes: &[u8], lt_idx: usize) -> Option<usize> {
+    let mut pos = lt_idx + 1;
+
+    while pos < bytes.len() {
+        // Jump to the next byte that can change scan state: a quote opens an
+        // attribute value to skip, a `>` closes the tag.
+        let offset = memchr::memchr3(b'"', b'\'', b'>', &bytes[pos..])?;
+        let idx = pos + offset;
+        match bytes[idx] {
+            b'>' => return Some(idx),
+            quote => {
+                // Skip the quoted attribute value, including any `>`/`<` inside.
+                match memchr::memchr(quote, &bytes[idx + 1..]) {
+                    Some(end) => pos = idx + 1 + end + 1,
+                    None => return None,
+                }
+            }
+        }
+    }
+
+    None
+}
+
 pub(super) fn find_closing_tag(bytes: &[u8], tag_name: &[u8], from: usize) -> Option<usize> {
     let mut pos = from;
 

--- a/crates/vize_patina/src/linter/engine/template_extract.rs
+++ b/crates/vize_patina/src/linter/engine/template_extract.rs
@@ -4,7 +4,9 @@
 use vize_carton::String;
 use vize_carton::ToCompactString;
 
-use super::tag_scan::{closing_tag_name_at, find_closing_tag, find_tag_end, tag_name_at};
+use super::tag_scan::{
+    closing_tag_name_at, find_closing_tag, find_start_tag_end, find_tag_end, tag_name_at,
+};
 
 /// Ultra-fast template extraction using memchr for SIMD-accelerated search.
 #[inline]
@@ -36,18 +38,21 @@ pub(crate) fn extract_template_fast(source: &str) -> Option<(String, u32)> {
         }
 
         // Check if it's <template or </template
-        if tag_name_at(bytes, next_lt)
-            .is_some_and(|(name, _)| name.eq_ignore_ascii_case(b"template"))
-        {
-            // Check if self-closing
-            if let Some(gt) = memchr::memchr(b'>', &bytes[next_lt..]) {
-                let tag_end_pos = next_lt + gt;
-                if tag_end_pos > 0 && bytes[tag_end_pos - 1] != b'/' {
+        if let Some((name, _)) = tag_name_at(bytes, next_lt) {
+            // Any start tag is skipped to its real end. Doing so quote-aware
+            // means a `<` or `</template>` embedded in a quoted attribute value
+            // (e.g. `<div title="</template>">`) is consumed as part of this
+            // tag and never mis-counted as a real tag of its own.
+            let is_template = name.eq_ignore_ascii_case(b"template");
+            if let Some(tag_end_pos) = find_start_tag_end(bytes, next_lt) {
+                if is_template && bytes[tag_end_pos - 1] != b'/' {
                     depth += 1;
                 }
                 pos = tag_end_pos + 1;
-            } else {
+            } else if is_template {
                 pos = next_lt + 9;
+            } else {
+                pos = next_lt + 1;
             }
         } else if closing_tag_name_at(bytes, next_lt)
             .is_some_and(|(name, _)| name.eq_ignore_ascii_case(b"template"))
@@ -157,6 +162,53 @@ mod tests {
         assert_eq!(
             extract(source).as_deref(),
             Some("<!-- <template> --><div />")
+        );
+    }
+
+    #[test]
+    fn extract_template_fast_ignores_closing_tag_in_double_quoted_attr() {
+        // `</template>` inside a double-quoted attribute value must not close
+        // the block early.
+        let source = "<template><div title=\"</template>\"><span /></div></template>";
+
+        assert_eq!(
+            extract(source).as_deref(),
+            Some("<div title=\"</template>\"><span /></div>")
+        );
+    }
+
+    #[test]
+    fn extract_template_fast_ignores_closing_tag_in_single_quoted_attr() {
+        // Same for single-quoted attribute values.
+        let source = "<template><div title='</template>'><span /></div></template>";
+
+        assert_eq!(
+            extract(source).as_deref(),
+            Some("<div title='</template>'><span /></div>")
+        );
+    }
+
+    #[test]
+    fn extract_template_fast_ignores_opening_tag_in_quoted_attr() {
+        // A `<template>` substring in a quoted attribute value must not inflate
+        // the nesting depth and swallow the real closing tag.
+        let source = "<template><div data-x=\"<template>\" /></template><script>x</script>";
+
+        assert_eq!(
+            extract(source).as_deref(),
+            Some("<div data-x=\"<template>\" />")
+        );
+    }
+
+    #[test]
+    fn extract_template_fast_handles_gt_in_quoted_attr() {
+        // A `>` inside a quoted attribute value is not the tag's real end, so
+        // the inner `</template>` substring after it stays scoped to the tag.
+        let source = "<template><div title=\"a > </template>\"><span /></div></template>";
+
+        assert_eq!(
+            extract(source).as_deref(),
+            Some("<div title=\"a > </template>\"><span /></div>")
         );
     }
 


### PR DESCRIPTION
## Problem

`extract_template_fast` (`crates/vize_patina/src/linter/engine/template_extract.rs`) scans the template body for tags and tracks nesting depth to find the matching `</template>`. PR #1435 taught it to skip HTML comments, but a remaining edge persisted: a `</template>` (or `<template>`) substring inside a **quoted attribute value** of a start tag in the body — e.g.

```html
<template><div title="</template>"><span /></div></template>
```

was still counted as a real closing tag, dropping depth to 0 early and truncating the extracted template.

## Fix

When the body scan reaches a start tag, it now skips to that tag's **real** `>` quote-aware via a new `find_start_tag_end` helper in `tag_scan.rs`. That helper uses `memchr3` to jump between quote/`>` boundaries and skips over single- and double-quoted attribute values wholesale, so any `<` or `>` embedded in a quoted value is consumed as part of the tag and never mis-scanned as a standalone tag. This covers the closing-`</template>`, opening-`<template>`, and embedded-`>` cases. HTML-comment handling from #1435 is unchanged, and normal templates take the identical path.

## Verification

- `cargo test -p vize_patina` — 1080 passed, 0 failed (4 new tests for double/single-quoted closing tag, quoted opening tag, and `>` inside a quoted value).
- `cargo fmt -p vize_patina --check` — clean.
- `cargo clippy -p vize_patina --lib -- -D warnings` — clean.

Refs #1394

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1477"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->