### PR TITLE
[Next Gen] refactor(atelier): carry directive modifiers on rendu ops

### DIFF
--- a/crates/vize_atelier_core/src/rendu.rs
+++ b/crates/vize_atelier_core/src/rendu.rs
@@ -11,7 +11,7 @@ mod semantic;
 mod walk;
 
 pub use capability::{RenduCapability, VaporSupport};
-pub use model::{RenduElementKind, RenduExprRef, RenduSource, RenduSpan};
+pub use model::{RenduElementKind, RenduExprRef, RenduModifiers, RenduSource, RenduSpan};
 pub use semantic::{RenduBlock, RenduCapabilities, RenduOp, RenduRoot};
 pub use walk::{RenduWalkSummary, summarize_rendu_ops, walk_rendu_ops};
 

--- a/crates/vize_atelier_core/src/rendu/model.rs
+++ b/crates/vize_atelier_core/src/rendu/model.rs
@@ -2,7 +2,7 @@
 //! refs, and element classification. Kept separate from the operation vocabulary
 //! in `semantic.rs` so each file stays focused and under the source-length guard.
 
-use crate::{ElementType, ExpressionNode, Position, SourceLocation};
+use crate::{ElementType, ExpressionNode, Position, SimpleExpressionNode, SourceLocation};
 
 /// Source span carried by Rendu operations.
 ///
@@ -143,3 +143,52 @@ impl From<ElementType> for RenduElementKind {
         }
     }
 }
+
+/// Borrowed directive modifiers (`.stop`, `.prevent`, `.camel`, ...).
+///
+/// Carries a directive's modifier expressions without owning them. Equality is
+/// by modifier *name* (the expression `content`), matching [`RenduExprRef`]'s
+/// by-text equality, so an op holding `RenduModifiers` can still be `Copy + Eq`.
+#[derive(Debug, Clone, Copy)]
+pub struct RenduModifiers<'a> {
+    modifiers: &'a [SimpleExpressionNode<'a>],
+}
+
+impl<'a> RenduModifiers<'a> {
+    pub const fn new(modifiers: &'a [SimpleExpressionNode<'a>]) -> Self {
+        Self { modifiers }
+    }
+
+    /// An empty modifier set, for ops with no directive modifiers.
+    pub const fn empty() -> Self {
+        Self { modifiers: &[] }
+    }
+
+    pub const fn is_empty(self) -> bool {
+        self.modifiers.is_empty()
+    }
+
+    pub const fn len(self) -> usize {
+        self.modifiers.len()
+    }
+
+    /// The modifier names in source order.
+    pub fn names(self) -> impl Iterator<Item = &'a str> {
+        self.modifiers
+            .iter()
+            .map(|modifier| modifier.content.as_str())
+    }
+
+    /// Whether a modifier with the given name is present.
+    pub fn contains(self, name: &str) -> bool {
+        self.names().any(|present| present == name)
+    }
+}
+
+impl PartialEq for RenduModifiers<'_> {
+    fn eq(&self, other: &Self) -> bool {
+        self.len() == other.len() && self.names().zip(other.names()).all(|(a, b)| a == b)
+    }
+}
+
+impl Eq for RenduModifiers<'_> {}

--- a/crates/vize_atelier_core/src/rendu/semantic.rs
+++ b/crates/vize_atelier_core/src/rendu/semantic.rs
@@ -1,6 +1,6 @@
 //! Borrowed render-semantic Rendu vocabulary.
 
-use super::model::{RenduElementKind, RenduExprRef, RenduSource, RenduSpan};
+use super::model::{RenduElementKind, RenduExprRef, RenduModifiers, RenduSource, RenduSpan};
 use crate::{
     AttributeNode, DirectiveNode, PropNode, TemplateChildNode, TextCallContent,
     source_atlas::{SourceAtlasCoordinate, SourceAtlasTarget, SourceAtlasTargetSet},
@@ -22,11 +22,12 @@ pub enum RenduOp<'a> {
         span: RenduSpan,
     },
     /// A directive (`v-bind`/`v-on`/`v-model`/custom) on the nearest preceding
-    /// `Element` op. Modifiers are not yet carried; see #1695 follow-up.
+    /// `Element` op, with its modifiers (`.stop`, `.camel`, ...).
     Directive {
         name: &'a str,
         arg: Option<RenduExprRef<'a>>,
         exp: Option<RenduExprRef<'a>>,
+        modifiers: RenduModifiers<'a>,
         span: RenduSpan,
     },
     Text {
@@ -98,6 +99,7 @@ impl<'a> RenduOp<'a> {
             name: directive.name.as_str(),
             arg: directive.arg.as_ref().map(RenduExprRef::from_expression),
             exp: directive.exp.as_ref().map(RenduExprRef::from_expression),
+            modifiers: RenduModifiers::new(directive.modifiers.as_slice()),
             span: RenduSpan::from_location(&directive.loc),
         }
     }

--- a/crates/vize_atelier_core/src/rendu/walk.rs
+++ b/crates/vize_atelier_core/src/rendu/walk.rs
@@ -269,4 +269,34 @@ mod tests {
         assert_eq!(branches, 2);
         assert_eq!(elements, 2);
     }
+
+    #[test]
+    fn directive_ops_carry_their_modifiers() {
+        let allocator = Allocator::default();
+        let bump = allocator.as_bump();
+        let (root, errors) = parse(bump, "<button @click.stop.prevent=\"onClick\">X</button>");
+        assert!(errors.is_empty());
+
+        let mut modifiers = None;
+        walk_rendu_ops(&root, |op| {
+            if let RenduOp::Directive {
+                name: "on",
+                modifiers: mods,
+                ..
+            } = op
+            {
+                modifiers = Some(mods);
+            }
+        });
+
+        let mods = modifiers.expect("v-on directive op");
+        assert_eq!(mods.len(), 2);
+        assert!(mods.contains("stop"));
+        assert!(mods.contains("prevent"));
+        assert!(!mods.contains("capture"));
+        assert_eq!(
+            mods.names().collect::<std::vec::Vec<_>>(),
+            ["stop", "prevent"]
+        );
+    }
 }


### PR DESCRIPTION
Closes #1757. Continues the Rendu render-plate track from #1634 / #1695.

## What this adds

`RenduOp::Directive` did not carry modifiers (the in-code TODO). This adds them while keeping `RenduOp: Copy + Eq`.

- `RenduModifiers<'a>` — a borrowed `&'a [SimpleExpressionNode]` newtype with **by-name equality** (compares modifier `content`, matching `RenduExprRef`'s by-text equality). Accessors: `names()`, `contains(name)`, `len()`, `is_empty()`. Because the newtype implements `PartialEq`/`Eq`, `RenduOp` keeps its derive (no manual 14-variant `impl`).
- `RenduOp::Directive { ..., modifiers }`, populated by `from_directive` and surfaced through `walk_rendu_ops`.

`SimpleExpressionNode` can't derive `Eq` (it holds OXC `js_ast`/`hoisted`), which is why the by-name newtype is used rather than a raw slice field.

## Verification

- `cargo test -p vize_atelier_core rendu` — 21 passing, incl. `@click.stop.prevent` → `["stop","prevent"]`.
- `cargo clippy -p vize_atelier_core --lib` clean; new code matches canary fmt; files under the 350-line guard.
- Borrowed/allocation-free; no output rerouted.

---

**[Next Gen]** stack for #1634 via `nextgen/1692-plate-families` (#1735).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1771"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->