### PR TITLE
[Next Gen] refactor(codegen): split v-for item prop emission into item_props_merge

### DIFF
--- a/crates/vize_atelier_core/src/codegen/v_for.rs
+++ b/crates/vize_atelier_core/src/codegen/v_for.rs
@@ -5,6 +5,7 @@
 
 mod generate;
 pub(crate) mod helpers;
+mod item_props_merge;
 
 use crate::steps::v_memo::{get_memo_exp, has_v_memo};
 use crate::{ForNode, RuntimeHelper, TemplateChildNode};

--- a/crates/vize_atelier_core/src/codegen/v_for/generate.rs
+++ b/crates/vize_atelier_core/src/codegen/v_for/generate.rs
@@ -18,7 +18,7 @@ use super::super::{
         has_custom_directives, has_vmodel_directive, has_vshow_directive,
     },
     expression::generate_expression,
-    helpers::{escape_js_string, is_builtin_component, to_valid_asset_identifier},
+    helpers::{is_builtin_component, to_valid_asset_identifier},
     node::generate_node,
     patch_flag::{
         calculate_element_patch_info, calculate_element_patch_info_skip_is, patch_flag_name,
@@ -29,6 +29,7 @@ use super::super::{
     },
 };
 use super::helpers::{get_element_key, has_other_props, should_skip_prop};
+use super::item_props_merge::{generate_for_item_props_merged, generate_single_prop};
 use vize_carton::ToCompactString;
 
 fn strip_need_patch_for_v_for_item(patch_flag: Option<i32>) -> Option<i32> {
@@ -677,171 +678,5 @@ pub(crate) fn generate_for_item_props(
         }
 
         ctx.push(" }");
-    }
-}
-
-/// Generate props using _mergeProps when v-bind/v-on object spreads are present.
-fn generate_for_item_props_merged(
-    ctx: &mut CodegenContext,
-    el: &ElementNode<'_>,
-    key_exp: Option<&ExpressionNode<'_>>,
-    scope_id: &Option<vize_carton::String>,
-    has_vbind_spread: bool,
-    has_von_spread: bool,
-    skip_is_prop: bool,
-) {
-    ctx.use_helper(RuntimeHelper::MergeProps);
-    ctx.push(ctx.helper(RuntimeHelper::MergeProps));
-    ctx.push("(");
-
-    let mut first_merge_arg = true;
-
-    if has_vbind_spread {
-        super::super::props::generate_vbind_object_exp(ctx, &el.props);
-        first_merge_arg = false;
-    }
-
-    if has_von_spread {
-        if !first_merge_arg {
-            ctx.push(", ");
-        }
-        super::super::props::generate_von_object_exp(ctx, &el.props);
-        first_merge_arg = false;
-    }
-
-    let has_remaining = key_exp.is_some()
-        || scope_id.is_some()
-        || el.props.iter().any(|p| {
-            if should_skip_prop(p) || (skip_is_prop && is_is_prop(p)) {
-                return false;
-            }
-            if let PropNode::Directive(dir) = p
-                && dir.arg.is_none()
-                && (dir.name == "bind" || dir.name == "on")
-            {
-                return false;
-            }
-            true
-        });
-
-    if has_remaining {
-        if !first_merge_arg {
-            ctx.push(", ");
-        }
-        ctx.push("{");
-        ctx.indent();
-        let mut first_prop = true;
-
-        if let Some(key) = key_exp {
-            ctx.newline();
-            ctx.push("key: ");
-            generate_expression(ctx, key);
-            first_prop = false;
-        }
-
-        for prop in el.props.iter() {
-            if should_skip_prop(prop) || (skip_is_prop && is_is_prop(prop)) {
-                continue;
-            }
-            if let PropNode::Directive(dir) = prop
-                && dir.arg.is_none()
-                && (dir.name == "bind" || dir.name == "on")
-            {
-                continue;
-            }
-            if !first_prop {
-                ctx.push(",");
-            }
-            ctx.newline();
-            generate_single_prop(ctx, prop, super::super::props::StaticMerge::default());
-            first_prop = false;
-        }
-
-        if let Some(sid) = scope_id {
-            if !first_prop {
-                ctx.push(",");
-            }
-            ctx.newline();
-            ctx.push("\"");
-            ctx.push(sid.as_str());
-            ctx.push("\": \"\"");
-        }
-
-        ctx.deindent();
-        ctx.newline();
-        ctx.push("}");
-    }
-
-    ctx.push(")");
-}
-
-/// Generate a single prop (attribute or directive)
-fn generate_single_prop(
-    ctx: &mut CodegenContext,
-    prop: &PropNode<'_>,
-    static_merge: super::super::props::StaticMerge<'_>,
-) {
-    match prop {
-        PropNode::Attribute(attr) => {
-            let ref_value = if attr.name == "ref" && ctx.options.inline {
-                attr.value.as_ref()
-            } else {
-                None
-            };
-            let ref_binding_type = ref_value.and_then(|v| {
-                ctx.options
-                    .binding_metadata
-                    .as_ref()
-                    .and_then(|m| m.bindings.get(v.content.as_str()).copied())
-            });
-            let should_ref_runtime_binding = matches!(
-                ref_binding_type,
-                Some(
-                    crate::options::BindingType::SetupLet
-                        | crate::options::BindingType::SetupRef
-                        | crate::options::BindingType::SetupMaybeRef
-                )
-            );
-            let needs_ref_for = attr.name == "ref" && ctx.in_v_for;
-
-            if let (true, Some(ref_value)) = (should_ref_runtime_binding, ref_value) {
-                let ref_name = &ref_value.content;
-                if needs_ref_for {
-                    ctx.push("ref_for: true, ");
-                }
-                ctx.push("ref_key: \"");
-                ctx.push(ref_name);
-                ctx.push("\", ref: ");
-                ctx.push(ref_name);
-                return;
-            }
-
-            if needs_ref_for {
-                ctx.push("ref_for: true, ");
-            }
-            let needs_quotes = !super::super::helpers::is_valid_js_identifier(&attr.name);
-            if needs_quotes {
-                ctx.push("\"");
-            }
-            ctx.push(&attr.name);
-            if needs_quotes {
-                ctx.push("\"");
-            }
-            ctx.push(": ");
-            if let Some(value) = &attr.value {
-                if should_ref_runtime_binding {
-                    ctx.push(&value.content);
-                } else {
-                    ctx.push("\"");
-                    ctx.push(&escape_js_string(&value.content));
-                    ctx.push("\"");
-                }
-            } else {
-                ctx.push("\"\"");
-            }
-        }
-        PropNode::Directive(dir) => {
-            super::super::props::generate_directive_prop_with_static(ctx, dir, static_merge);
-        }
     }
 }

--- a/crates/vize_atelier_core/src/codegen/v_for/item_props_merge.rs
+++ b/crates/vize_atelier_core/src/codegen/v_for/item_props_merge.rs
@@ -1,0 +1,178 @@
+//! v-for item prop emission: merged-props (`_mergeProps`) and single-prop.
+//!
+//! Split out of `v_for/generate` to keep that file focused on item/block
+//! generation. `generate_for_item_props` (still in `generate`) calls these.
+
+use crate::{ElementNode, ExpressionNode, PropNode, RuntimeHelper};
+
+use super::super::{
+    context::CodegenContext, element::helpers::is_is_prop, expression::generate_expression,
+    helpers::escape_js_string,
+};
+use super::helpers::should_skip_prop;
+
+/// Generate props using _mergeProps when v-bind/v-on object spreads are present.
+pub(super) fn generate_for_item_props_merged(
+    ctx: &mut CodegenContext,
+    el: &ElementNode<'_>,
+    key_exp: Option<&ExpressionNode<'_>>,
+    scope_id: &Option<vize_carton::String>,
+    has_vbind_spread: bool,
+    has_von_spread: bool,
+    skip_is_prop: bool,
+) {
+    ctx.use_helper(RuntimeHelper::MergeProps);
+    ctx.push(ctx.helper(RuntimeHelper::MergeProps));
+    ctx.push("(");
+
+    let mut first_merge_arg = true;
+
+    if has_vbind_spread {
+        super::super::props::generate_vbind_object_exp(ctx, &el.props);
+        first_merge_arg = false;
+    }
+
+    if has_von_spread {
+        if !first_merge_arg {
+            ctx.push(", ");
+        }
+        super::super::props::generate_von_object_exp(ctx, &el.props);
+        first_merge_arg = false;
+    }
+
+    let has_remaining = key_exp.is_some()
+        || scope_id.is_some()
+        || el.props.iter().any(|p| {
+            if should_skip_prop(p) || (skip_is_prop && is_is_prop(p)) {
+                return false;
+            }
+            if let PropNode::Directive(dir) = p
+                && dir.arg.is_none()
+                && (dir.name == "bind" || dir.name == "on")
+            {
+                return false;
+            }
+            true
+        });
+
+    if has_remaining {
+        if !first_merge_arg {
+            ctx.push(", ");
+        }
+        ctx.push("{");
+        ctx.indent();
+        let mut first_prop = true;
+
+        if let Some(key) = key_exp {
+            ctx.newline();
+            ctx.push("key: ");
+            generate_expression(ctx, key);
+            first_prop = false;
+        }
+
+        for prop in el.props.iter() {
+            if should_skip_prop(prop) || (skip_is_prop && is_is_prop(prop)) {
+                continue;
+            }
+            if let PropNode::Directive(dir) = prop
+                && dir.arg.is_none()
+                && (dir.name == "bind" || dir.name == "on")
+            {
+                continue;
+            }
+            if !first_prop {
+                ctx.push(",");
+            }
+            ctx.newline();
+            generate_single_prop(ctx, prop, super::super::props::StaticMerge::default());
+            first_prop = false;
+        }
+
+        if let Some(sid) = scope_id {
+            if !first_prop {
+                ctx.push(",");
+            }
+            ctx.newline();
+            ctx.push("\"");
+            ctx.push(sid.as_str());
+            ctx.push("\": \"\"");
+        }
+
+        ctx.deindent();
+        ctx.newline();
+        ctx.push("}");
+    }
+
+    ctx.push(")");
+}
+
+/// Generate a single prop (attribute or directive)
+pub(super) fn generate_single_prop(
+    ctx: &mut CodegenContext,
+    prop: &PropNode<'_>,
+    static_merge: super::super::props::StaticMerge<'_>,
+) {
+    match prop {
+        PropNode::Attribute(attr) => {
+            let ref_value = if attr.name == "ref" && ctx.options.inline {
+                attr.value.as_ref()
+            } else {
+                None
+            };
+            let ref_binding_type = ref_value.and_then(|v| {
+                ctx.options
+                    .binding_metadata
+                    .as_ref()
+                    .and_then(|m| m.bindings.get(v.content.as_str()).copied())
+            });
+            let should_ref_runtime_binding = matches!(
+                ref_binding_type,
+                Some(
+                    crate::options::BindingType::SetupLet
+                        | crate::options::BindingType::SetupRef
+                        | crate::options::BindingType::SetupMaybeRef
+                )
+            );
+            let needs_ref_for = attr.name == "ref" && ctx.in_v_for;
+
+            if let (true, Some(ref_value)) = (should_ref_runtime_binding, ref_value) {
+                let ref_name = &ref_value.content;
+                if needs_ref_for {
+                    ctx.push("ref_for: true, ");
+                }
+                ctx.push("ref_key: \"");
+                ctx.push(ref_name);
+                ctx.push("\", ref: ");
+                ctx.push(ref_name);
+                return;
+            }
+
+            if needs_ref_for {
+                ctx.push("ref_for: true, ");
+            }
+            let needs_quotes = !super::super::helpers::is_valid_js_identifier(&attr.name);
+            if needs_quotes {
+                ctx.push("\"");
+            }
+            ctx.push(&attr.name);
+            if needs_quotes {
+                ctx.push("\"");
+            }
+            ctx.push(": ");
+            if let Some(value) = &attr.value {
+                if should_ref_runtime_binding {
+                    ctx.push(&value.content);
+                } else {
+                    ctx.push("\"");
+                    ctx.push(&escape_js_string(&value.content));
+                    ctx.push("\"");
+                }
+            } else {
+                ctx.push("\"\"");
+            }
+        }
+        PropNode::Directive(dir) => {
+            super::super::props::generate_directive_prop_with_static(ctx, dir, static_merge);
+        }
+    }
+}


### PR DESCRIPTION
Co-authored-by: Claude Opus 4.8 <noreply@anthropic.com>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1825"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->