### PR TITLE
[Next Gen] refactor(atelier): add a query surface to the rendu render plate

### DIFF
--- a/crates/vize_atelier_core/src/rendu/model.rs
+++ b/crates/vize_atelier_core/src/rendu/model.rs
@@ -110,6 +110,29 @@ pub enum RenduElementKind {
     Template,
 }
 
+impl RenduElementKind {
+    /// Whether this is a user component rather than a plain host element.
+    pub const fn is_component(self) -> bool {
+        matches!(self, Self::Component)
+    }
+
+    /// Whether this is a `<slot>` outlet.
+    pub const fn is_slot_outlet(self) -> bool {
+        matches!(self, Self::SlotOutlet)
+    }
+
+    /// Whether this is a `<template>` fragment wrapper.
+    pub const fn is_template(self) -> bool {
+        matches!(self, Self::Template)
+    }
+
+    /// Whether this is a plain host element (not a component, slot, or
+    /// template).
+    pub const fn is_plain_element(self) -> bool {
+        matches!(self, Self::Element)
+    }
+}
+
 impl From<ElementType> for RenduElementKind {
     fn from(kind: ElementType) -> Self {
         match kind {

--- a/crates/vize_atelier_core/src/rendu/semantic.rs
+++ b/crates/vize_atelier_core/src/rendu/semantic.rs
@@ -162,6 +162,55 @@ impl<'a> RenduOp<'a> {
             TemplateChildNode::Hoisted(index) => Self::HoistRef { index: *index },
         }
     }
+
+    /// The source span this operation covers, if it carries one.
+    ///
+    /// Every operation except a [`HoistRef`](Self::HoistRef) — which only points
+    /// at a module-level hoist index — carries a span, so a backend can emit
+    /// source-mapped output straight from the Rendu op without reaching back
+    /// into the Relief node.
+    pub fn span(self) -> Option<RenduSpan> {
+        match self {
+            Self::Element { span, .. }
+            | Self::Attribute { span, .. }
+            | Self::Directive { span, .. }
+            | Self::Text { span, .. }
+            | Self::Comment { span, .. }
+            | Self::Interpolation { span, .. }
+            | Self::If { span }
+            | Self::IfBranch { span, .. }
+            | Self::For { span, .. }
+            | Self::TextCall { span, .. }
+            | Self::CompoundExpression { span, .. } => Some(span),
+            Self::HoistRef { .. } => None,
+        }
+    }
+
+    /// The single dominant borrowed expression this operation renders, if any.
+    ///
+    /// Returns the one expression for ops that have a clear primary
+    /// (interpolation content, a `v-for` source, an `if`-branch condition, a
+    /// compound expression, a text-call expression). Ops that carry several
+    /// expressions (a directive's arg and exp, a `v-for`'s aliases) or none
+    /// (elements, static text) return `None`; read those fields directly.
+    pub fn primary_expr(self) -> Option<RenduExprRef<'a>> {
+        match self {
+            Self::Interpolation { expression, .. }
+            | Self::CompoundExpression { expression, .. } => Some(expression),
+            Self::For { source, .. } => Some(source),
+            Self::IfBranch { condition, .. } => condition,
+            Self::TextCall { content, .. } => content,
+            _ => None,
+        }
+    }
+
+    /// Whether this operation is structured control flow (`if`, branch, `for`).
+    pub const fn is_control_flow(self) -> bool {
+        matches!(
+            self,
+            Self::If { .. } | Self::IfBranch { .. } | Self::For { .. }
+        )
+    }
 }
 
 /// Ordered render operations.
@@ -177,6 +226,11 @@ impl<'a> RenduBlock<'a> {
 
     pub const fn is_empty(self) -> bool {
         self.ops.is_empty()
+    }
+
+    /// Number of render operations in this block.
+    pub const fn len(self) -> usize {
+        self.ops.len()
     }
 }
 

--- a/crates/vize_atelier_core/src/rendu/semantic_tests.rs
+++ b/crates/vize_atelier_core/src/rendu/semantic_tests.rs
@@ -129,3 +129,85 @@ fn for_ops_carry_value_key_and_index_aliases_losslessly() {
         other => panic!("expected RenduOp::For, got {other:?}"),
     }
 }
+
+#[test]
+fn element_kinds_report_exactly_one_classification() {
+    assert!(RenduElementKind::Component.is_component());
+    assert!(RenduElementKind::SlotOutlet.is_slot_outlet());
+    assert!(RenduElementKind::Template.is_template());
+    assert!(RenduElementKind::Element.is_plain_element());
+
+    for kind in [
+        RenduElementKind::Element,
+        RenduElementKind::Component,
+        RenduElementKind::SlotOutlet,
+        RenduElementKind::Template,
+    ] {
+        let flags = [
+            kind.is_plain_element(),
+            kind.is_component(),
+            kind.is_slot_outlet(),
+            kind.is_template(),
+        ];
+        assert_eq!(flags.iter().filter(|on| **on).count(), 1, "{kind:?}");
+    }
+}
+
+#[test]
+fn span_is_present_for_every_op_except_hoist_refs() {
+    let allocator = Allocator::default();
+    let bump = allocator.as_bump();
+    let text =
+        TemplateChildNode::Text(AllocBox::new_in(TextNode::new("hi", loc("hi", 0, 2)), bump));
+
+    assert_eq!(
+        RenduOp::from_template_child(&text).span(),
+        Some(RenduSpan::new(
+            Position::new(0, 1, 1),
+            Position::new(2, 1, 3)
+        ))
+    );
+    // A hoist reference points only at a module index, so it has no span.
+    assert_eq!(RenduOp::HoistRef { index: 0 }.span(), None);
+}
+
+#[test]
+fn primary_expr_and_control_flow_classify_ops() {
+    let interpolation = RenduOp::Interpolation {
+        expression: RenduExprRef::Relief("count"),
+        raw: false,
+        span: RenduSpan::default(),
+    };
+    assert_eq!(
+        interpolation.primary_expr().map(RenduExprRef::text),
+        Some("count")
+    );
+    assert!(!interpolation.is_control_flow());
+
+    let if_op = RenduOp::If {
+        span: RenduSpan::default(),
+    };
+    assert!(if_op.is_control_flow());
+    // `if` itself carries no condition expression; its branches do.
+    assert!(if_op.primary_expr().is_none());
+
+    let element = RenduOp::Element {
+        tag: "div",
+        kind: RenduElementKind::Element,
+        span: RenduSpan::default(),
+    };
+    assert!(element.primary_expr().is_none());
+    assert!(!element.is_control_flow());
+}
+
+#[test]
+fn blocks_report_their_operation_count() {
+    let ops = [
+        RenduOp::HoistRef { index: 0 },
+        RenduOp::HoistRef { index: 1 },
+    ];
+    let block = RenduBlock::new(&ops);
+    assert_eq!(block.len(), 2);
+    assert!(!block.is_empty());
+    assert!(RenduBlock::new(&[]).is_empty());
+}


### PR DESCRIPTION
Closes #1695. Rendu render-plate track from #1634.

## What this adds

The Rendu vocabulary (`RenduRoot/Block/Op/ExprRef/Capabilities`, `walk_rendu_ops`) already exists and DOM codegen already emits some output from it. This slice adds the small **render-semantic query surface** a backend needs so it can interrogate an op without re-matching Relief variants.

- `RenduElementKind::is_component() / is_slot_outlet() / is_template() / is_plain_element()`.
- `RenduOp::span()` — the source span every op carries except a bare `HoistRef`, so a backend can source-map straight from the op.
- `RenduOp::primary_expr()` — the single dominant borrowed expression for ops that have one (interpolation, `v-for` source, `if`-branch condition, compound, text-call); `None` for multi-expression or expression-free ops.
- `RenduOp::is_control_flow()` and `RenduBlock::len()`.

All additions are borrowed, allocation-free, `Copy`-friendly accessors. No `RenduOp` variant changes shape and no production output path is rerouted.

## Non-goals (per #1695)

- Vapor IR is untouched (`Rendu -> Vapor IR -> Vapor output` stays).
- No CFG.
- Rendu is not built for Patina/Canon/Maestro/formatter lanes.

## Verification

- `cargo test -p vize_atelier_core rendu` — 19 passing, incl. new classifier / span / primary-expression / block-size tests.
- `cargo clippy -p vize_atelier_core --lib` — clean.
- `model.rs` clean under `rustfmt --check`; new test code formatted to match; files under the 350-line guard.

---

Part of the **[Next Gen]** stack for #1634, targeting `canary` through the `nextgen/1692-plate-families` integration branch (#1735): #1692 → #1698 → **#1695 (this)** → #1696 → #1697.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1743"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->