### PR TITLE
feat(armature): support Vue 1.x triple-mustache raw-HTML interpolation

### DIFF
--- a/crates/vize_armature/Cargo.toml
+++ b/crates/vize_armature/Cargo.toml
@@ -9,8 +9,10 @@ description = "Armature - The structural parser framework for Vize Vue templates
 
 [features]
 # Opt-in support for legacy Vue lines (v0.10 / v0.11 / v1 / v2). Off by default so the
-# Vue 3 `vize` binary never compiles it. See the `legacy` module.
-legacy = []
+# Vue 3 `vize` binary never compiles it. See the `legacy` module. Forwards to
+# `vize_relief/_legacy` so legacy-only AST surface (e.g. the Vue 1 raw-HTML
+# `InterpolationNode::raw` flag this parser sets) is available.
+legacy = ["vize_relief/_legacy"]
 
 [dependencies]
 vize_carton = { workspace = true }

--- a/crates/vize_armature/src/legacy.rs
+++ b/crates/vize_armature/src/legacy.rs
@@ -141,6 +141,7 @@ impl LegacyVueVersion {
                 computed_dollar_get_set: true,
                 attr_value_interpolation: true,
                 scoped_slot_attrs: false,
+                raw_html_interpolation: true,
             },
             Self::V0_11 => LegacyDialectCapabilities {
                 supports_filters: true,
@@ -152,6 +153,7 @@ impl LegacyVueVersion {
                 computed_dollar_get_set: false,
                 attr_value_interpolation: true,
                 scoped_slot_attrs: false,
+                raw_html_interpolation: true,
             },
             Self::V1 => LegacyDialectCapabilities {
                 supports_filters: true,
@@ -163,6 +165,7 @@ impl LegacyVueVersion {
                 computed_dollar_get_set: false,
                 attr_value_interpolation: true,
                 scoped_slot_attrs: false,
+                raw_html_interpolation: true,
             },
             Self::V2 => LegacyDialectCapabilities {
                 supports_filters: true,
@@ -174,6 +177,7 @@ impl LegacyVueVersion {
                 computed_dollar_get_set: false,
                 attr_value_interpolation: false,
                 scoped_slot_attrs: true,
+                raw_html_interpolation: false,
             },
         }
     }
@@ -239,6 +243,13 @@ pub struct LegacyDialectCapabilities {
     /// Scoped-slot attribute sugar: `scope` (added in 2.1) and `slot-scope`
     /// (added in 2.5). Vue 2 only; superseded by `v-slot` in 2.6 and Vue 3.
     pub scoped_slot_attrs: bool,
+    /// Triple-mustache raw-HTML (unescaped) text interpolation,
+    /// `{{{ html }}}` — the pre-Vue-2 equivalent of `v-html`. Vue 0.x / 1.x;
+    /// removed in Vue 2 in favor of `v-html` (Vue 2 migration guide,
+    /// "Interpolation"). Vue 2+ treats `{{{ x }}}` as an ordinary `{{ … }}`
+    /// mustache containing a stray brace, which is also the default (Vue 3)
+    /// behavior.
+    pub raw_html_interpolation: bool,
 }
 
 impl LegacyDialectCapabilities {
@@ -258,6 +269,7 @@ impl LegacyDialectCapabilities {
         computed_dollar_get_set: false,
         attr_value_interpolation: false,
         scoped_slot_attrs: false,
+        raw_html_interpolation: false,
     };
 
     /// Resolve a config-selected [`VueVersion`] straight to its capability
@@ -317,6 +329,8 @@ mod tests {
         assert!(v0_10.v_repeat_syntax && v0_11.v_repeat_syntax);
         assert!(v0_10.v_with_directive && v0_11.v_with_directive);
         assert!(v0_10.v_component_directive && v0_11.v_component_directive);
+        // Both 0.x lines support `{{{ html }}}` raw-HTML interpolation.
+        assert!(v0_10.raw_html_interpolation && v0_11.raw_html_interpolation);
     }
 
     #[test]
@@ -329,6 +343,8 @@ mod tests {
         assert!(!v1.v_with_directive && !v1.v_component_directive);
         assert!(v1.supports_filters && v1.space_separated_filter_args);
         assert!(v1.attr_value_interpolation);
+        // Vue 1.x keeps the `{{{ html }}}` raw-HTML interpolation.
+        assert!(v1.raw_html_interpolation);
     }
 
     #[test]
@@ -339,6 +355,8 @@ mod tests {
         assert!(v1.space_separated_filter_args && !v2.space_separated_filter_args);
         assert!(v1.attr_value_interpolation && !v2.attr_value_interpolation);
         assert!(!v1.scoped_slot_attrs && v2.scoped_slot_attrs);
+        // Vue 2 dropped triple-mustache raw-HTML interpolation in favor of `v-html`.
+        assert!(v1.raw_html_interpolation && !v2.raw_html_interpolation);
     }
 
     #[test]
@@ -359,6 +377,7 @@ mod tests {
         assert_eq!(caps, LegacyDialectCapabilities::default());
         assert!(!caps.supports_filters);
         assert!(!caps.v_repeat_syntax);
+        assert!(!caps.raw_html_interpolation);
         assert_eq!(caps.directive_arg_style, DirectiveArgStyle::Colon);
         // Every legacy line differs from the default set, so a capability
         // check can never confuse a legacy document with a Vue 3 one.

--- a/crates/vize_armature/src/parser.rs
+++ b/crates/vize_armature/src/parser.rs
@@ -216,6 +216,15 @@ impl<'a> Parser<'a> {
         parser
     }
 
+    /// Whether the configured dialect recognizes Vue 1.x triple-mustache
+    /// raw-HTML interpolation (`{{{ expr }}}`). Resolved once per file from the
+    /// dialect capabilities; `false` for the default Vue 3 dialect.
+    #[cfg(feature = "legacy")]
+    fn raw_html_interpolation_enabled(&self) -> bool {
+        crate::legacy::LegacyDialectCapabilities::for_dialect(self.options.dialect)
+            .raw_html_interpolation
+    }
+
     /// Parse the source and return the AST
     pub fn parse(mut self) -> (RootNode<'a>, Vec<'a, CompilerError>) {
         // Initialize root node
@@ -231,6 +240,8 @@ impl<'a> Parser<'a> {
         // We need to use a struct that implements Callbacks
         // Create a wrapper that can capture the parser
         let document = self.document;
+        #[cfg(feature = "legacy")]
+        let triple_mustache = self.raw_html_interpolation_enabled();
         let mut tokenizer = Tokenizer::with_delimiters(
             self.source,
             ParserCallbacks { parser: &mut self },
@@ -238,6 +249,8 @@ impl<'a> Parser<'a> {
             &delimiter_close,
         );
         tokenizer.set_tolerate_declarations(document);
+        #[cfg(feature = "legacy")]
+        tokenizer.set_triple_mustache(triple_mustache);
         tokenizer.tokenize();
 
         // Handle any unclosed elements

--- a/crates/vize_armature/src/parser/callbacks.rs
+++ b/crates/vize_armature/src/parser/callbacks.rs
@@ -47,6 +47,11 @@ impl<'a, 'p> Callbacks for ParserCallbacks<'a, 'p> {
         self.parser.on_interpolation_impl(start, end);
     }
 
+    #[cfg(feature = "legacy")]
+    fn on_raw_interpolation(&mut self, start: usize, end: usize) {
+        self.parser.on_raw_interpolation_impl(start, end);
+    }
+
     fn on_open_tag_name(&mut self, start: usize, end: usize) {
         self.parser.on_open_tag_name_impl(start, end);
     }

--- a/crates/vize_armature/src/parser/element/text.rs
+++ b/crates/vize_armature/src/parser/element/text.rs
@@ -98,6 +98,24 @@ impl<'a> Parser<'a> {
 
     /// Process interpolation
     pub(in crate::parser) fn on_interpolation_impl(&mut self, start: usize, end: usize) {
+        self.build_interpolation(start, end, false);
+    }
+
+    /// Process a Vue 1.x raw-HTML interpolation (`{{{ expr }}}`), the pre-Vue-2
+    /// `v-html` equivalent. Only reached behind the `legacy` feature with a
+    /// Vue 1.x dialect; the resulting node is flagged `raw` so codegen emits the
+    /// expression unescaped instead of through `_toDisplayString`.
+    ///
+    /// `start`/`end` already span the trimmed-by-delimiter expression (the
+    /// tokenizer strips the extra `{` / `}`), so the only difference from a plain
+    /// interpolation is the triple-mustache delimiter width used for the node's
+    /// outer source location.
+    #[cfg(feature = "legacy")]
+    pub(in crate::parser) fn on_raw_interpolation_impl(&mut self, start: usize, end: usize) {
+        self.build_interpolation(start, end, true);
+    }
+
+    fn build_interpolation(&mut self, start: usize, end: usize, raw: bool) {
         let raw_content = self.get_source(start, end);
         let content = raw_content.trim();
 
@@ -106,9 +124,19 @@ impl<'a> Parser<'a> {
         let trimmed_start = start + leading_ws;
         let trimmed_end = trimmed_start + content.len();
 
-        let delim_len = self.options.delimiters.0.len();
-        let full_start = start - delim_len;
-        let full_end = end + self.options.delimiters.1.len();
+        // Raw `{{{ … }}}` interpolation uses three-byte delimiters; a plain
+        // `{{ … }}` uses the configured (default two-byte) delimiters. `raw` is
+        // only ever true behind the `legacy` feature.
+        let (open_len, close_len) = if raw {
+            (3, 3)
+        } else {
+            (
+                self.options.delimiters.0.len(),
+                self.options.delimiters.1.len(),
+            )
+        };
+        let full_start = start - open_len;
+        let full_end = end + close_len;
         let loc = self.create_loc(full_start, full_end);
         let inner_loc = self.create_loc(trimmed_start, trimmed_end);
 
@@ -119,6 +147,10 @@ impl<'a> Parser<'a> {
         let interp = InterpolationNode {
             content: ExpressionNode::Simple(expr_boxed),
             loc,
+            // `vize_armature/legacy` forwards to `vize_relief/_legacy`, so the
+            // `raw` field exists exactly when this feature is enabled.
+            #[cfg(feature = "legacy")]
+            raw,
         };
         let boxed = Box::new_in(interp, self.allocator);
         self.add_child(TemplateChildNode::Interpolation(boxed));

--- a/crates/vize_armature/src/parser/tests.rs
+++ b/crates/vize_armature/src/parser/tests.rs
@@ -1938,3 +1938,103 @@ fn test_document_mode_with_options() {
         "custom delimiters should produce an interpolation node"
     );
 }
+
+// ===== Legacy Vue 1.x triple-mustache (`{{{ raw }}}`) raw-HTML interpolation =====
+
+/// Vue 2/3 (and the default build) treat `{{{ x }}}` as a `{{ … }}` mustache
+/// containing a stray brace, followed by a trailing `}` text node. This is the
+/// zero-cost path: it must stay byte-identical whether or not the `legacy`
+/// feature is compiled, and for any non-Vue-1.x dialect.
+#[test]
+fn triple_mustache_is_a_braced_mustache_outside_legacy_v1() {
+    use vize_carton::config::VueVersion;
+
+    for dialect in [VueVersion::V3, VueVersion::V2] {
+        let allocator = Bump::new();
+        let mut options = ParserOptions::default();
+        options.dialect = dialect;
+        let (root, errors) = parse_with_options(&allocator, "{{{ rawHtml }}}", options);
+
+        assert!(errors.is_empty(), "{dialect:?}: {errors:?}");
+        assert_eq!(
+            root.children.len(),
+            2,
+            "{dialect:?}: interp + trailing text"
+        );
+
+        match &root.children[0] {
+            TemplateChildNode::Interpolation(interp) => {
+                let ExpressionNode::Simple(expr) = &interp.content else {
+                    panic!("expected simple expression");
+                };
+                // The leading brace stays inside the expression, exactly as today.
+                assert_eq!(expr.content.as_str(), "{ rawHtml");
+            }
+            other => panic!(
+                "{dialect:?}: expected interpolation, got {:?}",
+                other.node_type()
+            ),
+        }
+        match &root.children[1] {
+            TemplateChildNode::Text(text) => assert_eq!(text.content.as_str(), "}"),
+            other => panic!(
+                "{dialect:?}: expected trailing text, got {:?}",
+                other.node_type()
+            ),
+        }
+    }
+}
+
+#[cfg(feature = "legacy")]
+#[test]
+fn triple_mustache_under_v1_lowers_to_raw_html_interpolation() {
+    use vize_carton::config::VueVersion;
+
+    let allocator = Bump::new();
+    let mut options = ParserOptions::default();
+    options.dialect = VueVersion::V1;
+    let (root, errors) = parse_with_options(&allocator, "{{{ rawHtml }}}", options);
+
+    assert!(errors.is_empty(), "{errors:?}");
+    assert_eq!(root.children.len(), 1, "single raw-HTML interpolation");
+
+    let TemplateChildNode::Interpolation(interp) = &root.children[0] else {
+        panic!("expected interpolation node");
+    };
+    assert!(
+        interp.raw,
+        "Vue 1.x `{{{{{{ … }}}}}}` is a raw-HTML interpolation"
+    );
+    let ExpressionNode::Simple(expr) = &interp.content else {
+        panic!("expected simple expression");
+    };
+    // The extra braces are stripped from the expression and the node spans the
+    // full triple-mustache.
+    assert_eq!(expr.content.as_str(), "rawHtml");
+    assert_eq!(interp.loc.source.as_str(), "{{{ rawHtml }}}");
+}
+
+#[cfg(feature = "legacy")]
+#[test]
+fn v1_double_mustache_stays_escaped_alongside_triple() {
+    use vize_carton::config::VueVersion;
+
+    let allocator = Bump::new();
+    let mut options = ParserOptions::default();
+    options.dialect = VueVersion::V1;
+    let (root, errors) = parse_with_options(&allocator, "{{ a }} {{{ b }}}", options);
+
+    assert!(errors.is_empty(), "{errors:?}");
+    let interps: std::vec::Vec<_> = root
+        .children
+        .iter()
+        .filter_map(|c| match c {
+            TemplateChildNode::Interpolation(i) => Some(i),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(interps.len(), 2);
+    // Plain `{{ a }}` is escaped; `{{{ b }}}` is raw.
+    assert!(!interps[0].raw);
+    assert!(interps[1].raw);
+}

--- a/crates/vize_armature/src/tokenizer.rs
+++ b/crates/vize_armature/src/tokenizer.rs
@@ -65,6 +65,21 @@ pub struct Tokenizer<'a, C: Callbacks> {
     /// HTML document's doctype is skipped silently instead of producing a
     /// spurious parse error.
     tolerate_declarations: bool,
+
+    /// Whether to recognize Vue 1.x triple-mustache raw-HTML interpolation,
+    /// `{{{ expr }}}` (the pre-Vue-2 `v-html` equivalent).
+    ///
+    /// Resolved once per file from the dialect capabilities; the default Vue 3
+    /// path leaves it `false`, so the interpolation states stay byte-identical
+    /// to today and `{{{ x }}}` keeps tokenizing as a `{{ … }}` mustache with a
+    /// stray brace. Only ever set behind the `legacy` feature for a Vue 1.x
+    /// document, and only honored with the default `{{`/`}}` delimiters.
+    triple_mustache: bool,
+
+    /// True while the currently open interpolation is a `{{{ … }}}` raw-HTML
+    /// one. Reset when the interpolation closes; meaningless (always `false`)
+    /// unless [`Tokenizer::triple_mustache`] is set.
+    in_raw_interpolation: bool,
 }
 
 impl<'a, C: Callbacks> Tokenizer<'a, C> {
@@ -98,6 +113,8 @@ impl<'a, C: Callbacks> Tokenizer<'a, C> {
             in_rcdata: false,
             after_quoted_attr_value: false,
             tolerate_declarations: false,
+            triple_mustache: false,
+            in_raw_interpolation: false,
         }
     }
 
@@ -105,6 +122,14 @@ impl<'a, C: Callbacks> Tokenizer<'a, C> {
     /// reporting them as recoverable errors. Used by document parse mode.
     pub fn set_tolerate_declarations(&mut self, tolerate: bool) {
         self.tolerate_declarations = tolerate;
+    }
+
+    /// Enable recognition of Vue 1.x triple-mustache raw-HTML interpolation
+    /// (`{{{ expr }}}`). Off by default; only the `legacy` Vue 1.x path turns it
+    /// on. Honored only with the default `{{`/`}}` delimiters, so a custom
+    /// delimiter configuration is unaffected.
+    pub fn set_triple_mustache(&mut self, enabled: bool) {
+        self.triple_mustache = enabled && self.delimiter_open == b"{{";
     }
 
     /// Get the position for a given index

--- a/crates/vize_armature/src/tokenizer/states.rs
+++ b/crates/vize_armature/src/tokenizer/states.rs
@@ -207,6 +207,16 @@ impl<'a, C: Callbacks> Tokenizer<'a, C> {
                 self.section_start = self.index + 1;
                 self.state = State::Interpolation;
                 self.delimiter_index = 0;
+                // Vue 1.x triple-mustache (`{{{ expr }}}`): if a third `{`
+                // immediately follows the opened `{{`, treat this as a raw-HTML
+                // interpolation and drop the extra brace from the expression
+                // span. Gated on `triple_mustache`, so the default Vue 3 path is
+                // byte-identical (it falls through with the brace kept in the
+                // expression, exactly as today).
+                if self.triple_mustache && self.input.get(self.index + 1) == Some(&b'{') {
+                    self.in_raw_interpolation = true;
+                    self.section_start = self.index + 2;
+                }
             }
         } else if self.in_rcdata {
             self.state = State::InRCDATA;
@@ -229,16 +239,30 @@ impl<'a, C: Callbacks> Tokenizer<'a, C> {
         if c == self.delimiter_close[self.delimiter_index] {
             self.delimiter_index += 1;
             if self.delimiter_index == self.delimiter_close.len() {
-                self.callbacks.on_interpolation(
-                    self.section_start,
-                    self.index + 1 - self.delimiter_close.len(),
-                );
+                let expr_end = self.index + 1 - self.delimiter_close.len();
+                if self.in_raw_interpolation {
+                    // Vue 1.x `{{{ expr }}}`: consume a trailing third `}` (if
+                    // present) so the raw closing brace is not left as text, then
+                    // emit a raw-HTML interpolation. This branch only runs behind
+                    // `triple_mustache`, so the default path is untouched.
+                    self.in_raw_interpolation = false;
+                    self.callbacks
+                        .on_raw_interpolation(self.section_start, expr_end);
+                    let consumed_brace = self.input.get(self.index + 1) == Some(&b'}');
+                    self.section_start = self.index + 1 + usize::from(consumed_brace);
+                    if consumed_brace {
+                        self.index += 1;
+                    }
+                } else {
+                    self.callbacks
+                        .on_interpolation(self.section_start, expr_end);
+                    self.section_start = self.index + 1;
+                }
                 if self.in_rcdata {
                     self.state = State::InRCDATA
                 } else {
                     self.state = State::Text
                 }
-                self.section_start = self.index + 1;
             }
         } else {
             self.state = State::Interpolation;

--- a/crates/vize_armature/src/tokenizer/tests.rs
+++ b/crates/vize_armature/src/tokenizer/tests.rs
@@ -13,6 +13,8 @@ enum TokenEvent {
     Text(usize, usize),
     TextEntity(char, usize, usize),
     Interpolation(usize, usize),
+    #[cfg(feature = "legacy")]
+    RawInterpolation(usize, usize),
     OpenTagName(usize, usize),
     OpenTagEnd(usize),
     SelfClosingTag(usize),
@@ -44,6 +46,10 @@ impl Callbacks for TestCallbacks {
     }
     fn on_interpolation(&mut self, start: usize, end: usize) {
         self.events.push(TokenEvent::Interpolation(start, end));
+    }
+    #[cfg(feature = "legacy")]
+    fn on_raw_interpolation(&mut self, start: usize, end: usize) {
+        self.events.push(TokenEvent::RawInterpolation(start, end));
     }
     fn on_open_tag_name(&mut self, start: usize, end: usize) {
         self.events.push(TokenEvent::OpenTagName(start, end));
@@ -778,4 +784,78 @@ fn test_script_pseudo_close_kept_as_text_until_real_close() {
     assert!(cb.events.contains(&TokenEvent::OpenTagEnd(7)));
     assert!(cb.events.contains(&TokenEvent::Text(8, 20)));
     assert!(cb.events.contains(&TokenEvent::CloseTag(22, 28)));
+}
+
+// ===== Vue 1.x triple-mustache raw-HTML interpolation =====
+
+/// Without `set_triple_mustache`, `{{{ x }}}` tokenizes exactly as today: a
+/// `{{ … }}` interpolation whose expression keeps the leading `{`, plus a
+/// trailing `}` text node. This is the zero-cost default path.
+#[test]
+fn triple_mustache_default_is_braced_interpolation_plus_text() {
+    // "{{{ x }}}": indices 0..9
+    let cb = tokenize("{{{ x }}}");
+    assert!(cb.errors.is_empty());
+    // Expression span is `{ x ` -> [2, 6); trailing `}` text is [8, 9).
+    assert!(cb.events.contains(&TokenEvent::Interpolation(2, 6)));
+    assert!(cb.events.contains(&TokenEvent::Text(8, 9)));
+    // With no capability set, the raw-interpolation callback never fires; the
+    // `RawInterpolation` event variant only exists behind `legacy`.
+    #[cfg(feature = "legacy")]
+    assert!(
+        !cb.events
+            .iter()
+            .any(|e| matches!(e, TokenEvent::RawInterpolation(..))),
+        "no raw interpolation without the capability"
+    );
+}
+
+#[cfg(feature = "legacy")]
+fn tokenize_triple(input: &str) -> TestCallbacks {
+    let cb = TestCallbacks::default();
+    let mut tok = Tokenizer::new(input, cb);
+    tok.set_triple_mustache(true);
+    tok.tokenize();
+    tok.callbacks
+}
+
+#[cfg(feature = "legacy")]
+#[test]
+fn triple_mustache_with_capability_emits_raw_interpolation() {
+    // "{{{ x }}}": the expression span is ` x ` -> [3, 6); both extra braces
+    // are dropped and no trailing text is produced.
+    let cb = tokenize_triple("{{{ x }}}");
+    assert!(cb.errors.is_empty(), "{:?}", cb.errors);
+    assert!(cb.events.contains(&TokenEvent::RawInterpolation(3, 6)));
+    assert!(
+        !cb.events.iter().any(|e| matches!(e, TokenEvent::Text(..))),
+        "no stray brace text: {:?}",
+        cb.events
+    );
+}
+
+#[cfg(feature = "legacy")]
+#[test]
+fn double_mustache_with_capability_is_unchanged() {
+    // A plain `{{ x }}` is still an ordinary (escaped) interpolation even when
+    // triple-mustache recognition is enabled.
+    let cb = tokenize_triple("{{ x }}");
+    assert!(cb.errors.is_empty());
+    assert!(cb.events.contains(&TokenEvent::Interpolation(2, 5)));
+    assert!(
+        !cb.events
+            .iter()
+            .any(|e| matches!(e, TokenEvent::RawInterpolation(..))),
+        "`{{{{ … }}}}` stays a plain interpolation"
+    );
+}
+
+#[cfg(feature = "legacy")]
+#[test]
+fn triple_mustache_adjacent_and_mixed_with_text() {
+    let cb = tokenize_triple("a {{{ x }}} b");
+    assert!(cb.errors.is_empty());
+    assert!(cb.events.contains(&TokenEvent::Text(0, 2))); // "a "
+    assert!(cb.events.contains(&TokenEvent::RawInterpolation(5, 8))); // " x "
+    assert!(cb.events.contains(&TokenEvent::Text(11, 13))); // " b"
 }

--- a/crates/vize_armature/src/tokenizer/types.rs
+++ b/crates/vize_armature/src/tokenizer/types.rs
@@ -77,6 +77,18 @@ pub trait Callbacks {
 
     fn on_interpolation(&mut self, start: usize, end: usize);
 
+    /// A Vue 1.x raw-HTML (unescaped) interpolation, `{{{ expr }}}`.
+    ///
+    /// Only ever called when the tokenizer was built with triple-mustache
+    /// recognition enabled (the `legacy` feature + a Vue 1.x dialect); the
+    /// default Vue 3 path never emits it. The default implementation forwards to
+    /// [`Callbacks::on_interpolation`] so callers that do not model raw HTML get
+    /// the ordinary interpolation, but a `legacy`-aware parser overrides this to
+    /// flag the node as raw (the pre-Vue-2 `v-html` equivalent).
+    fn on_raw_interpolation(&mut self, start: usize, end: usize) {
+        self.on_interpolation(start, end);
+    }
+
     fn on_open_tag_name(&mut self, start: usize, end: usize);
     fn on_open_tag_end(&mut self, end: usize);
     fn on_self_closing_tag(&mut self, end: usize);

--- a/crates/vize_atelier_core/src/codegen/children.rs
+++ b/crates/vize_atelier_core/src/codegen/children.rs
@@ -53,12 +53,7 @@ fn generate_children_inner(
                 return;
             }
             TemplateChildNode::Interpolation(interp) => {
-                let helper = ctx.helper(RuntimeHelper::ToDisplayString);
-                ctx.use_helper(RuntimeHelper::ToDisplayString);
-                ctx.push(helper);
-                ctx.push("(");
-                generate_expression(ctx, &interp.content);
-                ctx.push(")");
+                push_interpolation_value(ctx, interp);
                 return;
             }
             _ => {}
@@ -86,12 +81,7 @@ fn generate_children_inner(
                     ctx.push("\"");
                 }
                 TemplateChildNode::Interpolation(interp) => {
-                    let helper = ctx.helper(RuntimeHelper::ToDisplayString);
-                    ctx.use_helper(RuntimeHelper::ToDisplayString);
-                    ctx.push(helper);
-                    ctx.push("(");
-                    generate_expression(ctx, &interp.content);
-                    ctx.push(")");
+                    push_interpolation_value(ctx, interp);
                 }
                 _ => {}
             }
@@ -165,8 +155,7 @@ fn generate_children_inner(
 
             if has_interp {
                 // Merge text + interpolation: "text" + _toDisplayString(expr)
-                let to_display = ctx.helper(RuntimeHelper::ToDisplayString);
-                ctx.use_helper(RuntimeHelper::ToDisplayString);
+                // (a raw `{{{ … }}}` interpolation is concatenated unescaped).
                 for (j, child) in run.iter().enumerate() {
                     if j > 0 {
                         ctx.push(" + ");
@@ -178,10 +167,7 @@ fn generate_children_inner(
                             ctx.push("\"");
                         }
                         TemplateChildNode::Interpolation(interp) => {
-                            ctx.push(to_display);
-                            ctx.push("(");
-                            generate_expression(ctx, &interp.content);
-                            ctx.push(")");
+                            push_interpolation_value(ctx, interp);
                         }
                         _ => {}
                     }
@@ -345,12 +331,28 @@ pub fn generate_comment(ctx: &mut CodegenContext, comment: &CommentNode) {
     ctx.push("\")");
 }
 
-/// Generate interpolation
-pub fn generate_interpolation(ctx: &mut CodegenContext, interp: &InterpolationNode<'_>) {
+/// Emit an interpolation as a value expression.
+///
+/// A plain `{{ expr }}` is escaped through `_toDisplayString(expr)`. A Vue 1.x
+/// raw-HTML interpolation (`{{{ expr }}}`, the pre-Vue-2 `v-html` equivalent;
+/// only producible behind the `legacy` feature) renders unescaped, so the bare
+/// expression is emitted without the wrapper. Shared by every child-codegen
+/// path so the raw flag is honored consistently.
+pub fn push_interpolation_value(ctx: &mut CodegenContext, interp: &InterpolationNode<'_>) {
+    #[cfg(feature = "legacy")]
+    if interp.raw {
+        generate_expression(ctx, &interp.content);
+        return;
+    }
     let helper = ctx.helper(RuntimeHelper::ToDisplayString);
     ctx.use_helper(RuntimeHelper::ToDisplayString);
     ctx.push(helper);
     ctx.push("(");
     generate_expression(ctx, &interp.content);
     ctx.push(")");
+}
+
+/// Generate interpolation
+pub fn generate_interpolation(ctx: &mut CodegenContext, interp: &InterpolationNode<'_>) {
+    push_interpolation_value(ctx, interp);
 }

--- a/crates/vize_atelier_core/src/codegen/element/v_once.rs
+++ b/crates/vize_atelier_core/src/codegen/element/v_once.rs
@@ -8,6 +8,7 @@ use crate::ast::{
 };
 
 use super::super::{
+    children::push_interpolation_value,
     context::CodegenContext,
     expression::generate_expression,
     helpers::{escape_js_string, to_valid_asset_identifier},
@@ -209,13 +210,10 @@ pub fn generate_v_once_child(ctx: &mut CodegenContext, node: &TemplateChildNode<
         }
         TemplateChildNode::Interpolation(interp) => {
             ctx.use_helper(RuntimeHelper::CreateText);
-            ctx.use_helper(RuntimeHelper::ToDisplayString);
             ctx.push(ctx.helper(RuntimeHelper::CreateText));
             ctx.push("(");
-            ctx.push(ctx.helper(RuntimeHelper::ToDisplayString));
-            ctx.push("(");
-            generate_expression(ctx, &interp.content);
-            ctx.push("), 1 /* TEXT */)");
+            push_interpolation_value(ctx, interp);
+            ctx.push(", 1 /* TEXT */)");
         }
         _ => generate_node(ctx, node),
     }

--- a/crates/vize_atelier_core/src/codegen/slots/generate.rs
+++ b/crates/vize_atelier_core/src/codegen/slots/generate.rs
@@ -528,11 +528,20 @@ fn generate_slot_children(ctx: &mut CodegenContext, children: &[TemplateChildNod
                     ctx.push("\"");
                 }
                 TemplateChildNode::Interpolation(interp) => {
-                    ctx.use_helper(RuntimeHelper::ToDisplayString);
-                    ctx.push(ctx.helper(RuntimeHelper::ToDisplayString));
-                    ctx.push("(");
-                    generate_slot_expression(ctx, &interp.content);
-                    ctx.push(")");
+                    // Vue 1.x raw-HTML `{{{ … }}}` renders unescaped.
+                    #[cfg(feature = "legacy")]
+                    let raw = interp.raw;
+                    #[cfg(not(feature = "legacy"))]
+                    let raw = false;
+                    if raw {
+                        generate_slot_expression(ctx, &interp.content);
+                    } else {
+                        ctx.use_helper(RuntimeHelper::ToDisplayString);
+                        ctx.push(ctx.helper(RuntimeHelper::ToDisplayString));
+                        ctx.push("(");
+                        generate_slot_expression(ctx, &interp.content);
+                        ctx.push(")");
+                    }
                 }
                 _ => {}
             }
@@ -566,14 +575,25 @@ fn generate_slot_child_node(ctx: &mut CodegenContext, child: &TemplateChildNode<
         }
         TemplateChildNode::Interpolation(interp) => {
             ctx.use_helper(RuntimeHelper::CreateText);
-            ctx.use_helper(RuntimeHelper::ToDisplayString);
             ctx.push(ctx.helper(RuntimeHelper::CreateText));
             ctx.push("(");
-            ctx.push(ctx.helper(RuntimeHelper::ToDisplayString));
-            ctx.push("(");
-            // Generate expression, stripping _ctx. prefix for slot params
-            generate_slot_expression(ctx, &interp.content);
-            ctx.push("), 1 /* TEXT */)");
+            // Vue 1.x raw-HTML `{{{ … }}}` renders unescaped.
+            #[cfg(feature = "legacy")]
+            let raw = interp.raw;
+            #[cfg(not(feature = "legacy"))]
+            let raw = false;
+            if raw {
+                // Generate expression, stripping _ctx. prefix for slot params
+                generate_slot_expression(ctx, &interp.content);
+            } else {
+                ctx.use_helper(RuntimeHelper::ToDisplayString);
+                ctx.push(ctx.helper(RuntimeHelper::ToDisplayString));
+                ctx.push("(");
+                // Generate expression, stripping _ctx. prefix for slot params
+                generate_slot_expression(ctx, &interp.content);
+                ctx.push(")");
+            }
+            ctx.push(", 1 /* TEXT */)");
         }
         _ => {
             generate_node(ctx, child);

--- a/crates/vize_atelier_core/src/codegen/tests.rs
+++ b/crates/vize_atelier_core/src/codegen/tests.rs
@@ -895,3 +895,61 @@ fn test_codegen_static_style_merged_with_dynamic_does_not_split_inside_parens() 
         output
     );
 }
+
+/// Vue 1.x triple-mustache (`{{{ html }}}`) is the pre-Vue-2 `v-html`
+/// equivalent: under the Vue 1.x dialect it renders the expression unescaped,
+/// so codegen emits the bare expression instead of wrapping it in
+/// `_toDisplayString`. Under the default Vue 3 dialect (and the non-`legacy`
+/// build) `{{{ x }}}` stays a `{{ … }}` mustache and is escaped as usual.
+#[cfg(feature = "legacy")]
+#[test]
+fn test_codegen_v1_triple_mustache_is_raw_unescaped() {
+    use crate::options::{CodegenOptions, ParserOptions, TransformOptions};
+    use crate::parser::parse_with_options;
+    use crate::transform::transform;
+    use bumpalo::Bump;
+    use vize_carton::config::VueVersion;
+
+    let allocator = Bump::new();
+    let mut options = ParserOptions::default();
+    options.dialect = VueVersion::V1;
+    let (mut root, errors) = parse_with_options(&allocator, "<div>{{{ rawHtml }}}</div>", options);
+    assert!(errors.is_empty(), "Parse errors: {errors:?}");
+
+    transform(
+        &allocator,
+        &mut root,
+        TransformOptions {
+            dialect: VueVersion::V1,
+            ..Default::default()
+        },
+        None,
+    );
+    let result = super::generate(&root, CodegenOptions::default());
+
+    // Raw interpolation: the expression is emitted directly, never escaped.
+    assert!(
+        result.code.contains("rawHtml"),
+        "raw expression should appear in output. Got:\n{}",
+        result.code
+    );
+    assert!(
+        !result.code.contains("_toDisplayString(rawHtml)"),
+        "raw-HTML interpolation must not be escaped through _toDisplayString. Got:\n{}",
+        result.code
+    );
+}
+
+/// The default Vue 3 dialect keeps `{{{ x }}}` as a `{{ … }}` mustache (with a
+/// stray brace) followed by a `}` text node, and the interpolation is escaped —
+/// byte-identical to the non-`legacy` build.
+#[cfg(feature = "legacy")]
+#[test]
+fn test_codegen_triple_mustache_escaped_under_default_dialect() {
+    let result = compile!("<div>{{{ rawHtml }}}</div>");
+    assert!(
+        result.code.contains("_toDisplayString"),
+        "default dialect escapes the interpolation. Got:\n{}",
+        result.code
+    );
+}

--- a/crates/vize_atelier_core/src/codegen/v_if/branch.rs
+++ b/crates/vize_atelier_core/src/codegen/v_if/branch.rs
@@ -11,7 +11,7 @@ use vize_carton::ToCompactString;
 
 use super::{
     super::{
-        children::{generate_children_force_array, is_directive_comment},
+        children::{generate_children_force_array, is_directive_comment, push_interpolation_value},
         context::CodegenContext,
         element::{
             generate_custom_directives_closing, generate_vmodel_closing, generate_vshow_closing,
@@ -619,11 +619,7 @@ fn generate_if_branch_children(ctx: &mut CodegenContext, children: &[TemplateChi
             }
             match child {
                 TemplateChildNode::Interpolation(interp) => {
-                    ctx.use_helper(RuntimeHelper::ToDisplayString);
-                    ctx.push(ctx.helper(RuntimeHelper::ToDisplayString));
-                    ctx.push("(");
-                    generate_expression(ctx, &interp.content);
-                    ctx.push(")");
+                    push_interpolation_value(ctx, interp);
                 }
                 TemplateChildNode::Text(text) => {
                     ctx.push("\"");

--- a/crates/vize_relief/src/ast/elements.rs
+++ b/crates/vize_relief/src/ast/elements.rs
@@ -184,6 +184,19 @@ impl CommentNode {
 pub struct InterpolationNode<'a> {
     pub content: ExpressionNode<'a>,
     pub loc: SourceLocation,
+    /// Raw-HTML (unescaped) interpolation produced by Vue 1.x triple-mustache
+    /// syntax (`{{{ html }}}`), the pre-Vue-2 equivalent of `v-html`. When set,
+    /// codegen emits the expression directly instead of escaping it through
+    /// `_toDisplayString`, matching Vue 1's unescaped output.
+    ///
+    /// Legacy-only: triple-mustache was removed in Vue 2, so this field is
+    /// compiled only behind the internal `_legacy` cargo feature (enabled
+    /// transitively by `vize_atelier_core/legacy` / `vize_armature/legacy`). The
+    /// default Vue 3 build never sees it, keeping the public AST surface — and
+    /// `cargo-semver-checks`, whose feature heuristic skips `_`-prefixed
+    /// features — byte-identical.
+    #[cfg(feature = "_legacy")]
+    pub raw: bool,
 }
 
 impl<'a> InterpolationNode<'a> {


### PR DESCRIPTION
## What

Vue 0.x / 1.x supported `{{{ html }}}` for unescaped (raw) HTML interpolation — the pre-Vue-2 equivalent of `v-html`. Vue 2 removed it in favor of `v-html`. This wires that syntax into the existing legacy dialect plumbing.

Behind the `legacy` cargo feature **and** a Vue 1.x (or 0.x) dialect, the tokenizer recognizes `{{{ expr }}}` and the parser lowers it to a raw-HTML interpolation node; codegen then emits the expression directly instead of wrapping it in `_toDisplayString`, matching Vue 1's unescaped output.

- **`vize_armature::legacy`**: new `raw_html_interpolation` capability on `LegacyDialectCapabilities` (on for V0.10 / V0.11 / V1, off for V2 and the default Vue 3 set).
- **`vize_relief`**: `_legacy`-gated `InterpolationNode::raw` flag, following the existing `RootNode::filters` pattern so it stays invisible to `cargo-semver-checks`.
- **tokenizer**: opt-in `set_triple_mustache` + a defaulted `on_raw_interpolation` callback. The triple-mustache states recognize `{{{` / `}}}` only when the capability is set and only with the default `{{` / `}}` delimiters, stripping the extra braces from the expression span.
- **codegen**: a shared `push_interpolation_value` helper honors the `raw` flag across every interpolation path (element children, text runs, slots, `v-if` branches, `v-once`).

## Vue 1 parity

- `{{{ rawHtml }}}` under V1 → a single raw-HTML interpolation, expression `rawHtml`, node span `{{{ rawHtml }}}`; codegen emits the bare expression (no `_toDisplayString`).
- Plain `{{ a }}` stays escaped even alongside `{{{ b }}}`.
- Mixed text, adjacent triple-mustaches, and `v-html`-style semantics all verified.

## Zero-cost

With the feature **off** (default) or **any non-Vue-1.x dialect**, `{{{ x }}}` tokenizes byte-identically to today: a `{{ … }}` mustache whose expression keeps the leading brace (`{ x`) followed by a trailing `}` text node. The triple-mustache field defaults to `false`, every capability check short-circuits to the existing Vue 3 branch, and without the feature none of this is compiled at all.

## Verification

- `cargo test` for `vize_armature` / `vize_relief` / `vize_atelier_core` — green in **both** default and `--features legacy`.
- `cargo fmt --check`, `cargo clippy --lib -D warnings` — clean in both modes.
- Conformance coverage on the default build: **VDOM 457/457**, **SFC 167/167** (100%); SFC allocation budget test unchanged.
- `cargo-semver-checks` clean for the touched crates: `InterpolationNode::raw` is not surfaced (the only flagged fields are the pre-existing `ParserOptions`/`TransformOptions::dialect`).

Refs #1392

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1487"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->