### PR TITLE
fix(ci): isolate docs musea cargo target

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -116,6 +116,8 @@ jobs:
         run: vp run --filter './playground' build
 
       - name: Build musea-examples
+        env:
+          CARGO_TARGET_DIR: target/docs-example
         run: vp run --filter './examples/vite-musea' build
 
       - name: Upload playground artifact

--- a/tests/tooling/github-workflows.test.ts
+++ b/tests/tooling/github-workflows.test.ts
@@ -844,6 +844,16 @@ test("deploy-docs deploy job keeps a full checkout so local actions and scripts 
   assert.doesNotMatch(deployJob, /sparse-checkout:/);
 });
 
+test("deploy-docs isolates musea example cargo checks from the sticky target cache", () => {
+  const workflow = readRepoFile(".github", "workflows", "deploy-docs.yml");
+  const buildPlaygroundJob = workflowJobBody(workflow, "build-playground");
+
+  assert.match(
+    buildPlaygroundJob,
+    /- name: Build musea-examples\s+env:\s+CARGO_TARGET_DIR:\s*target\/docs-example\s+run: vp run --filter '\.\/examples\/vite-musea' build/,
+  );
+});
+
 test("WASM build jobs install MoonBit before invoking moon run", () => {
   const cases = [
     {


### PR DESCRIPTION
## Summary

- isolate the docs Musea example cargo check with `CARGO_TARGET_DIR=target/docs-example`
- add a workflow-shape test so the isolated target is kept in place

## Why

Main currently has a failing Deploy docs run in `build-playground` while building `examples/vite-musea`. The failing command uses `cargo run`, and the shared sticky `target/debug` cache referenced a missing proc-macro artifact. Keeping this step on an isolated target avoids poisoning or consuming that shared cache while preserving the example package script for local development.

Closes #1567

## Validation

- `node --test tests/tooling/github-workflows.test.ts`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1568"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->