### PR TITLE
[Next Gen] refactor(codegen): emit block child arrays from the Rendu stream

### DIFF
--- a/crates/vize_atelier_core/src/codegen/element/block.rs
+++ b/crates/vize_atelier_core/src/codegen/element/block.rs
@@ -8,11 +8,10 @@ use crate::{ElementNode, ElementType, ExpressionNode, PropNode, RuntimeHelper};
 
 use super::{
     super::{
-        children::{generate_children, generate_children_force_array, is_directive_comment},
+        children::{emit_children_array_body, generate_children, generate_children_force_array},
         context::CodegenContext,
         expression::generate_expression,
         helpers::{is_builtin_component, to_valid_asset_identifier},
-        node::generate_node,
         patch_flag::{
             calculate_element_patch_info, calculate_element_patch_info_skip_is, patch_flag_name,
         },
@@ -104,18 +103,7 @@ pub fn generate_element_block(ctx: &mut CodegenContext, el: &ElementNode<'_>) {
                 ctx.push(", {}, () => [");
             }
             ctx.indent();
-            let filtered: Vec<_> = el
-                .children
-                .iter()
-                .filter(|c| !is_directive_comment(c))
-                .collect();
-            for (i, child) in filtered.iter().enumerate() {
-                if i > 0 {
-                    ctx.push(",");
-                }
-                ctx.newline();
-                generate_node(ctx, child);
-            }
+            emit_children_array_body(ctx, &el.children);
             ctx.deindent();
             ctx.newline();
             ctx.push("])");
@@ -379,18 +367,7 @@ pub fn generate_element_block(ctx: &mut CodegenContext, el: &ElementNode<'_>) {
                 // (whitespace-only children are skipped to match Vue's behavior)
                 ctx.push(", [");
                 ctx.indent();
-                let filtered: Vec<_> = el
-                    .children
-                    .iter()
-                    .filter(|c| !is_directive_comment(c))
-                    .collect();
-                for (i, child) in filtered.iter().enumerate() {
-                    if i > 0 {
-                        ctx.push(",");
-                    }
-                    ctx.newline();
-                    generate_node(ctx, child);
-                }
+                emit_children_array_body(ctx, &el.children);
                 ctx.deindent();
                 ctx.newline();
                 ctx.push("]");
@@ -457,18 +434,7 @@ pub fn generate_element_block(ctx: &mut CodegenContext, el: &ElementNode<'_>) {
                 }
                 ctx.push(", () => [");
                 ctx.indent();
-                let filtered: Vec<_> = el
-                    .children
-                    .iter()
-                    .filter(|c| !is_directive_comment(c))
-                    .collect();
-                for (i, child) in filtered.iter().enumerate() {
-                    if i > 0 {
-                        ctx.push(",");
-                    }
-                    ctx.newline();
-                    generate_node(ctx, child);
-                }
+                emit_children_array_body(ctx, &el.children);
                 ctx.deindent();
                 ctx.newline();
                 ctx.push("])");


### PR DESCRIPTION
Structural #1756 slice 3 (block.rs portion). Completes the simple child-array conversions.

Applies the shared `emit_children_array_body` (#1806) to the three remaining component/slot/teleport fallback child loops in `block.rs` (slot-outlet fallback, Teleport children array, block slot-outlet fallback). Each now dispatches children from the Rendu op stream instead of collecting a directive-comment-filtered `Vec` and looping `generate_node`.

## Byte-equivalence

Same child set, order, separators → byte-identical. `block.rs` shrinks **501 → 467**; `generate_node` / `is_directive_comment` no longer imported there. Verified across `vize_atelier_dom`, `vize_atelier_sfc` (528), `vize_atelier_ssr` (76); clippy and rustfmt clean.

With this, the Template/Component/Slot/Teleport child arrays across inline.rs and block.rs all emit from the Rendu stream. Remaining: `generate_children_inner` grouping, control flow, and the slots object body.

CI is under an Actions spending-cap outage; merging via admin per the verified-locally policy.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1807"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->