### PR TITLE
fix: indent multiline directive attributes

### DIFF
--- a/crates/vize_glyph/src/template/attributes.rs
+++ b/crates/vize_glyph/src/template/attributes.rs
@@ -17,6 +17,8 @@ pub(crate) struct ParsedAttribute {
     pub(crate) priority: u8,
     /// Original index in the source for stable sorting
     pub(crate) original_index: usize,
+    /// Whether multiline value lines should be indented from the attribute line.
+    pub(crate) indent_multiline_value: bool,
 }
 
 /// Sort attributes based on the configured options.
@@ -147,6 +149,107 @@ pub(crate) fn render_attribute(attr: &ParsedAttribute) -> String {
     }
 }
 
+pub(crate) fn rendered_attribute_is_multiline(attr: &str) -> bool {
+    attr.contains('\n')
+}
+
+pub(crate) fn should_use_multiline_attrs(
+    options: &FormatOptions,
+    tag_name: &str,
+    attrs: &[ParsedAttribute],
+    rendered: &[String],
+    depth: usize,
+    indent: &[u8],
+) -> bool {
+    if attrs.iter().zip(rendered).any(|(attr, rendered)| {
+        attr.indent_multiline_value && rendered_attribute_is_multiline(rendered)
+    }) {
+        return true;
+    }
+
+    if attrs.len() <= 1 {
+        return false;
+    }
+
+    if let Some(max) = options.max_attributes_per_line {
+        return attrs.len() > max as usize;
+    }
+
+    if options.single_attribute_per_line {
+        return true;
+    }
+
+    let indent_len = indent.len() * depth;
+    let tag_len = 1 + tag_name.len();
+    let attrs_len: usize = rendered.iter().map(|a| 1 + a.len()).sum();
+    let closing_len = 1;
+
+    indent_len + tag_len + attrs_len + closing_len > options.print_width as usize
+}
+
+pub(crate) fn write_rendered_attributes(
+    output: &mut Vec<u8>,
+    attrs: &[ParsedAttribute],
+    rendered: &[String],
+    newline: &[u8],
+    indent: &[u8],
+    depth: usize,
+    max_per_line: usize,
+) {
+    debug_assert_eq!(attrs.len(), rendered.len());
+    let mut line_count = 0;
+    for (attr, rendered) in attrs.iter().zip(rendered) {
+        let attr_is_multiline = rendered_attribute_is_multiline(rendered);
+        if line_count == 0 || attr_is_multiline {
+            output.extend_from_slice(newline);
+            write_indent(output, indent, depth);
+        } else {
+            output.push(b' ');
+        }
+        write_rendered_attribute(
+            output,
+            rendered,
+            newline,
+            indent,
+            depth,
+            attr.indent_multiline_value,
+        );
+        if attr_is_multiline || line_count + 1 >= max_per_line {
+            line_count = 0;
+        } else {
+            line_count += 1;
+        }
+    }
+}
+
+fn write_rendered_attribute(
+    output: &mut Vec<u8>,
+    attr: &str,
+    newline: &[u8],
+    indent: &[u8],
+    continuation_depth: usize,
+    indent_continuation: bool,
+) {
+    let mut lines = attr.split('\n');
+    if let Some(first) = lines.next() {
+        output.extend_from_slice(first.trim_end_matches('\r').as_bytes());
+    }
+
+    for line in lines {
+        output.extend_from_slice(newline);
+        if indent_continuation {
+            write_indent(output, indent, continuation_depth);
+        }
+        output.extend_from_slice(line.trim_end_matches('\r').as_bytes());
+    }
+}
+
+fn write_indent(output: &mut Vec<u8>, indent: &[u8], depth: usize) {
+    for _ in 0..depth {
+        output.extend_from_slice(indent);
+    }
+}
+
 fn attribute_quote(value: &str) -> char {
     if value.contains('"') && !value.contains('\'') {
         '\''
@@ -173,7 +276,7 @@ fn escape_attribute_value(value: &str, quote: char) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{ParsedAttribute, render_attribute};
+    use super::{ParsedAttribute, render_attribute, write_rendered_attribute};
 
     #[test]
     fn render_attribute_uses_single_quotes_when_value_contains_double_quotes() {
@@ -182,6 +285,7 @@ mod tests {
             value: Some(r#"say "hello""#.into()),
             priority: 0,
             original_index: 0,
+            indent_multiline_value: false,
         };
 
         assert_eq!(render_attribute(&attr).as_str(), r#"title='say "hello"'"#);
@@ -194,11 +298,45 @@ mod tests {
             value: Some(r#"say "hello" and 'bye'"#.into()),
             priority: 0,
             original_index: 0,
+            indent_multiline_value: false,
         };
 
         assert_eq!(
             render_attribute(&attr).as_str(),
             r#"title="say &quot;hello&quot; and 'bye'""#
         );
+    }
+
+    #[test]
+    fn write_rendered_attribute_indents_multiline_value_lines() {
+        let mut output = Vec::new();
+        write_rendered_attribute(
+            &mut output,
+            ":class='[\n  active\n]'",
+            b"\n",
+            b"  ",
+            2,
+            true,
+        );
+
+        assert_eq!(
+            String::from_utf8(output).unwrap(),
+            ":class='[\n      active\n    ]'"
+        );
+    }
+
+    #[test]
+    fn write_rendered_attribute_leaves_literal_multiline_values_verbatim() {
+        let mut output = Vec::new();
+        write_rendered_attribute(
+            &mut output,
+            "class=\"\n  active\n\"",
+            b"\n",
+            b"  ",
+            2,
+            false,
+        );
+
+        assert_eq!(String::from_utf8(output).unwrap(), "class=\"\n  active\n\"");
     }
 }

--- a/crates/vize_glyph/src/template/directives.rs
+++ b/crates/vize_glyph/src/template/directives.rs
@@ -14,7 +14,7 @@ pub(crate) fn normalize_attribute(
     name: &str,
     value: Option<String>,
     options: &FormatOptions,
-) -> (String, Option<String>, u8) {
+) -> (String, Option<String>, u8, bool) {
     // Normalize directive shorthands (only if enabled)
     let normalized_name: String = if options.normalize_directive_shorthands {
         if let Some(rest) = name.strip_prefix("v-bind:") {
@@ -31,9 +31,12 @@ pub(crate) fn normalize_attribute(
     };
 
     // Format JS expressions in directive values
+    let mut indent_multiline_value = false;
     let formatted_value = value.map(|v| {
         if should_format_expression(&normalized_name) {
-            format_directive_value(&normalized_name, &v, options)
+            let (formatted, should_indent) = format_directive_value(&normalized_name, &v, options);
+            indent_multiline_value = should_indent;
+            formatted
         } else {
             v
         }
@@ -45,7 +48,12 @@ pub(crate) fn normalize_attribute(
         attribute_priority(&normalized_name)
     };
 
-    (normalized_name, formatted_value, priority)
+    (
+        normalized_name,
+        formatted_value,
+        priority,
+        indent_multiline_value,
+    )
 }
 
 /// Determine if an attribute's value should be formatted as a JS expression.
@@ -64,19 +72,25 @@ fn should_format_expression(name: &str) -> bool {
 }
 
 /// Format a directive value expression.
-fn format_directive_value(name: &str, value: &str, options: &FormatOptions) -> String {
+fn format_directive_value(name: &str, value: &str, options: &FormatOptions) -> (String, bool) {
     let trimmed = value.trim();
     if trimmed.is_empty() {
-        return value.to_compact_string();
+        return (value.to_compact_string(), false);
     }
 
     // v-for has special syntax: "(item, index) in items"
     if name == "v-for" {
-        return format_v_for_expression(trimmed);
+        return (format_v_for_expression(trimmed), false);
     }
 
     // Try to format as JS expression via oxc_formatter
-    script::format_js_expression(trimmed, options).unwrap_or_else(|| value.to_compact_string())
+    match script::format_js_expression(trimmed, options) {
+        Some(formatted) => {
+            let indent_multiline_value = formatted.contains('\n');
+            (formatted, indent_multiline_value)
+        }
+        None => (value.to_compact_string(), false),
+    }
 }
 
 /// Format `v-for` expression: normalize spacing in `(item, index) in items`.

--- a/crates/vize_glyph/src/template/formatter.rs
+++ b/crates/vize_glyph/src/template/formatter.rs
@@ -9,7 +9,10 @@ use memchr::memchr3;
 use vize_carton::{String, ToCompactString};
 
 use super::{
-    attributes::{ParsedAttribute, render_attribute, sort_attributes},
+    attributes::{
+        ParsedAttribute, render_attribute, should_use_multiline_attrs, sort_attributes,
+        write_rendered_attributes,
+    },
     directives::normalize_attribute,
     helpers::{
         find_bytes, is_tag_name_char, is_void_element_str, is_whitespace, parse_closing_tag,
@@ -130,8 +133,14 @@ impl<'a> TemplateFormatter<'a> {
                         let mut rendered: Vec<String> = Vec::with_capacity(sorted_attrs.len());
                         rendered.extend(sorted_attrs.iter().map(render_attribute));
 
-                        let use_multiline =
-                            self.should_use_multiline_attrs(&tag_name, &rendered, depth);
+                        let use_multiline = should_use_multiline_attrs(
+                            self.options,
+                            &tag_name,
+                            &sorted_attrs,
+                            &rendered,
+                            depth,
+                            self.indent,
+                        );
 
                         if use_multiline {
                             let max_per_line = self
@@ -140,21 +149,15 @@ impl<'a> TemplateFormatter<'a> {
                                 .unwrap_or(1) // default 1 when multiline
                                 .max(1) as usize;
 
-                            let mut line_count = 0;
-                            for attr in &rendered {
-                                if line_count == 0 {
-                                    // Start a new attribute line
-                                    output.extend_from_slice(self.newline);
-                                    self.write_indent(&mut output, depth + 1);
-                                } else {
-                                    output.push(b' ');
-                                }
-                                output.extend_from_slice(attr.as_bytes());
-                                line_count += 1;
-                                if line_count >= max_per_line {
-                                    line_count = 0;
-                                }
-                            }
+                            write_rendered_attributes(
+                                &mut output,
+                                &sorted_attrs,
+                                &rendered,
+                                self.newline,
+                                self.indent,
+                                depth + 1,
+                                max_per_line,
+                            );
                             if !self.options.bracket_same_line {
                                 output.extend_from_slice(self.newline);
                                 self.write_indent(&mut output, depth);
@@ -469,43 +472,6 @@ impl<'a> TemplateFormatter<'a> {
         output.extend_from_slice(self.newline);
     }
 
-    /// Determine whether attributes should be rendered in multiline mode.
-    ///
-    /// Takes the pre-rendered attribute strings so each attribute is rendered
-    /// exactly once on the common path (shared with the emission loop).
-    fn should_use_multiline_attrs(
-        &self,
-        tag_name: &str,
-        rendered: &[String],
-        depth: usize,
-    ) -> bool {
-        if rendered.len() <= 1 {
-            return false;
-        }
-
-        // Explicit max_attributes_per_line takes priority
-        if let Some(max) = self.options.max_attributes_per_line {
-            return rendered.len() > max as usize;
-        }
-
-        // single_attribute_per_line
-        if self.options.single_attribute_per_line {
-            return true;
-        }
-
-        // Check if all attributes on one line would exceed print_width
-        let indent_len = self.indent.len() * depth;
-        let tag_len = 1 + tag_name.len(); // '<' + tag_name
-        let attrs_len: usize = rendered
-            .iter()
-            .map(|a| 1 + a.len()) // ' ' + attr
-            .sum();
-        let closing_len = 1; // '>'
-        let total = indent_len + tag_len + attrs_len + closing_len;
-
-        total > self.options.print_width as usize
-    }
-
     /// Parse an opening tag into structured attributes.
     fn parse_opening_tag(
         &self,
@@ -677,7 +643,8 @@ impl<'a> TemplateFormatter<'a> {
         };
 
         // Normalize directives and determine priority
-        let (name, value, priority) = normalize_attribute(&raw_name, value, self.options);
+        let (name, value, priority, indent_multiline_value) =
+            normalize_attribute(&raw_name, value, self.options);
 
         (
             Some(ParsedAttribute {
@@ -685,6 +652,7 @@ impl<'a> TemplateFormatter<'a> {
                 value,
                 priority,
                 original_index: index,
+                indent_multiline_value,
             }),
             pos,
         )

--- a/crates/vize_glyph/tests/template_directive_attributes.rs
+++ b/crates/vize_glyph/tests/template_directive_attributes.rs
@@ -1,0 +1,34 @@
+use vize_glyph::{FormatOptions, format_template};
+
+#[test]
+fn multiline_directive_attribute_value_is_indented_from_attribute_depth() {
+    let source = r#"<span
+  :class='[
+rec.years.includes(y) && selectedYear === y
+  ? "bg-accent border border-accent text-accent-ink"
+  : rec.years.includes(y)
+    ? "bg-ink border border-ink text-paper"
+    : "border border-ink text-ink",
+]'
+  :title="y"
+></span>"#;
+
+    let options = FormatOptions::default();
+    let first = format_template(source, &options).unwrap();
+    let second = format_template(&first, &options).unwrap();
+
+    assert_eq!(
+        first.as_str(),
+        r#"<span
+  :class='[
+    rec.years.includes(y) && selectedYear === y
+      ? "bg-accent border border-accent text-accent-ink"
+      : rec.years.includes(y)
+        ? "bg-ink border border-ink text-paper"
+        : "border border-ink text-ink",
+  ]'
+  :title="y"
+></span>"#
+    );
+    assert_eq!(first, second);
+}


### PR DESCRIPTION
## Summary

Fix glyph template attribute rendering so multiline directive expression values keep formatter line breaks while each continuation line is indented from the attribute line depth.

Root cause: rendered attribute strings can contain newlines from JS expression formatting, but the template writer copied those embedded newlines without re-applying the current tag/attribute indent.

This keeps literal multiline static attribute values verbatim so existing idempotency behavior is preserved.

## Checks

- cargo test -p vize_glyph
- cargo clippy -p vize_glyph --lib -- -D warnings
- cargo fmt --all -- --check
- node --test tests/tooling/source-file-lengths.test.ts
- git diff --check