### PR TITLE
fix(flake): re-pin drifted Blacksmith CLI hashes

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -132,19 +132,19 @@
         blacksmithArtifacts = {
           aarch64-darwin = {
             url = "https://clireleases.blacksmith.sh/cli/latest/darwin/arm64/blacksmith";
-            hash = "sha256-ozZ6tBUbEqTqdxUVwxSg1ItiKUwLZxMl1Ccx8r6XP2Y=";
+            hash = "sha256-wTCMj9d5siTpB01ljPFa3NAwN28lJicaJcc7AiqTRWw=";
           };
           x86_64-darwin = {
             url = "https://clireleases.blacksmith.sh/cli/latest/darwin/amd64/blacksmith";
-            hash = "sha256-YhC5jCuLeQNHlFYnd1PdCVntNPAibp1cQAIcl6JG9OE=";
+            hash = "sha256-aT3dpCOy00OyuEp/08z9pZxA31lZQEQ1MhRdNzwNgxM=";
           };
           x86_64-linux = {
             url = "https://clireleases.blacksmith.sh/cli/latest/linux/amd64/blacksmith";
-            hash = "sha256-h5HZEqBDHiO//2w2xPdQGYN6b2JgS+deRX66zk8FGDQ=";
+            hash = "sha256-zzc5MFZaS2xvqSGyG1uuTFYFLQhoIb7FEzxp1c0prvk=";
           };
           aarch64-linux = {
             url = "https://clireleases.blacksmith.sh/cli/latest/linux/arm64/blacksmith";
-            hash = "sha256-+HBaib2jDECu1UIxkWX0jO5H6W+9XlT/leB5Uow8hy4=";
+            hash = "sha256-6XF/S/sn4s6zktPJbadkXt0yALLIySppZTUeNvoiWss=";
           };
         };
         blacksmith =


### PR DESCRIPTION
## Why

The push-to-main **nix-flake** gate fails on `nix flake check`:

```
error: build of 'blacksmith.drv' failed: hash mismatch in fixed-output
derivation '…-blacksmith.drv'
```

The Blacksmith CLI is fetched from a mutable `latest` channel (`clireleases.blacksmith.sh/cli/latest/<os>/<arch>/blacksmith`) with each platform's content hash pinned in `flake.nix`. Blacksmith published a new `latest` build, so all four pinned hashes went stale and the fixed-output fetch no longer validates. (The earlier red on the latest main run was masked by a separate `Sticky disk limit exceeded` infra 429; once that cleared on re-run, this hash mismatch surfaced.)

## What

Re-pin every platform to the current `latest` binary — the refresh procedure the in-file comment documents:

| platform | new hash |
| --- | --- |
| aarch64-darwin | `sha256-wTCMj9d5siTpB01ljPFa3NAwN28lJicaJcc7AiqTRWw=` |
| x86_64-darwin | `sha256-aT3dpCOy00OyuEp/08z9pZxA31lZQEQ1MhRdNzwNgxM=` |
| x86_64-linux | `sha256-zzc5MFZaS2xvqSGyG1uuTFYFLQhoIb7FEzxp1c0prvk=` |
| aarch64-linux | `sha256-6XF/S/sn4s6zktPJbadkXt0yALLIySppZTUeNvoiWss=` |

Each captured with `nix store prefetch-file`; the x86_64-linux hash (the CI platform) was independently cross-checked against `sha256sum` of the downloaded binary.

## Note

This is the recurring cost of pinning a `latest` channel — it will drift again on the next Blacksmith CLI release. Pinning a versioned URL instead would end the churn, but that's a larger design change left to the maintainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1505"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->