### PR TITLE
feat(atelier-jsx): lower JSX event option-modifiers to v-on

### DIFF
--- a/crates/vize_atelier_jsx/src/lower/attr.rs
+++ b/crates/vize_atelier_jsx/src/lower/attr.rs
@@ -17,6 +17,8 @@ use vize_carton::{Box, String, Vec};
 use vize_relief::ast::core::SourceLocation;
 use vize_relief::ast::{AttributeNode, DirectiveNode, PropNode, TextNode};
 
+use vize_relief::ast::SimpleExpressionNode;
+
 use super::Lowerer;
 use super::expr::container_expr_span;
 
@@ -74,7 +76,22 @@ impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
                 match container_expr_span(container) {
                     // `name={}` behaves like a boolean attribute.
                     None => self.boolean_attr(name, name_loc, loc),
-                    Some(span) => self.bind_prop(&name, attr.name.span(), span, loc),
+                    Some(span) => {
+                        // `onClickCapture={h}` (event name + option modifiers) ->
+                        // a `v-on` directive so core codegen emits the suffixed
+                        // listener key. Plain `onClick={h}` has no recognized
+                        // suffix and stays a `v-bind` like before.
+                        if let Some((event, mods)) = split_on_event_modifiers(&name) {
+                            return self.von_modifier_prop(
+                                &event,
+                                attr.name.span(),
+                                span,
+                                &mods,
+                                loc,
+                            );
+                        }
+                        self.bind_prop(&name, attr.name.span(), span, loc)
+                    }
                 }
             }
             Some(JSXAttributeValue::Element(element)) => {
@@ -114,6 +131,28 @@ impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
         let mut directive = DirectiveNode::new(self.bump(), "bind", loc);
         directive.arg = Some(self.static_expr(name, name_span));
         directive.exp = Some(self.dyn_expr(value_span));
+        PropNode::Directive(Box::new_in(directive, self.bump()))
+    }
+
+    /// `onClickCapture={expr}` -> `v-on:click.capture="expr"`.
+    fn von_modifier_prop(
+        &self,
+        event: &str,
+        name_span: Span,
+        value_span: Span,
+        mods: &[&str],
+        loc: SourceLocation,
+    ) -> PropNode<'a> {
+        let mut directive = DirectiveNode::new(self.bump(), "on", loc);
+        directive.arg = Some(self.static_expr(event, name_span));
+        directive.exp = Some(self.dyn_expr(value_span));
+        for modifier in mods {
+            directive.modifiers.push(SimpleExpressionNode::new(
+                *modifier,
+                false,
+                self.mapper().location(name_span),
+            ));
+        }
         PropNode::Directive(Box::new_in(directive, self.bump()))
     }
 
@@ -159,6 +198,54 @@ impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
             JSXAttributeValue::Fragment(fragment) => Some(self.dyn_expr(fragment.span())),
         }
     }
+}
+
+/// Split a babel-plugin-jsx event attribute name into its event name and
+/// trailing option modifiers, e.g. `onClickCapture` -> `("click", ["capture"])`
+/// and `onInputPassiveCapture` -> `("input", ["passive", "capture"])`.
+///
+/// Returns `None` for names without an `on<Event>` shape, without any
+/// recognized trailing modifier, or whose only content is modifiers (so bare
+/// `onCapture` / `onOnce` keep their plain-bind behavior).
+fn split_on_event_modifiers(name: &str) -> Option<(String, std::vec::Vec<&str>)> {
+    // Require an `on` prefix immediately followed by an uppercase event char.
+    let rest = name.strip_prefix("on")?;
+    if !rest.chars().next()?.is_ascii_uppercase() {
+        return None;
+    }
+
+    // Peel recognized option modifiers off the END, preserving source order.
+    let mut event = rest;
+    let mut mods = std::vec::Vec::new();
+    loop {
+        let modifier = if let Some(head) = event.strip_suffix("Capture") {
+            event = head;
+            "capture"
+        } else if let Some(head) = event.strip_suffix("Once") {
+            event = head;
+            "once"
+        } else if let Some(head) = event.strip_suffix("Passive") {
+            event = head;
+            "passive"
+        } else {
+            break;
+        };
+        mods.push(modifier);
+    }
+    mods.reverse();
+
+    // Require at least one modifier and a non-empty event tail.
+    if mods.is_empty() || event.is_empty() {
+        return None;
+    }
+
+    // Lowercase the first char of the remaining event name.
+    let mut chars = event.chars();
+    let first = chars.next()?;
+    let mut lowered = String::new("");
+    lowered.push(first.to_ascii_lowercase());
+    lowered.push_str(chars.as_str());
+    Some((lowered, mods))
 }
 
 fn attr_full_name(name: &JSXAttributeName<'_>) -> String {

--- a/crates/vize_atelier_jsx/tests/events.rs
+++ b/crates/vize_atelier_jsx/tests/events.rs
@@ -1,0 +1,67 @@
+//! JSX event handler option-modifiers (feature C).
+//!
+//! babel-plugin-jsx encodes event option modifiers as a name suffix:
+//! `onClickCapture` / `onClickOnce` / `onClickPassive` (composable). These are
+//! lowered to a `v-on` directive so the core codegen emits the suffixed
+//! listener key, while plain `onClick` (no recognized suffix) stays a `v-bind`
+//! exactly as before.
+
+mod common;
+
+use common::{as_directive, lower_one, root_element, simple_content};
+use vize_atelier_jsx::{DomCompileOptions, JsxLang, compile_to_dom};
+use vize_carton::Bump;
+
+fn dom(src: &str) -> vize_carton::String {
+    let bump = Bump::new();
+    let out = compile_to_dom(&bump, src, JsxLang::Jsx, DomCompileOptions::default());
+    assert!(!out.has_errors(), "diagnostics: {:?}", out.diagnostics);
+    assert_eq!(out.components.len(), 1, "expected one component");
+    out.components.into_iter().next().unwrap().code
+}
+
+#[test]
+fn capture_modifier_yields_capture_listener_key() {
+    let code = dom("const A = () => <button onClickCapture={h}/>;");
+    assert!(code.contains("onClickCapture: h"), "{code}");
+}
+
+#[test]
+fn once_modifier_yields_once_listener_key() {
+    let code = dom("const A = () => <button onClickOnce={h}/>;");
+    assert!(code.contains("onClickOnce: h"), "{code}");
+}
+
+#[test]
+fn composed_passive_capture_yields_combined_listener_key() {
+    let code = dom("const A = () => <input onInputPassiveCapture={h}/>;");
+    assert!(code.contains("onInputPassiveCapture: h"), "{code}");
+}
+
+#[test]
+fn plain_on_click_stays_a_bare_bind_prop() {
+    // Regression: no recognized suffix -> plain `v-bind:onClick`, unchanged.
+    let code = dom("const A = () => <button onClick={h}/>;");
+    assert!(code.contains("onClick: h"), "{code}");
+}
+
+#[test]
+fn capture_modifier_lowers_to_a_v_on_directive() {
+    let bump = Bump::new();
+    let root = lower_one(&bump, "const a = <button onClickCapture={h}/>;");
+    let element = root_element(&root);
+    assert_eq!(element.props.len(), 1, "expected one prop");
+
+    let directive = as_directive(&element.props[0]);
+    assert_eq!(directive.name, "on", "directive name");
+
+    let arg = directive.arg.as_ref().expect("v-on arg");
+    assert_eq!(simple_content(arg), "click", "event name");
+
+    assert_eq!(directive.modifiers.len(), 1, "one modifier");
+    assert_eq!(
+        directive.modifiers[0].content.as_str(),
+        "capture",
+        "modifier content"
+    );
+}


### PR DESCRIPTION
## Summary
`onClick={h}` lowers as a plain `v-bind` prop. That works for the no-modifier case but leaves no path for event option-modifiers expressed via the `@vue/babel-plugin-jsx` name suffix. This detects `on<Event>(Capture|Once|Passive)+` attribute names with a dynamic value and lowers them to a `v-on` directive (event arg + modifiers), so the existing core v-on codegen emits e.g. `onClickCapture: h`.

**Hybrid by design:** plain `onClick` (no recognized suffix) stays a bind, so VDOM/Vapor output for the common case is byte-identical and **no existing test changes**. (Full v-on conversion of plain `onClick` would change Vapor to delegated `$evt`/`_delegateEvents` output and break existing tests.)

## Test plan
- `tests/events.rs`: `onClickCapture`/`onClickOnce` → modifier keys, composed `onInputPassiveCapture`, plain `onClick` regression (still a bind), and a lowering-shape assertion (directive `on`, arg `click`, modifier `capture`).
- `cargo test -p vize_atelier_jsx` green; `fmt --check` + `clippy --all-targets -- -D warnings` clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1518"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->