### PR TITLE
feat(maestro): hover petite-vue v-scope bindings in standalone HTML

### DIFF
--- a/crates/vize_maestro/src/ide/hover.rs
+++ b/crates/vize_maestro/src/ide/hover.rs
@@ -737,6 +737,68 @@ const double = computed(() => count.value * 2)
     }
 
     #[test]
+    fn test_hover_petite_vue_v_scope_binding_in_expression() {
+        let dir = tempfile::tempdir().unwrap();
+        let source_path = dir.path().join("index.html");
+        let source = r#"<script src="https://unpkg.com/petite-vue" defer init></script>
+<div v-scope="{ count: 0, msg: 'x' }">{{ count }}</div>
+"#;
+        fs::write(&source_path, source).unwrap();
+
+        let uri = Url::from_file_path(&source_path).unwrap();
+        let state = ServerState::new();
+        state
+            .documents
+            .open(uri.clone(), source.to_string(), 1, "html".to_string());
+        state.update_virtual_docs(&uri, source);
+
+        // Cursor inside the `{{ count }}` interpolation expression.
+        let offset = source.find("{{ count").unwrap() + "{{ co".len();
+        let ctx = IdeContext::new(&state, &uri, offset).unwrap();
+        let hover = HoverService::hover(&ctx).expect("v-scope binding should produce hover");
+        let value = hover_markdown(hover);
+
+        assert!(value.contains("count"), "got {value:?}");
+        assert!(
+            value.contains("petite-vue scope binding"),
+            "hover should label the binding as a petite-vue scope binding; got {value:?}"
+        );
+    }
+
+    #[test]
+    fn test_hover_petite_vue_v_scope_binding_does_not_leak_to_sibling() {
+        let dir = tempfile::tempdir().unwrap();
+        let source_path = dir.path().join("index.html");
+        let source = r#"<script src="https://unpkg.com/petite-vue" defer init></script>
+<span v-scope="{ count: 0 }">{{ count }}</span><p>{{ count }}</p>
+"#;
+        fs::write(&source_path, source).unwrap();
+
+        let uri = Url::from_file_path(&source_path).unwrap();
+        let state = ServerState::new();
+        state
+            .documents
+            .open(uri.clone(), source.to_string(), 1, "html".to_string());
+        state.update_virtual_docs(&uri, source);
+
+        // Cursor inside the sibling `<p>` interpolation, outside the v-scope subtree.
+        let p_start = source.find("<p>").unwrap();
+        let offset = source[p_start..].find("{{ count").unwrap() + p_start + "{{ co".len();
+        let ctx = IdeContext::new(&state, &uri, offset).unwrap();
+        let hover = HoverService::hover(&ctx);
+
+        // Either no hover, or a generic template-expression hover — but never the
+        // petite-vue scope binding hover, since the binding is out of scope here.
+        if let Some(hover) = hover {
+            let value = hover_markdown(hover);
+            assert!(
+                !value.contains("petite-vue scope binding"),
+                "v-scope binding must not leak to a sibling subtree; got {value:?}"
+            );
+        }
+    }
+
+    #[test]
     fn test_hover_supports_art_variant_binding_at_identifier_boundary() {
         let dir = tempfile::tempdir().unwrap();
         let source_path = dir.path().join("HoverButton.art.vue");

--- a/crates/vize_maestro/src/ide/hover/template.rs
+++ b/crates/vize_maestro/src/ide/hover/template.rs
@@ -40,6 +40,13 @@ impl HoverService {
             return None;
         }
 
+        // petite-vue standalone HTML documents have no SFC `<script>`/`<template>`
+        // split, so the croquis/Corsa paths below find nothing. Resolve the
+        // identifier under the cursor against the `v-scope` scope chain instead.
+        if let Some(hover) = Self::hover_petite_vue_scope_binding(ctx, &word) {
+            return Some(hover);
+        }
+
         // Try to get TypeScript type information from croquis analysis
         if let Some(hover) = Self::hover_ts_binding(ctx, &word) {
             return Some(hover);
@@ -114,6 +121,12 @@ impl HoverService {
 
         if !crate::ide::is_in_vue_template_expression(&ctx.content, ctx.offset) {
             return None;
+        }
+
+        // petite-vue standalone HTML `v-scope` bindings have no virtual TS
+        // declaration for Corsa to resolve; surface them from the scope chain.
+        if let Some(hover) = Self::hover_petite_vue_scope_binding(ctx, &word) {
+            return Some(hover);
         }
 
         // Try to get type information from Corsa via virtual TypeScript.
@@ -236,6 +249,84 @@ impl HoverService {
                     &[
                         "Ref values are automatically unwrapped in templates.",
                         resolved_from,
+                    ],
+                )
+                .build(),
+        )
+    }
+
+    /// Get hover for a petite-vue `v-scope` binding in a standalone HTML
+    /// document.
+    ///
+    /// petite-vue documents have no SFC `<template>` block, so the whole
+    /// document is the template. We parse it with the document parser
+    /// (`<!DOCTYPE>`-tolerant, raw-text `<script>`/`<style>`) and run Croquis
+    /// over the resulting AST. `v-scope` keys are modeled as `v-slot`-kind
+    /// scopes, so the identifier under the cursor resolves through the same
+    /// `bindings_visible_at` walk the completion path uses. Offsets are
+    /// document-absolute (no `<template>` block offset to subtract).
+    ///
+    /// Gated on `is_standalone_html_path` + petite-vue dialect, so `.vue` SFC
+    /// hover is unaffected.
+    pub(super) fn hover_petite_vue_scope_binding(ctx: &IdeContext, word: &str) -> Option<Hover> {
+        use vize_croquis::{Drawer, DrawerOptions, ScopeKind};
+
+        if !crate::utils::is_standalone_html_path(ctx.uri.path()) || !ctx.dialect().is_petite_vue()
+        {
+            return None;
+        }
+
+        let allocator = vize_carton::Bump::new();
+        let (root, _errors) = vize_armature::parse_document(&allocator, &ctx.content);
+
+        let mut drawer = Drawer::with_options(DrawerOptions::full());
+        drawer.draw_template(&root);
+        let croquis = drawer.finish();
+
+        let offset = ctx.offset.min(ctx.content.len()) as u32;
+        let (binding, scope_kind) = croquis
+            .scopes
+            .bindings_visible_at(offset)
+            .into_iter()
+            .find(|(name, _, scope_kind)| {
+                *name == word
+                    && matches!(
+                        scope_kind,
+                        ScopeKind::VSlot
+                            | ScopeKind::VFor
+                            | ScopeKind::EventHandler
+                            | ScopeKind::Callback
+                    )
+            })
+            .map(|(_, binding, scope_kind)| (binding, scope_kind))?;
+
+        let inferred_type = Self::binding_type_to_ts_display(binding.binding_type);
+        #[allow(clippy::disallowed_macros)]
+        let signature = format!("{word}: {inferred_type}");
+
+        let scope_note = match scope_kind {
+            ScopeKind::VFor => {
+                "Local binding introduced by a `v-for` inside the `v-scope` subtree."
+            }
+            ScopeKind::EventHandler | ScopeKind::Callback => {
+                "Local binding visible inside the `v-scope` subtree."
+            }
+            _ => "Reactive key declared by the enclosing `v-scope` object.",
+        };
+
+        Some(
+            HoverBuilder::new()
+                .title(word)
+                .meta("petite-vue scope binding")
+                .code("typescript", &signature)
+                .description(
+                    "Resolved from the petite-vue `v-scope` chain of this standalone HTML document.",
+                )
+                .bullets(
+                    "Behavior",
+                    &[
+                        scope_note,
+                        "Visible only inside its `v-scope` subtree's expressions and directives.",
                     ],
                 )
                 .build(),


### PR DESCRIPTION
## What

petite-vue standalone HTML documents have no SFC `<template>`/`<script>` split, so template hover (`hover_template`) parsed them with `parse_sfc`, found nothing, and surfaced no information when hovering a `v-scope` key inside `{{ }}` or directive expressions. PR #1474 closed the matching completion gap but left hover as the deferred IDE follow-up.

This mirrors that completion path for hover:

- Gated on `is_standalone_html_path(uri) && dialect().is_petite_vue()`, so `.vue` SFC hover is untouched.
- Parses the whole document with `vize_armature::parse_document` and runs a Croquis `Drawer` (`DrawerOptions::full()` + `draw_template`).
- Resolves the identifier under the cursor against the `v-scope` scope chain via `bindings_visible_at` (document-absolute offsets; `v-scope` keys are modeled as `v-slot`-kind scopes), filtering to template scope kinds so siblings outside the subtree do not resolve.
- Returns a hover labelling it a **petite-vue scope binding** (name + type from `binding_type_to_ts_display` + scope note), reusing the existing `HoverBuilder`.
- Wired into both the sync `hover_template` and the `hover_template_with_corsa` paths, ahead of the SFC/Corsa lookups (which have no virtual TS declaration for `v-scope` keys to resolve).

Self-contained to `vize_maestro`; no other crate source touched.

## Verification

- `cargo test -p vize_maestro` — 310 passed (incl. 2 new hover tests: in-scope `v-scope` key resolves and labels as a petite-vue scope binding; sibling subtree does not leak the binding).
- `cargo fmt -p vize_maestro --check` — clean.
- `cargo clippy -p vize_maestro --lib -- -D warnings` — clean.

Refs #1393

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1478"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->