### PR TITLE
fix: expose Options API setup returns to templates

### DIFF
--- a/crates/vize_canon/src/batch/type_checker/tests/emit_object_recursion.rs
+++ b/crates/vize_canon/src/batch/type_checker/tests/emit_object_recursion.rs
@@ -4,6 +4,7 @@ use super::{create_project_case, relative_path, resolve_test_tsgo_binary};
 use crate::batch::Diagnostic;
 use crate::batch::TypeChecker;
 use crate::batch::type_checker::{BatchTypeChecker, BatchTypeCheckerOptions, TypeCheckResult};
+use vize_carton::cstr;
 
 #[test]
 fn test_type_check_result() {
@@ -82,6 +83,100 @@ void (null as unknown as TestProps);
         found,
         "expected TS2589 in the TS consumer, got: {:?}",
         result.diagnostics
+    );
+
+    let _ = std::fs::remove_dir_all(&project_root);
+}
+
+#[test]
+fn batch_type_checker_unwraps_options_api_setup_return_refs() {
+    if resolve_test_tsgo_binary().is_none() {
+        return;
+    }
+
+    let project_root = create_project_case(
+        "options-api-setup-return-ref",
+        &[(
+            "src/App.vue",
+            r#"<script lang="ts">
+import { defineComponent, ref } from 'vue'
+
+export default defineComponent({
+  setup() {
+    const count = ref(0)
+    return { count }
+  },
+})
+</script>
+
+<template>
+  <div>{{ count.toFixed(true) }}</div>
+</template>
+"#,
+        )],
+    );
+
+    if !project_root.join("node_modules/vue/dist").exists() {
+        let _ = std::fs::remove_dir_all(&project_root);
+        return;
+    }
+
+    let mut checker = match BatchTypeChecker::new(&project_root) {
+        Ok(checker) => checker,
+        Err(_) => {
+            let _ = std::fs::remove_dir_all(&project_root);
+            return;
+        }
+    };
+    checker.enable_options_api();
+    if checker.scan_project().is_err() {
+        let _ = std::fs::remove_dir_all(&project_root);
+        return;
+    }
+    let result = match checker.check_project() {
+        Ok(result) => result,
+        Err(_) => {
+            let _ = std::fs::remove_dir_all(&project_root);
+            return;
+        }
+    };
+
+    let snapshot: Vec<_> = result
+        .diagnostics
+        .iter()
+        .map(|diagnostic| {
+            (
+                relative_path(&project_root, &diagnostic.file),
+                diagnostic.code,
+                cstr!(
+                    "{}:{}:{} {}",
+                    diagnostic.line + 1,
+                    diagnostic.column + 1,
+                    match diagnostic.severity {
+                        1 => "error",
+                        2 => "warning",
+                        3 => "info",
+                        _ => "hint",
+                    },
+                    diagnostic.message
+                ),
+            )
+        })
+        .collect();
+
+    assert!(
+        snapshot.iter().any(|(file, code, message)| {
+            file == "src/App.vue" && *code == Some(2345) && message.contains("boolean")
+        }),
+        "expected Options API setup ref return to unwrap to number in the template: {snapshot:#?}"
+    );
+    assert!(
+        snapshot.iter().all(|(file, code, message)| {
+            file != "src/App.vue"
+                || !matches!(*code, Some(2304 | 2339))
+                || (!message.contains("count") && !message.contains("toFixed"))
+        }),
+        "setup return should not produce missing-binding/member false positives: {snapshot:#?}"
     );
 
     let _ = std::fs::remove_dir_all(&project_root);

--- a/crates/vize_canon/src/virtual_ts/generator/mod.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/mod.rs
@@ -4,8 +4,9 @@ mod options_api;
 mod options_api_support;
 mod setup_props;
 mod spans;
+mod template_refs;
 
-use vize_croquis::{BindingType, Croquis, ScopeData, ScopeKind};
+use vize_croquis::{Croquis, ScopeData, ScopeKind};
 
 use self::generics::{generic_injection_point, references_any_identifier};
 use self::imports::{
@@ -19,8 +20,9 @@ use self::options_api::{
 use self::setup_props::SetupPropsPlan;
 use self::spans::{
     DEFINE_COMPONENT_HELPER, DEFINE_COMPONENT_REF, collect_template_referenced_names,
-    is_local_setup_binding, merge_overlapping_spans, rewrite_export_default_for_module_scope,
+    merge_overlapping_spans, rewrite_export_default_for_module_scope,
 };
+use self::template_refs::TemplateRefUnwraps;
 use super::{
     helpers::{
         EMIT_OVERLOAD_HELPERS, EMIT_PROPS_HELPER, IMPORT_META_AUGMENTATION,
@@ -35,8 +37,6 @@ use super::{
     types::{VirtualTsGenerationOptions, VirtualTsOptions, VirtualTsOutput, VizeMapping},
 };
 use vize_carton::{FxHashMap, FxHashSet, String, append, cstr, profile};
-
-const REF_UNWRAP_HELPER: &str = "    type __U<T> = T extends import('vue').Ref ? T['value'] : T;\n";
 
 /// Generate virtual TypeScript from Vue SFC analysis.
 ///
@@ -736,44 +736,12 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
         profile!("canon.virtual_ts.emit_template_scope", {
             ts.push_str("  // ========== Template Scope (inherits from setup) ==========\n");
 
-            // Collect ref bindings for auto-unwrapping in template
-            let mut ref_bindings: Vec<&str> =
-                if let Some(template_referenced_names) = template_referenced_names.as_ref() {
-                    summary
-                        .bindings
-                        .bindings
-                        .iter()
-                        .filter(|(name, _)| template_referenced_names.contains(name.as_str()))
-                        .filter(|(name, binding_type)| {
-                            summary.reactivity.needs_value_access(name.as_str())
-                                || matches!(binding_type, BindingType::SetupMaybeRef)
-                                    && is_local_setup_binding(summary, name.as_str())
-                        })
-                        .map(|(name, _)| name.as_str())
-                        .collect()
-                } else {
-                    summary
-                        .bindings
-                        .bindings
-                        .iter()
-                        .filter(|(name, binding_type)| {
-                            summary.reactivity.needs_value_access(name.as_str())
-                                || matches!(binding_type, BindingType::SetupMaybeRef)
-                                    && is_local_setup_binding(summary, name.as_str())
-                        })
-                        .map(|(name, _)| name.as_str())
-                        .collect()
-                };
-            ref_bindings.sort_unstable();
-
-            // Capture ref types BEFORE template scope to avoid circular references.
-            // `typeof count` here refers to the setup-scope Ref<number>.
-            if !ref_bindings.is_empty() {
-                ts.push_str("  // Ref type captures (before template scope shadows them)\n");
-                for name in &ref_bindings {
-                    append!(ts, "  type __R_{name} = typeof {name};\n");
-                }
-            }
+            let template_ref_unwraps = TemplateRefUnwraps::collect(
+                summary,
+                options_api,
+                template_referenced_names.as_ref(),
+            );
+            template_ref_unwraps.emit_type_captures(&mut ts);
 
             // Semicolon prevents ASI issues when user script doesn't end with `;`
             // (e.g., `console.log(x)\n(function...)` would be parsed as a call)
@@ -781,13 +749,7 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
 
             // Shadow ref bindings with unwrapped types.
             // `var` allows reassignment (Vue templates can assign to refs).
-            if !ref_bindings.is_empty() {
-                ts.push_str("    // Auto-unwrap Vue refs in template scope\n");
-                ts.push_str(REF_UNWRAP_HELPER);
-                for name in &ref_bindings {
-                    append!(ts, "    var {name}: __U<__R_{name}> = undefined as any;\n");
-                }
-            }
+            template_ref_unwraps.emit_template_variables(&mut ts);
 
             // Vue template context (available in template expressions)
             let template_context = profile!(

--- a/crates/vize_canon/src/virtual_ts/generator/template_refs.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/template_refs.rs
@@ -1,0 +1,120 @@
+//! Template ref and Options API setup-return unwrapping.
+
+use vize_carton::{FxHashSet, String, append};
+use vize_croquis::{BindingType, Croquis, OptionGroup};
+
+use super::options_api_support::is_safe_value_identifier;
+use super::spans::is_local_setup_binding;
+
+const REF_UNWRAP_HELPER: &str = "    type __U<T> = T extends import('vue').Ref ? T['value'] : T;\n";
+
+pub(super) struct TemplateRefUnwraps {
+    setup_bindings: Vec<String>,
+    options_api_setup_bindings: Vec<String>,
+}
+
+impl TemplateRefUnwraps {
+    pub(super) fn collect(
+        summary: &Croquis,
+        options_api: bool,
+        template_referenced_names: Option<&FxHashSet<String>>,
+    ) -> Self {
+        let mut options_api_setup_bindings =
+            collect_options_api_setup_bindings(summary, options_api);
+        if let Some(template_referenced_names) = template_referenced_names {
+            options_api_setup_bindings
+                .retain(|name| template_referenced_names.contains(name.as_str()));
+        }
+        let options_api_setup_binding_names: FxHashSet<&str> = options_api_setup_bindings
+            .iter()
+            .map(|name| name.as_str())
+            .collect();
+
+        let mut setup_bindings: Vec<String> = summary
+            .bindings
+            .bindings
+            .iter()
+            .filter(|(name, _)| {
+                template_referenced_names
+                    .is_none_or(|referenced| referenced.contains(name.as_str()))
+            })
+            .filter(|(name, _)| !options_api_setup_binding_names.contains(name.as_str()))
+            .filter(|(name, binding_type)| {
+                summary.reactivity.needs_value_access(name.as_str())
+                    || matches!(binding_type, BindingType::SetupMaybeRef)
+                        && is_local_setup_binding(summary, name.as_str())
+            })
+            .map(|(name, _)| String::from(name.as_str()))
+            .collect();
+        setup_bindings.sort_unstable();
+
+        Self {
+            setup_bindings,
+            options_api_setup_bindings,
+        }
+    }
+
+    pub(super) fn emit_type_captures(&self, mut ts: &mut String) {
+        if !self.setup_bindings.is_empty() {
+            ts.push_str("  // Ref type captures (before template scope shadows them)\n");
+            for name in &self.setup_bindings {
+                append!(ts, "  type __R_{name} = typeof {name};\n");
+            }
+        }
+        if !self.options_api_setup_bindings.is_empty() {
+            ts.push_str(
+                "  // Options API setup return type captures (before template scope shadows them)\n",
+            );
+            ts.push_str(
+                "  type __VizeOptionsSetupBinding<K extends string> = typeof __default__ extends abstract new (...args: any) => infer __I ? K extends keyof __I ? __I[K] : any : any;\n",
+            );
+            for name in &self.options_api_setup_bindings {
+                append!(
+                    ts,
+                    "  type __R_{name} = __VizeOptionsSetupBinding<\"{name}\">;\n"
+                );
+            }
+        }
+    }
+
+    pub(super) fn emit_template_variables(&self, mut ts: &mut String) {
+        if self.setup_bindings.is_empty() && self.options_api_setup_bindings.is_empty() {
+            return;
+        }
+
+        ts.push_str("    // Auto-unwrap Vue refs in template scope\n");
+        ts.push_str(REF_UNWRAP_HELPER);
+        for name in &self.setup_bindings {
+            append!(ts, "    var {name}: __U<__R_{name}> = undefined as any;\n");
+        }
+        for name in &self.options_api_setup_bindings {
+            append!(ts, "    var {name}: __U<__R_{name}> = undefined as any;\n");
+        }
+    }
+}
+
+fn collect_options_api_setup_bindings(summary: &Croquis, options_api: bool) -> Vec<String> {
+    if !options_api || summary.bindings.is_script_setup {
+        return Vec::new();
+    }
+
+    let Some(descriptor) = summary.options_descriptor.as_ref() else {
+        return Vec::new();
+    };
+
+    let mut names: Vec<String> = descriptor
+        .members_in(OptionGroup::Setup)
+        .map(|member| member.name.as_str())
+        .filter(|name| {
+            is_safe_value_identifier(name)
+                && matches!(
+                    summary.bindings.get(name),
+                    Some(BindingType::SetupMaybeRef | BindingType::SetupRef)
+                )
+        })
+        .map(String::from)
+        .collect();
+    names.sort_unstable();
+    names.dedup();
+    names
+}

--- a/crates/vize_canon/src/virtual_ts/tests/options_api_props_spread.rs
+++ b/crates/vize_canon/src/virtual_ts/tests/options_api_props_spread.rs
@@ -1,6 +1,65 @@
 use super::{analyze_options_api_script, generate_virtual_ts_with_offsets_options_api};
 
 #[test]
+fn test_options_api_setup_return_bindings_use_default_instance_type() {
+    let script = r#"import { defineComponent, ref } from '@nuxtjs/composition-api'
+
+export default defineComponent({
+    setup() {
+        const count = ref(0)
+        const store = { ready: true }
+        return { count, store }
+    },
+})
+"#;
+    let allocator = vize_carton::Bump::new();
+    let (root, _) = vize_armature::parse(
+        &allocator,
+        "<div>{{ count.toFixed(0) }} {{ store.ready }}</div>",
+    );
+    let mut analyzer = vize_croquis::Analyzer::with_options(vize_croquis::AnalyzerOptions::full())
+        .with_options_api();
+    analyzer.analyze_script_plain(script);
+    analyzer.analyze_template(&root);
+    let summary = analyzer.finish();
+    let output = generate_virtual_ts_with_offsets_options_api(
+        &summary,
+        Some(script),
+        Some(&root),
+        0,
+        0,
+        &Default::default(),
+    );
+
+    assert!(
+        !output.code.contains("type __R_count = typeof count;"),
+        "Options API setup return must not reference setup() locals outside their scope:\n{}",
+        output.code
+    );
+    assert!(
+        output
+            .code
+            .contains("type __R_count = __VizeOptionsSetupBinding<\"count\">;"),
+        "setup return binding should be captured from the default component instance:\n{}",
+        output.code
+    );
+    assert!(
+        output
+            .code
+            .contains("type __R_store = __VizeOptionsSetupBinding<\"store\">;"),
+        "plain setup return binding should also be exposed through the instance:\n{}",
+        output.code
+    );
+    assert!(
+        output
+            .code
+            .contains("var count: __U<__R_count> = undefined as any;"),
+        "setup ref return should be available as an auto-unwrapped template variable:\n{}",
+        output.code
+    );
+}
+
+#[test]
 fn test_options_api_props_object_with_spread_defers_to_setup_scope() {
     let script = r#"import { defineComponent } from 'vue'
 


### PR DESCRIPTION
## Summary
- expose Options API setup() return bindings in template virtual TS through the default component instance
- avoid direct `typeof <binding>` captures for setup() locals that are scoped inside the component options object
- add virtual TS and batch type-check regressions for ref auto-unwrapping in templates

## Root Cause
Options API setup() return names were collected as setup-maybe-ref bindings, but template virtual TS captured them with `typeof name` outside the actual setup() method scope. That produced missing-name diagnostics instead of resolving through the component public instance.

## Validation
- cargo fmt
- cargo test -p vize_canon test_options_api_
- cargo test -p vize_canon batch_type_checker_unwraps_options_api_setup_return_refs
- cargo test -p vize_canon test_type_check_options_api_resolves_this_across_blocks

Closes #1892

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1897"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->