### PR TITLE
refactor(atelier): introduce transform pipeline aliases

### DIFF
--- a/crates/vize_atelier_core/src/lib.rs
+++ b/crates/vize_atelier_core/src/lib.rs
@@ -17,6 +17,8 @@ pub mod runtime_helpers;
 pub mod test_macros;
 pub mod transform;
 pub mod transforms;
+pub use transform as pipeline;
+pub use transforms as passes;
 
 // Re-export from vize_relief (AST, errors, options)
 pub use vize_relief::errors::{CompilerError, CompilerResult, ErrorCode};

--- a/crates/vize_atelier_dom/src/compile.rs
+++ b/crates/vize_atelier_dom/src/compile.rs
@@ -6,7 +6,7 @@ use vize_atelier_core::{
     codegen::generate_with_sections,
     options::{CodegenOptions, ParserOptions, TemplateSyntaxMode, TransformOptions},
     parser::parse_with_options_and_template_syntax,
-    transform::{
+    pipeline::{
         transform as do_transform, transform_with_hoisted_scope_id,
         transform_with_template_syntax_quirks,
         transform_with_template_syntax_quirks_and_hoisted_scope_id,

--- a/crates/vize_atelier_dom/src/lib.rs
+++ b/crates/vize_atelier_dom/src/lib.rs
@@ -17,6 +17,7 @@ mod compile;
 mod namespace;
 pub mod options;
 pub mod transforms;
+pub use transforms as passes;
 
 #[cfg(test)]
 mod tests;
@@ -44,5 +45,5 @@ pub use transforms::{
 // Re-export core types
 pub use vize_atelier_core::{
     Allocator, CompilerError, ElementNode, Namespace, RootNode, TemplateChildNode, codegen, errors,
-    parser, runtime_helpers, tokenizer, transform,
+    parser, pipeline, runtime_helpers, tokenizer, transform,
 };

--- a/crates/vize_atelier_ssr/src/codegen/element/component.rs
+++ b/crates/vize_atelier_ssr/src/codegen/element/component.rs
@@ -823,7 +823,7 @@ impl<'a> SsrCodegenContext<'a> {
         match arg {
             // `@click`, `@custom-event`, desugared `onUpdate:foo` (`Update:foo`).
             ExpressionNode::Simple(arg) if arg.is_static => {
-                let key = vize_atelier_core::transforms::create_on_name(&arg.content);
+                let key = vize_atelier_core::passes::create_on_name(&arg.content);
                 entries.push(component_prop_entry(&key, &handler, false));
             }
             // Dynamic event name: `@[name]="handler"`.
@@ -846,8 +846,8 @@ impl<'a> SsrCodegenContext<'a> {
             return rendered;
         }
 
-        if vize_atelier_core::transforms::transform_expression::is_function_expression(&rendered)
-            || vize_atelier_core::transforms::is_event_handler_reference_expression(&rendered)
+        if vize_atelier_core::passes::transform_expression::is_function_expression(&rendered)
+            || vize_atelier_core::passes::is_event_handler_reference_expression(&rendered)
         {
             return rendered;
         }

--- a/crates/vize_atelier_ssr/src/codegen/element/props.rs
+++ b/crates/vize_atelier_ssr/src/codegen/element/props.rs
@@ -20,7 +20,7 @@ pub(super) fn slot_props_pattern_to_string(expr: &ExpressionNode) -> String {
         ExpressionNode::Simple(simple) => simple.loc.source.clone(),
         ExpressionNode::Compound(compound) => compound.loc.source.clone(),
     };
-    vize_atelier_core::transforms::strip_typescript_from_expression(&source)
+    vize_atelier_core::passes::strip_typescript_from_expression(&source)
 }
 
 pub(super) fn component_prop_entry(key: &str, value: &str, dynamic: bool) -> VNodePropEntry {

--- a/crates/vize_atelier_ssr/src/lib.rs
+++ b/crates/vize_atelier_ssr/src/lib.rs
@@ -20,6 +20,7 @@ pub mod codegen;
 pub mod errors;
 pub mod options;
 pub mod transforms;
+pub use transforms as passes;
 
 pub use codegen::{SsrCodegenContext, SsrCodegenResult};
 pub use errors::SsrErrorCode;
@@ -32,13 +33,14 @@ pub use transforms::{
 // Re-export core types
 pub use vize_atelier_core::{
     Allocator, CompilerError, Namespace, RootNode, RuntimeHelper, TemplateChildNode,
-    codegen as core_codegen, errors as core_errors, parser, runtime_helpers, tokenizer, transform,
+    codegen as core_codegen, errors as core_errors, parser, pipeline, runtime_helpers, tokenizer,
+    transform,
 };
 
 use vize_atelier_core::{
     options::{ParserOptions, TemplateSyntaxMode, TransformOptions},
     parser::parse_with_options_and_template_syntax,
-    transform::{transform as do_transform, transform_with_template_syntax_quirks},
+    pipeline::{transform as do_transform, transform_with_template_syntax_quirks},
 };
 use vize_carton::{Bump, String, profile};
 

--- a/crates/vize_atelier_vapor/src/compile.rs
+++ b/crates/vize_atelier_vapor/src/compile.rs
@@ -4,12 +4,12 @@
 //! code generation behind the public `compile_vapor*` functions.
 
 use crate::generate::generate_vapor;
-use crate::transform;
+use crate::pipeline as vapor_pipeline;
 use vize_atelier_core::{
     CompilerError, Namespace,
     options::{ParserOptions, TemplateSyntaxMode, TransformOptions},
     parser::parse_with_options_and_template_syntax,
-    transform::{transform, transform_with_template_syntax_quirks},
+    pipeline::{transform, transform_with_template_syntax_quirks},
 };
 use vize_carton::{Bump, String};
 
@@ -150,7 +150,8 @@ fn compile_vapor_inner<'a>(
     }
 
     // Transform to Vapor IR
-    let (ir, transform_diagnostics) = transform::transform_to_ir_with_diagnostics(allocator, &root);
+    let (ir, transform_diagnostics) =
+        vapor_pipeline::transform_to_ir_with_diagnostics(allocator, &root);
 
     // Generate Vapor code
     let result = generate_vapor(&ir, binding_metadata.as_ref());

--- a/crates/vize_atelier_vapor/src/lib.rs
+++ b/crates/vize_atelier_vapor/src/lib.rs
@@ -11,6 +11,8 @@ pub mod generators;
 pub mod ir;
 pub mod transform;
 pub mod transforms;
+pub use transform as pipeline;
+pub use transforms as passes;
 
 #[cfg(test)]
 mod tests;


### PR DESCRIPTION
## Summary
- Add public `pipeline` aliases for atelier transform driver/context modules.
- Add public `passes` aliases for atelier transform pass collections.
- Update a few internal compile/codegen call sites to use the clearer aliases while preserving existing `transform` and `transforms` exports.

Refs #1575

## Tests
- `cargo fmt --check`
- `cargo check -p vize_atelier_core -p vize_atelier_dom -p vize_atelier_ssr -p vize_atelier_vapor`
- `cargo test -p vize_atelier_core -p vize_atelier_dom -p vize_atelier_ssr -p vize_atelier_vapor`