### PR TITLE
feat(atelier): first-cut Vapor SSR render codegen for JSX (#1533)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3497,6 +3497,7 @@ dependencies = [
  "serde_json",
  "vize_atelier_core",
  "vize_atelier_sfc",
+ "vize_atelier_ssr",
  "vize_atelier_vapor",
  "vize_carton",
  "vize_croquis",

--- a/crates/vize_atelier_jsx/Cargo.toml
+++ b/crates/vize_atelier_jsx/Cargo.toml
@@ -14,6 +14,10 @@ vize_relief = { workspace = true }
 vize_croquis = { workspace = true }
 vize_atelier_core = { workspace = true }
 vize_atelier_vapor = { workspace = true }
+# Reused for the first-cut JSX Vapor SSR render path (#1533): the lowered
+# RootNode is the same `vize_relief` type the SSR codegen consumes, so the
+# `ssrRender` HTML-string generator is shared rather than reimplemented.
+vize_atelier_ssr = { workspace = true }
 # Reused for scoped-CSS rewriting (`style::apply_scoped_css`) and scope-id
 # generation (`generate_bundler_scope_id`). No template/CSS preprocessing is
 # needed here, so the heavy `native`/lightningcss default feature is dropped.

--- a/crates/vize_atelier_jsx/src/vapor.rs
+++ b/crates/vize_atelier_jsx/src/vapor.rs
@@ -14,6 +14,7 @@
 
 use vize_atelier_core::options::TransformOptions;
 use vize_atelier_core::transform::transform;
+use vize_atelier_ssr::{SsrCodegenContext, SsrCompilerOptions};
 use vize_atelier_vapor::{VaporGenerateOptions, generate_vapor_with_options, transform_to_ir};
 use vize_carton::{Bump, String};
 use vize_croquis::Croquis;
@@ -25,7 +26,11 @@ use crate::{JsxLang, JsxOutputMode, LoweredRoot, lower_source};
 /// Options controlling JSX/TSX -> Vapor compilation.
 #[derive(Debug, Clone, Default)]
 pub struct VaporCompileOptions {
-    /// Compile in SSR mode.
+    /// Compile in SSR mode. When set, the component is server-rendered: instead
+    /// of the client Vapor IR pipeline, the lowered template is run through
+    /// `vize_atelier_ssr`'s `ssrRender` codegen and [`VaporComponent::code`]
+    /// holds an HTML-string render function (first cut, #1533 — see
+    /// [`compile_root_to_vapor_ssr`]).
     pub ssr: bool,
 }
 
@@ -113,6 +118,16 @@ pub(crate) fn compile_root_to_vapor(
     let scoped_style =
         scoped_css.map(|css| build_scoped_style(component_name.as_deref(), css.as_str()));
 
+    // SSR (#1533, first cut): when SSR is requested, the lowered root is the same
+    // `vize_relief` `RootNode` the SSR crate consumes, so we run the SSR-flavored
+    // core transform and `vize_atelier_ssr`'s `ssrRender` codegen instead of the
+    // client Vapor IR pipeline. This produces an HTML-string render function
+    // (`_push(`…`)`) covering static elements, static/dynamic attributes, and
+    // text interpolation. See `compile_root_to_vapor_ssr` for the deferred scope.
+    if options.ssr {
+        return compile_root_to_vapor_ssr(bump, root, analysis, mode, component_name, scoped_style);
+    }
+
     let transform_opts = TransformOptions {
         // JSX render fns close over the setup scope; don't prefix `_ctx.`.
         prefix_identifiers: false,
@@ -140,6 +155,77 @@ pub(crate) fn compile_root_to_vapor(
         mode: mode.unwrap_or(JsxOutputMode::Vapor),
         code,
         templates,
+        scoped_style,
+    }
+}
+
+/// First-cut JSX/TSX -> Vapor **SSR** render codegen (#1533).
+///
+/// Reuses [`vize_atelier_ssr`] end to end: the lowered [`RootNode`] is run
+/// through the SSR-flavored core transform (the same options
+/// `vize_atelier_ssr::compile_ssr` uses) and then `SsrCodegenContext`, which
+/// emits an `ssrRender(_ctx, _push, _parent, _attrs)` function that server-
+/// renders the component to an HTML string via `_push(`…`)`.
+///
+/// Identifiers stay **bare** (no `_ctx.` prefix) to match the JSX closure model
+/// the client Vapor path documents: a JSX component is a plain function whose
+/// render — client or server — closes over the setup scope. The generated
+/// `code` is the SSR preamble (`@vue/server-renderer` / `vue` imports) followed
+/// by the render function, mirroring the shape of the client Vapor `code`.
+///
+/// Implemented subset: static elements, static + dynamic (`v-bind`) attributes,
+/// dynamic class/style, and text interpolation. Control flow (`v-if`/`v-for`),
+/// slots, nested components, and `renderToString` runtime wiring flow through
+/// the shared SSR codegen too but are **not** part of this first cut's tested
+/// contract — see the PR's "Deferred" section.
+fn compile_root_to_vapor_ssr<'a>(
+    bump: &'a Bump,
+    mut root: vize_atelier_core::RootNode<'a>,
+    analysis: &'a Croquis,
+    mode: Option<JsxOutputMode>,
+    component_name: Option<String>,
+    scoped_style: Option<ScopedStyle>,
+) -> VaporComponent {
+    let transform_opts = TransformOptions {
+        // JSX render fns close over the setup scope; keep identifiers bare so the
+        // SSR render function references the closure's bindings directly (no
+        // `_ctx.` prefix), consistent with the client Vapor path above.
+        prefix_identifiers: false,
+        // SSR transforms disable DOM-only optimizations (hoisting, handler
+        // caching) and desugar directives for string output instead of vnodes.
+        hoist_static: false,
+        cache_handlers: false,
+        ssr: true,
+        binding_metadata: None,
+        ..Default::default()
+    };
+    transform(bump, &mut root, transform_opts, Some(analysis));
+
+    // The scope id is already embedded in the SSR options so `ssrRender` emits
+    // the `data-v-<hash>` attribute inline, matching the SFC SSR scope path
+    // (no post-generation string injection needed, unlike the client templates).
+    let ssr_options = SsrCompilerOptions {
+        component_name: component_name.clone(),
+        scope_id: scoped_style.as_ref().map(|style| style.scope_id.clone()),
+        ..SsrCompilerOptions::default()
+    };
+    let generated = SsrCodegenContext::new(bump, &ssr_options).generate(&root);
+
+    // Combine preamble (imports) + render function into a single module, mirroring
+    // the client Vapor `code` field which also inlines its imports.
+    let mut code = generated.preamble;
+    if !code.is_empty() && !generated.code.is_empty() {
+        code.push('\n');
+    }
+    code.push_str(&generated.code);
+
+    VaporComponent {
+        component_name,
+        mode: mode.unwrap_or(JsxOutputMode::Vapor),
+        code,
+        // SSR output is a single HTML-string render function; the client-only
+        // static `_template("…")` strings do not apply.
+        templates: Vec::new(),
         scoped_style,
     }
 }

--- a/crates/vize_atelier_jsx/tests/vapor_ssr.rs
+++ b/crates/vize_atelier_jsx/tests/vapor_ssr.rs
@@ -1,0 +1,161 @@
+//! JSX/TSX -> Vue Vapor **SSR** render codegen (#1533, first cut).
+//!
+//! When [`VaporCompileOptions::ssr`] is set, a JSX/Vapor component is
+//! server-rendered: [`vize_atelier_ssr`]'s `ssrRender` codegen is reused to emit
+//! an HTML-string render function (`_push(`…`)`) instead of the client Vapor IR
+//! pipeline. These tests pin the implemented first-cut subset — static elements,
+//! static + dynamic attributes, and text interpolation — and guard that the
+//! normal client Vapor output is unchanged when SSR is off.
+
+use vize_atelier_jsx::{JsxLang, JsxOutputMode, VaporCompileOptions, compile_to_vapor};
+use vize_carton::Bump;
+
+/// Compile a single JSX component and return its generated `code`.
+fn compile(src: &str, ssr: bool) -> vize_carton::String {
+    let bump = Bump::new();
+    let out = compile_to_vapor(&bump, src, JsxLang::Jsx, VaporCompileOptions { ssr });
+    assert!(!out.has_errors(), "diagnostics: {:?}", out.diagnostics);
+    assert_eq!(out.components.len(), 1, "expected one component");
+    out.components.into_iter().next().unwrap().code
+}
+
+fn ssr(src: &str) -> vize_carton::String {
+    compile(src, true)
+}
+
+fn client(src: &str) -> vize_carton::String {
+    compile(src, false)
+}
+
+#[test]
+fn ssr_emits_an_ssr_render_function() {
+    let code = ssr("const A = () => <div/>;");
+    assert!(
+        code.contains("function ssrRender(_ctx, _push, _parent, _attrs)"),
+        "{code}"
+    );
+    // Server output is an HTML string pushed via `_push`, not a client render fn.
+    assert!(code.contains("_push(`<div"), "{code}");
+    assert!(!code.contains("export function render"), "{code}");
+    assert!(!code.contains("_template("), "{code}");
+}
+
+#[test]
+fn ssr_imports_the_server_renderer_helpers() {
+    let code = ssr("const A = () => <div>{msg}</div>;");
+    assert!(
+        code.contains("from \"@vue/server-renderer\""),
+        "SSR helpers must import from the server renderer:\n{code}"
+    );
+}
+
+#[test]
+fn ssr_renders_a_static_element_to_an_html_string() {
+    let code = ssr("const A = () => <p>hi</p>;");
+    assert!(code.contains("_push(`<p"), "{code}");
+    assert!(code.contains(">hi</p>`)"), "{code}");
+}
+
+#[test]
+fn ssr_bakes_a_static_attribute_into_the_html() {
+    let code = ssr("const A = () => <div class=\"box\">x</div>;");
+    // A purely static attribute is rendered as a merged prop in the fallthrough
+    // attrs object (Vue's standard SSR shape for a single root element).
+    assert!(code.contains("class: \"box\""), "{code}");
+}
+
+#[test]
+fn ssr_renders_a_dynamic_attribute_from_the_closure() {
+    let code = ssr("const A = () => <div id={x}/>;");
+    // Dynamic bindings flow through `_ssrRenderAttrs` / `_mergeProps`, and the
+    // bound value stays a bare closure reference (no `_ctx.` prefix).
+    assert!(code.contains("id: x"), "{code}");
+    assert!(code.contains("_ssrRenderAttrs("), "{code}");
+    assert!(!code.contains("_ctx.x"), "{code}");
+}
+
+#[test]
+fn ssr_interpolates_text_with_the_ssr_helper() {
+    let code = ssr("const A = () => <div>{msg}</div>;");
+    assert!(code.contains("_ssrInterpolate(msg)"), "{code}");
+    assert!(!code.contains("_ctx.msg"), "{code}");
+}
+
+#[test]
+fn ssr_combines_static_element_dynamic_attr_and_interpolation() {
+    // The headline first-cut case: one element carrying a static attribute, a
+    // dynamic attribute, and a text interpolation, all in one `_push`.
+    let code = ssr("const A = () => <div id={x} class=\"box\">{msg}</div>;");
+    assert!(
+        code.contains("function ssrRender(_ctx, _push, _parent, _attrs)"),
+        "{code}"
+    );
+    assert!(code.contains("id: x"), "{code}");
+    assert!(code.contains("class: \"box\""), "{code}");
+    assert!(code.contains("_ssrInterpolate(msg)"), "{code}");
+    // Single HTML-string push, no client IR helpers.
+    assert!(code.contains("_push(`<div"), "{code}");
+    assert!(!code.contains("_renderEffect("), "{code}");
+    assert!(!code.contains("_setProp("), "{code}");
+}
+
+#[test]
+fn ssr_member_expression_interpolation_stays_bare() {
+    let code = ssr("const A = () => <p>{user.name}</p>;");
+    assert!(code.contains("_ssrInterpolate(user.name)"), "{code}");
+    assert!(!code.contains("_ctx.user"), "{code}");
+}
+
+#[test]
+fn ssr_keeps_the_resolved_component_name_and_vapor_mode() {
+    let bump = Bump::new();
+    let out = compile_to_vapor(
+        &bump,
+        "const Widget = () => <div/>;",
+        JsxLang::Jsx,
+        VaporCompileOptions { ssr: true },
+    );
+    assert_eq!(out.components[0].component_name.as_deref(), Some("Widget"));
+    assert_eq!(out.components[0].mode, JsxOutputMode::Vapor);
+    // SSR output carries no client-only static template strings.
+    assert!(out.components[0].templates.is_empty());
+}
+
+#[test]
+fn tsx_compiles_to_ssr() {
+    let bump = Bump::new();
+    let out = compile_to_vapor(
+        &bump,
+        "const A = (): JSX.Element => <span>{label}</span>;",
+        JsxLang::Tsx,
+        VaporCompileOptions { ssr: true },
+    );
+    assert!(!out.has_errors(), "{:?}", out.diagnostics);
+    let code = &out.components[0].code;
+    assert!(code.contains("function ssrRender("), "{code}");
+    assert!(code.contains("_ssrInterpolate(label)"), "{code}");
+}
+
+#[test]
+fn client_output_is_unchanged_when_ssr_is_off() {
+    // The exact same source compiled with SSR off must still produce the client
+    // Vapor render function (template instantiation + reactive effects), with no
+    // SSR machinery leaking in.
+    let code = client("const A = () => <div id={x} class=\"box\">{msg}</div>;");
+    assert!(code.contains("export function render"), "{code}");
+    assert!(code.contains("_template("), "{code}");
+    assert!(code.contains("_renderEffect("), "{code}");
+    assert!(code.contains("_setText("), "{code}");
+    assert!(code.contains("_toDisplayString(msg)"), "{code}");
+
+    // None of the SSR shape appears in client output.
+    assert!(!code.contains("ssrRender"), "{code}");
+    assert!(!code.contains("_push("), "{code}");
+    assert!(!code.contains("@vue/server-renderer"), "{code}");
+}
+
+#[test]
+fn client_and_ssr_outputs_differ_for_the_same_source() {
+    let src = "const A = () => <div>{msg}</div>;";
+    assert_ne!(ssr(src).as_str(), client(src).as_str());
+}


### PR DESCRIPTION
Part of #1533.

## What's implemented

`VaporCompileOptions.ssr` previously only forwarded into the core transform — there was **no** Vapor `ssrRender`/`renderToString` codegen path for JSX, so an SSR-flagged JSX/TSX component silently produced the *client* Vapor output (`_template(...)` + reactive effects).

This first cut wires the JSX Vapor backend to the existing `vize_atelier_ssr` crate rather than inventing a parallel system. The key enabler: the JSX lowering produces a `vize_relief::ast::RootNode`, which is the exact type `SsrCodegenContext::generate` already consumes (`vize_atelier_core` re-exports it from `vize_relief`), so no conversion is needed.

In `crates/vize_atelier_jsx/src/vapor.rs`, `compile_root_to_vapor` now branches on `options.ssr`:
- **SSR on** → new `compile_root_to_vapor_ssr`: runs the SSR-flavored core transform (the same options `vize_atelier_ssr::compile_ssr` uses — `prefix_identifiers` off for the JSX closure model, `hoist_static`/`cache_handlers` off, `ssr: true`), then `SsrCodegenContext::generate`. `VaporComponent.code` holds the SSR preamble (`@vue/server-renderer` / `vue` imports) followed by an `ssrRender(_ctx, _push, _parent, _attrs)` function that server-renders to an HTML string via `_push(\`…\`)`.
- **SSR off** → existing client Vapor IR pipeline, byte-for-byte unchanged.

Identifiers stay **bare** (no `_ctx.` prefix), consistent with the JSX closure model the client Vapor path documents and the existing `tests/vapor.rs` enforces. `<style scoped>` scope ids are threaded into the SSR options so the `data-v-<hash>` attribute is emitted inline in the HTML (and `ssrRender` gains the standard `_scopeId` param), mirroring the SFC SSR scope path.

Implemented subset (the high-value cases, tested): static elements, static attributes, dynamic attributes (`v-bind` / `id={x}`), dynamic class/style, and text interpolation.

Example — `const A = () => <div id={x} class="box">{msg}</div>;` with `ssr: true`:

```js
import { ssrInterpolate as _ssrInterpolate, ssrRenderAttrs as _ssrRenderAttrs } from "@vue/server-renderer"
import { mergeProps as _mergeProps } from "vue"

function ssrRender(_ctx, _push, _parent, _attrs) {
  _push(`<div${_ssrRenderAttrs(_mergeProps({ id: x, class: "box" }, _attrs))}>${_ssrInterpolate(msg)}</div>`)
}
```

The same source with `ssr: false` still emits `export function render(_ctx)` with `_template(...)` / `_renderEffect` / `_setProp` / `_setText` — unchanged.

## Verify-real

- New suite `crates/vize_atelier_jsx/tests/vapor_ssr.rs` (12 tests), proving the headline case (static element + dynamic attr + interpolation → correct `ssrRender` HTML-string function), bare identifiers, server-renderer imports, TSX parity, and — critically — that the **client output is unchanged when `ssr` is off** (asserts the client shape is present and no SSR machinery leaks in; plus `client != ssr` for the same source).
- Manually probed the `<style scoped>` path: `data-v-<hash>` is injected inline into the SSR HTML and the style block is extracted from the rendered content.
- Confirmed downstream consumers (`vize_maestro`, `vize_patina`, `vize_vitrine`, `vize_canon`) still build — the change is additive (the public `ssr` field already existed; only a doc update + a new *private* fn + the new dep).

## Deferred (honest)

This is the SSR *render-codegen* item of #1533 only; source maps, HMR, CSS emission, and preamble work are separate. Within SSR, deliberately **not** part of this first cut's tested/guaranteed contract:
- **Control flow** — `v-if` / `v-for`. The shared SSR codegen does handle these, but they are not exercised/pinned here for JSX and may need closure-model (bare-identifier) review for scoped params.
- **Slots & nested components** — `ssrRenderComponent` / `ssrRenderSlot` paths are reachable via the reused codegen but unverified for the JSX authoring shape.
- **`renderToString` runtime integration** — this emits the `ssrRender` *function*; wiring it into a runnable `@vue/server-renderer` `renderToString` entry (component object assembly, client/server hydration pairing) is out of scope.
- **Compound interpolation expressions** — the SSR codegen has a known `_ctx.value` placeholder for compound expressions; simple and member expressions are correct.
- **Bare vs `_ctx.` identifier strategy** — chose bare to match the JSX closure model; a `_ctx.`-prefixed standalone-component variant may be wanted later depending on how the runtime wraps these.

The implemented subset is correct and pinned by tests.

## Gates

- **fmt**: `RUSTFMT="$(rustc +1.95.0 --print sysroot)/bin/rustfmt" cargo fmt -p vize_atelier_jsx -- --check` → clean (rustfmt 1.9.0, style_edition 2024).
- **clippy**: `cargo clippy -p vize_atelier_jsx -p vize_atelier_vapor -p vize_atelier_ssr -- -D warnings` → zero warnings.
- **tests**: `cargo test -p vize_atelier_vapor -p vize_atelier_ssr -p vize_atelier_jsx` → all green (new `vapor_ssr` suite: 12/12; existing `vapor` suite + SSR + vapor crate suites unchanged & passing).
- **semver**: additive only (new private fn, new internal dep, doc-only change to the existing `VaporCompileOptions::ssr` field). `vize_atelier_jsx` is unpublished so the crates.io baseline check is N/A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1545"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->