### PR TITLE
fix(vscode-vize): preserve highlighting after nested template

### DIFF
--- a/npm/vscode-vize/syntaxes/vue.tmLanguage.json
+++ b/npm/vscode-vize/syntaxes/vue.tmLanguage.json
@@ -69,13 +69,19 @@
       "endCaptures": {
         "0": { "name": "punctuation.definition.tag.end.html" }
       },
-      "patterns": [{ "include": "#vue-tag-attributes" }]
+      "patterns": [
+        { "include": "#vue-directive-attributes" },
+        { "include": "#vue-directives" },
+        { "include": "#vue-tag-attributes" }
+      ]
     },
     "vue-template-content": {
       "begin": "(?<=>)",
       "end": "(?=</template>)",
       "patterns": [
+        { "include": "#vue-comments" },
         { "include": "#vue-interpolation" },
+        { "include": "#vue-template" },
         { "include": "#vue-directives" },
         { "include": "#html-tags" },
         { "include": "#html-entities" }
@@ -93,6 +99,79 @@
       "name": "meta.embedded.expression.vue",
       "patterns": [{ "include": "source.ts#expression" }]
     },
+    "vue-ts-expression": {
+      "patterns": [
+        { "include": "#vue-ts-comments" },
+        { "include": "#vue-ts-strings" },
+        { "include": "#vue-ts-generic-call" },
+        {
+          "match": "\\b([A-Za-z_$][\\w$]*)(?=\\s*\\()",
+          "captures": { "1": { "name": "entity.name.function.ts" } }
+        },
+        { "match": "\\b(as|satisfies)\\b", "name": "keyword.control.as.ts" },
+        {
+          "match": "\\b(keyof|typeof|infer|extends|in|of|instanceof|new|await)\\b",
+          "name": "keyword.operator.expression.ts"
+        },
+        { "match": "\\b(true|false|null|undefined)\\b", "name": "constant.language.ts" },
+        { "match": "\\b\\d+(?:\\.\\d+)?\\b", "name": "constant.numeric.ts" },
+        { "match": "\\b[A-Z][\\w$]*\\b", "name": "entity.name.type.ts" },
+        { "match": "\\b[A-Za-z_$][\\w$]*\\b", "name": "variable.other.readwrite.ts" },
+        { "match": "[{}()\\[\\].,?:+\\-*/%&|!~=<>]+", "name": "keyword.operator.ts" }
+      ]
+    },
+    "vue-ts-type": {
+      "patterns": [
+        { "include": "#vue-ts-comments" },
+        { "include": "#vue-ts-strings" },
+        { "include": "#vue-ts-type-arguments" },
+        {
+          "match": "\\b(extends|keyof|typeof|infer|readonly|in|out)\\b",
+          "name": "keyword.operator.type.ts"
+        },
+        { "match": "\\b[A-Za-z_$][\\w$]*\\b", "name": "entity.name.type.ts" },
+        { "match": "[{}()\\[\\].,?:+\\-*/%&|!~=<>]+", "name": "keyword.operator.type.ts" }
+      ]
+    },
+    "vue-ts-generic-call": {
+      "begin": "\\b([A-Za-z_$][\\w$]*)(\\s*<)",
+      "beginCaptures": {
+        "1": { "name": "entity.name.function.ts" },
+        "2": { "name": "punctuation.definition.typeparameters.begin.ts" }
+      },
+      "end": ">",
+      "endCaptures": {
+        "0": { "name": "punctuation.definition.typeparameters.end.ts" }
+      },
+      "name": "meta.type.parameters.ts",
+      "patterns": [{ "include": "#vue-ts-type" }]
+    },
+    "vue-ts-type-arguments": {
+      "begin": "\\b([A-Za-z_$][\\w$]*)(\\s*<)",
+      "beginCaptures": {
+        "1": { "name": "entity.name.type.ts" },
+        "2": { "name": "punctuation.definition.typeparameters.begin.ts" }
+      },
+      "end": ">",
+      "endCaptures": {
+        "0": { "name": "punctuation.definition.typeparameters.end.ts" }
+      },
+      "name": "meta.type.parameters.ts",
+      "patterns": [{ "include": "#vue-ts-type" }]
+    },
+    "vue-ts-comments": {
+      "patterns": [
+        { "begin": "/\\*", "end": "\\*/", "name": "comment.block.ts" },
+        { "begin": "//", "end": "$", "name": "comment.line.double-slash.ts" }
+      ]
+    },
+    "vue-ts-strings": {
+      "patterns": [
+        { "begin": "`", "end": "`", "name": "string.quoted.template.ts" },
+        { "begin": "\"", "end": "\"", "name": "string.quoted.double.ts" },
+        { "begin": "'", "end": "'", "name": "string.quoted.single.ts" }
+      ]
+    },
     "vue-directives": {
       "patterns": [
         {
@@ -108,7 +187,7 @@
             "4": { "name": "punctuation.section.brackets.begin.vue" },
             "5": {
               "name": "meta.embedded.expression.vue",
-              "patterns": [{ "include": "source.ts#expression" }]
+              "patterns": [{ "include": "#vue-ts-expression" }]
             },
             "6": { "name": "punctuation.section.brackets.end.vue" }
           }
@@ -121,7 +200,7 @@
             "3": { "name": "punctuation.section.brackets.begin.vue" },
             "4": {
               "name": "meta.embedded.expression.vue",
-              "patterns": [{ "include": "source.ts#expression" }]
+              "patterns": [{ "include": "#vue-ts-expression" }]
             },
             "5": { "name": "punctuation.section.brackets.end.vue" }
           }
@@ -134,7 +213,7 @@
             "3": { "name": "punctuation.section.brackets.begin.vue" },
             "4": {
               "name": "meta.embedded.expression.vue",
-              "patterns": [{ "include": "source.ts#expression" }]
+              "patterns": [{ "include": "#vue-ts-expression" }]
             },
             "5": { "name": "punctuation.section.brackets.end.vue" }
           }
@@ -147,7 +226,7 @@
             "3": { "name": "punctuation.section.brackets.begin.vue" },
             "4": {
               "name": "meta.embedded.expression.vue",
-              "patterns": [{ "include": "source.ts#expression" }]
+              "patterns": [{ "include": "#vue-ts-expression" }]
             },
             "5": { "name": "punctuation.section.brackets.end.vue" }
           }
@@ -269,32 +348,18 @@
     "vue-generic-attribute": {
       "patterns": [
         {
-          "begin": "\\b(generic)\\b\\s*(=)\\s*(\")",
+          "begin": "\\b(generic)\\b\\s*(=)\\s*([\"'])",
           "beginCaptures": {
             "1": { "name": "entity.other.attribute-name.html" },
             "2": { "name": "punctuation.separator.key-value.html" },
             "3": { "name": "punctuation.definition.string.begin.html" }
           },
-          "end": "(\")",
+          "end": "(\\3)",
           "endCaptures": {
             "1": { "name": "punctuation.definition.string.end.html" }
           },
           "contentName": "meta.embedded.type.typescript",
-          "patterns": [{ "include": "source.ts#type-inner" }]
-        },
-        {
-          "begin": "\\b(generic)\\b\\s*(=)\\s*(')",
-          "beginCaptures": {
-            "1": { "name": "entity.other.attribute-name.html" },
-            "2": { "name": "punctuation.separator.key-value.html" },
-            "3": { "name": "punctuation.definition.string.begin.html" }
-          },
-          "end": "(')",
-          "endCaptures": {
-            "1": { "name": "punctuation.definition.string.end.html" }
-          },
-          "contentName": "meta.embedded.type.typescript",
-          "patterns": [{ "include": "source.ts#type-inner" }]
+          "patterns": [{ "include": "#vue-ts-type" }]
         }
       ]
     },
@@ -573,8 +638,7 @@
     "vue-directive-attributes": {
       "patterns": [
         {
-          "comment": "v-* directive with double-quoted expression",
-          "begin": "(?<!\\S)(v-[a-zA-Z0-9_-]+)(?:(:)(?:([a-zA-Z_][\\w.-]*)|(\\[)([^\\]\\n]+)(\\])))?((?:\\.[a-zA-Z_$][\\w$-]*)*)\\s*(=)\\s*(\")",
+          "begin": "(?<!\\S)(v-[a-zA-Z0-9_-]+)(?:(:)(?:([a-zA-Z_][\\w.-]*)|(\\[)([^\\]\\n]+)(\\])))?((?:\\.[a-zA-Z_$][\\w$-]*)*)\\s*(=)\\s*([\"'])",
           "beginCaptures": {
             "1": { "name": "keyword.control.directive.vue" },
             "2": { "name": "punctuation.definition.directive.vue" },
@@ -582,181 +646,85 @@
             "4": { "name": "punctuation.section.brackets.begin.vue" },
             "5": {
               "name": "meta.embedded.expression.vue",
-              "patterns": [{ "include": "source.ts#expression" }]
+              "patterns": [{ "include": "#vue-ts-expression" }]
             },
             "6": { "name": "punctuation.section.brackets.end.vue" },
             "7": { "name": "storage.modifier.directive.vue" },
             "8": { "name": "punctuation.separator.key-value.html" },
             "9": { "name": "punctuation.definition.string.begin.html" }
           },
-          "end": "(\")",
+          "end": "(\\9)",
           "endCaptures": {
             "1": { "name": "punctuation.definition.string.end.html" }
           },
           "contentName": "meta.embedded.expression.vue",
-          "patterns": [{ "include": "source.ts#expression" }]
+          "patterns": [{ "include": "#vue-ts-expression" }]
         },
         {
-          "comment": "v-* directive with single-quoted expression",
-          "begin": "(?<!\\S)(v-[a-zA-Z0-9_-]+)(?:(:)(?:([a-zA-Z_][\\w.-]*)|(\\[)([^\\]\\n]+)(\\])))?((?:\\.[a-zA-Z_$][\\w$-]*)*)\\s*(=)\\s*(')",
-          "beginCaptures": {
-            "1": { "name": "keyword.control.directive.vue" },
-            "2": { "name": "punctuation.definition.directive.vue" },
-            "3": { "name": "entity.other.attribute-name.directive.argument.vue" },
-            "4": { "name": "punctuation.section.brackets.begin.vue" },
-            "5": {
-              "name": "meta.embedded.expression.vue",
-              "patterns": [{ "include": "source.ts#expression" }]
-            },
-            "6": { "name": "punctuation.section.brackets.end.vue" },
-            "7": { "name": "storage.modifier.directive.vue" },
-            "8": { "name": "punctuation.separator.key-value.html" },
-            "9": { "name": "punctuation.definition.string.begin.html" }
-          },
-          "end": "(')",
-          "endCaptures": {
-            "1": { "name": "punctuation.definition.string.end.html" }
-          },
-          "contentName": "meta.embedded.expression.vue",
-          "patterns": [{ "include": "source.ts#expression" }]
-        },
-        {
-          "comment": ":prop shorthand with double-quoted expression",
-          "begin": "(?<!\\S)(:)(?:([a-zA-Z_][\\w.-]*)|(\\[)([^\\]\\n]+)(\\]))((?:\\.[a-zA-Z_$][\\w$-]*)*)\\s*(=)\\s*(\")",
+          "begin": "(?<!\\S)(:)(?:([a-zA-Z_][\\w.-]*)|(\\[)([^\\]\\n]+)(\\]))((?:\\.[a-zA-Z_$][\\w$-]*)*)\\s*(=)\\s*([\"'])",
           "beginCaptures": {
             "1": { "name": "punctuation.definition.directive.vue" },
             "2": { "name": "entity.other.attribute-name.binding.vue" },
             "3": { "name": "punctuation.section.brackets.begin.vue" },
             "4": {
               "name": "meta.embedded.expression.vue",
-              "patterns": [{ "include": "source.ts#expression" }]
+              "patterns": [{ "include": "#vue-ts-expression" }]
             },
             "5": { "name": "punctuation.section.brackets.end.vue" },
             "6": { "name": "storage.modifier.directive.vue" },
             "7": { "name": "punctuation.separator.key-value.html" },
             "8": { "name": "punctuation.definition.string.begin.html" }
           },
-          "end": "(\")",
+          "end": "(\\8)",
           "endCaptures": {
             "1": { "name": "punctuation.definition.string.end.html" }
           },
           "contentName": "meta.embedded.expression.vue",
-          "patterns": [{ "include": "source.ts#expression" }]
+          "patterns": [{ "include": "#vue-ts-expression" }]
         },
         {
-          "comment": ":prop shorthand with single-quoted expression",
-          "begin": "(?<!\\S)(:)(?:([a-zA-Z_][\\w.-]*)|(\\[)([^\\]\\n]+)(\\]))((?:\\.[a-zA-Z_$][\\w$-]*)*)\\s*(=)\\s*(')",
-          "beginCaptures": {
-            "1": { "name": "punctuation.definition.directive.vue" },
-            "2": { "name": "entity.other.attribute-name.binding.vue" },
-            "3": { "name": "punctuation.section.brackets.begin.vue" },
-            "4": {
-              "name": "meta.embedded.expression.vue",
-              "patterns": [{ "include": "source.ts#expression" }]
-            },
-            "5": { "name": "punctuation.section.brackets.end.vue" },
-            "6": { "name": "storage.modifier.directive.vue" },
-            "7": { "name": "punctuation.separator.key-value.html" },
-            "8": { "name": "punctuation.definition.string.begin.html" }
-          },
-          "end": "(')",
-          "endCaptures": {
-            "1": { "name": "punctuation.definition.string.end.html" }
-          },
-          "contentName": "meta.embedded.expression.vue",
-          "patterns": [{ "include": "source.ts#expression" }]
-        },
-        {
-          "comment": "@event shorthand with double-quoted expression",
-          "begin": "(?<!\\S)(@)(?:([a-zA-Z_][\\w.-]*)|(\\[)([^\\]\\n]+)(\\]))((?:\\.[a-zA-Z_$][\\w$-]*)*)\\s*(=)\\s*(\")",
+          "begin": "(?<!\\S)(@)(?:([a-zA-Z_][\\w.-]*)|(\\[)([^\\]\\n]+)(\\]))((?:\\.[a-zA-Z_$][\\w$-]*)*)\\s*(=)\\s*([\"'])",
           "beginCaptures": {
             "1": { "name": "punctuation.definition.directive.vue" },
             "2": { "name": "entity.other.attribute-name.event.vue" },
             "3": { "name": "punctuation.section.brackets.begin.vue" },
             "4": {
               "name": "meta.embedded.expression.vue",
-              "patterns": [{ "include": "source.ts#expression" }]
+              "patterns": [{ "include": "#vue-ts-expression" }]
             },
             "5": { "name": "punctuation.section.brackets.end.vue" },
             "6": { "name": "storage.modifier.directive.vue" },
             "7": { "name": "punctuation.separator.key-value.html" },
             "8": { "name": "punctuation.definition.string.begin.html" }
           },
-          "end": "(\")",
+          "end": "(\\8)",
           "endCaptures": {
             "1": { "name": "punctuation.definition.string.end.html" }
           },
           "contentName": "meta.embedded.expression.vue",
-          "patterns": [{ "include": "source.ts#expression" }]
+          "patterns": [{ "include": "#vue-ts-expression" }]
         },
         {
-          "comment": "@event shorthand with single-quoted expression",
-          "begin": "(?<!\\S)(@)(?:([a-zA-Z_][\\w.-]*)|(\\[)([^\\]\\n]+)(\\]))((?:\\.[a-zA-Z_$][\\w$-]*)*)\\s*(=)\\s*(')",
-          "beginCaptures": {
-            "1": { "name": "punctuation.definition.directive.vue" },
-            "2": { "name": "entity.other.attribute-name.event.vue" },
-            "3": { "name": "punctuation.section.brackets.begin.vue" },
-            "4": {
-              "name": "meta.embedded.expression.vue",
-              "patterns": [{ "include": "source.ts#expression" }]
-            },
-            "5": { "name": "punctuation.section.brackets.end.vue" },
-            "6": { "name": "storage.modifier.directive.vue" },
-            "7": { "name": "punctuation.separator.key-value.html" },
-            "8": { "name": "punctuation.definition.string.begin.html" }
-          },
-          "end": "(')",
-          "endCaptures": {
-            "1": { "name": "punctuation.definition.string.end.html" }
-          },
-          "contentName": "meta.embedded.expression.vue",
-          "patterns": [{ "include": "source.ts#expression" }]
-        },
-        {
-          "comment": "#slot shorthand with double-quoted expression",
-          "begin": "(?<!\\S)(#)(?:([a-zA-Z_][\\w.-]*)|(\\[)([^\\]\\n]+)(\\]))((?:\\.[a-zA-Z_$][\\w$-]*)*)\\s*(=)\\s*(\")",
+          "begin": "(?<!\\S)(#)(?:([a-zA-Z_][\\w.-]*)|(\\[)([^\\]\\n]+)(\\]))((?:\\.[a-zA-Z_$][\\w$-]*)*)\\s*(=)\\s*([\"'])",
           "beginCaptures": {
             "1": { "name": "punctuation.definition.directive.vue" },
             "2": { "name": "entity.other.attribute-name.slot.vue" },
             "3": { "name": "punctuation.section.brackets.begin.vue" },
             "4": {
               "name": "meta.embedded.expression.vue",
-              "patterns": [{ "include": "source.ts#expression" }]
+              "patterns": [{ "include": "#vue-ts-expression" }]
             },
             "5": { "name": "punctuation.section.brackets.end.vue" },
             "6": { "name": "storage.modifier.directive.vue" },
             "7": { "name": "punctuation.separator.key-value.html" },
             "8": { "name": "punctuation.definition.string.begin.html" }
           },
-          "end": "(\")",
+          "end": "(\\8)",
           "endCaptures": {
             "1": { "name": "punctuation.definition.string.end.html" }
           },
           "contentName": "meta.embedded.expression.vue",
-          "patterns": [{ "include": "source.ts#expression" }]
-        },
-        {
-          "comment": "#slot shorthand with single-quoted expression",
-          "begin": "(?<!\\S)(#)(?:([a-zA-Z_][\\w.-]*)|(\\[)([^\\]\\n]+)(\\]))((?:\\.[a-zA-Z_$][\\w$-]*)*)\\s*(=)\\s*(')",
-          "beginCaptures": {
-            "1": { "name": "punctuation.definition.directive.vue" },
-            "2": { "name": "entity.other.attribute-name.slot.vue" },
-            "3": { "name": "punctuation.section.brackets.begin.vue" },
-            "4": {
-              "name": "meta.embedded.expression.vue",
-              "patterns": [{ "include": "source.ts#expression" }]
-            },
-            "5": { "name": "punctuation.section.brackets.end.vue" },
-            "6": { "name": "storage.modifier.directive.vue" },
-            "7": { "name": "punctuation.separator.key-value.html" },
-            "8": { "name": "punctuation.definition.string.begin.html" }
-          },
-          "end": "(')",
-          "endCaptures": {
-            "1": { "name": "punctuation.definition.string.end.html" }
-          },
-          "contentName": "meta.embedded.expression.vue",
-          "patterns": [{ "include": "source.ts#expression" }]
+          "patterns": [{ "include": "#vue-ts-expression" }]
         }
       ]
     },

--- a/tests/tooling/editor-integrations.test.ts
+++ b/tests/tooling/editor-integrations.test.ts
@@ -272,35 +272,35 @@ test("vscode-vize grammar keeps quote-aware block lookaheads", () => {
   );
   assert.match(
     ' :[activeKey as keyof Props].prop="makeValue<User>() as User"',
-    new RegExp(directivePatterns[2]?.begin ?? ""),
+    new RegExp(directivePatterns[1]?.begin ?? ""),
   );
   assert.match(
     ' @[eventName as keyof Emits].stop="handler($event as MouseEvent)"',
-    new RegExp(directivePatterns[4]?.begin ?? ""),
+    new RegExp(directivePatterns[2]?.begin ?? ""),
   );
   assert.match(
     ' #[slotName as keyof Slots]="slotProps as SlotProps"',
-    new RegExp(directivePatterns[6]?.begin ?? ""),
+    new RegExp(directivePatterns[3]?.begin ?? ""),
   );
   for (const pattern of directivePatterns) {
     assert.equal(pattern.contentName, "meta.embedded.expression.vue");
-    assert.equal(pattern.patterns?.[0]?.include, "source.ts#expression");
+    assert.equal(pattern.patterns?.[0]?.include, "#vue-ts-expression");
   }
   assert.equal(
     directivePatterns[0]?.beginCaptures?.["5"]?.patterns?.[0]?.include,
-    "source.ts#expression",
+    "#vue-ts-expression",
+  );
+  assert.equal(
+    directivePatterns[1]?.beginCaptures?.["4"]?.patterns?.[0]?.include,
+    "#vue-ts-expression",
   );
   assert.equal(
     directivePatterns[2]?.beginCaptures?.["4"]?.patterns?.[0]?.include,
-    "source.ts#expression",
+    "#vue-ts-expression",
   );
   assert.equal(
-    directivePatterns[4]?.beginCaptures?.["4"]?.patterns?.[0]?.include,
-    "source.ts#expression",
-  );
-  assert.equal(
-    directivePatterns[6]?.beginCaptures?.["4"]?.patterns?.[0]?.include,
-    "source.ts#expression",
+    directivePatterns[3]?.beginCaptures?.["4"]?.patterns?.[0]?.include,
+    "#vue-ts-expression",
   );
   assert.equal(repository["vue-interpolation"]?.patterns?.[0]?.include, "source.ts#expression");
   assert.equal(repository["vue-template-pug"]?.patterns?.[1]?.patterns?.[0]?.include, "text.pug");
@@ -311,7 +311,7 @@ test("vscode-vize grammar keeps quote-aware block lookaheads", () => {
   );
   assert.equal(
     repository["vue-generic-attribute"]?.patterns?.[0]?.patterns?.[0]?.include,
-    "source.ts#type-inner",
+    "#vue-ts-type",
   );
   assert.match(
     'generic="T extends Record<string, unknown> = Foo<User>"',
@@ -324,11 +324,11 @@ test("vscode-vize grammar keeps quote-aware block lookaheads", () => {
   );
   assert.equal(
     valueLessDirectivePatterns[1]?.captures?.["5"]?.patterns?.[0]?.include,
-    "source.ts#expression",
+    "#vue-ts-expression",
   );
   assert.equal(
     valueLessDirectivePatterns[2]?.captures?.["4"]?.patterns?.[0]?.include,
-    "source.ts#expression",
+    "#vue-ts-expression",
   );
   assert.match(
     '<i18n message="a > b" lang="json">',

--- a/tests/tooling/vscode-vize-template-grammar.test.ts
+++ b/tests/tooling/vscode-vize-template-grammar.test.ts
@@ -1,0 +1,281 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const textmateModulePath = path.join(
+  root,
+  "node_modules/.pnpm/@shikijs+vscode-textmate@10.0.2/node_modules/@shikijs/vscode-textmate/dist/index.js",
+);
+const onigurumaModulePath = path.join(
+  root,
+  "node_modules/.pnpm/@shikijs+engine-oniguruma@4.0.2/node_modules/@shikijs/engine-oniguruma/dist/index.mjs",
+);
+const onigurumaWasmPath = path.join(
+  root,
+  "node_modules/.pnpm/shiki@4.0.2/node_modules/shiki/dist/onig.wasm",
+);
+const shikiLangsPath = path.join(
+  root,
+  "node_modules/.pnpm/@shikijs+langs@4.0.2/node_modules/@shikijs/langs/dist",
+);
+
+type TextMateToken = {
+  endIndex: number;
+  line: string;
+  scopes: string[];
+  startIndex: number;
+  text: string;
+};
+
+function readJson<T>(relativePath: string): T {
+  return JSON.parse(fs.readFileSync(path.join(root, relativePath), "utf-8")) as T;
+}
+
+function createStubGrammar(scopeName: string) {
+  const patterns = [
+    { match: "\\b(as|extends|keyof|typeof|infer|satisfies)\\b", name: "keyword.operator.ts" },
+    { match: "\\b[A-Za-z_$][\\w$]*\\b", name: "identifier.ts" },
+    { match: "[<>{}()\\[\\].,:?=+\\-*/|&!]+", name: "punctuation.ts" },
+    { match: "\"(?:\\\\.|[^\"])*\"|'(?:\\\\.|[^'])*'|`(?:\\\\.|[^`])*`", name: "string.ts" },
+  ];
+
+  return {
+    scopeName,
+    patterns,
+    repository: {
+      expression: { patterns },
+      "type-inner": { patterns },
+    },
+  };
+}
+
+async function loadBundledLanguageGrammar(name: string) {
+  const module = await import(pathToFileURL(path.join(shikiLangsPath, `${name}.mjs`)).href);
+  return Array.isArray(module.default) ? module.default[0] : module.default;
+}
+
+async function loadVueTextMateGrammar(scopeName = "source.vue") {
+  const [{ Registry }, { createOnigurumaEngine }, sourceTs, sourceJson] = await Promise.all([
+    import(pathToFileURL(textmateModulePath).href),
+    import(pathToFileURL(onigurumaModulePath).href),
+    loadBundledLanguageGrammar("typescript"),
+    loadBundledLanguageGrammar("json"),
+  ]);
+  const engine = await createOnigurumaEngine(fs.readFileSync(onigurumaWasmPath));
+  const grammars = new Map<string, unknown>([
+    ["source.vue", readJson("npm/vscode-vize/syntaxes/vue.tmLanguage.json")],
+    ["source.art-vue", readJson("npm/vscode-vize/syntaxes/art-vue.tmLanguage.json")],
+    ["source.ts", sourceTs],
+    ["source.json", sourceJson],
+  ]);
+  const registry = new Registry({
+    onigLib: {
+      createOnigScanner(patterns: Array<string | RegExp>) {
+        return engine.createScanner(patterns);
+      },
+      createOnigString(value: string) {
+        return engine.createString(value);
+      },
+    },
+    loadGrammar(scopeName: string) {
+      return grammars.get(scopeName) ?? createStubGrammar(scopeName);
+    },
+  });
+
+  const grammar = registry.loadGrammar(scopeName);
+  assert.ok(grammar);
+  return { grammar, registry };
+}
+
+function tokenizeLines(
+  grammar: {
+    tokenizeLine(
+      lineText: string,
+      prevState: unknown,
+    ): { ruleStack: unknown; tokens: TextMateToken[] };
+  },
+  lines: string[],
+): TextMateToken[] {
+  let ruleStack: unknown = null;
+  const tokens: TextMateToken[] = [];
+
+  for (const line of lines) {
+    const result = grammar.tokenizeLine(line, ruleStack);
+    tokens.push(
+      ...result.tokens.map((token) => ({
+        endIndex: token.endIndex,
+        line,
+        scopes: token.scopes,
+        startIndex: token.startIndex,
+        text: line.slice(token.startIndex, token.endIndex),
+      })),
+    );
+    ruleStack = result.ruleStack;
+  }
+
+  return tokens;
+}
+
+function tokensForText(tokens: TextMateToken[], text: string): TextMateToken[] {
+  return tokens.filter((token) => token.text.includes(text));
+}
+
+function assertTextHasScope(tokens: TextMateToken[], text: string, scopePart: string): void {
+  assert.equal(
+    tokensForText(tokens, text).some((token) =>
+      token.scopes.some((scope) => scope.includes(scopePart)),
+    ),
+    true,
+    `${JSON.stringify(text)} should include scope ${scopePart}. Tokens: ${JSON.stringify(
+      tokensForText(tokens, text),
+    )}`,
+  );
+}
+
+function assertTextDoesNotHaveScope(
+  tokens: TextMateToken[],
+  text: string,
+  scopePart: string,
+): void {
+  assert.equal(
+    tokensForText(tokens, text).some((token) =>
+      token.scopes.some((scope) => scope.includes(scopePart)),
+    ),
+    false,
+    `${JSON.stringify(text)} should not include scope ${scopePart}. Tokens: ${JSON.stringify(
+      tokensForText(tokens, text),
+    )}`,
+  );
+}
+
+test("vscode-vize template grammar recurses through template content", () => {
+  const grammar = readJson<{
+    repository?: Record<string, { patterns?: Array<{ include?: string }> }>;
+  }>("npm/vscode-vize/syntaxes/vue.tmLanguage.json");
+  const repository = grammar.repository ?? {};
+
+  assert.deepEqual(
+    (repository["vue-template-content"]?.patterns ?? []).map((pattern) => pattern.include),
+    [
+      "#vue-comments",
+      "#vue-interpolation",
+      "#vue-template",
+      "#vue-directives",
+      "#html-tags",
+      "#html-entities",
+    ],
+  );
+  assert.deepEqual(
+    (repository["vue-template-tag"]?.patterns ?? []).map((pattern) => pattern.include),
+    ["#vue-directive-attributes", "#vue-directives", "#vue-tag-attributes"],
+  );
+  assert.equal(
+    repository["vue-generic-attribute"]?.patterns?.[0]?.patterns?.[0]?.include,
+    "#vue-ts-type",
+  );
+  assert.equal(
+    repository["vue-directive-attributes"]?.patterns?.[0]?.patterns?.[0]?.include,
+    "#vue-ts-expression",
+  );
+  assert.match(
+    "generic='T extends Foo<User>'",
+    new RegExp(repository["vue-generic-attribute"]?.patterns?.[0]?.begin ?? ""),
+  );
+});
+
+test("vscode-vize grammar keeps Vue scopes after nested template blocks", async () => {
+  const { grammar, registry } = await loadVueTextMateGrammar();
+
+  try {
+    const tokens = tokenizeLines(grammar, [
+      "<template>",
+      '  <div class="foo">',
+      "    <!-- nested branch -->",
+      '    <template v-if="true">',
+      "      <Foo>label</Foo>",
+      "    </template>",
+      "    <div v-else>fallback</div>",
+      "",
+      '    <Bar :open="false">',
+      "      message<br />more",
+      "    </Bar>",
+      "  </div>",
+      "</template>",
+    ]);
+
+    assertTextHasScope(tokens, "nested branch", "comment.block.html");
+    assertTextHasScope(tokens, "v-if", "keyword.control.directive.vue");
+    assertTextHasScope(tokens, "true", "meta.embedded.expression.vue");
+    assertTextHasScope(tokens, "v-else", "keyword.control.directive.vue");
+    assertTextHasScope(tokens, "open", "entity.other.attribute-name.binding.vue");
+    assertTextHasScope(tokens, "false", "meta.embedded.expression.vue");
+    assertTextHasScope(tokens, "Bar", "entity.name.tag.html");
+    assertTextHasScope(tokens, "br", "entity.name.tag.html");
+  } finally {
+    registry.dispose();
+  }
+});
+
+test("vscode-vize grammar keeps TS generics and assertions inside attribute values", async () => {
+  const { grammar, registry } = await loadVueTextMateGrammar();
+
+  try {
+    const tokens = tokenizeLines(grammar, [
+      '<script setup lang="ts" generic="T extends Record<string, unknown> = Foo<User>">',
+      "const value = makeValue<T>() as T",
+      "</script>",
+      "<template>",
+      '  <button :items="makeList<User>() as Array<User>" v-bind:[activeKey as keyof Props].camel="makeValue<User>() as User" data-x="ok">',
+      "    {{ makeValue<User>() as User }}",
+      "  </button>",
+      "  <input :value='makeValue<User>() as User' data-single=\"ok\" />",
+      "  <span>after</span>",
+      "</template>",
+    ]);
+
+    assertTextHasScope(tokens, "Record", "meta.embedded.type.typescript");
+    assertTextHasScope(tokens, "makeList", "entity.name.function.ts");
+    assertTextHasScope(tokens, "as", "keyword.control.as.ts");
+    assertTextHasScope(tokens, "Props", "entity.name.type.ts");
+    assertTextHasScope(tokens, "data-x", "entity.other.attribute-name.html");
+    assertTextHasScope(tokens, "data-single", "entity.other.attribute-name.html");
+    assertTextHasScope(tokens, "span", "entity.name.tag.html");
+    assertTextDoesNotHaveScope(tokens, "data-x", "meta.embedded.expression.vue");
+    assertTextDoesNotHaveScope(tokens, "data-single", "meta.embedded.expression.vue");
+    assertTextDoesNotHaveScope(tokens, "span", "meta.embedded.expression.vue");
+    assertTextDoesNotHaveScope(tokens, "after", "meta.embedded.type.typescript");
+  } finally {
+    registry.dispose();
+  }
+});
+
+test("vscode-vize art grammar preserves Musea art highlighting around TS attributes", async () => {
+  const { grammar, registry } = await loadVueTextMateGrammar("source.art-vue");
+
+  try {
+    const tokens = tokenizeLines(grammar, [
+      '<art title="Button" component="Button">',
+      '  <variant name="typed" args=\'{"items":[1]}\'>',
+      '    <Button :items="makeList<User>() as Array<User>" v-bind:[activeKey as keyof Props].camel="makeValue<User>() as User" data-x="ok">',
+      "      {{ makeValue<User>() as User }}",
+      "    </Button>",
+      "  </variant>",
+      "</art>",
+    ]);
+
+    assertTextHasScope(tokens, "art", "entity.name.tag.art.vue");
+    assertTextHasScope(tokens, "variant", "entity.name.tag.variant.vue");
+    assertTextHasScope(tokens, "makeList", "entity.name.function.ts");
+    assertTextHasScope(tokens, "as", "keyword.control.as.ts");
+    assertTextHasScope(tokens, "Props", "entity.name.type.ts");
+    assertTextHasScope(tokens, "data-x", "entity.other.attribute-name.html");
+    assertTextHasScope(tokens, "Button", "entity.name.tag.html");
+    assertTextDoesNotHaveScope(tokens, "variant", "meta.embedded.expression.vue");
+    assertTextDoesNotHaveScope(tokens, "data-x", "meta.embedded.expression.vue");
+  } finally {
+    registry.dispose();
+  }
+});


### PR DESCRIPTION
## Summary

- Make the Vue TextMate `vue-template` rule recursive so nested `<template>` blocks consume their own closing tag instead of ending the root template block.
- Add quote-safe Vue attribute expression/type highlighting for TS generics, `as` assertions, `keyof`, and dynamic directive arguments without letting TypeScript grammar consume the attribute closing quote.
- Keep Musea `.art.vue` highlighting aligned by routing `<art>/<variant>` template content through the same directive and TS attribute expression rules.
- Add focused TextMate tokenizer coverage for nested templates, TS generic/assertion attributes, single-quoted directive values, and Musea art files.

## Root cause

`vue-template-content` ended at the first `</template>` it saw, while nested `<template>` tags were tokenized as plain HTML tags. Attribute expressions had a second boundary issue: directly embedding `source.ts#expression` let TS generic/type parsing treat the closing attribute quote as a TypeScript string start, so subsequent attributes and tags could lose Vue scopes.

Fixes #1837

## Verification

- `node --test tests/tooling/vscode-vize-template-grammar.test.ts tests/tooling/editor-integrations.test.ts tests/tooling/editor-integrations-consistency.test.ts tests/tooling/source-file-lengths.test.ts`
- `corepack pnpm exec vp check npm/vscode-vize/syntaxes/vue.tmLanguage.json tests/tooling/vscode-vize-template-grammar.test.ts tests/tooling/editor-integrations.test.ts`
- `corepack pnpm exec vp run --workspace-root check:vscode-extension`
- `corepack pnpm exec vp run --workspace-root test:vscode-extension:vsix`
