### PR TITLE
[Next Gen] refactor(codegen): emit static attribute props from the Rendu op

### DIFF
--- a/crates/vize_atelier_core/src/codegen/props/generate.rs
+++ b/crates/vize_atelier_core/src/codegen/props/generate.rs
@@ -1,5 +1,6 @@
 //! Main props generation logic.
 
+use crate::rendu::RenduOp;
 use crate::{ExpressionNode, PropNode, RuntimeHelper};
 use vize_relief::options::BindingType;
 
@@ -263,12 +264,12 @@ fn try_generate_static_attrs(
 
     let mut first = true;
     for prop in unique_props {
-        let PropNode::Attribute(attr) = prop else {
-            // Panic path by invariant: the preflight `all(Attribute)` check above
-            // has already rejected directive props. Reaching this arm would mean
-            // `props` was mutated while iterating, which is impossible through the
-            // shared slice used by codegen.
-            unreachable!("checked above");
+        // Lower static-prop emission through the Rendu plate (#1756): name,
+        // value, and source spans come from `RenduOp::Attribute`, not Relief.
+        let RenduOp::Attribute { name, name_span, value, value_span, .. } =
+            RenduOp::from_prop(prop)
+        else {
+            unreachable!("checked above: all props are attributes");
         };
 
         if !first {
@@ -281,25 +282,24 @@ fn try_generate_static_attrs(
         }
         first = false;
 
-        let needs_quotes = !is_valid_js_identifier(&attr.name);
+        let needs_quotes = !is_valid_js_identifier(name);
         if needs_quotes {
             ctx.push("\"");
         }
-        // Anchor the generated prop key back to the attribute name in source,
-        // recording the symbol so it lands in the v3 `names` array. No-op
-        // without `source_map`.
-        ctx.record_mapping_named(&attr.name_loc.start, &attr.name);
-        ctx.push(&attr.name);
+        // Anchor the prop key back to the attribute name (no-op without
+        // `source_map`); records the symbol for the v3 `names` array.
+        ctx.record_mapping_named(&name_span.start, name);
+        ctx.push(name);
         if needs_quotes {
             ctx.push("\"");
         }
         ctx.push(": ");
-        if let Some(value) = &attr.value {
+        if let Some(value) = value {
             ctx.push("\"");
-            // Anchor the generated value literal back to the attribute value in
-            // source, just inside the opening quote. No-op without `source_map`.
-            ctx.record_mapping(&value.loc.start);
-            ctx.push(&escape_js_string(&value.content));
+            if let Some(span) = value_span {
+                ctx.record_mapping(&span.start);
+            }
+            ctx.push(&escape_js_string(value));
             ctx.push("\"");
         } else {
             ctx.push("\"\"");

--- a/crates/vize_atelier_core/src/rendu/semantic.rs
+++ b/crates/vize_atelier_core/src/rendu/semantic.rs
@@ -16,9 +16,15 @@ pub enum RenduOp<'a> {
         span: RenduSpan,
     },
     /// A static attribute on the nearest preceding `Element` op.
+    ///
+    /// `name_span`/`value_span` carry the source positions of the name and
+    /// value separately so a backend can source-map the emitted prop key and
+    /// value literal straight from the op.
     Attribute {
         name: &'a str,
+        name_span: RenduSpan,
         value: Option<&'a str>,
+        value_span: Option<RenduSpan>,
         span: RenduSpan,
     },
     /// A directive (`v-bind`/`v-on`/`v-model`/custom) on the nearest preceding
@@ -89,7 +95,12 @@ impl<'a> RenduOp<'a> {
     fn from_attribute(attr: &'a AttributeNode) -> Self {
         Self::Attribute {
             name: attr.name.as_str(),
+            name_span: RenduSpan::from_location(&attr.name_loc),
             value: attr.value.as_ref().map(|text| text.content.as_str()),
+            value_span: attr
+                .value
+                .as_ref()
+                .map(|text| RenduSpan::from_location(&text.loc)),
             span: RenduSpan::from_location(&attr.loc),
         }
     }


### PR DESCRIPTION
Advances #1756 (staged plan item 4 from #1634) — the first real prop **emission** driven by `RenduOp`, not just classification.

- `RenduOp::Attribute` now carries `name_span` and `value_span`, so a backend can source-map the emitted prop key and value literal straight from the op.
- `try_generate_static_attrs` emits the all-static props object from `RenduOp::from_prop(prop)` (`RenduOp::Attribute`) — reading name, value, and their spans from the Rendu plate instead of the Relief `AttributeNode`.

## Byte-equivalence — verified across the full Atelier snapshot suites

`vize_atelier_dom` (`dom_snapshot`), `vize_atelier_sfc` (528, incl. source-map tests), `vize_atelier_ssr` (76), and `vize_atelier_core` (67) all pass with **no snapshot changes**. The op borrows the same name/value and their exact source positions, so output — including source maps — is byte-for-byte identical. `generate.rs` is net-neutral against the source-length guard; `clippy --lib` clean; the one `rustfmt` diff is a pre-existing import-ordering divergence on an unchanged line.

## Scope note

This lowers the **static-attribute** emission path. Dynamic props, events, directives, and element/slot emission still read Relief and remain on the #1756 track; each is a further snapshot-verified increment.

---
**[Next Gen]** for #1634, targeting `canary`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1793"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->