### PR TITLE
fix(jsx): support v-model modifier array and underscore-suffix forms (#1489)

### DIFF
--- a/crates/vize_atelier_jsx/src/lower/attr.rs
+++ b/crates/vize_atelier_jsx/src/lower/attr.rs
@@ -10,7 +10,8 @@
 //! - `v-x` / `v-x:arg` -> [`DirectiveNode`] named `x`
 
 use oxc_ast::ast::{
-    JSXAttribute, JSXAttributeItem, JSXAttributeName, JSXAttributeValue, JSXSpreadAttribute,
+    ArrayExpressionElement, Expression, JSXAttribute, JSXAttributeItem, JSXAttributeName,
+    JSXAttributeValue, JSXSpreadAttribute,
 };
 use oxc_span::{GetSpan, Span};
 use vize_carton::{Box, String, Vec};
@@ -161,25 +162,136 @@ impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
         attr: &JSXAttribute<'_>,
         loc: &SourceLocation,
     ) -> Option<PropNode<'a>> {
-        let (directive_name, arg) = match &attr.name {
+        let (raw_name, arg) = match &attr.name {
             JSXAttributeName::NamespacedName(named) => {
-                let directive_name = named.namespace.name.as_str().strip_prefix("v-")?;
+                let raw_name = named.namespace.name.as_str().strip_prefix("v-")?;
                 (
-                    directive_name,
+                    raw_name,
                     Some((named.name.name.as_str(), named.name.span())),
                 )
             }
             JSXAttributeName::Identifier(id) => {
-                let directive_name = id.name.as_str().strip_prefix("v-")?;
-                (directive_name, None)
+                let raw_name = id.name.as_str().strip_prefix("v-")?;
+                (raw_name, None)
             }
         };
 
-        let mut directive = DirectiveNode::new(self.bump(), directive_name, loc.clone());
+        // `v-model_lazy` / `v-model_number_lazy` — babel-plugin-jsx encodes
+        // v-model modifiers as `_<mod>` name suffixes (JSX attribute names cannot
+        // contain `.`). Strip the suffixes and lower as a `model` directive with
+        // those modifiers, NOT a `model_lazy` custom directive.
+        if let Some((directive_name, suffix_mods)) = split_underscore_model_modifiers(raw_name) {
+            let mut directive = DirectiveNode::new(self.bump(), directive_name, loc.clone());
+            if let Some((arg_name, arg_span)) = arg {
+                directive.arg = Some(self.static_expr(arg_name, arg_span));
+            }
+            directive.exp = self.directive_value_expr(attr.value.as_ref());
+            for modifier in suffix_mods {
+                directive
+                    .modifiers
+                    .push(SimpleExpressionNode::new(modifier, false, loc.clone()));
+            }
+            return Some(PropNode::Directive(Box::new_in(directive, self.bump())));
+        }
+
+        // `v-model={[value, ['trim']]}` — babel-plugin-jsx encodes the model
+        // expression, an optional string arg (component prop name), and a
+        // trailing modifiers array as an array literal. Destructure it instead of
+        // treating the whole array as the bound expression (which produced a
+        // malformed `$event => ($event => (...))` chain).
+        if raw_name == "model"
+            && arg.is_none()
+            && let Some(array) = self.model_array_value(attr.value.as_ref())
+            && let Some(prop) = self.lower_model_array(array, loc)
+        {
+            return Some(prop);
+        }
+
+        let mut directive = DirectiveNode::new(self.bump(), raw_name, loc.clone());
         if let Some((arg_name, arg_span)) = arg {
             directive.arg = Some(self.static_expr(arg_name, arg_span));
         }
         directive.exp = self.directive_value_expr(attr.value.as_ref());
+        Some(PropNode::Directive(Box::new_in(directive, self.bump())))
+    }
+
+    /// The `[value, ...]` array literal backing a `v-model={[...]}` attribute,
+    /// or `None` when the value is not an array-literal expression container.
+    fn model_array_value<'e>(
+        &self,
+        value: Option<&'e JSXAttributeValue<'e>>,
+    ) -> Option<&'e oxc_ast::ast::ArrayExpression<'e>> {
+        let JSXAttributeValue::ExpressionContainer(container) = value? else {
+            return None;
+        };
+        match &container.expression {
+            oxc_ast::ast::JSXExpression::ArrayExpression(array) => Some(array),
+            _ => None,
+        }
+    }
+
+    /// Lower a `v-model={[value, argString?, modifiersArray?]}` array into a
+    /// `model` directive. Layout (per babel-plugin-jsx):
+    ///   - element 0: the model expression (required)  -> `exp`
+    ///   - a trailing array-literal element: modifiers  -> `directive.modifiers`
+    ///   - an intermediate string-literal element: arg  -> `directive.arg`
+    ///
+    /// Returns `None` (fall back to default handling) for shapes we cannot
+    /// confidently destructure (e.g. empty array, spread/hole elements).
+    fn lower_model_array(
+        &self,
+        array: &oxc_ast::ast::ArrayExpression<'_>,
+        loc: &SourceLocation,
+    ) -> Option<PropNode<'a>> {
+        // Collect the plain (non-hole, non-spread) expression elements.
+        let mut elems: std::vec::Vec<&Expression<'_>> = std::vec::Vec::new();
+        for element in &array.elements {
+            match element {
+                ArrayExpressionElement::SpreadElement(_) | ArrayExpressionElement::Elision(_) => {
+                    return None;
+                }
+                _ => match element.as_expression() {
+                    Some(expr) => elems.push(expr),
+                    None => return None,
+                },
+            }
+        }
+
+        let value_expr = *elems.first()?;
+
+        // A trailing array-literal element is the modifiers list. Its index marks
+        // the boundary so a middle string element can be recognized as the arg.
+        let modifiers_idx = match elems.last() {
+            Some(Expression::ArrayExpression(_)) if elems.len() >= 2 => Some(elems.len() - 1),
+            _ => None,
+        };
+
+        let mut directive = DirectiveNode::new(self.bump(), "model", loc.clone());
+        directive.exp = Some(self.dyn_expr(value_expr.span()));
+
+        // An intermediate string-literal element (index 1, before any modifiers
+        // array) is the arg: the bound prop name for component v-model.
+        if let Some(Expression::StringLiteral(s)) = elems.get(1).copied()
+            && modifiers_idx != Some(1)
+        {
+            directive.arg = Some(self.static_expr(s.value.as_str(), s.span));
+        }
+
+        if let Some(idx) = modifiers_idx
+            && let Expression::ArrayExpression(modifiers) = elems[idx]
+        {
+            for element in &modifiers.elements {
+                let Some(Expression::StringLiteral(s)) = element.as_expression() else {
+                    continue;
+                };
+                directive.modifiers.push(SimpleExpressionNode::new(
+                    s.value.as_str(),
+                    false,
+                    loc.clone(),
+                ));
+            }
+        }
+
         Some(PropNode::Directive(Box::new_in(directive, self.bump())))
     }
 
@@ -246,6 +358,28 @@ fn split_on_event_modifiers(name: &str) -> Option<(String, std::vec::Vec<&str>)>
     lowered.push(first.to_ascii_lowercase());
     lowered.push_str(chars.as_str());
     Some((lowered, mods))
+}
+
+/// Split a babel-plugin-jsx `v-model_<mod>(_<mod>)*` attribute name (already
+/// stripped of its `v-` prefix) into `("model", [modifiers...])`.
+///
+/// JSX attribute names cannot contain `.`, so babel-plugin-jsx encodes v-model
+/// modifiers as `_`-joined suffixes: `model_lazy`, `model_number_lazy`. The
+/// recognized standard modifiers are `lazy` / `trim` / `number`; any further
+/// `_`-separated segments are passed through verbatim (custom modifiers).
+///
+/// Returns `None` for names that are not `model` with at least one suffix (so
+/// bare `model` and unrelated directives keep their default behavior).
+fn split_underscore_model_modifiers(name: &str) -> Option<(&'static str, std::vec::Vec<&str>)> {
+    let rest = name.strip_prefix("model_")?;
+    if rest.is_empty() {
+        return None;
+    }
+    let mods: std::vec::Vec<&str> = rest.split('_').filter(|s| !s.is_empty()).collect();
+    if mods.is_empty() {
+        return None;
+    }
+    Some(("model", mods))
 }
 
 fn attr_full_name(name: &JSXAttributeName<'_>) -> String {

--- a/crates/vize_atelier_jsx/tests/PARITY_INVENTORY.md
+++ b/crates/vize_atelier_jsx/tests/PARITY_INVENTORY.md
@@ -89,9 +89,9 @@ fine-grained lowering coverage; this inventory tracks the **parity** layer.
 
 Tracked as `#[ignore = "deferred: …"]` in `tests/parity_vdom.rs`:
 
-| Case | Reason | Tracking |
-| ---- | ------ | -------- |
-| _(none currently)_ | | |
+| Case               | Reason | Tracking |
+| ------------------ | ------ | -------- |
+| _(none currently)_ |        |          |
 
 > Resolved in #1489: the `v-model` modifier-array form `{[val, ['trim']]}` and
 > the `v-model_lazy` / `v-model_number_lazy` underscore-suffix form now lower to

--- a/crates/vize_atelier_jsx/tests/PARITY_INVENTORY.md
+++ b/crates/vize_atelier_jsx/tests/PARITY_INVENTORY.md
@@ -59,6 +59,9 @@ fine-grained lowering coverage; this inventory tracks the **parity** layer.
 |                  | `v-model` on checkbox → `vModelCheckbox`                                             |      ✅       |       |     |
 |                  | `v-model` on component → `modelValue` prop                                           |      ✅       |  ✅   |     |
 |                  | `v-model:foo` named arg → `foo` + `onUpdate:foo`                                     |      ✅       |       |     |
+|                  | `v-model={[val, ['trim']]}` modifier-array → `modelModifiers` `{ trim: true }`       |      ✅       |       |     |
+|                  | `v-model={[val, 'foo', ['trim']]}` array arg+modifiers → `fooModifiers`              |      ✅       |       |     |
+|                  | `v-model_lazy` / `v-model_number_lazy` suffix → v-model modifiers                    |      ✅       |       |     |
 |                  | `v-show` → `vShow` / `applyVShow`                                                    |      ✅       |  ✅   |     |
 |                  | `v-html` → `innerHTML` prop                                                          |      ✅       |       |     |
 |                  | `v-text` → `textContent` prop                                                        |      ✅       |       |     |
@@ -86,10 +89,15 @@ fine-grained lowering coverage; this inventory tracks the **parity** layer.
 
 Tracked as `#[ignore = "deferred: …"]` in `tests/parity_vdom.rs`:
 
-| Case                                              | Reason                                                                                                                                                     | Tracking               |
-| ------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------- |
-| `v-model` modifier-array form `{[val, ['trim']]}` | Lowers to a malformed nested `$event => ($event => …)` chain instead of attaching `.trim` as a model modifier.                                             | this inventory / #1491 |
-| `v-model_lazy` suffix-modifier form               | babel-jsx's `v-model_lazy` / `v-model_number` underscore-suffix syntax resolves as a `model_lazy` **custom directive** instead of a lazy v-model modifier. | this inventory / #1491 |
+| Case | Reason | Tracking |
+| ---- | ------ | -------- |
+| _(none currently)_ | | |
+
+> Resolved in #1489: the `v-model` modifier-array form `{[val, ['trim']]}` and
+> the `v-model_lazy` / `v-model_number_lazy` underscore-suffix form now lower to
+> a `model` directive with `modelModifiers` + a single clean
+> `onUpdate:modelValue` handler (see the `v_model_modifier_array_*` /
+> `v_model_underscore_suffix_*` tests in `parity_vdom.rs`).
 
 ### Type-level / resolve-type parity — deferred
 

--- a/crates/vize_atelier_jsx/tests/parity_vdom.rs
+++ b/crates/vize_atelier_jsx/tests/parity_vdom.rs
@@ -367,30 +367,77 @@ fn plain_element_children_form_implicit_default_slot() {
 }
 
 // ---------------------------------------------------------------------------
-// Category: DEFERRED — see PARITY_INVENTORY.md.
+// Category: v-model modifier forms (babel-plugin-jsx parity — #1489/#1491).
 //
-// These are reference @vue/babel-plugin-jsx behaviors Vize does not yet handle
-// correctly; they are ignored (never red) and tracked in the inventory.
+// JSX attribute names cannot contain `.`, so @vue/babel-plugin-jsx expresses
+// v-model modifiers two ways: an array value `{[val, ['trim']]}` and an
+// underscore-suffixed name `v-model_lazy`. Both lower to a `model` directive
+// with `modelModifiers` + a single clean `onUpdate:modelValue` handler.
 // ---------------------------------------------------------------------------
 
 #[test]
-#[ignore = "deferred: v-model modifier-array form `{[val, ['trim']]}` lowers to a malformed nested $event chain; tracked in PARITY_INVENTORY.md / #1491"]
-fn v_model_with_modifier_array_is_not_yet_supported() {
+fn v_model_modifier_array_attaches_model_modifiers() {
     let code = dom("const A = () => <input v-model={[val, ['trim']]}/>;");
-    // Reference babel-jsx attaches `.trim` as a model modifier; Vize currently
-    // emits `$event => ($event => (...))`. When fixed, assert a single clean
-    // update handler + a `modelModifiers` entry here.
+    // No malformed nested handler, no leftover array as the bound expression.
     assert!(!code.contains("$event => ($event =>"), "{code}");
+    assert!(!code.contains("[val, ['trim']]"), "{code}");
+    // Single clean update handler bound to the model expression.
+    assert!(
+        code.contains("\"onUpdate:modelValue\": $event => ((val) = $event)"),
+        "{code}"
+    );
+    // `.trim` lands as a model modifier on the v-model directive entry.
+    assert!(code.contains("{ trim: true }"), "{code}");
 }
 
 #[test]
-#[ignore = "deferred: babel-jsx `v-model_lazy` suffix-modifier form resolves as a custom directive instead of a lazy model modifier; tracked in PARITY_INVENTORY.md / #1491"]
-fn v_model_underscore_suffix_modifier_is_not_yet_supported() {
+fn v_model_modifier_array_single_element_has_no_modifiers() {
+    // `{[val]}` is just the bound expression with no modifiers/arg.
+    let code = dom("const A = () => <input v-model={[val]}/>;");
+    assert!(!code.contains("$event => ($event =>"), "{code}");
+    assert!(
+        code.contains("\"onUpdate:modelValue\": $event => ((val) = $event)"),
+        "{code}"
+    );
+    assert!(code.contains("[_vModelText, val]"), "{code}");
+}
+
+#[test]
+fn v_model_modifier_array_with_component_arg_and_modifiers() {
+    // `{[val, 'foo', ['trim']]}` — arg `foo` + `.trim` on a component v-model.
+    let code = dom("const A = () => <Comp v-model={[val, 'foo', ['trim']]}/>;");
+    assert!(!code.contains("$event => ($event =>"), "{code}");
+    assert!(code.contains("foo: val"), "{code}");
+    assert!(
+        code.contains("\"onUpdate:foo\": $event => ((val) = $event)"),
+        "{code}"
+    );
+    assert!(code.contains("fooModifiers: { trim: true }"), "{code}");
+}
+
+#[test]
+fn v_model_underscore_suffix_attaches_lazy_modifier() {
     let code = dom("const A = () => <input v-model_lazy={val}/>;");
-    // Reference treats the `_lazy` suffix as a v-model modifier; Vize resolves a
-    // `model_lazy` custom directive. When fixed, assert `lazy: true` modifier.
+    // No bogus custom directive resolution for the `_lazy` suffix.
     assert!(
         !code.contains("_resolveDirective(\"model_lazy\")"),
         "{code}"
     );
+    assert!(!code.contains("_directive_model_lazy"), "{code}");
+    assert!(
+        code.contains("\"onUpdate:modelValue\": $event => ((val) = $event)"),
+        "{code}"
+    );
+    assert!(code.contains("{ lazy: true }"), "{code}");
+}
+
+#[test]
+fn v_model_underscore_suffix_chains_multiple_modifiers() {
+    let code = dom("const A = () => <input v-model_number_lazy={val}/>;");
+    assert!(
+        !code.contains("_resolveDirective(\"model_number_lazy\")"),
+        "{code}"
+    );
+    assert!(code.contains("number: true"), "{code}");
+    assert!(code.contains("lazy: true"), "{code}");
 }


### PR DESCRIPTION
## Summary

`@vue/babel-plugin-jsx` expresses `v-model` modifiers two ways because JSX attribute names can't contain `.`:

1. **Array form** `<input v-model={[value, ['trim']]}/>` — element 0 is the model expression, a trailing array literal is the modifiers list, and an intermediate string literal is the arg (component v-model prop name).
2. **Underscore-suffix form** `<input v-model_lazy={value}/>` — `_<modifier>` suffix(es) on the attribute name.

Before this change the JSX lowerer:
- treated the **whole array** as the bound expression, emitting a malformed `$event => ($event => (...))` chain; and
- resolved a bogus `_resolveDirective("model_lazy")` custom directive for the suffix form.

Both now lower to a `model` `DirectiveNode` with populated `modifiers`, so the existing core v-model codegen emits `modelModifiers` + a single clean `onUpdate:modelValue` handler — matching `v-model.trim` / `v-model.lazy` parity.

## Fixed codegen

`<input v-model={[val, ['trim']]}/>`:
```js
_withDirectives((_openBlock(), _createElementBlock("input", {
  "onUpdate:modelValue": $event => ((val) = $event)
}, null, 8 /* PROPS */, ["onUpdate:modelValue"])), [
  [_vModelText, val, void 0, { trim: true }]
])
```

`<input v-model_lazy={val}/>`:
```js
_withDirectives((_openBlock(), _createElementBlock("input", {
  "onUpdate:modelValue": $event => ((val) = $event)
}, null, 8 /* PROPS */, ["onUpdate:modelValue"])), [
  [_vModelText, val, void 0, { lazy: true }]
])
```

Component array form `<Comp v-model={[val, 'foo', ['trim']]}/>` produces `foo: val`, `"onUpdate:foo"`, and `fooModifiers: { trim: true }`.

## Tests

- Un-ignored the two deferred `#1491` parity cases in `tests/parity_vdom.rs` and replaced placeholders with real assertions (single `onUpdate:modelValue` handler, `modelModifiers`, no `$event => ($event =>`, no `_resolveDirective("model_lazy")`).
- Added cases: single-element array `{[val]}`, component arg+modifiers array, and `v-model_number_lazy` multi-modifier chain.
- Moved both cases from deferred to covered in `PARITY_INVENTORY.md`.

Fixes the two deferred #1491 parity cases (part of #1489).

## Gates

- `cargo test -p vize_atelier_jsx` — all green, 0 ignored.
- `cargo fmt -p vize_atelier_jsx -- --check` — clean.
- `cargo clippy -p vize_atelier_jsx --all-targets -- -D warnings` — clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1525"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->