### PR TITLE
feat(canon): type Vue 2 template instance members from dialect

### DIFF
--- a/crates/vize_canon/src/batch/virtual_project/tests.rs
+++ b/crates/vize_canon/src/batch/virtual_project/tests.rs
@@ -196,12 +196,13 @@ defineProps<{
 }
 
 #[test]
-fn test_configured_dialect_threads_through_generation_without_changing_output() {
-    // Plumbing check for issue #1392: a configured non-default Vue dialect
-    // (`vue.version`) is threaded through `set_dialect` into virtual-TS
-    // generation. This PR is plumbing only, so the dialect must reach the
-    // generator without changing output yet — Vue 2 output is byte-identical to
-    // the default Vue 3 output until the dialect-aware emission lands.
+fn test_configured_dialect_drives_dialect_aware_instance_typing() {
+    // Issue #1392: a configured non-default Vue dialect (`vue.version`) is
+    // threaded through `set_dialect` into virtual-TS generation and now drives
+    // dialect-aware template instance typing. A Vue 2 dialect augments the
+    // template context with Vue 2-only public-instance members (`$listeners`,
+    // `$children`, ...) so legacy templates type-check, while the default Vue 3
+    // dialect stays byte-identical to before.
     let vue_content = r#"<script setup lang="ts">
 defineProps<{
   test: string
@@ -245,11 +246,23 @@ defineProps<{
         .content
         .clone();
 
-    // The dialect reached generation (the call compiles and registration
-    // succeeds), and plumbing-only means default-V3 output is unchanged.
-    assert_eq!(
+    // The default Vue 3 output never gains Vue 2-only members.
+    assert!(
+        !default_content.contains("$listeners"),
+        "default Vue 3 output must not emit Vue 2-only instance members"
+    );
+    // The Vue 2 dialect augments the template instance context.
+    assert!(
+        v2_content.contains("const $listeners = undefined as any;"),
+        "Vue 2 dialect must emit Vue 2-only instance members"
+    );
+    assert!(
+        v2_content.contains("const $children = undefined as any;"),
+        "Vue 2 dialect must emit Vue 2-only instance members"
+    );
+    assert_ne!(
         v2_content, default_content,
-        "plumbing-only: Vue 2 dialect must not change generated virtual TS yet"
+        "Vue 2 dialect output must differ from default Vue 3 output"
     );
 
     let _ = fs::remove_dir_all(&v3_dir);

--- a/crates/vize_canon/src/virtual_ts/generator/mod.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/mod.rs
@@ -148,12 +148,11 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
     generation_options: VirtualTsGenerationOptions,
 ) -> VirtualTsOutput {
     let check_options = generation_options.check_options;
-    // Configured Vue dialect, plumbed in for future dialect-aware instance
-    // typing (e.g. a Vue 2 `this` shape). Not branched on yet: today's output is
-    // dialect-independent, so reading it here only anchors the plumbing without
-    // changing generated TS. The leading underscore keeps the unused binding
-    // explicit until the dialect-aware emission lands.
-    let _dialect = generation_options.dialect;
+    // Configured Vue dialect, used to emit dialect-aware template instance
+    // typing (e.g. a Vue 2 `this`/template shape with `$listeners`,
+    // `$children`, `$on`, ... that Vue 3's `ComponentPublicInstance` lacks).
+    // Vue 3 (the default) is unaffected: its output stays byte-identical.
+    let dialect = generation_options.dialect;
     let legacy_vue2 = generation_options.legacy_vue2;
     let options_api = generation_options.options_api || legacy_vue2;
     let hoist_shared_preamble = generation_options.hoist_shared_preamble;
@@ -783,7 +782,7 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
             // Vue template context (available in template expressions)
             let template_context = profile!(
                 "canon.virtual_ts.generate_template_context",
-                generate_template_context(options)
+                generate_template_context(options, dialect)
             );
             ts.push_str(&template_context);
             ts.push('\n');

--- a/crates/vize_canon/src/virtual_ts/helpers.rs
+++ b/crates/vize_canon/src/virtual_ts/helpers.rs
@@ -8,6 +8,7 @@ use std::ops::Range;
 use super::types::VirtualTsOptions;
 use vize_carton::String;
 use vize_carton::append;
+use vize_carton::config::VueVersion;
 use vize_croquis::macros::{
     DEFINE_EMITS, DEFINE_EXPOSE, DEFINE_MODEL, DEFINE_PROPS, DEFINE_SLOTS, WITH_DEFAULTS,
 };
@@ -232,16 +233,48 @@ pub const DECLARATION_HELPERS_DTS: &str = concat!(
     emit_overload_helpers_text!(),
 );
 
+/// Vue 2-only public-instance members that are absent from Vue 3's
+/// `ComponentPublicInstance`.
+///
+/// In a Vue 2 / 2.7 dialect, template (and `this`) references such as
+/// `$listeners`, `$children`, `$scopedSlots`, the `$on`/`$off`/`$once` event
+/// emitter, `$set`/`$delete`, and `$createElement`/`_c` are valid but resolve
+/// to nothing on the Vue 3 instance type, so Corsa would false-error on them.
+/// They are emitted as permissive `any` bindings so v2 templates type-check.
+/// Vue 3 output never emits these, so it stays byte-identical.
+const VUE2_INSTANCE_MEMBERS: &[&str] = &[
+    "$listeners",
+    "$children",
+    "$scopedSlots",
+    "$on",
+    "$off",
+    "$once",
+    "$set",
+    "$delete",
+    "$createElement",
+    "_c",
+];
+
 /// Generate Vue template context declarations dynamically.
 ///
 /// Derives `$`-prefixed globals from `ComponentPublicInstance` so that
 /// type resolution is delegated to Corsa via Vue's type system
 /// (including `ComponentCustomProperties` augmentations from plugins).
-pub(crate) fn generate_template_context(options: &VirtualTsOptions) -> String {
+///
+/// When `dialect` is a Vue 2 line (`V2` / `V2_7`), the context is additionally
+/// augmented with Vue 2-only public-instance members (see
+/// [`VUE2_INSTANCE_MEMBERS`]) so legacy templates do not false-error. Vue 3
+/// (the default) emits the exact same output as before — byte-identical.
+pub(crate) fn generate_template_context(options: &VirtualTsOptions, dialect: VueVersion) -> String {
     let mut ctx = String::default();
 
     let needs_global_helper =
         !options.template_globals.is_empty() || !options.css_modules.is_empty();
+
+    // Vue 2 / 2.7 share a template dialect whose public instance still exposes
+    // members removed in Vue 3 (`$listeners`, `$children`, the `$on`/`$off`/
+    // `$once` event emitter, `$set`/`$delete`, `$createElement`, ...).
+    let vue2_dialect = matches!(dialect, VueVersion::V2 | VueVersion::V2_7);
 
     // Instance type + conditional accessor helper
     ctx.push_str("    // Vue template context (delegates to ComponentPublicInstance)\n");
@@ -256,6 +289,14 @@ pub(crate) fn generate_template_context(options: &VirtualTsOptions) -> String {
     ctx.push_str("    const $slots = __ctx.$slots;\n");
     ctx.push_str("    const $refs = __ctx.$refs;\n");
     ctx.push_str("    const $emit = __ctx.$emit;\n");
+
+    // Vue 2-only instance members (absent from Vue 3's ComponentPublicInstance).
+    if vue2_dialect {
+        ctx.push_str("    // Vue 2 instance members (not on Vue 3 ComponentPublicInstance)\n");
+        for member in VUE2_INSTANCE_MEMBERS {
+            append!(ctx, "    const {member} = undefined as any;\n");
+        }
+    }
 
     // Plugin globals (resolved via ComponentCustomProperties if augmented,
     // otherwise falls back to the configured type_annotation)
@@ -286,6 +327,13 @@ pub(crate) fn generate_template_context(options: &VirtualTsOptions) -> String {
 
     // Mark all as used
     ctx.push_str("    void __ctx; void $attrs; void $slots; void $refs; void $emit;\n");
+    if vue2_dialect {
+        ctx.push_str("    ");
+        for member in VUE2_INSTANCE_MEMBERS {
+            append!(ctx, "void {member};");
+        }
+        ctx.push('\n');
+    }
     if !options.template_globals.is_empty() {
         ctx.push_str("    ");
         for (i, global) in options.template_globals.iter().enumerate() {

--- a/crates/vize_canon/src/virtual_ts/tests.rs
+++ b/crates/vize_canon/src/virtual_ts/tests.rs
@@ -26,8 +26,72 @@ fn test_vue_setup_helpers_are_actual_functions() {
 #[test]
 fn test_vue_template_context() {
     // Template context should contain Vue instance properties
-    let ctx = generate_template_context(&VirtualTsOptions::default());
+    let ctx = generate_template_context(
+        &VirtualTsOptions::default(),
+        vize_carton::config::VueVersion::V3,
+    );
     assert_virtual_ts_snapshot("virtual_ts_vue_template_context", ctx.as_str());
+}
+
+#[test]
+fn test_vue_template_context_v3_default_is_unchanged() {
+    // The default Vue 3 dialect must emit the exact same context as the
+    // dialect-unaware default — no Vue 2-only members leak into Vue 3.
+    let v3 = generate_template_context(
+        &VirtualTsOptions::default(),
+        vize_carton::config::VueVersion::V3,
+    );
+    assert!(!v3.contains("$listeners"));
+    assert!(!v3.contains("$children"));
+    assert!(!v3.contains("$scopedSlots"));
+    assert!(!v3.contains("$createElement"));
+    assert!(!v3.contains("Vue 2 instance members"));
+}
+
+#[test]
+fn test_vue_template_context_v2_dialect_adds_vue2_members() {
+    // A Vue 2 dialect augments the template context with Vue 2-only public
+    // instance members so legacy templates ($listeners, $children, the
+    // $on/$off/$once emitter, $set/$delete, $createElement, ...) type-check.
+    let v2 = generate_template_context(
+        &VirtualTsOptions::default(),
+        vize_carton::config::VueVersion::V2,
+    );
+    for member in [
+        "$listeners",
+        "$children",
+        "$scopedSlots",
+        "$on",
+        "$off",
+        "$once",
+        "$set",
+        "$delete",
+        "$createElement",
+        "_c",
+    ] {
+        assert!(
+            v2.contains(&format!("const {member} = undefined as any;")),
+            "Vue 2 context should declare `{member}`"
+        );
+        assert!(
+            v2.contains(&format!("void {member};")),
+            "Vue 2 context should mark `{member}` as used"
+        );
+    }
+    // Vue 2.7 shares the same template-instance shape.
+    let v2_7 = generate_template_context(
+        &VirtualTsOptions::default(),
+        vize_carton::config::VueVersion::V2_7,
+    );
+    assert!(v2_7.contains("const $listeners = undefined as any;"));
+
+    // Vue 3 must NOT contain any of these (byte-identical to before).
+    let v3 = generate_template_context(
+        &VirtualTsOptions::default(),
+        vize_carton::config::VueVersion::V3,
+    );
+    assert!(!v3.contains("$listeners"));
+    assert!(!v3.contains("$createElement"));
 }
 
 #[test]
@@ -48,7 +112,7 @@ fn test_vue_template_context_with_globals() {
         ],
         ..Default::default()
     };
-    let ctx = generate_template_context(&options);
+    let ctx = generate_template_context(&options, vize_carton::config::VueVersion::V3);
     assert_virtual_ts_snapshot("virtual_ts_vue_template_context_with_globals", ctx.as_str());
 }
 


### PR DESCRIPTION
## What

For Options API / template scopes, canon types the template context against Vue 3's `ComponentPublicInstance`. Vue 2's public instance exposes members removed in Vue 3, so v2 templates referencing them (e.g. `$listeners`, `this.$children`) false-error instead of type-checking.

This PR makes the template instance context **dialect-aware**: when the configured dialect (`vue.version`) is V2/V2.7, the generated template context is augmented with Vue 2-only instance members. The dialect is read from `VirtualTsGenerationOptions.dialect` (plumbed by #1485) right at the template-context emission point, replacing the prior `let _dialect` anchor.

## Vue 2 members added

Emitted as permissive `any` bindings (declared + `void`-marked) only when the dialect is `V2`/`V2_7`:

`$listeners`, `$children`, `$scopedSlots`, `$on`, `$off`, `$once`, `$set`, `$delete`, `$createElement`, `_c`

## Byte-identical Vue 3

Vue 3 (the default) emits the exact same output as before — no Vue 2-only members are produced. The existing `virtual_ts_vue_template_context` snapshot is **unchanged** (no `.snap` diff), and a dedicated test asserts Vue 3 never contains any v2 member. Full `cargo test -p vize_canon` (+ `--features native`) is green: 346/346.

## Verification

- `cargo test -p vize_canon` and `--features native`: 346 passed
- `cargo fmt --check`: clean
- `cargo clippy -p vize_canon --lib -- -D warnings`: clean
- New tests: V2 dialect adds `$listeners`/`$children`/... (unit + end-to-end via `VirtualProject::set_dialect`); V3 default stays byte-identical
- semver: no new pub fields (dialect was already plumbed via `pub(crate)` by #1485; `generate_template_context` is `pub(crate)`)

## Notes

Stacked on #1485 (`feat/canon-dialect-plumbing`) — that PR threads the dialect through to the generator; this PR consumes it. Base for review is the plumbing branch until #1485 merges.

Refs #1392

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1486"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->