### PR TITLE
[Next Gen] fix(atelier): complete the render_ir relocation imports

### DIFF
--- a/crates/vize_atelier_core/src/lib.rs
+++ b/crates/vize_atelier_core/src/lib.rs
@@ -15,6 +15,8 @@
 pub mod atelier_output;
 pub mod codegen;
 #[doc(hidden)]
+pub mod render_ir;
+#[doc(hidden)]
 pub mod rendu;
 pub mod runtime_helpers;
 #[doc(hidden)]
@@ -32,19 +34,22 @@ pub use vize_relief::options::{
     BindingMetadata, BindingType, CodegenMode, CodegenOptions, CompilerOptions, ParseMode,
     ParserOptions, TemplateSyntaxMode, TextMode, TransformOptions, WhitespaceStrategy,
 };
+// Render/codegen IR types — relocated out of vize_relief into this crate (#1760).
+pub use render_ir::{
+    ArrayElement, ArrayExpression, AssignmentExpression, BlockStatement, BlockStatementBody,
+    CacheExpression, CallArgument, CallExpression, Callee, ConditionalExpression,
+    DirectiveArgumentNode, DirectiveArguments, DynamicProps, FunctionBody, FunctionExpression,
+    FunctionParam, FunctionParams, FunctionReturns, IfStatement, IfStatementAlternate, JsChildNode,
+    ObjectExpression, Property, PropsExpression, ReturnStatement, ReturnValue, SequenceExpression,
+    SlotsExpression, TemplateLiteral, TemplateLiteralElement, TemplateTextChildNode, VNodeCall,
+    VNodeChildren, VNodeTag,
+};
 pub use vize_relief::{
-    ArrayElement, ArrayExpression, AssignmentExpression, AttributeNode, BlockStatement,
-    BlockStatementBody, CacheExpression, CallArgument, CallExpression, Callee, CommentNode,
-    CompoundExpressionChild, CompoundExpressionNode, ConditionalExpression, ConstantType,
-    DirectiveArgumentNode, DirectiveArguments, DirectiveNode, DynamicProps, ElementNode,
-    ElementType, ExpressionNode, ForNode, ForParseResult, FunctionBody, FunctionExpression,
-    FunctionParam, FunctionParams, FunctionReturns, IfBranchNode, IfNode, IfStatement,
-    IfStatementAlternate, ImportItem, InterpolationNode, JsChildNode, JsExpression, Namespace,
-    NodeType, ObjectExpression, Position, PropNode, Property, PropsExpression, ReturnStatement,
-    ReturnValue, RootNode, RuntimeHelper, SequenceExpression, SimpleExpressionNode,
-    SlotsExpression, SourceLocation, TemplateChildNode, TemplateLiteral, TemplateLiteralElement,
-    TemplateTextChildNode, TextCallContent, TextCallNode, TextNode, VNodeCall, VNodeChildren,
-    VNodeTag,
+    AttributeNode, CommentNode, CompoundExpressionChild, CompoundExpressionNode, ConstantType,
+    DirectiveNode, ElementNode, ElementType, ExpressionNode, ForNode, ForParseResult, IfBranchNode,
+    IfNode, ImportItem, InterpolationNode, JsExpression, Namespace, NodeType, Position, PropNode,
+    RootNode, RuntimeHelper, SimpleExpressionNode, SourceLocation, TemplateChildNode,
+    TextCallContent, TextCallNode, TextNode,
 };
 pub use vize_relief::{errors, options};
 

--- a/crates/vize_atelier_core/src/render_ir.rs
+++ b/crates/vize_atelier_core/src/render_ir.rs
@@ -1,15 +1,16 @@
-//! Code generation AST node types.
+//! Render/codegen IR node types.
 //!
-//! `VNodeCall`, JS expression nodes, and SSR codegen nodes — render/codegen
-//! types slated to move out of Relief into Rendu/Atelier (#1760, #1634).
+//! `VNodeCall`, the JS expression nodes, and the SSR statement nodes — the
+//! render/codegen IR, relocated out of the `vize_relief` source AST into the
+//! atelier so the source AST no longer carries codegen types (#1760, #1634).
+//! The borrowed Relief nodes these reference (expressions, text, interpolation)
+//! still live in `vize_relief`.
 
 use vize_carton::{Box, Bump, PatchFlags, String, Vec};
 
-use super::{
-    RuntimeHelper,
-    core::{NodeType, SourceLocation},
-    expressions::{CompoundExpressionNode, ExpressionNode, SimpleExpressionNode},
-    nodes::TemplateChildNode,
+use vize_relief::{
+    CompoundExpressionNode, ExpressionNode, InterpolationNode, NodeType, RuntimeHelper,
+    SimpleExpressionNode, SourceLocation, TemplateChildNode, TextNode,
 };
 
 /// VNode call expression
@@ -55,8 +56,8 @@ pub enum VNodeChildren<'a> {
 /// Template text child node
 #[derive(Debug)]
 pub enum TemplateTextChildNode<'a> {
-    Text(Box<'a, super::elements::TextNode>),
-    Interpolation(Box<'a, super::elements::InterpolationNode<'a>>),
+    Text(Box<'a, TextNode>),
+    Interpolation(Box<'a, InterpolationNode<'a>>),
     Compound(Box<'a, CompoundExpressionNode<'a>>),
 }
 

--- a/crates/vize_atelier_core/tests/render_ir.rs
+++ b/crates/vize_atelier_core/tests/render_ir.rs
@@ -1,0 +1,46 @@
+//! Construction smoke tests for the relocated render/codegen IR (#1760).
+//!
+//! These types moved out of `vize_relief` into `vize_atelier_core`; the tests
+//! moved with them and now exercise the public re-exports.
+
+use bumpalo::Bump;
+use vize_atelier_core::{
+    ArrayExpression, BlockStatement, CallExpression, Callee, NodeType, ObjectExpression,
+    RuntimeHelper, SourceLocation,
+};
+
+#[test]
+fn call_expression_new() {
+    let allocator = Bump::new();
+    let call = CallExpression::new(
+        &allocator,
+        Callee::Symbol(RuntimeHelper::CreateVNode),
+        SourceLocation::STUB,
+    );
+    assert!(call.arguments.is_empty());
+    assert_eq!(call.node_type(), NodeType::JsCallExpression);
+}
+
+#[test]
+fn object_expression_new() {
+    let allocator = Bump::new();
+    let obj = ObjectExpression::new(&allocator, SourceLocation::STUB);
+    assert!(obj.properties.is_empty());
+    assert_eq!(obj.node_type(), NodeType::JsObjectExpression);
+}
+
+#[test]
+fn array_expression_new() {
+    let allocator = Bump::new();
+    let arr = ArrayExpression::new(&allocator, SourceLocation::STUB);
+    assert!(arr.elements.is_empty());
+    assert_eq!(arr.node_type(), NodeType::JsArrayExpression);
+}
+
+#[test]
+fn block_statement_new() {
+    let allocator = Bump::new();
+    let block = BlockStatement::new(&allocator, SourceLocation::STUB);
+    assert!(block.body.is_empty());
+    assert_eq!(block.node_type(), NodeType::JsBlockStatement);
+}

--- a/crates/vize_relief/src/relief.rs
+++ b/crates/vize_relief/src/relief.rs
@@ -4,7 +4,6 @@
 //! target. All nodes are allocated in a bumpalo arena for efficient memory
 //! management and zero-copy transfer to JavaScript.
 
-pub mod codegen;
 pub mod control_flow;
 pub mod core;
 pub mod elements;
@@ -14,7 +13,6 @@ pub mod nodes;
 #[cfg(test)]
 mod tests;
 
-pub use codegen::*;
 pub use control_flow::*;
 pub use core::*;
 pub use elements::*;

--- a/crates/vize_relief/src/relief/tests.rs
+++ b/crates/vize_relief/src/relief/tests.rs
@@ -1,9 +1,8 @@
 //! Tests for AST node types.
 
 use super::{
-    ArrayExpression, AttributeNode, BlockStatement, CallExpression, Callee, CommentNode,
-    CompoundExpressionNode, ConstantType, DirectiveNode, ElementNode, ElementType, IfBranchNode,
-    IfNode, Namespace, NodeType, ObjectExpression, Position, RootNode, RuntimeHelper,
+    AttributeNode, CommentNode, CompoundExpressionNode, ConstantType, DirectiveNode, ElementNode,
+    ElementType, IfBranchNode, IfNode, Namespace, NodeType, Position, RootNode, RuntimeHelper,
     SimpleExpressionNode, SourceLocation, TemplateChildNode, TextNode,
 };
 use vize_carton::Bump;
@@ -292,42 +291,6 @@ fn if_branch_node_new() {
     assert!(branch.user_key.is_none());
     assert!(!branch.is_template_if);
     assert_eq!(branch.node_type(), NodeType::IfBranch);
-}
-
-#[test]
-fn call_expression_new() {
-    let allocator = Bump::new();
-    let call = CallExpression::new(
-        &allocator,
-        Callee::Symbol(RuntimeHelper::CreateVNode),
-        SourceLocation::STUB,
-    );
-    assert!(call.arguments.is_empty());
-    assert_eq!(call.node_type(), NodeType::JsCallExpression);
-}
-
-#[test]
-fn object_expression_new() {
-    let allocator = Bump::new();
-    let obj = ObjectExpression::new(&allocator, SourceLocation::STUB);
-    assert!(obj.properties.is_empty());
-    assert_eq!(obj.node_type(), NodeType::JsObjectExpression);
-}
-
-#[test]
-fn array_expression_new() {
-    let allocator = Bump::new();
-    let arr = ArrayExpression::new(&allocator, SourceLocation::STUB);
-    assert!(arr.elements.is_empty());
-    assert_eq!(arr.node_type(), NodeType::JsArrayExpression);
-}
-
-#[test]
-fn block_statement_new() {
-    let allocator = Bump::new();
-    let block = BlockStatement::new(&allocator, SourceLocation::STUB);
-    assert!(block.body.is_empty());
-    assert_eq!(block.node_type(), NodeType::JsBlockStatement);
 }
 
 // ========================================================================


### PR DESCRIPTION
**Fixes a broken canary.** PR #1817 committed the `codegen.rs` → `render_ir.rs` move but a `git add` pathspec error dropped the accompanying edits, so canary currently fails to compile (`vize_relief` declares `pub mod codegen` for a file that no longer exists; `render_ir.rs` keeps `use super::` imports that don't resolve in `vize_atelier_core`).

This applies the missing edits:
- `render_ir.rs` imports the borrowed Relief types from `vize_relief`.
- `vize_relief/relief.rs` drops `pub mod codegen` / `pub use codegen::*`.
- `vize_atelier_core/lib.rs` re-exports the moved IR from `render_ir`, keeps genuine Relief types from `vize_relief`.
- `relief/tests.rs` drops the codegen-type tests (moved to `tests/render_ir.rs`).

BREAKING CHANGE: vize_relief no longer exposes the render/codegen IR types; they live in vize_atelier_core (re-exported).

## Verified

`cargo build --workspace`; `vize_atelier_core` (261 + render_ir 4), `vize_atelier_dom`, `vize_atelier_sfc` (528), `vize_atelier_ssr` (76), `vize_relief` (49); clippy clean.

CI is under an Actions spending-cap outage; merging via admin per the verified-locally policy.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1821"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->