### PR TITLE
[Next Gen] refactor(codegen): emit Component/Slot child arrays from the Rendu stream

### DIFF
--- a/crates/vize_atelier_core/src/codegen/children.rs
+++ b/crates/vize_atelier_core/src/codegen/children.rs
@@ -1,6 +1,6 @@
 //! Children, text, comment, and interpolation generation functions.
 
-use crate::rendu::RenduOp;
+use crate::rendu::{RenduChildren, RenduOp};
 use crate::{Position, RuntimeHelper, TemplateChildNode, TextNode};
 
 use super::children_static::{
@@ -10,7 +10,7 @@ use super::children_static::{
 use super::context::CodegenContext;
 use super::helpers::escape_js_string;
 use super::interpolation::push_interpolation_value;
-use super::node::generate_node;
+use super::node::{dispatch_rendu_op, generate_node};
 
 /// Generate children array
 pub fn generate_children(ctx: &mut CodegenContext, children: &[TemplateChildNode<'_>]) {
@@ -20,6 +20,27 @@ pub fn generate_children(ctx: &mut CodegenContext, children: &[TemplateChildNode
 /// Generate children, forcing array form with createTextVNode (for withDirectives elements)
 pub fn generate_children_force_array(ctx: &mut CodegenContext, children: &[TemplateChildNode<'_>]) {
     generate_children_inner(ctx, children, true);
+}
+
+/// Emit `,`-separated, newline-prefixed children into an already-open array,
+/// driven by the Rendu op stream (#1756).
+///
+/// The caller emits the surrounding `[` / `]` and manages indentation; each
+/// child is dispatched via [`dispatch_rendu_op`] from its op. Directive
+/// comments are skipped, exactly as the previous `is_directive_comment` filter
+/// did, so component/slot fallback bodies emit the same child set in the same
+/// order.
+pub(crate) fn emit_children_array_body(
+    ctx: &mut CodegenContext,
+    children: &[TemplateChildNode<'_>],
+) {
+    for (i, (op, node)) in RenduChildren::new(children).rendered().enumerate() {
+        if i > 0 {
+            ctx.push(",");
+        }
+        ctx.newline();
+        dispatch_rendu_op(ctx, op, node);
+    }
 }
 
 /// Check if a child node is a directive comment that should be stripped.

--- a/crates/vize_atelier_core/src/codegen/element/inline.rs
+++ b/crates/vize_atelier_core/src/codegen/element/inline.rs
@@ -11,11 +11,11 @@ use crate::{
 
 use super::{
     super::{
-        children::{generate_children, is_directive_comment},
+        children::{emit_children_array_body, generate_children},
         context::CodegenContext,
         expression::generate_expression,
         helpers::{is_builtin_component, to_valid_asset_identifier},
-        node::{dispatch_rendu_op, generate_node},
+        node::dispatch_rendu_op,
         patch_flag::{
             calculate_element_patch_info, calculate_element_patch_info_skip_is, patch_flag_name,
         },
@@ -329,18 +329,7 @@ pub fn generate_element(ctx: &mut CodegenContext, el: &ElementNode<'_>) {
             } else if el.children.iter().any(|c| !is_whitespace_or_comment(c)) {
                 ctx.push(", [");
                 ctx.indent();
-                let filtered: Vec<_> = el
-                    .children
-                    .iter()
-                    .filter(|c| !is_directive_comment(c))
-                    .collect();
-                for (i, child) in filtered.iter().enumerate() {
-                    if i > 0 {
-                        ctx.push(",");
-                    }
-                    ctx.newline();
-                    generate_node(ctx, child);
-                }
+                emit_children_array_body(ctx, &el.children);
                 ctx.deindent();
                 ctx.newline();
                 ctx.push("]");
@@ -404,18 +393,7 @@ pub fn generate_element(ctx: &mut CodegenContext, el: &ElementNode<'_>) {
                 ctx.push(", () => [");
                 ctx.skip_scope_id = prev_skip_scope_id;
                 ctx.indent();
-                let filtered: Vec<_> = el
-                    .children
-                    .iter()
-                    .filter(|c| !is_directive_comment(c))
-                    .collect();
-                for (i, child) in filtered.iter().enumerate() {
-                    if i > 0 {
-                        ctx.push(",");
-                    }
-                    ctx.newline();
-                    generate_node(ctx, child);
-                }
+                emit_children_array_body(ctx, &el.children);
                 ctx.deindent();
                 ctx.newline();
                 ctx.push("])");


### PR DESCRIPTION
Structural #1756 slice 3 (inline.rs portion). Consolidates duplicated child-array loops onto the Rendu op stream.

- New `emit_children_array_body(ctx, children)` walks children as Rendu ops (`RenduChildren`) and dispatches each via `dispatch_rendu_op`.
- The two `inline.rs` sites — the **Component** children array and the **Slot** fallback array — call it instead of collecting a directive-comment-filtered `Vec` and looping `generate_node`.

## Byte-equivalence & perf

Same child set (directive comments skipped), order, and separators → byte-identical. The shared helper drops the per-call `filtered` `Vec` allocation. `inline.rs` shrinks **458 → 436**. Verified across `vize_atelier_dom`, `vize_atelier_sfc` (528), `vize_atelier_ssr` (76); clippy and rustfmt clean.

Follow-up applies the same helper to the `block.rs` component/slot/teleport loops.

CI is under an Actions spending-cap outage; merging via admin per the verified-locally policy.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1806"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->