### PR TITLE
[Next Gen] refactor(atelier): add the AtelierOutput finishing plate

### DIFF
--- a/crates/vize_atelier_core/src/atelier_output.rs
+++ b/crates/vize_atelier_core/src/atelier_output.rs
@@ -1,0 +1,157 @@
+//! The `AtelierOutput` finishing plate.
+//!
+//! `AtelierOutput` is the structured output a target Atelier produces *before*
+//! its generated JavaScript becomes a flat string: imports, hoists, render
+//! functions, exports, the section ranges that describe them, an optional
+//! source-map fragment, and any fallback marks observed while emitting. It is
+//! the owned counterpart to the borrowed [`RenduPlate`], and the shared shape
+//! DOM/SSR/Vapor/SFC assembly can grow onto so structure is registered while
+//! emitting instead of recovered by scanning generated code later.
+
+use crate::rendu::{RenduModuleSections, RenduPlate};
+use crate::source_atlas::{SourceAtlasFallback, SourceAtlasFallbackSet, SourceAtlasTarget};
+use vize_carton::String;
+
+/// Structured target output before it is flattened to a single module string.
+#[derive(Debug, Clone, Default, Eq, PartialEq)]
+pub struct AtelierOutput {
+    pub imports: String,
+    pub hoists: String,
+    pub functions: String,
+    pub exports: String,
+    source_map: Option<String>,
+    fallbacks: SourceAtlasFallbackSet,
+}
+
+impl AtelierOutput {
+    /// Build a finishing plate from its module chunks.
+    pub fn new(imports: String, hoists: String, functions: String, exports: String) -> Self {
+        Self {
+            imports,
+            hoists,
+            functions,
+            exports,
+            source_map: None,
+            fallbacks: SourceAtlasFallbackSet::empty(),
+        }
+    }
+
+    /// Attach a source-map fragment for this output.
+    pub fn with_source_map(mut self, source_map: String) -> Self {
+        self.source_map = Some(source_map);
+        self
+    }
+
+    /// Record a fallback observed while emitting this output.
+    pub fn with_fallback(mut self, fallback: SourceAtlasFallback) -> Self {
+        self.fallbacks = self.fallbacks.with(fallback);
+        self
+    }
+
+    /// The source-map fragment, if one was attached.
+    pub fn source_map(&self) -> Option<&str> {
+        self.source_map.as_deref()
+    }
+
+    /// The fallback marks recorded for this output.
+    pub fn fallbacks(&self) -> SourceAtlasFallbackSet {
+        self.fallbacks
+    }
+
+    /// Section ranges describing the chunks once flattened.
+    ///
+    /// Matches [`flatten`](Self::flatten)'s layout, so a consumer can slice the
+    /// flat string by section without rescanning it.
+    pub fn sections(&self) -> RenduModuleSections {
+        RenduModuleSections::from_chunk_lengths(
+            self.imports.len(),
+            self.hoists.len(),
+            self.functions.len(),
+            self.exports.len(),
+        )
+    }
+
+    /// Flatten the chunks into the final module string.
+    ///
+    /// `imports` and `hoists` are adjacent; a single newline separates the
+    /// hoists from the functions and the functions from the exports, matching
+    /// the marks [`RenduModuleSections::from_chunk_lengths`] records.
+    pub fn flatten(&self) -> String {
+        let mut code = String::with_capacity(
+            self.imports.len() + self.hoists.len() + self.functions.len() + self.exports.len() + 2,
+        );
+        code.push_str(&self.imports);
+        code.push_str(&self.hoists);
+        code.push('\n');
+        code.push_str(&self.functions);
+        code.push('\n');
+        code.push_str(&self.exports);
+        code
+    }
+
+    /// A borrowed [`RenduPlate`] view of this output for a target lane.
+    pub fn borrowed_plate(&self, target: SourceAtlasTarget) -> RenduPlate<'_> {
+        RenduPlate::new(
+            target,
+            &self.imports,
+            &self.hoists,
+            &self.functions,
+            &self.exports,
+        )
+        .with_source_map(self.source_map())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample() -> AtelierOutput {
+        AtelierOutput::new(
+            String::from("import { h } from \"vue\"\n"),
+            String::from("const _hoisted_1 = null\n"),
+            String::from("function render() {}"),
+            String::from("export default _sfc_main\n"),
+        )
+    }
+
+    #[test]
+    fn sections_match_the_flattened_layout() {
+        let output = sample();
+        let sections = output.sections();
+        // The exports section ends at the flattened length, so section ranges
+        // slice the flat string without a rescan.
+        assert_eq!(sections.exports.end, output.flatten().len());
+        assert_eq!(sections.imports.start, 0);
+    }
+
+    #[test]
+    fn flatten_keeps_imports_and_hoists_adjacent_with_newline_separators() {
+        let output = sample();
+        let flat = output.flatten();
+        let expected = vize_carton::cstr!(
+            "{}{}\n{}\n{}",
+            "import { h } from \"vue\"\n",
+            "const _hoisted_1 = null\n",
+            "function render() {}",
+            "export default _sfc_main\n"
+        );
+        assert_eq!(flat.as_str(), expected.as_str());
+    }
+
+    #[test]
+    fn carries_source_map_and_fallback_marks() {
+        let output = sample()
+            .with_source_map(String::from("{\"version\":3}"))
+            .with_fallback(SourceAtlasFallback::SourceMapCompositionSkipped);
+
+        assert_eq!(output.source_map(), Some("{\"version\":3}"));
+        let fallbacks = output.fallbacks();
+        assert!(fallbacks.contains(SourceAtlasFallback::SourceMapCompositionSkipped));
+
+        // The borrowed plate exposes the same chunks and map for a target lane.
+        let plate = output.borrowed_plate(SourceAtlasTarget::Ssr);
+        assert_eq!(plate.functions, "function render() {}");
+        assert!(plate.has_source_map());
+    }
+}

--- a/crates/vize_atelier_core/src/lib.rs
+++ b/crates/vize_atelier_core/src/lib.rs
@@ -11,6 +11,8 @@
 //! `vize_atelier_core` provides the foundational infrastructure
 //! that all other Vize compilers build upon.
 
+#[doc(hidden)]
+pub mod atelier_output;
 pub mod codegen;
 #[doc(hidden)]
 pub mod rendu;


### PR DESCRIPTION
Closes #1763. AtelierOutput unification track from #1634 (staged plan item 2).

Introduces `AtelierOutput` in atelier core — the **owned** structured-output finishing plate (imports, hoists, functions, exports, section ranges, optional source-map fragment, fallback marks), the owned counterpart to the borrowed `RenduPlate`.

- `sections()` matches `flatten()`'s layout exactly (imports+hoists adjacent; one newline before functions and before exports — the marks `RenduModuleSections::from_chunk_lengths` records), so a consumer slices the flat string without rescanning it.
- `borrowed_plate(target)` bridges to `RenduPlate`.
- Carries `source_map` and `fallbacks` marks.

## Byte-equivalence

Additive vocabulary only — no DOM/SSR/Vapor/SFC producer is rerouted. Growing those producers (and the SFC-private `OutputModule`) onto this plate is the staged follow-up; output bytes are unchanged here.

`cargo test -p vize_atelier_core atelier_output` (3) + `clippy --lib` clean; file 159 lines, `rustfmt --check` clean.

---
**[Next Gen]** stack for #1634 via `nextgen/1692-plate-families` (#1735).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1775"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->