### PR TITLE
fix(croquis): preserve aliased prop defaults

### DIFF
--- a/crates/vize_croquis/src/script_parser.rs
+++ b/crates/vize_croquis/src/script_parser.rs
@@ -35,3 +35,6 @@ pub use result::{ScriptParseResult, ScriptParserOptions};
 
 #[cfg(test)]
 mod tests;
+
+#[cfg(test)]
+mod props_destructure_tests;

--- a/crates/vize_croquis/src/script_parser/process/macros.rs
+++ b/crates/vize_croquis/src/script_parser/process/macros.rs
@@ -445,9 +445,9 @@ pub(in crate::script_parser) fn process_variable_declarator(
                             .map(CompactString::new)
                             .unwrap_or_else(|| CompactString::new(&local_name));
 
-                        // Extract default value if present (assignment pattern)
-                        let default_value = if prop.shorthand {
-                            // Check if the value is an assignment pattern with default
+                        // Extract default value if present (assignment pattern), including
+                        // renamed destructures such as `{ source: local = fallback }`.
+                        let default_value =
                             if let BindingPattern::AssignmentPattern(assign) = &prop.value {
                                 Some(CompactString::new(
                                     &source[assign.right.span().start as usize
@@ -455,10 +455,7 @@ pub(in crate::script_parser) fn process_variable_declarator(
                                 ))
                             } else {
                                 None
-                            }
-                        } else {
-                            None
-                        };
+                            };
 
                         destructure.insert(key, CompactString::new(&local_name), default_value);
                     }

--- a/crates/vize_croquis/src/script_parser/props_destructure_tests.rs
+++ b/crates/vize_croquis/src/script_parser/props_destructure_tests.rs
@@ -1,0 +1,40 @@
+use super::parse_script_setup;
+use vize_relief::BindingType;
+
+#[test]
+fn test_parse_define_props_destructure_tracks_aliased_defaults() {
+    let result = parse_script_setup(
+        r#"
+            const {
+                count: localCount = 1,
+                label = "Untitled",
+                ...rest
+            } = defineProps<{
+                count?: number
+                label?: string
+                id?: string
+            }>()
+        "#,
+    );
+
+    let destructure = result
+        .macros
+        .props_destructure()
+        .expect("defineProps destructure metadata should be recorded");
+    let count = destructure
+        .get("count")
+        .expect("renamed prop should use the original prop key");
+    assert_eq!(count.local.as_str(), "localCount");
+    assert_eq!(count.default.as_deref(), Some("1"));
+
+    let label = destructure
+        .get("label")
+        .expect("shorthand prop should be recorded");
+    assert_eq!(label.local.as_str(), "label");
+    assert_eq!(label.default.as_deref(), Some("\"Untitled\""));
+    assert_eq!(destructure.rest_id.as_deref(), Some("rest"));
+
+    assert_eq!(result.bindings.get("localCount"), Some(BindingType::Props));
+    assert_eq!(result.bindings.get("label"), Some(BindingType::Props));
+    assert_eq!(result.bindings.get("rest"), Some(BindingType::Props));
+}

--- a/crates/vize_croquis_cf/src/analyzer/tests_reactivity_props/direct.rs
+++ b/crates/vize_croquis_cf/src/analyzer/tests_reactivity_props/direct.rs
@@ -35,6 +35,39 @@ const state = reactive({ count: 0 })"#,
 }
 
 #[test]
+fn test_reactive_prop_aliased_default_define_props_destructure_preserves_cross_file_flow() {
+    let (mut analyzer, parent_id, child_id) = analyzer_with_parent_child(
+        r#"import { ref } from 'vue'
+import Child from './Child.vue'
+const selected = ref({ id: 1 })"#,
+        r#"const { item: selectedItem = { id: 0 } } = defineProps<{ item?: { id: number } }>()"#,
+        &[("Child", &[("item", "selected")])],
+    );
+
+    let result = analyzer.analyze();
+    assert!(!result.cross_file_reactivity_issues.iter().any(|issue| {
+        issue.file_id == child_id
+            && issue.related_file == Some(parent_id)
+            && matches!(
+                &issue.kind,
+                CrossFileReactivityIssueKind::ReactivityLostInPropChain { prop_name, .. }
+                    if prop_name == "item"
+            )
+    }));
+    assert!(!result.diagnostics.iter().any(|diagnostic| {
+        diagnostic.primary_file == child_id
+            && diagnostic
+                .related_files
+                .iter()
+                .any(|(file_id, _, _)| *file_id == parent_id)
+            && matches!(
+                &diagnostic.kind,
+                CrossFileDiagnosticKind::DestructuringBreaksReactivity { .. }
+            )
+    }));
+}
+
+#[test]
 fn test_reactive_prop_indirect_props_alias_destructure_is_tracked_by_prop_key() {
     let (mut analyzer, parent_id, child_id) = analyzer_with_parent_child(
         r#"import { ref } from 'vue'


### PR DESCRIPTION
## Summary
- preserve default expressions for aliased defineProps destructures such as { source: local = fallback }
- add Croquis parser coverage for aliased defaults, shorthand defaults, and rest bindings
- add Croquis CF regression coverage for aliased-default props destructure preserving parent reactive flow

Closes #1596

## Verification
- cargo test -p vize_croquis test_parse_define_props_destructure_tracks_aliased_defaults
- cargo test -p vize_croquis_cf test_reactive_prop_aliased_default_define_props_destructure_preserves_cross_file_flow
- cargo fmt --check