### PR TITLE
docs(atelier): prefer pipeline and passes terminology

### DIFF
--- a/crates/vize_atelier_core/Cargo.toml
+++ b/crates/vize_atelier_core/Cargo.toml
@@ -5,12 +5,12 @@ edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
-description = "Atelier Core - The core workshop for Vize Vue template parsing and transforms"
+description = "Atelier Core - The core workshop for Vize Vue template parsing, pipeline passes, and code generation"
 
 [features]
 # Opt-in support for legacy Vue lines (v0.10 / v0.11 / v1 / v2). Off by default
 # so the Vue 3 `vize` binary never compiles it. Enables dialect-gated legacy
-# transforms such as Vue 2 pipe filters and the Vue 2 template-sugar pre-pass
+# passes such as Vue 2 pipe filters and the Vue 2 template-sugar pre-pass
 # (`.sync`, `slot-scope`/`scope`). Forwards to the `legacy` features of the AST
 # (`vize_relief`) and dialect-capability (`vize_armature`) crates.
 legacy = ["vize_relief/_legacy", "vize_armature/legacy"]

--- a/crates/vize_atelier_core/README.md
+++ b/crates/vize_atelier_core/README.md
@@ -1,23 +1,24 @@
 # vize_atelier_core
 
-`vize_atelier_core` contains the shared transform and code generation infrastructure used by the
+`vize_atelier_core` contains the shared pipeline and code generation infrastructure used by the
 DOM, Vapor, and SSR compilers.
 
 ## Highlights
 
-- Core transform pipeline and `TransformContext`
+- Core pipeline and pass APIs
 - Shared Vue template code generation
 - Runtime helper resolution
 - Re-exports for the Relief AST and Armature parser APIs
 
 ## Key Entry Points
 
-- `transform`
+- `pipeline::transform`
+- `passes`
 - `generate`
 - `RuntimeHelpers`
-- `TransformContext`
-- `DirectiveTransform`
-- `NodeTransform`
+- `pipeline::TransformContext`
+- `pipeline::DirectiveTransform`
+- `pipeline::NodeTransform`
 
 ## Related Crates
 

--- a/crates/vize_atelier_dom/README.md
+++ b/crates/vize_atelier_dom/README.md
@@ -4,9 +4,9 @@
 
 ## Highlights
 
-- DOM-aware transforms for directives such as `v-model`, `v-show`, `v-text`, `v-html`, and `v-on`
+- DOM-aware passes for directives such as `v-model`, `v-show`, `v-text`, `v-html`, and `v-on`
 - Platform-specific namespace handling for HTML, SVG, and MathML
-- Shared parser and transform pipeline from `vize_atelier_core`
+- Shared parser and pipeline from `vize_atelier_core`
 
 ## Key Entry Points
 
@@ -16,7 +16,7 @@
 
 ## Related Crates
 
-- `vize_atelier_core` provides shared transforms and codegen
+- `vize_atelier_core` provides shared passes and codegen
 - `vize_croquis` can be passed in through compiler options for semantic context
 - `vize_atelier_sfc` uses this crate for standard template compilation
 

--- a/crates/vize_atelier_ssr/README.md
+++ b/crates/vize_atelier_ssr/README.md
@@ -4,9 +4,9 @@
 
 ## Highlights
 
-- SSR-specific transform configuration
+- SSR-specific pass configuration
 - String-oriented code generation with SSR helpers
-- Shared Relief AST and Atelier Core transform pipeline
+- Shared Relief AST and Atelier Core pipeline
 
 ## Key Entry Points
 
@@ -17,7 +17,7 @@
 
 ## Related Crates
 
-- `vize_atelier_core` provides shared parsing and transform infrastructure
+- `vize_atelier_core` provides shared parsing and pipeline infrastructure
 - `vize_atelier_sfc` can route template blocks through SSR compilation paths
 - `@vizejs/vite-plugin` and Nuxt integration rely on this backend for SSR builds
 

--- a/crates/vize_atelier_vapor/README.md
+++ b/crates/vize_atelier_vapor/README.md
@@ -6,7 +6,7 @@
 
 - Vapor-specific IR generation
 - Code generation helpers for direct DOM-oriented updates
-- Shared parser and transform pipeline with the rest of the Vize compiler stack
+- Shared parser and pipeline with the rest of the Vize compiler stack
 
 ## Key Entry Points
 
@@ -17,7 +17,7 @@
 
 ## Related Crates
 
-- `vize_atelier_core` provides shared transforms and parser access
+- `vize_atelier_core` provides shared passes and parser access
 - `vize_atelier_sfc` delegates Vapor template compilation here
 - `vize_patina` includes Vapor-oriented lint rules that align with this backend
 


### PR DESCRIPTION
## Summary
- update atelier README wording toward pipeline and passes terminology
- update the core crate description to match the new naming direction
- keep compatibility aliases and module names untouched for this docs-only slice

## Verification
- cargo fmt --all -- --check
- cargo check -p vize_atelier_core -p vize_atelier_dom -p vize_atelier_ssr -p vize_atelier_vapor
- git diff --check

Refs #1575

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1624"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->