### PR TITLE
feat(atelier-jsx): mode-aware compile_jsx entry point (#1496)

### DIFF
--- a/crates/vize_atelier_jsx/src/compile.rs
+++ b/crates/vize_atelier_jsx/src/compile.rs
@@ -1,0 +1,131 @@
+//! Mode-aware JSX/TSX compilation (#1496).
+//!
+//! Selects the output backend (VDOM or Vapor) per component: a global default
+//! mode from [`JsxCompileConfig`], overridden per component by a
+//! `"use vue:vapor"` / `"use vue:vdom"` directive prologue (detected during
+//! lowering as [`LoweredRoot::mode`](crate::LoweredRoot)).
+//!
+//! The module is lowered once and analyzed once; each render root is then
+//! routed to the backend its resolved mode selects, so a single file may mix
+//! VDOM and Vapor components.
+
+use vize_carton::Bump;
+use vize_croquis::Croquis;
+
+use crate::diagnostics::JsxDiagnostic;
+use crate::dom::{DomCompileOptions, DomComponent, compile_root_to_dom};
+use crate::vapor::{VaporCompileOptions, VaporComponent, compile_root_to_vapor};
+use crate::{JsxLang, JsxOutputMode, lower_source};
+
+/// Configuration for mode-aware JSX compilation.
+#[derive(Debug, Clone, Default)]
+pub struct JsxCompileConfig {
+    /// Default output mode applied to components without an explicit
+    /// `"use vue:vapor"` / `"use vue:vdom"` directive.
+    pub default_mode: JsxOutputMode,
+    /// Options for components compiled to VDOM.
+    pub dom: DomCompileOptions,
+    /// Options for components compiled to Vapor.
+    pub vapor: VaporCompileOptions,
+}
+
+/// A compiled component, tagged by the backend it was routed to.
+pub enum JsxComponent {
+    /// Compiled to Virtual DOM output.
+    Dom(DomComponent),
+    /// Compiled to Vapor output.
+    Vapor(VaporComponent),
+}
+
+impl JsxComponent {
+    /// The enclosing component-function name, if resolved.
+    pub fn component_name(&self) -> Option<&str> {
+        match self {
+            Self::Dom(component) => component.component_name.as_deref(),
+            Self::Vapor(component) => component.component_name.as_deref(),
+        }
+    }
+
+    /// The backend this component was compiled with.
+    pub fn mode(&self) -> JsxOutputMode {
+        match self {
+            Self::Dom(_) => JsxOutputMode::Vdom,
+            Self::Vapor(_) => JsxOutputMode::Vapor,
+        }
+    }
+
+    /// The generated render code.
+    pub fn code(&self) -> &str {
+        match self {
+            Self::Dom(component) => component.code.as_str(),
+            Self::Vapor(component) => component.code.as_str(),
+        }
+    }
+}
+
+/// Result of mode-aware JSX/TSX compilation.
+pub struct JsxCompileOutput {
+    /// One entry per outermost JSX render root, in source order.
+    pub components: Vec<JsxComponent>,
+    /// Parse, lowering, and transform diagnostics.
+    pub diagnostics: Vec<JsxDiagnostic>,
+}
+
+impl JsxCompileOutput {
+    /// Whether any error-severity diagnostic was produced.
+    pub fn has_errors(&self) -> bool {
+        self.diagnostics.iter().any(JsxDiagnostic::is_error)
+    }
+}
+
+/// Resolve the effective output mode for a component: an explicit per-component
+/// directive wins, otherwise the configured default applies.
+pub fn resolve_mode(
+    component: Option<JsxOutputMode>,
+    default_mode: JsxOutputMode,
+) -> JsxOutputMode {
+    component.unwrap_or(default_mode)
+}
+
+/// Compile a JSX/TSX module, routing each component to VDOM or Vapor per the
+/// resolved output mode.
+pub fn compile_jsx(
+    bump: &Bump,
+    source: &str,
+    lang: JsxLang,
+    config: &JsxCompileConfig,
+) -> JsxCompileOutput {
+    let lowered = lower_source(bump, source, lang);
+    let mut diagnostics = lowered.diagnostics;
+    let is_ts = lang.is_typescript();
+
+    // Move the analysis into the arena so the transforms can borrow it.
+    let analysis: &Croquis = &*bump.alloc(lowered.analysis);
+
+    let mut components = Vec::with_capacity(lowered.roots.len());
+    for lowered_root in lowered.roots {
+        let mode = resolve_mode(lowered_root.mode, config.default_mode);
+        let component = match mode {
+            JsxOutputMode::Vdom => JsxComponent::Dom(compile_root_to_dom(
+                bump,
+                lowered_root,
+                analysis,
+                is_ts,
+                &config.dom,
+                &mut diagnostics,
+            )),
+            JsxOutputMode::Vapor => JsxComponent::Vapor(compile_root_to_vapor(
+                bump,
+                lowered_root,
+                analysis,
+                &config.vapor,
+            )),
+        };
+        components.push(component);
+    }
+
+    JsxCompileOutput {
+        components,
+        diagnostics,
+    }
+}

--- a/crates/vize_atelier_jsx/src/dom.rs
+++ b/crates/vize_atelier_jsx/src/dom.rs
@@ -80,49 +80,71 @@ pub fn compile_to_dom(
     let analysis: &Croquis = &*bump.alloc(lowered.analysis);
 
     let mut components = Vec::with_capacity(lowered.roots.len());
-    for LoweredRoot {
-        mut root,
-        mode,
-        component_name,
-    } in lowered.roots
-    {
-        let transform_opts = TransformOptions {
-            // JSX render fns close over the setup scope; don't prefix `_ctx.`.
-            prefix_identifiers: false,
-            hoist_static: options.hoist_static,
-            cache_handlers: options.cache_handlers,
+    for lowered_root in lowered.roots {
+        components.push(compile_root_to_dom(
+            bump,
+            lowered_root,
+            analysis,
             is_ts,
-            // Binding info is supplied via the `analysis` Croquis below; the
-            // relief-side `binding_metadata` (a distinct type) is only needed
-            // for SFC inline-mode ref unwrapping, which JSX closures don't use.
-            binding_metadata: None,
-            ..Default::default()
-        };
-        let errors = transform(bump, &mut root, transform_opts, Some(analysis));
-        diagnostics.extend(errors.iter().map(compiler_error_to_diagnostic));
-
-        let codegen_opts = CodegenOptions {
-            mode: CodegenMode::Module,
-            source_map: options.source_map,
-            component_name: component_name.clone(),
-            is_ts,
-            cache_handlers: options.cache_handlers,
-            binding_metadata: None,
-            ..Default::default()
-        };
-        let result = generate(&root, codegen_opts);
-
-        components.push(DomComponent {
-            component_name,
-            mode: mode.unwrap_or(JsxOutputMode::Vdom),
-            code: result.code,
-            preamble: result.preamble,
-        });
+            &options,
+            &mut diagnostics,
+        ));
     }
 
     DomOutput {
         components,
         diagnostics,
+    }
+}
+
+/// Compile a single already-lowered root to a VDOM [`DomComponent`], appending
+/// any transform diagnostics. Shared by [`compile_to_dom`] and the mode-aware
+/// dispatcher in [`crate::compile`].
+pub(crate) fn compile_root_to_dom(
+    bump: &Bump,
+    lowered: LoweredRoot,
+    analysis: &Croquis,
+    is_ts: bool,
+    options: &DomCompileOptions,
+    diagnostics: &mut Vec<JsxDiagnostic>,
+) -> DomComponent {
+    let LoweredRoot {
+        mut root,
+        mode,
+        component_name,
+    } = lowered;
+
+    let transform_opts = TransformOptions {
+        // JSX render fns close over the setup scope; don't prefix `_ctx.`.
+        prefix_identifiers: false,
+        hoist_static: options.hoist_static,
+        cache_handlers: options.cache_handlers,
+        is_ts,
+        // Binding info is supplied via the `analysis` Croquis below; the
+        // relief-side `binding_metadata` (a distinct type) is only needed
+        // for SFC inline-mode ref unwrapping, which JSX closures don't use.
+        binding_metadata: None,
+        ..Default::default()
+    };
+    let errors = transform(bump, &mut root, transform_opts, Some(analysis));
+    diagnostics.extend(errors.iter().map(compiler_error_to_diagnostic));
+
+    let codegen_opts = CodegenOptions {
+        mode: CodegenMode::Module,
+        source_map: options.source_map,
+        component_name: component_name.clone(),
+        is_ts,
+        cache_handlers: options.cache_handlers,
+        binding_metadata: None,
+        ..Default::default()
+    };
+    let result = generate(&root, codegen_opts);
+
+    DomComponent {
+        component_name,
+        mode: mode.unwrap_or(JsxOutputMode::Vdom),
+        code: result.code,
+        preamble: result.preamble,
     }
 }
 

--- a/crates/vize_atelier_jsx/src/lib.rs
+++ b/crates/vize_atelier_jsx/src/lib.rs
@@ -28,6 +28,7 @@
 //! assert!(out.diagnostics.is_empty());
 //! ```
 
+pub mod compile;
 pub mod diagnostics;
 pub mod dom;
 pub mod lang;
@@ -45,6 +46,7 @@ use vize_croquis::Croquis;
 use vize_croquis::croquis::BindingMetadata;
 use vize_relief::ast::RootNode;
 
+pub use compile::{JsxCompileConfig, JsxCompileOutput, JsxComponent, compile_jsx, resolve_mode};
 pub use diagnostics::{JsxDiagnostic, Severity};
 pub use dom::{DomCompileOptions, DomComponent, DomOutput, compile_to_dom};
 pub use lang::JsxLang;

--- a/crates/vize_atelier_jsx/src/mode.rs
+++ b/crates/vize_atelier_jsx/src/mode.rs
@@ -12,9 +12,12 @@
 //! ```
 
 /// The compilation target for a JSX/TSX component.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+///
+/// [`JsxOutputMode::Vdom`] is the default (matching Vue's default renderer).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
 pub enum JsxOutputMode {
     /// Virtual DOM output (`"use vue:vdom"`).
+    #[default]
     Vdom,
     /// Vapor output (`"use vue:vapor"`).
     Vapor,

--- a/crates/vize_atelier_jsx/src/vapor.rs
+++ b/crates/vize_atelier_jsx/src/vapor.rs
@@ -69,38 +69,55 @@ pub fn compile_to_vapor(
     let analysis: &Croquis = &*bump.alloc(lowered.analysis);
 
     let mut components = Vec::with_capacity(lowered.roots.len());
-    for LoweredRoot {
-        mut root,
-        mode,
-        component_name,
-    } in lowered.roots
-    {
-        let transform_opts = TransformOptions {
-            // JSX render fns close over the setup scope; don't prefix `_ctx.`.
-            prefix_identifiers: false,
-            ssr: options.ssr,
-            // Vapor IR lowering requires the core transform to run in vapor mode
-            // (e.g. it skips v-model desugaring, handled by the Vapor backend).
-            vapor: true,
-            binding_metadata: None,
-            ..Default::default()
-        };
-        transform(bump, &mut root, transform_opts, Some(analysis));
-
-        let ir = transform_to_ir(bump, &root);
-        let generated =
-            generate_vapor_with_options(&ir, None, VaporGenerateOptions { jsx_closure: true });
-
-        components.push(VaporComponent {
-            component_name,
-            mode: mode.unwrap_or(JsxOutputMode::Vapor),
-            code: generated.code,
-            templates: generated.templates,
-        });
+    for lowered_root in lowered.roots {
+        components.push(compile_root_to_vapor(
+            bump,
+            lowered_root,
+            analysis,
+            &options,
+        ));
     }
 
     VaporOutput {
         components,
         diagnostics,
+    }
+}
+
+/// Compile a single already-lowered root to a [`VaporComponent`]. Shared by
+/// [`compile_to_vapor`] and the mode-aware dispatcher in [`crate::compile`].
+pub(crate) fn compile_root_to_vapor(
+    bump: &Bump,
+    lowered: LoweredRoot,
+    analysis: &Croquis,
+    options: &VaporCompileOptions,
+) -> VaporComponent {
+    let LoweredRoot {
+        mut root,
+        mode,
+        component_name,
+    } = lowered;
+
+    let transform_opts = TransformOptions {
+        // JSX render fns close over the setup scope; don't prefix `_ctx.`.
+        prefix_identifiers: false,
+        ssr: options.ssr,
+        // Vapor IR lowering requires the core transform to run in vapor mode
+        // (e.g. it skips v-model desugaring, handled by the Vapor backend).
+        vapor: true,
+        binding_metadata: None,
+        ..Default::default()
+    };
+    transform(bump, &mut root, transform_opts, Some(analysis));
+
+    let ir = transform_to_ir(bump, &root);
+    let generated =
+        generate_vapor_with_options(&ir, None, VaporGenerateOptions { jsx_closure: true });
+
+    VaporComponent {
+        component_name,
+        mode: mode.unwrap_or(JsxOutputMode::Vapor),
+        code: generated.code,
+        templates: generated.templates,
     }
 }

--- a/crates/vize_atelier_jsx/tests/compile.rs
+++ b/crates/vize_atelier_jsx/tests/compile.rs
@@ -1,0 +1,155 @@
+//! Mode-aware JSX/TSX compilation via [`compile_jsx`] (#1496).
+//!
+//! These cover the dispatcher in `src/compile.rs`: how the configured default
+//! mode and per-component `"use vue:vapor"` / `"use vue:vdom"` directives route
+//! each render root to the VDOM or Vapor backend, including a single module that
+//! mixes both.
+
+use vize_atelier_jsx::{
+    JsxCompileConfig, JsxCompileOutput, JsxComponent, JsxLang, JsxOutputMode, compile_jsx,
+    resolve_mode,
+};
+use vize_carton::Bump;
+
+/// Compile JSX with the given config, asserting it produced no errors. The
+/// returned output owns its components, so the arena can be dropped here.
+fn compile(src: &str, config: &JsxCompileConfig) -> JsxCompileOutput {
+    let bump = Bump::new();
+    let out = compile_jsx(&bump, src, JsxLang::Jsx, config);
+    assert!(!out.has_errors(), "diagnostics: {:?}", out.diagnostics);
+    out
+}
+
+#[test]
+fn resolve_mode_prefers_component_directive_over_default() {
+    // An explicit per-component mode always wins.
+    assert_eq!(
+        resolve_mode(Some(JsxOutputMode::Vapor), JsxOutputMode::Vdom),
+        JsxOutputMode::Vapor
+    );
+    assert_eq!(
+        resolve_mode(Some(JsxOutputMode::Vdom), JsxOutputMode::Vapor),
+        JsxOutputMode::Vdom
+    );
+    // No directive falls back to the configured default.
+    assert_eq!(
+        resolve_mode(None, JsxOutputMode::Vapor),
+        JsxOutputMode::Vapor
+    );
+    assert_eq!(resolve_mode(None, JsxOutputMode::Vdom), JsxOutputMode::Vdom);
+}
+
+#[test]
+fn default_config_routes_undirected_component_to_vdom() {
+    // `JsxOutputMode::Vdom` is the derived default, matching Vue's renderer.
+    let out = compile("const App = () => <div/>;", &JsxCompileConfig::default());
+    assert_eq!(out.components.len(), 1);
+    let component = &out.components[0];
+    assert_eq!(component.component_name(), Some("App"));
+    assert_eq!(component.mode(), JsxOutputMode::Vdom);
+    assert!(
+        component.code().contains("_createElementBlock(\"div\")"),
+        "{}",
+        component.code()
+    );
+}
+
+#[test]
+fn default_mode_can_be_overridden_to_vapor() {
+    let config = JsxCompileConfig {
+        default_mode: JsxOutputMode::Vapor,
+        ..Default::default()
+    };
+    let out = compile("const App = () => <div/>;", &config);
+    assert_eq!(out.components.len(), 1);
+    let component = &out.components[0];
+    assert_eq!(component.mode(), JsxOutputMode::Vapor);
+    // Vapor emits a hoisted template rather than a VDOM block call.
+    assert!(
+        component.code().contains("template("),
+        "{}",
+        component.code()
+    );
+}
+
+#[test]
+fn vapor_directive_overrides_vdom_default() {
+    let src = "const Fast = () => { \"use vue:vapor\"; return <div/>; };";
+    let out = compile(src, &JsxCompileConfig::default());
+    assert_eq!(out.components.len(), 1);
+    assert_eq!(out.components[0].mode(), JsxOutputMode::Vapor);
+}
+
+#[test]
+fn vdom_directive_overrides_vapor_default() {
+    let config = JsxCompileConfig {
+        default_mode: JsxOutputMode::Vapor,
+        ..Default::default()
+    };
+    let src = "function Slow() { \"use vue:vdom\"; return <div/>; }";
+    let out = compile(src, &config);
+    assert_eq!(out.components.len(), 1);
+    assert_eq!(out.components[0].mode(), JsxOutputMode::Vdom);
+    assert!(
+        out.components[0].code().contains("_createElementBlock"),
+        "{}",
+        out.components[0].code()
+    );
+}
+
+#[test]
+fn one_module_can_mix_vdom_and_vapor_components() {
+    // `A` opts into Vapor via directive; `B` takes the Vdom default. Both are
+    // lowered and analyzed once, then routed to their respective backends.
+    let src = "const A = () => { \"use vue:vapor\"; return <a/>; };\nconst B = () => <b/>;";
+    let out = compile(src, &JsxCompileConfig::default());
+    assert_eq!(
+        out.components.len(),
+        2,
+        "expected two components in source order"
+    );
+
+    assert_eq!(out.components[0].component_name(), Some("A"));
+    assert_eq!(out.components[0].mode(), JsxOutputMode::Vapor);
+    assert!(
+        out.components[0].code().contains("template("),
+        "{}",
+        out.components[0].code()
+    );
+
+    assert_eq!(out.components[1].component_name(), Some("B"));
+    assert_eq!(out.components[1].mode(), JsxOutputMode::Vdom);
+    assert!(
+        out.components[1]
+            .code()
+            .contains("_createElementBlock(\"b\")"),
+        "{}",
+        out.components[1].code()
+    );
+}
+
+#[test]
+fn jsx_component_variant_matches_reported_mode() {
+    let src = "const A = () => { \"use vue:vapor\"; return <a/>; };\nconst B = () => <b/>;";
+    let out = compile(src, &JsxCompileConfig::default());
+    assert_eq!(out.components.len(), 2);
+
+    match &out.components[0] {
+        JsxComponent::Vapor(_) => {}
+        JsxComponent::Dom(_) => panic!("component A should route to Vapor"),
+    }
+    assert_eq!(out.components[0].mode(), JsxOutputMode::Vapor);
+
+    match &out.components[1] {
+        JsxComponent::Dom(_) => {}
+        JsxComponent::Vapor(_) => panic!("component B should route to Vdom"),
+    }
+    assert_eq!(out.components[1].mode(), JsxOutputMode::Vdom);
+}
+
+#[test]
+fn empty_module_yields_no_components_and_no_errors() {
+    let out = compile("const x = 1;", &JsxCompileConfig::default());
+    assert!(out.components.is_empty(), "expected no render roots");
+    assert!(!out.has_errors(), "diagnostics: {:?}", out.diagnostics);
+}


### PR DESCRIPTION
## Summary
Adds `compile_jsx`, a mode-aware entry point that lowers a JSX/TSX module once and routes each render root to the VDOM or Vapor backend per its resolved output mode:
- a configured `default_mode` (defaults to `Vdom`, matching Vue's renderer), and
- a per-component override via a `"use vue:vapor"` / `"use vue:vdom"` directive prologue.

A single module may therefore mix VDOM and Vapor components. `compile_root_to_dom` / `compile_root_to_vapor` are extracted as shared single-root entry points reused by both the standalone backends and the dispatcher, so behavior is identical to the existing per-backend paths.

## Test plan
- `tests/compile.rs`: default→Vdom routing, `default_mode=Vapor` override, per-component directive override (both directions), one module mixing Vdom+Vapor, `JsxComponent` variant/mode consistency, empty module, `resolve_mode` unit cases.
- `cargo test -p vize_atelier_jsx` green; `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1514"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->