### PR TITLE
fix: normalize Windows check paths

### DIFF
--- a/crates/vize/src/commands/check/imports.rs
+++ b/crates/vize/src/commands/check/imports.rs
@@ -268,7 +268,7 @@ fn cstr_index(ext: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-
+    use vize_carton::path::canonicalize_non_verbatim;
     fn write(dir: &Path, rel: &str, contents: &str) -> PathBuf {
         let path = dir.join(rel);
         if let Some(parent) = path.parent() {
@@ -308,7 +308,7 @@ mod tests {
             false,
         );
 
-        let canon = |p: &Path| p.canonicalize().unwrap();
+        let canon = canonicalize_non_verbatim;
         assert_eq!(discovered, vec![canon(&types), canon(&child), canon(&util)]);
 
         let _ = std::fs::remove_dir_all(&root);
@@ -360,7 +360,7 @@ mod tests {
         );
 
         assert_eq!(disabled, Vec::<PathBuf>::new());
-        assert_eq!(enabled, vec![panel.canonicalize().unwrap()]);
+        assert_eq!(enabled, vec![canonicalize_non_verbatim(&panel)]);
 
         let _ = std::fs::remove_dir_all(&root);
     }

--- a/crates/vize/src/commands/check/path_cache.rs
+++ b/crates/vize/src/commands/check/path_cache.rs
@@ -26,7 +26,7 @@ impl CanonicalPathCache {
         if let Some(cached) = self.cache.get(path) {
             return cached.clone();
         }
-        let canonical = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+        let canonical = vize_carton::path::canonicalize_non_verbatim(path);
         self.cache.insert(path.to_path_buf(), canonical.clone());
         canonical
     }
@@ -44,7 +44,10 @@ mod tests {
 
         let mut cache = CanonicalPathCache::default();
         let canonical = cache.canonicalize(&file);
-        assert_eq!(canonical, file.canonicalize().unwrap());
+        assert_eq!(
+            canonical,
+            vize_carton::path::canonicalize_non_verbatim(&file)
+        );
         // Cached lookups return the same result.
         assert_eq!(cache.canonicalize(&file), canonical);
 

--- a/crates/vize/src/commands/check/runner/collect.rs
+++ b/crates/vize/src/commands/check/runner/collect.rs
@@ -231,7 +231,7 @@ fn strip_leading_current_dir(value: &str) -> String {
 }
 
 fn normalize_input_path(path: &Path) -> PathBuf {
-    path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
+    vize_carton::path::canonicalize_non_verbatim(path)
 }
 
 fn normalize_walked_path(root: &Path, normalized_root: &Path, path: &Path) -> PathBuf {

--- a/crates/vize/src/commands/check/runner/diagnostics.rs
+++ b/crates/vize/src/commands/check/runner/diagnostics.rs
@@ -234,13 +234,11 @@ fn normalize_requested_virtual_ts_path(cwd: &Path, path: &Path) -> PathBuf {
     } else {
         cwd.join(path)
     };
-    absolute.canonicalize().unwrap_or(absolute)
+    vize_carton::path::canonicalize_non_verbatim(&absolute)
 }
 
 fn paths_refer_to_same_file(candidate_path: &Path, requested_path: &Path) -> bool {
-    let candidate_path = candidate_path
-        .canonicalize()
-        .unwrap_or_else(|_| candidate_path.to_path_buf());
+    let candidate_path = vize_carton::path::canonicalize_non_verbatim(candidate_path);
     candidate_path == requested_path
 }
 

--- a/crates/vize/src/commands/check/runner/global_components.rs
+++ b/crates/vize/src/commands/check/runner/global_components.rs
@@ -231,9 +231,7 @@ fn load_tsconfig_type_packages(
     tsconfig_path: &Path,
     seen: &mut FxHashSet<PathBuf>,
 ) -> Option<Vec<String>> {
-    let resolved = tsconfig_path
-        .canonicalize()
-        .unwrap_or_else(|_| tsconfig_path.to_path_buf());
+    let resolved = vize_carton::path::canonicalize_non_verbatim(tsconfig_path);
     if !seen.insert(resolved.clone()) {
         return None;
     }
@@ -415,15 +413,13 @@ fn push_declaration_entry_candidate(candidates: &mut Vec<PathBuf>, path: PathBuf
 }
 
 fn collect_package_declaration_graph(entry: &Path, package_root: &Path) -> Vec<PathBuf> {
-    let package_root = package_root
-        .canonicalize()
-        .unwrap_or_else(|_| package_root.to_path_buf());
+    let package_root = vize_carton::path::canonicalize_non_verbatim(package_root);
     let mut files = Vec::new();
     let mut seen = FxHashSet::default();
     let mut queue = vec![entry.to_path_buf()];
 
     while let Some(path) = queue.pop() {
-        let path = path.canonicalize().unwrap_or(path);
+        let path = vize_carton::path::canonicalize_non_verbatim(&path);
         if !seen.insert(path.clone()) {
             continue;
         }
@@ -437,7 +433,7 @@ fn collect_package_declaration_graph(entry: &Path, package_root: &Path) -> Vec<P
         };
         for reference in content.lines().filter_map(reference_path_attribute) {
             let referenced = base_dir.join(reference);
-            let referenced = referenced.canonicalize().unwrap_or(referenced);
+            let referenced = vize_carton::path::canonicalize_non_verbatim(&referenced);
             if referenced.starts_with(&package_root)
                 && is_declaration_path(&referenced)
                 && referenced.is_file()

--- a/crates/vize/src/commands/check/runner/nuxt_tsconfig.rs
+++ b/crates/vize/src/commands/check/runner/nuxt_tsconfig.rs
@@ -97,9 +97,7 @@ fn load_tsconfig_paths_for_wrapper_inner(
     wrapper_dir: &Path,
     seen: &mut FxHashSet<PathBuf>,
 ) -> Result<JsonObject, std::io::Error> {
-    let resolved = tsconfig_path
-        .canonicalize()
-        .unwrap_or_else(|_| tsconfig_path.to_path_buf());
+    let resolved = vize_carton::path::canonicalize_non_verbatim(tsconfig_path);
     if !seen.insert(resolved.clone()) {
         return Ok(Map::new());
     }

--- a/crates/vize/src/commands/check/runner/resolve.rs
+++ b/crates/vize/src/commands/check/runner/resolve.rs
@@ -52,9 +52,7 @@ pub(super) fn resolve_project_root(
         } else {
             cwd.join(tsconfig)
         };
-        let tsconfig_dir = tsconfig_path
-            .canonicalize()
-            .unwrap_or(tsconfig_path)
+        let tsconfig_dir = vize_carton::path::canonicalize_non_verbatim(&tsconfig_path)
             .parent()
             .map(|parent| parent.to_path_buf())
             .unwrap_or_else(|| cwd.to_path_buf());
@@ -88,7 +86,7 @@ pub(super) fn resolve_tsconfig_path(
         } else {
             cwd.join(tsconfig)
         };
-        return Some(tsconfig_path.canonicalize().unwrap_or(tsconfig_path));
+        return Some(vize_carton::path::canonicalize_non_verbatim(&tsconfig_path));
     }
 
     let candidate = project_root.join("tsconfig.json");

--- a/crates/vize/src/commands/check/tsconfig_inputs/glob.rs
+++ b/crates/vize/src/commands/check/tsconfig_inputs/glob.rs
@@ -72,7 +72,7 @@ pub(super) fn normalize_path_separators(path: &Path) -> std::string::String {
 }
 
 pub(super) fn normalize_input_path(path: &Path) -> PathBuf {
-    path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
+    vize_carton::path::canonicalize_non_verbatim(path)
 }
 
 pub(super) fn normalize_walked_path(root: &Path, normalized_root: &Path, path: &Path) -> PathBuf {

--- a/crates/vize/src/commands/check/tsconfig_inputs/tests.rs
+++ b/crates/vize/src/commands/check/tsconfig_inputs/tests.rs
@@ -5,7 +5,7 @@
 use super::{TsconfigInputCache, load_tsconfig_declaration_options, resolve_extended_tsconfig};
 use std::fs;
 use std::path::{Path, PathBuf};
-use vize_carton::cstr;
+use vize_carton::{cstr, path::canonicalize_non_verbatim};
 
 // Each call uses a fresh run-scoped cache, mirroring how an actual `vize
 // check` run constructs one `TsconfigInputCache` per invocation.
@@ -1053,7 +1053,7 @@ fn owner_resolution_returns_root_for_no_supported_files() {
     let root = case_dir.join("tsconfig.json");
     fs::write(&root, r#"{ "include": ["src/**/*.ts"] }"#).unwrap();
 
-    let normalized_root = root.canonicalize().unwrap_or(root.clone());
+    let normalized_root = canonicalize_non_verbatim(&root);
 
     // Empty file list -> root.
     assert_eq!(
@@ -1091,7 +1091,7 @@ fn owner_resolution_falls_back_to_root_when_files_span_projects() {
 
     let owner = resolve_tsconfig_for_files(Some(&root), &[a_file, b_file]);
 
-    assert_eq!(owner, Some(root.canonicalize().unwrap_or(root.clone())));
+    assert_eq!(owner, Some(canonicalize_non_verbatim(&root)));
 
     let _ = fs::remove_dir_all(&case_dir);
 }
@@ -1113,7 +1113,7 @@ fn owner_resolution_falls_back_to_root_for_an_unowned_file() {
 
     let owner = resolve_tsconfig_for_files(Some(&root), &[unowned]);
 
-    assert_eq!(owner, Some(root.canonicalize().unwrap_or(root.clone())));
+    assert_eq!(owner, Some(canonicalize_non_verbatim(&root)));
 
     let _ = fs::remove_dir_all(&case_dir);
 }

--- a/crates/vize/tests/check_cli.rs
+++ b/crates/vize/tests/check_cli.rs
@@ -4,7 +4,7 @@ use std::{
     process::{Command, Stdio},
 };
 
-use vize_carton::cstr;
+use vize_carton::{cstr, path::canonicalize_non_verbatim};
 
 #[test]
 fn check_json_reports_type_errors_via_project_typechecker() {
@@ -370,7 +370,6 @@ import { message } from '../shared'
     )
     .unwrap();
     let source_arg = source_file.to_string_lossy().into_owned();
-
     let output = Command::new(env!("CARGO_BIN_EXE_vize"))
         .current_dir(&cwd)
         .env("CORSA_PATH", corsa_path)
@@ -389,7 +388,6 @@ import { message } from '../shared'
     let json: serde_json::Value = serde_json::from_str(&stdout).unwrap_or_else(|error| {
         panic!("failed to parse stdout as JSON: {error}\nstdout:\n{stdout}\nstderr:\n{stderr}")
     });
-
     assert_eq!(
         output.status.code(),
         Some(0),
@@ -400,7 +398,9 @@ import { message } from '../shared'
         json["errorCount"], 0,
         "stdout:\n{stdout}\nstderr:\n{stderr}"
     );
-    let expected_file = source_file.canonicalize().unwrap().display().to_string();
+    let expected_file = canonicalize_non_verbatim(&source_file)
+        .display()
+        .to_string();
     assert_eq!(
         json["files"][0]["file"], expected_file,
         "stdout:\n{stdout}\nstderr:\n{stderr}"
@@ -3661,7 +3661,7 @@ fn recv_lsp_matching(
 }
 
 fn file_uri(path: &Path) -> std::string::String {
-    let path = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+    let path = canonicalize_non_verbatim(path);
     let path = path.to_string_lossy().replace('\\', "/");
     let prefix = if path.starts_with('/') {
         "file://"
@@ -3910,7 +3910,7 @@ fn link_or_stub_package(
 
 fn package_link_source(source: &Path, package: &str) -> std::path::PathBuf {
     if package == "vue" {
-        std::fs::canonicalize(source).unwrap_or_else(|_| source.to_path_buf())
+        canonicalize_non_verbatim(source)
     } else {
         source.to_path_buf()
     }

--- a/crates/vize_canon/src/batch/runtime_deps.rs
+++ b/crates/vize_canon/src/batch/runtime_deps.rs
@@ -281,7 +281,7 @@ fn resolve_package(project_root: &Path, package: &str) -> Option<PathBuf> {
 }
 
 fn package_link_source(source: &Path) -> PathBuf {
-    std::fs::canonicalize(source).unwrap_or_else(|_| source.to_path_buf())
+    vize_carton::path::canonicalize_non_verbatim(source)
 }
 
 fn resolve_explicit_package_env(name: &str) -> Option<PathBuf> {

--- a/crates/vize_canon/src/batch/type_checker.rs
+++ b/crates/vize_canon/src/batch/type_checker.rs
@@ -135,7 +135,7 @@ impl BatchTypeChecker {
         let mut project = project;
         project.set_tsconfig_path(options.tsconfig_path);
         project.set_virtual_ts_options(options.virtual_ts_options);
-        let executor = CorsaExecutor::with_corsa_path(project_root, corsa_path)?;
+        let executor = CorsaExecutor::with_corsa_path(project.project_root(), corsa_path)?;
 
         Ok(Self {
             project,

--- a/crates/vize_canon/src/batch/type_checker/tests.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests.rs
@@ -2361,7 +2361,7 @@ fn link_or_stub_package(
 
 fn package_link_source(source: &Path, package: &str) -> PathBuf {
     if package == "vue" {
-        std::fs::canonicalize(source).unwrap_or_else(|_| source.to_path_buf())
+        vize_carton::path::canonicalize_non_verbatim(source)
     } else {
         source.to_path_buf()
     }

--- a/crates/vize_canon/src/batch/virtual_project/passthrough.rs
+++ b/crates/vize_canon/src/batch/virtual_project/passthrough.rs
@@ -132,5 +132,5 @@ fn append_json_extension(base: &Path) -> PathBuf {
 }
 
 fn normalize_existing_path(path: &Path) -> PathBuf {
-    path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
+    vize_carton::path::canonicalize_non_verbatim(path)
 }

--- a/crates/vize_canon/src/batch/virtual_project/project.rs
+++ b/crates/vize_canon/src/batch/virtual_project/project.rs
@@ -23,9 +23,7 @@ use super::build::{
 impl VirtualProject {
     /// Create a new virtual project.
     pub fn new(project_root: &Path) -> CorsaResult<Self> {
-        let project_root = project_root
-            .canonicalize()
-            .unwrap_or_else(|_| project_root.to_path_buf());
+        let project_root = vize_carton::path::canonicalize_non_verbatim(project_root);
         let virtual_root = project_root
             .join("node_modules")
             .join(".vize")
@@ -57,7 +55,7 @@ impl VirtualProject {
 
     /// Set the tsconfig path to extend.
     pub fn set_tsconfig_path(&mut self, tsconfig_path: Option<PathBuf>) {
-        self.tsconfig_path = tsconfig_path;
+        self.tsconfig_path = tsconfig_path.map(vize_carton::path::normalize_windows_verbatim_path);
         self.preserve_unused_diagnostics = self.resolve_tsconfig_preserves_unused_diagnostics();
     }
 

--- a/crates/vize_canon/src/batch/virtual_project/tests.rs
+++ b/crates/vize_canon/src/batch/virtual_project/tests.rs
@@ -8,6 +8,7 @@ use std::path::{Path, PathBuf};
 use vize_atelier_core::TemplateSyntaxMode;
 use vize_carton::cstr;
 mod tsconfig_native_options;
+mod windows_paths;
 fn unique_case_dir(name: &str) -> PathBuf {
     static NEXT_CASE_ID: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
     let case_id = NEXT_CASE_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
@@ -81,7 +82,6 @@ fn test_virtual_project_new() {
     fs::create_dir_all(&case_dir).unwrap();
 
     let project = VirtualProject::new(&case_dir).unwrap();
-
     assert_eq!(project.project_root(), case_dir.as_path());
     assert!(project.virtual_root().ends_with("node_modules/.vize/canon"));
 

--- a/crates/vize_canon/src/batch/virtual_project/tests/windows_paths.rs
+++ b/crates/vize_canon/src/batch/virtual_project/tests/windows_paths.rs
@@ -1,0 +1,28 @@
+#[cfg(windows)]
+use super::{VirtualProject, unique_case_dir};
+#[cfg(windows)]
+use std::fs;
+
+#[cfg(windows)]
+#[test]
+fn virtual_project_new_strips_windows_verbatim_project_root() {
+    let case_dir = unique_case_dir("windows-verbatim-root");
+    let _ = fs::remove_dir_all(&case_dir);
+    fs::create_dir_all(&case_dir).unwrap();
+
+    let verbatim_root = case_dir.canonicalize().unwrap();
+    let project = VirtualProject::new(&verbatim_root).unwrap();
+
+    assert_eq!(
+        project.project_root(),
+        vize_carton::path::canonicalize_non_verbatim(&case_dir).as_path()
+    );
+    assert!(
+        !project
+            .virtual_root()
+            .to_string_lossy()
+            .starts_with("\\\\?\\")
+    );
+
+    let _ = fs::remove_dir_all(&case_dir);
+}

--- a/crates/vize_carton/src/lib.rs
+++ b/crates/vize_carton/src/lib.rs
@@ -54,6 +54,7 @@ mod i18n_supplemental_extra;
 mod i18n_supplemental_extra2;
 pub mod line_index;
 pub mod lsp;
+pub mod path;
 pub mod profiler;
 pub mod source_range;
 pub mod string_builder;

--- a/crates/vize_carton/src/path.rs
+++ b/crates/vize_carton/src/path.rs
@@ -1,0 +1,96 @@
+//! Filesystem path helpers shared by CLI and native type-checking code.
+
+use std::path::{Path, PathBuf};
+
+/// Canonicalize a path while avoiding Windows extended-length prefixes in the
+/// returned path.
+///
+/// `std::fs::canonicalize` returns paths such as `\\?\C:\repo` on Windows.
+/// Those are valid Win32 paths, but Node/TypeScript normalize them to
+/// `//?/C:/repo` and can reject them as missing config paths. The checker only
+/// needs a stable absolute path, so strip the verbatim prefix back to the
+/// ordinary DOS/UNC spelling before handing paths to TypeScript-facing code.
+pub fn canonicalize_non_verbatim(path: &Path) -> PathBuf {
+    let canonical = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+    normalize_windows_verbatim_path(canonical)
+}
+
+/// Strip a Windows verbatim path prefix from `path` when running on Windows.
+pub fn normalize_windows_verbatim_path(path: PathBuf) -> PathBuf {
+    normalize_windows_verbatim_path_impl(path)
+}
+
+#[cfg(windows)]
+fn normalize_windows_verbatim_path_impl(path: PathBuf) -> PathBuf {
+    let Some(path_str) = path.to_str() else {
+        return path;
+    };
+    strip_windows_verbatim_prefix(path_str)
+        .map(PathBuf::from)
+        .unwrap_or(path)
+}
+
+#[cfg(not(windows))]
+fn normalize_windows_verbatim_path_impl(path: PathBuf) -> PathBuf {
+    path
+}
+
+#[cfg(any(windows, test))]
+fn strip_windows_verbatim_prefix(value: &str) -> Option<std::string::String> {
+    if let Some(rest) = value.strip_prefix("\\\\?\\UNC\\") {
+        let mut normalized = std::string::String::with_capacity(rest.len() + 2);
+        normalized.push_str("\\\\");
+        normalized.push_str(rest);
+        return Some(normalized);
+    }
+    if let Some(rest) = value.strip_prefix("//?/UNC/") {
+        let mut normalized = std::string::String::with_capacity(rest.len() + 2);
+        normalized.push_str("//");
+        normalized.push_str(rest);
+        return Some(normalized);
+    }
+    if let Some(rest) = value.strip_prefix("\\\\?\\") {
+        return Some(rest.to_owned());
+    }
+    if let Some(rest) = value.strip_prefix("//?/") {
+        return Some(rest.to_owned());
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::strip_windows_verbatim_prefix;
+
+    #[test]
+    fn strips_windows_drive_verbatim_prefixes() {
+        assert_eq!(
+            strip_windows_verbatim_prefix("\\\\?\\D:\\a\\ox-jsdoc\\ox-jsdoc\\apps\\playground")
+                .as_deref(),
+            Some("D:\\a\\ox-jsdoc\\ox-jsdoc\\apps\\playground")
+        );
+    }
+
+    #[test]
+    fn strips_windows_unc_verbatim_prefixes() {
+        assert_eq!(
+            strip_windows_verbatim_prefix("\\\\?\\UNC\\server\\share\\project").as_deref(),
+            Some("\\\\server\\share\\project")
+        );
+    }
+
+    #[test]
+    fn strips_forward_slash_verbatim_prefixes_from_tool_output() {
+        assert_eq!(
+            strip_windows_verbatim_prefix("//?/D:/repo/node_modules/.vize/canon/tsconfig.json")
+                .as_deref(),
+            Some("D:/repo/node_modules/.vize/canon/tsconfig.json")
+        );
+    }
+
+    #[test]
+    fn leaves_normal_paths_alone() {
+        assert_eq!(strip_windows_verbatim_prefix("D:\\repo\\src"), None);
+        assert_eq!(strip_windows_verbatim_prefix("/repo/src"), None);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #1728.

Normalize Windows extended-length paths returned by `std::fs::canonicalize` before they reach the `vize check` virtual project and TypeScript-facing config paths. This keeps paths such as `\\?\D:\repo\...` from being passed to Corsa/TypeScript as `//?/D:/repo/...`, which triggered TS5058 for the generated `.vize/canon/tsconfig.json` on Windows CI.

## Changes

- Add a shared `vize_carton::path::canonicalize_non_verbatim` helper.
- Use it in `vize check` input collection, tsconfig ownership, explicit tsconfig resolution, virtual project setup, and related test helpers.
- Add coverage for stripping Windows verbatim drive/UNC prefixes and for `VirtualProject::new` keeping a non-verbatim project root on Windows.

## Validation

- `cargo fmt --all`
- `cargo test -p vize_carton path::tests`
- `cargo test -p vize_canon batch::virtual_project::tests`
- `cargo test -p vize --lib commands::check`
- `cargo test -p vize --test check_cli`
- `cargo clippy -p vize_carton --lib -- -D warnings`
- `cargo clippy -p vize_canon --lib -- -D warnings`
- `cargo clippy -p vize --lib -- -D warnings`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1730"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->