### PR TITLE
fix: prevent Musea preview reset from overriding Tailwind

### DIFF
--- a/npm/vite-plugin-musea/README.md
+++ b/npm/vite-plugin-musea/README.md
@@ -175,6 +175,9 @@ export default function setup(app: App) {
 }
 ```
 
+Musea's preview scaffold styles are emitted in a low-priority cascade layer, so layered CSS from
+frameworks such as Tailwind v4 can still override them when loaded through `previewCss`.
+
 ## Design Tokens
 
 Expose a Style Dictionary-compatible token file in the gallery:

--- a/npm/vite-plugin-musea/gallery/components/VariantCard.vue
+++ b/npm/vite-plugin-musea/gallery/components/VariantCard.vue
@@ -196,7 +196,8 @@ const window = globalThis.window;
 }
 
 .variant-preview {
-  aspect-ratio: 16 / 7;
+  aspect-ratio: 16 / 9;
+  min-height: clamp(260px, 36vw, 560px);
   background: var(--musea-bg-tertiary);
   display: flex;
   align-items: center;
@@ -208,13 +209,13 @@ const window = globalThis.window;
 
 .variant-preview.viewport-mode {
   aspect-ratio: unset;
-  min-height: 200px;
-  max-height: 350px;
+  min-height: 260px;
+  max-height: min(70vh, 720px);
   overflow: auto;
 }
 
 .variant-preview iframe {
-  width: 70%;
+  width: 100%;
   height: 100%;
   max-width: 100%;
   max-height: 100%;

--- a/npm/vite-plugin-musea/src/preview/html.test.ts
+++ b/npm/vite-plugin-musea/src/preview/html.test.ts
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { generatePreviewHtml } from "./html.ts";
+import type { ArtFileInfo } from "../types/art.ts";
+
+const art: ArtFileInfo = {
+  path: "/repo/components/Button.art.vue",
+  metadata: {
+    title: "Button",
+    tags: [],
+    status: "ready",
+  },
+  variants: [
+    {
+      name: "Default",
+      template: '<button class="px-4 py-2">Save</button>',
+      isDefault: true,
+      skipVrt: false,
+    },
+  ],
+  hasScriptSetup: false,
+  hasScript: false,
+  styleCount: 0,
+};
+
+void test("preview reset stays in a low-priority cascade layer", () => {
+  const html = generatePreviewHtml(art, art.variants[0], "/__musea__");
+  const resetLayerIndex = html.indexOf("@layer musea-preview");
+
+  assert.notEqual(resetLayerIndex, -1);
+  assert.doesNotMatch(html, /\*\s*\{\s*box-sizing:\s*border-box;\s*margin:\s*0;\s*padding:\s*0;/);
+  assert.match(html, /\*\s*,\s*\*::before\s*,\s*\*::after\s*\{\s*box-sizing:\s*border-box;/);
+  assert.equal(/@layer musea-preview[\s\S]*\*\s*\{[^}]*padding:\s*0/.test(html), false);
+  assert.equal(/@layer musea-preview[\s\S]*\*\s*\{[^}]*margin:\s*0/.test(html), false);
+});

--- a/npm/vite-plugin-musea/src/preview/html.ts
+++ b/npm/vite-plugin-musea/src/preview/html.ts
@@ -30,63 +30,70 @@ export function generatePreviewHtml(
   <title>${escapeHtml(art.metadata.title)} - ${escapeHtml(variant.name)}</title>
   <script type="module" src="${base}/@vite/client"></script>
   <style>
-    * { box-sizing: border-box; margin: 0; padding: 0; }
-    :root {
-      --musea-preview-padding: clamp(1rem, 2vw, 1.5rem);
+    @layer musea-preview {
+      *,
+      *::before,
+      *::after {
+        box-sizing: border-box;
+      }
+      :root {
+        --musea-preview-padding: clamp(1rem, 2vw, 1.5rem);
+      }
+      html, body {
+        width: 100%;
+        height: 100%;
+        margin: 0;
+      }
+      body {
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+        background: #ffffff;
+        padding: var(--musea-preview-padding);
+        overflow: auto;
+      }
+      .musea-variant {
+        width: 100%;
+        min-height: calc(100vh - (var(--musea-preview-padding) * 2));
+      }
+      .musea-error {
+        color: #dc2626;
+        background: #fef2f2;
+        border: 1px solid #fecaca;
+        border-radius: 8px;
+        padding: 1rem;
+        font-size: 0.875rem;
+        max-width: 400px;
+      }
+      .musea-error-title {
+        font-weight: 600;
+        margin-bottom: 0.5rem;
+      }
+      .musea-error pre {
+        font-family: monospace;
+        font-size: 0.75rem;
+        white-space: pre-wrap;
+        word-break: break-all;
+        margin-top: 0.5rem;
+        padding: 0.5rem;
+        background: #fff;
+        border-radius: 4px;
+      }
+      .musea-loading {
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+        color: #6b7280;
+        font-size: 0.875rem;
+      }
+      .musea-spinner {
+        width: 20px;
+        height: 20px;
+        border: 2px solid #e5e7eb;
+        border-top-color: #3b82f6;
+        border-radius: 50%;
+        animation: musea-preview-spin 0.8s linear infinite;
+      }
     }
-    html, body {
-      width: 100%;
-      height: 100%;
-    }
-    body {
-      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-      background: #ffffff;
-      padding: var(--musea-preview-padding);
-      overflow: auto;
-    }
-    .musea-variant {
-      width: 100%;
-      min-height: calc(100vh - (var(--musea-preview-padding) * 2));
-    }
-    .musea-error {
-      color: #dc2626;
-      background: #fef2f2;
-      border: 1px solid #fecaca;
-      border-radius: 8px;
-      padding: 1rem;
-      font-size: 0.875rem;
-      max-width: 400px;
-    }
-    .musea-error-title {
-      font-weight: 600;
-      margin-bottom: 0.5rem;
-    }
-    .musea-error pre {
-      font-family: monospace;
-      font-size: 0.75rem;
-      white-space: pre-wrap;
-      word-break: break-all;
-      margin-top: 0.5rem;
-      padding: 0.5rem;
-      background: #fff;
-      border-radius: 4px;
-    }
-    .musea-loading {
-      display: flex;
-      align-items: center;
-      gap: 0.75rem;
-      color: #6b7280;
-      font-size: 0.875rem;
-    }
-    .musea-spinner {
-      width: 20px;
-      height: 20px;
-      border: 2px solid #e5e7eb;
-      border-top-color: #3b82f6;
-      border-radius: 50%;
-      animation: spin 0.8s linear infinite;
-    }
-    @keyframes spin { to { transform: rotate(360deg); } }
+    @keyframes musea-preview-spin { to { transform: rotate(360deg); } }
 
     /* Musea Addons: Checkerboard background for transparent mode */
     .musea-bg-checkerboard {


### PR DESCRIPTION
## Summary

- move Musea preview scaffold reset styles into a low-priority `@layer musea-preview`
- stop applying a universal `margin: 0; padding: 0` reset inside preview iframes
- widen and heighten variant preview cards so page-like variants are less cramped
- document the preview CSS cascade behavior and add a regression test

## Root Cause

Musea injected an unlayered universal reset before `previewCss` imports. Tailwind v4 emits utilities in cascade layers, and normal unlayered author CSS has higher priority than layered utilities, so Musea's `padding: 0` reset could override classes such as `px-*` and `py-*` in the preview iframe.

## Validation

- `vp run --filter @vizejs/vite-plugin-musea test`
- `vp run --filter @vizejs/vite-plugin-musea check`
- `vp run --filter @vizejs/vite-plugin-musea build`
- `SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts`
- `git diff --check`

Fixes #1719

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1720"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->