### PR TITLE
[Next Gen] perf(atelier): add a rendu construction benchmark

### DIFF
--- a/crates/vize_atelier_core/Cargo.toml
+++ b/crates/vize_atelier_core/Cargo.toml
@@ -44,3 +44,8 @@ thiserror = { workspace = true }
 
 [dev-dependencies]
 insta = { workspace = true }
+criterion = { workspace = true }
+
+[[bench]]
+name = "rendu"
+harness = false

--- a/crates/vize_atelier_core/benches/rendu.rs
+++ b/crates/vize_atelier_core/benches/rendu.rs
@@ -1,0 +1,38 @@
+//! Rendu construction benchmarks.
+//!
+//! Guards the #1634 performance rule: walking transformed Relief as Rendu
+//! operations must stay cheap and allocation-free. A regression here (for
+//! example an owned render-tree rebuild on the hot path) should show up in the
+//! PR benchmark budget rather than being discovered after the fact.
+#![allow(deprecated)]
+
+use criterion::{Criterion, black_box, criterion_group, criterion_main};
+
+use vize_atelier_core::rendu::summarize_rendu_ops;
+use vize_atelier_core::{Allocator, TransformOptions, parse, transform};
+
+const FLAT: &str = "<div><span>a</span><span>b</span><span>c</span><p>{{ msg }}</p></div>";
+const NESTED: &str = "<ul><li><a><span><b><i>{{ deep }}</i></b></span></a></li></ul>";
+const CONTROL_FLOW: &str =
+    "<div v-if=\"ok\"><p v-for=\"x in items\">{{ x }}</p></div><p v-else>no</p>";
+
+fn bench_walk(c: &mut Criterion, name: &str, source: &str) {
+    c.bench_function(name, |b| {
+        b.iter(|| {
+            let allocator = Allocator::default();
+            let bump = allocator.as_bump();
+            let (mut root, _errors) = parse(bump, black_box(source));
+            let _ = transform(bump, &mut root, TransformOptions::default(), None);
+            black_box(summarize_rendu_ops(&root))
+        });
+    });
+}
+
+fn benchmark_rendu_walk(c: &mut Criterion) {
+    bench_walk(c, "rendu_walk_flat", FLAT);
+    bench_walk(c, "rendu_walk_nested", NESTED);
+    bench_walk(c, "rendu_walk_control_flow", CONTROL_FLOW);
+}
+
+criterion_group!(benches, benchmark_rendu_walk);
+criterion_main!(benches);


### PR DESCRIPTION
Closes #1767. Performance-guardrail track from #1634 / #1601.

Adds a criterion bench (`benches/rendu.rs`) exercising `summarize_rendu_ops` — parse → transform → Rendu walk — over flat, nested, and control-flow templates. `cargo bench` discovers it via the new `[[bench]]` entry, so the existing PR benchmark budget / criterion gate runs it and a regression (e.g. an owned render-tree rebuild on the hot path) is caught there.

- New dev-dependency `criterion` (workspace) + `[[bench]] name = "rendu"`.
- The bench borrows Relief and builds no persistent IR, matching the demand-shaped Rendu rule.

Verified: `cargo bench --no-run -p vize_atelier_core` builds; a smoke run executes (`rendu_walk_flat`, 145k iterations). Import ordering matches the canary/CI convention (as in `vize_fresco`'s bench: `Criterion, black_box`).

---
**[Next Gen]** stack for #1634 via `nextgen/1692-plate-families` (#1735).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1774"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->