### PR TITLE
feat(patina): add script/no-deprecated-data-object-declaration

### DIFF
--- a/crates/vize_patina/src/linter/script_rules/registry/names.rs
+++ b/crates/vize_patina/src/linter/script_rules/registry/names.rs
@@ -42,6 +42,8 @@ pub(crate) const RULE_NO_POTENTIAL_COMPONENT_OPTION_TYPO: &str =
 pub(crate) const RULE_RETURN_IN_COMPUTED_PROPERTY: &str = "script/return-in-computed-property";
 pub(crate) const RULE_NO_DEPRECATED_DOLLAR_SCOPEDSLOTS_API: &str =
     "script/no-deprecated-dollar-scopedslots-api";
+pub(crate) const RULE_NO_DEPRECATED_DATA_OBJECT_DECLARATION: &str =
+    "script/no-deprecated-data-object-declaration";
 
 pub(in crate::linter::script_rules) const ALL_BUILTIN_SCRIPT_RULE_NAMES: &[&str] = &[
     RULE_NO_OPTIONS_API,
@@ -75,6 +77,7 @@ pub(in crate::linter::script_rules) const ALL_BUILTIN_SCRIPT_RULE_NAMES: &[&str]
     RULE_NO_POTENTIAL_COMPONENT_OPTION_TYPO,
     RULE_RETURN_IN_COMPUTED_PROPERTY,
     RULE_NO_DEPRECATED_DOLLAR_SCOPEDSLOTS_API,
+    RULE_NO_DEPRECATED_DATA_OBJECT_DECLARATION,
 ];
 
 #[cfg(test)]
@@ -107,4 +110,5 @@ pub(in crate::linter::script_rules) const OPT_IN_SCRIPT_RULE_NAMES: &[&str] = &[
     RULE_NO_POTENTIAL_COMPONENT_OPTION_TYPO,
     RULE_RETURN_IN_COMPUTED_PROPERTY,
     RULE_NO_DEPRECATED_DOLLAR_SCOPEDSLOTS_API,
+    RULE_NO_DEPRECATED_DATA_OBJECT_DECLARATION,
 ];

--- a/crates/vize_patina/src/linter/script_rules/registry/rules.rs
+++ b/crates/vize_patina/src/linter/script_rules/registry/rules.rs
@@ -11,11 +11,10 @@
 use super::names::{
     RULE_NO_ARROW_FUNCTIONS_IN_WATCH, RULE_NO_ASYNC_IN_COMPUTED, RULE_NO_DEEP_DESTRUCTURE_IN_PROPS,
     RULE_NO_DEPRECATED_DATA_OBJECT_DECLARATION, RULE_NO_DEPRECATED_DOLLAR_LISTENERS_API,
-    RULE_NO_DEPRECATED_DOLLAR_SCOPEDSLOTS_API,
-    RULE_NO_DUPE_KEYS, RULE_NO_EXPORT_IN_SCRIPT_SETUP, RULE_NO_GET_CURRENT_INSTANCE,
-    RULE_NO_IMPORT_COMPILER_MACROS, RULE_NO_INTERNAL_IMPORTS, RULE_NO_NEXT_TICK,
-    RULE_NO_OPTIONS_API, RULE_NO_POTENTIAL_COMPONENT_OPTION_TYPO, RULE_NO_REACTIVE_DESTRUCTURE,
-    RULE_NO_RESERVED_IDENTIFIERS, RULE_NO_SIDE_EFFECTS_IN_COMPUTED,
+    RULE_NO_DEPRECATED_DOLLAR_SCOPEDSLOTS_API, RULE_NO_DUPE_KEYS, RULE_NO_EXPORT_IN_SCRIPT_SETUP,
+    RULE_NO_GET_CURRENT_INSTANCE, RULE_NO_IMPORT_COMPILER_MACROS, RULE_NO_INTERNAL_IMPORTS,
+    RULE_NO_NEXT_TICK, RULE_NO_OPTIONS_API, RULE_NO_POTENTIAL_COMPONENT_OPTION_TYPO,
+    RULE_NO_REACTIVE_DESTRUCTURE, RULE_NO_RESERVED_IDENTIFIERS, RULE_NO_SIDE_EFFECTS_IN_COMPUTED,
     RULE_NO_TOP_LEVEL_REF_IN_SCRIPT, RULE_NO_WITH_DEFAULTS, RULE_PINIA_PREFER_STORE_TO_REFS,
     RULE_PREFER_COMPUTED, RULE_PREFER_IMPORT_FROM_VUE, RULE_PREFER_REF_OVER_REACTIVE,
     RULE_PREFER_USE_ATTRS, RULE_PREFER_USE_ID, RULE_PREFER_USE_SLOTS, RULE_PREFER_USE_TEMPLATE_REF,
@@ -30,14 +29,13 @@ use super::{
 use crate::rules::script::{
     NoArrowFunctionsInWatch, NoAsyncInComputed, NoDeepDestructureInProps,
     NoDeprecatedDataObjectDeclaration, NoDeprecatedDollarListenersApi,
-    NoDeprecatedDollarScopedSlotsApi, NoDupeKeys,
-    NoExportInScriptSetup, NoGetCurrentInstance, NoImportCompilerMacros, NoInternalImports,
-    NoNextTick, NoOptionsApi, NoPotentialComponentOptionTypo, NoReactiveDestructure,
-    NoReservedIdentifiers, NoSideEffectsInComputed, NoTopLevelRefInScript, NoWithDefaults,
-    PiniaPreferStoreToRefs, PreferComputed, PreferImportFromVue, PreferRefOverReactive,
-    PreferUseAttrs, PreferUseId, PreferUseSlots, PreferUseTemplateRef, RequireFunctionReturnType,
-    RequireSymbolProvide, ReturnInComputedProperty, VueRouterPreferNamedPush,
-    VueTestUtilsNoHtmlSnapshot,
+    NoDeprecatedDollarScopedSlotsApi, NoDupeKeys, NoExportInScriptSetup, NoGetCurrentInstance,
+    NoImportCompilerMacros, NoInternalImports, NoNextTick, NoOptionsApi,
+    NoPotentialComponentOptionTypo, NoReactiveDestructure, NoReservedIdentifiers,
+    NoSideEffectsInComputed, NoTopLevelRefInScript, NoWithDefaults, PiniaPreferStoreToRefs,
+    PreferComputed, PreferImportFromVue, PreferRefOverReactive, PreferUseAttrs, PreferUseId,
+    PreferUseSlots, PreferUseTemplateRef, RequireFunctionReturnType, RequireSymbolProvide,
+    ReturnInComputedProperty, VueRouterPreferNamedPush, VueTestUtilsNoHtmlSnapshot,
 };
 
 static NO_DEEP_DESTRUCTURE_IN_PROPS_RULE: NoDeepDestructureInProps =

--- a/crates/vize_patina/src/linter/script_rules/registry/rules.rs
+++ b/crates/vize_patina/src/linter/script_rules/registry/rules.rs
@@ -10,7 +10,8 @@
 
 use super::names::{
     RULE_NO_ARROW_FUNCTIONS_IN_WATCH, RULE_NO_ASYNC_IN_COMPUTED, RULE_NO_DEEP_DESTRUCTURE_IN_PROPS,
-    RULE_NO_DEPRECATED_DOLLAR_LISTENERS_API, RULE_NO_DEPRECATED_DOLLAR_SCOPEDSLOTS_API,
+    RULE_NO_DEPRECATED_DATA_OBJECT_DECLARATION, RULE_NO_DEPRECATED_DOLLAR_LISTENERS_API,
+    RULE_NO_DEPRECATED_DOLLAR_SCOPEDSLOTS_API,
     RULE_NO_DUPE_KEYS, RULE_NO_EXPORT_IN_SCRIPT_SETUP, RULE_NO_GET_CURRENT_INSTANCE,
     RULE_NO_IMPORT_COMPILER_MACROS, RULE_NO_INTERNAL_IMPORTS, RULE_NO_NEXT_TICK,
     RULE_NO_OPTIONS_API, RULE_NO_POTENTIAL_COMPONENT_OPTION_TYPO, RULE_NO_REACTIVE_DESTRUCTURE,
@@ -28,7 +29,8 @@ use super::{
 };
 use crate::rules::script::{
     NoArrowFunctionsInWatch, NoAsyncInComputed, NoDeepDestructureInProps,
-    NoDeprecatedDollarListenersApi, NoDeprecatedDollarScopedSlotsApi, NoDupeKeys,
+    NoDeprecatedDataObjectDeclaration, NoDeprecatedDollarListenersApi,
+    NoDeprecatedDollarScopedSlotsApi, NoDupeKeys,
     NoExportInScriptSetup, NoGetCurrentInstance, NoImportCompilerMacros, NoInternalImports,
     NoNextTick, NoOptionsApi, NoPotentialComponentOptionTypo, NoReactiveDestructure,
     NoReservedIdentifiers, NoSideEffectsInComputed, NoTopLevelRefInScript, NoWithDefaults,
@@ -294,5 +296,13 @@ pub(in crate::linter::script_rules) static BUILTIN_SCRIPT_RULES: &[BuiltinScript
         fixable: false,
         presets: OPT_IN_SCRIPT_PRESETS,
         rule: &NoDeprecatedDollarScopedSlotsApi,
+    },
+    BuiltinScriptRuleEntry {
+        rule_name: RULE_NO_DEPRECATED_DATA_OBJECT_DECLARATION,
+        profile_name: "patina.script_rule.no_deprecated_data_object_declaration",
+        category: "Script",
+        fixable: false,
+        presets: OPT_IN_SCRIPT_PRESETS,
+        rule: &NoDeprecatedDataObjectDeclaration,
     },
 ];

--- a/crates/vize_patina/src/rules/script.rs
+++ b/crates/vize_patina/src/rules/script.rs
@@ -24,6 +24,7 @@
 mod no_arrow_functions_in_watch;
 mod no_async_in_computed;
 mod no_deep_destructure_in_props;
+mod no_deprecated_data_object_declaration;
 mod no_deprecated_dollar_listeners_api;
 mod no_deprecated_dollar_scopedslots_api;
 mod no_dupe_keys;
@@ -65,6 +66,7 @@ use vize_carton::profile;
 pub use no_arrow_functions_in_watch::NoArrowFunctionsInWatch;
 pub use no_async_in_computed::NoAsyncInComputed;
 pub use no_deep_destructure_in_props::NoDeepDestructureInProps;
+pub use no_deprecated_data_object_declaration::NoDeprecatedDataObjectDeclaration;
 pub use no_deprecated_dollar_listeners_api::NoDeprecatedDollarListenersApi;
 pub use no_deprecated_dollar_scopedslots_api::NoDeprecatedDollarScopedSlotsApi;
 pub use no_dupe_keys::NoDupeKeys;

--- a/crates/vize_patina/src/rules/script/no_deprecated_data_object_declaration.rs
+++ b/crates/vize_patina/src/rules/script/no_deprecated_data_object_declaration.rs
@@ -1,0 +1,243 @@
+//! script/no-deprecated-data-object-declaration
+//!
+//! Disallow an object literal as the component `data` option.
+//!
+//! In Vue 2 a component's `data` option could be declared either as a function
+//! returning the initial state or, for a root instance, as a plain object
+//! literal. Vue 3 dropped the object-literal form: component `data` must be a
+//! function so each instance receives a fresh state object and instances do not
+//! share (and mutate) the same reactive object. Declaring `data` as an object
+//! literal is therefore a Vue 2 -> 3 migration hazard.
+//!
+//! This is a port of the object-literal half of
+//! [`vue/no-deprecated-data-object-declaration`](https://eslint.vuejs.org/rules/no-deprecated-data-object-declaration.html)
+//! from eslint-plugin-vue: it flags `data` declared as an `ObjectExpression`
+//! and leaves the function forms (`data() {}`, `data: function () {}`,
+//! `data: () => ({})`) alone.
+//!
+//! ## Examples
+//!
+//! ### Invalid
+//! ```ts
+//! export default {
+//!   // `data` must be a function in Vue 3, not an object literal.
+//!   data: {
+//!     count: 0
+//!   }
+//! }
+//! ```
+//!
+//! ### Valid
+//! ```ts
+//! export default {
+//!   data() {
+//!     return { count: 0 }
+//!   }
+//! }
+//! ```
+
+use super::{ScriptLintResult, ScriptRule, ScriptRuleMeta};
+use crate::diagnostic::{LintDiagnostic, Severity};
+use oxc_ast::ast::{
+    Argument, BindingPattern, CallExpression, ExportDefaultDeclarationKind, Expression,
+    ObjectExpression, ObjectPropertyKind, Program, PropertyKey, Statement,
+};
+use oxc_span::Span;
+use vize_carton::FxHashMap;
+
+static META: ScriptRuleMeta = ScriptRuleMeta {
+    name: "script/no-deprecated-data-object-declaration",
+    description: "Disallow an object literal as the component data option (Vue 3 requires a function)",
+    default_severity: Severity::Error,
+};
+
+/// Disallow an object literal as the component `data` option.
+pub struct NoDeprecatedDataObjectDeclaration;
+
+impl ScriptRule for NoDeprecatedDataObjectDeclaration {
+    fn meta(&self) -> &'static ScriptRuleMeta {
+        &META
+    }
+
+    #[inline]
+    fn uses_ast(&self) -> bool {
+        true
+    }
+
+    #[inline]
+    fn check_program<'a>(
+        &self,
+        program: &'a Program<'a>,
+        _source: &str,
+        offset: usize,
+        result: &mut ScriptLintResult,
+    ) {
+        let Some(options) = find_component_options(program) else {
+            return;
+        };
+        let Some(data) = find_data_object_literal(options) else {
+            return;
+        };
+        report(data, offset, result);
+    }
+}
+
+/// The object-literal value of the `data` option, if `data` is declared as a
+/// plain object (`data: { ... }`) rather than a function.
+fn find_data_object_literal<'a>(
+    options: &'a ObjectExpression<'a>,
+) -> Option<&'a ObjectExpression<'a>> {
+    for property in &options.properties {
+        let ObjectPropertyKind::ObjectProperty(property) = property else {
+            continue;
+        };
+        if property.computed {
+            continue;
+        }
+        // A method shorthand (`data() {}`) parses as an ObjectProperty whose
+        // value is a FunctionExpression, so it is naturally excluded by the
+        // `ObjectExpression` match below.
+        if matches!(property_key_name(&property.key), Some("data"))
+            && let Expression::ObjectExpression(object) = &property.value
+        {
+            return Some(object);
+        }
+    }
+    None
+}
+
+fn report(data: &ObjectExpression<'_>, offset: usize, result: &mut ScriptLintResult) {
+    let span: Span = data.span;
+    let start = offset as u32 + span.start;
+    let end = offset as u32 + span.end;
+    let diagnostic = LintDiagnostic::error(
+        META.name,
+        "Object declaration on `data` is deprecated. Use a function that returns the object instead.",
+        start,
+        end,
+    )
+    .with_label("`data` is declared as an object literal", start, end)
+    .with_help(
+        "Vue 3 requires the component `data` option to be a function so each \
+         instance gets a fresh state object. Wrap the object in a function, e.g. \
+         `data() { return { count: 0 } }`.",
+    );
+    result.add_diagnostic(diagnostic);
+}
+
+fn property_key_name<'a>(key: &'a PropertyKey<'a>) -> Option<&'a str> {
+    match key {
+        PropertyKey::StaticIdentifier(id) => Some(id.name.as_str()),
+        PropertyKey::StringLiteral(string) => Some(string.value.as_str()),
+        _ => None,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Component options resolution (export default / defineComponent).
+//
+// Mirrors the resolution in `no_arrow_functions_in_watch` / `no_dupe_keys`: a
+// plain object, an identifier bound to one, or a `defineComponent(...)` wrapper,
+// optionally through TS expression wrappers.
+// ---------------------------------------------------------------------------
+
+fn find_component_options<'a>(program: &'a Program<'a>) -> Option<&'a ObjectExpression<'a>> {
+    let mut bindings: FxHashMap<&'a str, &'a ObjectExpression<'a>> = FxHashMap::default();
+
+    for statement in program.body.iter() {
+        let Statement::VariableDeclaration(declaration) = statement else {
+            continue;
+        };
+        for declarator in &declaration.declarations {
+            let Some(init) = declarator.init.as_ref() else {
+                continue;
+            };
+            if let BindingPattern::BindingIdentifier(id) = &declarator.id
+                && let Some(object) = options_from_expression(init, &bindings)
+            {
+                bindings.insert(id.name.as_str(), object);
+            }
+        }
+    }
+
+    for statement in program.body.iter() {
+        let Statement::ExportDefaultDeclaration(export) = statement else {
+            continue;
+        };
+        if let Some(object) = options_from_export(&export.declaration, &bindings) {
+            return Some(object);
+        }
+    }
+
+    None
+}
+
+fn options_from_export<'a>(
+    declaration: &'a ExportDefaultDeclarationKind<'a>,
+    bindings: &FxHashMap<&'a str, &'a ObjectExpression<'a>>,
+) -> Option<&'a ObjectExpression<'a>> {
+    match declaration {
+        ExportDefaultDeclarationKind::ObjectExpression(object) => Some(object),
+        ExportDefaultDeclarationKind::CallExpression(call) => options_from_call(call, bindings),
+        ExportDefaultDeclarationKind::Identifier(identifier) => {
+            bindings.get(identifier.name.as_str()).copied()
+        }
+        ExportDefaultDeclarationKind::ParenthesizedExpression(paren) => {
+            options_from_expression(&paren.expression, bindings)
+        }
+        ExportDefaultDeclarationKind::TSAsExpression(ts_as) => {
+            options_from_expression(&ts_as.expression, bindings)
+        }
+        ExportDefaultDeclarationKind::TSSatisfiesExpression(ts_satisfies) => {
+            options_from_expression(&ts_satisfies.expression, bindings)
+        }
+        ExportDefaultDeclarationKind::TSNonNullExpression(ts_non_null) => {
+            options_from_expression(&ts_non_null.expression, bindings)
+        }
+        _ => None,
+    }
+}
+
+fn options_from_expression<'a>(
+    expression: &'a Expression<'a>,
+    bindings: &FxHashMap<&'a str, &'a ObjectExpression<'a>>,
+) -> Option<&'a ObjectExpression<'a>> {
+    match expression {
+        Expression::ObjectExpression(object) => Some(object),
+        Expression::CallExpression(call) => options_from_call(call, bindings),
+        Expression::Identifier(identifier) => bindings.get(identifier.name.as_str()).copied(),
+        Expression::ParenthesizedExpression(paren) => {
+            options_from_expression(&paren.expression, bindings)
+        }
+        Expression::TSAsExpression(ts_as) => options_from_expression(&ts_as.expression, bindings),
+        Expression::TSSatisfiesExpression(ts_satisfies) => {
+            options_from_expression(&ts_satisfies.expression, bindings)
+        }
+        Expression::TSNonNullExpression(ts_non_null) => {
+            options_from_expression(&ts_non_null.expression, bindings)
+        }
+        _ => None,
+    }
+}
+
+fn options_from_call<'a>(
+    call: &'a CallExpression<'a>,
+    bindings: &FxHashMap<&'a str, &'a ObjectExpression<'a>>,
+) -> Option<&'a ObjectExpression<'a>> {
+    let Expression::Identifier(callee) = &call.callee else {
+        return None;
+    };
+    if !matches!(callee.name.as_str(), "defineComponent" | "_defineComponent") {
+        return None;
+    }
+    match call.arguments.first()? {
+        Argument::ObjectExpression(object) => Some(object),
+        Argument::Identifier(identifier) => bindings.get(identifier.name.as_str()).copied(),
+        argument => argument
+            .as_expression()
+            .and_then(|expression| options_from_expression(expression, bindings)),
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/vize_patina/src/rules/script/no_deprecated_data_object_declaration/snapshots/vize_patina__rules__script__no_deprecated_data_object_declaration__tests__invalid_empty_object_literal_data.snap
+++ b/crates/vize_patina/src/rules/script/no_deprecated_data_object_declaration/snapshots/vize_patina__rules__script__no_deprecated_data_object_declaration__tests__invalid_empty_object_literal_data.snap
@@ -1,0 +1,24 @@
+---
+source: crates/vize_patina/src/rules/script/no_deprecated_data_object_declaration/tests.rs
+expression: result.diagnostics
+---
+[
+    LintDiagnostic {
+        rule_name: "script/no-deprecated-data-object-declaration",
+        severity: Error,
+        message: "Object declaration on `data` is deprecated. Use a function that returns the object instead.",
+        start: 26,
+        end: 28,
+        help: Some(
+            "Vue 3 requires the component `data` option to be a function so each instance gets a fresh state object. Wrap the object in a function, e.g. `data() { return { count: 0 } }`.",
+        ),
+        labels: [
+            Label {
+                message: "`data` is declared as an object literal",
+                start: 26,
+                end: 28,
+            },
+        ],
+        fix: None,
+    },
+]

--- a/crates/vize_patina/src/rules/script/no_deprecated_data_object_declaration/snapshots/vize_patina__rules__script__no_deprecated_data_object_declaration__tests__invalid_object_literal_data.snap
+++ b/crates/vize_patina/src/rules/script/no_deprecated_data_object_declaration/snapshots/vize_patina__rules__script__no_deprecated_data_object_declaration__tests__invalid_object_literal_data.snap
@@ -1,0 +1,24 @@
+---
+source: crates/vize_patina/src/rules/script/no_deprecated_data_object_declaration/tests.rs
+expression: result.diagnostics
+---
+[
+    LintDiagnostic {
+        rule_name: "script/no-deprecated-data-object-declaration",
+        severity: Error,
+        message: "Object declaration on `data` is deprecated. Use a function that returns the object instead.",
+        start: 26,
+        end: 44,
+        help: Some(
+            "Vue 3 requires the component `data` option to be a function so each instance gets a fresh state object. Wrap the object in a function, e.g. `data() { return { count: 0 } }`.",
+        ),
+        labels: [
+            Label {
+                message: "`data` is declared as an object literal",
+                start: 26,
+                end: 44,
+            },
+        ],
+        fix: None,
+    },
+]

--- a/crates/vize_patina/src/rules/script/no_deprecated_data_object_declaration/tests.rs
+++ b/crates/vize_patina/src/rules/script/no_deprecated_data_object_declaration/tests.rs
@@ -1,0 +1,200 @@
+use super::NoDeprecatedDataObjectDeclaration;
+use crate::rules::script::ScriptLinter;
+
+fn create_linter() -> ScriptLinter {
+    let mut linter = ScriptLinter::new();
+    linter.add_rule(Box::new(NoDeprecatedDataObjectDeclaration));
+    linter
+}
+
+#[test]
+fn test_valid_data_method_shorthand() {
+    let source = r#"
+export default {
+  data() {
+    return { count: 0 }
+  }
+}
+"#;
+    let result = create_linter().lint(source, 0);
+    assert_eq!(result.error_count, 0);
+}
+
+#[test]
+fn test_valid_data_function_expression() {
+    let source = r#"
+export default {
+  data: function () {
+    return { count: 0 }
+  }
+}
+"#;
+    let result = create_linter().lint(source, 0);
+    assert_eq!(result.error_count, 0);
+}
+
+#[test]
+fn test_valid_data_arrow_function() {
+    let source = r#"
+export default {
+  data: () => ({ count: 0 })
+}
+"#;
+    let result = create_linter().lint(source, 0);
+    assert_eq!(result.error_count, 0);
+}
+
+#[test]
+fn test_valid_no_data_option() {
+    let source = r#"
+export default {
+  computed: {
+    doubled() { return this.count * 2 }
+  }
+}
+"#;
+    let result = create_linter().lint(source, 0);
+    assert_eq!(result.error_count, 0);
+}
+
+#[test]
+fn test_valid_no_options_object() {
+    let source = r#"
+import { ref } from 'vue'
+const count = ref(0)
+"#;
+    let result = create_linter().lint(source, 0);
+    assert_eq!(result.error_count, 0);
+}
+
+#[test]
+fn test_valid_data_is_identifier_reference() {
+    // `data` referencing a variable is not an inline object literal; this rule
+    // only flags object literals declared directly on the option.
+    let source = r#"
+const initialData = { count: 0 }
+export default {
+  data: initialData
+}
+"#;
+    let result = create_linter().lint(source, 0);
+    assert_eq!(result.error_count, 0);
+}
+
+#[test]
+fn test_invalid_object_literal_data() {
+    let source = r#"
+export default {
+  data: {
+    count: 0
+  }
+}
+"#;
+    let result = create_linter().lint(source, 0);
+    assert_eq!(result.error_count, 1);
+    insta::assert_debug_snapshot!(result.diagnostics);
+}
+
+#[test]
+fn test_invalid_empty_object_literal_data() {
+    let source = r#"
+export default {
+  data: {}
+}
+"#;
+    let result = create_linter().lint(source, 0);
+    assert_eq!(result.error_count, 1);
+    insta::assert_debug_snapshot!(result.diagnostics);
+}
+
+#[test]
+fn test_invalid_define_component_object_data() {
+    let source = r#"
+import { defineComponent } from 'vue'
+
+export default defineComponent({
+  data: {
+    count: 0
+  }
+})
+"#;
+    let result = create_linter().lint(source, 0);
+    assert_eq!(result.error_count, 1);
+}
+
+#[test]
+fn test_invalid_identifier_bound_options_object_data() {
+    let source = r#"
+const component = {
+  data: {
+    count: 0
+  }
+}
+
+export default component
+"#;
+    let result = create_linter().lint(source, 0);
+    assert_eq!(result.error_count, 1);
+}
+
+#[test]
+fn test_invalid_ts_satisfies_wrapped_options() {
+    let source = r#"
+export default {
+  data: {
+    count: 0
+  }
+} satisfies ComponentOptions
+"#;
+    let result = create_linter().lint(source, 0);
+    assert_eq!(result.error_count, 1);
+}
+
+#[test]
+fn test_invalid_string_key_data() {
+    let source = r#"
+export default {
+  'data': {
+    count: 0
+  }
+}
+"#;
+    let result = create_linter().lint(source, 0);
+    assert_eq!(result.error_count, 1);
+}
+
+#[test]
+fn test_computed_key_data_ignored() {
+    // A computed key is not statically the `data` option, so it is not flagged.
+    let source = r#"
+const key = 'data'
+export default {
+  [key]: {
+    count: 0
+  }
+}
+"#;
+    let result = create_linter().lint(source, 0);
+    assert_eq!(result.error_count, 0);
+}
+
+#[test]
+fn test_only_data_reported_among_other_object_options() {
+    // Other object-valued options (computed, methods, watch) are not `data` and
+    // must not be flagged; only the object-literal `data` is reported.
+    let source = r#"
+export default {
+  computed: {
+    doubled() { return 0 }
+  },
+  data: {
+    count: 0
+  },
+  methods: {
+    inc() {}
+  }
+}
+"#;
+    let result = create_linter().lint(source, 0);
+    assert_eq!(result.error_count, 1);
+}

--- a/crates/vize_patina/src/snapshots/vize_patina__preset__tests__lint_preset_rule_membership.snap
+++ b/crates/vize_patina/src/snapshots/vize_patina__preset__tests__lint_preset_rule_membership.snap
@@ -550,6 +550,7 @@ expression: "serde_json::to_string_pretty(&snapshot).unwrap()"
     "script/no-deprecated-dollar-listeners-api",
     "script/no-potential-component-option-typo",
     "script/return-in-computed-property",
-    "script/no-deprecated-dollar-scopedslots-api"
+    "script/no-deprecated-dollar-scopedslots-api",
+    "script/no-deprecated-data-object-declaration"
   ]
 }

--- a/npm/vize/src/types/rules.ts
+++ b/npm/vize/src/types/rules.ts
@@ -68,6 +68,7 @@ export const LINT_RULE_NAMES = [
   "script/no-arrow-functions-in-watch",
   "script/no-async-in-computed",
   "script/no-deep-destructure-in-props",
+  "script/no-deprecated-data-object-declaration",
   "script/no-deprecated-dollar-listeners-api",
   "script/no-deprecated-dollar-scopedslots-api",
   "script/no-dupe-keys",


### PR DESCRIPTION
Part of #1629. New Vue script rule (oxc AST), registered via the growable script-rule registry; snapshot + rules.ts regenerated.