### PR TITLE
fix(vue): respect user-selected Vue type versions

### DIFF
--- a/npm/vize/package.json
+++ b/npm/vize/package.json
@@ -58,8 +58,7 @@
   },
   "dependencies": {
     "@vizejs/native": "workspace:*",
-    "oxc-transform": "catalog:oxc",
-    "vue": "catalog:vue-stable"
+    "oxc-transform": "catalog:oxc"
   },
   "devDependencies": {
     "@pkl-community/pkl": "catalog:repo-tooling",
@@ -68,13 +67,18 @@
     "tsdown": "catalog:vite-stack",
     "typescript": "catalog:typescript",
     "vite": "catalog:vite-stack",
-    "vite-plus": "catalog:vite-stack"
+    "vite-plus": "catalog:vite-stack",
+    "vue": "catalog:vue-stable"
   },
   "peerDependencies": {
-    "@pkl-community/pkl": "catalog:repo-tooling"
+    "@pkl-community/pkl": "catalog:repo-tooling",
+    "vue": ">=2.7.0"
   },
   "peerDependenciesMeta": {
     "@pkl-community/pkl": {
+      "optional": true
+    },
+    "vue": {
       "optional": true
     }
   },

--- a/npm/vize/src/cli.ts
+++ b/npm/vize/src/cli.ts
@@ -1,9 +1,6 @@
 import { createRequire } from "node:module";
-import { dirname } from "node:path";
 
 const require = createRequire(import.meta.url);
 const native = require("@vizejs/native") as typeof import("@vizejs/native");
-
-process.env.VIZE_VUE_PACKAGE ??= dirname(require.resolve("vue/package.json"));
 
 native.runCli(process.argv.slice(2));

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -743,9 +743,6 @@ importers:
       oxc-transform:
         specifier: catalog:oxc
         version: 0.130.0
-      vue:
-        specifier: catalog:vue-stable
-        version: 3.5.35(typescript@6.0.3)
     devDependencies:
       '@pkl-community/pkl':
         specifier: catalog:repo-tooling
@@ -768,6 +765,9 @@ importers:
       vite-plus:
         specifier: catalog:vite-stack
         version: 0.1.21(@tsdown/css@0.22.0)(@types/node@25.9.2)(@voidzero-dev/vite-plus-core@0.1.21(@tsdown/css@0.22.0)(@types/node@25.9.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.4)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0))(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.1)(tsx@4.22.4)(typescript@6.0.3)(unrun@0.2.39)(yaml@2.9.0)
+      vue:
+        specifier: catalog:vue-stable
+        version: 3.5.35(typescript@6.0.3)
     optionalDependencies:
       '@typescript/native-preview':
         specifier: catalog:typescript

--- a/tests/tooling/package-manifests.test.ts
+++ b/tests/tooling/package-manifests.test.ts
@@ -324,6 +324,27 @@ test("native preview runtime is declared for vize check users", () => {
   assert.equal(packageJson.peerDependenciesMeta?.["@typescript/native-preview"], undefined);
 });
 
+test("vize package leaves Vue type versions to the consuming project", () => {
+  const packageJson = JSON.parse(readRepoFile("npm/vize/package.json")) as {
+    dependencies?: Record<string, string>;
+    devDependencies?: Record<string, string>;
+    optionalDependencies?: Record<string, string>;
+    peerDependencies?: Record<string, string>;
+    peerDependenciesMeta?: Record<string, { optional?: boolean }>;
+  };
+  const cliEntry = readRepoFile("npm/vize/src/cli.ts");
+
+  assert.equal(packageJson.dependencies?.vue, undefined);
+  assert.equal(packageJson.optionalDependencies?.vue, undefined);
+  assert.equal(packageJson.devDependencies?.vue, "catalog:vue-stable");
+  assert.equal(packageJson.peerDependencies?.vue, ">=2.7.0");
+  assert.deepEqual(packageJson.peerDependenciesMeta?.vue, {
+    optional: true,
+  });
+  assert.doesNotMatch(cliEntry, /VIZE_VUE_PACKAGE\s*\?\?=/);
+  assert.doesNotMatch(cliEntry, /require\.resolve\("vue\/package\.json"\)/);
+});
+
 test("musea Nuxt tests the same vue-router major that it declares as a peer", () => {
   const workspaceYaml = readRepoFile("pnpm-workspace.yaml");
   const catalogVersion = workspaceYaml.match(/^\s+vue-router: "([^"]+)"$/m)?.[1];


### PR DESCRIPTION
## Summary
- stop the vize CLI from defaulting VIZE_VUE_PACKAGE to the package-local Vue install
- move Vue out of vize runtime dependencies and declare it as an optional peer so projects keep their selected Vue type package
- add a manifest policy test to keep Vue type resolution project-owned

Refs #1589

## Tests
- node --test tests/tooling/package-manifests.test.ts
- vp run --filter ./npm/vize check
- vp run --filter ./npm/vite-plugin-vize check
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1611"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->