### PR TITLE
fix(check): surface Corsa tsconfig diagnostics

### DIFF
--- a/crates/vize_canon/src/batch/executor/cli.rs
+++ b/crates/vize_canon/src/batch/executor/cli.rs
@@ -13,6 +13,8 @@ use vize_carton::path::canonicalize_non_verbatim;
 use vize_carton::{FxHashMap, profile};
 use vize_carton::{String, cstr};
 
+mod project_diagnostics;
+
 pub(super) fn check_with_cli(
     corsa_path: &Path,
     project: &VirtualProject,
@@ -525,7 +527,7 @@ fn parse_cli_diagnostics(
         // user-actionable problems — tsc and vue-tsc report them and the
         // runtime may skip the semantic pass because of them — so they are
         // attributed to the project's tsconfig instead of being dropped.
-        if let Some(diagnostic) = parse_global_diagnostic_line(line, project) {
+        if let Some(diagnostic) = project_diagnostics::global(line, project) {
             diagnostics.push(diagnostic);
             continue;
         }
@@ -543,33 +545,6 @@ fn parse_cli_diagnostics(
         last.message.push('\n');
         last.message.push_str(line);
     }
-}
-
-/// Parse a file-less project-level diagnostic such as
-/// `error TS2688: Cannot find type definition file for 'vite/client'.`
-fn parse_global_diagnostic_line(line: &str, project: &VirtualProject) -> Option<Diagnostic> {
-    let (severity, rest) = line.split_once(' ')?;
-    let severity = match severity {
-        "error" => 1,
-        "warning" => 2,
-        "info" => 3,
-        _ => return None,
-    };
-    let (code, message) = rest.split_once(": ")?;
-    let code = code.strip_prefix("TS")?.parse::<u32>().ok()?;
-    if should_skip_diagnostic(Some(code), message) {
-        return None;
-    }
-
-    Some(Diagnostic {
-        file: project.project_diagnostics_anchor(),
-        line: 0,
-        column: 0,
-        message: message.into(),
-        code: Some(code),
-        severity,
-        block_type: None,
-    })
 }
 
 fn parse_cli_diagnostic_line(
@@ -604,6 +579,12 @@ fn parse_cli_diagnostic_line(
     }
 
     let virtual_path = normalize_cli_path(path, project.virtual_root());
+    if let Some(diagnostic) =
+        project_diagnostics::config(&virtual_path, project, message, code, severity)
+    {
+        return Some(diagnostic);
+    }
+
     let original = mapper.map_to_original(&virtual_path, line, column)?;
     if should_skip_original_diagnostic(code, &original) {
         return None;

--- a/crates/vize_canon/src/batch/executor/cli/project_diagnostics.rs
+++ b/crates/vize_canon/src/batch/executor/cli/project_diagnostics.rs
@@ -1,0 +1,70 @@
+use std::path::Path;
+
+use crate::batch::{Diagnostic, VirtualProject};
+
+use super::super::diagnostics::should_skip_diagnostic;
+
+pub(super) fn global(line: &str, project: &VirtualProject) -> Option<Diagnostic> {
+    let (severity, rest) = line.split_once(' ')?;
+    let severity = match severity {
+        "error" => 1,
+        "warning" => 2,
+        "info" => 3,
+        _ => return None,
+    };
+    let (code, message) = rest.split_once(": ")?;
+    let code = code.strip_prefix("TS")?.parse::<u32>().ok()?;
+    if should_skip_diagnostic(Some(code), message) {
+        return None;
+    }
+
+    Some(Diagnostic {
+        file: project.project_diagnostics_anchor(),
+        line: 0,
+        column: 0,
+        message: message.into(),
+        code: Some(code),
+        severity,
+        block_type: None,
+    })
+}
+
+pub(super) fn config(
+    path: &Path,
+    project: &VirtualProject,
+    message: &str,
+    code: Option<u32>,
+    severity: u8,
+) -> Option<Diagnostic> {
+    if !is_project_config_path(path, project) {
+        return None;
+    }
+
+    Some(Diagnostic {
+        file: project.project_diagnostics_anchor(),
+        line: 0,
+        column: 0,
+        message: message.into(),
+        code,
+        severity,
+        block_type: None,
+    })
+}
+
+fn is_project_config_path(path: &Path, project: &VirtualProject) -> bool {
+    let Ok(relative) = path.strip_prefix(project.virtual_root()) else {
+        return false;
+    };
+    if relative.components().count() != 1 {
+        return false;
+    }
+
+    relative
+        .file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| {
+            name == "tsconfig.json"
+                || name == "tsconfig.declaration.json"
+                || (name.starts_with("tsconfig.shard") && name.ends_with(".json"))
+        })
+}

--- a/crates/vize_canon/src/batch/executor/cli/tests.rs
+++ b/crates/vize_canon/src/batch/executor/cli/tests.rs
@@ -208,3 +208,45 @@ fn parses_cli_diagnostics_with_relative_dotdot_paths() {
 
     let _ = fs::remove_dir_all(&case_dir);
 }
+
+#[test]
+fn parses_materialized_tsconfig_diagnostics_as_project_level_errors() {
+    let case_dir = unique_case_dir("diagnostics-tsconfig");
+    let _ = fs::remove_dir_all(&case_dir);
+    let source = case_dir.join("src").join("main.ts");
+    fs::create_dir_all(source.parent().unwrap()).unwrap();
+    fs::write(
+        case_dir.join("tsconfig.json"),
+        r#"{
+  "compilerOptions": {
+    "moduleResolution": "node"
+  },
+  "include": ["src/**/*"]
+}"#,
+    )
+    .unwrap();
+    fs::write(&source, "const value: number = 1;\n").unwrap();
+
+    let mut project = VirtualProject::new(&case_dir).unwrap();
+    project.register_path(&source).unwrap();
+    project.materialize().unwrap();
+
+    let output =
+        "tsconfig.json(5,25): error TS5108: Option 'moduleResolution=node10' has been removed.";
+    let mut diagnostics = Vec::new();
+    let mut mapper = DiagnosticMapper::new(&project);
+    parse_cli_diagnostics(output, &project, &mut mapper, &mut diagnostics);
+
+    assert_eq!(diagnostics.len(), 1);
+    assert_eq!(diagnostics[0].file, case_dir.join("tsconfig.json"));
+    assert_eq!(diagnostics[0].line, 0);
+    assert_eq!(diagnostics[0].column, 0);
+    assert_eq!(diagnostics[0].code, Some(5108));
+    assert_eq!(diagnostics[0].severity, 1);
+    assert!(
+        diagnostics[0].message.contains("moduleResolution=node10"),
+        "{diagnostics:#?}"
+    );
+
+    let _ = fs::remove_dir_all(&case_dir);
+}


### PR DESCRIPTION
## Summary

Fixes #1799.

- Preserve Corsa CLI diagnostics that are attached to the materialized `tsconfig*.json` files instead of dropping them during virtual-source mapping.
- Re-anchor those config diagnostics to the project's effective tsconfig/project diagnostic target so `vize check` reports an error and exits non-zero instead of printing `No type errors found!`.
- Keep the existing over-limit CLI executor file from growing by moving project-level diagnostic parsing into a small helper module.
- Add a regression test for `tsconfig.json(5,25): error TS5108: ...` style diagnostics.

## Root Cause

Corsa config diagnostics such as `TS5108` are emitted as positioned CLI diagnostics against the generated `tsconfig.json`. The CLI parser recognized the line shape, then attempted to map the generated config file through the virtual source map. Because `tsconfig.json` is not a registered virtual source file, the diagnostic was discarded, leaving no reported errors.

## Validation

- `cargo fmt --check`
- `cargo test -p vize_canon batch::executor::cli::tests::parses_materialized_tsconfig_diagnostics_as_project_level_errors`
- `cargo test -p vize_canon batch::executor::cli::tests`
- `cargo test -p vize_canon batch::executor::tests::cli_global_diagnostics_do_not_trigger_session_fallback`
- `node --test --test-concurrency=1 tests/tooling/source-file-lengths.test.ts`

Notes:

- Local end-to-end `cargo run -p vize` verification is blocked in this environment because default `rustc 1.94.1` cannot compile the workspace crate requiring Rust 1.95 syntax.
- Full local `cargo test -p vize_canon` passed 390 tests and failed the existing `batch_type_checker_reports_runtime_emit_object_instance_props_recursion` expectation because the local Corsa run returned no `TS2589` diagnostic.
