### PR TITLE
feat(atelier): Vapor SSR control-flow and slots for JSX (#1533)

### DIFF
--- a/crates/vize_atelier_jsx/src/lower/control_flow.rs
+++ b/crates/vize_atelier_jsx/src/lower/control_flow.rs
@@ -49,7 +49,11 @@ impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
         self.lower_control_flow_expr(expr, container_span)
     }
 
-    fn lower_control_flow_expr(
+    /// Lower an arbitrary expression as JSX control flow (`&&`, `?:`, `.map`)
+    /// against `container_span`, or `None` when it is not a recognized pattern.
+    /// Shared with slot-body lowering ([`super::slot`]) so a `.map`/conditional
+    /// rendered inside a slot reuses the same If/For relief lowering.
+    pub(crate) fn lower_control_flow_expr(
         &mut self,
         expr: &Expression<'_>,
         container_span: Span,
@@ -83,45 +87,83 @@ impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
         }
     }
 
-    /// `test ? consequent : alternate` -> two-branch `IfNode`, but only if at
+    /// `test ? consequent : alternate` -> a multi-branch `IfNode`, but only if at
     /// least one arm is JSX (otherwise it is an ordinary value expression that
     /// belongs in interpolation).
+    ///
+    /// A nested ternary in the alternate (`a ? <A/> : b ? <B/> : <C/>`) is the
+    /// idiomatic JSX `v-else-if` chain, so it is flattened into the *same*
+    /// `IfNode` as additional condition-carrying branches rather than nested as
+    /// a child. That matches the `if / else if / else` shape both the SSR and
+    /// client codegen already lower, and — critically — avoids re-slicing the
+    /// nested ternary's raw source into an interpolation expression, which is
+    /// invalid JS (`{a ? <A/> : ...}` embeds JSX in a string) and crashes the
+    /// client transform.
     fn lower_conditional(
         &mut self,
         conditional: &ConditionalExpression<'_>,
         container_span: Span,
     ) -> Option<TemplateChildNode<'a>> {
-        let consequent_is_jsx = is_jsx(unwrap_parens(&conditional.consequent));
-        let alternate_is_jsx = is_jsx(unwrap_parens(&conditional.alternate));
-        if !consequent_is_jsx && !alternate_is_jsx {
+        if !self.conditional_has_jsx_arm(conditional) {
             return None;
         }
 
-        let consequent_child = self.lower_branch_child(&conditional.consequent);
-        let alternate_child = self.lower_branch_child(&conditional.alternate);
-
         let mut if_node = IfNode::new(self.bump(), self.mapper().location(container_span));
+        self.push_conditional_branches(&mut if_node, conditional);
+        Some(TemplateChildNode::If(Box::new_in(if_node, self.bump())))
+    }
 
-        // Branch 0: the `test` condition.
+    /// Whether a conditional renders JSX in either arm (recursing through a
+    /// nested ternary alternate), i.e. it is conditional *rendering* and not a
+    /// plain value expression. A bare-value ternary (`a ? x : y`) stays
+    /// interpolation, preserving today's behavior.
+    fn conditional_has_jsx_arm(&self, conditional: &ConditionalExpression<'_>) -> bool {
+        if is_jsx(unwrap_parens(&conditional.consequent)) {
+            return true;
+        }
+        match unwrap_parens(&conditional.alternate) {
+            Expression::ConditionalExpression(nested) => self.conditional_has_jsx_arm(nested),
+            other => is_jsx(other),
+        }
+    }
+
+    /// Append the `if` / `else if` / `else` branches of a (possibly nested)
+    /// ternary to `if_node`. The first call contributes the `if` branch; a
+    /// nested ternary alternate recurses to contribute `else if` branches; a
+    /// non-ternary alternate becomes the final condition-less `else` branch.
+    fn push_conditional_branches(
+        &mut self,
+        if_node: &mut IfNode<'a>,
+        conditional: &ConditionalExpression<'_>,
+    ) {
+        // Condition-carrying branch for `test`.
+        let consequent_child = self.lower_branch_child(&conditional.consequent);
         let condition = self.dyn_expr(conditional.test.span());
-        let mut then_branch = IfBranchNode::new(
+        let mut branch = IfBranchNode::new(
             self.bump(),
             Some(condition),
             self.mapper().location(conditional.consequent.span()),
         );
-        then_branch.children.push(consequent_child);
-        if_node.branches.push(then_branch);
+        branch.children.push(consequent_child);
+        if_node.branches.push(branch);
 
-        // Branch 1: the `else` branch (no condition).
-        let mut else_branch = IfBranchNode::new(
-            self.bump(),
-            None,
-            self.mapper().location(conditional.alternate.span()),
-        );
-        else_branch.children.push(alternate_child);
-        if_node.branches.push(else_branch);
-
-        Some(TemplateChildNode::If(Box::new_in(if_node, self.bump())))
+        // Flatten a nested ternary alternate into further `else if` branches;
+        // otherwise emit the terminal `else` branch.
+        match unwrap_parens(&conditional.alternate) {
+            Expression::ConditionalExpression(nested) => {
+                self.push_conditional_branches(if_node, nested);
+            }
+            _ => {
+                let alternate_child = self.lower_branch_child(&conditional.alternate);
+                let mut else_branch = IfBranchNode::new(
+                    self.bump(),
+                    None,
+                    self.mapper().location(conditional.alternate.span()),
+                );
+                else_branch.children.push(alternate_child);
+                if_node.branches.push(else_branch);
+            }
+        }
     }
 
     /// `<expr>.map((value, index) => <jsx/>)` -> `ForNode`.
@@ -240,12 +282,22 @@ impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
         }
     }
 
-    /// Lower a conditional arm: JSX becomes an element child; anything else
-    /// reuses the interpolation path so non-JSX arms stay correct text.
+    /// Lower a conditional arm into a single child. JSX becomes an element
+    /// child; a `&&` / `.map(...)` arm recurses into nested control flow (so an
+    /// arm like `cond && <X/>` or `items.map(...)` renders correctly instead of
+    /// being sliced into an invalid interpolation expression); anything else
+    /// reuses the interpolation path so non-JSX value arms stay correct text.
     fn lower_branch_child(&mut self, expr: &Expression<'_>) -> TemplateChildNode<'a> {
-        match unwrap_parens(expr) {
+        let inner = unwrap_parens(expr);
+        match inner {
             Expression::JSXElement(element) => self.element_child(element),
             Expression::JSXFragment(fragment) => self.fragment_child(fragment),
+            Expression::LogicalExpression(_) | Expression::CallExpression(_) => self
+                .lower_control_flow_expr(inner, inner.span())
+                .unwrap_or_else(|| {
+                    let content = self.dyn_expr(inner.span());
+                    self.interpolation_child(content, inner.span())
+                }),
             other => {
                 let content = self.dyn_expr(other.span());
                 self.interpolation_child(content, other.span())

--- a/crates/vize_atelier_jsx/src/lower/slot.rs
+++ b/crates/vize_atelier_jsx/src/lower/slot.rs
@@ -181,29 +181,39 @@ impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
     /// Lower the body of a slot function into template children.
     ///
     /// Expression-body arrows (`() => <p/>`) reach the returned expression;
-    /// block bodies (`() => { return <p/>; }`) reach the `return` argument.
-    /// Only JSX elements/fragments are lowered as slot content; anything else
-    /// is reported and produces an empty body.
+    /// block bodies (`() => { return <p/>; }`) reach the `return` argument. A
+    /// JSX element/fragment becomes the slot content directly; a control-flow
+    /// expression (`(rows) => rows.map(...)`, a conditional, or `&&`) reuses the
+    /// shared control-flow lowering so a list/conditional rendered inside a slot
+    /// works the same as one rendered as an ordinary child. Anything else
+    /// produces an empty body.
     fn extract_fn_slot_body(&mut self, slot_fn: &SlotFn<'_>) -> Vec<'a, TemplateChildNode<'a>> {
-        match slot_fn.return_expr {
-            Some(Expression::JSXElement(element)) => {
-                let mut out = Vec::new_in(self.bump());
+        let mut out = Vec::new_in(self.bump());
+        let Some(expr) = slot_fn.return_expr else {
+            return out;
+        };
+        match expr.get_inner_expression() {
+            Expression::JSXElement(element) => {
                 out.push(TemplateChildNode::Element(Box::new_in(
                     self.lower_element_node(element),
                     self.bump(),
                 )));
-                out
             }
-            Some(Expression::JSXFragment(fragment)) => {
-                let mut out = Vec::new_in(self.bump());
+            Expression::JSXFragment(fragment) => {
                 out.push(TemplateChildNode::Element(Box::new_in(
                     self.lower_fragment_node(fragment),
                     self.bump(),
                 )));
-                out
             }
-            _ => Vec::new_in(self.bump()),
+            // `&&` / ternary / `.map(...)` slot bodies lower to the same
+            // If/For relief children as control-flow expression children.
+            other => {
+                if let Some(child) = self.lower_control_flow_expr(other, other.span()) {
+                    out.push(child);
+                }
+            }
         }
+        out
     }
 }
 

--- a/crates/vize_atelier_jsx/tests/control_flow.rs
+++ b/crates/vize_atelier_jsx/tests/control_flow.rs
@@ -108,3 +108,40 @@ fn vapor_map_uses_create_for() {
     assert!(code.contains("items") && !code.contains("_ctx."), "{code}");
     assert!(code.contains("\"<li></li>\""), "{code}");
 }
+
+// 9. A nested ternary in the alternate is the idiomatic `v-else-if` chain and
+//    flattens into one IfNode with multiple branches — rather than slicing the
+//    inner ternary into an interpolation expression (invalid JS embedding the
+//    JSX), which previously overflowed the Vapor transform's stack. Each arm's
+//    element must be reachable as a conditional VNode/template.
+#[test]
+fn nested_ternary_alternate_flattens_to_else_if_chain() {
+    let code = dom("const A = () => <div>{a ? <p/> : b ? <em/> : <span/>}</div>;");
+    assert!(!code.contains("_toDisplayString"), "{code}");
+    assert!(code.contains("_createElementBlock(\"p\""), "{code}");
+    assert!(code.contains("_createElementBlock(\"em\""), "{code}");
+    assert!(code.contains("_createElementBlock(\"span\""), "{code}");
+    assert!(code.contains("(a)") && code.contains("(b)"), "{code}");
+}
+
+// 10. Vapor parity for the nested ternary: it lowers to nested `createIf`
+//     without crashing, and conditions stay bare under JSX closure semantics.
+#[test]
+fn vapor_nested_ternary_uses_nested_create_if() {
+    let code = vapor("const A = () => <div>{a ? <p/> : b ? <em/> : <span/>}</div>;");
+    assert!(code.contains("_createIf(() => (a)"), "{code}");
+    assert!(code.contains("_createIf(() => (b)"), "{code}");
+    assert!(!code.contains("_ctx."), "{code}");
+}
+
+// 11. A `&&` arm inside a ternary recurses into a nested v-if instead of being
+//     mis-lowered as text.
+#[test]
+fn logical_and_arm_inside_ternary_recurses() {
+    let code = dom("const A = () => <div>{a ? <p/> : (cond && <span/>)}</div>;");
+    assert!(!code.contains("_toDisplayString"), "{code}");
+    assert!(code.contains("_createElementBlock(\"p\""), "{code}");
+    assert!(code.contains("_createElementBlock(\"span\""), "{code}");
+    // The `&&` arm contributes its own v-if comment fallback.
+    assert!(code.contains("_createCommentVNode(\"v-if\""), "{code}");
+}

--- a/crates/vize_atelier_jsx/tests/vapor_ssr.rs
+++ b/crates/vize_atelier_jsx/tests/vapor_ssr.rs
@@ -1,11 +1,18 @@
-//! JSX/TSX -> Vue Vapor **SSR** render codegen (#1533, first cut).
+//! JSX/TSX -> Vue Vapor **SSR** render codegen (#1533).
 //!
 //! When [`VaporCompileOptions::ssr`] is set, a JSX/Vapor component is
 //! server-rendered: [`vize_atelier_ssr`]'s `ssrRender` codegen is reused to emit
 //! an HTML-string render function (`_push(`…`)`) instead of the client Vapor IR
-//! pipeline. These tests pin the implemented first-cut subset — static elements,
-//! static + dynamic attributes, and text interpolation — and guard that the
-//! normal client Vapor output is unchanged when SSR is off.
+//! pipeline. These tests pin the implemented subset — static elements, static +
+//! dynamic attributes, text interpolation, **control flow** (`&&` / ternary
+//! v-if, `.map` v-for), and **slots** (default scoped + named/object slots),
+//! plus nested-component invocation — and guard that the normal client Vapor
+//! output is unchanged when SSR is off.
+//!
+//! Control flow and slots reuse the shared SSR engine end to end: JSX lowering
+//! already produces the same `IfNode` / `ForNode` / `<template v-slot>`
+//! structures the SFC SSR path emits, so `SsrCodegenContext::generate` renders
+//! them without a JSX-specific codegen fork.
 
 use vize_atelier_jsx::{JsxLang, JsxOutputMode, VaporCompileOptions, compile_to_vapor};
 use vize_carton::Bump;
@@ -158,4 +165,169 @@ fn client_output_is_unchanged_when_ssr_is_off() {
 fn client_and_ssr_outputs_differ_for_the_same_source() {
     let src = "const A = () => <div>{msg}</div>;";
     assert_ne!(ssr(src).as_str(), client(src).as_str());
+}
+
+// ---------------------------------------------------------------------------
+// Control flow (#1533): `&&` / ternary -> SSR `if`/`else`; `.map` -> for list.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn ssr_renders_logical_and_as_a_conditional_push() {
+    // `{cond && <span/>}` lowers to a single-branch IfNode; the SSR engine emits
+    // an `if` with the absent branch rendering the `<!---->` v-if placeholder.
+    let code = ssr("const A = () => <div>{cond && <span>yes</span>}</div>;");
+    assert!(code.contains("if (cond) {"), "{code}");
+    assert!(code.contains("_push(`<span>yes</span>`)"), "{code}");
+    assert!(code.contains("_push(`<!---->`)"), "{code}");
+    // Closure semantics: the condition stays bare, never `_ctx.`-prefixed.
+    assert!(!code.contains("_ctx."), "{code}");
+}
+
+#[test]
+fn ssr_renders_a_ternary_as_two_branches() {
+    let code = ssr("const A = () => <div>{cond ? <span>a</span> : <em>b</em>}</div>;");
+    assert!(code.contains("if (cond) {"), "{code}");
+    assert!(code.contains("_push(`<span>a</span>`)"), "{code}");
+    assert!(code.contains("} else {"), "{code}");
+    assert!(code.contains("_push(`<em>b</em>`)"), "{code}");
+}
+
+#[test]
+fn ssr_renders_a_map_call_as_a_render_list() {
+    // `{items.map((i) => <li>{i}</li>)}` -> `_ssrRenderList` with fragment markers
+    // and the inner interpolation rendered server-side.
+    let code = ssr("const A = () => <ul>{items.map((i) => <li>{i}</li>)}</ul>;");
+    assert!(code.contains("_ssrRenderList(items, (i) =>"), "{code}");
+    assert!(code.contains("_ssrInterpolate(i)"), "{code}");
+    assert!(
+        code.contains("from \"@vue/server-renderer\"") && code.contains("ssrRenderList"),
+        "{code}"
+    );
+    assert!(!code.contains("_ctx."), "{code}");
+}
+
+#[test]
+fn ssr_renders_a_map_of_components_as_a_render_list_of_components() {
+    let code = ssr("const A = () => <ul>{rows.map((row) => <Item data={row}/>)}</ul>;");
+    assert!(code.contains("_ssrRenderList(rows, (row) =>"), "{code}");
+    assert!(
+        code.contains("_ssrRenderComponent(_resolveComponent(\"Item\")"),
+        "{code}"
+    );
+    assert!(code.contains("data: row"), "{code}");
+}
+
+#[test]
+fn ssr_flattens_a_nested_ternary_into_an_else_if_chain() {
+    // Regression for the nested-ternary alternate: previously the inner ternary
+    // was sliced into an interpolation expression (`_ssrInterpolate(b ? <em/> :
+    // <span/>)`, invalid JS) on SSR and crashed the client transform. It now
+    // flattens into a real `if / else if / else` chain.
+    let code = ssr("const A = () => <div>{a ? <p>A</p> : b ? <em>B</em> : <span>C</span>}</div>;");
+    assert!(code.contains("if (a) {"), "{code}");
+    assert!(code.contains("} else if (b) {"), "{code}");
+    assert!(code.contains("} else {"), "{code}");
+    assert!(code.contains("_push(`<p>A</p>`)"), "{code}");
+    assert!(code.contains("_push(`<em>B</em>`)"), "{code}");
+    assert!(code.contains("_push(`<span>C</span>`)"), "{code}");
+    // The nested ternary must NOT survive as embedded JSX in an interpolation.
+    assert!(!code.contains("_ssrInterpolate(b"), "{code}");
+    assert!(!code.contains("<em>B</em> :"), "{code}");
+}
+
+// ---------------------------------------------------------------------------
+// Slots (#1533): default scoped + named/object slots render server-side.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn ssr_renders_a_default_scoped_slot() {
+    // `<List>{(item) => <li>{item}</li>}</List>` lowers to a `<template v-slot>`
+    // whose SSR codegen is the standard `_ssrRenderComponent(..., { default:
+    // _withCtx(...) })` shape, with the scoped param threaded through bare.
+    let code = ssr("const A = () => <List>{(item) => <li>{item}</li>}</List>;");
+    assert!(
+        code.contains("_ssrRenderComponent(_resolveComponent(\"List\")"),
+        "{code}"
+    );
+    assert!(
+        code.contains("default: _withCtx((item, _push, _parent, _scopeId) =>"),
+        "{code}"
+    );
+    assert!(
+        code.contains("_push(`<li>${_ssrInterpolate(item)}</li>`)"),
+        "{code}"
+    );
+    assert!(!code.contains("_ctx.item"), "{code}");
+}
+
+#[test]
+fn ssr_renders_named_object_slots() {
+    let code = ssr(
+        "const A = () => <Comp>{{ header: () => <h1>H</h1>, default: () => <p>P</p> }}</Comp>;",
+    );
+    assert!(
+        code.contains("_ssrRenderComponent(_resolveComponent(\"Comp\")"),
+        "{code}"
+    );
+    assert!(code.contains("header: _withCtx("), "{code}");
+    assert!(code.contains("default: _withCtx("), "{code}");
+    assert!(code.contains("_push(`<h1>H</h1>`)"), "{code}");
+    assert!(code.contains("_push(`<p>P</p>`)"), "{code}");
+}
+
+#[test]
+fn ssr_renders_a_nested_component_invocation() {
+    // A component used as a plain child renders through `_ssrRenderComponent`,
+    // with its bound prop kept as a bare closure reference.
+    let code = ssr("const A = () => <div><Child msg={x}/></div>;");
+    assert!(code.contains("_push(`<div"), "{code}");
+    assert!(
+        code.contains("_ssrRenderComponent(_resolveComponent(\"Child\")"),
+        "{code}"
+    );
+    assert!(code.contains("msg: x"), "{code}");
+    assert!(!code.contains("_ctx.x"), "{code}");
+}
+
+#[test]
+fn ssr_combines_control_flow_and_slots_in_one_component() {
+    // Headline composite: a component whose default scoped slot body itself uses
+    // `.map` — both the slot and the nested for-list render server-side.
+    let code = ssr("const A = () => <List>{(rows) => rows.map((r) => <li>{r}</li>)}</List>;");
+    assert!(
+        code.contains("default: _withCtx((rows, _push, _parent, _scopeId) =>"),
+        "{code}"
+    );
+    assert!(code.contains("_ssrRenderList(rows, (r) =>"), "{code}");
+    assert!(code.contains("_ssrInterpolate(r)"), "{code}");
+}
+
+// ---------------------------------------------------------------------------
+// Client parity: control flow / slots stay on the client Vapor IR when SSR off.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn client_control_flow_is_unchanged_when_ssr_is_off() {
+    // The same control-flow source on the client must drive the Vapor IR paths
+    // (`_createIf` / `_createFor`), with no SSR machinery leaking in.
+    let cond = client("const A = () => <div>{cond ? <span>a</span> : <em>b</em>}</div>;");
+    assert!(cond.contains("_createIf("), "{cond}");
+    assert!(!cond.contains("ssrRender"), "{cond}");
+    assert!(!cond.contains("_push("), "{cond}");
+
+    let list = client("const A = () => <ul>{items.map((i) => <li>{i}</li>)}</ul>;");
+    assert!(list.contains("_createFor("), "{list}");
+    assert!(!list.contains("@vue/server-renderer"), "{list}");
+}
+
+#[test]
+fn client_nested_ternary_lowers_to_nested_create_if() {
+    // The nested-ternary fix also unblocks the client path (which previously
+    // overflowed the stack on the embedded-JSX interpolation slice). It now
+    // lowers to nested `_createIf` calls.
+    let code =
+        client("const A = () => <div>{a ? <p>A</p> : b ? <em>B</em> : <span>C</span>}</div>;");
+    assert!(code.contains("_createIf(() => (a)"), "{code}");
+    assert!(code.contains("_createIf(() => (b)"), "{code}");
+    assert!(!code.contains("ssrRender"), "{code}");
 }


### PR DESCRIPTION
Part of #1533.

## What's implemented

The first cut (#1545) already reused `vize_atelier_ssr`'s `SsrCodegenContext::generate` for the JSX Vapor SSR path. The investigation here found that the reused engine **already server-renders control flow, slots, and nested components** for the relief `RootNode` — because JSX lowering produces the *same* `IfNode` / `ForNode` / `<template v-slot>` structures the SFC SSR path emits. So control flow and slots plug into the shared `ssrRender` codegen with **no JSX-specific codegen fork**. This PR pins that contract with tests and closes the one real lowering gap found.

- **Control flow (`crates/vize_atelier_jsx/src/lower/control_flow.rs`)**: a nested ternary in the alternate (`a ? <A/> : b ? <B/> : <C/>`) — the idiomatic JSX `v-else-if` chain — now flattens into a single `IfNode` with `if / else if / else` branches. Previously the inner ternary fell through to `lower_branch_child` and was re-sliced into an interpolation expression (`_ssrInterpolate(b ? <em/> : <span/>)`), which is invalid JS (it embeds JSX in a string): it mis-rendered on SSR and **overflowed the client Vapor transform's stack**. A `&&` / `.map(...)` conditional arm now recurses into nested control flow as well. This lives in shared lowering, so **both** the client and SSR backends benefit.
- **Slots (`crates/vize_atelier_jsx/src/lower/slot.rs`)**: a slot body returning a control-flow expression (`(rows) => rows.map(...)`, a conditional, or `&&`) now reuses the same control-flow lowering, so a list/conditional rendered *inside* a slot server-renders instead of producing an empty slot body.
- Tests extend `crates/vize_atelier_jsx/tests/vapor_ssr.rs` and `crates/vize_atelier_jsx/tests/control_flow.rs`.

## Verify-real

Probed the actual generated `ssrRender` output (since runtime `renderToString` integration is deferred — see below). Confirmed end to end:

- `{cond && <span/>}` → `if (cond) { _push(`<span/>`) } else { _push(`<!---->`) }`
- `{cond ? <a/> : <b/>}` → two-branch `if`/`else`
- `{a ? <p/> : b ? <em/> : <span/>}` → `if (a) … else if (b) … else …` (was broken/crashing)
- `{items.map((i) => <li>{i}</li>)}` → `_ssrRenderList(items, (i) => { _push(`<li>${_ssrInterpolate(i)}</li>`) })`
- `{rows.map((r) => <Item data={r}/>)}` → `_ssrRenderList` of `_ssrRenderComponent(_resolveComponent("Item"), { data: r }, …)`
- `<List>{(item) => <li>{item}</li>}</List>` → `_ssrRenderComponent(_resolveComponent("List"), _attrs, { default: _withCtx((item, …) => …) })`
- `<Comp>{{ header: () => <h1/>, default: () => <p/> }}</Comp>` → named `header` + `default` `_withCtx` slots
- `<div><Child msg={x}/></div>` → `_ssrRenderComponent(_resolveComponent("Child"), { msg: x }, null, _parent)`
- `<List>{(rows) => rows.map((r) => <li>{r}</li>)}</List>` → `.map` inside the default slot body renders
- Closure semantics hold throughout: no `_ctx.` prefix leaks (bare identifiers).
- Regression: plain-value ternary (`flag ? x : y`) and non-`.map` call arms (`flag ? <p/> : fmt(x)`) still fall back to interpolation; client output for control flow stays on `_createIf` / `_createFor` with no SSR machinery.

## Deferred (honest)

- **`renderToString` runtime integration**: tests assert on generated `ssrRender` source, not executed HTML. Wiring the emitted module into a real `@vue/server-renderer` run (resolving component imports, the closure setup scope) is a larger toolchain task, unchanged from #1545.
- **Compound-expression interpolation placeholder**: the shared SSR codegen emits `_ctx.value` for `ExpressionNode::Compound` (`helpers.rs`). JSX lowering does **not** hit this for ordinary compound source like `{a + b}` (it builds a single `SimpleExpressionNode` from the raw span, so `_ssrInterpolate(a + b)` is correct), so it does not bite the tested cases — but the shared-codegen placeholder itself is untouched here.
- **Dynamic / `createSlots` slots** (conditional or `v-for`-generated slot *names*): only static object/named/default-render-prop slot idioms are lowered by `slot.rs`; that is out of scope for this PR.

## Gates

- Stable pinned rustfmt (`rustc +1.95.0` sysroot rustfmt, `cargo fmt -p vize_atelier_jsx -- --check`): 0 diffs.
- `cargo clippy -p vize_atelier_jsx -p vize_atelier_ssr -- -D warnings`: clean (exit 0).
- `cargo test -p vize_atelier_jsx -p vize_atelier_ssr -p vize_atelier_vapor`: all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1551"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->