### PR TITLE
feat(integrations): support JSX/TSX in the Vize Nuxt module (#1500)

### DIFF
--- a/npm/nuxt/src/index.ts
+++ b/npm/nuxt/src/index.ts
@@ -31,6 +31,7 @@ import {
 import {
   buildNuxtDevAssetBase,
   isVizeGeneratedVueModuleId,
+  isVizeJsxModuleId,
   isVizeVirtualVueModuleId,
   normalizeVizeVirtualVueModuleId,
   preserveExplicitVueImportsFromNuxtAutoImports,
@@ -426,10 +427,13 @@ export default defineNuxtModule<VizeNuxtOptions>({
         name: "vizejs:nuxt-transform-bridge",
         enforce: "post" as const,
         async transform(code: string, id: string, ...args: unknown[]) {
-          // Only process vize-generated Vue modules. In dev, Vite can call
+          // Only process Vize-compiled component modules. In dev, Vite can call
           // transform hooks with the plugin-visible `.vue.ts?vue&vize` ID
-          // rather than Rollup's internal `\0` virtual ID.
-          if (!isVizeGeneratedVueModuleId(id)) return;
+          // rather than Rollup's internal `\0` virtual ID. Raw `.jsx`/`.tsx`
+          // Vue components are compiled in place (no `.vue.ts` virtual id), so
+          // they are matched separately and still receive Nuxt's auto-import,
+          // component, and i18n bridging.
+          if (!isVizeGeneratedVueModuleId(id) && !isVizeJsxModuleId(id)) return;
 
           let result = code;
           let changed = false;

--- a/npm/nuxt/src/utils-edge.test.ts
+++ b/npm/nuxt/src/utils-edge.test.ts
@@ -7,6 +7,7 @@ import {
   buildNuxtCompilerOptions,
   buildNuxtDevAssetBase,
   isVizeGeneratedVueModuleId,
+  isVizeJsxModuleId,
   isVizeVirtualVueModuleId,
   normalizeNuxtInjectedKeysForVizeVirtualModule,
   normalizeVizeGeneratedVueModuleId,
@@ -95,6 +96,30 @@ void test("ids without .vue are rejected and a query after .vue.ts is accepted",
   assert.equal(isVizeGeneratedVueModuleId("/App.ts"), false);
   assert.equal(isVizeVirtualVueModuleId("\0/App.vue.ts?vue"), true);
   assert.equal(isVizeGeneratedVueModuleId("/App.vue.ts?vue"), true);
+});
+
+void test("isVizeJsxModuleId matches in-place .jsx and .tsx component modules", () => {
+  // Raw JSX/TSX Vue components are compiled in place: the underlying Vite
+  // plugin keeps the original id (no `.vue.ts` virtual), so the Nuxt bridge
+  // must recognize them through this predicate to apply auto-imports etc.
+  assert.equal(isVizeJsxModuleId("/components/Foo.jsx"), true);
+  assert.equal(isVizeJsxModuleId("/components/Foo.tsx"), true);
+  // A plain `?vue` dev-server query suffix still matches.
+  assert.equal(isVizeJsxModuleId("/components/Foo.tsx?vue"), true);
+  // Such modules are NOT seen as `.vue` virtual/generated modules.
+  assert.equal(isVizeGeneratedVueModuleId("/components/Foo.tsx"), false);
+  assert.equal(isVizeVirtualVueModuleId("\0/components/Foo.tsx"), false);
+});
+
+void test("isVizeJsxModuleId rejects non-JSX ids and asset-import queries", () => {
+  assert.equal(isVizeJsxModuleId("/App.vue.ts"), false);
+  assert.equal(isVizeJsxModuleId("/App.ts"), false);
+  assert.equal(isVizeJsxModuleId("/App.js"), false);
+  // `.jsx`/`.tsx` referenced as raw/url/worker assets are not component modules.
+  assert.equal(isVizeJsxModuleId("/icon.tsx?raw"), false);
+  assert.equal(isVizeJsxModuleId("/icon.tsx?url"), false);
+  assert.equal(isVizeJsxModuleId("/worker.jsx?worker"), false);
+  assert.equal(isVizeJsxModuleId("/worker.jsx?sharedworker"), false);
 });
 
 void test("normalizeVizeVirtualVueModuleId strips the NUL and the optional vize-ssr prefix", () => {

--- a/npm/nuxt/src/utils.ts
+++ b/npm/nuxt/src/utils.ts
@@ -77,6 +77,40 @@ export function isVizeGeneratedVueModuleId(id: string): boolean {
   return /\.vue\.ts(?:\?|$)/.test(normalized);
 }
 
+/**
+ * Recognize raw `.jsx`/`.tsx` Vue component modules compiled by Vize.
+ *
+ * Unlike `.vue` files, JSX/TSX modules are transformed in place by the
+ * underlying Vite plugin (the original `.jsx`/`.tsx` id is preserved, no
+ * `\0`-prefixed `.vue.ts` virtual id is created). Nuxt's auto-import,
+ * component, and i18n transforms still need to run on these modules, so the
+ * Nuxt transform bridge keys off this predicate in addition to
+ * `isVizeGeneratedVueModuleId`.
+ *
+ * A bare query suffix (e.g. `?vue`) is ignored so dev-server requests still
+ * match, but `?raw`/`?url`/`?worker` asset imports are rejected since those
+ * are not compiled component modules.
+ */
+export function isVizeJsxModuleId(id: string): boolean {
+  const queryIndex = id.indexOf("?");
+  const pathPart = queryIndex === -1 ? id : id.slice(0, queryIndex);
+  if (!/\.(?:jsx|tsx)$/.test(pathPart)) {
+    return false;
+  }
+
+  if (queryIndex === -1) {
+    return true;
+  }
+
+  const params = new URLSearchParams(id.slice(queryIndex + 1));
+  return !(
+    params.has("raw") ||
+    params.has("url") ||
+    params.has("worker") ||
+    params.has("sharedworker")
+  );
+}
+
 export function normalizeVizeVirtualVueModuleId(id: string): string {
   const withoutPrefix = id.startsWith("\0vize-ssr:") ? id.slice("\0vize-ssr:".length) : id.slice(1);
   return withoutPrefix.replace(/\.ts(?=\?|$)/, "");


### PR DESCRIPTION
Part of #1500.

Makes the Vize Nuxt module cover raw `.jsx`/`.tsx` Vue components.

## What

The Nuxt module already forwards its compiler config to `@vizejs/vite-plugin` untouched, with no `.vue`-only gate — so `.jsx`/`.tsx` compile through Vize once the Vite plugin routes them (its JSX path is the sibling part of #1500). The one Nuxt-owned gap was the **transform bridge**: it re-applies Nuxt's auto-import / component / i18n injection (which Nuxt's own plugins skip on Vize's virtual ids), but it only recognized `.vue` modules.

Unlike `.vue` files — compiled into `\0`-prefixed `.vue.ts` virtual modules — JSX/TSX modules are transformed **in place** (original id preserved). `isVizeGeneratedVueModuleId` only matches `.vue.ts` virtual ids, so the bridge skipped JSX/TSX.

This PR:
- Adds `isVizeJsxModuleId` (matches in-place `.jsx`/`.tsx` ids; honors a bare `?vue` dev query, rejects `?raw`/`?url`/`?worker` asset imports).
- Extends the `vizejs:nuxt-transform-bridge` gate to accept JSX/TSX in addition to `.vue.ts`, so Nuxt auto-imports/components/i18n reach JSX components — mirroring `.vue`.
- Adds unit tests for the predicate (positive + asset-query rejection).

The `.vue`-source-reading bridge helpers (`preserveExplicitVueImportsFromVizeModuleSource`, `stabilizeNuxtInjectedKeysForVizeVirtualModule`) already self-guard to `.vue` sources, so they remain no-ops on JSX.

## Tests

`npm/nuxt` `node --test`: 103 pass / 0 fail. `vp check` (fmt + lint, 22 files): clean.

## Deferred

- SSR-specific JSX handling
- HMR for JSX/TSX components
- Sourcemaps for JSX output
- CSS / scoped-style handling for JSX components

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1529"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->