### PR TITLE
ci(bench): criterion A/B gate, main-snapshot ratchet, and dialect-guard harness (#1386)

### DIFF
--- a/.github/workflows/criterion-bench.yml
+++ b/.github/workflows/criterion-bench.yml
@@ -1,0 +1,152 @@
+name: Criterion Bench
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - "crates/**"
+      - "bench/criterion-ab.mjs"
+      - "bench/dialect-guard.mjs"
+      - "bench/generate.mjs"
+      - ".github/workflows/criterion-bench.yml"
+
+concurrency:
+  group: criterion-bench-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  # Report-only: criterion micro-benchmarks are noisy on shared CI runners, so
+  # the A/B table is surfaced for review but the empty threshold keeps it from
+  # blocking a PR. The dialect guard below is a hard gate because byte-identical
+  # codegen is deterministic and not subject to timing jitter.
+  CRITERION_AB_THRESHOLD: ""
+  # The dialect-guard corpus is small so the legacy OFF/ON binaries compile it
+  # quickly; identity is exact, and the A/B timing tolerates a 2% delta.
+  DIALECT_GUARD_FILE_COUNT: 400
+  DIALECT_GUARD_THRESHOLD_PERCENT: 2
+
+jobs:
+  criterion-ab:
+    name: criterion-ab
+    runs-on: blacksmith-32vcpu-ubuntu-2404
+    timeout-minutes: 45
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout head
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          path: head
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Checkout base
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          path: base
+          ref: ${{ github.event.pull_request.base.sha }}
+
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+
+      - uses: wild-linker/action@0bbbfa5df4380cab8e63cb8505a1ce65e1d10203 # v0.9.0
+        with:
+          wild-version: "0.9.0"
+
+      # Both sides bench into head/target so critcmp can read both baselines, so
+      # a single shared target disk is mounted (base and head compile into it).
+      - uses: ./head/.github/actions/setup-rust-sticky-cache
+        with:
+          key: criterion-bench
+          cache-key-suffix: ${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('head/Cargo.lock') }}
+          target-path: head/target
+
+      # The A/B driver is plain Node (no npm deps); pin the runtime so the
+      # script never runs under an unexpected runner-default Node version.
+      - uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1
+        with:
+          node-version-file: "head/.node-version"
+          cache: true
+          run-install: false
+
+      - name: Cache critcmp
+        id: cache-critcmp
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        with:
+          path: ~/.cargo/bin/critcmp
+          key: ${{ runner.os }}-critcmp-0.1.8
+
+      - name: Install critcmp
+        if: steps.cache-critcmp.outputs.cache-hit != 'true'
+        run: cargo install critcmp --version 0.1.8 --locked
+
+      # Both checkouts save their criterion baselines into the head checkout's
+      # shared target dir so critcmp can diff base against head in one pass.
+      - name: Run criterion A/B
+        run: |
+          node head/bench/criterion-ab.mjs \
+            --base-dir "$GITHUB_WORKSPACE/base" \
+            --head-dir "$GITHUB_WORKSPACE/head" \
+            --target-dir "$GITHUB_WORKSPACE/head/target" \
+            ${CRITERION_AB_THRESHOLD:+--threshold "$CRITERION_AB_THRESHOLD"} \
+            --out "$GITHUB_WORKSPACE/criterion-ab-summary.md"
+
+      - name: Upload criterion A/B summary
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: criterion-ab
+          path: criterion-ab-summary.md
+          if-no-files-found: warn
+          retention-days: 14
+
+  dialect-guard:
+    name: dialect-guard
+    runs-on: blacksmith-32vcpu-ubuntu-2404
+    timeout-minutes: 45
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout head
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+
+      - uses: wild-linker/action@0bbbfa5df4380cab8e63cb8505a1ce65e1d10203 # v0.9.0
+        with:
+          wild-version: "0.9.0"
+
+      - uses: ./.github/actions/setup-rust-sticky-cache
+        with:
+          key: dialect-guard
+          cache-key-suffix: ${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('Cargo.lock') }}
+
+      # The corpus generator and guard driver are plain Node (no npm deps).
+      - uses: voidzero-dev/setup-vp@ca1c46663915d6c1042ae23bd39ab85718bfb0fa # v1
+        with:
+          node-version-file: ".node-version"
+          cache: true
+          run-install: false
+
+      # A vize binary with the legacy Vue feature OFF (the shipped Vue 3 build)
+      # and one with it ON. Distinct target dirs keep the two feature sets from
+      # invalidating each other's incremental cache.
+      - name: Build vize (legacy OFF)
+        run: cargo build --profile ci-opt -p vize --target-dir target/off
+
+      - name: Build vize (legacy ON)
+        run: cargo build --profile ci-opt -p vize --features legacy --target-dir target/on
+
+      - name: Generate Vue 3 corpus
+        run: node bench/generate.mjs "$DIALECT_GUARD_FILE_COUNT"
+
+      - name: Compare legacy OFF vs ON
+        run: |
+          node bench/dialect-guard.mjs \
+            --input bench/__in__ \
+            --off-bin target/off/ci-opt/vize \
+            --on-bin target/on/ci-opt/vize \
+            --out-dir "$GITHUB_WORKSPACE/dialect-guard-out" \
+            --threshold "$DIALECT_GUARD_THRESHOLD_PERCENT"

--- a/.github/workflows/tool-benchmark.yml
+++ b/.github/workflows/tool-benchmark.yml
@@ -39,6 +39,13 @@ on:
   pull_request:
     branches: [main]
     types: [opened, synchronize, reopened, ready_for_review]
+  schedule:
+    # Weekly ratchet: a full tool benchmark is far too heavy (75 min) to run on
+    # every push to main, so a scheduled run refreshes the committed baseline
+    # snapshot (bench/results/tool-benchmark-latest.json) on a fixed cadence.
+    # This stops sub-threshold drift from accumulating silently between the
+    # manual workflow_dispatch refreshes the snapshot was previously limited to.
+    - cron: "41 5 * * 1"
 
 concurrency:
   group: tool-benchmark-${{ github.event.pull_request.number || github.ref }}
@@ -174,7 +181,7 @@ jobs:
     name: tool-benchmark-commit
     runs-on: blacksmith-32vcpu-ubuntu-2404
     timeout-minutes: 5
-    if: ${{ github.event_name == 'workflow_dispatch' && inputs.commit_results && startsWith(github.ref, 'refs/heads/') }}
+    if: ${{ ((github.event_name == 'workflow_dispatch' && inputs.commit_results) || github.event_name == 'schedule') && startsWith(github.ref, 'refs/heads/') }}
     needs:
       - tool-benchmark
     permissions:

--- a/bench/criterion-ab.mjs
+++ b/bench/criterion-ab.mjs
@@ -152,9 +152,7 @@ export function parseCritcmpRegressions(table, thresholdPercent) {
       continue;
     }
     // Columns: <name> <baseFactor> <baseTime> <headFactor> <headTime>
-    const match = line.match(
-      /^(\S+)\s+(\d+(?:\.\d+)?)\s+\S+\s+(\d+(?:\.\d+)?)\s+\S+/,
-    );
+    const match = line.match(/^(\S+)\s+(\d+(?:\.\d+)?)\s+\S+\s+(\d+(?:\.\d+)?)\s+\S+/);
     if (!match) {
       continue;
     }

--- a/bench/criterion-ab.mjs
+++ b/bench/criterion-ab.mjs
@@ -76,7 +76,7 @@ function parsePositiveFloat(value) {
 function run(command, commandArgs, options = {}) {
   const result = spawnSync(command, commandArgs, {
     cwd: options.cwd,
-    env: { ...process.env, ...(options.env ?? {}) },
+    env: { ...process.env, ...options.env },
     encoding: "utf8",
     stdio: options.capture ? "pipe" : "inherit",
     maxBuffer: 64 * 1024 * 1024,

--- a/bench/criterion-ab.mjs
+++ b/bench/criterion-ab.mjs
@@ -1,0 +1,260 @@
+#!/usr/bin/env node
+/**
+ * Run criterion micro-benchmarks for a base and head checkout and compare the
+ * two saved baselines with `critcmp`, surfacing the table in the GitHub Actions
+ * step summary.
+ *
+ * Unlike `compare-pr.mjs` (which times the whole CLI on a generated corpus),
+ * this script drives the in-crate criterion suites under the crate `benches`
+ * directories. Both sides save a named baseline into the same `--target-dir`,
+ * so critcmp can diff `base` against `head` for each benchmark id in one pass.
+ *
+ * The script is dependency-free (besides `cargo`, `critcmp`, and a checkout of
+ * each side) so GitHub Actions can run it after checking out both commits.
+ *
+ * Cadence note: criterion is noisy on shared CI runners, so this is a reporting
+ * gate by default — it prints the critcmp delta table and only fails when
+ * `--threshold <pct>` is passed and a benchmark regresses past it. The workflow
+ * runs it in report-only mode so micro-benchmark jitter never blocks a PR; the
+ * threshold knob is wired so the gate can be tightened later without a code
+ * change.
+ */
+
+import { spawnSync } from "node:child_process";
+import { appendFileSync, existsSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+// Criterion benches that exist under crates/*/benches and represent the hot
+// compiler/analysis/codegen paths. Each entry maps a cargo package to the
+// `[[bench]]` targets it owns; the `bench filter` narrows criterion to the
+// specific group so a full sweep stays inside the job timeout.
+export const CRITERION_SUITES = [
+  {
+    package: "vize_atelier_sfc",
+    benches: ["sfc_parse", "sfc_compile"],
+    label: "SFC parse + compile",
+  },
+  { package: "vize_atelier_jsx", benches: ["jsx_compile"], label: "JSX compile" },
+  { package: "vize_croquis_cf", benches: ["cross_file"], label: "Cross-file analysis" },
+  { package: "vize_glyph", benches: ["formatter"], label: "Formatter" },
+  { package: "vize_patina", benches: ["lint_bench"], label: "Lint" },
+];
+
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (!arg.startsWith("--")) {
+      continue;
+    }
+    const key = arg.slice(2);
+    const next = argv[i + 1];
+    if (next == null || next.startsWith("--")) {
+      args[key] = "true";
+    } else {
+      args[key] = next;
+      i++;
+    }
+  }
+  return args;
+}
+
+function requireArg(args, key) {
+  const value = args[key];
+  if (!value) {
+    throw new Error(`Missing required argument: --${key}`);
+  }
+  return value;
+}
+
+function parsePositiveFloat(value) {
+  const parsed = Number.parseFloat(value ?? "");
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+function run(command, commandArgs, options = {}) {
+  const result = spawnSync(command, commandArgs, {
+    cwd: options.cwd,
+    env: { ...process.env, ...(options.env ?? {}) },
+    encoding: "utf8",
+    stdio: options.capture ? "pipe" : "inherit",
+    maxBuffer: 64 * 1024 * 1024,
+  });
+  if (result.error) {
+    throw result.error;
+  }
+  if (result.status !== 0 && !options.allowFailure) {
+    throw new Error(`${command} ${commandArgs.join(" ")} exited with ${result.status}`);
+  }
+  return result;
+}
+
+/**
+ * Build the `cargo bench` argument vector for one side of the comparison.
+ * `targetDir` is shared between base and head so critcmp can read both
+ * baselines; `baseline` is the criterion baseline name (`base` or `head`).
+ */
+export function cargoBenchArgs({ pkg, benches, baseline, targetDir }) {
+  const args = ["bench", "-p", pkg];
+  for (const bench of benches) {
+    args.push("--bench", bench);
+  }
+  args.push("--target-dir", targetDir);
+  // Everything after `--` is forwarded to the criterion harness.
+  args.push("--", "--save-baseline", baseline);
+  return args;
+}
+
+function benchSide({ side, checkoutDir, baseline, targetDir, suites }) {
+  for (const suite of suites) {
+    const args = cargoBenchArgs({
+      pkg: suite.package,
+      benches: suite.benches,
+      baseline,
+      targetDir,
+    });
+    console.log(`\n==> [${side}] cargo ${args.join(" ")}`);
+    run("cargo", args, { cwd: checkoutDir });
+  }
+}
+
+function critcmpCompare({ targetDir, threshold }) {
+  // `--target-dir` points criterion at <dir>/criterion; critcmp reads the same
+  // location via CRITERION_HOME so both baselines resolve without extra flags.
+  const env = { CRITERION_HOME: resolve(targetDir, "criterion") };
+  const args = ["base", "head"];
+  if (threshold != null) {
+    // critcmp's own threshold only colorizes; we still parse the table below to
+    // decide pass/fail so the behaviour is identical across critcmp versions.
+    args.push("--threshold", String(threshold));
+  }
+  const result = run("critcmp", args, { capture: true, allowFailure: true, env });
+  return `${result.stdout ?? ""}${result.stderr ?? ""}`;
+}
+
+/**
+ * Parse a critcmp table into per-benchmark base/head nanosecond medians.
+ * critcmp prints rows like:
+ *   group/bench   1.00   3.2±0.1µs   1.04  3.4±0.2µs
+ * where the two timing columns are base and head. We only need the ratio, which
+ * critcmp already encodes as the leading multiplier on each side (1.00 for the
+ * faster side). Rather than re-derive units we read the explicit factor columns.
+ */
+export function parseCritcmpRegressions(table, thresholdPercent) {
+  if (thresholdPercent == null) {
+    return [];
+  }
+  const regressions = [];
+  for (const rawLine of table.split("\n")) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith("group")) {
+      continue;
+    }
+    // Columns: <name> <baseFactor> <baseTime> <headFactor> <headTime>
+    const match = line.match(
+      /^(\S+)\s+(\d+(?:\.\d+)?)\s+\S+\s+(\d+(?:\.\d+)?)\s+\S+/,
+    );
+    if (!match) {
+      continue;
+    }
+    const name = match[1];
+    const baseFactor = Number.parseFloat(match[2]);
+    const headFactor = Number.parseFloat(match[3]);
+    if (!Number.isFinite(baseFactor) || !Number.isFinite(headFactor) || baseFactor === 0) {
+      continue;
+    }
+    // critcmp normalises the faster column to 1.00; head/base ratio is the
+    // head factor when base is the 1.00 baseline, otherwise its reciprocal.
+    const ratio = headFactor / baseFactor;
+    const changePercent = (ratio - 1) * 100;
+    if (changePercent >= thresholdPercent) {
+      regressions.push({ name, changePercent });
+    }
+  }
+  return regressions;
+}
+
+export function renderSummary({ table, threshold, regressions }) {
+  const lines = [];
+  lines.push("## Criterion A/B");
+  lines.push("");
+  lines.push(
+    threshold == null
+      ? "Report-only: micro-benchmark medians for base vs head (no gate)."
+      : `Regression threshold: ${threshold}%.`,
+  );
+  lines.push("");
+  lines.push("```");
+  lines.push(table.trimEnd());
+  lines.push("```");
+  if (regressions.length > 0) {
+    lines.push("");
+    lines.push(`Regressions past ${threshold}%:`);
+    for (const regression of regressions) {
+      lines.push(`- ${regression.name}: +${regression.changePercent.toFixed(2)}%`);
+    }
+  }
+  lines.push("");
+  return `${lines.join("\n")}\n`;
+}
+
+export function main(argv = process.argv.slice(2)) {
+  const args = parseArgs(argv);
+  const baseDir = resolve(requireArg(args, "base-dir"));
+  const headDir = resolve(requireArg(args, "head-dir"));
+  const targetDir = resolve(requireArg(args, "target-dir"));
+  const threshold = parsePositiveFloat(args.threshold);
+
+  if (!existsSync(baseDir)) {
+    throw new Error(`Base checkout not found: ${baseDir}`);
+  }
+  if (!existsSync(headDir)) {
+    throw new Error(`Head checkout not found: ${headDir}`);
+  }
+
+  // Base first, then head, into the shared target dir so critcmp sees both.
+  benchSide({
+    side: "base",
+    checkoutDir: baseDir,
+    baseline: "base",
+    targetDir,
+    suites: CRITERION_SUITES,
+  });
+  benchSide({
+    side: "head",
+    checkoutDir: headDir,
+    baseline: "head",
+    targetDir,
+    suites: CRITERION_SUITES,
+  });
+
+  const table = critcmpCompare({ targetDir, threshold });
+  const regressions = parseCritcmpRegressions(table, threshold);
+  const summary = renderSummary({ table, threshold, regressions });
+
+  if (args.out) {
+    writeFileSync(resolve(args.out), summary);
+  }
+  if (process.env.GITHUB_STEP_SUMMARY) {
+    appendFileSync(process.env.GITHUB_STEP_SUMMARY, summary);
+  } else {
+    process.stdout.write(summary);
+  }
+
+  if (threshold != null && regressions.length > 0) {
+    console.error(
+      `Criterion budget failed: ${regressions.length} benchmark(s) regressed past ${threshold}%.`,
+    );
+    process.exitCode = 1;
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    main();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+}

--- a/bench/dialect-guard.mjs
+++ b/bench/dialect-guard.mjs
@@ -140,7 +140,7 @@ export function diffOutputs(off, on) {
 function run(command, commandArgs, options = {}) {
   const result = spawnSync(command, commandArgs, {
     cwd: options.cwd,
-    env: { ...process.env, ...(options.env ?? {}) },
+    env: { ...process.env, ...options.env },
     encoding: "utf8",
     stdio: options.capture ? "pipe" : "inherit",
     maxBuffer: 64 * 1024 * 1024,

--- a/bench/dialect-guard.mjs
+++ b/bench/dialect-guard.mjs
@@ -1,0 +1,286 @@
+#!/usr/bin/env node
+/**
+ * Dialect guard: prove that the opt-in `legacy` Vue (v0/v1/v2) cargo feature is
+ * truly zero-impact on the default Vue 3 path.
+ *
+ * Two independent checks run against the same generated Vue 3 corpus:
+ *
+ *   1. Codegen identity — compile the corpus once with a `legacy`-OFF binary and
+ *      once with a `legacy`-ON binary and assert the emitted output is
+ *      byte-identical. Legacy support is dialect-gated, so with a Vue 3 corpus
+ *      the ON binary must produce exactly the Vue 3 output; any divergence means
+ *      legacy code leaked into the default path.
+ *
+ *   2. A/B timing — time the OFF vs ON binary on the corpus and fail if the ON
+ *      build regresses the Vue 3 hot path past `--threshold` (default 2%). The
+ *      feature is meant to add code behind a flag, not slow the default binary.
+ *
+ * HONEST STATUS: the `legacy` feature is still largely a stub today, so the
+ * codegen-identity assertion is currently expected to pass trivially and the A/B
+ * delta is near zero. This harness exists so the gate is wired and starts
+ * catching divergence the moment `legacy` grows real, dialect-gated code. See
+ * the PR's "Deferred" section.
+ *
+ * Dependency-free besides `cargo` and a built corpus generator.
+ */
+
+import { spawnSync } from "node:child_process";
+import { appendFileSync, existsSync, readdirSync, readFileSync, rmSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { performance } from "node:perf_hooks";
+import { pathToFileURL } from "node:url";
+import { createHash } from "node:crypto";
+
+const DEFAULT_THRESHOLD_PERCENT = 2;
+const DEFAULT_RUNS = 5;
+const DEFAULT_WARMUPS = 1;
+
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (!arg.startsWith("--")) {
+      continue;
+    }
+    const key = arg.slice(2);
+    const next = argv[i + 1];
+    if (next == null || next.startsWith("--")) {
+      args[key] = "true";
+    } else {
+      args[key] = next;
+      i++;
+    }
+  }
+  return args;
+}
+
+function requireArg(args, key) {
+  const value = args[key];
+  if (!value) {
+    throw new Error(`Missing required argument: --${key}`);
+  }
+  return value;
+}
+
+function parsePositiveInt(value, fallback) {
+  const parsed = Number.parseInt(value ?? "", 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function parseNonNegativeInt(value, fallback) {
+  const parsed = Number.parseInt(value ?? "", 10);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback;
+}
+
+function parsePositiveFloat(value, fallback) {
+  const parsed = Number.parseFloat(value ?? "");
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function median(values) {
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  if (sorted.length % 2 === 1) {
+    return sorted[mid];
+  }
+  return (sorted[mid - 1] + sorted[mid]) / 2;
+}
+
+/**
+ * Hash every emitted file under a build output directory so two builds can be
+ * compared independent of filesystem walk order. Returns a map of relative
+ * path -> sha256, and a combined digest over the sorted entries.
+ */
+export function hashOutputDir(dir) {
+  const files = {};
+  const walk = (current, prefix) => {
+    for (const entry of readdirSync(current, { withFileTypes: true }).sort((a, b) =>
+      a.name.localeCompare(b.name),
+    )) {
+      const full = join(current, entry.name);
+      const rel = prefix ? `${prefix}/${entry.name}` : entry.name;
+      if (entry.isDirectory()) {
+        walk(full, rel);
+      } else if (entry.isFile()) {
+        files[rel] = createHash("sha256").update(readFileSync(full)).digest("hex");
+      }
+    }
+  };
+  if (existsSync(dir)) {
+    walk(dir, "");
+  }
+  const combined = createHash("sha256");
+  for (const rel of Object.keys(files).sort()) {
+    combined.update(rel).update("\0").update(files[rel]).update("\0");
+  }
+  return { files, digest: combined.digest("hex") };
+}
+
+/**
+ * Diff two output-directory hash maps. Returns the list of paths that are
+ * missing on one side or whose contents differ.
+ */
+export function diffOutputs(off, on) {
+  const differences = [];
+  const names = new Set([...Object.keys(off.files), ...Object.keys(on.files)]);
+  for (const name of [...names].sort()) {
+    const offHash = off.files[name];
+    const onHash = on.files[name];
+    if (offHash == null) {
+      differences.push(`${name}: only emitted with legacy ON`);
+    } else if (onHash == null) {
+      differences.push(`${name}: only emitted with legacy OFF`);
+    } else if (offHash !== onHash) {
+      differences.push(`${name}: byte content differs between legacy OFF and ON`);
+    }
+  }
+  return differences;
+}
+
+function run(command, commandArgs, options = {}) {
+  const result = spawnSync(command, commandArgs, {
+    cwd: options.cwd,
+    env: { ...process.env, ...(options.env ?? {}) },
+    encoding: "utf8",
+    stdio: options.capture ? "pipe" : "inherit",
+    maxBuffer: 64 * 1024 * 1024,
+  });
+  if (result.error) {
+    throw result.error;
+  }
+  if (result.status !== 0 && !options.allowFailure) {
+    throw new Error(`${command} ${commandArgs.join(" ")} exited with ${result.status}`);
+  }
+  return result;
+}
+
+function buildArgs(inputDir, outDir) {
+  // Deterministic, single-threaded JS emit so the OFF/ON outputs are comparable
+  // and the timing lane is stable on shared runners.
+  return [
+    "build",
+    inputDir,
+    "--output",
+    outDir,
+    "--format",
+    "js",
+    "--threads",
+    "1",
+    "--continue-on-error",
+  ];
+}
+
+function compileCorpus(bin, inputDir, outDir) {
+  rmSync(outDir, { recursive: true, force: true });
+  run(bin, buildArgs(inputDir, outDir), {
+    env: { NO_COLOR: "1", RAYON_NUM_THREADS: "1", VIZE_BENCH: "1" },
+  });
+}
+
+function timeCorpus(bin, inputDir, outDir, { runs, warmups }) {
+  const samples = [];
+  for (let i = 0; i < warmups; i++) {
+    compileCorpus(bin, inputDir, outDir);
+  }
+  for (let i = 0; i < runs; i++) {
+    const start = performance.now();
+    compileCorpus(bin, inputDir, outDir);
+    samples.push(performance.now() - start);
+  }
+  return samples;
+}
+
+export function main(argv = process.argv.slice(2)) {
+  const args = parseArgs(argv);
+  const inputDir = resolve(requireArg(args, "input"));
+  const offBin = resolve(requireArg(args, "off-bin"));
+  const onBin = resolve(requireArg(args, "on-bin"));
+  const outRoot = resolve(args["out-dir"] ?? "dialect-guard-out");
+  const threshold = parsePositiveFloat(args.threshold, DEFAULT_THRESHOLD_PERCENT);
+  const runs = parsePositiveInt(args.runs, DEFAULT_RUNS);
+  const warmups = parseNonNegativeInt(args.warmups, DEFAULT_WARMUPS);
+
+  if (!existsSync(inputDir)) {
+    throw new Error(`Input directory not found: ${inputDir}`);
+  }
+  if (!existsSync(offBin)) {
+    throw new Error(`legacy-OFF binary not found: ${offBin}`);
+  }
+  if (!existsSync(onBin)) {
+    throw new Error(`legacy-ON binary not found: ${onBin}`);
+  }
+
+  const offOut = join(outRoot, "off");
+  const onOut = join(outRoot, "on");
+
+  // --- 1. Codegen identity -------------------------------------------------
+  compileCorpus(offBin, inputDir, offOut);
+  compileCorpus(onBin, inputDir, onOut);
+  const offHash = hashOutputDir(offOut);
+  const onHash = hashOutputDir(onOut);
+  const differences = diffOutputs(offHash, onHash);
+  const identical = differences.length === 0;
+
+  // --- 2. A/B timing -------------------------------------------------------
+  const offSamples = timeCorpus(offBin, inputDir, offOut, { runs, warmups });
+  const onSamples = timeCorpus(onBin, inputDir, onOut, { runs, warmups });
+  const offMs = median(offSamples);
+  const onMs = median(onSamples);
+  const ratio = offMs === 0 ? Number.NaN : onMs / offMs;
+  const changePercent = Number.isFinite(ratio) ? (ratio - 1) * 100 : Number.NaN;
+  const regressed = Number.isFinite(changePercent) && changePercent >= threshold;
+
+  const lines = [];
+  lines.push("## Dialect Guard (legacy feature)");
+  lines.push("");
+  lines.push(
+    `Vue 3 corpus compiled with the \`legacy\` feature OFF vs ON. Codegen must stay byte-identical and the default path must not regress past ${threshold}%.`,
+  );
+  lines.push("");
+  lines.push("| Check | Result |");
+  lines.push("| --- | --- |");
+  const identityCell = identical ? "identical" : `${differences.length} diff(s)`;
+  const offDigest = offHash.digest.slice(0, 12);
+  lines.push(`| Codegen identity (OFF digest \`${offDigest}\`) | ${identityCell} |`);
+  const deltaCell = Number.isFinite(changePercent)
+    ? `${changePercent >= 0 ? "+" : ""}${changePercent.toFixed(2)}%`
+    : "n/a";
+  const timingLabel = `A/B timing (OFF ${offMs.toFixed(1)}ms to ON ${onMs.toFixed(1)}ms)`;
+  lines.push(`| ${timingLabel} | ${deltaCell} ${regressed ? "regression" : "ok"} |`);
+  if (!identical) {
+    lines.push("");
+    lines.push("Codegen divergences:");
+    for (const difference of differences.slice(0, 20)) {
+      lines.push(`- ${difference}`);
+    }
+  }
+  lines.push("");
+  const summary = `${lines.join("\n")}\n`;
+
+  if (process.env.GITHUB_STEP_SUMMARY) {
+    appendFileSync(process.env.GITHUB_STEP_SUMMARY, summary);
+  } else {
+    process.stdout.write(summary);
+  }
+
+  if (!identical) {
+    console.error(
+      `Dialect guard failed: legacy ON changed Vue 3 codegen in ${differences.length} file(s).`,
+    );
+    process.exitCode = 1;
+  } else if (regressed) {
+    console.error(
+      `Dialect guard failed: legacy ON regressed the Vue 3 compile path by ${changePercent.toFixed(2)}% (threshold ${threshold}%).`,
+    );
+    process.exitCode = 1;
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    main();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+}

--- a/tests/tooling/github-workflows.test.ts
+++ b/tests/tooling/github-workflows.test.ts
@@ -329,6 +329,7 @@ test("Linux Rust CI installs Wild linker before cargo builds", () => {
   for (const workflowName of [
     "benchmark.yml",
     "check.yml",
+    "criterion-bench.yml",
     "deploy-docs.yml",
     "e2e.yml",
     "native-smoke.yml",
@@ -356,6 +357,7 @@ test("Blacksmith Rust CI uses sticky disks for Cargo and target caches", () => {
 
   for (const workflowName of [
     "check.yml",
+    "criterion-bench.yml",
     "deploy-docs.yml",
     "e2e.yml",
     "fuzz.yml",
@@ -610,9 +612,11 @@ test("tool benchmark workflow produces docs artifacts, PR comments, and conventi
     /node bench\/comment-pr\.mjs --body tool-benchmark-summary\.md --comment-key "\$BENCHMARK_COMMENT_KEY"/,
   );
 
+  // The snapshot commit job fires on a manual dispatch with commit_results set
+  // OR on the weekly scheduled ratchet, but never for tags (refs/heads guard).
   assert.match(
     commitJob,
-    /if:\s*\$\{\{\s*github\.event_name == 'workflow_dispatch' && inputs\.commit_results && startsWith\(github\.ref, 'refs\/heads\/'\)\s*\}\}/,
+    /if:\s*\$\{\{\s*\(\(github\.event_name == 'workflow_dispatch' && inputs\.commit_results\) \|\| github\.event_name == 'schedule'\) && startsWith\(github\.ref, 'refs\/heads\/'\)\s*\}\}/,
   );
   assert.match(commitJob, /contents:\s*write/);
   assert.match(commitJob, /docs\/content\/architecture\/performance-blacksmith\.md/);
@@ -620,6 +624,71 @@ test("tool benchmark workflow produces docs artifacts, PR comments, and conventi
   assert.match(commitJob, /git commit -m "docs: update blacksmith benchmark snapshot"/);
   assert.match(commitJob, /git push origin HEAD:\$\{\{\s*github\.ref_name\s*\}\}/);
   assert.doesNotMatch(commitJob, /codex/i);
+});
+
+test("tool benchmark workflow ratchets the committed snapshot on a scheduled cadence", () => {
+  const workflow = readRepoFile(".github", "workflows", "tool-benchmark.yml");
+
+  // A weekly cron refreshes bench/results/tool-benchmark-latest.json on main so
+  // sub-threshold drift cannot accumulate between manual dispatches. A full run
+  // on every push is too heavy (the job is capped at 75 minutes).
+  assert.match(workflow, /\n  schedule:\n/);
+  assert.match(workflow, /- cron:\s*"41 5 \* \* 1"/);
+});
+
+test("criterion bench workflow runs an A/B micro-benchmark and a dialect guard", () => {
+  const workflow = readRepoFile(".github", "workflows", "criterion-bench.yml");
+  const abJob = workflowJobBody(workflow, "criterion-ab");
+  const guardJob = workflowJobBody(workflow, "dialect-guard");
+
+  // Only runs on PRs and only when Rust or the bench harness changes.
+  assert.match(workflow, /\n  pull_request:\n/);
+  assert.match(workflow, /paths:\n\s+- "crates\/\*\*"/);
+  assert.match(workflow, /- "bench\/criterion-ab\.mjs"/);
+  assert.match(workflow, /- "bench\/dialect-guard\.mjs"/);
+  assert.match(workflow, /FORCE_JAVASCRIPT_ACTIONS_TO_NODE24:\s*true/);
+
+  for (const [jobName, minutes] of [
+    ["criterion-ab", 45],
+    ["dialect-guard", 45],
+  ] as const) {
+    assert.match(
+      workflowJobBody(workflow, jobName),
+      new RegExp(`timeout-minutes:\\s*${minutes}\\b`),
+    );
+  }
+
+  // A/B: alternating base/head criterion baselines compared with critcmp into a
+  // shared target dir; report-only by default (no threshold blocks the PR).
+  assert.match(abJob, /runs-on:\s*blacksmith-32vcpu-ubuntu-2404/);
+  assert.match(abJob, /contents:\s*read/);
+  assert.doesNotMatch(abJob, /contents:\s*write/);
+  assert.match(
+    abJob,
+    /path:\s*head[\s\S]*ref:\s*\$\{\{\s*github\.event\.pull_request\.head\.sha\s*\}\}/,
+  );
+  assert.match(
+    abJob,
+    /path:\s*base[\s\S]*ref:\s*\$\{\{\s*github\.event\.pull_request\.base\.sha\s*\}\}/,
+  );
+  assert.match(abJob, /uses:\s*\.\/head\/\.github\/actions\/setup-rust-sticky-cache/);
+  assert.match(abJob, /cargo install critcmp --version 0\.1\.8 --locked/);
+  assert.match(abJob, /node head\/bench\/criterion-ab\.mjs/);
+  assert.match(abJob, /--target-dir "\$GITHUB_WORKSPACE\/head\/target"/);
+
+  // Dialect guard: build vize with legacy OFF and ON, then assert byte-identical
+  // Vue 3 codegen plus a small A/B timing budget.
+  assert.match(guardJob, /runs-on:\s*blacksmith-32vcpu-ubuntu-2404/);
+  assert.match(guardJob, /cargo build --profile ci-opt -p vize --target-dir target\/off/);
+  assert.match(
+    guardJob,
+    /cargo build --profile ci-opt -p vize --features legacy --target-dir target\/on/,
+  );
+  assert.match(guardJob, /node bench\/generate\.mjs "\$DIALECT_GUARD_FILE_COUNT"/);
+  assert.match(guardJob, /node bench\/dialect-guard\.mjs/);
+  assert.match(guardJob, /--off-bin target\/off\/ci-opt\/vize/);
+  assert.match(guardJob, /--on-bin target\/on\/ci-opt\/vize/);
+  assert.match(guardJob, /--threshold "\$DIALECT_GUARD_THRESHOLD_PERCENT"/);
 });
 
 test("check workflow comments a detailed PR test report for each head push", () => {


### PR DESCRIPTION
Part of #1386. Implements the remaining zero-cost CI bench-gate items: the main-snapshot ratchet (PR7), the criterion A/B gate (PR5), and the dialect-guard harness (PR6, honestly partial — see Deferred).

## What's implemented

**PR7 — main-snapshot ratchet (`.github/workflows/tool-benchmark.yml`)**
- Added a weekly `schedule:` cron (`41 5 * * 1`) that refreshes the committed baseline `bench/results/tool-benchmark-latest.json` (and the docs snapshot) on `main`.
- Extended the existing `tool-benchmark-commit` job's `if:` so it fires on the scheduled run as well as the manual `workflow_dispatch` + `commit_results` path, still guarded by `startsWith(github.ref, 'refs/heads/')` so tags never commit.
- Cadence rationale: a full tool benchmark is capped at 75 min, so running it on every push to main is too heavy; a weekly scheduled refresh stops sub-threshold drift from accumulating silently between manual dispatches (the snapshot's only prior refresh path).

**PR5 — criterion A/B gate (`.github/workflows/criterion-bench.yml` + `bench/criterion-ab.mjs`)**
- New PR workflow (path-filtered to `crates/**` and the bench harness) that checks out base + head, runs `cargo bench --save-baseline base|head` for the hot in-crate criterion suites (`vize_atelier_sfc` parse+compile, `vize_atelier_jsx` compile, `vize_croquis_cf` cross-file, `vize_glyph` formatter, `vize_patina` lint) into a shared `--target-dir`, then diffs them with `critcmp` and writes the table to the step summary.
- Same alternating-side philosophy as `bench/compare-pr.mjs`; report-only by default (empty `CRITERION_AB_THRESHOLD`) because criterion is noisy on shared runners, with a `--threshold` knob already wired so the gate can be tightened to blocking later without a code change.

**PR6 — dialect-guard harness (`dialect-guard` job + `bench/dialect-guard.mjs`)**
- Builds `-p vize` twice (legacy feature OFF and ON) into separate target dirs, compiles the generated Vue 3 corpus with each, and asserts the emitted output is **byte-identical** (sha256 per-file + combined digest). Any divergence means legacy code leaked into the default Vue 3 path and fails the job.
- Also runs an A/B timing comparison of the OFF vs ON binary on the corpus and fails past a 2% regression threshold (the default path must not slow down when the flag exists but is off).

## Verify-real
- `bench/criterion-ab.mjs` pure logic unit-checked locally: `cargoBenchArgs` vector, `CRITERION_SUITES` coverage, `parseCritcmpRegressions` (correctly flags a +10% head row, ignores faster rows, no-ops with no threshold), `renderSummary`.
- `bench/dialect-guard.mjs` `hashOutputDir`/`diffOutputs` unit-checked against real temp dirs: identical trees → identical digest + empty diff; a mutated file + an extra file → reported as `byte content differs` / `only emitted with legacy ON` and a changed digest.
- `cargo bench -p vize_croquis_cf --bench cross_file --no-run` compiles the criterion target and accepts the invocation (PR5 mechanic).
- `cargo check -p vize --features legacy` compiles cleanly across the stack (PR6 mechanic — both OFF/ON binaries are buildable).
- Both workflow YAMLs parse; `criterion-bench.yml` exposes `criterion-ab` + `dialect-guard`, `tool-benchmark.yml` now carries `workflow_dispatch` + `pull_request` + `schedule` triggers.

## Deferred (honest)
- **PR6 is a ready-but-currently-trivial gate.** The `legacy` cargo feature is still largely a stub, and its surface is dialect-gated, so on a Vue 3 corpus the OFF and ON binaries emit identical codegen today — the byte-identical assertion passes trivially and the A/B delta is ~0. The harness and job are wired now so the gate starts catching divergence (and a >2% slowdown) the moment `legacy` grows real, dialect-gated code; no second PR is needed to "turn it on".
- **Criterion A/B is report-only**, not blocking, by design (micro-benchmark jitter on shared runners). Promoting it to a hard gate is a one-line `CRITERION_AB_THRESHOLD` change once a stable noise floor is established.
- The A/B job assumes the base checkout owns the same `[[bench]]` targets as head; a PR that adds a brand-new bench would have no base baseline for it. Acceptable for an initial report-only gate (mirrors `benchmark.yml`'s "base must build" assumption).
- Because PR6 is intentionally partial, this is "Part of #1386", not "Closes".

## Gates
- `node --test tests/tooling/github-workflows.test.ts tests/tooling/benchmark-budget.test.ts tests/tooling/benchmark-generator.test.ts tests/tooling/tool-benchmark.test.ts` → **61 pass / 0 fail** (added 2 new workflow-shape tests; updated the `tool-benchmark-commit` `if:` assertion in lockstep with the schedule change).
- `tests/tooling/repo-governance.test.ts` + `language-engineering-practices.test.ts` → pass.
- Pre-existing unrelated failure: `tests/tooling/production-readiness.test.ts` fails identically on clean `origin/main` in this worktree (it shells out to a built `vize` binary that isn't present); not touched by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1543"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->