### PR TITLE
test(check): cover ant-design-vue semantic diagnostics

### DIFF
--- a/tests/tooling/cli-check-diagnostics.test.ts
+++ b/tests/tooling/cli-check-diagnostics.test.ts
@@ -103,6 +103,17 @@ function stripAnsi(input: string): string {
 
 const corsaSkip = CHECKER == null ? { skip: "no corsa/tsgo checker in node_modules/.bin" } : {};
 
+const ANT_DESIGN_VUE_FIXTURE = path.join(root, "tests/_fixtures/_git/ant-design-vue");
+const ANT_DESIGN_VUE_COMPONENTS = path.join(ANT_DESIGN_VUE_FIXTURE, "components");
+const ANT_DESIGN_VUE_SEMANTIC_ERROR =
+  '<script setup lang="ts">\nconst value: string = 1;\n</script>\n\n<template>\n  <div>{{ value }}</div>\n</template>\n';
+const antDesignVueSkip =
+  CHECKER == null
+    ? corsaSkip
+    : fs.existsSync(ANT_DESIGN_VUE_COMPONENTS)
+      ? {}
+      : { skip: "ant-design-vue fixture checkout unavailable" };
+
 test(
   "SFC template parse errors reported with stable 1-based position and message",
   corsaSkip,
@@ -197,6 +208,33 @@ test("TS2322 in plain .ts: exit 1 with verbatim virtualTs passthrough", corsaSki
     assert.equal(parsed.files[0]?.virtualTs, "export const x: string = 123;\n");
   });
 });
+
+test(
+  "explicit ant-design-vue SFC checks report semantic TypeScript diagnostics",
+  antDesignVueSkip,
+  () => {
+    const probeName = `__vize_semantic_probe_${process.pid}.vue`;
+    const probeRelativePath = path.join("components", probeName);
+    const probePath = path.join(ANT_DESIGN_VUE_FIXTURE, probeRelativePath);
+    try {
+      fs.writeFileSync(probePath, ANT_DESIGN_VUE_SEMANTIC_ERROR, "utf8");
+      const { result, parsed } = runJsonCheck(
+        [probeRelativePath, "--servers", "1"],
+        ANT_DESIGN_VUE_FIXTURE,
+      );
+
+      assert.equal(result.status, 1, `${result.stdout}\n${result.stderr}`);
+      assert.ok(parsed.errorCount > 0, result.stdout);
+      const diagnostics = parsed.files[0]?.diagnostics ?? [];
+      assert.ok(
+        diagnostics.some((d) => d.includes("[TS2322]")),
+        `expected semantic TS2322 diagnostic, got ${JSON.stringify(diagnostics)}`,
+      );
+    } finally {
+      fs.rmSync(probePath, { force: true });
+    }
+  },
+);
 
 test("--quiet suppresses per-file diagnostics but keeps summary and exit code", corsaSkip, () => {
   withWorkspace((dir) => {


### PR DESCRIPTION
## Summary
- add a CLI regression for explicit ant-design-vue SFC checks
- assert semantic TypeScript diagnostics are reported for a temporary fixture file

Closes #1727

## Verification
- node --test tests/tooling/cli-check-diagnostics.test.ts
- vp check tests/tooling/cli-check-diagnostics.test.ts

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1734"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->