### PR TITLE
feat: improve art typing and Tailwind tokens

### DIFF
--- a/crates/vize_maestro/src/ide/completion.rs
+++ b/crates/vize_maestro/src/ide/completion.rs
@@ -13,6 +13,7 @@ mod dispatch;
 mod items;
 mod script;
 mod service;
+mod service_inline_art;
 mod style;
 pub(crate) mod template;
 

--- a/crates/vize_maestro/src/ide/completion/service.rs
+++ b/crates/vize_maestro/src/ide/completion/service.rs
@@ -15,7 +15,7 @@ use tower_lsp::lsp_types::{
 #[cfg(feature = "native")]
 use vize_canon::{CorsaBridge, LspCompletionItem, LspDocumentation};
 
-use super::{is_inside_html_comment, script, style, template};
+use super::{is_inside_html_comment, script, service_inline_art, style, template};
 #[cfg(feature = "native")]
 use crate::ide::corsa_support;
 use crate::ide::{IdeContext, ecosystem};
@@ -56,9 +56,8 @@ impl super::CompletionService {
             };
         }
 
-        // Check if cursor is inside <art> block in a regular .vue file
         if matches!(ctx.block_type, Some(BlockType::Art(_))) {
-            return template::complete_inline_art(ctx);
+            return service_inline_art::complete(ctx);
         }
 
         if ctx.state.lsp_features().ecosystem {
@@ -137,9 +136,8 @@ impl super::CompletionService {
             };
         }
 
-        // Check if cursor is inside <art> block in a regular .vue file
         if matches!(ctx.block_type, Some(BlockType::Art(_))) {
-            return template::complete_inline_art(ctx);
+            return service_inline_art::complete_with_corsa(ctx, corsa_bridge).await;
         }
 
         if ctx.state.lsp_features().ecosystem {
@@ -203,7 +201,7 @@ impl super::CompletionService {
 
     /// Get completions for an art variant template with Corsa.
     #[cfg(feature = "native")]
-    async fn complete_art_variant_with_corsa(
+    pub(super) async fn complete_art_variant_with_corsa(
         ctx: &IdeContext<'_>,
         info: &crate::virtual_code::ArtVariantInfo,
         bridge: &CorsaBridge,

--- a/crates/vize_maestro/src/ide/completion/service_inline_art.rs
+++ b/crates/vize_maestro/src/ide/completion/service_inline_art.rs
@@ -1,0 +1,58 @@
+//! Inline `<art>` completion routing for regular Vue SFCs.
+
+use tower_lsp::lsp_types::CompletionResponse;
+
+#[cfg(feature = "native")]
+use std::sync::Arc;
+#[cfg(feature = "native")]
+use vize_canon::CorsaBridge;
+
+use super::template;
+use crate::ide::IdeContext;
+use crate::virtual_code::{ArtCursorPosition, BlockType};
+
+pub(super) fn complete(ctx: &IdeContext) -> Option<CompletionResponse> {
+    let Some(BlockType::Art(ref art_position)) = ctx.block_type else {
+        return None;
+    };
+
+    match art_position {
+        ArtCursorPosition::VariantTemplate(_) => {
+            let mut items = template::complete_template(ctx);
+            if let Some(CompletionResponse::Array(inline_items)) =
+                template::complete_inline_art(ctx)
+            {
+                items.extend(inline_items);
+            }
+            (!items.is_empty()).then_some(CompletionResponse::Array(items))
+        }
+        _ => template::complete_inline_art(ctx),
+    }
+}
+
+#[cfg(feature = "native")]
+pub(super) async fn complete_with_corsa(
+    ctx: &IdeContext<'_>,
+    corsa_bridge: Option<Arc<CorsaBridge>>,
+) -> Option<CompletionResponse> {
+    let Some(BlockType::Art(ref art_position)) = ctx.block_type else {
+        return None;
+    };
+
+    match art_position {
+        ArtCursorPosition::VariantTemplate(info) => {
+            if let Some(ref bridge) = corsa_bridge {
+                let items =
+                    super::CompletionService::complete_art_variant_with_corsa(ctx, info, bridge)
+                        .await;
+                if !items.is_empty() {
+                    let mut all = items;
+                    all.extend(template::complete_template(ctx));
+                    return Some(CompletionResponse::Array(all));
+                }
+            }
+            super::CompletionService::complete(ctx)
+        }
+        _ => template::complete_inline_art(ctx),
+    }
+}

--- a/crates/vize_maestro/src/ide/completion/template/component_meta.rs
+++ b/crates/vize_maestro/src/ide/completion/template/component_meta.rs
@@ -1,7 +1,9 @@
-//! Imported-component metadata: prop/slot extraction, caching, and the
-//! prop/slot completion items surfaced inside an opening component tag.
+//! Imported-component metadata, caching, and prop/slot completion items.
 
-use std::collections::{BTreeMap, BTreeSet};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    sync::Arc,
+};
 
 use tower_lsp::lsp_types::{
     CompletionItem, CompletionItemKind, CompletionItemLabelDetails, Documentation,
@@ -73,16 +75,13 @@ pub(crate) struct ComponentMetadata {
     slots: Vec<ComponentSlot>,
 }
 
-/// Cached, parsed metadata for an imported component file, keyed in
-/// [`crate::server::ServerState`] by resolved path. The `len` + `modified`
-/// file stamp invalidates the entry when the component file changes on disk,
-/// so completion doesn't re-read + re-parse + re-analyze the same component on
-/// every keystroke inside an opening tag.
+/// Cached metadata for an imported component, keyed by resolved path.
+/// `len` + `modified` invalidate the entry when the file changes on disk.
 #[derive(Clone)]
 pub(crate) struct CachedComponentMetadata {
     pub len: u64,
     pub modified: Option<std::time::SystemTime>,
-    pub metadata: std::sync::Arc<ComponentMetadata>,
+    pub metadata: Arc<ComponentMetadata>,
 }
 
 #[derive(Debug, Clone)]
@@ -108,10 +107,11 @@ struct ComponentSlot {
     props_type: Option<String>,
 }
 
-fn component_metadata(
-    ctx: &IdeContext,
-    component_name: &str,
-) -> Option<std::sync::Arc<ComponentMetadata>> {
+fn component_metadata(ctx: &IdeContext, component_name: &str) -> Option<Arc<ComponentMetadata>> {
+    if let Some(metadata) = super::self_component::metadata(ctx, component_name) {
+        return Some(metadata);
+    }
+
     let mut names = vec![component_name.to_string()];
     let pascal = kebab_to_pascal(component_name);
     if !names.iter().any(|name| name == &pascal) {
@@ -141,7 +141,7 @@ fn component_metadata(
 pub(super) fn cached_component_metadata(
     ctx: &IdeContext,
     resolved: &std::path::Path,
-) -> Option<std::sync::Arc<ComponentMetadata>> {
+) -> Option<Arc<ComponentMetadata>> {
     let cache = ctx.state.component_metadata_cache();
     let (len, modified) = std::fs::metadata(resolved)
         .map(|meta| (meta.len(), meta.modified().ok()))
@@ -155,7 +155,7 @@ pub(super) fn cached_component_metadata(
     }
 
     let component_content = std::fs::read_to_string(resolved).ok()?;
-    let metadata = std::sync::Arc::new(extract_component_metadata(
+    let metadata = Arc::new(extract_component_metadata(
         &component_content,
         &resolved.to_string_lossy(),
         ctx.state.options_api_enabled(),

--- a/crates/vize_maestro/src/ide/completion/template/mod.rs
+++ b/crates/vize_maestro/src/ide/completion/template/mod.rs
@@ -13,6 +13,7 @@ mod bindings;
 mod component_meta;
 mod components;
 mod directives;
+mod self_component;
 mod tag_context;
 mod ts_parse;
 

--- a/crates/vize_maestro/src/ide/completion/template/self_component.rs
+++ b/crates/vize_maestro/src/ide/completion/template/self_component.rs
@@ -1,0 +1,22 @@
+//! Inline `<art>` `Self` component metadata lookup.
+
+use std::sync::Arc;
+
+use super::component_meta::{ComponentMetadata, cached_component_metadata};
+use crate::ide::IdeContext;
+
+pub(super) fn metadata(ctx: &IdeContext, component_name: &str) -> Option<Arc<ComponentMetadata>> {
+    if component_name != "Self"
+        || ctx.uri.path().ends_with(".art.vue")
+        || !matches!(
+            ctx.block_type,
+            Some(crate::virtual_code::BlockType::Art(
+                crate::virtual_code::ArtCursorPosition::VariantTemplate(_)
+            ))
+        )
+    {
+        return None;
+    }
+
+    cached_component_metadata(ctx, &ctx.uri.to_file_path().ok()?)
+}

--- a/crates/vize_maestro/src/ide/definition.rs
+++ b/crates/vize_maestro/src/ide/definition.rs
@@ -5,9 +5,9 @@
 //! - Component usages -> component definitions
 //! - Import statements -> imported files
 //! - Real definitions from Corsa (when available)
-
 pub mod bindings;
 pub(crate) mod helpers;
+mod inline_art;
 pub(crate) mod script;
 mod service;
 mod template;

--- a/crates/vize_maestro/src/ide/definition/inline_art.rs
+++ b/crates/vize_maestro/src/ide/definition/inline_art.rs
@@ -1,0 +1,32 @@
+//! Inline `<art>` definition helpers.
+
+use tower_lsp::lsp_types::{GotoDefinitionResponse, Location, Position, Range};
+
+use super::IdeContext;
+
+pub(super) fn self_component_definition(ctx: &IdeContext<'_>) -> Option<GotoDefinitionResponse> {
+    if ctx.uri.path().ends_with(".art.vue")
+        || !matches!(
+            ctx.block_type,
+            Some(crate::virtual_code::BlockType::Art(
+                crate::virtual_code::ArtCursorPosition::VariantTemplate(_)
+            ))
+        )
+    {
+        return None;
+    }
+
+    Some(GotoDefinitionResponse::Scalar(Location {
+        uri: ctx.uri.clone(),
+        range: Range {
+            start: Position {
+                line: 0,
+                character: 0,
+            },
+            end: Position {
+                line: 0,
+                character: 0,
+            },
+        },
+    }))
+}

--- a/crates/vize_maestro/src/ide/definition/template.rs
+++ b/crates/vize_maestro/src/ide/definition/template.rs
@@ -1,7 +1,4 @@
-//! Template definition lookup.
-//!
-//! Handles go-to-definition for template expressions, component tags,
-//! and prop references.
+//! Template go-to-definition for expressions, component tags, and props.
 #![allow(clippy::disallowed_types, clippy::disallowed_methods)]
 
 use tower_lsp::lsp_types::{GotoDefinitionResponse, Location, Position, Range};
@@ -506,14 +503,17 @@ pub(crate) fn find_component_definition(
     ctx: &IdeContext<'_>,
     tag_name: &str,
 ) -> Option<GotoDefinitionResponse> {
+    if tag_name == "Self" {
+        return super::inline_art::self_component_definition(ctx);
+    }
+
     let options = vize_atelier_sfc::SfcParseOptions {
         filename: ctx.uri.path().to_string().into(),
         ..Default::default()
     };
 
-    let descriptor = vize_atelier_sfc::parse_sfc(&ctx.content, options).ok()?;
-
     let mut analyzer = Drawer::with_options(DrawerOptions::full());
+    let descriptor = vize_atelier_sfc::parse_sfc(&ctx.content, options).ok()?;
 
     if let Some(ref script_setup) = descriptor.script_setup {
         analyzer.analyze_script_setup(&script_setup.content);

--- a/crates/vize_maestro/src/ide/diagnostics/corsa/collect.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/corsa/collect.rs
@@ -1,12 +1,11 @@
 //! Orchestration of Corsa diagnostic collection for a single SFC document.
 
-use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, Position, Range, Url};
+use tower_lsp::lsp_types::{Diagnostic, Url};
 
 use crate::server::ServerState;
 
-use super::super::{DiagnosticService, sources};
-use super::mapping::{map_diagnostic_with_source_mappings, source_offset_to_position};
-use super::message::rewrite_corsa_message;
+use super::super::DiagnosticService;
+use super::collect_virtual::collect_virtual_result_diagnostics;
 use vize_carton::cstr;
 
 /// Overlay the virtual TS for every relative `.vue` import of `host_uri`
@@ -18,7 +17,7 @@ use vize_carton::cstr;
 /// logged and skipped — a missing sibling falls through to the existing
 /// TS2307 surface, which is the desired behavior for genuinely missing
 /// modules.
-async fn overlay_sibling_vue_mirrors(
+pub(super) async fn overlay_sibling_vue_mirrors(
     bridge: &std::sync::Arc<vize_canon::CorsaBridge>,
     host_uri: &Url,
     initial_specifiers: &[std::string::String],
@@ -150,227 +149,39 @@ impl DiagnosticService {
             tracing::warn!("failed to generate virtual ts for {}", uri);
             return vec![];
         };
-        let virtual_ts = &virtual_result.code;
-        let user_code_start_line = virtual_result.user_code_start_line;
-        let sfc_script_start_line = virtual_result.sfc_script_start_line;
-        let template_scope_start_line = virtual_result.template_scope_start_line;
-        let line_mappings = &virtual_result.line_mappings;
-        let source_mappings = &virtual_result.source_mappings;
-        tracing::info!(
-            "generated virtual ts ({} bytes), user_code_start={}, sfc_script_start={}, template_scope_start={}, mappings_count={}",
-            virtual_ts.len(),
-            user_code_start_line,
-            sfc_script_start_line,
-            template_scope_start_line,
-            line_mappings.iter().filter(|m| m.is_some()).count()
-        );
-
-        // Create the virtual document name used to derive a stable URI.
-        let virtual_name = cstr!("{}.ts", uri.path());
-
-        // Issue #752: Overlay sibling `.vue.ts` mirrors for every relative
-        // `.vue` import so TypeScript's module resolution succeeds against
-        // the temp-dir Corsa session. Without this, `import App from
-        // './app.vue'` rewrites correctly to `./app.vue.ts` but still
-        // reports TS2307 because the sibling is not present.
-        overlay_sibling_vue_mirrors(
+        let mut diagnostics = collect_virtual_result_diagnostics(
             &bridge,
             uri,
-            &virtual_result.relative_vue_imports,
+            content.as_str(),
+            cstr!("{}.ts", uri.path()).to_string(),
+            virtual_result,
             options_api,
             legacy_vue2,
         )
         .await;
 
-        // Open or update the document in Corsa (uses didChange if already open).
-        tracing::info!("opening/updating virtual document: {}", virtual_name);
-        let virtual_uri = match bridge
-            .open_or_update_virtual_document(&virtual_name, virtual_ts)
-            .await
-        {
-            Ok(uri) => {
-                tracing::info!("virtual document opened/updated successfully: {}", uri);
-                uri
+        if !is_art_file {
+            for (variant_index, inline_virtual) in Self::generate_virtual_ts_for_inline_art_variants(
+                uri,
+                &content,
+                options_api,
+                legacy_vue2,
+            ) {
+                diagnostics.extend(
+                    collect_virtual_result_diagnostics(
+                        &bridge,
+                        uri,
+                        content.as_str(),
+                        cstr!("{}.inline_art_{variant_index}.ts", uri.path()).to_string(),
+                        inline_virtual,
+                        options_api,
+                        legacy_vue2,
+                    )
+                    .await,
+                );
             }
-            Err(e) => {
-                tracing::warn!("failed to open/update virtual document: {}", e);
-                return vec![];
-            }
-        };
-
-        // Get diagnostics (this polls until publishDiagnostics has landed).
-        tracing::info!(
-            "waiting for diagnostics from corsa bridge for {}",
-            virtual_uri
-        );
-        let Ok(corsa_diags) = bridge.get_diagnostics(&virtual_uri).await else {
-            tracing::warn!("failed to get diagnostics from corsa");
-            return vec![];
-        };
-
-        tracing::info!(
-            "corsa returned {} raw diagnostics for {}",
-            corsa_diags.len(),
-            virtual_uri
-        );
-
-        // Log each diagnostic for debugging
-        for (i, diag) in corsa_diags.iter().enumerate() {
-            tracing::info!(
-                "  raw diag[{}]: line {}-{}, message: {}",
-                i,
-                diag.range.start.line,
-                diag.range.end.line,
-                &diag.message[..diag.message.len().min(100)]
-            );
         }
 
-        // Convert to LSP diagnostics with proper position mapping
-        corsa_diags
-            .into_iter()
-            .filter_map(|diag| {
-                // Skip warnings about internal generated variables
-                // TS6133: 'X' is declared but its value is never read
-                // TS6196: 'X' is declared but never used
-                let is_unused_warning = diag.message.contains("is declared but")
-                    && (diag.message.contains("never read") || diag.message.contains("never used"));
-                let is_internal_var = diag.message.contains("'__")
-                    || diag.message.contains("'$event'")
-                    || diag.message.contains("'$attrs'")
-                    || diag.message.contains("'$slots'")
-                    || diag.message.contains("'$refs'")
-                    || diag.message.contains("'$emit'");
-
-                if is_unused_warning && is_internal_var {
-                    tracing::debug!(
-                        "skipping internal variable warning: {}",
-                        &diag.message[..diag.message.len().min(80)]
-                    );
-                    return None;
-                }
-
-                let mapped_range = map_diagnostic_with_source_mappings(
-                    virtual_ts,
-                    content.as_str(),
-                    source_mappings,
-                    &virtual_result.import_source_map,
-                    diag.range.start.line,
-                    diag.range.start.character,
-                    diag.range.end.line,
-                    diag.range.end.character,
-                );
-
-                // Determine if this is a script error or template error.
-                // Prefer byte-range source maps from canon. The older line
-                // mapping remains as a fallback for diagnostics that land on
-                // synthetic wrapper statements.
-                let is_template_error = diag.range.start.line >= template_scope_start_line;
-
-                let (start_line, end_line, start_char, end_char) = if let Some(mapped_range) = mapped_range {
-                    mapped_range
-                } else if is_template_error {
-                    // Template scope error - try to find source mapping from @vize-map comments
-                    let virtual_line = diag.range.start.line as usize;
-
-                    // @vize-map comments are placed AFTER the code line they map.
-                    // So for an error at line N, the mapping is at line N (from comment at N+1).
-                    // Search forward (down) from the error line to find the mapping.
-                    let mapping = (0..=10)
-                        .filter_map(|offset| {
-                            let search_line = virtual_line + offset;
-                            line_mappings.get(search_line).and_then(|m| m.as_ref())
-                        })
-                        .next();
-
-                    if let Some(src_mapping) = mapping {
-                        // Found a source mapping - convert byte offset to line/column
-                        let (start_line, start_col) =
-                            source_offset_to_position(&content, src_mapping.start as usize);
-                        let (end_line, end_col) =
-                            source_offset_to_position(&content, src_mapping.end as usize);
-
-                        tracing::info!(
-                            "template error with mapping: virtual_line={} -> offset {}:{} -> sfc_line={} (message: {})",
-                            diag.range.start.line,
-                            src_mapping.start,
-                            src_mapping.end,
-                            start_line,
-                            &diag.message[..diag.message.len().min(50)]
-                        );
-                        (start_line, end_line, start_col, end_col)
-                    } else {
-                        // No mapping found - skip this diagnostic
-                        tracing::debug!(
-                            "skipping unmapped template error at line {}: {}",
-                            diag.range.start.line,
-                            &diag.message[..diag.message.len().min(50)]
-                        );
-                        return None;
-                    }
-                } else {
-                    // Skip diagnostics in generated preamble when no source map
-                    // points back to user code.
-                    if diag.range.start.line < user_code_start_line {
-                        tracing::debug!(
-                            "skipping preamble diagnostic at line {} (user code starts at {}): {}",
-                            diag.range.start.line,
-                            user_code_start_line,
-                            &diag.message[..diag.message.len().min(50)]
-                        );
-                        return None;
-                    }
-
-                    // Script error - map using user code offset
-                    let user_code_offset =
-                        diag.range.start.line.saturating_sub(user_code_start_line);
-                    let user_code_offset_end =
-                        diag.range.end.line.saturating_sub(user_code_start_line);
-
-                    // sfc_script_start_line is 1-indexed, convert to 0-indexed
-                    // Add skipped_import_lines to account for import lines that were moved to module scope
-                    let skipped_lines = virtual_result.skipped_import_lines;
-                    let start =
-                        (sfc_script_start_line.saturating_sub(1)) + user_code_offset + skipped_lines;
-                    let end = (sfc_script_start_line.saturating_sub(1))
-                        + user_code_offset_end
-                        + skipped_lines;
-
-                    // Adjust character offset: virtual TS adds 2 spaces of indentation
-                    let start_ch = diag.range.start.character.saturating_sub(2);
-                    let end_ch = diag.range.end.character.saturating_sub(2);
-
-                    tracing::debug!(
-                        "script error: virtual_line={} -> sfc_line={} (skipped_imports={}, message: {})",
-                        diag.range.start.line,
-                        start,
-                        skipped_lines,
-                        &diag.message[..diag.message.len().min(50)]
-                    );
-                    (start, end, start_ch, end_ch)
-                };
-
-                Some(Diagnostic {
-                    range: Range {
-                        start: Position {
-                            line: start_line,
-                            character: start_char,
-                        },
-                        end: Position {
-                            line: end_line,
-                            character: end_char,
-                        },
-                    },
-                    severity: diag.severity.map(|s| match s {
-                        1 => DiagnosticSeverity::ERROR,
-                        2 => DiagnosticSeverity::WARNING,
-                        3 => DiagnosticSeverity::INFORMATION,
-                        _ => DiagnosticSeverity::HINT,
-                    }),
-                    source: Some(sources::TYPE_CHECKER.to_string()),
-                    message: rewrite_corsa_message(&diag.message),
-                    ..Default::default()
-                })
-            })
-            .collect()
+        diagnostics
     }
 }

--- a/crates/vize_maestro/src/ide/diagnostics/corsa/collect_virtual.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/corsa/collect_virtual.rs
@@ -1,0 +1,189 @@
+//! Mapping Corsa virtual-document diagnostics back to the host SFC.
+
+use tower_lsp::lsp_types::{Diagnostic, DiagnosticSeverity, Position, Range, Url};
+
+use super::super::{VirtualTsResult, sources};
+use super::collect::overlay_sibling_vue_mirrors;
+use super::mapping::{map_diagnostic_with_source_mappings, source_offset_to_position};
+use super::message::rewrite_corsa_message;
+
+pub(super) async fn collect_virtual_result_diagnostics(
+    bridge: &std::sync::Arc<vize_canon::CorsaBridge>,
+    host_uri: &Url,
+    content: &str,
+    virtual_name: String,
+    virtual_result: VirtualTsResult,
+    options_api: bool,
+    legacy_vue2: bool,
+) -> Vec<Diagnostic> {
+    let virtual_ts = &virtual_result.code;
+    let user_code_start_line = virtual_result.user_code_start_line;
+    let sfc_script_start_line = virtual_result.sfc_script_start_line;
+    let template_scope_start_line = virtual_result.template_scope_start_line;
+    let line_mappings = &virtual_result.line_mappings;
+    let source_mappings = &virtual_result.source_mappings;
+    tracing::info!(
+        "generated virtual ts ({} bytes), user_code_start={}, sfc_script_start={}, template_scope_start={}, mappings_count={}",
+        virtual_ts.len(),
+        user_code_start_line,
+        sfc_script_start_line,
+        template_scope_start_line,
+        line_mappings.iter().filter(|m| m.is_some()).count()
+    );
+
+    overlay_sibling_vue_mirrors(
+        bridge,
+        host_uri,
+        &virtual_result.relative_vue_imports,
+        options_api,
+        legacy_vue2,
+    )
+    .await;
+
+    tracing::info!("opening/updating virtual document: {}", virtual_name);
+    let virtual_uri = match bridge
+        .open_or_update_virtual_document(&virtual_name, virtual_ts)
+        .await
+    {
+        Ok(uri) => {
+            tracing::info!("virtual document opened/updated successfully: {}", uri);
+            uri
+        }
+        Err(e) => {
+            tracing::warn!("failed to open/update virtual document: {}", e);
+            return vec![];
+        }
+    };
+
+    tracing::info!(
+        "waiting for diagnostics from corsa bridge for {}",
+        virtual_uri
+    );
+    let Ok(corsa_diags) = bridge.get_diagnostics(&virtual_uri).await else {
+        tracing::warn!("failed to get diagnostics from corsa");
+        return vec![];
+    };
+
+    tracing::info!(
+        "corsa returned {} raw diagnostics for {}",
+        corsa_diags.len(),
+        virtual_uri
+    );
+
+    for (i, diag) in corsa_diags.iter().enumerate() {
+        tracing::info!(
+            "  raw diag[{}]: line {}-{}, message: {}",
+            i,
+            diag.range.start.line,
+            diag.range.end.line,
+            &diag.message[..diag.message.len().min(100)]
+        );
+    }
+
+    corsa_diags
+        .into_iter()
+        .filter_map(|diag| {
+            let is_unused_warning = diag.message.contains("is declared but")
+                && (diag.message.contains("never read") || diag.message.contains("never used"));
+            let is_internal_var = diag.message.contains("'__")
+                || diag.message.contains("'$event'")
+                || diag.message.contains("'$attrs'")
+                || diag.message.contains("'$slots'")
+                || diag.message.contains("'$refs'")
+                || diag.message.contains("'$emit'");
+
+            if is_unused_warning && is_internal_var {
+                tracing::debug!(
+                    "skipping internal variable warning: {}",
+                    &diag.message[..diag.message.len().min(80)]
+                );
+                return None;
+            }
+
+            let mapped_range = map_diagnostic_with_source_mappings(
+                virtual_ts,
+                content,
+                source_mappings,
+                &virtual_result.import_source_map,
+                diag.range.start.line,
+                diag.range.start.character,
+                diag.range.end.line,
+                diag.range.end.character,
+            );
+
+            let is_template_error = diag.range.start.line >= template_scope_start_line;
+
+            let (start_line, end_line, start_char, end_char) = if let Some(mapped_range) =
+                mapped_range
+            {
+                mapped_range
+            } else if is_template_error {
+                let virtual_line = diag.range.start.line as usize;
+                let mapping =
+                    (0..=10).find_map(|offset| line_mappings.get(virtual_line + offset)?.as_ref());
+
+                if let Some(src_mapping) = mapping {
+                    let (start_line, start_col) =
+                        source_offset_to_position(content, src_mapping.start as usize);
+                    let (end_line, end_col) =
+                        source_offset_to_position(content, src_mapping.end as usize);
+                    (start_line, end_line, start_col, end_col)
+                } else {
+                    tracing::debug!(
+                        "skipping unmapped template error at line {}: {}",
+                        diag.range.start.line,
+                        &diag.message[..diag.message.len().min(50)]
+                    );
+                    return None;
+                }
+            } else {
+                if diag.range.start.line < user_code_start_line {
+                    tracing::debug!(
+                        "skipping preamble diagnostic at line {} (user code starts at {}): {}",
+                        diag.range.start.line,
+                        user_code_start_line,
+                        &diag.message[..diag.message.len().min(50)]
+                    );
+                    return None;
+                }
+
+                let user_code_offset = diag.range.start.line.saturating_sub(user_code_start_line);
+                let user_code_offset_end = diag.range.end.line.saturating_sub(user_code_start_line);
+                let skipped_lines = virtual_result.skipped_import_lines;
+                let start =
+                    (sfc_script_start_line.saturating_sub(1)) + user_code_offset + skipped_lines;
+                let end = (sfc_script_start_line.saturating_sub(1))
+                    + user_code_offset_end
+                    + skipped_lines;
+                (
+                    start,
+                    end,
+                    diag.range.start.character.saturating_sub(2),
+                    diag.range.end.character.saturating_sub(2),
+                )
+            };
+
+            Some(Diagnostic {
+                range: Range {
+                    start: Position {
+                        line: start_line,
+                        character: start_char,
+                    },
+                    end: Position {
+                        line: end_line,
+                        character: end_char,
+                    },
+                },
+                severity: diag.severity.map(|s| match s {
+                    1 => DiagnosticSeverity::ERROR,
+                    2 => DiagnosticSeverity::WARNING,
+                    3 => DiagnosticSeverity::INFORMATION,
+                    _ => DiagnosticSeverity::HINT,
+                }),
+                source: Some(sources::TYPE_CHECKER.to_string()),
+                message: rewrite_corsa_message(&diag.message),
+                ..Default::default()
+            })
+        })
+        .collect()
+}

--- a/crates/vize_maestro/src/ide/diagnostics/corsa/mod.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/corsa/mod.rs
@@ -5,9 +5,12 @@
 #![allow(clippy::disallowed_types, clippy::disallowed_methods)]
 
 mod collect;
+mod collect_virtual;
 mod mapping;
 mod message;
 mod virtual_ts;
+mod virtual_ts_art;
+mod virtual_ts_inline_art;
 
 #[cfg(test)]
 mod tests;

--- a/crates/vize_maestro/src/ide/diagnostics/corsa/tests.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/corsa/tests.rs
@@ -98,3 +98,83 @@ fn editor_virtual_ts_rewrites_dot_vue_imports() {
         "alias specifier must not appear in relative_vue_imports",
     );
 }
+
+#[test]
+fn editor_virtual_ts_for_inline_art_binds_self_to_host_props() {
+    use crate::DiagnosticService;
+    use tower_lsp::lsp_types::Url;
+
+    let uri = Url::parse("file:///tmp/Button.vue").expect("parse uri");
+    let content = r#"<script setup lang="ts">
+defineProps<{ variant?: "primary" | "secondary" }>();
+</script>
+
+<template><button /></template>
+
+<art>
+  <variant name="Primary" default>
+    <Self :variant="123" />
+  </variant>
+</art>"#;
+
+    let results =
+        DiagnosticService::generate_virtual_ts_for_inline_art_variants(&uri, content, false, false);
+
+    assert_eq!(results.len(), 1);
+    let (_, result) = &results[0];
+    assert!(
+        result
+            .code
+            .contains("declare const Self: { new (): { $props: Props } };"),
+        "expected Self component binding, got:\n{}",
+        result.code,
+    );
+    assert!(
+        result.code.contains("type __Self_Props_0 = typeof Self"),
+        "expected Self prop checks, got:\n{}",
+        result.code,
+    );
+}
+
+#[test]
+fn editor_virtual_ts_for_art_imports_define_art_target_component() {
+    use crate::DiagnosticService;
+    use tower_lsp::lsp_types::Url;
+
+    let uri = Url::parse("file:///tmp/Button.art.vue").expect("parse uri");
+    let content = r#"<script setup lang="ts">
+defineArt("./Button.vue", { title: "Button" });
+</script>
+
+<art>
+  <variant name="Primary" default>
+    <Button :variant="123" />
+  </variant>
+</art>"#;
+
+    let result = DiagnosticService::generate_virtual_ts_for_art(&uri, content)
+        .expect("virtual TS generated");
+
+    assert!(
+        result
+            .code
+            .contains("import __VizeArtTarget_Button from \"./Button.vue.ts\";"),
+        "expected defineArt component import, got:\n{}",
+        result.code,
+    );
+    assert!(
+        result
+            .relative_vue_imports
+            .iter()
+            .any(|s| s == "./Button.vue"),
+        "expected ./Button.vue to be overlaid, got {:?}",
+        result.relative_vue_imports,
+    );
+    assert!(
+        result
+            .code
+            .contains("type __Button_Props_0 = typeof Button"),
+        "expected Button prop checks, got:\n{}",
+        result.code,
+    );
+}

--- a/crates/vize_maestro/src/ide/diagnostics/corsa/virtual_ts.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/corsa/virtual_ts.rs
@@ -14,14 +14,14 @@ use vize_canon::{ImportRewriter, ImportSourceMap};
 /// `map_diagnostic_with_source_mappings` uses to translate post-rewrite
 /// diagnostic offsets back into pre-rewrite virtual TS offsets (which are the
 /// coordinate system the byte-range source mappings operate in).
-fn rewrite_vue_imports(code: &str) -> (std::string::String, ImportSourceMap) {
+pub(super) fn rewrite_vue_imports(code: &str) -> (std::string::String, ImportSourceMap) {
     use oxc_span::SourceType;
     let result = ImportRewriter::new().rewrite(code, SourceType::ts());
     #[allow(clippy::disallowed_methods)]
     (result.code.to_string(), result.source_map)
 }
 
-fn collect_relative_vue_specifiers(code: &str) -> Vec<std::string::String> {
+pub(super) fn collect_relative_vue_specifiers(code: &str) -> Vec<std::string::String> {
     use oxc_span::SourceType;
     #[allow(clippy::disallowed_methods)]
     ImportRewriter::new()
@@ -235,151 +235,5 @@ impl DiagnosticService {
 
         tracing::info!("parse_vize_map_comments: found {} mappings", found_count);
         mappings
-    }
-
-    /// Generate virtual TypeScript for an art file (*.art.vue).
-    ///
-    /// Uses the default variant's template as the synthetic template,
-    /// and the script_setup block from the SFC parse.
-    pub(in crate::ide::diagnostics) fn generate_virtual_ts_for_art(
-        uri: &Url,
-        content: &str,
-    ) -> Option<VirtualTsResult> {
-        use vize_atelier_sfc::{SfcParseOptions, parse_sfc};
-        use vize_canon::virtual_ts::{VirtualTsOptions, generate_virtual_ts_with_offsets};
-        use vize_croquis::{Drawer, DrawerOptions};
-
-        // Parse as art file to get variant templates
-        let art_allocator = vize_carton::Bump::new();
-        let art_desc = vize_musea::parse_art(
-            &art_allocator,
-            content,
-            vize_musea::ArtParseOptions::default(),
-        )
-        .ok()?;
-
-        // Get default variant's template
-        let (_, variant) = art_desc
-            .variants
-            .iter()
-            .enumerate()
-            .find(|(_, variant)| variant.is_default)
-            .or_else(|| art_desc.variants.iter().enumerate().next())?;
-        let template_content = variant.template;
-        if template_content.trim().is_empty() {
-            return None;
-        }
-
-        // Calculate template offset in the original art file
-        let template_ptr = template_content.as_ptr() as usize;
-        let source_ptr = content.as_ptr() as usize;
-        let template_offset = (template_ptr - source_ptr) as u32;
-
-        // Parse SFC for script blocks
-        let sfc_options = SfcParseOptions {
-            filename: uri.path().to_string().into(),
-            ..Default::default()
-        };
-        let descriptor = parse_sfc(content, sfc_options).ok()?;
-
-        let mut combined_script = String::new();
-        let (script_offset, sfc_script_start_line) =
-            if let Some(script_setup) = descriptor.script_setup.as_ref() {
-                let isolate = !script_setup
-                    .attrs
-                    .get("isolate")
-                    .is_some_and(|value| value.as_ref().eq_ignore_ascii_case("false"));
-                let parts = crate::virtual_code::analyze_art_script_setup(
-                    script_setup.content.as_ref(),
-                    script_setup.loc.start,
-                    isolate,
-                );
-
-                for chunk in parts
-                    .shared_imports
-                    .iter()
-                    .chain(parts.isolated_body.iter())
-                {
-                    combined_script.push_str(&chunk.text);
-                    if !combined_script.ends_with('\n') {
-                        combined_script.push('\n');
-                    }
-                }
-
-                (
-                    script_setup.loc.start as u32,
-                    script_setup.loc.start_line as u32,
-                )
-            } else if let Some(script) = descriptor.script.as_ref() {
-                combined_script.push_str(script.content.as_ref());
-                if !combined_script.ends_with('\n') {
-                    combined_script.push('\n');
-                }
-                (script.loc.start as u32, script.loc.start_line as u32)
-            } else {
-                return None;
-            };
-
-        let script_content = combined_script.as_str();
-
-        // Parse template AST
-        let template_allocator = vize_carton::Bump::new();
-        let (template_ast, _) = vize_armature::parse(&template_allocator, template_content);
-
-        // Analyze script + template
-        let mut analyzer = Drawer::with_options(DrawerOptions::full());
-        analyzer.analyze_script(script_content);
-        analyzer.analyze_template(&template_ast);
-
-        let summary = analyzer.finish();
-        let output = generate_virtual_ts_with_offsets(
-            &summary,
-            Some(script_content),
-            Some(&template_ast),
-            script_offset,
-            template_offset,
-            &VirtualTsOptions::default(),
-        );
-        let code = output.code;
-        let source_mappings = output.mappings;
-
-        // Count import lines
-        let skipped_import_lines = Self::count_import_lines(script_content);
-
-        // Find where user code starts
-        let user_code_start_line = code
-            .lines()
-            .enumerate()
-            .find(|(_, line)| line.contains("// User setup code"))
-            .map(|(i, _)| i as u32 + 1)
-            .unwrap_or(0);
-
-        // Find where template scope starts
-        let template_scope_start_line = code
-            .lines()
-            .enumerate()
-            .find(|(_, line)| line.contains("Template Scope"))
-            .map(|(i, _)| i as u32)
-            .unwrap_or(u32::MAX);
-
-        // Parse @vize-map comments
-        let line_mappings = Self::parse_vize_map_comments(&code);
-
-        // Issue #752: same rewrite as the non-art path so `.vue` imports in
-        // the art file's `<script setup>` resolve to virtual `.vue.ts` mirrors.
-        let relative_vue_imports = collect_relative_vue_specifiers(&code);
-        let (rewritten_code, import_source_map) = rewrite_vue_imports(&code);
-
-        Some(VirtualTsResult {
-            code: rewritten_code,
-            source_mappings,
-            import_source_map,
-            relative_vue_imports,
-            user_code_start_line,
-            sfc_script_start_line,
-            template_scope_start_line,
-            line_mappings,
-            skipped_import_lines,
-        })
     }
 }

--- a/crates/vize_maestro/src/ide/diagnostics/corsa/virtual_ts_art.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/corsa/virtual_ts_art.rs
@@ -1,0 +1,325 @@
+//! Virtual TypeScript generation for standalone `.art.vue` files.
+
+use tower_lsp::lsp_types::Url;
+use vize_canon::virtual_ts::{VirtualTsOptions, generate_virtual_ts_with_offsets};
+use vize_croquis::{Drawer, DrawerOptions};
+
+use super::super::{DiagnosticService, VirtualTsResult};
+use super::virtual_ts::{collect_relative_vue_specifiers, rewrite_vue_imports};
+
+fn quote_ts_string(value: &str) -> String {
+    let mut quoted = String::from("\"");
+    for ch in value.chars() {
+        match ch {
+            '\\' => quoted.push_str("\\\\"),
+            '"' => quoted.push_str("\\\""),
+            '\n' => quoted.push_str("\\n"),
+            '\r' => quoted.push_str("\\r"),
+            '\t' => quoted.push_str("\\t"),
+            _ => quoted.push(ch),
+        }
+    }
+    quoted.push('"');
+    quoted
+}
+
+fn to_safe_identifier_fragment(value: &str) -> String {
+    let mut result = String::with_capacity(value.len().max(1));
+    for ch in value.chars() {
+        if ch.is_ascii_alphanumeric() || ch == '_' || ch == '$' {
+            result.push(ch);
+        } else {
+            result.push('_');
+        }
+    }
+    if result.is_empty() {
+        result.push('_');
+    }
+    result
+}
+
+fn to_safe_identifier(value: &str) -> String {
+    let mut result = to_safe_identifier_fragment(value);
+    if !result
+        .chars()
+        .next()
+        .is_some_and(|ch| ch.is_ascii_alphabetic() || ch == '_' || ch == '$')
+    {
+        result.insert(0, '_');
+    }
+    if is_reserved_identifier(result.as_str()) {
+        result.insert(0, '_');
+    }
+    result
+}
+
+fn is_valid_identifier(value: &str) -> bool {
+    let mut chars = value.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    (first.is_ascii_alphabetic() || first == '_' || first == '$')
+        && !is_reserved_identifier(value)
+        && chars.all(|ch| ch.is_ascii_alphanumeric() || ch == '_' || ch == '$')
+}
+
+fn is_reserved_identifier(value: &str) -> bool {
+    matches!(
+        value,
+        "await"
+            | "break"
+            | "case"
+            | "catch"
+            | "class"
+            | "const"
+            | "continue"
+            | "debugger"
+            | "default"
+            | "delete"
+            | "do"
+            | "else"
+            | "enum"
+            | "export"
+            | "extends"
+            | "false"
+            | "finally"
+            | "for"
+            | "function"
+            | "if"
+            | "import"
+            | "in"
+            | "instanceof"
+            | "new"
+            | "null"
+            | "return"
+            | "super"
+            | "switch"
+            | "this"
+            | "throw"
+            | "true"
+            | "try"
+            | "typeof"
+            | "var"
+            | "void"
+            | "while"
+            | "with"
+            | "yield"
+    )
+}
+
+fn kebab_case_component_name(name: &str) -> Option<String> {
+    let mut kebab = String::new();
+    let mut previous_was_separator = false;
+
+    for (index, ch) in name.char_indices() {
+        if ch.is_ascii_uppercase() {
+            if index > 0 && !previous_was_separator {
+                kebab.push('-');
+            }
+            kebab.push(ch.to_ascii_lowercase());
+            previous_was_separator = false;
+        } else if ch == '_' || ch == '-' || ch.is_whitespace() {
+            if !kebab.ends_with('-') && !kebab.is_empty() {
+                kebab.push('-');
+            }
+            previous_was_separator = true;
+        } else {
+            kebab.push(ch.to_ascii_lowercase());
+            previous_was_separator = false;
+        }
+    }
+
+    while kebab.ends_with('-') {
+        kebab.pop();
+    }
+    (kebab.contains('-') && kebab != name).then_some(kebab)
+}
+
+fn add_art_target_component_bindings(
+    options: &mut VirtualTsOptions,
+    summary: &vize_croquis::Croquis,
+    target: &crate::virtual_code::ArtTargetComponent,
+) {
+    if target.source.trim().is_empty() {
+        return;
+    }
+
+    let has_component_binding = summary.bindings.bindings.contains_key(target.name.as_str());
+    let mut component_ref = target.name.clone();
+
+    if !has_component_binding {
+        let import_alias = vize_carton::cstr!(
+            "__VizeArtTarget_{}",
+            to_safe_identifier_fragment(target.name.as_str())
+        );
+        options.auto_import_stubs.push(vize_carton::cstr!(
+            "import {import_alias} from {};",
+            quote_ts_string(target.source.as_str())
+        ));
+        component_ref = import_alias.to_string();
+
+        if is_valid_identifier(target.name.as_str()) {
+            options.auto_import_stubs.push(vize_carton::cstr!(
+                "const {} = {import_alias};",
+                target.name
+            ));
+            options
+                .external_template_bindings
+                .push(target.name.clone().into());
+            component_ref = target.name.clone();
+        }
+    }
+
+    if has_component_binding {
+        options
+            .external_template_bindings
+            .push(target.name.clone().into());
+    }
+
+    if let Some(kebab_name) = kebab_case_component_name(target.name.as_str()) {
+        let kebab_ref = to_safe_identifier(kebab_name.as_str());
+        options
+            .auto_import_stubs
+            .push(vize_carton::cstr!("const {kebab_ref} = {component_ref};"));
+        options.external_template_bindings.push(kebab_name.into());
+    }
+}
+
+impl DiagnosticService {
+    pub(in crate::ide::diagnostics) fn generate_virtual_ts_for_art(
+        uri: &Url,
+        content: &str,
+    ) -> Option<VirtualTsResult> {
+        let art_allocator = vize_carton::Bump::new();
+        let art_desc = vize_musea::parse_art(
+            &art_allocator,
+            content,
+            vize_musea::ArtParseOptions::default(),
+        )
+        .ok()?;
+
+        let (_, variant) = art_desc
+            .variants
+            .iter()
+            .enumerate()
+            .find(|(_, variant)| variant.is_default)
+            .or_else(|| art_desc.variants.iter().enumerate().next())?;
+        let template_content = variant.template;
+        if template_content.trim().is_empty() {
+            return None;
+        }
+
+        let template_ptr = template_content.as_ptr() as usize;
+        let source_ptr = content.as_ptr() as usize;
+        let template_offset = (template_ptr - source_ptr) as u32;
+
+        let descriptor = vize_atelier_sfc::parse_sfc(
+            content,
+            vize_atelier_sfc::SfcParseOptions {
+                filename: uri.path().to_string().into(),
+                ..Default::default()
+            },
+        )
+        .ok()?;
+
+        let target_component = descriptor
+            .script_setup
+            .as_ref()
+            .and_then(|script_setup| {
+                crate::virtual_code::find_define_art_target_component(script_setup.content.as_ref())
+            })
+            .or_else(|| {
+                art_desc
+                    .metadata
+                    .component
+                    .and_then(crate::virtual_code::art_target_component_from_source)
+            });
+
+        let mut combined_script = String::new();
+        let (script_offset, sfc_script_start_line) =
+            if let Some(script_setup) = descriptor.script_setup.as_ref() {
+                let isolate = !script_setup
+                    .attrs
+                    .get("isolate")
+                    .is_some_and(|value| value.as_ref().eq_ignore_ascii_case("false"));
+                let parts = crate::virtual_code::analyze_art_script_setup(
+                    script_setup.content.as_ref(),
+                    script_setup.loc.start,
+                    isolate,
+                );
+
+                for chunk in parts
+                    .shared_imports
+                    .iter()
+                    .chain(parts.isolated_body.iter())
+                {
+                    combined_script.push_str(&chunk.text);
+                    if !combined_script.ends_with('\n') {
+                        combined_script.push('\n');
+                    }
+                }
+
+                (
+                    script_setup.loc.start as u32,
+                    script_setup.loc.start_line as u32,
+                )
+            } else if let Some(script) = descriptor.script.as_ref() {
+                combined_script.push_str(script.content.as_ref());
+                if !combined_script.ends_with('\n') {
+                    combined_script.push('\n');
+                }
+                (script.loc.start as u32, script.loc.start_line as u32)
+            } else {
+                (0, 1)
+            };
+
+        let script_content = combined_script.as_str();
+        let template_allocator = vize_carton::Bump::new();
+        let (template_ast, _) = vize_armature::parse(&template_allocator, template_content);
+
+        let mut analyzer = Drawer::with_options(DrawerOptions::full());
+        analyzer.analyze_script(script_content);
+        analyzer.analyze_template(&template_ast);
+
+        let summary = analyzer.finish();
+        let mut virtual_ts_options = VirtualTsOptions::default();
+        if let Some(target) = target_component.as_ref() {
+            add_art_target_component_bindings(&mut virtual_ts_options, &summary, target);
+        }
+
+        let output = generate_virtual_ts_with_offsets(
+            &summary,
+            Some(script_content),
+            Some(&template_ast),
+            script_offset,
+            template_offset,
+            &virtual_ts_options,
+        );
+        let code = output.code;
+        let line_mappings = Self::parse_vize_map_comments(&code);
+        let relative_vue_imports = collect_relative_vue_specifiers(&code);
+        let (rewritten_code, import_source_map) = rewrite_vue_imports(&code);
+
+        Some(VirtualTsResult {
+            code: rewritten_code,
+            source_mappings: output.mappings,
+            import_source_map,
+            relative_vue_imports,
+            user_code_start_line: code
+                .lines()
+                .enumerate()
+                .find(|(_, line)| line.contains("// User setup code"))
+                .map(|(i, _)| i as u32 + 1)
+                .unwrap_or(0),
+            sfc_script_start_line,
+            template_scope_start_line: code
+                .lines()
+                .enumerate()
+                .find(|(_, line)| line.contains("Template Scope"))
+                .map(|(i, _)| i as u32)
+                .unwrap_or(u32::MAX),
+            line_mappings,
+            skipped_import_lines: Self::count_import_lines(script_content),
+        })
+    }
+}

--- a/crates/vize_maestro/src/ide/diagnostics/corsa/virtual_ts_inline_art.rs
+++ b/crates/vize_maestro/src/ide/diagnostics/corsa/virtual_ts_inline_art.rs
@@ -1,0 +1,148 @@
+//! Virtual TypeScript generation for inline `<art>` blocks in Vue SFCs.
+
+use tower_lsp::lsp_types::Url;
+use vize_canon::virtual_ts::{
+    VirtualTsOptions, generate_virtual_ts_with_offsets,
+    generate_virtual_ts_with_offsets_legacy_vue2, generate_virtual_ts_with_offsets_options_api,
+};
+
+use super::super::{DiagnosticService, VirtualTsResult};
+use super::virtual_ts::{collect_relative_vue_specifiers, rewrite_vue_imports};
+
+fn add_inline_self_component_binding(
+    options: &mut VirtualTsOptions,
+    summary: &vize_croquis::Croquis,
+) {
+    if summary
+        .component_usages
+        .iter()
+        .any(|usage| usage.name.as_str() == "Self")
+    {
+        options
+            .auto_import_stubs
+            .push("declare const Self: { new (): { $props: Props } };".into());
+        options.external_template_bindings.push("Self".into());
+    }
+}
+
+impl DiagnosticService {
+    pub(in crate::ide::diagnostics) fn generate_virtual_ts_for_inline_art_variants(
+        uri: &Url,
+        content: &str,
+        options_api: bool,
+        legacy_vue2: bool,
+    ) -> Vec<(usize, VirtualTsResult)> {
+        if uri.path().ends_with(".art.vue") || !content.contains("<art") {
+            return Vec::new();
+        }
+
+        let descriptor = match vize_atelier_sfc::parse_sfc(
+            content,
+            vize_atelier_sfc::SfcParseOptions {
+                filename: uri.path().to_string().into(),
+                ..Default::default()
+            },
+        ) {
+            Ok(descriptor) => descriptor,
+            Err(_) => return Vec::new(),
+        };
+
+        let mut results = Vec::new();
+        let mut variant_index = 0usize;
+
+        for custom in &descriptor.custom_blocks {
+            if custom.block_type != "art" {
+                continue;
+            }
+
+            let variants =
+                crate::virtual_code::inline_art_variants(custom.content.as_ref(), custom.loc.start);
+            if variants.is_empty() {
+                continue;
+            }
+
+            for variant in variants {
+                let current_variant_index = variant_index;
+                variant_index += 1;
+
+                let Some(template_content) =
+                    content.get(variant.template_start..variant.template_end)
+                else {
+                    continue;
+                };
+                if template_content.trim().is_empty() {
+                    continue;
+                }
+
+                let template_allocator = vize_carton::Bump::new();
+                let (template_ast, _) = vize_armature::parse(&template_allocator, template_content);
+                let analysis = vize_atelier_sfc::croquis::analyze_sfc_descriptor_resolved(
+                    &descriptor,
+                    Some(&template_ast),
+                    vize_atelier_sfc::croquis::SfcCroquisOptions::full(),
+                    options_api,
+                    legacy_vue2,
+                    uri.path(),
+                );
+
+                let script_content = analysis.script_content.unwrap_or_default();
+                let script_offset = analysis.script_offset;
+                let sfc_script_start_line = if script_content.is_empty() {
+                    1
+                } else {
+                    crate::ide::offset_to_position(content, script_offset as usize).0 + 1
+                };
+
+                let mut virtual_ts_options = VirtualTsOptions::default();
+                add_inline_self_component_binding(&mut virtual_ts_options, &analysis.croquis);
+
+                let generate_virtual_ts = if legacy_vue2 {
+                    generate_virtual_ts_with_offsets_legacy_vue2
+                } else if options_api {
+                    generate_virtual_ts_with_offsets_options_api
+                } else {
+                    generate_virtual_ts_with_offsets
+                };
+                let output = generate_virtual_ts(
+                    &analysis.croquis,
+                    Some(script_content.as_str()),
+                    Some(&template_ast),
+                    script_offset,
+                    variant.template_start as u32,
+                    &virtual_ts_options,
+                );
+                let code = output.code;
+                let line_mappings = Self::parse_vize_map_comments(&code);
+                let relative_vue_imports = collect_relative_vue_specifiers(&code);
+                let (rewritten_code, import_source_map) = rewrite_vue_imports(&code);
+
+                results.push((
+                    current_variant_index,
+                    VirtualTsResult {
+                        code: rewritten_code,
+                        source_mappings: output.mappings,
+                        import_source_map,
+                        relative_vue_imports,
+                        user_code_start_line: code
+                            .lines()
+                            .enumerate()
+                            .find(|(_, line)| line.contains("// User setup code"))
+                            .map(|(i, _)| i as u32 + 1)
+                            .unwrap_or(0),
+                        sfc_script_start_line,
+                        template_scope_start_line: code
+                            .lines()
+                            .enumerate()
+                            .find(|(_, line)| line.contains("Template Scope"))
+                            .map(|(i, _)| i as u32)
+                            .unwrap_or(u32::MAX),
+                        line_mappings,
+                        skipped_import_lines: Self::count_import_lines(script_content.as_str()),
+                    },
+                ));
+            }
+        }
+
+        results
+    }
+}

--- a/crates/vize_maestro/src/server/state/virtual_docs.rs
+++ b/crates/vize_maestro/src/server/state/virtual_docs.rs
@@ -39,7 +39,8 @@ impl ServerState {
         };
 
         let base_uri = uri.path();
-        let virtual_docs = self.virtual_gen.write().generate(&descriptor, base_uri);
+        let mut virtual_docs = self.virtual_gen.write().generate(&descriptor, base_uri);
+        add_inline_art_template_virtual_docs(&mut virtual_docs, &descriptor, base_uri);
         self.virtual_docs_cache.insert(uri.clone(), virtual_docs);
     }
 
@@ -183,6 +184,57 @@ impl ServerState {
         &self,
     ) -> &DashMap<PathBuf, crate::ide::completion::template::CachedComponentMetadata> {
         &self.component_metadata_cache
+    }
+}
+
+fn add_inline_art_template_virtual_docs(
+    docs: &mut VirtualDocuments,
+    descriptor: &vize_atelier_sfc::SfcDescriptor<'_>,
+    base_uri: &str,
+) {
+    use crate::virtual_code::TemplateCodeGenerator;
+
+    let source = descriptor.source.as_ref();
+    let mut variant_index = docs.art_templates.len();
+
+    for custom in &descriptor.custom_blocks {
+        if custom.block_type != "art" {
+            continue;
+        }
+
+        let variants =
+            crate::virtual_code::inline_art_variants(custom.content.as_ref(), custom.loc.start);
+        if variants.is_empty() {
+            continue;
+        }
+
+        docs.art_templates
+            .resize(docs.art_templates.len() + variants.len(), None);
+
+        for variant in variants {
+            let current_variant_index = variant_index;
+            variant_index += 1;
+
+            let Some(template_content) = source.get(variant.template_start..variant.template_end)
+            else {
+                continue;
+            };
+            if template_content.trim().is_empty() {
+                continue;
+            }
+
+            let template_allocator = vize_carton::Bump::new();
+            let (ast, _errors) = vize_armature::parse(&template_allocator, template_content);
+
+            let mut template_gen = TemplateCodeGenerator::new();
+            template_gen.set_block_offset(variant.template_start as u32);
+            let mut template_doc = template_gen.generate(&ast, template_content);
+            template_doc.uri =
+                vize_carton::cstr!("{base_uri}.art_variant_{current_variant_index}.template.ts")
+                    .to_string();
+
+            docs.art_templates[current_variant_index] = Some(template_doc);
+        }
     }
 }
 

--- a/crates/vize_maestro/src/virtual_code.rs
+++ b/crates/vize_maestro/src/virtual_code.rs
@@ -34,10 +34,12 @@ mod source_map;
 mod style_code;
 mod template_code;
 
+pub(crate) use generator::inline_art_variants;
 pub use generator::{
-    ArtCursorPosition, ArtScriptChunk, ArtScriptSetupParts, ArtVariantInfo,
+    ArtCursorPosition, ArtScriptChunk, ArtScriptSetupParts, ArtTargetComponent, ArtVariantInfo,
     BatchVirtualCodeGenerator, BlockType, VirtualCodeGenerator, analyze_art_script_setup,
-    find_art_block_at_offset, find_block_at_offset, find_define_art_component_name,
+    art_target_component_from_source, find_art_block_at_offset, find_block_at_offset,
+    find_define_art_component_name, find_define_art_target_component,
 };
 pub use script_code::{ScriptCodeGenerator, extract_simple_bindings};
 pub use source_map::{MappingData, MappingFeatures, SourceMap, SourceMapping};
@@ -145,15 +147,15 @@ impl VirtualDocuments {
     /// Get all virtual documents as a vector.
     pub fn all(&self) -> Vec<&VirtualDocument> {
         let mut docs = Vec::new();
-        if self.art_templates.is_empty() {
-            if let Some(ref t) = self.template {
-                docs.push(t);
-            }
-        } else {
-            for art_template in &self.art_templates {
-                if let Some(template) = art_template.as_ref() {
-                    docs.push(template);
-                }
+        let template_uri = self.template.as_ref().map(|template| template.uri.as_str());
+        if let Some(ref t) = self.template {
+            docs.push(t);
+        }
+        for art_template in &self.art_templates {
+            if let Some(template) = art_template.as_ref()
+                && Some(template.uri.as_str()) != template_uri
+            {
+                docs.push(template);
             }
         }
         if let Some(ref s) = self.script {

--- a/crates/vize_maestro/src/virtual_code/generator.rs
+++ b/crates/vize_maestro/src/virtual_code/generator.rs
@@ -6,6 +6,7 @@
 mod art_script;
 mod binding;
 mod block;
+mod inline_art;
 
 #[cfg(test)]
 mod tests;
@@ -24,11 +25,14 @@ use super::{
 };
 
 pub use art_script::{
-    ArtScriptChunk, ArtScriptSetupParts, analyze_art_script_setup, find_define_art_component_name,
+    ArtScriptChunk, ArtScriptSetupParts, ArtTargetComponent, analyze_art_script_setup,
+    art_target_component_from_source, find_define_art_component_name,
+    find_define_art_target_component,
 };
 pub use block::{
     ArtCursorPosition, ArtVariantInfo, BlockType, find_art_block_at_offset, find_block_at_offset,
 };
+pub(crate) use inline_art::inline_art_variants;
 
 /// Virtual code generator for SFC files.
 ///

--- a/crates/vize_maestro/src/virtual_code/generator/art_script.rs
+++ b/crates/vize_maestro/src/virtual_code/generator/art_script.rs
@@ -17,12 +17,23 @@ pub struct ArtScriptChunk {
 pub struct ArtScriptSetupParts {
     /// The inferred component tag from `defineArt(...)`, if present.
     pub component_name: Option<String>,
+    /// The component source from `defineArt(...)`, if present.
+    pub component_source: Option<String>,
     /// Whether the setup body should be isolated per variant.
     pub isolate: bool,
     /// Imports that are safe to keep at module level for generated variant setup functions.
     pub shared_imports: Vec<ArtScriptChunk>,
     /// Top-level setup code used as variant-local state.
     pub isolated_body: Vec<ArtScriptChunk>,
+}
+
+/// Component target declared by art metadata.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ArtTargetComponent {
+    /// Template binding name used for the target component.
+    pub name: String,
+    /// Import source of the target component.
+    pub source: String,
 }
 
 impl ArtScriptSetupParts {
@@ -47,10 +58,10 @@ pub fn analyze_art_script_setup(
     isolate: bool,
 ) -> ArtScriptSetupParts {
     let parsed = vize_croquis::script_parser::parse_script_setup(script);
-    let component_name = parsed
-        .macros
-        .define_art()
-        .map(|art| art.component_name.to_string());
+    let define_art = parsed.macros.define_art();
+    let component_name = define_art.map(|art| art.component_name.to_string());
+    let component_source =
+        define_art.and_then(|art| art.component_source.as_ref().map(ToString::to_string));
     let define_art_range = parsed
         .macros
         .define_art_call()
@@ -95,6 +106,7 @@ pub fn analyze_art_script_setup(
 
     ArtScriptSetupParts {
         component_name,
+        component_source,
         isolate,
         shared_imports,
         isolated_body,
@@ -107,6 +119,60 @@ pub fn find_define_art_component_name(script: &str) -> Option<String> {
         .macros
         .define_art()
         .map(|art| art.component_name.to_string())
+}
+
+/// Find the component target inferred from `defineArt(...)`.
+pub fn find_define_art_target_component(script: &str) -> Option<ArtTargetComponent> {
+    let parsed = vize_croquis::script_parser::parse_script_setup(script);
+    let art = parsed.macros.define_art()?;
+    let source = art.component_source.as_ref()?;
+    Some(ArtTargetComponent {
+        name: art.component_name.to_string(),
+        source: source.to_string(),
+    })
+}
+
+/// Infer the component target from a legacy `<art component="...">` source.
+pub fn art_target_component_from_source(source: &str) -> Option<ArtTargetComponent> {
+    let name = component_name_from_source(source);
+    if source.trim().is_empty() {
+        return None;
+    }
+    Some(ArtTargetComponent {
+        name,
+        source: source.to_string(),
+    })
+}
+
+fn component_name_from_source(source: &str) -> String {
+    let without_query = source.split(['?', '#']).next().unwrap_or(source);
+    let filename = without_query
+        .rsplit(['/', '\\'])
+        .next()
+        .filter(|name| !name.is_empty())
+        .unwrap_or("Component");
+    let stem = filename
+        .rsplit_once('.')
+        .map_or(filename, |(name, _extension)| name);
+
+    let mut component_name = String::new();
+    for segment in stem.split(|ch: char| !ch.is_ascii_alphanumeric()) {
+        if segment.is_empty() {
+            continue;
+        }
+
+        let mut chars = segment.chars();
+        if let Some(first) = chars.next() {
+            component_name.push(first.to_ascii_uppercase());
+            component_name.extend(chars);
+        }
+    }
+
+    if component_name.is_empty() {
+        "Component".to_string()
+    } else {
+        component_name
+    }
 }
 
 fn split_top_level_statements(script: &str, source_start: usize) -> Vec<ArtScriptChunk> {

--- a/crates/vize_maestro/src/virtual_code/generator/block.rs
+++ b/crates/vize_maestro/src/virtual_code/generator/block.rs
@@ -3,6 +3,7 @@
 use vize_atelier_sfc::SfcDescriptor;
 
 use super::VirtualLanguage;
+use super::inline_art_variants;
 
 /// Information about cursor position within an art variant template.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -88,13 +89,75 @@ pub fn find_block_at_offset(descriptor: &SfcDescriptor, offset: usize) -> Option
     }
 
     // Check custom blocks (art, i18n, etc.)
+    let mut inline_art_variant_base = 0usize;
     for custom in descriptor.custom_blocks.iter() {
-        if custom.block_type == "art" && offset >= custom.loc.start && offset < custom.loc.end {
-            return Some(BlockType::Art(ArtCursorPosition::ArtContent));
+        if custom.block_type != "art" {
+            continue;
         }
+
+        let variant_count = inline_art_variant_count(descriptor.source.as_ref(), custom);
+        if offset >= custom.loc.tag_start && offset < custom.loc.tag_end {
+            return find_inline_art_block_at_offset(custom, offset, inline_art_variant_base)
+                .or(Some(BlockType::Art(ArtCursorPosition::ArtContent)));
+        }
+
+        inline_art_variant_base += variant_count;
     }
 
     None
+}
+
+fn inline_art_variant_count(_source: &str, custom: &vize_atelier_sfc::SfcCustomBlock<'_>) -> usize {
+    inline_art_variants(custom.content.as_ref(), custom.loc.start).len()
+}
+
+fn find_inline_art_block_at_offset(
+    custom: &vize_atelier_sfc::SfcCustomBlock<'_>,
+    offset: usize,
+    variant_base: usize,
+) -> Option<BlockType> {
+    if offset >= custom.loc.tag_start && offset < custom.loc.start {
+        return Some(BlockType::Art(ArtCursorPosition::ArtTag));
+    }
+
+    for (index, variant) in inline_art_variants(custom.content.as_ref(), custom.loc.start)
+        .into_iter()
+        .enumerate()
+    {
+        if offset < variant.variant_start || offset >= variant.variant_end {
+            continue;
+        }
+
+        if offset >= variant.body_start && offset < variant.body_end {
+            let template_len = variant.template_end.saturating_sub(variant.template_start);
+            let relative_offset = if offset <= variant.template_start {
+                0
+            } else if offset >= variant.template_end {
+                template_len
+            } else {
+                offset - variant.template_start
+            };
+
+            return Some(BlockType::Art(ArtCursorPosition::VariantTemplate(
+                ArtVariantInfo {
+                    variant_index: variant_base + index,
+                    template_start: variant.template_start,
+                    template_end: variant.template_end,
+                    relative_offset,
+                },
+            )));
+        }
+
+        return Some(BlockType::Art(ArtCursorPosition::VariantTag(
+            variant_base + index,
+        )));
+    }
+
+    if offset >= custom.loc.tag_start && offset < custom.loc.tag_end {
+        Some(BlockType::Art(ArtCursorPosition::ArtContent))
+    } else {
+        None
+    }
 }
 
 /// Find which block contains the given offset in an art file (*.art.vue).

--- a/crates/vize_maestro/src/virtual_code/generator/inline_art.rs
+++ b/crates/vize_maestro/src/virtual_code/generator/inline_art.rs
@@ -1,0 +1,132 @@
+//! Inline `<art>` variant scanning for regular Vue SFC custom blocks.
+
+/// Byte ranges for a `<variant>` inside an inline `<art>` custom block.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct InlineArtVariant {
+    /// Start offset of the `<variant...>` opening tag in the original file.
+    pub variant_start: usize,
+    /// End offset of the `</variant>` closing tag in the original file.
+    pub variant_end: usize,
+    /// Offset immediately after the opening tag.
+    pub body_start: usize,
+    /// Offset immediately before the closing tag.
+    pub body_end: usize,
+    /// Start offset of non-whitespace template content.
+    pub template_start: usize,
+    /// End offset of non-whitespace template content.
+    pub template_end: usize,
+}
+
+pub(crate) fn inline_art_variants(content: &str, content_start: usize) -> Vec<InlineArtVariant> {
+    let mut variants = Vec::new();
+    let mut cursor = 0usize;
+
+    while let Some(open_start) = find_next_variant_open(content, cursor) {
+        let Some(open_tag_end) = find_tag_end(content, open_start).map(|end| end + 1) else {
+            break;
+        };
+
+        let (body_end, variant_end) =
+            if let Some((close_start, close_tag_end)) = find_variant_close(content, open_tag_end) {
+                (close_start, close_tag_end)
+            } else {
+                (content.len(), content.len())
+            };
+
+        let body_start = open_tag_end;
+        let (template_start, template_end) = trim_template_range(content, body_start, body_end);
+        variants.push(InlineArtVariant {
+            variant_start: content_start + open_start,
+            variant_end: content_start + variant_end,
+            body_start: content_start + body_start,
+            body_end: content_start + body_end,
+            template_start: content_start + template_start,
+            template_end: content_start + template_end,
+        });
+
+        if variant_end <= open_start {
+            break;
+        }
+        cursor = variant_end;
+    }
+
+    variants
+}
+
+fn find_next_variant_open(content: &str, start: usize) -> Option<usize> {
+    let bytes = content.as_bytes();
+    let mut cursor = start;
+    while let Some(relative) = content.get(cursor..)?.find('<') {
+        let candidate = cursor + relative;
+        let name_end = candidate + "<variant".len();
+        if bytes
+            .get(candidate..name_end)?
+            .eq_ignore_ascii_case(b"<variant")
+            && bytes
+                .get(name_end)
+                .is_none_or(|byte| is_tag_name_boundary(*byte))
+        {
+            return Some(candidate);
+        }
+        cursor = candidate + 1;
+    }
+    None
+}
+
+fn find_variant_close(content: &str, start: usize) -> Option<(usize, usize)> {
+    let bytes = content.as_bytes();
+    let mut cursor = start;
+    while let Some(relative) = content.get(cursor..)?.find("</") {
+        let candidate = cursor + relative;
+        let name_end = candidate + "</variant".len();
+        if bytes
+            .get(candidate..name_end)?
+            .eq_ignore_ascii_case(b"</variant")
+            && bytes
+                .get(name_end)
+                .is_none_or(|byte| is_tag_name_boundary(*byte))
+        {
+            let close_tag_end = find_tag_end(content, candidate)? + 1;
+            return Some((candidate, close_tag_end));
+        }
+        cursor = candidate + 2;
+    }
+    None
+}
+
+fn find_tag_end(content: &str, start: usize) -> Option<usize> {
+    let mut quote = None;
+    for (relative, byte) in content.as_bytes().get(start..)?.iter().copied().enumerate() {
+        match quote {
+            Some(current) if byte == current => quote = None,
+            Some(_) => {}
+            None if byte == b'\'' || byte == b'"' => quote = Some(byte),
+            None if byte == b'>' => return Some(start + relative),
+            None => {}
+        }
+    }
+    None
+}
+
+fn is_tag_name_boundary(byte: u8) -> bool {
+    byte.is_ascii_whitespace() || byte == b'>' || byte == b'/'
+}
+
+fn trim_template_range(content: &str, start: usize, end: usize) -> (usize, usize) {
+    if start >= end || end > content.len() {
+        return (end, end);
+    }
+
+    let segment = &content[start..end];
+    let Some((first, _)) = segment.char_indices().find(|(_, ch)| !ch.is_whitespace()) else {
+        return (end, end);
+    };
+    let last_end = segment
+        .char_indices()
+        .rev()
+        .find(|(_, ch)| !ch.is_whitespace())
+        .map(|(index, ch)| index + ch.len_utf8())
+        .unwrap_or(first);
+
+    (start + first, start + last_end)
+}

--- a/crates/vize_maestro/src/virtual_code/generator/tests.rs
+++ b/crates/vize_maestro/src/virtual_code/generator/tests.rs
@@ -128,11 +128,15 @@ const x = 1
     assert_eq!(descriptor.custom_blocks.len(), 1);
     assert_eq!(descriptor.custom_blocks[0].block_type, "art");
 
-    // Offset inside <art> content area
+    // Offset inside <art> content area before the first variant
     let art_content_start = descriptor.custom_blocks[0].loc.start;
     assert_eq!(
-        find_block_at_offset(&descriptor, art_content_start + 5),
+        find_block_at_offset(&descriptor, art_content_start + 1),
         Some(BlockType::Art(ArtCursorPosition::ArtContent))
+    );
+    assert_eq!(
+        find_block_at_offset(&descriptor, source.find("<variant").unwrap() + 1),
+        Some(BlockType::Art(ArtCursorPosition::VariantTag(0)))
     );
 
     // In template - should still be Template
@@ -143,6 +147,29 @@ const x = 1
 
     // Outside any block
     assert_eq!(find_block_at_offset(&descriptor, 0), None);
+}
+
+#[test]
+fn test_find_block_at_offset_detects_inline_art_variant_template() {
+    let source = r#"<template><button /></template>
+
+<art>
+  <variant name="Primary">
+    <Self variant="primary" />
+  </variant>
+</art>"#;
+
+    let descriptor = vize_atelier_sfc::parse_sfc(source, Default::default()).unwrap();
+    let offset = source.find("variant=\"primary\"").unwrap();
+
+    let Some(BlockType::Art(ArtCursorPosition::VariantTemplate(info))) =
+        find_block_at_offset(&descriptor, offset)
+    else {
+        panic!("expected inline art variant template");
+    };
+
+    assert_eq!(info.variant_index, 0);
+    assert_eq!(info.template_start, source.find("<Self").unwrap());
 }
 
 #[test]

--- a/examples/vite-musea/src/env.d.ts
+++ b/examples/vite-musea/src/env.d.ts
@@ -1,20 +1,8 @@
 /// <reference types="vite-plus/client" />
+/// <reference types="@vizejs/vite-plugin-musea/client" />
 
 declare module "*.vue" {
   import type { DefineComponent } from "vue";
   const component: DefineComponent<{}, {}, any>;
   export default component;
 }
-
-type MuseaArtStatus = "draft" | "ready" | "deprecated";
-
-interface MuseaArtOptions {
-  title?: string;
-  description?: string;
-  category?: string;
-  tags?: string[];
-  status?: MuseaArtStatus;
-  order?: number;
-}
-
-declare function defineArt(source: string, options?: MuseaArtOptions): void;

--- a/examples/vite-musea/tsconfig.json
+++ b/examples/vite-musea/tsconfig.json
@@ -16,5 +16,8 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true
   },
-  "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.vue"]
+  "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.vue", "src/**/*.art.vue"],
+  "vueCompilerOptions": {
+    "extensions": [".vue", ".art.vue"]
+  }
 }

--- a/npm/vite-plugin-musea/README.md
+++ b/npm/vite-plugin-musea/README.md
@@ -91,6 +91,26 @@ and the metadata shown in the gallery. Prefer a relative component path string; 
 removed and Musea generates the component import. The Musea language server uses the same source
 for path completion, missing-file diagnostics, go-to-definition, and prop/slot inference.
 
+## TypeScript and Editor Setup
+
+Add the client types once, usually in `src/env.d.ts`:
+
+```ts
+/// <reference types="@vizejs/vite-plugin-musea/client" />
+```
+
+If your project type-checks `.art.vue` files with Volar or `vue-tsc`, include the extension in
+`tsconfig.json`:
+
+```json
+{
+  "include": ["src/**/*.ts", "src/**/*.vue", "src/**/*.art.vue"],
+  "vueCompilerOptions": {
+    "extensions": [".vue", ".art.vue"]
+  }
+}
+```
+
 Root `<script setup>` state is variant-local by default, so each variant gets its own refs,
 computed values, and composable calls:
 
@@ -164,6 +184,28 @@ musea({
   tokensPath: "src/tokens.json",
 });
 ```
+
+Tailwind v4 theme variables can also be used as the token source:
+
+```css
+/* src/styles/main.css */
+@import "tailwindcss";
+
+@theme {
+  --color-brand: oklch(70.5% 0.213 47.604);
+  --color-accent: var(--color-brand);
+  --spacing-card: 1.5rem;
+}
+```
+
+```ts
+musea({
+  tokensPath: "src/styles/main.css",
+});
+```
+
+`tokensPath` reads tokens for the gallery and token APIs. Use `previewCss` separately when that
+CSS file should also be loaded inside component preview iframes.
 
 ## Commands
 

--- a/npm/vite-plugin-musea/client.d.ts
+++ b/npm/vite-plugin-musea/client.d.ts
@@ -1,0 +1,19 @@
+type MuseaArtStatus = "draft" | "ready" | "deprecated";
+
+interface MuseaArtOptions {
+  title?: string;
+  description?: string;
+  category?: string;
+  tags?: string[];
+  status?: MuseaArtStatus;
+  order?: number;
+  actionEvents?: string[];
+}
+
+declare function defineArt(source: string, options?: MuseaArtOptions): void;
+declare function defineArt<TComponent>(component: TComponent, options?: MuseaArtOptions): void;
+
+declare module "*.art.vue" {
+  const component: import("vue").DefineComponent<{}, {}, any>;
+  export default component;
+}

--- a/npm/vite-plugin-musea/package.json
+++ b/npm/vite-plugin-musea/package.json
@@ -27,7 +27,8 @@
   "files": [
     "dist",
     "dist/gallery",
-    "bin"
+    "bin",
+    "client.d.ts"
   ],
   "type": "module",
   "main": "./dist/index.mjs",
@@ -36,6 +37,9 @@
     ".": {
       "import": "./dist/index.mjs",
       "types": "./dist/index.d.mts"
+    },
+    "./client": {
+      "types": "./client.d.ts"
     },
     "./vrt": {
       "import": "./dist/vrt.mjs",

--- a/npm/vite-plugin-musea/src/api-tokens.ts
+++ b/npm/vite-plugin-musea/src/api-tokens.ts
@@ -36,7 +36,7 @@ function sendTokenMutationError(e: unknown, sendError: SendError): void {
     return;
   }
 
-  if (e instanceof Error && /token path/i.test(e.message)) {
+  if (e instanceof Error && /(token path|token editing)/i.test(e.message)) {
     sendError(e.message, 400);
     return;
   }

--- a/npm/vite-plugin-musea/src/style-dictionary.ts
+++ b/npm/vite-plugin-musea/src/style-dictionary.ts
@@ -35,6 +35,7 @@ export {
   generateTokensMarkdown,
   processStyleDictionary,
 } from "./tokens/generator.js";
+export { isTailwindTokenPath, parseTailwindTokens } from "./tokens/tailwind.js";
 
 import { processStyleDictionary } from "./tokens/generator.js";
 export default processStyleDictionary;

--- a/npm/vite-plugin-musea/src/tokens.test.ts
+++ b/npm/vite-plugin-musea/src/tokens.test.ts
@@ -9,6 +9,7 @@ import {
   buildTokenMap,
   deleteTokenAtPath,
   resolveReferences,
+  scanTokenUsage,
   setTokenAtPath,
 } from "./tokens/resolver.ts";
 
@@ -85,6 +86,82 @@ void test("token parsing keeps prototype-like token names as data", async () => 
     assert.equal(Object.getPrototypeOf(tokenMap), null);
     assert.equal(tokenMap["color.__proto__"]?.value, "#fff");
     assert.equal(({} as Record<string, unknown>).value, undefined);
+  } finally {
+    await fs.promises.rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+void test("parseTokens reads Tailwind CSS theme variables", async () => {
+  const tempDir = await makeAgentTempDir();
+  const cssPath = path.join(tempDir, "main.css");
+
+  try {
+    await fs.promises.writeFile(
+      cssPath,
+      `
+@import "tailwindcss";
+
+@theme {
+  --color-brand: oklch(70.5% 0.213 47.604);
+  --color-accent: var(--color-brand);
+  --spacing-card: 1.5rem;
+  --font-weight-semibold: 600;
+}
+`,
+      "utf-8",
+    );
+
+    const categories = await parseTokens(cssPath);
+    const tokenMap = buildTokenMap(categories);
+    resolveReferences(categories, tokenMap);
+    const resolvedTokenMap = buildTokenMap(categories);
+
+    assert.equal(resolvedTokenMap["color.brand"]?.value, "oklch(70.5% 0.213 47.604)");
+    assert.equal(resolvedTokenMap["color.accent"]?.$reference, "color.brand");
+    assert.equal(resolvedTokenMap["color.accent"]?.$resolvedValue, "oklch(70.5% 0.213 47.604)");
+    assert.equal(resolvedTokenMap["spacing.card"]?.value, "1.5rem");
+    assert.equal(resolvedTokenMap["typography.fontweight.semibold"]?.value, "600");
+    assert.equal(resolvedTokenMap["color.brand"]?.attributes?.tailwindVariable, "--color-brand");
+  } finally {
+    await fs.promises.rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+void test("scanTokenUsage matches Tailwind CSS variable usage", async () => {
+  const tempDir = await makeAgentTempDir();
+  const artPath = path.join(tempDir, "Button.art.vue");
+  const tokenMap = {
+    "color.brand": {
+      value: "oklch(70.5% 0.213 47.604)",
+      type: "color",
+      attributes: { tailwindVariable: "--color-brand" },
+    },
+  };
+  try {
+    await fs.promises.writeFile(
+      artPath,
+      `
+<art><variant name="Default"><button /></variant></art>
+<style>
+.button {
+  color: var(--color-brand);
+}
+</style>
+`,
+      "utf-8",
+    );
+
+    const artFiles = new Map([
+      [
+        artPath,
+        {
+          path: artPath,
+          metadata: { title: "Button", category: "UI" },
+        },
+      ],
+    ]);
+    const usage = scanTokenUsage(artFiles, tokenMap);
+    assert.equal(usage["color.brand"]?.[0]?.matches[0]?.property, "color");
   } finally {
     await fs.promises.rm(tempDir, { recursive: true, force: true });
   }

--- a/npm/vite-plugin-musea/src/tokens/generator.ts
+++ b/npm/vite-plugin-musea/src/tokens/generator.ts
@@ -13,7 +13,8 @@ import { parseTokens } from "./parser.js";
 import { tokenNative } from "./native.js";
 import { escapeHtml } from "../utils.js";
 
-const SAFE_CSS_COLOR_PATTERN = /^(?:#[0-9a-fA-F]{3,8}|(?:rgb|hsl)a?\(\s*[-+.\d,%\s]+\))$/;
+const SAFE_CSS_COLOR_PATTERN =
+  /^(?:#[0-9a-fA-F]{3,8}|(?:rgb|hsl)a?\(\s*[-+.\d,%\s/]+\)|(?:oklch|oklab|lab|lch)\(\s*[-+.\d,%\s/]+\))$/;
 const DANGEROUS_PROTOCOL_PATTERN = /\b(javascript|vbscript):/gi;
 
 function escapeTokenText(value: string): string {

--- a/npm/vite-plugin-musea/src/tokens/index.ts
+++ b/npm/vite-plugin-musea/src/tokens/index.ts
@@ -33,6 +33,7 @@ export {
 } from "./resolver.js";
 
 export { generateTokensHtml, generateTokensMarkdown, processStyleDictionary } from "./generator.js";
+export { isTailwindTokenPath, parseTailwindTokens } from "./tailwind.js";
 
 import { processStyleDictionary } from "./generator.js";
 export default processStyleDictionary;

--- a/npm/vite-plugin-musea/src/tokens/parser.ts
+++ b/npm/vite-plugin-musea/src/tokens/parser.ts
@@ -5,6 +5,7 @@
  */
 
 import { normalizeCategories, tokenNative } from "./native.js";
+import { isTailwindTokenPath, parseTailwindTokens } from "./tailwind.js";
 
 /**
  * Design token value.
@@ -45,7 +46,7 @@ export interface StyleDictionaryOutput {
  */
 export interface StyleDictionaryConfig {
   /**
-   * Path to tokens JSON/JS file or directory.
+   * Path to tokens JSON file/directory or Tailwind CSS theme file.
    */
   tokensPath: string;
 
@@ -73,8 +74,11 @@ export interface StyleDictionaryConfig {
 export type TokenTransform = (token: DesignToken, path: string[]) => DesignToken;
 
 /**
- * Parse Style Dictionary tokens file or directory.
+ * Parse Style Dictionary tokens file/directory or Tailwind CSS theme variables.
  */
 export async function parseTokens(tokensPath: string): Promise<TokenCategory[]> {
+  if (await isTailwindTokenPath(tokensPath)) {
+    return parseTailwindTokens(tokensPath);
+  }
   return normalizeCategories(tokenNative().parseDesignTokensFromPath(tokensPath));
 }

--- a/npm/vite-plugin-musea/src/tokens/resolver.ts
+++ b/npm/vite-plugin-musea/src/tokens/resolver.ts
@@ -6,9 +6,12 @@
  */
 
 import fs from "node:fs";
+import path from "node:path";
 
 import type { DesignToken, TokenCategory } from "./parser.js";
 import { normalizeCategories, nullRecord, tokenNative } from "./native.js";
+
+const JSON_TOKEN_EXTENSIONS = new Set([".json", ".tokens.json"]);
 
 // Re-export usage scanning and normalization from usage
 export { normalizeTokenValue, scanTokenUsage } from "./usage.js";
@@ -75,6 +78,9 @@ export function resolveReferences(
  * Read raw JSON token file.
  */
 export async function readRawTokenFile(tokensPath: string): Promise<Record<string, unknown>> {
+  if (!isJsonTokenPath(tokensPath)) {
+    throw new Error("Token editing is only supported for JSON token files");
+  }
   const content = await fs.promises.readFile(tokensPath, "utf-8");
   return JSON.parse(content) as Record<string, unknown>;
 }
@@ -86,9 +92,16 @@ export async function writeRawTokenFile(
   tokensPath: string,
   data: Record<string, unknown>,
 ): Promise<void> {
+  if (!isJsonTokenPath(tokensPath)) {
+    throw new Error("Token editing is only supported for JSON token files");
+  }
   const tmpPath = tokensPath + ".tmp";
   await fs.promises.writeFile(tmpPath, JSON.stringify(data, null, 2) + "\n", "utf-8");
   await fs.promises.rename(tmpPath, tokensPath);
+}
+
+function isJsonTokenPath(tokensPath: string): boolean {
+  return JSON_TOKEN_EXTENSIONS.has(path.extname(tokensPath)) || tokensPath.endsWith(".tokens.json");
 }
 
 /**

--- a/npm/vite-plugin-musea/src/tokens/tailwind.ts
+++ b/npm/vite-plugin-musea/src/tokens/tailwind.ts
@@ -1,0 +1,207 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { nullRecord, normalizeCategories } from "./native.js";
+import type { DesignToken, TokenCategory } from "./parser.js";
+
+interface TailwindTokenCandidate {
+  variable: string;
+  value: string;
+  category: string;
+  path: string[];
+  type: string;
+}
+
+const TAILWIND_TOKEN_EXTENSIONS = new Set([".css", ".pcss", ".postcss"]);
+const VARIABLE_DECLARATION_RE = /(--[A-Za-z0-9_-]+)\s*:\s*([^;{}]+);/g;
+const CSS_COMMENT_RE = /\/\*[\s\S]*?\*\//g;
+
+const NAMESPACE_MAPPINGS: Array<{
+  prefix: string;
+  category: string;
+  pathPrefix?: string[];
+  type: string;
+}> = [
+  { prefix: "inset-shadow", category: "shadow", pathPrefix: ["inset"], type: "shadow" },
+  { prefix: "drop-shadow", category: "shadow", pathPrefix: ["drop"], type: "shadow" },
+  { prefix: "font-weight", category: "typography", pathPrefix: ["fontWeight"], type: "fontWeight" },
+  { prefix: "color", category: "color", type: "color" },
+  { prefix: "spacing", category: "spacing", type: "dimension" },
+  { prefix: "font", category: "typography", pathPrefix: ["font"], type: "fontFamily" },
+  { prefix: "text", category: "typography", pathPrefix: ["fontSize"], type: "dimension" },
+  { prefix: "leading", category: "typography", pathPrefix: ["lineHeight"], type: "number" },
+  {
+    prefix: "tracking",
+    category: "typography",
+    pathPrefix: ["letterSpacing"],
+    type: "dimension",
+  },
+  { prefix: "radius", category: "radius", type: "dimension" },
+  { prefix: "shadow", category: "shadow", type: "shadow" },
+  { prefix: "breakpoint", category: "breakpoint", type: "dimension" },
+  { prefix: "container", category: "container", type: "dimension" },
+  { prefix: "ease", category: "easing", type: "cubicBezier" },
+  { prefix: "animate", category: "animation", type: "transition" },
+  { prefix: "blur", category: "blur", type: "dimension" },
+  { prefix: "perspective", category: "perspective", type: "dimension" },
+  { prefix: "aspect", category: "aspectRatio", type: "number" },
+];
+
+export async function isTailwindTokenPath(tokensPath: string): Promise<boolean> {
+  const stat = await fs.promises.stat(tokensPath).catch(() => null);
+  if (!stat) return false;
+  if (stat.isFile()) {
+    return TAILWIND_TOKEN_EXTENSIONS.has(path.extname(tokensPath));
+  }
+  if (!stat.isDirectory()) {
+    return false;
+  }
+  const entries = await fs.promises.readdir(tokensPath, { withFileTypes: true });
+  return entries.some(
+    (entry) => entry.isFile() && TAILWIND_TOKEN_EXTENSIONS.has(path.extname(entry.name)),
+  );
+}
+
+export async function parseTailwindTokens(tokensPath: string): Promise<TokenCategory[]> {
+  const files = await collectTailwindTokenFiles(tokensPath);
+  const candidates: TailwindTokenCandidate[] = [];
+
+  for (const file of files) {
+    const css = await fs.promises.readFile(file, "utf-8");
+    candidates.push(...extractTailwindTokenCandidates(css));
+  }
+
+  return normalizeCategories(buildCategories(candidates));
+}
+
+async function collectTailwindTokenFiles(tokensPath: string): Promise<string[]> {
+  const stat = await fs.promises.stat(tokensPath);
+  if (stat.isFile()) {
+    return [tokensPath];
+  }
+
+  const entries = await fs.promises.readdir(tokensPath, { withFileTypes: true });
+  return entries
+    .filter((entry) => entry.isFile() && TAILWIND_TOKEN_EXTENSIONS.has(path.extname(entry.name)))
+    .map((entry) => path.join(tokensPath, entry.name))
+    .sort();
+}
+
+function extractTailwindTokenCandidates(css: string): TailwindTokenCandidate[] {
+  const source = css.replace(CSS_COMMENT_RE, "");
+  const candidates: TailwindTokenCandidate[] = [];
+  let match: RegExpExecArray | null;
+  VARIABLE_DECLARATION_RE.lastIndex = 0;
+
+  while ((match = VARIABLE_DECLARATION_RE.exec(source)) !== null) {
+    const variable = match[1];
+    const value = match[2].trim();
+    const mapped = mapTailwindVariable(variable);
+    if (!mapped || !value) {
+      continue;
+    }
+    candidates.push({ variable, value, ...mapped });
+  }
+
+  return candidates;
+}
+
+function mapTailwindVariable(
+  variable: string,
+): Omit<TailwindTokenCandidate, "variable" | "value"> | null {
+  const name = variable.replace(/^--/, "");
+  const mapping = NAMESPACE_MAPPINGS.find(
+    (candidate) => name === candidate.prefix || name.startsWith(`${candidate.prefix}-`),
+  );
+  if (!mapping) {
+    return null;
+  }
+
+  const rest = name === mapping.prefix ? "DEFAULT" : name.slice(mapping.prefix.length + 1);
+  const pathParts = [...(mapping.pathPrefix ?? []), ...tailwindNameToPath(rest)];
+  if (pathParts.length === 0) {
+    return null;
+  }
+
+  return {
+    category: mapping.category,
+    path: pathParts,
+    type: mapping.type,
+  };
+}
+
+function tailwindNameToPath(name: string): string[] {
+  if (!name || name === "DEFAULT") {
+    return ["DEFAULT"];
+  }
+
+  const parts = name.split("-").filter(Boolean);
+  if (parts.length <= 1) {
+    return parts;
+  }
+
+  const last = parts[parts.length - 1];
+  if (/^\d+$/.test(last)) {
+    return [...parts.slice(0, -1), last];
+  }
+
+  return [parts.join("-")];
+}
+
+function buildCategories(candidates: TailwindTokenCandidate[]): TokenCategory[] {
+  const variableToPath = new Map<string, string>();
+  for (const candidate of candidates) {
+    variableToPath.set(candidate.variable, [candidate.category, ...candidate.path].join("."));
+  }
+
+  const categoryMap = new Map<string, TokenCategory>();
+  for (const candidate of candidates) {
+    const category = categoryMap.get(candidate.category) ?? {
+      name: candidate.category,
+      tokens: nullRecord<DesignToken>({}),
+    };
+    categoryMap.set(candidate.category, category);
+
+    const valueReference = parseTailwindVariableReference(candidate.value);
+    const referencedPath = valueReference ? variableToPath.get(valueReference) : undefined;
+    const token: DesignToken = {
+      value: referencedPath ? `{${referencedPath}}` : candidate.value,
+      type: candidate.type,
+      description: `Tailwind theme variable ${candidate.variable}`,
+      attributes: {
+        tailwindVariable: candidate.variable,
+      },
+      $tier: referencedPath ? "semantic" : "primitive",
+      ...(referencedPath ? { $reference: referencedPath } : {}),
+    };
+
+    setCategoryToken(category, candidate.path, token);
+  }
+
+  return [...categoryMap.values()];
+}
+
+function parseTailwindVariableReference(value: string): string | undefined {
+  const match = value.match(/^var\(\s*(--[A-Za-z0-9_-]+)\s*(?:,[^)]+)?\)$/);
+  return match?.[1];
+}
+
+function setCategoryToken(category: TokenCategory, pathParts: string[], token: DesignToken): void {
+  if (pathParts.length === 1) {
+    category.tokens[pathParts[0]] = token;
+    return;
+  }
+
+  let current = category;
+  for (const part of pathParts.slice(0, -1)) {
+    current.subcategories ??= [];
+    let next = current.subcategories.find((subcategory) => subcategory.name === part);
+    if (!next) {
+      next = { name: part, tokens: nullRecord<DesignToken>({}) };
+      current.subcategories.push(next);
+    }
+    current = next;
+  }
+
+  current.tokens[pathParts[pathParts.length - 1]] = token;
+}

--- a/npm/vite-plugin-musea/src/tokens/usage.ts
+++ b/npm/vite-plugin-musea/src/tokens/usage.ts
@@ -54,6 +54,17 @@ export function scanTokenUsage(
     } else {
       valueLookup.set(normalized, [tokenPath]);
     }
+
+    const tailwindVariable = token.attributes?.tailwindVariable;
+    if (typeof tailwindVariable === "string") {
+      const normalizedVariable = normalizeTokenValue(`var(${tailwindVariable})`);
+      const variableMatches = valueLookup.get(normalizedVariable);
+      if (variableMatches) {
+        variableMatches.push(tokenPath);
+      } else {
+        valueLookup.set(normalizedVariable, [tokenPath]);
+      }
+    }
   }
 
   const usageMap: TokenUsageMap = {};

--- a/npm/vite-plugin-musea/src/types/plugin.ts
+++ b/npm/vite-plugin-musea/src/types/plugin.ts
@@ -85,9 +85,9 @@ export interface MuseaOptions {
   vrt?: VrtOptions;
 
   /**
-   * Path to Style Dictionary tokens JSON file or directory.
-   * Supports standard Style Dictionary format.
-   * @example 'src/tokens.json' or 'src/tokens/'
+   * Path to a Style Dictionary tokens JSON file/directory or Tailwind CSS theme file.
+   * Supports standard Style Dictionary format and Tailwind v4 `@theme` CSS variables.
+   * @example 'src/tokens.json', 'src/tokens/', or 'src/styles/main.css'
    */
   tokensPath?: string;
 


### PR DESCRIPTION
## Summary

- Improve `.art.vue` editor virtual TypeScript so `defineArt("./Component.vue", ...)` drives target component import resolution, prop checks, and relative `.vue` overlay resolution.
- Add inline `<art>` variant handling for regular `.vue` files, including variant template virtual documents and type-safe `Self` props based on the host component.
- Add published client types for `defineArt` and `*.art.vue`, and update the example TypeScript setup for `.art.vue` files.
- Add Tailwind CSS design token support by parsing CSS theme custom properties from `tokensPath`, resolving `var(--token)` references, and scanning Tailwind variable usage.
- Clarify that `tokensPath` only reads tokens and `previewCss` is needed to load CSS such as `main.css` in previews.

## Root Cause

`.art.vue` diagnostics and editor features were treating art templates as mostly structural templates without binding them to the target Vue component, and inline `<art>` blocks relied on the standalone art parser even though inline blocks can omit standalone metadata. Token parsing also only handled JSON-style token sources, so Tailwind CSS theme variables could not be used directly.

## Validation

- `cargo test -p vize_maestro`
- `vp run --filter @vizejs/vite-plugin-musea test`
- `vp run --filter @vizejs/vite-plugin-musea check`
- `vp run --filter @vizejs/vite-plugin-musea build`
- `vp run --filter vite-musea-example check`
- TypeScript compiler API validation for `npm/vite-plugin-musea/client.d.ts`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1718"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->