### PR TITLE
[Next Gen] refactor(ssr): expose the ssr result as an AtelierOutput plate

### DIFF
--- a/crates/vize_atelier_ssr/src/lib.rs
+++ b/crates/vize_atelier_ssr/src/lib.rs
@@ -19,6 +19,7 @@
 pub mod codegen;
 pub mod errors;
 pub mod options;
+mod output_plate;
 pub mod steps;
 
 pub use codegen::{SsrCodegenContext, SsrCodegenResult};

--- a/crates/vize_atelier_ssr/src/output_plate.rs
+++ b/crates/vize_atelier_ssr/src/output_plate.rs
@@ -1,0 +1,45 @@
+//! SSR result as a shared `AtelierOutput` finishing plate.
+//!
+//! Lets the SSR result speak the same finish-plate vocabulary as DOM and Vapor
+//! (#1758), so SFC assembly can eventually slice SSR output through structured
+//! sections instead of the bespoke `{ code, preamble }` pair.
+
+use crate::codegen::SsrCodegenResult;
+use vize_atelier_core::atelier_output::AtelierOutput;
+use vize_carton::String;
+
+impl SsrCodegenResult {
+    /// Structure this result as an [`AtelierOutput`] finishing plate.
+    ///
+    /// SSR's `preamble` (helper imports) maps to imports and `code` (the
+    /// `ssrRender` function) maps to functions. The owned `code`/`preamble`
+    /// fields are unchanged — this is an additive structured view, not yet the
+    /// assembly contract, so SSR output stays byte-equivalent.
+    pub fn atelier_output(&self) -> AtelierOutput {
+        AtelierOutput::new(
+            self.preamble.clone(),
+            String::default(),
+            self.code.clone(),
+            String::default(),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn atelier_output_maps_preamble_to_imports_and_code_to_functions() {
+        let result = SsrCodegenResult {
+            code: String::from("function ssrRender() {}"),
+            preamble: String::from("import { x } from \"vue\"\n"),
+        };
+
+        let output = result.atelier_output();
+        assert_eq!(output.imports.as_str(), "import { x } from \"vue\"\n");
+        assert_eq!(output.functions.as_str(), "function ssrRender() {}");
+        assert!(output.hoists.is_empty());
+        assert!(output.exports.is_empty());
+    }
+}


### PR DESCRIPTION
Advances #1758 (staged plan item 6 from #1634). Builds on the `AtelierOutput` plate from #1763.

`SsrCodegenResult::atelier_output()` structures the SSR result as the shared finish plate — `preamble` → imports, `code` → the `ssrRender` function — so SSR speaks the same vocabulary as DOM and Vapor.

## Byte-equivalence

Additive structured **view**: the owned `code`/`preamble` fields and SSR output are unchanged. **Verified** by the SSR snapshots:

- `cargo test -p vize_atelier_ssr` — 47 + 76 passing incl. the `ssr_snapshot` gate (no changes), plus the new mapping test.
- `clippy --lib` + `rustfmt --check` clean.

The impl lives in a new `output_plate.rs` so the already-long `codegen.rs` (431 lines) doesn't grow past the source-length guard.

## Scope note (honest)

This is **one increment**, not the whole of #1758. Replacing `{ code, preamble }` as the SFC assembly contract (slicing SSR through `AtelierOutput` sections) is the heavier, snapshot-gated follow-up. #1758 stays open for that.

---
**[Next Gen]** for #1634, targeting `canary`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1790"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->