### PR TITLE
refactor(canon): span-based export-default rewrite, drop line scanner (#1394)

### DIFF
--- a/crates/vize_canon/src/virtual_ts/generator/mod.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/mod.rs
@@ -242,6 +242,7 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
     };
     let default_export_object = default_export_targets.object;
     let default_export_class = default_export_targets.class;
+    let default_export_expr = default_export_targets.expr;
     if default_export_object.is_some() {
         ts.push_str(DEFINE_COMPONENT_HELPER);
     }
@@ -351,20 +352,27 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
 
                 let gen_start = ts.len();
                 if text.contains("export default") {
-                    // Re-base the script-absolute default-export-object
-                    // offsets onto this module span so the rewrite can wrap
-                    // a plain options object with `defineComponent`.
-                    let span_relative_object = default_export_object.and_then(
-                        |(export_start, object_start, object_end)| {
-                            let span_start = start as usize;
-                            (export_start >= span_start && object_end <= end as usize).then_some((
-                                export_start - span_start,
-                                object_start - span_start,
-                                object_end - span_start,
-                            ))
-                        },
+                    // Re-base the script-absolute default-export offsets onto
+                    // this module span so the rewrite can wrap a plain options
+                    // object with `defineComponent`, or rewrite any other shape
+                    // to a bare `const __default__ = <expr>`, by slicing on AST
+                    // byte offsets instead of scanning lines.
+                    let span_start = start as usize;
+                    let span_end = end as usize;
+                    let rebase = |(export_start, inner_start, inner_end): (usize, usize, usize)| {
+                        (export_start >= span_start && inner_end <= span_end).then_some((
+                            export_start - span_start,
+                            inner_start - span_start,
+                            inner_end - span_start,
+                        ))
+                    };
+                    let span_relative_object = default_export_object.and_then(rebase);
+                    let span_relative_expr = default_export_expr.and_then(rebase);
+                    let text = rewrite_export_default_for_module_scope(
+                        text,
+                        span_relative_object,
+                        span_relative_expr,
                     );
-                    let text = rewrite_export_default_for_module_scope(text, span_relative_object);
                     ts.push_str(&text);
                 } else {
                     ts.push_str(text);

--- a/crates/vize_canon/src/virtual_ts/generator/options_api.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/options_api.rs
@@ -413,7 +413,7 @@ fn collect_mapped_type(call: &CallExpression<'_>, mapped_types: &mut Vec<String>
 
 /// Byte offsets locating the rewriteable shape of a `<script>` default export.
 ///
-/// Both fields are offsets into the parsed `script`. A single default export is
+/// All fields are offsets into the parsed `script`. A single default export is
 /// at most one of these (an SFC module has one default export), so at most one
 /// field is `Some`.
 #[derive(Default, Clone, Copy)]
@@ -435,9 +435,21 @@ pub(super) struct DefaultExportTargets {
     /// so stripping only the keyword run keeps `@Component()` on a real class
     /// declaration either way (the line-based fallback would move it onto a
     /// `const`, which TypeScript rejects with TS1206). Anonymous default classes
-    /// stay `None` (no name to alias by) and fall through to the existing
-    /// rewrite.
+    /// stay `None` (no name to alias by) and fall through to the generic
+    /// `expr` rewrite below.
     pub class: Option<(usize, usize, usize, usize, usize)>,
+    /// Any other default-export shape, rewritten to a bare
+    /// `const __default__ = <expr>` at module scope, as
+    /// `(export_start, expr_start, expr_end)`. Covers
+    /// `export default defineComponent({...})`, identifiers, parenthesized /
+    /// `as` / `satisfies` expressions, anonymous classes/functions, and
+    /// `export default{` with no space — including multi-line / awkwardly
+    /// formatted variants. `export_start..expr_start` is the `export default`
+    /// keyword run that is dropped; `expr_start..expr_end` is the exported
+    /// expression copied verbatim. This is the span-based replacement for the
+    /// former line-scanning fallback, so it is only populated when neither
+    /// `object` nor `class` applies.
+    pub expr: Option<(usize, usize, usize)>,
 }
 
 /// Classify a `<script>` default export in a single parse. Parsing once keeps
@@ -466,18 +478,31 @@ pub(super) fn find_default_export_targets(script: &str) -> DefaultExportTargets 
                     object_span.end as usize,
                 ));
             }
-            ExportDefaultDeclarationKind::ClassDeclaration(class) => {
-                if let Some(id) = class.id.as_ref() {
-                    targets.class = Some((
-                        export.span.start as usize,
-                        class.span.start as usize,
-                        class.span.end as usize,
-                        id.span.start as usize,
-                        id.span.end as usize,
-                    ));
-                }
+            ExportDefaultDeclarationKind::ClassDeclaration(class) if class.id.is_some() => {
+                let id = class.id.as_ref().expect("class id checked by guard");
+                targets.class = Some((
+                    export.span.start as usize,
+                    class.span.start as usize,
+                    class.span.end as usize,
+                    id.span.start as usize,
+                    id.span.end as usize,
+                ));
             }
-            _ => {}
+            // Every other default-export shape (already-wrapped
+            // `defineComponent(...)`, identifiers, `as`/`satisfies`,
+            // anonymous classes/functions, ...) is rewritten verbatim to a
+            // bare `const __default__ = <expr>` using the declaration span.
+            // Slicing on these AST offsets is correct regardless of source
+            // formatting (`export default{` with no space, multi-line calls),
+            // which the previous line scanner mishandled.
+            other => {
+                let declaration_span = other.span();
+                targets.expr = Some((
+                    export.span.start as usize,
+                    declaration_span.start as usize,
+                    declaration_span.end as usize,
+                ));
+            }
         }
         // A module has a single default export; stop at the first one.
         break;

--- a/crates/vize_canon/src/virtual_ts/generator/spans.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/spans.rs
@@ -5,7 +5,6 @@ use vize_croquis::{Croquis, ScopeData};
 
 use vize_carton::FxHashSet;
 use vize_carton::String;
-use vize_carton::append;
 
 pub(super) fn collect_template_referenced_names(summary: &Croquis) -> FxHashSet<String> {
     let mut names = FxHashSet::default();
@@ -99,38 +98,61 @@ pub(super) const DEFINE_COMPONENT_HELPER: &str =
 pub(super) fn rewrite_export_default_for_module_scope(
     text: &str,
     default_object: Option<(usize, usize, usize)>,
+    default_expr: Option<(usize, usize, usize)>,
 ) -> String {
     // Plain `export default { ... }` (the Options API shape) is wrapped with
-    // Vue's `defineComponent`; any other default-export shape falls through
-    // to the line-based `const __default__ =` rewrite below.
+    // Vue's `defineComponent`; every other default-export shape is rewritten to
+    // a bare `const __default__ = <expr>` using the AST-provided byte offsets.
     if let Some(output) = wrap_default_export_object(text, default_object) {
         return output;
     }
-
-    let mut output = String::with_capacity(text.len());
-    for segment in text.split_inclusive('\n') {
-        let (line_with_optional_cr, newline) = segment
-            .strip_suffix('\n')
-            .map_or((segment, ""), |line| (line, "\n"));
-        let (line, carriage_return) = line_with_optional_cr
-            .strip_suffix('\r')
-            .map_or((line_with_optional_cr, ""), |line| (line, "\r"));
-
-        let trimmed_line = line.trim_start();
-        if let Some(default_expr) = trimmed_line
-            .strip_prefix("export default")
-            .filter(|rest| rest.chars().next().is_none_or(char::is_whitespace))
-        {
-            let leading_ws = &line[..line.len() - trimmed_line.len()];
-            append!(output, "{leading_ws}const __default__ ={default_expr}");
-        } else {
-            output.push_str(line);
-        }
-        output.push_str(carriage_return);
-        output.push_str(newline);
+    if let Some(output) = rewrite_default_export_expression(text, default_expr) {
+        return output;
     }
 
-    output
+    // No rewriteable default export in this span (e.g. a re-export statement
+    // such as `export { default } from './x'`): leave the text untouched.
+    text.into()
+}
+
+/// Rewrite an arbitrary `export default <expr>` to `const __default__ = <expr>`
+/// using the `(export_start, expr_start, expr_end)` offsets (relative to
+/// `text`) located by the AST. The `export default` keyword run
+/// (`export_start..expr_start`) is dropped and the exported expression
+/// (`expr_start..expr_end`) is copied verbatim, so source formatting —
+/// `export default{` with no space, multi-line calls, decorated/anonymous
+/// classes — is preserved exactly. Returns `None` when the offsets do not
+/// describe a default export inside `text`.
+fn rewrite_default_export_expression(
+    text: &str,
+    default_expr: Option<(usize, usize, usize)>,
+) -> Option<String> {
+    const EXPORT_DEFAULT: &str = "export default";
+    const REPLACEMENT: &str = "const __default__ =";
+
+    let (export_start, expr_start, expr_end) = default_expr?;
+    if expr_end > text.len() || expr_start >= expr_end || export_start >= expr_start {
+        return None;
+    }
+    let keyword_end = export_start.checked_add(EXPORT_DEFAULT.len())?;
+    if keyword_end > expr_start
+        || !text.is_char_boundary(export_start)
+        || !text.is_char_boundary(expr_start)
+        || !text.is_char_boundary(expr_end)
+        || !text[export_start..].starts_with(EXPORT_DEFAULT)
+    {
+        return None;
+    }
+
+    let mut output = String::with_capacity(text.len() + REPLACEMENT.len());
+    output.push_str(&text[..export_start]);
+    output.push_str(REPLACEMENT);
+    // `keyword_end..expr_start` is the inter-token whitespace/comment run
+    // between the keyword and the expression (empty for `export default{`).
+    output.push_str(&text[keyword_end..expr_start]);
+    output.push_str(&text[expr_start..expr_end]);
+    output.push_str(&text[expr_end..]);
+    Some(output)
 }
 
 /// Rewrite `export default { ... }` to
@@ -181,4 +203,121 @@ pub(super) fn is_local_setup_binding(summary: &Croquis, name: &str) -> bool {
         .import_statements
         .iter()
         .any(|import| start >= import.start && end <= import.end)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::rewrite_export_default_for_module_scope;
+    use crate::virtual_ts::generator::options_api::find_default_export_targets;
+
+    /// Drive the rewrite exactly as the generator does: classify the default
+    /// export with the shared single-parse `find_default_export_targets`, then
+    /// feed the resulting AST byte offsets (here the whole script is one span,
+    /// so offsets need no re-basing) into the rewrite.
+    fn rewrite(script: &str) -> super::String {
+        let targets = find_default_export_targets(script);
+        rewrite_export_default_for_module_scope(script, targets.object, targets.expr)
+    }
+
+    #[test]
+    fn plain_object_literal_is_wrapped_with_define_component() {
+        // The Options API object-literal shape is unchanged by this PR: it is
+        // still wrapped in `__vizeDefineComponent(...)` via the object path.
+        let out = rewrite("export default { name: 'A' }");
+        assert_eq!(
+            out.as_str(),
+            "const __default__ = __vizeDefineComponent({ name: 'A' })"
+        );
+    }
+
+    #[test]
+    fn define_component_call_is_rewritten_via_span() {
+        // `export default defineComponent({...})` used to fall to the line
+        // scanner; it now slices on the call expression span and is NOT wrapped
+        // again in `defineComponent`.
+        let out = rewrite("export default defineComponent({ name: 'A' })");
+        assert_eq!(
+            out.as_str(),
+            "const __default__ = defineComponent({ name: 'A' })"
+        );
+    }
+
+    #[test]
+    fn anonymous_class_is_rewritten_via_span() {
+        // Anonymous default classes have no name to alias by, so the class
+        // path declines them; the generic expr span handles them instead.
+        let out = rewrite("export default class { x = 1 }");
+        assert_eq!(out.as_str(), "const __default__ = class { x = 1 }");
+    }
+
+    #[test]
+    fn named_class_is_left_to_the_per_line_class_path() {
+        // A *named* class default export is captured as `class`, not `expr`,
+        // and the module-scope rewrite leaves it untouched (the per-line
+        // setup-scope path keeps decorators on a real class declaration —
+        // PR #1434). The module-scope function is a no-op here.
+        let script = "export default class Foo { x = 1 }";
+        let out = rewrite(script);
+        assert_eq!(out.as_str(), script);
+    }
+
+    #[test]
+    fn export_default_with_no_space_is_rewritten_correctly() {
+        // `export default{` (no space before the brace). The old line scanner
+        // required `export default` be followed by whitespace, so it failed to
+        // match and emitted `export default{ ... }` verbatim — invalid at
+        // module scope. The span path drops the keyword run exactly.
+        let out = rewrite("export default{ name: 'A' }");
+        assert_eq!(
+            out.as_str(),
+            "const __default__ =__vizeDefineComponent({ name: 'A' })"
+        );
+    }
+
+    #[test]
+    fn define_component_call_with_no_space_is_rewritten_correctly() {
+        // Same no-space hazard, but a call expression so it takes the generic
+        // expr path rather than the object-wrap path.
+        let out = rewrite("export default(defineComponent({ name: 'A' }))");
+        assert_eq!(
+            out.as_str(),
+            "const __default__ =(defineComponent({ name: 'A' }))"
+        );
+    }
+
+    #[test]
+    fn multi_line_call_is_rewritten_across_lines() {
+        // An awkwardly formatted multi-line default export. The old scanner
+        // rewrote only the first physical line containing `export default`,
+        // leaving trailing lines under a dangling `const`; the span path
+        // replaces just the keyword run and keeps the expression — including
+        // its newlines — verbatim.
+        let script = "export default\n  defineComponent({\n    name: 'A',\n  })";
+        let out = rewrite(script);
+        assert_eq!(
+            out.as_str(),
+            "const __default__ =\n  defineComponent({\n    name: 'A',\n  })"
+        );
+    }
+
+    #[test]
+    fn leading_code_before_export_default_is_preserved() {
+        // Statements before the default export are copied verbatim; only the
+        // keyword run is replaced.
+        let script = "const a = 1;\nexport default defineComponent({ a })";
+        let out = rewrite(script);
+        assert_eq!(
+            out.as_str(),
+            "const a = 1;\nconst __default__ = defineComponent({ a })"
+        );
+    }
+
+    #[test]
+    fn re_export_default_is_left_untouched() {
+        // `export { default } from './x'` is not a default-export declaration;
+        // neither offset is produced and the text is returned unchanged.
+        let script = "export { default } from './x'";
+        let out = rewrite(script);
+        assert_eq!(out.as_str(), script);
+    }
 }


### PR DESCRIPTION
## Summary

Closes the clean tail of #1394 (PR9): replaces the line-based text-scan fallback in `vize_canon`'s module-scope `export default` rewriter with a **byte-span / AST-offset-based** rewrite, mirroring the established pattern in `crates/vize_atelier_sfc/src/rewrite_default.rs`.

`rewrite_export_default_for_module_scope` (`crates/vize_canon/src/virtual_ts/generator/spans.rs`) previously:
- wrapped the plain object-literal Options API shape (`export default { ... }`) via croquis offsets (`wrap_default_export_object`), and
- fell through to a brittle line scanner (`text.split_inclusive('\n')` + `trimmed_line.strip_prefix("export default")`) for **every other** default-export shape.

That scanner mis-rewrote on unusual formatting: it required whitespace after `export default` (so `export default{` with no space was emitted verbatim — invalid at module scope), and it only rewrote the first physical line, dangling a `const` over multi-line expressions.

## What changed

- `find_default_export_targets` (already a single shared OXC parse inside canon) now also captures a generic `expr: (export_start, expr_start, expr_end)` declaration span for any default-export shape that is **not** a plain object literal and **not** a named class.
- The generator re-bases those AST offsets onto the module span and threads them into `rewrite_export_default_for_module_scope`, which now slices on byte offsets: it drops only the `export default` keyword run and copies the exported expression verbatim. The line scanner is removed.
- Shapes now correctly rewritten: `export default defineComponent({...})`, anonymous `export default class {}`, `export default{` (no space), parenthesized / `as` / `satisfies`, and multi-line / awkwardly-formatted variants.

## Pre-check (scope guard) result

**Not blocked — no croquis API change needed.** The offsets feeding `wrap_default_export_object` do not come from `vize_croquis`; they come from `find_default_export_targets`, which already parses the script with OXC *inside* `vize_canon` and holds the full AST. Extending it to expose the generic declaration span is a self-contained 1-crate change.

## Relationship to PR #1434

PR #1434's decorated/named-class handling lives in a **different** path — the setup-scope per-line emission (which keeps `@Component()` decorators on a real class declaration to avoid TS1206) and consumes `targets.class`. This PR only touches the module-scope rewriter and the new `targets.expr`; named classes still route to `targets.class` and are left untouched by the module-scope function (verified by a unit test). No duplication or conflict.

## Verify-real

Added direct unit tests on the `pub(super)` `rewrite_export_default_for_module_scope`, driving it through the real `find_default_export_targets` classifier (same offset derivation as production): plain object literal (unchanged `__vizeDefineComponent(...)` wrap), `defineComponent({...})` call, anonymous class, named class (no-op at module scope), `export default{` no-space, no-space call, multi-line call across lines, leading code preserved, and re-export left untouched.

## Tests / gates

- `cargo test -p vize_canon`: **361 passed** (9 new), **0 snapshot changes** — the line scanner was effectively dead for real fixtures (module-scope spans only carry imports/re-exports/hoisted types), so the span replacement is behavior-preserving.
- `cargo fmt -p vize_canon -- --check`: clean
- `cargo clippy -p vize_canon -- -D warnings`: clean
- `cargo semver-checks -p vize_canon`: no semver update required (all changes are `pub(super)`/internal)

Note: `vize check` JS fixture parity (`vp run --filter './tests' test:check:fixtures`) was not regenerated locally (needs `vp install`); no virtual-TS output change is expected since snapshots are unchanged, but flagging per the #1512 lesson.

Refs #1394

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1532"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->