### PR TITLE
refactor(relief)!: remove legacy render attachments

### DIFF
--- a/crates/vize_atelier_core/src/lane/mod.rs
+++ b/crates/vize_atelier_core/src/lane/mod.rs
@@ -285,10 +285,10 @@ fn transform_inner<'a>(
         hoist_static(&mut ctx, &mut root.children)
     );
 
-    // Create root codegen node
+    // Register helpers implied by the root shape.
     profile!(
-        "atelier.transform.create_root_codegen",
-        create_root_codegen(&mut ctx, root)
+        "atelier.transform.register_root_helpers",
+        register_root_helpers(&mut ctx, root)
     );
 
     // Update root with context results
@@ -316,8 +316,7 @@ fn transform_inner<'a>(
     ctx.errors
 }
 
-/// Create codegen node for root
-fn create_root_codegen<'a>(ctx: &mut TransformContext<'a>, root: &mut RootNode<'a>) {
+fn register_root_helpers<'a>(ctx: &mut TransformContext<'a>, root: &mut RootNode<'a>) {
     if root.children.is_empty() {
         return;
     }
@@ -328,9 +327,6 @@ fn create_root_codegen<'a>(ctx: &mut TransformContext<'a>, root: &mut RootNode<'
         ctx.helper(RuntimeHelper::CreateElementBlock);
         ctx.helper(RuntimeHelper::Fragment);
     }
-
-    // Root codegen node is handled in codegen directly for now
-    root.codegen_node = None;
 }
 
 #[cfg(test)]

--- a/crates/vize_atelier_core/src/lib.rs
+++ b/crates/vize_atelier_core/src/lib.rs
@@ -26,17 +26,17 @@ pub use vize_relief::options::{
 };
 pub use vize_relief::{
     ArrayElement, ArrayExpression, AssignmentExpression, AttributeNode, BlockStatement,
-    BlockStatementBody, CacheExpression, CallArgument, CallExpression, Callee, CodegenNode,
-    CommentNode, CompoundExpressionChild, CompoundExpressionNode, ConditionalExpression,
-    ConstantType, DirectiveArgumentNode, DirectiveArguments, DirectiveNode, DynamicProps,
-    ElementCodegenNode, ElementNode, ElementType, ExpressionNode, ForNode, ForParseResult,
-    FunctionBody, FunctionExpression, FunctionParam, FunctionParams, FunctionReturns, IfBranchNode,
-    IfCodegenNode, IfNode, IfStatement, IfStatementAlternate, ImportItem, InterpolationNode,
-    JsChildNode, JsExpression, Namespace, NodeType, ObjectExpression, Position, PropNode, Property,
-    PropsExpression, ReturnStatement, ReturnValue, RootNode, RuntimeHelper, SequenceExpression,
-    SimpleExpressionNode, SlotsExpression, SourceLocation, TemplateChildNode, TemplateLiteral,
-    TemplateLiteralElement, TemplateTextChildNode, TextCallCodegenNode, TextCallContent,
-    TextCallNode, TextNode, VNodeCall, VNodeChildren, VNodeTag,
+    BlockStatementBody, CacheExpression, CallArgument, CallExpression, Callee, CommentNode,
+    CompoundExpressionChild, CompoundExpressionNode, ConditionalExpression, ConstantType,
+    DirectiveArgumentNode, DirectiveArguments, DirectiveNode, DynamicProps, ElementNode,
+    ElementType, ExpressionNode, ForNode, ForParseResult, FunctionBody, FunctionExpression,
+    FunctionParam, FunctionParams, FunctionReturns, IfBranchNode, IfNode, IfStatement,
+    IfStatementAlternate, ImportItem, InterpolationNode, JsChildNode, JsExpression, Namespace,
+    NodeType, ObjectExpression, Position, PropNode, Property, PropsExpression, ReturnStatement,
+    ReturnValue, RootNode, RuntimeHelper, SequenceExpression, SimpleExpressionNode,
+    SlotsExpression, SourceLocation, TemplateChildNode, TemplateLiteral, TemplateLiteralElement,
+    TemplateTextChildNode, TextCallContent, TextCallNode, TextNode, VNodeCall, VNodeChildren,
+    VNodeTag,
 };
 pub use vize_relief::{errors, options};
 

--- a/crates/vize_atelier_core/src/transform/structural.rs
+++ b/crates/vize_atelier_core/src/transform/structural.rs
@@ -249,7 +249,6 @@ pub(crate) fn transform_v_if_with_directive<'a>(
 
         let if_node = IfNode {
             branches,
-            codegen_node: None,
             loc: element_loc,
         };
 
@@ -492,7 +491,6 @@ pub fn transform_v_for<'a>(
         object_index_alias: index_alias,
         parse_result,
         children: for_children,
-        codegen_node: None,
         loc: element_loc,
     };
 

--- a/crates/vize_atelier_jsx/src/lower/control_flow.rs
+++ b/crates/vize_atelier_jsx/src/lower/control_flow.rs
@@ -229,7 +229,6 @@ impl<'a, 'm, 's> Lowerer<'a, 'm, 's> {
             parse_result,
             children,
             loc: self.mapper().location(container_span),
-            codegen_node: None,
         };
         Some(TemplateChildNode::For(Box::new_in(for_node, self.bump())))
     }

--- a/crates/vize_atelier_sfc/src/compile.rs
+++ b/crates/vize_atelier_sfc/src/compile.rs
@@ -7,6 +7,7 @@
 mod bindings;
 mod helpers;
 mod normal_script;
+pub(crate) mod output_module;
 mod styles;
 #[cfg(test)]
 mod tests;
@@ -23,7 +24,7 @@ use crate::rewrite_default::rewrite_default;
 use crate::script::ScriptCompileContext;
 use crate::types::{
     BindingMetadata, BindingType, SfcCompileOptions, SfcCompileResult, SfcDescriptor, SfcError,
-    SfcMacroArtifact, css_modules_object_literal,
+    SfcMacroArtifact,
 };
 use vize_atelier_core::TemplateSyntaxMode;
 
@@ -34,6 +35,10 @@ use self::helpers::{
     demote_v_model_reactive_const_bindings, extract_component_name, generate_scope_id,
 };
 use self::normal_script::extract_normal_script_content;
+use self::output_module::{
+    RenderFunctionName, append_component_render_export, append_css_modules_assignment,
+    rewrite_client_render_for_sfc_main,
+};
 use self::styles::compile_styles;
 
 // Re-export ScriptCompileResult for public API
@@ -78,37 +83,6 @@ fn create_standalone_import_warning() -> SfcError {
 
 pub(crate) fn is_ts_lang(lang: Option<&str>) -> bool {
     matches!(lang, Some("ts" | "tsx"))
-}
-
-fn append_css_modules_assignment(
-    code: &mut String,
-    target: &str,
-    css_modules: &[crate::types::CssModuleMapping],
-) {
-    if css_modules.is_empty() {
-        return;
-    }
-
-    code.push_str(target);
-    code.push_str(".__cssModules = ");
-    code.push_str(&css_modules_object_literal(css_modules, ""));
-    code.push('\n');
-}
-
-fn rewrite_client_render_for_sfc_main(template_code: &str) -> String {
-    if template_code.contains("export function render(") {
-        return template_code
-            .replacen("export function render(", "function _sfc_render(", 1)
-            .to_compact_string();
-    }
-
-    if template_code.contains("function render(") {
-        return template_code
-            .replacen("function render(", "function _sfc_render(", 1)
-            .to_compact_string();
-    }
-
-    template_code.to_compact_string()
 }
 
 fn extract_descriptor_macro_artifacts(descriptor: &SfcDescriptor) -> Vec<SfcMacroArtifact> {
@@ -408,31 +382,28 @@ fn compile_sfc_inner(
                 code = template_output.code;
                 if is_vapor {
                     code.push_str("const _sfc_main = { __vapor: true }\n");
-                    code.push_str("_sfc_main.render = render\n");
-                    append_css_modules_assignment(
+                    append_component_render_export(
                         &mut code,
                         "_sfc_main",
+                        RenderFunctionName::Render,
                         &compiled_styles.css_modules,
                     );
-                    code.push_str("export default _sfc_main\n");
                 } else if options.template.ssr {
                     code.push_str("const _sfc_main = {}\n");
-                    code.push_str("_sfc_main.ssrRender = ssrRender\n");
-                    append_css_modules_assignment(
+                    append_component_render_export(
                         &mut code,
                         "_sfc_main",
+                        RenderFunctionName::SsrRender,
                         &compiled_styles.css_modules,
                     );
-                    code.push_str("export default _sfc_main\n");
                 } else if !compiled_styles.css_modules.is_empty() {
                     code.push_str("const _sfc_main = {}\n");
-                    code.push_str("_sfc_main.render = render\n");
-                    append_css_modules_assignment(
+                    append_component_render_export(
                         &mut code,
                         "_sfc_main",
+                        RenderFunctionName::Render,
                         &compiled_styles.css_modules,
                     );
-                    code.push_str("export default _sfc_main\n");
                 }
             }
             // Previously this just collected the error into a local vec
@@ -627,19 +598,19 @@ fn compile_sfc_inner(
                     if is_vapor {
                         code.push_str("_sfc_main.__vapor = true\n");
                     }
-                    if options.template.ssr {
-                        code.push_str("_sfc_main.ssrRender = ssrRender\n");
+                    let render = if options.template.ssr {
+                        RenderFunctionName::SsrRender
                     } else if is_vapor {
-                        code.push_str("_sfc_main.render = render\n");
+                        RenderFunctionName::Render
                     } else {
-                        code.push_str("_sfc_main.render = _sfc_render\n");
-                    }
-                    append_css_modules_assignment(
+                        RenderFunctionName::SfcRender
+                    };
+                    append_component_render_export(
                         &mut code,
                         "_sfc_main",
+                        render,
                         &compiled_styles.css_modules,
                     );
-                    code.push_str("export default _sfc_main\n");
                 }
                 Err(e) => {
                     errors.push(e);

--- a/crates/vize_atelier_sfc/src/compile/output_module.rs
+++ b/crates/vize_atelier_sfc/src/compile/output_module.rs
@@ -1,0 +1,115 @@
+//! Shared SFC render output assembly.
+
+use crate::types::{CssModuleMapping, css_modules_object_literal};
+use vize_carton::{String, ToCompactString};
+
+/// The render function a generated SFC component should expose.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub(crate) enum RenderFunctionName {
+    Render,
+    SfcRender,
+    SsrRender,
+}
+
+impl RenderFunctionName {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Render => "render",
+            Self::SfcRender => "_sfc_render",
+            Self::SsrRender => "ssrRender",
+        }
+    }
+
+    fn component_field(self) -> &'static str {
+        match self {
+            Self::Render | Self::SfcRender => "render",
+            Self::SsrRender => "ssrRender",
+        }
+    }
+}
+
+/// Structural output module used before SFC code is flattened into a string.
+///
+/// This is intentionally small: it gives the SFC layer a typed boundary for
+/// imports/hoists/functions/exports without changing backend emitters yet.
+#[derive(Debug, Default)]
+pub(crate) struct OutputModule {
+    pub(crate) imports: String,
+    pub(crate) hoists: String,
+    pub(crate) functions: String,
+    pub(crate) exports: String,
+}
+
+impl OutputModule {
+    pub(crate) fn from_render_chunks(imports: String, functions: String) -> Self {
+        Self {
+            imports,
+            functions,
+            ..Self::default()
+        }
+    }
+
+    pub(crate) fn function_base_offset(&self) -> usize {
+        self.imports.len() + self.hoists.len() + 1
+    }
+
+    pub(crate) fn into_code(self) -> String {
+        let mut code = String::default();
+        code.push_str(&self.imports);
+        code.push_str(&self.hoists);
+        code.push('\n');
+        code.push_str(&self.functions);
+        code.push('\n');
+        code.push_str(&self.exports);
+        code
+    }
+}
+
+pub(crate) fn rewrite_client_render_for_sfc_main(template_code: &str) -> String {
+    if template_code.contains("export function render(") {
+        return template_code
+            .replacen("export function render(", "function _sfc_render(", 1)
+            .to_compact_string();
+    }
+
+    if template_code.contains("function render(") {
+        return template_code
+            .replacen("function render(", "function _sfc_render(", 1)
+            .to_compact_string();
+    }
+
+    template_code.to_compact_string()
+}
+
+pub(crate) fn append_css_modules_assignment(
+    code: &mut String,
+    target: &str,
+    css_modules: &[CssModuleMapping],
+) {
+    if css_modules.is_empty() {
+        return;
+    }
+
+    code.push_str(target);
+    code.push_str(".__cssModules = ");
+    code.push_str(&css_modules_object_literal(css_modules, ""));
+    code.push('\n');
+}
+
+pub(crate) fn append_component_render_export(
+    code: &mut String,
+    target: &str,
+    render: RenderFunctionName,
+    css_modules: &[CssModuleMapping],
+) {
+    code.push_str(target);
+    code.push('.');
+    code.push_str(render.component_field());
+    code.push_str(" = ");
+    code.push_str(render.as_str());
+    code.push('\n');
+    append_css_modules_assignment(code, target, css_modules);
+    code.push_str("export default ");
+    code.push_str(target);
+    code.push('\n');
+}

--- a/crates/vize_atelier_sfc/src/compile_template.rs
+++ b/crates/vize_atelier_sfc/src/compile_template.rs
@@ -19,6 +19,7 @@ pub(crate) use vapor::compile_template_block_vapor;
 use vize_atelier_core::TemplateSyntaxMode;
 use vize_carton::Bump;
 
+use crate::compile::output_module::OutputModule;
 use crate::types::{BindingMetadata, SfcError, SfcTemplateBlock, TemplateCompileOptions};
 
 pub(crate) struct TemplateBlockCompileResult {
@@ -130,11 +131,7 @@ pub(crate) fn compile_template_block(
             });
         }
 
-        let mut output = String::default();
-        output.push_str(&result.preamble);
-        output.push('\n');
-        output.push_str(&result.code);
-        output.push('\n');
+        let output = OutputModule::from_render_chunks(result.preamble, result.code).into_code();
         return Ok(TemplateBlockCompileResult {
             code: output,
             warnings: recoverable_template_warnings(&errors),
@@ -210,35 +207,24 @@ pub(crate) fn compile_template_block(
         });
     }
 
-    // Generate render function with proper imports
-    let mut output = String::default();
-
-    // Add Vue imports
-    output.push_str(&result.result.preamble);
-    output.push('\n');
-
-    // The codegen already generates a complete function with closing brace,
-    // so we just need to use it directly
-    output.push_str(&result.result.code);
-    output.push('\n');
-
     // Translate the emission-recorded section offsets into the concatenated
     // output: `output = preamble + '\n' + code + '\n'`, where `preamble` is
     // the import statement followed (when hoists exist) by '\n' + hoists.
-    let sections = result.sections.map(|s| {
-        let preamble_len = result.result.preamble.len();
-        let fn_base = preamble_len + 1;
-        TemplateCodeSections {
-            imports: (0, s.imports_len),
-            hoisted: if preamble_len > s.imports_len {
-                (s.imports_len + 1, preamble_len)
-            } else {
-                (preamble_len, preamble_len)
-            },
-            assets: (fn_base + s.assets_start, fn_base + s.assets_end),
-            return_expr: (fn_base + s.return_expr_start, fn_base + s.return_expr_end),
-        }
+    let output_module =
+        OutputModule::from_render_chunks(result.result.preamble, result.result.code);
+    let preamble_len = output_module.imports.len();
+    let fn_base = output_module.function_base_offset();
+    let sections = result.sections.map(|s| TemplateCodeSections {
+        imports: (0, s.imports_len),
+        hoisted: if preamble_len > s.imports_len {
+            (s.imports_len + 1, preamble_len)
+        } else {
+            (preamble_len, preamble_len)
+        },
+        assets: (fn_base + s.assets_start, fn_base + s.assets_end),
+        return_expr: (fn_base + s.return_expr_start, fn_base + s.return_expr_end),
     });
+    let output = output_module.into_code();
 
     Ok(TemplateBlockCompileResult {
         code: output,

--- a/crates/vize_relief/src/relief/codegen.rs
+++ b/crates/vize_relief/src/relief/codegen.rs
@@ -118,14 +118,6 @@ pub enum JsChildNode<'a> {
     CompoundExpression(Box<'a, CompoundExpressionNode<'a>>),
 }
 
-/// Codegen node union type
-#[derive(Debug)]
-pub enum CodegenNode<'a> {
-    TemplateChild(TemplateChildNode<'a>),
-    JsChild(JsChildNode<'a>),
-    BlockStatement(Box<'a, BlockStatement<'a>>),
-}
-
 /// Call expression
 #[derive(Debug)]
 pub struct CallExpression<'a> {

--- a/crates/vize_relief/src/relief/control_flow.rs
+++ b/crates/vize_relief/src/relief/control_flow.rs
@@ -6,10 +6,9 @@
 use vize_carton::{Box, Bump, Vec};
 
 use super::{
-    codegen::{CacheExpression, CallExpression, ConditionalExpression, VNodeCall},
     core::{NodeType, SourceLocation},
     elements::PropNode,
-    expressions::{CompoundExpressionNode, ExpressionNode, SimpleExpressionNode},
+    expressions::{CompoundExpressionNode, ExpressionNode},
     nodes::TemplateChildNode,
 };
 
@@ -18,7 +17,6 @@ use super::{
 pub struct IfNode<'a> {
     pub branches: Vec<'a, IfBranchNode<'a>>,
     pub loc: SourceLocation,
-    pub codegen_node: Option<IfCodegenNode<'a>>,
 }
 
 impl<'a> IfNode<'a> {
@@ -26,20 +24,12 @@ impl<'a> IfNode<'a> {
         Self {
             branches: Vec::new_in(allocator),
             loc,
-            codegen_node: None,
         }
     }
 
     pub fn node_type(&self) -> NodeType {
         NodeType::If
     }
-}
-
-/// If codegen node type
-#[derive(Debug)]
-pub enum IfCodegenNode<'a> {
-    Conditional(Box<'a, ConditionalExpression<'a>>),
-    Cache(Box<'a, CacheExpression<'a>>),
 }
 
 /// If branch node (v-if, v-else-if, v-else)
@@ -82,7 +72,6 @@ pub struct ForNode<'a> {
     pub parse_result: ForParseResult<'a>,
     pub children: Vec<'a, TemplateChildNode<'a>>,
     pub loc: SourceLocation,
-    pub codegen_node: Option<Box<'a, VNodeCall<'a>>>,
 }
 
 impl<'a> ForNode<'a> {
@@ -106,7 +95,6 @@ pub struct ForParseResult<'a> {
 pub struct TextCallNode<'a> {
     pub content: TextCallContent<'a>,
     pub loc: SourceLocation,
-    pub codegen_node: Option<TextCallCodegenNode<'a>>,
 }
 
 impl<'a> TextCallNode<'a> {
@@ -121,11 +109,4 @@ pub enum TextCallContent<'a> {
     Text(Box<'a, super::elements::TextNode>),
     Interpolation(Box<'a, super::elements::InterpolationNode<'a>>),
     Compound(Box<'a, CompoundExpressionNode<'a>>),
-}
-
-/// Text call codegen node
-#[derive(Debug)]
-pub enum TextCallCodegenNode<'a> {
-    Call(Box<'a, CallExpression<'a>>),
-    Simple(Box<'a, SimpleExpressionNode<'a>>),
 }

--- a/crates/vize_relief/src/relief/elements.rs
+++ b/crates/vize_relief/src/relief/elements.rs
@@ -6,7 +6,6 @@
 use vize_carton::{Box, Bump, String, Vec, directive::DirectiveKind};
 
 use super::{
-    codegen::{CacheExpression, VNodeCall},
     control_flow::ForParseResult,
     core::{ElementType, Namespace, NodeType, SourceLocation},
     expressions::{ExpressionNode, SimpleExpressionNode},
@@ -23,7 +22,6 @@ pub struct ElementNode<'a> {
     pub is_self_closing: bool,
     pub loc: SourceLocation,
     pub inner_loc: Option<SourceLocation>,
-    pub codegen_node: Option<ElementCodegenNode<'a>>,
     /// If props are hoisted, this is the index into the hoists array (1-based for _hoisted_N)
     pub hoisted_props_index: Option<usize>,
 }
@@ -39,7 +37,6 @@ impl<'a> ElementNode<'a> {
             is_self_closing: false,
             loc,
             inner_loc: None,
-            codegen_node: None,
             hoisted_props_index: None,
         }
     }
@@ -47,14 +44,6 @@ impl<'a> ElementNode<'a> {
     pub fn node_type(&self) -> NodeType {
         NodeType::Element
     }
-}
-
-/// Element codegen node (VNodeCall, SimpleExpression, CacheExpression, etc.)
-#[derive(Debug)]
-pub enum ElementCodegenNode<'a> {
-    VNodeCall(Box<'a, VNodeCall<'a>>),
-    SimpleExpression(Box<'a, SimpleExpressionNode<'a>>),
-    CacheExpression(Box<'a, CacheExpression<'a>>),
 }
 
 /// Prop node (attribute or directive)

--- a/crates/vize_relief/src/relief/nodes.rs
+++ b/crates/vize_relief/src/relief/nodes.rs
@@ -6,8 +6,7 @@
 use vize_carton::{Box, Bump, String, Vec};
 
 use super::{
-    CodegenNode, ForNode, IfBranchNode, IfNode, ImportItem, JsChildNode, RuntimeHelper,
-    TextCallNode,
+    ForNode, IfBranchNode, IfNode, ImportItem, JsChildNode, RuntimeHelper, TextCallNode,
     codegen::CacheExpression,
     core::{NodeType, STUB_LOCATION, SourceLocation},
     elements::{CommentNode, ElementNode, InterpolationNode, TextNode},
@@ -40,7 +39,6 @@ pub struct RootNode<'a> {
     pub temps: u32,
     pub source: String,
     pub loc: SourceLocation,
-    pub codegen_node: Option<CodegenNode<'a>>,
     pub transformed: bool,
 }
 
@@ -59,7 +57,6 @@ impl<'a> RootNode<'a> {
             temps: 0,
             source: source.into(),
             loc: SourceLocation::STUB,
-            codegen_node: None,
             transformed: false,
         }
     }

--- a/crates/vize_relief/src/relief/tests.rs
+++ b/crates/vize_relief/src/relief/tests.rs
@@ -195,7 +195,6 @@ fn root_node_new() {
     assert!(root.components.is_empty());
     assert_eq!(root.temps, 0);
     assert!(!root.transformed);
-    assert!(root.codegen_node.is_none());
     assert_eq!(root.node_type(), NodeType::Root);
 }
 
@@ -209,7 +208,6 @@ fn element_node_new() {
     assert!(el.props.is_empty());
     assert!(el.children.is_empty());
     assert!(!el.is_self_closing);
-    assert!(el.codegen_node.is_none());
     assert_eq!(el.node_type(), NodeType::Element);
 }
 
@@ -282,7 +280,6 @@ fn if_node_new() {
     let allocator = Bump::new();
     let if_node = IfNode::new(&allocator, SourceLocation::STUB);
     assert!(if_node.branches.is_empty());
-    assert!(if_node.codegen_node.is_none());
     assert_eq!(if_node.node_type(), NodeType::If);
 }
 


### PR DESCRIPTION
## Summary
- remove unused `CodegenNode`-style attachment fields from Relief AST nodes
- stop re-exporting the legacy render attachment wrapper types from atelier core
- introduce a small SFC `OutputModule` assembly boundary for render imports/functions/exports

## Tracking
Refs #1634

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p vize_relief -p vize_atelier_core -p vize_atelier_ssr -p vize_atelier_vapor -p vize_atelier_jsx -p vize_atelier_sfc`
- `vp run --workspace-root source:lengths --check --base-ref origin/main`
- `cargo semver-checks check-release --package vize_relief --baseline-rev origin/main --release-type major`
- `cargo semver-checks check-release --package vize_atelier_core --baseline-rev origin/main --release-type major`
- `cargo clippy -p vize_relief -p vize_atelier_core -p vize_atelier_ssr -p vize_atelier_vapor -p vize_atelier_jsx -p vize_atelier_sfc --lib -- -D warnings`

Note: broader local `--all-targets` clippy currently hits pre-existing test-only lint failures unrelated to this change; GitHub Actions uses the workspace clippy command configured in CI.

## Breaking Change
`vize_relief` and `vize_atelier_core` no longer expose the unused `CodegenNode`, `ElementCodegenNode`, `IfCodegenNode`, or `TextCallCodegenNode` attachment types, and affected AST nodes no longer have `codegen_node` fields.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1640"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->