### PR TITLE
feat(canon): type-check JSX/TSX emits and slots from the Ctx second parameter (#1497, #1502)

### DIFF
--- a/crates/vize_canon/src/batch/virtual_project/jsx_codegen.rs
+++ b/crates/vize_canon/src/batch/virtual_project/jsx_codegen.rs
@@ -34,6 +34,11 @@
 //! The result type-checks exactly what this first cut promises:
 //! - the **typed first parameter** stays verbatim, so every `props.X` access is
 //!   checked against the declared props type;
+//! - the **typed second parameter** (`{ emit, slots }: Ctx<Emits, Slots>`) stays
+//!   verbatim, and an ambient [`Ctx<Emits, Slots>`](CTX_HELPER) type is injected
+//!   so `emit(name, ...args)` checks `name` against `keyof Emits` and the payload
+//!   against the tuple `Emits[name]` (Vue's emits-as-tuple convention), and
+//!   `slots` is typed as `Slots`;
 //! - the **setup-scope** statements above the `return <jsx/>` stay verbatim, so
 //!   their declarations and uses are checked;
 //! - each **JSX expression** (`{props.msg}`, `class={cls}`, `{count + 1}`, …) is
@@ -41,10 +46,9 @@
 //!   byte range, so a wrong type inside a JSX expression is reported at the right
 //!   location.
 //!
-//! Deferred (see issue #1497): emits/slots typing from the `Ctx` second
-//! parameter, directive / `v-model` / style-expression checks, the stateful
-//! `defineComponent(() => () => VNode)` form, and full source-map fidelity for
-//! the synthesized wrapper scaffolding.
+//! Deferred (see issue #1497): directive / `v-model` / style-expression checks,
+//! the stateful `defineComponent(() => () => VNode)` form, and full source-map
+//! fidelity for the synthesized wrapper scaffolding.
 
 use std::path::Path;
 
@@ -73,6 +77,28 @@ pub(super) struct GeneratedJsxFile {
 /// expression. Declaring it ambient and `any`-returning lets each argument be
 /// type-checked independently while the whole call stays a valid render return.
 const JSX_EXPR_SINK: &str = "__vize_jsx_expr__";
+
+/// Ambient `Ctx<Emits, Slots>` type injected at module scope so the typed
+/// second parameter of a Vize JSX/TSX component (`{ emit, slots }: Ctx<…>`)
+/// resolves and type-checks (#1502).
+///
+/// `emit` reuses the very same emits-as-tuple convention as the `.vue` path's
+/// `defineEmits<E>()` (see `crate::virtual_ts::helpers`): the `__EmitFn<E>`
+/// alias resolves `E = { change: [value: number] }` to a callable
+/// `<K extends keyof E>(event: K, ...args: E[K]) => void`, so `emit('change', 1)`
+/// checks the payload against the declared tuple and an unknown event name or a
+/// wrong payload is reported at the `emit(...)` call site. `slots` is typed as
+/// the second type argument so slot access/usage type-checks. Both fall back to
+/// `{}` when omitted (`Ctx`, `Ctx<Emits>`). The type is purely ambient and fully
+/// erased — no runtime is emitted.
+///
+/// Kept self-contained (the emit trio is duplicated rather than pulling in the
+/// broader Vue helper blob) so JSX/TSX virtual TS never depends on resolving the
+/// `vue` module, matching the minimal, fully-erased intent of this path.
+const CTX_HELPER: &str = "type __EmitShape<T> = T extends (...args: any[]) => any ? T : T extends Record<string, any> ? { [K in keyof T]: T[K] extends (...args: infer A) => any ? A : T[K] extends any[] ? T[K] : any[]; } : Record<string, any[]>;\n\
+type __EmitArgs<T, K extends keyof T> = T[K] extends any[] ? T[K] : any[];\n\
+type __EmitFn<T> = __EmitShape<T> extends (...args: any[]) => any ? __EmitShape<T> : (<K extends keyof __EmitShape<T>>(event: K, ...args: __EmitArgs<__EmitShape<T>, K>) => void);\n\
+type Ctx<Emits = {}, Slots = {}> = { emit: __EmitFn<Emits>; slots: Slots; attrs: Record<string, unknown>; };\n";
 
 /// A dynamic JSX expression recovered from the lowered tree: its original source
 /// text plus the byte range it occupied in the `.jsx`/`.tsx` source.
@@ -142,11 +168,14 @@ fn render_plain_ts(
     let mut out = CompactString::default();
     let mut mappings: Vec<VizeMapping> = Vec::new();
 
-    // Ambient helper: declared once at module scope so the re-emitted JSX
+    // Ambient helpers: declared once at module scope so the re-emitted JSX
     // expressions and the synthesized render returns both type-check.
     out.push_str("declare function ");
     out.push_str(JSX_EXPR_SINK);
     out.push_str("(...args: unknown[]): any;\n");
+    // Ambient `Ctx<Emits, Slots>` so the typed second parameter resolves and the
+    // `emit`/`slots` usages in the setup body and JSX expressions type-check.
+    out.push_str(CTX_HELPER);
 
     let mut cursor = 0usize;
     for (start, end, exprs) in roots {
@@ -392,5 +421,76 @@ mod tests {
         let source = "const Comp = (props: { cls: string }) => <div class={props.cls}>hi</div>;\n";
         let generated = generate(source);
         assert!(generated.code.contains("__vize_jsx_expr__(props.cls)"));
+    }
+
+    #[test]
+    fn injects_ambient_ctx_helper() {
+        // The ambient `Ctx<Emits, Slots>` is declared at module scope, with
+        // `emit` typed via the same `__EmitFn` emits-as-tuple convention as the
+        // `.vue` path so a component's typed second parameter resolves.
+        let generated = generate("const Comp = () => <div>hi</div>;\n");
+        assert!(
+            generated
+                .code
+                .contains("type Ctx<Emits = {}, Slots = {}> = { emit: __EmitFn<Emits>;"),
+            "ambient Ctx not injected: {}",
+            generated.code
+        );
+        assert!(
+            generated.code.contains("type __EmitFn<T>"),
+            "emit-typing helper not injected: {}",
+            generated.code
+        );
+    }
+
+    #[test]
+    fn keeps_typed_ctx_param_verbatim_and_reemits_emit_call() {
+        // `props` is the typed first parameter; `{ emit }: Ctx<…>` is the typed
+        // second parameter. Both stay verbatim, and the `emit(...)` call in a
+        // JSX expression is re-emitted as plain TS so its payload type-checks.
+        let source = "const Comp = (\n  props: { msg: string },\n  { emit }: Ctx<{ change: [value: number] }>,\n) => <button onClick={() => emit('change', 1)}>{props.msg}</button>;\n";
+        let generated = generate(source);
+        // The typed second parameter is preserved verbatim.
+        assert!(
+            generated
+                .code
+                .contains("{ emit }: Ctx<{ change: [value: number] }>"),
+            "typed Ctx param dropped: {}",
+            generated.code
+        );
+        // The `emit(...)` call inside the JSX handler is re-emitted as plain TS.
+        assert!(
+            generated.code.contains("emit('change', 1)"),
+            "emit call not re-emitted: {}",
+            generated.code
+        );
+        // Output stays plain TS.
+        assert!(
+            !generated.code.contains("<button"),
+            "JSX element leaked into virtual TS: {}",
+            generated.code
+        );
+    }
+
+    #[test]
+    fn reemits_slots_usage_from_typed_ctx_param() {
+        // `slots` comes from the typed second parameter and is re-emitted inside
+        // the JSX expression so slot access type-checks against `Slots`.
+        let source = "const Comp = (\n  _props: {},\n  { slots }: Ctx<{}, { default: () => unknown }>,\n) => <div>{slots.default()}</div>;\n";
+        let generated = generate(source);
+        assert!(
+            generated
+                .code
+                .contains("{ slots }: Ctx<{}, { default: () => unknown }>"),
+            "typed Ctx slots param dropped: {}",
+            generated.code
+        );
+        assert!(
+            generated
+                .code
+                .contains("__vize_jsx_expr__(slots.default())"),
+            "slots usage not re-emitted: {}",
+            generated.code
+        );
     }
 }

--- a/crates/vize_canon/src/batch/virtual_project/tests.rs
+++ b/crates/vize_canon/src/batch/virtual_project/tests.rs
@@ -1209,3 +1209,149 @@ fn jsx_typecheck_on_lowers_tsx_to_plain_ts() {
 
     let _ = fs::remove_dir_all(&case_dir);
 }
+
+#[test]
+fn jsx_typecheck_on_types_emits_from_ctx_second_param() {
+    // The typed second parameter `{ emit }: Ctx<Emits>` resolves against the
+    // injected ambient `Ctx`, and the `emit(...)` call is re-emitted as plain TS
+    // so the payload is checked against the declared tuple (#1502, #1497).
+    let case_dir = unique_case_dir("jsx-emits");
+    let _ = fs::remove_dir_all(&case_dir);
+    fs::create_dir_all(&case_dir).unwrap();
+    let tsx_path = case_dir.join("Comp.tsx");
+    let source = "const Comp = (\n  props: { msg: string },\n  { emit }: Ctx<{ change: [value: number] }>,\n) => <button onClick={() => emit('change', props.msg.length)}>{props.msg}</button>;\n";
+
+    let mut project = VirtualProject::new(&case_dir).unwrap();
+    project.set_jsx_typecheck(true);
+    project
+        .register_path_with_content(&tsx_path, source)
+        .unwrap();
+    let virtual_file = project.find_by_original(&tsx_path).unwrap();
+
+    // Plain TS, and the ambient `Ctx` plus its emit-typing helper are injected so
+    // the verbatim `Ctx<{ change: [value: number] }>` annotation resolves.
+    assert_ts_parses(&virtual_file.content);
+    assert!(
+        virtual_file
+            .content
+            .contains("type Ctx<Emits = {}, Slots = {}>"),
+        "{}",
+        virtual_file.content
+    );
+    assert!(
+        virtual_file
+            .content
+            .contains("{ emit }: Ctx<{ change: [value: number] }>"),
+        "{}",
+        virtual_file.content
+    );
+    // The `emit(...)` call is re-emitted, so its payload type-checks at the call
+    // site against `[value: number]`.
+    assert!(
+        virtual_file
+            .content
+            .contains("emit('change', props.msg.length)"),
+        "{}",
+        virtual_file.content
+    );
+
+    let _ = fs::remove_dir_all(&case_dir);
+}
+
+#[test]
+fn jsx_typecheck_on_types_slots_from_ctx_second_param() {
+    // `slots` from the typed second parameter is typed as the `Slots` argument,
+    // and its usage in a JSX expression is re-emitted so slot access checks.
+    let case_dir = unique_case_dir("jsx-slots");
+    let _ = fs::remove_dir_all(&case_dir);
+    fs::create_dir_all(&case_dir).unwrap();
+    let tsx_path = case_dir.join("Comp.tsx");
+    let source = "const Comp = (\n  _props: {},\n  { slots }: Ctx<{}, { default: () => unknown }>,\n) => <div>{slots.default()}</div>;\n";
+
+    let mut project = VirtualProject::new(&case_dir).unwrap();
+    project.set_jsx_typecheck(true);
+    project
+        .register_path_with_content(&tsx_path, source)
+        .unwrap();
+    let virtual_file = project.find_by_original(&tsx_path).unwrap();
+
+    assert_ts_parses(&virtual_file.content);
+    assert!(
+        virtual_file
+            .content
+            .contains("{ slots }: Ctx<{}, { default: () => unknown }>"),
+        "{}",
+        virtual_file.content
+    );
+    assert!(
+        virtual_file
+            .content
+            .contains("__vize_jsx_expr__(slots.default())"),
+        "{}",
+        virtual_file.content
+    );
+
+    let _ = fs::remove_dir_all(&case_dir);
+}
+
+#[test]
+fn jsx_typecheck_on_handles_mixed_props_emits_slots() {
+    // A component that uses all three of the typed props, emits, and slots
+    // lowers to plain TS that keeps both typed parameters verbatim and re-emits
+    // every dynamic JSX expression.
+    let case_dir = unique_case_dir("jsx-mixed");
+    let _ = fs::remove_dir_all(&case_dir);
+    fs::create_dir_all(&case_dir).unwrap();
+    let tsx_path = case_dir.join("Comp.tsx");
+    let source = "const Comp = (\n  props: { label: string; count?: number },\n  { emit, slots }: Ctx<{ change: [next: number] }, { default: () => unknown }>,\n) => {\n  const next = (props.count ?? 0) + 1;\n  return (\n    <button onClick={() => emit('change', next)}>\n      {props.label}\n      {slots.default()}\n    </button>\n  );\n};\n";
+
+    let mut project = VirtualProject::new(&case_dir).unwrap();
+    project.set_jsx_typecheck(true);
+    project
+        .register_path_with_content(&tsx_path, source)
+        .unwrap();
+    let virtual_file = project.find_by_original(&tsx_path).unwrap();
+
+    assert_ts_parses(&virtual_file.content);
+    // Both typed parameters and the setup statement stay verbatim.
+    assert!(
+        virtual_file
+            .content
+            .contains("props: { label: string; count?: number }"),
+        "{}",
+        virtual_file.content
+    );
+    assert!(
+        virtual_file.content.contains(
+            "{ emit, slots }: Ctx<{ change: [next: number] }, { default: () => unknown }>"
+        ),
+        "{}",
+        virtual_file.content
+    );
+    assert!(
+        virtual_file
+            .content
+            .contains("const next = (props.count ?? 0) + 1;"),
+        "{}",
+        virtual_file.content
+    );
+    // The emit and slots usages survive as re-emitted plain TS.
+    assert!(
+        virtual_file.content.contains("emit('change', next)"),
+        "{}",
+        virtual_file.content
+    );
+    assert!(
+        virtual_file.content.contains("slots.default()"),
+        "{}",
+        virtual_file.content
+    );
+    // No JSX element syntax leaks into the virtual TS.
+    assert!(
+        !virtual_file.content.contains("<button"),
+        "{}",
+        virtual_file.content
+    );
+
+    let _ = fs::remove_dir_all(&case_dir);
+}


### PR DESCRIPTION
## Summary

PR #1535 landed opt-in JSX/TSX type-checking (`typeChecker.jsxTypecheck`, default OFF) that type-checks the typed **props** (first parameter of the plain-function component) plus JSX/setup-scope expressions, but **explicitly deferred** "emits/slots typing from the `Ctx` second param". This PR implements exactly that, completing the #1502 authoring API on the type-check side and advancing #1497.

Per the locked #1502 authoring design, a Vize JSX/TSX component is a plain function whose second parameter carries emits/slots:

```tsx
const Comp = (
  props: { msg: string; count?: number },
  { emit, slots }: Ctx<{ change: [value: number] }, { default: () => unknown }>,
) => <button onClick={() => emit('change', props.count ?? 0)}>{props.msg}</button>;
```

## What changed

`crates/vize_canon/src/batch/virtual_project/jsx_codegen.rs`:
- Inject an ambient **`Ctx<Emits, Slots>`** type into the generated plain-`.ts` virtual document, alongside the existing `__vize_jsx_expr__` sink (same preamble mechanism).
- `emit` is typed with the **exact same emits-as-tuple convention as the `.vue` path's `defineEmits<E>()`** (`__EmitShape` / `__EmitArgs` / `__EmitFn`, mirrored from `crate::virtual_ts::helpers`): `emit(name, ...args)` checks `name` against `keyof Emits` and the payload against the tuple `Emits[name]` (e.g. `{ change: [value: number] }`).
- `slots` is typed as the `Slots` argument so slot access/usage type-checks; `attrs: Record<string, unknown>`. Both type args default to `{}` (`Ctx`, `Ctx<Emits>`, `Ctx<Emits, Slots>`).
- The typed **second parameter already stays verbatim** (it sits in the verbatim prefix before the JSX root), so `emit`/`slots` usages in the setup body and inside JSX expressions are type-checked and source-mapped back to their original byte ranges — no new plumbing needed there.
- The `Ctx` type is purely ambient and **fully erased (zero runtime)**, and kept **self-contained** (the emit trio is duplicated rather than pulling in the broader Vue helper blob) so JSX/TSX virtual TS never depends on resolving the `vue` module.

JSX/TSX virtual TS **stays plain `.ts`** (standing directive) — unchanged.

## Tests

- **Unit** (`jsx_codegen.rs`): ambient `Ctx`/`__EmitFn` injected; typed second param kept verbatim + `emit(...)` re-emitted; `slots` usage re-emitted.
- **Integration** (`virtual_project/tests.rs`): typed-emits component, typed-slots component, and a mixed props+emits+slots component (both typed params verbatim, every dynamic JSX expression re-emitted, no JSX leaking into the virtual TS).
- Full suite: **372 passing** (366 baseline + 6 new), 0 failures.

## Verify-real (actual `vize check` CLI + real `tsgo` checker)

A temp workspace with `vize.config.json` = `{ "typeChecker": { "jsxTypecheck": true } }`, run via `vize check <file> --format json --corsa-path <tsgo>`.

**Wrong emit payload** (string where the tuple declares `number`):
```tsx
const BadEmit = (
  props: { msg: string },
  { emit }: Ctx<{ change: [value: number] }>,
) => <button onClick={() => emit('change', props.msg)}>{props.msg}</button>;
```
```
error:4:44 [TS2345] Argument of type 'string' is not assignable to parameter of type 'number'.   (errorCount: 1, exit 1)
```
Column 44 is exactly the `props.msg` payload argument inside `emit('change', props.msg)` — the diagnostic lands on the original source location, not the virtual TS.

**Correct emit + slots** → `errorCount: 0`, exit 0:
```tsx
const GoodEmit = (
  props: { msg: string },
  { emit, slots }: Ctx<{ change: [value: number] }, { default: () => unknown }>,
) => (
  <button onClick={() => emit('change', props.msg.length)}>
    {props.msg}
    {slots.default()}
  </button>
);
```

Additional negatives confirmed (proving the typing is real, not permissive):
- Unknown event name `emit('save', 1)` when only `change` exists → `error [TS2345] Argument of type '"save"' is not assignable to parameter of type '"change"'.`
- Bad slot access `slots.footer()` when only `header` is declared → `error [TS2339] Property 'footer' does not exist on type '{ header: () => unknown; }'.`

## Gate results

- `cargo fmt --all -- --check` — clean (verified with the toolchain rustfmt 1.9.0 / `style_edition = 2024`, matching CI; the repo is edition 2024).
- `cargo clippy -p vize_canon -- -D warnings` — clean, zero findings.
- `cargo test -p vize_canon` — 372 passed, 0 failed.
- No public API change (only a private `const` + tests added), so `semver-checks` is N/A.

## Deferred — honest scope

This is **Part of #1497, #1502** — it does **not** close either:
- #1497 also wants directive / `v-model` / style-expression type-checking and LSP integration — not in this PR.
- #1502's LSP hover/completion/signature-help is #1498's territory.
- Still deferred in the JSX path: the stateful `defineComponent(() => () => VNode)` form and full source-map fidelity for the synthesized wrapper scaffolding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1538"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->