### PR TITLE
[Next Gen] refactor(codegen): dispatch block element emission on RenduElementKind

### DIFF
--- a/crates/vize_atelier_core/src/codegen/element/block.rs
+++ b/crates/vize_atelier_core/src/codegen/element/block.rs
@@ -4,7 +4,7 @@
 //! `createElementBlock()` / `createBlock()` for efficient patching.
 
 use crate::steps::v_memo::{get_memo_exp, has_v_memo};
-use crate::{ElementNode, ElementType, ExpressionNode, PropNode, RuntimeHelper};
+use crate::{ElementNode, ExpressionNode, PropNode, RuntimeHelper, rendu::RenduElementKind};
 
 use super::{
     super::{
@@ -86,7 +86,7 @@ pub fn generate_element_block(ctx: &mut CodegenContext, el: &ElementNode<'_>) {
     }
 
     // Slots are not blocks - handle them separately
-    if el.tag_type == ElementType::Slot {
+    if RenduElementKind::from(el.tag_type).is_slot_outlet() {
         let helper = ctx.helper(RuntimeHelper::RenderSlot);
         ctx.use_helper(RuntimeHelper::RenderSlot);
         ctx.push(helper);
@@ -125,7 +125,8 @@ pub fn generate_element_block(ctx: &mut CodegenContext, el: &ElementNode<'_>) {
     }
 
     // v-memo on components: use createVNode without block wrapper
-    let is_memo_component = memo_cache_index.is_some() && el.tag_type == ElementType::Component;
+    let is_memo_component =
+        memo_cache_index.is_some() && RenduElementKind::from(el.tag_type).is_component();
 
     if !is_memo_component {
         // Track helpers for preamble
@@ -137,8 +138,8 @@ pub fn generate_element_block(ctx: &mut CodegenContext, el: &ElementNode<'_>) {
         ctx.push("(), ");
     }
 
-    match el.tag_type {
-        ElementType::Element => {
+    match RenduElementKind::from(el.tag_type) {
+        RenduElementKind::Element => {
             ctx.use_helper(RuntimeHelper::CreateElementBlock);
             ctx.push(ctx.helper(RuntimeHelper::CreateElementBlock));
             ctx.push("(\"");
@@ -237,7 +238,7 @@ pub fn generate_element_block(ctx: &mut CodegenContext, el: &ElementNode<'_>) {
                 generate_vshow_closing(ctx, el);
             }
         }
-        ElementType::Component => {
+        RenduElementKind::Component => {
             if is_memo_component {
                 ctx.use_helper(RuntimeHelper::CreateVNode);
                 ctx.push(ctx.helper(RuntimeHelper::CreateVNode));
@@ -415,7 +416,7 @@ pub fn generate_element_block(ctx: &mut CodegenContext, el: &ElementNode<'_>) {
                 generate_vshow_closing(ctx, el);
             }
         }
-        ElementType::Slot => {
+        RenduElementKind::SlotOutlet => {
             // Slots don't use blocks - use renderSlot directly
             let helper = ctx.helper(RuntimeHelper::RenderSlot);
             ctx.use_helper(RuntimeHelper::RenderSlot);
@@ -446,7 +447,7 @@ pub fn generate_element_block(ctx: &mut CodegenContext, el: &ElementNode<'_>) {
                 ctx.push(")");
             }
         }
-        ElementType::Template => {
+        RenduElementKind::Template => {
             ctx.use_helper(RuntimeHelper::CreateElementBlock);
             ctx.use_helper(RuntimeHelper::Fragment);
             ctx.push(ctx.helper(RuntimeHelper::CreateElementBlock));


### PR DESCRIPTION
Advances #1756, mirroring #1818 for the block emitter. The block element emitter now classifies through `RenduElementKind`: top-level dispatch on `RenduElementKind::from(el.tag_type)`, and the slot-outlet / memo-component checks via `is_slot_outlet()` / `is_component()`. `ElementType` is no longer referenced in `block.rs`.

## Byte-equivalence

`RenduElementKind` maps 1:1 from `ElementType`. Verified across `vize_atelier_dom`, `vize_atelier_sfc` (528), `vize_atelier_ssr` (76); clippy and rustfmt clean.

With this, both element emitters (inline + block) dispatch on the render-semantic kind.

CI is under an Actions spending-cap outage; merging via admin per the verified-locally policy.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1819"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->