### PR TITLE
[Next Gen] refactor: carry hoists in TransformResult, off RootNode

### DIFF
--- a/crates/vize_atelier_core/src/codegen/emit.rs
+++ b/crates/vize_atelier_core/src/codegen/emit.rs
@@ -3,7 +3,7 @@
 //! Drives the top-level `generate()` entry point and computes the deduplicated,
 //! import-ranked helper list used to build the module preamble.
 
-use crate::{RootNode, RuntimeHelper, TemplateChildNode, options::CodegenOptions};
+use crate::{JsChildNode, RootNode, RuntimeHelper, TemplateChildNode, options::CodegenOptions};
 use vize_carton::profile;
 
 use super::children::is_directive_comment;
@@ -17,17 +17,26 @@ use super::root::{
 };
 
 /// Generate code from root AST.
-pub fn generate(root: &RootNode<'_>, options: CodegenOptions) -> CodegenResult {
-    generate_with_sections(root, options).into_result()
+pub fn generate(
+    root: &RootNode<'_>,
+    hoists: &[Option<JsChildNode<'_>>],
+    options: CodegenOptions,
+) -> CodegenResult {
+    generate_with_sections(root, hoists, options).into_result()
 }
 
 /// Generate code from root AST and return emission-recorded section boundaries.
+///
+/// `hoists` are the render-IR nodes lifted out by the transform (previously
+/// read from `RootNode.hoists`); they are threaded in explicitly so the source
+/// AST no longer carries the codegen `JsChildNode` type (#1760).
 pub fn generate_with_sections(
     root: &RootNode<'_>,
+    hoists: &[Option<JsChildNode<'_>>],
     options: CodegenOptions,
 ) -> CodegenResultWithSections {
     let mut ctx = CodegenContext::new(options);
-    ctx.static_cache = ctx.options.inline || !root.hoists.is_empty();
+    ctx.static_cache = ctx.options.inline || !hoists.is_empty();
     let root_children: std::vec::Vec<&TemplateChildNode<'_>> = root
         .children
         .iter()
@@ -119,7 +128,7 @@ pub fn generate_with_sections(
     // so helpers used in hoisted VNodes aren't tracked via use_helper(). Pre-scan them here.
     profile!(
         "atelier.codegen.collect_hoist_helpers",
-        collect_hoist_helpers(root, &mut all_helpers)
+        collect_hoist_helpers(hoists, &mut all_helpers)
     );
     all_helper_bits = retain_unique_helpers(&mut all_helpers);
 
@@ -142,7 +151,7 @@ pub fn generate_with_sections(
     let imports_len = preamble.len();
 
     // Generate hoisted variable declarations (appended to preamble)
-    let hoists_code = profile!("atelier.codegen.hoists", generate_hoists(&ctx, root));
+    let hoists_code = profile!("atelier.codegen.hoists", generate_hoists(&ctx, hoists));
     if !hoists_code.is_empty() {
         preamble.push('\n');
         preamble.push_str(&hoists_code);

--- a/crates/vize_atelier_core/src/codegen/generate.rs
+++ b/crates/vize_atelier_core/src/codegen/generate.rs
@@ -4,8 +4,8 @@
 //! VNode calls, props expressions, and children to byte output.
 
 use crate::{
-    DynamicProps, ExpressionNode, JsChildNode, PropsExpression, RootNode, RuntimeHelper,
-    TemplateChildNode, TemplateTextChildNode, VNodeCall, VNodeChildren, VNodeTag,
+    DynamicProps, ExpressionNode, JsChildNode, PropsExpression, RuntimeHelper, TemplateChildNode,
+    TemplateTextChildNode, VNodeCall, VNodeChildren, VNodeTag,
 };
 
 use super::{context::CodegenContext, helpers::escape_js_string};
@@ -13,10 +13,10 @@ use vize_carton::String;
 use vize_carton::ToCompactString;
 
 /// Generate hoisted variable declarations.
-pub(super) fn generate_hoists(ctx: &CodegenContext, root: &RootNode<'_>) -> String {
+pub(super) fn generate_hoists(ctx: &CodegenContext, hoists: &[Option<JsChildNode<'_>>]) -> String {
     let mut hoists_code = String::default();
 
-    for (i, hoist) in root.hoists.iter().enumerate() {
+    for (i, hoist) in hoists.iter().enumerate() {
         if let Some(node) = hoist {
             hoists_code.push_str("const _hoisted_");
             hoists_code.push_str((i + 1).to_compact_string().as_str());
@@ -37,8 +37,11 @@ pub(super) fn generate_hoists(ctx: &CodegenContext, root: &RootNode<'_>) -> Stri
 ///
 /// Since `generate_hoists()` takes `&CodegenContext` (immutable), helpers used in hoisted
 /// VNodes are not tracked via `use_helper()`. This function pre-scans hoists to collect them.
-pub(super) fn collect_hoist_helpers(root: &RootNode<'_>, helpers: &mut Vec<RuntimeHelper>) {
-    for node in root.hoists.iter().flatten() {
+pub(super) fn collect_hoist_helpers(
+    hoists: &[Option<JsChildNode<'_>>],
+    helpers: &mut Vec<RuntimeHelper>,
+) {
+    for node in hoists.iter().flatten() {
         collect_helpers_from_js_child_node(node, helpers);
     }
 }

--- a/crates/vize_atelier_core/src/codegen/tests.rs
+++ b/crates/vize_atelier_core/src/codegen/tests.rs
@@ -57,13 +57,17 @@ fn test_codegen_component_name_with_colon_uses_valid_identifier() {
     );
     assert!(errors.is_empty(), "Parse errors: {:?}", errors);
 
-    crate::lane::transform(
+    let _t = crate::lane::transform(
         &allocator,
         &mut root,
         crate::TransformOptions::default(),
         None,
     );
-    let output = result_output(&super::generate(&root, crate::CodegenOptions::default()));
+    let output = result_output(&super::generate(
+        &root,
+        &_t.hoists,
+        crate::CodegenOptions::default(),
+    ));
 
     // Vue encodes non-word characters by char code (`:` -> 58), matching
     // `toValidAssetId` (issue #4422).
@@ -105,7 +109,7 @@ fn test_codegen_inline_setup_ref_component_prop_uses_value() {
         is_script_setup: true,
     };
 
-    crate::lane::transform(
+    let _t = crate::lane::transform(
         &allocator,
         &mut root,
         crate::TransformOptions {
@@ -119,6 +123,7 @@ fn test_codegen_inline_setup_ref_component_prop_uses_value() {
 
     let output = result_output(&super::generate(
         &root,
+        &_t.hoists,
         crate::CodegenOptions {
             prefix_identifiers: true,
             inline: true,
@@ -199,13 +204,14 @@ fn test_codegen_duplicate_attribute_keeps_first_occurrence() {
         "expected a DuplicateAttribute diagnostic, got {errors:?}"
     );
     assert!(errors.iter().all(|e| e.is_recoverable()));
-    crate::lane::transform(
+    let _t = crate::lane::transform(
         &allocator,
         &mut root,
         crate::options::TransformOptions::default(),
         None,
     );
-    let result = crate::codegen::generate(&root, crate::options::CodegenOptions::default());
+    let result =
+        crate::codegen::generate(&root, &_t.hoists, crate::options::CodegenOptions::default());
     assert!(!result.code.is_empty(), "compiled output must not be empty");
     assert!(
         result.code.contains(r#"id: "a""#),
@@ -478,7 +484,7 @@ fn test_codegen_looped_slot_key_and_index_aliases_stay_local_in_dynamic_args() {
 </Comp>"#,
     );
 
-    transform(
+    let _t = transform(
         &allocator,
         &mut root,
         TransformOptions {
@@ -490,6 +496,7 @@ fn test_codegen_looped_slot_key_and_index_aliases_stay_local_in_dynamic_args() {
 
     let result = super::generate(
         &root,
+        &_t.hoists,
         CodegenOptions {
             prefix_identifiers: true,
             ..Default::default()
@@ -592,7 +599,7 @@ fn test_codegen_v_for_aliases_without_parentheses_stay_local() {
         r#"<div><template v-for="item, index of items" :key="index"><UserCard :user="item" :data-index="index" /></template></div>"#,
     );
 
-    transform(
+    let _t = transform(
         &allocator,
         &mut root,
         TransformOptions {
@@ -604,6 +611,7 @@ fn test_codegen_v_for_aliases_without_parentheses_stay_local() {
 
     let result = super::generate(
         &root,
+        &_t.hoists,
         CodegenOptions {
             prefix_identifiers: true,
             ..Default::default()
@@ -640,7 +648,7 @@ fn test_codegen_v_for_scope_handlers_are_not_cached() {
         r#"<button v-for="tab in tabs" :key="tab.id" @click="select(tab)">{{ tab.label }}</button>"#,
     );
 
-    transform(
+    let _t = transform(
         &allocator,
         &mut root,
         TransformOptions {
@@ -652,6 +660,7 @@ fn test_codegen_v_for_scope_handlers_are_not_cached() {
 
     let result = super::generate(
         &root,
+        &_t.hoists,
         CodegenOptions {
             prefix_identifiers: true,
             cache_handlers: true,
@@ -675,7 +684,7 @@ fn test_codegen_merged_v_on_handlers_are_cached() {
         r#"<div @click="() => x++" @click.stop="() => y++"></div>"#,
     );
 
-    transform(
+    let _t = transform(
         &allocator,
         &mut root,
         TransformOptions {
@@ -687,6 +696,7 @@ fn test_codegen_merged_v_on_handlers_are_cached() {
 
     let result = super::generate(
         &root,
+        &_t.hoists,
         CodegenOptions {
             prefix_identifiers: true,
             cache_handlers: true,
@@ -751,7 +761,7 @@ fn test_codegen_scoped_slot_params_stay_local_in_handlers() {
 </CommonPaginator>"#,
     );
 
-    transform(
+    let _t = transform(
         &allocator,
         &mut root,
         TransformOptions {
@@ -763,6 +773,7 @@ fn test_codegen_scoped_slot_params_stay_local_in_handlers() {
 
     let result = super::generate(
         &root,
+        &_t.hoists,
         CodegenOptions {
             prefix_identifiers: true,
             cache_handlers: true,
@@ -808,7 +819,7 @@ fn compile_prefixed(source: &str) -> vize_carton::String {
     let allocator = bumpalo::Bump::new();
     let (mut root, errors) = crate::parse(&allocator, source);
     assert!(errors.is_empty(), "Parse errors: {:?}", errors);
-    crate::lane::transform(
+    let _t = crate::lane::transform(
         &allocator,
         &mut root,
         crate::TransformOptions {
@@ -819,6 +830,7 @@ fn compile_prefixed(source: &str) -> vize_carton::String {
     );
     result_output(&super::generate(
         &root,
+        &_t.hoists,
         crate::CodegenOptions {
             prefix_identifiers: true,
             ..Default::default()
@@ -916,7 +928,7 @@ fn test_codegen_v1_triple_mustache_is_raw_unescaped() {
     let (mut root, errors) = parse_with_options(&allocator, "<div>{{{ rawHtml }}}</div>", options);
     assert!(errors.is_empty(), "Parse errors: {errors:?}");
 
-    transform(
+    let _t = transform(
         &allocator,
         &mut root,
         TransformOptions {
@@ -925,7 +937,7 @@ fn test_codegen_v1_triple_mustache_is_raw_unescaped() {
         },
         None,
     );
-    let result = super::generate(&root, CodegenOptions::default());
+    let result = super::generate(&root, &_t.hoists, CodegenOptions::default());
 
     // Raw interpolation: the expression is emitted directly, never escaped.
     assert!(
@@ -1042,7 +1054,7 @@ fn compile_with_map(src: &str, filename: &str) -> super::CodegenResult {
     let allocator = bumpalo::Bump::new();
     let (mut root, errors) = crate::parser::parse(&allocator, src);
     assert!(errors.is_empty(), "Parse errors: {:?}", errors);
-    crate::lane::transform(
+    let _t = crate::lane::transform(
         &allocator,
         &mut root,
         crate::options::TransformOptions {
@@ -1053,6 +1065,7 @@ fn compile_with_map(src: &str, filename: &str) -> super::CodegenResult {
     );
     super::generate(
         &root,
+        &_t.hoists,
         crate::options::CodegenOptions {
             prefix_identifiers: true,
             source_map: true,
@@ -1148,7 +1161,7 @@ fn source_map_does_not_alter_generated_code() {
     let allocator = bumpalo::Bump::new();
     let (mut root, errors) = crate::parser::parse(&allocator, src);
     assert!(errors.is_empty(), "Parse errors: {:?}", errors);
-    crate::lane::transform(
+    let _t = crate::lane::transform(
         &allocator,
         &mut root,
         crate::options::TransformOptions {
@@ -1159,6 +1172,7 @@ fn source_map_does_not_alter_generated_code() {
     );
     let without_map = super::generate(
         &root,
+        &_t.hoists,
         crate::options::CodegenOptions {
             prefix_identifiers: true,
             source_map: false,
@@ -1357,7 +1371,7 @@ fn source_map_static_attr_and_text_do_not_alter_generated_code() {
     let allocator = bumpalo::Bump::new();
     let (mut root, errors) = crate::parser::parse(&allocator, src);
     assert!(errors.is_empty(), "Parse errors: {:?}", errors);
-    crate::lane::transform(
+    let _t = crate::lane::transform(
         &allocator,
         &mut root,
         crate::options::TransformOptions {
@@ -1368,6 +1382,7 @@ fn source_map_static_attr_and_text_do_not_alter_generated_code() {
     );
     let without_map = super::generate(
         &root,
+        &_t.hoists,
         crate::options::CodegenOptions {
             prefix_identifiers: true,
             source_map: false,

--- a/crates/vize_atelier_core/src/lane/mod.rs
+++ b/crates/vize_atelier_core/src/lane/mod.rs
@@ -152,6 +152,21 @@ impl<'a> ParentNode<'a> {
     }
 }
 
+/// The output of a transform pass: collected diagnostics and the hoisted
+/// render-IR nodes.
+///
+/// `hoists` was previously stored on `RootNode.hoists`; carrying it here keeps
+/// the render/codegen `JsChildNode` type out of the source AST (#1760). The
+/// `#[must_use]` makes callers thread the hoists into codegen rather than
+/// dropping them, which would silently lose hoisted vnodes.
+#[must_use]
+pub struct TransformResult<'a> {
+    /// Diagnostics collected during the transform.
+    pub errors: std::vec::Vec<CompilerError>,
+    /// Hoisted render-IR nodes, indexed by `TemplateChildNode::Hoisted`.
+    pub hoists: Vec<'a, Option<JsChildNode<'a>>>,
+}
+
 /// Transform the root AST node.
 ///
 /// Returns the diagnostics collected during the transform (e.g. invalid
@@ -162,7 +177,7 @@ pub fn transform<'a>(
     root: &mut RootNode<'a>,
     options: TransformOptions,
     analysis: Option<&'a Croquis>,
-) -> std::vec::Vec<CompilerError> {
+) -> TransformResult<'a> {
     transform_inner(allocator, root, options, analysis, false, None)
 }
 
@@ -172,7 +187,7 @@ pub fn transform_with_template_syntax_quirks<'a>(
     root: &mut RootNode<'a>,
     options: TransformOptions,
     analysis: Option<&'a Croquis>,
-) -> std::vec::Vec<CompilerError> {
+) -> TransformResult<'a> {
     transform_inner(allocator, root, options, analysis, true, None)
 }
 
@@ -183,7 +198,7 @@ pub fn transform_with_vue_parser_quirks<'a>(
     root: &mut RootNode<'a>,
     options: TransformOptions,
     analysis: Option<&'a Croquis>,
-) -> std::vec::Vec<CompilerError> {
+) -> TransformResult<'a> {
     transform_with_template_syntax_quirks(allocator, root, options, analysis)
 }
 
@@ -195,7 +210,7 @@ pub fn transform_with_hoisted_scope_id<'a>(
     options: TransformOptions,
     analysis: Option<&'a Croquis>,
     hoisted_scope_id: Option<String>,
-) -> std::vec::Vec<CompilerError> {
+) -> TransformResult<'a> {
     transform_inner(allocator, root, options, analysis, false, hoisted_scope_id)
 }
 
@@ -207,7 +222,7 @@ pub fn transform_with_template_syntax_quirks_and_hoisted_scope_id<'a>(
     options: TransformOptions,
     analysis: Option<&'a Croquis>,
     hoisted_scope_id: Option<String>,
-) -> std::vec::Vec<CompilerError> {
+) -> TransformResult<'a> {
     transform_inner(allocator, root, options, analysis, true, hoisted_scope_id)
 }
 
@@ -220,7 +235,7 @@ pub fn transform_with_vue_parser_quirks_and_hoisted_scope_id<'a>(
     options: TransformOptions,
     analysis: Option<&'a Croquis>,
     hoisted_scope_id: Option<String>,
-) -> std::vec::Vec<CompilerError> {
+) -> TransformResult<'a> {
     transform_with_template_syntax_quirks_and_hoisted_scope_id(
         allocator,
         root,
@@ -237,7 +252,7 @@ fn transform_inner<'a>(
     analysis: Option<&'a Croquis>,
     template_syntax_quirks: bool,
     hoisted_scope_id: Option<String>,
-) -> std::vec::Vec<CompilerError> {
+) -> TransformResult<'a> {
     let source = root.source.clone();
     let mut ctx = if let Some(analysis) = analysis {
         TransformContext::with_analysis_and_template_syntax_quirks(
@@ -304,14 +319,13 @@ fn transform_inner<'a>(
     for filter in ctx.filters.into_iter() {
         root.filters.push(filter);
     }
-    // Transfer hoisted nodes to root
-    for hoist in ctx.hoists.into_iter() {
-        root.hoists.push(hoist);
-    }
     root.temps = ctx.temps;
     root.transformed = true;
 
-    ctx.errors
+    TransformResult {
+        errors: ctx.errors,
+        hoists: ctx.hoists,
+    }
 }
 
 fn register_root_helpers<'a>(ctx: &mut TransformContext<'a>, root: &mut RootNode<'a>) {

--- a/crates/vize_atelier_core/src/lane/tests.rs
+++ b/crates/vize_atelier_core/src/lane/tests.rs
@@ -28,7 +28,7 @@ fn test_transform_pascal_case_dynamic_component() {
     let (mut root, errors) = parse(&allocator, r#"<Component :is="current" />"#);
     assert!(errors.is_empty(), "Parse errors: {:?}", errors);
 
-    transform(&allocator, &mut root, TransformOptions::default(), None);
+    let _ = transform(&allocator, &mut root, TransformOptions::default(), None);
 
     assert!(
         !root
@@ -62,7 +62,7 @@ fn test_transform_v_for_rejects_unmatched_edge_parens_by_default() {
     let (mut root, errors) = parse(&allocator, r#"<div v-for="item) in items"></div>"#);
     assert!(errors.is_empty(), "Parse errors: {:?}", errors);
 
-    transform(&allocator, &mut root, TransformOptions::default(), None);
+    let _ = transform(&allocator, &mut root, TransformOptions::default(), None);
 
     assert!(
         !matches!(&root.children[0], crate::TemplateChildNode::For(_)),
@@ -76,7 +76,12 @@ fn test_transform_v_for_template_syntax_quirks_accepts_unmatched_edge_parens() {
     let (mut root, errors) = parse(&allocator, r#"<div v-for="item) in items"></div>"#);
     assert!(errors.is_empty(), "Parse errors: {:?}", errors);
 
-    transform_with_template_syntax_quirks(&allocator, &mut root, TransformOptions::default(), None);
+    let _ = transform_with_template_syntax_quirks(
+        &allocator,
+        &mut root,
+        TransformOptions::default(),
+        None,
+    );
 
     match &root.children[0] {
         crate::TemplateChildNode::For(for_node) => match &for_node.value_alias {
@@ -95,7 +100,7 @@ fn test_v_if_creates_if_node() {
     let (mut root, errors) = parse(&allocator, r#"<div v-if="show">visible</div>"#);
     assert!(errors.is_empty(), "Parse errors: {:?}", errors);
 
-    transform(&allocator, &mut root, TransformOptions::default(), None);
+    let _ = transform(&allocator, &mut root, TransformOptions::default(), None);
 
     // After transform, root should have 1 child: an IfNode
     assert_eq!(
@@ -124,7 +129,7 @@ fn test_v_if_else_creates_branches() {
     );
     assert!(errors.is_empty(), "Parse errors: {:?}", errors);
 
-    transform(&allocator, &mut root, TransformOptions::default(), None);
+    let _ = transform(&allocator, &mut root, TransformOptions::default(), None);
 
     // After transform, should have 1 IfNode with 2 branches
     assert_eq!(
@@ -161,7 +166,7 @@ fn test_v_for_creates_for_node() {
     let (mut root, errors) = parse(&allocator, r#"<div v-for="item in items">{{ item }}</div>"#);
     assert!(errors.is_empty(), "Parse errors: {:?}", errors);
 
-    transform(&allocator, &mut root, TransformOptions::default(), None);
+    let _ = transform(&allocator, &mut root, TransformOptions::default(), None);
 
     // After transform, root should have 1 child: a ForNode
     assert_eq!(
@@ -196,8 +201,8 @@ fn test_v_for_creates_for_node() {
 fn test_codegen_v_if() {
     let allocator = Bump::new();
     let (mut root, _) = parse(&allocator, r#"<div v-if="show">visible</div>"#);
-    transform(&allocator, &mut root, TransformOptions::default(), None);
+    let _t = transform(&allocator, &mut root, TransformOptions::default(), None);
 
-    let result = generate(&root, CodegenOptions::default());
+    let result = generate(&root, &_t.hoists, CodegenOptions::default());
     insta::assert_snapshot!(result.code.as_str());
 }

--- a/crates/vize_atelier_core/src/rendu/walk.rs
+++ b/crates/vize_atelier_core/src/rendu/walk.rs
@@ -215,7 +215,7 @@ mod tests {
         );
         assert!(errors.is_empty());
         let diagnostics = transform(bump, &mut root, TransformOptions::default(), None);
-        assert!(diagnostics.is_empty());
+        assert!(diagnostics.errors.is_empty());
 
         let mut for_aliases = None;
         walk_rendu_ops(&root, |op| {
@@ -250,7 +250,7 @@ mod tests {
         let (mut root, errors) = parse(bump, "<div v-if=\"ok\">A</div><p v-else>B</p>");
         assert!(errors.is_empty());
         let diagnostics = transform(bump, &mut root, TransformOptions::default(), None);
-        assert!(diagnostics.is_empty());
+        assert!(diagnostics.errors.is_empty());
 
         let mut has_if = false;
         let mut branches = 0;

--- a/crates/vize_atelier_core/src/test_macros.rs
+++ b/crates/vize_atelier_core/src/test_macros.rs
@@ -209,7 +209,7 @@ macro_rules! assert_transform {
         let allocator = bumpalo::Bump::new();
         let (mut root, errors) = $crate::parser::parse(&allocator, $input);
         assert!(errors.is_empty(), "Parse errors: {:?}", errors);
-        $crate::lane::transform(&allocator, &mut root, $crate::options::TransformOptions::default(), None);
+        let _ = $crate::lane::transform(&allocator, &mut root, $crate::options::TransformOptions::default(), None);
         assert!(root.transformed, "Expected root to be transformed");
         $(
             assert!(
@@ -223,7 +223,7 @@ macro_rules! assert_transform {
         let allocator = bumpalo::Bump::new();
         let (mut root, errors) = $crate::parser::parse(&allocator, $input);
         assert!(errors.is_empty(), "Parse errors: {:?}", errors);
-        $crate::lane::transform(&allocator, &mut root, $crate::options::TransformOptions::default(), None);
+        let _ = $crate::lane::transform(&allocator, &mut root, $crate::options::TransformOptions::default(), None);
         $(
             assert!(
                 root.components.iter().any(|c| c.as_str() == $comp),
@@ -272,13 +272,17 @@ macro_rules! assert_codegen {
         let allocator = bumpalo::Bump::new();
         let (mut root, errors) = $crate::parser::parse(&allocator, $input);
         assert!(errors.is_empty(), "Parse errors: {:?}", errors);
-        $crate::lane::transform(
+        let __transformed = $crate::lane::transform(
             &allocator,
             &mut root,
             $crate::options::TransformOptions::default(),
             None,
         );
-        let result = $crate::codegen::generate(&root, $crate::options::CodegenOptions::default());
+        let result = $crate::codegen::generate(
+            &root,
+            &__transformed.hoists,
+            $crate::options::CodegenOptions::default(),
+        );
         insta::assert_snapshot!(result.code.as_str());
         result
     }};
@@ -291,26 +295,30 @@ macro_rules! compile {
         let allocator = bumpalo::Bump::new();
         let (mut root, errors) = $crate::parser::parse(&allocator, $input);
         assert!(errors.is_empty(), "Parse errors: {:?}", errors);
-        $crate::lane::transform(
+        let __transformed = $crate::lane::transform(
             &allocator,
             &mut root,
             $crate::options::TransformOptions::default(),
             None,
         );
-        $crate::codegen::generate(&root, $crate::options::CodegenOptions::default())
+        $crate::codegen::generate(
+            &root,
+            &__transformed.hoists,
+            $crate::options::CodegenOptions::default(),
+        )
     }};
 
     ($input:expr, $options:expr) => {{
         let allocator = bumpalo::Bump::new();
         let (mut root, errors) = $crate::parser::parse(&allocator, $input);
         assert!(errors.is_empty(), "Parse errors: {:?}", errors);
-        $crate::lane::transform(
+        let __transformed = $crate::lane::transform(
             &allocator,
             &mut root,
             $crate::options::TransformOptions::default(),
             None,
         );
-        $crate::codegen::generate(&root, $options)
+        $crate::codegen::generate(&root, &__transformed.hoists, $options)
     }};
 }
 

--- a/crates/vize_atelier_core/src/transforms/hoist_static.rs
+++ b/crates/vize_atelier_core/src/transforms/hoist_static.rs
@@ -867,8 +867,9 @@ mod tests {
         let (mut root, _errors) = parse(&allocator, src);
         let mut opts = crate::options::TransformOptions::default();
         opts.hoist_static = true;
-        crate::lane::transform(&allocator, &mut root, opts, None);
-        let r = crate::codegen::generate(&root, crate::options::CodegenOptions::default());
+        let _t = crate::lane::transform(&allocator, &mut root, opts, None);
+        let r =
+            crate::codegen::generate(&root, &_t.hoists, crate::options::CodegenOptions::default());
         (r.preamble.to_string(), r.code.to_string())
     }
 

--- a/crates/vize_atelier_core/src/transforms/legacy.rs
+++ b/crates/vize_atelier_core/src/transforms/legacy.rs
@@ -319,8 +319,8 @@ mod tests {
             dialect,
             ..Default::default()
         };
-        transform(&allocator, &mut root, opts, None);
-        generate(&root, CodegenOptions::default())
+        let transformed = transform(&allocator, &mut root, opts, None);
+        generate(&root, &transformed.hoists, CodegenOptions::default())
             .code
             .as_str()
             .to_owned()

--- a/crates/vize_atelier_core/tests/legacy_event_modifiers.rs
+++ b/crates/vize_atelier_core/tests/legacy_event_modifiers.rs
@@ -28,13 +28,13 @@ fn compile(input: &str, dialect: VueVersion) -> String {
         dialect,
         ..Default::default()
     };
-    lane::transform(&allocator, &mut root, transform_opts, None);
+    let _t = lane::transform(&allocator, &mut root, transform_opts, None);
 
     let codegen_opts = CodegenOptions {
         prefix_identifiers: true,
         ..Default::default()
     };
-    let result = codegen::generate(&root, codegen_opts);
+    let result = codegen::generate(&root, &_t.hoists, codegen_opts);
     let mut out = String::with_capacity(result.preamble.len() + result.code.len() + 1);
     out.push_str(result.preamble.as_str());
     out.push('\n');

--- a/crates/vize_atelier_core/tests/legacy_filters.rs
+++ b/crates/vize_atelier_core/tests/legacy_filters.rs
@@ -28,13 +28,13 @@ fn compile(input: &str, dialect: VueVersion) -> String {
         dialect,
         ..Default::default()
     };
-    lane::transform(&allocator, &mut root, transform_opts, None);
+    let _t = lane::transform(&allocator, &mut root, transform_opts, None);
 
     let codegen_opts = CodegenOptions {
         prefix_identifiers: true,
         ..Default::default()
     };
-    let result = codegen::generate(&root, codegen_opts);
+    let result = codegen::generate(&root, &_t.hoists, codegen_opts);
     let mut out = String::with_capacity(result.preamble.len() + result.code.len() + 1);
     out.push_str(result.preamble.as_str());
     out.push('\n');

--- a/crates/vize_atelier_core/tests/legacy_template_sugar.rs
+++ b/crates/vize_atelier_core/tests/legacy_template_sugar.rs
@@ -28,13 +28,13 @@ fn compile(input: &str, dialect: VueVersion) -> String {
         dialect,
         ..Default::default()
     };
-    lane::transform(&allocator, &mut root, transform_opts, None);
+    let _t = lane::transform(&allocator, &mut root, transform_opts, None);
 
     let codegen_opts = CodegenOptions {
         prefix_identifiers: true,
         ..Default::default()
     };
-    let result = codegen::generate(&root, codegen_opts);
+    let result = codegen::generate(&root, &_t.hoists, codegen_opts);
     let mut out = String::with_capacity(result.preamble.len() + result.code.len() + 1);
     out.push_str(result.preamble.as_str());
     out.push('\n');

--- a/crates/vize_atelier_dom/src/compile.rs
+++ b/crates/vize_atelier_dom/src/compile.rs
@@ -253,7 +253,7 @@ fn compile_template_inner_with_sections<'a>(
     // parse errors instead of dropping them — the official compiler reports
     // both through the same `errors` channel.
     let mut errors = errors.to_vec();
-    errors.extend(transform_errors);
+    errors.extend(transform_errors.errors);
 
     // Codegen
     let codegen_opts = CodegenOptions {
@@ -270,7 +270,7 @@ fn compile_template_inner_with_sections<'a>(
     };
     let codegen_result = profile!(
         "atelier.dom.template.codegen",
-        generate_with_sections(&root, codegen_opts)
+        generate_with_sections(&root, &transform_errors.hoists, codegen_opts)
     );
 
     (root, errors, codegen_result)

--- a/crates/vize_atelier_jsx/src/vapor.rs
+++ b/crates/vize_atelier_jsx/src/vapor.rs
@@ -141,7 +141,7 @@ pub(crate) fn compile_root_to_vapor(
         binding_metadata: None,
         ..Default::default()
     };
-    transform(bump, &mut root, transform_opts, Some(analysis));
+    let _ = transform(bump, &mut root, transform_opts, Some(analysis));
 
     let ir = transform_to_ir(bump, &root);
     let generated =
@@ -202,7 +202,7 @@ fn compile_root_to_vapor_ssr<'a>(
         binding_metadata: None,
         ..Default::default()
     };
-    transform(bump, &mut root, transform_opts, Some(analysis));
+    let _ = transform(bump, &mut root, transform_opts, Some(analysis));
 
     // The scope id is already embedded in the SSR options so `ssrRender` emits
     // the `data-v-<hash>` attribute inline, matching the SFC SSR scope path

--- a/crates/vize_atelier_jsx/src/vdom.rs
+++ b/crates/vize_atelier_jsx/src/vdom.rs
@@ -150,8 +150,8 @@ pub(crate) fn compile_root_to_vdom(
         binding_metadata: None,
         ..Default::default()
     };
-    let errors = transform(bump, &mut root, transform_opts, Some(analysis));
-    diagnostics.extend(errors.iter().map(compiler_error_to_diagnostic));
+    let transformed = transform(bump, &mut root, transform_opts, Some(analysis));
+    diagnostics.extend(transformed.errors.iter().map(compiler_error_to_diagnostic));
 
     let codegen_opts = CodegenOptions {
         mode: CodegenMode::Module,
@@ -165,7 +165,7 @@ pub(crate) fn compile_root_to_vdom(
         scope_id: scoped_style.as_ref().map(|style| style.scope_id.clone()),
         ..Default::default()
     };
-    let result = generate(&root, codegen_opts);
+    let result = generate(&root, &transformed.hoists, codegen_opts);
 
     VdomComponent {
         component_name,

--- a/crates/vize_atelier_ssr/src/lib.rs
+++ b/crates/vize_atelier_ssr/src/lib.rs
@@ -150,7 +150,9 @@ fn compile_ssr_inner<'a>(
     // parse errors instead of dropping them — same channel as the DOM
     // compiler.
     let mut errors = errors.to_vec();
-    errors.extend(transform_errors);
+    // SSR runs its own codegen (no shared hoists), so only the diagnostics are
+    // threaded; the transform's hoists are unused here (#1760).
+    errors.extend(transform_errors.errors);
 
     // SSR codegen
     let codegen_ctx = SsrCodegenContext::new(allocator, &codegen_options);

--- a/crates/vize_atelier_vapor/src/compile.rs
+++ b/crates/vize_atelier_vapor/src/compile.rs
@@ -143,11 +143,13 @@ fn compile_vapor_inner<'a>(
         custom_renderer: options.custom_renderer,
         ..Default::default()
     };
-    if template_syntax.is_quirks() {
-        transform_with_template_syntax_quirks(allocator, &mut root, transform_opts, None);
+    // Vapor lowers its own IR and does not use the shared hoists, so the
+    // transform result (diagnostics + hoists) is intentionally dropped (#1760).
+    let _ = if template_syntax.is_quirks() {
+        transform_with_template_syntax_quirks(allocator, &mut root, transform_opts, None)
     } else {
-        transform(allocator, &mut root, transform_opts, None);
-    }
+        transform(allocator, &mut root, transform_opts, None)
+    };
 
     // Lower to Vapor IR
     let (ir, transform_diagnostics) =

--- a/crates/vize_relief/src/relief/nodes.rs
+++ b/crates/vize_relief/src/relief/nodes.rs
@@ -6,7 +6,7 @@
 use vize_carton::{Box, Bump, String, Vec};
 
 use super::{
-    ForNode, IfBranchNode, IfNode, ImportItem, JsChildNode, RuntimeHelper, TextCallNode,
+    ForNode, IfBranchNode, IfNode, ImportItem, RuntimeHelper, TextCallNode,
     core::{NodeType, STUB_LOCATION, SourceLocation},
     elements::{CommentNode, ElementNode, InterpolationNode, TextNode},
     expressions::CompoundExpressionNode,
@@ -32,7 +32,6 @@ pub struct RootNode<'a> {
     /// feature heuristic skips `_`-prefixed features — byte-identical.
     #[cfg(feature = "_legacy")]
     pub filters: Vec<'a, String>,
-    pub hoists: Vec<'a, Option<JsChildNode<'a>>>,
     pub imports: Vec<'a, ImportItem<'a>>,
     pub temps: u32,
     pub source: String,
@@ -49,7 +48,6 @@ impl<'a> RootNode<'a> {
             directives: Vec::new_in(allocator),
             #[cfg(feature = "_legacy")]
             filters: Vec::new_in(allocator),
-            hoists: Vec::new_in(allocator),
             imports: Vec::new_in(allocator),
             temps: 0,
             source: source.into(),

--- a/tests/vize_test_runner/src/lib.rs
+++ b/tests/vize_test_runner/src/lib.rs
@@ -223,7 +223,7 @@ pub fn compile_vdom(input: &str, options: &TestOptions) -> String {
         ssr: options.ssr.unwrap_or(false),
         ..Default::default()
     };
-    transform(&allocator, &mut root, transform_opts, None);
+    let transformed = transform(&allocator, &mut root, transform_opts, None);
 
     let codegen_opts = CodegenOptions {
         mode: CodegenMode::Module,
@@ -231,7 +231,7 @@ pub fn compile_vdom(input: &str, options: &TestOptions) -> String {
         cache_handlers: options.cache_handlers.unwrap_or(false),
         ..Default::default()
     };
-    let result = generate(&root, codegen_opts);
+    let result = generate(&root, &transformed.hoists, codegen_opts);
 
     // Combine preamble and code like Vue does
     let preamble = result.preamble.trim();


### PR DESCRIPTION
Third step of #1760, severing the **last** reverse edge by which `vize_relief` references the render/codegen IR: `RootNode.hoists: Vec<Option<JsChildNode>>`.

The hoists are a codegen artifact (produced by the static-hoist transform, consumed only by codegen) — `RootNode` was merely the carrier, and both endpoints already live in `vize_atelier_core`.

## What

- `transform()` + variants return `TransformResult<'a> { errors, hoists }` instead of writing `root.hoists`. `#[must_use]` ensures callers thread the hoists rather than silently dropping them (the safety net that made this rewire compile-checked across ~20 call sites).
- `generate` / `generate_with_sections` take an explicit `hoists` slice; `generate_hoists` / `collect_hoist_helpers` read it.
- **`RootNode.hoists` removed** → `vize_relief` no longer names any render/codegen type. This unblocks moving `JsChildNode` & friends out of `vize_relief` (the final #1760 step).
- Callers thread the hoists (DOM), or discard where unused (SSR/Vapor run their own codegen).

## Byte-equivalence

Same hoist nodes, same serializers — only the carrier changed (and the transform→codegen copy loop is dropped, one fewer arena `Vec`/compile). Verified across `vize_atelier_dom`, `vize_atelier_sfc` (528), `vize_atelier_ssr` (76), `vize_atelier_core` (261); clippy clean.

CI is under an Actions spending-cap outage; merging via admin per the verified-locally policy.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1815"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->