### PR TITLE
refactor(vdom): remove vdomm typo references

### DIFF
--- a/crates/vize_atelier_jsx/src/finder.rs
+++ b/crates/vize_atelier_jsx/src/finder.rs
@@ -102,7 +102,7 @@ impl RootLowerer<'_, '_, '_, '_> {
     /// prologue, reporting diagnostics for malformed or conflicting directives.
     ///
     /// - A directive that opens with `"use vue:"` but does not name a known mode
-    ///   (e.g. `"use vue:vdomm"`) is almost always a typo, so it is reported as
+    ///   (e.g. `"use vue:vdomx"`) is almost always a typo, so it is reported as
     ///   an error and otherwise ignored.
     /// - Two directives selecting *different* modes in one body conflict; the
     ///   first wins and the later one is reported as an error.

--- a/crates/vize_atelier_jsx/src/mode.rs
+++ b/crates/vize_atelier_jsx/src/mode.rs
@@ -86,7 +86,7 @@ pub enum DirectiveKind {
     /// A recognized mode directive (`"use vue:vapor"` / `"use vue:vdom"`).
     Mode(JsxOutputMode),
     /// A directive that opens with the Vize `"use vue:"` prefix but does not
-    /// name a known mode (e.g. `"use vue:vdomm"`). The payload is the unknown
+    /// name a known mode (e.g. `"use vue:vdomx"`). The payload is the unknown
     /// suffix after the prefix, for a targeted diagnostic.
     MalformedVue,
     /// A directive unrelated to Vize JSX mode selection (e.g. `"use strict"`),
@@ -98,7 +98,7 @@ pub enum DirectiveKind {
 ///
 /// Distinguishes a recognized mode directive from a *malformed* one — a
 /// directive that begins with `"use vue:"` but does not name a known mode,
-/// which is almost always a typo (`"use vue:vdomm"`, `"use vue:VAPOR"`) and so
+/// which is almost always a typo (`"use vue:vdomx"`, `"use vue:VAPOR"`) and so
 /// should be surfaced — and from an unrelated prologue, which is ignored.
 pub fn classify_directive(directive: &str) -> DirectiveKind {
     if let Some(mode) = JsxOutputMode::from_directive(directive) {
@@ -175,7 +175,7 @@ mod tests {
     fn classify_flags_malformed_vue_directives() {
         // Typos in the suffix are the common case we want to catch.
         assert_eq!(
-            classify_directive("use vue:vdomm"),
+            classify_directive("use vue:vdomx"),
             DirectiveKind::MalformedVue
         );
         assert_eq!(

--- a/crates/vize_atelier_jsx/tests/modes.rs
+++ b/crates/vize_atelier_jsx/tests/modes.rs
@@ -61,10 +61,10 @@ fn unrelated_prologue_produces_no_diagnostic() {
 
 #[test]
 fn malformed_vue_directive_is_diagnosed() {
-    // A typo'd suffix (`vdomm`) opens with `use vue:` so it is almost certainly
+    // A typo'd suffix (`vdomx`) opens with `use vue:` so it is almost certainly
     // a mistyped mode directive; report it instead of silently ignoring it.
     let bump = Bump::new();
-    let src = "const App = () => { \"use vue:vdomm\"; return <div/>; };";
+    let src = "const App = () => { \"use vue:vdomx\"; return <div/>; };";
     let out = lower_source(&bump, src, JsxLang::Jsx);
     assert!(out.has_errors(), "expected a diagnostic for the typo");
     assert_eq!(out.diagnostics.len(), 1);
@@ -74,7 +74,7 @@ fn malformed_vue_directive_is_diagnosed() {
     assert!(diag.end > diag.start);
     assert_eq!(
         &src[diag.start as usize..diag.end as usize],
-        "\"use vue:vdomm\""
+        "\"use vue:vdomx\""
     );
     // The unknown directive does not select a mode.
     assert_eq!(out.roots.len(), 1);

--- a/crates/vize_atelier_jsx/tests/snapshots/modes__malformed_vue_directive_is_diagnosed.snap
+++ b/crates/vize_atelier_jsx/tests/snapshots/modes__malformed_vue_directive_is_diagnosed.snap
@@ -5,7 +5,7 @@ expression: out.diagnostics
 [
     JsxDiagnostic {
         severity: Error,
-        message: "unknown JSX mode directive \"use vue:vdomm\": expected \"use vue:vdom\" or \"use vue:vapor\"",
+        message: "unknown JSX mode directive \"use vue:vdomx\": expected \"use vue:vdom\" or \"use vue:vapor\"",
         start: 20,
         end: 35,
     },

--- a/crates/vize_maestro/src/ide/diagnostics/tests.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/tests.rs
@@ -666,7 +666,7 @@ fn collect_does_not_misdiagnose_valid_vapor_mode_tsx() {
     );
 }
 
-/// A malformed mode directive (`"use vue:vdomm"`, a typo) surfaces as a JSX
+/// A malformed mode directive (`"use vue:vdomx"`, a typo) surfaces as a JSX
 /// compiler error with the exact guidance message.
 #[test]
 fn collect_surfaces_malformed_mode_directive_on_tsx() {
@@ -674,7 +674,7 @@ fn collect_surfaces_malformed_mode_directive_on_tsx() {
     let uri = Url::parse("file:///Typo.tsx").unwrap();
     state.documents.open(
         uri.clone(),
-        "const C = () => {\n  \"use vue:vdomm\";\n  return <div>hi</div>;\n};\n".to_string(),
+        "const C = () => {\n  \"use vue:vdomx\";\n  return <div>hi</div>;\n};\n".to_string(),
         1,
         "typescriptreact".to_string(),
     );
@@ -692,7 +692,7 @@ fn collect_surfaces_malformed_mode_directive_on_tsx() {
     );
     assert_eq!(
         mode_errors[0].message,
-        "unknown JSX mode directive \"use vue:vdomm\": expected \"use vue:vdom\" or \"use vue:vapor\""
+        "unknown JSX mode directive \"use vue:vdomx\": expected \"use vue:vdom\" or \"use vue:vapor\""
     );
     assert_eq!(mode_errors[0].severity, Some(DiagnosticSeverity::ERROR));
     // The squiggle lands on the directive line (line index 1).

--- a/crates/vize_maestro/src/server/handlers.rs
+++ b/crates/vize_maestro/src/server/handlers.rs
@@ -1271,7 +1271,7 @@ mod tests {
         let uri = Url::parse("file:///ModeSwitch.tsx").unwrap();
         // A typo'd mode directive (error) plus a `<style scoped>` so the JSX
         // scoped-CSS virtual doc is part of what must be rebuilt.
-        let before = "const C = () => {\n  \"use vue:vdomm\";\n  return (\n    <>\n      <div class=\"box\">hi</div>\n      <style scoped>{`.box { color: red; }`}</style>\n    </>\n  );\n};\n";
+        let before = "const C = () => {\n  \"use vue:vdomx\";\n  return (\n    <>\n      <div class=\"box\">hi</div>\n      <style scoped>{`.box { color: red; }`}</style>\n    </>\n  );\n};\n";
         futures::executor::block_on(server.did_open(DidOpenTextDocumentParams {
             text_document: TextDocumentItem {
                 uri: uri.clone(),
@@ -1286,7 +1286,7 @@ mod tests {
         let before_diags = crate::ide::DiagnosticService::collect(&server.state, &uri);
         assert!(
             before_diags.iter().any(|d| d.message
-                == "unknown JSX mode directive \"use vue:vdomm\": expected \"use vue:vdom\" or \"use vue:vapor\""),
+                == "unknown JSX mode directive \"use vue:vdomx\": expected \"use vue:vdom\" or \"use vue:vapor\""),
             "expected the malformed-directive diagnostic before the edit, got: {before_diags:?}"
         );
         assert_eq!(

--- a/docs/content/guide/configuration.md
+++ b/docs/content/guide/configuration.md
@@ -318,7 +318,7 @@ The output mode for a component resolves in this order:
 ### Diagnostics
 
 A directive that begins with `"use vue:"` but does not name a known mode (a typo such as
-`"use vue:vdomm"`) is reported as a compile error rather than silently ignored, and two conflicting
+`"use vue:vdomx"`) is reported as a compile error rather than silently ignored, and two conflicting
 mode directives in one component (`"use vue:vapor"` followed by `"use vue:vdom"`) are likewise
 diagnosed. Unrelated prologues such as `"use strict"` are left untouched.
 

--- a/docs/content/guide/jsx.md
+++ b/docs/content/guide/jsx.md
@@ -248,7 +248,7 @@ The output mode for a component resolves in this order:
 Malformed or conflicting directives are reported rather than silently ignored:
 
 - A directive that begins with `"use vue:"` but does not name a known mode (a typo such as
-  `"use vue:vdomm"`) is a compile error.
+  `"use vue:vdomx"`) is a compile error.
 - Two conflicting mode directives in one component (`"use vue:vapor"` followed by `"use vue:vdom"`)
   are diagnosed; the first directive still wins for the resolved mode.
 - Unrelated prologues such as `"use strict"` are left untouched.


### PR DESCRIPTION
## Summary\n- Replace stale malformed-directive examples that used `vdomm` with `vdomx`.\n- Keep the valid JSX directive name as `use vue:vdom` and preserve malformed-directive coverage.\n- Confirm there are no remaining `vdomm` references in docs, crates, npm, or tests.\n\n## Validation\n- cargo test -p vize_atelier_jsx --test modes malformed_vue_directive_is_diagnosed\n- cargo test -p vize_maestro collect_surfaces_malformed_mode_directive_on_tsx\n- cargo test -p vize_maestro directive_edit_reinvalidates_jsx_diagnostics_and_virtual_docs\n- rg -n "vdomm|Vdomm|VDOMM" docs crates npm tests --glob '!target/**'\n- git diff --check\n\nCloses #1576

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1602"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->