### PR TITLE
[Next Gen] refactor(codegen): dispatch inline element emission on RenduElementKind

### DIFF
--- a/crates/vize_atelier_core/src/codegen/element/inline.rs
+++ b/crates/vize_atelier_core/src/codegen/element/inline.rs
@@ -5,7 +5,7 @@
 
 use crate::{
     ElementNode, ElementType, ExpressionNode, PropNode, RuntimeHelper,
-    rendu::RenduChildren,
+    rendu::{RenduChildren, RenduElementKind},
     steps::v_memo::{get_memo_exp, has_v_memo},
 };
 
@@ -85,8 +85,8 @@ pub fn generate_element(ctx: &mut CodegenContext, el: &ElementNode<'_>) {
         None
     };
 
-    match el.tag_type {
-        ElementType::Element => {
+    match RenduElementKind::from(el.tag_type) {
+        RenduElementKind::Element => {
             // Check for custom directives.
             // Inline children need the same withDirectives wrapping as block roots.
             let has_custom_dirs = has_custom_directives(el);
@@ -196,7 +196,7 @@ pub fn generate_element(ctx: &mut CodegenContext, el: &ElementNode<'_>) {
                 generate_vshow_closing(ctx, el);
             }
         }
-        ElementType::Component => {
+        RenduElementKind::Component => {
             let has_custom_dirs = has_custom_directives(el);
             if has_custom_dirs {
                 ctx.use_helper(RuntimeHelper::WithDirectives);
@@ -370,7 +370,7 @@ pub fn generate_element(ctx: &mut CodegenContext, el: &ElementNode<'_>) {
                 generate_vshow_closing(ctx, el);
             }
         }
-        ElementType::Slot => {
+        RenduElementKind::SlotOutlet => {
             let helper = ctx.helper(RuntimeHelper::RenderSlot);
             ctx.use_helper(RuntimeHelper::RenderSlot);
             ctx.push(helper);
@@ -407,7 +407,7 @@ pub fn generate_element(ctx: &mut CodegenContext, el: &ElementNode<'_>) {
                 ctx.push(")");
             }
         }
-        ElementType::Template => {
+        RenduElementKind::Template => {
             // Template elements render their children directly, driven by the
             // Rendu op stream rather than the Relief child list (#1756).
             let rendered: Vec<_> = RenduChildren::new(&el.children).rendered().collect();


### PR DESCRIPTION
Advances #1756. The inline element emitter's top-level dispatch matches on `RenduElementKind` (the render-semantic kind) via `RenduElementKind::from(el.tag_type)` instead of the Relief `ElementType` — element emission now selects its arm by the same render-semantic classification the node/children dispatch already use.

## Byte-equivalence

`RenduElementKind` maps 1:1 from `ElementType` (Element / Component / SlotOutlet / Template). Net-neutral (no line growth). Verified across `vize_atelier_dom`, `vize_atelier_sfc` (528), `vize_atelier_ssr` (76); clippy and rustfmt clean.

CI is under an Actions spending-cap outage; merging via admin per the verified-locally policy.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1818"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->