### PR TITLE
[Next Gen] refactor(codegen): split node dispatch into dispatch_rendu_op

### DIFF
--- a/crates/vize_atelier_core/src/codegen/node.rs
+++ b/crates/vize_atelier_core/src/codegen/node.rs
@@ -13,13 +13,28 @@ use vize_carton::ToCompactString;
 
 /// Generate node code.
 ///
-/// Dispatch flows through the Rendu render-IR classification
-/// ([`RenduOp::from_template_child`]) rather than matching Relief variants
-/// directly: this is the first seam where DOM codegen consumes Rendu. Output is
-/// byte-for-byte unchanged — the concrete Relief node is still read for the
-/// details Rendu does not yet carry (props, source positions, hoist bodies).
+/// Classifies the node through the Rendu render-IR
+/// ([`RenduOp::from_template_child`]) and dispatches via [`dispatch_rendu_op`].
+/// Output is byte-for-byte unchanged.
 pub fn generate_node(ctx: &mut CodegenContext, node: &TemplateChildNode<'_>) {
-    match RenduOp::from_template_child(node) {
+    dispatch_rendu_op(ctx, RenduOp::from_template_child(node), node);
+}
+
+/// Emit one already-classified Rendu op.
+///
+/// Split from [`generate_node`] so a caller that already holds the op — a child
+/// iterator walking the Rendu stream — can dispatch without re-running
+/// [`RenduOp::from_template_child`]. This is the seam for driving structural
+/// emission from the Rendu op stream (#1756): the concrete Relief `node` is
+/// still read for the details Rendu does not yet carry (element props, hoist
+/// bodies, control-flow subtrees), so output is byte-for-byte identical to
+/// matching the op inline.
+pub(crate) fn dispatch_rendu_op<'a>(
+    ctx: &mut CodegenContext,
+    op: RenduOp<'a>,
+    node: &'a TemplateChildNode<'a>,
+) {
+    match op {
         RenduOp::Element { .. } => {
             if let TemplateChildNode::Element(el) = node {
                 generate_element(ctx, el);


### PR DESCRIPTION
First slice of the structural #1756 work (drive emission from the Rendu op stream).

Extracts the Rendu-op match in `generate_node` into `dispatch_rendu_op(ctx, op, node)`, which emits one **already-classified** op. `generate_node` now classifies via `RenduOp::from_template_child` and delegates.

This is the seam every later structural slice builds on: a child iterator that walks the Rendu stream can dispatch each op without re-running `from_template_child`.

## Byte-equivalence

Pure extraction — output is byte-for-byte identical. Verified across `vize_atelier_dom`, `vize_atelier_sfc` (528), `vize_atelier_ssr` (76); clippy clean.

CI is under an Actions spending-cap outage (no runs trigger); merging via admin per the verified-locally policy.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1803"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->