### PR TITLE
feat(canon): opt-in type-checking for JSX/TSX Vue components (#1497, #1502)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3587,6 +3587,7 @@ dependencies = [
  "tracing",
  "vize_armature",
  "vize_atelier_core",
+ "vize_atelier_jsx",
  "vize_atelier_sfc",
  "vize_carton",
  "vize_croquis",

--- a/crates/vize/src/commands/check/runner/mod.rs
+++ b/crates/vize/src/commands/check/runner/mod.rs
@@ -106,6 +106,9 @@ pub(crate) fn run_direct(args: &CheckArgs) {
     // Vue 3 Options API binding resolution is officially supported and is a
     // standard-build opt-in (not the `legacy` feature).
     let options_api = loaded_config.features.type_checker_options_api;
+    // Opt-in type-checking of `.jsx`/`.tsx` Vize components (#1497). Default-off:
+    // JSX is experimental and React `.tsx` must not be Vue-JSX type-checked.
+    let jsx_typecheck = loaded_config.features.type_checker_jsx_typecheck;
     // Legacy Vue 2.7 / Nuxt 2 Options-API type checking is opt-in and compiled out
     // of the default Vue 3 binary. Without the `legacy` feature, honor the config
     // flag by warning instead of silently ignoring it.
@@ -307,6 +310,9 @@ pub(crate) fn run_direct(args: &CheckArgs) {
     #[cfg(feature = "legacy")]
     if legacy_vue2 {
         checker.enable_legacy_vue2();
+    }
+    if jsx_typecheck {
+        checker.enable_jsx_typecheck();
     }
     checker.set_template_syntax(template_syntax_mode(compiler_template_syntax));
     checker.set_dialect(dialect);

--- a/crates/vize_canon/Cargo.toml
+++ b/crates/vize_canon/Cargo.toml
@@ -20,6 +20,7 @@ vize_croquis.workspace = true
 vize_relief.workspace = true
 vize_armature.workspace = true
 vize_atelier_core.workspace = true
+vize_atelier_jsx.workspace = true
 vize_atelier_sfc.workspace = true
 
 # OXC for parsing and AST manipulation (import rewriting)

--- a/crates/vize_canon/Cargo.toml
+++ b/crates/vize_canon/Cargo.toml
@@ -12,7 +12,7 @@ default = ["native"]
 native = ["dep:walkdir", "dep:dirs", "dep:corsa", "dep:lsp-types"]
 # Opt-in legacy Vue (v0.10 / v0.11 / v1 / v2) type-checking surface. Not enabled by the
 # default Vue 3 build; turns on the parser-side legacy feature too.
-legacy = ["vize_armature/legacy"]
+legacy = ["vize_armature/legacy", "vize_atelier_jsx/legacy"]
 
 [dependencies]
 vize_carton.workspace = true

--- a/crates/vize_canon/src/batch/type_checker.rs
+++ b/crates/vize_canon/src/batch/type_checker.rs
@@ -163,6 +163,16 @@ impl BatchTypeChecker {
         self.project.set_legacy_vue2(true);
     }
 
+    /// Enable opt-in type-checking of `.jsx`/`.tsx` Vize components (#1497).
+    ///
+    /// Off by default: JSX support is experimental and a repository may contain
+    /// React `.tsx` files that must not be type-checked as Vue JSX. When
+    /// enabled, `.jsx`/`.tsx` route through the Vize JSX virtual-TS path instead
+    /// of the verbatim React passthrough.
+    pub fn enable_jsx_typecheck(&mut self) {
+        self.project.set_jsx_typecheck(true);
+    }
+
     /// Configure which virtual TypeScript checks are generated for Vue files.
     pub fn set_virtual_ts_checks(
         &mut self,

--- a/crates/vize_canon/src/batch/virtual_project/build.rs
+++ b/crates/vize_canon/src/batch/virtual_project/build.rs
@@ -43,6 +43,11 @@ pub(super) struct VirtualBuildContext<'a> {
     pub(super) preserve_unused_diagnostics: bool,
     pub(super) options_api: bool,
     pub(super) legacy_vue2: bool,
+    /// Opt-in type-checking of `.jsx`/`.tsx` Vue components (#1497). When
+    /// `false` (default), `.jsx`/`.tsx` are passed to TypeScript verbatim
+    /// (React passthrough); when `true`, they route through the Vize JSX
+    /// virtual-TS path.
+    pub(super) jsx_typecheck: bool,
     /// Configured Vue dialect (default [`VueVersion::V3`]); plumbing only today.
     pub(super) dialect: vize_carton::config::VueVersion,
     pub(super) template_syntax: TemplateSyntaxMode,
@@ -71,6 +76,16 @@ pub(super) fn build_registered_file(
             context.virtual_root,
             context.rewriter,
         );
+    }
+
+    // Opt-in Vize JSX/TSX type-checking (#1497). Only when the user explicitly
+    // enabled `typeChecker.jsxTypecheck`: otherwise `.jsx`/`.tsx` is passed to
+    // TypeScript verbatim (React passthrough) by the script path below.
+    if context.jsx_typecheck
+        && let Some(name) = path.file_name().and_then(|name| name.to_str())
+        && (name.ends_with(".jsx") || name.ends_with(".tsx"))
+    {
+        return build_jsx_registered_file(path, content, context);
     }
 
     let source_type = source_type_for_path(path).ok_or_else(|| CorsaError::PathError {
@@ -154,6 +169,86 @@ pub(super) fn build_vue_registered_file(
         ),
         diagnostics,
     })
+}
+
+/// Build a virtual file for a `.jsx`/`.tsx` Vize component (#1497, opt-in).
+///
+/// Parallels [`build_vue_registered_file`]: lower the JSX/TSX to plain virtual
+/// TypeScript (props from the typed first parameter + setup scope + JSX
+/// expressions), rewrite imports, and mirror the file to `<name>.ts` so Corsa
+/// type-checks it as plain TypeScript. Reached only when `jsx_typecheck` is on.
+pub(super) fn build_jsx_registered_file(
+    path: &Path,
+    content: &str,
+    context: VirtualBuildContext<'_>,
+) -> CorsaResult<RegisteredFile> {
+    let lang = jsx_lang_for_path(path);
+    let generated = profile!(
+        "canon.jsx.virtual_ts",
+        super::jsx_codegen::generate_jsx_virtual_ts(path, content, lang)
+    )?;
+    let super::jsx_codegen::GeneratedJsxFile {
+        code,
+        mappings,
+        diagnostics,
+    } = generated;
+
+    let rewritten = profile!(
+        "canon.import.rewrite.jsx",
+        context.rewriter.rewrite(&code, SourceType::ts())
+    );
+
+    // The whole `.jsx`/`.tsx` body is one Script block for block-type recovery.
+    let blocks = vec![crate::batch::source_map::SfcBlockRange {
+        start: 0,
+        end: content.len() as u32,
+        block_type: crate::batch::SfcBlockType::Script,
+    }];
+    let source_map =
+        CompositeSourceMap::new_vue(SfcSourceMap::new(mappings, blocks), rewritten.source_map);
+    let virtual_path = virtual_jsx_path(context.project_root, context.virtual_root, path)?;
+
+    Ok(RegisteredFile {
+        file: VirtualFile {
+            content: rewritten.code,
+            source_map,
+            original_path: path.to_path_buf(),
+            virtual_path,
+        },
+        original_content: content.to_compact_string(),
+        passthrough_files: collect_passthrough_json_modules(
+            path,
+            content,
+            context.project_root,
+            context.virtual_root,
+        ),
+        diagnostics,
+    })
+}
+
+fn jsx_lang_for_path(path: &Path) -> vize_atelier_jsx::JsxLang {
+    let is_tsx = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name.ends_with(".tsx"));
+    if is_tsx {
+        vize_atelier_jsx::JsxLang::Tsx
+    } else {
+        vize_atelier_jsx::JsxLang::Jsx
+    }
+}
+
+fn virtual_jsx_path(project_root: &Path, virtual_root: &Path, path: &Path) -> CorsaResult<PathBuf> {
+    let mut virtual_path = mirrored_virtual_path(project_root, virtual_root, path)?;
+    let file_name = virtual_path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .map(|name| cstr!("{name}.ts"))
+        .ok_or_else(|| CorsaError::PathError {
+            path: path.to_path_buf(),
+        })?;
+    virtual_path.set_file_name(file_name.as_str());
+    Ok(virtual_path)
 }
 
 /// Rewritten virtual TypeScript for a single in-memory `.vue` document,

--- a/crates/vize_canon/src/batch/virtual_project/jsx_codegen.rs
+++ b/crates/vize_canon/src/batch/virtual_project/jsx_codegen.rs
@@ -1,0 +1,396 @@
+//! Generating plain `.ts` virtual TypeScript for `.jsx`/`.tsx` Vue components
+//! (issue #1497, opt-in).
+//!
+//! This is the JSX/TSX parallel to [`super::vue_codegen`]. It is reached only
+//! when the user explicitly enables `typeChecker.jsxTypecheck` (default off):
+//! JSX support is experimental and a repository may contain React `.tsx` files
+//! that must *not* be type-checked as Vue JSX.
+//!
+//! # Authoring convention (#1502)
+//!
+//! A Vize JSX/TSX component is a plain function whose parameters carry the
+//! component contract, with no macros and no runtime validation:
+//!
+//! ```tsx
+//! const Comp = (
+//!     props: { msg: string; count?: number },
+//!     { emit }: Ctx<{ change: [value: number] }>,
+//! ) => <div>{props.msg}</div>;
+//! ```
+//!
+//! The **typed first parameter is the props type**; the optional typed second
+//! parameter is the `Ctx<Emits, Slots>` context. Defaults are plain
+//! destructuring defaults.
+//!
+//! # Why a textual JSX → plain-TS lowering
+//!
+//! `vize_canon` virtual TypeScript stays plain `.ts` (never JSX-format virtual
+//! documents — standing directive). A `.tsx` Vue component is, syntactically,
+//! already valid TypeScript *except* for the JSX elements themselves. So this
+//! pass keeps every non-JSX byte verbatim (component functions, the typed props
+//! parameter, the setup body) and replaces only the JSX render roots with a
+//! synthesized plain-TS expression that re-lists every embedded JSX expression.
+//!
+//! The result type-checks exactly what this first cut promises:
+//! - the **typed first parameter** stays verbatim, so every `props.X` access is
+//!   checked against the declared props type;
+//! - the **setup-scope** statements above the `return <jsx/>` stay verbatim, so
+//!   their declarations and uses are checked;
+//! - each **JSX expression** (`{props.msg}`, `class={cls}`, `{count + 1}`, …) is
+//!   re-emitted as real TypeScript at — and source-mapped back to — its original
+//!   byte range, so a wrong type inside a JSX expression is reported at the right
+//!   location.
+//!
+//! Deferred (see issue #1497): emits/slots typing from the `Ctx` second
+//! parameter, directive / `v-model` / style-expression checks, the stateful
+//! `defineComponent(() => () => VNode)` form, and full source-map fidelity for
+//! the synthesized wrapper scaffolding.
+
+use std::path::Path;
+
+use vize_atelier_jsx::{JsxDiagnostic, JsxLang, lower_source};
+use vize_carton::{Bump, String as CompactString, ToCompactString, cstr};
+use vize_relief::ast::{
+    ExpressionNode, RootNode, TemplateChildNode,
+    elements::PropNode,
+    expressions::{CompoundExpressionChild, CompoundExpressionNode},
+};
+
+use crate::batch::error::CorsaResult;
+use crate::batch::{Diagnostic, SfcBlockType};
+use crate::virtual_ts::VizeMapping;
+
+use super::diagnostics::diagnostic_for_offset;
+
+/// The generated plain-`.ts` virtual file for one `.jsx`/`.tsx` source.
+pub(super) struct GeneratedJsxFile {
+    pub(super) code: CompactString,
+    pub(super) mappings: Vec<VizeMapping>,
+    pub(super) diagnostics: Vec<Diagnostic>,
+}
+
+/// Name of the synthesized helper that swallows every re-emitted JSX
+/// expression. Declaring it ambient and `any`-returning lets each argument be
+/// type-checked independently while the whole call stays a valid render return.
+const JSX_EXPR_SINK: &str = "__vize_jsx_expr__";
+
+/// A dynamic JSX expression recovered from the lowered tree: its original source
+/// text plus the byte range it occupied in the `.jsx`/`.tsx` source.
+struct JsxExpr {
+    content: CompactString,
+    start: u32,
+    end: u32,
+}
+
+/// Lower a `.jsx`/`.tsx` Vize component to plain virtual TypeScript.
+pub(super) fn generate_jsx_virtual_ts(
+    path: &Path,
+    source: &str,
+    lang: JsxLang,
+) -> CorsaResult<GeneratedJsxFile> {
+    let bump = Bump::new();
+    let lowered = lower_source(&bump, source, lang);
+
+    // Collect every outermost JSX root's byte range together with the dynamic
+    // expressions inside it, in source order.
+    let mut roots: Vec<(u32, u32, Vec<JsxExpr>)> = Vec::with_capacity(lowered.roots.len());
+    for root in &lowered.roots {
+        let mut exprs = Vec::new();
+        collect_root_expressions(&root.root, &mut exprs);
+        roots.push((root.root.loc.start.offset, root.root.loc.end.offset, exprs));
+    }
+    // Outermost roots never overlap and are produced in source order, but guard
+    // the rewrite against any accidental disorder.
+    roots.sort_by_key(|(start, _, _)| *start);
+
+    let mut diagnostics = Vec::new();
+    for diagnostic in &lowered.diagnostics {
+        if !diagnostic.is_error() {
+            continue;
+        }
+        diagnostics.push(diagnostic_for_offset(
+            path,
+            source,
+            diagnostic.start,
+            jsx_parse_message(diagnostic),
+            SfcBlockType::Script,
+        ));
+    }
+
+    let (code, mappings) = render_plain_ts(source, &roots);
+
+    Ok(GeneratedJsxFile {
+        code,
+        mappings,
+        diagnostics,
+    })
+}
+
+fn jsx_parse_message(diagnostic: &JsxDiagnostic) -> CompactString {
+    cstr!("JSX parse error: {}", diagnostic.message)
+}
+
+/// Build the plain-`.ts` text and its source mappings.
+///
+/// Every byte outside a JSX render root is copied verbatim; each render root is
+/// replaced by `__vize_jsx_expr__(<expr>, <expr>, …)`, with each re-emitted
+/// expression mapped back to its original byte range.
+fn render_plain_ts(
+    source: &str,
+    roots: &[(u32, u32, Vec<JsxExpr>)],
+) -> (CompactString, Vec<VizeMapping>) {
+    let mut out = CompactString::default();
+    let mut mappings: Vec<VizeMapping> = Vec::new();
+
+    // Ambient helper: declared once at module scope so the re-emitted JSX
+    // expressions and the synthesized render returns both type-check.
+    out.push_str("declare function ");
+    out.push_str(JSX_EXPR_SINK);
+    out.push_str("(...args: unknown[]): any;\n");
+
+    let mut cursor = 0usize;
+    for (start, end, exprs) in roots {
+        let start = (*start as usize).min(source.len());
+        let end = (*end as usize).min(source.len());
+        if start < cursor {
+            // Overlapping/disordered root: skip defensively.
+            continue;
+        }
+        // Verbatim prefix (component function header, typed params, setup body).
+        // Emit an identity mapping so diagnostics in this region (e.g. a wrong
+        // `props.X` use in the setup body) map back to their true source range
+        // despite the prepended ambient-helper preamble.
+        push_verbatim(&mut out, &mut mappings, source, cursor, start);
+
+        out.push_str(JSX_EXPR_SINK);
+        out.push('(');
+        for (index, expr) in exprs.iter().enumerate() {
+            if index > 0 {
+                out.push_str(", ");
+            }
+            let gen_start = out.len();
+            out.push_str(&expr.content);
+            let gen_end = out.len();
+            mappings.push(VizeMapping {
+                gen_range: gen_start..gen_end,
+                src_range: expr.start as usize..expr.end as usize,
+                sub_spans: Vec::new(),
+            });
+        }
+        out.push(')');
+        cursor = end.max(start);
+    }
+    // Trailing verbatim suffix (e.g. `export default Comp;`).
+    push_verbatim(&mut out, &mut mappings, source, cursor, source.len());
+
+    (out, mappings)
+}
+
+/// Copy `source[src_start..src_end)` verbatim into `out`, recording an identity
+/// mapping (generated range -> original range) for diagnostics in the region.
+fn push_verbatim(
+    out: &mut CompactString,
+    mappings: &mut Vec<VizeMapping>,
+    source: &str,
+    src_start: usize,
+    src_end: usize,
+) {
+    if src_start >= src_end {
+        return;
+    }
+    let gen_start = out.len();
+    out.push_str(&source[src_start..src_end]);
+    let gen_end = out.len();
+    mappings.push(VizeMapping {
+        gen_range: gen_start..gen_end,
+        src_range: src_start..src_end,
+        sub_spans: Vec::new(),
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Expression collection: walk the lowered relief tree and gather every dynamic
+// (non-static) expression's source text and byte range.
+// ---------------------------------------------------------------------------
+
+fn collect_root_expressions(root: &RootNode<'_>, out: &mut Vec<JsxExpr>) {
+    for child in &root.children {
+        collect_child(child, out);
+    }
+}
+
+fn collect_child(child: &TemplateChildNode<'_>, out: &mut Vec<JsxExpr>) {
+    match child {
+        TemplateChildNode::Element(element) => {
+            for prop in &element.props {
+                collect_prop(prop, out);
+            }
+            for child in &element.children {
+                collect_child(child, out);
+            }
+        }
+        TemplateChildNode::Interpolation(interpolation) => {
+            collect_expression(&interpolation.content, out);
+        }
+        TemplateChildNode::CompoundExpression(compound) => {
+            collect_compound(compound, out);
+        }
+        TemplateChildNode::If(node) => {
+            for branch in &node.branches {
+                if let Some(condition) = &branch.condition {
+                    collect_expression(condition, out);
+                }
+                for child in &branch.children {
+                    collect_child(child, out);
+                }
+            }
+        }
+        TemplateChildNode::IfBranch(branch) => {
+            if let Some(condition) = &branch.condition {
+                collect_expression(condition, out);
+            }
+            for child in &branch.children {
+                collect_child(child, out);
+            }
+        }
+        TemplateChildNode::For(node) => {
+            collect_expression(&node.source, out);
+            for child in &node.children {
+                collect_child(child, out);
+            }
+        }
+        TemplateChildNode::TextCall(node) => {
+            collect_text_call(&node.content, out);
+        }
+        TemplateChildNode::Text(_)
+        | TemplateChildNode::Comment(_)
+        | TemplateChildNode::Hoisted(_) => {}
+    }
+}
+
+fn collect_text_call(content: &vize_relief::ast::TextCallContent<'_>, out: &mut Vec<JsxExpr>) {
+    use vize_relief::ast::TextCallContent;
+    match content {
+        TextCallContent::Interpolation(interpolation) => {
+            collect_expression(&interpolation.content, out);
+        }
+        TextCallContent::Compound(compound) => collect_compound(compound, out),
+        TextCallContent::Text(_) => {}
+    }
+}
+
+fn collect_prop(prop: &PropNode<'_>, out: &mut Vec<JsxExpr>) {
+    match prop {
+        // Static `class="a"` style attributes carry only literal text.
+        PropNode::Attribute(_) => {}
+        PropNode::Directive(directive) => {
+            if let Some(exp) = &directive.exp {
+                collect_expression(exp, out);
+            }
+            if let Some(arg) = &directive.arg {
+                collect_expression(arg, out);
+            }
+        }
+    }
+}
+
+fn collect_expression(expression: &ExpressionNode<'_>, out: &mut Vec<JsxExpr>) {
+    match expression {
+        ExpressionNode::Simple(simple) => {
+            if simple.is_static {
+                return;
+            }
+            push_expr(&simple.content, &simple.loc, out);
+        }
+        ExpressionNode::Compound(compound) => collect_compound(compound, out),
+    }
+}
+
+fn collect_compound(compound: &CompoundExpressionNode<'_>, out: &mut Vec<JsxExpr>) {
+    for child in &compound.children {
+        match child {
+            CompoundExpressionChild::Simple(simple) => {
+                if !simple.is_static {
+                    push_expr(&simple.content, &simple.loc, out);
+                }
+            }
+            CompoundExpressionChild::Compound(compound) => collect_compound(compound, out),
+            CompoundExpressionChild::Interpolation(interpolation) => {
+                collect_expression(&interpolation.content, out);
+            }
+            CompoundExpressionChild::Text(_)
+            | CompoundExpressionChild::String(_)
+            | CompoundExpressionChild::Symbol(_) => {}
+        }
+    }
+}
+
+fn push_expr(content: &str, loc: &vize_relief::ast::core::SourceLocation, out: &mut Vec<JsxExpr>) {
+    let content = content.trim();
+    if content.is_empty() {
+        return;
+    }
+    out.push(JsxExpr {
+        content: content.to_compact_string(),
+        start: loc.start.offset,
+        end: loc.end.offset,
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn generate(source: &str) -> GeneratedJsxFile {
+        generate_jsx_virtual_ts(Path::new("Comp.tsx"), source, JsxLang::Tsx).unwrap()
+    }
+
+    #[test]
+    fn keeps_typed_props_param_verbatim_and_reemits_jsx_expr() {
+        let source =
+            "const Comp = (props: { msg: string }) => <div class=\"a\">{props.msg}</div>;\n";
+        let generated = generate(source);
+        // The typed first parameter stays verbatim so `props.msg` type-checks.
+        assert!(
+            generated.code.contains("props: { msg: string }"),
+            "typed props param dropped: {}",
+            generated.code
+        );
+        // The JSX expression is re-emitted as plain TS through the sink helper.
+        assert!(
+            generated.code.contains("__vize_jsx_expr__(props.msg)"),
+            "jsx expr not re-emitted: {}",
+            generated.code
+        );
+        // Output is plain TS: no JSX element syntax survives.
+        assert!(
+            !generated.code.contains("<div"),
+            "JSX element leaked into virtual TS: {}",
+            generated.code
+        );
+        // A mapping points the re-emitted `props.msg` back at its source range.
+        let src = source.find("props.msg").unwrap();
+        assert!(
+            generated
+                .mappings
+                .iter()
+                .any(|mapping| mapping.src_range.start == src),
+            "no source mapping for re-emitted expression"
+        );
+    }
+
+    #[test]
+    fn setup_scope_statements_stay_verbatim() {
+        let source = "const Comp = (props: { n: number }) => {\n  const doubled = props.n * 2;\n  return <span>{doubled}</span>;\n};\n";
+        let generated = generate(source);
+        assert!(generated.code.contains("const doubled = props.n * 2;"));
+        assert!(generated.code.contains("__vize_jsx_expr__(doubled)"));
+    }
+
+    #[test]
+    fn collects_bound_attribute_expressions() {
+        let source = "const Comp = (props: { cls: string }) => <div class={props.cls}>hi</div>;\n";
+        let generated = generate(source);
+        assert!(generated.code.contains("__vize_jsx_expr__(props.cls)"));
+    }
+}

--- a/crates/vize_canon/src/batch/virtual_project/mod.rs
+++ b/crates/vize_canon/src/batch/virtual_project/mod.rs
@@ -27,6 +27,7 @@ use crate::virtual_ts::{VirtualTsCheckOptions, VirtualTsOptions};
 mod build;
 pub use build::{VueDocumentVirtualTs, generate_vue_document_virtual_ts};
 mod diagnostics;
+mod jsx_codegen;
 mod mapping;
 mod materialize;
 mod passthrough;
@@ -93,6 +94,12 @@ pub struct VirtualProject {
     /// Enable Vue 2.7 / Nuxt 2 Options API compatibility for virtual files.
     options_api: bool,
     legacy_vue2: bool,
+
+    /// Opt-in type-checking of `.jsx`/`.tsx` Vue components (#1497). Default-off:
+    /// when disabled, `.jsx`/`.tsx` are passed to TypeScript verbatim (React
+    /// passthrough); when enabled, they are routed through the Vize JSX
+    /// virtual-TS path.
+    jsx_typecheck: bool,
 
     /// Configured Vue dialect from `vue.version` (default [`VueVersion::V3`]).
     ///

--- a/crates/vize_canon/src/batch/virtual_project/project.rs
+++ b/crates/vize_canon/src/batch/virtual_project/project.rs
@@ -40,6 +40,7 @@ impl VirtualProject {
             virtual_ts_check_options: VirtualTsCheckOptions::default(),
             options_api: false,
             legacy_vue2: false,
+            jsx_typecheck: false,
             dialect: vize_carton::config::VueVersion::default(),
             template_syntax: TemplateSyntaxMode::default(),
             virtual_files: FxHashMap::default(),
@@ -75,6 +76,11 @@ impl VirtualProject {
 
     pub(crate) fn set_legacy_vue2(&mut self, enabled: bool) {
         self.legacy_vue2 = enabled;
+    }
+
+    /// Enable opt-in type-checking of `.jsx`/`.tsx` Vue components (#1497).
+    pub(crate) fn set_jsx_typecheck(&mut self, enabled: bool) {
+        self.jsx_typecheck = enabled;
     }
 
     /// Set the configured Vue dialect (default [`VueVersion::V3`]).
@@ -118,6 +124,7 @@ impl VirtualProject {
                 preserve_unused_diagnostics: self.tsconfig_preserves_unused_diagnostics(),
                 options_api: self.options_api,
                 legacy_vue2: self.legacy_vue2,
+                jsx_typecheck: self.jsx_typecheck,
                 dialect: self.dialect,
                 template_syntax: self.template_syntax,
                 rewriter: &self.rewriter,
@@ -164,6 +171,7 @@ impl VirtualProject {
             preserve_unused_diagnostics,
             options_api: self.options_api,
             legacy_vue2: self.legacy_vue2,
+            jsx_typecheck: self.jsx_typecheck,
             dialect: self.dialect,
             template_syntax: self.template_syntax,
             rewriter: &self.rewriter,
@@ -197,6 +205,7 @@ impl VirtualProject {
                 preserve_unused_diagnostics: self.tsconfig_preserves_unused_diagnostics(),
                 options_api: self.options_api,
                 legacy_vue2: self.legacy_vue2,
+                jsx_typecheck: self.jsx_typecheck,
                 dialect: self.dialect,
                 template_syntax: self.template_syntax,
                 rewriter: &self.rewriter,

--- a/crates/vize_canon/src/batch/virtual_project/tests.rs
+++ b/crates/vize_canon/src/batch/virtual_project/tests.rs
@@ -1135,3 +1135,77 @@ fn test_source_type_for_path() {
     );
     assert_eq!(source_type_for_path(Path::new("foo.vue")), None);
 }
+
+// --- JSX/TSX opt-in type-checking (#1497, #1502) -------------------------
+
+#[test]
+fn jsx_typecheck_off_keeps_tsx_verbatim_passthrough() {
+    let case_dir = unique_case_dir("jsx-off");
+    let _ = fs::remove_dir_all(&case_dir);
+    fs::create_dir_all(&case_dir).unwrap();
+    let tsx_path = case_dir.join("Comp.tsx");
+    let source = "const Comp = (props: { msg: string }) => <div>{props.msg}</div>;\n";
+
+    // Flag off (the default): the .tsx is mirrored verbatim (React passthrough),
+    // its virtual path keeps the `.tsx` extension, and no JSX lowering happens.
+    let mut project = VirtualProject::new(&case_dir).unwrap();
+    project
+        .register_path_with_content(&tsx_path, source)
+        .unwrap();
+    let virtual_file = project.find_by_original(&tsx_path).unwrap();
+    assert_eq!(virtual_file.content.as_str(), source);
+    assert!(
+        virtual_file
+            .virtual_path
+            .to_string_lossy()
+            .ends_with(".tsx")
+    );
+
+    let _ = fs::remove_dir_all(&case_dir);
+}
+
+#[test]
+fn jsx_typecheck_on_lowers_tsx_to_plain_ts() {
+    let case_dir = unique_case_dir("jsx-on");
+    let _ = fs::remove_dir_all(&case_dir);
+    fs::create_dir_all(&case_dir).unwrap();
+    let tsx_path = case_dir.join("Comp.tsx");
+    let source = "const Comp = (props: { msg: string }) => <div class=\"a\">{props.msg}</div>;\n";
+
+    let mut project = VirtualProject::new(&case_dir).unwrap();
+    project.set_jsx_typecheck(true);
+    project
+        .register_path_with_content(&tsx_path, source)
+        .unwrap();
+    let virtual_file = project.find_by_original(&tsx_path).unwrap();
+
+    // Plain `.ts` output: the JSX element is gone, the typed props parameter is
+    // verbatim, and the JSX expression is re-emitted as plain TS.
+    assert_ts_parses(&virtual_file.content);
+    assert!(
+        !virtual_file.content.contains("<div"),
+        "{}",
+        virtual_file.content
+    );
+    assert!(
+        virtual_file.content.contains("props: { msg: string }"),
+        "{}",
+        virtual_file.content
+    );
+    assert!(
+        virtual_file
+            .content
+            .contains("__vize_jsx_expr__(props.msg)"),
+        "{}",
+        virtual_file.content
+    );
+    // Virtual path mirrors to `<name>.ts` so Corsa checks it as TypeScript.
+    assert!(
+        virtual_file
+            .virtual_path
+            .to_string_lossy()
+            .ends_with("Comp.tsx.ts")
+    );
+
+    let _ = fs::remove_dir_all(&case_dir);
+}

--- a/crates/vize_carton/src/config/model.rs
+++ b/crates/vize_carton/src/config/model.rs
@@ -71,6 +71,12 @@ pub struct ConfigFeatureFlags {
     /// build (not a legacy feature).
     pub type_checker_options_api: bool,
     pub type_checker_legacy_vue2: bool,
+    /// Opt-in type-checking of `.jsx`/`.tsx` Vue components (#1497). Default-off
+    /// because JSX support is experimental and a repository may contain React
+    /// `.tsx` files that must not be type-checked as Vue JSX. Set
+    /// `typeChecker.jsxTypecheck: true` to route `.jsx`/`.tsx` through the Vize
+    /// JSX virtual-TS path instead of the verbatim passthrough.
+    pub type_checker_jsx_typecheck: bool,
     pub language_server_legacy_vue2: Option<bool>,
     /// Dialect selected by `vue.version`; `None` when the key is absent
     /// (modern Vue 3). Validated at parse time — unknown or ambiguous values
@@ -86,6 +92,7 @@ impl Default for ConfigFeatureFlags {
             // Options API resolution is default-on (matches vue-tsc).
             type_checker_options_api: true,
             type_checker_legacy_vue2: false,
+            type_checker_jsx_typecheck: false,
             language_server_legacy_vue2: None,
             vue_version: None,
         }
@@ -126,6 +133,8 @@ struct RawTypeCheckerConfig {
     /// (matches vue-tsc). Set `false` to opt out.
     options_api: Option<bool>,
     legacy_vue2: bool,
+    /// Opt-in type-checking of JSX/TSX Vue components (#1497). Default-off.
+    jsx_typecheck: bool,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -168,6 +177,7 @@ impl RawVizeConfig {
         // Default-on (matches vue-tsc); explicit `false` opts out.
         let type_checker_options_api = raw_type_checker.options_api.unwrap_or(true);
         let type_checker_legacy_vue2 = raw_type_checker.legacy_vue2;
+        let type_checker_jsx_typecheck = raw_type_checker.jsx_typecheck;
         let mut type_checker = raw_type_checker.config;
         if let Some(legacy_check) = legacy_check {
             if type_checker.globals_file.is_none() {
@@ -193,6 +203,7 @@ impl RawVizeConfig {
         let features = ConfigFeatureFlags {
             type_checker_options_api,
             type_checker_legacy_vue2,
+            type_checker_jsx_typecheck,
             language_server_legacy_vue2: language_server_raw.legacy_vue2,
             vue_version: vue.version,
         };

--- a/npm/vize/pkl/TypeCheckerConfig.pkl
+++ b/npm/vize/pkl/TypeCheckerConfig.pkl
@@ -38,6 +38,12 @@ class TypeCheckerConfig {
   /// Enable Vue 2.7 / Nuxt 2 Options API template binding support.
   legacyVue2: Boolean = false
 
+  /// Opt-in type-checking of `.jsx`/`.tsx` Vue components (#1497). Default-off:
+  /// JSX support is experimental and a repository may contain React `.tsx`
+  /// files that must not be type-checked as Vue JSX. Set to `true` to route
+  /// `.jsx`/`.tsx` through the Vize JSX virtual-TS path.
+  jsxTypecheck: Boolean = false
+
   /// Path to tsconfig.json.
   tsconfig: String? = null
 

--- a/npm/vize/pkl/vize.pkl
+++ b/npm/vize/pkl/vize.pkl
@@ -60,6 +60,7 @@ class TypeCheckerConfig {
   checkInvalidExports: Boolean? = null
   checkFallthroughAttrs: Boolean? = null
   legacyVue2: Boolean? = null
+  jsxTypecheck: Boolean? = null
   tsconfig: String? = null
   corsaPath: String? = null
   tsgoPath: String? = null

--- a/npm/vize/schemas/vize.config.schema.json
+++ b/npm/vize/schemas/vize.config.schema.json
@@ -289,6 +289,11 @@
           "default": false,
           "type": "boolean"
         },
+        "jsxTypecheck": {
+          "description": "Opt-in type-checking of .jsx/.tsx Vue components (#1497). Default-off: JSX support is experimental and a repository may contain React .tsx files that must not be type-checked as Vue JSX. Set to true to route .jsx/.tsx through the Vize JSX virtual-TS path.",
+          "default": false,
+          "type": "boolean"
+        },
         "tsconfig": {
           "description": "Path to tsconfig.json",
           "type": "string"


### PR DESCRIPTION
First cut of **#1497** (type-check JSX/TSX Vue components in Canon) with the **#1502** plain-function authoring convention.

## Locked design

**#1502 authoring** — a Vize JSX/TSX component is a plain function with typed params (no macros, no runtime validation, type-only/erased):

```tsx
const Comp = (
  props: { msg: string; count?: number },
  { emit }: Ctx<{ change: [value: number] }>,
) => <div>{props.msg}</div>;
```

props = typed **first** param; emits/slots = typed **second** param (`Ctx<Emits, Slots>`); defaults = destructuring defaults.

**#1497 type-check** — **opt-in** via `typeChecker.jsxTypecheck` (default **off**). JSX is experimental, and a repo may contain React `.tsx` that must not be Vue-JSX-type-checked. Virtual TS for `.jsx`/`.tsx` stays **plain `.ts`** (not JSX-format virtual docs — standing directive).

## What's implemented

1. **Config opt-in** — `typeChecker.jsxTypecheck` (default false) as a `ConfigFeatureFlags` feature flag (mirrors `optionsApi`/`legacyVue2`), wired through the Rust model, Pkl schema (`TypeCheckerConfig.pkl`, `vize.pkl`), and JSON schema.
2. **Router** — when the flag is on, `.jsx`/`.tsx` route through a new `build_jsx_registered_file` (parallel to `build_vue_registered_file`); when off, the verbatim React passthrough is preserved. Added `vize_atelier_jsx` as a `vize_canon` dependency.
3. **JSX virtual-TS codegen** — new `jsx_codegen.rs` (parallel to `vue_codegen.rs`): lowers `.jsx`/`.tsx` via `vize_atelier_jsx::lower_source`, then emits **plain `.ts`**. A `.tsx` is already valid TS except for the JSX elements, so the pass keeps every non-JSX byte verbatim (component fn, **typed props param**, setup body) and replaces only JSX render roots with `__vize_jsx_expr__(<expr>, …)`, re-emitting each embedded JSX expression at its original byte range. Type-checks: **props from the typed first parameter** (`props.X` against the declared type), **setup-scope** statements, and **JSX/template expressions**. Source maps map both verbatim regions and re-emitted expressions back to original ranges.

## Verify-real (`vize check` on a temp `.tsx`)

Bad.tsx (`const n: number = props.msg;`), Good.tsx (correct):

**Flag ON** — only the genuine Vue-JSX error, correct location:
```
/.../Bad.tsx
  error:2:9 [TS2322] Type 'string' is not assignable to type 'number'.
  1 error(s)
```
A JSX-expression-level error (`{takesNum(props.msg)}`) is caught at `3:25` — exactly inside the `{...}`. Good.tsx: no errors.

**Flag OFF** — React passthrough preserved (`.tsx` mirrored verbatim, checked as raw React TSX):
```
/.../Bad.tsx
  error:2:9  [TS2322] Type 'string' is not assignable to type 'number'.
  error:3:10 [TS7026] JSX element implicitly has type 'any' ... no interface 'JSX.IntrinsicElements'
/.../Good.tsx
  error:3:10 [TS7026] JSX element implicitly has type 'any' ...
```
The `TS7026 JSX.IntrinsicElements` noise (and errors on the otherwise-clean Good.tsx) confirm React-JSX semantics, not Vize-JSX — i.e. the passthrough is untouched when the flag is off.

## Tests

- `jsx_codegen` unit tests (typed-props verbatim, JSX-expr re-emit, plain-TS output, setup-scope verbatim, bound-attribute expressions, source mapping).
- `virtual_project` integration tests: flag-off keeps `.tsx` verbatim passthrough; flag-on lowers `.tsx` to plain `.ts` (`Comp.tsx.ts`).
- `cargo test -p vize_canon`: **366 passed**.

## Deferred (honest)

- emits/slots typing from the `Ctx` second param
- directives, v-model, style-expression type-check
- stateful `defineComponent(() => () => VNode)` form (functional form first)
- `.jsx` (plain JS, no types) file discovery — `.tsx` is the discovered/supported path; `.jsx` is handled by the router if discovered
- full source-map fidelity for the synthesized wrapper scaffolding

## Gates / parity

- `cargo fmt --check`: clean.
- `cargo clippy --workspace -- -D warnings` (lib, CI form): clean. (Pre-existing `--all-targets` test-file lints in `vize_armature`/canon are untouched by this PR.)
- `cargo semver-checks` (`vize_carton`): the additive `ConfigFeatureFlags.type_checker_jsxTypecheck` field trips `constructible_struct_adds_field`, exactly as the prior additive config-flag PR #1464 (`type_checker_options_api`) did — this is the established additive pattern for this struct; version-bumping the accumulated delta is a release-time concern per the workflow's own note. Flagged here for transparency.
- **vue-parity / #1512**: unaffected. The change only touches `.jsx`/`.tsx` when the opt-in flag is on (default off); `.vue` virtual-TS output is byte-identical (the `shared_document_generator_is_byte_identical_to_batch_pipeline` test still passes).

Refs #1497, #1502.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1535"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->