### PR TITLE
feat(atelier-jsx): add shared JSX/TSX lowering layer (#1492)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3482,6 +3482,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "vize_atelier_jsx"
+version = "0.206.0"
+dependencies = [
+ "oxc_allocator",
+ "oxc_ast",
+ "oxc_ast_visit",
+ "oxc_diagnostics",
+ "oxc_parser",
+ "oxc_span",
+ "oxc_syntax",
+ "vize_carton",
+ "vize_croquis",
+ "vize_relief",
+]
+
+[[package]]
 name = "vize_atelier_sfc"
 version = "0.206.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
   "crates/vize_atelier_vapor",
   "crates/vize_atelier_ssr",
   "crates/vize_atelier_sfc",
+  "crates/vize_atelier_jsx",
   "crates/vize_vitrine",
   "crates/vize",
   "crates/vize_canon",
@@ -42,6 +43,7 @@ vize_atelier_dom = { path = "crates/vize_atelier_dom", version = "=0.206.0" }
 vize_atelier_vapor = { path = "crates/vize_atelier_vapor", version = "=0.206.0" }
 vize_atelier_ssr = { path = "crates/vize_atelier_ssr", version = "=0.206.0" }
 vize_atelier_sfc = { path = "crates/vize_atelier_sfc", version = "=0.206.0", default-features = false }
+vize_atelier_jsx = { path = "crates/vize_atelier_jsx", version = "=0.206.0" }
 vize_musea = { path = "crates/vize_musea", version = "=0.206.0" }
 vize_patina = { path = "crates/vize_patina", version = "=0.206.0" }
 vize_canon = { path = "crates/vize_canon", version = "=0.206.0", default-features = false }

--- a/crates/vize_atelier_jsx/Cargo.toml
+++ b/crates/vize_atelier_jsx/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "vize_atelier_jsx"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Atelier JSX - Shared JSX/TSX lowering layer for Vize"
+
+[dependencies]
+# Internal crates
+vize_carton = { workspace = true }
+vize_relief = { workspace = true }
+vize_croquis = { workspace = true }
+
+# OXC for JSX/TSX parsing and diagnostics
+oxc_allocator = { workspace = true }
+oxc_parser = { workspace = true }
+oxc_ast = { workspace = true }
+oxc_ast_visit = { workspace = true }
+oxc_syntax = { workspace = true }
+oxc_span = { workspace = true }
+oxc_diagnostics = { workspace = true }
+
+[features]
+default = []
+# Mirror the relief legacy surface so the `InterpolationNode::raw` field stays
+# in sync under workspace feature unification (see vize_armature's `legacy`).
+legacy = ["vize_relief/_legacy"]

--- a/crates/vize_atelier_jsx/src/analyze.rs
+++ b/crates/vize_atelier_jsx/src/analyze.rs
@@ -1,0 +1,21 @@
+//! Running Croquis semantic analysis over a parsed JSX/TSX module.
+//!
+//! Croquis normally parses script text itself with a TypeScript [`SourceType`],
+//! which would reject JSX. We sidestep that by feeding it the program we have
+//! *already* parsed with the correct JSX/TSX dialect via its parse-free entry
+//! point, so the binding/scope/reactivity analysis runs without a second parse.
+//!
+//! [`SourceType`]: oxc_span::SourceType
+
+use oxc_ast::ast::Program;
+use vize_croquis::script_parser::analyze_script_setup_program;
+use vize_croquis::{Croquis, Drawer};
+
+/// Analyze a parsed JSX/TSX program, returning the Croquis binding metadata,
+/// scope chain, reactivity tracking, and macro/import information.
+pub(crate) fn analyze_program(program: &Program<'_>, source: &str) -> Croquis {
+    let result = analyze_script_setup_program(program, source, None);
+    let mut croquis = Drawer::new().finish();
+    result.apply_to_croquis(&mut croquis);
+    croquis
+}

--- a/crates/vize_atelier_jsx/src/diagnostics.rs
+++ b/crates/vize_atelier_jsx/src/diagnostics.rs
@@ -1,0 +1,77 @@
+//! Diagnostics produced while parsing and lowering JSX/TSX.
+//!
+//! Every diagnostic carries a Vize byte range so it can be mapped back to the
+//! original `.jsx`/`.tsx` source by the compiler, type checker, and LSP.
+
+use vize_carton::String;
+use vize_relief::ast::core::SourceLocation;
+
+/// Severity of a JSX lowering diagnostic.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Severity {
+    /// A hard error: lowering could not faithfully represent the input.
+    Error,
+    /// A non-fatal warning: lowering continued but something is suspect.
+    Warning,
+}
+
+/// A diagnostic with a message and a source location.
+#[derive(Debug, Clone, PartialEq)]
+pub struct JsxDiagnostic {
+    /// Severity of the diagnostic.
+    pub severity: Severity,
+    /// Human-readable message.
+    pub message: String,
+    /// Inclusive-start / exclusive-end byte range in the original source.
+    pub start: u32,
+    /// End byte offset.
+    pub end: u32,
+}
+
+impl JsxDiagnostic {
+    /// Build an error diagnostic spanning `[start, end)`.
+    pub fn error(message: impl Into<String>, start: u32, end: u32) -> Self {
+        Self {
+            severity: Severity::Error,
+            message: message.into(),
+            start,
+            end,
+        }
+    }
+
+    /// Build a warning diagnostic spanning `[start, end)`.
+    pub fn warning(message: impl Into<String>, start: u32, end: u32) -> Self {
+        Self {
+            severity: Severity::Warning,
+            message: message.into(),
+            start,
+            end,
+        }
+    }
+
+    /// Build an error diagnostic from a Vize [`SourceLocation`].
+    pub fn error_at(message: impl Into<String>, loc: &SourceLocation) -> Self {
+        Self::error(message, loc.start.offset, loc.end.offset)
+    }
+
+    /// Whether this diagnostic is an error.
+    pub fn is_error(&self) -> bool {
+        self.severity == Severity::Error
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn error_and_warning_constructors() {
+        let e = JsxDiagnostic::error("boom", 1, 4);
+        assert!(e.is_error());
+        assert_eq!((e.start, e.end), (1, 4));
+
+        let w = JsxDiagnostic::warning("hmm", 2, 3);
+        assert!(!w.is_error());
+        assert_eq!(w.severity, Severity::Warning);
+    }
+}

--- a/crates/vize_atelier_jsx/src/finder.rs
+++ b/crates/vize_atelier_jsx/src/finder.rs
@@ -1,0 +1,130 @@
+//! Finding outermost JSX render roots and their component context.
+//!
+//! A JSX/TSX module can embed JSX anywhere an expression is allowed (arrow
+//! bodies, `return` statements, ternaries, …). We treat every *outermost* JSX
+//! element or fragment — one not nested inside another JSX node — as a render
+//! root and lower it immediately, while the OXC node is still live, so no JSX
+//! references escape the parse arena.
+//!
+//! While walking we maintain a stack of enclosing function scopes so each root
+//! can record:
+//! - the nearest `"use vue:vapor"` / `"use vue:vdom"` directive prologue, and
+//! - the enclosing component function's name (`function App` or
+//!   `const App = () => …`).
+
+use oxc_ast::ast::{
+    ArrowFunctionExpression, Function, FunctionBody, JSXElement, JSXFragment, Program,
+    VariableDeclarator,
+};
+use oxc_ast_visit::{Visit, walk};
+use oxc_syntax::scope::ScopeFlags;
+use vize_carton::String;
+
+use crate::LoweredRoot;
+use crate::lower::Lowerer;
+use crate::mode::JsxOutputMode;
+
+/// Lower every outermost JSX root in `program` into a [`LoweredRoot`].
+pub(crate) fn lower_program_roots<'a>(
+    program: &Program<'_>,
+    lowerer: &mut Lowerer<'a, '_, '_>,
+) -> std::vec::Vec<LoweredRoot<'a>> {
+    let mut collector = RootLowerer {
+        lowerer,
+        roots: std::vec::Vec::new(),
+        scopes: std::vec::Vec::new(),
+        pending_name: None,
+    };
+    collector.visit_program(program);
+    collector.roots
+}
+
+/// An enclosing function scope.
+struct FnScope {
+    mode: Option<JsxOutputMode>,
+    name: Option<String>,
+}
+
+struct RootLowerer<'l, 'a, 'm, 's> {
+    lowerer: &'l mut Lowerer<'a, 'm, 's>,
+    roots: std::vec::Vec<LoweredRoot<'a>>,
+    scopes: std::vec::Vec<FnScope>,
+    /// Name captured from a `const X = ...` declarator, claimed by the next
+    /// function/arrow we enter.
+    pending_name: Option<String>,
+}
+
+impl RootLowerer<'_, '_, '_, '_> {
+    fn current_mode(&self) -> Option<JsxOutputMode> {
+        self.scopes.iter().rev().find_map(|scope| scope.mode)
+    }
+
+    fn current_name(&self) -> Option<String> {
+        self.scopes
+            .iter()
+            .rev()
+            .find_map(|scope| scope.name.clone())
+    }
+
+    fn push_scope(&mut self, body: Option<&FunctionBody<'_>>, name: Option<String>) {
+        let mode = body.and_then(body_mode);
+        self.scopes.push(FnScope { mode, name });
+    }
+}
+
+impl<'ast> Visit<'ast> for RootLowerer<'_, '_, '_, '_> {
+    fn visit_variable_declarator(&mut self, it: &VariableDeclarator<'ast>) {
+        // Capture `const App = ...` so an immediately-initialized function or
+        // arrow can adopt the binding name.
+        if let Some(name) = it.id.get_identifier_name() {
+            self.pending_name = Some(String::from(name.as_str()));
+        }
+        walk::walk_variable_declarator(self, it);
+        self.pending_name = None;
+    }
+
+    fn visit_function(&mut self, it: &Function<'ast>, flags: ScopeFlags) {
+        let name = it
+            .id
+            .as_ref()
+            .map(|id| String::from(id.name.as_str()))
+            .or_else(|| self.pending_name.take());
+        self.push_scope(it.body.as_deref(), name);
+        walk::walk_function(self, it, flags);
+        self.scopes.pop();
+    }
+
+    fn visit_arrow_function_expression(&mut self, it: &ArrowFunctionExpression<'ast>) {
+        let name = self.pending_name.take();
+        self.push_scope(Some(&it.body), name);
+        walk::walk_arrow_function_expression(self, it);
+        self.scopes.pop();
+    }
+
+    fn visit_jsx_element(&mut self, element: &JSXElement<'ast>) {
+        // Lower this root and intentionally do NOT descend: nested JSX is
+        // lowered as part of this root's children, not as separate roots.
+        let root = self.lowerer.lower_element_root(element);
+        self.roots.push(LoweredRoot {
+            root,
+            mode: self.current_mode(),
+            component_name: self.current_name(),
+        });
+    }
+
+    fn visit_jsx_fragment(&mut self, fragment: &JSXFragment<'ast>) {
+        let root = self.lowerer.lower_fragment_root(fragment);
+        self.roots.push(LoweredRoot {
+            root,
+            mode: self.current_mode(),
+            component_name: self.current_name(),
+        });
+    }
+}
+
+/// The first JSX output-mode directive in a function body's prologue, if any.
+fn body_mode(body: &FunctionBody<'_>) -> Option<JsxOutputMode> {
+    body.directives
+        .iter()
+        .find_map(|directive| JsxOutputMode::from_directive(directive.directive.as_str()))
+}

--- a/crates/vize_atelier_jsx/src/lang.rs
+++ b/crates/vize_atelier_jsx/src/lang.rs
@@ -1,0 +1,83 @@
+//! JSX/TSX source language selection.
+
+use oxc_span::SourceType;
+
+/// The flavor of JSX source being lowered.
+///
+/// Vize supports both plain `.jsx` (JavaScript + JSX) and `.tsx`
+/// (TypeScript + JSX). The distinction only affects how OXC parses the
+/// surrounding script; the lowering of JSX nodes themselves is identical.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum JsxLang {
+    /// JavaScript with JSX (`.jsx`).
+    Jsx,
+    /// TypeScript with JSX (`.tsx`).
+    Tsx,
+}
+
+impl JsxLang {
+    /// Infer the language from a file extension or `lang` attribute value.
+    ///
+    /// Anything that is not recognized as TypeScript falls back to [`JsxLang::Jsx`].
+    pub fn from_lang(lang: Option<&str>) -> Self {
+        match lang.map(str::trim) {
+            Some("tsx") | Some("ts") | Some("typescript") => Self::Tsx,
+            _ => Self::Jsx,
+        }
+    }
+
+    /// Infer the language from a file path by its extension.
+    pub fn from_path(path: &str) -> Self {
+        if path.ends_with(".tsx") {
+            Self::Tsx
+        } else {
+            Self::Jsx
+        }
+    }
+
+    /// Whether this language carries TypeScript syntax.
+    pub fn is_typescript(self) -> bool {
+        matches!(self, Self::Tsx)
+    }
+
+    /// The OXC [`SourceType`] used to parse this language as an ES module.
+    pub fn source_type(self) -> SourceType {
+        match self {
+            Self::Jsx => SourceType::jsx().with_module(true),
+            Self::Tsx => SourceType::tsx().with_module(true),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_lang_maps_typescript_variants() {
+        assert_eq!(JsxLang::from_lang(Some("tsx")), JsxLang::Tsx);
+        assert_eq!(JsxLang::from_lang(Some("ts")), JsxLang::Tsx);
+        assert_eq!(JsxLang::from_lang(Some("typescript")), JsxLang::Tsx);
+        assert_eq!(JsxLang::from_lang(Some(" tsx ")), JsxLang::Tsx);
+    }
+
+    #[test]
+    fn from_lang_defaults_to_jsx() {
+        assert_eq!(JsxLang::from_lang(Some("jsx")), JsxLang::Jsx);
+        assert_eq!(JsxLang::from_lang(None), JsxLang::Jsx);
+        assert_eq!(JsxLang::from_lang(Some("js")), JsxLang::Jsx);
+    }
+
+    #[test]
+    fn from_path_uses_extension() {
+        assert_eq!(JsxLang::from_path("App.tsx"), JsxLang::Tsx);
+        assert_eq!(JsxLang::from_path("App.jsx"), JsxLang::Jsx);
+        assert_eq!(JsxLang::from_path("App.js"), JsxLang::Jsx);
+    }
+
+    #[test]
+    fn is_typescript_flag() {
+        assert!(JsxLang::Tsx.is_typescript());
+        assert!(!JsxLang::Jsx.is_typescript());
+    }
+}

--- a/crates/vize_atelier_jsx/src/lib.rs
+++ b/crates/vize_atelier_jsx/src/lib.rs
@@ -1,0 +1,113 @@
+//! Shared JSX/TSX lowering layer for Vize.
+//!
+//! This crate turns OXC-parsed JSX/TSX into Vize's shared template IR
+//! ([`vize_relief::ast::RootNode`]) exactly once, so the VDOM
+//! ([`vize_atelier_dom`](https://docs.rs/vize_atelier_dom)) and Vapor
+//! (`vize_atelier_vapor`) backends, the type checker, the LSP, and Patina all
+//! consume the same lowered representation instead of forking JSX-only logic.
+//!
+//! The lowering layer is intentionally backend-neutral: it does **not** invoke
+//! VDOM or Vapor codegen. It only:
+//!
+//! 1. parses `.jsx`/`.tsx` with OXC ([`parse`]),
+//! 2. maps OXC byte spans to Vize [`SourceLocation`](vize_relief::ast::core::SourceLocation)s
+//!    ([`span`]), and
+//! 3. lowers JSX elements, fragments, text, expressions, spreads, attributes,
+//!    directives, and component references into [`vize_relief`] structures
+//!    ([`lower`]).
+//!
+//! # Example
+//!
+//! ```
+//! use vize_atelier_jsx::{lower_source, JsxLang};
+//! use vize_carton::Bump;
+//!
+//! let bump = Bump::new();
+//! let out = lower_source(&bump, "const App = () => <div class=\"a\">{count}</div>;", JsxLang::Jsx);
+//! assert_eq!(out.roots.len(), 1);
+//! assert!(out.diagnostics.is_empty());
+//! ```
+
+pub mod diagnostics;
+pub mod lang;
+pub mod lower;
+pub mod mode;
+pub mod parse;
+pub mod span;
+
+mod analyze;
+mod finder;
+
+use vize_carton::{Bump, String};
+use vize_croquis::Croquis;
+use vize_croquis::croquis::BindingMetadata;
+use vize_relief::ast::RootNode;
+
+pub use diagnostics::{JsxDiagnostic, Severity};
+pub use lang::JsxLang;
+pub use lower::Lowerer;
+pub use mode::JsxOutputMode;
+pub use parse::{ParsedModule, parse_module};
+pub use span::SpanMapper;
+
+/// A single lowered render root plus the component metadata recovered from its
+/// enclosing function.
+pub struct LoweredRoot<'a> {
+    /// The lowered template IR.
+    pub root: RootNode<'a>,
+    /// Output mode override from the nearest enclosing component function's
+    /// `"use vue:vapor"` / `"use vue:vdom"` directive prologue, if any. `None`
+    /// means the configured default applies.
+    pub mode: Option<JsxOutputMode>,
+    /// Name of the enclosing component function (`function App` / `const App =
+    /// () => …`), if it could be resolved.
+    pub component_name: Option<String>,
+}
+
+/// The result of lowering a whole JSX/TSX module.
+pub struct LowerOutput<'a> {
+    /// One lowered render root per outermost JSX expression found in the module,
+    /// in source order.
+    pub roots: Vec<LoweredRoot<'a>>,
+    /// Croquis semantic analysis of the whole module: binding metadata, scope
+    /// chain, reactivity, macros, and imports. Exposed so the VDOM/Vapor
+    /// backends, Canon, Maestro, and Patina can consume the same analysis the
+    /// lowering layer saw instead of re-deriving it.
+    pub analysis: Croquis,
+    /// Parse and lowering diagnostics, mapped to Vize byte ranges.
+    pub diagnostics: Vec<JsxDiagnostic>,
+}
+
+impl<'a> LowerOutput<'a> {
+    /// Whether any error-severity diagnostic was produced.
+    pub fn has_errors(&self) -> bool {
+        self.diagnostics.iter().any(JsxDiagnostic::is_error)
+    }
+
+    /// Script binding metadata recovered by Croquis (refs, props, imports, …).
+    pub fn bindings(&self) -> &BindingMetadata {
+        &self.analysis.bindings
+    }
+}
+
+/// Parse and lower a JSX/TSX source string into Vize render roots.
+///
+/// All JSX nodes are lowered into the supplied `bump` arena; the temporary OXC
+/// allocator used for parsing is dropped before returning, so the result only
+/// borrows `bump`.
+pub fn lower_source<'a>(bump: &'a Bump, source: &str, lang: JsxLang) -> LowerOutput<'a> {
+    let allocator = oxc_allocator::Allocator::default();
+    let parsed = parse::parse_module(&allocator, source, lang);
+    let mapper = SpanMapper::new(source);
+    let mut lowerer = Lowerer::new(bump, &mapper);
+    for diagnostic in parsed.diagnostics {
+        lowerer.report(diagnostic);
+    }
+    let roots = finder::lower_program_roots(&parsed.program, &mut lowerer);
+    let analysis = analyze::analyze_program(&parsed.program, source);
+    LowerOutput {
+        roots,
+        analysis,
+        diagnostics: lowerer.into_diagnostics(),
+    }
+}

--- a/crates/vize_atelier_jsx/src/lower/attr.rs
+++ b/crates/vize_atelier_jsx/src/lower/attr.rs
@@ -1,0 +1,174 @@
+//! Lowering JSX attributes into Vize props (attributes, binds, directives).
+//!
+//! The mapping is backend-neutral; richer `v-on`/`v-model` semantics belong to
+//! the VDOM/Vapor backends (#1493/#1494). Here we faithfully classify:
+//!
+//! - `name="str"`      -> static [`AttributeNode`]
+//! - `name` (no value) -> boolean [`AttributeNode`]
+//! - `name={expr}`     -> `v-bind:name` [`DirectiveNode`]
+//! - `{...obj}`        -> `v-bind="obj"` [`DirectiveNode`]
+//! - `v-x` / `v-x:arg` -> [`DirectiveNode`] named `x`
+
+use oxc_ast::ast::{
+    JSXAttribute, JSXAttributeItem, JSXAttributeName, JSXAttributeValue, JSXSpreadAttribute,
+};
+use oxc_span::{GetSpan, Span};
+use vize_carton::{Box, String, Vec};
+use vize_relief::ast::core::SourceLocation;
+use vize_relief::ast::{AttributeNode, DirectiveNode, PropNode, TextNode};
+
+use super::Lowerer;
+use super::expr::container_expr_span;
+
+impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
+    /// Lower a JSX opening element's attribute list into Vize props.
+    pub(crate) fn lower_attributes(
+        &mut self,
+        items: &[JSXAttributeItem<'_>],
+    ) -> Vec<'a, PropNode<'a>> {
+        let mut props = Vec::new_in(self.bump());
+        for item in items {
+            let prop = match item {
+                JSXAttributeItem::Attribute(attr) => self.lower_attribute(attr),
+                JSXAttributeItem::SpreadAttribute(spread) => self.lower_spread_attribute(spread),
+            };
+            props.push(prop);
+        }
+        props
+    }
+
+    /// `{...obj}` -> `v-bind="obj"`.
+    fn lower_spread_attribute(&mut self, spread: &JSXSpreadAttribute<'_>) -> PropNode<'a> {
+        let loc = self.mapper().location(spread.span);
+        let mut directive = DirectiveNode::new(self.bump(), "bind", loc);
+        directive.exp = Some(self.dyn_expr(spread.argument.span()));
+        PropNode::Directive(Box::new_in(directive, self.bump()))
+    }
+
+    fn lower_attribute(&mut self, attr: &JSXAttribute<'_>) -> PropNode<'a> {
+        let loc = self.mapper().location(attr.span);
+
+        // Directive forms: `v-model`, `v-show`, `v-on:click`, custom `v-foo:arg`.
+        if let Some(directive) = self.try_directive_attribute(attr, &loc) {
+            return directive;
+        }
+
+        let name = attr_full_name(&attr.name);
+        let name_loc = self.mapper().location(attr.name.span());
+        match attr.value.as_ref() {
+            None => self.boolean_attr(name, name_loc, loc),
+            Some(JSXAttributeValue::StringLiteral(string)) => {
+                let value =
+                    TextNode::new(string.value.as_str(), self.mapper().location(string.span));
+                PropNode::Attribute(Box::new_in(
+                    AttributeNode {
+                        name,
+                        name_loc,
+                        value: Some(value),
+                        loc,
+                    },
+                    self.bump(),
+                ))
+            }
+            Some(JSXAttributeValue::ExpressionContainer(container)) => {
+                match container_expr_span(container) {
+                    // `name={}` behaves like a boolean attribute.
+                    None => self.boolean_attr(name, name_loc, loc),
+                    Some(span) => self.bind_prop(&name, attr.name.span(), span, loc),
+                }
+            }
+            Some(JSXAttributeValue::Element(element)) => {
+                self.bind_prop(&name, attr.name.span(), element.span(), loc)
+            }
+            Some(JSXAttributeValue::Fragment(fragment)) => {
+                self.bind_prop(&name, attr.name.span(), fragment.span(), loc)
+            }
+        }
+    }
+
+    fn boolean_attr(
+        &self,
+        name: String,
+        name_loc: SourceLocation,
+        loc: SourceLocation,
+    ) -> PropNode<'a> {
+        PropNode::Attribute(Box::new_in(
+            AttributeNode {
+                name,
+                name_loc,
+                value: None,
+                loc,
+            },
+            self.bump(),
+        ))
+    }
+
+    /// `name={expr}` -> `v-bind:name="expr"`.
+    fn bind_prop(
+        &self,
+        name: &str,
+        name_span: Span,
+        value_span: Span,
+        loc: SourceLocation,
+    ) -> PropNode<'a> {
+        let mut directive = DirectiveNode::new(self.bump(), "bind", loc);
+        directive.arg = Some(self.static_expr(name, name_span));
+        directive.exp = Some(self.dyn_expr(value_span));
+        PropNode::Directive(Box::new_in(directive, self.bump()))
+    }
+
+    fn try_directive_attribute(
+        &self,
+        attr: &JSXAttribute<'_>,
+        loc: &SourceLocation,
+    ) -> Option<PropNode<'a>> {
+        let (directive_name, arg) = match &attr.name {
+            JSXAttributeName::NamespacedName(named) => {
+                let directive_name = named.namespace.name.as_str().strip_prefix("v-")?;
+                (
+                    directive_name,
+                    Some((named.name.name.as_str(), named.name.span())),
+                )
+            }
+            JSXAttributeName::Identifier(id) => {
+                let directive_name = id.name.as_str().strip_prefix("v-")?;
+                (directive_name, None)
+            }
+        };
+
+        let mut directive = DirectiveNode::new(self.bump(), directive_name, loc.clone());
+        if let Some((arg_name, arg_span)) = arg {
+            directive.arg = Some(self.static_expr(arg_name, arg_span));
+        }
+        directive.exp = self.directive_value_expr(attr.value.as_ref());
+        Some(PropNode::Directive(Box::new_in(directive, self.bump())))
+    }
+
+    fn directive_value_expr(
+        &self,
+        value: Option<&JSXAttributeValue<'_>>,
+    ) -> Option<vize_relief::ast::ExpressionNode<'a>> {
+        match value? {
+            JSXAttributeValue::StringLiteral(string) => {
+                Some(self.static_expr(string.value.as_str(), string.span))
+            }
+            JSXAttributeValue::ExpressionContainer(container) => {
+                container_expr_span(container).map(|span| self.dyn_expr(span))
+            }
+            JSXAttributeValue::Element(element) => Some(self.dyn_expr(element.span())),
+            JSXAttributeValue::Fragment(fragment) => Some(self.dyn_expr(fragment.span())),
+        }
+    }
+}
+
+fn attr_full_name(name: &JSXAttributeName<'_>) -> String {
+    match name {
+        JSXAttributeName::Identifier(id) => String::from(id.name.as_str()),
+        JSXAttributeName::NamespacedName(named) => {
+            let mut full = String::from(named.namespace.name.as_str());
+            full.push(':');
+            full.push_str(named.name.name.as_str());
+            full
+        }
+    }
+}

--- a/crates/vize_atelier_jsx/src/lower/child.rs
+++ b/crates/vize_atelier_jsx/src/lower/child.rs
@@ -1,0 +1,82 @@
+//! Lowering JSX children into Vize template child nodes.
+
+use oxc_ast::ast::{JSXChild, JSXExpression, JSXExpressionContainer, JSXSpreadChild};
+use oxc_span::GetSpan;
+use vize_carton::{Box, Vec};
+use vize_relief::ast::{InterpolationNode, TemplateChildNode, TextNode};
+
+use super::Lowerer;
+
+impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
+    /// Lower a list of JSX children, dropping whitespace-only text.
+    pub(crate) fn lower_children(
+        &mut self,
+        children: &[JSXChild<'_>],
+    ) -> Vec<'a, TemplateChildNode<'a>> {
+        let mut out = Vec::new_in(self.bump());
+        for child in children {
+            if let Some(node) = self.lower_child(child) {
+                out.push(node);
+            }
+        }
+        out
+    }
+
+    fn lower_child(&mut self, child: &JSXChild<'_>) -> Option<TemplateChildNode<'a>> {
+        match child {
+            JSXChild::Text(text) => self.lower_text(text),
+            JSXChild::Element(element) => Some(TemplateChildNode::Element(Box::new_in(
+                self.lower_element_node(element),
+                self.bump(),
+            ))),
+            JSXChild::Fragment(fragment) => Some(TemplateChildNode::Element(Box::new_in(
+                self.lower_fragment_node(fragment),
+                self.bump(),
+            ))),
+            JSXChild::ExpressionContainer(container) => self.lower_child_container(container),
+            JSXChild::Spread(spread) => Some(self.lower_spread_child(spread)),
+        }
+    }
+
+    fn lower_child_container(
+        &mut self,
+        container: &JSXExpressionContainer<'_>,
+    ) -> Option<TemplateChildNode<'a>> {
+        match &container.expression {
+            // `{}` / `{/* comment */}` produce nothing.
+            JSXExpression::EmptyExpression(_) => None,
+            // `{'literal'}` lowers to plain text, covering the explicit-space
+            // idiom `{' '}`.
+            JSXExpression::StringLiteral(string) => Some(TemplateChildNode::Text(Box::new_in(
+                TextNode::new(string.value.as_str(), self.mapper().location(string.span)),
+                self.bump(),
+            ))),
+            expression => {
+                let content = self.dyn_expr(expression.span());
+                Some(self.interpolation(content, container.span))
+            }
+        }
+    }
+
+    /// `{...children}` keeps the spread argument as an interpolation expression.
+    fn lower_spread_child(&mut self, spread: &JSXSpreadChild<'_>) -> TemplateChildNode<'a> {
+        let content = self.dyn_expr(spread.expression.span());
+        self.interpolation(content, spread.span)
+    }
+
+    fn interpolation(
+        &self,
+        content: vize_relief::ast::ExpressionNode<'a>,
+        span: oxc_span::Span,
+    ) -> TemplateChildNode<'a> {
+        let node = InterpolationNode {
+            content,
+            loc: self.mapper().location(span),
+            // JSX interpolation is always escaped; the legacy raw-HTML flag
+            // (Vue 1 triple-mustache) never applies here.
+            #[cfg(feature = "legacy")]
+            raw: false,
+        };
+        TemplateChildNode::Interpolation(Box::new_in(node, self.bump()))
+    }
+}

--- a/crates/vize_atelier_jsx/src/lower/element.rs
+++ b/crates/vize_atelier_jsx/src/lower/element.rs
@@ -1,0 +1,40 @@
+//! Lowering JSX elements and fragments into [`ElementNode`]s.
+
+use oxc_ast::ast::{JSXElement, JSXElementName, JSXFragment};
+use vize_relief::ast::ElementNode;
+use vize_relief::ast::core::ElementType;
+
+use super::{Lowerer, name};
+
+impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
+    /// Lower a JSX element into an [`ElementNode`] (tag, kind, props, children).
+    pub(crate) fn lower_element_node(&mut self, element: &JSXElement<'_>) -> ElementNode<'a> {
+        let opening = &element.opening_element;
+        let tag = name::element_tag(&opening.name);
+        let loc = self.mapper().location(element.span);
+        let mut node = ElementNode::new(self.bump(), tag, loc);
+        node.tag_type = element_type(&opening.name);
+        node.is_self_closing = element.closing_element.is_none();
+        node.props = self.lower_attributes(&opening.attributes);
+        node.children = self.lower_children(&element.children);
+        node
+    }
+
+    /// Lower a JSX fragment (`<>...</>`) used as a child into an [`ElementNode`]
+    /// tagged `Fragment`, matching `@vue/babel-plugin-jsx` semantics.
+    pub(crate) fn lower_fragment_node(&mut self, fragment: &JSXFragment<'_>) -> ElementNode<'a> {
+        let loc = self.mapper().location(fragment.span);
+        let mut node = ElementNode::new(self.bump(), "Fragment", loc);
+        node.tag_type = ElementType::Component;
+        node.children = self.lower_children(&fragment.children);
+        node
+    }
+}
+
+fn element_type(name: &JSXElementName<'_>) -> ElementType {
+    if name::is_component(name) {
+        ElementType::Component
+    } else {
+        ElementType::Element
+    }
+}

--- a/crates/vize_atelier_jsx/src/lower/expr.rs
+++ b/crates/vize_atelier_jsx/src/lower/expr.rs
@@ -1,0 +1,41 @@
+//! Building Vize expression nodes from OXC spans.
+
+use oxc_ast::ast::{JSXExpression, JSXExpressionContainer};
+use oxc_span::{GetSpan, Span};
+use vize_carton::Box;
+use vize_relief::ast::{ExpressionNode, SimpleExpressionNode};
+
+use super::Lowerer;
+
+impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
+    /// A dynamic (non-static) simple expression whose content is the source
+    /// slice covered by `span`. Vize's later transform passes parse and prefix
+    /// the identifiers; the lowering layer only needs the raw text + location.
+    pub(crate) fn dyn_expr(&self, span: Span) -> ExpressionNode<'a> {
+        let loc = self.mapper().location(span);
+        let content = self.mapper().slice(span);
+        ExpressionNode::Simple(Box::new_in(
+            SimpleExpressionNode::new(content, false, loc),
+            self.bump(),
+        ))
+    }
+
+    /// A static simple expression with explicit `content` at `span` (used for
+    /// directive arguments and bound attribute names).
+    pub(crate) fn static_expr(&self, content: &str, span: Span) -> ExpressionNode<'a> {
+        let loc = self.mapper().location(span);
+        ExpressionNode::Simple(Box::new_in(
+            SimpleExpressionNode::new(content, true, loc),
+            self.bump(),
+        ))
+    }
+}
+
+/// The span of the expression inside a container, or `None` for an empty
+/// container (`{}` / `{/* comment */}`).
+pub(crate) fn container_expr_span(container: &JSXExpressionContainer<'_>) -> Option<Span> {
+    match &container.expression {
+        JSXExpression::EmptyExpression(_) => None,
+        expression => Some(expression.span()),
+    }
+}

--- a/crates/vize_atelier_jsx/src/lower/mod.rs
+++ b/crates/vize_atelier_jsx/src/lower/mod.rs
@@ -1,0 +1,83 @@
+//! Lowering OXC JSX nodes into Vize's shared template IR.
+//!
+//! The [`Lowerer`] walks OXC JSX/TSX nodes and produces
+//! [`vize_relief::ast::RootNode`]s. Owned strings are copied out of the OXC
+//! arena (Vize uses `CompactString`), and the tree structure is built in the
+//! caller-supplied [`Bump`] arena, so the lowered IR does not borrow the OXC
+//! allocator and outlives parsing.
+
+mod attr;
+mod child;
+mod element;
+mod expr;
+mod name;
+mod text;
+
+use oxc_ast::ast::{JSXElement, JSXFragment};
+use vize_carton::{Box, Bump};
+use vize_relief::ast::{RootNode, TemplateChildNode};
+
+use crate::diagnostics::JsxDiagnostic;
+use crate::span::SpanMapper;
+
+/// Lowers OXC JSX nodes into Vize IR against a single source text.
+pub struct Lowerer<'a, 'm, 's> {
+    bump: &'a Bump,
+    mapper: &'m SpanMapper<'s>,
+    diagnostics: std::vec::Vec<JsxDiagnostic>,
+}
+
+impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
+    /// Build a lowerer that allocates IR in `bump` and maps spans via `mapper`.
+    pub fn new(bump: &'a Bump, mapper: &'m SpanMapper<'s>) -> Self {
+        Self {
+            bump,
+            mapper,
+            diagnostics: std::vec::Vec::new(),
+        }
+    }
+
+    /// Diagnostics accumulated so far.
+    pub fn diagnostics(&self) -> &[JsxDiagnostic] {
+        &self.diagnostics
+    }
+
+    /// Consume the lowerer and return its diagnostics.
+    pub fn into_diagnostics(self) -> std::vec::Vec<JsxDiagnostic> {
+        self.diagnostics
+    }
+
+    /// Record a diagnostic.
+    pub fn report(&mut self, diagnostic: JsxDiagnostic) {
+        self.diagnostics.push(diagnostic);
+    }
+
+    /// Lower a JSX element as the single root of a render output.
+    pub fn lower_element_root(&mut self, element: &JSXElement<'_>) -> RootNode<'a> {
+        let mut root = RootNode::new(self.bump, self.mapper.slice(element.span));
+        root.loc = self.mapper.location(element.span);
+        let node = self.lower_element_node(element);
+        root.children
+            .push(TemplateChildNode::Element(Box::new_in(node, self.bump)));
+        root
+    }
+
+    /// Lower a JSX fragment (`<>...</>`) as a render root whose children become
+    /// the root children directly (no wrapper element).
+    pub fn lower_fragment_root(&mut self, fragment: &JSXFragment<'_>) -> RootNode<'a> {
+        let mut root = RootNode::new(self.bump, self.mapper.slice(fragment.span));
+        root.loc = self.mapper.location(fragment.span);
+        root.children = self.lower_children(&fragment.children);
+        root
+    }
+
+    /// Shared accessor used by sibling lowering modules.
+    pub(crate) fn bump(&self) -> &'a Bump {
+        self.bump
+    }
+
+    /// Shared accessor used by sibling lowering modules.
+    pub(crate) fn mapper(&self) -> &'m SpanMapper<'s> {
+        self.mapper
+    }
+}

--- a/crates/vize_atelier_jsx/src/lower/name.rs
+++ b/crates/vize_atelier_jsx/src/lower/name.rs
@@ -1,0 +1,61 @@
+//! Resolving JSX element names into Vize tag strings and element kinds.
+
+use oxc_ast::ast::{JSXElementName, JSXMemberExpression, JSXMemberExpressionObject};
+use vize_carton::String;
+
+/// The Vize tag string for a JSX element name.
+///
+/// Member expressions keep their full dotted path (`Foo.Bar`), namespaced names
+/// keep the `ns:name` form, and `this.X` resolves to `this.X`.
+pub(crate) fn element_tag(name: &JSXElementName<'_>) -> String {
+    match name {
+        JSXElementName::Identifier(id) => String::from(id.name.as_str()),
+        JSXElementName::IdentifierReference(reference) => String::from(reference.name.as_str()),
+        JSXElementName::NamespacedName(named) => {
+            let mut tag = String::from(named.namespace.name.as_str());
+            tag.push(':');
+            tag.push_str(named.name.name.as_str());
+            tag
+        }
+        JSXElementName::MemberExpression(member) => member_to_string(member),
+        JSXElementName::ThisExpression(_) => String::from("this"),
+    }
+}
+
+/// Whether a JSX element name refers to a component rather than an intrinsic
+/// (HTML/SVG) element.
+///
+/// Mirrors the Vue JSX convention also used by `vize_patina`: a tag whose name
+/// begins with a lowercase ASCII letter is intrinsic; everything else
+/// (capitalized identifiers, member expressions, `this`) is a component.
+pub(crate) fn is_component(name: &JSXElementName<'_>) -> bool {
+    match name {
+        JSXElementName::Identifier(id) => !is_intrinsic(id.name.as_str()),
+        JSXElementName::IdentifierReference(reference) => !is_intrinsic(reference.name.as_str()),
+        JSXElementName::NamespacedName(named) => !is_intrinsic(named.name.name.as_str()),
+        JSXElementName::MemberExpression(_) | JSXElementName::ThisExpression(_) => true,
+    }
+}
+
+fn is_intrinsic(name: &str) -> bool {
+    name.chars()
+        .next()
+        .is_some_and(|ch| ch.is_ascii_lowercase())
+}
+
+fn member_to_string(member: &JSXMemberExpression<'_>) -> String {
+    let mut base = member_object_to_string(&member.object);
+    base.push('.');
+    base.push_str(member.property.name.as_str());
+    base
+}
+
+fn member_object_to_string(object: &JSXMemberExpressionObject<'_>) -> String {
+    match object {
+        JSXMemberExpressionObject::IdentifierReference(reference) => {
+            String::from(reference.name.as_str())
+        }
+        JSXMemberExpressionObject::MemberExpression(member) => member_to_string(member),
+        JSXMemberExpressionObject::ThisExpression(_) => String::from("this"),
+    }
+}

--- a/crates/vize_atelier_jsx/src/lower/text.rs
+++ b/crates/vize_atelier_jsx/src/lower/text.rs
@@ -1,0 +1,102 @@
+//! JSX text whitespace handling.
+//!
+//! JSX text is cleaned with the same rule `@vue/babel-plugin-jsx` inherits from
+//! Babel: lines are split, tabs become spaces, whitespace adjacent to a newline
+//! is trimmed, blank lines are dropped, and the remaining lines are joined with
+//! a single space. Leading whitespace on the first line and trailing whitespace
+//! on the last line are preserved.
+
+use oxc_ast::ast::JSXText;
+use vize_carton::{Box, String};
+use vize_relief::ast::{TemplateChildNode, TextNode};
+
+use super::Lowerer;
+
+impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
+    /// Lower a JSX text child, returning `None` if it cleans to nothing.
+    pub(crate) fn lower_text(&mut self, text: &JSXText<'_>) -> Option<TemplateChildNode<'a>> {
+        let cleaned = clean_jsx_text(text.value.as_str());
+        if cleaned.is_empty() {
+            return None;
+        }
+        let loc = self.mapper().location(text.span);
+        Some(TemplateChildNode::Text(Box::new_in(
+            TextNode::new(cleaned, loc),
+            self.bump(),
+        )))
+    }
+}
+
+/// Clean JSX text per the Babel/Vue JSX whitespace algorithm.
+pub(crate) fn clean_jsx_text(raw: &str) -> String {
+    // Normalize line endings by stripping a trailing `\r` from each `\n`-split
+    // line so `\r\n` collapses to a single line break.
+    let lines: std::vec::Vec<&str> = raw
+        .split('\n')
+        .map(|line| line.strip_suffix('\r').unwrap_or(line))
+        .collect();
+    let line_count = lines.len();
+
+    // Index of the last line containing a non-whitespace byte. Babel keeps the
+    // initial value of `0` when every line is blank, so we mirror that.
+    let last_non_blank = lines
+        .iter()
+        .rposition(|line| line.bytes().any(|b| b != b' ' && b != b'\t'))
+        .unwrap_or(0);
+
+    let mut result = String::default();
+    for (index, line) in lines.iter().enumerate() {
+        let is_first = index == 0;
+        let is_last = index == line_count - 1;
+
+        // Tabs are treated as spaces, matching Babel's `replace(/\t/g, " ")`.
+        let normalized = line.replace('\t', " ");
+        let mut trimmed: &str = &normalized;
+        if !is_first {
+            trimmed = trimmed.trim_start_matches(' ');
+        }
+        if !is_last {
+            trimmed = trimmed.trim_end_matches(' ');
+        }
+        if trimmed.is_empty() {
+            continue;
+        }
+        result.push_str(trimmed);
+        if index != last_non_blank {
+            result.push(' ');
+        }
+    }
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::clean_jsx_text;
+
+    #[test]
+    fn collapses_indentation_between_lines() {
+        let input = "\n      Hello\n      World\n    ";
+        assert_eq!(clean_jsx_text(input), "Hello World");
+    }
+
+    #[test]
+    fn preserves_single_line_internal_spaces() {
+        assert_eq!(clean_jsx_text("a   b"), "a   b");
+    }
+
+    #[test]
+    fn preserves_first_line_leading_and_last_line_trailing() {
+        assert_eq!(clean_jsx_text("  hi  "), "  hi  ");
+    }
+
+    #[test]
+    fn whitespace_only_is_empty() {
+        assert_eq!(clean_jsx_text("\n   \n   \n"), "");
+        assert_eq!(clean_jsx_text("   "), "   ");
+    }
+
+    #[test]
+    fn crlf_is_normalized() {
+        assert_eq!(clean_jsx_text("a\r\n  b"), "a b");
+    }
+}

--- a/crates/vize_atelier_jsx/src/mode.rs
+++ b/crates/vize_atelier_jsx/src/mode.rs
@@ -1,0 +1,58 @@
+//! JSX output-mode selection.
+//!
+//! A JSX/TSX file compiles to either Vue VDOM or Vue Vapor output. The default
+//! is chosen by configuration (#1496); individual component functions can
+//! override it with a directive prologue, mirroring the `"use strict"` form:
+//!
+//! ```tsx
+//! const Fast = () => {
+//!   "use vue:vapor";
+//!   return <div/>;
+//! };
+//! ```
+
+/// The compilation target for a JSX/TSX component.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum JsxOutputMode {
+    /// Virtual DOM output (`"use vue:vdom"`).
+    Vdom,
+    /// Vapor output (`"use vue:vapor"`).
+    Vapor,
+}
+
+impl JsxOutputMode {
+    /// Resolve a component-function directive prologue string into a mode.
+    ///
+    /// Returns `None` for any directive that is not a Vize JSX-mode directive,
+    /// so unrelated prologues (e.g. `"use strict"`) are ignored.
+    pub fn from_directive(directive: &str) -> Option<Self> {
+        match directive {
+            "use vue:vapor" => Some(Self::Vapor),
+            "use vue:vdom" => Some(Self::Vdom),
+            _ => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn recognizes_mode_directives() {
+        assert_eq!(
+            JsxOutputMode::from_directive("use vue:vapor"),
+            Some(JsxOutputMode::Vapor)
+        );
+        assert_eq!(
+            JsxOutputMode::from_directive("use vue:vdom"),
+            Some(JsxOutputMode::Vdom)
+        );
+    }
+
+    #[test]
+    fn ignores_unrelated_directives() {
+        assert_eq!(JsxOutputMode::from_directive("use strict"), None);
+        assert_eq!(JsxOutputMode::from_directive("use vue:other"), None);
+    }
+}

--- a/crates/vize_atelier_jsx/src/parse.rs
+++ b/crates/vize_atelier_jsx/src/parse.rs
@@ -1,0 +1,120 @@
+//! Parsing `.jsx`/`.tsx` source into an OXC program.
+//!
+//! This is a thin wrapper over `oxc_parser` that selects the right
+//! [`SourceType`](oxc_span::SourceType) for the [`JsxLang`] and surfaces parse
+//! errors as Vize [`JsxDiagnostic`]s with byte ranges.
+
+use oxc_allocator::Allocator;
+use oxc_ast::ast::Program;
+use oxc_parser::Parser;
+
+use vize_carton::ToCompactString;
+
+use crate::diagnostics::JsxDiagnostic;
+use crate::lang::JsxLang;
+
+/// The result of parsing a JSX/TSX module.
+///
+/// The [`Program`] borrows the supplied [`Allocator`], so the allocator must
+/// outlive the parsed module. Callers typically lower the program into Vize IR
+/// (which copies out owned strings) before dropping the allocator.
+pub struct ParsedModule<'a> {
+    /// The parsed program. Empty body if parsing panicked.
+    pub program: Program<'a>,
+    /// Parse diagnostics, already mapped to Vize byte ranges.
+    pub diagnostics: Vec<JsxDiagnostic>,
+    /// Whether the parser bailed out unrecoverably.
+    pub panicked: bool,
+}
+
+impl<'a> ParsedModule<'a> {
+    /// Whether parsing produced any error-severity diagnostics.
+    pub fn has_errors(&self) -> bool {
+        self.panicked || self.diagnostics.iter().any(JsxDiagnostic::is_error)
+    }
+}
+
+/// Parse `source` as a JSX/TSX module using `lang` to select the dialect.
+pub fn parse_module<'a>(
+    allocator: &'a Allocator,
+    source: &'a str,
+    lang: JsxLang,
+) -> ParsedModule<'a> {
+    let ret = Parser::new(allocator, source, lang.source_type()).parse();
+    let source_len = source.len();
+    let diagnostics = ret
+        .errors
+        .iter()
+        .map(|error| oxc_error_to_diagnostic(error, source_len))
+        .collect();
+    ParsedModule {
+        program: ret.program,
+        diagnostics,
+        panicked: ret.panicked,
+    }
+}
+
+/// Convert an OXC diagnostic into a Vize [`JsxDiagnostic`] with a byte range.
+///
+/// Mirrors the primary-label extraction used by the maestro diagnostics
+/// collectors so JSX parse errors point at the same offsets the editor uses.
+fn oxc_error_to_diagnostic(
+    error: &oxc_diagnostics::OxcDiagnostic,
+    source_len: usize,
+) -> JsxDiagnostic {
+    let (start, end) = error
+        .labels
+        .as_ref()
+        .and_then(|labels| labels.iter().find(|label| label.primary()))
+        .or_else(|| error.labels.as_ref().and_then(|labels| labels.first()))
+        .map(|label| {
+            let start = label.offset().min(source_len);
+            let end = start
+                .saturating_add(label.len().max(1))
+                .min(source_len)
+                .max(start + 1);
+            (start as u32, end as u32)
+        })
+        .unwrap_or((0, source_len.max(1) as u32));
+    JsxDiagnostic::error(error.message.to_compact_string(), start, end)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_valid_jsx() {
+        let allocator = Allocator::default();
+        let parsed = parse_module(&allocator, "const a = <div/>;", JsxLang::Jsx);
+        assert!(!parsed.panicked);
+        assert!(!parsed.has_errors());
+        assert_eq!(parsed.program.body.len(), 1);
+    }
+
+    #[test]
+    fn parses_tsx_with_type_annotations() {
+        let allocator = Allocator::default();
+        let src = "const a = (x: number): JSX.Element => <p>{x}</p>;";
+        let parsed = parse_module(&allocator, src, JsxLang::Tsx);
+        assert!(!parsed.has_errors(), "{:?}", parsed.diagnostics);
+    }
+
+    #[test]
+    fn reports_syntax_error_with_range() {
+        let allocator = Allocator::default();
+        let parsed = parse_module(&allocator, "const a = <div>;", JsxLang::Jsx);
+        assert!(parsed.has_errors());
+        let diag = &parsed.diagnostics[0];
+        assert!(diag.end > diag.start);
+        assert!(diag.end <= "const a = <div>;".len() as u32);
+    }
+
+    #[test]
+    fn type_annotation_is_error_in_plain_jsx() {
+        // `.jsx` should not accept TS type annotations.
+        let allocator = Allocator::default();
+        let parsed = parse_module(&allocator, "const a = (x: number) => x;", JsxLang::Jsx);
+        assert!(parsed.has_errors());
+    }
+}

--- a/crates/vize_atelier_jsx/src/span.rs
+++ b/crates/vize_atelier_jsx/src/span.rs
@@ -1,0 +1,101 @@
+//! Mapping OXC byte spans to Vize [`SourceLocation`]s.
+//!
+//! The lowering layer must preserve enough source information for compiler
+//! diagnostics, the type checker, the LSP, and Patina fixes. OXC reports byte
+//! offsets only; Vize's [`SourceLocation`] additionally carries 1-indexed
+//! line/column positions (mirroring the template parser's convention) plus the
+//! original source slice. This module is the single home for that conversion.
+
+use oxc_span::Span;
+use vize_carton::line_index::LineIndex;
+use vize_relief::ast::core::{Position, SourceLocation};
+
+/// Converts OXC byte spans into Vize source locations against one source text.
+///
+/// Build it once per module and reuse it: the underlying [`LineIndex`] turns
+/// each position lookup into a binary search over line starts rather than a
+/// full scan of the source.
+pub struct SpanMapper<'s> {
+    source: &'s str,
+    line_index: LineIndex<'s>,
+}
+
+impl<'s> SpanMapper<'s> {
+    /// Build a span mapper for `source`.
+    pub fn new(source: &'s str) -> Self {
+        Self {
+            source,
+            line_index: LineIndex::new(source),
+        }
+    }
+
+    /// The source text this mapper indexes.
+    pub fn source(&self) -> &'s str {
+        self.source
+    }
+
+    /// Convert a byte offset to a 1-indexed [`Position`].
+    ///
+    /// [`LineIndex`] reports 0-indexed LSP coordinates (UTF-16 columns); we add
+    /// one to each axis so the resulting [`Position`] matches the 1-indexed
+    /// convention the rest of the relief AST uses.
+    pub fn position(&self, offset: u32) -> Position {
+        let (line, column) = self.line_index.line_col(offset as usize);
+        Position::new(offset, line + 1, column + 1)
+    }
+
+    /// The source slice covered by `span`, clamped to the source bounds.
+    pub fn slice(&self, span: Span) -> &'s str {
+        let start = (span.start as usize).min(self.source.len());
+        let end = (span.end as usize).min(self.source.len()).max(start);
+        &self.source[start..end]
+    }
+
+    /// Convert an OXC [`Span`] to a full [`SourceLocation`].
+    pub fn location(&self, span: Span) -> SourceLocation {
+        SourceLocation::new(
+            self.position(span.start),
+            self.position(span.end),
+            self.slice(span),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn position_is_one_indexed() {
+        let mapper = SpanMapper::new("ab\ncd");
+        // offset 0 -> line 1, col 1
+        let p = mapper.position(0);
+        assert_eq!((p.line, p.column), (1, 1));
+        // offset 3 is 'c' on the second line -> line 2, col 1
+        let p = mapper.position(3);
+        assert_eq!((p.line, p.column), (2, 1));
+    }
+
+    #[test]
+    fn slice_extracts_substring() {
+        let mapper = SpanMapper::new("<div>hi</div>");
+        let span = Span::new(5, 7);
+        assert_eq!(mapper.slice(span), "hi");
+    }
+
+    #[test]
+    fn slice_clamps_out_of_range() {
+        let mapper = SpanMapper::new("abc");
+        assert_eq!(mapper.slice(Span::new(2, 99)), "c");
+        assert_eq!(mapper.slice(Span::new(99, 99)), "");
+    }
+
+    #[test]
+    fn location_records_offsets_and_source() {
+        let mapper = SpanMapper::new("x = <a/>");
+        let loc = mapper.location(Span::new(4, 8));
+        assert_eq!(loc.start.offset, 4);
+        assert_eq!(loc.end.offset, 8);
+        assert_eq!(loc.source.as_str(), "<a/>");
+    }
+}

--- a/crates/vize_atelier_jsx/tests/analysis.rs
+++ b/crates/vize_atelier_jsx/tests/analysis.rs
@@ -1,0 +1,51 @@
+//! Croquis semantic analysis exposed alongside the lowered roots.
+
+mod common;
+
+use vize_atelier_jsx::{JsxLang, lower_source};
+use vize_carton::Bump;
+
+#[test]
+fn top_level_bindings_are_collected() {
+    let bump = Bump::new();
+    let out = lower_source(
+        &bump,
+        "const count = 1;\nconst App = () => <div>{count}</div>;",
+        JsxLang::Jsx,
+    );
+    assert!(!out.has_errors(), "{:?}", out.diagnostics);
+    let bindings = out.bindings();
+    assert!(bindings.contains("count"));
+    assert!(bindings.contains("App"));
+}
+
+#[test]
+fn ref_binding_is_recognized_as_reactive() {
+    let bump = Bump::new();
+    let out = lower_source(
+        &bump,
+        "import { ref } from 'vue';\nconst n = ref(0);\nconst C = () => <p>{n.value}</p>;",
+        JsxLang::Jsx,
+    );
+    assert!(!out.has_errors(), "{:?}", out.diagnostics);
+    assert!(out.bindings().is_ref("n"));
+}
+
+#[test]
+fn analysis_runs_on_tsx_modules() {
+    let bump = Bump::new();
+    let out = lower_source(
+        &bump,
+        "const label: string = 'x';\nconst C = (): JSX.Element => <span>{label}</span>;",
+        JsxLang::Tsx,
+    );
+    assert!(!out.has_errors(), "{:?}", out.diagnostics);
+    assert!(out.bindings().contains("label"));
+}
+
+#[test]
+fn undefined_binding_is_absent() {
+    let bump = Bump::new();
+    let out = lower_source(&bump, "const C = () => <div>{ghost}</div>;", JsxLang::Jsx);
+    assert!(!out.bindings().contains("ghost"));
+}

--- a/crates/vize_atelier_jsx/tests/attributes.rs
+++ b/crates/vize_atelier_jsx/tests/attributes.rs
@@ -1,0 +1,93 @@
+//! Lowering of JSX attributes into static attributes and `v-bind` directives.
+
+mod common;
+
+use common::{as_attribute, as_directive, lower_one, root_element, simple_content};
+use vize_carton::Bump;
+
+#[test]
+fn static_string_attribute() {
+    let bump = Bump::new();
+    let root = lower_one(&bump, "const a = <div class=\"box\"/>;");
+    let attr = as_attribute(&root_element(&root).props[0]);
+    assert_eq!(attr.name.as_str(), "class");
+    assert_eq!(attr.value.as_ref().unwrap().content.as_str(), "box");
+}
+
+#[test]
+fn boolean_attribute_has_no_value() {
+    let bump = Bump::new();
+    let root = lower_one(&bump, "const a = <input disabled/>;");
+    let attr = as_attribute(&root_element(&root).props[0]);
+    assert_eq!(attr.name.as_str(), "disabled");
+    assert!(attr.value.is_none());
+}
+
+#[test]
+fn dynamic_attribute_becomes_bind_directive() {
+    let bump = Bump::new();
+    let root = lower_one(&bump, "const a = <div class={cls}/>;");
+    let directive = as_directive(&root_element(&root).props[0]);
+    assert_eq!(directive.name, "bind");
+    assert_eq!(simple_content(directive.arg.as_ref().unwrap()), "class");
+    assert_eq!(simple_content(directive.exp.as_ref().unwrap()), "cls");
+}
+
+#[test]
+fn bind_argument_is_static_and_expression_is_dynamic() {
+    let bump = Bump::new();
+    let root = lower_one(&bump, "const a = <div id={x}/>;");
+    let directive = as_directive(&root_element(&root).props[0]);
+    assert!(common::is_static(directive.arg.as_ref().unwrap()));
+    assert!(!common::is_static(directive.exp.as_ref().unwrap()));
+}
+
+#[test]
+fn spread_attribute_becomes_argless_bind() {
+    let bump = Bump::new();
+    let root = lower_one(&bump, "const a = <div {...props}/>;");
+    let directive = as_directive(&root_element(&root).props[0]);
+    assert_eq!(directive.name, "bind");
+    assert!(directive.arg.is_none());
+    assert_eq!(simple_content(directive.exp.as_ref().unwrap()), "props");
+}
+
+#[test]
+fn namespaced_attribute_name_is_joined() {
+    let bump = Bump::new();
+    let root = lower_one(&bump, "const a = <use xlink:href=\"#id\"/>;");
+    let attr = as_attribute(&root_element(&root).props[0]);
+    assert_eq!(attr.name.as_str(), "xlink:href");
+    assert_eq!(attr.value.as_ref().unwrap().content.as_str(), "#id");
+}
+
+#[test]
+fn event_handler_is_a_dynamic_bind() {
+    let bump = Bump::new();
+    let root = lower_one(&bump, "const a = <button onClick={handler}/>;");
+    let directive = as_directive(&root_element(&root).props[0]);
+    assert_eq!(directive.name, "bind");
+    assert_eq!(simple_content(directive.arg.as_ref().unwrap()), "onClick");
+    assert_eq!(simple_content(directive.exp.as_ref().unwrap()), "handler");
+}
+
+#[test]
+fn multiple_attributes_preserve_order() {
+    let bump = Bump::new();
+    let root = lower_one(&bump, "const a = <div id=\"x\" class={c} hidden/>;");
+    let props = &root_element(&root).props;
+    assert_eq!(props.len(), 3);
+    assert_eq!(as_attribute(&props[0]).name.as_str(), "id");
+    assert_eq!(as_directive(&props[1]).name, "bind");
+    assert_eq!(as_attribute(&props[2]).name.as_str(), "hidden");
+}
+
+#[test]
+fn jsx_element_as_attribute_value_is_dynamic_bind() {
+    let bump = Bump::new();
+    let root = lower_one(&bump, "const a = <Comp icon={<Icon/>}/>;");
+    let directive = as_directive(&root_element(&root).props[0]);
+    assert_eq!(directive.name, "bind");
+    assert_eq!(simple_content(directive.arg.as_ref().unwrap()), "icon");
+    assert_eq!(simple_content(directive.exp.as_ref().unwrap()), "<Icon/>");
+}

--- a/crates/vize_atelier_jsx/tests/children.rs
+++ b/crates/vize_atelier_jsx/tests/children.rs
@@ -1,0 +1,98 @@
+//! Lowering of JSX children: text cleaning, interpolation, mixed content.
+
+mod common;
+
+use common::{as_text, lower_one, root_element, simple_content};
+use vize_carton::Bump;
+use vize_relief::ast::TemplateChildNode;
+
+#[test]
+fn plain_text_child_is_lowered() {
+    let bump = Bump::new();
+    let root = lower_one(&bump, "const a = <p>Hello</p>;");
+    let p = root_element(&root);
+    assert_eq!(p.children.len(), 1);
+    assert_eq!(as_text(&p.children[0]).content.as_str(), "Hello");
+}
+
+#[test]
+fn whitespace_only_children_are_dropped() {
+    let bump = Bump::new();
+    let root = lower_one(&bump, "const a = <ul>\n   <li/>\n</ul>;");
+    let ul = root_element(&root);
+    // The surrounding newlines/indentation collapse to nothing, leaving one li.
+    assert_eq!(ul.children.len(), 1);
+}
+
+#[test]
+fn expression_child_becomes_interpolation() {
+    let bump = Bump::new();
+    let root = lower_one(&bump, "const a = <p>{count}</p>;");
+    let p = root_element(&root);
+    match &p.children[0] {
+        TemplateChildNode::Interpolation(interp) => {
+            assert_eq!(simple_content(&interp.content), "count");
+        }
+        other => panic!("expected interpolation, got {:?}", other.node_type()),
+    }
+}
+
+#[test]
+fn complex_expression_child_keeps_source_text() {
+    let bump = Bump::new();
+    let root = lower_one(&bump, "const a = <p>{a + b * c}</p>;");
+    let p = root_element(&root);
+    match &p.children[0] {
+        TemplateChildNode::Interpolation(interp) => {
+            assert_eq!(simple_content(&interp.content), "a + b * c");
+        }
+        other => panic!("expected interpolation, got {:?}", other.node_type()),
+    }
+}
+
+#[test]
+fn string_literal_container_becomes_text() {
+    let bump = Bump::new();
+    let root = lower_one(&bump, "const a = <p>{'literal'}</p>;");
+    let p = root_element(&root);
+    assert_eq!(as_text(&p.children[0]).content.as_str(), "literal");
+}
+
+#[test]
+fn explicit_space_idiom_is_text() {
+    let bump = Bump::new();
+    let root = lower_one(&bump, "const a = <p>a{' '}b</p>;");
+    let p = root_element(&root);
+    let texts: Vec<&str> = p
+        .children
+        .iter()
+        .filter_map(|c| match c {
+            TemplateChildNode::Text(t) => Some(t.content.as_str()),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(texts, vec!["a", " ", "b"]);
+}
+
+#[test]
+fn empty_expression_container_is_dropped() {
+    let bump = Bump::new();
+    let root = lower_one(&bump, "const a = <p>{/* a comment */}</p>;");
+    let p = root_element(&root);
+    assert_eq!(p.children.len(), 0);
+}
+
+#[test]
+fn mixed_text_and_expression_children() {
+    let bump = Bump::new();
+    let root = lower_one(&bump, "const a = <p>Hi {name}!</p>;");
+    let p = root_element(&root);
+    // "Hi " text, {name} interpolation, "!" text.
+    assert_eq!(p.children.len(), 3);
+    assert_eq!(as_text(&p.children[0]).content.as_str(), "Hi ");
+    assert!(matches!(
+        &p.children[1],
+        TemplateChildNode::Interpolation(_)
+    ));
+    assert_eq!(as_text(&p.children[2]).content.as_str(), "!");
+}

--- a/crates/vize_atelier_jsx/tests/common/mod.rs
+++ b/crates/vize_atelier_jsx/tests/common/mod.rs
@@ -1,0 +1,112 @@
+//! Shared helpers for the JSX lowering integration tests.
+//!
+//! Each integration test binary pulls in this module but uses only a subset of
+//! the helpers, so unused-helper warnings are expected and silenced.
+#![allow(dead_code)]
+
+use vize_atelier_jsx::{JsxLang, LowerOutput, lower_source};
+use vize_carton::Bump;
+use vize_relief::ast::{
+    AttributeNode, DirectiveNode, ElementNode, ExpressionNode, PropNode, TemplateChildNode,
+    TextNode,
+};
+
+/// Lower JSX source, asserting a single error-free render root, and return it.
+pub fn lower_one<'a>(bump: &'a Bump, source: &str) -> vize_relief::ast::RootNode<'a> {
+    lower_one_in(bump, source, JsxLang::Jsx)
+}
+
+/// Lower TSX source, asserting a single error-free render root, and return it.
+pub fn lower_one_tsx<'a>(bump: &'a Bump, source: &str) -> vize_relief::ast::RootNode<'a> {
+    lower_one_in(bump, source, JsxLang::Tsx)
+}
+
+fn lower_one_in<'a>(bump: &'a Bump, source: &str, lang: JsxLang) -> vize_relief::ast::RootNode<'a> {
+    lower_single(bump, source, lang).root
+}
+
+/// Lower source, asserting a single error-free render root, returning the full
+/// [`LoweredRoot`] (including mode/name metadata).
+pub fn lower_single<'a>(
+    bump: &'a Bump,
+    source: &str,
+    lang: JsxLang,
+) -> vize_atelier_jsx::LoweredRoot<'a> {
+    let out = lower_source(bump, source, lang);
+    assert!(
+        !out.has_errors(),
+        "unexpected diagnostics: {:?}",
+        out.diagnostics
+    );
+    assert_eq!(out.roots.len(), 1, "expected exactly one render root");
+    out.roots.into_iter().next().unwrap()
+}
+
+/// Lower JSX source and return the full output (roots + diagnostics).
+pub fn lower_all<'a>(bump: &'a Bump, source: &str) -> LowerOutput<'a> {
+    lower_source(bump, source, JsxLang::Jsx)
+}
+
+/// Borrow a child as an element, panicking otherwise.
+pub fn as_element<'a>(child: &'a TemplateChildNode<'a>) -> &'a ElementNode<'a> {
+    match child {
+        TemplateChildNode::Element(element) => element,
+        other => panic!("expected element child, got {:?}", other.node_type()),
+    }
+}
+
+/// Borrow a child as a text node, panicking otherwise.
+pub fn as_text<'a>(child: &'a TemplateChildNode<'a>) -> &'a TextNode {
+    match child {
+        TemplateChildNode::Text(text) => text,
+        other => panic!("expected text child, got {:?}", other.node_type()),
+    }
+}
+
+/// The first child of a root, as an element.
+pub fn root_element<'a>(root: &'a vize_relief::ast::RootNode<'a>) -> &'a ElementNode<'a> {
+    as_element(&root.children[0])
+}
+
+/// Borrow a prop as a static attribute.
+pub fn as_attribute<'a>(prop: &'a PropNode<'a>) -> &'a AttributeNode {
+    match prop {
+        PropNode::Attribute(attr) => attr,
+        PropNode::Directive(dir) => panic!("expected attribute, got directive {:?}", dir.name),
+    }
+}
+
+/// Borrow a prop as a directive.
+pub fn as_directive<'a>(prop: &'a PropNode<'a>) -> &'a DirectiveNode<'a> {
+    match prop {
+        PropNode::Directive(dir) => dir,
+        PropNode::Attribute(attr) => panic!("expected directive, got attribute {:?}", attr.name),
+    }
+}
+
+/// The textual content of a simple expression.
+pub fn simple_content<'a>(expr: &'a ExpressionNode<'a>) -> &'a str {
+    match expr {
+        ExpressionNode::Simple(simple) => simple.content.as_str(),
+        ExpressionNode::Compound(_) => panic!("expected simple expression, got compound"),
+    }
+}
+
+/// Whether a simple expression is marked static.
+pub fn is_static(expr: &ExpressionNode<'_>) -> bool {
+    match expr {
+        ExpressionNode::Simple(simple) => simple.is_static,
+        ExpressionNode::Compound(_) => panic!("expected simple expression, got compound"),
+    }
+}
+
+/// Find the first directive on an element with the given normalized name.
+pub fn find_directive<'a>(
+    element: &'a ElementNode<'a>,
+    name: &str,
+) -> Option<&'a DirectiveNode<'a>> {
+    element.props.iter().find_map(|prop| match prop {
+        PropNode::Directive(dir) if dir.name == name => Some(&**dir),
+        _ => None,
+    })
+}

--- a/crates/vize_atelier_jsx/tests/components.rs
+++ b/crates/vize_atelier_jsx/tests/components.rs
@@ -1,0 +1,90 @@
+//! Lowering of components, multiple roots, and slot-shaped children.
+
+mod common;
+
+use common::{as_element, lower_all, lower_one, root_element, simple_content};
+use vize_carton::Bump;
+use vize_relief::ast::TemplateChildNode;
+use vize_relief::ast::core::ElementType;
+
+#[test]
+fn multiple_top_level_roots_are_each_lowered() {
+    let bump = Bump::new();
+    let out = lower_all(&bump, "const A = () => <a/>;\nconst B = () => <b/>;");
+    assert!(!out.has_errors(), "{:?}", out.diagnostics);
+    assert_eq!(out.roots.len(), 2);
+    assert_eq!(root_element(&out.roots[0].root).tag.as_str(), "a");
+    assert_eq!(root_element(&out.roots[1].root).tag.as_str(), "b");
+}
+
+#[test]
+fn component_with_element_children() {
+    let bump = Bump::new();
+    let root = lower_one(&bump, "const a = <Card><h1>Title</h1></Card>;");
+    let card = root_element(&root);
+    assert_eq!(card.tag.as_str(), "Card");
+    assert_eq!(card.tag_type, ElementType::Component);
+    assert_eq!(as_element(&card.children[0]).tag.as_str(), "h1");
+}
+
+#[test]
+fn object_slot_children_become_interpolation() {
+    let bump = Bump::new();
+    // babel-plugin-jsx slot object syntax: the single object-expression child
+    // is preserved as an interpolation expression for the backends to interpret.
+    let root = lower_one(&bump, "const a = <Comp>{{ default: () => <p/> }}</Comp>;");
+    let comp = root_element(&root);
+    match &comp.children[0] {
+        TemplateChildNode::Interpolation(interp) => {
+            assert!(simple_content(&interp.content).contains("default"));
+        }
+        other => panic!(
+            "expected interpolation slot object, got {:?}",
+            other.node_type()
+        ),
+    }
+}
+
+#[test]
+fn render_prop_child_is_interpolation() {
+    let bump = Bump::new();
+    let root = lower_one(&bump, "const a = <List>{(item) => <li/>}</List>;");
+    let list = root_element(&root);
+    assert!(matches!(
+        &list.children[0],
+        TemplateChildNode::Interpolation(_)
+    ));
+}
+
+#[test]
+fn nested_components_and_intrinsics_mix() {
+    let bump = Bump::new();
+    let root = lower_one(
+        &bump,
+        "const a = <Layout><Header/><main><Content/></main></Layout>;",
+    );
+    let layout = root_element(&root);
+    assert_eq!(layout.children.len(), 2);
+    assert_eq!(
+        as_element(&layout.children[0]).tag_type,
+        ElementType::Component
+    );
+    let main = as_element(&layout.children[1]);
+    assert_eq!(main.tag_type, ElementType::Element);
+    assert_eq!(as_element(&main.children[0]).tag.as_str(), "Content");
+}
+
+#[test]
+fn jsx_in_return_statement_is_found() {
+    let bump = Bump::new();
+    let out = lower_all(&bump, "function App() {\n  return <div>ok</div>;\n}");
+    assert_eq!(out.roots.len(), 1);
+    assert_eq!(root_element(&out.roots[0].root).tag.as_str(), "div");
+}
+
+#[test]
+fn jsx_in_ternary_finds_both_branches() {
+    let bump = Bump::new();
+    let out = lower_all(&bump, "const a = ok ? <yes/> : <no/>;");
+    assert_eq!(out.roots.len(), 2);
+}

--- a/crates/vize_atelier_jsx/tests/diagnostics.rs
+++ b/crates/vize_atelier_jsx/tests/diagnostics.rs
@@ -1,0 +1,75 @@
+//! Parse/lowering diagnostics and span mapping back to source.
+
+mod common;
+
+use common::{lower_all, root_element};
+use vize_atelier_jsx::{JsxLang, lower_source};
+use vize_carton::Bump;
+
+#[test]
+fn valid_source_has_no_diagnostics() {
+    let bump = Bump::new();
+    let out = lower_all(&bump, "const a = <div/>;");
+    assert!(out.diagnostics.is_empty());
+    assert!(!out.has_errors());
+}
+
+#[test]
+fn syntax_error_is_reported_with_a_range() {
+    let bump = Bump::new();
+    let src = "const a = <div>;";
+    let out = lower_source(&bump, src, JsxLang::Jsx);
+    assert!(out.has_errors());
+    let diag = &out.diagnostics[0];
+    assert!(diag.end > diag.start);
+    assert!(diag.end as usize <= src.len());
+}
+
+#[test]
+fn diagnostic_range_maps_into_source() {
+    let bump = Bump::new();
+    let src = "const a = <div>{</div>;";
+    let out = lower_source(&bump, src, JsxLang::Jsx);
+    assert!(out.has_errors());
+    for diag in &out.diagnostics {
+        // Every diagnostic range must be sliceable from the original source.
+        let _ = &src[diag.start as usize..diag.end as usize];
+    }
+}
+
+#[test]
+fn element_location_round_trips_through_source() {
+    let bump = Bump::new();
+    let src = "const App = () => <button class=\"x\">Go</button>;";
+    let out = lower_all(&bump, src);
+    let element = root_element(&out.roots[0].root);
+    let start = element.loc.start.offset as usize;
+    let end = element.loc.end.offset as usize;
+    assert_eq!(&src[start..end], "<button class=\"x\">Go</button>");
+}
+
+#[test]
+fn attribute_value_location_round_trips() {
+    let bump = Bump::new();
+    let src = "const a = <div title=\"hello\"/>;";
+    let out = lower_all(&bump, src);
+    let attr = match &root_element(&out.roots[0].root).props[0] {
+        vize_relief::ast::PropNode::Attribute(a) => a,
+        _ => panic!("expected attribute"),
+    };
+    let value = attr.value.as_ref().unwrap();
+    let start = value.loc.start.offset as usize;
+    let end = value.loc.end.offset as usize;
+    assert_eq!(&src[start..end], "\"hello\"");
+}
+
+#[test]
+fn line_and_column_are_one_indexed() {
+    let bump = Bump::new();
+    // `<div/>` begins at column 1 of line 2.
+    let src = "x;\n<div/>;";
+    let out = lower_all(&bump, src);
+    let loc = &root_element(&out.roots[0].root).loc;
+    assert_eq!(loc.start.line, 2);
+    assert_eq!(loc.start.column, 1);
+}

--- a/crates/vize_atelier_jsx/tests/directives.rs
+++ b/crates/vize_atelier_jsx/tests/directives.rs
@@ -1,0 +1,81 @@
+//! Lowering of Vue directive (`v-x`) attribute syntax in JSX.
+
+mod common;
+
+use common::{find_directive, lower_one, root_element, simple_content};
+use vize_carton::Bump;
+
+#[test]
+fn v_model_directive() {
+    let bump = Bump::new();
+    let root = lower_one(&bump, "const a = <input v-model={value}/>;");
+    let element = root_element(&root);
+    let directive = find_directive(element, "model").expect("v-model directive");
+    assert!(directive.arg.is_none());
+    assert_eq!(simple_content(directive.exp.as_ref().unwrap()), "value");
+}
+
+#[test]
+fn v_show_directive() {
+    let bump = Bump::new();
+    let root = lower_one(&bump, "const a = <div v-show={visible}/>;");
+    let directive = find_directive(root_element(&root), "show").expect("v-show directive");
+    assert_eq!(simple_content(directive.exp.as_ref().unwrap()), "visible");
+}
+
+#[test]
+fn v_html_directive() {
+    let bump = Bump::new();
+    let root = lower_one(&bump, "const a = <div v-html={raw}/>;");
+    let directive = find_directive(root_element(&root), "html").expect("v-html directive");
+    assert_eq!(simple_content(directive.exp.as_ref().unwrap()), "raw");
+}
+
+#[test]
+fn namespaced_v_on_directive_has_argument() {
+    let bump = Bump::new();
+    let root = lower_one(&bump, "const a = <button v-on:click={onClick}/>;");
+    let directive = find_directive(root_element(&root), "on").expect("v-on directive");
+    assert_eq!(simple_content(directive.arg.as_ref().unwrap()), "click");
+    assert_eq!(simple_content(directive.exp.as_ref().unwrap()), "onClick");
+}
+
+#[test]
+fn custom_directive_with_argument() {
+    let bump = Bump::new();
+    let root = lower_one(&bump, "const a = <div v-focus:lazy={opts}/>;");
+    let directive = find_directive(root_element(&root), "focus").expect("v-focus directive");
+    assert_eq!(simple_content(directive.arg.as_ref().unwrap()), "lazy");
+    assert_eq!(simple_content(directive.exp.as_ref().unwrap()), "opts");
+}
+
+#[test]
+fn directive_without_value_has_no_expression() {
+    let bump = Bump::new();
+    let root = lower_one(&bump, "const a = <div v-focus/>;");
+    let directive = find_directive(root_element(&root), "focus").expect("v-focus directive");
+    assert!(directive.exp.is_none());
+    assert!(directive.arg.is_none());
+}
+
+#[test]
+fn directive_with_string_value_is_static() {
+    let bump = Bump::new();
+    let root = lower_one(&bump, "const a = <div v-pre=\"keep\"/>;");
+    let directive = find_directive(root_element(&root), "pre").expect("v-pre directive");
+    assert!(common::is_static(directive.exp.as_ref().unwrap()));
+    assert_eq!(simple_content(directive.exp.as_ref().unwrap()), "keep");
+}
+
+#[test]
+fn directive_and_plain_attributes_coexist() {
+    let bump = Bump::new();
+    let root = lower_one(&bump, "const a = <input class=\"f\" v-model={v}/>;");
+    let element = root_element(&root);
+    assert!(find_directive(element, "model").is_some());
+    let has_class = element.props.iter().any(|p| match p {
+        vize_relief::ast::PropNode::Attribute(a) => a.name.as_str() == "class",
+        _ => false,
+    });
+    assert!(has_class);
+}

--- a/crates/vize_atelier_jsx/tests/elements.rs
+++ b/crates/vize_atelier_jsx/tests/elements.rs
@@ -1,0 +1,107 @@
+//! Lowering of JSX elements: tags, kinds, nesting, self-closing.
+
+mod common;
+
+use common::{as_element, lower_one, root_element};
+use vize_carton::Bump;
+use vize_relief::ast::core::ElementType;
+
+#[test]
+fn lowers_a_single_intrinsic_element() {
+    let bump = Bump::new();
+    let root = lower_one(&bump, "const a = <div></div>;");
+    let element = root_element(&root);
+    assert_eq!(element.tag.as_str(), "div");
+    assert_eq!(element.tag_type, ElementType::Element);
+}
+
+#[test]
+fn self_closing_element_is_flagged() {
+    let bump = Bump::new();
+    let root = lower_one(&bump, "const a = <img/>;");
+    let element = root_element(&root);
+    assert_eq!(element.tag.as_str(), "img");
+    assert!(element.is_self_closing);
+}
+
+#[test]
+fn element_with_explicit_close_is_not_self_closing() {
+    let bump = Bump::new();
+    let root = lower_one(&bump, "const a = <div></div>;");
+    assert!(!root_element(&root).is_self_closing);
+}
+
+#[test]
+fn capitalized_tag_is_a_component() {
+    let bump = Bump::new();
+    let root = lower_one(&bump, "const a = <MyComp/>;");
+    let element = root_element(&root);
+    assert_eq!(element.tag.as_str(), "MyComp");
+    assert_eq!(element.tag_type, ElementType::Component);
+}
+
+#[test]
+fn member_expression_tag_keeps_dotted_path() {
+    let bump = Bump::new();
+    let root = lower_one(&bump, "const a = <Foo.Bar.Baz/>;");
+    let element = root_element(&root);
+    assert_eq!(element.tag.as_str(), "Foo.Bar.Baz");
+    assert_eq!(element.tag_type, ElementType::Component);
+}
+
+#[test]
+fn this_member_tag_is_a_component() {
+    let bump = Bump::new();
+    let root = lower_one(&bump, "const a = <this.Dynamic/>;");
+    let element = root_element(&root);
+    assert_eq!(element.tag.as_str(), "this.Dynamic");
+    assert_eq!(element.tag_type, ElementType::Component);
+}
+
+#[test]
+fn nested_elements_are_lowered_recursively() {
+    let bump = Bump::new();
+    let root = lower_one(&bump, "const a = <ul><li></li><li></li></ul>;");
+    let ul = root_element(&root);
+    assert_eq!(ul.tag.as_str(), "ul");
+    assert_eq!(ul.children.len(), 2);
+    for child in &ul.children {
+        assert_eq!(as_element(child).tag.as_str(), "li");
+    }
+}
+
+#[test]
+fn deeply_nested_tree_preserves_structure() {
+    let bump = Bump::new();
+    let root = lower_one(
+        &bump,
+        "const a = <div><section><p><span/></p></section></div>;",
+    );
+    let div = root_element(&root);
+    let section = as_element(&div.children[0]);
+    let p = as_element(&section.children[0]);
+    let span = as_element(&p.children[0]);
+    assert_eq!(span.tag.as_str(), "span");
+    assert!(span.is_self_closing);
+}
+
+#[test]
+fn namespaced_element_name_is_preserved() {
+    let bump = Bump::new();
+    let root = lower_one(&bump, "const a = <svg:circle/>;");
+    let element = root_element(&root);
+    assert_eq!(element.tag.as_str(), "svg:circle");
+    // `circle` starts lowercase -> intrinsic.
+    assert_eq!(element.tag_type, ElementType::Element);
+}
+
+#[test]
+fn root_location_points_at_the_element() {
+    let bump = Bump::new();
+    let src = "const a = <div></div>;";
+    let root = lower_one(&bump, src);
+    let element = root_element(&root);
+    let start = element.loc.start.offset as usize;
+    let end = element.loc.end.offset as usize;
+    assert_eq!(&src[start..end], "<div></div>");
+}

--- a/crates/vize_atelier_jsx/tests/fragments.rs
+++ b/crates/vize_atelier_jsx/tests/fragments.rs
@@ -1,0 +1,43 @@
+//! Lowering of JSX fragments (`<>...</>`).
+
+mod common;
+
+use common::{as_element, as_text, lower_one, root_element};
+use vize_carton::Bump;
+use vize_relief::ast::core::ElementType;
+
+#[test]
+fn top_level_fragment_lifts_children_to_root() {
+    let bump = Bump::new();
+    let root = lower_one(&bump, "const a = <><span/><b/></>;");
+    assert_eq!(root.children.len(), 2);
+    assert_eq!(as_element(&root.children[0]).tag.as_str(), "span");
+    assert_eq!(as_element(&root.children[1]).tag.as_str(), "b");
+}
+
+#[test]
+fn fragment_with_text_and_elements() {
+    let bump = Bump::new();
+    let root = lower_one(&bump, "const a = <>hi<b/></>;");
+    assert_eq!(root.children.len(), 2);
+    assert_eq!(as_text(&root.children[0]).content.as_str(), "hi");
+    assert_eq!(as_element(&root.children[1]).tag.as_str(), "b");
+}
+
+#[test]
+fn nested_fragment_becomes_fragment_component() {
+    let bump = Bump::new();
+    let root = lower_one(&bump, "const a = <div><><p/></></div>;");
+    let div = root_element(&root);
+    let fragment = as_element(&div.children[0]);
+    assert_eq!(fragment.tag.as_str(), "Fragment");
+    assert_eq!(fragment.tag_type, ElementType::Component);
+    assert_eq!(as_element(&fragment.children[0]).tag.as_str(), "p");
+}
+
+#[test]
+fn empty_fragment_has_no_children() {
+    let bump = Bump::new();
+    let root = lower_one(&bump, "const a = <></>;");
+    assert_eq!(root.children.len(), 0);
+}

--- a/crates/vize_atelier_jsx/tests/modes.rs
+++ b/crates/vize_atelier_jsx/tests/modes.rs
@@ -1,0 +1,92 @@
+//! Component-boundary detection: output-mode directives and component names.
+
+mod common;
+
+use common::lower_single;
+use vize_atelier_jsx::{JsxLang, JsxOutputMode, lower_source};
+use vize_carton::Bump;
+
+fn jsx<'a>(bump: &'a Bump, src: &str) -> vize_atelier_jsx::LoweredRoot<'a> {
+    lower_single(bump, src, JsxLang::Jsx)
+}
+
+#[test]
+fn no_directive_means_default_mode() {
+    let bump = Bump::new();
+    let lowered = jsx(&bump, "const App = () => <div/>;");
+    assert_eq!(lowered.mode, None);
+}
+
+#[test]
+fn use_vue_vapor_prologue_selects_vapor() {
+    let bump = Bump::new();
+    let lowered = jsx(
+        &bump,
+        "const Fast = () => { \"use vue:vapor\"; return <div/>; };",
+    );
+    assert_eq!(lowered.mode, Some(JsxOutputMode::Vapor));
+}
+
+#[test]
+fn use_vue_vdom_prologue_selects_vdom() {
+    let bump = Bump::new();
+    let lowered = jsx(
+        &bump,
+        "function Slow() { \"use vue:vdom\"; return <div/>; }",
+    );
+    assert_eq!(lowered.mode, Some(JsxOutputMode::Vdom));
+}
+
+#[test]
+fn unrelated_prologue_is_ignored() {
+    let bump = Bump::new();
+    let lowered = jsx(
+        &bump,
+        "const App = () => { \"use strict\"; return <div/>; };",
+    );
+    assert_eq!(lowered.mode, None);
+}
+
+#[test]
+fn arrow_component_name_is_resolved() {
+    let bump = Bump::new();
+    let lowered = jsx(&bump, "const MyButton = () => <button/>;");
+    assert_eq!(lowered.component_name.as_deref(), Some("MyButton"));
+}
+
+#[test]
+fn function_declaration_name_is_resolved() {
+    let bump = Bump::new();
+    let lowered = jsx(&bump, "function Card() { return <div/>; }");
+    assert_eq!(lowered.component_name.as_deref(), Some("Card"));
+}
+
+#[test]
+fn nested_function_uses_innermost_directive() {
+    let bump = Bump::new();
+    // Outer is vdom, inner arrow overrides to vapor for its own JSX.
+    let src = "function Outer() {\n  \"use vue:vdom\";\n  const Inner = () => { \"use vue:vapor\"; return <span/>; };\n  return Inner;\n}";
+    let lowered = jsx(&bump, src);
+    assert_eq!(lowered.mode, Some(JsxOutputMode::Vapor));
+    assert_eq!(lowered.component_name.as_deref(), Some("Inner"));
+}
+
+#[test]
+fn directive_modes_apply_per_component_in_a_module() {
+    let bump = Bump::new();
+    let src = "const A = () => { \"use vue:vapor\"; return <a/>; };\nconst B = () => <b/>;";
+    let out = lower_source(&bump, src, JsxLang::Jsx);
+    assert_eq!(out.roots.len(), 2);
+    assert_eq!(out.roots[0].mode, Some(JsxOutputMode::Vapor));
+    assert_eq!(out.roots[0].component_name.as_deref(), Some("A"));
+    assert_eq!(out.roots[1].mode, None);
+    assert_eq!(out.roots[1].component_name.as_deref(), Some("B"));
+}
+
+#[test]
+fn jsx_outside_any_function_has_no_component_name() {
+    let bump = Bump::new();
+    let lowered = jsx(&bump, "const node = <div/>;");
+    assert_eq!(lowered.component_name, None);
+    assert_eq!(lowered.mode, None);
+}

--- a/crates/vize_atelier_jsx/tests/tsx.rs
+++ b/crates/vize_atelier_jsx/tests/tsx.rs
@@ -1,0 +1,62 @@
+//! Lowering of TSX-specific syntax (type annotations, generics, casts).
+
+mod common;
+
+use common::{lower_one_tsx, root_element, simple_content};
+use vize_atelier_jsx::{JsxLang, lower_source};
+use vize_carton::Bump;
+use vize_relief::ast::TemplateChildNode;
+use vize_relief::ast::core::ElementType;
+
+#[test]
+fn typed_arrow_component_lowers() {
+    let bump = Bump::new();
+    let root = lower_one_tsx(
+        &bump,
+        "const App = (props: { id: number }): JSX.Element => <div id={props.id}/>;",
+    );
+    let element = root_element(&root);
+    assert_eq!(element.tag.as_str(), "div");
+}
+
+#[test]
+fn generic_component_call_is_a_component() {
+    let bump = Bump::new();
+    let root = lower_one_tsx(&bump, "const a = <List<number> items={xs}/>;");
+    let element = root_element(&root);
+    assert_eq!(element.tag.as_str(), "List");
+    assert_eq!(element.tag_type, ElementType::Component);
+}
+
+#[test]
+fn as_cast_inside_interpolation_keeps_source() {
+    let bump = Bump::new();
+    let root = lower_one_tsx(&bump, "const a = <p>{(x as string)}</p>;");
+    let p = root_element(&root);
+    match &p.children[0] {
+        TemplateChildNode::Interpolation(interp) => {
+            assert_eq!(simple_content(&interp.content), "(x as string)");
+        }
+        other => panic!("expected interpolation, got {:?}", other.node_type()),
+    }
+}
+
+#[test]
+fn non_null_assertion_in_attribute_binding() {
+    let bump = Bump::new();
+    let root = lower_one_tsx(&bump, "const a = <div ref={el!}/>;");
+    let directive = common::as_directive(&root_element(&root).props[0]);
+    assert_eq!(simple_content(directive.exp.as_ref().unwrap()), "el!");
+}
+
+#[test]
+fn tsx_type_annotation_rejected_as_plain_jsx() {
+    // The same source is a hard error when parsed as plain `.jsx`.
+    let bump = Bump::new();
+    let out = lower_source(
+        &bump,
+        "const App = (props: { id: number }) => <div/>;",
+        JsxLang::Jsx,
+    );
+    assert!(out.has_errors());
+}

--- a/tools/moon/scripts/publish_crates.mbtx
+++ b/tools/moon/scripts/publish_crates.mbtx
@@ -31,6 +31,7 @@ let published_crates : Array[String] = [
   "vize_croquis_cf",
   "vize_atelier_core",
   "vize_atelier_dom",
+  "vize_atelier_jsx",
   "vize_atelier_vapor",
   "vize_atelier_ssr",
   "vize_atelier_sfc",


### PR DESCRIPTION
Part of #1489. Closes #1492.

## Goal

Add a shared JSX/TSX lowering layer (`vize_atelier_jsx`) that turns OXC-parsed JSX into Vize compiler data structures **once**, then feeds the existing semantic analysis and (later) the VDOM/Vapor backends — no standalone Babel-style pipeline.

## Design

Both DOM and Vapor backends already consume the same `vize_relief::ast::RootNode` IR. So this layer's only job is: parse `.jsx`/`.tsx` with OXC → walk the JSX AST → build that same `RootNode` IR. Existing transform/codegen is reused downstream. A separate OXC allocator (parsing) and Vize `Bump` (IR) are used; all strings are copied into `CompactString`, so the lowered IR never borrows the OXC arena and outlives parsing.

## What's included

- **`parse`** — OXC wrapper selecting the jsx/tsx `SourceType`; parse errors mapped to Vize byte ranges
- **`span`** — OXC span → Vize `SourceLocation` (1-indexed line/col + source slice)
- **`lower/*`** — elements, fragments, text (Babel JSX whitespace rules), interpolation, string-literal/explicit-space text, attributes (static / boolean / `v-bind`), spreads, `v-x` directive syntax with args, component-vs-intrinsic detection, member-expression & namespaced names
- **`finder`** — outermost JSX roots via a `Visit` walk; per-component `"use vue:vapor"` / `"use vue:vdom"` directive prologues; component-name resolution
- **`analyze`** — reuses Croquis' parse-free entry point on the JSX program to expose binding metadata / scope / reactivity **without a second parse**
- **`mode`** — `JsxOutputMode` (Vdom/Vapor) directive resolution

Backend-specific output is intentionally kept out of this layer; VDOM (#1493) and Vapor (#1494) will consume the same lowered representation.

## Acceptance criteria

- [x] Basic JSX/TSX inputs parsed, analyzed with Croquis, and lowered without invoking VDOM/Vapor codegen
- [x] Lowering tests cover elements, fragments, components, dynamic expressions, spreads, slot-shaped children, directives, TSX syntax, and component-mode directives
- [x] Diagnostics use Vize spans and map back to original JSX/TSX source
- [x] Lowering API exposes Croquis binding metadata to downstream callers (`LowerOutput::bindings()` / `.analysis`)
- [x] Component boundaries / directive prologues detected through the parsed AST, not text scanning

## Validation

- `cargo test -p vize_atelier_jsx` — 91 tests pass (unit + doctest + 10 integration suites)
- `cargo clippy -p vize_atelier_jsx --all-targets` — clean under `-D warnings` (respects the workspace `String`/`HashMap` disallow lints)
- `cargo fmt -p vize_atelier_jsx -- --check` — clean
- builds with default **and** `legacy` features; `cargo build --workspace` OK
- every source file stays under ~180 lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1507"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->