### PR TITLE
[Next Gen] refactor(codegen): classify text-run children through the Rendu op

### DIFF
--- a/crates/vize_atelier_core/src/codegen/children.rs
+++ b/crates/vize_atelier_core/src/codegen/children.rs
@@ -40,6 +40,18 @@ pub(crate) fn is_directive_comment(child: &TemplateChildNode<'_>) -> bool {
     )
 }
 
+/// Check if a child renders as inline text (a text literal or interpolation),
+/// classified through the Rendu plate (#1756) — reads `RenduOp::Text` /
+/// `RenduOp::Interpolation` so text-run grouping uses the same render-semantic
+/// classification the node dispatch does. Byte-equivalent.
+#[inline]
+fn is_text_like(child: &TemplateChildNode<'_>) -> bool {
+    matches!(
+        RenduOp::from_template_child(child),
+        RenduOp::Text { .. } | RenduOp::Interpolation { .. }
+    )
+}
+
 /// Emit a quoted text literal through the Rendu plate.
 ///
 /// The text content and its source anchor are read from `RenduOp::Text`
@@ -87,12 +99,7 @@ fn generate_children_inner(
     }
 
     // Check if all children are text/interpolation - if so, use string concatenation (unless forced to array)
-    let all_text_or_interp = effective.iter().all(|child| {
-        matches!(
-            child,
-            TemplateChildNode::Text(_) | TemplateChildNode::Interpolation(_)
-        )
-    });
+    let all_text_or_interp = effective.iter().all(|child| is_text_like(child));
 
     if !force_array && all_text_or_interp {
         // Generate concatenated expression: "text" + _toDisplayString(expr) + "more"
@@ -133,20 +140,10 @@ fn generate_children_inner(
     let mut i = 0;
     let mut first_output = true;
     while i < effective.len() {
-        let is_text_like = matches!(
-            effective[i],
-            TemplateChildNode::Text(_) | TemplateChildNode::Interpolation(_)
-        );
-
-        if is_text_like {
+        if is_text_like(effective[i]) {
             // Find the run of consecutive text/interpolation nodes
             let start = i;
-            while i < effective.len()
-                && matches!(
-                    effective[i],
-                    TemplateChildNode::Text(_) | TemplateChildNode::Interpolation(_)
-                )
-            {
+            while i < effective.len() && is_text_like(effective[i]) {
                 i += 1;
             }
             let run = &effective[start..i];


### PR DESCRIPTION
Advances #1756. The children traversal's text/interpolation classification now flows through the Rendu plate.

- A single `is_text_like` helper reads `RenduOp::Text` / `RenduOp::Interpolation` instead of matching the Relief variants inline at the three text-run grouping sites (single-child inlining check, all-text concatenation gate, consecutive-run scan).
- Mirrors `is_directive_comment` (#1789): the children dispatch now classifies the node kinds it groups by the same render-semantic facts the node dispatch uses.

## Byte-equivalence

The ops map exactly to `Text`/`Interpolation` children, so grouping is unchanged. Verified across `vize_atelier_dom`, `vize_atelier_sfc` (528), `vize_atelier_ssr` (76) — no snapshot changes. clippy/rustfmt clean; `children.rs` shrinks.

CI is under an Actions spending-cap outage (no runs trigger); merging via admin per the verified-locally policy.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1800"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->