### PR TITLE
refactor(cf): use rules naming for analyzer collection

### DIFF
--- a/crates/vize_croquis_cf/src/analyzers.rs
+++ b/crates/vize_croquis_cf/src/analyzers.rs
@@ -1,4 +1,4 @@
-//! Individual cross-file analyzers.
+//! Individual cross-file rules.
 //!
 //! Each analyzer focuses on a specific aspect of cross-file analysis.
 //!
@@ -23,7 +23,7 @@ mod race_conditions;
 mod reactivity;
 mod setup_context;
 
-// Re-export analyzer types
+// Re-export rule result types
 pub use boundary::{BoundaryInfo, BoundaryKind, analyze_boundaries};
 pub use component_resolution::{ComponentResolutionIssue, analyze_component_resolution};
 pub use element_id::{UniqueIdIssue, analyze_element_ids};

--- a/crates/vize_croquis_cf/src/lib.rs
+++ b/crates/vize_croquis_cf/src/lib.rs
@@ -8,7 +8,7 @@
 //!
 //! - **Dependency Graph**: Track import/export relationships between files
 //! - **Module Registry**: Cache analyzed file results for incremental updates
-//! - **Cross-File Analyzers**:
+//! - **Cross-File Rules**:
 //!   - Fallthrough Attributes: Detect unused `$attrs` and `inheritAttrs` issues
 //!   - Component Emits: Track emit call flows across component boundaries
 //!   - Event Bubbling: Analyze event propagation through component trees
@@ -44,7 +44,7 @@
 //! - Builds and traverses dependency graphs
 //! - May require multiple passes over component trees
 //!
-//! Enable only the analyzers you need to minimize overhead.
+//! Enable only the rules you need to minimize overhead.
 
 mod analyzer;
 mod diagnostics;
@@ -52,7 +52,8 @@ mod graph;
 mod registry;
 mod suppression;
 
-// Analyzer implementations
+// Rule implementations. The historical module is kept as a compatibility
+// source path while internal callers use the clearer `rules` name.
 pub(crate) mod analyzers;
 pub(crate) use analyzers as rules;
 
@@ -63,8 +64,8 @@ pub use graph::{DependencyEdge, DependencyGraph, ModuleNode};
 pub use registry::{FileId, ModuleEntry, ModuleRegistry};
 pub use suppression::{SuppressionDirective, SuppressionError, SuppressionMap};
 
-// Re-export analyzer types
-pub use analyzers::{
+// Re-export rule result types
+pub use rules::{
     BoundaryInfo, BoundaryKind, EmitFlow, EventBubble, FallthroughInfo, PropsValidationIssue,
     PropsValidationIssueKind, ProvideInjectMatch, ReactivityIssue, ReactivityIssueKind,
     UniqueIdIssue,


### PR DESCRIPTION
## Summary

- Describe the cross-file analyzer collection as rules in crate docs and module comments.
- Re-export public rule result types through the existing internal `rules` alias instead of spelling the collection as analyzers at the public re-export point.
- Keep the historical source module path for now so this PR does not move existing >350-line files; splitting those files should happen before any physical directory rename.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p vize_croquis_cf`
- `git diff --check origin/main...HEAD`
- `vp run --workspace-root source:lengths --check --base-ref origin/main`
- `CARGO_INCREMENTAL=0 cargo test -p vize cross_file_opt_in -j1`
- GitHub Actions: in progress

Refs #1583

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1630"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->
