### PR TITLE
feat(patina): lint JSX/TSX through the zero-cost rule IR (#1499)

### DIFF
--- a/crates/vize_atelier_jsx/src/analyze.rs
+++ b/crates/vize_atelier_jsx/src/analyze.rs
@@ -13,7 +13,12 @@ use vize_croquis::{Croquis, Drawer};
 
 /// Analyze a parsed JSX/TSX program, returning the Croquis binding metadata,
 /// scope chain, reactivity tracking, and macro/import information.
-pub(crate) fn analyze_program(program: &Program<'_>, source: &str) -> Croquis {
+///
+/// Exposed (re-exported as [`crate::analyze_jsx_program`]) so consumers that
+/// parse the program themselves — e.g. Patina's zero-cost JSX lint path, which
+/// drives rules straight over the OXC AST without lowering — can attach the same
+/// semantic analysis the lowering pipeline produces without a second parse.
+pub fn analyze_program(program: &Program<'_>, source: &str) -> Croquis {
     let result = analyze_script_setup_program(program, source, None);
     let mut croquis = Drawer::new().finish();
     result.apply_to_croquis(&mut croquis);

--- a/crates/vize_atelier_jsx/src/lib.rs
+++ b/crates/vize_atelier_jsx/src/lib.rs
@@ -42,6 +42,8 @@ pub mod vapor;
 mod analyze;
 mod finder;
 
+pub use analyze::analyze_program as analyze_jsx_program;
+
 use vize_carton::{Bump, String};
 use vize_croquis::Croquis;
 use vize_croquis::croquis::BindingMetadata;

--- a/crates/vize_patina/benches/markup_ir_bench.rs
+++ b/crates/vize_patina/benches/markup_ir_bench.rs
@@ -18,7 +18,7 @@ use vize_carton::append;
 use vize_patina::ir::TemplateSyntax;
 use vize_patina::markup::{MarkupContext, MarkupDocument};
 use vize_patina::rules::a11y::ImgAlt;
-use vize_patina::{LintContext, Linter, RuleRegistry};
+use vize_patina::{JsxLang, LintContext, Linter, RuleRegistry};
 
 /// A representative template with a mix of elements, bindings, and `<img>`
 /// nodes (the rule's trigger), large enough to exercise traversal.
@@ -60,6 +60,80 @@ fn lint_via_markup_ir(source: &str) -> usize {
     lint.warning_count()
 }
 
+/// A representative JSX module: a component returning a gallery with many
+/// `<img>` nodes (the rule's trigger), bindings, and events — large enough to
+/// exercise the projection / lowering traversal.
+fn sample_jsx() -> String {
+    let mut module = String::from("const Gallery = () => (\n  <div className=\"gallery\">\n");
+    for i in 0..80 {
+        append!(
+            module,
+            r#"    <figure className="item">
+      <img src={{`/photo{i}.jpg`}} />
+      <figcaption title={{`caption{i}`}}>Photo {i}</figcaption>
+      <button onClick={{() => open({i})}}>Open</button>
+    </figure>
+"#,
+        );
+    }
+    module.push_str("  </div>\n);");
+    module
+}
+
+/// JSX lint over the **zero-cost rule IR**: `a11y/img-alt` is markup-capable, so
+/// `lint_jsx` parses the OXC program once and runs the rule straight over the
+/// borrow-based [`MarkupDocument::from_jsx`] facade — no template reconstruction.
+fn lint_jsx_via_ir(linter: &Linter, source: &str) -> usize {
+    linter
+        .lint_jsx(source, "bench.jsx", JsxLang::Jsx)
+        .warning_count
+}
+
+/// JSX lint over the **lowering fallback**: `vue/a11y-img-alt` has only a legacy
+/// `Rule` impl, so the same `<img>` alt check is served by lowering the JSX to a
+/// synthetic relief template AST first — the allocation-heavy reconstruction the
+/// IR path avoids.
+fn lint_jsx_via_lowering(linter: &Linter, source: &str) -> usize {
+    linter
+        .lint_jsx(source, "bench.jsx", JsxLang::Jsx)
+        .warning_count
+}
+
+fn bench_jsx_ir_vs_lowering(c: &mut Criterion) {
+    use vize_patina::rules::vue::A11yImgAlt;
+
+    let module = sample_jsx();
+
+    // IR arm: a markup-capable rule (runs over the OXC projection).
+    let mut ir_registry = RuleRegistry::new();
+    ir_registry.register(Box::new(ImgAlt));
+    let ir_linter = Linter::with_registry(ir_registry);
+
+    // Lowering arm: an equivalent unmigrated rule (forces the lowering fallback).
+    let mut lowering_registry = RuleRegistry::new();
+    lowering_registry.register(Box::new(A11yImgAlt));
+    let lowering_linter = Linter::with_registry(lowering_registry);
+
+    // Sanity: both arms must flag the same number of `<img>` nodes, otherwise
+    // the comparison is meaningless.
+    let expected = lint_jsx_via_ir(&ir_linter, &module);
+    assert_eq!(lint_jsx_via_lowering(&lowering_linter, &module), expected);
+    assert!(expected > 0, "fixture should trigger the rule");
+
+    let mut group = c.benchmark_group("jsx_lint");
+    group.throughput(Throughput::Bytes(module.len() as u64));
+
+    group.bench_function("ir_projection", |b| {
+        b.iter(|| lint_jsx_via_ir(&ir_linter, black_box(&module)))
+    });
+
+    group.bench_function("lowering_fallback", |b| {
+        b.iter(|| lint_jsx_via_lowering(&lowering_linter, black_box(&module)))
+    });
+
+    group.finish();
+}
+
 fn bench_markup_ir_vs_template(c: &mut Criterion) {
     let template = sample_template();
 
@@ -88,5 +162,9 @@ fn bench_markup_ir_vs_template(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, bench_markup_ir_vs_template);
+criterion_group!(
+    benches,
+    bench_markup_ir_vs_template,
+    bench_jsx_ir_vs_lowering
+);
 criterion_main!(benches);

--- a/crates/vize_patina/src/lib.rs
+++ b/crates/vize_patina/src/lib.rs
@@ -131,9 +131,10 @@ pub fn lint(source: &str, filename: &str) -> LintResult {
 
 /// Lint JSX/TSX source with default rules.
 ///
-/// Lowers the JSX/TSX to the shared relief template AST and runs the existing
-/// element/attribute/binding template rules over it. See [`Linter::lint_jsx`]
-/// for the directive-rule caveat.
+/// Runs rules over the zero-cost markup IR projected straight from the OXC AST
+/// ([`MarkupDocument::from_jsx`](markup::MarkupDocument::from_jsx)) — no
+/// synthetic template AST on the common path. Rules not yet migrated to the
+/// markup IR fall back to a lowering pass. See [`Linter::lint_jsx`].
 pub fn lint_jsx(source: &str, filename: &str, lang: JsxLang) -> LintResult {
     Linter::new().lint_jsx(source, filename, lang)
 }

--- a/crates/vize_patina/src/linter/engine.rs
+++ b/crates/vize_patina/src/linter/engine.rs
@@ -335,17 +335,31 @@ impl Linter {
         self.lint_template_with_allocator(&allocator, source, filename)
     }
 
-    /// Lint JSX/TSX source by lowering it to the shared relief template AST and
-    /// running the existing element/attribute/binding template rules over it.
+    /// Lint JSX/TSX source through the zero-cost rule IR.
     ///
-    /// JSX/TSX lowers (via [`vize_atelier_jsx::lower_source`]) to the same
-    /// [`RootNode`] that SFC `<template>` blocks produce, so any AST-driven
-    /// template rule (e.g. `vue/a11y-img-alt`) runs unchanged.
+    /// This is the [`MarkupDocument::from_jsx`](crate::markup::MarkupDocument::from_jsx)
+    /// path: `.jsx`/`.tsx` is parsed once to an OXC program and every rule that
+    /// exposes a [`MarkupRule`](crate::markup::MarkupRule) projection (via
+    /// [`Rule::as_markup_rule`](crate::rule::Rule::as_markup_rule)) runs straight
+    /// over the borrow-based markup facade — **no synthetic template AST is
+    /// materialized on this common path**. Diagnostics and fixes carry
+    /// `ByteRange`s that already address the original JSX/TSX syntax.
     ///
-    /// Note: directive-structure rules such as `vue/require-v-for-key` do **not**
-    /// fire on JSX. JSX `items.map(...)` lowers to a `ForNode` and
-    /// `cond && <x/>` to an `IfNode` *structurally*, not as `v-for`/`v-if`
-    /// directives, so directive-shaped rules have nothing to match against.
+    /// Rules that have *not* been migrated to the markup IR (e.g. interpolation-
+    /// or expression-shaped template rules with no borrow-based JSX projection
+    /// yet) are still served, but only by a fallback that lowers the JSX to the
+    /// shared relief AST via [`vize_atelier_jsx::lower_source`] and runs the
+    /// remaining rules over it. The fallback is skipped entirely when every
+    /// active rule is markup-capable, so the hot path never reconstructs a
+    /// template.
+    ///
+    /// Migrated directive-shaped rules such as `vue/require-v-for-key` still fire
+    /// on JSX: `v-for`'s JSX form (`items.map(…)`) only becomes a list scope
+    /// after lowering, so that rule is driven over the *lowered* markup IR (via
+    /// the same markup visitor — see [`Rule::jsx_needs_lowering`]), while
+    /// element/attribute/binding-shaped rules run on the zero-cost OXC
+    /// projection. A directive with no JSX analogue at all (e.g. `v-html`) simply
+    /// never matches anything in JSX, the documented no-op behavior.
     pub fn lint_jsx(
         &self,
         source: &str,
@@ -355,29 +369,262 @@ impl Linter {
         let capacity = (source.len() * 4).max(self.initial_capacity);
         let allocator = Allocator::with_capacity(capacity);
 
-        let lowered = profile!(
-            "patina.jsx.lower",
-            vize_atelier_jsx::lower_source(allocator.as_bump(), source, lang)
+        // Partition the active rules into three disjoint groups so each rule runs
+        // exactly once (no double-report):
+        //
+        //   ir       — markup-capable, runs over the zero-cost OXC projection.
+        //   lowered  — markup-capable but needs the lowered list/branch shape
+        //              (`jsx_needs_lowering`), driven over the lowered markup IR.
+        //   legacy   — no markup entry point, served by the lowering fallback.
+        let rules = self.registry.rules();
+        let mut any_ir = false;
+        let mut any_lowered_markup = false;
+        let legacy_keep_mask: Vec<bool> = rules
+            .iter()
+            .map(|rule| match rule.as_markup_rule() {
+                Some(_) if rule.jsx_needs_lowering() => {
+                    any_lowered_markup = true;
+                    false
+                }
+                Some(_) => {
+                    any_ir = true;
+                    false
+                }
+                None => true,
+            })
+            .collect();
+        let any_legacy = legacy_keep_mask.iter().any(|keep| *keep);
+        let needs_lowering = any_lowered_markup || any_legacy;
+
+        // Parse `.jsx`/`.tsx` once with OXC. The same program backs the IR pass
+        // (directly) and, when needed, the Croquis analysis.
+        let oxc_allocator = oxc_allocator::Allocator::default();
+        let parsed = profile!(
+            "patina.jsx.parse",
+            vize_atelier_jsx::parse_module(&oxc_allocator, source, lang)
         );
 
-        let mut result = Self::jsx_diagnostics_lint_result(filename, &lowered.diagnostics);
+        let mut result = Self::jsx_diagnostics_lint_result(filename, &parsed.diagnostics);
 
-        for lowered_root in &lowered.roots {
-            let root_result = self.lint_template_root(
-                &allocator,
-                source,
-                filename,
-                &lowered_root.root,
-                TemplateAnalysis::Lazy,
-                TemplateRuleEnv {
-                    sfc_descriptor: None,
-                    dialect: VueDialect::Vue,
-                },
+        // --- Zero-cost IR pass: rules run over the OXC AST, no template AST. ---
+        if any_ir {
+            let ir_result = self.lint_jsx_over_ir(&allocator, source, filename, &parsed.program);
+            result = Self::merge_lint_results(result, ir_result);
+        }
+
+        // --- Lowering: only when a lowered-shape rule or a legacy rule needs it.
+        if needs_lowering {
+            let lowered = profile!(
+                "patina.jsx.lower",
+                vize_atelier_jsx::lower_source(allocator.as_bump(), source, lang)
             );
-            result = Self::merge_lint_results(result, root_result);
+            // Lowering re-parses, so its diagnostic set is a superset of the IR
+            // parse's; keep only the ones the IR parse did not already report.
+            let mut lower_diags = Self::jsx_diagnostics_lint_result(filename, &lowered.diagnostics);
+            Self::dedupe_against(&mut lower_diags, &result);
+            result = Self::merge_lint_results(result, lower_diags);
+
+            for lowered_root in &lowered.roots {
+                // Markup-capable rules whose JSX shape only exists post-lowering,
+                // driven over the lowered relief AST with the markup visitor.
+                if any_lowered_markup {
+                    let lowered_markup = self.lint_jsx_lowered_markup_root(
+                        &allocator,
+                        source,
+                        filename,
+                        &lowered_root.root,
+                    );
+                    result = Self::merge_lint_results(result, lowered_markup);
+                }
+                // Rules with no markup entry point, over the legacy visitor.
+                if any_legacy {
+                    let legacy = self.lint_jsx_fallback_root(
+                        &allocator,
+                        source,
+                        filename,
+                        &lowered_root.root,
+                        &legacy_keep_mask,
+                    );
+                    result = Self::merge_lint_results(result, legacy);
+                }
+            }
         }
 
         result
+    }
+
+    /// Drive the markup-capable rules that need the lowered list/branch shape
+    /// (`jsx_needs_lowering`) over a single lowered JSX root, using the **markup
+    /// visitor** so reporting stays unified with the OXC IR pass. This is how a
+    /// rule like `vue/require-v-for-key` catches the JSX `.map()` form, whose
+    /// list scope only materializes after lowering.
+    fn lint_jsx_lowered_markup_root(
+        &self,
+        allocator: &Allocator,
+        source: &str,
+        filename: &str,
+        root: &RootNode<'_>,
+    ) -> LintResult {
+        use crate::ir::TemplateSyntax;
+        use crate::markup::{MarkupContext, MarkupDocument};
+
+        let mut ctx = LintContext::with_locale(allocator, source, filename, self.locale);
+        ctx.set_enabled_rules(self.enabled_rules.clone());
+        ctx.set_config_disabled_rules(self.disabled_rules.clone());
+        ctx.set_help_level(self.help_level);
+
+        let document = MarkupDocument::new(root, TemplateSyntax::Vue);
+        profile!("patina.jsx.lowered_markup.visit", {
+            let mut markup_ctx = MarkupContext::new(&mut ctx, &document);
+            for rule in self.registry.rules() {
+                if rule.jsx_needs_lowering()
+                    && let Some(markup_rule) = rule.as_markup_rule()
+                {
+                    document.visit_with(markup_rule, &mut markup_ctx);
+                }
+            }
+        });
+
+        let error_count = ctx.error_count();
+        let warning_count = ctx.warning_count();
+        let diagnostics = ctx.into_diagnostics();
+
+        LintResult {
+            filename: filename.to_compact_string(),
+            diagnostics,
+            error_count,
+            warning_count,
+        }
+    }
+
+    /// Run every markup-capable rule over the JSX/TSX program projected straight
+    /// from the OXC AST — the zero-cost path that never builds a template AST.
+    fn lint_jsx_over_ir(
+        &self,
+        allocator: &Allocator,
+        source: &str,
+        filename: &str,
+        program: &oxc_ast::ast::Program<'_>,
+    ) -> LintResult {
+        use crate::ir::TemplateSyntax;
+        use crate::markup::{MarkupContext, MarkupDocument};
+
+        let mut ctx = LintContext::with_locale(allocator, source, filename, self.locale);
+        ctx.set_enabled_rules(self.enabled_rules.clone());
+        ctx.set_config_disabled_rules(self.disabled_rules.clone());
+        ctx.set_help_level(self.help_level);
+
+        // Croquis is only worth computing when a semantic rule is active *and*
+        // markup-capable; attach it to the document so type/binding-aware markup
+        // rules reach the same analysis the lowering pipeline would have seen.
+        let analysis = if self.jsx_ir_needs_analysis() {
+            Some(profile!(
+                "patina.jsx.croquis",
+                vize_atelier_jsx::analyze_jsx_program(program, source)
+            ))
+        } else {
+            None
+        };
+
+        let mut document = MarkupDocument::from_jsx(program, TemplateSyntax::Vue, 0);
+        if let Some(analysis) = analysis.as_ref() {
+            ctx.set_analysis(analysis);
+            document = document.with_analysis(analysis);
+        }
+
+        profile!("patina.jsx.ir.visit", {
+            let mut markup_ctx = MarkupContext::new(&mut ctx, &document);
+            for rule in self.registry.rules() {
+                // `jsx_needs_lowering` rules are driven over the lowered IR
+                // instead (their JSX shape is absent from the OXC projection).
+                if rule.jsx_needs_lowering() {
+                    continue;
+                }
+                if let Some(markup_rule) = rule.as_markup_rule() {
+                    document.visit_with(markup_rule, &mut markup_ctx);
+                }
+            }
+        });
+
+        let error_count = ctx.error_count();
+        let warning_count = ctx.warning_count();
+        let diagnostics = ctx.into_diagnostics();
+
+        LintResult {
+            filename: filename.to_compact_string(),
+            diagnostics,
+            error_count,
+            warning_count,
+        }
+    }
+
+    /// Whether any active rule needs semantic analysis, so the IR path should
+    /// compute Croquis for the JSX program and attach it to the markup document.
+    fn jsx_ir_needs_analysis(&self) -> bool {
+        self.has_active_semantic_template_rules()
+    }
+
+    /// Run the lowering-based legacy fallback for a single lowered JSX root,
+    /// dispatching only the rules whose `keep_mask` entry is `true` (the rules
+    /// with no markup-IR entry point), so rules already handled by the IR or
+    /// lowered-markup passes do not report a second time.
+    fn lint_jsx_fallback_root(
+        &self,
+        allocator: &Allocator,
+        source: &str,
+        filename: &str,
+        root: &RootNode<'_>,
+        keep_mask: &[bool],
+    ) -> LintResult {
+        let mut ctx = LintContext::with_locale(allocator, source, filename, self.locale);
+        ctx.set_enabled_rules(self.enabled_rules.clone());
+        ctx.set_config_disabled_rules(self.disabled_rules.clone());
+        ctx.set_help_level(self.help_level);
+        ctx.set_dialect(VueDialect::Vue);
+
+        let rule_count = self.registry.rules().len();
+        let mut visitor = LintVisitor::with_rule_filter(
+            &mut ctx,
+            &self.registry.rules()[..rule_count],
+            &self.rule_names()[..rule_count],
+            self.registry.has_exit_element_rules(),
+            &keep_mask[..rule_count],
+        );
+        profile!("patina.jsx.fallback.visit", visitor.visit_root(root));
+
+        let error_count = ctx.error_count();
+        let warning_count = ctx.warning_count();
+        let diagnostics = ctx.into_diagnostics();
+
+        LintResult {
+            filename: filename.to_compact_string(),
+            diagnostics,
+            error_count,
+            warning_count,
+        }
+    }
+
+    /// Remove from `result` any diagnostic that already appears in `seen`
+    /// (matched by rule name and range). Used so the lowering fallback does not
+    /// re-emit parse diagnostics the IR-path parse already produced.
+    fn dedupe_against(result: &mut LintResult, seen: &LintResult) {
+        if seen.diagnostics.is_empty() || result.diagnostics.is_empty() {
+            return;
+        }
+        result.diagnostics.retain(|candidate| {
+            !seen.diagnostics.iter().any(|existing| {
+                existing.rule_name == candidate.rule_name
+                    && existing.start == candidate.start
+                    && existing.end == candidate.end
+            })
+        });
+        // Recount after retain so the summary stays accurate.
+        result.error_count = result
+            .diagnostics
+            .iter()
+            .filter(|diagnostic| matches!(diagnostic.severity, crate::diagnostic::Severity::Error))
+            .count();
+        result.warning_count = result.diagnostics.len() - result.error_count;
     }
 
     fn jsx_diagnostics_lint_result(

--- a/crates/vize_patina/src/linter/tests/jsx.rs
+++ b/crates/vize_patina/src/linter/tests/jsx.rs
@@ -1,24 +1,42 @@
-//! Tests for linting JSX/TSX by lowering it to the shared relief template AST.
+//! End-to-end tests for linting `.jsx`/`.tsx` through [`Linter::lint_jsx`].
 //!
-//! These exercise an element/attribute rule (`vue/a11y-img-alt`) over JSX,
-//! confirming AST-driven template rules run unchanged on lowered JSX. Directive
-//! structure rules (e.g. `vue/require-v-for-key`) are intentionally out of scope
-//! because JSX loops/conditionals lower structurally, not as directives.
+//! [`Linter::lint_jsx`] runs two layers:
+//!
+//! 1. the **zero-cost markup-IR pass** — rules with a
+//!    [`MarkupRule`](crate::markup::MarkupRule) projection run straight over the
+//!    OXC AST via [`MarkupDocument::from_jsx`](crate::markup::MarkupDocument::from_jsx),
+//!    with no synthetic template AST; and
+//! 2. a **lowering fallback** — rules without a markup entry point run over the
+//!    relief AST produced by `vize_atelier_jsx::lower_source`.
+//!
+//! The first group of tests targets the IR pass (the `#1499` common path); the
+//! `fallback_*` tests keep an unmigrated rule (`vue/a11y-img-alt`, which only has
+//! a legacy `Rule` impl) firing over the lowering path; and `no_jsx_equivalent_*`
+//! documents that a directive with no JSX analogue is silently skipped.
 
 use crate::linter::Linter;
-use crate::rule::RuleRegistry;
-use crate::rules::vue::A11yImgAlt;
+use crate::rule::{Rule, RuleRegistry};
+use crate::rules::a11y::{
+    ImgAlt, NoAccessKey, NoAutofocus, NoDistractingElements, TabindexNoPositive,
+};
+use crate::rules::html::DeprecatedElement;
+use crate::rules::vue::{A11yImgAlt, NoVHtml, RequireVForKey};
 use vize_atelier_jsx::JsxLang;
 
-fn img_alt_linter() -> Linter {
+fn linter_with(rule: Box<dyn Rule>) -> Linter {
     let mut registry = RuleRegistry::new();
-    registry.register(Box::new(A11yImgAlt));
+    registry.register(rule);
     Linter::with_registry(registry)
 }
 
+// ===========================================================================
+// Zero-cost IR pass: migrated rules fire on JSX/TSX with no template AST.
+// ===========================================================================
+
 #[test]
-fn jsx_img_without_alt_is_flagged() {
-    let linter = img_alt_linter();
+fn ir_img_alt_jsx_without_alt_is_flagged() {
+    // `a11y/img-alt` (the markup-migrated rule) runs over the OXC AST directly.
+    let linter = linter_with(Box::new(ImgAlt));
     let result = linter.lint_jsx(
         r#"const A = () => <img src="/x.jpg"/>;"#,
         "test.jsx",
@@ -27,7 +45,291 @@ fn jsx_img_without_alt_is_flagged() {
 
     assert_eq!(
         result.warning_count, 1,
-        "<img> without alt should be flagged: {:?}",
+        "<img> without alt must flag through the IR pass: {:?}",
+        result.diagnostics
+    );
+    assert!(
+        result
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.rule_name == "a11y/img-alt"),
+        "expected a11y/img-alt diagnostic: {:?}",
+        result.diagnostics
+    );
+}
+
+#[test]
+fn ir_img_alt_jsx_with_static_alt_is_clean() {
+    let linter = linter_with(Box::new(ImgAlt));
+    let result = linter.lint_jsx(
+        r#"const A = () => <img src="/x.jpg" alt="hi"/>;"#,
+        "test.jsx",
+        JsxLang::Jsx,
+    );
+    assert_eq!(
+        result.warning_count, 0,
+        "static alt must be clean: {:?}",
+        result.diagnostics
+    );
+}
+
+#[test]
+fn ir_img_alt_jsx_with_dynamic_alt_is_clean() {
+    let linter = linter_with(Box::new(ImgAlt));
+    let result = linter.lint_jsx(
+        r#"const A = () => <img src={photo} alt={caption}/>;"#,
+        "test.jsx",
+        JsxLang::Jsx,
+    );
+    assert_eq!(
+        result.warning_count, 0,
+        "dynamic alt={{…}} must be clean: {:?}",
+        result.diagnostics
+    );
+}
+
+#[test]
+fn ir_img_alt_tsx_is_flagged() {
+    let linter = linter_with(Box::new(ImgAlt));
+    let result = linter.lint_jsx(
+        "const A = (p: Props): JSX.Element => <img src=\"/x.jpg\"/>;",
+        "test.tsx",
+        JsxLang::Tsx,
+    );
+    assert_eq!(
+        result.warning_count, 1,
+        "TSX <img> without alt must flag: {:?}",
+        result.diagnostics
+    );
+}
+
+#[test]
+fn ir_diagnostic_range_points_at_jsx_source() {
+    // The reported range must address the original JSX bytes, so editor fixes
+    // land on the written `<img>` and not some reconstructed offset.
+    let source = r#"const A = () => <div><img src="/x.jpg"/></div>;"#;
+    let linter = linter_with(Box::new(ImgAlt));
+    let result = linter.lint_jsx(source, "test.jsx", JsxLang::Jsx);
+
+    assert_eq!(result.diagnostics.len(), 1);
+    let diag = &result.diagnostics[0];
+    let img_start = source.find("<img").unwrap() as u32;
+    assert_eq!(diag.start, img_start, "range must start at the <img> tag");
+    assert_eq!(&source[diag.start as usize..diag.end as usize][..4], "<img");
+}
+
+#[test]
+fn ir_no_distracting_elements_fires_on_jsx() {
+    let linter = linter_with(Box::new(NoDistractingElements));
+    let result = linter.lint_jsx(
+        "const A = () => <marquee>hi</marquee>;",
+        "test.jsx",
+        JsxLang::Jsx,
+    );
+    assert_eq!(
+        result.warning_count, 1,
+        "<marquee> must flag: {:?}",
+        result.diagnostics
+    );
+
+    let clean = linter.lint_jsx("const A = () => <div>hi</div>;", "test.jsx", JsxLang::Jsx);
+    assert_eq!(
+        clean.warning_count, 0,
+        "<div> must be clean: {:?}",
+        clean.diagnostics
+    );
+}
+
+#[test]
+fn ir_no_distracting_elements_skips_components() {
+    // A PascalCase JSX tag is a component, never an intrinsic <marquee>.
+    let linter = linter_with(Box::new(NoDistractingElements));
+    let result = linter.lint_jsx(
+        "const A = () => <Marquee>hi</Marquee>;",
+        "test.jsx",
+        JsxLang::Jsx,
+    );
+    assert_eq!(
+        result.warning_count, 0,
+        "component <Marquee> must be clean: {:?}",
+        result.diagnostics
+    );
+}
+
+#[test]
+fn ir_deprecated_element_fires_on_jsx() {
+    let linter = linter_with(Box::new(DeprecatedElement));
+    let result = linter.lint_jsx(
+        "const A = () => <center>hi</center>;",
+        "test.jsx",
+        JsxLang::Jsx,
+    );
+    assert_eq!(
+        result.warning_count, 1,
+        "<center> must flag: {:?}",
+        result.diagnostics
+    );
+}
+
+#[test]
+fn ir_no_autofocus_fires_on_jsx() {
+    let linter = linter_with(Box::new(NoAutofocus));
+    // Boolean-shorthand prop.
+    let shorthand = linter.lint_jsx(
+        "const A = () => <input autofocus/>;",
+        "test.jsx",
+        JsxLang::Jsx,
+    );
+    assert_eq!(
+        shorthand.warning_count, 1,
+        "autofocus must flag: {:?}",
+        shorthand.diagnostics
+    );
+
+    // JSX camelCase + expression value — still the same `autofocus` arg.
+    let expr = linter.lint_jsx(
+        "const A = () => <input autoFocus={true}/>;",
+        "test.jsx",
+        JsxLang::Jsx,
+    );
+    assert_eq!(
+        expr.warning_count, 1,
+        "autoFocus={{true}} must flag: {:?}",
+        expr.diagnostics
+    );
+
+    let clean = linter.lint_jsx(
+        "const A = () => <input type=\"text\"/>;",
+        "test.jsx",
+        JsxLang::Jsx,
+    );
+    assert_eq!(
+        clean.warning_count, 0,
+        "no autofocus must be clean: {:?}",
+        clean.diagnostics
+    );
+}
+
+#[test]
+fn ir_no_access_key_fires_on_jsx() {
+    let linter = linter_with(Box::new(NoAccessKey));
+    let result = linter.lint_jsx(
+        "const A = () => <div accessKey=\"h\">x</div>;",
+        "test.jsx",
+        JsxLang::Jsx,
+    );
+    assert_eq!(
+        result.warning_count, 1,
+        "accessKey must flag: {:?}",
+        result.diagnostics
+    );
+}
+
+#[test]
+fn ir_tabindex_no_positive_fires_on_jsx() {
+    let linter = linter_with(Box::new(TabindexNoPositive));
+    let positive = linter.lint_jsx(
+        "const A = () => <div tabIndex=\"1\">x</div>;",
+        "test.jsx",
+        JsxLang::Jsx,
+    );
+    assert_eq!(
+        positive.warning_count, 1,
+        "tabIndex=\"1\" must flag: {:?}",
+        positive.diagnostics
+    );
+
+    let zero = linter.lint_jsx(
+        "const A = () => <div tabIndex=\"0\">x</div>;",
+        "test.jsx",
+        JsxLang::Jsx,
+    );
+    assert_eq!(
+        zero.warning_count, 0,
+        "tabIndex=\"0\" must be clean: {:?}",
+        zero.diagnostics
+    );
+
+    let negative = linter.lint_jsx(
+        "const A = () => <div tabIndex=\"-1\">x</div>;",
+        "test.jsx",
+        JsxLang::Jsx,
+    );
+    assert_eq!(
+        negative.warning_count, 0,
+        "tabIndex=\"-1\" must be clean: {:?}",
+        negative.diagnostics
+    );
+}
+
+#[test]
+fn ir_require_v_for_key_fires_on_jsx_map() {
+    // `.map()` repeats without a `key` are the JSX shape of a keyless `v-for`.
+    // The markup facade surfaces the repeated <li> and asks for a key binding.
+    let linter = linter_with(Box::new(RequireVForKey));
+    let missing = linter.lint_jsx(
+        "const L = () => <ul>{items.map((item) => <li>{item}</li>)}</ul>;",
+        "test.jsx",
+        JsxLang::Jsx,
+    );
+    assert_eq!(
+        missing.error_count, 1,
+        ".map() without key must flag: {:?}",
+        missing.diagnostics
+    );
+
+    let keyed = linter.lint_jsx(
+        "const L = () => <ul>{items.map((item) => <li key={item.id}>{item}</li>)}</ul>;",
+        "test.jsx",
+        JsxLang::Jsx,
+    );
+    assert_eq!(
+        keyed.error_count, 0,
+        ".map() with key must be clean: {:?}",
+        keyed.diagnostics
+    );
+}
+
+// ===========================================================================
+// Each migrated rule fires exactly once (IR pass, no double-report via fallback).
+// ===========================================================================
+
+#[test]
+fn migrated_rule_reports_once_not_per_backend() {
+    // `a11y/img-alt` is markup-capable, so it must run on the IR pass only and
+    // never additionally via the lowering fallback — exactly one diagnostic.
+    let linter = linter_with(Box::new(ImgAlt));
+    let result = linter.lint_jsx(
+        r#"const A = () => <img src="/x.jpg"/>;"#,
+        "test.jsx",
+        JsxLang::Jsx,
+    );
+    assert_eq!(
+        result.diagnostics.len(),
+        1,
+        "a migrated rule must report once, not once per backend: {:?}",
+        result.diagnostics
+    );
+}
+
+// ===========================================================================
+// Fallback pass: an unmigrated rule still runs over the lowered relief AST.
+// ===========================================================================
+
+#[test]
+fn fallback_img_without_alt_is_flagged() {
+    // `vue/a11y-img-alt` has only a legacy `Rule` impl (no markup projection),
+    // so it is served by the lowering fallback and must still fire.
+    let linter = linter_with(Box::new(A11yImgAlt));
+    let result = linter.lint_jsx(
+        r#"const A = () => <img src="/x.jpg"/>;"#,
+        "test.jsx",
+        JsxLang::Jsx,
+    );
+
+    assert_eq!(
+        result.warning_count, 1,
+        "<img> without alt should be flagged via fallback: {:?}",
         result.diagnostics
     );
     assert!(
@@ -41,41 +343,94 @@ fn jsx_img_without_alt_is_flagged() {
 }
 
 #[test]
-fn jsx_img_with_alt_is_not_flagged() {
-    let linter = img_alt_linter();
+fn fallback_img_with_alt_is_not_flagged() {
+    let linter = linter_with(Box::new(A11yImgAlt));
     let result = linter.lint_jsx(
         r#"const A = () => <img src="/x.jpg" alt=""/>;"#,
         "test.jsx",
         JsxLang::Jsx,
     );
-
     assert_eq!(
         result.warning_count, 0,
-        "<img> with alt should not be flagged: {:?}",
+        "<img> with alt should be clean: {:?}",
+        result.diagnostics
+    );
+}
+
+#[test]
+fn fallback_tsx_img_without_alt_is_flagged() {
+    let linter = linter_with(Box::new(A11yImgAlt));
+    let result = linter.lint_jsx(
+        r#"const A = () => <img src="/x.jpg"/>;"#,
+        "test.tsx",
+        JsxLang::Tsx,
+    );
+    assert_eq!(
+        result.warning_count, 1,
+        "TSX fallback must flag: {:?}",
+        result.diagnostics
+    );
+}
+
+// ===========================================================================
+// No JSX equivalent: documented + skipped.
+// ===========================================================================
+
+#[test]
+fn no_jsx_equivalent_v_html_is_skipped() {
+    // `vue/no-v-html` matches the `v-html` directive, which has no JSX analogue
+    // (`dangerouslySetInnerHTML` is a different prop entirely). It is not
+    // migrated to the markup IR, and the lowering fallback finds no `v-html`
+    // directive in JSX, so linting JSX produces no diagnostic. This is the
+    // documented "rule with no JSX equivalent is skipped" behavior.
+    let linter = linter_with(Box::new(NoVHtml));
+    let result = linter.lint_jsx(
+        r#"const A = () => <div dangerouslySetInnerHTML={{ __html: x }}/>;"#,
+        "test.jsx",
+        JsxLang::Jsx,
+    );
+    assert_eq!(
+        result.error_count + result.warning_count,
+        0,
+        "no-v-html has no JSX equivalent and must stay silent on JSX: {:?}",
+        result.diagnostics
+    );
+}
+
+// ===========================================================================
+// Combined: a markup rule + an unmigrated rule coexist on one lint pass.
+// ===========================================================================
+
+#[test]
+fn ir_and_fallback_rules_coexist() {
+    // ImgAlt (markup IR) and A11yImgAlt (fallback) both target <img> without
+    // alt. A single `lint_jsx` call must fire both — one through each path —
+    // proving the two passes compose without dropping or duplicating either.
+    let mut registry = RuleRegistry::new();
+    registry.register(Box::new(ImgAlt));
+    registry.register(Box::new(A11yImgAlt));
+    let linter = Linter::with_registry(registry);
+
+    let result = linter.lint_jsx(
+        r#"const A = () => <img src="/x.jpg"/>;"#,
+        "test.jsx",
+        JsxLang::Jsx,
+    );
+    assert_eq!(
+        result.warning_count, 2,
+        "both the IR rule and the fallback rule must fire once each: {:?}",
         result.diagnostics
     );
     assert!(
         result
             .diagnostics
             .iter()
-            .all(|diagnostic| diagnostic.rule_name != "vue/a11y-img-alt"),
-        "did not expect vue/a11y-img-alt diagnostic: {:?}",
-        result.diagnostics
+            .any(|d| d.rule_name == "a11y/img-alt")
     );
-}
-
-#[test]
-fn tsx_img_without_alt_is_flagged() {
-    let linter = img_alt_linter();
-    let result = linter.lint_jsx(
-        r#"const A = () => <img src="/x.jpg"/>;"#,
-        "test.tsx",
-        JsxLang::Tsx,
-    );
-
-    assert_eq!(
-        result.warning_count, 1,
-        "<img> without alt should be flagged in TSX: {:?}",
-        result.diagnostics
+    assert!(
+        result
+            .diagnostics
+            .iter()
+            .any(|d| d.rule_name == "vue/a11y-img-alt")
     );
 }

--- a/crates/vize_patina/src/rule.rs
+++ b/crates/vize_patina/src/rule.rs
@@ -2,6 +2,7 @@
 
 use crate::context::LintContext;
 use crate::diagnostic::Severity;
+use crate::markup::MarkupRule;
 use crate::preset::LintPreset;
 use vize_relief::ast::{DirectiveNode, ElementNode, ForNode, IfNode, InterpolationNode, RootNode};
 
@@ -49,6 +50,39 @@ pub struct RuleMeta {
 pub trait Rule: Send + Sync {
     /// Get rule metadata
     fn meta(&self) -> &'static RuleMeta;
+
+    /// Project this rule onto the zero-copy markup IR, when it has a
+    /// cross-backend [`MarkupRule`] implementation.
+    ///
+    /// Rules that also implement [`MarkupRule`] override this to return
+    /// `Some(self)`, which lets the JSX/TSX lint path drive them directly over
+    /// the borrow-based [`MarkupDocument`](crate::markup::MarkupDocument)
+    /// projected from the OXC AST — no synthetic template reconstruction. Rules
+    /// that return `None` (the default) have no JSX-capable entry point and are
+    /// handled by the fallback lowering path instead.
+    ///
+    /// The returned reference borrows `self`, so the projection costs nothing.
+    fn as_markup_rule(&self) -> Option<&dyn MarkupRule> {
+        None
+    }
+
+    /// Whether this (markup-capable) rule's JSX/TSX equivalent only materializes
+    /// after lowering, so it must run over the **lowered** markup IR rather than
+    /// the OXC projection.
+    ///
+    /// Most migrated rules are element/attribute/binding-shaped and run on the
+    /// zero-cost OXC projection directly. A few are structural: `v-for`'s JSX
+    /// form is `items.map(…)`, a JS *expression* with no markup until lowering
+    /// turns it into a `ForNode`/list scope. Such a rule returns `true` so the
+    /// JSX path drives its [`MarkupRule`] hooks over the lowered relief AST (via
+    /// the same markup visitor, so reporting stays unified and single), instead
+    /// of the OXC AST where the list shape is absent.
+    ///
+    /// Ignored unless [`Self::as_markup_rule`] is `Some`. No effect on Vue
+    /// templates, where the directive shape is present pre-lowering.
+    fn jsx_needs_lowering(&self) -> bool {
+        false
+    }
 
     /// Run on the full SFC source before template extraction.
     #[allow(unused_variables)]
@@ -156,6 +190,17 @@ impl RuleRegistry {
     /// Check whether a rule with the given name is registered.
     pub fn has_rule(&self, name: &str) -> bool {
         self.rule_names.contains(&name)
+    }
+
+    /// Whether any registered rule exposes a [`MarkupRule`] projection (i.e. has
+    /// a JSX-capable IR entry point via [`Rule::as_markup_rule`]).
+    ///
+    /// Lets the JSX lint path skip building the markup IR entirely when the
+    /// active rule set has nothing to run over it.
+    pub fn has_markup_rules(&self) -> bool {
+        self.rules
+            .iter()
+            .any(|rule| rule.as_markup_rule().is_some())
     }
 
     /// Create a registry for a named preset.

--- a/crates/vize_patina/src/rules/a11y/img_alt.rs
+++ b/crates/vize_patina/src/rules/a11y/img_alt.rs
@@ -69,6 +69,10 @@ impl Rule for ImgAlt {
         &META
     }
 
+    fn as_markup_rule(&self) -> Option<&dyn MarkupRule> {
+        Some(self)
+    }
+
     fn enter_element<'a>(&self, ctx: &mut LintContext<'a>, element: &ElementNode<'a>) {
         if element.tag != "img" {
             return;

--- a/crates/vize_patina/src/rules/a11y/no_access_key.rs
+++ b/crates/vize_patina/src/rules/a11y/no_access_key.rs
@@ -10,6 +10,7 @@
 
 use crate::context::LintContext;
 use crate::diagnostic::Severity;
+use crate::markup::{MarkupBinding, MarkupBindingKind, MarkupContext, MarkupElement, MarkupRule};
 use crate::rule::{Rule, RuleCategory, RuleMeta};
 use vize_relief::ast::{ElementNode, ElementType, ExpressionNode, PropNode};
 
@@ -25,9 +26,47 @@ static META: RuleMeta = RuleMeta {
 #[derive(Default)]
 pub struct NoAccessKey;
 
+/// Markup-IR entry point for `a11y/no-access-key`.
+///
+/// Flags any `accesskey` binding — static (`accesskey="h"`), `v-bind`
+/// (`:accesskey`), or JSX (`accessKey={…}`). Reasoning over the normalized
+/// [`MarkupBinding`] view lets one rule body handle both backends; the
+/// ASCII-case-insensitive `arg_name_eq` absorbs the JSX `accessKey` casing.
+/// Components are exempt on both sides.
+impl MarkupRule for NoAccessKey {
+    fn name(&self) -> &'static str {
+        META.name
+    }
+
+    fn enter_binding<'a>(
+        &self,
+        ctx: &mut MarkupContext<'_, 'a>,
+        element: &MarkupElement<'a>,
+        binding: &MarkupBinding<'a>,
+    ) {
+        if element.is_component() {
+            return;
+        }
+        if !matches!(
+            binding.kind(),
+            MarkupBindingKind::Attribute | MarkupBindingKind::Bind
+        ) || !binding.arg_name_eq("accesskey")
+        {
+            return;
+        }
+        let message = ctx.lint().t("a11y/no-access-key.message");
+        let help = ctx.lint().t("a11y/no-access-key.help");
+        ctx.lint().warn_at_with_help(message, binding.range(), help);
+    }
+}
+
 impl Rule for NoAccessKey {
     fn meta(&self) -> &'static RuleMeta {
         &META
+    }
+
+    fn as_markup_rule(&self) -> Option<&dyn MarkupRule> {
+        Some(self)
     }
 
     fn enter_element<'a>(&self, ctx: &mut LintContext<'a>, element: &ElementNode<'a>) {

--- a/crates/vize_patina/src/rules/a11y/no_autofocus.rs
+++ b/crates/vize_patina/src/rules/a11y/no_autofocus.rs
@@ -10,6 +10,7 @@
 
 use crate::context::LintContext;
 use crate::diagnostic::Severity;
+use crate::markup::{MarkupBinding, MarkupBindingKind, MarkupContext, MarkupElement, MarkupRule};
 use crate::rule::{Rule, RuleCategory, RuleMeta};
 use vize_relief::ast::{ElementNode, ElementType, ExpressionNode, PropNode};
 
@@ -25,9 +26,47 @@ static META: RuleMeta = RuleMeta {
 #[derive(Default)]
 pub struct NoAutofocus;
 
+/// Markup-IR entry point for `a11y/no-autofocus`.
+///
+/// Flags any `autofocus` binding — static (`autofocus` / `autofocus="true"`),
+/// `v-bind` (`:autofocus`), or JSX (`autofocus={…}` / `autoFocus={…}`). The
+/// normalized [`MarkupBinding`] view answers "is there an autofocus prop?"
+/// identically on both backends; `arg_name_eq` is ASCII-case-insensitive, so
+/// the JSX `autoFocus` casing matches too. Components are exempt on both sides.
+impl MarkupRule for NoAutofocus {
+    fn name(&self) -> &'static str {
+        META.name
+    }
+
+    fn enter_binding<'a>(
+        &self,
+        ctx: &mut MarkupContext<'_, 'a>,
+        element: &MarkupElement<'a>,
+        binding: &MarkupBinding<'a>,
+    ) {
+        if element.is_component() {
+            return;
+        }
+        if !matches!(
+            binding.kind(),
+            MarkupBindingKind::Attribute | MarkupBindingKind::Bind
+        ) || !binding.arg_name_eq("autofocus")
+        {
+            return;
+        }
+        let message = ctx.lint().t("a11y/no-autofocus.message");
+        let help = ctx.lint().t("a11y/no-autofocus.help");
+        ctx.lint().warn_at_with_help(message, binding.range(), help);
+    }
+}
+
 impl Rule for NoAutofocus {
     fn meta(&self) -> &'static RuleMeta {
         &META
+    }
+
+    fn as_markup_rule(&self) -> Option<&dyn MarkupRule> {
+        Some(self)
     }
 
     fn enter_element<'a>(&self, ctx: &mut LintContext<'a>, element: &ElementNode<'a>) {

--- a/crates/vize_patina/src/rules/a11y/no_distracting_elements.rs
+++ b/crates/vize_patina/src/rules/a11y/no_distracting_elements.rs
@@ -9,6 +9,7 @@
 
 use crate::context::LintContext;
 use crate::diagnostic::Severity;
+use crate::markup::{MarkupContext, MarkupElement, MarkupRule};
 use crate::rule::{Rule, RuleCategory, RuleMeta};
 use vize_relief::ast::ElementNode;
 
@@ -30,9 +31,40 @@ impl NoDistractingElements {
     }
 }
 
+/// Markup-IR entry point for `a11y/no-distracting-elements`.
+///
+/// A pure tag-name rule, so it maps one-to-one across backends: a Vue
+/// `<marquee>` and a JSX `<marquee />` both reach the same intrinsic tag check,
+/// and the diagnostic range addresses the original syntax. Components are exempt
+/// on both sides ([`MarkupElement::is_component`]), so a JSX `<Marquee/>` — a
+/// user component, not the intrinsic element — is never flagged.
+impl MarkupRule for NoDistractingElements {
+    fn name(&self) -> &'static str {
+        META.name
+    }
+
+    fn enter_element<'a>(&self, ctx: &mut MarkupContext<'_, 'a>, element: &MarkupElement<'a>) {
+        if element.is_component() {
+            return;
+        }
+        let tag = element.tag();
+        if Self::is_distracting(tag) {
+            let message = ctx
+                .lint()
+                .t_fmt("a11y/no-distracting-elements.message", &[("tag", tag)]);
+            let help = ctx.lint().t("a11y/no-distracting-elements.help");
+            ctx.lint().warn_at_with_help(message, element.range(), help);
+        }
+    }
+}
+
 impl Rule for NoDistractingElements {
     fn meta(&self) -> &'static RuleMeta {
         &META
+    }
+
+    fn as_markup_rule(&self) -> Option<&dyn MarkupRule> {
+        Some(self)
     }
 
     fn enter_element<'a>(&self, ctx: &mut LintContext<'a>, element: &ElementNode<'a>) {

--- a/crates/vize_patina/src/rules/a11y/tabindex_no_positive.rs
+++ b/crates/vize_patina/src/rules/a11y/tabindex_no_positive.rs
@@ -9,6 +9,7 @@
 
 use crate::context::LintContext;
 use crate::diagnostic::Severity;
+use crate::markup::{MarkupBinding, MarkupContext, MarkupElement, MarkupRule};
 use crate::rule::{Rule, RuleCategory, RuleMeta};
 use vize_relief::ast::{ElementNode, PropNode};
 
@@ -24,9 +25,52 @@ static META: RuleMeta = RuleMeta {
 #[derive(Default)]
 pub struct TabindexNoPositive;
 
+impl TabindexNoPositive {
+    /// Whether a statically-written `tabindex` value parses to a positive int.
+    fn is_positive(value: &str) -> bool {
+        value.parse::<i32>().is_ok_and(|num| num > 0)
+    }
+}
+
+/// Markup-IR entry point for `a11y/tabindex-no-positive`.
+///
+/// Inspects the statically-written `tabindex` value on both backends: a Vue
+/// `tabindex="1"` and a JSX `tabIndex="1"` both surface a static binding value
+/// of `"1"`. A JSX numeric-expression `tabIndex={1}` has no static string value,
+/// so — exactly like the legacy template path, which only reads static
+/// attribute text — it is not flagged here.
+impl MarkupRule for TabindexNoPositive {
+    fn name(&self) -> &'static str {
+        META.name
+    }
+
+    fn enter_binding<'a>(
+        &self,
+        ctx: &mut MarkupContext<'_, 'a>,
+        _element: &MarkupElement<'a>,
+        binding: &MarkupBinding<'a>,
+    ) {
+        if !binding.arg_name_eq("tabindex") {
+            return;
+        }
+        let Some(value) = binding.static_value() else {
+            return;
+        };
+        if Self::is_positive(value) {
+            let message = ctx.lint().t("a11y/tabindex-no-positive.message");
+            let help = ctx.lint().t("a11y/tabindex-no-positive.help");
+            ctx.lint().warn_at_with_help(message, binding.range(), help);
+        }
+    }
+}
+
 impl Rule for TabindexNoPositive {
     fn meta(&self) -> &'static RuleMeta {
         &META
+    }
+
+    fn as_markup_rule(&self) -> Option<&dyn MarkupRule> {
+        Some(self)
     }
 
     fn enter_element<'a>(&self, ctx: &mut LintContext<'a>, element: &ElementNode<'a>) {

--- a/crates/vize_patina/src/rules/html/deprecated_element.rs
+++ b/crates/vize_patina/src/rules/html/deprecated_element.rs
@@ -24,6 +24,7 @@
 
 use crate::context::LintContext;
 use crate::diagnostic::Severity;
+use crate::markup::{MarkupContext, MarkupElement, MarkupRule};
 use crate::rule::{Rule, RuleCategory, RuleMeta};
 use vize_relief::ast::{ElementNode, ElementType};
 
@@ -40,9 +41,40 @@ static META: RuleMeta = RuleMeta {
 #[derive(Default)]
 pub struct DeprecatedElement;
 
+/// Markup-IR entry point for `html/deprecated-element`.
+///
+/// HTML conformance is purely tag-driven, so the same lookup runs over a Vue
+/// template `<center>` and a JSX `<center />`. Components are exempt on both
+/// backends ([`MarkupElement::is_component`]), and `DEPRECATED_ELEMENTS` is an
+/// HTML-name set so the JSX lowercase-intrinsic convention lines up.
+impl MarkupRule for DeprecatedElement {
+    fn name(&self) -> &'static str {
+        META.name
+    }
+
+    fn enter_element<'a>(&self, ctx: &mut MarkupContext<'_, 'a>, element: &MarkupElement<'a>) {
+        if element.is_component() {
+            return;
+        }
+
+        let tag = element.tag();
+        if DEPRECATED_ELEMENTS.contains(&tag) {
+            let message = ctx
+                .lint()
+                .t_fmt("html/deprecated-element.message", &[("tag", tag)]);
+            let help = ctx.lint().t("html/deprecated-element.help");
+            ctx.lint().warn_at_with_help(message, element.range(), help);
+        }
+    }
+}
+
 impl Rule for DeprecatedElement {
     fn meta(&self) -> &'static RuleMeta {
         &META
+    }
+
+    fn as_markup_rule(&self) -> Option<&dyn MarkupRule> {
+        Some(self)
     }
 
     fn enter_element<'a>(&self, ctx: &mut LintContext<'a>, element: &ElementNode<'a>) {

--- a/crates/vize_patina/src/rules/opinionated/vapor/prefer_static_class.rs
+++ b/crates/vize_patina/src/rules/opinionated/vapor/prefer_static_class.rs
@@ -92,6 +92,10 @@ impl Rule for PreferStaticClass {
         &META
     }
 
+    fn as_markup_rule(&self) -> Option<&dyn MarkupRule> {
+        Some(self)
+    }
+
     fn check_directive<'a>(
         &self,
         ctx: &mut LintContext<'a>,

--- a/crates/vize_patina/src/rules/vapor/no_vue_lifecycle_events.rs
+++ b/crates/vize_patina/src/rules/vapor/no_vue_lifecycle_events.rs
@@ -83,6 +83,10 @@ impl Rule for NoVueLifecycleEvents {
         &META
     }
 
+    fn as_markup_rule(&self) -> Option<&dyn MarkupRule> {
+        Some(self)
+    }
+
     fn check_directive<'a>(
         &self,
         ctx: &mut LintContext<'a>,

--- a/crates/vize_patina/src/rules/vue/require_v_for_key.rs
+++ b/crates/vize_patina/src/rules/vue/require_v_for_key.rs
@@ -98,6 +98,17 @@ impl Rule for RequireVForKey {
         &META
     }
 
+    fn as_markup_rule(&self) -> Option<&dyn MarkupRule> {
+        Some(self)
+    }
+
+    fn jsx_needs_lowering(&self) -> bool {
+        // `v-for`'s JSX form is `items.map(…)`, which is a JS expression with no
+        // list scope until lowering. The `enter_list` hook only fires over the
+        // lowered relief AST, so route this rule there for JSX.
+        true
+    }
+
     fn check_directive<'a>(
         &self,
         ctx: &mut LintContext<'a>,

--- a/crates/vize_patina/src/visitor.rs
+++ b/crates/vize_patina/src/visitor.rs
@@ -18,6 +18,12 @@ pub struct LintVisitor<'a, 'ctx, 'rules> {
     run_exit_element_rules: bool,
     /// When true, suppress all diagnostics for the next element
     forget_next_element: bool,
+    /// Optional per-rule keep mask, parallel to `rules`. When `Some`, a rule is
+    /// dispatched only where its entry is `true`. Used by the JSX/TSX fallback
+    /// lowering pass to skip rules already handled by the zero-cost markup IR
+    /// pass, so a migrated rule never reports twice. `None` (the common
+    /// template path) runs every rule with no extra work.
+    keep_mask: Option<&'rules [bool]>,
 }
 
 impl<'a, 'ctx, 'rules> LintVisitor<'a, 'ctx, 'rules> {
@@ -35,6 +41,45 @@ impl<'a, 'ctx, 'rules> LintVisitor<'a, 'ctx, 'rules> {
             rule_names,
             run_exit_element_rules,
             forget_next_element: false,
+            keep_mask: None,
+        }
+    }
+
+    /// Create a visitor that dispatches only the rules whose `keep_mask` entry
+    /// is `true`. The mask must be the same length as `rules`.
+    ///
+    /// The JSX/TSX lint path uses this for its fallback lowering pass: rules
+    /// that already ran over the zero-cost markup IR are masked out here so a
+    /// migrated rule produces exactly one diagnostic, not one per backend.
+    #[inline]
+    pub fn with_rule_filter(
+        ctx: &'ctx mut LintContext<'a>,
+        rules: &'rules [Box<dyn Rule>],
+        rule_names: &'rules [&'static str],
+        run_exit_element_rules: bool,
+        keep_mask: &'rules [bool],
+    ) -> Self {
+        Self {
+            ctx,
+            rules,
+            rule_names,
+            run_exit_element_rules,
+            forget_next_element: false,
+            keep_mask: Some(keep_mask),
+        }
+    }
+
+    /// Whether the rule at `index` is active under the current [`Self::keep_mask`].
+    ///
+    /// Hot path: with no mask (the common template path) this is a constant
+    /// `true`; the JSX fallback pass uses it to skip rules the markup IR pass
+    /// already handled. Reads only `keep_mask`, so it does not conflict with the
+    /// `&mut self.ctx` the dispatch loops hold.
+    #[inline]
+    fn rule_active(keep_mask: Option<&[bool]>, index: usize) -> bool {
+        match keep_mask {
+            Some(mask) => mask[index],
+            None => true,
         }
     }
 
@@ -52,8 +97,17 @@ impl<'a, 'ctx, 'rules> LintVisitor<'a, 'ctx, 'rules> {
         // Run template-level checks under one profiling span. Rule dispatch
         // happens for every file, so profiling once around the callback batch is
         // cheaper than creating a span for every individual rule callback.
+        let keep_mask = self.keep_mask;
         profile!("patina.rules.run_on_template", {
-            for (rule, rule_name) in self.rules.iter().zip(self.rule_names.iter().copied()) {
+            for (index, (rule, rule_name)) in self
+                .rules
+                .iter()
+                .zip(self.rule_names.iter().copied())
+                .enumerate()
+            {
+                if !Self::rule_active(keep_mask, index) {
+                    continue;
+                }
                 self.ctx.current_rule = rule_name;
                 rule.run_on_template(self.ctx, root);
             }
@@ -198,9 +252,17 @@ impl<'a, 'ctx, 'rules> LintVisitor<'a, 'ctx, 'rules> {
                 // Coalesce all interpolation rule callbacks into one span for
                 // the same reason as template-level checks: callback dispatch is
                 // hot and individual rule spans add measurable overhead.
+                let keep_mask = self.keep_mask;
                 profile!("patina.rules.check_interpolation", {
-                    for (rule, rule_name) in self.rules.iter().zip(self.rule_names.iter().copied())
+                    for (index, (rule, rule_name)) in self
+                        .rules
+                        .iter()
+                        .zip(self.rule_names.iter().copied())
+                        .enumerate()
                     {
+                        if !Self::rule_active(keep_mask, index) {
+                            continue;
+                        }
                         self.ctx.current_rule = rule_name;
                         rule.check_interpolation(self.ctx, interp);
                     }
@@ -336,8 +398,17 @@ impl<'a, 'ctx, 'rules> LintVisitor<'a, 'ctx, 'rules> {
         // Enter element - run rules. Element/directive/exit/branch callbacks
         // follow the same coalesced-span pattern as root/interpolation checks:
         // one guard around the rule batch, not one guard per rule.
+        let keep_mask = self.keep_mask;
         profile!("patina.rules.enter_element", {
-            for (rule, rule_name) in self.rules.iter().zip(self.rule_names.iter().copied()) {
+            for (index, (rule, rule_name)) in self
+                .rules
+                .iter()
+                .zip(self.rule_names.iter().copied())
+                .enumerate()
+            {
+                if !Self::rule_active(keep_mask, index) {
+                    continue;
+                }
                 self.ctx.current_rule = rule_name;
                 rule.enter_element(self.ctx, el);
             }
@@ -347,8 +418,15 @@ impl<'a, 'ctx, 'rules> LintVisitor<'a, 'ctx, 'rules> {
         for prop in el.props.iter() {
             if let PropNode::Directive(dir) = prop {
                 profile!("patina.rules.check_directive", {
-                    for (rule, rule_name) in self.rules.iter().zip(self.rule_names.iter().copied())
+                    for (index, (rule, rule_name)) in self
+                        .rules
+                        .iter()
+                        .zip(self.rule_names.iter().copied())
+                        .enumerate()
                     {
+                        if !Self::rule_active(keep_mask, index) {
+                            continue;
+                        }
                         self.ctx.current_rule = rule_name;
                         rule.check_directive(self.ctx, el, dir);
                     }
@@ -364,7 +442,15 @@ impl<'a, 'ctx, 'rules> LintVisitor<'a, 'ctx, 'rules> {
         if self.run_exit_element_rules {
             // Exit element - run rules
             profile!("patina.rules.exit_element", {
-                for (rule, rule_name) in self.rules.iter().zip(self.rule_names.iter().copied()) {
+                for (index, (rule, rule_name)) in self
+                    .rules
+                    .iter()
+                    .zip(self.rule_names.iter().copied())
+                    .enumerate()
+                {
+                    if !Self::rule_active(keep_mask, index) {
+                        continue;
+                    }
                     self.ctx.current_rule = rule_name;
                     rule.exit_element(self.ctx, el);
                 }
@@ -377,8 +463,17 @@ impl<'a, 'ctx, 'rules> LintVisitor<'a, 'ctx, 'rules> {
     #[inline]
     fn visit_if(&mut self, if_node: &vize_relief::ast::IfNode<'a>) {
         // Run if checks
+        let keep_mask = self.keep_mask;
         profile!("patina.rules.check_if", {
-            for (rule, rule_name) in self.rules.iter().zip(self.rule_names.iter().copied()) {
+            for (index, (rule, rule_name)) in self
+                .rules
+                .iter()
+                .zip(self.rule_names.iter().copied())
+                .enumerate()
+            {
+                if !Self::rule_active(keep_mask, index) {
+                    continue;
+                }
                 self.ctx.current_rule = rule_name;
                 rule.check_if(self.ctx, if_node);
             }
@@ -395,8 +490,17 @@ impl<'a, 'ctx, 'rules> LintVisitor<'a, 'ctx, 'rules> {
     #[inline]
     fn visit_for(&mut self, for_node: &vize_relief::ast::ForNode<'a>) {
         // Run for checks
+        let keep_mask = self.keep_mask;
         profile!("patina.rules.check_for", {
-            for (rule, rule_name) in self.rules.iter().zip(self.rule_names.iter().copied()) {
+            for (index, (rule, rule_name)) in self
+                .rules
+                .iter()
+                .zip(self.rule_names.iter().copied())
+                .enumerate()
+            {
+                if !Self::rule_active(keep_mask, index) {
+                    continue;
+                }
                 self.ctx.current_rule = rule_name;
                 rule.check_for(self.ctx, for_node);
             }


### PR DESCRIPTION
Closes #1499.

Runs Patina rules over `.jsx`/`.tsx` via `MarkupDocument::from_jsx` — the borrow-based projection straight off the OXC AST — so the common lint path never reconstructs a synthetic relief template. The lowering path remains only as a fallback for the few rules whose JSX shape needs it (or that aren't migrated yet).

## What's implemented

- **`Rule::as_markup_rule()`** (default `None`): a rule that also implements `MarkupRule` overrides it to `Some(self)`, opting into the zero-cost IR path. **`Rule::jsx_needs_lowering()`** (default `false`) flags the rare structural rule whose JSX equivalent only materializes after lowering (`v-for` ⇄ `items.map(…)`).
- **`Linter::lint_jsx` rewritten** to parse the OXC program once and partition the active rules into three disjoint groups so each fires exactly once (no double-report):
  - `ir` — markup-capable, run over the OXC projection (`MarkupDocument::from_jsx`), **no template AST**;
  - `lowered` — markup-capable but needing the lowered list/branch shape, driven over the lowered relief AST **through the same markup visitor** (keeps reporting unified);
  - `legacy` — no markup entry point, served by the lowering fallback.
  Lowering is skipped entirely when every active rule is OXC-capable.
- **Rule migrations** to `MarkupRule` (reusing existing logic; legacy `Rule` impls kept intact for template compat): `a11y/no-autofocus`, `a11y/no-access-key`, `a11y/no-distracting-elements`, `a11y/tabindex-no-positive`, `html/deprecated-element`. The four pre-migrated rules from #1540 (`a11y/img-alt`, `vue/require-v-for-key`, `vapor/no-vue-lifecycle-events`, `vapor/prefer-static-class`) are now wired into the path via `as_markup_rule()`.
- **Croquis** is attached to the JSX markup document when a semantic rule is active (new public `vize_atelier_jsx::analyze_jsx_program`, reusing the already-parsed program — no second parse), so binding/type-aware markup rules reach the same analysis the lowering pipeline sees.
- **`LintVisitor::with_rule_filter`** drives the legacy fallback over a rule subset without reordering the registry; the template hot path is untouched (mask is `None` there).
- Diagnostics/fix ranges carry `ByteRange`s that address the original JSX/TSX bytes.

## Verify-real

- `cargo test -p vize_patina`: **1139 pass** (was 1124 baseline; +15 net). New `linter::tests::jsx` (18 tests) cover: migrated rules firing on `.jsx`/`.tsx` via the IR path (img-alt, no-autofocus incl. camelCase `autoFocus`, no-access-key `accessKey`, tabindex `tabIndex`, deprecated-element, no-distracting-elements + component-exemption); `require-v-for-key` catching JSX `.map()` keyless via the lowered-markup path; diagnostic ranges pointing at the `<img>` source; "reports once, not per backend"; the fallback (`vue/a11y-img-alt`) still firing; IR + fallback rules coexisting in one pass; and `vue/no-v-html` documented as a silent no-op on JSX.
- **Bench** (`markup_ir_bench`, new `jsx_lint` group): IR projection ≈ **81µs** vs lowering fallback ≈ **409µs** on an 80-`<figure>` module — ~5x faster, confirming the IR path skips the allocation-heavy template rebuild. The bench asserts both arms agree on the diagnostic count.

## Deferred (honest)

- Only a representative set of rules is migrated to `MarkupRule`. The remaining directive/v-model/slot/event and a11y/HTML rules still run via the **lowering fallback** on JSX (they work — just not yet on the zero-cost path). The infrastructure (`as_markup_rule` / `jsx_needs_lowering` / three-group dispatch) makes each further migration a localized change with no engine churn.
- `require-v-for-key` uses the lowered-markup path for JSX because `.map()` is a JS expression with no list scope pre-lowering; this is intrinsic (not avoidable reconstruction) and is documented on `jsx_needs_lowering`.
- `prefer-static-class`'s IR entry point reports through `ByteRange`s but its **autofix** still rides the legacy `Rule` path (pre-existing from #1540), so JSX gets the diagnostic without the class-rewrite fix.
- Autofix coverage for the newly-migrated rules is unchanged (they were non-fixable already).

## Gates

- fmt: `RUSTFMT=…1.95.0…/rustfmt cargo fmt -p vize_patina -- --check` clean (rustfmt **1.9.0**); `-p vize_atelier_jsx` clean.
- clippy: `cargo clippy --workspace -- -D warnings` clean (also per-crate lib form); zero new disallowed-macro/type hits.
- tests: `cargo test -p vize_patina -p vize_atelier_jsx` green.
- semver: `cargo semver-checks check-release -p vize_patina` → additive (no update required); all new `Rule`/registry/visitor methods have defaults.
- `cargo build --workspace` clean; no external callers of the changed APIs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1548"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->