### PR TITLE
fix(ci): isolate musea example cargo target

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -116,8 +116,6 @@ jobs:
         run: vp run --filter './playground' build
 
       - name: Build musea-examples
-        env:
-          CARGO_TARGET_DIR: target/docs-example
         run: vp run --filter './examples/vite-musea' build
 
       - name: Upload playground artifact

--- a/examples/vite-musea/package.json
+++ b/examples/vite-musea/package.json
@@ -7,7 +7,7 @@
     "dev": "vp dev --config vite.app.config.ts",
     "build": "pnpm check && vp build --config vite.app.config.ts",
     "preview": "vp preview --config vite.app.config.ts",
-    "check": "cargo run --quiet --manifest-path ../../Cargo.toml -p vize -- check && vp check src vite.config.ts vite.app.config.ts vize.config.ts playwright.config.ts",
+    "check": "cargo run --quiet --target-dir ../../target/docs-example --manifest-path ../../Cargo.toml -p vize -- check && vp check src vite.config.ts vite.app.config.ts vize.config.ts playwright.config.ts",
     "check:fix": "vp check --fix src vite.config.ts vite.app.config.ts vize.config.ts playwright.config.ts",
     "fmt": "vp fmt --write src vite.config.ts vite.app.config.ts vize.config.ts playwright.config.ts",
     "vrt": "musea-vrt",

--- a/tests/tooling/github-workflows.test.ts
+++ b/tests/tooling/github-workflows.test.ts
@@ -845,12 +845,16 @@ test("deploy-docs deploy job keeps a full checkout so local actions and scripts 
 });
 
 test("deploy-docs isolates musea example cargo checks from the sticky target cache", () => {
-  const workflow = readRepoFile(".github", "workflows", "deploy-docs.yml");
-  const buildPlaygroundJob = workflowJobBody(workflow, "build-playground");
+  const manifest = JSON.parse(readRepoFile("examples", "vite-musea", "package.json")) as {
+    scripts?: Record<string, string>;
+  };
+  const checkScript = manifest.scripts?.check;
+  assert.ok(checkScript, "examples/vite-musea/package.json must define a check script");
 
   assert.match(
-    buildPlaygroundJob,
-    /- name: Build musea-examples\s+env:\s+CARGO_TARGET_DIR:\s*target\/docs-example\s+run: vp run --filter '\.\/examples\/vite-musea' build/,
+    checkScript,
+    /cargo run\s[^&]*--target-dir\s+\.\.\/\.\.\/target\/docs-example\b/,
+    "musea example check script must pin cargo's target dir to target/docs-example so it does not reuse the sticky target cache",
   );
 });
 


### PR DESCRIPTION
## Summary
- make the vite-musea check script pass an explicit Cargo target dir
- remove the workflow-only CARGO_TARGET_DIR override that did not prevent the restored target/debug artifact from being reused

## Context
Main Deploy docs failed in run 27461256258 during build-playground because the musea example check reused a missing rkyv_derive artifact from target/debug.

## Verification
- node -e "JSON.parse(require('fs').readFileSync('examples/vite-musea/package.json','utf8')); console.log('package json ok')"
- cargo run --help | rg -- '--target-dir'
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1619"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->