### PR TITLE
fix(musea): fail VRT CI on capture errors

### DIFF
--- a/docs/content/guide/musea.md
+++ b/docs/content/guide/musea.md
@@ -294,32 +294,17 @@ vp dev --host 0.0.0.0
 vp exec musea-vrt --base-url http://localhost:5173 --ci --json
 ```
 
-The workflow is:
+The workflow: commit baselines under the snapshot directory, run `musea-vrt --ci --json` against a
+running dev server, then inspect `vrt-report.json`/`vrt-report.html` plus `snapshots/current` and
+`snapshots/diff` on failure. Re-run with `--update` (or `approve` for selected variants) for
+intentional changes, and run `clean` after removing art files so stale baselines do not hide gaps.
+`--ci` exits non-zero for visual diffs and for preview/capture errors (missing route, browser
+failure, selector timeout); new baselines are reported as `new`, so run `--update` locally first.
 
-1. Commit the baseline images under the configured snapshot directory.
-2. Run `musea-vrt --ci --json` in CI against a running Musea dev server.
-3. Inspect `vrt-report.json`, `vrt-report.html`, `snapshots/current`, and `snapshots/diff` when a
-   run fails.
-4. Re-run locally with `--update`, or use `approve` for selected variants, when the visual change is
-   intentional.
-5. Run `clean` after removing art files or variants so stale baselines do not hide coverage gaps.
-
-`--ci` exits non-zero for visual diffs and for preview/capture errors such as a missing route,
-browser failure, or selector timeout. New baselines are reported as `new`; use `--update` locally
-before depending on those variants in CI.
-
-The example app wires the Playwright-native VRT path as well:
-
-```bash
-cd examples/vite-musea
-vp run test:vrt
-vp run test:vrt:update
-```
-
-Its Playwright config stores screenshots in `e2e/vrt/__snapshots__`, failure artifacts in
-`e2e/vrt/test-results`, and an HTML report in `playwright-report`. GitHub Actions uploads those
-artifacts on failure so reviewers can inspect the baseline, current, and diff images without
-reproducing the run locally.
+The example app also wires the Playwright-native VRT path (`examples/vite-musea`, run via
+`vp run test:vrt` / `vp run test:vrt:update`). Snapshots live in `e2e/vrt/__snapshots__`, failure
+artifacts in `e2e/vrt/test-results`, and the HTML report in `playwright-report`; GitHub Actions
+uploads them on failure so reviewers can inspect the baseline, current, and diff images.
 
 ## Generate Art Files
 

--- a/docs/content/guide/musea.md
+++ b/docs/content/guide/musea.md
@@ -294,8 +294,32 @@ vp dev --host 0.0.0.0
 vp exec musea-vrt --base-url http://localhost:5173 --ci --json
 ```
 
-Use `--update` locally to refresh baselines, `approve` to accept failed snapshots, and `clean` to
-remove orphaned snapshots after deleting variants.
+The workflow is:
+
+1. Commit the baseline images under the configured snapshot directory.
+2. Run `musea-vrt --ci --json` in CI against a running Musea dev server.
+3. Inspect `vrt-report.json`, `vrt-report.html`, `snapshots/current`, and `snapshots/diff` when a
+   run fails.
+4. Re-run locally with `--update`, or use `approve` for selected variants, when the visual change is
+   intentional.
+5. Run `clean` after removing art files or variants so stale baselines do not hide coverage gaps.
+
+`--ci` exits non-zero for visual diffs and for preview/capture errors such as a missing route,
+browser failure, or selector timeout. New baselines are reported as `new`; use `--update` locally
+before depending on those variants in CI.
+
+The example app wires the Playwright-native VRT path as well:
+
+```bash
+cd examples/vite-musea
+vp run test:vrt
+vp run test:vrt:update
+```
+
+Its Playwright config stores screenshots in `e2e/vrt/__snapshots__`, failure artifacts in
+`e2e/vrt/test-results`, and an HTML report in `playwright-report`. GitHub Actions uploads those
+artifacts on failure so reviewers can inspect the baseline, current, and diff images without
+reproducing the run locally.
 
 ## Generate Art Files
 

--- a/npm/vite-plugin-musea/src/cli/commands.test.ts
+++ b/npm/vite-plugin-musea/src/cli/commands.test.ts
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { hasCiBlockingVrtResult } from "./commands.ts";
+import type { VrtSummary } from "../vrt.ts";
+
+function summary(overrides: Partial<VrtSummary>): VrtSummary {
+  return {
+    total: 1,
+    passed: 1,
+    failed: 0,
+    new: 0,
+    skipped: 0,
+    duration: 25,
+    ...overrides,
+  };
+}
+
+void test("VRT CI blocks on visual diffs", () => {
+  assert.equal(hasCiBlockingVrtResult(summary({ failed: 1, passed: 0 })), true);
+});
+
+void test("VRT CI blocks on capture errors", () => {
+  assert.equal(hasCiBlockingVrtResult(summary({ skipped: 1, passed: 0 })), true);
+});
+
+void test("VRT CI allows clean and newly-created baselines", () => {
+  assert.equal(hasCiBlockingVrtResult(summary({})), false);
+  assert.equal(hasCiBlockingVrtResult(summary({ passed: 0, new: 1 })), false);
+});

--- a/npm/vite-plugin-musea/src/cli/commands.ts
+++ b/npm/vite-plugin-musea/src/cli/commands.ts
@@ -9,9 +9,14 @@ import fs from "node:fs";
 import path from "node:path";
 
 import { MuseaVrtRunner, generateVrtReport, generateVrtJsonReport } from "../vrt.js";
+import type { VrtSummary } from "../vrt.js";
 import type { ArtFileInfo, VrtOptions } from "../types/index.js";
 
 import type { CliOptions } from "./index.js";
+
+export function hasCiBlockingVrtResult(summary: VrtSummary): boolean {
+  return summary.failed > 0 || summary.skipped > 0;
+}
 
 export async function runVrt(options: CliOptions, artFiles: ArtFileInfo[]): Promise<void> {
   const totalVariants = artFiles.reduce(
@@ -119,8 +124,8 @@ export async function runVrt(options: CliOptions, artFiles: ArtFileInfo[]): Prom
       console.log(`  HTML report: ${htmlPath}\n`);
     }
 
-    // CI mode - exit with error if failures
-    if (options.ci && summary.failed > 0) {
+    // CI mode - exit with error if visual diffs or capture/runtime errors occurred.
+    if (options.ci && hasCiBlockingVrtResult(summary)) {
       console.log("  CI mode: Exiting with error due to failures\n");
       process.exit(1);
     }


### PR DESCRIPTION
## Summary
- fail Musea VRT CI when preview capture/runtime errors are reported
- add regression coverage for the VRT CI blocking decision
- document the Musea VRT baseline, diff, artifact, and approval workflow

Closes #1584

## Verification
- vp run --filter './npm/vite-plugin-musea' test -- src/cli/commands.test.ts
- vp check docs/content/guide/musea.md npm/vite-plugin-musea/src/cli/commands.ts npm/vite-plugin-musea/src/cli/commands.test.ts
- vp run --filter './docs' build

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1754"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->