### PR TITLE
refactor(vdom): clarify JSX VDOM naming

### DIFF
--- a/bench/criterion-ab.mjs
+++ b/bench/criterion-ab.mjs
@@ -22,7 +22,7 @@
  * Documented JSX regression threshold (#1501): the four JSX cost dimensions —
  * parser/lowering (`jsx_lower`), Croquis semantic analysis
  * (`jsx_croquis_analyze`), Patina rule traversal (`jsx_lint`), and VDOM/Vapor
- * codegen (`jsx_compile_dom` / `jsx_compile_vapor` / `jsx_compile_mode_aware`) —
+ * codegen (`jsx_compile_vdom` / `jsx_compile_vapor` / `jsx_compile_mode_aware`) —
  * are all A/B-compared here. When the gate is enabled, run with
  * `--threshold 10`: a +10% median regression on any of these ids fails the run.
  * 10% sits above the run-to-run jitter we observe for these microsecond-scale

--- a/crates/vize_atelier_core/src/codegen.rs
+++ b/crates/vize_atelier_core/src/codegen.rs
@@ -1,4 +1,4 @@
-//! VDom code generation.
+//! VDOM code generation.
 //!
 //! This module generates JavaScript render function code from the transformed AST.
 

--- a/crates/vize_atelier_jsx/benches/jsx_compile.rs
+++ b/crates/vize_atelier_jsx/benches/jsx_compile.rs
@@ -13,7 +13,7 @@
 //! - `jsx_croquis_analyze` — Croquis semantic analysis (binding/scope/
 //!   reactivity) over an already-parsed program, isolated from lowering and
 //!   codegen so this group moves only when the analysis itself does.
-//! - `jsx_compile_dom` / `jsx_compile_vapor` / `jsx_compile_mode_aware` —
+//! - `jsx_compile_vdom` / `jsx_compile_vapor` / `jsx_compile_mode_aware` —
 //!   VDOM / Vapor backend codegen.
 //! - (Patina rule traversal lives in `vize_patina`'s `jsx_lint` group.)
 //!
@@ -23,8 +23,8 @@ use std::hint::black_box;
 
 use criterion::{Criterion, Throughput, criterion_group, criterion_main};
 use vize_atelier_jsx::{
-    DomCompileOptions, JsxCompileConfig, JsxLang, VaporCompileOptions, analyze_jsx_program,
-    compile_jsx, compile_to_dom, compile_to_vapor, lower_source, parse_module,
+    JsxCompileConfig, JsxLang, VaporCompileOptions, VdomCompileOptions, analyze_jsx_program,
+    compile_jsx, compile_to_vapor, compile_to_vdom, lower_source, parse_module,
 };
 use vize_carton::Bump;
 
@@ -125,18 +125,18 @@ fn bench_croquis_analyze(c: &mut Criterion) {
     group.finish();
 }
 
-fn bench_compile_dom(c: &mut Criterion) {
-    let mut group = c.benchmark_group("jsx_compile_dom");
+fn bench_compile_vdom(c: &mut Criterion) {
+    let mut group = c.benchmark_group("jsx_compile_vdom");
     for &(name, source, lang) in CASES {
         group.throughput(Throughput::Bytes(source.len() as u64));
         group.bench_function(name, |b| {
             b.iter(|| {
                 let bump = Bump::new();
-                let out = compile_to_dom(
+                let out = compile_to_vdom(
                     &bump,
                     black_box(source),
                     black_box(lang),
-                    DomCompileOptions::default(),
+                    VdomCompileOptions::default(),
                 );
                 black_box(out);
             });
@@ -185,7 +185,7 @@ criterion_group!(
     benches,
     bench_lower,
     bench_croquis_analyze,
-    bench_compile_dom,
+    bench_compile_vdom,
     bench_compile_vapor,
     bench_compile_mode_aware,
 );

--- a/crates/vize_atelier_jsx/src/compile.rs
+++ b/crates/vize_atelier_jsx/src/compile.rs
@@ -13,7 +13,7 @@ use vize_carton::{Bump, FxHashSet, String};
 use vize_croquis::Croquis;
 
 use crate::diagnostics::JsxDiagnostic;
-use crate::dom::{DomCompileOptions, DomComponent, compile_root_to_dom};
+use crate::dom::{VdomCompileOptions, VdomComponent, compile_root_to_vdom};
 use crate::scoped::ScopedStyle;
 use crate::vapor::{VaporCompileOptions, VaporComponent, compile_root_to_vapor};
 use crate::{JsxLang, JsxOutputMode, lower_source};
@@ -25,7 +25,7 @@ pub struct JsxCompileConfig {
     /// `"use vue:vapor"` / `"use vue:vdom"` directive.
     pub default_mode: JsxOutputMode,
     /// Options for components compiled to VDOM.
-    pub dom: DomCompileOptions,
+    pub dom: VdomCompileOptions,
     /// Options for components compiled to Vapor.
     pub vapor: VaporCompileOptions,
 }
@@ -33,7 +33,7 @@ pub struct JsxCompileConfig {
 /// A compiled component, tagged by the backend it was routed to.
 pub enum JsxComponent {
     /// Compiled to Virtual DOM output.
-    Dom(DomComponent),
+    Dom(VdomComponent),
     /// Compiled to Vapor output.
     Vapor(VaporComponent),
 }
@@ -79,7 +79,7 @@ impl JsxComponent {
 
     /// The v3 source map (JSON) for the component's render code, present only
     /// when source-map emission was requested via
-    /// [`DomCompileOptions::source_map`](crate::DomCompileOptions::source_map)
+    /// [`VdomCompileOptions::source_map`](crate::VdomCompileOptions::source_map)
     /// (#1533). VDOM output carries it; the Vapor backend does not emit one yet,
     /// so it is always `None` there.
     pub fn map(&self) -> Option<&str> {
@@ -290,7 +290,7 @@ pub fn compile_jsx(
     for lowered_root in lowered.roots {
         let mode = resolve_mode(lowered_root.mode, config.default_mode);
         let component = match mode {
-            JsxOutputMode::Vdom => JsxComponent::Dom(compile_root_to_dom(
+            JsxOutputMode::Vdom => JsxComponent::Dom(compile_root_to_vdom(
                 bump,
                 lowered_root,
                 analysis,

--- a/crates/vize_atelier_jsx/src/dom.rs
+++ b/crates/vize_atelier_jsx/src/dom.rs
@@ -30,7 +30,7 @@ use crate::{JsxLang, JsxOutputMode, LoweredRoot, lower_source};
 /// Defaults keep `@vue/babel-plugin-jsx`-shaped output: no static hoisting, no
 /// handler caching, no source map.
 #[derive(Debug, Clone, Default)]
-pub struct DomCompileOptions {
+pub struct VdomCompileOptions {
     /// Hoist static subtrees out of the render function.
     pub hoist_static: bool,
     /// Cache inline event handlers.
@@ -40,7 +40,7 @@ pub struct DomCompileOptions {
 }
 
 /// One compiled component render expression.
-pub struct DomComponent {
+pub struct VdomComponent {
     /// Enclosing component-function name, if resolved.
     pub component_name: Option<String>,
     /// Resolved output mode (defaults to [`JsxOutputMode::Vdom`]).
@@ -50,7 +50,7 @@ pub struct DomComponent {
     /// Import/preamble section for runtime helpers.
     pub preamble: String,
     /// v3 source map (JSON) mapping the generated render code back to the JSX
-    /// source, emitted only when [`DomCompileOptions::source_map`] is set
+    /// source, emitted only when [`VdomCompileOptions::source_map`] is set
     /// (#1533). `None` otherwise. The map's `mappings` cover the render
     /// expression; it does not account for a prepended preamble, so a consumer
     /// that inlines the preamble must offset accordingly (the bindings surface
@@ -65,14 +65,14 @@ pub struct DomComponent {
 }
 
 /// Result of compiling a JSX/TSX module to VDOM.
-pub struct DomOutput {
+pub struct VdomOutput {
     /// One entry per outermost JSX render root, in source order.
-    pub components: Vec<DomComponent>,
+    pub components: Vec<VdomComponent>,
     /// Parse, lowering, and transform diagnostics.
     pub diagnostics: Vec<JsxDiagnostic>,
 }
 
-impl DomOutput {
+impl VdomOutput {
     /// Whether any error-severity diagnostic was produced.
     pub fn has_errors(&self) -> bool {
         self.diagnostics.iter().any(JsxDiagnostic::is_error)
@@ -80,12 +80,12 @@ impl DomOutput {
 }
 
 /// Compile a JSX/TSX module into Vue VDOM render functions.
-pub fn compile_to_dom(
+pub fn compile_to_vdom(
     bump: &Bump,
     source: &str,
     lang: JsxLang,
-    options: DomCompileOptions,
-) -> DomOutput {
+    options: VdomCompileOptions,
+) -> VdomOutput {
     let lowered = lower_source(bump, source, lang);
     let mut diagnostics = lowered.diagnostics;
     let is_ts = lang.is_typescript();
@@ -95,7 +95,7 @@ pub fn compile_to_dom(
 
     let mut components = Vec::with_capacity(lowered.roots.len());
     for lowered_root in lowered.roots {
-        components.push(compile_root_to_dom(
+        components.push(compile_root_to_vdom(
             bump,
             lowered_root,
             analysis,
@@ -105,23 +105,23 @@ pub fn compile_to_dom(
         ));
     }
 
-    DomOutput {
+    VdomOutput {
         components,
         diagnostics,
     }
 }
 
-/// Compile a single already-lowered root to a VDOM [`DomComponent`], appending
-/// any transform diagnostics. Shared by [`compile_to_dom`] and the mode-aware
+/// Compile a single already-lowered root to a VDOM [`VdomComponent`], appending
+/// any transform diagnostics. Shared by [`compile_to_vdom`] and the mode-aware
 /// dispatcher in [`crate::compile`].
-pub(crate) fn compile_root_to_dom(
+pub(crate) fn compile_root_to_vdom(
     bump: &Bump,
     lowered: LoweredRoot,
     analysis: &Croquis,
     is_ts: bool,
-    options: &DomCompileOptions,
+    options: &VdomCompileOptions,
     diagnostics: &mut Vec<JsxDiagnostic>,
-) -> DomComponent {
+) -> VdomComponent {
     let LoweredRoot {
         mut root,
         mode,
@@ -167,7 +167,7 @@ pub(crate) fn compile_root_to_dom(
     };
     let result = generate(&root, codegen_opts);
 
-    DomComponent {
+    VdomComponent {
         component_name,
         mode: mode.unwrap_or(JsxOutputMode::Vdom),
         code: result.code,
@@ -175,6 +175,25 @@ pub(crate) fn compile_root_to_dom(
         map: result.map,
         scoped_style,
     }
+}
+
+#[deprecated(note = "use VdomCompileOptions")]
+pub type DomCompileOptions = VdomCompileOptions;
+
+#[deprecated(note = "use VdomComponent")]
+pub type DomComponent = VdomComponent;
+
+#[deprecated(note = "use VdomOutput")]
+pub type DomOutput = VdomOutput;
+
+#[deprecated(note = "use compile_to_vdom")]
+pub fn compile_to_dom(
+    bump: &Bump,
+    source: &str,
+    lang: JsxLang,
+    options: VdomCompileOptions,
+) -> VdomOutput {
+    compile_to_vdom(bump, source, lang, options)
 }
 
 fn compiler_error_to_diagnostic(error: &CompilerError) -> JsxDiagnostic {

--- a/crates/vize_atelier_jsx/src/lib.rs
+++ b/crates/vize_atelier_jsx/src/lib.rs
@@ -51,7 +51,9 @@ use vize_relief::RootNode;
 
 pub use compile::{JsxCompileConfig, JsxCompileOutput, JsxComponent, compile_jsx, resolve_mode};
 pub use diagnostics::{JsxDiagnostic, Severity};
+#[allow(deprecated)]
 pub use dom::{DomCompileOptions, DomComponent, DomOutput, compile_to_dom};
+pub use dom::{VdomCompileOptions, VdomComponent, VdomOutput, compile_to_vdom};
 pub use lang::JsxLang;
 pub use lower::Lowerer;
 pub use mode::JsxOutputMode;
@@ -75,7 +77,7 @@ pub struct LoweredRoot<'a> {
     /// Raw (un-rewritten) CSS of the component's `<style scoped>` block(s),
     /// extracted from the markup and removed from the rendered children
     /// (#1495). `None` when the component had no `<style scoped>`. The backends
-    /// ([`compile_to_dom`] / [`compile_to_vapor`]) run the scoped-CSS rewrite +
+    /// ([`compile_to_vdom`] / [`compile_to_vapor`]) run the scoped-CSS rewrite +
     /// scope-id generation over this and expose the result on the compiled
     /// component.
     pub scoped_css: Option<String>,

--- a/crates/vize_atelier_jsx/tests/PARITY_INVENTORY.md
+++ b/crates/vize_atelier_jsx/tests/PARITY_INVENTORY.md
@@ -16,7 +16,7 @@ Suites are split so a failure points at the correct backend:
 
 | Suite        | File                    | Backend            | Passing | Ignored |
 | ------------ | ----------------------- | ------------------ | ------- | ------- |
-| VDOM parity  | `tests/parity_vdom.rs`  | `compile_to_dom`   | 41      | 2       |
+| VDOM parity  | `tests/parity_vdom.rs`  | `compile_to_vdom`  | 41      | 2       |
 | Vapor parity | `tests/parity_vapor.rs` | `compile_to_vapor` | 24      | 0       |
 | TSX + modes  | `tests/parity_tsx.rs`   | both               | 10      | 0       |
 
@@ -153,12 +153,12 @@ four are A/B-compared (base vs head) in the `criterion-ab` GitHub Actions lane
 runs both the `vize_atelier_jsx` `jsx_compile` and the `vize_patina`
 `markup_ir_bench` targets:
 
-| Dimension             | Bench group(s)                                                   | Bench file                                | Measures                                           |
-| --------------------- | ---------------------------------------------------------------- | ----------------------------------------- | -------------------------------------------------- |
-| Parser / lowering     | `jsx_lower`                                                      | `vize_atelier_jsx/benches/jsx_compile.rs` | parse + lower to the shared relief IR              |
-| Croquis analysis      | `jsx_croquis_analyze`                                            | `vize_atelier_jsx/benches/jsx_compile.rs` | binding/scope/reactivity, isolated (parse hoisted) |
-| Patina rule traversal | `jsx_lint`                                                       | `vize_patina/benches/markup_ir_bench.rs`  | `Linter::lint_jsx` IR path vs lowering fallback    |
-| VDOM / Vapor codegen  | `jsx_compile_dom`, `jsx_compile_vapor`, `jsx_compile_mode_aware` | `vize_atelier_jsx/benches/jsx_compile.rs` | backend codegen for each output mode               |
+| Dimension             | Bench group(s)                                                    | Bench file                                | Measures                                           |
+| --------------------- | ----------------------------------------------------------------- | ----------------------------------------- | -------------------------------------------------- |
+| Parser / lowering     | `jsx_lower`                                                       | `vize_atelier_jsx/benches/jsx_compile.rs` | parse + lower to the shared relief IR              |
+| Croquis analysis      | `jsx_croquis_analyze`                                             | `vize_atelier_jsx/benches/jsx_compile.rs` | binding/scope/reactivity, isolated (parse hoisted) |
+| Patina rule traversal | `jsx_lint`                                                        | `vize_patina/benches/markup_ir_bench.rs`  | `Linter::lint_jsx` IR path vs lowering fallback    |
+| VDOM / Vapor codegen  | `jsx_compile_vdom`, `jsx_compile_vapor`, `jsx_compile_mode_aware` | `vize_atelier_jsx/benches/jsx_compile.rs` | backend codegen for each output mode               |
 
 **Regression threshold.** The lane is report-only by default (criterion is noisy
 on shared runners). The documented JSX regression threshold is **10%**: setting

--- a/crates/vize_atelier_jsx/tests/adversarial_snapshots.rs
+++ b/crates/vize_atelier_jsx/tests/adversarial_snapshots.rs
@@ -9,9 +9,9 @@ use std::fmt::Write as _;
 use std::ops::Range;
 
 use vize_atelier_jsx::{
-    DomCompileOptions, DomOutput, JsxCompileConfig, JsxCompileOutput, JsxComponent, JsxDiagnostic,
-    JsxLang, JsxOutputMode, LowerOutput, VaporCompileOptions, VaporOutput, compile_jsx,
-    compile_to_dom, compile_to_vapor, lower_source,
+    JsxCompileConfig, JsxCompileOutput, JsxComponent, JsxDiagnostic, JsxLang, JsxOutputMode,
+    LowerOutput, VaporCompileOptions, VaporOutput, VdomCompileOptions, VdomOutput, compile_jsx,
+    compile_to_vapor, compile_to_vdom, lower_source,
 };
 use vize_carton::Bump;
 use vize_relief::{
@@ -365,7 +365,7 @@ fn assert_lower_snapshot(name: &str, source: &str, lang: JsxLang) {
 
 fn assert_dom_snapshot(name: &str, source: &str, lang: JsxLang) {
     let bump = Bump::new();
-    let output = compile_to_dom(&bump, source, lang, DomCompileOptions::default());
+    let output = compile_to_vdom(&bump, source, lang, VdomCompileOptions::default());
     insta::assert_debug_snapshot!(format!("{name}_dom"), dom_output_summary(source, &output));
 }
 
@@ -544,7 +544,7 @@ fn compound_summary(compound: &vize_relief::CompoundExpressionNode<'_>) -> Strin
     out
 }
 
-fn dom_output_summary<'a>(source: &'a str, output: &'a DomOutput) -> DomOutputSummary<'a> {
+fn dom_output_summary<'a>(source: &'a str, output: &'a VdomOutput) -> DomOutputSummary<'a> {
     DomOutputSummary {
         diagnostics: diagnostics_summary(source, &output.diagnostics),
         components: output

--- a/crates/vize_atelier_jsx/tests/common/mod.rs
+++ b/crates/vize_atelier_jsx/tests/common/mod.rs
@@ -6,8 +6,8 @@
 
 use std::fmt::Write as _;
 use vize_atelier_jsx::{
-    DomCompileOptions, JsxLang, LowerOutput, VaporCompileOptions, compile_to_dom, compile_to_vapor,
-    lower_source,
+    JsxLang, LowerOutput, VaporCompileOptions, VdomCompileOptions, compile_to_vapor,
+    compile_to_vdom, lower_source,
 };
 use vize_carton::Bump;
 use vize_relief::{
@@ -54,7 +54,7 @@ pub fn lower_all<'a>(bump: &'a Bump, source: &str) -> LowerOutput<'a> {
 /// Compile one component to VDOM render code.
 pub fn dom_code(source: &str, lang: JsxLang) -> vize_carton::String {
     let bump = Bump::new();
-    let out = compile_to_dom(&bump, source, lang, DomCompileOptions::default());
+    let out = compile_to_vdom(&bump, source, lang, VdomCompileOptions::default());
     assert!(
         !out.has_errors(),
         "unexpected diagnostics: {:?}",

--- a/crates/vize_atelier_jsx/tests/dom.rs
+++ b/crates/vize_atelier_jsx/tests/dom.rs
@@ -7,7 +7,7 @@
 mod common;
 
 use common::{dom_code, snapshot_lang_cases};
-use vize_atelier_jsx::{DomCompileOptions, JsxLang, JsxOutputMode, compile_to_dom};
+use vize_atelier_jsx::{JsxLang, JsxOutputMode, VdomCompileOptions, compile_to_vdom};
 use vize_carton::Bump;
 
 #[test]
@@ -69,11 +69,11 @@ fn vdom_codegen_matrix() {
 #[test]
 fn multiple_components_each_compile_with_their_name() {
     let bump = Bump::new();
-    let out = compile_to_dom(
+    let out = compile_to_vdom(
         &bump,
         "const A = () => <a/>;\nconst B = () => <b/>;",
         JsxLang::Jsx,
-        DomCompileOptions::default(),
+        VdomCompileOptions::default(),
     );
 
     assert_eq!(out.components.len(), 2);
@@ -91,11 +91,11 @@ fn multiple_components_each_compile_with_their_name() {
 #[test]
 fn mode_defaults_to_vdom() {
     let bump = Bump::new();
-    let out = compile_to_dom(
+    let out = compile_to_vdom(
         &bump,
         "const A = () => <div/>;",
         JsxLang::Jsx,
-        DomCompileOptions::default(),
+        VdomCompileOptions::default(),
     );
 
     assert_eq!(out.components[0].mode, JsxOutputMode::Vdom);
@@ -104,11 +104,11 @@ fn mode_defaults_to_vdom() {
 #[test]
 fn vapor_directive_is_recorded_on_the_component() {
     let bump = Bump::new();
-    let out = compile_to_dom(
+    let out = compile_to_vdom(
         &bump,
         "const A = () => { \"use vue:vapor\"; return <div/>; };",
         JsxLang::Jsx,
-        DomCompileOptions::default(),
+        VdomCompileOptions::default(),
     );
 
     assert_eq!(out.components[0].mode, JsxOutputMode::Vapor);
@@ -117,11 +117,11 @@ fn vapor_directive_is_recorded_on_the_component() {
 #[test]
 fn preamble_imports_runtime_helpers() {
     let bump = Bump::new();
-    let out = compile_to_dom(
+    let out = compile_to_vdom(
         &bump,
         "const A = () => <div>{x}</div>;",
         JsxLang::Jsx,
-        DomCompileOptions::default(),
+        VdomCompileOptions::default(),
     );
 
     insta::assert_snapshot!(out.components[0].preamble.as_str());

--- a/crates/vize_atelier_jsx/tests/parity_tsx.rs
+++ b/crates/vize_atelier_jsx/tests/parity_tsx.rs
@@ -4,8 +4,8 @@ mod common;
 
 use common::{dom_code, snapshot_cases, vapor_code};
 use vize_atelier_jsx::{
-    DomCompileOptions, JsxLang, JsxOutputMode, VaporCompileOptions, compile_to_dom,
-    compile_to_vapor, lower_source,
+    JsxLang, JsxOutputMode, VaporCompileOptions, VdomCompileOptions, compile_to_vapor,
+    compile_to_vdom, lower_source,
 };
 use vize_carton::Bump;
 
@@ -60,11 +60,11 @@ fn tsx_type_annotation_is_an_error_when_parsed_as_plain_jsx() {
 #[test]
 fn default_mode_is_vdom_for_dom_backend() {
     let bump = Bump::new();
-    let out = compile_to_dom(
+    let out = compile_to_vdom(
         &bump,
         "const A = () => <div/>;",
         JsxLang::Tsx,
-        DomCompileOptions::default(),
+        VdomCompileOptions::default(),
     );
 
     assert_eq!(out.components[0].mode, JsxOutputMode::Vdom);
@@ -73,11 +73,11 @@ fn default_mode_is_vdom_for_dom_backend() {
 #[test]
 fn use_vue_vapor_directive_is_surfaced_on_component_mode() {
     let bump = Bump::new();
-    let out = compile_to_dom(
+    let out = compile_to_vdom(
         &bump,
         "const A = () => { \"use vue:vapor\"; return <div/>; };",
         JsxLang::Tsx,
-        DomCompileOptions::default(),
+        VdomCompileOptions::default(),
     );
 
     assert_eq!(out.components[0].mode, JsxOutputMode::Vapor);

--- a/crates/vize_atelier_jsx/tests/style.rs
+++ b/crates/vize_atelier_jsx/tests/style.rs
@@ -2,7 +2,8 @@
 
 use std::fmt::Write as _;
 use vize_atelier_jsx::{
-    DomCompileOptions, JsxLang, VaporCompileOptions, compile_to_dom, compile_to_vapor, lower_source,
+    JsxLang, VaporCompileOptions, VdomCompileOptions, compile_to_vapor, compile_to_vdom,
+    lower_source,
 };
 use vize_carton::Bump;
 
@@ -27,9 +28,9 @@ const Comp = () => (
 );
 "#;
 
-fn dom(src: &str, lang: JsxLang) -> vize_atelier_jsx::DomComponent {
+fn dom(src: &str, lang: JsxLang) -> vize_atelier_jsx::VdomComponent {
     let bump = Bump::new();
-    let out = compile_to_dom(&bump, src, lang, DomCompileOptions::default());
+    let out = compile_to_vdom(&bump, src, lang, VdomCompileOptions::default());
     assert!(!out.has_errors(), "diagnostics: {:?}", out.diagnostics);
     assert_eq!(out.components.len(), 1, "expected one component");
     out.components.into_iter().next().unwrap()
@@ -43,7 +44,7 @@ fn vapor(src: &str) -> vize_atelier_jsx::VaporComponent {
     out.components.into_iter().next().unwrap()
 }
 
-fn dom_snapshot(component: &vize_atelier_jsx::DomComponent) -> std::string::String {
+fn dom_snapshot(component: &vize_atelier_jsx::VdomComponent) -> std::string::String {
     let mut snapshot = std::string::String::new();
     writeln!(snapshot, "## code").unwrap();
     snapshot.push_str(component.code.as_str());


### PR DESCRIPTION
Refs #1578

## Summary
- Add JSX-facing Vdom* compile names while keeping Dom* Rust names as deprecated compatibility aliases.
- Update JSX VDOM benchmark IDs and local JSX tests/docs to use the clearer names.
- Keep package/crate names and generated snapshots unchanged.

## Tests
- cargo test -p vize_atelier_jsx
- cargo test -p vize_atelier_core
- cargo check -p vize_vitrine
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1614"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->