### PR TITLE
fix(patina): don't run no-top-level-ref-in-script on <script setup>

### DIFF
--- a/crates/vize_patina/src/linter/script_rules.rs
+++ b/crates/vize_patina/src/linter/script_rules.rs
@@ -136,7 +136,7 @@ pub(crate) fn append_builtin_script_diagnostics<'a>(
         if let Some((source, offset)) = script {
             run_builtin_script_rule(entry, source, offset, script_parsed.as_ref(), result);
         }
-        if let Some((source, offset)) = script_setup {
+        if let Some((source, offset)) = script_setup.filter(|_| entry.rule.runs_on_script_setup()) {
             run_builtin_script_rule(entry, source, offset, script_setup_parsed.as_ref(), result);
         }
     }

--- a/crates/vize_patina/src/linter/tests.rs
+++ b/crates/vize_patina/src/linter/tests.rs
@@ -5,4 +5,5 @@ use vize_carton::{Allocator, ToCompactString};
 mod basic;
 mod directives;
 mod jsx;
+mod no_top_level_ref;
 mod sfc;

--- a/crates/vize_patina/src/linter/tests/basic.rs
+++ b/crates/vize_patina/src/linter/tests/basic.rs
@@ -458,50 +458,6 @@ const data = computed(async () => await fetch('/api'))
 }
 
 #[test]
-fn test_lint_sfc_no_top_level_ref_skips_script_setup() {
-    // In `<script setup>` top-level reactive state is fresh per component
-    // instance, so `const count = ref(0)` is idiomatic and must NOT be flagged.
-    let linter =
-        Linter::new().with_enabled_rules(Some(vec!["script/no-top-level-ref-in-script".into()]));
-    let sfc = r#"<script setup>
-const count = ref(0)
-</script>
-"#;
-    let result = linter.lint_sfc(sfc, "test.vue");
-    assert_eq!(
-        result
-            .diagnostics
-            .iter()
-            .filter(|diagnostic| diagnostic.rule_name == "script/no-top-level-ref-in-script")
-            .count(),
-        0,
-        "no-top-level-ref-in-script must not fire on <script setup>"
-    );
-}
-
-#[test]
-fn test_lint_sfc_no_top_level_ref_reports_plain_script() {
-    // Regression guard: a plain (module-scoped) `<script>` still leaks reactive
-    // state across SSR requests, so the rule must keep firing there.
-    let linter =
-        Linter::new().with_enabled_rules(Some(vec!["script/no-top-level-ref-in-script".into()]));
-    let sfc = r#"<script>
-const count = ref(0)
-</script>
-"#;
-    let result = linter.lint_sfc(sfc, "test.vue");
-    assert_eq!(
-        result
-            .diagnostics
-            .iter()
-            .filter(|diagnostic| diagnostic.rule_name == "script/no-top-level-ref-in-script")
-            .count(),
-        1,
-        "no-top-level-ref-in-script must still fire on a plain <script>"
-    );
-}
-
-#[test]
 fn test_lint_standalone_html_reports_cdn_options_api() {
     let linter = Linter::with_preset(LintPreset::Opinionated)
         .with_enabled_rules(Some(vec!["script/no-options-api".into()]));

--- a/crates/vize_patina/src/linter/tests/basic.rs
+++ b/crates/vize_patina/src/linter/tests/basic.rs
@@ -458,6 +458,50 @@ const data = computed(async () => await fetch('/api'))
 }
 
 #[test]
+fn test_lint_sfc_no_top_level_ref_skips_script_setup() {
+    // In `<script setup>` top-level reactive state is fresh per component
+    // instance, so `const count = ref(0)` is idiomatic and must NOT be flagged.
+    let linter =
+        Linter::new().with_enabled_rules(Some(vec!["script/no-top-level-ref-in-script".into()]));
+    let sfc = r#"<script setup>
+const count = ref(0)
+</script>
+"#;
+    let result = linter.lint_sfc(sfc, "test.vue");
+    assert_eq!(
+        result
+            .diagnostics
+            .iter()
+            .filter(|diagnostic| diagnostic.rule_name == "script/no-top-level-ref-in-script")
+            .count(),
+        0,
+        "no-top-level-ref-in-script must not fire on <script setup>"
+    );
+}
+
+#[test]
+fn test_lint_sfc_no_top_level_ref_reports_plain_script() {
+    // Regression guard: a plain (module-scoped) `<script>` still leaks reactive
+    // state across SSR requests, so the rule must keep firing there.
+    let linter =
+        Linter::new().with_enabled_rules(Some(vec!["script/no-top-level-ref-in-script".into()]));
+    let sfc = r#"<script>
+const count = ref(0)
+</script>
+"#;
+    let result = linter.lint_sfc(sfc, "test.vue");
+    assert_eq!(
+        result
+            .diagnostics
+            .iter()
+            .filter(|diagnostic| diagnostic.rule_name == "script/no-top-level-ref-in-script")
+            .count(),
+        1,
+        "no-top-level-ref-in-script must still fire on a plain <script>"
+    );
+}
+
+#[test]
 fn test_lint_standalone_html_reports_cdn_options_api() {
     let linter = Linter::with_preset(LintPreset::Opinionated)
         .with_enabled_rules(Some(vec!["script/no-options-api".into()]));

--- a/crates/vize_patina/src/linter/tests/no_top_level_ref.rs
+++ b/crates/vize_patina/src/linter/tests/no_top_level_ref.rs
@@ -1,0 +1,45 @@
+use super::Linter;
+
+#[test]
+fn test_lint_sfc_no_top_level_ref_skips_script_setup() {
+    // In `<script setup>` top-level reactive state is fresh per component
+    // instance, so `const count = ref(0)` is idiomatic and must NOT be flagged.
+    let linter =
+        Linter::new().with_enabled_rules(Some(vec!["script/no-top-level-ref-in-script".into()]));
+    let sfc = r#"<script setup>
+const count = ref(0)
+</script>
+"#;
+    let result = linter.lint_sfc(sfc, "test.vue");
+    assert_eq!(
+        result
+            .diagnostics
+            .iter()
+            .filter(|diagnostic| diagnostic.rule_name == "script/no-top-level-ref-in-script")
+            .count(),
+        0,
+        "no-top-level-ref-in-script must not fire on <script setup>"
+    );
+}
+
+#[test]
+fn test_lint_sfc_no_top_level_ref_reports_plain_script() {
+    // Regression guard: a plain (module-scoped) `<script>` still leaks reactive
+    // state across SSR requests, so the rule must keep firing there.
+    let linter =
+        Linter::new().with_enabled_rules(Some(vec!["script/no-top-level-ref-in-script".into()]));
+    let sfc = r#"<script>
+const count = ref(0)
+</script>
+"#;
+    let result = linter.lint_sfc(sfc, "test.vue");
+    assert_eq!(
+        result
+            .diagnostics
+            .iter()
+            .filter(|diagnostic| diagnostic.rule_name == "script/no-top-level-ref-in-script")
+            .count(),
+        1,
+        "no-top-level-ref-in-script must still fire on a plain <script>"
+    );
+}

--- a/crates/vize_patina/src/rules/script.rs
+++ b/crates/vize_patina/src/rules/script.rs
@@ -197,6 +197,12 @@ pub trait ScriptRule: Send + Sync {
     fn uses_ast(&self) -> bool {
         false
     }
+
+    /// Whether this rule runs against `<script setup>` blocks (defaults to `true`).
+    #[inline]
+    fn runs_on_script_setup(&self) -> bool {
+        true
+    }
 }
 
 /// Linter for script blocks

--- a/crates/vize_patina/src/rules/script/no_top_level_ref_in_script.rs
+++ b/crates/vize_patina/src/rules/script/no_top_level_ref_in_script.rs
@@ -69,6 +69,13 @@ impl ScriptRule for NoTopLevelRefInScript {
         &META
     }
 
+    // Top-level state in `<script setup>` is fresh per component instance, so it
+    // is the idiomatic pattern there and must not be flagged. Only plain
+    // `<script>` (module scope) leaks reactive state across SSR requests.
+    fn runs_on_script_setup(&self) -> bool {
+        false
+    }
+
     fn check(&self, source: &str, offset: usize, result: &mut ScriptLintResult) {
         let bytes = source.as_bytes();
 


### PR DESCRIPTION
The script-rule dispatcher (`append_builtin_script_diagnostics`) ran every active script rule against both the plain `<script>` block and the `<script setup>` block, so `script/no-top-level-ref-in-script` fired on `<script setup>` and flagged idiomatic top-level state (`const count = ref(0)`) as a false positive. That state is fresh per component instance; the rule only applies to module-scoped `<script>`, where reactive state leaks across SSR requests.

Fix: add a defaulted `runs_on_script_setup()` to the `ScriptRule` trait (default `true`), override it to `false` for `NoTopLevelRefInScript`, and gate the dispatcher's `script_setup` branch on it (net-zero line change). Adds integration tests covering both the `<script setup>` (zero diagnostics) and plain `<script>` (still reports) paths.

Refs #1629