### PR TITLE
[Next Gen] test(vitrine): guard that internal rendu/atelier plates stay unexposed

### DIFF
--- a/tests/tooling/internal-plates-not-exposed.test.ts
+++ b/tests/tooling/internal-plates-not-exposed.test.ts
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+
+// `Rendu` and `AtelierOutput` are unstable, internal Atelier-stage plates
+// (#1765). They give DOM/SSR/Vapor a shared render-semantic surface, but they
+// are not a public contract — they must not leak through the Vitrine surface
+// (NAPI/WASM bindings and public payload types), or downstream code would pin a
+// shape Vize needs to keep evolving.
+const FORBIDDEN = [/\bRendu[A-Za-z0-9_]*/, /\bAtelierOutput\b/];
+
+// Lines that publicly expose a name: re-exports and public signatures/types.
+const PUBLIC_PREFIXES = ["pub use ", "pub fn ", "pub struct ", "pub enum ", "pub type "];
+
+function rustFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...rustFiles(full));
+    } else if (entry.name.endsWith(".rs")) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+test("vitrine does not expose internal Rendu/AtelierOutput plates", () => {
+  const srcDir = path.join(root, "crates", "vize_vitrine", "src");
+  const offenders: string[] = [];
+
+  for (const file of rustFiles(srcDir)) {
+    const lines = fs.readFileSync(file, "utf8").split("\n");
+    lines.forEach((line, index) => {
+      const trimmed = line.trim();
+      if (!PUBLIC_PREFIXES.some((prefix) => trimmed.startsWith(prefix))) {
+        return;
+      }
+      if (FORBIDDEN.some((pattern) => pattern.test(trimmed))) {
+        offenders.push(`${path.relative(root, file)}:${index + 1}: ${trimmed}`);
+      }
+    });
+  }
+
+  assert.deepEqual(
+    offenders,
+    [],
+    `internal Rendu/AtelierOutput plates leaked through the Vitrine surface:\n${offenders.join("\n")}`,
+  );
+});


### PR DESCRIPTION
Closes #1765. Stable-MIR-boundary track from #1634.

`Rendu` and `AtelierOutput` are unstable internal Atelier-stage plates. This adds a tooling guard so they stay behind the Vitrine boundary and don't leak into the public NAPI/WASM/payload surface (which would pin a shape Vize needs to keep evolving).

- `tests/tooling/internal-plates-not-exposed.test.ts` scans `crates/vize_vitrine/src` and fails if any `pub use`/`pub fn`/`pub struct`/`pub enum`/`pub type` exposes a `Rendu*` or `AtelierOutput` name.
- The boundary already holds: the `rendu`/`source_atlas`/`source_map`/`atelier_output` modules are `#[doc(hidden)]` and Vitrine re-exports only `typecheck` + payload `types`. This guards against regression.

Verified: `node --test tests/tooling/internal-plates-not-exposed.test.ts` passes (no offenders).

---
**[Next Gen]** stack for #1634 via `nextgen/1692-plate-families` (#1735).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1777"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->