### PR TITLE
test(jsx): pin ecosystem testbeds with a manual coverage smoke (#1491)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3493,6 +3493,8 @@ dependencies = [
  "oxc_parser",
  "oxc_span",
  "oxc_syntax",
+ "serde",
+ "serde_json",
  "vize_atelier_core",
  "vize_atelier_sfc",
  "vize_atelier_vapor",

--- a/crates/vize_atelier_jsx/Cargo.toml
+++ b/crates/vize_atelier_jsx/Cargo.toml
@@ -30,6 +30,8 @@ oxc_diagnostics = { workspace = true }
 
 [dev-dependencies]
 criterion = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
 
 [features]
 default = []

--- a/crates/vize_atelier_jsx/tests/PARITY_INVENTORY.md
+++ b/crates/vize_atelier_jsx/tests/PARITY_INVENTORY.md
@@ -107,17 +107,39 @@ infrastructure that is not yet wired through this crate. Deferred pending the
 type-checker work in **#1497 / #1502**. The current TSX suite covers _syntax_
 acceptance and type-stripping, not type-driven prop/emit generation.
 
-### Ecosystem testbeds — deferred (network / CI infra)
+### Ecosystem testbeds — documented manual workflow
 
-Running the full `@vue/babel-plugin-jsx` + `vue-jsx-vapor` reference fixture
-corpora and real-world component-library testbeds requires cloning external
-repos and network access, which is unavailable in this build and gated on CI
-infrastructure:
+Running the upstream `@vue/babel-plugin-jsx` + `vue-jsx-vapor` reference corpora
+and real-world component-library testbeds requires cloning external repos and
+network access, so it stays out of the fast, offline PR CI lane. It is instead a
+**documented manual workflow**: a pinned-revision manifest plus an `#[ignore]`d
+coverage smoke.
 
-| Testbed  | Repo                | Reason deferred                           |
-| -------- | ------------------- | ----------------------------------------- |
-| Vuetify  | `vuetifyjs/vuetify` | Network clone + CI build matrix required. |
-| Naive UI | `tusen-ai/naive-ui` | Network clone + CI build matrix required. |
+- **Manifest** (`tests/ecosystem/testbeds.json`) — each entry pins a full commit
+  SHA so reruns are deterministic; bump revisions deliberately.
 
-These are tracked as the ecosystem-CI portion of **#1491** and are **not** closed
-by this PR. This PR delivers the parity-suite + inventory **foundation** only.
+  | Entry                 | Repo                     | Pinned revision |
+  | --------------------- | ------------------------ | --------------- |
+  | @vue/babel-plugin-jsx | `vuejs/babel-plugin-jsx` | `803aab3c…`     |
+  | vue-jsx-vapor         | `vuejs/vue-jsx-vapor`    | `25eba175…`     |
+  | Vuetify               | `vuetifyjs/vuetify`      | `e5555ae8…`     |
+  | Naive UI              | `tusen-ai/naive-ui`      | `7a12097e…`     |
+
+- **Run it**:
+
+  ```text
+  cargo test -p vize_atelier_jsx --test ecosystem_smoke -- --ignored --nocapture
+  ```
+
+  The smoke (`tests/ecosystem_smoke.rs`) shallow-clones each pinned entry, walks
+  its roots for `.jsx`/`.tsx`, runs every file through `lower_source`, and prints
+  a per-testbed table of files / clean / with-diagnostics / panicked. A panic
+  fails the run — the compiler must surface a diagnostic, never unwind. Offline,
+  the smoke degrades gracefully ("clone failed — skipped") instead of failing.
+
+- **CI guard** — `tests/tooling/jsx-ecosystem-fixtures.test.ts` validates the
+  manifest shape (pinned SHAs, github repos, roots, extensions) offline on every
+  PR, keeping the testbed list honest without network access.
+
+Wiring the smoke into a scheduled GitHub Actions lane (sharded, non-PR-gating)
+is a maintainer infra decision, tracked alongside #1501's benchmark-CI lane.

--- a/crates/vize_atelier_jsx/tests/ecosystem/testbeds.json
+++ b/crates/vize_atelier_jsx/tests/ecosystem/testbeds.json
@@ -1,0 +1,49 @@
+{
+  "schemaVersion": 1,
+  "description": "Pinned JSX/TSX ecosystem testbeds and upstream reference suites for the Vize JSX compiler. This is the documented manual workflow for the ecosystem-CI portion of #1491: a network-gated coverage smoke that is NOT part of PR CI (so PR CI stays fast and offline). Run it explicitly with the command below; it shallow-clones each entry at its pinned revision and feeds every matched .jsx/.tsx file through the Vize JSX lowerer, reporting parse/lower coverage. Revisions are pinned by full commit SHA so reruns are deterministic; bump them deliberately.",
+  "command": "cargo test -p vize_atelier_jsx --test ecosystem_smoke -- --ignored --nocapture",
+  "references": [
+    {
+      "id": "babel-plugin-jsx",
+      "displayName": "@vue/babel-plugin-jsx",
+      "repository": "https://github.com/vuejs/babel-plugin-jsx.git",
+      "revision": "803aab3cce56e2b53ba65d302e7abb3f82856544",
+      "branch": "main",
+      "roots": ["packages"],
+      "extensions": [".jsx", ".tsx"],
+      "kind": "reference-suite"
+    },
+    {
+      "id": "vue-jsx-vapor",
+      "displayName": "vue-jsx-vapor",
+      "repository": "https://github.com/vuejs/vue-jsx-vapor.git",
+      "revision": "25eba175780cbaf00ccf389e2044f3691d6a8b60",
+      "branch": "main",
+      "roots": ["packages"],
+      "extensions": [".jsx", ".tsx"],
+      "kind": "reference-suite"
+    }
+  ],
+  "testbeds": [
+    {
+      "id": "vuetify",
+      "displayName": "Vuetify",
+      "repository": "https://github.com/vuetifyjs/vuetify.git",
+      "revision": "e5555ae86a03de867b54e6a7a90402bb8e1a23af",
+      "branch": "master",
+      "roots": ["packages/vuetify/src"],
+      "extensions": [".tsx"],
+      "kind": "component-library"
+    },
+    {
+      "id": "naive-ui",
+      "displayName": "Naive UI",
+      "repository": "https://github.com/tusen-ai/naive-ui.git",
+      "revision": "7a12097edc91962712d78f8cd9e301928eb5e558",
+      "branch": "main",
+      "roots": ["src"],
+      "extensions": [".tsx"],
+      "kind": "component-library"
+    }
+  ]
+}

--- a/crates/vize_atelier_jsx/tests/ecosystem_smoke.rs
+++ b/crates/vize_atelier_jsx/tests/ecosystem_smoke.rs
@@ -1,0 +1,210 @@
+//! JSX/TSX ecosystem testbed smoke (the ecosystem-CI portion of #1489 / #1491).
+//!
+//! A manual, network-gated coverage run over upstream JSX reference suites
+//! (`@vue/babel-plugin-jsx`, `vue-jsx-vapor`) and real-world component libraries
+//! (Vuetify, Naive UI), each pinned by full commit SHA in
+//! `tests/ecosystem/testbeds.json`.
+//!
+//! It is `#[ignore]`d so PR CI stays fast and offline; run it explicitly:
+//!
+//! ```text
+//! cargo test -p vize_atelier_jsx --test ecosystem_smoke -- --ignored --nocapture
+//! ```
+//!
+//! The smoke shallow-clones each pinned entry, walks the configured roots for
+//! `.jsx`/`.tsx` files, and feeds every file through [`lower_source`]. It reports
+//! how many files lower cleanly, lower with diagnostics, or panic. This is a
+//! robustness/coverage signal over real-world JSX — not a byte-for-byte parity
+//! gate. A panic is always a Vize bug (the compiler must surface a diagnostic,
+//! never unwind), so the run fails if any input panics.
+
+// Std-only manual test harness: the manifest deserializes into plain structs, so
+// std `String` (what `serde` derives into) is intentional here rather than the
+// workspace `vize_carton::String`.
+#![allow(clippy::disallowed_types)]
+
+use std::fs;
+use std::panic;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use serde::Deserialize;
+use vize_atelier_jsx::{JsxLang, lower_source};
+use vize_carton::Bump;
+
+#[derive(Deserialize)]
+struct Manifest {
+    references: Vec<Entry>,
+    testbeds: Vec<Entry>,
+}
+
+#[derive(Deserialize, Clone)]
+struct Entry {
+    id: String,
+    #[serde(rename = "displayName")]
+    display_name: String,
+    repository: String,
+    revision: String,
+    roots: Vec<String>,
+    extensions: Vec<String>,
+}
+
+#[derive(Default)]
+struct Coverage {
+    files: usize,
+    clean: usize,
+    diagnostics: usize,
+    panicked: usize,
+}
+
+fn load_manifest() -> Manifest {
+    let path = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/ecosystem/testbeds.json");
+    let raw = fs::read_to_string(path).expect("read testbeds.json");
+    serde_json::from_str(&raw).expect("parse testbeds.json")
+}
+
+/// Shallow-checkout `revision` of `repository` into `dest`. Returns false (with a
+/// printed note) when the network/git is unavailable so an offline manual run
+/// degrades gracefully instead of looking like a code failure.
+fn shallow_checkout(repository: &str, revision: &str, dest: &Path) -> bool {
+    let _ = fs::create_dir_all(dest);
+    let git = |args: &[&str]| -> bool {
+        Command::new("git")
+            .arg("-C")
+            .arg(dest)
+            .args(args)
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false)
+    };
+    git(&["init", "-q"])
+        && git(&["remote", "add", "origin", repository])
+        && git(&["fetch", "--depth", "1", "-q", "origin", revision])
+        && git(&["checkout", "-q", "FETCH_HEAD"])
+}
+
+fn collect_files(root: &Path, extensions: &[String], out: &mut Vec<PathBuf>) {
+    let Ok(entries) = fs::read_dir(root) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            // Skip vendored/transient dirs that never hold authored components.
+            let name = entry.file_name();
+            let name = name.to_string_lossy();
+            if name == "node_modules" || name == ".git" || name == "dist" {
+                continue;
+            }
+            collect_files(&path, extensions, out);
+        } else if let Some(ext) = path.extension().and_then(|e| e.to_str()) {
+            // Match `.tsx`/`.jsx` against the manifest's dotted extensions without
+            // allocating a `format!` string per file.
+            if extensions
+                .iter()
+                .any(|wanted| wanted.strip_prefix('.').is_some_and(|bare| bare == ext))
+            {
+                out.push(path);
+            }
+        }
+    }
+}
+
+fn lang_for(path: &Path) -> JsxLang {
+    match path.extension().and_then(|e| e.to_str()) {
+        Some("tsx") => JsxLang::Tsx,
+        _ => JsxLang::Jsx,
+    }
+}
+
+fn measure(entry: &Entry, checkout: &Path) -> Coverage {
+    let mut files = Vec::new();
+    for root in &entry.roots {
+        collect_files(&checkout.join(root), &entry.extensions, &mut files);
+    }
+
+    let mut cov = Coverage {
+        files: files.len(),
+        ..Coverage::default()
+    };
+    for path in &files {
+        let Ok(source) = fs::read_to_string(path) else {
+            continue;
+        };
+        let lang = lang_for(path);
+        let outcome = panic::catch_unwind(panic::AssertUnwindSafe(|| {
+            let bump = Bump::new();
+            lower_source(&bump, &source, lang).has_errors()
+        }));
+        match outcome {
+            Ok(false) => cov.clean += 1,
+            Ok(true) => cov.diagnostics += 1,
+            Err(_) => {
+                cov.panicked += 1;
+                eprintln!("  PANIC lowering {}", path.display());
+            }
+        }
+    }
+    cov
+}
+
+#[test]
+#[ignore = "network-gated ecosystem coverage smoke; run with --ignored"]
+fn jsx_ecosystem_coverage_smoke() {
+    // Quiet panic hook so caught per-file panics don't spam the report; we count
+    // and surface them ourselves.
+    let previous_hook = panic::take_hook();
+    panic::set_hook(Box::new(|_| {}));
+
+    let manifest = load_manifest();
+    let base = std::env::temp_dir().join("vize-jsx-ecosystem");
+    let _ = fs::remove_dir_all(&base);
+
+    let mut cloned = 0usize;
+    let mut total_files = 0usize;
+    let mut total_panicked = 0usize;
+
+    eprintln!("\nJSX ecosystem coverage smoke (lower_source over pinned testbeds)\n");
+    eprintln!(
+        "{:<22} {:>7} {:>7} {:>11} {:>9}",
+        "testbed", "files", "clean", "w/diag", "PANIC"
+    );
+
+    for entry in manifest.references.iter().chain(manifest.testbeds.iter()) {
+        let dest = base.join(&entry.id);
+        if !shallow_checkout(&entry.repository, &entry.revision, &dest) {
+            eprintln!(
+                "{:<22} (clone failed — offline? skipped)",
+                entry.display_name
+            );
+            continue;
+        }
+        cloned += 1;
+        let cov = measure(entry, &dest);
+        total_files += cov.files;
+        total_panicked += cov.panicked;
+        eprintln!(
+            "{:<22} {:>7} {:>7} {:>11} {:>9}",
+            entry.display_name, cov.files, cov.clean, cov.diagnostics, cov.panicked
+        );
+    }
+
+    let _ = fs::remove_dir_all(&base);
+    panic::set_hook(previous_hook);
+
+    if cloned == 0 {
+        eprintln!("\nNo testbeds could be cloned (network/git unavailable). Smoke skipped.");
+        return;
+    }
+
+    // A successful clone with zero matched files means the manifest roots drifted.
+    assert!(
+        total_files > 0,
+        "cloned {cloned} testbeds but matched no .jsx/.tsx files — manifest roots are stale"
+    );
+    // The compiler must never unwind on real-world input; surface diagnostics instead.
+    assert_eq!(
+        total_panicked, 0,
+        "Vize JSX lowering panicked on {total_panicked} real-world file(s) — that is a compiler bug"
+    );
+}

--- a/tests/tooling/jsx-ecosystem-fixtures.test.ts
+++ b/tests/tooling/jsx-ecosystem-fixtures.test.ts
@@ -1,0 +1,97 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+// Offline shape guard for the JSX/TSX ecosystem testbed manifest (the manual
+// ecosystem-coverage workflow for #1491). The smoke that actually clones and
+// compiles these repos lives in the ignored Rust test
+// `crates/vize_atelier_jsx/tests/ecosystem_smoke.rs`; this test only validates
+// that the committed manifest stays pinned and well-formed, so PR CI keeps the
+// ecosystem list honest without any network access.
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const manifestPath = path.join(
+  root,
+  "crates",
+  "vize_atelier_jsx",
+  "tests",
+  "ecosystem",
+  "testbeds.json",
+);
+
+interface ManifestEntry {
+  id: string;
+  displayName: string;
+  repository: string;
+  revision: string;
+  branch: string;
+  roots: string[];
+  extensions: string[];
+  kind: string;
+}
+
+interface Manifest {
+  schemaVersion: number;
+  description: string;
+  command: string;
+  references: ManifestEntry[];
+  testbeds: ManifestEntry[];
+}
+
+function readManifest(): Manifest {
+  return JSON.parse(fs.readFileSync(manifestPath, "utf8")) as Manifest;
+}
+
+const requiredTestbeds = ["vuetify", "naive-ui"] as const;
+const requiredReferences = ["babel-plugin-jsx", "vue-jsx-vapor"] as const;
+
+test("JSX ecosystem manifest pins the requested testbeds and reference suites", () => {
+  const manifest = readManifest();
+  assert.equal(manifest.schemaVersion, 1);
+
+  const testbedIds = new Set(manifest.testbeds.map((entry) => entry.id));
+  for (const id of requiredTestbeds) {
+    assert.ok(testbedIds.has(id), `${id} should be a pinned ecosystem testbed`);
+  }
+
+  const referenceIds = new Set(manifest.references.map((entry) => entry.id));
+  for (const id of requiredReferences) {
+    assert.ok(referenceIds.has(id), `${id} should be a pinned reference suite`);
+  }
+});
+
+test("every JSX ecosystem entry pins a full-SHA revision, github repo, roots, and extensions", () => {
+  const manifest = readManifest();
+
+  for (const entry of [...manifest.references, ...manifest.testbeds]) {
+    assert.match(
+      entry.revision,
+      /^[0-9a-f]{40}$/,
+      `${entry.id} should pin a full commit SHA (got "${entry.revision}")`,
+    );
+    assert.match(
+      entry.repository,
+      /^https:\/\/github\.com\/.+\.git$/,
+      `${entry.id} should declare an https github repository`,
+    );
+    assert.ok(entry.roots.length > 0, `${entry.id} should declare at least one walk root`);
+    assert.ok(
+      entry.extensions.length > 0 && entry.extensions.every((ext) => ext.startsWith(".")),
+      `${entry.id} should declare dotted file extensions`,
+    );
+    assert.ok(entry.displayName.length > 0, `${entry.id} should declare a display name`);
+    assert.ok(entry.branch.length > 0, `${entry.id} should record the upstream branch it pins`);
+  }
+});
+
+test("JSX ecosystem manifest documents the manual run command", () => {
+  const manifest = readManifest();
+  assert.match(
+    manifest.command,
+    /cargo test -p vize_atelier_jsx --test ecosystem_smoke -- --ignored/,
+    "manifest should document how to run the manual ecosystem smoke",
+  );
+  assert.ok(manifest.description.length > 0, "manifest should describe the manual workflow");
+});


### PR DESCRIPTION
Closes #1491.

Completes the ecosystem-CI portion of #1491. PR #1522 already landed the backend-separated parity suite + inventory (VDOM/Vapor categories, covered-vs-deferred matrix); this PR adds the Vuetify + Naive UI ecosystem testbeds as a **documented manual workflow** (the acceptance criterion's accepted alternative to a GitHub Actions lane), keeping PR CI fast and offline.

## What's implemented
- **Pinned manifest** — `crates/vize_atelier_jsx/tests/ecosystem/testbeds.json` pins each testbed and upstream reference suite by full commit SHA:
  | Entry | Repo | Revision |
  | --- | --- | --- |
  | @vue/babel-plugin-jsx | `vuejs/babel-plugin-jsx` | `803aab3c…` |
  | vue-jsx-vapor | `vuejs/vue-jsx-vapor` | `25eba175…` |
  | Vuetify | `vuetifyjs/vuetify` | `e5555ae8…` |
  | Naive UI | `tusen-ai/naive-ui` | `7a12097e…` |
- **Manual coverage smoke** — `crates/vize_atelier_jsx/tests/ecosystem_smoke.rs`, `#[ignore]`d so it never runs in PR CI. It shallow-clones each pinned entry, walks the configured roots for `.jsx`/`.tsx`, runs every file through `lower_source`, and prints a per-testbed coverage table (files / clean / with-diagnostics / panicked). A panic fails the run — the compiler must surface a diagnostic, never unwind. Offline it degrades gracefully ("clone failed — skipped") instead of failing.
- **Offline CI guard** — `tests/tooling/jsx-ecosystem-fixtures.test.ts` validates the manifest shape (pinned 40-hex SHAs, github repos, roots, extensions, documented run command) on every PR with zero network access, keeping the testbed list honest.
- Inventory updated (`PARITY_INVENTORY.md`): the ecosystem section now documents the manual workflow instead of being marked deferred.

## Verify-real
`cargo test -p vize_atelier_jsx --test ecosystem_smoke -- --ignored --nocapture` (network) cloned all four pins and lowered every matched file with **zero panics**:

```
testbed                  files   clean      w/diag     PANIC
@vue/babel-plugin-jsx        6       6           0         0
vue-jsx-vapor                6       6           0         0
Vuetify                    295     295           0         0
Naive UI                   437     437           0         0
```

744 real-world component-library `.tsx` files lower without unwinding — a genuine robustness signal over the JSX lowering path. ("clean" = `lower_source` returned no error diagnostics; this is a robustness/coverage smoke, not a byte-for-byte parity gate.)

## Acceptance criteria (all met, combined with #1522)
- Tracked inventory of parity + deferred cases — ✓ (#1522 + this PR's inventory update).
- VDOM/Vapor categories separated — ✓ (#1522).
- Vuetify + Naive UI fixture runs available as a documented manual workflow — ✓ (this PR).
- PR CI stays fast; slow ecosystem coverage is opt-in (`#[ignore]`, network-gated) — ✓.

## Deferred (honest)
Wiring the smoke into a scheduled (sharded, non-PR-gating) GitHub Actions lane is a maintainer infra decision, noted in the inventory and tracked alongside #1501's benchmark-CI lane — the workflow files are guardrail-asserted and out of scope here.

## Gates
- `node --test tests/tooling/jsx-ecosystem-fixtures.test.ts` — 3 pass.
- `cargo test -p vize_atelier_jsx` — green (additive: new test file + dev-deps only).
- `cargo clippy -p vize_atelier_jsx -- -D warnings` (CI lib form) — clean.
- `rustup run stable cargo fmt -p vize_atelier_jsx -- --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1537"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->