### PR TITLE
fix(atelier): preserve legacy scoped-slot value locations

### DIFF
--- a/crates/vize_atelier_core/src/transforms/legacy.rs
+++ b/crates/vize_atelier_core/src/transforms/legacy.rs
@@ -186,7 +186,10 @@ fn desugar_scoped_slot_attrs<'a>(allocator: &'a Bump, el: &mut ElementNode<'a>) 
     let PropNode::Attribute(scope_attr) = &el.props[scope_idx] else {
         return;
     };
-    let slot_props = scope_attr.value.as_ref().map(|v| v.content.clone());
+    let slot_props = scope_attr
+        .value
+        .as_ref()
+        .map(|value| (value.content.clone(), value.loc.clone()));
     let scope_loc = scope_attr.loc.clone();
 
     // The companion `slot="name"` static attribute names the target slot. Its
@@ -197,22 +200,24 @@ fn desugar_scoped_slot_attrs<'a>(allocator: &'a Bump, el: &mut ElementNode<'a>) 
         .position(|prop| matches!(prop, PropNode::Attribute(attr) if attr.name.as_str() == "slot"));
     let slot_name = slot_name_idx.and_then(|idx| {
         if let PropNode::Attribute(attr) = &el.props[idx] {
-            attr.value.as_ref().map(|v| v.content.clone())
+            attr.value
+                .as_ref()
+                .map(|value| (value.content.clone(), value.loc.clone()))
         } else {
             None
         }
     });
 
     // Build the v-slot directive: name="slot", arg=<slot name> (static), exp=<slot props>.
-    let arg = slot_name.map(|name| {
+    let arg = slot_name.map(|(name, loc)| {
         ExpressionNode::Simple(Box::new_in(
-            SimpleExpressionNode::new(name.as_str(), true, scope_loc.clone()),
+            SimpleExpressionNode::new(name.as_str(), true, loc),
             allocator,
         ))
     });
-    let exp = slot_props.map(|props| {
+    let exp = slot_props.map(|(props, loc)| {
         ExpressionNode::Simple(Box::new_in(
-            SimpleExpressionNode::new(props.as_str(), false, scope_loc.clone()),
+            SimpleExpressionNode::new(props.as_str(), false, loc),
             allocator,
         ))
     });
@@ -411,20 +416,19 @@ mod tests {
         assert_eq!(dirs.len(), 1);
         let v_slot = dirs[0];
         assert_eq!(v_slot.name.as_str(), "slot");
-        assert_eq!(
-            match v_slot.arg.as_ref().unwrap() {
-                ExpressionNode::Simple(s) => s.content.as_str(),
-                _ => panic!(),
-            },
-            "header"
-        );
-        assert_eq!(
-            match v_slot.exp.as_ref().unwrap() {
-                ExpressionNode::Simple(s) => s.content.as_str(),
-                _ => panic!(),
-            },
-            "props"
-        );
+        let arg = match v_slot.arg.as_ref().unwrap() {
+            ExpressionNode::Simple(s) => s,
+            _ => panic!(),
+        };
+        assert_eq!(arg.content.as_str(), "header");
+        assert_eq!(arg.loc.source.as_str(), "header");
+
+        let exp = match v_slot.exp.as_ref().unwrap() {
+            ExpressionNode::Simple(s) => s,
+            _ => panic!(),
+        };
+        assert_eq!(exp.content.as_str(), "props");
+        assert_eq!(exp.loc.source.as_str(), "props");
     }
 
     #[test]
@@ -445,13 +449,12 @@ mod tests {
         assert_eq!(dirs.len(), 1);
         assert_eq!(dirs[0].name.as_str(), "slot");
         assert!(dirs[0].arg.is_none(), "no slot= means default slot");
-        assert_eq!(
-            match dirs[0].exp.as_ref().unwrap() {
-                ExpressionNode::Simple(s) => s.content.as_str(),
-                _ => panic!(),
-            },
-            "props"
-        );
+        let exp = match dirs[0].exp.as_ref().unwrap() {
+            ExpressionNode::Simple(s) => s,
+            _ => panic!(),
+        };
+        assert_eq!(exp.content.as_str(), "props");
+        assert_eq!(exp.loc.source.as_str(), "props");
     }
 
     #[test]

--- a/crates/vize_atelier_core/tests/legacy_template_sugar.rs
+++ b/crates/vize_atelier_core/tests/legacy_template_sugar.rs
@@ -1,0 +1,164 @@
+//! Vue 2 template-sugar codegen parity + zero-cost dialect gating.
+//!
+//! Compiled only under `--features legacy`; the whole file is gated so the
+//! default Vue 3 build never sees it. Asserts that:
+//!
+//! - under dialect V2 (and V2.7), `.sync` lowers to the same output as an
+//!   explicit `@update:*` listener;
+//! - legacy scoped-slot attributes (`slot-scope` / `scope`) lower to the same
+//!   output as their `v-slot` equivalents; and
+//! - under the default dialect V3, the same legacy input stays inert even in a
+//!   `legacy`-enabled build.
+#![cfg(feature = "legacy")]
+// Integration test: plain `std::string::String` / `{out}` formatting is fine
+// here (the crate's internal `vize_carton::String` rule does not apply to an
+// out-of-crate test harness).
+#![allow(clippy::disallowed_types, clippy::disallowed_macros)]
+
+use vize_atelier_core::{CodegenOptions, TransformOptions, codegen, parser, transform};
+use vize_carton::config::VueVersion;
+
+fn compile(input: &str, dialect: VueVersion) -> String {
+    let allocator = bumpalo::Bump::new();
+    let (mut root, errors) = parser::parse(&allocator, input);
+    assert!(errors.is_empty(), "parse errors: {errors:?}");
+
+    let transform_opts = TransformOptions {
+        prefix_identifiers: true,
+        dialect,
+        ..Default::default()
+    };
+    transform::transform(&allocator, &mut root, transform_opts, None);
+
+    let codegen_opts = CodegenOptions {
+        prefix_identifiers: true,
+        ..Default::default()
+    };
+    let result = codegen::generate(&root, codegen_opts);
+    let mut out = String::with_capacity(result.preamble.len() + result.code.len() + 1);
+    out.push_str(result.preamble.as_str());
+    out.push('\n');
+    out.push_str(result.code.as_str());
+    out
+}
+
+// --- `.sync` (`:foo.sync` -> `:foo` + `@update:foo`) ------------------------
+
+#[test]
+fn v2_sync_matches_explicit_update_listener() {
+    let sync = compile(r#"<MyComp :foo.sync="bar" />"#, VueVersion::V2);
+    let explicit = compile(
+        r#"<MyComp :foo="bar" @update:foo="$event => ((bar) = $event)" />"#,
+        VueVersion::V2,
+    );
+
+    assert!(sync.contains(r#""onUpdate:foo""#), "{sync}");
+    assert_eq!(sync, explicit);
+}
+
+#[test]
+fn v2_sync_preserves_other_bind_modifiers() {
+    let sync = compile(r#"<MyComp :foo.sync.camel="bar" />"#, VueVersion::V2);
+    let explicit = compile(
+        r#"<MyComp :foo.camel="bar" @update:foo="$event => ((bar) = $event)" />"#,
+        VueVersion::V2,
+    );
+
+    assert!(sync.contains(r#""onUpdate:foo""#), "{sync}");
+    assert_eq!(sync, explicit);
+}
+
+#[test]
+fn v2_7_shares_the_v2_sync_dialect() {
+    let out = compile(r#"<MyComp :foo.sync="bar" />"#, VueVersion::V2_7);
+    assert!(out.contains(r#""onUpdate:foo""#), "{out}");
+}
+
+#[test]
+fn v3_default_dialect_does_not_synthesize_sync_listener() {
+    let out = compile(r#"<MyComp :foo.sync="bar" />"#, VueVersion::V3);
+    assert!(!out.contains("onUpdate:foo"), "{out}");
+}
+
+// --- `slot-scope` / `scope` (`template` attrs -> `v-slot`) ------------------
+
+#[test]
+fn v2_named_slot_scope_matches_v_slot() {
+    let legacy = compile(
+        r#"<MyComp><template slot="header" slot-scope="props">{{ props.title }}</template></MyComp>"#,
+        VueVersion::V2,
+    );
+    let modern = compile(
+        r#"<MyComp><template #header="props">{{ props.title }}</template></MyComp>"#,
+        VueVersion::V2,
+    );
+
+    assert!(legacy.contains("header:"), "{legacy}");
+    assert_eq!(legacy, modern);
+}
+
+#[test]
+fn v2_default_slot_scope_matches_v_slot_default() {
+    let legacy = compile(
+        r#"<MyComp><template slot-scope="props">{{ props.title }}</template></MyComp>"#,
+        VueVersion::V2,
+    );
+    let modern = compile(
+        r#"<MyComp><template #default="props">{{ props.title }}</template></MyComp>"#,
+        VueVersion::V2,
+    );
+
+    assert!(legacy.contains("default:"), "{legacy}");
+    assert_eq!(legacy, modern);
+}
+
+#[test]
+fn v2_scope_alias_matches_v_slot_default() {
+    let legacy = compile(
+        r#"<MyComp><template scope="props">{{ props.title }}</template></MyComp>"#,
+        VueVersion::V2,
+    );
+    let modern = compile(
+        r#"<MyComp><template #default="props">{{ props.title }}</template></MyComp>"#,
+        VueVersion::V2,
+    );
+
+    assert!(legacy.contains("default:"), "{legacy}");
+    assert_eq!(legacy, modern);
+}
+
+#[test]
+fn v2_7_shares_the_v2_scoped_slot_dialect() {
+    let legacy = compile(
+        r#"<MyComp><template slot="header" slot-scope="props">{{ props.title }}</template></MyComp>"#,
+        VueVersion::V2_7,
+    );
+    let modern = compile(
+        r#"<MyComp><template #header="props">{{ props.title }}</template></MyComp>"#,
+        VueVersion::V2_7,
+    );
+
+    assert_eq!(legacy, modern);
+}
+
+#[test]
+fn v3_default_dialect_keeps_scoped_slot_attrs_inert() {
+    let legacy = compile(
+        r#"<MyComp><template slot="header" slot-scope="props">{{ props.title }}</template></MyComp>"#,
+        VueVersion::V3,
+    );
+    let modern = compile(
+        r#"<MyComp><template #header="props">{{ props.title }}</template></MyComp>"#,
+        VueVersion::V3,
+    );
+
+    assert_ne!(legacy, modern);
+}
+
+#[test]
+fn v2_and_v3_outputs_match_without_template_sugar() {
+    let src = r#"<MyComp :foo="bar" @update:foo="onUpdate"><template #header="props">{{ props.title }}</template></MyComp>"#;
+    let v2 = compile(src, VueVersion::V2);
+    let v3 = compile(src, VueVersion::V3);
+    assert_eq!(v2, v3);
+}


### PR DESCRIPTION
## What

Fixes Vue 2 legacy scoped-slot desugaring so synthesized `v-slot` args/expressions keep the source location of the attribute value, not the whole legacy attribute.

`slot` / `slot-scope` / `scope` values now carry their own `loc`, which matters because slot codegen reads scoped-slot params from `exp.loc.source`.

## Why

Before this, a template like:

```vue
<MyComp><template slot=header slot-scope=props>{{ props.title }}</template></MyComp>
```

could lower into a malformed scoped-slot function shaped like `(slot-scope=props) => ...`, and the slot body treated `props` as `_ctx.props` instead of a slot param.

## Tests

Adds a legacy integration test covering:

- `.sync` output parity with an explicit `@update:*` listener
- `slot-scope` / `scope` output parity with equivalent `v-slot` syntax
- V2.7 sharing the V2 template-sugar dialect
- V3 staying inert for the same legacy input

## Verification

- `rustfmt --edition 2024 --check crates/vize_atelier_core/src/transforms/legacy.rs crates/vize_atelier_core/tests/legacy_template_sugar.rs`
- `cargo test -p vize_atelier_core --features legacy --test legacy_template_sugar`
- `cargo test -p vize_atelier_core --features legacy`
- `cargo clippy -p vize_atelier_core --features legacy --lib -- -D warnings`
- `cargo clippy -p vize_atelier_core --features legacy --test legacy_template_sugar -- -D warnings`

Refs #1392

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1490"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783815534&installation_id=136613492&pr_number=1490&repository=ubugeeei-prod%2Fvize&return_to=https%3A%2F%2Fgithub.com%2Fubugeeei-prod%2Fvize%2Fpull%2F1490&signature=6c4ad3fec13d94909709a3991871374ecc64bc74561aceec34ef6d663329e997"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->