### PR TITLE
refactor(croquis): use drawer naming in sfc consumer

### DIFF
--- a/crates/vize_atelier_sfc/src/croquis.rs
+++ b/crates/vize_atelier_sfc/src/croquis.rs
@@ -4,6 +4,9 @@
 //! compiler, linter, type checker, and bindings do not each reinvent script
 //! merging, generic extraction, and virtual-script offsets.
 
+mod drawer;
+
+use self::drawer::{analyze_scripts, apply_options_api_mode};
 use crate::types::SfcDescriptor;
 use vize_atelier_core::RootNode;
 use vize_carton::{String, ToCompactString, cstr, profile};
@@ -131,19 +134,6 @@ pub fn analyze_sfc_descriptor_with_context_legacy_vue2(
     analyze_sfc_descriptor_with_context_impl(descriptor, template_ast, options, false, true)
 }
 
-/// Apply the Options API / legacy binding-resolution mode to a drawer.
-/// `legacy_vue2` implies Options API resolution and additionally pulls in the
-/// Nuxt 2 globals; `options_api` alone resolves only the Options API bindings.
-fn apply_options_api_mode(analyzer: Drawer, options_api: bool, legacy_vue2: bool) -> Drawer {
-    if legacy_vue2 {
-        analyzer.with_legacy_vue2()
-    } else if options_api {
-        analyzer.with_options_api()
-    } else {
-        analyzer
-    }
-}
-
 fn analyze_sfc_descriptor_with_context_impl(
     descriptor: &SfcDescriptor<'_>,
     template_ast: Option<&RootNode<'_>>,
@@ -196,26 +186,23 @@ fn analyze_sfc_descriptor_resolved_impl(
     legacy_vue2: bool,
     resolve_filename: Option<&str>,
 ) -> SfcCroquisAnalysis {
-    let script_analyzed = options.analyzer_options.analyze_script
+    let drawer_options = options.analyzer_options;
+    let script_analyzed = drawer_options.analyze_script
         && (descriptor.script.is_some() || descriptor.script_setup.is_some());
     let mut summary = analyze_scripts(descriptor, options, options_api, legacy_vue2);
     if let Some(filename) = resolve_filename {
         merge_resolved_props_into_croquis(&mut summary, descriptor, filename);
     }
-    let summary = summary;
-    let analyzer = Drawer::with_summary(options.analyzer_options, summary, script_analyzed);
-    let mut analyzer = apply_options_api_mode(analyzer, options_api, legacy_vue2);
+    let drawer = Drawer::with_summary(drawer_options, summary, script_analyzed);
+    let mut drawer = apply_options_api_mode(drawer, options_api, legacy_vue2);
 
     if let Some(root) = template_ast {
-        profile!(
-            "atelier.sfc.croquis.template",
-            analyzer.analyze_template(root)
-        );
+        profile!("atelier.sfc.croquis.template", drawer.draw_template(root));
     }
 
     let (script_content, script_offset) = script_content_for_descriptor(descriptor, options);
     SfcCroquisAnalysis {
-        croquis: analyzer.finish(),
+        croquis: drawer.finish(),
         script_content,
         script_offset,
     }
@@ -240,72 +227,6 @@ pub fn script_content_for_descriptor(
             script.loc.start as u32,
         ),
         (None, None) => (None, 0),
-    }
-}
-
-fn analyze_scripts(
-    descriptor: &SfcDescriptor<'_>,
-    options: SfcCroquisOptions,
-    options_api: bool,
-    legacy_vue2: bool,
-) -> Croquis {
-    if !options.analyzer_options.analyze_script {
-        return Croquis::new();
-    }
-
-    match (descriptor.script.as_ref(), descriptor.script_setup.as_ref()) {
-        (Some(script), Some(script_setup)) if options.merge_scripts => {
-            let plain_analyzer = Drawer::with_options(options.analyzer_options);
-            let mut plain_analyzer =
-                apply_options_api_mode(plain_analyzer, options_api, legacy_vue2);
-            profile!(
-                "atelier.sfc.croquis.script_plain",
-                plain_analyzer.analyze_script_plain(script.content.as_ref())
-            );
-            let plain = plain_analyzer.finish();
-
-            let setup_analyzer = Drawer::with_options(options.analyzer_options);
-            let mut setup_analyzer =
-                apply_options_api_mode(setup_analyzer, options_api, legacy_vue2);
-            let generic = script_setup
-                .attrs
-                .get("generic")
-                .map(|value| value.as_ref());
-            profile!(
-                "atelier.sfc.croquis.script_setup",
-                setup_analyzer
-                    .analyze_script_setup_with_generic(script_setup.content.as_ref(), generic)
-            );
-
-            let mut summary = setup_analyzer.finish();
-            let setup_offset = script.content.len() as u32 + 1;
-            summary.shift_script_offsets(setup_offset);
-            summary.merge_plain_script(plain);
-            summary
-        }
-        (_, Some(script_setup)) => {
-            let analyzer = Drawer::with_options(options.analyzer_options);
-            let mut analyzer = apply_options_api_mode(analyzer, options_api, legacy_vue2);
-            let generic = script_setup
-                .attrs
-                .get("generic")
-                .map(|value| value.as_ref());
-            profile!(
-                "atelier.sfc.croquis.script_setup",
-                analyzer.analyze_script_setup_with_generic(script_setup.content.as_ref(), generic)
-            );
-            analyzer.finish()
-        }
-        (Some(script), None) => {
-            let analyzer = Drawer::with_options(options.analyzer_options);
-            let mut analyzer = apply_options_api_mode(analyzer, options_api, legacy_vue2);
-            profile!(
-                "atelier.sfc.croquis.script_plain",
-                analyzer.analyze_script_plain(script.content.as_ref())
-            );
-            analyzer.finish()
-        }
-        (None, None) => Croquis::new(),
     }
 }
 

--- a/crates/vize_atelier_sfc/src/croquis/drawer.rs
+++ b/crates/vize_atelier_sfc/src/croquis/drawer.rs
@@ -1,0 +1,81 @@
+use super::SfcCroquisOptions;
+use crate::types::SfcDescriptor;
+use vize_carton::profile;
+use vize_croquis::{Croquis, Drawer};
+
+pub(super) fn apply_options_api_mode(
+    drawer: Drawer,
+    options_api: bool,
+    legacy_vue2: bool,
+) -> Drawer {
+    if legacy_vue2 {
+        drawer.with_legacy_vue2()
+    } else if options_api {
+        drawer.with_options_api()
+    } else {
+        drawer
+    }
+}
+
+pub(super) fn analyze_scripts(
+    descriptor: &SfcDescriptor<'_>,
+    options: SfcCroquisOptions,
+    options_api: bool,
+    legacy_vue2: bool,
+) -> Croquis {
+    let drawer_options = options.analyzer_options;
+    if !drawer_options.analyze_script {
+        return Croquis::new();
+    }
+    match (descriptor.script.as_ref(), descriptor.script_setup.as_ref()) {
+        (Some(script), Some(script_setup)) if options.merge_scripts => {
+            let plain_drawer = Drawer::with_options(drawer_options);
+            let mut plain_drawer = apply_options_api_mode(plain_drawer, options_api, legacy_vue2);
+            profile!(
+                "atelier.sfc.croquis.script_plain",
+                plain_drawer.draw_script_plain(script.content.as_ref())
+            );
+            let plain = plain_drawer.finish();
+
+            let setup_drawer = Drawer::with_options(drawer_options);
+            let mut setup_drawer = apply_options_api_mode(setup_drawer, options_api, legacy_vue2);
+            let generic = script_setup
+                .attrs
+                .get("generic")
+                .map(|value| value.as_ref());
+            profile!(
+                "atelier.sfc.croquis.script_setup",
+                setup_drawer.draw_script_setup_with_generic(script_setup.content.as_ref(), generic)
+            );
+
+            let mut summary = setup_drawer.finish();
+            let setup_offset = script.content.len() as u32 + 1;
+            summary.shift_script_offsets(setup_offset);
+            summary.merge_plain_script(plain);
+            summary
+        }
+        (_, Some(script_setup)) => {
+            let drawer = Drawer::with_options(drawer_options);
+            let mut drawer = apply_options_api_mode(drawer, options_api, legacy_vue2);
+            let generic = script_setup
+                .attrs
+                .get("generic")
+                .map(|value| value.as_ref());
+            profile!(
+                "atelier.sfc.croquis.script_setup",
+                drawer.draw_script_setup_with_generic(script_setup.content.as_ref(), generic)
+            );
+            drawer.finish()
+        }
+        (Some(script), None) => {
+            let drawer = Drawer::with_options(drawer_options);
+            let mut drawer = apply_options_api_mode(drawer, options_api, legacy_vue2);
+            profile!(
+                "atelier.sfc.croquis.script_plain",
+                drawer.draw_script_plain(script.content.as_ref())
+            );
+            drawer.finish()
+        }
+        (None, None) => Croquis::new(),
+    }
+}


### PR DESCRIPTION
## Summary

- Move SFC croquis script-drawing helpers into a dedicated `croquis::drawer` submodule.
- Rename local SFC consumer terminology from analyzer wording to drawer wording while keeping public compatibility aliases untouched.
- Keep the touched source files under the 350-line target.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p vize_croquis`
- `cargo test -p vize_atelier_sfc`
- `git diff --check origin/main...HEAD`
- `vp run --workspace-root source:lengths --check --base-ref origin/main`

Refs #1581

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1628"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->