### PR TITLE
fix(flake): re-pin drifted MoonBit toolchain + core hashes

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -43,19 +43,19 @@
         );
         moonbitArtifacts = {
           aarch64-darwin = {
-            version = "0.9.3-2026-05-22";
+            version = "0.1.20260608-2026-06-08";
             url = "https://cli.moonbitlang.com/binaries/latest/moonbit-darwin-aarch64.tar.gz";
-            hash = "sha256-wYckl/EM1e8w+Nj+2d7p0DtqTe6i71d2wPXjRG/j+Zs=";
+            hash = "sha256-YAgKPu+uA4e2Z/UXJJpwt2ezdMANIjLuczet2ff3JIc=";
           };
           x86_64-linux = {
-            version = "0.9.3-2026-05-22";
+            version = "0.1.20260608-2026-06-08";
             url = "https://cli.moonbitlang.com/binaries/latest/moonbit-linux-x86_64.tar.gz";
-            hash = "sha256-/FRxLbk/zuLMmMBUbwJVI++fcECnvjsV7jj0itzwa9U=";
+            hash = "sha256-PFAX9WkoSALxoLhCLRSZY6AcpYfFFEURZK75HGXfiqg=";
           };
           aarch64-linux = {
-            version = "0.9.3-2026-05-22";
+            version = "0.1.20260608-2026-06-08";
             url = "https://cli.moonbitlang.com/binaries/latest/moonbit-linux-aarch64.tar.gz";
-            hash = "sha256-0Lrjab3LTISXN4/JRu8I1/78wS89/fLPS4y6F/JPG3w=";
+            hash = "sha256-fw4LyzobPWKaDV/9sattbQzjs2GXdRJ+wLhr/4dtVo4=";
           };
         };
         moonbit =
@@ -71,7 +71,7 @@
               };
               coreSrc = pkgs.fetchurl {
                 url = "https://cli.moonbitlang.com/cores/core-latest.tar.gz";
-                hash = "sha256-IfB4RrsGhm7Vj79Tq9CTmC3/SKcNX+Jfb5zpDF12Ct0=";
+                hash = "sha256-LMOHyw9HPsEBp+BnOAAUnIhHgSFkRfBgTtXx4RDPc+o=";
               };
               nativeBuildInputs = lib.optionals pkgs.stdenv.isLinux [ pkgs.patchelf ];
               dontUnpack = true;


### PR DESCRIPTION
## Why

After the Blacksmith re-pin (#1505), the push-to-main **nix-flake** gate still fails — now on a different mutable-`latest` fixed-output derivation:

```
error: build of 'core-latest.tar.gz.drv' failed: hash mismatch in fixed-output derivation
  specified: sha256-IfB4RrsGhm7Vj79Tq9CTmC3/SKcNX+Jfb5zpDF12Ct0=
  got:       sha256-LMOHyw9HPsEBp+BnOAAUnIhHgSFkRfBgTtXx4RDPc+o=
```

The MoonBit block pins four `latest`-channel artifacts (three platform toolchain tarballs + the shared `core-latest.tar.gz`), exactly like Blacksmith. MoonBit shipped a new `latest` build — `moon` now self-reports `0.1.20260608 (2026-06-08)` (was `0.9.3-2026-05-22`) — so **all four** drifted; CI just surfaced `core-latest` first.

## What

Re-pin all four, captured with `nix store prefetch-file`:

| artifact | new hash |
| --- | --- |
| moonbit-darwin-aarch64 | `sha256-YAgKPu+uA4e2Z/UXJJpwt2ezdMANIjLuczet2ff3JIc=` |
| moonbit-linux-x86_64 | `sha256-PFAX9WkoSALxoLhCLRSZY6AcpYfFFEURZK75HGXfiqg=` |
| moonbit-linux-aarch64 | `sha256-fw4LyzobPWKaDV/9sattbQzjs2GXdRJ+wLhr/4dtVo4=` |
| core-latest | `sha256-LMOHyw9HPsEBp+BnOAAUnIhHgSFkRfBgTtXx4RDPc+o=` |

The `core-latest` value matches CI's reported `got:` exactly. Also bump the `version` label (`0.9.3-2026-05-22` → `0.1.20260608-2026-06-08`, from the new binary's `moon version`) so the devShell's `.nix-version` cache key invalidates for local developers — adjust if your label convention differs.

## Note

This is the third `latest`-channel drift in a row (Blacksmith #1505, now MoonBit ×4). Pinning **versioned** URLs instead of `latest` would end the recurring churn, but that's a larger design change left to you.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1506"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->