### PR TITLE
bench(jsx): criterion benchmarks for JSX/TSX lowering and compile (#1501)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3485,6 +3485,7 @@ dependencies = [
 name = "vize_atelier_jsx"
 version = "0.206.0"
 dependencies = [
+ "criterion",
  "oxc_allocator",
  "oxc_ast",
  "oxc_ast_visit",

--- a/crates/vize_atelier_jsx/Cargo.toml
+++ b/crates/vize_atelier_jsx/Cargo.toml
@@ -24,8 +24,15 @@ oxc_syntax = { workspace = true }
 oxc_span = { workspace = true }
 oxc_diagnostics = { workspace = true }
 
+[dev-dependencies]
+criterion = { workspace = true }
+
 [features]
 default = []
 # Mirror the relief legacy surface so the `InterpolationNode::raw` field stays
 # in sync under workspace feature unification (see vize_armature's `legacy`).
 legacy = ["vize_relief/_legacy"]
+
+[[bench]]
+name = "jsx_compile"
+harness = false

--- a/crates/vize_atelier_jsx/benches/jsx_compile.rs
+++ b/crates/vize_atelier_jsx/benches/jsx_compile.rs
@@ -1,0 +1,153 @@
+//! Native Rust benchmarks for JSX/TSX compilation performance.
+//!
+//! Mirrors `vize_atelier_sfc`'s `sfc_compile` bench: each case measures the
+//! full parse + lower + compile pipeline (the whole call lives inside
+//! `b.iter`, with no parse hoisting), tagged with `Throughput::Bytes` so
+//! criterion reports MB/s.
+//!
+//! Run with: cargo bench -p vize_atelier_jsx --bench jsx_compile
+
+use std::hint::black_box;
+
+use criterion::{Criterion, Throughput, criterion_group, criterion_main};
+use vize_atelier_jsx::{
+    DomCompileOptions, JsxCompileConfig, JsxLang, VaporCompileOptions, compile_jsx, compile_to_dom,
+    compile_to_vapor, lower_source,
+};
+use vize_carton::Bump;
+
+/// A minimal single-element component.
+const SMALL_JSX: &str = r#"const App = () => <div class="hero">{title}</div>;"#;
+
+/// A medium component exercising attributes, interpolation, a `.map` list, a
+/// conditional, and an event handler.
+const MEDIUM_JSX: &str = r#"const Dashboard = () => (
+  <section class="dashboard" id={dashboardId}>
+    <header class="topbar">
+      <h1>{title}</h1>
+      <button class="refresh" onClick={refresh}>{loading ? "Refreshing" : "Refresh"}</button>
+    </header>
+    <ul class="metrics">
+      {metrics.map((metric) => (
+        <li key={metric.id} class="metric">
+          <span class="label">{metric.label}</span>
+          <strong class="value">{metric.value}</strong>
+        </li>
+      ))}
+    </ul>
+    {hasFooter && <footer class="footer">{footerText}</footer>}
+  </section>
+);"#;
+
+/// A TSX variant of the medium component: typed signatures plus the same
+/// attribute / interpolation / list / conditional / handler surface.
+const MEDIUM_TSX: &str = r#"interface Metric {
+  id: number;
+  label: string;
+  value: string;
+}
+
+const Dashboard = (): JSX.Element => (
+  <section class="dashboard" id={dashboardId}>
+    <header class="topbar">
+      <h1>{title}</h1>
+      <button class="refresh" onClick={refresh}>{loading ? "Refreshing" : "Refresh"}</button>
+    </header>
+    <ul class="metrics">
+      {metrics.map((metric: Metric) => (
+        <li key={metric.id} class="metric">
+          <span class="label">{metric.label}</span>
+          <strong class="value">{metric.value}</strong>
+        </li>
+      ))}
+    </ul>
+    {hasFooter && <footer class="footer">{footerText}</footer>}
+  </section>
+);"#;
+
+/// The cases shared across every benchmark group: `(name, source, lang)`.
+const CASES: &[(&str, &str, JsxLang)] = &[
+    ("small_jsx", SMALL_JSX, JsxLang::Jsx),
+    ("medium_jsx", MEDIUM_JSX, JsxLang::Jsx),
+    ("medium_tsx", MEDIUM_TSX, JsxLang::Tsx),
+];
+
+fn bench_lower(c: &mut Criterion) {
+    let mut group = c.benchmark_group("jsx_lower");
+    for &(name, source, lang) in CASES {
+        group.throughput(Throughput::Bytes(source.len() as u64));
+        group.bench_function(name, |b| {
+            b.iter(|| {
+                let bump = Bump::new();
+                let out = lower_source(&bump, black_box(source), black_box(lang));
+                black_box(out);
+            });
+        });
+    }
+    group.finish();
+}
+
+fn bench_compile_dom(c: &mut Criterion) {
+    let mut group = c.benchmark_group("jsx_compile_dom");
+    for &(name, source, lang) in CASES {
+        group.throughput(Throughput::Bytes(source.len() as u64));
+        group.bench_function(name, |b| {
+            b.iter(|| {
+                let bump = Bump::new();
+                let out = compile_to_dom(
+                    &bump,
+                    black_box(source),
+                    black_box(lang),
+                    DomCompileOptions::default(),
+                );
+                black_box(out);
+            });
+        });
+    }
+    group.finish();
+}
+
+fn bench_compile_vapor(c: &mut Criterion) {
+    let mut group = c.benchmark_group("jsx_compile_vapor");
+    for &(name, source, lang) in CASES {
+        group.throughput(Throughput::Bytes(source.len() as u64));
+        group.bench_function(name, |b| {
+            b.iter(|| {
+                let bump = Bump::new();
+                let out = compile_to_vapor(
+                    &bump,
+                    black_box(source),
+                    black_box(lang),
+                    VaporCompileOptions::default(),
+                );
+                black_box(out);
+            });
+        });
+    }
+    group.finish();
+}
+
+fn bench_compile_mode_aware(c: &mut Criterion) {
+    let config = JsxCompileConfig::default();
+    let mut group = c.benchmark_group("jsx_compile_mode_aware");
+    for &(name, source, lang) in CASES {
+        group.throughput(Throughput::Bytes(source.len() as u64));
+        group.bench_function(name, |b| {
+            b.iter(|| {
+                let bump = Bump::new();
+                let out = compile_jsx(&bump, black_box(source), black_box(lang), &config);
+                black_box(out);
+            });
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_lower,
+    bench_compile_dom,
+    bench_compile_vapor,
+    bench_compile_mode_aware,
+);
+criterion_main!(benches);


### PR DESCRIPTION
Part of #1501.

Adds a criterion benchmark for the JSX/TSX compiler, mirroring the existing `vize_atelier_sfc` `sfc_compile` bench (group + `Throughput::Bytes` + `harness = false`). The whole parse+lower+compile call lives inside `b.iter` (no parse hoisting), and a fresh `Bump::new()` is allocated per iteration so the arena cost is measured the way the compiler is actually used.

## Bench groups added (`crates/vize_atelier_jsx/benches/jsx_compile.rs`)
- `jsx_lower` — `lower_source`
- `jsx_compile_dom` — `compile_to_dom` (VDOM backend)
- `jsx_compile_vapor` — `compile_to_vapor` (Vapor backend)
- `jsx_compile_mode_aware` — `compile_jsx` (mode-aware dispatch)

Each group runs three representative inline fixtures tagged with `Throughput::Bytes(src.len())`:
- `small_jsx` — single-element component
- `medium_jsx` — attributes + interpolation + a `.map` list + a conditional + an event handler
- `medium_tsx` — TSX variant of the medium case (typed signatures + same surface)

## Sample timings
`cargo bench -p vize_atelier_jsx --bench jsx_compile -- --warm-up-time 1 --measurement-time 2`

```
jsx_compile_dom/medium_tsx          time: [29.966 µs 30.143 µs 30.328 µs]  thrpt: [20.31 MiB/s]
jsx_compile_vapor/small_jsx         time: [13.623 µs 13.712 µs 13.803 µs]  thrpt: [3.477 MiB/s]
jsx_compile_vapor/medium_jsx        time: [32.748 µs 32.923 µs 33.098 µs]  thrpt: [16.08 MiB/s]
jsx_compile_vapor/medium_tsx        time: [33.574 µs 33.738 µs 33.896 µs]  thrpt: [18.26 MiB/s]
jsx_compile_mode_aware/small_jsx    time: [12.209 µs 12.270 µs 12.333 µs]  thrpt: [3.886 MiB/s]
jsx_compile_mode_aware/medium_jsx   time: [27.684 µs 27.839 µs 27.992 µs]  thrpt: [19.01 MiB/s]
jsx_compile_mode_aware/medium_tsx   time: [29.648 µs 29.851 µs 30.070 µs]  thrpt: [20.64 MiB/s]
```

## Gates
- `cargo build --benches -p vize_atelier_jsx` — ok
- `cargo bench -p vize_atelier_jsx` — runs, prints timings for all four groups
- `cargo test -p vize_atelier_jsx` — green (Cargo.toml change does not break existing tests)
- `cargo fmt -p vize_atelier_jsx -- --check` — clean
- `cargo clippy -p vize_atelier_jsx --all-targets -- -D warnings` — clean (uses `std::hint::black_box` to avoid the deprecation warning from criterion `=0.8.2`; arena type is `vize_carton::Bump`)

## Deferred: CI-visibility half of #1501
This PR ships **only the bench code**. The CI-visibility half is intentionally **not** addressed here and needs a maintainer infra decision:

- The existing `benchmark.yml` / `tool-benchmark.yml` workflows run a separate CLI/JS benchmark harness — there is **no criterion lane** in GitHub Actions today.
- Wiring these JSX/TSX criterion benches into CI (regression tracking, comparison baselines) requires a maintainer decision on harness/infra.
- Those workflow files are **deliberately untouched** — they are sensitive and other tests assert their literal inline content, so editing them is out of scope for this PR.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1523"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->