### PR TITLE
[Next Gen] refactor(codegen): emit v-for slot-outlet children from the Rendu stream

### DIFF
--- a/crates/vize_atelier_core/src/codegen/v_for/generate.rs
+++ b/crates/vize_atelier_core/src/codegen/v_for/generate.rs
@@ -5,11 +5,12 @@
 
 use crate::{
     ElementNode, ElementType, ExpressionNode, PropNode, RuntimeHelper, TemplateChildNode,
+    rendu::RenduChildren,
     steps::v_memo::{get_memo_exp, has_v_memo},
 };
 
 use super::super::{
-    children::{generate_children, generate_children_force_array, is_directive_comment},
+    children::{emit_children_array_body, generate_children, generate_children_force_array},
     context::CodegenContext,
     element::helpers::{child_namespace, is_dynamic_component, is_is_prop},
     element::{
@@ -449,13 +450,9 @@ fn generate_for_slot_outlet(ctx: &mut CodegenContext, el: &ElementNode<'_>) {
     generate_slot_outlet_name(ctx, el);
 
     let has_slot_props = has_slot_outlet_props(el);
-    let filtered: Vec<_> = el
-        .children
-        .iter()
-        .filter(|c| !is_directive_comment(c))
-        .collect();
+    let has_rendered_children = RenduChildren::new(&el.children).rendered().next().is_some();
 
-    if !filtered.is_empty() {
+    if has_rendered_children {
         if has_slot_props {
             ctx.push(", ");
             generate_slot_outlet_props(ctx, el);
@@ -464,13 +461,7 @@ fn generate_for_slot_outlet(ctx: &mut CodegenContext, el: &ElementNode<'_>) {
         }
         ctx.push(", () => [");
         ctx.indent();
-        for (i, child) in filtered.iter().enumerate() {
-            if i > 0 {
-                ctx.push(",");
-            }
-            ctx.newline();
-            generate_node(ctx, child);
-        }
+        emit_children_array_body(ctx, &el.children);
         ctx.deindent();
         ctx.newline();
         ctx.push("])");

--- a/crates/vize_atelier_core/src/codegen/v_if/branch.rs
+++ b/crates/vize_atelier_core/src/codegen/v_if/branch.rs
@@ -6,12 +6,13 @@
 use crate::{
     ElementNode, ElementType, ExpressionNode, ForNode, IfBranchNode, PropNode, RuntimeHelper,
     TemplateChildNode,
+    rendu::RenduChildren,
 };
 use vize_carton::ToCompactString;
 
 use super::{
     super::{
-        children::{generate_children_force_array, is_directive_comment},
+        children::generate_children_force_array,
         context::CodegenContext,
         element::{
             generate_custom_directives_closing, generate_vmodel_closing, generate_vshow_closing,
@@ -24,7 +25,7 @@ use super::{
         expression::generate_expression,
         helpers::{escape_js_string, is_builtin_component, to_valid_asset_identifier},
         interpolation::push_interpolation_value,
-        node::generate_node,
+        node::dispatch_rendu_op,
         patch_flag::{
             calculate_element_patch_info, calculate_element_patch_info_skip_is, patch_flag_name,
         },
@@ -122,16 +123,11 @@ fn generate_if_branch_slot(
 
     if !el.children.is_empty() {
         ctx.push(", () => [");
-        let filtered: Vec<_> = el
-            .children
-            .iter()
-            .filter(|c| !is_directive_comment(c))
-            .collect();
-        for (i, child) in filtered.iter().enumerate() {
+        for (i, (op, node)) in RenduChildren::new(&el.children).rendered().enumerate() {
             if i > 0 {
                 ctx.push(",");
             }
-            generate_node(ctx, child);
+            dispatch_rendu_op(ctx, op, node);
         }
         ctx.push("]");
     }
@@ -330,16 +326,11 @@ fn generate_if_branch_component(
     } else if el.children.iter().any(|c| !is_whitespace_or_comment(c)) {
         // Teleport passes children as an array, not a slot object.
         ctx.push(", [");
-        let filtered: Vec<_> = el
-            .children
-            .iter()
-            .filter(|c| !is_directive_comment(c))
-            .collect();
-        for (i, child) in filtered.iter().enumerate() {
+        for (i, (op, node)) in RenduChildren::new(&el.children).rendered().enumerate() {
             if i > 0 {
                 ctx.push(",");
             }
-            generate_node(ctx, child);
+            dispatch_rendu_op(ctx, op, node);
         }
         ctx.push("]");
     } else if has_patch_info {


### PR DESCRIPTION
Structural #1756: routes the last directive-comment-filtered child loop (outside `generate_children_inner`) through the Rendu op stream.

`generate_for_slot_outlet` in `v_for/generate.rs`: the non-empty guard now reads `RenduChildren::rendered()` and the body emits via the shared `emit_children_array_body` instead of collecting a `filtered` `Vec` and looping `generate_node`.

## Byte-equivalence

Same guard, child set, order, and multi-line layout → byte-identical. Drops the `filtered` `Vec` and the `is_directive_comment` import. `generate.rs` shrinks **856 → 847**. Verified across `vize_atelier_dom`, `vize_atelier_sfc` (528), `vize_atelier_ssr` (76); clippy and rustfmt clean.

With this, **every directive-comment-filtered child loop except the grouping inside `generate_children_inner`** emits from the Rendu op stream.

CI is under an Actions spending-cap outage; merging via admin per the verified-locally policy.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1810"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->