### PR TITLE
perf(build): report stats compile cache counters

### DIFF
--- a/crates/vize/src/commands/build/runner/compile.rs
+++ b/crates/vize/src/commands/build/runner/compile.rs
@@ -85,6 +85,7 @@ pub(super) fn compile_file_stats_with_cache(
             .map(|entries| entries.get(&key).cloned())
             .unwrap_or(None)
     {
+        global_profiler().record_counter("cache.stats_compile.hits", 1);
         return match entry {
             StatsCompileCacheEntry::Success {
                 output_bytes,
@@ -111,6 +112,9 @@ pub(super) fn compile_file_stats_with_cache(
             }),
         };
     }
+    if cache_key.is_some() {
+        global_profiler().record_counter("cache.stats_compile.misses", 1);
+    }
 
     let parse_start = Instant::now();
     let parse_opts = SfcParseOptions {
@@ -123,12 +127,13 @@ pub(super) fn compile_file_stats_with_cache(
             if let Some(key) = cache_key
                 && let Ok(mut entries) = cache.entries.lock()
             {
-                entries
-                    .entry(key)
-                    .or_insert_with(|| StatsCompileCacheEntry::Failure {
+                entries.entry(key).or_insert_with(|| {
+                    global_profiler().record_counter("cache.stats_compile.stores", 1);
+                    StatsCompileCacheEntry::Failure {
                         phase: ErrorPhase::Parse,
                         message: error.message.clone(),
-                    });
+                    }
+                });
             }
             return Err(CompileError {
                 path: path.clone(),
@@ -199,12 +204,13 @@ pub(super) fn compile_file_stats_with_cache(
             if let Some(key) = cache_key
                 && let Ok(mut entries) = cache.entries.lock()
             {
-                entries
-                    .entry(key)
-                    .or_insert_with(|| StatsCompileCacheEntry::Failure {
+                entries.entry(key).or_insert_with(|| {
+                    global_profiler().record_counter("cache.stats_compile.stores", 1);
+                    StatsCompileCacheEntry::Failure {
                         phase: ErrorPhase::Compile,
                         message: error.message.clone(),
-                    });
+                    }
+                });
             }
             return Err(CompileError {
                 path: path.clone(),
@@ -222,14 +228,15 @@ pub(super) fn compile_file_stats_with_cache(
     if let Some(key) = cache_key
         && let Ok(mut entries) = cache.entries.lock()
     {
-        entries
-            .entry(key)
-            .or_insert_with(|| StatsCompileCacheEntry::Success {
+        entries.entry(key).or_insert_with(|| {
+            global_profiler().record_counter("cache.stats_compile.stores", 1);
+            StatsCompileCacheEntry::Success {
                 output_bytes,
                 template_size,
                 script_size,
                 style_count,
-            });
+            }
+        });
     }
 
     Ok((

--- a/crates/vize/tests/build_cli.rs
+++ b/crates/vize/tests/build_cli.rs
@@ -42,7 +42,8 @@ fn build_stats_profile_reports_compile_cache_counters() {
             "--profile",
             "--threads",
             "1",
-            "src/*.vue",
+            "src/App.vue",
+            "src/Foo.vue",
         ])
         .output()
         .unwrap();

--- a/crates/vize/tests/build_cli.rs
+++ b/crates/vize/tests/build_cli.rs
@@ -26,6 +26,44 @@ fn write_project_file(root: &Path, path: &str, content: &str) {
 }
 
 #[test]
+fn build_stats_profile_reports_compile_cache_counters() {
+    let project_root = temp_project_dir("stats-profile-cache-counters");
+    let source = r#"<template><div>Hello</div></template>
+"#;
+    write_project_file(&project_root, "src/App.vue", source);
+    write_project_file(&project_root, "src/Foo.vue", source);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_vize"))
+        .current_dir(&project_root)
+        .args([
+            "build",
+            "--format",
+            "stats",
+            "--profile",
+            "--threads",
+            "1",
+            "src/*.vue",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("Stats compile cache"), "{stderr}");
+    assert!(stderr.contains("cache.stats_compile.hits"), "{stderr}");
+    assert!(stderr.contains("cache.stats_compile.misses"), "{stderr}");
+    assert!(stderr.contains("cache.stats_compile.stores"), "{stderr}");
+
+    let _ = fs::remove_dir_all(project_root);
+}
+
+#[test]
 fn build_resolves_imported_base_interface_props_in_normal_script() {
     let project_root = temp_project_dir("imported-base-interface-props");
     write_project_file(

--- a/crates/vize_curator/src/profile/mod.rs
+++ b/crates/vize_curator/src/profile/mod.rs
@@ -93,6 +93,12 @@ pub fn render_profile_report(report: &ProfileReport<'_>) -> String {
 
     render_strict_audit(&mut out, report);
     render_allocation_table(&mut out, report);
+    render_counter_table(
+        &mut out,
+        report,
+        "Stats compile cache",
+        "cache.stats_compile.",
+    );
     render_counter_table(&mut out, report, "I/O counters", "io.");
     render_counter_table(&mut out, report, "System calls", "syscall.");
     render_phase_table(&mut out, report);

--- a/crates/vize_curator/src/profile/snapshots/vize_curator__profile__tests__profile_report_snapshot.snap
+++ b/crates/vize_curator/src/profile/snapshots/vize_curator__profile__tests__profile_report_snapshot.snap
@@ -30,6 +30,12 @@ expression: render_profile_report(&report)
   dealloc                  35      48.00 KiB         0  [90mreleased layouts[0m
   net delta        n/a             32.00 KiB         0  profile-window requested minus released
 
+[1mStats compile cache[0m
+[90m  counter                                samples    total        avg         min         max[0m
+  cache.stats_compile.hits                     1           7         7.0           7           7
+  cache.stats_compile.misses                   1           3         3.0           3           3
+  cache.stats_compile.stores                   1           3         3.0           3           3
+
 [1mI/O counters[0m
 [90m  counter                                samples    total        avg         min         max[0m
   io.read.bytes                                1     2.00 KiB        2.00 KiB     2.00 KiB     2.00 KiB

--- a/crates/vize_curator/src/profile/tests.rs
+++ b/crates/vize_curator/src/profile/tests.rs
@@ -81,6 +81,30 @@ fn profile_report_snapshot() {
     let counters = CounterSummary {
         entries: vec![
             CounterEntry {
+                name: "cache.stats_compile.hits",
+                samples: 1,
+                total: 7,
+                average: 7.0,
+                min: 7,
+                max: 7,
+            },
+            CounterEntry {
+                name: "cache.stats_compile.misses",
+                samples: 1,
+                total: 3,
+                average: 3.0,
+                min: 3,
+                max: 3,
+            },
+            CounterEntry {
+                name: "cache.stats_compile.stores",
+                samples: 1,
+                total: 3,
+                average: 3.0,
+                min: 3,
+                max: 3,
+            },
+            CounterEntry {
                 name: "io.read.bytes",
                 samples: 1,
                 total: 2048,


### PR DESCRIPTION
## Summary
- record stats-only compile cache hits, misses, and stores in profile counters
- render a dedicated stats compile cache counter table in profile reports
- add focused coverage for profile rendering and stats-profile CLI output

Refs #1601

## Tests
- `git diff --check`
- `INSTA_UPDATE=always cargo test -p vize_curator profile_report_snapshot`
- `cargo test -p vize_curator profile_report_snapshot`
- `cargo check -p vize --test build_cli`
- `cargo test -p vize --test build_cli build_stats_profile_reports_compile_cache_counters` attempted locally, but the machine ran out of disk space while writing build artifacts (`os error 28`); full integration validation is left to GitHub Actions.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1609"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->