### PR TITLE
fix(croquis): AST-backed cross-file resolution, per-usage attrs, and defineStore detection (#1394)

### DIFF
--- a/crates/vize_croquis_cf/src/analyzer/core/deps.rs
+++ b/crates/vize_croquis_cf/src/analyzer/core/deps.rs
@@ -79,8 +79,21 @@ impl CrossFileAnalyzer {
             }
         }
 
-        // Fallback for flat in-memory playground projects and non-relative
-        // imports where only the filename is meaningful.
+        // Bare-filename fallback for flat in-memory/playground projects where
+        // files have no real directory structure (a "virtual path" scheme):
+        // every file lives at the root, so only the filename is meaningful and
+        // a bare specifier like `Button` is matched to `Button.vue`.
+        //
+        // This fallback must NOT fire for relative specifiers (`./`, `../`):
+        // their directory is meaningful, so `./Button.vue` may only resolve to
+        // a sibling, never to a same-named file in a different directory (e.g.
+        // `admin/Button.vue`). Restricting the fallback to non-relative
+        // specifiers keeps the virtual-path case working while preventing
+        // cross-directory leakage.
+        if is_relative_specifier(specifier) {
+            return None;
+        }
+
         let basename = specifier
             .rsplit('/')
             .next()
@@ -106,5 +119,161 @@ impl CrossFileAnalyzer {
 
     pub(super) fn find_component_by_name(&self, name: &str) -> Option<FileId> {
         self.graph.find_by_component(name)
+    }
+}
+
+/// Whether an import specifier is relative (`./` or `../`).
+///
+/// Relative specifiers carry a meaningful directory and must resolve against
+/// the importing file's path, so they are excluded from the bare-filename
+/// fallback used for flat virtual/playground projects.
+fn is_relative_specifier(specifier: &str) -> bool {
+    specifier.starts_with("./")
+        || specifier.starts_with("../")
+        || specifier == "."
+        || specifier == ".."
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_relative_specifier;
+    use crate::{CrossFileAnalyzer, CrossFileOptions, DependencyEdge, FileId};
+    use std::path::Path;
+    use vize_croquis::Croquis;
+
+    fn analyzer_with(files: &[(&str, &str)]) -> CrossFileAnalyzer {
+        let mut analyzer = CrossFileAnalyzer::new(CrossFileOptions::default());
+        for (path, source) in files {
+            analyzer.add_file_with_analysis(Path::new(path), source, Croquis::new());
+        }
+        analyzer
+    }
+
+    #[test]
+    fn is_relative_specifier_classifies_correctly() {
+        assert!(is_relative_specifier("./Button.vue"));
+        assert!(is_relative_specifier("../Button.vue"));
+        assert!(is_relative_specifier("./nested/Button.vue"));
+        assert!(is_relative_specifier("."));
+        assert!(is_relative_specifier(".."));
+        // Non-relative: bare module, alias, absolute.
+        assert!(!is_relative_specifier("Button.vue"));
+        assert!(!is_relative_specifier("@/components/Button.vue"));
+        assert!(!is_relative_specifier("pinia"));
+        assert!(!is_relative_specifier("/abs/Button.vue"));
+        // A bare name that merely starts with a dot (extensionless dotfile-ish)
+        // is not a relative path because it lacks the `./`/`../` prefix.
+        assert!(!is_relative_specifier(".env"));
+    }
+
+    /// `./Button.vue` imported from `pages/Home.vue` must NOT resolve to
+    /// `admin/Button.vue`: the relative directory is meaningful, so a sibling
+    /// that does not exist must stay unresolved rather than fall through to a
+    /// same-named file elsewhere via the bare-filename fallback.
+    #[test]
+    fn relative_import_never_crosses_directories() {
+        let analyzer = analyzer_with(&[("pages/Home.vue", ""), ("admin/Button.vue", "")]);
+
+        let from_dir = Path::new("pages/Home.vue").parent();
+        assert_eq!(analyzer.resolve_import("./Button.vue", from_dir), None);
+    }
+
+    /// The sibling that actually exists is resolved by canonical path.
+    #[test]
+    fn relative_import_resolves_to_sibling() {
+        let analyzer = analyzer_with(&[
+            ("pages/Home.vue", ""),
+            ("pages/Button.vue", ""),
+            ("admin/Button.vue", ""),
+        ]);
+
+        let from_dir = Path::new("pages/Home.vue").parent();
+        let resolved = analyzer.resolve_import("./Button.vue", from_dir);
+        let expected = analyzer.registry().get_id(Path::new("pages/Button.vue"));
+        assert!(resolved.is_some());
+        assert_eq!(resolved, expected);
+    }
+
+    /// Flat in-memory/playground projects have no directory structure, so a
+    /// bare (non-relative) specifier still resolves by filename — preserving the
+    /// virtual-path scheme the playground relies on.
+    #[test]
+    fn bare_specifier_resolves_by_filename_for_virtual_projects() {
+        let analyzer = analyzer_with(&[("App.vue", ""), ("Button.vue", "")]);
+
+        // No directory information; only the filename is meaningful.
+        let resolved = analyzer.resolve_import("Button", None);
+        let expected = analyzer.registry().get_id(Path::new("Button.vue"));
+        assert!(resolved.is_some());
+        assert_eq!(resolved, expected);
+    }
+
+    fn import_edge_target(analyzer: &CrossFileAnalyzer, from: FileId, to: FileId) -> bool {
+        analyzer
+            .graph()
+            .nodes()
+            .find(|n| n.file_id == from)
+            .is_some_and(|node| {
+                node.imports
+                    .iter()
+                    .any(|(target, edge)| *target == to && matches!(edge, DependencyEdge::Import))
+            })
+    }
+
+    /// End-to-end through the dependency graph and the real single-file import
+    /// parser: a relative `import` whose sibling does not exist must not create
+    /// an `Import` edge to a same-named file in a different directory.
+    #[test]
+    fn relative_import_edge_does_not_cross_directories() {
+        // `pages/Home.ts` imports `./Button.vue`, but the only `Button.vue`
+        // lives in `admin/`.
+        let mut analyzer = CrossFileAnalyzer::new(CrossFileOptions::default());
+        let home_id = analyzer.add_file(
+            Path::new("pages/Home.ts"),
+            "import Button from './Button.vue'\n",
+        );
+        analyzer.add_file(Path::new("admin/Button.vue"), "");
+        analyzer.rebuild_import_edges();
+
+        let admin_id = analyzer
+            .registry()
+            .get_id(Path::new("admin/Button.vue"))
+            .unwrap();
+
+        assert!(
+            !import_edge_target(&analyzer, home_id, admin_id),
+            "relative import must not create an Import edge across directories"
+        );
+    }
+
+    /// The Import edge IS created when the relative sibling exists.
+    #[test]
+    fn relative_import_edge_resolves_to_sibling() {
+        let mut analyzer = CrossFileAnalyzer::new(CrossFileOptions::default());
+        let home_id = analyzer.add_file(
+            Path::new("pages/Home.ts"),
+            "import Button from './Button.vue'\n",
+        );
+        analyzer.add_file(Path::new("pages/Button.vue"), "");
+        analyzer.add_file(Path::new("admin/Button.vue"), "");
+        analyzer.rebuild_import_edges();
+
+        let sibling_id = analyzer
+            .registry()
+            .get_id(Path::new("pages/Button.vue"))
+            .unwrap();
+        let admin_id = analyzer
+            .registry()
+            .get_id(Path::new("admin/Button.vue"))
+            .unwrap();
+
+        assert!(
+            import_edge_target(&analyzer, home_id, sibling_id),
+            "relative import must edge to the sibling"
+        );
+        assert!(
+            !import_edge_target(&analyzer, home_id, admin_id),
+            "relative import must not also edge to the unrelated admin/Button.vue"
+        );
     }
 }

--- a/crates/vize_croquis_cf/src/analyzers/cross_file_reactivity/path_helpers.rs
+++ b/crates/vize_croquis_cf/src/analyzers/cross_file_reactivity/path_helpers.rs
@@ -1,9 +1,27 @@
 use std::path::{Component, Path, PathBuf};
 pub(super) fn import_targets_path(specifier: &str, from_dir: Option<&Path>, target: &Path) -> bool {
     let normalized_target = normalize_logical_path(target.to_path_buf());
+    // The component-suffix fallback (`target` ends with the candidate path) lets
+    // a flat in-memory/playground file matched by bare filename line up with a
+    // `target` that carries a directory prefix. It must NOT apply to relative
+    // specifiers (`./`, `../`): their directory is meaningful, so `./Child.vue`
+    // may only match its sibling, never a same-named file in a different
+    // directory. Relative specifiers therefore require exact canonical equality.
+    let allow_suffix = !is_relative_specifier(specifier);
     import_candidates(specifier, from_dir)
         .into_iter()
-        .any(|candidate| candidate == normalized_target || normalized_target.ends_with(&candidate))
+        .any(|candidate| {
+            candidate == normalized_target
+                || (allow_suffix && normalized_target.ends_with(&candidate))
+        })
+}
+
+/// Whether an import specifier is relative (`./` or `../`).
+fn is_relative_specifier(specifier: &str) -> bool {
+    specifier.starts_with("./")
+        || specifier.starts_with("../")
+        || specifier == "."
+        || specifier == ".."
 }
 
 fn import_candidates(specifier: &str, from_dir: Option<&Path>) -> Vec<PathBuf> {
@@ -75,4 +93,70 @@ fn normalize_logical_path(path: PathBuf) -> PathBuf {
     }
 
     normalized
+}
+
+#[cfg(test)]
+mod tests {
+    use super::import_targets_path;
+    use std::path::Path;
+
+    /// Relative composable imports must resolve to their sibling only; a
+    /// same-named module in a different directory must not be treated as the
+    /// flow target.
+    #[test]
+    fn relative_composable_import_does_not_cross_directories() {
+        let from_dir = Some(Path::new("features/cart"));
+        assert!(import_targets_path(
+            "./useCart.ts",
+            from_dir,
+            Path::new("features/cart/useCart.ts")
+        ));
+        assert!(!import_targets_path(
+            "./useCart.ts",
+            from_dir,
+            Path::new("features/admin/useCart.ts")
+        ));
+    }
+
+    /// The cross-directory hazard manifests when the importing file is at the
+    /// project root (flat in-memory/playground), so `from_dir` is empty: a
+    /// relative `./useCart.ts` then normalizes to the bare `useCart.ts`. Without
+    /// the relative-specifier guard the bare candidate would suffix-match a
+    /// `target` carrying any directory prefix (e.g. `features/admin/useCart.ts`),
+    /// crossing directories. The guard requires exact equality for relative
+    /// specifiers, so only a root-level sibling matches.
+    #[test]
+    fn relative_import_from_root_does_not_suffix_match_nested_target() {
+        // Importing file is at the root: `parent.path.parent()` is empty.
+        let from_dir = Some(Path::new(""));
+        // Sibling at the root resolves.
+        assert!(import_targets_path(
+            "./useCart.ts",
+            from_dir,
+            Path::new("useCart.ts")
+        ));
+        // A nested same-named module must NOT be treated as the target.
+        assert!(!import_targets_path(
+            "./useCart.ts",
+            from_dir,
+            Path::new("features/admin/useCart.ts")
+        ));
+        // Same hazard with `from_dir = None`.
+        assert!(!import_targets_path(
+            "./useCart.ts",
+            None,
+            Path::new("features/admin/useCart.ts")
+        ));
+    }
+
+    /// A bare specifier in a flat virtual/playground project still matches a
+    /// directory-prefixed target via the component-suffix fallback.
+    #[test]
+    fn bare_composable_import_targets_via_suffix() {
+        assert!(import_targets_path(
+            "useCart",
+            None,
+            Path::new("composables/useCart.ts")
+        ));
+    }
 }

--- a/crates/vize_croquis_cf/src/analyzers/props_validation.rs
+++ b/crates/vize_croquis_cf/src/analyzers/props_validation.rs
@@ -426,9 +426,27 @@ fn imported_aliases_for_child(
 
 fn import_targets_path(specifier: &str, from_dir: Option<&Path>, target: &Path) -> bool {
     let normalized_target = normalize_logical_path(target.to_path_buf());
+    // The component-suffix fallback (`target` ends with the candidate path) lets
+    // a flat in-memory/playground file matched by bare filename line up with a
+    // `target` that carries a directory prefix. It must NOT apply to relative
+    // specifiers (`./`, `../`): their directory is meaningful, so `./Child.vue`
+    // may only match its sibling, never a same-named file in a different
+    // directory. Relative specifiers therefore require exact canonical equality.
+    let allow_suffix = !is_relative_specifier(specifier);
     import_candidates(specifier, from_dir)
         .into_iter()
-        .any(|candidate| candidate == normalized_target || normalized_target.ends_with(&candidate))
+        .any(|candidate| {
+            candidate == normalized_target
+                || (allow_suffix && normalized_target.ends_with(&candidate))
+        })
+}
+
+/// Whether an import specifier is relative (`./` or `../`).
+fn is_relative_specifier(specifier: &str) -> bool {
+    specifier.starts_with("./")
+        || specifier.starts_with("../")
+        || specifier == "."
+        || specifier == ".."
 }
 
 fn import_candidates(specifier: &str, from_dir: Option<&Path>) -> Vec<PathBuf> {
@@ -553,7 +571,8 @@ fn is_builtin_attr(name: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::is_builtin_attr;
+    use super::{import_targets_path, is_builtin_attr};
+    use std::path::Path;
 
     #[test]
     fn test_is_builtin_attr() {
@@ -562,5 +581,60 @@ mod tests {
         assert!(is_builtin_attr("v-model"));
         assert!(!is_builtin_attr("myProp"));
         assert!(!is_builtin_attr("customAttr"));
+    }
+
+    /// `./Button.vue` imported from `pages/` must not be treated as targeting
+    /// `admin/Button.vue`: relative specifiers require exact canonical equality,
+    /// so the prop-validation alias mapping never crosses directories.
+    #[test]
+    fn relative_import_targets_only_sibling() {
+        let from_dir = Some(Path::new("pages"));
+        assert!(import_targets_path(
+            "./Button.vue",
+            from_dir,
+            Path::new("pages/Button.vue")
+        ));
+        assert!(!import_targets_path(
+            "./Button.vue",
+            from_dir,
+            Path::new("admin/Button.vue")
+        ));
+    }
+
+    /// When the parent is at the project root (flat in-memory/playground), its
+    /// `from_dir` is empty and `./Button.vue` normalizes to the bare
+    /// `Button.vue`. The relative-specifier guard prevents that bare candidate
+    /// from suffix-matching a nested `admin/Button.vue`, so the alias mapping
+    /// still does not cross directories. A root-level sibling does resolve.
+    #[test]
+    fn relative_import_from_root_targets_only_root_sibling() {
+        let from_dir = Some(Path::new(""));
+        assert!(import_targets_path(
+            "./Button.vue",
+            from_dir,
+            Path::new("Button.vue")
+        ));
+        assert!(!import_targets_path(
+            "./Button.vue",
+            from_dir,
+            Path::new("admin/Button.vue")
+        ));
+        assert!(!import_targets_path(
+            "./Button.vue",
+            None,
+            Path::new("admin/Button.vue")
+        ));
+    }
+
+    /// A bare specifier in a flat virtual/playground project still matches a
+    /// `target` that carries a directory prefix, via the component-suffix
+    /// fallback.
+    #[test]
+    fn bare_import_targets_via_suffix_for_virtual_projects() {
+        assert!(import_targets_path(
+            "Button.vue",
+            None,
+            Path::new("components/Button.vue")
+        ));
     }
 }


### PR DESCRIPTION
Part of #1394 (PR8 — croquis_cf cross-file fixes).

## What's implemented

Relative import specifiers (`./`, `../`) carry a meaningful directory, but the
cross-file resolvers still fell through to a **bare-filename / component-suffix
match across the entire registry**. As a result `./Button.vue` imported from
`pages/Home.vue` could wrongly resolve to an unrelated `admin/Button.vue` when
no sibling existed — violating the #1394 acceptance bar ("`./Button.vue` never
resolves to a different directory's file").

This PR gates every such fallback on a new `is_relative_specifier` check:

- **Relative specifiers** (`./`, `../`, `.`, `..`) now require **exact
  canonical-path equality** and never cross directories.
- **Non-relative specifiers** (bare `Button`, `@/...`, absolute `/...`) keep the
  bare-filename fallback — this is the **virtual-path scheme** for flat
  in-memory/playground projects, where every file lives at the root and only the
  filename is meaningful.

Fixed in all three resolvers that drive cross-file diagnostics:

| File | Function | Drives |
|------|----------|--------|
| `analyzer/core/deps.rs` | `resolve_import` | import + component-usage graph edges |
| `analyzers/props_validation.rs` | `import_targets_path` | parent→child prop alias mapping |
| `analyzers/cross_file_reactivity/path_helpers.rs` | `import_targets_path` | composable reactive-flow targeting |

The other two behaviors named in the PR8 task were already resolved on `main` by
earlier merged work and are covered by existing tests, so they are intentionally
not re-touched here:

- **Per-usage attr attribution** — `extract_passed_attrs` already threads the
  per-usage child identity through the dependency graph (#1462;
  `fallthrough.rs`), with `passed_attrs_are_attributed_per_child` /
  `same_child_used_twice_does_not_leak_sibling_attrs`.
- **`defineStore` detection** — stores are detected structurally via
  `StoreFactories`/`collect_store_factories` (import + call-site tracking,
  alias-aware), wired through `registry.pinia_stores`; a non-store `useFoo()` is
  not misdetected and a non-`use*Store`-named factory still is.

## Verify-real

- Bug reproduced by reading the code path: for a relative specifier whose
  canonical candidate misses, `resolve_import` (deps.rs) and `import_targets_path`
  (props/path_helpers) fell through to filename/`ends_with` matching across all
  directories.
- Each fix is **proven by a deliberately-failing test**: temporarily forcing the
  old behavior (`allow_suffix = true` / removing the guard) makes
  `relative_import_never_crosses_directories`,
  `relative_import_edge_does_not_cross_directories`,
  `relative_import_from_root_does_not_suffix_match_nested_target`, and
  `relative_import_from_root_targets_only_root_sibling` **fail**; with the guard
  they pass.
- Virtual-path scheme preserved:
  `bare_specifier_resolves_by_filename_for_virtual_projects`,
  `bare_import_targets_via_suffix_for_virtual_projects`,
  `bare_composable_import_targets_via_suffix`.
- Sibling resolution intact: `relative_import_resolves_to_sibling`,
  `relative_import_edge_resolves_to_sibling`.
- 10 new tests; full crate suite 150 passed / 0 failed.

## Deferred (honest)

- The template **component-name** fallback (`find_by_component`) in `deps.rs`
  resolves `<Button>` template usages by name and is still directory-agnostic.
  This is a separate, intentional heuristic that the flat playground relies on
  (template usages have no import statement); the #1394 acceptance bar is about
  *import-path* resolution, which this PR fully addresses. Left untouched to keep
  the change focused and avoid regressing playground component resolution.
- `cross_file_reactivity/flow_composable.rs` uses `path.ends_with("<src>.ts")`
  for a re-export style check; it operates on already-resolved registry paths,
  not on raw relative specifiers, so it is not part of the cross-directory
  hazard fixed here.

## Gates

- `rustup run stable rustfmt --edition 2024 --check` on all 3 changed files: clean.
- `RUSTFMT=<stable> rustup run stable cargo fmt -p vize_croquis_cf -- --check`: clean.
  (Note: bare `cargo fmt` on this host resolves a nix nightly rustfmt from PATH;
  the stable binary — matching CI rustfmt 1.9.0 — was invoked explicitly.)
- `cargo clippy -p vize_croquis_cf -- -D warnings`: clean. Also clean for
  `vize` and `vize_vitrine` (the downstream consumers).
- `cargo test -p vize_croquis_cf`: 150 passed, 0 failed.
- `semver-checks`: N/A — no public API changed (only private fns + a `pub(super)`
  internal; verified via diff).
- Pre-existing unrelated failure: `vize`'s
  `inspector_compare_outputs_cli_diff_report_when_dev_runtime_is_available`
  requires the `vue`/`@vue/compiler-sfc` npm packages (absent in this sandbox);
  fails with `ERR_MODULE_NOT_FOUND` independent of this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1542"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->