### PR TITLE
feat(patina): add vue/no-deprecated-functional-template

### DIFF
--- a/crates/vize_carton/src/i18n_supplemental_extra.rs
+++ b/crates/vize_carton/src/i18n_supplemental_extra.rs
@@ -174,4 +174,23 @@ static ENTRIES: &[(&str, &str, &str, &str)] = &[
         "オブジェクトを1つにまとめてください。例: :class=\"[{ a }, { b }]\" は :class=\"{ a, b }\" になります。",
         "请将这些对象合并为一个，例如 :class=\"[{ a }, { b }]\" 改为 :class=\"{ a, b }\"。",
     ),
+    // vue/no-deprecated-functional-template
+    (
+        "vue/no-deprecated-functional-template.description",
+        "Disallow the `functional` attribute on the SFC `<template>`",
+        "SFCの`<template>`への`functional`属性を禁止する",
+        "禁止在SFC的`<template>`上使用`functional`属性",
+    ),
+    (
+        "vue/no-deprecated-functional-template.message",
+        "the `functional` attribute on `<template>` (functional SFC templates) was removed in Vue 3",
+        "`<template>`の`functional`属性（関数型SFCテンプレート）はVue 3で削除されました",
+        "`<template>`上的`functional`属性（函数式SFC模板）已在Vue 3中移除",
+    ),
+    (
+        "vue/no-deprecated-functional-template.help",
+        "Remove `functional` and use a stateful component, or write the functional component as a plain function (e.g. a render function or JSX).",
+        "`functional`を削除してステートフルなコンポーネントにするか、関数型コンポーネントを通常の関数（レンダー関数やJSXなど）として記述してください。",
+        "请移除`functional`并改用有状态组件，或将函数式组件写成普通函数（例如渲染函数或JSX）。",
+    ),
 ];

--- a/crates/vize_patina/src/rules/vue.rs
+++ b/crates/vize_patina/src/rules/vue.rs
@@ -13,6 +13,7 @@
 mod attribute_hyphenation;
 mod attribute_order;
 mod no_child_content;
+mod no_deprecated_functional_template;
 mod no_deprecated_html_element_is;
 mod no_deprecated_router_link_tag_prop;
 mod no_deprecated_scope_attribute;
@@ -88,6 +89,7 @@ mod single_style_block;
 pub use crate::rules::opinionated::vue::MultiWordComponentNames;
 pub use crate::rules::opinionated::vue::UseVOnExact;
 pub use no_child_content::NoChildContent;
+pub use no_deprecated_functional_template::NoDeprecatedFunctionalTemplate;
 pub use no_deprecated_html_element_is::NoDeprecatedHtmlElementIs;
 pub use no_deprecated_router_link_tag_prop::NoDeprecatedRouterLinkTagProp;
 pub use no_deprecated_scope_attribute::NoDeprecatedScopeAttribute;
@@ -208,6 +210,9 @@ pub(crate) fn register_opt_in(registry: &mut crate::rule::RuleRegistry) {
     }
     if !registry.has_rule("vue/no-deprecated-html-element-is") {
         registry.register(Box::new(NoDeprecatedHtmlElementIs));
+    }
+    if !registry.has_rule("vue/no-deprecated-functional-template") {
+        registry.register(Box::new(NoDeprecatedFunctionalTemplate));
     }
     if !registry.has_rule("vue/no-deprecated-slot-attribute") {
         registry.register(Box::new(NoDeprecatedSlotAttribute));

--- a/crates/vize_patina/src/rules/vue/no_deprecated_functional_template.rs
+++ b/crates/vize_patina/src/rules/vue/no_deprecated_functional_template.rs
@@ -1,0 +1,227 @@
+//! vue/no-deprecated-functional-template
+//!
+//! Disallow the `functional` attribute on the SFC `<template>` (removed in Vue
+//! 3).
+//!
+//! Vue 2 let you author a functional component as a single-file component by
+//! marking the template block functional: `<template functional>`. The render
+//! output had no instance, props were read off a `props` context object, and the
+//! component skipped the reactivity/lifecycle machinery. Vue 3 removed functional
+//! single-file-component templates entirely: the performance gap that motivated
+//! them closed, and a stateful component is now the one way to author a `.vue`
+//! file. A lingering `<template functional>` no longer produces a functional
+//! component — the `functional` attribute is simply ignored — so the migration
+//! intent silently breaks. Functional components in Vue 3 are written as plain
+//! functions (typically in JSX / a render function), not as SFC templates.
+//!
+//! This mirrors eslint-plugin-vue's `vue/no-deprecated-functional-template`. It
+//! is an opt-in migration rule and only fires for the default Vue 3 dialect.
+//!
+//! ## Scope
+//!
+//! eslint-plugin-vue reports the `functional` attribute on the SFC root
+//! `<template>` element. patina runs markup rules and SFC-level rules in separate
+//! passes, and the `<template>` SFC block's opening tag (with its attributes) is
+//! not part of the template AST handed to markup rules — only the block's inner
+//! content is. The `functional` attribute is, however, preserved on the parsed
+//! SFC descriptor's template block, so this rule runs as an SFC-level rule
+//! (`run_on_sfc`) over `descriptor.template.attrs`. That is exactly the SFC root
+//! `<template>` element eslint-plugin-vue targets — a nested
+//! `<template functional>` inside the markup is not valid SFC syntax and has no
+//! analogue — so the SFC-descriptor check is both sound and complete for the
+//! cases the original rule covers.
+//!
+//! ## Examples
+//!
+//! ### Invalid (Vue 3)
+//! ```vue
+//! <template functional>
+//!   <div>{{ props.msg }}</div>
+//! </template>
+//! ```
+//!
+//! ### Valid (Vue 3)
+//! ```vue
+//! <template>
+//!   <div>{{ msg }}</div>
+//! </template>
+//! ```
+
+use crate::context::LintContext;
+use crate::diagnostic::{LintDiagnostic, Severity};
+use crate::rule::{Rule, RuleCategory, RuleMeta};
+use vize_atelier_sfc::{SfcParseOptions, parse_sfc};
+use vize_carton::dialect::VueDialect;
+use vize_carton::profile;
+
+static META: RuleMeta = RuleMeta {
+    name: "vue/no-deprecated-functional-template",
+    description: "Disallow the `functional` attribute on the SFC `<template>`",
+    category: RuleCategory::Essential,
+    fixable: false,
+    default_severity: Severity::Error,
+};
+
+/// Disallow the `functional` attribute on the SFC `<template>`.
+#[derive(Default)]
+pub struct NoDeprecatedFunctionalTemplate;
+
+impl Rule for NoDeprecatedFunctionalTemplate {
+    fn meta(&self) -> &'static RuleMeta {
+        &META
+    }
+
+    fn run_on_sfc<'a>(&self, ctx: &mut LintContext<'a>) {
+        // Only the default Vue 3 dialect removed functional SFC templates. SFCs
+        // are always the Vue dialect (petite-vue uses standalone HTML, never a
+        // `.vue` file), so this guard is effectively always true here; it mirrors
+        // the sibling migration rules and keeps the rule inert for any non-Vue
+        // dialect a future caller might thread through.
+        if ctx.dialect() != VueDialect::Vue {
+            return;
+        }
+
+        // Prefer the descriptor prepared by the engine; only parse the SFC
+        // ourselves when one was not shared. `run_on_sfc` never runs for plain
+        // template input (that path does not invoke SFC-level rules), so this rule
+        // does nothing in that case.
+        let owned_descriptor;
+        let descriptor = if let Some(descriptor) = ctx.sfc_descriptor() {
+            descriptor
+        } else {
+            owned_descriptor = match profile!(
+                "patina.rule.no_deprecated_functional_template.parse_sfc",
+                parse_sfc(
+                    ctx.source,
+                    SfcParseOptions {
+                        filename: ctx.filename.into(),
+                        ..Default::default()
+                    },
+                )
+            ) {
+                Ok(descriptor) => descriptor,
+                Err(_) => return,
+            };
+            &owned_descriptor
+        };
+
+        let Some(template) = descriptor.template.as_ref() else {
+            return;
+        };
+
+        // The `functional` attribute is recorded on the template block's attribute
+        // map (a boolean attribute keeps an empty value). Vue 2 only ever emitted
+        // it lowercase, and HTML attribute names are ASCII case-insensitive, so an
+        // exact `functional` match is both sufficient and free of false positives.
+        if !template.attrs.contains_key("functional") {
+            return;
+        }
+
+        // Highlight just the opening `<template ...>` tag: `tag_start` is the `<`
+        // of the opening tag and `loc.start` is the content start (the byte right
+        // after the opening tag's `>`), so this span is the opening tag exactly,
+        // not the whole block.
+        let start = template.loc.tag_start as u32;
+        let end = template.loc.start as u32;
+
+        let message = ctx
+            .t("vue/no-deprecated-functional-template.message")
+            .into_owned();
+        let help = ctx
+            .t("vue/no-deprecated-functional-template.help")
+            .into_owned();
+        ctx.report(LintDiagnostic::error(META.name, message, start, end).with_help(help));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::NoDeprecatedFunctionalTemplate;
+    use crate::linter::Linter;
+    use crate::rule::RuleRegistry;
+
+    fn create_linter() -> Linter {
+        let mut registry = RuleRegistry::new();
+        registry.register(Box::new(NoDeprecatedFunctionalTemplate));
+        Linter::with_registry(registry)
+    }
+
+    #[test]
+    fn reports_functional_template() {
+        let linter = create_linter();
+        let result = linter.lint_sfc(
+            "<template functional>\n  <div>{{ props.msg }}</div>\n</template>\n",
+            "App.vue",
+        );
+        assert_eq!(result.error_count, 1);
+        assert_eq!(
+            result.diagnostics[0].rule_name,
+            "vue/no-deprecated-functional-template"
+        );
+        insta::assert_debug_snapshot!(result.diagnostics);
+    }
+
+    #[test]
+    fn reports_functional_template_with_other_attrs() {
+        // `functional` combined with another block attribute (e.g. `lang`) is
+        // still the removed functional template and must be flagged.
+        let linter = create_linter();
+        let result = linter.lint_sfc(
+            "<template lang=\"html\" functional>\n  <div>{{ props.msg }}</div>\n</template>\n",
+            "App.vue",
+        );
+        assert_eq!(result.error_count, 1);
+    }
+
+    #[test]
+    fn allows_plain_template() {
+        let linter = create_linter();
+        let result = linter.lint_sfc(
+            "<template>\n  <div>{{ msg }}</div>\n</template>\n",
+            "App.vue",
+        );
+        assert_eq!(result.error_count, 0);
+    }
+
+    #[test]
+    fn allows_template_with_unrelated_attr() {
+        // A non-`functional` block attribute (e.g. `lang`) must not be flagged.
+        let linter = create_linter();
+        let result = linter.lint_sfc(
+            "<template lang=\"pug\">\n  div Hello\n</template>\n",
+            "App.vue",
+        );
+        assert_eq!(result.error_count, 0);
+    }
+
+    #[test]
+    fn does_not_flag_functional_inside_markup() {
+        // A nested `<div is="functional">`-style usage, or the word "functional"
+        // appearing as content/attribute value inside the template body, is not
+        // the SFC root `functional` attribute and must not be flagged.
+        let linter = create_linter();
+        let result = linter.lint_sfc(
+            "<template>\n  <div data-kind=\"functional\">functional</div>\n</template>\n",
+            "App.vue",
+        );
+        assert_eq!(result.error_count, 0);
+    }
+
+    #[test]
+    fn does_nothing_on_plain_template_input() {
+        // Plain template input (not a full SFC) never runs SFC-level rules.
+        let linter = create_linter();
+        let result = linter.lint_template("<div>Hello</div>", "App.vue");
+        assert_eq!(result.error_count, 0);
+    }
+
+    #[test]
+    fn flags_only_once_with_script_block_present() {
+        let linter = create_linter();
+        let result = linter.lint_sfc(
+            "<template functional>\n  <div>{{ props.msg }}</div>\n</template>\n<script>\nexport default {};\n</script>\n",
+            "App.vue",
+        );
+        assert_eq!(result.error_count, 1);
+    }
+}

--- a/crates/vize_patina/src/rules/vue/snapshots/vize_patina__rules__vue__no_deprecated_functional_template__tests__reports_functional_template.snap
+++ b/crates/vize_patina/src/rules/vue/snapshots/vize_patina__rules__vue__no_deprecated_functional_template__tests__reports_functional_template.snap
@@ -1,0 +1,18 @@
+---
+source: crates/vize_patina/src/rules/vue/no_deprecated_functional_template.rs
+expression: result.diagnostics
+---
+[
+    LintDiagnostic {
+        rule_name: "vue/no-deprecated-functional-template",
+        severity: Error,
+        message: "the `functional` attribute on `<template>` (functional SFC templates) was removed in Vue 3",
+        start: 0,
+        end: 21,
+        help: Some(
+            "Remove `functional` and use a stateful component, or write the functional component as a plain function (e.g. a render function or JSX).",
+        ),
+        labels: [],
+        fix: None,
+    },
+]

--- a/crates/vize_patina/src/snapshots/vize_patina__preset__tests__lint_preset_rule_membership.snap
+++ b/crates/vize_patina/src/snapshots/vize_patina__preset__tests__lint_preset_rule_membership.snap
@@ -519,6 +519,7 @@ expression: "serde_json::to_string_pretty(&snapshot).unwrap()"
     "vue/no-deprecated-v-on-number-modifiers",
     "vue/no-deprecated-v-bind-sync",
     "vue/no-deprecated-html-element-is",
+    "vue/no-deprecated-functional-template",
     "vue/no-deprecated-slot-attribute",
     "vue/no-deprecated-slot-scope-attribute",
     "vue/no-deprecated-scope-attribute",

--- a/npm/vize/src/types/rules.ts
+++ b/npm/vize/src/types/rules.ts
@@ -137,6 +137,7 @@ export const LINT_RULE_NAMES = [
   "vue/mustache-interpolation-spacing",
   "vue/no-boolean-attr-value",
   "vue/no-child-content",
+  "vue/no-deprecated-functional-template",
   "vue/no-deprecated-html-element-is",
   "vue/no-deprecated-router-link-tag-prop",
   "vue/no-deprecated-scope-attribute",


### PR DESCRIPTION
Implements `vue/no-deprecated-functional-template` from #1629 (M5: Vue 2 → 3 migration pack, opt-in).

## What it does

Reports the Vue 2 `functional` attribute on the SFC `<template>` block. Functional single-file-component templates (`<template functional>`) were removed in Vue 3 — the attribute is now silently ignored, so the migration intent breaks. Functional components in Vue 3 are written as plain functions (render function / JSX), not as SFC templates. This mirrors eslint-plugin-vue's rule of the same name. It is **opt-in** (registered only via `rules::vue::register_opt_in`, not in any preset) and gates itself on the default Vue 3 dialect, following the sibling `no-deprecated-*` migration rules.

## Scope / architecture note

patina runs markup rules and SFC-level rules in **separate passes**. The SFC `<template>` opening tag (and its attributes) is not part of the template AST handed to markup rules — `extract_template_fast` / the descriptor template-parse only feed the block's *inner content* to the markup pass, so a markup-AST rule (`enter_element`) can never observe the root `<template functional>`.

The `functional` attribute is, however, preserved on the parsed SFC descriptor's template block (`descriptor.template.attrs`). The rule therefore runs as an SFC-level rule (`run_on_sfc`) over that descriptor — reusing the engine's shared descriptor when present and otherwise parsing the SFC itself, exactly like `vue/no-empty-component-block` and `vue/single-style-block`. This is precisely the SFC root `<template>` element eslint-plugin-vue targets (a nested `<template functional>` is not valid SFC syntax and has no analogue), so the descriptor-level check is **both sound and complete** for the cases the original rule covers — zero false positives (it matches an exact `functional` attribute key on the template block only; the word appearing as element content or another attribute's value is never flagged). The diagnostic span is the opening `<template ...>` tag exactly.

## Tests / gates

- 7 inline `#[cfg(test)]` cases (valid + invalid, including: combined with `lang`, unrelated attrs, `functional` as content/attr-value, plain-template input no-op, presence of a `<script>` block) — all green.
- `cargo test -p vize_patina` (1657 passed) and `cargo test -p vize_carton` (i18n touched) green.
- i18n en/ja/zh rows added to the growable `i18n_supplemental_extra.rs` (pinned `i18n_supplemental.rs` untouched at 347).
- Preset membership snapshot regenerated (appears once, under `opt_in`); `npm/vize/src/types/rules.ts` updated in sorted position.
- Source-length guard respected: no edited file grew past 350; `engine.rs` and `rule.rs` untouched.
- Formatted with the repo's pinned `rustfmt +1.95.0 --edition 2024`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1714"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->