### PR TITLE
test(check): cover setup-scoped defineProps typeof

### DIFF
--- a/crates/vize/tests/check_define_props_cli.rs
+++ b/crates/vize/tests/check_define_props_cli.rs
@@ -121,6 +121,21 @@ void props;
         !stdout.contains("Cannot find name 'someDefinition'"),
         "{stdout}"
     );
+    let virtual_ts = json["files"][0]["virtualTs"]
+        .as_str()
+        .expect("check JSON should include generated Virtual TS");
+    assert!(
+        virtual_ts.contains("type __VizeSetupProps = SomeGenericType<typeof someDefinition>;"),
+        "{virtual_ts}"
+    );
+    let module_scope = virtual_ts
+        .split("// ========== Setup Scope ==========")
+        .next()
+        .unwrap_or(virtual_ts);
+    assert!(
+        !module_scope.contains("typeof someDefinition"),
+        "setup binding leaked into module scope:\n{virtual_ts}"
+    );
 
     let _ = std::fs::remove_dir_all(&project_root);
 }


### PR DESCRIPTION
## Summary
- strengthen the defineProps typeof CLI regression for setup-local bindings
- assert the generated Virtual TS keeps the typeof reference in setup scope, not module scope

Closes #1726

## Verification
- cargo test -p vize --test check_define_props_cli check_define_props_typeof_setup_binding_resolves_in_setup_scope

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1733"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->