### PR TITLE
feat(canon): thread configured Vue dialect into virtual-TS path

### DIFF
--- a/crates/vize/src/commands/check/runner/global_components.rs
+++ b/crates/vize/src/commands/check/runner/global_components.rs
@@ -63,6 +63,18 @@ pub(super) fn build_virtual_ts_options(
     }
 }
 
+/// Resolve the configured Vue dialect for canon's virtual-TS generation.
+///
+/// `vue.version` is optional in `vize.config`; an unset value means the default
+/// Vue 3 dialect. Plumbing only today (issue #1392): the resolved dialect is
+/// threaded into canon so it can later emit dialect-aware instance types, but it
+/// does not change generated output yet.
+pub(super) fn dialect_from_features(
+    vue_version: Option<crate::config::VueVersion>,
+) -> crate::config::VueVersion {
+    vue_version.unwrap_or(crate::config::VueVersion::V3)
+}
+
 pub(super) fn template_syntax_mode(
     template_syntax: Option<&str>,
 ) -> vize_atelier_core::TemplateSyntaxMode {

--- a/crates/vize/src/commands/check/runner/mod.rs
+++ b/crates/vize/src/commands/check/runner/mod.rs
@@ -46,7 +46,8 @@ use diagnostics::{
     save_virtual_ts_for_path, write_profile_virtual_ts,
 };
 use global_components::{
-    build_virtual_ts_options, collect_project_global_component_stubs, template_syntax_mode,
+    build_virtual_ts_options, collect_project_global_component_stubs, dialect_from_features,
+    template_syntax_mode,
 };
 use nuxt_tsconfig::resolve_checker_tsconfig_path;
 #[cfg(test)]
@@ -98,6 +99,10 @@ pub(crate) fn run_direct(args: &CheckArgs) {
         .source_path
         .as_deref()
         .and_then(|path| crate::config::load_compiler_template_syntax(Some(path)));
+    // Configured Vue dialect (`vue.version`). Defaults to Vue 3 when unset.
+    // Plumbing only today: threaded into canon's virtual-TS generation so it can
+    // later emit dialect-aware instance types; it does not change output yet.
+    let dialect = dialect_from_features(loaded_config.features.vue_version);
     // Vue 3 Options API binding resolution is officially supported and is a
     // standard-build opt-in (not the `legacy` feature).
     let options_api = loaded_config.features.type_checker_options_api;
@@ -304,6 +309,7 @@ pub(crate) fn run_direct(args: &CheckArgs) {
         checker.enable_legacy_vue2();
     }
     checker.set_template_syntax(template_syntax_mode(compiler_template_syntax));
+    checker.set_dialect(dialect);
     checker.set_virtual_ts_checks(
         config.type_checker.check_props && !args.no_check_props,
         config.type_checker.check_template_bindings && !args.no_check_template_bindings,

--- a/crates/vize/src/commands/check/runner/tests.rs
+++ b/crates/vize/src/commands/check/runner/tests.rs
@@ -1,5 +1,5 @@
 use super::{
-    collect_project_global_component_stubs, find_nearest_tsconfig_dir,
+    collect_project_global_component_stubs, dialect_from_features, find_nearest_tsconfig_dir,
     is_suppressed_false_positive, resolve_declaration_dir, resolve_declaration_emit_options,
     resolve_project_root, resolve_tsconfig_path, validate_corsa_server_count,
     write_nuxt_fallback_tsconfig,
@@ -331,6 +331,22 @@ fn writes_nuxt_fallback_tsconfig_without_overwriting_existing_paths() {
     assert_eq!(paths["#shared/*"], serde_json::json!(["../../../shared/*"]));
 
     let _ = std::fs::remove_dir_all(&project_root);
+}
+
+#[test]
+fn resolves_configured_vue_dialect_for_canon_generation() {
+    use crate::config::VueVersion;
+
+    // Plumbing for issue #1392: `vue.version` from config reaches canon's
+    // virtual-TS generation. An explicit Vue 2 config selects V2; an unset
+    // `vue.version` defaults to Vue 3 so the default path stays unchanged.
+    assert_eq!(dialect_from_features(Some(VueVersion::V2)), VueVersion::V2);
+    assert_eq!(
+        dialect_from_features(Some(VueVersion::V2_7)),
+        VueVersion::V2_7
+    );
+    assert_eq!(dialect_from_features(None), VueVersion::V3);
+    assert_eq!(dialect_from_features(Some(VueVersion::V3)), VueVersion::V3);
 }
 
 #[test]

--- a/crates/vize_canon/src/batch/type_checker.rs
+++ b/crates/vize_canon/src/batch/type_checker.rs
@@ -183,6 +183,17 @@ impl BatchTypeChecker {
         self.project.set_template_syntax(template_syntax);
     }
 
+    /// Set the configured Vue dialect (`vue.version`; default
+    /// [`VueVersion::V3`](vize_carton::config::VueVersion::V3)).
+    ///
+    /// Plumbing only today: the dialect is threaded into virtual-TS generation
+    /// so canon can later emit dialect-aware instance types (e.g. a Vue 2 `this`
+    /// shape). It does not change generated output yet, so the default V3 path
+    /// stays byte-identical.
+    pub fn set_dialect(&mut self, dialect: vize_carton::config::VueVersion) {
+        self.project.set_dialect(dialect);
+    }
+
     /// Scan an explicit set of project files.
     ///
     /// The underlying virtual project parallelizes registration for multi-file

--- a/crates/vize_canon/src/batch/virtual_project/build.rs
+++ b/crates/vize_canon/src/batch/virtual_project/build.rs
@@ -43,6 +43,8 @@ pub(super) struct VirtualBuildContext<'a> {
     pub(super) preserve_unused_diagnostics: bool,
     pub(super) options_api: bool,
     pub(super) legacy_vue2: bool,
+    /// Configured Vue dialect (default [`VueVersion::V3`]); plumbing only today.
+    pub(super) dialect: vize_carton::config::VueVersion,
     pub(super) template_syntax: TemplateSyntaxMode,
     pub(super) rewriter: &'a ImportRewriter,
 }
@@ -115,6 +117,7 @@ pub(super) fn build_vue_registered_file(
                 preserve_unused_diagnostics: context.preserve_unused_diagnostics,
                 options_api: context.options_api,
                 legacy_vue2: context.legacy_vue2,
+                dialect: context.dialect,
                 template_syntax: context.template_syntax,
                 hoist_shared_preamble: true,
             },
@@ -206,6 +209,8 @@ pub fn generate_vue_document_virtual_ts(
             preserve_unused_diagnostics: false,
             options_api: false,
             legacy_vue2: false,
+            // Single-document socket path is always the default Vue 3 dialect.
+            dialect: vize_carton::config::VueVersion::default(),
             template_syntax: TemplateSyntaxMode::default(),
             hoist_shared_preamble,
         },

--- a/crates/vize_canon/src/batch/virtual_project/mod.rs
+++ b/crates/vize_canon/src/batch/virtual_project/mod.rs
@@ -94,6 +94,12 @@ pub struct VirtualProject {
     options_api: bool,
     legacy_vue2: bool,
 
+    /// Configured Vue dialect from `vue.version` (default [`VueVersion::V3`]).
+    ///
+    /// Threaded in for future dialect-aware instance typing; plumbing only
+    /// today, so it does not affect generated virtual TS yet.
+    dialect: vize_carton::config::VueVersion,
+
     /// Template syntax compatibility used when parsing SFC templates.
     template_syntax: TemplateSyntaxMode,
 

--- a/crates/vize_canon/src/batch/virtual_project/project.rs
+++ b/crates/vize_canon/src/batch/virtual_project/project.rs
@@ -40,6 +40,7 @@ impl VirtualProject {
             virtual_ts_check_options: VirtualTsCheckOptions::default(),
             options_api: false,
             legacy_vue2: false,
+            dialect: vize_carton::config::VueVersion::default(),
             template_syntax: TemplateSyntaxMode::default(),
             virtual_files: FxHashMap::default(),
             passthrough_files: FxHashMap::default(),
@@ -76,6 +77,14 @@ impl VirtualProject {
         self.legacy_vue2 = enabled;
     }
 
+    /// Set the configured Vue dialect (default [`VueVersion::V3`]).
+    ///
+    /// Plumbing only today: carried into virtual-TS generation for future
+    /// dialect-aware instance typing without changing current output.
+    pub(crate) fn set_dialect(&mut self, dialect: vize_carton::config::VueVersion) {
+        self.dialect = dialect;
+    }
+
     pub(crate) fn set_template_syntax(&mut self, template_syntax: TemplateSyntaxMode) {
         self.template_syntax = template_syntax;
     }
@@ -109,6 +118,7 @@ impl VirtualProject {
                 preserve_unused_diagnostics: self.tsconfig_preserves_unused_diagnostics(),
                 options_api: self.options_api,
                 legacy_vue2: self.legacy_vue2,
+                dialect: self.dialect,
                 template_syntax: self.template_syntax,
                 rewriter: &self.rewriter,
             },
@@ -154,6 +164,7 @@ impl VirtualProject {
             preserve_unused_diagnostics,
             options_api: self.options_api,
             legacy_vue2: self.legacy_vue2,
+            dialect: self.dialect,
             template_syntax: self.template_syntax,
             rewriter: &self.rewriter,
         };
@@ -186,6 +197,7 @@ impl VirtualProject {
                 preserve_unused_diagnostics: self.tsconfig_preserves_unused_diagnostics(),
                 options_api: self.options_api,
                 legacy_vue2: self.legacy_vue2,
+                dialect: self.dialect,
                 template_syntax: self.template_syntax,
                 rewriter: &self.rewriter,
             },

--- a/crates/vize_canon/src/batch/virtual_project/tests.rs
+++ b/crates/vize_canon/src/batch/virtual_project/tests.rs
@@ -196,6 +196,67 @@ defineProps<{
 }
 
 #[test]
+fn test_configured_dialect_threads_through_generation_without_changing_output() {
+    // Plumbing check for issue #1392: a configured non-default Vue dialect
+    // (`vue.version`) is threaded through `set_dialect` into virtual-TS
+    // generation. This PR is plumbing only, so the dialect must reach the
+    // generator without changing output yet — Vue 2 output is byte-identical to
+    // the default Vue 3 output until the dialect-aware emission lands.
+    let vue_content = r#"<script setup lang="ts">
+defineProps<{
+  test: string
+}>()
+</script>
+
+<template>
+  <div>{{ test }}</div>
+</template>
+"#;
+
+    let v3_dir = unique_case_dir("dialect-default-v3");
+    let _ = fs::remove_dir_all(&v3_dir);
+    let v3_src = v3_dir.join("src");
+    fs::create_dir_all(&v3_src).unwrap();
+    let v3_path = v3_src.join("App.vue");
+    fs::write(&v3_path, vue_content).unwrap();
+
+    let mut default_project = VirtualProject::new(&v3_dir).unwrap();
+    // No `set_dialect` call: the default is Vue 3.
+    default_project.register_path(&v3_path).unwrap();
+    let default_content = default_project
+        .find_by_original(&v3_path)
+        .unwrap()
+        .content
+        .clone();
+
+    let v2_dir = unique_case_dir("dialect-v2");
+    let _ = fs::remove_dir_all(&v2_dir);
+    let v2_src = v2_dir.join("src");
+    fs::create_dir_all(&v2_src).unwrap();
+    let v2_path = v2_src.join("App.vue");
+    fs::write(&v2_path, vue_content).unwrap();
+
+    let mut v2_project = VirtualProject::new(&v2_dir).unwrap();
+    v2_project.set_dialect(vize_carton::config::VueVersion::V2);
+    v2_project.register_path(&v2_path).unwrap();
+    let v2_content = v2_project
+        .find_by_original(&v2_path)
+        .unwrap()
+        .content
+        .clone();
+
+    // The dialect reached generation (the call compiles and registration
+    // succeeds), and plumbing-only means default-V3 output is unchanged.
+    assert_eq!(
+        v2_content, default_content,
+        "plumbing-only: Vue 2 dialect must not change generated virtual TS yet"
+    );
+
+    let _ = fs::remove_dir_all(&v3_dir);
+    let _ = fs::remove_dir_all(&v2_dir);
+}
+
+#[test]
 fn test_register_vue_file_reports_script_parse_error_with_fallback() {
     let case_dir = unique_case_dir("script-parse-error");
     let _ = fs::remove_dir_all(&case_dir);

--- a/crates/vize_canon/src/batch/virtual_project/vue_codegen.rs
+++ b/crates/vize_canon/src/batch/virtual_project/vue_codegen.rs
@@ -44,6 +44,8 @@ pub(super) struct VueCodegenOptions {
     pub(super) preserve_unused_diagnostics: bool,
     pub(super) options_api: bool,
     pub(super) legacy_vue2: bool,
+    /// Configured Vue dialect (default [`VueVersion::V3`]); plumbing only today.
+    pub(super) dialect: vize_carton::config::VueVersion,
     pub(super) template_syntax: TemplateSyntaxMode,
     /// Whether the shared preamble (ImportMeta augmentation + helper types) is
     /// hoisted to a program-wide ambient `.d.ts`. The batch path materializes
@@ -190,6 +192,7 @@ pub(super) fn generate_vue_virtual_ts(
             options,
             VirtualTsGenerationOptions {
                 check_options: codegen_options.check_options,
+                dialect: codegen_options.dialect,
                 preserve_unused_diagnostics: codegen_options.preserve_unused_diagnostics,
                 options_api: codegen_options.options_api,
                 legacy_vue2: codegen_options.legacy_vue2,

--- a/crates/vize_canon/src/virtual_ts/generator/mod.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/mod.rs
@@ -148,6 +148,12 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
     generation_options: VirtualTsGenerationOptions,
 ) -> VirtualTsOutput {
     let check_options = generation_options.check_options;
+    // Configured Vue dialect, plumbed in for future dialect-aware instance
+    // typing (e.g. a Vue 2 `this` shape). Not branched on yet: today's output is
+    // dialect-independent, so reading it here only anchors the plumbing without
+    // changing generated TS. The leading underscore keeps the unused binding
+    // explicit until the dialect-aware emission lands.
+    let _dialect = generation_options.dialect;
     let legacy_vue2 = generation_options.legacy_vue2;
     let options_api = generation_options.options_api || legacy_vue2;
     let hoist_shared_preamble = generation_options.hoist_shared_preamble;

--- a/crates/vize_canon/src/virtual_ts/types.rs
+++ b/crates/vize_canon/src/virtual_ts/types.rs
@@ -2,6 +2,7 @@
 
 use std::ops::Range;
 use vize_carton::String;
+use vize_carton::config::VueVersion;
 
 /// A mapping from generated virtual TS position to SFC source position.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -107,6 +108,13 @@ impl Default for VirtualTsCheckOptions {
 #[derive(Debug, Clone, Copy, Default)]
 pub(crate) struct VirtualTsGenerationOptions {
     pub(crate) check_options: VirtualTsCheckOptions,
+    /// Configured Vue dialect for this project (default [`VueVersion::V3`]).
+    ///
+    /// Threaded from `vue.version` in `vize.config` through the check runner so
+    /// canon can later emit dialect-aware instance types (e.g. a Vue 2 `this`
+    /// shape). Plumbing only today: the generator carries it but does not branch
+    /// on it yet, so default-V3 output stays byte-identical.
+    pub(crate) dialect: VueVersion,
     /// Resolve Vue 3 Options API template bindings (opt-in, standard build).
     pub(crate) options_api: bool,
     /// Legacy Vue 2.7 / Nuxt 2 (implies `options_api` plus Nuxt 2 globals).


### PR DESCRIPTION
## What

Threads the configured Vue dialect (`vue.version` from `vize.config`,
`features.vue_version`) from the `vize check` runner into canon's
virtual-TS generation, so canon can later emit dialect-aware instance
types (e.g. a Vue 2 `this` shape) instead of always assuming Vue 3.

The dialect flows: runner (`dialect_from_features`) →
`BatchTypeChecker::set_dialect` → `VirtualProject` (private field) →
`VirtualBuildContext` → `VueCodegenOptions` →
`VirtualTsGenerationOptions.dialect` (held by the generator).

Background: #1458 threaded `dialect: VueVersion` (default V3) into the
*compiler* options, but canon's virtual-TS / `vize check` path never
received it, so canon always emitted Vue 3 virtual TS even for a
`vue.version: "v2"` project. This closes that gap on the check side.

## Plumbing only

No behavior change yet. The generator carries the dialect but does not
branch on it, so default-V3 output is byte-identical. The dialect-aware
emission lands in a follow-up.

## Semver

No new `pub` field on an all-pub struct (the trap from #1458). The only
new public surface is a method, `BatchTypeChecker::set_dialect` (a
non-breaking minor addition). All new fields live on `pub(crate)` /
`pub(super)` / private structs (`VirtualTsGenerationOptions`,
`VueCodegenOptions`, `VirtualBuildContext`, `VirtualProject`).
`cargo semver-checks check-release` is clean for both `vize_canon` and
`vize_carton`.

## Verification

- `cargo semver-checks check-release` — clean for `vize_canon` and `vize_carton`
- `cargo test` — `vize_canon` (344), `vize_carton`, `vize` runner all green
  (pre-existing env-only failure `inspector_compare_outputs_cli_diff_report_when_dev_runtime_is_available`,
  reproduces on clean `main`)
- `cargo run -p vize_test_runner --bin coverage` — VDOM 457/457, SFC 167/167
  (the lone Vapor miss is a known v1-alpha failure)
- `cargo fmt --check` + `cargo clippy --lib -D warnings` — clean for touched crates
- New tests: `resolves_configured_vue_dialect_for_canon_generation`
  (config → dialect mapping, default → V3) and
  `test_configured_dialect_threads_through_generation_without_changing_output`
  (a `set_dialect(V2)` project's generated virtual TS is byte-identical to default V3)

Refs #1392

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1485"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->