### PR TITLE
test(canon): stabilize emit recursion coverage

### DIFF
--- a/crates/vize_canon/src/batch/type_checker/tests/emit_object_recursion.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests/emit_object_recursion.rs
@@ -63,6 +63,7 @@ void (null as unknown as TestProps);
         Some(corsa_path.as_path()),
     )
     .expect("batch checker should initialize with explicit tsgo");
+    checker.set_server_count(Some(1));
     checker.scan_project().expect("project should scan");
     let result = checker.check_project().expect("project should check");
 


### PR DESCRIPTION
## Summary
- pin the emit object recursion regression test to a single Corsa checker worker
- keep the TS2589 diagnostic assertion while avoiding coverage-run sharding instability

## Verification
- cargo fmt --all --check
- CARGO_TARGET_DIR=target/codex-ci-fix cargo test -p vize_canon batch_type_checker_reports_runtime_emit_object_instance_props_recursion -- --nocapture
- CARGO_TARGET_DIR=target/codex-ci-fix-cov cargo llvm-cov --no-report -p vize_canon -- batch_type_checker_reports_runtime_emit_object_instance_props_recursion --nocapture

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1786"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->