### PR TITLE
[Next Gen] refactor(codegen): emit v-if branch child arrays from the Rendu stream

### DIFF
--- a/crates/vize_atelier_core/src/codegen/v_if/branch.rs
+++ b/crates/vize_atelier_core/src/codegen/v_if/branch.rs
@@ -6,12 +6,13 @@
 use crate::{
     ElementNode, ElementType, ExpressionNode, ForNode, IfBranchNode, PropNode, RuntimeHelper,
     TemplateChildNode,
+    rendu::RenduChildren,
 };
 use vize_carton::ToCompactString;
 
 use super::{
     super::{
-        children::{generate_children_force_array, is_directive_comment},
+        children::generate_children_force_array,
         context::CodegenContext,
         element::{
             generate_custom_directives_closing, generate_vmodel_closing, generate_vshow_closing,
@@ -24,7 +25,7 @@ use super::{
         expression::generate_expression,
         helpers::{escape_js_string, is_builtin_component, to_valid_asset_identifier},
         interpolation::push_interpolation_value,
-        node::generate_node,
+        node::dispatch_rendu_op,
         patch_flag::{
             calculate_element_patch_info, calculate_element_patch_info_skip_is, patch_flag_name,
         },
@@ -122,16 +123,11 @@ fn generate_if_branch_slot(
 
     if !el.children.is_empty() {
         ctx.push(", () => [");
-        let filtered: Vec<_> = el
-            .children
-            .iter()
-            .filter(|c| !is_directive_comment(c))
-            .collect();
-        for (i, child) in filtered.iter().enumerate() {
+        for (i, (op, node)) in RenduChildren::new(&el.children).rendered().enumerate() {
             if i > 0 {
                 ctx.push(",");
             }
-            generate_node(ctx, child);
+            dispatch_rendu_op(ctx, op, node);
         }
         ctx.push("]");
     }
@@ -330,16 +326,11 @@ fn generate_if_branch_component(
     } else if el.children.iter().any(|c| !is_whitespace_or_comment(c)) {
         // Teleport passes children as an array, not a slot object.
         ctx.push(", [");
-        let filtered: Vec<_> = el
-            .children
-            .iter()
-            .filter(|c| !is_directive_comment(c))
-            .collect();
-        for (i, child) in filtered.iter().enumerate() {
+        for (i, (op, node)) in RenduChildren::new(&el.children).rendered().enumerate() {
             if i > 0 {
                 ctx.push(",");
             }
-            generate_node(ctx, child);
+            dispatch_rendu_op(ctx, op, node);
         }
         ctx.push("]");
     } else if has_patch_info {


### PR DESCRIPTION
Structural #1756: routes the v-if branch child-array loops through the Rendu op stream.

The two compact child-array loops in `v_if/branch.rs` (slot-outlet branch fallback, Teleport branch children) now iterate `RenduChildren::rendered()` and dispatch via `dispatch_rendu_op` instead of collecting a directive-comment-filtered `Vec` and looping `generate_node`.

## Byte-equivalence

The compact, no-newline layout is preserved → byte-identical. Drops two `Vec` allocations and the `generate_node` / `is_directive_comment` imports. `branch.rs` shrinks **638 → 629**. Verified across `vize_atelier_dom`, `vize_atelier_sfc` (528), `vize_atelier_ssr` (76); clippy and rustfmt clean.

CI is under an Actions spending-cap outage; merging via admin per the verified-locally policy.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1809"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->