### PR TITLE
feat(patina): add script/require-valid-default-prop

### DIFF
--- a/crates/vize_patina/src/linter/script_rules/registry/names.rs
+++ b/crates/vize_patina/src/linter/script_rules/registry/names.rs
@@ -67,6 +67,7 @@ pub(crate) const RULE_REQUIRE_PROP_TYPES: &str = "script/require-prop-types";
 pub(crate) const RULE_NO_RESERVED_PROPS: &str = "script/no-reserved-props";
 pub(crate) const RULE_NO_UNUSED_EMIT_DECLARATIONS: &str = "script/no-unused-emit-declarations";
 pub(crate) const RULE_RETURN_IN_EMITS_VALIDATOR: &str = "script/return-in-emits-validator";
+pub(crate) const RULE_REQUIRE_VALID_DEFAULT_PROP: &str = "script/require-valid-default-prop";
 
 pub(in crate::linter::script_rules) const ALL_BUILTIN_SCRIPT_RULE_NAMES: &[&str] = &[
     RULE_NO_OPTIONS_API,
@@ -122,6 +123,7 @@ pub(in crate::linter::script_rules) const ALL_BUILTIN_SCRIPT_RULE_NAMES: &[&str]
     RULE_NO_RESERVED_PROPS,
     RULE_NO_UNUSED_EMIT_DECLARATIONS,
     RULE_RETURN_IN_EMITS_VALIDATOR,
+    RULE_REQUIRE_VALID_DEFAULT_PROP,
 ];
 
 #[cfg(test)]
@@ -176,4 +178,5 @@ pub(in crate::linter::script_rules) const OPT_IN_SCRIPT_RULE_NAMES: &[&str] = &[
     RULE_NO_RESERVED_PROPS,
     RULE_NO_UNUSED_EMIT_DECLARATIONS,
     RULE_RETURN_IN_EMITS_VALIDATOR,
+    RULE_REQUIRE_VALID_DEFAULT_PROP,
 ];

--- a/crates/vize_patina/src/linter/script_rules/registry/rules.rs
+++ b/crates/vize_patina/src/linter/script_rules/registry/rules.rs
@@ -20,9 +20,9 @@ use super::names::{
     RULE_PREFER_USE_ATTRS, RULE_PREFER_USE_ID, RULE_PREFER_USE_SLOTS, RULE_PREFER_USE_TEMPLATE_REF,
     RULE_REQUIRE_DEFAULT_PROP, RULE_REQUIRE_FUNCTION_RETURN_TYPE,
     RULE_REQUIRE_PROP_TYPE_CONSTRUCTOR, RULE_REQUIRE_PROP_TYPES, RULE_REQUIRE_SYMBOL_PROVIDE,
-    RULE_REQUIRE_TYPED_REF, RULE_RETURN_IN_COMPUTED_PROPERTY, RULE_RETURN_IN_EMITS_VALIDATOR,
-    RULE_VALID_DEFINE_OPTIONS, RULE_VALID_NEXT_TICK, RULE_VUE_ROUTER_PREFER_NAMED_PUSH,
-    RULE_VUE_TEST_UTILS_NO_HTML_SNAPSHOT,
+    RULE_REQUIRE_TYPED_REF, RULE_REQUIRE_VALID_DEFAULT_PROP, RULE_RETURN_IN_COMPUTED_PROPERTY,
+    RULE_RETURN_IN_EMITS_VALIDATOR, RULE_VALID_DEFINE_OPTIONS, RULE_VALID_NEXT_TICK,
+    RULE_VUE_ROUTER_PREFER_NAMED_PUSH, RULE_VUE_TEST_UTILS_NO_HTML_SNAPSHOT,
 };
 use super::{
     BuiltinScriptRuleEntry, ECOSYSTEM_SCRIPT_PRESETS, OPINIONATED_SCRIPT_PRESETS,
@@ -41,8 +41,8 @@ use crate::rules::script::{
     PreferDefineOptions, PreferImportFromVue, PreferRefOverReactive, PreferUseAttrs, PreferUseId,
     PreferUseSlots, PreferUseTemplateRef, RequireDefaultProp, RequireFunctionReturnType,
     RequirePropTypeConstructor, RequirePropTypes, RequireSymbolProvide, RequireTypedRef,
-    ReturnInComputedProperty, ReturnInEmitsValidator, ValidDefineOptions, ValidNextTick,
-    VueRouterPreferNamedPush, VueTestUtilsNoHtmlSnapshot,
+    RequireValidDefaultProp, ReturnInComputedProperty, ReturnInEmitsValidator, ValidDefineOptions,
+    ValidNextTick, VueRouterPreferNamedPush, VueTestUtilsNoHtmlSnapshot,
 };
 
 static NO_DEEP_DESTRUCTURE_IN_PROPS_RULE: NoDeepDestructureInProps =
@@ -105,4 +105,5 @@ pub(in crate::linter::script_rules) static BUILTIN_SCRIPT_RULES: &[BuiltinScript
     BuiltinScriptRuleEntry { rule_name: RULE_NO_RESERVED_PROPS, profile_name: "patina.script_rule.no_reserved_props", category: "Script", fixable: false, presets: OPINIONATED_SCRIPT_PRESETS, rule: &NoReservedProps },
     BuiltinScriptRuleEntry { rule_name: RULE_NO_UNUSED_EMIT_DECLARATIONS, profile_name: "patina.script_rule.no_unused_emit_declarations", category: "Script", fixable: false, presets: OPINIONATED_SCRIPT_PRESETS, rule: &NoUnusedEmitDeclarations },
     BuiltinScriptRuleEntry { rule_name: RULE_RETURN_IN_EMITS_VALIDATOR, profile_name: "patina.script_rule.return_in_emits_validator", category: "Script", fixable: false, presets: OPINIONATED_SCRIPT_PRESETS, rule: &ReturnInEmitsValidator },
+    BuiltinScriptRuleEntry { rule_name: RULE_REQUIRE_VALID_DEFAULT_PROP, profile_name: "patina.script_rule.require_valid_default_prop", category: "Script", fixable: false, presets: OPINIONATED_SCRIPT_PRESETS, rule: &RequireValidDefaultProp },
 ];

--- a/crates/vize_patina/src/rules/script/props_emits.rs
+++ b/crates/vize_patina/src/rules/script/props_emits.rs
@@ -11,6 +11,7 @@ mod no_unused_emit_declarations;
 mod props_source;
 mod require_default_prop;
 mod require_prop_types;
+mod require_valid_default_prop;
 mod return_in_emits_validator;
 
 pub use no_required_prop_with_default::NoRequiredPropWithDefault;
@@ -18,4 +19,5 @@ pub use no_reserved_props::NoReservedProps;
 pub use no_unused_emit_declarations::NoUnusedEmitDeclarations;
 pub use require_default_prop::RequireDefaultProp;
 pub use require_prop_types::RequirePropTypes;
+pub use require_valid_default_prop::RequireValidDefaultProp;
 pub use return_in_emits_validator::ReturnInEmitsValidator;

--- a/crates/vize_patina/src/rules/script/props_emits/require_valid_default_prop.rs
+++ b/crates/vize_patina/src/rules/script/props_emits/require_valid_default_prop.rs
@@ -1,0 +1,298 @@
+//! script/require-valid-default-prop
+//!
+//! Require a prop's `default` value to be valid for its declared runtime type.
+//!
+//! Vue applies a prop's `default` when the parent omits the prop. The default
+//! must agree with the declared `type`, otherwise the component renders a value
+//! the type contract forbids:
+//!
+//! * a scalar type with a mismatched literal — `type: Number, default: 'x'`,
+//!   `type: Boolean, default: 0` — silently feeds the wrong kind of value, and
+//! * an `Object` / `Array` type with a literal default — `default: {}`,
+//!   `default: []` — shares one mutable instance across every component using
+//!   the component, so Vue requires a **factory function**
+//!   (`default: () => ({})`) instead.
+//!
+//! A function default is always accepted: it is the factory Vue calls per
+//! instance, and its return value cannot be checked statically. A default whose
+//! kind cannot be determined (an identifier, a call expression, …) is left
+//! alone. A prop whose declared `type` is not one of the native constructors
+//! (`String`, `Number`, `Boolean`, `Array`, `Object`, `Function`, `Symbol`,
+//! `BigInt`) — e.g. an imported `PropType` or a custom class — is also skipped,
+//! since its valid defaults cannot be known.
+//!
+//! Covers the Options API object form (`props: { x: { type, default } }`),
+//! including `defineComponent({...})` and same-file identifier-bound
+//! options/props objects, and the `<script setup>` runtime form
+//! `defineProps({ ... })`. The array shorthand and the type-based
+//! `defineProps<{...}>()` form carry no runtime `default` and are not checked.
+//!
+//! Port of [`vue/require-valid-default-prop`](https://eslint.vuejs.org/rules/require-valid-default-prop.html).
+//!
+//! ## Examples
+//!
+//! ### Invalid
+//! ```ts
+//! export default {
+//!   props: {
+//!     count: { type: Number, default: '0' },     // string default for Number
+//!     enabled: { type: Boolean, default: 1 },     // non-boolean default for Boolean
+//!     items: { type: Array, default: [] },        // literal must be a factory
+//!     config: { type: Object, default: {} }       // literal must be a factory
+//!   }
+//! }
+//! ```
+//!
+//! ### Valid
+//! ```ts
+//! export default {
+//!   props: {
+//!     count: { type: Number, default: 0 },
+//!     enabled: { type: Boolean, default: false },
+//!     items: { type: Array, default: () => [] },
+//!     config: { type: Object, default: () => ({}) },
+//!     label: { type: [String, Number], default: '' }
+//!   }
+//! }
+//! ```
+
+use oxc_ast::ast::{Expression, ObjectExpression, ObjectPropertyKind, Program, PropertyKey};
+use oxc_span::GetSpan;
+
+use vize_carton::CompactString;
+
+use super::super::{ScriptLintResult, ScriptRule, ScriptRuleMeta};
+use super::props_source::{PropDescriptor, collect_runtime_props};
+use crate::diagnostic::{LintDiagnostic, Severity};
+
+static META: ScriptRuleMeta = ScriptRuleMeta {
+    name: "script/require-valid-default-prop",
+    description: "Require a prop's default value to be valid for its declared type",
+    default_severity: Severity::Error,
+};
+
+/// The native constructor types Vue recognizes for runtime prop validation.
+const NATIVE_TYPES: [&str; 8] = [
+    "String", "Number", "Boolean", "Function", "Object", "Array", "Symbol", "BigInt",
+];
+
+/// Declared types whose only acceptable default is a factory function: a literal
+/// `Object`/`Array` would be shared across instances, and a `Function` prop's
+/// value is the function itself.
+const FUNCTION_VALUE_TYPES: [&str; 3] = ["Function", "Object", "Array"];
+
+/// Require a prop's `default` to be valid for its declared type.
+pub struct RequireValidDefaultProp;
+
+impl ScriptRule for RequireValidDefaultProp {
+    fn meta(&self) -> &'static ScriptRuleMeta {
+        &META
+    }
+
+    #[inline]
+    fn uses_ast(&self) -> bool {
+        true
+    }
+
+    fn check_program<'a>(
+        &self,
+        program: &'a Program<'a>,
+        _source: &str,
+        offset: usize,
+        result: &mut ScriptLintResult,
+    ) {
+        for source in collect_runtime_props(program) {
+            for prop in source.object_props() {
+                check_prop(prop, offset, result);
+            }
+        }
+    }
+}
+
+/// The value-type a default expression denotes, mirroring Vue's runtime
+/// `typeof`/constructor check. `None` means the kind cannot be determined
+/// statically (an identifier, a call, …), so no validation is attempted.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum DefaultKind {
+    /// A literal of a native scalar/reference type (`"x"`, `0`, `true`, `[]`,
+    /// `{}`, `1n`).
+    Value(&'static str),
+    /// A function (`function () {}` / `() => …`): the factory Vue calls.
+    Function,
+}
+
+/// Validate the `default` of a single object-descriptor prop against its `type`.
+fn check_prop(prop: PropDescriptor<'_>, offset: usize, result: &mut ScriptLintResult) {
+    // Only an object descriptor can carry both `type` and `default`. A shorthand
+    // value (`name: String`) declares no default, so there is nothing to check.
+    let Expression::ObjectExpression(descriptor) = prop.value else {
+        return;
+    };
+    let Some(default_value) = descriptor_member(descriptor, "default") else {
+        return;
+    };
+    let Some(type_value) = descriptor_member(descriptor, "type") else {
+        return;
+    };
+
+    // The declared native types; non-native types (imported `PropType`, custom
+    // classes) cannot be validated and are skipped.
+    let type_names = native_type_names(type_value);
+    if type_names.is_empty() {
+        return;
+    }
+
+    let Some(default_kind) = default_kind(default_value) else {
+        // Identifier, call expression, etc. — kind unknown, do not guess.
+        return;
+    };
+
+    match default_kind {
+        // A function default is the factory Vue invokes per instance; accept it
+        // for every declared type (its return value is not checked statically).
+        DefaultKind::Function => {}
+        DefaultKind::Value(value_type) => {
+            if type_names.contains(&value_type) && !FUNCTION_VALUE_TYPES.contains(&value_type) {
+                // A scalar literal matching a declared scalar type is valid.
+                return;
+            }
+            // Either a type mismatch, or an `Object`/`Array` literal that must be
+            // a factory function. The expected-type wording maps the
+            // factory-only types to "function".
+            report(prop.name, default_value, &type_names, offset, result);
+        }
+    }
+}
+
+/// The default value's [`DefaultKind`], or `None` if it cannot be determined.
+fn default_kind(expression: &Expression<'_>) -> Option<DefaultKind> {
+    match expression {
+        Expression::StringLiteral(_) | Expression::TemplateLiteral(_) => {
+            Some(DefaultKind::Value("String"))
+        }
+        Expression::NumericLiteral(_) => Some(DefaultKind::Value("Number")),
+        Expression::BooleanLiteral(_) => Some(DefaultKind::Value("Boolean")),
+        Expression::BigIntLiteral(_) => Some(DefaultKind::Value("BigInt")),
+        Expression::ArrayExpression(_) => Some(DefaultKind::Value("Array")),
+        Expression::ObjectExpression(_) => Some(DefaultKind::Value("Object")),
+        Expression::FunctionExpression(_) | Expression::ArrowFunctionExpression(_) => {
+            Some(DefaultKind::Function)
+        }
+        _ => None,
+    }
+}
+
+/// The declared native constructor types of a `type` value: a single
+/// constructor (`Number`) or the native entries of a `[...]` union
+/// (`[String, Number]`). Non-native and non-identifier entries are dropped.
+fn native_type_names(type_value: &Expression<'_>) -> Vec<&'static str> {
+    match type_value {
+        Expression::Identifier(identifier) => {
+            native_type(identifier.name.as_str()).into_iter().collect()
+        }
+        Expression::ArrayExpression(array) => array
+            .elements
+            .iter()
+            .filter_map(|element| match element.as_expression() {
+                Some(Expression::Identifier(identifier)) => native_type(identifier.name.as_str()),
+                _ => None,
+            })
+            .collect(),
+        _ => Vec::new(),
+    }
+}
+
+/// The canonical `'static` spelling of a native constructor name, or `None` if
+/// `name` is not one of Vue's native prop types.
+fn native_type(name: &str) -> Option<&'static str> {
+    NATIVE_TYPES.into_iter().find(|native| *native == name)
+}
+
+/// The value of a named member of a prop-descriptor object, if present.
+fn descriptor_member<'a>(
+    descriptor: &'a ObjectExpression<'a>,
+    key: &str,
+) -> Option<&'a Expression<'a>> {
+    descriptor.properties.iter().find_map(|property| {
+        let ObjectPropertyKind::ObjectProperty(property) = property else {
+            return None;
+        };
+        if property.computed || property_key_name(&property.key) != Some(key) {
+            return None;
+        }
+        Some(&property.value)
+    })
+}
+
+/// Emit the diagnostic for an invalid default, naming the expected type(s).
+///
+/// Factory-only declared types (`Object`/`Array`/`Function`) are reported as
+/// `function`, matching Vue's requirement that they use a factory; other types
+/// are listed verbatim. The set is joined with " or " and lowercased.
+fn report(
+    name: &str,
+    default_value: &Expression<'_>,
+    type_names: &[&'static str],
+    offset: usize,
+    result: &mut ScriptLintResult,
+) {
+    let span = default_value.span();
+    let start = offset as u32 + span.start;
+    let end = offset as u32 + span.end;
+
+    let expected = expected_types(type_names);
+
+    let mut message = CompactString::with_capacity(name.len() + expected.len() + 48);
+    message.push_str("Type of the default value for '");
+    message.push_str(name);
+    message.push_str("' prop must be a ");
+    message.push_str(&expected);
+    message.push('.');
+
+    let mut help = CompactString::with_capacity(expected.len() + 56);
+    help.push_str("Make the default a ");
+    help.push_str(&expected);
+    help.push_str(" (use a factory like `() => ({})` for Object/Array props).");
+
+    let diagnostic = LintDiagnostic::error(META.name, message, start, end)
+        .with_label("default does not match the declared type", start, end)
+        .with_help(help);
+    result.add_diagnostic(diagnostic);
+}
+
+/// The expected-type wording: declared types with the factory-only ones mapped
+/// to `function`, joined with " or " and lowercased (`"string or number"`,
+/// `"function"`).
+fn expected_types(type_names: &[&'static str]) -> CompactString {
+    let mut seen: Vec<&str> = Vec::with_capacity(type_names.len());
+    for name in type_names {
+        let mapped = if FUNCTION_VALUE_TYPES.contains(name) {
+            "function"
+        } else {
+            *name
+        };
+        if !seen.contains(&mapped) {
+            seen.push(mapped);
+        }
+    }
+
+    let mut joined = CompactString::default();
+    for (index, name) in seen.iter().enumerate() {
+        if index > 0 {
+            joined.push_str(" or ");
+        }
+        joined.push_str(name);
+    }
+    joined.to_lowercase()
+}
+
+fn property_key_name<'a>(key: &'a PropertyKey<'a>) -> Option<&'a str> {
+    match key {
+        PropertyKey::StaticIdentifier(identifier) => Some(identifier.name.as_str()),
+        PropertyKey::StringLiteral(string) => Some(string.value.as_str()),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/vize_patina/src/rules/script/props_emits/require_valid_default_prop/snapshots/vize_patina__rules__script__props_emits__require_valid_default_prop__tests__invalid_string_default_for_number.snap
+++ b/crates/vize_patina/src/rules/script/props_emits/require_valid_default_prop/snapshots/vize_patina__rules__script__props_emits__require_valid_default_prop__tests__invalid_string_default_for_number.snap
@@ -1,0 +1,24 @@
+---
+source: crates/vize_patina/src/rules/script/props_emits/require_valid_default_prop/tests.rs
+expression: result.diagnostics
+---
+[
+    LintDiagnostic {
+        rule_name: "script/require-valid-default-prop",
+        severity: Error,
+        message: "Type of the default value for 'count' prop must be a number.",
+        start: 65,
+        end: 68,
+        help: Some(
+            "Make the default a number (use a factory like `() => ({})` for Object/Array props).",
+        ),
+        labels: [
+            Label {
+                message: "default does not match the declared type",
+                start: 65,
+                end: 68,
+            },
+        ],
+        fix: None,
+    },
+]

--- a/crates/vize_patina/src/rules/script/props_emits/require_valid_default_prop/tests.rs
+++ b/crates/vize_patina/src/rules/script/props_emits/require_valid_default_prop/tests.rs
@@ -1,0 +1,335 @@
+use crate::rules::script::RequireValidDefaultProp;
+use crate::rules::script::ScriptLinter;
+
+fn create_linter() -> ScriptLinter {
+    let mut linter = ScriptLinter::new();
+    linter.add_rule(Box::new(RequireValidDefaultProp));
+    linter
+}
+
+#[test]
+fn test_valid_number_default() {
+    let source = r#"
+export default {
+  props: {
+    count: { type: Number, default: 0 }
+  }
+}
+"#;
+    let result = create_linter().lint(source, 0);
+    assert_eq!(result.error_count, 0);
+}
+
+#[test]
+fn test_valid_string_default() {
+    let source = r#"
+export default {
+  props: {
+    label: { type: String, default: 'hi' }
+  }
+}
+"#;
+    let result = create_linter().lint(source, 0);
+    assert_eq!(result.error_count, 0);
+}
+
+#[test]
+fn test_valid_boolean_default() {
+    let source = r#"
+export default {
+  props: {
+    enabled: { type: Boolean, default: false }
+  }
+}
+"#;
+    let result = create_linter().lint(source, 0);
+    assert_eq!(result.error_count, 0);
+}
+
+#[test]
+fn test_valid_object_factory() {
+    let source = r#"
+export default {
+  props: {
+    config: { type: Object, default: () => ({}) }
+  }
+}
+"#;
+    let result = create_linter().lint(source, 0);
+    assert_eq!(result.error_count, 0);
+}
+
+#[test]
+fn test_valid_array_factory() {
+    let source = r#"
+export default {
+  props: {
+    items: { type: Array, default: () => [] }
+  }
+}
+"#;
+    let result = create_linter().lint(source, 0);
+    assert_eq!(result.error_count, 0);
+}
+
+#[test]
+fn test_valid_array_factory_function_expression() {
+    let source = r#"
+export default {
+  props: {
+    items: { type: Array, default: function () { return [] } }
+  }
+}
+"#;
+    let result = create_linter().lint(source, 0);
+    assert_eq!(result.error_count, 0);
+}
+
+#[test]
+fn test_valid_union_type_matching_default() {
+    let source = r#"
+export default {
+  props: {
+    value: { type: [String, Number], default: '' }
+  }
+}
+"#;
+    let result = create_linter().lint(source, 0);
+    assert_eq!(result.error_count, 0);
+}
+
+#[test]
+fn test_valid_no_default() {
+    // No `default` to validate.
+    let source = r#"
+export default {
+  props: {
+    count: { type: Number }
+  }
+}
+"#;
+    let result = create_linter().lint(source, 0);
+    assert_eq!(result.error_count, 0);
+}
+
+#[test]
+fn test_valid_shorthand_type_is_ignored() {
+    // Shorthand has no default to validate.
+    let source = r#"
+export default {
+  props: {
+    count: Number
+  }
+}
+"#;
+    let result = create_linter().lint(source, 0);
+    assert_eq!(result.error_count, 0);
+}
+
+#[test]
+fn test_valid_array_form_is_ignored() {
+    let source = r#"
+export default {
+  props: ['count', 'label']
+}
+"#;
+    let result = create_linter().lint(source, 0);
+    assert_eq!(result.error_count, 0);
+}
+
+#[test]
+fn test_valid_non_native_type_is_ignored() {
+    // An imported/custom type cannot be validated against a literal.
+    let source = r#"
+export default {
+  props: {
+    when: { type: Date, default: makeDate() }
+  }
+}
+"#;
+    let result = create_linter().lint(source, 0);
+    assert_eq!(result.error_count, 0);
+}
+
+#[test]
+fn test_valid_identifier_default_is_ignored() {
+    // The default's kind cannot be determined statically.
+    let source = r#"
+export default {
+  props: {
+    count: { type: Number, default: FALLBACK }
+  }
+}
+"#;
+    let result = create_linter().lint(source, 0);
+    assert_eq!(result.error_count, 0);
+}
+
+#[test]
+fn test_valid_function_default_for_scalar() {
+    // A function default is a factory Vue calls; accepted for any type.
+    let source = r#"
+export default {
+  props: {
+    count: { type: Number, default: () => 0 }
+  }
+}
+"#;
+    let result = create_linter().lint(source, 0);
+    assert_eq!(result.error_count, 0);
+}
+
+#[test]
+fn test_invalid_string_default_for_number() {
+    let source = r#"
+export default {
+  props: {
+    count: { type: Number, default: '0' }
+  }
+}
+"#;
+    let result = create_linter().lint(source, 0);
+    assert_eq!(result.error_count, 1);
+    insta::assert_debug_snapshot!(result.diagnostics);
+}
+
+#[test]
+fn test_invalid_number_default_for_boolean() {
+    let source = r#"
+export default {
+  props: {
+    enabled: { type: Boolean, default: 1 }
+  }
+}
+"#;
+    let result = create_linter().lint(source, 0);
+    assert_eq!(result.error_count, 1);
+}
+
+#[test]
+fn test_invalid_object_literal_default() {
+    let source = r#"
+export default {
+  props: {
+    config: { type: Object, default: {} }
+  }
+}
+"#;
+    let result = create_linter().lint(source, 0);
+    assert_eq!(result.error_count, 1);
+}
+
+#[test]
+fn test_invalid_array_literal_default() {
+    let source = r#"
+export default {
+  props: {
+    items: { type: Array, default: [] }
+  }
+}
+"#;
+    let result = create_linter().lint(source, 0);
+    assert_eq!(result.error_count, 1);
+}
+
+#[test]
+fn test_invalid_boolean_default_for_string() {
+    let source = r#"
+export default {
+  props: {
+    label: { type: String, default: true }
+  }
+}
+"#;
+    let result = create_linter().lint(source, 0);
+    assert_eq!(result.error_count, 1);
+}
+
+#[test]
+fn test_invalid_union_type_no_match() {
+    // Default is Boolean but neither String nor Number is satisfied.
+    let source = r#"
+export default {
+  props: {
+    value: { type: [String, Number], default: true }
+  }
+}
+"#;
+    let result = create_linter().lint(source, 0);
+    assert_eq!(result.error_count, 1);
+}
+
+#[test]
+fn test_define_props_runtime_invalid() {
+    let source = r#"
+const props = defineProps({
+  count: { type: Number, default: '0' }
+})
+"#;
+    let result = create_linter().lint(source, 0);
+    assert_eq!(result.error_count, 1);
+}
+
+#[test]
+fn test_define_props_runtime_valid() {
+    let source = r#"
+const props = defineProps({
+  items: { type: Array, default: () => [] }
+})
+"#;
+    let result = create_linter().lint(source, 0);
+    assert_eq!(result.error_count, 0);
+}
+
+#[test]
+fn test_define_props_type_based_is_ignored() {
+    let source = r#"
+const props = defineProps<{ count?: number }>()
+"#;
+    let result = create_linter().lint(source, 0);
+    assert_eq!(result.error_count, 0);
+}
+
+#[test]
+fn test_define_component_invalid() {
+    let source = r#"
+import { defineComponent } from 'vue'
+
+export default defineComponent({
+  props: {
+    config: { type: Object, default: {} }
+  }
+})
+"#;
+    let result = create_linter().lint(source, 0);
+    assert_eq!(result.error_count, 1);
+}
+
+#[test]
+fn test_multiple_invalid_props_reported() {
+    let source = r#"
+export default {
+  props: {
+    count: { type: Number, default: '0' },
+    items: { type: Array, default: [] },
+    label: { type: String, default: '' },
+    enabled: { type: Boolean, default: true }
+  }
+}
+"#;
+    let result = create_linter().lint(source, 0);
+    assert_eq!(result.error_count, 2);
+}
+
+#[test]
+fn test_no_props_option() {
+    let source = r#"
+export default {
+  data() {
+    return { count: 0 }
+  }
+}
+"#;
+    let result = create_linter().lint(source, 0);
+    assert_eq!(result.error_count, 0);
+}

--- a/crates/vize_patina/src/snapshots/vize_patina__preset__tests__lint_preset_rule_membership.snap
+++ b/crates/vize_patina/src/snapshots/vize_patina__preset__tests__lint_preset_rule_membership.snap
@@ -572,6 +572,7 @@ expression: "serde_json::to_string_pretty(&snapshot).unwrap()"
     "script/require-prop-types",
     "script/no-reserved-props",
     "script/no-unused-emit-declarations",
-    "script/return-in-emits-validator"
+    "script/return-in-emits-validator",
+    "script/require-valid-default-prop"
   ]
 }

--- a/npm/vize/src/types/rules.ts
+++ b/npm/vize/src/types/rules.ts
@@ -111,6 +111,7 @@ export const LINT_RULE_NAMES = [
   "script/require-prop-types",
   "script/require-symbol-provide",
   "script/require-typed-ref",
+  "script/require-valid-default-prop",
   "script/return-in-computed-property",
   "script/return-in-emits-validator",
   "script/valid-define-options",


### PR DESCRIPTION
Implements `script/require-valid-default-prop` from #1629.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1706"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->