### PR TITLE
fix(canon): extract prop interface fields via AST, drop the text scanner (#1394)

### DIFF
--- a/crates/vize_canon/src/batch/virtual_project/vue_codegen.rs
+++ b/crates/vize_canon/src/batch/virtual_project/vue_codegen.rs
@@ -24,7 +24,7 @@ use crate::batch::error::CorsaResult;
 use crate::batch::{Diagnostic, SfcBlockType};
 use crate::script_parse::collect_script_parse_diagnostics;
 use crate::virtual_ts::{
-    VirtualTsCheckOptions, VirtualTsGenerationOptions, VirtualTsOptions, extract_interface_fields,
+    VirtualTsCheckOptions, VirtualTsGenerationOptions, VirtualTsOptions,
     generate_virtual_ts_with_offsets_and_checks,
 };
 
@@ -262,7 +262,7 @@ fn augment_type_based_props_from_script_context(
     );
     ctx.analyze();
 
-    let known_props = known_type_based_prop_names(croquis, &script_setup.content);
+    let known_props = known_type_based_prop_names(croquis);
     let mut missing_props: Vec<CompactString> = ctx
         .bindings
         .bindings
@@ -296,10 +296,7 @@ fn augment_type_based_props_from_script_context(
     }
 }
 
-fn known_type_based_prop_names(
-    croquis: &vize_croquis::Croquis,
-    script_setup: &str,
-) -> FxHashSet<CompactString> {
+fn known_type_based_prop_names(croquis: &vize_croquis::Croquis) -> FxHashSet<CompactString> {
     let mut names: FxHashSet<CompactString> = croquis
         .macros
         .props()
@@ -315,12 +312,15 @@ fn known_type_based_prop_names(
         return names;
     };
 
+    // Resolve the named type's fields through the croquis TypeResolver, which
+    // script analysis populates from the OXC AST — including local interfaces
+    // and type literals. This replaces the old raw-text interface scanner.
     let type_name = strip_outer_angle_brackets(type_args.trim());
-    for prop in croquis.types.extract_properties(type_name) {
+    for prop in croquis
+        .types
+        .extract_properties(type_reference_lookup_key(type_name))
+    {
         names.insert(prop.name);
-    }
-    for field in extract_interface_fields(script_setup, type_name) {
-        names.insert(CompactString::new(field));
     }
 
     names
@@ -331,4 +331,19 @@ fn strip_outer_angle_brackets(value: &str) -> &str {
         .strip_prefix('<')
         .and_then(|value| value.strip_suffix('>'))
         .unwrap_or(value)
+}
+
+/// Lookup key for a `defineProps<...>` type argument: inline object literals
+/// (`{ ... }`) are passed through, while a type *reference* drops any generic
+/// instantiation (`Foo<T>` -> `Foo`) so the resolver can find the local
+/// declaration registered under its bare name.
+fn type_reference_lookup_key(type_name: &str) -> &str {
+    let trimmed = type_name.trim();
+    if trimmed.starts_with('{') {
+        return type_name;
+    }
+    match trimmed.find('<') {
+        Some(pos) => trimmed[..pos].trim_end(),
+        None => trimmed,
+    }
 }

--- a/crates/vize_canon/src/virtual_ts.rs
+++ b/crates/vize_canon/src/virtual_ts.rs
@@ -24,7 +24,6 @@ pub use generator::{
     generate_virtual_ts_with_offsets_legacy_vue2, generate_virtual_ts_with_offsets_options_api,
 };
 pub use helpers::{DECLARATION_HELPERS_DTS, SHARED_PREAMBLE_DTS, SHARED_PREAMBLE_FILE_NAME};
-pub(crate) use props::extract_interface_fields;
 pub use types::{TemplateGlobal, VirtualTsOptions, VirtualTsOutput, VizeMapping};
 #[cfg(any(test, feature = "native"))]
 pub(crate) use types::{VirtualTsCheckOptions, VirtualTsGenerationOptions};

--- a/crates/vize_canon/src/virtual_ts/generator/mod.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/mod.rs
@@ -798,7 +798,7 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
             // Props are available in template as variables
             profile!(
                 "canon.virtual_ts.generate_props_variables",
-                generate_props_variables(&mut ts, summary, script_content, generic_param)
+                generate_props_variables(&mut ts, summary, generic_param)
             );
             if options_api {
                 profile!(
@@ -808,7 +808,7 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
             }
             let template_prop_names = profile!(
                 "canon.virtual_ts.collect_template_prop_names",
-                collect_template_prop_names(summary, script_content)
+                collect_template_prop_names(summary)
             );
 
             // Generate scope closures

--- a/crates/vize_canon/src/virtual_ts/props.rs
+++ b/crates/vize_canon/src/virtual_ts/props.rs
@@ -11,7 +11,6 @@ use vize_carton::FxHashSet;
 use vize_carton::String;
 use vize_carton::append;
 use vize_carton::cstr;
-use vize_carton::profile;
 use vize_croquis::BindingType;
 use vize_croquis::Croquis;
 use vize_croquis::macros::{MacroKind, ModelDefinition};
@@ -404,7 +403,6 @@ fn emit_options_api_props_type(
 pub(crate) fn generate_props_variables(
     ts: &mut String,
     summary: &Croquis,
-    script_content: Option<&str>,
     generic_param: Option<&str>,
 ) {
     let props = summary.macros.props();
@@ -461,39 +459,25 @@ pub(crate) fn generate_props_variables(
             // type_args may include angle brackets (e.g., "<Props>", "<Foo<T>>"), strip outer pair
             let type_name = strip_outer_angle_brackets(type_args.trim());
 
-            // Try TypeResolver first (handles inline object types and registered types)
-            let type_properties = summary.types.extract_properties(type_name);
-            if !type_properties.is_empty() {
-                for prop in &type_properties {
-                    if should_skip_template_prop_binding(summary, prop.name.as_str()) {
-                        continue;
-                    }
-                    emit_template_prop_binding(
-                        ts,
-                        template_props_type_ref.as_str(),
-                        prop.name.as_str(),
-                        defaulted_prop_names.contains(&prop.name),
-                    );
-                    emitted_names.insert(prop.name.as_str().into());
+            // Resolve the named type's fields through the croquis TypeResolver,
+            // which the script analysis populates from the OXC AST (local
+            // interfaces/type literals included). This handles inline object
+            // types, registered local types, nested braces, generics, and
+            // comments — no raw-text scanning.
+            let type_properties = summary
+                .types
+                .extract_properties(type_reference_lookup_key(type_name));
+            for prop in &type_properties {
+                if should_skip_template_prop_binding(summary, prop.name.as_str()) {
+                    continue;
                 }
-            } else if let Some(script) = script_content {
-                // Fallback: extract field names from script text (for local interfaces)
-                let field_names = profile!(
-                    "canon.virtual_ts.extract_interface_fields",
-                    extract_interface_fields(script, type_name)
+                emit_template_prop_binding(
+                    ts,
+                    template_props_type_ref.as_str(),
+                    prop.name.as_str(),
+                    defaulted_prop_names.contains(&prop.name),
                 );
-                for field in &field_names {
-                    if should_skip_template_prop_binding(summary, field.as_str()) {
-                        continue;
-                    }
-                    emit_template_prop_binding(
-                        ts,
-                        template_props_type_ref.as_str(),
-                        field.as_str(),
-                        defaulted_prop_names.contains(field),
-                    );
-                    emitted_names.insert(field.as_str().into());
-                }
+                emitted_names.insert(prop.name.as_str().into());
             }
 
             if should_emit_keyed_template_prop_bindings(summary, type_name, &emitted_names) {
@@ -525,10 +509,7 @@ pub(crate) fn generate_props_variables(
     }
 }
 
-pub(crate) fn collect_template_prop_names(
-    summary: &Croquis,
-    script_content: Option<&str>,
-) -> FxHashSet<String> {
+pub(crate) fn collect_template_prop_names(summary: &Croquis) -> FxHashSet<String> {
     let mut names = FxHashSet::default();
     let props = summary.macros.props();
     if !props.is_empty() {
@@ -562,196 +543,33 @@ pub(crate) fn collect_template_prop_names(
         return names;
     };
     let type_name = strip_outer_angle_brackets(type_args.trim());
-    let type_properties = summary.types.extract_properties(type_name);
-    if !type_properties.is_empty() {
-        for prop in &type_properties {
-            if should_skip_template_prop_binding(summary, prop.name.as_str()) {
-                continue;
-            }
-            if !is_reserved_identifier(prop.name.as_str()) {
-                continue;
-            }
-            names.insert(prop.name.as_str().into());
-        }
-        return names;
-    }
-
-    let Some(script) = script_content else {
-        return names;
-    };
-    let field_names = profile!(
-        "canon.virtual_ts.extract_interface_fields_for_expressions",
-        extract_interface_fields(script, type_name)
-    );
-    for field in &field_names {
-        if should_skip_template_prop_binding(summary, field.as_str()) {
+    let type_properties = summary
+        .types
+        .extract_properties(type_reference_lookup_key(type_name));
+    for prop in &type_properties {
+        if should_skip_template_prop_binding(summary, prop.name.as_str()) {
             continue;
         }
-        if !is_reserved_identifier(field.as_str()) {
+        if !is_reserved_identifier(prop.name.as_str()) {
             continue;
         }
-        names.insert(field.clone());
+        names.insert(prop.name.as_str().into());
     }
     names
 }
 
-/// Extract field names from an interface or type literal in script content.
-/// Fallback for when TypeResolver doesn't have the type registered.
-pub(crate) fn extract_interface_fields(script: &str, type_name: &str) -> Vec<String> {
-    let mut fields = Vec::new();
-
-    let body = if type_name.starts_with('{') {
-        Some(type_name)
+/// Lookup key for a `defineProps<...>` type argument when resolving its fields
+/// through the croquis `TypeResolver`.
+///
+/// Inline object types (`{ msg: string }`) are passed through verbatim — the
+/// resolver parses them directly. A type *reference* may carry a generic
+/// instantiation (`Foo<T>`); the resolver registers local types under their
+/// bare declaration name, so strip the arguments to recover `Foo`.
+fn type_reference_lookup_key(type_name: &str) -> &str {
+    if type_name.trim_start().starts_with('{') {
+        type_name
     } else {
-        find_type_body(script, type_name)
-    };
-
-    if let Some(body) = body {
-        let inner = if let Some(start) = body.find('{') {
-            let end = find_matching_brace(body, start);
-            &body[start + 1..end]
-        } else {
-            body
-        };
-
-        fields.extend(extract_top_level_type_fields(inner));
-    }
-
-    fields
-}
-
-fn extract_top_level_type_fields(inner: &str) -> Vec<String> {
-    let mut fields = Vec::new();
-    let mut member_start = 0usize;
-    let mut collecting_name = true;
-    let mut brace_depth = 0u32;
-    let mut bracket_depth = 0u32;
-    let mut paren_depth = 0u32;
-    let mut angle_depth = 0u32;
-    let mut quote = None;
-    let mut escaped = false;
-    let mut line_comment = false;
-    let mut block_comment = false;
-    let mut chars = inner.char_indices().peekable();
-
-    while let Some((idx, ch)) = chars.next() {
-        if line_comment {
-            if ch == '\n' {
-                line_comment = false;
-                if brace_depth == 0 && bracket_depth == 0 && paren_depth == 0 && angle_depth == 0 {
-                    collecting_name = true;
-                    member_start = idx + ch.len_utf8();
-                }
-            }
-            continue;
-        }
-
-        if block_comment {
-            if ch == '*'
-                && let Some(&(slash_idx, '/')) = chars.peek()
-            {
-                chars.next();
-                block_comment = false;
-                if collecting_name
-                    && brace_depth == 0
-                    && bracket_depth == 0
-                    && paren_depth == 0
-                    && angle_depth == 0
-                    && inner[member_start..idx].trim().is_empty()
-                {
-                    member_start = slash_idx + 1;
-                }
-            }
-            continue;
-        }
-
-        if let Some(quote_ch) = quote {
-            if escaped {
-                escaped = false;
-            } else if ch == '\\' {
-                escaped = true;
-            } else if ch == quote_ch {
-                quote = None;
-            }
-            continue;
-        }
-
-        if ch == '/'
-            && let Some(&(_, next)) = chars.peek()
-        {
-            match next {
-                '/' => {
-                    chars.next();
-                    line_comment = true;
-                    continue;
-                }
-                '*' => {
-                    chars.next();
-                    block_comment = true;
-                    continue;
-                }
-                _ => {}
-            }
-        }
-
-        match ch {
-            '\'' | '"' | '`' => {
-                quote = Some(ch);
-                escaped = false;
-                continue;
-            }
-            '{' => brace_depth += 1,
-            '}' => brace_depth = brace_depth.saturating_sub(1),
-            '[' => bracket_depth += 1,
-            ']' => bracket_depth = bracket_depth.saturating_sub(1),
-            '(' => paren_depth += 1,
-            ')' => paren_depth = paren_depth.saturating_sub(1),
-            '<' => angle_depth += 1,
-            '>' if angle_depth > 0 => angle_depth -= 1,
-            _ => {}
-        }
-
-        if brace_depth != 0 || bracket_depth != 0 || paren_depth != 0 || angle_depth != 0 {
-            continue;
-        }
-
-        match ch {
-            ':' if collecting_name => {
-                if let Some(field_name) = parse_top_level_field_name(&inner[member_start..idx]) {
-                    fields.push(field_name);
-                }
-                collecting_name = false;
-            }
-            ';' | ',' => {
-                collecting_name = true;
-                member_start = idx + ch.len_utf8();
-            }
-            '\n' if !collecting_name => {
-                collecting_name = true;
-                member_start = idx + ch.len_utf8();
-            }
-            '\n' if inner[member_start..idx].trim().is_empty() => {
-                member_start = idx + ch.len_utf8();
-            }
-            _ => {}
-        }
-    }
-
-    fields
-}
-
-fn parse_top_level_field_name(candidate: &str) -> Option<String> {
-    let candidate = candidate.trim();
-    let candidate = candidate.strip_prefix("readonly ").unwrap_or(candidate);
-    let field_name = candidate.trim().trim_end_matches('?').trim();
-    if !field_name.is_empty()
-        && field_name
-            .chars()
-            .all(|c| c.is_alphanumeric() || c == '_' || c == '$')
-    {
-        Some(field_name.into())
-    } else {
-        None
+        strip_generic_params(type_name).trim()
     }
 }
 
@@ -787,46 +605,6 @@ fn strip_generic_params(type_name: &str) -> &str {
         Some(pos) => &type_name[..pos],
         None => type_name,
     }
-}
-
-/// Find the body of an interface or type declaration in script content.
-fn find_type_body<'a>(script: &'a str, type_name: &str) -> Option<&'a str> {
-    // Strip generic params from name for searching (e.g., "Foo<T>" → "Foo")
-    let base_name = strip_generic_params(type_name);
-    for pattern in &[
-        cstr!("interface {base_name} "),
-        cstr!("interface {base_name}{{"),
-        cstr!("interface {base_name}<"),
-        cstr!("type {base_name} "),
-        cstr!("type {base_name}<"),
-    ] {
-        if let Some(pos) = script.find(pattern.as_str()) {
-            let rest = &script[pos..];
-            if let Some(brace_start) = rest.find('{') {
-                let end = find_matching_brace(rest, brace_start);
-                return Some(&rest[..end + 1]);
-            }
-        }
-    }
-    None
-}
-
-/// Find the matching closing brace for an opening brace at `start`.
-fn find_matching_brace(s: &str, start: usize) -> usize {
-    let mut depth = 0;
-    for (i, c) in s[start..].char_indices() {
-        match c {
-            '{' => depth += 1,
-            '}' => {
-                depth -= 1;
-                if depth == 0 {
-                    return start + i;
-                }
-            }
-            _ => {}
-        }
-    }
-    s.len().saturating_sub(1)
 }
 
 /// First identifier of a generic parameter declaration, skipping the TS 5.0
@@ -994,8 +772,8 @@ fn append_param_with_default(result: &mut String, param: &str) {
 mod tests {
     use super::{
         add_generic_defaults, collect_with_defaults_default_names_from_source,
-        extract_generic_names, extract_interface_fields, strip_const_modifiers,
-        template_props_type_ref,
+        extract_generic_names, strip_const_modifiers, template_props_type_ref,
+        type_reference_lookup_key,
     };
     use vize_carton::{FxHashSet, String};
 
@@ -1083,24 +861,24 @@ mod tests {
     }
 
     #[test]
-    fn extracts_only_top_level_interface_fields() {
-        let script = r#"
-interface Props {
-  config: {
-    inner: string
-    nested: { value: number }
-  }
-  readonly name?: string
-  handler: (event: { inner: string }) => void
-  items: Array<{ id: string }>
-  method(): void
-  [key: string]: unknown
-}
-"#;
-
+    fn type_reference_lookup_key_strips_generics_but_preserves_inline_literals() {
+        // Type references drop their generic instantiation so the resolver can
+        // find the local declaration registered under its bare name.
+        assert_eq!(type_reference_lookup_key("Props"), "Props");
+        assert_eq!(type_reference_lookup_key("Foo<T>"), "Foo");
         assert_eq!(
-            extract_interface_fields(script, "Props"),
-            vec!["config", "name", "handler", "items"]
+            type_reference_lookup_key("ContextMenuContentProps<T, U>"),
+            "ContextMenuContentProps"
+        );
+        // Inline object literals are passed through verbatim — the `<` inside a
+        // property type must not be mistaken for a generic argument list.
+        assert_eq!(
+            type_reference_lookup_key("{ items: Array<{ id: string }> }"),
+            "{ items: Array<{ id: string }> }"
+        );
+        assert_eq!(
+            type_reference_lookup_key("  { msg: string }"),
+            "  { msg: string }"
         );
     }
 }

--- a/crates/vize_canon/src/virtual_ts/tests.rs
+++ b/crates/vize_canon/src/virtual_ts/tests.rs
@@ -565,6 +565,105 @@ fn generate_script_setup_virtual_ts(script: &str) -> String {
 }
 
 #[test]
+fn test_define_props_local_interface_fields_resolved_via_ast() {
+    // Verify-real for #1394: a local `interface Props` whose body the old
+    // raw-text scanner mis-handled is now resolved through the OXC AST that
+    // croquis registers into the TypeResolver. The script exercises three
+    // failure modes of the deleted scanner at once:
+    //   1. A leading comment that literally contains `interface Props { ... }`.
+    //      The old `find_type_body` anchored on the *first* substring match of
+    //      `interface Props `, so it would extract the decoy field from the
+    //      comment instead of the real declaration.
+    //   2. A field whose type is a generic with a comma (`Map<string, number>`).
+    //   3. A nested object type and a trailing line comment containing a `}`.
+    use vize_croquis::{Analyzer, AnalyzerOptions};
+
+    let script = r#"
+// A real interface Props { decoy: never } lives further down.
+interface Props {
+  title: string;
+  meta: {
+    createdAt: number;
+    tags: string[];
+  };
+  lookup: Map<string, number>;
+  count?: number; // counts things } and quotes "}"
+}
+
+defineProps<Props>();
+"#;
+    let template = r#"<div>{{ title }}{{ meta }}{{ lookup }}{{ count }}</div>"#;
+
+    let allocator = vize_carton::Bump::new();
+    let (root, _) = vize_armature::parse(&allocator, template);
+
+    let mut analyzer = Analyzer::with_options(AnalyzerOptions::full());
+    analyzer.analyze_script_setup(script);
+    analyzer.analyze_template(&root);
+    let summary = analyzer.finish();
+
+    // The interface was registered into the TypeResolver from the OXC AST, so
+    // its top-level fields resolve directly — no raw-text scan.
+    let props = summary.types.extract_properties("Props");
+    let names: Vec<&str> = props.iter().map(|p| p.name.as_str()).collect();
+    assert_eq!(
+        names,
+        vec!["title", "meta", "lookup", "count"],
+        "AST-backed TypeResolver must yield exactly the top-level interface fields"
+    );
+
+    let output = generate_virtual_ts(&summary, Some(script), Some(&root), 0);
+
+    for field in ["title", "meta", "lookup", "count"] {
+        assert!(
+            output.code.contains(&format!("void {field};")),
+            "expected AST-resolved prop `{field}` to be bound in template scope:\n{}",
+            output.code
+        );
+    }
+    assert!(
+        !output.code.contains("void decoy;"),
+        "the decoy field from the comment must not be extracted as a prop:\n{}",
+        output.code
+    );
+}
+
+#[test]
+fn test_define_props_local_intersection_alias_emits_keyed_bindings() {
+    // A local `type Props = A & B` resolves through the now-populated
+    // TypeResolver: its body carries a top-level `&`, so the generator falls
+    // back to keyed `satisfies keyof Props` bindings rather than field-by-field
+    // extraction. This path previously relied on the definitions map being
+    // empty; registering local types from the AST drives it correctly.
+    use vize_croquis::{Analyzer, AnalyzerOptions};
+
+    let script = r#"
+interface Base { id: string }
+interface Extra { label: string }
+type Props = Base & Extra;
+
+defineProps<Props>();
+"#;
+    let template = r#"<div>{{ id }}{{ label }}</div>"#;
+
+    let allocator = vize_carton::Bump::new();
+    let (root, _) = vize_armature::parse(&allocator, template);
+
+    let mut analyzer = Analyzer::with_options(AnalyzerOptions::full());
+    analyzer.analyze_script_setup(script);
+    analyzer.analyze_template(&root);
+    let summary = analyzer.finish();
+
+    let output = generate_virtual_ts(&summary, Some(script), Some(&root), 0);
+
+    assert!(
+        output.code.contains("satisfies keyof Props"),
+        "an intersection prop alias should emit keyed template bindings:\n{}",
+        output.code
+    );
+}
+
+#[test]
 fn test_script_setup_top_level_await_emits_async_setup() {
     let output = generate_script_setup_virtual_ts("const data = await fetchData()\n");
 

--- a/crates/vize_croquis/src/croquis/model.rs
+++ b/crates/vize_croquis/src/croquis/model.rs
@@ -73,6 +73,7 @@ impl Croquis {
         self.race_conditions.extend(plain.race_conditions);
         self.provide_inject.extend(plain.provide_inject);
         self.setup_context.extend(plain.setup_context);
+        self.types.merge_keep_existing(plain.types);
         self.type_exports.extend(plain.type_exports);
         self.import_statements.extend(plain.import_statements);
         self.re_exports.extend(plain.re_exports);

--- a/crates/vize_croquis/src/script_parser/process/statements.rs
+++ b/crates/vize_croquis/src/script_parser/process/statements.rs
@@ -168,11 +168,13 @@ pub fn process_statement(result: &mut ScriptParseResult, stmt: &Statement<'_>, s
                     Declaration::TSTypeAliasDeclaration(_)
                     | Declaration::TSInterfaceDeclaration(_) => {
                         // Type exports are valid in script setup
+                        result.register_local_type(decl, source);
                         process_type_export(result, decl, stmt.span());
                     }
                     _ => {
                         // Check if it's a type-only export (export type { ... })
                         if export.export_kind.is_type() {
+                            result.register_local_type(decl, source);
                             process_type_export(result, decl, stmt.span());
                         } else if result.is_non_setup_script {
                             // Plain <script> exports stay in the synthetic setup
@@ -201,6 +203,10 @@ pub fn process_statement(result: &mut ScriptParseResult, stmt: &Statement<'_>, s
         Statement::TSTypeAliasDeclaration(type_alias) => {
             // Type aliases are allowed (not bindings, but tracked)
             let name = type_alias.id.name.as_str();
+            result.types.add_type_alias(
+                name,
+                type_alias.type_annotation.span().source_text(source).trim(),
+            );
             let typeof_refs = super::super::typeof_refs::collect_from_type_alias(type_alias);
             result.record_type_export(
                 TypeExport {
@@ -217,6 +223,9 @@ pub fn process_statement(result: &mut ScriptParseResult, stmt: &Statement<'_>, s
         Statement::TSInterfaceDeclaration(interface) => {
             // Interfaces are allowed (not bindings, but tracked)
             let name = interface.id.name.as_str();
+            result
+                .types
+                .add_interface(name, interface.body.span.source_text(source));
             let typeof_refs = super::super::typeof_refs::collect_from_interface(interface);
             result.record_type_export(
                 TypeExport {

--- a/crates/vize_croquis/src/script_parser/result.rs
+++ b/crates/vize_croquis/src/script_parser/result.rs
@@ -4,6 +4,9 @@
 //! [`ScriptParserOptions`], and the small metadata enums/structs that back
 //! plain-value and runtime-object tracking.
 
+use oxc_ast::ast::Declaration;
+use oxc_span::GetSpan;
+
 use crate::croquis::{BindingMetadata, ComponentRegistration, ComponentShape, Croquis};
 use crate::croquis::{
     ImportStatementInfo, InvalidExport, OptionsDescriptor, ReExportInfo, TypeExport,
@@ -14,6 +17,7 @@ use crate::race::RaceConditionTracker;
 use crate::reactivity::ReactivityTracker;
 use crate::scope::ScopeChain;
 use crate::setup_context::SetupContextTracker;
+use crate::types::TypeResolver;
 use vize_carton::{CompactString, FxHashMap, FxHashSet};
 
 /// Origin of a local binding that already carries a plain, non-reactive value.
@@ -60,6 +64,11 @@ pub struct ScriptParseResult {
     pub macros: MacroTracker,
     pub reactivity: ReactivityTracker,
     pub race_conditions: RaceConditionTracker,
+    /// Local `interface` / `type` definitions registered by name, so
+    /// `defineProps<Name>()` and template-binding analysis can resolve the
+    /// fields of a locally declared type through an OXC-backed AST walk
+    /// rather than a raw-text scan.
+    pub types: TypeResolver,
     pub type_exports: Vec<TypeExport>,
     pub invalid_exports: Vec<InvalidExport>,
     /// Scope chain for tracking nested JavaScript scopes
@@ -121,6 +130,31 @@ pub struct ScriptParserOptions {
 }
 
 impl ScriptParseResult {
+    /// Register a top-level `interface Name { ... }` or `type Name = ...`
+    /// declaration into the [`TypeResolver`] by name, keyed to its body source
+    /// text (`{ ... }` for interfaces, the RHS for aliases). This is the
+    /// AST-backed replacement for canon's old raw-text interface scanner:
+    /// `defineProps<Name>()` and template-binding analysis recover the type's
+    /// fields by resolving the name here, which handles nested braces,
+    /// generics, and comments correctly.
+    pub(crate) fn register_local_type(&mut self, decl: &Declaration<'_>, source: &str) {
+        match decl {
+            Declaration::TSInterfaceDeclaration(interface) => {
+                self.types.add_interface(
+                    interface.id.name.as_str(),
+                    interface.body.span.source_text(source),
+                );
+            }
+            Declaration::TSTypeAliasDeclaration(alias) => {
+                self.types.add_type_alias(
+                    alias.id.name.as_str(),
+                    alias.type_annotation.span().source_text(source).trim(),
+                );
+            }
+            _ => {}
+        }
+    }
+
     /// Record a `TypeExport` together with the `typeof` value-identifier
     /// references found in its body. Must be the only call site that pushes
     /// to `type_exports` so the two vectors stay in lockstep for
@@ -180,6 +214,7 @@ impl ScriptParseResult {
         summary.macros = self.macros;
         summary.reactivity = self.reactivity;
         summary.race_conditions = self.race_conditions;
+        summary.types = self.types;
         summary.type_exports = self.type_exports;
         summary.invalid_exports = self.invalid_exports;
         summary.scopes = self.scopes;

--- a/crates/vize_croquis/src/script_parser/snapshots/vize_croquis__script_parser__tests__parse_imports.snap
+++ b/crates/vize_croquis/src/script_parser/snapshots/vize_croquis__script_parser__tests__parse_imports.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/vize_croquis/src/script_parser/tests.rs
+assertion_line: 342
 expression: result
 ---
 ScriptParseResult {
@@ -39,6 +40,13 @@ ScriptParseResult {
     },
     race_conditions: RaceConditionTracker {
         risks: [],
+    },
+    types: TypeResolver {
+        definitions: TypeDefinitions {
+            interfaces: {},
+            type_aliases: {},
+            imported_types: {},
+        },
     },
     type_exports: [],
     invalid_exports: [],

--- a/crates/vize_croquis/src/script_parser/snapshots/vize_croquis__script_parser__tests__parse_reactivity.snap
+++ b/crates/vize_croquis/src/script_parser/snapshots/vize_croquis__script_parser__tests__parse_reactivity.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/vize_croquis/src/script_parser/tests.rs
+assertion_line: 330
 expression: result
 ---
 ScriptParseResult {
@@ -78,6 +79,13 @@ ScriptParseResult {
     },
     race_conditions: RaceConditionTracker {
         risks: [],
+    },
+    types: TypeResolver {
+        definitions: TypeDefinitions {
+            interfaces: {},
+            type_aliases: {},
+            imported_types: {},
+        },
     },
     type_exports: [],
     invalid_exports: [],

--- a/crates/vize_croquis/src/types.rs
+++ b/crates/vize_croquis/src/types.rs
@@ -96,6 +96,21 @@ impl TypeDefinitions {
     pub fn is_imported(&self, type_name: &str) -> bool {
         self.imported_types.contains_key(type_name)
     }
+
+    /// Merge another set of definitions in, keeping existing entries on a name
+    /// clash. Used to fold a plain `<script>`'s local types into a
+    /// `<script setup>` summary, which keeps precedence for setup-local data.
+    pub fn merge_keep_existing(&mut self, other: TypeDefinitions) {
+        for (name, body) in other.interfaces {
+            self.interfaces.entry(name).or_insert(body);
+        }
+        for (name, body) in other.type_aliases {
+            self.type_aliases.entry(name).or_insert(body);
+        }
+        for (name, source) in other.imported_types {
+            self.imported_types.entry(name).or_insert(source);
+        }
+    }
 }
 
 /// Type resolver for Vue compiler macros
@@ -142,6 +157,14 @@ impl TypeResolver {
         body: impl Into<CompactString>,
     ) {
         self.definitions.add_type_alias(name, body);
+    }
+
+    /// Fold another resolver's definitions in, keeping existing entries on a
+    /// name clash (the receiver wins). Used when merging a plain `<script>`'s
+    /// local types into a `<script setup>` summary.
+    #[inline]
+    pub fn merge_keep_existing(&mut self, other: TypeResolver) {
+        self.definitions.merge_keep_existing(other.definitions);
     }
 
     /// Extract properties from type arguments


### PR DESCRIPTION
Part of #1394 — and the **last remaining sub-PR**, so landing it lets the umbrella close.

Replaces canon's hand-rolled raw-text interface/type scanner with AST-backed type resolution. Local `interface` / `type` declarations are now registered into the croquis `TypeResolver` during OXC script analysis (the same analysis #1409 introduced for cross-file types), and `defineProps<Name>()` field extraction resolves through `TypeResolver::extract_properties` instead of scanning the script string.

## What's implemented
- **croquis** — `ScriptParseResult` gains a `types: TypeResolver`, populated from the OXC AST at the three top-level type-declaration sites in `process/statements.rs` (non-exported `interface`, non-exported `type` alias, and the exported-type path via `register_local_type`). It is carried into `Croquis` through `apply_to_croquis`, and `merge_plain_script` folds a plain `<script>`'s local types into a `<script setup>` summary (receiver keeps precedence). Interface bodies are keyed by their `TSInterfaceBody` span source text (`{ ... }`); type aliases by their RHS — mirroring the existing `import_resolver` AST analysis, so `extract_properties` resolves them unchanged.
- **canon** — both `defineProps<...>` field call sites in `virtual_ts/props.rs` (`generate_props_variables`, `collect_template_prop_names`) and the batch consumer `known_type_based_prop_names` in `vue_codegen.rs` now resolve through the populated resolver. A small `type_reference_lookup_key` helper strips a generic instantiation for a type *reference* (`Foo<T>` → `Foo`) while passing inline object literals (`{ ... }`) through verbatim.
- The text scanner — `extract_interface_fields`, `find_type_body`, `find_matching_brace`, `extract_top_level_type_fields`, `parse_top_level_field_name` — and its re-export, the now-unused `script_content` parameters, and its unit test are **deleted** (~290 lines removed).

Per #1394 acceptance ("No regex/text-based type extraction … remains on default paths"), this removes the final text scanner on that list.

## Verify-real
`test_define_props_local_interface_fields_resolved_via_ast` (in `crates/vize_canon/src/virtual_ts/tests.rs`) exercises a `<script setup>` where a **decoy comment** — `// A real interface Props { decoy: never } lives further down.` — precedes the real `interface Props`, whose body also contains a generic-with-comma field (`Map<string, number>`), a nested object type, and a trailing line comment containing `}` and a quoted `"}"`. The deleted `find_type_body` did `script.find("interface Props ")` and would have anchored on the comment, extracting `decoy`. The test asserts:
- `summary.types.extract_properties("Props")` yields exactly `["title", "meta", "lookup", "count"]`;
- the generated virtual TS emits `void title; … void count;` and **not** `void decoy;`.

A second test, `test_define_props_local_intersection_alias_emits_keyed_bindings`, locks in that a local `type Props = Base & Extra` still routes to keyed `satisfies keyof Props` bindings — the `should_emit_keyed_template_prop_bindings` path that previously relied on the definitions map being empty and is now driven correctly by the registered type body.

## Deferred (honest)
- Cross-component / cross-`<script>` imported-type resolution beyond what `import_resolver` already provides is unchanged; this PR only registers types declared in the analyzed script. Imported types still flow through the existing context-merge (`merge_resolved_props_into_croquis`).
- The two croquis snapshot fixtures (`parse_imports`, `parse_reactivity`) gained an empty `types: TypeResolver { … }` block — a pure additive struct-field serialization on fixtures that declare no local types; no behavioral change.

## Gates
- `RUSTFMT=<1.95.0 toolchain rustfmt 1.9.0> cargo fmt -p vize_canon -p vize_croquis -- --check` → clean (the machine's PATH `rustfmt` is the 1.5.1 shim and must be bypassed).
- `cargo clippy -p vize_canon -p vize_croquis -- -D warnings` → zero warnings.
- `cargo test -p vize_canon` → 374 passed; `-p vize_croquis` → 203 + 7 doctests; `-p vize_atelier_sfc` → 524 passed. `cargo build --workspace` clean.
- semver: only `pub(crate)`/private items in canon changed; the new croquis `TypeResolver` methods and `ScriptParseResult.types` field are additive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1544"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->