### PR TITLE
[Next Gen] docs(relief): mark render/codegen types for relocation to Rendu

### DIFF
--- a/crates/vize_relief/src/relief/codegen.rs
+++ b/crates/vize_relief/src/relief/codegen.rs
@@ -1,7 +1,7 @@
 //! Code generation AST node types.
 //!
-//! Contains VNodeCall, JavaScript expression nodes, SSR codegen nodes,
-//! and all types used during code generation from the template AST.
+//! `VNodeCall`, JS expression nodes, and SSR codegen nodes — render/codegen
+//! types slated to move out of Relief into Rendu/Atelier (#1760, #1634).
 
 use vize_carton::{Box, Bump, PatchFlags, String, Vec};
 


### PR DESCRIPTION
First compatibility-aware step of #1760 (staged plan item 8 from #1634).

#1760 wants Relief's render/codegen AST types (`VNodeCall`, `VNodeChildren`, `PropsExpression`, `SlotsExpression`, `JsChildNode`, ...) moved out into Rendu / Atelier-private modules so Relief is a source-faithful surface only.

## Why a doc step, not the move

The issue gates the move on "after benchmark-neutral replacement paths exist." Those paths (full Rendu lowering) are still incremental — `atelier_core` re-exports these types today, so moving them now would break consumers and is premature. So this records the relocation plan **at the definition site** (`relief/codegen.rs`) without the consumer-breaking move, the same document-first approach as #1581.

Net-neutral doc edit (the file is already over the 350-line guard, so it must not grow). Build + length guard pass; the two `rustfmt --check` diffs are pre-existing import-ordering in the unchanged `use` block, not my edit.

## Scope note (honest)

This does **not** perform the move — #1760 stays open for the actual relocation once Rendu lowering (#1756 et al.) carries these shapes.

---
**[Next Gen]** for #1634, targeting `canary`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1791"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->