### PR TITLE
feat(patina): add vue/no-deprecated-router-link-tag-prop

### DIFF
--- a/crates/vize_carton/src/i18n_supplemental.rs
+++ b/crates/vize_carton/src/i18n_supplemental.rs
@@ -248,4 +248,23 @@ static ENTRIES: &[(&str, &str, &str, &str)] = &[
         "スロット名をケバブケースに変更してください。例: '#mySlot' や '#my_slot' ではなく '#my-slot'。",
         "请将插槽名称改为短横线命名，例如使用 '#my-slot' 而非 '#mySlot' 或 '#my_slot'。",
     ),
+    // vue/no-deprecated-router-link-tag-prop
+    (
+        "vue/no-deprecated-router-link-tag-prop.description",
+        "Disallow the deprecated `tag` prop on <router-link>",
+        "<router-link> の非推奨な `tag` プロパティを禁止する",
+        "禁止 <router-link> 上已弃用的 `tag` 属性",
+    ),
+    (
+        "vue/no-deprecated-router-link-tag-prop.message",
+        "The `tag` prop on `<router-link>` was removed in Vue Router 4; use the v-slot API instead",
+        "`<router-link>` の `tag` プロパティは Vue Router 4 で削除されました。代わりに v-slot API を使用してください",
+        "`<router-link>` 上的 `tag` 属性已在 Vue Router 4 中移除；请改用 v-slot API",
+    ),
+    (
+        "vue/no-deprecated-router-link-tag-prop.help",
+        "Remove the `tag` prop and render the element yourself using `v-slot` (it exposes `href`, `navigate`, and `isActive`).",
+        "`tag` プロパティを削除し、`v-slot`（`href`・`navigate`・`isActive` を公開します）を使って要素を自分でレンダリングしてください。",
+        "请移除 `tag` 属性，并使用 `v-slot`（它会暴露 `href`、`navigate` 和 `isActive`）自行渲染元素。",
+    ),
 ];

--- a/crates/vize_patina/src/rules/vue.rs
+++ b/crates/vize_patina/src/rules/vue.rs
@@ -13,6 +13,7 @@
 mod attribute_hyphenation;
 mod attribute_order;
 mod no_child_content;
+mod no_deprecated_router_link_tag_prop;
 mod no_deprecated_scope_attribute;
 mod no_deprecated_slot_attribute;
 mod no_deprecated_slot_scope_attribute;
@@ -85,6 +86,7 @@ mod single_style_block;
 pub use crate::rules::opinionated::vue::MultiWordComponentNames;
 pub use crate::rules::opinionated::vue::UseVOnExact;
 pub use no_child_content::NoChildContent;
+pub use no_deprecated_router_link_tag_prop::NoDeprecatedRouterLinkTagProp;
 pub use no_deprecated_scope_attribute::NoDeprecatedScopeAttribute;
 pub use no_deprecated_slot_attribute::NoDeprecatedSlotAttribute;
 pub use no_deprecated_slot_scope_attribute::NoDeprecatedSlotScopeAttribute;
@@ -205,5 +207,8 @@ pub(crate) fn register_opt_in(registry: &mut crate::rule::RuleRegistry) {
     }
     if !registry.has_rule("vue/no-deprecated-scope-attribute") {
         registry.register(Box::new(NoDeprecatedScopeAttribute));
+    }
+    if !registry.has_rule("vue/no-deprecated-router-link-tag-prop") {
+        registry.register(Box::new(NoDeprecatedRouterLinkTagProp));
     }
 }

--- a/crates/vize_patina/src/rules/vue/no_deprecated_router_link_tag_prop.rs
+++ b/crates/vize_patina/src/rules/vue/no_deprecated_router_link_tag_prop.rs
@@ -1,0 +1,151 @@
+//! vue/no-deprecated-router-link-tag-prop
+//!
+//! Disallow the `tag` prop on `<router-link>` (removed in Vue Router 4).
+//!
+//! Vue Router 4 removed the `tag` prop (and the related `event` prop) in favour
+//! of the scoped-slot (`v-slot`) API, which exposes `href`, `navigate`, and
+//! `isActive` so the caller renders any element they like.
+//!
+//! The rule flags both a static `tag` attribute and a `v-bind:tag` binding on
+//! the `<router-link>` / `<RouterLink>` element. It is an opt-in migration rule
+//! and only fires for the default Vue 3 dialect.
+//!
+//! ## Examples
+//!
+//! ### Invalid (Vue 3)
+//! ```vue
+//! <template>
+//!   <router-link to="/home" tag="button">Home</router-link>
+//! </template>
+//! ```
+//!
+//! ### Valid (Vue 3)
+//! ```vue
+//! <template>
+//!   <router-link to="/home" v-slot="{ navigate }">
+//!     <button @click="navigate">Home</button>
+//!   </router-link>
+//! </template>
+//! ```
+
+use crate::context::LintContext;
+use crate::diagnostic::Severity;
+use crate::rule::{Rule, RuleCategory, RuleMeta};
+use vize_carton::dialect::VueDialect;
+use vize_relief::{ElementNode, ExpressionNode, PropNode};
+
+static META: RuleMeta = RuleMeta {
+    name: "vue/no-deprecated-router-link-tag-prop",
+    description: "Disallow the `tag` prop on <router-link>",
+    category: RuleCategory::Essential,
+    fixable: false,
+    default_severity: Severity::Error,
+};
+
+/// Disallow the `tag` prop on `<router-link>`.
+pub struct NoDeprecatedRouterLinkTagProp;
+
+impl Rule for NoDeprecatedRouterLinkTagProp {
+    fn meta(&self) -> &'static RuleMeta {
+        &META
+    }
+
+    fn enter_element<'a>(&self, ctx: &mut LintContext<'a>, element: &ElementNode<'a>) {
+        // Vue Router 4 (the router for the default Vue 3 dialect) removed `tag`.
+        if ctx.dialect() != VueDialect::Vue {
+            return;
+        }
+
+        // Match both the kebab-case and PascalCase spellings of the component.
+        if element.tag != "router-link" && element.tag != "RouterLink" {
+            return;
+        }
+
+        for prop in element.props.iter() {
+            match prop {
+                PropNode::Attribute(attr) if attr.name == "tag" => {
+                    ctx.error_with_help(
+                        ctx.t("vue/no-deprecated-router-link-tag-prop.message"),
+                        &attr.loc,
+                        ctx.t("vue/no-deprecated-router-link-tag-prop.help"),
+                    );
+                }
+                PropNode::Directive(dir)
+                    if dir.name == "bind"
+                        && matches!(
+                            &dir.arg,
+                            Some(ExpressionNode::Simple(s)) if s.content == "tag"
+                        ) =>
+                {
+                    ctx.error_with_help(
+                        ctx.t("vue/no-deprecated-router-link-tag-prop.message"),
+                        &dir.loc,
+                        ctx.t("vue/no-deprecated-router-link-tag-prop.help"),
+                    );
+                }
+                _ => {}
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::NoDeprecatedRouterLinkTagProp;
+    use crate::linter::Linter;
+    use crate::rule::RuleRegistry;
+
+    fn create_linter() -> Linter {
+        let mut registry = RuleRegistry::new();
+        registry.register(Box::new(NoDeprecatedRouterLinkTagProp));
+        Linter::with_registry(registry)
+    }
+
+    #[test]
+    fn reports_static_tag_prop() {
+        let linter = create_linter();
+        let result = linter.lint_template(
+            r#"<router-link to="/home" tag="button">Home</router-link>"#,
+            "App.vue",
+        );
+        assert_eq!(result.error_count, 1);
+        insta::assert_debug_snapshot!(result.diagnostics);
+    }
+
+    #[test]
+    fn reports_static_tag_prop_pascal_case() {
+        let linter = create_linter();
+        let result = linter.lint_template(
+            r#"<RouterLink to="/home" tag="button">Home</RouterLink>"#,
+            "App.vue",
+        );
+        assert_eq!(result.error_count, 1);
+    }
+
+    #[test]
+    fn reports_bound_tag_prop() {
+        let linter = create_linter();
+        let result = linter.lint_template(
+            r#"<router-link to="/home" :tag="el">Home</router-link>"#,
+            "App.vue",
+        );
+        assert_eq!(result.error_count, 1);
+    }
+
+    #[test]
+    fn allows_router_link_without_tag() {
+        let linter = create_linter();
+        let result = linter.lint_template(
+            r#"<router-link to="/home" v-slot="{ navigate }"><button @click="navigate">Home</button></router-link>"#,
+            "App.vue",
+        );
+        assert_eq!(result.error_count, 0);
+    }
+
+    #[test]
+    fn allows_tag_on_other_elements() {
+        let linter = create_linter();
+        let result = linter.lint_template(r#"<my-link tag="button">Home</my-link>"#, "App.vue");
+        assert_eq!(result.error_count, 0);
+    }
+}

--- a/crates/vize_patina/src/rules/vue/snapshots/vize_patina__rules__vue__no_deprecated_router_link_tag_prop__tests__reports_static_tag_prop.snap
+++ b/crates/vize_patina/src/rules/vue/snapshots/vize_patina__rules__vue__no_deprecated_router_link_tag_prop__tests__reports_static_tag_prop.snap
@@ -1,0 +1,18 @@
+---
+source: crates/vize_patina/src/rules/vue/no_deprecated_router_link_tag_prop.rs
+expression: result.diagnostics
+---
+[
+    LintDiagnostic {
+        rule_name: "vue/no-deprecated-router-link-tag-prop",
+        severity: Error,
+        message: "vue/no-deprecated-router-link-tag-prop.message",
+        start: 24,
+        end: 36,
+        help: Some(
+            "vue/no-deprecated-router-link-tag-prop.help",
+        ),
+        labels: [],
+        fix: None,
+    },
+]

--- a/crates/vize_patina/src/rules/vue/snapshots/vize_patina__rules__vue__no_deprecated_router_link_tag_prop__tests__reports_static_tag_prop.snap
+++ b/crates/vize_patina/src/rules/vue/snapshots/vize_patina__rules__vue__no_deprecated_router_link_tag_prop__tests__reports_static_tag_prop.snap
@@ -6,11 +6,11 @@ expression: result.diagnostics
     LintDiagnostic {
         rule_name: "vue/no-deprecated-router-link-tag-prop",
         severity: Error,
-        message: "vue/no-deprecated-router-link-tag-prop.message",
+        message: "The `tag` prop on `<router-link>` was removed in Vue Router 4; use the v-slot API instead",
         start: 24,
         end: 36,
         help: Some(
-            "vue/no-deprecated-router-link-tag-prop.help",
+            "Remove the `tag` prop and render the element yourself using `v-slot` (it exposes `href`, `navigate`, and `isActive`).",
         ),
         labels: [],
         fix: None,

--- a/crates/vize_patina/src/snapshots/vize_patina__preset__tests__lint_preset_rule_membership.snap
+++ b/crates/vize_patina/src/snapshots/vize_patina__preset__tests__lint_preset_rule_membership.snap
@@ -500,6 +500,7 @@ expression: "serde_json::to_string_pretty(&snapshot).unwrap()"
     "vue/no-deprecated-slot-attribute",
     "vue/no-deprecated-slot-scope-attribute",
     "vue/no-deprecated-scope-attribute",
+    "vue/no-deprecated-router-link-tag-prop",
     "ecosystem/pinia-prefer-store-to-refs",
     "ecosystem/vue-router-prefer-named-push",
     "ecosystem/vue-test-utils-no-html-snapshot",

--- a/npm/vize/src/types/rules.ts
+++ b/npm/vize/src/types/rules.ts
@@ -107,6 +107,7 @@ export const LINT_RULE_NAMES = [
   "vue/mustache-interpolation-spacing",
   "vue/no-boolean-attr-value",
   "vue/no-child-content",
+  "vue/no-deprecated-router-link-tag-prop",
   "vue/no-deprecated-scope-attribute",
   "vue/no-deprecated-slot-attribute",
   "vue/no-deprecated-slot-scope-attribute",


### PR DESCRIPTION
Part of #1629. Adds an opt-in migration rule that disallows the `tag` prop on `<router-link>` (removed in Vue Router 4 in favour of the v-slot API). Opt-in migration rule (dialect-gated to Vue 3), registered via register_opt_in; detects both a static `tag` attribute and a `v-bind:tag` binding on `<router-link>` / `<RouterLink>`; translations in i18n_supplemental.rs; snapshot + rules.ts regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1658"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->