### PR TITLE
[Next Gen] refactor(infra): model virtual ts as a source atlas projection plate

### DIFF
--- a/crates/vize_atelier_core/src/source_atlas/registry.rs
+++ b/crates/vize_atelier_core/src/source_atlas/registry.rs
@@ -203,6 +203,20 @@ impl SourceAtlasRegistry {
     pub fn is_render_free(self) -> bool {
         !self.requests_render()
     }
+
+    /// Request the Virtual TS projection — a `Projection`-family plate built
+    /// only for typecheck/editor lanes (Canon/Maestro), never for compiler-only
+    /// lanes. Pairs the `VirtualTs` plate with the `VirtualTs` target so the
+    /// request reads as "project Virtual TS", not "emit a render target".
+    pub const fn with_virtual_ts(self) -> Self {
+        self.with_plate(SourceAtlasPlate::VirtualTs)
+            .with_target(SourceAtlasTarget::VirtualTs)
+    }
+
+    /// Whether this lane requested a projection-family plate (e.g. Virtual TS).
+    pub fn requests_projection(self) -> bool {
+        self.touches_family(PlateFamily::Projection)
+    }
 }
 
 #[cfg(test)]
@@ -261,5 +275,35 @@ mod tests {
             SourceAtlasRegistry::language_server().lane,
             SourceAtlasLane::LanguageServer
         );
+    }
+
+    #[test]
+    fn typecheck_lane_requesting_virtual_ts_is_a_render_free_projection() {
+        let typecheck = SourceAtlasRegistry::typecheck()
+            .with_source(SourceAtlasSource::Sfc)
+            .with_plate(SourceAtlasPlate::Croquis)
+            .with_virtual_ts();
+
+        assert!(typecheck.requests_projection());
+        assert!(typecheck.touches_family(PlateFamily::Projection));
+        // A typecheck/editor projection never builds render semantics.
+        assert!(typecheck.is_render_free());
+
+        let route = typecheck.route;
+        assert!(route.targets.contains(SourceAtlasTarget::VirtualTs));
+        assert!(route.plates.contains(SourceAtlasPlate::VirtualTs));
+    }
+
+    #[test]
+    fn a_lane_that_skips_virtual_ts_records_the_skip_fallback() {
+        // A lane that could produce Virtual TS but does not need it records the
+        // skip as an observable fallback rather than a silent gap.
+        let registry = SourceAtlasRegistry::typecheck()
+            .with_source(SourceAtlasSource::Sfc)
+            .with_optional_fallback(Some(SourceAtlasFallback::VirtualTsSkipped));
+
+        assert!(!registry.requests_projection());
+        let fallbacks = registry.fallbacks;
+        assert!(fallbacks.contains(SourceAtlasFallback::VirtualTsSkipped));
     }
 }


### PR DESCRIPTION
Closes #1764. Source Atlas projection track from #1634.

Formalizes Virtual TS as a `PlateFamily::Projection` plate that typecheck/editor lanes request — never built for compiler-only lanes.

- `SourceAtlasRegistry::with_virtual_ts()` — requests the `VirtualTs` plate + target together.
- `SourceAtlasRegistry::requests_projection()` — mirrors `requests_render()`.

Tests prove a typecheck lane requesting Virtual TS is projection-family **and** render-free, and that skipping it records `VirtualTsSkipped`. Atlas vocabulary only — Canon's `VirtualTsGenerator` is untouched (wiring the generator to record through this registry is the deeper follow-up).

`cargo test -p vize_atelier_core source_atlas::registry` (5) + `clippy --lib` clean; file under the 350-line guard.

---
**[Next Gen]** stack for #1634 via `nextgen/1692-plate-families` (#1735).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1772"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->