### PR TITLE
feat(jsx): add SSR output

### DIFF
--- a/crates/vize_atelier_jsx/src/compile.rs
+++ b/crates/vize_atelier_jsx/src/compile.rs
@@ -14,6 +14,7 @@ use vize_croquis::Croquis;
 
 use crate::diagnostics::JsxDiagnostic;
 use crate::scoped::ScopedStyle;
+use crate::ssr::{SsrComponent, compile_lowered_root_to_ssr};
 use crate::vapor::{VaporCompileOptions, VaporComponent, compile_root_to_vapor};
 use crate::vdom::{VdomCompileOptions, VdomComponent, compile_root_to_vdom};
 use crate::{JsxLang, JsxOutputMode, lower_source};
@@ -24,6 +25,12 @@ pub struct JsxCompileConfig {
     /// Default output mode applied to components without an explicit
     /// `"use vue:vapor"` / `"use vue:vdom"` directive.
     pub default_mode: JsxOutputMode,
+    /// Emit server-side render functions instead of client VDOM/Vapor code.
+    ///
+    /// The resolved VDOM/Vapor mode is still recorded on each component as
+    /// client-hydration metadata, but code generation is routed through the
+    /// shared SSR backend.
+    pub ssr: bool,
     /// Options for components compiled to VDOM.
     pub vdom: VdomCompileOptions,
     /// Options for components compiled to Vapor.
@@ -36,6 +43,8 @@ pub enum JsxComponent {
     Vdom(VdomComponent),
     /// Compiled to Vapor output.
     Vapor(VaporComponent),
+    /// Compiled to SSR output.
+    Ssr(SsrComponent),
 }
 
 impl JsxComponent {
@@ -44,14 +53,16 @@ impl JsxComponent {
         match self {
             Self::Vdom(component) => component.component_name.as_deref(),
             Self::Vapor(component) => component.component_name.as_deref(),
+            Self::Ssr(component) => component.component_name.as_deref(),
         }
     }
 
-    /// The backend this component was compiled with.
+    /// The resolved client output mode for this component.
     pub fn mode(&self) -> JsxOutputMode {
         match self {
             Self::Vdom(_) => JsxOutputMode::Vdom,
             Self::Vapor(_) => JsxOutputMode::Vapor,
+            Self::Ssr(component) => component.mode,
         }
     }
 
@@ -60,6 +71,7 @@ impl JsxComponent {
         match self {
             Self::Vdom(component) => component.code.as_str(),
             Self::Vapor(component) => component.code.as_str(),
+            Self::Ssr(component) => component.code.as_str(),
         }
     }
 
@@ -74,6 +86,7 @@ impl JsxComponent {
         match self {
             Self::Vdom(component) => component.preamble.as_str(),
             Self::Vapor(_) => "",
+            Self::Ssr(_) => "",
         }
     }
 
@@ -85,7 +98,7 @@ impl JsxComponent {
     pub fn map(&self) -> Option<&str> {
         match self {
             Self::Vdom(component) => component.map.as_deref(),
-            Self::Vapor(_) => None,
+            Self::Vapor(_) | Self::Ssr(_) => None,
         }
     }
 
@@ -99,6 +112,7 @@ impl JsxComponent {
         match self {
             Self::Vdom(component) => component.scoped_style.as_ref(),
             Self::Vapor(component) => component.scoped_style.as_ref(),
+            Self::Ssr(component) => component.scoped_style.as_ref(),
         }
     }
 }
@@ -126,8 +140,8 @@ impl JsxCompileOutput {
     /// treat JSX/TSX output the same way (#1533). The per-component VDOM
     /// preambles (`import { … } from "vue"`) are merged into one import per
     /// source so concatenating several components never redeclares a helper
-    /// binding; Vapor components inline their own imports into `code` and report
-    /// an empty preamble, so they pass through untouched.
+    /// binding; Vapor and SSR components inline their own imports into `code`
+    /// and report an empty preamble, so they pass through untouched.
     pub fn module_code(&self) -> String {
         let preamble = merge_preambles(self.components.iter().map(JsxComponent::preamble));
 
@@ -288,22 +302,31 @@ pub fn compile_jsx(
 
     let mut components = Vec::with_capacity(lowered.roots.len());
     for lowered_root in lowered.roots {
-        let mode = resolve_mode(lowered_root.mode, config.default_mode);
-        let component = match mode {
-            JsxOutputMode::Vdom => JsxComponent::Vdom(compile_root_to_vdom(
+        let component = if config.ssr {
+            JsxComponent::Ssr(compile_lowered_root_to_ssr(
                 bump,
                 lowered_root,
                 analysis,
-                is_ts,
-                &config.vdom,
-                &mut diagnostics,
-            )),
-            JsxOutputMode::Vapor => JsxComponent::Vapor(compile_root_to_vapor(
-                bump,
-                lowered_root,
-                analysis,
-                &config.vapor,
-            )),
+                config.default_mode,
+            ))
+        } else {
+            let mode = resolve_mode(lowered_root.mode, config.default_mode);
+            match mode {
+                JsxOutputMode::Vdom => JsxComponent::Vdom(compile_root_to_vdom(
+                    bump,
+                    lowered_root,
+                    analysis,
+                    is_ts,
+                    &config.vdom,
+                    &mut diagnostics,
+                )),
+                JsxOutputMode::Vapor => JsxComponent::Vapor(compile_root_to_vapor(
+                    bump,
+                    lowered_root,
+                    analysis,
+                    &config.vapor,
+                )),
+            }
         };
         components.push(component);
     }

--- a/crates/vize_atelier_jsx/src/compile.rs
+++ b/crates/vize_atelier_jsx/src/compile.rs
@@ -9,15 +9,18 @@
 //! routed to the backend its resolved mode selects, so a single file may mix
 //! VDOM and Vapor components.
 
+mod component;
+
 use vize_carton::{Bump, FxHashSet, String};
 use vize_croquis::Croquis;
 
 use crate::diagnostics::JsxDiagnostic;
-use crate::scoped::ScopedStyle;
-use crate::ssr::{SsrComponent, compile_lowered_root_to_ssr};
-use crate::vapor::{VaporCompileOptions, VaporComponent, compile_root_to_vapor};
-use crate::vdom::{VdomCompileOptions, VdomComponent, compile_root_to_vdom};
+use crate::ssr::compile_lowered_root_to_ssr;
+use crate::vapor::{VaporCompileOptions, compile_root_to_vapor};
+use crate::vdom::{VdomCompileOptions, compile_root_to_vdom};
 use crate::{JsxLang, JsxOutputMode, lower_source};
+
+pub use component::JsxComponent;
 
 /// Configuration for mode-aware JSX compilation.
 #[derive(Debug, Clone, Default)]
@@ -35,86 +38,6 @@ pub struct JsxCompileConfig {
     pub vdom: VdomCompileOptions,
     /// Options for components compiled to Vapor.
     pub vapor: VaporCompileOptions,
-}
-
-/// A compiled component, tagged by the backend it was routed to.
-pub enum JsxComponent {
-    /// Compiled to Virtual DOM output.
-    Vdom(VdomComponent),
-    /// Compiled to Vapor output.
-    Vapor(VaporComponent),
-    /// Compiled to SSR output.
-    Ssr(SsrComponent),
-}
-
-impl JsxComponent {
-    /// The enclosing component-function name, if resolved.
-    pub fn component_name(&self) -> Option<&str> {
-        match self {
-            Self::Vdom(component) => component.component_name.as_deref(),
-            Self::Vapor(component) => component.component_name.as_deref(),
-            Self::Ssr(component) => component.component_name.as_deref(),
-        }
-    }
-
-    /// The resolved client output mode for this component.
-    pub fn mode(&self) -> JsxOutputMode {
-        match self {
-            Self::Vdom(_) => JsxOutputMode::Vdom,
-            Self::Vapor(_) => JsxOutputMode::Vapor,
-            Self::Ssr(component) => component.mode,
-        }
-    }
-
-    /// The generated render code.
-    pub fn code(&self) -> &str {
-        match self {
-            Self::Vdom(component) => component.code.as_str(),
-            Self::Vapor(component) => component.code.as_str(),
-            Self::Ssr(component) => component.code.as_str(),
-        }
-    }
-
-    /// The import/preamble section for the component's runtime helpers.
-    ///
-    /// VDOM output keeps its `import { … } from "vue"` preamble structurally
-    /// separate from [`code`](Self::code), so a binding can hoist and dedupe it
-    /// across a module's components. The Vapor backend instead inlines its
-    /// imports into `code` (mirroring the SFC Vapor path), so its preamble is
-    /// empty here.
-    pub fn preamble(&self) -> &str {
-        match self {
-            Self::Vdom(component) => component.preamble.as_str(),
-            Self::Vapor(_) => "",
-            Self::Ssr(_) => "",
-        }
-    }
-
-    /// The v3 source map (JSON) for the component's render code, present only
-    /// when source-map emission was requested via
-    /// [`VdomCompileOptions::source_map`](crate::VdomCompileOptions::source_map)
-    /// (#1533). VDOM output carries it; the Vapor backend does not emit one yet,
-    /// so it is always `None` there.
-    pub fn map(&self) -> Option<&str> {
-        match self {
-            Self::Vdom(component) => component.map.as_deref(),
-            Self::Vapor(_) | Self::Ssr(_) => None,
-        }
-    }
-
-    /// The component's extracted `<style scoped>` block (#1495): the generated
-    /// scope id plus the scoped-rewritten CSS, with the `data-v-<hash>`
-    /// attribute already applied to the selectors. `None` when the component had
-    /// no `<style scoped>`. A bundler integration emits this CSS through the same
-    /// path SFC styles use (#1533); the scope id is already injected into the
-    /// rendered elements.
-    pub fn scoped_style(&self) -> Option<&ScopedStyle> {
-        match self {
-            Self::Vdom(component) => component.scoped_style.as_ref(),
-            Self::Vapor(component) => component.scoped_style.as_ref(),
-            Self::Ssr(component) => component.scoped_style.as_ref(),
-        }
-    }
 }
 
 /// Result of mode-aware JSX/TSX compilation.

--- a/crates/vize_atelier_jsx/src/compile/component.rs
+++ b/crates/vize_atelier_jsx/src/compile/component.rs
@@ -1,0 +1,71 @@
+use crate::JsxOutputMode;
+use crate::scoped::ScopedStyle;
+use crate::ssr::SsrComponent;
+use crate::vapor::VaporComponent;
+use crate::vdom::VdomComponent;
+
+/// A component compiled through the mode-aware JSX pipeline.
+pub enum JsxComponent {
+    /// Compiled to VDOM output.
+    Vdom(VdomComponent),
+    /// Compiled to Vapor output.
+    Vapor(VaporComponent),
+    /// Compiled to SSR output.
+    Ssr(SsrComponent),
+}
+
+impl JsxComponent {
+    /// The component name recovered from the enclosing function, if any.
+    pub fn component_name(&self) -> Option<&str> {
+        match self {
+            Self::Vdom(component) => component.component_name.as_deref(),
+            Self::Vapor(component) => component.component_name.as_deref(),
+            Self::Ssr(component) => component.component_name.as_deref(),
+        }
+    }
+
+    /// The resolved client output mode for this component.
+    pub fn mode(&self) -> JsxOutputMode {
+        match self {
+            Self::Vdom(_) => JsxOutputMode::Vdom,
+            Self::Vapor(_) => JsxOutputMode::Vapor,
+            Self::Ssr(component) => component.mode,
+        }
+    }
+
+    /// Generated render code.
+    pub fn code(&self) -> &str {
+        match self {
+            Self::Vdom(component) => component.code.as_str(),
+            Self::Vapor(component) => component.code.as_str(),
+            Self::Ssr(component) => component.code.as_str(),
+        }
+    }
+
+    /// Runtime-helper preamble to place before [`Self::code`].
+    ///
+    /// Vapor and SSR currently inline their imports into the generated code.
+    pub fn preamble(&self) -> &str {
+        match self {
+            Self::Vdom(component) => component.preamble.as_str(),
+            Self::Vapor(_) | Self::Ssr(_) => "",
+        }
+    }
+
+    /// Optional source map JSON.
+    pub fn map(&self) -> Option<&str> {
+        match self {
+            Self::Vdom(component) => component.map.as_deref(),
+            Self::Vapor(_) | Self::Ssr(_) => None,
+        }
+    }
+
+    /// Optional extracted scoped style metadata for bundlers.
+    pub fn scoped_style(&self) -> Option<&ScopedStyle> {
+        match self {
+            Self::Vdom(component) => component.scoped_style.as_ref(),
+            Self::Vapor(component) => component.scoped_style.as_ref(),
+            Self::Ssr(component) => component.scoped_style.as_ref(),
+        }
+    }
+}

--- a/crates/vize_atelier_jsx/src/lib.rs
+++ b/crates/vize_atelier_jsx/src/lib.rs
@@ -36,6 +36,7 @@ pub mod mode;
 pub mod parse;
 pub mod scoped;
 pub mod span;
+pub mod ssr;
 pub mod vapor;
 pub mod vdom;
 
@@ -57,6 +58,7 @@ pub use mode::JsxOutputMode;
 pub use parse::{ParsedModule, parse_module};
 pub use scoped::ScopedStyle;
 pub use span::SpanMapper;
+pub use ssr::{SsrCompileOptions, SsrComponent, SsrOutput, compile_to_ssr};
 pub use vapor::{VaporCompileOptions, VaporComponent, VaporOutput, compile_to_vapor};
 pub use vdom::{VdomCompileOptions, VdomComponent, VdomOutput, compile_to_vdom};
 

--- a/crates/vize_atelier_jsx/src/ssr.rs
+++ b/crates/vize_atelier_jsx/src/ssr.rs
@@ -1,0 +1,133 @@
+//! Compiling lowered JSX/TSX into Vue SSR render output.
+//!
+//! JSX SSR is backend-neutral: VDOM/Vapor still describe the client renderer
+//! used for hydration, while this module emits server-side `ssrRender` code via
+//! the shared `vize_atelier_ssr` pipeline.
+
+use vize_atelier_core::lane::transform;
+use vize_atelier_core::options::TransformOptions;
+use vize_atelier_ssr::{SsrCodegenContext, SsrCompilerOptions};
+use vize_carton::{Bump, String};
+use vize_croquis::Croquis;
+
+use crate::diagnostics::JsxDiagnostic;
+use crate::scoped::{ScopedStyle, build_scoped_style};
+use crate::{JsxLang, JsxOutputMode, LoweredRoot, lower_source};
+
+/// Options controlling JSX/TSX -> SSR compilation.
+#[derive(Debug, Clone, Default)]
+pub struct SsrCompileOptions {
+    /// Default client output mode metadata for components without an explicit
+    /// `"use vue:vapor"` / `"use vue:vdom"` directive.
+    pub default_mode: JsxOutputMode,
+}
+
+/// One compiled SSR component.
+pub struct SsrComponent {
+    /// Enclosing component-function name, if resolved.
+    pub component_name: Option<String>,
+    /// Resolved client output mode metadata for hydration.
+    pub mode: JsxOutputMode,
+    /// Generated SSR code: imports plus an `ssrRender` function.
+    pub code: String,
+    /// Extracted `<style scoped>` block (#1495): the generated scope id and the
+    /// scoped-rewritten CSS. `None` when the component had no `<style scoped>`.
+    /// The scope id is injected into the SSR output through `SsrCompilerOptions`.
+    pub scoped_style: Option<ScopedStyle>,
+}
+
+/// Result of compiling a JSX/TSX module to SSR.
+pub struct SsrOutput {
+    /// One entry per outermost JSX render root, in source order.
+    pub components: Vec<SsrComponent>,
+    /// Parse, lowering, and transform diagnostics.
+    pub diagnostics: Vec<JsxDiagnostic>,
+}
+
+impl SsrOutput {
+    /// Whether any error-severity diagnostic was produced.
+    pub fn has_errors(&self) -> bool {
+        self.diagnostics.iter().any(JsxDiagnostic::is_error)
+    }
+}
+
+/// Compile a JSX/TSX module into Vue SSR render code.
+pub fn compile_to_ssr(
+    bump: &Bump,
+    source: &str,
+    lang: JsxLang,
+    options: SsrCompileOptions,
+) -> SsrOutput {
+    let lowered = lower_source(bump, source, lang);
+    let diagnostics = lowered.diagnostics;
+
+    let analysis: &Croquis = &*bump.alloc(lowered.analysis);
+
+    let mut components = Vec::with_capacity(lowered.roots.len());
+    for lowered_root in lowered.roots {
+        components.push(compile_lowered_root_to_ssr(
+            bump,
+            lowered_root,
+            analysis,
+            options.default_mode,
+        ));
+    }
+
+    SsrOutput {
+        components,
+        diagnostics,
+    }
+}
+
+/// Compile one lowered JSX root into SSR output.
+///
+/// Identifiers stay bare (no `_ctx.` prefix) because JSX render functions are
+/// closures over their setup scope. The mode stored on the result is metadata
+/// for the corresponding client renderer; SSR codegen itself is shared.
+pub(crate) fn compile_lowered_root_to_ssr(
+    bump: &Bump,
+    lowered: LoweredRoot,
+    analysis: &Croquis,
+    default_mode: JsxOutputMode,
+) -> SsrComponent {
+    let LoweredRoot {
+        mut root,
+        mode,
+        component_name,
+        scoped_css,
+        scoped_style_exprs: _,
+    } = lowered;
+
+    let scoped_style =
+        scoped_css.map(|css| build_scoped_style(component_name.as_deref(), css.as_str()));
+
+    let transform_opts = TransformOptions {
+        prefix_identifiers: false,
+        hoist_static: false,
+        cache_handlers: false,
+        ssr: true,
+        binding_metadata: None,
+        ..Default::default()
+    };
+    transform(bump, &mut root, transform_opts, Some(analysis));
+
+    let ssr_options = SsrCompilerOptions {
+        component_name: component_name.clone(),
+        scope_id: scoped_style.as_ref().map(|style| style.scope_id.clone()),
+        ..SsrCompilerOptions::default()
+    };
+    let generated = SsrCodegenContext::new(bump, &ssr_options).generate(&root);
+
+    let mut code = generated.preamble;
+    if !code.is_empty() && !generated.code.is_empty() {
+        code.push('\n');
+    }
+    code.push_str(&generated.code);
+
+    SsrComponent {
+        component_name,
+        mode: mode.unwrap_or(default_mode),
+        code,
+        scoped_style,
+    }
+}

--- a/crates/vize_atelier_jsx/src/vapor.rs
+++ b/crates/vize_atelier_jsx/src/vapor.rs
@@ -14,7 +14,6 @@
 
 use vize_atelier_core::lane::transform;
 use vize_atelier_core::options::TransformOptions;
-use vize_atelier_ssr::{SsrCodegenContext, SsrCompilerOptions};
 use vize_atelier_vapor::{VaporGenerateOptions, generate_vapor_with_options, transform_to_ir};
 use vize_carton::{Bump, String};
 use vize_croquis::Croquis;
@@ -29,8 +28,7 @@ pub struct VaporCompileOptions {
     /// Compile in SSR mode. When set, the component is server-rendered: instead
     /// of the client Vapor IR lowering, the lowered template is run through
     /// `vize_atelier_ssr`'s `ssrRender` codegen and [`VaporComponent::code`]
-    /// holds an HTML-string render function (first cut, #1533 — see
-    /// [`compile_root_to_vapor_ssr`]).
+    /// holds an HTML-string render function.
     pub ssr: bool,
 }
 
@@ -103,6 +101,18 @@ pub(crate) fn compile_root_to_vapor(
     analysis: &Croquis,
     options: &VaporCompileOptions,
 ) -> VaporComponent {
+    if options.ssr {
+        let ssr =
+            crate::ssr::compile_lowered_root_to_ssr(bump, lowered, analysis, JsxOutputMode::Vapor);
+        return VaporComponent {
+            component_name: ssr.component_name,
+            mode: ssr.mode,
+            code: ssr.code,
+            templates: Vec::new(),
+            scoped_style: ssr.scoped_style,
+        };
+    }
+
     let LoweredRoot {
         mut root,
         mode,
@@ -120,16 +130,6 @@ pub(crate) fn compile_root_to_vapor(
     // `data-v-<hash>` attribute is injected into those strings post-generation.
     let scoped_style =
         scoped_css.map(|css| build_scoped_style(component_name.as_deref(), css.as_str()));
-
-    // SSR (#1533, first cut): when SSR is requested, the lowered root is the same
-    // `vize_relief` `RootNode` the SSR crate consumes, so we run the SSR-flavored
-    // core transform and `vize_atelier_ssr`'s `ssrRender` codegen instead of the
-    // client Vapor IR lowering. This produces an HTML-string render function
-    // (`_push(`…`)`) covering static elements, static/dynamic attributes, and
-    // text interpolation. See `compile_root_to_vapor_ssr` for the deferred scope.
-    if options.ssr {
-        return compile_root_to_vapor_ssr(bump, root, analysis, mode, component_name, scoped_style);
-    }
 
     let transform_opts = TransformOptions {
         // JSX render fns close over the setup scope; don't prefix `_ctx.`.
@@ -158,77 +158,6 @@ pub(crate) fn compile_root_to_vapor(
         mode: mode.unwrap_or(JsxOutputMode::Vapor),
         code,
         templates,
-        scoped_style,
-    }
-}
-
-/// First-cut JSX/TSX -> Vapor **SSR** render codegen (#1533).
-///
-/// Reuses [`vize_atelier_ssr`] end to end: the lowered [`RootNode`] is run
-/// through the SSR-flavored core transform (the same options
-/// `vize_atelier_ssr::compile_ssr` uses) and then `SsrCodegenContext`, which
-/// emits an `ssrRender(_ctx, _push, _parent, _attrs)` function that server-
-/// renders the component to an HTML string via `_push(`…`)`.
-///
-/// Identifiers stay **bare** (no `_ctx.` prefix) to match the JSX closure model
-/// the client Vapor path documents: a JSX component is a plain function whose
-/// render — client or server — closes over the setup scope. The generated
-/// `code` is the SSR preamble (`@vue/server-renderer` / `vue` imports) followed
-/// by the render function, mirroring the shape of the client Vapor `code`.
-///
-/// Implemented subset: static elements, static + dynamic (`v-bind`) attributes,
-/// dynamic class/style, and text interpolation. Control flow (`v-if`/`v-for`),
-/// slots, nested components, and `renderToString` runtime wiring flow through
-/// the shared SSR codegen too but are **not** part of this first cut's tested
-/// contract — see the PR's "Deferred" section.
-fn compile_root_to_vapor_ssr<'a>(
-    bump: &'a Bump,
-    mut root: vize_atelier_core::RootNode<'a>,
-    analysis: &'a Croquis,
-    mode: Option<JsxOutputMode>,
-    component_name: Option<String>,
-    scoped_style: Option<ScopedStyle>,
-) -> VaporComponent {
-    let transform_opts = TransformOptions {
-        // JSX render fns close over the setup scope; keep identifiers bare so the
-        // SSR render function references the closure's bindings directly (no
-        // `_ctx.` prefix), consistent with the client Vapor path above.
-        prefix_identifiers: false,
-        // SSR transforms disable DOM-only optimizations (hoisting, handler
-        // caching) and desugar directives for string output instead of vnodes.
-        hoist_static: false,
-        cache_handlers: false,
-        ssr: true,
-        binding_metadata: None,
-        ..Default::default()
-    };
-    transform(bump, &mut root, transform_opts, Some(analysis));
-
-    // The scope id is already embedded in the SSR options so `ssrRender` emits
-    // the `data-v-<hash>` attribute inline, matching the SFC SSR scope path
-    // (no post-generation string injection needed, unlike the client templates).
-    let ssr_options = SsrCompilerOptions {
-        component_name: component_name.clone(),
-        scope_id: scoped_style.as_ref().map(|style| style.scope_id.clone()),
-        ..SsrCompilerOptions::default()
-    };
-    let generated = SsrCodegenContext::new(bump, &ssr_options).generate(&root);
-
-    // Combine preamble (imports) + render function into a single module, mirroring
-    // the client Vapor `code` field which also inlines its imports.
-    let mut code = generated.preamble;
-    if !code.is_empty() && !generated.code.is_empty() {
-        code.push('\n');
-    }
-    code.push_str(&generated.code);
-
-    VaporComponent {
-        component_name,
-        mode: mode.unwrap_or(JsxOutputMode::Vapor),
-        code,
-        // SSR output is a single HTML-string render function; the client-only
-        // static `_template("…")` strings do not apply.
-        templates: Vec::new(),
         scoped_style,
     }
 }

--- a/crates/vize_atelier_jsx/tests/adversarial_snapshots.rs
+++ b/crates/vize_atelier_jsx/tests/adversarial_snapshots.rs
@@ -626,6 +626,17 @@ fn compile_output_summary<'a>(
                         .as_ref()
                         .map(ScopedStyleSummary::from),
                 },
+                JsxComponent::Ssr(component) => RenderComponentSummary {
+                    name: component.component_name.as_ref().map(|name| name.as_str()),
+                    mode: "Ssr".to_string(),
+                    preamble: None,
+                    code: component.code.as_str(),
+                    templates: Vec::new(),
+                    scoped_style: component
+                        .scoped_style
+                        .as_ref()
+                        .map(ScopedStyleSummary::from),
+                },
             })
             .collect(),
     }

--- a/crates/vize_atelier_jsx/tests/adversarial_snapshots.rs
+++ b/crates/vize_atelier_jsx/tests/adversarial_snapshots.rs
@@ -599,44 +599,29 @@ fn compile_output_summary<'a>(
         components: output
             .components
             .iter()
-            .map(|component| match component {
-                JsxComponent::Vdom(component) => RenderComponentSummary {
-                    name: component.component_name.as_ref().map(|name| name.as_str()),
-                    mode: "Vdom".to_string(),
-                    preamble: Some(component.preamble.as_str()),
-                    code: component.code.as_str(),
-                    templates: Vec::new(),
-                    scoped_style: component
-                        .scoped_style
-                        .as_ref()
-                        .map(ScopedStyleSummary::from),
-                },
-                JsxComponent::Vapor(component) => RenderComponentSummary {
-                    name: component.component_name.as_ref().map(|name| name.as_str()),
-                    mode: "Vapor".to_string(),
-                    preamble: None,
-                    code: component.code.as_str(),
-                    templates: component
+            .map(|component| {
+                let templates = match component {
+                    JsxComponent::Vapor(component) => component
                         .templates
                         .iter()
                         .map(|template| template.as_str())
                         .collect(),
-                    scoped_style: component
-                        .scoped_style
-                        .as_ref()
-                        .map(ScopedStyleSummary::from),
-                },
-                JsxComponent::Ssr(component) => RenderComponentSummary {
-                    name: component.component_name.as_ref().map(|name| name.as_str()),
-                    mode: "Ssr".to_string(),
-                    preamble: None,
-                    code: component.code.as_str(),
-                    templates: Vec::new(),
-                    scoped_style: component
-                        .scoped_style
-                        .as_ref()
-                        .map(ScopedStyleSummary::from),
-                },
+                    JsxComponent::Vdom(_) | JsxComponent::Ssr(_) => Vec::new(),
+                };
+                let mode = match component {
+                    JsxComponent::Vdom(_) => "Vdom",
+                    JsxComponent::Vapor(_) => "Vapor",
+                    JsxComponent::Ssr(_) => "Ssr",
+                };
+                RenderComponentSummary {
+                    name: component.component_name(),
+                    mode: mode.to_string(),
+                    preamble: matches!(component, JsxComponent::Vdom(_))
+                        .then(|| component.preamble()),
+                    code: component.code(),
+                    templates,
+                    scoped_style: component.scoped_style().map(ScopedStyleSummary::from),
+                }
             })
             .collect(),
     }

--- a/crates/vize_atelier_jsx/tests/compile.rs
+++ b/crates/vize_atelier_jsx/tests/compile.rs
@@ -34,6 +34,7 @@ fn component_variant(component: &JsxComponent) -> &'static str {
     match component {
         JsxComponent::Vdom(_) => "vdom",
         JsxComponent::Vapor(_) => "vapor",
+        JsxComponent::Ssr(_) => "ssr",
     }
 }
 
@@ -103,6 +104,22 @@ fn one_module_can_mix_vdom_and_vapor_components() {
     let out = compile(src, &JsxCompileConfig::default());
 
     assert_eq!(out.components.len(), 2);
+    insta::assert_snapshot!(component_matrix(&out));
+}
+
+#[test]
+fn ssr_config_routes_components_to_ssr_and_preserves_client_mode_metadata() {
+    let config = JsxCompileConfig {
+        ssr: true,
+        ..Default::default()
+    };
+    let src = "const A = () => <a>{msg}</a>;\n\
+               const B = () => { \"use vue:vapor\"; return <b/>; };";
+    let out = compile(src, &config);
+
+    assert_eq!(out.components.len(), 2);
+    assert_eq!(out.components[0].mode(), JsxOutputMode::Vdom);
+    assert_eq!(out.components[1].mode(), JsxOutputMode::Vapor);
     insta::assert_snapshot!(component_matrix(&out));
 }
 

--- a/crates/vize_atelier_jsx/tests/snapshots/compile__ssr_config_routes_components_to_ssr_and_preserves_client_mode_metadata.snap
+++ b/crates/vize_atelier_jsx/tests/snapshots/compile__ssr_config_routes_components_to_ssr_and_preserves_client_mode_metadata.snap
@@ -1,0 +1,26 @@
+---
+source: crates/vize_atelier_jsx/tests/compile.rs
+expression: component_matrix(&out)
+---
+## component 0
+name: Some("A")
+mode: Vdom
+variant: ssr
+code:
+import { ssrInterpolate as _ssrInterpolate, ssrRenderAttrs as _ssrRenderAttrs } from "@vue/server-renderer"
+
+function ssrRender(_ctx, _push, _parent, _attrs) {
+  _push(`<a${_ssrRenderAttrs(_attrs)}>${_ssrInterpolate(msg)}</a>`)
+}
+
+
+## component 1
+name: Some("B")
+mode: Vapor
+variant: ssr
+code:
+import { ssrRenderAttrs as _ssrRenderAttrs } from "@vue/server-renderer"
+
+function ssrRender(_ctx, _push, _parent, _attrs) {
+  _push(`<b${_ssrRenderAttrs(_attrs)}></b>`)
+}

--- a/crates/vize_atelier_jsx/tests/snapshots/ssr__ssr_codegen_matrix.snap
+++ b/crates/vize_atelier_jsx/tests/snapshots/ssr__ssr_codegen_matrix.snap
@@ -1,0 +1,81 @@
+---
+source: crates/vize_atelier_jsx/tests/ssr.rs
+expression: "snapshot_cases(&cases, |source| { ssr_code(source, JsxLang::Jsx) })"
+---
+## element
+### source
+const A = () => <div/>;
+### output
+import { ssrRenderAttrs as _ssrRenderAttrs } from "@vue/server-renderer"
+
+function ssrRender(_ctx, _push, _parent, _attrs) {
+  _push(`<div${_ssrRenderAttrs(_attrs)}></div>`)
+}
+
+
+## text
+### source
+const A = () => <p>hello</p>;
+### output
+import { ssrRenderAttrs as _ssrRenderAttrs } from "@vue/server-renderer"
+
+function ssrRender(_ctx, _push, _parent, _attrs) {
+  _push(`<p${_ssrRenderAttrs(_attrs)}>hello</p>`)
+}
+
+
+## interpolation
+### source
+const A = () => <div>{msg}</div>;
+### output
+import { ssrInterpolate as _ssrInterpolate, ssrRenderAttrs as _ssrRenderAttrs } from "@vue/server-renderer"
+
+function ssrRender(_ctx, _push, _parent, _attrs) {
+  _push(`<div${_ssrRenderAttrs(_attrs)}>${_ssrInterpolate(msg)}</div>`)
+}
+
+
+## dynamic attr
+### source
+const A = () => <div id={id}>{msg}</div>;
+### output
+import { ssrInterpolate as _ssrInterpolate, ssrRenderAttrs as _ssrRenderAttrs } from "@vue/server-renderer"
+import { mergeProps as _mergeProps } from "vue"
+
+function ssrRender(_ctx, _push, _parent, _attrs) {
+  _push(`<div${_ssrRenderAttrs(_mergeProps({ id: id }, _attrs))}>${_ssrInterpolate(msg)}</div>`)
+}
+
+
+## control flow
+### source
+const A = () => <div>{ok ? <span>yes</span> : <em>no</em>}</div>;
+### output
+import { ssrRenderAttrs as _ssrRenderAttrs } from "@vue/server-renderer"
+
+function ssrRender(_ctx, _push, _parent, _attrs) {
+  _push(`<div${_ssrRenderAttrs(_attrs)}>`)
+  if (ok) {
+    _push(`<span>yes</span>`)
+  } else {
+    _push(`<em>no</em>`)
+  }
+  _push(`</div>`)
+}
+
+
+## list
+### source
+const A = () => <ul>{items.map((item) => <li>{item}</li>)}</ul>;
+### output
+import { ssrInterpolate as _ssrInterpolate, ssrRenderAttrs as _ssrRenderAttrs, ssrRenderList as _ssrRenderList } from "@vue/server-renderer"
+
+function ssrRender(_ctx, _push, _parent, _attrs) {
+  _push(`<ul${_ssrRenderAttrs(_attrs)}>`)
+  _push(`<!--[-->`)
+  _ssrRenderList(items, (item) => {
+    _push(`<li>${_ssrInterpolate(item)}</li>`)
+  })
+  _push(`<!--]-->`)
+  _push(`</ul>`)
+}

--- a/crates/vize_atelier_jsx/tests/snapshots/ssr__ssr_tsx_codegen_snapshot.snap
+++ b/crates/vize_atelier_jsx/tests/snapshots/ssr__ssr_tsx_codegen_snapshot.snap
@@ -1,0 +1,15 @@
+---
+source: crates/vize_atelier_jsx/tests/ssr.rs
+expression: "snapshot_lang_cases(&cases, ssr_code)"
+---
+## tsx ssr
+### lang
+Tsx
+### source
+const A = (): JSX.Element => <span>{label}</span>;
+### output
+import { ssrInterpolate as _ssrInterpolate, ssrRenderAttrs as _ssrRenderAttrs } from "@vue/server-renderer"
+
+function ssrRender(_ctx, _push, _parent, _attrs) {
+  _push(`<span${_ssrRenderAttrs(_attrs)}>${_ssrInterpolate(label)}</span>`)
+}

--- a/crates/vize_atelier_jsx/tests/ssr.rs
+++ b/crates/vize_atelier_jsx/tests/ssr.rs
@@ -1,0 +1,66 @@
+//! JSX/TSX -> Vue SSR compilation (#1580).
+
+mod common;
+
+use common::{snapshot_cases, snapshot_lang_cases};
+use vize_atelier_jsx::{JsxLang, JsxOutputMode, SsrCompileOptions, compile_to_ssr};
+use vize_carton::Bump;
+
+fn ssr_code(source: &str, lang: JsxLang) -> vize_carton::String {
+    let bump = Bump::new();
+    let out = compile_to_ssr(&bump, source, lang, SsrCompileOptions::default());
+    assert!(
+        !out.has_errors(),
+        "unexpected diagnostics: {:?}",
+        out.diagnostics
+    );
+    assert_eq!(out.components.len(), 1, "expected exactly one component");
+    out.components.into_iter().next().unwrap().code
+}
+
+#[test]
+fn ssr_codegen_matrix() {
+    let cases = [
+        ("element", "const A = () => <div/>;"),
+        ("text", "const A = () => <p>hello</p>;"),
+        ("interpolation", "const A = () => <div>{msg}</div>;"),
+        ("dynamic attr", "const A = () => <div id={id}>{msg}</div>;"),
+        (
+            "control flow",
+            "const A = () => <div>{ok ? <span>yes</span> : <em>no</em>}</div>;",
+        ),
+        (
+            "list",
+            "const A = () => <ul>{items.map((item) => <li>{item}</li>)}</ul>;",
+        ),
+    ];
+
+    insta::assert_snapshot!(snapshot_cases(&cases, |source| {
+        ssr_code(source, JsxLang::Jsx)
+    }));
+}
+
+#[test]
+fn ssr_tsx_codegen_snapshot() {
+    let cases = [(
+        "tsx ssr",
+        JsxLang::Tsx,
+        "const A = (): JSX.Element => <span>{label}</span>;",
+    )];
+
+    insta::assert_snapshot!(snapshot_lang_cases(&cases, ssr_code));
+}
+
+#[test]
+fn ssr_preserves_component_metadata_and_client_mode() {
+    let bump = Bump::new();
+    let out = compile_to_ssr(
+        &bump,
+        "const Fast = () => { \"use vue:vapor\"; return <div/>; };",
+        JsxLang::Jsx,
+        SsrCompileOptions::default(),
+    );
+
+    assert_eq!(out.components[0].component_name.as_deref(), Some("Fast"));
+    assert_eq!(out.components[0].mode, JsxOutputMode::Vapor);
+}

--- a/crates/vize_vitrine/src/napi/jsx.rs
+++ b/crates/vize_vitrine/src/napi/jsx.rs
@@ -9,6 +9,8 @@
 //! Mode selection follows the project's `compiler.jsxMode` config: the explicit
 //! `jsxMode` string (`"vdom"` / `"vapor"`) wins when present; otherwise the
 //! legacy `vapor` bool applies for back-compat; otherwise the default is VDOM.
+//! When `ssr` is true, that mode is kept as client-hydration metadata while
+//! generated code is routed through JSX SSR output.
 //!
 //! FFI boundary code: uses std types for JavaScript interop.
 #![allow(
@@ -42,6 +44,8 @@ pub struct JsxCompileOptionsNapi {
     /// result's `map` carries the map JSON; when `false` (default), `map` is
     /// `null` and no mapping work is done (#1533).
     pub source_map: Option<bool>,
+    /// Emit SSR render code instead of client render code.
+    pub ssr: Option<bool>,
 }
 
 /// A JSX component's extracted `<style scoped>` block, surfaced to the bundler
@@ -131,9 +135,9 @@ fn compile_jsx_impl(
         default_mode,
         ..Default::default()
     };
-    // Surface a v3 source map when requested. The flag only affects the VDOM
-    // codegen path (the Vapor backend does not emit a map yet); enabling it is a
-    // no-op for Vapor output.
+    config.ssr = opts.ssr.unwrap_or(false);
+    // Surface a v3 source map when requested. The flag only affects client VDOM
+    // codegen; enabling it is a no-op for Vapor and SSR output.
     config.vdom.source_map = opts.source_map.unwrap_or(false);
 
     let bump = Bump::new();
@@ -295,5 +299,30 @@ mod tests {
         assert!(with.errors.is_empty(), "errors: {:?}", with.errors);
         let map = with.map.expect("a map is surfaced when requested");
         assert!(map.contains("\"version\":3"), "v3 source map: {map}");
+    }
+
+    #[test]
+    fn jsx_compile_result_supports_ssr_output() {
+        let result = compile_jsx_impl(
+            "const App = () => <div>{message}</div>;".to_string(),
+            Some(JsxCompileOptionsNapi {
+                ssr: Some(true),
+                source_map: Some(true),
+                ..Default::default()
+            }),
+        );
+
+        assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+        assert!(
+            result.code.contains("function ssrRender"),
+            "{}",
+            result.code
+        );
+        assert!(
+            result.code.contains("@vue/server-renderer"),
+            "{}",
+            result.code
+        );
+        assert!(result.map.is_none(), "SSR output has no source map yet");
     }
 }

--- a/crates/vize_vitrine/src/wasm/jsx.rs
+++ b/crates/vize_vitrine/src/wasm/jsx.rs
@@ -9,7 +9,9 @@
 //!
 //! Mode selection mirrors the NAPI binding and the `compiler.jsxMode` config:
 //! the explicit `jsxMode` string (`"vdom"` / `"vapor"`) wins, then the legacy
-//! `vapor` bool, then VDOM.
+//! `vapor` bool, then VDOM. When `ssr` is true, that mode is kept as
+//! client-hydration metadata while generated code is routed through JSX SSR
+//! output.
 
 use serde::Serialize;
 use wasm_bindgen::prelude::*;
@@ -107,11 +109,19 @@ fn resolve_source_map(options: &JsValue) -> bool {
         .unwrap_or(false)
 }
 
+fn resolve_ssr(options: &JsValue) -> bool {
+    js_sys::Reflect::get(options, &JsValue::from_str("ssr"))
+        .ok()
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false)
+}
+
 fn compile_jsx_internal(source: &str, options: &JsValue) -> JsxWasmResult {
     let lang = resolve_lang(options);
     let default_mode = resolve_default_mode(options);
     let source_map = resolve_source_map(options);
-    build_jsx_wasm_result(source, lang, default_mode, source_map)
+    let ssr = resolve_ssr(options);
+    build_jsx_wasm_result(source, lang, default_mode, source_map, ssr)
 }
 
 /// Build the JSX compile result from already-resolved options. Kept free of
@@ -122,12 +132,14 @@ fn build_jsx_wasm_result(
     lang: JsxLang,
     default_mode: JsxOutputMode,
     source_map: bool,
+    ssr: bool,
 ) -> JsxWasmResult {
     let mut config = JsxCompileConfig {
         default_mode,
         ..Default::default()
     };
-    // Source maps are emitted by the VDOM codegen path; a no-op for Vapor.
+    config.ssr = ssr;
+    // Source maps are emitted by client VDOM codegen; a no-op for Vapor/SSR.
     config.vdom.source_map = source_map;
 
     let bump = Bump::new();
@@ -189,7 +201,7 @@ mod tests {
                 </div>
             );
         "#;
-        let result = build_jsx_wasm_result(source, JsxLang::Jsx, JsxOutputMode::Vdom, false);
+        let result = build_jsx_wasm_result(source, JsxLang::Jsx, JsxOutputMode::Vdom, false, false);
 
         assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
         assert_eq!(
@@ -217,6 +229,7 @@ mod tests {
             JsxLang::Jsx,
             JsxOutputMode::Vdom,
             false,
+            false,
         );
         assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
         assert!(
@@ -235,6 +248,7 @@ mod tests {
             JsxLang::Jsx,
             JsxOutputMode::Vdom,
             false,
+            false,
         );
         assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
         assert!(
@@ -248,12 +262,37 @@ mod tests {
     fn wasm_jsx_result_surfaces_source_map_when_requested() {
         let source = "const App = () => <div>{message}</div>;";
 
-        let without = build_jsx_wasm_result(source, JsxLang::Jsx, JsxOutputMode::Vdom, false);
+        let without =
+            build_jsx_wasm_result(source, JsxLang::Jsx, JsxOutputMode::Vdom, false, false);
         assert!(without.map.is_none(), "no map unless requested");
 
-        let with = build_jsx_wasm_result(source, JsxLang::Jsx, JsxOutputMode::Vdom, true);
+        let with = build_jsx_wasm_result(source, JsxLang::Jsx, JsxOutputMode::Vdom, true, false);
         assert!(with.errors.is_empty(), "errors: {:?}", with.errors);
         let map = with.map.expect("a map is surfaced when requested");
         assert!(map.contains("\"version\":3"), "v3 source map: {map}");
+    }
+
+    #[test]
+    fn wasm_jsx_result_supports_ssr_output() {
+        let result = build_jsx_wasm_result(
+            "const App = () => <div>{message}</div>;",
+            JsxLang::Jsx,
+            JsxOutputMode::Vdom,
+            true,
+            true,
+        );
+
+        assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+        assert!(
+            result.code.contains("function ssrRender"),
+            "{}",
+            result.code
+        );
+        assert!(
+            result.code.contains("@vue/server-renderer"),
+            "{}",
+            result.code
+        );
+        assert!(result.map.is_none(), "SSR output has no source map yet");
     }
 }


### PR DESCRIPTION
## Summary

- add a JSX/TSX SSR compile path backed by the shared SSR code generator
- route `JsxCompileConfig { ssr: true }` through SSR while preserving resolved client mode metadata
- expose the SSR option through the NAPI and WASM JSX bindings
- keep Vapor SSR on the same shared JSX SSR implementation

Closes #1580

## Change Class

- [ ] Parser or AST
- [x] Compiler and codegen
- [ ] Semantic analysis, lint, and cross-file analysis
- [ ] Virtual TypeScript and type checking
- [ ] Formatter and LSP
- [ ] Runtime packaging, release, or docs
- [ ] Not language-facing

## Behavior Reference

- #1580

## Verification Evidence

- [x] Minimal fixture or focused regression test added or updated
- [x] Snapshot/baseline changes reviewed and explained
- [x] Parity or real-world fixture coverage considered
- [ ] Security/audit impact considered
- [ ] Performance status or PR benchmark impact considered
- [ ] Fuzzing target or crash-reproducer coverage considered
- [ ] Editor/LSP scenario coverage considered
- [x] Ecosystem or broad app compatibility impact considered
- [ ] Docs, release, or stability notes updated when public behavior changed

Commands:

- `cargo fmt --all --check`
- `cargo test -p vize_atelier_jsx --test ssr`
- `cargo test -p vize_atelier_jsx --test compile ssr_config_routes_components_to_ssr_and_preserves_client_mode_metadata`
- `cargo test -p vize_atelier_jsx --test vapor_ssr`
- `cargo check -p vize_vitrine`
- `cargo test -p vize_vitrine --features napi jsx_compile_result_supports_ssr_output`
- `cargo test -p vize_vitrine --features wasm wasm_jsx_result_supports_ssr_output`

## Risk

Low to medium. SSR output is opt-in for generic JSX compile and reuses the existing SSR backend; existing client output remains the default. Public binding docs can be updated separately once the option is finalized.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1784"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->