### PR TITLE
feat(maestro): references, rename, symbols, semantic tokens, code actions, and embedded CSS for JSX/TSX (#1498)

### DIFF
--- a/crates/vize_maestro/src/ide.rs
+++ b/crates/vize_maestro/src/ide.rs
@@ -47,8 +47,12 @@ pub use document_link::DocumentLinkService;
 pub use file_rename::FileRenameService;
 pub use hover::{HoverBuilder, HoverService};
 pub use inlay_hint::InlayHintService;
+pub use jsx::{
+    JsxCodeActionService, JsxDocumentSymbolsService, JsxScopedStyleService,
+    JsxSemanticTokensService,
+};
 #[cfg(feature = "native")]
-pub use jsx::JsxService;
+pub use jsx::{JsxReferencesService, JsxRenameService, JsxService};
 pub use references::ReferencesService;
 pub use rename::RenameService;
 pub use semantic_tokens::{SemanticTokensService, TokenModifier, TokenType};

--- a/crates/vize_maestro/src/ide/jsx.rs
+++ b/crates/vize_maestro/src/ide/jsx.rs
@@ -15,8 +15,33 @@
 mod position;
 pub mod virtual_ts;
 
+// Structural (parse-based) JSX/TSX LSP providers. These need no Corsa bridge —
+// like their SFC counterparts they answer from the parsed/lowered document —
+// so they are available regardless of the `native` feature and are NOT gated on
+// `typeChecker.jsxTypecheck`.
+mod code_action;
+mod document_symbols;
+mod scoped_style;
+mod semantic_tokens;
+
+pub use code_action::JsxCodeActionService;
+pub use document_symbols::JsxDocumentSymbolsService;
+pub use scoped_style::JsxScopedStyleService;
+pub use semantic_tokens::JsxSemanticTokensService;
+
+// Type-aware JSX/TSX LSP providers over the Corsa bridge. Gated on `native`
+// (the bridge is a native-only feature) and reached only when
+// `typeChecker.jsxTypecheck` is enabled.
+#[cfg(feature = "native")]
+mod references;
+#[cfg(feature = "native")]
+mod rename;
 #[cfg(feature = "native")]
 mod service;
 
+#[cfg(feature = "native")]
+pub use references::JsxReferencesService;
+#[cfg(feature = "native")]
+pub use rename::JsxRenameService;
 #[cfg(feature = "native")]
 pub use service::JsxService;

--- a/crates/vize_maestro/src/ide/jsx/code_action.rs
+++ b/crates/vize_maestro/src/ide/jsx/code_action.rs
@@ -1,0 +1,196 @@
+//! Code actions for `.jsx`/`.tsx` Vue components (#1498).
+//!
+//! Surfaces the fixable Patina/JSX-compiler diagnostics on a `.jsx`/`.tsx`
+//! document as quickfix code actions, the JSX parallel to the SFC
+//! [`CodeActionService`](crate::ide::CodeActionService) lint-fix collector.
+//!
+//! It reuses the **same** plumbing: [`vize_patina::lint_jsx`] runs the shared
+//! template lint rules over the lowered JSX (so e.g. a `v-for` missing `:key`
+//! yields the identical fixable diagnostic an SFC template would), and each
+//! diagnostic carrying a [`Fix`](vize_patina) becomes a
+//! [`CodeActionKind::QUICKFIX`] whose edits are the fix edits. Crucially —
+//! unlike the SFC template path, whose lint offsets are relative to the
+//! `<template>` block — `lint_jsx` reports offsets in the **original source**,
+//! so the edits map straight onto `.jsx`/`.tsx` coordinates with no block-offset
+//! translation.
+//!
+//! This is a lint-based (parse-only) provider, like the SFC code-action handler;
+//! it needs no Corsa bridge and is not gated on `typeChecker.jsxTypecheck`.
+#![allow(clippy::disallowed_types, clippy::disallowed_methods)]
+
+use std::collections::HashMap;
+
+use tower_lsp::lsp_types::{
+    CodeAction, CodeActionKind, CodeActionOrCommand, Position, Range, TextEdit, Url, WorkspaceEdit,
+};
+use vize_atelier_jsx::JsxLang;
+use vize_carton::line_index::offset_to_line_col;
+
+/// Code-action provider for `.jsx`/`.tsx` components.
+pub struct JsxCodeActionService;
+
+impl JsxCodeActionService {
+    /// Collect quickfix code actions for the fixable diagnostics overlapping
+    /// `range` in a `.jsx`/`.tsx` document.
+    pub fn code_actions(content: &str, uri: &Url, range: Range) -> Vec<CodeActionOrCommand> {
+        let lang = JsxLang::from_path(uri.path());
+        let result = vize_patina::lint_jsx(content, uri.path(), lang);
+
+        let mut actions = Vec::new();
+        for diag in &result.diagnostics {
+            let Some(ref fix) = diag.fix else {
+                continue;
+            };
+
+            // The diagnostic's own span (original-source offsets) decides whether
+            // this fix is relevant to the requested range.
+            let diag_range = offsets_to_range(content, diag.start, diag.end);
+            if !ranges_overlap(&diag_range, &range) {
+                continue;
+            }
+
+            let edits: Vec<TextEdit> = fix
+                .edits
+                .iter()
+                .map(|edit| TextEdit {
+                    range: offsets_to_range(content, edit.start, edit.end),
+                    new_text: edit.new_text.to_string(),
+                })
+                .collect();
+
+            let mut changes = HashMap::new();
+            changes.insert(uri.clone(), edits);
+
+            #[allow(clippy::disallowed_macros)]
+            let action = CodeAction {
+                title: format!("Fix: {}", fix.message),
+                kind: Some(CodeActionKind::QUICKFIX),
+                diagnostics: None,
+                edit: Some(WorkspaceEdit {
+                    changes: Some(changes),
+                    document_changes: None,
+                    change_annotations: None,
+                }),
+                command: None,
+                is_preferred: Some(true),
+                disabled: None,
+                data: None,
+            };
+            actions.push(CodeActionOrCommand::CodeAction(action));
+        }
+
+        actions
+    }
+}
+
+/// Convert an original-source byte range into an LSP [`Range`] (UTF-16 columns).
+fn offsets_to_range(content: &str, start: u32, end: u32) -> Range {
+    let (start_line, start_col) = offset_to_line_col(content, start as usize);
+    let (end_line, end_col) = offset_to_line_col(content, end as usize);
+    Range {
+        start: Position {
+            line: start_line,
+            character: start_col,
+        },
+        end: Position {
+            line: end_line,
+            character: end_col,
+        },
+    }
+}
+
+/// Whether two LSP ranges overlap (touching endpoints count, so a cursor at the
+/// diagnostic's start still offers the fix).
+fn ranges_overlap(a: &Range, b: &Range) -> bool {
+    !(a.end.line < b.start.line
+        || (a.end.line == b.start.line && a.end.character < b.start.character)
+        || b.end.line < a.start.line
+        || (b.end.line == a.start.line && b.end.character < a.start.character))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn quickfixes(source: &str, range: Range) -> Vec<CodeActionOrCommand> {
+        let uri = Url::parse("file:///tmp/Comp.tsx").unwrap();
+        JsxCodeActionService::code_actions(source, &uri, range)
+    }
+
+    fn whole_doc_range() -> Range {
+        Range {
+            start: Position {
+                line: 0,
+                character: 0,
+            },
+            end: Position {
+                line: u32::MAX,
+                character: 0,
+            },
+        }
+    }
+
+    #[test]
+    fn surfaces_quickfix_for_fixable_jsx_diagnostic() {
+        // Multiple consecutive spaces inside an opening tag is a fixable
+        // template-rule diagnostic (`vue/no-multi-spaces`); `lint_jsx` reports it
+        // on the lowered JSX, so it must surface as a quickfix.
+        let source = "const C = () => <div    class=\"a\">x</div>;\n";
+        let actions = quickfixes(source, whole_doc_range());
+        let has_quickfix = actions.iter().any(|action| match action {
+            CodeActionOrCommand::CodeAction(a) => a.kind == Some(CodeActionKind::QUICKFIX),
+            _ => false,
+        });
+        assert!(
+            has_quickfix,
+            "expected at least one quickfix code action, got: {actions:?}"
+        );
+    }
+
+    #[test]
+    fn quickfix_carries_a_workspace_edit() {
+        let source = "const C = () => <div    class=\"a\">x</div>;\n";
+        let actions = quickfixes(source, whole_doc_range());
+        let action = actions.iter().find_map(|action| match action {
+            CodeActionOrCommand::CodeAction(a) if a.kind == Some(CodeActionKind::QUICKFIX) => {
+                Some(a)
+            }
+            _ => None,
+        });
+        let action = action.expect("a quickfix action");
+        let edit = action.edit.as_ref().expect("quickfix carries an edit");
+        let changes = edit.changes.as_ref().expect("edit has changes");
+        assert!(changes.values().any(|edits| !edits.is_empty()));
+    }
+
+    #[test]
+    fn no_actions_for_clean_component() {
+        let source = "const C = () => <div class=\"a\">hi</div>;\n";
+        let actions = quickfixes(source, whole_doc_range());
+        assert!(
+            actions.is_empty(),
+            "clean component must not offer quickfixes, got: {actions:?}"
+        );
+    }
+
+    #[test]
+    fn no_actions_when_range_misses_diagnostic() {
+        let source = "const C = (props: { items: number[] }) => <ul><li v-for={item in props.items}>x</li></ul>;\n";
+        // A zero-width range on the very first column, far from the `v-for`.
+        let range = Range {
+            start: Position {
+                line: 0,
+                character: 0,
+            },
+            end: Position {
+                line: 0,
+                character: 1,
+            },
+        };
+        let actions = quickfixes(source, range);
+        assert!(
+            actions.is_empty(),
+            "a range that misses the diagnostic must offer no fix, got: {actions:?}"
+        );
+    }
+}

--- a/crates/vize_maestro/src/ide/jsx/document_symbols.rs
+++ b/crates/vize_maestro/src/ide/jsx/document_symbols.rs
@@ -1,0 +1,142 @@
+//! Document symbols for `.jsx`/`.tsx` Vue components (#1498).
+//!
+//! The SFC document-symbol handler lists the structural blocks of an SFC
+//! (`template` / `script` / `script setup` / `style`). A `.jsx`/`.tsx` document
+//! has no SFC blocks; its structural units are the **component functions** —
+//! each outermost JSX render root belongs to one component function (`function
+//! App` / `const App = () => …`). This is the JSX parallel: it lists one symbol
+//! per component, named from the enclosing function (falling back to a stable
+//! placeholder), with each symbol's range covering that component's JSX render
+//! root in the original source.
+//!
+//! Symbols are derived from the same [`vize_atelier_jsx::lower_source`] pass the
+//! diagnostics + virtual-TS paths use, so the names and ranges line up exactly
+//! with what the type-aware features see. This is a structural (parse-based)
+//! provider, like the SFC handler — it needs no Corsa bridge and is therefore
+//! **not** gated on `typeChecker.jsxTypecheck`.
+//!
+//! `deprecated` is allowed for the `DocumentSymbol::deprecated` wire field;
+//! `disallowed_methods` for the `std::string::String` conversions the LSP
+//! `DocumentSymbol` type requires, matching the SFC document-symbol handler.
+#![allow(deprecated, clippy::disallowed_methods)]
+
+use tower_lsp::lsp_types::{DocumentSymbol, Position, Range, SymbolKind, Url};
+use vize_atelier_jsx::{JsxLang, lower_source};
+use vize_carton::Bump;
+
+use crate::ide::offset_to_position;
+
+/// Document-symbol provider for `.jsx`/`.tsx` components.
+pub struct JsxDocumentSymbolsService;
+
+impl JsxDocumentSymbolsService {
+    /// Collect one symbol per component render root in the document, or `None`
+    /// when the file contains no JSX components.
+    pub fn symbols(content: &str, uri: &Url) -> Option<Vec<DocumentSymbol>> {
+        let lang = JsxLang::from_path(uri.path());
+        let bump = Bump::new();
+        let lowered = lower_source(&bump, content, lang);
+
+        if lowered.roots.is_empty() {
+            return None;
+        }
+
+        let mut symbols = Vec::with_capacity(lowered.roots.len());
+        for (index, root) in lowered.roots.iter().enumerate() {
+            let name = root
+                .component_name
+                .as_ref()
+                .map(|name| name.as_str().to_string())
+                .unwrap_or_else(|| {
+                    // Anonymous default-exported / inline component: use a stable
+                    // 1-based placeholder so the outline stays deterministic.
+                    #[allow(clippy::disallowed_macros)]
+                    {
+                        format!("component {}", index + 1)
+                    }
+                });
+
+            let start = (root.root.loc.start.offset as usize).min(content.len());
+            let end = (root.root.loc.end.offset as usize)
+                .min(content.len())
+                .max(start);
+            let (start_line, start_char) = offset_to_position(content, start);
+            let (end_line, end_char) = offset_to_position(content, end);
+
+            let range = Range {
+                start: Position {
+                    line: start_line,
+                    character: start_char,
+                },
+                end: Position {
+                    line: end_line,
+                    character: end_char,
+                },
+            };
+
+            symbols.push(DocumentSymbol {
+                name,
+                kind: SymbolKind::FUNCTION,
+                tags: None,
+                deprecated: None,
+                range,
+                // The render root has no separate selectable identifier span in
+                // JSX coordinates, so the selection range mirrors the full range
+                // (clamped to be non-empty), matching how the SFC handler points
+                // its block selection at the block's own span.
+                selection_range: range,
+                detail: None,
+                children: None,
+            });
+        }
+
+        Some(symbols)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn symbols_for(source: &str) -> Vec<DocumentSymbol> {
+        let uri = Url::parse("file:///tmp/Comp.tsx").unwrap();
+        JsxDocumentSymbolsService::symbols(source, &uri).unwrap_or_default()
+    }
+
+    #[test]
+    fn lists_named_component() {
+        let source = "const Counter = (props: { n: number }) => <span>{props.n}</span>;\n";
+        let symbols = symbols_for(source);
+        assert_eq!(symbols.len(), 1);
+        assert_eq!(symbols[0].name, "Counter");
+        assert_eq!(symbols[0].kind, SymbolKind::FUNCTION);
+        // The range covers the JSX render root on the first line.
+        assert_eq!(symbols[0].range.start.line, 0);
+    }
+
+    #[test]
+    fn lists_multiple_components_in_order() {
+        let source = "const A = () => <div>a</div>;\nconst B = () => <p>b</p>;\n";
+        let symbols = symbols_for(source);
+        assert_eq!(symbols.len(), 2);
+        assert_eq!(symbols[0].name, "A");
+        assert_eq!(symbols[1].name, "B");
+        assert!(symbols[1].range.start.line >= symbols[0].range.start.line);
+    }
+
+    #[test]
+    fn falls_back_to_placeholder_for_anonymous() {
+        // A bare default-exported arrow has no resolvable component name.
+        let source = "export default () => <main>hi</main>;\n";
+        let symbols = symbols_for(source);
+        assert_eq!(symbols.len(), 1);
+        assert_eq!(symbols[0].name, "component 1");
+    }
+
+    #[test]
+    fn no_symbols_for_non_component_module() {
+        let source = "export const value = 1;\n";
+        let uri = Url::parse("file:///tmp/Comp.tsx").unwrap();
+        assert!(JsxDocumentSymbolsService::symbols(source, &uri).is_none());
+    }
+}

--- a/crates/vize_maestro/src/ide/jsx/references.rs
+++ b/crates/vize_maestro/src/ide/jsx/references.rs
@@ -1,0 +1,96 @@
+//! Find-all-references for `.jsx`/`.tsx` Vue components over the Corsa bridge
+//! (#1498).
+//!
+//! The SFC [`ReferencesService`](crate::ide::ReferencesService) only fires when
+//! the cursor lands in an SFC block; a `.jsx`/`.tsx` document has none, so this
+//! is the JSX parallel. It reuses the exact same machinery as the JSX
+//! hover/definition path: lower the document to plain virtual TS via
+//! [`super::virtual_ts`], forward-map the cursor with [`JsxService`], call the
+//! **same** `CorsaBridge::references` the SFC path uses, then map each returned
+//! location back to the original `.jsx`/`.tsx` source (locations in real project
+//! files pass through unchanged).
+//!
+//! Gated by the caller on `typeChecker.jsxTypecheck`, so React `.tsx` files are
+//! never touched unless the user opts in.
+
+use std::sync::Arc;
+
+use tower_lsp::lsp_types::Location;
+use vize_canon::CorsaBridge;
+
+use super::service::JsxService;
+use crate::ide::IdeContext;
+
+/// Find-all-references service for `.jsx`/`.tsx` components.
+pub struct JsxReferencesService;
+
+impl JsxReferencesService {
+    /// Find all references to the symbol at the cursor in a `.jsx`/`.tsx`
+    /// document, resolved through the virtual TS and the type backend.
+    pub async fn references(
+        ctx: &IdeContext<'_>,
+        include_declaration: bool,
+        corsa_bridge: Option<Arc<CorsaBridge>>,
+    ) -> Option<Vec<Location>> {
+        let bridge = corsa_bridge?;
+        let (virtual_ts, uri, line, character) = JsxService::prepare_request(ctx, &bridge).await?;
+
+        let locations = bridge
+            .references(&uri, line, character, include_declaration)
+            .await
+            .ok()?;
+        if locations.is_empty() {
+            return None;
+        }
+
+        // Map each reference back: own-document locations become `.jsx`/`.tsx`
+        // source ranges; locations in real files (a `.d.ts`, another module)
+        // pass through. Reuses the definition path's `map_location` so JSX
+        // references and definitions translate identically.
+        let mapped: Vec<Location> = locations
+            .iter()
+            .filter_map(|location| JsxService::map_location(ctx, &virtual_ts, &uri, location))
+            .collect();
+
+        if mapped.is_empty() {
+            None
+        } else {
+            Some(mapped)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::server::ServerState;
+    use tower_lsp::lsp_types::Url;
+
+    fn ctx_for<'a>(
+        state: &'a ServerState,
+        uri: &'a Url,
+        source: &str,
+        marker: &str,
+    ) -> IdeContext<'a> {
+        let offset = source.find(marker).expect("marker present") + marker.len();
+        IdeContext::with_content(state, uri, offset, source.to_string())
+    }
+
+    // Without a Corsa bridge the type-aware references path degrades gracefully
+    // (returns `None`) rather than panicking, exercising the full virtual-TS
+    // generation + forward position mapping up to the bridge call.
+    #[test]
+    fn references_without_bridge_returns_none() {
+        crate::runtime::block_on(async {
+            let source = "const C = (props: { msg: string }) => {\n  const total = props.msg;\n  return <span>{total}</span>;\n};\n";
+            let uri = Url::parse("file:///tmp/Comp.tsx").unwrap();
+            let state = ServerState::new();
+            let ctx = ctx_for(&state, &uri, source, "total");
+            assert!(
+                JsxReferencesService::references(&ctx, true, None)
+                    .await
+                    .is_none()
+            );
+        });
+    }
+}

--- a/crates/vize_maestro/src/ide/jsx/rename.rs
+++ b/crates/vize_maestro/src/ide/jsx/rename.rs
@@ -1,0 +1,287 @@
+//! Rename for `.jsx`/`.tsx` Vue components over the Corsa bridge (#1498).
+//!
+//! The JSX parallel to the SFC [`RenameService`](crate::ide::RenameService):
+//! lower the document to plain virtual TS, forward-map the cursor, call the
+//! **same** `CorsaBridge::prepare_rename` / `CorsaBridge::rename` the SFC path
+//! uses, then map every returned edit range back to the original `.jsx`/`.tsx`
+//! source. Edits the backend produces against this document's own virtual TS are
+//! retargeted at the real source range; edits in other real files pass through
+//! unchanged.
+//!
+//! The rename **guard** mirrors SFC: `rename` validates the new name is a legal
+//! identifier before touching the backend (the type backend's own
+//! prepare-rename gates *where* a rename may start). Gated by the caller on
+//! `typeChecker.jsxTypecheck`.
+#![allow(clippy::disallowed_types, clippy::disallowed_methods)]
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use tower_lsp::lsp_types::{
+    AnnotatedTextEdit, DocumentChangeOperation, DocumentChanges, OneOf, PrepareRenameResponse,
+    TextDocumentEdit, TextEdit, Url, WorkspaceEdit,
+};
+use vize_canon::CorsaBridge;
+
+use super::service::JsxService;
+use super::virtual_ts::JsxVirtualTs;
+use crate::ide::IdeContext;
+
+/// Rename service for `.jsx`/`.tsx` components.
+pub struct JsxRenameService;
+
+impl JsxRenameService {
+    /// Check whether a rename may start at the cursor, in `.jsx`/`.tsx`
+    /// coordinates. Delegates the decision to the type backend (so it only
+    /// allows renaming real symbols) and maps the returned range back to source.
+    pub async fn prepare_rename(
+        ctx: &IdeContext<'_>,
+        corsa_bridge: Option<Arc<CorsaBridge>>,
+    ) -> Option<PrepareRenameResponse> {
+        let bridge = corsa_bridge?;
+        let (virtual_ts, uri, line, character) = JsxService::prepare_request(ctx, &bridge).await?;
+
+        let response = bridge.prepare_rename(&uri, line, character).await.ok()??;
+        let response: PrepareRenameResponse = serde_json::from_value(response).ok()?;
+        Self::map_prepare_rename(ctx, &virtual_ts, response)
+    }
+
+    /// Rename the symbol at the cursor across the project, mapping the edits in
+    /// this document's virtual TS back onto the original `.jsx`/`.tsx` source.
+    pub async fn rename(
+        ctx: &IdeContext<'_>,
+        new_name: &str,
+        corsa_bridge: Option<Arc<CorsaBridge>>,
+    ) -> Option<WorkspaceEdit> {
+        // Guard: reject illegal identifiers before touching the backend, as the
+        // SFC rename service does.
+        if !is_valid_identifier(new_name) {
+            return None;
+        }
+
+        let bridge = corsa_bridge?;
+        let (virtual_ts, uri, line, character) = JsxService::prepare_request(ctx, &bridge).await?;
+
+        let edit = bridge
+            .rename(&uri, line, character, new_name)
+            .await
+            .ok()??;
+        let edit: WorkspaceEdit = serde_json::from_value(edit).ok()?;
+        Self::map_workspace_edit(ctx, &virtual_ts, &uri, edit)
+    }
+
+    /// Translate a prepare-rename payload from virtual-TS coordinates into the
+    /// original `.jsx`/`.tsx` source.
+    fn map_prepare_rename(
+        ctx: &IdeContext<'_>,
+        virtual_ts: &JsxVirtualTs,
+        response: PrepareRenameResponse,
+    ) -> Option<PrepareRenameResponse> {
+        match response {
+            PrepareRenameResponse::Range(range) => {
+                JsxService::map_virtual_range(virtual_ts, &ctx.content, range)
+                    .map(PrepareRenameResponse::Range)
+            }
+            PrepareRenameResponse::RangeWithPlaceholder { range, placeholder } => {
+                JsxService::map_virtual_range(virtual_ts, &ctx.content, range)
+                    .map(|range| PrepareRenameResponse::RangeWithPlaceholder { range, placeholder })
+            }
+            PrepareRenameResponse::DefaultBehavior { default_behavior } => {
+                Some(PrepareRenameResponse::DefaultBehavior { default_behavior })
+            }
+        }
+    }
+
+    /// Rewrite a workspace edit so edits in this document's virtual TS target the
+    /// original `.jsx`/`.tsx` source; edits in other real files pass through.
+    fn map_workspace_edit(
+        ctx: &IdeContext<'_>,
+        virtual_ts: &JsxVirtualTs,
+        request_uri: &str,
+        mut edit: WorkspaceEdit,
+    ) -> Option<WorkspaceEdit> {
+        if let Some(changes) = edit.changes.take() {
+            let mut mapped: HashMap<Url, Vec<TextEdit>> = HashMap::with_capacity(changes.len());
+            for (uri, edits) in changes {
+                if JsxService::same_uri(uri.as_str(), request_uri) {
+                    let entry = mapped.entry(ctx.uri.clone()).or_default();
+                    entry.extend(
+                        edits
+                            .into_iter()
+                            .filter_map(|edit| Self::map_text_edit(ctx, virtual_ts, edit)),
+                    );
+                } else {
+                    mapped.insert(uri, edits);
+                }
+            }
+            if !mapped.is_empty() {
+                edit.changes = Some(mapped);
+            }
+        }
+
+        if let Some(document_changes) = edit.document_changes.take() {
+            let mapped = match document_changes {
+                DocumentChanges::Edits(edits) => {
+                    let edits = edits
+                        .into_iter()
+                        .filter_map(|edit| {
+                            Self::map_document_edit(ctx, virtual_ts, request_uri, edit)
+                        })
+                        .collect::<Vec<_>>();
+                    (!edits.is_empty()).then_some(DocumentChanges::Edits(edits))
+                }
+                DocumentChanges::Operations(operations) => {
+                    let operations = operations
+                        .into_iter()
+                        .filter_map(|operation| match operation {
+                            DocumentChangeOperation::Edit(edit) => {
+                                Self::map_document_edit(ctx, virtual_ts, request_uri, edit)
+                                    .map(DocumentChangeOperation::Edit)
+                            }
+                            DocumentChangeOperation::Op(op) => {
+                                Some(DocumentChangeOperation::Op(op))
+                            }
+                        })
+                        .collect::<Vec<_>>();
+                    (!operations.is_empty()).then_some(DocumentChanges::Operations(operations))
+                }
+            };
+            if let Some(mapped) = mapped {
+                edit.document_changes = Some(mapped);
+            }
+        }
+
+        if workspace_edit_is_empty(&edit) {
+            None
+        } else {
+            Some(edit)
+        }
+    }
+
+    fn map_document_edit(
+        ctx: &IdeContext<'_>,
+        virtual_ts: &JsxVirtualTs,
+        request_uri: &str,
+        mut edit: TextDocumentEdit,
+    ) -> Option<TextDocumentEdit> {
+        if JsxService::same_uri(edit.text_document.uri.as_str(), request_uri) {
+            edit.text_document.uri = ctx.uri.clone();
+            edit.edits = edit
+                .edits
+                .into_iter()
+                .filter_map(|entry| match entry {
+                    OneOf::Left(text_edit) => {
+                        Self::map_text_edit(ctx, virtual_ts, text_edit).map(OneOf::Left)
+                    }
+                    OneOf::Right(annotated) => {
+                        Self::map_annotated_text_edit(ctx, virtual_ts, annotated).map(OneOf::Right)
+                    }
+                })
+                .collect();
+        }
+
+        if edit.edits.is_empty() {
+            None
+        } else {
+            Some(edit)
+        }
+    }
+
+    fn map_annotated_text_edit(
+        ctx: &IdeContext<'_>,
+        virtual_ts: &JsxVirtualTs,
+        mut edit: AnnotatedTextEdit,
+    ) -> Option<AnnotatedTextEdit> {
+        edit.text_edit = Self::map_text_edit(ctx, virtual_ts, edit.text_edit)?;
+        Some(edit)
+    }
+
+    fn map_text_edit(
+        ctx: &IdeContext<'_>,
+        virtual_ts: &JsxVirtualTs,
+        mut edit: TextEdit,
+    ) -> Option<TextEdit> {
+        edit.range = JsxService::map_virtual_range(virtual_ts, &ctx.content, edit.range)?;
+        Some(edit)
+    }
+}
+
+fn workspace_edit_is_empty(edit: &WorkspaceEdit) -> bool {
+    let changes_empty = edit
+        .changes
+        .as_ref()
+        .is_none_or(|changes| changes.values().all(Vec::is_empty));
+    let document_changes_empty =
+        edit.document_changes
+            .as_ref()
+            .is_none_or(|changes| match changes {
+                DocumentChanges::Edits(edits) => edits.is_empty(),
+                DocumentChanges::Operations(operations) => operations.is_empty(),
+            });
+    changes_empty && document_changes_empty
+}
+
+/// Whether `s` is a legal JS/TS identifier (rename target guard).
+fn is_valid_identifier(s: &str) -> bool {
+    let mut chars = s.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    if !(first.is_ascii_alphabetic() || first == '_' || first == '$') {
+        return false;
+    }
+    chars.all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '$')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::server::ServerState;
+
+    fn ctx_for<'a>(
+        state: &'a ServerState,
+        uri: &'a Url,
+        source: &str,
+        marker: &str,
+    ) -> IdeContext<'a> {
+        let offset = source.find(marker).expect("marker present") + marker.len();
+        IdeContext::with_content(state, uri, offset, source.to_string())
+    }
+
+    #[test]
+    fn rejects_invalid_new_name() {
+        assert!(!is_valid_identifier(""));
+        assert!(!is_valid_identifier("123abc"));
+        assert!(!is_valid_identifier("has space"));
+        assert!(is_valid_identifier("renamed"));
+        assert!(is_valid_identifier("_x"));
+        assert!(is_valid_identifier("$ref"));
+    }
+
+    #[test]
+    fn rename_with_invalid_identifier_returns_none() {
+        crate::runtime::block_on(async {
+            let source = "const C = (props: { msg: string }) => <div>{props.msg}</div>;\n";
+            let uri = Url::parse("file:///tmp/Comp.tsx").unwrap();
+            let state = ServerState::new();
+            let ctx = ctx_for(&state, &uri, source, "props.msg");
+            // Even with a (would-be) bridge, an illegal name short-circuits.
+            assert!(
+                JsxRenameService::rename(&ctx, "not valid", None)
+                    .await
+                    .is_none()
+            );
+        });
+    }
+
+    #[test]
+    fn prepare_rename_without_bridge_returns_none() {
+        crate::runtime::block_on(async {
+            let source = "const C = (props: { msg: string }) => <div>{props.msg}</div>;\n";
+            let uri = Url::parse("file:///tmp/Comp.tsx").unwrap();
+            let state = ServerState::new();
+            let ctx = ctx_for(&state, &uri, source, "props.msg");
+            assert!(JsxRenameService::prepare_rename(&ctx, None).await.is_none());
+        });
+    }
+}

--- a/crates/vize_maestro/src/ide/jsx/scoped_style.rs
+++ b/crates/vize_maestro/src/ide/jsx/scoped_style.rs
@@ -1,0 +1,296 @@
+//! Embedded CSS virtual documents for JSX `<style scoped>` blocks (#1495,
+//! #1498).
+//!
+//! A Vize JSX/TSX component may carry a `<style scoped>` intrinsic element whose
+//! body is the component's scoped CSS (`vize_atelier_jsx` extracts this at
+//! compile time, see [`vize_atelier_jsx::ScopedStyle`]). For the editor this is
+//! exactly an embedded language: the SFC path exposes each `<style>` block as a
+//! CSS [`VirtualDocument`](crate::virtual_code::VirtualDocument) with a 1:1
+//! source map so the editor's CSS language service can attach CSS diagnostics
+//! and the positions map straight back to the `.vue` source. This module mirrors
+//! that for JSX so CSS inside a JSX `<style scoped>` gets the same treatment.
+//!
+//! The CSS content is taken as the **raw source slice** spanning the `<style>`
+//! element's children, which keeps the generated→source map a true byte-for-byte
+//! 1:1 (no escape cooking), matching the SFC [`StyleCodeGenerator`] precisely.
+//! Detection mirrors `vize_atelier_jsx`'s extractor: a lowercase intrinsic
+//! `style` element carrying a bare `scoped` attribute.
+#![allow(clippy::disallowed_methods)]
+
+use oxc_allocator::Allocator;
+use oxc_ast::ast::{JSXAttributeItem, JSXAttributeName, JSXChild, JSXElement, JSXElementName};
+use oxc_ast_visit::{Visit, walk};
+use oxc_span::GetSpan;
+use tower_lsp::lsp_types::Url;
+use vize_atelier_jsx::{JsxLang, parse_module};
+
+use crate::virtual_code::{
+    MappingFeatures, SourceMap, SourceMapping, SourceRange, VirtualDocument, VirtualLanguage,
+};
+
+/// One JSX `<style scoped>` block's CSS content and its byte range in the
+/// original `.jsx`/`.tsx` source.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(in crate::ide) struct JsxScopedStyle {
+    /// Raw CSS text, exactly as it appears between the `<style>` tags.
+    pub(in crate::ide) css: String,
+    /// Inclusive-start byte offset of the CSS in the original source.
+    pub(in crate::ide) start: u32,
+    /// Exclusive-end byte offset of the CSS in the original source.
+    pub(in crate::ide) end: u32,
+}
+
+/// Embedded-CSS provider for JSX `<style scoped>` blocks.
+pub struct JsxScopedStyleService;
+
+impl JsxScopedStyleService {
+    /// Extract every JSX `<style scoped>` block's CSS content + source span from
+    /// a `.jsx`/`.tsx` document, in source order.
+    pub(in crate::ide) fn extract(content: &str, lang: JsxLang) -> Vec<JsxScopedStyle> {
+        let allocator = Allocator::default();
+        let parsed = parse_module(&allocator, content, lang);
+
+        let mut collector = ScopedStyleCollector {
+            source: content,
+            styles: Vec::new(),
+        };
+        collector.visit_program(&parsed.program);
+        collector.styles
+    }
+
+    /// Build embedded CSS virtual documents for a `.jsx`/`.tsx` document's
+    /// `<style scoped>` blocks, one per block, each with a 1:1 source map back
+    /// into the original source. Returns an empty vector when the component has
+    /// no scoped style. Mirrors the SFC style virtual-document path so the
+    /// editor's CSS service sees JSX scoped CSS identically.
+    pub fn virtual_css_documents(content: &str, uri: &Url) -> Vec<VirtualDocument> {
+        let lang = JsxLang::from_path(uri.path());
+        let styles = Self::extract(content, lang);
+
+        styles
+            .into_iter()
+            .enumerate()
+            .map(|(index, style)| Self::build_virtual_document(uri.path(), index, &style))
+            .collect()
+    }
+
+    /// Build one 1:1-mapped CSS [`VirtualDocument`] for a scoped-style block.
+    fn build_virtual_document(
+        base_path: &str,
+        index: usize,
+        style: &JsxScopedStyle,
+    ) -> VirtualDocument {
+        let content_len = style.css.len() as u32;
+
+        // A single 1:1 mapping for the whole CSS body (generated == source
+        // bytes), exactly like the SFC `StyleCodeGenerator`.
+        let mappings = if content_len > 0 {
+            vec![SourceMapping::with_features(
+                SourceRange::new(0, content_len),
+                SourceRange::new(0, content_len),
+                MappingFeatures::all(),
+            )]
+        } else {
+            Vec::new()
+        };
+
+        let mut source_map = SourceMap::from_mappings(mappings);
+        // The block offset is where the CSS starts in the original source, so the
+        // CSS service's positions resolve back to the right `.jsx`/`.tsx` bytes.
+        source_map.set_block_offset(style.start);
+
+        VirtualDocument {
+            uri: vize_carton::cstr!("{base_path}.__jsx_style_{index}.css").to_string(),
+            content: style.css.clone(),
+            language: VirtualLanguage::Style,
+            source_map,
+        }
+    }
+}
+
+/// Walks the parsed program collecting `<style scoped>` CSS spans. Only
+/// `visit_jsx_element` is overridden, so no scope bookkeeping (and hence no
+/// `oxc_syntax`) is needed — `walk` still descends into nested elements.
+struct ScopedStyleCollector<'s> {
+    source: &'s str,
+    styles: Vec<JsxScopedStyle>,
+}
+
+impl<'a, 's> Visit<'a> for ScopedStyleCollector<'s> {
+    fn visit_jsx_element(&mut self, element: &JSXElement<'a>) {
+        if let Some(style) = self.try_extract(element) {
+            self.styles.push(style);
+        }
+        // Descend so a `<style scoped>` nested in fragments/children is still
+        // found, and so multiple components in one module each contribute.
+        walk::walk_jsx_element(self, element);
+    }
+}
+
+impl ScopedStyleCollector<'_> {
+    /// If `element` is an intrinsic `<style scoped>`, return its CSS slice + span.
+    fn try_extract(&self, element: &JSXElement<'_>) -> Option<JsxScopedStyle> {
+        let opening = &element.opening_element;
+        if !is_intrinsic_style(&opening.name) || !has_scoped_attr(&opening.attributes) {
+            return None;
+        }
+        self.children_css_span(element)
+    }
+
+    /// Byte range covering the element's CSS, as a raw source slice (positions
+    /// map 1:1).
+    ///
+    /// For the idiomatic single template-literal (`` {`…`} ``) or string-literal
+    /// (`{'…'}`) body the span is narrowed to the literal's inner text, so the
+    /// CSS document is pure CSS with no JSX braces/quotes. For bare-text or mixed
+    /// children it falls back to first-child-start..last-child-end.
+    fn children_css_span(&self, element: &JSXElement<'_>) -> Option<JsxScopedStyle> {
+        let children = &element.children;
+        // For the idiomatic single template-literal / string body, narrow the
+        // span to the literal's inner text so the CSS document is pure CSS.
+        if let [JSXChild::ExpressionContainer(container)] = children.as_slice() {
+            use oxc_ast::ast::JSXExpression;
+            match &container.expression {
+                JSXExpression::TemplateLiteral(template) => {
+                    // Cover from the first quasi to the last quasi (the static
+                    // CSS text), excluding the backticks.
+                    let first = template.quasis.first()?;
+                    let last = template.quasis.last()?;
+                    let start = first.span.start;
+                    let end = last.span.end;
+                    return self.slice_span(start, end);
+                }
+                JSXExpression::StringLiteral(string) => {
+                    // Inside the quotes.
+                    let span = string.span;
+                    let start = span.start.saturating_add(1);
+                    let end = span.end.saturating_sub(1).max(start);
+                    return self.slice_span(start, end);
+                }
+                _ => {}
+            }
+        }
+
+        // Fallback: bare JSX text and/or mixed children — cover from the first
+        // child's start to the last child's end.
+        let first = children.first()?;
+        let last = children.last()?;
+        let start = first.span().start;
+        let end = last.span().end;
+        self.slice_span(start, end)
+    }
+
+    /// Materialize a [`JsxScopedStyle`] from a `[start, end)` source byte range.
+    fn slice_span(&self, start: u32, end: u32) -> Option<JsxScopedStyle> {
+        let s = start as usize;
+        let e = (end as usize).min(self.source.len());
+        if s >= e {
+            return None;
+        }
+        let css = self.source.get(s..e)?;
+        // Skip whitespace-only bodies — there is no CSS to diagnose.
+        if css.trim().is_empty() {
+            return None;
+        }
+        #[allow(clippy::disallowed_methods)]
+        Some(JsxScopedStyle {
+            css: css.to_string(),
+            start,
+            end: e as u32,
+        })
+    }
+}
+
+/// Whether a JSX element name is the intrinsic lowercase `style` tag.
+fn is_intrinsic_style(name: &JSXElementName<'_>) -> bool {
+    match name {
+        JSXElementName::Identifier(id) => id.name.as_str() == "style",
+        JSXElementName::IdentifierReference(reference) => reference.name.as_str() == "style",
+        _ => false,
+    }
+}
+
+/// Whether the opening element carries a bare `scoped` attribute.
+fn has_scoped_attr(attributes: &[JSXAttributeItem<'_>]) -> bool {
+    attributes.iter().any(|item| match item {
+        JSXAttributeItem::Attribute(attr) => match &attr.name {
+            JSXAttributeName::Identifier(id) => id.name.as_str() == "scoped",
+            JSXAttributeName::NamespacedName(_) => false,
+        },
+        JSXAttributeItem::SpreadAttribute(_) => false,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn extract(source: &str) -> Vec<JsxScopedStyle> {
+        JsxScopedStyleService::extract(source, JsxLang::Tsx)
+    }
+
+    #[test]
+    fn extracts_template_literal_scoped_css() {
+        let source = "const C = () => (\n  <>\n    <div class=\"box\">hi</div>\n    <style scoped>{`\n      .box { color: red; }\n    `}</style>\n  </>\n);\n";
+        let styles = extract(source);
+        assert_eq!(styles.len(), 1, "expected one scoped style block");
+        let style = &styles[0];
+        assert!(style.css.contains(".box"), "css: {:?}", style.css);
+        assert!(style.css.contains("color: red"));
+        // The template literal's backticks are excluded, so the body is pure CSS.
+        assert!(
+            !style.css.contains('`'),
+            "backtick leaked into CSS: {:?}",
+            style.css
+        );
+        // The captured span is a verbatim slice of the source (1:1 mapping
+        // invariant).
+        assert_eq!(&source[style.start as usize..style.end as usize], style.css);
+    }
+
+    #[test]
+    fn extracts_string_literal_scoped_css() {
+        let source = "const C = () => <style scoped>{'.a{color:blue}'}</style>;\n";
+        let styles = extract(source);
+        assert_eq!(styles.len(), 1);
+        assert_eq!(styles[0].css, ".a{color:blue}");
+        assert_eq!(
+            &source[styles[0].start as usize..styles[0].end as usize],
+            styles[0].css
+        );
+    }
+
+    #[test]
+    fn ignores_non_scoped_style() {
+        let source = "const C = () => <style>{`.a{color:red}`}</style>;\n";
+        assert!(extract(source).is_empty());
+    }
+
+    #[test]
+    fn ignores_component_without_style() {
+        let source = "const C = () => <div class=\"a\">hi</div>;\n";
+        assert!(extract(source).is_empty());
+    }
+
+    #[test]
+    fn virtual_document_has_one_to_one_source_map() {
+        let source = "const C = () => <style scoped>{`.box{color:red}`}</style>;\n";
+        let uri = Url::parse("file:///tmp/Comp.tsx").unwrap();
+        let docs = JsxScopedStyleService::virtual_css_documents(source, &uri);
+        assert_eq!(docs.len(), 1);
+        let doc = &docs[0];
+        assert_eq!(doc.language, VirtualLanguage::Style);
+        assert!(doc.uri.as_str().ends_with(".css"));
+        assert_eq!(doc.content, ".box{color:red}");
+        // The 1:1 map round-trips: generated offset 0 maps back to the CSS start.
+        let css_start = source.find(".box").unwrap() as u32;
+        assert_eq!(doc.source_map.to_source(0), Some(css_start));
+    }
+
+    #[test]
+    fn no_virtual_documents_without_scoped_style() {
+        let source = "const C = () => <div>hi</div>;\n";
+        let uri = Url::parse("file:///tmp/Comp.tsx").unwrap();
+        assert!(JsxScopedStyleService::virtual_css_documents(source, &uri).is_empty());
+    }
+}

--- a/crates/vize_maestro/src/ide/jsx/semantic_tokens.rs
+++ b/crates/vize_maestro/src/ide/jsx/semantic_tokens.rs
@@ -1,0 +1,161 @@
+//! Semantic tokens for `.jsx`/`.tsx` Vue components (#1498).
+//!
+//! The SFC semantic-tokens provider highlights the dynamic
+//! JavaScript/TypeScript inside template interpolations, directive values, and
+//! event handlers. A `.jsx`/`.tsx` document carries the analogous dynamic
+//! expressions — interpolations (`{expr}`), bound attributes (`class={expr}`),
+//! and directive expressions — so this is the JSX parallel.
+//!
+//! It reuses the **same** JS/TS expression tokenizer
+//! ([`tokenize_expression`](crate::ide::semantic_tokens::tokenize_expression))
+//! and delta encoder the SFC template path uses, running it over each dynamic
+//! JSX expression recovered by [`super::virtual_ts::collect_jsx_expressions`].
+//! Because each expression carries its original source byte range, the tokens
+//! are emitted directly in `.jsx`/`.tsx` coordinates — no virtual-TS round-trip
+//! is needed, so this is a structural provider (no Corsa, not gated on
+//! `typeChecker.jsxTypecheck`), mirroring the SFC handler.
+
+use tower_lsp::lsp_types::{
+    Range, SemanticTokens, SemanticTokensRangeResult, SemanticTokensResult, Url,
+};
+use vize_atelier_jsx::JsxLang;
+
+use super::virtual_ts::collect_jsx_expressions;
+use crate::ide::semantic_tokens::{AbsoluteToken, encode_semantic_tokens, tokenize_expression};
+
+/// Semantic-tokens provider for `.jsx`/`.tsx` components.
+pub struct JsxSemanticTokensService;
+
+impl JsxSemanticTokensService {
+    /// Collect semantic tokens for the dynamic expressions in a `.jsx`/`.tsx`
+    /// document, or `None` when there is nothing to highlight.
+    pub fn tokens(content: &str, uri: &Url) -> Option<SemanticTokensResult> {
+        let tokens = Self::collect_tokens(content, uri);
+        if tokens.is_empty() {
+            return None;
+        }
+        Some(SemanticTokensResult::Tokens(SemanticTokens {
+            result_id: None,
+            data: encode_semantic_tokens(&tokens),
+        }))
+    }
+
+    /// Collect semantic tokens for the dynamic expressions overlapping `range`,
+    /// mirroring the SFC range provider (filter absolute tokens, then encode).
+    pub fn tokens_range(
+        content: &str,
+        uri: &Url,
+        range: Range,
+    ) -> Option<SemanticTokensRangeResult> {
+        let tokens = Self::collect_tokens(content, uri)
+            .into_iter()
+            .filter(|token| token_overlaps_range(token, range))
+            .collect::<Vec<_>>();
+        if tokens.is_empty() {
+            return None;
+        }
+        Some(SemanticTokensRangeResult::Tokens(SemanticTokens {
+            result_id: None,
+            data: encode_semantic_tokens(&tokens),
+        }))
+    }
+
+    fn collect_tokens(content: &str, uri: &Url) -> Vec<AbsoluteToken> {
+        let lang = JsxLang::from_path(uri.path());
+        let exprs = collect_jsx_expressions(content, lang);
+
+        let mut tokens: Vec<AbsoluteToken> = Vec::new();
+        for expr in &exprs {
+            let start = (expr.start as usize).min(content.len());
+            let end = (expr.end as usize).min(content.len());
+            if start >= end {
+                continue;
+            }
+            // Tokenize the expression text against the whole document so the
+            // emitted positions are absolute source `(line, character)` pairs;
+            // `base_line` is 0 because `content` already spans from line 0.
+            tokenize_expression(&content[start..end], content, start, 0, &mut tokens);
+        }
+
+        tokens.sort_by_key(|token| (token.line, token.start));
+        tokens
+    }
+}
+
+/// Whether an absolute token overlaps an LSP range. Mirrors the SFC provider's
+/// overlap test so JSX range requests filter tokens the same way.
+fn token_overlaps_range(token: &AbsoluteToken, range: Range) -> bool {
+    if token.line < range.start.line || token.line > range.end.line {
+        return false;
+    }
+    let token_end = token.start.saturating_add(token.length);
+    if token.line == range.start.line && token_end <= range.start.character {
+        return false;
+    }
+    if token.line == range.end.line && token.start >= range.end.character {
+        return false;
+    }
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ide::semantic_tokens::TokenType;
+
+    fn tokens_for(source: &str) -> Vec<AbsoluteToken> {
+        let uri = Url::parse("file:///tmp/Comp.tsx").unwrap();
+        JsxSemanticTokensService::collect_tokens(source, &uri)
+    }
+
+    #[test]
+    fn tokenizes_interpolation_expression() {
+        let source = "const C = (props: { msg: string }) => <div>{props.msg}</div>;\n";
+        let tokens = tokens_for(source);
+        assert!(!tokens.is_empty(), "expected tokens for the interpolation");
+
+        // `props` is a variable, `msg` a property access. Find the property
+        // token and confirm it lands on the source line of `{props.msg}`.
+        let property = tokens
+            .iter()
+            .find(|t| t.token_type == TokenType::Property as u32);
+        assert!(
+            property.is_some(),
+            "expected a property token for `props.msg`"
+        );
+        // All tokens land on line 0 (single-line component).
+        assert!(tokens.iter().all(|t| t.line == 0));
+    }
+
+    #[test]
+    fn tokenizes_bound_attribute_expression() {
+        let source = "const C = (props: { cls: string }) => <div class={props.cls}>hi</div>;\n";
+        let tokens = tokens_for(source);
+        assert!(
+            tokens
+                .iter()
+                .any(|t| t.token_type == TokenType::Property as u32),
+            "expected a property token for the bound attribute expression"
+        );
+    }
+
+    #[test]
+    fn tokens_land_at_source_columns() {
+        let source = "const C = () => <span>{count}</span>;\n";
+        let tokens = tokens_for(source);
+        // The only dynamic expression is `count`; its token should start at the
+        // exact source column of `count`.
+        let expected_col = source.find("count").unwrap() as u32;
+        assert!(
+            tokens.iter().any(|t| t.start == expected_col),
+            "token did not land on the source column of `count`: {tokens:?}"
+        );
+    }
+
+    #[test]
+    fn no_tokens_for_static_only_component() {
+        let source = "const C = () => <div class=\"a\">static</div>;\n";
+        let uri = Url::parse("file:///tmp/Comp.tsx").unwrap();
+        assert!(JsxSemanticTokensService::tokens(source, &uri).is_none());
+    }
+}

--- a/crates/vize_maestro/src/ide/jsx/service.rs
+++ b/crates/vize_maestro/src/ide/jsx/service.rs
@@ -42,15 +42,43 @@ impl JsxService {
     ///
     /// Distinct from the SFC `.script.ts`/`.setup.ts`/`.template.ts` suffixes so
     /// a JSX document never collides with an SFC virtual doc in the Corsa
-    /// session.
-    fn request_path(uri: &Url) -> vize_carton::String {
+    /// session. Shared by every type-aware JSX request (hover, completion,
+    /// definition, references, rename, diagnostics) so they all key the same
+    /// virtual document in the session cache.
+    pub(super) fn request_path(uri: &Url) -> vize_carton::String {
         cstr!("{}.jsx.ts", uri.path())
     }
 
     /// Lower the current document to its plain virtual TypeScript.
-    fn virtual_ts(ctx: &IdeContext<'_>) -> Option<JsxVirtualTs> {
+    pub(super) fn virtual_ts(ctx: &IdeContext<'_>) -> Option<JsxVirtualTs> {
         let lang = JsxLang::from_path(ctx.uri.path());
         generate_jsx_virtual_ts(&ctx.content, lang)
+    }
+
+    /// Generate the virtual TS, forward-map the editor cursor into it, and open
+    /// the (shared) virtual document on the bridge. Returns everything a
+    /// position-based request needs: the virtual TS, the opened virtual-doc URI,
+    /// and the cursor's `(line, character)` in virtual-TS coordinates.
+    ///
+    /// `None` when the bridge is missing/uninitialized, lowering fails, or the
+    /// cursor doesn't map into the virtual TS — every type-aware JSX entry point
+    /// degrades gracefully in those cases.
+    pub(super) async fn prepare_request(
+        ctx: &IdeContext<'_>,
+        bridge: &CorsaBridge,
+    ) -> Option<(JsxVirtualTs, vize_carton::String, u32, u32)> {
+        if !bridge.is_initialized() {
+            return None;
+        }
+        let virtual_ts = Self::virtual_ts(ctx)?;
+        let (line, character) =
+            source_offset_to_virtual_position(&virtual_ts.code, &virtual_ts.mappings, ctx.offset)?;
+        let request_path = Self::request_path(ctx.uri);
+        let uri = bridge
+            .open_or_update_virtual_document(&request_path, &virtual_ts.code)
+            .await
+            .ok()?;
+        Some((virtual_ts, uri, line, character))
     }
 
     /// Hover on a `.jsx`/`.tsx` component, resolved through virtual TS.
@@ -59,18 +87,7 @@ impl JsxService {
         corsa_bridge: Option<Arc<CorsaBridge>>,
     ) -> Option<Hover> {
         let bridge = corsa_bridge?;
-        if !bridge.is_initialized() {
-            return None;
-        }
-        let virtual_ts = Self::virtual_ts(ctx)?;
-        let (line, character) =
-            source_offset_to_virtual_position(&virtual_ts.code, &virtual_ts.mappings, ctx.offset)?;
-
-        let request_path = Self::request_path(ctx.uri);
-        let uri = bridge
-            .open_or_update_virtual_document(&request_path, &virtual_ts.code)
-            .await
-            .ok()?;
+        let (virtual_ts, uri, line, character) = Self::prepare_request(ctx, &bridge).await?;
 
         let lsp_hover = bridge.hover(&uri, line, character).await.ok()??;
         let mut hover = HoverService::convert_lsp_hover(lsp_hover);
@@ -89,18 +106,7 @@ impl JsxService {
         corsa_bridge: Option<Arc<CorsaBridge>>,
     ) -> Option<CompletionResponse> {
         let bridge = corsa_bridge?;
-        if !bridge.is_initialized() {
-            return None;
-        }
-        let virtual_ts = Self::virtual_ts(ctx)?;
-        let (line, character) =
-            source_offset_to_virtual_position(&virtual_ts.code, &virtual_ts.mappings, ctx.offset)?;
-
-        let request_path = Self::request_path(ctx.uri);
-        let uri = bridge
-            .open_or_update_virtual_document(&request_path, &virtual_ts.code)
-            .await
-            .ok()?;
+        let (_virtual_ts, uri, line, character) = Self::prepare_request(ctx, &bridge).await?;
 
         let items = bridge.completion(&uri, line, character).await.ok()?;
         if items.is_empty() {
@@ -120,18 +126,8 @@ impl JsxService {
         corsa_bridge: Option<Arc<CorsaBridge>>,
     ) -> Option<GotoDefinitionResponse> {
         let bridge = corsa_bridge?;
-        if !bridge.is_initialized() {
-            return None;
-        }
-        let virtual_ts = Self::virtual_ts(ctx)?;
-        let (line, character) =
-            source_offset_to_virtual_position(&virtual_ts.code, &virtual_ts.mappings, ctx.offset)?;
-
-        let request_path = Self::request_path(ctx.uri);
-        let request_uri = bridge
-            .open_or_update_virtual_document(&request_path, &virtual_ts.code)
-            .await
-            .ok()?;
+        let (virtual_ts, request_uri, line, character) =
+            Self::prepare_request(ctx, &bridge).await?;
 
         let locations = bridge
             .definition(&request_uri, line, character)
@@ -236,7 +232,7 @@ impl JsxService {
     /// Locations pointing at this document's own virtual TS are remapped to the
     /// original `.jsx`/`.tsx` source range; locations in real project files
     /// (e.g. a `node_modules` `.d.ts`) pass through unchanged.
-    fn map_location(
+    pub(super) fn map_location(
         ctx: &IdeContext<'_>,
         virtual_ts: &JsxVirtualTs,
         request_uri: &str,
@@ -280,7 +276,11 @@ impl JsxService {
     }
 
     /// Map an LSP range in virtual-TS coordinates back to the source document.
-    fn map_virtual_range(virtual_ts: &JsxVirtualTs, source: &str, range: Range) -> Option<Range> {
+    pub(super) fn map_virtual_range(
+        virtual_ts: &JsxVirtualTs,
+        source: &str,
+        range: Range,
+    ) -> Option<Range> {
         let (start_line, end_line, start_char, end_char) = virtual_range_to_source(
             &virtual_ts.code,
             source,
@@ -305,7 +305,7 @@ impl JsxService {
     /// Compare a Corsa-returned URI against the virtual-document URI we opened.
     /// Corsa may echo the URI in `file://` form while the request path is a
     /// bare filesystem path, so compare on the path component.
-    fn same_uri(candidate: &str, request_uri: &str) -> bool {
+    pub(super) fn same_uri(candidate: &str, request_uri: &str) -> bool {
         if candidate == request_uri {
             return true;
         }

--- a/crates/vize_maestro/src/ide/jsx/virtual_ts.rs
+++ b/crates/vize_maestro/src/ide/jsx/virtual_ts.rs
@@ -59,10 +59,28 @@ pub(in crate::ide) struct JsxVirtualTs {
 
 /// A dynamic JSX expression recovered from the lowered tree: its original
 /// source text plus the byte range it occupied in the `.jsx`/`.tsx` source.
-struct JsxExpr {
-    content: String,
-    start: u32,
-    end: u32,
+pub(in crate::ide) struct JsxExpr {
+    pub(in crate::ide) content: String,
+    pub(in crate::ide) start: u32,
+    pub(in crate::ide) end: u32,
+}
+
+/// Collect every dynamic (non-static) JSX expression in `source` with its
+/// original source byte range, in source order.
+///
+/// Shares the exact lowering + expression walk that builds the virtual TS, so
+/// callers (e.g. semantic tokens) see the same set of expressions, at the same
+/// spans, that the type-aware features re-emit. Returns the expressions across
+/// all render roots flattened into one list.
+pub(in crate::ide) fn collect_jsx_expressions(source: &str, lang: JsxLang) -> Vec<JsxExpr> {
+    let bump = Bump::new();
+    let lowered = lower_source(&bump, source, lang);
+    let mut exprs = Vec::new();
+    for root in &lowered.roots {
+        collect_root_expressions(&root.root, &mut exprs);
+    }
+    exprs.sort_by_key(|expr| expr.start);
+    exprs
 }
 
 /// Lower a `.jsx`/`.tsx` Vize component to plain virtual TypeScript.

--- a/crates/vize_maestro/src/ide/semantic_tokens/mod.rs
+++ b/crates/vize_maestro/src/ide/semantic_tokens/mod.rs
@@ -19,12 +19,20 @@ mod tests;
 
 pub use types::{TokenModifier, TokenType};
 
+// Re-exported for the JSX/TSX semantic-tokens path (#1498), which tokenizes
+// each re-emitted JSX expression directly in source coordinates using the same
+// JS/TS expression tokenizer + delta encoder the SFC template path uses.
+pub(crate) use encoding::encode_tokens as encode_semantic_tokens;
+pub(crate) use expressions::tokenize_expression;
+// `AbsoluteToken` is also used locally below; the `pub(crate) use` both brings
+// it into this module's scope and re-exports it for the JSX path.
+pub(crate) use types::AbsoluteToken;
+
 use tower_lsp::lsp_types::{
     Range, SemanticTokens, SemanticTokensRangeResult, SemanticTokensResult,
 };
 
 use encoding::{LineIndex, encode_tokens};
-use types::AbsoluteToken;
 
 /// Semantic tokens service.
 pub struct SemanticTokensService;

--- a/crates/vize_maestro/src/server/handlers.rs
+++ b/crates/vize_maestro/src/server/handlers.rs
@@ -324,6 +324,27 @@ impl LanguageServer for MaestroServer {
         };
 
         let ctx = IdeContext::with_content(&self.state, uri, offset, content);
+
+        // Type-aware references for `.jsx`/`.tsx` (opt-in `typeChecker.jsxTypecheck`).
+        // Routed before the SFC path since JSX documents never produce an SFC
+        // block type. React `.tsx` is untouched when the flag is off.
+        #[cfg(feature = "native")]
+        if crate::utils::is_jsx_path(uri.path()) {
+            if self.state.jsx_typecheck_enabled() {
+                let corsa_bridge = self.state.get_corsa_bridge().await;
+                if let Some(locations) = crate::ide::JsxReferencesService::references(
+                    &ctx,
+                    include_declaration,
+                    corsa_bridge,
+                )
+                .await
+                {
+                    return Ok(Some(locations));
+                }
+            }
+            return Ok(None);
+        }
+
         {
             #[cfg(feature = "native")]
             {
@@ -391,6 +412,17 @@ impl LanguageServer for MaestroServer {
         };
 
         let content = doc.text();
+
+        // `.jsx`/`.tsx` documents have no SFC blocks; list their component
+        // functions instead. Structural (parse-based), so it is not gated on
+        // `typeChecker.jsxTypecheck`.
+        if crate::utils::is_jsx_path(uri.path()) {
+            return Ok(
+                crate::ide::JsxDocumentSymbolsService::symbols(&content, uri)
+                    .map(DocumentSymbolResponse::Nested),
+            );
+        }
+
         let options = vize_atelier_sfc::SfcParseOptions {
             filename: uri.path().to_string().into(),
             ..Default::default()
@@ -552,6 +584,18 @@ impl LanguageServer for MaestroServer {
         };
 
         let content = doc.text();
+
+        // `.jsx`/`.tsx`: surface the fixable Patina/JSX-compiler diagnostics as
+        // quickfix code actions. Lint-based (parse-only), so not gated on
+        // `typeChecker.jsxTypecheck`.
+        if crate::utils::is_jsx_path(uri.path()) {
+            let actions = crate::ide::JsxCodeActionService::code_actions(&content, uri, range);
+            if actions.is_empty() {
+                return Ok(None);
+            }
+            return Ok(Some(actions));
+        }
+
         let Some(offset) = position_to_offset(&content, range.start.line, range.start.character)
         else {
             return Ok(None);
@@ -589,6 +633,16 @@ impl LanguageServer for MaestroServer {
 
         let ctx = IdeContext::with_content(&self.state, uri, offset, content);
 
+        // Type-aware prepare-rename for `.jsx`/`.tsx` (opt-in `typeChecker.jsxTypecheck`).
+        #[cfg(feature = "native")]
+        if crate::utils::is_jsx_path(uri.path()) {
+            if self.state.jsx_typecheck_enabled() {
+                let corsa_bridge = self.state.get_corsa_bridge().await;
+                return Ok(crate::ide::JsxRenameService::prepare_rename(&ctx, corsa_bridge).await);
+            }
+            return Ok(None);
+        }
+
         #[cfg(feature = "native")]
         {
             let corsa_bridge = self.state.get_corsa_bridge().await;
@@ -621,6 +675,18 @@ impl LanguageServer for MaestroServer {
 
         let ctx = IdeContext::with_content(&self.state, uri, offset, content);
 
+        // Type-aware rename for `.jsx`/`.tsx` (opt-in `typeChecker.jsxTypecheck`).
+        #[cfg(feature = "native")]
+        if crate::utils::is_jsx_path(uri.path()) {
+            if self.state.jsx_typecheck_enabled() {
+                let corsa_bridge = self.state.get_corsa_bridge().await;
+                return Ok(
+                    crate::ide::JsxRenameService::rename(&ctx, new_name, corsa_bridge).await,
+                );
+            }
+            return Ok(None);
+        }
+
         #[cfg(feature = "native")]
         {
             let corsa_bridge = self.state.get_corsa_bridge().await;
@@ -648,6 +714,13 @@ impl LanguageServer for MaestroServer {
         };
 
         let content = doc.text();
+
+        // `.jsx`/`.tsx`: highlight the dynamic JSX expressions. Structural, so
+        // not gated on `typeChecker.jsxTypecheck`.
+        if crate::utils::is_jsx_path(uri.path()) {
+            return Ok(crate::ide::JsxSemanticTokensService::tokens(&content, uri));
+        }
+
         Ok(SemanticTokensService::get_tokens(&content, uri))
     }
 
@@ -666,6 +739,15 @@ impl LanguageServer for MaestroServer {
         };
 
         let content = doc.text();
+
+        if crate::utils::is_jsx_path(uri.path()) {
+            return Ok(crate::ide::JsxSemanticTokensService::tokens_range(
+                &content,
+                uri,
+                params.range,
+            ));
+        }
+
         Ok(SemanticTokensService::get_tokens_range(
             &content,
             uri,
@@ -980,6 +1062,224 @@ mod tests {
             let edits =
                 futures::executor::block_on(server.formatting(formatting_params(vue_uri))).unwrap();
             assert!(edits.is_some(), "Vue SFC formatting must keep working");
+        }
+    }
+
+    // ----------------------------------------------------------------------
+    // JSX/TSX LSP routing (#1498). These exercise the request handlers
+    // end-to-end for a standalone `.tsx` document: the structural features
+    // (document symbols, semantic tokens, code actions, embedded CSS) answer
+    // without a Corsa bridge, and the type-aware features (references, rename)
+    // stay gated on `typeChecker.jsxTypecheck`.
+    // ----------------------------------------------------------------------
+
+    use tower_lsp::lsp_types::{
+        CodeActionContext, CodeActionParams, DocumentSymbolParams, PartialResultParams,
+        ReferenceContext, ReferenceParams, RenameParams, SemanticTokensParams,
+        TextDocumentPositionParams,
+    };
+
+    fn open_tsx(server: &MaestroServer, uri: &Url, source: &str) {
+        server.state.documents.open(
+            uri.clone(),
+            source.to_string(),
+            1,
+            "typescriptreact".to_string(),
+        );
+        server.state.update_virtual_docs(uri, source);
+    }
+
+    fn tsx_server(source: &str, uri: &Url) -> tower_lsp::LspService<MaestroServer> {
+        let (service, _socket) = LspService::new(MaestroServer::new);
+        let server = service.inner();
+        // Enable the structural LSP features (default off in tests).
+        server
+            .state
+            .apply_lsp_initialization_options(Some(&serde_json::json!({
+                "documentSymbols": true,
+                "semanticTokens": true,
+                "codeActions": true,
+                "lint": true,
+                "references": true,
+                "rename": true,
+            })));
+        open_tsx(server, uri, source);
+        service
+    }
+
+    #[test]
+    fn document_symbol_lists_tsx_components() {
+        let uri = Url::parse("file:///Counter.tsx").unwrap();
+        let source = "const Counter = (props: { n: number }) => <span>{props.n}</span>;\n";
+        let service = tsx_server(source, &uri);
+        let server = service.inner();
+
+        let params = DocumentSymbolParams {
+            text_document: TextDocumentIdentifier { uri },
+            work_done_progress_params: WorkDoneProgressParams::default(),
+            partial_result_params: PartialResultParams::default(),
+        };
+        let response = futures::executor::block_on(server.document_symbol(params)).unwrap();
+        match response {
+            Some(DocumentSymbolResponse::Nested(symbols)) => {
+                assert_eq!(symbols.len(), 1);
+                assert_eq!(symbols[0].name, "Counter");
+            }
+            other => panic!("expected nested TSX component symbols, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn semantic_tokens_full_highlights_tsx_expressions() {
+        let uri = Url::parse("file:///Comp.tsx").unwrap();
+        let source = "const C = (props: { msg: string }) => <div>{props.msg}</div>;\n";
+        let service = tsx_server(source, &uri);
+        let server = service.inner();
+
+        let params = SemanticTokensParams {
+            text_document: TextDocumentIdentifier { uri },
+            work_done_progress_params: WorkDoneProgressParams::default(),
+            partial_result_params: PartialResultParams::default(),
+        };
+        let response = futures::executor::block_on(server.semantic_tokens_full(params)).unwrap();
+        match response {
+            Some(SemanticTokensResult::Tokens(tokens)) => {
+                assert!(!tokens.data.is_empty(), "expected highlighted TSX tokens");
+            }
+            other => panic!("expected TSX semantic tokens, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn code_action_surfaces_tsx_quickfix() {
+        let uri = Url::parse("file:///Comp.tsx").unwrap();
+        // Multi-space inside the opening tag is a fixable JSX lint diagnostic.
+        let source = "const C = () => <div    class=\"a\">x</div>;\n";
+        let service = tsx_server(source, &uri);
+        let server = service.inner();
+
+        let params = CodeActionParams {
+            text_document: TextDocumentIdentifier { uri },
+            range: Range::new(Position::new(0, 0), Position::new(1, 0)),
+            context: CodeActionContext::default(),
+            work_done_progress_params: WorkDoneProgressParams::default(),
+            partial_result_params: PartialResultParams::default(),
+        };
+        let response = futures::executor::block_on(server.code_action(params)).unwrap();
+        let actions = response.expect("expected TSX quickfix code actions");
+        assert!(
+            actions.iter().any(|action| matches!(
+                action,
+                tower_lsp::lsp_types::CodeActionOrCommand::CodeAction(_)
+            )),
+            "expected at least one quickfix, got: {actions:?}"
+        );
+    }
+
+    #[test]
+    fn embedded_scoped_style_produces_css_virtual_document() {
+        let uri = Url::parse("file:///Styled.tsx").unwrap();
+        let source = "const C = () => (\n  <>\n    <div class=\"box\">hi</div>\n    <style scoped>{`\n      .box { color: red; }\n    `}</style>\n  </>\n);\n";
+        let service = tsx_server(source, &uri);
+        let server = service.inner();
+
+        let docs = server
+            .state
+            .get_virtual_docs(&uri)
+            .expect("virtual docs cached for a TSX with <style scoped>");
+        assert_eq!(docs.styles.len(), 1, "one CSS virtual document expected");
+        let style = &docs.styles[0];
+        assert!(style.uri.as_str().ends_with(".css"));
+        assert!(style.content.contains(".box"));
+    }
+
+    #[test]
+    fn references_gated_off_returns_none_for_tsx() {
+        // jsxTypecheck defaults off, so the type-aware references path must not
+        // run for `.tsx` (and the SFC fallback never fires for non-SFC JSX).
+        let uri = Url::parse("file:///Comp.tsx").unwrap();
+        let source = "const C = (props: { msg: string }) => {\n  const total = props.msg;\n  return <span>{total}</span>;\n};\n";
+        let service = tsx_server(source, &uri);
+        let server = service.inner();
+        assert!(
+            !server.state.jsx_typecheck_enabled(),
+            "precondition: jsxTypecheck is off by default"
+        );
+
+        let offset = source.find("total").unwrap();
+        let (line, character) = crate::ide::offset_to_position(source, offset);
+        let params = ReferenceParams {
+            text_document_position: TextDocumentPositionParams {
+                text_document: TextDocumentIdentifier { uri },
+                position: Position::new(line, character),
+            },
+            context: ReferenceContext {
+                include_declaration: true,
+            },
+            work_done_progress_params: WorkDoneProgressParams::default(),
+            partial_result_params: PartialResultParams::default(),
+        };
+        let response = futures::executor::block_on(server.references(params)).unwrap();
+        assert!(
+            response.is_none(),
+            "references must be gated off for TSX when jsxTypecheck is disabled"
+        );
+    }
+
+    #[test]
+    fn rename_gated_off_returns_none_for_tsx() {
+        let uri = Url::parse("file:///Comp.tsx").unwrap();
+        let source = "const C = (props: { msg: string }) => <div>{props.msg}</div>;\n";
+        let service = tsx_server(source, &uri);
+        let server = service.inner();
+
+        let offset = source.find("msg").unwrap();
+        let (line, character) = crate::ide::offset_to_position(source, offset);
+        let params = RenameParams {
+            text_document_position: TextDocumentPositionParams {
+                text_document: TextDocumentIdentifier { uri },
+                position: Position::new(line, character),
+            },
+            new_name: "renamed".to_string(),
+            work_done_progress_params: WorkDoneProgressParams::default(),
+        };
+        let response = futures::executor::block_on(server.rename(params)).unwrap();
+        assert!(
+            response.is_none(),
+            "rename must be gated off for TSX when jsxTypecheck is disabled"
+        );
+    }
+
+    #[test]
+    fn document_symbol_still_parses_sfc_after_jsx_routing() {
+        // Guard against the JSX gate over-matching: a regular `.vue` SFC must
+        // still go through the SFC document-symbol path.
+        let (service, _socket) = LspService::new(MaestroServer::new);
+        let server = service.inner();
+        server.state.apply_lsp_initialization_options(Some(
+            &serde_json::json!({ "documentSymbols": true }),
+        ));
+        let uri = Url::parse("file:///App.vue").unwrap();
+        let source = "<template>\n  <div>hi</div>\n</template>\n<script setup lang=\"ts\">\nconst x = 1\n</script>\n";
+        server
+            .state
+            .documents
+            .open(uri.clone(), source.to_string(), 1, "vue".to_string());
+
+        let params = DocumentSymbolParams {
+            text_document: TextDocumentIdentifier { uri },
+            work_done_progress_params: WorkDoneProgressParams::default(),
+            partial_result_params: PartialResultParams::default(),
+        };
+        let response = futures::executor::block_on(server.document_symbol(params)).unwrap();
+        match response {
+            Some(DocumentSymbolResponse::Nested(symbols)) => {
+                assert!(
+                    symbols.iter().any(|s| s.name == "template"),
+                    "SFC document symbols must still include the template block"
+                );
+            }
+            other => panic!("expected SFC block symbols, got: {other:?}"),
         }
     }
 }

--- a/crates/vize_maestro/src/server/state/virtual_docs.rs
+++ b/crates/vize_maestro/src/server/state/virtual_docs.rs
@@ -23,6 +23,11 @@ impl ServerState {
             return;
         }
 
+        if crate::utils::is_jsx_path(uri.path()) {
+            self.update_jsx_virtual_docs(uri, content);
+            return;
+        }
+
         let options = vize_atelier_sfc::SfcParseOptions {
             filename: uri.path().to_string().into(),
             ..Default::default()
@@ -53,6 +58,25 @@ impl ServerState {
 
         let mut docs = VirtualDocuments::new();
         docs.template = Some(template_doc);
+        self.virtual_docs_cache.insert(uri.clone(), docs);
+    }
+
+    /// Generate and cache virtual documents for a `.jsx`/`.tsx` document.
+    ///
+    /// JSX/TSX components are not SFCs, so the only embedded-language virtual
+    /// documents they produce are the CSS blocks of any `<style scoped>` (#1495,
+    /// #1498). The type-aware features build their own per-request virtual TS
+    /// (see [`crate::ide::JsxService`]); this cache only needs to expose the
+    /// scoped CSS so the editor's CSS service gets diagnostics + source mapping,
+    /// mirroring the SFC style virtual-document path.
+    fn update_jsx_virtual_docs(&self, uri: &Url, content: &str) {
+        let styles = crate::ide::JsxScopedStyleService::virtual_css_documents(content, uri);
+        if styles.is_empty() {
+            self.remove_virtual_docs(uri);
+            return;
+        }
+        let mut docs = VirtualDocuments::new();
+        docs.styles = styles;
         self.virtual_docs_cache.insert(uri.clone(), docs);
     }
 


### PR DESCRIPTION
## What's implemented

Builds on the JSX/TSX LSP bridge from #1546 (hover, completion, go-to-definition, type diagnostics over the Corsa virtual-TS bridge) and adds the remaining SFC-equivalent LSP features for `.jsx`/`.tsx` Vue components. Every feature reuses the existing JSX `position.rs` mapping + `virtual_ts.rs` lowering (and the SFC token/lint/edit plumbing) rather than forking the SFC services.

**Type-aware (over the Corsa bridge, gated on `typeChecker.jsxTypecheck`):**
- **references** — `CorsaBridge::references` on the virtual TS, each location mapped back to JSX ranges (own-document → source range; real files pass through), reusing the definition path's `map_location`.
- **rename / prepare-rename** — `CorsaBridge::prepare_rename` / `rename`; the workspace edit's virtual-TS ranges are remapped onto the `.jsx`/`.tsx` source. The new name is guarded as a legal identifier before touching the backend, mirroring the SFC rename guard.

**Structural (parse-based, no Corsa, not gated):**
- **document symbols** — one `FUNCTION` symbol per component render root (named from the enclosing function, falling back to `component N`), from `lower_source`.
- **semantic tokens** (full + range) — every dynamic JSX expression (interpolations, bound attributes, directive expressions) tokenized **in source coordinates** by the same SFC JS/TS expression tokenizer + delta encoder. No virtual-TS round-trip needed since each expression carries its source byte range.
- **code actions** — `vize_patina::lint_jsx` runs the shared template rules over the lowered JSX; each fixable diagnostic becomes a `QUICKFIX`. `lint_jsx` reports original-source offsets, so edits map straight onto JSX coordinates (no block-offset translation).
- **embedded CSS for JSX `<style scoped>`** (#1495) — a 1:1-mapped CSS `VirtualDocument` per scoped-style block, mirroring the SFC `StyleCodeGenerator` path, so the editor's CSS service gets CSS diagnostics + source mapping. The CSS body is the raw source slice (backticks/quotes excluded for the idiomatic template-/string-literal form), guaranteeing a true byte-for-byte map. Re-derived on every `update_virtual_docs`, so directive/markup edits invalidate stale CSS docs.

Handlers route `.jsx`/`.tsx` before the SFC path; the SFC path is untouched, so JSX inside SFC `<script setup lang="tsx">` keeps its existing (SFC-routed) behavior.

## Verify-real

- `cargo test -p vize_maestro --lib` → **360 passed** (baseline 331; +29 new tests).
- New unit tests per feature on `.tsx` fixtures: references/rename degrade-without-bridge + rename name guard; document symbols (named/multiple/anonymous/none); semantic tokens (interpolation/bound-attr/source-column/static-only); code actions (fixable quickfix via `vue/no-multi-spaces`, carries edit, range-miss, clean); embedded CSS (template-literal/string-literal extraction, no-backtick invariant, 1:1 source map).
- New **handler-level integration tests** through `MaestroServer`: `document_symbol`/`semantic_tokens_full`/`code_action` answer for a standalone `.tsx`; `<style scoped>` produces a cached CSS virtual doc; references/rename are gated off when `jsxTypecheck` is disabled; and a guard test that a regular `.vue` SFC still routes through the SFC document-symbol path (gate doesn't over-match).

## Deferred (honest)

- **Inlay hints** for JSX/TSX (type/parameter hints over the virtual TS) — not wired; SFC has them.
- **Document highlight** for JSX (the SFC `document_highlight` is a separate sync provider; references is covered).
- **Vapor-mode-specific** LSP behavior for `"use vue:vapor"` components — same virtual-TS lowering is used regardless of mode; no Vapor-specific handling.
- Multi-expression / `${}`-interpolated CSS inside `<style scoped>` is captured as static text (matching `vize_atelier_jsx`'s extractor; CSS `v-bind()`-style expressions are a follow-up).

This is why the PR is **Part of #1498** rather than Closes — the core SFC-equivalent feature set + embedded CSS is complete, but the deferrals above remain.

Part of #1498

## Gates

- stable-pinned rustfmt (`rustfmt 1.95.0`, `-p vize_maestro -- --check`): **0 diffs**.
- `cargo clippy -p vize_maestro -- -D warnings`: **clean** (zero new; lib form, matching CI's no-`--all-targets` invocation).
- `cargo test -p vize_maestro --lib`: **green** (360 passed, 1 ignored pre-existing).
- semver: additive — only new public items in `vize_maestro` (`publish = false`, not in the semver-checks matrix); no public API change to any publishable crate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1553"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->