### PR TITLE
feat(patina): gate native type-aware lint

### DIFF
--- a/crates/vize/src/commands/lint/args.rs
+++ b/crates/vize/src/commands/lint/args.rs
@@ -51,6 +51,10 @@ pub struct LintArgs {
     #[arg(long)]
     pub cross_file_tree: bool,
 
+    /// Enable native type-aware lint rules from the active lint configuration.
+    #[arg(long)]
+    pub type_aware: bool,
+
     /// Enable opt-in type-aware reactivity-loss linting through the native checker.
     #[arg(long)]
     pub strict_reactivity: bool,

--- a/crates/vize/src/commands/lint/mod.rs
+++ b/crates/vize/src/commands/lint/mod.rs
@@ -9,9 +9,9 @@ mod tests;
 
 pub use args::LintArgs;
 
+use crate::profile_support;
 use collect::{collect_lint_files, is_standalone_html_path, resolve_lint_config_path};
 use cross_file::{build_cross_file_lint_output, merge_lint_result};
-
 use rayon::prelude::*;
 use std::fs;
 use std::io::Write;
@@ -21,13 +21,11 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 use std::time::Instant;
 use vize_carton::{String, ToCompactString, cstr, profile, profiler::global_profiler};
-use vize_patina::{
-    HelpLevel, JsxLang, LintPreset, Linter, OutputFormat, format_results, format_summary,
-};
-
-use crate::profile_support;
 use vize_curator::profile::{
     ProfileFileRow, ProfilePhase, ProfilePhaseKind, ProfileReport, print_profile_report,
+};
+use vize_patina::{
+    HelpLevel, JsxLang, LintPreset, Linter, OutputFormat, format_results, format_summary,
 };
 
 pub fn run(args: LintArgs) {
@@ -77,7 +75,6 @@ pub fn run(args: LintArgs) {
         .type_checker
         .runtime_path()
         .map(|path| resolve_lint_config_path(config_dir, path));
-
     // Collect .vue, standalone .html, and JSX/TSX files using glob patterns or directory walking
     let collect_start = Instant::now();
     let files = collect_lint_files(&args.patterns);
@@ -101,10 +98,13 @@ pub fn run(args: LintArgs) {
         .as_deref()
         .unwrap_or(args.preset.as_str());
     let preset = LintPreset::parse(preset_name).unwrap_or_default();
+    let type_aware_enabled =
+        args.type_aware || args.strict_reactivity || linter_config.type_aware_lint_enabled();
     let mut linter = Linter::with_preset(preset)
         .with_additional_rules(linter_config.enabled_rules())
         .with_disabled_rules(linter_config.disabled_rules())
-        .with_help_level(help_level);
+        .with_help_level(help_level)
+        .with_type_aware_lint(type_aware_enabled);
     #[cfg(not(target_arch = "wasm32"))]
     {
         linter = linter.with_corsa_path(configured_corsa_path);

--- a/crates/vize/src/commands/ready.rs
+++ b/crates/vize/src/commands/ready.rs
@@ -74,6 +74,7 @@ pub fn run(args: ReadyArgs) {
         preset: "ecosystem".into(),
         cross_file: false,
         cross_file_tree: false,
+        type_aware: false,
         strict_reactivity: false,
         profile: false,
         slow_threshold: 100,

--- a/crates/vize/tests/check_cli.rs
+++ b/crates/vize/tests/check_cli.rs
@@ -1790,6 +1790,7 @@ loadData()
             "lint",
             "--preset",
             "opinionated",
+            "--type-aware",
             "--help-level",
             "none",
             "src/App.vue",
@@ -1804,7 +1805,6 @@ loadData()
         "{stdout}"
     );
     assert!(stdout.contains("__missing_lint_corsa__"), "{stdout}");
-
     let _ = std::fs::remove_dir_all(&project_root);
 }
 

--- a/crates/vize_carton/src/config/loader.rs
+++ b/crates/vize_carton/src/config/loader.rs
@@ -158,7 +158,7 @@ pub fn load_compiler_jsx_mode(path: Option<&Path>) -> Option<crate::config::JsxM
 /// parsing and normalizing the same config file twice.
 pub fn load_config_and_linter_with_source(path: Option<&Path>) -> (LoadedConfig, LinterConfig) {
     let loaded = load_raw_config_with_source(path);
-    let linter = loaded.config.linter.clone();
+    let linter = LinterConfig::from(loaded.config.linter.clone());
     let (config, _) = loaded.config.into_config_and_features();
     (
         LoadedConfig {
@@ -177,7 +177,7 @@ pub fn load_config_and_linter_with_features_and_source(
     path: Option<&Path>,
 ) -> (LoadedConfigWithFeatures, LinterConfig) {
     let loaded = load_raw_config_with_source(path);
-    let linter = loaded.config.linter.clone();
+    let linter = LinterConfig::from(loaded.config.linter.clone());
     let (config, features) = loaded.config.into_config_and_features();
     (
         LoadedConfigWithFeatures {
@@ -191,7 +191,7 @@ pub fn load_config_and_linter_with_features_and_source(
 
 /// Load linter-specific configuration from a directory or file path.
 pub fn load_linter_config(path: Option<&Path>) -> LinterConfig {
-    load_raw_config_with_source(path).config.linter
+    LinterConfig::from(load_raw_config_with_source(path).config.linter)
 }
 
 fn load_raw_config_with_source(path: Option<&Path>) -> LoadedRawConfig {

--- a/crates/vize_carton/src/config/model.rs
+++ b/crates/vize_carton/src/config/model.rs
@@ -23,6 +23,7 @@ pub use formatter::{
 pub use global_types::{GlobalTypeDeclaration, GlobalTypesConfig, RawGlobalTypesConfig};
 pub use language_server::{LanguageServerConfig, LspConfig};
 #[allow(unused_imports)]
+pub(crate) use linter::RawLinterConfig;
 pub use linter::{LintRuleSeverity, LinterConfig};
 pub use type_checker::TypeCheckerConfig;
 pub use vue::{ParseVueVersionError, VueVersion};
@@ -118,7 +119,7 @@ pub(crate) struct RawVizeConfig {
     pub formatter: FormatterConfig,
     pub(crate) compiler: RawCompilerConfig,
     pub(crate) vue: RawVueConfig,
-    pub linter: LinterConfig,
+    pub linter: RawLinterConfig,
     #[serde(rename = "typeChecker")]
     type_checker: RawTypeCheckerConfig,
     #[serde(rename = "languageServer")]

--- a/crates/vize_carton/src/config/model/linter.rs
+++ b/crates/vize_carton/src/config/model/linter.rs
@@ -4,6 +4,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::{FxHashMap, String};
 
+const TYPE_AWARE_LINT_MARKER: &str = "__vize_internal/type-aware-lint";
+
 /// Per-rule lint severity.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -20,6 +22,15 @@ pub struct LinterConfig {
     pub enabled: bool,
     pub preset: Option<String>,
     pub rules: FxHashMap<String, LintRuleSeverity>,
+}
+
+/// Raw linter config with unstable config-only switches.
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default, rename_all = "camelCase")]
+pub(crate) struct RawLinterConfig {
+    #[serde(flatten)]
+    config: LinterConfig,
+    type_aware: bool,
 }
 
 impl LinterConfig {
@@ -39,12 +50,32 @@ impl LinterConfig {
             .unwrap_or(false)
     }
 
+    /// Whether native type-aware lint should run.
+    ///
+    /// The config-only `typeAware` switch enables preset-provided type-aware
+    /// rules. An explicitly enabled `type/*` rule also counts as an opt-in.
+    pub fn type_aware_lint_enabled(&self) -> bool {
+        self.rules.contains_key(TYPE_AWARE_LINT_MARKER)
+            || self.rules.iter().any(|(rule, severity)| {
+                is_public_rule(rule)
+                    && rule.starts_with("type/")
+                    && !matches!(severity, LintRuleSeverity::Off)
+            })
+    }
+
+    fn enable_type_aware_lint(&mut self) {
+        self.rules
+            .insert(TYPE_AWARE_LINT_MARKER.into(), LintRuleSeverity::Warn);
+    }
+
     /// Rule names explicitly disabled by config.
     pub fn disabled_rules(&self) -> Vec<String> {
         let mut rules = self
             .rules
             .iter()
-            .filter(|(_, severity)| matches!(severity, LintRuleSeverity::Off))
+            .filter(|(rule, severity)| {
+                is_public_rule(rule) && matches!(severity, LintRuleSeverity::Off)
+            })
             .map(|(rule, _)| rule.clone())
             .collect::<Vec<_>>();
         rules.sort();
@@ -56,7 +87,9 @@ impl LinterConfig {
         let mut rules = self
             .rules
             .iter()
-            .filter(|(_, severity)| !matches!(severity, LintRuleSeverity::Off))
+            .filter(|(rule, severity)| {
+                is_public_rule(rule) && !matches!(severity, LintRuleSeverity::Off)
+            })
             .map(|(rule, _)| rule.clone())
             .collect::<Vec<_>>();
         rules.sort();
@@ -71,5 +104,68 @@ impl Default for LinterConfig {
             preset: None,
             rules: FxHashMap::default(),
         }
+    }
+}
+
+impl From<RawLinterConfig> for LinterConfig {
+    fn from(raw: RawLinterConfig) -> Self {
+        let mut config = raw.config;
+        if raw.type_aware {
+            config.enable_type_aware_lint();
+        }
+        config
+    }
+}
+
+fn is_public_rule(rule: &str) -> bool {
+    rule != TYPE_AWARE_LINT_MARKER
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{LintRuleSeverity, LinterConfig, RawLinterConfig};
+
+    #[test]
+    fn type_aware_lint_defaults_to_disabled() {
+        assert!(!LinterConfig::default().type_aware_lint_enabled());
+    }
+
+    #[test]
+    fn type_aware_lint_can_be_enabled_as_a_group() {
+        let mut config = LinterConfig::default();
+        config.enable_type_aware_lint();
+
+        assert!(config.type_aware_lint_enabled());
+        assert!(config.enabled_rules().is_empty());
+    }
+
+    #[test]
+    fn raw_type_aware_deserializes_as_group_opt_in() {
+        let raw = serde_json::from_str::<RawLinterConfig>(r#"{ "typeAware": true }"#).unwrap();
+        let config = LinterConfig::from(raw);
+
+        assert!(config.type_aware_lint_enabled());
+        assert!(config.enabled_rules().is_empty());
+    }
+
+    #[test]
+    fn enabled_type_rule_counts_as_type_aware_opt_in() {
+        let mut config = LinterConfig::default();
+        config.rules.insert(
+            "type/no-unsafe-template-binding".into(),
+            LintRuleSeverity::Warn,
+        );
+
+        assert!(config.type_aware_lint_enabled());
+    }
+
+    #[test]
+    fn disabled_type_rule_does_not_opt_in() {
+        let mut config = LinterConfig::default();
+        config
+            .rules
+            .insert("type/no-reactivity-loss".into(), LintRuleSeverity::Off);
+
+        assert!(!config.type_aware_lint_enabled());
     }
 }

--- a/crates/vize_patina/src/linter/config.rs
+++ b/crates/vize_patina/src/linter/config.rs
@@ -70,6 +70,8 @@ pub struct Linter {
     pub(crate) script_rules: &'static [&'static str],
     /// Built-in `css/*` rules enabled for this linter.
     pub(crate) css_rules: &'static [&'static str],
+    /// Whether native type-aware lint rules may run.
+    pub(crate) type_aware_enabled: bool,
     /// Lazily initialized native corsa session for type-aware lint.
     #[cfg(not(target_arch = "wasm32"))]
     pub(crate) native_corsa: Mutex<Option<CorsaTypeAwareSession>>,
@@ -96,6 +98,7 @@ impl Linter {
             help_level: HelpLevel::default(),
             script_rules: builtin_script_rule_names(preset),
             css_rules: builtin_css_rule_names(preset),
+            type_aware_enabled: false,
             #[cfg(not(target_arch = "wasm32"))]
             native_corsa: Mutex::new(None),
             #[cfg(not(target_arch = "wasm32"))]
@@ -116,6 +119,7 @@ impl Linter {
             help_level: HelpLevel::default(),
             script_rules: builtin_script_rule_names(preset),
             css_rules: builtin_css_rule_names(preset),
+            type_aware_enabled: false,
             #[cfg(not(target_arch = "wasm32"))]
             native_corsa: Mutex::new(None),
             #[cfg(not(target_arch = "wasm32"))]
@@ -136,6 +140,7 @@ impl Linter {
             help_level: HelpLevel::default(),
             script_rules: ecosystem_builtin_script_rule_names(),
             css_rules: builtin_css_rule_names(LintPreset::Ecosystem),
+            type_aware_enabled: false,
             #[cfg(not(target_arch = "wasm32"))]
             native_corsa: Mutex::new(None),
             #[cfg(not(target_arch = "wasm32"))]
@@ -156,6 +161,7 @@ impl Linter {
             help_level: HelpLevel::default(),
             script_rules: &[],
             css_rules: &[],
+            type_aware_enabled: false,
             #[cfg(not(target_arch = "wasm32"))]
             native_corsa: Mutex::new(None),
             #[cfg(not(target_arch = "wasm32"))]
@@ -191,6 +197,9 @@ impl Linter {
             self.script_rules = super::script_rules::all_builtin_script_rule_names();
             self.css_rules = super::css_rules::all_builtin_css_rule_names();
         }
+        if rules.as_ref().is_some_and(|rules| has_type_rule(rules)) {
+            self.type_aware_enabled = true;
+        }
         self.enabled_rules = rules.map(|r| r.into_iter().collect());
         self
     }
@@ -217,6 +226,9 @@ impl Linter {
         if matches!(self.preset, Some(LintPreset::Incremental)) {
             self.registry = RuleRegistry::with_preset(LintPreset::Opinionated);
         }
+        if has_type_rule(&rules) {
+            self.type_aware_enabled = true;
+        }
         self.registry.register_opt_in_rules();
         self.script_rules = super::script_rules::all_builtin_script_rule_names();
         self.css_rules = super::css_rules::all_builtin_css_rule_names();
@@ -236,6 +248,9 @@ impl Linter {
     #[inline]
     pub fn with_rule(mut self, rule: Box<dyn crate::rule::Rule>) -> Self {
         let rule_name = rule.meta().name;
+        if is_type_rule(rule_name) {
+            self.type_aware_enabled = true;
+        }
         if !self.registry.has_rule(rule_name) {
             self.registry.register(rule);
             self.registry.mark_has_exit_element_rules();
@@ -247,6 +262,17 @@ impl Linter {
     #[inline]
     pub fn with_help_level(mut self, level: HelpLevel) -> Self {
         self.help_level = level;
+        self
+    }
+
+    /// Allow native type-aware lint rules to run.
+    ///
+    /// Keeping this separate from rule membership preserves zero-cost defaults:
+    /// presets may contain `type/*` rules, but Patina will not parse SFCs for
+    /// Corsa-backed checks or start Corsa unless hosts explicitly opt in.
+    #[inline]
+    pub fn with_type_aware_lint(mut self, enabled: bool) -> Self {
+        self.type_aware_enabled = enabled;
         self
     }
 
@@ -299,4 +325,12 @@ impl Default for Linter {
     fn default() -> Self {
         Self::new()
     }
+}
+
+fn has_type_rule(rules: &[String]) -> bool {
+    rules.iter().any(|rule| is_type_rule(rule.as_str()))
+}
+
+fn is_type_rule(rule_name: &str) -> bool {
+    rule_name.starts_with("type/")
 }

--- a/crates/vize_patina/src/linter/native_type_aware.rs
+++ b/crates/vize_patina/src/linter/native_type_aware.rs
@@ -34,6 +34,10 @@ pub(crate) const TYPE_AWARE_RULES: &[&str] = &[
 ];
 
 pub(crate) fn has_active_type_aware_rules(linter: &Linter) -> bool {
+    if !linter.type_aware_enabled {
+        return false;
+    }
+
     TYPE_AWARE_RULES
         .iter()
         .copied()

--- a/crates/vize_patina/src/linter/native_type_aware/tests.rs
+++ b/crates/vize_patina/src/linter/native_type_aware/tests.rs
@@ -1,7 +1,8 @@
+mod opt_in;
+
 use super::{
     RULE_NO_FLOATING_PROMISES, RULE_NO_REACTIVITY_LOSS, RULE_NO_UNSAFE_TEMPLATE_BINDING,
-    RULE_REQUIRE_TYPED_EMITS, RULE_REQUIRE_TYPED_PROPS, has_active_type_aware_rules,
-    lint_sfc_with_corsa,
+    RULE_REQUIRE_TYPED_EMITS, RULE_REQUIRE_TYPED_PROPS, lint_sfc_with_corsa,
 };
 use crate::{LintPreset, Linter};
 
@@ -17,12 +18,6 @@ fn corsa_available() -> bool {
     }
     session.close();
     true
-}
-
-#[test]
-fn opinionated_preset_enables_native_type_aware_rules() {
-    let linter = Linter::with_preset(LintPreset::Opinionated);
-    assert!(has_active_type_aware_rules(&linter));
 }
 
 #[test]
@@ -1215,7 +1210,7 @@ fn type_aware_diagnostics_snapshot() {
         return;
     }
 
-    let linter = Linter::with_preset(LintPreset::Opinionated);
+    let linter = Linter::with_preset(LintPreset::Opinionated).with_type_aware_lint(true);
     let source = r#"<script setup lang="ts">
 import { ref } from 'vue'
 defineProps(['msg'])

--- a/crates/vize_patina/src/linter/native_type_aware/tests/opt_in.rs
+++ b/crates/vize_patina/src/linter/native_type_aware/tests/opt_in.rs
@@ -1,0 +1,28 @@
+use super::super::{RULE_NO_UNSAFE_TEMPLATE_BINDING, has_active_type_aware_rules};
+use crate::{LintPreset, Linter};
+
+#[test]
+fn opinionated_preset_keeps_native_type_aware_rules_disabled() {
+    let linter = Linter::with_preset(LintPreset::Opinionated);
+    assert!(!has_active_type_aware_rules(&linter));
+}
+
+#[test]
+fn explicit_opt_in_enables_native_type_aware_rules() {
+    let linter = Linter::with_preset(LintPreset::Opinionated).with_type_aware_lint(true);
+    assert!(has_active_type_aware_rules(&linter));
+}
+
+#[test]
+fn explicit_type_rule_enables_native_type_aware_rules() {
+    let linter = Linter::with_preset(LintPreset::HappyPath)
+        .with_additional_rules(vec![RULE_NO_UNSAFE_TEMPLATE_BINDING.into()]);
+    assert!(has_active_type_aware_rules(&linter));
+}
+
+#[test]
+fn explicit_type_rule_registration_enables_native_type_aware_rules() {
+    let linter = Linter::with_preset(LintPreset::HappyPath)
+        .with_rule(Box::new(crate::rules::type_aware::NoReactivityLoss::new()));
+    assert!(has_active_type_aware_rules(&linter));
+}

--- a/npm/vize/schemas/vize.config.schema.json
+++ b/npm/vize/schemas/vize.config.schema.json
@@ -181,18 +181,18 @@
       "additionalProperties": false
     },
     "LinterConfig": {
-      "description": "Linter options",
       "type": "object",
       "properties": {
         "enabled": {
-          "description": "Enable linting",
           "type": "boolean"
         },
         "preset": {
-          "description": "Built-in lint preset",
           "default": "ecosystem",
           "type": "string",
           "enum": ["happy-path", "opinionated", "essential", "incremental", "ecosystem", "nuxt"]
+        },
+        "typeAware": {
+          "type": "boolean"
         },
         "rules": {
           "description": "Rules to enable/disable",

--- a/npm/vize/src/types/generated.ts
+++ b/npm/vize/src/types/generated.ts
@@ -177,10 +177,10 @@ export interface LinterConfig {
    * Enable linting
    */
   enabled?: boolean;
-  /**
-   * Built-in lint preset
-   */
+  /** Built-in lint preset */
   preset?: "happy-path" | "opinionated" | "essential" | "incremental" | "ecosystem" | "nuxt";
+  /** Enable native type-aware lint rules from the active lint configuration */
+  typeAware?: boolean;
   /**
    * Rules to enable/disable
    */


### PR DESCRIPTION
## Summary
- add an explicit native type-aware lint gate in Patina so preset membership is zero-cost until opted in
- wire `vize lint --type-aware` and `linter.typeAware` config, with explicit `type/*` rule entries and `--strict-reactivity` also counting as opt-in
- update config schema/types and focused tests for opt-in behavior

## Validation
- `cargo fmt --check`
- `cargo test -p vize_carton config::model::linter --lib`
- `cargo test -p vize_patina linter::native_type_aware --lib`
- `cargo test -p vize commands::lint::tests --lib`
- `cargo test -p vize cli::tests --lib`
- `cargo clippy -p vize_carton -p vize_patina -p vize --lib -- -D warnings`

## Notes
- `cargo clippy -p vize_carton -p vize_patina -p vize --lib --tests -- -D warnings` is blocked by pre-existing `clippy::disallowed_macros` failures in `crates/vize_carton/src/config/loader/tests.rs`.
- Changed-file line counts were checked against `origin/main`; the over-350 files touched in this slice were already over 350 before this change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1642"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->