### PR TITLE
feat(canon): type-check JSX style-block expressions (#1497)

### DIFF
--- a/crates/vize_atelier_jsx/src/dom.rs
+++ b/crates/vize_atelier_jsx/src/dom.rs
@@ -119,6 +119,9 @@ pub(crate) fn compile_root_to_dom(
         mode,
         component_name,
         scoped_css,
+        // The style interpolation spans are consumed by the type checker
+        // (`vize_canon`), not the DOM scoping backend.
+        scoped_style_exprs: _,
     } = lowered;
 
     // Extract + rewrite the `<style scoped>` CSS and derive the scope id, reusing

--- a/crates/vize_atelier_jsx/src/finder.rs
+++ b/crates/vize_atelier_jsx/src/finder.rs
@@ -20,10 +20,10 @@ use oxc_ast_visit::{Visit, walk};
 use oxc_syntax::scope::ScopeFlags;
 use vize_carton::String;
 
-use crate::LoweredRoot;
 use crate::diagnostics::JsxDiagnostic;
-use crate::lower::Lowerer;
+use crate::lower::{Lowerer, ScopedStyleExpr};
 use crate::mode::{DirectiveKind, JsxOutputMode, classify_directive};
+use crate::{LoweredRoot, StyleExprSpan};
 
 /// Lower every outermost JSX root in `program` into a [`LoweredRoot`].
 pub(crate) fn lower_program_roots<'a>(
@@ -65,6 +65,32 @@ impl RootLowerer<'_, '_, '_, '_> {
             .iter()
             .rev()
             .find_map(|scope| scope.name.clone())
+    }
+
+    /// Drain the current root's `<style scoped>` blocks into the raw CSS (for
+    /// the scoping backends) and the public interpolation spans (for the type
+    /// checker), mapping each internal [`ScopedStyleExpr`] to a [`StyleExprSpan`].
+    fn take_scoped_style(&mut self) -> (Option<String>, std::vec::Vec<StyleExprSpan>) {
+        match self.lowerer.take_scoped_styles() {
+            None => (None, std::vec::Vec::new()),
+            Some((css, exprs)) => {
+                let spans = exprs
+                    .into_iter()
+                    .map(
+                        |ScopedStyleExpr {
+                             content,
+                             start,
+                             end,
+                         }| StyleExprSpan {
+                            content,
+                            start,
+                            end,
+                        },
+                    )
+                    .collect();
+                (Some(css), spans)
+            }
+        }
     }
 
     fn push_scope(&mut self, body: Option<&FunctionBody<'_>>, name: Option<String>) {
@@ -155,23 +181,25 @@ impl<'ast> Visit<'ast> for RootLowerer<'_, '_, '_, '_> {
         // Lower this root and intentionally do NOT descend: nested JSX is
         // lowered as part of this root's children, not as separate roots.
         let root = self.lowerer.lower_element_root(element);
-        let scoped_css = self.lowerer.take_scoped_styles();
+        let (scoped_css, scoped_style_exprs) = self.take_scoped_style();
         self.roots.push(LoweredRoot {
             root,
             mode: self.current_mode(),
             component_name: self.current_name(),
             scoped_css,
+            scoped_style_exprs,
         });
     }
 
     fn visit_jsx_fragment(&mut self, fragment: &JSXFragment<'ast>) {
         let root = self.lowerer.lower_fragment_root(fragment);
-        let scoped_css = self.lowerer.take_scoped_styles();
+        let (scoped_css, scoped_style_exprs) = self.take_scoped_style();
         self.roots.push(LoweredRoot {
             root,
             mode: self.current_mode(),
             component_name: self.current_name(),
             scoped_css,
+            scoped_style_exprs,
         });
     }
 }

--- a/crates/vize_atelier_jsx/src/lib.rs
+++ b/crates/vize_atelier_jsx/src/lib.rs
@@ -79,6 +79,30 @@ pub struct LoweredRoot<'a> {
     /// scope-id generation over this and expose the result on the compiled
     /// component.
     pub scoped_css: Option<String>,
+    /// Template-literal interpolation expressions (`${expr}`) embedded in the
+    /// component's `<style scoped>` block(s), in source order, each paired with
+    /// its byte range in the original source (#1497).
+    ///
+    /// The style extractor consumes these (they are not CSS text), but they
+    /// reference script values that must type-check against the component scope.
+    /// The type checker ([`vize_canon`](https://docs.rs/vize_canon)) re-emits
+    /// each as plain TypeScript, source-mapped back to its `.jsx`/`.tsx` range,
+    /// so a wrong type inside a style interpolation is reported at the
+    /// interpolation. Empty when no `<style scoped>` interpolations were present.
+    pub scoped_style_exprs: Vec<StyleExprSpan>,
+}
+
+/// A `<style scoped>` template-literal interpolation expression (`${expr}`)
+/// recovered from a JSX/TSX component, with the byte range it occupied in the
+/// original source (#1497).
+#[derive(Debug, Clone)]
+pub struct StyleExprSpan {
+    /// The expression source text, exactly as authored between `${` and `}`.
+    pub content: String,
+    /// Byte offset of the expression's start in the original source.
+    pub start: u32,
+    /// Byte offset of the expression's end in the original source.
+    pub end: u32,
 }
 
 /// The result of lowering a whole JSX/TSX module.

--- a/crates/vize_atelier_jsx/src/lower/mod.rs
+++ b/crates/vize_atelier_jsx/src/lower/mod.rs
@@ -16,7 +16,7 @@ mod slot;
 mod style;
 mod text;
 
-pub(crate) use style::RawScopedStyle;
+pub(crate) use style::{RawScopedStyle, ScopedStyleExpr};
 
 use oxc_ast::ast::{JSXElement, JSXFragment};
 use vize_carton::{Box, Bump, String};
@@ -55,20 +55,26 @@ impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
     /// Drain the `<style scoped>` blocks accumulated while lowering the current
     /// render root, concatenating their CSS into one block (multiple `<style
     /// scoped>` elements in one component join, mirroring SFC's multi-`<style>`
-    /// behavior). Returns `None` when no scoped style was present.
-    pub(crate) fn take_scoped_styles(&mut self) -> Option<String> {
+    /// behavior) and flattening every template-literal interpolation expression
+    /// (`${expr}`) across them, in source order. Returns `None` when no scoped
+    /// style was present.
+    pub(crate) fn take_scoped_styles(
+        &mut self,
+    ) -> Option<(String, std::vec::Vec<ScopedStyleExpr>)> {
         if self.pending_styles.is_empty() {
             return None;
         }
         let styles = std::mem::take(&mut self.pending_styles);
         let mut css = String::default();
+        let mut exprs = std::vec::Vec::new();
         for (index, style) in styles.into_iter().enumerate() {
             if index > 0 {
                 css.push('\n');
             }
             css.push_str(style.css.trim());
+            exprs.extend(style.exprs);
         }
-        Some(css)
+        Some((css, exprs))
     }
 
     /// Diagnostics accumulated so far.

--- a/crates/vize_atelier_jsx/src/lower/style.rs
+++ b/crates/vize_atelier_jsx/src/lower/style.rs
@@ -26,6 +26,7 @@
 use oxc_ast::ast::{
     JSXAttributeItem, JSXAttributeName, JSXChild, JSXElement, JSXElementName, JSXExpression,
 };
+use oxc_span::GetSpan;
 
 use vize_carton::String;
 
@@ -36,6 +37,23 @@ use super::Lowerer;
 pub(crate) struct RawScopedStyle {
     /// The CSS text exactly as authored between the `<style>` tags.
     pub css: String,
+    /// The template-literal interpolation expressions (`${expr}`) embedded in
+    /// the style block, in source order, each paired with its byte range in the
+    /// original `.jsx`/`.tsx` source. These are consumed by the style extractor
+    /// (they are *not* CSS text), but the type checker re-emits them so they
+    /// type-check against the component scope (#1497).
+    pub exprs: std::vec::Vec<ScopedStyleExpr>,
+}
+
+/// One interpolation expression (`${expr}`) recovered from a `<style scoped>`
+/// template literal: its source text and the byte range it occupied.
+pub(crate) struct ScopedStyleExpr {
+    /// The expression source text, exactly as authored between `${` and `}`.
+    pub content: String,
+    /// Byte offset of the expression's start in the original source.
+    pub start: u32,
+    /// Byte offset of the expression's end in the original source.
+    pub end: u32,
 }
 
 impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
@@ -48,9 +66,74 @@ impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
         if !is_intrinsic_style(&opening.name) || !has_scoped_attr(&opening.attributes) {
             return false;
         }
-        let css = collect_style_css(&element.children);
-        self.push_scoped_style(RawScopedStyle { css });
+        let mut css = String::default();
+        let mut exprs = std::vec::Vec::new();
+        self.collect_style(&element.children, &mut css, &mut exprs);
+        self.push_scoped_style(RawScopedStyle { css, exprs });
         true
+    }
+
+    /// Concatenate the CSS text from a `<style>` element's children, recording
+    /// each template-literal interpolation expression's source text and byte
+    /// range into `exprs`. Supports the idiomatic template-literal form
+    /// (`{`…`}`), a plain string literal (`{'…'}`), and bare JSX text.
+    fn collect_style(
+        &self,
+        children: &[JSXChild<'_>],
+        css: &mut String,
+        exprs: &mut std::vec::Vec<ScopedStyleExpr>,
+    ) {
+        for child in children {
+            match child {
+                JSXChild::Text(text) => css.push_str(text.value.as_str()),
+                JSXChild::ExpressionContainer(container) => match &container.expression {
+                    JSXExpression::StringLiteral(string) => css.push_str(string.value.as_str()),
+                    JSXExpression::TemplateLiteral(template) => {
+                        self.push_template_css(css, exprs, template);
+                    }
+                    _ => {}
+                },
+                _ => {}
+            }
+        }
+    }
+
+    /// Append a template literal's cooked CSS text and record each `${expr}`
+    /// interpolation's source text + byte range.
+    ///
+    /// A `<style scoped>` body is typically a static template literal, but any
+    /// `${expr}` substitutions (e.g. `color: ${props.color}`) reference script
+    /// values that must type-check against the component scope (#1497); their
+    /// spans are captured here so the type checker can re-emit them. The cooked
+    /// quasis are still concatenated so the static rules survive for the CSS
+    /// scoping backends.
+    fn push_template_css(
+        &self,
+        css: &mut String,
+        exprs: &mut std::vec::Vec<ScopedStyleExpr>,
+        template: &oxc_ast::ast::TemplateLiteral<'_>,
+    ) {
+        for quasi in &template.quasis {
+            let text = quasi
+                .value
+                .cooked
+                .as_ref()
+                .map(|cooked| cooked.as_str())
+                .unwrap_or_else(|| quasi.value.raw.as_str());
+            css.push_str(text);
+        }
+        for expression in &template.expressions {
+            let span = expression.span();
+            let content = self.mapper().slice(span);
+            if content.trim().is_empty() {
+                continue;
+            }
+            exprs.push(ScopedStyleExpr {
+                content: String::from(content),
+                start: span.start,
+                end: span.end,
+            });
+        }
     }
 }
 
@@ -73,41 +156,4 @@ fn has_scoped_attr(attributes: &[JSXAttributeItem<'_>]) -> bool {
         },
         JSXAttributeItem::SpreadAttribute(_) => false,
     })
-}
-
-/// Concatenate the CSS text from a `<style>` element's children. Supports the
-/// idiomatic template-literal form (`{`…`}`), a plain string literal
-/// (`{'…'}`), and bare JSX text. Interpolations and other expressions are
-/// skipped (CSS `v-bind()` / style expressions are a deferred follow-up).
-fn collect_style_css(children: &[JSXChild<'_>]) -> String {
-    let mut css = String::default();
-    for child in children {
-        match child {
-            JSXChild::Text(text) => css.push_str(text.value.as_str()),
-            JSXChild::ExpressionContainer(container) => match &container.expression {
-                JSXExpression::StringLiteral(string) => css.push_str(string.value.as_str()),
-                JSXExpression::TemplateLiteral(template) => {
-                    push_template_css(&mut css, template);
-                }
-                _ => {}
-            },
-            _ => {}
-        }
-    }
-    css
-}
-
-/// Append a template literal's cooked text. A `<style scoped>` body is expected
-/// to be a static template literal with no `${}` substitutions; if any are
-/// present we still emit the literal quasis so the static rules survive.
-fn push_template_css(css: &mut String, template: &oxc_ast::ast::TemplateLiteral<'_>) {
-    for quasi in &template.quasis {
-        let text = quasi
-            .value
-            .cooked
-            .as_ref()
-            .map(|cooked| cooked.as_str())
-            .unwrap_or_else(|| quasi.value.raw.as_str());
-        css.push_str(text);
-    }
 }

--- a/crates/vize_atelier_jsx/src/vapor.rs
+++ b/crates/vize_atelier_jsx/src/vapor.rs
@@ -108,6 +108,9 @@ pub(crate) fn compile_root_to_vapor(
         mode,
         component_name,
         scoped_css,
+        // The style interpolation spans are consumed by the type checker
+        // (`vize_canon`), not the Vapor scoping backend.
+        scoped_style_exprs: _,
     } = lowered;
 
     // Extract + rewrite the `<style scoped>` CSS and derive the scope id, reusing

--- a/crates/vize_atelier_jsx/tests/style.rs
+++ b/crates/vize_atelier_jsx/tests/style.rs
@@ -8,7 +8,7 @@
 //! scope id are exposed on the compiled component for a bundler to emit later.
 
 use vize_atelier_jsx::{
-    DomCompileOptions, JsxLang, VaporCompileOptions, compile_to_dom, compile_to_vapor,
+    DomCompileOptions, JsxLang, VaporCompileOptions, compile_to_dom, compile_to_vapor, lower_source,
 };
 use vize_carton::{Bump, cstr};
 
@@ -195,6 +195,64 @@ fn dom_and_vapor_agree_on_scope_id() {
         d.scoped_style.unwrap().scope_id,
         v.scoped_style.unwrap().scope_id,
         "VDOM and Vapor should derive the same scope id for the same component"
+    );
+}
+
+// --- Style-block interpolation expressions (#1497) ---------------------------
+
+#[test]
+fn scoped_style_interpolations_are_recovered_with_source_spans() {
+    // A `${expr}` in the style template literal is consumed by the extractor (so
+    // it is not CSS text) but recovered on `LoweredRoot::scoped_style_exprs` with
+    // its source byte range, so the type checker can re-emit it (#1497).
+    let bump = Bump::new();
+    let src = r#"const Comp = (props: { color: string }) => (
+  <>
+    <div class="box"/>
+    <style scoped>{`.box { color: ${props.color}; border: ${props.color}; }`}</style>
+  </>
+);
+"#;
+    let out = lower_source(&bump, src, JsxLang::Tsx);
+    assert!(!out.has_errors(), "diagnostics: {:?}", out.diagnostics);
+    let root = &out.roots[0];
+
+    // Both interpolations are captured, in source order.
+    assert_eq!(
+        root.scoped_style_exprs.len(),
+        2,
+        "expected two style interpolations: {:?}",
+        root.scoped_style_exprs
+            .iter()
+            .map(|e| e.content.as_str())
+            .collect::<std::vec::Vec<_>>()
+    );
+    for expr in &root.scoped_style_exprs {
+        assert_eq!(expr.content.as_str(), "props.color");
+        // The recorded span recovers the exact source text it points at.
+        assert_eq!(&src[expr.start as usize..expr.end as usize], "props.color");
+    }
+    // The static CSS still survives for the scoping backends; the interpolation
+    // placeholders are not part of the captured CSS text.
+    let css = root.scoped_css.as_deref().expect("scoped css");
+    assert!(css.contains("color:"), "css: {css:?}");
+    assert!(!css.contains("props.color"), "css: {css:?}");
+}
+
+#[test]
+fn static_scoped_style_has_no_interpolations() {
+    // A static `<style scoped>` (no `${}`) records no interpolation expressions.
+    let bump = Bump::new();
+    let out = lower_source(&bump, SCOPED, JsxLang::Jsx);
+    assert!(!out.has_errors(), "diagnostics: {:?}", out.diagnostics);
+    assert!(
+        out.roots[0].scoped_style_exprs.is_empty(),
+        "static style block should expose no interpolations: {:?}",
+        out.roots[0]
+            .scoped_style_exprs
+            .iter()
+            .map(|e| e.content.as_str())
+            .collect::<std::vec::Vec<_>>()
     );
 }
 

--- a/crates/vize_canon/src/batch/virtual_project/jsx_codegen.rs
+++ b/crates/vize_canon/src/batch/virtual_project/jsx_codegen.rs
@@ -52,14 +52,22 @@
 //!   callback so the loop aliases bind with their inferred element types; and
 //!   `v-show`/`v-if` conditions, directive arg/value expressions, and event
 //!   handlers are re-emitted as plain reads.
+//! - **style-block expressions** are checked too (#1497): a `<style scoped>` JSX
+//!   block (#1495) is extracted out of the rendered children, but its
+//!   template-literal interpolations (`${expr}`, e.g. `color: ${props.color}`)
+//!   reference script values and are re-emitted through the same sink and
+//!   component scope as that root's JSX expressions, so a wrong type inside a
+//!   style interpolation is reported at the interpolation.
 //!
-//! Deferred (see issue #1497): style-block-expression checks, the stateful
-//! `defineComponent(() => () => VNode)` form, and full source-map fidelity for
-//! the synthesized wrapper scaffolding.
+//! Deferred (see issue #1497): CSS `v-bind(expr)` references inside a
+//! `<style scoped>` block (their spans live in cooked CSS text whose offsets no
+//! longer map to source bytes, so recovering them needs dedicated extraction);
+//! the stateful `defineComponent(() => () => VNode)` form; and full source-map
+//! fidelity for the synthesized wrapper scaffolding.
 
 use std::path::Path;
 
-use vize_atelier_jsx::{JsxDiagnostic, JsxLang, lower_source};
+use vize_atelier_jsx::{JsxDiagnostic, JsxLang, StyleExprSpan, lower_source};
 use vize_carton::{Bump, String as CompactString, ToCompactString, cstr};
 use vize_relief::ast::{
     ExpressionNode, RootNode, TemplateChildNode,
@@ -160,6 +168,13 @@ pub(super) fn generate_jsx_virtual_ts(
     for root in &lowered.roots {
         let mut exprs = Vec::new();
         collect_root_expressions(&root.root, &mut exprs);
+        // The `<style scoped>` block is extracted out of the rendered children
+        // (#1495), so its template-literal interpolations (`${expr}`) never reach
+        // the lowered tree above. Append them as plain reads so they type-check
+        // against the very same component scope (props, setup vars, ctx) as the
+        // root's JSX expressions, source-mapped back to their `.tsx` ranges
+        // (#1497).
+        collect_style_expressions(&root.scoped_style_exprs, &mut exprs);
         roots.push((root.root.loc.start.offset, root.root.loc.end.offset, exprs));
     }
     // Outermost roots never overlap and are produced in source order, but guard
@@ -340,6 +355,28 @@ fn push_verbatim(
 fn collect_root_expressions(root: &RootNode<'_>, out: &mut Vec<JsxEmit>) {
     for child in &root.children {
         collect_child(child, out);
+    }
+}
+
+/// Append a component's `<style scoped>` template-literal interpolations as
+/// plain reads.
+///
+/// The style block is extracted out of the rendered tree (#1495), so its
+/// `${expr}` interpolations are recovered separately on
+/// [`LoweredRoot::scoped_style_exprs`](vize_atelier_jsx::LoweredRoot). Each
+/// references script values in the component scope (`props`, setup-scope
+/// bindings, the `Ctx` context), so re-emitting it through the same sink and
+/// scope as the root's JSX expressions type-checks it, with its mapping pointing
+/// diagnostics back at the original `${…}` byte range (#1497).
+///
+/// CSS `v-bind(expr)` references are *not* handled here (see the deferral note in
+/// the module docs): they live in the cooked CSS text whose offsets no longer map
+/// to source bytes, so recovering their spans needs dedicated extraction infra.
+fn collect_style_expressions(style_exprs: &[StyleExprSpan], out: &mut Vec<JsxEmit>) {
+    for style_expr in style_exprs {
+        if let Some(expr) = jsx_expr(&style_expr.content, style_expr.start, style_expr.end) {
+            out.push(JsxEmit::Expr(expr));
+        }
     }
 }
 
@@ -741,6 +778,67 @@ mod tests {
             if_attr.code.contains("__vize_jsx_expr__(props.ok)"),
             "v-if condition not re-emitted: {}",
             if_attr.code
+        );
+    }
+
+    #[test]
+    fn reemits_style_block_interpolation_through_sink() {
+        // A `<style scoped>` template-literal interpolation references a script
+        // value (`props.color`); it is extracted out of the rendered children but
+        // re-emitted through the sink so it type-checks against the component
+        // scope, source-mapped back to its `${…}` range.
+        let source = "const Comp = (props: { color: string }) => (\n  <>\n    <div class=\"box\">hi</div>\n    <style scoped>{`.box { color: ${props.color}; }`}</style>\n  </>\n);\n";
+        let generated = generate(source);
+        assert!(
+            generated.code.contains("__vize_jsx_expr__(props.color)"),
+            "style interpolation not re-emitted: {}",
+            generated.code
+        );
+        // Output stays plain TS: no `<style>` element survives.
+        assert!(
+            !generated.code.contains("<style"),
+            "style element leaked into virtual TS: {}",
+            generated.code
+        );
+        // A mapping points the re-emitted interpolation back at its source range.
+        let src = source.find("props.color").unwrap();
+        assert!(
+            generated
+                .mappings
+                .iter()
+                .any(|mapping| mapping.src_range.start == src),
+            "no source mapping for re-emitted style interpolation: {:?}",
+            generated.mappings
+        );
+    }
+
+    #[test]
+    fn reemits_multiple_style_block_interpolations() {
+        // Every `${expr}` in the style block is re-emitted, in source order.
+        let source = "const Comp = (props: { fg: string; bg: string }) => (\n  <>\n    <div class=\"box\"/>\n    <style scoped>{`.box { color: ${props.fg}; background: ${props.bg}; }`}</style>\n  </>\n);\n";
+        let generated = generate(source);
+        assert!(
+            generated.code.contains("props.fg") && generated.code.contains("props.bg"),
+            "not all style interpolations re-emitted: {}",
+            generated.code
+        );
+    }
+
+    #[test]
+    fn static_style_block_emits_no_extra_sink_args() {
+        // A static `<style scoped>` (no `${}`) contributes no re-emitted
+        // expressions: the sink call stays empty for an otherwise-static root.
+        let source = "const Comp = () => (\n  <>\n    <div class=\"box\"/>\n    <style scoped>{`.box { color: red; }`}</style>\n  </>\n);\n";
+        let generated = generate(source);
+        assert!(
+            generated.code.contains("__vize_jsx_expr__()"),
+            "static style block should not add sink arguments: {}",
+            generated.code
+        );
+        assert!(
+            !generated.code.contains("<style"),
+            "style element leaked into virtual TS: {}",
+            generated.code
         );
     }
 

--- a/crates/vize_canon/src/batch/virtual_project/tests.rs
+++ b/crates/vize_canon/src/batch/virtual_project/tests.rs
@@ -1427,3 +1427,39 @@ fn jsx_typecheck_on_binds_v_for_alias_inside_map_callback() {
 
     let _ = fs::remove_dir_all(&case_dir);
 }
+
+#[test]
+fn jsx_typecheck_on_reemits_style_block_interpolation() {
+    // A `<style scoped>` template-literal interpolation (`${props.color}`) is
+    // extracted out of the rendered children (#1495) but re-emitted through the
+    // sink so it type-checks against the component scope (#1497). The virtual TS
+    // stays plain and parses, and the `<style>` element is gone.
+    let case_dir = unique_case_dir("jsx-style-expr");
+    let _ = fs::remove_dir_all(&case_dir);
+    fs::create_dir_all(&case_dir).unwrap();
+    let tsx_path = case_dir.join("Comp.tsx");
+    let source = "const Comp = (props: { color: string }) => (\n  <>\n    <div class=\"box\">hi</div>\n    <style scoped>{`.box { color: ${props.color}; }`}</style>\n  </>\n);\n";
+
+    let mut project = VirtualProject::new(&case_dir).unwrap();
+    project.set_jsx_typecheck(true);
+    project
+        .register_path_with_content(&tsx_path, source)
+        .unwrap();
+    let virtual_file = project.find_by_original(&tsx_path).unwrap();
+
+    assert_ts_parses(&virtual_file.content);
+    assert!(
+        virtual_file
+            .content
+            .contains("__vize_jsx_expr__(props.color)"),
+        "{}",
+        virtual_file.content
+    );
+    assert!(
+        !virtual_file.content.contains("<style"),
+        "{}",
+        virtual_file.content
+    );
+
+    let _ = fs::remove_dir_all(&case_dir);
+}


### PR DESCRIPTION
## What's implemented

The final deferred piece of #1497: type-checking expressions embedded in JSX/TSX `<style scoped>` blocks (#1495).

A `<style scoped>` block is extracted out of the rendered children at lower time (PR #1534), so its **template-literal interpolations** (`${expr}`, e.g. `color: ${props.color}`) never reach the lowered relief tree and were previously not type-checked. This PR recovers them and routes them through the same type-checking path as every other JSX expression:

- **`vize_atelier_jsx`** — during style extraction (`lower/style.rs`), each `${expr}` in the style template literal is captured as a `ScopedStyleExpr { content, start, end }` (source text + byte range from `template.expressions`), instead of being silently dropped. These are exposed additively on `LoweredRoot::scoped_style_exprs` as a public `StyleExprSpan` list (mirroring the additive `scoped_css` field PR #1534 already added). The cooked CSS quasis are still concatenated for the scoping backends, and the DOM/Vapor backends ignore the new field (they only do CSS scoping).
- **`vize_canon`** — `jsx_codegen.rs` appends each style interpolation to its render root's collected expressions as a plain read, so it is re-emitted through the existing `__vize_jsx_expr__(...)` sink **in the root's scope** (props, setup-scope bindings, the `Ctx` context all in scope) and **source-mapped back** to its original `.tsx` `${…}` byte range. A wrong type inside a style interpolation is therefore reported at the interpolation.

## Verify-real

Real CLI under `typeChecker.jsxTypecheck: true`, checked with the actual tsgo (`@typescript/native-preview`) engine via `--corsa-path`:

- **Correct interpolation** (`color: ${props.color}` with `props: { color: string }`):
  - `vize check --show-virtual-ts` emits `const Good = (props: { color: string }) => ( __vize_jsx_expr__(props.color) );` — the `<div>`/`<style>` elements are gone and the interpolation is re-emitted through the sink.
  - tsgo: **No type errors found.**
- **Mistyped interpolation** (`width: ${props.widthhh}` with `props: { color: string }`):
  - tsgo: `error:4:43 [TS2339] Property 'widthhh' does not exist on type '{ color: string; }'.` — line 4, **column 43**, which is exactly the `widthhh` member inside the `${…}` of the `<style scoped>` block. The diagnostic maps to the original `.tsx`, not the synthesized virtual TS.

## Deferred (honest)

**CSS `v-bind(expr)`** references inside a `<style scoped>` block are *not* type-checked. Unlike template-literal interpolations (whose expression spans come straight from the OXC AST), `v-bind(...)` references live inside the cooked CSS text whose byte offsets no longer map back to source bytes after escape processing — recovering an accurate source span for the inner expression requires dedicated CSS-scanning + span-recovery infra, which would significantly expand this PR. The module docs and `jsx_codegen.rs` carry a clear deferral note. Template-literal-interpolation checking (the embedded style expressions) is fully covered.

Also still deferred from #1497 (unchanged): the stateful `defineComponent(() => () => VNode)` form and full source-map fidelity for the synthesized wrapper scaffolding.

## Gates

- **stable rustfmt** (`rustfmt` 1.95.0): clean (0 diffs) for `vize_canon` and `vize_atelier_jsx`.
- **clippy** (`-D warnings`): clean for both crates and `--workspace`.
- **tests**: `cargo test -p vize_canon -p vize_atelier_jsx` green. New unit tests in `jsx_codegen.rs` (single + multiple interpolations re-emitted through the sink with source mapping; static block adds no sink args), integration tests in `batch/virtual_project/tests.rs` (CLI-shape: re-emitted + `<style>` gone + parses), and `vize_atelier_jsx/tests/style.rs` (spans recovered with exact source text; static block exposes none).
- **semver**: `vize_canon` semver-checks passes (no public API change). `vize_atelier_jsx` adds a `pub` field + new `pub` struct — additive, matching the exact pattern PR #1534 landed for `scoped_css`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
