### PR TITLE
[Next Gen] refactor(ssr): assemble SSR output on AtelierOutput

### DIFF
--- a/crates/vize_atelier_sfc/src/compile/output_module.rs
+++ b/crates/vize_atelier_sfc/src/compile/output_module.rs
@@ -96,7 +96,20 @@ impl OutputModule {
     }
 
     pub(crate) fn from_ssr_codegen(result: SsrCodegenResult) -> Self {
-        Self::from_render_chunks(result.preamble, result.code)
+        // Assemble SSR through the shared AtelierOutput finishing plate (#1758):
+        // the SSR result declares its own finish-plate structure (preamble →
+        // imports, code → functions) via `into_atelier_output`, and the output
+        // module is built from those owned sections rather than a bespoke
+        // positional pairing. The sections move straight through — byte-for-byte
+        // and allocation-equivalent to the previous `from_render_chunks` call.
+        let output = result.into_atelier_output();
+        Self {
+            imports: output.imports,
+            hoists: output.hoists,
+            functions: output.functions,
+            exports: output.exports,
+            ..Self::default()
+        }
     }
 
     pub(crate) fn from_dom_codegen(result: CodegenResultWithSections) -> Self {

--- a/crates/vize_atelier_ssr/src/output_plate.rs
+++ b/crates/vize_atelier_ssr/src/output_plate.rs
@@ -1,8 +1,9 @@
 //! SSR result as a shared `AtelierOutput` finishing plate.
 //!
 //! Lets the SSR result speak the same finish-plate vocabulary as DOM and Vapor
-//! (#1758), so SFC assembly can eventually slice SSR output through structured
-//! sections instead of the bespoke `{ code, preamble }` pair.
+//! (#1758): SFC assembly builds its output module from these structured sections
+//! (via [`into_atelier_output`](SsrCodegenResult::into_atelier_output)) instead
+//! of the bespoke `{ code, preamble }` pair.
 
 use crate::codegen::SsrCodegenResult;
 use vize_atelier_core::atelier_output::AtelierOutput;
@@ -12,14 +13,30 @@ impl SsrCodegenResult {
     /// Structure this result as an [`AtelierOutput`] finishing plate.
     ///
     /// SSR's `preamble` (helper imports) maps to imports and `code` (the
-    /// `ssrRender` function) maps to functions. The owned `code`/`preamble`
-    /// fields are unchanged — this is an additive structured view, not yet the
-    /// assembly contract, so SSR output stays byte-equivalent.
+    /// `ssrRender` function) maps to functions. This borrowed view clones for
+    /// inspection; [`into_atelier_output`](Self::into_atelier_output) is the
+    /// consuming form SFC assembly uses.
     pub fn atelier_output(&self) -> AtelierOutput {
         AtelierOutput::new(
             self.preamble.clone(),
             String::default(),
             self.code.clone(),
+            String::default(),
+        )
+    }
+
+    /// Consume this result into its [`AtelierOutput`] finishing plate.
+    ///
+    /// The consuming sibling of [`atelier_output`](Self::atelier_output): the
+    /// owned `preamble`/`code` move straight into the imports/functions sections
+    /// with no clone, so SFC assembly builds its output module from the shared
+    /// finish-plate structure (#1758) at zero allocation cost — byte-for-byte
+    /// identical to the previous `{ preamble, code }` positional pairing.
+    pub fn into_atelier_output(self) -> AtelierOutput {
+        AtelierOutput::new(
+            self.preamble,
+            String::default(),
+            self.code,
             String::default(),
         )
     }
@@ -37,6 +54,20 @@ mod tests {
         };
 
         let output = result.atelier_output();
+        assert_eq!(output.imports.as_str(), "import { x } from \"vue\"\n");
+        assert_eq!(output.functions.as_str(), "function ssrRender() {}");
+        assert!(output.hoists.is_empty());
+        assert!(output.exports.is_empty());
+    }
+
+    #[test]
+    fn into_atelier_output_moves_sections_identically() {
+        let result = SsrCodegenResult {
+            code: String::from("function ssrRender() {}"),
+            preamble: String::from("import { x } from \"vue\"\n"),
+        };
+
+        let output = result.into_atelier_output();
         assert_eq!(output.imports.as_str(), "import { x } from \"vue\"\n");
         assert_eq!(output.functions.as_str(), "function ssrRender() {}");
         assert!(output.hoists.is_empty());


### PR DESCRIPTION
Closes the assembly half of #1758. SSR module assembly now flows through the shared `AtelierOutput` finishing plate, so SSR, DOM, and Vapor all assemble on one structure.

## What

- `SsrCodegenResult::into_atelier_output(self)` — consuming sibling of the borrowed `atelier_output()` view (#1790). Moves `preamble → imports` and `code → functions` into the finish plate with **no clone**.
- `OutputModule::from_ssr_codegen` builds its module from those owned sections instead of the bespoke `from_render_chunks(preamble, code)` positional pairing.

## Byte-equivalence

The owned sections move straight through (allocation-equivalent — no extra clone), and the final flatten was already `AtelierOutput`-driven (#1792), so output is byte-identical. Verified:

- `vize_atelier_ssr` — `ssr_snapshot` (76) + `output_plate` unit tests (incl. new `into_atelier_output_moves_sections_identically`)
- `vize_atelier_sfc` (528), `vize_atelier_dom` (23) — no snapshot changes
- `clippy` / `rustfmt` clean

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1798"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->