### PR TITLE
feat(integrations): compile .jsx/.tsx through vite-plugin-vize (#1500)

### DIFF
--- a/npm/vite-plugin-vize/src/compiler.test.ts
+++ b/npm/vite-plugin-vize/src/compiler.test.ts
@@ -3,7 +3,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-import { compileBatch, compileFile } from "./compiler.ts";
+import { compileBatch, compileFile, compileJsxModule } from "./compiler.ts";
 
 const invalidCache = new Map();
 assert.throws(
@@ -991,6 +991,49 @@ assert.match(
   ssrNormalScriptImportCompiled.code,
   /resolver: \$props\.schema \? (?:_unref\(\$setup\.valibotResolver\)|\$setup\.valibotResolver)\(\$props\.schema\) : undefined/,
   "SSR component props should call normal-script template imports through setup bindings",
+);
+
+const jsxSource = `const App = () => <div class="greeting">{message}</div>;\nexport default App;\n`;
+
+const jsxVdomCompiled = compileJsxModule("/src/App.jsx", jsxSource, { vapor: false });
+assert.match(
+  jsxVdomCompiled.code,
+  /_createElementBlock\("div"/,
+  "VDOM JSX compilation should emit the element block factory",
+);
+assert.deepEqual(
+  jsxVdomCompiled.warnings,
+  [],
+  "VDOM JSX compilation of a valid component should emit no warnings",
+);
+
+const jsxVaporCompiled = compileJsxModule("/src/App.jsx", jsxSource, { vapor: true });
+assert.match(
+  jsxVaporCompiled.code,
+  /_template\(/,
+  "Vapor JSX compilation should hoist a static template",
+);
+assert.doesNotMatch(
+  jsxVaporCompiled.code,
+  /_createElementBlock/,
+  "Vapor JSX compilation should not emit the VDOM element block factory",
+);
+
+const tsxCompiled = compileJsxModule(
+  "/src/Typed.tsx",
+  `const Typed = (props: { label: string }) => <span>{props.label}</span>;\nexport default Typed;\n`,
+  { vapor: false },
+);
+assert.match(
+  tsxCompiled.code,
+  /_createElementBlock\("span"|_createBlock|render/,
+  "TSX compilation should infer the tsx language from the .tsx filename and emit render code",
+);
+
+assert.throws(
+  () => compileJsxModule("/src/Broken.jsx", `const Broken = () => <div>{;`, { vapor: false }),
+  /Compilation failed in \/src\/Broken\.jsx/,
+  "JSX compilation errors should fail the Vite plugin instead of emitting broken code",
 );
 
 console.log("✅ vite-plugin-vize compiler tests passed!");

--- a/npm/vite-plugin-vize/src/compiler.ts
+++ b/npm/vite-plugin-vize/src/compiler.ts
@@ -15,8 +15,10 @@ import {
   type CompileFileOptions,
 } from "./compile-options.ts";
 import { generateScopeId } from "./utils/index.ts";
+import type { CompileJsxFn } from "./types.ts";
 
 const { compileSfc, compileSfcBatchWithResults } = native;
+const compileJsx = (native as { compileJsx: CompileJsxFn }).compileJsx;
 
 export class VizeSfcCompileError extends Error {
   readonly filePath: string;
@@ -186,6 +188,38 @@ export function compileFile(
 
   cache.set(filePath, compiled);
   return compiled;
+}
+
+export interface JsxCompileFileOptions {
+  vapor?: boolean;
+}
+
+/**
+ * Compile a `.jsx`/`.tsx` Vue component module to render code through Vize.
+ *
+ * Mirrors `compileFile` for SFCs but routes through the native `compileJsx`
+ * binding. JSX/TSX modules carry no `<style>` blocks or src imports, so the
+ * result is just the generated render code plus any warnings.
+ */
+export function compileJsxModule(
+  filePath: string,
+  source: string,
+  options: JsxCompileFileOptions = {},
+): { code: string; warnings: string[] } {
+  const result = compileJsx(source, {
+    filename: filePath,
+    lang: filePath.endsWith(".tsx") ? "tsx" : "jsx",
+    vapor: options.vapor ?? false,
+  });
+
+  if (result.errors.length > 0) {
+    throw new VizeSfcCompileError(filePath, result.errors);
+  }
+
+  return {
+    code: result.code,
+    warnings: result.warnings,
+  };
 }
 
 /**

--- a/npm/vite-plugin-vize/src/plugin/load.test.ts
+++ b/npm/vite-plugin-vize/src/plugin/load.test.ts
@@ -880,4 +880,82 @@ assert.match(
   "Production on-demand loads should emit a virtual style import for CSS extraction",
 );
 
+// A real .jsx file Vize fixture flows through the transform hook and compiles
+// to render code through Vize (the headline acceptance of #1500).
+const jsxFixturePath = path.resolve(__dirname, "..", "test", "fixtures", "jsx", "App.jsx");
+const jsxFixtureSource = fs.readFileSync(jsxFixturePath, "utf8");
+
+const jsxState: VizePluginState = {
+  ...hmrState,
+  cache: new Map(),
+  ssrCache: new Map(),
+  mergedOptions: { vapor: false },
+};
+
+const jsxTransform = await transformHook(jsxState, jsxFixtureSource, jsxFixturePath, {
+  ssr: false,
+});
+assert.ok(
+  jsxTransform && typeof jsxTransform === "object",
+  "Vite should hand .jsx files to Vize and receive a transform result",
+);
+assert.match(
+  jsxTransform.code,
+  /_createElementBlock\("div"/,
+  "VDOM .jsx components should compile to Vize render code through the transform hook",
+);
+assert.equal(jsxTransform.map, null, "JSX transform should not allocate a discarded sourcemap");
+
+const jsxVaporState: VizePluginState = {
+  ...jsxState,
+  mergedOptions: { vapor: true },
+};
+
+const jsxVaporTransform = await transformHook(jsxVaporState, jsxFixtureSource, jsxFixturePath, {
+  ssr: false,
+});
+assert.ok(
+  jsxVaporTransform && typeof jsxVaporTransform === "object",
+  "Vapor .jsx transforms should also produce a result",
+);
+assert.match(
+  jsxVaporTransform.code,
+  /_template\(/,
+  "Vapor .jsx components should compile to hoisted templates through the transform hook",
+);
+
+const tsxFsTransform = await transformHook(
+  jsxState,
+  `const T = () => <span class="t">x</span>;\nexport default T;\n`,
+  "/@fs/abs/src/Widget.tsx",
+  { ssr: false },
+);
+assert.ok(
+  tsxFsTransform && typeof tsxFsTransform === "object",
+  "/@fs-prefixed .tsx requests should be claimed and compiled through Vize",
+);
+assert.match(
+  tsxFsTransform.code,
+  /render|_createElementBlock/,
+  "/@fs .tsx requests should emit Vize render code",
+);
+
+const nonJsxTransform = await transformHook(jsxState, "export default 1;", "/src/plain.ts", {
+  ssr: false,
+});
+assert.equal(
+  nonJsxTransform,
+  null,
+  "Plain non-JSX modules should bypass the Vize JSX transform path",
+);
+
+const rawJsxTransform = await transformHook(jsxState, jsxFixtureSource, `${jsxFixturePath}?raw`, {
+  ssr: false,
+});
+assert.equal(
+  rawJsxTransform,
+  null,
+  "?raw imports of a .jsx file should keep Vite's default asset handling, not Vize compilation",
+);
+
 console.log("✅ vite-plugin-vize load boundary tests passed!");

--- a/npm/vite-plugin-vize/src/plugin/load.ts
+++ b/npm/vite-plugin-vize/src/plugin/load.ts
@@ -12,7 +12,7 @@ import {
   syncCollectedCssForFile,
   type VizePluginState,
 } from "./state.ts";
-import { compileFile } from "../compiler.ts";
+import { compileFile, compileJsxModule } from "../compiler.ts";
 import { generateOutput, hasDelegatedStyles } from "../utils/index.ts";
 import {
   resolveCssImports,
@@ -383,6 +383,70 @@ export function loadHook(
   return null;
 }
 
+function isJsxComponentPath(path: string): boolean {
+  return path.endsWith(".jsx") || path.endsWith(".tsx");
+}
+
+function shouldTransformJsxRequest(
+  state: VizePluginState,
+  request: ReturnType<typeof classifyVitePluginRequest>,
+): boolean {
+  if (!isJsxComponentPath(request.path)) {
+    return false;
+  }
+  // Skip Vite asset/worker imports of a JSX file (?raw, ?url, ?worker), which
+  // must keep Vite's default handling rather than being compiled to render code.
+  if (request.querySuffix) {
+    const params = new URLSearchParams(request.querySuffix.slice(1));
+    if (
+      params.has("raw") ||
+      params.has("url") ||
+      params.has("worker") ||
+      params.has("sharedworker")
+    ) {
+      return false;
+    }
+  }
+  // Honor an explicit user exclude (e.g. third-party JSX), but JSX/TSX is not
+  // covered by the default `**/*.vue` filter, so a bare extension match is enough.
+  if (state.mergedOptions.exclude && !state.filter(request.path)) {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Route a raw `.jsx`/`.tsx` request through Vize's JSX compiler.
+ *
+ * Returns `undefined` when the request is not a JSX/TSX component (so the
+ * caller falls through to the virtual-module pipeline), or a transform result
+ * otherwise.
+ */
+export function transformJsxRequest(
+  state: VizePluginState,
+  code: string,
+  id: string,
+): TransformResult | undefined {
+  const request = classifyVitePluginRequest(id);
+  if (!shouldTransformJsxRequest(state, request)) {
+    return undefined;
+  }
+
+  const realPath = request.normalizedFsId
+    ? classifyVitePluginRequest(request.normalizedFsId).path
+    : request.path;
+
+  const { code: compiled, warnings } = compileJsxModule(realPath, code, {
+    vapor: state.mergedOptions.vapor ?? false,
+  });
+
+  for (const warning of warnings) {
+    state.logger.warn(`Warning in ${realPath}: ${warning}`);
+  }
+
+  return { code: compiled, map: null };
+}
+
 // Strip TypeScript from compiled .vue output and apply define replacements
 export async function transformHook(
   state: VizePluginState,
@@ -391,6 +455,15 @@ export async function transformHook(
   options?: { ssr?: boolean },
 ): Promise<TransformResult | null> {
   const pluginVisibleVirtualPath = fromPluginVisibleVirtualId(id);
+
+  // Compile `.jsx`/`.tsx` Vue components through Vize. Unlike SFCs, JSX/TSX
+  // modules are real files Vite hands directly to the transform hook, so they
+  // are handled here rather than through the virtual-module load pipeline.
+  const jsxResult = transformJsxRequest(state, code, id);
+  if (jsxResult !== undefined) {
+    return jsxResult;
+  }
+
   if (!id.startsWith("\0") && !pluginVisibleVirtualPath) {
     return null;
   }

--- a/npm/vite-plugin-vize/src/test/fixtures/jsx/App.jsx
+++ b/npm/vite-plugin-vize/src/test/fixtures/jsx/App.jsx
@@ -1,0 +1,3 @@
+const App = () => <div class="greeting">{message}</div>;
+
+export default App;

--- a/npm/vite-plugin-vize/src/types.ts
+++ b/npm/vite-plugin-vize/src/types.ts
@@ -50,6 +50,25 @@ export type CompileSfcFn = (
   options?: SfcCompileOptionsNapi,
 ) => SfcCompileResultNapi;
 
+/** Options for the native `compileJsx` binding. */
+export interface JsxCompileOptionsNapi {
+  filename?: string;
+  lang?: string;
+  vapor?: boolean;
+}
+
+/** Result of the native `compileJsx` binding. */
+export interface JsxCompileResultNapi {
+  code: string;
+  errors: string[];
+  warnings: string[];
+}
+
+export type CompileJsxFn = (
+  source: string,
+  options?: JsxCompileOptionsNapi,
+) => JsxCompileResultNapi;
+
 export type VizeVueVersion = 0.11 | 1 | 2 | 3 | "legacy";
 
 export interface VizeCompatibilityOptions {


### PR DESCRIPTION
Part of #1500.

## What's implemented

Vite projects can now compile JSX/TSX Vue components through Vize — the headline acceptance of #1500. Raw `.jsx`/`.tsx` modules are routed through Vize's native `compileJsx` binding in `vite-plugin-vize`'s `transform` hook, mirroring how `unplugin-vize` handles JSX/TSX (#1524).

- `npm/vite-plugin-vize/src/compiler.ts` — new `compileJsxModule(filePath, source, { vapor })` wrapper calling native `compileJsx` (mirrors the SFC `compileFile` wrapper and unplugin-vize's `compileJsxModule`); infers `tsx`/`jsx` from the filename, surfaces compile errors as `VizeSfcCompileError`.
- `npm/vite-plugin-vize/src/plugin/load.ts` — `transformJsxRequest` detects `.jsx`/`.tsx` requests and compiles them; wired into `transformHook` ahead of the virtual-module pipeline. Skips Vite asset/worker imports (`?raw`/`?url`/`?worker`/`?sharedworker`) and honors an explicit user `exclude`. Both VDOM (default) and Vapor (`vapor: true`) output paths are supported.
- `npm/vite-plugin-vize/src/types.ts` — `CompileJsxFn` / `JsxCompileOptionsNapi` / `JsxCompileResultNapi` typings for the native binding.
- Tests + fixture: `src/test/fixtures/jsx/App.jsx`; unit tests in `compiler.test.ts` (VDOM/Vapor/TSX/error) and plugin-level transform routing tests in `plugin/load.test.ts` (raw `.jsx` → render code, Vapor template, `/@fs` `.tsx`, `?raw` bypass, non-JSX bypass).

### Where Vite request classification lives

In **Rust** (`classifyVitePluginRequest`, `crates/vize_vitrine` → `vize_atelier_sfc::vite_plugin`). JSX/TSX detection reads the already-exposed `request.path` by extension, so **no native API change was required** and the existing prebuilt `@vizejs/native` (which gained `compileJsx` in #1524, now on main) is sufficient. (An additive `is_jsx_path` classification field was prototyped but reverted: adding a `pub` field to the externally-constructible `VitePluginRequest`/`VitePluginRequestNapi` structs trips `cargo-semver-checks` `constructible_struct_adds_field` against the PR base, and the suffix check needs no native round-trip.)

## Deferred (out of scope for this PR)

rspack/webpack and Nuxt JSX integration, SSR/HMR/sourcemaps/CSS handling for JSX modules, and the wasm build path.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1528"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->