### PR TITLE
feat(musea): persist props editor state

### DIFF
--- a/npm/vite-plugin-musea/gallery/components/PropsPanel.vue
+++ b/npm/vite-plugin-musea/gallery/components/PropsPanel.vue
@@ -31,6 +31,8 @@ const {
   loading,
   error,
   values,
+  customProps,
+  deletedPaletteProps,
   allControls,
   mergedValues,
   customPropNames,
@@ -40,6 +42,8 @@ const {
   addProp,
   removeProp,
   resetValues,
+  saveValues,
+  clearSavedValues,
 } = usePalette();
 const { getArt } = useArts();
 
@@ -51,6 +55,7 @@ const art = computed(() => getArt(props.artPath));
 
 // Mode toggle
 const controlsMode = ref<"controls" | "code">("controls");
+const saveStatus = ref<"idle" | "saved">("idle");
 
 // Code mode state
 const codeEditorContent = ref("");
@@ -85,6 +90,14 @@ watch(
     const iframe = iframeRef.value;
     if (!iframe || !iframeReady.value) return;
     sendMessage(iframe, "musea:set-props", { props: newValues });
+  },
+  { deep: true },
+);
+
+watch(
+  [values, customProps, deletedPaletteProps],
+  () => {
+    saveStatus.value = "idle";
   },
   { deep: true },
 );
@@ -164,12 +177,19 @@ onUnmounted(() => {
 
 function onResetValues() {
   resetValues();
+  clearSavedValues(props.artPath);
   slotContent.value = {};
   controlsMode.value = "controls";
+  saveStatus.value = "idle";
   const iframe = iframeRef.value;
   if (!iframe || !iframeReady.value) return;
   sendMessage(iframe, "musea:set-props", { props: mergedValues.value });
   sendMessage(iframe, "musea:set-slots", { slots: {} });
+}
+
+function onSaveValues() {
+  saveValues(props.artPath);
+  saveStatus.value = "saved";
 }
 
 function onSlotsUpdate(slots: Record<string, string>) {
@@ -449,6 +469,14 @@ const controlKindOptions = [
                 </button>
               </div>
               <button type="button" class="props-reset" @click="onResetValues">Reset</button>
+              <button
+                type="button"
+                class="props-save"
+                :class="{ saved: saveStatus === 'saved' }"
+                @click="onSaveValues"
+              >
+                {{ saveStatus === "saved" ? "Saved" : "Save" }}
+              </button>
             </div>
           </div>
 
@@ -745,7 +773,8 @@ const controlKindOptions = [
   color: var(--musea-text);
 }
 
-.props-reset {
+.props-reset,
+.props-save {
   background: var(--musea-bg-tertiary);
   border: 1px solid var(--musea-border);
   border-radius: var(--musea-radius-sm);
@@ -756,9 +785,15 @@ const controlKindOptions = [
   transition: all var(--musea-transition);
 }
 
-.props-reset:hover {
+.props-reset:hover,
+.props-save:hover {
   border-color: var(--musea-text-muted);
   color: var(--musea-text);
+}
+
+.props-save.saved {
+  border-color: var(--musea-accent);
+  color: var(--musea-accent);
 }
 
 .props-grid {

--- a/npm/vite-plugin-musea/gallery/components/PropsPanel.vue
+++ b/npm/vite-plugin-musea/gallery/components/PropsPanel.vue
@@ -7,6 +7,7 @@ import { usePalette } from "../composables/usePalette";
 import { useArts } from "../composables/useArts";
 import { getPreviewUrl } from "../api";
 import { sendMessage } from "../composables/usePostMessage";
+import { indentUsage, usageScript } from "../utils/usageCode";
 import TextControl from "./controls/TextControl.vue";
 import NumberControl from "./controls/NumberControl.vue";
 import BooleanControl from "./controls/BooleanControl.vue";
@@ -279,73 +280,6 @@ async function copyUsage() {
   } catch {
     // fallback
   }
-}
-
-function usageScript(content?: string, isolated = true): string {
-  if (!content) return "";
-  const lines = content.split("\n");
-  const componentName = extractDefineArtComponentName(content);
-  const kept: string[] = [];
-  let defineArtBalance = 0;
-
-  for (const line of lines) {
-    const trimmed = line.trim();
-    if (defineArtBalance > 0) {
-      defineArtBalance += parenBalance(line);
-      continue;
-    }
-    if (/\bdefineArt\s*\(/.test(trimmed)) {
-      defineArtBalance = Math.max(0, parenBalance(line));
-      continue;
-    }
-    if (isolated && componentName && importDeclaresName(line, componentName)) {
-      continue;
-    }
-    kept.push(line);
-  }
-
-  return kept.join("\n").trim();
-}
-
-function extractDefineArtComponentName(content: string): string | undefined {
-  const sourceMatch = content.match(/\bdefineArt\s*\(\s*(['"])([^'"]+)\1/);
-  if (sourceMatch) {
-    return componentNameFromSource(sourceMatch[2]);
-  }
-  return content.match(/\bdefineArt\s*\(\s*([A-Za-z_$][\w$]*)/)?.[1];
-}
-
-function componentNameFromSource(source: string): string {
-  const withoutQuery = source.split(/[?#]/, 1)[0] || source;
-  const filename = withoutQuery.split(/[\\/]/).pop() || "Component";
-  const stem = filename.replace(/\.[^.]+$/, "");
-  const name = stem
-    .split(/[^A-Za-z0-9]+/)
-    .filter(Boolean)
-    .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
-    .join("");
-  return name || "Component";
-}
-
-function importDeclaresName(line: string, name: string): boolean {
-  const trimmed = line.trim();
-  if (!trimmed.startsWith("import ") || trimmed.startsWith("import type ")) return false;
-  return new RegExp(`^import\\s+${name}(?:\\s|,|$)`).test(trimmed);
-}
-
-function parenBalance(line: string): number {
-  return [...line].reduce((balance, char) => {
-    if (char === "(") return balance + 1;
-    if (char === ")") return balance - 1;
-    return balance;
-  }, 0);
-}
-
-function indentUsage(code: string): string {
-  return code
-    .split("\n")
-    .map((line) => (line.trim() ? `  ${line}` : line))
-    .join("\n");
 }
 
 function getControlComponent(kind: string) {

--- a/npm/vite-plugin-musea/gallery/composables/paletteState.ts
+++ b/npm/vite-plugin-musea/gallery/composables/paletteState.ts
@@ -1,0 +1,186 @@
+import type { PaletteControl } from "../api";
+
+export interface CustomProp {
+  name: string;
+  control: string;
+  default_value: unknown;
+}
+
+export interface SavedPaletteState {
+  version: 1;
+  values: Record<string, unknown>;
+  customProps: CustomProp[];
+  deletedPaletteProps: string[];
+}
+
+export interface RestoredPaletteState {
+  values: Record<string, unknown>;
+  customProps: CustomProp[];
+  deletedPaletteProps: Set<string>;
+}
+
+export const PALETTE_STATE_VERSION = 1;
+
+const PALETTE_STATE_STORAGE_PREFIX = "musea:props-editor:";
+
+export function getPaletteStateStorageKey(artPath: string): string {
+  return `${PALETTE_STATE_STORAGE_PREFIX}${artPath}`;
+}
+
+export function normalizeSavedPaletteState(input: unknown): SavedPaletteState | null {
+  if (!isRecord(input) || input.version !== PALETTE_STATE_VERSION) {
+    return null;
+  }
+
+  if (!isRecord(input.values)) {
+    return null;
+  }
+
+  const customPropsInput = Array.isArray(input.customProps) ? input.customProps : [];
+  const customProps: CustomProp[] = [];
+  const seenNames = new Set<string>();
+  for (const item of customPropsInput) {
+    const customProp = normalizeCustomProp(item);
+    if (!customProp || seenNames.has(customProp.name)) {
+      continue;
+    }
+    seenNames.add(customProp.name);
+    customProps.push(customProp);
+  }
+
+  const deletedPaletteProps = Array.isArray(input.deletedPaletteProps)
+    ? input.deletedPaletteProps.filter((name): name is string => typeof name === "string")
+    : [];
+
+  return {
+    version: PALETTE_STATE_VERSION,
+    values: { ...input.values },
+    customProps,
+    deletedPaletteProps,
+  };
+}
+
+export function restorePaletteState(
+  controls: PaletteControl[],
+  saved: SavedPaletteState,
+): RestoredPaletteState {
+  const paletteNames = new Set(controls.map((control) => control.name));
+  const customProps: CustomProp[] = [];
+  const customNames = new Set<string>();
+
+  for (const customProp of saved.customProps) {
+    if (paletteNames.has(customProp.name) || customNames.has(customProp.name)) {
+      continue;
+    }
+    customNames.add(customProp.name);
+    customProps.push(customProp);
+  }
+
+  const deletedPaletteProps = new Set(
+    saved.deletedPaletteProps.filter((name) => paletteNames.has(name)),
+  );
+  const allowedNames = new Set([...paletteNames, ...customNames]);
+  const restoredValues = initialPaletteValues(controls);
+
+  for (const customProp of customProps) {
+    restoredValues[customProp.name] = customProp.default_value;
+  }
+
+  for (const [name, value] of Object.entries(saved.values)) {
+    if (allowedNames.has(name)) {
+      restoredValues[name] = value;
+    }
+  }
+
+  return {
+    values: restoredValues,
+    customProps,
+    deletedPaletteProps,
+  };
+}
+
+export function readSavedPaletteState(artPath: string): SavedPaletteState | null {
+  const storage = getPaletteStateStorage();
+  if (!storage) return null;
+
+  try {
+    const raw = storage.getItem(getPaletteStateStorageKey(artPath));
+    if (!raw) return null;
+    return normalizeSavedPaletteState(JSON.parse(raw));
+  } catch {
+    return null;
+  }
+}
+
+export function writeSavedPaletteState(artPath: string, state: SavedPaletteState): void {
+  const storage = getPaletteStateStorage();
+  if (!storage) return;
+
+  try {
+    storage.setItem(getPaletteStateStorageKey(artPath), JSON.stringify(state));
+  } catch {
+    // Browsers can reject localStorage writes in private or quota-limited contexts.
+  }
+}
+
+export function clearSavedPaletteState(artPath: string): void {
+  const storage = getPaletteStateStorage();
+  if (!storage) return;
+
+  try {
+    storage.removeItem(getPaletteStateStorageKey(artPath));
+  } catch {
+    // Ignore storage cleanup failures for the same reason as writes.
+  }
+}
+
+export function initialPaletteValues(controls: PaletteControl[]): Record<string, unknown> {
+  const initial: Record<string, unknown> = {};
+  for (const control of controls) {
+    initial[control.name] =
+      control.default_value !== undefined ? control.default_value : fallbackValue(control);
+  }
+  return initial;
+}
+
+function getPaletteStateStorage(): Storage | null {
+  if (typeof localStorage === "undefined") {
+    return null;
+  }
+  return localStorage;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function normalizeCustomProp(input: unknown): CustomProp | null {
+  if (!isRecord(input) || typeof input.name !== "string" || typeof input.control !== "string") {
+    return null;
+  }
+
+  const name = input.name.trim();
+  const control = input.control.trim();
+  if (!name || !control) {
+    return null;
+  }
+
+  return {
+    name,
+    control,
+    default_value: input.default_value,
+  };
+}
+
+function fallbackValue(control: PaletteControl): unknown {
+  if ((control.control === "select" || control.control === "radio") && control.options.length > 0) {
+    return control.options[0].value;
+  }
+  if (control.control === "boolean") return false;
+  if (control.control === "number" || control.control === "range") {
+    return control.range?.min ?? 0;
+  }
+  if (control.control === "array") return [];
+  if (control.control === "object") return {};
+  return "";
+}

--- a/npm/vite-plugin-musea/gallery/composables/usePalette.ts
+++ b/npm/vite-plugin-musea/gallery/composables/usePalette.ts
@@ -1,12 +1,15 @@
 import { ref, computed } from "vue";
 import type { PaletteApiResponse, PaletteControl } from "../api";
 import { fetchPalette } from "../api";
-
-export interface CustomProp {
-  name: string;
-  control: string;
-  default_value: unknown;
-}
+import {
+  PALETTE_STATE_VERSION,
+  clearSavedPaletteState,
+  initialPaletteValues,
+  readSavedPaletteState,
+  restorePaletteState,
+  writeSavedPaletteState,
+  type CustomProp,
+} from "./paletteState";
 
 export function usePalette() {
   const palette = ref<PaletteApiResponse | null>(null);
@@ -49,9 +52,17 @@ export function usePalette() {
     error.value = null;
     try {
       palette.value = await fetchPalette(artPath);
-      values.value = initialValues(palette.value.controls);
-      customProps.value = [];
-      deletedPaletteProps.value = new Set();
+      const saved = readSavedPaletteState(artPath);
+      if (saved) {
+        const restored = restorePaletteState(palette.value.controls, saved);
+        values.value = restored.values;
+        customProps.value = restored.customProps;
+        deletedPaletteProps.value = restored.deletedPaletteProps;
+      } else {
+        values.value = initialPaletteValues(palette.value.controls);
+        customProps.value = [];
+        deletedPaletteProps.value = new Set();
+      }
     } catch (e) {
       error.value = e instanceof Error ? e.message : String(e);
       palette.value = null;
@@ -98,9 +109,22 @@ export function usePalette() {
 
   function resetValues() {
     if (!palette.value) return;
-    values.value = initialValues(palette.value.controls);
+    values.value = initialPaletteValues(palette.value.controls);
     customProps.value = [];
     deletedPaletteProps.value = new Set();
+  }
+
+  function saveValues(artPath: string) {
+    writeSavedPaletteState(artPath, {
+      version: PALETTE_STATE_VERSION,
+      values: values.value,
+      customProps: customProps.value,
+      deletedPaletteProps: [...deletedPaletteProps.value],
+    });
+  }
+
+  function clearSavedValues(artPath: string) {
+    clearSavedPaletteState(artPath);
   }
 
   return {
@@ -119,27 +143,7 @@ export function usePalette() {
     addProp,
     removeProp,
     resetValues,
+    saveValues,
+    clearSavedValues,
   };
-}
-
-function initialValues(controls: PaletteControl[]): Record<string, unknown> {
-  const initial: Record<string, unknown> = {};
-  for (const control of controls) {
-    initial[control.name] =
-      control.default_value !== undefined ? control.default_value : fallbackValue(control);
-  }
-  return initial;
-}
-
-function fallbackValue(control: PaletteControl): unknown {
-  if ((control.control === "select" || control.control === "radio") && control.options.length > 0) {
-    return control.options[0].value;
-  }
-  if (control.control === "boolean") return false;
-  if (control.control === "number" || control.control === "range") {
-    return control.range?.min ?? 0;
-  }
-  if (control.control === "array") return [];
-  if (control.control === "object") return {};
-  return "";
 }

--- a/npm/vite-plugin-musea/gallery/utils/usageCode.ts
+++ b/npm/vite-plugin-musea/gallery/utils/usageCode.ts
@@ -1,0 +1,66 @@
+export function usageScript(content?: string, isolated = true): string {
+  if (!content) return "";
+  const lines = content.split("\n");
+  const componentName = extractDefineArtComponentName(content);
+  const kept: string[] = [];
+  let defineArtBalance = 0;
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (defineArtBalance > 0) {
+      defineArtBalance += parenBalance(line);
+      continue;
+    }
+    if (/\bdefineArt\s*\(/.test(trimmed)) {
+      defineArtBalance = Math.max(0, parenBalance(line));
+      continue;
+    }
+    if (isolated && componentName && importDeclaresName(line, componentName)) {
+      continue;
+    }
+    kept.push(line);
+  }
+
+  return kept.join("\n").trim();
+}
+
+export function extractDefineArtComponentName(content: string): string | undefined {
+  const sourceMatch = content.match(/\bdefineArt\s*\(\s*(['"])([^'"]+)\1/);
+  if (sourceMatch) {
+    return componentNameFromSource(sourceMatch[2]);
+  }
+  return content.match(/\bdefineArt\s*\(\s*([A-Za-z_$][\w$]*)/)?.[1];
+}
+
+export function componentNameFromSource(source: string): string {
+  const withoutQuery = source.split(/[?#]/, 1)[0] || source;
+  const filename = withoutQuery.split(/[\\/]/).pop() || "Component";
+  const stem = filename.replace(/\.[^.]+$/, "");
+  const name = stem
+    .split(/[^A-Za-z0-9]+/)
+    .filter(Boolean)
+    .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+    .join("");
+  return name || "Component";
+}
+
+export function importDeclaresName(line: string, name: string): boolean {
+  const trimmed = line.trim();
+  if (!trimmed.startsWith("import ") || trimmed.startsWith("import type ")) return false;
+  return new RegExp(`^import\\s+${name}(?:\\s|,|$)`).test(trimmed);
+}
+
+export function parenBalance(line: string): number {
+  return [...line].reduce((balance, char) => {
+    if (char === "(") return balance + 1;
+    if (char === ")") return balance - 1;
+    return balance;
+  }, 0);
+}
+
+export function indentUsage(code: string): string {
+  return code
+    .split("\n")
+    .map((line) => (line.trim() ? `  ${line}` : line))
+    .join("\n");
+}

--- a/npm/vite-plugin-musea/gallery/utils/usageCode.ts
+++ b/npm/vite-plugin-musea/gallery/utils/usageCode.ts
@@ -51,11 +51,12 @@ export function importDeclaresName(line: string, name: string): boolean {
 }
 
 export function parenBalance(line: string): number {
-  return [...line].reduce((balance, char) => {
-    if (char === "(") return balance + 1;
-    if (char === ")") return balance - 1;
-    return balance;
-  }, 0);
+  let balance = 0;
+  for (const char of line) {
+    if (char === "(") balance += 1;
+    else if (char === ")") balance -= 1;
+  }
+  return balance;
 }
 
 export function indentUsage(code: string): string {

--- a/npm/vite-plugin-musea/src/palette-state.test.ts
+++ b/npm/vite-plugin-musea/src/palette-state.test.ts
@@ -1,0 +1,126 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  clearSavedPaletteState,
+  getPaletteStateStorageKey,
+  normalizeSavedPaletteState,
+  readSavedPaletteState,
+  restorePaletteState,
+  writeSavedPaletteState,
+  type SavedPaletteState,
+} from "../gallery/composables/paletteState.ts";
+
+const controls = [
+  {
+    name: "tone",
+    control: "select",
+    default_value: "brand",
+    required: false,
+    options: [
+      { label: "brand", value: "brand" },
+      { label: "danger", value: "danger" },
+    ],
+  },
+  {
+    name: "size",
+    control: "number",
+    default_value: 4,
+    required: false,
+    options: [],
+  },
+];
+
+void test("saved props editor state is restored against current palette controls", () => {
+  const saved = normalizeSavedPaletteState({
+    version: 1,
+    values: {
+      tone: "danger",
+      size: 10,
+      stale: "removed",
+      "data-test": "card",
+      toneCustom: "ignored",
+    },
+    customProps: [
+      { name: "data-test", control: "text", default_value: "fallback" },
+      { name: "tone", control: "text", default_value: "collision" },
+      { name: "data-test", control: "text", default_value: "duplicate" },
+    ],
+    deletedPaletteProps: ["size", "missing"],
+  });
+
+  assert.ok(saved);
+
+  const restored = restorePaletteState(controls, saved);
+
+  assert.deepEqual(restored.values, {
+    tone: "danger",
+    size: 10,
+    "data-test": "card",
+  });
+  assert.deepEqual(restored.customProps, [
+    { name: "data-test", control: "text", default_value: "fallback" },
+  ]);
+  assert.deepEqual([...restored.deletedPaletteProps], ["size"]);
+});
+
+void test("saved props editor state round-trips through localStorage", () => {
+  const storage = new MemoryStorage();
+  const original = Object.getOwnPropertyDescriptor(globalThis, "localStorage");
+  Object.defineProperty(globalThis, "localStorage", {
+    value: storage,
+    configurable: true,
+  });
+
+  const state: SavedPaletteState = {
+    version: 1,
+    values: { tone: "brand" },
+    customProps: [],
+    deletedPaletteProps: [],
+  };
+
+  try {
+    writeSavedPaletteState("/src/Button.art.vue", state);
+
+    assert.equal(storage.getItem(getPaletteStateStorageKey("/src/Button.art.vue")) !== null, true);
+    assert.deepEqual(readSavedPaletteState("/src/Button.art.vue"), state);
+
+    clearSavedPaletteState("/src/Button.art.vue");
+
+    assert.equal(readSavedPaletteState("/src/Button.art.vue"), null);
+  } finally {
+    if (original) {
+      Object.defineProperty(globalThis, "localStorage", original);
+    } else {
+      Reflect.deleteProperty(globalThis, "localStorage");
+    }
+  }
+});
+
+class MemoryStorage implements Storage {
+  private readonly items = new Map<string, string>();
+
+  get length(): number {
+    return this.items.size;
+  }
+
+  clear(): void {
+    this.items.clear();
+  }
+
+  getItem(key: string): string | null {
+    return this.items.get(key) ?? null;
+  }
+
+  key(index: number): string | null {
+    return [...this.items.keys()][index] ?? null;
+  }
+
+  removeItem(key: string): void {
+    this.items.delete(key);
+  }
+
+  setItem(key: string, value: string): void {
+    this.items.set(key, value);
+  }
+}


### PR DESCRIPTION
## Summary
- add per-art-file localStorage persistence for props editor values, custom props, and removed palette props
- add Save/Reset flow to the props panel while keeping live preview application unchanged
- cover saved state normalization and restore behavior with unit tests

Closes #1585

## Verification
- vp run --filter './npm/vite-plugin-musea' test -- src/palette-state.test.ts
- vp check npm/vite-plugin-musea/gallery/composables/usePalette.ts npm/vite-plugin-musea/gallery/composables/paletteState.ts npm/vite-plugin-musea/gallery/components/PropsPanel.vue npm/vite-plugin-musea/src/palette-state.test.ts
- vp run --filter './npm/vite-plugin-musea' build

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1768"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->