### PR TITLE
[Next Gen] docs(croquis): clarify the analysis vs analyzer naming rule

### DIFF
--- a/crates/vize_croquis_cf/src/lib.rs
+++ b/crates/vize_croquis_cf/src/lib.rs
@@ -17,6 +17,23 @@
 //!   - Server/Client Boundaries: Identify SSR hydration boundary issues
 //!   - Error/Suspense Boundaries: Track error and async handling scopes
 //!
+//! ## Naming
+//!
+//! "Analysis" and "analyzer" are kept distinct on purpose, so a symbol's name
+//! tells you whether it is a driver, a pass, or data:
+//!
+//! - an **`*Analyzer`** (e.g. [`CrossFileAnalyzer`]) is a *driver*: it owns
+//!   state, accepts files and options, and runs passes;
+//! - an **`analyze_*`** free function is one *pass* over already-collected
+//!   facts;
+//! - the produced *data* is a result type — [`CrossFileResult`] here, and the
+//!   `*Analysis` facts (such as `SfcCroquisAnalysis`/`NodeAnalysis`) for
+//!   single-file Croquis — never an `Analyzer`.
+//!
+//! New code keeps drivers as `*Analyzer`, passes as `analyze_*`, and data as a
+//! result/analysis type; renames toward this rule land as small,
+//! compatibility-aware steps so snapshots and public APIs stay stable.
+//!
 //! ## Usage
 //!
 //! ```ignore


### PR DESCRIPTION
Part of #1581 (TODO items 1–2: inventory + decide a consistent naming rule).

## What this does

`analysis`/`analyzer` blur together across the Croquis crates. This is the **first compatibility-aware step**: decide and document the rule before any mechanical rename, so subsequent renames can be small and snapshot-safe.

The rule (now on the `vize_croquis_cf` crate root doc):

- **`*Analyzer`** (e.g. `CrossFileAnalyzer`) = a *driver* — owns state, accepts files/options, runs passes;
- **`analyze_*`** free function = one *pass* over collected facts;
- produced *data* = a result/`*Analysis` type (`CrossFileResult`, `SfcCroquisAnalysis`, `NodeAnalysis`) — never an `Analyzer`.

Inventory shows the split is already mostly consistent; the lone outlier is `CrossFileResult` (a data type named `Result`). Renaming it (and aligning the rest) is public-API/snapshot-affecting, so per the issue's own "small compatibility-aware steps" it is deferred to follow-up rather than churned here.

## Verification

- `cargo build -p vize_croquis_cf` — clean.
- `cargo doc -p vize_croquis_cf` with `-D rustdoc::broken_intra_doc_links` — clean (intra-doc links resolve).
- Doc-only change; no behavior, no snapshots, file under the 350-line guard.

---

Carried with the **[Next Gen]** work for #1634, targeting `canary` via `nextgen/1692-plate-families` (#1735).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1755"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->