### PR TITLE
test(e2e): refresh app lint snapshots

### DIFF
--- a/tests/snapshots/lint/__snapshots__/ant-design-vue-lint.snap
+++ b/tests/snapshots/lint/__snapshots__/ant-design-vue-lint.snap
@@ -4488,6 +4488,17 @@
         "help": "Use CSS text-align or margin: auto instead."
       },
       {
+        "ruleId": "vue/no-template-target-blank",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
+        "line": 33,
+        "column": 9,
+        "endLine": 33,
+        "endColumn": 75,
+        "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
+      },
+      {
         "ruleId": "vue/sfc-element-order",
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
@@ -4500,7 +4511,7 @@
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 3
   },
   {
     "file": "components/flex/demo/gap.vue",
@@ -12145,6 +12156,17 @@
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
       },
       {
+        "ruleId": "vue/no-unsandboxed-iframe",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-unsandboxed-iframe] <iframe> is missing a sandbox attribute",
+        "line": 22,
+        "column": 3,
+        "endLine": 22,
+        "endColumn": 69,
+        "help": "Add a sandbox attribute (e.g. sandbox=\"\" for the most restrictive policy) and re-grant only the capabilities the embedded content needs"
+      },
+      {
         "ruleId": "a11y/iframe-has-title",
         "ruleDocsPath": "docs/content/rules/accessibility.md",
         "severity": 1,
@@ -12168,7 +12190,7 @@
       }
     ],
     "errorCount": 0,
-    "warningCount": 3
+    "warningCount": 4
   },
   {
     "file": "components/table/demo/bordered.vue",
@@ -15286,9 +15308,21 @@
   },
   {
     "file": "components/typography/demo/text.vue",
-    "messages": [],
+    "messages": [
+      {
+        "ruleId": "vue/no-template-target-blank",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
+        "line": 31,
+        "column": 5,
+        "endLine": 31,
+        "endColumn": 65,
+        "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
+      }
+    ],
     "errorCount": 0,
-    "warningCount": 0
+    "warningCount": 1
   },
   {
     "file": "components/typography/demo/title.vue",
@@ -15957,6 +15991,17 @@
     "file": "site/src/components/Contributors/index.vue",
     "messages": [
       {
+        "ruleId": "vue/no-template-target-blank",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
+        "line": 59,
+        "column": 11,
+        "endLine": 59,
+        "endColumn": 47,
+        "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
+      },
+      {
         "ruleId": "a11y/anchor-has-content",
         "ruleDocsPath": "docs/content/rules/accessibility.md",
         "severity": 1,
@@ -15991,11 +16036,22 @@
       }
     ],
     "errorCount": 0,
-    "warningCount": 3
+    "warningCount": 4
   },
   {
     "file": "site/src/components/DemoBox.vue",
     "messages": [
+      {
+        "ruleId": "vue/no-unsandboxed-iframe",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-unsandboxed-iframe] <iframe> is missing a sandbox attribute",
+        "line": 9,
+        "column": 11,
+        "endLine": 9,
+        "endColumn": 77,
+        "help": "Add a sandbox attribute (e.g. sandbox=\"\" for the most restrictive policy) and re-grant only the capabilities the embedded content needs"
+      },
       {
         "ruleId": "a11y/iframe-has-title",
         "ruleDocsPath": "docs/content/rules/accessibility.md",
@@ -16174,7 +16230,7 @@
       }
     ],
     "errorCount": 0,
-    "warningCount": 16
+    "warningCount": 17
   },
   {
     "file": "site/src/components/SimpleLayout.vue",
@@ -16451,6 +16507,28 @@
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
       },
       {
+        "ruleId": "vue/no-template-target-blank",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
+        "line": 5,
+        "column": 7,
+        "endLine": 5,
+        "endColumn": 79,
+        "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
+      },
+      {
+        "ruleId": "vue/no-template-target-blank",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
+        "line": 18,
+        "column": 7,
+        "endLine": 18,
+        "endColumn": 77,
+        "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
+      },
+      {
         "ruleId": "vue/sfc-element-order",
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
@@ -16463,7 +16541,7 @@
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 4
   },
   {
     "file": "site/src/components/surelyVue.vue",
@@ -16480,6 +16558,17 @@
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
       },
       {
+        "ruleId": "vue/no-template-target-blank",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
+        "line": 4,
+        "column": 7,
+        "endLine": 4,
+        "endColumn": 90,
+        "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
+      },
+      {
         "ruleId": "vue/sfc-element-order",
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
@@ -16492,7 +16581,7 @@
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 3
   },
   {
     "file": "site/src/layouts/BaseLayout.vue",
@@ -16567,6 +16656,17 @@
         "help": "Rename the component to avoid using reserved names"
       },
       {
+        "ruleId": "vue/no-template-target-blank",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
+        "line": 9,
+        "column": 15,
+        "endLine": 9,
+        "endColumn": 89,
+        "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
+      },
+      {
         "ruleId": "a11y/no-i-for-icon",
         "ruleDocsPath": "docs/content/rules/accessibility.md",
         "severity": 1,
@@ -16578,6 +16678,61 @@
         "help": "Why: The <i> element semantically represents *italic text*, not icons. Using it for icon fonts creates accessibility issues — screen readers may announce meaningless content.\nFix: Use <span> with aria-hidden=\"true\" instead:\n  <span class=\"fas fa-home\" aria-hidden=\"true\"></span>\n  <span class=\"sr-only\">Home</span>\nOr use an SVG icon component for best accessibility."
       },
       {
+        "ruleId": "vue/no-template-target-blank",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
+        "line": 18,
+        "column": 15,
+        "endLine": 18,
+        "endColumn": 84,
+        "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
+      },
+      {
+        "ruleId": "vue/no-template-target-blank",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
+        "line": 23,
+        "column": 15,
+        "endLine": 23,
+        "endColumn": 83,
+        "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
+      },
+      {
+        "ruleId": "vue/no-template-target-blank",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
+        "line": 28,
+        "column": 15,
+        "endLine": 28,
+        "endColumn": 93,
+        "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
+      },
+      {
+        "ruleId": "vue/no-template-target-blank",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
+        "line": 43,
+        "column": 15,
+        "endLine": 43,
+        "endColumn": 83,
+        "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
+      },
+      {
+        "ruleId": "vue/no-template-target-blank",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
+        "line": 48,
+        "column": 15,
+        "endLine": 48,
+        "endColumn": 97,
+        "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
+      },
+      {
         "ruleId": "vue/no-unsafe-url",
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
@@ -16587,6 +16742,17 @@
         "endLine": 56,
         "endColumn": 96,
         "help": "Consider using <router-link :to=\"...\"> or sanitize URLs with @braintree/sanitize-url"
+      },
+      {
+        "ruleId": "vue/no-template-target-blank",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
+        "line": 91,
+        "column": 15,
+        "endLine": 91,
+        "endColumn": 81,
+        "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
       },
       {
         "ruleId": "vue/sfc-element-order",
@@ -16601,7 +16767,7 @@
       }
     ],
     "errorCount": 1,
-    "warningCount": 3
+    "warningCount": 10
   },
   {
     "file": "site/src/layouts/Iframe.vue",
@@ -16705,6 +16871,39 @@
     "file": "site/src/layouts/header/Ecosystem.vue",
     "messages": [
       {
+        "ruleId": "vue/no-template-target-blank",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
+        "line": 5,
+        "column": 9,
+        "endLine": 5,
+        "endColumn": 57,
+        "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
+      },
+      {
+        "ruleId": "vue/no-template-target-blank",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
+        "line": 8,
+        "column": 9,
+        "endLine": 8,
+        "endColumn": 63,
+        "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
+      },
+      {
+        "ruleId": "vue/no-template-target-blank",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
+        "line": 24,
+        "column": 9,
+        "endLine": 24,
+        "endColumn": 90,
+        "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
+      },
+      {
         "ruleId": "a11y/anchor-is-valid",
         "ruleDocsPath": "docs/content/rules/accessibility.md",
         "severity": 1,
@@ -16750,11 +16949,22 @@
       }
     ],
     "errorCount": 0,
-    "warningCount": 4
+    "warningCount": 7
   },
   {
     "file": "site/src/layouts/header/Github.vue",
     "messages": [
+      {
+        "ruleId": "vue/no-template-target-blank",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
+        "line": 5,
+        "column": 7,
+        "endLine": 5,
+        "endColumn": 95,
+        "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
+      },
       {
         "ruleId": "a11y/anchor-has-content",
         "ruleDocsPath": "docs/content/rules/accessibility.md",
@@ -16779,7 +16989,7 @@
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 3
   },
   {
     "file": "site/src/layouts/header/Logo.vue",
@@ -16908,6 +17118,28 @@
     "file": "site/src/layouts/header/index.vue",
     "messages": [
       {
+        "ruleId": "vue/no-template-target-blank",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
+        "line": 43,
+        "column": 11,
+        "endLine": 43,
+        "endColumn": 64,
+        "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
+      },
+      {
+        "ruleId": "vue/no-template-target-blank",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
+        "line": 48,
+        "column": 11,
+        "endLine": 48,
+        "endColumn": 83,
+        "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
+      },
+      {
         "ruleId": "vue/sfc-element-order",
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
@@ -16931,7 +17163,7 @@
       }
     ],
     "errorCount": 0,
-    "warningCount": 2
+    "warningCount": 4
   },
   {
     "file": "site/src/layouts/icons/ThemeIcon.vue",
@@ -16986,6 +17218,17 @@
         "endLine": 2,
         "endColumn": 13,
         "help": "Remove the unused import or use the component in your template"
+      },
+      {
+        "ruleId": "vue/no-template-target-blank",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
+        "line": 11,
+        "column": 5,
+        "endLine": 11,
+        "endColumn": 84,
+        "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
       },
       {
         "ruleId": "a11y/anchor-has-content",
@@ -17077,7 +17320,7 @@
       }
     ],
     "errorCount": 0,
-    "warningCount": 11
+    "warningCount": 12
   },
   {
     "file": "site/src/theme/template/IconDisplay/CopyableIcon.vue",

--- a/tests/snapshots/lint/__snapshots__/elk-lint.snap
+++ b/tests/snapshots/lint/__snapshots__/elk-lint.snap
@@ -305,6 +305,17 @@
     "file": "app/components/account/AccountPaginator.vue",
     "messages": [
       {
+        "ruleId": "vue/no-template-target-blank",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
+        "line": 32,
+        "column": 9,
+        "endLine": 36,
+        "endColumn": 10,
+        "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
+      },
+      {
         "ruleId": "ecosystem/router-link-require-to",
         "ruleDocsPath": "docs/content/rules/ecosystem.md",
         "severity": 2,
@@ -317,7 +328,7 @@
       }
     ],
     "errorCount": 1,
-    "warningCount": 0
+    "warningCount": 1
   },
   {
     "file": "app/components/account/AccountPostsFollowers.vue",
@@ -682,6 +693,17 @@
     "file": "app/components/common/CommonPreviewPrompt.vue",
     "messages": [
       {
+        "ruleId": "vue/no-template-target-blank",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
+        "line": 16,
+        "column": 9,
+        "endLine": 16,
+        "endColumn": 126,
+        "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
+      },
+      {
         "ruleId": "ecosystem/router-link-require-to",
         "ruleDocsPath": "docs/content/rules/ecosystem.md",
         "severity": 2,
@@ -694,7 +716,7 @@
       }
     ],
     "errorCount": 1,
-    "warningCount": 0
+    "warningCount": 1
   },
   {
     "file": "app/components/common/CommonRadio.vue",
@@ -924,6 +946,17 @@
         "help": "Ensure URLs are sanitized before binding to prevent XSS via javascript: protocol"
       },
       {
+        "ruleId": "vue/no-template-target-blank",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
+        "line": 28,
+        "column": 7,
+        "endLine": 28,
+        "endColumn": 95,
+        "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
+      },
+      {
         "ruleId": "ecosystem/router-link-require-to",
         "ruleDocsPath": "docs/content/rules/ecosystem.md",
         "severity": 2,
@@ -933,6 +966,17 @@
         "endLine": 28,
         "endColumn": 95,
         "help": "Add to or :to so navigation is explicit and typed-route tooling can infer the target."
+      },
+      {
+        "ruleId": "vue/no-template-target-blank",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
+        "line": 33,
+        "column": 5,
+        "endLine": 33,
+        "endColumn": 94,
+        "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
       },
       {
         "ruleId": "ecosystem/router-link-require-to",
@@ -957,6 +1001,17 @@
         "help": "Add text content, child elements, or use aria-label for accessible content."
       },
       {
+        "ruleId": "vue/no-template-target-blank",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
+        "line": 38,
+        "column": 9,
+        "endLine": 38,
+        "endColumn": 155,
+        "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
+      },
+      {
         "ruleId": "ecosystem/router-link-require-to",
         "ruleDocsPath": "docs/content/rules/ecosystem.md",
         "severity": 2,
@@ -979,6 +1034,17 @@
         "help": "Ensure URLs are sanitized before binding to prevent XSS via javascript: protocol"
       },
       {
+        "ruleId": "vue/no-template-target-blank",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
+        "line": 44,
+        "column": 7,
+        "endLine": 44,
+        "endColumn": 77,
+        "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
+      },
+      {
         "ruleId": "ecosystem/router-link-require-to",
         "ruleDocsPath": "docs/content/rules/ecosystem.md",
         "severity": 2,
@@ -991,7 +1057,7 @@
       }
     ],
     "errorCount": 4,
-    "warningCount": 3
+    "warningCount": 7
   },
   {
     "file": "app/components/list/Account.vue",
@@ -1313,6 +1379,17 @@
     "file": "app/components/nav/NavFooter.vue",
     "messages": [
       {
+        "ruleId": "vue/no-template-target-blank",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
+        "line": 35,
+        "column": 9,
+        "endLine": 42,
+        "endColumn": 11,
+        "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
+      },
+      {
         "ruleId": "ecosystem/router-link-require-to",
         "ruleDocsPath": "docs/content/rules/ecosystem.md",
         "severity": 2,
@@ -1324,6 +1401,17 @@
         "help": "Add to or :to so navigation is explicit and typed-route tooling can infer the target."
       },
       {
+        "ruleId": "vue/no-template-target-blank",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
+        "line": 53,
+        "column": 7,
+        "endLine": 59,
+        "endColumn": 8,
+        "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
+      },
+      {
         "ruleId": "ecosystem/router-link-require-to",
         "ruleDocsPath": "docs/content/rules/ecosystem.md",
         "severity": 2,
@@ -1333,6 +1421,17 @@
         "endLine": 59,
         "endColumn": 8,
         "help": "Add to or :to so navigation is explicit and typed-route tooling can infer the target."
+      },
+      {
+        "ruleId": "vue/no-template-target-blank",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
+        "line": 65,
+        "column": 9,
+        "endLine": 70,
+        "endColumn": 10,
+        "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
       },
       {
         "ruleId": "ecosystem/router-link-require-to",
@@ -1357,6 +1456,17 @@
         "help": "Use :to=\"{ name: 'route-name' }\" so route params and Vue Router 5 typed routes stay visible to the editor."
       },
       {
+        "ruleId": "vue/no-template-target-blank",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
+        "line": 86,
+        "column": 7,
+        "endLine": 86,
+        "endColumn": 58,
+        "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
+      },
+      {
         "ruleId": "ecosystem/router-link-require-to",
         "ruleDocsPath": "docs/content/rules/ecosystem.md",
         "severity": 2,
@@ -1368,6 +1478,17 @@
         "help": "Add to or :to so navigation is explicit and typed-route tooling can infer the target."
       },
       {
+        "ruleId": "vue/no-template-target-blank",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
+        "line": 90,
+        "column": 7,
+        "endLine": 90,
+        "endColumn": 71,
+        "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
+      },
+      {
         "ruleId": "ecosystem/router-link-require-to",
         "ruleDocsPath": "docs/content/rules/ecosystem.md",
         "severity": 2,
@@ -1377,6 +1498,17 @@
         "endLine": 90,
         "endColumn": 71,
         "help": "Add to or :to so navigation is explicit and typed-route tooling can infer the target."
+      },
+      {
+        "ruleId": "vue/no-template-target-blank",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
+        "line": 94,
+        "column": 7,
+        "endLine": 94,
+        "endColumn": 81,
+        "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
       },
       {
         "ruleId": "ecosystem/router-link-require-to",
@@ -1391,7 +1523,7 @@
       }
     ],
     "errorCount": 6,
-    "warningCount": 1
+    "warningCount": 7
   },
   {
     "file": "app/components/nav/NavLogo.vue",
@@ -1877,6 +2009,17 @@
         "help": "Use CSS border instead."
       },
       {
+        "ruleId": "vue/no-template-target-blank",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
+        "line": 39,
+        "column": 9,
+        "endLine": 39,
+        "endColumn": 123,
+        "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
+      },
+      {
         "ruleId": "ecosystem/router-link-require-to",
         "ruleDocsPath": "docs/content/rules/ecosystem.md",
         "severity": 2,
@@ -1886,6 +2029,17 @@
         "endLine": 39,
         "endColumn": 123,
         "help": "Add to or :to so navigation is explicit and typed-route tooling can infer the target."
+      },
+      {
+        "ruleId": "vue/no-template-target-blank",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
+        "line": 46,
+        "column": 7,
+        "endLine": 46,
+        "endColumn": 129,
+        "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
       },
       {
         "ruleId": "ecosystem/router-link-require-to",
@@ -1900,7 +2054,7 @@
       }
     ],
     "errorCount": 2,
-    "warningCount": 1
+    "warningCount": 3
   },
   {
     "file": "app/components/publish/PublishAttachment.vue",
@@ -2483,6 +2637,17 @@
     "file": "app/components/settings/SettingsSponsorsList.vue",
     "messages": [
       {
+        "ruleId": "vue/no-template-target-blank",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
+        "line": 3,
+        "column": 5,
+        "endLine": 3,
+        "endColumn": 59,
+        "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
+      },
+      {
         "ruleId": "ecosystem/router-link-require-to",
         "ruleDocsPath": "docs/content/rules/ecosystem.md",
         "severity": 2,
@@ -2492,6 +2657,17 @@
         "endLine": 3,
         "endColumn": 59,
         "help": "Add to or :to so navigation is explicit and typed-route tooling can infer the target."
+      },
+      {
+        "ruleId": "vue/no-template-target-blank",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
+        "line": 13,
+        "column": 5,
+        "endLine": 13,
+        "endColumn": 61,
+        "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
       },
       {
         "ruleId": "ecosystem/router-link-require-to",
@@ -2506,7 +2682,7 @@
       }
     ],
     "errorCount": 2,
-    "warningCount": 0
+    "warningCount": 2
   },
   {
     "file": "app/components/settings/SettingsThemeColors.vue",
@@ -2827,6 +3003,17 @@
     "file": "app/components/status/StatusEmbeddedMedia.vue",
     "messages": [
       {
+        "ruleId": "vue/no-template-target-blank",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
+        "line": 35,
+        "column": 9,
+        "endLine": 35,
+        "endColumn": 119,
+        "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
+      },
+      {
         "ruleId": "ecosystem/router-link-require-to",
         "ruleDocsPath": "docs/content/rules/ecosystem.md",
         "severity": 2,
@@ -2861,7 +3048,7 @@
       }
     ],
     "errorCount": 1,
-    "warningCount": 2
+    "warningCount": 3
   },
   {
     "file": "app/components/status/StatusEmojiReaction.vue",
@@ -3043,6 +3230,17 @@
     "file": "app/components/status/StatusPreviewGitHub.vue",
     "messages": [
       {
+        "ruleId": "vue/no-template-target-blank",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
+        "line": 99,
+        "column": 11,
+        "endLine": 99,
+        "endColumn": 122,
+        "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
+      },
+      {
         "ruleId": "ecosystem/router-link-require-to",
         "ruleDocsPath": "docs/content/rules/ecosystem.md",
         "severity": 2,
@@ -3054,6 +3252,17 @@
         "help": "Add to or :to so navigation is explicit and typed-route tooling can infer the target."
       },
       {
+        "ruleId": "vue/no-template-target-blank",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
+        "line": 105,
+        "column": 11,
+        "endLine": 105,
+        "endColumn": 74,
+        "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
+      },
+      {
         "ruleId": "ecosystem/router-link-require-to",
         "ruleDocsPath": "docs/content/rules/ecosystem.md",
         "severity": 2,
@@ -3063,6 +3272,17 @@
         "endLine": 105,
         "endColumn": 74,
         "help": "Add to or :to so navigation is explicit and typed-route tooling can infer the target."
+      },
+      {
+        "ruleId": "vue/no-template-target-blank",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
+        "line": 116,
+        "column": 11,
+        "endLine": 116,
+        "endColumn": 68,
+        "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
       },
       {
         "ruleId": "ecosystem/router-link-require-to",
@@ -3143,7 +3363,7 @@
       }
     ],
     "errorCount": 3,
-    "warningCount": 6
+    "warningCount": 9
   },
   {
     "file": "app/components/status/StatusPreviewStackBlitz.vue",
@@ -3508,6 +3728,17 @@
         "help": "Use CSS border instead."
       },
       {
+        "ruleId": "vue/no-template-target-blank",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
+        "line": 56,
+        "column": 11,
+        "endLine": 60,
+        "endColumn": 12,
+        "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
+      },
+      {
         "ruleId": "ecosystem/router-link-require-to",
         "ruleDocsPath": "docs/content/rules/ecosystem.md",
         "severity": 2,
@@ -3520,7 +3751,7 @@
       }
     ],
     "errorCount": 1,
-    "warningCount": 1
+    "warningCount": 2
   },
   {
     "file": "app/components/timeline/TimelinePinned.vue",
@@ -3561,6 +3792,17 @@
         "help": "Use CSS border instead."
       },
       {
+        "ruleId": "vue/no-template-target-blank",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
+        "line": 60,
+        "column": 11,
+        "endLine": 64,
+        "endColumn": 12,
+        "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
+      },
+      {
         "ruleId": "ecosystem/router-link-require-to",
         "ruleDocsPath": "docs/content/rules/ecosystem.md",
         "severity": 2,
@@ -3573,7 +3815,7 @@
       }
     ],
     "errorCount": 1,
-    "warningCount": 1
+    "warningCount": 2
   },
   {
     "file": "app/components/timeline/TimelineSkeleton.vue",
@@ -3735,6 +3977,17 @@
         "help": "Reorder attributes to follow the recommended order"
       },
       {
+        "ruleId": "vue/no-template-target-blank",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
+        "line": 170,
+        "column": 11,
+        "endLine": 170,
+        "endColumn": 125,
+        "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
+      },
+      {
         "ruleId": "ecosystem/router-link-require-to",
         "ruleDocsPath": "docs/content/rules/ecosystem.md",
         "severity": 2,
@@ -3747,7 +4000,7 @@
       }
     ],
     "errorCount": 1,
-    "warningCount": 5
+    "warningCount": 6
   },
   {
     "file": "app/components/user/UserSignInEntry.vue",
@@ -4345,6 +4598,17 @@
     "file": "app/pages/settings/language/index.vue",
     "messages": [
       {
+        "ruleId": "vue/no-template-target-blank",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
+        "line": 33,
+        "column": 9,
+        "endLine": 37,
+        "endColumn": 10,
+        "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
+      },
+      {
         "ruleId": "ecosystem/router-link-require-to",
         "ruleDocsPath": "docs/content/rules/ecosystem.md",
         "severity": 2,
@@ -4357,7 +4621,7 @@
       }
     ],
     "errorCount": 1,
-    "warningCount": 0
+    "warningCount": 1
   },
   {
     "file": "app/pages/settings/notifications/index.vue",

--- a/tests/snapshots/lint/__snapshots__/misskey-lint.snap
+++ b/tests/snapshots/lint/__snapshots__/misskey-lint.snap
@@ -1200,6 +1200,17 @@
         "help": "Why: Screen readers announce the title to help users understand the iframe content.\nFix:\n  <iframe\n  src=\"https://example.com/video\"\n  title=\"Product demo video\"\n  ></iframe>\nNote: The title should describe the content, not the source."
       },
       {
+        "ruleId": "vue/no-unsandboxed-iframe",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-unsandboxed-iframe] <iframe> is missing a sandbox attribute",
+        "line": 10,
+        "column": 3,
+        "endLine": 15,
+        "endColumn": 4,
+        "help": "Add a sandbox attribute (e.g. sandbox=\"\" for the most restrictive policy) and re-grant only the capabilities the embedded content needs"
+      },
+      {
         "ruleId": "vue/no-unsafe-url",
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
@@ -1256,7 +1267,7 @@
       }
     ],
     "errorCount": 0,
-    "warningCount": 6
+    "warningCount": 7
   },
   {
     "file": "src/components/MkChannelFollowButton.vue",
@@ -3352,6 +3363,17 @@
         "help": "Why: Screen readers announce the title to help users understand the iframe content.\nFix:\n  <iframe\n  src=\"https://example.com/video\"\n  title=\"Product demo video\"\n  ></iframe>\nNote: The title should describe the content, not the source."
       },
       {
+        "ruleId": "vue/no-unsandboxed-iframe",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-unsandboxed-iframe] <iframe> is missing a sandbox attribute",
+        "line": 35,
+        "column": 9,
+        "endLine": 41,
+        "endColumn": 10,
+        "help": "Add a sandbox attribute (e.g. sandbox=\"\" for the most restrictive policy) and re-grant only the capabilities the embedded content needs"
+      },
+      {
         "ruleId": "vue/no-unsafe-url",
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
@@ -3419,7 +3441,7 @@
       }
     ],
     "errorCount": 0,
-    "warningCount": 19
+    "warningCount": 20
   },
   {
     "file": "src/components/MkEmojiPicker.section.vue",
@@ -12426,6 +12448,17 @@
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
       },
       {
+        "ruleId": "vue/no-template-target-blank",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
+        "line": 39,
+        "column": 31,
+        "endLine": 39,
+        "endColumn": 101,
+        "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
+      },
+      {
         "ruleId": "vue/no-unsafe-url",
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
@@ -12435,6 +12468,17 @@
         "endLine": 39,
         "endColumn": 70,
         "help": "Consider using <router-link :to=\"...\"> or sanitize URLs with @braintree/sanitize-url"
+      },
+      {
+        "ruleId": "vue/no-template-target-blank",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
+        "line": 40,
+        "column": 41,
+        "endLine": 40,
+        "endColumn": 121,
+        "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
       },
       {
         "ruleId": "vue/no-unsafe-url",
@@ -12492,6 +12536,17 @@
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
       },
       {
+        "ruleId": "vue/no-template-target-blank",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
+        "line": 50,
+        "column": 5,
+        "endLine": 50,
+        "endColumn": 104,
+        "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
+      },
+      {
         "ruleId": "vue/attribute-hyphenation",
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
@@ -12526,7 +12581,7 @@
       }
     ],
     "errorCount": 1,
-    "warningCount": 16
+    "warningCount": 19
   },
   {
     "file": "src/components/MkSignupDialog.vue",
@@ -14175,6 +14230,17 @@
         "help": "Ensure URLs are sanitized before binding to prevent XSS via javascript: protocol"
       },
       {
+        "ruleId": "vue/no-template-target-blank",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
+        "line": 21,
+        "column": 4,
+        "endLine": 21,
+        "endColumn": 102,
+        "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
+      },
+      {
         "ruleId": "vue/sfc-element-order",
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
@@ -14187,7 +14253,7 @@
       }
     ],
     "errorCount": 1,
-    "warningCount": 4
+    "warningCount": 5
   },
   {
     "file": "src/components/MkTutorialDialog.vue",
@@ -14292,6 +14358,17 @@
         "help": "Ensure URLs are sanitized before binding to prevent XSS via javascript: protocol"
       },
       {
+        "ruleId": "vue/no-template-target-blank",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
+        "line": 133,
+        "column": 10,
+        "endLine": 133,
+        "endColumn": 90,
+        "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
+      },
+      {
         "ruleId": "vue/sfc-element-order",
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
@@ -14304,7 +14381,7 @@
       }
     ],
     "errorCount": 0,
-    "warningCount": 10
+    "warningCount": 11
   },
   {
     "file": "src/components/MkUpdated.vue",
@@ -17062,6 +17139,17 @@
         "help": "Why: Screen readers announce the title to help users understand the iframe content.\nFix:\n  <iframe\n  src=\"https://example.com/video\"\n  title=\"Product demo video\"\n  ></iframe>\nNote: The title should describe the content, not the source."
       },
       {
+        "ruleId": "vue/no-unsandboxed-iframe",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-unsandboxed-iframe] <iframe> is missing a sandbox attribute",
+        "line": 16,
+        "column": 5,
+        "endLine": 16,
+        "endColumn": 134,
+        "help": "Add a sandbox attribute (e.g. sandbox=\"\" for the most restrictive policy) and re-grant only the capabilities the embedded content needs"
+      },
+      {
         "ruleId": "vue/no-unsafe-url",
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
@@ -17096,7 +17184,7 @@
       }
     ],
     "errorCount": 0,
-    "warningCount": 13
+    "warningCount": 14
   },
   {
     "file": "src/components/form/link.vue",
@@ -19325,6 +19413,28 @@
         "help": "Why: Screen readers use alt text to describe images to visually impaired users.\nFor informative images:\n  <img src=\"chart.png\" alt=\"Sales increased 20% in Q4\">\nFor decorative images:\n  <img src=\"decoration.png\" alt=\"\">\nFor complex images:\n  <img src=\"diagram.png\" alt=\"Process flow\" aria-describedby=\"desc\">\n  <p id=\"desc\">Detailed description...</p>"
       },
       {
+        "ruleId": "vue/no-template-target-blank",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
+        "line": 24,
+        "column": 43,
+        "endLine": 24,
+        "endColumn": 127,
+        "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
+      },
+      {
+        "ruleId": "vue/no-template-target-blank",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
+        "line": 70,
+        "column": 7,
+        "endLine": 70,
+        "endColumn": 87,
+        "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
+      },
+      {
         "ruleId": "a11y/alt-text",
         "ruleDocsPath": "docs/content/rules/accessibility.md",
         "severity": 1,
@@ -19345,6 +19455,17 @@
         "endLine": 71,
         "endColumn": 105,
         "help": "Why: Screen readers use alt text to describe images to visually impaired users.\nFor informative images:\n  <img src=\"chart.png\" alt=\"Sales increased 20% in Q4\">\nFor decorative images:\n  <img src=\"decoration.png\" alt=\"\">\nFor complex images:\n  <img src=\"diagram.png\" alt=\"Process flow\" aria-describedby=\"desc\">\n  <p id=\"desc\">Detailed description...</p>"
+      },
+      {
+        "ruleId": "vue/no-template-target-blank",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
+        "line": 74,
+        "column": 7,
+        "endLine": 74,
+        "endColumn": 93,
+        "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
       },
       {
         "ruleId": "a11y/alt-text",
@@ -19369,6 +19490,17 @@
         "help": "Why: Screen readers use alt text to describe images to visually impaired users.\nFor informative images:\n  <img src=\"chart.png\" alt=\"Sales increased 20% in Q4\">\nFor decorative images:\n  <img src=\"decoration.png\" alt=\"\">\nFor complex images:\n  <img src=\"diagram.png\" alt=\"Process flow\" aria-describedby=\"desc\">\n  <p id=\"desc\">Detailed description...</p>"
       },
       {
+        "ruleId": "vue/no-template-target-blank",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
+        "line": 78,
+        "column": 7,
+        "endLine": 78,
+        "endColumn": 96,
+        "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
+      },
+      {
         "ruleId": "a11y/alt-text",
         "ruleDocsPath": "docs/content/rules/accessibility.md",
         "severity": 1,
@@ -19389,6 +19521,17 @@
         "endLine": 79,
         "endColumn": 106,
         "help": "Why: Screen readers use alt text to describe images to visually impaired users.\nFor informative images:\n  <img src=\"chart.png\" alt=\"Sales increased 20% in Q4\">\nFor decorative images:\n  <img src=\"decoration.png\" alt=\"\">\nFor complex images:\n  <img src=\"diagram.png\" alt=\"Process flow\" aria-describedby=\"desc\">\n  <p id=\"desc\">Detailed description...</p>"
+      },
+      {
+        "ruleId": "vue/no-template-target-blank",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
+        "line": 82,
+        "column": 7,
+        "endLine": 82,
+        "endColumn": 88,
+        "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
       },
       {
         "ruleId": "a11y/alt-text",
@@ -19413,6 +19556,17 @@
         "help": "Why: Screen readers use alt text to describe images to visually impaired users.\nFor informative images:\n  <img src=\"chart.png\" alt=\"Sales increased 20% in Q4\">\nFor decorative images:\n  <img src=\"decoration.png\" alt=\"\">\nFor complex images:\n  <img src=\"diagram.png\" alt=\"Process flow\" aria-describedby=\"desc\">\n  <p id=\"desc\">Detailed description...</p>"
       },
       {
+        "ruleId": "vue/no-template-target-blank",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
+        "line": 86,
+        "column": 7,
+        "endLine": 86,
+        "endColumn": 91,
+        "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
+      },
+      {
         "ruleId": "a11y/alt-text",
         "ruleDocsPath": "docs/content/rules/accessibility.md",
         "severity": 1,
@@ -19435,6 +19589,17 @@
         "help": "Why: Screen readers use alt text to describe images to visually impaired users.\nFor informative images:\n  <img src=\"chart.png\" alt=\"Sales increased 20% in Q4\">\nFor decorative images:\n  <img src=\"decoration.png\" alt=\"\">\nFor complex images:\n  <img src=\"diagram.png\" alt=\"Process flow\" aria-describedby=\"desc\">\n  <p id=\"desc\">Detailed description...</p>"
       },
       {
+        "ruleId": "vue/no-template-target-blank",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
+        "line": 90,
+        "column": 7,
+        "endLine": 90,
+        "endColumn": 90,
+        "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
+      },
+      {
         "ruleId": "a11y/alt-text",
         "ruleDocsPath": "docs/content/rules/accessibility.md",
         "severity": 1,
@@ -19455,6 +19620,72 @@
         "endLine": 91,
         "endColumn": 106,
         "help": "Why: Screen readers use alt text to describe images to visually impaired users.\nFor informative images:\n  <img src=\"chart.png\" alt=\"Sales increased 20% in Q4\">\nFor decorative images:\n  <img src=\"decoration.png\" alt=\"\">\nFor complex images:\n  <img src=\"diagram.png\" alt=\"Process flow\" aria-describedby=\"desc\">\n  <p id=\"desc\">Detailed description...</p>"
+      },
+      {
+        "ruleId": "vue/no-template-target-blank",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
+        "line": 100,
+        "column": 8,
+        "endLine": 100,
+        "endColumn": 123,
+        "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
+      },
+      {
+        "ruleId": "vue/no-template-target-blank",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
+        "line": 103,
+        "column": 8,
+        "endLine": 103,
+        "endColumn": 124,
+        "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
+      },
+      {
+        "ruleId": "vue/no-template-target-blank",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
+        "line": 106,
+        "column": 8,
+        "endLine": 106,
+        "endColumn": 108,
+        "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
+      },
+      {
+        "ruleId": "vue/no-template-target-blank",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
+        "line": 109,
+        "column": 8,
+        "endLine": 109,
+        "endColumn": 119,
+        "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
+      },
+      {
+        "ruleId": "vue/no-template-target-blank",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
+        "line": 112,
+        "column": 8,
+        "endLine": 112,
+        "endColumn": 147,
+        "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
+      },
+      {
+        "ruleId": "vue/no-template-target-blank",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
+        "line": 115,
+        "column": 8,
+        "endLine": 115,
+        "endColumn": 122,
+        "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
       },
       {
         "ruleId": "vue/require-v-for-key",
@@ -19513,7 +19744,7 @@
       }
     ],
     "errorCount": 1,
-    "warningCount": 26
+    "warningCount": 39
   },
   {
     "file": "src/pages/about.emojis.vue",
@@ -19737,6 +19968,17 @@
         "help": "Fix options:\n1. Add text content:\n  <a href=\"/about\">About Us</a>\n2. Add aria-label for icon-only links:\n  <a href=\"/settings\" aria-label=\"Settings\">\n  <IconSettings />\n  </a>\n3. Include image with alt:\n  <a href=\"/\"><img src=\"logo.png\" alt=\"Home\"></a>"
       },
       {
+        "ruleId": "vue/no-template-target-blank",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
+        "line": 10,
+        "column": 4,
+        "endLine": 10,
+        "endColumn": 58,
+        "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
+      },
+      {
         "ruleId": "vue/no-unsafe-url",
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
@@ -19826,7 +20068,7 @@
       }
     ],
     "errorCount": 0,
-    "warningCount": 9
+    "warningCount": 10
   },
   {
     "file": "src/pages/admin-file.vue",
@@ -20521,6 +20763,17 @@
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
       },
       {
+        "ruleId": "vue/no-template-target-blank",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
+        "line": 57,
+        "column": 26,
+        "endLine": 57,
+        "endColumn": 109,
+        "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
+      },
+      {
         "ruleId": "vue/attribute-hyphenation",
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
@@ -20587,6 +20840,17 @@
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
       },
       {
+        "ruleId": "vue/no-template-target-blank",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
+        "line": 111,
+        "column": 8,
+        "endLine": 114,
+        "endColumn": 9,
+        "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
+      },
+      {
         "ruleId": "vue/attribute-hyphenation",
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
@@ -20607,6 +20871,17 @@
         "endLine": 135,
         "endColumn": 62,
         "help": "Use kebab-case for prop names in templates:\n  <!-- Bad -->\n  <MyComponent myProp=\"value\" />\n  \n  <!-- Good -->\n  <MyComponent my-prop=\"value\" />"
+      },
+      {
+        "ruleId": "vue/no-template-target-blank",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
+        "line": 144,
+        "column": 26,
+        "endLine": 144,
+        "endColumn": 121,
+        "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
       },
       {
         "ruleId": "vue/no-v-html",
@@ -20632,7 +20907,7 @@
       }
     ],
     "errorCount": 0,
-    "warningCount": 16
+    "warningCount": 19
   },
   {
     "file": "src/pages/admin/branding.vue",
@@ -41887,6 +42162,17 @@
     "file": "src/ui/visitor.vue",
     "messages": [
       {
+        "ruleId": "vue/no-template-target-blank",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
+        "line": 8,
+        "column": 2,
+        "endLine": 8,
+        "endColumn": 138,
+        "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
+      },
+      {
         "ruleId": "vue/no-unsafe-url",
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
@@ -41943,7 +42229,7 @@
       }
     ],
     "errorCount": 0,
-    "warningCount": 5
+    "warningCount": 6
   },
   {
     "file": "src/ui/zen.vue",
@@ -42131,6 +42417,17 @@
         "help": "Why: Non-interactive elements (div, span, etc.) should not have click/keyboard handlers without a role.\nFix options:\n1. Use a native interactive element:\n  <button @click=\"handle\">Click me</button>\n2. Add role and tabindex:\n  <div role=\"button\" tabindex=\"0\" @click=\"handle\">\n  Click me\n  </div>"
       },
       {
+        "ruleId": "vue/no-unsandboxed-iframe",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-unsandboxed-iframe] <iframe> is missing a sandbox attribute",
+        "line": 8,
+        "column": 2,
+        "endLine": 8,
+        "endColumn": 134,
+        "help": "Add a sandbox attribute (e.g. sandbox=\"\" for the most restrictive policy) and re-grant only the capabilities the embedded content needs"
+      },
+      {
         "ruleId": "vue/sfc-element-order",
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
@@ -42143,7 +42440,7 @@
       }
     ],
     "errorCount": 0,
-    "warningCount": 6
+    "warningCount": 7
   },
   {
     "file": "src/widgets/WidgetAiscript.vue",

--- a/tests/snapshots/lint/__snapshots__/reka-ui-lint.snap
+++ b/tests/snapshots/lint/__snapshots__/reka-ui-lint.snap
@@ -1585,6 +1585,17 @@
     "file": "packages/core/src/Combobox/story/ComboboxCustom.story.vue",
     "messages": [
       {
+        "ruleId": "vue/no-template-target-blank",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
+        "line": 59,
+        "column": 17,
+        "endLine": 62,
+        "endColumn": 18,
+        "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
+      },
+      {
         "ruleId": "vue/no-unsafe-url",
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
@@ -1597,7 +1608,7 @@
       }
     ],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 2
   },
   {
     "file": "packages/core/src/Combobox/story/ComboboxMultiple.story.vue",
@@ -5047,6 +5058,17 @@
     "file": "packages/core/src/NavigationMenu/story/NavigationMenuAlignment.story.vue",
     "messages": [
       {
+        "ruleId": "vue/no-template-target-blank",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
+        "line": 50,
+        "column": 21,
+        "endLine": 55,
+        "endColumn": 22,
+        "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
+      },
+      {
         "ruleId": "vue/permitted-contents",
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 2,
@@ -5138,7 +5160,7 @@
       }
     ],
     "errorCount": 9,
-    "warningCount": 0
+    "warningCount": 1
   },
   {
     "file": "packages/core/src/NavigationMenu/story/NavigationMenuBasic.story.vue",
@@ -5327,6 +5349,17 @@
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
       },
       {
+        "ruleId": "vue/no-template-target-blank",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
+        "line": 53,
+        "column": 17,
+        "endLine": 58,
+        "endColumn": 18,
+        "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
+      },
+      {
         "ruleId": "vue/permitted-contents",
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 2,
@@ -5418,7 +5451,7 @@
       }
     ],
     "errorCount": 9,
-    "warningCount": 1
+    "warningCount": 2
   },
   {
     "file": "packages/core/src/NavigationMenu/story/_NavigationMenuListItem.vue",
@@ -8710,9 +8743,21 @@
   },
   {
     "file": "packages/core/src/Toolbar/story/Toolbar.story.vue",
-    "messages": [],
+    "messages": [
+      {
+        "ruleId": "vue/no-template-target-blank",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
+        "line": 83,
+        "column": 9,
+        "endLine": 88,
+        "endColumn": 10,
+        "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
+      }
+    ],
     "errorCount": 0,
-    "warningCount": 0
+    "warningCount": 1
   },
   {
     "file": "packages/core/src/Toolbar/story/_Toolbar.vue",
@@ -8727,10 +8772,21 @@
         "endLine": 17,
         "endColumn": 11,
         "help": "Rename the file to PascalCase:\n  my-component.vue -> MyComponent.vue\n  myComponent.vue  -> MyComponent.vue"
+      },
+      {
+        "ruleId": "vue/no-template-target-blank",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
+        "line": 78,
+        "column": 5,
+        "endLine": 83,
+        "endColumn": 6,
+        "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
       }
     ],
     "errorCount": 0,
-    "warningCount": 1
+    "warningCount": 2
   },
   {
     "file": "packages/core/src/Tooltip/TooltipArrow.vue",

--- a/tests/snapshots/lint/__snapshots__/vuefes-2025-lint.snap
+++ b/tests/snapshots/lint/__snapshots__/vuefes-2025-lint.snap
@@ -704,6 +704,17 @@
         "help": "Add text content, child elements, or use aria-label for accessible content."
       },
       {
+        "ruleId": "vue/no-template-target-blank",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
+        "line": 142,
+        "column": 13,
+        "endLine": 147,
+        "endColumn": 14,
+        "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
+      },
+      {
         "ruleId": "vue/no-unsafe-url",
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
@@ -713,6 +724,17 @@
         "endLine": 144,
         "endColumn": 55,
         "help": "Consider using <router-link :to=\"...\"> or sanitize URLs with @braintree/sanitize-url"
+      },
+      {
+        "ruleId": "vue/no-template-target-blank",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
+        "line": 150,
+        "column": 13,
+        "endLine": 155,
+        "endColumn": 14,
+        "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
       },
       {
         "ruleId": "vue/no-unsafe-url",
@@ -726,6 +748,17 @@
         "help": "Consider using <router-link :to=\"...\"> or sanitize URLs with @braintree/sanitize-url"
       },
       {
+        "ruleId": "vue/no-template-target-blank",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
+        "line": 158,
+        "column": 13,
+        "endLine": 163,
+        "endColumn": 14,
+        "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
+      },
+      {
         "ruleId": "vue/no-unsafe-url",
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
@@ -735,6 +768,17 @@
         "endLine": 160,
         "endColumn": 56,
         "help": "Consider using <router-link :to=\"...\"> or sanitize URLs with @braintree/sanitize-url"
+      },
+      {
+        "ruleId": "vue/no-template-target-blank",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
+        "line": 183,
+        "column": 13,
+        "endLine": 188,
+        "endColumn": 14,
+        "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
       },
       {
         "ruleId": "vue/no-unsafe-url",
@@ -748,6 +792,17 @@
         "help": "Consider using <router-link :to=\"...\"> or sanitize URLs with @braintree/sanitize-url"
       },
       {
+        "ruleId": "vue/no-template-target-blank",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
+        "line": 191,
+        "column": 13,
+        "endLine": 196,
+        "endColumn": 14,
+        "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
+      },
+      {
         "ruleId": "vue/no-unsafe-url",
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
@@ -757,6 +812,17 @@
         "endLine": 193,
         "endColumn": 50,
         "help": "Consider using <router-link :to=\"...\"> or sanitize URLs with @braintree/sanitize-url"
+      },
+      {
+        "ruleId": "vue/no-template-target-blank",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
+        "line": 199,
+        "column": 13,
+        "endLine": 204,
+        "endColumn": 14,
+        "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
       },
       {
         "ruleId": "vue/no-unsafe-url",
@@ -782,7 +848,7 @@
       }
     ],
     "errorCount": 0,
-    "warningCount": 9
+    "warningCount": 15
   },
   {
     "file": "app/pages/speaker/_components/SpeakerCard.vue",
@@ -1012,10 +1078,21 @@
         "endLine": 180,
         "endColumn": 170,
         "help": "Use useId() for unique IDs, or wrap in <ClientOnly> for client-only values"
+      },
+      {
+        "ruleId": "vue/no-template-target-blank",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
+        "line": 219,
+        "column": 11,
+        "endLine": 219,
+        "endColumn": 72,
+        "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
       }
     ],
     "errorCount": 0,
-    "warningCount": 6
+    "warningCount": 7
   },
   {
     "file": "app/pages/timetable/_components/TimetableCard.vue",
@@ -1043,6 +1120,17 @@
         "help": "Ensure URLs are sanitized before binding to prevent XSS via javascript: protocol"
       },
       {
+        "ruleId": "vue/no-template-target-blank",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
+        "line": 106,
+        "column": 15,
+        "endLine": 106,
+        "endColumn": 91,
+        "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
+      },
+      {
         "ruleId": "vue/no-unsafe-url",
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
@@ -1055,7 +1143,7 @@
       }
     ],
     "errorCount": 0,
-    "warningCount": 3
+    "warningCount": 4
   },
   {
     "file": "app/pages/timetable/_components/TimetableCell.vue",
@@ -1083,6 +1171,17 @@
         "help": "Ensure URLs are sanitized before binding to prevent XSS via javascript: protocol"
       },
       {
+        "ruleId": "vue/no-template-target-blank",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
+        "line": 111,
+        "column": 15,
+        "endLine": 111,
+        "endColumn": 91,
+        "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
+      },
+      {
         "ruleId": "vue/no-unsafe-url",
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
@@ -1095,7 +1194,7 @@
       }
     ],
     "errorCount": 0,
-    "warningCount": 3
+    "warningCount": 4
   },
   {
     "file": "app/pages/timetable/_components/TimetableHead.vue",
@@ -1157,6 +1256,17 @@
         "endColumn": 17
       },
       {
+        "ruleId": "vue/no-template-target-blank",
+        "ruleDocsPath": "docs/content/rules/vue.md",
+        "severity": 1,
+        "message": "[vize:vue/no-template-target-blank] Using target=\"_blank\" without rel=\"noopener\" or rel=\"noreferrer\" is a security risk",
+        "line": 121,
+        "column": 7,
+        "endLine": 124,
+        "endColumn": 8,
+        "help": "Add rel=\"noopener\" (or rel=\"noreferrer\") to links that open in a new tab to prevent reverse tabnabbing via window.opener"
+      },
+      {
         "ruleId": "vue/no-unsafe-url",
         "ruleDocsPath": "docs/content/rules/vue.md",
         "severity": 1,
@@ -1180,7 +1290,7 @@
       }
     ],
     "errorCount": 5,
-    "warningCount": 2
+    "warningCount": 3
   },
   {
     "file": "app/pages/tokusho/index.vue",


### PR DESCRIPTION
Closes #1655.

## Summary
- refresh stale App E2E lint snapshots for existing real-world fixtures
- capture the new `vue/no-template-target-blank` and `vue/no-unsandboxed-iframe` diagnostics now emitted in the app lint lane

## Verification
- `VIZE_TEST_WORKTREE_ID=lint-refresh-verify vp run --filter ./tests test:lint`
- `git diff --check`
- `vp run --workspace-root source:lengths --check --base-ref origin/main`