### PR TITLE
[Next Gen] refactor: drop the dead RootNode.cached / CacheExpression data path

### DIFF
--- a/crates/vize_atelier_core/src/lane/mod.rs
+++ b/crates/vize_atelier_core/src/lane/mod.rs
@@ -11,15 +11,15 @@ pub mod structural;
 #[path = "../transform/traverse.rs"]
 pub mod traverse;
 
-use vize_carton::{Box, Bump, SmallVec, String, Vec, profile};
+use vize_carton::{Bump, SmallVec, String, Vec, profile};
 use vize_croquis::{Croquis, ScopeChain};
 
 use crate::errors::CompilerError;
 use crate::options::TransformOptions;
 use crate::runtime_helpers::RuntimeHelpers;
 use crate::{
-    CacheExpression, DirectiveNode, ElementNode, ForNode, IfBranchNode, IfNode, JsChildNode,
-    PropNode, RootNode, RuntimeHelper, TemplateChildNode,
+    DirectiveNode, ElementNode, ForNode, IfBranchNode, IfNode, JsChildNode, PropNode, RootNode,
+    RuntimeHelper, TemplateChildNode,
 };
 
 use traverse::traverse_children;
@@ -84,8 +84,6 @@ pub struct TransformContext<'a> {
     pub(crate) filters: std::vec::Vec<String>,
     /// Hoisted expressions
     pub hoists: Vec<'a, Option<JsChildNode<'a>>>,
-    /// Cached expressions
-    pub cached: Vec<'a, Option<Box<'a, CacheExpression<'a>>>>,
     /// Temp variable count
     pub temps: u32,
     /// Scope chain for tracking variable visibility

--- a/crates/vize_atelier_core/src/transform/context.rs
+++ b/crates/vize_atelier_core/src/transform/context.rs
@@ -7,8 +7,8 @@ use vize_croquis::{BindingType, Croquis, ScopeBinding, ScopeKind, VForScopeData,
 use crate::errors::{CompilerError, ErrorCode};
 use crate::options::TransformOptions;
 use crate::{
-    CacheExpression, CommentNode, ConstantType, ExpressionNode, JsChildNode, RuntimeHelper,
-    SimpleExpressionNode, SourceLocation, TemplateChildNode,
+    CommentNode, ConstantType, ExpressionNode, JsChildNode, RuntimeHelper, SimpleExpressionNode,
+    SourceLocation, TemplateChildNode,
 };
 
 use super::TransformContext;
@@ -42,7 +42,6 @@ impl<'a> TransformContext<'a> {
             #[cfg(feature = "legacy")]
             filters: std::vec::Vec::new(),
             hoists: vize_carton::Vec::new_in(allocator),
-            cached: vize_carton::Vec::new_in(allocator),
             temps: 0,
             scope_chain: vize_croquis::ScopeChain::new(),
             scoped_slots: 0,
@@ -417,14 +416,6 @@ impl<'a> TransformContext<'a> {
     pub fn hoist(&mut self, node: JsChildNode<'a>) -> usize {
         let index = self.hoists.len();
         self.hoists.push(Some(node));
-        index
-    }
-
-    /// Cache an expression
-    pub fn cache(&mut self, exp: CacheExpression<'a>) -> usize {
-        let index = self.cached.len();
-        let boxed = Box::new_in(exp, self.allocator);
-        self.cached.push(Some(boxed));
         index
     }
 

--- a/crates/vize_relief/src/relief/nodes.rs
+++ b/crates/vize_relief/src/relief/nodes.rs
@@ -7,7 +7,6 @@ use vize_carton::{Box, Bump, String, Vec};
 
 use super::{
     ForNode, IfBranchNode, IfNode, ImportItem, JsChildNode, RuntimeHelper, TextCallNode,
-    codegen::CacheExpression,
     core::{NodeType, STUB_LOCATION, SourceLocation},
     elements::{CommentNode, ElementNode, InterpolationNode, TextNode},
     expressions::CompoundExpressionNode,
@@ -35,7 +34,6 @@ pub struct RootNode<'a> {
     pub filters: Vec<'a, String>,
     pub hoists: Vec<'a, Option<JsChildNode<'a>>>,
     pub imports: Vec<'a, ImportItem<'a>>,
-    pub cached: Vec<'a, Option<Box<'a, CacheExpression<'a>>>>,
     pub temps: u32,
     pub source: String,
     pub loc: SourceLocation,
@@ -53,7 +51,6 @@ impl<'a> RootNode<'a> {
             filters: Vec::new_in(allocator),
             hoists: Vec::new_in(allocator),
             imports: Vec::new_in(allocator),
-            cached: Vec::new_in(allocator),
             temps: 0,
             source: source.into(),
             loc: SourceLocation::STUB,


### PR DESCRIPTION
Second step of #1760 (move render/codegen IR types out of `vize_relief`).

`RootNode.cached`, `TransformContext.cached`, and `TransformContext::cache()` form a **dead** cache-expression path: `CacheExpression` is never constructed, `cache()` has no callers, and `root.cached` is never read. This removes all three (and the now-unused `CacheExpression` / `Box` imports), keeping the `CacheExpression` *type* (still referenced by the codegen IR enum, which travels in a later step).

## Why

Severs the second of three reverse edges by which `vize_relief` references the render/codegen IR. After this, only `RootNode.hoists` remains.

## Byte-equivalence

Pure dead-code removal. Verified across `vize_atelier_dom`, `vize_atelier_sfc` (528), `vize_atelier_ssr` (76); clippy clean.

CI is under an Actions spending-cap outage; merging via admin per the verified-locally policy.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1813"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->