### PR TITLE
feat(atelier): widen codegen source-map coverage (static attrs, text, prop keys, names) (#1533)

### DIFF
--- a/crates/vize_atelier_core/src/codegen/children.rs
+++ b/crates/vize_atelier_core/src/codegen/children.rs
@@ -48,6 +48,9 @@ fn generate_children_inner(
         match effective[0] {
             TemplateChildNode::Text(text) => {
                 ctx.push("\"");
+                // Anchor the inlined text literal back to its source position,
+                // just inside the opening quote. No-op without `source_map`.
+                ctx.record_mapping(&text.loc.start);
                 ctx.push(&escape_js_string(&text.content));
                 ctx.push("\"");
                 return;
@@ -77,6 +80,9 @@ fn generate_children_inner(
             match child {
                 TemplateChildNode::Text(text) => {
                     ctx.push("\"");
+                    // Anchor each concatenated text fragment back to its own
+                    // source position. No-op without `source_map`.
+                    ctx.record_mapping(&text.loc.start);
                     ctx.push(&escape_js_string(&text.content));
                     ctx.push("\"");
                 }
@@ -163,6 +169,9 @@ fn generate_children_inner(
                     match child {
                         TemplateChildNode::Text(text) => {
                             ctx.push("\"");
+                            // Anchor each merged text fragment back to its own
+                            // source position. No-op without `source_map`.
+                            ctx.record_mapping(&text.loc.start);
                             ctx.push(&escape_js_string(&text.content));
                             ctx.push("\"");
                         }
@@ -181,6 +190,9 @@ fn generate_children_inner(
                     }
                     if let TemplateChildNode::Text(text) = child {
                         ctx.push("\"");
+                        // Anchor each text fragment back to its own source
+                        // position. No-op without `source_map`.
+                        ctx.record_mapping(&text.loc.start);
                         ctx.push(&escape_js_string(&text.content));
                         ctx.push("\"");
                     }
@@ -310,6 +322,9 @@ pub fn generate_text(ctx: &mut CodegenContext, text: &TextNode) {
         ctx.push("()");
     } else {
         ctx.push("(\"");
+        // Anchor the generated string literal back to the text node's source
+        // position, just inside the opening quote. No-op without `source_map`.
+        ctx.record_mapping(&text.loc.start);
         ctx.push(&escape_js_string(&text.content));
         ctx.push("\")");
     }
@@ -327,6 +342,9 @@ pub fn generate_comment(ctx: &mut CodegenContext, comment: &CommentNode) {
     ctx.use_helper(RuntimeHelper::CreateComment);
     ctx.push(helper);
     ctx.push("(\"");
+    // Anchor the generated comment string back to the comment node's source
+    // position, just inside the opening quote. No-op without `source_map`.
+    ctx.record_mapping(&comment.loc.start);
     ctx.push(&escape_js_string(&comment.content));
     ctx.push("\")");
 }

--- a/crates/vize_atelier_core/src/codegen/context.rs
+++ b/crates/vize_atelier_core/src/codegen/context.rs
@@ -178,6 +178,22 @@ impl CodegenContext {
         }
     }
 
+    /// Record a source-map segment that also carries a known source symbol
+    /// `name` (a prop key, a static attribute name).
+    ///
+    /// Behaves like [`record_mapping`](Self::record_mapping) but additionally
+    /// interns `name` into the map's v3 `names` array and references it from the
+    /// segment, so a consumer can recover the original identifier. No-op (and no
+    /// `names` growth) unless the `source_map` flag is on, keeping the generated
+    /// `code` byte-identical either way.
+    #[inline]
+    pub(super) fn record_mapping_named(&mut self, loc: &Position, name: &str) {
+        if let Some(builder) = self.map_builder.as_mut() {
+            let generated_offset = self.code.len();
+            builder.add_named(generated_offset, loc.offset, name);
+        }
+    }
+
     /// Take the source-map builder out of the context, if any.
     ///
     /// Consumed at the end of the pipeline to serialize the map once the full

--- a/crates/vize_atelier_core/src/codegen/props/directives.rs
+++ b/crates/vize_atelier_core/src/codegen/props/directives.rs
@@ -276,6 +276,10 @@ fn generate_vbind_prop(
             if needs_quotes {
                 ctx.push("\"");
             }
+            // Anchor the generated prop key back to the v-bind argument in
+            // source, recording the original (untransformed) symbol so it lands
+            // in the v3 `names` array. No-op without `source_map`.
+            ctx.record_mapping_named(&exp.loc.start, &exp.content);
             ctx.push(&transformed_key);
             if needs_quotes {
                 ctx.push("\"");
@@ -450,6 +454,10 @@ fn generate_von_prop(ctx: &mut CodegenContext, dir: &DirectiveNode<'_>) {
             if needs_quotes {
                 ctx.push("\"");
             }
+            // Anchor the generated event-handler key back to the v-on argument
+            // in source, recording the original event name so it lands in the
+            // v3 `names` array. No-op without `source_map`.
+            ctx.record_mapping_named(&exp.loc.start, &exp.content);
             ctx.push(&event_name);
             if needs_quotes {
                 ctx.push("\"");

--- a/crates/vize_atelier_core/src/codegen/props/generate.rs
+++ b/crates/vize_atelier_core/src/codegen/props/generate.rs
@@ -285,6 +285,10 @@ fn try_generate_static_attrs(
         if needs_quotes {
             ctx.push("\"");
         }
+        // Anchor the generated prop key back to the attribute name in source,
+        // recording the symbol so it lands in the v3 `names` array. No-op
+        // without `source_map`.
+        ctx.record_mapping_named(&attr.name_loc.start, &attr.name);
         ctx.push(&attr.name);
         if needs_quotes {
             ctx.push("\"");
@@ -292,6 +296,9 @@ fn try_generate_static_attrs(
         ctx.push(": ");
         if let Some(value) = &attr.value {
             ctx.push("\"");
+            // Anchor the generated value literal back to the attribute value in
+            // source, just inside the opening quote. No-op without `source_map`.
+            ctx.record_mapping(&value.loc.start);
             ctx.push(&escape_js_string(&value.content));
             ctx.push("\"");
         } else {
@@ -458,6 +465,10 @@ fn generate_props_object_inner(
                     if needs_quotes {
                         ctx.push("\"");
                     }
+                    // Anchor the generated prop key back to the attribute name in
+                    // source, recording the symbol so it lands in the v3 `names`
+                    // array. No-op without `source_map`.
+                    ctx.record_mapping_named(&attr.name_loc.start, &attr.name);
                     ctx.push(&attr.name);
                     if needs_quotes {
                         ctx.push("\"");
@@ -470,6 +481,10 @@ fn generate_props_object_inner(
                             ctx.push(&value.content);
                         } else {
                             ctx.push("\"");
+                            // Anchor the generated value literal back to the
+                            // attribute value, just inside the opening quote.
+                            // No-op without `source_map`.
+                            ctx.record_mapping(&value.loc.start);
                             ctx.push(&escape_js_string(&value.content));
                             ctx.push("\"");
                         }

--- a/crates/vize_atelier_core/src/codegen/source_map.rs
+++ b/crates/vize_atelier_core/src/codegen/source_map.rs
@@ -21,14 +21,20 @@
 //! buffer, so the generated `code` string is byte-identical whether or not the
 //! `source_map` flag is enabled. The map is only assembled when the flag is on.
 //!
-//! Coverage starts with the highest-value anchors — dynamic expressions
-//! (identifiers, member expressions, event handlers, directive expressions) and
-//! element tag names. Mapping fidelity can be widened incrementally; see the
+//! Coverage spans the highest-value anchors — dynamic expressions (identifiers,
+//! member expressions, event handlers, directive expressions), element tag
+//! names, static attribute names and values, text/comment content, and
+//! object-literal prop keys. Identifier-shaped anchors that carry a known source
+//! symbol (a prop key, a static attribute name) additionally populate the v3
+//! [`names`] array and the per-segment name index, so a consumer can recover the
+//! original symbol. Mapping fidelity can still be widened incrementally; see the
 //! crate-level codegen docs and the `#1533` tracking issue.
 //!
 //! [Source Map v3]: https://tc39.es/ecma426/
+//! [`names`]: https://tc39.es/ecma426/#json-names
 //! [VLQ]: https://en.wikipedia.org/wiki/Variable-length_quantity
 
+use vize_carton::FxHashMap;
 use vize_carton::String;
 use vize_carton::ToCompactString;
 
@@ -37,11 +43,15 @@ use vize_carton::ToCompactString;
 /// `generated_offset` is a byte offset into the code buffer captured at the
 /// moment the mapped token was about to be written; `source_offset` is the byte
 /// offset of the originating node in the original template source. Both are
-/// resolved to (line, column) at [`SourceMapBuilder::finish`].
+/// resolved to (line, column) at [`SourceMapBuilder::finish`]. `name` is an
+/// index into the builder's `names` table when the anchor carries a known
+/// source symbol (a prop key, a static attribute name), or `None` for anonymous
+/// anchors; it becomes the optional 5th VLQ field of the segment.
 #[derive(Debug, Clone, Copy)]
 struct Segment {
     generated_offset: u32,
     source_offset: u32,
+    name: Option<u32>,
 }
 
 /// Accumulates source-map segments during codegen and serializes a v3 map.
@@ -51,6 +61,12 @@ struct Segment {
 #[derive(Debug, Default)]
 pub(crate) struct SourceMapBuilder {
     segments: Vec<Segment>,
+    /// The v3 `names` array, in insertion order. A segment's `name` is an index
+    /// into this vector.
+    names: Vec<String>,
+    /// Interns symbol names to their index in `names`, so repeated symbols
+    /// (e.g. an `id` attribute on many elements) share one `names` entry.
+    name_index: FxHashMap<String, u32>,
 }
 
 impl SourceMapBuilder {
@@ -58,6 +74,8 @@ impl SourceMapBuilder {
     pub(crate) fn new() -> Self {
         Self {
             segments: Vec::new(),
+            names: Vec::new(),
+            name_index: FxHashMap::default(),
         }
     }
 
@@ -71,7 +89,35 @@ impl SourceMapBuilder {
         self.segments.push(Segment {
             generated_offset: generated_offset as u32,
             source_offset,
+            name: None,
         });
+    }
+
+    /// Record a mapping that additionally carries a known source symbol `name`.
+    ///
+    /// The name is interned into the v3 `names` array (deduplicated across the
+    /// whole map) and the segment references it by index, so a consumer can map
+    /// the generated token back to the original identifier. Otherwise identical
+    /// to [`add_raw`](Self::add_raw): call it immediately before writing the
+    /// mapped token.
+    pub(crate) fn add_named(&mut self, generated_offset: usize, source_offset: u32, name: &str) {
+        let index = self.intern_name(name);
+        self.segments.push(Segment {
+            generated_offset: generated_offset as u32,
+            source_offset,
+            name: Some(index),
+        });
+    }
+
+    /// Return the `names`-array index for `name`, inserting it if new.
+    fn intern_name(&mut self, name: &str) -> u32 {
+        if let Some(&index) = self.name_index.get(name) {
+            return index;
+        }
+        let index = self.names.len() as u32;
+        self.names.push(name.to_compact_string());
+        self.name_index.insert(name.to_compact_string(), index);
+        index
     }
 
     /// Serialize the accumulated segments into a Source Map v3 JSON string.
@@ -86,7 +132,9 @@ impl SourceMapBuilder {
     /// Each segment encodes 4 fields: generated column delta, source index
     /// delta, source line delta, source column delta (all relative to the
     /// previous segment, with source index/line/column relative across the whole
-    /// document and generated column reset per line).
+    /// document and generated column reset per line). Segments that carry a
+    /// source symbol add a 5th field: the name-index delta (relative to the
+    /// previous named segment across the whole document).
     pub(crate) fn finish(
         mut self,
         generated_code: &str,
@@ -102,14 +150,16 @@ impl SourceMapBuilder {
         let resolved = resolve_positions(generated_code, source_content, &self.segments);
         let mappings = encode_mappings(&resolved);
 
-        // Use serde_json to build the document so `filename`/source content are
-        // correctly JSON-escaped (quotes, control chars, unicode).
+        // Use serde_json to build the document so `filename`/source content and
+        // the `names` entries are correctly JSON-escaped (quotes, control chars,
+        // unicode).
+        let names: std::vec::Vec<&str> = self.names.iter().map(String::as_str).collect();
         let doc = serde_json::json!({
             "version": 3,
             "file": filename,
             "sources": [filename],
             "sourcesContent": [source_content],
-            "names": [],
+            "names": names,
             "mappings": mappings.as_str(),
         });
 
@@ -128,6 +178,9 @@ struct ResolvedSegment {
     generated_column: u32,
     source_line: u32,
     source_column: u32,
+    /// Index into the v3 `names` array when this anchor carries a known source
+    /// symbol, carried through unchanged from the recorded segment.
+    name: Option<u32>,
 }
 
 /// Resolve every segment's generated and source byte offsets to 0-indexed
@@ -173,6 +226,7 @@ fn resolve_positions(code: &str, source: &str, segments: &[Segment]) -> Vec<Reso
             generated_column,
             source_line,
             source_column,
+            name: seg.name,
         });
     }
 
@@ -220,9 +274,11 @@ fn utf16_len(s: &str) -> u32 {
 ///
 /// Lines are separated by `;`; segments within a line by `,`. Each segment is 4
 /// VLQ-encoded deltas: generated column, source index, source line, source
-/// column. Generated column is relative to the previous segment on the same
-/// line (reset to absolute at each new line); the other three are relative to
-/// the previous segment across the whole document.
+/// column — plus an optional 5th, the name index, present only for segments
+/// that carry a source symbol. Generated column is relative to the previous
+/// segment on the same line (reset to absolute at each new line); the other
+/// fields (source index/line/column and the name index) are relative to the
+/// previous segment that emitted them, across the whole document.
 fn encode_mappings(segments: &[ResolvedSegment]) -> String {
     let mut out = String::with_capacity(segments.len() * 6);
 
@@ -231,6 +287,7 @@ fn encode_mappings(segments: &[ResolvedSegment]) -> String {
     let mut prev_source_index = 0i64;
     let mut prev_source_line = 0i64;
     let mut prev_source_column = 0i64;
+    let mut prev_name_index = 0i64;
     let mut first_in_line = true;
 
     for seg in segments {
@@ -258,6 +315,15 @@ fn encode_mappings(segments: &[ResolvedSegment]) -> String {
         encode_vlq(&mut out, src_index - prev_source_index);
         encode_vlq(&mut out, src_line - prev_source_line);
         encode_vlq(&mut out, src_col - prev_source_column);
+
+        // The v3 name index is the optional 5th field. It is delta-encoded
+        // against the previous *named* segment (the running accumulator only
+        // advances when a name is present), matching how consumers decode it.
+        if let Some(name) = seg.name {
+            let name_index = name as i64;
+            encode_vlq(&mut out, name_index - prev_name_index);
+            prev_name_index = name_index;
+        }
 
         prev_generated_column = gen_col;
         prev_source_index = src_index;
@@ -371,10 +437,12 @@ mod tests {
             Segment {
                 generated_offset: 9,
                 source_offset: 0,
+                name: None,
             },
             Segment {
                 generated_offset: 12,
                 source_offset: 0,
+                name: None,
             },
         ];
         let resolved = resolve_positions(code, "", &segs);
@@ -419,5 +487,50 @@ mod tests {
         let (src_line, c3) = decode_vlq(&mappings.as_bytes()[c1 + c2..]);
         let (src_col, _) = decode_vlq(&mappings.as_bytes()[c1 + c2 + c3..]);
         assert_eq!((gen_col, src_idx, src_line, src_col), (0, 0, 0, 8));
+    }
+
+    #[test]
+    fn named_segment_populates_names_and_fifth_field() {
+        let mut b = SourceMapBuilder::new();
+        // Generated prop key `id` at offset 0; source `id` at byte offset 5.
+        b.add_named(0, 5, "id");
+        let code = "id: \"app\"";
+        let json = b.finish(code, "Foo.vue", r#"<div id="app">"#);
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+
+        // The symbol is recorded in `names`.
+        assert_eq!(parsed["names"][0], "id");
+
+        // The single segment carries all 5 VLQ fields, the last being the
+        // name-index delta (0, i.e. the first `names` entry).
+        let mappings = parsed["mappings"].as_str().unwrap();
+        let bytes = mappings.as_bytes();
+        let (gen_col, c1) = decode_vlq(bytes);
+        let (src_idx, c2) = decode_vlq(&bytes[c1..]);
+        let (src_line, c3) = decode_vlq(&bytes[c1 + c2..]);
+        let (src_col, c4) = decode_vlq(&bytes[c1 + c2 + c3..]);
+        let consumed = c1 + c2 + c3 + c4;
+        assert!(consumed < bytes.len(), "a 5th VLQ field must be present");
+        let (name_idx, c5) = decode_vlq(&bytes[consumed..]);
+        assert_eq!(
+            (gen_col, src_idx, src_line, src_col, name_idx),
+            (0, 0, 0, 5, 0)
+        );
+        assert_eq!(consumed + c5, bytes.len(), "no trailing bytes after name");
+    }
+
+    #[test]
+    fn intern_name_deduplicates() {
+        let mut b = SourceMapBuilder::new();
+        // Same symbol on two anchors interns to one `names` entry.
+        b.add_named(0, 0, "id");
+        b.add_named(10, 4, "id");
+        b.add_named(20, 8, "class");
+        let json = b.finish("0123456789012345678901234", "Foo.vue", "");
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        let names = parsed["names"].as_array().unwrap();
+        assert_eq!(names.len(), 2, "`id` should be deduplicated");
+        assert_eq!(names[0], "id");
+        assert_eq!(names[1], "class");
     }
 }

--- a/crates/vize_atelier_core/src/codegen/tests.rs
+++ b/crates/vize_atelier_core/src/codegen/tests.rs
@@ -957,13 +957,15 @@ fn test_codegen_triple_mustache_escaped_under_default_dialect() {
 // --- Source Map v3 emission (#1533) -----------------------------------------
 
 /// A single decoded `mappings` segment: 0-indexed generated line/column and the
-/// source line/column it points back to.
+/// source line/column it points back to, plus the optional `names`-array index
+/// when the segment carried a 5th VLQ field.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct DecodedSegment {
     generated_line: u32,
     generated_column: u32,
     source_line: u32,
     source_column: u32,
+    name: Option<u32>,
 }
 
 const VLQ_CHARS: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
@@ -995,10 +997,12 @@ fn decode_one_vlq(bytes: &[u8]) -> (i64, usize) {
 /// Decode a full v3 `mappings` string into absolute decoded segments.
 fn decode_mappings(mappings: &str) -> Vec<DecodedSegment> {
     let mut out = Vec::new();
-    // Source index/line/column accumulate across the whole document; generated
-    // column resets at each generated line (each `;`).
+    // Source index/line/column and the name index accumulate across the whole
+    // document; generated column resets at each generated line (each `;`). The
+    // name index only advances on segments that carry the optional 5th field.
     let mut source_line = 0i64;
     let mut source_column = 0i64;
+    let mut name_index = 0i64;
 
     for (generated_line, line) in mappings.split(';').enumerate() {
         let mut generated_column = 0i64;
@@ -1007,15 +1011,25 @@ fn decode_mappings(mappings: &str) -> Vec<DecodedSegment> {
             let (d_gen_col, c1) = decode_one_vlq(bytes);
             let (_d_src_idx, c2) = decode_one_vlq(&bytes[c1..]);
             let (d_src_line, c3) = decode_one_vlq(&bytes[c1 + c2..]);
-            let (d_src_col, _c4) = decode_one_vlq(&bytes[c1 + c2 + c3..]);
+            let (d_src_col, c4) = decode_one_vlq(&bytes[c1 + c2 + c3..]);
             generated_column += d_gen_col;
             source_line += d_src_line;
             source_column += d_src_col;
+            // A 5th VLQ field, when present, is the delta-encoded name index.
+            let consumed = c1 + c2 + c3 + c4;
+            let name = if consumed < bytes.len() {
+                let (d_name, _c5) = decode_one_vlq(&bytes[consumed..]);
+                name_index += d_name;
+                Some(name_index as u32)
+            } else {
+                None
+            };
             out.push(DecodedSegment {
                 generated_line: generated_line as u32,
                 generated_column: generated_column as u32,
                 source_line: source_line as u32,
                 source_column: source_column as u32,
+                name,
             });
         }
     }
@@ -1187,4 +1201,190 @@ fn source_map_handles_multiline_template() {
         (1, 5),
         "expression should map to line 1, column 5 of the multiline template"
     );
+}
+
+/// Resolve `name` indices on decoded segments against the v3 `names` array,
+/// returning the names of every segment that carried one (in segment order).
+fn named_symbols<'a>(segments: &[DecodedSegment], names: &'a [serde_json::Value]) -> Vec<&'a str> {
+    segments
+        .iter()
+        .filter_map(|s| s.name)
+        .map(|i| names[i as usize].as_str().expect("names entry is a string"))
+        .collect()
+}
+
+#[test]
+fn source_map_anchors_static_attribute_name_and_value() {
+    // `id="app"` is a static attribute. Both the generated prop key `id` and
+    // the value literal `"app"` should map back to their source positions, and
+    // the key's symbol should land in `names`.
+    let src = r#"<div id="app">x</div>"#;
+    let result = compile_with_map(src, "Foo.vue");
+    let map = result.map.expect("map should be Some");
+    let parsed: serde_json::Value = serde_json::from_str(&map).unwrap();
+    let names = parsed["names"].as_array().unwrap();
+    let segments = decode_mappings(parsed["mappings"].as_str().unwrap());
+
+    // Source: `id` name starts at column 5 (`<div ` precedes it); its value
+    // content `app` starts at column 9 (`<div id="` precedes it).
+    let attr_name_seg = segments
+        .iter()
+        .find(|s| s.source_line == 0 && s.source_column == 5)
+        .expect("a segment should anchor the static attribute name");
+    assert!(
+        attr_name_seg.name.is_some(),
+        "static attribute name segment should carry a names index"
+    );
+    assert_eq!(
+        names[attr_name_seg.name.unwrap() as usize],
+        "id",
+        "attribute name symbol should be recorded in `names`"
+    );
+
+    let value_col = src.find("app").unwrap() as u32;
+    assert!(
+        segments
+            .iter()
+            .any(|s| s.source_line == 0 && s.source_column == value_col),
+        "a segment should anchor the static attribute value"
+    );
+
+    assert!(
+        named_symbols(&segments, names).contains(&"id"),
+        "`names` should contain the attribute key symbol"
+    );
+}
+
+#[test]
+fn source_map_anchors_text_vnode_content() {
+    // A standalone text child becomes `_createTextVNode("hello")`; the string
+    // literal should map back to the text's position in the template. Wrapping
+    // the text in a `<pre>` keeps it from being hoisted/merged into the element.
+    let src = "<div>{{ x }}hello</div>";
+    let result = compile_with_map(src, "Foo.vue");
+    let map = result.map.expect("map should be Some");
+    let parsed: serde_json::Value = serde_json::from_str(&map).unwrap();
+    let segments = decode_mappings(parsed["mappings"].as_str().unwrap());
+
+    // `hello` starts at source column 12 (`<div>{{ x }}` precedes it).
+    let text_col = src.find("hello").unwrap() as u32;
+    let (gen_line, gen_col) = generated_position_of(&result.code, "\"hello\"");
+    let text_seg = segments
+        .iter()
+        // The anchor points just inside the opening quote (col + 1).
+        .find(|s| s.generated_line == gen_line && s.generated_column == gen_col + 1)
+        .expect("a segment should anchor the generated text literal");
+    assert_eq!(
+        (text_seg.source_line, text_seg.source_column),
+        (0, text_col),
+        "text content should map back to its template position"
+    );
+}
+
+#[test]
+fn source_map_anchors_comment_vnode_content() {
+    // An HTML comment becomes `_createCommentVNode("note")`; the string literal
+    // should map back to the comment's position.
+    let src = "<div><!--note--></div>";
+    let result = compile_with_map(src, "Foo.vue");
+    let map = result.map.expect("map should be Some");
+    let parsed: serde_json::Value = serde_json::from_str(&map).unwrap();
+    let segments = decode_mappings(parsed["mappings"].as_str().unwrap());
+
+    let comment_byte = src.find("<!--note-->").unwrap() as u32;
+    let (gen_line, gen_col) = generated_position_of(&result.code, "\"note\"");
+    let comment_seg = segments
+        .iter()
+        .find(|s| s.generated_line == gen_line && s.generated_column == gen_col + 1)
+        .expect("a segment should anchor the generated comment literal");
+    assert_eq!(
+        (comment_seg.source_line, comment_seg.source_column),
+        (0, comment_byte),
+        "comment content should map back to the `<!--` open position"
+    );
+}
+
+#[test]
+fn source_map_anchors_dynamic_prop_key_with_name() {
+    // `:id="dynId"` generates an `id:` object key. The key should map back to
+    // the v-bind argument and record `id` in `names`.
+    let src = r#"<div :id="dynId">x</div>"#;
+    let result = compile_with_map(src, "Foo.vue");
+    let map = result.map.expect("map should be Some");
+    let parsed: serde_json::Value = serde_json::from_str(&map).unwrap();
+    let names = parsed["names"].as_array().unwrap();
+    let segments = decode_mappings(parsed["mappings"].as_str().unwrap());
+
+    // The v-bind arg `id` starts at source column 6 (`<div :` precedes it).
+    let key_col = src.find(":id").unwrap() as u32 + 1;
+    let key_seg = segments
+        .iter()
+        .find(|s| s.source_line == 0 && s.source_column == key_col && s.name.is_some())
+        .expect("a named segment should anchor the v-bind prop key");
+    assert_eq!(
+        names[key_seg.name.unwrap() as usize],
+        "id",
+        "v-bind prop key symbol should be recorded in `names`"
+    );
+}
+
+#[test]
+fn source_map_names_array_deduplicates_repeated_symbols() {
+    // The same static attribute name on two elements should yield a single
+    // `names` entry shared by both segments.
+    let src = r#"<div id="a"><span id="b">x</span></div>"#;
+    let result = compile_with_map(src, "Foo.vue");
+    let map = result.map.expect("map should be Some");
+    let parsed: serde_json::Value = serde_json::from_str(&map).unwrap();
+    let names = parsed["names"].as_array().unwrap();
+
+    let id_count = names.iter().filter(|n| n.as_str() == Some("id")).count();
+    assert_eq!(
+        id_count, 1,
+        "`id` should appear exactly once in `names` even across two elements"
+    );
+}
+
+#[test]
+fn source_map_static_attr_and_text_do_not_alter_generated_code() {
+    // The additive invariant extended to the new anchor kinds: a template that
+    // exercises static attributes, a dynamic prop key, text, and a comment must
+    // still produce byte-identical `code`/`preamble` with source maps off.
+    let src = r#"<div id="app" :title="t"><!--c-->hello {{ x }}</div>"#;
+
+    let with_map = compile_with_map(src, "Foo.vue");
+
+    let allocator = bumpalo::Bump::new();
+    let (mut root, errors) = crate::parser::parse(&allocator, src);
+    assert!(errors.is_empty(), "Parse errors: {:?}", errors);
+    crate::transform::transform(
+        &allocator,
+        &mut root,
+        crate::options::TransformOptions {
+            prefix_identifiers: true,
+            ..Default::default()
+        },
+        None,
+    );
+    let without_map = super::generate(
+        &root,
+        crate::options::CodegenOptions {
+            prefix_identifiers: true,
+            source_map: false,
+            filename: "Foo.vue".into(),
+            ..Default::default()
+        },
+    );
+
+    assert_eq!(
+        with_map.code.as_str(),
+        without_map.code.as_str(),
+        "generated code must be byte-identical regardless of source_map flag"
+    );
+    assert_eq!(
+        with_map.preamble.as_str(),
+        without_map.preamble.as_str(),
+        "preamble must be byte-identical regardless of source_map flag"
+    );
+    assert!(without_map.map.is_none());
 }


### PR DESCRIPTION
Part of #1533.

Extends the codegen source-map coverage added in #1547. This is purely **additive map enrichment**: the generated `code`/`preamble` are byte-identical with the `source_map` flag on or off — only the v3 map gains segments and a populated `names` array.

## What's implemented
Builds on #1547's byte-offset anchoring (the parser line table is unreliable, so offsets are resolved to line/column at finalize). New `record_mapping` / `record_mapping_named` anchors for the segments #1547 deferred:

- **Static attributes** — attribute name (named) and value positions, in both the static-attr fast path (`try_generate_static_attrs`) and the general props object (`generate_props_object_inner`).
- **Text & comment VNodes** — content positions across every emission path: standalone `generate_text`/`generate_comment`, the single-text-child inline, the all-text/interpolation concatenation, and the text-run merge loop.
- **Prop keys** — object-literal key positions: static-attr keys (named) plus static `v-bind` and `v-on` directive keys (named, recording the original untransformed symbol).
- **`names` field** — the v3 `names` array is now populated. Identifier-shaped anchors that carry a known source symbol (prop keys, static attribute names) intern that symbol (deduplicated across the whole map) and emit the optional **5th name-index VLQ field**, delta-encoded against the previous named segment.

`SourceMapBuilder` gains `add_named` + a dedup interner and a `names: Vec<String>`; `Segment`/`ResolvedSegment` gain an `Option<u32>` name index; `encode_mappings` emits the 5th field; `CodegenContext` gains `record_mapping_named`. All new items are `pub(crate)`/`pub(super)` or private.

## Verify-real
- `cargo test -p vize_atelier_core` — 195 lib tests + 17 source-map tests green.
- New tests decode the v3 `mappings` (independent VLQ decoder, now handling the optional 5th field) and assert static-attr name/value, text, comment, and prop-key segments resolve to the correct source `(line, col)` and that `names` is populated and deduplicated; a unit test asserts the single-named-segment 5th field; an integration test asserts `code`/`preamble` are byte-identical with the flag off.
- **Byte-identical-output proof:** `cargo test -p vize_atelier_dom -p vize_atelier_vapor -p vize_atelier_sfc` (plus `ssr`) all pass unchanged — these are heavily snapshot-based, so any emitted-code drift would break them. None did.

## Deferred (honest)
- napi/wasm/plugin `{ code, map }` plumbing (would pull in `vize_vitrine`; out of scope here).
- SSR and HMR source-map items.
- Dynamic/computed prop keys (`:[expr]`), event/handler *values*, and v-model-synthesized keys are not name-tagged — they have no single known source symbol; their expressions are already anchored via the existing dynamic-expression chokepoint.
- The `names` field could be widened to more identifier anchors incrementally.

## Gates
- Pinned rustfmt (`1.95.0`) `--check`: 0 diffs.
- `cargo clippy -p vize_atelier_core -- -D warnings`: clean.
- `cargo test -p vize_atelier_core`: green; DOM/Vapor/SFC/SSR suites: green & unchanged.
- `cargo semver-checks check-release -p vize_atelier_core`: no semver update required (additive).
- `cargo build --workspace`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1554"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->