### PR TITLE
docs(examples): add CLI typecheck sample

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -35,6 +35,7 @@ building the local package.
 | `src/App.vue`         | A correctly formatted Vue file                      |
 | `src/Unformatted.vue` | A Vue file that needs formatting                    |
 | `src/HasErrors.vue`   | A Vue file containing lint and security diagnostics |
+| `src/TypeChecked.vue` | A typed props/emits file for `vize check` examples  |
 
 ### Formatter (`vize fmt`)
 
@@ -99,6 +100,20 @@ The SSR rule docs include extra boundary examples for `typeof window`, comments,
 | `--max-warnings` | Warning limit                                                                    | -       |
 | `--quiet`, `-q`  | Show only the summary                                                            | false   |
 | `--fix`          | Auto-fix (not implemented yet)                                                   | false   |
+
+### Type Checker (`vize check`)
+
+```bash
+# Check a typed props/emits example
+vp exec vize check examples/cli/src/TypeChecked.vue
+
+# Emit the generated Virtual TS and diagnostics as JSON
+vp exec vize check examples/cli/src/TypeChecked.vue --format json
+```
+
+`src/TypeChecked.vue` demonstrates typed `defineProps`, `withDefaults`, tuple-style `defineEmits`,
+and template usage of setup bindings. It should type-check cleanly and is a small starting point for
+copying Vize's type-check workflow into an application package script.
 
 ### Rust LSP Server (`vize lsp`)
 

--- a/examples/cli/src/TypeChecked.vue
+++ b/examples/cli/src/TypeChecked.vue
@@ -1,0 +1,41 @@
+<script setup lang="ts">
+import { computed } from "vue";
+
+type Status = "idle" | "loading" | "ready";
+
+const props = withDefaults(
+  defineProps<{
+    label: string;
+    count?: number;
+    status?: Status;
+  }>(),
+  {
+    count: 0,
+    status: "idle",
+  },
+);
+
+const emit = defineEmits<{
+  refresh: [nextStatus: Status];
+}>();
+
+const badge = computed(() => `${props.label}: ${props.count}`);
+
+function refresh() {
+  emit("refresh", "loading");
+}
+</script>
+
+<template>
+  <section class="type-checked">
+    <p>{{ badge }}</p>
+    <button type="button" :disabled="status === 'loading'" @click="refresh">Refresh</button>
+  </section>
+</template>
+
+<style scoped>
+.type-checked {
+  display: grid;
+  gap: 8px;
+}
+</style>


### PR DESCRIPTION
## Summary
- add a typed CLI example SFC for vize check
- document the type-check workflow in the examples README

Closes #1591

## Verification
- vp check examples/README.md examples/cli/src/TypeChecked.vue
- target/debug/vize check examples/cli/src/TypeChecked.vue --format json --quiet --corsa-path node_modules/.bin/tsgo

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1748"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->