### PR TITLE
feat(patina): add script/require-typed-object-prop

### DIFF
--- a/crates/vize_patina/src/linter/script_rules/registry/names.rs
+++ b/crates/vize_patina/src/linter/script_rules/registry/names.rs
@@ -67,6 +67,7 @@ pub(crate) const RULE_REQUIRE_PROP_TYPES: &str = "script/require-prop-types";
 pub(crate) const RULE_NO_RESERVED_PROPS: &str = "script/no-reserved-props";
 pub(crate) const RULE_NO_UNUSED_EMIT_DECLARATIONS: &str = "script/no-unused-emit-declarations";
 pub(crate) const RULE_RETURN_IN_EMITS_VALIDATOR: &str = "script/return-in-emits-validator";
+pub(crate) const RULE_REQUIRE_TYPED_OBJECT_PROP: &str = "script/require-typed-object-prop";
 
 pub(in crate::linter::script_rules) const ALL_BUILTIN_SCRIPT_RULE_NAMES: &[&str] = &[
     RULE_NO_OPTIONS_API,
@@ -122,6 +123,7 @@ pub(in crate::linter::script_rules) const ALL_BUILTIN_SCRIPT_RULE_NAMES: &[&str]
     RULE_NO_RESERVED_PROPS,
     RULE_NO_UNUSED_EMIT_DECLARATIONS,
     RULE_RETURN_IN_EMITS_VALIDATOR,
+    RULE_REQUIRE_TYPED_OBJECT_PROP,
 ];
 
 #[cfg(test)]
@@ -176,4 +178,5 @@ pub(in crate::linter::script_rules) const OPT_IN_SCRIPT_RULE_NAMES: &[&str] = &[
     RULE_NO_RESERVED_PROPS,
     RULE_NO_UNUSED_EMIT_DECLARATIONS,
     RULE_RETURN_IN_EMITS_VALIDATOR,
+    RULE_REQUIRE_TYPED_OBJECT_PROP,
 ];

--- a/crates/vize_patina/src/linter/script_rules/registry/rules.rs
+++ b/crates/vize_patina/src/linter/script_rules/registry/rules.rs
@@ -20,9 +20,9 @@ use super::names::{
     RULE_PREFER_USE_ATTRS, RULE_PREFER_USE_ID, RULE_PREFER_USE_SLOTS, RULE_PREFER_USE_TEMPLATE_REF,
     RULE_REQUIRE_DEFAULT_PROP, RULE_REQUIRE_FUNCTION_RETURN_TYPE,
     RULE_REQUIRE_PROP_TYPE_CONSTRUCTOR, RULE_REQUIRE_PROP_TYPES, RULE_REQUIRE_SYMBOL_PROVIDE,
-    RULE_REQUIRE_TYPED_REF, RULE_RETURN_IN_COMPUTED_PROPERTY, RULE_RETURN_IN_EMITS_VALIDATOR,
-    RULE_VALID_DEFINE_OPTIONS, RULE_VALID_NEXT_TICK, RULE_VUE_ROUTER_PREFER_NAMED_PUSH,
-    RULE_VUE_TEST_UTILS_NO_HTML_SNAPSHOT,
+    RULE_REQUIRE_TYPED_OBJECT_PROP, RULE_REQUIRE_TYPED_REF, RULE_RETURN_IN_COMPUTED_PROPERTY,
+    RULE_RETURN_IN_EMITS_VALIDATOR, RULE_VALID_DEFINE_OPTIONS, RULE_VALID_NEXT_TICK,
+    RULE_VUE_ROUTER_PREFER_NAMED_PUSH, RULE_VUE_TEST_UTILS_NO_HTML_SNAPSHOT,
 };
 use super::{
     BuiltinScriptRuleEntry, ECOSYSTEM_SCRIPT_PRESETS, OPINIONATED_SCRIPT_PRESETS,
@@ -40,9 +40,9 @@ use crate::rules::script::{
     NoUseComputedPropertyLikeMethod, NoWithDefaults, PiniaPreferStoreToRefs, PreferComputed,
     PreferDefineOptions, PreferImportFromVue, PreferRefOverReactive, PreferUseAttrs, PreferUseId,
     PreferUseSlots, PreferUseTemplateRef, RequireDefaultProp, RequireFunctionReturnType,
-    RequirePropTypeConstructor, RequirePropTypes, RequireSymbolProvide, RequireTypedRef,
-    ReturnInComputedProperty, ReturnInEmitsValidator, ValidDefineOptions, ValidNextTick,
-    VueRouterPreferNamedPush, VueTestUtilsNoHtmlSnapshot,
+    RequirePropTypeConstructor, RequirePropTypes, RequireSymbolProvide, RequireTypedObjectProp,
+    RequireTypedRef, ReturnInComputedProperty, ReturnInEmitsValidator, ValidDefineOptions,
+    ValidNextTick, VueRouterPreferNamedPush, VueTestUtilsNoHtmlSnapshot,
 };
 
 static NO_DEEP_DESTRUCTURE_IN_PROPS_RULE: NoDeepDestructureInProps =
@@ -105,4 +105,5 @@ pub(in crate::linter::script_rules) static BUILTIN_SCRIPT_RULES: &[BuiltinScript
     BuiltinScriptRuleEntry { rule_name: RULE_NO_RESERVED_PROPS, profile_name: "patina.script_rule.no_reserved_props", category: "Script", fixable: false, presets: OPINIONATED_SCRIPT_PRESETS, rule: &NoReservedProps },
     BuiltinScriptRuleEntry { rule_name: RULE_NO_UNUSED_EMIT_DECLARATIONS, profile_name: "patina.script_rule.no_unused_emit_declarations", category: "Script", fixable: false, presets: OPINIONATED_SCRIPT_PRESETS, rule: &NoUnusedEmitDeclarations },
     BuiltinScriptRuleEntry { rule_name: RULE_RETURN_IN_EMITS_VALIDATOR, profile_name: "patina.script_rule.return_in_emits_validator", category: "Script", fixable: false, presets: OPINIONATED_SCRIPT_PRESETS, rule: &ReturnInEmitsValidator },
+    BuiltinScriptRuleEntry { rule_name: RULE_REQUIRE_TYPED_OBJECT_PROP, profile_name: "patina.script_rule.require_typed_object_prop", category: "Script", fixable: false, presets: OPINIONATED_SCRIPT_PRESETS, rule: &RequireTypedObjectProp },
 ];

--- a/crates/vize_patina/src/rules/script/props_emits.rs
+++ b/crates/vize_patina/src/rules/script/props_emits.rs
@@ -11,6 +11,7 @@ mod no_unused_emit_declarations;
 mod props_source;
 mod require_default_prop;
 mod require_prop_types;
+mod require_typed_object_prop;
 mod return_in_emits_validator;
 
 pub use no_required_prop_with_default::NoRequiredPropWithDefault;
@@ -18,4 +19,5 @@ pub use no_reserved_props::NoReservedProps;
 pub use no_unused_emit_declarations::NoUnusedEmitDeclarations;
 pub use require_default_prop::RequireDefaultProp;
 pub use require_prop_types::RequirePropTypes;
+pub use require_typed_object_prop::RequireTypedObjectProp;
 pub use return_in_emits_validator::ReturnInEmitsValidator;

--- a/crates/vize_patina/src/rules/script/props_emits/require_typed_object_prop.rs
+++ b/crates/vize_patina/src/rules/script/props_emits/require_typed_object_prop.rs
@@ -1,0 +1,199 @@
+//! script/require-typed-object-prop
+//!
+//! Require an explicit element type on a prop whose runtime type is the bare
+//! `Object` / `Array` constructor.
+//!
+//! A runtime prop declared as `Object` or `Array` accepts any object / any
+//! array — Vue can validate only the constructor, so the prop's value type
+//! collapses to `Record<string, any>` / `any[]` and downstream code loses all
+//! type-checking. Pairing the constructor with an `as PropType<T>` cast (or
+//! switching to the type-based `defineProps<{ ... }>()` form) restores the
+//! intended element type while keeping the runtime declaration.
+//!
+//! This flags an object-form prop whose runtime type is `Object` or `Array`
+//! with no `as PropType<...>` cast, in either notation:
+//!
+//! * the shorthand where the prop value *is* the constructor
+//!   (`foo: Object` / `foo: Array`), and
+//! * an explicit `type` member (`foo: { type: Object }` /
+//!   `foo: { type: Array }`).
+//!
+//! A cast (`Object as PropType<Foo>`, `Array as PropType<Bar[]>`) is the fix and
+//! is left alone, as is any other constructor (`String`, `Number`, a custom
+//! class), an array of constructors, an imported type, or a validator function.
+//! The type-based `defineProps<{ ... }>()` form carries no runtime descriptor
+//! and is never flagged. Covers the Options API `props` option (including
+//! `defineComponent({...})` and same-file identifier-bound objects) and the
+//! `<script setup>` runtime `defineProps(...)`.
+//!
+//! Mirrors [`vue/require-typed-object-prop`](https://eslint.vuejs.org/rules/require-typed-object-prop.html),
+//! which applies to TypeScript only. All built-in script rules parse with
+//! TypeScript semantics, so the `as PropType<...>` cast is observable.
+//!
+//! ## Examples
+//!
+//! ### Invalid
+//! ```ts
+//! const props = defineProps({
+//!   foo: Object,
+//!   bar: { type: Array },
+//! })
+//! ```
+//!
+//! ### Valid
+//! ```ts
+//! const props = defineProps({
+//!   foo: Object as PropType<Foo>,
+//!   bar: { type: Array as PropType<Bar[]> },
+//! })
+//!
+//! // Type-based form carries the element type directly.
+//! const typed = defineProps<{ foo: Foo; bar: Bar[] }>()
+//! ```
+
+use oxc_ast::ast::{Expression, ObjectExpression, ObjectPropertyKind, Program, PropertyKey};
+use oxc_span::GetSpan;
+
+use vize_carton::CompactString;
+
+use super::super::{ScriptLintResult, ScriptRule, ScriptRuleMeta};
+use super::props_source::{PropDescriptor, collect_runtime_props};
+use crate::diagnostic::{LintDiagnostic, Severity};
+
+static META: ScriptRuleMeta = ScriptRuleMeta {
+    name: "script/require-typed-object-prop",
+    description: "Require an explicit type on a prop whose runtime type is `Object` or `Array`",
+    default_severity: Severity::Warning,
+};
+
+/// Require `as PropType<T>` on a prop typed with the bare `Object`/`Array` constructor.
+pub struct RequireTypedObjectProp;
+
+impl ScriptRule for RequireTypedObjectProp {
+    fn meta(&self) -> &'static ScriptRuleMeta {
+        &META
+    }
+
+    #[inline]
+    fn uses_ast(&self) -> bool {
+        true
+    }
+
+    fn check_program<'a>(
+        &self,
+        program: &'a Program<'a>,
+        _source: &str,
+        offset: usize,
+        result: &mut ScriptLintResult,
+    ) {
+        // Array-form props (`['foo']` / `defineProps(['foo'])`) declare only a
+        // name and carry no runtime type, so there is nothing to inspect here;
+        // a missing type is `script/require-prop-types`' concern.
+        for source in collect_runtime_props(program) {
+            for prop in source.object_props() {
+                check_prop(prop, offset, result);
+            }
+        }
+    }
+}
+
+/// Inspect a single object-form prop for a bare `Object`/`Array` runtime type.
+fn check_prop(prop: PropDescriptor<'_>, offset: usize, result: &mut ScriptLintResult) {
+    match prop.value {
+        // Descriptor object: inspect its `type` member, if any.
+        Expression::ObjectExpression(descriptor) => {
+            if let Some(type_value) = find_type_value(descriptor) {
+                check_type_expression(prop.name, type_value, offset, result);
+            }
+        }
+        // Shorthand: the prop value *is* the type (`foo: Object`).
+        value => check_type_expression(prop.name, value, offset, result),
+    }
+}
+
+/// Report a `type` expression that is the bare `Object`/`Array` constructor.
+///
+/// An `as PropType<...>` cast (a [`TSAsExpression`]) is the fix, so a cast value
+/// is intentionally *not* flagged regardless of what it wraps. Every other
+/// expression — a different constructor, an array of constructors, an imported
+/// type, a validator — carries (or is) a type and is left alone.
+///
+/// [`TSAsExpression`]: oxc_ast::ast::Expression::TSAsExpression
+fn check_type_expression(
+    name: &str,
+    type_value: &Expression<'_>,
+    offset: usize,
+    result: &mut ScriptLintResult,
+) {
+    if let Expression::Identifier(identifier) = type_value
+        && let Some(constructor) = bare_object_or_array(identifier.name.as_str())
+    {
+        report(name, constructor, type_value.span(), offset, result);
+    }
+}
+
+/// The `Object` / `Array` constructor name, or `None` for any other identifier.
+fn bare_object_or_array(name: &str) -> Option<&'static str> {
+    match name {
+        "Object" => Some("Object"),
+        "Array" => Some("Array"),
+        _ => None,
+    }
+}
+
+/// The expression bound to the `type` member of a prop descriptor object, if
+/// present (`{ type: <value>, ... }`). Computed keys are skipped.
+fn find_type_value<'a>(descriptor: &'a ObjectExpression<'a>) -> Option<&'a Expression<'a>> {
+    descriptor.properties.iter().find_map(|property| {
+        let ObjectPropertyKind::ObjectProperty(property) = property else {
+            return None;
+        };
+        if property.computed || property_key_name(&property.key) != Some("type") {
+            return None;
+        }
+        Some(&property.value)
+    })
+}
+
+fn report(
+    name: &str,
+    constructor: &str,
+    span: oxc_span::Span,
+    offset: usize,
+    result: &mut ScriptLintResult,
+) {
+    let start = offset as u32 + span.start;
+    let end = offset as u32 + span.end;
+
+    let mut message = CompactString::with_capacity(name.len() + constructor.len() + 48);
+    message.push_str("Prop '");
+    message.push_str(name);
+    message.push_str("' typed as `");
+    message.push_str(constructor);
+    message.push_str("` should have an explicit element type.");
+
+    let mut help = CompactString::with_capacity(constructor.len() + 64);
+    help.push_str("Add an `as PropType<T>` cast, e.g. `");
+    help.push_str(constructor);
+    help.push_str(" as PropType<T>`, or use the type-based `defineProps<{ ... }>()` form.");
+
+    let diagnostic = LintDiagnostic::warn(META.name, message, start, end)
+        .with_label(
+            "bare `Object`/`Array` constructor used as a prop type",
+            start,
+            end,
+        )
+        .with_help(help);
+    result.add_diagnostic(diagnostic);
+}
+
+fn property_key_name<'a>(key: &'a PropertyKey<'a>) -> Option<&'a str> {
+    match key {
+        PropertyKey::StaticIdentifier(identifier) => Some(identifier.name.as_str()),
+        PropertyKey::StringLiteral(string) => Some(string.value.as_str()),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/vize_patina/src/rules/script/props_emits/require_typed_object_prop/snapshots/vize_patina__rules__script__props_emits__require_typed_object_prop__tests__invalid_shorthand_array.snap
+++ b/crates/vize_patina/src/rules/script/props_emits/require_typed_object_prop/snapshots/vize_patina__rules__script__props_emits__require_typed_object_prop__tests__invalid_shorthand_array.snap
@@ -1,0 +1,24 @@
+---
+source: crates/vize_patina/src/rules/script/props_emits/require_typed_object_prop/tests.rs
+expression: result.diagnostics
+---
+[
+    LintDiagnostic {
+        rule_name: "script/require-typed-object-prop",
+        severity: Warning,
+        message: "Prop 'foo' typed as `Array` should have an explicit element type.",
+        start: 36,
+        end: 41,
+        help: Some(
+            "Add an `as PropType<T>` cast, e.g. `Array as PropType<T>`, or use the type-based `defineProps<{ ... }>()` form.",
+        ),
+        labels: [
+            Label {
+                message: "bare `Object`/`Array` constructor used as a prop type",
+                start: 36,
+                end: 41,
+            },
+        ],
+        fix: None,
+    },
+]

--- a/crates/vize_patina/src/rules/script/props_emits/require_typed_object_prop/snapshots/vize_patina__rules__script__props_emits__require_typed_object_prop__tests__invalid_shorthand_object.snap
+++ b/crates/vize_patina/src/rules/script/props_emits/require_typed_object_prop/snapshots/vize_patina__rules__script__props_emits__require_typed_object_prop__tests__invalid_shorthand_object.snap
@@ -1,0 +1,24 @@
+---
+source: crates/vize_patina/src/rules/script/props_emits/require_typed_object_prop/tests.rs
+expression: result.diagnostics
+---
+[
+    LintDiagnostic {
+        rule_name: "script/require-typed-object-prop",
+        severity: Warning,
+        message: "Prop 'foo' typed as `Object` should have an explicit element type.",
+        start: 36,
+        end: 42,
+        help: Some(
+            "Add an `as PropType<T>` cast, e.g. `Object as PropType<T>`, or use the type-based `defineProps<{ ... }>()` form.",
+        ),
+        labels: [
+            Label {
+                message: "bare `Object`/`Array` constructor used as a prop type",
+                start: 36,
+                end: 42,
+            },
+        ],
+        fix: None,
+    },
+]

--- a/crates/vize_patina/src/rules/script/props_emits/require_typed_object_prop/tests.rs
+++ b/crates/vize_patina/src/rules/script/props_emits/require_typed_object_prop/tests.rs
@@ -1,0 +1,235 @@
+use crate::rules::script::RequireTypedObjectProp;
+use crate::rules::script::ScriptLinter;
+
+fn create_linter() -> ScriptLinter {
+    let mut linter = ScriptLinter::new();
+    linter.add_rule(Box::new(RequireTypedObjectProp));
+    linter
+}
+
+// ---------------------------------------------------------------------------
+// Valid
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_valid_shorthand_object_with_prop_type() {
+    let source = r#"
+const props = defineProps({
+  foo: Object as PropType<Foo>
+})
+"#;
+    let result = create_linter().lint(source, 0);
+    assert_eq!(result.warning_count, 0);
+}
+
+#[test]
+fn test_valid_shorthand_array_with_prop_type() {
+    let source = r#"
+const props = defineProps({
+  foo: Array as PropType<string[]>
+})
+"#;
+    let result = create_linter().lint(source, 0);
+    assert_eq!(result.warning_count, 0);
+}
+
+#[test]
+fn test_valid_descriptor_type_with_prop_type() {
+    let source = r#"
+const props = defineProps({
+  foo: { type: Object as PropType<Foo> },
+  bar: { type: Array as PropType<Bar[]>, default: () => [] }
+})
+"#;
+    let result = create_linter().lint(source, 0);
+    assert_eq!(result.warning_count, 0);
+}
+
+#[test]
+fn test_valid_other_constructors() {
+    // String / Number / Boolean / a custom class carry their own type and are
+    // never flagged.
+    let source = r#"
+const props = defineProps({
+  a: String,
+  b: { type: Number },
+  c: Boolean,
+  d: Date,
+  e: { type: MyClass }
+})
+"#;
+    let result = create_linter().lint(source, 0);
+    assert_eq!(result.warning_count, 0);
+}
+
+#[test]
+fn test_valid_array_of_constructors() {
+    // `[Object, Array]` is a union of accepted constructors, not a bare typeless
+    // `Object`/`Array`; left alone (matches vue/require-typed-object-prop).
+    let source = r#"
+const props = defineProps({
+  foo: [Object, Array],
+  bar: { type: [String, Object] }
+})
+"#;
+    let result = create_linter().lint(source, 0);
+    assert_eq!(result.warning_count, 0);
+}
+
+#[test]
+fn test_valid_type_based_define_props_ignored() {
+    let source = r#"
+const props = defineProps<{ foo: Foo; bar: Bar[] }>()
+"#;
+    let result = create_linter().lint(source, 0);
+    assert_eq!(result.warning_count, 0);
+}
+
+#[test]
+fn test_valid_array_form_define_props_ignored() {
+    // Array form declares only names — no runtime type to inspect here.
+    let source = r#"
+const props = defineProps(['foo', 'bar'])
+"#;
+    let result = create_linter().lint(source, 0);
+    assert_eq!(result.warning_count, 0);
+}
+
+#[test]
+fn test_valid_no_props_option() {
+    let source = r#"
+export default {
+  data() {
+    return { count: 0 }
+  }
+}
+"#;
+    let result = create_linter().lint(source, 0);
+    assert_eq!(result.warning_count, 0);
+}
+
+#[test]
+fn test_valid_validator_function() {
+    // A function value sits in the type position (a validator / PropType
+    // factory) and is not the bare `Object`/`Array` constructor.
+    let source = r#"
+const props = defineProps({
+  foo: { type: makeType() }
+})
+"#;
+    let result = create_linter().lint(source, 0);
+    assert_eq!(result.warning_count, 0);
+}
+
+#[test]
+fn test_valid_object_options_api_with_prop_type() {
+    let source = r#"
+export default {
+  props: {
+    foo: { type: Object as PropType<Foo> }
+  }
+}
+"#;
+    let result = create_linter().lint(source, 0);
+    assert_eq!(result.warning_count, 0);
+}
+
+// ---------------------------------------------------------------------------
+// Invalid
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_invalid_shorthand_object() {
+    let source = r#"
+const props = defineProps({
+  foo: Object
+})
+"#;
+    let result = create_linter().lint(source, 0);
+    assert_eq!(result.warning_count, 1);
+    insta::assert_debug_snapshot!(result.diagnostics);
+}
+
+#[test]
+fn test_invalid_shorthand_array() {
+    let source = r#"
+const props = defineProps({
+  foo: Array
+})
+"#;
+    let result = create_linter().lint(source, 0);
+    assert_eq!(result.warning_count, 1);
+    insta::assert_debug_snapshot!(result.diagnostics);
+}
+
+#[test]
+fn test_invalid_descriptor_type_object() {
+    let source = r#"
+const props = defineProps({
+  foo: { type: Object }
+})
+"#;
+    let result = create_linter().lint(source, 0);
+    assert_eq!(result.warning_count, 1);
+}
+
+#[test]
+fn test_invalid_descriptor_type_array() {
+    let source = r#"
+const props = defineProps({
+  foo: { type: Array, default: () => [] }
+})
+"#;
+    let result = create_linter().lint(source, 0);
+    assert_eq!(result.warning_count, 1);
+}
+
+#[test]
+fn test_invalid_options_api_props() {
+    let source = r#"
+export default {
+  props: {
+    foo: Object,
+    bar: { type: Array }
+  }
+}
+"#;
+    let result = create_linter().lint(source, 0);
+    assert_eq!(result.warning_count, 2);
+}
+
+#[test]
+fn test_invalid_define_component() {
+    let source = r#"
+export default defineComponent({
+  props: {
+    foo: { type: Object }
+  }
+})
+"#;
+    let result = create_linter().lint(source, 0);
+    assert_eq!(result.warning_count, 1);
+}
+
+#[test]
+fn test_invalid_mixed_counts() {
+    let source = r#"
+const props = defineProps({
+  typed: Object as PropType<Foo>,
+  bad1: Object,
+  bad2: { type: Array },
+  ok: String
+})
+"#;
+    let result = create_linter().lint(source, 0);
+    assert_eq!(result.warning_count, 2);
+}
+
+#[test]
+fn test_offset_applied() {
+    let source = r#"const props = defineProps({ foo: Object })"#;
+    let result = create_linter().lint(source, 100);
+    assert_eq!(result.warning_count, 1);
+    let object_start = source.find("Object").unwrap() as u32 + 100;
+    assert_eq!(result.diagnostics[0].start, object_start);
+}

--- a/crates/vize_patina/src/snapshots/vize_patina__preset__tests__lint_preset_rule_membership.snap
+++ b/crates/vize_patina/src/snapshots/vize_patina__preset__tests__lint_preset_rule_membership.snap
@@ -572,6 +572,7 @@ expression: "serde_json::to_string_pretty(&snapshot).unwrap()"
     "script/require-prop-types",
     "script/no-reserved-props",
     "script/no-unused-emit-declarations",
-    "script/return-in-emits-validator"
+    "script/return-in-emits-validator",
+    "script/require-typed-object-prop"
   ]
 }

--- a/npm/vize/src/types/rules.ts
+++ b/npm/vize/src/types/rules.ts
@@ -110,6 +110,7 @@ export const LINT_RULE_NAMES = [
   "script/require-prop-type-constructor",
   "script/require-prop-types",
   "script/require-symbol-provide",
+  "script/require-typed-object-prop",
   "script/require-typed-ref",
   "script/return-in-computed-property",
   "script/return-in-emits-validator",


### PR DESCRIPTION
Implements `script/require-typed-object-prop` from #1629.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1708"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->