### PR TITLE
[Next Gen] refactor(codegen): classify directive comments through the Rendu op

### DIFF
--- a/crates/vize_atelier_core/src/codegen/children.rs
+++ b/crates/vize_atelier_core/src/codegen/children.rs
@@ -1,5 +1,6 @@
 //! Children, text, comment, and interpolation generation functions.
 
+use crate::rendu::RenduOp;
 use crate::steps::hoist_static::is_static_node;
 use crate::{ElementNode, Position, RuntimeHelper, TemplateChildNode};
 
@@ -22,9 +23,21 @@ pub fn generate_children_force_array(ctx: &mut CodegenContext, children: &[Templ
 }
 
 /// Check if a child node is a directive comment that should be stripped.
+///
+/// Classified through the Rendu plate rather than matching the Relief variant
+/// directly: `RenduOp::Comment` already carries the `is_directive` fact, so the
+/// children traversal reads the same render-semantic classification DOM node
+/// dispatch uses. Byte-for-byte equivalent — `is_directive` is exactly
+/// `comment.directive.is_some()`.
 #[inline]
 pub(crate) fn is_directive_comment(child: &TemplateChildNode<'_>) -> bool {
-    matches!(child, TemplateChildNode::Comment(c) if c.directive.is_some())
+    matches!(
+        RenduOp::from_template_child(child),
+        RenduOp::Comment {
+            is_directive: true,
+            ..
+        }
+    )
 }
 
 fn generate_children_inner(


### PR DESCRIPTION
Advances #1756 (staged plan item 4 from #1634). One byte-equivalent increment of the template-lowering track.

`is_directive_comment` (the DOM children directive-comment filter) now classifies through `RenduOp::Comment { is_directive }` instead of matching the Relief `Comment` variant directly — so the children traversal shares the same render-semantic classification that `generate_node` already uses for DOM dispatch.

## Byte-equivalence

`is_directive` is exactly `comment.directive.is_some()`, so output is unchanged. **Verified** by the DOM insta snapshots:

- `cargo test -p vize_atelier_dom` — 261 passing incl. the `dom_snapshot` gate (no snapshot changes).
- `cargo test -p vize_atelier_core` lib — passing; `clippy --lib` + `rustfmt --check` clean.

## Scope note (honest)

This is **one increment**, not the whole of #1756. Element/component, prop/event/directive, and slot **emission** still read Relief details that Rendu does not yet carry; rerouting those emitters is larger, snapshot-gated work that continues on this track (the same incremental approach as canary's earlier "emit interpolations from the Rendu IR"). #1756 stays open for that emission work.

---
**[Next Gen]** for #1634, targeting `canary`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1789"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->