### PR TITLE
feat(patina): document type-aware lint opt-in

### DIFF
--- a/crates/vize_patina/src/linter/native_type_aware/tests/opt_in.rs
+++ b/crates/vize_patina/src/linter/native_type_aware/tests/opt_in.rs
@@ -26,3 +26,29 @@ fn explicit_type_rule_registration_enables_native_type_aware_rules() {
         .with_rule(Box::new(crate::rules::type_aware::NoReactivityLoss::new()));
     assert!(has_active_type_aware_rules(&linter));
 }
+
+#[test]
+fn type_aware_opt_in_warns_when_corsa_runtime_is_missing() {
+    let missing_corsa = std::env::temp_dir().join("vize-missing-corsa-for-type-aware-lint");
+    let linter = Linter::with_preset(LintPreset::Opinionated)
+        .with_type_aware_lint(true)
+        .with_corsa_path(Some(missing_corsa));
+    let result = linter.lint_sfc(
+        r#"<script setup lang="ts">
+const payload: any = { title: "Untyped" };
+</script>
+
+<template>
+  <p>{{ payload.title }}</p>
+</template>
+"#,
+        "TypeAwareFixture.vue",
+    );
+
+    assert!(
+        result
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.rule_name == "type/corsa-runtime")
+    );
+}

--- a/docs/content/rules/type-and-script.md
+++ b/docs/content/rules/type-and-script.md
@@ -11,6 +11,22 @@ project shape that TypeScript reads from `tsconfig.json`, so shared ambient name
 Script rules are Patina rules for Composition API and Vapor-oriented code. They focus on patterns
 that are hard to compile efficiently or hard to reason about in Vapor mode.
 
+Type-aware linting is opt-in. Enable it with `linter.typeAware: true`, `vize lint --type-aware`, or
+by explicitly enabling a `type/*` rule. `type/no-reactivity-loss` can be enabled directly with
+`vize lint --strict-reactivity`. If Corsa cannot be started, Patina reports `type/corsa-runtime` and
+skips the checker-backed rule pass instead of silently dropping the configured rules.
+
+`--type-aware` uses the same Corsa executable resolution as `vize check`; configure
+`typeChecker.corsaPath` when the project needs an explicit `tsgo` or Corsa binary. Defaults stay
+zero-cost: Patina does not parse SFCs for checker-backed linting or start Corsa unless the flag,
+`linter.typeAware`, or an explicitly enabled `type/*` rule opts in.
+
+```ts
+export default defineConfig({
+  linter: { typeAware: true },
+});
+```
+
 ## `type/require-typed-props`
 
 Requires `defineProps` to be typed instead of using a runtime array declaration.

--- a/npm/vize/pkl/LinterConfig.pkl
+++ b/npm/vize/pkl/LinterConfig.pkl
@@ -14,6 +14,9 @@ class LinterConfig {
   /// Built-in lint preset.
   preset: LintPreset = "ecosystem"
 
+  /// Enable native type-aware lint rules from the active lint configuration.
+  typeAware: Boolean = false
+
   /// Rules to enable/disable.
   rules: Mapping<String, RuleSeverity> = new Mapping {}
 

--- a/npm/vize/pkl/jsonschema/generate.pkl
+++ b/npm/vize/pkl/jsonschema/generate.pkl
@@ -2,19 +2,15 @@
 ///
 /// Usage: pkl eval -f json pkl/jsonschema/generate.pkl
 module vize.jsonschema.generate
-
 import "@json_schema/JsonSchema.pkl"
-
 local ruleSeverityEnum: JsonSchema = new JsonSchema {
   type = "string"
   enum = new Listing { "off"; "warn"; "error" }
 }
-
 local lintPresetEnum: JsonSchema = new JsonSchema {
   type = "string"
   enum = new Listing { "happy-path"; "opinionated"; "essential"; "incremental"; "ecosystem"; "nuxt" }
 }
-
 local stringListDef: JsonSchema = new JsonSchema {
   type = "array"
   items = new JsonSchema { type = "string" }
@@ -155,6 +151,10 @@ local linterConfigDef: JsonSchema = new JsonSchema {
       enum = lintPresetEnum.enum
       description = "Built-in lint preset"
       default = "happy-path"
+    }
+    ["typeAware"] = new JsonSchema {
+      type = "boolean"
+      description = "Enable native type-aware lint rules from the active lint configuration"
     }
     ["rules"] = new JsonSchema {
       type = "object"

--- a/npm/vize/pkl/vize.pkl
+++ b/npm/vize/pkl/vize.pkl
@@ -47,6 +47,7 @@ class VitePluginConfig {
 class LinterConfig {
   enabled: Boolean? = null
   preset: LintPreset? = null
+  typeAware: Boolean? = null
   rules: Mapping<String, RuleSeverity>? = null
   categories: Mapping<String, RuleSeverity>? = null
 }

--- a/tests/tooling/config-json-shape.test.ts
+++ b/tests/tooling/config-json-shape.test.ts
@@ -82,3 +82,34 @@ test("nested null values are stripped from object config", async () => {
     entries: [{ formatter: { printWidth: 5 } }],
   });
 });
+
+test("type-aware lint opt-in is exposed across config artifacts", () => {
+  const schema = JSON.parse(
+    fs.readFileSync(path.join("npm", "vize", "schemas", "vize.config.schema.json"), "utf8"),
+  ) as {
+    definitions: {
+      LinterConfig: {
+        properties: Record<string, { type?: string; description?: string }>;
+      };
+    };
+  };
+  const generatedTypes = fs.readFileSync(
+    path.join("npm", "vize", "src", "types", "generated.ts"),
+    "utf8",
+  );
+  const pklLinterConfig = fs.readFileSync(
+    path.join("npm", "vize", "pkl", "LinterConfig.pkl"),
+    "utf8",
+  );
+  const pklCompatConfig = fs.readFileSync(path.join("npm", "vize", "pkl", "vize.pkl"), "utf8");
+  const pklSchemaGenerator = fs.readFileSync(
+    path.join("npm", "vize", "pkl", "jsonschema", "generate.pkl"),
+    "utf8",
+  );
+
+  assert.equal(schema.definitions.LinterConfig.properties.typeAware.type, "boolean");
+  assert.match(generatedTypes, /typeAware\?: boolean;/);
+  assert.match(pklLinterConfig, /typeAware: Boolean = false/);
+  assert.match(pklCompatConfig, /typeAware: Boolean\? = null/);
+  assert.match(pklSchemaGenerator, /\["typeAware"\] = new JsonSchema/);
+});


### PR DESCRIPTION
## Summary
- expose linter.typeAware in Pkl config artifacts and schema generation
- document the CLI/config opt-in paths for native Corsa-backed type-aware lint
- add tests for config artifact coverage and missing-Corsa failure behavior

Closes #1586

## Verification
- cargo test -p vize_patina type_aware_opt_in_warns_when_corsa_runtime_is_missing
- node --test tests/tooling/config-json-shape.test.ts
- vp check crates/vize_patina/src/linter/native_type_aware/tests/opt_in.rs npm/vize/pkl/LinterConfig.pkl npm/vize/pkl/vize.pkl npm/vize/pkl/jsonschema/generate.pkl npm/vize/schemas/vize.config.schema.json tests/tooling/config-json-shape.test.ts docs/content/guide/configuration.md docs/content/guide/cli.md docs/content/rules/type-and-script.md
- vp run --filter './docs' build

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1769"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->