### PR TITLE
feat(integrations): expose compileJsx in the WASM binding (#1500)

### DIFF
--- a/crates/vize_vitrine/src/wasm/jsx.rs
+++ b/crates/vize_vitrine/src/wasm/jsx.rs
@@ -1,0 +1,109 @@
+//! WASM binding for JSX/TSX compilation.
+//!
+//! Mirrors the NAPI `compileJsx` binding (`crate::napi::jsx`) and the WASM
+//! `compileSfc` binding: a `.jsx`/`.tsx` source string in, generated render
+//! code + diagnostics out. The per-component `"use vue:vapor"` /
+//! `"use vue:vdom"` directive prologue is handled inside
+//! [`vize_atelier_jsx::compile_jsx`]; the `vapor` option here only selects the
+//! default mode for components without an explicit directive.
+
+use serde::Serialize;
+use wasm_bindgen::prelude::*;
+
+use vize_atelier_jsx::{JsxCompileConfig, JsxLang, JsxOutputMode, compile_jsx as jsx_compile};
+use vize_carton::Bump;
+
+use super::serde::to_json_js_value;
+
+/// JSX/TSX compile result for WASM.
+#[derive(Serialize)]
+struct JsxWasmResult {
+    /// Generated render code for every component in the module, in source
+    /// order, concatenated.
+    code: String,
+    /// Error-severity diagnostic messages.
+    errors: Vec<String>,
+    /// Warning-severity diagnostic messages.
+    warnings: Vec<String>,
+}
+
+/// Resolve the source language from the JS options object, mirroring the NAPI
+/// binding: explicit `lang` wins, otherwise infer from `filename`, otherwise
+/// default to JSX.
+fn resolve_lang(options: &JsValue) -> JsxLang {
+    let lang = js_sys::Reflect::get(options, &JsValue::from_str("lang"))
+        .ok()
+        .and_then(|v| v.as_string());
+
+    match lang.as_deref() {
+        Some(lang) => JsxLang::from_lang(Some(lang)),
+        None => {
+            let filename = js_sys::Reflect::get(options, &JsValue::from_str("filename"))
+                .ok()
+                .and_then(|v| v.as_string());
+            match filename.as_deref() {
+                Some(filename) => JsxLang::from_path(filename),
+                None => JsxLang::Jsx,
+            }
+        }
+    }
+}
+
+/// Resolve the default output mode from the JS options object. `vapor: true`
+/// selects Vapor; anything else (including absent) defaults to VDOM, matching
+/// the NAPI binding.
+fn resolve_default_mode(options: &JsValue) -> JsxOutputMode {
+    let vapor = js_sys::Reflect::get(options, &JsValue::from_str("vapor"))
+        .ok()
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+
+    if vapor {
+        JsxOutputMode::Vapor
+    } else {
+        JsxOutputMode::Vdom
+    }
+}
+
+fn compile_jsx_internal(source: &str, options: &JsValue) -> JsxWasmResult {
+    let lang = resolve_lang(options);
+    let default_mode = resolve_default_mode(options);
+
+    let config = JsxCompileConfig {
+        default_mode,
+        ..Default::default()
+    };
+
+    let bump = Bump::new();
+    let output = jsx_compile(&bump, source, lang, &config);
+
+    let mut code = String::new();
+    for component in &output.components {
+        if !code.is_empty() {
+            code.push('\n');
+        }
+        code.push_str(component.code());
+    }
+
+    let mut errors = Vec::new();
+    let mut warnings = Vec::new();
+    for diagnostic in &output.diagnostics {
+        if diagnostic.is_error() {
+            errors.push(diagnostic.message.as_str().to_string());
+        } else {
+            warnings.push(diagnostic.message.as_str().to_string());
+        }
+    }
+
+    JsxWasmResult {
+        code,
+        errors,
+        warnings,
+    }
+}
+
+/// Compile JSX/TSX to render code (free function).
+#[wasm_bindgen(js_name = "compileJsx")]
+pub fn compile_jsx(source: &str, options: JsValue) -> Result<JsValue, JsValue> {
+    to_json_js_value(&compile_jsx_internal(source, &options))
+}

--- a/crates/vize_vitrine/src/wasm/mod.rs
+++ b/crates/vize_vitrine/src/wasm/mod.rs
@@ -20,6 +20,7 @@ mod cross_file;
 #[cfg(feature = "glyph")]
 mod format;
 mod inspector;
+mod jsx;
 mod lint;
 mod musea;
 mod options;
@@ -40,6 +41,7 @@ pub use cross_file::*;
 #[cfg(feature = "glyph")]
 pub use format::*;
 pub use inspector::*;
+pub use jsx::*;
 pub use lint::*;
 pub use musea::*;
 pub use sfc_types::*;

--- a/npm/vize-wasm/index.d.ts
+++ b/npm/vize-wasm/index.d.ts
@@ -151,6 +151,36 @@ export interface SfcCompileResult {
   macroArtifacts?: MacroArtifact[];
 }
 
+/** JSX/TSX compile options */
+export interface JsxCompileOptions {
+  /** Source filename, used to infer the language when `lang` is omitted. */
+  filename?: string;
+  /**
+   * Source language. Defaults to `"jsx"` (or is inferred from a `.tsx`
+   * `filename`).
+   */
+  lang?: "jsx" | "tsx";
+  /**
+   * Default output mode: `true` compiles components to Vapor, `false`
+   * (default) to VDOM. Per-component `"use vue:vapor"` / `"use vue:vdom"`
+   * directives override this.
+   */
+  vapor?: boolean;
+}
+
+/** Result of JSX/TSX compilation */
+export interface JsxCompileResult {
+  /**
+   * Generated render code for every component in the module, in source order,
+   * concatenated.
+   */
+  code: string;
+  /** Compilation errors */
+  errors: string[];
+  /** Compilation warnings */
+  warnings: string[];
+}
+
 /** CSS compile options */
 export interface CssCompileOptions {
   /** Scope ID for scoped CSS */
@@ -246,6 +276,12 @@ export declare function compileSfc(
   source: string,
   options?: SfcCompileOptions
 ): SfcCompileResult;
+
+/** Compile JSX/TSX to render code */
+export declare function compileJsx(
+  source: string,
+  options?: JsxCompileOptions
+): JsxCompileResult;
 
 /** Compile CSS with LightningCSS */
 export declare function compileCss(

--- a/npm/vize-wasm/index.js
+++ b/npm/vize-wasm/index.js
@@ -11,6 +11,7 @@ import initWasm, {
   parseTemplate as wasmParseTemplate,
   parseSfc as wasmParseSfc,
   compileSfc as wasmCompileSfc,
+  compileJsx as wasmCompileJsx,
   compileCss as wasmCompileCss,
 } from "./vize_vitrine.js";
 
@@ -210,6 +211,18 @@ export function parseSfc(source, options = {}) {
 export function compileSfc(source, options = {}) {
   ensureInitialized();
   return wasmCompileSfc(source, options);
+}
+
+/**
+ * Compile JSX/TSX to render code.
+ *
+ * @param {string} source
+ * @param {object} [options]
+ * @returns {object}
+ */
+export function compileJsx(source, options = {}) {
+  ensureInitialized();
+  return wasmCompileJsx(source, options);
 }
 
 /**

--- a/tests/tooling/wasm-package-smoke.test.ts
+++ b/tests/tooling/wasm-package-smoke.test.ts
@@ -38,6 +38,7 @@ export function compileVapor() {}
 export function parseTemplate() {}
 export function parseSfc() {}
 export function compileSfc() {}
+export function compileJsx() {}
 export function compileCss() {}
 `,
   );

--- a/tools/npm/smoke-wasm-package.mjs
+++ b/tools/npm/smoke-wasm-package.mjs
@@ -20,6 +20,7 @@ const REQUIRED_EXPORTS = [
   "Compiler",
   "compile",
   "compileCss",
+  "compileJsx",
   "compileSfc",
   "compileVapor",
   "default",


### PR DESCRIPTION
Part of #1500.

Adds a WASM/browser `compileJsx` binding mirroring the NAPI one (`crates/vize_vitrine/src/napi/jsx.rs`).

## What
- New WASM free function `compileJsx(source, options)` in `crates/vize_vitrine/src/wasm/jsx.rs`, registered in `wasm/mod.rs`. Calls `vize_atelier_jsx::compile_jsx` with a `Bump`, mirroring the `compileSfc` WASM pattern (JS options object parsed via `js_sys::Reflect`, result serialized via `to_json_js_value`).
- Options: `lang` (`jsx`|`tsx`, inferred from `filename` when omitted), `vapor` (default output mode; per-component `use vue:vapor`/`use vue:vdom` directives override). Result: `{ code, errors, warnings }` — same shape as the NAPI binding.
- `npm/vize-wasm`: added `compileJsx` export + JSDoc to `index.js`, `JsxCompileOptions`/`JsxCompileResult` + function decl to `index.d.ts`, and `compileJsx` to the package smoke test's required-exports list.

## Verified
- Native `cargo build -p vize_vitrine` green.
- wasm-cfg `cargo build -p vize_vitrine --no-default-features --features wasm --target wasm32-unknown-unknown` (with `RUSTFLAGS=--cfg getrandom_backend="wasm_js"`) green.
- Built the release wasm + `wasm-bindgen --target web`, loaded in Node, and confirmed `compileJsx('const A = () => <div/>;', { lang: 'jsx' })` returns render code (VDOM default, `vapor: true`, and `.tsx`-via-filename all produce correct output).
- `cargo fmt -p vize_vitrine -- --check` clean; `cargo clippy --workspace -- -D warnings` clean; `cargo semver-checks -p vize_vitrine` additive (no semver update required).

## Remaining (deferred, part of #1500)
SSR / HMR / sourcemaps / CSS for the JSX path.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1531"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->