### PR TITLE
fix(ci): use hosted Windows runners for release builds

### DIFF
--- a/tools/github/release-platforms.mjs
+++ b/tools/github/release-platforms.mjs
@@ -26,7 +26,7 @@ export const cliReleasePlatforms = [
     archive: "vize-aarch64-apple-darwin.tar.gz",
   },
   {
-    host: "blacksmith-32vcpu-windows-2025",
+    host: "windows-2025",
     target: "x86_64-pc-windows-msvc",
     archive: "vize-x86_64-pc-windows-msvc.zip",
   },
@@ -59,7 +59,7 @@ export const nativeReleasePlatforms = [
     cross_compile: false,
   },
   {
-    host: "blacksmith-32vcpu-windows-2025",
+    host: "windows-2025",
     target: "x86_64-pc-windows-msvc",
     cross_compile: false,
   },


### PR DESCRIPTION
## Summary
- move release x64 Windows CLI/native builds from Blacksmith Windows to GitHub-hosted windows-2025
- keep the existing release platform cadence and target set unchanged

## Root Cause
The latest release runs failed before publish because both x86_64-pc-windows-msvc release build jobs stopped during Rust setup/target installation on Blacksmith Windows. The later npm and GitHub release jobs were skipped because they depend on those build artifacts.

## Validation
- node --test tests/tooling/github-workflows-release-build.test.ts tests/tooling/release-platforms.test.ts tests/tooling/github-workflows.test.ts
- node tools/github/release-platforms.mjs print v0.233.0

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1840"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->