### PR TITLE
fix(ci): allow slow nix flake checks

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -27,7 +27,7 @@ env:
 jobs:
   nix-flake:
     runs-on: blacksmith-32vcpu-ubuntu-2404
-    timeout-minutes: 30
+    timeout-minutes: 60
     # Nix store cache restore + `nix flake check` was the second-slowest PR
     # gate after playground-test. The flake itself rarely changes between
     # PRs, so run it on push-to-main (catches merge regressions within

--- a/tests/tooling/github-workflows.test.ts
+++ b/tests/tooling/github-workflows.test.ts
@@ -219,7 +219,7 @@ test("PR CI jobs cap runtime with explicit timeouts", () => {
   const toolBenchmarkWorkflow = readRepoFile(".github", "workflows", "tool-benchmark.yml");
 
   for (const [jobName, minutes] of [
-    ["nix-flake", 30],
+    ["nix-flake", 60],
     ["fmt-rust", 10],
     ["check-js", 15],
     ["security-audit", 20],


### PR DESCRIPTION
## Summary\n- Raise the main/scheduled nix flake check timeout from 30 to 60 minutes.\n- Keep the workflow timeout assertion in sync.\n\n## Context\nThe post-merge main Check for #1602 timed out while `nix flake check` was still fetching dependencies over a slow connection.\n\n## Validation\n- node --test tests/tooling/github-workflows.test.ts\n- git diff --check\n\nRefs #1597

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1603"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->