### PR TITLE
test(e2e): inventory real-world browser smokes

### DIFF
--- a/tests/tooling/e2e-tasks.test.ts
+++ b/tests/tooling/e2e-tasks.test.ts
@@ -10,6 +10,10 @@ function readRepoFile(...segments: string[]): string {
   return fs.readFileSync(path.join(root, ...segments), "utf8");
 }
 
+function assertExists(...segments: string[]): void {
+  assert.ok(fs.existsSync(path.join(root, ...segments)), segments.join("/"));
+}
+
 test("workspace exposes app e2e task aliases with scoped cache inputs", () => {
   const taskInputs = readRepoFile("tools/vite-plus/task-inputs.ts");
   const taskGroups = readRepoFile("tools/vite-plus/tasks/test-benchmark.ts");
@@ -34,4 +38,33 @@ test("workspace exposes app e2e task aliases with scoped cache inputs", () => {
   assert.match(taskGroups, /"test:e2e:vrt":\s*task\(runInPackages\("test:vrt", \["\.\/tests"\]\)/);
   assert.match(taskGroups, /input:\s*cacheInputs\.e2e/);
   assert.match(testPackage.scripts?.["test:dev:ci"] ?? "", /app\/dev\/nuxt-ui\.spec\.ts/);
+});
+
+test("real-world browser smoke inventory stays wired into app e2e scripts", () => {
+  const testPackage = JSON.parse(readRepoFile("tests", "package.json")) as {
+    scripts?: Record<string, string>;
+  };
+  const devScript = testPackage.scripts?.["test:dev:ci"] ?? "";
+  const previewScript = testPackage.scripts?.["test:preview"] ?? "";
+  const vrtScript = testPackage.scripts?.["test:vrt"] ?? "";
+
+  const devProjects = ["elk", "misskey", "npmx", "nuxt-ui", "vuefes"];
+  for (const project of devProjects) {
+    const spec = `app/dev/${project}.spec.ts`;
+    assertExists("tests", spec);
+    assert.match(devScript, new RegExp(spec.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+  }
+
+  const previewProjects = ["elk", "misskey", "npmx", "vuefes"];
+  for (const project of previewProjects) {
+    const script = `app/preview/${project}.ts`;
+    assertExists("tests", script);
+    assert.match(previewScript, new RegExp(script.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+  }
+
+  const vrtProjects = ["elk", "frontend-phpcon", "misskey", "npmx", "vuefes"];
+  for (const project of vrtProjects) {
+    assertExists("tests", "app", "vrt", `${project}.spec.ts`);
+  }
+  assert.match(vrtScript, /playwright test --config app\/playwright\.vrt\.config\.ts/);
 });


### PR DESCRIPTION
## Summary
- assert dev browser smoke specs stay wired into tests/package.json
- assert preview and VRT real-world browser targets have matching script/spec coverage

Closes #1595

## Verification
- node --test tests/tooling/e2e-tasks.test.ts
- vp check tests/tooling/e2e-tasks.test.ts

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1751"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->