### PR TITLE
feat(maestro): surface JSX/TSX compiler diagnostics in LSP (#1498)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3729,6 +3729,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "vize_armature",
+ "vize_atelier_jsx",
  "vize_atelier_sfc",
  "vize_canon",
  "vize_carton",

--- a/crates/vize_maestro/Cargo.toml
+++ b/crates/vize_maestro/Cargo.toml
@@ -52,6 +52,7 @@ vize_carton.workspace = true
 vize_relief.workspace = true
 vize_armature.workspace = true
 vize_atelier_sfc.workspace = true
+vize_atelier_jsx.workspace = true
 vize_glyph = { workspace = true, optional = true }
 vize_patina.workspace = true
 vize_canon = { workspace = true }

--- a/crates/vize_maestro/src/ide/diagnostics.rs
+++ b/crates/vize_maestro/src/ide/diagnostics.rs
@@ -33,6 +33,7 @@ pub mod sources {
     pub const SFC_COMPILER: &str = "vize/sfc-compile";
     pub const TEMPLATE_PARSER: &str = "vize/template";
     pub const SCRIPT_PARSER: &str = "vize/script";
+    pub const JSX_COMPILER: &str = "vize/jsx";
     pub const LINTER: &str = "vize/lint";
     pub const TYPE_CHECKER: &str = "vize/types";
     pub const MUSEA: &str = "vize/musea";

--- a/crates/vize_maestro/src/ide/diagnostics/collectors.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/collectors.rs
@@ -84,6 +84,56 @@ impl DiagnosticService {
         diagnostics
     }
 
+    /// Collect JSX/TSX compiler diagnostics for a `.jsx`/`.tsx` document.
+    ///
+    /// This lowers the source through `vize_atelier_jsx::lower_source` and maps
+    /// each [`vize_atelier_jsx::JsxDiagnostic`] (byte range + severity) onto an
+    /// LSP [`Diagnostic`] via the shared [`LineIndex`]. It does **not** generate
+    /// any virtual TypeScript document — type-aware JSX features (hover,
+    /// completion, type errors) are deferred to #1497. This is the
+    /// diagnostics-only lane: parse errors and lowering warnings surface as
+    /// editor squiggles, nothing more.
+    pub(super) fn collect_jsx_diagnostics(
+        uri: &Url,
+        content: &str,
+        line_index: &LineIndex<'_>,
+    ) -> Vec<Diagnostic> {
+        let lang = vize_atelier_jsx::JsxLang::from_path(uri.path());
+
+        let bump = vize_carton::Bump::new();
+        let output = vize_atelier_jsx::lower_source(&bump, content, lang);
+
+        output
+            .diagnostics
+            .iter()
+            .map(|diag| {
+                let (start_line, start_col) = line_index.line_col(diag.start as usize);
+                let (end_line, end_col) = line_index.line_col(diag.end as usize);
+
+                Diagnostic {
+                    range: Range {
+                        start: Position {
+                            line: start_line,
+                            character: start_col,
+                        },
+                        end: Position {
+                            line: end_line,
+                            character: end_col,
+                        },
+                    },
+                    severity: Some(match diag.severity {
+                        vize_atelier_jsx::Severity::Error => DiagnosticSeverity::ERROR,
+                        vize_atelier_jsx::Severity::Warning => DiagnosticSeverity::WARNING,
+                    }),
+                    source: Some(sources::JSX_COMPILER.to_string()),
+                    #[allow(clippy::disallowed_methods)]
+                    message: diag.message.to_string(),
+                    ..Default::default()
+                }
+            })
+            .collect()
+    }
+
     /// Collect diagnostics for inline <art> custom blocks in regular .vue files.
     pub(super) fn collect_inline_art_diagnostics(
         _uri: &Url,

--- a/crates/vize_maestro/src/ide/diagnostics/service.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/service.rs
@@ -4,7 +4,7 @@ use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, NumberOrString, Range
 
 use crate::ide::ecosystem;
 use crate::server::ServerState;
-use crate::utils::is_standalone_html_path;
+use crate::utils::{is_jsx_path, is_standalone_html_path};
 
 use super::{LineIndex, Severity, sources};
 
@@ -98,6 +98,17 @@ impl DiagnosticService {
                 );
                 diagnostics.extend(lint_diags);
             }
+            return diagnostics;
+        }
+
+        // JSX/TSX files (*.jsx, *.tsx): surface JSX compiler/lowering
+        // diagnostics (parse errors, lowering warnings) as LSP squiggles. This
+        // is diagnostics-only — no virtual TypeScript document is generated for
+        // JSX/TSX (type-aware features are deferred to #1497).
+        if is_jsx_path(path) {
+            let jsx_diags = Self::collect_jsx_diagnostics(uri, &content, &line_index);
+            tracing::info!("collect: jsx compiler diagnostics: {}", jsx_diags.len());
+            diagnostics.extend(jsx_diags);
             return diagnostics;
         }
 

--- a/crates/vize_maestro/src/ide/diagnostics/tests.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/tests.rs
@@ -497,6 +497,86 @@ fn collect_skips_unsupported_script_language() {
     );
 }
 
+#[test]
+fn collect_surfaces_jsx_compiler_error_for_broken_tsx() {
+    // `has_diagnostics()` gates the whole pipeline; enable lint so the
+    // JSX branch is reached (lint itself does not apply to `.tsx`).
+    let state = state_with_lsp_diagnostics(true, false);
+    let uri = Url::parse("file:///Broken.tsx").unwrap();
+    // Unclosed JSX element — the JSX compiler reports a parse error.
+    state.documents.open(
+        uri.clone(),
+        "const a = <div>;".to_string(),
+        1,
+        "typescriptreact".to_string(),
+    );
+
+    let diagnostics = DiagnosticService::collect(&state, &uri);
+
+    let jsx_errors: Vec<_> = diagnostics
+        .iter()
+        .filter(|d| {
+            d.source.as_deref() == Some(sources::JSX_COMPILER)
+                && d.severity == Some(DiagnosticSeverity::ERROR)
+        })
+        .collect();
+
+    assert!(
+        !jsx_errors.is_empty(),
+        "expected a JSX compiler error diagnostic, got: {diagnostics:?}"
+    );
+    // The range must be non-empty and land on the first (only) line.
+    let diag = jsx_errors[0];
+    assert_eq!(diag.range.start.line, 0);
+    assert!(
+        diag.range.end >= diag.range.start,
+        "diagnostic range must be well-ordered: {:?}",
+        diag.range
+    );
+}
+
+#[test]
+fn collect_produces_no_error_for_valid_tsx() {
+    let state = state_with_lsp_diagnostics(true, false);
+    let uri = Url::parse("file:///Valid.tsx").unwrap();
+    state.documents.open(
+        uri.clone(),
+        "const App = () => <div class=\"a\">{count}</div>;".to_string(),
+        1,
+        "typescriptreact".to_string(),
+    );
+
+    let diagnostics = DiagnosticService::collect(&state, &uri);
+
+    assert!(
+        !diagnostics
+            .iter()
+            .any(|d| d.severity == Some(DiagnosticSeverity::ERROR)),
+        "valid TSX must not produce error diagnostics, got: {diagnostics:?}"
+    );
+}
+
+#[test]
+fn collect_produces_no_error_for_valid_jsx() {
+    let state = state_with_lsp_diagnostics(true, false);
+    let uri = Url::parse("file:///Valid.jsx").unwrap();
+    state.documents.open(
+        uri.clone(),
+        "const App = () => <div class=\"a\">hello</div>;".to_string(),
+        1,
+        "javascriptreact".to_string(),
+    );
+
+    let diagnostics = DiagnosticService::collect(&state, &uri);
+
+    assert!(
+        !diagnostics
+            .iter()
+            .any(|d| d.severity == Some(DiagnosticSeverity::ERROR)),
+        "valid JSX must not produce error diagnostics, got: {diagnostics:?}"
+    );
+}
+
 fn lint_subset(diagnostics: &[Diagnostic]) -> Vec<Diagnostic> {
     diagnostics
         .iter()

--- a/crates/vize_maestro/src/utils.rs
+++ b/crates/vize_maestro/src/utils.rs
@@ -13,3 +13,12 @@ pub fn is_standalone_html_path(path: &str) -> bool {
     let path = path.to_ascii_lowercase();
     path.ends_with(".html") || path.ends_with(".htm")
 }
+
+/// Returns true for JSX/TSX files that should be compiled outside the SFC
+/// pipeline. These surface JSX compiler/lowering diagnostics only — no virtual
+/// TypeScript document is generated for them (see #1497).
+#[inline]
+pub fn is_jsx_path(path: &str) -> bool {
+    let path = path.to_ascii_lowercase();
+    path.ends_with(".jsx") || path.ends_with(".tsx")
+}


### PR DESCRIPTION
Part of #1498.

## Implemented (diagnostics-only)
- JSX/TSX **compiler/lowering diagnostics** surfaced through the LSP: JSX parse errors and lowering warnings now appear as editor squiggles on `.jsx`/`.tsx` files.
- Document-type detection for `.jsx`/`.tsx` (`utils::is_jsx_path`), mirroring the existing standalone-HTML branch.
- New diagnostic source `vize/jsx`.

### How it works
`DiagnosticService::collect` gains a `.jsx`/`.tsx` branch (before the SFC fallthrough) that calls the new `collect_jsx_diagnostics`. That collector lowers the document via `vize_atelier_jsx::lower_source` (lang picked from the extension: `.tsx`→`Tsx`, `.jsx`→`Jsx`) and maps each `JsxDiagnostic` (byte range + severity) onto an LSP `Diagnostic` using the shared `LineIndex`, exactly like the existing musea/SFC collectors.

## Explicitly deferred / OUT OF SCOPE
- Hover, completion, signature help, go-to-definition, and **type diagnostics** for JSX/TSX.
- All of these require virtual-TypeScript generation for `.jsx`/`.tsx`, which is a separate larger decision (#1497) and intersects the standing "virtual TS docs stay plain `.vue.ts`" directive.
- **This PR adds NO virtual TypeScript document for `.jsx`/`.tsx`.**

## Tests
Added to `crates/vize_maestro/src/ide/diagnostics/tests.rs`:
- Broken `.tsx` (`const a = <div>;`, unclosed JSX) produces a `vize/jsx` ERROR diagnostic with a sensible range.
- Valid `.tsx` and valid `.jsx` produce no error diagnostics.

## Gates
- `cargo test -p vize_maestro`: 315 passed (incl. 3 new).
- `cargo fmt -p vize_maestro -- --check`: clean.
- `cargo clippy -p vize_maestro -- -D warnings` (CI form, lib): clean. Pre-existing `disallowed_macros` lints under `--all-targets` in unrelated test files (`virtual_code/template_code.rs`) confirmed to pre-date this change; this PR adds zero new clippy findings.
- Public API additions are additive-only (`pub fn is_jsx_path`, `pub const JSX_COMPILER`).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1527"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->