### PR TITLE
feat(integrations): compile .jsx/.tsx through rspack-vize-plugin (#1500)

### DIFF
--- a/npm/rspack-vize-plugin/package.json
+++ b/npm/rspack-vize-plugin/package.json
@@ -39,6 +39,11 @@
       "import": "./dist/loader/index.mjs",
       "default": "./dist/loader/index.mjs"
     },
+    "./jsx-loader": {
+      "types": "./dist/loader/jsx-loader.d.mts",
+      "import": "./dist/loader/jsx-loader.mjs",
+      "default": "./dist/loader/jsx-loader.mjs"
+    },
     "./style-loader": {
       "types": "./dist/loader/style-loader.d.mts",
       "import": "./dist/loader/style-loader.mjs",

--- a/npm/rspack-vize-plugin/src/index.ts
+++ b/npm/rspack-vize-plugin/src/index.ts
@@ -8,6 +8,7 @@ export type { VizeRspackPluginOptions } from "./types/index.ts";
 
 // Loaders (for direct import)
 export { default as vizeLoader } from "./loader/index.ts";
+export { default as vizeJsxLoader } from "./loader/jsx-loader.ts";
 export { default as vizeStyleLoader } from "./loader/style-loader.ts";
 export { default as vizeScopeLoader } from "./loader/scope-loader.ts";
 export type { VizeLoaderOptions, VizeStyleLoaderOptions } from "./types/index.ts";
@@ -25,7 +26,13 @@ export {
 
 export { genHotReloadCode } from "./shared/hotReload.ts";
 
-export { compileFile, generateOutput, clearCompilationCache } from "./shared/compiler.ts";
+export {
+  compileFile,
+  compileJsxModule,
+  isJsxFile,
+  generateOutput,
+  clearCompilationCache,
+} from "./shared/compiler.ts";
 
 // Types
 export type {
@@ -36,5 +43,7 @@ export type {
   SfcSrcInfo,
   SfcCompileOptionsNapi,
   SfcCompileResultNapi,
+  JsxCompileOptionsNapi,
+  JsxCompileResultNapi,
   LoaderEntry,
 } from "./types/index.ts";

--- a/npm/rspack-vize-plugin/src/jsx.test.ts
+++ b/npm/rspack-vize-plugin/src/jsx.test.ts
@@ -1,0 +1,124 @@
+import { test } from "node:test";
+import path from "node:path";
+import { rspack } from "@rspack/core";
+import "./test/setup.ts";
+import { VizePlugin } from "./plugin/index.ts";
+import { packageRoot, prepareOutputDir, resolveFixturePath } from "./test/helpers.ts";
+
+function runCompiler(compiler: ReturnType<typeof rspack>) {
+  return new Promise<NonNullable<Parameters<Parameters<typeof compiler.run>[0]>[1]>>(
+    (resolve, reject) => {
+      compiler.run((error, stats) => {
+        compiler.close((closeError) => {
+          if (error || closeError) {
+            reject(error ?? closeError);
+            return;
+          }
+          if (!stats) {
+            reject(new Error("Rspack did not return stats"));
+            return;
+          }
+          resolve(stats);
+        });
+      });
+    },
+  );
+}
+
+/** Build a fixture routing `.jsx`/`.tsx` through the dist JSX loader. */
+function createJsxCompiler(
+  fixtureName: string,
+  outputName: string,
+  vapor: boolean,
+): ReturnType<typeof rspack> {
+  return rspack({
+    mode: "development",
+    devtool: false,
+    context: resolveFixturePath(fixtureName, "."),
+    entry: {
+      main: resolveFixturePath(fixtureName, "entry.ts"),
+    },
+    output: {
+      path: prepareOutputDir(outputName),
+      filename: "bundle.js",
+      clean: true,
+    },
+    externals: {
+      vue: "vue",
+    },
+    infrastructureLogging: {
+      level: "error",
+    },
+    resolve: {
+      extensions: ["...", ".ts", ".js", ".jsx", ".tsx"],
+    },
+    module: {
+      rules: [
+        {
+          test: /\.ts$/,
+          loader: "builtin:swc-loader",
+          options: { jsc: { parser: { syntax: "typescript" } } },
+        },
+        // Route `.jsx`/`.tsx` Vue components through the Vize JSX loader.
+        {
+          test: /\.[jt]sx$/,
+          use: [
+            {
+              loader: path.join(packageRoot, "dist", "loader", "jsx-loader.mjs"),
+              options: { vapor },
+            },
+          ],
+        },
+      ],
+    },
+    plugins: [new VizePlugin({ vapor })],
+  });
+}
+
+function bundleSource(stats: Awaited<ReturnType<typeof runCompiler>>): string {
+  return Object.values(stats.compilation.assets)
+    .map((asset) => asset.source().toString())
+    .join("\n");
+}
+
+void test("jsx: a .jsx Vue component compiles to VDOM render code", async (t) => {
+  const compiler = createJsxCompiler("jsx-vdom", "jsx-vdom", false);
+  const stats = await runCompiler(compiler);
+
+  if (stats.hasErrors()) {
+    const info = stats.toJson({ all: false, errors: true });
+    throw new Error(JSON.stringify(info.errors, null, 2));
+  }
+
+  const bundle = bundleSource(stats);
+  t.assert.ok(
+    bundle.includes("_createElementBlock"),
+    "VDOM bundle should contain _createElementBlock",
+  );
+});
+
+void test("jsx: a vapor .jsx component compiles to template render code", async (t) => {
+  const compiler = createJsxCompiler("jsx-vapor", "jsx-vapor", true);
+  const stats = await runCompiler(compiler);
+
+  if (stats.hasErrors()) {
+    const info = stats.toJson({ all: false, errors: true });
+    throw new Error(JSON.stringify(info.errors, null, 2));
+  }
+
+  const bundle = bundleSource(stats);
+  // The vapor path emits a `_template(...)` call importing `template` from
+  // `vue`; rspack rewrites the externalized import (e.g.
+  // `(0,vue__rspack_import_0.template)(...)`). The vapor output never goes
+  // through the VDOM `_createElementBlock` block helper, and it inlines the
+  // component markup into a static template string.
+  t.assert.ok(bundle.includes(".template)"), "vapor bundle should contain a template() call");
+  t.assert.ok(
+    bundle.includes("jsx-vapor-app") && bundle.includes("hello vapor jsx"),
+    "vapor bundle should inline the component markup into a template string",
+  );
+  t.assert.ok(
+    !bundle.includes("_createElementBlock"),
+    "vapor bundle should not contain VDOM _createElementBlock",
+  );
+});

--- a/npm/rspack-vize-plugin/src/loader/jsx-loader.ts
+++ b/npm/rspack-vize-plugin/src/loader/jsx-loader.ts
@@ -1,0 +1,60 @@
+/**
+ * JSX/TSX loader. Compiles `.jsx`/`.tsx` Vue components → render code via the
+ * native JSX compiler. Mirrors the main `.vue` loader's routing, but the JSX
+ * lowering path has no style/custom blocks, so the output is the render module
+ * verbatim. TypeScript stripping for `.tsx` is left to a `builtin:swc-loader`
+ * post-rule, exactly as `.vue` files rely on one.
+ */
+
+import type { LoaderContext } from "@rspack/core";
+import { compileJsxModule } from "../shared/compiler.ts";
+import { matchesPattern } from "../shared/utils.ts";
+import type { VizeLoaderOptions } from "../types/index.ts";
+
+export default function vizeJsxLoader(
+  this: LoaderContext<VizeLoaderOptions>,
+  source: string,
+): void {
+  const callback = this.async();
+  const options = this.getOptions();
+  const resourcePath = this.resourcePath;
+
+  this.addDependency(resourcePath);
+
+  if (!shouldCompileFile(resourcePath, options)) {
+    this.emitWarning(
+      new Error(
+        `[vize] File is filtered out by loader options include/exclude: ${resourcePath}. ` +
+          `Passing through source unchanged.`,
+      ),
+    );
+    callback(null, source);
+    return;
+  }
+
+  try {
+    const { code, warnings } = compileJsxModule(resourcePath, source, {
+      vapor: options.vapor ?? false,
+    });
+
+    for (const warning of warnings) {
+      this.emitWarning(new Error(`[vize] ${warning}`));
+    }
+
+    callback(null, code);
+  } catch (error) {
+    callback(error as Error);
+  }
+}
+
+function shouldCompileFile(file: string, options: VizeLoaderOptions): boolean {
+  if (!matchesPattern(file, options.include, true)) {
+    return false;
+  }
+
+  if (matchesPattern(file, options.exclude, false)) {
+    return false;
+  }
+
+  return true;
+}

--- a/npm/rspack-vize-plugin/src/shared/compiler.ts
+++ b/npm/rspack-vize-plugin/src/shared/compiler.ts
@@ -2,7 +2,11 @@
 
 import { createHash } from "node:crypto";
 import * as native from "@vizejs/native";
-import type { CompiledModule, SfcCompileOptionsNapi } from "../types/index.ts";
+import type {
+  CompiledModule,
+  JsxCompileResultNapi,
+  SfcCompileOptionsNapi,
+} from "../types/index.ts";
 import {
   generateScopeId,
   collectTemplateAssetUrls,
@@ -13,6 +17,38 @@ import {
 export { generateOutput } from "./output.ts";
 
 const { compileSfc } = native;
+
+const { compileJsx } = native as {
+  compileJsx: (source: string, options?: Record<string, unknown>) => JsxCompileResultNapi;
+};
+
+/** `.jsx`/`.tsx` Vue components routed to the native JSX compiler. */
+export function isJsxFile(filePath: string): boolean {
+  return filePath.endsWith(".jsx") || filePath.endsWith(".tsx");
+}
+
+/**
+ * Compile a `.jsx`/`.tsx` Vue module to render code via the native JSX
+ * compiler. Mirrors {@link compileFile} but for the JSX lowering path: no
+ * scoped CSS, custom blocks, or asset-url rewriting apply.
+ */
+export function compileJsxModule(
+  filePath: string,
+  source: string,
+  options: { vapor?: boolean } = {},
+): { code: string; warnings: string[] } {
+  const result = compileJsx(source, {
+    filename: filePath,
+    lang: filePath.endsWith(".tsx") ? "tsx" : "jsx",
+    vapor: options.vapor ?? false,
+  });
+
+  if (result.errors.length > 0) {
+    throw new Error(`[vize] Compilation failed for ${filePath}:\n${result.errors.join("\n")}`);
+  }
+
+  return { code: result.code, warnings: result.warnings };
+}
 
 // Compilation Cache
 

--- a/npm/rspack-vize-plugin/src/test/fixtures/jsx-vapor/App.jsx
+++ b/npm/rspack-vize-plugin/src/test/fixtures/jsx-vapor/App.jsx
@@ -1,0 +1,9 @@
+export default function App() {
+  const count = 1;
+  return (
+    <div class="jsx-vapor-app">
+      <p>hello vapor jsx</p>
+      <span>{count + 1}</span>
+    </div>
+  );
+}

--- a/npm/rspack-vize-plugin/src/test/fixtures/jsx-vapor/entry.ts
+++ b/npm/rspack-vize-plugin/src/test/fixtures/jsx-vapor/entry.ts
@@ -1,0 +1,4 @@
+// The JSX loader lowers `App.jsx` to a vapor render module exporting `render`.
+import { render } from "./App.jsx";
+
+export default render;

--- a/npm/rspack-vize-plugin/src/test/fixtures/jsx-vdom/App.jsx
+++ b/npm/rspack-vize-plugin/src/test/fixtures/jsx-vdom/App.jsx
@@ -1,0 +1,9 @@
+export default function App() {
+  const count = 1;
+  return (
+    <div class="jsx-app">
+      <p>hello jsx</p>
+      <span>{count + 1}</span>
+    </div>
+  );
+}

--- a/npm/rspack-vize-plugin/src/test/fixtures/jsx-vdom/entry.ts
+++ b/npm/rspack-vize-plugin/src/test/fixtures/jsx-vdom/entry.ts
@@ -1,0 +1,4 @@
+// The JSX loader lowers `App.jsx` to a render module exporting `render`.
+import { render } from "./App.jsx";
+
+export default render;

--- a/npm/rspack-vize-plugin/src/types/index.ts
+++ b/npm/rspack-vize-plugin/src/types/index.ts
@@ -62,6 +62,28 @@ export interface SfcCompileResultNapi {
   macroArtifacts?: MacroArtifact[];
 }
 
+// JSX Compile API Types
+
+/** Options for the native `compileJsx`. */
+export interface JsxCompileOptionsNapi {
+  /** Source filename, used to infer the language when `lang` is omitted. */
+  filename?: string;
+  /** Source language: "jsx" or "tsx". Inferred from a `.tsx` filename. */
+  lang?: string;
+  /** Default output mode: `true` → Vapor, `false` (default) → VDOM. */
+  vapor?: boolean;
+}
+
+/** Result of the native `compileJsx`. */
+export interface JsxCompileResultNapi {
+  /** Generated render code for every component in the module. */
+  code: string;
+  /** Error-severity diagnostic messages. */
+  errors: string[];
+  /** Warning-severity diagnostic messages. */
+  warnings: string[];
+}
+
 // CSS Compile API Types
 
 export interface CssCompileTargets {

--- a/npm/rspack-vize-plugin/vite.config.ts
+++ b/npm/rspack-vize-plugin/vite.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
     entry: [
       "src/index.ts",
       "src/loader/index.ts",
+      "src/loader/jsx-loader.ts",
       "src/loader/style-loader.ts",
       "src/loader/scope-loader.ts",
     ],


### PR DESCRIPTION
Part of #1500

Routes `.jsx`/`.tsx` Vue components through the native `compileJsx` lowering in `@vizejs/rspack-plugin`, mirroring the unplugin/vite JS-only approach (no native API change).

- `shared/compiler.ts`: `compileJsxModule()` wrapper over native `compileJsx` + `isJsxFile()` detection
- `loader/jsx-loader.ts`: new rspack loader routing `.jsx`/`.tsx` to the JSX compiler (exported as `@vizejs/rspack-plugin/jsx-loader`)
- JSX types (`JsxCompileOptionsNapi`/`JsxCompileResultNapi`) + exports
- `jsx.test.ts` + `jsx-vdom`/`jsx-vapor` fixtures: assert a `.jsx` component compiles to VDOM (`_createElementBlock`) and a vapor build to a `template()` render module

rspack JSX done; deferred: SSR/HMR/sourcemaps/CSS/wasm.

All 80 package tests pass; `vp check` clean. No Rust changes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1530"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->