### PR TITLE
refactor(jsx): use vdom terminology in tests

### DIFF
--- a/crates/vize_atelier_jsx/src/dom.rs
+++ b/crates/vize_atelier_jsx/src/dom.rs
@@ -128,7 +128,7 @@ pub(crate) fn compile_root_to_vdom(
         component_name,
         scoped_css,
         // The style interpolation spans are consumed by the type checker
-        // (`vize_canon`), not the DOM scoping backend.
+        // (`vize_canon`), not the VDOM scoping backend.
         scoped_style_exprs: _,
     } = lowered;
 

--- a/crates/vize_atelier_jsx/tests/common/mod.rs
+++ b/crates/vize_atelier_jsx/tests/common/mod.rs
@@ -52,7 +52,7 @@ pub fn lower_all<'a>(bump: &'a Bump, source: &str) -> LowerOutput<'a> {
 }
 
 /// Compile one component to VDOM render code.
-pub fn dom_code(source: &str, lang: JsxLang) -> vize_carton::String {
+pub fn vdom_code(source: &str, lang: JsxLang) -> vize_carton::String {
     let bump = Bump::new();
     let out = compile_to_vdom(&bump, source, lang, VdomCompileOptions::default());
     assert!(

--- a/crates/vize_atelier_jsx/tests/compile.rs
+++ b/crates/vize_atelier_jsx/tests/compile.rs
@@ -32,7 +32,7 @@ fn component_matrix(out: &JsxCompileOutput) -> std::string::String {
 
 fn component_variant(component: &JsxComponent) -> &'static str {
     match component {
-        JsxComponent::Dom(_) => "dom",
+        JsxComponent::Dom(_) => "vdom",
         JsxComponent::Vapor(_) => "vapor",
     }
 }

--- a/crates/vize_atelier_jsx/tests/control_flow.rs
+++ b/crates/vize_atelier_jsx/tests/control_flow.rs
@@ -2,7 +2,7 @@
 
 mod common;
 
-use common::{dom_code, snapshot_cases, vapor_code};
+use common::{snapshot_cases, vapor_code, vdom_code};
 use vize_atelier_jsx::JsxLang;
 
 #[test]
@@ -40,7 +40,7 @@ fn vdom_control_flow_matrix() {
     ];
 
     insta::assert_snapshot!(snapshot_cases(&cases, |source| {
-        dom_code(source, JsxLang::Jsx)
+        vdom_code(source, JsxLang::Jsx)
     }));
 }
 

--- a/crates/vize_atelier_jsx/tests/dom.rs
+++ b/crates/vize_atelier_jsx/tests/dom.rs
@@ -6,7 +6,7 @@
 
 mod common;
 
-use common::{dom_code, snapshot_lang_cases};
+use common::{snapshot_lang_cases, vdom_code};
 use vize_atelier_jsx::{JsxLang, JsxOutputMode, VdomCompileOptions, compile_to_vdom};
 use vize_carton::Bump;
 
@@ -63,7 +63,7 @@ fn vdom_codegen_matrix() {
         ),
     ];
 
-    insta::assert_snapshot!(snapshot_lang_cases(&cases, dom_code));
+    insta::assert_snapshot!(snapshot_lang_cases(&cases, vdom_code));
 }
 
 #[test]

--- a/crates/vize_atelier_jsx/tests/events.rs
+++ b/crates/vize_atelier_jsx/tests/events.rs
@@ -8,7 +8,7 @@
 
 mod common;
 
-use common::{as_directive, dom_code, lower_one, root_element, simple_content};
+use common::{as_directive, lower_one, root_element, simple_content, vdom_code};
 use vize_atelier_jsx::JsxLang;
 use vize_carton::Bump;
 
@@ -25,7 +25,7 @@ fn event_modifier_codegen_snapshot() {
     ];
 
     insta::assert_snapshot!(common::snapshot_cases(&cases, |source| {
-        dom_code(source, JsxLang::Jsx)
+        vdom_code(source, JsxLang::Jsx)
     }));
 }
 

--- a/crates/vize_atelier_jsx/tests/parity_tsx.rs
+++ b/crates/vize_atelier_jsx/tests/parity_tsx.rs
@@ -2,7 +2,7 @@
 
 mod common;
 
-use common::{dom_code, snapshot_cases, vapor_code};
+use common::{snapshot_cases, vapor_code, vdom_code};
 use vize_atelier_jsx::{
     JsxLang, JsxOutputMode, VaporCompileOptions, VdomCompileOptions, compile_to_vapor,
     compile_to_vdom, lower_source,
@@ -28,7 +28,7 @@ fn tsx_vdom_codegen_matrix() {
     ];
 
     insta::assert_snapshot!(snapshot_cases(&cases, |source| {
-        dom_code(source, JsxLang::Tsx)
+        vdom_code(source, JsxLang::Tsx)
     }));
 }
 
@@ -58,7 +58,7 @@ fn tsx_type_annotation_is_an_error_when_parsed_as_plain_jsx() {
 }
 
 #[test]
-fn default_mode_is_vdom_for_dom_backend() {
+fn default_mode_is_vdom_for_vdom_backend() {
     let bump = Bump::new();
     let out = compile_to_vdom(
         &bump,

--- a/crates/vize_atelier_jsx/tests/parity_vdom.rs
+++ b/crates/vize_atelier_jsx/tests/parity_vdom.rs
@@ -2,7 +2,7 @@
 
 mod common;
 
-use common::{dom_code, snapshot_cases};
+use common::{snapshot_cases, vdom_code};
 use vize_atelier_jsx::JsxLang;
 
 #[test]
@@ -125,6 +125,6 @@ fn vdom_parity_matrix_snapshot() {
     ];
 
     insta::assert_snapshot!(snapshot_cases(&cases, |source| {
-        dom_code(source, JsxLang::Jsx)
+        vdom_code(source, JsxLang::Jsx)
     }));
 }

--- a/crates/vize_atelier_jsx/tests/slots.rs
+++ b/crates/vize_atelier_jsx/tests/slots.rs
@@ -40,7 +40,7 @@ fn slot_codegen_snapshot() {
     ];
 
     insta::assert_snapshot!(common::snapshot_cases(&cases, |source| {
-        common::dom_code(source, JsxLang::Jsx)
+        common::vdom_code(source, JsxLang::Jsx)
     }));
 }
 

--- a/crates/vize_atelier_jsx/tests/snapshots/compile__component_directives_override_defaults.snap
+++ b/crates/vize_atelier_jsx/tests/snapshots/compile__component_directives_override_defaults.snap
@@ -21,7 +21,7 @@ export function render(_ctx) {
 ## component 0
 name: Some("Slow")
 mode: Vdom
-variant: dom
+variant: vdom
 code:
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("div"))

--- a/crates/vize_atelier_jsx/tests/snapshots/compile__default_config_routes_undirected_component_to_vdom.snap
+++ b/crates/vize_atelier_jsx/tests/snapshots/compile__default_config_routes_undirected_component_to_vdom.snap
@@ -5,7 +5,7 @@ expression: component_matrix(&out)
 ## component 0
 name: Some("App")
 mode: Vdom
-variant: dom
+variant: vdom
 code:
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("div"))

--- a/crates/vize_atelier_jsx/tests/snapshots/compile__one_module_can_mix_vdom_and_vapor_components.snap
+++ b/crates/vize_atelier_jsx/tests/snapshots/compile__one_module_can_mix_vdom_and_vapor_components.snap
@@ -19,7 +19,7 @@ export function render(_ctx) {
 ## component 1
 name: Some("B")
 mode: Vdom
-variant: dom
+variant: vdom
 code:
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("b"))

--- a/crates/vize_atelier_jsx/tests/snapshots/compile__vapor_default_with_vdom_directive_override_in_one_module.snap
+++ b/crates/vize_atelier_jsx/tests/snapshots/compile__vapor_default_with_vdom_directive_override_in_one_module.snap
@@ -19,7 +19,7 @@ export function render(_ctx) {
 ## component 1
 name: Some("Overridden")
 mode: Vdom
-variant: dom
+variant: vdom
 code:
 export function render(_ctx, _cache) {
   return (_openBlock(), _createElementBlock("b"))

--- a/crates/vize_atelier_jsx/tests/snapshots/control_flow__vdom_control_flow_matrix.snap
+++ b/crates/vize_atelier_jsx/tests/snapshots/control_flow__vdom_control_flow_matrix.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/vize_atelier_jsx/tests/control_flow.rs
-expression: "snapshot_cases(&cases, |source| { dom_code(source, JsxLang::Jsx) })"
+expression: "snapshot_cases(&cases, |source| { vdom_code(source, JsxLang::Jsx) })"
 ---
 ## logical and with jsx
 ### source

--- a/crates/vize_atelier_jsx/tests/snapshots/dom__vdom_codegen_matrix.snap
+++ b/crates/vize_atelier_jsx/tests/snapshots/dom__vdom_codegen_matrix.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/vize_atelier_jsx/tests/dom.rs
-expression: "snapshot_lang_cases(&cases, dom_code)"
+expression: "snapshot_lang_cases(&cases, vdom_code)"
 ---
 ## single element
 ### lang

--- a/crates/vize_atelier_jsx/tests/snapshots/events__event_modifier_codegen_snapshot.snap
+++ b/crates/vize_atelier_jsx/tests/snapshots/events__event_modifier_codegen_snapshot.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/vize_atelier_jsx/tests/events.rs
-expression: "common::snapshot_cases(&cases, |source| { dom_code(source, JsxLang::Jsx) })"
+expression: "common::snapshot_cases(&cases, |source| { vdom_code(source, JsxLang::Jsx) })"
 ---
 ## capture
 ### source

--- a/crates/vize_atelier_jsx/tests/snapshots/parity_tsx__tsx_vdom_codegen_matrix.snap
+++ b/crates/vize_atelier_jsx/tests/snapshots/parity_tsx__tsx_vdom_codegen_matrix.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/vize_atelier_jsx/tests/parity_tsx.rs
-expression: "snapshot_cases(&cases, |source| { dom_code(source, JsxLang::Tsx) })"
+expression: "snapshot_cases(&cases, |source| { vdom_code(source, JsxLang::Tsx) })"
 ---
 ## typed arrow component
 ### source

--- a/crates/vize_atelier_jsx/tests/snapshots/slots__slot_codegen_snapshot.snap
+++ b/crates/vize_atelier_jsx/tests/snapshots/slots__slot_codegen_snapshot.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/vize_atelier_jsx/tests/slots.rs
-expression: "common::snapshot_cases(&cases, |source|\n{ common::dom_code(source, JsxLang::Jsx) })"
+expression: "common::snapshot_cases(&cases, |source|\n{ common::vdom_code(source, JsxLang::Jsx) })"
 ---
 ## object child named slots
 ### source

--- a/crates/vize_atelier_jsx/tests/snapshots/style__tsx_components_support_scoped_styles.snap
+++ b/crates/vize_atelier_jsx/tests/snapshots/style__tsx_components_support_scoped_styles.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/vize_atelier_jsx/tests/style.rs
-expression: dom_snapshot(&component)
+expression: vdom_snapshot(&component)
 ---
 ## code
 export function render(_ctx, _cache) {

--- a/crates/vize_atelier_jsx/tests/snapshots/style__vdom_scoped_style_snapshot.snap
+++ b/crates/vize_atelier_jsx/tests/snapshots/style__vdom_scoped_style_snapshot.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/vize_atelier_jsx/tests/style.rs
-expression: dom_snapshot(&component)
+expression: vdom_snapshot(&component)
 ---
 ## code
 export function render(_ctx, _cache) {

--- a/crates/vize_atelier_jsx/tests/snapshots/style__vdom_without_scoped_style_snapshot.snap
+++ b/crates/vize_atelier_jsx/tests/snapshots/style__vdom_without_scoped_style_snapshot.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/vize_atelier_jsx/tests/style.rs
-expression: dom_snapshot(&component)
+expression: vdom_snapshot(&component)
 ---
 ## code
 export function render(_ctx, _cache) {

--- a/crates/vize_atelier_jsx/tests/style.rs
+++ b/crates/vize_atelier_jsx/tests/style.rs
@@ -28,7 +28,7 @@ const Comp = () => (
 );
 "#;
 
-fn dom(src: &str, lang: JsxLang) -> vize_atelier_jsx::VdomComponent {
+fn vdom(src: &str, lang: JsxLang) -> vize_atelier_jsx::VdomComponent {
     let bump = Bump::new();
     let out = compile_to_vdom(&bump, src, lang, VdomCompileOptions::default());
     assert!(!out.has_errors(), "diagnostics: {:?}", out.diagnostics);
@@ -44,7 +44,7 @@ fn vapor(src: &str) -> vize_atelier_jsx::VaporComponent {
     out.components.into_iter().next().unwrap()
 }
 
-fn dom_snapshot(component: &vize_atelier_jsx::VdomComponent) -> std::string::String {
+fn vdom_snapshot(component: &vize_atelier_jsx::VdomComponent) -> std::string::String {
     let mut snapshot = std::string::String::new();
     writeln!(snapshot, "## code").unwrap();
     snapshot.push_str(component.code.as_str());
@@ -82,9 +82,9 @@ fn vapor_snapshot(component: &vize_atelier_jsx::VaporComponent) -> std::string::
 
 #[test]
 fn vdom_scoped_style_snapshot() {
-    let component = dom(SCOPED, JsxLang::Jsx);
+    let component = vdom(SCOPED, JsxLang::Jsx);
 
-    insta::assert_snapshot!(dom_snapshot(&component));
+    insta::assert_snapshot!(vdom_snapshot(&component));
 }
 
 #[test]
@@ -96,10 +96,10 @@ fn vapor_scoped_style_snapshot() {
 
 #[test]
 fn vdom_without_scoped_style_snapshot() {
-    let component = dom(PLAIN, JsxLang::Jsx);
+    let component = vdom(PLAIN, JsxLang::Jsx);
 
     assert!(component.scoped_style.is_none());
-    insta::assert_snapshot!(dom_snapshot(&component));
+    insta::assert_snapshot!(vdom_snapshot(&component));
 }
 
 #[test]
@@ -111,8 +111,8 @@ fn vapor_without_scoped_style_snapshot() {
 }
 
 #[test]
-fn dom_and_vapor_agree_on_scope_id() {
-    let d = dom(SCOPED, JsxLang::Jsx);
+fn vdom_and_vapor_agree_on_scope_id() {
+    let d = vdom(SCOPED, JsxLang::Jsx);
     let v = vapor(SCOPED);
 
     assert_eq!(
@@ -167,7 +167,7 @@ fn static_scoped_style_has_no_interpolations() {
 #[test]
 fn non_scoped_style_element_still_renders() {
     let src = r#"const C = () => <div><style>{`.x{}`}</style></div>;"#;
-    let component = dom(src, JsxLang::Jsx);
+    let component = vdom(src, JsxLang::Jsx);
 
     assert!(component.scoped_style.is_none());
     insta::assert_snapshot!(component.code.as_str());
@@ -187,7 +187,7 @@ const Comp = (): any => (
   </>
 );
 "#;
-    let component = dom(src, JsxLang::Tsx);
+    let component = vdom(src, JsxLang::Tsx);
 
-    insta::assert_snapshot!(dom_snapshot(&component));
+    insta::assert_snapshot!(vdom_snapshot(&component));
 }


### PR DESCRIPTION
## Summary
- rename JSX VDOM test helpers and snapshot labels away from DOM wording
- keep deprecated public Dom compatibility aliases intact
- leave larger public API renames for a separate compatibility-focused slice

## Verification
- cargo fmt --all -- --check
- cargo test -p vize_atelier_jsx
- git diff --check

Refs #1578

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1625"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->