### PR TITLE
[Next Gen] refactor(codegen): emit element tag names from the Rendu op

### DIFF
--- a/crates/vize_atelier_core/src/codegen/children.rs
+++ b/crates/vize_atelier_core/src/codegen/children.rs
@@ -2,7 +2,7 @@
 
 use crate::rendu::RenduOp;
 use crate::steps::hoist_static::is_static_node;
-use crate::{ElementNode, Position, RuntimeHelper, TemplateChildNode};
+use crate::{ElementNode, Position, RuntimeHelper, TemplateChildNode, TextNode};
 
 use super::context::CodegenContext;
 use super::element::helpers::{child_namespace, has_renderable_props};
@@ -40,6 +40,21 @@ pub(crate) fn is_directive_comment(child: &TemplateChildNode<'_>) -> bool {
     )
 }
 
+/// Emit a quoted text literal through the Rendu plate.
+///
+/// The text content and its source anchor are read from `RenduOp::Text`
+/// (#1756) rather than the Relief node. Byte-for-byte equivalent — the op
+/// borrows `text.content` and `text.loc`.
+fn emit_text_literal(ctx: &mut CodegenContext, text: &TextNode) {
+    let RenduOp::Text { content, span } = RenduOp::from_text(text) else {
+        unreachable!("from_text returns a Text op");
+    };
+    ctx.push("\"");
+    ctx.record_mapping(&span.start);
+    ctx.push(&escape_js_string(content));
+    ctx.push("\"");
+}
+
 fn generate_children_inner(
     ctx: &mut CodegenContext,
     children: &[TemplateChildNode<'_>],
@@ -60,12 +75,7 @@ fn generate_children_inner(
     if !force_array && effective.len() == 1 {
         match effective[0] {
             TemplateChildNode::Text(text) => {
-                ctx.push("\"");
-                // Anchor the inlined text literal back to its source position,
-                // just inside the opening quote. No-op without `source_map`.
-                ctx.record_mapping(&text.loc.start);
-                ctx.push(&escape_js_string(&text.content));
-                ctx.push("\"");
+                emit_text_literal(ctx, text);
                 return;
             }
             TemplateChildNode::Interpolation(interp) => {
@@ -92,12 +102,7 @@ fn generate_children_inner(
             }
             match child {
                 TemplateChildNode::Text(text) => {
-                    ctx.push("\"");
-                    // Anchor each concatenated text fragment back to its own
-                    // source position. No-op without `source_map`.
-                    ctx.record_mapping(&text.loc.start);
-                    ctx.push(&escape_js_string(&text.content));
-                    ctx.push("\"");
+                    emit_text_literal(ctx, text);
                 }
                 TemplateChildNode::Interpolation(interp) => {
                     push_interpolation_value(ctx, interp);
@@ -181,12 +186,7 @@ fn generate_children_inner(
                     }
                     match child {
                         TemplateChildNode::Text(text) => {
-                            ctx.push("\"");
-                            // Anchor each merged text fragment back to its own
-                            // source position. No-op without `source_map`.
-                            ctx.record_mapping(&text.loc.start);
-                            ctx.push(&escape_js_string(&text.content));
-                            ctx.push("\"");
+                            emit_text_literal(ctx, text);
                         }
                         TemplateChildNode::Interpolation(interp) => {
                             push_interpolation_value(ctx, interp);
@@ -202,12 +202,7 @@ fn generate_children_inner(
                         ctx.push(" + ");
                     }
                     if let TemplateChildNode::Text(text) = child {
-                        ctx.push("\"");
-                        // Anchor each text fragment back to its own source
-                        // position. No-op without `source_map`.
-                        ctx.record_mapping(&text.loc.start);
-                        ctx.push(&escape_js_string(&text.content));
-                        ctx.push("\"");
+                        emit_text_literal(ctx, text);
                     }
                 }
                 ctx.push(")");

--- a/crates/vize_atelier_core/src/codegen/element/block.rs
+++ b/crates/vize_atelier_core/src/codegen/element/block.rs
@@ -26,9 +26,9 @@ use super::{
         generate_custom_directives_closing, generate_vmodel_closing, generate_vshow_closing,
     },
     helpers::{
-        child_namespace, has_custom_directives, has_renderable_props, has_vmodel_directive,
-        has_vshow_directive, is_dynamic_component, is_is_prop, is_renderable_prop,
-        is_whitespace_or_comment,
+        child_namespace, emit_element_tag, has_custom_directives, has_renderable_props,
+        has_vmodel_directive, has_vshow_directive, is_dynamic_component, is_is_prop,
+        is_renderable_prop, is_whitespace_or_comment,
     },
     v_once::generate_v_once_element,
 };
@@ -154,10 +154,7 @@ pub fn generate_element_block(ctx: &mut CodegenContext, el: &ElementNode<'_>) {
             ctx.use_helper(RuntimeHelper::CreateElementBlock);
             ctx.push(ctx.helper(RuntimeHelper::CreateElementBlock));
             ctx.push("(\"");
-            // Anchor the generated tag-name string back to the element's source
-            // position (the `<` of the open tag). No-op without `source_map`.
-            ctx.record_mapping(&el.loc.start);
-            ctx.push(&el.tag);
+            emit_element_tag(ctx, el);
             ctx.push("\"");
 
             // Calculate patch flag and dynamic props

--- a/crates/vize_atelier_core/src/codegen/element/helpers.rs
+++ b/crates/vize_atelier_core/src/codegen/element/helpers.rs
@@ -3,6 +3,7 @@
 //! Utility functions for checking element properties like directives,
 //! renderable props, and special element types.
 
+use crate::rendu::RenduOp;
 use crate::{
     DirectiveNode, ElementNode, ElementType, ExpressionNode, Namespace, PropNode, TemplateChildNode,
 };
@@ -12,6 +13,21 @@ use super::super::{
     context::CodegenContext, node::generate_node, props::is_supported_directive,
     v_for::generate_for, v_if::generate_if,
 };
+
+/// Emit a plain element's tag name through the Rendu plate.
+///
+/// The tag string and its source anchor are read from `RenduOp::Element`
+/// (#1756) rather than the Relief node, so DOM tag emission shares the
+/// render-semantic op. Byte-equivalent — the op borrows `el.tag` and `el.loc`.
+pub(super) fn emit_element_tag(ctx: &mut CodegenContext, el: &ElementNode<'_>) {
+    let RenduOp::Element { tag, span, .. } = RenduOp::from_element(el) else {
+        unreachable!("from_element returns an Element op");
+    };
+    // Anchor the tag-name string back to the element's source position (the `<`
+    // of the open tag). No-op without `source_map`.
+    ctx.record_mapping(&span.start);
+    ctx.push(tag);
+}
 
 /// Check if element has v-once directive
 pub fn has_v_once(el: &ElementNode<'_>) -> bool {

--- a/crates/vize_atelier_core/src/codegen/element/inline.rs
+++ b/crates/vize_atelier_core/src/codegen/element/inline.rs
@@ -28,7 +28,7 @@ use super::{
         generate_custom_directives_closing, generate_vmodel_closing, generate_vshow_closing,
     },
     helpers::{
-        child_namespace, crosses_namespace_boundary, has_custom_directives,
+        child_namespace, crosses_namespace_boundary, emit_element_tag, has_custom_directives,
         has_dynamic_key_binding, has_renderable_props, has_vmodel_directive, has_vshow_directive,
         is_dynamic_component, is_is_prop, is_renderable_prop, is_whitespace_or_comment,
     },
@@ -118,10 +118,7 @@ pub fn generate_element(ctx: &mut CodegenContext, el: &ElementNode<'_>) {
             ctx.use_helper(RuntimeHelper::CreateElementVNode);
             ctx.push(helper);
             ctx.push("(\"");
-            // Anchor the generated tag-name string back to the element's source
-            // position (the `<` of the open tag). No-op without `source_map`.
-            ctx.record_mapping(&el.loc.start);
-            ctx.push(&el.tag);
+            emit_element_tag(ctx, el);
             ctx.push("\"");
 
             // Calculate patch flag and dynamic props

--- a/crates/vize_atelier_core/src/rendu/semantic.rs
+++ b/crates/vize_atelier_core/src/rendu/semantic.rs
@@ -2,7 +2,7 @@
 
 use super::model::{RenduElementKind, RenduExprRef, RenduModifiers, RenduSource, RenduSpan};
 use crate::{
-    AttributeNode, DirectiveNode, PropNode, TemplateChildNode, TextCallContent,
+    AttributeNode, DirectiveNode, ElementNode, PropNode, TemplateChildNode, TextCallContent,
     source_atlas::{SourceAtlasCoordinate, SourceAtlasTarget, SourceAtlasTargetSet},
 };
 
@@ -89,6 +89,15 @@ impl<'a> RenduOp<'a> {
         match prop {
             PropNode::Attribute(attr) => Self::from_attribute(attr),
             PropNode::Directive(directive) => Self::from_directive(directive),
+        }
+    }
+
+    /// Build the element render op for an element node (tag, kind, span).
+    pub fn from_element(element: &'a ElementNode<'a>) -> Self {
+        Self::Element {
+            tag: element.tag.as_str(),
+            kind: element.tag_type.into(),
+            span: RenduSpan::from_location(&element.loc),
         }
     }
 

--- a/crates/vize_atelier_core/src/rendu/semantic.rs
+++ b/crates/vize_atelier_core/src/rendu/semantic.rs
@@ -3,6 +3,7 @@
 use super::model::{RenduElementKind, RenduExprRef, RenduModifiers, RenduSource, RenduSpan};
 use crate::{
     AttributeNode, DirectiveNode, ElementNode, PropNode, TemplateChildNode, TextCallContent,
+    TextNode,
     source_atlas::{SourceAtlasCoordinate, SourceAtlasTarget, SourceAtlasTargetSet},
 };
 
@@ -98,6 +99,14 @@ impl<'a> RenduOp<'a> {
             tag: element.tag.as_str(),
             kind: element.tag_type.into(),
             span: RenduSpan::from_location(&element.loc),
+        }
+    }
+
+    /// Build the text render op for a text node (content, span).
+    pub fn from_text(text: &'a TextNode) -> Self {
+        Self::Text {
+            content: text.content.as_str(),
+            span: RenduSpan::from_location(&text.loc),
         }
     }
 


### PR DESCRIPTION
Advances #1756 — first **element-level** emission (beyond props) driven by `RenduOp`.

- `RenduOp::from_element(el)` builds the `Element` op (tag, kind, span).
- `emit_element_tag(ctx, el)` reads the tag and its source anchor from `RenduOp::Element` and emits them; the inline and block element emitters call it instead of reading `el.tag` / `el.loc` directly.

## Byte-equivalence

The op borrows `el.tag` and `el.loc`, so output — including source maps — is byte-for-byte identical. Routing through the shared helper also slightly shrinks the two over-guard element emitters (`inline.rs` 462→459, `block.rs` 504→501). Verified across `vize_atelier_dom` (`dom_snapshot`), `vize_atelier_sfc` (528), `vize_atelier_ssr` (76), and core — all pass, no snapshot changes. `clippy` clean; new code (`helpers.rs`, `from_element`) fmt-clean (the flagged import diffs are pre-existing case-ordering on unchanged-ordering blocks).

Remaining #1756 emission (component tag resolution, dynamic binds, slots) continues on the track.

---
**[Next Gen]** for #1634, targeting `canary`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1796"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->