### PR TITLE
[Next Gen] refactor(sourcemap): add the sfc source-map composition authority

### DIFF
--- a/crates/vize_atelier_core/src/source_map.rs
+++ b/crates/vize_atelier_core/src/source_map.rs
@@ -127,6 +127,65 @@ impl<'a> SourceMapRegistration<'a> {
     }
 }
 
+/// Outcome of composing an SFC source map from registered output sections.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum SfcMapComposition<'a> {
+    /// A single template-render fragment is the whole generated map, so it can
+    /// be surfaced directly as the SFC source map.
+    Composed(&'a str),
+    /// Composition is valid but deferred to a later script/template/style
+    /// assembly plate.
+    Deferred(SourceAtlasFallback),
+    /// No registered fragment was available to compose.
+    Omitted(SourceAtlasFallback),
+}
+
+impl<'a> SfcMapComposition<'a> {
+    /// The composed map, when composition succeeded.
+    pub const fn composed_map(self) -> Option<&'a str> {
+        match self {
+            Self::Composed(map) => Some(map),
+            Self::Deferred(_) | Self::Omitted(_) => None,
+        }
+    }
+
+    /// The fallback reason recorded for a deferred or omitted composition.
+    pub const fn fallback(self) -> Option<SourceAtlasFallback> {
+        match self {
+            Self::Composed(_) => None,
+            Self::Deferred(reason) | Self::Omitted(reason) => Some(reason),
+        }
+    }
+}
+
+/// Decide whether registered sections compose into one SFC source map.
+///
+/// This is the single authority for the composition rule, instead of each
+/// caller hand-deciding composed-vs-skipped. Composition is only correct today
+/// for a single template-render fragment that covers the whole module (a
+/// template-only SFC): then the fragment *is* the final map. A module that also
+/// registers script/style sections still needs a composition plate and is
+/// reported as [`Deferred`](SfcMapComposition::Deferred); a module with no
+/// fragment is [`Omitted`](SfcMapComposition::Omitted). It composes from
+/// already-registered sections and never rescans generated JavaScript.
+pub fn compose_sfc_source_map<'a>(
+    registrations: &[SourceMapRegistration<'a>],
+) -> SfcMapComposition<'a> {
+    let mut with_fragment = registrations.iter().filter(|reg| reg.has_fragment());
+    let Some(first) = with_fragment.next() else {
+        return SfcMapComposition::Omitted(SourceAtlasFallback::SourceMapFragmentUnavailable);
+    };
+    // A lone template-render fragment is the entire module map.
+    if with_fragment.next().is_none()
+        && matches!(first.section, SourceMapRegistrationSection::TemplateRender)
+        && let Some(fragment) = first.fragment
+    {
+        return SfcMapComposition::Composed(fragment);
+    }
+    SfcMapComposition::Deferred(SourceAtlasFallback::SourceMapCompositionSkipped)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -175,6 +234,58 @@ mod tests {
         assert!(!registration.is_composed());
         assert_eq!(
             registration.fallback(),
+            Some(SourceAtlasFallback::SourceMapCompositionSkipped)
+        );
+    }
+
+    fn template_fragment(fragment: &str) -> SourceMapRegistration<'_> {
+        SourceMapRegistration::for_template_fragment(
+            RenduRange::new(0, 20),
+            fragment,
+            SourceMapRegistrationState::Composed,
+        )
+    }
+
+    fn script_fragment(fragment: &str) -> SourceMapRegistration<'_> {
+        SourceMapRegistration::new(
+            SourceAtlasRoute::empty().with_source(SourceAtlasSource::Script),
+            SourceMapRegistrationSection::Script,
+            RenduRange::new(0, 10),
+            Some(fragment),
+            SourceMapRegistrationState::Composed,
+        )
+    }
+
+    #[test]
+    fn a_lone_template_fragment_composes_into_the_module_map() {
+        let regs = [template_fragment("{\"version\":3}")];
+        let composition = compose_sfc_source_map(&regs);
+        assert_eq!(composition.composed_map(), Some("{\"version\":3}"));
+        assert_eq!(composition.fallback(), None);
+    }
+
+    #[test]
+    fn no_registered_fragment_is_an_omitted_composition() {
+        let composition = compose_sfc_source_map(&[]);
+        assert_eq!(composition.composed_map(), None);
+        assert_eq!(
+            composition.fallback(),
+            Some(SourceAtlasFallback::SourceMapFragmentUnavailable)
+        );
+    }
+
+    #[test]
+    fn template_plus_script_fragments_defer_composition() {
+        // Two sections still need a real composition plate, so the rule reports
+        // a deferred composition rather than surfacing a half-composed map.
+        let regs = [
+            template_fragment("{\"version\":3,\"file\":\"t\"}"),
+            script_fragment("{\"version\":3,\"file\":\"s\"}"),
+        ];
+        let composition = compose_sfc_source_map(&regs);
+        assert_eq!(composition.composed_map(), None);
+        assert_eq!(
+            composition.fallback(),
             Some(SourceAtlasFallback::SourceMapCompositionSkipped)
         );
     }

--- a/crates/vize_atelier_sfc/src/compile/source_maps.rs
+++ b/crates/vize_atelier_sfc/src/compile/source_maps.rs
@@ -211,4 +211,37 @@ mod tests {
             Some(SourceAtlasFallback::SourceMapCompositionSkipped)
         );
     }
+
+    #[test]
+    fn template_only_registration_composes_into_a_module_map() {
+        use vize_atelier_core::source_map::compose_sfc_source_map;
+
+        // A template-only SFC registers a single template-render fragment, so
+        // the shared composition authority surfaces it as the whole module map.
+        let output = template_result_with_map();
+        let registration = output
+            .source_map_registration(SourceMapRegistrationState::Composed)
+            .expect("template fragment should register");
+
+        let composition = compose_sfc_source_map(&[registration]);
+        assert_eq!(composition.composed_map(), Some("{\"version\":3}"));
+        assert_eq!(composition.fallback(), None);
+    }
+
+    #[test]
+    fn a_template_without_a_fragment_omits_composition() {
+        use vize_atelier_core::source_map::compose_sfc_source_map;
+
+        let output = template_result_without_map();
+        let composition = match output.source_map_registration(SourceMapRegistrationState::Composed)
+        {
+            Some(registration) => compose_sfc_source_map(&[registration]),
+            None => compose_sfc_source_map(&[]),
+        };
+        assert_eq!(composition.composed_map(), None);
+        assert_eq!(
+            composition.fallback(),
+            Some(SourceAtlasFallback::SourceMapFragmentUnavailable)
+        );
+    }
 }

--- a/docs/content/architecture/source-atlas.md
+++ b/docs/content/architecture/source-atlas.md
@@ -257,9 +257,9 @@ Required registration facts:
 
 The first canary registration is intentionally narrow: template map fragments
 are registered as `SourceMapRegistration` values covering the generated render
-function range through `TemplateBlockCompileResult`. Composed template-only maps
-and deferred script/template maps share the same registration mark, so Vize can
-later compose SFC maps without rescanning generated JavaScript.
+function range through `TemplateBlockCompileResult`. `compose_sfc_source_map`
+is the single authority that turns those registered sections into a composed
+template-only map or a deferred/omitted reason, without rescanning JavaScript.
 
 Source-map work is allowed to cost more only when `sourceMap` or an explicit
 debug/profile lane requests it. The normal compiler and linter paths must remain


### PR DESCRIPTION
Closes #1696. Source-map track from #1634.

## What this adds

`SourceMapRegistration` already records template fragments with a section, generated range, and composition state. Today each SFC caller hand-passes a *composed-vs-skipped* hint. This slice centralizes that into one composition authority over registered sections.

- `SfcMapComposition { Composed(&str) | Deferred(reason) | Omitted(reason) }` and `compose_sfc_source_map(&[SourceMapRegistration])` in `vize_atelier_core::source_map`.
- The rule: a lone template-render fragment covering the module composes into the final map; a module that also registers script/style sections is `Deferred(SourceMapCompositionSkipped)`; no fragment is `Omitted(SourceMapFragmentUnavailable)`.
- Composes from already-registered sections — never rescans generated JavaScript.

## Byte-equivalence

This is registration/observation only: no public source map is surfaced where one was not produced before. Surfacing composed maps into the public SFC result is a follow-up once script/style sections are registered. Output bytes are unchanged.

## Verification

- `cargo test -p vize_atelier_core source_map` (26) and `cargo test -p vize_atelier_sfc source_maps` (6) — passing, incl. omission / template-only composition / deferred multi-section / SFC registration-path tests.
- `cargo clippy --lib` clean for both crates; new code passes `rustfmt --check`; doc updated in place.

---

Part of the **[Next Gen]** stack for #1634, targeting `canary` via `nextgen/1692-plate-families` (#1735): #1692 → #1698 → #1695 → **#1696 (this)** → #1697.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1745"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->