### PR TITLE
fix(check): skip template scope when bindings disabled

### DIFF
--- a/crates/vize_canon/src/virtual_ts/generator/mod.rs
+++ b/crates/vize_canon/src/virtual_ts/generator/mod.rs
@@ -732,7 +732,7 @@ pub(crate) fn generate_virtual_ts_with_offsets_and_checks(
     setup_props_plan.emit_artifact(&mut ts, summary);
 
     // Template scope (nested inside setup)
-    if template_ast.is_some() {
+    if template_ast.is_some() && check_options.check_template_bindings {
         profile!("canon.virtual_ts.emit_template_scope", {
             ts.push_str("  // ========== Template Scope (inherits from setup) ==========\n");
 

--- a/crates/vize_canon/src/virtual_ts/tests.rs
+++ b/crates/vize_canon/src/virtual_ts/tests.rs
@@ -6,6 +6,7 @@ use super::{
 };
 
 mod define_props_scope;
+mod no_check_template_bindings;
 mod options_api_props_spread;
 mod vif_chain;
 fn assert_virtual_ts_snapshot(name: &str, value: &str) {
@@ -1002,40 +1003,6 @@ const wrong = 'not a number'
 
     assert!(!output.code.contains("__vize_prop_check"));
     assert!(!output.code.contains("type __Child_Props_0"));
-}
-
-#[test]
-fn test_check_template_bindings_option_disables_template_expressions() {
-    use vize_croquis::{Analyzer, AnalyzerOptions};
-
-    let script = "const message = 'hello'\n";
-    let template = r#"<div>{{ message }}</div>"#;
-
-    let allocator = vize_carton::Bump::new();
-    let (root, _) = vize_armature::parse(&allocator, template);
-
-    let mut analyzer = Analyzer::with_options(AnalyzerOptions::full());
-    analyzer.analyze_script_setup(script);
-    analyzer.analyze_template(&root);
-    let summary = analyzer.finish();
-
-    let output = generate_virtual_ts_with_offsets_and_checks(
-        &summary,
-        Some(script),
-        Some(&root),
-        0,
-        0,
-        &VirtualTsOptions::default(),
-        VirtualTsGenerationOptions {
-            check_options: VirtualTsCheckOptions {
-                check_template_bindings: false,
-                ..Default::default()
-            },
-            ..Default::default()
-        },
-    );
-
-    assert!(!output.code.contains("void (message);"));
 }
 
 #[test]

--- a/crates/vize_canon/src/virtual_ts/tests/no_check_template_bindings.rs
+++ b/crates/vize_canon/src/virtual_ts/tests/no_check_template_bindings.rs
@@ -1,0 +1,55 @@
+use crate::virtual_ts::{
+    VirtualTsCheckOptions, VirtualTsGenerationOptions, VirtualTsOptions,
+    generate_virtual_ts_with_offsets_and_checks,
+};
+use vize_croquis::{Analyzer, AnalyzerOptions};
+
+#[test]
+fn skips_template_scope_but_keeps_script_checks() {
+    let script = r#"import { ref } from 'vue'
+import Child from './Child.vue'
+
+const scriptOnly: string = 1
+const isLoading = ref(false)
+"#;
+    let template = r#"<div>
+  <Child v-for="item in missingItems" :key="item.id" :busy="isLoading" @save="confirmDialog" />
+  {{ confirmDialog }}
+</div>"#;
+
+    let allocator = vize_carton::Bump::new();
+    let (root, _) = vize_armature::parse(&allocator, template);
+
+    let mut analyzer = Analyzer::with_options(AnalyzerOptions::full());
+    analyzer.analyze_script_setup(script);
+    analyzer.analyze_template(&root);
+    let summary = analyzer.finish();
+
+    let output = generate_virtual_ts_with_offsets_and_checks(
+        &summary,
+        Some(script),
+        Some(&root),
+        0,
+        0,
+        &VirtualTsOptions::default(),
+        VirtualTsGenerationOptions {
+            check_options: VirtualTsCheckOptions {
+                check_template_bindings: false,
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+    );
+
+    assert!(output.code.contains("const scriptOnly: string = 1"));
+    assert!(output.code.contains("__setup();"));
+    assert!(!output.code.contains("Template Scope"));
+    assert!(!output.code.contains("ComponentPublicInstance"));
+    assert!(!output.code.contains("type __R_isLoading"));
+    assert!(!output.code.contains("var isLoading:"));
+    assert!(!output.code.contains("void isLoading;"));
+    assert!(!output.code.contains("missingItems"));
+    assert!(!output.code.contains("confirmDialog"));
+    assert!(!output.code.contains("__vize_prop_check"));
+    assert!(!output.code.contains("@save handler"));
+}


### PR DESCRIPTION
## Summary
- Skip generated template scope when template binding checks are disabled.
- Keep script setup/module code emitted so script-side diagnostics still run.
- Add regression coverage for template-scope helpers, refs, props, and event scaffolding staying out of the output.

Closes #1894

## Verification
- cargo fmt --check
- cargo test -p vize_canon no_check_template_bindings -- --nocapture
- cargo test -p vize_canon virtual_ts -- --nocapture
- cargo clippy -p vize_canon -- -D warnings -D clippy::wildcard_imports
- SOURCE_LENGTH_BASE_REF=origin/main node --test tests/tooling/source-file-lengths.test.ts
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ubugeeei-prod/codesmith/vize/pr/1903"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is enabled.</sup>

<!-- codesmith:autofix:enabled -->
<!-- /codesmith:footer -->