### PR TITLE
feat(integrations): JSX/TSX source-map + preamble plumbing and HMR (#1533)

### DIFF
--- a/crates/vize_atelier_jsx/src/compile.rs
+++ b/crates/vize_atelier_jsx/src/compile.rs
@@ -9,7 +9,7 @@
 //! routed to the backend its resolved mode selects, so a single file may mix
 //! VDOM and Vapor components.
 
-use vize_carton::Bump;
+use vize_carton::{Bump, FxHashSet, String};
 use vize_croquis::Croquis;
 
 use crate::diagnostics::JsxDiagnostic;
@@ -63,6 +63,32 @@ impl JsxComponent {
         }
     }
 
+    /// The import/preamble section for the component's runtime helpers.
+    ///
+    /// VDOM output keeps its `import { … } from "vue"` preamble structurally
+    /// separate from [`code`](Self::code), so a binding can hoist and dedupe it
+    /// across a module's components. The Vapor backend instead inlines its
+    /// imports into `code` (mirroring the SFC Vapor path), so its preamble is
+    /// empty here.
+    pub fn preamble(&self) -> &str {
+        match self {
+            Self::Dom(component) => component.preamble.as_str(),
+            Self::Vapor(_) => "",
+        }
+    }
+
+    /// The v3 source map (JSON) for the component's render code, present only
+    /// when source-map emission was requested via
+    /// [`DomCompileOptions::source_map`](crate::DomCompileOptions::source_map)
+    /// (#1533). VDOM output carries it; the Vapor backend does not emit one yet,
+    /// so it is always `None` there.
+    pub fn map(&self) -> Option<&str> {
+        match self {
+            Self::Dom(component) => component.map.as_deref(),
+            Self::Vapor(_) => None,
+        }
+    }
+
     /// The component's extracted `<style scoped>` block (#1495): the generated
     /// scope id plus the scoped-rewritten CSS, with the `data-v-<hash>`
     /// attribute already applied to the selectors. `None` when the component had
@@ -90,6 +116,150 @@ impl JsxCompileOutput {
     pub fn has_errors(&self) -> bool {
         self.diagnostics.iter().any(JsxDiagnostic::is_error)
     }
+
+    /// Assemble a single self-contained module string: the module's deduplicated
+    /// runtime-helper preamble followed by every component's render code in
+    /// source order.
+    ///
+    /// This mirrors the shape the SFC compile result surfaces — one ready-to-emit
+    /// module with its imports inlined — so the bindings and bundler plugins
+    /// treat JSX/TSX output the same way (#1533). The per-component VDOM
+    /// preambles (`import { … } from "vue"`) are merged into one import per
+    /// source so concatenating several components never redeclares a helper
+    /// binding; Vapor components inline their own imports into `code` and report
+    /// an empty preamble, so they pass through untouched.
+    pub fn module_code(&self) -> String {
+        let preamble = merge_preambles(self.components.iter().map(JsxComponent::preamble));
+
+        let mut module = preamble;
+        for component in &self.components {
+            let code = component.code();
+            if code.is_empty() {
+                continue;
+            }
+            if !module.is_empty() && !module.ends_with('\n') {
+                module.push('\n');
+            }
+            module.push_str(code);
+        }
+        module
+    }
+
+    /// The v3 source map (JSON) for the module's render code, when source-map
+    /// emission was requested (#1533).
+    ///
+    /// A map is surfaced only for a single-component module: codegen maps each
+    /// component's render code against the JSX source independently, and
+    /// concatenating several components shifts line offsets such that the
+    /// per-component maps no longer line up. A `.jsx`/`.tsx` file authored as one
+    /// component (the shape the bundler plugins consume) is the case that carries
+    /// a map; multi-component modules report `None` rather than a misaligned map.
+    pub fn source_map(&self) -> Option<&str> {
+        match self.components.as_slice() {
+            [only] => only.map(),
+            _ => None,
+        }
+    }
+}
+
+/// Merge a sequence of per-component preambles into one deduplicated preamble.
+///
+/// Each VDOM preamble is a line-oriented block — typically a single
+/// `import { name as _alias, … } from "vue"` statement (default JSX options emit
+/// no hoists, but any extra lines are preserved verbatim). Concatenating several
+/// components' preambles as-is would redeclare the same `_alias` bindings, which
+/// is an ESM error, so this collapses every `import … from "<src>"` line into a
+/// single import per source carrying the union of its specifiers in first-seen
+/// order. Non-import lines (e.g. static hoists) are kept verbatim, deduplicated,
+/// and appended after the merged imports.
+fn merge_preambles<'a>(preambles: impl Iterator<Item = &'a str>) -> String {
+    // Imports grouped by source module, each preserving first-seen specifier
+    // order; sources themselves preserve first-seen order via `import_sources`.
+    let mut import_sources: Vec<&str> = Vec::new();
+    let mut import_specifiers: Vec<Vec<&str>> = Vec::new();
+    let mut seen_specifiers: FxHashSet<(&str, &str)> = FxHashSet::default();
+    let mut extra_lines: Vec<&str> = Vec::new();
+    let mut seen_extra: FxHashSet<&str> = FxHashSet::default();
+
+    for preamble in preambles {
+        for line in preamble.lines() {
+            let trimmed = line.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+            match parse_named_import(trimmed) {
+                Some((specifiers, source)) => {
+                    let group = match import_sources.iter().position(|s| *s == source) {
+                        Some(index) => index,
+                        None => {
+                            import_sources.push(source);
+                            import_specifiers.push(Vec::new());
+                            import_sources.len() - 1
+                        }
+                    };
+                    for specifier in specifiers.split(',') {
+                        let specifier = specifier.trim();
+                        if specifier.is_empty() {
+                            continue;
+                        }
+                        if seen_specifiers.insert((source, specifier)) {
+                            import_specifiers[group].push(specifier);
+                        }
+                    }
+                }
+                None => {
+                    if seen_extra.insert(trimmed) {
+                        extra_lines.push(trimmed);
+                    }
+                }
+            }
+        }
+    }
+
+    let mut merged = String::default();
+    for (source, specifiers) in import_sources.iter().zip(import_specifiers.iter()) {
+        merged.push_str("import { ");
+        for (i, specifier) in specifiers.iter().enumerate() {
+            if i > 0 {
+                merged.push_str(", ");
+            }
+            merged.push_str(specifier);
+        }
+        merged.push_str(" } from \"");
+        merged.push_str(source);
+        merged.push_str("\"\n");
+    }
+    for line in extra_lines {
+        merged.push_str(line);
+        merged.push('\n');
+    }
+    merged
+}
+
+/// Parse a `import { a as _a, b as _b } from "src"` line into its
+/// specifier list (the text between the braces) and source module. Returns
+/// `None` for any line that is not a brace-style named import (so it is kept
+/// verbatim by [`merge_preambles`]).
+fn parse_named_import(line: &str) -> Option<(&str, &str)> {
+    let rest = line.strip_prefix("import")?;
+    let open = rest.find('{')?;
+    let close = rest.find('}')?;
+    if close < open {
+        return None;
+    }
+    let specifiers = &rest[open + 1..close];
+
+    let after = &rest[close + 1..];
+    let from = after.find("from")?;
+    let quoted = after[from + "from".len()..].trim();
+    let bytes = quoted.as_bytes();
+    let quote = *bytes.first()?;
+    if quote != b'"' && quote != b'\'' {
+        return None;
+    }
+    let inner = &quoted[1..];
+    let end = inner.find(quote as char)?;
+    Some((specifiers, &inner[..end]))
 }
 
 /// Resolve the effective output mode for a component: an explicit per-component
@@ -141,5 +311,113 @@ pub fn compile_jsx(
     JsxCompileOutput {
         components,
         diagnostics,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_named_import_specifiers_and_source() {
+        assert_eq!(
+            parse_named_import("import { a as _a, b as _b } from \"vue\""),
+            Some((" a as _a, b as _b ", "vue"))
+        );
+        // Single-quoted source is accepted too.
+        assert_eq!(
+            parse_named_import("import { x } from 'vue'"),
+            Some((" x ", "vue"))
+        );
+        // Non-imports and namespace/default imports are not brace-named imports.
+        assert_eq!(parse_named_import("const _hoisted = 1"), None);
+        assert_eq!(parse_named_import("import Foo from \"bar\""), None);
+    }
+
+    #[test]
+    fn merge_preambles_dedups_overlapping_vue_imports() {
+        // Two components importing overlapping helpers from "vue" must collapse to
+        // one import with each binding declared exactly once (concatenating the
+        // raw lines would redeclare `_createElementBlock`, an ESM error).
+        let merged = merge_preambles(
+            [
+                "import { createElementBlock as _createElementBlock } from \"vue\"\n",
+                "import { createElementBlock as _createElementBlock, toDisplayString as _toDisplayString } from \"vue\"\n",
+            ]
+            .into_iter(),
+        );
+        assert_eq!(
+            merged,
+            "import { createElementBlock as _createElementBlock, toDisplayString as _toDisplayString } from \"vue\"\n"
+        );
+    }
+
+    #[test]
+    fn merge_preambles_keeps_distinct_sources_and_hoists() {
+        // Distinct sources each get their own import (first-seen order), and a
+        // non-import hoist line is preserved verbatim after the imports.
+        let merged = merge_preambles(
+            [
+                "import { a as _a } from \"vue\"\nconst _hoisted = 1\n",
+                "import { b as _b } from \"other\"\n",
+            ]
+            .into_iter(),
+        );
+        assert_eq!(
+            merged,
+            "import { a as _a } from \"vue\"\nimport { b as _b } from \"other\"\nconst _hoisted = 1\n"
+        );
+    }
+
+    #[test]
+    fn module_code_prepends_merged_preamble_to_render_code() {
+        // A single VDOM component's module string is its preamble followed by the
+        // render code, so the emitted helpers are actually imported.
+        let bump = Bump::new();
+        let out = compile_jsx(
+            &bump,
+            "const A = () => <div>{x}</div>;",
+            JsxLang::Jsx,
+            &JsxCompileConfig::default(),
+        );
+        let module = out.module_code();
+        assert!(module.contains("from \"vue\""), "{module}");
+        assert!(module.contains("_createElementBlock"), "{module}");
+        // The import precedes the render code that references it.
+        let import_at = module.find("from \"vue\"").unwrap();
+        let usage_at = module.find("_createElementBlock(").unwrap();
+        assert!(
+            import_at < usage_at,
+            "preamble must precede usage: {module}"
+        );
+    }
+
+    #[test]
+    fn source_map_present_only_for_single_component_module() {
+        let bump = Bump::new();
+        let mut config = JsxCompileConfig::default();
+        config.dom.source_map = true;
+
+        let single = compile_jsx(
+            &bump,
+            "const A = () => <div>{x}</div>;",
+            JsxLang::Jsx,
+            &config,
+        );
+        assert_eq!(single.components.len(), 1);
+        let map = single.source_map().expect("single component carries a map");
+        assert!(map.contains("\"version\":3"), "{map}");
+
+        let multi = compile_jsx(
+            &bump,
+            "const A = () => <div>{x}</div>;\nconst B = () => <span>{y}</span>;",
+            JsxLang::Jsx,
+            &config,
+        );
+        assert!(multi.components.len() >= 2);
+        assert!(
+            multi.source_map().is_none(),
+            "multi-component module reports no map to avoid misalignment"
+        );
     }
 }

--- a/crates/vize_atelier_jsx/src/dom.rs
+++ b/crates/vize_atelier_jsx/src/dom.rs
@@ -49,6 +49,14 @@ pub struct DomComponent {
     pub code: String,
     /// Import/preamble section for runtime helpers.
     pub preamble: String,
+    /// v3 source map (JSON) mapping the generated render code back to the JSX
+    /// source, emitted only when [`DomCompileOptions::source_map`] is set
+    /// (#1533). `None` otherwise. The map's `mappings` cover the render
+    /// expression; it does not account for a prepended preamble, so a consumer
+    /// that inlines the preamble must offset accordingly (the bindings surface
+    /// the map alongside a `preamble` kept structurally separate for exactly
+    /// this reason).
+    pub map: Option<String>,
     /// Extracted `<style scoped>` block (#1495): the generated scope id and the
     /// scoped-rewritten CSS. `None` when the component had no `<style scoped>`.
     /// A bundler emits this CSS to a stylesheet (deferred, #1533); the scope id
@@ -161,6 +169,7 @@ pub(crate) fn compile_root_to_dom(
         mode: mode.unwrap_or(JsxOutputMode::Vdom),
         code: result.code,
         preamble: result.preamble,
+        map: result.map,
         scoped_style,
     }
 }

--- a/crates/vize_vitrine/src/napi/jsx.rs
+++ b/crates/vize_vitrine/src/napi/jsx.rs
@@ -38,6 +38,10 @@ pub struct JsxCompileOptionsNapi {
     /// (default) to VDOM. Kept for back-compat; prefer `jsxMode`. Ignored when
     /// `jsxMode` is set.
     pub vapor: Option<bool>,
+    /// Emit a v3 source map for the generated render code. When `true`, the
+    /// result's `map` carries the map JSON; when `false` (default), `map` is
+    /// `null` and no mapping work is done (#1533).
+    pub source_map: Option<bool>,
 }
 
 /// A JSX component's extracted `<style scoped>` block, surfaced to the bundler
@@ -57,9 +61,16 @@ pub struct JsxScopedStyleNapi {
 /// Result of [`compile_jsx`].
 #[napi(object)]
 pub struct JsxCompileResultNapi {
-    /// Generated render code for every component in the module, in source order,
-    /// concatenated.
+    /// Generated render code for the module: the deduplicated runtime-helper
+    /// preamble (`import { … } from "vue"`) followed by every component's render
+    /// code in source order. This is a self-contained module string, matching
+    /// the shape `compileSfc` returns, so a bundler can emit it directly
+    /// (the runtime-helper imports are no longer dropped, #1533).
     pub code: String,
+    /// v3 source map (JSON) for `code`, present only when `sourceMap` was
+    /// requested and the module is a single component (the per-file shape the
+    /// bundler plugins consume). `null` otherwise (#1533).
+    pub map: Option<String>,
     /// Error-severity diagnostic messages.
     pub errors: Vec<String>,
     /// Warning-severity diagnostic messages.
@@ -116,21 +127,23 @@ fn compile_jsx_impl(
 
     let default_mode = resolve_default_mode(opts.jsx_mode.as_deref(), opts.vapor);
 
-    let config = JsxCompileConfig {
+    let mut config = JsxCompileConfig {
         default_mode,
         ..Default::default()
     };
+    // Surface a v3 source map when requested. The flag only affects the VDOM
+    // codegen path (the Vapor backend does not emit a map yet); enabling it is a
+    // no-op for Vapor output.
+    config.dom.source_map = opts.source_map.unwrap_or(false);
 
     let bump = Bump::new();
     let output = jsx_compile(&bump, &source, lang, &config);
 
-    let mut code = String::new();
-    for component in &output.components {
-        if !code.is_empty() {
-            code.push('\n');
-        }
-        code.push_str(component.code());
-    }
+    // A single self-contained module: the deduplicated runtime-helper preamble
+    // followed by every component's render code (the preamble is no longer
+    // dropped, #1533).
+    let code = output.module_code().as_str().to_string();
+    let map = output.source_map().map(|map| map.to_string());
 
     let mut scoped_styles = Vec::new();
     for component in &output.components {
@@ -154,6 +167,7 @@ fn compile_jsx_impl(
 
     JsxCompileResultNapi {
         code,
+        map,
         errors,
         warnings,
         scoped_styles,
@@ -233,5 +247,53 @@ mod tests {
             result.scoped_styles.is_empty(),
             "no scoped styles without a <style scoped> block"
         );
+    }
+
+    #[test]
+    fn jsx_compile_result_includes_runtime_helper_preamble() {
+        // The result `code` must carry the runtime-helper imports so the emitted
+        // `_createElementBlock` / `_toDisplayString` helpers are actually
+        // imported (previously the preamble was dropped, #1533).
+        let source = "const App = () => <div>{message}</div>;\nexport default App;\n";
+        let result = compile_jsx_impl(source.to_string(), None);
+
+        assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+        assert!(
+            result.code.contains("from \"vue\""),
+            "code carries the runtime-helper import: {}",
+            result.code
+        );
+        // The import precedes the render code that references the helper.
+        let import_at = result.code.find("from \"vue\"").expect("vue import");
+        let usage_at = result
+            .code
+            .find("_createElementBlock(")
+            .expect("render uses _createElementBlock");
+        assert!(
+            import_at < usage_at,
+            "preamble precedes usage: {}",
+            result.code
+        );
+    }
+
+    #[test]
+    fn jsx_compile_result_surfaces_source_map_when_requested() {
+        let source = "const App = () => <div>{message}</div>;\nexport default App;\n";
+
+        // Off by default: no map.
+        let without = compile_jsx_impl(source.to_string(), None);
+        assert!(without.map.is_none(), "no map unless requested");
+
+        // On request: a non-empty v3 map.
+        let with = compile_jsx_impl(
+            source.to_string(),
+            Some(JsxCompileOptionsNapi {
+                source_map: Some(true),
+                ..Default::default()
+            }),
+        );
+        assert!(with.errors.is_empty(), "errors: {:?}", with.errors);
+        let map = with.map.expect("a map is surfaced when requested");
+        assert!(map.contains("\"version\":3"), "v3 source map: {map}");
     }
 }

--- a/crates/vize_vitrine/src/wasm/jsx.rs
+++ b/crates/vize_vitrine/src/wasm/jsx.rs
@@ -35,9 +35,14 @@ struct JsxScopedStyleWasm {
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 struct JsxWasmResult {
-    /// Generated render code for every component in the module, in source
-    /// order, concatenated.
+    /// Generated render code for the module: the deduplicated runtime-helper
+    /// preamble (`import { … } from "vue"`) followed by every component's render
+    /// code in source order — a self-contained module, matching the NAPI binding
+    /// and `compileSfc` (the helper imports are no longer dropped, #1533).
     code: String,
+    /// v3 source map (JSON) for `code`, present only when `sourceMap` was
+    /// requested and the module is a single component. `null` otherwise (#1533).
+    map: Option<String>,
     /// Error-severity diagnostic messages.
     errors: Vec<String>,
     /// Warning-severity diagnostic messages.
@@ -93,10 +98,20 @@ fn resolve_default_mode(options: &JsValue) -> JsxOutputMode {
     }
 }
 
+/// Resolve the `sourceMap` flag from the JS options object: `true` enables v3
+/// source-map emission, anything else (including omission) leaves it off.
+fn resolve_source_map(options: &JsValue) -> bool {
+    js_sys::Reflect::get(options, &JsValue::from_str("sourceMap"))
+        .ok()
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false)
+}
+
 fn compile_jsx_internal(source: &str, options: &JsValue) -> JsxWasmResult {
     let lang = resolve_lang(options);
     let default_mode = resolve_default_mode(options);
-    build_jsx_wasm_result(source, lang, default_mode)
+    let source_map = resolve_source_map(options);
+    build_jsx_wasm_result(source, lang, default_mode, source_map)
 }
 
 /// Build the JSX compile result from already-resolved options. Kept free of
@@ -106,22 +121,22 @@ fn build_jsx_wasm_result(
     source: &str,
     lang: JsxLang,
     default_mode: JsxOutputMode,
+    source_map: bool,
 ) -> JsxWasmResult {
-    let config = JsxCompileConfig {
+    let mut config = JsxCompileConfig {
         default_mode,
         ..Default::default()
     };
+    // Source maps are emitted by the VDOM codegen path; a no-op for Vapor.
+    config.dom.source_map = source_map;
 
     let bump = Bump::new();
     let output = jsx_compile(&bump, source, lang, &config);
 
-    let mut code = String::new();
-    for component in &output.components {
-        if !code.is_empty() {
-            code.push('\n');
-        }
-        code.push_str(component.code());
-    }
+    // A single self-contained module: deduplicated runtime-helper preamble + every
+    // component's render code (the preamble is no longer dropped, #1533).
+    let code = output.module_code().as_str().to_string();
+    let map = output.source_map().map(|map| map.to_string());
 
     let mut scoped_styles = Vec::new();
     for component in &output.components {
@@ -145,6 +160,7 @@ fn build_jsx_wasm_result(
 
     JsxWasmResult {
         code,
+        map,
         errors,
         warnings,
         scoped_styles,
@@ -173,7 +189,7 @@ mod tests {
                 </div>
             );
         "#;
-        let result = build_jsx_wasm_result(source, JsxLang::Jsx, JsxOutputMode::Vdom);
+        let result = build_jsx_wasm_result(source, JsxLang::Jsx, JsxOutputMode::Vdom, false);
 
         assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
         assert_eq!(
@@ -200,11 +216,44 @@ mod tests {
             "const App = () => <div class=\"box\">hi</div>;",
             JsxLang::Jsx,
             JsxOutputMode::Vdom,
+            false,
         );
         assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
         assert!(
             result.scoped_styles.is_empty(),
             "no scoped styles without a block"
         );
+    }
+
+    #[test]
+    fn wasm_jsx_result_includes_runtime_helper_preamble() {
+        // The WASM result `code` carries the runtime-helper imports so the
+        // playground emits a self-contained module (preamble no longer dropped,
+        // #1533).
+        let result = build_jsx_wasm_result(
+            "const App = () => <div>{message}</div>;",
+            JsxLang::Jsx,
+            JsxOutputMode::Vdom,
+            false,
+        );
+        assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+        assert!(
+            result.code.contains("from \"vue\"") && result.code.contains("_createElementBlock"),
+            "code carries the runtime-helper import: {}",
+            result.code
+        );
+    }
+
+    #[test]
+    fn wasm_jsx_result_surfaces_source_map_when_requested() {
+        let source = "const App = () => <div>{message}</div>;";
+
+        let without = build_jsx_wasm_result(source, JsxLang::Jsx, JsxOutputMode::Vdom, false);
+        assert!(without.map.is_none(), "no map unless requested");
+
+        let with = build_jsx_wasm_result(source, JsxLang::Jsx, JsxOutputMode::Vdom, true);
+        assert!(with.errors.is_empty(), "errors: {:?}", with.errors);
+        let map = with.map.expect("a map is surfaced when requested");
+        assert!(map.contains("\"version\":3"), "v3 source map: {map}");
     }
 }

--- a/npm/rspack-vize-plugin/src/loader/jsx-loader.ts
+++ b/npm/rspack-vize-plugin/src/loader/jsx-loader.ts
@@ -33,16 +33,24 @@ export default function vizeJsxLoader(
   }
 
   try {
-    const { code, warnings } = compileJsxModule(resourcePath, source, {
+    // Honor the loader's source-map setting (rspack toggles `this.sourceMap`
+    // from devtool); fall back to the explicit option, then on by default to
+    // match the `.vue` loader. Skipped only when the compiler tooling is off.
+    const sourceMap = options.sourceMap ?? this.sourceMap ?? true;
+
+    const { code, map, warnings } = compileJsxModule(resourcePath, source, {
       jsxMode: options.jsxMode,
       vapor: options.vapor ?? false,
+      sourceMap,
     });
 
     for (const warning of warnings) {
       this.emitWarning(new Error(`[vize] ${warning}`));
     }
 
-    callback(null, code);
+    // Forward the v3 map (parsed to the object rspack expects) so downstream
+    // devtools chain it back to the JSX source (#1533).
+    callback(null, code, map ? JSON.parse(map) : undefined);
   } catch (error) {
     callback(error as Error);
   }

--- a/npm/rspack-vize-plugin/src/shared/compiler.ts
+++ b/npm/rspack-vize-plugin/src/shared/compiler.ts
@@ -68,13 +68,14 @@ ${output}`;
 export function compileJsxModule(
   filePath: string,
   source: string,
-  options: { jsxMode?: "vdom" | "vapor"; vapor?: boolean } = {},
-): { code: string; warnings: string[] } {
+  options: { jsxMode?: "vdom" | "vapor"; vapor?: boolean; sourceMap?: boolean } = {},
+): { code: string; map: string | null; warnings: string[] } {
   const result = compileJsx(source, {
     filename: filePath,
     lang: filePath.endsWith(".tsx") ? "tsx" : "jsx",
     jsxMode: options.jsxMode,
     vapor: options.vapor ?? false,
+    sourceMap: options.sourceMap ?? false,
   });
 
   if (result.errors.length > 0) {
@@ -83,12 +84,16 @@ export function compileJsxModule(
 
   const css = (result.scopedStyles ?? []).map((style) => style.css).join("\n");
   let code = result.code;
+  // The native v3 map targets the unshifted render code; drop it once the
+  // inline-style injection prepends to `code` (#1533).
+  let map = result.map ?? null;
   if (css) {
     const styleKey = result.scopedStyles[0].scopeId.replace(/^data-v-/, "");
     code = prependInlineStyleInjection(code, css, styleKey);
+    map = null;
   }
 
-  return { code, warnings: result.warnings };
+  return { code, map, warnings: result.warnings };
 }
 
 // Compilation Cache

--- a/npm/rspack-vize-plugin/src/shared/jsx-compile.test.ts
+++ b/npm/rspack-vize-plugin/src/shared/jsx-compile.test.ts
@@ -1,0 +1,36 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { compileJsxModule } from "./compiler.ts";
+
+const SOURCE = "const App = () => <div>{message}</div>;\nexport default App;\n";
+
+void test("compileJsxModule includes the runtime-helper preamble in the emitted module", () => {
+  // The VDOM render code references `_createElementBlock` / `_toDisplayString`,
+  // so the emitted module must import them — the preamble is no longer dropped
+  // (#1533).
+  const { code } = compileJsxModule("/src/App.tsx", SOURCE, { jsxMode: "vdom" });
+  assert.match(
+    code,
+    /import \{[^}]*createElementBlock[^}]*\} from "vue"/,
+    "the module imports its runtime helpers",
+  );
+  assert.match(code, /_createElementBlock\("div"/, "the render code uses the imported helper");
+});
+
+void test("compileJsxModule surfaces a v3 source map when sourceMap is requested", () => {
+  const { map } = compileJsxModule("/src/App.tsx", SOURCE, { jsxMode: "vdom", sourceMap: true });
+  assert.equal(typeof map, "string", "a source map is surfaced when requested");
+  assert.match(String(map), /"version":\s*3/, "the source map is v3");
+});
+
+void test("compileJsxModule omits the source map when sourceMap is off", () => {
+  const { map } = compileJsxModule("/src/App.tsx", SOURCE, { jsxMode: "vdom", sourceMap: false });
+  assert.equal(map, null, "no source map unless requested");
+});
+
+void test("compileJsxModule has no source map for Vapor output", () => {
+  // The Vapor backend does not emit a source map yet, so even with `sourceMap`
+  // requested the result carries none (#1533).
+  const { map } = compileJsxModule("/src/App.tsx", SOURCE, { vapor: true, sourceMap: true });
+  assert.equal(map, null, "Vapor output reports no source map");
+});

--- a/npm/rspack-vize-plugin/src/types/index.ts
+++ b/npm/rspack-vize-plugin/src/types/index.ts
@@ -77,6 +77,8 @@ export interface JsxCompileOptionsNapi {
   jsxMode?: "vdom" | "vapor";
   /** Legacy default-mode toggle: `true` → Vapor, `false` (default) → VDOM. */
   vapor?: boolean;
+  /** Emit a v3 source map for the generated render code (#1533). */
+  sourceMap?: boolean;
 }
 
 /** A JSX component's extracted `<style scoped>` block (#1495, #1533). */
@@ -89,8 +91,17 @@ export interface JsxScopedStyleNapi {
 
 /** Result of the native `compileJsx`. */
 export interface JsxCompileResultNapi {
-  /** Generated render code for every component in the module. */
+  /**
+   * Generated render code for the module: the deduplicated runtime-helper
+   * preamble followed by every component's render code (the helper imports are
+   * no longer dropped, #1533).
+   */
   code: string;
+  /**
+   * v3 source map (JSON) for `code`, present only when `sourceMap` was requested
+   * and the module is a single component. `null`/absent otherwise (#1533).
+   */
+  map?: string;
   /** Error-severity diagnostic messages. */
   errors: string[];
   /** Warning-severity diagnostic messages. */

--- a/npm/unplugin-vize/src/compiler.ts
+++ b/npm/unplugin-vize/src/compiler.ts
@@ -96,12 +96,13 @@ export function compileJsxModule(
   filePath: string,
   source: string,
   options: NormalizedVizeUnpluginOptions,
-): { code: string; warnings: string[] } {
+): { code: string; map: string | null; warnings: string[] } {
   const result = compileJsx(source, {
     filename: filePath,
     lang: filePath.endsWith(".tsx") ? "tsx" : "jsx",
     jsxMode: options.jsxMode,
     vapor: options.vapor,
+    sourceMap: options.sourceMap,
   });
 
   if (result.errors.length > 0) {
@@ -115,13 +116,18 @@ export function compileJsxModule(
   // are concatenated and emitted verbatim.
   const css = (result.scopedStyles ?? []).map((style) => style.css).join("\n");
   let code = result.code;
+  // The native v3 map targets the unshifted render code, so it is dropped once
+  // the inline-style injection prepends to `code` (#1533).
+  let map = result.map ?? null;
   if (css) {
     const styleKey = result.scopedStyles[0].scopeId.replace(/^data-v-/, "");
     code = prependInlineStyleInjection(code, css, styleKey);
+    map = null;
   }
 
   return {
     code,
+    map,
     warnings: result.warnings,
   };
 }

--- a/npm/unplugin-vize/src/jsx.test.ts
+++ b/npm/unplugin-vize/src/jsx.test.ts
@@ -118,6 +118,36 @@ void test("jsxMode:'vdom' keeps the vdom default even when vapor:true", async (t
   );
 });
 
+void test("a .tsx transform carries the runtime-helper preamble and a source map", async (t) => {
+  // The VDOM render code references `_createElementBlock` / `_toDisplayString`,
+  // so the emitted module must import them (the preamble is no longer dropped);
+  // with `sourceMap` on, a single-component module also surfaces a v3 map
+  // (#1533).
+  const id = resolveFixturePath("jsx", "App.tsx");
+  const plugin = vizeUnplugin.raw(
+    { isProduction: false, sourceMap: true, root: packageRoot },
+    { framework: "rollup" },
+  );
+  const transform = plugin.transform;
+  if (typeof transform !== "function") {
+    throw new Error("plugin.transform is not a function");
+  }
+  const result = (await transform.call(
+    { warn() {} } as never,
+    "const App = () => <div>{message}</div>;\nexport default App;\n",
+    id,
+  )) as TransformResult | null;
+
+  t.assert.ok(result && typeof result === "object", "transform returns a result object");
+  t.assert.match(
+    result.code,
+    /import \{[^}]*createElementBlock[^}]*\} from "vue"/,
+    "the emitted module imports its runtime helpers",
+  );
+  t.assert.equal(typeof result.map, "string", "a source map is surfaced when requested");
+  t.assert.match(String(result.map), /"version":\s*3/, "the surfaced source map is v3");
+});
+
 void test("a .tsx <style scoped> block emits scope-rewritten CSS through the plugin", async (t) => {
   // Mirrors the SFC plain-CSS path: a JSX/TSX `<style scoped>` block becomes
   // emitted CSS the bundler picks up, with the `data-v-<hash>` scope id already

--- a/npm/unplugin-vize/src/types.ts
+++ b/npm/unplugin-vize/src/types.ts
@@ -18,6 +18,8 @@ export interface JsxCompileOptionsNapi {
   /** Default JSX output mode; mirrors `compiler.jsxMode`, wins over `vapor`. */
   jsxMode?: "vdom" | "vapor";
   vapor?: boolean;
+  /** Emit a v3 source map for the generated render code (#1533). */
+  sourceMap?: boolean;
 }
 
 /** A JSX component's extracted `<style scoped>` block (#1495, #1533). */
@@ -29,7 +31,17 @@ export interface JsxScopedStyleNapi {
 }
 
 export interface JsxCompileResultNapi {
+  /**
+   * Self-contained module: the deduplicated runtime-helper preamble followed by
+   * every component's render code (the helper imports are no longer dropped,
+   * #1533).
+   */
   code: string;
+  /**
+   * v3 source map (JSON) for `code`, present only when `sourceMap` was requested
+   * and the module is a single component. `null` otherwise (#1533).
+   */
+  map?: string;
   errors: string[];
   warnings: string[];
   /**

--- a/npm/unplugin-vize/src/unplugin.ts
+++ b/npm/unplugin-vize/src/unplugin.ts
@@ -241,13 +241,18 @@ export const vizeUnplugin = createUnplugin<VizeUnpluginOptions | undefined>((raw
         if (!filter(id)) {
           return null;
         }
-        const { code: jsxCode, warnings } = compileJsxModule(id, code, options);
+        const { code: jsxCode, map: jsxMap, warnings } = compileJsxModule(id, code, options);
         for (const warning of warnings) {
           this.warn(`[vize] ${warning}`);
         }
+        // HMR (deferred, #1533): the JSX compiler emits a render-function-only
+        // module with no component object to attach a Vue HMR record to (unlike
+        // the `.vue` path's `_sfc_main`), so a state-preserving boundary awaits
+        // the JSX component-wrapper output. Source map + preamble plumbing land
+        // now (`map` above, preamble inside `compileJsxModule`).
         return {
           code: jsxCode,
-          map: null,
+          map: jsxMap,
         };
       }
 

--- a/npm/vite-plugin-vize/src/compiler.ts
+++ b/npm/vite-plugin-vize/src/compiler.ts
@@ -200,26 +200,35 @@ export interface JsxCompileFileOptions {
    * path which only injects on the client.
    */
   ssr?: boolean;
+  /**
+   * Request a v3 source map for the generated render code (#1533). When set,
+   * the returned `map` carries the map JSON (or `null` when the native compiler
+   * produced none, e.g. a Vapor component or a multi-component module).
+   */
+  sourceMap?: boolean;
 }
 
 /**
  * Compile a `.jsx`/`.tsx` Vue component module to render code through Vize.
  *
  * Mirrors `compileFile` for SFCs but routes through the native `compileJsx`
- * binding. A component's `<style scoped>` CSS is surfaced (already
- * scope-rewritten) and emitted through the same inline-injection path plain SFC
- * `<style>` blocks use (#1495, #1533).
+ * binding. The returned `code` is a self-contained module (the runtime-helper
+ * preamble is included, #1533), and `map` carries a v3 source map when
+ * `sourceMap` is requested. A component's `<style scoped>` CSS is surfaced
+ * (already scope-rewritten) and emitted through the same inline-injection path
+ * plain SFC `<style>` blocks use (#1495, #1533).
  */
 export function compileJsxModule(
   filePath: string,
   source: string,
   options: JsxCompileFileOptions = {},
-): { code: string; warnings: string[] } {
+): { code: string; map: string | null; warnings: string[] } {
   const result = compileJsx(source, {
     filename: filePath,
     lang: filePath.endsWith(".tsx") ? "tsx" : "jsx",
     jsxMode: options.jsxMode,
     vapor: options.vapor ?? false,
+    sourceMap: options.sourceMap ?? false,
   });
 
   if (result.errors.length > 0) {
@@ -232,13 +241,18 @@ export function compileJsxModule(
   // verbatim. Skipped under SSR, matching the SFC inline-CSS path.
   const css = (result.scopedStyles ?? []).map((style) => style.css).join("\n");
   let code = result.code;
+  // Prepending the inline-style injection shifts the render code, so the v3 map
+  // (which targets the unshifted render code) is dropped once we mutate `code`.
+  let map = result.map ?? null;
   if (css && !options.ssr) {
     const styleKey = result.scopedStyles[0].scopeId.replace(/^data-v-/, "");
     code = prependInlineStyleInjection(code, css, styleKey);
+    map = null;
   }
 
   return {
     code,
+    map,
     warnings: result.warnings,
   };
 }

--- a/npm/vite-plugin-vize/src/plugin/load.test.ts
+++ b/npm/vite-plugin-vize/src/plugin/load.test.ts
@@ -904,7 +904,25 @@ assert.match(
   /_createElementBlock\("div"/,
   "VDOM .jsx components should compile to Vize render code through the transform hook",
 );
-assert.equal(jsxTransform.map, null, "JSX transform should not allocate a discarded sourcemap");
+// The render code's runtime helpers must be imported (the preamble is no longer
+// dropped, #1533).
+assert.match(
+  jsxTransform.code,
+  /import \{[^}]*createElementBlock[^}]*\} from "vue"/,
+  "VDOM .jsx output should carry the runtime-helper import preamble",
+);
+// Source maps are on in dev (isProduction === false), so a single-component
+// .jsx transform surfaces a v3 map (parsed to the object form Vite expects) for
+// the bundler to consume (#1533).
+assert.ok(
+  jsxTransform.map && typeof jsxTransform.map === "object",
+  "JSX transform should surface a source map object in dev",
+);
+assert.equal(
+  (jsxTransform.map as { version?: number }).version,
+  3,
+  "the surfaced JSX source map should be v3",
+);
 
 const jsxVaporState: VizePluginState = {
   ...jsxState,
@@ -922,6 +940,12 @@ assert.match(
   jsxVaporTransform.code,
   /_template\(/,
   "Vapor .jsx components should compile to hoisted templates through the transform hook",
+);
+// The Vapor backend does not emit a source map yet, so the transform reports none.
+assert.equal(
+  jsxVaporTransform.map,
+  null,
+  "Vapor .jsx transform has no source map (Vapor codegen does not emit one yet)",
 );
 
 const tsxFsTransform = await transformHook(

--- a/npm/vite-plugin-vize/src/plugin/load.ts
+++ b/npm/vite-plugin-vize/src/plugin/load.ts
@@ -437,17 +437,40 @@ export function transformJsxRequest(
     ? classifyVitePluginRequest(request.normalizedFsId).path
     : request.path;
 
-  const { code: compiled, warnings } = compileJsxModule(realPath, code, {
+  const ssr = options?.ssr ?? false;
+  // Match the SFC path's source-map policy: on unless explicitly disabled or in
+  // a production build (#1533).
+  const sourceMap = getCompileOptionsForRequest(state, ssr).sourceMap;
+
+  const {
+    code: compiled,
+    map,
+    warnings,
+  } = compileJsxModule(realPath, code, {
     jsxMode: state.mergedOptions.jsxMode,
     vapor: state.mergedOptions.vapor ?? false,
-    ssr: options?.ssr ?? false,
+    ssr,
+    sourceMap,
   });
 
   for (const warning of warnings) {
     state.logger.warn(`Warning in ${realPath}: ${warning}`);
   }
 
-  return { code: compiled, map: null };
+  // HMR (deferred, #1533): unlike `.vue` SFCs — whose compiled module exposes a
+  // `_sfc_main` component object that the injected `import.meta.hot.accept`
+  // boundary attaches an `__hmrId`/HMR record to (see
+  // `vize_atelier_sfc::vite_plugin::generate_hmr_code`) — the JSX compiler emits
+  // a render-function-only module (`export function render(…)`) with no
+  // component object to register against. A state-preserving Vue HMR boundary
+  // (`__VUE_HMR_RUNTIME__.rerender`/`reload`) therefore needs the upcoming
+  // JSX component-wrapper output before it can hook up; until then `.jsx`/`.tsx`
+  // edits fall back to Vite's default module reload. Source map + preamble
+  // plumbing (this function's `map`/preamble) land now.
+  //
+  // Vite's `TransformResult.map` is the object form, so parse the native v3 JSON
+  // map before handing it back (#1533).
+  return { code: compiled, map: map ? JSON.parse(map) : null };
 }
 
 // Strip TypeScript from compiled .vue output and apply define replacements

--- a/npm/vite-plugin-vize/src/types.ts
+++ b/npm/vite-plugin-vize/src/types.ts
@@ -61,6 +61,11 @@ export interface JsxCompileOptionsNapi {
    */
   jsxMode?: "vdom" | "vapor";
   vapor?: boolean;
+  /**
+   * Emit a v3 source map for the generated render code (#1533). When `true`,
+   * the result's `map` carries the map JSON; `null` otherwise.
+   */
+  sourceMap?: boolean;
 }
 
 /** A JSX component's extracted `<style scoped>` block (#1495, #1533). */
@@ -73,7 +78,17 @@ export interface JsxScopedStyleNapi {
 
 /** Result of the native `compileJsx` binding. */
 export interface JsxCompileResultNapi {
+  /**
+   * Self-contained module: the deduplicated runtime-helper preamble followed by
+   * every component's render code, in source order (the helper imports are no
+   * longer dropped, #1533).
+   */
   code: string;
+  /**
+   * v3 source map (JSON) for `code`, present only when `sourceMap` was
+   * requested and the module is a single component. `null` otherwise (#1533).
+   */
+  map?: string;
   errors: string[];
   warnings: string[];
   /**

--- a/npm/vize-native/index.d.ts
+++ b/npm/vize-native/index.d.ts
@@ -246,15 +246,30 @@ export interface JsxCompileOptionsNapi {
    * `jsxMode` is set.
    */
   vapor?: boolean;
+  /**
+   * Emit a v3 source map for the generated render code. When `true`, the
+   * result's `map` carries the map JSON; when `false` (default), `map` is
+   * `null` and no mapping work is done (#1533).
+   */
+  sourceMap?: boolean;
 }
 
 /** Result of `compileJsx`. */
 export interface JsxCompileResultNapi {
   /**
-   * Generated render code for every component in the module, in source order,
-   * concatenated.
+   * Generated render code for the module: the deduplicated runtime-helper
+   * preamble (`import { … } from "vue"`) followed by every component's render
+   * code in source order. A self-contained module string, matching the shape
+   * `compileSfc` returns (the runtime-helper imports are no longer dropped,
+   * #1533).
    */
   code: string;
+  /**
+   * v3 source map (JSON) for `code`, present only when `sourceMap` was
+   * requested and the module is a single component (the per-file shape the
+   * bundler plugins consume). `null` otherwise (#1533).
+   */
+  map?: string;
   /** Error-severity diagnostic messages. */
   errors: Array<string>;
   /** Warning-severity diagnostic messages. */


### PR DESCRIPTION
Part of #1533. Lands the source-map and preamble integration tail for JSX/TSX components through the napi/wasm bindings and the vite/unplugin/rspack plugins, and documents the HMR deferral. Builds on the merged source-map codegen (#1547), CSS emission (#1550), and `jsxMode` (#1539).

## Source maps
- **atelier_jsx**: `DomComponent` now retains `result.map` (it was dropped). `JsxComponent` gains `map()` / `preamble()` accessors; `JsxCompileOutput` gains `module_code()` (merged preamble + concatenated render code) and `source_map()`.
- **napi/wasm `compileJsx`**: a new `sourceMap` option enables the previously dead `source_map` passthrough; the result surfaces `map` (v3 JSON). A map is surfaced only for a single-component module (the per-`.jsx`/`.tsx`-file shape the plugins consume); a multi-component module reports `null` rather than a misaligned map (concatenation shifts line offsets).
- **vite / unplugin / rspack**: the JSX compile path now requests source maps (matching each plugin's existing source-map policy) and forwards the map through the bundler `transform` / loader return — parsed to the object form Vite/rspack expect. The map is dropped when the inline `<style scoped>` injection prepends to the code (it would no longer line up).

## Preamble
- `compileJsx` output is now a **self-contained module**: the deduplicated runtime-helper preamble (`import { … } from "vue"`) followed by every component's render code, matching how the SFC compile result inlines its imports. Previously only `component.code()` was concatenated and `DomComponent.preamble` was **dropped**, so the emitted `_createElementBlock` / `_toDisplayString` helpers were never imported.
- Overlapping per-component imports are merged into one import per source so concatenating several components never redeclares a helper binding (an ESM error); non-import preamble lines (e.g. static hoists) are preserved verbatim.

## HMR (honestly deferred, documented)
The JSX compiler emits a **render-function-only** module (`export function render(_ctx, _cache)`) and drops the source's component definition / `export default`. Unlike the `.vue` path — whose compiled module exposes a `_sfc_main` component object that the injected `import.meta.hot.accept` boundary attaches an `__hmrId` / HMR record to (`vize_atelier_sfc::vite_plugin::generate_hmr_code`) — there is no component object to register against, so a state-preserving Vue HMR boundary (`__VUE_HMR_RUNTIME__.rerender` / `reload`) can't hook up until the JSX **component-wrapper** output lands. This is documented at the vite/unplugin JSX transform sites; `.jsx`/`.tsx` edits fall back to the bundler's default module reload today. Per the issue's guidance, the two fully-completable items (source maps + preamble) land solidly and HMR is deferred with a clear note.

## Tests
- **napi** (`vize_vitrine --features napi`): preamble present in `code` (import precedes helper usage); non-empty v3 `map` only when `sourceMap` requested.
- **wasm** (`vize_vitrine --features wasm`): same preamble + map coverage on the host-testable result builder.
- **atelier_jsx**: `merge_preambles` dedups overlapping `vue` imports / keeps distinct sources + hoists; `module_code()` prepends the merged preamble; `source_map()` present only for a single-component module.
- **plugins** (`node --test`): vite `load.test.ts` (VDOM `.jsx` transform carries the import preamble + a v3 map object; Vapor transform has no map); unplugin `jsx.test.ts` (`.tsx` transform preamble + v3 map); rspack `shared/jsx-compile.test.ts` (preamble, map on/off, Vapor → no map).

## Gates
- Stable rustfmt (1.95.0) clean for `vize_atelier_jsx` + `vize_vitrine`.
- `cargo clippy -p vize_vitrine --features napi|wasm -- -D warnings`: zero new lints on the touched `napi/jsx.rs` / `wasm/jsx.rs` (the pre-existing `napi/config/*` + `template_syntax.rs` errors are untouched and unrelated).
- `cargo clippy -p vize_atelier_jsx -- -D warnings`: clean.
- `cargo test -p vize_atelier_jsx` / `-p vize_vitrine` (napi + wasm) / `cargo check --workspace`: green.
- `node --test` for the three plugins: green (native module rebuilt with the changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1557"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->