### PR TITLE
[Next Gen] refactor(codegen): drive Template children from the Rendu op stream

### DIFF
--- a/crates/vize_atelier_core/src/codegen/element/inline.rs
+++ b/crates/vize_atelier_core/src/codegen/element/inline.rs
@@ -5,6 +5,7 @@
 
 use crate::{
     ElementNode, ElementType, ExpressionNode, PropNode, RuntimeHelper,
+    rendu::RenduChildren,
     steps::v_memo::{get_memo_exp, has_v_memo},
 };
 
@@ -14,7 +15,7 @@ use super::{
         context::CodegenContext,
         expression::generate_expression,
         helpers::{is_builtin_component, to_valid_asset_identifier},
-        node::generate_node,
+        node::{dispatch_rendu_op, generate_node},
         patch_flag::{
             calculate_element_patch_info, calculate_element_patch_info_skip_is, patch_flag_name,
         },
@@ -429,21 +430,19 @@ pub fn generate_element(ctx: &mut CodegenContext, el: &ElementNode<'_>) {
             }
         }
         ElementType::Template => {
-            // Template elements render their children directly
-            let filtered: Vec<_> = el
-                .children
-                .iter()
-                .filter(|c| !is_directive_comment(c))
-                .collect();
-            if filtered.len() == 1 {
-                generate_node(ctx, filtered[0]);
+            // Template elements render their children directly, driven by the
+            // Rendu op stream rather than the Relief child list (#1756).
+            let rendered: Vec<_> = RenduChildren::new(&el.children).rendered().collect();
+            if rendered.len() == 1 {
+                let (op, node) = rendered[0];
+                dispatch_rendu_op(ctx, op, node);
             } else {
                 ctx.push("[");
-                for (i, child) in filtered.iter().enumerate() {
+                for (i, &(op, node)) in rendered.iter().enumerate() {
                     if i > 0 {
                         ctx.push(", ");
                     }
-                    generate_node(ctx, child);
+                    dispatch_rendu_op(ctx, op, node);
                 }
                 ctx.push("]");
             }

--- a/crates/vize_atelier_core/src/rendu.rs
+++ b/crates/vize_atelier_core/src/rendu.rs
@@ -6,11 +6,13 @@
 //! another render or flattening pass.
 
 mod capability;
+mod children;
 mod model;
 mod semantic;
 mod walk;
 
 pub use capability::{RenduCapability, VaporPlan, VaporSupport};
+pub use children::RenduChildren;
 pub use model::{RenduElementKind, RenduExprRef, RenduModifiers, RenduSource, RenduSpan};
 pub use semantic::{RenduBlock, RenduCapabilities, RenduOp, RenduRoot};
 pub use walk::{RenduWalkSummary, summarize_rendu_ops, walk_rendu_ops};

--- a/crates/vize_atelier_core/src/rendu/children.rs
+++ b/crates/vize_atelier_core/src/rendu/children.rs
@@ -1,0 +1,43 @@
+//! A borrowed view of a node's children as Rendu ops.
+
+use crate::{TemplateChildNode, rendu::RenduOp};
+
+/// A borrowed, allocation-free view of a node's children as Rendu ops.
+///
+/// Wraps the Relief child slice without copying; iterating yields each child's
+/// [`RenduOp`] paired with the borrowed node, so the emitter can drive child
+/// emission from the Rendu stream while still reaching the Relief node for the
+/// details the op does not yet carry (#1756).
+#[derive(Debug, Clone, Copy)]
+pub struct RenduChildren<'a> {
+    children: &'a [TemplateChildNode<'a>],
+}
+
+impl<'a> RenduChildren<'a> {
+    /// View a borrowed child slice as Rendu ops.
+    pub const fn new(children: &'a [TemplateChildNode<'a>]) -> Self {
+        Self { children }
+    }
+
+    /// Iterate `(op, node)` pairs for the children visible to codegen.
+    ///
+    /// Directive comments (`@vize:`), which never emit, are skipped — exactly
+    /// as the emitter's `is_directive_comment` filter does — so a caller groups
+    /// and separates the same child set it does today.
+    pub fn rendered(self) -> impl Iterator<Item = (RenduOp<'a>, &'a TemplateChildNode<'a>)> {
+        self.children.iter().filter_map(|child| {
+            let op = RenduOp::from_template_child(child);
+            if matches!(
+                op,
+                RenduOp::Comment {
+                    is_directive: true,
+                    ..
+                }
+            ) {
+                None
+            } else {
+                Some((op, child))
+            }
+        })
+    }
+}


### PR DESCRIPTION
Second slice of structural #1756. Introduces the borrowed children view and proves the op-stream emission pattern on the simplest container.

- **`RenduChildren`** (`rendu/children.rs`): a borrowed, allocation-free view of a child slice as Rendu ops. `rendered()` yields `(op, node)` pairs, skipping directive comments exactly as the emitter's `is_directive_comment` filter does.
- The `Template` element arm now iterates `RenduChildren::rendered()` and dispatches each op via `dispatch_rendu_op` (#1803) instead of walking `el.children` + `generate_node`.

## Byte-equivalence & perf

Same child set, order, and dispatch → byte-identical. The view borrows the Relief slice (no allocation beyond the `Vec` the arm already built), and the codegen path is not exercised by the Rendu-construction benchmark. Verified across `vize_atelier_dom`, `vize_atelier_sfc` (528), `vize_atelier_ssr` (76); clippy clean; `inline.rs` shrinks (459→458).

Next slices route `generate_children_inner` and the Component/Slot loops through `RenduChildren`.

CI is under an Actions spending-cap outage; merging via admin per the verified-locally policy.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1804"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->