### PR TITLE
feat(patina): lint JSX/TSX by lowering to the template AST (#1499)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3775,6 +3775,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "vize_armature",
+ "vize_atelier_jsx",
  "vize_atelier_sfc",
  "vize_carton",
  "vize_croquis",

--- a/crates/vize_patina/Cargo.toml
+++ b/crates/vize_patina/Cargo.toml
@@ -14,6 +14,7 @@ vize_armature.workspace = true
 vize_carton.workspace = true
 vize_croquis.workspace = true
 vize_atelier_sfc.workspace = true
+vize_atelier_jsx.workspace = true
 
 # OXC for JS/TS parsing and diagnostics
 oxc_allocator.workspace = true

--- a/crates/vize_patina/src/lib.rs
+++ b/crates/vize_patina/src/lib.rs
@@ -106,6 +106,7 @@ pub use telegraph::{
     Emitter, FormatEmitter, JsonEmitter, LintTransmission, LspDiagnostic, LspEmitter, Telegraph,
     TextEmitter,
 };
+pub use vize_atelier_jsx::JsxLang;
 pub use vize_carton::i18n::Locale;
 
 /// Lint a Vue template source with default rules
@@ -114,6 +115,15 @@ pub use vize_carton::i18n::Locale;
 /// For more control, use `Linter::new()` directly.
 pub fn lint(source: &str, filename: &str) -> LintResult {
     Linter::new().lint_template(source, filename)
+}
+
+/// Lint JSX/TSX source with default rules.
+///
+/// Lowers the JSX/TSX to the shared relief template AST and runs the existing
+/// element/attribute/binding template rules over it. See [`Linter::lint_jsx`]
+/// for the directive-rule caveat.
+pub fn lint_jsx(source: &str, filename: &str, lang: JsxLang) -> LintResult {
+    Linter::new().lint_jsx(source, filename, lang)
 }
 
 #[cfg(test)]

--- a/crates/vize_patina/src/linter/engine.rs
+++ b/crates/vize_patina/src/linter/engine.rs
@@ -335,6 +335,92 @@ impl Linter {
         self.lint_template_with_allocator(&allocator, source, filename)
     }
 
+    /// Lint JSX/TSX source by lowering it to the shared relief template AST and
+    /// running the existing element/attribute/binding template rules over it.
+    ///
+    /// JSX/TSX lowers (via [`vize_atelier_jsx::lower_source`]) to the same
+    /// [`RootNode`] that SFC `<template>` blocks produce, so any AST-driven
+    /// template rule (e.g. `vue/a11y-img-alt`) runs unchanged.
+    ///
+    /// Note: directive-structure rules such as `vue/require-v-for-key` do **not**
+    /// fire on JSX. JSX `items.map(...)` lowers to a `ForNode` and
+    /// `cond && <x/>` to an `IfNode` *structurally*, not as `v-for`/`v-if`
+    /// directives, so directive-shaped rules have nothing to match against.
+    pub fn lint_jsx(
+        &self,
+        source: &str,
+        filename: &str,
+        lang: vize_atelier_jsx::JsxLang,
+    ) -> LintResult {
+        let capacity = (source.len() * 4).max(self.initial_capacity);
+        let allocator = Allocator::with_capacity(capacity);
+
+        let lowered = profile!(
+            "patina.jsx.lower",
+            vize_atelier_jsx::lower_source(allocator.as_bump(), source, lang)
+        );
+
+        let mut result = Self::jsx_diagnostics_lint_result(filename, &lowered.diagnostics);
+
+        for lowered_root in &lowered.roots {
+            let root_result = self.lint_template_root(
+                &allocator,
+                source,
+                filename,
+                &lowered_root.root,
+                TemplateAnalysis::Lazy,
+                TemplateRuleEnv {
+                    sfc_descriptor: None,
+                    dialect: VueDialect::Vue,
+                },
+            );
+            result = Self::merge_lint_results(result, root_result);
+        }
+
+        result
+    }
+
+    fn jsx_diagnostics_lint_result(
+        filename: &str,
+        diagnostics: &[vize_atelier_jsx::JsxDiagnostic],
+    ) -> LintResult {
+        use crate::diagnostic::LintDiagnostic;
+
+        const JSX_PARSE_RULE: &str = "parser/jsx";
+
+        let mut lint_diagnostics = Vec::with_capacity(diagnostics.len());
+        let mut error_count = 0;
+        let mut warning_count = 0;
+
+        for diagnostic in diagnostics {
+            let lint_diagnostic = if diagnostic.is_error() {
+                error_count += 1;
+                LintDiagnostic::error(
+                    JSX_PARSE_RULE,
+                    diagnostic.message.clone(),
+                    diagnostic.start,
+                    diagnostic.end,
+                )
+            } else {
+                warning_count += 1;
+                LintDiagnostic::warn(
+                    JSX_PARSE_RULE,
+                    diagnostic.message.clone(),
+                    diagnostic.start,
+                    diagnostic.end,
+                )
+            };
+            lint_diagnostics.push(lint_diagnostic);
+        }
+
+        LintResult {
+            filename: filename.to_compact_string(),
+            diagnostics: lint_diagnostics,
+            error_count,
+            warning_count,
+        }
+    }
+
     /// Lint a Vue template with a provided allocator (for reuse).
     pub fn lint_template_with_allocator(
         &self,

--- a/crates/vize_patina/src/linter/tests.rs
+++ b/crates/vize_patina/src/linter/tests.rs
@@ -4,4 +4,5 @@ use vize_carton::{Allocator, ToCompactString};
 
 mod basic;
 mod directives;
+mod jsx;
 mod sfc;

--- a/crates/vize_patina/src/linter/tests/jsx.rs
+++ b/crates/vize_patina/src/linter/tests/jsx.rs
@@ -1,0 +1,81 @@
+//! Tests for linting JSX/TSX by lowering it to the shared relief template AST.
+//!
+//! These exercise an element/attribute rule (`vue/a11y-img-alt`) over JSX,
+//! confirming AST-driven template rules run unchanged on lowered JSX. Directive
+//! structure rules (e.g. `vue/require-v-for-key`) are intentionally out of scope
+//! because JSX loops/conditionals lower structurally, not as directives.
+
+use crate::linter::Linter;
+use crate::rule::RuleRegistry;
+use crate::rules::vue::A11yImgAlt;
+use vize_atelier_jsx::JsxLang;
+
+fn img_alt_linter() -> Linter {
+    let mut registry = RuleRegistry::new();
+    registry.register(Box::new(A11yImgAlt));
+    Linter::with_registry(registry)
+}
+
+#[test]
+fn jsx_img_without_alt_is_flagged() {
+    let linter = img_alt_linter();
+    let result = linter.lint_jsx(
+        r#"const A = () => <img src="/x.jpg"/>;"#,
+        "test.jsx",
+        JsxLang::Jsx,
+    );
+
+    assert_eq!(
+        result.warning_count, 1,
+        "<img> without alt should be flagged: {:?}",
+        result.diagnostics
+    );
+    assert!(
+        result
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.rule_name == "vue/a11y-img-alt"),
+        "expected vue/a11y-img-alt diagnostic: {:?}",
+        result.diagnostics
+    );
+}
+
+#[test]
+fn jsx_img_with_alt_is_not_flagged() {
+    let linter = img_alt_linter();
+    let result = linter.lint_jsx(
+        r#"const A = () => <img src="/x.jpg" alt=""/>;"#,
+        "test.jsx",
+        JsxLang::Jsx,
+    );
+
+    assert_eq!(
+        result.warning_count, 0,
+        "<img> with alt should not be flagged: {:?}",
+        result.diagnostics
+    );
+    assert!(
+        result
+            .diagnostics
+            .iter()
+            .all(|diagnostic| diagnostic.rule_name != "vue/a11y-img-alt"),
+        "did not expect vue/a11y-img-alt diagnostic: {:?}",
+        result.diagnostics
+    );
+}
+
+#[test]
+fn tsx_img_without_alt_is_flagged() {
+    let linter = img_alt_linter();
+    let result = linter.lint_jsx(
+        r#"const A = () => <img src="/x.jpg"/>;"#,
+        "test.tsx",
+        JsxLang::Tsx,
+    );
+
+    assert_eq!(
+        result.warning_count, 1,
+        "<img> without alt should be flagged in TSX: {:?}",
+        result.diagnostics
+    );
+}


### PR DESCRIPTION
Part of #1499.

## What this implements

JSX/TSX now lowers to the **same** relief template AST (`vize_relief::ast::RootNode`) that SFC `<template>` blocks produce, via `vize_atelier_jsx::lower_source`. Since Patina's lint engine already runs rules over a `&RootNode`, we can lint JSX by lowering it and feeding the existing AST-driven template rules.

- New `Linter::lint_jsx(source, filename, JsxLang) -> LintResult` (in `crates/vize_patina/src/linter/engine.rs`): creates one `Allocator`, calls `lower_source(allocator.as_bump(), source, lang)`, runs the existing private `lint_template_root` / `run_template_rules` pass over each lowered `RootNode` with `TemplateRuleEnv { sfc_descriptor: None, dialect: VueDialect::Vue }`, and merges per-root results via `merge_lint_results`.
- JSX parse/lower diagnostics (`LowerOutput.diagnostics`) are mapped into the result under a `parser/jsx` pseudo-rule, mirroring how `parser/template` parse errors are surfaced.
- Re-exported `lint_jsx` free fn and `JsxLang` from `vize_patina` (`src/lib.rs`).
- Added `vize_atelier_jsx` as a dependency of `vize_patina` (no cycle: patina is not a dep of atelier_jsx).

### Verify (real anchor)

New tests in `crates/vize_patina/src/linter/tests/jsx.rs` assert an **element/attribute** rule (`vue/a11y-img-alt`, an `enter_element` rule) runs over lowered JSX:

- `const A = () => <img src="/x.jpg"/>;` -> flagged (1 `vue/a11y-img-alt` warning), in both JSX and TSX.
- `const A = () => <img src="/x.jpg" alt=""/>;` -> not flagged.

## Deferred (honest scope)

This runs **existing** relief-AST template rules (element / attribute / `v-bind` / `v-on` / interpolation rules) over JSX. Not in this slice:

- **Directive-structure rules** like `vue/require-v-for-key` will **not** fire on JSX loops/conditionals, because JSX lowers `items.map(...)` -> `ForNode` and `cond && <x/>` -> `IfNode` **structurally** (not as `v-for` / `v-if` directives), so directive-shaped rules have nothing to match against.
- JSX-specific rules and `eslint-plugin-jsx` parity.
- The issue's "without runtime overhead" perf framing: this slice is correctness-only, no benchmark.

## Gates

- `cargo test -p vize_patina`: 1114 passed (incl. 3 new JSX tests).
- `cargo fmt -p vize_patina -- --check`: clean.
- `cargo clippy -p vize_patina -- -D warnings` (CI/lib invocation): clean. Note: `--all-targets` shows 81 pre-existing `disallowed_macros` errors from `insta::assert_debug_snapshot!` in existing rule test code (identical count with my change stashed); my new code adds zero lints.
- `cargo semver-checks check-release -p vize_patina`: additive-clean (no semver update required).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1526"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->