### PR TITLE
[Next Gen] refactor(codegen): split static-cache emission into children_static

### DIFF
--- a/crates/vize_atelier_core/src/codegen.rs
+++ b/crates/vize_atelier_core/src/codegen.rs
@@ -3,6 +3,7 @@
 //! This module generates JavaScript render function code from the transformed AST.
 
 mod children;
+mod children_static;
 mod context;
 mod element;
 mod emit;

--- a/crates/vize_atelier_core/src/codegen/children.rs
+++ b/crates/vize_atelier_core/src/codegen/children.rs
@@ -1,16 +1,16 @@
 //! Children, text, comment, and interpolation generation functions.
 
 use crate::rendu::RenduOp;
-use crate::steps::hoist_static::is_static_node;
-use crate::{ElementNode, Position, RuntimeHelper, TemplateChildNode, TextNode};
+use crate::{Position, RuntimeHelper, TemplateChildNode, TextNode};
 
+use super::children_static::{
+    generate_cached_static_children_array, generate_cached_static_element,
+    generate_cached_static_vnode, is_static_cacheable_element,
+};
 use super::context::CodegenContext;
-use super::element::helpers::{child_namespace, has_renderable_props};
 use super::helpers::escape_js_string;
 use super::interpolation::push_interpolation_value;
 use super::node::generate_node;
-use super::props::generate_props;
-use vize_carton::ToCompactString;
 
 /// Generate children array
 pub fn generate_children(ctx: &mut CodegenContext, children: &[TemplateChildNode<'_>]) {
@@ -229,92 +229,6 @@ fn generate_children_inner(
     ctx.deindent();
     ctx.newline();
     ctx.push("]");
-}
-
-fn is_static_cacheable_element(child: &TemplateChildNode<'_>) -> bool {
-    matches!(child, TemplateChildNode::Element(_)) && is_static_node(child)
-}
-
-fn generate_cached_static_children_array(
-    ctx: &mut CodegenContext,
-    children: &[&TemplateChildNode<'_>],
-) {
-    let cache_index = ctx.next_cache_index();
-    ctx.push("[...(_cache[");
-    ctx.push(&cache_index.to_compact_string());
-    ctx.push("] || (_cache[");
-    ctx.push(&cache_index.to_compact_string());
-    ctx.push("] = [");
-    ctx.indent();
-
-    for (i, child) in children.iter().enumerate() {
-        if i > 0 {
-            ctx.push(",");
-        }
-        ctx.newline();
-        if let TemplateChildNode::Element(el) = child {
-            generate_cached_static_vnode(ctx, el, true);
-        }
-    }
-
-    ctx.deindent();
-    ctx.newline();
-    ctx.push("]))]");
-}
-
-fn generate_cached_static_element(ctx: &mut CodegenContext, el: &ElementNode<'_>) {
-    let cache_index = ctx.next_cache_index();
-    ctx.push("_cache[");
-    ctx.push(&cache_index.to_compact_string());
-    ctx.push("] || (_cache[");
-    ctx.push(&cache_index.to_compact_string());
-    ctx.push("] = ");
-    generate_cached_static_vnode(ctx, el, true);
-    ctx.push(")");
-}
-
-/// Emit one static element as `createElementVNode(...)`.
-///
-/// `cached` controls whether this vnode is the top-most cached node of a static
-/// subtree (gets the `-1 /* CACHED */` patch flag) or a descendant inside an
-/// already-cached subtree (plain vnode, no flag), matching how
-/// @vue/compiler-core serializes a cached static subtree: a single cache entry
-/// whose children are plain recursive `createElementVNode` calls.
-fn generate_cached_static_vnode(ctx: &mut CodegenContext, el: &ElementNode<'_>, cached: bool) {
-    ctx.use_helper(RuntimeHelper::CreateElementVNode);
-    ctx.push(ctx.helper(RuntimeHelper::CreateElementVNode));
-    ctx.push("(\"");
-    ctx.push(&el.tag);
-    ctx.push("\"");
-
-    if has_renderable_props(el) {
-        ctx.push(", ");
-        ctx.props_is_plain_element = true;
-        generate_props(ctx, &el.props);
-        ctx.props_is_plain_element = false;
-    } else {
-        ctx.push(", null");
-    }
-
-    if !el.children.is_empty() {
-        ctx.push(", ");
-        // Descendants of a cached subtree are emitted as plain vnodes: suppress
-        // the cache wrapper and the per-descendant CACHED flag while recursing.
-        let prev_in_cached = ctx.in_cached_static;
-        ctx.in_cached_static = true;
-        ctx.with_parent_namespace(child_namespace(el), |ctx| {
-            generate_children(ctx, &el.children);
-        });
-        ctx.in_cached_static = prev_in_cached;
-    } else {
-        ctx.push(", null");
-    }
-
-    if cached {
-        ctx.push(", -1 /* CACHED */)");
-    } else {
-        ctx.push(")");
-    }
 }
 
 /// Generate text node

--- a/crates/vize_atelier_core/src/codegen/children_static.rs
+++ b/crates/vize_atelier_core/src/codegen/children_static.rs
@@ -1,0 +1,104 @@
+//! Static-subtree cache emission.
+//!
+//! Emits hoisted `_cache[...]` static vnodes for subtrees the static-hoist pass
+//! marked cacheable. Split out of `children` so the children dispatch stays
+//! focused on grouping and the Rendu op stream.
+
+use crate::steps::hoist_static::is_static_node;
+use crate::{ElementNode, RuntimeHelper, TemplateChildNode};
+
+use super::children::generate_children;
+use super::context::CodegenContext;
+use super::element::helpers::{child_namespace, has_renderable_props};
+use super::props::generate_props;
+use vize_carton::ToCompactString;
+
+pub(crate) fn is_static_cacheable_element(child: &TemplateChildNode<'_>) -> bool {
+    matches!(child, TemplateChildNode::Element(_)) && is_static_node(child)
+}
+
+pub(crate) fn generate_cached_static_children_array(
+    ctx: &mut CodegenContext,
+    children: &[&TemplateChildNode<'_>],
+) {
+    let cache_index = ctx.next_cache_index();
+    ctx.push("[...(_cache[");
+    ctx.push(&cache_index.to_compact_string());
+    ctx.push("] || (_cache[");
+    ctx.push(&cache_index.to_compact_string());
+    ctx.push("] = [");
+    ctx.indent();
+
+    for (i, child) in children.iter().enumerate() {
+        if i > 0 {
+            ctx.push(",");
+        }
+        ctx.newline();
+        if let TemplateChildNode::Element(el) = child {
+            generate_cached_static_vnode(ctx, el, true);
+        }
+    }
+
+    ctx.deindent();
+    ctx.newline();
+    ctx.push("]))]");
+}
+
+pub(crate) fn generate_cached_static_element(ctx: &mut CodegenContext, el: &ElementNode<'_>) {
+    let cache_index = ctx.next_cache_index();
+    ctx.push("_cache[");
+    ctx.push(&cache_index.to_compact_string());
+    ctx.push("] || (_cache[");
+    ctx.push(&cache_index.to_compact_string());
+    ctx.push("] = ");
+    generate_cached_static_vnode(ctx, el, true);
+    ctx.push(")");
+}
+
+/// Emit one static element as `createElementVNode(...)`.
+///
+/// `cached` controls whether this vnode is the top-most cached node of a static
+/// subtree (gets the `-1 /* CACHED */` patch flag) or a descendant inside an
+/// already-cached subtree (plain vnode, no flag), matching how
+/// @vue/compiler-core serializes a cached static subtree: a single cache entry
+/// whose children are plain recursive `createElementVNode` calls.
+pub(crate) fn generate_cached_static_vnode(
+    ctx: &mut CodegenContext,
+    el: &ElementNode<'_>,
+    cached: bool,
+) {
+    ctx.use_helper(RuntimeHelper::CreateElementVNode);
+    ctx.push(ctx.helper(RuntimeHelper::CreateElementVNode));
+    ctx.push("(\"");
+    ctx.push(&el.tag);
+    ctx.push("\"");
+
+    if has_renderable_props(el) {
+        ctx.push(", ");
+        ctx.props_is_plain_element = true;
+        generate_props(ctx, &el.props);
+        ctx.props_is_plain_element = false;
+    } else {
+        ctx.push(", null");
+    }
+
+    if !el.children.is_empty() {
+        ctx.push(", ");
+        // Descendants of a cached subtree are emitted as plain vnodes: suppress
+        // the cache wrapper and the per-descendant CACHED flag while recursing.
+        let prev_in_cached = ctx.in_cached_static;
+        ctx.in_cached_static = true;
+        ctx.with_parent_namespace(child_namespace(el), |ctx| {
+            generate_children(ctx, &el.children);
+        });
+        ctx.in_cached_static = prev_in_cached;
+    } else {
+        ctx.push(", null");
+    }
+
+    if cached {
+        ctx.push(", -1 /* CACHED */)");
+    } else {
+        ctx.push(")");
+    }
+}


### PR DESCRIPTION
Prep for the next structural #1756 slice. Pure code movement — no behavior change.

Moves the static-subtree cache emitters (`is_static_cacheable_element`, `generate_cached_static_children_array`, `generate_cached_static_element`, `generate_cached_static_vnode`) out of `children.rs` into a new `children_static` module, so the children dispatch file stays focused on grouping and the Rendu op stream.

Drops `children.rs` from **351 → 265** lines (back under the source-length guard), making room to route `generate_children_inner` through the Rendu op stream next.

## Byte-equivalence

Pure move. Verified across `vize_atelier_dom`, `vize_atelier_sfc` (528), `vize_atelier_ssr` (76); clippy and rustfmt clean.

CI is under an Actions spending-cap outage; merging via admin per the verified-locally policy.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1805"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->