### PR TITLE
feat(jsx): reuse croquis program analysis

### DIFF
--- a/crates/vize_atelier_jsx/src/analyze.rs
+++ b/crates/vize_atelier_jsx/src/analyze.rs
@@ -8,7 +8,6 @@
 //! [`SourceType`]: oxc_span::SourceType
 
 use oxc_ast::ast::Program;
-use vize_croquis::script_parser::analyze_script_setup_program;
 use vize_croquis::{Croquis, Drawer};
 
 /// Analyze a parsed JSX/TSX program, returning the Croquis binding metadata,
@@ -19,8 +18,7 @@ use vize_croquis::{Croquis, Drawer};
 /// drives rules straight over the OXC AST without lowering — can attach the same
 /// semantic analysis the lowering lane produces without a second parse.
 pub fn analyze_program(program: &Program<'_>, source: &str) -> Croquis {
-    let result = analyze_script_setup_program(program, source, None);
-    let mut croquis = Drawer::new().finish();
-    result.apply_to_croquis(&mut croquis);
-    croquis
+    let mut drawer = Drawer::for_compile();
+    drawer.draw_script_setup_program(program, source, None);
+    drawer.finish()
 }

--- a/crates/vize_atelier_jsx/tests/PARITY_INVENTORY.md
+++ b/crates/vize_atelier_jsx/tests/PARITY_INVENTORY.md
@@ -25,6 +25,26 @@ The lower-level IR-shape tests (`tests/elements.rs`, `attributes.rs`,
 `directives.rs`, `modes.rs`, `tsx.rs`, `vdom.rs`, `vapor.rs`) remain the
 fine-grained lowering coverage; this inventory tracks the **parity** layer.
 
+## Croquis reuse inventory (#1579)
+
+JSX/TSX intentionally parses with OXC in the JSX dialect, then hands the parsed
+`Program` to Croquis rather than reparsing as plain TypeScript. This keeps
+binding, scope, macro, import, reactivity, and virtual-TS metadata owned by
+Croquis while allowing JSX syntax to remain valid.
+
+| JSX surface                    | Croquis reuse point                                      | Coverage / measurement                                      |
+| ------------------------------ | -------------------------------------------------------- | ----------------------------------------------------------- |
+| Script semantic analysis       | `Drawer::draw_script_setup_program` over the parsed OXC `Program` | `tests/analysis.rs`, `jsx_croquis_analyze` criterion group |
+| Backend transform metadata     | `LowerOutput.analysis` shared with VDOM, Vapor, SSR, Canon, and Patina | `tests/compile.rs`, `tests/vdom.rs`, `tests/vapor.rs`      |
+| Template expression identifiers | Core transform consumes the Croquis binding metadata instead of JSX-specific binding inference | backend parity snapshots                                    |
+
+Intentional divergences:
+
+| Surface                  | Reason |
+| ------------------------ | ------ |
+| JSX component tag classification | Vue template analysis treats unknown lowercase tags as components in some contexts; JSX follows the Babel/Vue JSX convention where lowercase element names are intrinsic/custom elements and capitalized/member names are components. |
+| `.map(...)` control flow lowering | The JSX source is already an OXC callback AST, so alias spans come directly from callback parameter patterns instead of reserializing through Croquis's string-based `v-for` parser. |
+
 ## Covered categories
 
 | Category         | Reference case                                                                       |     VDOM      | Vapor | TSX |

--- a/crates/vize_atelier_jsx/tests/PARITY_INVENTORY.md
+++ b/crates/vize_atelier_jsx/tests/PARITY_INVENTORY.md
@@ -32,18 +32,18 @@ JSX/TSX intentionally parses with OXC in the JSX dialect, then hands the parsed
 binding, scope, macro, import, reactivity, and virtual-TS metadata owned by
 Croquis while allowing JSX syntax to remain valid.
 
-| JSX surface                    | Croquis reuse point                                      | Coverage / measurement                                      |
-| ------------------------------ | -------------------------------------------------------- | ----------------------------------------------------------- |
-| Script semantic analysis       | `Drawer::draw_script_setup_program` over the parsed OXC `Program` | `tests/analysis.rs`, `jsx_croquis_analyze` criterion group |
-| Backend transform metadata     | `LowerOutput.analysis` shared with VDOM, Vapor, SSR, Canon, and Patina | `tests/compile.rs`, `tests/vdom.rs`, `tests/vapor.rs`      |
-| Template expression identifiers | Core transform consumes the Croquis binding metadata instead of JSX-specific binding inference | backend parity snapshots                                    |
+| JSX surface                     | Croquis reuse point                                                                            | Coverage / measurement                                     |
+| ------------------------------- | ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
+| Script semantic analysis        | `Drawer::draw_script_setup_program` over the parsed OXC `Program`                              | `tests/analysis.rs`, `jsx_croquis_analyze` criterion group |
+| Backend transform metadata      | `LowerOutput.analysis` shared with VDOM, Vapor, SSR, Canon, and Patina                         | `tests/compile.rs`, `tests/vdom.rs`, `tests/vapor.rs`      |
+| Template expression identifiers | Core transform consumes the Croquis binding metadata instead of JSX-specific binding inference | backend parity snapshots                                   |
 
 Intentional divergences:
 
-| Surface                  | Reason |
-| ------------------------ | ------ |
-| JSX component tag classification | Vue template analysis treats unknown lowercase tags as components in some contexts; JSX follows the Babel/Vue JSX convention where lowercase element names are intrinsic/custom elements and capitalized/member names are components. |
-| `.map(...)` control flow lowering | The JSX source is already an OXC callback AST, so alias spans come directly from callback parameter patterns instead of reserializing through Croquis's string-based `v-for` parser. |
+| Surface                           | Reason                                                                                                                                                                                                                                |
+| --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| JSX component tag classification  | Vue template analysis treats unknown lowercase tags as components in some contexts; JSX follows the Babel/Vue JSX convention where lowercase element names are intrinsic/custom elements and capitalized/member names are components. |
+| `.map(...)` control flow lowering | The JSX source is already an OXC callback AST, so alias spans come directly from callback parameter patterns instead of reserializing through Croquis's string-based `v-for` parser.                                                  |
 
 ## Covered categories
 

--- a/crates/vize_atelier_jsx/tests/analysis.rs
+++ b/crates/vize_atelier_jsx/tests/analysis.rs
@@ -2,18 +2,22 @@
 
 mod common;
 
-use vize_atelier_jsx::{JsxLang, lower_source};
+use vize_atelier_jsx::{JsxLang, analyze_jsx_program, lower_source, parse_module};
 use vize_carton::Bump;
+use vize_croquis::BindingMetadata;
 use vize_relief::BindingType;
 
-fn sorted_bindings(out: &vize_atelier_jsx::LowerOutput<'_>) -> Vec<(String, BindingType)> {
-    let mut bindings: Vec<_> = out
-        .bindings()
+fn sorted_binding_entries(bindings: &BindingMetadata) -> Vec<(String, BindingType)> {
+    let mut entries: Vec<_> = bindings
         .iter()
         .map(|(name, binding_type)| (name.to_owned(), binding_type))
         .collect();
-    bindings.sort_by(|left, right| left.0.cmp(&right.0));
-    bindings
+    entries.sort_by(|left, right| left.0.cmp(&right.0));
+    entries
+}
+
+fn sorted_bindings(out: &vize_atelier_jsx::LowerOutput<'_>) -> Vec<(String, BindingType)> {
+    sorted_binding_entries(out.bindings())
 }
 
 #[test]
@@ -71,5 +75,35 @@ fn undefined_binding_is_absent() {
     assert_eq!(
         sorted_bindings(&out),
         vec![("C".to_owned(), BindingType::SetupConst)]
+    );
+}
+
+#[test]
+fn parse_free_croquis_analysis_matches_lowering_analysis() {
+    let source = r#"
+        import { ref } from 'vue';
+        const count = ref(0);
+        const props = defineProps<{ label: string }>();
+        const C = (): JSX.Element => <span>{props.label}{count.value}</span>;
+    "#;
+
+    let allocator = oxc_allocator::Allocator::default();
+    let parsed = parse_module(&allocator, source, JsxLang::Tsx);
+    assert!(
+        parsed.diagnostics.is_empty(),
+        "parse diagnostics: {:?}",
+        parsed.diagnostics
+    );
+
+    let analyzed = analyze_jsx_program(&parsed.program, source);
+    let bump = Bump::new();
+    let lowered = lower_source(&bump, source, JsxLang::Tsx);
+    assert!(!lowered.has_errors(), "{:?}", lowered.diagnostics);
+
+    assert!(analyzed.bindings.is_ref("count"));
+    assert!(analyzed.bindings.contains("props"));
+    assert_eq!(
+        sorted_binding_entries(&analyzed.bindings),
+        sorted_bindings(&lowered)
     );
 }

--- a/crates/vize_croquis/src/drawer/script.rs
+++ b/crates/vize_croquis/src/drawer/script.rs
@@ -1,3 +1,4 @@
+use oxc_ast::ast::Program;
 use vize_carton::profile;
 
 use super::Drawer;
@@ -39,6 +40,33 @@ impl Drawer {
         let result = profile!(
             "croquis.drawer.script_setup",
             crate::script_parser::parse_script_setup_with_generic(source, generic)
+        );
+
+        result.apply_to_croquis(&mut self.croquis);
+
+        self
+    }
+
+    /// Draw an already-parsed script setup program.
+    ///
+    /// This is the parse-free equivalent of [`Self::draw_script_setup_with_generic`]
+    /// for callers that already parsed the source with a dialect Croquis should
+    /// not reparse, such as JSX/TSX.
+    pub fn draw_script_setup_program(
+        &mut self,
+        program: &Program<'_>,
+        source: &str,
+        generic: Option<&str>,
+    ) -> &mut Self {
+        if !self.options.analyze_script {
+            return self;
+        }
+
+        self.script_drawn = true;
+
+        let result = profile!(
+            "croquis.drawer.script_setup_program",
+            crate::script_parser::analyze_script_setup_program(program, source, generic)
         );
 
         result.apply_to_croquis(&mut self.croquis);
@@ -93,6 +121,17 @@ impl Drawer {
         generic: Option<&str>,
     ) -> &mut Self {
         self.draw_script_setup_with_generic(source, generic)
+    }
+
+    /// Compatibility wrapper for the old Analyzer naming.
+    #[inline]
+    pub fn analyze_script_setup_program(
+        &mut self,
+        program: &Program<'_>,
+        source: &str,
+        generic: Option<&str>,
+    ) -> &mut Self {
+        self.draw_script_setup_program(program, source, generic)
     }
 
     /// Compatibility wrapper for the old Analyzer naming.


### PR DESCRIPTION
## Summary

- add a Croquis `Drawer::draw_script_setup_program` API for parse-free script setup analysis over an existing OXC `Program`
- route JSX semantic analysis through the Croquis drawer facade instead of manually applying parser output
- add JSX analysis coverage showing direct Croquis analysis matches lowering-time analysis
- document the JSX Croquis reuse surface and intentional divergences

Closes #1579

## Change Class

- [ ] Parser or AST
- [ ] Compiler and codegen
- [x] Semantic analysis, lint, and cross-file analysis
- [ ] Virtual TypeScript and type checking
- [ ] Formatter and LSP
- [ ] Runtime packaging, release, or docs
- [ ] Not language-facing

## Behavior Reference

- #1579
- `crates/vize_atelier_jsx/tests/PARITY_INVENTORY.md`

## Verification Evidence

- [x] Minimal fixture or focused regression test added or updated
- [ ] Snapshot/baseline changes reviewed and explained
- [x] Parity or real-world fixture coverage considered
- [ ] Security/audit impact considered
- [x] Performance status or PR benchmark impact considered
- [ ] Fuzzing target or crash-reproducer coverage considered
- [ ] Editor/LSP scenario coverage considered
- [ ] Ecosystem or broad app compatibility impact considered
- [x] Docs, release, or stability notes updated when public behavior changed

Commands:

- `cargo fmt --all --check`
- `cargo test -p vize_atelier_jsx --test analysis`
- `cargo test -p vize_croquis drawer`
- `cargo test -p vize_atelier_jsx`

## Risk

Low. The JSX analysis result still comes from the same Croquis script parser; this only moves the parse-free handoff behind the Croquis drawer API and documents the remaining JSX-specific behavior.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1785"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->