### PR TITLE
feat(patina): add script/require-explicit-emits

### DIFF
--- a/crates/vize_patina/src/linter/script_rules/registry/names.rs
+++ b/crates/vize_patina/src/linter/script_rules/registry/names.rs
@@ -67,6 +67,7 @@ pub(crate) const RULE_REQUIRE_PROP_TYPES: &str = "script/require-prop-types";
 pub(crate) const RULE_NO_RESERVED_PROPS: &str = "script/no-reserved-props";
 pub(crate) const RULE_NO_UNUSED_EMIT_DECLARATIONS: &str = "script/no-unused-emit-declarations";
 pub(crate) const RULE_RETURN_IN_EMITS_VALIDATOR: &str = "script/return-in-emits-validator";
+pub(crate) const RULE_REQUIRE_EXPLICIT_EMITS: &str = "script/require-explicit-emits";
 
 pub(in crate::linter::script_rules) const ALL_BUILTIN_SCRIPT_RULE_NAMES: &[&str] = &[
     RULE_NO_OPTIONS_API,
@@ -122,6 +123,7 @@ pub(in crate::linter::script_rules) const ALL_BUILTIN_SCRIPT_RULE_NAMES: &[&str]
     RULE_NO_RESERVED_PROPS,
     RULE_NO_UNUSED_EMIT_DECLARATIONS,
     RULE_RETURN_IN_EMITS_VALIDATOR,
+    RULE_REQUIRE_EXPLICIT_EMITS,
 ];
 
 #[cfg(test)]
@@ -176,4 +178,5 @@ pub(in crate::linter::script_rules) const OPT_IN_SCRIPT_RULE_NAMES: &[&str] = &[
     RULE_NO_RESERVED_PROPS,
     RULE_NO_UNUSED_EMIT_DECLARATIONS,
     RULE_RETURN_IN_EMITS_VALIDATOR,
+    RULE_REQUIRE_EXPLICIT_EMITS,
 ];

--- a/crates/vize_patina/src/linter/script_rules/registry/rules.rs
+++ b/crates/vize_patina/src/linter/script_rules/registry/rules.rs
@@ -18,7 +18,7 @@ use super::names::{
     RULE_NO_WITH_DEFAULTS, RULE_PINIA_PREFER_STORE_TO_REFS, RULE_PREFER_COMPUTED,
     RULE_PREFER_DEFINE_OPTIONS, RULE_PREFER_IMPORT_FROM_VUE, RULE_PREFER_REF_OVER_REACTIVE,
     RULE_PREFER_USE_ATTRS, RULE_PREFER_USE_ID, RULE_PREFER_USE_SLOTS, RULE_PREFER_USE_TEMPLATE_REF,
-    RULE_REQUIRE_DEFAULT_PROP, RULE_REQUIRE_FUNCTION_RETURN_TYPE,
+    RULE_REQUIRE_DEFAULT_PROP, RULE_REQUIRE_EXPLICIT_EMITS, RULE_REQUIRE_FUNCTION_RETURN_TYPE,
     RULE_REQUIRE_PROP_TYPE_CONSTRUCTOR, RULE_REQUIRE_PROP_TYPES, RULE_REQUIRE_SYMBOL_PROVIDE,
     RULE_REQUIRE_TYPED_REF, RULE_RETURN_IN_COMPUTED_PROPERTY, RULE_RETURN_IN_EMITS_VALIDATOR,
     RULE_VALID_DEFINE_OPTIONS, RULE_VALID_NEXT_TICK, RULE_VUE_ROUTER_PREFER_NAMED_PUSH,
@@ -39,10 +39,10 @@ use crate::rules::script::{
     NoReservedProps, NoSideEffectsInComputed, NoTopLevelRefInScript, NoUnusedEmitDeclarations,
     NoUseComputedPropertyLikeMethod, NoWithDefaults, PiniaPreferStoreToRefs, PreferComputed,
     PreferDefineOptions, PreferImportFromVue, PreferRefOverReactive, PreferUseAttrs, PreferUseId,
-    PreferUseSlots, PreferUseTemplateRef, RequireDefaultProp, RequireFunctionReturnType,
-    RequirePropTypeConstructor, RequirePropTypes, RequireSymbolProvide, RequireTypedRef,
-    ReturnInComputedProperty, ReturnInEmitsValidator, ValidDefineOptions, ValidNextTick,
-    VueRouterPreferNamedPush, VueTestUtilsNoHtmlSnapshot,
+    PreferUseSlots, PreferUseTemplateRef, RequireDefaultProp, RequireExplicitEmits,
+    RequireFunctionReturnType, RequirePropTypeConstructor, RequirePropTypes, RequireSymbolProvide,
+    RequireTypedRef, ReturnInComputedProperty, ReturnInEmitsValidator, ValidDefineOptions,
+    ValidNextTick, VueRouterPreferNamedPush, VueTestUtilsNoHtmlSnapshot,
 };
 
 static NO_DEEP_DESTRUCTURE_IN_PROPS_RULE: NoDeepDestructureInProps =
@@ -105,4 +105,5 @@ pub(in crate::linter::script_rules) static BUILTIN_SCRIPT_RULES: &[BuiltinScript
     BuiltinScriptRuleEntry { rule_name: RULE_NO_RESERVED_PROPS, profile_name: "patina.script_rule.no_reserved_props", category: "Script", fixable: false, presets: OPINIONATED_SCRIPT_PRESETS, rule: &NoReservedProps },
     BuiltinScriptRuleEntry { rule_name: RULE_NO_UNUSED_EMIT_DECLARATIONS, profile_name: "patina.script_rule.no_unused_emit_declarations", category: "Script", fixable: false, presets: OPINIONATED_SCRIPT_PRESETS, rule: &NoUnusedEmitDeclarations },
     BuiltinScriptRuleEntry { rule_name: RULE_RETURN_IN_EMITS_VALIDATOR, profile_name: "patina.script_rule.return_in_emits_validator", category: "Script", fixable: false, presets: OPINIONATED_SCRIPT_PRESETS, rule: &ReturnInEmitsValidator },
+    BuiltinScriptRuleEntry { rule_name: RULE_REQUIRE_EXPLICIT_EMITS, profile_name: "patina.script_rule.require_explicit_emits", category: "Script", fixable: false, presets: OPINIONATED_SCRIPT_PRESETS, rule: &RequireExplicitEmits },
 ];

--- a/crates/vize_patina/src/rules/script/props_emits.rs
+++ b/crates/vize_patina/src/rules/script/props_emits.rs
@@ -10,6 +10,7 @@ mod no_reserved_props;
 mod no_unused_emit_declarations;
 mod props_source;
 mod require_default_prop;
+mod require_explicit_emits;
 mod require_prop_types;
 mod return_in_emits_validator;
 
@@ -17,5 +18,6 @@ pub use no_required_prop_with_default::NoRequiredPropWithDefault;
 pub use no_reserved_props::NoReservedProps;
 pub use no_unused_emit_declarations::NoUnusedEmitDeclarations;
 pub use require_default_prop::RequireDefaultProp;
+pub use require_explicit_emits::RequireExplicitEmits;
 pub use require_prop_types::RequirePropTypes;
 pub use return_in_emits_validator::ReturnInEmitsValidator;

--- a/crates/vize_patina/src/rules/script/props_emits/emits_source.rs
+++ b/crates/vize_patina/src/rules/script/props_emits/emits_source.rs
@@ -1,18 +1,25 @@
-//! Shared resolution of the Options API `emits` declaration object for the
-//! `script/*` emits rules.
+//! Shared resolution of the Options API `emits` declaration for the `script/*`
+//! emits rules.
 //!
-//! Resolves the object form of the `emits` option
-//! (`export default { emits: { ... } }` / `defineComponent({ emits: { ... } })`
-//! / a same-file identifier bound to such an object). The array form
-//! (`emits: ['submit']`) and type-based declarations carry no validator
-//! functions, so only the object form is returned.
+//! Resolves the `emits` option from an `export default { ... }` /
+//! `defineComponent({ ... })` / same-file identifier-bound options object.
+//! [`resolve_emits_object`] returns only the object form (the only form that
+//! carries validator functions); [`resolve_emits_declaration`] returns either
+//! the array or the object form, for rules that need the full declared name set.
 
 use oxc_ast::ast::{
-    Argument, BindingPattern, CallExpression, ExportDefaultDeclarationKind, Expression,
-    ObjectExpression, ObjectPropertyKind, Program, PropertyKey, Statement,
+    Argument, ArrayExpression, BindingPattern, CallExpression, ExportDefaultDeclarationKind,
+    Expression, ObjectExpression, ObjectPropertyKind, Program, PropertyKey, Statement,
 };
 
 use vize_carton::FxHashMap;
+
+/// The Options API `emits` option in either declared runtime form. The type
+/// (`defineEmits<...>`) and bare-identifier forms are not represented here.
+pub(super) enum EmitsDeclaration<'a> {
+    Array(&'a ArrayExpression<'a>),
+    Object(&'a ObjectExpression<'a>),
+}
 
 /// The Options API `emits` option as an object literal, if declared in object
 /// form. Resolves `export default` / `defineComponent(...)` / identifier-bound
@@ -23,6 +30,37 @@ pub(super) fn resolve_emits_object<'a>(
     let bindings = collect_object_bindings(program);
     let options = resolve_options_object(program, &bindings)?;
     option_emits_object(options, &bindings)
+}
+
+/// The Options API `emits` option as an array or object literal. Resolves the
+/// same options-object forms as [`resolve_emits_object`], and additionally
+/// recognizes the array form (`emits: ['submit']`). An identifier-bound object
+/// value is resolved; other shapes yield `None`.
+pub(super) fn resolve_emits_declaration<'a>(
+    program: &'a Program<'a>,
+) -> Option<EmitsDeclaration<'a>> {
+    let bindings = collect_object_bindings(program);
+    let options = resolve_options_object(program, &bindings)?;
+    option_emits_declaration(options, &bindings)
+}
+
+/// The `emits` option's value as an array or object literal.
+fn option_emits_declaration<'a>(
+    options: &'a ObjectExpression<'a>,
+    bindings: &FxHashMap<&'a str, &'a ObjectExpression<'a>>,
+) -> Option<EmitsDeclaration<'a>> {
+    options.properties.iter().find_map(|property| {
+        let ObjectPropertyKind::ObjectProperty(property) = property else {
+            return None;
+        };
+        if property.computed || property_key_name(&property.key) != Some("emits") {
+            return None;
+        }
+        if let Some(array) = unwrap_array_expression(&property.value) {
+            return Some(EmitsDeclaration::Array(array));
+        }
+        resolve_object_or_binding(&property.value, bindings).map(EmitsDeclaration::Object)
+    })
 }
 
 /// The `emits` option's value as an object literal, resolving an
@@ -139,6 +177,17 @@ fn unwrap_object_expression<'a>(
         Expression::TSAsExpression(ts) => unwrap_object_expression(&ts.expression),
         Expression::TSSatisfiesExpression(ts) => unwrap_object_expression(&ts.expression),
         Expression::TSNonNullExpression(ts) => unwrap_object_expression(&ts.expression),
+        _ => None,
+    }
+}
+
+fn unwrap_array_expression<'a>(expression: &'a Expression<'a>) -> Option<&'a ArrayExpression<'a>> {
+    match expression {
+        Expression::ArrayExpression(array) => Some(array.as_ref()),
+        Expression::ParenthesizedExpression(paren) => unwrap_array_expression(&paren.expression),
+        Expression::TSAsExpression(ts) => unwrap_array_expression(&ts.expression),
+        Expression::TSSatisfiesExpression(ts) => unwrap_array_expression(&ts.expression),
+        Expression::TSNonNullExpression(ts) => unwrap_array_expression(&ts.expression),
         _ => None,
     }
 }

--- a/crates/vize_patina/src/rules/script/props_emits/require_explicit_emits.rs
+++ b/crates/vize_patina/src/rules/script/props_emits/require_explicit_emits.rs
@@ -1,0 +1,181 @@
+//! script/require-explicit-emits
+//!
+//! Require every emitted event to be declared in `defineEmits` / the Options API
+//! `emits` option. An undeclared emit is invisible to tooling and (since
+//! Vue 3.3) falls through as a native DOM listener on the root element, which is
+//! rarely intended. Declaring emits documents the component's event surface.
+//!
+//! Port of
+//! [`vue/require-explicit-emits`](https://eslint.vuejs.org/rules/require-explicit-emits.html).
+//!
+//! ## Sound subset
+//!
+//! Upstream also scans the template (`@evt` / `v-on:evt`), which a `script/*`
+//! rule cannot observe. This implementation only decides what is sound from the
+//! script alone:
+//!
+//! * It reports only when a declaration **exists** and is **fully known**. With
+//!   no declaration, nothing is reported (the emits may be declared elsewhere, or
+//!   intentionally not at all) — flagging would be a false positive.
+//! * A declaration that cannot be fully enumerated — an array/object spread
+//!   (`defineEmits([...names])`), a computed object key, or a bare type reference
+//!   (`defineEmits<Emits>()`) — is treated as unknown, so nothing is reported.
+//! * Only string-literal emit names are checked; a dynamic name (`emit(name)`)
+//!   is skipped.
+//!
+//! Emit call sites are the captured `defineEmits` binding (`emit('change')`) and
+//! `this.$emit('change')`. The declaration-resolution logic lives in the
+//! [`declared`] submodule.
+//!
+//! ```ts
+//! const emit = defineEmits(['change'])
+//! emit('change') // ok
+//! emit('input')  // reported: 'input' is not declared
+//! ```
+
+mod declared;
+
+use oxc_ast::ast::{Argument, CallExpression, Expression, Program};
+use oxc_ast_visit::{Visit, walk::walk_call_expression};
+use oxc_span::Span;
+
+use vize_carton::{CompactString, FxHashSet};
+
+use self::declared::{Declared, resolve_declared_emits};
+use super::super::{ScriptLintResult, ScriptRule, ScriptRuleMeta};
+use crate::diagnostic::{LintDiagnostic, Severity};
+
+static META: ScriptRuleMeta = ScriptRuleMeta {
+    name: "script/require-explicit-emits",
+    description: "Require emitted events to be declared in defineEmits or the emits option",
+    default_severity: Severity::Warning,
+};
+
+/// Require every emitted event to be declared.
+pub struct RequireExplicitEmits;
+
+impl ScriptRule for RequireExplicitEmits {
+    fn meta(&self) -> &'static ScriptRuleMeta {
+        &META
+    }
+
+    #[inline]
+    fn uses_ast(&self) -> bool {
+        true
+    }
+
+    fn check_program<'a>(
+        &self,
+        program: &'a Program<'a>,
+        _source: &str,
+        offset: usize,
+        result: &mut ScriptLintResult,
+    ) {
+        // Bail unless a declaration exists AND is fully known; a missing or
+        // partially-unknown declaration would make any report a false positive.
+        let Declared::Known {
+            names: declared,
+            binding,
+        } = resolve_declared_emits(program)
+        else {
+            return;
+        };
+
+        let mut visitor = EmitCallVisitor {
+            declared: &declared,
+            binding,
+            offset,
+            result,
+        };
+        visitor.visit_program(program);
+    }
+}
+
+/// Walks the program reporting every string-literal emit whose name is absent
+/// from the declared set. Emit call sites are the captured `defineEmits` binding
+/// and `this.$emit(...)`.
+struct EmitCallVisitor<'a, 'result> {
+    declared: &'a FxHashSet<CompactString>,
+    binding: Option<&'a str>,
+    offset: usize,
+    result: &'result mut ScriptLintResult,
+}
+
+impl<'a> Visit<'a> for EmitCallVisitor<'_, '_> {
+    fn visit_call_expression(&mut self, it: &CallExpression<'a>) {
+        if let Some(event) = emitted_event(it, self.binding)
+            && !self.declared.contains(event.value)
+        {
+            self.report(event.value, event.span);
+        }
+        walk_call_expression(self, it);
+    }
+}
+
+impl EmitCallVisitor<'_, '_> {
+    fn report(&mut self, name: &str, span: Span) {
+        let start = self.offset as u32 + span.start;
+        let end = self.offset as u32 + span.end;
+
+        let mut message = CompactString::with_capacity(name.len() + 48);
+        message.push_str("The emitted event '");
+        message.push_str(name);
+        message.push_str("' is not declared in defineEmits or the emits option.");
+
+        let diagnostic = LintDiagnostic::warn(META.name, message, start, end)
+            .with_label("undeclared emitted event", start, end)
+            .with_help(
+                "Add this event to the defineEmits declaration (or the Options API `emits` \
+                 option) so the component's event surface is explicit.",
+            );
+        self.result.add_diagnostic(diagnostic);
+    }
+}
+
+/// The string-literal event name of an emit call, if `call` is one we track.
+struct EmittedEvent<'a> {
+    value: &'a str,
+    span: Span,
+}
+
+/// The emitted event of `call` when it is one we track: the captured
+/// `defineEmits` binding (`emit('x')`) or `this.$emit('x')`. Only a
+/// string-literal first argument yields an event.
+fn emitted_event<'a>(
+    call: &'a CallExpression<'a>,
+    binding: Option<&str>,
+) -> Option<EmittedEvent<'a>> {
+    if !is_emit_callee(&call.callee, binding) {
+        return None;
+    }
+    match call.arguments.first()? {
+        Argument::StringLiteral(literal) => Some(EmittedEvent {
+            value: literal.value.as_str(),
+            span: literal.span,
+        }),
+        _ => None,
+    }
+}
+
+/// Whether `callee` is an emit dispatcher: the captured `defineEmits` binding
+/// (when one exists), or a `*.$emit` member access (`this.$emit`, ...).
+fn is_emit_callee(callee: &Expression<'_>, binding: Option<&str>) -> bool {
+    match callee {
+        Expression::Identifier(identifier) => {
+            binding.is_some_and(|binding| binding == identifier.name.as_str())
+        }
+        expression if expression.is_member_expression() => expression
+            .as_member_expression()
+            .and_then(|member| member.static_property_name())
+            .is_some_and(|property| property == "$emit"),
+        // Look through wrappers so `(emit)('x')` / `(this.$emit)('x')` count.
+        Expression::ParenthesizedExpression(paren) => is_emit_callee(&paren.expression, binding),
+        Expression::TSAsExpression(ts) => is_emit_callee(&ts.expression, binding),
+        Expression::TSSatisfiesExpression(ts) => is_emit_callee(&ts.expression, binding),
+        Expression::TSNonNullExpression(ts) => is_emit_callee(&ts.expression, binding),
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/vize_patina/src/rules/script/props_emits/require_explicit_emits/declared.rs
+++ b/crates/vize_patina/src/rules/script/props_emits/require_explicit_emits/declared.rs
@@ -1,0 +1,243 @@
+//! Declared-emit resolution for `script/require-explicit-emits`.
+//!
+//! Resolves a component's declared event set from `defineEmits` (`<script
+//! setup>`) or the Options API `emits` option, distinguishing a fully-known set
+//! from one that cannot be enumerated (so the rule can stay sound). See the
+//! parent module for the overall scope.
+
+use oxc_ast::ast::{
+    Argument, ArrayExpression, ArrayExpressionElement, BindingPattern, CallExpression, Expression,
+    ObjectExpression, ObjectPropertyKind, Program, PropertyKey, Statement,
+    TSCallSignatureDeclaration, TSLiteral, TSSignature, TSType,
+};
+
+use vize_carton::{CompactString, FxHashSet};
+
+use super::super::emits_source::{EmitsDeclaration, resolve_emits_declaration};
+
+/// The outcome of resolving a component's declared emits.
+pub(super) enum Declared<'a> {
+    /// The declared set is fully known. `binding` is the identifier the
+    /// `defineEmits` return value was assigned to, if any (used to match
+    /// `emit('x')` call sites in `<script setup>`).
+    Known {
+        names: FxHashSet<CompactString>,
+        binding: Option<&'a str>,
+    },
+    /// No declaration was found, or one was found but cannot be fully resolved
+    /// (spread / computed key / bare type reference). Either way, do not report.
+    Unknown,
+}
+
+impl<'a> Declared<'a> {
+    /// Map a collected name set (`None` = not fully enumerable) to a [`Declared`].
+    fn from_names(names: Option<FxHashSet<CompactString>>, binding: Option<&'a str>) -> Self {
+        match names {
+            Some(names) => Declared::Known { names, binding },
+            None => Declared::Unknown,
+        }
+    }
+}
+
+/// Resolve the declared emit names from `defineEmits` (`<script setup>`) or the
+/// Options API `emits` option. Returns [`Declared::Unknown`] when nothing is
+/// declared or when the declaration cannot be fully enumerated.
+pub(super) fn resolve_declared_emits<'a>(program: &'a Program<'a>) -> Declared<'a> {
+    if let Some(declaration) = find_define_emits(program) {
+        return Declared::from_names(collect_call_emits(declaration.call), declaration.binding);
+    }
+
+    // Options API: `export default { emits: [...] | { ... } }`. The captured
+    // binding is irrelevant here (events are emitted via `this.$emit`).
+    match resolve_emits_declaration(program) {
+        Some(EmitsDeclaration::Array(array)) => {
+            Declared::from_names(collect_array_emits(array), None)
+        }
+        Some(EmitsDeclaration::Object(object)) => {
+            Declared::from_names(collect_object_emits(object), None)
+        }
+        None => Declared::Unknown,
+    }
+}
+
+/// A resolved `defineEmits(...)` call and the binding it was assigned to.
+struct DefineEmitsDeclaration<'a> {
+    binding: Option<&'a str>,
+    call: &'a CallExpression<'a>,
+}
+
+/// Find the first top-level `defineEmits(...)` call, whether assigned to a
+/// binding (`const emit = defineEmits(...)`) or bare (`defineEmits(...)`).
+fn find_define_emits<'a>(program: &'a Program<'a>) -> Option<DefineEmitsDeclaration<'a>> {
+    for statement in &program.body {
+        match statement {
+            Statement::VariableDeclaration(declaration) => {
+                for declarator in &declaration.declarations {
+                    let Some(call) = declarator.init.as_ref().and_then(unwrap_call) else {
+                        continue;
+                    };
+                    if is_define_emits(call) {
+                        let binding = match &declarator.id {
+                            BindingPattern::BindingIdentifier(id) => Some(id.name.as_str()),
+                            _ => None,
+                        };
+                        return Some(DefineEmitsDeclaration { binding, call });
+                    }
+                }
+            }
+            Statement::ExpressionStatement(expression) => {
+                if let Some(call) = unwrap_call(&expression.expression)
+                    && is_define_emits(call)
+                {
+                    return Some(DefineEmitsDeclaration {
+                        binding: None,
+                        call,
+                    });
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+/// Collect the declared events from a `defineEmits(...)` call: its type literal
+/// (property / method / call signatures) or its runtime array/object argument.
+/// `None` means the declaration cannot be fully enumerated (bare type reference,
+/// spread, or computed/non-literal key), so the caller suppresses all reports.
+fn collect_call_emits(call: &CallExpression<'_>) -> Option<FxHashSet<CompactString>> {
+    if let Some(type_arguments) = &call.type_arguments {
+        let mut names = FxHashSet::default();
+        for type_param in &type_arguments.params {
+            let TSType::TSTypeLiteral(literal) = type_param else {
+                // `defineEmits<Emits>()` — the named type is not visible here.
+                return None;
+            };
+            for member in &literal.members {
+                // Index signatures etc. cannot be enumerated; treat as unknown.
+                if !collect_event_from_signature(member, &mut names) {
+                    return None;
+                }
+            }
+        }
+        return Some(names);
+    }
+
+    match call.arguments.first() {
+        Some(Argument::ArrayExpression(array)) => collect_array_emits(array),
+        Some(Argument::ObjectExpression(object)) => collect_object_emits(object),
+        // No argument at all (`defineEmits()`): no events declared.
+        None => Some(FxHashSet::default()),
+        // Any other argument shape (identifier, spread, call, ...) is unknown.
+        _ => None,
+    }
+}
+
+/// Collect string-literal names from an array declaration (`['a', 'b']`).
+/// Returns `None` if a spread or non-string element makes the set unknown.
+fn collect_array_emits(array: &ArrayExpression<'_>) -> Option<FxHashSet<CompactString>> {
+    let mut names = FxHashSet::default();
+    for element in &array.elements {
+        match element {
+            ArrayExpressionElement::StringLiteral(literal) => {
+                names.insert(CompactString::new(literal.value.as_str()));
+            }
+            // A hole (`[, 'a']`) declares nothing for that slot; skip it.
+            ArrayExpressionElement::Elision(_) => {}
+            // Spread or any non-string element: the set is no longer fully known.
+            _ => return None,
+        }
+    }
+    Some(names)
+}
+
+/// Collect names from an object declaration (`{ a: null, b: validator }`).
+/// Returns `None` if a spread or computed key makes the set unknown.
+fn collect_object_emits(object: &ObjectExpression<'_>) -> Option<FxHashSet<CompactString>> {
+    let mut names = FxHashSet::default();
+    for property in &object.properties {
+        match property {
+            ObjectPropertyKind::ObjectProperty(property) => {
+                if property.computed {
+                    return None;
+                }
+                match property_key_name(&property.key) {
+                    Some(name) => {
+                        names.insert(CompactString::new(name));
+                    }
+                    None => return None,
+                }
+            }
+            // `{ ...others }`: the set is no longer fully known.
+            ObjectPropertyKind::SpreadProperty(_) => return None,
+        }
+    }
+    Some(names)
+}
+
+/// Extract an event name from a type-literal member. Returns `false` when the
+/// member is a shape we cannot enumerate (an index signature, a non-literal
+/// key/event), so the caller treats the whole declaration as unknown.
+fn collect_event_from_signature(
+    member: &TSSignature<'_>,
+    names: &mut FxHashSet<CompactString>,
+) -> bool {
+    let name = match member {
+        // `change: [id: number]`
+        TSSignature::TSPropertySignature(property) => property_key_name(&property.key),
+        // `change(id: number): void`
+        TSSignature::TSMethodSignature(method) => property_key_name(&method.key),
+        // `(e: 'change', id: number): void`
+        TSSignature::TSCallSignatureDeclaration(signature) => call_signature_event(signature),
+        // Index / construct signatures, etc.: unknown surface.
+        _ => None,
+    };
+    match name {
+        Some(name) => {
+            names.insert(CompactString::new(name));
+            true
+        }
+        None => false,
+    }
+}
+
+/// The string-literal event name of a call-signature whose first parameter is a
+/// `'event'` literal type, e.g. `(e: 'change', id: number): void`.
+fn call_signature_event<'a>(signature: &'a TSCallSignatureDeclaration<'a>) -> Option<&'a str> {
+    let first = signature.params.items.first()?;
+    let annotation = first.type_annotation.as_ref()?;
+    let TSType::TSLiteralType(literal_type) = &annotation.type_annotation else {
+        return None;
+    };
+    match &literal_type.literal {
+        TSLiteral::StringLiteral(string) => Some(string.value.as_str()),
+        _ => None,
+    }
+}
+
+/// Whether the callee is the bare `defineEmits` compiler macro.
+fn is_define_emits(call: &CallExpression<'_>) -> bool {
+    matches!(
+        &call.callee,
+        Expression::Identifier(identifier) if identifier.name.as_str() == "defineEmits"
+    )
+}
+
+fn unwrap_call<'a, 'b>(expression: &'b Expression<'a>) -> Option<&'b CallExpression<'a>> {
+    match expression {
+        Expression::CallExpression(call) => Some(call),
+        Expression::ParenthesizedExpression(paren) => unwrap_call(&paren.expression),
+        Expression::TSAsExpression(ts) => unwrap_call(&ts.expression),
+        Expression::TSSatisfiesExpression(ts) => unwrap_call(&ts.expression),
+        Expression::TSNonNullExpression(ts) => unwrap_call(&ts.expression),
+        _ => None,
+    }
+}
+
+fn property_key_name<'a>(key: &'a PropertyKey<'a>) -> Option<&'a str> {
+    match key {
+        PropertyKey::StaticIdentifier(identifier) => Some(identifier.name.as_str()),
+        PropertyKey::StringLiteral(string) => Some(string.value.as_str()),
+        _ => None,
+    }
+}

--- a/crates/vize_patina/src/rules/script/props_emits/require_explicit_emits/snapshots/vize_patina__rules__script__props_emits__require_explicit_emits__tests__invalid_array_undeclared.snap
+++ b/crates/vize_patina/src/rules/script/props_emits/require_explicit_emits/snapshots/vize_patina__rules__script__props_emits__require_explicit_emits__tests__invalid_array_undeclared.snap
@@ -1,0 +1,24 @@
+---
+source: crates/vize_patina/src/rules/script/props_emits/require_explicit_emits/tests.rs
+expression: result.diagnostics
+---
+[
+    LintDiagnostic {
+        rule_name: "script/require-explicit-emits",
+        severity: Warning,
+        message: "The emitted event 'input' is not declared in defineEmits or the emits option.",
+        start: 43,
+        end: 50,
+        help: Some(
+            "Add this event to the defineEmits declaration (or the Options API `emits` option) so the component's event surface is explicit.",
+        ),
+        labels: [
+            Label {
+                message: "undeclared emitted event",
+                start: 43,
+                end: 50,
+            },
+        ],
+        fix: None,
+    },
+]

--- a/crates/vize_patina/src/rules/script/props_emits/require_explicit_emits/tests.rs
+++ b/crates/vize_patina/src/rules/script/props_emits/require_explicit_emits/tests.rs
@@ -1,0 +1,339 @@
+use crate::rules::script::RequireExplicitEmits;
+use crate::rules::script::ScriptLinter;
+
+fn create_linter() -> ScriptLinter {
+    let mut linter = ScriptLinter::new();
+    linter.add_rule(Box::new(RequireExplicitEmits));
+    linter
+}
+
+// --- defineEmits: array form -----------------------------------------------
+
+#[test]
+fn test_valid_array_all_declared() {
+    let source = r#"
+const emit = defineEmits(['change', 'input'])
+emit('change')
+emit('input')
+"#;
+    let result = create_linter().lint(source, 0);
+    assert_eq!(result.warning_count, 0);
+}
+
+#[test]
+fn test_invalid_array_undeclared() {
+    let source = r#"
+const emit = defineEmits(['change'])
+emit('input')
+"#;
+    let result = create_linter().lint(source, 0);
+    assert_eq!(result.warning_count, 1);
+    insta::assert_debug_snapshot!(result.diagnostics);
+}
+
+#[test]
+fn test_invalid_emit_inside_nested_scope() {
+    let source = r#"
+const emit = defineEmits(['change'])
+function onClick() {
+  emit('input')
+}
+"#;
+    let result = create_linter().lint(source, 0);
+    assert_eq!(result.warning_count, 1);
+}
+
+#[test]
+fn test_custom_binding_name_tracked() {
+    // The captured binding (not necessarily named `emit`) is what is matched.
+    let source = r#"
+const myEmit = defineEmits(['change'])
+myEmit('change')
+myEmit('input')
+"#;
+    let result = create_linter().lint(source, 0);
+    assert_eq!(result.warning_count, 1);
+}
+
+// --- defineEmits: object form ----------------------------------------------
+
+#[test]
+fn test_valid_object_all_declared() {
+    let source = r#"
+const emit = defineEmits({ change: null, input: (v) => true })
+emit('change')
+emit('input')
+"#;
+    let result = create_linter().lint(source, 0);
+    assert_eq!(result.warning_count, 0);
+}
+
+#[test]
+fn test_invalid_object_undeclared() {
+    let source = r#"
+const emit = defineEmits({ change: null })
+emit('input')
+"#;
+    let result = create_linter().lint(source, 0);
+    assert_eq!(result.warning_count, 1);
+}
+
+// --- defineEmits: type form ------------------------------------------------
+
+#[test]
+fn test_valid_type_property_form() {
+    let source = r#"
+const emit = defineEmits<{ change: [id: number]; input: [value: string] }>()
+emit('change')
+emit('input')
+"#;
+    let result = create_linter().lint(source, 0);
+    assert_eq!(result.warning_count, 0);
+}
+
+#[test]
+fn test_invalid_type_property_form() {
+    let source = r#"
+const emit = defineEmits<{ change: [id: number] }>()
+emit('input')
+"#;
+    let result = create_linter().lint(source, 0);
+    assert_eq!(result.warning_count, 1);
+}
+
+#[test]
+fn test_valid_type_call_signature_form() {
+    let source = r#"
+const emit = defineEmits<{
+  (e: 'change', id: number): void
+  (e: 'input', value: string): void
+}>()
+emit('change')
+emit('input')
+"#;
+    let result = create_linter().lint(source, 0);
+    assert_eq!(result.warning_count, 0);
+}
+
+// --- Soundness: unresolvable declarations suppress all reports -------------
+
+#[test]
+fn test_no_define_emits_not_flagged() {
+    // No emits declaration at all: emitting anything is fine (the component may
+    // declare emits elsewhere, or intentionally not at all).
+    let source = r#"
+const foo = 1
+function f() {}
+"#;
+    let result = create_linter().lint(source, 0);
+    assert_eq!(result.warning_count, 0);
+}
+
+#[test]
+fn test_emit_without_define_emits_not_flagged() {
+    // An emit call but no declaration in this script: cannot decide soundly.
+    let source = r#"
+const emit = useEmitter()
+emit('change')
+"#;
+    let result = create_linter().lint(source, 0);
+    assert_eq!(result.warning_count, 0);
+}
+
+#[test]
+fn test_array_spread_is_unknown() {
+    // A spread makes the declared set unknowable, so nothing is reported.
+    let source = r#"
+const names = ['change']
+const emit = defineEmits([...names])
+emit('input')
+"#;
+    let result = create_linter().lint(source, 0);
+    assert_eq!(result.warning_count, 0);
+}
+
+#[test]
+fn test_object_spread_is_unknown() {
+    let source = r#"
+const base = { change: null }
+const emit = defineEmits({ ...base })
+emit('input')
+"#;
+    let result = create_linter().lint(source, 0);
+    assert_eq!(result.warning_count, 0);
+}
+
+#[test]
+fn test_object_computed_key_is_unknown() {
+    let source = r#"
+const key = 'change'
+const emit = defineEmits({ [key]: null })
+emit('input')
+"#;
+    let result = create_linter().lint(source, 0);
+    assert_eq!(result.warning_count, 0);
+}
+
+#[test]
+fn test_type_reference_is_unknown() {
+    // `defineEmits<Emits>()` — the named type is not resolvable here.
+    let source = r#"
+type Emits = { change: [id: number] }
+const emit = defineEmits<Emits>()
+emit('input')
+"#;
+    let result = create_linter().lint(source, 0);
+    assert_eq!(result.warning_count, 0);
+}
+
+#[test]
+fn test_dynamic_emit_name_not_flagged() {
+    // A non-string-literal emit name cannot be matched and is skipped.
+    let source = r#"
+const emit = defineEmits(['change'])
+const name = 'input'
+emit(name)
+"#;
+    let result = create_linter().lint(source, 0);
+    assert_eq!(result.warning_count, 0);
+}
+
+#[test]
+fn test_empty_array_flags_any_emit() {
+    // `defineEmits([])` is a known, empty declaration: any emit is undeclared.
+    let source = r#"
+const emit = defineEmits([])
+emit('change')
+"#;
+    let result = create_linter().lint(source, 0);
+    assert_eq!(result.warning_count, 1);
+}
+
+// --- this.$emit: Options API -----------------------------------------------
+
+#[test]
+fn test_valid_options_api_array_this_emit() {
+    let source = r#"
+export default {
+  emits: ['change', 'input'],
+  methods: {
+    onClick() {
+      this.$emit('change')
+      this.$emit('input')
+    }
+  }
+}
+"#;
+    let result = create_linter().lint(source, 0);
+    assert_eq!(result.warning_count, 0);
+}
+
+#[test]
+fn test_invalid_options_api_array_this_emit() {
+    let source = r#"
+export default {
+  emits: ['change'],
+  methods: {
+    onClick() {
+      this.$emit('input')
+    }
+  }
+}
+"#;
+    let result = create_linter().lint(source, 0);
+    assert_eq!(result.warning_count, 1);
+}
+
+#[test]
+fn test_valid_options_api_object_this_emit() {
+    let source = r#"
+export default {
+  emits: { change: null },
+  methods: {
+    onClick() {
+      this.$emit('change')
+    }
+  }
+}
+"#;
+    let result = create_linter().lint(source, 0);
+    assert_eq!(result.warning_count, 0);
+}
+
+#[test]
+fn test_invalid_options_api_object_this_emit() {
+    let source = r#"
+export default {
+  emits: { change: null },
+  methods: {
+    onClick() {
+      this.$emit('input')
+    }
+  }
+}
+"#;
+    let result = create_linter().lint(source, 0);
+    assert_eq!(result.warning_count, 1);
+}
+
+#[test]
+fn test_options_api_no_emits_option_not_flagged() {
+    // No `emits` option: undeclared `this.$emit` is not our call to make.
+    let source = r#"
+export default {
+  methods: {
+    onClick() {
+      this.$emit('change')
+    }
+  }
+}
+"#;
+    let result = create_linter().lint(source, 0);
+    assert_eq!(result.warning_count, 0);
+}
+
+#[test]
+fn test_define_component_emits_this_emit() {
+    let source = r#"
+import { defineComponent } from 'vue'
+
+export default defineComponent({
+  emits: ['change'],
+  methods: {
+    onClick() {
+      this.$emit('input')
+    }
+  }
+})
+"#;
+    let result = create_linter().lint(source, 0);
+    assert_eq!(result.warning_count, 1);
+}
+
+#[test]
+fn test_this_emit_dynamic_name_not_flagged() {
+    let source = r#"
+export default {
+  emits: ['change'],
+  methods: {
+    onClick(name) {
+      this.$emit(name)
+    }
+  }
+}
+"#;
+    let result = create_linter().lint(source, 0);
+    assert_eq!(result.warning_count, 0);
+}
+
+#[test]
+fn test_offset_is_applied() {
+    let source = r#"
+const emit = defineEmits(['change'])
+emit('input')
+"#;
+    // The reported span is shifted by the block offset.
+    let result = create_linter().lint(source, 100);
+    assert_eq!(result.warning_count, 1);
+    assert!(result.diagnostics[0].start >= 100);
+}

--- a/crates/vize_patina/src/snapshots/vize_patina__preset__tests__lint_preset_rule_membership.snap
+++ b/crates/vize_patina/src/snapshots/vize_patina__preset__tests__lint_preset_rule_membership.snap
@@ -572,6 +572,7 @@ expression: "serde_json::to_string_pretty(&snapshot).unwrap()"
     "script/require-prop-types",
     "script/no-reserved-props",
     "script/no-unused-emit-declarations",
-    "script/return-in-emits-validator"
+    "script/return-in-emits-validator",
+    "script/require-explicit-emits"
   ]
 }

--- a/npm/vize/src/types/rules.ts
+++ b/npm/vize/src/types/rules.ts
@@ -106,6 +106,7 @@ export const LINT_RULE_NAMES = [
   "script/prefer-use-slots",
   "script/prefer-use-template-ref",
   "script/require-default-prop",
+  "script/require-explicit-emits",
   "script/require-function-return-type",
   "script/require-prop-type-constructor",
   "script/require-prop-types",


### PR DESCRIPTION
Implements `script/require-explicit-emits` from #1629 (M4 strongly-recommended). It is roughly the inverse of `script/no-unused-emit-declarations`: instead of flagging declared-but-unemitted events, it flags **emitted-but-undeclared** events.

## What it does

Reports a string-literal emit whose event name is absent from the component's declared emits. Declarations are read from:

- `<script setup>` `defineEmits([...])`, `defineEmits({ ... })`, and the type forms `defineEmits<{ change: [id] }>()` / `defineEmits<{ (e: 'change', id): void }>()`.
- The Options API `emits: [...]` / `emits: { ... }` (resolved via the shared `emits_source` helper, extended here to also return the array form).

Emit call sites are the captured `defineEmits` binding (`const emit = defineEmits(...); emit('x')`, any binding name) and `this.$emit('x')`.

```ts
const emit = defineEmits(['change'])
emit('change') // ok
emit('input')  // reported: 'input' is not declared
```

## Sound subset (vs. upstream `vue/require-explicit-emits`)

patina's markup-rules and script-rules are **separate passes that cannot see each other**, so a `script/*` rule cannot observe template `@evt` / `v-on:evt` usage — which is half of what the upstream rule cross-references. Rather than ship an unsound approximation, this rule restricts itself to what is decidable from the script alone, with **zero/minimal false positives**:

- **Reports only when a declaration exists *and* is fully known.** With no `defineEmits`/`emits` declaration at all, nothing is reported (the emits may be declared elsewhere, or intentionally omitted) — flagging would be a false positive. This is the explicit guidance in the rule's #1629 note.
- **A declaration that cannot be fully enumerated is treated as unknown** (no reports): array/object spread (`defineEmits([...names])`), a computed object key (`{ [k]: null }`), or a bare type reference (`defineEmits<Emits>()`, whose named type isn't visible to the rule).
- **Only string-literal emit names are checked**; a dynamic name (`emit(name)` / `this.$emit(name)`) is skipped.

The template half of upstream (warn on a template-used event that is undeclared) is intentionally **out of scope** here; it would need a template-aware pass.

## Implementation notes

- Rule: `crates/vize_patina/src/rules/script/props_emits/require_explicit_emits.rs` (trait impl + emit-call walking/reporting), with declaration-resolution logic split into a sibling `require_explicit_emits/declared.rs` to keep both files under the 350-line source-length guard.
- Modeled after `no_unused_emit_declarations.rs` and `return_in_emits_validator.rs`; reuses/extends `props_emits/emits_source.rs`.
- Registered with the other props/emits script rules (`OPINIONATED_SCRIPT_PRESETS`, same convention as `require-default-prop` / `require-prop-types`); opt-in by name like its siblings.
- Inline diagnostic messages (no i18n table changes), matching the props/emits batch (#1690).
- 25 inline tests (valid + invalid across all declaration/emit forms, plus the soundness suppression cases). Preset membership snapshot and `npm/vize/src/types/rules.ts` regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1715"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->