### PR TITLE
[Next Gen] refactor(codegen): split fragment-shaped if-branch emission into branch_fragment

### DIFF
--- a/crates/vize_atelier_core/src/codegen/v_if.rs
+++ b/crates/vize_atelier_core/src/codegen/v_if.rs
@@ -6,6 +6,7 @@
 
 mod branch;
 mod branch_component;
+mod branch_fragment;
 mod generate;
 
 use crate::{IfBranchNode, IfNode, PropNode, RuntimeHelper};

--- a/crates/vize_atelier_core/src/codegen/v_if/branch.rs
+++ b/crates/vize_atelier_core/src/codegen/v_if/branch.rs
@@ -11,7 +11,6 @@ use vize_carton::ToCompactString;
 
 use super::{
     super::{
-        children::generate_children_force_array,
         context::CodegenContext,
         element::{
             generate_custom_directives_closing, generate_vmodel_closing, generate_vshow_closing,
@@ -20,12 +19,15 @@ use super::{
         element::helpers::child_namespace,
         expression::generate_expression,
         helpers::escape_js_string,
-        interpolation::push_interpolation_value,
         node::dispatch_rendu_op,
         patch_flag::{calculate_element_patch_info, patch_flag_name},
         slots::{generate_slot_outlet_name, generate_slot_outlet_props_with_key},
     },
     branch_component::generate_if_branch_component,
+    branch_fragment::{
+        generate_if_branch_children, generate_if_branch_fragment,
+        generate_if_branch_template_fragment,
+    },
     generate::{
         extract_static_class_style, generate_if_branch_props_object, has_dynamic_class,
         has_dynamic_style, has_vbind_spread, has_von_spread,
@@ -300,87 +302,5 @@ fn generate_if_branch_element(
     }
     if has_vshow {
         generate_vshow_closing(ctx, el);
-    }
-}
-
-/// Generate template fragment for if branch (multiple children from template).
-fn generate_if_branch_template_fragment(
-    ctx: &mut CodegenContext,
-    children: &[TemplateChildNode<'_>],
-    branch: &IfBranchNode<'_>,
-    branch_index: usize,
-) {
-    ctx.use_helper(RuntimeHelper::CreateElementBlock);
-    ctx.use_helper(RuntimeHelper::Fragment);
-    ctx.push("(");
-    ctx.push(ctx.helper(RuntimeHelper::OpenBlock));
-    ctx.push("(), ");
-    ctx.push(ctx.helper(RuntimeHelper::CreateElementBlock));
-    ctx.push("(");
-    ctx.push(ctx.helper(RuntimeHelper::Fragment));
-    ctx.push(", { key: ");
-    generate_if_branch_key(ctx, branch, branch_index);
-    ctx.push(" }, ");
-    generate_children_force_array(ctx, children);
-    ctx.push(", 64 /* STABLE_FRAGMENT */))");
-}
-
-/// Generate fragment wrapper for if branch with multiple children.
-fn generate_if_branch_fragment(
-    ctx: &mut CodegenContext,
-    branch: &IfBranchNode<'_>,
-    branch_index: usize,
-) {
-    ctx.use_helper(RuntimeHelper::CreateElementBlock);
-    ctx.use_helper(RuntimeHelper::Fragment);
-    ctx.push("(");
-    ctx.push(ctx.helper(RuntimeHelper::OpenBlock));
-    ctx.push("(), ");
-    ctx.push(ctx.helper(RuntimeHelper::CreateElementBlock));
-    ctx.push("(");
-    ctx.push(ctx.helper(RuntimeHelper::Fragment));
-    ctx.push(", { key: ");
-    generate_if_branch_key(ctx, branch, branch_index);
-    ctx.push(" }, ");
-    generate_children_force_array(ctx, &branch.children);
-    ctx.push(", 64 /* STABLE_FRAGMENT */))");
-}
-
-/// Generate children for if branch element.
-fn generate_if_branch_children(ctx: &mut CodegenContext, children: &[TemplateChildNode<'_>]) {
-    if children.is_empty() {
-        return;
-    }
-
-    // Check if all children are simple (text or interpolation)
-    let has_only_text_or_interpolation = children.iter().all(|c| {
-        matches!(
-            c,
-            TemplateChildNode::Text(_) | TemplateChildNode::Interpolation(_)
-        )
-    });
-
-    if has_only_text_or_interpolation {
-        // Use string concatenation for text/interpolation mix
-        for (i, child) in children.iter().enumerate() {
-            if i > 0 {
-                ctx.push(" + ");
-            }
-            match child {
-                TemplateChildNode::Interpolation(interp) => {
-                    push_interpolation_value(ctx, interp);
-                }
-                TemplateChildNode::Text(text) => {
-                    ctx.push("\"");
-                    ctx.push(&escape_js_string(text.content.as_str()));
-                    ctx.push("\"");
-                }
-                _ => {}
-            }
-        }
-    } else {
-        // Mixed children in block-optimized branches must emit text as createTextVNode,
-        // otherwise Vue skips child normalization and raw strings become invalid VNodes.
-        generate_children_force_array(ctx, children);
     }
 }

--- a/crates/vize_atelier_core/src/codegen/v_if/branch_fragment.rs
+++ b/crates/vize_atelier_core/src/codegen/v_if/branch_fragment.rs
@@ -1,0 +1,100 @@
+//! Fragment-shaped v-if branch emission.
+//!
+//! Emits the template-fragment and multi-child fragment branch shapes and the
+//! shared branch-children serialization. Split out of `branch` to keep that
+//! file focused on branch dispatch and the component/element shapes.
+
+use crate::{IfBranchNode, RuntimeHelper, TemplateChildNode};
+
+use super::{
+    super::{
+        children::generate_children_force_array, context::CodegenContext,
+        helpers::escape_js_string, interpolation::push_interpolation_value,
+    },
+    generate_if_branch_key,
+};
+
+/// Generate template fragment for if branch (multiple children from template).
+pub(super) fn generate_if_branch_template_fragment(
+    ctx: &mut CodegenContext,
+    children: &[TemplateChildNode<'_>],
+    branch: &IfBranchNode<'_>,
+    branch_index: usize,
+) {
+    ctx.use_helper(RuntimeHelper::CreateElementBlock);
+    ctx.use_helper(RuntimeHelper::Fragment);
+    ctx.push("(");
+    ctx.push(ctx.helper(RuntimeHelper::OpenBlock));
+    ctx.push("(), ");
+    ctx.push(ctx.helper(RuntimeHelper::CreateElementBlock));
+    ctx.push("(");
+    ctx.push(ctx.helper(RuntimeHelper::Fragment));
+    ctx.push(", { key: ");
+    generate_if_branch_key(ctx, branch, branch_index);
+    ctx.push(" }, ");
+    generate_children_force_array(ctx, children);
+    ctx.push(", 64 /* STABLE_FRAGMENT */))");
+}
+
+/// Generate fragment wrapper for if branch with multiple children.
+pub(super) fn generate_if_branch_fragment(
+    ctx: &mut CodegenContext,
+    branch: &IfBranchNode<'_>,
+    branch_index: usize,
+) {
+    ctx.use_helper(RuntimeHelper::CreateElementBlock);
+    ctx.use_helper(RuntimeHelper::Fragment);
+    ctx.push("(");
+    ctx.push(ctx.helper(RuntimeHelper::OpenBlock));
+    ctx.push("(), ");
+    ctx.push(ctx.helper(RuntimeHelper::CreateElementBlock));
+    ctx.push("(");
+    ctx.push(ctx.helper(RuntimeHelper::Fragment));
+    ctx.push(", { key: ");
+    generate_if_branch_key(ctx, branch, branch_index);
+    ctx.push(" }, ");
+    generate_children_force_array(ctx, &branch.children);
+    ctx.push(", 64 /* STABLE_FRAGMENT */))");
+}
+
+/// Generate children for if branch element.
+pub(super) fn generate_if_branch_children(
+    ctx: &mut CodegenContext,
+    children: &[TemplateChildNode<'_>],
+) {
+    if children.is_empty() {
+        return;
+    }
+
+    // Check if all children are simple (text or interpolation)
+    let has_only_text_or_interpolation = children.iter().all(|c| {
+        matches!(
+            c,
+            TemplateChildNode::Text(_) | TemplateChildNode::Interpolation(_)
+        )
+    });
+
+    if has_only_text_or_interpolation {
+        // Use string concatenation for text/interpolation mix
+        for (i, child) in children.iter().enumerate() {
+            if i > 0 {
+                ctx.push(" + ");
+            }
+            match child {
+                TemplateChildNode::Interpolation(interp) => {
+                    push_interpolation_value(ctx, interp);
+                }
+                TemplateChildNode::Text(text) => {
+                    ctx.push("\"");
+                    ctx.push(&escape_js_string(text.content.as_str()));
+                    ctx.push("\"");
+                }
+                _ => {}
+            }
+        }
+    } else {
+        // Mixed children in block-optimized branches must emit text as createTextVNode,
+        // otherwise Vue skips child normalization and raw strings become invalid VNodes.
+        generate_children_force_array(ctx, children);
+    }
+}


### PR DESCRIPTION
Co-authored-by: Claude Opus 4.8 <noreply@anthropic.com>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1833"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->