### PR TITLE
docs(examples): wire jsx tsx example into workspace checks

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -137,11 +137,13 @@ checker, LSP, and formatter.
 ### Setup
 
 ```bash
-cd examples/jsx-tsx
-vp check src
-vp lint src
-vp fmt --write src
+vp run --filter './examples/jsx-tsx' check
+vp run --filter './examples/jsx-tsx' lint
+vp run --filter './examples/jsx-tsx' fmt
 ```
+
+The workspace quality gate also includes this package, so `vp run check` covers these JSX/TSX
+inputs alongside the other checked examples.
 
 ### File Structure
 

--- a/examples/jsx-tsx/README.md
+++ b/examples/jsx-tsx/README.md
@@ -4,10 +4,13 @@ This directory keeps focused JSX/TSX inputs for the compiler, linter, type check
 formatter.
 
 ```bash
-vp check src
-vp lint src
-vp fmt --write src
+vp run --filter './examples/jsx-tsx' check
+vp run --filter './examples/jsx-tsx' lint
+vp run --filter './examples/jsx-tsx' fmt
 ```
+
+Run these commands from the repository root. The example is part of the pnpm workspace and the
+repository Vite+ check list, so `vp run check` includes it in aggregate workspace checks.
 
 - `src/StatefulPanel.tsx` shows typed destructured props, setup state, emits, slots, JSX list
   rendering, scoped styles, and CSS custom properties for dynamic styling.

--- a/examples/jsx-tsx/package.json
+++ b/examples/jsx-tsx/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "scripts": {
     "check": "vp check src",
+    "check:fix": "vp check --fix src",
     "lint": "vp lint src",
     "fmt": "vp fmt --write src"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -314,6 +314,19 @@ importers:
         specifier: catalog:vue-stable
         version: 3.5.35(typescript@6.0.3)
 
+  examples/jsx-tsx:
+    dependencies:
+      vue:
+        specifier: catalog:vue-stable
+        version: 3.5.35(typescript@6.0.3)
+    devDependencies:
+      typescript:
+        specifier: catalog:typescript
+        version: 6.0.3
+      vize:
+        specifier: workspace:*
+        version: link:../../npm/vize
+
   examples/oxlint-vize:
     devDependencies:
       oxlint:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,6 +8,7 @@ packages:
   - "npm/fresco/examples/*"
   - "examples/vite-musea"
   - "examples/oxlint-vize"
+  - "examples/jsx-tsx"
   - "docs"
   - "tests"
   - "bench"

--- a/tools/vite-plus/task-inputs.ts
+++ b/tools/vite-plus/task-inputs.ts
@@ -25,6 +25,7 @@ export const checkedPackages = [
   "./npm/rspack-vize-plugin/example",
   "./examples/vite-musea",
   "./examples/oxlint-vize",
+  "./examples/jsx-tsx",
   "./playground",
 ] satisfies PackagePath[];
 


### PR DESCRIPTION
## Summary
- add the JSX/TSX example to the pnpm workspace
- include it in the Vite+ checked package list
- update example docs to use workspace-filtered commands

## Verification
- vp install
- vp install --frozen-lockfile
- vp run --filter './examples/jsx-tsx' check\n- vp run --filter './examples/jsx-tsx' check:fix\n- vp exec node --test tests/tooling/task-shell.test.ts\n- git diff --check\n\nRefs #1591

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1622"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->