### PR TITLE
docs(vdom): use VDOM output terminology

### DIFF
--- a/crates/vize_atelier_dom/src/options.rs
+++ b/crates/vize_atelier_dom/src/options.rs
@@ -1,4 +1,4 @@
-//! DOM compiler options.
+//! VDOM compiler options.
 
 use serde::{Deserialize, Serialize};
 use vize_atelier_core::options::{BindingMetadata, CodegenMode};
@@ -6,7 +6,7 @@ use vize_carton::String;
 use vize_carton::config::VueVersion;
 use vize_croquis::Croquis;
 
-/// DOM compiler options
+/// VDOM compiler options
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct DomCompilerOptions {

--- a/crates/vize_atelier_dom/src/tests.rs
+++ b/crates/vize_atelier_dom/src/tests.rs
@@ -1,4 +1,4 @@
-//! Integration tests for the DOM compiler entry points.
+//! Integration tests for the VDOM compiler entry points.
 
 use super::{
     DomCompilerOptions, Namespace, TemplateChildNode, compile_template,

--- a/docs/content/architecture/crates.md
+++ b/docs/content/architecture/crates.md
@@ -24,7 +24,7 @@ editor tooling can share the same syntax model.
 | Crate                | Role                                                          |
 | -------------------- | ------------------------------------------------------------- |
 | `vize_atelier_core`  | Shared transform pipeline and code generation infrastructure  |
-| `vize_atelier_dom`   | DOM-oriented template compilation                             |
+| `vize_atelier_dom`   | VDOM-oriented template compilation                            |
 | `vize_atelier_vapor` | Vapor-mode template compilation                               |
 | `vize_atelier_ssr`   | Server-side rendering template compilation                    |
 | `vize_atelier_sfc`   | `.vue` parsing plus script, template, and style orchestration |

--- a/docs/content/architecture/overview.md
+++ b/docs/content/architecture/overview.md
@@ -65,7 +65,7 @@ graph LR
     B --> C[Relief<br/>AST]
     C --> D[Croquis<br/>Semantic Analysis]
     D --> E{Atelier}
-    E --> F[DOM Compiler]
+    E --> F[VDOM Compiler]
     E --> G[Vapor Compiler]
     E --> H[SSR Compiler]
     F --> I[Output JS]
@@ -80,7 +80,7 @@ graph LR
 3. **Relief** (AST) — The intermediate representation. All downstream stages operate on this shared AST, eliminating redundant parsing.
 4. **Croquis** (Semantic Analysis) — Resolves template expressions, tracks variable scopes, detects binding types (setup, data, props, inject), and validates expression correctness. Uses OXC for JavaScript/TypeScript AST parsing.
 5. **Atelier** (Compilation) — Transforms the analyzed AST into JavaScript output. Three backends serve different targets:
-   - **DOM** (`vize_atelier_dom`) — `createVNode`/`h` calls with patch flag optimization and static hoisting
+   - **VDOM** (`vize_atelier_dom`) — `createVNode`/`h` calls with patch flag optimization and static hoisting
    - **Vapor** (`vize_atelier_vapor`) — Fine-grained reactive code with direct DOM manipulation (no VDOM)
    - **SSR** (`vize_atelier_ssr`) — String concatenation with hydration markers
 6. **Output** — Generated JavaScript code with source maps
@@ -120,7 +120,7 @@ parity, benchmark, and readiness evidence expected for review.
 | Parsing       | `vize_armature`      | Tokenizer + recursive descent parser                   |
 | Analysis      | `vize_croquis`       | Semantic analysis, scope tracking, binding detection   |
 | Compilation   | `vize_atelier_core`  | Shared transforms, codegen utilities, source maps      |
-| Compilation   | `vize_atelier_dom`   | DOM (VDom) code generation                             |
+| Compilation   | `vize_atelier_dom`   | VDOM code generation                                   |
 | Compilation   | `vize_atelier_vapor` | Vapor mode code generation                             |
 | Compilation   | `vize_atelier_sfc`   | SFC orchestration (script + template + style + HMR)    |
 | Compilation   | `vize_atelier_ssr`   | Server-side rendering compilation                      |
@@ -167,7 +167,7 @@ The analogy between software compilation and artistic creation is surprisingly d
 - The **linter** (Patina) examines the surface finish — finding imperfections that affect the overall quality
 - The **formatter** (Glyph) ensures consistent proportions — like a typographer carving letterforms with precise spacing
 
-This naming convention makes the crate hierarchy intuitive: when you see `vize_atelier_dom`, you immediately understand it is a _workshop_ that produces _DOM output_.
+This naming convention makes the crate hierarchy intuitive: when you see `vize_atelier_dom`, you immediately understand it is a _workshop_ that produces _VDOM output_.
 
 ## External Dependencies
 

--- a/docs/content/guide/compiler-inspector.md
+++ b/docs/content/guide/compiler-inspector.md
@@ -74,7 +74,7 @@ Useful options:
 
 | Option              | Description                                   |
 | ------------------- | --------------------------------------------- |
-| `--target dom`      | Compare DOM compiler output                   |
+| `--target dom`      | Compare VDOM compiler output                  |
 | `--target ssr`      | Compare SSR compiler output                   |
 | `--format agent`    | Emit agent-readable JSON with graph metadata  |
 | `--format compare`  | Run dev-only CLI comparison against Vue       |

--- a/docs/content/guide/vite-plugin.md
+++ b/docs/content/guide/vite-plugin.md
@@ -317,7 +317,7 @@ See [Nuxt Integration](../integrations/nuxt.md) for more details.
 
 - The plugin requires `@vizejs/native` for Node.js NAPI bindings (installed automatically as a dependency)
 - Vapor mode compilation is available via `vize_atelier_vapor` (Vue 3.6+)
-- DOM (VDom) compilation uses `vize_atelier_dom`
+- VDOM compilation uses `vize_atelier_dom`
 - The plugin supports `virtual:vize-styles` for importing all compiled CSS as a module
 - `.jsx`/`.tsx` Vue components are compiled automatically through the same plugin — see the [JSX & TSX](./jsx.md) guide
 - For experimental rollup / webpack / esbuild / Rspack support, see [Experimental Bundler Integrations](./unplugin.md)

--- a/docs/content/philosophy.md
+++ b/docs/content/philosophy.md
@@ -66,7 +66,7 @@ Every Vize crate is named after a concept from the visual arts — painting, scu
 | **Musea**    | Plural of museum                | Component gallery — exhibiting the work |
 | **Fresco**   | Wall painting technique         | TUI framework — painting the terminal   |
 
-This naming system serves a practical purpose: it makes the crate hierarchy intuitive. When you see `vize_atelier_dom`, you immediately understand it is a _workshop_ that produces _DOM output_. When you see `vize_patina`, you know it _polishes_ your code.
+This naming system serves a practical purpose: it makes the crate hierarchy intuitive. When you see `vize_atelier_dom`, you immediately understand it is a _workshop_ that produces _VDOM output_. When you see `vize_patina`, you know it _polishes_ your code.
 
 #### The Sculpture Analogy
 
@@ -78,7 +78,7 @@ The deepest analogy is between software compilation and sculpture. Consider how 
 
 3. **Croquis** — Before committing to a final sculpture, the artist makes quick sketches (_croquis_) to understand the subject's essential character. In Vize, semantic analysis (`vize_croquis`) is a quick pass that captures the meaning of code — what variables are bound, what expressions are valid — without committing to a compilation target.
 
-4. **Atelier** — The sculptor moves to the _atelier_ (workshop) to create the final piece. Multiple ateliers may produce different renditions of the same subject. In Vize, the compilation backends (`vize_atelier_dom`, `vize_atelier_vapor`, `vize_atelier_ssr`) are different workshops that produce different renditions (DOM, Vapor, SSR) of the same analyzed AST.
+4. **Atelier** — The sculptor moves to the _atelier_ (workshop) to create the final piece. Multiple ateliers may produce different renditions of the same subject. In Vize, the compilation backends (`vize_atelier_dom`, `vize_atelier_vapor`, `vize_atelier_ssr`) are different workshops that produce different renditions (VDOM, Vapor, SSR) of the same analyzed AST.
 
 5. **Vitrine** — The finished work is placed in a _vitrine_ (glass display case) so others can observe it. In Vize, the bindings (`vize_vitrine`) are a transparent layer that lets JavaScript consumers access the compiled output.
 

--- a/tests/fuzz/fuzz_targets/template_compile.rs
+++ b/tests/fuzz/fuzz_targets/template_compile.rs
@@ -2,7 +2,7 @@
 
 // Vue template → render IR fuzz target.
 //
-// Drives `vize_atelier_dom::compile_template` (parse + transform + codegen)
+// Drives `vize_atelier_dom::compile_template` (parse + VDOM codegen)
 // with arbitrary UTF-8 input. Compile errors are returned in the
 // `Vec<CompilerError>` channel; a panic here means the template pipeline lost
 // invariants on adversarial input.


### PR DESCRIPTION
## Summary

- Use VDOM wording for the `vize_atelier_dom` output path in architecture and guide docs.
- Keep compatibility names such as the crate name and `--target dom` flag unchanged.
- Update nearby Rust/fuzz comments where they describe the compiler output model rather than browser DOM APIs.

## Validation

- `git diff --check`
- `cargo fmt --all -- --check`
- `vp run --workspace-root source:lengths --check --base-ref origin/main`
- `cargo check -p vize_atelier_dom`

Refs #1578

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1632"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->