### PR TITLE
[Next Gen] refactor(vapor): gate inclusion vapor on shared rendu capability facts

### DIFF
--- a/crates/vize_atelier_core/src/rendu.rs
+++ b/crates/vize_atelier_core/src/rendu.rs
@@ -10,7 +10,7 @@ mod model;
 mod semantic;
 mod walk;
 
-pub use capability::RenduCapability;
+pub use capability::{RenduCapability, VaporSupport};
 pub use model::{RenduElementKind, RenduExprRef, RenduSource, RenduSpan};
 pub use semantic::{RenduBlock, RenduCapabilities, RenduOp, RenduRoot};
 pub use walk::{RenduWalkSummary, summarize_rendu_ops, walk_rendu_ops};

--- a/crates/vize_atelier_core/src/rendu/capability.rs
+++ b/crates/vize_atelier_core/src/rendu/capability.rs
@@ -24,6 +24,39 @@ pub enum RenduCapability {
     VersionedSyntax(SourceAtlasCoordinate),
 }
 
+/// How a Vapor render route resolves for a capability set.
+///
+/// This is the shared classification the Vapor lane consumes and fallback
+/// reporting agrees with, so `Rendu -> Vapor IR -> Vapor output` does not
+/// re-derive the route rule inline.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum VaporSupport {
+    /// The shape renders on the Vapor target as-is.
+    Renderable,
+    /// Vapor was requested together with SSR; the SFC compiler degrades to the
+    /// standard SSR Atelier because Vapor SSR is unimplemented.
+    DegradesToSsr,
+    /// The template shape is outside the current Vapor capability set.
+    Unsupported,
+}
+
+impl VaporSupport {
+    /// The atlas fallback this Vapor outcome records, if any.
+    pub const fn fallback(self) -> Option<SourceAtlasFallback> {
+        match self {
+            Self::Renderable => None,
+            Self::DegradesToSsr => Some(SourceAtlasFallback::VaporSsr),
+            Self::Unsupported => Some(SourceAtlasFallback::UnsupportedVaporShape),
+        }
+    }
+
+    /// Whether the Vapor target renders this shape without degrading.
+    pub const fn is_renderable(self) -> bool {
+        matches!(self, Self::Renderable)
+    }
+}
+
 impl RenduCapabilities {
     /// Whether a single capability fact holds for this set.
     pub fn supports(self, capability: RenduCapability) -> bool {
@@ -51,6 +84,24 @@ impl RenduCapabilities {
             Some(SourceAtlasFallback::VaporSsr)
         } else {
             None
+        }
+    }
+
+    /// Classify how a Vapor render route resolves for this capability set.
+    ///
+    /// `shape_renderable` is whether the Vapor Atelier could lower the template
+    /// shape (Vapor reports this by succeeding or failing). The single rule:
+    /// an unrenderable shape is [`VaporSupport::Unsupported`], a Vapor+SSR route
+    /// degrades to standard SSR ([`VaporSupport::DegradesToSsr`]), and anything
+    /// else is [`VaporSupport::Renderable`]. The Vapor lane and `AtelierFallback`
+    /// reporting consume this instead of re-deriving the rule.
+    pub fn vapor_support(self, shape_renderable: bool) -> VaporSupport {
+        if !shape_renderable {
+            VaporSupport::Unsupported
+        } else if self.vapor_route_fallback() == Some(SourceAtlasFallback::VaporSsr) {
+            VaporSupport::DegradesToSsr
+        } else {
+            VaporSupport::Renderable
         }
     }
 
@@ -118,6 +169,32 @@ mod tests {
         assert_eq!(vapor_only.vapor_route_fallback(), None);
         let ssr_only = RenduCapabilities::empty().with_target(SourceAtlasTarget::Ssr);
         assert_eq!(ssr_only.vapor_route_fallback(), None);
+    }
+
+    #[test]
+    fn vapor_support_classifies_renderable_degraded_and_unsupported() {
+        let vapor = RenduCapabilities::empty().with_target(SourceAtlasTarget::Vapor);
+        // A renderable Vapor-only shape needs no fallback.
+        assert_eq!(vapor.vapor_support(true), VaporSupport::Renderable);
+        assert!(vapor.vapor_support(true).is_renderable());
+        assert_eq!(vapor.vapor_support(true).fallback(), None);
+
+        // An unrenderable shape reports UnsupportedVaporShape regardless of route.
+        assert_eq!(vapor.vapor_support(false), VaporSupport::Unsupported);
+        assert_eq!(
+            vapor.vapor_support(false).fallback(),
+            Some(SourceAtlasFallback::UnsupportedVaporShape)
+        );
+
+        // Vapor + SSR degrades to standard SSR even when the shape renders.
+        let vapor_ssr = vapor.with_target(SourceAtlasTarget::Ssr);
+        assert_eq!(vapor_ssr.vapor_support(true), VaporSupport::DegradesToSsr);
+        assert_eq!(
+            vapor_ssr.vapor_support(true).fallback(),
+            Some(SourceAtlasFallback::VaporSsr)
+        );
+        // An unrenderable shape wins over the route degrade.
+        assert_eq!(vapor_ssr.vapor_support(false), VaporSupport::Unsupported);
     }
 
     #[test]

--- a/crates/vize_atelier_sfc/src/compile/fallbacks.rs
+++ b/crates/vize_atelier_sfc/src/compile/fallbacks.rs
@@ -42,6 +42,18 @@ pub(crate) fn record_atelier_fallback(fallback: SourceAtlasFallback) {
     global_profiler().record_counter(fallback.profile_counter(), 1);
 }
 
+/// Record that the Vapor Atelier could not lower a template shape.
+///
+/// Routes the decision through the shared `RenduCapabilities::vapor_support`
+/// gate so the unsupported-shape fallback is reported the same way every Vapor
+/// lane reports it, instead of naming the fallback variant inline.
+pub(crate) fn record_unsupported_vapor_shape() {
+    let vapor = RenduCapabilities::empty().with_target(SourceAtlasTarget::Vapor);
+    if let Some(fallback) = vapor.vapor_support(false).fallback() {
+        record_atelier_fallback(fallback);
+    }
+}
+
 fn create_vapor_ssr_fallback_warning(descriptor: &SfcDescriptor) -> SfcError {
     SfcError {
         message: "SFC Vapor SSR is not supported yet; falling back to standard SSR output."

--- a/crates/vize_atelier_sfc/src/compile_template/vapor.rs
+++ b/crates/vize_atelier_sfc/src/compile_template/vapor.rs
@@ -7,14 +7,14 @@ use output::{
 };
 
 use super::string_tracking::{StringTrackState, count_braces_with_state};
-use vize_atelier_core::{TemplateSyntaxMode, source_atlas::SourceAtlasFallback};
+use vize_atelier_core::TemplateSyntaxMode;
 use vize_atelier_vapor::{
     VaporCompilerOptions, compile_vapor_with_template_syntax_and_diagnostics,
 };
 use vize_carton::{Bump, String, ToCompactString};
 
 use crate::{
-    compile::fallbacks::record_atelier_fallback,
+    compile::fallbacks::record_unsupported_vapor_shape,
     compile::output_module::AtelierOutputMaps,
     compile_template::{TemplateBlockCompileResult, recoverable_template_warnings},
     types::{BindingMetadata, SfcError, SfcTemplateBlock},
@@ -49,9 +49,9 @@ pub(crate) fn compile_template_block_vapor(
     );
 
     if !result.error_messages.is_empty() {
-        // Vapor could not lower this template shape: record the mismatch as an
-        // observable atlas fallback before surfacing the hard error.
-        record_atelier_fallback(SourceAtlasFallback::UnsupportedVaporShape);
+        // Vapor could not lower this template shape: record the shared
+        // unsupported-shape fallback before surfacing the hard error.
+        record_unsupported_vapor_shape();
         let mut message = String::from("Vapor template compilation errors: ");
         use std::fmt::Write as _;
         let _ = write!(&mut message, "{:?}", result.error_messages);

--- a/docs/content/architecture/source-atlas.md
+++ b/docs/content/architecture/source-atlas.md
@@ -74,7 +74,7 @@ Current `canary` state:
 - Follow-up tracks #1692-#1698 build on this foundation without new hot-path
   cost: `PlateFamily`/`PlateFamilySet` keep lint/editor lanes render-free;
   `SourceAtlasCoordinate::compatibility_fallback` reports pre-v3 lines as
-  `LegacySyntaxCompatibility`; `RenduCapability` / `vapor_route_fallback` let the
+  `LegacySyntaxCompatibility`; `RenduCapability` / `VaporSupport` let the
   Vapor lane consume shared facts and record `UnsupportedVaporShape`;
   fragment-less source maps report `SourceMapFragmentUnavailable`; and
   `render_fallback_report` / `render_registry_report` make fallbacks and plate


### PR DESCRIPTION
Closes #1697. Inclusion-Vapor track from #1634.

## What this adds

The shared `vapor_route_fallback()` already detects the Vapor+SSR degrade. This slice turns the full Vapor route decision into one capability gate the Vapor lane consumes, so `Rendu -> Vapor IR -> Vapor output` keeps its target-specific plan while capability mismatches stay observable.

- `VaporSupport { Renderable | DegradesToSsr | Unsupported }` and `RenduCapabilities::vapor_support(shape_renderable)` in `vize_atelier_core::rendu`. One rule: unrenderable shape → `Unsupported` (`UnsupportedVaporShape`); Vapor+SSR → `DegradesToSsr` (`VaporSsr`); else `Renderable`.
- The SFC Vapor adapter now reports unsupported shapes through a `record_unsupported_vapor_shape()` helper that consumes the gate, instead of naming the fallback variant inline.

## Non-goals (per #1697)

- Vapor IR is **not** flattened into Rendu — the route stays `Rendu -> Vapor IR -> Vapor output`.
- DOM/SSR output gains no Vapor-only assumptions.
- No second render traversal.

## Byte-equivalence

The recorded fallback (`UnsupportedVaporShape`) is unchanged — only its decision path is centralized. Vapor output bytes are unchanged.

## Verification

- `cargo test -p vize_atelier_core rendu::capability` (6) and `cargo test -p vize_atelier_sfc vapor` (12) — passing, incl. renderable / degraded / unsupported classification tests.
- `cargo clippy --lib` clean for both crates; changed code is CI-fmt-clean; files under the 350-line guard.

---

Part of the **[Next Gen]** stack for #1634, targeting `canary` via `nextgen/1692-plate-families` (#1735): #1692 → #1698 → #1695 → #1696 → **#1697 (this)**.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1752"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->