### PR TITLE
docs(rules): prefer cross-file rule terminology

### DIFF
--- a/docs/content/guide/analysis-diagnostics.md
+++ b/docs/content/guide/analysis-diagnostics.md
@@ -17,7 +17,7 @@ examples together.
 - [HTML rules](../rules/html.md)
 - [SSR rules](../rules/ssr.md)
 - [Vapor rules](../rules/vapor.md)
-- [Cross-file analyzer rules](../rules/cross-file.md)
+- [Cross-file rules](../rules/cross-file.md)
 - [Musea and CSS rules](../rules/musea-and-css.md)
 
 ## Diagnostic Families
@@ -25,7 +25,7 @@ examples together.
 Patina rules are single-file lint rules. They use names such as `vue/require-v-for-key` and can be
 configured from `vize.config.*`, the CLI, the JavaScript API, and the Oxlint bridge.
 
-Cross-file analyzer diagnostics use `vize:croquis/cf/*` codes. They are emitted by
+Cross-file diagnostics use `vize:croquis/cf/*` codes. They are emitted by
 `vize lint --cross-file` after Vize builds a project graph, so they can compare providers with
 injectors, track duplicated IDs, and spot reactivity hazards across component boundaries.
 

--- a/docs/content/guide/static-analysis.md
+++ b/docs/content/guide/static-analysis.md
@@ -117,7 +117,7 @@ The built-in presets are meant to support adoption in stages:
 | `nuxt`        | Opinionated rules adjusted for Nuxt auto-import assumptions          |
 | `incremental` | Empty starting point for host-driven, rule-by-rule adoption          |
 
-## Cross-File Analyzer
+## Cross-File Rules
 
 Cross-file analysis lives in Croquis and is exposed to linting through Patina diagnostics. It is
 opt-in because it builds a module registry, import graph, component-usage graph, and additional
@@ -132,9 +132,9 @@ vp run vize:lint:cross-file
 vp run vize:lint:cross-file-tree
 ```
 
-The lower-level analyzer is broader than the current CLI surface:
+The lower-level cross-file engine is broader than the current CLI surface:
 
-| Analyzer option           | Intended diagnostics or facts                                               |
+| Cross-file option         | Intended diagnostics or facts                                               |
 | ------------------------- | --------------------------------------------------------------------------- |
 | `provide_inject`          | Unmatched injects, unused provides, string-key warnings, non-reactive flows |
 | `unique_ids`              | Duplicate IDs and non-unique IDs introduced inside loops                    |

--- a/docs/content/rules/cross-file.md
+++ b/docs/content/rules/cross-file.md
@@ -1,8 +1,8 @@
 ---
-title: Cross-file Analyzer Rules
+title: Cross-file Rules
 ---
 
-# Cross-file Analyzer Rules
+# Cross-file Rules
 
 Cross-file diagnostics are emitted by `vize lint --cross-file`. They use
 `vize:croquis/cf/*` diagnostic codes because they analyze a project graph rather than one isolated
@@ -355,7 +355,7 @@ provide(ThemeKey, theme);
 
 ## `vize:croquis/cf/duplicate-id`
 
-Reports duplicate static IDs across the analyzed component graph. The analyzer reports this when two
+Reports duplicate static IDs across the analyzed component graph. The rule reports this when two
 different components can be rendered together and produce the same DOM ID.
 
 Bad:
@@ -877,8 +877,8 @@ watch(query, async (value, _oldValue, onCleanup) => {
 </script>
 ```
 
-## Analyzer Direction
+## Implementation Direction
 
-The cross-file analyzer is intentionally shaped like rule documentation, even though it uses
+The cross-file engine is intentionally documented as rules, even though it uses
 diagnostic codes today. Future work can promote more Patina rules into this layer when they need
 imports, component relationships, or project-wide symbol identity to explain a bug accurately.

--- a/docs/content/rules/index.md
+++ b/docs/content/rules/index.md
@@ -22,7 +22,7 @@ manual.
 - [Ecosystem rules](./ecosystem.md): preset-backed checks for Nuxt, Vue Router, Pinia, vue-i18n,
   Vue Test Utils, and Void Vue.
 - [Musea and CSS rules](./musea-and-css.md): Musea art-block checks and style diagnostics.
-- [Cross-file analyzer rules](./cross-file.md): project-graph diagnostics emitted by
+- [Cross-file rules](./cross-file.md): project-graph diagnostics emitted by
   `vize lint --cross-file`.
 
 ## Presets

--- a/docs/theme/navigation.js
+++ b/docs/theme/navigation.js
@@ -58,7 +58,7 @@ const vizeDocsNavigation = (() => {
     ["/rules/ssr", "SSR"],
     ["/rules/vapor", "Vapor"],
     ["/rules/musea-and-css", "Musea & CSS"],
-    ["/rules/cross-file", "Cross-file Analyzer"],
+    ["/rules/cross-file", "Cross-file Rules"],
     ["/guide/musea", "Musea"],
     ["/integrations/nuxt", "Nuxt"],
     ["/integrations/vscode", "VS Code"],


### PR DESCRIPTION
## Summary

- Rename the cross-file rule docs page and navigation label from analyzer wording to rule wording.
- Describe the implementation as the cross-file engine where the text is not naming a public API.
- Keep the diagnostic codes and CLI surface unchanged.

## Validation

- `git diff --check origin/main...HEAD`
- `vp run --workspace-root source:lengths --check --base-ref origin/main`
- `pnpm --filter vize-docs build` (build exits 0; optional OG image batch reports the existing local `@vizejs/vite-plugin` resolution warning)

Refs #1583

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1631"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->