### PR TITLE
[Next Gen] refactor(sfc): assemble output through the shared AtelierOutput plate

### DIFF
--- a/crates/vize_atelier_sfc/src/compile/output_module.rs
+++ b/crates/vize_atelier_sfc/src/compile/output_module.rs
@@ -2,6 +2,7 @@
 
 use crate::types::{CssModuleMapping, css_modules_object_literal};
 use vize_atelier_core::{
+    atelier_output::AtelierOutput,
     codegen::CodegenResultWithSections,
     rendu::{RenduModuleSections, RenduPlate, RenduRange, RenduRenderSections},
     source_atlas::SourceAtlasTarget,
@@ -166,14 +167,12 @@ impl OutputModule {
         functions: String,
         exports: String,
     ) -> String {
-        let mut code = String::default();
-        code.push_str(&imports);
-        code.push_str(&hoists);
-        code.push('\n');
-        code.push_str(&functions);
-        code.push('\n');
-        code.push_str(&exports);
-        code
+        // Flatten through the shared core `AtelierOutput` plate so SFC, SSR, and
+        // DOM output all use one flattening authority (imports+hoists adjacent,
+        // a newline before functions and before exports) instead of each
+        // re-implementing the layout. Byte-for-byte identical to the previous
+        // inline assembly.
+        AtelierOutput::new(imports, hoists, functions, exports).flatten()
     }
 }
 


### PR DESCRIPTION
Advances #1758 (SSR/SFC output assembled on `AtelierOutput`) and completes the `OutputModule` unification from #1763.

`OutputModule::assemble_code` now delegates to the core `AtelierOutput::new(...).flatten()`, so SFC, SSR, and DOM output all flatten through **one finish-plate authority** instead of each re-implementing the chunk layout (imports+hoists adjacent, newline before functions and before exports).

## Byte-equivalence — verified across the full Atelier snapshot suites

- `vize_atelier_sfc` — 528 passing (incl. TS/patches/script-setup snapshot suites)
- `vize_atelier_ssr` — 76 passing incl. `ssr_snapshot`
- `vize_atelier_dom` — 46 passing incl. `dom_snapshot`

No snapshot changes. The layout is identical, so every target's output is byte-for-byte unchanged. `clippy --lib` clean; the one `rustfmt --check` diff is pre-existing case-ordering on an unchanged sibling import (CI accepts canary's ASCII ordering); my added import is correctly ordered.

## Scope note

This unifies the **assembly/flattening**. Fully retiring `SsrCodegenResult { code, preamble }` as a type (vs. the structured `AtelierOutput`) is the remaining bit on #1758; combined with #1790 (SSR exposes an `AtelierOutput` view) the SSR output now both flattens through and can be viewed as the shared plate.

---
**[Next Gen]** for #1634, targeting `canary`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1792"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->