### PR TITLE
fix(musea): populate props controls for inline art

### DIFF
--- a/npm/vite-plugin-musea/src/api-routes/handler-palette.ts
+++ b/npm/vite-plugin-musea/src/api-routes/handler-palette.ts
@@ -58,8 +58,8 @@ export async function handleArtPalette(
       };
     }
 
-    // If the native palette returned no controls, try JS-based SFC analysis
-    if (palette.controls.length === 0 && art.metadata.component) {
+    // If the native palette returned no controls, try SFC analysis of the resolved component.
+    if (palette.controls.length === 0) {
       const resolvedComponentPath = resolveComponentSourcePath(
         art,
         artPath,

--- a/npm/vite-plugin-musea/src/api-routes/index.test.ts
+++ b/npm/vite-plugin-musea/src/api-routes/index.test.ts
@@ -203,3 +203,81 @@ void test("createApiMiddleware returns 400 for malformed art source JSON", async
     await fs.promises.rm(tempDir, { recursive: true, force: true });
   }
 });
+
+void test("createApiMiddleware populates inline art palette controls from host component props", async () => {
+  const tempDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "musea-api-inline-palette-"));
+  const componentPath = path.join(tempDir, "src", "InlineButton.vue");
+
+  try {
+    await fs.promises.mkdir(path.dirname(componentPath), { recursive: true });
+    await fs.promises.writeFile(
+      componentPath,
+      `<script setup lang="ts">
+defineProps<{
+  tone?: "brand" | "neutral";
+  disabled?: boolean;
+}>()
+</script>
+
+<template>
+  <button :disabled="disabled">{{ tone }}</button>
+</template>
+
+<art title="Inline Button">
+  <variant name="Default">
+    <Self tone="brand" :disabled="false" />
+  </variant>
+</art>
+`,
+      "utf-8",
+    );
+
+    const art = createArt(componentPath);
+    art.isInline = true;
+    art.componentPath = componentPath;
+
+    const ctx = createContext(tempDir, new Map([[componentPath, art]]));
+    const response = await invokeApi(ctx, {
+      method: "GET",
+      url: `/arts/${encodeURIComponent(componentPath)}/palette`,
+    });
+
+    assert.equal(response.statusCode, 200, response.body);
+
+    const body = JSON.parse(response.body) as {
+      controls: Array<{
+        name: string;
+        control: string;
+        required: boolean;
+        options: Array<{ label: string; value: unknown }>;
+      }>;
+    };
+    assert.deepEqual(
+      body.controls.map((control) => ({
+        name: control.name,
+        control: control.control,
+        required: control.required,
+        options: control.options,
+      })),
+      [
+        {
+          name: "tone",
+          control: "select",
+          required: false,
+          options: [
+            { label: "brand", value: "brand" },
+            { label: "neutral", value: "neutral" },
+          ],
+        },
+        {
+          name: "disabled",
+          control: "boolean",
+          required: false,
+          options: [],
+        },
+      ],
+    );
+  } finally {
+    await fs.promises.rm(tempDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Refs #1585

## Summary
- use the shared component-source resolver when native palette generation returns no controls
- add an inline art API regression test for controls populated from host component props

## Tests
- vp run --filter './npm/vite-plugin-musea' test
- vp run --filter './npm/vite-plugin-musea' check
- vp run --filter './npm/vite-plugin-musea' build:gallery

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1608"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->