### PR TITLE
fix(glyph): stabilize multiline directive attributes

### DIFF
--- a/crates/vize_glyph/src/template/attributes.rs
+++ b/crates/vize_glyph/src/template/attributes.rs
@@ -161,9 +161,10 @@ pub(crate) fn should_use_multiline_attrs(
     depth: usize,
     indent: &[u8],
 ) -> bool {
-    if attrs.iter().zip(rendered).any(|(attr, rendered)| {
-        attr.indent_multiline_value && rendered_attribute_is_multiline(rendered)
-    }) {
+    if rendered
+        .iter()
+        .any(|rendered| rendered_attribute_is_multiline(rendered))
+    {
         return true;
     }
 

--- a/crates/vize_glyph/src/template/directives.rs
+++ b/crates/vize_glyph/src/template/directives.rs
@@ -83,14 +83,67 @@ fn format_directive_value(name: &str, value: &str, options: &FormatOptions) -> (
         return (format_v_for_expression(trimmed), false);
     }
 
+    let decoded = decode_expression_attribute_entities(trimmed);
+    let expression = decoded.as_deref().unwrap_or(trimmed);
+
     // Try to format as JS expression via oxc_formatter
-    match script::format_js_expression(trimmed, options) {
+    match script::format_js_expression(expression, options) {
         Some(formatted) => {
             let indent_multiline_value = formatted.contains('\n');
             (formatted, indent_multiline_value)
         }
         None => (value.to_compact_string(), false),
     }
+}
+
+fn decode_expression_attribute_entities(value: &str) -> Option<std::string::String> {
+    if !value.contains('&') {
+        return None;
+    }
+
+    let mut decoded = std::string::String::with_capacity(value.len());
+    let mut changed = false;
+    let mut rest = value;
+    while !rest.is_empty() {
+        if let Some(tail) = rest.strip_prefix("&quot;") {
+            decoded.push('"');
+            rest = tail;
+            changed = true;
+        } else if let Some(tail) = rest
+            .strip_prefix("&#34;")
+            .or_else(|| rest.strip_prefix("&#x22;"))
+            .or_else(|| rest.strip_prefix("&#X22;"))
+        {
+            decoded.push('"');
+            rest = tail;
+            changed = true;
+        } else if let Some(tail) = rest.strip_prefix("&apos;") {
+            decoded.push('\'');
+            rest = tail;
+            changed = true;
+        } else if let Some(tail) = rest
+            .strip_prefix("&#39;")
+            .or_else(|| rest.strip_prefix("&#x27;"))
+            .or_else(|| rest.strip_prefix("&#X27;"))
+        {
+            decoded.push('\'');
+            rest = tail;
+            changed = true;
+        } else if let Some(tail) = rest.strip_prefix("&amp;") {
+            decoded.push('&');
+            rest = tail;
+            changed = true;
+        } else {
+            let ch = rest
+                .chars()
+                .next()
+                .expect("non-empty string must have a next char");
+            decoded.push(ch);
+            rest = &rest[ch.len_utf8()..];
+        }
+    }
+
+    changed.then_some(decoded)
 }
 
 /// Format `v-for` expression: normalize spacing in `(item, index) in items`.

--- a/crates/vize_glyph/src/template/directives.rs
+++ b/crates/vize_glyph/src/template/directives.rs
@@ -96,12 +96,12 @@ fn format_directive_value(name: &str, value: &str, options: &FormatOptions) -> (
     }
 }
 
-fn decode_expression_attribute_entities(value: &str) -> Option<std::string::String> {
+fn decode_expression_attribute_entities(value: &str) -> Option<String> {
     if !value.contains('&') {
         return None;
     }
 
-    let mut decoded = std::string::String::with_capacity(value.len());
+    let mut decoded = String::with_capacity(value.len());
     let mut changed = false;
     let mut rest = value;
     while !rest.is_empty() {

--- a/crates/vize_glyph/tests/template_directive_attributes.rs
+++ b/crates/vize_glyph/tests/template_directive_attributes.rs
@@ -46,3 +46,28 @@ fn sfc_multiline_directive_attribute_keeps_template_indent() {
     );
     assert_eq!(first.code, second.code);
 }
+
+#[test]
+fn sfc_single_multiline_directive_attribute_is_idempotent() {
+    let source = r#"<template>
+  <label
+    :style="props.reverseOrder
+      ? 'grid-template-areas: \'toggle . label-text\''
+      : 'grid-template-areas: \'label-text . toggle\''"
+  >
+  </label>
+</template>
+"#;
+    let options = FormatOptions::default();
+    let first = format_sfc(source, &options).unwrap();
+    let second = format_sfc(&first.code, &options).unwrap();
+    let third = format_sfc(&second.code, &options).unwrap();
+
+    assert_eq!(first.code, second.code, "fmt; fmt must be a no-op");
+    assert_eq!(second.code, third.code, "fmt must stay at its fixed point");
+    assert!(
+        first.code.contains("\n    :style="),
+        "single multiline attribute should stay on its own line:\n{}",
+        first.code
+    );
+}


### PR DESCRIPTION
## Summary

Fixes #1737.

- Keep any rendered multiline attribute in multiline tag layout, even when it is the only attribute.
- Decode escaped quote entities before formatting directive expressions so repeated formatter passes keep the same continuation indentation.
- Add a regression test for a single multiline `:style` directive attribute.

## Validation

- `cargo test -p vize_glyph --test template_directive_attributes`
- `cargo test -p vize_glyph template`
- `cargo fmt --all --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1780"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->