### PR TITLE
feat(patina): add vue/no-bare-strings-in-template

### DIFF
--- a/crates/vize_carton/src/i18n_supplemental_extra.rs
+++ b/crates/vize_carton/src/i18n_supplemental_extra.rs
@@ -174,4 +174,23 @@ static ENTRIES: &[(&str, &str, &str, &str)] = &[
         "オブジェクトを1つにまとめてください。例: :class=\"[{ a }, { b }]\" は :class=\"{ a, b }\" になります。",
         "请将这些对象合并为一个，例如 :class=\"[{ a }, { b }]\" 改为 :class=\"{ a, b }\"。",
     ),
+    // vue/no-bare-strings-in-template
+    (
+        "vue/no-bare-strings-in-template.description",
+        "Disallow raw human-readable text in the template that should be internationalized",
+        "国際化すべきテンプレート内の生の人間可読テキストを禁止する",
+        "禁止在模板中使用应当国际化的原始可读文本",
+    ),
+    (
+        "vue/no-bare-strings-in-template.message",
+        "Raw text should be wrapped in a translation function instead of being written directly in the template",
+        "生のテキストはテンプレートに直接書くのではなく、翻訳関数で囲んでください",
+        "原始文本应使用翻译函数包裹，而不是直接写在模板中",
+    ),
+    (
+        "vue/no-bare-strings-in-template.help",
+        "Move the text into a translation function, e.g. {{ $t('key') }} for content or :title=\"$t('key')\" for an attribute.",
+        "テキストを翻訳関数に移してください。例: 内容には {{ $t('key') }}、属性には :title=\"$t('key')\" を使用します。",
+        "请将文本移入翻译函数，例如内容使用 {{ $t('key') }}，属性使用 :title=\"$t('key')\"。",
+    ),
 ];

--- a/crates/vize_patina/src/rules/vue.rs
+++ b/crates/vize_patina/src/rules/vue.rs
@@ -12,6 +12,7 @@
 // Essential rules
 mod attribute_hyphenation;
 mod attribute_order;
+mod no_bare_strings_in_template;
 mod no_child_content;
 mod no_deprecated_html_element_is;
 mod no_deprecated_router_link_tag_prop;
@@ -87,6 +88,7 @@ mod single_style_block;
 // Essential rules exports
 pub use crate::rules::opinionated::vue::MultiWordComponentNames;
 pub use crate::rules::opinionated::vue::UseVOnExact;
+pub use no_bare_strings_in_template::NoBareStringsInTemplate;
 pub use no_child_content::NoChildContent;
 pub use no_deprecated_html_element_is::NoDeprecatedHtmlElementIs;
 pub use no_deprecated_router_link_tag_prop::NoDeprecatedRouterLinkTagProp;
@@ -220,5 +222,8 @@ pub(crate) fn register_opt_in(registry: &mut crate::rule::RuleRegistry) {
     }
     if !registry.has_rule("vue/no-deprecated-router-link-tag-prop") {
         registry.register(Box::new(NoDeprecatedRouterLinkTagProp));
+    }
+    if !registry.has_rule("vue/no-bare-strings-in-template") {
+        registry.register(Box::new(NoBareStringsInTemplate));
     }
 }

--- a/crates/vize_patina/src/rules/vue/no_bare_strings_in_template.rs
+++ b/crates/vize_patina/src/rules/vue/no_bare_strings_in_template.rs
@@ -45,8 +45,7 @@ use vize_relief::{ElementNode, PropNode, TemplateChildNode};
 
 static META: RuleMeta = RuleMeta {
     name: "vue/no-bare-strings-in-template",
-    description:
-        "Disallow raw human-readable text in the template that should be internationalized",
+    description: "Disallow raw human-readable text in the template that should be internationalized",
     category: RuleCategory::Recommended,
     fixable: false,
     default_severity: Severity::Warning,

--- a/crates/vize_patina/src/rules/vue/no_bare_strings_in_template.rs
+++ b/crates/vize_patina/src/rules/vue/no_bare_strings_in_template.rs
@@ -1,0 +1,249 @@
+//! vue/no-bare-strings-in-template
+//!
+//! Disallow raw (bare) human-readable text in the template that should be
+//! internationalized.
+//!
+//! Raw text written directly in a template — whether as an element's text
+//! content or inside a user-facing attribute such as `title`, `alt`,
+//! `placeholder`, or `aria-label` — bakes a single language into the markup. In
+//! an internationalized application that text should instead flow through a
+//! translation function (e.g. `{{ $t('...') }}` / `:title="$t('...')"`).
+//!
+//! To stay conservative this rule only reports text that contains an actual
+//! letter (any Unicode alphabetic character). Whitespace-, punctuation-, symbol-
+//! and number-only text (`-`, `|`, `/`, `123`, `&nbsp;`, …) is ignored, as are
+//! mustache interpolations `{{ }}` (already dynamic), bound attributes
+//! (`:title="..."`), and the content of `<script>` / `<style>` blocks.
+//!
+//! Mirrors eslint's `vue/no-bare-strings-in-template` (with its default target
+//! attributes). It is opt-in: it only runs when a project explicitly enables the
+//! i18n rule set.
+//!
+//! ## Examples
+//!
+//! ### Invalid
+//! ```vue
+//! <div>hello</div>
+//! <img alt="a cat" />
+//! <input placeholder="Search" />
+//! <button title="Close">x</button>
+//! ```
+//!
+//! ### Valid
+//! ```vue
+//! <div>{{ $t('hello') }}</div>
+//! <img :alt="$t('cat')" />
+//! <div>-</div>
+//! <div>123</div>
+//! <button :title="$t('close')">{{ $t('x') }}</button>
+//! ```
+
+use crate::context::LintContext;
+use crate::diagnostic::Severity;
+use crate::rule::{Rule, RuleCategory, RuleMeta};
+use vize_relief::{ElementNode, PropNode, TemplateChildNode};
+
+static META: RuleMeta = RuleMeta {
+    name: "vue/no-bare-strings-in-template",
+    description:
+        "Disallow raw human-readable text in the template that should be internationalized",
+    category: RuleCategory::Recommended,
+    fixable: false,
+    default_severity: Severity::Warning,
+};
+
+/// Attribute names whose raw string value is user-facing and should be
+/// internationalized. Matches eslint `vue/no-bare-strings-in-template`'s default
+/// target attributes.
+const TARGET_ATTRIBUTES: &[&str] = &[
+    "alt",
+    "title",
+    "placeholder",
+    "aria-label",
+    "aria-placeholder",
+    "aria-roledescription",
+    "aria-valuetext",
+];
+
+/// Disallow raw human-readable text directly in the template.
+pub struct NoBareStringsInTemplate;
+
+impl Rule for NoBareStringsInTemplate {
+    fn meta(&self) -> &'static RuleMeta {
+        &META
+    }
+
+    fn enter_element<'a>(&self, ctx: &mut LintContext<'a>, element: &ElementNode<'a>) {
+        // The content of <script>/<style> is code/CSS, never user-facing copy.
+        if is_raw_text_element(element.tag.as_str()) {
+            return;
+        }
+
+        // Bare text content of the element (direct text children only; nested
+        // elements are visited on their own).
+        for child in element.children.iter() {
+            if let TemplateChildNode::Text(text) = child
+                && has_bare_string(text.content.as_str())
+            {
+                ctx.warn_with_help(
+                    ctx.t("vue/no-bare-strings-in-template.message"),
+                    &text.loc,
+                    ctx.t("vue/no-bare-strings-in-template.help"),
+                );
+            }
+        }
+
+        // Bare string in a user-facing static attribute. Bound attributes
+        // (`:title="..."`) are directives, so they are skipped here.
+        for prop in element.props.iter() {
+            if let PropNode::Attribute(attr) = prop
+                && is_target_attribute(attr.name.as_str())
+                && let Some(value) = &attr.value
+                && has_bare_string(value.content.as_str())
+            {
+                ctx.warn_with_help(
+                    ctx.t("vue/no-bare-strings-in-template.message"),
+                    &attr.loc,
+                    ctx.t("vue/no-bare-strings-in-template.help"),
+                );
+            }
+        }
+    }
+}
+
+/// Whether `tag` is an element whose text content is raw (non-markup) data and
+/// therefore never user-facing copy.
+fn is_raw_text_element(tag: &str) -> bool {
+    tag.eq_ignore_ascii_case("script") || tag.eq_ignore_ascii_case("style")
+}
+
+/// Whether `name` is one of the user-facing attributes whose literal value
+/// should be internationalized.
+fn is_target_attribute(name: &str) -> bool {
+    TARGET_ATTRIBUTES
+        .iter()
+        .any(|target| name.eq_ignore_ascii_case(target))
+}
+
+/// Whether `text` contains human-readable copy: at least one alphabetic
+/// character (any language). Whitespace-, punctuation-, symbol- and number-only
+/// text is treated as non-translatable and ignored.
+fn has_bare_string(text: &str) -> bool {
+    text.chars().any(char::is_alphabetic)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::NoBareStringsInTemplate;
+    use crate::linter::Linter;
+    use crate::rule::RuleRegistry;
+
+    fn create_linter() -> Linter {
+        let mut registry = RuleRegistry::new();
+        registry.register(Box::new(NoBareStringsInTemplate));
+        Linter::with_registry(registry)
+    }
+
+    #[test]
+    fn reports_bare_text_content() {
+        let linter = create_linter();
+        let result = linter.lint_template(r#"<div>hello</div>"#, "App.vue");
+        assert_eq!(result.warning_count, 1);
+        insta::assert_debug_snapshot!(result.diagnostics);
+    }
+
+    #[test]
+    fn reports_bare_text_in_nested_element() {
+        let linter = create_linter();
+        let result = linter.lint_template(r#"<div><span>Save</span></div>"#, "App.vue");
+        assert_eq!(result.warning_count, 1);
+    }
+
+    #[test]
+    fn reports_non_ascii_bare_text() {
+        let linter = create_linter();
+        let result = linter.lint_template(r#"<div>こんにちは</div>"#, "App.vue");
+        assert_eq!(result.warning_count, 1);
+    }
+
+    #[test]
+    fn reports_bare_alt_attribute() {
+        let linter = create_linter();
+        let result = linter.lint_template(r#"<img alt="a cat" />"#, "App.vue");
+        assert_eq!(result.warning_count, 1);
+    }
+
+    #[test]
+    fn reports_bare_title_attribute() {
+        let linter = create_linter();
+        let result = linter.lint_template(r#"<button title="Close">x</button>"#, "App.vue");
+        // Both the title attribute and the "x"-free text? "x" is alphabetic, so
+        // the button text "x" also reports. Expect 2.
+        assert_eq!(result.warning_count, 2);
+    }
+
+    #[test]
+    fn reports_bare_placeholder_attribute() {
+        let linter = create_linter();
+        let result = linter.lint_template(r#"<input placeholder="Search" />"#, "App.vue");
+        assert_eq!(result.warning_count, 1);
+    }
+
+    #[test]
+    fn reports_bare_aria_label_attribute() {
+        let linter = create_linter();
+        let result = linter.lint_template(r#"<div aria-label="Menu"></div>"#, "App.vue");
+        assert_eq!(result.warning_count, 1);
+    }
+
+    #[test]
+    fn allows_interpolation() {
+        let linter = create_linter();
+        let result = linter.lint_template(r#"<div>{{ $t('hello') }}</div>"#, "App.vue");
+        assert_eq!(result.warning_count, 0);
+    }
+
+    #[test]
+    fn allows_bound_attribute() {
+        let linter = create_linter();
+        let result = linter.lint_template(r#"<img :alt="$t('cat')" />"#, "App.vue");
+        assert_eq!(result.warning_count, 0);
+    }
+
+    #[test]
+    fn allows_whitespace_only_text() {
+        let linter = create_linter();
+        let result = linter.lint_template("<div>   </div>", "App.vue");
+        assert_eq!(result.warning_count, 0);
+    }
+
+    #[test]
+    fn allows_punctuation_and_symbol_only_text() {
+        let linter = create_linter();
+        let result = linter.lint_template(r#"<div>-</div>"#, "App.vue");
+        assert_eq!(result.warning_count, 0);
+        let result = linter.lint_template(r#"<span>|</span>"#, "App.vue");
+        assert_eq!(result.warning_count, 0);
+    }
+
+    #[test]
+    fn allows_number_only_text() {
+        let linter = create_linter();
+        let result = linter.lint_template(r#"<div>123</div>"#, "App.vue");
+        assert_eq!(result.warning_count, 0);
+    }
+
+    #[test]
+    fn allows_non_target_attribute() {
+        let linter = create_linter();
+        let result = linter.lint_template(r#"<div class="container"></div>"#, "App.vue");
+        assert_eq!(result.warning_count, 0);
+    }
+
+    #[test]
+    fn allows_id_attribute() {
+        let linter = create_linter();
+        let result = linter.lint_template(r#"<input type="text" name="q" />"#, "App.vue");
+        assert_eq!(result.warning_count, 0);
+    }
+}

--- a/crates/vize_patina/src/rules/vue/snapshots/vize_patina__rules__vue__no_bare_strings_in_template__tests__reports_bare_text_content.snap
+++ b/crates/vize_patina/src/rules/vue/snapshots/vize_patina__rules__vue__no_bare_strings_in_template__tests__reports_bare_text_content.snap
@@ -1,0 +1,18 @@
+---
+source: crates/vize_patina/src/rules/vue/no_bare_strings_in_template.rs
+expression: result.diagnostics
+---
+[
+    LintDiagnostic {
+        rule_name: "vue/no-bare-strings-in-template",
+        severity: Warning,
+        message: "Raw text should be wrapped in a translation function instead of being written directly in the template",
+        start: 5,
+        end: 10,
+        help: Some(
+            "Move the text into a translation function, e.g. {{ $t('key') }} for content or :title=\"$t('key')\" for an attribute.",
+        ),
+        labels: [],
+        fix: None,
+    },
+]

--- a/crates/vize_patina/src/snapshots/vize_patina__preset__tests__lint_preset_rule_membership.snap
+++ b/crates/vize_patina/src/snapshots/vize_patina__preset__tests__lint_preset_rule_membership.snap
@@ -523,6 +523,7 @@ expression: "serde_json::to_string_pretty(&snapshot).unwrap()"
     "vue/no-deprecated-slot-scope-attribute",
     "vue/no-deprecated-scope-attribute",
     "vue/no-deprecated-router-link-tag-prop",
+    "vue/no-bare-strings-in-template",
     "ecosystem/pinia-prefer-store-to-refs",
     "ecosystem/vue-router-prefer-named-push",
     "ecosystem/vue-test-utils-no-html-snapshot",

--- a/npm/vize/src/types/rules.ts
+++ b/npm/vize/src/types/rules.ts
@@ -135,6 +135,7 @@ export const LINT_RULE_NAMES = [
   "vue/html-self-closing",
   "vue/multi-word-component-names",
   "vue/mustache-interpolation-spacing",
+  "vue/no-bare-strings-in-template",
   "vue/no-boolean-attr-value",
   "vue/no-child-content",
   "vue/no-deprecated-html-element-is",


### PR DESCRIPTION
Implements `vue/no-bare-strings-in-template` from #1629.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1707"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->