### PR TITLE
[Next Gen] refactor(codegen): split v-on/v-model prop emission into von_vmodel

### DIFF
--- a/crates/vize_atelier_core/src/codegen/props.rs
+++ b/crates/vize_atelier_core/src/codegen/props.rs
@@ -5,6 +5,7 @@ mod events;
 mod generate;
 mod object;
 mod scan;
+mod von_vmodel;
 
 use crate::{PropNode, RuntimeHelper};
 

--- a/crates/vize_atelier_core/src/codegen/props/directives.rs
+++ b/crates/vize_atelier_core/src/codegen/props/directives.rs
@@ -7,6 +7,7 @@ use super::super::{
     expression::{generate_expression, generate_simple_expression},
     helpers::{camelize, escape_js_string, is_constant_simple_expression, is_valid_js_identifier},
 };
+use super::von_vmodel::{generate_vmodel_prop, generate_von_prop};
 use vize_carton::String;
 use vize_carton::ToCompactString;
 
@@ -403,120 +404,4 @@ fn split_style_declarations(value: &str) -> Vec<&str> {
     }
     declarations.push(&value[start..]);
     declarations
-}
-
-/// Generate v-on directive as a prop
-fn generate_von_prop(ctx: &mut CodegenContext, dir: &DirectiveNode<'_>) {
-    let is_dynamic_event = if let Some(ExpressionNode::Simple(exp)) = &dir.arg {
-        !exp.is_static
-    } else {
-        false
-    };
-
-    if let Some(ExpressionNode::Simple(exp)) = &dir.arg {
-        if is_dynamic_event {
-            // Dynamic event name: [_toHandlerKey(_ctx.event)]:
-            ctx.use_helper(RuntimeHelper::ToHandlerKey);
-            ctx.push("[");
-            ctx.push(ctx.helper(RuntimeHelper::ToHandlerKey));
-            ctx.push("(");
-            let content = exp.content.as_str();
-            if let Some(local) = content
-                .strip_prefix("_ctx.")
-                .filter(|local| ctx.is_slot_param(local))
-            {
-                ctx.push(local);
-            } else if content.contains('.') || content.starts_with('_') || content.starts_with('$')
-            {
-                generate_simple_expression(ctx, exp);
-            } else if ctx.is_slot_param(content) {
-                ctx.push(content);
-            } else {
-                ctx.push("_ctx.");
-                ctx.push(content);
-            }
-            ctx.push(")]: ");
-        } else {
-            // Mirror Vue's event-name casing rule (transforms/vOn.ts), including
-            // mouse-button event renaming, `vue:` vnode hooks, and the `on:`
-            // case-preserving form for custom-element events on plain elements.
-            // The `on:` case-preserving form only applies to user-authored v-on
-            // directives (those carry a `raw_name`). Compiler-synthesized handlers
-            // like v-model's `update:modelValue` always camelize.
-            let on_plain_element = ctx.props_is_plain_element && dir.raw_name.is_some();
-            let event_name = super::events::von_event_key_for(
-                exp.content.as_str(),
-                on_plain_element,
-                dir.modifiers.iter().map(|m| m.content.as_str()),
-            );
-
-            let needs_quotes = !is_valid_js_identifier(&event_name);
-            if needs_quotes {
-                ctx.push("\"");
-            }
-            // Anchor the generated event-handler key back to the v-on argument
-            // in source, recording the original event name so it lands in the
-            // v3 `names` array. No-op without `source_map`.
-            ctx.record_mapping_named(&exp.loc.start, &exp.content);
-            ctx.push(&event_name);
-            if needs_quotes {
-                ctx.push("\"");
-            }
-            ctx.push(": ");
-        }
-    }
-
-    super::events::generate_von_handler_value(ctx, dir);
-}
-
-/// Generate dynamic v-model on component as props
-fn generate_vmodel_prop(ctx: &mut CodegenContext, dir: &DirectiveNode<'_>) {
-    // Handle dynamic v-model on component
-    // Generate: [_ctx.prop]: _ctx.value, ["onUpdate:" + _ctx.prop]: handler
-    if let Some(ExpressionNode::Simple(arg_exp)) = &dir.arg
-        && !arg_exp.is_static
-    {
-        let prop_name = &arg_exp.content;
-        let value_exp = dir
-            .exp
-            .as_ref()
-            .map(|e| match e {
-                ExpressionNode::Simple(s) => s.content.as_str(),
-                ExpressionNode::Compound(c) => c.loc.source.as_str(),
-            })
-            .unwrap_or("undefined");
-
-        // [_ctx.prop]: _ctx.value
-        ctx.push("[_ctx.");
-        ctx.push(prop_name);
-        ctx.push("]: ");
-        ctx.push(value_exp);
-        ctx.push(",");
-        ctx.newline();
-
-        // ["onUpdate:" + _ctx.prop]: $event => ((_ctx.value) = $event)
-        ctx.push("[\"onUpdate:\" + _ctx.");
-        ctx.push(prop_name);
-        ctx.push("]: $event => ((");
-        ctx.push(value_exp);
-        ctx.push(") = $event)");
-
-        // Add modifiers if present
-        if !dir.modifiers.is_empty() {
-            ctx.push(",");
-            ctx.newline();
-            // [_ctx.prop + "Modifiers"]: { modifier: true }
-            ctx.push("[_ctx.");
-            ctx.push(prop_name);
-            ctx.push(" + \"Modifiers\"]: { ");
-            for (i, modifier) in dir.modifiers.iter().enumerate() {
-                if i > 0 {
-                    ctx.push(", ");
-                }
-                ctx.push(&modifier.content);
-                ctx.push(": true");
-            }
-            ctx.push(" }");
-        }
-    }
 }

--- a/crates/vize_atelier_core/src/codegen/props/von_vmodel.rs
+++ b/crates/vize_atelier_core/src/codegen/props/von_vmodel.rs
@@ -1,0 +1,128 @@
+//! `v-on` and dynamic `v-model` prop emission.
+//!
+//! Emits the object-property form of a `v-on` handler and of a dynamic-argument
+//! `v-model` on a component. Split out of `directives` to keep that file focused
+//! on `v-bind` and directive dispatch.
+
+use crate::{DirectiveNode, ExpressionNode, RuntimeHelper};
+
+use super::super::{
+    context::CodegenContext, expression::generate_simple_expression,
+    helpers::is_valid_js_identifier,
+};
+
+/// Generate v-on directive as a prop
+pub(super) fn generate_von_prop(ctx: &mut CodegenContext, dir: &DirectiveNode<'_>) {
+    let is_dynamic_event = if let Some(ExpressionNode::Simple(exp)) = &dir.arg {
+        !exp.is_static
+    } else {
+        false
+    };
+
+    if let Some(ExpressionNode::Simple(exp)) = &dir.arg {
+        if is_dynamic_event {
+            // Dynamic event name: [_toHandlerKey(_ctx.event)]:
+            ctx.use_helper(RuntimeHelper::ToHandlerKey);
+            ctx.push("[");
+            ctx.push(ctx.helper(RuntimeHelper::ToHandlerKey));
+            ctx.push("(");
+            let content = exp.content.as_str();
+            if let Some(local) = content
+                .strip_prefix("_ctx.")
+                .filter(|local| ctx.is_slot_param(local))
+            {
+                ctx.push(local);
+            } else if content.contains('.') || content.starts_with('_') || content.starts_with('$')
+            {
+                generate_simple_expression(ctx, exp);
+            } else if ctx.is_slot_param(content) {
+                ctx.push(content);
+            } else {
+                ctx.push("_ctx.");
+                ctx.push(content);
+            }
+            ctx.push(")]: ");
+        } else {
+            // Mirror Vue's event-name casing rule (transforms/vOn.ts), including
+            // mouse-button event renaming, `vue:` vnode hooks, and the `on:`
+            // case-preserving form for custom-element events on plain elements.
+            // The `on:` case-preserving form only applies to user-authored v-on
+            // directives (those carry a `raw_name`). Compiler-synthesized handlers
+            // like v-model's `update:modelValue` always camelize.
+            let on_plain_element = ctx.props_is_plain_element && dir.raw_name.is_some();
+            let event_name = super::events::von_event_key_for(
+                exp.content.as_str(),
+                on_plain_element,
+                dir.modifiers.iter().map(|m| m.content.as_str()),
+            );
+
+            let needs_quotes = !is_valid_js_identifier(&event_name);
+            if needs_quotes {
+                ctx.push("\"");
+            }
+            // Anchor the generated event-handler key back to the v-on argument
+            // in source, recording the original event name so it lands in the
+            // v3 `names` array. No-op without `source_map`.
+            ctx.record_mapping_named(&exp.loc.start, &exp.content);
+            ctx.push(&event_name);
+            if needs_quotes {
+                ctx.push("\"");
+            }
+            ctx.push(": ");
+        }
+    }
+
+    super::events::generate_von_handler_value(ctx, dir);
+}
+
+/// Generate dynamic v-model on component as props
+pub(super) fn generate_vmodel_prop(ctx: &mut CodegenContext, dir: &DirectiveNode<'_>) {
+    // Handle dynamic v-model on component
+    // Generate: [_ctx.prop]: _ctx.value, ["onUpdate:" + _ctx.prop]: handler
+    if let Some(ExpressionNode::Simple(arg_exp)) = &dir.arg
+        && !arg_exp.is_static
+    {
+        let prop_name = &arg_exp.content;
+        let value_exp = dir
+            .exp
+            .as_ref()
+            .map(|e| match e {
+                ExpressionNode::Simple(s) => s.content.as_str(),
+                ExpressionNode::Compound(c) => c.loc.source.as_str(),
+            })
+            .unwrap_or("undefined");
+
+        // [_ctx.prop]: _ctx.value
+        ctx.push("[_ctx.");
+        ctx.push(prop_name);
+        ctx.push("]: ");
+        ctx.push(value_exp);
+        ctx.push(",");
+        ctx.newline();
+
+        // ["onUpdate:" + _ctx.prop]: $event => ((_ctx.value) = $event)
+        ctx.push("[\"onUpdate:\" + _ctx.");
+        ctx.push(prop_name);
+        ctx.push("]: $event => ((");
+        ctx.push(value_exp);
+        ctx.push(") = $event)");
+
+        // Add modifiers if present
+        if !dir.modifiers.is_empty() {
+            ctx.push(",");
+            ctx.newline();
+            // [_ctx.prop + "Modifiers"]: { modifier: true }
+            ctx.push("[_ctx.");
+            ctx.push(prop_name);
+            ctx.push(" + \"Modifiers\"]: { ");
+            for (i, modifier) in dir.modifiers.iter().enumerate() {
+                if i > 0 {
+                    ctx.push(", ");
+                }
+                ctx.push(&modifier.content);
+                ctx.push(": true");
+            }
+            ctx.push(" }");
+        }
+    }
+}


### PR DESCRIPTION
Co-authored-by: Claude Opus 4.8 <noreply@anthropic.com>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1829"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->