### PR TITLE
test(vize): refresh declaration snapshot

### DIFF
--- a/crates/vize/tests/snapshots/check_cli__check_can_emit_declarations.snap
+++ b/crates/vize/tests/snapshots/check_cli__check_can_emit_declarations.snap
@@ -12,7 +12,7 @@ expression: "serde_json::to_string_pretty(&snapshot).unwrap()"
   "files": [
     [
       "App.vue.d.ts",
-      "/// <reference path=\"__vize_helpers.d.ts\" />\nexport interface PublicProps {\n    count: number;\n}\nexport type Props = PublicProps;\nexport type Emits = {};\nexport type Slots = {};\ntype __VizeComponentInstance = {\n    $props: Props;\n    $emit: __EmitFn<Emits>;\n    $slots: Slots;\n};\ndeclare const __vize_component__: new (...args: any[]) => __VizeComponentInstance;\nexport default __vize_component__;\n"
+      "/// <reference path=\"__vize_helpers.d.ts\" />\nexport interface PublicProps {\n    count: number;\n}\nexport type Props = PublicProps;\nexport type Emits = {};\nexport type Slots = {};\ntype __VizeComponentInstance = {\n    $props: Props;\n    $emit: __EmitFn<Emits>;\n    $slots: Slots;\n};\ntype __VizeComponentConstructor = new (...args: any[]) => __VizeComponentInstance;\ntype __VizeVueComponentOptions = {\n    name?: string;\n    __name?: string;\n    __file?: string;\n    __vccOpts?: any;\n    props?: any;\n    emits?: any;\n    slots?: any;\n    setup?: any;\n    render?: Function;\n    components?: any;\n    directives?: any;\n    inheritAttrs?: boolean;\n    compatConfig?: any;\n    call?: (this: unknown, ...args: unknown[]) => never;\n    __isFragment?: never;\n    __isTeleport?: never;\n    __isSuspense?: never;\n    __defaults?: any;\n    __vapor?: boolean;\n    __multiRoot?: boolean;\n    __isKeepAlive?: boolean;\n    __isBuiltIn?: boolean;\n};\ndeclare const __vize_component__: __VizeComponentConstructor & __VizeVueComponentOptions;\nexport default __vize_component__;\n"
     ],
     [
       "__vize_helpers.d.ts",


### PR DESCRIPTION
## Summary
- refresh the declaration emit snapshot for the Vue component option statics shape
- keep main source coverage unblocked after the latest canon change

## Verification
- CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo test -p vize --test check_cli check_can_emit_declarations -- --nocapture
- CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0 cargo llvm-cov --no-report -p vize --test check_cli -- check_can_emit_declarations --nocapture

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1618"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->