### PR TITLE
feat(cli): make --save-virtual-ts-for repeatable and support __vize_helpers

### DIFF
--- a/crates/vize/src/commands/check.rs
+++ b/crates/vize/src/commands/check.rs
@@ -46,9 +46,11 @@ pub struct CheckArgs {
     #[arg(long, alias = "include-virtual-ts")]
     pub show_virtual_ts: bool,
 
-    /// Save generated virtual TypeScript for a file next to that file
+    /// Save generated virtual TypeScript for a file next to that file.
+    /// Repeatable: pass the flag multiple times to save several files in one run.
+    /// Pass `__vize_helpers.d.ts` to save the shared helpers preamble file.
     #[arg(long, value_name = "FILE")]
-    pub save_virtual_ts_for: Option<PathBuf>,
+    pub save_virtual_ts_for: Vec<PathBuf>,
 
     /// Maximum number of warnings before failing
     #[arg(long)]

--- a/crates/vize/src/commands/check/runner/diagnostics.rs
+++ b/crates/vize/src/commands/check/runner/diagnostics.rs
@@ -112,11 +112,37 @@ pub(super) fn render_diagnostics(
         .collect()
 }
 
+/// Whether a `--save-virtual-ts-for` target names the shared ambient helpers
+/// file (`__vize_helpers.d.ts`) rather than a per-`.vue` virtual module.
+///
+/// Matched purely on the file name so the flag accepts the bare
+/// `__vize_helpers.d.ts`, a relative path, or an absolute path interchangeably.
+fn is_shared_helpers_target(requested_path: &Path) -> bool {
+    requested_path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name == vize_canon::virtual_ts::SHARED_PREAMBLE_FILE_NAME)
+}
+
+/// Save the generated virtual TypeScript for a single `--save-virtual-ts-for`
+/// target.
+///
+/// A target that names the shared helpers file (`__vize_helpers.d.ts`) writes
+/// the program-wide helpers preamble ([`SHARED_PREAMBLE_DTS`]) verbatim at the
+/// requested location. Every other target resolves to a generated per-`.vue`
+/// virtual module and is written next to its source as `<file>.virtual.ts`,
+/// exactly as before.
+///
+/// [`SHARED_PREAMBLE_DTS`]: vize_canon::virtual_ts::SHARED_PREAMBLE_DTS
 pub(super) fn save_virtual_ts_for_path<'a>(
     requested_path: &Path,
     cwd: &Path,
     candidates: impl IntoIterator<Item = (&'a Path, &'a str)>,
 ) -> Result<PathBuf, CompactString> {
+    if is_shared_helpers_target(requested_path) {
+        return save_shared_helpers_virtual_ts(requested_path, cwd);
+    }
+
     let requested_path = normalize_requested_virtual_ts_path(cwd, requested_path);
     let Some((original_path, content)) = candidates
         .into_iter()
@@ -129,14 +155,56 @@ pub(super) fn save_virtual_ts_for_path<'a>(
     };
 
     let target = virtual_ts_save_path(original_path)?;
+    write_virtual_ts(&target, content)
+}
+
+/// Save several `--save-virtual-ts-for` targets in one run, writing each one in
+/// turn and reporting every saved path. A failure on any target aborts the run.
+pub(super) fn save_virtual_ts_targets<'a, C>(
+    requested_paths: &[PathBuf],
+    cwd: &Path,
+    candidates: impl Fn() -> C,
+    quiet: bool,
+) where
+    C: IntoIterator<Item = (&'a Path, &'a str)>,
+{
+    for requested_path in requested_paths {
+        match save_virtual_ts_for_path(requested_path, cwd, candidates()) {
+            Ok(target) => {
+                if !quiet {
+                    eprintln!("Saved Virtual TS to {}", target.display());
+                }
+            }
+            Err(error) => {
+                eprintln!("\x1b[31mError:\x1b[0m {}", error);
+                std::process::exit(1);
+            }
+        }
+    }
+}
+
+/// Write the shared ambient helpers preamble to the requested location.
+fn save_shared_helpers_virtual_ts(
+    requested_path: &Path,
+    cwd: &Path,
+) -> Result<PathBuf, CompactString> {
+    let target = if requested_path.is_absolute() {
+        requested_path.to_path_buf()
+    } else {
+        cwd.join(requested_path)
+    };
+    write_virtual_ts(&target, vize_canon::virtual_ts::SHARED_PREAMBLE_DTS)
+}
+
+fn write_virtual_ts(target: &Path, content: &str) -> Result<PathBuf, CompactString> {
     let bytes = content.len();
     match profile!(
         "cli.check.save_virtual_ts.write",
-        fs::write(&target, content)
+        fs::write(target, content)
     ) {
         Ok(()) => {
             global_profiler().record_fs_write(bytes);
-            Ok(target)
+            Ok(target.to_path_buf())
         }
         Err(error) => {
             global_profiler().record_fs_write_failure(bytes);
@@ -237,7 +305,7 @@ pub(super) fn write_profile_virtual_ts(files: &[&vize_canon::VirtualFile]) {
 
 #[cfg(test)]
 mod tests {
-    use super::{save_virtual_ts_for_path, virtual_ts_save_path};
+    use super::{is_shared_helpers_target, save_virtual_ts_for_path, virtual_ts_save_path};
 
     #[test]
     fn virtual_ts_save_path_appends_virtual_ts_after_full_file_name() {
@@ -271,6 +339,69 @@ mod tests {
         assert_eq!(
             std::fs::read_to_string(saved).unwrap(),
             "const value = 1;\n"
+        );
+    }
+
+    #[test]
+    fn is_shared_helpers_target_matches_helpers_file_name_in_any_form() {
+        let bare = std::path::Path::new(vize_canon::virtual_ts::SHARED_PREAMBLE_FILE_NAME);
+        assert!(is_shared_helpers_target(bare));
+        assert!(is_shared_helpers_target(std::path::Path::new(
+            "some/nested/dir/__vize_helpers.d.ts"
+        )));
+        assert!(is_shared_helpers_target(std::path::Path::new(
+            "/abs/__vize_helpers.d.ts"
+        )));
+        assert!(!is_shared_helpers_target(std::path::Path::new(
+            "src/App.vue"
+        )));
+        assert!(!is_shared_helpers_target(std::path::Path::new(
+            "__vize_helpers.ts"
+        )));
+    }
+
+    #[test]
+    fn save_virtual_ts_for_path_writes_shared_helpers_preamble() {
+        let temp = tempfile::tempdir().unwrap();
+
+        // No `.vue` candidate matches the helpers target; it is served from the
+        // shared preamble constant instead of the per-file virtual modules.
+        let saved = save_virtual_ts_for_path(
+            std::path::Path::new(vize_canon::virtual_ts::SHARED_PREAMBLE_FILE_NAME),
+            temp.path(),
+            std::iter::empty(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            saved,
+            temp.path()
+                .join(vize_canon::virtual_ts::SHARED_PREAMBLE_FILE_NAME)
+        );
+        assert_eq!(
+            std::fs::read_to_string(saved).unwrap(),
+            vize_canon::virtual_ts::SHARED_PREAMBLE_DTS
+        );
+    }
+
+    #[test]
+    fn save_virtual_ts_for_path_writes_shared_helpers_to_absolute_target() {
+        let temp = tempfile::tempdir().unwrap();
+        let target = temp.path().join("out").join("__vize_helpers.d.ts");
+        std::fs::create_dir_all(target.parent().unwrap()).unwrap();
+
+        // An unrelated cwd must not redirect an absolute helpers target.
+        let saved = save_virtual_ts_for_path(
+            &target,
+            std::path::Path::new("/nonexistent"),
+            std::iter::empty(),
+        )
+        .unwrap();
+
+        assert_eq!(saved, target);
+        assert_eq!(
+            std::fs::read_to_string(saved).unwrap(),
+            vize_canon::virtual_ts::SHARED_PREAMBLE_DTS
         );
     }
 }

--- a/crates/vize/src/commands/check/runner/mod.rs
+++ b/crates/vize/src/commands/check/runner/mod.rs
@@ -43,7 +43,7 @@ mod tests;
 use collect::collect_check_files;
 use diagnostics::{
     emit_json_output, is_reported, is_suppressed_false_positive, render_diagnostics,
-    save_virtual_ts_for_path, write_profile_virtual_ts,
+    save_virtual_ts_targets, write_profile_virtual_ts,
 };
 use global_components::{
     build_virtual_ts_options, collect_project_global_component_stubs, dialect_from_features,
@@ -350,24 +350,17 @@ pub(crate) fn run_direct(args: &CheckArgs) {
         }
     }
 
-    if let Some(path) = args.save_virtual_ts_for.as_deref() {
-        match save_virtual_ts_for_path(
-            path,
+    if !args.save_virtual_ts_for.is_empty() {
+        save_virtual_ts_targets(
+            &args.save_virtual_ts_for,
             &cwd,
-            virtual_files
-                .iter()
-                .map(|file| (file.original_path.as_path(), file.content.as_str())),
-        ) {
-            Ok(target) => {
-                if !args.quiet {
-                    eprintln!("Saved Virtual TS to {}", target.display());
-                }
-            }
-            Err(error) => {
-                eprintln!("\x1b[31mError:\x1b[0m {}", error);
-                std::process::exit(1);
-            }
-        }
+            || {
+                virtual_files
+                    .iter()
+                    .map(|file| (file.original_path.as_path(), file.content.as_str()))
+            },
+            args.quiet,
+        );
     }
 
     let profile_artifact_start = Instant::now();

--- a/crates/vize/src/commands/check/runner/socket.rs
+++ b/crates/vize/src/commands/check/runner/socket.rs
@@ -22,7 +22,7 @@ use crate::{
     profile_support,
 };
 
-use super::{collect::collect_vue_files, diagnostics::save_virtual_ts_for_path, display_path};
+use super::{collect::collect_vue_files, diagnostics::save_virtual_ts_targets, display_path};
 use vize_curator::profile::{ProfilePhase, ProfilePhaseKind, ProfileReport, print_profile_report};
 
 /// Run type checking via Unix socket connection to check-server.
@@ -180,25 +180,18 @@ pub(crate) fn run_with_socket(args: &CheckArgs, socket_path: &str) {
     }
     let request_time = request_start.elapsed();
 
-    if let Some(path) = args.save_virtual_ts_for.as_deref() {
+    if !args.save_virtual_ts_for.is_empty() {
         let cwd = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
-        match save_virtual_ts_for_path(
-            path,
+        save_virtual_ts_targets(
+            &args.save_virtual_ts_for,
             &cwd,
-            results.iter().map(|(filename, result)| {
-                (std::path::Path::new(filename), result.virtual_ts.as_str())
-            }),
-        ) {
-            Ok(target) => {
-                if !args.quiet {
-                    eprintln!("Saved Virtual TS to {}", target.display());
-                }
-            }
-            Err(error) => {
-                eprintln!("\x1b[31mError:\x1b[0m {}", error);
-                std::process::exit(1);
-            }
-        }
+            || {
+                results.iter().map(|(filename, result)| {
+                    (std::path::Path::new(filename), result.virtual_ts.as_str())
+                })
+            },
+            args.quiet,
+        );
     }
 
     let render_start = Instant::now();

--- a/crates/vize/src/commands/ready.rs
+++ b/crates/vize/src/commands/ready.rs
@@ -89,7 +89,7 @@ pub fn run(args: ReadyArgs) {
         tsconfig: None,
         format: "text".into(),
         show_virtual_ts: false,
-        save_virtual_ts_for: None,
+        save_virtual_ts_for: Vec::new(),
         max_warnings: None,
         no_check_props: false,
         no_check_emits: false,

--- a/crates/vize/src/snapshots/vize__cli__tests__cli_check_help.snap
+++ b/crates/vize/src/snapshots/vize__cli__tests__cli_check_help.snap
@@ -33,7 +33,7 @@ Options:
           Show generated virtual TypeScript
 
       --save-virtual-ts-for <FILE>
-          Save generated virtual TypeScript for a file next to that file
+          Save generated virtual TypeScript for a file next to that file. Repeatable: pass the flag multiple times to save several files in one run. Pass `__vize_helpers.d.ts` to save the shared helpers preamble file
 
       --max-warnings <MAX_WARNINGS>
           Maximum number of warnings before failing

--- a/crates/vize/tests/check_cli.rs
+++ b/crates/vize/tests/check_cli.rs
@@ -120,6 +120,121 @@ void props
 }
 
 #[test]
+fn check_save_virtual_ts_for_accepts_multiple_targets() {
+    let Some(corsa_path) = resolve_test_corsa_path() else {
+        return;
+    };
+    let project_root = create_cli_project(
+        "save-virtual-ts-multiple",
+        &[
+            (
+                "src/Foo.vue",
+                "<script setup lang=\"ts\">\nconst foo = 1\n</script>\n<template><div>{{ foo }}</div></template>\n",
+            ),
+            (
+                "src/Bar.vue",
+                "<script setup lang=\"ts\">\nconst bar = 2\n</script>\n<template><span>{{ bar }}</span></template>\n",
+            ),
+        ],
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(&project_root)
+        .env("CORSA_PATH", corsa_path)
+        .args([
+            "check",
+            "src/Foo.vue",
+            "src/Bar.vue",
+            "--save-virtual-ts-for",
+            "src/Foo.vue",
+            "--save-virtual-ts-for",
+            "src/Bar.vue",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "check failed: {}",
+        std::string::String::from_utf8_lossy(&output.stderr)
+    );
+
+    let foo_virtual = project_root.join("src/Foo.vue.virtual.ts");
+    let bar_virtual = project_root.join("src/Bar.vue.virtual.ts");
+    assert!(
+        foo_virtual.exists(),
+        "expected {} to be written",
+        foo_virtual.display()
+    );
+    assert!(
+        bar_virtual.exists(),
+        "expected {} to be written",
+        bar_virtual.display()
+    );
+    assert!(
+        std::fs::read_to_string(&foo_virtual)
+            .unwrap()
+            .contains("foo")
+    );
+    assert!(
+        std::fs::read_to_string(&bar_virtual)
+            .unwrap()
+            .contains("bar")
+    );
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}
+
+#[test]
+fn check_save_virtual_ts_for_writes_shared_helpers_target() {
+    let Some(corsa_path) = resolve_test_corsa_path() else {
+        return;
+    };
+    let project_root = create_cli_project(
+        "save-virtual-ts-helpers",
+        &[(
+            "src/Foo.vue",
+            "<script setup lang=\"ts\">\nconst foo = 1\n</script>\n<template><div>{{ foo }}</div></template>\n",
+        )],
+    );
+
+    let helpers_name = vize_canon::virtual_ts::SHARED_PREAMBLE_FILE_NAME;
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(&project_root)
+        .env("CORSA_PATH", corsa_path)
+        .args([
+            "check",
+            "src/Foo.vue",
+            "--save-virtual-ts-for",
+            "src/Foo.vue",
+            "--save-virtual-ts-for",
+            helpers_name,
+        ])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "check failed: {}",
+        std::string::String::from_utf8_lossy(&output.stderr)
+    );
+
+    let helpers_path = project_root.join(helpers_name);
+    assert!(
+        helpers_path.exists(),
+        "expected {} to be written",
+        helpers_path.display()
+    );
+    assert_eq!(
+        std::fs::read_to_string(&helpers_path).unwrap(),
+        vize_canon::virtual_ts::SHARED_PREAMBLE_DTS
+    );
+    assert!(project_root.join("src/Foo.vue.virtual.ts").exists());
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}
+
+#[test]
 fn check_without_patterns_uses_parent_relative_tsconfig_includes() {
     let Some(corsa_path) = resolve_test_corsa_path() else {
         return;


### PR DESCRIPTION
## Summary

Two related `vize check` CLI enhancements:

- **#1509 — repeatable flag:** `--save-virtual-ts-for` can now be passed multiple times to save several files' virtual TS in one `vize check` run. `CheckArgs.save_virtual_ts_for` changes from `Option<PathBuf>` to `Vec<PathBuf>` (clap-derive makes `Vec<PathBuf>` naturally repeatable).
- **#1510 — helpers virtual file:** a target naming the shared helpers file `__vize_helpers.d.ts` now saves the program-wide helpers preamble (`vize_canon::virtual_ts::SHARED_PREAMBLE_DTS`) verbatim at the requested location, instead of looking for a matching per-`.vue` virtual module. Matched on file name, so the bare name, a relative path, or an absolute path all work.

Per-`.vue` targets keep writing `<file>.virtual.ts` next to the source exactly as before, and a single `--save-virtual-ts-for X` invocation is fully backward compatible.

### Changes
- `crates/vize/src/commands/check.rs` — field type `Option<PathBuf>` → `Vec<PathBuf>`, updated help text.
- `crates/vize/src/commands/check/runner/diagnostics.rs` — new `save_virtual_ts_targets()` (loops targets), `is_shared_helpers_target()`, `save_shared_helpers_virtual_ts()`, shared `write_virtual_ts()`; `save_virtual_ts_for_path()` now dispatches helpers vs per-`.vue`.
- `crates/vize/src/commands/check/runner/mod.rs` and `.../socket.rs` — call sites updated to the multi-target API.
- `crates/vize/src/commands/ready.rs` — construct `save_virtual_ts_for: Vec::new()`.
- `crates/vize/src/snapshots/vize__cli__tests__cli_check_help.snap` — refreshed help.

## Test plan
- `cargo build -p vize` — succeeds.
- New unit tests in `diagnostics.rs`: helpers-target detection, helpers-preamble save, absolute helpers target with unrelated cwd.
- New CLI integration tests in `tests/check_cli.rs`: two `--save-virtual-ts-for` targets in one run (both written); helpers target in a mixed run (helpers + per-`.vue` both written, helpers bytes == `SHARED_PREAMBLE_DTS`).
- Verified the built binary by hand against a temp project with two `.vue` files: two targets wrote both `*.virtual.ts`; `--save-virtual-ts-for __vize_helpers.d.ts` wrote the 5485-byte preamble; mixed run wrote both.
- Gates: `cargo test -p vize --lib` (127 passed) and `--test check_cli` (43 passed) green; `cargo fmt -p vize -- --check` clean; `cargo clippy --workspace -- -D warnings` (CI's clippy invocation) clean.

Note: `cargo clippy -p vize --all-targets -- -D warnings` reports pre-existing `disallowed_types`/`disallowed_methods` lints in `tests/check_cli.rs` (146 on the clean base; CI runs `--workspace` without `--all-targets`, so the test target is not linted). My two added test assertions reuse the existing `std::string::String::from_utf8_lossy(&output.stderr)` house style already used throughout that file. A pre-existing `inspector_cli` test fails on the clean base too (a Node `ERR_MODULE_NOT_FOUND` env issue), unrelated to this change.

Closes #1509
Closes #1510

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1519"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->