### PR TITLE
refactor(croquis): prefer drawer naming in consumers

### DIFF
--- a/crates/vize_atelier_sfc/src/croquis.rs
+++ b/crates/vize_atelier_sfc/src/croquis.rs
@@ -7,13 +7,13 @@
 use crate::types::SfcDescriptor;
 use vize_atelier_core::RootNode;
 use vize_carton::{String, ToCompactString, cstr, profile};
-use vize_croquis::{Analyzer, AnalyzerOptions, Croquis};
+use vize_croquis::{Croquis, Drawer, DrawerOptions};
 
 /// Options for descriptor-level Croquis analysis.
 #[derive(Debug, Clone, Copy)]
 pub struct SfcCroquisOptions {
-    /// Low-level analyzer options.
-    pub analyzer_options: AnalyzerOptions,
+    /// Low-level drawer options.
+    pub analyzer_options: DrawerOptions,
     /// Merge `<script>` into the synthetic script used by downstream tools when
     /// a component also has `<script setup>`.
     pub merge_scripts: bool,
@@ -24,7 +24,7 @@ impl SfcCroquisOptions {
     #[inline]
     pub const fn full() -> Self {
         Self {
-            analyzer_options: AnalyzerOptions::full(),
+            analyzer_options: DrawerOptions::full(),
             merge_scripts: true,
         }
     }
@@ -33,7 +33,7 @@ impl SfcCroquisOptions {
     #[inline]
     pub const fn for_lint() -> Self {
         Self {
-            analyzer_options: AnalyzerOptions::for_lint(),
+            analyzer_options: DrawerOptions::for_lint(),
             merge_scripts: true,
         }
     }
@@ -42,7 +42,7 @@ impl SfcCroquisOptions {
     #[inline]
     pub const fn for_compile() -> Self {
         Self {
-            analyzer_options: AnalyzerOptions::for_compile(),
+            analyzer_options: DrawerOptions::for_compile(),
             merge_scripts: true,
         }
     }
@@ -51,7 +51,7 @@ impl SfcCroquisOptions {
     #[inline]
     pub const fn for_declaration() -> Self {
         Self {
-            analyzer_options: AnalyzerOptions {
+            analyzer_options: DrawerOptions {
                 analyze_script: true,
                 analyze_template_scopes: false,
                 track_usage: false,
@@ -131,10 +131,10 @@ pub fn analyze_sfc_descriptor_with_context_legacy_vue2(
     analyze_sfc_descriptor_with_context_impl(descriptor, template_ast, options, false, true)
 }
 
-/// Apply the Options API / legacy binding-resolution mode to an analyzer.
+/// Apply the Options API / legacy binding-resolution mode to a drawer.
 /// `legacy_vue2` implies Options API resolution and additionally pulls in the
 /// Nuxt 2 globals; `options_api` alone resolves only the Options API bindings.
-fn apply_options_api_mode(analyzer: Analyzer, options_api: bool, legacy_vue2: bool) -> Analyzer {
+fn apply_options_api_mode(analyzer: Drawer, options_api: bool, legacy_vue2: bool) -> Drawer {
     if legacy_vue2 {
         analyzer.with_legacy_vue2()
     } else if options_api {
@@ -203,7 +203,7 @@ fn analyze_sfc_descriptor_resolved_impl(
         merge_resolved_props_into_croquis(&mut summary, descriptor, filename);
     }
     let summary = summary;
-    let analyzer = Analyzer::with_summary(options.analyzer_options, summary, script_analyzed);
+    let analyzer = Drawer::with_summary(options.analyzer_options, summary, script_analyzed);
     let mut analyzer = apply_options_api_mode(analyzer, options_api, legacy_vue2);
 
     if let Some(root) = template_ast {
@@ -255,7 +255,7 @@ fn analyze_scripts(
 
     match (descriptor.script.as_ref(), descriptor.script_setup.as_ref()) {
         (Some(script), Some(script_setup)) if options.merge_scripts => {
-            let plain_analyzer = Analyzer::with_options(options.analyzer_options);
+            let plain_analyzer = Drawer::with_options(options.analyzer_options);
             let mut plain_analyzer =
                 apply_options_api_mode(plain_analyzer, options_api, legacy_vue2);
             profile!(
@@ -264,7 +264,7 @@ fn analyze_scripts(
             );
             let plain = plain_analyzer.finish();
 
-            let setup_analyzer = Analyzer::with_options(options.analyzer_options);
+            let setup_analyzer = Drawer::with_options(options.analyzer_options);
             let mut setup_analyzer =
                 apply_options_api_mode(setup_analyzer, options_api, legacy_vue2);
             let generic = script_setup
@@ -284,7 +284,7 @@ fn analyze_scripts(
             summary
         }
         (_, Some(script_setup)) => {
-            let analyzer = Analyzer::with_options(options.analyzer_options);
+            let analyzer = Drawer::with_options(options.analyzer_options);
             let mut analyzer = apply_options_api_mode(analyzer, options_api, legacy_vue2);
             let generic = script_setup
                 .attrs
@@ -297,7 +297,7 @@ fn analyze_scripts(
             analyzer.finish()
         }
         (Some(script), None) => {
-            let analyzer = Analyzer::with_options(options.analyzer_options);
+            let analyzer = Drawer::with_options(options.analyzer_options);
             let mut analyzer = apply_options_api_mode(analyzer, options_api, legacy_vue2);
             profile!(
                 "atelier.sfc.croquis.script_plain",

--- a/crates/vize_canon/src/sfc_typecheck.rs
+++ b/crates/vize_canon/src/sfc_typecheck.rs
@@ -22,7 +22,7 @@
 //!     |
 //!     v
 //! +-------------------------------------+
-//! |  vize_croquis::Analyzer             |
+//! |  vize_croquis::Drawer               |
 //! |  - Script analysis (bindings)       |
 //! |  - Template analysis (scopes)       |
 //! |  - Macro tracking (defineProps)     |

--- a/crates/vize_croquis/README.md
+++ b/crates/vize_croquis/README.md
@@ -11,8 +11,8 @@
 
 ## Key Entry Points
 
-- `Analyzer`
-- `AnalyzerOptions`
+- `Drawer`
+- `DrawerOptions`
 - `Croquis`
 - `BindingMetadata`
 - `ScopeChain`

--- a/crates/vize_maestro/src/ide/code_action.rs
+++ b/crates/vize_maestro/src/ide/code_action.rs
@@ -618,7 +618,7 @@ fn sfc_script_declares(content: &str, name: &str) -> bool {
     let Some(script_content) = script_content else {
         return false;
     };
-    let mut analyzer = vize_croquis::Analyzer::with_options(vize_croquis::AnalyzerOptions {
+    let mut analyzer = vize_croquis::Drawer::with_options(vize_croquis::DrawerOptions {
         analyze_script: true,
         ..Default::default()
     });
@@ -727,7 +727,7 @@ fn is_reactive_ref_in_script(content: &str, uri: &tower_lsp::lsp_types::Url, nam
     let Some(ref script_setup) = descriptor.script_setup else {
         return false;
     };
-    let mut analyzer = vize_croquis::Analyzer::with_options(vize_croquis::AnalyzerOptions {
+    let mut analyzer = vize_croquis::Drawer::with_options(vize_croquis::DrawerOptions {
         analyze_script: true,
         ..Default::default()
     });

--- a/crates/vize_maestro/src/ide/completion/script/mod.rs
+++ b/crates/vize_maestro/src/ide/completion/script/mod.rs
@@ -21,7 +21,7 @@ use tower_lsp::lsp_types::{
     MarkupKind,
 };
 use vize_croquis::ScopeKind;
-use vize_croquis::{Analyzer, AnalyzerOptions};
+use vize_croquis::{Drawer, DrawerOptions};
 use vize_relief::BindingType;
 
 use self::context::{
@@ -92,7 +92,7 @@ pub(crate) fn complete_script(ctx: &IdeContext, is_setup: bool) -> Vec<Completio
     if let Some((script_content, script_offset)) =
         script_content_and_offset_for_context(ctx, is_setup)
     {
-        let mut analyzer = Analyzer::with_options(AnalyzerOptions {
+        let mut analyzer = Drawer::with_options(DrawerOptions {
             analyze_script: true,
             ..Default::default()
         });

--- a/crates/vize_maestro/src/ide/completion/script/reactive_infer.rs
+++ b/crates/vize_maestro/src/ide/completion/script/reactive_infer.rs
@@ -8,7 +8,7 @@
 )]
 
 use vize_croquis::reactivity::ReactiveKind;
-use vize_croquis::{Analyzer, AnalyzerOptions};
+use vize_croquis::{Drawer, DrawerOptions};
 
 pub(super) fn reactive_completion_info(
     script_content: &str,
@@ -37,7 +37,7 @@ fn reactive_wrapper_type(kind: ReactiveKind) -> Option<&'static str> {
 }
 
 pub(super) fn reactive_kind_for_name(script_content: &str, name: &str) -> Option<ReactiveKind> {
-    let mut analyzer = Analyzer::with_options(AnalyzerOptions {
+    let mut analyzer = Drawer::with_options(DrawerOptions {
         analyze_script: true,
         ..Default::default()
     });

--- a/crates/vize_maestro/src/ide/completion/template/component_meta.rs
+++ b/crates/vize_maestro/src/ide/completion/template/component_meta.rs
@@ -7,7 +7,7 @@ use tower_lsp::lsp_types::{
     CompletionItem, CompletionItemKind, CompletionItemLabelDetails, Documentation,
     InsertTextFormat, MarkupContent, MarkupKind,
 };
-use vize_croquis::{Analyzer, AnalyzerOptions};
+use vize_croquis::{Drawer, DrawerOptions};
 use vize_relief::BindingType;
 
 use crate::ide::definition::helpers as definition_helpers;
@@ -240,11 +240,11 @@ fn extract_component_metadata(
                 .map(|script| script.content.as_ref())
         })
     {
-        let analyzer_options = AnalyzerOptions {
+        let analyzer_options = DrawerOptions {
             analyze_script: true,
             ..Default::default()
         };
-        let mut analyzer = Analyzer::with_options(analyzer_options);
+        let mut analyzer = Drawer::with_options(analyzer_options);
         if legacy_vue2 {
             analyzer = analyzer.with_legacy_vue2();
         } else if options_api {

--- a/crates/vize_maestro/src/ide/definition/template.rs
+++ b/crates/vize_maestro/src/ide/definition/template.rs
@@ -5,7 +5,7 @@
 #![allow(clippy::disallowed_types, clippy::disallowed_methods)]
 
 use tower_lsp::lsp_types::{GotoDefinitionResponse, Location, Position, Range};
-use vize_croquis::{Analyzer, AnalyzerOptions};
+use vize_croquis::{Drawer, DrawerOptions};
 use vize_relief::BindingType;
 
 use super::{IdeContext, helpers};
@@ -513,7 +513,7 @@ pub(crate) fn find_component_definition(
 
     let descriptor = vize_atelier_sfc::parse_sfc(&ctx.content, options).ok()?;
 
-    let mut analyzer = Analyzer::with_options(AnalyzerOptions::full());
+    let mut analyzer = Drawer::with_options(DrawerOptions::full());
 
     if let Some(ref script_setup) = descriptor.script_setup {
         analyzer.analyze_script_setup(&script_setup.content);
@@ -638,7 +638,7 @@ pub(crate) fn find_prop_definition_by_name(
 ) -> Option<GotoDefinitionResponse> {
     let script_setup = descriptor.script_setup.as_ref()?;
 
-    let mut analyzer = Analyzer::with_options(AnalyzerOptions {
+    let mut analyzer = Drawer::with_options(DrawerOptions {
         analyze_script: true,
         ..Default::default()
     });

--- a/crates/vize_maestro/src/ide/diagnostics/corsa/virtual_ts.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/corsa/virtual_ts.rs
@@ -247,7 +247,7 @@ impl DiagnosticService {
     ) -> Option<VirtualTsResult> {
         use vize_atelier_sfc::{SfcParseOptions, parse_sfc};
         use vize_canon::virtual_ts::{VirtualTsOptions, generate_virtual_ts_with_offsets};
-        use vize_croquis::{Analyzer, AnalyzerOptions};
+        use vize_croquis::{Drawer, DrawerOptions};
 
         // Parse as art file to get variant templates
         let art_allocator = vize_carton::Bump::new();
@@ -327,7 +327,7 @@ impl DiagnosticService {
         let (template_ast, _) = vize_armature::parse(&template_allocator, template_content);
 
         // Analyze script + template
-        let mut analyzer = Analyzer::with_options(AnalyzerOptions::full());
+        let mut analyzer = Drawer::with_options(DrawerOptions::full());
         analyzer.analyze_script(script_content);
         analyzer.analyze_template(&template_ast);
 

--- a/crates/vize_maestro/src/ide/hover/script.rs
+++ b/crates/vize_maestro/src/ide/hover/script.rs
@@ -9,7 +9,7 @@
 )]
 
 use tower_lsp::lsp_types::{Hover, HoverContents};
-use vize_croquis::{Analyzer, AnalyzerOptions};
+use vize_croquis::{Drawer, DrawerOptions};
 use vize_relief::BindingType;
 
 #[cfg(feature = "native")]
@@ -133,9 +133,9 @@ impl HoverService {
             .map(|s| s.content.as_ref())
             .or_else(|| descriptor.script.as_ref().map(|s| s.content.as_ref()));
 
-        // Create analyzer and analyze script
-        let analyzer_options = AnalyzerOptions::full();
-        let mut analyzer = Analyzer::with_options(analyzer_options);
+        // Create a drawer and analyze script.
+        let analyzer_options = DrawerOptions::full();
+        let mut analyzer = Drawer::with_options(analyzer_options);
         if ctx.state.lsp_features().legacy_vue2 {
             analyzer = analyzer.with_legacy_vue2();
         } else if ctx.state.options_api_enabled() {

--- a/crates/vize_maestro/src/ide/hover/template.rs
+++ b/crates/vize_maestro/src/ide/hover/template.rs
@@ -9,7 +9,7 @@
 )]
 
 use tower_lsp::lsp_types::Hover;
-use vize_croquis::{Analyzer, AnalyzerOptions};
+use vize_croquis::{Drawer, DrawerOptions};
 use vize_relief::BindingType;
 
 #[cfg(feature = "native")]
@@ -179,9 +179,9 @@ impl HoverService {
             .map(|s| s.content.as_ref())
             .or_else(|| descriptor.script.as_ref().map(|s| s.content.as_ref()));
 
-        // Create analyzer and analyze script
-        let analyzer_options = AnalyzerOptions::full();
-        let mut analyzer = Analyzer::with_options(analyzer_options);
+        // Create a drawer and analyze script.
+        let analyzer_options = DrawerOptions::full();
+        let mut analyzer = Drawer::with_options(analyzer_options);
         if ctx.state.lsp_features().legacy_vue2 {
             analyzer = analyzer.with_legacy_vue2();
         } else if ctx.state.options_api_enabled() {

--- a/crates/vize_maestro/src/ide/inlay_hint.rs
+++ b/crates/vize_maestro/src/ide/inlay_hint.rs
@@ -10,7 +10,7 @@ mod script;
 mod template;
 
 use tower_lsp::lsp_types::{InlayHint, Position, Range, Url};
-use vize_croquis::{Analyzer, AnalyzerOptions};
+use vize_croquis::{Drawer, DrawerOptions};
 
 use crate::ide::ecosystem;
 use crate::ide::offset_to_position;
@@ -52,13 +52,13 @@ impl InlayHintService {
             );
         }
 
-        // Use vize_croquis analyzer for proper scope analysis
+        // Use the Croquis drawer for proper scope analysis.
         let Some(ref script_setup) = descriptor.script_setup else {
             return hints;
         };
 
         // Analyze the script setup using croquis
-        let mut analyzer = Analyzer::with_options(AnalyzerOptions {
+        let mut analyzer = Drawer::with_options(DrawerOptions {
             analyze_script: true,
             ..Default::default()
         });

--- a/crates/vize_maestro/src/ide/workspace_symbols.rs
+++ b/crates/vize_maestro/src/ide/workspace_symbols.rs
@@ -164,7 +164,7 @@ impl WorkspaceSymbolsService {
             return;
         };
 
-        let mut analyzer = vize_croquis::Analyzer::with_options(vize_croquis::AnalyzerOptions {
+        let mut analyzer = vize_croquis::Drawer::with_options(vize_croquis::DrawerOptions {
             analyze_script: true,
             ..Default::default()
         });

--- a/crates/vize_patina/src/linter/engine.rs
+++ b/crates/vize_patina/src/linter/engine.rs
@@ -27,7 +27,7 @@ use vize_carton::String;
 use vize_carton::ToCompactString;
 use vize_carton::dialect::{VueDialect, standalone_html_dialect};
 use vize_carton::profile;
-use vize_croquis::{Analyzer, Croquis};
+use vize_croquis::{Croquis, Drawer};
 use vize_relief::RootNode;
 
 use super::config::{LintResult, Linter};
@@ -314,7 +314,7 @@ impl Linter {
             TemplateAnalysis::Precomputed(analysis) => analysis,
             TemplateAnalysis::Lazy => {
                 owned_analysis = profile!("patina.template.croquis", {
-                    let mut analyzer = Analyzer::for_lint();
+                    let mut analyzer = Drawer::for_lint();
                     analyzer.analyze_template(root);
                     analyzer.finish()
                 });


### PR DESCRIPTION
## Summary
- Prefer the canonical `Drawer` / `DrawerOptions` names in first-party Croquis consumers.
- Update Croquis README entry points and the SFC typecheck pipeline comment to use drawer naming.
- Keep the existing public `Analyzer` / `AnalyzerOptions` compatibility aliases untouched.

Refs #1581

## Tests
- `cargo fmt --all -- --check`
- `cargo check -p vize_croquis -p vize_atelier_sfc -p vize_patina -p vize_maestro -p vize_canon`
- `cargo test -p vize_croquis -p vize_atelier_sfc -p vize_patina -p vize_canon`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1613"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->