### PR TITLE
[Next Gen] refactor(codegen): source children-grouping input from the Rendu stream

### DIFF
--- a/crates/vize_atelier_core/src/codegen/children.rs
+++ b/crates/vize_atelier_core/src/codegen/children.rs
@@ -93,10 +93,11 @@ fn generate_children_inner(
     children: &[TemplateChildNode<'_>],
     force_array: bool,
 ) {
-    // Filter out directive comments — they are invisible to codegen
-    let effective: Vec<&TemplateChildNode<'_>> = children
-        .iter()
-        .filter(|c| !is_directive_comment(c))
+    // Source the children from the Rendu stream; `rendered()` skips directive
+    // comments, which are invisible to codegen (#1756).
+    let effective: Vec<&TemplateChildNode<'_>> = RenduChildren::new(children)
+        .rendered()
+        .map(|(_, node)| node)
         .collect();
 
     if effective.is_empty() {


### PR DESCRIPTION
Structural #1756: `generate_children_inner` now sources its `effective` child set from `RenduChildren::rendered()` (which skips directive comments) instead of an inline `is_directive_comment` filter.

With this, **every directive-comment-filtered child traversal in codegen** — including the children grouping itself — reads its child set from the Rendu children view.

## Byte-equivalence

`rendered()` applies the same directive-comment filter in the same order; the grouping logic over `effective` is unchanged → byte-identical. Verified across `vize_atelier_dom`, `vize_atelier_sfc` (528), `vize_atelier_ssr` (76); clippy and rustfmt clean.

CI is under an Actions spending-cap outage; merging via admin per the verified-locally policy.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1811"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->