### PR TITLE
fix(canon): narrow v-for source by enclosing v-if in virtual TS (#1511)

### DIFF
--- a/crates/vize_canon/src/batch/type_checker/tests.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests.rs
@@ -861,6 +861,96 @@ const val = 0 as unknown as UnionType
 }
 
 #[test]
+fn batch_type_checker_narrows_v_for_source_by_enclosing_v_if() {
+    // Regression for #1511: a v-for whose source depends on a value narrowed by
+    // an *enclosing* v-if must type-check without a spurious diagnostic — the
+    // iterated element type follows the narrowed source (`elems['b']` is
+    // `string[]`, so `value` is `string`).
+    if resolve_test_tsgo_binary().is_none() {
+        return;
+    }
+
+    let project_root = create_project_case_without_node_modules(
+        "vfor-source-narrowed-by-enclosing-vif",
+        &[(
+            "src/VForNarrowedByVif.vue",
+            r#"<script setup lang="ts">
+const elems = { a: [1], b: ["a"] } as const;
+const key = "a" as "a" | "b";
+function wantsString(value: string) { void value; }
+</script>
+
+<template>
+  <div v-if="key === 'b'">
+    <button v-for="value in elems[key]" :key="value">
+      {{ wantsString(value) }}
+    </button>
+  </div>
+</template>
+"#,
+        )],
+    );
+
+    let Some(snapshot) = snapshot_project_diagnostics(&project_root) else {
+        let _ = std::fs::remove_dir_all(&project_root);
+        return;
+    };
+
+    assert!(
+        snapshot
+            .iter()
+            .all(|(file, _, _)| file != "src/VForNarrowedByVif.vue"),
+        "expected no diagnostics for v-for narrowed by enclosing v-if, got: {snapshot:#?}"
+    );
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}
+
+#[test]
+fn batch_type_checker_keeps_v_for_error_without_enclosing_v_if() {
+    // Companion guard for #1511: when there is NO enclosing v-if to narrow the
+    // source, the unnarrowed union element type must still produce a diagnostic
+    // (we must not over-narrow). `elems[key]` with `key: "a" | "b"` yields a
+    // `(string | number)` element, so `wantsString(value)` is a real error.
+    if resolve_test_tsgo_binary().is_none() {
+        return;
+    }
+
+    let project_root = create_project_case_without_node_modules(
+        "vfor-source-not-narrowed-without-vif",
+        &[(
+            "src/VForNotNarrowed.vue",
+            r#"<script setup lang="ts">
+const elems = { a: [1], b: ["a"] } as const;
+const key = "a" as "a" | "b";
+function wantsString(value: string) { void value; }
+</script>
+
+<template>
+  <button v-for="value in elems[key]" :key="value">
+    {{ wantsString(value) }}
+  </button>
+</template>
+"#,
+        )],
+    );
+
+    let Some(snapshot) = snapshot_project_diagnostics(&project_root) else {
+        let _ = std::fs::remove_dir_all(&project_root);
+        return;
+    };
+
+    assert!(
+        snapshot
+            .iter()
+            .any(|(file, code, _)| { file == "src/VForNotNarrowed.vue" && *code == Some(2345) }),
+        "expected TS2345 for un-narrowed v-for source, got: {snapshot:#?}"
+    );
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}
+
+#[test]
 fn batch_type_checker_uses_workspace_vue_runtime_without_node_modules() {
     if resolve_test_tsgo_binary().is_none() {
         return;

--- a/crates/vize_canon/src/snapshots/vize_canon__tests__virtual_ts_tests__virtual_ts_nested_v_if_v_else.snap
+++ b/crates/vize_canon/src/snapshots/vize_canon__tests__virtual_ts_tests__virtual_ts_nested_v_if_v_else.snap
@@ -104,19 +104,21 @@ function __setup() {
     void (message); // Interpolation
     // @vize-map: expr -> 311:318
   }
+  if (!(status === 'loading') && !(status === 'error')) {
 
-  // v-for scope: item in data
-  __vForList(data).forEach(([item]) => {
-    void item;
-    if (!(status === 'loading') && !(status === 'error')) {
-      void (item); // VBind
-      // @vize-map: expr -> 386:390
-    }
-    if (!(status === 'loading') && !(status === 'error')) {
-      void (item); // Interpolation
-      // @vize-map: expr -> 395:399
-    }
-  });
+    // v-for scope: item in data
+    __vForList(data).forEach(([item]) => {
+      void item;
+      if (!(status === 'loading') && !(status === 'error')) {
+        void (item); // VBind
+        // @vize-map: expr -> 386:390
+      }
+      if (!(status === 'loading') && !(status === 'error')) {
+        void (item); // Interpolation
+        // @vize-map: expr -> 395:399
+      }
+    });
+  }
 
   // Reference setup bindings (used in template/CSS v-bind)
   void data; void message; void ref; void status;

--- a/crates/vize_canon/src/virtual_ts/scope/closures.rs
+++ b/crates/vize_canon/src/virtual_ts/scope/closures.rs
@@ -190,9 +190,38 @@ fn generate_scope_node(
 
     match scope.data() {
         ScopeData::VFor(data) => {
+            // When the v-for element is nested inside an enclosing `v-if`, wrap
+            // the whole `__vForList(source).forEach(...)` loop in `if (guard) {}`
+            // so TypeScript narrows identifiers used in the v-for source
+            // expression (e.g. `elems[key]` with `key` narrowed by the parent
+            // `v-if="key === 'b'"`). Without this the source is evaluated outside
+            // the narrowing scope and yields the unnarrowed (wider) type (#1511).
+            //
+            // The v-for element's own bindings (`:key`, etc.) and interpolations
+            // are recorded as expressions in this scope carrying that enclosing
+            // guard; any deeper `v-if` nested *inside* the loop body extends the
+            // guard with extra `&& (...)` terms. The enclosing guard is therefore
+            // the longest `&&`-separated prefix common to every direct expression
+            // in the scope — conservative enough never to import a nested
+            // branch's condition.
+            let enclosing_guard: Option<String> = ctx
+                .expressions_by_scope
+                .get(&scope_id)
+                .filter(|_| ctx.check_options.check_template_bindings)
+                .and_then(|exprs| common_vif_guard_prefix(exprs));
+            let enclosing_guard = enclosing_guard.as_deref();
+            let (loop_indent, vfor_inner_indent) = if enclosing_guard.is_some() {
+                (cstr!("{indent}  "), cstr!("{inner_indent}  "))
+            } else {
+                (String::from(indent), inner_indent.clone())
+            };
+            if let Some(guard) = enclosing_guard {
+                append!(*ts, "{indent}if ({guard}) {{\n");
+            }
+
             append_v_for_comment(
                 ts,
-                indent,
+                &loop_indent,
                 "v-for scope",
                 data.value_alias.as_str(),
                 data.source.as_str(),
@@ -200,7 +229,7 @@ fn generate_scope_node(
 
             emit_v_for_loop_open(
                 ts,
-                indent,
+                &loop_indent,
                 data.value_alias.as_str(),
                 data.key_alias.as_deref(),
                 data.index_alias.as_deref(),
@@ -209,13 +238,13 @@ fn generate_scope_node(
 
             // Mark v-for variables as used to avoid TS6133
             for value in &data.value_bindings {
-                append!(*ts, "{inner_indent}void {value};\n");
+                append!(*ts, "{vfor_inner_indent}void {value};\n");
             }
             if let Some(ref key) = data.key_alias {
-                append!(*ts, "{inner_indent}void {key};\n");
+                append!(*ts, "{vfor_inner_indent}void {key};\n");
             }
             if let Some(ref index) = data.index_alias {
-                append!(*ts, "{inner_indent}void {index};\n");
+                append!(*ts, "{vfor_inner_indent}void {index};\n");
             }
 
             // Generate expressions in this scope
@@ -228,18 +257,22 @@ fn generate_scope_node(
                     exprs,
                     ctx.template_prop_names,
                     ctx.template_offset,
-                    &inner_indent,
+                    &vfor_inner_indent,
                 );
             }
 
             // Recursively generate child scopes inside this closure
             profile!(
                 "canon.virtual_ts.child_scopes",
-                generate_child_scopes(ts, mappings, ctx, scope_id, &inner_indent)
+                generate_child_scopes(ts, mappings, ctx, scope_id, &vfor_inner_indent)
             );
 
-            ts.push_str(indent);
+            ts.push_str(&loop_indent);
             ts.push_str("});\n");
+
+            if enclosing_guard.is_some() {
+                append!(*ts, "{indent}}}\n");
+            }
         }
         ScopeData::VSlot(data) => {
             append!(*ts, "\n{indent}// v-slot scope: #{}\n", data.name);
@@ -439,4 +472,77 @@ fn generate_child_scopes(
             }
         }
     }
+}
+
+/// Compute the v-if guard active for a v-for *element* from the template
+/// expressions recorded in its scope.
+///
+/// Every expression carries the joined `v-if` guard (`(a) && (b) && ...`)
+/// active where it appears. For a v-for element, its own bindings/interpolations
+/// share the element's enclosing guard, while expressions under a `v-if` nested
+/// *inside* the loop body extend that guard with further `&& (...)` terms. The
+/// enclosing guard is therefore the longest `&&`-separated prefix common to
+/// every expression in the scope: it can never include a nested branch's
+/// condition, and is `None` when any expression is unguarded (i.e. the v-for is
+/// not inside a `v-if`). Returns the re-joined guard string when non-empty.
+fn common_vif_guard_prefix(exprs: &[&vize_croquis::TemplateExpression]) -> Option<String> {
+    let mut iter = exprs.iter();
+    // Seed the common prefix with the first expression's guard terms; an
+    // unguarded expression immediately rules out any common guard.
+    let first = iter.next()?.vif_guard.as_ref()?;
+    let mut common: Vec<&str> = split_guard_terms(first.as_str());
+
+    for expr in iter {
+        let guard = expr.vif_guard.as_ref()?;
+        let terms = split_guard_terms(guard.as_str());
+        let shared = common
+            .iter()
+            .zip(terms.iter())
+            .take_while(|(a, b)| a == b)
+            .count();
+        common.truncate(shared);
+        if common.is_empty() {
+            return None;
+        }
+    }
+
+    (!common.is_empty()).then(|| String::from(common.join(" && ").as_str()))
+}
+
+/// Split a joined v-if guard into its top-level ` && `-separated terms.
+///
+/// The drawer joins each branch condition — already wrapped as `(cond)` or
+/// `!(cond)` — with ` && `, so a single condition may itself contain ` && `
+/// inside its parentheses (`v-if="a && b"` becomes the term `(a && b)`). The
+/// split must therefore only break on the ` && ` joiner at paren depth zero so
+/// such conditions stay intact.
+fn split_guard_terms(guard: &str) -> Vec<&str> {
+    let bytes = guard.as_bytes();
+    let mut terms = Vec::new();
+    let mut depth = 0i32;
+    let mut start = 0usize;
+    let mut index = 0usize;
+
+    while index < bytes.len() {
+        match bytes[index] {
+            b'(' | b'[' | b'{' => depth += 1,
+            b')' | b']' | b'}' => depth -= 1,
+            b'&' if depth == 0
+                && bytes.get(index + 1) == Some(&b'&')
+                && index >= 1
+                && bytes[index - 1] == b' '
+                && bytes.get(index + 2) == Some(&b' ') =>
+            {
+                terms.push(guard[start..index - 1].trim());
+                index += 3;
+                start = index;
+                continue;
+            }
+            _ => {}
+        }
+        index += 1;
+    }
+
+    terms.push(guard[start..].trim());
+    terms
 }

--- a/crates/vize_canon/src/virtual_ts/tests.rs
+++ b/crates/vize_canon/src/virtual_ts/tests.rs
@@ -1027,6 +1027,101 @@ const items = ref([{ id: 1, name: 'Hello' }])
 }
 
 #[test]
+fn test_vfor_source_nested_in_vif_is_wrapped_for_narrowing() {
+    // Regression for #1511: a v-for whose source expression depends on a value
+    // narrowed by an *enclosing* v-if must have its whole
+    // `__vForList(source).forEach(...)` loop emitted INSIDE the `if (guard) {}`
+    // block, so TypeScript narrows identifiers used in the source expression.
+    use vize_croquis::{Analyzer, AnalyzerOptions};
+
+    let script = r#"const elems = { a: [1], b: ["a"] } as const;
+const key = "a" as "a" | "b";
+"#;
+    let template = r#"<div v-if="key === 'b'">
+  <button v-for="value in elems[key]" :key="value">{{ value }}</button>
+</div>"#;
+
+    let allocator = vize_carton::Bump::new();
+    let (root, _) = vize_armature::parse(&allocator, template);
+
+    let mut analyzer = Analyzer::with_options(AnalyzerOptions::full());
+    analyzer.analyze_script_setup(script);
+    analyzer.analyze_template(&root);
+    let summary = analyzer.finish();
+
+    let output = generate_virtual_ts(&summary, Some(script), Some(&root), 0);
+    let code = output.code.as_str();
+
+    let vfor_pos = code
+        .find("__vForList(elems[key])")
+        .expect("expected the v-for loop over `elems[key]` to be emitted");
+
+    // The enclosing v-if guard must open *before* the v-for source is evaluated.
+    let guard_open = code[..vfor_pos]
+        .rfind("if ((key === 'b')) {")
+        .expect("expected the enclosing v-if guard to wrap the v-for loop");
+
+    // Nothing should close that `if` block between the guard open and the loop.
+    let between = &code[guard_open..vfor_pos];
+    assert!(
+        !between.contains("\n}\n") && !between.contains("});\n"),
+        "v-for source `elems[key]` must be emitted inside the enclosing `if (key === 'b')` block, got:\n{code}"
+    );
+}
+
+#[test]
+fn test_vfor_with_nested_vif_in_body_is_not_wrapped() {
+    // Guard for #1511: a `v-if` *inside* the v-for body must NOT cause the whole
+    // loop to be wrapped — only an *enclosing* v-if narrows the source. Here the
+    // loop source `items` has no enclosing guard, so `__vForList(items)` must be
+    // emitted at the scope's own indentation, not inside any `if (...)`.
+    use vize_croquis::{Analyzer, AnalyzerOptions};
+
+    let script = r#"const items = [1, 2, 3];
+const show = true;
+"#;
+    let template = r#"<ul>
+  <li v-for="item in items" :key="item">
+    <span v-if="show">{{ item }}</span>
+  </li>
+</ul>"#;
+
+    let allocator = vize_carton::Bump::new();
+    let (root, _) = vize_armature::parse(&allocator, template);
+
+    let mut analyzer = Analyzer::with_options(AnalyzerOptions::full());
+    analyzer.analyze_script_setup(script);
+    analyzer.analyze_template(&root);
+    let summary = analyzer.finish();
+
+    let output = generate_virtual_ts(&summary, Some(script), Some(&root), 0);
+    let code = output.code.as_str();
+
+    let vfor_pos = code
+        .find("__vForList(items)")
+        .expect("expected the v-for loop over `items` to be emitted");
+
+    // The line that opens the loop must not be wrapped: no `if (` should open on
+    // the v-for comment / loop line. Look at the line immediately preceding the
+    // loop's `__vForList` to ensure it is the v-for comment, not an `if (`.
+    let line_start = code[..vfor_pos].rfind('\n').map_or(0, |idx| idx + 1);
+    let loop_indent = &code[line_start..vfor_pos];
+    assert!(
+        loop_indent.trim().is_empty(),
+        "v-for loop should start a line, got prefix {loop_indent:?}\n{code}"
+    );
+    // The nested v-if narrowing for `show` must still appear, but only *inside*
+    // the forEach body (after the loop opens), never wrapping the loop itself.
+    let show_guard = code
+        .find("if ((show))")
+        .expect("expected the nested v-if `show` narrowing inside the loop body");
+    assert!(
+        show_guard > vfor_pos,
+        "nested v-if `show` must be emitted inside the loop body, not around it\n{code}"
+    );
+}
+
+#[test]
 fn test_nested_vif_velse_chain() {
     use vize_croquis::{Analyzer, AnalyzerOptions};
 


### PR DESCRIPTION
## Summary

Fixes #1511: a `v-for` whose source expression depends on a value narrowed by an **enclosing** `v-if` was type-checked with the value **unnarrowed**.

```vue
<script setup lang="ts">
const elems = { a: [1], b: ["a"] } as const;
const key = "a" as "a" | "b";
function wantsString(value: string) { void value; }
</script>
<template>
  <div v-if="key === 'b'">
    <button v-for="value in elems[key]" :key="value">
      {{ wantsString(value) }}
    </button>
  </div>
</template>
```

`vize check` wrongly raised `TS2345` because the generated `__vForList(elems[key]).forEach(...)` was emitted **outside** the `if (key === 'b') { ... }` block, so `key` kept the union `"a" | "b"`, making `elems[key]` a `string[] | number[]` and `value` a `string | number`.

## Root cause

`crates/vize_canon/src/virtual_ts/scope/closures.rs` — the `ScopeData::VFor` arm emitted the loop (source + body) at the scope's own indentation with no awareness of an enclosing `v-if`. v-if narrowing in the virtual TS is otherwise expression-level (each template expression carries a joined `vif_guard` and gets wrapped in `if (guard) {}`), but the **v-for source expression itself** was never wrapped — so the iterated element type was computed from the unnarrowed source.

## Fix

The VFor arm now derives the guard active for the v-for **element** and, when present, wraps the whole `__vForList(source).forEach(...)` loop in `if (guard) { ... }`.

The guard is derived from the template expressions already recorded in the v-for scope: it is the longest ` && `-separated prefix common to every expression's `vif_guard`. The v-for element's own bindings (`:key`) and interpolations carry exactly the enclosing guard; a `v-if` nested *inside* the loop body only extends that guard with extra `&& (...)` terms, so the common prefix can never import a nested branch's condition, and is absent when the loop is not inside a `v-if`. Deriving from existing per-expression guards avoids adding a field to the public `VForScopeData` / `Croquis` API (no `cargo-semver-checks` break — verified).

## Test plan

- New unit tests (no tsgo needed): `test_vfor_source_nested_in_vif_is_wrapped_for_narrowing` (loop wrapped inside the enclosing guard) and `test_vfor_with_nested_vif_in_body_is_not_wrapped` (a `v-if` *inside* the body must not wrap the loop — no over-narrowing).
- New batch type-checker tests: `batch_type_checker_narrows_v_for_source_by_enclosing_v_if` (0 diagnostics for the repro) and `batch_type_checker_keeps_v_for_error_without_enclosing_v_if` (TS2345 still reported when there is no enclosing `v-if`).
- Updated `virtual_ts_nested_v_if_v_else` snapshot: the v-for inside a v-else branch is now wrapped in the branch guard (intended).
- Verified the built `vize check` on the repro and variations: repro now reports **0 errors**; `v-if="key === 'a'"` correctly errors with `number` not assignable to `string`; no-v-if still errors; plain v-for, v-else, and nested v-if all behave correctly.

Gates: `cargo test -p vize_canon` (350 pass), `cargo fmt -p vize_canon -- --check` clean, `cargo clippy -p vize_canon --lib -- -D warnings` clean, `cargo semver-checks` clean for `vize_canon`.

Closes #1511

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1520"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->