### PR TITLE
test(jsx): backend-separated JSX/TSX parity suite and inventory (#1491)

### DIFF
--- a/crates/vize_atelier_jsx/tests/PARITY_INVENTORY.md
+++ b/crates/vize_atelier_jsx/tests/PARITY_INVENTORY.md
@@ -14,11 +14,11 @@ codegen, so hoisting and block-tree details are intentionally Vize-shaped.
 
 Suites are split so a failure points at the correct backend:
 
-| Suite | File | Backend | Passing | Ignored |
-| --- | --- | --- | --- | --- |
-| VDOM parity | `tests/parity_vdom.rs` | `compile_to_dom` | 41 | 2 |
-| Vapor parity | `tests/parity_vapor.rs` | `compile_to_vapor` | 24 | 0 |
-| TSX + modes | `tests/parity_tsx.rs` | both | 10 | 0 |
+| Suite        | File                    | Backend            | Passing | Ignored |
+| ------------ | ----------------------- | ------------------ | ------- | ------- |
+| VDOM parity  | `tests/parity_vdom.rs`  | `compile_to_dom`   | 41      | 2       |
+| Vapor parity | `tests/parity_vapor.rs` | `compile_to_vapor` | 24      | 0       |
+| TSX + modes  | `tests/parity_tsx.rs`   | both               | 10      | 0       |
 
 The lower-level IR-shape tests (`tests/elements.rs`, `attributes.rs`,
 `children.rs`, `components.rs`, `slots.rs`, `control_flow.rs`, `events.rs`,
@@ -27,58 +27,58 @@ fine-grained lowering coverage; this inventory tracks the **parity** layer.
 
 ## Covered categories
 
-| Category | Reference case | VDOM | Vapor | TSX |
-| --- | --- | :---: | :---: | :---: |
-| **Elements** | intrinsic → `createElementBlock` / `_template` | ✅ | ✅ | |
-| | component (PascalCase) resolution | ✅ | ✅ | |
-| | fragment (`<>…</>`) | ✅ | ✅ | |
-| | member-expr / namespaced tags | ✅ (lowering) | | |
-| **Attributes** | static (inlined, no patch flag / baked into template) | ✅ | ✅ | |
-| | boolean (`disabled`) | ✅ | | |
-| | dynamic `{expr}` → `PROPS` flag + dynamic-key array / `setProp` | ✅ | ✅ | |
-| | multiple dynamic keys collected | ✅ | | |
-| | spread `{...props}` → `FULL_PROPS` / `setDynamicProps` | ✅ | ✅ | |
-| | spread + static → `mergeProps` | ✅ | | |
-| | dynamic class → `normalizeClass` + `CLASS` flag / `setClass` | ✅ | ✅ | |
-| | array class binding | ✅ | | |
-| | dynamic style → `normalizeStyle` + `STYLE` flag / `setStyle` | ✅ | ✅ | |
-| | namespaced `xlink:href` | ✅ | | |
-| | `key` (reserved, no patch flag) | ✅ | | |
-| | `ref` → `NEED_PATCH` flag | ✅ | | |
-| **Children** | static text (no flag / baked) | ✅ | ✅ | |
-| | interpolation → `toDisplayString` + `TEXT` flag / `setText` | ✅ | ✅ | |
-| | mixed text + interpolation concatenation | ✅ | ✅ | |
-| | free identifiers stay bare (no `_ctx.`) | ✅ | ✅ | |
-| | member-expr interpolation stays bare | | ✅ | |
-| **Control flow** | `cond && <x/>` → `v-if` / `createIf` | ✅ | ✅ | |
-| | `cond ? <a/> : <b/>` → two-branch `v-if` / `createIf` | ✅ | ✅ | |
-| | `list.map(...)` → `v-for` (`UNKEYED_FRAGMENT`) / `createFor` | ✅ | ✅ | |
-| | `v-if` directive on element | ✅ | | |
-| | non-JSX `&&` stays interpolation (regression) | ✅ | | |
-| **Directives** | `v-model` on input → `vModelText` + `onUpdate:modelValue` / `applyTextModel` | ✅ | ✅ | |
-| | `v-model` on checkbox → `vModelCheckbox` | ✅ | | |
-| | `v-model` on component → `modelValue` prop | ✅ | ✅ | |
-| | `v-model:foo` named arg → `foo` + `onUpdate:foo` | ✅ | | |
-| | `v-show` → `vShow` / `applyVShow` | ✅ | ✅ | |
-| | `v-html` → `innerHTML` prop | ✅ | | |
-| | `v-text` → `textContent` prop | ✅ | | |
-| | custom directive `v-foo` → `resolveDirective` | ✅ | | |
-| **Events** | plain `onClick` → bind prop | ✅ | ✅ | |
-| | capture modifier (`onClickCapture`) → suffix key + `NEED_HYDRATION` / `_on{capture}` | ✅ | ✅ | |
-| | once modifier (`onClickOnce`) | ✅ | | |
-| | composed passive+capture | ✅ | | |
-| **Slots** | object child named slots → `_withCtx` + `_: 1 /* STABLE */` / slot fn | ✅ | ✅ | |
-| | render-prop child → default scoped slot | ✅ | | |
-| | scoped named slot (destructured param stays bare) | ✅ | | |
-| | plain element children → implicit default slot | ✅ | | |
-| **TSX** | typed arrow component → both backends | | | ✅ |
-| | generic component call `<List<number>/>` | | | ✅ |
-| | `as` cast inside interpolation (type-stripped by codegen) | | | ✅ |
-| | non-null assertion in binding (type-stripped by codegen) | | | ✅ |
-| | TS annotation rejected in `.jsx` mode | | | ✅ |
-| **Modes** | default mode (vdom / vapor) | ✅ | ✅ | ✅ |
-| | `"use vue:vapor"` / `"use vue:vdom"` prologue | ✅ | | ✅ |
-| | mixed module, per-component mode | | | ✅ |
+| Category         | Reference case                                                                       |     VDOM      | Vapor | TSX |
+| ---------------- | ------------------------------------------------------------------------------------ | :-----------: | :---: | :-: |
+| **Elements**     | intrinsic → `createElementBlock` / `_template`                                       |      ✅       |  ✅   |     |
+|                  | component (PascalCase) resolution                                                    |      ✅       |  ✅   |     |
+|                  | fragment (`<>…</>`)                                                                  |      ✅       |  ✅   |     |
+|                  | member-expr / namespaced tags                                                        | ✅ (lowering) |       |     |
+| **Attributes**   | static (inlined, no patch flag / baked into template)                                |      ✅       |  ✅   |     |
+|                  | boolean (`disabled`)                                                                 |      ✅       |       |     |
+|                  | dynamic `{expr}` → `PROPS` flag + dynamic-key array / `setProp`                      |      ✅       |  ✅   |     |
+|                  | multiple dynamic keys collected                                                      |      ✅       |       |     |
+|                  | spread `{...props}` → `FULL_PROPS` / `setDynamicProps`                               |      ✅       |  ✅   |     |
+|                  | spread + static → `mergeProps`                                                       |      ✅       |       |     |
+|                  | dynamic class → `normalizeClass` + `CLASS` flag / `setClass`                         |      ✅       |  ✅   |     |
+|                  | array class binding                                                                  |      ✅       |       |     |
+|                  | dynamic style → `normalizeStyle` + `STYLE` flag / `setStyle`                         |      ✅       |  ✅   |     |
+|                  | namespaced `xlink:href`                                                              |      ✅       |       |     |
+|                  | `key` (reserved, no patch flag)                                                      |      ✅       |       |     |
+|                  | `ref` → `NEED_PATCH` flag                                                            |      ✅       |       |     |
+| **Children**     | static text (no flag / baked)                                                        |      ✅       |  ✅   |     |
+|                  | interpolation → `toDisplayString` + `TEXT` flag / `setText`                          |      ✅       |  ✅   |     |
+|                  | mixed text + interpolation concatenation                                             |      ✅       |  ✅   |     |
+|                  | free identifiers stay bare (no `_ctx.`)                                              |      ✅       |  ✅   |     |
+|                  | member-expr interpolation stays bare                                                 |               |  ✅   |     |
+| **Control flow** | `cond && <x/>` → `v-if` / `createIf`                                                 |      ✅       |  ✅   |     |
+|                  | `cond ? <a/> : <b/>` → two-branch `v-if` / `createIf`                                |      ✅       |  ✅   |     |
+|                  | `list.map(...)` → `v-for` (`UNKEYED_FRAGMENT`) / `createFor`                         |      ✅       |  ✅   |     |
+|                  | `v-if` directive on element                                                          |      ✅       |       |     |
+|                  | non-JSX `&&` stays interpolation (regression)                                        |      ✅       |       |     |
+| **Directives**   | `v-model` on input → `vModelText` + `onUpdate:modelValue` / `applyTextModel`         |      ✅       |  ✅   |     |
+|                  | `v-model` on checkbox → `vModelCheckbox`                                             |      ✅       |       |     |
+|                  | `v-model` on component → `modelValue` prop                                           |      ✅       |  ✅   |     |
+|                  | `v-model:foo` named arg → `foo` + `onUpdate:foo`                                     |      ✅       |       |     |
+|                  | `v-show` → `vShow` / `applyVShow`                                                    |      ✅       |  ✅   |     |
+|                  | `v-html` → `innerHTML` prop                                                          |      ✅       |       |     |
+|                  | `v-text` → `textContent` prop                                                        |      ✅       |       |     |
+|                  | custom directive `v-foo` → `resolveDirective`                                        |      ✅       |       |     |
+| **Events**       | plain `onClick` → bind prop                                                          |      ✅       |  ✅   |     |
+|                  | capture modifier (`onClickCapture`) → suffix key + `NEED_HYDRATION` / `_on{capture}` |      ✅       |  ✅   |     |
+|                  | once modifier (`onClickOnce`)                                                        |      ✅       |       |     |
+|                  | composed passive+capture                                                             |      ✅       |       |     |
+| **Slots**        | object child named slots → `_withCtx` + `_: 1 /* STABLE */` / slot fn                |      ✅       |  ✅   |     |
+|                  | render-prop child → default scoped slot                                              |      ✅       |       |     |
+|                  | scoped named slot (destructured param stays bare)                                    |      ✅       |       |     |
+|                  | plain element children → implicit default slot                                       |      ✅       |       |     |
+| **TSX**          | typed arrow component → both backends                                                |               |       | ✅  |
+|                  | generic component call `<List<number>/>`                                             |               |       | ✅  |
+|                  | `as` cast inside interpolation (type-stripped by codegen)                            |               |       | ✅  |
+|                  | non-null assertion in binding (type-stripped by codegen)                             |               |       | ✅  |
+|                  | TS annotation rejected in `.jsx` mode                                                |               |       | ✅  |
+| **Modes**        | default mode (vdom / vapor)                                                          |      ✅       |  ✅   | ✅  |
+|                  | `"use vue:vapor"` / `"use vue:vdom"` prologue                                        |      ✅       |       | ✅  |
+|                  | mixed module, per-component mode                                                     |               |       | ✅  |
 
 ## Explicitly deferred
 
@@ -86,17 +86,17 @@ fine-grained lowering coverage; this inventory tracks the **parity** layer.
 
 Tracked as `#[ignore = "deferred: …"]` in `tests/parity_vdom.rs`:
 
-| Case | Reason | Tracking |
-| --- | --- | --- |
-| `v-model` modifier-array form `{[val, ['trim']]}` | Lowers to a malformed nested `$event => ($event => …)` chain instead of attaching `.trim` as a model modifier. | this inventory / #1491 |
-| `v-model_lazy` suffix-modifier form | babel-jsx's `v-model_lazy` / `v-model_number` underscore-suffix syntax resolves as a `model_lazy` **custom directive** instead of a lazy v-model modifier. | this inventory / #1491 |
+| Case                                              | Reason                                                                                                                                                     | Tracking               |
+| ------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------- |
+| `v-model` modifier-array form `{[val, ['trim']]}` | Lowers to a malformed nested `$event => ($event => …)` chain instead of attaching `.trim` as a model modifier.                                             | this inventory / #1491 |
+| `v-model_lazy` suffix-modifier form               | babel-jsx's `v-model_lazy` / `v-model_number` underscore-suffix syntax resolves as a `model_lazy` **custom directive** instead of a lazy v-model modifier. | this inventory / #1491 |
 
 ### Type-level / resolve-type parity — deferred
 
 `@vue/babel-plugin-jsx`'s `resolveType` (deriving runtime props/emits from TS
 type annotations) and broader type-level parity require the type-resolution
 infrastructure that is not yet wired through this crate. Deferred pending the
-type-checker work in **#1497 / #1502**. The current TSX suite covers *syntax*
+type-checker work in **#1497 / #1502**. The current TSX suite covers _syntax_
 acceptance and type-stripping, not type-driven prop/emit generation.
 
 ### Ecosystem testbeds — deferred (network / CI infra)
@@ -106,9 +106,9 @@ corpora and real-world component-library testbeds requires cloning external
 repos and network access, which is unavailable in this build and gated on CI
 infrastructure:
 
-| Testbed | Repo | Reason deferred |
-| --- | --- | --- |
-| Vuetify | `vuetifyjs/vuetify` | Network clone + CI build matrix required. |
+| Testbed  | Repo                | Reason deferred                           |
+| -------- | ------------------- | ----------------------------------------- |
+| Vuetify  | `vuetifyjs/vuetify` | Network clone + CI build matrix required. |
 | Naive UI | `tusen-ai/naive-ui` | Network clone + CI build matrix required. |
 
 These are tracked as the ecosystem-CI portion of **#1491** and are **not** closed

--- a/crates/vize_atelier_jsx/tests/PARITY_INVENTORY.md
+++ b/crates/vize_atelier_jsx/tests/PARITY_INVENTORY.md
@@ -1,0 +1,115 @@
+# JSX/TSX Parity Inventory (Part of #1491)
+
+A tracked matrix of the JSX/TSX parity surface for `vize_atelier_jsx`: which
+reference cases (from `@vue/babel-plugin-jsx` and `vue-jsx-vapor`) are **covered**
+by an executable test, the **backend** that covers them, and which are
+**explicitly deferred** with a reason.
+
+These tests assert **Vize's** output structure (helper calls, patch flags,
+template strings, slot objects, `v-if`/`v-for`/`v-model` shapes), not byte-for-byte
+babel parity — Vize emits through its own `vize_atelier_dom` / `vize_atelier_vapor`
+codegen, so hoisting and block-tree details are intentionally Vize-shaped.
+
+## Backend separation
+
+Suites are split so a failure points at the correct backend:
+
+| Suite | File | Backend | Passing | Ignored |
+| --- | --- | --- | --- | --- |
+| VDOM parity | `tests/parity_vdom.rs` | `compile_to_dom` | 41 | 2 |
+| Vapor parity | `tests/parity_vapor.rs` | `compile_to_vapor` | 24 | 0 |
+| TSX + modes | `tests/parity_tsx.rs` | both | 10 | 0 |
+
+The lower-level IR-shape tests (`tests/elements.rs`, `attributes.rs`,
+`children.rs`, `components.rs`, `slots.rs`, `control_flow.rs`, `events.rs`,
+`directives.rs`, `modes.rs`, `tsx.rs`, `dom.rs`, `vapor.rs`) remain the
+fine-grained lowering coverage; this inventory tracks the **parity** layer.
+
+## Covered categories
+
+| Category | Reference case | VDOM | Vapor | TSX |
+| --- | --- | :---: | :---: | :---: |
+| **Elements** | intrinsic → `createElementBlock` / `_template` | ✅ | ✅ | |
+| | component (PascalCase) resolution | ✅ | ✅ | |
+| | fragment (`<>…</>`) | ✅ | ✅ | |
+| | member-expr / namespaced tags | ✅ (lowering) | | |
+| **Attributes** | static (inlined, no patch flag / baked into template) | ✅ | ✅ | |
+| | boolean (`disabled`) | ✅ | | |
+| | dynamic `{expr}` → `PROPS` flag + dynamic-key array / `setProp` | ✅ | ✅ | |
+| | multiple dynamic keys collected | ✅ | | |
+| | spread `{...props}` → `FULL_PROPS` / `setDynamicProps` | ✅ | ✅ | |
+| | spread + static → `mergeProps` | ✅ | | |
+| | dynamic class → `normalizeClass` + `CLASS` flag / `setClass` | ✅ | ✅ | |
+| | array class binding | ✅ | | |
+| | dynamic style → `normalizeStyle` + `STYLE` flag / `setStyle` | ✅ | ✅ | |
+| | namespaced `xlink:href` | ✅ | | |
+| | `key` (reserved, no patch flag) | ✅ | | |
+| | `ref` → `NEED_PATCH` flag | ✅ | | |
+| **Children** | static text (no flag / baked) | ✅ | ✅ | |
+| | interpolation → `toDisplayString` + `TEXT` flag / `setText` | ✅ | ✅ | |
+| | mixed text + interpolation concatenation | ✅ | ✅ | |
+| | free identifiers stay bare (no `_ctx.`) | ✅ | ✅ | |
+| | member-expr interpolation stays bare | | ✅ | |
+| **Control flow** | `cond && <x/>` → `v-if` / `createIf` | ✅ | ✅ | |
+| | `cond ? <a/> : <b/>` → two-branch `v-if` / `createIf` | ✅ | ✅ | |
+| | `list.map(...)` → `v-for` (`UNKEYED_FRAGMENT`) / `createFor` | ✅ | ✅ | |
+| | `v-if` directive on element | ✅ | | |
+| | non-JSX `&&` stays interpolation (regression) | ✅ | | |
+| **Directives** | `v-model` on input → `vModelText` + `onUpdate:modelValue` / `applyTextModel` | ✅ | ✅ | |
+| | `v-model` on checkbox → `vModelCheckbox` | ✅ | | |
+| | `v-model` on component → `modelValue` prop | ✅ | ✅ | |
+| | `v-model:foo` named arg → `foo` + `onUpdate:foo` | ✅ | | |
+| | `v-show` → `vShow` / `applyVShow` | ✅ | ✅ | |
+| | `v-html` → `innerHTML` prop | ✅ | | |
+| | `v-text` → `textContent` prop | ✅ | | |
+| | custom directive `v-foo` → `resolveDirective` | ✅ | | |
+| **Events** | plain `onClick` → bind prop | ✅ | ✅ | |
+| | capture modifier (`onClickCapture`) → suffix key + `NEED_HYDRATION` / `_on{capture}` | ✅ | ✅ | |
+| | once modifier (`onClickOnce`) | ✅ | | |
+| | composed passive+capture | ✅ | | |
+| **Slots** | object child named slots → `_withCtx` + `_: 1 /* STABLE */` / slot fn | ✅ | ✅ | |
+| | render-prop child → default scoped slot | ✅ | | |
+| | scoped named slot (destructured param stays bare) | ✅ | | |
+| | plain element children → implicit default slot | ✅ | | |
+| **TSX** | typed arrow component → both backends | | | ✅ |
+| | generic component call `<List<number>/>` | | | ✅ |
+| | `as` cast inside interpolation (type-stripped by codegen) | | | ✅ |
+| | non-null assertion in binding (type-stripped by codegen) | | | ✅ |
+| | TS annotation rejected in `.jsx` mode | | | ✅ |
+| **Modes** | default mode (vdom / vapor) | ✅ | ✅ | ✅ |
+| | `"use vue:vapor"` / `"use vue:vdom"` prologue | ✅ | | ✅ |
+| | mixed module, per-component mode | | | ✅ |
+
+## Explicitly deferred
+
+### Compiler features Vize does not yet handle (ignored tests, never red)
+
+Tracked as `#[ignore = "deferred: …"]` in `tests/parity_vdom.rs`:
+
+| Case | Reason | Tracking |
+| --- | --- | --- |
+| `v-model` modifier-array form `{[val, ['trim']]}` | Lowers to a malformed nested `$event => ($event => …)` chain instead of attaching `.trim` as a model modifier. | this inventory / #1491 |
+| `v-model_lazy` suffix-modifier form | babel-jsx's `v-model_lazy` / `v-model_number` underscore-suffix syntax resolves as a `model_lazy` **custom directive** instead of a lazy v-model modifier. | this inventory / #1491 |
+
+### Type-level / resolve-type parity — deferred
+
+`@vue/babel-plugin-jsx`'s `resolveType` (deriving runtime props/emits from TS
+type annotations) and broader type-level parity require the type-resolution
+infrastructure that is not yet wired through this crate. Deferred pending the
+type-checker work in **#1497 / #1502**. The current TSX suite covers *syntax*
+acceptance and type-stripping, not type-driven prop/emit generation.
+
+### Ecosystem testbeds — deferred (network / CI infra)
+
+Running the full `@vue/babel-plugin-jsx` + `vue-jsx-vapor` reference fixture
+corpora and real-world component-library testbeds requires cloning external
+repos and network access, which is unavailable in this build and gated on CI
+infrastructure:
+
+| Testbed | Repo | Reason deferred |
+| --- | --- | --- |
+| Vuetify | `vuetifyjs/vuetify` | Network clone + CI build matrix required. |
+| Naive UI | `tusen-ai/naive-ui` | Network clone + CI build matrix required. |
+
+These are tracked as the ecosystem-CI portion of **#1491** and are **not** closed
+by this PR. This PR delivers the parity-suite + inventory **foundation** only.

--- a/crates/vize_atelier_jsx/tests/parity_tsx.rs
+++ b/crates/vize_atelier_jsx/tests/parity_tsx.rs
@@ -1,0 +1,140 @@
+//! TSX-syntax + mode-directive parity suite (Part of #1491).
+//!
+//! Covers the TSX-specific surface (type annotations, generic component calls,
+//! `as` casts, non-null assertions) plus the `"use vue:vapor"` / `"use vue:vdom"`
+//! mode-directive prologue and mixed VDOM/Vapor modules — verifying TSX flows
+//! cleanly through both backends and that per-component mode selection holds.
+
+use vize_atelier_jsx::{
+    DomCompileOptions, JsxLang, JsxOutputMode, VaporCompileOptions, compile_to_dom,
+    compile_to_vapor, lower_source,
+};
+use vize_carton::Bump;
+
+fn dom_tsx(src: &str) -> vize_carton::String {
+    let bump = Bump::new();
+    let out = compile_to_dom(&bump, src, JsxLang::Tsx, DomCompileOptions::default());
+    assert!(!out.has_errors(), "diagnostics: {:?}", out.diagnostics);
+    assert_eq!(out.components.len(), 1, "expected one component");
+    out.components.into_iter().next().unwrap().code
+}
+
+fn vapor_tsx(src: &str) -> vize_carton::String {
+    let bump = Bump::new();
+    let out = compile_to_vapor(&bump, src, JsxLang::Tsx, VaporCompileOptions::default());
+    assert!(!out.has_errors(), "diagnostics: {:?}", out.diagnostics);
+    assert_eq!(out.components.len(), 1, "expected one component");
+    out.components.into_iter().next().unwrap().code
+}
+
+// ---------------------------------------------------------------------------
+// Category: TSX type syntax flows through to both backends
+// ---------------------------------------------------------------------------
+
+#[test]
+fn typed_arrow_component_compiles_to_vdom() {
+    let code = dom_tsx("const A = (props: { id: number }): JSX.Element => <div id={props.id}/>;");
+    assert!(code.contains("id: props.id"), "{code}");
+    assert!(code.contains("8 /* PROPS */"), "{code}");
+}
+
+#[test]
+fn typed_arrow_component_compiles_to_vapor() {
+    let code = vapor_tsx("const A = (): JSX.Element => <span>{label}</span>;");
+    assert!(code.contains("_toDisplayString(label)"), "{code}");
+    assert!(!code.contains("_ctx.label"), "{code}");
+}
+
+#[test]
+fn generic_component_call_resolves_as_a_component() {
+    // `<List<number> .../>` — the type argument is stripped, `List` resolves.
+    let code = dom_tsx("const A = () => <List<number> items={xs}/>;");
+    assert!(code.contains("_resolveComponent(\"List\")"), "{code}");
+    assert!(code.contains("items: xs"), "{code}");
+}
+
+#[test]
+fn as_cast_inside_interpolation_is_type_stripped_in_codegen() {
+    // The `as` cast survives lowering (see tests/tsx.rs) but VDOM codegen runs
+    // the expression through the JS code generator, which drops the type cast.
+    let code = dom_tsx("const A = () => <p>{(x as string)}</p>;");
+    assert!(code.contains("_toDisplayString(x)"), "{code}");
+}
+
+#[test]
+fn non_null_assertion_in_binding_is_type_stripped_in_codegen() {
+    // The `!` assertion is recovered at the IR level (tests/tsx.rs) but codegen
+    // strips it; the binding still emits as a dynamic `PROPS` prop.
+    let code = dom_tsx("const A = () => <div title={el!}/>;");
+    assert!(code.contains("title: el"), "{code}");
+    assert!(code.contains("8 /* PROPS */"), "{code}");
+}
+
+#[test]
+fn tsx_type_annotation_is_an_error_when_parsed_as_plain_jsx() {
+    // The same source is a hard parse error in `.jsx` mode — guards the lang flag.
+    let bump = Bump::new();
+    let out = lower_source(
+        &bump,
+        "const A = (props: { id: number }) => <div/>;",
+        JsxLang::Jsx,
+    );
+    assert!(out.has_errors(), "expected a JSX-mode parse error");
+}
+
+// ---------------------------------------------------------------------------
+// Category: mode directives + mixed VDOM/Vapor module
+// ---------------------------------------------------------------------------
+
+#[test]
+fn default_mode_is_vdom_for_dom_backend() {
+    let bump = Bump::new();
+    let out = compile_to_dom(
+        &bump,
+        "const A = () => <div/>;",
+        JsxLang::Tsx,
+        DomCompileOptions::default(),
+    );
+    assert_eq!(out.components[0].mode, JsxOutputMode::Vdom);
+}
+
+#[test]
+fn use_vue_vapor_directive_is_surfaced_on_component_mode() {
+    let bump = Bump::new();
+    let out = compile_to_dom(
+        &bump,
+        "const A = () => { \"use vue:vapor\"; return <div/>; };",
+        JsxLang::Tsx,
+        DomCompileOptions::default(),
+    );
+    assert_eq!(out.components[0].mode, JsxOutputMode::Vapor);
+}
+
+#[test]
+fn use_vue_vdom_directive_overrides_vapor_default() {
+    let bump = Bump::new();
+    let out = compile_to_vapor(
+        &bump,
+        "const A = () => { \"use vue:vdom\"; return <div/>; };",
+        JsxLang::Tsx,
+        VaporCompileOptions::default(),
+    );
+    assert_eq!(out.components[0].mode, JsxOutputMode::Vdom);
+}
+
+#[test]
+fn mixed_module_selects_mode_per_component() {
+    // One Vapor-directed component and one default component in the same module;
+    // lowering records the per-component mode override.
+    let bump = Bump::new();
+    let out = lower_source(
+        &bump,
+        "const A = () => { \"use vue:vapor\"; return <a/>; };\nconst B = () => <b/>;",
+        JsxLang::Tsx,
+    );
+    assert_eq!(out.roots.len(), 2);
+    assert_eq!(out.roots[0].mode, Some(JsxOutputMode::Vapor));
+    assert_eq!(out.roots[0].component_name.as_deref(), Some("A"));
+    assert_eq!(out.roots[1].mode, None);
+    assert_eq!(out.roots[1].component_name.as_deref(), Some("B"));
+}

--- a/crates/vize_atelier_jsx/tests/parity_vapor.rs
+++ b/crates/vize_atelier_jsx/tests/parity_vapor.rs
@@ -1,0 +1,253 @@
+//! Vapor-backend JSX/TSX parity suite (Part of #1491).
+//!
+//! These mirror the reference areas of `vue-jsx-vapor` (compiler-rs) but assert
+//! **Vize's** Vapor codegen output — `_template` strings, `_renderEffect` /
+//! `_setProp` / `_setText` effects, `_createIf` / `_createFor` blocks, slot
+//! objects on `_createComponentWithFallback` — rather than byte-for-byte parity,
+//! since Vize emits through its own `vize_atelier_vapor` codegen path.
+//!
+//! Backend separation: every failure here points at the **Vapor** lowering +
+//! codegen path. The VDOM mirror lives in `parity_vdom.rs`. See
+//! `PARITY_INVENTORY.md` for the full covered-vs-deferred matrix.
+
+use vize_atelier_jsx::{JsxLang, VaporCompileOptions, compile_to_vapor};
+use vize_carton::Bump;
+
+/// Compile JSX to Vapor render code, asserting a single error-free component.
+fn vapor(src: &str) -> vize_carton::String {
+    let bump = Bump::new();
+    let out = compile_to_vapor(&bump, src, JsxLang::Jsx, VaporCompileOptions::default());
+    assert!(!out.has_errors(), "diagnostics: {:?}", out.diagnostics);
+    assert_eq!(out.components.len(), 1, "expected one component");
+    out.components.into_iter().next().unwrap().code
+}
+
+// ---------------------------------------------------------------------------
+// Category: elements / intrinsic vs component resolution / fragments
+// ---------------------------------------------------------------------------
+
+#[test]
+fn intrinsic_element_is_baked_into_a_template() {
+    let code = vapor("const A = () => <div/>;");
+    assert!(code.contains("_template(\"<div>"), "{code}");
+    assert!(code.contains("export function render"), "{code}");
+}
+
+#[test]
+fn component_resolves_and_uses_create_component_with_fallback() {
+    let code = vapor("const A = () => <Comp/>;");
+    assert!(code.contains("_resolveComponent(\"Comp\")"), "{code}");
+    assert!(
+        code.contains("_createComponentWithFallback(_component_Comp"),
+        "{code}"
+    );
+}
+
+#[test]
+fn fragment_returns_an_array_of_template_nodes() {
+    let code = vapor("const A = () => <><a/><b/></>;");
+    assert!(code.contains("_template(\"<a>"), "{code}");
+    assert!(code.contains("_template(\"<b>"), "{code}");
+    assert!(code.contains("return [n0, n1]"), "{code}");
+}
+
+// ---------------------------------------------------------------------------
+// Category: attributes (static / dynamic / spread / class / style)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn static_attributes_are_baked_into_the_template() {
+    let code = vapor("const A = () => <div class=\"a\" id=\"b\" data-x=\"y\"/>;");
+    assert!(
+        code.contains("<div class=\\\"a\\\" id=\\\"b\\\" data-x=\\\"y\\\">"),
+        "{code}"
+    );
+}
+
+#[test]
+fn dynamic_bind_uses_render_effect_set_prop() {
+    let code = vapor("const A = () => <div id={x}/>;");
+    assert!(code.contains("_renderEffect("), "{code}");
+    assert!(code.contains("_setProp(n0, \"id\", x)"), "{code}");
+    assert!(!code.contains("_ctx.x"), "{code}");
+}
+
+#[test]
+fn spread_uses_set_dynamic_props() {
+    let code = vapor("const A = () => <div {...attrs}/>;");
+    assert!(code.contains("_setDynamicProps(n0, [attrs])"), "{code}");
+    assert!(!code.contains("_ctx.attrs"), "{code}");
+}
+
+#[test]
+fn dynamic_class_uses_set_class() {
+    let code = vapor("const A = () => <div class={c}/>;");
+    assert!(code.contains("_setClass(n0, c)"), "{code}");
+}
+
+#[test]
+fn dynamic_style_uses_set_style() {
+    let code = vapor("const A = () => <div style={s}/>;");
+    assert!(code.contains("_setStyle(n0, s)"), "{code}");
+}
+
+// ---------------------------------------------------------------------------
+// Category: children (text / interpolation / mixed)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn static_text_is_baked_into_the_template() {
+    let code = vapor("const A = () => <div>hello</div>;");
+    assert!(code.contains("_template(\"<div>hello</div>\""), "{code}");
+}
+
+#[test]
+fn interpolation_uses_render_effect_and_set_text() {
+    let code = vapor("const A = () => <div>{count}</div>;");
+    assert!(code.contains("_renderEffect("), "{code}");
+    assert!(code.contains("_setText("), "{code}");
+    assert!(code.contains("_toDisplayString(count)"), "{code}");
+    assert!(!code.contains("_ctx.count"), "{code}");
+}
+
+#[test]
+fn mixed_text_and_interpolation_concatenates_in_set_text() {
+    let code = vapor("const A = () => <div>Hi {name}!</div>;");
+    assert!(
+        code.contains("\"Hi \" + _toDisplayString(name) + \"!\""),
+        "{code}"
+    );
+    assert!(code.contains("_setText("), "{code}");
+}
+
+#[test]
+fn member_expression_interpolation_stays_bare() {
+    let code = vapor("const A = () => <p>{user.name}</p>;");
+    assert!(code.contains("_toDisplayString(user.name)"), "{code}");
+    assert!(!code.contains("_ctx.user"), "{code}");
+}
+
+// ---------------------------------------------------------------------------
+// Category: control flow — conditional (&&, ternary), list (.map)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn logical_and_jsx_child_uses_create_if() {
+    let code = vapor("const A = () => <ul>{ok && <span/>}</ul>;");
+    assert!(code.contains("_createIf("), "{code}");
+    assert!(code.contains("() => (ok)"), "{code}");
+    assert!(code.contains("\"<span></span>\""), "{code}");
+    assert!(!code.contains("_ctx."), "{code}");
+}
+
+#[test]
+fn ternary_jsx_arms_use_create_if_with_two_branches() {
+    let code = vapor("const A = () => <div>{ok ? <a/> : <b/>}</div>;");
+    assert!(code.contains("_createIf("), "{code}");
+    assert!(code.contains("\"<a></a>\""), "{code}");
+    assert!(code.contains("\"<b></b>\""), "{code}");
+}
+
+#[test]
+fn map_callback_uses_create_for() {
+    let code = vapor("const A = () => <ul>{items.map((i) => <li/>)}</ul>;");
+    assert!(code.contains("_createFor("), "{code}");
+    assert!(code.contains("() => (items)"), "{code}");
+    assert!(code.contains("\"<li></li>\""), "{code}");
+    assert!(!code.contains("_ctx."), "{code}");
+}
+
+// ---------------------------------------------------------------------------
+// Category: event handlers + option modifiers
+// ---------------------------------------------------------------------------
+
+#[test]
+fn plain_event_handler_is_set_as_a_prop() {
+    let code = vapor("const A = () => <button onClick={h}>go</button>;");
+    assert!(code.contains("onClick"), "{code}");
+    assert!(!code.contains("_ctx.h"), "{code}");
+}
+
+#[test]
+fn capture_option_modifier_uses_on_with_capture_option() {
+    // Vapor lowers `onClickCapture` to `_on(el, "click", invoker, { capture })`.
+    let code = vapor("const A = () => <button onClickCapture={h}/>;");
+    assert!(code.contains("_on(n0, \"click\""), "{code}");
+    assert!(code.contains("capture: true"), "{code}");
+}
+
+// ---------------------------------------------------------------------------
+// Category: directives — v-model, v-show
+// ---------------------------------------------------------------------------
+
+#[test]
+fn v_model_on_input_applies_text_model() {
+    let code = vapor("const A = () => <input v-model={val}/>;");
+    assert!(code.contains("_applyTextModel(n0"), "{code}");
+}
+
+#[test]
+fn v_model_on_component_uses_model_value_prop() {
+    let code = vapor("const A = () => <Input v-model={val}/>;");
+    assert!(code.contains("modelValue: () => (val)"), "{code}");
+    assert!(code.contains("\"onUpdate:modelValue\""), "{code}");
+}
+
+#[test]
+fn v_show_applies_runtime_directive() {
+    let code = vapor("const A = () => <div v-show={ok}>x</div>;");
+    assert!(code.contains("_applyVShow(n0"), "{code}");
+}
+
+// ---------------------------------------------------------------------------
+// Category: object slots / scoped slots / default render-prop slot
+// ---------------------------------------------------------------------------
+
+#[test]
+fn object_child_lowers_to_named_slot_function() {
+    let code = vapor("const A = () => <Comp>{{ header: () => <h1>Hi</h1> }}</Comp>;");
+    assert!(
+        code.contains("_createComponentWithFallback(_component_Comp"),
+        "{code}"
+    );
+    assert!(code.contains("\"header\": () =>"), "{code}");
+    assert!(code.contains("_template(\"<h1>Hi</h1>\")"), "{code}");
+}
+
+// ---------------------------------------------------------------------------
+// Category: module-level — preamble, multiple components, names
+// ---------------------------------------------------------------------------
+
+#[test]
+fn generated_code_imports_template_from_vue() {
+    let code = vapor("const A = () => <div>{count}</div>;");
+    assert!(code.contains("from 'vue'"), "{code}");
+    assert!(code.contains("_template"), "{code}");
+}
+
+#[test]
+fn templates_are_exposed_on_the_component() {
+    let bump = Bump::new();
+    let out = compile_to_vapor(
+        &bump,
+        "const A = () => <div class=\"x\"/>;",
+        JsxLang::Jsx,
+        VaporCompileOptions::default(),
+    );
+    assert!(!out.components[0].templates.is_empty());
+    assert!(out.components[0].templates[0].contains("<div"));
+}
+
+#[test]
+fn multiple_components_compile_independently_with_names() {
+    let bump = Bump::new();
+    let out = compile_to_vapor(
+        &bump,
+        "const A = () => <a/>;\nconst B = () => <b/>;",
+        JsxLang::Jsx,
+        VaporCompileOptions::default(),
+    );
+    assert_eq!(out.components.len(), 2);
+    assert_eq!(out.components[0].component_name.as_deref(), Some("A"));
+    assert_eq!(out.components[1].component_name.as_deref(), Some("B"));
+}

--- a/crates/vize_atelier_jsx/tests/parity_vdom.rs
+++ b/crates/vize_atelier_jsx/tests/parity_vdom.rs
@@ -1,0 +1,396 @@
+//! VDOM-backend JSX/TSX parity suite (Part of #1491).
+//!
+//! These cases mirror the reference areas of `@vue/babel-plugin-jsx` (elements,
+//! attributes, children, control flow, slots, directives, events) but assert
+//! **Vize's** VDOM codegen output structure — helper calls, patch flags, prop
+//! shapes — rather than byte-for-byte babel parity, since Vize emits through its
+//! own `vize_atelier_dom` codegen path.
+//!
+//! Backend separation: every failure here points at the **VDOM** lowering +
+//! codegen path. The Vapor mirror lives in `parity_vapor.rs`; TSX-specific
+//! parity lives in `parity_tsx.rs`. See `PARITY_INVENTORY.md` for the full
+//! covered-vs-deferred matrix.
+
+use vize_atelier_jsx::{DomCompileOptions, JsxLang, compile_to_dom};
+use vize_carton::Bump;
+
+/// Compile JSX to VDOM render code, asserting a single error-free component.
+fn dom(src: &str) -> vize_carton::String {
+    let bump = Bump::new();
+    let out = compile_to_dom(&bump, src, JsxLang::Jsx, DomCompileOptions::default());
+    assert!(!out.has_errors(), "diagnostics: {:?}", out.diagnostics);
+    assert_eq!(out.components.len(), 1, "expected one component");
+    out.components.into_iter().next().unwrap().code
+}
+
+// ---------------------------------------------------------------------------
+// Category: elements / intrinsic vs component resolution / fragments
+// ---------------------------------------------------------------------------
+
+#[test]
+fn intrinsic_element_uses_create_element_block() {
+    let code = dom("const A = () => <div/>;");
+    assert!(code.contains("_createElementBlock(\"div\")"), "{code}");
+    assert!(code.contains("_openBlock()"), "{code}");
+}
+
+#[test]
+fn component_is_resolved_and_created_as_block() {
+    // PascalCase tag => resolveComponent + createBlock (not createElementBlock).
+    let code = dom("const A = () => <Comp/>;");
+    assert!(code.contains("_resolveComponent(\"Comp\")"), "{code}");
+    assert!(code.contains("_createBlock(_component_Comp"), "{code}");
+    assert!(!code.contains("_createElementBlock(\"Comp\""), "{code}");
+}
+
+#[test]
+fn fragment_uses_stable_fragment_flag() {
+    let code = dom("const A = () => <><a/><b/></>;");
+    assert!(code.contains("_Fragment"), "{code}");
+    assert!(code.contains("64 /* STABLE_FRAGMENT */"), "{code}");
+}
+
+#[test]
+fn fragment_with_dynamic_child_keeps_stable_fragment() {
+    // A root fragment with mixed static + interpolation children.
+    let code = dom("const A = () => <><h1>a</h1><p>{x}</p></>;");
+    assert!(code.contains("_Fragment"), "{code}");
+    assert!(code.contains("64 /* STABLE_FRAGMENT */"), "{code}");
+    assert!(code.contains("_toDisplayString(x)"), "{code}");
+}
+
+// ---------------------------------------------------------------------------
+// Category: attributes (static / dynamic / spread / boolean / namespaced /
+// class / style) and their patch flags
+// ---------------------------------------------------------------------------
+
+#[test]
+fn static_attributes_are_inlined_with_no_patch_flag() {
+    // Purely static props => no patch flag, no dynamic-prop array.
+    let code = dom("const A = () => <div class=\"a\" id=\"b\"/>;");
+    assert!(code.contains("class: \"a\""), "{code}");
+    assert!(code.contains("id: \"b\""), "{code}");
+    assert!(!code.contains("/* PROPS */"), "{code}");
+}
+
+#[test]
+fn boolean_attribute_lowers_to_empty_string_value() {
+    let code = dom("const A = () => <input disabled/>;");
+    assert!(code.contains("disabled: \"\""), "{code}");
+}
+
+#[test]
+fn single_dynamic_bind_emits_props_flag_and_dynamic_key() {
+    let code = dom("const A = () => <div id={x}/>;");
+    assert!(code.contains("{ id: x }"), "{code}");
+    assert!(code.contains("8 /* PROPS */"), "{code}");
+    assert!(code.contains("[\"id\"]"), "{code}");
+}
+
+#[test]
+fn multiple_dynamic_binds_collect_all_dynamic_keys() {
+    let code = dom("const A = () => <div id={a} title={b}/>;");
+    assert!(code.contains("8 /* PROPS */"), "{code}");
+    assert!(code.contains("[\"id\", \"title\"]"), "{code}");
+}
+
+#[test]
+fn spread_alone_uses_normalize_and_guard_with_full_props() {
+    let code = dom("const A = () => <div {...attrs}/>;");
+    assert!(
+        code.contains("_normalizeProps(_guardReactiveProps(attrs))"),
+        "{code}"
+    );
+    assert!(code.contains("16 /* FULL_PROPS */"), "{code}");
+}
+
+#[test]
+fn spread_mixed_with_static_uses_merge_props() {
+    let code = dom("const A = () => <div class=\"a\" {...attrs}/>;");
+    assert!(
+        code.contains("_mergeProps({ class: \"a\" }, attrs)"),
+        "{code}"
+    );
+    assert!(code.contains("16 /* FULL_PROPS */"), "{code}");
+}
+
+#[test]
+fn dynamic_class_is_normalized_with_class_flag() {
+    let code = dom("const A = () => <div class={c}/>;");
+    assert!(code.contains("_normalizeClass(c)"), "{code}");
+    assert!(code.contains("2 /* CLASS */"), "{code}");
+}
+
+#[test]
+fn array_class_binding_is_normalized() {
+    let code = dom("const A = () => <div class={['a', b]}/>;");
+    assert!(code.contains("_normalizeClass(['a', b])"), "{code}");
+    assert!(code.contains("2 /* CLASS */"), "{code}");
+}
+
+#[test]
+fn dynamic_style_is_normalized_with_style_flag() {
+    let code = dom("const A = () => <div style={s}/>;");
+    assert!(code.contains("_normalizeStyle(s)"), "{code}");
+    assert!(code.contains("4 /* STYLE */"), "{code}");
+}
+
+#[test]
+fn namespaced_colon_attribute_name_is_preserved() {
+    let code = dom("const A = () => <use xlink:href=\"#id\"/>;");
+    assert!(code.contains("\"xlink:href\": \"#id\""), "{code}");
+}
+
+#[test]
+fn key_prop_does_not_become_a_dynamic_patch_prop() {
+    // `key` is a reserved VNode prop, not a regular patch prop.
+    let code = dom("const A = () => <div key={k}/>;");
+    assert!(code.contains("key: k"), "{code}");
+    assert!(!code.contains("/* PROPS */"), "{code}");
+}
+
+#[test]
+fn ref_prop_emits_need_patch_flag() {
+    let code = dom("const A = () => <div ref={r}/>;");
+    assert!(code.contains("ref: r"), "{code}");
+    assert!(code.contains("512 /* NEED_PATCH */"), "{code}");
+}
+
+// ---------------------------------------------------------------------------
+// Category: children (text / interpolation / mixed) and the TEXT patch flag
+// ---------------------------------------------------------------------------
+
+#[test]
+fn static_text_child_has_no_text_flag() {
+    let code = dom("const A = () => <div>hello</div>;");
+    assert!(code.contains("\"hello\""), "{code}");
+    assert!(!code.contains("/* TEXT */"), "{code}");
+}
+
+#[test]
+fn interpolation_child_uses_to_display_string_with_text_flag() {
+    let code = dom("const A = () => <div>{count}</div>;");
+    assert!(code.contains("_toDisplayString(count)"), "{code}");
+    assert!(code.contains("1 /* TEXT */"), "{code}");
+}
+
+#[test]
+fn mixed_text_and_interpolation_concatenates_with_text_flag() {
+    let code = dom("const A = () => <div>Hi {name}!</div>;");
+    assert!(
+        code.contains("\"Hi \" + _toDisplayString(name) + \"!\""),
+        "{code}"
+    );
+    assert!(code.contains("1 /* TEXT */"), "{code}");
+}
+
+#[test]
+fn jsx_free_identifiers_are_not_ctx_prefixed() {
+    // JSX render fns close over setup scope; interpolations stay bare.
+    let code = dom("const A = () => <div>{count}</div>;");
+    assert!(!code.contains("_ctx.count"), "{code}");
+}
+
+// ---------------------------------------------------------------------------
+// Category: control flow — conditional (&&, ternary), list (.map)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn logical_and_jsx_child_becomes_v_if() {
+    let code = dom("const A = () => <ul>{ok && <li/>}</ul>;");
+    assert!(!code.contains("_toDisplayString"), "{code}");
+    assert!(code.contains("_createElementBlock(\"li\""), "{code}");
+    assert!(code.contains("_createCommentVNode(\"v-if\""), "{code}");
+}
+
+#[test]
+fn ternary_jsx_arms_become_two_branch_v_if() {
+    let code = dom("const A = () => <div>{ok ? <a/> : <b/>}</div>;");
+    assert!(code.contains("_createElementBlock(\"a\""), "{code}");
+    assert!(code.contains("_createElementBlock(\"b\""), "{code}");
+    assert!(code.contains("key: 0"), "{code}");
+    assert!(code.contains("key: 1"), "{code}");
+}
+
+#[test]
+fn map_callback_becomes_v_for_with_unkeyed_fragment() {
+    let code = dom("const A = () => <ul>{items.map((i) => <li>{i}</li>)}</ul>;");
+    assert!(code.contains("_renderList(items"), "{code}");
+    assert!(code.contains("256 /* UNKEYED_FRAGMENT */"), "{code}");
+    assert!(code.contains("_toDisplayString(i)"), "{code}");
+}
+
+#[test]
+fn directive_v_if_on_element_compiles_to_conditional() {
+    let code = dom("const A = () => <div v-if={ok}>x</div>;");
+    assert!(code.contains("(ok)"), "{code}");
+    assert!(code.contains("_createCommentVNode"), "{code}");
+}
+
+#[test]
+fn non_jsx_logical_and_stays_an_interpolation() {
+    // `{a && b}` with no JSX is value coalescing, not conditional rendering.
+    let code = dom("const A = () => <div>{a && b}</div>;");
+    assert!(code.contains("_toDisplayString(a && b)"), "{code}");
+    assert!(!code.contains("_createCommentVNode(\"v-if\""), "{code}");
+}
+
+// ---------------------------------------------------------------------------
+// Category: directives — v-model (element/component/typed), v-show, v-html,
+// v-text, custom directives
+// ---------------------------------------------------------------------------
+
+#[test]
+fn v_model_on_input_expands_to_update_handler_and_directive() {
+    let code = dom("const A = () => <input v-model={val}/>;");
+    assert!(code.contains("\"onUpdate:modelValue\""), "{code}");
+    assert!(code.contains("_vModelText"), "{code}");
+    assert!(code.contains("_withDirectives"), "{code}");
+}
+
+#[test]
+fn v_model_on_checkbox_uses_checkbox_runtime_directive() {
+    let code = dom("const A = () => <input type=\"checkbox\" v-model={checked}/>;");
+    assert!(code.contains("_vModelCheckbox"), "{code}");
+    assert!(code.contains("\"onUpdate:modelValue\""), "{code}");
+}
+
+#[test]
+fn v_model_on_component_uses_model_value_prop() {
+    // On a component, v-model becomes `modelValue` + `onUpdate:modelValue`.
+    let code = dom("const A = () => <Input v-model={val}/>;");
+    assert!(code.contains("modelValue: val"), "{code}");
+    assert!(code.contains("\"onUpdate:modelValue\""), "{code}");
+    assert!(!code.contains("_vModelText"), "{code}");
+}
+
+#[test]
+fn v_model_with_named_argument_targets_that_prop() {
+    // `v-model:foo` => `foo` prop + `onUpdate:foo` handler.
+    let code = dom("const A = () => <Comp v-model:foo={val}/>;");
+    assert!(code.contains("foo: val"), "{code}");
+    assert!(code.contains("\"onUpdate:foo\""), "{code}");
+}
+
+#[test]
+fn v_show_keeps_element_and_applies_runtime_directive() {
+    let code = dom("const A = () => <div v-show={ok}>x</div>;");
+    assert!(code.contains("_vShow"), "{code}");
+    assert!(code.contains("_withDirectives"), "{code}");
+}
+
+#[test]
+fn v_html_lowers_to_inner_html_prop() {
+    let code = dom("const A = () => <div v-html={raw}/>;");
+    assert!(code.contains("innerHTML: raw"), "{code}");
+    assert!(code.contains("8 /* PROPS */"), "{code}");
+}
+
+#[test]
+fn v_text_lowers_to_text_content_prop() {
+    let code = dom("const A = () => <div v-text={msg}/>;");
+    assert!(
+        code.contains("textContent: _toDisplayString(msg)"),
+        "{code}"
+    );
+}
+
+#[test]
+fn custom_directive_resolves_and_applies() {
+    let code = dom("const A = () => <div v-foo={bar}/>;");
+    assert!(code.contains("_resolveDirective(\"foo\")"), "{code}");
+    assert!(code.contains("_withDirectives"), "{code}");
+}
+
+// ---------------------------------------------------------------------------
+// Category: event handlers + option modifiers
+// ---------------------------------------------------------------------------
+
+#[test]
+fn plain_event_handler_stays_a_bind_prop() {
+    let code = dom("const A = () => <button onClick={h}/>;");
+    assert!(code.contains("onClick: h"), "{code}");
+}
+
+#[test]
+fn capture_option_modifier_yields_capture_listener_key_with_hydration_flag() {
+    // `onClickCapture` is lowered to a `v-on` with a capture modifier; codegen
+    // emits the suffixed key and a NEED_HYDRATION patch flag.
+    let code = dom("const A = () => <button onClickCapture={h}/>;");
+    assert!(code.contains("onClickCapture: h"), "{code}");
+    assert!(code.contains("40 /* PROPS, NEED_HYDRATION */"), "{code}");
+}
+
+#[test]
+fn once_option_modifier_yields_once_listener_key() {
+    let code = dom("const A = () => <button onClickOnce={h}/>;");
+    assert!(code.contains("onClickOnce: h"), "{code}");
+}
+
+#[test]
+fn composed_passive_capture_yields_combined_listener_key() {
+    let code = dom("const A = () => <input onInputPassiveCapture={h}/>;");
+    assert!(code.contains("onInputPassiveCapture: h"), "{code}");
+}
+
+// ---------------------------------------------------------------------------
+// Category: object slots / scoped slots / default render-prop slot
+// ---------------------------------------------------------------------------
+
+#[test]
+fn object_child_lowers_to_named_with_ctx_slots() {
+    let code = dom("const A = () => <Comp>{{ header: () => <h1>Hi</h1> }}</Comp>;");
+    assert!(code.contains("header: _withCtx"), "{code}");
+    assert!(code.contains("_createElementVNode(\"h1\""), "{code}");
+    assert!(code.contains("_: 1 /* STABLE */"), "{code}");
+}
+
+#[test]
+fn render_prop_child_lowers_to_default_scoped_slot() {
+    let code = dom("const A = () => <List>{(item) => <li>{item}</li>}</List>;");
+    assert!(code.contains("default: _withCtx((item) =>"), "{code}");
+    assert!(code.contains("_toDisplayString(item)"), "{code}");
+    assert!(!code.contains("_ctx.item"), "{code}");
+}
+
+#[test]
+fn scoped_named_slot_keeps_destructured_param_bare() {
+    let code = dom("const A = () => <List>{{ item: ({ x }) => <li>{x}</li> }}</List>;");
+    assert!(code.contains("item: _withCtx(({ x }) =>"), "{code}");
+    assert!(!code.contains("_ctx.x"), "{code}");
+}
+
+#[test]
+fn plain_element_children_form_implicit_default_slot() {
+    let code = dom("const A = () => <Card><h1>Title</h1></Card>;");
+    assert!(code.contains("default: _withCtx(() =>"), "{code}");
+}
+
+// ---------------------------------------------------------------------------
+// Category: DEFERRED — see PARITY_INVENTORY.md.
+//
+// These are reference @vue/babel-plugin-jsx behaviors Vize does not yet handle
+// correctly; they are ignored (never red) and tracked in the inventory.
+// ---------------------------------------------------------------------------
+
+#[test]
+#[ignore = "deferred: v-model modifier-array form `{[val, ['trim']]}` lowers to a malformed nested $event chain; tracked in PARITY_INVENTORY.md / #1491"]
+fn v_model_with_modifier_array_is_not_yet_supported() {
+    let code = dom("const A = () => <input v-model={[val, ['trim']]}/>;");
+    // Reference babel-jsx attaches `.trim` as a model modifier; Vize currently
+    // emits `$event => ($event => (...))`. When fixed, assert a single clean
+    // update handler + a `modelModifiers` entry here.
+    assert!(!code.contains("$event => ($event =>"), "{code}");
+}
+
+#[test]
+#[ignore = "deferred: babel-jsx `v-model_lazy` suffix-modifier form resolves as a custom directive instead of a lazy model modifier; tracked in PARITY_INVENTORY.md / #1491"]
+fn v_model_underscore_suffix_modifier_is_not_yet_supported() {
+    let code = dom("const A = () => <input v-model_lazy={val}/>;");
+    // Reference treats the `_lazy` suffix as a v-model modifier; Vize resolves a
+    // `model_lazy` custom directive. When fixed, assert `lazy: true` modifier.
+    assert!(
+        !code.contains("_resolveDirective(\"model_lazy\")"),
+        "{code}"
+    );
+}


### PR DESCRIPTION
**Part of #1491** (does not close it — the ecosystem-CI portion is deferred, see below).

Builds the JSX/TSX parity **test foundation**: a structured, backend-separated parity suite mirroring the reference areas of `@vue/babel-plugin-jsx` and `vue-jsx-vapor`, split so a failure points at the correct backend, plus a tracked covered-vs-deferred inventory.

These assert **Vize's** output structure (helper calls, patch flags, `_template` strings, slot objects, `v-if`/`v-for`/`v-model` shapes), not byte-for-byte babel parity — Vize emits through its own `vize_atelier_dom` / `vize_atelier_vapor` codegen.

## What's added

| Suite | File | Backend | Passing | Ignored |
| --- | --- | --- | --- | --- |
| VDOM parity | `tests/parity_vdom.rs` | `compile_to_dom` | 41 | 2 |
| Vapor parity | `tests/parity_vapor.rs` | `compile_to_vapor` | 24 | 0 |
| TSX + modes | `tests/parity_tsx.rs` | both | 10 | 0 |
| Inventory | `tests/PARITY_INVENTORY.md` | — | — | — |

## Covered categories

- **Elements**: intrinsic vs PascalCase-component resolution, fragments (VDOM + Vapor).
- **Attributes**: static (inlined / baked), boolean, dynamic `{expr}` (+`PROPS` flag / `setProp`), multiple dynamic keys, spread `{...props}` (`FULL_PROPS`/`mergeProps` / `setDynamicProps`), dynamic + array class (`CLASS` / `setClass`), dynamic style (`STYLE` / `setStyle`), namespaced `xlink:href`, `key` (reserved), `ref` (`NEED_PATCH`).
- **Children**: static text, interpolation (`TEXT` flag / `setText`), mixed concatenation, member-expr, free identifiers stay bare (no `_ctx.`).
- **Control flow**: `&&` / ternary → `v-if`/`createIf`, `.map` → `v-for` (`UNKEYED_FRAGMENT`)/`createFor`, non-JSX `&&` regression.
- **Directives**: `v-model` (input/checkbox/component/`:named`), `v-show`, `v-html`, `v-text`, custom directive.
- **Events**: plain handler, capture/once/composed option modifiers (VDOM suffix-key + `NEED_HYDRATION`; Vapor `_on{capture}`).
- **Slots**: object named slots (`_withCtx` + `_: 1 /* STABLE */`), render-prop default scoped slot, scoped named slot bare param, implicit default slot.
- **TSX + modes**: typed arrow component, generic component call, `as`/non-null type-stripping, `.jsx`-mode rejection, `"use vue:vapor"`/`"use vue:vdom"` prologue, mixed per-component mode module.

## Deferred (tracked in `PARITY_INVENTORY.md`)

- **2 ignored tests** (never red) for compiler forms Vize doesn't yet handle: `v-model` modifier-array `{[val, ['trim']]}` (malformed nested `$event` chain) and the babel-jsx `v-model_lazy` underscore-suffix modifier (resolves as a custom directive).
- **resolve-type / type-level parity** (props/emits from TS types) — needs type-resolution infra; deferred to **#1497 / #1502**.
- **Ecosystem testbeds** (Vuetify `vuetifyjs/vuetify`, Naive UI `tusen-ai/naive-ui`) — require network clone + CI build matrix; deferred as the ecosystem-CI portion of #1491.

## Gates

- `cargo test -p vize_atelier_jsx` — all green (75 new parity assertions passing, 2 ignored, 0 failing).
- `cargo fmt -p vize_atelier_jsx -- --check` — clean.
- `cargo clippy -p vize_atelier_jsx --all-targets -- -D warnings` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1522"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->