### PR TITLE
fix(vite-plugin-musea): limit gallery plugin to serve

### DIFF
--- a/npm/vite-plugin-musea/src/plugin/apply.ts
+++ b/npm/vite-plugin-musea/src/plugin/apply.ts
@@ -1,5 +1,5 @@
 import type { ConfigEnv } from "vite";
 
-export function shouldApplyMuseaPlugin(env: Pick<ConfigEnv, "mode">): boolean {
-  return env.mode !== "test";
+export function shouldApplyMuseaPlugin(env: Pick<ConfigEnv, "command" | "mode">): boolean {
+  return env.command === "serve" && env.mode !== "test";
 }

--- a/npm/vite-plugin-musea/src/plugin/index.test.ts
+++ b/npm/vite-plugin-musea/src/plugin/index.test.ts
@@ -3,9 +3,13 @@ import test from "node:test";
 import { shouldApplyMuseaPlugin } from "./apply.js";
 
 void test("musea plugin is inactive in Vite test mode", () => {
-  assert.equal(shouldApplyMuseaPlugin({ mode: "test" }), false);
+  assert.equal(shouldApplyMuseaPlugin({ command: "serve", mode: "test" }), false);
 });
 
-void test("musea plugin remains active outside Vite test mode", () => {
-  assert.equal(shouldApplyMuseaPlugin({ mode: "development" }), true);
+void test("musea plugin remains active during Vite serve outside test mode", () => {
+  assert.equal(shouldApplyMuseaPlugin({ command: "serve", mode: "development" }), true);
+});
+
+void test("musea plugin is inactive during production builds", () => {
+  assert.equal(shouldApplyMuseaPlugin({ command: "build", mode: "production" }), false);
 });


### PR DESCRIPTION
## Summary
- apply the Musea gallery plugin only during Vite serve
- keep test mode disabled and cover production builds explicitly

Closes #1724

## Verification
- pnpm --filter @vizejs/vite-plugin-musea test
- pnpm --filter @vizejs/vite-plugin-musea check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1731"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->