### PR TITLE
lint(rust): ban wildcard use imports

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -394,7 +394,7 @@ jobs:
           cache-key-suffix: ${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('Cargo.lock') }}
 
       - name: Clippy
-        run: cargo clippy --workspace -- -D warnings
+        run: cargo clippy --workspace -- -D warnings -D clippy::wildcard_imports
       - name: Install Pkl CLI
         run: npm install --global @pkl-community/pkl@0.27.2
       - name: Test

--- a/crates/vize_armature/src/parser.rs
+++ b/crates/vize_armature/src/parser.rs
@@ -17,9 +17,9 @@ mod tests;
 
 use vize_carton::{Bump, String, Vec};
 use vize_relief::{
+    ElementNode, Namespace, Position, PropNode, RootNode, SourceLocation, TemplateChildNode,
     errors::{CompilerError, ErrorCode},
     options::{ParserOptions, TemplateSyntaxMode, WhitespaceStrategy},
-    *,
 };
 
 use crate::tokenizer::Tokenizer;

--- a/crates/vize_armature/src/parser/element/classify.rs
+++ b/crates/vize_armature/src/parser/element/classify.rs
@@ -1,6 +1,6 @@
 //! Element-type classification, component detection, and namespace resolution.
 
-use vize_relief::*;
+use vize_relief::{ElementNode, ElementType, Namespace, PropNode};
 
 use super::super::Parser;
 

--- a/crates/vize_armature/src/parser/element/comment.rs
+++ b/crates/vize_armature/src/parser/element/comment.rs
@@ -1,7 +1,7 @@
 //! Comment and CDATA processing.
 
 use vize_carton::{Box, directive::parse_vize_directive};
-use vize_relief::*;
+use vize_relief::{CommentNode, ErrorCode, Namespace, TemplateChildNode};
 
 use super::super::Parser;
 

--- a/crates/vize_armature/src/parser/element/formatting.rs
+++ b/crates/vize_armature/src/parser/element/formatting.rs
@@ -1,7 +1,7 @@
 //! Adoption-agency recovery for misnested formatting end tags.
 
 use vize_carton::Vec;
-use vize_relief::*;
+use vize_relief::ElementNode;
 
 use super::super::{Parser, ParserStackEntry, StackInsertion};
 

--- a/crates/vize_armature/src/parser/element/scope.rs
+++ b/crates/vize_armature/src/parser/element/scope.rs
@@ -1,7 +1,7 @@
 //! "In body" start-tag handling: implicit end-tag closing and HTML scopes
 //! (`<a>`/`<button>`/`<li>`/`<dt>`/`<dd>`/`<option>`/`<optgroup>`/`<p>`).
 
-use vize_relief::*;
+use vize_relief::{ElementNode, ElementType};
 
 use super::super::Parser;
 

--- a/crates/vize_armature/src/parser/element/table.rs
+++ b/crates/vize_armature/src/parser/element/table.rs
@@ -1,7 +1,7 @@
 //! Table foster parenting and implicit table section/row insertion.
 
 use vize_carton::Vec;
-use vize_relief::*;
+use vize_relief::ElementNode;
 
 use super::super::{Parser, ParserStackEntry, StackInsertion};
 

--- a/crates/vize_armature/src/parser/element/tags.rs
+++ b/crates/vize_armature/src/parser/element/tags.rs
@@ -2,9 +2,10 @@
 
 use vize_carton::{Box, Vec};
 use vize_relief::{
+    AttributeNode, ElementNode, ElementType, ExpressionNode, Namespace, PropNode,
+    TemplateChildNode, TextNode,
     errors::{CompilerError, ErrorCode},
     options::TemplateSyntaxMode,
-    *,
 };
 
 use super::super::{CurrentElement, Parser, ParserStackEntry, StackInsertion};

--- a/crates/vize_armature/src/parser/element/text.rs
+++ b/crates/vize_armature/src/parser/element/text.rs
@@ -1,7 +1,9 @@
 //! Text, fostered text, and interpolation processing.
 
 use vize_carton::Box;
-use vize_relief::*;
+use vize_relief::{
+    ExpressionNode, InterpolationNode, SimpleExpressionNode, TemplateChildNode, TextNode,
+};
 
 use super::super::Parser;
 

--- a/crates/vize_atelier_core/src/codegen/children.rs
+++ b/crates/vize_atelier_core/src/codegen/children.rs
@@ -1,7 +1,9 @@
 //! Children, text, comment, and interpolation generation functions.
 
 use crate::transforms::hoist_static::is_static_node;
-use crate::*;
+use crate::{
+    CommentNode, ElementNode, InterpolationNode, RuntimeHelper, TemplateChildNode, TextNode,
+};
 
 use super::context::CodegenContext;
 use super::element::helpers::{child_namespace, has_renderable_props};

--- a/crates/vize_atelier_core/src/codegen/element/inline.rs
+++ b/crates/vize_atelier_core/src/codegen/element/inline.rs
@@ -4,8 +4,8 @@
 //! and `createVNode()` instead of their block counterparts.
 
 use crate::{
+    ElementNode, ElementType, ExpressionNode, PropNode, RuntimeHelper,
     transforms::v_memo::{get_memo_exp, has_v_memo},
-    *,
 };
 
 use super::{

--- a/crates/vize_atelier_core/src/codegen/node.rs
+++ b/crates/vize_atelier_core/src/codegen/node.rs
@@ -1,6 +1,6 @@
 //! Node generation functions.
 
-use crate::*;
+use crate::TemplateChildNode;
 
 use super::children::{generate_comment, generate_interpolation, generate_text};
 use super::context::CodegenContext;

--- a/crates/vize_atelier_core/src/codegen/patch_flag.rs
+++ b/crates/vize_atelier_core/src/codegen/patch_flag.rs
@@ -2,7 +2,7 @@
 
 use super::helpers::camelize;
 use crate::options::{BindingMetadata, BindingType};
-use crate::*;
+use crate::{DirectiveNode, ElementNode, ElementType, ExpressionNode, PropNode, TemplateChildNode};
 use oxc_ast::ast as oxc_ast_types;
 use oxc_parser::Parser;
 use oxc_span::SourceType;

--- a/crates/vize_atelier_core/src/codegen/slots/detect.rs
+++ b/crates/vize_atelier_core/src/codegen/slots/detect.rs
@@ -1,7 +1,7 @@
 //! Slot detection predicates (which children form slots, dynamic/forwarded checks).
 
 use crate::transforms::v_slot::{collect_slots, has_v_slot};
-use crate::*;
+use crate::{ElementNode, ElementType, PropNode, TemplateChildNode};
 
 /// Check if component has slot children that need to be generated as slots object
 pub fn has_slot_children(el: &ElementNode<'_>) -> bool {

--- a/crates/vize_atelier_core/src/codegen/slots/generate.rs
+++ b/crates/vize_atelier_core/src/codegen/slots/generate.rs
@@ -1,7 +1,9 @@
 //! Slots object generation for component children.
 
 use crate::transforms::v_slot::{collect_slots, get_slot_name, has_v_slot};
-use crate::*;
+use crate::{
+    ElementNode, ExpressionNode, ForNode, IfNode, PropNode, RuntimeHelper, TemplateChildNode,
+};
 use vize_carton::String;
 use vize_carton::ToCompactString;
 

--- a/crates/vize_atelier_core/src/codegen/slots/outlet.rs
+++ b/crates/vize_atelier_core/src/codegen/slots/outlet.rs
@@ -1,6 +1,6 @@
 //! Slot outlet (`<slot />`) name and props generation.
 
-use crate::*;
+use crate::{DirectiveNode, ElementNode, ExpressionNode, PropNode, RuntimeHelper};
 use vize_carton::String;
 
 use super::super::context::CodegenContext;

--- a/crates/vize_atelier_core/src/codegen/slots/params.rs
+++ b/crates/vize_atelier_core/src/codegen/slots/params.rs
@@ -1,6 +1,6 @@
 //! Slot parameter helpers (scoped slot props parsing and prefixing).
 
-use crate::*;
+use crate::{DirectiveNode, ExpressionNode};
 use vize_carton::String;
 
 /// Get slot props expression as raw source (not transformed)

--- a/crates/vize_atelier_core/src/codegen/v_for/generate.rs
+++ b/crates/vize_atelier_core/src/codegen/v_for/generate.rs
@@ -4,8 +4,8 @@
 //! including props merging, key handling, and block wrapping.
 
 use crate::{
+    ElementNode, ElementType, ExpressionNode, PropNode, RuntimeHelper, TemplateChildNode,
     transforms::v_memo::{get_memo_exp, has_v_memo},
-    *,
 };
 
 use super::super::{

--- a/crates/vize_atelier_core/src/transform.rs
+++ b/crates/vize_atelier_core/src/transform.rs
@@ -13,7 +13,10 @@ use vize_croquis::{Croquis, ScopeChain};
 use crate::errors::CompilerError;
 use crate::options::TransformOptions;
 use crate::runtime_helpers::RuntimeHelpers;
-use crate::*;
+use crate::{
+    CacheExpression, DirectiveNode, ElementNode, ForNode, IfBranchNode, IfNode, JsChildNode,
+    PropNode, RootNode, RuntimeHelper, TemplateChildNode,
+};
 
 use traverse::traverse_children;
 

--- a/crates/vize_atelier_core/src/transform/context.rs
+++ b/crates/vize_atelier_core/src/transform/context.rs
@@ -6,7 +6,10 @@ use vize_croquis::{BindingType, Croquis, ScopeBinding, ScopeKind, VForScopeData,
 
 use crate::errors::{CompilerError, ErrorCode};
 use crate::options::TransformOptions;
-use crate::*;
+use crate::{
+    CacheExpression, CommentNode, ConstantType, ExpressionNode, JsChildNode, RuntimeHelper,
+    SimpleExpressionNode, SourceLocation, TemplateChildNode,
+};
 
 use super::TransformContext;
 

--- a/crates/vize_atelier_core/src/transform/element.rs
+++ b/crates/vize_atelier_core/src/transform/element.rs
@@ -5,7 +5,10 @@ use vize_carton::{Box, String, Vec, capitalize, is_builtin_directive, is_native_
 use crate::errors::ErrorCode;
 use crate::transforms::transform_expression::process_inline_handler;
 use crate::transforms::v_slot::validate_v_slot_usage;
-use crate::*;
+use crate::{
+    ConstantType, DirectiveNode, ElementNode, ElementType, ExpressionNode, InterpolationNode,
+    PropNode, RuntimeHelper, SimpleExpressionNode, SourceLocation,
+};
 
 use super::{ExitFns, TransformContext};
 

--- a/crates/vize_atelier_core/src/transform/structural.rs
+++ b/crates/vize_atelier_core/src/transform/structural.rs
@@ -3,7 +3,10 @@
 use vize_carton::{Box, String, Vec};
 
 use crate::errors::ErrorCode;
-use crate::*;
+use crate::{
+    ConstantType, ElementNode, ElementType, ExpressionNode, ForNode, ForParseResult, IfBranchNode,
+    IfNode, PropNode, RuntimeHelper, SimpleExpressionNode, SourceLocation, TemplateChildNode,
+};
 
 use super::context::clone_expression;
 use super::traverse::traverse_children;

--- a/crates/vize_atelier_core/src/transform/traverse.rs
+++ b/crates/vize_atelier_core/src/transform/traverse.rs
@@ -1,7 +1,10 @@
 //! AST traversal functions for template transformation.
 
 use crate::transforms::v_slot::{get_slot_name, get_slot_prop_names, get_slot_props_string};
-use crate::*;
+use crate::{
+    ElementNode, ElementType, ExpressionNode, ForNode, IfBranchNode, PropNode, RuntimeHelper,
+    TemplateChildNode,
+};
 use vize_carton::profile;
 
 use super::element::{transform_element, transform_interpolation};

--- a/crates/vize_atelier_core/src/transforms/hoist_static.rs
+++ b/crates/vize_atelier_core/src/transforms/hoist_static.rs
@@ -6,7 +6,12 @@ use vize_carton::{Box, Bump, String, ToCompactString, Vec, camelize};
 
 use crate::codegen::is_constant_simple_expression;
 use crate::transform::TransformContext;
-use crate::*;
+use crate::{
+    AttributeNode, DirectiveNode, ElementNode, ElementType, ExpressionNode, JsChildNode, Namespace,
+    ObjectExpression, PropNode, Property, PropsExpression, RuntimeHelper, SimpleExpressionNode,
+    SourceLocation, TemplateChildNode, TemplateTextChildNode, TextNode, VNodeCall, VNodeChildren,
+    VNodeTag,
+};
 
 /// Check if a node is fully static (can be hoisted)
 pub fn is_static_node(node: &TemplateChildNode<'_>) -> bool {

--- a/crates/vize_atelier_core/src/transforms/legacy.rs
+++ b/crates/vize_atelier_core/src/transforms/legacy.rs
@@ -45,7 +45,10 @@
 use vize_armature::legacy::LegacyDialectCapabilities;
 use vize_carton::{Box, Bump, String, Vec};
 
-use crate::*;
+use crate::{
+    DirectiveNode, ElementNode, ExpressionNode, PropNode, RootNode, SimpleExpressionNode,
+    TemplateChildNode,
+};
 
 /// Desugar Vue 2 template sugar in `root` into Vue 3 equivalents.
 ///

--- a/crates/vize_atelier_core/src/transforms/transform_element.rs
+++ b/crates/vize_atelier_core/src/transforms/transform_element.rs
@@ -5,7 +5,7 @@
 use vize_carton::{String, capitalize, is_native_tag};
 
 use crate::transform::TransformContext;
-use crate::*;
+use crate::{ElementNode, ElementType, ExpressionNode, PropNode, RuntimeHelper, TemplateChildNode};
 
 /// Resolve element type
 pub fn resolve_element_type<'a>(

--- a/crates/vize_atelier_core/src/transforms/transform_text.rs
+++ b/crates/vize_atelier_core/src/transforms/transform_text.rs
@@ -5,7 +5,7 @@
 use vize_carton::{String, Vec};
 
 use crate::transform::TransformContext;
-use crate::*;
+use crate::{ExpressionNode, RuntimeHelper, TemplateChildNode};
 
 /// Transform text and interpolation children
 pub fn transform_text_children(

--- a/crates/vize_atelier_core/src/transforms/v_bind.rs
+++ b/crates/vize_atelier_core/src/transforms/v_bind.rs
@@ -5,7 +5,7 @@
 use vize_carton::String;
 
 use crate::transform::TransformContext;
-use crate::*;
+use crate::{DirectiveNode, ExpressionNode, RuntimeHelper};
 
 /// Transform v-bind directive - adds required helpers
 pub fn process_v_bind(ctx: &mut TransformContext<'_>, dir: &DirectiveNode<'_>) {

--- a/crates/vize_atelier_core/src/transforms/v_for.rs
+++ b/crates/vize_atelier_core/src/transforms/v_for.rs
@@ -5,7 +5,10 @@
 use vize_carton::{Box, Bump};
 
 use crate::transform::TransformContext;
-use crate::*;
+use crate::{
+    ElementNode, ExpressionNode, ForParseResult, Position, PropNode, RuntimeHelper,
+    SimpleExpressionNode, SourceLocation,
+};
 
 /// Check if an element has a v-for directive
 pub fn has_v_for(el: &ElementNode<'_>) -> bool {
@@ -281,9 +284,10 @@ pub fn process_v_for(ctx: &mut TransformContext<'_>) {
 #[cfg(test)]
 mod tests {
     use super::{
-        ExpressionNode, ForParseResult, SourceLocation, TemplateChildNode, has_v_for,
-        parse_for_expression, parse_for_expression_with_options,
+        ExpressionNode, ForParseResult, SourceLocation, has_v_for, parse_for_expression,
+        parse_for_expression_with_options,
     };
+    use crate::TemplateChildNode;
     use crate::parser::parse;
     use bumpalo::Bump;
 

--- a/crates/vize_atelier_core/src/transforms/v_if.rs
+++ b/crates/vize_atelier_core/src/transforms/v_if.rs
@@ -3,7 +3,7 @@
 //! Transforms elements with v-if, v-else-if, and v-else directives into IfNode.
 
 use crate::transform::TransformContext;
-use crate::*;
+use crate::{ElementNode, ExpressionNode, PropNode, RuntimeHelper};
 
 /// Check if an element has a v-if directive
 pub fn has_v_if(el: &ElementNode<'_>) -> bool {
@@ -63,7 +63,8 @@ pub fn process_v_if(ctx: &mut TransformContext<'_>) {
 
 #[cfg(test)]
 mod tests {
-    use super::{TemplateChildNode, has_v_else, has_v_else_if, has_v_if};
+    use super::{has_v_else, has_v_else_if, has_v_if};
+    use crate::TemplateChildNode;
     use crate::parser::parse;
     use bumpalo::Bump;
 

--- a/crates/vize_atelier_core/src/transforms/v_memo.rs
+++ b/crates/vize_atelier_core/src/transforms/v_memo.rs
@@ -6,7 +6,7 @@ use vize_carton::String;
 use vize_carton::ToCompactString;
 
 use crate::transform::TransformContext;
-use crate::*;
+use crate::{ElementNode, ExpressionNode, PropNode, RuntimeHelper};
 
 /// Check if element has v-memo directive
 pub fn has_v_memo(el: &ElementNode<'_>) -> bool {
@@ -95,7 +95,8 @@ pub fn generate_memo_check(deps: &str, cache_index: usize) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{TemplateChildNode, get_memo_deps, has_v_memo};
+    use super::{get_memo_deps, has_v_memo};
+    use crate::TemplateChildNode;
     use crate::parser::parse;
     use bumpalo::Bump;
 

--- a/crates/vize_atelier_core/src/transforms/v_model.rs
+++ b/crates/vize_atelier_core/src/transforms/v_model.rs
@@ -5,7 +5,10 @@
 use vize_carton::{Box, String, Vec};
 
 use crate::transform::TransformContext;
-use crate::*;
+use crate::{
+    DirectiveNode, ElementNode, ElementType, ExpressionNode, PropNode, RuntimeHelper,
+    SimpleExpressionNode,
+};
 
 /// v-model modifiers
 #[derive(Debug, Clone, Default)]
@@ -207,9 +210,8 @@ pub fn get_model_event_prop(el: &ElementNode<'_>) -> (&'static str, &'static str
 
 #[cfg(test)]
 mod tests {
-    use super::{
-        SimpleExpressionNode, SourceLocation, String, Vec, parse_model_modifiers, supports_v_model,
-    };
+    use super::{SimpleExpressionNode, String, Vec, parse_model_modifiers, supports_v_model};
+    use crate::SourceLocation;
     use vize_carton::Allocator;
 
     #[test]

--- a/crates/vize_atelier_core/src/transforms/v_on.rs
+++ b/crates/vize_atelier_core/src/transforms/v_on.rs
@@ -5,7 +5,7 @@
 use vize_carton::String;
 
 use crate::transform::TransformContext;
-use crate::*;
+use crate::{DirectiveNode, ExpressionNode, SimpleExpressionNode};
 
 /// Event modifier flags
 #[derive(Debug, Clone, Default)]
@@ -110,9 +110,10 @@ pub fn create_on_name(event: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        EventModifiers, SimpleExpressionNode, SourceLocation, camelize, create_on_name,
-        needs_guard, parse_event_modifiers,
+        EventModifiers, SimpleExpressionNode, camelize, create_on_name, needs_guard,
+        parse_event_modifiers,
     };
+    use crate::SourceLocation;
 
     #[test]
     fn test_parse_modifiers() {

--- a/crates/vize_atelier_core/src/transforms/v_once.rs
+++ b/crates/vize_atelier_core/src/transforms/v_once.rs
@@ -3,7 +3,7 @@
 //! Transforms v-once directives for one-time rendering.
 
 use crate::transform::TransformContext;
-use crate::*;
+use crate::{ElementNode, PropNode, RuntimeHelper};
 use vize_carton::String;
 use vize_carton::ToCompactString;
 
@@ -53,7 +53,8 @@ pub fn generate_v_once_wrapper(index: usize) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{TemplateChildNode, has_v_once};
+    use super::has_v_once;
+    use crate::TemplateChildNode;
     use crate::parser::parse;
     use bumpalo::Bump;
 

--- a/crates/vize_atelier_core/src/transforms/v_slot.rs
+++ b/crates/vize_atelier_core/src/transforms/v_slot.rs
@@ -10,7 +10,10 @@ use vize_carton::{String, is_builtin_directive};
 
 use crate::errors::ErrorCode;
 use crate::transform::TransformContext;
-use crate::*;
+use crate::{
+    DirectiveNode, ElementNode, ElementType, ExpressionNode, PropNode, RuntimeHelper,
+    SourceLocation, TemplateChildNode,
+};
 
 /// Check if element has v-slot directive
 pub fn has_v_slot(el: &ElementNode<'_>) -> bool {

--- a/crates/vize_atelier_ssr/src/codegen/element/component.rs
+++ b/crates/vize_atelier_ssr/src/codegen/element/component.rs
@@ -1,7 +1,15 @@
 //! Component, built-in component, and scoped slot SSR emission.
 
-use super::props::*;
-use super::*;
+use super::props::{
+    component_prop_entry, component_props_object, is_dynamic_component_tag, is_simple_identifier,
+    is_static_named_prop, is_valid_js_identifier, normalize_prop_entries, quoted_js_string,
+    slot_props_pattern_to_string, transform_bound_prop_key, wrap_call,
+};
+use super::{
+    ComponentSlotChildren, ComponentTemplateSlot, DirectiveNode, ElementNode, ElementType,
+    ExpressionNode, ForNode, FxHashSet, IfNode, PropNode, RuntimeHelper, SsrCodegenContext, String,
+    TemplateChildNode, ToCompactString, VNodePropEntry, cstr, extract_destructure_params,
+};
 
 impl<'a> SsrCodegenContext<'a> {
     /// Emit a component render call, including built-in SSR special cases.

--- a/crates/vize_atelier_ssr/src/codegen/element/plain.rs
+++ b/crates/vize_atelier_ssr/src/codegen/element/plain.rs
@@ -1,7 +1,13 @@
 //! Plain HTML element SSR emission and element-only directives.
 
-use super::props::*;
-use super::*;
+use super::props::{
+    component_prop_entry, component_props_object, is_static_named_prop, merge_prop_values,
+    normalize_prop_entries, quoted_js_string, transform_bound_prop_key, wrap_call,
+};
+use super::{
+    DirectiveNode, ElementNode, ExpressionNode, PropNode, RuntimeHelper, SsrCodegenContext, String,
+    ToCompactString, VNodePropEntry, cstr, escape_html_attr,
+};
 
 impl<'a> SsrCodegenContext<'a> {
     /// Process a plain HTML element

--- a/crates/vize_atelier_ssr/src/codegen/element/props.rs
+++ b/crates/vize_atelier_ssr/src/codegen/element/props.rs
@@ -1,6 +1,6 @@
 //! Shared JavaScript expression and prop-object builders for SSR element codegen.
 
-use super::*;
+use super::{DirectiveNode, ExpressionNode, PropNode, String, ToCompactString, VNodePropEntry};
 
 /// Build an object literal from normalized prop entries.
 pub(super) fn component_props_object(entries: &[VNodePropEntry]) -> String {

--- a/crates/vize_atelier_ssr/src/codegen/element/slot.rs
+++ b/crates/vize_atelier_ssr/src/codegen/element/slot.rs
@@ -1,7 +1,13 @@
 //! Slot outlet SSR emission and slot prop collection.
 
-use super::props::*;
-use super::*;
+use super::props::{
+    component_prop_entry, component_props_object, normalize_prop_entries, quoted_js_string,
+    static_slot_outlet_prop_key, transform_slot_outlet_bound_prop_key,
+};
+use super::{
+    ElementNode, ExpressionNode, PropNode, RuntimeHelper, SsrCodegenContext, String,
+    ToCompactString, VNodePropEntry,
+};
 
 impl<'a> SsrCodegenContext<'a> {
     /// Process a slot outlet (<slot>)

--- a/crates/vize_atelier_ssr/src/codegen/element/vnode.rs
+++ b/crates/vize_atelier_ssr/src/codegen/element/vnode.rs
@@ -2,8 +2,16 @@
 
 use super::super::helpers::collect_for_scoped_params;
 use super::component::{has_slot_directive, slot_template_in_children, template_slot_is_dynamic};
-use super::props::*;
-use super::*;
+use super::props::{
+    component_prop_entry, component_props_object, is_dynamic_component_tag, is_valid_js_identifier,
+    normalize_prop_entries, quoted_js_string, slot_props_pattern_to_string,
+    transform_bound_prop_key, wrap_call,
+};
+use super::{
+    ComponentSlotChildren, ElementNode, ElementType, ExpressionNode, FxHashSet, PropNode,
+    RuntimeHelper, SsrCodegenContext, String, TemplateChildNode, ToCompactString, VNodePropEntry,
+    extract_destructure_params,
+};
 use vize_atelier_core::ForNode;
 
 impl<'a> SsrCodegenContext<'a> {

--- a/crates/vize_atelier_vapor/src/transform/element/component.rs
+++ b/crates/vize_atelier_vapor/src/transform/element/component.rs
@@ -1,6 +1,10 @@
 //! Component, slot outlet, dynamic component, and v-model lowering.
 
-use super::*;
+use super::{
+    BlockIRNode, Box, ComponentKind, CreateComponentIRNode, ElementNode, ElementType,
+    ExpressionNode, IRProp, IRSlot, OperationNode, PropNode, SimpleExpressionNode, SourceLocation,
+    String, TemplateChildNode, TransformContext, Vec, transform_children,
+};
 
 /// Transform a component element into a `CreateComponent` operation.
 ///

--- a/crates/vize_atelier_vapor/src/transform/element/deferred.rs
+++ b/crates/vize_atelier_vapor/src/transform/element/deferred.rs
@@ -3,8 +3,17 @@
 use crate::ir::{ForIRNode, IfIRNode, InsertNodeIRNode, NegativeBranch};
 
 use super::component::transform_component;
-use super::template::*;
-use super::*;
+use super::template::{
+    generate_element_template, is_static_element, is_template_backed_element,
+    transform_template_ref,
+};
+use super::{
+    BlockIRNode, ChildRefIRNode, ElementNode, ElementType, NextRefIRNode, OperationNode, PropNode,
+    SlotOutletIRNode, String, TemplateChildNode, TransformContext, get_slot_outlet_name,
+    get_slot_outlet_props, transform_children, transform_directive,
+    transform_for_node_deferred_parent, transform_for_node_into_parent,
+    transform_if_node_deferred_parent, transform_if_node_into_parent, transform_text_children,
+};
 
 /// Transform an element that has control flow children (`v-if`/`v-for`).
 ///

--- a/crates/vize_atelier_vapor/src/transform/element/template.rs
+++ b/crates/vize_atelier_vapor/src/transform/element/template.rs
@@ -1,6 +1,10 @@
 //! Template string construction, escaping, and template-ref extraction.
 
-use super::*;
+use super::{
+    BlockIRNode, Box, ElementNode, ElementType, ExpressionNode, OperationNode, PropNode,
+    SetTemplateRefIRNode, SimpleExpressionNode, String, TemplateChildNode, TransformContext,
+    append, cstr,
+};
 
 /// Generate element template string (recursively includes static children)
 pub(crate) fn generate_element_template(el: &ElementNode<'_>) -> String {

--- a/crates/vize_canon/src/corsa_bridge/bridge.rs
+++ b/crates/vize_canon/src/corsa_bridge/bridge.rs
@@ -7,7 +7,11 @@ use std::sync::{Arc, Mutex};
 use vize_carton::profiler::{CacheStats, Profiler};
 use vize_carton::{String, cstr};
 
-use super::types::*;
+use super::types::{
+    CorsaBridgeConfig, CorsaBridgeError, LspCompletionItem, LspCompletionResponse,
+    LspDefinitionResponse, LspDiagnostic, LspHover, LspLocation, TypeCheckResult,
+    VIRTUAL_URI_SCHEME,
+};
 use crate::corsa_client::CorsaProjectClient;
 
 /// Bridge to Corsa for type checking and editor queries via project sessions.

--- a/crates/vize_fresco/src/layout/engine.rs
+++ b/crates/vize_fresco/src/layout/engine.rs
@@ -1,7 +1,7 @@
 //! Layout engine using taffy.
 
 use rustc_hash::FxHashMap;
-use taffy::prelude::*;
+use taffy::prelude::{AvailableSpace, Dimension, NodeId, Size, TaffyTree};
 
 use super::{flex::FlexStyle, rect::Rect};
 

--- a/crates/vize_fresco/src/napi/layout.rs
+++ b/crates/vize_fresco/src/napi/layout.rs
@@ -200,7 +200,10 @@ pub fn clear_layout() -> Result<()> {
 
 /// Convert FlexStyleNapi to FlexStyle.
 fn convert_flex_style(style: FlexStyleNapi) -> FlexStyle {
-    use crate::layout::*;
+    use crate::layout::{
+        AlignContent, AlignItems, AlignSelf, Display, Edges, FlexDirection, FlexWrap, Gap,
+        JustifyContent, LengthPercentageAuto, Overflow, Position,
+    };
 
     let mut result = FlexStyle::default();
 

--- a/crates/vize_maestro/src/server/capabilities.rs
+++ b/crates/vize_maestro/src/server/capabilities.rs
@@ -1,7 +1,17 @@
 //! LSP server capabilities declaration.
 #![allow(clippy::disallowed_methods)]
 
-use tower_lsp::lsp_types::*;
+use tower_lsp::lsp_types::{
+    CodeActionKind, CodeActionOptions, CodeActionProviderCapability, CodeLensOptions,
+    CompletionOptions, DocumentLinkOptions, FileOperationFilter, FileOperationPattern,
+    FileOperationPatternKind, FileOperationRegistrationOptions, FoldingRangeProviderCapability,
+    HoverProviderCapability, OneOf, RenameOptions, SaveOptions, SemanticTokenModifier,
+    SemanticTokenType, SemanticTokensFullOptions, SemanticTokensLegend, SemanticTokensOptions,
+    SemanticTokensServerCapabilities, ServerCapabilities, TextDocumentSyncCapability,
+    TextDocumentSyncKind, TextDocumentSyncOptions, TextDocumentSyncSaveOptions,
+    WorkDoneProgressOptions, WorkspaceFileOperationsServerCapabilities,
+    WorkspaceFoldersServerCapabilities, WorkspaceServerCapabilities,
+};
 
 use super::state::LspFeatureConfig;
 

--- a/crates/vize_maestro/src/virtual_code/template_code.rs
+++ b/crates/vize_maestro/src/virtual_code/template_code.rs
@@ -5,7 +5,10 @@
 #![allow(clippy::disallowed_types, clippy::disallowed_methods)]
 
 use vize_armature::RootNode;
-use vize_relief::*;
+use vize_relief::{
+    DirectiveNode, ElementNode, ExpressionNode, ForNode, IfNode, InterpolationNode, PropNode,
+    SimpleExpressionNode, SourceLocation, TemplateChildNode,
+};
 
 use super::{MappingData, SourceMap, SourceMapping, SourceRange, VirtualDocument, VirtualLanguage};
 use vize_carton::cstr;

--- a/crates/vize_vitrine/src/napi/config/js_value.rs
+++ b/crates/vize_vitrine/src/napi/config/js_value.rs
@@ -13,7 +13,11 @@ use napi::{
     bindgen_prelude::{Result, Unknown, ValueType, sys},
 };
 
-use raw::*;
+use raw::{
+    array_len, create_array, create_object, enumerable_keys, get_element, get_own_named_property,
+    get_property, get_prototype, has_own_property, invalid_arg, is_array, object_prototype,
+    set_element, set_named_property, set_property, strict_equals,
+};
 
 const ENTRY_METADATA_KEYS: &[&str] = &["name", "basePath", "files", "ignores", "extends"];
 

--- a/crates/vize_vitrine/src/wasm/cross_file.rs
+++ b/crates/vize_vitrine/src/wasm/cross_file.rs
@@ -9,6 +9,25 @@
 
 use super::{to_js_value, utf8_byte_to_utf16_offset};
 use vize_carton::Bump;
+use vize_croquis_cf::CrossFileDiagnosticKind::{
+    ArrayMutationNotTriggering, AsyncBoundaryCrossing, AsyncWithoutSuspense, BrowserApiInSsr,
+    CircularDependency, CircularReactiveDependency, ClosureCapturesReactive,
+    ComposableOutsideSetup, ComputedHasSideEffects, DeepImportChain,
+    DependencyInjectionOutsideSetup, DestructuringBreaksReactivity, DomAccessWithoutNextTick,
+    DuplicateElementId, EventListenerWithoutCleanup, EventModifierIssue, HydrationMismatchRisk,
+    InheritAttrsDisabledUnused, InjectedAsyncMutationRace, LifecycleHookWithoutCleanup,
+    LifecycleOutsideSetup, MissingRequiredProp, MissingSuspenseBoundary, MultiRootMissingAttrs,
+    NonReactiveProvideValue, NonUniqueIdInLoop, ObjectIdentityComparison,
+    PiniaGetterWithoutStoreToRefs, PropTypeMismatch, ProvideInjectTypeMismatch,
+    ProvideInjectWithoutSymbol, ReactiveObjectMutatedAfterEscape, ReactiveReferenceEscapes,
+    ReactiveStateAtModuleScope, ReactiveStateExported, ReactivityOutsideSetup,
+    ReassignmentBreaksReactivity, SetupContextViolation, ShallowReactiveDeepAccess,
+    SpreadBreaksReactivity, SuspenseWithoutFallback, TemplateRefAccessedBeforeMount, ToRawMutation,
+    UncaughtErrorBoundary, UndeclaredEmit, UndeclaredProp, UndefinedSlot, UnhandledEvent,
+    UnmatchedEventListener, UnmatchedInject, UnregisteredComponent, UnresolvedImport, UnusedEmit,
+    UnusedFallthroughAttrs, UnusedProvide, ValueExtractionBreaksReactivity, WatchEffectWithAsync,
+    WatchMutationCanBeComputed, WatcherOutsideSetup,
+};
 use wasm_bindgen::prelude::*;
 
 /// Analyze multiple Vue SFC files for cross-file issues
@@ -325,7 +344,6 @@ fn parse_cross_file_options(options: &JsValue) -> vize_croquis_cf::CrossFileOpti
 
 /// Convert diagnostic kind to string type
 fn diagnostic_kind_to_string(kind: &vize_croquis_cf::CrossFileDiagnosticKind) -> &'static str {
-    use vize_croquis_cf::CrossFileDiagnosticKind::*;
     match kind {
         // Fallthrough attributes
         UnusedFallthroughAttrs { .. } => "fallthrough-attrs",
@@ -424,7 +442,6 @@ fn diagnostic_kind_to_string(kind: &vize_croquis_cf::CrossFileDiagnosticKind) ->
 /// Determine if a diagnostic is template-related (uses template offsets)
 /// vs script-related (uses script offsets)
 fn is_template_related_diagnostic(kind: &vize_croquis_cf::CrossFileDiagnosticKind) -> bool {
-    use vize_croquis_cf::CrossFileDiagnosticKind::*;
     matches!(
         kind,
         // Template-based diagnostics (positions in template block)
@@ -443,7 +460,6 @@ fn is_template_related_diagnostic(kind: &vize_croquis_cf::CrossFileDiagnosticKin
 /// Determine if a diagnostic should span the entire <template> tag
 /// (uses tag_start and tag_end directly, not relative offsets)
 fn is_template_tag_span_diagnostic(kind: &vize_croquis_cf::CrossFileDiagnosticKind) -> bool {
-    use vize_croquis_cf::CrossFileDiagnosticKind::*;
     matches!(
         kind,
         // These diagnostics apply to the entire template, not a specific location

--- a/npm/zed-vize/src/lib.rs
+++ b/npm/zed-vize/src/lib.rs
@@ -106,7 +106,7 @@ fn merge_env(shell_env: zed::EnvVars, custom_env: Option<HashMap<String, String>
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use super::{CommandSettings, LspSettings, VizeExtension, zed};
 
     #[test]
     fn discovered_binary_defaults_to_lsp() {

--- a/tools/vite-plus/tasks/check.ts
+++ b/tools/vite-plus/tasks/check.ts
@@ -24,6 +24,7 @@ const ciPackageCheckCommand = runInPackages("check", ciCheckedPackages, {
   concurrencyLimit: 1,
 });
 const directPackageCheckCommand = runPackageScriptDirectly("check", directCheckPackages);
+const rustClippyCommand = "cargo clippy --workspace -- -D warnings -D clippy::wildcard_imports";
 const strictRepoCheckCommand = `node tools/vite-plus/check-warning-budget.mjs -- ${localVp} check`;
 const ciVizeAppCheckCommand = [
   runInDirectory(
@@ -77,7 +78,7 @@ export const checkTasks = defineTasks({
     runInVscodeExtension("pnpm exec tsgo --noEmit", "pnpm exec vp check src vite.config.ts"),
   ),
   "check:editor-extensions": noCacheTask(runTasks("check:vscode-extension", "check:zed-extension")),
-  clippy: task("cargo clippy --workspace -- -D warnings", { input: cacheInputs.rust }),
+  clippy: task(rustClippyCommand, { input: cacheInputs.rust }),
   fmt: noCacheTask(runTasks("fmt:repo", "fmt:rust", "fmt:js")),
   "fmt:repo": noCacheTask(`${localVp} fmt --write`),
   "fmt:js": noCacheTask(runInPackages("fmt", checkedPackages)),
@@ -86,7 +87,7 @@ export const checkTasks = defineTasks({
   // `vp lint` runs inside a Blacksmith Testbox; `check` stays local.
   lint: noCacheTask(inTestbox(runTask("check"))),
   "lint:fix": noCacheTask(runTask("check:fix")),
-  "lint:rust": task("cargo clippy --workspace -- -D warnings", { input: cacheInputs.rust }),
+  "lint:rust": task(rustClippyCommand, { input: cacheInputs.rust }),
   "lint:all": noCacheTask(runTasks("lint:rust", "check")),
   "fmt:check": noCacheTask(runTask("check")),
   actrun: noCacheTask(localActrunCommand),


### PR DESCRIPTION
Closes #1577

## Summary
- replace practical private wildcard Rust imports with explicit imports
- enable `clippy::wildcard_imports` in the CI clippy job
- reuse the same clippy command in local Rust lint/check tasks

## Verification
- `cargo fmt --all`
- `cargo clippy --workspace -- -D warnings -D clippy::wildcard_imports`
- `cargo clippy --manifest-path npm/zed-vize/Cargo.toml -- -D warnings -D clippy::wildcard_imports`
- `cargo test --manifest-path npm/zed-vize/Cargo.toml`
- feature-focused clippy checks for `vize_fresco`, `vize_vitrine` napi/wasm, and `vize_atelier_core` legacy
- `git diff --check`
- inventory scan for non-prelude private wildcard imports