### PR TITLE
test(lint): cover level off CLI suppression

### DIFF
--- a/tests/tooling/cli-lint-contract.test.ts
+++ b/tests/tooling/cli-lint-contract.test.ts
@@ -53,6 +53,8 @@ function withWorkspace<T>(run: (dir: string) => T): T {
 const MULTI_SPACE = '<template>\n  <div  id="x"></div>\n</template>\n';
 const CLEAN = '<template>\n  <div id="x" />\n</template>\n';
 const MULTIBYTE_BEFORE_DIRECTIVE = '<template><div title="café" v-html="x"></div></template>\n';
+const LEVEL_OFF_NEXT_LINE_UNSAFE_URL =
+  '<template>\n  <!-- @vize:level(off) -->\n  <a href="javascript:alert(1)">link</a>\n</template>\n';
 
 test("vize lint --help documents the fix/config/max-warnings surface", () => {
   const result = spawnSync(VIZE.command, [...VIZE.prefix, "lint", "--help"], {
@@ -143,6 +145,17 @@ test("vize lint --format json reports character columns after multibyte text", (
     assert.equal(message.column, 29);
     assert.equal(message.endLine, 1);
     assert.equal(message.endColumn, 39);
+  });
+});
+
+test("vize lint level(off) suppresses next-line template diagnostics", () => {
+  withWorkspace((dir) => {
+    fs.writeFileSync(path.join(dir, "UnsafeUrl.vue"), LEVEL_OFF_NEXT_LINE_UNSAFE_URL, "utf8");
+    const result = runLint(["UnsafeUrl.vue", "--help-level", "short", "--max-warnings", "0"], dir);
+
+    assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
+    assert.match(`${result.stdout}${result.stderr}`, /No problems found/);
+    assert.doesNotMatch(`${result.stdout}${result.stderr}`, /vue\/no-unsafe-url/);
   });
 });
 


### PR DESCRIPTION
## Summary
- add a CLI regression case for @vize:level(off) in Vue templates
- assert next-line vue/no-unsafe-url diagnostics are suppressed under --max-warnings 0

Closes #1722

## Verification
- node --test tests/tooling/cli-lint-contract.test.ts

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1732"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->