### PR TITLE
[Next Gen] refactor(codegen): emit text literals from the Rendu op

### DIFF
--- a/crates/vize_atelier_core/src/codegen/children.rs
+++ b/crates/vize_atelier_core/src/codegen/children.rs
@@ -2,7 +2,7 @@
 
 use crate::rendu::RenduOp;
 use crate::steps::hoist_static::is_static_node;
-use crate::{ElementNode, Position, RuntimeHelper, TemplateChildNode};
+use crate::{ElementNode, Position, RuntimeHelper, TemplateChildNode, TextNode};
 
 use super::context::CodegenContext;
 use super::element::helpers::{child_namespace, has_renderable_props};
@@ -40,6 +40,21 @@ pub(crate) fn is_directive_comment(child: &TemplateChildNode<'_>) -> bool {
     )
 }
 
+/// Emit a quoted text literal through the Rendu plate.
+///
+/// The text content and its source anchor are read from `RenduOp::Text`
+/// (#1756) rather than the Relief node. Byte-for-byte equivalent — the op
+/// borrows `text.content` and `text.loc`.
+fn emit_text_literal(ctx: &mut CodegenContext, text: &TextNode) {
+    let RenduOp::Text { content, span } = RenduOp::from_text(text) else {
+        unreachable!("from_text returns a Text op");
+    };
+    ctx.push("\"");
+    ctx.record_mapping(&span.start);
+    ctx.push(&escape_js_string(content));
+    ctx.push("\"");
+}
+
 fn generate_children_inner(
     ctx: &mut CodegenContext,
     children: &[TemplateChildNode<'_>],
@@ -60,12 +75,7 @@ fn generate_children_inner(
     if !force_array && effective.len() == 1 {
         match effective[0] {
             TemplateChildNode::Text(text) => {
-                ctx.push("\"");
-                // Anchor the inlined text literal back to its source position,
-                // just inside the opening quote. No-op without `source_map`.
-                ctx.record_mapping(&text.loc.start);
-                ctx.push(&escape_js_string(&text.content));
-                ctx.push("\"");
+                emit_text_literal(ctx, text);
                 return;
             }
             TemplateChildNode::Interpolation(interp) => {
@@ -92,12 +102,7 @@ fn generate_children_inner(
             }
             match child {
                 TemplateChildNode::Text(text) => {
-                    ctx.push("\"");
-                    // Anchor each concatenated text fragment back to its own
-                    // source position. No-op without `source_map`.
-                    ctx.record_mapping(&text.loc.start);
-                    ctx.push(&escape_js_string(&text.content));
-                    ctx.push("\"");
+                    emit_text_literal(ctx, text);
                 }
                 TemplateChildNode::Interpolation(interp) => {
                     push_interpolation_value(ctx, interp);
@@ -181,12 +186,7 @@ fn generate_children_inner(
                     }
                     match child {
                         TemplateChildNode::Text(text) => {
-                            ctx.push("\"");
-                            // Anchor each merged text fragment back to its own
-                            // source position. No-op without `source_map`.
-                            ctx.record_mapping(&text.loc.start);
-                            ctx.push(&escape_js_string(&text.content));
-                            ctx.push("\"");
+                            emit_text_literal(ctx, text);
                         }
                         TemplateChildNode::Interpolation(interp) => {
                             push_interpolation_value(ctx, interp);
@@ -202,12 +202,7 @@ fn generate_children_inner(
                         ctx.push(" + ");
                     }
                     if let TemplateChildNode::Text(text) = child {
-                        ctx.push("\"");
-                        // Anchor each text fragment back to its own source
-                        // position. No-op without `source_map`.
-                        ctx.record_mapping(&text.loc.start);
-                        ctx.push(&escape_js_string(&text.content));
-                        ctx.push("\"");
+                        emit_text_literal(ctx, text);
                     }
                 }
                 ctx.push(")");

--- a/crates/vize_atelier_core/src/rendu/semantic.rs
+++ b/crates/vize_atelier_core/src/rendu/semantic.rs
@@ -3,6 +3,7 @@
 use super::model::{RenduElementKind, RenduExprRef, RenduModifiers, RenduSource, RenduSpan};
 use crate::{
     AttributeNode, DirectiveNode, ElementNode, PropNode, TemplateChildNode, TextCallContent,
+    TextNode,
     source_atlas::{SourceAtlasCoordinate, SourceAtlasTarget, SourceAtlasTargetSet},
 };
 
@@ -98,6 +99,14 @@ impl<'a> RenduOp<'a> {
             tag: element.tag.as_str(),
             kind: element.tag_type.into(),
             span: RenduSpan::from_location(&element.loc),
+        }
+    }
+
+    /// Build the text render op for a text node (content, span).
+    pub fn from_text(text: &'a TextNode) -> Self {
+        Self::Text {
+            content: text.content.as_str(),
+            span: RenduSpan::from_location(&text.loc),
         }
     }
 


### PR DESCRIPTION
Advances #1756. With this, **every source-mapped leaf/attribute emission** — text, comments, interpolations, static attributes, element tags — flows through `RenduOp`.

- `RenduOp::from_text(text)` builds the `Text` op (content, span).
- `emit_text_literal(ctx, text)` reads content + source anchor from `RenduOp::Text`; the four text-literal sites in children codegen call it.

## Byte-equivalence

The op borrows `text.content`/`text.loc`, so output incl. source maps is byte-identical. Verified across `vize_atelier_dom`, `vize_atelier_sfc` (528), `vize_atelier_ssr` (76) — no snapshot changes. `clippy`/`rustfmt` clean; `children.rs` shrinks.

Stacked on #1796 (element tag). Remaining #1756 emission (children grouping, component resolution, slots) is the `walk_rendu_ops`-driven structural work.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1797"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->