### PR TITLE
fix(patina): avoid reserved filename component false positives

### DIFF
--- a/crates/vize_patina/src/linter/engine.rs
+++ b/crates/vize_patina/src/linter/engine.rs
@@ -70,6 +70,7 @@ const SEMANTIC_TEMPLATE_RULES: &[&str] = &[
 ];
 
 const SHARED_SFC_DESCRIPTOR_RULES: &[&str] = &[
+    "vue/no-reserved-component-names",
     "vue/no-unused-refs",
     "vue/sfc-element-order",
     "vue/require-scoped-style",

--- a/crates/vize_patina/src/linter/engine.rs
+++ b/crates/vize_patina/src/linter/engine.rs
@@ -68,7 +68,6 @@ const SEMANTIC_TEMPLATE_RULES: &[&str] = &[
     "vue/no-mutating-props",
     "a11y/no-refer-to-non-existent-id",
 ];
-
 const SHARED_SFC_DESCRIPTOR_RULES: &[&str] = &[
     "vue/no-reserved-component-names",
     "vue/no-unused-refs",

--- a/crates/vize_patina/src/rules/vue/no_reserved_component_names.rs
+++ b/crates/vize_patina/src/rules/vue/no_reserved_component_names.rs
@@ -5,32 +5,42 @@
 //! HTML element names, SVG element names, and Vue built-in component names
 //! should not be used as component names.
 //!
-//! This rule checks the **component definition** (filename), NOT the names
+//! This rule checks explicit component-name declarations (`name` option or
+//! `defineOptions({ name })`), NOT names inferred from filenames and NOT names
 //! of other components used in the template. This matches the behavior of
-//! eslint-plugin-vue. Using `<Transition>` or `<KeepAlive>` in a template
-//! is perfectly valid — they are Vue built-in components being used correctly.
+//! eslint-plugin-vue. Using `<Transition>` or `<KeepAlive>` in a template is
+//! perfectly valid — they are Vue built-in components being used correctly.
 //!
 //! ## Examples
 //!
-//! ### Invalid (filename)
-//! ```text
-//! Div.vue
-//! Slot.vue
-//! Transition.vue (shadows Vue built-in)
+//! ### Invalid
+//! ```ts
+//! export default {
+//!   name: 'button'
+//! }
 //! ```
 //!
-//! ### Valid (filename)
-//! ```text
-//! MyComponent.vue
-//! AppHeader.vue
+//! ### Valid
+//! ```vue
+//! <!-- Button.vue -->
+//! <script setup></script>
+//! <template><div /></template>
 //! ```
 
 use crate::context::LintContext;
 use crate::diagnostic::Severity;
+use crate::ir::ByteRange;
 use crate::rule::{Rule, RuleCategory, RuleMeta};
+use crate::rules::script::script_source_type;
+use oxc_allocator::Allocator as OxcAllocator;
+use oxc_ast::ast::{
+    Argument, BindingPattern, CallExpression, ExportDefaultDeclarationKind, Expression,
+    ObjectExpression, ObjectPropertyKind, Program, PropertyKey, Statement, StringLiteral,
+};
+use oxc_parser::Parser;
+use vize_carton::FxHashMap;
 use vize_carton::is_html_tag;
 use vize_croquis::builtins::is_builtin_component;
-use vize_relief::RootNode;
 
 static META: RuleMeta = RuleMeta {
     name: "vue/no-reserved-component-names",
@@ -69,69 +79,264 @@ impl Default for NoReservedComponentNames {
     }
 }
 
-impl NoReservedComponentNames {
-    /// Extract the component name from a filename.
-    fn extract_component_name(filename: &str) -> Option<&str> {
-        let basename = filename.rsplit('/').next().unwrap_or(filename);
-        let basename = basename.rsplit('\\').next().unwrap_or(basename);
-        basename.strip_suffix(".vue")
-    }
-}
-
 impl Rule for NoReservedComponentNames {
     fn meta(&self) -> &'static RuleMeta {
         &META
     }
 
-    fn run_on_template<'a>(&self, ctx: &mut LintContext<'a>, root: &RootNode<'a>) {
-        let filename = ctx.filename;
+    fn run_on_sfc<'a>(&self, ctx: &mut LintContext<'a>) {
+        let findings = {
+            let Some(descriptor) = ctx.sfc_descriptor() else {
+                return;
+            };
+            let mut findings = Vec::new();
 
-        // Only check .vue files
-        let Some(component_name) = Self::extract_component_name(filename) else {
-            return;
+            if let Some(script) = descriptor.script.as_ref() {
+                self.collect_script_block_findings(
+                    script.content.as_ref(),
+                    script.loc.start,
+                    &mut findings,
+                );
+            }
+            if let Some(script_setup) = descriptor.script_setup.as_ref() {
+                self.collect_script_setup_block_findings(
+                    script_setup.content.as_ref(),
+                    script_setup.loc.start,
+                    &mut findings,
+                );
+            }
+
+            findings
         };
 
-        let name_lower = component_name.to_lowercase();
-
-        // Check against reserved names
-        if RESERVED_NAMES.contains(&name_lower.as_str()) {
-            ctx.error_with_help(
+        for finding in findings {
+            ctx.error_at_with_help(
                 ctx.t_fmt(
                     "vue/no-reserved-component-names.message",
-                    &[("name", component_name)],
+                    &[("name", finding.name.as_str())],
                 ),
-                &root.loc,
+                ByteRange {
+                    start: finding.start,
+                    end: finding.end,
+                },
                 ctx.t("vue/no-reserved-component-names.help"),
             );
+        }
+    }
+}
+
+impl NoReservedComponentNames {
+    fn collect_script_block_findings(
+        &self,
+        source: &str,
+        offset: usize,
+        findings: &mut Vec<ComponentNameFinding>,
+    ) {
+        let allocator = OxcAllocator::default();
+        let parsed = Parser::new(&allocator, source, script_source_type()).parse();
+        if parsed.panicked || !parsed.errors.is_empty() {
             return;
         }
 
-        // Check against HTML elements
-        if self.disallow_html && is_html_tag(&name_lower) {
-            ctx.error_with_help(
-                ctx.t_fmt(
-                    "vue/no-reserved-component-names.message",
-                    &[("name", component_name)],
-                ),
-                &root.loc,
-                ctx.t("vue/no-reserved-component-names.help"),
-            );
-            return;
-        }
-
-        // Check against Vue built-ins
-        if self.disallow_vue_builtins
-            && (is_builtin_component(&name_lower) || is_builtin_component(component_name))
+        if let Some(options) = find_component_options(&parsed.program)
+            && let Some(name) = name_string_literal(options)
         {
-            ctx.error_with_help(
-                ctx.t_fmt(
-                    "vue/no-reserved-component-names.message",
-                    &[("name", component_name)],
-                ),
-                &root.loc,
-                ctx.t("vue/no-reserved-component-names.help"),
-            );
+            self.collect_name_finding(name, offset, findings);
         }
+    }
+
+    fn collect_script_setup_block_findings(
+        &self,
+        source: &str,
+        offset: usize,
+        findings: &mut Vec<ComponentNameFinding>,
+    ) {
+        let allocator = OxcAllocator::default();
+        let parsed = Parser::new(&allocator, source, script_source_type()).parse();
+        if parsed.panicked || !parsed.errors.is_empty() {
+            return;
+        }
+
+        if let Some(name) = define_options_name(&parsed.program) {
+            self.collect_name_finding(name, offset, findings);
+        }
+    }
+
+    fn collect_name_finding(
+        &self,
+        name: &StringLiteral<'_>,
+        offset: usize,
+        findings: &mut Vec<ComponentNameFinding>,
+    ) {
+        let value = name.value.as_str();
+        if !self.is_reserved_component_name(value) {
+            return;
+        }
+
+        findings.push(ComponentNameFinding {
+            name: value.to_owned(),
+            start: offset as u32 + name.span.start,
+            end: offset as u32 + name.span.end,
+        });
+    }
+
+    fn is_reserved_component_name(&self, name: &str) -> bool {
+        let name_lower = name.to_lowercase();
+        RESERVED_NAMES.contains(&name_lower.as_str())
+            || (self.disallow_html && is_html_tag(name))
+            || (self.disallow_vue_builtins
+                && (is_builtin_component(&name_lower) || is_builtin_component(name)))
+    }
+}
+
+struct ComponentNameFinding {
+    name: std::string::String,
+    start: u32,
+    end: u32,
+}
+
+fn name_string_literal<'a>(options: &'a ObjectExpression<'a>) -> Option<&'a StringLiteral<'a>> {
+    for property in &options.properties {
+        let ObjectPropertyKind::ObjectProperty(property) = property else {
+            continue;
+        };
+        if property.computed {
+            continue;
+        }
+        if !matches!(property_key_name(&property.key), Some("name")) {
+            continue;
+        }
+        if let Expression::StringLiteral(literal) = &property.value {
+            return Some(literal);
+        }
+    }
+    None
+}
+
+fn define_options_name<'a>(program: &'a Program<'a>) -> Option<&'a StringLiteral<'a>> {
+    for statement in program.body.iter() {
+        let Statement::ExpressionStatement(expression) = statement else {
+            continue;
+        };
+        let Expression::CallExpression(call) = &expression.expression else {
+            continue;
+        };
+        let Expression::Identifier(callee) = &call.callee else {
+            continue;
+        };
+        if !matches!(callee.name.as_str(), "defineOptions") {
+            continue;
+        }
+        if let Some(Argument::ObjectExpression(object)) = call.arguments.first() {
+            return name_string_literal(object);
+        }
+    }
+    None
+}
+
+fn property_key_name<'a>(key: &'a PropertyKey<'a>) -> Option<&'a str> {
+    match key {
+        PropertyKey::StaticIdentifier(id) => Some(id.name.as_str()),
+        PropertyKey::StringLiteral(string) => Some(string.value.as_str()),
+        _ => None,
+    }
+}
+
+fn find_component_options<'a>(program: &'a Program<'a>) -> Option<&'a ObjectExpression<'a>> {
+    let mut bindings: FxHashMap<&'a str, &'a ObjectExpression<'a>> = FxHashMap::default();
+
+    for statement in program.body.iter() {
+        let Statement::VariableDeclaration(declaration) = statement else {
+            continue;
+        };
+        for declarator in &declaration.declarations {
+            let Some(init) = declarator.init.as_ref() else {
+                continue;
+            };
+            if let BindingPattern::BindingIdentifier(id) = &declarator.id
+                && let Some(object) = options_from_expression(init, &bindings)
+            {
+                bindings.insert(id.name.as_str(), object);
+            }
+        }
+    }
+
+    for statement in program.body.iter() {
+        let Statement::ExportDefaultDeclaration(export) = statement else {
+            continue;
+        };
+        if let Some(object) = options_from_export(&export.declaration, &bindings) {
+            return Some(object);
+        }
+    }
+
+    None
+}
+
+fn options_from_export<'a>(
+    declaration: &'a ExportDefaultDeclarationKind<'a>,
+    bindings: &FxHashMap<&'a str, &'a ObjectExpression<'a>>,
+) -> Option<&'a ObjectExpression<'a>> {
+    match declaration {
+        ExportDefaultDeclarationKind::ObjectExpression(object) => Some(object),
+        ExportDefaultDeclarationKind::CallExpression(call) => options_from_call(call, bindings),
+        ExportDefaultDeclarationKind::Identifier(identifier) => {
+            bindings.get(identifier.name.as_str()).copied()
+        }
+        ExportDefaultDeclarationKind::ParenthesizedExpression(paren) => {
+            options_from_expression(&paren.expression, bindings)
+        }
+        ExportDefaultDeclarationKind::TSAsExpression(ts_as) => {
+            options_from_expression(&ts_as.expression, bindings)
+        }
+        ExportDefaultDeclarationKind::TSSatisfiesExpression(ts_satisfies) => {
+            options_from_expression(&ts_satisfies.expression, bindings)
+        }
+        ExportDefaultDeclarationKind::TSNonNullExpression(ts_non_null) => {
+            options_from_expression(&ts_non_null.expression, bindings)
+        }
+        _ => None,
+    }
+}
+
+fn options_from_expression<'a>(
+    expression: &'a Expression<'a>,
+    bindings: &FxHashMap<&'a str, &'a ObjectExpression<'a>>,
+) -> Option<&'a ObjectExpression<'a>> {
+    match expression {
+        Expression::ObjectExpression(object) => Some(object),
+        Expression::CallExpression(call) => options_from_call(call, bindings),
+        Expression::Identifier(identifier) => bindings.get(identifier.name.as_str()).copied(),
+        Expression::ParenthesizedExpression(paren) => {
+            options_from_expression(&paren.expression, bindings)
+        }
+        Expression::TSAsExpression(ts_as) => options_from_expression(&ts_as.expression, bindings),
+        Expression::TSSatisfiesExpression(ts_satisfies) => {
+            options_from_expression(&ts_satisfies.expression, bindings)
+        }
+        Expression::TSNonNullExpression(ts_non_null) => {
+            options_from_expression(&ts_non_null.expression, bindings)
+        }
+        _ => None,
+    }
+}
+
+fn options_from_call<'a>(
+    call: &'a CallExpression<'a>,
+    bindings: &FxHashMap<&'a str, &'a ObjectExpression<'a>>,
+) -> Option<&'a ObjectExpression<'a>> {
+    let Expression::Identifier(callee) = &call.callee else {
+        return None;
+    };
+    if !matches!(callee.name.as_str(), "defineComponent" | "_defineComponent") {
+        return None;
+    }
+    match call.arguments.first()? {
+        Argument::ObjectExpression(object) => Some(object),
+        Argument::Identifier(identifier) => bindings.get(identifier.name.as_str()).copied(),
+        argument => argument
+            .as_expression()
+            .and_then(|expression| options_from_expression(expression, bindings)),
     }
 }
 
@@ -150,21 +355,60 @@ mod tests {
     #[test]
     fn test_valid_custom_component() {
         let linter = create_linter();
-        let result = linter.lint_template(r#"<div>hello</div>"#, "MyComponent.vue");
+        let result = linter.lint_sfc(
+            r#"<script>export default { name: 'MyComponent' }</script><template><div>hello</div></template>"#,
+            "MyComponent.vue",
+        );
         assert_eq!(result.error_count, 0);
     }
 
     #[test]
-    fn test_invalid_html_name() {
+    fn test_pascal_case_html_filename_is_valid_without_explicit_name() {
         let linter = create_linter();
-        let result = linter.lint_template(r#"<div>hello</div>"#, "Div.vue");
+        let result = linter.lint_sfc(
+            r#"<script setup></script><template><div /></template>"#,
+            "Button.vue",
+        );
+        assert_eq!(result.error_count, 0);
+    }
+
+    #[test]
+    fn test_explicit_pascal_case_html_name_is_valid() {
+        let linter = create_linter();
+        let result = linter.lint_sfc(
+            r#"<script>export default { name: 'Button' }</script><template><div /></template>"#,
+            "Button.vue",
+        );
+        assert_eq!(result.error_count, 0);
+    }
+
+    #[test]
+    fn test_invalid_explicit_html_name() {
+        let linter = create_linter();
+        let result = linter.lint_sfc(
+            r#"<script>export default { name: 'button' }</script><template><div>hello</div></template>"#,
+            "Button.vue",
+        );
         assert_eq!(result.error_count, 1);
     }
 
     #[test]
-    fn test_invalid_vue_builtin() {
+    fn test_invalid_define_options_html_name() {
         let linter = create_linter();
-        let result = linter.lint_template(r#"<div>hello</div>"#, "Transition.vue");
+        let result = linter.lint_sfc(
+            r#"<script setup>defineOptions({ name: 'button' })</script><template><div /></template>"#,
+            "Button.vue",
+        );
+        assert_eq!(result.error_count, 1);
+    }
+
+    #[test]
+    fn test_invalid_explicit_vue_builtin() {
+        let linter = create_linter();
+        let result = linter.lint_sfc(
+            r#"<script>export default { name: 'Transition' }</script><template><div>hello</div></template>"#,
+            "Transition.vue",
+        );
         assert_eq!(result.error_count, 1);
     }
 
@@ -172,8 +416,8 @@ mod tests {
     fn test_using_transition_in_template_is_valid() {
         let linter = create_linter();
         // Using <Transition> in a template is CORRECT usage of Vue built-in
-        let result = linter.lint_template(
-            r#"<Transition name="fade"><div>hello</div></Transition>"#,
+        let result = linter.lint_sfc(
+            r#"<script>export default { name: 'MyComponent' }</script><template><Transition name="fade"><div>hello</div></Transition></template>"#,
             "MyComponent.vue",
         );
         assert_eq!(
@@ -185,8 +429,8 @@ mod tests {
     #[test]
     fn test_using_keep_alive_in_template_is_valid() {
         let linter = create_linter();
-        let result = linter.lint_template(
-            r#"<KeepAlive><div>hello</div></KeepAlive>"#,
+        let result = linter.lint_sfc(
+            r#"<script>export default { name: 'MyComponent' }</script><template><KeepAlive><div>hello</div></KeepAlive></template>"#,
             "MyComponent.vue",
         );
         assert_eq!(
@@ -198,8 +442,8 @@ mod tests {
     #[test]
     fn test_using_teleport_in_template_is_valid() {
         let linter = create_linter();
-        let result = linter.lint_template(
-            r#"<Teleport to="body"><div>hello</div></Teleport>"#,
+        let result = linter.lint_sfc(
+            r#"<script>export default { name: 'MyComponent' }</script><template><Teleport to="body"><div>hello</div></Teleport></template>"#,
             "MyComponent.vue",
         );
         assert_eq!(
@@ -211,8 +455,8 @@ mod tests {
     #[test]
     fn test_using_suspense_in_template_is_valid() {
         let linter = create_linter();
-        let result = linter.lint_template(
-            r#"<Suspense><div>hello</div></Suspense>"#,
+        let result = linter.lint_sfc(
+            r#"<script>export default { name: 'MyComponent' }</script><template><Suspense><div>hello</div></Suspense></template>"#,
             "MyComponent.vue",
         );
         assert_eq!(

--- a/crates/vize_patina/src/rules/vue/no_reserved_component_names.rs
+++ b/crates/vize_patina/src/rules/vue/no_reserved_component_names.rs
@@ -38,8 +38,8 @@ use oxc_ast::ast::{
     ObjectExpression, ObjectPropertyKind, Program, PropertyKey, Statement, StringLiteral,
 };
 use oxc_parser::Parser;
-use vize_carton::FxHashMap;
 use vize_carton::is_html_tag;
+use vize_carton::{FxHashMap, String};
 use vize_croquis::builtins::is_builtin_component;
 
 static META: RuleMeta = RuleMeta {
@@ -174,7 +174,7 @@ impl NoReservedComponentNames {
         }
 
         findings.push(ComponentNameFinding {
-            name: value.to_owned(),
+            name: String::from(value),
             start: offset as u32 + name.span.start,
             end: offset as u32 + name.span.end,
         });
@@ -190,7 +190,7 @@ impl NoReservedComponentNames {
 }
 
 struct ComponentNameFinding {
-    name: std::string::String,
+    name: String,
     start: u32,
     end: u32,
 }
@@ -341,134 +341,4 @@ fn options_from_call<'a>(
 }
 
 #[cfg(test)]
-mod tests {
-    use super::NoReservedComponentNames;
-    use crate::linter::Linter;
-    use crate::rule::RuleRegistry;
-
-    fn create_linter() -> Linter {
-        let mut registry = RuleRegistry::new();
-        registry.register(Box::new(NoReservedComponentNames::default()));
-        Linter::with_registry(registry)
-    }
-
-    #[test]
-    fn test_valid_custom_component() {
-        let linter = create_linter();
-        let result = linter.lint_sfc(
-            r#"<script>export default { name: 'MyComponent' }</script><template><div>hello</div></template>"#,
-            "MyComponent.vue",
-        );
-        assert_eq!(result.error_count, 0);
-    }
-
-    #[test]
-    fn test_pascal_case_html_filename_is_valid_without_explicit_name() {
-        let linter = create_linter();
-        let result = linter.lint_sfc(
-            r#"<script setup></script><template><div /></template>"#,
-            "Button.vue",
-        );
-        assert_eq!(result.error_count, 0);
-    }
-
-    #[test]
-    fn test_explicit_pascal_case_html_name_is_valid() {
-        let linter = create_linter();
-        let result = linter.lint_sfc(
-            r#"<script>export default { name: 'Button' }</script><template><div /></template>"#,
-            "Button.vue",
-        );
-        assert_eq!(result.error_count, 0);
-    }
-
-    #[test]
-    fn test_invalid_explicit_html_name() {
-        let linter = create_linter();
-        let result = linter.lint_sfc(
-            r#"<script>export default { name: 'button' }</script><template><div>hello</div></template>"#,
-            "Button.vue",
-        );
-        assert_eq!(result.error_count, 1);
-    }
-
-    #[test]
-    fn test_invalid_define_options_html_name() {
-        let linter = create_linter();
-        let result = linter.lint_sfc(
-            r#"<script setup>defineOptions({ name: 'button' })</script><template><div /></template>"#,
-            "Button.vue",
-        );
-        assert_eq!(result.error_count, 1);
-    }
-
-    #[test]
-    fn test_invalid_explicit_vue_builtin() {
-        let linter = create_linter();
-        let result = linter.lint_sfc(
-            r#"<script>export default { name: 'Transition' }</script><template><div>hello</div></template>"#,
-            "Transition.vue",
-        );
-        assert_eq!(result.error_count, 1);
-    }
-
-    #[test]
-    fn test_using_transition_in_template_is_valid() {
-        let linter = create_linter();
-        // Using <Transition> in a template is CORRECT usage of Vue built-in
-        let result = linter.lint_sfc(
-            r#"<script>export default { name: 'MyComponent' }</script><template><Transition name="fade"><div>hello</div></Transition></template>"#,
-            "MyComponent.vue",
-        );
-        assert_eq!(
-            result.error_count, 0,
-            "Using Vue built-in <Transition> in template should not be flagged"
-        );
-    }
-
-    #[test]
-    fn test_using_keep_alive_in_template_is_valid() {
-        let linter = create_linter();
-        let result = linter.lint_sfc(
-            r#"<script>export default { name: 'MyComponent' }</script><template><KeepAlive><div>hello</div></KeepAlive></template>"#,
-            "MyComponent.vue",
-        );
-        assert_eq!(
-            result.error_count, 0,
-            "Using Vue built-in <KeepAlive> in template should not be flagged"
-        );
-    }
-
-    #[test]
-    fn test_using_teleport_in_template_is_valid() {
-        let linter = create_linter();
-        let result = linter.lint_sfc(
-            r#"<script>export default { name: 'MyComponent' }</script><template><Teleport to="body"><div>hello</div></Teleport></template>"#,
-            "MyComponent.vue",
-        );
-        assert_eq!(
-            result.error_count, 0,
-            "Using Vue built-in <Teleport> in template should not be flagged"
-        );
-    }
-
-    #[test]
-    fn test_using_suspense_in_template_is_valid() {
-        let linter = create_linter();
-        let result = linter.lint_sfc(
-            r#"<script>export default { name: 'MyComponent' }</script><template><Suspense><div>hello</div></Suspense></template>"#,
-            "MyComponent.vue",
-        );
-        assert_eq!(
-            result.error_count, 0,
-            "Using Vue built-in <Suspense> in template should not be flagged"
-        );
-    }
-
-    #[test]
-    fn test_non_vue_file() {
-        let linter = create_linter();
-        let result = linter.lint_template(r#"<div>hello</div>"#, "test.html");
-        assert_eq!(result.error_count, 0);
-    }
-}
+mod tests;

--- a/crates/vize_patina/src/rules/vue/no_reserved_component_names.rs
+++ b/crates/vize_patina/src/rules/vue/no_reserved_component_names.rs
@@ -132,6 +132,17 @@ impl NoReservedComponentNames {
         offset: usize,
         findings: &mut Vec<ComponentNameFinding>,
     ) {
+        // A finding here requires a default-exported component options object
+        // carrying a `name` property. Skip the oxc parse entirely when either
+        // token is absent so the common case (no Options API `name`) stays a
+        // cheap byte scan instead of a full parse per file.
+        let bytes = source.as_bytes();
+        if memchr::memmem::find(bytes, b"export default").is_none()
+            || memchr::memmem::find(bytes, b"name").is_none()
+        {
+            return;
+        }
+
         let allocator = OxcAllocator::default();
         let parsed = Parser::new(&allocator, source, script_source_type()).parse();
         if parsed.panicked || !parsed.errors.is_empty() {
@@ -151,6 +162,13 @@ impl NoReservedComponentNames {
         offset: usize,
         findings: &mut Vec<ComponentNameFinding>,
     ) {
+        // The only `<script setup>` source of an explicit component name is
+        // `defineOptions({ name })`. Without that call there is nothing to
+        // flag, so avoid parsing files that never reference it.
+        if memchr::memmem::find(source.as_bytes(), b"defineOptions").is_none() {
+            return;
+        }
+
         let allocator = OxcAllocator::default();
         let parsed = Parser::new(&allocator, source, script_source_type()).parse();
         if parsed.panicked || !parsed.errors.is_empty() {

--- a/crates/vize_patina/src/rules/vue/no_reserved_component_names.rs
+++ b/crates/vize_patina/src/rules/vue/no_reserved_component_names.rs
@@ -27,19 +27,17 @@
 //! <template><div /></template>
 //! ```
 
+use self::extract::{define_options_name, find_component_options, name_string_literal};
 use crate::context::LintContext;
 use crate::diagnostic::Severity;
 use crate::ir::ByteRange;
 use crate::rule::{Rule, RuleCategory, RuleMeta};
 use crate::rules::script::script_source_type;
 use oxc_allocator::Allocator as OxcAllocator;
-use oxc_ast::ast::{
-    Argument, BindingPattern, CallExpression, ExportDefaultDeclarationKind, Expression,
-    ObjectExpression, ObjectPropertyKind, Program, PropertyKey, Statement, StringLiteral,
-};
+use oxc_ast::ast::StringLiteral;
 use oxc_parser::Parser;
+use vize_carton::String;
 use vize_carton::is_html_tag;
-use vize_carton::{FxHashMap, String};
 use vize_croquis::builtins::is_builtin_component;
 
 static META: RuleMeta = RuleMeta {
@@ -213,150 +211,7 @@ struct ComponentNameFinding {
     end: u32,
 }
 
-fn name_string_literal<'a>(options: &'a ObjectExpression<'a>) -> Option<&'a StringLiteral<'a>> {
-    for property in &options.properties {
-        let ObjectPropertyKind::ObjectProperty(property) = property else {
-            continue;
-        };
-        if property.computed {
-            continue;
-        }
-        if !matches!(property_key_name(&property.key), Some("name")) {
-            continue;
-        }
-        if let Expression::StringLiteral(literal) = &property.value {
-            return Some(literal);
-        }
-    }
-    None
-}
-
-fn define_options_name<'a>(program: &'a Program<'a>) -> Option<&'a StringLiteral<'a>> {
-    for statement in program.body.iter() {
-        let Statement::ExpressionStatement(expression) = statement else {
-            continue;
-        };
-        let Expression::CallExpression(call) = &expression.expression else {
-            continue;
-        };
-        let Expression::Identifier(callee) = &call.callee else {
-            continue;
-        };
-        if !matches!(callee.name.as_str(), "defineOptions") {
-            continue;
-        }
-        if let Some(Argument::ObjectExpression(object)) = call.arguments.first() {
-            return name_string_literal(object);
-        }
-    }
-    None
-}
-
-fn property_key_name<'a>(key: &'a PropertyKey<'a>) -> Option<&'a str> {
-    match key {
-        PropertyKey::StaticIdentifier(id) => Some(id.name.as_str()),
-        PropertyKey::StringLiteral(string) => Some(string.value.as_str()),
-        _ => None,
-    }
-}
-
-fn find_component_options<'a>(program: &'a Program<'a>) -> Option<&'a ObjectExpression<'a>> {
-    let mut bindings: FxHashMap<&'a str, &'a ObjectExpression<'a>> = FxHashMap::default();
-
-    for statement in program.body.iter() {
-        let Statement::VariableDeclaration(declaration) = statement else {
-            continue;
-        };
-        for declarator in &declaration.declarations {
-            let Some(init) = declarator.init.as_ref() else {
-                continue;
-            };
-            if let BindingPattern::BindingIdentifier(id) = &declarator.id
-                && let Some(object) = options_from_expression(init, &bindings)
-            {
-                bindings.insert(id.name.as_str(), object);
-            }
-        }
-    }
-
-    for statement in program.body.iter() {
-        let Statement::ExportDefaultDeclaration(export) = statement else {
-            continue;
-        };
-        if let Some(object) = options_from_export(&export.declaration, &bindings) {
-            return Some(object);
-        }
-    }
-
-    None
-}
-
-fn options_from_export<'a>(
-    declaration: &'a ExportDefaultDeclarationKind<'a>,
-    bindings: &FxHashMap<&'a str, &'a ObjectExpression<'a>>,
-) -> Option<&'a ObjectExpression<'a>> {
-    match declaration {
-        ExportDefaultDeclarationKind::ObjectExpression(object) => Some(object),
-        ExportDefaultDeclarationKind::CallExpression(call) => options_from_call(call, bindings),
-        ExportDefaultDeclarationKind::Identifier(identifier) => {
-            bindings.get(identifier.name.as_str()).copied()
-        }
-        ExportDefaultDeclarationKind::ParenthesizedExpression(paren) => {
-            options_from_expression(&paren.expression, bindings)
-        }
-        ExportDefaultDeclarationKind::TSAsExpression(ts_as) => {
-            options_from_expression(&ts_as.expression, bindings)
-        }
-        ExportDefaultDeclarationKind::TSSatisfiesExpression(ts_satisfies) => {
-            options_from_expression(&ts_satisfies.expression, bindings)
-        }
-        ExportDefaultDeclarationKind::TSNonNullExpression(ts_non_null) => {
-            options_from_expression(&ts_non_null.expression, bindings)
-        }
-        _ => None,
-    }
-}
-
-fn options_from_expression<'a>(
-    expression: &'a Expression<'a>,
-    bindings: &FxHashMap<&'a str, &'a ObjectExpression<'a>>,
-) -> Option<&'a ObjectExpression<'a>> {
-    match expression {
-        Expression::ObjectExpression(object) => Some(object),
-        Expression::CallExpression(call) => options_from_call(call, bindings),
-        Expression::Identifier(identifier) => bindings.get(identifier.name.as_str()).copied(),
-        Expression::ParenthesizedExpression(paren) => {
-            options_from_expression(&paren.expression, bindings)
-        }
-        Expression::TSAsExpression(ts_as) => options_from_expression(&ts_as.expression, bindings),
-        Expression::TSSatisfiesExpression(ts_satisfies) => {
-            options_from_expression(&ts_satisfies.expression, bindings)
-        }
-        Expression::TSNonNullExpression(ts_non_null) => {
-            options_from_expression(&ts_non_null.expression, bindings)
-        }
-        _ => None,
-    }
-}
-
-fn options_from_call<'a>(
-    call: &'a CallExpression<'a>,
-    bindings: &FxHashMap<&'a str, &'a ObjectExpression<'a>>,
-) -> Option<&'a ObjectExpression<'a>> {
-    let Expression::Identifier(callee) = &call.callee else {
-        return None;
-    };
-    if !matches!(callee.name.as_str(), "defineComponent" | "_defineComponent") {
-        return None;
-    }
-    match call.arguments.first()? {
-        Argument::ObjectExpression(object) => Some(object),
-        Argument::Identifier(identifier) => bindings.get(identifier.name.as_str()).copied(),
-        argument => argument
-            .as_expression()
-            .and_then(|expression| options_from_expression(expression, bindings)),
-    }
-}
+mod extract;
 
 #[cfg(test)]
 mod tests;

--- a/crates/vize_patina/src/rules/vue/no_reserved_component_names/extract.rs
+++ b/crates/vize_patina/src/rules/vue/no_reserved_component_names/extract.rs
@@ -1,0 +1,160 @@
+//! AST extraction helpers for `vue/no-reserved-component-names`.
+//!
+//! These walk a parsed `<script>` / `<script setup>` program to find the
+//! explicit component name declared via the Options API `name` field or
+//! `defineOptions({ name })`.
+
+use oxc_ast::ast::{
+    Argument, BindingPattern, CallExpression, ExportDefaultDeclarationKind, Expression,
+    ObjectExpression, ObjectPropertyKind, Program, PropertyKey, Statement, StringLiteral,
+};
+use vize_carton::FxHashMap;
+
+pub(super) fn name_string_literal<'a>(
+    options: &'a ObjectExpression<'a>,
+) -> Option<&'a StringLiteral<'a>> {
+    for property in &options.properties {
+        let ObjectPropertyKind::ObjectProperty(property) = property else {
+            continue;
+        };
+        if property.computed {
+            continue;
+        }
+        if !matches!(property_key_name(&property.key), Some("name")) {
+            continue;
+        }
+        if let Expression::StringLiteral(literal) = &property.value {
+            return Some(literal);
+        }
+    }
+    None
+}
+
+pub(super) fn define_options_name<'a>(program: &'a Program<'a>) -> Option<&'a StringLiteral<'a>> {
+    for statement in program.body.iter() {
+        let Statement::ExpressionStatement(expression) = statement else {
+            continue;
+        };
+        let Expression::CallExpression(call) = &expression.expression else {
+            continue;
+        };
+        let Expression::Identifier(callee) = &call.callee else {
+            continue;
+        };
+        if !matches!(callee.name.as_str(), "defineOptions") {
+            continue;
+        }
+        if let Some(Argument::ObjectExpression(object)) = call.arguments.first() {
+            return name_string_literal(object);
+        }
+    }
+    None
+}
+
+fn property_key_name<'a>(key: &'a PropertyKey<'a>) -> Option<&'a str> {
+    match key {
+        PropertyKey::StaticIdentifier(id) => Some(id.name.as_str()),
+        PropertyKey::StringLiteral(string) => Some(string.value.as_str()),
+        _ => None,
+    }
+}
+
+pub(super) fn find_component_options<'a>(
+    program: &'a Program<'a>,
+) -> Option<&'a ObjectExpression<'a>> {
+    let mut bindings: FxHashMap<&'a str, &'a ObjectExpression<'a>> = FxHashMap::default();
+
+    for statement in program.body.iter() {
+        let Statement::VariableDeclaration(declaration) = statement else {
+            continue;
+        };
+        for declarator in &declaration.declarations {
+            let Some(init) = declarator.init.as_ref() else {
+                continue;
+            };
+            if let BindingPattern::BindingIdentifier(id) = &declarator.id
+                && let Some(object) = options_from_expression(init, &bindings)
+            {
+                bindings.insert(id.name.as_str(), object);
+            }
+        }
+    }
+
+    for statement in program.body.iter() {
+        let Statement::ExportDefaultDeclaration(export) = statement else {
+            continue;
+        };
+        if let Some(object) = options_from_export(&export.declaration, &bindings) {
+            return Some(object);
+        }
+    }
+
+    None
+}
+
+fn options_from_export<'a>(
+    declaration: &'a ExportDefaultDeclarationKind<'a>,
+    bindings: &FxHashMap<&'a str, &'a ObjectExpression<'a>>,
+) -> Option<&'a ObjectExpression<'a>> {
+    match declaration {
+        ExportDefaultDeclarationKind::ObjectExpression(object) => Some(object),
+        ExportDefaultDeclarationKind::CallExpression(call) => options_from_call(call, bindings),
+        ExportDefaultDeclarationKind::Identifier(identifier) => {
+            bindings.get(identifier.name.as_str()).copied()
+        }
+        ExportDefaultDeclarationKind::ParenthesizedExpression(paren) => {
+            options_from_expression(&paren.expression, bindings)
+        }
+        ExportDefaultDeclarationKind::TSAsExpression(ts_as) => {
+            options_from_expression(&ts_as.expression, bindings)
+        }
+        ExportDefaultDeclarationKind::TSSatisfiesExpression(ts_satisfies) => {
+            options_from_expression(&ts_satisfies.expression, bindings)
+        }
+        ExportDefaultDeclarationKind::TSNonNullExpression(ts_non_null) => {
+            options_from_expression(&ts_non_null.expression, bindings)
+        }
+        _ => None,
+    }
+}
+
+fn options_from_expression<'a>(
+    expression: &'a Expression<'a>,
+    bindings: &FxHashMap<&'a str, &'a ObjectExpression<'a>>,
+) -> Option<&'a ObjectExpression<'a>> {
+    match expression {
+        Expression::ObjectExpression(object) => Some(object),
+        Expression::CallExpression(call) => options_from_call(call, bindings),
+        Expression::Identifier(identifier) => bindings.get(identifier.name.as_str()).copied(),
+        Expression::ParenthesizedExpression(paren) => {
+            options_from_expression(&paren.expression, bindings)
+        }
+        Expression::TSAsExpression(ts_as) => options_from_expression(&ts_as.expression, bindings),
+        Expression::TSSatisfiesExpression(ts_satisfies) => {
+            options_from_expression(&ts_satisfies.expression, bindings)
+        }
+        Expression::TSNonNullExpression(ts_non_null) => {
+            options_from_expression(&ts_non_null.expression, bindings)
+        }
+        _ => None,
+    }
+}
+
+fn options_from_call<'a>(
+    call: &'a CallExpression<'a>,
+    bindings: &FxHashMap<&'a str, &'a ObjectExpression<'a>>,
+) -> Option<&'a ObjectExpression<'a>> {
+    let Expression::Identifier(callee) = &call.callee else {
+        return None;
+    };
+    if !matches!(callee.name.as_str(), "defineComponent" | "_defineComponent") {
+        return None;
+    }
+    match call.arguments.first()? {
+        Argument::ObjectExpression(object) => Some(object),
+        Argument::Identifier(identifier) => bindings.get(identifier.name.as_str()).copied(),
+        argument => argument
+            .as_expression()
+            .and_then(|expression| options_from_expression(expression, bindings)),
+    }
+}

--- a/crates/vize_patina/src/rules/vue/no_reserved_component_names/tests.rs
+++ b/crates/vize_patina/src/rules/vue/no_reserved_component_names/tests.rs
@@ -1,0 +1,128 @@
+use super::NoReservedComponentNames;
+use crate::linter::Linter;
+use crate::rule::RuleRegistry;
+
+fn create_linter() -> Linter {
+    let mut registry = RuleRegistry::new();
+    registry.register(Box::new(NoReservedComponentNames::default()));
+    Linter::with_registry(registry)
+}
+
+#[test]
+fn test_valid_custom_component() {
+    let linter = create_linter();
+    let result = linter.lint_sfc(
+        r#"<script>export default { name: 'MyComponent' }</script><template><div>hello</div></template>"#,
+        "MyComponent.vue",
+    );
+    assert_eq!(result.error_count, 0);
+}
+
+#[test]
+fn test_pascal_case_html_filename_is_valid_without_explicit_name() {
+    let linter = create_linter();
+    let result = linter.lint_sfc(
+        r#"<script setup></script><template><div /></template>"#,
+        "Button.vue",
+    );
+    assert_eq!(result.error_count, 0);
+}
+
+#[test]
+fn test_explicit_pascal_case_html_name_is_valid() {
+    let linter = create_linter();
+    let result = linter.lint_sfc(
+        r#"<script>export default { name: 'Button' }</script><template><div /></template>"#,
+        "Button.vue",
+    );
+    assert_eq!(result.error_count, 0);
+}
+
+#[test]
+fn test_invalid_explicit_html_name() {
+    let linter = create_linter();
+    let result = linter.lint_sfc(
+        r#"<script>export default { name: 'button' }</script><template><div>hello</div></template>"#,
+        "Button.vue",
+    );
+    assert_eq!(result.error_count, 1);
+}
+
+#[test]
+fn test_invalid_define_options_html_name() {
+    let linter = create_linter();
+    let result = linter.lint_sfc(
+        r#"<script setup>defineOptions({ name: 'button' })</script><template><div /></template>"#,
+        "Button.vue",
+    );
+    assert_eq!(result.error_count, 1);
+}
+
+#[test]
+fn test_invalid_explicit_vue_builtin() {
+    let linter = create_linter();
+    let result = linter.lint_sfc(
+        r#"<script>export default { name: 'Transition' }</script><template><div>hello</div></template>"#,
+        "Transition.vue",
+    );
+    assert_eq!(result.error_count, 1);
+}
+
+#[test]
+fn test_using_transition_in_template_is_valid() {
+    let linter = create_linter();
+    let result = linter.lint_sfc(
+        r#"<script>export default { name: 'MyComponent' }</script><template><Transition name="fade"><div>hello</div></Transition></template>"#,
+        "MyComponent.vue",
+    );
+    assert_eq!(
+        result.error_count, 0,
+        "Using Vue built-in <Transition> in template should not be flagged"
+    );
+}
+
+#[test]
+fn test_using_keep_alive_in_template_is_valid() {
+    let linter = create_linter();
+    let result = linter.lint_sfc(
+        r#"<script>export default { name: 'MyComponent' }</script><template><KeepAlive><div>hello</div></KeepAlive></template>"#,
+        "MyComponent.vue",
+    );
+    assert_eq!(
+        result.error_count, 0,
+        "Using Vue built-in <KeepAlive> in template should not be flagged"
+    );
+}
+
+#[test]
+fn test_using_teleport_in_template_is_valid() {
+    let linter = create_linter();
+    let result = linter.lint_sfc(
+        r#"<script>export default { name: 'MyComponent' }</script><template><Teleport to="body"><div>hello</div></Teleport></template>"#,
+        "MyComponent.vue",
+    );
+    assert_eq!(
+        result.error_count, 0,
+        "Using Vue built-in <Teleport> in template should not be flagged"
+    );
+}
+
+#[test]
+fn test_using_suspense_in_template_is_valid() {
+    let linter = create_linter();
+    let result = linter.lint_sfc(
+        r#"<script>export default { name: 'MyComponent' }</script><template><Suspense><div>hello</div></Suspense></template>"#,
+        "MyComponent.vue",
+    );
+    assert_eq!(
+        result.error_count, 0,
+        "Using Vue built-in <Suspense> in template should not be flagged"
+    );
+}
+
+#[test]
+fn test_non_vue_file() {
+    let linter = create_linter();
+    let result = linter.lint_template(r#"<div>hello</div>"#, "test.html");
+    assert_eq!(result.error_count, 0);
+}


### PR DESCRIPTION
## Summary

Fixes #1742.

- Stop deriving `vue/no-reserved-component-names` diagnostics from `.vue` filenames.
- Check explicit component names from Options API `name` and `<script setup>` `defineOptions({ name })` instead.
- Keep PascalCase component names like `Button` valid while still flagging explicit lowercase HTML names such as `button`.

## Validation

- `cargo test -p vize_patina no_reserved_component_names`
- `cargo fmt --all --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1781"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->