### PR TITLE
fix(ci): allow cold coverage runs

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -402,7 +402,7 @@ jobs:
 
   coverage:
     runs-on: blacksmith-32vcpu-ubuntu-2404
-    timeout-minutes: 10
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 

--- a/tests/tooling/github-workflows.test.ts
+++ b/tests/tooling/github-workflows.test.ts
@@ -232,7 +232,7 @@ test("PR CI jobs cap runtime with explicit timeouts", () => {
     ["build-js-packages", 30],
     ["test-js-packages", 30],
     ["clippy-and-test", 30],
-    ["coverage", 10],
+    ["coverage", 30],
     ["source-coverage", 40],
     ["branch-coverage", 45],
     ["playground-test", 30],


### PR DESCRIPTION
## Summary\n- Increase the fixture coverage job timeout from 10 to 30 minutes so main can pass when sticky disks are unavailable.\n- Keep the workflow timeout assertion in sync.\n\n## Validation\n- node --test tests/tooling/github-workflows.test.ts\n- git diff --check\n\nCloses #1571

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1572"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->